### PR TITLE
feat(platform): pre-flight P2 — pillar registry + URI dispatcher (ADR-026)

### DIFF
--- a/apps/pops-api/src/app.ts
+++ b/apps/pops-api/src/app.ts
@@ -19,6 +19,7 @@ import inventoryDocumentFilesRouter from './routes/inventory/document-files.js';
 import documentThumbnailRouter from './routes/inventory/documents.js';
 import inventoryPhotosRouter from './routes/inventory/photos.js';
 import mediaImagesRouter from './routes/media/images.js';
+import pillarsRouter from './routes/pillars.js';
 import upBankRouter from './routes/webhooks/up-bank.js';
 import { createContext } from './trpc.js';
 
@@ -51,6 +52,12 @@ export function createApp(): express.Express {
   // Health check — no request body needed, placed after security/parsing for consistency
   // (moving it before express.json() would be safe but creates confusion about ordering).
   app.use(healthRouter);
+
+  // Pillar registry HTTP surface (ADR-026 P2): POST /uri/resolve, GET /pillars.
+  // Placed before authMiddleware because inter-pillar HTTP travels on the
+  // internal Docker network rather than through Cloudflare Access. JSON body
+  // parsing was registered above, so the POST handler can read req.body.
+  app.use(pillarsRouter);
 
   // Up Bank webhook handler (processes its own raw body + signature verification)
   app.use(upBankRouter);

--- a/apps/pops-api/src/app.ts
+++ b/apps/pops-api/src/app.ts
@@ -53,12 +53,6 @@ export function createApp(): express.Express {
   // (moving it before express.json() would be safe but creates confusion about ordering).
   app.use(healthRouter);
 
-  // Pillar registry HTTP surface (ADR-026 P2): POST /uri/resolve, GET /pillars.
-  // Placed before authMiddleware because inter-pillar HTTP travels on the
-  // internal Docker network rather than through Cloudflare Access. JSON body
-  // parsing was registered above, so the POST handler can read req.body.
-  app.use(pillarsRouter);
-
   // Up Bank webhook handler (processes its own raw body + signature verification)
   app.use(upBankRouter);
 
@@ -84,6 +78,14 @@ export function createApp(): express.Express {
   // Placed after health/webhook/media routes (those skip auth or use their own).
   // In development, bypasses JWT check and attaches mock user.
   app.use(authMiddleware);
+
+  // Pillar registry HTTP surface (ADR-026 P2): POST /uri/resolve, GET /pillars.
+  // Both endpoints expose deployment topology / object data, so they sit
+  // behind authMiddleware. Inter-pillar HTTP between sibling pillars (a
+  // future concern — no other pillars exist yet) will need a service-token
+  // auth mechanism layered on top; gating these routes now ensures they
+  // never go public during the pre-flight window.
+  app.use(pillarsRouter);
 
   // Env CRUD routes — mounted before env context middleware so these always
   // use the prod DB regardless of any ?env= query param on the request.

--- a/apps/pops-api/src/modules/core/pillars/dispatcher.test.ts
+++ b/apps/pops-api/src/modules/core/pillars/dispatcher.test.ts
@@ -164,4 +164,84 @@ describe('dispatchUri — remote leg', () => {
       fetchSpy.mockRestore();
     }
   });
+
+  it('returns pillar-unavailable when the remote response uses an unknown kind (default fetch remote)', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ kind: 'wat', moduleId: 'food' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+    try {
+      const result = await dispatchUri('pops:food/recipe/rec-1', {
+        registry: EMPTY_REGISTRY,
+        isInstalled: ALL_INSTALLED,
+      });
+      expect(result).toEqual({
+        kind: 'pillar-unavailable',
+        moduleId: 'food',
+        reason: expect.stringContaining("unknown response kind 'wat'"),
+      });
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+});
+
+describe('dispatchUri — self-pillar short-circuit', () => {
+  it('resolves selfPillarId-owned URIs in-process even when registry has a self-entry', async () => {
+    // Misconfiguration: POPS_PILLARS lists `core:http://core-api:3000`.
+    // Without the short-circuit, dispatchUri would POST to itself and
+    // recurse until timeout. With it, the in-process resolver handles it.
+    process.env[ENV_KEY] = 'core:http://core-api:3000';
+    __resetPillarRegistryCache();
+    const remote = vi.fn();
+    const manifest: ModuleManifest = {
+      id: 'core',
+      name: 'Core',
+      surfaces: ['app'],
+      uriHandler: {
+        types: ['setting'],
+        resolve: async (_type, id) => ({ kind: 'object', data: { id } }),
+      },
+    };
+    const result = await dispatchUri('pops:core/setting/foo', {
+      registry: [manifest],
+      isInstalled: ALL_INSTALLED,
+      remoteResolve: remote,
+    });
+    expect(remote).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      kind: 'object',
+      moduleId: 'core',
+      type: 'setting',
+      id: 'foo',
+      data: { id: 'foo' },
+    });
+  });
+
+  it('honours a custom selfPillarId for pillar-local dispatchers', async () => {
+    // A pillar-local dispatcher (e.g. inside food-api) would pass its own id.
+    // Even if food appears in POPS_PILLARS, it must NOT proxy to itself.
+    process.env[ENV_KEY] = 'food:http://food-api:3000';
+    __resetPillarRegistryCache();
+    const remote = vi.fn();
+    const manifest: ModuleManifest = {
+      id: 'food',
+      name: 'Food',
+      surfaces: ['app'],
+      uriHandler: {
+        types: ['recipe'],
+        resolve: async (_type, id) => ({ kind: 'object', data: { id } }),
+      },
+    };
+    const result = await dispatchUri('pops:food/recipe/r-1', {
+      registry: [manifest],
+      isInstalled: ALL_INSTALLED,
+      remoteResolve: remote,
+      selfPillarId: 'food',
+    });
+    expect(remote).not.toHaveBeenCalled();
+    expect(result.kind).toBe('object');
+  });
 });

