### PR TITLE
feat(core): scaffold @pops/core-db + service-accounts slice (pillar core phase 1 PR 1)

### DIFF
--- a/.github/workflows/core-quality.yml
+++ b/.github/workflows/core-quality.yml
@@ -1,0 +1,41 @@
+name: Core DB Quality
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/core-db/**"
+      - "packages/db-types/**"
+      - "apps/pops-api/src/db/drizzle-migrations/0054_service_accounts.sql"
+      - ".github/workflows/core-quality.yml"
+      - ".github/workflows/_pkg-check.yml"
+  pull_request:
+
+jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - 'packages/core-db/**'
+              - 'packages/db-types/**'
+              - 'apps/pops-api/src/db/drizzle-migrations/0054_service_accounts.sql'
+              - '.github/workflows/core-quality.yml'
+              - '.github/workflows/_pkg-check.yml'
+
+  quality:
+    needs: [changes]
+    if: always()
+    uses: ./.github/workflows/_pkg-check.yml
+    with:
+      package-path: packages/core-db
+      needs-db-build: true
+      skip: ${{ github.event_name == 'pull_request' && needs.changes.outputs.relevant != 'true' }}

--- a/packages/core-db/package.json
+++ b/packages/core-db/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@pops/core-db",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@pops/db-types": "workspace:*",
+    "drizzle-orm": "^0.45.2"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.12",
+    "@vitest/coverage-v8": "^4.1.8",
+    "better-sqlite3": "^12.10.0",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.8"
+  }
+}

--- a/packages/core-db/package.json
+++ b/packages/core-db/package.json
@@ -9,7 +9,8 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/core-db/src/__tests__/service-account-keys.test.ts
+++ b/packages/core-db/src/__tests__/service-account-keys.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Unit tests for the API-key generator + hash + verify primitives.
+ *
+ * Moved verbatim from `apps/pops-api/src/modules/core/service-accounts/key.test.ts`
+ * during the core pillar Phase 1 scaffold. The hot verify path runs on every
+ * authenticated machine call so the constant-time compare must not be regressed.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { generateApiKey, parseApiKey, verifySecret } from '../services/service-account-keys.js';
+
+describe('generateApiKey', () => {
+  it('produces a marker-prefixed key with an 8-char prefix and a long secret', async () => {
+    const issued = await generateApiKey();
+    expect(issued.plaintext.startsWith('pops_sa_')).toBe(true);
+    expect(issued.prefix).toHaveLength(8);
+    expect(issued.plaintext).toContain(`${issued.prefix}.`);
+    expect(issued.hash.startsWith('scrypt$')).toBe(true);
+  });
+
+  it('produces unique keys on repeated calls', async () => {
+    const a = await generateApiKey();
+    const b = await generateApiKey();
+    expect(a.plaintext).not.toBe(b.plaintext);
+    expect(a.prefix).not.toBe(b.prefix);
+    expect(a.hash).not.toBe(b.hash);
+  });
+});
+
+describe('parseApiKey', () => {
+  it('rejects values without the marker', () => {
+    expect(parseApiKey('not-a-key')).toBeNull();
+    expect(parseApiKey('Bearer abc')).toBeNull();
+  });
+
+  it('rejects malformed body (missing dot)', () => {
+    expect(parseApiKey('pops_sa_abc12345nodothere')).toBeNull();
+  });
+
+  it('rejects malformed body (prefix not 8 chars)', () => {
+    expect(parseApiKey('pops_sa_short.secret')).toBeNull();
+  });
+
+  it('rejects empty secret half', () => {
+    expect(parseApiKey('pops_sa_abc12345.')).toBeNull();
+  });
+
+  it('parses a valid key', () => {
+    const parsed = parseApiKey('pops_sa_abc12345.secretpart');
+    expect(parsed).toEqual({ prefix: 'abc12345', secret: 'secretpart' });
+  });
+
+  it('round-trips with generateApiKey', async () => {
+    const issued = await generateApiKey();
+    const parsed = parseApiKey(issued.plaintext);
+    expect(parsed?.prefix).toBe(issued.prefix);
+    expect(parsed?.secret).toBeTruthy();
+  });
+});
+
+describe('verifySecret', () => {
+  it('returns true for the correct secret', async () => {
+    const issued = await generateApiKey();
+    const parsed = parseApiKey(issued.plaintext);
+    expect(parsed).not.toBeNull();
+    if (!parsed) throw new Error('unreachable');
+    await expect(verifySecret(parsed.secret, issued.hash)).resolves.toBe(true);
+  });
+
+  it('returns false for a wrong secret', async () => {
+    const issued = await generateApiKey();
+    await expect(verifySecret('wrong-secret', issued.hash)).resolves.toBe(false);
+  });
+
+  it('returns false for a malformed stored hash without throwing', async () => {
+    await expect(verifySecret('anything', 'not-a-valid-hash')).resolves.toBe(false);
+    await expect(verifySecret('anything', 'scrypt$only-one-part')).resolves.toBe(false);
+    await expect(verifySecret('anything', '')).resolves.toBe(false);
+  });
+});

--- a/packages/core-db/src/__tests__/service-accounts.test.ts
+++ b/packages/core-db/src/__tests__/service-accounts.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Invariant tests for the service-accounts service against an in-memory
+ * SQLite seeded with the canonical `service_accounts` migration. Pure DB +
+ * service layer — no tRPC, no Express, no auth middleware.
+ *
+ * Higher-level scope-enforcement / admin-tRPC coverage lives in pops-api's
+ * own integration suite and exercises the same service via the
+ * pops-api wrapper.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  ServiceAccountAlreadyRevokedError,
+  ServiceAccountNameAlreadyExistsError,
+  ServiceAccountNotFoundError,
+} from '../errors.js';
+import { parseApiKey } from '../services/service-account-keys.js';
+import {
+  authenticateServiceAccount,
+  countActiveServiceAccounts,
+  createServiceAccount,
+  getActiveServiceAccountByPrefix,
+  hasScopeFor,
+  listServiceAccounts,
+  revokeServiceAccount,
+} from '../services/service-accounts.js';
+
+import type { CoreDb } from '../services/internal.js';
+
+const MIGRATION_PATH = join(
+  __dirname,
+  '../../../../apps/pops-api/src/db/drizzle-migrations/0054_service_accounts.sql'
+);
+
+function freshDb(): CoreDb {
+  const raw = new Database(':memory:');
+  raw.pragma('foreign_keys = ON');
+  const sql = readFileSync(MIGRATION_PATH, 'utf8');
+  for (const stmt of sql.split('--> statement-breakpoint')) {
+    const trimmed = stmt.trim();
+    if (trimmed.length > 0) raw.exec(trimmed);
+  }
+  return drizzle(raw);
+}
+
+describe('createServiceAccount', () => {
+  let db: CoreDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('inserts a row and returns the plaintext key exactly once', async () => {
+    const created = await createServiceAccount(
+      db,
+      { name: 'moltbot', scopes: ['cerebrum.ingest', 'cerebrum.query'] },
+      'admin@example.com'
+    );
+    expect(created.id).toMatch(/^sa_/);
+    expect(created.plaintextKey).toMatch(/^pops_sa_/);
+    expect(created.scopes).toEqual(['cerebrum.ingest', 'cerebrum.query']);
+    expect(created.createdBy).toBe('admin@example.com');
+
+    const rows = listServiceAccounts(db);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ name: 'moltbot' });
+    expect(rows[0]).not.toHaveProperty('plaintextKey');
+    expect(rows[0]).not.toHaveProperty('keyHash');
+  });
+
+  it('rejects duplicate names with a typed error', async () => {
+    await createServiceAccount(db, { name: 'dup', scopes: ['core.shell'] }, null);
+    await expect(
+      createServiceAccount(db, { name: 'dup', scopes: ['core.shell'] }, null)
+    ).rejects.toBeInstanceOf(ServiceAccountNameAlreadyExistsError);
+  });
+});
+
+describe('authenticateServiceAccount', () => {
+  let db: CoreDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('returns the principal when prefix + secret match', async () => {
+    const created = await createServiceAccount(
+      db,
+      { name: 'auth-ok', scopes: ['cerebrum.query'] },
+      null
+    );
+    const parsed = parseApiKey(created.plaintextKey);
+    expect(parsed).not.toBeNull();
+    if (!parsed) throw new Error('unreachable');
+
+    const principal = await authenticateServiceAccount(db, parsed.prefix, parsed.secret);
+    expect(principal?.name).toBe('auth-ok');
+    expect(principal?.scopes).toEqual(['cerebrum.query']);
+  });
+
+  it('returns null for a wrong secret', async () => {
+    const created = await createServiceAccount(
+      db,
+      { name: 'auth-bad-secret', scopes: ['cerebrum.query'] },
+      null
+    );
+    const parsed = parseApiKey(created.plaintextKey);
+    if (!parsed) throw new Error('unreachable');
+    const principal = await authenticateServiceAccount(db, parsed.prefix, 'tampered-secret');
+    expect(principal).toBeNull();
+  });
+
+  it('returns null for an unknown prefix', async () => {
+    const principal = await authenticateServiceAccount(db, '00000000', 'whatever');
+    expect(principal).toBeNull();
+  });
+
+  it('returns null after revocation', async () => {
+    const created = await createServiceAccount(
+      db,
+      { name: 'auth-revoked', scopes: ['cerebrum.query'] },
+      null
+    );
+    const parsed = parseApiKey(created.plaintextKey);
+    if (!parsed) throw new Error('unreachable');
+    revokeServiceAccount(db, created.id);
+    const principal = await authenticateServiceAccount(db, parsed.prefix, parsed.secret);
+    expect(principal).toBeNull();
+  });
+
+  it('updates last_used_at on a successful authentication', async () => {
+    const created = await createServiceAccount(
+      db,
+      { name: 'auth-touch', scopes: ['cerebrum.query'] },
+      null
+    );
+    const parsed = parseApiKey(created.plaintextKey);
+    if (!parsed) throw new Error('unreachable');
+
+    const beforeRow = getActiveServiceAccountByPrefix(db, parsed.prefix);
+    expect(beforeRow?.lastUsedAt).toBeNull();
+
+    await authenticateServiceAccount(db, parsed.prefix, parsed.secret);
+
+    const afterRow = getActiveServiceAccountByPrefix(db, parsed.prefix);
+    expect(afterRow?.lastUsedAt).not.toBeNull();
+  });
+});
+
+describe('revokeServiceAccount', () => {
+  let db: CoreDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('throws a typed error on second revoke', async () => {
+    const created = await createServiceAccount(
+      db,
+      { name: 'double-revoke', scopes: ['cerebrum.query'] },
+      null
+    );
+    revokeServiceAccount(db, created.id);
+    expect(() => revokeServiceAccount(db, created.id)).toThrow(ServiceAccountAlreadyRevokedError);
+  });
+
+  it('throws a typed error on unknown id', () => {
+    expect(() => revokeServiceAccount(db, 'sa_does-not-exist')).toThrow(
+      ServiceAccountNotFoundError
+    );
+  });
+});
+
+describe('countActiveServiceAccounts', () => {
+  let db: CoreDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('reflects revocations', async () => {
+    await createServiceAccount(db, { name: 'active-a', scopes: ['cerebrum.query'] }, null);
+    const b = await createServiceAccount(
+      db,
+      { name: 'active-b', scopes: ['cerebrum.query'] },
+      null
+    );
+    expect(countActiveServiceAccounts(db)).toBe(2);
+    revokeServiceAccount(db, b.id);
+    expect(countActiveServiceAccounts(db)).toBe(1);
+  });
+});
+
+describe('getActiveServiceAccountByPrefix', () => {
+  let db: CoreDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('returns null for unknown prefix', () => {
+    expect(getActiveServiceAccountByPrefix(db, 'nope----')).toBeNull();
+  });
+
+  it('returns null for revoked rows', async () => {
+    const created = await createServiceAccount(db, { name: 'a', scopes: ['cerebrum.query'] }, null);
+    revokeServiceAccount(db, created.id);
+    expect(getActiveServiceAccountByPrefix(db, created.keyPrefix)).toBeNull();
+  });
+
+  it('returns the public row for active accounts', async () => {
+    const created = await createServiceAccount(db, { name: 'a', scopes: ['cerebrum.query'] }, null);
+    const found = getActiveServiceAccountByPrefix(db, created.keyPrefix);
+    expect(found?.name).toBe('a');
+    expect(found).not.toHaveProperty('plaintextKey');
+  });
+});
+
+describe('hasScopeFor', () => {
+  it('matches exact and prefix paths', () => {
+    expect(hasScopeFor(['cerebrum.ingest'], 'cerebrum.ingest.quickCapture')).toBe(true);
+    expect(hasScopeFor(['cerebrum.ingest'], 'cerebrum.ingest')).toBe(true);
+    expect(hasScopeFor(['cerebrum.ingest'], 'cerebrum.query.ask')).toBe(false);
+  });
+
+  it('does not match a sibling that shares a prefix substring', () => {
+    expect(hasScopeFor(['cerebrum.ing'], 'cerebrum.ingest.quickCapture')).toBe(false);
+  });
+
+  it('returns false for empty granted scopes', () => {
+    expect(hasScopeFor([], 'cerebrum.query.ask')).toBe(false);
+  });
+});

--- a/packages/core-db/src/errors.ts
+++ b/packages/core-db/src/errors.ts
@@ -1,0 +1,38 @@
+/**
+ * Typed errors raised by the core domain service layer.
+ *
+ * These are plain Error subclasses — the service layer doesn't know about
+ * HTTP. The pops-api router/middleware maps them to the appropriate status
+ * codes when surfacing to clients. Mirrors `@pops/app-food-db`'s error
+ * pattern.
+ */
+
+export class ServiceAccountNameAlreadyExistsError extends Error {
+  override readonly name = 'ServiceAccountNameAlreadyExistsError' as const;
+  readonly accountName: string;
+
+  constructor(accountName: string) {
+    super(`Service account '${accountName}' already exists`);
+    this.accountName = accountName;
+  }
+}
+
+export class ServiceAccountNotFoundError extends Error {
+  override readonly name = 'ServiceAccountNotFoundError' as const;
+  readonly id: string;
+
+  constructor(id: string) {
+    super(`Service account '${id}' not found`);
+    this.id = id;
+  }
+}
+
+export class ServiceAccountAlreadyRevokedError extends Error {
+  override readonly name = 'ServiceAccountAlreadyRevokedError' as const;
+  readonly id: string;
+
+  constructor(id: string) {
+    super(`Service account '${id}' is already revoked`);
+    this.id = id;
+  }
+}

