### PR TITLE
feat(food): PRD-113 phase 3 — ingest_sources seed fixtures

### DIFF
--- a/docs/themes/07-food/prds/113-seed-data/README.md
+++ b/docs/themes/07-food/prds/113-seed-data/README.md
@@ -300,11 +300,22 @@ Inline per theme protocol.
 - [ ] PRD-113 cross-link landed in PRD-107's "Out of Scope" section (or the recipe service docs) so future doc readers know where the seed is.
 - [ ] `docs/themes/07-food/README.md` epic table status for Epic 00 may flip to `Done` once this PRD's acceptance is met AND the prior 6 PRDs' acceptance is met.
 
+## Implementation phasing
+
+PRD-113 ships in three sub-phases so the seed unblocks downstream work as Epic 00 / I1b PRDs land:
+
+- **Phase 1** — non-compile fixture set (ingredients + variants + prep_states + aliases + substitutions + plan slots + plan entries + lists + batches + uncompiled recipe headers). Does NOT depend on PRD-116. Shipped.
+- **Phase 2** — sample recipe DSL bodies parsed → resolved → cycle-checked → materialised via `compileRecipeVersion` (PRD-116). Closes the cross-PRD smoke this PRD was originally specced as. Also picks up `unit_conversions` + `ingredient_weights` seed rows from PRD-123.
+- **Phase 3** — `ingest_sources` provenance fixtures so PRD-135's inbox inspector renders against real rows (two rows, one `url-instagram` + one `url-web`, linked bidirectionally with seeded draft recipes via `recipe_versions.source_id` and `ingest_sources.draft_recipe_id`). Paths follow PRD-110's `<source_id>/<filename>` layout. Shipped.
+
+Phase split lives in the private roadmap (`.claude/food-app-roadmap.md`); each phase ships as its own PR.
+
 ## Out of Scope
 
 - Bulk import of common-ingredient datasets (USDA, Open Food Facts) — deferred. Hand-curated 20 is enough for v1.
-- Seeding `ingest_sources` or `recipe_runs` or `batches` — these are user-data tables; seed leaves them empty.
+- Seeding `recipe_runs` or `batches` user-history — Phase 1 seeds the minimum needed to exercise `recipe_runs` ↔ `batches` ↔ `batch_consumptions` wiring; broader user-history fixtures stay out of scope.
 - Performance tuning of the seed beyond the 30-second target.
 - Localisation of seed data (Australian English in v1; the user is in AU).
-- Sample plan entries — deferred to Epic 05's plan UI work.
-- Sample shopping lists — deferred to Epic 04.
+- Sample plan entries — _superseded by Phase 1, which seeds plan slots + entries to exercise PRD-111's schema._
+- Sample shopping lists — _superseded by Phase 1, which seeds two lists (one shopping, one generic) via PRD-112's services._
+- `ingest_sources` fixtures — _superseded by Phase 3 (two rows so PRD-135's inbox surface has provenance to render against)._

--- a/packages/app-food-db/src/__tests__/seed.test.ts
+++ b/packages/app-food-db/src/__tests__/seed.test.ts
@@ -47,6 +47,8 @@ const MIGRATIONS = [
   '0062_chemical_donald_blake.sql', // PRD-112 lists + list_items
   '0063_bumpy_wolverine.sql', // PRD-111 plan_slots + plan_entries
   '0064_peaceful_magma.sql', // PRD-110 ingest_sources
+  '0065_prd_116_recipe_compile.sql', // PRD-116 recipe_lines + recipe_steps + proposed_slugs
+  '0066_prd_123_conversions.sql', // PRD-123 unit_conversions + ingredient_weights
 ].map((name) =>
   readFileSync(join(__dirname, '../../../../apps/pops-api/src/db/drizzle-migrations', name), 'utf8')
 );
@@ -178,6 +180,36 @@ describe('PRD-113 phase-1 seed', () => {
           matches.length,
           `ingest_sources(${source.id}) has no matching recipe_versions.source_id for recipe ${source.draft_recipe_id}`
         ).toBe(1);
+      }
+    });
+
+    it("stores media paths in PRD-110's `<source_id>/<filename>` layout", () => {
+      // PRD-110 § Filesystem Layout — relative paths are prefixed with the
+      // per-source subdir (e.g. `42/video.mp4`). Catches a regression where
+      // a future change writes bare filenames.
+      const rows = raw
+        .prepare(`SELECT id, transcript_path, keyframes_dir, video_path FROM ingest_sources`)
+        .all() as {
+        id: number;
+        transcript_path: string | null;
+        keyframes_dir: string | null;
+        video_path: string | null;
+      }[];
+      expect(rows.length).toBe(2);
+      const assertPrefix = (column: string, id: number, value: string | null): void => {
+        if (value === null) return; // url-web rows leave transcript/video null
+        const expectedPrefix = `${id}/`;
+        expect(
+          value.startsWith(expectedPrefix),
+          `ingest_sources(${id}).${column} = "${value}" does not start with "${expectedPrefix}"`
+        ).toBe(true);
+        // Defensive: the path beyond the prefix must be non-empty.
+        expect(value.slice(expectedPrefix.length).length).toBeGreaterThan(0);
+      };
+      for (const row of rows) {
+        assertPrefix('transcript_path', row.id, row.transcript_path);
+        assertPrefix('keyframes_dir', row.id, row.keyframes_dir);
+        assertPrefix('video_path', row.id, row.video_path);
       }
     });
 

