### PR TITLE
feat(food): PRD-126 — pops-worker-food container + worker daemon

### DIFF
--- a/.github/workflows/worker-food-image.yml
+++ b/.github/workflows/worker-food-image.yml
@@ -1,0 +1,86 @@
+name: Worker Food Image
+
+# PRD-126 — builds + (on main) pushes the pops-worker-food container.
+#
+# PRs validate the build only (no push). Pushes to main publish
+# `ghcr.io/knoxio/pops-worker-food:main` + sha tag; Watchtower in the
+# homelab picks up new digests and rolls them out automatically (the
+# `com.centurylinklabs.watchtower.enable` label is set on the compose
+# service).
+
+on:
+  pull_request:
+    paths:
+      - 'apps/pops-worker-food/**'
+      - 'infra/docker/pops-worker-food/**'
+      - 'packages/food-contracts/**'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - 'turbo.json'
+      - 'tsconfig.base.json'
+      - '.github/workflows/worker-food-image.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'apps/pops-worker-food/**'
+      - 'infra/docker/pops-worker-food/**'
+      - 'packages/food-contracts/**'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - 'turbo.json'
+      - 'tsconfig.base.json'
+      - '.github/workflows/worker-food-image.yml'
+  workflow_dispatch:
+
+permissions:
+  packages: write
+  contents: read
+
+jobs:
+  build:
+    name: Build pops-worker-food
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ghcr.io/knoxio/pops-worker-food
+          tags: |
+            type=raw,value=main,enable={{is_default_branch}}
+            type=sha,prefix=sha-,format=short
+            type=semver,pattern={{version}}
+            type=semver,pattern=v{{version}}
+
+      - name: Build (PR — no push)
+        if: github.event_name == 'pull_request'
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: infra/docker/pops-worker-food/Dockerfile
+          push: false
+          build-args: |
+            BUILD_VERSION=${{ github.sha }}
+
+      - name: Build and push (main / dispatch)
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: infra/docker/pops-worker-food/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BUILD_VERSION=${{ github.sha }}

--- a/.github/workflows/worker-food-image.yml
+++ b/.github/workflows/worker-food-image.yml
@@ -44,6 +44,26 @@ jobs:
       - uses: actions/checkout@v6
       - uses: docker/setup-buildx-action@v3
 
+      - name: Read pinned tool versions
+        id: versions
+        run: |
+          set -euo pipefail
+          file=infra/docker/pops-worker-food/versions.json
+          yt_dlp=$(jq -r '.ytDlp' "$file")
+          fw=$(jq -r '.fasterWhisper' "$file")
+          model=$(jq -r '.whisperModel' "$file")
+          for v in "$yt_dlp" "$fw" "$model"; do
+            if [ -z "$v" ] || [ "$v" = "null" ]; then
+              echo "::error::versions.json is missing a required key (yt_dlp=$yt_dlp fw=$fw model=$model)"
+              exit 1
+            fi
+          done
+          {
+            echo "yt_dlp=$yt_dlp"
+            echo "faster_whisper=$fw"
+            echo "whisper_model=$model"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Log in to GHCR
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         uses: docker/login-action@v4
@@ -72,6 +92,9 @@ jobs:
           push: false
           build-args: |
             BUILD_VERSION=${{ github.sha }}
+            YT_DLP_VERSION=${{ steps.versions.outputs.yt_dlp }}
+            FASTER_WHISPER_VERSION=${{ steps.versions.outputs.faster_whisper }}
+            WHISPER_MODEL=${{ steps.versions.outputs.whisper_model }}
 
       - name: Build and push (main / dispatch)
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
@@ -84,3 +107,6 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             BUILD_VERSION=${{ github.sha }}
+            YT_DLP_VERSION=${{ steps.versions.outputs.yt_dlp }}
+            FASTER_WHISPER_VERSION=${{ steps.versions.outputs.faster_whisper }}
+            WHISPER_MODEL=${{ steps.versions.outputs.whisper_model }}

--- a/apps/pops-worker-food/package.json
+++ b/apps/pops-worker-food/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@pops/worker-food",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsx watch --clear-screen=false src/worker.ts",
+    "start": "node dist/worker.js",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@pops/food-contracts": "workspace:*",
+    "@trpc/client": "11.17.0",
+    "bullmq": "^5.78.0",
+    "ioredis": "^5.11.0",
+    "pino": "^10.3.1"
+  },
+  "devDependencies": {
+    "@pops/api": "workspace:*",
+    "@types/node": "^25.9.1",
+    "tsx": "^4.22.4",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.8"
+  }
+}

--- a/apps/pops-worker-food/src/__tests__/config.test.ts
+++ b/apps/pops-worker-food/src/__tests__/config.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { loadConfig } from '../config.js';
+
+const KEYS = [
+  'REDIS_URL',
+  'POPS_API_URL',
+  'POPS_API_INTERNAL_TOKEN',
+  'FOOD_WORKER_CONCURRENCY',
+  'FOOD_INGEST_RATE_PER_MIN',
+  'FOOD_WORKER_HEALTH_PORT',
+  'FOOD_WORKER_DRAIN_TIMEOUT_MS',
+  'POPS_WORKER_FOOD_VERSION',
+] as const;
+
+const snapshot: Partial<Record<(typeof KEYS)[number], string | undefined>> = {};
+
+beforeEach(() => {
+  for (const k of KEYS) {
+    snapshot[k] = process.env[k];
+    delete process.env[k];
+  }
+});
+
+afterEach(() => {
+  for (const k of KEYS) {
+    if (snapshot[k] === undefined) delete process.env[k];
+    else process.env[k] = snapshot[k];
+  }
+});
+
+describe('loadConfig', () => {
+  it('fails fast when the internal token is missing', () => {
+    expect(() => loadConfig()).toThrow(/POPS_API_INTERNAL_TOKEN/);
+  });
+
+  it('returns defaults when only the token is set', () => {
+    process.env['POPS_API_INTERNAL_TOKEN'] = 'tok';
+    const cfg = loadConfig();
+    expect(cfg).toEqual({
+      redisUrl: 'redis://localhost:6379',
+      apiUrl: 'http://localhost:3000',
+      internalToken: 'tok',
+      concurrency: 2,
+      ratePerMin: 30,
+      healthPort: 9090,
+      drainTimeoutMs: 60_000,
+      extractorVersion: 'pops-worker-food@0.1.0',
+    });
+  });
+
+  it('respects env overrides', () => {
+    process.env['POPS_API_INTERNAL_TOKEN'] = 'tok';
+    process.env['REDIS_URL'] = 'redis://redis:6379';
+    process.env['POPS_API_URL'] = 'http://api:3000/';
+    process.env['FOOD_WORKER_CONCURRENCY'] = '4';
+    process.env['FOOD_INGEST_RATE_PER_MIN'] = '60';
+    process.env['FOOD_WORKER_HEALTH_PORT'] = '9999';
+    process.env['FOOD_WORKER_DRAIN_TIMEOUT_MS'] = '30000';
+    process.env['POPS_WORKER_FOOD_VERSION'] = 'pops-worker-food@1.2.3';
+    const cfg = loadConfig();
+    expect(cfg).toEqual({
+      redisUrl: 'redis://redis:6379',
+      apiUrl: 'http://api:3000/',
+      internalToken: 'tok',
+      concurrency: 4,
+      ratePerMin: 60,
+      healthPort: 9999,
+      drainTimeoutMs: 30_000,
+      extractorVersion: 'pops-worker-food@1.2.3',
+    });
+  });
+
+  it('rejects non-positive concurrency', () => {
+    process.env['POPS_API_INTERNAL_TOKEN'] = 'tok';
+    process.env['FOOD_WORKER_CONCURRENCY'] = '0';
+    expect(() => loadConfig()).toThrow(/FOOD_WORKER_CONCURRENCY/);
+  });
+
+  it('rejects non-numeric rate limits', () => {
+    process.env['POPS_API_INTERNAL_TOKEN'] = 'tok';
+    process.env['FOOD_INGEST_RATE_PER_MIN'] = 'fast';
+    expect(() => loadConfig()).toThrow(/FOOD_INGEST_RATE_PER_MIN/);
+  });
+});

--- a/apps/pops-worker-food/src/__tests__/config.test.ts
+++ b/apps/pops-worker-food/src/__tests__/config.test.ts
@@ -8,6 +8,7 @@ const KEYS = [
   'POPS_API_INTERNAL_TOKEN',
   'FOOD_WORKER_CONCURRENCY',
   'FOOD_INGEST_RATE_PER_MIN',
+  'FOOD_INGEST_TIMEOUT_SEC',
   'FOOD_WORKER_HEALTH_PORT',
   'FOOD_WORKER_DRAIN_TIMEOUT_MS',
   'POPS_WORKER_FOOD_VERSION',
@@ -43,6 +44,7 @@ describe('loadConfig', () => {
       internalToken: 'tok',
       concurrency: 2,
       ratePerMin: 30,
+      jobTimeoutSec: 300,
       healthPort: 9090,
       drainTimeoutMs: 60_000,
       extractorVersion: 'pops-worker-food@0.1.0',
@@ -55,6 +57,7 @@ describe('loadConfig', () => {
     process.env['POPS_API_URL'] = 'http://api:3000/';
     process.env['FOOD_WORKER_CONCURRENCY'] = '4';
     process.env['FOOD_INGEST_RATE_PER_MIN'] = '60';
+    process.env['FOOD_INGEST_TIMEOUT_SEC'] = '120';
     process.env['FOOD_WORKER_HEALTH_PORT'] = '9999';
     process.env['FOOD_WORKER_DRAIN_TIMEOUT_MS'] = '30000';
     process.env['POPS_WORKER_FOOD_VERSION'] = 'pops-worker-food@1.2.3';
@@ -65,6 +68,7 @@ describe('loadConfig', () => {
       internalToken: 'tok',
       concurrency: 4,
       ratePerMin: 60,
+      jobTimeoutSec: 120,
       healthPort: 9999,
       drainTimeoutMs: 30_000,
       extractorVersion: 'pops-worker-food@1.2.3',
@@ -81,5 +85,11 @@ describe('loadConfig', () => {
     process.env['POPS_API_INTERNAL_TOKEN'] = 'tok';
     process.env['FOOD_INGEST_RATE_PER_MIN'] = 'fast';
     expect(() => loadConfig()).toThrow(/FOOD_INGEST_RATE_PER_MIN/);
+  });
+
+  it('rejects decimal values (silent floor would hide misconfiguration)', () => {
+    process.env['POPS_API_INTERNAL_TOKEN'] = 'tok';
+    process.env['FOOD_WORKER_CONCURRENCY'] = '1.9';
+    expect(() => loadConfig()).toThrow(/FOOD_WORKER_CONCURRENCY/);
   });
 });

--- a/apps/pops-worker-food/src/__tests__/dispatch.test.ts
+++ b/apps/pops-worker-food/src/__tests__/dispatch.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { runIngestJob } from '../dispatch.js';
+import { defaultHandlers } from '../handlers/index.js';
+import { NOT_IMPLEMENTED_EXTRACTOR_VERSION } from '../handlers/not-implemented.js';
+
+import type { IngestJobData, IngestJobResult } from '@pops/food-contracts';
+
+import type { IngestHandlerRegistry } from '../handlers/index.js';
+import type { HandlerContext } from '../handlers/types.js';
+
+const ctx: HandlerContext = { isCancelled: () => false };
+
+function okResult(tag: string): IngestJobResult {
+  return {
+    ok: true,
+    dsl: `@recipe(${tag})`,
+    meta: { extractor_version: 'mock@test', stages: {} },
+  };
+}
+
+function mockRegistry(): {
+  handlers: IngestHandlerRegistry;
+  calls: { kind: keyof IngestHandlerRegistry; data: IngestJobData; cancelled: boolean }[];
+} {
+  const calls: {
+    kind: keyof IngestHandlerRegistry;
+    data: IngestJobData;
+    cancelled: boolean;
+  }[] = [];
+  const handlers: IngestHandlerRegistry = {
+    'url-web': vi.fn(async (data, c) => {
+      calls.push({ kind: 'url-web', data, cancelled: await c.isCancelled() });
+      return okResult('web');
+    }),
+    'url-instagram': vi.fn(async (data, c) => {
+      calls.push({ kind: 'url-instagram', data, cancelled: await c.isCancelled() });
+      return okResult('ig');
+    }),
+    screenshot: vi.fn(async (data, c) => {
+      calls.push({ kind: 'screenshot', data, cancelled: await c.isCancelled() });
+      return okResult('screenshot');
+    }),
+    text: vi.fn(async (data, c) => {
+      calls.push({ kind: 'text', data, cancelled: await c.isCancelled() });
+      return okResult('text');
+    }),
+  };
+  return { handlers, calls };
+}
+
+describe('runIngestJob', () => {
+  it('dispatches url-web jobs to the web handler', async () => {
+    const { handlers, calls } = mockRegistry();
+    const result = await runIngestJob(
+      { kind: 'url-web', sourceId: 1, url: 'https://example.com' },
+      ctx,
+      handlers
+    );
+    expect(result.ok).toBe(true);
+    expect(calls).toEqual([
+      { kind: 'url-web', data: expect.objectContaining({ kind: 'url-web' }), cancelled: false },
+    ]);
+  });
+
+  it('dispatches url-instagram jobs to the instagram handler', async () => {
+    const { handlers, calls } = mockRegistry();
+    await runIngestJob(
+      { kind: 'url-instagram', sourceId: 2, url: 'https://instagram.com/r/abc' },
+      ctx,
+      handlers
+    );
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.kind).toBe('url-instagram');
+  });
+
+  it('dispatches screenshot jobs to the screenshot handler', async () => {
+    const { handlers, calls } = mockRegistry();
+    await runIngestJob(
+      {
+        kind: 'screenshot',
+        sourceId: 3,
+        mimeType: 'image/png',
+        contentPath: '/tmp/x.png',
+      },
+      ctx,
+      handlers
+    );
+    expect(calls[0]?.kind).toBe('screenshot');
+  });
+
+  it('dispatches text jobs to the text handler', async () => {
+    const { handlers, calls } = mockRegistry();
+    await runIngestJob({ kind: 'text', sourceId: 4, body: 'pasta' }, ctx, handlers);
+    expect(calls[0]?.kind).toBe('text');
+  });
+
+  it('does not invoke handlers for other kinds', async () => {
+    const { handlers } = mockRegistry();
+    await runIngestJob({ kind: 'text', sourceId: 5, body: 'x' }, ctx, handlers);
+    expect(handlers['url-web']).not.toHaveBeenCalled();
+    expect(handlers['url-instagram']).not.toHaveBeenCalled();
+    expect(handlers.screenshot).not.toHaveBeenCalled();
+  });
+
+  it('threads the cancellation context into the handler', async () => {
+    const { handlers, calls } = mockRegistry();
+    await runIngestJob(
+      { kind: 'text', sourceId: 6, body: 'x' },
+      { isCancelled: () => true },
+      handlers
+    );
+    expect(calls[0]?.cancelled).toBe(true);
+  });
+
+  it('returns the handler result verbatim', async () => {
+    const handlers: IngestHandlerRegistry = {
+      ...mockRegistry().handlers,
+      text: async () => ({
+        ok: false,
+        errorCode: 'TestFailure',
+        errorMessage: 'forced',
+        meta: { extractor_version: 'mock@test', stages: {} },
+      }),
+    };
+    const result = await runIngestJob({ kind: 'text', sourceId: 7, body: 'x' }, ctx, handlers);
+    expect(result).toEqual({
+      ok: false,
+      errorCode: 'TestFailure',
+      errorMessage: 'forced',
+      meta: { extractor_version: 'mock@test', stages: {} },
+    });
+  });
+});
+
+describe('default handler stubs', () => {
+  it('all kinds resolve to NotImplemented failures with the stub version', async () => {
+    const kinds: IngestJobData[] = [
+      { kind: 'url-web', sourceId: 1, url: 'https://example.com' },
+      { kind: 'url-instagram', sourceId: 2, url: 'https://instagram.com/r/abc' },
+      { kind: 'screenshot', sourceId: 3, mimeType: 'image/png', contentPath: '/tmp/x.png' },
+      { kind: 'text', sourceId: 4, body: 'hi' },
+    ];
+    for (const data of kinds) {
+      const result = await runIngestJob(data, ctx, defaultHandlers);
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error('unreachable');
+      expect(result.errorCode).toBe('NotImplemented');
+      expect(result.meta.extractor_version).toBe(NOT_IMPLEMENTED_EXTRACTOR_VERSION);
+    }
+  });
+});

--- a/apps/pops-worker-food/src/__tests__/health.test.ts
+++ b/apps/pops-worker-food/src/__tests__/health.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { startHealthServer } from '../health.js';
+
+import type { Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+let server: Server | null = null;
+
+afterEach(async () => {
+  if (server) {
+    await new Promise<void>((resolve, reject) => {
+      server?.close((err) => (err ? reject(err) : resolve()));
+    });
+    server = null;
+  }
+});
+
+function urlFor(s: Server, path: string): string {
+  const addr = s.address() as AddressInfo;
+  return `http://127.0.0.1:${addr.port}${path}`;
+}
+
+describe('startHealthServer', () => {
+  it('returns the documented healthz JSON shape', async () => {
+    server = startHealthServer(0, {
+      isQueueRunning: () => true,
+      getActiveJobCount: () => 3,
+    });
+    await new Promise<void>((resolve) => server?.once('listening', () => resolve()));
+
+    const res = await fetch(urlFor(server, '/healthz'));
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('application/json');
+    const body = (await res.json()) as { ok: boolean; queueRunning: boolean; activeJobs: number };
+    expect(body).toEqual({ ok: true, queueRunning: true, activeJobs: 3 });
+  });
+
+  it('reflects current queue state on each call', async () => {
+    let running = true;
+    let active = 0;
+    server = startHealthServer(0, {
+      isQueueRunning: () => running,
+      getActiveJobCount: () => active,
+    });
+    await new Promise<void>((resolve) => server?.once('listening', () => resolve()));
+
+    const first = await (await fetch(urlFor(server, '/healthz'))).json();
+    expect(first).toMatchObject({ queueRunning: true, activeJobs: 0 });
+
+    running = false;
+    active = 5;
+    const second = await (await fetch(urlFor(server, '/healthz'))).json();
+    expect(second).toMatchObject({ queueRunning: false, activeJobs: 5 });
+  });
+
+  it('404s on unknown paths', async () => {
+    server = startHealthServer(0, {
+      isQueueRunning: () => true,
+      getActiveJobCount: () => 0,
+    });
+    await new Promise<void>((resolve) => server?.once('listening', () => resolve()));
+
+    const res = await fetch(urlFor(server, '/anything-else'));
+    expect(res.status).toBe(404);
+  });
+});

--- a/apps/pops-worker-food/src/__tests__/timeout.test.ts
+++ b/apps/pops-worker-food/src/__tests__/timeout.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+
+import { timeoutResult } from '../worker.js';
+
+describe('timeoutResult', () => {
+  it('emits a TimedOut failure carrying the extractor version + timeout seconds', () => {
+    const result = timeoutResult('pops-worker-food@1.2.3', 300);
+    expect(result).toEqual({
+      ok: false,
+      errorCode: 'TimedOut',
+      errorMessage: 'Job exceeded FOOD_INGEST_TIMEOUT_SEC=300',
+      meta: { extractor_version: 'pops-worker-food@1.2.3', stages: {} },
+    });
+  });
+});

--- a/apps/pops-worker-food/src/api-client.ts
+++ b/apps/pops-worker-food/src/api-client.ts
@@ -1,0 +1,68 @@
+import { createTRPCClient, httpBatchLink } from '@trpc/client';
+
+import type { AppRouter } from '@pops/api';
+import type { IngestJobResult } from '@pops/food-contracts';
+
+export type TrpcClient = ReturnType<typeof createTRPCClient<AppRouter>>;
+
+/**
+ * Build a tRPC client that auths against pops-api's `internalProcedure`
+ * gate. The `x-pops-internal-token` header is the contract PRD-125
+ * landed; the PRD-126 spec text says `X-Internal-Token` but the actual
+ * api validates the lowercase `x-pops-internal-token` name (see
+ * `apps/pops-api/src/trpc.ts`'s `isInternalCall`).
+ */
+export function createApiClient(opts: { apiUrl: string; internalToken: string }): TrpcClient {
+  return createTRPCClient<AppRouter>({
+    links: [
+      httpBatchLink({
+        url: `${opts.apiUrl.replace(/\/+$/, '')}/trpc`,
+        headers: () => ({ 'x-pops-internal-token': opts.internalToken }),
+      }),
+    ],
+  });
+}
+
+/**
+ * Post a job result back to pops-api. The mutation input is flattened
+ * (sourceId + result fields) per PRD-125's `WorkerCompleteInput` shape.
+ */
+type WireMeta = {
+  extractor_version: string;
+  stages: Record<string, unknown>;
+  [k: string]: unknown;
+};
+
+/**
+ * pops-api's `MetaSchema` is a zod `.passthrough()`, so the inferred
+ * router input adds a `[k: string]: unknown` index signature that
+ * `IngestMeta`'s interface lacks. `toWireMeta` rebuilds it as a plain
+ * record so the shapes line up without weakening the contract type.
+ */
+function toWireMeta(meta: IngestJobResult['meta']): WireMeta {
+  return { ...meta, extractor_version: meta.extractor_version, stages: meta.stages };
+}
+
+export async function postWorkerComplete(
+  client: TrpcClient,
+  sourceId: number,
+  result: IngestJobResult
+): Promise<void> {
+  if (result.ok) {
+    await client.food.ingest.workerComplete.mutate({
+      sourceId,
+      ok: true,
+      dsl: result.dsl,
+      meta: toWireMeta(result.meta),
+      ...(result.partialReason !== undefined ? { partialReason: result.partialReason } : {}),
+    });
+    return;
+  }
+  await client.food.ingest.workerComplete.mutate({
+    sourceId,
+    ok: false,
+    errorCode: result.errorCode,
+    errorMessage: result.errorMessage,
+    meta: toWireMeta(result.meta),
+  });
+}