--- a/packages/core-db/src/index.ts
+++ b/packages/core-db/src/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Backend-safe barrel for the core domain's persistence layer.
+ *
+ * Hosts cross-cutting platform tables that every other pillar depends on
+ * (service accounts, settings, AI Ops, pillar registry). Extracted from
+ * `apps/pops-api/src/modules/core/` as the pilot for ADR-026.
+ *
+ * Per the CI-never-breaks pattern the migration is incremental — this PR
+ * scaffolds the package and moves only the `service-accounts` slice. The
+ * other slices (settings, AI Ops, URI dispatcher, pillars registry) follow
+ * in subsequent PRs.
+ */
+export * from './errors.js';
+export * from './schema.js';
+
+export type { CoreDb } from './services/internal.js';
+
+export * as serviceAccountsService from './services/service-accounts.js';
+export * as serviceAccountKeys from './services/service-account-keys.js';

--- a/packages/core-db/src/schema.ts
+++ b/packages/core-db/src/schema.ts
@@ -1,0 +1,13 @@
+/**
+ * Local re-export of the core domain tables.
+ *
+ * Canonical definitions live in `@pops/db-types/src/schema/*.ts` so the
+ * drizzle-kit config (which globs `packages/db-types/src/schema/*`) picks
+ * them up and the rest of the platform sees a single schema barrel.
+ *
+ * Services in this package import from here for ergonomics and so that
+ * the core module's read surface stays self-describing.
+ *
+ * Mirrors the `@pops/app-food-db` schema re-export pattern.
+ */
+export { serviceAccounts } from '@pops/db-types';

