### PR TITLE
feat(food): PRD-113 phase 2 — compile sample recipes + PRD-123 seed rows

### DIFF
--- a/packages/app-food-db/src/__tests__/seed.test.ts
+++ b/packages/app-food-db/src/__tests__/seed.test.ts
@@ -86,9 +86,13 @@ describe('PRD-113 phase-1 seed', () => {
     it('seeds at least 30 aliases (PRD-113 spec)', () => {
       expect(summary.aliases).toBeGreaterThanOrEqual(30);
     });
-    it('seeds at least 4 recipes (smash-burger + pasta + roast + eggs)', () => {
-      expect(summary.recipes).toBeGreaterThanOrEqual(4);
+    it('seeds at least 5 recipes (smash-patty + smash-burger + pasta + roast + eggs)', () => {
+      expect(summary.recipes).toBeGreaterThanOrEqual(5);
       expect(summary.recipeVersions).toBe(summary.recipes);
+    });
+    it('seeds PRD-123 conversion fixtures (unit_conversions + ingredient_weights)', () => {
+      expect(summary.unitConversions).toBeGreaterThanOrEqual(10);
+      expect(summary.ingredientWeights).toBeGreaterThanOrEqual(4);
     });
     it('seeds 10 batches and 1 cook run with consumptions', () => {
       expect(summary.batches).toBe(10);
@@ -142,7 +146,7 @@ describe('PRD-113 phase-1 seed', () => {
       // fixture growth (more ingest-sourced or more manual recipes both stay
       // green) while still checking the actual invariant: every
       // currently-manual recipe lands with source_id NULL.
-      const MANUAL_SLUGS = ['roast-chicken', 'breakfast-eggs'] as const;
+      const MANUAL_SLUGS = ['roast-chicken', 'breakfast-eggs', 'smash-patty'] as const;
       const rows = raw
         .prepare(
           `SELECT r.slug, v.source_id

--- a/packages/app-food-db/src/seed/data-conversions.ts
+++ b/packages/app-food-db/src/seed/data-conversions.ts
@@ -1,0 +1,107 @@
+/**
+ * PRD-113 phase-2 fixture set — PRD-123 conversion tables.
+ *
+ * `UNIT_CONVERSION_FIXTURES` populates `unit_conversions`: a small generic
+ * set covering the units the seed's sample recipes actually use plus the
+ * common kitchen-volume measures so the conversion-table CRUD pages
+ * (PRD-123 phase B / C) and the Phase-2 compile path have rows to exercise.
+ *
+ * `INGREDIENT_WEIGHT_FIXTURES` populates `ingredient_weights`: just enough
+ * to demonstrate the variant-specific and null-variant fallback paths in
+ * `resolveCanonicalQty`. Ingredients are referenced by slug + variant slug;
+ * the seed step resolves them to ids via `SeedContext`.
+ *
+ * Every row is seeded with `isSeeded=true` so the conversions CRUD UI
+ * blocks accidental deletes (see PRD-123's `SeededRowProtected` typed error).
+ */
+
+export interface UnitConversionFixture {
+  fromUnit: string;
+  toUnit: 'g' | 'ml' | 'count';
+  ratio: number;
+  notes?: string;
+}
+
+export const UNIT_CONVERSION_FIXTURES: readonly UnitConversionFixture[] = [
+  // Weight
+  { fromUnit: 'kg', toUnit: 'g', ratio: 1000, notes: 'SI kilogram → gram.' },
+  { fromUnit: 'mg', toUnit: 'g', ratio: 0.001, notes: 'SI milligram → gram.' },
+  { fromUnit: 'oz', toUnit: 'g', ratio: 28.3495, notes: 'Avoirdupois ounce.' },
+  { fromUnit: 'lb', toUnit: 'g', ratio: 453.592, notes: 'Avoirdupois pound.' },
+  // Volume
+  { fromUnit: 'l', toUnit: 'ml', ratio: 1000, notes: 'SI litre → millilitre.' },
+  { fromUnit: 'cl', toUnit: 'ml', ratio: 10, notes: 'SI centilitre.' },
+  { fromUnit: 'fl-oz', toUnit: 'ml', ratio: 29.5735, notes: 'US fluid ounce.' },
+  { fromUnit: 'cup', toUnit: 'ml', ratio: 240, notes: 'US/AU cup (240ml).' },
+  { fromUnit: 'tbsp', toUnit: 'ml', ratio: 15, notes: 'Tablespoon.' },
+  { fromUnit: 'tsp', toUnit: 'ml', ratio: 5, notes: 'Teaspoon.' },
+  // Count aliases
+  { fromUnit: 'each', toUnit: 'count', ratio: 1, notes: 'Singular alias for "count".' },
+  { fromUnit: 'whole', toUnit: 'count', ratio: 1, notes: 'Alias used by recipe scrapers.' },
+  { fromUnit: 'piece', toUnit: 'count', ratio: 1, notes: 'Alias used by recipe scrapers.' },
+];
+
+/**
+ * Per-ingredient weight overrides. `variantSlug=null` matches PRD-123's
+ * null-variant fallback row (applies to every variant of the ingredient
+ * unless a more specific row exists).
+ *
+ * The seeded weights are deliberately small: enough to exercise the
+ * variant-specific path (flour:plain, sugar:caster, salt:table) AND the
+ * null-variant fallback (butter), without claiming authority over the
+ * USDA/Open Food Facts datasets PRD-113 explicitly leaves out of scope.
+ */
+export interface IngredientWeightFixture {
+  ingredientSlug: string;
+  variantSlug: string | null;
+  unit: string;
+  grams: number;
+  notes?: string;
+}
+
+export const INGREDIENT_WEIGHT_FIXTURES: readonly IngredientWeightFixture[] = [
+  // Solids — variant-specific
+  {
+    ingredientSlug: 'flour',
+    variantSlug: 'plain',
+    unit: 'cup',
+    grams: 125,
+    notes: 'AU/US cup of sifted plain flour ≈ 125g.',
+  },
+  {
+    ingredientSlug: 'sugar',
+    variantSlug: 'caster',
+    unit: 'cup',
+    grams: 220,
+    notes: 'AU/US cup of caster sugar ≈ 220g.',
+  },
+  {
+    ingredientSlug: 'sugar',
+    variantSlug: 'brown',
+    unit: 'cup',
+    grams: 200,
+    notes: 'Lightly packed.',
+  },
+  {
+    ingredientSlug: 'salt',
+    variantSlug: 'table',
+    unit: 'tsp',
+    grams: 6,
+    notes: 'Fine table salt ≈ 6g/tsp.',
+  },
+  {
+    ingredientSlug: 'salt',
+    variantSlug: 'table',
+    unit: 'tbsp',
+    grams: 18,
+    notes: 'Fine table salt ≈ 18g/tbsp.',
+  },
+  // Null-variant fallback
+  {
+    ingredientSlug: 'butter',
+    variantSlug: null,
+    unit: 'cup',
+    grams: 227,
+    notes: 'Falls back across all butter variants.',
+  },
+];

--- a/packages/app-food-db/src/seed/data-recipes.ts
+++ b/packages/app-food-db/src/seed/data-recipes.ts
@@ -1,17 +1,24 @@
 /**
- * PRD-113 fixture set — recipe headers (phase 1: uncompiled DSL).
+ * PRD-113 fixture set — recipe headers + DSL bodies (phases 1 + 2).
  *
- * Phase 1 stores the DSL body verbatim and leaves `recipe_versions.status =
- * 'draft'` + `compile_state` uncompiled. Phase 2 (post PRD-116) replaces
- * `seedRecipeHeaders` with a `seedRecipesAndCompile()` that invokes
- * `compileRecipeVersion` so `recipe_lines` / `recipe_steps` get populated —
- * that's the cross-PRD smoke test PRD-113 originally specced.
+ * Phase 1 stores these bodies verbatim and leaves `recipe_versions.status =
+ * 'draft'` + `compile_state = 'uncompiled'`. Phase 2 (post PRD-116) drives
+ * `compileRecipeVersion` against each row so `recipe_lines` / `recipe_steps`
+ * get populated and the version is promoted to `current` — the cross-PRD
+ * smoke test PRD-113 was originally specced as.
  *
- * The DSL bodies below are deliberately shaped to exercise the resolver's
- * variant scoping (`onion:yellow`), alias resolution (`evoo`), recipe-as-
- * ingredient refs (smash-burger consumes a beef:patty produced by another
- * cook), and the yield form. Keeping them around now means phase 2 doesn't
- * have to author them from scratch.
+ * The DSL bodies follow PRD-114's grammar exactly:
+ *
+ *   - `@recipe(slug, title, recipe_type?, servings?, prep_time?, cook_time?)`
+ *   - `@yield(<ingredient-slug>, qty:unit)` — yield slugs that don't match
+ *     the seeded ingredient list are auto-created by PRD-115 → PRD-116.
+ *   - `@ingredient(N, head:variant:prep, qty:unit, optional?, notes?)` — both
+ *     compact and named-arg forms.
+ *   - `@step("body")` with inline `@N`, `@time(...)`, `@temperature(...)`.
+ *
+ * Fixture order matters: components first (so PRD-115's recipe-as-ingredient
+ * resolution finds a promoted `current_version_id`), then plates that
+ * reference them.
  */
 
 export interface RecipeFixture {
@@ -25,80 +32,122 @@ export interface RecipeFixture {
   bodyDsl: string;
 }
 
-const SMASH_BURGER_DSL = `@title Smash burger
-@yield(beef:mince:cooked, 360:g)
-
-@step prep "Smash"
-  @ingredient beef:mince 600:g
-  @ingredient salt 4:g
-  @ingredient pepper:black-ground 2:g
-
-@step cook "Sear"
-  @ingredient evoo 10:ml
-
-@step assemble "Build"
-  @ingredient bread:burger-bun 4:count
-  @ingredient cheese:cheddar-shredded 80:g
-  @ingredient onion:yellow 1:count
-  @ingredient tomato:beefsteak 1:count
+const SMASH_PATTY_DSL = `@recipe(
+  slug="smash-patty",
+  title="Smash Patty",
+  recipe_type="component",
+  servings=4,
+  prep_time=5:min,
+  cook_time=10:min
+)
+@yield(beef-patty-cooked, 4:count)
+@ingredient(1, beef:mince, 500:g)
+@ingredient(2, salt:flaky, 5:g)
+@ingredient(3, pepper:black-ground, 2:g)
+@step("Divide @1 into 4 loose balls and season with @2 and @3.")
+@step("Heat a heavy pan over high heat until smoking.")
+@step("Press flat and sear @time(2:min) per side at @temperature(220:c).")
 `;
 
-const WEEKNIGHT_PASTA_DSL = `@title Weeknight pasta
-@yield(flour:plain:cooked, 800:g)
-
-@step prep "Mise"
-  @ingredient flour:plain 400:g
-  @ingredient garlic:peeled-clove 4:count
-  @ingredient tomato:canned-whole 800:g
-
-@step cook "Simmer"
-  @ingredient evoo 30:ml
-  @ingredient salt:table 8:g
-  @ingredient pepper:black-ground 2:g
-
-@step plate "Plate"
-  @ingredient parsley:flat-leaf 10:g
-  @ingredient cheese:parmesan-grated 40:g
+const SMASH_BURGER_DSL = `@recipe(
+  slug="smash-burger",
+  title="Smash burger",
+  servings=4,
+  prep_time=5:min,
+  cook_time=5:min
+)
+@yield(smash-burger-served, 4:count)
+@ingredient(1, bread:burger-bun, 4:count)
+@ingredient(2, smash-patty, 4:count)
+@ingredient(3, cheese:colby-block, 4:count)
+@ingredient(4, onion:yellow:sliced, 1:count)
+@ingredient(5, tomato:beefsteak, 1:count)
+@step("Toast the @1 in the pan over @temperature(180:c).")
+@step("Place @3 on each @2 to melt while still hot.")
+@step("Assemble: bottom of @1, @2 with @3, @4, @5, top of @1.")
 `;
 
-const ROAST_CHICKEN_DSL = `@title Roast chicken
-@yield(chicken:whole:roasted, 1600:g)
-
-@step prep "Brine"
-  @ingredient chicken:whole 1.8:kg
-  @ingredient salt:flaky 30:g
-
-@step cook "Roast"
-  @ingredient butter:unsalted 50:g
-  @ingredient lemon 1:count
-  @ingredient parsley:flat-leaf 20:g
-
-@step rest "Carve"
-  @ingredient pepper:black-ground 3:g
+const WEEKNIGHT_PASTA_DSL = `@recipe(
+  slug="weeknight-pasta",
+  title="Weeknight pasta",
+  servings=4,
+  prep_time=10:min,
+  cook_time=25:min
+)
+@yield(pasta-plate, 4:count)
+@ingredient(1, flour:plain, 400:g)
+@ingredient(2, garlic:peeled-clove, 4:count)
+@ingredient(3, tomato:canned-whole, 800:g)
+@ingredient(4, olive-oil:extra-virgin, 30:ml)
+@ingredient(5, salt:table, 2:tsp)
+@ingredient(6, pepper:black-ground, 2:g)
+@ingredient(7, parsley:flat-leaf, 10:g)
+@ingredient(8, cheese:parmesan-grated, 40:g)
+@step("Boil @1 in salted water until al dente, @time(10:min).")
+@step("Crush @2 and bloom in @4 over low heat for @time(2:min).")
+@step("Add @3 and simmer @time(15:min) at @temperature(180:c). Season with @5 and @6.")
+@step("Toss the pasta into the sauce; plate with @7 and @8.")
 `;
 
-const BREAKFAST_EGGS_DSL = `@title Breakfast eggs
+const ROAST_CHICKEN_DSL = `@recipe(
+  slug="roast-chicken",
+  title="Roast chicken",
+  servings=6,
+  prep_time=20:min,
+  cook_time=90:min
+)
+@yield(roast-chicken-meat, 1600:g)
+@ingredient(1, chicken:whole, 1.8:kg)
+@ingredient(2, salt:flaky, 30:g)
+@ingredient(3, butter:unsalted, 50:g)
+@ingredient(4, lemon, 1:count)
+@ingredient(5, parsley:flat-leaf, 20:g)
+@ingredient(6, pepper:black-ground, 3:g)
+@step("Brine @1 with @2 for @time(60:min).")
+@step("Rub @3 under the skin; stuff the cavity with @4.")
+@step("Roast at @temperature(200:c) for @time(90:min) until juices run clear.")
+@step("Rest, then carve and season with @6 and @5.")
+`;
 
-@step cook "Scramble"
-  @ingredient egg:large 3:count
-  @ingredient butter:unsalted 20:g
-  @ingredient milk:full-cream 30:ml
-
-@step plate "Serve"
-  @ingredient bread:sourdough-loaf 2:count
-  @ingredient salt:table 1:g
-  @ingredient pepper:black-ground 1:g
+const BREAKFAST_EGGS_DSL = `@recipe(
+  slug="breakfast-eggs",
+  title="Breakfast eggs",
+  servings=1,
+  prep_time=2:min,
+  cook_time=5:min
+)
+@yield(scrambled-eggs, 1:count)
+@ingredient(1, egg, variant=large, qty=3, unit=count)
+@ingredient(2, butter, variant=unsalted, qty=20, unit=g)
+@ingredient(3, milk, variant=full-cream, qty=30, unit=ml)
+@ingredient(4, bread:sourdough-loaf:sliced, 2:count)
+@ingredient(5, salt:table, 1:g)
+@ingredient(6, pepper:black-ground, 1:g)
+@step("Whisk @1 in a bowl and season with @5 and @6.")
+@step("Melt @2 in a non-stick pan over @temperature(160:c).")
+@step("Pour @1 in and stir gently for @time(90:s); add @3 to slow the cook.")
+@step("Toast @4 and serve alongside.")
 `;
 
 export const RECIPE_FIXTURES: readonly RecipeFixture[] = [
+  {
+    slug: 'smash-patty',
+    recipeType: 'component',
+    title: 'Smash patty',
+    summary: 'Component recipe — the patty smash-burger composes with.',
+    servings: 4,
+    prepMinutes: 5,
+    cookMinutes: 10,
+    bodyDsl: SMASH_PATTY_DSL,
+  },
   {
     slug: 'smash-burger',
     recipeType: 'plate',
     title: 'Smash burger',
     summary: 'Cast-iron, crusty edges, simple toppings.',
     servings: 4,
-    prepMinutes: 10,
-    cookMinutes: 15,
+    prepMinutes: 5,
+    cookMinutes: 5,
     bodyDsl: SMASH_BURGER_DSL,
   },
   {
@@ -125,7 +174,7 @@ export const RECIPE_FIXTURES: readonly RecipeFixture[] = [
     slug: 'breakfast-eggs',
     recipeType: 'plate',
     title: 'Breakfast eggs',
-    summary: 'Three eggs, sourdough, no fuss.',
+    summary: 'Three eggs, sourdough, no fuss. Uses the named-arg DSL form.',
     servings: 1,
     prepMinutes: 2,
     cookMinutes: 5,

--- a/packages/app-food-db/src/seed/data-recipes.ts
+++ b/packages/app-food-db/src/seed/data-recipes.ts
@@ -2,7 +2,7 @@
  * PRD-113 fixture set — recipe headers + DSL bodies (phases 1 + 2).
  *
  * Phase 1 stores these bodies verbatim and leaves `recipe_versions.status =
- * 'draft'` + `compile_state = 'uncompiled'`. Phase 2 (post PRD-116) drives
+ * 'draft'` + `compile_status = 'uncompiled'`. Phase 2 (post PRD-116) drives
  * `compileRecipeVersion` against each row so `recipe_lines` / `recipe_steps`
  * get populated and the version is promoted to `current` — the cross-PRD
  * smoke test PRD-113 was originally specced as.

--- a/packages/app-food-db/src/seed/index.ts
+++ b/packages/app-food-db/src/seed/index.ts
@@ -1,21 +1,29 @@
 /**
- * PRD-113 phase 1 + 3 — food + lists seed entry point.
+ * PRD-113 phase 1 + 2 + 3 — food + lists seed entry point.
  *
  * Phase 1 shipped the non-compile fixture set (ingredients, variants, prep
  * states, aliases, substitutions, plan slots + entries, batches, recipe
- * headers with uncompiled DSL, lists + items). Phase 3 adds two
+ * headers with uncompiled DSL, lists + items). Phase 3 added two
  * `ingest_sources` rows so PRD-135's inbox inspector renders against real
- * provenance fixtures. Phase 2 will replace the `seedRecipeHeaders` call
- * with a `seedRecipesAndCompile` step that invokes `compileRecipeVersion`
- * once PRD-116-driven smoke gets wired in.
+ * provenance fixtures. Phase 2 closes the cross-PRD smoke test: when the
+ * caller supplies a `compile` callback (production: PRD-116's
+ * `compileRecipeVersion` from `@pops/app-food`), the recipe step parses →
+ * resolves → cycle-checks → materialises each fixture and promotes v1 to
+ * `current`. Phase 2 also seeds PRD-123's `unit_conversions` and
+ * `ingredient_weights` so the compile path's normalisation has rows to
+ * resolve against.
  *
- * Order matters for phase-3 wiring:
+ * Order matters:
  *
  *   1. `seedIngestSources` inserts ingest_sources rows BEFORE recipes so
- *      `seedRecipeHeaders` can pick up each source id and pass it as
+ *      `step-recipes` can pick up each source id and pass it as
  *      `recipe_versions.source_id`.
- *   2. `seedRecipeHeaders` creates the recipes (and stashes their ids).
- *   3. `linkIngestSourcesToDrafts` patches `ingest_sources.draft_recipe_id`
+ *   2. `seedConversions` runs BEFORE the recipe step so PRD-116's compile
+ *      normalisation can resolve qty:unit pairs like `cup` and `kg`.
+ *   3. `seedRecipesAndCompile` (Phase 2) or `seedRecipeHeaders` (Phase 1
+ *      fallback) creates each recipe; compile + promote run inline so
+ *      later fixtures can reference earlier ones via recipe-as-ingredient.
+ *   4. `linkIngestSourcesToDrafts` patches `ingest_sources.draft_recipe_id`
  *      to FK back to the freshly-created recipes.
  *
  * Idempotency: the seed early-returns when the `slug_registry` already has
@@ -32,12 +40,13 @@ import { sql } from 'drizzle-orm';
 import { slugRegistry } from '../schema.js';
 import { seedAliases } from './step-aliases.js';
 import { seedBatches } from './step-batches.js';
+import { seedConversions } from './step-conversions.js';
 import { linkIngestSourcesToDrafts, seedIngestSources } from './step-ingest-sources.js';
 import { seedIngredientsAndVariants } from './step-ingredients.js';
 import { seedLists } from './step-lists.js';
 import { seedPlan } from './step-plan.js';
 import { seedPrepStates } from './step-prep-states.js';
-import { seedRecipeHeaders } from './step-recipes.js';
+import { type SeedCompileFn, seedRecipeHeaders, seedRecipesAndCompile } from './step-recipes.js';
 import { seedSubstitutions } from './step-substitutions.js';
 import { freshContext, type SeedFoodSummary, ZERO_COUNTS } from './types.js';
 
@@ -45,7 +54,18 @@ import type { ListsDb } from '@pops/app-lists/db';
 
 import type { FoodDb } from '../services/internal.js';
 
+export type { SeedCompileFn, SeedCompileResult } from './step-recipes.js';
 export type { SeedFoodSummary } from './types.js';
+
+export interface SeedFoodOptions {
+  /**
+   * When provided, recipes are compiled via PRD-116 and v1 is promoted to
+   * `current`. When omitted, recipes land as uncompiled drafts (Phase 1
+   * behaviour — used by the in-package vitest suite that can't import the
+   * React-bound `@pops/app-food` package).
+   */
+  compileRecipeVersion?: SeedCompileFn;
+}
 
 function slugRegistryHasRows(db: FoodDb): boolean {
   const rows = db
@@ -57,14 +77,19 @@ function slugRegistryHasRows(db: FoodDb): boolean {
 }
 
 /**
- * Run the PRD-113 phase-1 seed.
+ * Run the PRD-113 seed.
  *
  * @param foodDb Drizzle wrapper over the SQLite handle (food domain).
  * @param listsDb Drizzle wrapper over the SAME handle (lists domain).
+ * @param options Optional `compileRecipeVersion` for Phase-2 compile + promote.
  * @returns Row counts per table; `skipped=true` when the slug_registry was
  *   non-empty and the seed early-returned.
  */
-export function seedFood(foodDb: FoodDb, listsDb: ListsDb): SeedFoodSummary {
+export function seedFood(
+  foodDb: FoodDb,
+  listsDb: ListsDb,
+  options: SeedFoodOptions = {}
+): SeedFoodSummary {
   if (slugRegistryHasRows(foodDb)) {
     return { ...ZERO_COUNTS, skipped: true };
   }
@@ -73,8 +98,12 @@ export function seedFood(foodDb: FoodDb, listsDb: ListsDb): SeedFoodSummary {
   const prepStates = seedPrepStates(foodDb, ctx);
   const ingredientCounts = seedIngredientsAndVariants(foodDb, ctx);
   const aliases = seedAliases(foodDb, ctx);
+  const conversionCounts = seedConversions(foodDb, ctx);
   const ingestSources = seedIngestSources(foodDb, ctx);
-  const recipeCounts = seedRecipeHeaders(foodDb, ctx);
+  const recipeCounts =
+    options.compileRecipeVersion === undefined
+      ? seedRecipeHeaders(foodDb, ctx)
+      : seedRecipesAndCompile(foodDb, ctx, options.compileRecipeVersion);
   linkIngestSourcesToDrafts(foodDb, ctx);
   const substitutions = seedSubstitutions(foodDb, ctx);
   const planCounts = seedPlan(foodDb, ctx);
@@ -98,5 +127,7 @@ export function seedFood(foodDb: FoodDb, listsDb: ListsDb): SeedFoodSummary {
     lists: listCounts.lists,
     listItems: listCounts.listItems,
     ingestSources,
+    unitConversions: conversionCounts.unitConversions,
+    ingredientWeights: conversionCounts.ingredientWeights,
   };
 }

--- a/packages/app-food-db/src/seed/step-conversions.ts
+++ b/packages/app-food-db/src/seed/step-conversions.ts
@@ -1,0 +1,74 @@
+/**
+ * PRD-113 phase-2 seed step — PRD-123 conversion fixtures.
+ *
+ * Inserts `unit_conversions` and `ingredient_weights` rows via the
+ * conversions service so the same insert paths the CRUD UI uses get
+ * exercised at seed time. Every row is marked `isSeeded=true` — the UI
+ * surfaces these as protected (cannot be deleted via `deleteUnitConversion`
+ * / `deleteIngredientWeight`).
+ *
+ * Idempotent contract matches every other seed step: callers wipe before
+ * re-running. The orchestrator guards on `slug_registry` so a populated DB
+ * short-circuits the whole seed.
+ */
+import { createIngredientWeight, createUnitConversion } from '../services/conversions.js';
+import { INGREDIENT_WEIGHT_FIXTURES, UNIT_CONVERSION_FIXTURES } from './data-conversions.js';
+
+import type { FoodDb } from '../services/internal.js';
+import type { SeedContext } from './types.js';
+
+export interface ConversionCounts {
+  unitConversions: number;
+  ingredientWeights: number;
+}
+
+export function seedConversions(db: FoodDb, ctx: SeedContext): ConversionCounts {
+  let unitConversions = 0;
+  for (const fixture of UNIT_CONVERSION_FIXTURES) {
+    createUnitConversion(db, {
+      fromUnit: fixture.fromUnit,
+      toUnit: fixture.toUnit,
+      ratio: fixture.ratio,
+      notes: fixture.notes,
+      isSeeded: true,
+    });
+    unitConversions += 1;
+  }
+
+  let ingredientWeights = 0;
+  for (const fixture of INGREDIENT_WEIGHT_FIXTURES) {
+    const ingredientId = ctx.ingredientIdBySlug.get(fixture.ingredientSlug);
+    if (ingredientId === undefined) {
+      throw new Error(
+        `seedConversions: ingredient "${fixture.ingredientSlug}" not in SeedContext — ` +
+          'seedIngredientsAndVariants must run first'
+      );
+    }
+    const variantId = resolveVariantId(ctx, fixture.ingredientSlug, fixture.variantSlug);
+    createIngredientWeight(db, {
+      ingredientId,
+      variantId,
+      unit: fixture.unit,
+      grams: fixture.grams,
+      notes: fixture.notes,
+      isSeeded: true,
+    });
+    ingredientWeights += 1;
+  }
+
+  return { unitConversions, ingredientWeights };
+}
+
+function resolveVariantId(
+  ctx: SeedContext,
+  ingredientSlug: string,
+  variantSlug: string | null
+): number | null {
+  if (variantSlug === null) return null;
+  const key = `${ingredientSlug}:${variantSlug}`;
+  const variantId = ctx.variantIdByCompositeSlug.get(key);
+  if (variantId === undefined) {
+    throw new Error(`seedConversions: variant "${key}" not in SeedContext`);
+  }
+  return variantId;
+}

--- a/packages/app-food-db/src/seed/step-recipes.ts
+++ b/packages/app-food-db/src/seed/step-recipes.ts
@@ -4,7 +4,7 @@
  * `seedRecipeHeaders` is the Phase-1 path: it calls `createRecipe` for each
  * fixture and stashes both the recipe id and the first-version id in the
  * SeedContext. The DSL body lives in `recipe_versions.body_dsl` as plain
- * text; `compile_state` defaults to uncompiled and `status` to draft.
+ * text; `compile_status` defaults to `'uncompiled'` and `status` to `'draft'`.
  *
  * `seedRecipesAndCompile` is the Phase-2 path: same create flow, plus a
  * caller-injected `compile` callback that drives PRD-116's

--- a/packages/app-food-db/src/seed/step-recipes.ts
+++ b/packages/app-food-db/src/seed/step-recipes.ts
@@ -1,47 +1,90 @@
 /**
- * PRD-113 seed step — recipe headers (phase 1).
+ * PRD-113 seed step — recipe headers + Phase-2 compile.
  *
- * Calls `createRecipe` for each fixture and stashes both the recipe id and
- * the first-version id in the SeedContext. The DSL body lives in
- * `recipe_versions.body_dsl` as plain text; `compile_state` defaults to
- * uncompiled and `status` to draft.
+ * `seedRecipeHeaders` is the Phase-1 path: it calls `createRecipe` for each
+ * fixture and stashes both the recipe id and the first-version id in the
+ * SeedContext. The DSL body lives in `recipe_versions.body_dsl` as plain
+ * text; `compile_state` defaults to uncompiled and `status` to draft.
+ *
+ * `seedRecipesAndCompile` is the Phase-2 path: same create flow, plus a
+ * caller-injected `compile` callback that drives PRD-116's
+ * `compileRecipeVersion`, plus a `promoteVersion` call so each recipe's
+ * `current_version_id` is set before the next fixture compiles. Order
+ * matters — components (e.g. `smash-patty`) must be promoted before plates
+ * that reference them via PRD-115's recipe-as-ingredient resolver.
+ *
+ * The callback indirection keeps `@pops/app-food-db` free of any dependency
+ * on the React-bound `@pops/app-food` package. Production callers (the
+ * `db:seed:food` CLI in `@pops/app-food`) supply the real
+ * `compileRecipeVersion`; the in-memory test in this package falls back to
+ * `seedRecipeHeaders` for Phase-1/3 coverage.
  *
  * Phase 3 wiring: if `seedIngestSources` already populated
  * `ctx.ingestSourceIdByRecipeSlug` for a given recipe slug, the matching
  * `ingest_sources.id` is passed through as `firstVersion.sourceId` so
  * PRD-135's `recipe_versions.source_id IS NOT NULL` scope sees the draft.
- *
- * Phase 2 (post PRD-116) replaces this step with one that calls
- * `compileRecipeVersion` so the DSL → resolve → cycle → materialise path
- * runs against real fixtures.
  */
+import { promoteVersion } from '../services/recipe-versions.js';
 import { createRecipe } from '../services/recipes.js';
-import { RECIPE_FIXTURES } from './data-recipes.js';
+import { RECIPE_FIXTURES, type RecipeFixture } from './data-recipes.js';
 
 import type { FoodDb } from '../services/internal.js';
 import type { SeedContext } from './types.js';
 
-export function seedRecipeHeaders(
-  db: FoodDb,
-  ctx: SeedContext
-): { recipes: number; recipeVersions: number } {
+/** Minimal compile callback contract. Structurally compatible with PRD-116's `CompileResult`. */
+export type SeedCompileResult =
+  | { ok: true; lineCount: number; stepCount: number; creationCount: number }
+  | { ok: false; phase: string; errors: readonly unknown[] };
+
+export type SeedCompileFn = (versionId: number, db: FoodDb) => SeedCompileResult;
+
+export interface RecipeStepCounts {
+  recipes: number;
+  recipeVersions: number;
+}
+
+export function seedRecipeHeaders(db: FoodDb, ctx: SeedContext): RecipeStepCounts {
   for (const fixture of RECIPE_FIXTURES) {
-    const sourceId = ctx.ingestSourceIdByRecipeSlug.get(fixture.slug) ?? null;
-    const result = createRecipe(db, {
-      slug: fixture.slug,
-      recipeType: fixture.recipeType ?? 'plate',
-      firstVersion: {
-        title: fixture.title,
-        bodyDsl: fixture.bodyDsl,
-        summary: fixture.summary ?? null,
-        servings: fixture.servings ?? null,
-        prepMinutes: fixture.prepMinutes ?? null,
-        cookMinutes: fixture.cookMinutes ?? null,
-        sourceId,
-      },
-    });
-    ctx.recipeIdBySlug.set(result.recipe.slug, result.recipe.id);
-    ctx.recipeVersionIdByRecipeSlug.set(result.recipe.slug, result.version.id);
+    createRecipeFromFixture(db, ctx, fixture);
   }
   return { recipes: RECIPE_FIXTURES.length, recipeVersions: RECIPE_FIXTURES.length };
+}
+
+export function seedRecipesAndCompile(
+  db: FoodDb,
+  ctx: SeedContext,
+  compile: SeedCompileFn
+): RecipeStepCounts {
+  for (const fixture of RECIPE_FIXTURES) {
+    const versionId = createRecipeFromFixture(db, ctx, fixture);
+    const result = compile(versionId, db);
+    if (!result.ok) {
+      throw new Error(
+        `seedRecipesAndCompile: recipe "${fixture.slug}" failed in phase "${result.phase}": ` +
+          JSON.stringify(result.errors)
+      );
+    }
+    promoteVersion(db, versionId);
+  }
+  return { recipes: RECIPE_FIXTURES.length, recipeVersions: RECIPE_FIXTURES.length };
+}
+
+function createRecipeFromFixture(db: FoodDb, ctx: SeedContext, fixture: RecipeFixture): number {
+  const sourceId = ctx.ingestSourceIdByRecipeSlug.get(fixture.slug) ?? null;
+  const result = createRecipe(db, {
+    slug: fixture.slug,
+    recipeType: fixture.recipeType ?? 'plate',
+    firstVersion: {
+      title: fixture.title,
+      bodyDsl: fixture.bodyDsl,
+      summary: fixture.summary ?? null,
+      servings: fixture.servings ?? null,
+      prepMinutes: fixture.prepMinutes ?? null,
+      cookMinutes: fixture.cookMinutes ?? null,
+      sourceId,
+    },
+  });
+  ctx.recipeIdBySlug.set(result.recipe.slug, result.recipe.id);
+  ctx.recipeVersionIdByRecipeSlug.set(result.recipe.slug, result.version.id);
+  return result.version.id;
 }

--- a/packages/app-food-db/src/seed/types.ts
+++ b/packages/app-food-db/src/seed/types.ts
@@ -35,6 +35,8 @@ export interface StepCounts {
   lists: number;
   listItems: number;
   ingestSources: number;
+  unitConversions: number;
+  ingredientWeights: number;
 }
 
 /** Final summary returned by `seedFood`. */
@@ -59,6 +61,8 @@ export const ZERO_COUNTS: StepCounts = {
   lists: 0,
   listItems: 0,
   ingestSources: 0,
+  unitConversions: 0,
+  ingredientWeights: 0,
 };
 
 /**

--- a/packages/app-food/scripts/db-seed-food.ts
+++ b/packages/app-food/scripts/db-seed-food.ts
@@ -17,6 +17,8 @@ import { drizzle } from 'drizzle-orm/better-sqlite3';
 
 import { seedFood } from '@pops/app-food-db/seed';
 
+import { compileRecipeVersion } from '../src/dsl/compile';
+
 if (process.env.NODE_ENV === 'production') {
   console.error("❌ Refusing to run: NODE_ENV is 'production'.");
   console.error('   This script is for development/testing only.');
@@ -66,7 +68,10 @@ try {
       db.exec(`DELETE FROM "${table}"`);
     }
     const drizzleDb = drizzle(db);
-    const summary = seedFood(drizzleDb, drizzleDb);
+    // Phase 2: drive PRD-116's compile + PRD-107's promote inline so the
+    // seed DB ends up with materialised recipe_lines / recipe_steps and
+    // every recipe's v1 promoted to `current`.
+    const summary = seedFood(drizzleDb, drizzleDb, { compileRecipeVersion });
     console.log('\n✅ Food seed complete\n');
     console.log('📊 Counts:');
     console.log(`  prep_states:       ${summary.prepStates}`);
@@ -84,6 +89,8 @@ try {
     console.log(`  lists:             ${summary.lists}`);
     console.log(`  list_items:        ${summary.listItems}`);
     console.log(`  ingest_sources:    ${summary.ingestSources}`);
+    console.log(`  unit_conversions:  ${summary.unitConversions}`);
+    console.log(`  ingredient_weights:${summary.ingredientWeights}`);
   })();
 } finally {
   db.pragma('foreign_keys = ON');

--- a/packages/app-food/scripts/db-seed-food.ts
+++ b/packages/app-food/scripts/db-seed-food.ts
@@ -34,7 +34,12 @@ if (!existsSync(DB_PATH)) {
 }
 
 // Wipe only food + lists tables. Children first; `foreign_keys = OFF` makes
-// the order purely defensive.
+// the order purely defensive. PRD-116 (recipe_lines / recipe_steps /
+// recipe_version_proposed_slugs) and PRD-123 (unit_conversions /
+// ingredient_weights) tables are wiped too so re-running the seed stays
+// idempotent — the conversion tables carry a UNIQUE on (from_unit,to_unit)
+// / a partial UNIQUE on (ingredient_id, variant_id, unit) that would
+// otherwise collide on the second run.
 const FOOD_AND_LISTS_TABLES = [
   'list_items',
   'lists',
@@ -45,8 +50,13 @@ const FOOD_AND_LISTS_TABLES = [
   'plan_slots',
   'substitutions',
   'recipe_tags',
+  'recipe_lines',
+  'recipe_steps',
+  'recipe_version_proposed_slugs',
   'recipe_versions',
   'recipes',
+  'ingredient_weights',
+  'unit_conversions',
   'ingredient_aliases',
   'ingredient_variants',
   'prep_states',
@@ -74,23 +84,28 @@ try {
     const summary = seedFood(drizzleDb, drizzleDb, { compileRecipeVersion });
     console.log('\n✅ Food seed complete\n');
     console.log('📊 Counts:');
-    console.log(`  prep_states:       ${summary.prepStates}`);
-    console.log(`  ingredients:       ${summary.ingredients}`);
-    console.log(`  variants:          ${summary.variants}`);
-    console.log(`  aliases:           ${summary.aliases}`);
-    console.log(`  substitutions:     ${summary.substitutions}`);
-    console.log(`  plan_slots:        ${summary.planSlots}`);
-    console.log(`  plan_entries:      ${summary.planEntries}`);
-    console.log(`  recipes:           ${summary.recipes}`);
-    console.log(`  recipe_versions:   ${summary.recipeVersions}`);
-    console.log(`  batches:           ${summary.batches}`);
-    console.log(`  recipe_runs:       ${summary.recipeRuns}`);
-    console.log(`  batch_consumptions:${summary.batchConsumptions}`);
-    console.log(`  lists:             ${summary.lists}`);
-    console.log(`  list_items:        ${summary.listItems}`);
-    console.log(`  ingest_sources:    ${summary.ingestSources}`);
-    console.log(`  unit_conversions:  ${summary.unitConversions}`);
-    console.log(`  ingredient_weights:${summary.ingredientWeights}`);
+    const printRow = (label: string, value: number): void => {
+      // Pad to one space past the widest label so values line up regardless
+      // of which counters are present in the summary.
+      console.log(`  ${`${label}:`.padEnd(21)}${value}`);
+    };
+    printRow('prep_states', summary.prepStates);
+    printRow('ingredients', summary.ingredients);
+    printRow('variants', summary.variants);
+    printRow('aliases', summary.aliases);
+    printRow('substitutions', summary.substitutions);
+    printRow('plan_slots', summary.planSlots);
+    printRow('plan_entries', summary.planEntries);
+    printRow('recipes', summary.recipes);
+    printRow('recipe_versions', summary.recipeVersions);
+    printRow('batches', summary.batches);
+    printRow('recipe_runs', summary.recipeRuns);
+    printRow('batch_consumptions', summary.batchConsumptions);
+    printRow('lists', summary.lists);
+    printRow('list_items', summary.listItems);
+    printRow('ingest_sources', summary.ingestSources);
+    printRow('unit_conversions', summary.unitConversions);
+    printRow('ingredient_weights', summary.ingredientWeights);
   })();
 } finally {
   db.pragma('foreign_keys = ON');

--- a/packages/app-food/src/__tests__/seed-phase-2.test.ts
+++ b/packages/app-food/src/__tests__/seed-phase-2.test.ts
@@ -91,9 +91,26 @@ describe('PRD-113 phase-2 — seed + compile smoke', () => {
   });
 
   describe('summary + counts', () => {
-    it('returns non-skipped summary with the expected recipe count', () => {
+    it('returns non-skipped summary and seeds the required Phase-2 fixtures', () => {
+      // Assert by slug rather than exact count so adding a sample recipe in a
+      // later phase doesn't false-fail this test — the invariant we care
+      // about is "Phase-2 compile works for every seeded fixture", not the
+      // fixture count itself.
       expect(summary.skipped).toBe(false);
-      expect(summary.recipes).toBe(5);
+      const REQUIRED_SLUGS = [
+        'smash-patty',
+        'smash-burger',
+        'weeknight-pasta',
+        'roast-chicken',
+        'breakfast-eggs',
+      ] as const;
+      const seededSlugs = db.select({ slug: recipes.slug }).from(recipes).all();
+      const slugSet = new Set(seededSlugs.map((row) => row.slug));
+      for (const slug of REQUIRED_SLUGS) {
+        expect(slugSet.has(slug), `recipe "${slug}" missing from seed`).toBe(true);
+      }
+      expect(summary.recipes).toBe(seededSlugs.length);
+      expect(summary.recipes).toBeGreaterThanOrEqual(REQUIRED_SLUGS.length);
     });
 
     it('seeds PRD-123 conversion rows alongside the recipes', () => {

--- a/packages/app-food/src/__tests__/seed-phase-2.test.ts
+++ b/packages/app-food/src/__tests__/seed-phase-2.test.ts
@@ -1,0 +1,241 @@
+/**
+ * PRD-113 phase-2 — seed-driven cross-PRD compile smoke test.
+ *
+ * `seedFood` accepts a `compileRecipeVersion` callback. Production: the CLI
+ * passes PRD-116's real implementation. This test does the same and asserts
+ * the full compile path runs against the fixture set:
+ *
+ *   - every recipe ends up `compile_status='compiled'` and v1 is promoted to
+ *     `current` (PRD-107 promote service)
+ *   - `recipe_lines` and `recipe_steps` get populated per fixture
+ *   - the smash-burger plate's compile honours PRD-115's recipe-as-ingredient
+ *     resolution, with one `recipe_lines.is_recipe_ref=1` row pointing at
+ *     smash-patty (whose currentVersionId was set moments before)
+ *   - no `recipe_version_proposed_slugs` survive — auto-created yield slugs
+ *     resolve cleanly on the recompile pass
+ *   - cycle detection on smash-burger passes (no loops back into itself)
+ *   - PRD-123 conversion seeds let `normaliseLineQty` resolve qty:unit pairs
+ *     like `kg` → `g` and variant-specific `tsp` → `g`
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import Database from 'better-sqlite3';
+import { and, eq, sql } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import {
+  type FoodDb,
+  ingredientWeights,
+  recipeLines,
+  recipeVersionProposedSlugs,
+  recipeVersions,
+  recipes,
+  unitConversions,
+} from '@pops/app-food-db';
+import { seedFood, type SeedFoodSummary } from '@pops/app-food-db/seed';
+
+import { compileRecipeVersion } from '../dsl/compile';
+import { detectRecipeCycle } from '../dsl/cycle';
+import { parseRecipeDsl } from '../dsl/parser';
+import { resolveRecipeAst } from '../dsl/resolver';
+
+const MIGRATIONS = [
+  '0058_high_sentinel.sql',
+  '0059_useful_hiroim.sql',
+  '0060_familiar_leo.sql',
+  '0061_shocking_skreet.sql',
+  '0062_chemical_donald_blake.sql',
+  '0063_bumpy_wolverine.sql',
+  '0064_peaceful_magma.sql',
+  '0065_prd_116_recipe_compile.sql',
+  '0066_prd_123_conversions.sql',
+].map((name) =>
+  readFileSync(join(__dirname, '../../../../apps/pops-api/src/db/drizzle-migrations', name), 'utf8')
+);
+
+function freshDb(): { db: FoodDb; raw: Database.Database } {
+  const raw = new Database(':memory:');
+  raw.pragma('foreign_keys = ON');
+  for (const migration of MIGRATIONS) {
+    const stmts = migration.split('--> statement-breakpoint');
+    for (const stmt of stmts) {
+      const trimmed = stmt.trim();
+      if (trimmed.length > 0) raw.exec(trimmed);
+    }
+  }
+  return { db: drizzle(raw), raw };
+}
+
+function selectRecipeId(db: FoodDb, slug: string): number {
+  const rows = db.select({ id: recipes.id }).from(recipes).where(eq(recipes.slug, slug)).all();
+  const id = rows[0]?.id;
+  if (id === undefined) throw new Error(`recipe "${slug}" not in seed`);
+  return id;
+}
+
+describe('PRD-113 phase-2 — seed + compile smoke', () => {
+  let db: FoodDb;
+  let raw: Database.Database;
+  let summary: SeedFoodSummary;
+
+  // The seed is deterministic and every assertion below is read-only, so a
+  // single rebuild keeps the test suite light — important because the
+  // compile path drives 5 transactions through better-sqlite3 in series and
+  // running it per-`it` would dominate the wall-clock budget for the whole
+  // package's parallel vitest pool.
+  beforeAll(() => {
+    ({ db, raw } = freshDb());
+    summary = seedFood(db, db, { compileRecipeVersion });
+  });
+
+  describe('summary + counts', () => {
+    it('returns non-skipped summary with the expected recipe count', () => {
+      expect(summary.skipped).toBe(false);
+      expect(summary.recipes).toBe(5);
+    });
+
+    it('seeds PRD-123 conversion rows alongside the recipes', () => {
+      const ucRows = db
+        .select({ n: sql<number>`count(*)` })
+        .from(unitConversions)
+        .all();
+      const iwRows = db
+        .select({ n: sql<number>`count(*)` })
+        .from(ingredientWeights)
+        .all();
+      expect(ucRows[0]?.n ?? 0).toBe(summary.unitConversions);
+      expect(iwRows[0]?.n ?? 0).toBe(summary.ingredientWeights);
+      expect(summary.unitConversions).toBeGreaterThanOrEqual(10);
+      expect(summary.ingredientWeights).toBeGreaterThanOrEqual(4);
+    });
+
+    it('marks every seeded conversion row isSeeded=true (protected from delete)', () => {
+      const ucUnseeded = db
+        .select({ n: sql<number>`count(*)` })
+        .from(unitConversions)
+        .where(eq(unitConversions.isSeeded, 0))
+        .all();
+      const iwUnseeded = db
+        .select({ n: sql<number>`count(*)` })
+        .from(ingredientWeights)
+        .where(eq(ingredientWeights.isSeeded, 0))
+        .all();
+      expect(ucUnseeded[0]?.n ?? 0).toBe(0);
+      expect(iwUnseeded[0]?.n ?? 0).toBe(0);
+    });
+  });
+
+  describe('recipe compile state', () => {
+    it('compiles every fixture and promotes v1 to current', () => {
+      const rows = db
+        .select({
+          slug: recipes.slug,
+          currentVersionId: recipes.currentVersionId,
+          compileStatus: recipeVersions.compileStatus,
+          status: recipeVersions.status,
+          yieldIngredientId: recipeVersions.yieldIngredientId,
+        })
+        .from(recipes)
+        .innerJoin(recipeVersions, eq(recipeVersions.recipeId, recipes.id))
+        .all();
+      expect(rows.length).toBe(summary.recipes);
+      for (const row of rows) {
+        expect(row.currentVersionId, `recipe "${row.slug}" was not promoted`).not.toBeNull();
+        expect(row.compileStatus, `recipe "${row.slug}" did not compile`).toBe('compiled');
+        expect(row.status).toBe('current');
+        expect(
+          row.yieldIngredientId,
+          `recipe "${row.slug}" did not capture a yield ingredient`
+        ).not.toBeNull();
+      }
+    });
+
+    it('materialises recipe_lines for every fixture', () => {
+      const rows = raw
+        .prepare(
+          `SELECT r.slug, COUNT(rl.id) AS n
+             FROM recipes r JOIN recipe_versions v ON v.id = r.current_version_id
+             LEFT JOIN recipe_lines rl ON rl.recipe_version_id = v.id
+             GROUP BY r.slug`
+        )
+        .all() as { slug: string; n: number }[];
+      for (const row of rows) {
+        expect(row.n, `recipe "${row.slug}" materialised 0 lines`).toBeGreaterThan(0);
+      }
+    });
+
+    it('materialises recipe_steps for every fixture', () => {
+      const rows = raw
+        .prepare(
+          `SELECT r.slug, COUNT(rs.id) AS n
+             FROM recipes r JOIN recipe_versions v ON v.id = r.current_version_id
+             LEFT JOIN recipe_steps rs ON rs.recipe_version_id = v.id
+             GROUP BY r.slug`
+        )
+        .all() as { slug: string; n: number }[];
+      for (const row of rows) {
+        expect(row.n, `recipe "${row.slug}" materialised 0 steps`).toBeGreaterThan(0);
+      }
+    });
+
+    it('leaves no proposed_slugs after compile (every auto-create resolved)', () => {
+      const orphans = db
+        .select({ n: sql<number>`count(*)` })
+        .from(recipeVersionProposedSlugs)
+        .all();
+      expect(orphans[0]?.n ?? 0).toBe(0);
+    });
+  });
+
+  describe('recipe-as-ingredient (PRD-115)', () => {
+    it('smash-burger has one recipe_lines row pointing at smash-patty', () => {
+      const burgerId = selectRecipeId(db, 'smash-burger');
+      const pattyId = selectRecipeId(db, 'smash-patty');
+      const versionRow = db
+        .select({ id: recipes.currentVersionId })
+        .from(recipes)
+        .where(eq(recipes.id, burgerId))
+        .all()[0];
+      const versionId = versionRow?.id;
+      expect(versionId, 'smash-burger has no current_version_id').not.toBeNull();
+      const refs = db
+        .select({
+          recipeRefId: recipeLines.recipeRefId,
+          isRecipeRef: recipeLines.isRecipeRef,
+        })
+        .from(recipeLines)
+        .where(
+          and(eq(recipeLines.recipeVersionId, versionId as number), eq(recipeLines.isRecipeRef, 1))
+        )
+        .all();
+      expect(refs.length).toBe(1);
+      expect(refs[0]?.recipeRefId).toBe(pattyId);
+    });
+  });
+
+  describe('cycle detection (PRD-117)', () => {
+    it('smash-burger has no recipe cycle', () => {
+      const burgerId = selectRecipeId(db, 'smash-burger');
+      const versionRow = db
+        .select({ bodyDsl: recipeVersions.bodyDsl })
+        .from(recipeVersions)
+        .where(eq(recipeVersions.recipeId, burgerId))
+        .all()[0];
+      const bodyDsl = versionRow?.bodyDsl;
+      expect(bodyDsl).toBeDefined();
+      const parsed = parseRecipeDsl(bodyDsl as string);
+      expect(parsed.ok, 'smash-burger DSL re-parse failed').toBe(true);
+      if (!parsed.ok) return;
+      const resolved = resolveRecipeAst(parsed.ast, { db, currentRecipeId: burgerId });
+      expect(resolved.ok, 'smash-burger DSL re-resolve failed').toBe(true);
+      if (!resolved.ok) return;
+      const cycle = detectRecipeCycle(resolved.resolved, {
+        db,
+        currentRecipeId: burgerId,
+      });
+      expect(cycle.ok).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes the cross-PRD smoke test PRD-113 was originally specced as. `seedFood` now accepts a `compileRecipeVersion` callback so the seed CLI drives PRD-116's full **parse → resolve → cycle → materialise** pipeline against every fixture and promotes v1 of each recipe to `current`. Also seeds PRD-123's `unit_conversions` + `ingredient_weights` so the compile normalisation has rows to resolve against.

### What's exercised

- **PRD-114** — every recipe body rewritten in the real grammar (compact + named-arg forms; `@yield`; inline `@time` / `@temperature`).
- **PRD-115** — `smash-patty` is a new component fixture; `smash-burger` references it via `@ingredient(2, smash-patty, 4:count)`. The resolver hits the recipe-as-ingredient branch with a real `currentVersionId` because `smash-patty` is compiled + promoted before the plate is.
- **PRD-116** — `compileRecipeVersion` runs for every fixture; `recipe_lines` + `recipe_steps` get materialised; `recipe_versions.compile_status='compiled'` everywhere.
- **PRD-117** — cycle detector validates `smash-burger` against the real DB.
- **PRD-123** — 13 `unit_conversions` (`kg`, `cup`, `tbsp`, `tsp`, `each`, …) + 6 `ingredient_weights` covering variant-specific (`flour:plain cup → 125g`, `salt:table tsp → 6g`) and null-variant fallback (`butter cup → 227g`) lookups. Every seeded row is `isSeeded=true` so the conversions UI blocks accidental deletes via `SeededRowProtected`.

### Architecture cut

`@pops/app-food-db` stays free of any dependency on the React-bound `@pops/app-food` (would close a turbo build cycle through `@pops/api-client`). The compile callback is injected:

- Production: `packages/app-food/scripts/db-seed-food.ts` imports `compileRecipeVersion` from `@pops/app-food` and passes it.
- Tests in `@pops/app-food-db` keep the Phase-1 fallback (`seedRecipeHeaders`) so they run in isolation.
- New integration suite in `@pops/app-food` drives the full Phase-2 path with the real compile.

## Test plan

- [x] `pnpm --filter @pops/app-food-db typecheck` clean
- [x] `pnpm --filter @pops/app-food-db build` clean
- [x] `pnpm --filter @pops/app-food-db test` — 204 / 204 pass (Phase-1+3 invariants + new PRD-123 count assertions + new manual-slug `smash-patty`)
- [x] `pnpm --filter @pops/app-food typecheck` clean
- [x] `pnpm --filter @pops/app-food test src/__tests__/seed-phase-2.test.ts` — 9 / 9 pass (full Phase-2 compile smoke)
- [x] `pnpm --filter @pops/pops-api test` — 4483 / 4483 pass
- [x] `pnpm lint` — no new errors in touched files

> Note: `apps/pops-food/src/pages/data/__tests__/FoodDataLayout.test.tsx` is a known-flaky lazy-route timing test (its own header acknowledges "consistently slow enough on CI runners" and bumps one assertion to 3s). The flakiness is reproducible on `main` without this PR; the other 18 test files in `@pops/app-food` consistently pass.

## PRD-113 acceptance criteria progress

Tooling, Documentation, "what can I cook" smoke: not addressed in this PR (PRD-150 solver still pending; tooling AC already partially met by Phase 1).

Fixture content:
- [x] 5 sample recipes with `compile_status='compiled'` and `recipes.current_version_id` set
- [x] `smash-burger` has `recipe_lines.is_recipe_ref=1` pointing at `smash-patty` (the spec mentions `caramelised-cheese-toastie → caramelised-onions`; in practice the seed pivoted to `smash-burger → smash-patty`)
- [x] No `recipe_version_proposed_slugs` rows after seed
- [x] `≥10 substitutions`, `≥30 aliases`, `15 prep_states` retained from Phase 1
- [x] **PRD-117** cycle detector returns `ok: true` for `smash-burger`

## Coordination with in-flight PRDs

Strictly additive. Only shared files touched:

- `packages/app-food-db/src/seed/index.ts` — append `seedConversions` step + add optional `options.compileRecipeVersion` param.
- `packages/app-food-db/src/seed/types.ts` — extend `StepCounts` with `unitConversions` + `ingredientWeights`.
- `packages/app-food-db/src/seed/step-recipes.ts` — add `seedRecipesAndCompile` alongside `seedRecipeHeaders` (the latter retained).
- `packages/app-food-db/src/seed/data-recipes.ts` — bodies rewritten in proper grammar; adds `smash-patty`.
- `packages/app-food-db/src/__tests__/seed.test.ts` — bump recipe-count floor to 5; add PRD-123 count assertions; add `smash-patty` to the manual-slug check.
- `packages/app-food/scripts/db-seed-food.ts` — wire `compileRecipeVersion`.

Disjoint from 122-B (different file tree under `pages/data/ingredients/`), 122-D (different file tree under `pages/data/substitutions/`), 120-C / 120-D (different file tree under `components/dsl-editor/`), 148 (different file tree under `pages/data/substitutions/graph/`), 139 (different package), and 125 (different layer entirely).