### PR TITLE
feat(food): PRD-132 — text ingest handler (paste → Claude → DSL)

### DIFF
--- a/apps/pops-worker-food/package.json
+++ b/apps/pops-worker-food/package.json
@@ -23,6 +23,7 @@
   "devDependencies": {
     "@pops/api": "workspace:*",
     "@pops/app-food": "workspace:*",
+    "@pops/app-food-db": "workspace:*",
     "@types/node": "^25.9.1",
     "tsx": "^4.22.4",
     "typescript": "^6.0.3",

--- a/apps/pops-worker-food/package.json
+++ b/apps/pops-worker-food/package.json
@@ -12,11 +12,13 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.100.1",
     "@pops/food-contracts": "workspace:*",
     "@trpc/client": "11.17.0",
     "bullmq": "^5.78.0",
     "ioredis": "^5.11.0",
-    "pino": "^10.3.1"
+    "pino": "^10.3.1",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@pops/api": "workspace:*",

--- a/apps/pops-worker-food/src/__tests__/dispatch.test.ts
+++ b/apps/pops-worker-food/src/__tests__/dispatch.test.ts
@@ -138,7 +138,6 @@ describe('default handler stubs', () => {
     const kinds: IngestJobData[] = [
       { kind: 'url-instagram', sourceId: 2, url: 'https://instagram.com/r/abc' },
       { kind: 'screenshot', sourceId: 3, mimeType: 'image/png', contentPath: '/tmp/x.png' },
-      { kind: 'text', sourceId: 4, body: 'hi' },
     ];
     for (const data of kinds) {
       const result = await runIngestJob(data, ctx, defaultHandlers);

--- a/apps/pops-worker-food/src/__tests__/map-to-dsl.test.ts
+++ b/apps/pops-worker-food/src/__tests__/map-to-dsl.test.ts
@@ -3,7 +3,7 @@
  */
 import { describe, expect, it } from 'vitest';
 
-import { parseRecipeDsl } from '@pops/app-food/src/dsl/parser';
+import { parseRecipeDsl } from '@pops/app-food-db';
 
 import { mapJsonLdToDsl } from '../handlers/web/map-to-dsl.js';
 

--- a/apps/pops-worker-food/src/__tests__/web-jsonld.fixtures.test.ts
+++ b/apps/pops-worker-food/src/__tests__/web-jsonld.fixtures.test.ts
@@ -20,10 +20,10 @@ import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
 
-// PRD-114 parser. Deep import is intentional — `@pops/app-food` package
-// root re-exports React components we don't want pulled into the worker
-// test harness.
-import { parseRecipeDsl } from '@pops/app-food/src/dsl/parser';
+// PRD-114 parser. PRD-119-API extracted the DSL pipeline out of `@pops/app-food`
+// into `@pops/app-food-db` so the backend (and this worker) can pull it in
+// without React + CodeMirror getting dragged along.
+import { parseRecipeDsl } from '@pops/app-food-db';
 
 import { runWebUrlIngestWith } from '../handlers/web-url.js';
 import { extractRecipeJsonLd } from '../handlers/web/extract-json-ld.js';

--- a/apps/pops-worker-food/src/ai/anthropic.ts
+++ b/apps/pops-worker-food/src/ai/anthropic.ts
@@ -1,0 +1,42 @@
+import Anthropic from '@anthropic-ai/sdk';
+
+import type { MessageCreateParamsNonStreaming } from '@anthropic-ai/sdk/resources/messages';
+
+/**
+ * Thin wrapper around the Anthropic SDK so handlers don't reach for the
+ * raw `Anthropic` import (keeps test mocks centralised on this module).
+ *
+ * `maxRetries: 0` matches the convention in `apps/pops-api` — retries
+ * belong in the BullMQ job lifecycle, not the SDK, so a transient 429
+ * surfaces here, the job throws, and BullMQ schedules the next attempt.
+ *
+ * The response shape declared here is a structural subset of the SDK's
+ * `Message` — handlers only read `content[].text` and `usage.input_tokens` /
+ * `usage.output_tokens`. Narrowing the type lets tests construct fixtures
+ * without dragging in every field of the real `Message` (and without the
+ * `as unknown as Message` cast that would imply).
+ */
+export interface AnthropicContentBlock {
+  type: string;
+  text?: string;
+}
+
+export interface AnthropicMessageUsage {
+  input_tokens?: number | null;
+  output_tokens?: number | null;
+}
+
+export interface AnthropicMessage {
+  content: AnthropicContentBlock[];
+  usage?: AnthropicMessageUsage | null;
+}
+
+export interface AnthropicLike {
+  messages: {
+    create(params: MessageCreateParamsNonStreaming): Promise<AnthropicMessage>;
+  };
+}
+
+export function createAnthropicClient(apiKey: string): AnthropicLike {
+  return new Anthropic({ apiKey, maxRetries: 0 });
+}

--- a/apps/pops-worker-food/src/ai/log-inference.ts
+++ b/apps/pops-worker-food/src/ai/log-inference.ts
@@ -3,18 +3,16 @@ import pino from 'pino';
 import type { AnthropicMessage } from './anthropic.js';
 
 /**
- * Local stub of PRD-133's `callClaudeWithLogging`. Records timings and
- * usage, fires the log payload through `opts.onLog` (caller-injected so
- * tests don't need to mock the network), and returns the Anthropic
- * response unchanged.
- *
- * Once PRD-133 ships its canonical `packages/app-food/src/ai/log-inference.ts`
- * wrapper, swap `opts.onLog` for the real `food.ai.logInference` tRPC
- * call. Until then the worker is the single producer and the API will
- * 404 on the route — fire-and-forget on the log POST keeps the handler
- * green either way.
- *
- * TODO(PRD-133): replace this with the canonical wrapper once landed.
+ * Worker-local `callClaudeWithLogging`. Records timings and usage, fires
+ * the log payload through `opts.onLog` (caller-injected so tests don't
+ * need to mock the network), and returns the Anthropic response
+ * unchanged. The PRD-133 canonical wrapper at
+ * `packages/app-food/src/ai/log-inference.ts` is React-coupled (lives in
+ * `@pops/app-food`); follow-up tracked in PRD-133 will extract it to a
+ * backend-only package, at which point this module's `onLog` plugs into
+ * the shared `LogFoodInferenceFn` instead of pino. Operation names here
+ * already match PRD-133's `FoodOperationSchema` literals, so the swap is
+ * mechanical.
  */
 
 const logger = pino({ name: 'food-ai-log-inference', level: process.env['LOG_LEVEL'] ?? 'info' });

--- a/apps/pops-worker-food/src/ai/log-inference.ts
+++ b/apps/pops-worker-food/src/ai/log-inference.ts
@@ -1,0 +1,108 @@
+import pino from 'pino';
+
+import type { AnthropicMessage } from './anthropic.js';
+
+/**
+ * Local stub of PRD-133's `callClaudeWithLogging`. Records timings and
+ * usage, fires the log payload through `opts.onLog` (caller-injected so
+ * tests don't need to mock the network), and returns the Anthropic
+ * response unchanged.
+ *
+ * Once PRD-133 ships its canonical `packages/app-food/src/ai/log-inference.ts`
+ * wrapper, swap `opts.onLog` for the real `food.ai.logInference` tRPC
+ * call. Until then the worker is the single producer and the API will
+ * 404 on the route — fire-and-forget on the log POST keeps the handler
+ * green either way.
+ *
+ * TODO(PRD-133): replace this with the canonical wrapper once landed.
+ */
+
+const logger = pino({ name: 'food-ai-log-inference', level: process.env['LOG_LEVEL'] ?? 'info' });
+
+export interface InferenceLogInput {
+  /** PRD-133 `operation` column — uniquely names the call site. */
+  operation: string;
+  /** Anthropic model id used. */
+  model: string;
+  /** Prompt template version (PRD-133 keys cost trends off this). */
+  promptVersion: string;
+  /** Stringly-namespaced FK to the originating row (`ingest_source:<id>`). */
+  contextId: string;
+  /** Provider-reported usage when available. */
+  inputTokens?: number;
+  outputTokens?: number;
+  /** Computed once the pricing table lookup runs (PRD-133); null until then. */
+  costUsd?: number;
+  durationMs: number;
+  /** `null` on success; error message on throw. */
+  error?: string;
+}
+
+export interface CallClaudeWithLoggingOpts {
+  operation: string;
+  model: string;
+  promptVersion: string;
+  contextId: string;
+  /** Returns the raw Anthropic message so usage stats survive. */
+  call: () => Promise<AnthropicMessage>;
+  /**
+   * Side-channel for the log row. PRD-133's wrapper will inject a tRPC
+   * mutation; the worker default just records to stdout so prod has
+   * something to scrape until then. Errors swallowed — logging never
+   * fails the ingest.
+   */
+  onLog?: (entry: InferenceLogInput) => void | Promise<void>;
+}
+
+export interface CallClaudeWithLoggingResult {
+  message: AnthropicMessage;
+  durationMs: number;
+  inputTokens?: number;
+  outputTokens?: number;
+}
+
+const defaultOnLog = (entry: InferenceLogInput): void => {
+  logger.info({ inference: entry }, 'food.inference');
+};
+
+export async function callClaudeWithLogging(
+  opts: CallClaudeWithLoggingOpts
+): Promise<CallClaudeWithLoggingResult> {
+  const start = Date.now();
+  const onLog = opts.onLog ?? defaultOnLog;
+  try {
+    const message = await opts.call();
+    const durationMs = Date.now() - start;
+    const inputTokens = message.usage?.input_tokens ?? undefined;
+    const outputTokens = message.usage?.output_tokens ?? undefined;
+    void Promise.resolve(
+      onLog({
+        operation: opts.operation,
+        model: opts.model,
+        promptVersion: opts.promptVersion,
+        contextId: opts.contextId,
+        inputTokens,
+        outputTokens,
+        durationMs,
+      })
+    ).catch((err) => {
+      logger.warn({ err: String(err) }, 'food.inference.log_failed');
+    });
+    return { message, durationMs, inputTokens, outputTokens };
+  } catch (err) {
+    const durationMs = Date.now() - start;
+    void Promise.resolve(
+      onLog({
+        operation: opts.operation,
+        model: opts.model,
+        promptVersion: opts.promptVersion,
+        contextId: opts.contextId,
+        durationMs,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    ).catch((logErr) => {
+      logger.warn({ err: String(logErr) }, 'food.inference.log_failed');
+    });
+    throw err;
+  }
+}

--- a/apps/pops-worker-food/src/handlers/__tests__/text.test.ts
+++ b/apps/pops-worker-food/src/handlers/__tests__/text.test.ts
@@ -114,8 +114,8 @@ describe('runTextIngest — validation', () => {
   });
 
   it('short-circuits when cancelled before the LLM call', async () => {
-    const create = vi.fn();
-    __setTextIngestClientForTests(buildMockClient(async () => mockMessage('{}')));
+    const create = vi.fn(async () => mockMessage('{}'));
+    __setTextIngestClientForTests({ messages: { create } });
     const cancelCtx: HandlerContext = { isCancelled: () => true };
     const result = await runTextIngest(
       { kind: 'text', sourceId: 1, body: 'A perfectly fine recipe body.' },
@@ -256,6 +256,55 @@ describe('runTextIngest — error paths', () => {
     if (result.ok) throw new Error('unreachable');
     expect(result.errorCode).toBe('LlmExtractFailed');
     expect(result.errorMessage).toMatch(/non-JSON/);
+  });
+
+  it('fails with LlmExtractFailed when the LLM returns empty strings for required numerics', async () => {
+    // Regression: `numericLike` must reject `""` rather than coercing it
+    // to 0 (Number("") === 0). Silently zeroing missing numeric fields
+    // would let an unusable extraction pass validation.
+    __setTextIngestClientForTests(
+      buildMockClient(async () =>
+        mockMessage(
+          JSON.stringify({
+            title: 'Plain Salad',
+            servings: '',
+            ingredients: [],
+            steps: [],
+          })
+        )
+      )
+    );
+    const result = await runTextIngest(
+      { kind: 'text', sourceId: 1, body: 'A perfectly fine recipe body.' },
+      ctx
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.errorCode).toBe('LlmExtractFailed');
+    expect(result.errorMessage).toMatch(/servings/);
+  });
+
+  it('records duration_ms on the LLM-failure stage when the call throws', async () => {
+    // Regression: the failure path used to hardcode durationMs: 0 which
+    // hid slow timeouts behind a zero-latency log line.
+    __setTextIngestClientForTests({
+      messages: {
+        create: vi.fn(async () => {
+          await new Promise((resolve) => setTimeout(resolve, 5));
+          throw new Error('network blew up');
+        }),
+      },
+    });
+    const result = await runTextIngest(
+      { kind: 'text', sourceId: 1, body: 'A perfectly fine recipe body.' },
+      ctx
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.errorCode).toBe('LlmExtractFailed');
+    const stage = result.meta.stages['llm_extract'] as Record<string, unknown>;
+    expect(typeof stage['duration_ms']).toBe('number');
+    expect(stage['duration_ms']).toBeGreaterThan(0);
   });
 
   it('fails with LlmExtractFailed on schema violation (missing title)', async () => {

--- a/apps/pops-worker-food/src/handlers/__tests__/text.test.ts
+++ b/apps/pops-worker-food/src/handlers/__tests__/text.test.ts
@@ -1,0 +1,314 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { extractedRecipeSchema, type ExtractedRecipe } from '../extracted-recipe.js';
+import {
+  __setTextIngestClientForTests,
+  __setTextIngestLogForTests,
+  extractWithClaudeText,
+  runTextIngest,
+} from '../text.js';
+
+import type { AnthropicLike, AnthropicMessage } from '../../ai/anthropic.js';
+import type { InferenceLogInput } from '../../ai/log-inference.js';
+import type { HandlerContext } from '../types.js';
+
+const ctx: HandlerContext = { isCancelled: () => false };
+
+function mockMessage(
+  text: string,
+  usage = { input_tokens: 100, output_tokens: 150 }
+): AnthropicMessage {
+  return {
+    content: [{ type: 'text', text }],
+    usage: {
+      input_tokens: usage.input_tokens,
+      output_tokens: usage.output_tokens,
+    },
+  };
+}
+
+function happyRecipeJson(overrides: Partial<ExtractedRecipe> = {}): ExtractedRecipe {
+  const base: ExtractedRecipe = extractedRecipeSchema.parse({
+    title: 'Smash Burger',
+    summary: 'Crispy edges, melty cheese.',
+    servings: 2,
+    prep_time_minutes: 10,
+    cook_time_minutes: 8,
+    yield_slug: 'smash-burger',
+    yield_qty: 2,
+    yield_unit: 'serving',
+    tags: ['american', 'beef'],
+    ingredients: [
+      {
+        qty: 250,
+        unit: 'g',
+        ingredient_slug: 'beef-chuck',
+        variant_slug: 'ground',
+        prep_state_slug: 'whole',
+        original_text: '250g ground beef',
+        optional: false,
+      },
+      {
+        qty: 2,
+        unit: 'count',
+        ingredient_slug: 'brioche-bun',
+      },
+      {
+        qty: 1,
+        unit: 'count',
+        ingredient_slug: 'yellow-onion',
+        prep_state_slug: 'sliced',
+        original_text: '1 onion, sliced',
+      },
+    ],
+    steps: [
+      { body: 'Form @beef-chuck into two loose balls.', duration_minutes: 2 },
+      { body: 'Smash onto a screaming-hot pan; cook 90 seconds.', duration_minutes: 3 },
+    ],
+  });
+  return { ...base, ...overrides };
+}
+
+function buildMockClient(impl: () => Promise<AnthropicMessage>): AnthropicLike {
+  return {
+    messages: {
+      create: vi.fn(impl),
+    },
+  };
+}
+
+let capturedLogs: InferenceLogInput[];
+
+beforeEach(() => {
+  process.env['ANTHROPIC_API_KEY'] = 'test-key';
+  process.env['FOOD_TEXT_LLM_MODEL'] = 'claude-haiku-4-5-20251001';
+  capturedLogs = [];
+  __setTextIngestLogForTests((entry) => {
+    capturedLogs.push(entry);
+  });
+});
+
+afterEach(() => {
+  __setTextIngestClientForTests(null);
+  __setTextIngestLogForTests(null);
+  delete process.env['ANTHROPIC_API_KEY'];
+  delete process.env['FOOD_TEXT_LLM_MODEL'];
+  vi.restoreAllMocks();
+});
+
+describe('runTextIngest — validation', () => {
+  it('rejects bodies under 10 chars with EmptyText', async () => {
+    const result = await runTextIngest({ kind: 'text', sourceId: 1, body: 'hi' }, ctx);
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.errorCode).toBe('EmptyText');
+    const stage = result.meta.stages['input_validate'] as Record<string, unknown>;
+    expect(stage).toMatchObject({ ok: false, reason: 'below-min' });
+  });
+
+  it('rejects whitespace-only bodies as EmptyText', async () => {
+    const result = await runTextIngest({ kind: 'text', sourceId: 1, body: '          ' }, ctx);
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.errorCode).toBe('EmptyText');
+  });
+
+  it('short-circuits when cancelled before the LLM call', async () => {
+    const create = vi.fn();
+    __setTextIngestClientForTests(buildMockClient(async () => mockMessage('{}')));
+    const cancelCtx: HandlerContext = { isCancelled: () => true };
+    const result = await runTextIngest(
+      { kind: 'text', sourceId: 1, body: 'A perfectly fine recipe body.' },
+      cancelCtx
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.errorCode).toBe('Cancelled');
+    expect(create).not.toHaveBeenCalled();
+  });
+});
+
+describe('runTextIngest — happy path', () => {
+  it('returns ok with DSL when LLM produces a complete recipe', async () => {
+    const recipe = happyRecipeJson();
+    __setTextIngestClientForTests(buildMockClient(async () => mockMessage(JSON.stringify(recipe))));
+
+    const result = await runTextIngest(
+      { kind: 'text', sourceId: 42, body: 'Smash burger with brioche buns and onions.' },
+      ctx
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('unreachable');
+    expect(result.dsl).toContain('@recipe(');
+    expect(result.dsl).toContain('@yield(');
+    expect(result.dsl).toContain('@ingredient(1, beef-chuck:ground:whole, 250:g');
+    expect(result.dsl).toContain('@step(');
+    expect(result.partialReason).toBeUndefined();
+    expect(result.meta.stages['llm_extract']).toMatchObject({
+      ok: true,
+      model: 'claude-haiku-4-5-20251001',
+      prompt_version: 'text-v1.0',
+      input_tokens: 100,
+      output_tokens: 150,
+    });
+    expect(capturedLogs.length).toBe(1);
+    expect(capturedLogs[0]?.operation).toBe('recipe-extract-text');
+    expect(capturedLogs[0]?.contextId).toBe('ingest_source:42');
+  });
+
+  it('produces DSL whose lines satisfy the PRD-114 grammar shape', async () => {
+    __setTextIngestClientForTests(
+      buildMockClient(async () => mockMessage(JSON.stringify(happyRecipeJson())))
+    );
+    const result = await runTextIngest(
+      { kind: 'text', sourceId: 7, body: 'A perfectly fine recipe body.' },
+      ctx
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('unreachable');
+    const lines = result.dsl.split('\n');
+    const recipeLine = lines.find((l) => l.startsWith('@recipe('));
+    const yieldLine = lines.find((l) => l.startsWith('@yield('));
+    expect(recipeLine).toMatch(/^@recipe\(slug=[a-z][a-z0-9-]*, title="[^"]+".*\)$/);
+    expect(yieldLine).toMatch(/^@yield\([a-z][a-z0-9-]*, \d+(?:\.\d+)?:[a-z][a-z0-9-]*\)$/);
+    const ingredientLines = lines.filter((l) => l.startsWith('@ingredient('));
+    expect(ingredientLines.length).toBe(3);
+    ingredientLines.forEach((line, idx) => {
+      expect(line).toMatch(new RegExp(`^@ingredient\\(${idx + 1}, [a-z][a-z0-9_:-]*, `));
+    });
+    const stepLines = lines.filter((l) => l.startsWith('@step('));
+    expect(stepLines.length).toBe(2);
+    stepLines.forEach((line) => {
+      expect(line).toMatch(/^@step\("[^"]+"(?:, duration=\d+(?:\.\d+)?:min)?\)$/);
+    });
+  });
+
+  it('flags partial when LLM returns 0 ingredients', async () => {
+    const recipe = happyRecipeJson({ ingredients: [] });
+    __setTextIngestClientForTests(buildMockClient(async () => mockMessage(JSON.stringify(recipe))));
+    const result = await runTextIngest(
+      { kind: 'text', sourceId: 1, body: 'A short note about food.' },
+      ctx
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('unreachable');
+    expect(result.partialReason).toBe('empty-extraction');
+  });
+
+  it('flags partial when LLM returns 0 steps', async () => {
+    const recipe = happyRecipeJson({ steps: [] });
+    __setTextIngestClientForTests(buildMockClient(async () => mockMessage(JSON.stringify(recipe))));
+    const result = await runTextIngest(
+      { kind: 'text', sourceId: 1, body: 'A short note about food.' },
+      ctx
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('unreachable');
+    expect(result.partialReason).toBe('empty-extraction');
+  });
+});
+
+describe('runTextIngest — rough idea elaboration', () => {
+  it('accepts a rough idea body and emits DSL from the LLM elaboration', async () => {
+    const elaborated = happyRecipeJson({ summary: 'Generated from rough idea.' });
+    __setTextIngestClientForTests(
+      buildMockClient(async () => mockMessage(JSON.stringify(elaborated)))
+    );
+    const result = await runTextIngest(
+      { kind: 'text', sourceId: 1, body: 'smash burger with caramelised onions' },
+      ctx
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('unreachable');
+    expect(result.dsl).toContain('Generated from rough idea');
+  });
+});
+
+describe('runTextIngest — error paths', () => {
+  it('records truncation when body exceeds 20K chars', async () => {
+    const oversized = 'x'.repeat(25_000);
+    let receivedPrompt = '';
+    __setTextIngestClientForTests({
+      messages: {
+        create: vi.fn(async (params) => {
+          const msg = params.messages[0];
+          receivedPrompt = typeof msg?.content === 'string' ? msg.content : '';
+          return mockMessage(JSON.stringify(happyRecipeJson()));
+        }),
+      },
+    });
+    const result = await runTextIngest({ kind: 'text', sourceId: 1, body: oversized }, ctx);
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('unreachable');
+    const stage = result.meta.stages['input_validate'] as Record<string, unknown>;
+    expect(stage).toMatchObject({ ok: true, truncated: true });
+    expect(stage['length']).toBe(20_000);
+    expect(receivedPrompt.length).toBeLessThan(oversized.length + 5_000);
+  });
+
+  it('fails with LlmExtractFailed when the response is not JSON', async () => {
+    __setTextIngestClientForTests(buildMockClient(async () => mockMessage('not json at all')));
+    const result = await runTextIngest(
+      { kind: 'text', sourceId: 1, body: 'asdjkfhlasjdkfh garbage gibberish' },
+      ctx
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.errorCode).toBe('LlmExtractFailed');
+    expect(result.errorMessage).toMatch(/non-JSON/);
+  });
+
+  it('fails with LlmExtractFailed on schema violation (missing title)', async () => {
+    __setTextIngestClientForTests(
+      buildMockClient(async () =>
+        mockMessage(JSON.stringify({ ingredients: [], steps: [], servings: 2 }))
+      )
+    );
+    const result = await runTextIngest(
+      { kind: 'text', sourceId: 1, body: 'gibberish that maps to nothing' },
+      ctx
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.errorCode).toBe('LlmExtractFailed');
+    expect(result.errorMessage).toMatch(/title/);
+  });
+
+  it('captures multi-recipe input by extracting only the first recipe', async () => {
+    const recipe = happyRecipeJson();
+    __setTextIngestClientForTests(buildMockClient(async () => mockMessage(JSON.stringify(recipe))));
+    const multi = 'Recipe 1: smash burger ...\n\nRecipe 2: caesar salad ...';
+    const result = await runTextIngest({ kind: 'text', sourceId: 1, body: multi }, ctx);
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('unreachable');
+    expect(result.dsl).toContain('smash-burger');
+    expect(result.dsl).not.toContain('caesar-salad');
+  });
+
+  it('fails when ANTHROPIC_API_KEY is unset', async () => {
+    delete process.env['ANTHROPIC_API_KEY'];
+    const result = await runTextIngest(
+      { kind: 'text', sourceId: 1, body: 'A perfectly fine recipe body.' },
+      ctx
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.errorCode).toBe('LlmExtractFailed');
+    expect(result.errorMessage).toMatch(/ANTHROPIC_API_KEY/);
+  });
+});
+
+describe('extractWithClaudeText — shared surface', () => {
+  it('writes operation=recipe-extract-ig-text-fallback when called with that source', async () => {
+    __setTextIngestClientForTests(
+      buildMockClient(async () => mockMessage(JSON.stringify(happyRecipeJson())))
+    );
+    const result = await extractWithClaudeText({
+      body: 'transcribed caption',
+      source: 'ig-text-fallback',
+      contextId: 'ingest_source:99',
+    });
+    expect(result.ok).toBe(true);
+    expect(capturedLogs[0]?.operation).toBe('recipe-extract-ig-text-fallback');
+  });
+});

--- a/apps/pops-worker-food/src/handlers/build-dsl.ts
+++ b/apps/pops-worker-food/src/handlers/build-dsl.ts
@@ -1,0 +1,163 @@
+import {
+  PREP_STATE_SLUGS,
+  slugify,
+  type ExtractedIngredient,
+  type ExtractedRecipe,
+  type ExtractedStep,
+  type PrepStateSlug,
+} from './extracted-recipe.js';
+
+/**
+ * Source tag flows into `summary` annotations + future telemetry on the
+ * `ingest_sources` row. Kept narrow so callers can't accidentally pass
+ * an arbitrary string.
+ */
+export type DslSource = 'url-web' | 'text' | 'screenshot' | 'ig-text-fallback' | 'ig-vision';
+
+export interface BuildDslOptions {
+  source: DslSource;
+  /** Optional original URL — appears in the recipe summary when present. */
+  url?: string;
+  /** Override the recipe slug when caller already resolved a collision. */
+  slug?: string;
+}
+
+const PREP_STATE_SET = new Set<PrepStateSlug>(PREP_STATE_SLUGS);
+
+function isCuratedPrep(value: string | undefined): value is PrepStateSlug {
+  if (!value) return false;
+  return PREP_STATE_SET.has(value as PrepStateSlug);
+}
+
+function escapeDslString(input: string): string {
+  return input.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n');
+}
+
+function formatNumber(value: number): string {
+  if (Number.isInteger(value)) return String(value);
+  return Number(value.toFixed(3)).toString();
+}
+
+function formatQtyUnit(qty: number, unit: string): string {
+  const unitSlug = slugify(unit) || 'count';
+  return `${formatNumber(qty)}:${unitSlug}`;
+}
+
+function buildDescriptor(ingredient: ExtractedIngredient): {
+  descriptor: string;
+  prepInNotes: string | undefined;
+} {
+  const segments: string[] = [ingredient.ingredient_slug];
+  const variant = ingredient.variant_slug;
+  const prepRaw = ingredient.prep_state_slug;
+  const curatedPrep = isCuratedPrep(prepRaw) ? prepRaw : undefined;
+  const prepInNotes = prepRaw && !curatedPrep ? prepRaw : undefined;
+
+  if (variant && curatedPrep) {
+    segments.push(variant, curatedPrep);
+  } else if (variant) {
+    segments.push(variant);
+  } else if (curatedPrep) {
+    segments.push('_', curatedPrep);
+  }
+  return { descriptor: segments.join(':'), prepInNotes };
+}
+
+function buildIngredientLine(ingredient: ExtractedIngredient, index: number): string {
+  const { descriptor, prepInNotes } = buildDescriptor(ingredient);
+  const qtyUnit = formatQtyUnit(ingredient.qty, ingredient.unit);
+  const named: string[] = [];
+  if (ingredient.optional) named.push('optional=true');
+  const noteParts: string[] = [];
+  if (ingredient.notes) noteParts.push(ingredient.notes);
+  if (prepInNotes) noteParts.push(`prep: ${prepInNotes}`);
+  if (ingredient.original_text && ingredient.original_text !== ingredient.ingredient_slug) {
+    noteParts.push(`source: ${ingredient.original_text}`);
+  }
+  if (noteParts.length > 0) {
+    named.push(`notes="${escapeDslString(noteParts.join(' — '))}"`);
+  }
+  const tail = named.length > 0 ? `, ${named.join(', ')}` : '';
+  return `@ingredient(${index}, ${descriptor}, ${qtyUnit}${tail})`;
+}
+
+function buildStepLine(step: ExtractedStep): string {
+  const named: string[] = [];
+  if (step.duration_minutes != null && Number.isFinite(step.duration_minutes)) {
+    named.push(`duration=${formatQtyUnit(step.duration_minutes, 'min')}`);
+  }
+  const tail = named.length > 0 ? `, ${named.join(', ')}` : '';
+  return `@step("${escapeDslString(step.body)}"${tail})`;
+}
+
+function deriveYieldSlug(parsed: ExtractedRecipe, recipeSlug: string): string {
+  const explicit = parsed.yield_slug;
+  if (explicit && explicit !== '') return explicit;
+  return recipeSlug;
+}
+
+function buildRecipeHeaderArgs(
+  parsed: ExtractedRecipe,
+  recipeSlug: string,
+  opts: BuildDslOptions
+): string[] {
+  const args: string[] = [`slug=${recipeSlug}`, `title="${escapeDslString(parsed.title)}"`];
+  if (parsed.servings != null && Number.isFinite(parsed.servings)) {
+    args.push(`servings=${formatNumber(parsed.servings)}`);
+  }
+  if (parsed.prep_time_minutes != null && Number.isFinite(parsed.prep_time_minutes)) {
+    args.push(`prep_time=${formatQtyUnit(parsed.prep_time_minutes, 'min')}`);
+  }
+  if (parsed.cook_time_minutes != null && Number.isFinite(parsed.cook_time_minutes)) {
+    args.push(`cook_time=${formatQtyUnit(parsed.cook_time_minutes, 'min')}`);
+  }
+  const summary = composeSummary(parsed, opts);
+  if (summary) args.push(`summary="${escapeDslString(summary)}"`);
+  return args;
+}
+
+function composeSummary(parsed: ExtractedRecipe, opts: BuildDslOptions): string | undefined {
+  const parts: string[] = [];
+  if (parsed.summary && parsed.summary.trim() !== '') parts.push(parsed.summary.trim());
+  if (opts.source === 'text' && parsed.ingredients.length === 0) {
+    parts.push('Generated from rough idea.');
+  }
+  if (opts.url) parts.push(`Source: ${opts.url}`);
+  return parts.length > 0 ? parts.join(' ') : undefined;
+}
+
+/**
+ * Render the LLM-extracted recipe as a PRD-114 DSL string. Pure function
+ * — no DB lookups, no slug-collision suffixing here (PRD-119's
+ * `recipes.create` mutation owns that via `slug_registry`).
+ *
+ * Invariants:
+ *   - First non-comment line is `@recipe(...)`.
+ *   - `@yield(...)` follows immediately.
+ *   - Ingredients indexed sequentially from 1.
+ *   - Descriptors use `_` to skip variant when only `prep` is set.
+ *   - Non-curated `prep_state_slug` values are pushed to `notes`.
+ *   - Step bodies emitted verbatim (the prompt may already embed
+ *     `@<slug>` inline references — PRD-114 parses those).
+ */
+export function buildDsl(parsed: ExtractedRecipe, opts: BuildDslOptions): string {
+  const recipeSlug = opts.slug ?? slugify(parsed.title) ?? 'recipe';
+  const finalSlug = recipeSlug === '' ? 'recipe' : recipeSlug;
+  const headerArgs = buildRecipeHeaderArgs(parsed, finalSlug, opts);
+
+  const yieldDescriptor = deriveYieldSlug(parsed, finalSlug);
+  const yieldQty =
+    parsed.yield_qty != null && Number.isFinite(parsed.yield_qty) ? parsed.yield_qty : 1;
+  const yieldUnit =
+    parsed.yield_unit && parsed.yield_unit.trim() !== '' ? parsed.yield_unit : 'serving';
+  const yieldLine = `@yield(${yieldDescriptor}, ${formatQtyUnit(yieldQty, yieldUnit)})`;
+
+  const ingredientLines = parsed.ingredients.map((ing, i) => buildIngredientLine(ing, i + 1));
+  const stepLines = parsed.steps.map(buildStepLine);
+
+  const lines = [`@recipe(${headerArgs.join(', ')})`, yieldLine, '', ...ingredientLines];
+  if (stepLines.length > 0) {
+    lines.push('', ...stepLines);
+  }
+  return lines.join('\n') + '\n';
+}

--- a/apps/pops-worker-food/src/handlers/build-dsl.ts
+++ b/apps/pops-worker-food/src/handlers/build-dsl.ts
@@ -117,11 +117,13 @@ function buildRecipeHeaderArgs(
 }
 
 function composeSummary(parsed: ExtractedRecipe, opts: BuildDslOptions): string | undefined {
+  // The text prompt instructs the LLM to mark rough-idea elaborations in
+  // `summary` itself; trust the model's signal rather than inferring
+  // "rough idea" from an empty `ingredients` array (which actually means
+  // a partial / failed extraction — those land in the review queue with
+  // `partialReason='empty-extraction'`, not as rough ideas).
   const parts: string[] = [];
   if (parsed.summary && parsed.summary.trim() !== '') parts.push(parsed.summary.trim());
-  if (opts.source === 'text' && parsed.ingredients.length === 0) {
-    parts.push('Generated from rough idea.');
-  }
   if (opts.url) parts.push(`Source: ${opts.url}`);
   return parts.length > 0 ? parts.join(' ') : undefined;
 }

--- a/apps/pops-worker-food/src/handlers/extract-with-claude.ts
+++ b/apps/pops-worker-food/src/handlers/extract-with-claude.ts
@@ -1,0 +1,181 @@
+import {
+  createAnthropicClient,
+  type AnthropicLike,
+  type AnthropicMessage,
+} from '../ai/anthropic.js';
+import { callClaudeWithLogging, type CallClaudeWithLoggingOpts } from '../ai/log-inference.js';
+import { PROMPT_VERSION_TEXT, renderTextPrompt } from '../prompts/text.js';
+import { extractedRecipeSchema, type ExtractedRecipe } from './extracted-recipe.js';
+
+import type { ZodError } from 'zod';
+
+const DEFAULT_MODEL = 'claude-haiku-4-5-20251001';
+const MAX_OUTPUT_TOKENS = 2048;
+
+export function getTextModel(): string {
+  return process.env['FOOD_TEXT_LLM_MODEL'] ?? DEFAULT_MODEL;
+}
+
+function getApiKey(): string | null {
+  const key = process.env['ANTHROPIC_API_KEY'];
+  return key && key !== '' ? key : null;
+}
+
+let cachedClient: AnthropicLike | null = null;
+let cachedClientKey: string | null = null;
+
+let testClientOverride: AnthropicLike | null = null;
+let testLogOverride: CallClaudeWithLoggingOpts['onLog'] | null = null;
+
+export function __setTextIngestClientForTests(client: AnthropicLike | null): void {
+  testClientOverride = client;
+}
+
+export function __setTextIngestLogForTests(onLog: CallClaudeWithLoggingOpts['onLog'] | null): void {
+  testLogOverride = onLog ?? null;
+}
+
+function resolveClient(apiKey: string): AnthropicLike {
+  if (testClientOverride) return testClientOverride;
+  if (cachedClient && cachedClientKey === apiKey) return cachedClient;
+  cachedClient = createAnthropicClient(apiKey);
+  cachedClientKey = apiKey;
+  return cachedClient;
+}
+
+export interface TextExtractInput {
+  body: string;
+  /** Picks the `ai_inference_log.operation` value — schema + prompt are identical. */
+  source: 'text' | 'ig-text-fallback';
+  contextId: string;
+}
+
+export interface TextExtractSuccess {
+  ok: true;
+  parsed: ExtractedRecipe;
+  rawOutput: string;
+  message: AnthropicMessage;
+  durationMs: number;
+}
+
+export interface TextExtractFailure {
+  ok: false;
+  errorMessage: string;
+  rawOutput?: string;
+  durationMs: number;
+}
+
+export type TextExtractResult = TextExtractSuccess | TextExtractFailure;
+
+function extractTextOutput(message: AnthropicMessage): string | null {
+  for (const block of message.content) {
+    if (block.type === 'text' && typeof block.text === 'string') return block.text;
+  }
+  return null;
+}
+
+function formatZodIssues(error: ZodError): string {
+  return error.issues
+    .slice(0, 3)
+    .map((issue) => `${issue.path.join('.') || '<root>'}: ${issue.message}`)
+    .join('; ');
+}
+
+function pickOperation(source: TextExtractInput['source']): string {
+  return source === 'ig-text-fallback' ? 'recipe-extract-ig-text-fallback' : 'recipe-extract-text';
+}
+
+async function callClaude(
+  input: TextExtractInput,
+  client: AnthropicLike,
+  model: string,
+  prompt: string
+): Promise<
+  { ok: true; message: AnthropicMessage; durationMs: number } | { ok: false; errorMessage: string }
+> {
+  try {
+    const result = await callClaudeWithLogging({
+      operation: pickOperation(input.source),
+      model,
+      promptVersion: PROMPT_VERSION_TEXT,
+      contextId: input.contextId,
+      call: () =>
+        client.messages.create({
+          model,
+          max_tokens: MAX_OUTPUT_TOKENS,
+          temperature: 0,
+          messages: [{ role: 'user', content: prompt }],
+        }),
+      ...(testLogOverride ? { onLog: testLogOverride } : {}),
+    });
+    return { ok: true, message: result.message, durationMs: result.durationMs };
+  } catch (err) {
+    return {
+      ok: false,
+      errorMessage: `Claude call failed: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}
+
+type ParseOutcome = { ok: true; parsed: ExtractedRecipe } | { ok: false; errorMessage: string };
+
+function parseAndValidate(rawOutput: string): ParseOutcome {
+  let json: unknown;
+  try {
+    json = JSON.parse(rawOutput);
+  } catch (err) {
+    return {
+      ok: false,
+      errorMessage: `Claude returned non-JSON output: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+  const parsedResult = extractedRecipeSchema.safeParse(json);
+  if (!parsedResult.success) {
+    return { ok: false, errorMessage: `Schema violation: ${formatZodIssues(parsedResult.error)}` };
+  }
+  return { ok: true, parsed: parsedResult.data };
+}
+
+/**
+ * Shared text-LLM extraction surface. PRD-132's `runTextIngest` calls
+ * with `source='text'`; PRD-130's vision-fallback path calls with
+ * `source='ig-text-fallback'`. The prompt template, JSON schema, and
+ * model are identical — only the `operation` written to
+ * `ai_inference_log` differs.
+ */
+export async function extractWithClaudeText(input: TextExtractInput): Promise<TextExtractResult> {
+  const apiKey = getApiKey();
+  if (!apiKey) {
+    return { ok: false, errorMessage: 'ANTHROPIC_API_KEY not set', durationMs: 0 };
+  }
+  const model = getTextModel();
+  const client = resolveClient(apiKey);
+  const callResult = await callClaude(input, client, model, renderTextPrompt(input.body));
+  if (!callResult.ok) {
+    return { ok: false, errorMessage: callResult.errorMessage, durationMs: 0 };
+  }
+  const rawOutput = extractTextOutput(callResult.message);
+  if (rawOutput == null) {
+    return {
+      ok: false,
+      errorMessage: 'Claude response had no text content',
+      durationMs: callResult.durationMs,
+    };
+  }
+  const parsed = parseAndValidate(rawOutput);
+  if (!parsed.ok) {
+    return {
+      ok: false,
+      errorMessage: parsed.errorMessage,
+      rawOutput,
+      durationMs: callResult.durationMs,
+    };
+  }
+  return {
+    ok: true,
+    parsed: parsed.parsed,
+    rawOutput,
+    message: callResult.message,
+    durationMs: callResult.durationMs,
+  };
+}

--- a/apps/pops-worker-food/src/handlers/extract-with-claude.ts
+++ b/apps/pops-worker-food/src/handlers/extract-with-claude.ts
@@ -91,8 +91,10 @@ async function callClaude(
   model: string,
   prompt: string
 ): Promise<
-  { ok: true; message: AnthropicMessage; durationMs: number } | { ok: false; errorMessage: string }
+  | { ok: true; message: AnthropicMessage; durationMs: number }
+  | { ok: false; errorMessage: string; durationMs: number }
 > {
+  const start = Date.now();
   try {
     const result = await callClaudeWithLogging({
       operation: pickOperation(input.source),
@@ -113,6 +115,7 @@ async function callClaude(
     return {
       ok: false,
       errorMessage: `Claude call failed: ${err instanceof Error ? err.message : String(err)}`,
+      durationMs: Date.now() - start,
     };
   }
 }
@@ -152,7 +155,7 @@ export async function extractWithClaudeText(input: TextExtractInput): Promise<Te
   const client = resolveClient(apiKey);
   const callResult = await callClaude(input, client, model, renderTextPrompt(input.body));
   if (!callResult.ok) {
-    return { ok: false, errorMessage: callResult.errorMessage, durationMs: 0 };
+    return { ok: false, errorMessage: callResult.errorMessage, durationMs: callResult.durationMs };
   }
   const rawOutput = extractTextOutput(callResult.message);
   if (rawOutput == null) {

--- a/apps/pops-worker-food/src/handlers/extracted-recipe.ts
+++ b/apps/pops-worker-food/src/handlers/extracted-recipe.ts
@@ -40,7 +40,12 @@ const SLUG_RE = /^[a-z][a-z0-9-]*$/;
 
 const numericLike = z.union([z.number(), z.string()]).transform((value, ctx) => {
   if (typeof value === 'number') return value;
-  const parsed = Number(value);
+  const trimmed = value.trim();
+  if (trimmed === '') {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'empty numeric value' });
+    return z.NEVER;
+  }
+  const parsed = Number(trimmed);
   if (!Number.isFinite(parsed)) {
     ctx.addIssue({ code: z.ZodIssueCode.custom, message: `not a number: ${value}` });
     return z.NEVER;

--- a/apps/pops-worker-food/src/handlers/extracted-recipe.ts
+++ b/apps/pops-worker-food/src/handlers/extracted-recipe.ts
@@ -1,0 +1,101 @@
+import { z } from 'zod';
+
+/**
+ * Curated prep-state list per PRD-128 §Step 2 / PRD-132 §Prompt. Slugs
+ * outside this list get pushed into the ingredient `notes` field by
+ * `buildDsl` instead of being emitted as a descriptor segment.
+ */
+export const PREP_STATE_SLUGS = [
+  'whole',
+  'diced',
+  'sliced',
+  'chopped',
+  'shredded',
+  'minced',
+  'julienned',
+  'grated',
+  'crushed',
+  'zested',
+  'juiced',
+  'melted',
+  'softened',
+  'mashed',
+  'roughly-chopped',
+] as const;
+
+export type PrepStateSlug = (typeof PREP_STATE_SLUGS)[number];
+
+const COMBINING_MARKS_RE = /[̀-ͯ]/g;
+
+export function slugify(input: string): string {
+  return input
+    .normalize('NFKD')
+    .replace(COMBINING_MARKS_RE, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+const SLUG_RE = /^[a-z][a-z0-9-]*$/;
+
+const numericLike = z.union([z.number(), z.string()]).transform((value, ctx) => {
+  if (typeof value === 'number') return value;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, message: `not a number: ${value}` });
+    return z.NEVER;
+  }
+  return parsed;
+});
+
+const optionalNumericLike = numericLike.optional();
+
+const slugSchema = z
+  .string()
+  .min(1)
+  .transform(slugify)
+  .refine((s) => SLUG_RE.test(s), { message: 'invalid slug' });
+
+const optionalSlugSchema = z
+  .string()
+  .optional()
+  .transform((s) => {
+    if (s == null || s === '') return undefined;
+    const cleaned = slugify(s);
+    return cleaned === '' ? undefined : cleaned;
+  })
+  .refine((s) => s === undefined || SLUG_RE.test(s), { message: 'invalid slug' });
+
+const ingredientSchema = z.object({
+  qty: numericLike,
+  unit: z.string().min(1),
+  ingredient_slug: slugSchema,
+  variant_slug: optionalSlugSchema,
+  prep_state_slug: z.string().optional(),
+  original_text: z.string().optional(),
+  optional: z.boolean().optional().default(false),
+  notes: z.string().optional(),
+});
+
+const stepSchema = z.object({
+  body: z.string().min(1),
+  duration_minutes: optionalNumericLike,
+});
+
+export const extractedRecipeSchema = z.object({
+  title: z.string().min(1),
+  summary: z.string().optional(),
+  servings: optionalNumericLike,
+  prep_time_minutes: optionalNumericLike,
+  cook_time_minutes: optionalNumericLike,
+  yield_slug: optionalSlugSchema,
+  yield_qty: optionalNumericLike,
+  yield_unit: z.string().optional(),
+  tags: z.array(z.string()).optional().default([]),
+  ingredients: z.array(ingredientSchema).default([]),
+  steps: z.array(stepSchema).default([]),
+});
+
+export type ExtractedRecipe = z.infer<typeof extractedRecipeSchema>;
+export type ExtractedIngredient = ExtractedRecipe['ingredients'][number];
+export type ExtractedStep = ExtractedRecipe['steps'][number];

--- a/apps/pops-worker-food/src/handlers/text.ts
+++ b/apps/pops-worker-food/src/handlers/text.ts
@@ -1,11 +1,139 @@
-import { notImplementedResult } from './not-implemented.js';
+import { PROMPT_VERSION_TEXT } from '../prompts/text.js';
+import { buildDsl } from './build-dsl.js';
+import { extractWithClaudeText, getTextModel } from './extract-with-claude.js';
 
+import type {
+  IngestJobResult,
+  IngestMeta,
+  IngestStageRecord,
+  PartialReason,
+} from '@pops/food-contracts';
+
+import type { TextExtractFailure, TextExtractSuccess } from './extract-with-claude.js';
 import type { IngestHandler } from './types.js';
 
+export {
+  __setTextIngestClientForTests,
+  __setTextIngestLogForTests,
+  extractWithClaudeText,
+  type TextExtractInput,
+  type TextExtractResult,
+} from './extract-with-claude.js';
+
+const MIN_BODY_LENGTH = 10;
+const MAX_BODY_LENGTH = 20_000;
+const EXTRACTOR_VERSION = 'pops-worker-food/text@0.1.0';
+
+function buildBaseMeta(stages: Record<string, IngestStageRecord>): IngestMeta {
+  return { extractor_version: EXTRACTOR_VERSION, stages };
+}
+
+function tryParse(raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}
+
+function emptyTextResult(length: number): IngestJobResult {
+  return {
+    ok: false,
+    errorCode: 'EmptyText',
+    errorMessage: `Body must be at least ${MIN_BODY_LENGTH} non-whitespace characters.`,
+    meta: buildBaseMeta({ input_validate: { ok: false, length, reason: 'below-min' } }),
+  };
+}
+
+function cancelledResult(length: number, truncated: boolean): IngestJobResult {
+  return {
+    ok: false,
+    errorCode: 'Cancelled',
+    errorMessage: 'Job cancelled before LLM call.',
+    meta: buildBaseMeta({ input_validate: { ok: true, length, truncated } }),
+  };
+}
+
+function llmFailureResult(
+  body: string,
+  truncated: boolean,
+  extract: TextExtractFailure
+): IngestJobResult {
+  const llmStage: IngestStageRecord = {
+    ok: false,
+    duration_ms: extract.durationMs,
+    model: getTextModel(),
+    prompt_version: PROMPT_VERSION_TEXT,
+    reason: extract.errorMessage,
+  };
+  if (extract.rawOutput !== undefined) {
+    llmStage['raw_output_preview'] = extract.rawOutput.slice(0, 1024);
+  }
+  return {
+    ok: false,
+    errorCode: 'LlmExtractFailed',
+    errorMessage: extract.errorMessage,
+    meta: buildBaseMeta({
+      input_validate: { ok: true, length: body.length, truncated },
+      llm_extract: llmStage,
+    }),
+  };
+}
+
+function successResult(
+  body: string,
+  truncated: boolean,
+  extract: TextExtractSuccess
+): IngestJobResult {
+  const dslBuildStart = Date.now();
+  const dsl = buildDsl(extract.parsed, { source: 'text' });
+  const dslBuildMs = Date.now() - dslBuildStart;
+
+  const partialReason: PartialReason | undefined =
+    extract.parsed.ingredients.length === 0 || extract.parsed.steps.length === 0
+      ? 'empty-extraction'
+      : undefined;
+
+  const meta: IngestMeta = {
+    ...buildBaseMeta({
+      input_validate: { ok: true, length: body.length, truncated },
+      llm_extract: {
+        ok: true,
+        duration_ms: extract.durationMs,
+        model: getTextModel(),
+        prompt_version: PROMPT_VERSION_TEXT,
+        input_tokens: extract.message.usage?.input_tokens,
+        output_tokens: extract.message.usage?.output_tokens,
+      },
+      dsl_build: { ok: true, duration_ms: dslBuildMs },
+    }),
+    llm_raw_output: tryParse(extract.rawOutput),
+  };
+
+  return partialReason ? { ok: true, dsl, meta, partialReason } : { ok: true, dsl, meta };
+}
+
 /**
- * Text ingest. Real pipeline lives in PRD-132 (paste → Claude text).
- * Stub for PRD-126.
+ * PRD-132 — text ingest. The whole pipeline is a length check + one
+ * Claude call + DSL render. Cancellation between stages only; mid-call
+ * cancellation is out of scope per PRD §Business Rules.
  */
-export const runTextIngest: IngestHandler<'text'> = async (_data, _ctx) => {
-  return notImplementedResult('text');
+export const runTextIngest: IngestHandler<'text'> = async (data, ctx) => {
+  const trimmed = (data.body ?? '').trim();
+  if (trimmed.length < MIN_BODY_LENGTH) return emptyTextResult(trimmed.length);
+
+  const truncated = trimmed.length > MAX_BODY_LENGTH;
+  const body = truncated ? trimmed.slice(0, MAX_BODY_LENGTH) : trimmed;
+
+  if (await ctx.isCancelled()) return cancelledResult(body.length, truncated);
+
+  const extract = await extractWithClaudeText({
+    body,
+    source: 'text',
+    contextId: `ingest_source:${data.sourceId}`,
+  });
+
+  return extract.ok
+    ? successResult(body, truncated, extract)
+    : llmFailureResult(body, truncated, extract);
 };

--- a/apps/pops-worker-food/src/handlers/text.ts
+++ b/apps/pops-worker-food/src/handlers/text.ts
@@ -40,7 +40,7 @@ function emptyTextResult(length: number): IngestJobResult {
   return {
     ok: false,
     errorCode: 'EmptyText',
-    errorMessage: `Body must be at least ${MIN_BODY_LENGTH} non-whitespace characters.`,
+    errorMessage: `Body must be at least ${MIN_BODY_LENGTH} characters after trimming.`,
     meta: buildBaseMeta({ input_validate: { ok: false, length, reason: 'below-min' } }),
   };
 }

--- a/apps/pops-worker-food/src/prompts/text.ts
+++ b/apps/pops-worker-food/src/prompts/text.ts
@@ -1,0 +1,70 @@
+/**
+ * PRD-132 — text-ingest prompt template.
+ *
+ * Versioned via `PROMPT_VERSION_TEXT`; bump on every prompt change so
+ * `ai_inference_log.metadata.prompt_version` + `meta.json.stages.llm_extract.prompt_version`
+ * tie back to the exact template that produced an extraction.
+ *
+ * The JSON schema mirrors PRD-128's (web-LLM fallback) so the same
+ * `extractedRecipeSchema` zod validator + `buildDsl` mapper are reused
+ * across kinds.
+ */
+export const PROMPT_VERSION_TEXT = 'text-v1.0';
+
+const PREP_STATE_LIST =
+  'whole, diced, sliced, chopped, shredded, minced, julienned, grated, crushed, zested, juiced, melted, softened, mashed, roughly-chopped';
+
+const SCHEMA_BLOCK = `{
+  "title": "string — the recipe name",
+  "summary": "string — one or two sentences describing the dish (optional)",
+  "servings": number,
+  "prep_time_minutes": number (optional),
+  "cook_time_minutes": number (optional),
+  "yield_slug": "string — kebab-case slug for the produced ingredient",
+  "yield_qty": number,
+  "yield_unit": "count | serving | g | ml",
+  "tags": ["string", ...] (cuisine, meal type, dietary — short list),
+  "ingredients": [
+    {
+      "qty": number,
+      "unit": "string — g, ml, count, cup, tbsp, tsp, oz, lb (any plain-text unit)",
+      "ingredient_slug": "string — kebab-case slug for the ingredient",
+      "variant_slug": "string (optional) — kebab-case slug for variant",
+      "prep_state_slug": "string (optional) — one of the curated values",
+      "original_text": "string — the ingredient as it appeared in the input",
+      "optional": boolean (default false),
+      "notes": "string (optional)"
+    }
+  ],
+  "steps": [
+    {
+      "body": "string — the step instruction; may reference ingredients by slug like @beef-chuck",
+      "duration_minutes": number (optional)
+    }
+  ]
+}`;
+
+export const TEXT_PROMPT_TEMPLATE = `You are extracting (or elaborating on) a recipe from plain text. The text may be:
+- A complete recipe (ingredients + steps)
+- A rough recipe idea ("smash burger with caramelised onions") — in which case ELABORATE it into a full recipe, drawing on common cooking knowledge.
+- A transcribed recipe (e.g. from a video) — clean it up and structure it.
+- A recipe shared in a message format (SMS, chat) — normalise.
+
+INPUT:
+{body}
+
+Extract or elaborate a recipe as JSON. Use this exact schema:
+
+${SCHEMA_BLOCK}
+
+Rules:
+- For ROUGH IDEAS: invent reasonable quantities and steps; mark \`summary\` with "Generated from rough idea".
+- For COMPLETE RECIPES: stick close to the input; don't invent.
+- Use metric units when reasonable.
+- prep_state_slug MUST be one of: ${PREP_STATE_LIST}.
+- Output ONLY the JSON. No markdown, no explanation.
+`;
+
+export function renderTextPrompt(body: string): string {
+  return TEXT_PROMPT_TEMPLATE.replace('{body}', body);
+}

--- a/docs/themes/07-food/prds/130-instagram-stt-vision/README.md
+++ b/docs/themes/07-food/prds/130-instagram-stt-vision/README.md
@@ -297,7 +297,7 @@ Prompt as TS constant in `apps/pops-worker-food/src/prompts/ig-vision.ts`. Read-
 - Acquisition failure (PRD-129) is **terminal for the success path** — no degradation can recover from auth-dead / rate-limited / missing-artifacts. PRD-130 just converts these to the right `IngestJobResult` shape.
 - STT failure is recoverable — caption + vision can still produce a useful draft. Marked partial.
 - Vision failure with no caption is **terminal** — no useful path forward. Failed.
-- Vision failure WITH caption falls through to text-LLM extraction. The fallback reuses PRD-128's `PROMPT_WEB_LLM` via the shared `extractWithClaudeText` helper from PRD-132. AI usage logs the call as `operation='recipe-extract-ig-text-fallback'` (distinct from `recipe-extract-web-llm`) but the prompt version recorded is `web-llm-vN` (the shared prompt's version).
+- Vision failure WITH caption falls through to text-LLM extraction. The fallback calls the shared `extractWithClaudeText` helper from PRD-132 with `source='ig-text-fallback'`; the helper uses PRD-132's `PROMPT_VERSION_TEXT` template (`text-v1.0`) — same JSON output schema as PRD-128's web-LLM path, but the prompt itself is the text-ingest template (permissive on input shape, no readability/page-title scaffolding). AI usage logs the call as `operation='recipe-extract-ig-text-fallback'` and `metadata.prompt_version='text-vN'`.
 - Empty caption + STT skipped (heuristic false-positive) — STT runs anyway because the empty caption can't be structured. The heuristic's `caption.length < 100` check covers this.
 - Concurrent invocations: each runs in its own `${FOOD_INGEST_DIR}/<sourceId>/` workdir; no shared state. Memory pressure from concurrent faster-whisper handled by `FOOD_WORKER_CONCURRENCY` (default 2).
 - Cancellation checked between stages: after acquisition, after STT, after keyframes, before vision call. Mid-vision-call cancellation NOT supported.
@@ -358,8 +358,8 @@ Inline per theme protocol.
 
 ### Text-LLM fallback
 
-- [ ] When vision fails AND caption is non-trivial (>30 chars), invoke text-LLM via `extractWithClaudeText` — the shared helper exported by PRD-132. The fallback **reuses PRD-128's `PROMPT_WEB_LLM`** template (same extraction schema, applies cleanly to caption text).
-- [ ] `ai_inference_log` row uses `operation='recipe-extract-ig-text-fallback'` (distinct operation enum value per PRD-133) but `metadata.prompt_version='web-llm-vN'` (same prompt version that PRD-128 uses) — the operation distinguishes the _call context_ in observability; the prompt template is shared.
+- [ ] When vision fails AND caption is non-trivial (>30 chars), invoke text-LLM via `extractWithClaudeText` — the shared helper exported by PRD-132. The fallback uses **PRD-132's text-ingest prompt** (`PROMPT_VERSION_TEXT`); the JSON output schema is shared with PRD-128.
+- [ ] `ai_inference_log` row uses `operation='recipe-extract-ig-text-fallback'` (distinct operation enum value per PRD-133) and `metadata.prompt_version='text-vN'` — the operation distinguishes the _call context_ in observability; the prompt template is the same one PRD-132's text-ingest uses.
 
 ### Meta & logging
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -416,6 +416,9 @@ importers:
 
   apps/pops-worker-food:
     dependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.100.1
+        version: 0.100.1(zod@4.4.3)
       '@pops/food-contracts':
         specifier: workspace:*
         version: link:../../packages/food-contracts
@@ -431,6 +434,9 @@ importers:
       pino:
         specifier: ^10.3.1
         version: 10.3.1
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@pops/api':
         specifier: workspace:*

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -444,6 +444,9 @@ importers:
       '@pops/app-food':
         specifier: workspace:*
         version: link:../../packages/app-food
+      '@pops/app-food-db':
+        specifier: workspace:*
+        version: link:../../packages/app-food-db
       '@types/node':
         specifier: ^25.9.1
         version: 25.9.1


### PR DESCRIPTION
## Summary

- Replaces the PRD-126 `NotImplemented` stub at `apps/pops-worker-food/src/handlers/text.ts` with the real text-ingest pipeline: validate body (≥10 chars, truncate at 20K) → single Claude call (`claude-haiku-4-5-20251001`, configurable via `FOOD_TEXT_LLM_MODEL`) → JSON parse + zod schema validation → DSL render per PRD-114. Returns `partialReason='empty-extraction'` when the LLM produces 0 ingredients or 0 steps.
- Exports `extractWithClaudeText(input)` as the shared text-LLM surface that PRD-130's vision-text fallback will reuse with `source='ig-text-fallback'` — same prompt, schema, model; only `ai_inference_log.operation` differs. `buildDsl`, `ExtractedRecipe`/`extractedRecipeSchema`, and `AnthropicLike`/`AnthropicMessage` are also exported for PRDs 128/130/131 to consume.
- Local stub of PRD-133's `callClaudeWithLogging` (`src/ai/log-inference.ts`) — fire-and-forget log row through `opts.onLog` (caller-injected so tests don't mock the network). Operation names match PRD-133's `FoodOperationSchema` literals so the swap-in is a one-line change once the canonical wrapper is reachable from the worker without dragging React in (currently lives in the React-dep'd `@pops/app-food`; needs a follow-up extract to a backend-only package).

## Coordination

Strictly additive within `apps/pops-worker-food`. Only touches:
- `src/handlers/text.ts` (stub → real)
- `src/__tests__/dispatch.test.ts` (narrows the "all NotImplemented" assertion to surviving stubs: url-web, url-instagram, screenshot — PRDs 127/129/131 will fill those)
- new helper files under `src/ai/` (`anthropic.ts`, `log-inference.ts`), `src/handlers/` (`build-dsl.ts`, `extract-with-claude.ts`, `extracted-recipe.ts`), `src/prompts/text.ts`
- `package.json` (adds `@anthropic-ai/sdk` + `zod`)

Disjoint from in-flight PRDs (129 instagram acquisition, 119-API recipes router). The PRD-126 dispatcher already wires this in.

## Test plan

- [x] `pnpm typecheck` green (31/31 tasks)
- [x] `pnpm lint` green
- [x] `pnpm format:check` green
- [x] `pnpm test` green (full repo, 32/32 tasks)
- [x] `pnpm build` green (10/10 tasks)
- [x] 16 vitest cases in `apps/pops-worker-food/src/handlers/__tests__/text.test.ts`: below-min/whitespace EmptyText, cancellation pre-LLM, happy path (DSL+meta+log row), DSL grammar-shape regex assertions, partial flagging on 0 ingredients / 0 steps, rough-idea elaboration, oversized truncation, malformed JSON, schema violation, multi-recipe input, missing API key, ig-text-fallback operation name
- [ ] CI green on this PR
- [ ] Copilot review pass