--- a/packages/core-db/src/services/internal.ts
+++ b/packages/core-db/src/services/internal.ts
@@ -1,0 +1,9 @@
+/**
+ * Shared helpers for the core schema service layer.
+ *
+ * Not exported from the package — internal to `src/services/*.ts`.
+ */
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+
+/** A drizzle handle — either the top-level db or a transaction. */
+export type CoreDb = BetterSQLite3Database<Record<string, unknown>>;

--- a/packages/core-db/src/services/internal.ts
+++ b/packages/core-db/src/services/internal.ts
@@ -1,7 +1,9 @@
 /**
  * Shared helpers for the core schema service layer.
  *
- * Not exported from the package — internal to `src/services/*.ts`.
+ * Only `CoreDb` is re-exported from the package barrel so callers can type
+ * the handle they pass in; any additional helpers added here stay internal
+ * to `src/services/*.ts`.
  */
 import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 

--- a/packages/core-db/src/services/service-account-keys.ts
+++ b/packages/core-db/src/services/service-account-keys.ts
@@ -1,0 +1,89 @@
+/**
+ * Service-account API key generation, parsing, hashing and verification.
+ *
+ * Wire format: `pops_sa_<prefix>.<secret>`
+ *   - `pops_sa_` is a literal marker so leaked keys are easy to detect by
+ *     pattern (similar to GitHub's `ghp_` / `ghs_` convention).
+ *   - `<prefix>` is 8 url-safe base64 characters (~48 bits of entropy)
+ *     used as a fast O(1) DB lookup. Stored in the clear.
+ *   - `<secret>` is 32 url-safe base64 characters (~192 bits of entropy)
+ *     hashed with scrypt before storage.
+ *
+ * Why scrypt: it ships with Node, no native deps to compile in CI / Alpine
+ * containers, and is good enough for a key with 192 bits of entropy where
+ * brute-force is not the threat model.
+ */
+import { randomBytes, scrypt, timingSafeEqual } from 'node:crypto';
+import { promisify } from 'node:util';
+
+const scryptAsync = promisify(scrypt);
+
+const KEY_MARKER = 'pops_sa_';
+const PREFIX_BYTES = 6;
+const SECRET_BYTES = 24;
+const SCRYPT_KEYLEN = 64;
+const SALT_BYTES = 16;
+const HASH_FORMAT_VERSION = 'scrypt';
+
+function urlSafeBase64(buf: Buffer): string {
+  return buf.toString('base64').replaceAll('+', '-').replaceAll('/', '_').replaceAll('=', '');
+}
+
+export interface IssuedKey {
+  /** The full plaintext key. Show to operator once, never persist. */
+  plaintext: string;
+  /** The 8-char prefix to store in the DB for fast lookup. */
+  prefix: string;
+  /** scrypt-encoded hash of the secret half, ready to persist. */
+  hash: string;
+}
+
+/** Generate a fresh API key plus its persistable prefix and hash. */
+export async function generateApiKey(): Promise<IssuedKey> {
+  const prefix = urlSafeBase64(randomBytes(PREFIX_BYTES)).slice(0, 8);
+  const secret = urlSafeBase64(randomBytes(SECRET_BYTES)).slice(0, 32);
+  const plaintext = `${KEY_MARKER}${prefix}.${secret}`;
+  const hash = await hashSecret(secret);
+  return { plaintext, prefix, hash };
+}
+
+/**
+ * Parse a presented header value into its prefix + secret components.
+ * Returns null if the input is malformed (caller should reject with 401).
+ */
+export function parseApiKey(header: string): { prefix: string; secret: string } | null {
+  if (!header.startsWith(KEY_MARKER)) return null;
+  const body = header.slice(KEY_MARKER.length);
+  const dot = body.indexOf('.');
+  if (dot !== 8) return null;
+  const prefix = body.slice(0, 8);
+  const secret = body.slice(9);
+  if (secret.length === 0) return null;
+  return { prefix, secret };
+}
+
+async function hashSecret(secret: string): Promise<string> {
+  const salt = randomBytes(SALT_BYTES);
+  const derived = (await scryptAsync(secret, salt, SCRYPT_KEYLEN)) as Buffer;
+  return `${HASH_FORMAT_VERSION}$${urlSafeBase64(salt)}$${urlSafeBase64(derived)}`;
+}
+
+/**
+ * Constant-time verify a presented secret against a stored hash. Returns
+ * false on any malformed input (never throws on bad data).
+ */
+export async function verifySecret(secret: string, stored: string): Promise<boolean> {
+  const [version, saltB64, hashB64] = stored.split('$');
+  if (version !== HASH_FORMAT_VERSION || !saltB64 || !hashB64) return false;
+  let salt: Buffer;
+  let expected: Buffer;
+  try {
+    salt = Buffer.from(saltB64.replaceAll('-', '+').replaceAll('_', '/'), 'base64');
+    expected = Buffer.from(hashB64.replaceAll('-', '+').replaceAll('_', '/'), 'base64');
+  } catch {
+    return false;
+  }
+  if (expected.length !== SCRYPT_KEYLEN) return false;
+  const derived = (await scryptAsync(secret, salt, SCRYPT_KEYLEN)) as Buffer;
+  return timingSafeEqual(derived, expected);
+}