--- a/apps/pops-worker-food/src/config.ts
+++ b/apps/pops-worker-food/src/config.ts
@@ -1,0 +1,71 @@
+/**
+ * Runtime configuration pulled from env. Reading env at import time would
+ * make tests painful and prevent `.env`-style overrides; a single load
+ * function called from `worker.ts` keeps the surface explicit.
+ *
+ * Secrets follow pops-api's `env.ts` convention: read from
+ * `/run/secrets/<lowercased-name>` first (Docker secrets file mount),
+ * fall back to `process.env[NAME]` (dev / non-Docker).
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const SECRETS_DIR = '/run/secrets';
+
+function readSecret(name: string): string | undefined {
+  try {
+    const value = readFileSync(join(SECRETS_DIR, name.toLowerCase()), 'utf-8').trim();
+    if (value) return value;
+  } catch {
+    // Falls through to env var on ENOENT / EACCES / etc.
+  }
+  return process.env[name];
+}
+
+export interface WorkerConfig {
+  redisUrl: string;
+  apiUrl: string;
+  internalToken: string;
+  concurrency: number;
+  ratePerMin: number;
+  healthPort: number;
+  drainTimeoutMs: number;
+  /** Pinned semicolon-delimited tool versions for `IngestMeta.extractor_version`. */
+  extractorVersion: string;
+}
+
+const DEFAULT_CONCURRENCY = 2;
+const DEFAULT_RATE_PER_MIN = 30;
+const DEFAULT_HEALTH_PORT = 9090;
+const DEFAULT_DRAIN_TIMEOUT_MS = 60_000;
+
+function readIntEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw == null || raw === '') return fallback;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`Invalid ${name}: ${raw} (expected positive integer)`);
+  }
+  return Math.floor(parsed);
+}
+
+function requireSecret(name: string): string {
+  const value = readSecret(name);
+  if (value == null || value === '') {
+    throw new Error(`Missing required secret: ${name}`);
+  }
+  return value;
+}
+
+export function loadConfig(): WorkerConfig {
+  return {
+    redisUrl: process.env['REDIS_URL'] ?? 'redis://localhost:6379',
+    apiUrl: process.env['POPS_API_URL'] ?? 'http://localhost:3000',
+    internalToken: requireSecret('POPS_API_INTERNAL_TOKEN'),
+    concurrency: readIntEnv('FOOD_WORKER_CONCURRENCY', DEFAULT_CONCURRENCY),
+    ratePerMin: readIntEnv('FOOD_INGEST_RATE_PER_MIN', DEFAULT_RATE_PER_MIN),
+    healthPort: readIntEnv('FOOD_WORKER_HEALTH_PORT', DEFAULT_HEALTH_PORT),
+    drainTimeoutMs: readIntEnv('FOOD_WORKER_DRAIN_TIMEOUT_MS', DEFAULT_DRAIN_TIMEOUT_MS),
+    extractorVersion: process.env['POPS_WORKER_FOOD_VERSION'] ?? 'pops-worker-food@0.1.0',
+  };
+}

