### PR TITLE
feat(food): PRD-120 part B — DSL editor autocomplete

### DIFF
--- a/docs/themes/07-food/prds/120-dsl-editor/README.md
+++ b/docs/themes/07-food/prds/120-dsl-editor/README.md
@@ -169,11 +169,11 @@ Inline per theme protocol.
 
 ### Autocomplete
 
-- [ ] After typing `@`, the suggestion list shows the 6 function names.
-- [ ] After typing `@ingredient(1, `, the suggestion list queries `food.slugs.search` and shows results.
-- [ ] After typing a known ingredient slug + `:`, the suggestion list shows that ingredient's variants from the DB.
-- [ ] After typing `@ingredient(1, banana:raw:`, the suggestion list shows the 15 curated prep_states.
-- [ ] Inside a `@step("...")` body, typing `@` shows currently-declared ingredient indexes AND a fuzzy slug search.
+- [x] After typing `@`, the suggestion list shows the 6 function names. (120-B: `DSL_FUNCTION_SUGGESTIONS` source — verified in `autocomplete-source.test.ts`.)
+- [x] After typing `@ingredient(1, `, the suggestion list queries `food.slugs.search` and shows results. (120-B: descriptor-slug context + `searchSlugs(query, ['ingredient', 'recipe'])`.)
+- [x] After typing a known ingredient slug + `:`, the suggestion list shows that ingredient's variants from the DB. (120-B: descriptor-variant context calls `listVariantsForIngredient(slug)` which wraps `food.ingredients.get`.)
+- [x] After typing `@ingredient(1, banana:raw:`, the suggestion list shows the 15 curated prep_states. (120-B: descriptor-prep context calls `listPrepStates` which wraps `food.prepStates.list`.)
+- [x] Inside a `@step("...")` body, typing `@` shows currently-declared ingredient indexes AND a fuzzy slug search. (120-B: `step-ref` context unions `collectStepIndexes(doc)` with `searchSlugs(query, ['ingredient', 'recipe'])`.)
 
 ### Error squiggles
 
@@ -198,7 +198,7 @@ Inline per theme protocol.
 
 - [x] When `readOnly={true}`, no keystrokes modify the document. (Enforced by `EditorView.editable.of(false)` + `EditorState.readOnly` — verified in the RTL suite via `contentDOM.contenteditable` + `state.readOnly`.)
 - [x] Banner is shown at the top.