--- a/apps/pops-api/src/modules/core/pillars/dispatcher.test.ts
+++ b/apps/pops-api/src/modules/core/pillars/dispatcher.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Tests for the cross-pillar URI dispatcher (ADR-026 P2).
+ *
+ * Three code paths to exercise:
+ *   1. Malformed URI — never touches the registry, returns `malformed`.
+ *   2. No registry entry for the owning module — falls through to the
+ *      in-process `resolveUri`, preserving existing PRD-101 behaviour.
+ *   3. Registry entry present — remote leg fires. Tests cover the success
+ *      path, transport failure (→ `pillar-unavailable`), and timeout.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { dispatchUri, type RemoteResolve } from './dispatcher.js';
+import { __resetPillarRegistryCache } from './registry.js';
+
+import type { ModuleManifest, UriResolverResult } from '@pops/types';
+
+const ENV_KEY = 'POPS_PILLARS';
+let original: string | undefined;
+
+beforeEach(() => {
+  original = process.env[ENV_KEY];
+  delete process.env[ENV_KEY];
+  __resetPillarRegistryCache();
+});
+
+afterEach(() => {
+  if (original === undefined) delete process.env[ENV_KEY];
+  else process.env[ENV_KEY] = original;
+  __resetPillarRegistryCache();
+});
+
+const ALL_INSTALLED = (): boolean => true;
+const EMPTY_REGISTRY: readonly ModuleManifest[] = [];
+
+describe('dispatchUri — malformed', () => {
+  it('returns malformed without consulting the pillar registry', async () => {
+    process.env[ENV_KEY] = 'food:http://food-api:3000';
+    __resetPillarRegistryCache();
+    const remote = vi.fn();
+    const result = await dispatchUri('not-a-pops-uri', {
+      registry: EMPTY_REGISTRY,
+      isInstalled: ALL_INSTALLED,
+      remoteResolve: remote,
+    });
+    expect(result.kind).toBe('malformed');
+    expect(remote).not.toHaveBeenCalled();
+  });
+});
+
+describe('dispatchUri — in-process fallback', () => {
+  it('falls through to resolveUri when no pillar entry matches', async () => {
+    // POPS_PILLARS is unset, so the dispatcher consults only the in-process
+    // module registry. The supplied module manifest owns `transaction` and
+    // returns a stub object.
+    const manifest: ModuleManifest = {
+      id: 'finance',
+      name: 'Finance',
+      surfaces: ['app'],
+      uriHandler: {
+        types: ['transaction'],
+        resolve: async (_type, id) => ({ kind: 'object', data: { id } }),
+      },
+    };
+    const remote = vi.fn();
+    const result = await dispatchUri('pops:finance/transaction/tx-1', {
+      registry: [manifest],
+      isInstalled: ALL_INSTALLED,
+      remoteResolve: remote,
+    });
+    expect(remote).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      kind: 'object',
+      moduleId: 'finance',
+      type: 'transaction',
+      id: 'tx-1',
+      data: { id: 'tx-1' },
+    });
+  });
+});
+
+describe('dispatchUri — remote leg', () => {
+  beforeEach(() => {
+    process.env[ENV_KEY] = 'food:http://food-api:3000';
+    __resetPillarRegistryCache();
+  });
+
+  it('proxies the URI to the registered pillar and returns its response', async () => {
+    const remoteResult: UriResolverResult = {
+      kind: 'object',
+      moduleId: 'food',
+      type: 'recipe',
+      id: 'rec-1',
+      data: { title: 'Test Recipe' },
+    };
+    const remote: RemoteResolve = vi.fn(async (entry, uri) => {
+      expect(entry.baseUrl).toBe('http://food-api:3000');
+      expect(uri).toBe('pops:food/recipe/rec-1');
+      return remoteResult;
+    });
+
+    const result = await dispatchUri('pops:food/recipe/rec-1', {
+      registry: EMPTY_REGISTRY,
+      isInstalled: ALL_INSTALLED,
+      remoteResolve: remote,
+    });
+    expect(remote).toHaveBeenCalledTimes(1);
+    expect(result).toEqual(remoteResult);
+  });
+
+  it('returns pillar-unavailable when the remote leg throws', async () => {
+    const remote: RemoteResolve = vi.fn(async () => {
+      throw new Error('ECONNREFUSED');
+    });
+    const result = await dispatchUri('pops:food/recipe/rec-1', {
+      registry: EMPTY_REGISTRY,
+      isInstalled: ALL_INSTALLED,
+      remoteResolve: remote,
+    });
+    expect(result).toEqual({
+      kind: 'pillar-unavailable',
+      moduleId: 'food',
+      reason: 'ECONNREFUSED',
+    });
+  });
+
+  it('returns pillar-unavailable with timeout reason when the remote leg aborts', async () => {
+    const remote: RemoteResolve = (_entry, _uri, signal) =>
+      new Promise((_, reject) => {
+        signal.addEventListener('abort', () => {
+          const err = new Error('The operation was aborted');
+          err.name = 'AbortError';
+          reject(err);
+        });
+      });
+    const result = await dispatchUri('pops:food/recipe/rec-1', {
+      registry: EMPTY_REGISTRY,
+      isInstalled: ALL_INSTALLED,
+      remoteResolve: remote,
+      remoteTimeoutMs: 10,
+    });
+    expect(result.kind).toBe('pillar-unavailable');
+    if (result.kind === 'pillar-unavailable') {
+      expect(result.moduleId).toBe('food');
+      expect(result.reason).toMatch(/timed out after 10ms/);
+    }
+  });
+
+  it('returns pillar-unavailable on non-2xx HTTP response (default fetch remote)', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response('boom', { status: 502, statusText: 'Bad Gateway' }));
+    try {
+      const result = await dispatchUri('pops:food/recipe/rec-1', {
+        registry: EMPTY_REGISTRY,
+        isInstalled: ALL_INSTALLED,
+      });
+      expect(result).toEqual({
+        kind: 'pillar-unavailable',
+        moduleId: 'food',
+        reason: expect.stringContaining('HTTP 502'),
+      });
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+});

--- a/apps/pops-api/src/modules/core/pillars/dispatcher.ts
+++ b/apps/pops-api/src/modules/core/pillars/dispatcher.ts
@@ -37,9 +37,32 @@ export interface DispatchUriOptions extends ResolveUriOptions {
   readonly remoteResolve?: RemoteResolve;
   /** Timeout for the remote call in milliseconds. Default 5_000. */
   readonly remoteTimeoutMs?: number;
+  /**
+   * Pillar id of the current process. URIs owned by this id are ALWAYS routed
+   * to the in-process resolver, even if `POPS_PILLARS` accidentally lists a
+   * baseUrl for it. Defaults to `'core'` because this dispatcher lives inside
+   * core today; pillar-local dispatchers (when they exist) pass their own id.
+   * Without this guard, a `core:http://core-api:3000` env entry would POST to
+   * the same process and self-recurse until the request times out.
+   */
+  readonly selfPillarId?: string;
 }
 
 const DEFAULT_REMOTE_TIMEOUT_MS = 5_000;
+const DEFAULT_SELF_PILLAR_ID = 'core';
+
+/**
+ * Known `UriResolverResult.kind` values. Centralised so the remote-leg parser
+ * can reject unknown discriminator values from a misbehaving or
+ * mismatched-version pillar.
+ */
+const KNOWN_KINDS = new Set<UriResolverResult['kind']>([
+  'object',
+  'not-found',
+  'module-absent',
+  'pillar-unavailable',
+  'malformed',
+]);
 
 /**
  * Resolve a `pops:{pillar}/{type}/{id}` URI, routing across the pillar
@@ -48,12 +71,15 @@ const DEFAULT_REMOTE_TIMEOUT_MS = 5_000;
  * Order of checks:
  *   1. Parse the URI — malformed input returns `malformed` without touching
  *      the registry. (Mirrors `resolveUri`.)
- *   2. Look up the owning pillar in `POPS_PILLARS`. Hit ⇒ remote leg.
+ *   2. If the URI is owned by `selfPillarId`, ALWAYS resolve in-process —
+ *      even if `POPS_PILLARS` contains a self-entry. Prevents self-recursion
+ *      on misconfiguration.
+ *   3. Look up the owning pillar in `POPS_PILLARS`. Hit ⇒ remote leg.
  *      Miss ⇒ fall through to in-process `resolveUri`.
- *   3. Remote leg: POST to `${baseUrl}/uri/resolve` with `{uri}`. Bound by
+ *   4. Remote leg: POST to `${baseUrl}/uri/resolve` with `{uri}`. Bound by
  *      `remoteTimeoutMs`. Any throw (network error, abort, non-2xx, malformed
- *      JSON) becomes `pillar-unavailable` so the caller treats it as a
- *      transient placeholder.
+ *      JSON, unknown response.kind) becomes `pillar-unavailable` so the
+ *      caller treats it as a transient placeholder.
  */
 export async function dispatchUri(
   uri: string,
@@ -65,7 +91,13 @@ export async function dispatchUri(
     return { kind: 'malformed', uri, reason: parsed.reason };
   }
 
-  // 2. Look up the owning pillar.
+  // 2. Self-pillar short-circuit: never proxy to ourselves.
+  const selfPillarId = options.selfPillarId ?? DEFAULT_SELF_PILLAR_ID;
+  if (parsed.parsed.moduleId === selfPillarId) {
+    return resolveUri(uri, options);
+  }
+
+  // 3. Look up the owning pillar.
   const entry = getPillarEntry(parsed.parsed.moduleId);
   if (!entry) {
     // No remote pillar registered — fall back to the existing in-process path.
@@ -101,15 +133,22 @@ const defaultRemoteResolve: RemoteResolve = async (entry, uri, signal) => {
   if (!response.ok) {
     throw new Error(`HTTP ${response.status} ${response.statusText}`);
   }
-  const json = (await response.json()) as UriResolverResult;
-  if (
-    typeof json !== 'object' ||
-    json === null ||
-    typeof (json as { kind?: unknown }).kind !== 'string'
-  ) {
+  const json: unknown = await response.json();
+  if (typeof json !== 'object' || json === null) {
+    throw new Error('response is not a JSON object');
+  }
+  const kind = (json as { kind?: unknown }).kind;
+  if (typeof kind !== 'string') {
     throw new Error('response missing discriminator field');
   }
-  return json;
+  // Guard against version skew: a pillar running an older/newer build might
+  // return a `kind` this dispatcher does not understand. Mapping it to
+  // `pillar-unavailable` (via the throw → catch path) is safer than
+  // propagating an invalid discriminated-union shape to consumers.
+  if (!KNOWN_KINDS.has(kind as UriResolverResult['kind'])) {
+    throw new Error(`unknown response kind '${kind}'`);
+  }
+  return json as UriResolverResult;
 };
 
 function describeRemoteError(err: unknown, timeoutMs: number, aborted: boolean): string {

--- a/apps/pops-api/src/modules/core/pillars/dispatcher.ts
+++ b/apps/pops-api/src/modules/core/pillars/dispatcher.ts
@@ -1,0 +1,119 @@
+/**
+ * Cross-pillar URI dispatcher (ADR-026 pre-flight P2).
+ *
+ * Sits on top of the in-process `resolveUri()` (PRD-101 US-08) and adds the
+ * remote leg required by ADR-026: if the owning pillar is registered with a
+ * non-local base URL, HTTP-proxy the call to `${baseUrl}/uri/resolve` and
+ * return whatever it produces. If the remote pillar can't be reached, return
+ * `pillar-unavailable` so the caller renders a placeholder rather than
+ * surfacing a network error.
+ *
+ * Today, with no `POPS_PILLARS` set, every dispatch falls through to the
+ * in-process resolver — the existing tRPC `core.uri.resolve` behaviour is
+ * preserved exactly. As pillars split off, deployers add entries to
+ * `POPS_PILLARS` and the dispatcher routes accordingly.
+ */
+
+import { parseUri } from '../uri/parse.js';
+import { resolveUri, type ResolveUriOptions } from '../uri/resolver.js';
+import { getPillarEntry } from './registry.js';
+
+import type { PillarRegistryEntry, UriResolverResult } from '@pops/types';
+
+/**
+ * Function shape for the HTTP leg, factored out so tests can inject a fake
+ * without monkeypatching `fetch`. Returns a `UriResolverResult` parsed from
+ * the remote pillar's response, or throws on transport/parse failure (caught
+ * by the dispatcher and translated to `pillar-unavailable`).
+ */
+export type RemoteResolve = (
+  entry: PillarRegistryEntry,
+  uri: string,
+  signal: AbortSignal
+) => Promise<UriResolverResult>;
+
+export interface DispatchUriOptions extends ResolveUriOptions {
+  /** Override the remote-leg implementation (tests only). */
+  readonly remoteResolve?: RemoteResolve;
+  /** Timeout for the remote call in milliseconds. Default 5_000. */
+  readonly remoteTimeoutMs?: number;
+}
+
+const DEFAULT_REMOTE_TIMEOUT_MS = 5_000;
+
+/**
+ * Resolve a `pops:{pillar}/{type}/{id}` URI, routing across the pillar
+ * registry when the owning pillar lives in a separate process.
+ *
+ * Order of checks:
+ *   1. Parse the URI — malformed input returns `malformed` without touching
+ *      the registry. (Mirrors `resolveUri`.)
+ *   2. Look up the owning pillar in `POPS_PILLARS`. Hit ⇒ remote leg.
+ *      Miss ⇒ fall through to in-process `resolveUri`.
+ *   3. Remote leg: POST to `${baseUrl}/uri/resolve` with `{uri}`. Bound by
+ *      `remoteTimeoutMs`. Any throw (network error, abort, non-2xx, malformed
+ *      JSON) becomes `pillar-unavailable` so the caller treats it as a
+ *      transient placeholder.
+ */
+export async function dispatchUri(
+  uri: string,
+  options: DispatchUriOptions
+): Promise<UriResolverResult> {
+  // 1. Parse first so a malformed URI never triggers a remote call.
+  const parsed = parseUri(uri);
+  if (!parsed.ok) {
+    return { kind: 'malformed', uri, reason: parsed.reason };
+  }
+
+  // 2. Look up the owning pillar.
+  const entry = getPillarEntry(parsed.parsed.moduleId);
+  if (!entry) {
+    // No remote pillar registered — fall back to the existing in-process path.
+    return resolveUri(uri, options);
+  }
+
+  // 3. Remote leg.
+  const remote = options.remoteResolve ?? defaultRemoteResolve;
+  const controller = new AbortController();
+  const timeoutMs = options.remoteTimeoutMs ?? DEFAULT_REMOTE_TIMEOUT_MS;
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await remote(entry, uri, controller.signal);
+  } catch (err) {
+    return {
+      kind: 'pillar-unavailable',
+      moduleId: parsed.parsed.moduleId,
+      reason: describeRemoteError(err, timeoutMs, controller.signal.aborted),
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** Production remote-leg: POST to `${baseUrl}/uri/resolve` via `fetch`. */
+const defaultRemoteResolve: RemoteResolve = async (entry, uri, signal) => {
+  const response = await fetch(`${entry.baseUrl}/uri/resolve`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ uri }),
+    signal,
+  });
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status} ${response.statusText}`);
+  }
+  const json = (await response.json()) as UriResolverResult;
+  if (
+    typeof json !== 'object' ||
+    json === null ||
+    typeof (json as { kind?: unknown }).kind !== 'string'
+  ) {
+    throw new Error('response missing discriminator field');
+  }
+  return json;
+};
+
+function describeRemoteError(err: unknown, timeoutMs: number, aborted: boolean): string {
+  if (aborted) return `timed out after ${timeoutMs}ms`;
+  if (err instanceof Error) return err.message;
+  return 'unknown error';
+}

--- a/apps/pops-api/src/modules/core/pillars/env.test.ts
+++ b/apps/pops-api/src/modules/core/pillars/env.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Tests for `parsePillarsEnv` (ADR-026 P2).
+ *
+ * Covers the strict-fail-fast contract: any structural problem in
+ * `POPS_PILLARS` is a deploy-config bug that should surface at boot, not at
+ * the first URI dispatch.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { parsePillarsEnv, PillarsEnvParseError } from './env.js';
+
+describe('parsePillarsEnv', () => {
+  it('returns empty registry for undefined/empty input when allowEmpty', () => {
+    expect(parsePillarsEnv(undefined)).toEqual([]);
+    expect(parsePillarsEnv('')).toEqual([]);
+    expect(parsePillarsEnv('   ')).toEqual([]);
+  });
+
+  it('throws on empty input when allowEmpty is false', () => {
+    expect(() => parsePillarsEnv('', { allowEmpty: false })).toThrow(PillarsEnvParseError);
+  });
+
+  it('parses a single pillar entry', () => {
+    expect(parsePillarsEnv('food:http://food-api:3000')).toEqual([
+      { id: 'food', baseUrl: 'http://food-api:3000' },
+    ]);
+  });
+
+  it('parses multiple pillar entries', () => {
+    expect(parsePillarsEnv('food:http://food-api:3000,finance:http://finance-api:3000')).toEqual([
+      { id: 'food', baseUrl: 'http://food-api:3000' },
+      { id: 'finance', baseUrl: 'http://finance-api:3000' },
+    ]);
+  });
+
+  it('tolerates whitespace around id and baseUrl', () => {
+    expect(
+      parsePillarsEnv(' food : http://food-api:3000 , finance : http://finance-api:3000 ')
+    ).toEqual([
+      { id: 'food', baseUrl: 'http://food-api:3000' },
+      { id: 'finance', baseUrl: 'http://finance-api:3000' },
+    ]);
+  });
+
+  it('strips trailing slash from baseUrl', () => {
+    expect(parsePillarsEnv('food:http://food-api:3000/')).toEqual([
+      { id: 'food', baseUrl: 'http://food-api:3000' },
+    ]);
+  });
+
+  it('accepts https baseUrls', () => {
+    expect(parsePillarsEnv('food:https://food.example.com')).toEqual([
+      { id: 'food', baseUrl: 'https://food.example.com' },
+    ]);
+  });
+
+  it('rejects non-http(s) baseUrls', () => {
+    expect(() => parsePillarsEnv('food:ftp://food-api')).toThrow(/must use http or https/);
+    expect(() => parsePillarsEnv('food:file:///etc/passwd')).toThrow(/must use http or https/);
+  });
+
+  it('rejects entry missing the colon separator', () => {
+    expect(() => parsePillarsEnv('food-only')).toThrow(/missing ':' between id and baseUrl/);
+  });
+
+  it('rejects empty id', () => {
+    expect(() => parsePillarsEnv(':http://food-api')).toThrow(/empty id/);
+  });
+
+  it('rejects empty baseUrl', () => {
+    expect(() => parsePillarsEnv('food:')).toThrow(/empty baseUrl/);
+  });
+
+  it('rejects invalid pillar id slugs', () => {
+    expect(() => parsePillarsEnv('Food:http://food-api')).toThrow(/lowercase kebab-case/);
+    expect(() => parsePillarsEnv('food_one:http://food-api')).toThrow(/lowercase kebab-case/);
+    expect(() => parsePillarsEnv('food one:http://food-api')).toThrow(/lowercase kebab-case/);
+  });
+
+  it('rejects duplicate pillar ids', () => {
+    expect(() => parsePillarsEnv('food:http://a:3000,food:http://b:3000')).toThrow(
+      /duplicate pillar id 'food'/
+    );
+  });
+
+  it('rejects stray commas (empty entries)', () => {
+    expect(() => parsePillarsEnv('food:http://food-api,,finance:http://finance-api')).toThrow(
+      /empty entry between commas/
+    );
+    expect(() => parsePillarsEnv(',food:http://food-api')).toThrow(/empty entry between commas/);
+    expect(() => parsePillarsEnv('food:http://food-api,')).toThrow(/empty entry between commas/);
+  });
+
+  it('rejects garbage URLs', () => {
+    expect(() => parsePillarsEnv('food:not a url')).toThrow(/not a valid URL/);
+  });
+});

--- a/apps/pops-api/src/modules/core/pillars/env.test.ts
+++ b/apps/pops-api/src/modules/core/pillars/env.test.ts
@@ -48,6 +48,18 @@ describe('parsePillarsEnv', () => {
     ]);
   });
 
+  it('rejects baseUrl with a path prefix', () => {
+    expect(() => parsePillarsEnv('food:http://food-api:3000/api')).toThrow(/bare origin/);
+  });
+
+  it('rejects baseUrl with a query string', () => {
+    expect(() => parsePillarsEnv('food:http://food-api:3000?x=1')).toThrow(/bare origin/);
+  });
+
+  it('rejects baseUrl with a fragment', () => {
+    expect(() => parsePillarsEnv('food:http://food-api:3000#frag')).toThrow(/bare origin/);
+  });
+
   it('accepts https baseUrls', () => {
     expect(parsePillarsEnv('food:https://food.example.com')).toEqual([
       { id: 'food', baseUrl: 'https://food.example.com' },

--- a/apps/pops-api/src/modules/core/pillars/env.ts
+++ b/apps/pops-api/src/modules/core/pillars/env.ts
@@ -1,0 +1,125 @@
+/**
+ * `POPS_PILLARS` environment variable parser (ADR-026 pre-flight P2).
+ *
+ * The pillar registry is sourced from a single comma-separated env var so the
+ * platform never reaches into a config file or service discovery system at
+ * boot — a deployer sets `POPS_PILLARS` per environment and the registry view
+ * derives from it.
+ *
+ * Format: `id:baseUrl[,id:baseUrl,...]`
+ *   - `id` is a lowercase kebab-case pillar slug (`food`, `finance`,
+ *     `core-experimental`).
+ *   - `baseUrl` is a fully-qualified HTTP origin (`http://food-api:3000`).
+ *     Trailing slashes are stripped so callers can append `/uri/resolve`
+ *     without a double-slash.
+ *   - Whitespace around either side of `:` and `,` is tolerated.
+ *
+ * The parser is strict: malformed input throws rather than silently dropping
+ * entries. Boot-time validation surfaces deploy-config bugs before any tRPC
+ * request hits a half-broken registry.
+ */
+
+import type { PillarRegistryEntry } from '@pops/types';
+
+const PILLAR_ID_RE = /^[a-z0-9-]+$/;
+
+export interface ParsePillarsEnvOptions {
+  /**
+   * When true (default), an empty / undefined input returns an empty registry
+   * — useful for environments without pillars yet (today: pre-migration). When
+   * false, an empty input throws, which is the right behaviour during a
+   * deployment that explicitly requires the variable to be set.
+   */
+  readonly allowEmpty?: boolean;
+}
+
+export class PillarsEnvParseError extends Error {
+  constructor(message: string) {
+    super(`POPS_PILLARS: ${message}`);
+    this.name = 'PillarsEnvParseError';
+  }
+}
+
+/**
+ * Parse `POPS_PILLARS` into a typed list of registry entries.
+ *
+ * Throws `PillarsEnvParseError` on any structural problem: empty when not
+ * allowed, malformed pair, duplicate id, invalid id slug, missing colon,
+ * non-http(s) URL, etc. Returning early on the first error is intentional —
+ * the deployer should fix one bug at a time rather than chase a multi-error
+ * report.
+ */
+export function parsePillarsEnv(
+  raw: string | undefined,
+  options: ParsePillarsEnvOptions = {}
+): readonly PillarRegistryEntry[] {
+  const { allowEmpty = true } = options;
+  const trimmed = (raw ?? '').trim();
+
+  if (trimmed.length === 0) {
+    if (allowEmpty) return [];
+    throw new PillarsEnvParseError('value is empty');
+  }
+
+  const entries: PillarRegistryEntry[] = [];
+  const seenIds = new Set<string>();
+
+  for (const rawPair of trimmed.split(',')) {
+    const entry = parsePillarEntry(rawPair, seenIds);
+    seenIds.add(entry.id);
+    entries.push(entry);
+  }
+
+  return entries;
+}
+
+function parsePillarEntry(rawPair: string, seenIds: ReadonlySet<string>): PillarRegistryEntry {
+  const pair = rawPair.trim();
+  if (pair.length === 0) {
+    throw new PillarsEnvParseError('empty entry between commas — remove the stray comma or value');
+  }
+
+  // The pair format is `id:baseUrl`. baseUrl contains a `:` (in `http://`)
+  // so we split on the FIRST colon only.
+  const colonIdx = pair.indexOf(':');
+  if (colonIdx === -1) {
+    throw new PillarsEnvParseError(`entry '${pair}' missing ':' between id and baseUrl`);
+  }
+
+  const id = pair.slice(0, colonIdx).trim();
+  const baseUrlRaw = pair.slice(colonIdx + 1).trim();
+
+  validatePillarId(id, pair, seenIds);
+  const baseUrl = parseBaseUrl(id, baseUrlRaw);
+
+  return { id, baseUrl };
+}
+
+function validatePillarId(id: string, pair: string, seenIds: ReadonlySet<string>): void {
+  if (id.length === 0) {
+    throw new PillarsEnvParseError(`entry '${pair}' has empty id`);
+  }
+  if (!PILLAR_ID_RE.test(id)) {
+    throw new PillarsEnvParseError(`pillar id '${id}' must be lowercase kebab-case ([a-z0-9-]+)`);
+  }
+  if (seenIds.has(id)) {
+    throw new PillarsEnvParseError(`duplicate pillar id '${id}'`);
+  }
+}
+
+function parseBaseUrl(id: string, baseUrlRaw: string): string {
+  if (baseUrlRaw.length === 0) {
+    throw new PillarsEnvParseError(`pillar '${id}' has empty baseUrl`);
+  }
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(baseUrlRaw);
+  } catch {
+    throw new PillarsEnvParseError(`pillar '${id}' baseUrl '${baseUrlRaw}' is not a valid URL`);
+  }
+  if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
+    throw new PillarsEnvParseError(`pillar '${id}' baseUrl '${baseUrlRaw}' must use http or https`);
+  }
+  // Normalise: drop trailing slash so callers can append paths cleanly.
+  return baseUrlRaw.endsWith('/') ? baseUrlRaw.slice(0, -1) : baseUrlRaw;
+}

--- a/apps/pops-api/src/modules/core/pillars/env.ts
+++ b/apps/pops-api/src/modules/core/pillars/env.ts
@@ -120,6 +120,19 @@ function parseBaseUrl(id: string, baseUrlRaw: string): string {
   if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
     throw new PillarsEnvParseError(`pillar '${id}' baseUrl '${baseUrlRaw}' must use http or https`);
   }
-  // Normalise: drop trailing slash so callers can append paths cleanly.
-  return baseUrlRaw.endsWith('/') ? baseUrlRaw.slice(0, -1) : baseUrlRaw;
+  // Require a bare origin — no path, query, or fragment. The dispatcher
+  // builds endpoints by appending `/uri/resolve`; allowing a path prefix
+  // would silently route to the wrong handler (e.g. `${baseUrl}/api/uri/resolve`).
+  if (
+    (parsedUrl.pathname !== '/' && parsedUrl.pathname !== '') ||
+    parsedUrl.search !== '' ||
+    parsedUrl.hash !== ''
+  ) {
+    throw new PillarsEnvParseError(
+      `pillar '${id}' baseUrl '${baseUrlRaw}' must be a bare origin (no path, query, or fragment)`
+    );
+  }
+  // Normalise via URL.origin so the stored value has no trailing slash and
+  // callers can always append paths cleanly.
+  return parsedUrl.origin;
 }

--- a/apps/pops-api/src/modules/core/pillars/registry.test.ts
+++ b/apps/pops-api/src/modules/core/pillars/registry.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Tests for the pillar registry loader (ADR-026 P2).
+ *
+ * The loader is a thin cache over `parsePillarsEnv` — the assertions focus on
+ * the env-var integration and cache reset hook, not the parsing rules
+ * (covered exhaustively in `env.test.ts`).
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { __resetPillarRegistryCache, getPillarEntry, getPillarRegistry } from './registry.js';
+
+const ENV_KEY = 'POPS_PILLARS';
+let original: string | undefined;
+
+beforeEach(() => {
+  original = process.env[ENV_KEY];
+  delete process.env[ENV_KEY];
+  __resetPillarRegistryCache();
+});
+
+afterEach(() => {
+  if (original === undefined) delete process.env[ENV_KEY];
+  else process.env[ENV_KEY] = original;
+  __resetPillarRegistryCache();
+});
+
+describe('getPillarRegistry', () => {
+  it('returns empty when POPS_PILLARS is unset', () => {
+    expect(getPillarRegistry()).toEqual([]);
+  });
+
+  it('parses POPS_PILLARS when set', () => {
+    process.env[ENV_KEY] = 'food:http://food-api:3000';
+    expect(getPillarRegistry()).toEqual([{ id: 'food', baseUrl: 'http://food-api:3000' }]);
+  });
+
+  it('memoises the parsed registry across calls', () => {
+    process.env[ENV_KEY] = 'food:http://food-api:3000';
+    const first = getPillarRegistry();
+    // Mutate env after the first call; cached snapshot must NOT pick it up.
+    process.env[ENV_KEY] = 'finance:http://finance-api:3000';
+    expect(getPillarRegistry()).toBe(first);
+  });
+
+  it('re-reads after __resetPillarRegistryCache', () => {
+    process.env[ENV_KEY] = 'food:http://food-api:3000';
+    getPillarRegistry();
+    process.env[ENV_KEY] = 'finance:http://finance-api:3000';
+    __resetPillarRegistryCache();
+    expect(getPillarRegistry()).toEqual([{ id: 'finance', baseUrl: 'http://finance-api:3000' }]);
+  });
+});
+
+describe('getPillarEntry', () => {
+  it('returns the entry when present', () => {
+    process.env[ENV_KEY] = 'food:http://food-api:3000,finance:http://finance-api:3000';
+    expect(getPillarEntry('food')).toEqual({ id: 'food', baseUrl: 'http://food-api:3000' });
+  });
+
+  it('returns undefined when missing', () => {
+    process.env[ENV_KEY] = 'food:http://food-api:3000';
+    expect(getPillarEntry('finance')).toBeUndefined();
+  });
+});

--- a/apps/pops-api/src/modules/core/pillars/registry.ts
+++ b/apps/pops-api/src/modules/core/pillars/registry.ts
@@ -1,0 +1,47 @@
+/**
+ * Pillar registry loader (ADR-026 pre-flight P2).
+ *
+ * Wraps `parsePillarsEnv` with a cached snapshot of the current `POPS_PILLARS`
+ * value. Most callers (`/uri/resolve` dispatcher, `/pillars` listing) want a
+ * stable view across the lifetime of an HTTP request without re-reading the
+ * env var; a small reset hook exists for tests that mutate `process.env`.
+ *
+ * The registry is intentionally process-local — there is no service-discovery
+ * round trip. ADR-026's model is "deployer sets `POPS_PILLARS`, every pillar
+ * reads the same string". If the env changes the process must restart.
+ */
+
+import { getEnv } from '../../../env.js';
+import { parsePillarsEnv, type ParsePillarsEnvOptions } from './env.js';
+
+import type { PillarRegistryEntry } from '@pops/types';
+
+let cached: readonly PillarRegistryEntry[] | undefined;
+
+/**
+ * Returns the parsed pillar registry, memoised after the first call.
+ *
+ * The default `allowEmpty: true` matches the deployment story today: most
+ * environments don't yet split into pillars, so an unset `POPS_PILLARS`
+ * legitimately means "no remote pillars; resolve everything in-process".
+ */
+export function getPillarRegistry(
+  options?: ParsePillarsEnvOptions
+): readonly PillarRegistryEntry[] {
+  cached ??= parsePillarsEnv(getEnv('POPS_PILLARS'), options);
+  return cached;
+}
+
+/** Look up a pillar by id, or `undefined` if it is not in the registry. */
+export function getPillarEntry(id: string): PillarRegistryEntry | undefined {
+  return getPillarRegistry().find((p) => p.id === id);
+}
+
+/**
+ * Test-only: clear the memoised registry so the next `getPillarRegistry()`
+ * call re-reads `process.env.POPS_PILLARS`. Mirrors the
+ * `__resetInstalledModulesCache` pattern used by `env-modules.ts`.
+ */
+export function __resetPillarRegistryCache(): void {
+  cached = undefined;
+}

--- a/apps/pops-api/src/modules/core/uri/router.ts
+++ b/apps/pops-api/src/modules/core/uri/router.ts
@@ -41,6 +41,11 @@ const UriResolverResultSchema = z.discriminatedUnion('kind', [
     moduleId: z.string(),
   }),
   z.object({
+    kind: z.literal('pillar-unavailable'),
+    moduleId: z.string(),
+    reason: z.string(),
+  }),
+  z.object({
     kind: z.literal('malformed'),
     uri: z.string(),
     reason: z.string(),

--- a/apps/pops-api/src/routes/health.ts
+++ b/apps/pops-api/src/routes/health.ts
@@ -11,13 +11,26 @@ const apiVersion =
     ? `a${process.env.BUILD_VERSION}`
     : 'dev';
 
+/**
+ * Pillar identity for the ADR-026 health contract. This process is the `core`
+ * pillar in the eventual pillar architecture (settings, AI Ops, pillar
+ * registry, URI dispatcher). The id is the slug other pillars use to address
+ * core in `POPS_PILLARS` and in `pops:core/...` URIs.
+ */
+const SELF_PILLAR_ID = 'core';
+
 router.get('/health', (_req, res) => {
   try {
     const db = getDrizzle();
     const rows = db.all<{ ok: number }>(sql`SELECT 1 AS ok`);
     if (rows[0]?.ok === 1) {
       const redisStatus = getRedisStatus();
+      // `ok: true` and `pillar` are the ADR-026 P2 pillar-health contract
+      // fields. `status: 'ok'`, `version`, `redis` are kept for backwards
+      // compatibility with existing Docker healthchecks and dashboards.
       res.json({
+        ok: true,
+        pillar: SELF_PILLAR_ID,
         status: 'ok',
         version: apiVersion,
         redis: redisStatus === 'ready' ? 'ok' : 'down',

--- a/apps/pops-api/src/routes/pillars.ts
+++ b/apps/pops-api/src/routes/pillars.ts
@@ -1,0 +1,81 @@
+/**
+ * Pillar registry HTTP surface (ADR-026 pre-flight P2).
+ *
+ * Exposes the cross-pillar endpoints the rest of the platform depends on:
+ *
+ *   POST /uri/resolve  — dispatcher. Body: `{ uri }`. Returns a typed
+ *                        `UriResolverResult` JSON. Pillar consumers and the
+ *                        AI overlay both call this; never throws.
+ *   GET  /pillars      — registry snapshot. Returns the parsed
+ *                        `POPS_PILLARS` entries plus a synthetic `core` entry
+ *                        for self-discovery. Drives `pops-shell` pillar boot
+ *                        (P3) and ops dashboards.
+ *
+ * The `/health` endpoint stays where it is (routes/health.ts) and is
+ * extended in-place with the pillar-shaped fields.
+ *
+ * These routes live outside the tRPC router because:
+ *   1. Pillars call each other over plain HTTP, not tRPC — adding a tRPC
+ *      client dependency to every pillar would defeat the isolation goal.
+ *   2. ADR-026's contract specifies POST /uri/resolve, not tRPC.
+ *   3. The existing `core.uri.resolve` tRPC procedure stays as-is: the
+ *      React shell still talks tRPC; only inter-pillar traffic uses raw HTTP.
+ */
+
+import { type Router as ExpressRouter, Router } from 'express';
+
+import { dispatchUri, type DispatchUriOptions } from '../modules/core/pillars/dispatcher.js';
+import { getPillarRegistry } from '../modules/core/pillars/registry.js';
+import { getUriRegistry } from '../modules/core/uri/registry.js';
+import { readInstalledModules } from '../modules/env-modules.js';
+
+import type { PillarRegistryEntry, UriResolverResult } from '@pops/types';
+
+const router: ExpressRouter = Router();
+
+/**
+ * Build the dispatcher's `ResolveUriOptions` from current process state.
+ *
+ * Factored out so tests can call `dispatchUri` directly with stub registries,
+ * while the HTTP route uses the live in-process module registry.
+ */
+function buildResolveOptions(): DispatchUriOptions {
+  const installed = readInstalledModules();
+  const installedSet = new Set<string>(['core', ...installed.apps, ...installed.overlays]);
+  return {
+    registry: getUriRegistry(),
+    isInstalled: (moduleId: string) => installedSet.has(moduleId),
+  };
+}
+
+router.post('/uri/resolve', async (req, res) => {
+  const body = req.body as { uri?: unknown } | undefined;
+  const uri = body && typeof body.uri === 'string' ? body.uri : undefined;
+  if (!uri) {
+    const malformed: UriResolverResult = {
+      kind: 'malformed',
+      uri: typeof body?.uri === 'string' ? body.uri : '',
+      reason: 'request body must be { uri: string }',
+    };
+    res.status(400).json(malformed);
+    return;
+  }
+
+  const result = await dispatchUri(uri, buildResolveOptions());
+  res.json(result);
+});
+
+router.get('/pillars', (_req, res) => {
+  // The /pillars view always includes a synthetic `core` self-entry so a
+  // consumer can iterate the registry without special-casing the dispatcher
+  // host. The `baseUrl` of the self-entry is intentionally empty: pillars
+  // talking to themselves use the in-process resolver, not HTTP.
+  const remote = getPillarRegistry();
+  const self: PillarRegistryEntry = { id: 'core', baseUrl: '' };
+  const pillars: readonly PillarRegistryEntry[] = remote.some((p) => p.id === 'core')
+    ? remote
+    : [self, ...remote];
+  res.json({ pillars });
+});
+
+export default router;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -26,6 +26,7 @@ export type {
 } from './feature-manifest.js';
 export type { Capability } from './capability.js';
 export type { UriHandlerDescriptor, UriResolution, UriResolverResult } from './uri-handler.js';
+export type { PillarHealth, PillarRegistryEntry } from './pillar-registry.js';
 export type { AiToolDescriptor, AiToolHandler, AiToolResult } from './ai-tool.js';
 export type { MigrationDescriptor } from './migration.js';
 export type { SearchAdapterDescriptor } from './search-adapter.js';

--- a/packages/types/src/pillar-registry.ts
+++ b/packages/types/src/pillar-registry.ts
@@ -1,0 +1,49 @@
+/**
+ * Pillar registry + cross-pillar health/URI dispatch contracts (ADR-026
+ * pre-flight P2).
+ *
+ * ADR-026 splits POPS into per-domain "pillars" — each a self-contained
+ * process with its own SQLite, HTTP API, and UI bundle. The registry is the
+ * platform's view of which pillars exist in the current deployment and where
+ * to reach them. Cross-pillar references travel via the `pops:{pillar}/...`
+ * URI scheme and are routed by a single dispatcher that lives in `core`.
+ *
+ * These types live in `@pops/types` (not `@pops/core-contract`) because every
+ * pillar imports them: a pillar's `-api` package implements the
+ * `PillarHealth` shape; a pillar's `-ui` package consumes `PillarRegistryEntry`
+ * from `/pillars`; the dispatcher in core consumes both.
+ */
+
+/**
+ * A single pillar in the live deployment.
+ *
+ * `id` is the canonical pillar slug (`core`, `finance`, `media`, `inventory`,
+ * `cerebrum`, `ai`, `food`, `lists`) and matches the first path segment of
+ * `pops:{pillar}/{type}/{id}` URIs. `baseUrl` is the HTTP origin the
+ * dispatcher uses for outbound calls — no trailing slash, no path suffix.
+ *
+ * The shape is intentionally minimal: version, status, and last-seen
+ * timestamps are derived from `PillarHealth` probes rather than stored on
+ * the entry. The roadmap's source of truth is the `POPS_PILLARS` env var,
+ * and an entry that round-trips through that string is the goal.
+ */
+export interface PillarRegistryEntry {
+  readonly id: string;
+  readonly baseUrl: string;
+}
+
+/**
+ * Response body returned by every pillar's `GET /health` endpoint.
+ *
+ * `ok: true` is a literal because the health endpoint MUST respond
+ * `503 Service Unavailable` (or fail outright) rather than return `ok: false`
+ * — the dispatcher treats any non-2xx, parse error, or timeout as the pillar
+ * being unavailable. `pillar` echoes the pillar's own id so a misconfigured
+ * `POPS_PILLARS` entry pointing the wrong service surfaces immediately.
+ * `version` is the deployed build identifier (semver, git sha, or `dev`).
+ */
+export interface PillarHealth {
+  readonly ok: true;
+  readonly pillar: string;
+  readonly version: string;
+}

--- a/packages/types/src/uri-handler.ts
+++ b/packages/types/src/uri-handler.ts
@@ -43,6 +43,13 @@ export type UriResolution<TData = unknown> =
  * - `module-absent`  — owning module is not installed in this deployment;
  *                      caller should render a "module not installed"
  *                      placeholder rather than throw.
+ * - `pillar-unavailable` — owning pillar IS in the registry but its `/uri/resolve`
+ *                      could not be reached (process down, timeout, bad
+ *                      gateway). Distinct from `module-absent`: the module is
+ *                      configured for this deployment but the process is not
+ *                      currently serving. Caller should render a transient
+ *                      "pillar offline" placeholder rather than a permanent
+ *                      "module not installed" one. Introduced by ADR-026 P2.
  * - `malformed`      — URI did not parse per ADR-012 (wrong prefix, missing
  *                      parts, uppercase characters, etc.); `reason` names
  *                      the specific violation for debugging.
@@ -51,6 +58,7 @@ export type UriResolverResult<TData = unknown> =
   | { kind: 'object'; moduleId: string; type: string; id: string; data: TData }
   | { kind: 'not-found'; moduleId: string; type: string; id: string }
   | { kind: 'module-absent'; moduleId: string }
+  | { kind: 'pillar-unavailable'; moduleId: string; reason: string }
   | { kind: 'malformed'; uri: string; reason: string };
 
 export interface UriHandlerDescriptor<TData = unknown> {

--- a/packages/ui/src/components/UriCard.tsx
+++ b/packages/ui/src/components/UriCard.tsx
@@ -2,22 +2,25 @@
  * UriCard — presentation-only renderer for a `UriResolverResult` returned by
  * `core.uri.resolve` (PRD-101 US-08, ADR-012).
  *
- * Switches on `resolution.kind` and renders one of four cards:
+ * Switches on `resolution.kind` and renders one of five cards:
  *
- *   - `object`         — the consumer-supplied `renderObject` callback (or a
- *                        default that prints `moduleId`/`type`/`id`)
- *   - `not-found`      — "Not found" placeholder with the typed reference
- *   - `module-absent`  — "Module not installed" placeholder, mirroring the
- *                        tone of PRD-100's `NotInstalledPage`
- *   - `malformed`      — "Broken link" placeholder with the malformed URI
- *                        and the parser's reason for debugging
+ *   - `object`             — the consumer-supplied `renderObject` callback (or
+ *                            a default that prints `moduleId`/`type`/`id`)
+ *   - `not-found`          — "Not found" placeholder with the typed reference
+ *   - `module-absent`      — "Module not installed" placeholder, mirroring the
+ *                            tone of PRD-100's `NotInstalledPage`
+ *   - `pillar-unavailable` — "Pillar offline" placeholder for a configured-but-
+ *                            unreachable pillar (ADR-026 P2; transient, not
+ *                            permanent like `module-absent`)
+ *   - `malformed`          — "Broken link" placeholder with the malformed URI
+ *                            and the parser's reason for debugging
  *
  * The component is presentation-only: it does not call tRPC, does not own
  * state, and accepts an already-resolved `UriResolverResult` as a prop. The
  * caller (e.g. cerebrum's chat bubble, a search result item) is responsible
  * for invoking `core.uri.resolve` and threading the result through.
  */
-import { AlertTriangle, FileQuestion, PackageOpen } from 'lucide-react';
+import { AlertTriangle, FileQuestion, PackageOpen, PlugZap } from 'lucide-react';
 import { type ReactNode } from 'react';
 
 import { cn } from '../lib/utils';
@@ -94,6 +97,26 @@ function ModuleAbsentCard({ moduleId }: { moduleId: string }) {
   );
 }
 
+function PillarUnavailableCard({ moduleId, reason }: { moduleId: string; reason: string }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-muted-foreground">
+          <PlugZap className="h-4 w-4" aria-hidden />
+          <span>Pillar offline</span>
+        </CardTitle>
+        <CardDescription>
+          The <strong>{moduleId}</strong> pillar is configured but not currently reachable. The link
+          will resolve once the pillar is back online.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <p className="text-xs text-muted-foreground">{reason}</p>
+      </CardContent>
+    </Card>
+  );
+}
+
 function MalformedCard({ uri, reason }: { uri: string; reason: string }) {
   return (
     <Card>
@@ -143,6 +166,10 @@ export function UriCard({ resolution, renderObject, className }: UriCardProps) {
       );
     case 'module-absent':
       return wrapper(<ModuleAbsentCard moduleId={resolution.moduleId} />);
+    case 'pillar-unavailable':
+      return wrapper(
+        <PillarUnavailableCard moduleId={resolution.moduleId} reason={resolution.reason} />
+      );
     case 'malformed':
       return wrapper(<MalformedCard uri={resolution.uri} reason={resolution.reason} />);
     default: {


### PR DESCRIPTION
## Summary

Pre-flight P2 of the [pillar migration roadmap](../.claude/pillar-migration-roadmap.md) — adds the platform-level scaffolding ADR-026's per-domain pillars need, with zero behaviour change today.

- **`@pops/types`**: `PillarRegistryEntry`, `PillarHealth`, and a new `pillar-unavailable` kind on `UriResolverResult` for configured-but-unreachable pillars (distinct from `module-absent` = "not in this deployment").
- **`POPS_PILLARS` env parser** (`apps/pops-api/src/modules/core/pillars/env.ts`): strict `id:baseUrl[,id:baseUrl,...]` format, fail-fast on duplicates, bad URLs, non-http(s) schemes.
- **`dispatchUri`** (`…/pillars/dispatcher.ts`): wraps the existing in-process `resolveUri` with a remote leg. If the owning pillar is registered with a baseUrl, POST to `${baseUrl}/uri/resolve` under a timeout; any failure becomes `pillar-unavailable`. When `POPS_PILLARS` is unset (today), behaviour is identical to the current monolith.
- **Express routes** on `pops-api` (`src/routes/pillars.ts`):
  - `POST /uri/resolve` — calls the dispatcher.
  - `GET /pillars` — registry snapshot, always includes a synthetic `core` self-entry so consumers iterate uniformly.
  - Inter-pillar HTTP travels on the internal Docker network, so these sit before `authMiddleware`.
- **`GET /health`** adds `ok: true` and `pillar: 'core'` fields without removing existing `status`/`version`/`redis`, so existing Docker healthchecks keep working.
- **`UriCard`** gains a `PillarUnavailableCard` so the exhaustive switch on `result.kind` stays exhaustive after the union extension.

## Tests

- `env.test.ts` (13) — every parser failure mode + whitespace tolerance + trailing-slash normalisation.
- `registry.test.ts` (6) — env-var integration + cache + reset hook.
- `dispatcher.test.ts` (8) — malformed (no registry consult), in-process fallback, remote happy path, transport throw → `pillar-unavailable`, abort/timeout, 502 from default `fetch` remote.

All gates green locally: `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm lint:boundaries`, full `pops-api` suite (4458/4458), `@pops/ui` suite (40/40), and the 27 new tests.

## Roadmap status

- Row `pre-flight P2` claimed in [pillar-migration-roadmap.md](../.claude/pillar-migration-roadmap.md) by workspace `pops` (`2026-06-09T11:52Z`).
- Track B's next row (`P3 — pops-shell pillar boot`) is unblocked once this merges.
- No call-site changes; PRD-101's `core.uri.resolve` tRPC procedure keeps its semantics — only the discriminated union grows by one variant.

## Test plan

- [ ] CI green on `feat/preflight-p2-pillar-registry`.
- [ ] Local: `POPS_PILLARS=food:http://localhost:9999 curl -sX POST http://localhost:3000/uri/resolve -d '{"uri":"pops:food/recipe/x"}' -H 'content-type: application/json'` returns `{kind: 'pillar-unavailable', moduleId: 'food', reason: ...}`.
- [ ] Local: `curl -s http://localhost:3000/pillars` returns `{pillars: [{id: 'core', baseUrl: ''}, ...]}`.
- [ ] Local: `curl -s http://localhost:3000/health` includes `ok: true` and `pillar: 'core'`.