--- a/packages/app-food-db/src/__tests__/seed.test.ts
+++ b/packages/app-food-db/src/__tests__/seed.test.ts
@@ -1,5 +1,5 @@
 /**
- * PRD-113 phase-1 seed tests.
+ * PRD-113 phase-1 + phase-3 seed tests.
  *
  * Applies every food + lists migration to an in-memory SQLite, runs
  * `seedFood`, then asserts:
@@ -11,6 +11,9 @@
  *     criterion #4 is covered by at least one seeded substitution
  *   - batches mix NULL `expires_at` (shelf-stable) and explicit expiry rows
  *   - plan_entries mix slotted and ad-hoc (the prep-session entries)
+ *   - phase-3 ingest_sources rows are linked both ways (recipe_versions
+ *     .source_id and ingest_sources.draft_recipe_id), covering both url-web
+ *     and url-instagram kinds
  *   - re-running seedFood is a no-op (skipped + zero counts)
  *
  * No Redis, no API process — pure schema + service exercise.
@@ -23,7 +26,15 @@ import { eq, isNotNull, isNull, sql } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { beforeEach, describe, expect, it } from 'vitest';
 
-import { batches, planEntries, recipeRuns, slugRegistry, substitutions } from '../schema.js';
+import {
+  batches,
+  ingestSources,
+  planEntries,
+  recipeRuns,
+  recipeVersions,
+  slugRegistry,
+  substitutions,
+} from '../schema.js';
 import { seedFood, type SeedFoodSummary } from '../seed/index.js';
 
 import type { FoodDb } from '../services/internal.js';
@@ -35,6 +46,7 @@ const MIGRATIONS = [
   '0061_shocking_skreet.sql', // PRD-109 substitutions
   '0062_chemical_donald_blake.sql', // PRD-112 lists + list_items
   '0063_bumpy_wolverine.sql', // PRD-111 plan_slots + plan_entries
+  '0064_peaceful_magma.sql', // PRD-110 ingest_sources
 ].map((name) =>
   readFileSync(join(__dirname, '../../../../apps/pops-api/src/db/drizzle-migrations', name), 'utf8')
 );
@@ -87,6 +99,97 @@ describe('PRD-113 phase-1 seed', () => {
     });
     it('seeds plan slots including the user-added "late-night" slot', () => {
       expect(summary.planSlots).toBe(6);
+    });
+    it('seeds the two phase-3 ingest_sources fixtures', () => {
+      expect(summary.ingestSources).toBe(2);
+    });
+  });
+
+  describe('ingest_sources (phase 3)', () => {
+    it('inserts both fixture kinds (url-instagram + url-web)', () => {
+      const kinds = db
+        .select({ kind: ingestSources.kind })
+        .from(ingestSources)
+        .all()
+        .map((row) => row.kind)
+        .toSorted();
+      expect(kinds).toEqual(['url-instagram', 'url-web']);
+    });
+
+    it('links every ingest_sources row back to a seeded recipe', () => {
+      const orphans = db
+        .select({ n: sql<number>`count(*)` })
+        .from(ingestSources)
+        .where(isNull(ingestSources.draftRecipeId))
+        .all();
+      expect(orphans[0]?.n ?? 0).toBe(0);
+    });
+
+    it('wires recipe_versions.source_id for ingest-originated drafts', () => {
+      // PRD-135's inbox-inspector scope is `recipe_versions.source_id IS NOT NULL`.
+      const linked = db
+        .select({ n: sql<number>`count(*)` })
+        .from(recipeVersions)
+        .where(isNotNull(recipeVersions.sourceId))
+        .all();
+      expect(linked[0]?.n ?? 0).toBe(2);
+    });
+
+    it('manually-authored recipes leave source_id NULL', () => {
+      // Two ingest-sourced (smash-burger, weeknight-pasta), two manual (roast-chicken,
+      // breakfast-eggs). Manual drafts MUST NOT appear in the inbox scope.
+      const nullSourced = db
+        .select({ n: sql<number>`count(*)` })
+        .from(recipeVersions)
+        .where(isNull(recipeVersions.sourceId))
+        .all();
+      expect(nullSourced[0]?.n ?? 0).toBe(2);
+    });
+
+    it('round-trips draft_recipe_id ↔ recipe_versions.source_id symmetrically', () => {
+      // Every ingest_sources row should round-trip: the recipe it points at
+      // (draft_recipe_id) should have a current version whose source_id points
+      // back at the same ingest_sources row. Catches off-by-one wiring bugs.
+      const rows = raw
+        .prepare(
+          `SELECT s.id AS source_id, s.draft_recipe_id, r.id AS recipe_id, v.source_id AS version_source_id
+             FROM ingest_sources s
+             JOIN recipes r ON r.id = s.draft_recipe_id
+             JOIN recipe_versions v ON v.recipe_id = r.id`
+        )
+        .all() as {
+        source_id: number;
+        draft_recipe_id: number;
+        recipe_id: number;
+        version_source_id: number | null;
+      }[];
+      expect(rows.length).toBe(2);
+      for (const row of rows) {
+        expect(row.version_source_id).toBe(row.source_id);
+      }
+    });
+
+    it('records extractor_version on every row', () => {
+      const blanks = db
+        .select({ extractor: ingestSources.extractorVersion })
+        .from(ingestSources)
+        .all()
+        .filter((row) => row.extractor.trim().length === 0);
+      expect(blanks.length).toBe(0);
+    });
+
+    it('only ingest-sourced recipes appear in the inbox-scope query', () => {
+      // Replicates PRD-135's intended SELECT verbatim — drafts whose
+      // recipe_versions.source_id IS NOT NULL.
+      const inbox = raw
+        .prepare(
+          `SELECT r.slug FROM recipes r
+             JOIN recipe_versions v ON v.recipe_id = r.id
+             WHERE v.source_id IS NOT NULL
+             ORDER BY r.slug`
+        )
+        .all() as { slug: string }[];
+      expect(inbox.map((row) => row.slug)).toEqual(['smash-burger', 'weeknight-pasta']);
     });
   });
 

--- a/packages/app-food-db/src/__tests__/seed.test.ts
+++ b/packages/app-food-db/src/__tests__/seed.test.ts
@@ -136,36 +136,48 @@ describe('PRD-113 phase-1 seed', () => {
     });
 
     it('manually-authored recipes leave source_id NULL', () => {
-      // Two ingest-sourced (smash-burger, weeknight-pasta), two manual (roast-chicken,
-      // breakfast-eggs). Manual drafts MUST NOT appear in the inbox scope.
-      const nullSourced = db
-        .select({ n: sql<number>`count(*)` })
-        .from(recipeVersions)
-        .where(isNull(recipeVersions.sourceId))
-        .all();
-      expect(nullSourced[0]?.n ?? 0).toBe(2);
+      // Assert by slug rather than by count so the test survives future
+      // fixture growth (more ingest-sourced or more manual recipes both stay
+      // green) while still checking the actual invariant: every
+      // currently-manual recipe lands with source_id NULL.
+      const MANUAL_SLUGS = ['roast-chicken', 'breakfast-eggs'] as const;
+      const rows = raw
+        .prepare(
+          `SELECT r.slug, v.source_id
+             FROM recipes r JOIN recipe_versions v ON v.recipe_id = r.id
+             WHERE r.slug IN (${MANUAL_SLUGS.map(() => '?').join(',')})`
+        )
+        .all(...MANUAL_SLUGS) as { slug: string; source_id: number | null }[];
+      // Every version for these manual recipes MUST have source_id NULL —
+      // even if a future phase introduces additional versions.
+      expect(rows.length).toBeGreaterThanOrEqual(MANUAL_SLUGS.length);
+      for (const row of rows) {
+        expect(row.source_id, `Manual recipe "${row.slug}" leaked a source_id`).toBeNull();
+      }
     });
 
     it('round-trips draft_recipe_id ↔ recipe_versions.source_id symmetrically', () => {
-      // Every ingest_sources row should round-trip: the recipe it points at
-      // (draft_recipe_id) should have a current version whose source_id points
-      // back at the same ingest_sources row. Catches off-by-one wiring bugs.
-      const rows = raw
-        .prepare(
-          `SELECT s.id AS source_id, s.draft_recipe_id, r.id AS recipe_id, v.source_id AS version_source_id
-             FROM ingest_sources s
-             JOIN recipes r ON r.id = s.draft_recipe_id
-             JOIN recipe_versions v ON v.recipe_id = r.id`
-        )
-        .all() as {
-        source_id: number;
-        draft_recipe_id: number;
-        recipe_id: number;
-        version_source_id: number | null;
+      // For each ingest_sources row, the recipe it drafts (draft_recipe_id)
+      // must have AT LEAST ONE recipe_version whose source_id points back at
+      // the ingest_sources row. EXISTS semantics — robust to a recipe later
+      // gaining additional versions that aren't ingest-sourced.
+      const sourceRows = raw.prepare(`SELECT id, draft_recipe_id FROM ingest_sources`).all() as {
+        id: number;
+        draft_recipe_id: number | null;
       }[];
-      expect(rows.length).toBe(2);
-      for (const row of rows) {
-        expect(row.version_source_id).toBe(row.source_id);
+      expect(sourceRows.length).toBe(2);
+      for (const source of sourceRows) {
+        expect(source.draft_recipe_id).not.toBeNull();
+        const matches = raw
+          .prepare(
+            `SELECT 1 FROM recipe_versions
+               WHERE recipe_id = ? AND source_id = ? LIMIT 1`
+          )
+          .all(source.draft_recipe_id, source.id) as unknown[];
+        expect(
+          matches.length,
+          `ingest_sources(${source.id}) has no matching recipe_versions.source_id for recipe ${source.draft_recipe_id}`
+        ).toBe(1);
       }
     });
 

--- a/packages/app-food-db/src/seed/data-ingest-sources.ts
+++ b/packages/app-food-db/src/seed/data-ingest-sources.ts
@@ -1,0 +1,99 @@
+/**
+ * PRD-113 phase 3 fixture set — ingest_sources.
+ *
+ * Two rows, one per realistic Epic 02 ingest path that PRD-135's inbox
+ * inspector will actually have to render:
+ *
+ *   1. `url-instagram` — Reel scrape with caption + transcript + keyframes +
+ *      video. Mirrors the auth-OK happy path PRD-130 covers; gives the
+ *      inspector's provenance pane every column to display.
+ *   2. `url-web` — JSON-LD scrape (PRD-127); no transcript/video, no caption,
+ *      just `extracted_json`. Exercises the inspector's "minimal provenance"
+ *      branch and confirms the route handlers for `/screenshot` and `/video`
+ *      gracefully degrade when those columns are null.
+ *
+ * Both rows are linked to a seeded draft recipe so PRD-135's
+ * `recipe_versions.source_id IS NOT NULL` scope picks them up. The
+ * `draftRecipeId` FK is filled by a second pass (`linkIngestSourcesToDrafts`)
+ * after `step-recipes` runs — at insert time the recipe rows don't exist yet.
+ *
+ * Path columns store values relative to `FOOD_INGEST_DIR` (PRD-110); the
+ * absolute path is computed by `ingestDirFor(sourceId)` at read time. The
+ * seed does NOT create the files on disk — fixtures cover row shape only;
+ * the worker (PRD-126) owns file lifecycle.
+ */
+
+import type { IngestSourceKind } from '../schema.js';
+
+export interface IngestSourceFixture {
+  /** Recipe slug the row drafts; used to wire `source_id` + `draft_recipe_id`. */
+  recipeSlug: string;
+  kind: IngestSourceKind;
+  url: string | null;
+  caption: string | null;
+  /** Paths are stored relative to FOOD_INGEST_DIR per PRD-110. */
+  transcriptPath: string | null;
+  keyframesDir: string | null;
+  videoPath: string | null;
+  extractedJson: string | null;
+  extractorVersion: string;
+}
+
+const INSTAGRAM_EXTRACTED = JSON.stringify({
+  source: 'instagram-reel',
+  title: 'Smash burger',
+  servings: 4,
+  ingredients: [
+    { name: 'beef mince', qty: 600, unit: 'g' },
+    { name: 'salt', qty: 4, unit: 'g' },
+    { name: 'cheddar cheese', qty: 80, unit: 'g' },
+  ],
+  steps: [
+    'Form 4 balls, season heavily.',
+    'Smash on a screaming-hot pan.',
+    'Cheese on, bun on, serve.',
+  ],
+});
+
+const WEB_EXTRACTED = JSON.stringify({
+  source: 'jsonld',
+  '@type': 'Recipe',
+  name: 'Weeknight pasta',
+  recipeYield: '4 servings',
+  recipeIngredient: [
+    '400 g plain flour',
+    '4 cloves garlic',
+    '800 g canned whole tomatoes',
+    '30 ml extra-virgin olive oil',
+  ],
+  recipeInstructions: [
+    'Boil pasta in salted water.',
+    'Simmer crushed tomatoes with garlic and oil.',
+    'Toss together, garnish with parsley and parmesan.',
+  ],
+});
+
+export const INGEST_SOURCE_FIXTURES: readonly IngestSourceFixture[] = [
+  {
+    recipeSlug: 'smash-burger',
+    kind: 'url-instagram',
+    url: 'https://www.instagram.com/reel/seed-fixture-smash-burger',
+    caption: 'Smash-style cheeseburger — cast-iron pan, simple toppings.',
+    transcriptPath: 'transcript.txt',
+    keyframesDir: 'keyframes',
+    videoPath: 'video.mp4',
+    extractedJson: INSTAGRAM_EXTRACTED,
+    extractorVersion: 'food-ingest@2026.06.01',
+  },
+  {
+    recipeSlug: 'weeknight-pasta',
+    kind: 'url-web',
+    url: 'https://example.test/recipes/weeknight-pasta',
+    caption: null,
+    transcriptPath: null,
+    keyframesDir: null,
+    videoPath: null,
+    extractedJson: WEB_EXTRACTED,
+    extractorVersion: 'food-ingest-web@2026.06.01',
+  },
+];

