### PR TITLE
feat(platform): pre-flight P3 — pops-shell pillar boot (ADR-026)

### DIFF
--- a/apps/pops-api/src/middleware/rate-limit.ts
+++ b/apps/pops-api/src/middleware/rate-limit.ts
@@ -9,6 +9,12 @@ import rateLimit from 'express-rate-limit';
  * Media image routes are excluded — the library grid loads 24-96 poster
  * images per page which easily exhausts 100 req/15min. These are read-only
  * cached files behind Cloudflare Access, so rate-limiting them is unnecessary.
+ *
+ * Pillar boot endpoints (`/pillars`, `/pillars/health`) are excluded —
+ * the shell calls them once per page load and the aggregated probe fans
+ * out across every registered pillar; either signal counted against this
+ * window starves the boot path during E2E suites and on visits from
+ * machines proxied behind a single egress IP.
  */
 export const rateLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
@@ -16,5 +22,9 @@ export const rateLimiter = rateLimit({
   standardHeaders: 'draft-7',
   legacyHeaders: false,
   message: { error: 'Too many requests, try again later' },
-  skip: (req) => req.path.startsWith('/trpc') || req.path.startsWith('/media/images'),
+  skip: (req) =>
+    req.path.startsWith('/trpc') ||
+    req.path.startsWith('/media/images') ||
+    req.path === '/pillars' ||
+    req.path.startsWith('/pillars/'),
 });

--- a/apps/pops-api/src/modules/core/pillars/health-probe.test.ts
+++ b/apps/pops-api/src/modules/core/pillars/health-probe.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Tests for the cross-pillar health probe (ADR-026 P3).
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+import { probeAllPillars, probePillarHealth } from './health-probe.js';
+
+import type { PillarRegistryEntry } from '@pops/types';
+
+const FOOD: PillarRegistryEntry = { id: 'food', baseUrl: 'http://food-api:3000' };
+const FINANCE: PillarRegistryEntry = { id: 'finance', baseUrl: 'http://finance-api:3000' };
+const CORE_REMOTE: PillarRegistryEntry = { id: 'core', baseUrl: 'http://core-api:3000' };
+
+function jsonResponse(body: unknown, init: { status?: number } = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: init.status ?? 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('probePillarHealth', () => {
+  it('reports healthy on a well-shaped 200 response with matching pillar id', async () => {
+    const fetchStub = vi.fn(async () =>
+      jsonResponse({ ok: true, pillar: 'food', version: '1.0.0' })
+    );
+    const status = await probePillarHealth(FOOD, { fetch: fetchStub });
+    expect(status).toBe('healthy');
+    expect(fetchStub).toHaveBeenCalledWith(
+      'http://food-api:3000/health',
+      expect.objectContaining({ method: 'GET' })
+    );
+  });
+
+  it('reports unavailable when the response status is non-2xx', async () => {
+    const fetchStub = vi.fn(async () => new Response('down', { status: 503 }));
+    expect(await probePillarHealth(FOOD, { fetch: fetchStub })).toBe('unavailable');
+  });
+
+  it('reports unavailable when the body is not the PillarHealth shape', async () => {
+    const fetchStub = vi.fn(async () => jsonResponse({ status: 'ok' }));
+    expect(await probePillarHealth(FOOD, { fetch: fetchStub })).toBe('unavailable');
+  });
+
+  it('reports unavailable when the body pillar id mismatches the registry entry', async () => {
+    // Misconfigured POPS_PILLARS: entry says 'food' but the upstream is 'finance'.
+    const fetchStub = vi.fn(async () =>
+      jsonResponse({ ok: true, pillar: 'finance', version: '1.0.0' })
+    );
+    expect(await probePillarHealth(FOOD, { fetch: fetchStub })).toBe('unavailable');
+  });
+
+  it('reports unavailable when fetch throws (network failure)', async () => {
+    const fetchStub = vi.fn(async () => {
+      throw new TypeError('fetch failed');
+    });
+    expect(await probePillarHealth(FOOD, { fetch: fetchStub })).toBe('unavailable');
+  });
+
+  it('aborts and reports unavailable when the probe exceeds timeoutMs', async () => {
+    const fetchStub = vi.fn(async (_url, init?: RequestInit) => {
+      // Wait until the abort signal fires; the helper aborts with reason='timeout'.
+      await new Promise<void>((resolve, reject) => {
+        init?.signal?.addEventListener('abort', () =>
+          reject(new DOMException('aborted', 'AbortError'))
+        );
+      });
+      throw new Error('unreachable');
+    });
+    const status = await probePillarHealth(FOOD, { fetch: fetchStub, timeoutMs: 5 });
+    expect(status).toBe('unavailable');
+  });
+});
+
+describe('probeAllPillars', () => {
+  it('returns an empty map for an empty registry', async () => {
+    expect(await probeAllPillars([])).toEqual({});
+  });
+
+  it('short-circuits the self-pillar to healthy without HTTP', async () => {
+    const fetchStub = vi.fn();
+    const map = await probeAllPillars([{ id: 'core', baseUrl: '' }], { fetch: fetchStub });
+    expect(map).toEqual({ core: 'healthy' });
+    expect(fetchStub).not.toHaveBeenCalled();
+  });
+
+  it('short-circuits the self-pillar even if a baseUrl is configured', async () => {
+    // A misconfigured registry that lists `core` with a remote baseUrl must
+    // still bypass HTTP — otherwise core probing itself can deadlock the boot.
+    const fetchStub = vi.fn();
+    const map = await probeAllPillars([CORE_REMOTE], { fetch: fetchStub });
+    expect(map).toEqual({ core: 'healthy' });
+    expect(fetchStub).not.toHaveBeenCalled();
+  });
+
+  it('fans out one probe per remote pillar concurrently', async () => {
+    const calls: string[] = [];
+    const fetchStub = vi.fn(async (url) => {
+      calls.push(String(url));
+      return jsonResponse({
+        ok: true,
+        pillar: String(url).includes('food') ? 'food' : 'finance',
+        version: 'dev',
+      });
+    });
+    const map = await probeAllPillars([FOOD, FINANCE], { fetch: fetchStub });
+    expect(map).toEqual({ food: 'healthy', finance: 'healthy' });
+    expect(calls).toHaveLength(2);
+  });
+
+  it('reports unavailable for the failing pillar and healthy for the others', async () => {
+    const fetchStub = vi.fn(async (url) => {
+      if (String(url).includes('food')) throw new TypeError('boom');
+      return jsonResponse({ ok: true, pillar: 'finance', version: 'dev' });
+    });
+    const map = await probeAllPillars([FOOD, FINANCE], { fetch: fetchStub });
+    expect(map).toEqual({ food: 'unavailable', finance: 'healthy' });
+  });
+
+  it('honours a custom selfPillarId', async () => {
+    const fetchStub = vi.fn();
+    const map = await probeAllPillars([{ id: 'finance', baseUrl: '' }], {
+      fetch: fetchStub,
+      selfPillarId: 'finance',
+    });
+    expect(map).toEqual({ finance: 'healthy' });
+    expect(fetchStub).not.toHaveBeenCalled();
+  });
+});

--- a/apps/pops-api/src/modules/core/pillars/health-probe.ts
+++ b/apps/pops-api/src/modules/core/pillars/health-probe.ts
@@ -1,0 +1,106 @@
+/**
+ * Cross-pillar health probe (ADR-026 pre-flight P3).
+ *
+ * Fans out concurrent `GET {baseUrl}/health` requests against the live
+ * `POPS_PILLARS` registry and reports each pillar as `'healthy'` or
+ * `'unavailable'`. The aggregator runs inside `core-api` because:
+ *
+ *   1. Pillar base URLs are container-network addresses (e.g.
+ *      `http://food-api:3000`) and are not reachable from the browser. The
+ *      shell calls a single `GET /pillars/health` and gets the aggregated
+ *      result instead of probing each pillar directly.
+ *   2. Core already proxies `POST /uri/resolve`; folding the health probe
+ *      into the same surface keeps inter-pillar HTTP on one path prefix.
+ *
+ * The probe is intentionally cheap: small timeout, no retries, no body
+ * inspection beyond the `PillarHealth` shape validation. Aggregating
+ * pillar status is a UX hint for the shell; long retry budgets belong in
+ * the consuming code (the shell offers a manual retry button).
+ */
+
+import type { PillarRegistryEntry } from '@pops/types';
+
+/** Health view of a single pillar from the aggregator's perspective. */
+export type PillarHealthStatus = 'healthy' | 'unavailable';
+
+/** Aggregated probe result keyed by pillar id. */
+export type PillarHealthMap = Record<string, PillarHealthStatus>;
+
+export interface ProbePillarHealthOptions {
+  /** Self-pillar id; the probe assumes `'healthy'` for this id without HTTP. */
+  readonly selfPillarId?: string;
+  /** Per-probe timeout in milliseconds. Defaults to 2000. */
+  readonly timeoutMs?: number;
+  /** Override the global `fetch` (tests inject a stub). */
+  readonly fetch?: typeof fetch;
+}
+
+const DEFAULT_TIMEOUT_MS = 2000;
+const DEFAULT_SELF_PILLAR_ID = 'core';
+
+/**
+ * Probe a single pillar's `/health` endpoint. Any non-200, parse error,
+ * timeout, network failure, or shape mismatch maps to `'unavailable'`.
+ *
+ * The pillar field of the response is checked against the registry id —
+ * a misconfigured `POPS_PILLARS` pointing at the wrong service is treated
+ * as unavailable rather than silently misreporting the upstream's health.
+ */
+export async function probePillarHealth(
+  entry: PillarRegistryEntry,
+  options: ProbePillarHealthOptions = {}
+): Promise<PillarHealthStatus> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const fetchImpl = options.fetch ?? fetch;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort('timeout'), timeoutMs);
+  try {
+    const response = await fetchImpl(`${entry.baseUrl}/health`, {
+      method: 'GET',
+      signal: controller.signal,
+    });
+    if (!response.ok) return 'unavailable';
+    const body: unknown = await response.json();
+    if (!isPillarHealthShape(body)) return 'unavailable';
+    if (body.pillar !== entry.id) return 'unavailable';
+    return 'healthy';
+  } catch {
+    return 'unavailable';
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Concurrently probe every entry in the registry. The self-pillar entry
+ * (matched on `id`, regardless of `baseUrl`) is reported `'healthy'`
+ * without HTTP — the aggregator is part of that pillar's process, so if
+ * it is serving requests it is definitionally up.
+ *
+ * Returns a partial map: an empty registry yields `{}`. The ordering of
+ * the resulting object is registry order; consumers should not depend on
+ * iteration order.
+ */
+export async function probeAllPillars(
+  entries: readonly PillarRegistryEntry[],
+  options: ProbePillarHealthOptions = {}
+): Promise<PillarHealthMap> {
+  const selfPillarId = options.selfPillarId ?? DEFAULT_SELF_PILLAR_ID;
+  const probes = entries.map(async (entry) => {
+    if (entry.id === selfPillarId) return [entry.id, 'healthy'] as const;
+    const status = await probePillarHealth(entry, options);
+    return [entry.id, status] as const;
+  });
+  const results = await Promise.all(probes);
+  const out: PillarHealthMap = {};
+  for (const [id, status] of results) out[id] = status;
+  return out;
+}
+
+function isPillarHealthShape(
+  body: unknown
+): body is { readonly ok: true; readonly pillar: string; readonly version: string } {
+  if (typeof body !== 'object' || body === null) return false;
+  const obj = body as Record<string, unknown>;
+  return obj.ok === true && typeof obj.pillar === 'string' && typeof obj.version === 'string';
+}

--- a/apps/pops-api/src/routes/pillars.ts
+++ b/apps/pops-api/src/routes/pillars.ts
@@ -25,6 +25,7 @@
 import { type Router as ExpressRouter, Router } from 'express';
 
 import { dispatchUri, type DispatchUriOptions } from '../modules/core/pillars/dispatcher.js';
+import { probeAllPillars } from '../modules/core/pillars/health-probe.js';
 import { getPillarRegistry } from '../modules/core/pillars/registry.js';
 import { getUriRegistry } from '../modules/core/uri/registry.js';
 import { readInstalledModules } from '../modules/env-modules.js';
@@ -66,16 +67,35 @@ router.post('/uri/resolve', async (req, res) => {
 });
 
 router.get('/pillars', (_req, res) => {
+  res.json({ pillars: listPillarsWithSelf() });
+});
+
+/**
+ * Aggregated cross-pillar health probe (ADR-026 P3).
+ *
+ * Fans out `GET {baseUrl}/health` against every remote pillar in the registry
+ * and returns a map of pillar id to health. The self-pillar is short-circuited
+ * to `'healthy'` — if this handler is serving requests, core is up.
+ *
+ * The shell calls this once at boot and uses the result to gate per-pillar
+ * routes via a `PillarUnavailable` placeholder. Container-network base URLs
+ * are not reachable from the browser, which is why the probe runs server-side.
+ */
+router.get('/pillars/health', async (_req, res) => {
+  const pillars = listPillarsWithSelf();
+  const health = await probeAllPillars(pillars);
+  res.json({ health });
+});
+
+function listPillarsWithSelf(): readonly PillarRegistryEntry[] {
   // The /pillars view always includes a synthetic `core` self-entry so a
   // consumer can iterate the registry without special-casing the dispatcher
   // host. The `baseUrl` of the self-entry is intentionally empty: pillars
   // talking to themselves use the in-process resolver, not HTTP.
   const remote = getPillarRegistry();
+  if (remote.some((p) => p.id === 'core')) return remote;
   const self: PillarRegistryEntry = { id: 'core', baseUrl: '' };
-  const pillars: readonly PillarRegistryEntry[] = remote.some((p) => p.id === 'core')
-    ? remote
-    : [self, ...remote];
-  res.json({ pillars });
-});
+  return [self, ...remote];
+}
 
 export default router;

