### PR TITLE
feat(core-db): split migration journal — 0054_service_accounts (pillar core phase 1 PR 2)

### DIFF
--- a/.github/workflows/core-quality.yml
+++ b/.github/workflows/core-quality.yml
@@ -6,7 +6,6 @@ on:
     paths:
       - "packages/core-db/**"
       - "packages/db-types/**"
-      - "apps/pops-api/src/db/drizzle-migrations/0054_service_accounts.sql"
       - ".github/workflows/core-quality.yml"
       - ".github/workflows/_pkg-check.yml"
   pull_request:
@@ -27,7 +26,6 @@ jobs:
             relevant:
               - 'packages/core-db/**'
               - 'packages/db-types/**'
-              - 'apps/pops-api/src/db/drizzle-migrations/0054_service_accounts.sql'
               - '.github/workflows/core-quality.yml'
               - '.github/workflows/_pkg-check.yml'
 

--- a/.github/workflows/core-quality.yml
+++ b/.github/workflows/core-quality.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "packages/core-db/**"
       - "packages/db-types/**"
+      - "apps/pops-api/src/db/drizzle-migrations/0054_service_accounts.sql"
       - ".github/workflows/core-quality.yml"
       - ".github/workflows/_pkg-check.yml"
   pull_request:
@@ -26,8 +27,33 @@ jobs:
             relevant:
               - 'packages/core-db/**'
               - 'packages/db-types/**'
+              - 'apps/pops-api/src/db/drizzle-migrations/0054_service_accounts.sql'
               - '.github/workflows/core-quality.yml'
               - '.github/workflows/_pkg-check.yml'
+
+  migration-drift-guard:
+    name: Migration drift (shared vs core-db)
+    needs: [changes]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Skip — no relevant changes"
+        if: github.event_name == 'pull_request' && needs.changes.outputs.relevant != 'true'
+        run: echo "Skipping — no relevant changes"
+      - uses: actions/checkout@v6
+        if: github.event_name != 'pull_request' || needs.changes.outputs.relevant == 'true'
+      - name: Diff core-db copy against shared journal copy
+        if: github.event_name != 'pull_request' || needs.changes.outputs.relevant == 'true'
+        run: |
+          set -euo pipefail
+          shared='apps/pops-api/src/db/drizzle-migrations/0054_service_accounts.sql'
+          pillar='packages/core-db/migrations/0054_service_accounts.sql'
+          if ! diff -q "$shared" "$pillar"; then
+            echo "::error::Migration drift detected: $shared and $pillar must be byte-identical during the transitional release cycle (core pillar phase 1)."
+            diff "$shared" "$pillar" || true
+            exit 1
+          fi
+          echo "OK — both 0054_service_accounts.sql copies are byte-identical."
 
   quality:
     needs: [changes]

--- a/apps/pops-api/src/db/per-pillar-migrations.test.ts
+++ b/apps/pops-api/src/db/per-pillar-migrations.test.ts
@@ -200,14 +200,21 @@ describe('runPerPillarMigrations', () => {
   });
 
   it('falls back to the real repo root when no override is supplied', async () => {
-    // Smoke check: importing the runner under the real layout shouldn't
-    // crash on the (currently absent) `packages/<id>-db/migrations/` dirs.
-    // Every pillar should land in `pillarsSkipped`.
+    // Smoke check: importing the runner under the real layout exercises
+    // the workspace fallback path against an actual on-disk pillar dir.
+    // `core` now owns its journal at `packages/core-db/migrations/` (core
+    // pillar Phase 1 PR 2) so the runner discovers + applies the
+    // 0054_service_accounts entry. Pillars without their own journal yet
+    // still skip cleanly.
     await withDb((db) => {
-      const realPillars: PillarDescriptor[] = [{ id: 'core', dbPackageDir: 'packages/core-db' }];
+      const realPillars: PillarDescriptor[] = [
+        { id: 'core', dbPackageDir: 'packages/core-db' },
+        { id: 'unmigrated', dbPackageDir: 'packages/this-dir-does-not-exist-db' },
+      ];
       const result = runPerPillarMigrations(db, realPillars);
-      expect(result.applied).toEqual([]);
-      expect(result.pillarsSkipped).toEqual(['core']);
+      expect(result.applied).toEqual(['0054_service_accounts']);
+      expect(result.pillarsApplied).toEqual(['core']);
+      expect(result.pillarsSkipped).toEqual(['unmigrated']);
     });
   });
 });

