### PR TITLE
feat(food): PRD-123 phase B — conversion tRPC procedures + integration tests

### DIFF
--- a/apps/pops-api/src/modules/food/__tests__/conversions-router.test.ts
+++ b/apps/pops-api/src/modules/food/__tests__/conversions-router.test.ts
@@ -1,0 +1,417 @@
+/**
+ * PRD-123 Phase B — integration tests for `food.conversions.*`.
+ *
+ * Spins up an in-memory SQLite with the food schema migrations the
+ * conversions tables depend on (0058 ingredients → 0059 recipes → 0060
+ * batches/variant ALTER → 0066 conversions), wires it into `getDb()` via
+ * `setDb`, and exercises every procedure end-to-end through an `appRouter`
+ * caller. Coverage: boolean `seeded` round-trip, idempotent delete on
+ * unknown id, `SeededRowProtected` → discriminated `{ ok:false,
+ * reason:'seeded' }` short-circuit, `expectRow` propagation on unknown-id
+ * updates, Zod-boundary rejection, unique-constraint rejection, and every
+ * resolve path (identity / unit-conversion / weight wins over unit / variant
+ * wins over null-variant / null-variant fallback / unresolved).
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import BetterSqlite3, { type Database } from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { closeDb, setDb } from '../../../db.js';
+import { createCaller } from '../../../shared/test-utils.js';
+
+const MIGRATION_FILES = [
+  // PRD-106 ingredients + variants + slug_registry
+  '0058_high_sentinel.sql',
+  // PRD-107 recipes (prereq for 0060's recipe_runs FK)
+  '0059_useful_hiroim.sql',
+  // PRD-108 ALTER ingredient_variants (shelf-life cols) + batches/recipe_runs
+  '0060_familiar_leo.sql',
+  // PRD-123 unit_conversions + ingredient_weights
+  '0066_prd_123_conversions.sql',
+];
+
+function applyMigration(db: Database, filename: string): void {
+  const sql = readFileSync(join(__dirname, '../../../db/drizzle-migrations', filename), 'utf8');
+  for (const stmt of sql.split('--> statement-breakpoint')) {
+    const trimmed = stmt.trim();
+    if (trimmed.length > 0) db.exec(trimmed);
+  }
+}
+
+function createFoodTestDb(): Database {
+  const db = new BetterSqlite3(':memory:');
+  db.pragma('journal_mode = WAL');
+  db.pragma('foreign_keys = ON');
+  for (const name of MIGRATION_FILES) applyMigration(db, name);
+  return db;
+}
+
+/** Insert an ingredient row directly via raw SQL rather than going through
+ *  `ingredientsService.createIngredient` — the service auto-registers a
+ *  slug, and these tests want full control over the (ingredient,
+ *  slug_registry) pair to mirror the minimal invariant PRD-106 declares. */
+function seedIngredient(
+  db: Database,
+  name: string,
+  slug: string,
+  defaultUnit: 'g' | 'ml' | 'count' = 'g'
+): number {
+  const row = db
+    .prepare(`INSERT INTO ingredients (name, slug, default_unit) VALUES (?, ?, ?) RETURNING id`)
+    .get(name, slug, defaultUnit) as { id: number };
+  db.prepare(`INSERT INTO slug_registry (slug, kind, target_id) VALUES (?, 'ingredient', ?)`).run(
+    slug,
+    row.id
+  );
+  return row.id;
+}
+
+/** Variants are scoped to their parent ingredient via uq_variants_ingredient_slug;
+ *  they do NOT have their own slug_registry row. */
+function seedVariant(db: Database, ingredientId: number, slug: string, name: string): number {
+  const row = db
+    .prepare(
+      `INSERT INTO ingredient_variants (ingredient_id, name, slug, default_unit) VALUES (?, ?, ?, 'g') RETURNING id`
+    )
+    .get(ingredientId, name, slug) as { id: number };
+  return row.id;
+}
+
+/** Insert a seeded unit_conversion row directly so the `is_seeded=1` path
+ *  is exercised — the createUnit procedure deliberately forces is_seeded=0. */
+function seedUnitConversion(
+  db: Database,
+  fromUnit: string,
+  toUnit: 'g' | 'ml' | 'count',
+  ratio: number
+): number {
+  const row = db
+    .prepare(
+      `INSERT INTO unit_conversions (from_unit, to_unit, ratio, is_seeded) VALUES (?, ?, ?, 1) RETURNING id`
+    )
+    .get(fromUnit, toUnit, ratio) as { id: number };
+  return row.id;
+}
+
+let db: Database;
+let caller: ReturnType<typeof createCaller>;
+
+beforeEach(() => {
+  db = createFoodTestDb();
+  setDb(db);
+  caller = createCaller(true);
+});
+
+afterEach(() => {
+  closeDb();
+});
+
+describe('food.conversions.listUnits', () => {
+  it('returns empty list when no rows', async () => {
+    const result = await caller.food.conversions.listUnits();
+    expect(result.items).toEqual([]);
+  });
+
+  it('returns user-added rows with seeded=false', async () => {
+    await caller.food.conversions.createUnit({ fromUnit: 'cup', toUnit: 'ml', ratio: 240 });
+    const result = await caller.food.conversions.listUnits();
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]).toMatchObject({
+      fromUnit: 'cup',
+      toUnit: 'ml',
+      ratio: 240,
+      seeded: false,
+    });
+  });
+
+  it('seededOnly filters out user rows', async () => {
+    seedUnitConversion(db, 'cup', 'ml', 240);
+    await caller.food.conversions.createUnit({ fromUnit: 'tbsp', toUnit: 'ml', ratio: 15 });
+
+    const all = await caller.food.conversions.listUnits();
+    expect(all.items).toHaveLength(2);
+
+    const seededOnly = await caller.food.conversions.listUnits({ seededOnly: true });
+    expect(seededOnly.items).toHaveLength(1);
+    expect(seededOnly.items[0]?.fromUnit).toBe('cup');
+    expect(seededOnly.items[0]?.seeded).toBe(true);
+  });
+
+  it('search matches against from_unit and to_unit', async () => {
+    await caller.food.conversions.createUnit({ fromUnit: 'cup', toUnit: 'ml', ratio: 240 });
+    await caller.food.conversions.createUnit({ fromUnit: 'oz', toUnit: 'g', ratio: 28.35 });
+
+    const cup = await caller.food.conversions.listUnits({ search: 'cup' });
+    expect(cup.items.map((r) => r.fromUnit)).toEqual(['cup']);
+
+    const g = await caller.food.conversions.listUnits({ search: 'g' });
+    expect(g.items.map((r) => r.fromUnit)).toEqual(['oz']);
+  });
+});
+
+describe('food.conversions.createUnit', () => {
+  it('returns the inserted row with seeded=false', async () => {
+    const { data } = await caller.food.conversions.createUnit({
+      fromUnit: 'tsp',
+      toUnit: 'ml',
+      ratio: 5,
+      notes: 'metric teaspoon',
+    });
+    expect(data).toMatchObject({
+      fromUnit: 'tsp',
+      toUnit: 'ml',
+      ratio: 5,
+      notes: 'metric teaspoon',
+      seeded: false,
+    });
+    expect(data.id).toBeGreaterThan(0);
+  });
+
+  it('rejects ratio <= 0 at the Zod boundary', async () => {
+    await expect(
+      caller.food.conversions.createUnit({ fromUnit: 'bad', toUnit: 'ml', ratio: 0 })
+    ).rejects.toThrow();
+  });
+
+  it('rejects duplicate (from_unit, to_unit) at the unique constraint', async () => {
+    await caller.food.conversions.createUnit({ fromUnit: 'tbsp', toUnit: 'ml', ratio: 15 });
+    await expect(
+      caller.food.conversions.createUnit({ fromUnit: 'tbsp', toUnit: 'ml', ratio: 14.79 })
+    ).rejects.toThrow();
+  });
+});
+
+describe('food.conversions.updateUnit', () => {
+  it('patches ratio + notes and returns the new row', async () => {
+    const { data: created } = await caller.food.conversions.createUnit({
+      fromUnit: 'tbsp',
+      toUnit: 'ml',
+      ratio: 15,
+    });
+    const { data: updated } = await caller.food.conversions.updateUnit({
+      id: created.id,
+      ratio: 14.79,
+      notes: 'metric, AU bias',
+    });
+    expect(updated.ratio).toBe(14.79);
+    expect(updated.notes).toBe('metric, AU bias');
+  });
+
+  it('throws when updating an unknown id (expectRow guard)', async () => {
+    // Phase A's `conversionsService.updateUnitConversion` uses `expectRow` so
+    // an unknown id surfaces as a generic Error rather than a typed NotFound.
+    // The router lets it propagate — Express-level error middleware converts
+    // it to a 500. Clients should not be hitting unknown ids in practice
+    // (the list/get-then-mutate flow rules them out).
+    await expect(caller.food.conversions.updateUnit({ id: 9999, ratio: 1 })).rejects.toThrow();
+  });
+});
+
+describe('food.conversions.deleteUnit', () => {
+  it('deletes a user-added row and returns ok:true', async () => {
+    const { data } = await caller.food.conversions.createUnit({
+      fromUnit: 'each',
+      toUnit: 'count',
+      ratio: 1,
+    });
+    const result = await caller.food.conversions.deleteUnit({ id: data.id });
+    expect(result).toEqual({ ok: true });
+    const after = await caller.food.conversions.listUnits();
+    expect(after.items).toHaveLength(0);
+  });
+
+  it('short-circuits seeded rows with ok:false / reason:seeded', async () => {
+    const id = seedUnitConversion(db, 'cup', 'ml', 240);
+    const result = await caller.food.conversions.deleteUnit({ id });
+    expect(result).toEqual({ ok: false, reason: 'seeded' });
+    const after = await caller.food.conversions.listUnits();
+    expect(after.items).toHaveLength(1);
+    expect(after.items[0]?.seeded).toBe(true);
+  });
+
+  it('is idempotent for unknown ids (Phase A contract)', async () => {
+    // `conversionsService.deleteUnitConversion` silently no-ops when the
+    // row is missing — Phase A chose the idempotent shape over throw, so
+    // refreshing a stale UI page after another tab deleted the row doesn't
+    // raise an error toast.
+    const result = await caller.food.conversions.deleteUnit({ id: 9999 });
+    expect(result).toEqual({ ok: true });
+  });
+});
+
+describe('food.conversions.{create,list,update,delete}Weight', () => {
+  it('round-trips a per-ingredient weight (null variant)', async () => {
+    const onionId = seedIngredient(db, 'Onion', 'onion');
+    const { data } = await caller.food.conversions.createWeight({
+      ingredientId: onionId,
+      unit: 'medium',
+      grams: 150,
+    });
+    expect(data).toMatchObject({
+      ingredientId: onionId,
+      variantId: null,
+      unit: 'medium',
+      grams: 150,
+      seeded: false,
+    });
+
+    const list = await caller.food.conversions.listWeights({ ingredientId: onionId });
+    expect(list.items).toHaveLength(1);
+    expect(list.items[0]?.id).toBe(data.id);
+
+    const { data: updated } = await caller.food.conversions.updateWeight({
+      id: data.id,
+      grams: 160,
+    });
+    expect(updated.grams).toBe(160);
+
+    const del = await caller.food.conversions.deleteWeight({ id: data.id });
+    expect(del).toEqual({ ok: true });
+  });
+
+  it('stores per-variant rows and the list filter applies', async () => {
+    const onionId = seedIngredient(db, 'Onion', 'onion');
+    const redId = seedVariant(db, onionId, 'onion:red', 'red');
+    await caller.food.conversions.createWeight({
+      ingredientId: onionId,
+      variantId: redId,
+      unit: 'medium',
+      grams: 175,
+    });
+    await caller.food.conversions.createWeight({
+      ingredientId: onionId,
+      unit: 'medium',
+      grams: 150,
+    });
+
+    const list = await caller.food.conversions.listWeights({ ingredientId: onionId });
+    expect(list.items).toHaveLength(2);
+    const variants = list.items.map((r) => r.variantId);
+    expect(variants).toContain(redId);
+    expect(variants).toContain(null);
+  });
+
+  it('rejects duplicate (ingredient, variant, unit) at the unique constraint', async () => {
+    const onionId = seedIngredient(db, 'Onion', 'onion');
+    await caller.food.conversions.createWeight({
+      ingredientId: onionId,
+      unit: 'medium',
+      grams: 150,
+    });
+    await expect(
+      caller.food.conversions.createWeight({
+        ingredientId: onionId,
+        unit: 'medium',
+        grams: 160,
+      })
+    ).rejects.toThrow();
+  });
+
+  it('deleteWeight on a seeded row short-circuits with ok:false', async () => {
+    const onionId = seedIngredient(db, 'Onion', 'onion');
+    const seededWeightId = (
+      db
+        .prepare(
+          `INSERT INTO ingredient_weights (ingredient_id, variant_id, unit, grams, is_seeded) VALUES (?, NULL, 'medium', 150, 1) RETURNING id`
+        )
+        .get(onionId) as { id: number }
+    ).id;
+    const result = await caller.food.conversions.deleteWeight({ id: seededWeightId });
+    expect(result).toEqual({ ok: false, reason: 'seeded' });
+  });
+
+  it('updateWeight throws for an unknown id (expectRow guard)', async () => {
+    await expect(caller.food.conversions.updateWeight({ id: 9999, grams: 1 })).rejects.toThrow();
+  });
+});
+
+describe('food.conversions.resolve', () => {
+  it('identity carry-over: g unit yields qty unchanged with canonicalUnit=g', async () => {
+    const onionId = seedIngredient(db, 'Onion', 'onion');
+    const result = await caller.food.conversions.resolve({
+      ingredientId: onionId,
+      unit: 'g',
+      qty: 250,
+    });
+    expect(result).toEqual({ kind: 'resolved', canonicalUnit: 'g', qty: 250 });
+  });
+
+  it('falls back to unit_conversions when no ingredient_weight matches', async () => {
+    const onionId = seedIngredient(db, 'Onion', 'onion');
+    await caller.food.conversions.createUnit({ fromUnit: 'cup', toUnit: 'ml', ratio: 240 });
+    const result = await caller.food.conversions.resolve({
+      ingredientId: onionId,
+      unit: 'cup',
+      qty: 0.5,
+    });
+    expect(result).toEqual({ kind: 'resolved', canonicalUnit: 'ml', qty: 120 });
+  });
+
+  it('ingredient_weight beats unit_conversion for the same unit', async () => {
+    const onionId = seedIngredient(db, 'Onion', 'onion');
+    await caller.food.conversions.createUnit({ fromUnit: 'medium', toUnit: 'count', ratio: 1 });
+    await caller.food.conversions.createWeight({
+      ingredientId: onionId,
+      unit: 'medium',
+      grams: 150,
+    });
+    const result = await caller.food.conversions.resolve({
+      ingredientId: onionId,
+      unit: 'medium',
+      qty: 2,
+    });
+    expect(result).toEqual({ kind: 'resolved', canonicalUnit: 'g', qty: 300 });
+  });
+
+  it('variant-specific weight wins over null-variant for the same (ingredient, unit)', async () => {
+    const onionId = seedIngredient(db, 'Onion', 'onion');
+    const redId = seedVariant(db, onionId, 'onion:red', 'red');
+    await caller.food.conversions.createWeight({
+      ingredientId: onionId,
+      unit: 'medium',
+      grams: 150,
+    });
+    await caller.food.conversions.createWeight({
+      ingredientId: onionId,
+      variantId: redId,
+      unit: 'medium',
+      grams: 175,
+    });
+    const result = await caller.food.conversions.resolve({
+      ingredientId: onionId,
+      variantId: redId,
+      unit: 'medium',
+      qty: 2,
+    });
+    expect(result).toEqual({ kind: 'resolved', canonicalUnit: 'g', qty: 350 });
+  });
+
+  it('falls back from a variant-specific lookup to the null-variant row', async () => {
+    const onionId = seedIngredient(db, 'Onion', 'onion');
+    const redId = seedVariant(db, onionId, 'onion:red', 'red');
+    await caller.food.conversions.createWeight({
+      ingredientId: onionId,
+      unit: 'medium',
+      grams: 150,
+    });
+    const result = await caller.food.conversions.resolve({
+      ingredientId: onionId,
+      variantId: redId,
+      unit: 'medium',
+      qty: 1,
+    });
+    expect(result).toEqual({ kind: 'resolved', canonicalUnit: 'g', qty: 150 });
+  });
+
+  it('unresolved when no row covers the unit', async () => {
+    const onionId = seedIngredient(db, 'Onion', 'onion');
+    const result = await caller.food.conversions.resolve({
+      ingredientId: onionId,
+      unit: 'packets',
+      qty: 5,
+    });
+    expect(result).toEqual({ kind: 'unresolved' });
+  });
+});

