### PR TITLE
feat(food): DSL editor chip widgets — @N/@slug/@time/@temperature (PRD-120 part D)

### DIFF
--- a/packages/app-food/src/components/DslEditor.stories.tsx
+++ b/packages/app-food/src/components/DslEditor.stories.tsx
@@ -1,0 +1,70 @@
+/**
+ * DslEditor stories — covers the chip-widget surface added in PRD-120 part D.
+ *
+ * `apps/pops-storybook/.storybook/main.ts` discovers stories from
+ * `packages/*\/src/**\/*.stories.@(...)`, so this file lives next to the
+ * component (same convention RecipeRenderer.stories.tsx adopted).
+ *
+ * Stories intentionally render the editor in a controlled wrapper that
+ * doesn't pump value changes back into the editor on each keystroke —
+ * the editor is the source of truth for its own document while the
+ * story is on screen. 120-F will broaden this with the empty / with-errors
+ * / with-proposed-slugs / read-only variants the PRD enumerates.
+ */
+import { useState } from 'react';
+
+import { DslEditor } from './DslEditor';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const SAMPLE = [
+  '@recipe(slug="smash-burger", title="Smash Burger", servings=2)',
+  '@yield(burger, 2:count)',
+  '@ingredient(1, chuck:ground, 300:g)',
+  '@ingredient(2, brioche-bun, 2:count)',
+  '@ingredient(3, american-cheese, 2:count)',
+  '@step("Smash @1 into thin patties on a screaming-hot pan for @time(2:min) per side at @temperature(220:c)")',
+  '@step("Melt @3 over each patty, then sandwich in @brioche-bun")',
+].join('\n');
+
+function StoryHost({
+  initialValue,
+  readOnly,
+}: {
+  initialValue: string;
+  readOnly?: boolean;
+}): JSX.Element {
+  const [value, setValue] = useState(initialValue);
+  return (
+    <div style={{ maxWidth: 720, margin: '24px auto' }}>
+      <DslEditor
+        initialValue={value}
+        readOnly={readOnly}
+        onChange={(next) => {
+          setValue(next);
+        }}
+      />
+    </div>
+  );
+}
+
+const meta: Meta<typeof StoryHost> = {
+  title: 'food/DslEditor',
+  component: StoryHost,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof StoryHost>;
+
+export const SampleRecipe: Story = {
+  args: { initialValue: SAMPLE },
+};
+
+export const ReadOnly: Story = {
+  args: { initialValue: SAMPLE, readOnly: true },
+};
+
+export const Empty: Story = {
+  args: { initialValue: '' },
+};

--- a/packages/app-food/src/components/DslEditor.stories.tsx
+++ b/packages/app-food/src/components/DslEditor.stories.tsx
@@ -36,21 +36,28 @@ function StoryHost({
 }): JSX.Element {
   const [value, setValue] = useState(initialValue);
   return (
-    <div style={{ maxWidth: 720, margin: '24px auto' }}>
-      <DslEditor
-        initialValue={value}
-        readOnly={readOnly}
-        onChange={(next) => {
-          setValue(next);
-        }}
-      />
-    </div>
+    <DslEditor
+      initialValue={value}
+      readOnly={readOnly}
+      onChange={(next) => {
+        setValue(next);
+      }}
+    />
   );
 }
 
 const meta: Meta<typeof StoryHost> = {
-  title: 'food/DslEditor',
+  title: 'Food/DslEditor',
   component: StoryHost,
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div className="mx-auto my-6 w-[720px] max-w-full">
+        <Story />
+      </div>
+    ),
+  ],
 };
 
 export default meta;

--- a/packages/app-food/src/components/__tests__/DslEditor.test.tsx
+++ b/packages/app-food/src/components/__tests__/DslEditor.test.tsx
@@ -237,6 +237,34 @@ describe('DslEditor — PRD-120 part D (chip widgets)', () => {
     expect(line.text.startsWith('@ingredient(1,')).toBe(true);
   });
 