--- a/apps/pops-worker-food/src/config.ts
+++ b/apps/pops-worker-food/src/config.ts
@@ -28,6 +28,7 @@ export interface WorkerConfig {
   internalToken: string;
   concurrency: number;
   ratePerMin: number;
+  jobTimeoutSec: number;
   healthPort: number;
   drainTimeoutMs: number;
   /** Pinned semicolon-delimited tool versions for `IngestMeta.extractor_version`. */
@@ -36,6 +37,7 @@ export interface WorkerConfig {
 
 const DEFAULT_CONCURRENCY = 2;
 const DEFAULT_RATE_PER_MIN = 30;
+const DEFAULT_JOB_TIMEOUT_SEC = 300;
 const DEFAULT_HEALTH_PORT = 9090;
 const DEFAULT_DRAIN_TIMEOUT_MS = 60_000;
 
@@ -43,10 +45,10 @@ function readIntEnv(name: string, fallback: number): number {
   const raw = process.env[name];
   if (raw == null || raw === '') return fallback;
   const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed <= 0) {
+  if (!Number.isInteger(parsed) || parsed <= 0) {
     throw new Error(`Invalid ${name}: ${raw} (expected positive integer)`);
   }
-  return Math.floor(parsed);
+  return parsed;
 }
 
 function requireSecret(name: string): string {
@@ -64,6 +66,7 @@ export function loadConfig(): WorkerConfig {
     internalToken: requireSecret('POPS_API_INTERNAL_TOKEN'),
     concurrency: readIntEnv('FOOD_WORKER_CONCURRENCY', DEFAULT_CONCURRENCY),
     ratePerMin: readIntEnv('FOOD_INGEST_RATE_PER_MIN', DEFAULT_RATE_PER_MIN),
+    jobTimeoutSec: readIntEnv('FOOD_INGEST_TIMEOUT_SEC', DEFAULT_JOB_TIMEOUT_SEC),
     healthPort: readIntEnv('FOOD_WORKER_HEALTH_PORT', DEFAULT_HEALTH_PORT),
     drainTimeoutMs: readIntEnv('FOOD_WORKER_DRAIN_TIMEOUT_MS', DEFAULT_DRAIN_TIMEOUT_MS),
     extractorVersion: process.env['POPS_WORKER_FOOD_VERSION'] ?? 'pops-worker-food@0.1.0',

--- a/apps/pops-worker-food/src/dispatch.ts
+++ b/apps/pops-worker-food/src/dispatch.ts
@@ -1,0 +1,33 @@
+import { defaultHandlers } from './handlers/index.js';
+
+import type { IngestJobData, IngestJobResult } from '@pops/food-contracts';
+
+import type { IngestHandlerRegistry } from './handlers/index.js';
+import type { HandlerContext } from './handlers/types.js';
+
+/**
+ * PRD-126 dispatch shell. Routes a `food.ingest` job to its per-kind
+ * handler. The switch over the `data.kind` discriminator carries the
+ * narrowed type into each handler — no `as` cast needed — and the
+ * compiler enforces exhaustiveness via the `never`-typed default branch.
+ */
+export async function runIngestJob(
+  data: IngestJobData,
+  ctx: HandlerContext,
+  handlers: IngestHandlerRegistry = defaultHandlers
+): Promise<IngestJobResult> {
+  switch (data.kind) {
+    case 'url-web':
+      return handlers['url-web'](data, ctx);
+    case 'url-instagram':
+      return handlers['url-instagram'](data, ctx);
+    case 'screenshot':
+      return handlers.screenshot(data, ctx);
+    case 'text':
+      return handlers.text(data, ctx);
+    default: {
+      const exhaustive: never = data;
+      throw new Error(`Unhandled ingest kind: ${JSON.stringify(exhaustive)}`);
+    }
+  }
+}

--- a/apps/pops-worker-food/src/handlers/index.ts
+++ b/apps/pops-worker-food/src/handlers/index.ts
@@ -1,0 +1,30 @@
+import { runInstagramIngest } from './instagram.js';
+import { runScreenshotIngest } from './screenshot.js';
+import { runTextIngest } from './text.js';
+import { runWebUrlIngest } from './web-url.js';
+
+import type { IngestHandler } from './types.js';
+
+/**
+ * Per-kind dispatch table. Injecting it into `runIngestJob` lets unit
+ * tests substitute deterministic mocks without monkey-patching imports.
+ *
+ * Each handler matches its `IngestJobData` discriminator. The compiler
+ * enforces exhaustiveness via the `IngestHandlerRegistry` shape — adding
+ * a new kind without an entry will fail typecheck.
+ */
+export interface IngestHandlerRegistry {
+  'url-web': IngestHandler<'url-web'>;
+  'url-instagram': IngestHandler<'url-instagram'>;
+  screenshot: IngestHandler<'screenshot'>;
+  text: IngestHandler<'text'>;
+}
+
+export const defaultHandlers: IngestHandlerRegistry = {
+  'url-web': runWebUrlIngest,
+  'url-instagram': runInstagramIngest,
+  screenshot: runScreenshotIngest,
+  text: runTextIngest,
+};
+
+export type { HandlerContext, IngestHandler } from './types.js';

--- a/apps/pops-worker-food/src/handlers/instagram.ts
+++ b/apps/pops-worker-food/src/handlers/instagram.ts
@@ -1,0 +1,11 @@
+import { notImplementedResult } from './not-implemented.js';
+
+import type { IngestHandler } from './types.js';
+
+/**
+ * Instagram ingest. Real pipeline lives in PRDs 129 (yt-dlp + cookies +
+ * auth-dead detection) + 130 (STT + vision). Stub for PRD-126.
+ */
+export const runInstagramIngest: IngestHandler<'url-instagram'> = async (_data, _ctx) => {
+  return notImplementedResult('url-instagram');
+};

--- a/apps/pops-worker-food/src/handlers/not-implemented.ts
+++ b/apps/pops-worker-food/src/handlers/not-implemented.ts
@@ -1,0 +1,23 @@
+import type { IngestJobData, IngestJobResult } from '@pops/food-contracts';
+
+/**
+ * Shared NotImplemented stub. PRDs 127–132 replace each per-kind handler
+ * with the real pipeline. Until then every dispatch lands here so the
+ * worker → pops-api round-trip is end-to-end exercisable.
+ *
+ * `extractor_version` carries the worker's own version so the inbox can
+ * tell apart a deliberate stub from an old worker image still in flight.
+ */
+export const NOT_IMPLEMENTED_EXTRACTOR_VERSION = 'pops-worker-food/stub@0.1.0';
+
+export function notImplementedResult(kind: IngestJobData['kind']): IngestJobResult {
+  return {
+    ok: false,
+    errorCode: 'NotImplemented',
+    errorMessage: `Handler for kind="${kind}" is not implemented yet (PRDs 127–132).`,
+    meta: {
+      extractor_version: NOT_IMPLEMENTED_EXTRACTOR_VERSION,
+      stages: {},
+    },
+  };
+}

--- a/apps/pops-worker-food/src/handlers/screenshot.ts
+++ b/apps/pops-worker-food/src/handlers/screenshot.ts
@@ -1,0 +1,11 @@
+import { notImplementedResult } from './not-implemented.js';
+
+import type { IngestHandler } from './types.js';
+
+/**
+ * Screenshot ingest. Real pipeline lives in PRD-131 (single image →
+ * Claude vision). Stub for PRD-126.
+ */
+export const runScreenshotIngest: IngestHandler<'screenshot'> = async (_data, _ctx) => {
+  return notImplementedResult('screenshot');
+};

--- a/apps/pops-worker-food/src/handlers/text.ts
+++ b/apps/pops-worker-food/src/handlers/text.ts
@@ -1,0 +1,11 @@
+import { notImplementedResult } from './not-implemented.js';
+
+import type { IngestHandler } from './types.js';
+
+/**
+ * Text ingest. Real pipeline lives in PRD-132 (paste → Claude text).
+ * Stub for PRD-126.
+ */
+export const runTextIngest: IngestHandler<'text'> = async (_data, _ctx) => {
+  return notImplementedResult('text');
+};

--- a/apps/pops-worker-food/src/handlers/types.ts
+++ b/apps/pops-worker-food/src/handlers/types.ts
@@ -1,0 +1,23 @@
+import type { IngestJobData, IngestJobResult } from '@pops/food-contracts';
+
+/**
+ * Cancellation contract. Handlers MUST check `await ctx.isCancelled()`
+ * between pipeline stages and short-circuit with `{ ok: false, errorCode:
+ * 'Cancelled', ... }` when it returns `true`.
+ *
+ * Cancellation is cooperative — mid-stage cancellation requires killing
+ * the process (BullMQ stalled retry).
+ */
+export interface HandlerContext {
+  isCancelled: () => boolean | Promise<boolean>;
+}
+
+/**
+ * Per-kind handler signature. PRDs 127–132 each export one of these.
+ * v1 ships stubs that return a NotImplemented failure so the dispatch
+ * round-trip can be exercised end-to-end before the real pipelines land.
+ */
+export type IngestHandler<K extends IngestJobData['kind']> = (
+  data: Extract<IngestJobData, { kind: K }>,
+  ctx: HandlerContext
+) => Promise<IngestJobResult>;

--- a/apps/pops-worker-food/src/handlers/web-url.ts
+++ b/apps/pops-worker-food/src/handlers/web-url.ts
@@ -1,0 +1,12 @@
+import { notImplementedResult } from './not-implemented.js';
+
+import type { IngestHandler } from './types.js';
+
+/**
+ * Web-URL ingest. Real pipeline lives in PRDs 127 (JSON-LD) + 128 (LLM
+ * fallback). PRD-126 ships the dispatch shell; this stub keeps the
+ * round-trip honest.
+ */
+export const runWebUrlIngest: IngestHandler<'url-web'> = async (_data, _ctx) => {
+  return notImplementedResult('url-web');
+};

--- a/apps/pops-worker-food/src/health.ts
+++ b/apps/pops-worker-food/src/health.ts
@@ -1,0 +1,34 @@
+import { createServer } from 'node:http';
+
+import type { Server } from 'node:http';
+
+/**
+ * Health endpoint contract from PRD-126:
+ *   GET /healthz → { ok: true, queueRunning: boolean, activeJobs: number }
+ *
+ * Anything else (path, method) returns 404. Used by compose healthcheck
+ * and any external monitoring; pops-api never calls this.
+ */
+export interface HealthState {
+  isQueueRunning: () => boolean;
+  getActiveJobCount: () => number;
+}
+
+export function startHealthServer(port: number, state: HealthState): Server {
+  const server = createServer((req, res) => {
+    if (req.method === 'GET' && req.url === '/healthz') {
+      const body = JSON.stringify({
+        ok: true,
+        queueRunning: state.isQueueRunning(),
+        activeJobs: state.getActiveJobCount(),
+      });
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(body);
+      return;
+    }
+    res.writeHead(404, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ error: 'not_found' }));
+  });
+  server.listen(port);
+  return server;
+}

--- a/apps/pops-worker-food/src/redis.ts
+++ b/apps/pops-worker-food/src/redis.ts
@@ -1,0 +1,11 @@
+import { Redis } from 'ioredis';
+
+/**
+ * Single Redis connection helper shared by BullMQ. `maxRetriesPerRequest:
+ * null` is mandatory — BullMQ uses blocking commands and ioredis's
+ * default retry-on-timeout behaviour fights with them, leading to
+ * spurious disconnects.
+ */
+export function createRedisConnection(redisUrl: string): Redis {
+  return new Redis(redisUrl, { maxRetriesPerRequest: null });
+}

--- a/apps/pops-worker-food/src/worker.ts
+++ b/apps/pops-worker-food/src/worker.ts
@@ -17,8 +17,11 @@
  *      exits.
  *
  * Cancellation is cooperative — handlers check `ctx.isCancelled()`
- * between pipeline stages. We forward `job.isToBeRemoved()` from BullMQ
- * so a `cancel` from the API surfaces inside the running handler.
+ * between pipeline stages. We surface it by polling `job.getState()`
+ * for `'unknown'` (BullMQ has no `isToBeRemoved()` method; the PRD
+ * spec text sketches one). When the API calls `food.ingest.cancel`,
+ * `job.remove()` deletes the row in Redis, the next state check returns
+ * `'unknown'`, and the handler short-circuits with `errorCode='Cancelled'`.
  */
 import { Worker } from 'bullmq';
 import pino from 'pino';
@@ -57,9 +60,44 @@ async function isJobCancelled(job: Job<IngestJobData>): Promise<boolean> {
   }
 }
 
-async function processJob(job: Job<IngestJobData>, client: TrpcClient): Promise<IngestJobResult> {
+/**
+ * Per-job timeout enforced in-band via `Promise.race`. BullMQ has no
+ * native per-job timeout — `stalledInterval` only detects lost-lock
+ * after the fact. Racing the handler against a timer gives the worker
+ * a deterministic failure path (and a callback to pops-api with a
+ * `TimedOut` error code) instead of leaking long-running stages.
+ */
+export function timeoutResult(extractorVersion: string, sec: number): IngestJobResult {
+  return {
+    ok: false,
+    errorCode: 'TimedOut',
+    errorMessage: `Job exceeded FOOD_INGEST_TIMEOUT_SEC=${sec}`,
+    meta: { extractor_version: extractorVersion, stages: {} },
+  };
+}
+
+async function processJob(
+  job: Job<IngestJobData>,
+  client: TrpcClient,
+  config: WorkerConfig
+): Promise<IngestJobResult> {
   const ctx: HandlerContext = { isCancelled: () => isJobCancelled(job) };
-  const result = await runIngestJob(job.data, ctx);
+  const timeoutMs = config.jobTimeoutSec * 1000;
+
+  let timer: NodeJS.Timeout | undefined;
+  const timeoutPromise = new Promise<IngestJobResult>((resolve) => {
+    timer = setTimeout(() => {
+      logger.warn(
+        { jobId: job.id, sourceId: job.data.sourceId, jobTimeoutSec: config.jobTimeoutSec },
+        'job timed out'
+      );
+      resolve(timeoutResult(config.extractorVersion, config.jobTimeoutSec));
+    }, timeoutMs);
+  });
+
+  const result = await Promise.race([runIngestJob(job.data, ctx), timeoutPromise]);
+  if (timer) clearTimeout(timer);
+
   try {
     await postWorkerComplete(client, job.data.sourceId, result);
   } catch (err) {
@@ -84,7 +122,7 @@ export async function startWorker(config: WorkerConfig): Promise<{
 
   const worker = new Worker<IngestJobData, IngestJobResult>(
     FOOD_INGEST_QUEUE_NAME,
-    (job) => processJob(job, client),
+    (job) => processJob(job, client, config),
     {
       connection,
       concurrency: config.concurrency,

--- a/apps/pops-worker-food/src/worker.ts
+++ b/apps/pops-worker-food/src/worker.ts
@@ -1,0 +1,166 @@
+/**
+ * PRD-126 — pops-worker-food daemon entry point.
+ *
+ * Connects to the `food.ingest` BullMQ queue (contract from
+ * `@pops/food-contracts`), dispatches each job to its per-kind handler
+ * via `runIngestJob`, and POSTs the result back to pops-api's
+ * `food.ingest.workerComplete` mutation. Auth uses the shared
+ * `POPS_API_INTERNAL_TOKEN` secret in the `x-pops-internal-token`
+ * header (PRD-125 contract).
+ *
+ * Lifecycle:
+ *   1. `loadConfig()` reads env (fails fast on missing token).
+ *   2. BullMQ Worker starts with the configured concurrency + rate limiter.
+ *   3. A small HTTP server on `FOOD_WORKER_HEALTH_PORT` exposes /healthz.
+ *   4. SIGTERM triggers `worker.close()` which drains active jobs up to
+ *      `FOOD_WORKER_DRAIN_TIMEOUT_MS` (60s default) before the process
+ *      exits.
+ *
+ * Cancellation is cooperative — handlers check `ctx.isCancelled()`
+ * between pipeline stages. We forward `job.isToBeRemoved()` from BullMQ
+ * so a `cancel` from the API surfaces inside the running handler.
+ */
+import { Worker } from 'bullmq';
+import pino from 'pino';
+
+import { FOOD_INGEST_QUEUE_NAME } from '@pops/food-contracts';
+
+import { createApiClient, postWorkerComplete } from './api-client.js';
+import { loadConfig } from './config.js';
+import { runIngestJob } from './dispatch.js';
+import { startHealthServer } from './health.js';
+import { createRedisConnection } from './redis.js';
+
+import type { Job } from 'bullmq';
+
+import type { IngestJobData, IngestJobResult } from '@pops/food-contracts';
+
+import type { TrpcClient } from './api-client.js';
+import type { WorkerConfig } from './config.js';
+import type { HandlerContext } from './handlers/types.js';
+
+const logger = pino({ name: 'pops-worker-food' });
+
+/**
+ * Cancellation contract: PRD-125's `food.ingest.cancel` calls `job.remove()`,
+ * which deletes the BullMQ row but does NOT abort an already-running
+ * processor. The processor cooperatively polls `job.getState()` between
+ * stages — once removed, the state is `'unknown'`. This is the same
+ * pattern the PRD-126 spec sketches as "isToBeRemoved", which is not a
+ * real BullMQ method.
+ */
+async function isJobCancelled(job: Job<IngestJobData>): Promise<boolean> {
+  try {
+    return (await job.getState()) === 'unknown';
+  } catch {
+    return true;
+  }
+}
+
+async function processJob(job: Job<IngestJobData>, client: TrpcClient): Promise<IngestJobResult> {
+  const ctx: HandlerContext = { isCancelled: () => isJobCancelled(job) };
+  const result = await runIngestJob(job.data, ctx);
+  try {
+    await postWorkerComplete(client, job.data.sourceId, result);
+  } catch (err) {
+    logger.error(
+      { err, jobId: job.id, sourceId: job.data.sourceId },
+      'workerComplete callback failed; BullMQ will retry the job'
+    );
+    throw err;
+  }
+  return result;
+}
+
+export async function startWorker(config: WorkerConfig): Promise<{
+  worker: Worker<IngestJobData, IngestJobResult>;
+  shutdown: () => Promise<void>;
+}> {
+  const connection = createRedisConnection(config.redisUrl);
+  const client = createApiClient({
+    apiUrl: config.apiUrl,
+    internalToken: config.internalToken,
+  });
+
+  const worker = new Worker<IngestJobData, IngestJobResult>(
+    FOOD_INGEST_QUEUE_NAME,
+    (job) => processJob(job, client),
+    {
+      connection,
+      concurrency: config.concurrency,
+      limiter: { max: config.ratePerMin, duration: 60_000 },
+    }
+  );
+
+  worker.on('completed', (job, result) => {
+    logger.info(
+      {
+        jobId: job.id,
+        sourceId: job.data.sourceId,
+        kind: job.data.kind,
+        ok: result.ok,
+      },
+      'job completed'
+    );
+  });
+
+  worker.on('failed', (job, err) => {
+    logger.error({ jobId: job?.id, sourceId: job?.data.sourceId, err }, 'job failed');
+  });
+
+  const activeJobs = new Set<string>();
+  worker.on('active', (job) => {
+    if (job.id != null) activeJobs.add(job.id);
+  });
+  worker.on('completed', (job) => {
+    if (job.id != null) activeJobs.delete(job.id);
+  });
+  worker.on('failed', (job) => {
+    if (job?.id != null) activeJobs.delete(job.id);
+  });
+
+  const healthServer = startHealthServer(config.healthPort, {
+    isQueueRunning: () => worker.isRunning(),
+    getActiveJobCount: () => activeJobs.size,
+  });
+
+  const shutdown = async (): Promise<void> => {
+    logger.info('shutting down');
+    await Promise.race([
+      worker.close(),
+      new Promise((resolve) => setTimeout(resolve, config.drainTimeoutMs)),
+    ]);
+    await new Promise<void>((resolve) => healthServer.close(() => resolve()));
+    await connection.quit();
+  };
+
+  return { worker, shutdown };
+}
+
+async function main(): Promise<void> {
+  const config = loadConfig();
+  const { shutdown } = await startWorker(config);
+  logger.info(
+    { concurrency: config.concurrency, ratePerMin: config.ratePerMin },
+    'pops-worker-food started'
+  );
+
+  const onSignal = (signal: NodeJS.Signals): void => {
+    logger.info({ signal }, 'received shutdown signal');
+    shutdown()
+      .then(() => process.exit(0))
+      .catch((err: unknown) => {
+        logger.error({ err }, 'shutdown failed');
+        process.exit(1);
+      });
+  };
+  process.on('SIGTERM', onSignal);
+  process.on('SIGINT', onSignal);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err: unknown) => {
+    logger.error({ err }, 'worker bootstrap failed');
+    process.exit(1);
+  });
+}

--- a/apps/pops-worker-food/tsconfig.json
+++ b/apps/pops-worker-food/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "sourceMap": true,
+    "types": ["node"]
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/__tests__/**"]
+}

--- a/apps/pops-worker-food/vitest.config.ts
+++ b/apps/pops-worker-food/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/docs/themes/07-food/epics/02-ingestion-pipeline.md
+++ b/docs/themes/07-food/epics/02-ingestion-pipeline.md
@@ -15,7 +15,7 @@ This epic is pipeline-only. The review queue UI that promotes drafts to canonica
 | #   | PRD                                                                           | Summary                                                                                               | Status      |
 | --- | ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- | ----------- |
 | 125 | [Ingest API & BullMQ Queue Contract](../prds/125-ingest-api/README.md)        | `POST /api/food/ingest` endpoint; BullMQ `food.ingest` queue; job shape, retries, backoff; status API | Not started |
-| 126 | [pops-worker-food Container](../prds/126-worker-container/README.md)          | Docker image (Node + Python venv + yt-dlp + ffmpeg + faster-whisper); long-running daemon; lifecycle  | Not started |
+| 126 | [pops-worker-food Container](../prds/126-worker-container/README.md)          | Docker image (Node + Python venv + yt-dlp + ffmpeg + faster-whisper); long-running daemon; lifecycle  | Partial     |
 | 127 | [Web URL — JSON-LD Extraction](../prds/127-web-jsonld/README.md)              | Fetch HTML, parse `application/ld+json` Recipe schema, map to draft. Fast path, no LLM call.          | Not started |
 | 128 | [Web URL — LLM Fallback Extraction](../prds/128-web-llm-fallback/README.md)   | When JSON-LD absent: readability extract → DSL via text LLM. Slower path; one Claude call per ingest. | Not started |
 | 129 | [Instagram Acquisition](../prds/129-instagram-acquisition/README.md)          | yt-dlp + cookie management; caption + video + info JSON download; auth-dead detection                 | Not started |

--- a/docs/themes/07-food/prds/126-worker-container/README.md
+++ b/docs/themes/07-food/prds/126-worker-container/README.md
@@ -221,7 +221,7 @@ Inline per theme protocol.
 - [x] Multi-stage build; final image < 2 GB.
 - [x] faster-whisper `distil-large-v3` model baked into the image (downloaded at build time).
 - [x] yt-dlp and faster-whisper versions pinned; documented in the Dockerfile + a `versions.json` in `infra/docker/pops-worker-food/`.
-- [x] GitHub Actions workflow builds + pushes to `ghcr.io/knoxio/pops-worker-food:latest` on changes under `apps/pops-worker-food/**` or `infra/docker/pops-worker-food/**`.
+- [x] GitHub Actions workflow builds + pushes to `ghcr.io/knoxio/pops-worker-food:main` (matches the `pops-api` / `pops-shell` / `pops-mcp` `:main` + `sha-<short>` tagging convention; the spec text said `:latest`, but POPS uses `:main` for the rolling default-branch image) on changes under `apps/pops-worker-food/**` or `infra/docker/pops-worker-food/**`.
 
 ### Compose
 

--- a/docs/themes/07-food/prds/126-worker-container/README.md
+++ b/docs/themes/07-food/prds/126-worker-container/README.md
@@ -217,41 +217,41 @@ Inline per theme protocol.
 
 ### Image
 
-- [ ] `infra/docker/pops-worker-food/Dockerfile` matches the structure above.
-- [ ] Multi-stage build; final image < 2 GB.
-- [ ] faster-whisper `distil-large-v3` model baked into the image (downloaded at build time).
-- [ ] yt-dlp and faster-whisper versions pinned; documented in the Dockerfile + a `versions.json` in `infra/docker/pops-worker-food/`.
-- [ ] GitHub Actions workflow builds + pushes to `ghcr.io/knoxio/pops-worker-food:latest` on changes under `apps/pops-worker-food/**` or `infra/docker/pops-worker-food/**`.
+- [x] `infra/docker/pops-worker-food/Dockerfile` matches the structure above.
+- [x] Multi-stage build; final image < 2 GB.
+- [x] faster-whisper `distil-large-v3` model baked into the image (downloaded at build time).
+- [x] yt-dlp and faster-whisper versions pinned; documented in the Dockerfile + a `versions.json` in `infra/docker/pops-worker-food/`.
+- [x] GitHub Actions workflow builds + pushes to `ghcr.io/knoxio/pops-worker-food:latest` on changes under `apps/pops-worker-food/**` or `infra/docker/pops-worker-food/**`.
 
 ### Compose
 
-- [ ] `infra/docker-compose.yml` adds the `worker-food` service per the spec.
-- [ ] Cookie volume mount documented; `infra/secrets/.gitignore` excludes the cookie file.
-- [ ] Healthcheck succeeds when worker is running.
+- [x] `infra/docker-compose.yml` adds the `worker-food` service per the spec.
+- [ ] Cookie volume mount documented; `infra/secrets/.gitignore` excludes the cookie file. <!-- Documented inline in compose; the `infra/secrets/` directory is operator-managed and out of repo (PRD-129 owns the cookie-refresh runbook). -->
+- [x] Healthcheck succeeds when worker is running.
 
 ### Worker daemon
 
-- [ ] `apps/pops-worker-food/src/worker.ts` exists; compiled output runs in the container.
-- [ ] BullMQ Worker connects, picks up `food.ingest` jobs, dispatches to per-kind handlers via `runIngestJob`.
-- [ ] Graceful shutdown on SIGTERM drains active jobs (up to 60s).
-- [ ] Cancellation is checked between pipeline stages.
+- [x] `apps/pops-worker-food/src/worker.ts` exists; compiled output runs in the container.
+- [x] BullMQ Worker connects, picks up `food.ingest` jobs, dispatches to per-kind handlers via `runIngestJob`.
+- [x] Graceful shutdown on SIGTERM drains active jobs (up to 60s).
+- [x] Cancellation is checked between pipeline stages.
 
 ### Internal API auth
 
-- [ ] `POPS_API_INTERNAL_TOKEN` env var consumed; passed in `X-Internal-Token` header.
-- [ ] pops-api validates the token on `food.ingest.workerComplete` mutation; rejects without it.
+- [x] `POPS_API_INTERNAL_TOKEN` env var consumed; passed in `x-pops-internal-token` header (PRD-125's actual contract; the spec text says `X-Internal-Token`, but the implemented producer reads `x-pops-internal-token` per `apps/pops-api/src/trpc.ts`).
+- [x] pops-api validates the token on `food.ingest.workerComplete` mutation; rejects without it.
 
 ### Observability
 
-- [ ] `/healthz` endpoint at port 9090 returns the documented JSON.
-- [ ] Every log line includes `sourceId` and `jobId` when in a job context.
-- [ ] Compose healthcheck succeeds.
+- [x] `/healthz` endpoint at port 9090 returns the documented JSON.
+- [x] Every log line includes `sourceId` and `jobId` when in a job context.
+- [x] Compose healthcheck succeeds.
 
 ### Tests
 
-- [ ] Vitest unit tests at `apps/pops-worker-food/src/__tests__/dispatch.test.ts` cover `runIngestJob` dispatching to each handler (handlers mocked).
-- [ ] Integration test (Vitest + testcontainers OR docker-compose-based) spins up worker + redis + mock api; submits a job; asserts the worker picks it up and calls the mock api's `workerComplete`.
-- [ ] CI builds the image on PR (image not pushed unless on main).
+- [x] Vitest unit tests at `apps/pops-worker-food/src/__tests__/dispatch.test.ts` cover `runIngestJob` dispatching to each handler (handlers mocked).
+- [ ] Integration test (Vitest + testcontainers OR docker-compose-based) spins up worker + redis + mock api; submits a job; asserts the worker picks it up and calls the mock api's `workerComplete`. <!-- Deferred to a follow-up — testcontainers infra not yet wired into the monorepo. The unit suite exercises the dispatch round-trip with mocked handlers + a mocked api client. -->
+- [x] CI builds the image on PR (image not pushed unless on main).
 
 ## Out of Scope
 

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -115,14 +115,15 @@ services:
       - backend
     volumes:
       - food-ingest-data:/data/food/ingest
-      # Cookie file is operator-managed (see PRD-129's runbook). Comment
-      # out the mount when no cookies are provisioned — yt-dlp falls
-      # back to anonymous mode and Instagram reels will fail with
-      # auth-dead, which the inbox surfaces as a `partial` outcome.
-      - ../secrets/instagram-cookies.txt:/secrets/instagram-cookies.txt:ro
     secrets:
       - claude_api_key
       - pops_api_internal_token
+      # Cookie file is operator-managed (see PRD-129's runbook). Mounted
+      # via a Docker secret rather than a bind-mount so an empty
+      # placeholder under `infra/secrets/instagram_cookies` is enough to
+      # start the stack — yt-dlp falls back to anonymous mode when the
+      # file is empty, which the inbox surfaces as `auth-dead` partials.
+      - instagram_cookies
     environment:
       NODE_ENV: production
       REDIS_URL: redis://pops-redis:6379
@@ -134,7 +135,7 @@ services:
       FOOD_INGEST_TIMEOUT_SEC: ${FOOD_INGEST_TIMEOUT_SEC:-300}
       FOOD_INGEST_RATE_PER_MIN: ${FOOD_INGEST_RATE_PER_MIN:-30}
       FOOD_INGEST_DIR: /data/food/ingest
-      INSTAGRAM_COOKIES_PATH: /secrets/instagram-cookies.txt
+      INSTAGRAM_COOKIES_PATH: /run/secrets/instagram_cookies
       # Per-handler model overrides (PRDs 128 / 130 / 131 / 132).
       FOOD_WEB_LLM_MODEL: ${FOOD_WEB_LLM_MODEL:-claude-haiku-4-5-20251001}
       FOOD_IG_VISION_MODEL: ${FOOD_IG_VISION_MODEL:-claude-haiku-4-5-20251001}
@@ -385,6 +386,8 @@ secrets:
     file: ../secrets/pops_api_key
   pops_api_internal_token:
     file: ../secrets/pops_api_internal_token
+  instagram_cookies:
+    file: ../secrets/instagram_cookies
   tmdb_api_key:
     file: ../secrets/tmdb_api_key
   thetvdb_api_key:

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -99,6 +99,62 @@ services:
       pops-redis:
         condition: service_healthy
 
+  # ── FOOD INGEST WORKER ───────────────────────────────────────────
+  # PRD-126 — consumes the `food.ingest` BullMQ queue produced by
+  # pops-api (PRD-125) and runs the per-kind ingest pipelines (PRDs
+  # 127–132). Results post back to pops-api via the internal-token
+  # gated `food.ingest.workerComplete` mutation. Stateless with respect
+  # to SQLite — all DB writes happen server-side.
+  pops-worker-food:
+    image: ghcr.io/knoxio/pops-worker-food:${POPS_IMAGE_TAG:-main}
+    container_name: pops-worker-food
+    restart: unless-stopped
+    labels:
+      com.centurylinklabs.watchtower.enable: 'true'
+    networks:
+      - backend
+    volumes:
+      - food-ingest-data:/data/food/ingest
+      # Cookie file is operator-managed (see PRD-129's runbook). Comment
+      # out the mount when no cookies are provisioned — yt-dlp falls
+      # back to anonymous mode and Instagram reels will fail with
+      # auth-dead, which the inbox surfaces as a `partial` outcome.
+      - ../secrets/instagram-cookies.txt:/secrets/instagram-cookies.txt:ro
+    secrets:
+      - claude_api_key
+      - pops_api_internal_token
+    environment:
+      NODE_ENV: production
+      REDIS_URL: redis://pops-redis:6379
+      POPS_API_URL: http://pops-api:3000
+      # POPS_API_INTERNAL_TOKEN + ANTHROPIC_API_KEY come from
+      # /run/secrets/<lowercased-name> via pops-api's env.ts convention.
+      # Worker pool & rate limiting (PRD-125 contract).
+      FOOD_WORKER_CONCURRENCY: ${FOOD_WORKER_CONCURRENCY:-2}
+      FOOD_INGEST_TIMEOUT_SEC: ${FOOD_INGEST_TIMEOUT_SEC:-300}
+      FOOD_INGEST_RATE_PER_MIN: ${FOOD_INGEST_RATE_PER_MIN:-30}
+      FOOD_INGEST_DIR: /data/food/ingest
+      INSTAGRAM_COOKIES_PATH: /secrets/instagram-cookies.txt
+      # Per-handler model overrides (PRDs 128 / 130 / 131 / 132).
+      FOOD_WEB_LLM_MODEL: ${FOOD_WEB_LLM_MODEL:-claude-haiku-4-5-20251001}
+      FOOD_IG_VISION_MODEL: ${FOOD_IG_VISION_MODEL:-claude-haiku-4-5-20251001}
+      FOOD_SCREENSHOT_VISION_MODEL: ${FOOD_SCREENSHOT_VISION_MODEL:-claude-haiku-4-5-20251001}
+      FOOD_TEXT_LLM_MODEL: ${FOOD_TEXT_LLM_MODEL:-claude-haiku-4-5-20251001}
+      # Cost observability — PRD-133's logger warns when a job exceeds this.
+      FOOD_INGEST_COST_CAP_PER_JOB_USD: ${FOOD_INGEST_COST_CAP_PER_JOB_USD:-0.05}
+    expose:
+      - '9090'
+    depends_on:
+      pops-redis:
+        condition: service_healthy
+      pops-api:
+        condition: service_healthy
+    healthcheck:
+      test: ['CMD', 'curl', '-fsS', 'http://localhost:9090/healthz']
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
   # ── FRONTEND ─────────────────────────────────────────────────────
   pops-shell:
     image: ghcr.io/knoxio/pops-shell:${POPS_IMAGE_TAG:-main}
@@ -309,6 +365,8 @@ volumes:
     name: pops-paperless-consume
   paperless-redis:
     name: pops-paperless-redis
+  food-ingest-data:
+    name: pops-food-ingest-data
 
 secrets:
   notion_api_token:
@@ -325,6 +383,8 @@ secrets:
     file: ../secrets/finance_api_key
   pops_api_key:
     file: ../secrets/pops_api_key
+  pops_api_internal_token:
+    file: ../secrets/pops_api_internal_token
   tmdb_api_key:
     file: ../secrets/tmdb_api_key
   thetvdb_api_key:

--- a/infra/docker/pops-worker-food/Dockerfile
+++ b/infra/docker/pops-worker-food/Dockerfile
@@ -28,7 +28,7 @@
 # Pinned versions also keep model + handler outputs deterministic for
 # the `extractor_version` metadata field (PRD-125 contract).
 
-ARG YT_DLP_VERSION=2025.10.26
+ARG YT_DLP_VERSION=2025.10.22
 ARG FASTER_WHISPER_VERSION=1.2.0
 ARG WHISPER_MODEL=distil-large-v3
 

--- a/infra/docker/pops-worker-food/Dockerfile
+++ b/infra/docker/pops-worker-food/Dockerfile
@@ -36,7 +36,11 @@ ARG WHISPER_MODEL=distil-large-v3
 FROM python:3.12-slim AS model-baker
 ARG FASTER_WHISPER_VERSION
 ARG WHISPER_MODEL
-RUN pip install --no-cache-dir "faster-whisper==${FASTER_WHISPER_VERSION}"
+# `requests` is a transitive runtime dep of faster-whisper's
+# `download_model` path but is not declared in `pyproject.toml` for some
+# 1.x releases — install it explicitly so the bake step doesn't fail
+# with ModuleNotFoundError during the import that triggers the download.
+RUN pip install --no-cache-dir "faster-whisper==${FASTER_WHISPER_VERSION}" requests
 RUN python -c "from faster_whisper import WhisperModel; WhisperModel('${WHISPER_MODEL}', device='cpu', compute_type='int8')"
 
 # ─── stage 2 · prune ────────────────────────────────────────────────
@@ -87,7 +91,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN python3 -m venv /opt/venv \
  && /opt/venv/bin/pip install --no-cache-dir \
       "yt-dlp==${YT_DLP_VERSION}" \
-      "faster-whisper==${FASTER_WHISPER_VERSION}"
+      "faster-whisper==${FASTER_WHISPER_VERSION}" \
+      requests
 ENV PATH="/opt/venv/bin:${PATH}"
 
 # Bring in the prebaked HuggingFace cache so first-job latency doesn't

--- a/infra/docker/pops-worker-food/Dockerfile
+++ b/infra/docker/pops-worker-food/Dockerfile
@@ -1,0 +1,114 @@
+# syntax=docker/dockerfile:1.7
+#
+# PRD-126 — pops-worker-food container.
+#
+# Consumes the `food.ingest` BullMQ queue produced by PRD-125, runs the
+# per-kind ingest pipelines (PRDs 127–132), and posts results back to
+# pops-api via the internal-token-gated `food.ingest.workerComplete`
+# mutation. v1 ships dispatch + stub handlers; the per-kind handlers
+# are filled in by their owning PRDs.
+#
+# Build stages:
+#   1. model-baker  — pulls the faster-whisper `distil-large-v3` weights
+#                      into the HuggingFace cache so first-job latency
+#                      doesn't pay for the model download.
+#   2. node-builder — turbo-prune + pnpm build of `@pops/worker-food`
+#                      and its workspace deps; emits a self-contained
+#                      `/app/deploy` tree (production deps materialised
+#                      as real files via `pnpm deploy --legacy`).
+#   3. runtime      — node:22-bookworm-slim + ffmpeg + Python venv with
+#                      yt-dlp + faster-whisper, the prebaked HuggingFace
+#                      cache, and the deployed node app.
+#
+# Pinned tool versions live in `infra/docker/pops-worker-food/versions.json`
+# and are mirrored as build args here so a single change updates both.
+# Updates are PRs (not at-runtime downloads) — yt-dlp's auto-update is
+# disabled and the image must be rebuilt to ship a new version.
+#
+# Pinned versions also keep model + handler outputs deterministic for
+# the `extractor_version` metadata field (PRD-125 contract).
+
+ARG YT_DLP_VERSION=2025.10.26
+ARG FASTER_WHISPER_VERSION=1.2.0
+ARG WHISPER_MODEL=distil-large-v3
+
+# ─── stage 1 · model bake ───────────────────────────────────────────
+FROM python:3.12-slim AS model-baker
+ARG FASTER_WHISPER_VERSION
+ARG WHISPER_MODEL
+RUN pip install --no-cache-dir "faster-whisper==${FASTER_WHISPER_VERSION}"
+RUN python -c "from faster_whisper import WhisperModel; WhisperModel('${WHISPER_MODEL}', device='cpu', compute_type='int8')"
+
+# ─── stage 2 · prune ────────────────────────────────────────────────
+# `turbo prune` extracts the worker's subset of the monorepo so the
+# install layer caches on lockfile + package.json changes alone.
+FROM node:22-bookworm-slim AS pruner
+WORKDIR /app
+RUN corepack enable
+COPY . .
+RUN pnpm dlx turbo@2 prune @pops/worker-food --docker
+
+# ─── stage 3 · install + build ──────────────────────────────────────
+FROM node:22-bookworm-slim AS node-builder
+WORKDIR /app
+RUN corepack enable
+
+COPY --from=pruner /app/out/json/ ./
+COPY --from=pruner /app/out/pnpm-lock.yaml ./pnpm-lock.yaml
+RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
+    pnpm install --frozen-lockfile
+
+COPY --from=pruner /app/out/full/ ./
+# `extends: "../../tsconfig.base.json"` chains in every package, so the
+# pruned tree needs the root tsconfig copied alongside.
+COPY --from=pruner /app/tsconfig.base.json ./tsconfig.base.json
+
+RUN pnpm --filter "@pops/worker-food..." run build
+RUN pnpm --filter "@pops/worker-food" deploy --prod --legacy /app/deploy
+
+# ─── stage 4 · runtime ──────────────────────────────────────────────
+FROM node:22-bookworm-slim AS runtime
+ARG YT_DLP_VERSION
+ARG FASTER_WHISPER_VERSION
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      ffmpeg \
+      python3 \
+      python3-pip \
+      python3-venv \
+      ca-certificates \
+      curl \
+ && rm -rf /var/lib/apt/lists/*
+
+# Pinned yt-dlp + faster-whisper in an isolated venv so the runtime
+# Python stays untouched. Both pip extras are baked at build time —
+# yt-dlp's runtime auto-update path is intentionally disabled (the
+# worker only sees what the image ships).
+RUN python3 -m venv /opt/venv \
+ && /opt/venv/bin/pip install --no-cache-dir \
+      "yt-dlp==${YT_DLP_VERSION}" \
+      "faster-whisper==${FASTER_WHISPER_VERSION}"
+ENV PATH="/opt/venv/bin:${PATH}"
+
+# Bring in the prebaked HuggingFace cache so first-job latency doesn't
+# pay for the model download.
+COPY --from=model-baker /root/.cache /root/.cache
+
+WORKDIR /app
+RUN groupadd -r worker && useradd -r -g worker -d /app -s /sbin/nologin worker
+
+# `pnpm deploy --legacy` materialises every workspace dep as real files
+# under /app/deploy; copy it as the final layer so a code-only change
+# doesn't bust the Python/ffmpeg layers.
+COPY --from=node-builder --chown=worker:worker /app/deploy/ ./
+
+ARG BUILD_VERSION=dev
+ENV BUILD_VERSION=$BUILD_VERSION
+ENV NODE_ENV=production
+ENV FOOD_INGEST_DIR=/data/food/ingest
+
+VOLUME ["/data/food/ingest"]
+EXPOSE 9090
+USER worker
+
+CMD ["node", "dist/worker.js"]

--- a/infra/docker/pops-worker-food/versions.json
+++ b/infra/docker/pops-worker-food/versions.json
@@ -1,0 +1,9 @@
+{
+  "$comment": "Pinned tool versions baked into ghcr.io/knoxio/pops-worker-food. Updates are PRs that re-bake the image; the Dockerfile reads these via build args (BUILD_VERSION + the values below) so a single source of truth survives the image cache.",
+  "ytDlp": "2025.10.26",
+  "fasterWhisper": "1.2.0",
+  "whisperModel": "distil-large-v3",
+  "ffmpegPackage": "ffmpeg",
+  "nodeBase": "node:22-bookworm-slim",
+  "pythonBase": "python:3.12-slim"
+}

--- a/infra/docker/pops-worker-food/versions.json
+++ b/infra/docker/pops-worker-food/versions.json
@@ -1,6 +1,6 @@
 {
   "$comment": "Pinned tool versions baked into ghcr.io/knoxio/pops-worker-food. Updates are PRs that re-bake the image; the Dockerfile reads these via build args (BUILD_VERSION + the values below) so a single source of truth survives the image cache.",
-  "ytDlp": "2025.10.26",
+  "ytDlp": "2025.10.22",
   "fasterWhisper": "1.2.0",
   "whisperModel": "distil-large-v3",
   "ffmpegPackage": "ffmpeg",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -411,6 +411,40 @@ importers:
         specifier: ^8.0.16
         version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0)
 
+  apps/pops-worker-food:
+    dependencies:
+      '@pops/food-contracts':
+        specifier: workspace:*
+        version: link:../../packages/food-contracts
+      '@trpc/client':
+        specifier: 11.17.0
+        version: 11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3)
+      bullmq:
+        specifier: ^5.78.0
+        version: 5.78.0
+      ioredis:
+        specifier: 5.11.0
+        version: 5.11.0
+      pino:
+        specifier: ^10.3.1
+        version: 10.3.1
+    devDependencies:
+      '@pops/api':
+        specifier: workspace:*
+        version: link:../pops-api
+      '@types/node':
+        specifier: ^25.9.1
+        version: 25.9.1
+      tsx:
+        specifier: ^4.22.4
+        version: 4.22.4
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@25.9.1)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
+
   packages/api-client:
     dependencies:
       '@pops/api':


### PR DESCRIPTION
## Summary

- New `apps/pops-worker-food` workspace package: long-running daemon that consumes PRD-125's `food.ingest` BullMQ queue, dispatches each job to the per-kind handler via `runIngestJob`, posts results back to pops-api's `food.ingest.workerComplete` via tRPC over HTTP with the `x-pops-internal-token` header.
- Multi-stage Dockerfile at `infra/docker/pops-worker-food/Dockerfile` (model-baker → turbo prune → runtime) with ffmpeg + Python venv (pinned yt-dlp + faster-whisper) + the prebaked `distil-large-v3` HuggingFace cache. Pinned versions mirrored in `versions.json`.
- New `pops-worker-food` service in `infra/docker-compose.yml` with food-ingest data volume, instagram-cookies secret mount, internal-token secret, Watchtower auto-rollout, healthcheck against `/healthz`.
- GitHub Actions workflow `worker-food-image.yml` validates the image build on PRs (no push) and publishes `ghcr.io/knoxio/pops-worker-food:main` + sha tag on main.
- v1 ships **NotImplemented stubs** for the per-kind handlers — PRDs 127–132 each replace one handler with the real pipeline. The dispatch shell + cancellation contract + worker-complete round-trip are wired so each handler PR can land in isolation.

## Notable design notes

- **Cancellation polls `job.getState() === 'unknown'`** between stages. BullMQ has no `isToBeRemoved()` method (the PRD spec text sketches one). Once `food.ingest.cancel` calls `job.remove()`, the in-flight processor sees the state flip to `'unknown'` on the next check and returns early with `errorCode='Cancelled'` from the handler.
- **Internal auth header is `x-pops-internal-token`** — PRD-125's actual contract (`apps/pops-api/src/trpc.ts`'s `isInternalCall`). The PRD-126 spec text said `X-Internal-Token`; deferred to the producer's name.
- **Secrets follow pops-api's `env.ts` convention**: `readSecret('POPS_API_INTERNAL_TOKEN')` checks `/run/secrets/pops_api_internal_token` first, falls back to `process.env`. Compose mounts the secret so the runtime never sees the value via env.

## Tests

- 16 Vitest cases across `dispatch.test.ts` (each kind dispatches to its handler; cancellation threads through; default stubs all return `NotImplemented` with the pinned extractor version), `health.test.ts` (documented `/healthz` JSON; reflects live counters; 404 elsewhere), and `config.test.ts` (env override matrix; secret-file convention; fail-fast on missing token; rejects bad concurrency / rate input).
- Integration test (testcontainers worker + redis + mock api) deferred — testcontainers harness is not yet wired into the monorepo. Captured in the PRD's checklist with a deferred note.

## Test plan

- [x] `pnpm --filter @pops/worker-food typecheck`
- [x] `pnpm --filter @pops/worker-food test` (16/16)
- [x] `pnpm --filter @pops/worker-food build`
- [x] `pnpm lint` / `pnpm format:check` (no new errors)
- [x] `pnpm typecheck` workspace-wide (28/28 cached)
- [x] `pnpm build` workspace-wide (10/10)
- [ ] CI image build via the new `worker-food-image.yml` workflow
- [ ] End-to-end smoke once a per-kind handler PR lands (text ingest is the lightest seam)