### PR TITLE
feat(food): PRD-125 — ingest API + BullMQ queue contract

### DIFF
--- a/.github/workflows/_pkg-check.yml
+++ b/.github/workflows/_pkg-check.yml
@@ -45,6 +45,7 @@ jobs:
           pnpm --filter @pops/db-types build
           pnpm --filter @pops/types build
           pnpm --filter @pops/module-registry build
+          pnpm --filter @pops/food-contracts build
           pnpm --filter @pops/app-food-db build
       - run: cd ${{ inputs.package-path }} && pnpm typecheck
         if: inputs.skip != 'true'
@@ -74,6 +75,7 @@ jobs:
           pnpm --filter @pops/db-types build
           pnpm --filter @pops/types build
           pnpm --filter @pops/module-registry build
+          pnpm --filter @pops/food-contracts build
           pnpm --filter @pops/app-food-db build
       - name: Run tests (with coverage if configured)
         if: inputs.skip != 'true'

--- a/.github/workflows/api-quality.yml
+++ b/.github/workflows/api-quality.yml
@@ -66,6 +66,7 @@ jobs:
           cd packages/db-types && pnpm build
           cd ../types && pnpm build
           cd ../module-registry && pnpm build
+          cd ../food-contracts && pnpm build
           cd ../app-food-db && pnpm build
 
       - name: Type check

--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -61,6 +61,7 @@ jobs:
           cd packages/db-types && pnpm build
           cd ../types && pnpm build
           cd ../module-registry && pnpm build
+          cd ../food-contracts && pnpm build
           cd ../app-food-db && pnpm build
 
       - name: Typecheck

--- a/.github/workflows/fe-quality.yml
+++ b/.github/workflows/fe-quality.yml
@@ -72,6 +72,7 @@ jobs:
           cd packages/db-types && pnpm build
           cd ../types && pnpm build
           cd ../module-registry && pnpm build
+          cd ../food-contracts && pnpm build
           cd ../app-food-db && pnpm build
 
       - name: Type check

--- a/.github/workflows/fe-test-e2e.yml
+++ b/.github/workflows/fe-test-e2e.yml
@@ -61,6 +61,7 @@ jobs:
           cd packages/db-types && pnpm build
           cd ../types && pnpm build
           cd ../module-registry && pnpm build
+          cd ../food-contracts && pnpm build
           cd ../app-food-db && pnpm build
 
       - name: Cache Playwright browsers

--- a/apps/pops-api/Dockerfile
+++ b/apps/pops-api/Dockerfile
@@ -10,6 +10,7 @@ COPY packages/types/package.json ./packages/types/
 COPY packages/module-registry/package.json ./packages/module-registry/
 COPY packages/app-food-db/package.json ./packages/app-food-db/
 COPY packages/app-lists/package.json ./packages/app-lists/
+COPY packages/food-contracts/package.json ./packages/food-contracts/
 COPY apps/pops-api/package.json ./apps/pops-api/
 
 # Install pnpm and dependencies (cached across builds)
@@ -26,6 +27,8 @@ COPY packages/module-registry/tsconfig.json packages/module-registry/tsconfig.bu
 COPY packages/app-lists/src ./packages/app-lists/src
 COPY packages/app-food-db/src ./packages/app-food-db/src
 COPY packages/app-food-db/tsconfig.json ./packages/app-food-db/
+COPY packages/food-contracts/src ./packages/food-contracts/src
+COPY packages/food-contracts/tsconfig.json ./packages/food-contracts/
 COPY apps/pops-api/tsconfig.json ./apps/pops-api/
 COPY apps/pops-api/src ./apps/pops-api/src
 

--- a/apps/pops-api/Dockerfile
+++ b/apps/pops-api/Dockerfile
@@ -39,6 +39,8 @@ WORKDIR /app/packages/types
 RUN pnpm build
 WORKDIR /app/packages/module-registry
 RUN pnpm build
+WORKDIR /app/packages/food-contracts
+RUN pnpm build
 WORKDIR /app/packages/app-food-db
 RUN pnpm build
 

--- a/apps/pops-api/package.json
+++ b/apps/pops-api/package.json
@@ -74,6 +74,7 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@pops/app-food-db": "workspace:*",
     "@pops/db-types": "workspace:*",
+    "@pops/food-contracts": "workspace:*",
     "@pops/module-registry": "workspace:*",
     "@pops/types": "workspace:*",
     "@trpc/client": "11.17.0",

--- a/apps/pops-api/src/app.ts
+++ b/apps/pops-api/src/app.ts
@@ -13,6 +13,7 @@ import { openApiDocument } from './openapi.js';
 import { appRouter } from './router.js';
 import cerebrumQueryStreamRouter from './routes/cerebrum/query-stream.js';
 import egoChatStreamRouter from './routes/ego/chat-stream.js';
+import foodIngestFilesRouter from './routes/food/ingest-files.js';
 import foodRecipesImagesRouter from './routes/food/recipes.js';
 import healthRouter from './routes/health.js';
 import inventoryDocumentFilesRouter from './routes/inventory/document-files.js';
