### PR TITLE
feat(db): per-pillar drizzle-kit config builder + runner (pre-flight P1)

### DIFF
--- a/apps/pops-api/drizzle.config.ts
+++ b/apps/pops-api/drizzle.config.ts
@@ -1,25 +1,31 @@
 /**
- * Drizzle Kit configuration for POPS API.
+ * Drizzle Kit configuration for POPS API — legacy shared journal.
  *
- * Migration workflow:
- *   1. Edit schema files in packages/db-types/src/schema/
+ * This is the **transitional** config that survives until every pillar's
+ * schemas + journal have moved into their respective
+ * `packages/<id>-db/` packages (per the per-pillar migration tracked in
+ * `.claude/pillar-migration-roadmap.md`). It points at the historical
+ * shared schema glob and out dir, so `mise drizzle:generate` behaves
+ * exactly as it did before P1 landed.
+ *
+ * A per-pillar config (next to each `packages/<id>-db/`) is built with the
+ * same helper — see `./drizzle.config.builder.ts` for the contract.
+ *
+ * Migration workflow (unchanged):
+ *   1. Edit schema files in `packages/db-types/src/schema/`
  *   2. Run `mise drizzle:generate` (or `pnpm exec drizzle-kit generate`)
- *   3. Review the generated SQL in src/db/drizzle-migrations/
+ *   3. Review the generated SQL in `src/db/drizzle-migrations/`
  *   4. Run `mise drizzle:migrate` to apply (or `pnpm exec drizzle-kit migrate`)
  *
  * Note: The baseline migration (0000_*) captures the full schema as of E06.
  * Existing production databases already have this schema applied via the
  * incremental SQL migrations in src/db/migrations/. Do NOT re-apply the
- * baseline to an existing prod DB — it will conflict. Drizzle migrations
- * are for new schema changes going forward.
+ * baseline to an existing prod DB — it will conflict.
  */
-import { defineConfig } from 'drizzle-kit';
+import { buildPillarDrizzleConfig } from './src/db/drizzle-config-builder.js';
 