--- a/packages/core-db/src/services/service-accounts.ts
+++ b/packages/core-db/src/services/service-accounts.ts
@@ -1,0 +1,205 @@
+/**
+ * Service-account CRUD + verification.
+ *
+ * Verification path is hot — every authenticated machine call hits it once.
+ * It is intentionally a single indexed read on `key_prefix`, then one scrypt
+ * compare. Revoked rows return null without doing the scrypt work.
+ *
+ * Services take a `CoreDb` handle as their first argument; the calling layer
+ * (pops-api modules) is responsible for resolving the singleton or
+ * transaction handle to pass in.
+ */
+import { randomUUID } from 'node:crypto';
+
+import { eq, isNull, sql } from 'drizzle-orm';
+
+import {
+  ServiceAccountAlreadyRevokedError,
+  ServiceAccountNameAlreadyExistsError,
+  ServiceAccountNotFoundError,
+} from '../errors.js';
+import { serviceAccounts } from '../schema.js';
+import { generateApiKey, verifySecret } from './service-account-keys.js';
+
+import type { CoreDb } from './internal.js';
+
+export interface ServiceAccount {
+  id: string;
+  name: string;
+  keyPrefix: string;
+  scopes: string[];
+  createdAt: string;
+  lastUsedAt: string | null;
+  revokedAt: string | null;
+  createdBy: string | null;
+}
+
+export interface CreateServiceAccountInput {
+  name: string;
+  scopes: string[];
+}
+
+export interface CreatedServiceAccount extends ServiceAccount {
+  /** Plaintext key — shown to the operator exactly once at creation time. */
+  plaintextKey: string;
+}
+
+interface ServiceAccountRow {
+  id: string;
+  name: string;
+  keyPrefix: string;
+  keyHash: string;
+  scopes: string;
+  createdAt: string;
+  lastUsedAt: string | null;
+  revokedAt: string | null;
+  createdBy: string | null;
+}
+
+function rowToPublic(row: ServiceAccountRow): ServiceAccount {
+  let parsedScopes: string[];
+  try {
+    const parsed: unknown = JSON.parse(row.scopes);
+    parsedScopes = Array.isArray(parsed)
+      ? parsed.filter((s): s is string => typeof s === 'string')
+      : [];
+  } catch {
+    parsedScopes = [];
+  }
+  return {
+    id: row.id,
+    name: row.name,
+    keyPrefix: row.keyPrefix,
+    scopes: parsedScopes,
+    createdAt: row.createdAt,
+    lastUsedAt: row.lastUsedAt,
+    revokedAt: row.revokedAt,
+    createdBy: row.createdBy,
+  };
+}
+
+export async function createServiceAccount(
+  db: CoreDb,
+  input: CreateServiceAccountInput,
+  createdBy: string | null
+): Promise<CreatedServiceAccount> {
+  const existing = db
+    .select()
+    .from(serviceAccounts)
+    .where(eq(serviceAccounts.name, input.name))
+    .all();
+  if (existing.length > 0) {
+    throw new ServiceAccountNameAlreadyExistsError(input.name);
+  }
+  const issued = await generateApiKey();
+  const id = `sa_${randomUUID()}`;
+  const now = new Date().toISOString();
+  db.insert(serviceAccounts)
+    .values({
+      id,
+      name: input.name,
+      keyPrefix: issued.prefix,
+      keyHash: issued.hash,
+      scopes: JSON.stringify(input.scopes),
+      createdAt: now,
+      createdBy,
+    })
+    .run();
+  return {
+    id,
+    name: input.name,
+    keyPrefix: issued.prefix,
+    scopes: input.scopes,
+    createdAt: now,
+    lastUsedAt: null,
+    revokedAt: null,
+    createdBy,
+    plaintextKey: issued.plaintext,
+  };
+}
+
+export function listServiceAccounts(db: CoreDb): ServiceAccount[] {
+  const rows = db.select().from(serviceAccounts).orderBy(serviceAccounts.createdAt).all();
+  return rows.map((r): ServiceAccount => rowToPublic(r));
+}
+
+export function revokeServiceAccount(db: CoreDb, id: string): void {
+  const [row] = db.select().from(serviceAccounts).where(eq(serviceAccounts.id, id)).all();
+  if (!row) throw new ServiceAccountNotFoundError(id);
+  if (row.revokedAt !== null) {
+    throw new ServiceAccountAlreadyRevokedError(id);
+  }
+  db.update(serviceAccounts)
+    .set({ revokedAt: new Date().toISOString() })
+    .where(eq(serviceAccounts.id, id))
+    .run();
+}
+
+/** Result of a successful service-account authentication. */
+export interface AuthenticatedServiceAccount {
+  id: string;
+  name: string;
+  scopes: string[];
+}
+
+/**
+ * Verify a presented prefix + secret against the database. Returns the
+ * authenticated principal on success or null on any failure path. Updates
+ * `last_used_at` opportunistically on success — failures never write.
+ */
+export async function authenticateServiceAccount(
+  db: CoreDb,
+  prefix: string,
+  secret: string
+): Promise<AuthenticatedServiceAccount | null> {
+  const [row] = db
+    .select()
+    .from(serviceAccounts)
+    .where(eq(serviceAccounts.keyPrefix, prefix))
+    .all();
+  if (!row || row.revokedAt !== null) return null;
+  const ok = await verifySecret(secret, row.keyHash);
+  if (!ok) return null;
+
+  try {
+    db.update(serviceAccounts)
+      .set({ lastUsedAt: sql`(datetime('now'))` })
+      .where(eq(serviceAccounts.id, row.id))
+      .run();
+  } catch (err) {
+    console.warn('[service-accounts] failed to touch last_used_at:', err);
+  }
+
+  const publicRow = rowToPublic(row);
+  return { id: publicRow.id, name: publicRow.name, scopes: publicRow.scopes };
+}
+
+/**
+ * Returns true if the procedure path falls under any of the granted scope
+ * prefixes. Scopes use dot-prefix matching: a granted scope `cerebrum.ingest`
+ * authorises `cerebrum.ingest.quickCapture` but not `cerebrum.query.ask`.
+ */
+export function hasScopeFor(grantedScopes: string[], procedurePath: string): boolean {
+  for (const scope of grantedScopes) {
+    if (scope === procedurePath) return true;
+    if (procedurePath.startsWith(`${scope}.`)) return true;
+  }
+  return false;
+}
+
+/** Convenience for tests that need a quick lookup. */
+export function getActiveServiceAccountByPrefix(db: CoreDb, prefix: string): ServiceAccount | null {
+  const [row] = db
+    .select()
+    .from(serviceAccounts)
+    .where(eq(serviceAccounts.keyPrefix, prefix))
+    .all();
+  if (!row || row.revokedAt !== null) return null;
+  return rowToPublic(row);
+}
+
+/** Internal: count active accounts (used by health/admin tooling). */
+export function countActiveServiceAccounts(db: CoreDb): number {
+  const rows = db.select().from(serviceAccounts).where(isNull(serviceAccounts.revokedAt)).all();
+  return rows.length;
+}

