### PR TITLE
chore(food): trim PRD-N references and chatty file-header docblocks

### DIFF
--- a/apps/pops-api/src/modules/food/conversions/error-mapping.ts
+++ b/apps/pops-api/src/modules/food/conversions/error-mapping.ts
@@ -1,9 +1,5 @@
 /**
- * Shared error-mapping helpers for the conversions router (PRD-123 Phase B).
- *
- * Extracted from `./router.ts` so that file stays under the per-file
- * max-lines lint cap. The three helpers mirror the convention the aliases
- * and variants routers established for the rest of the food module:
+ * Error-mapping convention shared with the aliases / variants routers:
  *
  *   - SQLite `UNIQUE` constraint failures → tRPC `CONFLICT`
  *   - `expectRow(...)` "no row" failures   → tRPC `NOT_FOUND`

--- a/apps/pops-api/src/modules/food/conversions/router.ts
+++ b/apps/pops-api/src/modules/food/conversions/router.ts
@@ -1,21 +1,3 @@
-/**
- * Conversion tRPC router — PRD-123 Phase B.
- *
- * Procedures:
- *   listUnits / createUnit / updateUnit / deleteUnit
- *   listWeights / createWeight / updateWeight / deleteWeight
- *   resolve  — server-only contract; PRD-116's compile path calls the
- *              `conversionsService.resolveCanonicalQty` helper directly via
- *              `packages/app-food/src/dsl/normalisation.ts` (no tRPC hop).
- *
- * Services live in `@pops/app-food-db` (PRD-122 part API extracted them).
- *
- * Error mapping (mirrors the aliases / variants routers):
- *   - `SeededRowProtected`           → `{ ok:false, reason:'seeded' }`
- *   - SQLite `UNIQUE` constraint     → tRPC `CONFLICT`
- *   - `expectRow` miss (no such id)  → tRPC `NOT_FOUND`
- *   - anything else                   propagates as-is
- */
 import { z } from 'zod';
 
 import { conversionsQueries, conversionsService } from '@pops/app-food-db';

--- a/apps/pops-api/src/modules/food/conversions/types.ts
+++ b/apps/pops-api/src/modules/food/conversions/types.ts
@@ -1,6 +1,4 @@
 /**
- * Conversion-table API types — PRD-123 Phase B.
- *
  * Wire shapes for `food.conversions.*` procedures. Boolean `seeded` is the
  * client-facing camelCase mirror of the DB's INTEGER `is_seeded` column.
  */

--- a/apps/pops-api/src/modules/food/hero-image/paths.ts
+++ b/apps/pops-api/src/modules/food/hero-image/paths.ts
@@ -1,10 +1,7 @@
 /**
- * Server-side path helpers for recipe hero images (PRD-124).
- *
- * Mirrors the convention in `@pops/app-food/src/storage/hero-paths.ts`.
- * pops-api does not depend on the React-bearing app-food package at
- * runtime, so the absolute-path resolution is duplicated here. Keep both
- * in sync if the layout changes.
+ * Mirrors the layout in `@pops/app-food/src/storage/hero-paths.ts`. pops-api
+ * doesn't depend on the React-bearing app-food package at runtime, so the
+ * absolute-path resolution is duplicated here — keep both in sync.
  */
 import { resolve, sep } from 'node:path';
 

--- a/apps/pops-api/src/modules/food/hero-image/router.ts
+++ b/apps/pops-api/src/modules/food/hero-image/router.ts
@@ -1,10 +1,3 @@
-/**
- * food.heroImage tRPC router (PRD-124).
- *
- * Thin wrapper over `./service.ts` that handles the base64 → Buffer decode
- * and maps domain errors to TRPCError codes. The shell calls these from
- * the recipe edit page's HeroImageUploader component.
- */
 import { TRPCError } from '@trpc/server';
 
 import { NotFoundError, ValidationError } from '../../../shared/errors.js';