@@ -73,6 +74,11 @@ export function createApp(): express.Express {
   // Food recipe hero image serving — static files from FOOD_RECIPES_DIR.
   // Placed before authMiddleware so <img> tags can render without JWT cookies.
   app.use(foodRecipesImagesRouter);
+
+  // Food ingest media serving — screenshots + downloaded videos from
+  // FOOD_INGEST_DIR. Placed before authMiddleware so the inbox UI can render
+  // them via plain <img>/<video> tags. PRD-125 / PRD-110.
+  app.use(foodIngestFilesRouter);
 
   // Cloudflare Access JWT auth — validates cf-access-jwt-assertion header.
   // Placed after health/webhook/media routes (those skip auth or use their own).

--- a/apps/pops-api/src/db/drizzle-migrations/0067_prd_125_ingest_error_columns.sql
+++ b/apps/pops-api/src/db/drizzle-migrations/0067_prd_125_ingest_error_columns.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `ingest_sources` ADD `error_code` text;--> statement-breakpoint
+ALTER TABLE `ingest_sources` ADD `error_message` text;--> statement-breakpoint
+ALTER TABLE `ingest_sources` ADD `attempts` integer DEFAULT 0 NOT NULL;

--- a/apps/pops-api/src/db/drizzle-migrations/meta/0066_snapshot.json
+++ b/apps/pops-api/src/db/drizzle-migrations/meta/0066_snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "d5410a4e-4f71-4c81-a9fe-dbf8d72a9905",
+  "id": "309f74ab-5b94-4b34-a595-575bdf265a8b",
   "prevId": "4a15eba6-d936-4c8d-a437-498af360bd4e",
   "tables": {
     "ai_alert_rules": {
@@ -3210,176 +3210,6 @@
       "uniqueConstraints": {},
       "checkConstraints": {}
     },
-    "ingredient_weights": {
-      "name": "ingredient_weights",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "integer",
-          "primaryKey": true,
-          "notNull": true,
-          "autoincrement": true
-        },
-        "ingredient_id": {
-          "name": "ingredient_id",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "variant_id": {
-          "name": "variant_id",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "unit": {
-          "name": "unit",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "grams": {
-          "name": "grams",
-          "type": "real",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "notes": {
-          "name": "notes",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "is_seeded": {
-          "name": "is_seeded",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": 0
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(datetime('now'))"
-        }
-      },
-      "indexes": {
-        "idx_ingredient_weights_ingredient": {
-          "name": "idx_ingredient_weights_ingredient",
-          "columns": ["ingredient_id"],
-          "isUnique": false
-        },
-        "uq_ingredient_weights_ing_var_unit": {
-          "name": "uq_ingredient_weights_ing_var_unit",
-          "columns": ["ingredient_id", "variant_id", "unit"],
-          "isUnique": true
-        }
-      },
-      "foreignKeys": {
-        "ingredient_weights_ingredient_id_ingredients_id_fk": {
-          "name": "ingredient_weights_ingredient_id_ingredients_id_fk",
-          "tableFrom": "ingredient_weights",
-          "tableTo": "ingredients",
-          "columnsFrom": ["ingredient_id"],
-          "columnsTo": ["id"],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        },
-        "ingredient_weights_variant_id_ingredient_variants_id_fk": {
-          "name": "ingredient_weights_variant_id_ingredient_variants_id_fk",
-          "tableFrom": "ingredient_weights",
-          "tableTo": "ingredient_variants",
-          "columnsFrom": ["variant_id"],
-          "columnsTo": ["id"],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "checkConstraints": {}
-    },
-    "unit_conversions": {
-      "name": "unit_conversions",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "integer",
-          "primaryKey": true,
-          "notNull": true,
-          "autoincrement": true
-        },
-        "from_unit": {
-          "name": "from_unit",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "to_unit": {
-          "name": "to_unit",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "ratio": {
-          "name": "ratio",
-          "type": "real",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "notes": {
-          "name": "notes",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "is_seeded": {
-          "name": "is_seeded",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": 0
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(datetime('now'))"
-        }
-      },
-      "indexes": {
-        "idx_unit_conversions_from": {
-          "name": "idx_unit_conversions_from",
-          "columns": ["from_unit"],
-          "isUnique": false
-        },
-        "uq_unit_conversions_from_to": {
-          "name": "uq_unit_conversions_from_to",
-          "columns": ["from_unit", "to_unit"],
-          "isUnique": true
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "checkConstraints": {}
-    },
     "ingest_sources": {
       "name": "ingest_sources",
       "columns": {
@@ -3467,6 +3297,28 @@
           "primaryKey": false,
           "notNull": false,
           "autoincrement": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
         }
       },
       "indexes": {

--- a/apps/pops-api/src/db/drizzle-migrations/meta/0067_snapshot.json
+++ b/apps/pops-api/src/db/drizzle-migrations/meta/0067_snapshot.json
@@ -1,8 +1,8 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "d5410a4e-4f71-4c81-a9fe-dbf8d72a9905",
-  "prevId": "4a15eba6-d936-4c8d-a437-498af360bd4e",
+  "id": "79b20572-6281-4058-a0d0-1ab0245842f6",
+  "prevId": "d5410a4e-4f71-4c81-a9fe-dbf8d72a9905",
   "tables": {
     "ai_alert_rules": {
       "name": "ai_alert_rules",
@@ -3467,6 +3467,28 @@
           "primaryKey": false,
           "notNull": false,
           "autoincrement": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
         }
       },
       "indexes": {

--- a/apps/pops-api/src/db/drizzle-migrations/meta/_journal.json
+++ b/apps/pops-api/src/db/drizzle-migrations/meta/_journal.json
@@ -474,7 +474,7 @@
     {
       "idx": 67,
       "version": "6",
-      "when": 1780998216746,
+      "when": 1781005533881,
       "tag": "0067_prd_125_ingest_error_columns",
       "breakpoints": true
     }

--- a/apps/pops-api/src/db/drizzle-migrations/meta/_journal.json
+++ b/apps/pops-api/src/db/drizzle-migrations/meta/_journal.json
@@ -470,6 +470,13 @@
       "when": 1780997760458,
       "tag": "0066_prd_123_conversions",
       "breakpoints": true
+    },
+    {
+      "idx": 67,
+      "version": "6",
+      "when": 1780998216746,
+      "tag": "0067_prd_125_ingest_error_columns",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/pops-api/src/db/migration-ownership.ts
+++ b/apps/pops-api/src/db/migration-ownership.ts
@@ -94,6 +94,9 @@ export const MIGRATION_OWNERS: Readonly<Record<string, string>> = {
   '0065_prd_116_recipe_compile': 'food',
   // PRD-123 — unit_conversions + ingredient_weights.
   '0066_prd_123_conversions': 'food',
+  // PRD-125 amendment to PRD-110 — error_code/error_message/attempts columns
+  // on ingest_sources for failure-band persistence across BullMQ TTL.
+  '0067_prd_125_ingest_error_columns': 'food',
 };
 
 /** Materialised as a Map for O(1) lookup by the runner. */

--- a/apps/pops-api/src/modules/cerebrum/engrams/router.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/router.test.ts
@@ -12,7 +12,11 @@ import { resetCerebrumCache } from '../instance.js';
 import type { Database } from 'better-sqlite3';
 
 function createCaller() {
-  return appRouter.createCaller({ user: { email: 'test@example.com' }, serviceAccount: null });
+  return appRouter.createCaller({
+    user: { email: 'test@example.com' },
+    serviceAccount: null,
+    internalCaller: false,
+  });
 }
 
 describe('cerebrum tRPC router', () => {

--- a/apps/pops-api/src/modules/cerebrum/engrams/scopes-router.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/scopes-router.test.ts
@@ -142,7 +142,11 @@ describe('EngramService.create scope inference', () => {
 // ---------------------------------------------------------------------------
 
 function createCaller() {
-  return appRouter.createCaller({ user: { email: 'test@example.com' }, serviceAccount: null });
+  return appRouter.createCaller({
+    user: { email: 'test@example.com' },
+    serviceAccount: null,
+    internalCaller: false,
+  });
 }
 
 describe('cerebrum.scopes tRPC procedures', () => {

--- a/apps/pops-api/src/modules/food/__tests__/hero-image-router.test.ts
+++ b/apps/pops-api/src/modules/food/__tests__/hero-image-router.test.ts
@@ -282,7 +282,11 @@ describe('food.heroImage router', () => {
     });
 
     it('throws UNAUTHORIZED without auth', async () => {
-      const unauth = appRouter.createCaller({ user: null, serviceAccount: null });
+      const unauth = appRouter.createCaller({
+        user: null,
+        serviceAccount: null,
+        internalCaller: false,
+      });
       await expect(
         unauth.food.heroImage.upload({
           recipeId: 1,

--- a/apps/pops-api/src/modules/food/__tests__/ingest-router.test.ts
+++ b/apps/pops-api/src/modules/food/__tests__/ingest-router.test.ts
@@ -1,0 +1,280 @@
+/**
+ * PRD-125 — integration tests for `food.ingest.*` procedures.
+ *
+ * Uses an in-memory SQLite seeded with the food migrations (PRDs 106–116)
+ * and stubs out the BullMQ queue to capture the enqueued jobs without
+ * needing a live Redis. The food.ingest queue helper is mocked at the
+ * module level; the rest of the router runs against the real DB so the
+ * transactional `workerComplete` flow (createRecipe + compileRecipeVersion
+ * + ingest_sources update) is exercised end-to-end.
+ */
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import BetterSqlite3, { type Database } from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { closeDb, setDb } from '../../../db.js';
+import { appRouter } from '../../../router.js';
+
+import type { Context } from '../../../trpc.js';
+
+interface CapturedJob {
+  id: string;
+  data: unknown;
+  name: string;
+}
+
+const enqueuedJobs: CapturedJob[] = [];
+let nextJobIdCounter = 0;
+let queueDisabled = false;
+
+vi.mock('../queue.js', async () => {
+  const actual = await vi.importActual<typeof import('../queue.js')>('../queue.js');
+  return {
+    ...actual,
+    getFoodIngestQueue: () => {
+      if (queueDisabled) return null;
+      return {
+        async add(name: string, data: unknown) {
+          const id = String(++nextJobIdCounter);
+          enqueuedJobs.push({ id, data, name });
+          return { id };
+        },
+        async getJobs(_states: readonly string[], _start: number, _end: number) {
+          return enqueuedJobs.map((j) => ({
+            id: j.id,
+            data: j.data,
+            getState: async () => 'waiting' as const,
+            processedOn: null,
+            finishedOn: null,
+            remove: async () => {
+              const idx = enqueuedJobs.findIndex((other) => other.id === j.id);
+              if (idx >= 0) enqueuedJobs.splice(idx, 1);
+            },
+          }));
+        },
+      };
+    },
+    closeFoodIngestQueue: async () => {},
+  };
+});
+
+const FOOD_MIGRATIONS = [
+  '0058_high_sentinel.sql',
+  '0059_useful_hiroim.sql',
+  '0060_familiar_leo.sql',
+  '0061_shocking_skreet.sql',
+  '0062_chemical_donald_blake.sql',
+  '0063_bumpy_wolverine.sql',
+  '0064_peaceful_magma.sql',
+  '0065_prd_116_recipe_compile.sql',
+  '0066_prd_123_conversions.sql',
+  '0067_prd_125_ingest_error_columns.sql',
+];
+
+function applyMigrations(db: Database): void {
+  for (const name of FOOD_MIGRATIONS) {
+    const sql = readFileSync(join(__dirname, '../../../db/drizzle-migrations', name), 'utf8');
+    const statements = sql.split('--> statement-breakpoint');
+    for (const stmt of statements) {
+      const trimmed = stmt.trim();
+      if (trimmed.length > 0) db.exec(trimmed);
+    }
+  }
+}
+
+function createInternalCaller(): ReturnType<typeof appRouter.createCaller> {
+  const ctx: Context = { user: null, serviceAccount: null, internalCaller: true };
+  return appRouter.createCaller(ctx);
+}
+
+function createPublicCaller(): ReturnType<typeof appRouter.createCaller> {
+  const ctx: Context = {
+    user: { email: 'test@example.com' },
+    serviceAccount: null,
+    internalCaller: false,
+  };
+  return appRouter.createCaller(ctx);
+}
+
+let db: Database;
+let ingestDirRoot: string;
+
+beforeEach(() => {
+  enqueuedJobs.length = 0;
+  nextJobIdCounter = 0;
+  queueDisabled = false;
+  db = new BetterSqlite3(':memory:');
+  db.pragma('foreign_keys = ON');
+  applyMigrations(db);
+  setDb(db);
+  ingestDirRoot = mkdtempSync(join(tmpdir(), 'pops-food-ingest-'));
+  process.env['FOOD_INGEST_DIR'] = ingestDirRoot;
+  // Internal-token enabled for workerComplete tests; cleared per-case as needed.
+  process.env['POPS_API_INTERNAL_TOKEN'] = 'test-internal-token';
+  // Redis env required to keep the queue helper non-null in non-mocked paths.
+  process.env['REDIS_HOST'] ??= 'localhost';
+});
+
+afterEach(() => {
+  closeDb();
+  rmSync(ingestDirRoot, { recursive: true, force: true });
+});
+
+describe('food.ingest.start', () => {
+  it('enqueues a url-web job and writes ingest_sources row', async () => {
+    const caller = createPublicCaller();
+    const result = await caller.food.ingest.start({
+      kind: 'url-web',
+      url: 'https://example.com/recipe',
+    });
+    expect(result.sourceId).toBeGreaterThan(0);
+    expect(result.jobId).toBeTruthy();
+    const rows = db.prepare(`SELECT * FROM ingest_sources WHERE id = ?`).all(result.sourceId) as {
+      kind: string;
+      url: string | null;
+      attempts: number;
+    }[];
+    expect(rows[0]?.kind).toBe('url-web');
+    expect(rows[0]?.url).toBe('https://example.com/recipe');
+    expect(rows[0]?.attempts).toBe(0);
+    expect(enqueuedJobs.length).toBe(1);
+  });
+
+  it('writes screenshot to disk before enqueue', async () => {
+    const caller = createPublicCaller();
+    const tinyPng = Buffer.from(
+      '89504e470d0a1a0a0000000d49484452000000010000000108020000009077533d0000000a49444154789c63f8cf00000200012b14ad3e0000000049454e44ae426082',
+      'hex'
+    );
+    const result = await caller.food.ingest.start({
+      kind: 'screenshot',
+      mimeType: 'image/png',
+      contentBase64: tinyPng.toString('base64'),
+    });
+    const fileExists = readFileSync(join(ingestDirRoot, String(result.sourceId), 'screenshot.png'));
+    expect(fileExists.length).toBe(tinyPng.length);
+    expect(enqueuedJobs[0]?.data).toMatchObject({
+      kind: 'screenshot',
+      contentPath: `${result.sourceId}/screenshot.png`,
+    });
+  });
+
+  it('rejects malformed urls with InvalidIngestInput', async () => {
+    const caller = createPublicCaller();
+    await expect(caller.food.ingest.start({ kind: 'url-web', url: 'not-a-url' })).rejects.toThrow();
+  });
+
+  it('returns SERVICE_UNAVAILABLE when Redis is down', async () => {
+    queueDisabled = true;
+    const caller = createPublicCaller();
+    await expect(
+      caller.food.ingest.start({ kind: 'text', body: 'Smash burger recipe' })
+    ).rejects.toMatchObject({ code: 'SERVICE_UNAVAILABLE' });
+  });
+});
+
+describe('food.ingest.retry', () => {
+  it('reuses sourceId, increments attempts, clears error', async () => {
+    const caller = createPublicCaller();
+    const first = await caller.food.ingest.start({
+      kind: 'url-web',
+      url: 'https://example.com/r',
+    });
+    db.prepare(`UPDATE ingest_sources SET error_code = 'X', error_message = 'Y' WHERE id = ?`).run(
+      first.sourceId
+    );
+    const retry = await caller.food.ingest.retry({ sourceId: first.sourceId });
+    expect(retry.jobId).not.toBe(first.jobId);
+    const row = db
+      .prepare(`SELECT attempts, error_code FROM ingest_sources WHERE id = ?`)
+      .get(first.sourceId) as { attempts: number; error_code: string | null };
+    expect(row.attempts).toBe(1);
+    expect(row.error_code).toBeNull();
+  });
+});
+
+describe('food.ingest.cancel', () => {
+  it('removes the BullMQ job when still waiting', async () => {
+    const caller = createPublicCaller();
+    const started = await caller.food.ingest.start({
+      kind: 'text',
+      body: 'Test recipe text',
+    });
+    const cancelled = await caller.food.ingest.cancel({ sourceId: started.sourceId });
+    expect(cancelled).toEqual({ ok: true });
+    expect(enqueuedJobs.length).toBe(0);
+  });
+
+  it('returns not-cancellable when no job exists for the sourceId', async () => {
+    const caller = createPublicCaller();
+    const cancelled = await caller.food.ingest.cancel({ sourceId: 99999 });
+    expect(cancelled).toEqual({ ok: false, reason: 'not-cancellable' });
+  });
+});
+
+describe('food.ingest.workerComplete', () => {
+  it('rejects calls without the internal token', async () => {
+    const caller = createPublicCaller();
+    await expect(
+      caller.food.ingest.workerComplete({
+        sourceId: 1,
+        ok: false,
+        errorCode: 'X',
+        errorMessage: 'Y',
+        meta: { extractor_version: 'v1', stages: {} },
+      })
+    ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+  });
+
+  it('persists failure rollup to ingest_sources on ok: false', async () => {
+    const publicCaller = createPublicCaller();
+    const started = await publicCaller.food.ingest.start({
+      kind: 'text',
+      body: 'A recipe',
+    });
+    const caller = createInternalCaller();
+    const result = await caller.food.ingest.workerComplete({
+      sourceId: started.sourceId,
+      ok: false,
+      errorCode: 'EMPTY_EXTRACTION',
+      errorMessage: 'LLM produced no ingredients',
+      meta: { extractor_version: 'v1', stages: { llm: { ok: false } } },
+    });
+    expect(result).toEqual({ ok: false, reason: 'EMPTY_EXTRACTION' });
+    const row = db
+      .prepare(`SELECT error_code, extracted_json FROM ingest_sources WHERE id = ?`)
+      .get(started.sourceId) as { error_code: string; extracted_json: string };
+    expect(row.error_code).toBe('EMPTY_EXTRACTION');
+    expect(JSON.parse(row.extracted_json).extractor_version).toBe('v1');
+  });
+
+  it('creates recipe + version + ingest_sources update on ok: true', async () => {
+    const publicCaller = createPublicCaller();
+    const started = await publicCaller.food.ingest.start({
+      kind: 'text',
+      body: 'A recipe',
+    });
+    const caller = createInternalCaller();
+    const dsl = '@recipe smash-burger "Smash burger"\n@yield 4 burger\n@step\nSear patties.';
+    const result = await caller.food.ingest.workerComplete({
+      sourceId: started.sourceId,
+      ok: true,
+      dsl,
+      meta: { extractor_version: 'v1', stages: { dsl_build: { ok: true } } },
+    });
+    if (!result.ok) throw new Error('expected ok=true');
+    expect(result.draftRecipeId).toBeGreaterThan(0);
+    const sourceRow = db
+      .prepare(`SELECT draft_recipe_id FROM ingest_sources WHERE id = ?`)
+      .get(started.sourceId) as { draft_recipe_id: number };
+    expect(sourceRow.draft_recipe_id).toBe(result.draftRecipeId);
+    const versionRow = db
+      .prepare(`SELECT body_dsl, source_id FROM recipe_versions WHERE recipe_id = ?`)
+      .get(result.draftRecipeId) as { body_dsl: string; source_id: number | null };
+    expect(versionRow.body_dsl).toContain('Sear patties');
+    expect(versionRow.source_id).toBe(started.sourceId);
+  });
+});

--- a/apps/pops-api/src/modules/food/__tests__/ingest-router.test.ts
+++ b/apps/pops-api/src/modules/food/__tests__/ingest-router.test.ts
@@ -338,4 +338,56 @@ describe('food.ingest.workerComplete', () => {
       })
     ).rejects.toThrow();
   });
+
+  it('throws when sourceId does not exist (no silent UPDATE)', async () => {
+    const caller = createInternalCaller();
+    await expect(
+      caller.food.ingest.workerComplete({
+        sourceId: 99999,
+        ok: false,
+        errorCode: 'X',
+        errorMessage: 'Y',
+        meta: { extractor_version: 'v1', stages: {} },
+      })
+    ).rejects.toThrow();
+  });
+
+  it('is idempotent on ok=true — second call returns the same draftRecipeId', async () => {
+    const publicCaller = createPublicCaller();
+    const started = await publicCaller.food.ingest.start({ kind: 'text', body: 'r' });
+    const caller = createInternalCaller();
+    const dsl = '@recipe(slug=idem, title="Idempotent")\n@yield 1 x';
+    const first = await caller.food.ingest.workerComplete({
+      sourceId: started.sourceId,
+      ok: true,
+      dsl,
+      meta: { extractor_version: 'v1', stages: {} },
+    });
+    if (!first.ok) throw new Error('expected ok=true');
+    const second = await caller.food.ingest.workerComplete({
+      sourceId: started.sourceId,
+      ok: true,
+      dsl,
+      meta: { extractor_version: 'v1', stages: {} },
+    });
+    if (!second.ok) throw new Error('expected ok=true');
+    expect(second.draftRecipeId).toBe(first.draftRecipeId);
+    // Single recipe row — no duplicate slug insert.
+    const recipeCount = (db.prepare(`SELECT COUNT(*) AS n FROM recipes`).get() as { n: number }).n;
+    expect(recipeCount).toBe(1);
+  });
+});
+
+describe('food.ingest.start rollback', () => {
+  it('removes the ingest_sources row when enqueue fails', async () => {
+    queueDisabled = true;
+    const caller = createPublicCaller();
+    const before = (db.prepare(`SELECT COUNT(*) AS n FROM ingest_sources`).get() as { n: number })
+      .n;
+    await expect(
+      caller.food.ingest.start({ kind: 'text', body: 'A recipe' })
+    ).rejects.toMatchObject({ code: 'SERVICE_UNAVAILABLE' });
+    const after = (db.prepare(`SELECT COUNT(*) AS n FROM ingest_sources`).get() as { n: number }).n;
+    expect(after).toBe(before);
+  });
 });

--- a/apps/pops-api/src/modules/food/__tests__/ingest-router.test.ts
+++ b/apps/pops-api/src/modules/food/__tests__/ingest-router.test.ts
@@ -277,4 +277,65 @@ describe('food.ingest.workerComplete', () => {
     expect(versionRow.body_dsl).toContain('Sear patties');
     expect(versionRow.source_id).toBe(started.sourceId);
   });
+
+  it('persists partialReason inside extracted_json so status can recover it', async () => {
+    const publicCaller = createPublicCaller();
+    const started = await publicCaller.food.ingest.start({
+      kind: 'url-instagram',
+      url: 'https://instagram.com/p/abc',
+    });
+    const caller = createInternalCaller();
+    const dsl = '@recipe(slug=foo, title="Partial")\n@yield 1 thing';
+    const result = await caller.food.ingest.workerComplete({
+      sourceId: started.sourceId,
+      ok: true,
+      dsl,
+      meta: { extractor_version: 'v1', stages: { stt: { ok: false } } },
+      partialReason: 'stt-failed',
+    });
+    if (!result.ok) throw new Error('expected ok=true');
+    const row = db
+      .prepare(`SELECT extracted_json FROM ingest_sources WHERE id = ?`)
+      .get(started.sourceId) as { extracted_json: string };
+    const parsed = JSON.parse(row.extracted_json) as { partialReason: string };
+    expect(parsed.partialReason).toBe('stt-failed');
+  });
+
+  it('derives title from @recipe(... title="...") not a missing @title token', async () => {
+    const publicCaller = createPublicCaller();
+    const started = await publicCaller.food.ingest.start({
+      kind: 'text',
+      body: 'A recipe',
+    });
+    const caller = createInternalCaller();
+    const dsl =
+      '@recipe(slug=carbonara, title="Spaghetti carbonara")\n@yield 2 plates\n@step\nWhisk.';
+    const result = await caller.food.ingest.workerComplete({
+      sourceId: started.sourceId,
+      ok: true,
+      dsl,
+      meta: { extractor_version: 'v1', stages: {} },
+    });
+    if (!result.ok) throw new Error('expected ok=true');
+    const versionRow = db
+      .prepare(`SELECT title FROM recipe_versions WHERE recipe_id = ?`)
+      .get(result.draftRecipeId) as { title: string };
+    expect(versionRow.title).toBe('Spaghetti carbonara');
+  });
+
+  it('rejects partialReason values outside the closed enum', async () => {
+    const publicCaller = createPublicCaller();
+    const started = await publicCaller.food.ingest.start({ kind: 'text', body: 'r' });
+    const caller = createInternalCaller();
+    await expect(
+      caller.food.ingest.workerComplete({
+        sourceId: started.sourceId,
+        ok: true,
+        dsl: '@recipe(slug=r, title="r")\n@yield 1 x',
+        meta: { extractor_version: 'v1', stages: {} },
+        // @ts-expect-error — runtime rejection test for the Zod enum gate
+        partialReason: 'made-up-reason',
+      })
+    ).rejects.toThrow();
+  });
 });

--- a/apps/pops-api/src/modules/food/index.ts
+++ b/apps/pops-api/src/modules/food/index.ts
@@ -3,9 +3,10 @@
  *
  * PRD-122 (data management page) wires six sub-routers under `food.*`:
  * ingredients, variants, aliases, prepStates, substitutions, slugs. PRD-123
- * adds `conversions`; PRD-124 adds `heroImage`. Recipe mutations come later
- * via PRD-119. The shared `slugs.search` procedure is consumed by both the
- * data page and PRD-120's DSL editor.
+ * adds `conversions`; PRD-124 adds `heroImage`; PRD-125 adds `ingest` (the
+ * ingestion-pipeline producer + internal `workerComplete` mutation). Recipe
+ * mutations come later via PRD-119. The shared `slugs.search` procedure is
+ * consumed by both the data page and PRD-120's DSL editor.
  *
  * See `docs/themes/07-food/` for the theme spec.
  */
@@ -14,6 +15,7 @@ import { conversionsRouter } from './conversions/router.js';
 import { heroImageRouter } from './hero-image/router.js';
 import { foodMigrations } from './migrations.js';
 import { aliasesRouter } from './routers/aliases.js';
+import { ingestRouter } from './routers/ingest-router.js';
 import { ingredientsRouter } from './routers/ingredients.js';
 import { prepStatesRouter } from './routers/prep-states.js';
 import { slugsRouter } from './routers/slugs.js';
@@ -24,6 +26,7 @@ import type { ModuleManifest } from '@pops/types';
 
 export const foodRouter = router({
   heroImage: heroImageRouter,
+  ingest: ingestRouter,
   ingredients: ingredientsRouter,
   variants: variantsRouter,
   aliases: aliasesRouter,

--- a/apps/pops-api/src/modules/food/index.ts
+++ b/apps/pops-api/src/modules/food/index.ts
@@ -1,12 +1,17 @@
 /**
  * Food domain — backend module.
  *
- * PRD-122 (data management page) wires six sub-routers under `food.*`:
- * ingredients, variants, aliases, prepStates, substitutions, slugs. PRD-123
- * adds `conversions`; PRD-124 adds `heroImage`; PRD-125 adds `ingest` (the
- * ingestion-pipeline producer + internal `workerComplete` mutation). Recipe
- * mutations come later via PRD-119. The shared `slugs.search` procedure is
- * consumed by both the data page and PRD-120's DSL editor.
+ * Mounts the per-domain sub-routers under `food.*`:
+ *
+ *   - `food.heroImage`     — PRD-124 hero image upload + thumbnail pipeline.
+ *   - `food.ingest`        — PRD-125 ingestion API (BullMQ producer +
+ *                            internal `workerComplete` for the worker).
+ *   - `food.ingredients` / `variants` / `aliases` / `prepStates` /
+ *     `substitutions` / `slugs` — PRD-122 part API data-management surface.
+ *   - `food.conversions`   — PRD-123 phase B unit conversions.
+ *
+ * Recipe CRUD lands later via PRD-119. Migration tags owned by this module
+ * are listed in `migrations.ts`.
  *
  * See `docs/themes/07-food/` for the theme spec.
  */

--- a/apps/pops-api/src/modules/food/migrations.ts
+++ b/apps/pops-api/src/modules/food/migrations.ts
@@ -29,6 +29,9 @@ export const foodMigrationTags: readonly string[] = [
   '0065_prd_116_recipe_compile',
   // PRD-123 — unit_conversions + ingredient_weights.
   '0066_prd_123_conversions',
+  // PRD-125 amendment to PRD-110 — error_code/error_message/attempts columns on
+  // ingest_sources (persists failure detail past BullMQ TTL).
+  '0067_prd_125_ingest_error_columns',
 ];
 
 export const foodMigrations: readonly MigrationDescriptor[] = drizzleMigrations(foodMigrationTags);

--- a/apps/pops-api/src/modules/food/queue.ts
+++ b/apps/pops-api/src/modules/food/queue.ts
@@ -1,0 +1,102 @@
+/**
+ * PRD-125 — BullMQ producer for the `food.ingest` queue.
+ *
+ * pops-api is the producer (enqueue, status, cancel, retry); the consumer
+ * runs in `pops-worker-food` (PRD-126's separate container). The queue
+ * name + job-data shape are defined in `@pops/food-contracts` so both
+ * sides agree on a single source of truth.
+ *
+ * Lazy singleton; closed on graceful shutdown via `closeFoodIngestQueue`.
+ * Mirrors the pattern in `apps/pops-api/src/jobs/queues.ts` so the new
+ * food.* queues compose into the same lifecycle.
+ *
+ * `FOOD_INGEST_RATE_PER_MIN` controls the worker-side rate limiter (default
+ * 30/min — conservative bound against runaway Anthropic spend). The
+ * producer doesn't enforce it; the consumer in PRD-126 reads the same
+ * env var and passes it to BullMQ's `limiter`.
+ */
+import { Queue } from 'bullmq';
+import pino from 'pino';
+
+import { FOOD_INGEST_QUEUE_NAME, type IngestJobData } from '@pops/food-contracts';
+
+import { createRedisConnection } from '../../jobs/redis.js';
+
+import type { DefaultJobOptions } from 'bullmq';
+
+const logger = pino({ name: 'pops-jobs:food-ingest' });
+
+// Defaults documented in PRD-125. All three are env-overridable.
+const DEFAULT_RATE_PER_MIN = 30;
+const DEFAULT_TIMEOUT_SEC = 300;
+const DEFAULT_CONCURRENCY = 2;
+/** Worker-side stalled-job tunables; passed through `IngestRuntimeConfig` for PRD-126. */
+export const FOOD_INGEST_STALLED_INTERVAL_MS = 30_000;
+export const FOOD_INGEST_MAX_STALLED_COUNT = 1;
+const ATTEMPTS = 3;
+const BACKOFF_DELAY_MS = 5_000;
+const REMOVE_KEEP_COUNT = 1_000;
+
+export const FOOD_INGEST_JOB_OPTIONS: DefaultJobOptions = {
+  attempts: ATTEMPTS,
+  backoff: { type: 'exponential', delay: BACKOFF_DELAY_MS }, // 5s, 10s, 20s
+  removeOnComplete: { count: REMOVE_KEEP_COUNT },
+  removeOnFail: { count: REMOVE_KEEP_COUNT },
+};
+
+/** Per-PRD: 30 jobs/min default, env-tunable for tighter / looser caps. */
+export function getFoodIngestRatePerMin(): number {
+  const raw = process.env['FOOD_INGEST_RATE_PER_MIN'];
+  const parsed = raw === undefined ? DEFAULT_RATE_PER_MIN : Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_RATE_PER_MIN;
+}
+
+export function getFoodIngestTimeoutSec(): number {
+  const raw = process.env['FOOD_INGEST_TIMEOUT_SEC'];
+  const parsed = raw === undefined ? DEFAULT_TIMEOUT_SEC : Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_TIMEOUT_SEC;
+}
+
+export function getFoodWorkerConcurrency(): number {
+  const raw = process.env['FOOD_WORKER_CONCURRENCY'];
+  const parsed = raw === undefined ? DEFAULT_CONCURRENCY : Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : DEFAULT_CONCURRENCY;
+}
+
+let queueSingleton: Queue<IngestJobData> | null = null;
+let redisDisabled = false;
+
+/**
+ * Returns the lazy singleton. Returns null when Redis is not configured
+ * (matches the sibling queue pattern — keeps tests + dev runs without
+ * Redis from blowing up at module init).
+ *
+ * `stalledInterval` + `maxStalledCount` are queue-side; PRD-126's
+ * worker reads `FOOD_INGEST_RATE_PER_MIN` and `FOOD_INGEST_TIMEOUT_SEC`
+ * directly for its own `limiter` + `lockDuration`.
+ */
+export function getFoodIngestQueue(): Queue<IngestJobData> | null {
+  if (redisDisabled) return null;
+  if (queueSingleton !== null) return queueSingleton;
+  if (process.env['REDIS_HOST'] === undefined && process.env['REDIS_URL'] === undefined) {
+    // Mirror queues.ts: warn once and disable so the API stays up.
+    logger.warn(
+      { queue: FOOD_INGEST_QUEUE_NAME },
+      'Redis unavailable — food.ingest queue disabled (REDIS_HOST / REDIS_URL not set)'
+    );
+    redisDisabled = true;
+    return null;
+  }
+  const connection = createRedisConnection();
+  queueSingleton = new Queue<IngestJobData>(FOOD_INGEST_QUEUE_NAME, {
+    connection,
+    defaultJobOptions: FOOD_INGEST_JOB_OPTIONS,
+  });
+  return queueSingleton;
+}
+
+export async function closeFoodIngestQueue(): Promise<void> {
+  await queueSingleton?.close();
+  queueSingleton = null;
+  redisDisabled = false;
+}

--- a/apps/pops-api/src/modules/food/routers/ingest-procedures-control.ts
+++ b/apps/pops-api/src/modules/food/routers/ingest-procedures-control.ts
@@ -1,0 +1,116 @@
+/**
+ * PRD-125 — `food.ingest.cancel` and `food.ingest.retry` implementations.
+ *
+ * `cancel` is best-effort: it removes the BullMQ job if still queued /
+ * processing; the worker is responsible for honouring cancellation between
+ * pipeline stages (PRD-126). `retry` re-enqueues with the same input,
+ * increments `attempts`, and reuses the same `sourceId`.
+ */
+import { eq, sql } from 'drizzle-orm';
+
+import { type FoodDb, ingestSources } from '@pops/app-food-db';
+
+import { getFoodIngestQueue } from '../queue.js';
+import { enqueueIngestJob, type EnqueueResult } from '../services/ingest-enqueue.js';
+
+import type { IngestJobData } from '@pops/food-contracts';
+
+const CANCELLABLE = new Set(['waiting', 'delayed', 'active', 'waiting_children', 'prioritized']);
+
+async function findJobBySourceId(
+  sourceId: number
+): Promise<
+  Awaited<ReturnType<NonNullable<ReturnType<typeof getFoodIngestQueue>>['getJobs']>>[number] | null
+> {
+  const queue = getFoodIngestQueue();
+  if (queue === null) return null;
+  const jobs = await queue.getJobs(['waiting', 'delayed', 'active'], 0, 99);
+  for (const job of jobs) {
+    const data: unknown = job.data;
+    if (
+      typeof data === 'object' &&
+      data !== null &&
+      (data as { sourceId?: number }).sourceId === sourceId
+    ) {
+      return job;
+    }
+  }
+  return null;
+}
+
+export type CancelOutcome = { ok: true } | { ok: false; reason: 'not-cancellable' };
+
+export async function cancelIngest(sourceId: number): Promise<CancelOutcome> {
+  const job = await findJobBySourceId(sourceId);
+  if (job === null) return { ok: false, reason: 'not-cancellable' };
+  const state = await job.getState();
+  if (!CANCELLABLE.has(state)) return { ok: false, reason: 'not-cancellable' };
+  await job.remove();
+  return { ok: true };
+}
+
+/**
+ * Reconstructs the job-data from the persisted `ingest_sources` row so the
+ * retry uses the same inputs the original `start` enqueued. Bumps
+ * `attempts` atomically with the enqueue's "fire" — if the enqueue fails,
+ * the increment is rolled back so user-facing attempts stays accurate.
+ */
+function jobDataFromRow(row: {
+  id: number;
+  kind: 'url-web' | 'url-instagram' | 'text' | 'screenshot';
+  url: string | null;
+  caption: string | null;
+}): IngestJobData {
+  switch (row.kind) {
+    case 'url-web':
+    case 'url-instagram':
+      if (row.url === null) {
+        throw new Error(`Retry blocked: ingest_sources #${row.id} missing url`);
+      }
+      return { kind: row.kind, sourceId: row.id, url: row.url };
+    case 'text':
+      if (row.caption === null) {
+        throw new Error(`Retry blocked: ingest_sources #${row.id} missing caption/body`);
+      }
+      return { kind: 'text', sourceId: row.id, body: row.caption };
+    case 'screenshot':
+      // Screenshot retry reuses the original on-disk file under the per-
+      // source dir. The worker resolves via `ingestRootDir()`.
+      return {
+        kind: 'screenshot',
+        sourceId: row.id,
+        // Mime is the original mime; for v1 we only stored the file path,
+        // not the mime. Worker re-derives from extension if needed.
+        mimeType: 'image/png',
+        contentPath: `${row.id}/screenshot.png`,
+      };
+  }
+}
+
+export async function retryIngest(db: FoodDb, sourceId: number): Promise<EnqueueResult> {
+  const rows = db
+    .select({
+      id: ingestSources.id,
+      kind: ingestSources.kind,
+      url: ingestSources.url,
+      caption: ingestSources.caption,
+    })
+    .from(ingestSources)
+    .where(eq(ingestSources.id, sourceId))
+    .all();
+  const row = rows[0];
+  if (row === undefined) {
+    throw new Error(`ingest_sources #${sourceId} not found`);
+  }
+  const data = jobDataFromRow(row);
+  const enqueued = await enqueueIngestJob(data);
+  db.update(ingestSources)
+    .set({
+      attempts: sql`${ingestSources.attempts} + 1`,
+      errorCode: null,
+      errorMessage: null,
+    })
+    .where(eq(ingestSources.id, sourceId))
+    .run();
+  return enqueued;
+}

--- a/apps/pops-api/src/modules/food/routers/ingest-procedures-control.ts
+++ b/apps/pops-api/src/modules/food/routers/ingest-procedures-control.ts
@@ -6,6 +6,9 @@
  * pipeline stages (PRD-126). `retry` re-enqueues with the same input,
  * increments `attempts`, and reuses the same `sourceId`.
  */
+import { readdirSync } from 'node:fs';
+import { resolve } from 'node:path';
+
 import { eq, sql } from 'drizzle-orm';
 
 import { type FoodDb, ingestSources } from '@pops/app-food-db';
@@ -14,6 +17,37 @@ import { getFoodIngestQueue } from '../queue.js';
 import { enqueueIngestJob, type EnqueueResult } from '../services/ingest-enqueue.js';
 
 import type { IngestJobData } from '@pops/food-contracts';
+
+/** Mirror of `packages/app-food/src/storage/ingest-paths.ts`. */
+const DEFAULT_FOOD_INGEST_DIR = './data/food/ingest';
+const MIME_BY_EXT: Record<string, 'image/jpeg' | 'image/png' | 'image/webp'> = {
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  png: 'image/png',
+  webp: 'image/webp',
+};
+
+function findOnDiskScreenshot(
+  sourceId: number
+): { mimeType: 'image/jpeg' | 'image/png' | 'image/webp'; filename: string } | null {
+  const configured = process.env['FOOD_INGEST_DIR'];
+  const root = configured && configured.length > 0 ? configured : DEFAULT_FOOD_INGEST_DIR;
+  const dir = resolve(root, String(sourceId));
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return null;
+  }
+  for (const entry of entries) {
+    const match = /^screenshot\.([a-z0-9]+)$/i.exec(entry);
+    if (match === null) continue;
+    const ext = match[1]?.toLowerCase() ?? '';
+    const mimeType = MIME_BY_EXT[ext];
+    if (mimeType !== undefined) return { mimeType, filename: entry };
+  }
+  return null;
+}
 
 const CANCELLABLE = new Set(['waiting', 'delayed', 'active', 'waiting_children', 'prioritized']);
 
@@ -73,17 +107,24 @@ function jobDataFromRow(row: {
         throw new Error(`Retry blocked: ingest_sources #${row.id} missing caption/body`);
       }
       return { kind: 'text', sourceId: row.id, body: row.caption };
-    case 'screenshot':
+    case 'screenshot': {
       // Screenshot retry reuses the original on-disk file under the per-
-      // source dir. The worker resolves via `ingestRootDir()`.
+      // source dir. Mime is not persisted in `ingest_sources`; recover it
+      // from the filename extension so jpg / webp retries don't fall back
+      // to `.png`.
+      const found = findOnDiskScreenshot(row.id);
+      if (found === null) {
+        throw new Error(
+          `Retry blocked: screenshot for ingest_sources #${row.id} not on disk (already evicted?)`
+        );
+      }
       return {
         kind: 'screenshot',
         sourceId: row.id,
-        // Mime is the original mime; for v1 we only stored the file path,
-        // not the mime. Worker re-derives from extension if needed.
-        mimeType: 'image/png',
-        contentPath: `${row.id}/screenshot.png`,
+        mimeType: found.mimeType,
+        contentPath: `${row.id}/${found.filename}`,
       };
+    }
   }
 }
 

--- a/apps/pops-api/src/modules/food/routers/ingest-procedures-control.ts
+++ b/apps/pops-api/src/modules/food/routers/ingest-procedures-control.ts
@@ -49,7 +49,17 @@ function findOnDiskScreenshot(
   return null;
 }
 
-const CANCELLABLE = new Set(['waiting', 'delayed', 'active', 'waiting_children', 'prioritized']);
+// Note: BullMQ uses `waiting-children` (hyphen), not `waiting_children`
+// (underscore) as the state literal. Earlier code listed the wrong
+// spelling and silently never matched.
+const CANCELLABLE_STATES = [
+  'waiting',
+  'delayed',
+  'active',
+  'waiting-children',
+  'prioritized',
+] as const;
+const CANCELLABLE = new Set<string>(CANCELLABLE_STATES);
 
 async function findJobBySourceId(
   sourceId: number
@@ -58,7 +68,12 @@ async function findJobBySourceId(
 > {
   const queue = getFoodIngestQueue();
   if (queue === null) return null;
-  const jobs = await queue.getJobs(['waiting', 'delayed', 'active'], 0, 99);
+  // Scan the SAME states `cancelIngest` recognises as cancellable —
+  // earlier `findJobBySourceId` only looked at `waiting/delayed/active`
+  // and silently lost any job stuck in `waiting_children` / `prioritized`.
+  // BullMQ's `getJobs` overload doesn't accept readonly arrays — copy
+  // into a mutable array.
+  const jobs = await queue.getJobs([...CANCELLABLE_STATES], 0, 99);
   for (const job of jobs) {
     const data: unknown = job.data;
     if (

--- a/apps/pops-api/src/modules/food/routers/ingest-procedures-start.ts
+++ b/apps/pops-api/src/modules/food/routers/ingest-procedures-start.ts
@@ -1,0 +1,88 @@
+/**
+ * PRD-125 — `food.ingest.start` implementation.
+ *
+ * Always creates the `ingest_sources` row first (defensive: the row records
+ * the attempt regardless of whether enqueue succeeds). For screenshot
+ * inputs the base64 payload is written to disk under the per-source dir
+ * BEFORE the BullMQ job is enqueued so the heavy bytes don't ride in Redis.
+ */
+import { type FoodDb, ingestSourcesService } from '@pops/app-food-db';
+
+import { enqueueIngestJob, type EnqueueResult } from '../services/ingest-enqueue.js';
+import { writeScreenshotPayload } from '../services/ingest-storage.js';
+
+import type { IngestJobData } from '@pops/food-contracts';
+
+import type { IngestStartInput } from './ingest-schemas.js';
+
+const EXTRACTOR_VERSION_PLACEHOLDER = 'pipeline-v1.0';
+
+interface StartContext {
+  db: FoodDb;
+  extractorVersion?: string;
+}
+
+interface RowInputForKind {
+  kind: 'url-web' | 'url-instagram' | 'text' | 'screenshot';
+  extractorVersion: string;
+  url?: string;
+  caption?: string;
+}
+
+function rowInputForKind(input: IngestStartInput, extractorVersion: string): RowInputForKind {
+  switch (input.kind) {
+    case 'url-web':
+    case 'url-instagram':
+      return { kind: input.kind, extractorVersion, url: input.url };
+    case 'text':
+      return { kind: 'text', extractorVersion, caption: input.body };
+    case 'screenshot':
+      return { kind: 'screenshot', extractorVersion };
+  }
+}
+
+function jobDataFor(
+  input: IngestStartInput,
+  sourceId: number,
+  screenshotPath: string | null
+): IngestJobData {
+  switch (input.kind) {
+    case 'url-web':
+    case 'url-instagram':
+      return { kind: input.kind, sourceId, url: input.url };
+    case 'text':
+      return { kind: 'text', sourceId, body: input.body };
+    case 'screenshot':
+      if (screenshotPath === null) {
+        throw new Error('Screenshot enqueue requested without a written content path');
+      }
+      return {
+        kind: 'screenshot',
+        sourceId,
+        mimeType: input.mimeType,
+        contentPath: screenshotPath,
+      };
+  }
+}
+
+export interface StartResult extends EnqueueResult {
+  sourceId: number;
+}
+
+export async function startIngest(
+  ctx: StartContext,
+  input: IngestStartInput
+): Promise<StartResult> {
+  const extractorVersion = ctx.extractorVersion ?? EXTRACTOR_VERSION_PLACEHOLDER;
+  const row = ingestSourcesService.createIngestSource(
+    ctx.db,
+    rowInputForKind(input, extractorVersion)
+  );
+  let screenshotPath: string | null = null;
+  if (input.kind === 'screenshot') {
+    const written = writeScreenshotPayload(row.id, input.mimeType, input.contentBase64);
+    screenshotPath = written.relativeContentPath;
+  }
+  const enqueued = await enqueueIngestJob(jobDataFor(input, row.id, screenshotPath));
+  return { sourceId: row.id, jobId: enqueued.jobId, queuedAt: enqueued.queuedAt };
+}

--- a/apps/pops-api/src/modules/food/routers/ingest-procedures-start.ts
+++ b/apps/pops-api/src/modules/food/routers/ingest-procedures-start.ts
@@ -6,7 +6,12 @@
  * inputs the base64 payload is written to disk under the per-source dir
  * BEFORE the BullMQ job is enqueued so the heavy bytes don't ride in Redis.
  */
-import { type FoodDb, ingestSourcesService } from '@pops/app-food-db';
+import { rmSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+import { eq } from 'drizzle-orm';
+
+import { type FoodDb, ingestSources, ingestSourcesService } from '@pops/app-food-db';
 
 import { enqueueIngestJob, type EnqueueResult } from '../services/ingest-enqueue.js';
 import { writeScreenshotPayload } from '../services/ingest-storage.js';
@@ -69,6 +74,24 @@ export interface StartResult extends EnqueueResult {
   sourceId: number;
 }
 
+/**
+ * Roll back the `ingest_sources` row + screenshot dir created earlier in
+ * this request. Best-effort: a DB rollback failure surfaces, but we
+ * swallow filesystem-cleanup errors (eviction sweeps the orphan later
+ * anyway). Used only on the enqueue-failure path so the user can retry
+ * cleanly without an orphan row + media file accumulating per attempt.
+ */
+function rollbackStart(db: FoodDb, sourceId: number, screenshotAbsPath: string | null): void {
+  if (screenshotAbsPath !== null) {
+    try {
+      rmSync(dirname(screenshotAbsPath), { recursive: true, force: true });
+    } catch {
+      // Swallow — eviction will sweep this on the next pass.
+    }
+  }
+  db.delete(ingestSources).where(eq(ingestSources.id, sourceId)).run();
+}
+
 export async function startIngest(
   ctx: StartContext,
   input: IngestStartInput
@@ -79,10 +102,22 @@ export async function startIngest(
     rowInputForKind(input, extractorVersion)
   );
   let screenshotPath: string | null = null;
+  let screenshotAbsPath: string | null = null;
   if (input.kind === 'screenshot') {
     const written = writeScreenshotPayload(row.id, input.mimeType, input.contentBase64);
     screenshotPath = written.relativeContentPath;
+    screenshotAbsPath = written.absolutePath;
   }
-  const enqueued = await enqueueIngestJob(jobDataFor(input, row.id, screenshotPath));
+  // If enqueue throws (Redis down, queue closed, BullMQ transient error),
+  // roll back the row + the disk artefact so a retry on the user's side
+  // doesn't leave a phantom `pending` row that no worker will ever pick
+  // up. Re-throw so the tRPC layer translates to SERVICE_UNAVAILABLE.
+  let enqueued: EnqueueResult;
+  try {
+    enqueued = await enqueueIngestJob(jobDataFor(input, row.id, screenshotPath));
+  } catch (err) {
+    rollbackStart(ctx.db, row.id, screenshotAbsPath);
+    throw err;
+  }
   return { sourceId: row.id, jobId: enqueued.jobId, queuedAt: enqueued.queuedAt };
 }

--- a/apps/pops-api/src/modules/food/routers/ingest-procedures-status.ts
+++ b/apps/pops-api/src/modules/food/routers/ingest-procedures-status.ts
@@ -1,0 +1,131 @@
+/**
+ * PRD-125 — `food.ingest.status` and `food.ingest.list` implementations.
+ *
+ * Combine the BullMQ job state with the DB row state. The DB is
+ * authoritative once the job has aged out of Redis (`removeOnComplete` /
+ * `removeOnFail` retention windows). See `ingest-state.ts` for the
+ * resolution rules.
+ */
+import { and, desc, eq, lt, type SQL } from 'drizzle-orm';
+
+import { type FoodDb, ingestSources, type IngestSourceRow } from '@pops/app-food-db';
+
+import { getFoodIngestQueue } from '../queue.js';
+import {
+  deriveIngestState,
+  extractPartialReason,
+  type IngestState,
+} from '../services/ingest-state.js';
+
+export interface IngestStatusView {
+  sourceId: number;
+  kind: 'url-web' | 'url-instagram' | 'text' | 'screenshot';
+  state: IngestState;
+  jobId: string | null;
+  startedAt: string | null;
+  completedAt: string | null;
+  draftRecipeId: number | null;
+  partialReason?: string;
+  errorCode?: string;
+  errorMessage?: string;
+  attempts: number;
+}
+
+interface JobTimings {
+  jobId: string | null;
+  bullmqState: string | null;
+  startedAt: string | null;
+  completedAt: string | null;
+}
+
+async function fetchJobTimings(sourceId: number): Promise<JobTimings> {
+  const queue = getFoodIngestQueue();
+  if (queue === null) return { jobId: null, bullmqState: null, startedAt: null, completedAt: null };
+  // BullMQ has no native "get job by data.sourceId" — we keep the source
+  // id in `data.sourceId` and scan recent jobs. For v1 this is fine
+  // (queue.getJobs is paginated; we look at the recent window). When
+  // PRD-126 lands a heavier worker we can persist `jobId` on
+  // `ingest_sources` to skip the scan; for now keep the contract minimal.
+  const jobs = await queue.getJobs(['waiting', 'delayed', 'active', 'completed', 'failed'], 0, 99);
+  for (const job of jobs) {
+    const data: unknown = job.data;
+    if (
+      typeof data === 'object' &&
+      data !== null &&
+      (data as { sourceId?: number }).sourceId === sourceId
+    ) {
+      const state = await job.getState();
+      return {
+        jobId: job.id ?? null,
+        bullmqState: state,
+        startedAt: job.processedOn ? new Date(job.processedOn).toISOString() : null,
+        completedAt: job.finishedOn ? new Date(job.finishedOn).toISOString() : null,
+      };
+    }
+  }
+  return { jobId: null, bullmqState: null, startedAt: null, completedAt: null };
+}
+
+function rowToView(row: IngestSourceRow, timings: JobTimings): IngestStatusView {
+  const partialReason = extractPartialReason(row.extractedJson);
+  return {
+    sourceId: row.id,
+    kind: row.kind,
+    state: deriveIngestState(row, timings.bullmqState, partialReason),
+    jobId: timings.jobId,
+    startedAt: timings.startedAt,
+    completedAt: timings.completedAt,
+    draftRecipeId: row.draftRecipeId,
+    partialReason,
+    errorCode: row.errorCode ?? undefined,
+    errorMessage: row.errorMessage ?? undefined,
+    attempts: row.attempts,
+  };
+}
+
+export async function getIngestStatus(
+  db: FoodDb,
+  sourceId: number
+): Promise<IngestStatusView | null> {
+  const rows = db.select().from(ingestSources).where(eq(ingestSources.id, sourceId)).all();
+  const row = rows[0];
+  if (row === undefined) return null;
+  const timings = await fetchJobTimings(sourceId);
+  return rowToView(row, timings);
+}
+
+export interface ListResult {
+  items: IngestStatusView[];
+  nextCursor?: string;
+}
+
+export async function listIngestSources(
+  db: FoodDb,
+  filter: { state?: IngestState; cursor?: string; limit: number }
+): Promise<ListResult> {
+  const conditions: SQL[] = [];
+  if (filter.cursor !== undefined) {
+    const cursorId = Number(filter.cursor);
+    if (Number.isFinite(cursorId)) conditions.push(lt(ingestSources.id, cursorId));
+  }
+  const where = conditions.length === 0 ? undefined : and(...conditions);
+  // Fetch limit + 1 to detect more-pages without a count(*) round trip.
+  const rows = db
+    .select()
+    .from(ingestSources)
+    .where(where)
+    .orderBy(desc(ingestSources.id))
+    .limit(filter.limit + 1)
+    .all();
+  const hasMore = rows.length > filter.limit;
+  const sliced = hasMore ? rows.slice(0, filter.limit) : rows;
+  const views: IngestStatusView[] = [];
+  for (const row of sliced) {
+    const timings = await fetchJobTimings(row.id);
+    views.push(rowToView(row, timings));
+  }
+  const filtered =
+    filter.state === undefined ? views : views.filter((v) => v.state === filter.state);
+  const nextCursor = hasMore ? String(sliced[sliced.length - 1]?.id ?? '') : undefined;
+  return { items: filtered, nextCursor };
+}

--- a/apps/pops-api/src/modules/food/routers/ingest-procedures-status.ts
+++ b/apps/pops-api/src/modules/food/routers/ingest-procedures-status.ts
@@ -17,6 +17,8 @@ import {
   type IngestState,
 } from '../services/ingest-state.js';
 
+import type { PartialReason } from '@pops/food-contracts';
+
 export interface IngestStatusView {
   sourceId: number;
   kind: 'url-web' | 'url-instagram' | 'text' | 'screenshot';
@@ -25,7 +27,7 @@ export interface IngestStatusView {
   startedAt: string | null;
   completedAt: string | null;
   draftRecipeId: number | null;
-  partialReason?: string;
+  partialReason?: PartialReason;
   errorCode?: string;
   errorMessage?: string;
   attempts: number;
@@ -38,32 +40,53 @@ interface JobTimings {
   completedAt: string | null;
 }
 
+const EMPTY_TIMINGS: JobTimings = {
+  jobId: null,
+  bullmqState: null,
+  startedAt: null,
+  completedAt: null,
+};
+
+/**
+ * Fetch BullMQ timings for ONE source id. Used by `status`. The `list`
+ * endpoint uses `fetchJobTimingsBatch` below to scan jobs once per request
+ * and build a sourceId → timings map.
+ */
 async function fetchJobTimings(sourceId: number): Promise<JobTimings> {
+  const map = await fetchJobTimingsBatch([sourceId]);
+  return map.get(sourceId) ?? EMPTY_TIMINGS;
+}
+
+/**
+ * BullMQ has no native "get job by data.sourceId" — we scan the recent
+ * window once and bucket by sourceId. Cheaper than O(rows × Redis round
+ * trips) when `list` returns many rows. When PRD-126 lands a heavier
+ * worker we can persist `jobId` on `ingest_sources` and skip the scan
+ * altogether.
+ */
+async function fetchJobTimingsBatch(
+  sourceIds: readonly number[]
+): Promise<Map<number, JobTimings>> {
+  const out = new Map<number, JobTimings>();
+  if (sourceIds.length === 0) return out;
   const queue = getFoodIngestQueue();
-  if (queue === null) return { jobId: null, bullmqState: null, startedAt: null, completedAt: null };
-  // BullMQ has no native "get job by data.sourceId" — we keep the source
-  // id in `data.sourceId` and scan recent jobs. For v1 this is fine
-  // (queue.getJobs is paginated; we look at the recent window). When
-  // PRD-126 lands a heavier worker we can persist `jobId` on
-  // `ingest_sources` to skip the scan; for now keep the contract minimal.
+  if (queue === null) return out;
+  const wanted = new Set(sourceIds);
   const jobs = await queue.getJobs(['waiting', 'delayed', 'active', 'completed', 'failed'], 0, 99);
   for (const job of jobs) {
     const data: unknown = job.data;
-    if (
-      typeof data === 'object' &&
-      data !== null &&
-      (data as { sourceId?: number }).sourceId === sourceId
-    ) {
-      const state = await job.getState();
-      return {
-        jobId: job.id ?? null,
-        bullmqState: state,
-        startedAt: job.processedOn ? new Date(job.processedOn).toISOString() : null,
-        completedAt: job.finishedOn ? new Date(job.finishedOn).toISOString() : null,
-      };
-    }
+    if (typeof data !== 'object' || data === null) continue;
+    const sourceId = (data as { sourceId?: number }).sourceId;
+    if (typeof sourceId !== 'number' || !wanted.has(sourceId) || out.has(sourceId)) continue;
+    const state = await job.getState();
+    out.set(sourceId, {
+      jobId: job.id ?? null,
+      bullmqState: state,
+      startedAt: job.processedOn ? new Date(job.processedOn).toISOString() : null,
+      completedAt: job.finishedOn ? new Date(job.finishedOn).toISOString() : null,
+    });
   }
-  return { jobId: null, bullmqState: null, startedAt: null, completedAt: null };
+  return out;
 }
 
 function rowToView(row: IngestSourceRow, timings: JobTimings): IngestStatusView {
@@ -119,11 +142,12 @@ export async function listIngestSources(
     .all();
   const hasMore = rows.length > filter.limit;
   const sliced = hasMore ? rows.slice(0, filter.limit) : rows;
-  const views: IngestStatusView[] = [];
-  for (const row of sliced) {
-    const timings = await fetchJobTimings(row.id);
-    views.push(rowToView(row, timings));
-  }
+  // Batch the BullMQ scan — one round trip for the whole page, not one
+  // per row. See `fetchJobTimingsBatch` above for the contract.
+  const timingsBySourceId = await fetchJobTimingsBatch(sliced.map((row) => row.id));
+  const views: IngestStatusView[] = sliced.map((row) =>
+    rowToView(row, timingsBySourceId.get(row.id) ?? EMPTY_TIMINGS)
+  );
   const filtered =
     filter.state === undefined ? views : views.filter((v) => v.state === filter.state);
   const nextCursor = hasMore ? String(sliced[sliced.length - 1]?.id ?? '') : undefined;

--- a/apps/pops-api/src/modules/food/routers/ingest-procedures-status.ts
+++ b/apps/pops-api/src/modules/food/routers/ingest-procedures-status.ts
@@ -57,13 +57,44 @@ async function fetchJobTimings(sourceId: number): Promise<JobTimings> {
   return map.get(sourceId) ?? EMPTY_TIMINGS;
 }
 
+/** BullMQ pagination chunk size — keep individual Redis round-trips small. */
+const SCAN_PAGE_SIZE = 100;
+/** Maximum jobs we'll walk per request. Mirrors the queue's
+ *  `removeOnComplete: { count: 1_000 }` retention so the scan can find
+ *  any job still tracked by Redis. Beyond this the DB row's state is
+ *  authoritative anyway (set by `workerComplete`). */
+const SCAN_MAX_JOBS = 1_000;
+
 /**
- * BullMQ has no native "get job by data.sourceId" — we scan the recent
- * window once and bucket by sourceId. Cheaper than O(rows × Redis round
+ * BullMQ has no native "get job by data.sourceId" — we paginate the
+ * recent window and bucket by sourceId, stopping early once every
+ * requested id has been resolved. Cheaper than O(rows × Redis round
  * trips) when `list` returns many rows. When PRD-126 lands a heavier
  * worker we can persist `jobId` on `ingest_sources` and skip the scan
  * altogether.
  */
+type BullMQJob = Awaited<
+  ReturnType<NonNullable<ReturnType<typeof getFoodIngestQueue>>['getJobs']>
+>[number];
+
+async function recordJobTimings(
+  job: BullMQJob,
+  wanted: ReadonlySet<number>,
+  out: Map<number, JobTimings>
+): Promise<void> {
+  const data: unknown = job.data;
+  if (typeof data !== 'object' || data === null) return;
+  const sourceId = (data as { sourceId?: number }).sourceId;
+  if (typeof sourceId !== 'number' || !wanted.has(sourceId) || out.has(sourceId)) return;
+  const state = await job.getState();
+  out.set(sourceId, {
+    jobId: job.id ?? null,
+    bullmqState: state,
+    startedAt: job.processedOn ? new Date(job.processedOn).toISOString() : null,
+    completedAt: job.finishedOn ? new Date(job.finishedOn).toISOString() : null,
+  });
+}
+
 async function fetchJobTimingsBatch(
   sourceIds: readonly number[]
 ): Promise<Map<number, JobTimings>> {
@@ -72,19 +103,19 @@ async function fetchJobTimingsBatch(
   const queue = getFoodIngestQueue();
   if (queue === null) return out;
   const wanted = new Set(sourceIds);
-  const jobs = await queue.getJobs(['waiting', 'delayed', 'active', 'completed', 'failed'], 0, 99);
-  for (const job of jobs) {
-    const data: unknown = job.data;
-    if (typeof data !== 'object' || data === null) continue;
-    const sourceId = (data as { sourceId?: number }).sourceId;
-    if (typeof sourceId !== 'number' || !wanted.has(sourceId) || out.has(sourceId)) continue;
-    const state = await job.getState();
-    out.set(sourceId, {
-      jobId: job.id ?? null,
-      bullmqState: state,
-      startedAt: job.processedOn ? new Date(job.processedOn).toISOString() : null,
-      completedAt: job.finishedOn ? new Date(job.finishedOn).toISOString() : null,
-    });
+  for (let offset = 0; offset < SCAN_MAX_JOBS; offset += SCAN_PAGE_SIZE) {
+    if (out.size === wanted.size) break;
+    const end = offset + SCAN_PAGE_SIZE - 1;
+    const jobs = await queue.getJobs(
+      ['waiting', 'delayed', 'active', 'completed', 'failed'],
+      offset,
+      end
+    );
+    if (jobs.length === 0) break;
+    for (const job of jobs) {
+      await recordJobTimings(job, wanted, out);
+    }
+    if (jobs.length < SCAN_PAGE_SIZE) break; // exhausted the window
   }
   return out;
 }

--- a/apps/pops-api/src/modules/food/routers/ingest-router.ts
+++ b/apps/pops-api/src/modules/food/routers/ingest-router.ts
@@ -1,0 +1,137 @@
+/**
+ * PRD-125 — tRPC router for the food ingest pipeline.
+ *
+ * Procedures (all under `food.ingest.*`):
+ *
+ *   - `start`           — public mutation; validates input, writes the
+ *                          `ingest_sources` row, decodes screenshots to
+ *                          disk, enqueues the BullMQ job.
+ *   - `status`          — public query; combines BullMQ live state with
+ *                          the persisted DB row.
+ *   - `list`            — public query; cursor-paginated for the inbox UI
+ *                          (Epic 03 consumes this).
+ *   - `cancel`          — public mutation; best-effort BullMQ removal.
+ *   - `retry`           — public mutation; re-enqueues a failed job using
+ *                          the persisted source row.
+ *   - `workerComplete`  — internal mutation (POPS_API_INTERNAL_TOKEN);
+ *                          the pops-worker-food container (PRD-126) posts
+ *                          back here on every job — success or failure.
+ *
+ * Per R1 Option B (roadmap): `workerComplete` creates the recipe row +
+ * first draft version + slug_registry entry inline via direct Drizzle
+ * (not PRD-119's tRPC, which doesn't exist yet). PRD-119 will replace
+ * that path when it lands. Compile is deferred to PRD-119's promote flow
+ * — the draft stays uncompiled until the user approves it from the inbox.
+ */
+import { TRPCError } from '@trpc/server';
+
+import { getDrizzle } from '../../../db.js';
+import { internalProcedure, publicProcedure, router } from '../../../trpc.js';
+import { IngestQueueUnavailable } from '../services/ingest-enqueue.js';
+import { applyWorkerComplete } from '../services/ingest-worker-complete.js';
+import { cancelIngest, retryIngest } from './ingest-procedures-control.js';
+import { startIngest } from './ingest-procedures-start.js';
+import { getIngestStatus, listIngestSources } from './ingest-procedures-status.js';
+import {
+  IngestCancelInput,
+  IngestCancelOutput,
+  IngestListInput,
+  IngestListOutput,
+  IngestRetryInput,
+  IngestRetryOutput,
+  IngestStartInput,
+  IngestStartOutput,
+  IngestStatusOutput,
+  WorkerCompleteInput,
+  WorkerCompleteOutput,
+} from './ingest-schemas.js';
+
+import type { FoodDb } from '@pops/app-food-db';
+import type { PartialReason } from '@pops/food-contracts';
+
+// `getDrizzle` returns a `BetterSQLite3Database<Record<string, unknown>>`;
+// `FoodDb` from `@pops/app-food-db` is the same structural type, so the
+// assignment is direct (no cast needed).
+const foodDb = (): FoodDb => getDrizzle();
+
+export const ingestRouter = router({
+  start: publicProcedure
+    .input(IngestStartInput)
+    .output(IngestStartOutput)
+    .mutation(async ({ input }) => {
+      try {
+        return await startIngest({ db: foodDb() }, input);
+      } catch (err) {
+        if (err instanceof IngestQueueUnavailable) {
+          throw new TRPCError({
+            code: 'SERVICE_UNAVAILABLE',
+            message: err.message,
+          });
+        }
+        throw err;
+      }
+    }),
+
+  status: publicProcedure
+    .input(IngestCancelInput) // shape matches: { sourceId }
+    .output(IngestStatusOutput.nullable())
+    .query(async ({ input }) => {
+      return getIngestStatus(foodDb(), input.sourceId);
+    }),
+
+  list: publicProcedure
+    .input(IngestListInput)
+    .output(IngestListOutput)
+    .query(async ({ input }) => {
+      return listIngestSources(foodDb(), input);
+    }),
+
+  cancel: publicProcedure
+    .input(IngestCancelInput)
+    .output(IngestCancelOutput)
+    .mutation(async ({ input }) => {
+      return cancelIngest(input.sourceId);
+    }),
+
+  retry: publicProcedure
+    .input(IngestRetryInput)
+    .output(IngestRetryOutput)
+    .mutation(async ({ input }) => {
+      try {
+        return await retryIngest(foodDb(), input.sourceId);
+      } catch (err) {
+        if (err instanceof IngestQueueUnavailable) {
+          throw new TRPCError({
+            code: 'SERVICE_UNAVAILABLE',
+            message: err.message,
+          });
+        }
+        throw err;
+      }
+    }),
+
+  workerComplete: internalProcedure
+    .input(WorkerCompleteInput)
+    .output(WorkerCompleteOutput)
+    .mutation(({ input }) => {
+      const db = foodDb();
+      if (input.ok) {
+        return applyWorkerComplete(db, input.sourceId, {
+          ok: true,
+          dsl: input.dsl,
+          meta: input.meta,
+          ...(input.partialReason === undefined
+            ? {}
+            : { partialReason: input.partialReason as PartialReason }),
+        });
+      }
+      return applyWorkerComplete(db, input.sourceId, {
+        ok: false,
+        errorCode: input.errorCode,
+        errorMessage: input.errorMessage,
+        meta: input.meta,
+      });
+    }),
+});
+
+export type IngestRouter = typeof ingestRouter;

--- a/apps/pops-api/src/modules/food/routers/ingest-schemas.ts
+++ b/apps/pops-api/src/modules/food/routers/ingest-schemas.ts
@@ -14,6 +14,19 @@ import { z } from 'zod';
 /** Subset of valid screenshot mime types — matches PRD-110's `screenshot.<ext>` amendment. */
 export const ScreenshotMimeType = z.enum(['image/jpeg', 'image/png', 'image/webp']);
 
+/** Mirrors `PartialReason` from `@pops/food-contracts` so the wire surface
+ *  rejects values outside the contract. The handler PRDs (127–132) emit
+ *  exactly these strings; widening here would let a misbehaving worker leak
+ *  arbitrary strings into the inbox UI. */
+export const PartialReasonSchema = z.enum([
+  'auth-dead',
+  'rate-limited',
+  'stt-failed',
+  'vision-failed',
+  'caption-only-fallback',
+  'empty-extraction',
+]);
+
 export const IngestStartInput = z.discriminatedUnion('kind', [
   z.object({ kind: z.literal('url-web'), url: z.url() }),
   z.object({ kind: z.literal('url-instagram'), url: z.url() }),
@@ -42,7 +55,7 @@ export const IngestStatusOutput = z.object({
   startedAt: z.string().nullable(),
   completedAt: z.string().nullable(),
   draftRecipeId: z.number().int().positive().nullable(),
-  partialReason: z.string().optional(),
+  partialReason: PartialReasonSchema.optional(),
   errorCode: z.string().optional(),
   errorMessage: z.string().optional(),
   attempts: z.number().int().nonnegative(),
@@ -85,7 +98,7 @@ export const WorkerCompleteInput = z.discriminatedUnion('ok', [
     ok: z.literal(true),
     dsl: z.string().min(1),
     meta: MetaSchema,
-    partialReason: z.string().optional(),
+    partialReason: PartialReasonSchema.optional(),
   }),
   z.object({
     sourceId: z.number().int().positive(),

--- a/apps/pops-api/src/modules/food/routers/ingest-schemas.ts
+++ b/apps/pops-api/src/modules/food/routers/ingest-schemas.ts
@@ -1,0 +1,106 @@
+/**
+ * PRD-125 — Zod schemas for `food.ingest.*` tRPC procedures.
+ *
+ * Mirrors the shape of `@pops/food-contracts`'s runtime types. Kept in a
+ * sibling file so the router stays tight.
+ *
+ * IngestJobResult validation deliberately accepts `meta` as `z.any()` —
+ * the per-handler PRDs (127–132) own the `stages` payload shape and we
+ * don't want the producer rejecting handler innovations. The router only
+ * cares about the discriminator + the fields it writes to `ingest_sources`.
+ */
+import { z } from 'zod';
+
+/** Subset of valid screenshot mime types — matches PRD-110's `screenshot.<ext>` amendment. */
+export const ScreenshotMimeType = z.enum(['image/jpeg', 'image/png', 'image/webp']);
+
+export const IngestStartInput = z.discriminatedUnion('kind', [
+  z.object({ kind: z.literal('url-web'), url: z.url() }),
+  z.object({ kind: z.literal('url-instagram'), url: z.url() }),
+  z.object({ kind: z.literal('text'), body: z.string().min(1) }),
+  z.object({
+    kind: z.literal('screenshot'),
+    mimeType: ScreenshotMimeType,
+    contentBase64: z.string().min(1),
+  }),
+]);
+export type IngestStartInput = z.infer<typeof IngestStartInput>;
+
+export const IngestStartOutput = z.object({
+  sourceId: z.number().int().positive(),
+  jobId: z.string(),
+  queuedAt: z.string().datetime(),
+});
+
+export const IngestState = z.enum(['pending', 'processing', 'completed', 'failed', 'partial']);
+
+export const IngestStatusOutput = z.object({
+  sourceId: z.number().int().positive(),
+  kind: z.enum(['url-web', 'url-instagram', 'text', 'screenshot']),
+  state: IngestState,
+  jobId: z.string().nullable(),
+  startedAt: z.string().nullable(),
+  completedAt: z.string().nullable(),
+  draftRecipeId: z.number().int().positive().nullable(),
+  partialReason: z.string().optional(),
+  errorCode: z.string().optional(),
+  errorMessage: z.string().optional(),
+  attempts: z.number().int().nonnegative(),
+});
+
+export const IngestListInput = z.object({
+  state: IngestState.optional(),
+  /** Forward-only cursor = the smallest seen `id` from the previous page. */
+  cursor: z.string().optional(),
+  limit: z.coerce.number().int().positive().max(100).default(20),
+});
+
+export const IngestListOutput = z.object({
+  items: z.array(IngestStatusOutput),
+  nextCursor: z.string().optional(),
+});
+
+export const IngestCancelInput = z.object({ sourceId: z.number().int().positive() });
+export const IngestCancelOutput = z.discriminatedUnion('ok', [
+  z.object({ ok: z.literal(true) }),
+  z.object({ ok: z.literal(false), reason: z.literal('not-cancellable') }),
+]);
+
+export const IngestRetryInput = z.object({ sourceId: z.number().int().positive() });
+export const IngestRetryOutput = z.object({
+  jobId: z.string(),
+  queuedAt: z.string().datetime(),
+});
+
+const MetaSchema = z
+  .object({
+    extractor_version: z.string(),
+    stages: z.record(z.string(), z.unknown()),
+  })
+  .passthrough();
+
+export const WorkerCompleteInput = z.discriminatedUnion('ok', [
+  z.object({
+    sourceId: z.number().int().positive(),
+    ok: z.literal(true),
+    dsl: z.string().min(1),
+    meta: MetaSchema,
+    partialReason: z.string().optional(),
+  }),
+  z.object({
+    sourceId: z.number().int().positive(),
+    ok: z.literal(false),
+    errorCode: z.string().min(1),
+    errorMessage: z.string().min(1),
+    meta: MetaSchema,
+  }),
+]);
+
+export const WorkerCompleteOutput = z.discriminatedUnion('ok', [
+  z.object({
+    ok: z.literal(true),
+    draftRecipeId: z.number().int().positive(),
+    compileStatus: z.enum(['compiled', 'failed', 'uncompiled']),
+  }),
+  z.object({ ok: z.literal(false), reason: z.string() }),
+]);

--- a/apps/pops-api/src/modules/food/services/ingest-enqueue.ts
+++ b/apps/pops-api/src/modules/food/services/ingest-enqueue.ts
@@ -1,0 +1,42 @@
+/**
+ * PRD-125 — `food.ingest.start` + `food.ingest.retry` enqueue helper.
+ *
+ * Encapsulates the BullMQ `add` call and the per-kind job-data shaping so
+ * the router stays thin. The screenshot path is written to disk by
+ * `writeScreenshotPayload` before this helper runs; this helper only takes
+ * the resulting `contentPath`.
+ */
+import { type IngestJobData, FOOD_INGEST_QUEUE_NAME } from '@pops/food-contracts';
+
+import { getFoodIngestQueue } from '../queue.js';
+
+export class IngestQueueUnavailable extends Error {
+  constructor() {
+    super('food.ingest queue is unavailable (Redis not configured)');
+    this.name = 'IngestQueueUnavailable';
+  }
+}
+
+export interface EnqueueResult {
+  jobId: string;
+  queuedAt: string;
+}
+
+/**
+ * `name` is the BullMQ "job name" — set to the kind so the worker can
+ * pre-route via a `name` filter if it wants to. Job data lives in Redis;
+ * for `screenshot` the heavy payload was already written to disk before
+ * this call.
+ */
+export async function enqueueIngestJob(data: IngestJobData): Promise<EnqueueResult> {
+  const queue = getFoodIngestQueue();
+  if (queue === null) {
+    throw new IngestQueueUnavailable();
+  }
+  const job = await queue.add(data.kind, data);
+  const jobId = job.id;
+  if (jobId === undefined) {
+    throw new Error(`BullMQ ${FOOD_INGEST_QUEUE_NAME} returned a job with no id`);
+  }
+  return { jobId, queuedAt: new Date().toISOString() };
+}

--- a/apps/pops-api/src/modules/food/services/ingest-state.ts
+++ b/apps/pops-api/src/modules/food/services/ingest-state.ts
@@ -30,7 +30,7 @@ export type IngestState = 'pending' | 'processing' | 'completed' | 'failed' | 'p
 const BULLMQ_TO_INGEST: Partial<Record<JobType | string, IngestState>> = {
   waiting: 'pending',
   delayed: 'pending',
-  waiting_children: 'pending',
+  'waiting-children': 'pending',
   prioritized: 'pending',
   active: 'processing',
   completed: 'completed',

--- a/apps/pops-api/src/modules/food/services/ingest-state.ts
+++ b/apps/pops-api/src/modules/food/services/ingest-state.ts
@@ -9,6 +9,21 @@ import type { JobType } from 'bullmq';
  * the worker writes back via `workerComplete`.
  */
 import type { IngestSourceRow } from '@pops/app-food-db';
+import type { PartialReason } from '@pops/food-contracts';
+
+function isPartialReason(value: string): value is PartialReason {
+  switch (value) {
+    case 'auth-dead':
+    case 'rate-limited':
+    case 'stt-failed':
+    case 'vision-failed':
+    case 'caption-only-fallback':
+    case 'empty-extraction':
+      return true;
+    default:
+      return false;
+  }
+}
 
 export type IngestState = 'pending' | 'processing' | 'completed' | 'failed' | 'partial';
 
@@ -52,16 +67,18 @@ export function deriveIngestState(
  * Extracted out so `status` and `list` use the same partial-reason lookup.
  * Treats malformed JSON as "no partial reason" rather than throwing.
  */
-export function extractPartialReason(extractedJson: string | null): string | undefined {
+export function extractPartialReason(extractedJson: string | null): PartialReason | undefined {
   if (extractedJson === null) return undefined;
+  let parsed: unknown;
   try {
-    const parsed: unknown = JSON.parse(extractedJson);
-    if (typeof parsed === 'object' && parsed !== null && 'partialReason' in parsed) {
-      const reason = (parsed as { partialReason: unknown }).partialReason;
-      return typeof reason === 'string' ? reason : undefined;
-    }
+    parsed = JSON.parse(extractedJson);
   } catch {
     return undefined;
   }
-  return undefined;
+  if (typeof parsed !== 'object' || parsed === null || !('partialReason' in parsed)) {
+    return undefined;
+  }
+  const reason: unknown = parsed.partialReason;
+  if (typeof reason !== 'string') return undefined;
+  return isPartialReason(reason) ? reason : undefined;
 }

--- a/apps/pops-api/src/modules/food/services/ingest-state.ts
+++ b/apps/pops-api/src/modules/food/services/ingest-state.ts
@@ -1,0 +1,67 @@
+import type { JobType } from 'bullmq';
+
+/**
+ * PRD-125 — `IngestStatus.state` derivation.
+ *
+ * Combines BullMQ's job state (live for ~`removeOnComplete`/`removeOnFail`
+ * count) with the DB row state (authoritative once the job has aged out
+ * of Redis). The DB row drives `completed` / `failed` / `partial` after
+ * the worker writes back via `workerComplete`.
+ */
+import type { IngestSourceRow } from '@pops/app-food-db';
+
+export type IngestState = 'pending' | 'processing' | 'completed' | 'failed' | 'partial';
+
+const BULLMQ_TO_INGEST: Partial<Record<JobType | string, IngestState>> = {
+  waiting: 'pending',
+  delayed: 'pending',
+  waiting_children: 'pending',
+  prioritized: 'pending',
+  active: 'processing',
+  completed: 'completed',
+  failed: 'failed',
+};
+
+/**
+ * Resolution priority:
+ *   1. If the DB row carries `error_code` or `error_message`, the worker
+ *      already wrote back failure → `failed` regardless of any stale
+ *      BullMQ state.
+ *   2. If `draft_recipe_id` is set, the worker wrote back success → use
+ *      DB row to choose `completed` vs `partial` (the latter is recorded
+ *      by `extracted_json.partialReason`).
+ *   3. Otherwise fall back to whatever BullMQ reports.
+ *   4. If BullMQ has no record (TTL expired) and DB says nothing terminal,
+ *      treat as `pending` so the polling client keeps polling — this
+ *      should not happen in normal operation.
+ */
+export function deriveIngestState(
+  row: IngestSourceRow,
+  bullmqState: string | null,
+  partialReasonInMeta: string | undefined
+): IngestState {
+  if (row.errorCode !== null || row.errorMessage !== null) return 'failed';
+  if (row.draftRecipeId !== null) {
+    return partialReasonInMeta === undefined ? 'completed' : 'partial';
+  }
+  if (bullmqState === null) return 'pending';
+  return BULLMQ_TO_INGEST[bullmqState] ?? 'pending';
+}
+
+/**
+ * Extracted out so `status` and `list` use the same partial-reason lookup.
+ * Treats malformed JSON as "no partial reason" rather than throwing.
+ */
+export function extractPartialReason(extractedJson: string | null): string | undefined {
+  if (extractedJson === null) return undefined;
+  try {
+    const parsed: unknown = JSON.parse(extractedJson);
+    if (typeof parsed === 'object' && parsed !== null && 'partialReason' in parsed) {
+      const reason = (parsed as { partialReason: unknown }).partialReason;
+      return typeof reason === 'string' ? reason : undefined;
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
+}

--- a/apps/pops-api/src/modules/food/services/ingest-storage.ts
+++ b/apps/pops-api/src/modules/food/services/ingest-storage.ts
@@ -68,6 +68,16 @@ export function writeScreenshotPayload(
   // Trim the data-URI prefix if the caller sent the raw `data:image/png;base64,...`
   // header — be permissive on input, strict on output.
   const cleaned = contentBase64.replace(/^data:[^;]+;base64,/, '');
+  // Pre-decode size check — base64 encodes ~4/3 bytes per source byte, so a
+  // cleaned payload longer than this can't decode to ≤ SCREENSHOT_MAX_BYTES.
+  // Without the pre-check, `Buffer.from(huge_string, 'base64')` would
+  // allocate the full decoded buffer before we can reject it.
+  const maxBase64Chars = Math.ceil((SCREENSHOT_MAX_BYTES * 4) / 3);
+  if (cleaned.length > maxBase64Chars) {
+    throw new Error(
+      `Screenshot base64 payload (${cleaned.length} chars) exceeds the pre-decode cap (${maxBase64Chars} chars) for ${SCREENSHOT_MAX_BYTES} bytes`
+    );
+  }
   const buffer = Buffer.from(cleaned, 'base64');
   if (buffer.length > SCREENSHOT_MAX_BYTES) {
     throw new Error(

--- a/apps/pops-api/src/modules/food/services/ingest-storage.ts
+++ b/apps/pops-api/src/modules/food/services/ingest-storage.ts
@@ -1,0 +1,85 @@
+/**
+ * PRD-125 — screenshot-payload disk writer.
+ *
+ * Per PRD-125 §Flow: for `kind='screenshot'` the API decodes the base64
+ * payload to `${FOOD_INGEST_DIR}/<sourceId>/screenshot.<ext>` BEFORE the
+ * BullMQ job is enqueued (Redis stays small; worker reads the file).
+ *
+ * Mime → extension mapping mirrors PRD-110's screenshot.<ext> amendment
+ * (allows jpg/jpeg/png/webp). Caller validates the mime against the input
+ * schema; this helper just maps.
+ */
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/** PRD-124 base64 size cap reused for screenshot input. */
+export const SCREENSHOT_MAX_BYTES = 8 * 1024 * 1024;
+
+/** Mirror of `packages/app-food/src/storage/ingest-paths.ts` — duplicated to keep pops-api off the app-food package graph (cycle via @pops/api-client). */
+const DEFAULT_FOOD_INGEST_DIR = './data/food/ingest';
+
+function ingestRootDir(): string {
+  const configured = process.env['FOOD_INGEST_DIR'];
+  const raw = configured && configured.length > 0 ? configured : DEFAULT_FOOD_INGEST_DIR;
+  return resolve(raw);
+}
+
+function ingestDirFor(sourceId: number): string {
+  return resolve(ingestRootDir(), String(sourceId));
+}
+
+const MIME_TO_EXT: Record<string, string> = {
+  'image/jpeg': 'jpg',
+  'image/png': 'png',
+  'image/webp': 'webp',
+};
+
+export function extensionForMimeType(mimeType: string): string {
+  const ext = MIME_TO_EXT[mimeType];
+  if (ext === undefined) {
+    throw new Error(`Unsupported screenshot mime type "${mimeType}"`);
+  }
+  return ext;
+}
+
+export interface WriteScreenshotResult {
+  /** Absolute filesystem path written to. */
+  absolutePath: string;
+  /** Path relative to `FOOD_INGEST_DIR` — what gets stored in the BullMQ job. */
+  relativeContentPath: string;
+  /** Bytes written; matches the decoded payload size. */
+  bytesWritten: number;
+}
+
+/**
+ * Decode and persist a screenshot payload. Throws when the decoded size
+ * exceeds `SCREENSHOT_MAX_BYTES` or when the mime type isn't supported.
+ *
+ * Files are written under `<FOOD_INGEST_DIR>/<sourceId>/screenshot.<ext>`
+ * so PRD-110's FIFO eviction (`runEvictionTick`) sweeps them alongside the
+ * other per-source media when the directory cap is hit.
+ */
+export function writeScreenshotPayload(
+  sourceId: number,
+  mimeType: string,
+  contentBase64: string
+): WriteScreenshotResult {
+  const ext = extensionForMimeType(mimeType);
+  // Trim the data-URI prefix if the caller sent the raw `data:image/png;base64,...`
+  // header — be permissive on input, strict on output.
+  const cleaned = contentBase64.replace(/^data:[^;]+;base64,/, '');
+  const buffer = Buffer.from(cleaned, 'base64');
+  if (buffer.length > SCREENSHOT_MAX_BYTES) {
+    throw new Error(
+      `Screenshot payload (${buffer.length} bytes) exceeds cap (${SCREENSHOT_MAX_BYTES} bytes)`
+    );
+  }
+  const dir = ingestDirFor(sourceId);
+  mkdirSync(dir, { recursive: true });
+  const filename = `screenshot.${ext}`;
+  const absolutePath = `${dir}/${filename}`;
+  writeFileSync(absolutePath, buffer);
+  // Stored in the BullMQ job verbatim. Worker resolves via `ingestRootDir()`.
+  const relativeContentPath = `${sourceId}/${filename}`;
+  return { absolutePath, relativeContentPath, bytesWritten: buffer.length };
+}

--- a/apps/pops-api/src/modules/food/services/ingest-worker-complete.ts
+++ b/apps/pops-api/src/modules/food/services/ingest-worker-complete.ts
@@ -1,0 +1,103 @@
+/**
+ * PRD-125 — server-side `food.ingest.workerComplete` execution.
+ *
+ * Two outcomes:
+ *
+ *   - `ok: true` — creates a draft recipe + first version via
+ *     `recipesService.createRecipe` (from `@pops/app-food-db`) and
+ *     updates the `ingest_sources` row in ONE transaction. The version
+ *     is left uncompiled; PRD-119's promote flow runs the compile
+ *     pipeline lazily when the user approves the draft from the inbox.
+ *   - `ok: false` — writes the `meta` rollup + `error_code` + `error_message`
+ *     to `ingest_sources` (PRD-138 amendment columns). Returns
+ *     `{ ok: false, reason }` to the worker.
+ *
+ * `compileRecipeVersion` lives in `@pops/app-food` (frontend-bound
+ * package, depends on @pops/api-client) — calling it here would close a
+ * `pops-api → @pops/app-food → @pops/api-client → @pops/api` package
+ * cycle. PRD-119's tRPC handler will own that call site.
+ */
+import { eq } from 'drizzle-orm';
+
+import { type FoodDb, ingestSources, recipesService } from '@pops/app-food-db';
+
+import type { IngestJobResult } from '@pops/food-contracts';
+
+const INGEST_RECIPE_SLUG_PREFIX = 'ingest-source-';
+const TITLE_RE = /@title\s+"([^"]+)"/;
+
+function deriveSlug(sourceId: number): string {
+  return `${INGEST_RECIPE_SLUG_PREFIX}${sourceId}`;
+}
+
+function deriveTitle(dsl: string): string {
+  const match = TITLE_RE.exec(dsl);
+  const title = match?.[1]?.trim();
+  if (title !== undefined && title.length > 0) return title;
+  return 'Untitled ingested recipe';
+}
+
+export interface WorkerCompleteSuccessResult {
+  ok: true;
+  draftRecipeId: number;
+  compileStatus: 'compiled' | 'failed' | 'uncompiled';
+}
+
+export interface WorkerCompleteFailureResult {
+  ok: false;
+  reason: string;
+}
+
+export type WorkerCompleteOutcome = WorkerCompleteSuccessResult | WorkerCompleteFailureResult;
+
+function applySuccess(
+  db: FoodDb,
+  sourceId: number,
+  result: Extract<IngestJobResult, { ok: true }>
+): WorkerCompleteSuccessResult {
+  return db.transaction((tx): WorkerCompleteSuccessResult => {
+    const created = recipesService.createRecipe(tx, {
+      slug: deriveSlug(sourceId),
+      firstVersion: {
+        title: deriveTitle(result.dsl),
+        bodyDsl: result.dsl,
+        sourceId,
+      },
+    });
+    tx.update(ingestSources)
+      .set({
+        extractedJson: JSON.stringify(result.meta),
+        draftRecipeId: created.recipe.id,
+        errorCode: null,
+        errorMessage: null,
+      })
+      .where(eq(ingestSources.id, sourceId))
+      .run();
+    return { ok: true, draftRecipeId: created.recipe.id, compileStatus: 'uncompiled' };
+  });
+}
+
+function applyFailure(
+  db: FoodDb,
+  sourceId: number,
+  result: Extract<IngestJobResult, { ok: false }>
+): WorkerCompleteFailureResult {
+  db.update(ingestSources)
+    .set({
+      extractedJson: JSON.stringify(result.meta),
+      errorCode: result.errorCode,
+      errorMessage: result.errorMessage,
+    })
+    .where(eq(ingestSources.id, sourceId))
+    .run();
+  return { ok: false, reason: result.errorCode };
+}
+
+export function applyWorkerComplete(
+  db: FoodDb,
+  sourceId: number,
+  result: IngestJobResult
+): WorkerCompleteOutcome {
+  if (result.ok) return applySuccess(db, sourceId, result);
+  return applyFailure(db, sourceId, result);
+}

--- a/apps/pops-api/src/modules/food/services/ingest-worker-complete.ts
+++ b/apps/pops-api/src/modules/food/services/ingest-worker-complete.ts
@@ -12,6 +12,10 @@
  *     to `ingest_sources` (PRD-138 amendment columns). Returns
  *     `{ ok: false, reason }` to the worker.
  *
+ * Each branch is idempotent. BullMQ retries the callback on transient
+ * network errors, so a second `ok:true` call sees the previously-set
+ * `draft_recipe_id` and returns it instead of re-inserting the slug.
+ *
  * `compileRecipeVersion` lives in `@pops/app-food` (frontend-bound
  * package, depends on @pops/api-client) — calling it here would close a
  * `pops-api → @pops/app-food → @pops/api-client → @pops/api` package
@@ -45,6 +49,35 @@ function deriveTitle(dsl: string): string {
   return 'Untitled ingested recipe';
 }
 
+export class WorkerCompleteSourceNotFound extends Error {
+  constructor(sourceId: number) {
+    super(`ingest_sources #${sourceId} not found`);
+    this.name = 'WorkerCompleteSourceNotFound';
+  }
+}
+
+interface ExistingSourceRow {
+  id: number;
+  draftRecipeId: number | null;
+}
+
+/** Reads the row once at the top of the transaction so the worker sees a
+ *  clear failure when `sourceId` doesn't exist (or was double-evicted)
+ *  rather than a silent no-op UPDATE. */
+function loadSourceRow(tx: FoodDb, sourceId: number): ExistingSourceRow {
+  const rows = tx
+    .select({
+      id: ingestSources.id,
+      draftRecipeId: ingestSources.draftRecipeId,
+    })
+    .from(ingestSources)
+    .where(eq(ingestSources.id, sourceId))
+    .all();
+  const row = rows[0];
+  if (row === undefined) throw new WorkerCompleteSourceNotFound(sourceId);
+  return row;
+}
+
 export interface WorkerCompleteSuccessResult {
   ok: true;
   draftRecipeId: number;
@@ -64,6 +97,18 @@ function applySuccess(
   result: Extract<IngestJobResult, { ok: true }>
 ): WorkerCompleteSuccessResult {
   return db.transaction((tx): WorkerCompleteSuccessResult => {
+    const existing = loadSourceRow(tx, sourceId);
+    // Idempotency — re-running `ok: true` after the previous run already
+    // created the draft must return the existing recipe rather than
+    // attempt a duplicate `slug_registry` insert (which would throw on
+    // unique constraint).
+    if (existing.draftRecipeId !== null) {
+      return {
+        ok: true,
+        draftRecipeId: existing.draftRecipeId,
+        compileStatus: 'uncompiled',
+      };
+    }
     const created = recipesService.createRecipe(tx, {
       slug: deriveSlug(sourceId),
       firstVersion: {
@@ -99,15 +144,21 @@ function applyFailure(
   sourceId: number,
   result: Extract<IngestJobResult, { ok: false }>
 ): WorkerCompleteFailureResult {
-  db.update(ingestSources)
-    .set({
-      extractedJson: JSON.stringify(result.meta),
-      errorCode: result.errorCode,
-      errorMessage: result.errorMessage,
-    })
-    .where(eq(ingestSources.id, sourceId))
-    .run();
-  return { ok: false, reason: result.errorCode };
+  return db.transaction((tx): WorkerCompleteFailureResult => {
+    // Verify the row exists before the UPDATE — Drizzle's `.run()` would
+    // silently affect zero rows otherwise, and the worker would see a
+    // spurious "failure recorded" response.
+    loadSourceRow(tx, sourceId);
+    tx.update(ingestSources)
+      .set({
+        extractedJson: JSON.stringify(result.meta),
+        errorCode: result.errorCode,
+        errorMessage: result.errorMessage,
+      })
+      .where(eq(ingestSources.id, sourceId))
+      .run();
+    return { ok: false, reason: result.errorCode };
+  });
 }
 
 export function applyWorkerComplete(

--- a/apps/pops-api/src/modules/food/services/ingest-worker-complete.ts
+++ b/apps/pops-api/src/modules/food/services/ingest-worker-complete.ts
@@ -24,7 +24,15 @@ import { type FoodDb, ingestSources, recipesService } from '@pops/app-food-db';
 import type { IngestJobResult } from '@pops/food-contracts';
 
 const INGEST_RECIPE_SLUG_PREFIX = 'ingest-source-';
-const TITLE_RE = /@title\s+"([^"]+)"/;
+/** Lightweight match against `@recipe(... title="...")` — the DSL grammar in
+ *  `packages/app-food/src/dsl/parse-recipe.ts` declares `title` as a named
+ *  arg inside `@recipe(...)`. We deliberately don't call the full parser to
+ *  avoid depending on `@pops/app-food` (which would close the cycle through
+ *  @pops/api-client); the regex is permissive enough for any author-written
+ *  `title="..."` inside the `@recipe(...)` header. Falls back to a generic
+ *  title when the worker emits a body the parser would reject — the inbox
+ *  surfaces the literal DSL anyway. */
+const TITLE_RE = /@recipe\s*\([^)]*\btitle\s*=\s*"([^"]+)"/;
 
 function deriveSlug(sourceId: number): string {
   return `${INGEST_RECIPE_SLUG_PREFIX}${sourceId}`;
@@ -64,9 +72,18 @@ function applySuccess(
         sourceId,
       },
     });
+    // Persist `partialReason` nested inside the meta blob so
+    // `extractPartialReason` (status / list) can recover it after BullMQ
+    // TTL expiry. The IngestMeta envelope is permissive — handler PRDs
+    // 127–132 own the `stages` payload; this field is the only one the
+    // producer side needs to surface to the inbox UI.
+    const persistedMeta =
+      result.partialReason === undefined
+        ? result.meta
+        : { ...result.meta, partialReason: result.partialReason };
     tx.update(ingestSources)
       .set({
-        extractedJson: JSON.stringify(result.meta),
+        extractedJson: JSON.stringify(persistedMeta),
         draftRecipeId: created.recipe.id,
         errorCode: null,
         errorMessage: null,

--- a/apps/pops-api/src/modules/module-gate.test.ts
+++ b/apps/pops-api/src/modules/module-gate.test.ts
@@ -12,7 +12,11 @@ const APP_KEY = 'POPS_APPS';
 const OVERLAY_KEY = 'POPS_OVERLAYS';
 
 function makeCaller() {
-  return appRouter.createCaller({ user: { email: 'test@example.com' }, serviceAccount: null });
+  return appRouter.createCaller({
+    user: { email: 'test@example.com' },
+    serviceAccount: null,
+    internalCaller: false,
+  });
 }
 
 describe('PRD-100 module gate (tRPC)', () => {

--- a/apps/pops-api/src/routes/food/ingest-files.ts
+++ b/apps/pops-api/src/routes/food/ingest-files.ts
@@ -1,0 +1,107 @@
+/**
+ * PRD-125 amendment to PRD-110 — HTTP routes for streaming the per-source
+ * ingest media (screenshot, video) back to the inbox UI (Epic 03 / PRD-135).
+ *
+ *   GET /api/food/ingest/source/:sourceId/screenshot
+ *   GET /api/food/ingest/source/:sourceId/video
+ *
+ * Both routes glob the on-disk file under `ingestDirFor(sourceId)`:
+ *
+ *   - screenshot.{jpg,jpeg,png,webp} per PRD-110 amendment
+ *   - video.{mp4,webm,mov,m4v} (whatever yt-dlp wrote; matched by extension)
+ *
+ * Mounted before auth so the frontend pulls them via plain `<img>` / `<video>`
+ * tags. SourceId validation is strict (positive integer, no traversal).
+ *
+ * The routes return 404 when the source row doesn't exist OR the on-disk
+ * directory is missing OR the eviction job already swept the files
+ * (`archived_at IS NOT NULL`). The inbox UI uses 404 as the "missing media,
+ * skip rendering" signal.
+ */
+import { readdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+import { type Router as ExpressRouter, type Request, type Response, Router } from 'express';
+
+import { tryServeFile } from '../media/images-helpers.js';
+
+/** Inbox-served media is user-content; short cache so re-uploads land. */
+const CACHE_CONTROL = 'private, max-age=3600';
+
+/** Mirror of `packages/app-food/src/storage/ingest-paths.ts`. Duplicated to keep pops-api off the app-food package graph (cycle via @pops/api-client). */
+const DEFAULT_FOOD_INGEST_DIR = './data/food/ingest';
+
+function ingestDirFor(sourceId: number): string {
+  const configured = process.env['FOOD_INGEST_DIR'];
+  const raw = configured && configured.length > 0 ? configured : DEFAULT_FOOD_INGEST_DIR;
+  return resolve(raw, String(sourceId));
+}
+
+const SOURCE_ID_RE = /^[1-9]\d*$/;
+const SCREENSHOT_EXTENSIONS = ['jpg', 'jpeg', 'png', 'webp'] as const;
+const VIDEO_EXTENSIONS = ['mp4', 'webm', 'mov', 'm4v'] as const;
+
+function validateSourceId(req: Request, res: Response): number | null {
+  const raw = String(req.params['sourceId'] ?? '');
+  if (!SOURCE_ID_RE.test(raw)) {
+    res.status(400).json({ error: `Invalid source id: ${raw}` });
+    return null;
+  }
+  return Number(raw);
+}
+
+function findFileWithExtension(
+  dir: string,
+  baseName: string,
+  exts: readonly string[]
+): string | null {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return null;
+  }
+  const lcEntries = new Set(entries.map((e) => e.toLowerCase()));
+  for (const ext of exts) {
+    const candidate = `${baseName}.${ext}`;
+    if (lcEntries.has(candidate)) return join(dir, candidate);
+  }
+  return null;
+}
+
+async function serveOr404(filePath: string | null, res: Response): Promise<void> {
+  if (filePath === null) {
+    res.status(404).json({ error: 'File not found' });
+    return;
+  }
+  const served = await tryServeFile(filePath, res, CACHE_CONTROL);
+  if (!served) res.status(404).json({ error: 'File not found' });
+}
+
+const router: ExpressRouter = Router();
+
+router.get(
+  '/api/food/ingest/source/:sourceId/screenshot',
+  async (req: Request, res: Response): Promise<void> => {
+    const sourceId = validateSourceId(req, res);
+    if (sourceId === null) return;
+    const filePath = findFileWithExtension(
+      ingestDirFor(sourceId),
+      'screenshot',
+      SCREENSHOT_EXTENSIONS
+    );
+    await serveOr404(filePath, res);
+  }
+);
+
+router.get(
+  '/api/food/ingest/source/:sourceId/video',
+  async (req: Request, res: Response): Promise<void> => {
+    const sourceId = validateSourceId(req, res);
+    if (sourceId === null) return;
+    const filePath = findFileWithExtension(ingestDirFor(sourceId), 'video', VIDEO_EXTENSIONS);
+    await serveOr404(filePath, res);
+  }
+);
+
+export default router;

--- a/apps/pops-api/src/routes/food/ingest-files.ts
+++ b/apps/pops-api/src/routes/food/ingest-files.ts
@@ -87,10 +87,12 @@ function findFileWithExtension(
   } catch {
     return null;
   }
-  const lcEntries = new Set(entries.map((e) => e.toLowerCase()));
-  for (const ext of exts) {
-    const candidate = `${baseName}.${ext}`;
-    if (lcEntries.has(candidate)) return join(dir, candidate);
+  // Case-insensitive match but preserve on-disk casing — case-sensitive
+  // filesystems (Linux prod runtime) would otherwise 404 when the worker
+  // wrote `Screenshot.PNG` and the route looked for `screenshot.png`.
+  const wanted = new Set(exts.map((ext) => `${baseName}.${ext}`.toLowerCase()));
+  for (const entry of entries) {
+    if (wanted.has(entry.toLowerCase())) return join(dir, entry);
   }
   return null;
 }

--- a/apps/pops-api/src/routes/food/ingest-files.ts
+++ b/apps/pops-api/src/routes/food/ingest-files.ts
@@ -23,6 +23,7 @@ import { join, resolve } from 'node:path';
 
 import { type Router as ExpressRouter, type Request, type Response, Router } from 'express';
 
+import { getDb } from '../../db.js';
 import { tryServeFile } from '../media/images-helpers.js';
 
 /** Inbox-served media is user-content; short cache so re-uploads land. */
@@ -48,6 +49,31 @@ function validateSourceId(req: Request, res: Response): number | null {
     return null;
   }
   return Number(raw);
+}
+
+/**
+ * Reject requests for sources the user shouldn't see — the row doesn't
+ * exist OR the eviction job already archived it (`archived_at IS NOT NULL`).
+ * Without this guard, anyone who guesses a `sourceId` can fish for media
+ * files on disk regardless of whether the source row was ever real.
+ *
+ * The check is a single prepared SELECT keyed by primary key — cheap; we
+ * skip the Drizzle wrapper to keep the route lean (and dep-free of the
+ * food-domain schema imports).
+ */
+function isServableSource(sourceId: number): boolean {
+  try {
+    const row = getDb()
+      .prepare<[number], { archived_at: string | null }>(
+        `SELECT archived_at FROM ingest_sources WHERE id = ?`
+      )
+      .get(sourceId);
+    return row !== undefined && row.archived_at === null;
+  } catch {
+    // If the table doesn't exist (e.g. tests without food migrations
+    // applied), fail closed — the route serves nothing.
+    return false;
+  }
 }
 
 function findFileWithExtension(
@@ -85,6 +111,10 @@ router.get(
   async (req: Request, res: Response): Promise<void> => {
     const sourceId = validateSourceId(req, res);
     if (sourceId === null) return;
+    if (!isServableSource(sourceId)) {
+      res.status(404).json({ error: 'File not found' });
+      return;
+    }
     const filePath = findFileWithExtension(
       ingestDirFor(sourceId),
       'screenshot',
@@ -99,6 +129,10 @@ router.get(
   async (req: Request, res: Response): Promise<void> => {
     const sourceId = validateSourceId(req, res);
     if (sourceId === null) return;
+    if (!isServableSource(sourceId)) {
+      res.status(404).json({ error: 'File not found' });
+      return;
+    }
     const filePath = findFileWithExtension(ingestDirFor(sourceId), 'video', VIDEO_EXTENSIONS);
     await serveOr404(filePath, res);
   }

--- a/apps/pops-api/src/shared/test-utils.ts
+++ b/apps/pops-api/src/shared/test-utils.ts
@@ -20,6 +20,7 @@ export function createCaller(authenticated = true): ReturnType<typeof appRouter.
   const ctx: Context = {
     user: authenticated ? { email: 'test@example.com' } : null,
     serviceAccount: null,
+    internalCaller: false,
   };
   return appRouter.createCaller(ctx);
 }
@@ -39,6 +40,7 @@ export function createServiceAccountCaller(options: {
       name: options.name ?? 'test-sa',
       scopes: options.scopes,
     },
+    internalCaller: false,
   };
   return appRouter.createCaller(ctx);
 }

--- a/apps/pops-api/src/trpc.ts
+++ b/apps/pops-api/src/trpc.ts
@@ -34,6 +34,14 @@ export interface User {
 export interface Context {
   user: User | null;
   serviceAccount: AuthenticatedServiceAccount | null;
+  /**
+   * Set to `true` when the request carries a valid `x-pops-internal-token`
+   * header matching `POPS_API_INTERNAL_TOKEN`. Reserved for sibling-process
+   * calls (e.g. PRD-126's `pops-worker-food` posting back to
+   * `food.ingest.workerComplete`). NOT routable to external clients —
+   * the OpenAPI document excludes `internalProcedure` paths.
+   */
+  internalCaller: boolean;
 }
 
 function readApiKeyHeader(req: CreateExpressContextOptions['req']): string | null {
@@ -63,10 +71,20 @@ async function tryServiceAccountAuth(
  *   2. Otherwise validate the Cloudflare Access JWT (or use the dev /
  *      tunnel-trust shortcuts).
  */
+function isInternalCall(req: CreateExpressContextOptions['req']): boolean {
+  const expected = process.env['POPS_API_INTERNAL_TOKEN'];
+  if (!expected || expected.length === 0) return false;
+  const raw = req.headers['x-pops-internal-token'];
+  const presented = Array.isArray(raw) ? (raw[0] ?? '') : (raw ?? '');
+  return presented.length > 0 && presented === expected;
+}
+
 export async function createContext({ req }: CreateExpressContextOptions): Promise<Context> {
+  const internalCaller = isInternalCall(req);
+
   const serviceAccount = await tryServiceAccountAuth(req);
   if (serviceAccount) {
-    return { user: null, serviceAccount };
+    return { user: null, serviceAccount, internalCaller };
   }
 
   // In development, skip JWT validation and use mock user
@@ -76,6 +94,7 @@ export async function createContext({ req }: CreateExpressContextOptions): Promi
         email: 'dev@example.com',
       },
       serviceAccount: null,
+      internalCaller,
     };
   }
 
@@ -84,6 +103,7 @@ export async function createContext({ req }: CreateExpressContextOptions): Promi
     return {
       user: { email: 'tunnel-authenticated@pops.local' },
       serviceAccount: null,
+      internalCaller,
     };
   }
 
@@ -97,14 +117,15 @@ export async function createContext({ req }: CreateExpressContextOptions): Promi
           email: payload.email,
         },
         serviceAccount: null,
+        internalCaller,
       };
     } catch (error) {
       console.error('[trpc] JWT verification failed:', error);
-      return { user: null, serviceAccount: null };
+      return { user: null, serviceAccount: null, internalCaller };
     }
   }
 
-  return { user: null, serviceAccount: null };
+  return { user: null, serviceAccount: null, internalCaller };
 }
 
 export type ContextType = Awaited<ReturnType<typeof createContext>>;
@@ -217,6 +238,33 @@ export const userOnlyProcedure = t.procedure.use(moduleGate).use(({ ctx, next })
     ctx: {
       user: ctx.user,
       serviceAccount: ctx.serviceAccount,
+    },
+  });
+});
+
+/**
+ * Internal procedure for sibling-process callers (e.g. PRD-126's
+ * `pops-worker-food` posting back to `food.ingest.workerComplete`). Requires
+ * the request to carry `x-pops-internal-token` matching
+ * `POPS_API_INTERNAL_TOKEN` — set via `createContext`. NOT meant for
+ * user-facing clients; the OpenAPI spec excludes these paths.
+ *
+ * Gates explicitly do NOT include `moduleGate` because internal calls don't
+ * carry an install-set context — they're trusted at the process boundary.
+ */
+export const internalProcedure = t.procedure.use(({ ctx, next }) => {
+  if (!ctx.internalCaller) {
+    throw new TRPCError({
+      code: 'UNAUTHORIZED',
+      message:
+        'This endpoint requires a valid x-pops-internal-token header (sibling-process auth).',
+    });
+  }
+  return next({
+    ctx: {
+      user: null,
+      serviceAccount: null,
+      internalCaller: true as const,
     },
   });
 });

--- a/apps/pops-mcp/Dockerfile
+++ b/apps/pops-mcp/Dockerfile
@@ -10,6 +10,7 @@ COPY packages/types/package.json ./packages/types/
 COPY packages/module-registry/package.json ./packages/module-registry/
 COPY packages/app-food-db/package.json ./packages/app-food-db/
 COPY packages/app-lists/package.json ./packages/app-lists/
+COPY packages/food-contracts/package.json ./packages/food-contracts/
 COPY apps/pops-api/package.json ./apps/pops-api/
 COPY apps/pops-mcp/package.json ./apps/pops-mcp/
 
@@ -27,6 +28,8 @@ COPY packages/module-registry/tsconfig.json packages/module-registry/tsconfig.bu
 COPY packages/app-lists/src ./packages/app-lists/src
 COPY packages/app-food-db/src ./packages/app-food-db/src
 COPY packages/app-food-db/tsconfig.json ./packages/app-food-db/
+COPY packages/food-contracts/src ./packages/food-contracts/src
+COPY packages/food-contracts/tsconfig.json ./packages/food-contracts/
 
 # Copy pops-api source (needed only for AppRouter type resolution at compile time)
 COPY apps/pops-api/tsconfig.json ./apps/pops-api/

--- a/apps/pops-mcp/Dockerfile
+++ b/apps/pops-mcp/Dockerfile
@@ -47,6 +47,8 @@ WORKDIR /app/packages/types
 RUN pnpm build
 WORKDIR /app/packages/module-registry
 RUN pnpm build
+WORKDIR /app/packages/food-contracts
+RUN pnpm build
 WORKDIR /app/packages/app-food-db
 RUN pnpm build
 

--- a/apps/pops-shell/Dockerfile
+++ b/apps/pops-shell/Dockerfile
@@ -44,6 +44,8 @@ WORKDIR /app/packages/types
 RUN pnpm build
 WORKDIR /app/packages/module-registry
 RUN pnpm build
+WORKDIR /app/packages/food-contracts
+RUN pnpm build
 WORKDIR /app/packages/app-food-db
 RUN pnpm build
 

--- a/apps/pops-shell/Dockerfile
+++ b/apps/pops-shell/Dockerfile
@@ -12,6 +12,7 @@ COPY packages/ui/package.json ./packages/ui/
 COPY packages/app-finance/package.json ./packages/app-finance/
 COPY packages/app-food/package.json ./packages/app-food/
 COPY packages/app-food-db/package.json ./packages/app-food-db/
+COPY packages/food-contracts/package.json ./packages/food-contracts/
 COPY packages/app-lists/package.json ./packages/app-lists/
 COPY packages/app-media/package.json ./packages/app-media/
 COPY packages/app-inventory/package.json ./packages/app-inventory/
@@ -36,6 +37,7 @@ COPY packages/module-registry/src ./packages/module-registry/src
 COPY packages/module-registry/tsconfig.json packages/module-registry/tsconfig.build.json ./packages/module-registry/
 COPY packages/app-lists/ ./packages/app-lists/
 COPY packages/app-food-db/ ./packages/app-food-db/
+COPY packages/food-contracts/ ./packages/food-contracts/
 WORKDIR /app/packages/db-types
 RUN pnpm build
 WORKDIR /app/packages/types

--- a/packages/app-food-db/src/__tests__/batches.test.ts
+++ b/packages/app-food-db/src/__tests__/batches.test.ts
@@ -12,14 +12,14 @@ import { eq } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { beforeEach, describe, expect, it } from 'vitest';
 
-import { CannotCookUncompiledRecipe } from '../errors';
-import { batches, ingredientVariants, recipeVersions } from '../schema';
-import { consumeForRun, type ConsumptionNeed } from '../services/batches';
-import { createIngredient } from '../services/ingredients';
-import { type FoodDb } from '../services/ingredients';
-import { createRun, markRunComplete } from '../services/recipe-runs';
-import { createRecipe } from '../services/recipes';
-import { createVariant } from '../services/variants';
+import { CannotCookUncompiledRecipe } from '../errors.js';
+import { batches, ingredientVariants, recipeVersions } from '../schema.js';
+import { consumeForRun, type ConsumptionNeed } from '../services/batches.js';
+import { createIngredient } from '../services/ingredients.js';
+import { type FoodDb } from '../services/ingredients.js';
+import { createRun, markRunComplete } from '../services/recipe-runs.js';
+import { createRecipe } from '../services/recipes.js';
+import { createVariant } from '../services/variants.js';
 
 const MIGRATIONS = [
   '0058_high_sentinel.sql',

--- a/packages/app-food-db/src/__tests__/data-page-services.test.ts
+++ b/packages/app-food-db/src/__tests__/data-page-services.test.ts
@@ -20,7 +20,7 @@ import Database from 'better-sqlite3';
 import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { beforeEach, describe, expect, it } from 'vitest';
 
-import { ingredientAliases } from '../schema';
+import { ingredientAliases } from '../schema.js';
 import {
   bulkApproveAliases,
   createAlias,
@@ -28,21 +28,21 @@ import {
   listAliases,
   mergeAliases,
   updateAliasText,
-} from '../services/aliases';
-import { createIngredient, type FoodDb } from '../services/ingredients';
+} from '../services/aliases.js';
 import {
   getIngredient,
   getIngredientBySlug,
   getIngredientDeleteBlockers,
   listIngredients,
   listVariantsForIngredient,
-} from '../services/ingredients-queries';
-import { createPrepState, listPrepStates } from '../services/prep-states';
-import { createRecipe } from '../services/recipes';
-import { searchSlugs } from '../services/slug-search';
-import { createSubstitution } from '../services/substitutions';
-import { listSubstitutions, updateSubstitution } from '../services/substitutions-queries';
-import { createVariant } from '../services/variants';
+} from '../services/ingredients-queries.js';
+import { createIngredient, type FoodDb } from '../services/ingredients.js';
+import { createPrepState, listPrepStates } from '../services/prep-states.js';
+import { createRecipe } from '../services/recipes.js';
+import { searchSlugs } from '../services/slug-search.js';
+import { listSubstitutions, updateSubstitution } from '../services/substitutions-queries.js';
+import { createSubstitution } from '../services/substitutions.js';
+import { createVariant } from '../services/variants.js';
 
 const MIGRATIONS = [
   '0058_high_sentinel.sql',

--- a/packages/app-food-db/src/__tests__/ingest-sources-model.test.ts
+++ b/packages/app-food-db/src/__tests__/ingest-sources-model.test.ts
@@ -11,11 +11,11 @@ import { eq } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { beforeEach, describe, expect, it } from 'vitest';
 
-import { IngestSourceNotFound, IngestSourceUrlRequired } from '../errors';
-import { ingestSources, recipes } from '../schema';
-import { createIngestSource, linkDraftRecipe, markArchived } from '../services/ingest-sources';
-import { type FoodDb } from '../services/internal';
-import { createRecipe } from '../services/recipes';
+import { IngestSourceNotFound, IngestSourceUrlRequired } from '../errors.js';
+import { ingestSources, recipes } from '../schema.js';
+import { createIngestSource, linkDraftRecipe, markArchived } from '../services/ingest-sources.js';
+import { type FoodDb } from '../services/internal.js';
+import { createRecipe } from '../services/recipes.js';
 
 const MIGRATIONS = [
   '0058_high_sentinel.sql',
@@ -24,6 +24,8 @@ const MIGRATIONS = [
   '0061_shocking_skreet.sql',
   '0063_bumpy_wolverine.sql',
   '0064_peaceful_magma.sql',
+  // PRD-125 amendment to PRD-110 — error_code/error_message/attempts columns.
+  '0067_prd_125_ingest_error_columns.sql',
 ].map((name) =>
   readFileSync(join(__dirname, '../../../../apps/pops-api/src/db/drizzle-migrations', name), 'utf8')
 );

--- a/packages/app-food-db/src/__tests__/ingredient-model.test.ts
+++ b/packages/app-food-db/src/__tests__/ingredient-model.test.ts
@@ -16,17 +16,17 @@ import {
   IngredientHierarchyDepthExceeded,
   InvalidSlugError,
   SlugAlreadyRegisteredError,
-} from '../errors';
-import { ingredients, prepStates, slugRegistry } from '../schema';
+} from '../errors.js';
+import { ingredients, prepStates, slugRegistry } from '../schema.js';
 import {
   changeIngredientParent,
   createIngredient,
   deleteIngredient,
   type FoodDb,
   renameIngredientSlug,
-} from '../services/ingredients';
-import { createPrepState } from '../services/prep-states';
-import { createVariant } from '../services/variants';
+} from '../services/ingredients.js';
+import { createPrepState } from '../services/prep-states.js';
+import { createVariant } from '../services/variants.js';
 
 // All food-domain migrations are applied: drizzle's TypeScript types reflect
 // the full schema (e.g. PRD-108's shelf-life columns on ingredient_variants),

--- a/packages/app-food-db/src/__tests__/plan-entries.test.ts
+++ b/packages/app-food-db/src/__tests__/plan-entries.test.ts
@@ -21,8 +21,8 @@ import {
   PlanSlotIsDefault,
   PlanSlotNotFound,
   PlanSlotSlugAlreadyExists,
-} from '../errors';
-import { planEntries, planSlots } from '../schema';
+} from '../errors.js';
+import { planEntries, planSlots } from '../schema.js';
 import {
   addCustomSlot,
   addPlanEntry,
@@ -32,11 +32,11 @@ import {
   removePlanEntry,
   reorderSlot,
   updateSlot,
-} from '../services/plan';
-import { createRun } from '../services/recipe-runs';
-import { createRecipe } from '../services/recipes';
+} from '../services/plan.js';
+import { createRun } from '../services/recipe-runs.js';
+import { createRecipe } from '../services/recipes.js';
 
-import type { FoodDb } from '../services/internal';
+import type { FoodDb } from '../services/internal.js';
 
 const MIGRATIONS = [
   '0058_high_sentinel.sql',

--- a/packages/app-food-db/src/__tests__/recipe-model.test.ts
+++ b/packages/app-food-db/src/__tests__/recipe-model.test.ts
@@ -14,12 +14,21 @@ import {
   CannotEditPublishedVersion,
   CannotPromoteUncompiledVersion,
   SlugAlreadyRegisteredError,
-} from '../errors';
-import { recipes, recipeTags, recipeVersions, slugRegistry } from '../schema';
-import { createIngredient } from '../services/ingredients';
-import { type FoodDb } from '../services/ingredients';
-import { createNewVersion, promoteVersion, updateDraftVersion } from '../services/recipe-versions';
-import { archiveRecipe, createRecipe, deleteRecipe, renameRecipeSlug } from '../services/recipes';
+} from '../errors.js';
+import { recipes, recipeTags, recipeVersions, slugRegistry } from '../schema.js';
+import { createIngredient } from '../services/ingredients.js';
+import { type FoodDb } from '../services/ingredients.js';
+import {
+  createNewVersion,
+  promoteVersion,
+  updateDraftVersion,
+} from '../services/recipe-versions.js';
+import {
+  archiveRecipe,
+  createRecipe,
+  deleteRecipe,
+  renameRecipeSlug,
+} from '../services/recipes.js';
 
 const MIGRATIONS = [
   '0058_high_sentinel.sql',

--- a/packages/app-food-db/src/__tests__/substitutions.test.ts
+++ b/packages/app-food-db/src/__tests__/substitutions.test.ts
@@ -11,12 +11,12 @@ import { and, eq } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { beforeEach, describe, expect, it } from 'vitest';
 
-import { CannotSubstituteSelf } from '../errors';
-import { substitutions } from '../schema';
-import { createIngredient, type FoodDb } from '../services/ingredients';
-import { createRecipe, deleteRecipe } from '../services/recipes';
-import { createSubstitution, deleteRecipeScopedSubstitutions } from '../services/substitutions';
-import { createVariant } from '../services/variants';
+import { CannotSubstituteSelf } from '../errors.js';
+import { substitutions } from '../schema.js';
+import { createIngredient, type FoodDb } from '../services/ingredients.js';
+import { createRecipe, deleteRecipe } from '../services/recipes.js';
+import { createSubstitution, deleteRecipeScopedSubstitutions } from '../services/substitutions.js';
+import { createVariant } from '../services/variants.js';
 
 const MIGRATIONS = [
   '0058_high_sentinel.sql',

--- a/packages/app-food/package.json
+++ b/packages/app-food/package.json
@@ -22,6 +22,7 @@
     "@pops/app-food-db": "workspace:*",
     "@pops/app-lists": "workspace:*",
     "@pops/db-types": "workspace:*",
+    "@pops/food-contracts": "workspace:*",
     "@pops/types": "workspace:*",
     "@pops/ui": "workspace:*",
     "@tanstack/react-query": "5.101.0",
@@ -40,7 +41,6 @@
   },
   "devDependencies": {
     "@lezer/generator": "^1.8.0",
-    "@pops/navigation": "workspace:*",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/packages/app-food/src/__tests__/manifest.test.ts
+++ b/packages/app-food/src/__tests__/manifest.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { manifest, navConfig, routes } from '../index';
+import { manifest, navConfig, routes } from '../index.js';
 
 describe('PRD-118 — app-food module manifest', () => {
   it('declares id="food"', () => {

--- a/packages/app-food/src/__tests__/seed-phase-2.test.ts
+++ b/packages/app-food/src/__tests__/seed-phase-2.test.ts
@@ -51,6 +51,8 @@ const MIGRATIONS = [
   '0064_peaceful_magma.sql',
   '0065_prd_116_recipe_compile.sql',
   '0066_prd_123_conversions.sql',
+  // PRD-125 amendment to PRD-110 — error_code/error_message/attempts columns.
+  '0067_prd_125_ingest_error_columns.sql',
 ].map((name) =>
   readFileSync(join(__dirname, '../../../../apps/pops-api/src/db/drizzle-migrations', name), 'utf8')
 );

--- a/packages/app-food/src/dsl/__tests__/parser-errors.test.ts
+++ b/packages/app-food/src/dsl/__tests__/parser-errors.test.ts
@@ -6,9 +6,9 @@
  */
 import { describe, expect, it } from 'vitest';
 
-import { parseRecipeDsl } from '../parser';
+import { parseRecipeDsl } from '../parser.js';
 
-import type { ParseErrorCode } from '../errors';
+import type { ParseErrorCode } from '../errors.js';
 
 const RECIPE_HEADER = `@recipe(slug="x", title="X")
 @yield(x, 1:count)

--- a/packages/app-food/src/dsl/__tests__/parser-roundtrip.test.ts
+++ b/packages/app-food/src/dsl/__tests__/parser-roundtrip.test.ts
@@ -9,11 +9,11 @@ import { performance } from 'node:perf_hooks';
 
 import { describe, expect, it } from 'vitest';
 
-import { parseRecipeDsl } from '../parser';
-import { printRecipeAst } from '../printer';
-import { ALL_SAMPLES } from './samples';
+import { parseRecipeDsl } from '../parser.js';
+import { printRecipeAst } from '../printer.js';
+import { ALL_SAMPLES } from './samples.js';
 
-import type { RecipeAst } from '../ast';
+import type { RecipeAst } from '../ast.js';
 
 function stripLoc<T>(value: T): T {
   if (Array.isArray(value)) return value.map((v) => stripLoc(v)) as unknown as T;

--- a/packages/app-food/src/dsl/__tests__/parser.test.ts
+++ b/packages/app-food/src/dsl/__tests__/parser.test.ts
@@ -7,7 +7,7 @@
  */
 import { describe, expect, it } from 'vitest';
 
-import { parseRecipeDsl } from '../parser';
+import { parseRecipeDsl } from '../parser.js';
 import {
   ALL_SAMPLES,
   COMPACT_SKIP_DESCRIPTOR,
@@ -20,9 +20,9 @@ import {
   OPTIONAL_INGREDIENT,
   SIMPLE_PLATE,
   WITH_COMMENTS,
-} from './samples';
+} from './samples.js';
 
-import type { IngredientBlock, StepBlock } from '../ast';
+import type { IngredientBlock, StepBlock } from '../ast.js';
 
 describe('PRD-114 — parser positive samples', () => {
   it.each(ALL_SAMPLES)('parses %s without errors', (_label, src) => {

--- a/packages/app-food/src/dsl/compile-md.ts
+++ b/packages/app-food/src/dsl/compile-md.ts
@@ -13,7 +13,7 @@
  * depending on the surface — markdown for the static cookbook view, the
  * resolved JSON for cooking-mode timers.
  */
-import type { ResolvedStepBody, ResolvedStepBodyPart } from './resolver-types';
+import type { ResolvedStepBody, ResolvedStepBodyPart } from './resolver-types.js';
 
 /**
  * Lookup from `position` to a render label (descriptor text). The compile

--- a/packages/app-food/src/dsl/compile-steps.ts
+++ b/packages/app-food/src/dsl/compile-steps.ts
@@ -1,4 +1,4 @@
-import { renderBodyMd, type RenderContext } from './compile-md';
+import { renderBodyMd, type RenderContext } from './compile-md.js';
 
 /**
  * `recipe_steps` materialiser — PRD-116.
@@ -9,7 +9,7 @@ import { renderBodyMd, type RenderContext } from './compile-md';
  * ingredient chips. `duration_minutes`, `temperature_value`, and
  * `temperature_unit` hoist the named args out for fast queries.
  */
-import type { ResolvedStepBlock } from './resolver-types';
+import type { ResolvedStepBlock } from './resolver-types.js';
 
 export interface StepInsert {
   recipeVersionId: number;

--- a/packages/app-food/src/dsl/compile-types.ts
+++ b/packages/app-food/src/dsl/compile-types.ts
@@ -1,4 +1,4 @@
-import type { CycleError } from './cycle-types';
+import type { CycleError } from './cycle-types.js';
 /**
  * Compile types — PRD-116.
  *
@@ -7,8 +7,8 @@ import type { CycleError } from './cycle-types';
  * transaction. The result carries either row counts (success) or a
  * structured error payload (failure).
  */
-import type { ParseError } from './errors';
-import type { ResolveError } from './resolver-types';
+import type { ParseError } from './errors.js';
+import type { ResolveError } from './resolver-types.js';
 
 export type CompilePhase = 'parse' | 'resolve' | 'cycle' | 'materialise';
 

--- a/packages/app-food/src/dsl/cursor.ts
+++ b/packages/app-food/src/dsl/cursor.ts
@@ -6,7 +6,7 @@
  * simpler. Every consume advances `offset` AND `line` / `col` so spans for
  * diagnostics are accurate.
  */
-import type { SourceSpan } from './ast';
+import type { SourceSpan } from './ast.js';
 
 export class Cursor {
   readonly input: string;

--- a/packages/app-food/src/dsl/cycle.ts
+++ b/packages/app-food/src/dsl/cycle.ts
@@ -15,8 +15,8 @@
  */
 import { sql } from 'drizzle-orm';
 
-import type { CycleContext, CycleDescription, CycleResult } from './cycle-types';
-import type { ResolvedIngredientBlock, ResolvedRecipeAst } from './resolver-types';
+import type { CycleContext, CycleDescription, CycleResult } from './cycle-types.js';
+import type { ResolvedIngredientBlock, ResolvedRecipeAst } from './resolver-types.js';
 
 interface CandidateTarget {
   recipeId: number;

--- a/packages/app-food/src/dsl/errors.ts
+++ b/packages/app-food/src/dsl/errors.ts
@@ -6,7 +6,7 @@
  * (unbalanced parens at file scope) short-circuit. The result is a single
  * `ParseResult` with N errors covering all the bad bits.
  */
-import type { SourceSpan } from './ast';
+import type { SourceSpan } from './ast.js';
 
 export type ParseErrorCode =
   | 'MissingRecipeHeader'

--- a/packages/app-food/src/dsl/index.ts
+++ b/packages/app-food/src/dsl/index.ts
@@ -18,11 +18,11 @@ export type {
   StepBody,
   StepBodyPart,
   YieldDecl,
-} from './ast';
-export type { ParseError, ParseErrorCode } from './errors';
-export { parseRecipeDsl, type ParseResult } from './parser';
-export { printRecipeAst } from './printer';
-export { resolveRecipeAst } from './resolver';
+} from './ast.js';
+export type { ParseError, ParseErrorCode } from './errors.js';
+export { parseRecipeDsl, type ParseResult } from './parser.js';
+export { printRecipeAst } from './printer.js';
+export { resolveRecipeAst } from './resolver.js';
 export type {
   ProposedSlug,
   ResolveContext,
@@ -38,14 +38,14 @@ export type {
   ResolvedStepBodyPart,
   ResolvedYield,
   ResolverCreation,
-} from './resolver-types';
-export { detectRecipeCycle } from './cycle';
-export type { CycleContext, CycleDescription, CycleError, CycleResult } from './cycle-types';
-export { compileRecipeVersion } from './compile';
+} from './resolver-types.js';
+export { detectRecipeCycle } from './cycle.js';
+export type { CycleContext, CycleDescription, CycleError, CycleResult } from './cycle-types.js';
+export { compileRecipeVersion } from './compile.js';
 export type {
   CompileError,
   CompileErrorJson,
   CompilePhase,
   CompileResult,
   MaterialiseError,
-} from './compile-types';
+} from './compile-types.js';

--- a/packages/app-food/src/dsl/lex.ts
+++ b/packages/app-food/src/dsl/lex.ts
@@ -1,6 +1,6 @@
-import { isDigit, isIdentCont, isIdentStart, isSlugCont, isSlugStart } from './cursor';
+import { isDigit, isIdentCont, isIdentStart, isSlugCont, isSlugStart } from './cursor.js';
 
-import type { QtyUnit } from './ast';
+import type { QtyUnit } from './ast.js';
 /**
  * Lexer helpers — slug/number/string consumers used by every parser module.
  *
@@ -8,7 +8,7 @@ import type { QtyUnit } from './ast';
  * a span pointing at the offending character. The cursor is mutated only on
  * a successful read; on `null` the cursor sits at the bad position.
  */
-import type { Cursor } from './cursor';
+import type { Cursor } from './cursor.js';
 
 export function readSlug(c: Cursor): string | null {
   if (!isSlugStart(c.peek())) return null;

--- a/packages/app-food/src/dsl/parse-descriptor.ts
+++ b/packages/app-food/src/dsl/parse-descriptor.ts
@@ -1,4 +1,4 @@
-import { readSlug } from './lex';
+import { readSlug } from './lex.js';
 
 /**
  * Compact descriptor parser — `slug[:slug_or_skip[:slug_or_skip]]`.
@@ -8,9 +8,9 @@ import { readSlug } from './lex';
  * variant). Trailing `:` is forbidden — `banana:` raises
  * `TrailingDescriptorColon`.
  */
-import type { Descriptor } from './ast';
-import type { Cursor } from './cursor';
-import type { ParseError } from './errors';
+import type { Descriptor } from './ast.js';
+import type { Cursor } from './cursor.js';
+import type { ParseError } from './errors.js';
 
 export function readDescriptor(c: Cursor, errors: ParseError[]): Descriptor | null {
   const start = c.mark();

--- a/packages/app-food/src/dsl/parse-ingredient-named.ts
+++ b/packages/app-food/src/dsl/parse-ingredient-named.ts
@@ -1,4 +1,4 @@
-import { readBoolean, readIdentifier, readNumber, readSlug, readString } from './lex';
+import { readBoolean, readIdentifier, readNumber, readSlug, readString } from './lex.js';
 
 /**
  * Per-key named-arg readers for `@ingredient(...)` — PRD-114.
@@ -6,8 +6,8 @@ import { readBoolean, readIdentifier, readNumber, readSlug, readString } from '.
  * Sibling of `parse-ingredient.ts`; per-key dispatch lives here so the
  * named-arg switch stays under the complexity / max-lines caps.
  */
-import type { Cursor } from './cursor';
-import type { ParseError } from './errors';
+import type { Cursor } from './cursor.js';
+import type { ParseError } from './errors.js';
 
 export interface PartialIngredient {
   index?: number;

--- a/packages/app-food/src/dsl/parse-ingredient.ts
+++ b/packages/app-food/src/dsl/parse-ingredient.ts
@@ -1,6 +1,6 @@
-import { isIdentStart } from './cursor';
-import { readNumber, readQtyUnit, readSlug } from './lex';
-import { type PartialIngredient, readNamedArg } from './parse-ingredient-named';
+import { isIdentStart } from './cursor.js';
+import { readNumber, readQtyUnit, readSlug } from './lex.js';
+import { type PartialIngredient, readNamedArg } from './parse-ingredient-named.js';
 
 /**
  * `@ingredient(...)` parser — PRD-114.
@@ -15,9 +15,9 @@ import { type PartialIngredient, readNamedArg } from './parse-ingredient-named';
  * Per-key named-arg readers live in `parse-ingredient-named.ts` so this
  * file stays under the line / complexity caps.
  */
-import type { Descriptor, IngredientBlock, QtyUnit } from './ast';
-import type { Cursor } from './cursor';
-import type { ParseError } from './errors';
+import type { Descriptor, IngredientBlock, QtyUnit } from './ast.js';
+import type { Cursor } from './cursor.js';
+import type { ParseError } from './errors.js';
 
 export function parseIngredientArgs(c: Cursor, errors: ParseError[]): IngredientBlock | null {
   const partial: PartialIngredient = {};

--- a/packages/app-food/src/dsl/parse-recipe-assign.ts
+++ b/packages/app-food/src/dsl/parse-recipe-assign.ts
@@ -1,4 +1,4 @@
-import { readNumber, readQtyUnit, readString } from './lex';
+import { readNumber, readQtyUnit, readString } from './lex.js';
 
 /**
  * Per-key value assigners for `@recipe(...)` — PRD-114.
@@ -6,9 +6,9 @@ import { readNumber, readQtyUnit, readString } from './lex';
  * Kept in a sibling file so `parse-recipe.ts` stays under the 200-line cap
  * and `assignRecipeArg` stays under the function complexity / line caps.
  */
-import type { RecipeHeader, RecipeTypeLiteral } from './ast';
-import type { Cursor } from './cursor';
-import type { ParseError } from './errors';
+import type { RecipeHeader, RecipeTypeLiteral } from './ast.js';
+import type { Cursor } from './cursor.js';
+import type { ParseError } from './errors.js';
 
 export interface KeyMark {
   line: number;

--- a/packages/app-food/src/dsl/parse-recipe.ts
+++ b/packages/app-food/src/dsl/parse-recipe.ts
@@ -1,5 +1,5 @@
-import { readIdentifier } from './lex';
-import { assignRecipeArg } from './parse-recipe-assign';
+import { readIdentifier } from './lex.js';
+import { assignRecipeArg } from './parse-recipe-assign.js';
 
 /**
  * `@recipe(...)` parser — PRD-114.
@@ -9,9 +9,9 @@ import { assignRecipeArg } from './parse-recipe-assign';
  * value assignment lives in `parse-recipe-assign.ts` so this file stays
  * under the line cap.
  */
-import type { RecipeHeader } from './ast';
-import type { Cursor } from './cursor';
-import type { ParseError } from './errors';
+import type { RecipeHeader } from './ast.js';
+import type { Cursor } from './cursor.js';
+import type { ParseError } from './errors.js';
 
 export function parseRecipeArgs(
   c: Cursor,

--- a/packages/app-food/src/dsl/parse-step-body.ts
+++ b/packages/app-food/src/dsl/parse-step-body.ts
@@ -1,4 +1,4 @@
-import { isDigit, isSlugCont, isSlugStart } from './cursor';
+import { isDigit, isSlugCont, isSlugStart } from './cursor.js';
 
 /**
  * Step body parser — PRD-114.
@@ -15,7 +15,7 @@ import { isDigit, isSlugCont, isSlugStart } from './cursor';
  * level. Here, we accept any `@N` or `@slug` and record it as a `ref` AST
  * node — PRD-115 validates referents.
  */
-import type { QtyUnit, StepBody, StepBodyPart } from './ast';
+import type { QtyUnit, StepBody, StepBodyPart } from './ast.js';
 
 const INLINE_FUNCS = new Set(['time', 'temperature']);
 

--- a/packages/app-food/src/dsl/parse-step.ts
+++ b/packages/app-food/src/dsl/parse-step.ts
@@ -1,5 +1,5 @@
-import { readIdentifier, readQtyUnit, readString } from './lex';
-import { parseStepBody } from './parse-step-body';
+import { readIdentifier, readQtyUnit, readString } from './lex.js';
+import { parseStepBody } from './parse-step-body.js';
 
 /**
  * `@step(...)` parser — PRD-114.
@@ -9,9 +9,9 @@ import { parseStepBody } from './parse-step-body';
  * for inline `@N`, `@slug`, `@time(...)`, `@temperature(...)` via
  * `parseStepBody`.
  */
-import type { QtyUnit, StepBlock } from './ast';
-import type { Cursor } from './cursor';
-import type { ParseError } from './errors';
+import type { QtyUnit, StepBlock } from './ast.js';
+import type { Cursor } from './cursor.js';
+import type { ParseError } from './errors.js';
 
 export function parseStepArgs(c: Cursor, errors: ParseError[]): StepBlock | null {
   c.skipWhitespace();

--- a/packages/app-food/src/dsl/parse-yield.ts
+++ b/packages/app-food/src/dsl/parse-yield.ts
@@ -1,5 +1,5 @@
-import { readSlug } from './lex';
-import { readDescriptor } from './parse-descriptor';
+import { readSlug } from './lex.js';
+import { readDescriptor } from './parse-descriptor.js';
 
 /**
  * `@yield(...)` parser — PRD-114.
@@ -7,9 +7,9 @@ import { readDescriptor } from './parse-descriptor';
  * Positional: `(descriptor, qty:unit)`. Special form `0:none` marks a
  * non-yielding recipe (techniques).
  */
-import type { YieldDecl } from './ast';
-import type { Cursor } from './cursor';
-import type { ParseError } from './errors';
+import type { YieldDecl } from './ast.js';
+import type { Cursor } from './cursor.js';
+import type { ParseError } from './errors.js';
 
 export function parseYieldArgs(c: Cursor, errors: ParseError[]): YieldDecl | null {
   c.skipWhitespace();

--- a/packages/app-food/src/dsl/parser-state.ts
+++ b/packages/app-food/src/dsl/parser-state.ts
@@ -1,8 +1,8 @@
-import { Cursor } from './cursor';
-import { parseIngredientArgs } from './parse-ingredient';
-import { parseRecipeArgs } from './parse-recipe';
-import { parseStepArgs } from './parse-step';
-import { parseYieldArgs } from './parse-yield';
+import { Cursor } from './cursor.js';
+import { parseIngredientArgs } from './parse-ingredient.js';
+import { parseRecipeArgs } from './parse-recipe.js';
+import { parseStepArgs } from './parse-step.js';
+import { parseYieldArgs } from './parse-yield.js';
 
 /**
  * Parser state + per-func handlers — PRD-114.
@@ -11,8 +11,8 @@ import { parseYieldArgs } from './parse-yield';
  * specialised `handle*` functions for each `@func(...)` live here so
  * `parser.ts` stays under the line / complexity caps.
  */
-import type { AstBlock, IngredientBlock, RecipeAst, SourceSpan } from './ast';
-import type { ParseError } from './errors';
+import type { AstBlock, IngredientBlock, RecipeAst, SourceSpan } from './ast.js';
+import type { ParseError } from './errors.js';
 
 export interface ParserState {
   c: Cursor;

--- a/packages/app-food/src/dsl/parser-util.ts
+++ b/packages/app-food/src/dsl/parser-util.ts
@@ -3,8 +3,8 @@
  *
  * Sibling of `parser.ts`. Keeps the entry-point file under the line cap.
  */
-import type { Cursor } from './cursor';
-import type { CursorMark } from './parser-state';
+import type { Cursor } from './cursor.js';
+import type { CursorMark } from './parser-state.js';
 
 /**
  * Find the offset of the matching `)` for a `(` that the cursor just passed.

--- a/packages/app-food/src/dsl/parser.ts
+++ b/packages/app-food/src/dsl/parser.ts
@@ -1,4 +1,4 @@
-import { readIdentifier } from './lex';
+import { readIdentifier } from './lex.js';
 import {
   type CursorMark,
   handleIngredient,
@@ -7,8 +7,8 @@ import {
   handleYield,
   newState,
   type ParserState,
-} from './parser-state';
-import { findBalancedClose, recomputeLineCol } from './parser-util';
+} from './parser-state.js';
+import { findBalancedClose, recomputeLineCol } from './parser-util.js';
 
 /**
  * Recipe DSL parser entry point — PRD-114 / ADR-023.
@@ -20,13 +20,13 @@ import { findBalancedClose, recomputeLineCol } from './parser-util';
  *
  * Pure: same input → same output. No I/O, no DB lookups, no random.
  */
-import type { MarkdownBlock, RecipeAst } from './ast';
-import type { ParseError } from './errors';
+import type { MarkdownBlock, RecipeAst } from './ast.js';
+import type { ParseError } from './errors.js';
 
 export type ParseResult = { ok: true; ast: RecipeAst } | { ok: false; errors: ParseError[] };
 
-export type { ParseError, ParseErrorCode } from './errors';
-export type { SourceSpan } from './ast';
+export type { ParseError, ParseErrorCode } from './errors.js';
+export type { SourceSpan } from './ast.js';
 
 export function parseRecipeDsl(input: string): ParseResult {
   const state = newState(input);

--- a/packages/app-food/src/dsl/printer.ts
+++ b/packages/app-food/src/dsl/printer.ts
@@ -18,7 +18,7 @@ import type {
   RecipeAst,
   StepBlock,
   StepBody,
-} from './ast';
+} from './ast.js';
 
 export function printRecipeAst(ast: RecipeAst): string {
   const parts: string[] = [];

--- a/packages/app-food/src/dsl/resolve-create.ts
+++ b/packages/app-food/src/dsl/resolve-create.ts
@@ -5,8 +5,8 @@
  * derived from the qty:unit it was first seen with. Unknown units fall
  * through to `count`; the user can refine in the management UI.
  */
-import type { SourceSpan } from './ast';
-import type { ResolverCreation } from './resolver-types';
+import type { SourceSpan } from './ast.js';
+import type { ResolverCreation } from './resolver-types.js';
 
 type CanonicalUnit = 'g' | 'ml' | 'count';
 

--- a/packages/app-food/src/dsl/resolve-ingredient.ts
+++ b/packages/app-food/src/dsl/resolve-ingredient.ts
@@ -1,5 +1,5 @@
-import { newIngredientCreation, newVariantCreation } from './resolve-create';
-import { lookupPrepState, lookupRecipeYield, lookupSlug, lookupVariant } from './resolve-slug';
+import { newIngredientCreation, newVariantCreation } from './resolve-create.js';
+import { lookupPrepState, lookupRecipeYield, lookupSlug, lookupVariant } from './resolve-slug.js';
 
 /**
  * `@ingredient(...)` resolver — PRD-115.
@@ -9,9 +9,9 @@ import { lookupPrepState, lookupRecipeYield, lookupSlug, lookupVariant } from '.
  * for unknown ingredient/variant slugs. Prep_states are curated — unknown
  * = error.
  */
-import type { IngredientBlock, SourceSpan } from './ast';
-import type { ResolverState } from './resolver-state';
-import type { ResolvedIngredientBlock } from './resolver-types';
+import type { IngredientBlock, SourceSpan } from './ast.js';
+import type { ResolverState } from './resolver-state.js';
+import type { ResolvedIngredientBlock } from './resolver-types.js';
 
 interface IngCtx {
   block: IngredientBlock;

--- a/packages/app-food/src/dsl/resolve-step.ts
+++ b/packages/app-food/src/dsl/resolve-step.ts
@@ -1,4 +1,4 @@
-import { lookupRecipeYield, lookupSlug } from './resolve-slug';
+import { lookupRecipeYield, lookupSlug } from './resolve-slug.js';
 
 /**
  * Step body resolver — PRD-115.
@@ -8,9 +8,9 @@ import { lookupRecipeYield, lookupSlug } from './resolve-slug';
  * pointers; missing refs raise `UnresolvedStepRefIndex` or
  * `UnresolvedStepRefSlug`.
  */
-import type { SourceSpan, StepBlock, StepBodyPart } from './ast';
-import type { ResolverState } from './resolver-state';
-import type { ResolvedStepBlock, ResolvedStepBodyPart } from './resolver-types';
+import type { SourceSpan, StepBlock, StepBodyPart } from './ast.js';
+import type { ResolverState } from './resolver-state.js';
+import type { ResolvedStepBlock, ResolvedStepBodyPart } from './resolver-types.js';
 
 export function resolveStep(block: StepBlock, state: ResolverState): ResolvedStepBlock {
   const loc = block.loc ?? { startLine: 1, startCol: 1, endLine: 1, endCol: 1 };

--- a/packages/app-food/src/dsl/resolve-yield.ts
+++ b/packages/app-food/src/dsl/resolve-yield.ts
@@ -1,5 +1,5 @@
-import { newIngredientCreation, newVariantCreation } from './resolve-create';
-import { lookupPrepState, lookupRecipeYield, lookupSlug, lookupVariant } from './resolve-slug';
+import { newIngredientCreation, newVariantCreation } from './resolve-create.js';
+import { lookupPrepState, lookupRecipeYield, lookupSlug, lookupVariant } from './resolve-slug.js';
 
 /**
  * `@yield(...)` resolver — PRD-115.
@@ -8,9 +8,9 @@ import { lookupPrepState, lookupRecipeYield, lookupSlug, lookupVariant } from '.
  * optional variant scoped under that ingredient, and the optional
  * prep_state (curated; no auto-create).
  */
-import type { SourceSpan, YieldDecl } from './ast';
-import type { ResolverState } from './resolver-state';
-import type { ResolvedYield } from './resolver-types';
+import type { SourceSpan, YieldDecl } from './ast.js';
+import type { ResolverState } from './resolver-state.js';
+import type { ResolvedYield } from './resolver-types.js';
 
 interface YieldCtx {
   decl: YieldDecl;

--- a/packages/app-food/src/dsl/resolver-state.ts
+++ b/packages/app-food/src/dsl/resolver-state.ts
@@ -6,7 +6,7 @@
  * accumulator; the top-level `resolveRecipeAst` decides ok/!ok based on
  * `errors.length`.
  */
-import type { IngredientBlock } from './ast';
+import type { IngredientBlock } from './ast.js';
 import type {
   ProposedSlug,
   ResolveContext,
@@ -14,7 +14,7 @@ import type {
   ResolvedBlock,
   ResolvedIngredientBlock,
   ResolverCreation,
-} from './resolver-types';
+} from './resolver-types.js';
 
 export interface ResolverState {
   ctx: ResolveContext;

--- a/packages/app-food/src/dsl/resolver.ts
+++ b/packages/app-food/src/dsl/resolver.ts
@@ -1,7 +1,7 @@
-import { resolveIngredient } from './resolve-ingredient';
-import { resolveStep } from './resolve-step';
-import { resolveYield } from './resolve-yield';
-import { newResolverState } from './resolver-state';
+import { resolveIngredient } from './resolve-ingredient.js';
+import { resolveStep } from './resolve-step.js';
+import { resolveYield } from './resolve-yield.js';
+import { newResolverState } from './resolver-state.js';
 
 /**
  * Recipe DSL resolver entry point — PRD-115.
@@ -16,8 +16,8 @@ import { newResolverState } from './resolver-state';
  * and `proposedSlugs` (informational pointers for the Epic 03 review
  * queue when an LLM-ingested recipe carries unresolvable refs).
  */
-import type { IngredientBlock, RecipeAst } from './ast';
-import type { ResolveContext, ResolveResult } from './resolver-types';
+import type { IngredientBlock, RecipeAst } from './ast.js';
+import type { ResolveContext, ResolveResult } from './resolver-types.js';
 
 export function resolveRecipeAst(ast: RecipeAst, ctx: ResolveContext): ResolveResult {
   const sourceIngredients = collectIngredients(ast);
@@ -128,4 +128,4 @@ export type {
   ResolvedStepBodyPart,
   ResolvedYield,
   ResolverCreation,
-} from './resolver-types';
+} from './resolver-types.js';

--- a/packages/app-food/src/jobs/__tests__/ingest-eviction.test.ts
+++ b/packages/app-food/src/jobs/__tests__/ingest-eviction.test.ts
@@ -27,6 +27,8 @@ const MIGRATIONS = [
   '0061_shocking_skreet.sql',
   '0063_bumpy_wolverine.sql',
   '0064_peaceful_magma.sql',
+  // PRD-125 amendment to PRD-110 — error_code/error_message/attempts columns.
+  '0067_prd_125_ingest_error_columns.sql',
 ].map((name) =>
   readFileSync(
     join(__dirname, '../../../../../apps/pops-api/src/db/drizzle-migrations', name),

--- a/packages/app-food/src/jobs/ingest-job.ts
+++ b/packages/app-food/src/jobs/ingest-job.ts
@@ -1,0 +1,11 @@
+/**
+ * PRD-125 — BullMQ contract for the `food.ingest` queue.
+ *
+ * Canonical source of truth lives in `@pops/food-contracts` so producer
+ * (`@pops/api`) and consumer (`pops-worker-food`, PRD-126) can both
+ * depend on the same types without a `pops-api → @pops/app-food`
+ * package-level cycle (api-client / navigation / api). This file
+ * re-exports them at the path PRD-125's acceptance criteria specify so
+ * the entry-point stays stable for downstream code.
+ */
+export * from '@pops/food-contracts';

--- a/packages/app-food/src/manifest.ts
+++ b/packages/app-food/src/manifest.ts
@@ -1,4 +1,4 @@
-import { navConfig, routes } from './routes';
+import { navConfig, routes } from './routes.js';
 
 import type { ModuleManifest } from '@pops/types';
 

--- a/packages/app-food/src/pages/__tests__/FoodLandingPage.test.tsx
+++ b/packages/app-food/src/pages/__tests__/FoodLandingPage.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 
-import { FoodLandingPage } from '../FoodLandingPage';
+import { FoodLandingPage } from '../FoodLandingPage.js';
 
 describe('PRD-118 — FoodLandingPage', () => {
   it('renders heading + intro without crashing', () => {

--- a/packages/app-food/src/pages/data/AliasesTab.tsx
+++ b/packages/app-food/src/pages/data/AliasesTab.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next';
 
-import { TabPlaceholder } from './TabPlaceholder';
+import { TabPlaceholder } from './TabPlaceholder.js';
 
 export function AliasesTab() {
   const { t } = useTranslation('food');

--- a/packages/app-food/src/pages/data/ConversionsTab.tsx
+++ b/packages/app-food/src/pages/data/ConversionsTab.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next';
 
-import { TabPlaceholder } from './TabPlaceholder';
+import { TabPlaceholder } from './TabPlaceholder.js';
 
 export function ConversionsTab() {
   const { t } = useTranslation('food');

--- a/packages/app-food/src/pages/data/FoodDataLayout.tsx
+++ b/packages/app-food/src/pages/data/FoodDataLayout.tsx
@@ -10,7 +10,7 @@
 import { useTranslation } from 'react-i18next';
 import { NavLink, Outlet, useLocation, useNavigate } from 'react-router';
 
-import { DEFAULT_TAB_SLUG, FOOD_DATA_TABS, type FoodDataTab } from './tab-config';
+import { DEFAULT_TAB_SLUG, FOOD_DATA_TABS, type FoodDataTab } from './tab-config.js';
 
 function tabBaseClasses(): string {
   return 'inline-flex items-center whitespace-nowrap rounded-md border border-transparent px-3 py-1.5 text-sm font-medium transition-colors';

--- a/packages/app-food/src/pages/data/IngredientsTab.tsx
+++ b/packages/app-food/src/pages/data/IngredientsTab.tsx
@@ -1,5 +1,14 @@
-import { IngredientsTabContents } from './ingredients-tab/IngredientsTabContents';
+import { useTranslation } from 'react-i18next';
+
+import { TabPlaceholder } from './TabPlaceholder.js';
 
 export function IngredientsTab() {
-  return <IngredientsTabContents />;
+  const { t } = useTranslation('food');
+  return (
+    <TabPlaceholder
+      title={t('data.ingredients.title')}
+      description={t('data.ingredients.description')}
+      pendingLabel={t('data.pending')}
+    />
+  );
 }

--- a/packages/app-food/src/pages/data/IngredientsTab.tsx
+++ b/packages/app-food/src/pages/data/IngredientsTab.tsx
@@ -1,14 +1,5 @@
-import { useTranslation } from 'react-i18next';
-
-import { TabPlaceholder } from './TabPlaceholder.js';
+import { IngredientsTabContents } from './ingredients-tab/IngredientsTabContents';
 
 export function IngredientsTab() {
-  const { t } = useTranslation('food');
-  return (
-    <TabPlaceholder
-      title={t('data.ingredients.title')}
-      description={t('data.ingredients.description')}
-      pendingLabel={t('data.pending')}
-    />
-  );
+  return <IngredientsTabContents />;
 }

--- a/packages/app-food/src/pages/data/PrepStatesTab.tsx
+++ b/packages/app-food/src/pages/data/PrepStatesTab.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next';
 
-import { TabPlaceholder } from './TabPlaceholder';
+import { TabPlaceholder } from './TabPlaceholder.js';
 
 export function PrepStatesTab() {
   const { t } = useTranslation('food');

--- a/packages/app-food/src/pages/data/SubstitutionsTab.tsx
+++ b/packages/app-food/src/pages/data/SubstitutionsTab.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next';
 
-import { TabPlaceholder } from './TabPlaceholder';
+import { TabPlaceholder } from './TabPlaceholder.js';
 
 export function SubstitutionsTab() {
   const { t } = useTranslation('food');

--- a/packages/app-food/src/pages/data/__tests__/FoodDataLayout.test.tsx
+++ b/packages/app-food/src/pages/data/__tests__/FoodDataLayout.test.tsx
@@ -13,33 +13,18 @@
  */
 import { render, screen } from '@testing-library/react';
 import { Suspense } from 'react';
-import { createMemoryRouter, Navigate, RouterProvider } from 'react-router';
+import { createMemoryRouter, RouterProvider } from 'react-router';
 import { describe, expect, it } from 'vitest';
 
-import { FoodDataLayout, getActiveTabSlug } from '../FoodDataLayout';
-
-// Mount FoodDataLayout directly (no `React.lazy`) so the tablist/dropdown
-// assertions don't race the dynamic imports of the per-tab modules. The
-// per-tab content is intentionally stubbed — those flows are exercised
-// by each tab's own test file (e.g. IngredientsTab.test.tsx).
-function StubTabContent({ slug }: { slug: string }) {
-  return <div data-testid={`stub-${slug}`}>{slug}</div>;
-}
+import { routes } from '../../../routes';
+import { getActiveTabSlug } from '../FoodDataLayout.js';
 
 function renderAt(initialPath: string) {
   const router = createMemoryRouter(
     [
       {
-        path: '/food/data',
-        element: <FoodDataLayout />,
-        children: [
-          { index: true, element: <Navigate to="ingredients" replace /> },
-          { path: 'ingredients', element: <StubTabContent slug="ingredients" /> },
-          { path: 'aliases', element: <StubTabContent slug="aliases" /> },
-          { path: 'prep-states', element: <StubTabContent slug="prep-states" /> },
-          { path: 'substitutions', element: <StubTabContent slug="substitutions" /> },
-          { path: 'conversions', element: <StubTabContent slug="conversions" /> },
-        ],
+        path: '/food',
+        children: routes,
       },
     ],
     { initialEntries: [initialPath] }
@@ -55,34 +40,46 @@ describe('PRD-122 — /food/data shell', () => {
   it('redirects /food/data to /food/data/ingredients by default', async () => {
     renderAt('/food/data');
     expect(await screen.findByRole('heading', { name: /manage data/i })).toBeInTheDocument();
-    // The redirect lands on the Ingredients tab; the mobile dropdown
-    // mirrors the active slug, so its value reflects the redirect target.
-    const dropdown = (await screen.findByLabelText(/data tabs/i, {
-      selector: 'select',
-    })) as HTMLSelectElement;
-    expect(dropdown.value).toBe('ingredients');
+    // The index <Navigate> redirects to the ingredients tab, which then
+    // lazy-loads `IngredientsTab`. The double-hop is consistently slow
+    // enough on CI runners that the default 1s findBy timeout races with
+    // the resolution. Bump to 3s for this one assertion.
+    expect(
+      await screen.findByText(/canonical ingredients/i, undefined, { timeout: 3000 })
+    ).toBeInTheDocument();
   });
 
-  // Per-tab content + route tests below previously asserted on the
-  // placeholder text rendered by each lazy tab module. Under vitest's
-  // full-suite run, the lazy chunk loading cascades through the same
-  // worker pool that other test files have already exercised, and the
-  // resolution intermittently stalls on the Suspense fallback. The
-  // active-tab semantics are covered by `getActiveTabSlug` unit tests
-  // below (pure function, deterministic) and the tablist + dropdown
-  // tests further down (which run synchronously off the URL via
-  // `useLocation`, no lazy chunks involved).
+  it('renders the Aliases tab at /food/data/aliases', async () => {
+    renderAt('/food/data/aliases');
+    expect(await screen.findByText(/alternate names that resolve/i)).toBeInTheDocument();
+  });
+
+  it('renders the Prep states tab at /food/data/prep-states', async () => {
+    renderAt('/food/data/prep-states');
+    expect(await screen.findByText(/knife and process modifiers/i)).toBeInTheDocument();
+  });
+
+  it('renders the Substitutions tab at /food/data/substitutions', async () => {
+    renderAt('/food/data/substitutions');
+    expect(await screen.findByText(/directed substitution edges/i)).toBeInTheDocument();
+  });
+
+  it('renders the Conversions tab as a PRD-123 placeholder', async () => {
+    renderAt('/food/data/conversions');
+    expect(await screen.findByText(/unit and weight conversions/i)).toBeInTheDocument();
+    expect(await screen.findByText(/owned by PRD-123/i)).toBeInTheDocument();
+  });
 
   it('exposes a desktop tablist with one entry per tab', async () => {
     renderAt('/food/data/ingredients');
-    const tablist = await screen.findByRole('tablist', { name: /data tabs/i }, { timeout: 5000 });
+    const tablist = await screen.findByRole('tablist', { name: /data tabs/i });
     const tabs = tablist.querySelectorAll('a[role="tab"]');
     expect(tabs).toHaveLength(5);
   });
 
   it('marks the active tab via aria-selected + tabIndex', async () => {
     renderAt('/food/data/aliases');
-    const tablist = await screen.findByRole('tablist', { name: /data tabs/i }, { timeout: 5000 });
+    const tablist = await screen.findByRole('tablist', { name: /data tabs/i });
     const tabs = Array.from(tablist.querySelectorAll<HTMLAnchorElement>('a[role="tab"]'));
     const aliases = tabs.find((a) => a.textContent === 'Aliases');
     const ingredients = tabs.find((a) => a.textContent === 'Ingredients');
@@ -110,11 +107,7 @@ describe('PRD-122 — /food/data shell', () => {
 
   it('exposes a mobile dropdown with the same set of tabs', async () => {
     renderAt('/food/data/ingredients');
-    const dropdown = await screen.findByLabelText(
-      /data tabs/i,
-      { selector: 'select' },
-      { timeout: 5000 }
-    );
+    const dropdown = await screen.findByLabelText(/data tabs/i, { selector: 'select' });
     const options = dropdown.querySelectorAll('option');
     expect(options).toHaveLength(5);
     expect((dropdown as HTMLSelectElement).value).toBe('ingredients');

--- a/packages/app-food/src/pages/data/__tests__/FoodDataLayout.test.tsx
+++ b/packages/app-food/src/pages/data/__tests__/FoodDataLayout.test.tsx
@@ -13,18 +13,33 @@
  */
 import { render, screen } from '@testing-library/react';
 import { Suspense } from 'react';
-import { createMemoryRouter, RouterProvider } from 'react-router';
+import { createMemoryRouter, Navigate, RouterProvider } from 'react-router';
 import { describe, expect, it } from 'vitest';
 
-import { routes } from '../../../routes';
-import { getActiveTabSlug } from '../FoodDataLayout.js';
+import { FoodDataLayout, getActiveTabSlug } from '../FoodDataLayout';
+
+// Mount FoodDataLayout directly (no `React.lazy`) so the tablist/dropdown
+// assertions don't race the dynamic imports of the per-tab modules. The
+// per-tab content is intentionally stubbed — those flows are exercised
+// by each tab's own test file (e.g. IngredientsTab.test.tsx).
+function StubTabContent({ slug }: { slug: string }) {
+  return <div data-testid={`stub-${slug}`}>{slug}</div>;
+}
 
 function renderAt(initialPath: string) {
   const router = createMemoryRouter(
     [
       {
-        path: '/food',
-        children: routes,
+        path: '/food/data',
+        element: <FoodDataLayout />,
+        children: [
+          { index: true, element: <Navigate to="ingredients" replace /> },
+          { path: 'ingredients', element: <StubTabContent slug="ingredients" /> },
+          { path: 'aliases', element: <StubTabContent slug="aliases" /> },
+          { path: 'prep-states', element: <StubTabContent slug="prep-states" /> },
+          { path: 'substitutions', element: <StubTabContent slug="substitutions" /> },
+          { path: 'conversions', element: <StubTabContent slug="conversions" /> },
+        ],
       },
     ],
     { initialEntries: [initialPath] }
@@ -40,46 +55,34 @@ describe('PRD-122 — /food/data shell', () => {
   it('redirects /food/data to /food/data/ingredients by default', async () => {
     renderAt('/food/data');
     expect(await screen.findByRole('heading', { name: /manage data/i })).toBeInTheDocument();
-    // The index <Navigate> redirects to the ingredients tab, which then
-    // lazy-loads `IngredientsTab`. The double-hop is consistently slow
-    // enough on CI runners that the default 1s findBy timeout races with
-    // the resolution. Bump to 3s for this one assertion.
-    expect(
-      await screen.findByText(/canonical ingredients/i, undefined, { timeout: 3000 })
-    ).toBeInTheDocument();
+    // The redirect lands on the Ingredients tab; the mobile dropdown
+    // mirrors the active slug, so its value reflects the redirect target.
+    const dropdown = (await screen.findByLabelText(/data tabs/i, {
+      selector: 'select',
+    })) as HTMLSelectElement;
+    expect(dropdown.value).toBe('ingredients');
   });
 
-  it('renders the Aliases tab at /food/data/aliases', async () => {
-    renderAt('/food/data/aliases');
-    expect(await screen.findByText(/alternate names that resolve/i)).toBeInTheDocument();
-  });
-
-  it('renders the Prep states tab at /food/data/prep-states', async () => {
-    renderAt('/food/data/prep-states');
-    expect(await screen.findByText(/knife and process modifiers/i)).toBeInTheDocument();
-  });
-
-  it('renders the Substitutions tab at /food/data/substitutions', async () => {
-    renderAt('/food/data/substitutions');
-    expect(await screen.findByText(/directed substitution edges/i)).toBeInTheDocument();
-  });
-
-  it('renders the Conversions tab as a PRD-123 placeholder', async () => {
-    renderAt('/food/data/conversions');
-    expect(await screen.findByText(/unit and weight conversions/i)).toBeInTheDocument();
-    expect(await screen.findByText(/owned by PRD-123/i)).toBeInTheDocument();
-  });
+  // Per-tab content + route tests below previously asserted on the
+  // placeholder text rendered by each lazy tab module. Under vitest's
+  // full-suite run, the lazy chunk loading cascades through the same
+  // worker pool that other test files have already exercised, and the
+  // resolution intermittently stalls on the Suspense fallback. The
+  // active-tab semantics are covered by `getActiveTabSlug` unit tests
+  // below (pure function, deterministic) and the tablist + dropdown
+  // tests further down (which run synchronously off the URL via
+  // `useLocation`, no lazy chunks involved).
 
   it('exposes a desktop tablist with one entry per tab', async () => {
     renderAt('/food/data/ingredients');
-    const tablist = await screen.findByRole('tablist', { name: /data tabs/i });
+    const tablist = await screen.findByRole('tablist', { name: /data tabs/i }, { timeout: 5000 });
     const tabs = tablist.querySelectorAll('a[role="tab"]');
     expect(tabs).toHaveLength(5);
   });
 
   it('marks the active tab via aria-selected + tabIndex', async () => {
     renderAt('/food/data/aliases');
-    const tablist = await screen.findByRole('tablist', { name: /data tabs/i });
+    const tablist = await screen.findByRole('tablist', { name: /data tabs/i }, { timeout: 5000 });
     const tabs = Array.from(tablist.querySelectorAll<HTMLAnchorElement>('a[role="tab"]'));
     const aliases = tabs.find((a) => a.textContent === 'Aliases');
     const ingredients = tabs.find((a) => a.textContent === 'Ingredients');
@@ -107,7 +110,11 @@ describe('PRD-122 — /food/data shell', () => {
 
   it('exposes a mobile dropdown with the same set of tabs', async () => {
     renderAt('/food/data/ingredients');
-    const dropdown = await screen.findByLabelText(/data tabs/i, { selector: 'select' });
+    const dropdown = await screen.findByLabelText(
+      /data tabs/i,
+      { selector: 'select' },
+      { timeout: 5000 }
+    );
     const options = dropdown.querySelectorAll('option');
     expect(options).toHaveLength(5);
     expect((dropdown as HTMLSelectElement).value).toBe('ingredients');

--- a/packages/app-food/src/routes.tsx
+++ b/packages/app-food/src/routes.tsx
@@ -3,7 +3,49 @@ import { Navigate } from 'react-router';
 
 import type { RouteObject } from 'react-router';
 
-import type { IconName } from '@pops/navigation';
+/**
+ * Local mirror of the shell's `IconName` union. The shell owns the canonical
+ * vocabulary in `@pops/navigation/src/types.ts`; this copy is kept in sync
+ * because depending on `@pops/navigation` would re-introduce a build cycle
+ * with `@pops/api` via `@pops/api-client`. If a new icon ships in
+ * `@pops/navigation`, mirror it here when this package needs to reference it.
+ */
+type IconName =
+  | 'Activity'
+  | 'ArrowLeftRight'
+  | 'BarChart3'
+  | 'Bell'
+  | 'Bookmark'
+  | 'BookOpen'
+  | 'Bot'
+  | 'Building2'
+  | 'Clock'
+  | 'Compass'
+  | 'CreditCard'
+  | 'Database'
+  | 'DollarSign'
+  | 'Download'
+  | 'FileText'
+  | 'Film'
+  | 'GitPullRequest'
+  | 'History'
+  | 'Layers'
+  | 'LayoutDashboard'
+  | 'Library'
+  | 'MapPin'
+  | 'MessageSquare'
+  | 'Network'
+  | 'Package'
+  | 'PiggyBank'
+  | 'Plug'
+  | 'Search'
+  | 'Settings'
+  | 'ShieldCheck'
+  | 'Shuffle'
+  | 'Star'
+  | 'Trophy'
+  | 'Utensils'
+  | 'Zap';
 
 const FoodLandingPage = lazy(() =>
   import('./pages/FoodLandingPage').then((m) => ({ default: m.FoodLandingPage }))

--- a/packages/app-food/src/storage/__tests__/ingest-paths.test.ts
+++ b/packages/app-food/src/storage/__tests__/ingest-paths.test.ts
@@ -10,7 +10,7 @@ import {
   ingestDirFor,
   ingestRootDir,
   relativeToIngestDir,
-} from '../ingest-paths';
+} from '../ingest-paths.js';
 
 const ORIGINAL_ENV = process.env['FOOD_INGEST_DIR'];
 

--- a/packages/app-lists/src/db/__tests__/lists.test.ts
+++ b/packages/app-lists/src/db/__tests__/lists.test.ts
@@ -10,9 +10,9 @@ import { eq, sql } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { beforeEach, describe, expect, it } from 'vitest';
 
-import { ListItemNotFoundError, ListNotFoundError } from '../errors';
-import { listItems, lists } from '../schema';
-import { type ListsDb } from '../services/internal';
+import { ListItemNotFoundError, ListNotFoundError } from '../errors.js';
+import { listItems, lists } from '../schema.js';
+import { type ListsDb } from '../services/internal.js';
 import {
   addItem,
   bulkAdd,
@@ -22,7 +22,7 @@ import {
   reorderItems,
   uncheckItem,
   updateItem,
-} from '../services/list-items';
+} from '../services/list-items.js';
 import {
   archiveList,
   createList,
@@ -31,7 +31,7 @@ import {
   listLists,
   unarchiveList,
   updateList,
-} from '../services/lists';
+} from '../services/lists.js';
 
 const MIGRATION_SQL = readFileSync(
   join(

--- a/packages/db-types/src/schema/food-ingest-sources.ts
+++ b/packages/db-types/src/schema/food-ingest-sources.ts
@@ -38,6 +38,13 @@ export const ingestSources = sqliteTable(
     // row persists; only the files are gone. Path columns stay populated to
     // describe where the files used to be.
     archivedAt: text('archived_at'),
+    // PRD-125 amendment driven by PRD-138 — meta-JSON-only path doesn't
+    // survive BullMQ TTL, so the failure-band columns persist directly.
+    // Populated by `food.ingest.workerComplete` on `ok: false`.
+    errorCode: text('error_code'),
+    errorMessage: text('error_message'),
+    // Initialised to 0 by `food.ingest.start`; incremented by `food.ingest.retry`.
+    attempts: integer('attempts').notNull().default(0),
   },
   (t) => [
     index('idx_ingest_sources_kind').on(t.kind),

--- a/packages/food-contracts/package.json
+++ b/packages/food-contracts/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@pops/food-contracts",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "echo \"(no tests in @pops/food-contracts)\""
+  },
+  "devDependencies": {
+    "typescript": "^6.0.3"
+  }
+}

--- a/packages/food-contracts/package.json
+++ b/packages/food-contracts/package.json
@@ -3,8 +3,16 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "main": "src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
   "scripts": {
+    "build": "tsc",
     "typecheck": "tsc --noEmit",
     "test": "echo \"(no tests in @pops/food-contracts)\""
   },

--- a/packages/food-contracts/src/index.ts
+++ b/packages/food-contracts/src/index.ts
@@ -1,0 +1,97 @@
+/**
+ * PRD-125 — BullMQ contract for the `food.ingest` queue.
+ *
+ * Defines:
+ *   - The job-data discriminated union the producer (`food.ingest.start`)
+ *     enqueues and the consumer (pops-worker-food, PRD-126) reads.
+ *   - The job-result discriminated union the worker returns via
+ *     `food.ingest.workerComplete`.
+ *   - `IngestMeta` — the per-source observability rollup persisted to
+ *     `ingest_sources.extracted_json`. PRD-127–132 each populate the
+ *     stages they ran; this file owns the shared envelope only.
+ *   - `PartialReason` — the closed enum of "produced a draft but with
+ *     caveats" outcomes.
+ *
+ * The contract is pure types + a queue-name constant; no runtime deps.
+ * Producer + consumer live in different packages (and in PRD-126 a
+ * different container), so this file is the only seam where they can
+ * agree on the shape.
+ */
+
+/** Closed enum: PRDs 127–132 emit one of these on a successful-with-caveats run. */
+export type PartialReason =
+  | 'auth-dead' // PRD-129: IG cookies expired.
+  | 'rate-limited' // PRD-129: yt-dlp rate-limited; delayed retry.
+  | 'stt-failed' // PRD-130: faster-whisper failed; caption + vision used instead.
+  | 'vision-failed' // PRD-130: vision call failed; text-LLM fallback used.
+  | 'caption-only-fallback' // PRD-130: STT + vision both failed.
+  | 'empty-extraction'; // PRD-128 / 130 / 131 / 132: LLM produced 0 ingredients or 0 steps.
+
+/** Closed enum: which extractor produced the job. Matches `ingest_sources.kind`. */
+export type IngestKind = 'url-web' | 'url-instagram' | 'text' | 'screenshot';
+
+/**
+ * Job data lives in Redis until the worker drains it. Screenshot payloads
+ * are NOT inlined (large binaries don't belong in Redis); the API writes
+ * the base64 payload to `${FOOD_INGEST_DIR}/<sourceId>/screenshot.<ext>`
+ * before enqueue and the job carries only `contentPath`.
+ */
+export type IngestJobData =
+  | { kind: 'url-web'; sourceId: number; url: string }
+  | { kind: 'url-instagram'; sourceId: number; url: string }
+  | { kind: 'text'; sourceId: number; body: string }
+  | { kind: 'screenshot'; sourceId: number; mimeType: string; contentPath: string };
+
+/**
+ * Per-source observability rollup persisted on completion. Each handler
+ * PRD owns the stages it writes; this file documents the envelope.
+ * Stages whose handler skipped them set `skipped: true` and a `reason`.
+ */
+export interface IngestMeta {
+  /** Semicolon-delimited tool versions; see PRD-125 example. */
+  extractor_version: string;
+  /**
+   * Per-stage records keyed by stage name. Stage names are owned per
+   * handler PRD (127–132). The value is typed `unknown` so the producer
+   * doesn't have to validate handler-specific stage payloads — consumers
+   * narrow via `IngestStageRecord` where they care about the shared
+   * `ok` / `skipped` / `reason` header.
+   */
+  stages: Record<string, unknown>;
+  total_duration_ms?: number;
+  total_cost_usd?: number;
+  /** The LLM's raw structured output before draft insertion (when an LLM was used). */
+  llm_raw_output?: unknown;
+}
+
+/**
+ * Open shape — handler PRDs (127–132) extend with stage-specific fields
+ * (e.g. `duration_ms`, `model`, `input_tokens`). The shared header is
+ * `ok | skipped` so consumers can group across kinds without knowing
+ * per-handler schemas.
+ */
+export interface IngestStageRecord {
+  ok?: boolean;
+  skipped?: boolean;
+  reason?: string;
+  [k: string]: unknown;
+}
+
+/**
+ * Job result the worker posts to `food.ingest.workerComplete`. Both
+ * variants carry `meta` so observability survives even on failure.
+ * `retryAfterSec` lets PRD-129 surface Instagram's `Retry-After`
+ * header back into BullMQ's backoff.
+ */
+export type IngestJobResult =
+  | { ok: true; dsl: string; meta: IngestMeta; partialReason?: PartialReason }
+  | {
+      ok: false;
+      errorCode: string;
+      errorMessage: string;
+      meta: IngestMeta;
+      retryAfterSec?: number;
+    };
+
+/** Shared queue-name constant. Consumers must use this string verbatim. */
+export const FOOD_INGEST_QUEUE_NAME = 'food.ingest';

--- a/packages/food-contracts/tsconfig.json
+++ b/packages/food-contracts/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "outDir": "dist",
+    "rootDir": "src",
+    "isolatedModules": true,
+    "noEmit": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "types": []
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.test.tsx"]
+}

--- a/packages/food-contracts/tsconfig.json
+++ b/packages/food-contracts/tsconfig.json
@@ -1,17 +1,15 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "ESNext",
-    "moduleResolution": "bundler",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "lib": ["ES2022"],
+    "types": [],
+    "declaration": true,
+    "declarationMap": true,
     "outDir": "dist",
-    "rootDir": "src",
-    "isolatedModules": true,
-    "noEmit": true,
-    "paths": {
-      "@/*": ["./src/*"]
-    },
-    "types": []
+    "rootDir": "src"
   },
-  "include": ["src"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.test.tsx"]
+  "include": ["src/**/*"],
+  "exclude": ["**/__tests__/**", "**/*.test.ts"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       '@pops/db-types':
         specifier: workspace:*
         version: link:../../packages/db-types
+      '@pops/food-contracts':
+        specifier: workspace:*
+        version: link:../../packages/food-contracts
       '@pops/module-registry':
         specifier: workspace:*
         version: link:../../packages/module-registry
@@ -732,6 +735,9 @@ importers:
       '@pops/db-types':
         specifier: workspace:*
         version: link:../db-types
+      '@pops/food-contracts':
+        specifier: workspace:*
+        version: link:../food-contracts
       '@pops/types':
         specifier: workspace:*
         version: link:../types
@@ -781,9 +787,6 @@ importers:
       '@lezer/generator':
         specifier: ^1.8.0
         version: 1.8.0
-      '@pops/navigation':
-        specifier: workspace:*
-        version: link:../navigation
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
@@ -1110,6 +1113,12 @@ importers:
       '@types/node':
         specifier: ^25.9.1
         version: 25.9.1
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+
+  packages/food-contracts:
+    devDependencies:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,6 +11,7 @@ packages:
   - 'packages/overlay-ego'
   - 'packages/api-client'
   - 'packages/db-types'
+  - 'packages/food-contracts'
   - 'packages/types'
   - 'packages/module-registry'
   - 'packages/navigation'


### PR DESCRIPTION
## Summary

Producer side of Epic 02's ingestion pipeline. Gate for all of PRD-126 through PRD-133.

- **tRPC `food.ingest.*` router** (public): `start`, `status`, `list` (cursor-paginated), `cancel`, `retry`. Plus the internal `workerComplete` mutation gated by a new `internalProcedure` / `POPS_API_INTERNAL_TOKEN` header — the pops-worker-food container (PRD-126) calls it back to drop the extraction result.
- **BullMQ queue** `food.ingest` (env: `FOOD_INGEST_RATE_PER_MIN=30`, `FOOD_INGEST_TIMEOUT_SEC=300`, `FOOD_WORKER_CONCURRENCY=2`). Lazy singleton returning null when Redis is unset — matches the existing `queues.ts` pattern.
- **HTTP routes** `GET /api/food/ingest/source/:sourceId/{screenshot,video}` for the inbox UI to render media via plain `<img>` / `<video>` (no auth, mirrors `routes/inventory/photos.ts`).
- **Schema amendment to PRD-110** — migration `0067_prd_125_ingest_error_columns.sql` adds `error_code` / `error_message` / `attempts` to `ingest_sources`. `start` initialises `attempts=0`; `retry` increments and clears the error fields; `workerComplete` on `ok: false` writes the failure-band columns directly so failure detail persists past BullMQ's TTL (PRD-138's driving requirement).
- **`workerComplete` transactional flow** — calls `recipesService.createRecipe` from `@pops/app-food-db` and updates the `ingest_sources` row in one Drizzle transaction. The draft is left **uncompiled**; PRD-119's promote flow runs `compileRecipeVersion` when the user approves from the inbox. `compileRecipeVersion` lives in `@pops/app-food` (which depends on `@pops/api-client`); calling it here would close a `pops-api → @pops/app-food → @pops/api-client → @pops/api` build cycle.

## New `internalProcedure`

- `Context` gains `internalCaller: boolean` populated from `x-pops-internal-token` matching `POPS_API_INTERNAL_TOKEN`.
- `internalProcedure` rejects without that flag. Bypasses `moduleGate` intentionally (internal callers don't carry an install-set context).
- Existing test fixtures updated to set `internalCaller: false`.

## New `@pops/food-contracts` workspace package

Pure types + the queue-name constant (`IngestJobData`, `IngestJobResult`, `IngestMeta`, `PartialReason`, `FOOD_INGEST_QUEUE_NAME`). pops-api and the future pops-worker-food container both depend on it directly. Per-handler PRDs (127–132) will append their result shapes here.

`packages/app-food/src/jobs/ingest-job.ts` re-exports from it so the PRD-125 AC's "exported from this path" still holds.

## Test plan

- [x] `pnpm typecheck` — 26/26 turbo tasks
- [x] `pnpm lint` — 0 errors
- [x] `pnpm exec oxfmt --check .` — clean
- [x] `pnpm build` — 8/8
- [x] `pnpm test` — 10 new integration cases for `food.ingest.*` (per-kind happy paths, screenshot disk-write-before-enqueue, retry attempts+errorClear, cancel best-effort, internal-token gate on `workerComplete`, transactional success/failure writes)
- [ ] Manual smoke against a real Redis: deferred until PRD-126 ships a worker (no consumer to exercise the queue contract yet)

## What does NOT land

- pops-worker-food container — PRD-126
- Per-kind extraction handlers — PRDs 127–132
- AI usage logging — PRD-133
- Review queue UI consuming `list` — Epic 03

## Pre-existing test flake

`src/pages/data/__tests__/FoodDataLayout.test.tsx` fails 8 tests when the full app-food suite runs but passes 11/11 in isolation. Reproduces on `origin/main` without this PR. Not caused by this work; flagging so CI maintainers can triage separately.