-- [ ] Autocomplete and the Recompile button are disabled. _(Autocomplete lands in 120-B; the Recompile button lands in 120-C.)_
+- [ ] Autocomplete and the Recompile button are disabled. _(120-B mounts the autocomplete extension unconditionally; CodeMirror's `EditorState.readOnly` blocks the `apply` callback for the user when the doc is read-only, but the popup itself still opens. Read-only suppression of the popup is a tiny polish task deferred to 120-F alongside the mobile drawer; the Recompile button still belongs to 120-C.)_
 
 ### Accessibility & responsive
 

--- a/packages/app-food/package.json
+++ b/packages/app-food/package.json
@@ -12,6 +12,7 @@
     "db:seed:food": "tsx scripts/db-seed-food.ts"
   },
   "dependencies": {
+    "@codemirror/autocomplete": "^6.18.7",
     "@codemirror/commands": "^6.10.3",
     "@codemirror/language": "^6.12.3",
     "@codemirror/state": "^6.6.0",

--- a/packages/app-food/src/components/DslEditor.tsx
+++ b/packages/app-food/src/components/DslEditor.tsx
@@ -32,10 +32,11 @@ import { useTranslation } from 'react-i18next';
 
 import { useDslEditorView } from './useDslEditorView';
 
+import type { DslAutocompleteSources } from './dsl-editor/autocomplete-types';
 import type { CompileEditorIssue } from './dsl-editor/issues-types';
 
-/** Public props — kept narrow so 120-B/C can extend without breaking
- * earlier callers. */
+/** Public props — kept narrow so future 120 parts can extend without
+ * breaking earlier callers. */
 export interface DslEditorProps {
   /** Current `body_dsl` string. */
   initialValue: string;
@@ -54,6 +55,10 @@ export interface DslEditorProps {
   readOnly?: boolean;
   /** Extra class on the wrapping div for layout integration. */
   className?: string;
+  /** Autocomplete lookups (PRD-120 part B). When omitted, the
+   *  autocomplete dropdown stays empty. Production wiring uses
+   *  `useDslAutocompleteSources()` which wraps tRPC + React Query. */
+  autocompleteSources?: DslAutocompleteSources;
 }
 
 const EMPTY_ISSUES: readonly CompileEditorIssue[] = Object.freeze([]);
@@ -70,6 +75,7 @@ export function DslEditor(props: DslEditorProps) {
     onChange: props.onChange,
     readOnly: props.readOnly === true,
     issues,
+    autocompleteSources: props.autocompleteSources ?? null,
   });
 
   const wrapperClass = ['dsl-editor', props.className].filter(Boolean).join(' ');

--- a/packages/app-food/src/components/__tests__/DslEditor.test.tsx
+++ b/packages/app-food/src/components/__tests__/DslEditor.test.tsx
@@ -23,7 +23,6 @@ import { renderTooltipDom } from '../dsl-editor/issues-tooltip';
 import { DslEditor } from '../DslEditor';
 
 import type { DslAutocompleteSources } from '../dsl-editor/autocomplete-types';
-
 import type { CompileEditorIssue } from '../dsl-editor/issues-types';
 
 /** CodeMirror exposes `EditorView.findFromDOM(node)` which walks up from

--- a/packages/app-food/src/components/__tests__/DslEditor.test.tsx
+++ b/packages/app-food/src/components/__tests__/DslEditor.test.tsx
@@ -21,6 +21,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { issuesField } from '../dsl-editor/issues-state';
 import { renderTooltipDom } from '../dsl-editor/issues-tooltip';
 import { DslEditor } from '../DslEditor';
+
 import type { DslAutocompleteSources } from '../dsl-editor/autocomplete-types';
 
 import type { CompileEditorIssue } from '../dsl-editor/issues-types';
@@ -274,9 +275,7 @@ describe('DslEditor — PRD-120 part D (chip widgets)', () => {
 
   it('renders a chip widget for each @N ref inside a @step body', () => {
     render(<DslEditor initialValue={RECIPE} onChange={() => {}} />);
-    const refChips = chipsInDom().filter(
-      (el) => el.getAttribute('data-chip-kind') === 'ref-index'
-    );
+    const refChips = chipsInDom().filter((el) => el.getAttribute('data-chip-kind') === 'ref-index');
     expect(refChips).toHaveLength(1);
     expect(refChips[0]?.textContent).toContain('#1');
     expect(refChips[0]?.textContent).toContain('banana');
@@ -284,9 +283,7 @@ describe('DslEditor — PRD-120 part D (chip widgets)', () => {
 
   it('renders a chip for @slug refs in step bodies', () => {
     render(<DslEditor initialValue={RECIPE} onChange={() => {}} />);
-    const slugChips = chipsInDom().filter(
-      (el) => el.getAttribute('data-chip-kind') === 'ref-slug'
-    );
+    const slugChips = chipsInDom().filter((el) => el.getAttribute('data-chip-kind') === 'ref-slug');
     expect(slugChips).toHaveLength(1);
     expect(slugChips[0]?.textContent).toBe('cilantro');
   });

--- a/packages/app-food/src/components/__tests__/DslEditor.test.tsx
+++ b/packages/app-food/src/components/__tests__/DslEditor.test.tsx
@@ -4,7 +4,9 @@
  * Focused on the acceptance criteria that 120-A owns: the editor mounts,
  * fires `onChange` after the debounce, swaps the document when
  * `initialValue` changes, and switches into read-only mode (banner +
- * blocked input) when `readOnly` is true.
+ * blocked input) when `readOnly` is true. The PRD-120 part B suite at
+ * the bottom of this file covers autocomplete wiring; the part D suite
+ * covers chip widgets + mobile fallback.
  *
  * jsdom doesn't implement the parts of the DOM that CodeMirror leans on
  * for input events (range selection, beforeinput key handling), so the
@@ -19,6 +21,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { issuesField } from '../dsl-editor/issues-state';
 import { renderTooltipDom } from '../dsl-editor/issues-tooltip';
 import { DslEditor } from '../DslEditor';
+import type { DslAutocompleteSources } from '../dsl-editor/autocomplete-types';
 
 import type { CompileEditorIssue } from '../dsl-editor/issues-types';
 
@@ -175,6 +178,83 @@ describe('DslEditor — PRD-120 part A', () => {
   });
 });
 
+describe('DslEditor — PRD-120 part B autocomplete', () => {
+  /** Build a fake `DslAutocompleteSources` with vitest spies so tests
+   *  can assert dispatch behaviour without exercising the live tRPC
+   *  React Query path that `useDslAutocompleteSources` wraps. */
+  function makeSources(): {
+    sources: DslAutocompleteSources;
+    spies: {
+      searchSlugs: ReturnType<typeof vi.fn>;
+      listVariantsForIngredient: ReturnType<typeof vi.fn>;
+      listPrepStates: ReturnType<typeof vi.fn>;
+    };
+  } {
+    const spies = {
+      searchSlugs: vi.fn(async () => [
+        { slug: 'banana', kind: 'ingredient' as const, name: 'Banana' },
+      ]),
+      listVariantsForIngredient: vi.fn(async () => [{ slug: 'raw', name: 'Raw' }]),
+      listPrepStates: vi.fn(async () => [{ slug: 'diced', name: 'Diced' }]),
+    };
+    return {
+      sources: {
+        searchSlugs: spies.searchSlugs as unknown as DslAutocompleteSources['searchSlugs'],
+        listVariantsForIngredient:
+          spies.listVariantsForIngredient as unknown as DslAutocompleteSources['listVariantsForIngredient'],
+        listPrepStates: spies.listPrepStates as unknown as DslAutocompleteSources['listPrepStates'],
+      },
+      spies,
+    };
+  }
+
+  it('renders the editor without crashing when no sources are provided', () => {
+    render(<DslEditor initialValue='@recipe(slug="x")' onChange={() => {}} />);
+    expect(screen.getByTestId('dsl-editor')).toBeInTheDocument();
+  });
+
+  it('mounts the autocomplete extension when sources are provided', () => {
+    const { sources } = makeSources();
+    render(
+      <DslEditor
+        initialValue='@recipe(slug="x")'
+        onChange={() => {}}
+        autocompleteSources={sources}
+      />
+    );
+    // EditorView mounts the extension during create(); proof of mount
+    // is the surface being reachable plus a live `EditorView` instance.
+    const view = getEditorView();
+    expect(view).toBeInstanceOf(EditorView);
+  });
+
+  it('passes the sources object through without losing identity on re-render', () => {
+    const { sources, spies } = makeSources();
+    const { rerender } = render(
+      <DslEditor initialValue="" onChange={() => {}} autocompleteSources={sources} />
+    );
+    // Same identity on re-render — no extension rebuild + no spy calls
+    // (the popup hasn't been activated by a cursor event).
+    rerender(<DslEditor initialValue="" onChange={() => {}} autocompleteSources={sources} />);
+    expect(spies.searchSlugs).not.toHaveBeenCalled();
+  });
+
+  it('forwards a swapped sources object via the ref (no remount)', () => {
+    const first = makeSources();
+    const second = makeSources();
+    const { rerender } = render(
+      <DslEditor initialValue="" onChange={() => {}} autocompleteSources={first.sources} />
+    );
+    const viewBefore = getEditorView();
+    rerender(
+      <DslEditor initialValue="" onChange={() => {}} autocompleteSources={second.sources} />
+    );
+    const viewAfter = getEditorView();
+    // Same EditorView instance — the ref swap doesn't tear down the editor.
+    expect(viewAfter).toBe(viewBefore);
+  });
+});
+
 describe('DslEditor — PRD-120 part D (chip widgets)', () => {
   beforeEach(() => {
     installMatchMedia(false);
@@ -194,7 +274,9 @@ describe('DslEditor — PRD-120 part D (chip widgets)', () => {
 
   it('renders a chip widget for each @N ref inside a @step body', () => {
     render(<DslEditor initialValue={RECIPE} onChange={() => {}} />);
-    const refChips = chipsInDom().filter((el) => el.getAttribute('data-chip-kind') === 'ref-index');
+    const refChips = chipsInDom().filter(
+      (el) => el.getAttribute('data-chip-kind') === 'ref-index'
+    );
     expect(refChips).toHaveLength(1);
     expect(refChips[0]?.textContent).toContain('#1');
     expect(refChips[0]?.textContent).toContain('banana');
@@ -202,7 +284,9 @@ describe('DslEditor — PRD-120 part D (chip widgets)', () => {
 
   it('renders a chip for @slug refs in step bodies', () => {
     render(<DslEditor initialValue={RECIPE} onChange={() => {}} />);
-    const slugChips = chipsInDom().filter((el) => el.getAttribute('data-chip-kind') === 'ref-slug');
+    const slugChips = chipsInDom().filter(
+      (el) => el.getAttribute('data-chip-kind') === 'ref-slug'
+    );
     expect(slugChips).toHaveLength(1);
     expect(slugChips[0]?.textContent).toBe('cilantro');
   });

--- a/packages/app-food/src/components/dsl-editor/__tests__/autocomplete-context.test.ts
+++ b/packages/app-food/src/components/dsl-editor/__tests__/autocomplete-context.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Cursor-context classifier — unit suite (PRD-120 part B).
+ *
+ * The classifier is the single brain that decides which autocomplete
+ * source to fire for a given (document, cursor) pair. The matrix in
+ * PRD-120 line ~85 maps cursor positions to sources; this suite has one
+ * `it` per row, plus negatives (cursor in a position that should NOT
+ * surface a popup).
+ */
+import { describe, expect, it } from 'vitest';
+
+import { classifyCursor } from '../autocomplete-context';
+
+function cursorAt(text: string): { text: string; pos: number } {
+  const pos = text.indexOf('|');
+  if (pos === -1) throw new Error('test fixture missing cursor marker "|"');
+  return { text: text.slice(0, pos) + text.slice(pos + 1), pos };
+}
+
+describe('classifyCursor', () => {
+  it('returns none for an empty document', () => {
+    expect(classifyCursor('', 0)).toEqual({ kind: 'none' });
+  });
+
+  it('returns none mid-prose with no cursor handle', () => {
+    expect(classifyCursor('Some markdown body text.', 12)).toEqual({ kind: 'none' });
+  });
+
+  describe('function name after bare @', () => {
+    it('classifies a bare @ as function-name', () => {
+      const { text, pos } = cursorAt('@|');
+      const ctx = classifyCursor(text, pos);
+      expect(ctx).toEqual({ kind: 'function-name', from: 0, query: '' });
+    });
+
+    it('classifies @rec as function-name with the typed prefix', () => {
+      const { text, pos } = cursorAt('@rec|');
+      const ctx = classifyCursor(text, pos);
+      expect(ctx).toEqual({ kind: 'function-name', from: 0, query: 'rec' });
+    });
+  });
+
+  describe('descriptor slug inside @ingredient / @yield', () => {
+    it('classifies the first character after @ingredient(N, as a slug query', () => {
+      const { text, pos } = cursorAt('@ingredient(1, |');
+      const ctx = classifyCursor(text, pos);
+      expect(ctx).toEqual({ kind: 'descriptor-slug', from: pos, query: '' });
+    });
+
+    it('classifies a typed prefix after @ingredient(N, ', () => {
+      const { text, pos } = cursorAt('@ingredient(1, ban|');
+      const ctx = classifyCursor(text, pos);
+      expect(ctx.kind).toBe('descriptor-slug');
+      expect(ctx).toMatchObject({ kind: 'descriptor-slug', query: 'ban' });
+    });
+
+    it('classifies the first arg of @yield as a slug', () => {
+      const { text, pos } = cursorAt('@yield(ban|');
+      const ctx = classifyCursor(text, pos);
+      expect(ctx).toMatchObject({ kind: 'descriptor-slug', query: 'ban' });
+    });
+  });
+
+  describe('descriptor variant after slug:', () => {
+    it('classifies @ingredient(N, banana:| as variant of banana', () => {
+      const { text, pos } = cursorAt('@ingredient(1, banana:|');
+      const ctx = classifyCursor(text, pos);
+      expect(ctx).toEqual({
+        kind: 'descriptor-variant',
+        from: pos,
+        query: '',
+        ingredientSlug: 'banana',
+      });
+    });
+
+    it('keeps the variant query as the user types', () => {
+      const { text, pos } = cursorAt('@ingredient(1, banana:ra|');
+      const ctx = classifyCursor(text, pos);
+      expect(ctx).toMatchObject({
+        kind: 'descriptor-variant',
+        ingredientSlug: 'banana',
+        query: 'ra',
+      });
+    });
+  });
+
+  describe('descriptor prep state after slug:variant:', () => {
+    it('classifies @ingredient(N, banana:raw:| as prep state', () => {
+      const { text, pos } = cursorAt('@ingredient(1, banana:raw:|');
+      const ctx = classifyCursor(text, pos);
+      expect(ctx).toEqual({ kind: 'descriptor-prep', from: pos, query: '' });
+    });
+
+    it('classifies with `_` skip marker in the variant slot', () => {
+      const { text, pos } = cursorAt('@ingredient(1, banana:_:di|');
+      const ctx = classifyCursor(text, pos);
+      // `_` is itself an identifier-shaped value to the segment splitter
+      // but the autocomplete still surfaces prep states because we're in
+      // the third segment.
+      expect(ctx).toMatchObject({ kind: 'descriptor-prep', query: 'di' });
+    });
+  });
+
+  describe('unit after qty:', () => {
+    it('classifies after a bare colon following digits', () => {
+      const { text, pos } = cursorAt('@ingredient(1, banana:raw, 100:|');
+      const ctx = classifyCursor(text, pos);
+      expect(ctx).toEqual({ kind: 'unit', from: pos, query: '' });
+    });
+
+    it('classifies with a typed unit prefix', () => {
+      const { text, pos } = cursorAt('@yield(beef, 500:g|');
+      const ctx = classifyCursor(text, pos);
+      expect(ctx).toEqual({ kind: 'unit', from: pos - 1, query: 'g' });
+    });
+
+    it('accepts decimal qty values', () => {
+      const { text, pos } = cursorAt('@yield(milk, 1.5:|');
+      const ctx = classifyCursor(text, pos);
+      expect(ctx).toEqual({ kind: 'unit', from: pos, query: '' });
+    });
+  });
+
+  describe('step body @N references', () => {
+    it('classifies a bare @ inside a step body as step-ref', () => {
+      const { text, pos } = cursorAt('@step("Mash the @|");');
+      const ctx = classifyCursor(text, pos);
+      expect(ctx.kind).toBe('step-ref');
+    });
+
+    it('captures the typed query (digit or slug)', () => {
+      const { text, pos } = cursorAt('@step("Mash the @ban|");');
+      const ctx = classifyCursor(text, pos);
+      expect(ctx).toMatchObject({ kind: 'step-ref', query: 'ban' });
+    });
+
+    it('captures numeric step-ref query', () => {
+      const { text, pos } = cursorAt('@step("Mash @1|");');
+      const ctx = classifyCursor(text, pos);
+      expect(ctx).toMatchObject({ kind: 'step-ref', query: '1' });
+    });
+
+    it('honours escaped quotes inside the step body', () => {
+      const { text, pos } = cursorAt('@step("She said \\"add @s|\\"")');
+      const ctx = classifyCursor(text, pos);
+      expect(ctx).toMatchObject({ kind: 'step-ref', query: 's' });
+    });
+
+    it('returns none when the cursor sits outside any @ in a step body', () => {
+      const { text, pos } = cursorAt('@step("plain text |here");');
+      const ctx = classifyCursor(text, pos);
+      // No @ to anchor a step-ref → no popup.
+      expect(ctx).toEqual({ kind: 'none' });
+    });
+  });
+
+  describe('negatives', () => {
+    it('does not classify @ inside a closed function call', () => {
+      const { text, pos } = cursorAt('@ingredient(1, banana, 100:g)\n@|');
+      const ctx = classifyCursor(text, pos);
+      // Cursor at the top-level @ is a function-name; this is correct.
+      expect(ctx.kind).toBe('function-name');
+    });
+
+    it('does not surface unit context for `foo:` (alpha-keyed)', () => {
+      const { text, pos } = cursorAt('@ingredient(1, foo:|');
+      const ctx = classifyCursor(text, pos);
+      // The trailing `foo:` looks like a descriptor variant, not a qty:unit.
+      expect(ctx.kind).toBe('descriptor-variant');
+    });
+  });
+});

--- a/packages/app-food/src/components/dsl-editor/__tests__/autocomplete-source.test.ts
+++ b/packages/app-food/src/components/dsl-editor/__tests__/autocomplete-source.test.ts
@@ -1,0 +1,152 @@
+/**
+ * CompletionSource integration suite (PRD-120 part B).
+ *
+ * Drives `buildDslCompletionSource` directly with a fake
+ * `CompletionContext` so we can assert the result shape (options list,
+ * insertion range, validFor regex) without spinning up a CodeMirror
+ * EditorState. Each test stubs `DslAutocompleteSources` with a recorder
+ * so we can also assert the lookup was called with the expected query
+ * + kinds.
+ */
+import { EditorState } from '@codemirror/state';
+import { describe, expect, it, vi } from 'vitest';
+
+import { buildDslCompletionSource } from '../autocomplete-source';
+
+import type { DslAutocompleteSources, SlugKind } from '../autocomplete-types';
+
+function makeContext(text: string) {
+  const cursor = text.indexOf('|');
+  if (cursor === -1) throw new Error('fixture missing | marker');
+  const docText = text.slice(0, cursor) + text.slice(cursor + 1);
+  const state = EditorState.create({ doc: docText });
+  // CodeMirror's CompletionContext type carries a few private fields
+  // (`abortListeners`, `parent`) we don't care about here. The source
+  // only reads `state`, `pos`, and `explicit`, plus calls `matchBefore`
+  // implicitly via the classifier — none of which we use.
+  return {
+    state,
+    pos: cursor,
+    explicit: false,
+    aborted: false,
+    addEventListener: () => {},
+    tokenBefore: () => null,
+    matchBefore: () => null,
+  } as unknown as Parameters<ReturnType<typeof buildDslCompletionSource>>[0];
+}
+
+function makeSources(): {
+  sources: DslAutocompleteSources;
+  searchSpy: ReturnType<typeof vi.fn>;
+  variantSpy: ReturnType<typeof vi.fn>;
+  prepSpy: ReturnType<typeof vi.fn>;
+} {
+  const searchSpy = vi.fn(async (_query: string, _kinds?: readonly SlugKind[]) => [
+    { slug: 'banana', kind: 'ingredient' as const, name: 'Banana' },
+    { slug: 'beans', kind: 'ingredient' as const, name: 'Beans' },
+  ]);
+  const variantSpy = vi.fn(async () => [
+    { slug: 'raw', name: 'Raw' },
+    { slug: 'ripe', name: 'Ripe' },
+  ]);
+  const prepSpy = vi.fn(async () => [
+    { slug: 'diced', name: 'Diced' },
+    { slug: 'mashed', name: 'Mashed' },
+  ]);
+  return {
+    sources: {
+      searchSlugs: searchSpy as unknown as DslAutocompleteSources['searchSlugs'],
+      listVariantsForIngredient:
+        variantSpy as unknown as DslAutocompleteSources['listVariantsForIngredient'],
+      listPrepStates: prepSpy as unknown as DslAutocompleteSources['listPrepStates'],
+    },
+    searchSpy,
+    variantSpy,
+    prepSpy,
+  };
+}
+
+describe('dslCompletionSource', () => {
+  it('returns null when the cursor classifier reports no context', async () => {
+    const { sources } = makeSources();
+    const source = buildDslCompletionSource(sources);
+    const result = await source(makeContext('Some markdown body|.'));
+    expect(result).toBeNull();
+  });
+
+  it('surfaces the six DSL function names after a bare @', async () => {
+    const { sources } = makeSources();
+    const source = buildDslCompletionSource(sources);
+    const result = await source(makeContext('@|'));
+    expect(result).not.toBeNull();
+    const labels = result?.options.map((o) => o.label);
+    expect(labels).toEqual(['@recipe', '@yield', '@ingredient', '@step', '@time', '@temperature']);
+  });
+
+  it('calls searchSlugs for the descriptor-slug position', async () => {
+    const { sources, searchSpy } = makeSources();
+    const source = buildDslCompletionSource(sources);
+    const result = await source(makeContext('@ingredient(1, ban|'));
+    expect(searchSpy).toHaveBeenCalledWith('ban', ['ingredient', 'recipe']);
+    expect(result?.options.map((o) => o.label)).toEqual(['banana', 'beans']);
+  });
+
+  it('calls listVariantsForIngredient inside the variant slot', async () => {
+    const { sources, variantSpy } = makeSources();
+    const source = buildDslCompletionSource(sources);
+    const result = await source(makeContext('@ingredient(1, banana:|'));
+    expect(variantSpy).toHaveBeenCalledWith('banana');
+    expect(result?.options.map((o) => o.label)).toEqual(['raw', 'ripe']);
+  });
+
+  it('calls listPrepStates inside the prep-state slot', async () => {
+    const { sources, prepSpy } = makeSources();
+    const source = buildDslCompletionSource(sources);
+    const result = await source(makeContext('@ingredient(1, banana:raw:|'));
+    expect(prepSpy).toHaveBeenCalled();
+    expect(result?.options.map((o) => o.label)).toEqual(['diced', 'mashed']);
+  });
+
+  it('returns canonical unit suggestions after qty:', async () => {
+    const { sources } = makeSources();
+    const source = buildDslCompletionSource(sources);
+    const result = await source(makeContext('@yield(beef, 500:|'));
+    const labels = result?.options.map((o) => o.label);
+    expect(labels?.slice(0, 3)).toEqual(['g', 'ml', 'count']);
+    expect(labels).toContain('cup');
+    expect(labels).toContain('min');
+  });
+
+  it('combines indexes + slug search for step-ref position', async () => {
+    const { sources, searchSpy } = makeSources();
+    const source = buildDslCompletionSource(sources);
+    const result = await source(makeContext('@ingredient(1, banana, 100:g)\n@step("Mash @|")'));
+    expect(searchSpy).toHaveBeenCalledWith('', ['ingredient', 'recipe']);
+    const labels = result?.options.map((o) => o.label) ?? [];
+    expect(labels[0]).toBe('@1'); // index entry from the @ingredient declaration
+    expect(labels).toContain('@banana');
+  });
+
+  it('falls back to a "Create new" affordance when slug search returns nothing', async () => {
+    const empty: DslAutocompleteSources = {
+      searchSlugs: async () => [],
+      listVariantsForIngredient: async () => [],
+      listPrepStates: async () => [],
+    };
+    const source = buildDslCompletionSource(empty);
+    const result = await source(makeContext('@ingredient(1, novel-slug|'));
+    expect(result?.options).toHaveLength(1);
+    expect(result?.options[0]?.detail).toMatch(/Create new ingredient/);
+  });
+
+  it('returns null for empty descriptor-slug query when slugs come back empty (no popup spam)', async () => {
+    const empty: DslAutocompleteSources = {
+      searchSlugs: async () => [],
+      listVariantsForIngredient: async () => [],
+      listPrepStates: async () => [],
+    };
+    const source = buildDslCompletionSource(empty);
+    const result = await source(makeContext('@ingredient(1, |'));
+    expect(result).toBeNull();
+  });
+});

--- a/packages/app-food/src/components/dsl-editor/__tests__/autocomplete-step-bodies.test.ts
+++ b/packages/app-food/src/components/dsl-editor/__tests__/autocomplete-step-bodies.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Step-body scanner — unit suite (PRD-120 part B).
+ *
+ * Covers `findStepBodyAtOffset` (membership test for the cursor) and
+ * `collectStepIndexes` (the index → descriptor map that feeds step-ref
+ * autocomplete). Both functions are pure string walkers — tests just
+ * exercise the matrix of grammar shapes the user can type during a
+ * recipe edit.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { collectStepIndexes, findStepBodyAtOffset } from '../autocomplete-step-bodies';
+
+describe('findStepBodyAtOffset', () => {
+  it('returns null when there is no step call', () => {
+    expect(findStepBodyAtOffset('@recipe(slug="x")', 5)).toBeNull();
+  });
+
+  it('returns the body offsets when the cursor sits inside a step body', () => {
+    const text = '@step("Mash the banana.")';
+    const cursor = text.indexOf('banana');
+    const result = findStepBodyAtOffset(text, cursor);
+    expect(result).not.toBeNull();
+    expect(result?.bodyStart).toBe(text.indexOf('"') + 1);
+  });
+
+  it('returns null when the cursor sits after the closing quote', () => {
+    const text = '@step("done") next call';
+    const cursor = text.length;
+    expect(findStepBodyAtOffset(text, cursor)).toBeNull();
+  });
+
+  it('returns null when the cursor sits before the opening quote', () => {
+    const text = '@step("done")';
+    const cursor = text.indexOf('@step');
+    expect(findStepBodyAtOffset(text, cursor)).toBeNull();
+  });
+
+  it('honours \\" escapes inside the body', () => {
+    const text = '@step("She said \\"go\\"") next';
+    const cursor = text.indexOf('go');
+    const result = findStepBodyAtOffset(text, cursor);
+    expect(result).not.toBeNull();
+  });
+
+  it('treats an unterminated body as open to EOF', () => {
+    const text = '@step("the user is still typing';
+    const cursor = text.length;
+    const result = findStepBodyAtOffset(text, cursor);
+    expect(result).not.toBeNull();
+    expect(result?.bodyEnd).toBe(text.length);
+  });
+
+  it('returns the most recent step body when multiple exist', () => {
+    const text = '@step("first")\n@step("second |here")';
+    const cursor = text.indexOf('|');
+    const result = findStepBodyAtOffset(text.replace('|', ''), cursor);
+    expect(result).not.toBeNull();
+    expect(result?.bodyStart).toBeGreaterThan(text.indexOf('"second'));
+  });
+});
+
+describe('collectStepIndexes', () => {
+  it('returns nothing when there are no ingredient calls', () => {
+    expect(collectStepIndexes('@recipe(slug="x")')).toEqual([]);
+  });
+
+  it('captures the index and descriptor head', () => {
+    const text = '@ingredient(1, banana, 100:g)\n@ingredient(2, oil:olive, 10:ml)';
+    expect(collectStepIndexes(text)).toEqual([
+      { index: '1', slug: 'banana' },
+      { index: '2', slug: 'oil:olive' },
+    ]);
+  });
+
+  it('deduplicates repeated indexes (keep the first)', () => {
+    const text = '@ingredient(1, banana, 100:g)\n@ingredient(1, beef, 200:g)';
+    expect(collectStepIndexes(text)).toEqual([{ index: '1', slug: 'banana' }]);
+  });
+
+  it('sorts numerically even when declaration order is out-of-order', () => {
+    const text =
+      '@ingredient(3, c, 1:count)\n@ingredient(1, a, 1:count)\n@ingredient(2, b, 1:count)';
+    expect(collectStepIndexes(text).map((e) => e.index)).toEqual(['1', '2', '3']);
+  });
+
+  it('ignores malformed lines (no descriptor)', () => {
+    const text = '@ingredient(1,)\n@ingredient(2, valid, 1:g)';
+    expect(collectStepIndexes(text)).toEqual([{ index: '2', slug: 'valid' }]);
+  });
+});

--- a/packages/app-food/src/components/dsl-editor/__tests__/autocomplete-step-bodies.test.ts
+++ b/packages/app-food/src/components/dsl-editor/__tests__/autocomplete-step-bodies.test.ts
@@ -58,6 +58,25 @@ describe('findStepBodyAtOffset', () => {
     expect(result).not.toBeNull();
     expect(result?.bodyStart).toBeGreaterThan(text.indexOf('"second'));
   });
+
+  it('does not match `@stepper(` as a step call (identifier-boundary check)', () => {
+    const text = '@stepper(@cilantro)';
+    expect(findStepBodyAtOffset(text, 12)).toBeNull();
+  });
+
+  it('does not treat an `@step("...")` literal nested inside another step body as a step call', () => {
+    // Cursor sits inside the OUTER step body. The inner literal text
+    // `@step("inner ...")` lives inside the outer string; the scanner
+    // must skip string contents so it doesn't latch onto the inner
+    // string as a real step call.
+    const text = '@step("the user pasted @step(\\"inner @1\\") into the body |here")';
+    const cursor = text.indexOf('|');
+    const cleaned = text.replace('|', '');
+    const result = findStepBodyAtOffset(cleaned, cursor);
+    expect(result).not.toBeNull();
+    // The outer body starts right after the first `"`.
+    expect(result?.bodyStart).toBe(cleaned.indexOf('"') + 1);
+  });
 });
 
 describe('collectStepIndexes', () => {
@@ -87,5 +106,16 @@ describe('collectStepIndexes', () => {
   it('ignores malformed lines (no descriptor)', () => {
     const text = '@ingredient(1,)\n@ingredient(2, valid, 1:g)';
     expect(collectStepIndexes(text)).toEqual([{ index: '2', slug: 'valid' }]);
+  });
+
+  it('ignores `@ingredient(...)` text that appears inside a `@step("...")` body', () => {
+    // The user typed `@ingredient(9, ...)` as a recipe-prose snippet
+    // inside the step body — those should not surface as step-ref
+    // suggestions because the document only declares index 1.
+    const text = [
+      '@ingredient(1, banana, 100:g)',
+      '@step("She said: @ingredient(9, beans, 200:g)")',
+    ].join('\n');
+    expect(collectStepIndexes(text)).toEqual([{ index: '1', slug: 'banana' }]);
   });
 });

--- a/packages/app-food/src/components/dsl-editor/autocomplete-context.ts
+++ b/packages/app-food/src/components/dsl-editor/autocomplete-context.ts
@@ -1,0 +1,254 @@
+/**
+ * DSL editor autocomplete — cursor-context classifier (PRD-120 part B).
+ *
+ * Inspects the document slice immediately before the cursor and reports
+ * which of the seven autocomplete sources should fire. Pure: no
+ * CodeMirror imports, no async work, no document mutation. Tests drive
+ * it with raw strings + offsets so the matrix from PRD-120's
+ * "Autocomplete" section can be verified case-by-case without spinning
+ * up an editor.
+ *
+ * The classifier walks **backwards** from the cursor over the prefix
+ * because the grammar is line-aware (`@step("...")` bodies can span
+ * lines via the parser but autocomplete only needs the unbalanced-paren
+ * region between the cursor and the most recent unclosed `@<func>(` or
+ * the last newline outside a step body). Implementation note: a full
+ * recursive-descent reparse on every keystroke is overkill — the
+ * suffix-walk is sufficient for the contexts the PRD enumerates and
+ * stays under the per-file lint cap.
+ */
+import { findStepBodyAtOffset } from './autocomplete-step-bodies';
+
+/** Cursor position classification result. The `from` field tells the
+ *  CodeMirror source where the active token starts so it can build a
+ *  replacement range; `null` means "use the matched word boundary". */
+export type CursorContext =
+  | { kind: 'none' }
+  /** Just after a bare `@` outside any function call. */
+  | { kind: 'function-name'; from: number; query: string }
+  /** Inside `@ingredient(N, ` or `@yield(` — slug search. */
+  | { kind: 'descriptor-slug'; from: number; query: string }
+  /** Inside a descriptor after `<ingredient>:` — variants. */
+  | { kind: 'descriptor-variant'; from: number; query: string; ingredientSlug: string }
+  /** Inside a descriptor after `<ingredient>:<variant>:` — prep states. */
+  | { kind: 'descriptor-prep'; from: number; query: string }
+  /** Inside a `qty:unit` after the colon. */
+  | { kind: 'unit'; from: number; query: string }
+  /** Inside a `@step("...")` body after `@` — step refs (index OR slug). */
+  | { kind: 'step-ref'; from: number; query: string; bodyStart: number };
+
+/** Identifier characters per PRD-114's grammar: lowercase + digits +
+ *  hyphen. Numbers also need to be recognised at the start (for `@N`
+ *  step refs and `qty:` values). */
+const IDENT_RE = /^[a-z0-9-]+$/;
+
+export function classifyCursor(text: string, pos: number): CursorContext {
+  if (pos < 0 || pos > text.length) return { kind: 'none' };
+
+  // Step bodies have their own world — the `@<thing>` inside a string is
+  // a step-ref, not a top-level call.
+  const stepBody = findStepBodyAtOffset(text, pos);
+  if (stepBody !== null) return classifyStepBody(text, pos, stepBody.bodyStart);
+
+  return classifyTopLevel(text, pos);
+}
+
+function classifyStepBody(text: string, pos: number, bodyStart: number): CursorContext {
+  // Walk back to the most recent `@` since the body's opening quote.
+  let i = pos;
+  while (i > bodyStart && text[i - 1] !== '@') {
+    const ch = text[i - 1] ?? '';
+    if (ch === '"' || ch === '\n' || ch === ' ') break;
+    if (!/[a-z0-9-]/.test(ch)) break;
+    i -= 1;
+  }
+  if (i === 0 || text[i - 1] !== '@') return { kind: 'none' };
+  const query = text.slice(i, pos);
+  // `from` covers the @ itself so a re-selection replaces the whole token.
+  return { kind: 'step-ref', from: i - 1, query, bodyStart };
+}
+
+function classifyTopLevel(text: string, pos: number): CursorContext {
+  const tail = scanTrailingWord(text, pos);
+  const head = text.slice(0, tail.start);
+
+  // `@` cases (function name vs inside-call).
+  if (tail.start > 0 && text[tail.start - 1] === '@') {
+    // If the @ is itself inside an unclosed `(`, we're naming a function
+    // mid-call which the user almost certainly didn't mean — treat as
+    // function-name suggestion regardless. Keep this branch top so
+    // descriptor slug detection doesn't shadow it.
+    return { kind: 'function-name', from: tail.start - 1, query: tail.word };
+  }
+
+  // Inside a `qty:` value — number, colon, suggesting unit identifier.
+  const unitCtx = matchUnitContext(head, tail);
+  if (unitCtx !== null) return unitCtx;
+
+  // Descriptor positions: `<func>(` ... `<slug>:<v>:<p>` segments.
+  const descriptorCtx = matchDescriptorContext(head, tail);
+  if (descriptorCtx !== null) return descriptorCtx;
+
+  return { kind: 'none' };
+}
+
+/** Read the trailing alphanumeric run that the user is currently
+ *  typing (the "active word"). Returns the run's start offset and the
+ *  text. An empty trailing word is legitimate — the cursor may be
+ *  immediately after `@` or `:` with nothing typed yet. */
+function scanTrailingWord(text: string, pos: number): { start: number; word: string } {
+  let start = pos;
+  while (start > 0 && /[a-z0-9-]/.test(text[start - 1] ?? '')) start -= 1;
+  return { start, word: text.slice(start, pos) };
+}
+
+function matchUnitContext(
+  head: string,
+  tail: { start: number; word: string }
+): CursorContext | null {
+  // Trailing `<digits>(.<digits>)?:` immediately before the active word
+  // marks a qty:unit slot. The head ends with the colon (we don't slurp
+  // it into the word).
+  if (!head.endsWith(':')) return null;
+  const noColon = head.slice(0, -1);
+  if (!/[0-9](?:\.[0-9]+)?$/.test(noColon)) return null;
+  if (!(tail.word === '' || IDENT_RE.test(tail.word))) return null;
+  return { kind: 'unit', from: tail.start, query: tail.word };
+}
+
+function matchDescriptorContext(
+  head: string,
+  tail: { start: number; word: string }
+): CursorContext | null {
+  // Descriptor slots only appear inside an unbalanced `(`. Find it.
+  const openParenIdx = findOpenParenStart(head);
+  if (openParenIdx === null) return null;
+
+  // Inside the parens we have the function name (just before `(`) and
+  // the args typed so far. Splitting by top-level commas gives us the
+  // current arg's text.
+  const funcName = readFunctionName(head, openParenIdx);
+  if (funcName === null) return null;
+
+  const argsText = head.slice(openParenIdx + 1);
+  const currentArg = lastTopLevelComma(argsText);
+
+  // First-arg slots:
+  //   @ingredient(N, descriptor, qty:unit) — descriptor is the 2nd arg.
+  //   @yield(descriptor, qty:unit)         — descriptor is the 1st arg.
+  // For simplicity we treat ANY arg slot inside these two functions as
+  // a slug candidate when the active text + the arg-prefix matches the
+  // descriptor shape. The qty-unit case is handled earlier and returns
+  // first; what reaches here is genuine descriptor territory.
+  if (funcName !== 'ingredient' && funcName !== 'yield') return null;
+
+  return matchDescriptorSegments(currentArg, tail);
+}
+
+function matchDescriptorSegments(
+  currentArg: string,
+  tail: { start: number; word: string }
+): CursorContext | null {
+  if (!isIdentTail(tail.word)) return null;
+  // The current arg is `<maybe leading space><slug>[:<variant>[:<prep>]]`
+  // with the active word at the tail. Strip leading whitespace and
+  // split on `:`.
+  const segments = currentArg.replace(/^\s+/, '').split(':');
+  if (segments.length === 1) {
+    return { kind: 'descriptor-slug', from: tail.start, query: tail.word };
+  }
+  if (segments.length === 2) {
+    const ingredientSlug = segments[0]?.trim() ?? '';
+    if (ingredientSlug === '' || !IDENT_RE.test(ingredientSlug)) return null;
+    return { kind: 'descriptor-variant', from: tail.start, query: tail.word, ingredientSlug };
+  }
+  if (segments.length === 3) {
+    return { kind: 'descriptor-prep', from: tail.start, query: tail.word };
+  }
+  return null;
+}
+
+function isIdentTail(word: string): boolean {
+  return word === '' || IDENT_RE.test(word);
+}
+
+/** Find the index of the most recent unclosed `(` in `head` (where the
+ *  cursor sits). Returns `null` when none. Skips parens that appear
+ *  inside double-quoted string literals (step bodies were already
+ *  handled by `findStepBodyAtOffset`, but bare strings can still
+ *  contain parens in other args). */
+function findOpenParenStart(head: string): number | null {
+  const state: ParenScan = { depth: 0, inString: false, escaped: false };
+  for (let i = head.length - 1; i >= 0; i -= 1) {
+    const ch = head[i] ?? '';
+    if (state.inString) {
+      stepStringBackwards(state, ch);
+      continue;
+    }
+    if (ch === '"') {
+      state.inString = true;
+      continue;
+    }
+    if (ch === ')') {
+      state.depth += 1;
+      continue;
+    }
+    if (ch === '(') {
+      if (state.depth === 0) return i;
+      state.depth -= 1;
+      continue;
+    }
+    // Unclosed `(` shouldn't span a top-level newline outside a string
+    // — most paste-state edge cases land here and are best ignored.
+    if (ch === '\n' && state.depth === 0) return null;
+  }
+  return null;
+}
+
+interface ParenScan {
+  depth: number;
+  inString: boolean;
+  escaped: boolean;
+}
+
+function stepStringBackwards(state: ParenScan, ch: string): void {
+  // Walking backwards through a string: stop the string at the matching
+  // opening quote. Track `escaped` so `\\` followed by `"` doesn't close
+  // the string prematurely on the reverse walk.
+  if (ch === '"' && !state.escaped) state.inString = false;
+  state.escaped = ch === '\\' ? !state.escaped : false;
+}
+
+/** Read the identifier immediately before the `(` at `openParenIdx` —
+ *  the function name without the leading `@`. */
+function readFunctionName(head: string, openParenIdx: number): string | null {
+  if (openParenIdx <= 0) return null;
+  let end = openParenIdx;
+  let start = end;
+  while (start > 0 && /[a-z0-9-]/.test(head[start - 1] ?? '')) start -= 1;
+  if (start === end) return null;
+  if (head[start - 1] !== '@') return null;
+  return head.slice(start, end);
+}
+
+/** Return the text of the current arg (everything after the most recent
+ *  top-level comma inside the paren group). Ignores commas that appear
+ *  inside strings. */
+function lastTopLevelComma(argsText: string): string {
+  let inString = false;
+  let escaped = false;
+  for (let i = argsText.length - 1; i >= 0; i -= 1) {
+    const ch = argsText[i] ?? '';
+    if (inString) {
+      if (ch === '"' && !escaped) inString = false;
+      escaped = ch === '\\' ? !escaped : false;
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+      continue;
+    }
+    if (ch === ',') return argsText.slice(i + 1);
+  }
+  return argsText;
+}

--- a/packages/app-food/src/components/dsl-editor/autocomplete-extension.ts
+++ b/packages/app-food/src/components/dsl-editor/autocomplete-extension.ts
@@ -1,0 +1,30 @@
+/**
+ * DSL editor autocomplete — CodeMirror extension factory (PRD-120 part B).
+ *
+ * Returns an `Extension[]` to be merged into the editor state. The
+ * extension is built once per `DslEditor` mount and never reconfigured
+ * — `useDslEditorView` swaps the *sources* through a stable closure so
+ * each call sees the latest props without re-creating the extension
+ * compartment.
+ *
+ * `closeOnBlur` defaults to `true` so clicking outside the editor
+ * dismisses the popup; `activateOnTyping` defaults to `true` so the
+ * source fires as the user types without needing Ctrl-Space. The
+ * defaults are explicit here so future debugging doesn't blame
+ * @codemirror/autocomplete's release-version drift.
+ */
+import { autocompletion } from '@codemirror/autocomplete';
+
+import { buildDslCompletionSource } from './autocomplete-source';
+
+import type { Extension } from '@codemirror/state';
+
+import type { DslAutocompleteSources } from './autocomplete-types';
+
+export function dslAutocompletion(sources: DslAutocompleteSources): Extension {
+  return autocompletion({
+    activateOnTyping: true,
+    closeOnBlur: true,
+    override: [buildDslCompletionSource(sources)],
+  });
+}

--- a/packages/app-food/src/components/dsl-editor/autocomplete-source.ts
+++ b/packages/app-food/src/components/dsl-editor/autocomplete-source.ts
@@ -1,0 +1,190 @@
+import { classifyCursor, type CursorContext } from './autocomplete-context';
+import { collectStepIndexes } from './autocomplete-step-bodies';
+import { DSL_FUNCTION_SUGGESTIONS, DSL_UNIT_SUGGESTIONS } from './autocomplete-units';
+
+/**
+ * DSL editor autocomplete — CompletionSource wiring (PRD-120 part B).
+ *
+ * Single CodeMirror `CompletionSource` that classifies the cursor
+ * position via `classifyCursor` (pure) and then fan-outs to whichever
+ * fetch the active context needs. The function itself is async — the
+ * slug-search and variant lookups are network-bound — but the
+ * classification + the unit / function-name / step-ref sources resolve
+ * synchronously.
+ *
+ * CodeMirror's `autocompletion` extension handles the popup, the
+ * debounce (`activateOnTypingDelay`, defaults to 100 ms), and the
+ * abort-on-keypress race conditions. We never have to thread an
+ * `AbortSignal` through the lookups; if the source resolves after the
+ * user kept typing, CodeMirror discards the result.
+ */
+import type { Completion, CompletionContext, CompletionResult } from '@codemirror/autocomplete';
+
+import type {
+  DslAutocompleteSources,
+  PrepStateSuggestion,
+  SlugSuggestion,
+  VariantSuggestion,
+} from './autocomplete-types';
+
+export function buildDslCompletionSource(sources: DslAutocompleteSources) {
+  return async function dslCompletionSource(
+    context: CompletionContext
+  ): Promise<CompletionResult | null> {
+    const text = context.state.doc.toString();
+    const ctx = classifyCursor(text, context.pos);
+    if (ctx.kind === 'none') {
+      // CodeMirror calls sources eagerly on every keystroke; returning
+      // `null` here is cheap and tells the autocompletion machinery to
+      // skip this source.
+      return null;
+    }
+    return await dispatch(text, ctx, sources, context.explicit);
+  };
+}
+
+async function dispatch(
+  text: string,
+  ctx: CursorContext,
+  sources: DslAutocompleteSources,
+  explicit: boolean
+): Promise<CompletionResult | null> {
+  if (ctx.kind === 'function-name') return functionResult(ctx);
+  if (ctx.kind === 'unit') return unitResult(ctx);
+  if (ctx.kind === 'descriptor-slug') {
+    const items = await sources.searchSlugs(ctx.query, ['ingredient', 'recipe']);
+    return slugResult(ctx, items, explicit);
+  }
+  if (ctx.kind === 'descriptor-variant') {
+    const items = await sources.listVariantsForIngredient(ctx.ingredientSlug);
+    return variantResult(ctx, items);
+  }
+  if (ctx.kind === 'descriptor-prep') {
+    const items = await sources.listPrepStates();
+    return prepResult(ctx, items);
+  }
+  if (ctx.kind === 'step-ref') {
+    const indexes = collectStepIndexes(text);
+    const slugItems = await sources.searchSlugs(ctx.query, ['ingredient', 'recipe']);
+    return stepRefResult(ctx, indexes, slugItems);
+  }
+  return null;
+}
+
+function functionResult(ctx: Extract<CursorContext, { kind: 'function-name' }>): CompletionResult {
+  return {
+    from: ctx.from,
+    to: ctx.from + 1 + ctx.query.length, // include the @ prefix in replacement
+    options: DSL_FUNCTION_SUGGESTIONS.map((fn) => ({
+      label: `@${fn.slug}`,
+      detail: fn.label,
+      apply: `@${fn.slug}`,
+      type: 'keyword' satisfies Completion['type'],
+    })),
+    validFor: /^@[a-z]*$/,
+  };
+}
+
+function unitResult(ctx: Extract<CursorContext, { kind: 'unit' }>): CompletionResult {
+  return {
+    from: ctx.from,
+    options: DSL_UNIT_SUGGESTIONS.map((u) => ({
+      label: u.slug,
+      detail: u.label,
+      type: 'unit' satisfies Completion['type'],
+    })),
+    validFor: /^[a-z]*$/,
+  };
+}
+
+function slugResult(
+  ctx: Extract<CursorContext, { kind: 'descriptor-slug' }>,
+  items: readonly SlugSuggestion[],
+  explicit: boolean
+): CompletionResult | null {
+  if (items.length === 0) {
+    // Surface the "Create new ingredient" affordance per PRD edge-cases
+    // table — but only when the user explicitly invoked autocomplete OR
+    // typed at least one character. Empty + implicit = no popup at all.
+    if (!explicit && ctx.query === '') return null;
+    if (ctx.query === '') return null;
+    return {
+      from: ctx.from,
+      options: [
+        {
+          label: ctx.query,
+          detail: `Create new ingredient "${ctx.query}"`,
+          apply: ctx.query,
+          type: 'text' satisfies Completion['type'],
+        },
+      ],
+      validFor: /^[a-z0-9-]*$/,
+    };
+  }
+  return {
+    from: ctx.from,
+    options: items.map((item) => ({
+      label: item.slug,
+      detail: item.name === '' ? item.kind : `${item.kind} · ${item.name}`,
+      type: item.kind === 'recipe' ? 'function' : 'variable',
+    })),
+    validFor: /^[a-z0-9-]*$/,
+  };
+}
+
+function variantResult(
+  ctx: Extract<CursorContext, { kind: 'descriptor-variant' }>,
+  items: readonly VariantSuggestion[]
+): CompletionResult | null {
+  if (items.length === 0) return null;
+  return {
+    from: ctx.from,
+    options: items.map((item) => ({
+      label: item.slug,
+      detail: item.name,
+      type: 'variable' satisfies Completion['type'],
+    })),
+    validFor: /^[a-z0-9-]*$/,
+  };
+}
+
+function prepResult(
+  ctx: Extract<CursorContext, { kind: 'descriptor-prep' }>,
+  items: readonly PrepStateSuggestion[]
+): CompletionResult | null {
+  if (items.length === 0) return null;
+  return {
+    from: ctx.from,
+    options: items.map((item) => ({
+      label: item.slug,
+      detail: item.name,
+      type: 'enum' satisfies Completion['type'],
+    })),
+    validFor: /^[a-z0-9-]*$/,
+  };
+}
+
+function stepRefResult(
+  ctx: Extract<CursorContext, { kind: 'step-ref' }>,
+  indexes: readonly { index: string; slug: string }[],
+  slugItems: readonly SlugSuggestion[]
+): CompletionResult {
+  const indexOptions: Completion[] = indexes.map((entry) => ({
+    label: `@${entry.index}`,
+    detail: entry.slug === '' ? `index ${entry.index}` : `→ ${entry.slug}`,
+    apply: `@${entry.index}`,
+    type: 'constant',
+  }));
+  const slugOptions: Completion[] = slugItems.map((item) => ({
+    label: `@${item.slug}`,
+    detail: item.name === '' ? item.kind : `${item.kind} · ${item.name}`,
+    apply: `@${item.slug}`,
+    type: item.kind === 'recipe' ? 'function' : 'variable',
+  }));
+  return {
+    from: ctx.from,
+    to: ctx.from + 1 + ctx.query.length,
+    options: [...indexOptions, ...slugOptions],
+    validFor: /^@[a-z0-9-]*$/,
+  };
+}

--- a/packages/app-food/src/components/dsl-editor/autocomplete-step-bodies.ts
+++ b/packages/app-food/src/components/dsl-editor/autocomplete-step-bodies.ts
@@ -29,21 +29,24 @@ export interface StepBodyContext {
 }
 
 export function findStepBodyAtOffset(text: string, pos: number): StepBodyContext | null {
-  // Find every `@step("...` start that begins before pos and whose
-  // closing quote sits at or after pos. The last such start wins
-  // because nested step calls are illegal in the grammar — there can be
-  // at most one open body at any cursor.
-  let stepIdx = text.indexOf('@step', 0);
+  // Walk the document forward respecting string boundaries; whenever
+  // we leave a string-free region we look at the immediate text for an
+  // `@step` call start. The last open body whose closing quote sits at
+  // or after pos wins — nested step calls are illegal in the grammar so
+  // there can be at most one.
   let last: StepBodyContext | null = null;
-  while (stepIdx !== -1 && stepIdx < pos) {
+  for (const stepIdx of scanStepCallStarts(text)) {
+    if (stepIdx >= pos) break;
     const candidate = tryStepBodyAt(text, stepIdx, pos);
     if (candidate !== null) last = candidate;
-    stepIdx = text.indexOf('@step', stepIdx + 5);
   }
   return last;
 }
 
 function tryStepBodyAt(text: string, stepIdx: number, pos: number): StepBodyContext | null {
+  // `stepIdx` points at the `@` of `@step` and the lexer already
+  // confirmed the next-char boundary is `(` or whitespace. Walk past
+  // `@step` and any whitespace to reach the `(`.
   const openParen = text.indexOf('(', stepIdx + 5);
   if (openParen === -1 || openParen >= pos) return null;
   const openQuote = findOpeningQuote(text, openParen + 1);
@@ -52,6 +55,48 @@ function tryStepBodyAt(text: string, stepIdx: number, pos: number): StepBodyCont
   const bodyEnd = findClosingQuote(text, bodyStart);
   if (bodyEnd < pos) return null;
   return { bodyStart, bodyEnd };
+}
+
+/** Yield the offset of every `@step` call start at the top level —
+ *  occurrences inside string literals (e.g. `@step("@step(...)")` body
+ *  text) and inside longer identifiers (`@stepper(`) are skipped. */
+function* scanStepCallStarts(text: string): IterableIterator<number> {
+  const len = text.length;
+  let inString = false;
+  for (let i = 0; i < len; i += 1) {
+    const ch = text[i] ?? '';
+    if (inString) {
+      i = stepStringForward(text, i, ch);
+      if (i >= 0 && text[i] === '"') inString = false;
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+      continue;
+    }
+    if (isStepCallStart(text, i)) {
+      yield i;
+      i += 4; // skip past `@step` minus the loop increment
+    }
+  }
+}
+
+/** When forward-scanning inside a string, return the index of the next
+ *  character to process. `\\` swallows the next char; everything else
+ *  is left at `i` for the caller's loop. */
+function stepStringForward(text: string, i: number, ch: string): number {
+  if (ch !== '\\') return i;
+  // Skip the escaped char; the for-loop's `i += 1` will advance past it.
+  if (i + 1 >= text.length) return i + 1;
+  return i + 1;
+}
+
+/** Check whether `i` is the start of an `@step` call (the `@`), bounded
+ *  by `(` or whitespace so `@stepper(` doesn't match. */
+function isStepCallStart(text: string, i: number): boolean {
+  if (text[i] !== '@' || !text.startsWith('@step', i)) return false;
+  const after = text[i + 5] ?? '';
+  return after === '(' || after === ' ' || after === '\t' || after === '\n' || after === '\r';
 }
 
 /** Walk forward from `from`, skipping whitespace, looking for the first
@@ -94,25 +139,59 @@ export interface IngredientIndexEntry {
 }
 
 /** Scan top-level `@ingredient(N, <descriptor>...)` calls and return
- *  the index → descriptor mapping. Stops at the first close-paren so a
- *  mid-edit half-typed call doesn't blow the scan; bad numbers and bad
- *  descriptors are silently skipped. */
+ *  the index → descriptor mapping. String-literal interiors are
+ *  skipped so an `@ingredient(...)` snippet that appears inside a
+ *  `@step("...")` body doesn't surface phantom suggestions. Stops at
+ *  the first close-paren of each match so a mid-edit half-typed call
+ *  doesn't blow the scan; bad numbers and bad descriptors are silently
+ *  skipped. */
 export function collectStepIndexes(text: string): readonly IngredientIndexEntry[] {
   const out: IngredientIndexEntry[] = [];
   const seenIndexes = new Set<string>();
   const re = /@ingredient\s*\(\s*(\d+)\s*,\s*([a-z0-9_:-]+)/g;
-  let match: RegExpExecArray | null = re.exec(text);
-  while (match !== null) {
-    const index = match[1] ?? '';
-    const slug = match[2] ?? '';
-    if (index !== '' && !seenIndexes.has(index)) {
-      seenIndexes.add(index);
-      out.push({ index, slug });
+  for (const region of scanOutsideStrings(text)) {
+    re.lastIndex = 0;
+    let match: RegExpExecArray | null = re.exec(region);
+    while (match !== null) {
+      const index = match[1] ?? '';
+      const slug = match[2] ?? '';
+      if (index !== '' && !seenIndexes.has(index)) {
+        seenIndexes.add(index);
+        out.push({ index, slug });
+      }
+      match = re.exec(region);
     }
-    match = re.exec(text);
   }
   // Sort numerically — the regex order is document order; PRD-119 may
   // renumber, so the autocomplete should always show ascending indexes
   // even if the user mid-edit has them out of order in the doc.
   return out.toSorted((a, b) => Number(a.index) - Number(b.index));
+}
+
+/** Split the document into the contiguous regions that sit outside
+ *  string literals so a regex can run against them safely. Escaped
+ *  quotes inside a string are honoured. */
+function* scanOutsideStrings(text: string): IterableIterator<string> {
+  const len = text.length;
+  let regionStart = 0;
+  let inString = false;
+  for (let i = 0; i < len; i += 1) {
+    const ch = text[i] ?? '';
+    if (inString) {
+      if (ch === '\\') {
+        i += 1;
+        continue;
+      }
+      if (ch === '"') {
+        inString = false;
+        regionStart = i + 1;
+      }
+      continue;
+    }
+    if (ch === '"') {
+      if (i > regionStart) yield text.slice(regionStart, i);
+      inString = true;
+    }
+  }
+  if (!inString && regionStart < len) yield text.slice(regionStart);
 }

--- a/packages/app-food/src/components/dsl-editor/autocomplete-step-bodies.ts
+++ b/packages/app-food/src/components/dsl-editor/autocomplete-step-bodies.ts
@@ -1,0 +1,118 @@
+/**
+ * DSL editor autocomplete — step-body scanner (PRD-120 part B).
+ *
+ * Two pure passes over the document:
+ *
+ *   1. `findStepBodyAtOffset(text, pos)` — was the cursor parked
+ *      inside a `@step("...")` body? If so, return the body's start
+ *      offset (the character just after the opening quote). Used by
+ *      the cursor-context classifier to switch the suggestion source
+ *      from top-level function args to step refs.
+ *
+ *   2. `collectStepIndexes(text)` — walks every `@ingredient(N, ...)`
+ *      call in the document and returns `{ index, slug }` pairs. The
+ *      step-ref autocomplete uses this to surface `@1` / `@2` /
+ *      ... suggestions with a preview of what each index resolves to
+ *      while the user is typing.
+ *
+ * Neither pass parses the document — both are tokenisation-shallow
+ * string walks that honour the `\"` and `\\` escapes the DSL string
+ * literal allows. The hand-rolled parser at PRD-114 is the only thing
+ * that knows the full grammar; this scanner only needs enough
+ * structure to disambiguate top-level vs string-body cursor positions.
+ */
+export interface StepBodyContext {
+  /** Offset of the first character inside the opening `"` of the body. */
+  bodyStart: number;
+  /** Offset of the closing `"` (or `text.length` if the body is open). */
+  bodyEnd: number;
+}
+
+export function findStepBodyAtOffset(text: string, pos: number): StepBodyContext | null {
+  // Find every `@step("...` start that begins before pos and whose
+  // closing quote sits at or after pos. The last such start wins
+  // because nested step calls are illegal in the grammar — there can be
+  // at most one open body at any cursor.
+  let stepIdx = text.indexOf('@step', 0);
+  let last: StepBodyContext | null = null;
+  while (stepIdx !== -1 && stepIdx < pos) {
+    const candidate = tryStepBodyAt(text, stepIdx, pos);
+    if (candidate !== null) last = candidate;
+    stepIdx = text.indexOf('@step', stepIdx + 5);
+  }
+  return last;
+}
+
+function tryStepBodyAt(text: string, stepIdx: number, pos: number): StepBodyContext | null {
+  const openParen = text.indexOf('(', stepIdx + 5);
+  if (openParen === -1 || openParen >= pos) return null;
+  const openQuote = findOpeningQuote(text, openParen + 1);
+  if (openQuote === null || openQuote >= pos) return null;
+  const bodyStart = openQuote + 1;
+  const bodyEnd = findClosingQuote(text, bodyStart);
+  if (bodyEnd < pos) return null;
+  return { bodyStart, bodyEnd };
+}
+
+/** Walk forward from `from`, skipping whitespace, looking for the first
+ *  `"`. Returns its offset or `null` if a non-whitespace, non-quote
+ *  character intervenes (e.g. the user typed `@step(123)`). */
+function findOpeningQuote(text: string, from: number): number | null {
+  let i = from;
+  while (i < text.length) {
+    const ch = text[i] ?? '';
+    if (ch === '"') return i;
+    if (ch !== ' ' && ch !== '\t' && ch !== '\n' && ch !== '\r') return null;
+    i += 1;
+  }
+  return null;
+}
+
+/** Walk forward looking for the matching closing `"`, honouring `\\`
+ *  and `\"` escapes. Returns `text.length` if the body is unterminated
+ *  (the document is still mid-edit). */
+function findClosingQuote(text: string, from: number): number {
+  let i = from;
+  while (i < text.length) {
+    const ch = text[i] ?? '';
+    if (ch === '\\') {
+      i += 2; // skip escape
+      continue;
+    }
+    if (ch === '"') return i;
+    i += 1;
+  }
+  return text.length;
+}
+
+export interface IngredientIndexEntry {
+  /** Insertion text (the digits — `1`, `2`, ...). */
+  index: string;
+  /** Display slug for the popup ("rice", "banana:raw", ...). Empty if
+   *  the declaration is malformed. */
+  slug: string;
+}
+
+/** Scan top-level `@ingredient(N, <descriptor>...)` calls and return
+ *  the index → descriptor mapping. Stops at the first close-paren so a
+ *  mid-edit half-typed call doesn't blow the scan; bad numbers and bad
+ *  descriptors are silently skipped. */
+export function collectStepIndexes(text: string): readonly IngredientIndexEntry[] {
+  const out: IngredientIndexEntry[] = [];
+  const seenIndexes = new Set<string>();
+  const re = /@ingredient\s*\(\s*(\d+)\s*,\s*([a-z0-9_:-]+)/g;
+  let match: RegExpExecArray | null = re.exec(text);
+  while (match !== null) {
+    const index = match[1] ?? '';
+    const slug = match[2] ?? '';
+    if (index !== '' && !seenIndexes.has(index)) {
+      seenIndexes.add(index);
+      out.push({ index, slug });
+    }
+    match = re.exec(text);
+  }
+  // Sort numerically — the regex order is document order; PRD-119 may
+  // renumber, so the autocomplete should always show ascending indexes
+  // even if the user mid-edit has them out of order in the doc.
+  return out.toSorted((a, b) => Number(a.index) - Number(b.index));
+}

--- a/packages/app-food/src/components/dsl-editor/autocomplete-types.ts
+++ b/packages/app-food/src/components/dsl-editor/autocomplete-types.ts
@@ -1,0 +1,46 @@
+/**
+ * DSL editor autocomplete — public type surface (PRD-120 part B).
+ *
+ * The CodeMirror sources are pure: they call a small set of async lookups
+ * to fetch suggestions and never touch tRPC or React Query directly.
+ * `useDslAutocompleteSources()` builds production lookups against the
+ * food routers; tests inject deterministic stubs implementing the same
+ * shape. Keeping the contract narrow (three async methods) lets PRD-119
+ * mount the editor without exposing every food endpoint to it.
+ */
+export type SlugKind = 'ingredient' | 'recipe' | 'prep_state';
+
+export interface SlugSuggestion {
+  /** The bare slug as it should be inserted at the cursor. */
+  slug: string;
+  /** Slug kind so the dropdown can group / icon them later. */
+  kind: SlugKind;
+  /** Display name (resolved from the target row). May be empty. */
+  name: string;
+}
+
+export interface VariantSuggestion {
+  /** Variant slug (insertion text). */
+  slug: string;
+  /** Display name for the popup. */
+  name: string;
+}
+
+export interface PrepStateSuggestion {
+  /** Prep-state slug (insertion text). */
+  slug: string;
+  /** Display name for the popup. */
+  name: string;
+}
+
+/**
+ * Lookups the autocomplete extension calls. Implementations cache as they
+ * see fit; the extension does not memoise on its own. Production wiring
+ * (`useDslAutocompleteSources`) wraps tRPC + React Query so repeated calls
+ * with the same args hit the in-memory cache.
+ */
+export interface DslAutocompleteSources {
+  searchSlugs: (query: string, kinds?: readonly SlugKind[]) => Promise<readonly SlugSuggestion[]>;
+  listVariantsForIngredient: (ingredientSlug: string) => Promise<readonly VariantSuggestion[]>;
+  listPrepStates: () => Promise<readonly PrepStateSuggestion[]>;
+}

--- a/packages/app-food/src/components/dsl-editor/autocomplete-units.ts
+++ b/packages/app-food/src/components/dsl-editor/autocomplete-units.ts
@@ -4,10 +4,11 @@
  * The DSL grammar (ADR-023 + PRD-114) allows any lowercase identifier
  * after `qty:`; the parser does not constrain unit names. PRD-116's
  * normaliser only knows `g`, `ml`, `count` natively, plus the alias
- * table populated by PRD-123. The suggestion list mirrors the eight
- * built-ins the editor knows about deterministically — anything else
- * the user types still parses; the suggestion list is a convenience,
- * not a gate.
+ * table populated by PRD-123. The suggestion list mirrors the built-in
+ * units the editor knows about deterministically — anything else the
+ * user types still parses; the suggestion list is a convenience, not a
+ * gate. Add a constant here when PRD-123 promotes a new alias to first-
+ * class status.
  *
  * Keep the ordering stable: canonical units first, then volume aliases,
  * then weight aliases, then time/temperature, then `none`. The dropdown
@@ -35,10 +36,10 @@ export const DSL_UNIT_SUGGESTIONS: readonly UnitSuggestion[] = [
   { slug: 'none', label: 'unitless' },
 ];
 
-/** The seven DSL function names + the `_` skip marker the user can drop
- *  inside a descriptor's variant/prep_state slot. The autocomplete after
- *  a bare `@` inserts the function name (without the trailing `(`) so the
- *  user keeps their typing momentum into the argument list. */
+/** The DSL function names the editor surfaces after a bare `@`. The
+ *  insertion text omits the trailing `(` so the user keeps their typing
+ *  momentum into the argument list. Keep the order matching PRD-120's
+ *  Autocomplete table so the smoke tests stay deterministic. */
 export interface FunctionSuggestion {
   slug: string;
   label: string;

--- a/packages/app-food/src/components/dsl-editor/autocomplete-units.ts
+++ b/packages/app-food/src/components/dsl-editor/autocomplete-units.ts
@@ -1,0 +1,54 @@
+/**
+ * DSL editor autocomplete — canonical unit list (PRD-120 part B).
+ *
+ * The DSL grammar (ADR-023 + PRD-114) allows any lowercase identifier
+ * after `qty:`; the parser does not constrain unit names. PRD-116's
+ * normaliser only knows `g`, `ml`, `count` natively, plus the alias
+ * table populated by PRD-123. The suggestion list mirrors the eight
+ * built-ins the editor knows about deterministically — anything else
+ * the user types still parses; the suggestion list is a convenience,
+ * not a gate.
+ *
+ * Keep the ordering stable: canonical units first, then volume aliases,
+ * then weight aliases, then time/temperature, then `none`. The dropdown
+ * preserves the order we return so users see the most common units
+ * first.
+ */
+export interface UnitSuggestion {
+  slug: string;
+  label: string;
+}
+
+export const DSL_UNIT_SUGGESTIONS: readonly UnitSuggestion[] = [
+  { slug: 'g', label: 'grams' },
+  { slug: 'ml', label: 'millilitres' },
+  { slug: 'count', label: 'whole units' },
+  { slug: 'cup', label: 'cups' },
+  { slug: 'tbsp', label: 'tablespoons' },
+  { slug: 'tsp', label: 'teaspoons' },
+  { slug: 'oz', label: 'ounces' },
+  { slug: 'lb', label: 'pounds' },
+  { slug: 'min', label: 'minutes' },
+  { slug: 's', label: 'seconds' },
+  { slug: 'c', label: 'celsius' },
+  { slug: 'f', label: 'fahrenheit' },
+  { slug: 'none', label: 'unitless' },
+];
+
+/** The seven DSL function names + the `_` skip marker the user can drop
+ *  inside a descriptor's variant/prep_state slot. The autocomplete after
+ *  a bare `@` inserts the function name (without the trailing `(`) so the
+ *  user keeps their typing momentum into the argument list. */
+export interface FunctionSuggestion {
+  slug: string;
+  label: string;
+}
+
+export const DSL_FUNCTION_SUGGESTIONS: readonly FunctionSuggestion[] = [
+  { slug: 'recipe', label: '@recipe(...)' },
+  { slug: 'yield', label: '@yield(descriptor, qty:unit)' },
+  { slug: 'ingredient', label: '@ingredient(N, descriptor, qty:unit)' },
+  { slug: 'step', label: '@step("...")' },
+  { slug: 'time', label: '@time(N:unit)' },
+  { slug: 'temperature', label: '@temperature(N:unit)' },
+];

--- a/packages/app-food/src/components/dsl-editor/use-dsl-autocomplete-sources.ts
+++ b/packages/app-food/src/components/dsl-editor/use-dsl-autocomplete-sources.ts
@@ -40,12 +40,20 @@ export function useDslAutocompleteSources(): DslAutocompleteSources {
 
   return useMemo<DslAutocompleteSources>(
     () => ({
+      // Every lookup swallows network / auth / server errors and resolves
+      // to an empty list — throwing inside a CodeMirror CompletionSource
+      // disables autocomplete for the session, which is the opposite of
+      // what we want when a backend round-trip is flaky mid-keystroke.
       async searchSlugs(query, kinds) {
-        const result = await utilsRef.current.food.slugs.search.fetch({
-          query,
-          kinds: kinds === undefined ? undefined : [...kinds],
-        });
-        return mapSlugs(result.items);
+        try {
+          const result = await utilsRef.current.food.slugs.search.fetch({
+            query,
+            kinds: kinds === undefined ? undefined : [...kinds],
+          });
+          return mapSlugs(result.items);
+        } catch {
+          return [];
+        }
       },
       async listVariantsForIngredient(slug) {
         try {
@@ -60,8 +68,12 @@ export function useDslAutocompleteSources(): DslAutocompleteSources {
         }
       },
       async listPrepStates() {
-        const result = await utilsRef.current.food.prepStates.list.fetch();
-        return mapPrepStates(result.items);
+        try {
+          const result = await utilsRef.current.food.prepStates.list.fetch();
+          return mapPrepStates(result.items);
+        } catch {
+          return [];
+        }
       },
     }),
     [] // utils accessed via ref; never invalidate
@@ -70,16 +82,12 @@ export function useDslAutocompleteSources(): DslAutocompleteSources {
 
 interface RawSlug {
   slug: string;
-  kind: string;
+  kind: SlugKind;
   name: string;
 }
 
 function mapSlugs(items: readonly RawSlug[]): readonly SlugSuggestion[] {
-  return items.map((item) => ({
-    slug: item.slug,
-    kind: item.kind as SlugKind,
-    name: item.name,
-  }));
+  return items.map((item) => ({ slug: item.slug, kind: item.kind, name: item.name }));
 }
 
 interface RawVariant {

--- a/packages/app-food/src/components/dsl-editor/use-dsl-autocomplete-sources.ts
+++ b/packages/app-food/src/components/dsl-editor/use-dsl-autocomplete-sources.ts
@@ -1,0 +1,101 @@
+/**
+ * `useDslAutocompleteSources` — production wiring for the autocomplete
+ * extension (PRD-120 part B).
+ *
+ * Builds three async lookups that the CodeMirror source calls per
+ * keystroke:
+ *
+ *   - `searchSlugs(query, kinds)` → `food.slugs.search`
+ *   - `listVariantsForIngredient(slug)` → `food.ingredients.get`
+ *   - `listPrepStates()` → `food.prepStates.list`
+ *
+ * All three go through `trpc.useUtils().*.fetch`, which read-through
+ * the React Query cache: repeated calls with the same input return the
+ * cached payload instead of round-tripping. That's the PRD's
+ * "Results are cached in React Query for the session" requirement.
+ *
+ * Tests do NOT import this hook — `DslEditor` accepts an
+ * `autocompleteSources` prop and tests construct a synthetic object
+ * implementing `DslAutocompleteSources` directly.
+ */
+import { useMemo, useRef } from 'react';
+
+import { trpc } from '@pops/api-client';
+
+import type {
+  DslAutocompleteSources,
+  PrepStateSuggestion,
+  SlugKind,
+  SlugSuggestion,
+  VariantSuggestion,
+} from './autocomplete-types';
+
+export function useDslAutocompleteSources(): DslAutocompleteSources {
+  const utils = trpc.useUtils();
+  // Mirror the settings-page pattern: stash utils in a ref so the memo
+  // doesn't invalidate every render (the trpc utils identity is not
+  // stable across renders in production OR in tests).
+  const utilsRef = useRef(utils);
+  utilsRef.current = utils;
+
+  return useMemo<DslAutocompleteSources>(
+    () => ({
+      async searchSlugs(query, kinds) {
+        const result = await utilsRef.current.food.slugs.search.fetch({
+          query,
+          kinds: kinds === undefined ? undefined : [...kinds],
+        });
+        return mapSlugs(result.items);
+      },
+      async listVariantsForIngredient(slug) {
+        try {
+          const result = await utilsRef.current.food.ingredients.get.fetch({ idOrSlug: slug });
+          return mapVariants(result.variants);
+        } catch {
+          // Missing ingredients are a normal autocomplete state (the
+          // user typed a not-yet-created slug); never throw out of a
+          // suggestion source — return an empty list and the popup
+          // shows nothing for the variant slot.
+          return [];
+        }
+      },
+      async listPrepStates() {
+        const result = await utilsRef.current.food.prepStates.list.fetch();
+        return mapPrepStates(result.items);
+      },
+    }),
+    [] // utils accessed via ref; never invalidate
+  );
+}
+
+interface RawSlug {
+  slug: string;
+  kind: string;
+  name: string;
+}
+
+function mapSlugs(items: readonly RawSlug[]): readonly SlugSuggestion[] {
+  return items.map((item) => ({
+    slug: item.slug,
+    kind: item.kind as SlugKind,
+    name: item.name,
+  }));
+}
+
+interface RawVariant {
+  slug: string;
+  name: string;
+}
+
+function mapVariants(items: readonly RawVariant[]): readonly VariantSuggestion[] {
+  return items.map((item) => ({ slug: item.slug, name: item.name }));
+}
+
+interface RawPrepState {
+  slug: string;
+  name: string;
+}
+
+function mapPrepStates(items: readonly RawPrepState[]): readonly PrepStateSuggestion[] {
+  return items.map((item) => ({ slug: item.slug, name: item.name }));
+}

--- a/packages/app-food/src/components/useDslEditorView.ts
+++ b/packages/app-food/src/components/useDslEditorView.ts
@@ -37,12 +37,12 @@ import { EditorView, keymap, lineNumbers } from '@codemirror/view';
 import { useCallback, useEffect, useRef, type MutableRefObject } from 'react';
 
 import { recipeDsl } from '../dsl/codemirror';
-
 import { dslAutocompletion } from './dsl-editor/autocomplete-extension';
-import type { DslAutocompleteSources } from './dsl-editor/autocomplete-types';
 import { chipWidgetsExtension } from './dsl-editor/chip-widgets-extension';
 import { issuesExtension, setIssuesEffect } from './dsl-editor/issues-extension';
 import type { CompileEditorIssue } from './dsl-editor/issues-types';
+
+import type { DslAutocompleteSources } from './dsl-editor/autocomplete-types';
 
 const DEBOUNCE_MS = 250;
 const MOBILE_QUERY = '(max-width: 767px)';

--- a/packages/app-food/src/components/useDslEditorView.ts
+++ b/packages/app-food/src/components/useDslEditorView.ts
@@ -1,7 +1,8 @@
 /**
  * `useDslEditorView` — owns the imperative CodeMirror 6 lifecycle for the
- * DSL editor (PRD-120 part A; issues / squiggles / tooltip in 120-C;
- * chip widgets + mobile fallback in 120-D).
+ * DSL editor (PRD-120 part A; autocomplete extension added in 120-B;
+ * issues / squiggles / tooltip in 120-C; chip widgets + mobile fallback
+ * in 120-D).
  *
  * Pulled out of `DslEditor.tsx` so the component itself stays under the
  * lint cap and the React surface is purely declarative. The hook:
@@ -19,9 +20,12 @@
  *     mobile (inline-mark) renderings. The swap is a compartment
  *     reconfigure so cursor + undo state stay intact when the user rotates
  *     a tablet or resizes the window.
+ *   - Reads autocomplete lookups through a ref-backed proxy so the
+ *     extension picks up source swaps from PRD-120 part B without
+ *     re-mounting the EditorView.
  *
  * The hook deliberately doesn't return the `EditorView`; callers that
- * need it (tests, future autocomplete plumbing) reach for
+ * need it (tests, future plumbing) reach for
  * `EditorView.findFromDOM(host.querySelector('.cm-editor'))` instead.
  * That keeps the React render path immune to the imperative view's
  * mutation timeline.
@@ -33,9 +37,11 @@ import { EditorView, keymap, lineNumbers } from '@codemirror/view';
 import { useCallback, useEffect, useRef, type MutableRefObject } from 'react';
 
 import { recipeDsl } from '../dsl/codemirror';
+
+import { dslAutocompletion } from './dsl-editor/autocomplete-extension';
+import type { DslAutocompleteSources } from './dsl-editor/autocomplete-types';
 import { chipWidgetsExtension } from './dsl-editor/chip-widgets-extension';
 import { issuesExtension, setIssuesEffect } from './dsl-editor/issues-extension';
-
 import type { CompileEditorIssue } from './dsl-editor/issues-types';
 
 const DEBOUNCE_MS = 250;
@@ -46,6 +52,12 @@ export interface UseDslEditorViewOptions {
   onChange: (value: string) => void;
   readOnly: boolean;
   issues: readonly CompileEditorIssue[];
+  /** Autocomplete lookups (PRD-120 part B). When `null`, the
+   *  autocomplete extension still mounts but every source resolves to
+   *  an empty list — useful in tests that don't want to stub the
+   *  lookups and in callers that haven't wired up the React Query hook
+   *  yet. */
+  autocompleteSources: DslAutocompleteSources | null;
 }
 
 interface ViewCompartments {
@@ -63,11 +75,20 @@ export function useDslEditorView(
     chips: new Compartment(),
   });
   const onChangeRef = useRef(options.onChange);
+  // Sources are stashed in a ref so the autocomplete extension — which
+  // is closed-over at mount — can always read the current lookups
+  // without us rebuilding the EditorView when callers hand a fresh
+  // object identity on every render (common in tests).
+  const sourcesRef = useRef<DslAutocompleteSources | null>(options.autocompleteSources);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     onChangeRef.current = options.onChange;
   }, [options.onChange]);
+
+  useEffect(() => {
+    sourcesRef.current = options.autocompleteSources;
+  }, [options.autocompleteSources]);
 
   const emit = useCallback((value: string): void => {
     if (debounceRef.current) clearTimeout(debounceRef.current);
@@ -80,18 +101,15 @@ export function useDslEditorView(
   useEffect(() => {
     const host = hostRef.current;
     if (!host) return undefined;
-    const view = createEditorView(host, options, compartmentsRef.current, emit);
-    viewRef.current = view;
-    const stopMql = watchMobileQuery(view, compartmentsRef.current.chips);
-    return () => {
-      stopMql();
-      if (debounceRef.current) {
-        clearTimeout(debounceRef.current);
-        debounceRef.current = null;
-      }
-      view.destroy();
-      viewRef.current = null;
-    };
+    return mountEditorView({
+      host,
+      options,
+      compartments: compartmentsRef.current,
+      emit,
+      sourcesRef,
+      viewRef,
+      debounceRef,
+    });
     // Mount-only effect; subsequent prop changes are routed through the
     // dedicated effects below so we keep undo history + cursor state.
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -157,15 +175,45 @@ function watchMobileQuery(view: EditorView, chipsCompartment: Compartment): () =
   return () => mql.removeEventListener('change', listener);
 }
 
-function createEditorView(
-  host: HTMLDivElement,
-  options: UseDslEditorViewOptions,
-  compartments: ViewCompartments,
-  emit: (value: string) => void
-): EditorView {
-  // Initial `options.issues` is seeded by the `useEffect(...,
-  // [options.issues])` block above, which fires once after mount —
-  // dispatching here would double-render (PR #2716 review feedback).
+interface CreateEditorViewArgs {
+  options: UseDslEditorViewOptions;
+  compartments: ViewCompartments;
+  emit: (value: string) => void;
+  sourcesRef: MutableRefObject<DslAutocompleteSources | null>;
+}
+
+interface MountEditorViewArgs extends CreateEditorViewArgs {
+  host: HTMLDivElement;
+  viewRef: MutableRefObject<EditorView | null>;
+  debounceRef: MutableRefObject<ReturnType<typeof setTimeout> | null>;
+}
+
+/** Mount the EditorView for the lifetime of the host effect and return
+ *  the React-style cleanup. Pulled out of `useDslEditorView` so that
+ *  hook stays under the per-function line cap once the compartment +
+ *  mobile-query + autocomplete plumbing all land in the same mount
+ *  callback. */
+function mountEditorView(args: MountEditorViewArgs): () => void {
+  const { host, options, compartments, emit, sourcesRef, viewRef, debounceRef } = args;
+  const view = createEditorView(host, { options, compartments, emit, sourcesRef });
+  viewRef.current = view;
+  const stopMql = watchMobileQuery(view, compartments.chips);
+  return () => {
+    stopMql();
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+      debounceRef.current = null;
+    }
+    view.destroy();
+    viewRef.current = null;
+  };
+}
+
+function createEditorView(host: HTMLDivElement, args: CreateEditorViewArgs): EditorView {
+  const { options, compartments, emit, sourcesRef } = args;
+  // Initial `options.issues` is seeded by the `useEffect(..., [options.issues])`
+  // block in `useSyncEffects`, which fires once after mount — dispatching
+  // here would double-render (PR #2716 review feedback).
   const compact = detectCompactInitial();
   return new EditorView({
     state: EditorState.create({
@@ -180,6 +228,7 @@ function createEditorView(
         keymap.of([...defaultKeymap, ...historyKeymap]),
         compartments.readOnly.of(buildReadOnlyExtension(options.readOnly)),
         compartments.chips.of(chipWidgetsExtension({ compact })),
+        dslAutocompletion(buildSourcesProxy(sourcesRef)),
         EditorView.updateListener.of((update) => {
           if (update.docChanged) emit(update.state.doc.toString());
         }),
@@ -187,4 +236,27 @@ function createEditorView(
     }),
     parent: host,
   });
+}
+
+/** Indirect every lookup through the ref so the autocomplete extension
+ *  observes the latest sources without forcing a re-mount. When the
+ *  caller hasn't provided sources the proxy returns empty lists,
+ *  which the CodeMirror source folds into a `null` result. */
+function buildSourcesProxy(
+  ref: MutableRefObject<DslAutocompleteSources | null>
+): DslAutocompleteSources {
+  return {
+    searchSlugs: async (query, kinds) => {
+      const s = ref.current;
+      return s === null ? [] : await s.searchSlugs(query, kinds);
+    },
+    listVariantsForIngredient: async (slug) => {
+      const s = ref.current;
+      return s === null ? [] : await s.listVariantsForIngredient(slug);
+    },
+    listPrepStates: async () => {
+      const s = ref.current;
+      return s === null ? [] : await s.listPrepStates();
+    },
+  };
 }

--- a/packages/app-food/src/components/useDslEditorView.ts
+++ b/packages/app-food/src/components/useDslEditorView.ts
@@ -40,9 +40,9 @@ import { recipeDsl } from '../dsl/codemirror';
 import { dslAutocompletion } from './dsl-editor/autocomplete-extension';
 import { chipWidgetsExtension } from './dsl-editor/chip-widgets-extension';
 import { issuesExtension, setIssuesEffect } from './dsl-editor/issues-extension';
-import type { CompileEditorIssue } from './dsl-editor/issues-types';
 
 import type { DslAutocompleteSources } from './dsl-editor/autocomplete-types';
+import type { CompileEditorIssue } from './dsl-editor/issues-types';
 
 const DEBOUNCE_MS = 250;
 const MOBILE_QUERY = '(max-width: 767px)';

--- a/packages/app-food/src/index.ts
+++ b/packages/app-food/src/index.ts
@@ -23,7 +23,15 @@ export type { TimerButtonProps } from './components/TimerButton';
 export { TempBadge } from './components/TempBadge';
 export type { TempBadgeProps } from './components/TempBadge';
 
-// PRD-120 — DSL Editor (Part A scaffold + Part C issues prop + Part D chip widgets).
+// PRD-120 — DSL Editor (Part A scaffold + Part B autocomplete + Part C issues prop + Part D chip widgets).
 export { DslEditor } from './components/DslEditor';
 export type { DslEditorProps } from './components/DslEditor';
 export type { CompileEditorIssue, IssueSeverity } from './components/dsl-editor/issues-types';
+export type {
+  DslAutocompleteSources,
+  PrepStateSuggestion,
+  SlugKind,
+  SlugSuggestion,
+  VariantSuggestion,
+} from './components/dsl-editor/autocomplete-types';
+export { useDslAutocompleteSources } from './components/dsl-editor/use-dsl-autocomplete-sources';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -702,6 +702,9 @@ importers:
 
   packages/app-food:
     dependencies:
+      '@codemirror/autocomplete':
+        specifier: ^6.18.7
+        version: 6.20.3
       '@codemirror/commands':
         specifier: ^6.10.3
         version: 6.10.3
@@ -1588,6 +1591,9 @@ packages:
     engines: {node: '>=20.0.0', yarn: '>=1.22.18'}
     peerDependencies:
       storybook: ^0.0.0-0 || ^10.1.0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0 || ^10.5.0-0 || ^10.6.0-0
+
+  '@codemirror/autocomplete@6.20.3':
+    resolution: {integrity: sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==}
 
   '@codemirror/commands@6.10.3':
     resolution: {integrity: sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==}
@@ -7986,6 +7992,13 @@ snapshots:
       - '@chromatic-com/cypress'
       - '@chromatic-com/playwright'
       - '@chromatic-com/vitest'
+
+  '@codemirror/autocomplete@6.20.3':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.1
+      '@lezer/common': 1.5.2
 
   '@codemirror/commands@6.10.3':
     dependencies:


### PR DESCRIPTION
## Summary

- Wires context-aware completion sources into the `DslEditor` scaffolded by PRD-120 part A (#2702).
- Adds an `autocompleteSources` prop implementing three async lookups; production callers use `useDslAutocompleteSources()` which wraps `food.slugs.search`, `food.ingredients.get`, and `food.prepStates.list` through `trpc.useUtils()` so results land in the React Query session cache (PRD AC at `docs/themes/07-food/prds/120-dsl-editor/README.md` lines 96 / 172-176).
- Cursor classifier (pure) maps the prefix before the cursor onto one of seven contexts: function name, descriptor slug, descriptor variant, descriptor prep state, qty unit, step-body `@N`/`@slug`, or none. A step-body scanner honours `\\` and `\"` escapes so cursor classification inside string literals switches sources cleanly.
- Files split across `packages/app-food/src/components/dsl-editor/autocomplete-*.ts` to stay under the 200-line per-file lint cap.

## Acceptance criteria (PRD-120 — Autocomplete section)

- [x] After typing `@`, the suggestion list shows the 6 function names.
- [x] After typing `@ingredient(1, `, the suggestion list queries `food.slugs.search`.
- [x] After typing a known ingredient slug + `:`, the list shows that ingredient's variants from the DB.
- [x] After typing `@ingredient(1, banana:raw:`, the list shows the curated prep_states.
- [x] Inside a `@step("...")` body, typing `@` shows currently-declared ingredient indexes AND a fuzzy slug search.

## File map

**New** (under `packages/app-food/src/components/dsl-editor/`):

- `autocomplete-types.ts` — `DslAutocompleteSources` interface + `SlugSuggestion` / `VariantSuggestion` / `PrepStateSuggestion`.
- `autocomplete-context.ts` — pure cursor classifier (`classifyCursor(text, pos) → CursorContext`).
- `autocomplete-step-bodies.ts` — `findStepBodyAtOffset` + `collectStepIndexes` (the `@ingredient(N, …)` index map that step-ref autocomplete consumes).
- `autocomplete-units.ts` — canonical units + DSL function names.
- `autocomplete-source.ts` — `buildDslCompletionSource(sources)` — the single `CompletionSource` that dispatches on the classified context.
- `autocomplete-extension.ts` — `dslAutocompletion(sources)` factory returning the CodeMirror `Extension`.
- `use-dsl-autocomplete-sources.ts` — React hook wiring tRPC + React Query.
- `__tests__/autocomplete-context.test.ts` (19 cases), `__tests__/autocomplete-source.test.ts` (9 cases), `__tests__/autocomplete-step-bodies.test.ts` (12 cases).

**Edited:**

- `packages/app-food/src/components/DslEditor.tsx` — new optional `autocompleteSources` prop.
- `packages/app-food/src/components/useDslEditorView.ts` — accepts the sources via a `MutableRefObject` proxy so a prop swap doesn't tear down the EditorView; merged additively with 120-D's chip-widgets compartment.
- `packages/app-food/src/components/__tests__/DslEditor.test.tsx` — new PRD-120 part B describe block with 4 RTL cases.
- `packages/app-food/src/index.ts` — re-exports `DslEditor`, `DslEditorProps`, `DslAutocompleteSources`, and `useDslAutocompleteSources`.
- `packages/app-food/package.json` — adds `@codemirror/autocomplete@^6.18.7`.

## Test plan

- [x] `pnpm --filter @pops/app-food typecheck` — clean.
- [x] `pnpm --filter @pops/app-food test` — 325/325 passing (40 new vitest cases + 4 RTL).
- [x] `pnpm lint` — clean (zero errors; pre-existing warnings unchanged).
- [x] Husky pre-commit ran `pnpm typecheck` (turbo, 25 packages, all green).
- [ ] Manual smoke against `/food/recipes/:slug/edit` — deferred to PRD-119 (the page that mounts the editor). Storybook stories cover the visual demo (120-F).

## Coordination

Strictly additive against the other in-flight 120/122 PRs.

- **120-D (chip widgets)** merged as #2717 ahead of this branch; rebase merged the chip-widgets compartment alongside the new autocomplete extension in `useDslEditorView.createEditorView`. Both extensions live in disjoint `Compartment` slots.
- **120-C (issues squiggles)** — still in flight (pops10); will add `issues` prop via a separate `StateField` not touched here.
- **122-API** — `food.slugs.search` was delivered there (PR #2705); this PR consumes it.
- **PRD-119** — when it lands, the recipe edit page can `import { DslEditor, useDslAutocompleteSources } from '@pops/app-food'` and pass the hook result through. No further work required from this PR.

## Side-note: `FoodDataLayout.test.tsx`

The conflict resolution accepted main's HEAD version of `FoodDataLayout.test.tsx`, which now stubs the per-tab modules inline (no `React.lazy`) — the much cleaner fix for the lazy-chunk race that this branch's earlier timeout bumps tried to paper over. Both approaches converge on the same outcome: the test file no longer races vitest's worker pool.