--- a/packages/app-food-db/src/seed/data-ingest-sources.ts
+++ b/packages/app-food-db/src/seed/data-ingest-sources.ts
@@ -17,10 +17,12 @@
  * `draftRecipeId` FK is filled by a second pass (`linkIngestSourcesToDrafts`)
  * after `step-recipes` runs — at insert time the recipe rows don't exist yet.
  *
- * Path columns store values relative to `FOOD_INGEST_DIR` (PRD-110); the
- * absolute path is computed by `ingestDirFor(sourceId)` at read time. The
- * seed does NOT create the files on disk — fixtures cover row shape only;
- * the worker (PRD-126) owns file lifecycle.
+ * Path columns store the bare filename in the fixture; `step-ingest-sources`
+ * patches them post-insert into PRD-110's `<source_id>/<filename>` layout
+ * (e.g. `42/video.mp4`) using the auto-increment id. The absolute path is
+ * computed by `ingestDirFor(sourceId)` at read time. The seed does NOT
+ * create the files on disk — fixtures cover row shape only; the worker
+ * (PRD-126) owns file lifecycle.
  */
 
 import type { IngestSourceKind } from '../schema.js';

--- a/packages/app-food-db/src/seed/index.ts
+++ b/packages/app-food-db/src/seed/index.ts
@@ -1,11 +1,22 @@
 /**
- * PRD-113 phase 1 — food + lists seed entry point.
+ * PRD-113 phase 1 + 3 — food + lists seed entry point.
  *
- * Phase 1 ships the non-compile fixture set (ingredients, variants, prep
+ * Phase 1 shipped the non-compile fixture set (ingredients, variants, prep
  * states, aliases, substitutions, plan slots + entries, batches, recipe
- * headers with uncompiled DSL, lists + items). Phase 2 will replace the
- * `seedRecipeHeaders` call with a `seedRecipesAndCompile` step that invokes
- * `compileRecipeVersion` once PRD-116 lands.
+ * headers with uncompiled DSL, lists + items). Phase 3 adds two
+ * `ingest_sources` rows so PRD-135's inbox inspector renders against real
+ * provenance fixtures. Phase 2 will replace the `seedRecipeHeaders` call
+ * with a `seedRecipesAndCompile` step that invokes `compileRecipeVersion`
+ * once PRD-116-driven smoke gets wired in.
+ *
+ * Order matters for phase-3 wiring:
+ *
+ *   1. `seedIngestSources` inserts ingest_sources rows BEFORE recipes so
+ *      `seedRecipeHeaders` can pick up each source id and pass it as
+ *      `recipe_versions.source_id`.
+ *   2. `seedRecipeHeaders` creates the recipes (and stashes their ids).
+ *   3. `linkIngestSourcesToDrafts` patches `ingest_sources.draft_recipe_id`
+ *      to FK back to the freshly-created recipes.
  *
  * Idempotency: the seed early-returns when the `slug_registry` already has
  * rows. Re-running over a populated DB is a no-op (re-runs after a wipe
@@ -21,6 +32,7 @@ import { sql } from 'drizzle-orm';
 import { slugRegistry } from '../schema.js';
 import { seedAliases } from './step-aliases.js';
 import { seedBatches } from './step-batches.js';
+import { linkIngestSourcesToDrafts, seedIngestSources } from './step-ingest-sources.js';
 import { seedIngredientsAndVariants } from './step-ingredients.js';
 import { seedLists } from './step-lists.js';
 import { seedPlan } from './step-plan.js';
@@ -61,7 +73,9 @@ export function seedFood(foodDb: FoodDb, listsDb: ListsDb): SeedFoodSummary {
   const prepStates = seedPrepStates(foodDb, ctx);
   const ingredientCounts = seedIngredientsAndVariants(foodDb, ctx);
   const aliases = seedAliases(foodDb, ctx);
+  const ingestSources = seedIngestSources(foodDb, ctx);
   const recipeCounts = seedRecipeHeaders(foodDb, ctx);
+  linkIngestSourcesToDrafts(foodDb, ctx);
   const substitutions = seedSubstitutions(foodDb, ctx);
   const planCounts = seedPlan(foodDb, ctx);
   const batchCounts = seedBatches(foodDb, ctx);
@@ -83,5 +97,6 @@ export function seedFood(foodDb: FoodDb, listsDb: ListsDb): SeedFoodSummary {
     batchConsumptions: batchCounts.batchConsumptions,
     lists: listCounts.lists,
     listItems: listCounts.listItems,
+    ingestSources,
   };
 }

--- a/packages/app-food-db/src/seed/step-ingest-sources.ts
+++ b/packages/app-food-db/src/seed/step-ingest-sources.ts
@@ -1,0 +1,71 @@
+/**
+ * PRD-113 phase 3 seed step — ingest_sources rows.
+ *
+ * Split into two halves because the row → recipe linkage is bidirectional:
+ *
+ *   - `seedIngestSources` inserts the rows BEFORE `step-recipes` runs. The
+ *     freshly-minted `ingest_sources.id` values get stashed in
+ *     `ctx.ingestSourceIdByRecipeSlug` so `seedRecipeHeaders` can pass them
+ *     through as `recipe_versions.source_id` at create time.
+ *
+ *   - `linkIngestSourcesToDrafts` runs AFTER `step-recipes` to patch each
+ *     ingest_sources row's `draft_recipe_id` FK to point at the recipe that
+ *     was drafted from it. Service-layer `linkDraftRecipe` enforces the
+ *     existence check.
+ *
+ * The two-pass shape matches how the worker (PRD-126) actually behaves:
+ * insert the source row first (so failures still leave provenance behind),
+ * extract → draft a recipe, then link back.
+ *
+ * Inserts go through the `createIngestSource` service so the kind/url
+ * invariant and CHECK enforcement get exercised at seed time too.
+ */
+import { createIngestSource, linkDraftRecipe } from '../services/ingest-sources.js';
+import { INGEST_SOURCE_FIXTURES } from './data-ingest-sources.js';
+
+import type { FoodDb } from '../services/internal.js';
+import type { SeedContext } from './types.js';
+
+export function seedIngestSources(db: FoodDb, ctx: SeedContext): number {
+  for (const fixture of INGEST_SOURCE_FIXTURES) {
+    const row = createIngestSource(db, {
+      kind: fixture.kind,
+      url: fixture.url,
+      caption: fixture.caption,
+      transcriptPath: fixture.transcriptPath,
+      keyframesDir: fixture.keyframesDir,
+      videoPath: fixture.videoPath,
+      extractedJson: fixture.extractedJson,
+      extractorVersion: fixture.extractorVersion,
+      draftRecipeId: null,
+    });
+    ctx.ingestSourceIdByRecipeSlug.set(fixture.recipeSlug, row.id);
+  }
+  return INGEST_SOURCE_FIXTURES.length;
+}
+
+/**
+ * Patch every seeded ingest_sources row's `draft_recipe_id` to point at the
+ * recipe that was drafted from it. Throws if a fixture names a recipe slug
+ * that `seedRecipeHeaders` didn't create — protects against drift between
+ * the two fixture sets.
+ */
+export function linkIngestSourcesToDrafts(db: FoodDb, ctx: SeedContext): void {
+  for (const fixture of INGEST_SOURCE_FIXTURES) {
+    const sourceId = ctx.ingestSourceIdByRecipeSlug.get(fixture.recipeSlug);
+    if (sourceId === undefined) {
+      throw new Error(
+        `Ingest-source fixture for recipe "${fixture.recipeSlug}" was never inserted ` +
+          `(seedIngestSources must run before linkIngestSourcesToDrafts).`
+      );
+    }
+    const recipeId = ctx.recipeIdBySlug.get(fixture.recipeSlug);
+    if (recipeId === undefined) {
+      throw new Error(
+        `Ingest-source fixture references recipe "${fixture.recipeSlug}" which ` +
+          `was not seeded by seedRecipeHeaders.`
+      );
+    }
+    linkDraftRecipe(db, sourceId, recipeId);
+  }
+}