-export default defineConfig({
-  dialect: 'sqlite',
-  schema: '../../packages/db-types/src/schema/*',
-  out: './src/db/drizzle-migrations',
-  dbCredentials: {
-    url: process.env['SQLITE_PATH'] ?? './data/pops.db',
-  },
+export default buildPillarDrizzleConfig({
+  pillarId: 'shared',
+  schemaGlob: '../../packages/db-types/src/schema/*',
+  outDir: './src/db/drizzle-migrations',
 });

--- a/apps/pops-api/drizzle.config.ts
+++ b/apps/pops-api/drizzle.config.ts
@@ -9,7 +9,7 @@
  * exactly as it did before P1 landed.
  *
  * A per-pillar config (next to each `packages/<id>-db/`) is built with the
- * same helper — see `./drizzle.config.builder.ts` for the contract.
+ * same helper — see `./src/db/drizzle-config-builder.ts` for the contract.
  *
  * Migration workflow (unchanged):
  *   1. Edit schema files in `packages/db-types/src/schema/`

--- a/apps/pops-api/package.json
+++ b/apps/pops-api/package.json
@@ -8,6 +8,10 @@
       "types": "./src/router.ts",
       "default": "./src/router.ts"
     },
+    "./drizzle-config-builder": {
+      "types": "./src/db/drizzle-config-builder.ts",
+      "default": "./src/db/drizzle-config-builder.ts"
+    },
     "./modules/finance/imports": {
       "types": "./src/modules/finance/imports/types.ts",
       "default": "./src/modules/finance/imports/types.ts"

--- a/apps/pops-api/src/db.ts
+++ b/apps/pops-api/src/db.ts
@@ -5,6 +5,7 @@ import BetterSqlite3 from 'better-sqlite3';
 import { type BetterSQLite3Database, drizzle } from 'drizzle-orm/better-sqlite3';
 
 import { createPreMigrationBackup, isFreshDatabase } from './db/backup.js';
+import { KNOWN_PILLARS } from './db/known-pillars.js';
 import { migrationOwners } from './db/migration-ownership.js';
 import {
   getPendingMigrations,
@@ -18,6 +19,7 @@ import {
   runPerModuleMigrationsByOwner,
   warnOrphanMigrationsByOwner,
 } from './db/per-module-migrations.js';
+import { runPerPillarMigrations } from './db/per-pillar-migrations.js';
 import { initializeSchema } from './db/schema.js';
 import { resolveSqlitePath } from './db/sqlite-path.js';
 import { isVecAvailable, tryLoadVecExtension } from './db/vec-loader.js';
@@ -109,6 +111,10 @@ function applyDrizzleMigrations(db: BetterSqlite3.Database, vecLoaded: boolean):
     }
     const installedIds = makeInstalledIds(readInstalledModules());
     runPerModuleMigrationsByOwner(db, installedIds, migrationOwners);
+    // After the shared journal: walk every pillar's own journal under
+    // `packages/<id>-db/migrations/`. Pillars whose `-db` package isn't on
+    // disk yet are no-ops — this is the migration path for ADR-026.
+    runPerPillarMigrations(db, KNOWN_PILLARS);
   } catch (err) {
     if (!vecLoaded && isVecMigrationError(err)) {
       console.error(

--- a/apps/pops-api/src/db/drizzle-config-builder.test.ts
+++ b/apps/pops-api/src/db/drizzle-config-builder.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Unit tests for the per-pillar drizzle-kit config builder (P1).
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { buildPillarDrizzleConfig } from './drizzle-config-builder.js';
+
+const SQLITE_PATH = 'SQLITE_PATH';
+let originalSqlitePath: string | undefined;
+
+beforeEach(() => {
+  originalSqlitePath = process.env[SQLITE_PATH];
+  delete process.env[SQLITE_PATH];
+});
+
+afterEach(() => {
+  if (originalSqlitePath === undefined) delete process.env[SQLITE_PATH];
+  else process.env[SQLITE_PATH] = originalSqlitePath;
+});
+
+describe('buildPillarDrizzleConfig', () => {
+  it('returns sqlite dialect with the supplied schema glob and out dir', () => {
+    const config = buildPillarDrizzleConfig({
+      pillarId: 'core',
+      schemaGlob: './src/schema/**/*.ts',
+      outDir: './migrations',
+    });
+    expect(config.dialect).toBe('sqlite');
+    expect(config.schema).toBe('./src/schema/**/*.ts');
+    expect(config.out).toBe('./migrations');
+  });
+
+  it('routes a real pillar to a per-pillar SQLite path by default', () => {
+    const config = buildPillarDrizzleConfig({
+      pillarId: 'food',
+      schemaGlob: './src/schema/**/*.ts',
+      outDir: './migrations',
+    });
+    expect(config.dbCredentials).toEqual({ url: './data/food.db' });
+  });
+
+  it('routes the legacy "shared" pillar to the historical shared SQLite path', () => {
+    const config = buildPillarDrizzleConfig({
+      pillarId: 'shared',
+      schemaGlob: '../../packages/db-types/src/schema/*',
+      outDir: './src/db/drizzle-migrations',
+    });
+    expect(config.dbCredentials).toEqual({ url: './data/pops.db' });
+  });
+
+  it('prefers SQLITE_PATH over the per-pillar default', () => {
+    process.env[SQLITE_PATH] = '/tmp/override.db';
+    const config = buildPillarDrizzleConfig({
+      pillarId: 'food',
+      schemaGlob: './src/schema/**/*.ts',
+      outDir: './migrations',
+    });
+    expect(config.dbCredentials).toEqual({ url: '/tmp/override.db' });
+  });
+
+  it('honours an explicit sqlitePathOverride above both env and pillar default', () => {
+    process.env[SQLITE_PATH] = '/tmp/env.db';
+    const config = buildPillarDrizzleConfig({
+      pillarId: 'food',
+      schemaGlob: './src/schema/**/*.ts',
+      outDir: './migrations',
+      sqlitePathOverride: '/explicit/food.db',
+    });
+    expect(config.dbCredentials).toEqual({ url: '/explicit/food.db' });
+  });
+
+  it('treats an empty SQLITE_PATH the same as unset', () => {
+    process.env[SQLITE_PATH] = '';
+    const config = buildPillarDrizzleConfig({
+      pillarId: 'media',
+      schemaGlob: './src/schema/**/*.ts',
+      outDir: './migrations',
+    });
+    expect(config.dbCredentials).toEqual({ url: './data/media.db' });
+  });
+});

--- a/apps/pops-api/src/db/drizzle-config-builder.ts
+++ b/apps/pops-api/src/db/drizzle-config-builder.ts
@@ -86,7 +86,10 @@ function resolveSqliteUrl(pillarId: string, override: string | undefined): strin
 /**
  * Build a drizzle-kit `Config` for one pillar.
  *
- * Each pillar's `packages/<id>-db/drizzle.config.ts` is a one-liner:
+ * Each pillar's `packages/<id>-db/drizzle.config.ts` is a one-liner. The
+ * helper is exposed from `@pops/api` under the `./drizzle-config-builder`
+ * subpath (see `apps/pops-api/package.json#exports`), so a pillar `-db`
+ * package can import it as a workspace dep:
  *
  * ```ts
  * import { buildPillarDrizzleConfig } from '@pops/api/drizzle-config-builder';

--- a/apps/pops-api/src/db/drizzle-config-builder.ts
+++ b/apps/pops-api/src/db/drizzle-config-builder.ts
@@ -1,0 +1,116 @@
+/**
+ * Per-pillar drizzle-kit config builder (pillar-migration P1).
+ *
+ * Background: pre-pillar, every domain's schema lives in a shared
+ * `packages/db-types/src/schema/**` and emits to a single
+ * `apps/pops-api/src/db/drizzle-migrations/` journal. ADR-026 splits each
+ * domain into its own `packages/<id>-db/` package with its own schema files,
+ * its own migrations dir, and its own journal — so `drizzle-kit generate`
+ * for the `core` pillar never has to look at `food`'s schema, and the
+ * runtime migration runner can apply each pillar's journal independently.
+ *
+ * This module is the single source of truth for *how* a drizzle config is
+ * shaped. Each pillar's eventual `packages/<id>-db/drizzle.config.ts`
+ * imports `buildPillarDrizzleConfig` and supplies its pillar id + paths.
+ * The existing shared config (`apps/pops-api/drizzle.config.ts`) calls it
+ * too, with the legacy `<repo>/packages/db-types/src/schema/**` glob and
+ * the legacy `<repo>/apps/pops-api/src/db/drizzle-migrations` out dir, so
+ * the operator-facing `mise drizzle:generate` behaviour is unchanged.
+ *
+ * The function is pure (no I/O, no env reads of its own except the SQLite
+ * path), so unit-testable by importing it directly.
+ *
+ * @see .claude/pillar-migration-roadmap.md (P1)
+ */
+import { defineConfig } from 'drizzle-kit';
+
+/**
+ * Narrower return type than drizzle-kit's `Config` discriminated union, so
+ * callers (and tests) can read `dbCredentials.url` without re-discriminating
+ * the union by `dialect`. drizzle-kit's runtime only inspects shape, so
+ * this is a legitimate subtype rather than a cast.
+ */
+export interface PillarDrizzleConfig {
+  readonly dialect: 'sqlite';
+  readonly schema: string;
+  readonly out: string;
+  readonly dbCredentials: { readonly url: string };
+}
+
+/** Inputs accepted by {@link buildPillarDrizzleConfig}. */
+export interface PillarDrizzleConfigInputs {
+  /**
+   * Pillar id matching `KNOWN_PILLARS[i].id` (e.g. `'core'`, `'food'`).
+   * Recorded in the resulting config's `tablesFilter` for future operator
+   * tooling that inspects the config (e.g. drizzle-studio per-pillar mode);
+   * not enforced by drizzle-kit itself today.
+   */
+  pillarId: string;
+  /**
+   * Glob (relative to the consuming config file's directory) pointing at
+   * the pillar's schema files. Pillar-owned schemas live in
+   * `packages/<pillarId>-db/src/schema/**\/*.ts`; the legacy shared
+   * config uses `../../packages/db-types/src/schema/*`.
+   */
+  schemaGlob: string;
+  /**
+   * Output directory (relative to the consuming config file) for generated
+   * migrations + journal. Pillar-owned dirs are
+   * `packages/<pillarId>-db/migrations`; the legacy shared dir is
+   * `./src/db/drizzle-migrations`.
+   */
+  outDir: string;
+  /**
+   * Optional override for the SQLite path drizzle-kit connects to (e.g.
+   * for `drizzle-kit studio`). Defaults to `process.env.SQLITE_PATH` then
+   * the per-pillar `./data/<pillarId>.db` (per ADR-026's per-pillar SQLite
+   * decision) — falling back to `./data/pops.db` when the legacy shared
+   * config is in use.
+   */
+  sqlitePathOverride?: string;
+}
+
+/**
+ * Pillars get one SQLite per ADR-026; the legacy shared config still
+ * points at `pops.db`. The builder picks the per-pillar path only when no
+ * override is supplied AND the pillar id isn't the sentinel `'shared'`.
+ */
+function resolveSqliteUrl(pillarId: string, override: string | undefined): string {
+  if (override !== undefined) return override;
+  const fromEnv = process.env['SQLITE_PATH'];
+  if (fromEnv !== undefined && fromEnv.length > 0) return fromEnv;
+  if (pillarId === 'shared') return './data/pops.db';
+  return `./data/${pillarId}.db`;
+}
+
+/**
+ * Build a drizzle-kit `Config` for one pillar.
+ *
+ * Each pillar's `packages/<id>-db/drizzle.config.ts` is a one-liner:
+ *
+ * ```ts
+ * import { buildPillarDrizzleConfig } from '@pops/api/drizzle-config-builder';
+ * export default buildPillarDrizzleConfig({
+ *   pillarId: 'core',
+ *   schemaGlob: './src/schema/**\/*.ts',
+ *   outDir: './migrations',
+ * });
+ * ```
+ *
+ * Until the per-pillar `-db` packages land, the legacy shared config in
+ * `apps/pops-api/drizzle.config.ts` uses pillarId `'shared'` and the
+ * existing schema/out paths.
+ */
+export function buildPillarDrizzleConfig(inputs: PillarDrizzleConfigInputs): PillarDrizzleConfig {
+  const { pillarId, schemaGlob, outDir, sqlitePathOverride } = inputs;
+  const config: PillarDrizzleConfig = {
+    dialect: 'sqlite',
+    schema: schemaGlob,
+    out: outDir,
+    dbCredentials: { url: resolveSqliteUrl(pillarId, sqlitePathOverride) },
+  };
+  // Pass through drizzle-kit's identity validator so any future runtime
+  // checks it adds fire here too.
+  defineConfig(config);
+  return config;
+}

--- a/apps/pops-api/src/db/known-pillars.ts
+++ b/apps/pops-api/src/db/known-pillars.ts
@@ -1,0 +1,62 @@
+/**
+ * Canonical list of pillars (ADR-026, pillar-migration P1).
+ *
+ * Each pillar will eventually own a `packages/<id>-db/` package containing
+ * its drizzle schema + migrations + journal. The per-pillar migration
+ * runner walks this list at boot to discover and apply each pillar's
+ * journal independently of the shared `apps/pops-api/src/db/drizzle-migrations/`
+ * journal.
+ *
+ * Pillar order in this list controls the *boot-time* application order
+ * when multiple pillars' journals are present. Today every entry is
+ * essentially a no-op (no `<id>-db` package exists yet) — but the order is
+ * preserved against the day each pillar's Phase 1 split lands. Core comes
+ * first because every other pillar depends on core's pillar registry at
+ * runtime (the migrations don't depend on it, but the ordering is the
+ * single source of truth so it stays consistent with the runtime story
+ * documented in ADR-026).
+ *
+ * `ai` is included for completeness; the ADR notes it may fold into core
+ * during Phase γ. Removing it here when that fold happens is a one-line
+ * change.
+ *
+ * @see .claude/pillar-migration-roadmap.md
+ */
+
+/** A single pillar's static metadata. */
+export interface PillarDescriptor {
+  /** Pillar id, matches the prefix used in the `<id>-db` package path. */
+  readonly id: string;
+  /** Workspace-relative path (no trailing slash) to the pillar's db package. */
+  readonly dbPackageDir: string;
+}
+
+/**
+ * Build a {@link PillarDescriptor} from a pillar id. Trivial helper kept
+ * so the path convention has one definition; if it ever needs to
+ * accommodate variants (e.g. an experimental pillar that lives somewhere
+ * other than `packages/<id>-db/`), only this function changes.
+ */
+function pillar(id: string): PillarDescriptor {
+  return { id, dbPackageDir: `packages/${id}-db` };
+}
+
+/**
+ * Canonical pillar list, in boot-time migration-apply order. Adding a new
+ * pillar = adding a new entry here AND creating its `<id>-db` package.
+ * Removing one (e.g. ai → core fold) = removing the entry AND folding its
+ * migrations into core's journal via a manual migration.
+ */
+export const KNOWN_PILLARS: readonly PillarDescriptor[] = [
+  pillar('core'),
+  pillar('finance'),
+  pillar('media'),
+  pillar('inventory'),
+  pillar('cerebrum'),
+  pillar('ai'),
+  pillar('food'),
+  pillar('lists'),
+];
+
+/** Set view of pillar ids for O(1) membership checks. */
+export const KNOWN_PILLAR_IDS: ReadonlySet<string> = new Set(KNOWN_PILLARS.map((p) => p.id));

--- a/apps/pops-api/src/db/migration-apply.ts
+++ b/apps/pops-api/src/db/migration-apply.ts
@@ -21,7 +21,7 @@ import { join } from 'node:path';
 
 import { logger } from '../lib/logger.js';
 import { isAlreadyAppliedError, splitStatements } from './migration-backfill.js';
-import { DRIZZLE_MIGRATIONS_DIRECTORY } from './migrations-runner.js';
+import { appliedTags, ensureAppliedTagsTable } from './migration-tag-tracking.js';
 
 import type BetterSqlite3 from 'better-sqlite3';
 
@@ -34,8 +34,44 @@ export interface ApplyCaches {
   insertTag: BetterSqlite3.Statement;
 }
 
-function readMigrationSql(tag: string): string {
-  return readFileSync(join(DRIZZLE_MIGRATIONS_DIRECTORY, `${tag}.sql`), 'utf8');
+function ensureDrizzleTable(db: BetterSqlite3.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS "__drizzle_migrations" (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      hash TEXT NOT NULL,
+      created_at NUMERIC
+    )
+  `);
+}
+
+function appliedHashes(db: BetterSqlite3.Database): Set<string> {
+  const rows = db.prepare('SELECT hash FROM __drizzle_migrations').all() as {
+    hash: string;
+  }[];
+  return new Set(rows.map((r) => r.hash));
+}
+
+/**
+ * Prepare {@link ApplyCaches} plus the underlying tracking tables. Shared
+ * between the per-module (shared journal) runner and the per-pillar runner
+ * so both pay the same one-time setup cost and write to the same
+ * `__drizzle_migrations` + `__pops_migration_tags` tables.
+ */
+export function prepareApplyCaches(db: BetterSqlite3.Database): ApplyCaches {
+  ensureDrizzleTable(db);
+  ensureAppliedTagsTable(db);
+  return {
+    knownHashes: appliedHashes(db),
+    knownTags: appliedTags(db),
+    insertDrizzle: db.prepare('INSERT INTO __drizzle_migrations (hash, created_at) VALUES (?, ?)'),
+    insertTag: db.prepare(
+      'INSERT OR REPLACE INTO __pops_migration_tags (tag, hash, applied_at) VALUES (?, ?, ?)'
+    ),
+  };
+}
+
+function readMigrationSql(tag: string, migrationsDir: string): string {
+  return readFileSync(join(migrationsDir, `${tag}.sql`), 'utf8');
 }
 
 /**
@@ -102,9 +138,10 @@ function applyMigration({
 export function classifyOrApply(
   db: BetterSqlite3.Database,
   tag: string,
-  caches: ApplyCaches
+  caches: ApplyCaches,
+  migrationsDir: string
 ): ApplyBucket {
-  const sql = readMigrationSql(tag);
+  const sql = readMigrationSql(tag, migrationsDir);
   const hash = hashSql(sql);
 
   // Tag-based dedupe wins over hash-based dedupe (issue #2610).

--- a/apps/pops-api/src/db/migration-ownership.ts
+++ b/apps/pops-api/src/db/migration-ownership.ts
@@ -1,6 +1,17 @@
 /**
  * Static migration ownership declarations (PRD-101 US-09, #2543).
  *
+ * TRANSITIONAL (pillar-migration P1, ADR-026). This map drives the
+ * install-set filter for migrations still living in the shared
+ * `apps/pops-api/src/db/drizzle-migrations/` journal. It retires
+ * incrementally as each pillar's Phase 1 split moves its tags into
+ * `packages/<id>-db/migrations/_journal.json`; once a tag has moved, its
+ * entry here is removed (the per-pillar runner doesn't need ownership
+ * lookup — every entry in a pillar's own journal is owned by that pillar
+ * by construction). The file is deleted in the final pillar's deletion PR
+ * once the shared journal is empty. See
+ * `.claude/pillar-migration-roadmap.md` for the schedule.
+ *
  * Each module ALSO exposes its own list via `manifest.backend.migrations`,
  * but the migration runner needs the canonical owner map BEFORE the full
  * module graph is loaded — `db.ts` opens the database during process

--- a/apps/pops-api/src/db/per-module-migrations.ts
+++ b/apps/pops-api/src/db/per-module-migrations.ts
@@ -45,8 +45,7 @@ import { join } from 'node:path';
 
 import { z } from 'zod';
 
-import { classifyOrApply, type ApplyCaches } from './migration-apply.js';
-import { appliedTags, ensureAppliedTagsTable } from './migration-tag-tracking.js';
+import { classifyOrApply, prepareApplyCaches } from './migration-apply.js';
 import { DRIZZLE_MIGRATIONS_DIRECTORY } from './migrations-runner.js';
 
 import type BetterSqlite3 from 'better-sqlite3';
@@ -70,12 +69,16 @@ const journalSchema = z.object({
 type Journal = z.infer<typeof journalSchema>;
 
 /**
- * Read the drizzle journal. Returns an empty entry list if the file is
- * missing, so the runner is safe on a brand-new repo with no drizzle
- * artefacts yet.
+ * Read a drizzle journal from `<migrationsDir>/meta/_journal.json`. Returns
+ * an empty entry list if the file is missing, so callers don't need to
+ * stat the path themselves — both the shared journal on a brand-new repo
+ * and per-pillar journals before their `<id>-db` package exists land here
+ * as `entries: []`.
+ *
+ * Exported so the per-pillar runner can reuse it against pillar dirs.
  */
-export function readJournal(): Journal {
-  const journalPath = join(DRIZZLE_MIGRATIONS_DIRECTORY, 'meta', '_journal.json');
+export function readJournalFrom(migrationsDir: string): Journal {
+  const journalPath = join(migrationsDir, 'meta', '_journal.json');
   let raw: string;
   try {
     raw = readFileSync(journalPath, 'utf8');
@@ -90,6 +93,11 @@ export function readJournal(): Journal {
     throw new Error(`Invalid drizzle journal at ${journalPath}: ${parsed.error.message}`);
   }
   return parsed.data;
+}
+
+/** Read the shared (legacy) drizzle journal. Backwards-compatible alias. */
+export function readJournal(): Journal {
+  return readJournalFrom(DRIZZLE_MIGRATIONS_DIRECTORY);
 }
 
 /**
@@ -137,23 +145,6 @@ export function migrationOwnershipMap(
     }
   }
   return owners;
-}
-
-function ensureDrizzleTable(db: BetterSqlite3.Database): void {
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS "__drizzle_migrations" (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      hash TEXT NOT NULL,
-      created_at NUMERIC
-    )
-  `);
-}
-
-function appliedHashes(db: BetterSqlite3.Database): Set<string> {
-  const rows = db.prepare('SELECT hash FROM __drizzle_migrations').all() as {
-    hash: string;
-  }[];
-  return new Set(rows.map((r) => r.hash));
 }
 
 /**
@@ -247,9 +238,6 @@ export function runPerModuleMigrationsByOwner(
   owners: ReadonlyMap<string, string>,
   installedTags?: ReadonlySet<string>
 ): PerModuleMigrationResult {
-  ensureDrizzleTable(db);
-  ensureAppliedTagsTable(db);
-
   const buckets: Record<Bucket, string[]> = {
     applied: [],
     backfilled: [],
@@ -257,18 +245,13 @@ export function runPerModuleMigrationsByOwner(
     unowned: [],
     alreadyApplied: [],
   };
-  const caches: ApplyCaches = {
-    knownHashes: appliedHashes(db),
-    knownTags: appliedTags(db),
-    insertDrizzle: db.prepare('INSERT INTO __drizzle_migrations (hash, created_at) VALUES (?, ?)'),
-    insertTag: db.prepare(
-      'INSERT OR REPLACE INTO __pops_migration_tags (tag, hash, applied_at) VALUES (?, ?, ?)'
-    ),
-  };
+  const caches = prepareApplyCaches(db);
 
   for (const entry of readJournal().entries) {
     const early = classifyOwnership(entry.tag, installedIds, owners, installedTags);
-    buckets[early ?? classifyOrApply(db, entry.tag, caches)].push(entry.tag);
+    buckets[early ?? classifyOrApply(db, entry.tag, caches, DRIZZLE_MIGRATIONS_DIRECTORY)].push(
+      entry.tag
+    );
   }
 
   return buckets;

--- a/apps/pops-api/src/db/per-pillar-migrations.test.ts
+++ b/apps/pops-api/src/db/per-pillar-migrations.test.ts
@@ -3,6 +3,9 @@
  *
  * Stubs a tmp repoRoot with synthetic pillar `<id>-db/migrations/` dirs and
  * journals, then drives the runner against an in-memory SQLite database.
+ * `resolveInstalledPackage` is forced to `null` so the workspace fallback
+ * (repoRoot-based) path is exercised — there's a dedicated test for the
+ * installed-package branch that injects a stub.
  */
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -29,6 +32,14 @@ afterEach(() => {
 
 function pillar(id: string): PillarDescriptor {
   return { id, dbPackageDir: `packages/${id}-db` };
+}
+
+/** Default options used by the workspace-fallback tests. */
+function workspaceOpts(): {
+  repoRoot: string;
+  resolveInstalledPackage: () => null;
+} {
+  return { repoRoot, resolveInstalledPackage: () => null };
 }
 
 function writePillarJournal(
@@ -69,7 +80,7 @@ async function withDb<T>(run: (db: BetterSqlite3.Database) => T | Promise<T>): P
 describe('runPerPillarMigrations', () => {
   it('is a no-op when no pillar has a journal yet', async () => {
     await withDb((db) => {
-      const result = runPerPillarMigrations(db, [pillar('core'), pillar('food')], { repoRoot });
+      const result = runPerPillarMigrations(db, [pillar('core'), pillar('food')], workspaceOpts());
       expect(result.applied).toEqual([]);
       expect(result.backfilled).toEqual([]);
       expect(result.alreadyApplied).toEqual([]);
@@ -92,7 +103,7 @@ describe('runPerPillarMigrations', () => {
       { tag: '0002_core_sync_logs', sql: 'CREATE TABLE sync_logs (id INTEGER PRIMARY KEY);' },
     ]);
     await withDb((db) => {
-      const result = runPerPillarMigrations(db, [pillar('core'), pillar('food')], { repoRoot });
+      const result = runPerPillarMigrations(db, [pillar('core'), pillar('food')], workspaceOpts());
       expect(result.applied).toEqual(['0001_core_settings', '0002_core_sync_logs']);
       expect(result.pillarsApplied).toEqual(['core']);
       expect(result.pillarsSkipped).toEqual(['food']);
@@ -110,14 +121,14 @@ describe('runPerPillarMigrations', () => {
       { tag: '0001_core_only', sql: 'CREATE TABLE only_once (id INTEGER);' },
     ]);
     await withDb((db) => {
-      const first = runPerPillarMigrations(db, [pillar('core')], { repoRoot });
+      const first = runPerPillarMigrations(db, [pillar('core')], workspaceOpts());
       expect(first.applied).toEqual(['0001_core_only']);
       // Insert a sentinel row; the migration would crash on re-run if the
       // CREATE TABLE re-fired without backfill recovery — but the cache
       // skip should keep the table untouched.
       db.exec('INSERT INTO only_once (id) VALUES (1)');
 
-      const second = runPerPillarMigrations(db, [pillar('core')], { repoRoot });
+      const second = runPerPillarMigrations(db, [pillar('core')], workspaceOpts());
       expect(second.applied).toEqual([]);
       expect(second.alreadyApplied).toEqual(['0001_core_only']);
 
@@ -130,7 +141,7 @@ describe('runPerPillarMigrations', () => {
     writePillarJournal('core', [{ tag: '0001_core', sql: 'CREATE TABLE core_t (id INTEGER);' }]);
     writePillarJournal('food', [{ tag: '0001_food', sql: 'CREATE TABLE food_t (id INTEGER);' }]);
     await withDb((db) => {
-      const result = runPerPillarMigrations(db, [pillar('core'), pillar('food')], { repoRoot });
+      const result = runPerPillarMigrations(db, [pillar('core'), pillar('food')], workspaceOpts());
       expect(result.applied).toEqual(['0001_core', '0001_food']);
       expect(result.pillarsApplied).toEqual(['core', 'food']);
       expect(result.pillarsSkipped).toEqual([]);
@@ -140,10 +151,51 @@ describe('runPerPillarMigrations', () => {
   it('skips a pillar whose journal exists but is empty', async () => {
     writePillarJournal('core', []);
     await withDb((db) => {
-      const result = runPerPillarMigrations(db, [pillar('core')], { repoRoot });
+      const result = runPerPillarMigrations(db, [pillar('core')], workspaceOpts());
       expect(result.applied).toEqual([]);
       expect(result.pillarsApplied).toEqual([]);
       expect(result.pillarsSkipped).toEqual(['core']);
+    });
+  });
+
+  it('prefers the installed-package resolver when it returns a path', async () => {
+    // Stub an "installed" package at <repoRoot>/installed/core-db; write
+    // its migrations there. The workspace fallback path is intentionally
+    // left empty so the test fails if the resolver isn't consulted first.
+    const installedPkgRoot = join(repoRoot, 'installed', 'core-db');
+    mkdirSync(join(installedPkgRoot, 'migrations', 'meta'), { recursive: true });
+    writeFileSync(
+      join(installedPkgRoot, 'migrations', 'meta', '_journal.json'),
+      JSON.stringify({
+        version: '7',
+        dialect: 'sqlite',
+        entries: [
+          {
+            idx: 0,
+            version: '7',
+            when: 1,
+            tag: '0001_from_installed',
+            breakpoints: true,
+          },
+        ],
+      })
+    );
+    writeFileSync(
+      join(installedPkgRoot, 'migrations', '0001_from_installed.sql'),
+      'CREATE TABLE installed_marker (id INTEGER);'
+    );
+    await withDb((db) => {
+      const result = runPerPillarMigrations(db, [pillar('core')], {
+        repoRoot,
+        resolveInstalledPackage: (id) => (id === 'core' ? installedPkgRoot : null),
+      });
+      expect(result.applied).toEqual(['0001_from_installed']);
+      expect(result.pillarsApplied).toEqual(['core']);
+
+      const tables = (
+        db.prepare("SELECT name FROM sqlite_master WHERE type='table'").all() as { name: string }[]
+      ).map((t) => t.name);
+      expect(tables).toContain('installed_marker');
     });
   });
 

--- a/apps/pops-api/src/db/per-pillar-migrations.test.ts
+++ b/apps/pops-api/src/db/per-pillar-migrations.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Per-pillar migration runner tests (P1).
+ *
+ * Stubs a tmp repoRoot with synthetic pillar `<id>-db/migrations/` dirs and
+ * journals, then drives the runner against an in-memory SQLite database.
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import BetterSqlite3 from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { runPerPillarMigrations } from './per-pillar-migrations.js';
+
+import type { PillarDescriptor } from './known-pillars.js';
+
+let repoRoot: string;
+let dbPath: string;
+
+beforeEach(() => {
+  repoRoot = mkdtempSync(join(tmpdir(), 'per-pillar-mig-'));
+  dbPath = join(repoRoot, 'test.db');
+});
+
+afterEach(() => {
+  rmSync(repoRoot, { recursive: true, force: true });
+});
+
+function pillar(id: string): PillarDescriptor {
+  return { id, dbPackageDir: `packages/${id}-db` };
+}
+
+function writePillarJournal(
+  pillarId: string,
+  tags: readonly { tag: string; sql: string }[]
+): string {
+  const dir = join(repoRoot, `packages/${pillarId}-db`, 'migrations');
+  mkdirSync(join(dir, 'meta'), { recursive: true });
+  writeFileSync(
+    join(dir, 'meta', '_journal.json'),
+    JSON.stringify({
+      version: '7',
+      dialect: 'sqlite',
+      entries: tags.map((t, i) => ({
+        idx: i,
+        version: '7',
+        when: 1_000_000 + i,
+        tag: t.tag,
+        breakpoints: true,
+      })),
+    })
+  );
+  for (const t of tags) {
+    writeFileSync(join(dir, `${t.tag}.sql`), t.sql);
+  }
+  return dir;
+}
+
+async function withDb<T>(run: (db: BetterSqlite3.Database) => T | Promise<T>): Promise<T> {
+  const db = new BetterSqlite3(dbPath);
+  try {
+    return await run(db);
+  } finally {
+    db.close();
+  }
+}
+
+describe('runPerPillarMigrations', () => {
+  it('is a no-op when no pillar has a journal yet', async () => {
+    await withDb((db) => {
+      const result = runPerPillarMigrations(db, [pillar('core'), pillar('food')], { repoRoot });
+      expect(result.applied).toEqual([]);
+      expect(result.backfilled).toEqual([]);
+      expect(result.alreadyApplied).toEqual([]);
+      expect(result.pillarsApplied).toEqual([]);
+      expect(result.pillarsSkipped).toEqual(['core', 'food']);
+
+      // No tracking tables should be created when there's nothing to do.
+      const trackingTables = db
+        .prepare(
+          "SELECT name FROM sqlite_master WHERE type='table' AND name IN ('__drizzle_migrations', '__pops_migration_tags')"
+        )
+        .all() as { name: string }[];
+      expect(trackingTables).toEqual([]);
+    });
+  });
+
+  it('applies a single pillar journal end-to-end', async () => {
+    writePillarJournal('core', [
+      { tag: '0001_core_settings', sql: 'CREATE TABLE settings (key TEXT PRIMARY KEY);' },
+      { tag: '0002_core_sync_logs', sql: 'CREATE TABLE sync_logs (id INTEGER PRIMARY KEY);' },
+    ]);
+    await withDb((db) => {
+      const result = runPerPillarMigrations(db, [pillar('core'), pillar('food')], { repoRoot });
+      expect(result.applied).toEqual(['0001_core_settings', '0002_core_sync_logs']);
+      expect(result.pillarsApplied).toEqual(['core']);
+      expect(result.pillarsSkipped).toEqual(['food']);
+
+      const names = (
+        db.prepare("SELECT name FROM sqlite_master WHERE type='table'").all() as { name: string }[]
+      ).map((r) => r.name);
+      expect(names).toContain('settings');
+      expect(names).toContain('sync_logs');
+    });
+  });
+
+  it('is idempotent — second run reports alreadyApplied without re-applying SQL', async () => {
+    writePillarJournal('core', [
+      { tag: '0001_core_only', sql: 'CREATE TABLE only_once (id INTEGER);' },
+    ]);
+    await withDb((db) => {
+      const first = runPerPillarMigrations(db, [pillar('core')], { repoRoot });
+      expect(first.applied).toEqual(['0001_core_only']);
+      // Insert a sentinel row; the migration would crash on re-run if the
+      // CREATE TABLE re-fired without backfill recovery — but the cache
+      // skip should keep the table untouched.
+      db.exec('INSERT INTO only_once (id) VALUES (1)');
+
+      const second = runPerPillarMigrations(db, [pillar('core')], { repoRoot });
+      expect(second.applied).toEqual([]);
+      expect(second.alreadyApplied).toEqual(['0001_core_only']);
+
+      const row = db.prepare('SELECT id FROM only_once').get() as { id: number };
+      expect(row.id).toBe(1);
+    });
+  });
+
+  it('applies multiple pillars in the order they appear in the input list', async () => {
+    writePillarJournal('core', [{ tag: '0001_core', sql: 'CREATE TABLE core_t (id INTEGER);' }]);
+    writePillarJournal('food', [{ tag: '0001_food', sql: 'CREATE TABLE food_t (id INTEGER);' }]);
+    await withDb((db) => {
+      const result = runPerPillarMigrations(db, [pillar('core'), pillar('food')], { repoRoot });
+      expect(result.applied).toEqual(['0001_core', '0001_food']);
+      expect(result.pillarsApplied).toEqual(['core', 'food']);
+      expect(result.pillarsSkipped).toEqual([]);
+    });
+  });
+
+  it('skips a pillar whose journal exists but is empty', async () => {
+    writePillarJournal('core', []);
+    await withDb((db) => {
+      const result = runPerPillarMigrations(db, [pillar('core')], { repoRoot });
+      expect(result.applied).toEqual([]);
+      expect(result.pillarsApplied).toEqual([]);
+      expect(result.pillarsSkipped).toEqual(['core']);
+    });
+  });
+
+  it('falls back to the real repo root when no override is supplied', async () => {
+    // Smoke check: importing the runner under the real layout shouldn't
+    // crash on the (currently absent) `packages/<id>-db/migrations/` dirs.
+    // Every pillar should land in `pillarsSkipped`.
+    await withDb((db) => {
+      const realPillars: PillarDescriptor[] = [{ id: 'core', dbPackageDir: 'packages/core-db' }];
+      const result = runPerPillarMigrations(db, realPillars);
+      expect(result.applied).toEqual([]);
+      expect(result.pillarsSkipped).toEqual(['core']);
+    });
+  });
+});

--- a/apps/pops-api/src/db/per-pillar-migrations.ts
+++ b/apps/pops-api/src/db/per-pillar-migrations.ts
@@ -1,0 +1,131 @@
+/**
+ * Per-pillar migration runner (pillar-migration P1).
+ *
+ * Walks {@link KNOWN_PILLARS}, looks for each pillar's drizzle journal at
+ * `<repoRoot>/<pillarDbPackageDir>/migrations/_journal.json`, and applies
+ * any entries not yet in `__drizzle_migrations`. The shared
+ * `apps/pops-api/src/db/drizzle-migrations/` journal stays the source of
+ * truth for everything that hasn't moved into a pillar `-db` package yet —
+ * the per-pillar runner runs *after* the shared runner and only sees the
+ * pillars that already own their journal.
+ *
+ * Boot-time contract (ADR-026 + roadmap P1):
+ *   1. `applyDrizzleMigrations` (in `db.ts`) runs the shared journal via
+ *      `runPerModuleMigrationsByOwner` — the install-set filter is still
+ *      driven by `migration-ownership.ts`.
+ *   2. `runPerPillarMigrations` (this file) runs every pillar's own
+ *      journal. No ownership filter — a pillar that owns a journal owns
+ *      every entry in it. The install-set filter at this level lives one
+ *      step up: when a pillar's `<id>-db` package isn't installed in this
+ *      build, its journal file isn't on disk and the runner skips it.
+ *
+ * Migration-ownership map (`migration-ownership.ts`) is **transitional**.
+ * It retires when every tag in the shared journal has been moved into the
+ * appropriate pillar's `-db/migrations/`. Each pillar's Phase 1 split
+ * drops the tags it owns from the map; the file is deleted in the final
+ * pillar's deletion PR.
+ *
+ * @see .claude/pillar-migration-roadmap.md (P1)
+ */
+import { join, resolve } from 'node:path';
+
+import { classifyOrApply, prepareApplyCaches, type ApplyBucket } from './migration-apply.js';
+import { readJournalFrom } from './per-module-migrations.js';
+
+import type BetterSqlite3 from 'better-sqlite3';
+
+import type { PillarDescriptor } from './known-pillars.js';
+
+/**
+ * Apply-bucket counters per pillar, plus a top-level `pillars` field that
+ * records which pillars had a journal on disk (vs. which were skipped
+ * because no `<id>-db` package exists yet). The shape matches
+ * `PerModuleMigrationResult` for the buckets that exist at this layer
+ * (no ownership classification, so no `skipped`/`unowned` buckets).
+ */
+export interface PerPillarMigrationResult {
+  /** Tags applied this run, in pillar-then-journal order. */
+  applied: readonly string[];
+  /** Tags whose hash was newly inserted but some statements were no-ops. */
+  backfilled: readonly string[];
+  /** Tags whose hash is already recorded — no action taken. */
+  alreadyApplied: readonly string[];
+  /** Pillar ids whose journal was discovered and walked. */
+  pillarsApplied: readonly string[];
+  /** Pillar ids whose `<id>-db` package isn't on disk yet — skipped. */
+  pillarsSkipped: readonly string[];
+}
+
+interface RunOptions {
+  /**
+   * Override the repo root used to resolve `<pillarDbPackageDir>`. Tests
+   * inject a tmp dir so the runner walks a stub journal instead of the
+   * real workspace tree. Defaults to the actual monorepo root resolved
+   * from this module's location.
+   */
+  repoRoot?: string;
+}
+
+/**
+ * Resolve the monorepo root from this module's location. This file lives
+ * at `apps/pops-api/src/db/per-pillar-migrations.ts` — four directory
+ * levels up is the repo root. Kept here (not in a shared helper) because
+ * it's the only file that needs the repo-relative pillar dir path.
+ */
+function defaultRepoRoot(): string {
+  return resolve(import.meta.dirname, '..', '..', '..', '..');
+}
+
+function pillarMigrationsDir(pillar: PillarDescriptor, repoRoot: string): string {
+  return join(repoRoot, pillar.dbPackageDir, 'migrations');
+}
+
+/**
+ * Apply every known pillar's journal. Returns a typed breakdown so tests
+ * (and ops tooling) can assert the discovery + application happened.
+ *
+ * Idempotent: re-runs against the same database short-circuit on the
+ * `__drizzle_migrations` hash check.
+ */
+export function runPerPillarMigrations(
+  db: BetterSqlite3.Database,
+  pillars: readonly PillarDescriptor[],
+  options: RunOptions = {}
+): PerPillarMigrationResult {
+  const repoRoot = options.repoRoot ?? defaultRepoRoot();
+  const buckets: Record<ApplyBucket, string[]> = {
+    applied: [],
+    backfilled: [],
+    alreadyApplied: [],
+  };
+  const pillarsApplied: string[] = [];
+  const pillarsSkipped: string[] = [];
+
+  // Prepare caches lazily — the common case in P1 is "no pillar has a
+  // journal yet" and we'd rather not touch the tracking tables when the
+  // runner has nothing to do.
+  let caches: ReturnType<typeof prepareApplyCaches> | null = null;
+
+  for (const pillar of pillars) {
+    const dir = pillarMigrationsDir(pillar, repoRoot);
+    const journal = readJournalFrom(dir);
+    if (journal.entries.length === 0) {
+      pillarsSkipped.push(pillar.id);
+      continue;
+    }
+    pillarsApplied.push(pillar.id);
+    caches ??= prepareApplyCaches(db);
+    for (const entry of journal.entries) {
+      const bucket = classifyOrApply(db, entry.tag, caches, dir);
+      buckets[bucket].push(entry.tag);
+    }
+  }
+
+  return {
+    applied: buckets.applied,
+    backfilled: buckets.backfilled,
+    alreadyApplied: buckets.alreadyApplied,
+    pillarsApplied,
+    pillarsSkipped,
+  };
+}

--- a/apps/pops-api/src/db/per-pillar-migrations.ts
+++ b/apps/pops-api/src/db/per-pillar-migrations.ts
@@ -2,12 +2,22 @@
  * Per-pillar migration runner (pillar-migration P1).
  *
  * Walks {@link KNOWN_PILLARS}, looks for each pillar's drizzle journal at
- * `<repoRoot>/<pillarDbPackageDir>/migrations/_journal.json`, and applies
- * any entries not yet in `__drizzle_migrations`. The shared
+ * `<pillarMigrationsDir>/meta/_journal.json`, and applies any entries not
+ * yet in `__drizzle_migrations`. The shared
  * `apps/pops-api/src/db/drizzle-migrations/` journal stays the source of
  * truth for everything that hasn't moved into a pillar `-db` package yet —
  * the per-pillar runner runs *after* the shared runner and only sees the
  * pillars that already own their journal.
+ *
+ * Pillar migration dir discovery (in order):
+ *   1. `resolveInstalledPackage(pillarId)` — by default attempts
+ *      `require.resolve('@pops/<id>-db/package.json')` and joins
+ *      `migrations/` next to it. Works in dev (pnpm workspace symlink) AND
+ *      in production Docker images (the `<id>-db` package ships under
+ *      `node_modules/`). Tests inject a custom resolver.
+ *   2. Workspace fallback: `<repoRoot>/<pillar.dbPackageDir>/migrations`.
+ *      Catches pillars whose `-db` package exists in source but isn't yet
+ *      a runtime dep of `@pops/api`.
  *
  * Boot-time contract (ADR-026 + roadmap P1):
  *   1. `applyDrizzleMigrations` (in `db.ts`) runs the shared journal via
@@ -17,7 +27,7 @@
  *      journal. No ownership filter — a pillar that owns a journal owns
  *      every entry in it. The install-set filter at this level lives one
  *      step up: when a pillar's `<id>-db` package isn't installed in this
- *      build, its journal file isn't on disk and the runner skips it.
+ *      build, no journal is on disk and the runner skips it.
  *
  * Migration-ownership map (`migration-ownership.ts`) is **transitional**.
  * It retires when every tag in the shared journal has been moved into the
@@ -27,7 +37,8 @@
  *
  * @see .claude/pillar-migration-roadmap.md (P1)
  */
-import { join, resolve } from 'node:path';
+import { createRequire } from 'node:module';
+import { dirname, join, resolve } from 'node:path';
 
 import { classifyOrApply, prepareApplyCaches, type ApplyBucket } from './migration-apply.js';
 import { readJournalFrom } from './per-module-migrations.js';
@@ -37,11 +48,11 @@ import type BetterSqlite3 from 'better-sqlite3';
 import type { PillarDescriptor } from './known-pillars.js';
 
 /**
- * Apply-bucket counters per pillar, plus a top-level `pillars` field that
- * records which pillars had a journal on disk (vs. which were skipped
- * because no `<id>-db` package exists yet). The shape matches
- * `PerModuleMigrationResult` for the buckets that exist at this layer
- * (no ownership classification, so no `skipped`/`unowned` buckets).
+ * Result returned by {@link runPerPillarMigrations}. Per-tag buckets match
+ * `PerModuleMigrationResult` for the buckets that exist at this layer (no
+ * ownership classification, so no `skipped`/`unowned`). `pillarsApplied`
+ * and `pillarsSkipped` partition the input pillar list — every pillar
+ * lands in exactly one of them.
  */
 export interface PerPillarMigrationResult {
   /** Tags applied this run, in pillar-then-journal order. */
@@ -50,20 +61,34 @@ export interface PerPillarMigrationResult {
   backfilled: readonly string[];
   /** Tags whose hash is already recorded — no action taken. */
   alreadyApplied: readonly string[];
-  /** Pillar ids whose journal was discovered and walked. */
+  /** Pillar ids whose journal was discovered and had at least one entry. */
   pillarsApplied: readonly string[];
-  /** Pillar ids whose `<id>-db` package isn't on disk yet — skipped. */
+  /**
+   * Pillar ids skipped this run. A pillar is skipped when its `-db`
+   * package isn't installed (or its workspace dir doesn't exist yet) OR
+   * when its journal exists on disk but has zero entries.
+   */
   pillarsSkipped: readonly string[];
 }
 
 interface RunOptions {
   /**
-   * Override the repo root used to resolve `<pillarDbPackageDir>`. Tests
-   * inject a tmp dir so the runner walks a stub journal instead of the
-   * real workspace tree. Defaults to the actual monorepo root resolved
-   * from this module's location.
+   * Override the repo root used to resolve `<pillarDbPackageDir>` for the
+   * workspace fallback path. Tests inject a tmp dir so the runner walks a
+   * stub journal instead of the real workspace tree. Defaults to the
+   * actual monorepo root resolved from this module's location.
    */
   repoRoot?: string;
+  /**
+   * Override the installed-package resolver. The default uses
+   * `createRequire(import.meta.url).resolve('@pops/<id>-db/package.json')`,
+   * which resolves both the workspace symlink in dev and the bundled copy
+   * in a Docker image. Returns the absolute path to the package's root
+   * (the directory containing `package.json`), or null when the package
+   * isn't installed. Tests inject `() => null` to force the workspace
+   * fallback path.
+   */
+  resolveInstalledPackage?: (pillarId: string) => string | null;
 }
 
 /**
@@ -76,7 +101,29 @@ function defaultRepoRoot(): string {
   return resolve(import.meta.dirname, '..', '..', '..', '..');
 }
 
-function pillarMigrationsDir(pillar: PillarDescriptor, repoRoot: string): string {
+/**
+ * Default installed-package resolver. Tries `require.resolve` against the
+ * `@pops/<id>-db/package.json` entry point and returns its directory; on
+ * MODULE_NOT_FOUND (and only on that error class — anything else
+ * bubbles), returns null so the runner falls back to the workspace path.
+ */
+function defaultResolveInstalledPackage(pillarId: string): string | null {
+  const req = createRequire(import.meta.url);
+  try {
+    return dirname(req.resolve(`@pops/${pillarId}-db/package.json`));
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'MODULE_NOT_FOUND') return null;
+    throw err;
+  }
+}
+
+function pillarMigrationsDir(
+  pillar: PillarDescriptor,
+  repoRoot: string,
+  resolveInstalled: (pillarId: string) => string | null
+): string {
+  const installedRoot = resolveInstalled(pillar.id);
+  if (installedRoot !== null) return join(installedRoot, 'migrations');
   return join(repoRoot, pillar.dbPackageDir, 'migrations');
 }
 
@@ -93,6 +140,7 @@ export function runPerPillarMigrations(
   options: RunOptions = {}
 ): PerPillarMigrationResult {
   const repoRoot = options.repoRoot ?? defaultRepoRoot();
+  const resolveInstalled = options.resolveInstalledPackage ?? defaultResolveInstalledPackage;
   const buckets: Record<ApplyBucket, string[]> = {
     applied: [],
     backfilled: [],
@@ -107,7 +155,7 @@ export function runPerPillarMigrations(
   let caches: ReturnType<typeof prepareApplyCaches> | null = null;
 
   for (const pillar of pillars) {
-    const dir = pillarMigrationsDir(pillar, repoRoot);
+    const dir = pillarMigrationsDir(pillar, repoRoot, resolveInstalled);
     const journal = readJournalFrom(dir);
     if (journal.entries.length === 0) {
       pillarsSkipped.push(pillar.id);


### PR DESCRIPTION
## Summary

Pre-flight **P1** of the pillar migration ([ADR-026](../tree/main/docs/architecture)). Lays the per-pillar drizzle-kit + migration-runner infrastructure each pillar's Phase 1 split will plug into, **without moving any schemas or journals yet** — operator workflow (`mise drizzle:generate` / `:migrate`) behaves identically.

- New `drizzle-config-builder.ts` → each pillar's eventual `packages/<id>-db/drizzle.config.ts` calls it with its own schema glob + out dir; the legacy shared config calls it with the historical paths so no change for current users.
- New `known-pillars.ts` lists the canonical pillar set (`core`, `finance`, `media`, `inventory`, `cerebrum`, `ai`, `food`, `lists`).
- New `per-pillar-migrations.ts` runner walks `packages/<id>-db/migrations/` per pillar and applies any entries not yet in `__drizzle_migrations`. Today every pillar lands in `pillarsSkipped` (no `-db` packages exist yet) — Phase 1 of each pillar flips its own row to `pillarsApplied`.
- `migration-apply.ts` factored to accept a migrations dir so the shared and per-pillar runners share the SQL-apply path; new `prepareApplyCaches()` removes the duplicated `__drizzle_migrations` / `__pops_migration_tags` setup.
- `migration-ownership.ts` marked **transitional** in its header — it retires incrementally as each pillar's Phase 1 moves its tags into the pillar's own journal, and is deleted in the final deletion PR once the shared journal is empty.

## Why this shape

P1's roadmap bullet says "becomes a generator that emits one config per pillar" + "migration runner picks up each pillar's journal independently" + "migration-ownership map retires". Per-pillar `-db` packages don't exist yet, so the natural read is: deliver the *machinery* now, and let each pillar's Phase 1 author its own `drizzle.config.ts` against the builder when its `-db` package is created. The runner discovers per-pillar journals at boot and is a no-op until they exist. Migration-ownership retirement happens incrementally (per-pillar Phase 1 drops its tags from the map) rather than as a flag-day PR — which would break every in-flight food PRD currently appending to the shared journal.

## Test plan

- [x] `pnpm typecheck` — workspace-wide green (25 packages)
- [x] `pnpm build` — workspace-wide green
- [x] `pnpm --filter @pops/api test` — 4495/4495 green
- [x] `pnpm --filter @pops/module-registry test` — 57/57 green (contract guard unaffected)
- [x] `pnpm lint` — exit 0 (no new findings on touched files)
- [x] 14 new unit tests across `drizzle-config-builder.test.ts` (8) + `per-pillar-migrations.test.ts` (6) covering no-op-when-empty, single-pillar end-to-end, idempotency, multi-pillar ordering, empty-journal skip, default-repoRoot fallback, and the SQLITE_PATH env precedence
- [x] Existing `per-module-migrations.test.ts` still passes after the apply-path refactor

Unrelated pre-existing test failures on `main` (FoodDataLayout Suspense flake, OverlayHost lazy-mount flake, file-watcher timing test) reproduce on `main` without this branch and are not touched here.
