### PR TITLE
feat(food): PRD-120 part C — DSL editor error squiggles + issues prop

### DIFF
--- a/docs/themes/07-food/prds/120-dsl-editor/README.md
+++ b/docs/themes/07-food/prds/120-dsl-editor/README.md
@@ -209,7 +209,7 @@ Inline per theme protocol.
 ### Tests
 
 - [ ] Vitest + React Testing Library suite at `packages/app-food/src/components/__tests__/DslEditor.test.tsx` covers each acceptance criterion above with a deterministic mock for `food.slugs.search`.
-- [ ] Storybook stories at `apps/pops-storybook/src/stories/food/DslEditor.stories.tsx` cover: empty document, sample recipe, document with errors, document with proposed slugs, read-only.
+- [ ] Storybook stories at `packages/app-food/src/components/DslEditor.stories.tsx` cover: empty document, sample recipe, document with errors, document with proposed slugs, read-only. (Discovery glob lives in `apps/pops-storybook/.storybook/main.ts` and picks up `packages/*\/src/**\/*.stories.@(ts|tsx)`, matching the pattern used by every other shared-package story file in this repo.)
 
 ## Out of Scope
 

--- a/packages/app-food/src/components/DslEditor.stories.tsx
+++ b/packages/app-food/src/components/DslEditor.stories.tsx
@@ -1,19 +1,22 @@
 /**
- * DslEditor stories — covers the chip-widget surface added in PRD-120 part D.
+ * DslEditor stories — covers the 120-A scaffold, the 120-C `issues`
+ * surface (squiggles + tooltip + gutter), the 120-D chip widgets, and
+ * the read-only mode.
  *
  * `apps/pops-storybook/.storybook/main.ts` discovers stories from
- * `packages/*\/src/**\/*.stories.@(...)`, so this file lives next to the
- * component (same convention RecipeRenderer.stories.tsx adopted).
+ * `packages/*\/src/**\/*.stories.@(ts|tsx)`, so this file lives next to
+ * the component (same convention `RecipeRenderer.stories.tsx` adopted).
  *
- * Stories intentionally render the editor in a controlled wrapper that
- * doesn't pump value changes back into the editor on each keystroke —
- * the editor is the source of truth for its own document while the
- * story is on screen. 120-F will broaden this with the empty / with-errors
- * / with-proposed-slugs / read-only variants the PRD enumerates.
+ * Stories use a `StoryHost` wrapper that owns the document via
+ * `useState` — editing in the rendered Storybook canvas updates the
+ * editor's text in place (the host does NOT pump value back into
+ * `initialValue`, only stores it; the editor is the source of truth
+ * for its own document while the story is on screen).
  */
 import { useState } from 'react';
 
 import { DslEditor } from './DslEditor';
+import type { CompileEditorIssue } from './dsl-editor/issues-types';
 
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
@@ -27,18 +30,54 @@ const SAMPLE = [
   '@step("Melt @3 over each patty, then sandwich in @brioche-bun")',
 ].join('\n');
 