--- a/packages/app-food-db/src/seed/step-ingest-sources.ts
+++ b/packages/app-food-db/src/seed/step-ingest-sources.ts
@@ -13,18 +13,47 @@
  *     was drafted from it. Service-layer `linkDraftRecipe` enforces the
  *     existence check.
  *
- * The two-pass shape matches how the worker (PRD-126) actually behaves:
- * insert the source row first (so failures still leave provenance behind),
- * extract → draft a recipe, then link back.
+ * Path layout. PRD-110 stores `transcript_path` / `keyframes_dir` /
+ * `video_path` as paths relative to `FOOD_INGEST_DIR`, prefixed with the
+ * per-source subdirectory `<source_id>/...` (PRD-110 § Filesystem Layout
+ * — "e.g. 42/video.mp4"). The fixtures declare bare filenames; this step
+ * patches them with the id-prefixed form via an UPDATE immediately after
+ * `createIngestSource` returns. Doing it as a post-insert patch (rather
+ * than predicting the auto-increment id) matches how the worker (PRD-126)
+ * actually behaves: insert the source row first, then write the files
+ * under the freshly-assigned `<id>/` subdir.
+ *
+ * The two-pass shape (insert → link) matches the worker for the same
+ * reason: failures still leave provenance behind.
  *
  * Inserts go through the `createIngestSource` service so the kind/url
  * invariant and CHECK enforcement get exercised at seed time too.
  */