--- a/apps/pops-api/src/routes/pillars.ts
+++ b/apps/pops-api/src/routes/pillars.ts
@@ -88,13 +88,17 @@ router.get('/pillars/health', async (_req, res) => {
 });
 
 function listPillarsWithSelf(): readonly PillarRegistryEntry[] {
-  // The /pillars view always includes a synthetic `core` self-entry so a
-  // consumer can iterate the registry without special-casing the dispatcher
-  // host. The `baseUrl` of the self-entry is intentionally empty: pillars
-  // talking to themselves use the in-process resolver, not HTTP.
+  // The /pillars view always includes a `core` self-entry so a consumer can
+  // iterate the registry without special-casing the dispatcher host. The
+  // `baseUrl` of the self-entry is always empty — pillars talking to
+  // themselves use the in-process resolver, not HTTP — and a deployer's
+  // misconfigured `core:http://...` entry is normalised the same way so the
+  // contract holds regardless of how `POPS_PILLARS` is set.
   const remote = getPillarRegistry();
-  if (remote.some((p) => p.id === 'core')) return remote;
   const self: PillarRegistryEntry = { id: 'core', baseUrl: '' };
+  if (remote.some((p) => p.id === 'core')) {
+    return remote.map((p) => (p.id === 'core' ? self : p));
+  }
   return [self, ...remote];
 }
 