--- a/packages/core-db/tsconfig.json
+++ b/packages/core-db/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "lib": ["ES2022"],
+    "types": [],
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/__tests__/**", "**/*.test.ts"]
+}

--- a/packages/core-db/vitest.config.ts
+++ b/packages/core-db/vitest.config.ts
@@ -1,0 +1,15 @@
+/// <reference types="vitest/config" />
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json-summary', 'html'],
+      reportsDirectory: 'coverage',
+      include: ['src/**/*.ts'],
+      exclude: ['**/node_modules/**', '**/dist/**', '**/*.test.ts'],
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1104,6 +1104,31 @@ importers:
         specifier: ^4.1.8
         version: 4.1.8(@types/node@25.9.1)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
 
+  packages/core-db:
+    dependencies:
+      '@pops/db-types':
+        specifier: workspace:*
+        version: link:../db-types
+      drizzle-orm:
+        specifier: ^0.45.2
+        version: 0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.10.0)
+    devDependencies:
+      '@types/better-sqlite3':
+        specifier: ^7.6.12
+        version: 7.6.13
+      '@vitest/coverage-v8':
+        specifier: ^4.1.8
+        version: 4.1.8(vitest@4.1.8)
+      better-sqlite3:
+        specifier: ^12.10.0
+        version: 12.10.0
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@25.9.1)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
+
   packages/db-types:
     dependencies:
       drizzle-orm:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,6 +10,7 @@ packages:
   - 'packages/app-cerebrum'
   - 'packages/overlay-ego'
   - 'packages/api-client'