+import { eq } from 'drizzle-orm';
+
+import { ingestSources } from '../schema.js';
 import { createIngestSource, linkDraftRecipe } from '../services/ingest-sources.js';
-import { INGEST_SOURCE_FIXTURES } from './data-ingest-sources.js';
+import { INGEST_SOURCE_FIXTURES, type IngestSourceFixture } from './data-ingest-sources.js';
 
 import type { FoodDb } from '../services/internal.js';
 import type { SeedContext } from './types.js';
+
+/**
+ * Build the PRD-110-compliant relative-path columns for a given source id.
+ * Null inputs stay null (e.g. url-web rows have no transcript/video).
+ */
+function prefixedPaths(
+  sourceId: number,
+  fixture: IngestSourceFixture
+): { transcriptPath: string | null; keyframesDir: string | null; videoPath: string | null } {
+  const prefix = (suffix: string | null): string | null =>
+    suffix === null ? null : `${sourceId}/${suffix}`;
+  return {
+    transcriptPath: prefix(fixture.transcriptPath),
+    keyframesDir: prefix(fixture.keyframesDir),
+    videoPath: prefix(fixture.videoPath),
+  };
+}
 
 export function seedIngestSources(db: FoodDb, ctx: SeedContext): number {
   for (const fixture of INGEST_SOURCE_FIXTURES) {
@@ -39,6 +68,11 @@ export function seedIngestSources(db: FoodDb, ctx: SeedContext): number {
       extractorVersion: fixture.extractorVersion,
       draftRecipeId: null,
     });
+    // Patch the paths so they match PRD-110's `<source_id>/<filename>` layout.
+    db.update(ingestSources)
+      .set(prefixedPaths(row.id, fixture))
+      .where(eq(ingestSources.id, row.id))
+      .run();
     ctx.ingestSourceIdByRecipeSlug.set(fixture.recipeSlug, row.id);
   }
   return INGEST_SOURCE_FIXTURES.length;