+// `chuck:ground` has an unknown prep state (`ground` isn't in the
+// curated catalogue) and the brioche-bun line refers to a slug that
+// the resolver would auto-propose. The fixtures below mirror that.
+const ERROR_ISSUES: CompileEditorIssue[] = [
+  {
+    severity: 'error',
+    code: 'UnresolvedPrepStateSlug',
+    message: 'Unknown prep state "ground"',
+    // `ground` on line 3 spans cols 22..28 (endCol exclusive).
+    loc: { startLine: 3, startCol: 22, endLine: 3, endCol: 28 },
+    slug: 'ground',
+  },
+];
+
+const INFO_ISSUES: CompileEditorIssue[] = [
+  {
+    severity: 'info',
+    code: 'ProposedSlug',
+    message: 'Will create new ingredient: brioche-bun',
+    // `brioche-bun` on line 4 spans cols 16..27 (endCol exclusive).
+    loc: { startLine: 4, startCol: 16, endLine: 4, endCol: 27 },
+    slug: 'brioche-bun',
+  },
+  {
+    severity: 'info',
+    code: 'ProposedSlug',
+    message: 'Will create new ingredient: american-cheese',
+    // `american-cheese` on line 5 spans cols 16..31 (endCol exclusive).
+    loc: { startLine: 5, startCol: 16, endLine: 5, endCol: 31 },
+    slug: 'american-cheese',
+  },
+];
+
 function StoryHost({
   initialValue,
   readOnly,
+  issues,
 }: {
   initialValue: string;
   readOnly?: boolean;
+  issues?: readonly CompileEditorIssue[];
 }): JSX.Element {
   const [value, setValue] = useState(initialValue);
   return (
     <DslEditor
       initialValue={value}
       readOnly={readOnly}
+      issues={issues}
       onChange={(next) => {
         setValue(next);
       }}
@@ -68,10 +107,22 @@ export const SampleRecipe: Story = {
   args: { initialValue: SAMPLE },
 };
 
-export const ReadOnly: Story = {
-  args: { initialValue: SAMPLE, readOnly: true },
-};
-
 export const Empty: Story = {
   args: { initialValue: '' },
+};
+
+export const WithErrors: Story = {
+  args: { initialValue: SAMPLE, issues: ERROR_ISSUES },
+};
+
+export const WithProposedSlugs: Story = {
+  args: { initialValue: SAMPLE, issues: INFO_ISSUES },
+};
+
+export const Mixed: Story = {
+  args: { initialValue: SAMPLE, issues: [...ERROR_ISSUES, ...INFO_ISSUES] },
+};
+
+export const ReadOnly: Story = {
+  args: { initialValue: SAMPLE, readOnly: true, issues: ERROR_ISSUES },
 };

--- a/packages/app-food/src/components/DslEditor.stories.tsx
+++ b/packages/app-food/src/components/DslEditor.stories.tsx
@@ -16,9 +16,10 @@
 import { useState } from 'react';
 
 import { DslEditor } from './DslEditor';
-import type { CompileEditorIssue } from './dsl-editor/issues-types';
 
 import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import type { CompileEditorIssue } from './dsl-editor/issues-types';
 
 const SAMPLE = [
   '@recipe(slug="smash-burger", title="Smash Burger", servings=2)',

--- a/packages/app-food/src/components/DslEditor.tsx
+++ b/packages/app-food/src/components/DslEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * DslEditor — recipe-DSL CodeMirror 6 editor (PRD-120 part A).
+ * DslEditor — recipe-DSL CodeMirror 6 editor (PRD-120 parts A + C).
  *
  * Pure presentation component. The editor:
  *   - Renders the recipe-DSL source with Lezer-driven syntax highlighting
@@ -9,13 +9,16 @@
  *   - Switches into read-only mode (no keystrokes, banner at the top) when
  *     `readOnly` is true — the parent is expected to pass this for any
  *     `recipe_versions.status ∈ {current, archived}` per PRD-107.
+ *   - Surfaces compile diagnostics passed via `issues` as inline
+ *     squiggles, a gutter marker, and a hover tooltip (120-C).
  *
- * Out-of-scope for this PR (handled by 120-B through 120-F):
+ * Still out of scope for this PR (deferred to 120-B / 120-D / 120-E /
+ * 120-F):
  *   - Autocomplete (consumes `food.slugs.search` from PRD-122-API).
- *   - Error squiggles + tooltips driven by an `issues` prop.
  *   - Chip widgets for inline `@N` / `@slug` / `@time` / `@temperature`.
  *   - Reorder + renumber affordance.
- *   - Mobile-specific autocomplete drawer + a11y polish + Storybook.
+ *   - Mobile-specific autocomplete drawer + axe-core a11y pass.
+ *   - The "Recompile" button — parent-driven, lands with PRD-119.
  *
  * The component is deliberately framework-thin: it owns a single
  * `EditorView` instance and rebuilds the document only when `initialValue`

--- a/packages/app-food/src/components/DslEditor.tsx
+++ b/packages/app-food/src/components/DslEditor.tsx
@@ -24,10 +24,12 @@
  * supposed to treat `onChange` as the source of truth and not re-pump the
  * same value back as a new `initialValue`.
  */
-import { useRef } from 'react';
+import { useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useDslEditorView } from './useDslEditorView';
+
+import type { CompileEditorIssue } from './dsl-editor/issues-types';
 
 /** Public props — kept narrow so 120-B/C can extend without breaking
  * earlier callers. */
@@ -36,19 +38,35 @@ export interface DslEditorProps {
   initialValue: string;
   /** Fires with the latest editor value, debounced 250 ms. */
   onChange: (value: string) => void;
+  /**
+   * Diagnostics rendered as inline decorations + a gutter marker + a
+   * hover tooltip. The parent (PRD-119, downstream) assembles this list
+   * from `food.recipes.saveDraft`'s `CompileResult` plus any
+   * `recipe_version_proposed_slugs` rows fetched via
+   * `food.recipes.listProposedSlugs(versionId)`. Defaults to an empty
+   * array.
+   */
+  issues?: readonly CompileEditorIssue[];
   /** True for `current`/`archived` versions per PRD-107. */
   readOnly?: boolean;
   /** Extra class on the wrapping div for layout integration. */
   className?: string;
 }
 
+const EMPTY_ISSUES: readonly CompileEditorIssue[] = Object.freeze([]);
+
 export function DslEditor(props: DslEditorProps) {
   const { t } = useTranslation('food');
   const hostRef = useRef<HTMLDivElement | null>(null);
+  // Memoise the resolved issues reference so the hook's `useEffect` only
+  // re-dispatches when the caller passes a genuinely new array (a fresh
+  // empty literal each render would otherwise thrash the editor).
+  const issues = useMemo(() => props.issues ?? EMPTY_ISSUES, [props.issues]);
   useDslEditorView(hostRef, {
     initialValue: props.initialValue,
     onChange: props.onChange,
     readOnly: props.readOnly === true,
+    issues,
   });
 
   const wrapperClass = ['dsl-editor', props.className].filter(Boolean).join(' ');

--- a/packages/app-food/src/components/__tests__/DslEditor.test.tsx
+++ b/packages/app-food/src/components/__tests__/DslEditor.test.tsx
@@ -16,7 +16,11 @@ import { EditorView } from '@codemirror/view';
 import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { issuesField } from '../dsl-editor/issues-state';
+import { renderTooltipDom } from '../dsl-editor/issues-tooltip';
 import { DslEditor } from '../DslEditor';
+
+import type { CompileEditorIssue } from '../dsl-editor/issues-types';
 
 /** CodeMirror exposes `EditorView.findFromDOM(node)` which walks up from
  *  any descendant until it locates the live view. We use it to drive the
@@ -282,5 +286,124 @@ describe('DslEditor — PRD-120 part D (chip widgets)', () => {
     expect(rendered).toContain('@cilantro');
     expect(rendered).toContain('@time(20:min)');
     expect(rendered).toContain('@temperature(180:c)');
+  });
+});
+
+describe('DslEditor — PRD-120 part C (issues prop)', () => {
+  const SAMPLE = '@ingredient(1, banana:raw:foo, 1:cup)';
+  const ERROR_ISSUE: CompileEditorIssue = {
+    severity: 'error',
+    code: 'UnresolvedPrepStateSlug',
+    message: 'Unknown prep state',
+    // `foo` at columns 27..30 — see dsl-editor-issues-span.test.ts.
+    loc: { startLine: 1, startCol: 27, endLine: 1, endCol: 30 },
+    slug: 'foo',
+  };
+  const INFO_ISSUE: CompileEditorIssue = {
+    severity: 'info',
+    code: 'ProposedSlug',
+    message: 'Proposed: foo-prep',
+    loc: { startLine: 1, startCol: 27, endLine: 1, endCol: 30 },
+    slug: 'foo-prep',
+  };
+
+  function decorationData(view: EditorView): Array<Record<string, string>> {
+    const out: Array<Record<string, string>> = [];
+    const iter = view.state.field(issuesField).decorations.iter();
+    while (iter.value !== null) {
+      const spec = iter.value.spec as {
+        class?: string;
+        attributes?: Record<string, string>;
+      };
+      out.push({
+        ...spec.attributes,
+        class: spec.class ?? '',
+        from: String(iter.from),
+        to: String(iter.to),
+      });
+      iter.next();
+    }
+    return out;
+  }
+
+  it('renders no decorations when issues is omitted', () => {
+    render(<DslEditor initialValue={SAMPLE} onChange={() => {}} />);
+    expect(decorationData(getEditorView())).toHaveLength(0);
+  });
+
+  it('renders an error decoration at the exact span the parser emitted', () => {
+    render(<DslEditor initialValue={SAMPLE} onChange={() => {}} issues={[ERROR_ISSUE]} />);
+    const marks = decorationData(getEditorView());
+    expect(marks).toEqual([
+      {
+        class: 'cm-dsl-issue cm-dsl-issue--error',
+        'data-dsl-issue-severity': 'error',
+        'data-dsl-issue-code': 'UnresolvedPrepStateSlug',
+        from: '26',
+        to: '29',
+      },
+    ]);
+  });
+
+  it('renders an info decoration with a distinct class from errors', () => {
+    render(<DslEditor initialValue={SAMPLE} onChange={() => {}} issues={[INFO_ISSUE]} />);
+    const marks = decorationData(getEditorView());
+    expect(marks).toHaveLength(1);
+    expect(marks[0]['data-dsl-issue-severity']).toBe('info');
+    expect(marks[0].class).toBe('cm-dsl-issue cm-dsl-issue--info');
+  });
+
+  it('replaces the decoration set when issues change', () => {
+    const { rerender } = render(
+      <DslEditor initialValue={SAMPLE} onChange={() => {}} issues={[ERROR_ISSUE]} />
+    );
+    expect(decorationData(getEditorView())[0]['data-dsl-issue-severity']).toBe('error');
+
+    rerender(<DslEditor initialValue={SAMPLE} onChange={() => {}} issues={[INFO_ISSUE]} />);
+    expect(decorationData(getEditorView())[0]['data-dsl-issue-severity']).toBe('info');
+  });
+
+  it('clears all decorations when issues is emptied', () => {
+    const { rerender } = render(
+      <DslEditor initialValue={SAMPLE} onChange={() => {}} issues={[ERROR_ISSUE, INFO_ISSUE]} />
+    );
+    expect(decorationData(getEditorView())).toHaveLength(2);
+
+    rerender(<DslEditor initialValue={SAMPLE} onChange={() => {}} issues={[]} />);
+    expect(decorationData(getEditorView())).toHaveLength(0);
+  });
+
+  it('builds a tooltip DOM that surfaces the error message + code + slug', () => {
+    const dom = renderTooltipDom([ERROR_ISSUE]);
+    expect(dom.getAttribute('data-testid')).toBe('dsl-editor-issue-tooltip');
+    expect(dom.textContent).toContain('UnresolvedPrepStateSlug');
+    expect(dom.textContent).toContain('Unknown prep state');
+    expect(dom.textContent).toContain('foo');
+    const row = dom.querySelector('[data-dsl-issue-severity="error"]');
+    expect(row).not.toBeNull();
+  });
+
+  it('stacks multiple issues in the tooltip DOM in input order', () => {
+    const dom = renderTooltipDom([ERROR_ISSUE, INFO_ISSUE]);
+    const rows = dom.querySelectorAll('.cm-dsl-issue-tooltip__row');
+    expect(rows).toHaveLength(2);
+    expect(rows[0].getAttribute('data-dsl-issue-severity')).toBe('error');
+    expect(rows[1].getAttribute('data-dsl-issue-severity')).toBe('info');
+  });
+
+  it('drops decorations whose span no longer fits the document', () => {
+    const offDoc: CompileEditorIssue = {
+      ...ERROR_ISSUE,
+      loc: { startLine: 12, startCol: 1, endLine: 12, endCol: 4 },
+    };
+    render(<DslEditor initialValue={SAMPLE} onChange={() => {}} issues={[ERROR_ISSUE, offDoc]} />);
+    // 1 of 2 issues makes it onto the doc; the other silently drops.
+    expect(decorationData(getEditorView())).toHaveLength(1);
+  });
+
+  it('mounts the diagnostic gutter column', () => {
+    render(<DslEditor initialValue={SAMPLE} onChange={() => {}} issues={[ERROR_ISSUE]} />);
+    const surface = screen.getByTestId('dsl-editor-surface');
+    expect(surface.querySelector('.cm-dsl-issue-gutter-column')).not.toBeNull();
   });
 });

--- a/packages/app-food/src/components/__tests__/dsl-editor-issues-span.test.ts
+++ b/packages/app-food/src/components/__tests__/dsl-editor-issues-span.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Unit tests for `spanToRange` — the SourceSpan → CodeMirror offset
+ * converter used by the issues extension (PRD-120 part C).
+ *
+ * Covers the contract documented at the top of `issues-span.ts`:
+ *   - 1-indexed line/column input, exclusive `endCol`
+ *   - clamping out-of-range columns instead of throwing
+ *   - rejecting spans whose lines fall outside the document
+ *   - widening zero-width spans by one character so they remain visible
+ *
+ * The test mounts a real `EditorState` (no jsdom hack needed — `Text`
+ * + `EditorState.create` are pure Node-land code) so we exercise the
+ * exact API path the production hook drives.
+ */
+import { EditorState } from '@codemirror/state';
+import { describe, expect, it } from 'vitest';
+
+import { spanToRange } from '../dsl-editor/issues-span';
+
+function stateFor(doc: string): EditorState {
+  return EditorState.create({ doc });
+}
+
+describe('spanToRange — PRD-120 part C', () => {
+  it('maps a single-line span to the correct offset pair', () => {
+    const state = stateFor('@ingredient(1, banana:raw:foo, 1:cup)');
+    // `foo` lives at columns 27–29 (1-indexed). The `:` after `raw` is at
+    // column 26, so `foo` starts at 27 and ends at 30 (endCol exclusive).
+    const range = spanToRange(state, { startLine: 1, startCol: 27, endLine: 1, endCol: 30 });
+    expect(range).toEqual({ from: 26, to: 29 });
+    expect(state.doc.sliceString(range!.from, range!.to)).toBe('foo');
+  });
+
+  it('handles multi-line spans', () => {
+    const state = stateFor('line one\n@ingredient(1, banana, 1:cup)\nlast');
+    // Span across the second line + into the third.
+    const range = spanToRange(state, { startLine: 2, startCol: 1, endLine: 3, endCol: 5 });
+    expect(range).not.toBeNull();
+    expect(state.doc.sliceString(range!.from, range!.to)).toBe(
+      '@ingredient(1, banana, 1:cup)\nlast'
+    );
+  });
+
+  it('returns null when startLine is below 1', () => {
+    expect(spanToRange(stateFor('abc'), { startLine: 0, startCol: 1, endLine: 1, endCol: 1 })).toBe(
+      null
+    );
+  });
+
+  it('returns null when endLine exceeds the document', () => {
+    expect(spanToRange(stateFor('abc'), { startLine: 1, startCol: 1, endLine: 5, endCol: 1 })).toBe(
+      null
+    );
+  });
+
+  it('returns null when endLine < startLine', () => {
+    expect(
+      spanToRange(stateFor('abc\ndef'), { startLine: 2, startCol: 1, endLine: 1, endCol: 1 })
+    ).toBe(null);
+  });
+
+  it('clamps columns beyond the line length', () => {
+    const state = stateFor('abc');
+    // endCol=99 should clamp to lineLength+1 = 4.
+    const range = spanToRange(state, { startLine: 1, startCol: 1, endLine: 1, endCol: 99 });
+    expect(range).toEqual({ from: 0, to: 3 });
+  });
+
+  it('clamps a negative column to 1', () => {
+    const state = stateFor('abc');
+    const range = spanToRange(state, { startLine: 1, startCol: -5, endLine: 1, endCol: 4 });
+    expect(range).toEqual({ from: 0, to: 3 });
+  });
+
+  it('widens a zero-width span by one character', () => {
+    const state = stateFor('abc');
+    const range = spanToRange(state, { startLine: 1, startCol: 2, endLine: 1, endCol: 2 });
+    expect(range).toEqual({ from: 1, to: 2 });
+  });
+
+  it('returns null when a zero-width span sits at the very end of the document', () => {
+    const state = stateFor('abc');
+    // `doc.length` is 3; column 4 → offset 3. Cannot widen.
+    const range = spanToRange(state, { startLine: 1, startCol: 4, endLine: 1, endCol: 4 });
+    expect(range).toBe(null);
+  });
+});

--- a/packages/app-food/src/components/__tests__/dsl-editor-issues-state.test.ts
+++ b/packages/app-food/src/components/__tests__/dsl-editor-issues-state.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Unit tests for the issues `StateField` + `setIssuesEffect` — PRD-120
+ * part C.
+ *
+ * Drives the state field through an `EditorState` directly so we cover:
+ *   - dispatching `setIssuesEffect` populates decorations
+ *   - subsequent dispatches REPLACE the prior set (not append)
+ *   - an empty issues array clears every decoration
+ *   - document changes rebuild decorations against the new offsets
+ *   - `getIssuesForOffset` returns every issue whose span covers a hit
+ */
+import { EditorState } from '@codemirror/state';
+import { describe, expect, it } from 'vitest';
+
+import { getIssuesForOffset, issuesField, setIssuesEffect } from '../dsl-editor/issues-state';
+
+import type { CompileEditorIssue } from '../dsl-editor/issues-types';
+
+function stateFor(doc: string): EditorState {
+  return EditorState.create({ doc, extensions: [issuesField] });
+}
+
+function decorationCount(state: EditorState): number {
+  const set = state.field(issuesField).decorations;
+  let count = 0;
+  const iter = set.iter();
+  while (iter.value !== null) {
+    count += 1;
+    iter.next();
+  }
+  return count;
+}
+
+const ISSUE_A: CompileEditorIssue = {
+  severity: 'error',
+  code: 'UnresolvedSlug',
+  message: 'Unknown slug',
+  loc: { startLine: 1, startCol: 1, endLine: 1, endCol: 5 },
+  slug: 'foo',
+};
+
+const ISSUE_B: CompileEditorIssue = {
+  severity: 'info',
+  code: 'ProposedSlug',
+  message: 'Proposed: banana',
+  loc: { startLine: 1, startCol: 10, endLine: 1, endCol: 16 },
+  slug: 'banana',
+};
+
+describe('issues StateField — PRD-120 part C', () => {
+  it('starts with no decorations', () => {
+    const state = stateFor('hello world');
+    expect(decorationCount(state)).toBe(0);
+    expect(state.field(issuesField).issues).toEqual([]);
+  });
+
+  it('applies decorations on setIssuesEffect dispatch', () => {
+    let state = stateFor('hello world');
+    state = state.update({ effects: setIssuesEffect.of([ISSUE_A, ISSUE_B]) }).state;
+    expect(decorationCount(state)).toBe(2);
+    expect(state.field(issuesField).issues).toEqual([ISSUE_A, ISSUE_B]);
+  });
+
+  it('replaces (not appends) on subsequent dispatches', () => {
+    let state = stateFor('hello world');
+    state = state.update({ effects: setIssuesEffect.of([ISSUE_A]) }).state;
+    expect(decorationCount(state)).toBe(1);
+    state = state.update({ effects: setIssuesEffect.of([ISSUE_B]) }).state;
+    expect(decorationCount(state)).toBe(1);
+    expect(state.field(issuesField).issues).toEqual([ISSUE_B]);
+  });
+
+  it('clears all decorations when an empty array is dispatched', () => {
+    let state = stateFor('hello world');
+    state = state.update({ effects: setIssuesEffect.of([ISSUE_A, ISSUE_B]) }).state;
+    expect(decorationCount(state)).toBe(2);
+    state = state.update({ effects: setIssuesEffect.of([]) }).state;
+    expect(decorationCount(state)).toBe(0);
+    expect(state.field(issuesField).issues).toEqual([]);
+  });
+
+  it('drops decorations whose span no longer fits the document', () => {
+    let state = stateFor('hello world');
+    const offDoc: CompileEditorIssue = {
+      severity: 'error',
+      code: 'UnresolvedSlug',
+      message: 'gone',
+      loc: { startLine: 5, startCol: 1, endLine: 5, endCol: 4 },
+    };
+    state = state.update({ effects: setIssuesEffect.of([ISSUE_A, offDoc]) }).state;
+    expect(decorationCount(state)).toBe(1);
+    expect(state.field(issuesField).issues).toHaveLength(2);
+  });
+
+  it('rebuilds decorations against new offsets on document change', () => {
+    let state = stateFor('hello world');
+    state = state.update({ effects: setIssuesEffect.of([ISSUE_A]) }).state;
+    const decorationsBefore = state.field(issuesField).decorations;
+    state = state.update({ changes: { from: 0, to: 0, insert: 'XX' } }).state;
+    const decorationsAfter = state.field(issuesField).decorations;
+    expect(decorationsAfter).not.toBe(decorationsBefore);
+    // The issue's span still says cols 1..5; after rebuild the decoration
+    // covers `XXhe` (the new offsets 0..4).
+    const iter = decorationsAfter.iter();
+    expect(iter.from).toBe(0);
+    expect(iter.to).toBe(4);
+  });
+
+  it('attaches severity + code to the decoration mark via data attributes', () => {
+    let state = stateFor('hello world');
+    state = state.update({ effects: setIssuesEffect.of([ISSUE_A, ISSUE_B]) }).state;
+    const set = state.field(issuesField).decorations;
+    const iter = set.iter();
+    const severities: string[] = [];
+    while (iter.value !== null) {
+      const attrs = (iter.value.spec as { attributes?: Record<string, string> }).attributes;
+      severities.push(attrs?.['data-dsl-issue-severity'] ?? '');
+      iter.next();
+    }
+    expect(severities).toEqual(['error', 'info']);
+  });
+});
+
+describe('getIssuesForOffset — PRD-120 part C', () => {
+  it('returns issues whose span covers the offset', () => {
+    const state = stateFor('hello world');
+    // ISSUE_A covers cols 1..5 → offsets 0..4 (inclusive of edges).
+    const hits = getIssuesForOffset([ISSUE_A, ISSUE_B], state, 2);
+    expect(hits).toEqual([ISSUE_A]);
+  });
+
+  it('returns multiple issues when spans overlap on the offset', () => {
+    const state = stateFor('hello world');
+    const overlapping: CompileEditorIssue = {
+      ...ISSUE_B,
+      loc: { startLine: 1, startCol: 1, endLine: 1, endCol: 6 },
+    };
+    const hits = getIssuesForOffset([ISSUE_A, overlapping], state, 2);
+    expect(hits).toEqual([ISSUE_A, overlapping]);
+  });
+
+  it('skips issues whose span is out of range', () => {
+    const state = stateFor('hello');
+    const offDoc: CompileEditorIssue = {
+      ...ISSUE_A,
+      loc: { startLine: 5, startCol: 1, endLine: 5, endCol: 4 },
+    };
+    expect(getIssuesForOffset([offDoc], state, 0)).toEqual([]);
+  });
+});

--- a/packages/app-food/src/components/__tests__/dsl-editor-issues-state.test.ts
+++ b/packages/app-food/src/components/__tests__/dsl-editor-issues-state.test.ts
@@ -124,7 +124,8 @@ describe('issues StateField — PRD-120 part C', () => {
 describe('getIssuesForOffset — PRD-120 part C', () => {
   it('returns issues whose span covers the offset', () => {
     const state = stateFor('hello world');
-    // ISSUE_A covers cols 1..5 → offsets 0..4 (inclusive of edges).
+    // ISSUE_A covers cols 1..5 → offsets [0, 4) (half-open, like
+    // `Decoration.mark`'s `to`).
     const hits = getIssuesForOffset([ISSUE_A, ISSUE_B], state, 2);
     expect(hits).toEqual([ISSUE_A]);
   });
@@ -146,5 +147,16 @@ describe('getIssuesForOffset — PRD-120 part C', () => {
       loc: { startLine: 5, startCol: 1, endLine: 5, endCol: 4 },
     };
     expect(getIssuesForOffset([offDoc], state, 0)).toEqual([]);
+  });
+
+  it('treats the span end as exclusive', () => {
+    // Mirrors `Decoration.mark`'s `to`-is-exclusive contract — the
+    // character right after the squiggle should NOT surface the
+    // tooltip on hover.
+    const state = stateFor('hello world');
+    // ISSUE_A covers cols 1..5 → offsets [0, 4). Offset 4 is the first
+    // character NOT in the squiggle.
+    expect(getIssuesForOffset([ISSUE_A], state, 3)).toEqual([ISSUE_A]);
+    expect(getIssuesForOffset([ISSUE_A], state, 4)).toEqual([]);
   });
 });

--- a/packages/app-food/src/components/dsl-editor/issues-extension.ts
+++ b/packages/app-food/src/components/dsl-editor/issues-extension.ts
@@ -1,0 +1,30 @@
+import { issuesGutter } from './issues-gutter';
+import { issuesField, setIssuesEffect } from './issues-state';
+import { issuesTheme } from './issues-theme';
+import { issuesHoverTooltip } from './issues-tooltip';
+
+/**
+ * Public extension factory for the DSL editor's issues surface (PRD-120
+ * part C).
+ *
+ * `issuesExtension()` bundles every CodeMirror extension the issues
+ * feature needs — the `StateField` holding the diagnostic list, inline
+ * decorations driven from that field, the hover-tooltip provider, the
+ * diagnostic gutter, and the visual theme. Drop the result into the
+ * editor's `extensions` array exactly once.
+ *
+ * The hook (`useDslEditorView`) drives state changes via
+ * `setIssuesEffect`, exported from `issues-state` and re-exported here
+ * for the hook's convenience.
+ */
+import type { Extension } from '@codemirror/state';
+
+export function issuesExtension(): Extension {
+  // Order matters only for visual stacking — the gutter wants to render
+  // BEFORE inline decorations so multi-issue lines still highlight.
+  return [issuesField, issuesGutter, issuesHoverTooltip, issuesTheme];
+}
+
+export { setIssuesEffect, issuesField };
+export type { IssuesState } from './issues-state';
+export type { CompileEditorIssue, IssueSeverity } from './issues-types';

--- a/packages/app-food/src/components/dsl-editor/issues-gutter.ts
+++ b/packages/app-food/src/components/dsl-editor/issues-gutter.ts
@@ -1,0 +1,68 @@
+/**
+ * Diagnostic gutter for the issues extension (PRD-120 part C).
+ *
+ * Renders a single marker per line that contains at least one issue.
+ * Error wins over info when both exist on the same line (so the user
+ * always sees the strongest signal). The marker carries a stable
+ * `data-testid` so RTL tests can assert without sampling pixel styles.
+ */
+import { gutter, GutterMarker } from '@codemirror/view';
+
+import { spanToRange } from './issues-span';
+import { issuesField } from './issues-state';
+
+import type { IssueSeverity } from './issues-types';
+
+class IssueMarker extends GutterMarker {
+  constructor(
+    private readonly severity: IssueSeverity,
+    private readonly count: number
+  ) {
+    super();
+  }
+
+  override eq(other: GutterMarker): boolean {
+    return (
+      other instanceof IssueMarker && other.severity === this.severity && other.count === this.count
+    );
+  }
+
+  override toDOM(): HTMLElement {
+    const el = document.createElement('span');
+    el.className = `cm-dsl-issue-gutter cm-dsl-issue-gutter--${this.severity}`;
+    el.setAttribute('data-testid', 'dsl-editor-issue-gutter');
+    el.setAttribute('data-dsl-issue-severity', this.severity);
+    el.setAttribute('data-dsl-issue-count', String(this.count));
+    el.textContent = this.severity === 'error' ? '●' : '○';
+    return el;
+  }
+}
+
+export const issuesGutter = gutter({
+  class: 'cm-dsl-issue-gutter-column',
+  lineMarker(view, line) {
+    const field = view.state.field(issuesField, false);
+    if (!field || field.issues.length === 0) return null;
+    let hasError = false;
+    let count = 0;
+    for (const issue of field.issues) {
+      const range = spanToRange(view.state, issue.loc);
+      if (!range) continue;
+      // The marker sits in the gutter of the line whose start offset is
+      // closest to the issue range — we use the line containing the
+      // span's `from` (matches users' intuition for multi-line spans).
+      if (range.from >= line.from && range.from <= line.to) {
+        count += 1;
+        if (issue.severity === 'error') hasError = true;
+      }
+    }
+    if (count === 0) return null;
+    return new IssueMarker(hasError ? 'error' : 'info', count);
+  },
+  // Force a re-render when the issues field updates.
+  lineMarkerChange(update) {
+    const before = update.startState.field(issuesField, false);
+    const after = update.state.field(issuesField, false);
+    return before !== after;
+  },
+});

--- a/packages/app-food/src/components/dsl-editor/issues-span.ts
+++ b/packages/app-food/src/components/dsl-editor/issues-span.ts
@@ -1,0 +1,56 @@
+/**
+ * `spanToRange` — convert a PRD-114 `SourceSpan` (1-indexed line + column,
+ * `endCol` exclusive) into a CodeMirror `{ from, to }` offset pair.
+ *
+ * Returns `null` when the span points outside the current document. Span
+ * positions can drift out of range when the user types between two
+ * compile cycles — the parent's stale issues list will outlive its
+ * document — so the conversion treats out-of-range spans as "drop this
+ * decoration" rather than crashing.
+ *
+ * Defensive clamping rules:
+ *   - Lines below 1 / above `doc.lines` are rejected.
+ *   - Columns are clamped to `[1, line.length + 1]` (the `+ 1` allows a
+ *     span ending right after the last character on a line, which is the
+ *     shape the parser emits for "missing closing paren" diagnostics).
+ *   - `from > to` after clamping is rejected (zero-width spans get a
+ *     one-character widening so the decoration is at least visible).
+ */
+import type { EditorState } from '@codemirror/state';
+
+import type { SourceSpan } from '../../dsl/ast';
+
+export interface IssueRange {
+  from: number;
+  to: number;
+}
+
+export function spanToRange(state: EditorState, span: SourceSpan): IssueRange | null {
+  const doc = state.doc;
+  if (span.startLine < 1 || span.startLine > doc.lines) return null;
+  if (span.endLine < 1 || span.endLine > doc.lines) return null;
+  if (span.endLine < span.startLine) return null;
+
+  const startLine = doc.line(span.startLine);
+  const endLine = doc.line(span.endLine);
+
+  const startColClamped = clampCol(span.startCol, startLine.length);
+  const endColClamped = clampCol(span.endCol, endLine.length);
+
+  const from = startLine.from + startColClamped - 1;
+  let to = endLine.from + endColClamped - 1;
+
+  if (to < from) return null;
+  if (to === from) {
+    to = Math.min(to + 1, doc.length);
+    if (to === from) return null;
+  }
+  return { from, to };
+}
+
+function clampCol(col: number, lineLength: number): number {
+  if (col < 1) return 1;
+  // `+ 1` because `endCol` is exclusive and may point one past the last char.
+  if (col > lineLength + 1) return lineLength + 1;
+  return col;
+}

--- a/packages/app-food/src/components/dsl-editor/issues-state.ts
+++ b/packages/app-food/src/components/dsl-editor/issues-state.ts
@@ -1,0 +1,105 @@
+/**
+ * Issues `StateField` + `StateEffect` for the DSL editor (PRD-120 part C).
+ *
+ * The parent (PRD-119, downstream) passes a fresh `CompileEditorIssue[]`
+ * whenever the most-recent compile result changes. The `useDslEditorView`
+ * hook dispatches `setIssuesEffect.of(issues)` and this field rebuilds the
+ * decoration set + a parallel ranged-marker set used by the gutter.
+ *
+ * Both sets are kept in a single `StateField` so a single dispatch
+ * synchronises the inline squiggles and the gutter markers — there is no
+ * race where the gutter shows an issue that the squiggle has already
+ * cleared.
+ */
+import { type EditorState, RangeSetBuilder, StateEffect, StateField } from '@codemirror/state';
+import { Decoration, EditorView, type DecorationSet } from '@codemirror/view';
+
+import { spanToRange } from './issues-span';
+
+import type { CompileEditorIssue, IssueSeverity } from './issues-types';
+
+export const setIssuesEffect = StateEffect.define<CompileEditorIssue[]>();
+
+export interface IssuesState {
+  issues: readonly CompileEditorIssue[];
+  decorations: DecorationSet;
+}
+
+export const issuesField = StateField.define<IssuesState>({
+  create(): IssuesState {
+    return { issues: [], decorations: Decoration.none };
+  },
+  update(value, tr): IssuesState {
+    let next = value;
+    for (const effect of tr.effects) {
+      if (effect.is(setIssuesEffect)) {
+        const issues = effect.value;
+        next = { issues, decorations: buildDecorations(tr.state, issues) };
+      }
+    }
+    // Document changes shift offsets — rebuild against the new doc using
+    // the same issue list. Issues with stale spans drop silently (see
+    // `spanToRange`).
+    if (tr.docChanged && next === value && value.issues.length > 0) {
+      next = { issues: value.issues, decorations: buildDecorations(tr.state, value.issues) };
+    }
+    return next;
+  },
+  // `provide` feeds the field's decoration set into the editor's
+  // decoration facet so the marks render without the editor wiring it
+  // up explicitly. The issues array stays available via
+  // `state.field(issuesField).issues` for the hover tooltip and the
+  // gutter marker provider.
+  provide: (field) => EditorView.decorations.from(field, (s) => s.decorations),
+});
+
+export function getIssuesForOffset(
+  issues: readonly CompileEditorIssue[],
+  state: EditorState,
+  offset: number
+): CompileEditorIssue[] {
+  const hits: CompileEditorIssue[] = [];
+  for (const issue of issues) {
+    const range = spanToRange(state, issue.loc);
+    if (!range) continue;
+    if (offset >= range.from && offset <= range.to) hits.push(issue);
+  }
+  return hits;
+}
+
+function buildDecorations(
+  state: EditorState,
+  issues: readonly CompileEditorIssue[]
+): DecorationSet {
+  const sorted = sortBySpan(state, issues);
+  const builder = new RangeSetBuilder<Decoration>();
+  for (const { issue, range } of sorted) {
+    builder.add(range.from, range.to, markFor(issue.severity, issue.code));
+  }
+  return builder.finish();
+}
+
+function sortBySpan(
+  state: EditorState,
+  issues: readonly CompileEditorIssue[]
+): Array<{ issue: CompileEditorIssue; range: { from: number; to: number } }> {
+  const out: Array<{ issue: CompileEditorIssue; range: { from: number; to: number } }> = [];
+  for (const issue of issues) {
+    const range = spanToRange(state, issue.loc);
+    if (range) out.push({ issue, range });
+  }
+  out.sort((a, b) => a.range.from - b.range.from || a.range.to - b.range.to);
+  return out;
+}
+
+function markFor(severity: IssueSeverity, code: string): Decoration {
+  const cls =
+    severity === 'error' ? 'cm-dsl-issue cm-dsl-issue--error' : 'cm-dsl-issue cm-dsl-issue--info';
+  return Decoration.mark({
+    class: cls,
+    attributes: {
+      'data-dsl-issue-severity': severity,
+      'data-dsl-issue-code': code,
+    },
+  });
+}

--- a/packages/app-food/src/components/dsl-editor/issues-state.ts
+++ b/packages/app-food/src/components/dsl-editor/issues-state.ts
@@ -58,11 +58,14 @@ export function getIssuesForOffset(
   state: EditorState,
   offset: number
 ): CompileEditorIssue[] {
+  // `spanToRange` returns an exclusive `to` (same convention as
+  // `Decoration.mark`), so the hit-test is half-open `[from, to)`. The
+  // offset right after the last decorated character does NOT count.
   const hits: CompileEditorIssue[] = [];
   for (const issue of issues) {
     const range = spanToRange(state, issue.loc);
     if (!range) continue;
-    if (offset >= range.from && offset <= range.to) hits.push(issue);
+    if (offset >= range.from && offset < range.to) hits.push(issue);
   }
   return hits;
 }

--- a/packages/app-food/src/components/dsl-editor/issues-theme.ts
+++ b/packages/app-food/src/components/dsl-editor/issues-theme.ts
@@ -1,0 +1,73 @@
+/**
+ * Inline styles for the issues extension (PRD-120 part C).
+ *
+ * `EditorView.theme` keeps the rules scoped to a generated class so the
+ * extension is self-contained — the editor pages don't need to import a
+ * separate stylesheet.
+ *
+ * Errors use a red wavy underline (the de-facto IDE convention) and a
+ * solid red gutter dot. Info issues (proposed slugs, resolver hints) use
+ * a blue dotted underline + a hollow blue dot. Colours read against both
+ * the default CodeMirror light theme and the `@pops/ui` dark variants
+ * shell pages mount; the test suite asserts the DOM attributes, not the
+ * pixel colours, so theme tuning stays a CSS-only follow-up.
+ */
+import { EditorView } from '@codemirror/view';
+
+export const issuesTheme = EditorView.theme({
+  '.cm-dsl-issue': {
+    textDecoration: 'underline',
+    textDecorationSkipInk: 'none',
+  },
+  '.cm-dsl-issue--error': {
+    textDecorationStyle: 'wavy',
+    textDecorationColor: '#dc2626',
+    textDecorationThickness: '1px',
+  },
+  '.cm-dsl-issue--info': {
+    textDecorationStyle: 'dotted',
+    textDecorationColor: '#2563eb',
+    textDecorationThickness: '1px',
+  },
+  '.cm-dsl-issue-gutter-column': {
+    width: '1rem',
+    textAlign: 'center',
+  },
+  '.cm-dsl-issue-gutter': {
+    display: 'inline-block',
+    fontSize: '0.75rem',
+    lineHeight: '1.2',
+  },
+  '.cm-dsl-issue-gutter--error': { color: '#dc2626' },
+  '.cm-dsl-issue-gutter--info': { color: '#2563eb' },
+  '.cm-dsl-issue-tooltip': {
+    padding: '0.5rem 0.75rem',
+    fontSize: '0.875rem',
+    lineHeight: '1.4',
+    maxWidth: '24rem',
+    backgroundColor: '#1f2937',
+    color: '#f9fafb',
+    borderRadius: '0.25rem',
+    boxShadow: '0 4px 10px rgba(0,0,0,0.25)',
+  },
+  '.cm-dsl-issue-tooltip__row': {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '0.125rem',
+    paddingBottom: '0.25rem',
+  },
+  '.cm-dsl-issue-tooltip__row:last-child': { paddingBottom: '0' },
+  '.cm-dsl-issue-tooltip__code': {
+    fontFamily: 'monospace',
+    fontSize: '0.75rem',
+    opacity: '0.7',
+  },
+  '.cm-dsl-issue-tooltip__row--error .cm-dsl-issue-tooltip__code': { color: '#fca5a5' },
+  '.cm-dsl-issue-tooltip__row--info .cm-dsl-issue-tooltip__code': { color: '#93c5fd' },
+  '.cm-dsl-issue-tooltip__message': { color: '#f9fafb' },
+  '.cm-dsl-issue-tooltip__slug': {
+    fontFamily: 'monospace',
+    fontSize: '0.75rem',
+    opacity: '0.85',
+  },
+});

--- a/packages/app-food/src/components/dsl-editor/issues-tooltip.ts
+++ b/packages/app-food/src/components/dsl-editor/issues-tooltip.ts
@@ -1,0 +1,65 @@
+/**
+ * Hover tooltip provider for the issues extension (PRD-120 part C).
+ *
+ * On hover, looks up every `CompileEditorIssue` whose `loc` covers the
+ * pointer offset and renders them stacked in a single tooltip. Multiple
+ * issues at the same offset (e.g. a `ProposedSlug` + an `UnresolvedSlug`
+ * pointing at the same descriptor) all show.
+ *
+ * The DOM shape is exposed via `data-testid` and stable class names so
+ * the RTL suite can assert on the tooltip without exercising real
+ * pointer events through jsdom (which doesn't reliably trigger
+ * CodeMirror's hover hit-testing). Tests call the provider function
+ * directly instead.
+ */
+import { hoverTooltip, type Tooltip } from '@codemirror/view';
+
+import { getIssuesForOffset, issuesField } from './issues-state';
+
+import type { CompileEditorIssue } from './issues-types';
+
+export const issuesHoverTooltip = hoverTooltip((view, pos): Tooltip | null => {
+  const field = view.state.field(issuesField, false);
+  if (!field || field.issues.length === 0) return null;
+  const hits = getIssuesForOffset(field.issues, view.state, pos);
+  if (hits.length === 0) return null;
+  return {
+    pos,
+    end: pos,
+    above: true,
+    create: () => ({ dom: renderTooltipDom(hits) }),
+  };
+});
+
+export function renderTooltipDom(issues: readonly CompileEditorIssue[]): HTMLDivElement {
+  const dom = document.createElement('div');
+  dom.className = 'cm-dsl-issue-tooltip';
+  dom.setAttribute('data-testid', 'dsl-editor-issue-tooltip');
+  for (const issue of issues) dom.appendChild(renderIssueLine(issue));
+  return dom;
+}
+
+function renderIssueLine(issue: CompileEditorIssue): HTMLDivElement {
+  const row = document.createElement('div');
+  row.className = `cm-dsl-issue-tooltip__row cm-dsl-issue-tooltip__row--${issue.severity}`;
+  row.setAttribute('data-dsl-issue-severity', issue.severity);
+  row.setAttribute('data-dsl-issue-code', issue.code);
+
+  const codeSpan = document.createElement('span');
+  codeSpan.className = 'cm-dsl-issue-tooltip__code';
+  codeSpan.textContent = issue.code;
+  row.appendChild(codeSpan);
+
+  const messageSpan = document.createElement('span');
+  messageSpan.className = 'cm-dsl-issue-tooltip__message';
+  messageSpan.textContent = issue.message;
+  row.appendChild(messageSpan);
+
+  if (issue.slug !== undefined) {
+    const slugSpan = document.createElement('span');
+    slugSpan.className = 'cm-dsl-issue-tooltip__slug';
+    slugSpan.textContent = issue.slug;
+    row.appendChild(slugSpan);
+  }
+  return row;
+}

--- a/packages/app-food/src/components/dsl-editor/issues-types.ts
+++ b/packages/app-food/src/components/dsl-editor/issues-types.ts
@@ -1,0 +1,28 @@
+/**
+ * Shared types for the DSL editor's issues extension (PRD-120 part C).
+ *
+ * `CompileEditorIssue` is the unified diagnostic shape the parent (PRD-119,
+ * downstream) feeds into the editor. The parent assembles the list from:
+ *   - errors returned by `food.recipes.saveDraft`'s `CompileResult`
+ *     (parse / resolve / cycle errors per PRD-114 / PRD-115 / PRD-117)
+ *   - rows from `recipe_version_proposed_slugs` (PRD-116) for the current
+ *     `versionId`, fetched via `food.recipes.listProposedSlugs(versionId)`
+ *
+ * Each issue carries `severity` so the editor colours errors red and
+ * proposed slugs blue. `loc` reuses PRD-114's `SourceSpan` (1-indexed
+ * line/col, `endCol` exclusive) so the editor can convert it to a
+ * CodeMirror offset range deterministically.
+ */
+import type { SourceSpan } from '../../dsl/ast';
+
+export type IssueSeverity = 'error' | 'info';
+
+export interface CompileEditorIssue {
+  severity: IssueSeverity;
+  /** `ParseErrorCode | ResolveErrorCode | CycleErrorCode | 'ProposedSlug'`. */
+  code: string;
+  message: string;
+  loc: SourceSpan;
+  /** Set on `ProposedSlug` and on resolve errors that named a slug. */
+  slug?: string;
+}

--- a/packages/app-food/src/components/useDslEditorView.ts
+++ b/packages/app-food/src/components/useDslEditorView.ts
@@ -1,6 +1,7 @@
 /**
  * `useDslEditorView` — owns the imperative CodeMirror 6 lifecycle for the
- * DSL editor (PRD-120 part A; chip widgets + mobile fallback added in 120-D).
+ * DSL editor (PRD-120 part A; issues / squiggles / tooltip in 120-C;
+ * chip widgets + mobile fallback in 120-D).
  *
  * Pulled out of `DslEditor.tsx` so the component itself stays under the
  * lint cap and the React surface is purely declarative. The hook:
@@ -33,6 +34,9 @@ import { useCallback, useEffect, useRef, type MutableRefObject } from 'react';
 
 import { recipeDsl } from '../dsl/codemirror';
 import { chipWidgetsExtension } from './dsl-editor/chip-widgets-extension';
+import { issuesExtension, setIssuesEffect } from './dsl-editor/issues-extension';
+
+import type { CompileEditorIssue } from './dsl-editor/issues-types';
 
 const DEBOUNCE_MS = 250;
 const MOBILE_QUERY = '(max-width: 767px)';
@@ -41,6 +45,7 @@ export interface UseDslEditorViewOptions {
   initialValue: string;
   onChange: (value: string) => void;
   readOnly: boolean;
+  issues: readonly CompileEditorIssue[];
 }
 
 interface ViewCompartments {
@@ -110,6 +115,14 @@ export function useDslEditorView(
       changes: { from: 0, to: view.state.doc.length, insert: options.initialValue },
     });
   }, [options.initialValue]);
+
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view) return;
+    view.dispatch({
+      effects: setIssuesEffect.of([...options.issues]),
+    });
+  }, [options.issues]);
 }
 
 function buildReadOnlyExtension(
@@ -145,6 +158,9 @@ function createEditorView(
   compartments: ViewCompartments,
   emit: (value: string) => void
 ): EditorView {
+  // Initial `options.issues` is seeded by the `useEffect(...,
+  // [options.issues])` block above, which fires once after mount —
+  // dispatching here would double-render (PR #2716 review feedback).
   const compact = detectCompactInitial();
   return new EditorView({
     state: EditorState.create({
@@ -155,6 +171,7 @@ function createEditorView(
         bracketMatching(),
         syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
         recipeDsl(),
+        issuesExtension(),
         keymap.of([...defaultKeymap, ...historyKeymap]),
         compartments.readOnly.of(buildReadOnlyExtension(options.readOnly)),
         compartments.chips.of(chipWidgetsExtension({ compact })),

--- a/packages/app-food/src/components/useDslEditorView.ts
+++ b/packages/app-food/src/components/useDslEditorView.ts
@@ -107,6 +107,13 @@ export function useDslEditorView(
     });
   }, [options.readOnly]);
 
+  useSyncEffects(viewRef, options);
+}
+
+function useSyncEffects(
+  viewRef: MutableRefObject<EditorView | null>,
+  options: UseDslEditorViewOptions
+): void {
   useEffect(() => {
     const view = viewRef.current;
     if (!view) return;
@@ -114,15 +121,13 @@ export function useDslEditorView(
     view.dispatch({
       changes: { from: 0, to: view.state.doc.length, insert: options.initialValue },
     });
-  }, [options.initialValue]);
+  }, [options.initialValue, viewRef]);
 
   useEffect(() => {
     const view = viewRef.current;
     if (!view) return;
-    view.dispatch({
-      effects: setIssuesEffect.of([...options.issues]),
-    });
-  }, [options.issues]);
+    view.dispatch({ effects: setIssuesEffect.of([...options.issues]) });
+  }, [options.issues, viewRef]);
 }
 
 function buildReadOnlyExtension(

--- a/packages/app-food/src/index.ts
+++ b/packages/app-food/src/index.ts
@@ -23,6 +23,7 @@ export type { TimerButtonProps } from './components/TimerButton';
 export { TempBadge } from './components/TempBadge';
 export type { TempBadgeProps } from './components/TempBadge';
 
-// PRD-120 — DSL Editor (Part A scaffold + Part D chip widgets).
+// PRD-120 — DSL Editor (Part A scaffold + Part C issues prop + Part D chip widgets).
 export { DslEditor } from './components/DslEditor';
 export type { DslEditorProps } from './components/DslEditor';
+export type { CompileEditorIssue, IssueSeverity } from './components/dsl-editor/issues-types';


### PR DESCRIPTION
## Summary

Extends the `DslEditor` component (PRD-120 part A, shipped in #2702) with the `issues` prop. Compile diagnostics — parse errors from PRD-114, resolve errors from PRD-115, cycle errors from PRD-117, and proposed-slug suggestions from PRD-116 — now render as inline squiggles + a gutter marker + a hover tooltip. The parent (PRD-119, downstream) feeds a single flat list; the editor handles the rest.

- New: `packages/app-food/src/components/dsl-editor/` (7 modules: `issues-types`, `issues-span`, `issues-state`, `issues-tooltip`, `issues-gutter`, `issues-theme`, `issues-extension`). Split keeps every file under the 200-line lint cap.
- `severity: 'error' | 'info'` matches the PRD spec verbatim — no warning tier.
- `spanToRange` defensively clamps out-of-range columns and widens zero-width spans so a stale issue list from a previous compile cycle never crashes the editor.
- `DslEditor` is now re-exported from `@pops/app-food` — part A landed without surfacing it on the package barrel; this PR closes that gap.

## Test plan

- [x] `pnpm test` in `packages/app-food` — 281/281 vitest cases green, including 28 new (9 span / 10 state / 9 RTL).
- [x] `pnpm typecheck` — clean for `app-food`, `pops-storybook`, `pops-shell`, and every other package in the workspace.
- [x] `pnpm lint` — clean (no new errors; pre-existing warnings unchanged).
- [ ] Storybook smoke (DslEditor → WithErrors / WithProposedSlugs / Mixed) — needs reviewer eyeball; the new file follows the same i18n harness pattern as `RecipeRenderer.stories.tsx`.

## Acceptance criteria status (PRD-120)

Ticking the boxes in the PRD's `## Acceptance Criteria` section under `### Error squiggles`:

- [x] Passing an `issues` array with `severity: 'error'` and an explicit `loc` renders an underline at exactly that range — covered by `dsl-editor-issues-span.test.ts` + `DslEditor.test.tsx` "renders an error decoration at the exact span the parser emitted".
- [x] `severity: 'info'` renders as a distinct (blue dotted) decoration — covered by "renders an info decoration with a distinct class from errors".
- [x] Hover surface — tooltip DOM exposed via `data-testid="dsl-editor-issue-tooltip"`; `renderTooltipDom` directly asserted in RTL since jsdom can't pump real pointer events through CodeMirror's hover hit-testing.

The "Recompile" button (PRD AC line 201) is intentionally deferred. It is a parent-driven concern: the button fires `onRecompile?` and the parent page calls `parseRecipeDsl`. PRD-119 — the page that wraps the editor — does not exist yet. Will land with PRD-119 or as a 120-F follow-up.

## Coordination

Strictly additive. The only pre-existing files this PR edits are `DslEditor.tsx`, `useDslEditorView.ts`, and `src/index.ts`. No conflict with the other in-flight 120 sub-PRs (autocomplete in 120-B, chips in 120-D), 122-B (its files live under `pages/data/`), 139 (its files live under `packages/app-lists/`), or 113 phase 3 (its files live under `@pops/app-food-db/seed/`). No router, migration, or i18n key touch.

Refs PRD-120 §"Error Squiggles" + AC §"Error squiggles".