--- a/apps/pops-shell/src/app/App.tsx
+++ b/apps/pops-shell/src/app/App.tsx
@@ -12,6 +12,7 @@ import { toast } from 'sonner';
 import { isNetworkError } from '@pops/api-client';
 import { Toaster, TooltipProvider } from '@pops/ui';
 
+import { PillarStatusProvider } from './pillars';
 import { router } from './router';
 
 const NETWORK_ERROR_TOAST_ID = 'network-down';
@@ -52,9 +53,11 @@ export function App() {
   return (
     <trpc.Provider client={trpcClient} queryClient={queryClient}>
       <QueryClientProvider client={queryClient}>
-        <TooltipProvider>
-          <RouterProvider router={router} />
-        </TooltipProvider>
+        <PillarStatusProvider>
+          <TooltipProvider>
+            <RouterProvider router={router} />
+          </TooltipProvider>
+        </PillarStatusProvider>
         {!import.meta.env.VITE_E2E && <ReactQueryDevtools initialIsOpen={false} />}
         <Toaster />
       </QueryClientProvider>

--- a/apps/pops-shell/src/app/pillars/PillarGuard.test.tsx
+++ b/apps/pops-shell/src/app/pillars/PillarGuard.test.tsx
@@ -1,0 +1,45 @@
+/**
+ * Tests for the per-route pillar guard (ADR-026 P3).
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+import { PillarGuard } from './PillarGuard';
+import { PillarStatusProvider } from './PillarStatusProvider';
+
+import type { PillarBootSnapshot } from './types';
+
+function renderWithSnapshot(pillarId: string, snapshot: PillarBootSnapshot) {
+  return render(
+    <PillarStatusProvider snapshot={snapshot}>
+      <PillarGuard pillarId={pillarId}>
+        <div data-testid="children">module content</div>
+      </PillarGuard>
+    </PillarStatusProvider>
+  );
+}
+
+describe('PillarGuard', () => {
+  it('renders the children when the owning pillar is healthy', () => {
+    renderWithSnapshot('food', { entries: [], health: { food: 'healthy' } });
+    expect(screen.getByTestId('children')).toBeInTheDocument();
+    expect(screen.queryByText('pillarUnavailableTitle')).not.toBeInTheDocument();
+  });
+
+  it('renders the placeholder when the owning pillar is unavailable', () => {
+    renderWithSnapshot('food', { entries: [], health: { food: 'unavailable' } });
+    expect(screen.queryByTestId('children')).not.toBeInTheDocument();
+    expect(screen.getByText('pillarUnavailableTitle')).toBeInTheDocument();
+  });
+
+  it('renders the children for an unknown pillar (boot fetch pending or failed)', () => {
+    // The shell prefers an optimistic render over flashing placeholders during
+    // a slow / failed boot. `'unknown'` falls through to the route subtree.
+    renderWithSnapshot('food', { entries: [], health: {} });
+    expect(screen.getByTestId('children')).toBeInTheDocument();
+  });
+});

--- a/apps/pops-shell/src/app/pillars/PillarGuard.tsx
+++ b/apps/pops-shell/src/app/pillars/PillarGuard.tsx
@@ -1,0 +1,24 @@
+/**
+ * Conditional renderer that short-circuits a per-module route subtree to
+ * `PillarUnavailableRoute` when the owning pillar's health is
+ * `'unavailable'` (ADR-026 P3).
+ *
+ * `'unknown'` (still booting / boot failed) and `'healthy'` both render
+ * the children. The shell explicitly does not paint placeholders during
+ * the boot fetch so transient probe failures stay invisible to users on
+ * working pillars.
+ */
+import { PillarUnavailableRoute } from './PillarUnavailableRoute';
+import { usePillarStatus } from './usePillarStatus';
+
+interface PillarGuardProps {
+  /** Pillar id this route belongs to (mapped via `pillarIdForModule`). */
+  readonly pillarId: string;
+  readonly children: React.ReactNode;
+}
+
+export function PillarGuard({ pillarId, children }: PillarGuardProps): React.ReactElement {
+  const status = usePillarStatus(pillarId);
+  if (status === 'unavailable') return <PillarUnavailableRoute pillarId={pillarId} />;
+  return <>{children}</>;
+}

--- a/apps/pops-shell/src/app/pillars/PillarStatusProvider.test.tsx
+++ b/apps/pops-shell/src/app/pillars/PillarStatusProvider.test.tsx
@@ -1,0 +1,186 @@
+/**
+ * Tests for the shell-side PillarStatusProvider (ADR-026 P3).
+ */
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { useState } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { PillarStatusProvider } from './PillarStatusProvider';
+import { usePillarStatus, usePillarStatusContext } from './usePillarStatus';
+
+// The provider's effect calls fetch via the registry-client module.
+vi.mock('./pillar-registry-client', () => ({
+  fetchPillarRegistry: vi.fn(),
+  fetchPillarHealth: vi.fn(),
+}));
+
+import { fetchPillarHealth, fetchPillarRegistry } from './pillar-registry-client';
+
+beforeEach(() => {
+  vi.mocked(fetchPillarRegistry).mockReset();
+  vi.mocked(fetchPillarHealth).mockReset();
+});
+
+function StatusProbe({ pillarId }: { pillarId: string }): React.ReactElement {
+  const status = usePillarStatus(pillarId);
+  const { loading } = usePillarStatusContext();
+  return (
+    <div>
+      <span data-testid="status">{status}</span>
+      <span data-testid="loading">{loading ? 'loading' : 'idle'}</span>
+    </div>
+  );
+}
+
+describe('PillarStatusProvider', () => {
+  it('renders the test-only snapshot synchronously and skips the boot fetch', () => {
+    render(
+      <PillarStatusProvider
+        snapshot={{
+          entries: [{ id: 'core', baseUrl: '' }],
+          health: { core: 'healthy', food: 'unavailable' },
+        }}
+      >
+        <StatusProbe pillarId="food" />
+      </PillarStatusProvider>
+    );
+    expect(screen.getByTestId('status').textContent).toBe('unavailable');
+    expect(screen.getByTestId('loading').textContent).toBe('idle');
+    expect(fetchPillarRegistry).not.toHaveBeenCalled();
+    expect(fetchPillarHealth).not.toHaveBeenCalled();
+  });
+
+  it('starts in the loading state with no known pillar status until the boot fetch resolves', async () => {
+    let resolveRegistry: (value: readonly { id: string; baseUrl: string }[]) => void = () => {};
+    let resolveHealth: (value: Record<string, 'healthy' | 'unavailable'>) => void = () => {};
+    vi.mocked(fetchPillarRegistry).mockImplementation(
+      () => new Promise((resolve) => (resolveRegistry = resolve))
+    );
+    vi.mocked(fetchPillarHealth).mockImplementation(
+      () => new Promise((resolve) => (resolveHealth = resolve))
+    );
+
+    render(
+      <PillarStatusProvider>
+        <StatusProbe pillarId="food" />
+      </PillarStatusProvider>
+    );
+    // Initially loading and no health entries — every pillar is 'unknown'.
+    expect(screen.getByTestId('status').textContent).toBe('unknown');
+    expect(screen.getByTestId('loading').textContent).toBe('loading');
+
+    await act(async () => {
+      resolveRegistry([
+        { id: 'core', baseUrl: '' },
+        { id: 'food', baseUrl: 'http://food-api:3000' },
+      ]);
+      resolveHealth({ core: 'healthy', food: 'unavailable' });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('status').textContent).toBe('unavailable');
+      expect(screen.getByTestId('loading').textContent).toBe('idle');
+    });
+  });
+
+  it('reports "unknown" for a pillar id missing from the health map after boot', async () => {
+    vi.mocked(fetchPillarRegistry).mockResolvedValue([{ id: 'core', baseUrl: '' }]);
+    vi.mocked(fetchPillarHealth).mockResolvedValue({ core: 'healthy' });
+    render(
+      <PillarStatusProvider>
+        <StatusProbe pillarId="food" />
+      </PillarStatusProvider>
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('loading').textContent).toBe('idle');
+    });
+    expect(screen.getByTestId('status').textContent).toBe('unknown');
+  });
+
+  it('re-fetches when refresh() is called', async () => {
+    vi.mocked(fetchPillarRegistry).mockResolvedValue([{ id: 'core', baseUrl: '' }]);
+    vi.mocked(fetchPillarHealth)
+      .mockResolvedValueOnce({ food: 'unavailable' })
+      .mockResolvedValueOnce({ food: 'healthy' });
+
+    function Trigger(): React.ReactElement {
+      const { refresh } = usePillarStatusContext();
+      return (
+        <button type="button" onClick={() => void refresh()}>
+          refresh
+        </button>
+      );
+    }
+
+    render(
+      <PillarStatusProvider>
+        <StatusProbe pillarId="food" />
+        <Trigger />
+      </PillarStatusProvider>
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('status').textContent).toBe('unavailable');
+    });
+
+    await act(async () => {
+      screen.getByRole('button', { name: 'refresh' }).click();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('status').textContent).toBe('healthy');
+    });
+    expect(fetchPillarHealth).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('usePillarStatusContext', () => {
+  it('throws when used outside a PillarStatusProvider', () => {
+    function Naked(): React.ReactElement {
+      usePillarStatusContext();
+      return <span />;
+    }
+    // React 18 logs to console.error on render-throw; suppress to keep test output clean.
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      expect(() => render(<Naked />)).toThrow(/inside <PillarStatusProvider>/);
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+});
+
+// Sanity check: setState inside `useState` is wired so re-mounts keep working
+// across tests (this guards against accidental module-level state).
+describe('PillarStatusProvider isolation', () => {
+  it('re-runs the boot fetch on a fresh mount with default props', async () => {
+    vi.mocked(fetchPillarRegistry).mockResolvedValue([{ id: 'core', baseUrl: '' }]);
+    vi.mocked(fetchPillarHealth).mockResolvedValue({ core: 'healthy' });
+
+    function Wrapper(): React.ReactElement {
+      const [n, setN] = useState(0);
+      return (
+        <div>
+          <button type="button" onClick={() => setN((x) => x + 1)}>
+            remount-{n}
+          </button>
+          <PillarStatusProvider key={n}>
+            <StatusProbe pillarId="core" />
+          </PillarStatusProvider>
+        </div>
+      );
+    }
+
+    render(<Wrapper />);
+    await waitFor(() => {
+      expect(screen.getByTestId('status').textContent).toBe('healthy');
+    });
+    expect(fetchPillarRegistry).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      screen.getByRole('button', { name: /remount-/ }).click();
+    });
+    await waitFor(() => {
+      expect(fetchPillarRegistry).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/apps/pops-shell/src/app/pillars/PillarStatusProvider.tsx
+++ b/apps/pops-shell/src/app/pillars/PillarStatusProvider.tsx
@@ -1,0 +1,76 @@
+/**
+ * React context + provider for the shell-side pillar boot snapshot
+ * (ADR-026 P3).
+ *
+ * The provider fetches the pillar registry and aggregated health map at
+ * mount and exposes them via context. Routes consult the snapshot via
+ * `usePillarStatus(pillarId)` (see ./usePillarStatus.ts) and render
+ * `PillarUnavailableRoute` when the owning pillar is marked
+ * `'unavailable'`.
+ *
+ * While the boot fetch is in flight, every pillar is reported as
+ * `'unknown'` and treated by `PillarGuard` as healthy — slow boots must
+ * not flash placeholders over working routes.
+ */
+import { createContext, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { fetchPillarHealth, fetchPillarRegistry } from './pillar-registry-client';
+
+import type { PillarBootSnapshot, PillarStatusContextValue } from './types';
+
+const EMPTY_SNAPSHOT: PillarBootSnapshot = { entries: [], health: {} };
+
+const PillarStatusContext = createContext<PillarStatusContextValue | null>(null);
+
+export { PillarStatusContext };
+
+interface PillarStatusProviderProps {
+  readonly children: React.ReactNode;
+  /**
+   * Test-only override that skips the boot fetch and seeds the snapshot
+   * directly. Production callers must not pass this.
+   */
+  readonly snapshot?: PillarBootSnapshot;
+}
+
+/**
+ * Top-level provider mounted in `App.tsx`. Owns a single boot fetch and
+ * exposes the resulting snapshot to every consumer.
+ *
+ * When a test passes `snapshot`, the provider skips the network call and
+ * renders the supplied state synchronously. The override is intended for
+ * RTL tests of consuming components.
+ */
+export function PillarStatusProvider({
+  children,
+  snapshot,
+}: PillarStatusProviderProps): React.ReactElement {
+  const [state, setState] = useState<PillarBootSnapshot>(snapshot ?? EMPTY_SNAPSHOT);
+  const [loading, setLoading] = useState(snapshot === undefined);
+  // Track the latest fetch so a stale refresh doesn't overwrite a newer one.
+  const fetchTokenRef = useRef(0);
+
+  const refresh = useCallback(async () => {
+    const token = ++fetchTokenRef.current;
+    setLoading(true);
+    try {
+      const [entries, health] = await Promise.all([fetchPillarRegistry(), fetchPillarHealth()]);
+      if (fetchTokenRef.current !== token) return;
+      setState({ entries, health });
+    } finally {
+      if (fetchTokenRef.current === token) setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (snapshot !== undefined) return;
+    void refresh();
+  }, [refresh, snapshot]);
+
+  const value = useMemo<PillarStatusContextValue>(
+    () => ({ snapshot: state, loading, refresh }),
+    [state, loading, refresh]
+  );
+
+  return <PillarStatusContext.Provider value={value}>{children}</PillarStatusContext.Provider>;
+}

--- a/apps/pops-shell/src/app/pillars/PillarUnavailableRoute.test.tsx
+++ b/apps/pops-shell/src/app/pillars/PillarUnavailableRoute.test.tsx
@@ -1,8 +1,8 @@
 /**
  * Tests for the pillar-unavailable placeholder (ADR-026 P3).
  */
-import { act, fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -13,6 +13,15 @@ vi.mock('react-i18next', () => ({
   }),
 }));
 
+// Same boot-fetch mock pattern as PillarStatusProvider.test.tsx — the
+// retry button calls the context's `refresh()`, which re-invokes the
+// registry-client. We assert on the call count.
+vi.mock('./pillar-registry-client', () => ({
+  fetchPillarRegistry: vi.fn(),
+  fetchPillarHealth: vi.fn(),
+}));
+
+import { fetchPillarHealth, fetchPillarRegistry } from './pillar-registry-client';
 import { PillarStatusProvider } from './PillarStatusProvider';
 import { PillarUnavailableRoute } from './PillarUnavailableRoute';
 
@@ -22,6 +31,11 @@ const UNAVAILABLE_SNAPSHOT: PillarBootSnapshot = {
   entries: [],
   health: { food: 'unavailable' },
 };
+
+beforeEach(() => {
+  vi.mocked(fetchPillarRegistry).mockReset();
+  vi.mocked(fetchPillarHealth).mockReset();
+});
 
 describe('PillarUnavailableRoute', () => {
   it('renders the title and a description that mentions the pillar id', () => {
@@ -34,26 +48,32 @@ describe('PillarUnavailableRoute', () => {
     expect(screen.getByText('pillarUnavailableDescription:food')).toBeInTheDocument();
   });
 
-  it('renders a retry button that triggers refresh on the context', () => {
-    const refresh = vi.fn(async () => undefined);
+  it('renders a retry button that triggers refresh on the context', async () => {
+    vi.mocked(fetchPillarRegistry).mockResolvedValue([{ id: 'core', baseUrl: '' }]);
+    vi.mocked(fetchPillarHealth).mockResolvedValue({ food: 'unavailable' });
+
+    // No `snapshot` prop → provider runs the real boot fetch, exercising the
+    // refresh path. After mount the registry + health endpoints are called
+    // exactly once each; clicking Retry must re-invoke both.
     render(
-      <PillarStatusProvider
-        snapshot={UNAVAILABLE_SNAPSHOT}
-        // Smuggle a custom refresh in by wrapping with our own provider
-        // exposure. Since PillarStatusProvider's snapshot path uses its own
-        // refresh, this test instead asserts on rendered button availability.
-      >
+      <PillarStatusProvider>
         <PillarUnavailableRoute pillarId="food" />
       </PillarStatusProvider>
     );
-    // The button uses the i18n key as label because the test mock returns the
-    // key verbatim.
+
+    await waitFor(() => {
+      expect(fetchPillarRegistry).toHaveBeenCalledTimes(1);
+      expect(fetchPillarHealth).toHaveBeenCalledTimes(1);
+    });
+
     const button = screen.getByRole('button', { name: 'pillarUnavailableRetry' });
-    expect(button).toBeEnabled();
-    // Clicking it does not throw — refresh logic exercised in the provider tests.
-    expect(refresh).not.toHaveBeenCalled();
-    act(() => {
+    await act(async () => {
       fireEvent.click(button);
+    });
+
+    await waitFor(() => {
+      expect(fetchPillarRegistry).toHaveBeenCalledTimes(2);
+      expect(fetchPillarHealth).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/apps/pops-shell/src/app/pillars/PillarUnavailableRoute.test.tsx
+++ b/apps/pops-shell/src/app/pillars/PillarUnavailableRoute.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * Tests for the pillar-unavailable placeholder (ADR-026 P3).
+ */
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, string>) => {
+      if (options?.pillar !== undefined) return `${key}:${options.pillar}`;
+      return key;
+    },
+  }),
+}));
+
+import { PillarStatusProvider } from './PillarStatusProvider';
+import { PillarUnavailableRoute } from './PillarUnavailableRoute';
+
+import type { PillarBootSnapshot } from './types';
+
+const UNAVAILABLE_SNAPSHOT: PillarBootSnapshot = {
+  entries: [],
+  health: { food: 'unavailable' },
+};
+
+describe('PillarUnavailableRoute', () => {
+  it('renders the title and a description that mentions the pillar id', () => {
+    render(
+      <PillarStatusProvider snapshot={UNAVAILABLE_SNAPSHOT}>
+        <PillarUnavailableRoute pillarId="food" />
+      </PillarStatusProvider>
+    );
+    expect(screen.getByText('pillarUnavailableTitle')).toBeInTheDocument();
+    expect(screen.getByText('pillarUnavailableDescription:food')).toBeInTheDocument();
+  });
+
+  it('renders a retry button that triggers refresh on the context', () => {
+    const refresh = vi.fn(async () => undefined);
+    render(
+      <PillarStatusProvider
+        snapshot={UNAVAILABLE_SNAPSHOT}
+        // Smuggle a custom refresh in by wrapping with our own provider
+        // exposure. Since PillarStatusProvider's snapshot path uses its own
+        // refresh, this test instead asserts on rendered button availability.
+      >
+        <PillarUnavailableRoute pillarId="food" />
+      </PillarStatusProvider>
+    );
+    // The button uses the i18n key as label because the test mock returns the
+    // key verbatim.
+    const button = screen.getByRole('button', { name: 'pillarUnavailableRetry' });
+    expect(button).toBeEnabled();
+    // Clicking it does not throw — refresh logic exercised in the provider tests.
+    expect(refresh).not.toHaveBeenCalled();
+    act(() => {
+      fireEvent.click(button);
+    });
+  });
+});

--- a/apps/pops-shell/src/app/pillars/PillarUnavailableRoute.tsx
+++ b/apps/pops-shell/src/app/pillars/PillarUnavailableRoute.tsx
@@ -1,0 +1,49 @@
+/**
+ * Placeholder rendered when a route's owning pillar is unavailable
+ * (ADR-026 P3).
+ *
+ * Distinct from `NotInstalledPage` (module excluded from this build) and
+ * `NotFoundPage` (unknown URL). This page fires when the module IS
+ * installed but its backend pillar is unreachable — typically because
+ * the pillar's container is restarting or its health check is failing.
+ *
+ * The retry button calls `refresh()` on the boot context, which re-runs
+ * `GET /pillars/health` against core-api. No global page reload — the
+ * shell and the working pillars stay mounted.
+ */
+import { CloudOff } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@pops/ui';
+
+import { usePillarStatusContext } from './usePillarStatus';
+
+interface PillarUnavailableRouteProps {
+  /** The id of the pillar that is unavailable (e.g. `'food'`). */
+  readonly pillarId: string;
+}
+
+export function PillarUnavailableRoute({
+  pillarId,
+}: PillarUnavailableRouteProps): React.ReactElement {
+  const { t } = useTranslation('shell');
+  const { refresh, loading } = usePillarStatusContext();
+
+  return (
+    <div className="flex flex-col items-center justify-center py-24 text-center px-4">
+      <CloudOff className="h-16 w-16 text-muted-foreground/40 mb-6" />
+      <h1 className="text-2xl font-bold mb-2">{t('pillarUnavailableTitle')}</h1>
+      <p className="text-muted-foreground mb-6 max-w-prose">
+        {t('pillarUnavailableDescription', { pillar: pillarId })}
+      </p>
+      <Button
+        onClick={() => {
+          void refresh();
+        }}
+        disabled={loading}
+      >
+        {loading ? t('pillarUnavailableRetrying') : t('pillarUnavailableRetry')}
+      </Button>
+    </div>
+  );
+}

--- a/apps/pops-shell/src/app/pillars/index.ts
+++ b/apps/pops-shell/src/app/pillars/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Public surface for the shell-side pillar boot module (ADR-026 P3).
+ *
+ * `App.tsx` mounts `<PillarStatusProvider>`; `router.tsx` wraps each
+ * per-module route subtree in `<PillarGuard>`. Everything else is a
+ * consumer hook or a placeholder.
+ */
+export { PillarGuard } from './PillarGuard';
+export { PillarStatusProvider } from './PillarStatusProvider';
+export { PillarUnavailableRoute } from './PillarUnavailableRoute';
+export { usePillarStatus, usePillarStatusContext } from './usePillarStatus';
+export { pillarIdForModule, CORE_PILLAR_ID } from './manifest-pillar';
+export type { PillarBootSnapshot, PillarHealthStatus, PillarStatusContextValue } from './types';

--- a/apps/pops-shell/src/app/pillars/manifest-pillar.test.ts
+++ b/apps/pops-shell/src/app/pillars/manifest-pillar.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Tests for the shell-side module→pillar mapping (ADR-026 P3).
+ */
+import { describe, expect, it } from 'vitest';
+
+import { CORE_PILLAR_ID, pillarIdForModule } from './manifest-pillar';
+
+describe('pillarIdForModule', () => {
+  it('returns the core pillar for every known module today', () => {
+    // Every shell-installable module currently runs in core-api. The list is
+    // pulled from `installed-modules.ts`'s known frontend manifests; if a
+    // module migrates, this test failure is the prompt to update the mapping.
+    const knownModules = [
+      'ai',
+      'cerebrum',
+      'ego',
+      'finance',
+      'food',
+      'inventory',
+      'lists',
+      'media',
+    ];
+    for (const id of knownModules) {
+      expect(pillarIdForModule(id)).toBe(CORE_PILLAR_ID);
+    }
+  });
+
+  it('returns the core pillar for unknown module ids (monolith fallback)', () => {
+    expect(pillarIdForModule('some-future-module')).toBe('core');
+  });
+
+  it('exports CORE_PILLAR_ID as the literal "core"', () => {
+    expect(CORE_PILLAR_ID).toBe('core');
+  });
+});

--- a/apps/pops-shell/src/app/pillars/manifest-pillar.ts
+++ b/apps/pops-shell/src/app/pillars/manifest-pillar.ts
@@ -1,0 +1,29 @@
+/**
+ * Static mapping from shell module id → pillar id (ADR-026 P3).
+ *
+ * Today the entire backend is the `core` pillar: every module manifest's
+ * routes resolve against `pops-api`'s tRPC. As mature pillars migrate
+ * (Track E/F/G/H/I in `pillar-migration-roadmap.md`), the corresponding
+ * module's mapping flips to the pillar's id and routes start observing
+ * its health.
+ *
+ * Keeping the mapping in a single function rather than on the manifest
+ * itself is deliberate: per-pillar migrations land in the
+ * CI-never-breaks PR sequence and the manifest doesn't need to know
+ * about pillars until its owning pillar actually exists.
+ */
+
+/** The canonical core pillar id, shared with `core-api`'s `/health` response. */
+export const CORE_PILLAR_ID = 'core';
+
+/**
+ * Returns the pillar id that owns the backend for a given module id.
+ *
+ * Unknown module ids also return `'core'`: a freshly-built shell with a
+ * module not yet known to this mapping is the monolith case, where every
+ * module's backend lives in `core-api`. The PR that migrates a module
+ * to its own pillar updates this function in the same change.
+ */
+export function pillarIdForModule(_moduleId: string): string {
+  return CORE_PILLAR_ID;
+}

--- a/apps/pops-shell/src/app/pillars/pillar-registry-client.test.ts
+++ b/apps/pops-shell/src/app/pillars/pillar-registry-client.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Tests for the shell-side pillar boot HTTP client (ADR-026 P3).
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+import { fetchPillarHealth, fetchPillarRegistry } from './pillar-registry-client';
+
+function jsonResponse(body: unknown, init: { status?: number } = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: init.status ?? 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('fetchPillarRegistry', () => {
+  it('returns the parsed pillar list from /pillars', async () => {
+    const fetchStub = vi.fn(async (url) => {
+      expect(url).toBe('/pillars');
+      return jsonResponse({
+        pillars: [
+          { id: 'core', baseUrl: '' },
+          { id: 'food', baseUrl: 'http://food-api:3000' },
+        ],
+      });
+    });
+    const entries = await fetchPillarRegistry({ fetch: fetchStub });
+    expect(entries).toEqual([
+      { id: 'core', baseUrl: '' },
+      { id: 'food', baseUrl: 'http://food-api:3000' },
+    ]);
+  });
+
+  it('falls back to the synthetic core self-entry when /pillars returns an empty list', async () => {
+    const fetchStub = vi.fn(async () => jsonResponse({ pillars: [] }));
+    const entries = await fetchPillarRegistry({ fetch: fetchStub });
+    expect(entries).toEqual([{ id: 'core', baseUrl: '' }]);
+  });
+
+  it('falls back to the synthetic core self-entry on network failure', async () => {
+    const fetchStub = vi.fn(async () => {
+      throw new TypeError('fetch failed');
+    });
+    const entries = await fetchPillarRegistry({ fetch: fetchStub });
+    expect(entries).toEqual([{ id: 'core', baseUrl: '' }]);
+  });
+
+  it('falls back when the response is a 500', async () => {
+    const fetchStub = vi.fn(async () => new Response('boom', { status: 500 }));
+    const entries = await fetchPillarRegistry({ fetch: fetchStub });
+    expect(entries).toEqual([{ id: 'core', baseUrl: '' }]);
+  });
+
+  it('falls back when the response body is malformed', async () => {
+    const fetchStub = vi.fn(async () => jsonResponse({ pillars: [{ id: 'food' }] }));
+    const entries = await fetchPillarRegistry({ fetch: fetchStub });
+    expect(entries).toEqual([{ id: 'core', baseUrl: '' }]);
+  });
+
+  it('falls back when the body is not the {pillars: [...]} shape', async () => {
+    const fetchStub = vi.fn(async () => jsonResponse({ entries: [] }));
+    const entries = await fetchPillarRegistry({ fetch: fetchStub });
+    expect(entries).toEqual([{ id: 'core', baseUrl: '' }]);
+  });
+
+  it('aborts and falls back when the fetch exceeds timeoutMs', async () => {
+    const fetchStub = vi.fn(async (_url, init?: RequestInit) => {
+      await new Promise<void>((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () =>
+          reject(new DOMException('aborted', 'AbortError'))
+        );
+      });
+      throw new Error('unreachable');
+    });
+    const entries = await fetchPillarRegistry({ fetch: fetchStub, timeoutMs: 5 });
+    expect(entries).toEqual([{ id: 'core', baseUrl: '' }]);
+  });
+});
+
+describe('fetchPillarHealth', () => {
+  it('returns the parsed health map from /pillars/health', async () => {
+    const fetchStub = vi.fn(async (url) => {
+      expect(url).toBe('/pillars/health');
+      return jsonResponse({
+        health: { core: 'healthy', food: 'unavailable' },
+      });
+    });
+    const map = await fetchPillarHealth({ fetch: fetchStub });
+    expect(map).toEqual({ core: 'healthy', food: 'unavailable' });
+  });
+
+  it('drops unknown status strings from the map', async () => {
+    const fetchStub = vi.fn(async () =>
+      jsonResponse({ health: { core: 'healthy', food: 'partial', finance: 'unavailable' } })
+    );
+    const map = await fetchPillarHealth({ fetch: fetchStub });
+    expect(map).toEqual({ core: 'healthy', finance: 'unavailable' });
+  });
+
+  it('returns an empty map on network failure', async () => {
+    const fetchStub = vi.fn(async () => {
+      throw new TypeError('fetch failed');
+    });
+    expect(await fetchPillarHealth({ fetch: fetchStub })).toEqual({});
+  });
+
+  it('returns an empty map on a non-2xx response', async () => {
+    const fetchStub = vi.fn(async () => new Response('boom', { status: 502 }));
+    expect(await fetchPillarHealth({ fetch: fetchStub })).toEqual({});
+  });
+
+  it('returns an empty map when the body is malformed', async () => {
+    const fetchStub = vi.fn(async () => jsonResponse({}));
+    expect(await fetchPillarHealth({ fetch: fetchStub })).toEqual({});
+  });
+
+  it('aborts and returns an empty map when the fetch exceeds timeoutMs', async () => {
+    const fetchStub = vi.fn(async (_url, init?: RequestInit) => {
+      await new Promise<void>((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () =>
+          reject(new DOMException('aborted', 'AbortError'))
+        );
+      });
+      throw new Error('unreachable');
+    });
+    const map = await fetchPillarHealth({ fetch: fetchStub, timeoutMs: 5 });
+    expect(map).toEqual({});
+  });
+});

--- a/apps/pops-shell/src/app/pillars/pillar-registry-client.ts
+++ b/apps/pops-shell/src/app/pillars/pillar-registry-client.ts
@@ -13,10 +13,13 @@ import { CORE_PILLAR_ID } from './manifest-pillar';
  * reachable from the browser; the aggregator on core-api does the
  * per-pillar HTTP fan-out. The shell consumes only the aggregated map.
  *
- * Failures are intentionally soft: a network problem or parse error
- * returns an empty registry / empty health map and is logged. The
- * provider treats every pillar as `'unknown'` in that state, which
- * collapses to "render the route optimistically".
+ * Failures are intentionally soft. A registry fetch that errors,
+ * parses to the wrong shape, or returns an empty list collapses to
+ * the synthetic `core` self-entry so the shell always has at least
+ * one pillar to reason about. A health fetch that fails returns an
+ * empty map, which the provider exposes as `'unknown'` for every
+ * pillar — `PillarGuard` treats unknown as healthy so a slow / failed
+ * boot does not paint placeholders over working routes.
  */
 import type { PillarRegistryEntry } from '@pops/types';
 

--- a/apps/pops-shell/src/app/pillars/pillar-registry-client.ts
+++ b/apps/pops-shell/src/app/pillars/pillar-registry-client.ts
@@ -1,0 +1,113 @@
+import { CORE_PILLAR_ID } from './manifest-pillar';
+
+/**
+ * Browser-side fetch helpers for the pillar boot endpoints (ADR-026 P3).
+ *
+ * The shell never reads `POPS_PILLARS` directly — that env var lives on
+ * core-api. The shell consults two HTTP endpoints at boot:
+ *
+ *   GET /pillars         → `{ pillars: PillarRegistryEntry[] }`
+ *   GET /pillars/health  → `{ health: Record<id, 'healthy' | 'unavailable'> }`
+ *
+ * Pillar `baseUrl`s are container-network addresses and are not
+ * reachable from the browser; the aggregator on core-api does the
+ * per-pillar HTTP fan-out. The shell consumes only the aggregated map.
+ *
+ * Failures are intentionally soft: a network problem or parse error
+ * returns an empty registry / empty health map and is logged. The
+ * provider treats every pillar as `'unknown'` in that state, which
+ * collapses to "render the route optimistically".
+ */
+import type { PillarRegistryEntry } from '@pops/types';
+
+import type { PillarHealthStatus } from './types';
+
+const REGISTRY_URL = '/pillars';
+const HEALTH_URL = '/pillars/health';
+
+/** Per-request timeout for boot fetches. */
+const DEFAULT_TIMEOUT_MS = 3000;
+
+export interface PillarFetchOptions {
+  /** Override the global `fetch` (tests inject a stub). */
+  readonly fetch?: typeof fetch;
+  /** Per-fetch timeout in milliseconds. Defaults to 3000. */
+  readonly timeoutMs?: number;
+}
+
+/**
+ * Fetches the pillar registry from core-api. Returns the parsed list of
+ * `PillarRegistryEntry` values, or a single-element list containing the
+ * synthetic `core` entry on any failure. The shell always has at least
+ * one pillar (itself) to reason about.
+ */
+export async function fetchPillarRegistry(
+  options: PillarFetchOptions = {}
+): Promise<readonly PillarRegistryEntry[]> {
+  try {
+    const body = await fetchJson(REGISTRY_URL, options);
+    const entries = parseRegistryBody(body);
+    if (entries === null) return [SELF_ENTRY];
+    return entries.length === 0 ? [SELF_ENTRY] : entries;
+  } catch {
+    return [SELF_ENTRY];
+  }
+}
+
+/**
+ * Fetches the aggregated pillar health map from core-api. Returns the
+ * parsed map, or an empty object on any failure. The provider treats a
+ * missing entry as `'unknown'` so transient probe failures don't paint
+ * placeholders over a working UI.
+ */
+export async function fetchPillarHealth(
+  options: PillarFetchOptions = {}
+): Promise<Readonly<Record<string, PillarHealthStatus>>> {
+  try {
+    const body = await fetchJson(HEALTH_URL, options);
+    return parseHealthBody(body);
+  } catch {
+    return {};
+  }
+}
+
+const SELF_ENTRY: PillarRegistryEntry = { id: CORE_PILLAR_ID, baseUrl: '' };
+
+async function fetchJson(url: string, options: PillarFetchOptions): Promise<unknown> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const fetchImpl = options.fetch ?? fetch;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort('timeout'), timeoutMs);
+  try {
+    const response = await fetchImpl(url, { method: 'GET', signal: controller.signal });
+    if (!response.ok) throw new Error(`status ${response.status}`);
+    return (await response.json()) as unknown;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function parseRegistryBody(body: unknown): readonly PillarRegistryEntry[] | null {
+  if (typeof body !== 'object' || body === null) return null;
+  const pillars = (body as { pillars?: unknown }).pillars;
+  if (!Array.isArray(pillars)) return null;
+  const out: PillarRegistryEntry[] = [];
+  for (const candidate of pillars) {
+    if (typeof candidate !== 'object' || candidate === null) return null;
+    const { id, baseUrl } = candidate as { id?: unknown; baseUrl?: unknown };
+    if (typeof id !== 'string' || typeof baseUrl !== 'string') return null;
+    out.push({ id, baseUrl });
+  }
+  return out;
+}
+
+function parseHealthBody(body: unknown): Readonly<Record<string, PillarHealthStatus>> {
+  if (typeof body !== 'object' || body === null) return {};
+  const health = (body as { health?: unknown }).health;
+  if (typeof health !== 'object' || health === null) return {};
+  const out: Record<string, PillarHealthStatus> = {};
+  for (const [id, status] of Object.entries(health as Record<string, unknown>)) {
+    if (status === 'healthy' || status === 'unavailable') out[id] = status;
+  }
+  return out;
+}

--- a/apps/pops-shell/src/app/pillars/types.ts
+++ b/apps/pops-shell/src/app/pillars/types.ts
@@ -1,0 +1,28 @@
+/**
+ * Shell-side pillar boot types (ADR-026 P3).
+ */
+import type { PillarRegistryEntry } from '@pops/types';
+
+/**
+ * Shell-side health view for a pillar:
+ *   - `'healthy'`     — the aggregated `/pillars/health` probe returned healthy.
+ *   - `'unavailable'` — the probe returned unavailable; routes for this pillar
+ *                       render `PillarUnavailableRoute`.
+ *   - `'unknown'`     — boot fetch hasn't completed (or failed outright); the
+ *                       UI optimistically renders module routes rather than
+ *                       flashing placeholders for the duration of a slow boot.
+ */
+export type PillarHealthStatus = 'healthy' | 'unavailable' | 'unknown';
+
+/** Snapshot returned by the shell-side registry + health fetch. */
+export interface PillarBootSnapshot {
+  readonly entries: readonly PillarRegistryEntry[];
+  readonly health: Readonly<Record<string, PillarHealthStatus>>;
+}
+
+/** Live state exposed by `PillarStatusProvider` via React context. */
+export interface PillarStatusContextValue {
+  readonly snapshot: PillarBootSnapshot;
+  readonly loading: boolean;
+  readonly refresh: () => Promise<void>;
+}

--- a/apps/pops-shell/src/app/pillars/usePillarStatus.ts
+++ b/apps/pops-shell/src/app/pillars/usePillarStatus.ts
@@ -1,0 +1,33 @@
+/**
+ * Hooks for consuming the pillar boot snapshot (ADR-026 P3).
+ */
+import { useContext } from 'react';
+
+import { PillarStatusContext } from './PillarStatusProvider';
+
+import type { PillarHealthStatus, PillarStatusContextValue } from './types';
+
+/**
+ * Returns the full boot context. Throws if used outside a
+ * `PillarStatusProvider` — the provider is mounted in `App.tsx` and is
+ * expected to wrap every route.
+ */
+export function usePillarStatusContext(): PillarStatusContextValue {
+  const ctx = useContext(PillarStatusContext);
+  if (ctx === null) {
+    throw new Error('usePillarStatusContext must be used inside <PillarStatusProvider>');
+  }
+  return ctx;
+}
+
+/**
+ * Returns the health status for a single pillar id. Pillars that are
+ * not present in the boot snapshot (the registry didn't include them,
+ * or the boot is still in flight) report `'unknown'` — which the
+ * `PillarGuard` component treats as healthy so a slow / failed boot
+ * does not flash a placeholder over working routes.
+ */
+export function usePillarStatus(pillarId: string): PillarHealthStatus {
+  const { snapshot } = usePillarStatusContext();
+  return snapshot.health[pillarId] ?? 'unknown';
+}

--- a/apps/pops-shell/src/app/router.tsx
+++ b/apps/pops-shell/src/app/router.tsx
@@ -8,7 +8,7 @@
  * module's URL renders `NotInstalledPage` via the catch-all.
  */
 import { Suspense } from 'react';
-import { createBrowserRouter, Link, Navigate, useLocation } from 'react-router';
+import { createBrowserRouter, Link, Navigate, Outlet, useLocation } from 'react-router';
 
 import { KNOWN_MODULES } from '@pops/module-registry';
 
@@ -19,6 +19,7 @@ import { FeaturesPage } from './pages/features-page/FeaturesPage';
 import { NotFoundPage } from './pages/NotFoundPage';
 import { NotInstalledPage } from './pages/NotInstalledPage';
 import { SettingsPage } from './pages/SettingsPage';
+import { PillarGuard, pillarIdForModule } from './pillars';
 
 import type { RouteObject } from 'react-router';
 
@@ -62,13 +63,28 @@ function withSuspense(routes: readonly RouteObject[]): RouteObject[] {
 
 /**
  * Build one router-level entry per installed app module. Each entry mounts
- * the module's routes under `/<id>/*`.
+ * the module's routes under `/<id>/*` and wraps them in `<PillarGuard>` so
+ * the subtree renders the `PillarUnavailableRoute` placeholder when the
+ * owning pillar's health is `'unavailable'` (ADR-026 P3).
+ *
+ * Today every module maps to the `core` pillar via `pillarIdForModule`;
+ * the guard is a no-op for healthy/unknown statuses. As mature pillars
+ * migrate, their module's mapping flips and routes start observing the
+ * pillar's reported health.
  */
 function appRouteEntries(): RouteObject[] {
-  return installedAppManifests().map((manifest) => ({
-    path: manifest.id,
-    children: withSuspense(manifest.frontend.routes),
-  }));
+  return installedAppManifests().map((manifest) => {
+    const pillarId = pillarIdForModule(manifest.id);
+    return {
+      path: manifest.id,
+      element: (
+        <PillarGuard pillarId={pillarId}>
+          <Outlet />
+        </PillarGuard>
+      ),
+      children: withSuspense(manifest.frontend.routes),
+    };
+  });
 }
 
 const ErrorElement = (

--- a/apps/pops-shell/src/i18n/locales/en-AU/shell.json
+++ b/apps/pops-shell/src/i18n/locales/en-AU/shell.json
@@ -16,5 +16,9 @@
   "locale": "Language",
   "localeEnAU": "English (Australia)",
   "localePtBR": "Portuguese (Brazil)",
-  "skipToContent": "Skip to content"
+  "skipToContent": "Skip to content",
+  "pillarUnavailableTitle": "Pillar unavailable",
+  "pillarUnavailableDescription": "The {{pillar}} pillar isn't responding. Its routes will come back online when the pillar recovers.",
+  "pillarUnavailableRetry": "Retry",
+  "pillarUnavailableRetrying": "Checking…"
 }

--- a/apps/pops-shell/src/i18n/locales/pt-BR/shell.json
+++ b/apps/pops-shell/src/i18n/locales/pt-BR/shell.json
@@ -16,5 +16,9 @@
   "locale": "Idioma",
   "localeEnAU": "English (Australia)",
   "localePtBR": "Português (Brasil)",
-  "skipToContent": "Pular para o conteúdo"
+  "skipToContent": "Pular para o conteúdo",
+  "pillarUnavailableTitle": "Pilar indisponível",
+  "pillarUnavailableDescription": "O pilar {{pillar}} não está a responder. As rotas voltarão quando o pilar recuperar.",
+  "pillarUnavailableRetry": "Tentar de novo",
+  "pillarUnavailableRetrying": "A verificar…"
 }

--- a/apps/pops-shell/vite.config.ts
+++ b/apps/pops-shell/vite.config.ts
@@ -77,6 +77,12 @@ export default defineConfig({
         target: 'http://localhost:3000',
         changeOrigin: true,
       },
+      '/pillars': {
+        // ADR-026 P3: shell-side pillar boot calls GET /pillars and
+        // GET /pillars/health on core-api.
+        target: 'http://localhost:3000',
+        changeOrigin: true,
+      },
       '/api': {
         target: 'http://localhost:3000',
         changeOrigin: true,


### PR DESCRIPTION
## Summary

Pre-flight **P3** from the [pillar-migration roadmap](../tree/main/docs/architecture/adr-026-pillar-architecture.md): wires the shell's boot path through the pillar registry that **P2** ([#2715](https://github.com/knoxio/pops/pull/2715)) exposed, so per-domain pillars (Track E–I) can come online and routes touching a down pillar render a placeholder instead of failing.

### Server-side (additive to P2)

- `GET /pillars/health` on core-api. Aggregated probe over `POPS_PILLARS` — fans out concurrent `GET {baseUrl}/health` with per-probe timeout, validates each upstream's `PillarHealth` shape against its registered id. The self-pillar is short-circuited to `'healthy'` (the aggregator runs in core's process — by definition it is up). Lives server-side because container-network base URLs are not reachable from the browser.

### Shell-side (`apps/pops-shell/src/app/pillars/`)

- `pillar-registry-client.ts` — fetches `/pillars` and `/pillars/health` at boot with timeouts; any failure soft-falls back to the synthetic `core` self-entry / empty health map.
- `PillarStatusProvider` — owns the boot fetch, exposes a snapshot via React context. Mounted in `App.tsx` between `QueryClientProvider` and the `RouterProvider`.
- `usePillarStatus(id)` — returns `'healthy' | 'unavailable' | 'unknown'`.
- `PillarGuard` — wraps each per-module subtree in `router.tsx`. Renders `PillarUnavailableRoute` when status is `'unavailable'`, otherwise the `<Outlet/>`. `'unknown'` falls through so a slow / failed boot never flashes a placeholder over a working route.
- `manifest-pillar.ts` — single consolidation point for the `moduleId → pillarId` mapping. Today every module returns `'core'` (the monolith case). Mature-pillar migrations (Track E–I) update this in the same PR that flips the module's backend.
- Vite dev proxy gains `/pillars → localhost:3000`.
- Shell i18n adds `pillarUnavailable*` keys (en-AU + pt-BR) under the `shell` namespace.

### Deferred (deliberately)

Per-pillar tRPC client factories ("`@pops/api-client` retires; per-pillar `useXTrpc()` hooks" — decisions log) are explicitly deferred to the first pillar migration. P3 is scaffolding; today the only pillar is core, so introducing factory infrastructure would be dead code.

## Test plan

- [x] **pops-api unit:** 12 health-probe tests covering happy path, non-2xx, malformed shape, pillar-id mismatch, network error, timeout abort, empty registry, self-pillar short-circuit (with empty + remote `baseUrl`), multi-pillar fan-out incl. partial failure, custom `selfPillarId`. Full API suite green: 4528/4528.
- [x] **pops-shell unit + RTL:** 27 tests across `pillar-registry-client` (10 — fetch/parse/timeout/fallbacks for both endpoints), `manifest-pillar` (3), `PillarStatusProvider` (6 — snapshot override / loading state / resolution / refresh / missing-id 'unknown' / context throw outside provider / re-mount), `PillarGuard` (3), `PillarUnavailableRoute` (2). Workspace lint, format check, lint:boundaries, typecheck, and build all clean on both apps.
- [x] One pre-existing local flake on `OverlayHost.test.tsx` (lazy-import Suspense timing) reproduces on `main` without these changes — not introduced by this PR.