+  it('jumps cursor when a focused chip is activated with Enter', () => {
+    render(<DslEditor initialValue={RECIPE} onChange={() => {}} />);
+    const view = getEditorView();
+    const refChip = chipsInDom().find((el) => el.getAttribute('data-chip-kind') === 'ref-index');
+    expect(refChip).toBeDefined();
+    if (!refChip) return;
+    const jumpFrom = Number.parseInt(refChip.getAttribute('data-chip-jump-from') ?? '0', 10);
+
+    act(() => {
+      fireEvent.keyDown(refChip, { key: 'Enter' });
+    });
+    expect(view.state.selection.main.head).toBe(jumpFrom);
+  });
+
+  it('jumps cursor when a focused chip is activated with Space', () => {
+    render(<DslEditor initialValue={RECIPE} onChange={() => {}} />);
+    const view = getEditorView();
+    const refChip = chipsInDom().find((el) => el.getAttribute('data-chip-kind') === 'ref-index');
+    expect(refChip).toBeDefined();
+    if (!refChip) return;
+    const jumpFrom = Number.parseInt(refChip.getAttribute('data-chip-jump-from') ?? '0', 10);
+
+    act(() => {
+      fireEvent.keyDown(refChip, { key: ' ' });
+    });
+    expect(view.state.selection.main.head).toBe(jumpFrom);
+  });
+
   it('renders chips as inline labels (no widget replacement) under mobile width', () => {
     const { setMatches } = installMatchMedia(true);
     // Confirm the helper is referenced so the lint cap on unused locals

--- a/packages/app-food/src/components/__tests__/DslEditor.test.tsx
+++ b/packages/app-food/src/components/__tests__/DslEditor.test.tsx
@@ -13,8 +13,8 @@
  * DOM. This is the same approach @codemirror/view's own test suite uses.
  */
 import { EditorView } from '@codemirror/view';
-import { act, cleanup, render, screen } from '@testing-library/react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { DslEditor } from '../DslEditor';
 
@@ -29,6 +29,36 @@ function getEditorView(): EditorView {
   const view = EditorView.findFromDOM(cmEditor as HTMLElement);
   if (!view) throw new Error('CodeMirror view not attached to surface');
   return view;
+}
+
+function installMatchMedia(matches: boolean): { setMatches: (next: boolean) => void } {
+  type Listener = (event: MediaQueryListEvent) => void;
+  const listeners = new Set<Listener>();
+  let current = matches;
+  const mql = {
+    get matches() {
+      return current;
+    },
+    media: '(max-width: 767px)',
+    onchange: null,
+    addEventListener: (_type: 'change', cb: Listener) => listeners.add(cb),
+    removeEventListener: (_type: 'change', cb: Listener) => listeners.delete(cb),
+    dispatchEvent: () => true,
+    addListener: (cb: Listener) => listeners.add(cb),
+    removeListener: (cb: Listener) => listeners.delete(cb),
+  } as unknown as MediaQueryList;
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: (_query: string) => mql,
+  });
+  return {
+    setMatches: (next: boolean) => {
+      current = next;
+      const event = { matches: next } as MediaQueryListEvent;
+      for (const cb of [...listeners]) cb(event);
+    },
+  };
 }
 
 afterEach(() => {
@@ -138,5 +168,91 @@ describe('DslEditor — PRD-120 part A', () => {
     rerender(<DslEditor initialValue="hello" onChange={() => {}} readOnly={false} />);
     expect(screen.queryByTestId('dsl-editor-readonly-banner')).toBeNull();
     expect(getEditorView().state.doc.toString()).toBe('hello');
+  });
+});
+
+describe('DslEditor — PRD-120 part D (chip widgets)', () => {
+  beforeEach(() => {
+    installMatchMedia(false);
+  });
+
+  const RECIPE = [
+    '@recipe(slug="x", title="X")',
+    '@yield(x, 1:count)',
+    '@ingredient(1, banana:raw, 100:g)',
+    '@ingredient(2, flour, 200:g)',
+    '@step("Mash the @1 and add @cilantro for @time(20:min) at @temperature(180:c)")',
+  ].join('\n');
+
+  function chipsInDom(): HTMLElement[] {
+    return Array.from(document.querySelectorAll<HTMLElement>('.cm-dsl-chip'));
+  }
+
+  it('renders a chip widget for each @N ref inside a @step body', () => {
+    render(<DslEditor initialValue={RECIPE} onChange={() => {}} />);
+    const refChips = chipsInDom().filter((el) => el.getAttribute('data-chip-kind') === 'ref-index');
+    expect(refChips).toHaveLength(1);
+    expect(refChips[0]?.textContent).toContain('#1');
+    expect(refChips[0]?.textContent).toContain('banana');
+  });
+
+  it('renders a chip for @slug refs in step bodies', () => {
+    render(<DslEditor initialValue={RECIPE} onChange={() => {}} />);
+    const slugChips = chipsInDom().filter((el) => el.getAttribute('data-chip-kind') === 'ref-slug');
+    expect(slugChips).toHaveLength(1);
+    expect(slugChips[0]?.textContent).toBe('cilantro');
+  });
+
+  it('renders @time(20:min) as a pill labeled "20 min"', () => {
+    render(<DslEditor initialValue={RECIPE} onChange={() => {}} />);
+    const time = chipsInDom().find((el) => el.getAttribute('data-chip-kind') === 'time');
+    expect(time).toBeDefined();
+    expect(time?.textContent).toBe('20 min');
+  });
+
+  it('renders @temperature(180:c) as a pill labeled "180 °C"', () => {
+    render(<DslEditor initialValue={RECIPE} onChange={() => {}} />);
+    const temp = chipsInDom().find((el) => el.getAttribute('data-chip-kind') === 'temperature');
+    expect(temp).toBeDefined();
+    expect(temp?.textContent).toBe('180 °C');
+  });
+
+  it('jumps cursor to matching @ingredient declaration on chip click', () => {
+    render(<DslEditor initialValue={RECIPE} onChange={() => {}} />);
+    const view = getEditorView();
+    const refChip = chipsInDom().find((el) => el.getAttribute('data-chip-kind') === 'ref-index');
+    expect(refChip).toBeDefined();
+    const jumpFrom = refChip?.getAttribute('data-chip-jump-from');
+    expect(jumpFrom).toBeTruthy();
+
+    act(() => {
+      if (refChip) fireEvent.click(refChip);
+    });
+
+    const cursor = view.state.selection.main.head;
+    expect(cursor).toBe(Number.parseInt(jumpFrom ?? '0', 10));
+    // The expected offset is the `@` of `@ingredient(1, ...)` — the third
+    // line in the document.
+    const line = view.state.doc.lineAt(cursor);
+    expect(line.text.startsWith('@ingredient(1,')).toBe(true);
+  });
+
+  it('renders chips as inline labels (no widget replacement) under mobile width', () => {
+    const { setMatches } = installMatchMedia(true);
+    // Confirm the helper is referenced so the lint cap on unused locals
+    // doesn't fire — also gives us a no-op handle for follow-on tests.
+    void setMatches;
+    render(<DslEditor initialValue={RECIPE} onChange={() => {}} />);
+    const view = getEditorView();
+    // In compact mode the chip ranges are `Decoration.mark` so the underlying
+    // source characters (`@1`, `@cilantro`, `@time(20:min)`,
+    // `@temperature(180:c)`) are still present in the contentDOM text. The
+    // desktop variant would replace those ranges with widgets, hiding the raw
+    // characters.
+    const rendered = view.contentDOM.textContent ?? '';
+    expect(rendered).toContain('@1');
+    expect(rendered).toContain('@cilantro');
+    expect(rendered).toContain('@time(20:min)');
+    expect(rendered).toContain('@temperature(180:c)');
   });
 });

--- a/packages/app-food/src/components/dsl-editor/__tests__/chip-scanner.test.ts
+++ b/packages/app-food/src/components/dsl-editor/__tests__/chip-scanner.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Unit tests for the chip scanner (PRD-120 part D).
+ *
+ * Pure function — no DOM, no CodeMirror. Each case asserts on the chip
+ * offsets and the `index → declaration` map directly.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { scanForChips } from '../chip-scanner';
+
+function snippet(text: string, from: number, to: number): string {
+  return text.slice(from, to);
+}
+
+describe('scanForChips', () => {
+  it('returns no chips for a document without @step bodies', () => {
+    const source = '@recipe(slug="x", title="X")\n@yield(x, 1:count)\n';
+    const result = scanForChips(source);
+    expect(result.chips).toEqual([]);
+    expect(result.declarations.size).toBe(0);
+  });
+
+  it('builds an index → declaration map from @ingredient calls', () => {
+    const source = [
+      '@recipe(slug="x", title="X")',
+      '@yield(x, 1:count)',
+      '@ingredient(1, banana:raw, 100:g)',
+      '@ingredient(2, flank:braised:shredded, 200:g)',
+    ].join('\n');
+    const result = scanForChips(source);
+    expect(result.declarations.get(1)).toMatchObject({ index: 1, slug: 'banana', variant: 'raw' });
+    expect(result.declarations.get(2)).toMatchObject({
+      index: 2,
+      slug: 'flank',
+      variant: 'braised',
+      prep: 'shredded',
+    });
+  });
+
+  it('detects @N index refs inside step bodies', () => {
+    const source = '@step("Mash the @1 in a bowl")';
+    const result = scanForChips(source);
+    expect(result.chips).toHaveLength(1);
+    const chip = result.chips[0];
+    expect(chip?.kind).toBe('ref-index');
+    if (chip?.kind === 'ref-index') {
+      expect(chip.index).toBe(1);
+      expect(snippet(source, chip.from, chip.to)).toBe('@1');
+    }
+  });
+
+  it('detects @slug refs inside step bodies', () => {
+    const source = '@step("Garnish with @cilantro and stir")';
+    const result = scanForChips(source);
+    const slug = result.chips.find((c) => c.kind === 'ref-slug');
+    expect(slug?.kind).toBe('ref-slug');
+    if (slug?.kind === 'ref-slug') {
+      expect(slug.slug).toBe('cilantro');
+      expect(snippet(source, slug.from, slug.to)).toBe('@cilantro');
+    }
+  });
+
+  it('detects @time and @temperature calls inside step bodies', () => {
+    const source = '@step("Rest @time(20:min) at @temperature(180:c)")';
+    const result = scanForChips(source);
+    const time = result.chips.find((c) => c.kind === 'time');
+    const temp = result.chips.find((c) => c.kind === 'temperature');
+    expect(time?.kind).toBe('time');
+    expect(temp?.kind).toBe('temperature');
+    if (time?.kind === 'time') {
+      expect(time.qty).toBe(20);
+      expect(time.unit).toBe('min');
+      expect(snippet(source, time.from, time.to)).toBe('@time(20:min)');
+    }
+    if (temp?.kind === 'temperature') {
+      expect(temp.qty).toBe(180);
+      expect(temp.unit).toBe('c');
+    }
+  });
+
+  it('does NOT match @N or @slug outside @step bodies', () => {
+    const source = '@ingredient(1, banana:raw, 100:g)\n@2 something\n@apple';
+    const result = scanForChips(source);
+    expect(result.chips).toEqual([]);
+  });
+
+  it('handles escaped quotes inside the step body string', () => {
+    const source = '@step("Quote \\"@1\\" mid-string then @2 ends")';
+    const result = scanForChips(source);
+    const indexes = result.chips.filter((c) => c.kind === 'ref-index');
+    expect(indexes).toHaveLength(2);
+    expect(indexes.map((c) => (c.kind === 'ref-index' ? c.index : -1))).toEqual([1, 2]);
+  });
+
+  it('survives unterminated @step body without throwing', () => {
+    const source = '@step("Mash the @1 in a bowl'; // missing closing quote
+    expect(() => scanForChips(source)).not.toThrow();
+    expect(scanForChips(source).chips).toEqual([]);
+  });
+
+  it('records callStart at the @ character of @ingredient declarations', () => {
+    const source = 'prologue\n@ingredient(1, banana:raw, 100:g)\n';
+    const result = scanForChips(source);
+    const decl = result.declarations.get(1);
+    expect(decl).toBeDefined();
+    if (decl) {
+      expect(source[decl.callStart]).toBe('@');
+      expect(source.slice(decl.callStart, decl.callStart + 11)).toBe('@ingredient');
+    }
+  });
+
+  it('ignores @<func>( whose name is not in the inline-func allow-list', () => {
+    const source = '@step("Skip @notafunc(1:g) but keep @time(5:min)")';
+    const result = scanForChips(source);
+    const time = result.chips.find((c) => c.kind === 'time');
+    const slugs = result.chips.filter((c) => c.kind === 'ref-slug');
+    expect(time).toBeDefined();
+    // `notafunc` should not produce a slug chip — the scanner consumes the
+    // `(...)` block so it doesn't degrade into a partial slug match either.
+    expect(slugs).toHaveLength(0);
+  });
+});

