### PR TITLE
feat(infra): pillar container template + per-pillar CI matrix (P4)

### DIFF
--- a/.github/workflows/pillar-images.yml
+++ b/.github/workflows/pillar-images.yml
@@ -1,0 +1,108 @@
+name: Pillar Images
+
+# Validates per-pillar container builds (ADR-026). Discovers pillars by
+# globbing `packages/*-api/package.json` so adding a new pillar requires
+# no workflow edit — drop the package set in place and CI picks it up.
+#
+# On PRs: builds the `builder` stage only (fast feedback, no push).
+# On main: full image build (still no push — publishing is gated on
+# `publish-images.yml` once pillar images need to ship to GHCR).
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+    paths:
+      - 'packages/**'
+      - 'infra/docker/pillar.Dockerfile'
+      - 'infra/docker-compose*.yml'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - 'turbo.json'
+      - 'tsconfig.base.json'
+      - '.github/workflows/pillar-images.yml'
+
+jobs:
+  discover:
+    name: Discover pillars
+    runs-on: ubuntu-latest
+    outputs:
+      pillars: ${{ steps.list.outputs.pillars }}
+      count: ${{ steps.list.outputs.count }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: list
+        name: Enumerate pillar -api packages
+        # A pillar's api package follows the convention
+        # `packages/<domain>-api/package.json` with name `@pops/<domain>-api`.
+        # Anything else is ignored — `app-food-db` etc. is a pre-pillar
+        # extraction and not yet a pillar.
+        run: |
+          set -euo pipefail
+          mapfile -t dirs < <(find packages -maxdepth 2 -type f -name package.json -path 'packages/*-api/package.json' | sort)
+          json='[]'
+          if [ "${#dirs[@]}" -gt 0 ]; then
+            json=$(printf '%s\n' "${dirs[@]}" \
+              | xargs -I{} jq -r '.name' {} \
+              | jq -R -s -c 'split("\n") | map(select(length > 0)) | map({name: ., short: (sub("^@pops/"; "") | sub("-api$"; ""))})')
+          fi
+          count=$(echo "$json" | jq 'length')
+          echo "pillars=$json" >> "$GITHUB_OUTPUT"
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+          echo "Discovered $count pillar(s):"
+          echo "$json" | jq .
+
+  build:
+    name: Build ${{ matrix.pillar.short }}
+    needs: [discover]
+    if: needs.discover.outputs.count != '0'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        pillar: ${{ fromJson(needs.discover.outputs.pillars) }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build ${{ matrix.pillar.name }} (builder stage)
+        if: github.event_name == 'pull_request'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: infra/docker/pillar.Dockerfile
+          target: builder
+          push: false
+          build-args: |
+            PILLAR_PACKAGE=${{ matrix.pillar.name }}
+
+      - name: Build ${{ matrix.pillar.name }} (full image)
+        if: github.event_name == 'push'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: infra/docker/pillar.Dockerfile
+          push: false
+          build-args: |
+            PILLAR_PACKAGE=${{ matrix.pillar.name }}
+            BUILD_VERSION=${{ github.sha }}
+          tags: pops-${{ matrix.pillar.short }}-api:${{ github.sha }}
+
+  # Synthetic green job so branch protection can require this workflow
+  # even when no pillars have been added yet (matrix is empty → build
+  # job is skipped, which would otherwise leave the workflow incomplete).
+  done:
+    name: Pillar images
+    needs: [discover, build]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Summarise
+        run: |
+          set -euo pipefail
+          echo "Discovered ${{ needs.discover.outputs.count }} pillar(s)."
+          if [ "${{ needs.build.result }}" = "failure" ] || [ "${{ needs.build.result }}" = "cancelled" ]; then
+            echo "::error::Pillar build job result: ${{ needs.build.result }}"
+            exit 1
+          fi
+          echo "Pillar build result: ${{ needs.build.result }} (skipped when no pillars exist)."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -458,6 +458,25 @@ See `CONVENTIONS.md` for coding conventions (styling, API patterns, component ru
 - Aim for small, well named and well structured code.
 - REuse reuse reuse. DRY principles!
 
+### Agent automation (overrides default ask-before-commit behavior)
+
+When working in this repository (any `pops*` workspace), agents should:
+
+- **Auto-commit logical chunks as you go.** Don't wait for explicit permission for each commit. A "logical chunk" is one coherent change: a feature increment, a bug fix, a refactor that compiles + passes tests. Don't bundle unrelated changes into one commit.
+- **Auto-open the PR when the work is ready for review.** Push the branch and run `gh pr create` without prompting first. PR title + body must follow the project conventions (see commit messages in git log for tone).
+- **Still ask before any destructive operation.** No force-push, no `git reset --hard` on shared branches, no pushes directly to `main`, no PR closes/merges, no branch deletes — these always require explicit user confirmation regardless of this override.
+- **Still respect signed-off / no-claude-references rules** from the global `~/.claude/CLAUDE.md`: no Claude as co-author, no Claude references in commit messages or PR bodies.
+- **Still verify CI passes locally before pushing** per the "CI should never fail" rule in `~/.claude/CLAUDE.md`.
+
+### PR review cadence
+
+GitHub Copilot's automated PR review is **disabled** on this repo (it was hitting usage limits). The user is **not** reviewing PRs manually either. There is no review safety net — every PR you open ships as-is.
+
+Implication for agents:
+
+- **Get the PR right before pushing.** Run typecheck, tests, lint, and the relevant Docker/compose validations locally. If it fails locally, it ships broken.
+- Do **not** suggest "request a re-review" or "ping a human" — neither will happen.
+
 ### UI Component Rule: Search Before You Build (mandatory, no exceptions)
 
 **Before writing any new UI element, run this search first:**

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -252,6 +252,78 @@ services:
       moltbot-validator:
         condition: service_completed_successfully
 
+  # ── PILLAR TEMPLATE (ADR-026) ─────────────────────────────────────
+  # Copy this block per pillar (food, finance, media, inventory,
+  # cerebrum, core, ai). Each pillar gets its OWN service entry — no
+  # shared image, no shared SQLite. See infra/docker/pillar.Dockerfile
+  # for the generic build, and `.claude/pillar-migration-roadmap.md`
+  # for the rollout DAG. The block below is commented because no
+  # pillar packages exist yet; uncomment + rename once the first
+  # pillar (core) lands.
+  #
+  # <pillar>-api:
+  #   build:
+  #     context: ..
+  #     dockerfile: infra/docker/pillar.Dockerfile
+  #     args:
+  #       PILLAR_PACKAGE: '@pops/<pillar>-api'
+  #       PILLAR_PORT: '30XX'           # pick a unique port per pillar
+  #       BUILD_VERSION: ${BUILD_VERSION:-dev}
+  #   container_name: pops-<pillar>-api
+  #   restart: unless-stopped
+  #   networks:
+  #     - frontend
+  #     - backend
+  #   volumes:
+  #     - <pillar>-sqlite-data:/data/sqlite
+  #   secrets: []                        # add only the secrets this pillar needs
+  #   environment:
+  #     NODE_ENV: production
+  #     PORT: '30XX'
+  #     <PILLAR>_SQLITE_PATH: /data/sqlite/<pillar>.db
+  #     # core-api hosts the pillar registry; every other pillar resolves
+  #     # cross-pillar URIs against POPS_PILLARS or via the registry.
+  #     POPS_PILLARS: ${POPS_PILLARS:-}
+  #   expose:
+  #     - '30XX'
+  #   depends_on:
+  #     core-api:                        # every pillar except core itself
+  #       condition: service_healthy
+  #   healthcheck:
+  #     test:
+  #       [
+  #         'CMD',
+  #         'node',
+  #         '-e',
+  #         "fetch('http://localhost:30XX/health').then(r=>{if(!r.ok)process.exit(1)})",
+  #       ]
+  #     interval: 30s
+  #     timeout: 5s
+  #     retries: 3
+  #
+  # Optional worker variant — same image, different entrypoint:
+  # <pillar>-worker:
+  #   build:
+  #     context: ..
+  #     dockerfile: infra/docker/pillar.Dockerfile
+  #     args:
+  #       PILLAR_PACKAGE: '@pops/<pillar>-api'
+  #       PILLAR_ENTRYPOINT: worker.js
+  #       BUILD_VERSION: ${BUILD_VERSION:-dev}
+  #   container_name: pops-<pillar>-worker
+  #   restart: unless-stopped
+  #   networks: [backend]
+  #   volumes:
+  #     - <pillar>-sqlite-data:/data/sqlite
+  #   environment:
+  #     NODE_ENV: production
+  #     <PILLAR>_SQLITE_PATH: /data/sqlite/<pillar>.db
+  #     REDIS_HOST: pops-redis
+  #     REDIS_PORT: '6379'
+  #   depends_on:
+  #     pops-redis:
+  #       condition: service_healthy
+
 networks:
   frontend:
     name: pops-frontend

--- a/infra/docker/pillar.Dockerfile
+++ b/infra/docker/pillar.Dockerfile
@@ -1,0 +1,106 @@
+# syntax=docker/dockerfile:1.7
+#
+# Generic per-pillar container template.
+#
+# Companion to ADR-026 (pillar architecture). One Dockerfile builds every
+# pillar's api/worker container by parameterising the workspace package
+# name. Pillars are not added to docker-compose individually — each
+# adds a service entry pointing at this Dockerfile + the right build args.
+#
+# Build args (required unless noted):
+#   PILLAR_PACKAGE    Full workspace package name to build, e.g.
+#                     @pops/food-api, @pops/finance-api, @pops/core-api.
+#   PILLAR_PORT       Port the pillar listens on (default 3000). Used only
+#                     for the EXPOSE directive — the process itself reads
+#                     its port from env, set by compose/runtime.
+#   PILLAR_ENTRYPOINT Path inside dist/ to invoke (default index.js).
+#                     Override to worker.js to produce a worker variant
+#                     from the same image.
+#   BUILD_VERSION     Optional version tag baked into the image as
+#                     $BUILD_VERSION (default "dev"). CI sets this to the
+#                     git sha.
+#
+# Usage from monorepo root:
+#   docker build \
+#     -f infra/docker/pillar.Dockerfile \
+#     --build-arg PILLAR_PACKAGE=@pops/food-api \
+#     --build-arg PILLAR_PORT=3010 \
+#     -t ghcr.io/knoxio/pops-food-api:dev .
+#
+# The build uses `turbo prune --docker` to isolate the pillar's dep
+# subgraph, then `pnpm deploy` to flatten it into a standalone runtime.
+# No pillar-specific COPY lines means adding a new pillar is just a new
+# compose service entry, not a Dockerfile edit.
+
+# ─── stage 1 · prune ───────────────────────────────────────────────
+# Walks the workspace dep graph and emits a minimal subtree containing
+# only the pillar's package + transitive workspace deps. `out/json` has
+# the package.jsons (used to cache `pnpm install`), `out/full` has the
+# real sources, and `out/pnpm-lock.yaml` is the pruned lockfile.
+FROM node:22-slim AS pruner
+WORKDIR /app
+RUN corepack enable
+ARG PILLAR_PACKAGE
+RUN test -n "$PILLAR_PACKAGE" \
+  || (echo "ERROR: PILLAR_PACKAGE build arg is required (e.g. @pops/food-api)" >&2 && exit 1)
+COPY . .
+RUN pnpm dlx turbo@2 prune "$PILLAR_PACKAGE" --docker
+
+# ─── stage 2 · install + build ─────────────────────────────────────
+# Two-phase copy so the `pnpm install` layer is cached on lockfile +
+# package.json changes alone. Source edits invalidate only the second
+# copy and the build step.
+FROM node:22-slim AS builder
+WORKDIR /app
+RUN corepack enable
+ARG PILLAR_PACKAGE
+
+COPY --from=pruner /app/out/json/ ./
+COPY --from=pruner /app/out/pnpm-lock.yaml ./pnpm-lock.yaml
+RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
+    pnpm install --frozen-lockfile
+
+COPY --from=pruner /app/out/full/ ./
+# turbo prune doesn't include root-level config files referenced by
+# package tsconfigs via `extends: "../../tsconfig.base.json"`. Without
+# this, every workspace tsc build fails with TS5083 and skipLibCheck
+# stops being applied, masking the real cause behind a wall of
+# lib-type errors.
+COPY --from=pruner /app/tsconfig.base.json ./tsconfig.base.json
+
+# Build the pillar and every workspace dep it imports, in topo order.
+# `<pkg>...` syntax means "the package and its dependencies".
+RUN pnpm --filter "${PILLAR_PACKAGE}..." run build
+
+# `pnpm deploy --prod --legacy` produces a self-contained directory
+# at /app/deploy with all production deps materialised as real files
+# (no workspace symlinks). This is what ships in the runtime stage.
+RUN pnpm --filter "$PILLAR_PACKAGE" deploy --prod --legacy /app/deploy
+
+# ─── stage 3 · runtime ─────────────────────────────────────────────
+# Minimal image: only the deployed package + node + curl (for arbitrary
+# pillar healthchecks that prefer it over node's fetch).
+FROM node:22-slim AS runner
+WORKDIR /app
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends curl ca-certificates \
+ && rm -rf /var/lib/apt/lists/* \
+ && groupadd -r pillar \
+ && useradd -r -g pillar -d /app -s /sbin/nologin pillar
+
+COPY --from=builder --chown=pillar:pillar /app/deploy/ ./
+
+ARG BUILD_VERSION=dev
+ARG PILLAR_PORT=3000
+ARG PILLAR_ENTRYPOINT=index.js
+ENV BUILD_VERSION=$BUILD_VERSION
+ENV PILLAR_ENTRYPOINT=$PILLAR_ENTRYPOINT
+ENV NODE_ENV=production
+
+EXPOSE ${PILLAR_PORT}
+USER pillar
+
+# Shell form so $PILLAR_ENTRYPOINT expands at container start. Compose
+# can override `command:` to point at worker.js without rebuilding.
+CMD ["sh", "-c", "exec node dist/$PILLAR_ENTRYPOINT"]


### PR DESCRIPTION
## Summary

Pre-flight track C for [ADR-026](docs/architecture/adr-026-pillar-architecture.md) — per-pillar container template. One generic `pillar.Dockerfile` builds any `@pops/<pillar>-api` package; new pillars need only a compose service entry, no Dockerfile edit.

- **`infra/docker/pillar.Dockerfile`** — 3-stage build (turbo prune → pnpm install + build → pnpm deploy → minimal runtime). Parameterised via `PILLAR_PACKAGE`, `PILLAR_PORT`, `PILLAR_ENTRYPOINT`. Runs as non-root `pillar` user. Explicit `tsconfig.base.json` copy works around turbo prune omitting root config files.
- **`infra/docker-compose.dev.yml`** — appended commented canonical pillar-api + pillar-worker service blocks. No live pillar services yet (no pillar packages exist).
- **`.github/workflows/pillar-images.yml`** — discovery job globs `packages/*-api/package.json`, emits matrix. Build job is skipped while the matrix is empty; synthetic `done` job keeps branch protection green.
- **`AGENTS.md`** — adds agent-automation + no-PR-review rules so future agent sessions know the cadence.

## Validation

- `docker build` of the full template against `@pops/app-food-db` succeeds locally — 411 MB runtime image, contains `dist/`, runs as uid 999.
- `docker compose -f infra/docker-compose.dev.yml config --quiet` passes.
- Discovery shell script tested in bash with 0 and 2 stub pillars; emits correct JSON.
- `pnpm typecheck` clean (pre-commit hook).

## Test plan

- [ ] CI `Pillar Images / discover` job runs and reports `count=0`.
- [ ] CI `Pillar Images / done` synthetic job goes green.
- [ ] `Docker Build / Validate docker-compose` still passes with the new template block.
- [ ] Existing CI suites (api / fe / quality) remain green.

## Roadmap

Flips P4 row in `.claude/pillar-migration-roadmap.md` to ✅ on merge.