+  - 'packages/core-db'
   - 'packages/db-types'
   - 'packages/food-contracts'
   - 'packages/types'


### PR DESCRIPTION
## Summary

First PR of the **core pillar migration** ([ADR-026](https://github.com/knoxio/pops/blob/main/docs/architecture/adr-026-pillar-architecture.md), pillar-migration-roadmap.md Track D · Phase 1 PR 1 of 4).

Scaffolds the backend-safe `@pops/core-db` package and moves the first slice — service-account CRUD + key primitives — out of \`apps/pops-api/src/modules/core/service-accounts/\` into the package with a db-arg service signature. Mirrors \`@pops/app-food-db\`.

**Strictly additive.** pops-api is unchanged in this PR; all existing callers keep resolving the old service path. The cutover (PR 3 of phase 1) flips pops-api to import the package and the deletion PR (PR 4) removes the old in-tree service.

## Scope decisions

- **service-accounts only.** Picked as the first slice because it has 5 call sites (vs 60 for settings) — bounded blast radius for the pilot.
- **No empty \`core-contract\` / \`core-api\` / \`core-ui\` shells.** Those packages get created when their first content lands rather than as dead scaffolds. PRD-122 part API set the same precedent (extracted \`app-food-db\` without the other three sibling packages).
- **Migrations stay in the shared journal.** PR 2 of Phase 1 (migration journal split) moves \`0054_service_accounts.sql\` into \`packages/core-db/migrations/\` with its own journal.

## What's in this PR

- \`packages/core-db/{package.json,tsconfig.json,vitest.config.ts}\`
- \`src/{index,schema,errors,services/internal}.ts\` (barrel + re-exported schema + typed errors)
- \`src/services/{service-account-keys,service-accounts}.ts\` — db-arg signatures; the pops-api wrapper (next PR) resolves \`getDrizzle()\` and forwards
- \`src/__tests__/service-account*.test.ts\` — 27 cases against in-memory \`better-sqlite3\` + the canonical \`0054_service_accounts.sql\` migration
- \`pnpm-workspace.yaml\` entry
- \`.github/workflows/core-quality.yml\` (mirrors food-quality)

## Verification

- \`pnpm typecheck\` — 28/28 packages green
- \`pnpm --filter @pops/core-db test\` — 27/27 cases pass
- \`pnpm lint\` — 0 new errors (only pre-existing warnings)
- \`pnpm format:check\` — clean

## Roadmap status

Updated \`.claude/pillar-migration-roadmap.md\` Track D row: \`⏳ Not started\` → \`🔄 In progress\` (pops6 · 2026-06-10T15:05Z).

Stale \`PRD-120-B\` in-flight entry in \`.claude/food-app-roadmap.md\` cleaned up (the PRD shipped as #2719).

## Test plan

- [ ] CI green on \`core-quality\` (typecheck + 27 tests)
- [ ] Workspace \`typecheck\` / \`api-quality\` / other pillar workflows unaffected (no behavioural changes)
- [ ] Copilot review pass