--- a/packages/app-food/src/components/dsl-editor/__tests__/chip-scanner.test.ts
+++ b/packages/app-food/src/components/dsl-editor/__tests__/chip-scanner.test.ts
@@ -109,6 +109,16 @@ describe('scanForChips', () => {
     }
   });
 
+  it('suppresses false-positive chips inside an unterminated unknown @func( call', () => {
+    // Mid-edit case: user typed `@bad(` and the paren never closes inside
+    // the step body. The scanner must not still emit chips for `@1` or
+    // `@cilantro` that fall inside the unterminated call's text.
+    const source = '@step("Use @bad(@1 and @cilantro never closes")';
+    const result = scanForChips(source);
+    expect(result.chips.filter((c) => c.kind === 'ref-index')).toHaveLength(0);
+    expect(result.chips.filter((c) => c.kind === 'ref-slug')).toHaveLength(0);
+  });
+
   it('ignores @<func>( whose name is not in the inline-func allow-list', () => {
     const source = '@step("Skip @notafunc(1:g) but keep @time(5:min)")';
     const result = scanForChips(source);

--- a/packages/app-food/src/components/dsl-editor/chip-scanner-step-body.ts
+++ b/packages/app-food/src/components/dsl-editor/chip-scanner-step-body.ts
@@ -1,0 +1,102 @@
+/**
+ * Step-body chip extraction (PRD-120 part D).
+ *
+ * Extracted from `chip-scanner.ts` to keep both files under the per-file
+ * line cap. The functions here walk the *interior* of a single
+ * `@step("...")` body and emit chip ranges for `@N`, `@slug`,
+ * `@time(qty:unit)`, and `@temperature(qty:unit)`. The outer scanner owns
+ * step-body detection, escape-aware string termination, and the parallel
+ * `@ingredient(N, ...)` sweep.
+ */
+import type { Chip } from './chip-scanner-types';
+
+const DIGIT = /[0-9]/;
+const SLUG_START = /[a-z]/;
+const SLUG_CONT = /[a-z0-9-]/;
+const INLINE_FUNCS = new Set(['time', 'temperature']);
+
+export function collectStepBodyChips(
+  source: string,
+  start: number,
+  end: number,
+  out: Chip[]
+): void {
+  let i = start;
+  while (i < end) {
+    if (source[i] !== '@') {
+      i += 1;
+      continue;
+    }
+    const next = source[i + 1] ?? '';
+    if (DIGIT.test(next)) {
+      const digits = readWhile(source, i + 1, DIGIT);
+      out.push({
+        kind: 'ref-index',
+        index: Number.parseInt(digits, 10),
+        from: i,
+        to: i + 1 + digits.length,
+      });
+      i += 1 + digits.length;
+      continue;
+    }
+    if (SLUG_START.test(next)) {
+      i = handleSlugOrFunc(source, i, end, out);
+      continue;
+    }
+    i += 1;
+  }
+}
+
+function handleSlugOrFunc(source: string, at: number, end: number, out: Chip[]): number {
+  const name = readIdentifierAt(source, at + 1);
+  if (name === null) return at + 1;
+  const afterName = at + 1 + name.length;
+  if (source[afterName] !== '(') {
+    out.push({ kind: 'ref-slug', slug: name, from: at, to: afterName });
+    return afterName;
+  }
+  // Slug followed by `(` is treated as an inline function. Only `@time`
+  // and `@temperature` are recognised (matches PRD-114's parser, which
+  // emits `BadInline` for any other identifier). For unknown functions,
+  // skip the whole `name(...)` span without emitting any chip.
+  if (!INLINE_FUNCS.has(name)) {
+    const close = source.indexOf(')', afterName + 1);
+    return close === -1 || close >= end ? afterName : close + 1;
+  }
+  const close = source.indexOf(')', afterName + 1);
+  if (close === -1 || close >= end) return afterName;
+  const inner = source.slice(afterName + 1, close);
+  const qu = parseInlineQtyUnit(inner);
+  if (qu === null) return close + 1;
+  out.push({
+    kind: name === 'time' ? 'time' : 'temperature',
+    qty: qu.qty,
+    unit: qu.unit,
+    from: at,
+    to: close + 1,
+  });
+  return close + 1;
+}
+
+function parseInlineQtyUnit(input: string): { qty: number; unit: string } | null {
+  const colon = input.indexOf(':');
+  if (colon === -1) return null;
+  const qty = Number(input.slice(0, colon).trim());
+  if (!Number.isFinite(qty)) return null;
+  const unit = input.slice(colon + 1).trim();
+  if (unit === '' || !SLUG_START.test(unit[0] ?? '')) return null;
+  for (const ch of unit) if (!SLUG_CONT.test(ch)) return null;
+  return { qty, unit };
+}
+
+function readIdentifierAt(source: string, start: number): string | null {
+  if (start >= source.length) return null;
+  if (!SLUG_START.test(source[start] ?? '')) return null;
+  return readWhile(source, start, SLUG_CONT);
+}
+
+function readWhile(source: string, start: number, pattern: RegExp): string {
+  let i = start;
+  while (i < source.length && pattern.test(source[i] ?? '')) i += 1;
+  return source.slice(start, i);
+}

--- a/packages/app-food/src/components/dsl-editor/chip-scanner-step-body.ts
+++ b/packages/app-food/src/components/dsl-editor/chip-scanner-step-body.ts
@@ -58,13 +58,16 @@ function handleSlugOrFunc(source: string, at: number, end: number, out: Chip[]):
   // Slug followed by `(` is treated as an inline function. Only `@time`
   // and `@temperature` are recognised (matches PRD-114's parser, which
   // emits `BadInline` for any other identifier). For unknown functions,
-  // skip the whole `name(...)` span without emitting any chip.
+  // skip the whole `name(...)` span without emitting any chip. When the
+  // closing `)` is missing (common mid-edit), advance past the body's
+  // end so subsequent scanning doesn't fire false-positive chips on
+  // tokens that belong to the unterminated call's argument text.
   if (!INLINE_FUNCS.has(name)) {
     const close = source.indexOf(')', afterName + 1);
-    return close === -1 || close >= end ? afterName : close + 1;
+    return close === -1 || close >= end ? end : close + 1;
   }
   const close = source.indexOf(')', afterName + 1);
-  if (close === -1 || close >= end) return afterName;
+  if (close === -1 || close >= end) return end;
   const inner = source.slice(afterName + 1, close);
   const qu = parseInlineQtyUnit(inner);
   if (qu === null) return close + 1;

--- a/packages/app-food/src/components/dsl-editor/chip-scanner-types.ts
+++ b/packages/app-food/src/components/dsl-editor/chip-scanner-types.ts
@@ -1,0 +1,46 @@
+/**
+ * Public types for the DSL chip scanner (PRD-120 part D).
+ *
+ * `Chip` is a single in-body decoration target with absolute document
+ * offsets. `IngredientDeclaration` is the per-index lookup entry used to
+ * resolve `@N` chip labels and click-jump targets.
+ */
+export type Chip = RefIndexChip | RefSlugChip | InlineFuncChip;
+
+interface BaseChip {
+  /** Absolute document offset (inclusive). */
+  from: number;
+  /** Absolute document offset (exclusive). */
+  to: number;
+}
+
+export interface RefIndexChip extends BaseChip {
+  kind: 'ref-index';
+  index: number;
+}
+
+export interface RefSlugChip extends BaseChip {
+  kind: 'ref-slug';
+  slug: string;
+}
+
+export interface InlineFuncChip extends BaseChip {
+  kind: 'time' | 'temperature';
+  qty: number;
+  unit: string;
+}
+
+export interface IngredientDeclaration {
+  index: number;
+  slug: string;
+  variant?: string;
+  prep?: string;
+  /** Document offset where the `@ingredient(` call starts — used as a
+   * click-jump target so the cursor lands at the `@`. */
+  callStart: number;
+}
+
+export interface ChipScanResult {
+  chips: Chip[];
+  declarations: Map<number, IngredientDeclaration>;
+}

--- a/packages/app-food/src/components/dsl-editor/chip-scanner.ts
+++ b/packages/app-food/src/components/dsl-editor/chip-scanner.ts
@@ -1,0 +1,178 @@
+/**
+ * Self-contained source scanner for the DSL editor's chip widgets (PRD-120
+ * part D).
+ *
+ * The chip extension cannot use PRD-114's AST: `parseRecipeDsl` returns
+ * `{ ok: false, errors }` with NO ast on any parse failure, and the user is
+ * constantly producing partial documents while typing. `StepBodyPart` also
+ * carries no `SourceSpan` for inline refs, so even a successful parse
+ * wouldn't supply chip offsets.
+ *
+ * Instead this scanner walks the text linearly:
+ *
+ *   - Recognises `@step("...")` bodies (escape-aware string termination on
+ *     `\\` / `\"`) so the chip ranges stay scoped to step bodies and never
+ *     leak into top-level markdown or `@ingredient(N, ...)` declarations.
+ *   - Inside a body, delegates to `chip-scanner-step-body.ts` which emits
+ *     ranges for `@N`, `@slug`, `@time(qty:unit)`, and
+ *     `@temperature(qty:unit)`.
+ *   - In a parallel sweep over the whole source, recognises
+ *     `@ingredient(N, <descriptor>` calls and builds an
+ *     `index → { slug, variant?, prep? }` map plus the offset where each
+ *     `@ingredient(` call starts (used as a click-jump target).
+ *
+ * Pure — no React, no CodeMirror types, no DOM.
+ */
+import { collectStepBodyChips } from './chip-scanner-step-body';
+
+import type { Chip, ChipScanResult, IngredientDeclaration } from './chip-scanner-types';
+
+const SLUG_START = /[a-z]/;
+const SLUG_CONT = /[a-z0-9-]/;
+const DIGIT = /[0-9]/;
+
+export function scanForChips(source: string): ChipScanResult {
+  const chips: Chip[] = [];
+  const declarations = new Map<number, IngredientDeclaration>();
+  let i = 0;
+  while (i < source.length) {
+    if (source[i] !== '@') {
+      i += 1;
+      continue;
+    }
+    const next = scanAtToken(source, i);
+    if (next.kind === 'step') collectStepBodyChips(source, next.bodyStart, next.bodyEnd, chips);
+    else if (next.kind === 'ingredient') declarations.set(next.declaration.index, next.declaration);
+    i = next.endOffset;
+  }
+  return { chips, declarations };
+}
+
+type AtScan =
+  | { kind: 'step'; bodyStart: number; bodyEnd: number; endOffset: number }
+  | { kind: 'ingredient'; declaration: IngredientDeclaration; endOffset: number }
+  | { kind: 'other'; endOffset: number };
+
+function scanAtToken(source: string, at: number): AtScan {
+  const name = readIdentifierAt(source, at + 1);
+  if (name === null) return { kind: 'other', endOffset: at + 1 };
+  const afterName = at + 1 + name.length;
+  const openParen = skipWhitespace(source, afterName);
+  if (source[openParen] !== '(') return { kind: 'other', endOffset: afterName };
+  if (name === 'step') return scanStepCall(source, openParen);
+  if (name === 'ingredient') return scanIngredientCall(source, at, openParen);
+  const close = findMatchingClose(source, openParen);
+  return { kind: 'other', endOffset: close === -1 ? source.length : close + 1 };
+}
+
+function scanStepCall(source: string, openParen: number): AtScan {
+  const quote = skipWhitespace(source, openParen + 1);
+  if (source[quote] !== '"') {
+    const close = findMatchingClose(source, openParen);
+    return { kind: 'other', endOffset: close === -1 ? source.length : close + 1 };
+  }
+  const bodyStart = quote + 1;
+  const bodyEnd = findStringClose(source, bodyStart);
+  if (bodyEnd === -1) return { kind: 'other', endOffset: source.length };
+  const callClose = findMatchingClose(source, openParen);
+  const endOffset = callClose === -1 ? bodyEnd + 1 : callClose + 1;
+  return { kind: 'step', bodyStart, bodyEnd, endOffset };
+}
+
+function scanIngredientCall(source: string, at: number, openParen: number): AtScan {
+  const close = findMatchingClose(source, openParen);
+  const endOffset = close === -1 ? source.length : close + 1;
+  const idxStart = skipWhitespace(source, openParen + 1);
+  const idxText = readWhile(source, idxStart, DIGIT);
+  if (idxText === '') return { kind: 'other', endOffset };
+  const afterIdx = skipWhitespace(source, idxStart + idxText.length);
+  if (source[afterIdx] !== ',') return { kind: 'other', endOffset };
+  const slugStart = skipWhitespace(source, afterIdx + 1);
+  const descriptor = readDescriptor(source, slugStart);
+  if (descriptor === null) return { kind: 'other', endOffset };
+  const declaration: IngredientDeclaration = {
+    index: Number.parseInt(idxText, 10),
+    slug: descriptor.slug,
+    variant: descriptor.variant,
+    prep: descriptor.prep,
+    callStart: at,
+  };
+  return { kind: 'ingredient', declaration, endOffset };
+}
+
+function readDescriptor(
+  source: string,
+  start: number
+): { slug: string; variant?: string; prep?: string } | null {
+  const slug = readWhile(source, start, SLUG_CONT);
+  if (slug === '' || !SLUG_START.test(slug[0] ?? '')) return null;
+  let cursor = start + slug.length;
+  const parts: (string | undefined)[] = [];
+  for (let n = 0; n < 2; n += 1) {
+    if (source[cursor] !== ':') break;
+    cursor += 1;
+    if (source[cursor] === '_') {
+      parts.push(undefined);
+      cursor += 1;
+      continue;
+    }
+    const next = readWhile(source, cursor, SLUG_CONT);
+    if (next === '') break;
+    parts.push(next);
+    cursor += next.length;
+  }
+  return { slug, variant: parts[0], prep: parts[1] };
+}
+
+function readIdentifierAt(source: string, start: number): string | null {
+  if (start >= source.length) return null;
+  if (!SLUG_START.test(source[start] ?? '')) return null;
+  return readWhile(source, start, SLUG_CONT);
+}
+
+function readWhile(source: string, start: number, pattern: RegExp): string {
+  let i = start;
+  while (i < source.length && pattern.test(source[i] ?? '')) i += 1;
+  return source.slice(start, i);
+}
+
+function skipWhitespace(source: string, start: number): number {
+  let i = start;
+  while (i < source.length && /\s/.test(source[i] ?? '')) i += 1;
+  return i;
+}
+
+function findStringClose(source: string, bodyStart: number): number {
+  let i = bodyStart;
+  while (i < source.length) {
+    const ch = source[i];
+    if (ch === '\\') {
+      i += 2;
+      continue;
+    }
+    if (ch === '"') return i;
+    i += 1;
+  }
+  return -1;
+}
+
+function findMatchingClose(source: string, openParen: number): number {
+  let depth = 0;
+  let i = openParen;
+  while (i < source.length) {
+    const ch = source[i];
+    if (ch === '"') {
+      const close = findStringClose(source, i + 1);
+      if (close === -1) return -1;
+      i = close + 1;
+      continue;
+    }
+    if (ch === '(') depth += 1;
+    else if (ch === ')') {
+      depth -= 1;
+      if (depth === 0) return i;
+    }
+    i += 1;
+  }
+  return -1;
+}

--- a/packages/app-food/src/components/dsl-editor/chip-widgets-extension.ts
+++ b/packages/app-food/src/components/dsl-editor/chip-widgets-extension.ts
@@ -143,33 +143,54 @@ function formatPillLabel(chip: InlineFuncChip): string {
 }
 
 /**
- * Click routing for chip widgets. Implemented as a `ViewPlugin` that
- * attaches a `click` listener directly to `view.contentDOM`. We tried
- * `EditorView.domEventHandlers({ click })` first, but its event-routing
- * pipeline doesn't fire reliably for synthetic clicks on widget DOM in
- * jsdom — attaching directly to `contentDOM` bypasses that and lets the
- * tests drive the chip via `fireEvent.click`.
+ * Click + keyboard activation routing for chip widgets. Implemented as a
+ * `ViewPlugin` that attaches listeners directly to `view.contentDOM`. We
+ * tried `EditorView.domEventHandlers({ click })` first, but its
+ * event-routing pipeline doesn't fire reliably for synthetic clicks on
+ * widget DOM in jsdom — attaching directly to `contentDOM` bypasses that
+ * and lets the tests drive the chip via `fireEvent.click`. The keydown
+ * handler covers Enter/Space so chips stay reachable via Tab → activate,
+ * which the PRD calls out as an accessibility requirement.
  */
+function jumpToFromChip(chip: HTMLElement, view: EditorView): boolean {
+  const raw = chip.getAttribute('data-chip-jump-from');
+  if (raw === null) return false;
+  const jumpTo = Number.parseInt(raw, 10);
+  if (!Number.isFinite(jumpTo)) return false;
+  view.dispatch({
+    selection: EditorSelection.cursor(Math.min(jumpTo, view.state.doc.length)),
+    scrollIntoView: true,
+  });
+  view.focus();
+  return true;
+}
+
 const clickHandler = ViewPlugin.define((view) => {
-  const handle = (event: MouseEvent): void => {
+  const onClick = (event: MouseEvent): void => {
     const target = event.target;
     if (!(target instanceof Element)) return;
     const chip = target.closest('[data-chip-jump-from]');
     if (!(chip instanceof HTMLElement)) return;
-    const raw = chip.getAttribute('data-chip-jump-from');
-    if (raw === null) return;
-    const jumpTo = Number.parseInt(raw, 10);
-    if (!Number.isFinite(jumpTo)) return;
-    view.dispatch({
-      selection: EditorSelection.cursor(Math.min(jumpTo, view.state.doc.length)),
-      scrollIntoView: true,
-    });
-    view.focus();
-    event.preventDefault();
+    if (jumpToFromChip(chip, view)) event.preventDefault();
   };
-  view.contentDOM.addEventListener('click', handle);
+  const onKeyDown = (event: KeyboardEvent): void => {
+    if (event.key !== 'Enter' && event.key !== ' ' && event.key !== 'Spacebar') return;
+    const target = event.target;
+    if (!(target instanceof Element)) return;
+    const chip = target.closest('[data-chip-jump-from]');
+    if (!(chip instanceof HTMLElement)) return;
+    if (jumpToFromChip(chip, view)) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+  };
+  view.contentDOM.addEventListener('click', onClick);
+  view.contentDOM.addEventListener('keydown', onKeyDown);
   return {
-    destroy: () => view.contentDOM.removeEventListener('click', handle),
+    destroy: () => {
+      view.contentDOM.removeEventListener('click', onClick);
+      view.contentDOM.removeEventListener('keydown', onKeyDown);
+    },
   };
 });
 
@@ -199,6 +220,11 @@ const theme = EditorView.baseTheme({
     borderRadius: 0,
     background: 'transparent',
     textDecoration: 'underline dotted',
+  },
+  '.cm-dsl-chip--jump': { cursor: 'pointer' },
+  '.cm-dsl-chip--jump:focus-visible': {
+    outline: '2px solid var(--cm-dsl-chip-focus, #2563eb)',
+    outlineOffset: '1px',
   },
 });
 

--- a/packages/app-food/src/components/dsl-editor/chip-widgets-extension.ts
+++ b/packages/app-food/src/components/dsl-editor/chip-widgets-extension.ts
@@ -1,0 +1,218 @@
+/**
+ * CodeMirror extension wiring for the DSL chip widgets (PRD-120 part D).
+ *
+ * Two visual modes selected by the caller:
+ *
+ *   - `chipWidgetsExtension({ compact: false })` — replaces each chip range
+ *     with a `WidgetType` (the default desktop behaviour).
+ *   - `chipWidgetsExtension({ compact: true })` — uses `Decoration.mark`
+ *     instead so the source characters stay visible. PRD-120 calls this out
+ *     for mobile widths (<768px): widget replacement shrinks tap targets
+ *     dangerously, so on mobile the chip becomes an inline label that
+ *     simply colours the source range.
+ *
+ * The matchMedia → compartment dance that picks between the two lives in
+ * `useDslEditorView.ts`; this module just builds the extension array.
+ */
+import { EditorSelection, StateField } from '@codemirror/state';
+import { Decoration, EditorView, ViewPlugin, type DecorationSet } from '@codemirror/view';
+
+import { scanForChips } from './chip-scanner';
+import { InlineFuncPillWidget, RefIndexChipWidget, RefSlugChipWidget } from './chip-widgets';
+
+import type { EditorState } from '@codemirror/state';
+
+import type {
+  Chip,
+  ChipScanResult,
+  IngredientDeclaration,
+  InlineFuncChip,
+  RefIndexChip,
+  RefSlugChip,
+} from './chip-scanner-types';
+
+export interface ChipWidgetsOptions {
+  /** Mobile fallback — use `Decoration.mark` instead of widget replacement. */
+  compact?: boolean;
+}
+
+function buildDecorations(state: EditorState, compact: boolean): DecorationSet {
+  const scan = scanForChips(state.doc.toString());
+  const ranges = scan.chips.map((chip) => decorationFor(chip, scan.declarations, compact));
+  ranges.sort((a, b) => a.from - b.from || a.value.startSide - b.value.startSide);
+  return Decoration.set(ranges, true);
+}
+
+function decorationFor(
+  chip: Chip,
+  declarations: ChipScanResult['declarations'],
+  compact: boolean
+): { from: number; to: number; value: Decoration } {
+  if (chip.kind === 'ref-index') return decorationForRefIndex(chip, declarations, compact);
+  if (chip.kind === 'ref-slug') return decorationForRefSlug(chip, compact);
+  return decorationForInlineFunc(chip, compact);
+}
+
+function decorationForRefIndex(
+  chip: RefIndexChip,
+  declarations: ChipScanResult['declarations'],
+  compact: boolean
+): { from: number; to: number; value: Decoration } {
+  const decl = declarations.get(chip.index);
+  const label = decl ? labelFor(decl) : `@${chip.index}`;
+  const jumpFrom = decl?.callStart ?? null;
+  const value = compact
+    ? Decoration.mark({
+        class: classFor('ref-index', !decl),
+        attributes: jumpAttrs('ref-index', jumpFrom, !decl),
+      })
+    : Decoration.replace({
+        widget: new RefIndexChipWidget({
+          index: chip.index,
+          label,
+          title: titleFor(decl, `@${chip.index}`),
+          jumpFrom,
+          hasError: !decl,
+        }),
+      });
+  return { from: chip.from, to: chip.to, value };
+}
+
+function decorationForRefSlug(
+  chip: RefSlugChip,
+  compact: boolean
+): { from: number; to: number; value: Decoration } {
+  const value = compact
+    ? Decoration.mark({
+        class: classFor('ref-slug', false),
+        attributes: jumpAttrs('ref-slug', null, false),
+      })
+    : Decoration.replace({
+        widget: new RefSlugChipWidget({ slug: chip.slug, title: chip.slug, jumpFrom: null }),
+      });
+  return { from: chip.from, to: chip.to, value };
+}
+
+function decorationForInlineFunc(
+  chip: InlineFuncChip,
+  compact: boolean
+): { from: number; to: number; value: Decoration } {
+  const label = formatPillLabel(chip);
+  const value = compact
+    ? Decoration.mark({ class: `cm-dsl-chip cm-dsl-chip--inline cm-dsl-chip--${chip.kind}` })
+    : Decoration.replace({ widget: new InlineFuncPillWidget({ kind: chip.kind, label }) });
+  return { from: chip.from, to: chip.to, value };
+}
+
+function labelFor(decl: IngredientDeclaration): string {
+  if (decl.variant) return `${decl.slug}:${decl.variant}`;
+  return decl.slug;
+}
+
+function titleFor(decl: IngredientDeclaration | undefined, fallback: string): string {
+  if (!decl) return fallback;
+  return [decl.slug, decl.variant, decl.prep].filter((p): p is string => Boolean(p)).join(':');
+}
+
+function classFor(kind: 'ref-index' | 'ref-slug', hasError: boolean): string {
+  return `cm-dsl-chip cm-dsl-chip--inline cm-dsl-chip--${kind}${
+    hasError ? ' cm-dsl-chip--error' : ''
+  }`;
+}
+
+function jumpAttrs(
+  kind: 'ref-index' | 'ref-slug',
+  jumpFrom: number | null,
+  hasError: boolean
+): Record<string, string> {
+  const attrs: Record<string, string> = { 'data-chip-kind': kind };
+  if (jumpFrom !== null) {
+    attrs['data-chip-jump-from'] = String(jumpFrom);
+    attrs.role = 'button';
+    attrs.tabindex = '0';
+  }
+  if (hasError) attrs['data-chip-error'] = 'true';
+  return attrs;
+}
+
+function formatPillLabel(chip: InlineFuncChip): string {
+  if (chip.kind === 'time') return `${chip.qty} ${chip.unit}`;
+  const unit = chip.unit.toLowerCase();
+  if (unit === 'c' || unit === 'f') return `${chip.qty} °${unit.toUpperCase()}`;
+  return `${chip.qty} ${chip.unit}`;
+}
+
+/**
+ * Click routing for chip widgets. Implemented as a `ViewPlugin` that
+ * attaches a `click` listener directly to `view.contentDOM`. We tried
+ * `EditorView.domEventHandlers({ click })` first, but its event-routing
+ * pipeline doesn't fire reliably for synthetic clicks on widget DOM in
+ * jsdom — attaching directly to `contentDOM` bypasses that and lets the
+ * tests drive the chip via `fireEvent.click`.
+ */
+const clickHandler = ViewPlugin.define((view) => {
+  const handle = (event: MouseEvent): void => {
+    const target = event.target;
+    if (!(target instanceof Element)) return;
+    const chip = target.closest('[data-chip-jump-from]');
+    if (!(chip instanceof HTMLElement)) return;
+    const raw = chip.getAttribute('data-chip-jump-from');
+    if (raw === null) return;
+    const jumpTo = Number.parseInt(raw, 10);
+    if (!Number.isFinite(jumpTo)) return;
+    view.dispatch({
+      selection: EditorSelection.cursor(Math.min(jumpTo, view.state.doc.length)),
+      scrollIntoView: true,
+    });
+    view.focus();
+    event.preventDefault();
+  };
+  view.contentDOM.addEventListener('click', handle);
+  return {
+    destroy: () => view.contentDOM.removeEventListener('click', handle),
+  };
+});
+
+const theme = EditorView.baseTheme({
+  '.cm-dsl-chip': {
+    display: 'inline-flex',
+    alignItems: 'center',
+    padding: '0 6px',
+    margin: '0 1px',
+    borderRadius: '999px',
+    fontSize: '0.85em',
+    border: '1px solid var(--cm-dsl-chip-border, #d4d4d8)',
+    background: 'var(--cm-dsl-chip-bg, #f4f4f5)',
+    color: 'var(--cm-dsl-chip-fg, #18181b)',
+  },
+  '.cm-dsl-chip--ref-index': { background: 'var(--cm-dsl-chip-bg-ref, #e0f2fe)' },
+  '.cm-dsl-chip--ref-slug': { background: 'var(--cm-dsl-chip-bg-slug, #ecfdf5)' },
+  '.cm-dsl-chip--time': { background: 'var(--cm-dsl-chip-bg-time, #fef3c7)' },
+  '.cm-dsl-chip--temperature': { background: 'var(--cm-dsl-chip-bg-temp, #fee2e2)' },
+  '.cm-dsl-chip--error': {
+    background: 'var(--cm-dsl-chip-bg-error, #fecaca)',
+    color: 'var(--cm-dsl-chip-fg-error, #7f1d1d)',
+  },
+  '.cm-dsl-chip--inline': {
+    padding: '0 2px',
+    border: 'none',
+    borderRadius: 0,
+    background: 'transparent',
+    textDecoration: 'underline dotted',
+  },
+});
+
+export function chipWidgetsExtension(options: ChipWidgetsOptions = {}) {
+  const compact = options.compact === true;
+  const field = StateField.define<DecorationSet>({
+    create: (state) => buildDecorations(state, compact),
+    update(value, tr) {
+      if (tr.docChanged) return buildDecorations(tr.state, compact);
+      return value.map(tr.changes);
+    },
+    provide: (f) => EditorView.decorations.from(f),
+  });
+  return [field, clickHandler, theme];
+}
+
+export type { Chip, ChipScanResult, IngredientDeclaration } from './chip-scanner-types';

--- a/packages/app-food/src/components/dsl-editor/chip-widgets.ts
+++ b/packages/app-food/src/components/dsl-editor/chip-widgets.ts
@@ -1,0 +1,133 @@
+/**
+ * `WidgetType` subclasses rendered by the chip extension (PRD-120 part D).
+ *
+ * Each widget produces a small inline DOM element that replaces (or marks)
+ * the source range while keeping the document text intact — the user can
+ * still cursor through, and copy/paste preserves the raw `@N` / `@slug` /
+ * `@time(...)` / `@temperature(...)` source.
+ *
+ * Click handling lives outside the widget instances. The chip-widgets
+ * extension installs a single `EditorView.domEventHandlers.click` that
+ * walks up from the event target, reads the `data-chip-jump-from` attribute,
+ * and dispatches an `EditorSelection.cursor(...)` transaction. Keeping the
+ * dispatch out of the widget means the widget doesn't need to capture the
+ * EditorView in its constructor (which would defeat WidgetType reuse).
+ */
+import { WidgetType } from '@codemirror/view';
+
+export class RefIndexChipWidget extends WidgetType {
+  readonly index: number;
+  readonly label: string;
+  readonly title: string;
+  readonly jumpFrom: number | null;
+  readonly hasError: boolean;
+
+  constructor(args: {
+    index: number;
+    label: string;
+    title: string;
+    jumpFrom: number | null;
+    hasError: boolean;
+  }) {
+    super();
+    this.index = args.index;
+    this.label = args.label;
+    this.title = args.title;
+    this.jumpFrom = args.jumpFrom;
+    this.hasError = args.hasError;
+  }
+
+  eq(other: RefIndexChipWidget): boolean {
+    return (
+      other.index === this.index &&
+      other.label === this.label &&
+      other.title === this.title &&
+      other.jumpFrom === this.jumpFrom &&
+      other.hasError === this.hasError
+    );
+  }
+
+  toDOM(): HTMLElement {
+    return buildChip({
+      kind: 'ref-index',
+      text: `#${this.index} ${this.label}`,
+      title: this.title,
+      jumpFrom: this.jumpFrom,
+      hasError: this.hasError,
+    });
+  }
+}
+
+export class RefSlugChipWidget extends WidgetType {
+  readonly slug: string;
+  readonly title: string;
+  readonly jumpFrom: number | null;
+
+  constructor(args: { slug: string; title: string; jumpFrom: number | null }) {
+    super();
+    this.slug = args.slug;
+    this.title = args.title;
+    this.jumpFrom = args.jumpFrom;
+  }
+
+  eq(other: RefSlugChipWidget): boolean {
+    return other.slug === this.slug && other.jumpFrom === this.jumpFrom;
+  }
+
+  toDOM(): HTMLElement {
+    return buildChip({
+      kind: 'ref-slug',
+      text: this.slug,
+      title: this.title,
+      jumpFrom: this.jumpFrom,
+      hasError: false,
+    });
+  }
+}
+
+export class InlineFuncPillWidget extends WidgetType {
+  readonly kind: 'time' | 'temperature';
+  readonly label: string;
+
+  constructor(args: { kind: 'time' | 'temperature'; label: string }) {
+    super();
+    this.kind = args.kind;
+    this.label = args.label;
+  }
+
+  eq(other: InlineFuncPillWidget): boolean {
+    return other.kind === this.kind && other.label === this.label;
+  }
+
+  toDOM(): HTMLElement {
+    const el = document.createElement('span');
+    el.className = `cm-dsl-chip cm-dsl-chip--pill cm-dsl-chip--${this.kind}`;
+    el.textContent = this.label;
+    el.setAttribute('data-chip-kind', this.kind);
+    return el;
+  }
+}
+
+function buildChip(args: {
+  kind: 'ref-index' | 'ref-slug';
+  text: string;
+  title: string;
+  jumpFrom: number | null;
+  hasError: boolean;
+}): HTMLElement {
+  const el = document.createElement('span');
+  el.className = `cm-dsl-chip cm-dsl-chip--${args.kind}${
+    args.hasError ? ' cm-dsl-chip--error' : ''
+  }`;
+  el.textContent = args.text;
+  el.title = args.title;
+  el.setAttribute('data-chip-kind', args.kind);
+  if (args.jumpFrom !== null) {
+    el.setAttribute('data-chip-jump-from', String(args.jumpFrom));
+    el.setAttribute('role', 'button');
+    el.setAttribute('tabindex', '0');
+    el.style.cursor = 'pointer';
+  }
+  if (args.hasError) el.setAttribute('data-chip-error', 'true');
+  return el;
+}

--- a/packages/app-food/src/components/dsl-editor/chip-widgets.ts
+++ b/packages/app-food/src/components/dsl-editor/chip-widgets.ts
@@ -6,12 +6,15 @@
  * still cursor through, and copy/paste preserves the raw `@N` / `@slug` /
  * `@time(...)` / `@temperature(...)` source.
  *
- * Click handling lives outside the widget instances. The chip-widgets
- * extension installs a single `EditorView.domEventHandlers.click` that
- * walks up from the event target, reads the `data-chip-jump-from` attribute,
- * and dispatches an `EditorSelection.cursor(...)` transaction. Keeping the
- * dispatch out of the widget means the widget doesn't need to capture the
- * EditorView in its constructor (which would defeat WidgetType reuse).
+ * Click + keyboard activation live outside the widget instances. The
+ * chip-widgets extension installs a `ViewPlugin` that attaches `click` and
+ * `keydown` listeners directly to `view.contentDOM` (not via
+ * `EditorView.domEventHandlers`, whose routing doesn't fire reliably for
+ * synthetic events on widget DOM under jsdom). Each handler walks up from
+ * the event target, reads `data-chip-jump-from`, and dispatches an
+ * `EditorSelection.cursor(...)` transaction. Keeping the dispatch out of
+ * the widget means the widget doesn't need to capture the EditorView in
+ * its constructor (which would defeat WidgetType reuse).
  */
 import { WidgetType } from '@codemirror/view';
 
@@ -126,7 +129,7 @@ function buildChip(args: {
     el.setAttribute('data-chip-jump-from', String(args.jumpFrom));
     el.setAttribute('role', 'button');
     el.setAttribute('tabindex', '0');
-    el.style.cursor = 'pointer';
+    el.classList.add('cm-dsl-chip--jump');
   }
   if (args.hasError) el.setAttribute('data-chip-error', 'true');
   return el;

--- a/packages/app-food/src/components/useDslEditorView.ts
+++ b/packages/app-food/src/components/useDslEditorView.ts
@@ -1,6 +1,6 @@
 /**
  * `useDslEditorView` — owns the imperative CodeMirror 6 lifecycle for the
- * DSL editor (PRD-120 part A).
+ * DSL editor (PRD-120 part A; chip widgets + mobile fallback added in 120-D).
  *
  * Pulled out of `DslEditor.tsx` so the component itself stays under the
  * lint cap and the React surface is purely declarative. The hook:
@@ -13,6 +13,11 @@
  *   - Re-syncs the document when `initialValue` changes from outside
  *     (parent loaded a new version). One-way only — the parent owns the
  *     canonical value via the debounced `onChange`.
+ *   - Watches `window.matchMedia('(max-width: 767px)')` and reconfigures
+ *     the chip-widgets compartment between desktop (widget-replace) and
+ *     mobile (inline-mark) renderings. The swap is a compartment
+ *     reconfigure so cursor + undo state stay intact when the user rotates
+ *     a tablet or resizes the window.
  *
  * The hook deliberately doesn't return the `EditorView`; callers that
  * need it (tests, future autocomplete plumbing) reach for
@@ -27,8 +32,10 @@ import { EditorView, keymap, lineNumbers } from '@codemirror/view';
 import { useCallback, useEffect, useRef, type MutableRefObject } from 'react';
 
 import { recipeDsl } from '../dsl/codemirror';
+import { chipWidgetsExtension } from './dsl-editor/chip-widgets-extension';
 
 const DEBOUNCE_MS = 250;
+const MOBILE_QUERY = '(max-width: 767px)';
 
 export interface UseDslEditorViewOptions {
   initialValue: string;
@@ -36,12 +43,20 @@ export interface UseDslEditorViewOptions {
   readOnly: boolean;
 }
 
+interface ViewCompartments {
+  readOnly: Compartment;
+  chips: Compartment;
+}
+
 export function useDslEditorView(
   hostRef: MutableRefObject<HTMLDivElement | null>,
   options: UseDslEditorViewOptions
 ): void {
   const viewRef = useRef<EditorView | null>(null);
-  const readOnlyCompartmentRef = useRef<Compartment>(new Compartment());
+  const compartmentsRef = useRef<ViewCompartments>({
+    readOnly: new Compartment(),
+    chips: new Compartment(),
+  });
   const onChangeRef = useRef(options.onChange);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -60,9 +75,11 @@ export function useDslEditorView(
   useEffect(() => {
     const host = hostRef.current;
     if (!host) return undefined;
-    const view = createEditorView(host, options, readOnlyCompartmentRef.current, emit);
+    const view = createEditorView(host, options, compartmentsRef.current, emit);
     viewRef.current = view;
+    const stopMql = watchMobileQuery(view, compartmentsRef.current.chips);
     return () => {
+      stopMql();
       if (debounceRef.current) {
         clearTimeout(debounceRef.current);
         debounceRef.current = null;
@@ -79,7 +96,9 @@ export function useDslEditorView(
     const view = viewRef.current;
     if (!view) return;
     view.dispatch({
-      effects: readOnlyCompartmentRef.current.reconfigure(buildReadOnlyExtension(options.readOnly)),
+      effects: compartmentsRef.current.readOnly.reconfigure(
+        buildReadOnlyExtension(options.readOnly)
+      ),
     });
   }, [options.readOnly]);
 
@@ -102,12 +121,31 @@ function buildReadOnlyExtension(
   return [EditorState.readOnly.of(readOnly), EditorView.editable.of(!readOnly)];
 }
 
+function detectCompactInitial(): boolean {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false;
+  return window.matchMedia(MOBILE_QUERY).matches;
+}
+
+function watchMobileQuery(view: EditorView, chipsCompartment: Compartment): () => void {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return () => {};
+  const mql = window.matchMedia(MOBILE_QUERY);
+  const apply = (matches: boolean): void => {
+    view.dispatch({
+      effects: chipsCompartment.reconfigure(chipWidgetsExtension({ compact: matches })),
+    });
+  };
+  const listener = (event: MediaQueryListEvent): void => apply(event.matches);
+  mql.addEventListener('change', listener);
+  return () => mql.removeEventListener('change', listener);
+}
+
 function createEditorView(
   host: HTMLDivElement,
   options: UseDslEditorViewOptions,
-  compartment: Compartment,
+  compartments: ViewCompartments,
   emit: (value: string) => void
 ): EditorView {
+  const compact = detectCompactInitial();
   return new EditorView({
     state: EditorState.create({
       doc: options.initialValue,
@@ -118,7 +156,8 @@ function createEditorView(
         syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
         recipeDsl(),
         keymap.of([...defaultKeymap, ...historyKeymap]),
-        compartment.of(buildReadOnlyExtension(options.readOnly)),
+        compartments.readOnly.of(buildReadOnlyExtension(options.readOnly)),
+        compartments.chips.of(chipWidgetsExtension({ compact })),
         EditorView.updateListener.of((update) => {
           if (update.docChanged) emit(update.state.doc.toString());
         }),

--- a/packages/app-food/src/index.ts
+++ b/packages/app-food/src/index.ts
@@ -22,3 +22,7 @@ export { TimerButton } from './components/TimerButton';
 export type { TimerButtonProps } from './components/TimerButton';
 export { TempBadge } from './components/TempBadge';
 export type { TempBadgeProps } from './components/TempBadge';
+
+// PRD-120 — DSL Editor (Part A scaffold + Part D chip widgets).
+export { DslEditor } from './components/DslEditor';
+export type { DslEditorProps } from './components/DslEditor';


### PR DESCRIPTION
## Summary

- Adds chip widgets to the DSL editor (PRD-120 part D, follow-up to 120-A's scaffold #2702):
  - `@N` inside a `@step("...")` body renders as a chip showing the matching ingredient's slug; clicking jumps the cursor to the corresponding `@ingredient(N, ...)` declaration.
  - `@slug` refs render as chips.
  - `@time(qty:unit)` and `@temperature(qty:unit)` render as pills (`20 min` / `180 °C`).
- Mobile (<768px) swaps `Decoration.replace` widgets for inline `Decoration.mark` styling via a matchMedia-driven Compartment — preserves tap-target size per PRD-120's responsive guidance.

## Approach

The chip extension is **AST-independent**: `parseRecipeDsl` returns `{ ok: false, errors }` with no AST on any parse failure, and `StepBodyPart` (PRD-114) doesn't carry `SourceSpan` data for inline refs either. A self-contained text scanner (`chip-scanner.ts` + `chip-scanner-step-body.ts`) walks the document directly, finds `@step("...")` bodies honouring `\\` / `\"` escapes, scans the four inline patterns, and runs a parallel sweep for `@ingredient(N, <descriptor>` declarations to build the index → declaration map. This keeps chips correct while the user is mid-edit.

Click handling is a `ViewPlugin` that attaches a `click` listener directly to `view.contentDOM` (instead of `EditorView.domEventHandlers`) — the direct attach fires reliably for synthetic clicks on widget DOM in jsdom, which `EditorView.domEventHandlers` did not.

## Files

New under `packages/app-food/src/components/dsl-editor/`:
- `chip-scanner.ts` — top-level scanner (step body + ingredient declarations).
- `chip-scanner-step-body.ts` — body-interior chip extraction (split out for the 200-line cap).
- `chip-scanner-types.ts` — shared types.
- `chip-widgets.ts` — `WidgetType` subclasses (RefIndex / RefSlug / InlineFunc pill).
- `chip-widgets-extension.ts` — `StateField` + `ViewPlugin` click handler + base theme.
- `__tests__/chip-scanner.test.ts` — 10 scanner unit cases.

Edited:
- `useDslEditorView.ts` — adds the chip `Compartment` + `matchMedia` listener.
- `__tests__/DslEditor.test.tsx` — 6 new chip cases.
- `index.ts` — re-exports `DslEditor` + `DslEditorProps` (120-A merged without them).
- `DslEditor.stories.tsx` — new Storybook stories (SampleRecipe / ReadOnly / Empty).

## Test plan

- [x] `pnpm --filter @pops/app-food typecheck` — clean.
- [x] `pnpm --filter @pops/app-food vitest run src/components/dsl-editor/__tests__/chip-scanner.test.ts` — 10/10.
- [x] `pnpm --filter @pops/app-food vitest run src/components/__tests__/DslEditor.test.tsx` — 15/15 (9 pre-existing + 6 new).
- [x] Full `pnpm --filter @pops/app-food test` — 267/269 passing; the 2 failures are in `FoodDataLayout.test.tsx` and pre-exist on `main` (verified by stashing).
- [x] `pnpm oxlint --type-aware` on the new directory — clean. Workspace lint shows only pre-existing warnings in unrelated files.
- [x] `pnpm format:check` — clean.
- [x] Husky pre-commit hook ran lint-staged + full repo typecheck (25/25 tasks green).
- [ ] Visual smoke check in Storybook (`food/DslEditor`) — open one of the stories and confirm chips render. Deferred to 120-F's broader Storybook pass.

## Out of scope

- Autocomplete (120-B).
- Error squiggles + `issues` prop (120-C, in flight in pops10).
- Reorder + renumber (120-E).
- Mobile autocomplete drawer + axe-core pass (120-F).