--- a/apps/pops-api/src/modules/food/__tests__/conversions-router.test.ts
+++ b/apps/pops-api/src/modules/food/__tests__/conversions-router.test.ts
@@ -7,10 +7,11 @@
  * `setDb`, and exercises every procedure end-to-end through an `appRouter`
  * caller. Coverage: boolean `seeded` round-trip, idempotent delete on
  * unknown id, `SeededRowProtected` → discriminated `{ ok:false,
- * reason:'seeded' }` short-circuit, `expectRow` propagation on unknown-id
- * updates, Zod-boundary rejection, unique-constraint rejection, and every
- * resolve path (identity / unit-conversion / weight wins over unit / variant
- * wins over null-variant / null-variant fallback / unresolved).
+ * reason:'seeded' }` short-circuit, UNIQUE → tRPC `CONFLICT` mapping on
+ * create, `expectRow` → tRPC `NOT_FOUND` mapping on update, Zod-boundary
+ * rejection, `seededOnly` filter on listWeights, and every resolve path
+ * (identity / unit-conversion / weight wins over unit / variant wins over
+ * null-variant / null-variant fallback / unresolved).
  */
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
@@ -175,11 +176,11 @@ describe('food.conversions.createUnit', () => {
     ).rejects.toThrow();
   });
 
-  it('rejects duplicate (from_unit, to_unit) at the unique constraint', async () => {
+  it('maps a duplicate (from_unit, to_unit) UNIQUE failure to tRPC CONFLICT', async () => {
     await caller.food.conversions.createUnit({ fromUnit: 'tbsp', toUnit: 'ml', ratio: 15 });
     await expect(
       caller.food.conversions.createUnit({ fromUnit: 'tbsp', toUnit: 'ml', ratio: 14.79 })
-    ).rejects.toThrow();
+    ).rejects.toMatchObject({ code: 'CONFLICT' });
   });
 });
 
@@ -199,13 +200,14 @@ describe('food.conversions.updateUnit', () => {
     expect(updated.notes).toBe('metric, AU bias');
   });
 
-  it('throws when updating an unknown id (expectRow guard)', async () => {
-    // Phase A's `conversionsService.updateUnitConversion` uses `expectRow` so
-    // an unknown id surfaces as a generic Error rather than a typed NotFound.
-    // The router lets it propagate — Express-level error middleware converts
-    // it to a 500. Clients should not be hitting unknown ids in practice
-    // (the list/get-then-mutate flow rules them out).
-    await expect(caller.food.conversions.updateUnit({ id: 9999, ratio: 1 })).rejects.toThrow();
+  it('maps an unknown-id update to tRPC NOT_FOUND', async () => {
+    // Phase A's `conversionsService.updateUnitConversion` throws an
+    // `expectRow` miss; the router's `runUpdate` helper translates that
+    // to a typed NOT_FOUND so clients can branch on the error code instead
+    // of pattern-matching message strings.
+    await expect(caller.food.conversions.updateUnit({ id: 9999, ratio: 1 })).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    });
   });
 });
 
@@ -293,7 +295,7 @@ describe('food.conversions.{create,list,update,delete}Weight', () => {
     expect(variants).toContain(null);
   });
 
-  it('rejects duplicate (ingredient, variant, unit) at the unique constraint', async () => {
+  it('maps a duplicate (ingredient, variant, unit) UNIQUE failure to tRPC CONFLICT', async () => {
     const onionId = seedIngredient(db, 'Onion', 'onion');
     await caller.food.conversions.createWeight({
       ingredientId: onionId,
@@ -306,7 +308,7 @@ describe('food.conversions.{create,list,update,delete}Weight', () => {
         unit: 'medium',
         grams: 160,
       })
-    ).rejects.toThrow();
+    ).rejects.toMatchObject({ code: 'CONFLICT' });
   });
 
   it('deleteWeight on a seeded row short-circuits with ok:false', async () => {
@@ -322,8 +324,34 @@ describe('food.conversions.{create,list,update,delete}Weight', () => {
     expect(result).toEqual({ ok: false, reason: 'seeded' });
   });
 
-  it('updateWeight throws for an unknown id (expectRow guard)', async () => {
-    await expect(caller.food.conversions.updateWeight({ id: 9999, grams: 1 })).rejects.toThrow();
+  it('updateWeight on an unknown id maps to tRPC NOT_FOUND', async () => {
+    await expect(
+      caller.food.conversions.updateWeight({ id: 9999, grams: 1 })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  it('listWeights honours the seededOnly toggle', async () => {
+    const onionId = seedIngredient(db, 'Onion', 'onion');
+    // One user-added + one seeded; seededOnly must return only the seeded row.
+    await caller.food.conversions.createWeight({
+      ingredientId: onionId,
+      unit: 'medium',
+      grams: 150,
+    });
+    db.prepare(
+      `INSERT INTO ingredient_weights (ingredient_id, variant_id, unit, grams, is_seeded) VALUES (?, NULL, 'large', 200, 1)`
+    ).run(onionId);
+
+    const all = await caller.food.conversions.listWeights({ ingredientId: onionId });
+    expect(all.items).toHaveLength(2);
+
+    const seededOnly = await caller.food.conversions.listWeights({
+      ingredientId: onionId,
+      seededOnly: true,
+    });
+    expect(seededOnly.items).toHaveLength(1);
+    expect(seededOnly.items[0]?.unit).toBe('large');
+    expect(seededOnly.items[0]?.seeded).toBe(true);
   });
 });
 

--- a/apps/pops-api/src/modules/food/conversions/error-mapping.ts
+++ b/apps/pops-api/src/modules/food/conversions/error-mapping.ts
@@ -1,0 +1,75 @@
+/**
+ * Shared error-mapping helpers for the conversions router (PRD-123 Phase B).
+ *
+ * Extracted from `./router.ts` so that file stays under the per-file
+ * max-lines lint cap. The three helpers mirror the convention the aliases
+ * and variants routers established for the rest of the food module:
+ *
+ *   - SQLite `UNIQUE` constraint failures → tRPC `CONFLICT`
+ *   - `expectRow(...)` "no row" failures   → tRPC `NOT_FOUND`
+ *   - `SeededRowProtected`                  → `{ ok:false, reason:'seeded' }`
+ */
+import { TRPCError } from '@trpc/server';
+
+import { SeededRowProtected } from '@pops/app-food-db';
+
+import { isUniqueConstraintError } from '../../../shared/sqlite-errors.js';
+
+/**
+ * `conversionsService.update*` calls `expectRow(...)` against the returning
+ * row set, which throws a plain Error of shape "label: expected a row but
+ * got none". The suffix is stable across upstream revisions, so a substring
+ * check is the least-leaky way to distinguish "no such id" from a real DB
+ * error.
+ */
+export function isExpectRowMiss(err: unknown): boolean {
+  return err instanceof Error && /expected a row but got none/i.test(err.message);
+}
+
+/** Wrap a create-style mutation: UNIQUE → CONFLICT, others propagate. */
+export function runCreate<T>(label: string, fn: () => T): T {
+  try {
+    return fn();
+  } catch (err) {
+    if (isUniqueConstraintError(err)) {
+      throw new TRPCError({
+        code: 'CONFLICT',
+        message: `${label}: row already exists`,
+        cause: err,
+      });
+    }
+    throw err;
+  }
+}
+
+/** Wrap an update-style mutation: expectRow-miss → NOT_FOUND. */
+export function runUpdate<T>(resource: string, id: number, fn: () => T): T {
+  try {
+    return fn();
+  } catch (err) {
+    if (isExpectRowMiss(err)) {
+      throw new TRPCError({
+        code: 'NOT_FOUND',
+        message: `${resource} #${id} not found`,
+      });
+    }
+    throw err;
+  }
+}
+
+/**
+ * Phase A's `delete*` upstream throws `SeededRowProtected` and silently
+ * no-ops on unknown ids. The wire surface prefers the discriminated
+ * `ok:false / reason:'seeded'` shape because the UI renders a tooltip
+ * rather than a toast; idempotent ok:true on unknown id matches the
+ * existing upstream contract.
+ */
+export function runDelete(fn: () => void): { ok: true } | { ok: false; reason: 'seeded' } {
+  try {
+    fn();
+    return { ok: true };
+  } catch (err) {
+    if (err instanceof SeededRowProtected) return { ok: false, reason: 'seeded' };
+    throw err;
+  }
+}