--- a/packages/core-db/migrations/0054_service_accounts.sql
+++ b/packages/core-db/migrations/0054_service_accounts.sql
@@ -1,0 +1,16 @@
+CREATE TABLE `service_accounts` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`key_prefix` text NOT NULL,
+	`key_hash` text NOT NULL,
+	`scopes` text DEFAULT '[]' NOT NULL,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL,
+	`last_used_at` text,
+	`revoked_at` text,
+	`created_by` text
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `service_accounts_name_unique` ON `service_accounts` (`name`);--> statement-breakpoint
+CREATE UNIQUE INDEX `service_accounts_key_prefix_unique` ON `service_accounts` (`key_prefix`);--> statement-breakpoint
+CREATE INDEX `idx_service_accounts_key_prefix` ON `service_accounts` (`key_prefix`);--> statement-breakpoint
+CREATE INDEX `idx_service_accounts_revoked_at` ON `service_accounts` (`revoked_at`);

--- a/packages/core-db/migrations/meta/_journal.json
+++ b/packages/core-db/migrations/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "6",
+      "when": 1778431569630,
+      "tag": "0054_service_accounts",
+      "breakpoints": true
+    }
+  ]
+}

--- a/packages/core-db/src/__tests__/service-accounts.test.ts
+++ b/packages/core-db/src/__tests__/service-accounts.test.ts
@@ -32,10 +32,7 @@ import {
 
 import type { CoreDb } from '../services/internal.js';
 
-const MIGRATION_PATH = join(
-  __dirname,
-  '../../../../apps/pops-api/src/db/drizzle-migrations/0054_service_accounts.sql'
-);
+const MIGRATION_PATH = join(__dirname, '../../migrations/0054_service_accounts.sql');
 
 function freshDb(): CoreDb {
   const raw = new Database(':memory:');


### PR DESCRIPTION
## Summary

Second PR of the **core pillar migration** (pillar-migration-roadmap.md Track D · Phase 1 PR 2 of 4).

Moves the core pillar's first migration into its own drizzle journal at \`packages/core-db/migrations/\`. The shared journal entry stays intact for one release cycle per the CI-never-breaks pattern (\"old shared-journal entries become documented no-ops for one release cycle, then deleted in step 4\").

## How both runners stay sane

Both the shared (\`runPerModuleMigrationsByOwner\`) and per-pillar (\`runPerPillarMigrations\`) runners now see a journal entry with tag \`0054_service_accounts\` and byte-identical SQL.

- **Existing production DBs:** \`__drizzle_migrations\` already has the hash. Both runners hit \`alreadyApplied\` on the existing-hash branch.
- **Fresh installs:** Shared runner runs first (P1's runtime contract). It applies 0054 and records the hash + tag. Per-pillar runner walks the pillar journal, sees the recorded tag with matching hash, returns \`alreadyApplied\`.
- **No drift:** Files are byte-for-byte identical, so the hash-drift warning in \`classifyOrApply\` never fires.

## What's in this PR

- \`packages/core-db/migrations/0054_service_accounts.sql\` — byte-identical copy of \`apps/pops-api/src/db/drizzle-migrations/0054_service_accounts.sql\`
- \`packages/core-db/migrations/meta/_journal.json\` — single entry (\`when\` carried over from the shared journal)
- \`packages/core-db/src/__tests__/service-accounts.test.ts\` reads the migration from the package's own \`migrations/\` dir instead of reaching into pops-api
- \`apps/pops-api/src/db/per-pillar-migrations.test.ts\` smoke test updated: the real-repo-root run now applies one core entry (previously asserted every pillar was skipped)
- \`.github/workflows/core-quality.yml\` path filter trimmed — the workflow no longer needs to watch the shared migration file

## Not touched in this PR (next 2 PRs)

- \`apps/pops-api/src/db/migration-ownership.ts\` — \`0054_service_accounts → core\` entry stays for the release cycle
- \`apps/pops-api/src/modules/core/migrations.ts\` — \`coreMigrationTags\` entry stays
- \`apps/pops-api/src/db/drizzle-migrations/0054_service_accounts.sql\` — original file stays
- \`apps/pops-api/src/db/drizzle-migrations/meta/_journal.json\` — shared journal entry stays

PR 3 (cutover) flips pops-api callers from the in-tree service-accounts service to \`@pops/core-db\`. PR 4 (deletion) removes everything above.

## Verification

- \`pnpm test\` — workspace-wide tests green (2616 cases)
- \`pnpm typecheck\` — 30/30 packages green
- \`pnpm lint\` — clean
- \`pnpm format:check\` — clean

## Test plan

- [ ] CI green on \`core-quality\` (uses new in-package migration path)
- [ ] CI green on \`api-quality\` (per-pillar runner smoke test updated)
- [ ] Copilot review pass