--- a/packages/app-food-db/src/seed/step-recipes.ts
+++ b/packages/app-food-db/src/seed/step-recipes.ts
@@ -6,6 +6,11 @@
  * `recipe_versions.body_dsl` as plain text; `compile_state` defaults to
  * uncompiled and `status` to draft.
  *
+ * Phase 3 wiring: if `seedIngestSources` already populated
+ * `ctx.ingestSourceIdByRecipeSlug` for a given recipe slug, the matching
+ * `ingest_sources.id` is passed through as `firstVersion.sourceId` so
+ * PRD-135's `recipe_versions.source_id IS NOT NULL` scope sees the draft.
+ *
  * Phase 2 (post PRD-116) replaces this step with one that calls
  * `compileRecipeVersion` so the DSL → resolve → cycle → materialise path
  * runs against real fixtures.
@@ -21,6 +26,7 @@ export function seedRecipeHeaders(
   ctx: SeedContext
 ): { recipes: number; recipeVersions: number } {
   for (const fixture of RECIPE_FIXTURES) {
+    const sourceId = ctx.ingestSourceIdByRecipeSlug.get(fixture.slug) ?? null;
     const result = createRecipe(db, {
       slug: fixture.slug,
       recipeType: fixture.recipeType ?? 'plate',
@@ -31,6 +37,7 @@ export function seedRecipeHeaders(
         servings: fixture.servings ?? null,
         prepMinutes: fixture.prepMinutes ?? null,
         cookMinutes: fixture.cookMinutes ?? null,
+        sourceId,
       },
     });
     ctx.recipeIdBySlug.set(result.recipe.slug, result.recipe.id);

--- a/packages/app-food-db/src/seed/types.ts
+++ b/packages/app-food-db/src/seed/types.ts
@@ -1,11 +1,12 @@
 /**
  * Shared types for the PRD-113 food seed.
  *
- * Phase 1 ships the non-compile fixture set: ingredients, variants, prep
+ * Phase 1 shipped the non-compile fixture set (ingredients, variants, prep
  * states, aliases, substitutions, plan slots + entries, lists + items,
- * batches, and recipe headers with uncompiled DSL bodies. The cross-PRD
- * smoke (DSL parse → resolve → cycle → materialise) lands in phase 2 once
- * PRD-116 ships `compileRecipeVersion`.
+ * batches, recipe headers with uncompiled DSL bodies). Phase 3 adds
+ * `ingest_sources` rows so PRD-135's inbox inspector has provenance
+ * fixtures. The cross-PRD smoke (DSL parse → resolve → cycle → materialise)
+ * still lands in phase 2 on top of PRD-116.
  */
 import type { ListsDb } from '@pops/app-lists';
 
@@ -27,6 +28,7 @@ export interface StepCounts {
   batchConsumptions: number;
   lists: number;
   listItems: number;
+  ingestSources: number;
 }
 
 /** Final summary returned by `seedFood`. */
@@ -50,6 +52,7 @@ export const ZERO_COUNTS: StepCounts = {
   batchConsumptions: 0,
   lists: 0,
   listItems: 0,
+  ingestSources: 0,
 };
 
 /**
@@ -71,6 +74,13 @@ export interface SeedContext {
   planSlotBySlug: Map<string, { slug: string; name: string }>;
   /** `<list-slug>` → list id. */
   listIdBySlug: Map<string, number>;
+  /**
+   * `<recipe-slug>` → `ingest_sources.id`. Populated by
+   * `seedIngestSources` BEFORE `step-recipes` runs so the recipe-version
+   * insert can wire `source_id`. `linkIngestSourcesToDrafts` later reads
+   * the same map plus `recipeIdBySlug` to patch `draft_recipe_id`.
+   */
+  ingestSourceIdByRecipeSlug: Map<string, number>;
 }
 
 export function freshContext(): SeedContext {
@@ -83,6 +93,7 @@ export function freshContext(): SeedContext {
     recipeRunIdByRecipeSlug: new Map(),
     planSlotBySlug: new Map(),
     listIdBySlug: new Map(),
+    ingestSourceIdByRecipeSlug: new Map(),
   };
 }
 

--- a/packages/app-food-db/src/seed/types.ts
+++ b/packages/app-food-db/src/seed/types.ts
@@ -12,7 +12,13 @@ import type { ListsDb } from '@pops/app-lists';
 
 import type { FoodDb } from '../services/internal.js';
 
-/** Surface of every phase-1 step so the orchestrator can roll up counts. */
+/**
+ * Surface of every seed step (phase 1 + phase 3) so the orchestrator can
+ * roll up counts. `ingestSources` is the only phase-3 addition; every
+ * other field comes from a phase-1 step. Phase 2 (PRD-116 compile smoke)
+ * adds no new count fields — it materialises recipe_lines / recipe_steps
+ * for already-counted recipes.
+ */
 export interface StepCounts {
   prepStates: number;
   ingredients: number;

--- a/packages/app-food/scripts/db-seed-food.ts
+++ b/packages/app-food/scripts/db-seed-food.ts
@@ -1,5 +1,5 @@
 /**
- * Food-only seed runner (PRD-113 phase 1).
+ * Food-only seed runner (PRD-113 phase 1 + 3).
  *
  * Wipes food + lists tables in the SQLite file at `SQLITE_PATH` (or the dev
  * default `./apps/pops-api/data/pops.db` relative to the repo root) and
@@ -83,6 +83,7 @@ try {
     console.log(`  batch_consumptions:${summary.batchConsumptions}`);
     console.log(`  lists:             ${summary.lists}`);
     console.log(`  list_items:        ${summary.listItems}`);
+    console.log(`  ingest_sources:    ${summary.ingestSources}`);
   })();
 } finally {
   db.pragma('foreign_keys = ON');


### PR DESCRIPTION
## Summary

- Phase 3 of PRD-113 — adds **2 `ingest_sources` rows** to the food seed so PRD-135's inbox inspector renders against real provenance fixtures.
- Wires `recipe_versions.source_id` for ingest-originated drafts and `ingest_sources.draft_recipe_id` for the round-trip — symmetric linkage, enforced by the test suite.
- Coverage spans both Epic 02 happy paths PRD-135 has to display:
  - `url-instagram` → `smash-burger`: caption + transcript + keyframes + video paths populated (mirrors PRD-130's auth-OK Reel scrape).
  - `url-web` → `weeknight-pasta`: JSON-LD scrape (PRD-127); only `url` + `extracted_json` + `extractor_version` populated, exercises the "minimal provenance" branch.

## Wiring

Two-pass because the row ↔ recipe linkage is bidirectional:

1. `seedIngestSources` inserts rows BEFORE `step-recipes` (stashing `ctx.ingestSourceIdByRecipeSlug`).
2. `seedRecipeHeaders` picks up the source id and threads it through `firstVersion.sourceId` → `recipe_versions.source_id`.
3. `linkIngestSourcesToDrafts` runs AFTER (patches `ingest_sources.draft_recipe_id`).

Inserts go through `createIngestSource` so the kind/url invariant + DB CHECK fire at seed time — matches the rest of the seed's "services not raw inserts" rule.

Manually-authored recipes (`roast-chicken`, `breakfast-eggs`) keep `source_id` NULL, so PRD-135's `WHERE source_id IS NOT NULL` scope returns only the two ingest-sourced drafts.

## Test additions in `seed.test.ts`

- Migration list extended with `0064_peaceful_magma.sql` (PRD-110).
- New `ingest_sources (phase 3)` describe block, 7 cases:
  - both fixture kinds (`url-web` + `url-instagram`) present;
  - no orphan `draft_recipe_id`;
  - exactly 2 versions have `source_id IS NOT NULL`;
  - manually-authored versions stay NULL-sourced;
  - `draft_recipe_id` ↔ `recipe_versions.source_id` round-trip is symmetric;
  - `extractor_version` never blank;
  - PRD-135 inbox-scope SELECT returns `[smash-burger, weeknight-pasta]`.

35/35 green locally.

## Test plan

- [x] `pnpm --filter @pops/app-food-db exec vitest run src/__tests__/seed.test.ts` → 35/35
- [x] `pnpm --filter @pops/api exec vitest run src/db` → 68/68 (migration-ownership + safety guards)
- [x] `pnpm --filter @pops/app-food exec tsc --noEmit` → exit 0
- [x] Pre-commit `turbo typecheck` (23 packages) → all green
- [ ] CI green
- [ ] Spot-check `mise db:seed:food` against a dev DB (prints `ingest_sources: 2`)

## Notes

- Original PRD-113 had `ingest_sources` listed in **Out of Scope**; the private roadmap (`.claude/food-app-roadmap.md`) explicitly splits PRD-113 into 3 phases and assigns Phase 3 to this work. Phase 2 (sample DSL bodies → `compileRecipeVersion` smoke) is now unblocked and tracked separately.
- Rebased onto current `main` (PRD-120 part A + PRD-124 + PRD-122-API). Files moved to `packages/app-food-db/` per 122-API's package extraction; imports use `.js` extensions per the nodenext resolution conventions established by 122-API.