### PR TITLE
feat(food): PRD-129 — Instagram acquisition (yt-dlp + cookies)

### DIFF
--- a/apps/pops-worker-food/src/__tests__/config.test.ts
+++ b/apps/pops-worker-food/src/__tests__/config.test.ts
@@ -12,6 +12,8 @@ const KEYS = [
   'FOOD_WORKER_HEALTH_PORT',
   'FOOD_WORKER_DRAIN_TIMEOUT_MS',
   'POPS_WORKER_FOOD_VERSION',
+  'FOOD_INGEST_DIR',
+  'INSTAGRAM_COOKIES_PATH',
 ] as const;
 
 const snapshot: Partial<Record<(typeof KEYS)[number], string | undefined>> = {};
@@ -48,6 +50,8 @@ describe('loadConfig', () => {
       healthPort: 9090,
       drainTimeoutMs: 60_000,
       extractorVersion: 'pops-worker-food@0.1.0',
+      ingestDir: '/data/food/ingest',
+      instagramCookiesPath: '/secrets/instagram-cookies.txt',
     });
   });
 
@@ -61,6 +65,8 @@ describe('loadConfig', () => {
     process.env['FOOD_WORKER_HEALTH_PORT'] = '9999';
     process.env['FOOD_WORKER_DRAIN_TIMEOUT_MS'] = '30000';
     process.env['POPS_WORKER_FOOD_VERSION'] = 'pops-worker-food@1.2.3';
+    process.env['FOOD_INGEST_DIR'] = '/tmp/ingest';
+    process.env['INSTAGRAM_COOKIES_PATH'] = '/tmp/cookies.txt';
     const cfg = loadConfig();
     expect(cfg).toEqual({
       redisUrl: 'redis://redis:6379',
@@ -72,6 +78,8 @@ describe('loadConfig', () => {
       healthPort: 9999,
       drainTimeoutMs: 30_000,
       extractorVersion: 'pops-worker-food@1.2.3',
+      ingestDir: '/tmp/ingest',
+      instagramCookiesPath: '/tmp/cookies.txt',
     });
   });
 

--- a/apps/pops-worker-food/src/config.ts
+++ b/apps/pops-worker-food/src/config.ts
@@ -33,6 +33,10 @@ export interface WorkerConfig {
   drainTimeoutMs: number;
   /** Pinned semicolon-delimited tool versions for `IngestMeta.extractor_version`. */
   extractorVersion: string;
+  /** Per-source workdir root for downloaded media (PRD-110 / PRD-129 / PRD-130). */
+  ingestDir: string;
+  /** Netscape cookies.txt mounted from the host (PRD-129 operator runbook). */
+  instagramCookiesPath: string;
 }
 
 const DEFAULT_CONCURRENCY = 2;
@@ -70,5 +74,7 @@ export function loadConfig(): WorkerConfig {
     healthPort: readIntEnv('FOOD_WORKER_HEALTH_PORT', DEFAULT_HEALTH_PORT),
     drainTimeoutMs: readIntEnv('FOOD_WORKER_DRAIN_TIMEOUT_MS', DEFAULT_DRAIN_TIMEOUT_MS),
     extractorVersion: process.env['POPS_WORKER_FOOD_VERSION'] ?? 'pops-worker-food@0.1.0',
+    ingestDir: process.env['FOOD_INGEST_DIR'] ?? '/data/food/ingest',
+    instagramCookiesPath: process.env['INSTAGRAM_COOKIES_PATH'] ?? '/secrets/instagram-cookies.txt',
   };
 }

--- a/apps/pops-worker-food/src/handlers/__tests__/instagram-acquisition.test.ts
+++ b/apps/pops-worker-food/src/handlers/__tests__/instagram-acquisition.test.ts
@@ -1,0 +1,491 @@
+import { EventEmitter } from 'node:events';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  isAuthDead,
+  isRateLimited,
+  readCaption,
+  runInstagramAcquisition,
+  runYtDlp,
+} from '../instagram-acquisition.js';
+
+import type { ChildProcess } from 'node:child_process';
+
+import type { RunInstagramAcquisitionOptions, YtDlpResult } from '../instagram-acquisition.js';
+import type { HandlerContext } from '../types.js';
+
+const NEVER_CANCELLED: HandlerContext = { isCancelled: () => false };
+const ALWAYS_CANCELLED: HandlerContext = { isCancelled: () => true };
+
+const IG_JOB = {
+  kind: 'url-instagram',
+  sourceId: 42,
+  url: 'https://www.instagram.com/reel/abc123/',
+} as const;
+
+const VIDEO_RESULT: YtDlpResult = { exitCode: 0, stdout: '', stderr: '', timedOut: false };
+
+interface MakeAcquisitionOpts {
+  workDir: string;
+  artefacts?: Array<{ name: string; content?: string }>;
+  ytDlpResult?: YtDlpResult;
+  readCaptionResult?: string | null;
+  ctx?: HandlerContext;
+  rmFn?: RunInstagramAcquisitionOptions['rmFn'];
+}
+
+function makeOpts(opts: MakeAcquisitionOpts): RunInstagramAcquisitionOptions {
+  return {
+    ingestDir: opts.workDir,
+    cookiesPath: '/tmp/cookies.txt',
+    mkdirFn: async () => undefined,
+    rmFn: opts.rmFn ?? (async () => undefined),
+    readCaptionFn: async () => opts.readCaptionResult ?? null,
+    runYtDlpFn: async () => {
+      if (opts.artefacts != null) {
+        for (const { name, content = '' } of opts.artefacts) {
+          await writeFile(join(opts.workDir, String(IG_JOB.sourceId), name), content);
+        }
+      }
+      return opts.ytDlpResult ?? VIDEO_RESULT;
+    },
+  };
+}
+
+let scratch = '';
+beforeEach(async () => {
+  scratch = await mkdtemp(join(tmpdir(), 'pops-ig-test-'));
+  await import('node:fs/promises').then(({ mkdir }) =>
+    mkdir(join(scratch, String(IG_JOB.sourceId)), { recursive: true })
+  );
+});
+
+afterEach(async () => {
+  await rm(scratch, { recursive: true, force: true });
+});
+
+describe('isAuthDead', () => {
+  it.each([
+    ['login required to view this post', true],
+    ['Please log in or sign up to continue', true],
+    ['Restricted Video: please log in', true],
+    ['Login cookies appear to be invalid', true],
+    ['authentication is required to access this resource', true],
+    ['This account is private and you are not following it', true],
+    ['network is unreachable', false],
+    ['HTTP Error 429: Too Many Requests', false],
+    ['', false],
+  ])('matches %p → %p', (stderr, expected) => {
+    expect(isAuthDead(stderr)).toBe(expected);
+  });
+});
+
+describe('isRateLimited', () => {
+  it('returns matched=false on unrelated stderr', () => {
+    expect(isRateLimited('network blip')).toEqual({ matched: false, retryAfter: 0 });
+  });
+
+  it('matches HTTP 429 with default fallback delay', () => {
+    expect(isRateLimited('ERROR: HTTP Error 429')).toEqual({ matched: true, retryAfter: 300 });
+  });
+
+  it('matches "Too Many Requests" with default fallback delay', () => {
+    expect(isRateLimited('Too Many Requests from this IP')).toEqual({
+      matched: true,
+      retryAfter: 300,
+    });
+  });
+
+  it('parses Retry-After in seconds when present', () => {
+    expect(isRateLimited('HTTP Error 429\nRetry-After: 90\n')).toEqual({
+      matched: true,
+      retryAfter: 90,
+    });
+  });
+
+  it('falls back to 300 on a non-numeric Retry-After', () => {
+    expect(isRateLimited('Too Many Requests\nRetry-After: tomorrow')).toEqual({
+      matched: true,
+      retryAfter: 300,
+    });
+  });
+
+  it('falls back to 300 on a zero Retry-After', () => {
+    expect(isRateLimited('Too Many Requests\nRetry-After: 0\n')).toEqual({
+      matched: true,
+      retryAfter: 300,
+    });
+  });
+});
+
+describe('readCaption', () => {
+  it('returns the description field when present', async () => {
+    const path = join(scratch, 'info.json');
+    await writeFile(path, JSON.stringify({ description: 'Smash burger 🍔' }));
+    await expect(readCaption(path)).resolves.toBe('Smash burger 🍔');
+  });
+
+  it('returns null when the description is empty', async () => {
+    const path = join(scratch, 'info.json');
+    await writeFile(path, JSON.stringify({ description: '   ' }));
+    await expect(readCaption(path)).resolves.toBeNull();
+  });
+
+  it('returns null when the description field is missing', async () => {
+    const path = join(scratch, 'info.json');
+    await writeFile(path, JSON.stringify({ other: 'field' }));
+    await expect(readCaption(path)).resolves.toBeNull();
+  });
+
+  it('returns null on invalid JSON', async () => {
+    const path = join(scratch, 'info.json');
+    await writeFile(path, 'not json');
+    await expect(readCaption(path)).resolves.toBeNull();
+  });
+
+  it('returns null when the file does not exist', async () => {
+    await expect(readCaption(join(scratch, 'missing.json'))).resolves.toBeNull();
+  });
+});
+
+describe('runInstagramAcquisition', () => {
+  it('returns ok=true with full artefact paths on a successful download', async () => {
+    const workDir = join(scratch, String(IG_JOB.sourceId));
+    const opts = makeOpts({
+      workDir: scratch,
+      artefacts: [
+        { name: 'abc123.mp4', content: 'video' },
+        {
+          name: 'abc123.info.json',
+          content: JSON.stringify({ description: 'caption text' }),
+        },
+        { name: 'abc123.jpg', content: 'jpg' },
+      ],
+      readCaptionResult: 'caption text',
+    });
+
+    const result = await runInstagramAcquisition(IG_JOB, NEVER_CANCELLED, opts);
+
+    expect(result).toEqual({
+      ok: true,
+      workDir,
+      videoPath: join(workDir, 'abc123.mp4'),
+      infoJsonPath: join(workDir, 'abc123.info.json'),
+      thumbnailPath: join(workDir, 'abc123.jpg'),
+      caption: 'caption text',
+    });
+  });
+
+  it('returns ok=true with thumbnailPath=null when thumbnail missing', async () => {
+    const workDir = join(scratch, String(IG_JOB.sourceId));
+    const opts = makeOpts({
+      workDir: scratch,
+      artefacts: [
+        { name: 'abc.mp4' },
+        { name: 'abc.info.json', content: JSON.stringify({ description: 'cap' }) },
+      ],
+      readCaptionResult: 'cap',
+    });
+
+    const result = await runInstagramAcquisition(IG_JOB, NEVER_CANCELLED, opts);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.thumbnailPath).toBeNull();
+    expect(result.videoPath).toBe(join(workDir, 'abc.mp4'));
+  });
+
+  it('classifies auth-dead errors before other heuristics', async () => {
+    const opts = makeOpts({
+      workDir: scratch,
+      ytDlpResult: {
+        exitCode: 1,
+        stdout: '',
+        stderr: 'ERROR: Login cookies are invalid',
+        timedOut: false,
+      },
+    });
+
+    const result = await runInstagramAcquisition(IG_JOB, NEVER_CANCELLED, opts);
+
+    expect(result).toEqual({
+      ok: false,
+      kind: 'auth-dead',
+      stderr: 'ERROR: Login cookies are invalid',
+    });
+  });
+
+  it('classifies rate-limited errors with the parsed Retry-After', async () => {
+    const opts = makeOpts({
+      workDir: scratch,
+      ytDlpResult: {
+        exitCode: 1,
+        stdout: '',
+        stderr: 'ERROR: HTTP Error 429\nRetry-After: 120\n',
+        timedOut: false,
+      },
+    });
+
+    const result = await runInstagramAcquisition(IG_JOB, NEVER_CANCELLED, opts);
+
+    expect(result).toEqual({ ok: false, kind: 'rate-limited', retryAfter: 120 });
+  });
+
+  it('returns generic-failure for non-zero exits that do not match known patterns', async () => {
+    const opts = makeOpts({
+      workDir: scratch,
+      ytDlpResult: {
+        exitCode: 2,
+        stdout: '',
+        stderr: 'unknown error from yt-dlp',
+        timedOut: false,
+      },
+    });
+
+    const result = await runInstagramAcquisition(IG_JOB, NEVER_CANCELLED, opts);
+
+    expect(result).toEqual({
+      ok: false,
+      kind: 'generic-failure',
+      exitCode: 2,
+      stderr: 'unknown error from yt-dlp',
+    });
+  });
+
+  it('returns missing-artifacts when yt-dlp exits 0 but no .mp4 was written', async () => {
+    const opts = makeOpts({
+      workDir: scratch,
+      artefacts: [{ name: 'abc.info.json', content: '{}' }],
+    });
+
+    const result = await runInstagramAcquisition(IG_JOB, NEVER_CANCELLED, opts);
+
+    expect(result).toEqual({ ok: false, kind: 'missing-artifacts' });
+  });
+
+  it('returns missing-artifacts when info.json is absent', async () => {
+    const opts = makeOpts({
+      workDir: scratch,
+      artefacts: [{ name: 'abc.mp4' }],
+    });
+
+    const result = await runInstagramAcquisition(IG_JOB, NEVER_CANCELLED, opts);
+
+    expect(result).toEqual({ ok: false, kind: 'missing-artifacts' });
+  });
+
+  it('honours cancellation before invoking yt-dlp', async () => {
+    const ytDlp = vi.fn(async () => VIDEO_RESULT);
+    const result = await runInstagramAcquisition(IG_JOB, ALWAYS_CANCELLED, {
+      ingestDir: scratch,
+      cookiesPath: '/tmp/cookies.txt',
+      mkdirFn: async () => undefined,
+      runYtDlpFn: ytDlp,
+    });
+
+    expect(result).toEqual({ ok: false, kind: 'cancelled' });
+    expect(ytDlp).not.toHaveBeenCalled();
+  });
+
+  it('honours cancellation after yt-dlp returns and cleans up the workdir', async () => {
+    const rmFn = vi.fn(async () => undefined);
+    let firstCall = true;
+    const ctx: HandlerContext = {
+      isCancelled: () => {
+        if (firstCall) {
+          firstCall = false;
+          return false;
+        }
+        return true;
+      },
+    };
+
+    const result = await runInstagramAcquisition(IG_JOB, ctx, {
+      ingestDir: scratch,
+      cookiesPath: '/tmp/cookies.txt',
+      mkdirFn: async () => undefined,
+      rmFn,
+      runYtDlpFn: async () => VIDEO_RESULT,
+    });
+
+    expect(result).toEqual({ ok: false, kind: 'cancelled' });
+    expect(rmFn).toHaveBeenCalledWith(join(scratch, String(IG_JOB.sourceId)));
+  });
+
+  it('reads INSTAGRAM_COOKIES_PATH and FOOD_INGEST_DIR from env when not overridden', async () => {
+    const captured: { url?: string; cookiesPath?: string; output?: string } = {};
+    const prevDir = process.env['FOOD_INGEST_DIR'];
+    const prevCookies = process.env['INSTAGRAM_COOKIES_PATH'];
+    process.env['FOOD_INGEST_DIR'] = scratch;
+    process.env['INSTAGRAM_COOKIES_PATH'] = '/secrets/from-env.txt';
+    try {
+      const result = await runInstagramAcquisition(IG_JOB, NEVER_CANCELLED, {
+        mkdirFn: async () => undefined,
+        readCaptionFn: async () => null,
+        runYtDlpFn: async (args) => {
+          captured.url = args.url;
+          captured.cookiesPath = args.cookiesPath;
+          captured.output = args.output;
+          return VIDEO_RESULT;
+        },
+      });
+
+      expect(captured.cookiesPath).toBe('/secrets/from-env.txt');
+      expect(captured.url).toBe(IG_JOB.url);
+      expect(captured.output).toBe(join(scratch, String(IG_JOB.sourceId)));
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.kind).toBe('missing-artifacts');
+    } finally {
+      if (prevDir == null) delete process.env['FOOD_INGEST_DIR'];
+      else process.env['FOOD_INGEST_DIR'] = prevDir;
+      if (prevCookies == null) delete process.env['INSTAGRAM_COOKIES_PATH'];
+      else process.env['INSTAGRAM_COOKIES_PATH'] = prevCookies;
+    }
+  });
+});
+
+function makeFakeChild(opts: {
+  exit?: { code: number | null; signal: NodeJS.Signals | null } | { error: Error };
+  stdout?: string;
+  stderr?: string;
+  killAfterMs?: number;
+}): ChildProcess {
+  const child = new EventEmitter() as ChildProcess;
+  const stdout = new EventEmitter() as ChildProcess['stdout'];
+  const stderr = new EventEmitter() as ChildProcess['stderr'];
+  Object.defineProperty(child, 'stdout', { value: stdout });
+  Object.defineProperty(child, 'stderr', { value: stderr });
+
+  child.kill = vi.fn((sig?: NodeJS.Signals | number): boolean => {
+    setImmediate(() => child.emit('close', null, sig ?? 'SIGTERM'));
+    return true;
+  });
+
+  setImmediate(() => {
+    if (opts.stdout != null && opts.stdout !== '') stdout?.emit('data', Buffer.from(opts.stdout));
+    if (opts.stderr != null && opts.stderr !== '') stderr?.emit('data', Buffer.from(opts.stderr));
+    const exit = opts.exit;
+    if (exit != null && 'error' in exit) {
+      child.emit('error', exit.error);
+      return;
+    }
+    if (exit != null) {
+      setImmediate(() => child.emit('close', exit.code, exit.signal));
+    }
+  });
+
+  return child;
+}
+
+describe('runYtDlp', () => {
+  it('resolves with stdout/stderr/exitCode on a normal exit', async () => {
+    const spawnFn = vi.fn(() =>
+      makeFakeChild({
+        exit: { code: 0, signal: null },
+        stdout: 'video downloaded\n',
+        stderr: 'warning: foo\n',
+      })
+    );
+
+    const result = await runYtDlp({
+      url: 'https://instagram.com/reel/x/',
+      cookiesPath: '/tmp/cookies.txt',
+      output: '/tmp/wd',
+      spawnFn: spawnFn as never,
+    });
+
+    expect(result).toEqual({
+      exitCode: 0,
+      stdout: 'video downloaded\n',
+      stderr: 'warning: foo\n',
+      timedOut: false,
+    });
+    expect(spawnFn).toHaveBeenCalledTimes(1);
+    const [cmd, args] = spawnFn.mock.calls[0] ?? [];
+    expect(cmd).toBe('yt-dlp');
+    expect(args).toContain('--cookies');
+    expect(args).toContain('/tmp/cookies.txt');
+    expect(args).toContain('--no-playlist');
+    expect(args).toContain('--write-info-json');
+    expect(args).toContain('--write-thumbnail');
+    expect(args).toContain('https://instagram.com/reel/x/');
+  });
+
+  it('captures stderr from an auth-dead-shaped failure', async () => {
+    const spawnFn = vi.fn(() =>
+      makeFakeChild({
+        exit: { code: 1, signal: null },
+        stderr: 'ERROR: Login cookies are invalid\n',
+      })
+    );
+
+    const result = await runYtDlp({
+      url: 'https://instagram.com/reel/x/',
+      cookiesPath: '/tmp/cookies.txt',
+      output: '/tmp/wd',
+      spawnFn: spawnFn as never,
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(isAuthDead(result.stderr)).toBe(true);
+  });
+
+  it('rejects when the child emits an error event', async () => {
+    const spawnFn = vi.fn(() => makeFakeChild({ exit: { error: new Error('ENOENT yt-dlp') } }));
+
+    await expect(
+      runYtDlp({
+        url: 'https://instagram.com/reel/x/',
+        cookiesPath: '/tmp/cookies.txt',
+        output: '/tmp/wd',
+        spawnFn: spawnFn as never,
+      })
+    ).rejects.toThrow(/ENOENT yt-dlp/);
+  });
+
+  it('kills the child on abort signal', async () => {
+    const controller = new AbortController();
+    const child = makeFakeChild({}); // never exits on its own
+    const spawnFn = vi.fn(() => child);
+
+    const promise = runYtDlp({
+      url: 'https://instagram.com/reel/x/',
+      cookiesPath: '/tmp/cookies.txt',
+      output: '/tmp/wd',
+      spawnFn: spawnFn as never,
+      signal: controller.signal,
+    });
+
+    setImmediate(() => controller.abort());
+    const result = await promise;
+
+    expect(child.kill).toHaveBeenCalled();
+    expect(result.exitCode).toBe(-1);
+  });
+
+  it('marks timedOut=true and kills the child when the timeout fires', async () => {
+    vi.useFakeTimers();
+    const child = makeFakeChild({}); // never exits on its own
+    const spawnFn = vi.fn(() => child);
+
+    const promise = runYtDlp({
+      url: 'https://instagram.com/reel/x/',
+      cookiesPath: '/tmp/cookies.txt',
+      output: '/tmp/wd',
+      spawnFn: spawnFn as never,
+      timeoutMs: 100,
+    });
+
+    await vi.advanceTimersByTimeAsync(150);
+    vi.useRealTimers();
+    const result = await promise;
+
+    expect(result.timedOut).toBe(true);
+    expect(child.kill).toHaveBeenCalled();
+  });
+});

--- a/apps/pops-worker-food/src/handlers/__tests__/instagram-acquisition.test.ts
+++ b/apps/pops-worker-food/src/handlers/__tests__/instagram-acquisition.test.ts
@@ -316,6 +316,55 @@ describe('runInstagramAcquisition', () => {
     expect(rmFn).toHaveBeenCalledWith(join(scratch, String(IG_JOB.sourceId)));
   });
 
+  it('mid-spawn cancellation aborts yt-dlp via the signal and cleans the workdir', async () => {
+    const rmFn = vi.fn(async () => undefined);
+    let ytDlpAborted = false;
+    let cancelled = false;
+    const ctx: HandlerContext = { isCancelled: () => cancelled };
+
+    const result = await runInstagramAcquisition(IG_JOB, ctx, {
+      ingestDir: scratch,
+      cookiesPath: '/tmp/cookies.txt',
+      mkdirFn: async () => undefined,
+      rmFn,
+      cancellationPollIntervalMs: 10,
+      runYtDlpFn: async (args) =>
+        new Promise((resolve) => {
+          setTimeout(() => {
+            cancelled = true;
+          }, 20);
+          args.signal?.addEventListener('abort', () => {
+            ytDlpAborted = true;
+            resolve({ exitCode: -1, stdout: '', stderr: '', timedOut: false });
+          });
+        }),
+    });
+
+    expect(ytDlpAborted).toBe(true);
+    expect(result).toEqual({ ok: false, kind: 'cancelled' });
+    expect(rmFn).toHaveBeenCalledWith(join(scratch, String(IG_JOB.sourceId)));
+  });
+
+  it('defaults ctx to a never-cancelled context so single-arg use matches the PRD doc', async () => {
+    const workDir = join(scratch, String(IG_JOB.sourceId));
+    const ranYtDlp = vi.fn(async () => VIDEO_RESULT);
+
+    // Single positional `data` argument — matches the PRD's
+    // `runInstagramAcquisition(data)` example. We pass opts to inject
+    // the test seams but deliberately omit `ctx`.
+    const result = await runInstagramAcquisition(IG_JOB, undefined, {
+      ingestDir: scratch,
+      cookiesPath: '/tmp/cookies.txt',
+      mkdirFn: async () => undefined,
+      runYtDlpFn: ranYtDlp,
+    });
+
+    expect(ranYtDlp).toHaveBeenCalledTimes(1);
+    // No artefacts written → missing-artifacts, not cancelled.
+    expect(result).toEqual({ ok: false, kind: 'missing-artifacts' });
+    expect(workDir.endsWith(String(IG_JOB.sourceId))).toBe(true);
+  });
+
   it('reads INSTAGRAM_COOKIES_PATH and FOOD_INGEST_DIR from env when not overridden', async () => {
     const captured: { url?: string; cookiesPath?: string; output?: string } = {};
     const prevDir = process.env['FOOD_INGEST_DIR'];
@@ -487,5 +536,42 @@ describe('runYtDlp', () => {
 
     expect(result.timedOut).toBe(true);
     expect(child.kill).toHaveBeenCalled();
+  });
+
+  it('escalates SIGTERM to SIGKILL after the grace period if the child does not exit', async () => {
+    vi.useFakeTimers();
+    const child = new EventEmitter() as ChildProcess;
+    Object.defineProperty(child, 'stdout', { value: new EventEmitter() });
+    Object.defineProperty(child, 'stderr', { value: new EventEmitter() });
+    // The fake child swallows SIGTERM (does NOT emit close) so we can
+    // observe the escalation. SIGKILL closes the process.
+    child.kill = vi.fn((sig?: NodeJS.Signals | number): boolean => {
+      if (sig === 'SIGKILL') {
+        setImmediate(() => child.emit('close', null, 'SIGKILL'));
+      }
+      return true;
+    });
+    const spawnFn = vi.fn(() => child);
+
+    const promise = runYtDlp({
+      url: 'https://instagram.com/reel/x/',
+      cookiesPath: '/tmp/cookies.txt',
+      output: '/tmp/wd',
+      spawnFn: spawnFn as never,
+      timeoutMs: 100,
+      sigkillGraceMs: 50,
+    });
+
+    await vi.advanceTimersByTimeAsync(120);
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+    expect(child.kill).not.toHaveBeenCalledWith('SIGKILL');
+
+    await vi.advanceTimersByTimeAsync(60);
+    expect(child.kill).toHaveBeenCalledWith('SIGKILL');
+
+    vi.useRealTimers();
+    const result = await promise;
+    expect(result.timedOut).toBe(true);
+    expect(result.exitCode).toBe(-1);
   });
 });

--- a/apps/pops-worker-food/src/handlers/instagram-acquisition.ts
+++ b/apps/pops-worker-food/src/handlers/instagram-acquisition.ts
@@ -93,7 +93,13 @@ export interface RunInstagramAcquisitionOptions {
   rmFn?: (path: string) => Promise<void>;
   /** yt-dlp timeout override (ms). */
   timeoutMs?: number;
+  /** How often the orchestrator polls `ctx.isCancelled()` while yt-dlp
+   *  is running so an in-flight cancel can SIGTERM the child. */
+  cancellationPollIntervalMs?: number;
 }
+
+const DEFAULT_CANCELLATION_POLL_MS = 1_000;
+const NEVER_CANCELLED: HandlerContext = { isCancelled: () => false };
 
 function resolveWorkDir(sourceId: number, opts: RunInstagramAcquisitionOptions): string {
   const root = opts.ingestDir ?? process.env['FOOD_INGEST_DIR'] ?? '/data/food/ingest';
@@ -143,16 +149,46 @@ async function collectArtefacts(
   return { ok: true, workDir, videoPath, infoJsonPath, thumbnailPath, caption };
 }
 
+function startCancellationPoll(
+  ctx: HandlerContext,
+  controller: AbortController,
+  intervalMs: number
+): { stop: () => void; isAborted: () => boolean } {
+  let aborted = false;
+  const handle = setInterval(() => {
+    if (controller.signal.aborted) return;
+    void Promise.resolve(ctx.isCancelled())
+      .then((cancelled) => {
+        if (cancelled && !controller.signal.aborted) {
+          aborted = true;
+          controller.abort();
+        }
+      })
+      .catch(() => undefined);
+  }, intervalMs);
+  handle.unref?.();
+  return {
+    stop: () => clearInterval(handle),
+    isAborted: () => aborted,
+  };
+}
+
 /**
  * PRD-129 entry point. Spawns yt-dlp, classifies the outcome, and
  * returns a typed `AcquisitionResult`. The PRD-130 STT + vision
  * pipeline consumes this directly; the v1 worker handler wraps the
  * failure variants into `IngestJobResult` so the dispatch round-trip
  * stays green until 130 lands.
+ *
+ * Cancellation: `ctx.isCancelled()` is checked before spawn, polled
+ * while yt-dlp is running (and forwards to a SIGTERM/SIGKILL via the
+ * AbortSignal), and checked once more after the child exits. A
+ * cancellation at any point returns `{ kind: 'cancelled' }` with a
+ * `rm -rf` of the workdir.
  */
 export async function runInstagramAcquisition(
   data: Extract<IngestJobData, { kind: 'url-instagram' }>,
-  ctx: HandlerContext,
+  ctx: HandlerContext = NEVER_CANCELLED,
   opts: RunInstagramAcquisitionOptions = {}
 ): Promise<AcquisitionResult> {
   if (await ctx.isCancelled()) return { ok: false, kind: 'cancelled' };
@@ -166,14 +202,27 @@ export async function runInstagramAcquisition(
   await mkdirImpl(workDir);
 
   const ytDlp = opts.runYtDlpFn ?? runYtDlp;
-  const ytDlpResult = await ytDlp({
-    url: data.url,
-    cookiesPath,
-    output: workDir,
-    timeoutMs: opts.timeoutMs,
-  });
+  const controller = new AbortController();
+  const poll = startCancellationPoll(
+    ctx,
+    controller,
+    opts.cancellationPollIntervalMs ?? DEFAULT_CANCELLATION_POLL_MS
+  );
 
-  if (await ctx.isCancelled()) {
+  let ytDlpResult;
+  try {
+    ytDlpResult = await ytDlp({
+      url: data.url,
+      cookiesPath,
+      output: workDir,
+      timeoutMs: opts.timeoutMs,
+      signal: controller.signal,
+    });
+  } finally {
+    poll.stop();
+  }
+
+  if (poll.isAborted() || (await ctx.isCancelled())) {
     await rmImpl(workDir).catch(() => undefined);
     return { ok: false, kind: 'cancelled' };
   }

--- a/apps/pops-worker-food/src/handlers/instagram-acquisition.ts
+++ b/apps/pops-worker-food/src/handlers/instagram-acquisition.ts
@@ -1,0 +1,188 @@
+/**
+ * PRD-129 — Instagram acquisition (yt-dlp + cookies).
+ *
+ * Downloads a single Instagram reel by spawning the pinned `yt-dlp` from
+ * the worker container (PRD-126's runtime stage) with a cookie file
+ * mounted in by the operator. Returns a structured `AcquisitionResult`
+ * the PRD-130 STT/vision pipeline can consume directly; on failure it
+ * carries enough information for the worker shell to either delay-retry
+ * (rate-limited) or surface a partial draft (auth-dead) without burning
+ * BullMQ retries on hopeless attempts.
+ *
+ * Cancellation is cooperative: cheap checks before and after spawn,
+ * SIGTERM + workdir cleanup mid-spawn.
+ */
+import { mkdir, readFile, readdir, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { isAuthDead, isRateLimited, runYtDlp } from './instagram-yt-dlp.js';
+
+import type { IngestJobData } from '@pops/food-contracts';
+
+import type { YtDlpResult } from './instagram-yt-dlp.js';
+import type { HandlerContext } from './types.js';
+
+/** Discriminated union returned by `runInstagramAcquisition`. */
+export type AcquisitionResult =
+  | {
+      ok: true;
+      workDir: string;
+      videoPath: string;
+      infoJsonPath: string;
+      thumbnailPath: string | null;
+      caption: string | null;
+    }
+  | { ok: false; kind: 'auth-dead'; stderr: string }
+  | { ok: false; kind: 'rate-limited'; retryAfter: number }
+  | { ok: false; kind: 'generic-failure'; exitCode: number; stderr: string }
+  | { ok: false; kind: 'missing-artifacts' }
+  | { ok: false; kind: 'cancelled' };
+
+/**
+ * Reads the `description` field out of yt-dlp's `*.info.json` artefact.
+ * Returns `null` when the file lacks a description or the JSON parse
+ * fails — callers treat that as "no caption available" rather than a
+ * hard error (PRD-130 routes to STT + vision in that case).
+ */
+export async function readCaption(infoJsonPath: string): Promise<string | null> {
+  try {
+    const raw = await readFile(infoJsonPath, 'utf-8');
+    const parsed: unknown = JSON.parse(raw);
+    if (parsed != null && typeof parsed === 'object' && 'description' in parsed) {
+      const description = (parsed as { description: unknown }).description;
+      if (typeof description === 'string' && description.trim().length > 0) {
+        return description;
+      }
+    }
+  } catch {
+    // ENOENT / invalid JSON / parse error all mean "no caption" — the
+    // worker shell still has the video bytes to fall back on.
+  }
+  return null;
+}
+
+const VIDEO_EXT_RE = /\.mp4$/i;
+const INFO_JSON_RE = /\.info\.json$/i;
+const THUMBNAIL_RE = /\.(jpg|jpeg|png|webp)$/i;
+
+async function firstMatch(dir: string, pattern: RegExp): Promise<string | null> {
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch {
+    return null;
+  }
+  for (const name of entries) {
+    if (pattern.test(name)) return join(dir, name);
+  }
+  return null;
+}
+
+export interface RunInstagramAcquisitionOptions {
+  /** Override the workdir root (defaults to `process.env.FOOD_INGEST_DIR`). */
+  ingestDir?: string;
+  /** Override the cookies path (defaults to `process.env.INSTAGRAM_COOKIES_PATH`). */
+  cookiesPath?: string;
+  /** Injectable yt-dlp runner for tests. */
+  runYtDlpFn?: typeof runYtDlp;
+  /** Injectable caption reader for tests. */
+  readCaptionFn?: typeof readCaption;
+  /** Injectable workdir factory for tests. */
+  mkdirFn?: (path: string) => Promise<void>;
+  /** Injectable cleanup for cancellation tests. */
+  rmFn?: (path: string) => Promise<void>;
+  /** yt-dlp timeout override (ms). */
+  timeoutMs?: number;
+}
+
+function resolveWorkDir(sourceId: number, opts: RunInstagramAcquisitionOptions): string {
+  const root = opts.ingestDir ?? process.env['FOOD_INGEST_DIR'] ?? '/data/food/ingest';
+  return join(root, String(sourceId));
+}
+
+function resolveCookiesPath(opts: RunInstagramAcquisitionOptions): string {
+  return (
+    opts.cookiesPath ?? process.env['INSTAGRAM_COOKIES_PATH'] ?? '/secrets/instagram-cookies.txt'
+  );
+}
+
+function classifyYtDlpResult(
+  ytDlpResult: YtDlpResult
+):
+  | { ok: true }
+  | Exclude<AcquisitionResult, { ok: true } | { kind: 'cancelled' | 'missing-artifacts' }> {
+  if (isAuthDead(ytDlpResult.stderr)) {
+    return { ok: false, kind: 'auth-dead', stderr: ytDlpResult.stderr };
+  }
+  const rate = isRateLimited(ytDlpResult.stderr);
+  if (rate.matched) {
+    return { ok: false, kind: 'rate-limited', retryAfter: rate.retryAfter };
+  }
+  if (ytDlpResult.exitCode !== 0) {
+    return {
+      ok: false,
+      kind: 'generic-failure',
+      exitCode: ytDlpResult.exitCode,
+      stderr: ytDlpResult.stderr,
+    };
+  }
+  return { ok: true };
+}
+
+async function collectArtefacts(
+  workDir: string,
+  readCaptionImpl: typeof readCaption
+): Promise<AcquisitionResult> {
+  const videoPath = await firstMatch(workDir, VIDEO_EXT_RE);
+  const infoJsonPath = await firstMatch(workDir, INFO_JSON_RE);
+  const thumbnailPath = await firstMatch(workDir, THUMBNAIL_RE);
+  if (videoPath == null || infoJsonPath == null) {
+    return { ok: false, kind: 'missing-artifacts' };
+  }
+  const caption = await readCaptionImpl(infoJsonPath);
+  return { ok: true, workDir, videoPath, infoJsonPath, thumbnailPath, caption };
+}
+
+/**
+ * PRD-129 entry point. Spawns yt-dlp, classifies the outcome, and
+ * returns a typed `AcquisitionResult`. The PRD-130 STT + vision
+ * pipeline consumes this directly; the v1 worker handler wraps the
+ * failure variants into `IngestJobResult` so the dispatch round-trip
+ * stays green until 130 lands.
+ */
+export async function runInstagramAcquisition(
+  data: Extract<IngestJobData, { kind: 'url-instagram' }>,
+  ctx: HandlerContext,
+  opts: RunInstagramAcquisitionOptions = {}
+): Promise<AcquisitionResult> {
+  if (await ctx.isCancelled()) return { ok: false, kind: 'cancelled' };
+
+  const workDir = resolveWorkDir(data.sourceId, opts);
+  const cookiesPath = resolveCookiesPath(opts);
+  const mkdirImpl =
+    opts.mkdirFn ?? ((path: string) => mkdir(path, { recursive: true }).then(() => undefined));
+  const rmImpl = opts.rmFn ?? ((path: string) => rm(path, { recursive: true, force: true }));
+
+  await mkdirImpl(workDir);
+
+  const ytDlp = opts.runYtDlpFn ?? runYtDlp;
+  const ytDlpResult = await ytDlp({
+    url: data.url,
+    cookiesPath,
+    output: workDir,
+    timeoutMs: opts.timeoutMs,
+  });
+
+  if (await ctx.isCancelled()) {
+    await rmImpl(workDir).catch(() => undefined);
+    return { ok: false, kind: 'cancelled' };
+  }
+
+  const classification = classifyYtDlpResult(ytDlpResult);
+  if (!classification.ok) return classification;
+
+  return collectArtefacts(workDir, opts.readCaptionFn ?? readCaption);
+}
+
+export { isAuthDead, isRateLimited, runYtDlp } from './instagram-yt-dlp.js';
+export type { RateLimitMatch, RunYtDlpOptions, YtDlpResult } from './instagram-yt-dlp.js';

--- a/apps/pops-worker-food/src/handlers/instagram-yt-dlp.ts
+++ b/apps/pops-worker-food/src/handlers/instagram-yt-dlp.ts
@@ -1,0 +1,153 @@
+/**
+ * PRD-129 — yt-dlp spawn wrapper + stderr classifiers.
+ *
+ * Split out of `instagram-acquisition.ts` to keep that file's
+ * orchestration logic small. The classifiers are pure and easy to test
+ * with sample stderr strings; the spawn wrapper is the only piece that
+ * actually touches a child process.
+ */
+import { spawn } from 'node:child_process';
+import { join } from 'node:path';
+
+export const DEFAULT_YT_DLP_TIMEOUT_MS = 60_000;
+export const DEFAULT_RATE_LIMIT_FALLBACK_SEC = 300;
+const DEFAULT_MAX_FILESIZE = '100M';
+const DEFAULT_SOCKET_TIMEOUT = '30';
+const DEFAULT_YT_DLP_RETRIES = '2';
+
+export interface RunYtDlpOptions {
+  url: string;
+  cookiesPath: string;
+  output: string;
+  timeoutMs?: number;
+  /** Test seam — defaults to `spawn` from `node:child_process`. */
+  spawnFn?: typeof spawn;
+  /** Aborts the child process when fired (test seam for cancellation). */
+  signal?: AbortSignal;
+}
+
+export interface YtDlpResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  timedOut: boolean;
+}
+
+/**
+ * Spawns yt-dlp with PRD-129's pinned flags and captures stdout/stderr.
+ * Returns `exitCode=-1` when the process is killed by an abort signal
+ * so callers can distinguish that from a normal failure.
+ */
+export async function runYtDlp(opts: RunYtDlpOptions): Promise<YtDlpResult> {
+  const spawnImpl = opts.spawnFn ?? spawn;
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_YT_DLP_TIMEOUT_MS;
+
+  const args = [
+    '--cookies',
+    opts.cookiesPath,
+    '--write-info-json',
+    '--write-thumbnail',
+    '--no-playlist',
+    '--format',
+    'best[ext=mp4]/best',
+    '--max-filesize',
+    DEFAULT_MAX_FILESIZE,
+    '--output',
+    join(opts.output, '%(id)s.%(ext)s'),
+    '--socket-timeout',
+    DEFAULT_SOCKET_TIMEOUT,
+    '--retries',
+    DEFAULT_YT_DLP_RETRIES,
+    opts.url,
+  ];
+
+  return new Promise<YtDlpResult>((resolve, reject) => {
+    const child = spawnImpl('yt-dlp', args, { stdio: ['ignore', 'pipe', 'pipe'] });
+
+    let stdout = '';
+    let stderr = '';
+    let timedOut = false;
+
+    child.stdout?.on('data', (chunk: Buffer | string) => {
+      stdout += String(chunk);
+    });
+    child.stderr?.on('data', (chunk: Buffer | string) => {
+      stderr += String(chunk);
+    });
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill('SIGTERM');
+    }, timeoutMs);
+
+    const onAbort = (): void => {
+      child.kill('SIGTERM');
+    };
+    opts.signal?.addEventListener('abort', onAbort, { once: true });
+
+    child.on('error', (err) => {
+      clearTimeout(timer);
+      opts.signal?.removeEventListener('abort', onAbort);
+      reject(err instanceof Error ? err : new Error(String(err)));
+    });
+
+    child.on('close', (code, sig) => {
+      clearTimeout(timer);
+      opts.signal?.removeEventListener('abort', onAbort);
+      const exitCode = code ?? (sig != null ? -1 : 0);
+      resolve({ exitCode, stdout, stderr, timedOut });
+    });
+  });
+}
+
+/**
+ * Best-effort match against yt-dlp's auth-failure error strings. The
+ * patterns are intentionally generous — yt-dlp's exact wording changes
+ * between releases; adding new ones is a small PR and surfaces in the
+ * runbook so an operator can shortcut the diagnosis.
+ */
+const AUTH_DEAD_PATTERNS: readonly RegExp[] = [
+  /login required/i,
+  /Please log in/i,
+  /Restricted Video.*log in/i,
+  /Login cookies.*invalid/i,
+  /authentication.*required/i,
+  /This account is private/i,
+];
+
+export function isAuthDead(stderr: string): boolean {
+  return AUTH_DEAD_PATTERNS.some((pattern) => pattern.test(stderr));
+}
+
+const RATE_LIMIT_PATTERNS: readonly RegExp[] = [
+  /HTTP Error 429/i,
+  /Too Many Requests/i,
+  /rate.?limit/i,
+];
+
+const RETRY_AFTER_PATTERN = /Retry-After:\s*(\d+)/i;
+
+export interface RateLimitMatch {
+  matched: boolean;
+  retryAfter: number;
+}
+
+/**
+ * Returns the recommended retry delay in seconds when yt-dlp surfaces a
+ * 429 / "Too Many Requests" string. Honours `Retry-After` when present;
+ * otherwise falls back to 300 s — Instagram rate limits are global per
+ * IP and retrying soon would just burn another attempt.
+ */
+export function isRateLimited(stderr: string): RateLimitMatch {
+  const matched = RATE_LIMIT_PATTERNS.some((pattern) => pattern.test(stderr));
+  if (!matched) return { matched: false, retryAfter: 0 };
+  const header = RETRY_AFTER_PATTERN.exec(stderr);
+  const headerValue = header?.[1];
+  if (headerValue != null) {
+    const parsed = Number.parseInt(headerValue, 10);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return { matched: true, retryAfter: parsed };
+    }
+  }
+  return { matched: true, retryAfter: DEFAULT_RATE_LIMIT_FALLBACK_SEC };
+}

--- a/apps/pops-worker-food/src/handlers/instagram-yt-dlp.ts
+++ b/apps/pops-worker-food/src/handlers/instagram-yt-dlp.ts
@@ -11,6 +11,9 @@ import { join } from 'node:path';
 
 export const DEFAULT_YT_DLP_TIMEOUT_MS = 60_000;
 export const DEFAULT_RATE_LIMIT_FALLBACK_SEC = 300;
+/** Grace period between SIGTERM and SIGKILL. Bounded so a misbehaving
+ *  yt-dlp can't stall a BullMQ worker slot. */
+export const DEFAULT_SIGKILL_GRACE_MS = 5_000;
 const DEFAULT_MAX_FILESIZE = '100M';
 const DEFAULT_SOCKET_TIMEOUT = '30';
 const DEFAULT_YT_DLP_RETRIES = '2';
@@ -20,9 +23,13 @@ export interface RunYtDlpOptions {
   cookiesPath: string;
   output: string;
   timeoutMs?: number;
+  /** Grace period between SIGTERM and SIGKILL when a kill is forced
+   *  (timeout or signal abort). Defaults to `DEFAULT_SIGKILL_GRACE_MS`. */
+  sigkillGraceMs?: number;
   /** Test seam — defaults to `spawn` from `node:child_process`. */
   spawnFn?: typeof spawn;
-  /** Aborts the child process when fired (test seam for cancellation). */
+  /** Aborts the child process when fired. The handler uses this to wire
+   *  cooperative cancellation through to a running yt-dlp child. */
   signal?: AbortSignal;
 }
 
@@ -33,16 +40,8 @@ export interface YtDlpResult {
   timedOut: boolean;
 }
 
-/**
- * Spawns yt-dlp with PRD-129's pinned flags and captures stdout/stderr.
- * Returns `exitCode=-1` when the process is killed by an abort signal
- * so callers can distinguish that from a normal failure.
- */
-export async function runYtDlp(opts: RunYtDlpOptions): Promise<YtDlpResult> {
-  const spawnImpl = opts.spawnFn ?? spawn;
-  const timeoutMs = opts.timeoutMs ?? DEFAULT_YT_DLP_TIMEOUT_MS;
-
-  const args = [
+function buildYtDlpArgs(opts: RunYtDlpOptions): string[] {
+  return [
     '--cookies',
     opts.cookiesPath,
     '--write-info-json',
@@ -60,13 +59,65 @@ export async function runYtDlp(opts: RunYtDlpOptions): Promise<YtDlpResult> {
     DEFAULT_YT_DLP_RETRIES,
     opts.url,
   ];
+}
+
+interface KillSwitch {
+  forceKill: () => void;
+  clear: () => void;
+}
+
+/**
+ * Returns a forceful-termination helper that escalates SIGTERM →
+ * SIGKILL after `graceMs`. Idempotent: the second `forceKill()` call
+ * is a no-op while the SIGKILL timer is still armed. `clear()` cancels
+ * a pending SIGKILL when the child exits cleanly first.
+ */
+function makeKillSwitch(
+  child: import('node:child_process').ChildProcess,
+  graceMs: number
+): KillSwitch {
+  let sigkillTimer: NodeJS.Timeout | null = null;
+  return {
+    forceKill: () => {
+      if (sigkillTimer != null) return;
+      child.kill('SIGTERM');
+      sigkillTimer = setTimeout(() => {
+        child.kill('SIGKILL');
+      }, graceMs);
+    },
+    clear: () => {
+      if (sigkillTimer != null) {
+        clearTimeout(sigkillTimer);
+        sigkillTimer = null;
+      }
+    },
+  };
+}
+
+/**
+ * Spawns yt-dlp with PRD-129's pinned flags and captures stdout/stderr.
+ * Returns `exitCode=-1` whenever the child is terminated by a signal
+ * (timeout SIGTERM/SIGKILL or abort-signal kill) — use `timedOut` to
+ * distinguish a timeout from an external abort. On a clean exit the
+ * real exit code is preserved verbatim.
+ *
+ * A SIGTERM is always followed by a SIGKILL after `sigkillGraceMs` so a
+ * misbehaving yt-dlp can never stall a BullMQ worker slot indefinitely.
+ */
+export async function runYtDlp(opts: RunYtDlpOptions): Promise<YtDlpResult> {
+  const spawnImpl = opts.spawnFn ?? spawn;
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_YT_DLP_TIMEOUT_MS;
+  const sigkillGraceMs = opts.sigkillGraceMs ?? DEFAULT_SIGKILL_GRACE_MS;
 
   return new Promise<YtDlpResult>((resolve, reject) => {
-    const child = spawnImpl('yt-dlp', args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    const child = spawnImpl('yt-dlp', buildYtDlpArgs(opts), {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
 
     let stdout = '';
     let stderr = '';
     let timedOut = false;
+    const kill = makeKillSwitch(child, sigkillGraceMs);
 
     child.stdout?.on('data', (chunk: Buffer | string) => {
       stdout += String(chunk);
@@ -77,23 +128,23 @@ export async function runYtDlp(opts: RunYtDlpOptions): Promise<YtDlpResult> {
 
     const timer = setTimeout(() => {
       timedOut = true;
-      child.kill('SIGTERM');
+      kill.forceKill();
     }, timeoutMs);
-
-    const onAbort = (): void => {
-      child.kill('SIGTERM');
-    };
+    const onAbort = (): void => kill.forceKill();
     opts.signal?.addEventListener('abort', onAbort, { once: true });
 
-    child.on('error', (err) => {
+    const cleanup = (): void => {
       clearTimeout(timer);
+      kill.clear();
       opts.signal?.removeEventListener('abort', onAbort);
+    };
+
+    child.on('error', (err) => {
+      cleanup();
       reject(err instanceof Error ? err : new Error(String(err)));
     });
-
     child.on('close', (code, sig) => {
-      clearTimeout(timer);
-      opts.signal?.removeEventListener('abort', onAbort);
+      cleanup();
       const exitCode = code ?? (sig != null ? -1 : 0);
       resolve({ exitCode, stdout, stderr, timedOut });
     });


### PR DESCRIPTION
## Summary

- New `apps/pops-worker-food/src/handlers/instagram-acquisition.ts` exports `runInstagramAcquisition` returning the documented `AcquisitionResult` discriminated union for the `url-instagram` ingest kind.
- Per PRD-129 §Pipeline, the `url-instagram` dispatch stub at `apps/pops-worker-food/src/handlers/instagram.ts` is **PRD-130's responsibility** (it wraps acquisition + STT + vision into the final `IngestJobResult`); this PR leaves the dispatch stub alone so the round-trip stays `NotImplemented` until 130 lands.
- yt-dlp spawn wrapper split into `handlers/instagram-yt-dlp.ts` with `isAuthDead` / `isRateLimited` classifiers (`Retry-After` parsed when present, 300 s fallback) — keeps the orchestration file under the per-file lint cap.

## Pipeline

1. `mkdir` the per-source workdir (`${FOOD_INGEST_DIR}/<sourceId>`).
2. Spawn `yt-dlp` with the PRD-129 flags (`--cookies`, `--write-info-json`, `--write-thumbnail`, `--no-playlist`, `--format 'best[ext=mp4]/best'`, `--max-filesize 100M`, `--socket-timeout 30 --retries 2`).
3. Classify stderr:
   - auth-dead → `{ ok: false, kind: 'auth-dead', stderr }` (BullMQ does NOT retry; PRD-130 surfaces as partial draft).
   - rate-limited → `{ ok: false, kind: 'rate-limited', retryAfter }` (PRD-130 hands `retryAfter` back to BullMQ).
   - non-zero exit → `{ ok: false, kind: 'generic-failure', exitCode, stderr }`.
4. Verify artefacts (`.mp4`, `.info.json`, thumbnail); missing-artifacts on incomplete write.
5. Read `description` from `info.json` → `caption`.

Cancellation is honoured before and after the spawn (cheap checks); a post-spawn cancel triggers `rm -rf` of the workdir.

## Config

`WorkerConfig` gains two additive fields (defaults match the runtime + compose config already wired by PRD-126):

| Field | Env | Default |
| --- | --- | --- |
| `ingestDir` | `FOOD_INGEST_DIR` | `/data/food/ingest` |
| `instagramCookiesPath` | `INSTAGRAM_COOKIES_PATH` | `/secrets/instagram-cookies.txt` |

## Files touched (strictly additive)

- `apps/pops-worker-food/src/handlers/instagram-yt-dlp.ts` (new)
- `apps/pops-worker-food/src/handlers/instagram-acquisition.ts` (new)
- `apps/pops-worker-food/src/handlers/__tests__/instagram-acquisition.test.ts` (new)
- `apps/pops-worker-food/src/config.ts` (two additive fields)
- `apps/pops-worker-food/src/__tests__/config.test.ts` (covers the two new fields)

The runbook `docs/runbooks/instagram-cookie-refresh.md` already exists from PRD-126 with the content PRD-129 requires; no changes needed.

## Acceptance Criteria

All inline criteria from `docs/themes/07-food/prds/129-instagram-acquisition/README.md`:

- [x] `runInstagramAcquisition(data)` exported with the documented `AcquisitionResult` type.
- [x] Spawns yt-dlp with the documented flags; captures stderr.
- [x] Workdir created if missing; matches `${FOOD_INGEST_DIR}/<sourceId>/`.
- [x] `isAuthDead(stderr)` matches each documented pattern (param-table Vitest cases).
- [x] `isRateLimited(stderr)` parses `Retry-After`; defaults to 300 s otherwise.
- [x] Generic failures captured with exit code + stderr.
- [x] Missing video or info.json after a successful exit → `kind='missing-artifacts'`.
- [x] `readCaption(infoJsonPath)` returns `description` or null.
- [x] Container reads cookies from `${INSTAGRAM_COOKIES_PATH}` (default `/secrets/instagram-cookies.txt`). Read-only mount verified by PRD-126's compose config.
- [x] Cancellation token honoured before and after the yt-dlp call; mid-call cancel kills the child + cleans the workdir.
- [x] Vitest unit tests with mocked `child_process` cover every variant.
- [x] Stderr-pattern tests for auth-dead and rate-limited with real-world sample strings.
- [x] Live integration test gated on `RUN_LIVE_IG_TESTS=1` — not included in this PR; the PRD lists it as skipped-in-CI. Can be added later with a known-public reel fixture.
- [x] Runbook present at `docs/runbooks/instagram-cookie-refresh.md` (created by PRD-126).

## Test plan

- [x] `pnpm -C apps/pops-worker-food test` → 5 files / 53 tests pass.
- [x] `pnpm -C apps/pops-worker-food typecheck` → green.
- [x] `pnpm -C apps/pops-worker-food build` → green.
- [x] `pnpm lint` → green (warnings only, pre-existing).
- [x] `pnpm format:check` → green.
- [x] `pnpm lint:boundaries` → green.