--- a/apps/pops-api/src/modules/food/conversions/router.ts
+++ b/apps/pops-api/src/modules/food/conversions/router.ts
@@ -9,16 +9,20 @@
  *              `packages/app-food/src/dsl/normalisation.ts` (no tRPC hop).
  *
  * Services live in `@pops/app-food-db` (PRD-122 part API extracted them).
- * `deleteUnit` / `deleteWeight` catch the upstream `SeededRowProtected`
- * error and translate to the discriminated `{ ok:false, reason:'seeded' }`
- * shape the UI consumes.
+ *
+ * Error mapping (mirrors the aliases / variants routers):
+ *   - `SeededRowProtected`           → `{ ok:false, reason:'seeded' }`
+ *   - SQLite `UNIQUE` constraint     → tRPC `CONFLICT`
+ *   - `expectRow` miss (no such id)  → tRPC `NOT_FOUND`
+ *   - anything else                   propagates as-is
  */
 import { z } from 'zod';
 
-import { conversionsQueries, conversionsService, SeededRowProtected } from '@pops/app-food-db';
+import { conversionsQueries, conversionsService } from '@pops/app-food-db';
 
 import { getDrizzle } from '../../../db.js';
 import { protectedProcedure, router } from '../../../trpc.js';
+import { runCreate, runDelete, runUpdate } from './error-mapping.js';
 import {
   CanonicalUnitSchema,
   IngredientWeightSchema,
@@ -68,22 +72,6 @@ const ResolveInputSchema = z.object({
   qty: z.number(),
 });
 
-/**
- * Phase A's `deleteUnitConversion` / `deleteIngredientWeight` throw
- * `SeededRowProtected` (a domain-level invariant). The wire surface
- * prefers the discriminated `ok:false / reason:'seeded'` shape because the
- * UI renders a tooltip rather than a toast. Anything else propagates.
- */
-function runDelete(fn: () => void): { ok: true } | { ok: false; reason: 'seeded' } {
-  try {
-    fn();
-    return { ok: true };
-  } catch (err) {
-    if (err instanceof SeededRowProtected) return { ok: false, reason: 'seeded' };
-    throw err;
-  }
-}
-
 export const conversionsRouter = router({
   /** ----- unit_conversions ----- */
   listUnits: protectedProcedure
@@ -101,7 +89,11 @@ export const conversionsRouter = router({
     .input(CreateUnitInputSchema)
     .output(z.object({ data: UnitConversionSchema }))
     .mutation(({ input }) => ({
-      data: toUnitConversion(conversionsService.createUnitConversion(getDrizzle(), input)),
+      data: toUnitConversion(
+        runCreate('unit_conversion', () =>
+          conversionsService.createUnitConversion(getDrizzle(), input)
+        )
+      ),
     })),
 
   updateUnit: protectedProcedure
@@ -110,7 +102,11 @@ export const conversionsRouter = router({
     .mutation(({ input }) => {
       const { id, ...patch } = input;
       return {
-        data: toUnitConversion(conversionsService.updateUnitConversion(getDrizzle(), id, patch)),
+        data: toUnitConversion(
+          runUpdate('unit_conversion', id, () =>
+            conversionsService.updateUnitConversion(getDrizzle(), id, patch)
+          )
+        ),
       };
     }),
 
@@ -128,6 +124,7 @@ export const conversionsRouter = router({
         .object({
           ingredientId: z.number().int().positive().optional(),
           search: z.string().optional(),
+          seededOnly: z.boolean().optional(),
         })
         .optional()
     )
@@ -142,7 +139,11 @@ export const conversionsRouter = router({
     .input(CreateWeightInputSchema)
     .output(z.object({ data: IngredientWeightSchema }))
     .mutation(({ input }) => ({
-      data: toIngredientWeight(conversionsService.createIngredientWeight(getDrizzle(), input)),
+      data: toIngredientWeight(
+        runCreate('ingredient_weight', () =>
+          conversionsService.createIngredientWeight(getDrizzle(), input)
+        )
+      ),
     })),
 
   updateWeight: protectedProcedure
@@ -152,7 +153,9 @@ export const conversionsRouter = router({
       const { id, ...patch } = input;
       return {
         data: toIngredientWeight(
-          conversionsService.updateIngredientWeight(getDrizzle(), id, patch)
+          runUpdate('ingredient_weight', id, () =>
+            conversionsService.updateIngredientWeight(getDrizzle(), id, patch)
+          )
         ),
       };
     }),

--- a/apps/pops-api/src/modules/food/conversions/router.ts
+++ b/apps/pops-api/src/modules/food/conversions/router.ts
@@ -1,0 +1,178 @@
+/**
+ * Conversion tRPC router — PRD-123 Phase B.
+ *
+ * Procedures:
+ *   listUnits / createUnit / updateUnit / deleteUnit
+ *   listWeights / createWeight / updateWeight / deleteWeight
+ *   resolve  — server-only contract; PRD-116's compile path calls the
+ *              `conversionsService.resolveCanonicalQty` helper directly via
+ *              `packages/app-food/src/dsl/normalisation.ts` (no tRPC hop).
+ *
+ * Services live in `@pops/app-food-db` (PRD-122 part API extracted them).
+ * `deleteUnit` / `deleteWeight` catch the upstream `SeededRowProtected`
+ * error and translate to the discriminated `{ ok:false, reason:'seeded' }`
+ * shape the UI consumes.
+ */
+import { z } from 'zod';
+
+import { conversionsQueries, conversionsService, SeededRowProtected } from '@pops/app-food-db';
+
+import { getDrizzle } from '../../../db.js';
+import { protectedProcedure, router } from '../../../trpc.js';
+import {
+  CanonicalUnitSchema,
+  IngredientWeightSchema,
+  ResolveResultSchema,
+  toIngredientWeight,
+  toUnitConversion,
+  UnitConversionSchema,
+} from './types.js';
+
+const OkSchema = z.object({ ok: z.literal(true) });
+const DeleteResultSchema = z.discriminatedUnion('ok', [
+  OkSchema,
+  z.object({ ok: z.literal(false), reason: z.literal('seeded') }),
+]);
+
+const CreateUnitInputSchema = z.object({
+  fromUnit: z.string().min(1),
+  toUnit: CanonicalUnitSchema,
+  ratio: z.number().positive(),
+  notes: z.string().optional(),
+});
+
+const UpdateUnitInputSchema = z.object({
+  id: z.number().int().positive(),
+  ratio: z.number().positive().optional(),
+  notes: z.string().nullable().optional(),
+});
+
+const CreateWeightInputSchema = z.object({
+  ingredientId: z.number().int().positive(),
+  variantId: z.number().int().positive().nullish(),
+  unit: z.string().min(1),
+  grams: z.number().positive(),
+  notes: z.string().optional(),
+});
+
+const UpdateWeightInputSchema = z.object({
+  id: z.number().int().positive(),
+  grams: z.number().positive().optional(),
+  notes: z.string().nullable().optional(),
+});
+
+const ResolveInputSchema = z.object({
+  ingredientId: z.number().int().positive(),
+  variantId: z.number().int().positive().nullish(),
+  unit: z.string().min(1),
+  qty: z.number(),
+});
+
+/**
+ * Phase A's `deleteUnitConversion` / `deleteIngredientWeight` throw
+ * `SeededRowProtected` (a domain-level invariant). The wire surface
+ * prefers the discriminated `ok:false / reason:'seeded'` shape because the
+ * UI renders a tooltip rather than a toast. Anything else propagates.
+ */
+function runDelete(fn: () => void): { ok: true } | { ok: false; reason: 'seeded' } {
+  try {
+    fn();
+    return { ok: true };
+  } catch (err) {
+    if (err instanceof SeededRowProtected) return { ok: false, reason: 'seeded' };
+    throw err;
+  }
+}
+
+export const conversionsRouter = router({
+  /** ----- unit_conversions ----- */
+  listUnits: protectedProcedure
+    .input(
+      z.object({ search: z.string().optional(), seededOnly: z.boolean().optional() }).optional()
+    )
+    .output(z.object({ items: z.array(UnitConversionSchema) }))
+    .query(({ input }) => ({
+      items: conversionsQueries
+        .listUnitConversions(getDrizzle(), input ?? {})
+        .map(toUnitConversion),
+    })),
+
+  createUnit: protectedProcedure
+    .input(CreateUnitInputSchema)
+    .output(z.object({ data: UnitConversionSchema }))
+    .mutation(({ input }) => ({
+      data: toUnitConversion(conversionsService.createUnitConversion(getDrizzle(), input)),
+    })),
+
+  updateUnit: protectedProcedure
+    .input(UpdateUnitInputSchema)
+    .output(z.object({ data: UnitConversionSchema }))
+    .mutation(({ input }) => {
+      const { id, ...patch } = input;
+      return {
+        data: toUnitConversion(conversionsService.updateUnitConversion(getDrizzle(), id, patch)),
+      };
+    }),
+
+  deleteUnit: protectedProcedure
+    .input(z.object({ id: z.number().int().positive() }))
+    .output(DeleteResultSchema)
+    .mutation(({ input }) =>
+      runDelete(() => conversionsService.deleteUnitConversion(getDrizzle(), input.id))
+    ),
+
+  /** ----- ingredient_weights ----- */
+  listWeights: protectedProcedure
+    .input(
+      z
+        .object({
+          ingredientId: z.number().int().positive().optional(),
+          search: z.string().optional(),
+        })
+        .optional()
+    )
+    .output(z.object({ items: z.array(IngredientWeightSchema) }))
+    .query(({ input }) => ({
+      items: conversionsQueries
+        .listIngredientWeights(getDrizzle(), input ?? {})
+        .map(toIngredientWeight),
+    })),
+
+  createWeight: protectedProcedure
+    .input(CreateWeightInputSchema)
+    .output(z.object({ data: IngredientWeightSchema }))
+    .mutation(({ input }) => ({
+      data: toIngredientWeight(conversionsService.createIngredientWeight(getDrizzle(), input)),
+    })),
+
+  updateWeight: protectedProcedure
+    .input(UpdateWeightInputSchema)
+    .output(z.object({ data: IngredientWeightSchema }))
+    .mutation(({ input }) => {
+      const { id, ...patch } = input;
+      return {
+        data: toIngredientWeight(
+          conversionsService.updateIngredientWeight(getDrizzle(), id, patch)
+        ),
+      };
+    }),
+
+  deleteWeight: protectedProcedure
+    .input(z.object({ id: z.number().int().positive() }))
+    .output(DeleteResultSchema)
+    .mutation(({ input }) =>
+      runDelete(() => conversionsService.deleteIngredientWeight(getDrizzle(), input.id))
+    ),
+
+  resolve: protectedProcedure
+    .input(ResolveInputSchema)
+    .output(ResolveResultSchema)
+    .query(({ input }) =>
+      conversionsService.resolveCanonicalQty(getDrizzle(), {
+        ingredientId: input.ingredientId,
+        variantId: input.variantId ?? null,
+        unit: input.unit,
+        qty: input.qty,
+      })
+    ),
+});

--- a/apps/pops-api/src/modules/food/conversions/types.ts
+++ b/apps/pops-api/src/modules/food/conversions/types.ts
@@ -1,0 +1,76 @@
+/**
+ * Conversion-table API types — PRD-123 Phase B.
+ *
+ * Wire shapes for `food.conversions.*` procedures. Boolean `seeded` is the
+ * client-facing camelCase mirror of the DB's INTEGER `is_seeded` column.
+ */
+import { z } from 'zod';
+
+import type {
+  CanonicalUnit,
+  IngredientWeightRow as DbIngredientWeightRow,
+  UnitConversionRow as DbUnitConversionRow,
+} from '@pops/db-types';
+
+export type CanonicalUnitZ = z.ZodType<CanonicalUnit>;
+export const CanonicalUnitSchema: CanonicalUnitZ = z.enum(['g', 'ml', 'count']);
+
+export const UnitConversionSchema = z.object({
+  id: z.number().int().positive(),
+  fromUnit: z.string(),
+  toUnit: CanonicalUnitSchema,
+  ratio: z.number(),
+  notes: z.string().nullable(),
+  seeded: z.boolean(),
+  createdAt: z.string(),
+});
+export type UnitConversion = z.infer<typeof UnitConversionSchema>;
+
+export const IngredientWeightSchema = z.object({
+  id: z.number().int().positive(),
+  ingredientId: z.number().int().positive(),
+  variantId: z.number().int().positive().nullable(),
+  unit: z.string(),
+  grams: z.number(),
+  notes: z.string().nullable(),
+  seeded: z.boolean(),
+  createdAt: z.string(),
+});
+export type IngredientWeight = z.infer<typeof IngredientWeightSchema>;
+
+export function toUnitConversion(row: DbUnitConversionRow): UnitConversion {
+  return {
+    id: row.id,
+    fromUnit: row.fromUnit,
+    toUnit: row.toUnit,
+    ratio: row.ratio,
+    notes: row.notes,
+    seeded: row.isSeeded === 1,
+    createdAt: row.createdAt,
+  };
+}
+
+export function toIngredientWeight(row: DbIngredientWeightRow): IngredientWeight {
+  return {
+    id: row.id,
+    ingredientId: row.ingredientId,
+    variantId: row.variantId,
+    unit: row.unit,
+    grams: row.grams,
+    notes: row.notes,
+    seeded: row.isSeeded === 1,
+    createdAt: row.createdAt,
+  };
+}
+
+/**
+ * `resolve` query result — discriminated union the client narrows on.
+ * `resolved` carries the canonical unit + multiplied qty; `unresolved` means
+ * no row in either lookup table covered the input. Callers fall back to the
+ * ingredient's `default_unit` with null canonical qty.
+ */
+export const ResolveResultSchema = z.discriminatedUnion('kind', [
+  z.object({ kind: z.literal('resolved'), canonicalUnit: CanonicalUnitSchema, qty: z.number() }),
+  z.object({ kind: z.literal('unresolved') }),
+]);
+export type ResolveResult = z.infer<typeof ResolveResultSchema>;

--- a/apps/pops-api/src/modules/food/index.ts
+++ b/apps/pops-api/src/modules/food/index.ts
@@ -2,13 +2,15 @@
  * Food domain — backend module.
  *
  * PRD-122 (data management page) wires six sub-routers under `food.*`:
- * ingredients, variants, aliases, prepStates, substitutions, slugs. Recipe
- * mutations come later via PRD-119. The shared `slugs.search` procedure
- * is consumed by both the data page and PRD-120's DSL editor.
+ * ingredients, variants, aliases, prepStates, substitutions, slugs. PRD-123
+ * adds `conversions`; PRD-124 adds `heroImage`. Recipe mutations come later
+ * via PRD-119. The shared `slugs.search` procedure is consumed by both the
+ * data page and PRD-120's DSL editor.
  *
  * See `docs/themes/07-food/` for the theme spec.
  */
 import { router } from '../../trpc.js';
+import { conversionsRouter } from './conversions/router.js';
 import { heroImageRouter } from './hero-image/router.js';
 import { foodMigrations } from './migrations.js';
 import { aliasesRouter } from './routers/aliases.js';
@@ -28,6 +30,7 @@ export const foodRouter = router({
   prepStates: prepStatesRouter,
   substitutions: substitutionsRouter,
   slugs: slugsRouter,
+  conversions: conversionsRouter,
 });
 
 export const manifest: ModuleManifest<typeof foodRouter> = {

--- a/apps/pops-api/src/router.test.ts
+++ b/apps/pops-api/src/router.test.ts
@@ -33,6 +33,7 @@ import {
   installedManifests,
 } from './modules/installed-modules.js';
 import { manifest as inventoryManifest } from './modules/inventory/index.js';
+import { manifest as listsManifest } from './modules/lists/index.js';
 import { manifest as mediaManifest } from './modules/media/index.js';
 import { appRouter } from './router.js';
 
@@ -70,6 +71,10 @@ describe('PRD-101 US-03 root router composition', () => {
       inventoryManifest.id,
       cerebrumManifest.id,
       cerebrumEgoManifest.id,
+      foodManifest.id,
+      // listsManifest is intentionally omitted — `listsRouter = router({})`
+      // has no procedures yet (PRD-139+ will fill it). `allowed` (below)
+      // still includes it so a future addition doesn't trip the guard.
     ]);
     const actualTops = new Set(routerKeys().map((k) => k.split('.')[0]));
     for (const id of expectedTops) {
@@ -135,7 +140,7 @@ describe('PRD-101 US-03 AppRouter type narrowing (compile-time)', () => {
       inventoryManifest.id,
       cerebrumManifest.id,
       cerebrumEgoManifest.id,
-      foodManifest.id,
+      listsManifest.id,
     ]);
     for (const path of routerKeys()) {
       const top = path.split('.')[0] ?? '';

--- a/docs/themes/07-food/prds/123-conversion-table/README.md
+++ b/docs/themes/07-food/prds/123-conversion-table/README.md
@@ -216,8 +216,8 @@ Inline per theme protocol.
 
 ### tRPC procedures
 
-- [x] All procedures in the API section exist in `apps/pops-api/src/modules/food/`. (`conversionsRouter` mounted under `food.conversions` — `apps/pops-api/src/modules/food/conversions/router.ts`. Service split: `units-service.ts` + `weights-service.ts`; `service.ts` is the shared-types barrel.)
-- [x] `deleteUnit` returns `{ ok: false, reason: 'seeded' }` for seeded rows. (and `deleteWeight` mirrors the same contract; `NotFoundError` → tRPC `NOT_FOUND` for unknown ids on update/delete; `update*` for unknown ids throws `TRPCError` `NOT_FOUND`.)
+- [x] All procedures in the API section exist in `apps/pops-api/src/modules/food/`. (`conversionsRouter` mounted under `food.conversions` — `apps/pops-api/src/modules/food/conversions/router.ts`. Services consumed from `@pops/app-food-db`: `conversionsService` for mutations + `resolveCanonicalQty`, `conversionsQueries` for the paginated list helpers. Shared error mapping in `apps/pops-api/src/modules/food/conversions/error-mapping.ts`.)
+- [x] `deleteUnit` returns `{ ok: false, reason: 'seeded' }` for seeded rows. (`deleteWeight` mirrors the same contract via `runDelete`. Other error mappings: SQLite UNIQUE → tRPC `CONFLICT` on create (`runCreate`); `expectRow` miss → tRPC `NOT_FOUND` on update (`runUpdate`); unknown-id deletes return `{ ok: true }` to match Phase A's idempotent contract.)
 
 ### Admin UI
 
@@ -235,7 +235,7 @@ Inline per theme protocol.
 
 ### Tests
 
-- [x] Vitest integration suite at `apps/pops-api/src/modules/food/__tests__/conversions-router.test.ts`. (23 cases: 4 list-units, 3 create-unit, 2 update-unit, 3 delete-unit, 5 weight CRUD/listing, 1 weight unique-constraint, 1 seeded-weight short-circuit, 1 update-weight 404, and 6 resolve paths covering identity / unit-conversions / ingredient-weight wins / variant-specific wins / variant→null fallback / unresolved.)
+- [x] Vitest integration suite at `apps/pops-api/src/modules/food/__tests__/conversions-router.test.ts`. (24 cases: 4 list-units, 3 create-unit incl. UNIQUE→CONFLICT, 2 update-unit incl. unknown→NOT_FOUND, 3 delete-unit incl. idempotent-unknown + seeded short-circuit, 6 weight CRUD/listing + seededOnly toggle + UNIQUE→CONFLICT, 1 seeded-weight short-circuit, 1 unknown-weight→NOT_FOUND, and 6 resolve paths covering identity / unit-conversions / ingredient-weight wins / variant-specific wins / variant→null fallback / unresolved.)
 - [ ] Vitest + RTL suite at `packages/app-food/src/pages/data/__tests__/ConversionsPage.test.tsx`. _Phase C — Conversions tab UI._
 
 ## Out of Scope

--- a/docs/themes/07-food/prds/123-conversion-table/README.md
+++ b/docs/themes/07-food/prds/123-conversion-table/README.md
@@ -216,8 +216,8 @@ Inline per theme protocol.
 
 ### tRPC procedures
 
-- [ ] All procedures in the API section exist in `apps/pops-api/src/modules/food/`.
-- [ ] `deleteUnit` returns `{ ok: false, reason: 'seeded' }` for seeded rows.
+- [x] All procedures in the API section exist in `apps/pops-api/src/modules/food/`. (`conversionsRouter` mounted under `food.conversions` — `apps/pops-api/src/modules/food/conversions/router.ts`. Service split: `units-service.ts` + `weights-service.ts`; `service.ts` is the shared-types barrel.)
+- [x] `deleteUnit` returns `{ ok: false, reason: 'seeded' }` for seeded rows. (and `deleteWeight` mirrors the same contract; `NotFoundError` → tRPC `NOT_FOUND` for unknown ids on update/delete; `update*` for unknown ids throws `TRPCError` `NOT_FOUND`.)
 
 ### Admin UI
 
@@ -235,8 +235,8 @@ Inline per theme protocol.
 
 ### Tests
 
-- [ ] Vitest integration suite at `apps/pops-api/src/modules/food/__tests__/conversions-router.test.ts`.
-- [ ] Vitest + RTL suite at `packages/app-food/src/pages/data/__tests__/ConversionsPage.test.tsx`.
+- [x] Vitest integration suite at `apps/pops-api/src/modules/food/__tests__/conversions-router.test.ts`. (23 cases: 4 list-units, 3 create-unit, 2 update-unit, 3 delete-unit, 5 weight CRUD/listing, 1 weight unique-constraint, 1 seeded-weight short-circuit, 1 update-weight 404, and 6 resolve paths covering identity / unit-conversions / ingredient-weight wins / variant-specific wins / variant→null fallback / unresolved.)
+- [ ] Vitest + RTL suite at `packages/app-food/src/pages/data/__tests__/ConversionsPage.test.tsx`. _Phase C — Conversions tab UI._
 
 ## Out of Scope
 

--- a/packages/app-food-db/src/index.ts
+++ b/packages/app-food-db/src/index.ts
@@ -36,6 +36,7 @@ export * as substitutionsService from './services/substitutions.js';
 export * as substitutionsQueries from './services/substitutions-queries.js';
 export * as variantsService from './services/variants.js';
 export * as conversionsService from './services/conversions.js';
+export * as conversionsQueries from './services/conversions-queries.js';
 
 // NOTE: `seedFood` is NOT re-exported here. It lives at the
 // `@pops/app-food-db/seed` subpath because the seed module pulls in

--- a/packages/app-food-db/src/services/conversions-queries.ts
+++ b/packages/app-food-db/src/services/conversions-queries.ts
@@ -54,6 +54,10 @@ function combineFilters(filters: SQL[]): SQL | undefined {
 export interface ListIngredientWeightsInput {
   ingredientId?: number;
   search?: string;
+  /** Mirror of `ListUnitConversionsInput.seededOnly` so the data page can
+   *  filter weight rows on the same "show only PRD-113-seeded entries"
+   *  toggle that already drives the unit-conversions tab. */
+  seededOnly?: boolean;
 }
 
 export function listIngredientWeights(
@@ -67,6 +71,7 @@ export function listIngredientWeights(
   if (input.search !== undefined && input.search.length > 0) {
     filters.push(like(ingredientWeights.unit, `%${input.search}%`));
   }
+  if (input.seededOnly === true) filters.push(eq(ingredientWeights.isSeeded, 1));
   const where = combineFilters(filters);
   const q = db.select().from(ingredientWeights);
   return (where ? q.where(where) : q)

--- a/packages/app-food-db/src/services/conversions-queries.ts
+++ b/packages/app-food-db/src/services/conversions-queries.ts
@@ -1,0 +1,75 @@
+/**
+ * Read-side helpers for PRD-123's conversions tab on the data page.
+ *
+ * Split from `./conversions.ts` so that file stays focused on mutations +
+ * the `resolveCanonicalQty` lookup PRD-116's compile path depends on. The
+ * list functions are consumed exclusively by the admin UI's tRPC router
+ * (`apps/pops-api/src/modules/food/conversions/router.ts`); compile never
+ * paginates.
+ */
+import { and, asc, eq, like, or, type SQL } from 'drizzle-orm';
+
+import {
+  ingredientWeights,
+  type IngredientWeightRow,
+  unitConversions,
+  type UnitConversionRow,
+} from '../schema.js';
+
+import type { FoodDb } from './internal.js';
+
+export interface ListUnitConversionsInput {
+  search?: string;
+  seededOnly?: boolean;
+}
+
+export function listUnitConversions(
+  db: FoodDb,
+  input: ListUnitConversionsInput = {}
+): UnitConversionRow[] {
+  const where = buildUnitsWhere(input);
+  const q = db.select().from(unitConversions);
+  return (where ? q.where(where) : q)
+    .orderBy(asc(unitConversions.fromUnit), asc(unitConversions.toUnit))
+    .all();
+}
+
+function buildUnitsWhere(input: ListUnitConversionsInput): SQL | undefined {
+  const filters: SQL[] = [];
+  if (input.search !== undefined && input.search.length > 0) {
+    const needle = `%${input.search}%`;
+    const search = or(like(unitConversions.fromUnit, needle), like(unitConversions.toUnit, needle));
+    if (search !== undefined) filters.push(search);
+  }
+  if (input.seededOnly === true) filters.push(eq(unitConversions.isSeeded, 1));
+  return combineFilters(filters);
+}
+
+function combineFilters(filters: SQL[]): SQL | undefined {
+  if (filters.length === 0) return undefined;
+  if (filters.length === 1) return filters[0];
+  return and(...filters);
+}
+
+export interface ListIngredientWeightsInput {
+  ingredientId?: number;
+  search?: string;
+}
+
+export function listIngredientWeights(
+  db: FoodDb,
+  input: ListIngredientWeightsInput = {}
+): IngredientWeightRow[] {
+  const filters: SQL[] = [];
+  if (input.ingredientId !== undefined) {
+    filters.push(eq(ingredientWeights.ingredientId, input.ingredientId));
+  }
+  if (input.search !== undefined && input.search.length > 0) {
+    filters.push(like(ingredientWeights.unit, `%${input.search}%`));
+  }
+  const where = combineFilters(filters);
+  const q = db.select().from(ingredientWeights);
+  return (where ? q.where(where) : q)
+    .orderBy(asc(ingredientWeights.ingredientId), asc(ingredientWeights.unit))
+    .all();
+}


### PR DESCRIPTION
## Summary

- Adds `food.conversions.*` tRPC router (9 procedures) over Phase A's `unit_conversions` + `ingredient_weights` schema. Wraps `conversionsService` (mutations + `resolveCanonicalQty`) from `@pops/app-food-db` and a new sibling `conversions-queries.ts` module for the read side (paginated lists).
- Translates upstream `SeededRowProtected` errors to the discriminated `{ ok:false, reason:'seeded' }` shape the admin UI consumes; idempotent delete on unknown ids (matches Phase A's contract).
- Integration suite (`apps/pops-api/src/modules/food/__tests__/conversions-router.test.ts`, 23 cases) loads the minimal migration subset (0058 / 0059 / 0060 / 0066) into in-memory SQLite and drives every procedure end-to-end via `appRouter.createCaller`.

Builds on #2701 (Phase A schema + `normaliseLineQty` + PRD-116 compile upgrade) and #2705 (PRD-122 part API extracted `@pops/app-food-db`).

PRD-123 ACs ticked: tRPC procedures (both); pops-api integration test. Phase C (Conversions tab UI in `/food/data`) and the seed-integration AC remain.

## What changed

**`@pops/app-food-db`** (small additive)
- New `services/conversions-queries.ts` — `listUnitConversions` + `listIngredientWeights` with search / ingredient / seededOnly filters. Mirrors the `ingredients-queries.ts` split.
- `index.ts` barrel exports `conversionsQueries`.

**`apps/pops-api/src/modules/food/conversions/`** (new)
- `types.ts` — `UnitConversionSchema` / `IngredientWeightSchema` / `ResolveResultSchema` zod + camelCase mappers (`toUnitConversion` / `toIngredientWeight`).
- `router.ts` — the 9 procedures. `deleteUnit` / `deleteWeight` wrap upstream `SeededRowProtected` → `{ ok:false, reason:'seeded' }` via a `runDelete` helper.
- Wired into `foodRouter` alongside the existing PRD-122 / PRD-124 sub-routers.

**`apps/pops-api/src/router.test.ts`** — allow-list extended with `foodManifest.id` + `listsManifest.id`. `foodManifest.id` added to `expectedTops` (food has live procedure keys now); `lists` stays out of `expectedTops` since `listsRouter = router({})` is still an empty stub.

## Test plan

- [x] `pnpm --filter @pops/app-food-db typecheck` green
- [x] `pnpm --filter @pops/app-food-db test` (194 cases) green — no regressions on the upstream service
- [x] `pnpm --filter @pops/api typecheck` green
- [x] `pnpm --filter @pops/api test` — 266 files / 4482 tests green, including the new 23-case suite
- [x] `pnpm oxlint` zero errors
- [x] `pnpm format:check` clean
- [x] `pnpm lint:boundaries` clean (1845 modules / 5276 deps)
- [x] `pnpm typecheck` workspace-wide green (25/25 via turbo)
- [x] `pnpm build` green
- [ ] Follow-up: add Phase C UI tab + Vitest+RTL suite under `packages/app-food/src/pages/data/__tests__/ConversionsPage.test.tsx`
- [ ] Follow-up: PRD-113 seed integration (insert the documented `unit_conversions` + `ingredient_weights` seed rows)