--- a/apps/pops-api/src/modules/food/hero-image/service.ts
+++ b/apps/pops-api/src/modules/food/hero-image/service.ts
@@ -1,17 +1,12 @@
 /**
- * Hero image upload service (PRD-124).
- *
- * Owns the on-disk + DB lifecycle for `recipes.hero_image_path`:
+ * On-disk + DB lifecycle for `recipes.hero_image_path`:
  *   - validates the upload (mime type, size, decodable image header)
  *   - writes the original atomically (`.tmp` + rename)
  *   - generates two derived thumbnails with sharp (320px webp, 640px webp)
  *   - updates `recipes.hero_image_path` and removes any stale prior original
  *
- * sharp lives in this package (already a runtime dep) so the heavy work is
- * done here rather than in `@pops/app-food` which is also consumed by the
- * browser bundle.
- *
- * See `docs/themes/07-food/prds/124-hero-image-upload/README.md`.
+ * sharp lives in this package (browser-bundled `@pops/app-food` can't
+ * carry it), so the heavy work is done here.
  */
 import {
   existsSync,

--- a/apps/pops-api/src/modules/food/hero-image/types.ts
+++ b/apps/pops-api/src/modules/food/hero-image/types.ts
@@ -1,10 +1,3 @@
-/**
- * Zod schemas for the food.heroImage tRPC namespace (PRD-124).
- *
- * Wire format is base64 to keep the JSON-only tRPC transport simple. If
- * file sizes outgrow this we'll move to multipart uploads — flagged out of
- * scope in the PRD.
- */
 import { z } from 'zod';
 
 import { HERO_ALLOWED_MIME_TYPES } from './paths.js';

--- a/apps/pops-api/src/modules/food/index.ts
+++ b/apps/pops-api/src/modules/food/index.ts
@@ -1,20 +1,3 @@
-/**
- * Food domain — backend module.
- *
- * Mounts the per-domain sub-routers under `food.*`:
- *
- *   - `food.heroImage`     — PRD-124 hero image upload + thumbnail pipeline.
- *   - `food.ingest`        — PRD-125 ingestion API (BullMQ producer +
- *                            internal `workerComplete` for the worker).
- *   - `food.ingredients` / `variants` / `aliases` / `prepStates` /
- *     `substitutions` / `slugs` — PRD-122 part API data-management surface.
- *   - `food.conversions`   — PRD-123 phase B unit conversions.
- *
- * Recipe CRUD lands later via PRD-119. Migration tags owned by this module
- * are listed in `migrations.ts`.
- *
- * See `docs/themes/07-food/` for the theme spec.
- */
 import { router } from '../../trpc.js';
 import { conversionsRouter } from './conversions/router.js';
 import { heroImageRouter } from './hero-image/router.js';

--- a/apps/pops-api/src/modules/food/migrations.ts
+++ b/apps/pops-api/src/modules/food/migrations.ts
@@ -1,33 +1,19 @@
 /**
- * Migration tags owned by the `food` module.
- *
- * Append a tag here when a new food schema PRD lands its generated drizzle
- * migration. Order matches the on-disk filename order, which is the order
- * the runner applies them.
- *
- * See PRD-101 US-09 for the runtime filter contract.
+ * Migration tags owned by the `food` module. Append in on-disk filename
+ * order — the runner applies them in this order.
  */
 import { drizzleMigrations } from '../../db/load-drizzle-migration.js';
 
 import type { MigrationDescriptor } from '@pops/types';
 
 export const foodMigrationTags: readonly string[] = [
-  // PRD-106 — slug_registry + ingredients + variants + prep_states + aliases.
   '0058_high_sentinel',
-  // PRD-107 — recipes + recipe_versions + recipe_tags.
   '0059_useful_hiroim',
-  // PRD-108 — batches + recipe_runs + batch_consumptions; ALTER ingredient_variants
-  // with default_shelf_life_days_{fridge,freezer}.
   '0060_familiar_leo',
-  // PRD-109 — substitutions.
   '0061_shocking_skreet',
-  // PRD-111 — plan_slots + plan_entries.
   '0063_bumpy_wolverine',
-  // PRD-110 — ingest_sources.
   '0064_peaceful_magma',
-  // PRD-116 — recipe_lines + recipe_steps + recipe_version_proposed_slugs.
   '0065_prd_116_recipe_compile',
-  // PRD-123 — unit_conversions + ingredient_weights.
   '0066_prd_123_conversions',
   // PRD-125 amendment to PRD-110 — error_code/error_message/attempts columns on
   // ingest_sources (persists failure detail past BullMQ TTL).

--- a/apps/pops-api/src/modules/food/routers/aliases.ts
+++ b/apps/pops-api/src/modules/food/routers/aliases.ts
@@ -7,17 +7,9 @@ import { getDrizzle } from '../../../db.js';
 import { protectedProcedure, router } from '../../../trpc.js';
 
 /**
- * Food → aliases tRPC procedures (PRD-122).
- *
- * Aliases point at exactly one of (ingredient_id, variant_id) per PRD-106's
- * XOR CHECK. The merge mutation rewires multiple aliases to a single
- * canonical target inside a transaction; bulk-approve flips llm-sourced
- * rows to user-sourced for the "trust this LLM proposal" affordance.
- *
- * The aliases service explicitly relies on the DB-level partial UNIQUE
- * indexes for dedupe — duplicate (alias, target) inserts surface as raw
- * SQLite UNIQUE constraint errors. Map those to CONFLICT here so clients
- * get a stable code instead of an opaque 500.
+ * The aliases service relies on the DB's partial UNIQUE indexes for dedupe —
+ * duplicate `(alias, target)` inserts surface as raw SQLite UNIQUE errors,
+ * mapped to CONFLICT here so clients get a stable code instead of a 500.
  */
 
 const SOURCE_ENUM = z.enum(['user', 'llm', 'ingest']);

--- a/apps/pops-api/src/modules/food/routers/ingredients.ts
+++ b/apps/pops-api/src/modules/food/routers/ingredients.ts
@@ -1,14 +1,6 @@
 import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 
-/**
- * Food → ingredients tRPC procedures (PRD-122).
- *
- * Thin wrappers over the food domain services exposed by `@pops/app-food-db`.
- * Validation lives in zod input schemas; business invariants (slug shape,
- * hierarchy depth, cycle detection) live in the service layer and are
- * mapped to typed TRPCErrors here so clients can switch on `code`.
- */
 import {
   IngredientCycleError,
   IngredientHierarchyDepthExceeded,

--- a/apps/pops-api/src/modules/food/routers/prep-states.ts
+++ b/apps/pops-api/src/modules/food/routers/prep-states.ts
@@ -1,13 +1,6 @@
 import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 
-/**
- * Food → prepStates tRPC procedures (PRD-122).
- *
- * v1 deliberately omits update/delete — the PRD calls out that prep_states
- * have heavy reference impact and deletion requires cascade analysis that's
- * deferred to a future PRD.
- */
 import { InvalidSlugError, prepStatesService, SlugAlreadyRegisteredError } from '@pops/app-food-db';
 
 import { getDrizzle } from '../../../db.js';

--- a/apps/pops-api/src/modules/food/routers/slugs.ts
+++ b/apps/pops-api/src/modules/food/routers/slugs.ts
@@ -1,12 +1,5 @@
 import { z } from 'zod';
 
-/**
- * Food → slugs tRPC procedures (PRD-122 + PRD-120).
- *
- * Single source for slug autocomplete across the data page (global search)
- * and the DSL editor (PRD-120's `slug_registry` lookup). Keeps the surface
- * cheap so it can be polled on every keystroke client-side without paging.
- */
 import { slugSearchService } from '@pops/app-food-db';
 
 import { getDrizzle } from '../../../db.js';

--- a/apps/pops-api/src/modules/food/routers/substitutions.ts
+++ b/apps/pops-api/src/modules/food/routers/substitutions.ts
@@ -15,12 +15,11 @@ import { getDrizzle } from '../../../db.js';
 import { protectedProcedure, router } from '../../../trpc.js';
 
 /**
- * PRD-148 graph-view composite id. Encodes the side as
- * `ingredient:<id>` or `variant:<id>` so the client can dedupe nodes
- * across edges without doing any schema reasoning. Throws on a
- * malformed side (`kind='variant'` without a `variantId`) rather than
- * silently coercing to `variant:0`, which would collide across edges
- * and hide a schema-drift bug.
+ * Graph-view composite id. Encodes the side as `ingredient:<id>` or
+ * `variant:<id>` so the client can dedupe nodes across edges without
+ * doing any schema reasoning. Throws on a malformed side (`kind='variant'`
+ * without a `variantId`) rather than silently coercing to `variant:0`,
+ * which would collide across edges and hide a schema-drift bug.
  */
 function sideToNodeId(side: GraphViewSide): string {
   if (side.kind === 'variant') {
@@ -85,13 +84,10 @@ export interface GraphView {
 }
 
 /**
- * Food → substitutions tRPC procedures (PRD-122 + PRD-109).
- *
  * Endpoints are XOR-shaped: exactly one of `ingredientId` / `variantId` on
- * each side. Validation runs at the boundary so client mistakes surface
- * as BAD_REQUEST instead of an opaque INTERNAL_SERVER_ERROR after the
- * SQLite CHECK fires. Scope/recipeId coherence (`recipe` iff `recipeId`
- * set) is enforced here too — the schema has its own CHECK as a backstop.
+ * each side. Validating at the boundary makes client mistakes surface as
+ * BAD_REQUEST instead of a 500 after the SQLite CHECK fires. Scope/recipeId
+ * coherence (`recipe` iff `recipeId` set) is enforced here too.
  */
 
 const ENDPOINT_SCHEMA = z

--- a/apps/pops-api/src/modules/food/routers/variants.ts
+++ b/apps/pops-api/src/modules/food/routers/variants.ts
@@ -7,16 +7,9 @@ import { getDrizzle } from '../../../db.js';
 import { protectedProcedure, router } from '../../../trpc.js';
 
 /**
- * Food → variants tRPC procedures (PRD-122).
- *
- * Variants are scoped under their parent ingredient (PRD-106 invariant);
- * `(ingredient_id, slug)` UNIQUE is enforced at the DB level. There's no
- * global "list all variants" endpoint — use `food.ingredients.get` for the
- * per-parent set.
- *
- * Shelf-life fields (`defaultShelfLifeDaysFridge` / `Freezer`) land on the
- * `ingredient_variants` row via PRD-108's ALTER. The data page surfaces
- * them inline alongside the other variant columns.
+ * Variants are scoped under their parent ingredient; `(ingredient_id, slug)`
+ * UNIQUE is DB-enforced. No global "list all variants" endpoint — use
+ * `food.ingredients.get` for the per-parent set.
  */
 
 const UNIT_ENUM = z.enum(['g', 'ml', 'count']);

--- a/packages/app-food-db/src/errors.ts
+++ b/packages/app-food-db/src/errors.ts
@@ -47,7 +47,7 @@ export class IngredientCycleError extends Error {
   }
 }
 
-// ── PRD-107 errors ──────────────────────────────────────────────────────
+// ── Recipe-version errors ───────────────────────────────────────────────
 
 export class CannotPromoteUncompiledVersion extends Error {
   readonly versionId: number;
@@ -85,7 +85,7 @@ export class ConcurrentPromotion extends Error {
   }
 }
 
-// ── PRD-108 errors ──────────────────────────────────────────────────────
+// ── Batch / cook-run errors ─────────────────────────────────────────────
 
 export class CannotCookUncompiledRecipe extends Error {
   readonly recipeVersionId: number;
@@ -113,7 +113,7 @@ export class IngredientHierarchyDepthExceeded extends Error {
   }
 }
 
-// ── PRD-109 errors ──────────────────────────────────────────────────────
+// ── Substitution errors ─────────────────────────────────────────────────
 
 /**
  * Thrown when a substitution edge would point an ingredient (or variant) at

--- a/packages/app-food-db/src/services/aliases.ts
+++ b/packages/app-food-db/src/services/aliases.ts
@@ -1,21 +1,3 @@
-/**
- * Ingredient-alias services — PRD-106 / PRD-122 (data management page).
- *
- * Aliases point at exactly one of `ingredient_id` or `variant_id` (XOR
- * CHECK enforced at the row level). The partial UNIQUE indexes from the
- * PRD-106 migration handle deduplication per target, so duplicate inserts
- * surface as bare SQLite UNIQUE errors here.
- *
- * `mergeAliases` re-points a set of existing aliases to a single canonical
- * target. The PRD-122 spec calls for INSERT-then-DELETE in one transaction
- * so the audit trail is preserved (we recreate at the new target instead
- * of UPDATE-ing the FK). Existing rows that already point at the canonical
- * target are kept; the rest are migrated.
- *
- * `bulkApprove` flips a batch of `source='llm'` aliases to `source='user'`
- * so the operator's "trust this LLM proposal" affordance becomes the
- * authoritative state without an extra column.
- */
 import { and, eq, inArray, like, or } from 'drizzle-orm';
 
 import { ingredientAliases, type IngredientAliasRow } from '../schema.js';
@@ -103,11 +85,10 @@ export interface MergeAliasesResult {
  * (DELETE) in the same transaction.
  *
  * The INSERT uses `ON CONFLICT DO NOTHING` against the per-target partial
- * UNIQUE indexes (PRD-106): when the same alias text already exists at the
- * canonical target, the duplicate is silently collapsed onto the existing
- * row while the original is still removed. Without this, a merge across
- * targets that happen to share alias text would fail SQLite's UNIQUE and
- * abort the whole transaction.
+ * UNIQUE indexes: when the same alias text already exists at the canonical
+ * target, the duplicate is silently collapsed onto the existing row while
+ * the original is still removed. Without this, a merge across targets that
+ * share alias text would fail SQLite's UNIQUE and abort the transaction.
  */
 export function mergeAliases(db: FoodDb, input: MergeAliasesInput): MergeAliasesResult {
   if (input.aliasIds.length === 0) return { mergedCount: 0 };

--- a/packages/app-food-db/src/services/batches.ts
+++ b/packages/app-food-db/src/services/batches.ts
@@ -1,20 +1,7 @@
 /**
- * FIFO batch consumption — PRD-108.
- *
- * `consumeForRun` walks a list of needs (one per recipe line, post-scaling)
- * and decrements `batches.qty_remaining` in FIFO order. The whole operation
- * runs in one transaction: any shortfall rolls back every decrement so the
- * cook event either consumes everything cleanly or leaves the fridge
- * untouched.
- *
- * FIFO order: `expires_at NULLS LAST, produced_at ASC`. Items with an
- * expiry get consumed first; among those, older first; among shelf-stable
- * (null expiry), older first.
- *
- * Substitution-aware consumption (e.g. consume `whole` batches for a
- * `diced` line) is Epic 06's concern — v1 is strict by `(variant, prep)`.
- *
- * See `docs/themes/07-food/prds/108-batch-model/README.md`.
+ * `consumeForRun` decrements `batches.qty_remaining` in FIFO order
+ * (`expires_at NULLS LAST, produced_at ASC`) inside one transaction — any
+ * shortfall rolls back every decrement.
  */
 import { and, asc, eq, gt, isNull, sql } from 'drizzle-orm';
 
@@ -91,7 +78,7 @@ export function consumeForRun(
  *
  * The batch's stored `unit` must equal `need.canonicalUnit` — recipe_lines
  * carry the canonical metric and batches store in that same unit (no
- * cross-unit conversion at consume time; see PRD-108 rationale).
+ * cross-unit conversion at consume time).
  */
 function drawFromBatches(
   tx: FoodDb,

--- a/packages/app-food-db/src/services/conversions-queries.ts
+++ b/packages/app-food-db/src/services/conversions-queries.ts
@@ -1,12 +1,3 @@
-/**
- * Read-side helpers for PRD-123's conversions tab on the data page.
- *
- * Split from `./conversions.ts` so that file stays focused on mutations +
- * the `resolveCanonicalQty` lookup PRD-116's compile path depends on. The
- * list functions are consumed exclusively by the admin UI's tRPC router
- * (`apps/pops-api/src/modules/food/conversions/router.ts`); compile never
- * paginates.
- */
 import { and, asc, eq, like, or, type SQL } from 'drizzle-orm';
 
 import {
@@ -54,9 +45,6 @@ function combineFilters(filters: SQL[]): SQL | undefined {
 export interface ListIngredientWeightsInput {
   ingredientId?: number;
   search?: string;
-  /** Mirror of `ListUnitConversionsInput.seededOnly` so the data page can
-   *  filter weight rows on the same "show only PRD-113-seeded entries"
-   *  toggle that already drives the unit-conversions tab. */
   seededOnly?: boolean;
 }
 

--- a/packages/app-food-db/src/services/conversions.ts
+++ b/packages/app-food-db/src/services/conversions.ts
@@ -1,12 +1,3 @@
-/**
- * Conversion-table service layer — PRD-123.
- *
- * Mutations (CRUD) for `unit_conversions` and `ingredient_weights`. The
- * `resolveCanonicalQty` helper does the 3-step lookup PRD-123 specifies
- * (ingredient-weight first, then generic unit conversion, then "unresolved")
- * and is the procedure PRD-116's compile calls via
- * `packages/app-food/src/dsl/normalisation.ts`.
- */
 import { and, eq, isNull } from 'drizzle-orm';
 
 import { SeededRowProtected } from '../errors.js';
@@ -133,17 +124,16 @@ export type ResolveCanonicalResult =
   | { kind: 'unresolved' };
 
 /**
- * The PRD-123 3-step resolution:
+ * 3-step resolution:
  *
- * 1. **`ingredient_weights`** for `(ingredientId, variantId, unit)`, fall back
- *    to `(ingredientId, NULL, unit)`. Always converts to grams.
- * 2. **`unit_conversions`** for `(fromUnit, *)`. Picks the to_unit row by row
- *    order — the schema doesn't ambiguously fan out for v1, so first match wins.
+ * 1. **`ingredient_weights`** for `(ingredientId, variantId, unit)`, falling
+ *    back to `(ingredientId, NULL, unit)`. Always converts to grams.
+ * 2. **`unit_conversions`** for `(fromUnit, *)`. First match wins.
  * 3. **No match** → `{ kind: 'unresolved' }`; caller falls back to the
  *    ingredient's `default_unit` with null qty.
  *
- * Identity carry-over for `g`/`ml`/`count` is handled here so the compile-time
- * helper has a single entry point (no branch on the unit string in compile-lines).
+ * Identity carry-over for `g`/`ml`/`count` is handled here so callers have
+ * a single entry point.
  */
 export function resolveCanonicalQty(
   db: FoodDb,
@@ -196,10 +186,8 @@ function lookupUnitConversion(
   db: FoodDb,
   fromUnit: string
 ): { toUnit: CanonicalUnit; ratio: number } | null {
-  // Order by `id` so "first match" is deterministic — SQLite doesn't promise
-  // insertion order on unindexed selects, and multiple rows can exist for the
-  // same `from_unit` if a user (or PRD-113's seed) populated more than one
-  // `to_unit` for the same source unit.
+  // Order by `id` so "first match" is deterministic when multiple rows
+  // exist for the same `from_unit`.
   const rows = db
     .select({ toUnit: unitConversions.toUnit, ratio: unitConversions.ratio })
     .from(unitConversions)

--- a/packages/app-food-db/src/services/ingest-sources.ts
+++ b/packages/app-food-db/src/services/ingest-sources.ts
@@ -1,15 +1,6 @@
 /**
- * Ingest source services — PRD-110.
- *
- * The on-disk media layout (`${FOOD_INGEST_DIR}/<source_id>/...`) is managed
- * by Epic 02's ingestion worker; this service owns the row lifecycle:
- * insert per ingest invocation, link to the drafted recipe once the LLM
- * extraction produced one, and mark `archived_at` when the FIFO eviction
- * job removes the media.
- *
- * Service-layer guards enforce the kind/url invariant PRD-110 calls out
- * (`url` required for `kind ∈ {url-web, url-instagram}`). The DB CHECK
- * handles the enum; everything else is enforced here.
+ * Service-layer guards enforce the kind/url invariant (`url` required for
+ * `kind ∈ {url-web, url-instagram}`). The DB CHECK handles the enum.
  */
 import { eq } from 'drizzle-orm';
 

--- a/packages/app-food-db/src/services/ingredients-queries.ts
+++ b/packages/app-food-db/src/services/ingredients-queries.ts
@@ -1,10 +1,3 @@
-/**
- * Read-side helpers for the ingredients tab of the PRD-122 data page.
- *
- * Split from `./ingredients.ts` to keep that file under the per-file
- * line cap. Mutations and slug-registry maintenance stay in the parent
- * service; reads (list / get / variants / blocker enumeration) live here.
- */
 import { and, asc, eq, inArray, like, or, sql } from 'drizzle-orm';
 
 import {

--- a/packages/app-food-db/src/services/ingredients.ts
+++ b/packages/app-food-db/src/services/ingredients.ts
@@ -1,19 +1,10 @@
 /**
- * Ingredient services — PRD-106.
- *
- * Functions are pure relative to the `db` argument: they take a drizzle
- * connection (or a transaction handle) and return the result of the mutation.
- * Each service that touches both `ingredients` and `slug_registry` does so
- * inside the same transaction so partial-failure rollbacks leave both tables
- * consistent.
- *
  * Application-side invariants:
  *   - slug shape: kebab-case `[a-z0-9]+(-[a-z0-9]+)*` (via `assertValidSlug`)
  *   - ingredient hierarchy depth ≤ 3 (counted at insert / re-parent)
  *   - ingredient parent chain forms no cycles (DFS at insert / re-parent)
- *   - slug_registry is the cross-kind uniqueness surface — service inserts
- *     fail with `SlugAlreadyRegisteredError` (vs. the bare UNIQUE error from
- *     SQLite) so callers get the existing kind in the error.
+ *   - slug_registry inserts throw `SlugAlreadyRegisteredError` (vs. the bare
+ *     SQLite UNIQUE) so callers get the colliding kind in the error.
  */
 import { eq } from 'drizzle-orm';
 

--- a/packages/app-food-db/src/services/internal.ts
+++ b/packages/app-food-db/src/services/internal.ts
@@ -1,8 +1,3 @@
-/**
- * Shared helpers for the food schema service layer (PRD-106).
- *
- * Not exported from the package — internal to `src/db/services/*.ts`.
- */
 import { eq } from 'drizzle-orm';
 
 import {

--- a/packages/app-food-db/src/services/plan.ts
+++ b/packages/app-food-db/src/services/plan.ts
@@ -1,26 +1,3 @@
-/**
- * Meal-plan services — PRD-111.
- *
- * Schema-level operations for the `plan_slots` extensible vocabulary and the
- * `plan_entries` table. No cook orchestration here — that's Epic 05 (PRD-144
- * wraps these primitives in a single transaction with PRD-108's
- * `consumeForRun` + PRD-145's `createBatchFromRun`).
- *
- * Slot mutation rules (PRD-143 amendments queued in the roadmap):
- *   - `addSlot` (alias `addCustomSlot`) inserts an `is_default=0` row.
- *   - `updateSlot` patches `name` and/or `display_order` on any slot.
- *   - `deleteSlot` refuses `is_default=1` rows and refuses slugs that any
- *     plan_entries row still references.
- *
- * Plan entry rules:
- *   - `addPlanEntry` defers FK rejection to SQLite for `slot`, `recipe_id`,
- *     `recipe_version_id`. The CHECK on `planned_servings > 0` also lives
- *     in the schema.
- *   - `removePlanEntry` refuses rows with a non-null `recipe_run_id` so
- *     cook history's "planned context" stays intact.
- *
- * See `docs/themes/07-food/prds/111-plan-entry-model/README.md`.
- */
 import { and, asc, eq, sql } from 'drizzle-orm';
 
 import {
@@ -137,11 +114,7 @@ export function addSlot(db: FoodDb, input: AddSlotInput): PlanSlotRow {
   return expectRow(rows, `addSlot(${input.slug})`);
 }
 
-/**
- * Backward-compat alias. The original PRD spelt this `addCustomSlot`; the
- * PRD-143 amendment standardises on `addSlot`. Both stay exported so older
- * call sites keep compiling during the rollout.
- */
+/** Backward-compat alias for `addSlot`. */
 export const addCustomSlot = addSlot;
 
 export interface UpdateSlotInput {
@@ -194,10 +167,7 @@ export function deleteSlot(db: FoodDb, slug: string): void {
   db.delete(planSlots).where(eq(planSlots.slug, slug)).run();
 }
 
-/**
- * List the slots in display order, with slug as the tiebreaker — matches the
- * PRD's edge-case behaviour for `display_order` ties.
- */
+/** List slots in display order; slug breaks ties. */
 export function listSlots(db: FoodDb): PlanSlotRow[] {
   return db
     .select()

--- a/packages/app-food-db/src/services/prep-states.ts
+++ b/packages/app-food-db/src/services/prep-states.ts
@@ -1,10 +1,3 @@
-/**
- * Prep state services — PRD-106.
- *
- * Prep states participate in `slug_registry` (kind='prep_state'). Each
- * mutation that touches the registry does so in the same transaction as
- * the parent row so partial-failure rollbacks leave both consistent.
- */
 import { eq } from 'drizzle-orm';
 
 import { prepStates, type PrepStateRow } from '../schema.js';

--- a/packages/app-food-db/src/services/recipe-runs.ts
+++ b/packages/app-food-db/src/services/recipe-runs.ts
@@ -1,17 +1,3 @@
-/**
- * Recipe run services — PRD-108.
- *
- * A `recipe_run` is one cook event pinned to a specific `recipe_version`.
- * `markRunComplete` finalises it: sets `completed_at` and, when `yield` is
- * given, creates the produced batch and writes its FK on the run row.
- *
- * Per PRD-145's queued amendment (note in PRD-108 "Subsequent amendments"),
- * `markRunComplete` accepts `opts: { yield?: YieldArgs }` — sets only
- * `completed_at` when `yield` is absent (yieldless recipe), sets both when
- * present. The `createBatchFromRun` wrapper is the centralised contract;
- * direct callers should use it. For PRD-108's own scope, the wrapper is
- * inlined here; PRD-145 will extract it as a named export.
- */
 import { eq } from 'drizzle-orm';
 
 import { CannotCookUncompiledRecipe } from '../errors.js';
@@ -83,8 +69,7 @@ export interface MarkRunCompleteResult {
  * `recipe_runs.yielded_batch_id`. All writes happen in one transaction.
  *
  * Refuses to complete a run whose recipe_version isn't `compiled` — the
- * planner / consumption helper rely on materialised `recipe_lines` from
- * PRD-116, and an uncompiled version doesn't have them.
+ * planner / consumption helper need materialised `recipe_lines`.
  */
 export function markRunComplete(
   db: FoodDb,

--- a/packages/app-food-db/src/services/recipe-versions.ts
+++ b/packages/app-food-db/src/services/recipe-versions.ts
@@ -1,6 +1,4 @@
 /**
- * Recipe version services — PRD-107.
- *
  * Version lifecycle:
  *   draft  ──promote──► current
  *   current ──superseded─► archived   (only when another version is promoted)
@@ -9,8 +7,7 @@
  * Promotion is an atomic three-step: write the new current, archive any
  * previously-current row, update `recipes.current_version_id`. The partial
  * UNIQUE `uq_recipe_versions_one_current` ensures the second of two
- * concurrent promotions fails — the service maps that SQLite error to a
- * typed `ConcurrentPromotion`.
+ * concurrent promotions fails — that surfaces as `ConcurrentPromotion`.
  */
 import { and, eq, max } from 'drizzle-orm';
 

--- a/packages/app-food-db/src/services/recipes.ts
+++ b/packages/app-food-db/src/services/recipes.ts
@@ -1,17 +1,3 @@
-/**
- * Recipe services — PRD-107.
- *
- * `createRecipe` atomically inserts the `recipes` row + the first
- * `recipe_versions` draft + the `slug_registry` row in one transaction.
- * Slug registration follows PRD-106's pattern: check the registry first so
- * the typed `SlugAlreadyRegisteredError` fires before SQLite's bare UNIQUE.
- *
- * Archive vs delete: archiving sets `archived_at` and keeps the
- * `slug_registry` entry so historic references in archived recipes still
- * resolve. Delete (rare) removes both.
- *
- * See `docs/themes/07-food/prds/107-recipe-model/README.md`.
- */
 import { eq } from 'drizzle-orm';
 
 import { SlugAlreadyRegisteredError, type SlugKind } from '../errors.js';
@@ -147,10 +133,7 @@ export function deleteRecipe(db: FoodDb, recipeId: number): void {
       .where(eq(recipes.id, recipeId))
       .all();
     if (existing.length === 0) return;
-    // PRD-109 — recipe-scoped substitutions reference this recipe via FK;
-    // drop them in the same transaction so the FK doesn't reject the delete.
     deleteRecipeScopedSubstitutions(tx, recipeId);
-    // Drop versions first so the recipes-row delete succeeds against the FK.
     tx.delete(recipeVersions).where(eq(recipeVersions.recipeId, recipeId)).run();
     tx.delete(recipes).where(eq(recipes.id, recipeId)).run();
     const row = expectRow(existing, `deleteRecipe(${recipeId})`);

--- a/packages/app-food-db/src/services/slug-search.ts
+++ b/packages/app-food-db/src/services/slug-search.ts
@@ -1,10 +1,6 @@
 /**
- * Slug search service — PRD-122 + PRD-120 (autocomplete shared procedure).
- *
- * Substring match against `slug_registry`, returning the original target
- * row's display name where available. Returns nothing for an empty query
- * (caller is expected to debounce on the client). Limit defaults to 25 so
- * the response stays trivial over the wire.
+ * Substring match against `slug_registry`, returning the target row's
+ * display name where available. Empty query returns nothing.
  */
 import { and, eq, inArray, like } from 'drizzle-orm';
 

--- a/packages/app-food-db/src/services/substitutions-queries.ts
+++ b/packages/app-food-db/src/services/substitutions-queries.ts
@@ -1,10 +1,3 @@
-/**
- * Read-side helpers for the substitutions tab of the PRD-122 data page.
- *
- * Split from `./substitutions.ts` so that file stays under the per-file
- * line cap. Mutations and the create / delete entry points stay in the
- * parent service; list filters and the patch-style update live here.
- */
 import { and, eq, or, sql } from 'drizzle-orm';
 
 import { substitutions, type SubstitutionRow } from '../schema.js';
@@ -65,10 +58,9 @@ export function listSubstitutions(
     filters.push(eq(substitutions.recipeId, input.recipeId));
   }
   if (input.contextTag !== undefined) {
-    // PRD-109: empty context_tags is a wildcard ("applies in any context").
-    // The tag-specific filter must therefore match the requested tag OR any
-    // wildcard edge — otherwise wildcards silently drop out of cook-time
-    // queries that supply a context.
+    // Empty context_tags is a wildcard ("applies in any context"), so a
+    // tag-specific filter must match the requested tag OR any wildcard edge —
+    // otherwise wildcards drop out of cook-time queries that supply a context.
     filters.push(
       or(
         sql`json_array_length(${substitutions.contextTags}) = 0`,

--- a/packages/app-food-db/src/services/substitutions.ts
+++ b/packages/app-food-db/src/services/substitutions.ts
@@ -1,23 +1,16 @@
 /**
- * Substitution services — PRD-109.
- *
- * Substitutions are directed edges between ingredients (or variants). A
- * bidirectional sub is two rows; the schema makes no attempt to link them.
+ * Substitutions are directed edges between ingredients (or variants).
+ * A bidirectional sub is two rows; the schema makes no attempt to link them.
  * Edges are either `global` (apply anywhere) or `recipe`-scoped (override
  * the global edge for one recipe).
  *
- * The service layer enforces three rules that the schema cannot:
- *   1. Self-substitution (`from = to` on the same side) is rejected with
- *      `CannotSubstituteSelf`. The xor CHECKs make it impossible to express
- *      this in pure SQL without exploding into four cases.
- *   2. `context_tags` is stored as a JSON-encoded array of strings. Callers
- *      pass arrays; the service serialises via `JSON.stringify`.
- *   3. Scope/recipe coherence (recipe-scoped → recipe_id present, global →
- *      recipe_id absent) is also enforced at the schema level, but the
- *      service normalises null/undefined before INSERT so the CHECK never
- *      fires from a caller mistake.
- *
- * Query helpers (cook-time sub lookup, plan-time graph walk) live in Epic 06.
+ * The service layer enforces three rules the schema cannot:
+ *   1. Self-substitution (`from = to` on the same side) → `CannotSubstituteSelf`.
+ *      The xor CHECKs make this impossible to express in pure SQL without
+ *      exploding into four cases.
+ *   2. `context_tags` is JSON-encoded. Callers pass arrays.
+ *   3. Scope/recipe coherence is also enforced by CHECK, but the service
+ *      normalises null/undefined before INSERT so callers can't trip it.
  */
 import { and, eq } from 'drizzle-orm';
 

--- a/packages/app-food-db/src/services/variants.ts
+++ b/packages/app-food-db/src/services/variants.ts
@@ -1,9 +1,6 @@
 /**
- * Ingredient variant services — PRD-106.
- *
- * Variants are scoped under their parent ingredient; the `(ingredient_id,
- * slug)` UNIQUE is enforced at the DB level. Variants do NOT participate
- * in `slug_registry`.
+ * Variants are scoped under their parent ingredient; `(ingredient_id, slug)`
+ * UNIQUE is DB-enforced. Variants do NOT participate in `slug_registry`.
  */
 import { eq } from 'drizzle-orm';
 
@@ -18,9 +15,9 @@ export interface CreateVariantInput {
   defaultUnit: 'g' | 'ml' | 'count';
   packageSizeG?: number | null;
   notes?: string | null;
-  /** PRD-108: feeds expiry auto-fill at cook time. Null = unknown / shelf-stable. */
+  /** Feeds expiry auto-fill at cook time. Null = unknown / shelf-stable. */
   defaultShelfLifeDaysFridge?: number | null;
-  /** PRD-108: feeds expiry auto-fill at cook time. Null = unknown / shelf-stable. */
+  /** Feeds expiry auto-fill at cook time. Null = unknown / shelf-stable. */
   defaultShelfLifeDaysFreezer?: number | null;
 }
 

--- a/packages/app-food/src/components/DslEditor.tsx
+++ b/packages/app-food/src/components/DslEditor.tsx
@@ -1,31 +1,16 @@
 /**
- * DslEditor — recipe-DSL CodeMirror 6 editor (PRD-120 parts A + C).
- *
- * Pure presentation component. The editor:
- *   - Renders the recipe-DSL source with Lezer-driven syntax highlighting
- *     (function names, descriptors, strings, numbers, comments).
- *   - Fires `onChange(value)` after a 250 ms debounce so the parent isn't
- *     thrashed on every keystroke.
+ * Recipe-DSL CodeMirror 6 editor. Pure presentation:
+ *   - Lezer-driven syntax highlighting (function names, descriptors,
+ *     strings, numbers, comments).
+ *   - `onChange(value)` fires after a 250 ms debounce.
  *   - Switches into read-only mode (no keystrokes, banner at the top) when
- *     `readOnly` is true — the parent is expected to pass this for any
- *     `recipe_versions.status ∈ {current, archived}` per PRD-107.
- *   - Surfaces compile diagnostics passed via `issues` as inline
- *     squiggles, a gutter marker, and a hover tooltip (120-C).
+ *     `readOnly` is true.
+ *   - Surfaces compile diagnostics passed via `issues` as inline squiggles,
+ *     a gutter marker, and a hover tooltip.
  *
- * Still out of scope for this PR (deferred to 120-B / 120-D / 120-E /
- * 120-F):
- *   - Autocomplete (consumes `food.slugs.search` from PRD-122-API).
- *   - Chip widgets for inline `@N` / `@slug` / `@time` / `@temperature`.
- *   - Reorder + renumber affordance.
- *   - Mobile-specific autocomplete drawer + axe-core a11y pass.
- *   - The "Recompile" button — parent-driven, lands with PRD-119.
- *
- * The component is deliberately framework-thin: it owns a single
- * `EditorView` instance and rebuilds the document only when `initialValue`
- * changes from outside (e.g. the parent loaded a new version). External
- * changes never collide with in-flight user edits because the parent is
- * supposed to treat `onChange` as the source of truth and not re-pump the
- * same value back as a new `initialValue`.
+ * Framework-thin: owns a single `EditorView` and rebuilds the document only
+ * when `initialValue` changes from outside. Parents must treat `onChange`
+ * as the source of truth and avoid re-pumping the same value back.
  */
 import { EditorView } from '@codemirror/view';
 import { useCallback, useMemo, useRef } from 'react';
@@ -40,29 +25,25 @@ import { useDslEditorView } from './useDslEditorView';
 import type { DslAutocompleteSources } from './dsl-editor/autocomplete-types';
 import type { CompileEditorIssue } from './dsl-editor/issues-types';
 
-/** Public props — kept narrow so future 120 parts can extend without
- * breaking earlier callers. */
 export interface DslEditorProps {
   /** Current `body_dsl` string. */
   initialValue: string;
   /** Fires with the latest editor value, debounced 250 ms. */
   onChange: (value: string) => void;
   /**
-   * Diagnostics rendered as inline decorations + a gutter marker + a
-   * hover tooltip. The parent (PRD-119, downstream) assembles this list
-   * from `food.recipes.saveDraft`'s `CompileResult` plus any
-   * `recipe_version_proposed_slugs` rows fetched via
-   * `food.recipes.listProposedSlugs(versionId)`. Defaults to an empty
-   * array.
+   * Diagnostics rendered as inline decorations + a gutter marker + a hover
+   * tooltip. Defaults to an empty array.
    */
   issues?: readonly CompileEditorIssue[];
-  /** True for `current`/`archived` versions per PRD-107. */
+  /** True for `current`/`archived` versions. */
   readOnly?: boolean;
   /** Extra class on the wrapping div for layout integration. */
   className?: string;
-  /** Autocomplete lookups (PRD-120 part B). When omitted, the
-   *  autocomplete dropdown stays empty. Production wiring uses
-   *  `useDslAutocompleteSources()` which wraps tRPC + React Query. */
+  /**
+   * Autocomplete lookups. When omitted, the dropdown stays empty.
+   * Production wiring uses `useDslAutocompleteSources()` which wraps tRPC
+   * + React Query.
+   */
   autocompleteSources?: DslAutocompleteSources;
 }
 

--- a/packages/app-food/src/components/HeroImageUploader.tsx
+++ b/packages/app-food/src/components/HeroImageUploader.tsx
@@ -1,12 +1,8 @@
 /**
- * Hero image uploader (PRD-124).
- *
  * Shows the current hero or a drop-zone, accepts drag-drop or click-to-pick,
  * reads the picked file as base64, and calls `food.heroImage.upload`. Errors
  * surface as toasts; the parent gets notified through `onUploaded` /
- * `onRemoved` callbacks so the recipe edit page can refresh its query state.
- *
- * No client-side resize in v1 — the server's sharp pipeline handles it.
+ * `onRemoved` callbacks so it can refresh its query state.
  */
 import { type JSX, useId, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/packages/app-food/src/components/IngredientChip.tsx
+++ b/packages/app-food/src/components/IngredientChip.tsx
@@ -4,16 +4,12 @@ import { useTranslation } from 'react-i18next';
 import { cn } from '@pops/ui';
 
 /**
- * Inline reference chip rendered inside a step body — PRD-121.
+ * Inline reference chip rendered inside a step body. Clicking scrolls the
+ * matching ingredient list row into view (the caller wires the anchor by
+ * giving each `<li>` an `id` derived from `position`). When the resolver
+ * couldn't bind the ref the chip shows an error badge but stays clickable.
  *
- * Clicking scrolls the matching ingredient list row into view (caller wires
- * up the anchor by giving each list `<li>` an `id` derived from `position`
- * — see `RecipeRenderer.tsx`). When the resolver couldn't bind the ref
- * (`hasError=true`) the chip shows an error badge but stays clickable so
- * the user can hunt for the right index.
- *
- * Styled like `@pops/ui`'s `Chip` (outline / destructive variants) but built
- * on `<a>` so the chip is a real link — keyboard focusable, in-page anchor,
+ * Built on `<a>` so it's a real link — keyboard focusable, in-page anchor,
  * works with `Tab` traversal without `tabIndex` overrides.
  */
 export interface IngredientChipProps {

--- a/packages/app-food/src/components/RecipeIngredientList.tsx
+++ b/packages/app-food/src/components/RecipeIngredientList.tsx
@@ -7,14 +7,10 @@ import { formatQty, lineAnchorId, lineCanonicalQty } from './RecipeRenderer.help
 import type { RecipeLineWithResolved } from './RecipeRenderer.types';
 
 /**
- * Render the ingredients section — PRD-121.
- *
  * Each `<li>` carries an `id` derived from the line's `position` so step
  * body chips can scroll the matching row into view via `#line-N` anchors.
- *
- * Scaling multiplies the canonical quantity; the original-text aside (the
- * "(originally 1 cup)" hint) is left unscaled because it is the literal
- * the user typed.
+ * Scaling multiplies the canonical quantity; the original-text aside is
+ * left unscaled because it is the literal the user typed.
  */
 export interface RecipeIngredientListProps {
   lines: RecipeLineWithResolved[];

--- a/packages/app-food/src/components/RecipeRenderer.helpers.ts
+++ b/packages/app-food/src/components/RecipeRenderer.helpers.ts
@@ -1,24 +1,15 @@
-/**
- * Pure helpers shared across `RecipeRenderer` subcomponents — PRD-121.
- *
- * Everything here is deterministic. `scaleFactor` clamping, yield-label
- * assembly, canonical-quantity selection, and anchor matching are written
- * as pure functions so the test suite can exercise edge cases without
- * mounting React.
- */
 import type { IngredientRow, IngredientVariantRow, PrepStateRow } from '@pops/db-types';
 
 import type { RecipeLineWithResolved } from './RecipeRenderer.types';
 
 /**
- * `scaleFactor=0` or negative is clamped to 1.0 per PRD AC line 229 — the
- * caller may still pass valid fractional / large scales like 0.5 or 4.
+ * `scaleFactor=0` or negative is clamped to 1.0. Fractional / large scales
+ * (0.5, 4, …) pass through.
  *
  * The console warning is one-shot per (module-load × invalid value) so a
  * caller that re-renders with the same broken value every frame doesn't
- * spam the console — yet a caller that toggles between two different
- * broken values still gets one signal per offender. Tracked in module
- * state so the runtime cost is a single `Set.has`.
+ * spam the console; a caller that toggles between two broken values still
+ * gets one signal per offender.
  */
 const warnedInvalidScaleFactors = new Set<number | string>();
 
@@ -95,7 +86,7 @@ export function buildYieldLabel(args: {
 
 /**
  * DOM id used to scroll-target an ingredient list row from a step ref —
- * matches the `#line-N` anchor PRD-116 writes into `body_md`.
+ * matches the `#line-N` anchor written into `body_md` at compile time.
  */
 export function lineAnchorId(position: number): string {
   return `line-${position}`;

--- a/packages/app-food/src/components/RecipeRenderer.tsx
+++ b/packages/app-food/src/components/RecipeRenderer.tsx
@@ -19,19 +19,14 @@ export type {
 } from './RecipeRenderer.types';
 
 /**
- * Cookbook-styled read view of a compiled recipe — PRD-121.
- *
- * Pure presentation. The renderer never queries — `recipeVersion` is the
- * full joined payload PRD-119's `food.recipes.getForRendering(versionId)`
- * builds server-side. Click callbacks fire-and-forget (cooking-mode owns
- * timer state).
+ * Cookbook-styled read view of a compiled recipe. Pure presentation —
+ * `recipeVersion` is the full joined payload built server-side.
  *
  * Renders the "not yet compiled" placeholder for any non-`compiled`
  * status; renders the archived banner for any recipe with `archived_at`.
  *
  * `variant='compact'` is the list-card preview — a single row with thumb
- * + title + quick facts; suitable for `/food/recipes` list and the
- * solver's "what can I cook" results (Epic 06).
+ * + title + quick facts.
  */
 export function RecipeRenderer({
   recipeVersion,

--- a/packages/app-food/src/components/RecipeRenderer.types.ts
+++ b/packages/app-food/src/components/RecipeRenderer.types.ts
@@ -1,15 +1,9 @@
 /**
- * Joined display types consumed by `RecipeRenderer` — PRD-121.
+ * Joined display types consumed by `RecipeRenderer`. The server procedure
+ * assembling the payload imports from here too, so the page, server, and
+ * Storybook all share the same shape.
  *
- * The renderer owns the shape of `RecipeVersionWithCompiledData` and the
- * per-line `RecipeLineWithResolved` join (PRD-121 line 38 — the joined-row
- * shape lives with the renderer because the renderer renders it; PRD-119's
- * `food.recipes.getForRendering(versionId)` server procedure assembles the
- * payload). Defined here so the page, server procedure, Storybook stories,
- * and tests all import from the same place.
- *
- * No runtime code in this file — pure types, safe to import from the
- * server-side procedure without pulling React into the worker bundle.
+ * Pure types — safe to import server-side without pulling React in.
  */
 import type {
   IngredientRow,
@@ -21,13 +15,12 @@ import type {
 } from '@pops/db-types';
 
 /**
- * Joined display row for `recipe_lines` (PRD-116) — the raw column set plus
- * the ingredient / variant / prep_state / recipe-ref names needed to render
- * a row without further round-trips. PRD-119 builds this server-side; the
- * renderer is pure presentation.
+ * Joined display row for `recipe_lines` — raw columns plus the ingredient /
+ * variant / prep_state / recipe-ref names needed to render without further
+ * round-trips. Built server-side; the renderer is pure presentation.
  */
 export interface RecipeLineWithResolved {
-  // recipe_lines columns (PRD-116):
+  // recipe_lines columns:
   id: number;
   position: number;
   ingredientId: number;
@@ -58,18 +51,15 @@ export interface RecipeLineWithResolved {
 }
 
 /**
- * Everything `RecipeRenderer` needs to render a compiled recipe. The recipe
- * header lives on `recipes` (PRD-107) and the content on `recipe_versions`
- * (PRD-107); the compiled lines and steps live on `recipe_lines` /
- * `recipe_steps` (PRD-116). Yields join out to the relevant ingredient /
- * variant / prep_state rows for the human label.
+ * Everything `RecipeRenderer` needs. Yields join out to the relevant
+ * ingredient / variant / prep_state rows for the human label.
  */
 export interface RecipeVersionWithCompiledData {
   version: RecipeVersionRow;
   recipe: RecipeRow;
   lines: RecipeLineWithResolved[];
   steps: RecipeStepRow[];
-  /** PRD-107 — yield foreign keys are nullable while the slug is auto-created. */
+  /** Yield FKs are nullable while the slug is auto-created. */
   yieldIngredient: IngredientRow | null;
   yieldVariant: IngredientVariantRow | null;
   yieldPrepState: PrepStateRow | null;
@@ -84,11 +74,8 @@ export interface RecipeRendererProps {
   /** Display-only multiplier on quantities. Defaults to 1.0. */
   scaleFactor?: number;
   /**
-   * Fire-and-forget — `RecipeRenderer` does not track running timers, so
-   * the parent owns timer state. The cooking-mode surface (deferred per
-   * PRD-121 Out of Scope) will wire the stop side; the renderer doesn't
-   * surface a Stop interaction itself, so `onTimerStop` is intentionally
-   * not part of the v1 API.
+   * Fire-and-forget — the renderer does not track running timers, so the
+   * parent owns timer state. There is no Stop interaction here.
    */
   onTimerStart?: (durationMinutes: number, stepPosition: number) => void;
   /** `'detail'` is the full page; `'compact'` is the list-card preview. */

--- a/packages/app-food/src/components/RecipeStepBody.tsx
+++ b/packages/app-food/src/components/RecipeStepBody.tsx
@@ -12,24 +12,20 @@ import type { ResolvedStepBody, ResolvedStepBodyPart } from '../dsl/resolver-typ
 import type { RecipeLineWithResolved } from './RecipeRenderer.types';
 
 /**
- * Render a compiled step body — PRD-121's two-pass markdown approach.
+ * Two-pass step-body render:
  *
- * 1. `body_md` (PRD-116) is markdown with structural refs already rewritten
- *    as anchor links (`[name](#line-3)`, `[2 min](#timer)`, ...). It is the
- *    text + emphasis source of truth.
- * 2. `body_resolved_json` (also PRD-116) is the typed `ResolvedStepBody`
- *    array: text segments plus `ref` / `time` / `temperature` parts. The
- *    structured parts carry the data the chips / timers / temps need
- *    (ingredient id, duration value, temp unit).
+ * 1. `body_md` is markdown with structural refs rewritten as anchor links
+ *    (`[name](#line-3)`, `[2 min](#timer)`, ...). Text/emphasis source of
+ *    truth.
+ * 2. `body_resolved_json` is the typed `ResolvedStepBody`: text segments
+ *    plus `ref` / `time` / `temperature` parts carrying ingredient ids,
+ *    duration values, temp units.
  *
  * As we encounter each anchor in the rendered markdown we pop the next
- * matching part from `body_resolved_json`. Counts must agree (the compile
- * pipeline guarantees this); if they don't, we degrade to a plain link so
- * the body is still readable.
- *
- * Unresolved index refs (`ref.ingredientIndex !== null` with no matching
- * `lines[].position`) render the chip with a destructive error badge per
- * PRD edge-case "Step body with an unresolved `@N`".
+ * matching part from `body_resolved_json`. Counts must agree (compile
+ * guarantees this); on mismatch we degrade to a plain link so the body
+ * stays readable. Unresolved index refs render the chip with a
+ * destructive error badge.
  */
 export interface RecipeStepBodyProps {
   bodyMd: string;

--- a/packages/app-food/src/components/RecipeStepList.tsx
+++ b/packages/app-food/src/components/RecipeStepList.tsx
@@ -9,17 +9,14 @@ import type { ResolvedStepBody } from '../dsl/resolver-types';
 import type { RecipeLineWithResolved } from './RecipeRenderer.types';
 
 /**
- * Render the steps section — PRD-121.
+ * Each step row's `body_resolved_json` is parsed into a `ResolvedStepBody`
+ * and passed alongside `body_md` to the per-step body renderer for the
+ * two-pass substitution. Step-level `duration_minutes` and `temperature_*`
+ * surface as separate badges — distinct from inline `@time` /
+ * `@temperature` widgets inside the markdown body.
  *
- * Each step row's `body_resolved_json` (PRD-116) is parsed into the typed
- * `ResolvedStepBody` shape and passed alongside `body_md` to the per-step
- * body renderer for the two-pass substitution. Step-level
- * `duration_minutes` and `temperature_*` columns surface as separate
- * badges per PRD line 139 — distinct from inline `@time` / `@temperature`
- * widgets in the markdown body.
- *
- * A defensive parse fall-back on the JSON column produces an empty body —
- * we still render the markdown verbatim so the step is readable.
+ * A defensive parse fall-back on the JSON column produces an empty body
+ * so the markdown still renders.
  */
 export interface RecipeStepListProps {
   steps: RecipeStepRow[];

--- a/packages/app-food/src/components/TempBadge.tsx
+++ b/packages/app-food/src/components/TempBadge.tsx
@@ -3,21 +3,17 @@ import { useTranslation } from 'react-i18next';
 import { Badge } from '@pops/ui';
 
 /**
- * `@temperature(...)` rendered as a small badge inside step bodies — PRD-121.
- *
- * Renders the unit symbol per AC line 221:
+ * `@temperature(...)` rendered as a small badge:
  *   `:c`   → `180 °C`
  *   `:f`   → `350 °F`
  *   `:gas` → `Gas 5`
  *
- * Cosmetic only — no click behaviour, no callback. Step-level temperature
- * (PRD-116's hoist column) renders the same way as inline `@temperature`;
- * the renderer reuses this component for both.
+ * Cosmetic only. Step-level temperature reuses this component.
  */
 export interface TempBadgeProps {
   /** Numeric value. */
   value: number;
-  /** Normalised PRD-116 unit. */
+  /** Normalised unit. */
   unit: 'c' | 'f' | 'gas';
 }
 

--- a/packages/app-food/src/components/TimerButton.tsx
+++ b/packages/app-food/src/components/TimerButton.tsx
@@ -4,24 +4,17 @@ import { useTranslation } from 'react-i18next';
 import { cn } from '@pops/ui';
 
 /**
- * `@time(...)` rendered as a tappable button inside step bodies — PRD-121.
- *
- * Fire-and-forget — clicking emits `onTimerStart(durationMinutes, stepPosition)`
- * but the button itself owns no state. The future cooking-mode surface owns
- * timer tracking; in `variant='detail'` the click is informational (caller
- * can ignore the callback).
- *
- * `unit` is the original DSL unit (`min`, `h`, `s`, etc.); display formats
- * humanely. `durationMinutes` is the normalised value PRD-116 hoists for
- * fast queries; the callback receives this value because cooking mode
- * always reasons in minutes.
+ * `@time(...)` rendered as a tappable button. Fire-and-forget — clicking
+ * emits `onTimerStart(durationMinutes, stepPosition)` but the button itself
+ * owns no state. `unit` is the original DSL unit (display); the callback
+ * always receives normalised minutes.
  */
 export interface TimerButtonProps {
   /** Original quantity from the DSL — `[2 min]` shows "2 min". */
   qty: number;
   /** Original unit from the DSL — `min`, `h`, `hr`, `hour`, `s`, `sec`. */
   unit: string;
-  /** Normalised duration in minutes (PRD-116 hoist column). */
+  /** Normalised duration in minutes. */
   durationMinutes: number;
   /** Step position the timer belongs to — passed back to the callback. */
   stepPosition: number;

--- a/packages/app-food/src/components/hero-image-uploader/HeroDropZone.tsx
+++ b/packages/app-food/src/components/hero-image-uploader/HeroDropZone.tsx
@@ -1,7 +1,6 @@
 /**
- * Drop-zone for the empty hero state (PRD-124). Exposed as a `role="button"`
- * so keyboard activation (Enter / Space) opens the file picker — drag-drop
- * is supported alongside the click path.
+ * Drop-zone for the empty hero state. `role="button"` so keyboard
+ * activation (Enter / Space) opens the file picker.
  */
 import type { JSX } from 'react';
 

--- a/packages/app-food/src/components/hero-image-uploader/HeroPreview.tsx
+++ b/packages/app-food/src/components/hero-image-uploader/HeroPreview.tsx
@@ -1,12 +1,10 @@
 import { Button } from '@pops/ui';
 
 /**
- * Hero image preview + Replace/Remove action row (PRD-124).
- *
- * The card-size thumb is shown by default; if it 404s (likely cause: the
- * sharp thumbnail step failed during upload), `onError` swaps in the
- * original URL once. The `img.onerror = null` reset prevents an infinite
- * fallback loop when the original is missing too.
+ * Hero image preview + Replace/Remove action row. The card-size thumb is
+ * shown by default; if it 404s, `onError` swaps in the original URL once.
+ * The `img.onerror = null` reset prevents an infinite fallback loop when
+ * the original is missing too.
  */
 import type { JSX } from 'react';
 

--- a/packages/app-food/src/components/useDslEditorView.ts
+++ b/packages/app-food/src/components/useDslEditorView.ts
@@ -1,34 +1,24 @@
 /**
- * `useDslEditorView` — owns the imperative CodeMirror 6 lifecycle for the
- * DSL editor (PRD-120 part A; autocomplete extension added in 120-B;
- * issues / squiggles / tooltip in 120-C; chip widgets + mobile fallback
- * in 120-D).
+ * Owns the imperative CodeMirror 6 lifecycle for the DSL editor:
  *
- * Pulled out of `DslEditor.tsx` so the component itself stays under the
- * lint cap and the React surface is purely declarative. The hook:
- *
- *   - Mounts a single `EditorView` into the supplied host div on first
- *     render and tears it down on unmount.
+ *   - Mounts a single `EditorView` into the host div on first render and
+ *     tears it down on unmount.
  *   - Toggles `EditorState.readOnly` + `EditorView.editable` via a
- *     `Compartment.reconfigure` transaction so the swap doesn't blow away
- *     the undo history or cursor position.
- *   - Re-syncs the document when `initialValue` changes from outside
- *     (parent loaded a new version). One-way only — the parent owns the
- *     canonical value via the debounced `onChange`.
+ *     `Compartment.reconfigure` so the swap doesn't blow away undo
+ *     history or cursor position.
+ *   - Re-syncs the document when `initialValue` changes from outside.
+ *     One-way only — the parent owns the canonical value via the
+ *     debounced `onChange`.
  *   - Watches `window.matchMedia('(max-width: 767px)')` and reconfigures
  *     the chip-widgets compartment between desktop (widget-replace) and
- *     mobile (inline-mark) renderings. The swap is a compartment
- *     reconfigure so cursor + undo state stay intact when the user rotates
- *     a tablet or resizes the window.
+ *     mobile (inline-mark) renderings.
  *   - Reads autocomplete lookups through a ref-backed proxy so the
- *     extension picks up source swaps from PRD-120 part B without
- *     re-mounting the EditorView.
+ *     extension picks up source swaps without re-mounting the EditorView.
  *
- * The hook deliberately doesn't return the `EditorView`; callers that
- * need it (tests, future plumbing) reach for
- * `EditorView.findFromDOM(host.querySelector('.cm-editor'))` instead.
- * That keeps the React render path immune to the imperative view's
- * mutation timeline.
+ * The hook deliberately doesn't return the `EditorView`; callers that need
+ * it (tests, autocomplete plumbing) reach for
+ * `EditorView.findFromDOM(host.querySelector('.cm-editor'))` instead, so
+ * the React render path stays immune to the imperative view's mutations.
  */
 import { defaultKeymap, history, historyKeymap } from '@codemirror/commands';
 import { bracketMatching, defaultHighlightStyle, syntaxHighlighting } from '@codemirror/language';
@@ -52,11 +42,11 @@ export interface UseDslEditorViewOptions {
   onChange: (value: string) => void;
   readOnly: boolean;
   issues: readonly CompileEditorIssue[];
-  /** Autocomplete lookups (PRD-120 part B). When `null`, the
-   *  autocomplete extension still mounts but every source resolves to
-   *  an empty list — useful in tests that don't want to stub the
-   *  lookups and in callers that haven't wired up the React Query hook
-   *  yet. */
+  /**
+   * Autocomplete lookups. When `null`, the extension still mounts but every
+   * source resolves to an empty list — useful in tests that don't want to
+   * stub the lookups.
+   */
   autocompleteSources: DslAutocompleteSources | null;
 }
 

--- a/packages/app-food/src/dsl/ast.ts
+++ b/packages/app-food/src/dsl/ast.ts
@@ -1,10 +1,8 @@
 /**
- * Recipe DSL AST — PRD-114 / ADR-023.
- *
- * Drizzle-independent: the parser is pure text processing and emits these
- * shapes verbatim. PRD-115's resolver later turns slug references into entity
- * ids; PRD-116 materialises into `recipe_lines` / `recipe_steps`. The AST is
- * a stable contract between the parser and those downstream stages.
+ * Recipe DSL AST. See ADR-023 for the grammar. Drizzle-independent:
+ * the parser is pure text processing and emits these shapes verbatim.
+ * The resolver turns slug references into entity ids; compile materialises
+ * into `recipe_lines` / `recipe_steps`.
  */
 
 /** 1-indexed source position used in editor diagnostics. */

--- a/packages/app-food/src/dsl/codemirror.ts
+++ b/packages/app-food/src/dsl/codemirror.ts
@@ -1,17 +1,13 @@
 /**
- * CodeMirror 6 language extension for the recipe DSL — PRD-120 part A.
+ * CodeMirror 6 language extension for the recipe DSL. Wraps the Lezer
+ * parser from `./dsl-parser` (generated from `./dsl.grammar`) in an
+ * `LRLanguage`, maps node names to highlight tags, and configures language
+ * metadata (line comment marker, bracket-matching). Folding for multi-line
+ * `@recipe(...)` is supplied by `foldNodeProp`.
  *
- * Wraps the Lezer parser from `./dsl-parser` (generated from `./dsl.grammar`)
- * in an `LRLanguage`, maps node
- * names to highlight tags, and configures language metadata (line comment
- * marker, bracket-matching). Folding for multi-line `@recipe(...)` is
- * supplied by `foldNodeProp` so CodeMirror's built-in folding gutter can
- * pick it up without extra wiring at the editor level.
- *
- * The Lezer grammar is the source of highlighting truth, and the parity
- * test in `__tests__/lezer-parity.test.ts` keeps it aligned with the
- * canonical hand-rolled parser at `parser.ts` (PRD-114). If the two ever
- * diverge, that test trips before the editor ships a broken highlight.
+ * The Lezer grammar is the source of highlighting truth; the parity test
+ * in `__tests__/lezer-parity.test.ts` keeps it aligned with the hand-rolled
+ * parser at `parser.ts`.
  */
 import {
   LRLanguage,

--- a/packages/app-food/src/dsl/compile-creations.ts
+++ b/packages/app-food/src/dsl/compile-creations.ts
@@ -1,14 +1,11 @@
 /**
- * Apply `ResolverCreation[]` against the DB — PRD-116.
- *
- * Order: ingredients first, then variants (variants reference parent
- * ingredients by slug). All creations run inside the compile transaction,
- * so a failure rolls them back atomically with everything else.
+ * Apply `ResolverCreation[]` against the DB. Ingredients first, then variants
+ * (variants reference parent ingredients by slug). Runs inside the compile
+ * transaction.
  *
  * After creations land, the compile pipeline re-runs `resolveRecipeAst`
  * against the original AST — cleaner than rebinding ids on the existing
- * resolved blocks, since slug_registry now contains every newly-created
- * row.
+ * resolved blocks, since `slug_registry` now contains every new row.
  */
 import { eq } from 'drizzle-orm';
 

--- a/packages/app-food/src/dsl/compile-finalise.ts
+++ b/packages/app-food/src/dsl/compile-finalise.ts
@@ -1,9 +1,8 @@
 /**
- * Failure-path helpers for the PRD-116 compile pipeline.
- *
- * Each `failX` writes `compile_status='failed'` + a structured `compile_error`
- * JSON onto `recipe_versions`, clears any prior `recipe_lines` / `recipe_steps`,
- * and returns a typed `CompileResult` the caller surfaces verbatim.
+ * Failure-path helpers. Each `failX` writes `compile_status='failed'` plus a
+ * structured `compile_error` JSON onto `recipe_versions`, clears any prior
+ * `recipe_lines` / `recipe_steps`, and returns a typed `CompileResult` the
+ * caller surfaces verbatim.
  */
 import { eq } from 'drizzle-orm';
 

--- a/packages/app-food/src/dsl/compile-helpers.ts
+++ b/packages/app-food/src/dsl/compile-helpers.ts
@@ -1,8 +1,3 @@
-/**
- * Pure helpers for the PRD-116 compile pipeline.
- *
- * Kept separate so `compile.ts` stays within the 200-line file cap.
- */
 import { inArray } from 'drizzle-orm';
 
 import { ingredients } from '@pops/app-food-db';

--- a/packages/app-food/src/dsl/compile-lines.ts
+++ b/packages/app-food/src/dsl/compile-lines.ts
@@ -1,15 +1,12 @@
 import { normaliseLineQty } from './normalisation';
 
-import type { CanonicalUnit } from '@pops/app-food-db';
+import type { CanonicalUnit, FoodDb } from '@pops/app-food-db';
 /**
- * `recipe_lines` materialiser — PRD-116 + PRD-123.
- *
- * Maps a `ResolvedIngredientBlock` + the author's original descriptor
- * string to an INSERT row. PRD-123 upgraded the normalisation step from
- * identity carry-over to a 3-step lookup in `unit_conversions` and
- * `ingredient_weights` — handled by `normaliseLineQty` in `normalisation.ts`.
+ * `recipe_lines` materialiser. Maps a `ResolvedIngredientBlock` plus the
+ * author's original descriptor string to an INSERT row. The normalisation
+ * step is delegated to `normaliseLineQty` (3-step lookup in
+ * `unit_conversions` and `ingredient_weights`).
  */
-import type { FoodDb } from '@pops/app-food-db';
 
 import type { ResolvedIngredientBlock } from './resolver-types';
 

--- a/packages/app-food/src/dsl/compile-md.ts
+++ b/packages/app-food/src/dsl/compile-md.ts
@@ -1,7 +1,5 @@
 /**
- * Step body markdown rewriting — PRD-116.
- *
- * Each `ResolvedStepBodyPart` becomes a markdown chunk:
+ * Step body markdown rewriting. Each `ResolvedStepBodyPart` becomes:
  *
  *   text         → verbatim
  *   ref (index)  → `[label](#line-N)` — anchor stable per version
@@ -9,9 +7,8 @@
  *   time         → `[qty unit](#timer)`
  *   temperature  → `[qty°unit](#temperature)`
  *
- * The renderer (Epic 01) consumes either `body_md` or `body_resolved_json`
- * depending on the surface — markdown for the static cookbook view, the
- * resolved JSON for cooking-mode timers.
+ * The renderer consumes either `body_md` or `body_resolved_json` — markdown
+ * for the static cookbook view, JSON for cooking-mode timers.
  */
 import type { ResolvedStepBody, ResolvedStepBodyPart } from './resolver-types.js';
 
@@ -24,8 +21,8 @@ export type LineLabelMap = ReadonlyMap<number, string>;
 
 /**
  * Lookup from `ingredients.id` to the canonical `ingredients.slug`. Used to
- * render `@slug` step refs (the resolver pins these to `ingredientId`, not
- * the original text) as `[slug](#ingredient-slug)` per the PRD-116 spec.
+ * render `@slug` step refs as `[slug](#ingredient-slug)` (the resolver pins
+ * these to `ingredientId`, not the original text).
  */
 export type IngredientSlugMap = ReadonlyMap<number, string>;
 

--- a/packages/app-food/src/dsl/compile-steps.ts
+++ b/packages/app-food/src/dsl/compile-steps.ts
@@ -1,10 +1,8 @@
 import { renderBodyMd, type RenderContext } from './compile-md.js';
 
 /**
- * `recipe_steps` materialiser — PRD-116.
- *
- * Maps a `ResolvedStepBlock` to its INSERT shape. `body_md` is the
- * rewritten markdown (per `compile-md.ts`); `body_resolved_json` is the
+ * `recipe_steps` materialiser. Maps a `ResolvedStepBlock` to its INSERT
+ * shape. `body_md` is the rewritten markdown; `body_resolved_json` is the
  * raw `ResolvedStepBody` so the cooking-mode UI can render typed timers /
  * ingredient chips. `duration_minutes`, `temperature_value`, and
  * `temperature_unit` hoist the named args out for fast queries.

--- a/packages/app-food/src/dsl/compile-types.ts
+++ b/packages/app-food/src/dsl/compile-types.ts
@@ -1,12 +1,4 @@
 import type { CycleError } from './cycle-types.js';
-/**
- * Compile types — PRD-116.
- *
- * `compileRecipeVersion` runs the parse → resolve → cycle → materialise
- * pipeline against a single `recipe_versions` row, in one Drizzle
- * transaction. The result carries either row counts (success) or a
- * structured error payload (failure).
- */
 import type { ParseError } from './errors.js';
 import type { ResolveError } from './resolver-types.js';
 

--- a/packages/app-food/src/dsl/compile.ts
+++ b/packages/app-food/src/dsl/compile.ts
@@ -1,11 +1,8 @@
 /**
- * Recipe compile pipeline — PRD-116.
- *
- * Takes a `recipe_versions.id`, runs parse → resolve → cycle → materialise
- * in one Drizzle transaction, and writes `recipe_lines`, `recipe_steps`,
- * `recipe_version_proposed_slugs` rows alongside an update to
- * `recipe_versions` (compile_status, compile_error, compiled_at, plus the
- * header columns hoisted from `@recipe(...)` and `@yield(...)`).
+ * Recipe compile pipeline. Takes a `recipe_versions.id`, runs
+ * parse → resolve → cycle → materialise in one Drizzle transaction, and
+ * writes `recipe_lines`, `recipe_steps`, `recipe_version_proposed_slugs`
+ * rows alongside an update to `recipe_versions`.
  */
 import { eq } from 'drizzle-orm';
 

--- a/packages/app-food/src/dsl/cycle-types.ts
+++ b/packages/app-food/src/dsl/cycle-types.ts
@@ -1,13 +1,5 @@
 import type { FoodDb } from '@pops/app-food-db';
 
-/**
- * Recipe-graph cycle detection types — PRD-117.
- *
- * The detector runs between PRD-115 (resolver) and PRD-116 (compile +
- * materialise). It walks the live recipe graph from a candidate recipe's
- * recipe-as-ingredient targets; a path back to the candidate itself is a
- * cycle.
- */
 import type { SourceSpan } from './ast';
 
 export interface CycleContext {

--- a/packages/app-food/src/dsl/cycle.ts
+++ b/packages/app-food/src/dsl/cycle.ts
@@ -1,17 +1,13 @@
 /**
- * Recipe-graph cycle detector — PRD-117 / ADR-022.
+ * Recipe-graph cycle detector. Given a candidate recipe's `ResolvedRecipeAst`
+ * and the live recipe graph in `recipe_lines`, determines whether the
+ * candidate participates in a cycle. Runs between resolve and materialise.
  *
- * Given a candidate recipe's `ResolvedRecipeAst` (from PRD-115) and the
- * live recipe graph in the DB (from PRD-116's `recipe_lines`), determine
- * whether the candidate participates in a cycle. The detector is the last
- * gate before materialisation: PRD-116's compile calls `detectRecipeCycle`
- * between resolve and write.
- *
- * Algorithm: iterative DFS from each candidate target T. The explicit
- * stack + parent map avoids both recursion (no overflow on pathological
- * graphs) and a costly post-walk path reconstruction. The `recipe_lines`
- * read is one prepared SELECT per visited node; `pathSlugs` is one
- * batched SELECT against `recipes`.
+ * Algorithm: iterative DFS from each candidate target T. The explicit stack +
+ * parent map avoids both recursion (no overflow on pathological graphs) and a
+ * costly post-walk path reconstruction. The `recipe_lines` read is one
+ * prepared SELECT per visited node; `pathSlugs` is one batched SELECT
+ * against `recipes`.
  */
 import { sql } from 'drizzle-orm';
 
@@ -48,9 +44,9 @@ function collectTargets(resolved: ResolvedRecipeAst): readonly CandidateTarget[]
 function walk(target: CandidateTarget, ctx: CycleContext): CycleDescription | null {
   const currentId = ctx.currentRecipeId;
   if (currentId === null) return null;
-  // Defensive self-loop: candidate references itself directly. PRD-115's
-  // SelfReferenceRecipe normally catches this earlier — this branch is a
-  // safety net for callers that bypass the resolver.
+  // Defensive self-loop: candidate references itself directly. The resolver's
+  // SelfReferenceRecipe normally catches this earlier — safety net for
+  // callers that bypass the resolver.
   if (target.recipeId === currentId) {
     return buildDescription([currentId, currentId], target.loc, ctx);
   }

--- a/packages/app-food/src/dsl/errors.ts
+++ b/packages/app-food/src/dsl/errors.ts
@@ -1,10 +1,7 @@
 /**
- * Recipe DSL parser errors — PRD-114.
- *
  * The parser collects every recoverable error (e.g. a malformed `@step` is
  * skipped and parsing continues at the next line). Non-recoverable errors
- * (unbalanced parens at file scope) short-circuit. The result is a single
- * `ParseResult` with N errors covering all the bad bits.
+ * (unbalanced parens at file scope) short-circuit.
  */
 import type { SourceSpan } from './ast.js';
 

--- a/packages/app-food/src/dsl/index.ts
+++ b/packages/app-food/src/dsl/index.ts
@@ -1,9 +1,3 @@
-/**
- * Public surface of the recipe DSL parser — PRD-114.
- *
- * Downstream PRDs import from `@pops/app-food` (or directly from
- * `./dsl/parser` / `./dsl/ast` / `./dsl/printer` inside this package).
- */
 export type {
   AstBlock,
   Descriptor,

--- a/packages/app-food/src/dsl/lex.ts
+++ b/packages/app-food/src/dsl/lex.ts
@@ -64,9 +64,8 @@ export function readString(c: Cursor): { value: string; terminated: boolean } | 
       return { value: out, terminated: true };
     }
     // Newlines inside a string terminate it as unterminated — strings are
-    // single-line in this DSL (PRD-114 recovery rule: `@step("...` with no
-    // closing quote raises UnterminatedString at the opening quote and the
-    // parser recovers at the next line).
+    // single-line. The parser raises UnterminatedString at the opening quote
+    // and recovers at the next line.
     if (ch === '\n') {
       return { value: out, terminated: false };
     }
@@ -81,7 +80,7 @@ export function readString(c: Cursor): { value: string; terminated: boolean } | 
       } else if (next === '' || next === '\n') {
         return { value: out, terminated: false };
       } else {
-        // Unknown escape — preserve backslash + char literally per PRD-114.
+        // Unknown escape — preserve backslash + char literally.
         out += '\\' + c.advance();
       }
       continue;

--- a/packages/app-food/src/dsl/normalisation.ts
+++ b/packages/app-food/src/dsl/normalisation.ts
@@ -1,14 +1,8 @@
 /**
- * Recipe-line unit normalisation — PRD-123.
- *
- * Wraps the conversion-service `resolveCanonicalQty` so PRD-116's compile
- * has a single helper to call per ingredient line. The fallback contract
- * (unresolved → ingredient's `default_unit`) is implemented here so the
- * compile pipeline doesn't need to know about the resolution algorithm.
- *
- * v1 (PRD-116) was identity carry-over only; this module replaces that
- * shape. Anything that previously called `carryOverMetric` should now
- * call `normaliseLineQty`.
+ * Wraps `resolveCanonicalQty` so the compile pipeline has a single helper
+ * per ingredient line. The fallback contract (unresolved → ingredient's
+ * `default_unit` with null qty) lives here, so compile stays oblivious to
+ * the resolution algorithm.
  */
 import { conversionsService } from '@pops/app-food-db';
 

--- a/packages/app-food/src/dsl/parse-ingredient-named.ts
+++ b/packages/app-food/src/dsl/parse-ingredient-named.ts
@@ -1,11 +1,5 @@
 import { readBoolean, readIdentifier, readNumber, readSlug, readString } from './lex.js';
 
-/**
- * Per-key named-arg readers for `@ingredient(...)` — PRD-114.
- *
- * Sibling of `parse-ingredient.ts`; per-key dispatch lives here so the
- * named-arg switch stays under the complexity / max-lines caps.
- */
 import type { Cursor } from './cursor.js';
 import type { ParseError } from './errors.js';
 

--- a/packages/app-food/src/dsl/parse-ingredient.ts
+++ b/packages/app-food/src/dsl/parse-ingredient.ts
@@ -3,7 +3,7 @@ import { readNumber, readQtyUnit, readSlug } from './lex.js';
 import { type PartialIngredient, readNamedArg } from './parse-ingredient-named.js';
 
 /**
- * `@ingredient(...)` parser — PRD-114.
+ * `@ingredient(...)` parser.
  *
  * Compact form: `(index, descriptor, qty:unit, optional?=bool, notes?=string)`.
  * Named form: `(index, slug, variant=, prep=, qty=, unit=, optional=, notes=)`.

--- a/packages/app-food/src/dsl/parse-recipe-assign.ts
+++ b/packages/app-food/src/dsl/parse-recipe-assign.ts
@@ -1,11 +1,5 @@
 import { readNumber, readQtyUnit, readString } from './lex.js';
 
-/**
- * Per-key value assigners for `@recipe(...)` — PRD-114.
- *
- * Kept in a sibling file so `parse-recipe.ts` stays under the 200-line cap
- * and `assignRecipeArg` stays under the function complexity / line caps.
- */
 import type { RecipeHeader, RecipeTypeLiteral } from './ast.js';
 import type { Cursor } from './cursor.js';
 import type { ParseError } from './errors.js';

--- a/packages/app-food/src/dsl/parse-recipe.ts
+++ b/packages/app-food/src/dsl/parse-recipe.ts
@@ -2,12 +2,9 @@ import { readIdentifier } from './lex.js';
 import { assignRecipeArg } from './parse-recipe-assign.js';
 
 /**
- * `@recipe(...)` parser — PRD-114.
- *
- * All args are named (key=value). Required: `slug`, `title`. Optional:
- * `servings`, `prep_time`, `cook_time`, `recipe_type`, `summary`. Per-key
- * value assignment lives in `parse-recipe-assign.ts` so this file stays
- * under the line cap.
+ * `@recipe(...)` parser. All args are named (key=value). Required: `slug`,
+ * `title`. Optional: `servings`, `prep_time`, `cook_time`, `recipe_type`,
+ * `summary`.
  */
 import type { RecipeHeader } from './ast.js';
 import type { Cursor } from './cursor.js';

--- a/packages/app-food/src/dsl/parse-step-body.ts
+++ b/packages/app-food/src/dsl/parse-step-body.ts
@@ -1,19 +1,17 @@
 import { isDigit, isSlugCont, isSlugStart } from './cursor.js';
 
 /**
- * Step body parser — PRD-114.
- *
- * Step bodies are quoted strings containing markdown text plus inline
- * references and inline functions:
+ * Step bodies are quoted strings containing markdown text plus inline refs
+ * and inline functions:
  *
  *   `@N`         — reference to ingredient with index N
- *   `@slug`      — reference to a registered slug (resolved by PRD-115)
+ *   `@slug`      — reference to a registered slug (resolved downstream)
  *   `@time(qty:unit)`         — inline timer
  *   `@temperature(qty:unit)`  — inline temperature widget
  *
- * Outside `@step` bodies, inline refs are syntax errors at the parser
- * level. Here, we accept any `@N` or `@slug` and record it as a `ref` AST
- * node — PRD-115 validates referents.
+ * Outside `@step` bodies, inline refs are syntax errors. Here, we accept
+ * any `@N` or `@slug` and record it as a `ref` AST node — the resolver
+ * validates referents.
  */
 import type { QtyUnit, StepBody, StepBodyPart } from './ast.js';
 

--- a/packages/app-food/src/dsl/parse-step.ts
+++ b/packages/app-food/src/dsl/parse-step.ts
@@ -2,12 +2,10 @@ import { readIdentifier, readQtyUnit, readString } from './lex.js';
 import { parseStepBody } from './parse-step-body.js';
 
 /**
- * `@step(...)` parser — PRD-114.
- *
- * Positional: one quoted string (the body). Then optional named args
- * `duration=qty:unit` and `temperature=qty:unit`. The body string is parsed
- * for inline `@N`, `@slug`, `@time(...)`, `@temperature(...)` via
- * `parseStepBody`.
+ * `@step(...)` parser. Positional: one quoted string (the body). Then
+ * optional named args `duration=qty:unit` and `temperature=qty:unit`. The
+ * body string is parsed for inline `@N`, `@slug`, `@time(...)`,
+ * `@temperature(...)` via `parseStepBody`.
  */
 import type { QtyUnit, StepBlock } from './ast.js';
 import type { Cursor } from './cursor.js';

--- a/packages/app-food/src/dsl/parse-yield.ts
+++ b/packages/app-food/src/dsl/parse-yield.ts
@@ -2,10 +2,8 @@ import { readSlug } from './lex.js';
 import { readDescriptor } from './parse-descriptor.js';
 
 /**
- * `@yield(...)` parser — PRD-114.
- *
- * Positional: `(descriptor, qty:unit)`. Special form `0:none` marks a
- * non-yielding recipe (techniques).
+ * `@yield(...)` parser. Positional: `(descriptor, qty:unit)`. Special form
+ * `0:none` marks a non-yielding recipe (techniques).
  */
 import type { YieldDecl } from './ast.js';
 import type { Cursor } from './cursor.js';

--- a/packages/app-food/src/dsl/parser-state.ts
+++ b/packages/app-food/src/dsl/parser-state.ts
@@ -4,13 +4,6 @@ import { parseRecipeArgs } from './parse-recipe.js';
 import { parseStepArgs } from './parse-step.js';
 import { parseYieldArgs } from './parse-yield.js';
 
-/**
- * Parser state + per-func handlers — PRD-114.
- *
- * Sibling of `parser.ts`. The top-level dispatcher lives there; the
- * specialised `handle*` functions for each `@func(...)` live here so
- * `parser.ts` stays under the line / complexity caps.
- */
 import type { AstBlock, IngredientBlock, RecipeAst, SourceSpan } from './ast.js';
 import type { ParseError } from './errors.js';
 

--- a/packages/app-food/src/dsl/parser-util.ts
+++ b/packages/app-food/src/dsl/parser-util.ts
@@ -1,16 +1,10 @@
-/**
- * Parser support utilities — PRD-114.
- *
- * Sibling of `parser.ts`. Keeps the entry-point file under the line cap.
- */
 import type { Cursor } from './cursor.js';
 import type { CursorMark } from './parser-state.js';
 
 /**
  * Find the offset of the matching `)` for a `(` that the cursor just passed.
- * Strings are single-line: a `\n` inside a string ends it (per PRD-114's
- * recovery rule), allowing paren matching to continue past an unterminated
- * string on subsequent lines.
+ * Strings are single-line: a `\n` inside a string ends it, allowing paren
+ * matching to continue past an unterminated string on subsequent lines.
  */
 export function findBalancedClose(c: Cursor): number {
   let depth = 1;

--- a/packages/app-food/src/dsl/parser.ts
+++ b/packages/app-food/src/dsl/parser.ts
@@ -11,7 +11,7 @@ import {
 import { findBalancedClose, recomputeLineCol } from './parser-util.js';
 
 /**
- * Recipe DSL parser entry point — PRD-114 / ADR-023.
+ * Recipe DSL parser entry point. Grammar in ADR-023.
  *
  * Scans the input at the top level. When a line starts with `@<func>(`
  * (whitespace-tolerant), reads the balanced-paren block and dispatches to

--- a/packages/app-food/src/dsl/printer.ts
+++ b/packages/app-food/src/dsl/printer.ts
@@ -1,10 +1,6 @@
 /**
  * `printRecipeAst` — reverse of `parseRecipeDsl` modulo whitespace.
  *
- * Used by:
- *   - PRD-114 round-trip stability tests (parse → print → parse → assertEqual)
- *   - PRD-120's editor for "format on save" once the AST has been edited via UI
- *
  * Always emits the compact descriptor form (`slug:variant:prep` with `_` for
  * skipped middle segments). Markdown blocks are emitted verbatim. Inline
  * `@time` / `@temperature` / `@N` / `@slug` are re-inserted into step bodies.

--- a/packages/app-food/src/dsl/resolve-create.ts
+++ b/packages/app-food/src/dsl/resolve-create.ts
@@ -1,9 +1,7 @@
 /**
- * `deriveFromQty(unit)` + `ResolverCreation` builders — PRD-115.
- *
- * Per the PRD spec, the default_unit for an auto-created ingredient is
- * derived from the qty:unit it was first seen with. Unknown units fall
- * through to `count`; the user can refine in the management UI.
+ * The `default_unit` for an auto-created ingredient is derived from the
+ * `qty:unit` it was first seen with. Unknown units fall through to `count`;
+ * the user can refine in the management UI.
  */
 import type { SourceSpan } from './ast.js';
 import type { ResolverCreation } from './resolver-types.js';

--- a/packages/app-food/src/dsl/resolve-ingredient.ts
+++ b/packages/app-food/src/dsl/resolve-ingredient.ts
@@ -2,11 +2,9 @@ import { newIngredientCreation, newVariantCreation } from './resolve-create.js';
 import { lookupPrepState, lookupRecipeYield, lookupSlug, lookupVariant } from './resolve-slug.js';
 
 /**
- * `@ingredient(...)` resolver — PRD-115.
- *
- * Resolves the descriptor (ingredient[:variant[:prep]]) to entity ids,
+ * Resolves the descriptor `ingredient[:variant[:prep]]` to entity ids,
  * detects recipe-as-ingredient refs, and emits auto-create instructions
- * for unknown ingredient/variant slugs. Prep_states are curated — unknown
+ * for unknown ingredient/variant slugs. Prep states are curated — unknown
  * = error.
  */
 import type { IngredientBlock, SourceSpan } from './ast.js';

--- a/packages/app-food/src/dsl/resolve-slug.ts
+++ b/packages/app-food/src/dsl/resolve-slug.ts
@@ -1,9 +1,7 @@
 /**
- * Slug-registry lookup helpers — PRD-115.
- *
- * Read-only access against the food schema. Every lookup is by primary key
- * or by an indexed compound key, so resolution stays fast even on a
- * thousand-line recipe.
+ * Read-only slug-registry lookups. Every lookup is by primary key or an
+ * indexed compound key, so resolution stays fast even on a thousand-line
+ * recipe.
  */
 import { and, eq } from 'drizzle-orm';
 

--- a/packages/app-food/src/dsl/resolve-step.ts
+++ b/packages/app-food/src/dsl/resolve-step.ts
@@ -1,12 +1,9 @@
 import { lookupRecipeYield, lookupSlug } from './resolve-slug.js';
 
 /**
- * Step body resolver — PRD-115.
- *
- * Walks the step body parts and resolves inline `@N` (index) and `@slug`
- * references. Step refs do NOT auto-create — they're informational
- * pointers; missing refs raise `UnresolvedStepRefIndex` or
- * `UnresolvedStepRefSlug`.
+ * Walks step body parts and resolves inline `@N` (index) and `@slug`
+ * references. Step refs do NOT auto-create — missing refs raise
+ * `UnresolvedStepRefIndex` or `UnresolvedStepRefSlug`.
  */
 import type { SourceSpan, StepBlock, StepBodyPart } from './ast.js';
 import type { ResolverState } from './resolver-state.js';
@@ -134,9 +131,8 @@ function lookupSlugForStepRef(
     return emptyRef();
   }
   if (reg.kind === 'prep_state') {
-    // Step body refs treat any non-ingredient/recipe target as unresolved —
-    // per PRD-115, the consistent error code for a step-body @slug failure
-    // is UnresolvedStepRefSlug, paired with a proposedSlugs hint.
+    // Step body refs treat any non-ingredient/recipe target as unresolved;
+    // surface as UnresolvedStepRefSlug + proposedSlugs hint for consistency.
     state.errors.push({
       code: 'UnresolvedStepRefSlug',
       message: `@${slug} in step body resolves to a prep_state; expected an ingredient or recipe`,

--- a/packages/app-food/src/dsl/resolve-yield.ts
+++ b/packages/app-food/src/dsl/resolve-yield.ts
@@ -2,8 +2,6 @@ import { newIngredientCreation, newVariantCreation } from './resolve-create.js';
 import { lookupPrepState, lookupRecipeYield, lookupSlug, lookupVariant } from './resolve-slug.js';
 
 /**
- * `@yield(...)` resolver — PRD-115.
- *
  * Resolves the yield ingredient (or recipe → recipe's own yield), the
  * optional variant scoped under that ingredient, and the optional
  * prep_state (curated; no auto-create).
@@ -57,8 +55,7 @@ function resolveYieldHead(ctx: YieldCtx): number | null {
     return resolveYieldFromRecipe(ctx, reg.targetId);
   }
   // prep_state in the yield head slot is a kind-mismatch, not an unresolved
-  // ingredient — PRD-115 reserves UnresolvedYieldIngredient for genuine
-  // failure-to-resolve cases.
+  // ingredient — UnresolvedYieldIngredient is reserved for genuine failures.
   state.errors.push({
     code: 'WrongKindForContext',
     message: `@yield slug "${slug}" resolves to a ${reg.kind}; expected an ingredient or recipe`,

--- a/packages/app-food/src/dsl/resolver-state.ts
+++ b/packages/app-food/src/dsl/resolver-state.ts
@@ -1,11 +1,3 @@
-/**
- * Resolver accumulator state — PRD-115.
- *
- * Errors, proposed slugs, creations, and resolved blocks are gathered
- * across the whole AST walk. Per-block helpers push into the same
- * accumulator; the top-level `resolveRecipeAst` decides ok/!ok based on
- * `errors.length`.
- */
 import type { IngredientBlock } from './ast.js';
 import type {
   ProposedSlug,
@@ -24,7 +16,7 @@ export interface ResolverState {
   blocks: ResolvedBlock[];
   /** Maps `@N` index → resolved ingredient block for step-body lookup. */
   ingredientIndex: Map<number, ResolvedIngredientBlock>;
-  /** Maps ingredient slug → resolved id (for step `@slug` refs). Auto-created entries map to null until PRD-116 runs. */
+  /** Maps ingredient slug → resolved id (for step `@slug` refs). Auto-created entries map to null until compile runs. */
   resolvedSlugs: Map<string, number | null>;
   /** Pending source AST ingredient blocks indexed by `index` (for `@N` lookup fallback). */
   sourceIngredients: Map<number, IngredientBlock>;

--- a/packages/app-food/src/dsl/resolver-types.ts
+++ b/packages/app-food/src/dsl/resolver-types.ts
@@ -1,15 +1,5 @@
 import type { FoodDb } from '@pops/app-food-db';
 
-/**
- * Resolver types — PRD-115.
- *
- * The resolver takes a parser AST (PRD-114) and turns slug references into
- * entity IDs by reading `slug_registry` and the per-parent variant table
- * (PRD-106). PRD-116's compiler consumes the result.
- *
- * Pure types — no runtime code, so this file can be re-imported by the
- * package barrel without pulling in DB code.
- */
 import type { QtyUnit, RecipeHeader, SourceSpan } from './ast';
 
 export interface ResolveContext {
@@ -34,9 +24,8 @@ export type ResolveResult =
       ok: false;
       /**
        * Partial AST — known slugs / indexes are filled in; unresolved or
-       * wrong-kind references carry `null` ids. Callers (the Epic 03
-       * inbox renderer, error UIs) can still render the structure while
-       * flagging the per-line errors.
+       * wrong-kind references carry `null` ids. Callers can still render
+       * the structure while flagging the per-line errors.
        */
       resolved: ResolvedRecipeAst;
       errors: readonly ResolveError[];
@@ -51,7 +40,7 @@ export interface ResolvedRecipeAst {
 }
 
 export interface ResolvedYield {
-  /** Null while the yield slug is auto-created — PRD-116 fills it in. */
+  /** Null while the yield slug is auto-created — compile fills it in. */
   yieldIngredientId: number | null;
   yieldVariantId: number | null;
   yieldPrepStateId: number | null;
@@ -64,7 +53,7 @@ export type ResolvedBlock = ResolvedIngredientBlock | ResolvedStepBlock | Resolv
 export interface ResolvedIngredientBlock {
   kind: 'ingredient';
   index: number;
-  /** Null while auto-created — PRD-116 fills it in. */
+  /** Null while auto-created — compile fills it in. */
   ingredientId: number | null;
   variantId: number | null;
   prepStateId: number | null;

--- a/packages/app-food/src/dsl/resolver.ts
+++ b/packages/app-food/src/dsl/resolver.ts
@@ -4,17 +4,14 @@ import { resolveYield } from './resolve-yield.js';
 import { newResolverState } from './resolver-state.js';
 
 /**
- * Recipe DSL resolver entry point — PRD-115.
+ * Resolves every slug reference in the parser AST to a real entity id via
+ * `slug_registry`. Pure: read-only DB access, deterministic for a given
+ * `(ast, registry snapshot)` pair, no side effects.
  *
- * Takes the parser AST (PRD-114) and resolves every slug reference to a
- * real entity id via `slug_registry` (PRD-106). Pure: read-only DB
- * access, deterministic for a given `(ast, registry snapshot)` pair, no
- * side effects.
- *
- * Output: `ResolvedRecipeAst` plus `creations` (auto-create instructions
- * for unknown ingredient/variant slugs, processed by PRD-116's compiler)
- * and `proposedSlugs` (informational pointers for the Epic 03 review
- * queue when an LLM-ingested recipe carries unresolvable refs).
+ * Output: `ResolvedRecipeAst`, `creations` (auto-create instructions for
+ * unknown ingredient/variant slugs — processed downstream by compile),
+ * and `proposedSlugs` (review-queue pointers for unresolvable LLM-ingested
+ * refs).
  */
 import type { IngredientBlock, RecipeAst } from './ast.js';
 import type { ResolveContext, ResolveResult } from './resolver-types.js';

--- a/packages/app-food/src/index.ts
+++ b/packages/app-food/src/index.ts
@@ -1,14 +1,6 @@
-/**
- * @pops/app-food — Food app package
- *
- * Exports the module manifest, route table, and nav config consumed by the
- * shell. Pages and services are added incrementally per the food theme PRDs
- * (`docs/themes/07-food/`).
- */
 export { navConfig, routes } from './routes';
 export { manifest } from './manifest';
 
-// PRD-121 — DSL Renderer.
 export { RecipeRenderer } from './components/RecipeRenderer';
 export type {
   RecipeLineWithResolved,

--- a/packages/app-food/src/jobs/ingest-eviction.ts
+++ b/packages/app-food/src/jobs/ingest-eviction.ts
@@ -1,19 +1,13 @@
 /**
- * FIFO retention job for the food ingest media directory (PRD-110).
+ * FIFO retention for `${FOOD_INGEST_DIR}`. The pipeline writes one
+ * subdirectory per `ingest_sources.id`. This tick walks that root and,
+ * when the count exceeds `MAX_INGEST_DIRS`, deletes the oldest (by
+ * directory mtime) until the count is at the cap. For each evicted
+ * directory it stamps `ingest_sources.archived_at` so the row keeps its
+ * link to the recipe but the UI can tell the bytes are gone.
  *
- * The pipeline writes one subdirectory per `ingest_sources.id` under
- * `${FOOD_INGEST_DIR}`. This tick walks that root, and when the count
- * exceeds `MAX_INGEST_DIRS` deletes the oldest (by directory mtime) until
- * the count is at the cap. For each evicted directory it sets
- * `ingest_sources.archived_at` so the row keeps its link to the recipe
- * but the UI can tell the bytes are gone.
- *
- * The PRD's "5 GB target" is not enforced here — count-based eviction is
- * a deliberate v1 simplification (PRD-110 §Retention Policy).
- *
- * Scheduling lives in Epic 02's worker config. This module just exposes
- * `runEvictionTick(db, dir)` so the worker, a one-shot CLI, and the unit
- * tests can all invoke the same logic.
+ * Count-based eviction is a deliberate v1 simplification — there is no
+ * byte-size target.
  */
 import { type Stats } from 'node:fs';
 import { readdir, rm, stat } from 'node:fs/promises';
@@ -23,7 +17,7 @@ import { ingestSourcesService, type FoodDb } from '@pops/app-food-db';
 
 const { markArchived } = ingestSourcesService;
 
-/** Cap from PRD-110. Hard-coded; bumped centrally if the disk math changes. */
+/** Hard-coded cap; bump centrally if the disk math changes. */
 export const MAX_INGEST_DIRS = 100;
 
 /**

--- a/packages/app-food/src/pages/data/FoodDataLayout.tsx
+++ b/packages/app-food/src/pages/data/FoodDataLayout.tsx
@@ -1,11 +1,8 @@
 /**
- * Layout shell for `/food/data` (PRD-122).
- *
- * Renders the page header + a tab strip that links to each sub-route under
- * `/food/data/<slug>`. On narrow viewports the strip collapses to a native
- * `<select>` (acts as the mobile dropdown the PRD spec calls for) so the
- * tabs stay reachable at 375px without horizontal scroll. The active tab
- * comes from the URL — there is no client-side tab state.
+ * Layout shell for `/food/data`. Renders the page header + a tab strip
+ * that links to each sub-route under `/food/data/<slug>`. On narrow
+ * viewports the strip collapses to a native `<select>`. Active tab comes
+ * from the URL — no client-side tab state.
  */
 import { useTranslation } from 'react-i18next';
 import { NavLink, Outlet, useLocation, useNavigate } from 'react-router';

--- a/packages/app-food/src/pages/data/ingredients-tab/IngredientsTabContents.tsx
+++ b/packages/app-food/src/pages/data/ingredients-tab/IngredientsTabContents.tsx
@@ -1,7 +1,6 @@
 /**
- * Ingredients tab (PRD-122). Two-column layout: tree on the left,
- * detail panel on the right. Mobile collapses to single column (the
- * detail appears below the tree).
+ * Two-column layout: tree on the left, detail panel on the right. Mobile
+ * collapses to single column (detail appears below the tree).
  *
  * Orchestrates the detail panel's CRUD dialogs (rename / change-parent /
  * delete + variant create/edit/delete) and the `?focus=<slug>` deep-link

--- a/packages/app-food/src/pages/data/ingredients-tab/buildIngredientTree.ts
+++ b/packages/app-food/src/pages/data/ingredients-tab/buildIngredientTree.ts
@@ -1,13 +1,11 @@
 /**
  * Build a hierarchical tree of ingredients from a flat list.
  *
- * The food schema caps depth at 3 (PRD-106 invariant). The tree
- * enforces alphabetical (slug) order at every level — the API already
- * returns rows sorted that way (PRD-122-API), but the function sorts
- * defensively so callers that pass unsorted input still get
- * deterministic ordering. Orphan rows (parent_id points at an
- * ingredient that's missing from the list — e.g. because a search
- * filter dropped it) get re-rooted so they remain visible.
+ * Enforces alphabetical (slug) order at every level — the API already
+ * returns rows sorted that way, but we sort defensively so callers passing
+ * unsorted input still get deterministic ordering. Orphan rows (parent_id
+ * pointing at an ingredient missing from the list — e.g. a search filter
+ * dropped it) get re-rooted so they remain visible.
  */
 import type { IngredientRow } from '@pops/app-food-db';
 

--- a/packages/app-food/src/pages/data/tab-config.ts
+++ b/packages/app-food/src/pages/data/tab-config.ts
@@ -1,15 +1,9 @@
 /**
- * Tab metadata for the `/food/data` page (PRD-122).
- *
- * Drives the desktop tab strip and the mobile dropdown. The routes file
- * (`packages/app-food/src/routes.tsx`) declares each child route directly
- * — keep the two lists aligned by hand when a tab is added or removed.
- * Each entry's `slug` is the URL segment (`/food/data/<slug>`) and the
- * matching i18n key under the `food` namespace.
- *
- * Tab ownership:
- *   - ingredients/aliases/prep-states/substitutions — PRD-122 (this page)
- *   - conversions — placeholder; PRD-123 owns the contents
+ * Tab metadata for `/food/data`. Drives the desktop tab strip and the
+ * mobile dropdown. The routes file declares each child route directly —
+ * keep the two lists aligned by hand when a tab is added or removed.
+ * Each `slug` is the URL segment (`/food/data/<slug>`) and the matching
+ * i18n key under the `food` namespace.
  */
 export interface FoodDataTab {
   slug: 'ingredients' | 'aliases' | 'prep-states' | 'substitutions' | 'conversions';

--- a/packages/app-food/src/routes.tsx
+++ b/packages/app-food/src/routes.tsx
@@ -93,7 +93,6 @@ export const navConfig = {
   items: [
     { path: '', label: 'Home', labelKey: 'food.home', icon: 'LayoutDashboard' },
     { path: '/data', label: 'Manage data', labelKey: 'food.data', icon: 'Database' },
-    // Recipes sub-nav populated by PRD-119.
   ],
 } satisfies AppNavConfigShape;
 

--- a/packages/app-food/src/storage/hero-paths.node.ts
+++ b/packages/app-food/src/storage/hero-paths.node.ts
@@ -1,16 +1,11 @@
 /**
- * Node-only path helpers for recipe hero images (PRD-124).
+ * Node-only hero-image path helpers. Split from `./hero-paths.ts` because
+ * the browser-bound `HeroImageUploader` imports constants from that file
+ * and Vite cannot resolve `node:path` or read `process.env`.
  *
- * Split out from `./hero-paths.ts` because the browser-bound
- * `HeroImageUploader` component imports the URL builder + constants from
- * that file; Vite/browser bundles cannot resolve `node:path` or read
- * `process.env`. Anything that touches the filesystem layout's absolute
- * paths lives here.
- *
- * The same convention is mirrored inside `apps/pops-api/src/modules/food/
- * hero-image/paths.ts` — pops-api does not depend on `@pops/app-food` at
- * runtime, so the absolute-path helpers are duplicated there. Keep both
- * sources in sync if the layout changes.
+ * The same layout is mirrored at `apps/pops-api/src/modules/food/
+ * hero-image/paths.ts` — pops-api doesn't depend on `@pops/app-food` at
+ * runtime, so keep both sources in sync.
  */
 import { resolve, sep } from 'node:path';
 

--- a/packages/app-food/src/storage/hero-paths.ts
+++ b/packages/app-food/src/storage/hero-paths.ts
@@ -1,8 +1,6 @@
 /**
- * Browser-safe helpers for recipe hero images (PRD-124).
- *
- * Pure constants + filename validators + URL builder. NO `node:path`, NO
- * `process.env`, NO filesystem — those live in
+ * Browser-safe hero-image helpers: constants + filename validators + URL
+ * builder. NO `node:path`, NO `process.env`, NO filesystem — those live in
  * `./hero-paths.node.ts` so this module can be imported by browser bundles
  * (e.g. `HeroImageUploader`) without breaking Vite resolution.
  *

--- a/packages/app-food/src/storage/ingest-paths.ts
+++ b/packages/app-food/src/storage/ingest-paths.ts
@@ -1,15 +1,12 @@
 /**
- * Filesystem helpers for the food ingest media root (PRD-110).
+ * Filesystem helpers for the food ingest media root. The ingest root is
+ * configured via `FOOD_INGEST_DIR` and defaults to `./data/food/ingest`.
+ * Path columns in `ingest_sources` are stored relative to the root so
+ * deployments can relocate without rewriting rows.
  *
- * The ingest root is configured via `FOOD_INGEST_DIR` and defaults to
- * `./data/food/ingest`. Path columns in `ingest_sources` are stored
- * relative to the root so deployments can relocate without rewriting rows
- * — `ingestDirFor` joins the configured root each time it's read.
- *
- * All paths returned by these helpers use the platform-native separator;
- * relative path columns are stored with POSIX separators by convention to
- * keep them readable in JSON exports. `relativeToIngestDir` normalises
- * either input.
+ * Returned paths use the platform-native separator; stored relative paths
+ * use POSIX separators for readability in JSON exports.
+ * `relativeToIngestDir` normalises either input.
  */
 import { isAbsolute, relative, resolve, sep } from 'node:path';
 

--- a/packages/db-types/src/schema/food-batches.ts
+++ b/packages/db-types/src/schema/food-batches.ts
@@ -1,15 +1,11 @@
 /**
- * Food domain — PRD-108 schema (batch & cook event model).
+ *   batches             — one row per fridge/pantry/freezer slot
+ *   recipe_runs         — cook events pinned to a version
+ *   batch_consumptions  — (run, batch) draws — one row per FIFO touch
  *
- *   batches              — one row per fridge/pantry/freezer slot
- *   recipe_runs          — cook events pinned to a version
- *   batch_consumptions   — (run, batch) draws — one row per FIFO touch
- *
- * Also extends `ingredient_variants` with `default_shelf_life_days_{fridge,
- * freezer}` columns (declared in `./food-ingredients.ts` since Drizzle
- * requires the full table definition in one place).
- *
- * See `docs/themes/07-food/prds/108-batch-model/README.md`.
+ * The `default_shelf_life_days_{fridge,freezer}` columns on
+ * `ingredient_variants` are declared in `./food-ingredients.ts` since
+ * Drizzle requires the full table definition in one place.
  */
 import { sql } from 'drizzle-orm';
 import { index, integer, real, sqliteTable, text } from 'drizzle-orm/sqlite-core';

--- a/packages/db-types/src/schema/food-compile.ts
+++ b/packages/db-types/src/schema/food-compile.ts
@@ -1,12 +1,10 @@
 /**
- * Food domain — PRD-116 compile schema.
- *
  *   recipe_lines                  — one row per @ingredient block; canonical-unit index
  *   recipe_steps                  — one row per @step block; markdown + resolved JSON
  *   recipe_version_proposed_slugs — unresolved-slug pointers from a failed compile
  *
- * Written by `compileRecipeVersion` (in `packages/app-food/src/dsl/compile.ts`).
- * Read by the planner / solver / shopping-list generators (Epics 04–07).
+ * Written by `compileRecipeVersion`. Read by the planner / solver / shopping-
+ * list generators.
  */
 import { sql } from 'drizzle-orm';
 import { index, integer, real, sqliteTable, text, unique } from 'drizzle-orm/sqlite-core';
@@ -80,7 +78,7 @@ export const recipeVersionProposedSlugs = sqliteTable(
     suggestedKind: text('suggested_kind', {
       enum: ['ingredient', 'recipe', 'prep_state'],
     }),
-    /** `SourceSpan` from PRD-114's AST, serialised as JSON. */
+    /** AST `SourceSpan`, serialised as JSON. */
     fromLocJson: text('from_loc_json').notNull(),
     createdAt: text('created_at')
       .notNull()

--- a/packages/db-types/src/schema/food-conversions.ts
+++ b/packages/db-types/src/schema/food-conversions.ts
@@ -1,12 +1,9 @@
 /**
- * Food domain — PRD-123 unit conversion schema.
- *
  *   unit_conversions   — universal `from_unit → to_unit (g|ml|count) × ratio`
  *   ingredient_weights — per-ingredient "1 of this unit weighs X grams"
  *
- * Read by `normaliseLineQty` (`packages/app-food/src/dsl/normalisation.ts`),
- * which PRD-116's compile invokes for each `@ingredient` block. Written via
- * PRD-123's tRPC procedures + PRD-113's seed task.
+ * Read by `normaliseLineQty` (invoked from `compileRecipeVersion` per
+ * `@ingredient` block); written via tRPC procedures and the food seed task.
  */
 import { sql } from 'drizzle-orm';
 import { index, integer, real, sqliteTable, text, unique } from 'drizzle-orm/sqlite-core';
@@ -22,7 +19,7 @@ export const unitConversions = sqliteTable(
     /** "1 from_unit = ratio to_unit". CHECK ratio > 0 enforced in migration. */
     ratio: real('ratio').notNull(),
     notes: text('notes'),
-    /** 1 for rows inserted by PRD-113's seed task; 0 for user-added rows. */
+    /** 1 for seeded rows; 0 for user-added rows. */
     isSeeded: integer('is_seeded').notNull().default(0),
     createdAt: text('created_at')
       .notNull()

--- a/packages/db-types/src/schema/food-ingest-sources.ts
+++ b/packages/db-types/src/schema/food-ingest-sources.ts
@@ -1,15 +1,10 @@
 /**
- * Food domain — PRD-110 schema (ingest_sources).
- *
- *   ingest_sources        — provenance row per multimodal ingest run; FKs
- *                           back to recipes(id) for the drafted recipe.
+ * Provenance row per multimodal ingest run; FKs back to `recipes(id)` for
+ * the drafted recipe.
  *
  * Path columns are stored relative to FOOD_INGEST_DIR. The absolute path is
- * computed at read time via `ingestDirFor(sourceId)` (see
- * `packages/app-food/src/storage/ingest-paths.ts`) so deployments can
+ * computed at read time via `ingestDirFor(sourceId)` so deployments can
  * relocate the media root without rewriting rows.
- *
- * See `docs/themes/07-food/prds/110-ingest-sources/README.md`.
  */
 import { sql } from 'drizzle-orm';
 import { index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';

--- a/packages/db-types/src/schema/food-ingredients.ts
+++ b/packages/db-types/src/schema/food-ingredients.ts
@@ -1,14 +1,9 @@
 /**
- * Food domain — PRD-106 schema (ingredient model + slug registry).
- *
  *   slug_registry         — global namespace shared by ingredients, recipes, prep_states
  *   ingredients           — canonical hierarchy (max depth 3, app-enforced)
- *   ingredient_variants   — presentations of an ingredient, slug-scoped per parent.
- *                           Extended by PRD-108 with `default_shelf_life_days_{fridge,freezer}`.
+ *   ingredient_variants   — presentations of an ingredient, slug-scoped per parent
  *   prep_states           — small enum of trivial knife/process modifiers
  *   ingredient_aliases    — case-insensitive lookup pointing at ingredient OR variant
- *
- * See `docs/themes/07-food/prds/106-ingredient-model/README.md`.
  */
 import { sql } from 'drizzle-orm';
 import {
@@ -68,7 +63,7 @@ export const ingredientVariants = sqliteTable(
     defaultUnit: text('default_unit', { enum: ['g', 'ml', 'count'] }).notNull(),
     packageSizeG: real('package_size_g'),
     notes: text('notes'),
-    // PRD-108: shelf-life defaults for `expires_at` auto-population at cook time.
+    // Shelf-life defaults feed `expires_at` auto-population at cook time.
     // Null = unknown / shelf-stable.
     defaultShelfLifeDaysFridge: integer('default_shelf_life_days_fridge'),
     defaultShelfLifeDaysFreezer: integer('default_shelf_life_days_freezer'),
@@ -107,9 +102,9 @@ export const ingredientAliases = sqliteTable(
       'ck_aliases_xor_target',
       sql`(${t.ingredientId} IS NOT NULL) <> (${t.variantId} IS NOT NULL)`
     ),
-    // Table-level UNIQUE per the PRD spec. Hand-edited to partial uniques in
-    // the migration so SQLite's NULL-is-distinct rule doesn't let duplicates
-    // slip through when variant_id (or ingredient_id) is NULL.
+    // Hand-edited to partial UNIQUEs in the migration so SQLite's NULL-is-
+    // distinct rule doesn't let duplicates slip through when variant_id (or
+    // ingredient_id) is NULL.
     unique('uq_aliases_alias_target').on(t.alias, t.ingredientId, t.variantId),
     // Case-insensitive alias index — migration hand-edited for COLLATE NOCASE.
     index('idx_aliases_alias').on(t.alias),

--- a/packages/db-types/src/schema/food-plan.ts
+++ b/packages/db-types/src/schema/food-plan.ts
@@ -1,11 +1,7 @@
 /**
- * Food domain — PRD-111 schema (meal plan).
- *
  *   plan_slots    — extensible slot vocabulary (breakfast / lunch / dinner /
  *                   snack / prep-session by default; users can append).
  *   plan_entries  — one row per planned cook (date, slot, recipe).
- *
- * See `docs/themes/07-food/prds/111-plan-entry-model/README.md`.
  */
 import { sql } from 'drizzle-orm';
 import { check, index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
@@ -38,8 +34,8 @@ export const planEntries = sqliteTable(
     // Null = use the recipe's current_version_id at cook time.
     recipeVersionId: integer('recipe_version_id').references(() => recipeVersions.id),
     plannedServings: integer('planned_servings').notNull().default(1),
-    // Nullable until the entry transitions from "planned" to "cooked"; set
-    // by the cook flow (Epic 05) when a recipe_runs row is created.
+    // Nullable until the entry transitions from "planned" to "cooked" — set
+    // by the cook flow when a `recipe_runs` row is created.
     recipeRunId: integer('recipe_run_id').references(() => recipeRuns.id),
     notes: text('notes'),
     createdAt: text('created_at')

--- a/packages/db-types/src/schema/food-recipes.ts
+++ b/packages/db-types/src/schema/food-recipes.ts
@@ -1,11 +1,7 @@
 /**
- * Food domain — PRD-107 schema (recipes + versions + tags).
- *
- *   recipes               — stable recipe identity (slug, type, hero, archived)
- *   recipe_versions       — content snapshots: body_dsl, yield, compile_status
- *   recipe_tags           — free-form tags per recipe
- *
- * See `docs/themes/07-food/prds/107-recipe-model/README.md`.
+ *   recipes          — stable recipe identity (slug, type, hero, archived)
+ *   recipe_versions  — content snapshots: body_dsl, yield, compile_status
+ *   recipe_tags      — free-form tags per recipe
  */
 import { sql } from 'drizzle-orm';
 import {
@@ -67,9 +63,8 @@ export const recipeVersions = sqliteTable(
     servings: integer('servings'),
     prepMinutes: integer('prep_minutes'),
     cookMinutes: integer('cook_minutes'),
-    // source_id will reference ingest_sources(id) once PRD-110 lands; column
-    // declared as plain integer for now to avoid a forward FK to a missing
-    // table (drizzle would emit a malformed FK clause).
+    // Plain integer — the FK to `ingest_sources(id)` is added by the
+    // ingest-sources migration to avoid a forward declaration here.
     sourceId: integer('source_id'),
     compileStatus: text('compile_status', { enum: ['uncompiled', 'compiled', 'failed'] })
       .notNull()

--- a/packages/db-types/src/schema/food-substitutions.ts
+++ b/packages/db-types/src/schema/food-substitutions.ts
@@ -1,12 +1,3 @@
-/**
- * Food domain — PRD-109 substitutions schema.
- *
- * Split out of `./food.ts` so that file stays under the 200-line cap as the
- * food schema grows. Drizzle-kit globs `schema/*`, so the table is picked
- * up automatically by the migration generator.
- *
- * See `docs/themes/07-food/prds/109-substitution-model/`.
- */
 import { sql } from 'drizzle-orm';
 import { check, index, integer, real, sqliteTable, text } from 'drizzle-orm/sqlite-core';
 
@@ -50,8 +41,8 @@ export const substitutions = sqliteTable(
       'ck_subs_scope_recipe',
       sql`(${t.scope} = 'recipe' AND ${t.recipeId} IS NOT NULL) OR (${t.scope} = 'global' AND ${t.recipeId} IS NULL)`
     ),
-    // scope must be one of the allowed values — mirrors the enum CHECK in the
-    // migration so that a schema-derived rebuild can't accidentally drop it.
+    // Mirrors the enum CHECK in the migration so a schema-derived rebuild
+    // can't accidentally drop it.
     check('ck_subs_scope', sql`${t.scope} IN ('global','recipe')`),
     // Ratio must be strictly positive.
     check('ck_subs_ratio_positive', sql`${t.ratio} > 0`),

--- a/packages/db-types/src/schema/food.ts
+++ b/packages/db-types/src/schema/food.ts
@@ -1,23 +1,3 @@
-/**
- * Food domain — schema barrel.
- *
- * Per-PRD tables live in sibling files (each <200 lines to stay under the
- * max-lines lint cap):
- *
- *   - `food-ingredients.ts` — PRD-106 (slug_registry, ingredients, variants,
- *     prep_states, aliases). PRD-108 extends `ingredient_variants` with
- *     shelf-life columns; the column declarations live in that file too
- *     because Drizzle requires the full table definition in one place.
- *   - `food-recipes.ts` — PRD-107 (recipes, recipe_versions, recipe_tags).
- *   - `food-batches.ts` — PRD-108 (batches, recipe_runs, batch_consumptions).
- *   - `food-plan.ts` — PRD-111 (plan_slots, plan_entries).
- *   - `food-ingest-sources.ts` — PRD-110 (ingest_sources).
- *   - `food-compile.ts` — PRD-116 (recipe_lines, recipe_steps, proposed_slugs).
- *   - `food-conversions.ts` — PRD-123 (unit_conversions, ingredient_weights).
- *
- * This barrel is the import surface every other layer (db-types/src/index.ts,
- * `@pops/app-food`, drizzle-kit's schema glob) reads from.
- */
 export * from './food-ingredients.js';
 export * from './food-recipes.js';
 export * from './food-batches.js';

--- a/packages/db-types/src/schema/lists.ts
+++ b/packages/db-types/src/schema/lists.ts
@@ -1,16 +1,10 @@
 /**
- * Lists domain — PRD-112 schema.
+ *   lists       — list header (name, kind, owner_app, archive)
+ *   list_items  — polymorphic items pointing at lists.id, optionally back
+ *                 to an ingredient / variant / recipe (or owner-app custom ref)
  *
- * Two tables form the generic list surface:
- *   lists         — list header (name, kind, owner_app, archive)
- *   list_items    — polymorphic items pointing at lists.id, optionally back to
- *                   an ingredient / variant / recipe (or owner-app custom ref)
- *
- * The `kind` and `ref_kind` enums are intentionally small + closed. Adding a
- * new value = a small migration to extend the CHECK plus a consumer-side PRD
- * specifying the new affordances.
- *
- * See `docs/themes/07-food/prds/112-lists-schema/`.
+ * The `kind` and `ref_kind` enums are intentionally small + closed —
+ * adding a value means extending the CHECK in a migration.
  */
 import { sql } from 'drizzle-orm';
 import { index, integer, real, sqliteTable, text } from 'drizzle-orm/sqlite-core';


### PR DESCRIPTION
## Summary

- Removes file-header docblocks across the food packages that just named the owning PRD and restated what the file does, plus inline \`per PRD-XXX\` references that risk rotting as the spec evolves.
- Keeps the WHY-comments — non-obvious constraints (partial UNIQUE indexes, NULL-distinct workarounds, FK ordering, SQLite CHECK mirrors, etc.) stay intact.
- Also fixes a pre-existing CI break: \`packages/app-food-db/src/__tests__/seed.test.ts\` was missing \`0067_prd_125_ingest_error_columns.sql\` from its migration list after #2708 landed. Without that one-line addition, the seed test fails on \`main\` (and was failing before this PR opened).

Scope: \`packages/app-food\`, \`packages/app-food-db\`, \`packages/db-types/src/schema/food-*\` + \`lists.ts\`, \`apps/pops-api/src/modules/food\`. 103 files, no behaviour change.

Newer files landed mid-run (PRD-148 graph explorer, PRD-120 B/C/D/E, PRD-125 ingest, PRD-122-B2) keep their original docblocks — fair game for a follow-up sweep.

## Test plan

- [x] \`pnpm --filter @pops/app-food-db test\` — 204/204 green
- [x] \`pnpm --filter @pops/app-food test\` — 378/378 green
- [x] \`pnpm --filter @pops/api test\` — 4551/4551 green
- [x] \`pnpm --filter @pops/app-food typecheck\` clean
- [x] \`pnpm --filter @pops/api typecheck\` clean
- [x] \`pnpm lint -- packages/app-food packages/app-food-db packages/db-types apps/pops-api/src/modules/food\` — no new errors