### PR TITLE
feat(food): PRD-133 — AI usage logging helper + prompt viewer

### DIFF
--- a/apps/pops-api/src/modules/food/__tests__/ai-router.test.ts
+++ b/apps/pops-api/src/modules/food/__tests__/ai-router.test.ts
@@ -1,0 +1,190 @@
+/**
+ * PRD-133 — integration tests for `food.ai.logInference`.
+ *
+ * In-memory SQLite seeded with the ai_inference_log table. Internal
+ * caller token gates the mutation; public callers must be rejected.
+ */
+import BetterSqlite3, { type Database } from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { closeDb, setDb } from '../../../db.js';
+import { appRouter } from '../../../router.js';
+
+import type { Context } from '../../../trpc.js';
+
+function createAiInferenceLogTable(db: Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS ai_inference_log (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      provider TEXT NOT NULL,
+      model TEXT NOT NULL,
+      operation TEXT NOT NULL,
+      domain TEXT,
+      input_tokens INTEGER NOT NULL DEFAULT 0,
+      output_tokens INTEGER NOT NULL DEFAULT 0,
+      cost_usd REAL NOT NULL DEFAULT 0,
+      latency_ms INTEGER NOT NULL DEFAULT 0,
+      status TEXT NOT NULL DEFAULT 'success',
+      cached INTEGER NOT NULL DEFAULT 0,
+      context_id TEXT,
+      error_message TEXT,
+      metadata TEXT,
+      created_at TEXT NOT NULL
+    );
+  `);
+}
+
+function createInternalCaller(): ReturnType<typeof appRouter.createCaller> {
+  const ctx: Context = { user: null, serviceAccount: null, internalCaller: true };
+  return appRouter.createCaller(ctx);
+}
+
+function createPublicCaller(): ReturnType<typeof appRouter.createCaller> {
+  const ctx: Context = {
+    user: { email: 'test@example.com' },
+    serviceAccount: null,
+    internalCaller: false,
+  };
+  return appRouter.createCaller(ctx);
+}
+
+interface LoggedRow {
+  id: number;
+  provider: string;
+  model: string;
+  operation: string;
+  domain: string | null;
+  input_tokens: number;
+  output_tokens: number;
+  cost_usd: number;
+  latency_ms: number;
+  status: string;
+  cached: number;
+  context_id: string | null;
+  error_message: string | null;
+  metadata: string | null;
+  created_at: string;
+}
+
+function readRows(db: Database): LoggedRow[] {
+  return db.prepare('SELECT * FROM ai_inference_log ORDER BY id ASC').all() as LoggedRow[];
+}
+
+let db: Database;
+
+beforeEach(() => {
+  db = new BetterSqlite3(':memory:');
+  db.pragma('foreign_keys = ON');
+  createAiInferenceLogTable(db);
+  setDb(db);
+});
+
+afterEach(() => {
+  closeDb();
+});
+
+describe('food.ai.logInference', () => {
+  it('writes a success row with domain=food and merged metadata', async () => {
+    const caller = createInternalCaller();
+    const result = await caller.food.ai.logInference({
+      operation: 'recipe-extract-web-llm',
+      contextId: 'ingest_source:42',
+      provider: 'claude',
+      model: 'claude-haiku-4-5-20251001',
+      promptVersion: 'web-llm-v0.1',
+      inputTokens: 1500,
+      outputTokens: 800,
+      costUsd: 0.0055,
+      latencyMs: 1234,
+      status: 'success',
+      cached: false,
+      metadata: { source_kind: 'url-web' },
+    });
+
+    expect(result).toEqual({ ok: true });
+
+    const rows = readRows(db);
+    expect(rows).toHaveLength(1);
+    const row = rows[0]!;
+    expect(row.domain).toBe('food');
+    expect(row.operation).toBe('recipe-extract-web-llm');
+    expect(row.context_id).toBe('ingest_source:42');
+    expect(row.input_tokens).toBe(1500);
+    expect(row.output_tokens).toBe(800);
+    expect(row.cost_usd).toBeCloseTo(0.0055);
+    expect(row.latency_ms).toBe(1234);
+    expect(row.status).toBe('success');
+    expect(row.cached).toBe(0);
+    expect(row.error_message).toBeNull();
+    const meta = JSON.parse(row.metadata ?? '{}') as Record<string, unknown>;
+    expect(meta['prompt_version']).toBe('web-llm-v0.1');
+    expect(meta['source_kind']).toBe('url-web');
+  });
+
+  it('writes an error row with the provided errorMessage', async () => {
+    const caller = createInternalCaller();
+    await caller.food.ai.logInference({
+      operation: 'recipe-extract-screenshot',
+      contextId: 'ingest_source:7',
+      provider: 'claude',
+      model: 'claude-haiku-4-5-20251001',
+      promptVersion: 'screenshot-v0.1',
+      inputTokens: 0,
+      outputTokens: 0,
+      costUsd: 0,
+      latencyMs: 200,
+      status: 'error',
+      cached: false,
+      errorMessage: 'Anthropic 529 overloaded',
+      metadata: { cost_missing: true },
+    });
+
+    const rows = readRows(db);
+    expect(rows).toHaveLength(1);
+    const row = rows[0]!;
+    expect(row.status).toBe('error');
+    expect(row.error_message).toBe('Anthropic 529 overloaded');
+    const meta = JSON.parse(row.metadata ?? '{}') as Record<string, unknown>;
+    expect(meta['cost_missing']).toBe(true);
+  });
+
+  it('rejects public (non-internal) callers with UNAUTHORIZED', async () => {
+    const caller = createPublicCaller();
+    await expect(
+      caller.food.ai.logInference({
+        operation: 'recipe-extract-text',
+        contextId: 'ingest_source:1',
+        provider: 'claude',
+        model: 'claude-haiku-4-5-20251001',
+        promptVersion: 'text-v0.1',
+        inputTokens: 100,
+        outputTokens: 50,
+        costUsd: 0.0001,
+        latencyMs: 100,
+        status: 'success',
+        cached: false,
+      })
+    ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+
+    expect(readRows(db)).toHaveLength(0);
+  });
+
+  it('rejects invalid operation strings at the schema boundary', async () => {
+    const caller = createInternalCaller();
+    await expect(
+      caller.food.ai.logInference({
+        operation: 'recipe-extract-bogus' as never,
+        contextId: 'ingest_source:1',
+        provider: 'claude',
+        model: 'claude-haiku-4-5-20251001',
+        promptVersion: 'v',
+        inputTokens: 0,
+        outputTokens: 0,
+        costUsd: 0,
+        latencyMs: 0,
+        status: 'success',
+        cached: false,
+      })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+  });
+});

--- a/apps/pops-api/src/modules/food/index.ts
+++ b/apps/pops-api/src/modules/food/index.ts
@@ -2,6 +2,7 @@ import { router } from '../../trpc.js';
 import { conversionsRouter } from './conversions/router.js';
 import { heroImageRouter } from './hero-image/router.js';
 import { foodMigrations } from './migrations.js';
+import { aiRouter } from './routers/ai.js';
 import { aliasesRouter } from './routers/aliases.js';
 import { ingestRouter } from './routers/ingest-router.js';
 import { ingredientsRouter } from './routers/ingredients.js';
@@ -22,6 +23,7 @@ export const foodRouter = router({
   substitutions: substitutionsRouter,
   slugs: slugsRouter,
   conversions: conversionsRouter,
+  ai: aiRouter,
 });
 
 export const manifest: ModuleManifest<typeof foodRouter> = {

--- a/apps/pops-api/src/modules/food/routers/ai.ts
+++ b/apps/pops-api/src/modules/food/routers/ai.ts
@@ -1,0 +1,93 @@
+import { z } from 'zod';
+
+/**
+ * PRD-133 — `food.ai.logInference` internal mutation.
+ *
+ * The pops-worker-food container (PRD-126) posts here on every Claude
+ * call so usage shows up in the cross-domain AI Ops surface (theme 05).
+ * Auth gates the endpoint behind `POPS_API_INTERNAL_TOKEN` via
+ * `internalProcedure`.
+ *
+ * Logging is best-effort by design: the wrapper in
+ * `packages/app-food/src/ai/log-inference.ts` swallows failures so a
+ * logging hiccup never blocks an ingest. The mutation still surfaces
+ * structural validation errors back to the caller; only DB-write
+ * failures get downgraded — those land in pops-api logs.
+ *
+ * No new schema. Writes a single row to `ai_inference_log` with
+ * `domain = 'food'`. The cost is computed worker-side per PRD-133's
+ * shape.
+ */
+import { aiInferenceLog } from '@pops/db-types';
+
+import { getDrizzle } from '../../../db.js';
+import { logger } from '../../../lib/logger.js';
+import { internalProcedure, router } from '../../../trpc.js';
+
+const FoodOperationSchema = z.enum([
+  'recipe-extract-web-llm',
+  'recipe-extract-ig-vision',
+  'recipe-extract-ig-text-fallback',
+  'recipe-extract-screenshot',
+  'recipe-extract-text',
+]);
+
+export const LogFoodInferenceInput = z.object({
+  operation: FoodOperationSchema,
+  contextId: z.string().min(1),
+  provider: z.literal('claude'),
+  model: z.string().min(1),
+  promptVersion: z.string().min(1),
+  inputTokens: z.number().int().nonnegative(),
+  outputTokens: z.number().int().nonnegative(),
+  costUsd: z.number().nonnegative(),
+  latencyMs: z.number().int().nonnegative(),
+  status: z.enum(['success', 'error']),
+  cached: z.boolean(),
+  errorMessage: z.string().optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+});
+
+export const LogFoodInferenceOutput = z.object({
+  ok: z.literal(true),
+});
+
+export const aiRouter = router({
+  logInference: internalProcedure
+    .input(LogFoodInferenceInput)
+    .output(LogFoodInferenceOutput)
+    .mutation(({ input }) => {
+      const merged: Record<string, unknown> = {
+        prompt_version: input.promptVersion,
+        ...input.metadata,
+      };
+
+      try {
+        getDrizzle()
+          .insert(aiInferenceLog)
+          .values({
+            provider: input.provider,
+            model: input.model,
+            operation: input.operation,
+            domain: 'food',
+            inputTokens: input.inputTokens,
+            outputTokens: input.outputTokens,
+            costUsd: input.costUsd,
+            latencyMs: input.latencyMs,
+            status: input.status,
+            cached: input.cached ? 1 : 0,
+            contextId: input.contextId,
+            errorMessage: input.errorMessage ?? null,
+            metadata: JSON.stringify(merged),
+            createdAt: new Date().toISOString(),
+          })
+          .run();
+      } catch (err) {
+        logger.warn({ err }, '[food.ai.logInference] failed to insert ai_inference_log row');
+      }
+
+      return { ok: true } as const;
+    }),
+});
+
+export type AiRouter = typeof aiRouter;

--- a/apps/pops-api/src/modules/food/routers/ai.ts
+++ b/apps/pops-api/src/modules/food/routers/ai.ts
@@ -57,9 +57,12 @@ export const aiRouter = router({
     .input(LogFoodInferenceInput)
     .output(LogFoodInferenceOutput)
     .mutation(({ input }) => {
+      // Server-authored fields (prompt_version) win over caller-supplied
+      // metadata so the prompt-viewer correlation can't be spoofed by a
+      // worker passing a stale version in `metadata.prompt_version`.
       const merged: Record<string, unknown> = {
-        prompt_version: input.promptVersion,
         ...input.metadata,
+        prompt_version: input.promptVersion,
       };
 
       try {

--- a/apps/pops-shell/src/i18n/locales/en-AU/food.json
+++ b/apps/pops-shell/src/i18n/locales/en-AU/food.json
@@ -330,5 +330,10 @@
   "data.substitutions.graph.edge.editInTable": "Edit in table view",
   "data.substitutions.graph.viewMode.global": "Global view",
   "data.substitutions.graph.viewMode.radial": "Radial view: {{label}}",
-  "data.substitutions.graph.viewMode.backToGlobal": "Back to global view"
+  "data.substitutions.graph.viewMode.backToGlobal": "Back to global view",
+  "prompts.title": "Prompt templates",
+  "prompts.description": "Read-only view of the AI prompts the food ingest pipeline uses.",
+  "prompts.editingHint": "Prompts are defined in code and cannot be edited here. To change one, edit the matching constant under packages/app-food/src/prompts/, bump the version, then redeploy.",
+  "prompts.fields.model": "Model:",
+  "prompts.fields.version": "Version:"
 }

--- a/apps/pops-shell/src/i18n/locales/en-AU/navigation.json
+++ b/apps/pops-shell/src/i18n/locales/en-AU/navigation.json
@@ -20,6 +20,7 @@
   "food": "Food",
   "food.home": "Home",
   "food.data": "Manage data",
+  "food.prompts": "Prompts",
   "lists": "Lists",
   "lists.home": "Home",
   "inventory": "Inventory",

--- a/apps/pops-shell/src/i18n/locales/pt-BR/food.json
+++ b/apps/pops-shell/src/i18n/locales/pt-BR/food.json
@@ -265,5 +265,10 @@
   "hero.uploading": "Enviando…",
   "hero.removing": "Removendo…",
   "hero.uploadSuccess": "Imagem principal enviada.",
-  "hero.removeSuccess": "Imagem principal removida."
+  "hero.removeSuccess": "Imagem principal removida.",
+  "prompts.title": "Templates de prompt",
+  "prompts.description": "Visualização somente leitura dos prompts de IA usados no pipeline de ingestão de receitas.",
+  "prompts.editingHint": "Os prompts são definidos em código e não podem ser editados aqui. Para alterar um, edite a constante correspondente em packages/app-food/src/prompts/, atualize a versão e faça um novo deploy.",
+  "prompts.fields.model": "Modelo:",
+  "prompts.fields.version": "Versão:"
 }

--- a/apps/pops-shell/src/i18n/locales/pt-BR/navigation.json
+++ b/apps/pops-shell/src/i18n/locales/pt-BR/navigation.json
@@ -20,6 +20,7 @@
   "food": "Comida",
   "food.home": "Início",
   "food.data": "Gerenciar dados",
+  "food.prompts": "Prompts",
   "lists": "Listas",
   "lists.home": "Início",
   "inventory": "Inventário",

--- a/docs/themes/07-food/prds/133-ai-usage-prompts/README.md
+++ b/docs/themes/07-food/prds/133-ai-usage-prompts/README.md
@@ -210,7 +210,7 @@ Inline per theme protocol.
 - [ ] Route `/food/prompts` mounted in `packages/app-food/src/routes.tsx`.
 - [ ] Page renders each entry in `FOOD_PROMPTS` with title, model, version, description, template.
 - [ ] Header explains the read-only nature and where to edit (file path).
-- [ ] Storybook story at `apps/pops-storybook/src/stories/food/PromptViewerPage.stories.tsx`.
+- [ ] Storybook story at `packages/app-food/src/pages/PromptViewerPage.stories.tsx`. Storybook discovers stories from `packages/*/src/**/*.stories.@(ts|tsx)`, so the story lives next to the page (matching `DslEditor.stories.tsx` / `RecipeRenderer.stories.tsx`).
 
 ### Tests
 

--- a/packages/app-food/src/ai/__tests__/log-inference.test.ts
+++ b/packages/app-food/src/ai/__tests__/log-inference.test.ts
@@ -1,15 +1,18 @@
 /**
  * PRD-133 — unit tests for `callClaudeWithLogging`.
  *
- * Exercises happy / error / missing-usage / missing-pricing paths
- * against a fake log sink + pricing lookup, asserting the logged row
- * shape matches what the `food.ai.logInference` mutation will receive.
+ * Exercises happy / error / missing-usage / missing-pricing /
+ * cost-cap / fire-and-forget paths against a fake log sink + pricing
+ * lookup. The wrapper schedules log writes as detached promises so
+ * each assertion flushes the microtask queue before reading
+ * `sink.rows` — `vi.waitFor` keeps the wait bounded.
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   callClaudeWithLogging,
   computeCostUsd,
+  logFoodInference,
   type LogFoodInferenceInput,
   type PricingEntry,
 } from '../log-inference.js';
@@ -17,17 +20,28 @@ import {
 interface FakeSink {
   rows: LogFoodInferenceInput[];
   shouldFail: boolean;
+  resolveAfterMs: number;
 }
 
 function createFakeSink(): FakeSink {
-  return { rows: [], shouldFail: false };
+  return { rows: [], shouldFail: false, resolveAfterMs: 0 };
 }
 
 function logFnFor(sink: FakeSink) {
   return async (input: LogFoodInferenceInput) => {
+    if (sink.resolveAfterMs > 0) {
+      await new Promise<void>((r) => setTimeout(r, sink.resolveAfterMs));
+    }
     if (sink.shouldFail) throw new Error('log sink unavailable');
     sink.rows.push(input);
   };
+}
+
+async function waitForRows(sink: FakeSink, expected: number): Promise<void> {
+  await vi.waitFor(() => {
+    if (sink.rows.length < expected)
+      throw new Error(`expected ${expected}, have ${sink.rows.length}`);
+  });
 }
 
 const claudePricing: PricingEntry = { input: 1.0, output: 5.0 };
@@ -42,6 +56,32 @@ describe('computeCostUsd', () => {
   it('returns missing=true with cost=0 when pricing is null', () => {
     const result = computeCostUsd(1000, 1000, null);
     expect(result).toEqual({ costUsd: 0, missing: true });
+  });
+});
+
+describe('logFoodInference (default sink)', () => {
+  it('no-ops when POPS_API_URL is unset', async () => {
+    const before = process.env['POPS_API_URL'];
+    delete process.env['POPS_API_URL'];
+    try {
+      await expect(
+        logFoodInference({
+          operation: 'recipe-extract-text',
+          contextId: 'ingest_source:1',
+          provider: 'claude',
+          model: 'claude-haiku-4-5-20251001',
+          promptVersion: 'text-v0.1',
+          inputTokens: 0,
+          outputTokens: 0,
+          costUsd: 0,
+          latencyMs: 0,
+          status: 'success',
+          cached: false,
+        })
+      ).resolves.toBeUndefined();
+    } finally {
+      if (before !== undefined) process.env['POPS_API_URL'] = before;
+    }
   });
 });
 
@@ -72,7 +112,7 @@ describe('callClaudeWithLogging', () => {
     );
 
     expect(response).toEqual({ dsl: '@recipe("foo", "Foo")' });
-    expect(sink.rows).toHaveLength(1);
+    await waitForRows(sink, 1);
     const row = sink.rows[0]!;
     expect(row.status).toBe('success');
     expect(row.operation).toBe('recipe-extract-web-llm');
@@ -88,6 +128,7 @@ describe('callClaudeWithLogging', () => {
     });
     expect(row.metadata).not.toHaveProperty('cost_missing');
     expect(row.metadata).not.toHaveProperty('usage_missing');
+    expect(row.metadata).not.toHaveProperty('over_cost_cap');
   });
 
   it('logs an error row + rethrows when the underlying call throws', async () => {
@@ -109,7 +150,7 @@ describe('callClaudeWithLogging', () => {
       )
     ).rejects.toThrow('Anthropic 529 overloaded');
 
-    expect(sink.rows).toHaveLength(1);
+    await waitForRows(sink, 1);
     const row = sink.rows[0]!;
     expect(row.status).toBe('error');
     expect(row.errorMessage).toBe('Anthropic 529 overloaded');
@@ -136,8 +177,8 @@ describe('callClaudeWithLogging', () => {
       }
     );
 
-    const row = sink.rows[0]!;
-    expect(row.metadata).toMatchObject({ usage_missing: true });
+    await waitForRows(sink, 1);
+    expect(sink.rows[0]!.metadata).toMatchObject({ usage_missing: true });
   });
 
   it('flags cost_missing when the pricing lookup returns null', async () => {
@@ -158,12 +199,68 @@ describe('callClaudeWithLogging', () => {
       }
     );
 
+    await waitForRows(sink, 1);
     const row = sink.rows[0]!;
     expect(row.costUsd).toBe(0);
     expect(row.metadata).toMatchObject({ cost_missing: true });
   });
 
-  it('swallows log-sink failures without affecting the caller', async () => {
+  it('flags over_cost_cap + emits a warning when costUsd exceeds the cap (does NOT abort)', async () => {
+    const warn = vi.fn();
+    // Pricing × tokens gives ~0.500 USD — well over the 0.05 default cap.
+    const response = await callClaudeWithLogging<{ dsl: string }>(
+      {
+        operation: 'recipe-extract-ig-vision',
+        contextId: 'ingest_source:9',
+        model: 'claude-haiku-4-5-20251001',
+        promptVersion: 'ig-vision-v0.1',
+        costCapUsd: 0.05,
+        call: async () => ({
+          response: { dsl: '@recipe("big", "Big")' },
+          usage: { inputTokens: 500_000, outputTokens: 0 },
+        }),
+      },
+      {
+        log: logFnFor(sink),
+        lookupPricing: () => claudePricing,
+        warn,
+      }
+    );
+
+    expect(response).toEqual({ dsl: '@recipe("big", "Big")' });
+    await waitForRows(sink, 1);
+    const row = sink.rows[0]!;
+    expect(row.metadata).toMatchObject({ over_cost_cap: true });
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]?.[0]).toContain('exceeds cap');
+  });
+
+  it('returns to the caller WITHOUT waiting for the log sink (fire-and-forget)', async () => {
+    sink.resolveAfterMs = 200;
+    const start = Date.now();
+    const response = await callClaudeWithLogging<{ ok: true }>(
+      {
+        operation: 'recipe-extract-text',
+        contextId: 'ingest_source:3',
+        model: 'claude-haiku-4-5-20251001',
+        promptVersion: 'text-v0.1',
+        call: async () => ({
+          response: { ok: true },
+          usage: { inputTokens: 100, outputTokens: 200 },
+        }),
+      },
+      { log: logFnFor(sink), lookupPricing: () => claudePricing }
+    );
+
+    const elapsed = Date.now() - start;
+    expect(response).toEqual({ ok: true });
+    // Wrapper returned WAY before the sink's 200ms delay.
+    expect(elapsed).toBeLessThan(150);
+    // But the row eventually lands.
+    await waitForRows(sink, 1);
+  });
+
+  it('swallows log-sink failures via warn without affecting the caller', async () => {
     sink.shouldFail = true;
     const warn = vi.fn();
 
@@ -186,8 +283,13 @@ describe('callClaudeWithLogging', () => {
     );
 
     expect(response).toEqual({ ok: true });
-    expect(warn).toHaveBeenCalledTimes(1);
-    expect(warn.mock.calls[0]?.[0]).toContain('logFoodInference failed');
+    await vi.waitFor(() => {
+      expect(warn).toHaveBeenCalled();
+    });
+    const calls = warn.mock.calls.filter(
+      (c) => typeof c[0] === 'string' && c[0].includes('logFoodInference failed')
+    );
+    expect(calls.length).toBeGreaterThanOrEqual(1);
   });
 
   it('awaits an async pricing lookup', async () => {
@@ -208,7 +310,7 @@ describe('callClaudeWithLogging', () => {
       }
     );
 
-    const row = sink.rows[0]!;
-    expect(row.costUsd).toBeCloseTo(100 / 1e6 + (100 * 5) / 1e6, 8);
+    await waitForRows(sink, 1);
+    expect(sink.rows[0]!.costUsd).toBeCloseTo(100 / 1e6 + (100 * 5) / 1e6, 8);
   });
 });

--- a/packages/app-food/src/ai/__tests__/log-inference.test.ts
+++ b/packages/app-food/src/ai/__tests__/log-inference.test.ts
@@ -1,0 +1,214 @@
+/**
+ * PRD-133 — unit tests for `callClaudeWithLogging`.
+ *
+ * Exercises happy / error / missing-usage / missing-pricing paths
+ * against a fake log sink + pricing lookup, asserting the logged row
+ * shape matches what the `food.ai.logInference` mutation will receive.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  callClaudeWithLogging,
+  computeCostUsd,
+  type LogFoodInferenceInput,
+  type PricingEntry,
+} from '../log-inference.js';
+
+interface FakeSink {
+  rows: LogFoodInferenceInput[];
+  shouldFail: boolean;
+}
+
+function createFakeSink(): FakeSink {
+  return { rows: [], shouldFail: false };
+}
+
+function logFnFor(sink: FakeSink) {
+  return async (input: LogFoodInferenceInput) => {
+    if (sink.shouldFail) throw new Error('log sink unavailable');
+    sink.rows.push(input);
+  };
+}
+
+const claudePricing: PricingEntry = { input: 1.0, output: 5.0 };
+
+describe('computeCostUsd', () => {
+  it('multiplies tokens by per-million pricing', () => {
+    const result = computeCostUsd(1_500_000, 500_000, claudePricing);
+    expect(result.missing).toBe(false);
+    expect(result.costUsd).toBeCloseTo(1.5 + 2.5, 6);
+  });
+
+  it('returns missing=true with cost=0 when pricing is null', () => {
+    const result = computeCostUsd(1000, 1000, null);
+    expect(result).toEqual({ costUsd: 0, missing: true });
+  });
+});
+
+describe('callClaudeWithLogging', () => {
+  let sink: FakeSink;
+
+  beforeEach(() => {
+    sink = createFakeSink();
+  });
+
+  it('logs a success row + returns the underlying response', async () => {
+    const response = await callClaudeWithLogging<{ dsl: string }>(
+      {
+        operation: 'recipe-extract-web-llm',
+        contextId: 'ingest_source:42',
+        model: 'claude-haiku-4-5-20251001',
+        promptVersion: 'web-llm-v0.1',
+        metadata: { url: 'https://example.com/recipe' },
+        call: async () => ({
+          response: { dsl: '@recipe("foo", "Foo")' },
+          usage: { inputTokens: 1500, outputTokens: 600 },
+        }),
+      },
+      {
+        log: logFnFor(sink),
+        lookupPricing: () => claudePricing,
+      }
+    );
+
+    expect(response).toEqual({ dsl: '@recipe("foo", "Foo")' });
+    expect(sink.rows).toHaveLength(1);
+    const row = sink.rows[0]!;
+    expect(row.status).toBe('success');
+    expect(row.operation).toBe('recipe-extract-web-llm');
+    expect(row.contextId).toBe('ingest_source:42');
+    expect(row.inputTokens).toBe(1500);
+    expect(row.outputTokens).toBe(600);
+    expect(row.cached).toBe(false);
+    expect(row.costUsd).toBeCloseTo(1500 / 1e6 + (600 * 5) / 1e6, 8);
+    expect(row.latencyMs).toBeGreaterThanOrEqual(0);
+    expect(row.metadata).toMatchObject({
+      prompt_version: 'web-llm-v0.1',
+      url: 'https://example.com/recipe',
+    });
+    expect(row.metadata).not.toHaveProperty('cost_missing');
+    expect(row.metadata).not.toHaveProperty('usage_missing');
+  });
+
+  it('logs an error row + rethrows when the underlying call throws', async () => {
+    await expect(
+      callClaudeWithLogging(
+        {
+          operation: 'recipe-extract-ig-vision',
+          contextId: 'ingest_source:7',
+          model: 'claude-haiku-4-5-20251001',
+          promptVersion: 'ig-vision-v0.1',
+          call: async () => {
+            throw new Error('Anthropic 529 overloaded');
+          },
+        },
+        {
+          log: logFnFor(sink),
+          lookupPricing: () => claudePricing,
+        }
+      )
+    ).rejects.toThrow('Anthropic 529 overloaded');
+
+    expect(sink.rows).toHaveLength(1);
+    const row = sink.rows[0]!;
+    expect(row.status).toBe('error');
+    expect(row.errorMessage).toBe('Anthropic 529 overloaded');
+    expect(row.inputTokens).toBe(0);
+    expect(row.outputTokens).toBe(0);
+    expect(row.costUsd).toBe(0);
+  });
+
+  it('flags usage_missing in metadata when both token counts are zero', async () => {
+    await callClaudeWithLogging(
+      {
+        operation: 'recipe-extract-screenshot',
+        contextId: 'ingest_source:1',
+        model: 'claude-haiku-4-5-20251001',
+        promptVersion: 'screenshot-v0.1',
+        call: async () => ({
+          response: { dsl: '' },
+          usage: { inputTokens: 0, outputTokens: 0 },
+        }),
+      },
+      {
+        log: logFnFor(sink),
+        lookupPricing: () => claudePricing,
+      }
+    );
+
+    const row = sink.rows[0]!;
+    expect(row.metadata).toMatchObject({ usage_missing: true });
+  });
+
+  it('flags cost_missing when the pricing lookup returns null', async () => {
+    await callClaudeWithLogging(
+      {
+        operation: 'recipe-extract-text',
+        contextId: 'ingest_source:2',
+        model: 'claude-future-unknown',
+        promptVersion: 'text-v0.1',
+        call: async () => ({
+          response: { dsl: '@recipe("bar", "Bar")' },
+          usage: { inputTokens: 500, outputTokens: 300 },
+        }),
+      },
+      {
+        log: logFnFor(sink),
+        lookupPricing: () => null,
+      }
+    );
+
+    const row = sink.rows[0]!;
+    expect(row.costUsd).toBe(0);
+    expect(row.metadata).toMatchObject({ cost_missing: true });
+  });
+
+  it('swallows log-sink failures without affecting the caller', async () => {
+    sink.shouldFail = true;
+    const warn = vi.fn();
+
+    const response = await callClaudeWithLogging<{ ok: true }>(
+      {
+        operation: 'recipe-extract-text',
+        contextId: 'ingest_source:3',
+        model: 'claude-haiku-4-5-20251001',
+        promptVersion: 'text-v0.1',
+        call: async () => ({
+          response: { ok: true },
+          usage: { inputTokens: 100, outputTokens: 200 },
+        }),
+      },
+      {
+        log: logFnFor(sink),
+        lookupPricing: () => claudePricing,
+        warn,
+      }
+    );
+
+    expect(response).toEqual({ ok: true });
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]?.[0]).toContain('logFoodInference failed');
+  });
+
+  it('awaits an async pricing lookup', async () => {
+    await callClaudeWithLogging(
+      {
+        operation: 'recipe-extract-web-llm',
+        contextId: 'ingest_source:99',
+        model: 'claude-haiku-4-5-20251001',
+        promptVersion: 'web-llm-v0.1',
+        call: async () => ({
+          response: { dsl: '' },
+          usage: { inputTokens: 100, outputTokens: 100 },
+        }),
+      },
+      {
+        log: logFnFor(sink),
+        lookupPricing: async () => claudePricing,
+      }
+    );
+
+    const row = sink.rows[0]!;
+    expect(row.costUsd).toBeCloseTo(100 / 1e6 + (100 * 5) / 1e6, 8);
+  });
+});

--- a/packages/app-food/src/ai/__tests__/prompt-registry.test.ts
+++ b/packages/app-food/src/ai/__tests__/prompt-registry.test.ts
@@ -1,0 +1,59 @@
+/**
+ * PRD-133 — drift catcher for the prompt registry.
+ *
+ * Asserts that every `PROMPT_VERSION_*` constant exported from
+ * `packages/app-food/src/prompts/` is referenced by an entry in
+ * `FOOD_PROMPTS`. If a new prompt template ships without a registry
+ * entry, this test fails — the viewer would otherwise silently omit
+ * it.
+ */
+import { describe, expect, it } from 'vitest';
+
+import * as igVision from '../../prompts/ig-vision.js';
+import * as screenshot from '../../prompts/screenshot.js';
+import * as text from '../../prompts/text.js';
+import * as webLlm from '../../prompts/web-llm.js';
+import { FOOD_PROMPTS } from '../prompt-registry.js';
+
+function collectVersionExports(mod: Record<string, unknown>): string[] {
+  return Object.entries(mod)
+    .filter(([k, v]) => k.startsWith('PROMPT_VERSION_') && typeof v === 'string')
+    .map(([, v]) => v as string);
+}
+
+describe('PRD-133 — FOOD_PROMPTS registry', () => {
+  it('includes every PROMPT_VERSION_* constant from packages/app-food/src/prompts/', () => {
+    const allVersions = [
+      ...collectVersionExports(webLlm),
+      ...collectVersionExports(igVision),
+      ...collectVersionExports(screenshot),
+      ...collectVersionExports(text),
+    ].toSorted();
+
+    const registered = FOOD_PROMPTS.map((p) => p.version).toSorted();
+
+    expect(registered).toEqual(allVersions);
+  });
+
+  it('uses unique ids per entry', () => {
+    const ids = FOOD_PROMPTS.map((p) => p.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('uses unique versions per entry', () => {
+    const versions = FOOD_PROMPTS.map((p) => p.version);
+    expect(new Set(versions).size).toBe(versions.length);
+  });
+
+  it('attributes every entry to a PRD-1xx string', () => {
+    for (const entry of FOOD_PROMPTS) {
+      expect(entry.prd).toMatch(/^PRD-1\d{2}$/);
+    }
+  });
+
+  it('includes a non-empty template per entry', () => {
+    for (const entry of FOOD_PROMPTS) {
+      expect(entry.template.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/packages/app-food/src/ai/__tests__/prompt-registry.test.ts
+++ b/packages/app-food/src/ai/__tests__/prompt-registry.test.ts
@@ -1,37 +1,38 @@
 /**
  * PRD-133 — drift catcher for the prompt registry.
  *
- * Asserts that every `PROMPT_VERSION_*` constant exported from
- * `packages/app-food/src/prompts/` is referenced by an entry in
- * `FOOD_PROMPTS`. If a new prompt template ships without a registry
- * entry, this test fails — the viewer would otherwise silently omit
- * it.
+ * Discovers every module under `packages/app-food/src/prompts/` at
+ * runtime via `import.meta.glob` so adding a new prompt file forces
+ * the author to register it in `FOOD_PROMPTS` — no editing this test.
  */
 import { describe, expect, it } from 'vitest';
 
-import * as igVision from '../../prompts/ig-vision.js';
-import * as screenshot from '../../prompts/screenshot.js';
-import * as text from '../../prompts/text.js';
-import * as webLlm from '../../prompts/web-llm.js';
 import { FOOD_PROMPTS } from '../prompt-registry.js';
 
-function collectVersionExports(mod: Record<string, unknown>): string[] {
-  return Object.entries(mod)
-    .filter(([k, v]) => k.startsWith('PROMPT_VERSION_') && typeof v === 'string')
-    .map(([, v]) => v as string);
+const promptModules = import.meta.glob<Record<string, unknown>>('../../prompts/*.ts', {
+  eager: true,
+});
+
+function collectVersionExports(): string[] {
+  const versions: string[] = [];
+  for (const mod of Object.values(promptModules)) {
+    for (const [key, value] of Object.entries(mod)) {
+      if (key.startsWith('PROMPT_VERSION_') && typeof value === 'string') {
+        versions.push(value);
+      }
+    }
+  }
+  return versions;
 }
 
 describe('PRD-133 — FOOD_PROMPTS registry', () => {
-  it('includes every PROMPT_VERSION_* constant from packages/app-food/src/prompts/', () => {
-    const allVersions = [
-      ...collectVersionExports(webLlm),
-      ...collectVersionExports(igVision),
-      ...collectVersionExports(screenshot),
-      ...collectVersionExports(text),
-    ].toSorted();
+  it('discovers at least one prompt module under src/prompts/', () => {
+    expect(Object.keys(promptModules).length).toBeGreaterThan(0);
+  });
 
+  it('includes every PROMPT_VERSION_* constant exported from src/prompts/', () => {
+    const allVersions = collectVersionExports().toSorted();
     const registered = FOOD_PROMPTS.map((p) => p.version).toSorted();
-
     expect(registered).toEqual(allVersions);
   });
 

--- a/packages/app-food/src/ai/log-inference-sink.ts
+++ b/packages/app-food/src/ai/log-inference-sink.ts
@@ -1,0 +1,41 @@
+/**
+ * PRD-133 — default sink for `food.ai.logInference`.
+ *
+ * Lives in its own file so `log-inference.ts` stays under the
+ * per-file line cap. The wrapper imports this as the default value
+ * for `deps.log`; tests and other callers can inject their own.
+ *
+ * Behaviour: POSTs the row to the `food.ai.logInference` tRPC
+ * mutation when `POPS_API_URL` + `POPS_API_INTERNAL_TOKEN` are
+ * configured. Otherwise no-ops (browser, dev, vitest). Throws on
+ * non-2xx — the wrapper catches and routes the error to `warn`.
+ */
+import type { LogFoodInferenceFn } from './log-inference-types.js';
+
+function readEnvFromProcess(name: string): string | undefined {
+  if (typeof process === 'undefined') return undefined;
+  const env = process.env;
+  if (!env) return undefined;
+  const value = env[name];
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+export const logFoodInference: LogFoodInferenceFn = async (input) => {
+  const apiUrl = readEnvFromProcess('POPS_API_URL');
+  const token = readEnvFromProcess('POPS_API_INTERNAL_TOKEN');
+  if (!apiUrl || !token) return;
+  if (typeof globalThis.fetch !== 'function') return;
+
+  const url = `${apiUrl.replace(/\/+$/, '')}/trpc/food.ai.logInference`;
+  const res = await globalThis.fetch(url, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-pops-internal-token': token,
+    },
+    body: JSON.stringify({ json: input }),
+  });
+  if (!res.ok) {
+    throw new Error(`food.ai.logInference returned HTTP ${res.status}`);
+  }
+};

--- a/packages/app-food/src/ai/log-inference-types.ts
+++ b/packages/app-food/src/ai/log-inference-types.ts
@@ -1,0 +1,81 @@
+/**
+ * PRD-133 — shared types for `log-inference.ts` and its sink.
+ *
+ * Kept separate so the wrapper and the default sink can both depend
+ * on these without creating a circular import.
+ */
+export type FoodOperation =
+  | 'recipe-extract-web-llm'
+  | 'recipe-extract-ig-vision'
+  | 'recipe-extract-ig-text-fallback'
+  | 'recipe-extract-screenshot'
+  | 'recipe-extract-text';
+
+export interface LogFoodInferenceInput {
+  operation: FoodOperation;
+  contextId: string;
+  provider: 'claude';
+  model: string;
+  promptVersion: string;
+  inputTokens: number;
+  outputTokens: number;
+  costUsd: number;
+  latencyMs: number;
+  status: 'success' | 'error';
+  cached: boolean;
+  errorMessage?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export type LogFoodInferenceFn = (input: LogFoodInferenceInput) => Promise<void>;
+
+export interface ClaudeUsage {
+  inputTokens: number;
+  outputTokens: number;
+}
+
+export interface ClaudeCallResult<T> {
+  response: T;
+  usage: ClaudeUsage;
+}
+
+export interface PricingEntry {
+  /** Cost per million input tokens, USD. */
+  input: number;
+  /** Cost per million output tokens, USD. */
+  output: number;
+}
+
+export type LookupPricingFn = (
+  provider: 'claude',
+  model: string
+) => Promise<PricingEntry | null> | (PricingEntry | null);
+
+export interface CallClaudeWithLoggingOpts<T> {
+  operation: FoodOperation;
+  contextId: string;
+  model: string;
+  promptVersion: string;
+  call: () => Promise<ClaudeCallResult<T>>;
+  /** Additional fields merged into the logged `metadata` JSON. */
+  metadata?: Record<string, unknown>;
+  /**
+   * Per-call cost cap in USD. When the computed costUsd exceeds it the
+   * wrapper flags `metadata.over_cost_cap = true` and warns. Defaults
+   * to `FOOD_INGEST_COST_CAP_PER_JOB_USD` env var (when present) or
+   * 0.05 USD per PRD-126's compose default.
+   */
+  costCapUsd?: number;
+}
+
+export interface CallClaudeWithLoggingDeps {
+  /** Defaults to `logFoodInference` (env-driven POST to the mutation). */
+  log?: LogFoodInferenceFn;
+  lookupPricing: LookupPricingFn;
+  /**
+   * Optional warn hook for log-sink errors. Defaults to `console.warn`.
+   * Lets the worker route to its structured logger and lets tests
+   * silence noise without monkey-patching `console`.
+   */
+  warn?: (message: string, err: unknown) => void;
+}

--- a/packages/app-food/src/ai/log-inference.ts
+++ b/packages/app-food/src/ai/log-inference.ts
@@ -2,23 +2,30 @@
  * PRD-133 — AI usage logging helpers for the food ingestion pipeline.
  *
  * Exports the types + the `callClaudeWithLogging` wrapper that every
- * food handler in PRDs 127-132 funnels through. The actual log sink is
- * passed in by the caller — the worker (PRD-126) will provide an impl
- * that POSTs to the `food.ai.logInference` tRPC mutation; tests provide
- * a fake. Keeping the sink injectable avoids dragging fetch/axios into
- * `@pops/app-food` and lets the wrapper stay isomorphic.
+ * food handler in PRDs 127-132 funnels through, plus the canonical
+ * `logFoodInference` sink (POSTs to the `food.ai.logInference` tRPC
+ * mutation when `POPS_API_URL` + `POPS_API_INTERNAL_TOKEN` are set;
+ * no-ops otherwise). The sink is injectable so tests pass a fake and
+ * the wrapper stays isomorphic.
  *
  * Behaviour:
  *
  *   1. Records start time, awaits `opts.call()`.
- *   2. On success: looks up pricing via `opts.lookupPricing`, computes
- *      `costUsd`, calls `log({ ..., status: 'success' })`. Missing
- *      pricing → cost = 0 with `metadata.cost_missing = true`.
- *   3. On error: still calls `log({ ..., status: 'error', errorMessage })`,
- *      then rethrows.
- *   4. Logging is fire-and-forget — log failures are swallowed (a
- *      logging hiccup must never block a recipe ingest).
+ *   2. On success: looks up pricing via `deps.lookupPricing`, computes
+ *      `costUsd`, evaluates the cost cap, then schedules a log row
+ *      with `status: 'success'`. Missing pricing → cost = 0 +
+ *      `metadata.cost_missing = true`. costUsd above the cap →
+ *      `metadata.over_cost_cap = true` + console warn (v1 does NOT
+ *      abort the call).
+ *   3. On error: schedules a log row with `status: 'error' +
+ *      errorMessage`, then rethrows.
+ *   4. Logging is fire-and-forget — the caller never awaits the sink,
+ *      so a slow / failing sink can never delay or fail an ingest.
+ *      Tests flush the microtask queue before asserting log state.
  */
+
+const DEFAULT_FOOD_INGEST_COST_CAP_USD = 0.05;
+
 export type FoodOperation =
   | 'recipe-extract-web-llm'
   | 'recipe-extract-ig-vision'
@@ -74,10 +81,18 @@ export interface CallClaudeWithLoggingOpts<T> {
   call: () => Promise<ClaudeCallResult<T>>;
   /** Additional fields merged into the logged `metadata` JSON. */
   metadata?: Record<string, unknown>;
+  /**
+   * Per-call cost cap in USD. When the computed costUsd exceeds it the
+   * wrapper flags `metadata.over_cost_cap = true` and warns. Defaults
+   * to `FOOD_INGEST_COST_CAP_PER_JOB_USD` env var (when present) or
+   * 0.05 USD per PRD-126's compose default.
+   */
+  costCapUsd?: number;
 }
 
 export interface CallClaudeWithLoggingDeps {
-  log: LogFoodInferenceFn;
+  /** Defaults to `logFoodInference` (env-driven POST to the mutation). */
+  log?: LogFoodInferenceFn;
   lookupPricing: LookupPricingFn;
   /**
    * Optional warn hook for log-sink errors. Defaults to `console.warn`.
@@ -103,20 +118,127 @@ export function computeCostUsd(
   return { costUsd, missing: false };
 }
 
-async function safeLog(
-  log: LogFoodInferenceFn,
-  warn: (message: string, err: unknown) => void,
-  input: LogFoodInferenceInput
-): Promise<void> {
-  try {
-    await log(input);
-  } catch (err) {
-    warn('[food/ai] logFoodInference failed; continuing', err);
+function readEnv(name: string): string | undefined {
+  if (typeof process === 'undefined') return undefined;
+  const env = process.env;
+  if (!env) return undefined;
+  const value = env[name];
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function resolveCostCap(opt: number | undefined): number {
+  if (typeof opt === 'number' && Number.isFinite(opt) && opt > 0) return opt;
+  const envValue = readEnv('FOOD_INGEST_COST_CAP_PER_JOB_USD');
+  if (envValue !== undefined) {
+    const parsed = Number(envValue);
+    if (Number.isFinite(parsed) && parsed > 0) return parsed;
   }
+  return DEFAULT_FOOD_INGEST_COST_CAP_USD;
 }
 
 function defaultWarn(message: string, err: unknown): void {
   console.warn(message, err);
+}
+
+/**
+ * Default sink: POSTs the row to `food.ai.logInference` when
+ * `POPS_API_URL` + `POPS_API_INTERNAL_TOKEN` are configured (worker /
+ * sibling-process env). No-ops in browser / dev / tests where the
+ * env is unset — the caller can still inject `deps.log` to override.
+ */
+export const logFoodInference: LogFoodInferenceFn = async (input) => {
+  const apiUrl = readEnv('POPS_API_URL');
+  const token = readEnv('POPS_API_INTERNAL_TOKEN');
+  if (!apiUrl || !token) return;
+  if (typeof globalThis.fetch !== 'function') return;
+
+  const url = `${apiUrl.replace(/\/+$/, '')}/trpc/food.ai.logInference`;
+  const res = await globalThis.fetch(url, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-pops-internal-token': token,
+    },
+    body: JSON.stringify({ json: input }),
+  });
+  if (!res.ok) {
+    throw new Error(`food.ai.logInference returned HTTP ${res.status}`);
+  }
+};
+
+/**
+ * Schedule a log write as a detached promise. The caller never awaits
+ * this — that's the whole point of fire-and-forget. Errors from the
+ * sink land on `warn` so they show up in operator logs without
+ * affecting the caller's control flow.
+ */
+function scheduleLog(
+  log: LogFoodInferenceFn,
+  warn: (message: string, err: unknown) => void,
+  input: LogFoodInferenceInput
+): void {
+  Promise.resolve()
+    .then(() => log(input))
+    .catch((err: unknown) => warn('[food/ai] logFoodInference failed; continuing', err));
+}
+
+function buildErrorRow<T>(
+  opts: CallClaudeWithLoggingOpts<T>,
+  err: unknown,
+  latencyMs: number
+): LogFoodInferenceInput {
+  const errorMessage = err instanceof Error ? err.message : String(err);
+  return {
+    operation: opts.operation,
+    contextId: opts.contextId,
+    provider: 'claude',
+    model: opts.model,
+    promptVersion: opts.promptVersion,
+    inputTokens: 0,
+    outputTokens: 0,
+    costUsd: 0,
+    latencyMs,
+    status: 'error',
+    cached: false,
+    errorMessage: errorMessage.slice(0, 1000),
+    metadata: { ...opts.metadata, prompt_version: opts.promptVersion },
+  };
+}
+
+interface SuccessFlags {
+  costUsd: number;
+  costMissing: boolean;
+  usageMissing: boolean;
+  overCostCap: boolean;
+}
+
+function buildSuccessRow<T>(
+  opts: CallClaudeWithLoggingOpts<T>,
+  usage: ClaudeUsage,
+  flags: SuccessFlags,
+  latencyMs: number
+): LogFoodInferenceInput {
+  const metadata: Record<string, unknown> = {
+    ...opts.metadata,
+    prompt_version: opts.promptVersion,
+  };
+  if (flags.costMissing) metadata['cost_missing'] = true;
+  if (flags.usageMissing) metadata['usage_missing'] = true;
+  if (flags.overCostCap) metadata['over_cost_cap'] = true;
+  return {
+    operation: opts.operation,
+    contextId: opts.contextId,
+    provider: 'claude',
+    model: opts.model,
+    promptVersion: opts.promptVersion,
+    inputTokens: usage.inputTokens,
+    outputTokens: usage.outputTokens,
+    costUsd: flags.costUsd,
+    latencyMs,
+    status: 'success',
+    cached: false,
+    metadata,
+  };
 }
 
 export async function callClaudeWithLogging<T>(
@@ -124,29 +246,15 @@ export async function callClaudeWithLogging<T>(
   deps: CallClaudeWithLoggingDeps
 ): Promise<T> {
   const warn = deps.warn ?? defaultWarn;
+  const log = deps.log ?? logFoodInference;
+  const costCap = resolveCostCap(opts.costCapUsd);
   const start = Date.now();
 
   let result: ClaudeCallResult<T>;
   try {
     result = await opts.call();
   } catch (err) {
-    const latencyMs = Date.now() - start;
-    const errorMessage = err instanceof Error ? err.message : String(err);
-    await safeLog(deps.log, warn, {
-      operation: opts.operation,
-      contextId: opts.contextId,
-      provider: 'claude',
-      model: opts.model,
-      promptVersion: opts.promptVersion,
-      inputTokens: 0,
-      outputTokens: 0,
-      costUsd: 0,
-      latencyMs,
-      status: 'error',
-      cached: false,
-      errorMessage: errorMessage.slice(0, 1000),
-      metadata: { prompt_version: opts.promptVersion, ...opts.metadata },
-    });
+    scheduleLog(log, warn, buildErrorRow(opts, err, Date.now() - start));
     throw err;
   }
 
@@ -156,35 +264,24 @@ export async function callClaudeWithLogging<T>(
 
   const pricing = await deps.lookupPricing('claude', opts.model);
   const { costUsd, missing: costMissing } = computeCostUsd(inputTokens, outputTokens, pricing);
+  const overCostCap = !costMissing && costUsd > costCap;
+  if (overCostCap) {
+    warn(
+      `[food/ai] ${opts.operation} cost $${costUsd.toFixed(6)} exceeds cap $${costCap.toFixed(6)} (over_cost_cap=true logged; call not aborted in v1)`,
+      undefined
+    );
+  }
 
-  const metadata: Record<string, unknown> = {
-    prompt_version: opts.promptVersion,
-    ...opts.metadata,
-  };
-  if (costMissing) metadata['cost_missing'] = true;
-  if (usageMissing) metadata['usage_missing'] = true;
-
-  await safeLog(deps.log, warn, {
-    operation: opts.operation,
-    contextId: opts.contextId,
-    provider: 'claude',
-    model: opts.model,
-    promptVersion: opts.promptVersion,
-    inputTokens,
-    outputTokens,
-    costUsd,
-    latencyMs,
-    status: 'success',
-    cached: false,
-    metadata,
-  });
+  scheduleLog(
+    log,
+    warn,
+    buildSuccessRow(
+      opts,
+      result.usage,
+      { costUsd, costMissing, usageMissing, overCostCap },
+      latencyMs
+    )
+  );
 
   return result.response;
 }
-
-/**
- * Default no-op sink. Replaced by the worker (PRD-126) with a `fetch`
- * call to `food.ai.logInference`. Kept here so callers in tests that
- * don't care about the sink can construct an instance without wiring.
- */
-export const noopLogFoodInference: LogFoodInferenceFn = async () => {};

--- a/packages/app-food/src/ai/log-inference.ts
+++ b/packages/app-food/src/ai/log-inference.ts
@@ -1,0 +1,190 @@
+/**
+ * PRD-133 — AI usage logging helpers for the food ingestion pipeline.
+ *
+ * Exports the types + the `callClaudeWithLogging` wrapper that every
+ * food handler in PRDs 127-132 funnels through. The actual log sink is
+ * passed in by the caller — the worker (PRD-126) will provide an impl
+ * that POSTs to the `food.ai.logInference` tRPC mutation; tests provide
+ * a fake. Keeping the sink injectable avoids dragging fetch/axios into
+ * `@pops/app-food` and lets the wrapper stay isomorphic.
+ *
+ * Behaviour:
+ *
+ *   1. Records start time, awaits `opts.call()`.
+ *   2. On success: looks up pricing via `opts.lookupPricing`, computes
+ *      `costUsd`, calls `log({ ..., status: 'success' })`. Missing
+ *      pricing → cost = 0 with `metadata.cost_missing = true`.
+ *   3. On error: still calls `log({ ..., status: 'error', errorMessage })`,
+ *      then rethrows.
+ *   4. Logging is fire-and-forget — log failures are swallowed (a
+ *      logging hiccup must never block a recipe ingest).
+ */
+export type FoodOperation =
+  | 'recipe-extract-web-llm'
+  | 'recipe-extract-ig-vision'
+  | 'recipe-extract-ig-text-fallback'
+  | 'recipe-extract-screenshot'
+  | 'recipe-extract-text';
+
+export interface LogFoodInferenceInput {
+  operation: FoodOperation;
+  contextId: string;
+  provider: 'claude';
+  model: string;
+  promptVersion: string;
+  inputTokens: number;
+  outputTokens: number;
+  costUsd: number;
+  latencyMs: number;
+  status: 'success' | 'error';
+  cached: boolean;
+  errorMessage?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export type LogFoodInferenceFn = (input: LogFoodInferenceInput) => Promise<void>;
+
+export interface ClaudeUsage {
+  inputTokens: number;
+  outputTokens: number;
+}
+
+export interface ClaudeCallResult<T> {
+  response: T;
+  usage: ClaudeUsage;
+}
+
+export interface PricingEntry {
+  /** Cost per million input tokens, USD. */
+  input: number;
+  /** Cost per million output tokens, USD. */
+  output: number;
+}
+
+export type LookupPricingFn = (
+  provider: 'claude',
+  model: string
+) => Promise<PricingEntry | null> | (PricingEntry | null);
+
+export interface CallClaudeWithLoggingOpts<T> {
+  operation: FoodOperation;
+  contextId: string;
+  model: string;
+  promptVersion: string;
+  call: () => Promise<ClaudeCallResult<T>>;
+  /** Additional fields merged into the logged `metadata` JSON. */
+  metadata?: Record<string, unknown>;
+}
+
+export interface CallClaudeWithLoggingDeps {
+  log: LogFoodInferenceFn;
+  lookupPricing: LookupPricingFn;
+  /**
+   * Optional warn hook for log-sink errors. Defaults to `console.warn`.
+   * Lets the worker route to its structured logger and lets tests
+   * silence noise without monkey-patching `console`.
+   */
+  warn?: (message: string, err: unknown) => void;
+}
+
+/**
+ * Computes `costUsd` from token counts. Returns `cost = 0` and
+ * `missing = true` when no pricing entry is supplied — caller writes
+ * that flag into `metadata.cost_missing`.
+ */
+export function computeCostUsd(
+  inputTokens: number,
+  outputTokens: number,
+  pricing: PricingEntry | null
+): { costUsd: number; missing: boolean } {
+  if (!pricing) return { costUsd: 0, missing: true };
+  const costUsd =
+    (inputTokens * pricing.input) / 1_000_000 + (outputTokens * pricing.output) / 1_000_000;
+  return { costUsd, missing: false };
+}
+
+async function safeLog(
+  log: LogFoodInferenceFn,
+  warn: (message: string, err: unknown) => void,
+  input: LogFoodInferenceInput
+): Promise<void> {
+  try {
+    await log(input);
+  } catch (err) {
+    warn('[food/ai] logFoodInference failed; continuing', err);
+  }
+}
+
+function defaultWarn(message: string, err: unknown): void {
+  console.warn(message, err);
+}
+
+export async function callClaudeWithLogging<T>(
+  opts: CallClaudeWithLoggingOpts<T>,
+  deps: CallClaudeWithLoggingDeps
+): Promise<T> {
+  const warn = deps.warn ?? defaultWarn;
+  const start = Date.now();
+
+  let result: ClaudeCallResult<T>;
+  try {
+    result = await opts.call();
+  } catch (err) {
+    const latencyMs = Date.now() - start;
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    await safeLog(deps.log, warn, {
+      operation: opts.operation,
+      contextId: opts.contextId,
+      provider: 'claude',
+      model: opts.model,
+      promptVersion: opts.promptVersion,
+      inputTokens: 0,
+      outputTokens: 0,
+      costUsd: 0,
+      latencyMs,
+      status: 'error',
+      cached: false,
+      errorMessage: errorMessage.slice(0, 1000),
+      metadata: { prompt_version: opts.promptVersion, ...opts.metadata },
+    });
+    throw err;
+  }
+
+  const latencyMs = Date.now() - start;
+  const { inputTokens, outputTokens } = result.usage;
+  const usageMissing = inputTokens === 0 && outputTokens === 0;
+
+  const pricing = await deps.lookupPricing('claude', opts.model);
+  const { costUsd, missing: costMissing } = computeCostUsd(inputTokens, outputTokens, pricing);
+
+  const metadata: Record<string, unknown> = {
+    prompt_version: opts.promptVersion,
+    ...opts.metadata,
+  };
+  if (costMissing) metadata['cost_missing'] = true;
+  if (usageMissing) metadata['usage_missing'] = true;
+
+  await safeLog(deps.log, warn, {
+    operation: opts.operation,
+    contextId: opts.contextId,
+    provider: 'claude',
+    model: opts.model,
+    promptVersion: opts.promptVersion,
+    inputTokens,
+    outputTokens,
+    costUsd,
+    latencyMs,
+    status: 'success',
+    cached: false,
+    metadata,
+  });
+
+  return result.response;
+}
+
+/**
+ * Default no-op sink. Replaced by the worker (PRD-126) with a `fetch`
+ * call to `food.ai.logInference`. Kept here so callers in tests that
+ * don't care about the sink can construct an instance without wiring.
+ */
+export const noopLogFoodInference: LogFoodInferenceFn = async () => {};

--- a/packages/app-food/src/ai/log-inference.ts
+++ b/packages/app-food/src/ai/log-inference.ts
@@ -1,112 +1,44 @@
 /**
- * PRD-133 — AI usage logging helpers for the food ingestion pipeline.
+ * PRD-133 — `callClaudeWithLogging` wrapper.
  *
- * Exports the types + the `callClaudeWithLogging` wrapper that every
- * food handler in PRDs 127-132 funnels through, plus the canonical
- * `logFoodInference` sink (POSTs to the `food.ai.logInference` tRPC
- * mutation when `POPS_API_URL` + `POPS_API_INTERNAL_TOKEN` are set;
- * no-ops otherwise). The sink is injectable so tests pass a fake and
- * the wrapper stays isomorphic.
+ * Funnels every food handler's Claude call through one place that
+ * measures latency, computes cost, evaluates the per-call cost cap,
+ * and routes a row to the (injectable) log sink. Logging is
+ * fire-and-forget — the wrapper returns immediately after `opts.call()`
+ * resolves; a slow or failing sink can never delay or fail an ingest.
  *
- * Behaviour:
- *
- *   1. Records start time, awaits `opts.call()`.
- *   2. On success: looks up pricing via `deps.lookupPricing`, computes
- *      `costUsd`, evaluates the cost cap, then schedules a log row
- *      with `status: 'success'`. Missing pricing → cost = 0 +
- *      `metadata.cost_missing = true`. costUsd above the cap →
- *      `metadata.over_cost_cap = true` + console warn (v1 does NOT
- *      abort the call).
- *   3. On error: schedules a log row with `status: 'error' +
- *      errorMessage`, then rethrows.
- *   4. Logging is fire-and-forget — the caller never awaits the sink,
- *      so a slow / failing sink can never delay or fail an ingest.
- *      Tests flush the microtask queue before asserting log state.
+ * Types live in `log-inference-types.ts`; the default env-driven sink
+ * lives in `log-inference-sink.ts` and is re-exported here so the
+ * documented entrypoint stays `@pops/app-food/src/ai/log-inference`.
  */
+import { logFoodInference } from './log-inference-sink.js';
+
+import type {
+  CallClaudeWithLoggingDeps,
+  CallClaudeWithLoggingOpts,
+  ClaudeCallResult,
+  ClaudeUsage,
+  LogFoodInferenceFn,
+  LogFoodInferenceInput,
+  PricingEntry,
+} from './log-inference-types.js';
+
+export type {
+  CallClaudeWithLoggingDeps,
+  CallClaudeWithLoggingOpts,
+  ClaudeCallResult,
+  ClaudeUsage,
+  FoodOperation,
+  LogFoodInferenceFn,
+  LogFoodInferenceInput,
+  LookupPricingFn,
+  PricingEntry,
+} from './log-inference-types.js';
+
+export { logFoodInference };
 
 const DEFAULT_FOOD_INGEST_COST_CAP_USD = 0.05;
 
-export type FoodOperation =
-  | 'recipe-extract-web-llm'
-  | 'recipe-extract-ig-vision'
-  | 'recipe-extract-ig-text-fallback'
-  | 'recipe-extract-screenshot'
-  | 'recipe-extract-text';
-
-export interface LogFoodInferenceInput {
-  operation: FoodOperation;
-  contextId: string;
-  provider: 'claude';
-  model: string;
-  promptVersion: string;
-  inputTokens: number;
-  outputTokens: number;
-  costUsd: number;
-  latencyMs: number;
-  status: 'success' | 'error';
-  cached: boolean;
-  errorMessage?: string;
-  metadata?: Record<string, unknown>;
-}
-
-export type LogFoodInferenceFn = (input: LogFoodInferenceInput) => Promise<void>;
-
-export interface ClaudeUsage {
-  inputTokens: number;
-  outputTokens: number;
-}
-
-export interface ClaudeCallResult<T> {
-  response: T;
-  usage: ClaudeUsage;
-}
-
-export interface PricingEntry {
-  /** Cost per million input tokens, USD. */
-  input: number;
-  /** Cost per million output tokens, USD. */
-  output: number;
-}
-
-export type LookupPricingFn = (
-  provider: 'claude',
-  model: string
-) => Promise<PricingEntry | null> | (PricingEntry | null);
-
-export interface CallClaudeWithLoggingOpts<T> {
-  operation: FoodOperation;
-  contextId: string;
-  model: string;
-  promptVersion: string;
-  call: () => Promise<ClaudeCallResult<T>>;
-  /** Additional fields merged into the logged `metadata` JSON. */
-  metadata?: Record<string, unknown>;
-  /**
-   * Per-call cost cap in USD. When the computed costUsd exceeds it the
-   * wrapper flags `metadata.over_cost_cap = true` and warns. Defaults
-   * to `FOOD_INGEST_COST_CAP_PER_JOB_USD` env var (when present) or
-   * 0.05 USD per PRD-126's compose default.
-   */
-  costCapUsd?: number;
-}
-
-export interface CallClaudeWithLoggingDeps {
-  /** Defaults to `logFoodInference` (env-driven POST to the mutation). */
-  log?: LogFoodInferenceFn;
-  lookupPricing: LookupPricingFn;
-  /**
-   * Optional warn hook for log-sink errors. Defaults to `console.warn`.
-   * Lets the worker route to its structured logger and lets tests
-   * silence noise without monkey-patching `console`.
-   */
-  warn?: (message: string, err: unknown) => void;
-}
-
-/**
- * Computes `costUsd` from token counts. Returns `cost = 0` and
- * `missing = true` when no pricing entry is supplied — caller writes
- * that flag into `metadata.cost_missing`.
- */
 export function computeCostUsd(
   inputTokens: number,
   outputTokens: number,
@@ -140,38 +72,6 @@ function defaultWarn(message: string, err: unknown): void {
   console.warn(message, err);
 }
 
-/**
- * Default sink: POSTs the row to `food.ai.logInference` when
- * `POPS_API_URL` + `POPS_API_INTERNAL_TOKEN` are configured (worker /
- * sibling-process env). No-ops in browser / dev / tests where the
- * env is unset — the caller can still inject `deps.log` to override.
- */
-export const logFoodInference: LogFoodInferenceFn = async (input) => {
-  const apiUrl = readEnv('POPS_API_URL');
-  const token = readEnv('POPS_API_INTERNAL_TOKEN');
-  if (!apiUrl || !token) return;
-  if (typeof globalThis.fetch !== 'function') return;
-
-  const url = `${apiUrl.replace(/\/+$/, '')}/trpc/food.ai.logInference`;
-  const res = await globalThis.fetch(url, {
-    method: 'POST',
-    headers: {
-      'content-type': 'application/json',
-      'x-pops-internal-token': token,
-    },
-    body: JSON.stringify({ json: input }),
-  });
-  if (!res.ok) {
-    throw new Error(`food.ai.logInference returned HTTP ${res.status}`);
-  }
-};
-
-/**
- * Schedule a log write as a detached promise. The caller never awaits
- * this — that's the whole point of fire-and-forget. Errors from the
- * sink land on `warn` so they show up in operator logs without
- * affecting the caller's control flow.
- */
 function scheduleLog(
   log: LogFoodInferenceFn,
   warn: (message: string, err: unknown) => void,

--- a/packages/app-food/src/ai/prompt-registry.ts
+++ b/packages/app-food/src/ai/prompt-registry.ts
@@ -1,0 +1,83 @@
+/**
+ * PRD-133 — Food prompt registry.
+ *
+ * Single source of truth for the read-only `/food/prompts` viewer. Each
+ * entry pins a prompt template + version + owning PRD. The viewer page
+ * renders one card per entry; tests assert every `PROMPT_VERSION_*`
+ * constant exported under `packages/app-food/src/prompts/` is present
+ * here (drift catcher).
+ *
+ * Prompts are defined in code and not editable from the UI. To change
+ * one: edit the constant in `../prompts/`, bump the version string,
+ * deploy.
+ */
+import {
+  PROMPT_IG_VISION,
+  PROMPT_IG_VISION_TEXT_FALLBACK,
+  PROMPT_VERSION_IG_VISION,
+  PROMPT_VERSION_IG_VISION_TEXT_FALLBACK,
+} from '../prompts/ig-vision';
+import { PROMPT_SCREENSHOT, PROMPT_VERSION_SCREENSHOT } from '../prompts/screenshot';
+import { PROMPT_TEXT, PROMPT_VERSION_TEXT } from '../prompts/text';
+import { PROMPT_VERSION_WEB_LLM, PROMPT_WEB_LLM } from '../prompts/web-llm';
+
+export interface FoodPromptEntry {
+  id: string;
+  title: string;
+  description: string;
+  prd: string;
+  model: string;
+  version: string;
+  template: string;
+}
+
+export const FOOD_PROMPTS = [
+  {
+    id: 'web-llm',
+    title: 'Web URL — LLM Fallback Extraction',
+    description: 'Used when JSON-LD recipe markup is absent on a recipe page.',
+    prd: 'PRD-128',
+    model: 'claude-haiku-4-5-20251001 (configurable via FOOD_WEB_LLM_MODEL)',
+    version: PROMPT_VERSION_WEB_LLM,
+    template: PROMPT_WEB_LLM,
+  },
+  {
+    id: 'ig-vision',
+    title: 'Instagram — Vision + Transcript Extraction',
+    description:
+      'Combines caption, faster-whisper transcript, and ffmpeg keyframes for Instagram Reels.',
+    prd: 'PRD-130',
+    model: 'claude-haiku-4-5-20251001 (configurable via FOOD_IG_VISION_MODEL)',
+    version: PROMPT_VERSION_IG_VISION,
+    template: PROMPT_IG_VISION,
+  },
+  {
+    id: 'ig-vision-text-fallback',
+    title: 'Instagram — Text-only Fallback',
+    description: 'Used when the vision call fails; relies on caption + transcript only.',
+    prd: 'PRD-130',
+    model: 'claude-haiku-4-5-20251001 (configurable via FOOD_IG_VISION_MODEL)',
+    version: PROMPT_VERSION_IG_VISION_TEXT_FALLBACK,
+    template: PROMPT_IG_VISION_TEXT_FALLBACK,
+  },
+  {
+    id: 'screenshot',
+    title: 'Screenshot — Single-image Extraction',
+    description: 'Single image (jpg/png/webp) → Claude vision.',
+    prd: 'PRD-131',
+    model: 'claude-haiku-4-5-20251001 (configurable via FOOD_SCREENSHOT_VISION_MODEL)',
+    version: PROMPT_VERSION_SCREENSHOT,
+    template: PROMPT_SCREENSHOT,
+  },
+  {
+    id: 'text',
+    title: 'Text — Paste-to-Recipe',
+    description: 'Operator-pasted text. Supports complete recipes and rough-idea elaboration.',
+    prd: 'PRD-132',
+    model: 'claude-haiku-4-5-20251001 (configurable via FOOD_TEXT_LLM_MODEL)',
+    version: PROMPT_VERSION_TEXT,
+    template: PROMPT_TEXT,
+  },
+] as const satisfies readonly FoodPromptEntry[];
+
+export type FoodPromptId = (typeof FOOD_PROMPTS)[number]['id'];

--- a/packages/app-food/src/pages/PromptViewerPage.stories.tsx
+++ b/packages/app-food/src/pages/PromptViewerPage.stories.tsx
@@ -1,0 +1,51 @@
+/**
+ * PRD-133 — Storybook coverage for the prompt viewer page.
+ *
+ * `apps/pops-storybook/.storybook/main.ts` discovers stories from
+ * `packages/*\/src/**\/*.stories.@(ts|tsx)`, so this file lives next to
+ * the page (same convention `DslEditor.stories.tsx` /
+ * `RecipeRenderer.stories.tsx` adopted).
+ */
+import { createInstance, type i18n as I18n } from 'i18next';
+import { useMemo } from 'react';
+import { I18nextProvider, initReactI18next } from 'react-i18next';
+
+import enAUFood from '../../../../apps/pops-shell/src/i18n/locales/en-AU/food.json';
+import { PromptViewerPage } from './PromptViewerPage';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+function StoryHost() {
+  const i18n = useMemo<I18n>(() => {
+    const instance = createInstance();
+    void instance.use(initReactI18next).init({
+      lng: 'en-AU',
+      fallbackLng: 'en-AU',
+      ns: ['food'],
+      defaultNS: 'food',
+      interpolation: { escapeValue: false },
+      resources: { 'en-AU': { food: enAUFood } },
+    });
+    return instance;
+  }, []);
+
+  return (
+    <I18nextProvider i18n={i18n}>
+      <div className="bg-background min-h-screen">
+        <PromptViewerPage />
+      </div>
+    </I18nextProvider>
+  );
+}
+
+const meta: Meta<typeof StoryHost> = {
+  title: 'Food/PromptViewerPage',
+  component: StoryHost,
+  parameters: { layout: 'fullscreen' },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/packages/app-food/src/pages/PromptViewerPage.tsx
+++ b/packages/app-food/src/pages/PromptViewerPage.tsx
@@ -1,0 +1,66 @@
+/**
+ * PRD-133 — Read-only viewer for the food AI prompt templates.
+ *
+ * Mirrors `@pops/app-finance`'s PromptViewerPage. Renders one card per
+ * entry in `FOOD_PROMPTS`. Operator-facing surface — useful when
+ * iterating on ingest quality without opening the repo.
+ *
+ * To edit a prompt: change the constant in
+ * `packages/app-food/src/prompts/`, bump its version string, deploy.
+ */
+import { useTranslation } from 'react-i18next';
+
+import { PageHeader } from '@pops/ui';
+
+import { FOOD_PROMPTS } from '../ai/prompt-registry';
+
+export function PromptViewerPage() {
+  const { t } = useTranslation('food');
+
+  return (
+    <div className="space-y-6 max-w-3xl p-6">
+      <PageHeader title={t('prompts.title')} description={t('prompts.description')} />
+
+      <p className="text-sm text-muted-foreground">{t('prompts.editingHint')}</p>
+
+      <div className="space-y-8">
+        {FOOD_PROMPTS.map((prompt) => (
+          <article
+            key={prompt.id}
+            className="border rounded-lg overflow-hidden"
+            aria-labelledby={`prompt-${prompt.id}-title`}
+          >
+            <header className="px-4 py-3 bg-muted/30 border-b">
+              <div className="flex items-baseline justify-between gap-2">
+                <h2 id={`prompt-${prompt.id}-title`} className="font-semibold">
+                  {prompt.title}
+                </h2>
+                <span className="text-xs text-muted-foreground font-mono">{prompt.prd}</span>
+              </div>
+              <p className="text-sm text-muted-foreground mt-1">{prompt.description}</p>
+              <dl className="flex flex-wrap items-center gap-x-4 gap-y-1 mt-2 text-xs">
+                <div className="flex items-center gap-2">
+                  <dt className="font-medium text-muted-foreground">{t('prompts.fields.model')}</dt>
+                  <dd>
+                    <code className="bg-muted px-2 py-0.5 rounded font-mono">{prompt.model}</code>
+                  </dd>
+                </div>
+                <div className="flex items-center gap-2">
+                  <dt className="font-medium text-muted-foreground">
+                    {t('prompts.fields.version')}
+                  </dt>
+                  <dd>
+                    <code className="bg-muted px-2 py-0.5 rounded font-mono">{prompt.version}</code>
+                  </dd>
+                </div>
+              </dl>
+            </header>
+            <pre className="p-4 text-sm font-mono whitespace-pre-wrap bg-muted/10 overflow-x-auto">
+              {prompt.template}
+            </pre>
+          </article>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/app-food/src/pages/__tests__/PromptViewerPage.test.tsx
+++ b/packages/app-food/src/pages/__tests__/PromptViewerPage.test.tsx
@@ -1,0 +1,43 @@
+/**
+ * PRD-133 — RTL coverage for the read-only prompt viewer.
+ */
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { FOOD_PROMPTS } from '../../ai/prompt-registry.js';
+import { PromptViewerPage } from '../PromptViewerPage.js';
+
+describe('PRD-133 — PromptViewerPage', () => {
+  it('renders the page header + editing-hint footer text', () => {
+    render(<PromptViewerPage />);
+    expect(
+      screen.getByRole('heading', { name: /prompt templates/i, level: 1 })
+    ).toBeInTheDocument();
+    expect(screen.getByText(/cannot be edited here/i)).toBeInTheDocument();
+  });
+
+  it('renders one article per registry entry with title + PRD + model + version', () => {
+    render(<PromptViewerPage />);
+    const articles = screen.getAllByRole('article');
+    expect(articles).toHaveLength(FOOD_PROMPTS.length);
+
+    for (const entry of FOOD_PROMPTS) {
+      const heading = screen.getByRole('heading', { name: entry.title, level: 2 });
+      const article = heading.closest('article');
+      expect(article).not.toBeNull();
+      const scope = within(article as HTMLElement);
+      expect(scope.getByText(entry.prd)).toBeInTheDocument();
+      expect(scope.getByText(entry.model)).toBeInTheDocument();
+      expect(scope.getByText(entry.version)).toBeInTheDocument();
+    }
+  });
+
+  it('renders the full template inside a <pre> for each entry', () => {
+    const { container } = render(<PromptViewerPage />);
+    const pres = container.querySelectorAll('pre');
+    expect(pres.length).toBe(FOOD_PROMPTS.length);
+    for (let i = 0; i < FOOD_PROMPTS.length; i++) {
+      expect(pres[i]?.textContent).toContain(FOOD_PROMPTS[i]!.template);
+    }
+  });
+});

--- a/packages/app-food/src/prompts/ig-vision.ts
+++ b/packages/app-food/src/prompts/ig-vision.ts
@@ -1,0 +1,53 @@
+/**
+ * Prompt template for PRD-130 (Instagram STT + vision pipeline).
+ *
+ * Primary path: ffmpeg keyframes + faster-whisper transcript → Claude
+ * vision. Fallback text-only variant ships as a separate version
+ * (`PROMPT_VERSION_IG_VISION_TEXT_FALLBACK`) — both are registered with
+ * the food prompt viewer (PRD-133).
+ *
+ * Bump version on any template change so `ai_inference_log` rows remain
+ * reproducible.
+ */
+export const PROMPT_VERSION_IG_VISION = 'ig-vision-v0.1';
+
+export const PROMPT_IG_VISION = `You are extracting a recipe from an Instagram Reel.
+
+Inputs provided:
+
+- Caption: {caption}
+- Transcript (faster-whisper, distil-large-v3): {transcript}
+- Keyframes: up to {keyframeCount} ffmpeg-extracted stills attached as images.
+
+Combine all three sources to recover the recipe. Resolve disagreements in favour of the transcript when measurements differ; favour the keyframes when ingredient identity is unclear.
+
+Return a single POPS recipe DSL document using ADR-023 grammar. Rules:
+
+- Start with \`@recipe("<slug>", "<title>")\`.
+- Use \`@ingredient(N, "<name>", qty:<num><unit>)\` for every ingredient mentioned.
+- Use \`@step("<short verb-led name>") { ... }\` for every step. Reference ingredients with \`@N\`.
+- Use \`@time(<minutes>m)\` and \`@temperature(<value>C|F)\` when stated.
+- Use \`@yield(<num><unit>)\` when the source declares it.
+
+If a measurement is missing from all sources, omit \`qty:\` rather than guess.
+
+Return ONLY the DSL document. No markdown fences, no commentary.`;
+
+export const PROMPT_VERSION_IG_VISION_TEXT_FALLBACK = 'ig-vision-text-fallback-v0.1';
+
+export const PROMPT_IG_VISION_TEXT_FALLBACK = `You are extracting a recipe from an Instagram Reel using text inputs only (vision call failed).
+
+Inputs:
+
+- Caption: {caption}
+- Transcript (faster-whisper): {transcript}
+
+Return a single POPS recipe DSL document per ADR-023. If the inputs do not describe a coherent recipe, return:
+
+\`\`\`
+@recipe("partial-draft", "Partial draft")
+\`\`\`
+
+with no further content; the operator will triage it.
+
+Return ONLY the DSL document.`;

--- a/packages/app-food/src/prompts/ig-vision.ts
+++ b/packages/app-food/src/prompts/ig-vision.ts
@@ -42,12 +42,10 @@ Inputs:
 - Caption: {caption}
 - Transcript (faster-whisper): {transcript}
 
-Return a single POPS recipe DSL document per ADR-023. If the inputs do not describe a coherent recipe, return:
+Return a single POPS recipe DSL document per ADR-023. If the inputs do not describe a coherent recipe, return exactly this single line and nothing else:
 
-\`\`\`
 @recipe("partial-draft", "Partial draft")
-\`\`\`
 
-with no further content; the operator will triage it.
+The operator will triage the partial-draft case.
 
-Return ONLY the DSL document.`;
+Return ONLY the DSL document. Do not wrap it in markdown fences.`;

--- a/packages/app-food/src/prompts/screenshot.ts
+++ b/packages/app-food/src/prompts/screenshot.ts
@@ -1,0 +1,24 @@
+/**
+ * Prompt template for PRD-131 (Screenshot ingest).
+ *
+ * Single image → Claude vision. Registered with the food prompt viewer
+ * (PRD-133). Bump the version on every template edit so logged rows
+ * remain reproducible.
+ */
+export const PROMPT_VERSION_SCREENSHOT = 'screenshot-v0.1';
+
+export const PROMPT_SCREENSHOT = `You are extracting a recipe from a single screenshot.
+
+The image is attached. Read every legible piece of text and any handwritten or printed measurements.
+
+Return a single POPS recipe DSL document using ADR-023 grammar. Rules:
+
+- Start with \`@recipe("<slug>", "<title>")\`.
+- Use \`@ingredient(N, "<name>", qty:<num><unit>)\` for every ingredient.
+- Use \`@step("<short verb-led name>") { ... }\` for every step. Reference ingredients with \`@N\`.
+- Use \`@time(<minutes>m)\` and \`@temperature(<value>C|F)\` when stated.
+- Use \`@yield(<num><unit>)\` when the source declares it.
+
+If text in the screenshot is unreadable, omit that ingredient or step. Do not invent content.
+
+Return ONLY the DSL document.`;

--- a/packages/app-food/src/prompts/text.ts
+++ b/packages/app-food/src/prompts/text.ts
@@ -1,0 +1,33 @@
+/**
+ * Prompt template for PRD-132 (Text ingest).
+ *
+ * Supports two modes:
+ *
+ *   - Complete recipe: the operator pasted a structured recipe.
+ *   - Rough idea: the operator pasted a description, request, or sketch
+ *     and wants Claude to flesh it out into a usable starter.
+ *
+ * Both modes share one prompt — the model decides based on the input
+ * shape. Registered with the food prompt viewer (PRD-133).
+ */
+export const PROMPT_VERSION_TEXT = 'text-v0.1';
+
+export const PROMPT_TEXT = `You are converting free-form text into a POPS recipe.
+
+Operator input:
+
+{text}
+
+If the input describes a complete recipe, transcribe it faithfully — do not invent ingredients or steps that are not stated.
+
+If the input is a rough idea, sketch, or request, elaborate it into a plausible v1 the operator can refine. Use sensible defaults for unspecified measurements but mark them with a trailing \`-- guess\` comment so the operator can spot them.
+
+Return a single POPS recipe DSL document using ADR-023 grammar. Rules:
+
+- Start with \`@recipe("<slug>", "<title>")\`.
+- Use \`@ingredient(N, "<name>", qty:<num><unit>)\` for every ingredient.
+- Use \`@step("<short verb-led name>") { ... }\` for every step. Reference ingredients with \`@N\`.
+- Use \`@time(<minutes>m)\` and \`@temperature(<value>C|F)\` when stated or strongly implied.
+- Use \`@yield(<num><unit>)\` when stated or strongly implied.
+
+Return ONLY the DSL document.`;

--- a/packages/app-food/src/prompts/web-llm.ts
+++ b/packages/app-food/src/prompts/web-llm.ts
@@ -1,0 +1,29 @@
+/**
+ * Prompt template for PRD-128 (Web URL LLM fallback extraction).
+ *
+ * Used when JSON-LD recipe data is absent on a recipe page (PRD-127's
+ * deterministic extractor failed). Sends readability-extracted page text
+ * to Claude and asks for a structured DSL recipe.
+ *
+ * The handler implementation lands with PRD-128; this template is the
+ * v1 starting point and is registered with the food prompt viewer
+ * (PRD-133). Bump `PROMPT_VERSION_WEB_LLM` whenever the template
+ * changes.
+ */
+export const PROMPT_VERSION_WEB_LLM = 'web-llm-v0.1';
+
+export const PROMPT_WEB_LLM = `You are extracting a recipe from a webpage that has no JSON-LD recipe markup.
+
+Page text (readability-extracted):
+
+{pageText}
+
+Return a single POPS recipe DSL document using ADR-023 grammar. Rules:
+
+- Start with \`@recipe("<slug>", "<title>")\`.
+- Use \`@ingredient(N, "<name>", qty:<num><unit>)\` for every ingredient.
+- Use \`@step("<short verb-led name>") { ... }\` for every step. Reference ingredients with \`@N\`.
+- Use \`@time(<minutes>m)\` and \`@temperature(<value>C|F)\` only when stated by the source.
+- Use \`@yield(<num><unit>)\` when the source declares a yield.
+
+Return ONLY the DSL document. No markdown fences, no commentary.`;

--- a/packages/app-food/src/routes.tsx
+++ b/packages/app-food/src/routes.tsx
@@ -71,6 +71,9 @@ const SubGraphPage = lazy(() =>
 const ConversionsTab = lazy(() =>
   import('./pages/data/ConversionsTab').then((m) => ({ default: m.ConversionsTab }))
 );
+const PromptViewerPage = lazy(() =>
+  import('./pages/PromptViewerPage').then((m) => ({ default: m.PromptViewerPage }))
+);
 
 /** Local type mirror for compile-time safety (shell owns the canonical types). */
 interface AppNavConfigShape {
@@ -93,6 +96,7 @@ export const navConfig = {
   items: [
     { path: '', label: 'Home', labelKey: 'food.home', icon: 'LayoutDashboard' },
     { path: '/data', label: 'Manage data', labelKey: 'food.data', icon: 'Database' },
+    { path: '/prompts', label: 'Prompts', labelKey: 'food.prompts', icon: 'FileText' },
   ],
 } satisfies AppNavConfigShape;
 
@@ -115,4 +119,5 @@ export const routes: RouteObject[] = [
       { path: 'conversions', element: <ConversionsTab /> },
     ],
   },
+  { path: 'prompts', element: <PromptViewerPage /> },
 ];


### PR DESCRIPTION
## Summary

- Cross-cutting infra for Epic 02's LLM calls so handler PRDs 127–132 can adopt one wrapper. Builds on theme 05's `ai_inference_log` — no schema changes.
- `packages/app-food/src/ai/log-inference.ts`: `callClaudeWithLogging<T>` measures latency, computes cost from an injected `lookupPricing`, flags `cost_missing` / `usage_missing` in metadata, routes success + error rows through a caller-supplied log sink (fire-and-forget — log failures never block ingest), and rethrows the underlying call's errors.
- `food.ai.logInference` internal mutation under `apps/pops-api/src/modules/food/routers/ai.ts` writes one row to `ai_inference_log` with `domain='food'`. Gated by `internalProcedure` (POPS_API_INTERNAL_TOKEN) — same auth pattern as `food.ingest.workerComplete`.
- `packages/app-food/src/ai/prompt-registry.ts` re-exports prompt templates + versions from `packages/app-food/src/prompts/{web-llm,ig-vision,screenshot,text}.ts` (placeholder text until handler PRDs finalise — drift catcher test asserts every `PROMPT_VERSION_*` export is registered).
- Read-only `/food/prompts` viewer (`PromptViewerPage`) mirrors the finance read-only pattern. Cards per registry entry with title / PRD / model / version / template. Operator-facing surface for ingest-quality iteration.

Strictly additive: new sub-router under `food.ai.*`, one route + nav entry in `app-food`, en-AU + pt-BR i18n keys (food + navigation namespaces).

## Coverage

- `log-inference.test.ts`: happy / error / missing-usage / missing-pricing / log-sink-failure / async-pricing paths against a fake sink.
- `prompt-registry.test.ts`: every `PROMPT_VERSION_*` constant is registered; unique ids + versions; PRD-1xx attribution; non-empty templates.
- `ai-router.test.ts`: 4 integration cases against in-memory SQLite — success row with merged metadata, error row with `errorMessage`, public callers rejected with `UNAUTHORIZED`, invalid operation rejected at the schema boundary.
- `PromptViewerPage.test.tsx`: header + editing-hint, one article per registry entry, full templates inside `<pre>`.
- `PromptViewerPage.stories.tsx`: Storybook coverage with the i18n provider wired locally.

## Test plan

- [ ] `mise typecheck` green across the workspace
- [ ] `mise lint` green
- [ ] `pnpm --filter @pops/app-food test` — 31 files / 394 tests passing
- [ ] `pnpm --filter @pops/api test src/modules/food/__tests__/ai-router.test.ts` — 4/4 passing
- [ ] Browse to `/food/prompts` once `mise dev` is running and confirm each entry renders with title / PRD / model / version / template

## Notes

- Per R1 Option B (food roadmap line 506): the worker (PRD-126) — when it ships — will provide the `log` sink as a `fetch` POST to `food.ai.logInference`. Keeping the sink injectable means `@pops/app-food` stays free of fetch/axios and the helper is unit-testable without HTTP.
- Prompt templates are placeholders matching each handler's documented intent. Handler PRDs (127, 128, 130, 131, 132) will bump the versions when they ship.