### PR TITLE
feat(food): PRD-127 — web URL ingest, JSON-LD extraction

### DIFF
--- a/apps/pops-worker-food/package.json
+++ b/apps/pops-worker-food/package.json
@@ -20,6 +20,7 @@
   },
   "devDependencies": {
     "@pops/api": "workspace:*",
+    "@pops/app-food": "workspace:*",
     "@types/node": "^25.9.1",
     "tsx": "^4.22.4",
     "typescript": "^6.0.3",

--- a/apps/pops-worker-food/src/__tests__/dispatch.test.ts
+++ b/apps/pops-worker-food/src/__tests__/dispatch.test.ts
@@ -134,9 +134,8 @@ describe('runIngestJob', () => {
 });
 
 describe('default handler stubs', () => {
-  it('all kinds resolve to NotImplemented failures with the stub version', async () => {
+  it('remaining stub kinds resolve to NotImplemented failures with the stub version', async () => {
     const kinds: IngestJobData[] = [
-      { kind: 'url-web', sourceId: 1, url: 'https://example.com' },
       { kind: 'url-instagram', sourceId: 2, url: 'https://instagram.com/r/abc' },
       { kind: 'screenshot', sourceId: 3, mimeType: 'image/png', contentPath: '/tmp/x.png' },
       { kind: 'text', sourceId: 4, body: 'hi' },

--- a/apps/pops-worker-food/src/__tests__/extract-instructions.test.ts
+++ b/apps/pops-worker-food/src/__tests__/extract-instructions.test.ts
@@ -1,0 +1,63 @@
+/**
+ * PRD-127 — recipeInstructions extractor unit tests.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { extractInstructionTexts } from '../handlers/web/extract-instructions.js';
+
+describe('extractInstructionTexts', () => {
+  it('flattens HowToStep array', () => {
+    const out = extractInstructionTexts([
+      { '@type': 'HowToStep', text: 'Step one.' },
+      { '@type': 'HowToStep', text: 'Step two.' },
+    ]);
+    expect(out).toEqual(['Step one.', 'Step two.']);
+  });
+
+  it('flattens HowToSection by inlining itemListElement', () => {
+    const out = extractInstructionTexts([
+      {
+        '@type': 'HowToSection',
+        name: 'Prep',
+        itemListElement: [
+          { '@type': 'HowToStep', text: 'Wash veg.' },
+          { '@type': 'HowToStep', text: 'Chop veg.' },
+        ],
+      },
+      {
+        '@type': 'HowToSection',
+        name: 'Cook',
+        itemListElement: [{ '@type': 'HowToStep', text: 'Sauté veg.' }],
+      },
+    ]);
+    expect(out).toEqual(['Wash veg.', 'Chop veg.', 'Sauté veg.']);
+  });
+
+  it('falls back to splitting a flat string by sentence boundary', () => {
+    const out = extractInstructionTexts(
+      'Whisk the eggs. Melt butter in a pan. Pour in eggs and cook.'
+    );
+    expect(out).toEqual(['Whisk the eggs.', 'Melt butter in a pan.', 'Pour in eggs and cook.']);
+  });
+
+  it('strips HTML tags', () => {
+    const out = extractInstructionTexts([
+      { '@type': 'HowToStep', text: 'Whisk <b>dry</b> ingredients.' },
+    ]);
+    expect(out).toEqual(['Whisk dry ingredients.']);
+  });
+
+  it('drops empty steps', () => {
+    const out = extractInstructionTexts([
+      { '@type': 'HowToStep', text: '' },
+      { '@type': 'HowToStep', text: '   ' },
+      { '@type': 'HowToStep', text: 'Do thing.' },
+    ]);
+    expect(out).toEqual(['Do thing.']);
+  });
+
+  it('handles arrays of plain strings', () => {
+    const out = extractInstructionTexts(['Do A.', 'Do B.']);
+    expect(out).toEqual(['Do A.', 'Do B.']);
+  });
+});

--- a/apps/pops-worker-food/src/__tests__/extract-json-ld.test.ts
+++ b/apps/pops-worker-food/src/__tests__/extract-json-ld.test.ts
@@ -1,0 +1,78 @@
+/**
+ * PRD-127 — JSON-LD extractor unit tests.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { extractRecipeJsonLd } from '../handlers/web/extract-json-ld.js';
+
+function scriptHtml(json: object): string {
+  return `<html><head><script type="application/ld+json">${JSON.stringify(json)}</script></head><body></body></html>`;
+}
+
+describe('extractRecipeJsonLd', () => {
+  it('finds a top-level Recipe', () => {
+    const html = scriptHtml({
+      '@type': 'Recipe',
+      name: 'X',
+      recipeIngredient: [],
+      recipeInstructions: [],
+    });
+    const out = extractRecipeJsonLd(html);
+    expect(out?.name).toBe('X');
+  });
+
+  it('finds a Recipe inside @graph', () => {
+    const html = scriptHtml({
+      '@graph': [{ '@type': 'WebSite' }, { '@type': 'Recipe', name: 'Inside Graph' }],
+    });
+    expect(extractRecipeJsonLd(html)?.name).toBe('Inside Graph');
+  });
+
+  it('finds a Recipe in mainEntity', () => {
+    const html = scriptHtml({
+      '@type': 'WebPage',
+      mainEntity: { '@type': 'Recipe', name: 'Main Entity Recipe' },
+    });
+    expect(extractRecipeJsonLd(html)?.name).toBe('Main Entity Recipe');
+  });
+
+  it('returns null when the page only has non-Recipe JSON-LD', () => {
+    const html = scriptHtml({ '@type': 'Article', headline: 'hi' });
+    expect(extractRecipeJsonLd(html)).toBeNull();
+  });
+
+  it('returns null when there are no JSON-LD blocks at all', () => {
+    expect(extractRecipeJsonLd('<html><body><h1>nope</h1></body></html>')).toBeNull();
+  });
+
+  it('skips malformed JSON-LD blocks but still finds a later valid Recipe', () => {
+    const malformed = '<script type="application/ld+json">{ not json }</script>';
+    const good = `<script type="application/ld+json">${JSON.stringify({
+      '@type': 'Recipe',
+      name: 'Recovered',
+    })}</script>`;
+    const html = `<html><head>${malformed}${good}</head></html>`;
+    expect(extractRecipeJsonLd(html)?.name).toBe('Recovered');
+  });
+
+  it('handles array of typed nodes', () => {
+    const html = scriptHtml([
+      { '@type': 'BreadcrumbList' },
+      { '@type': 'Recipe', name: 'Array Item' },
+    ] as unknown as object);
+    expect(extractRecipeJsonLd(html)?.name).toBe('Array Item');
+  });
+
+  it('matches schema.org/Recipe absolute @type', () => {
+    const html = scriptHtml({ '@type': 'https://schema.org/Recipe', name: 'Abs Type' });
+    expect(extractRecipeJsonLd(html)?.name).toBe('Abs Type');
+  });
+
+  it('matches Recipe in an @type array', () => {
+    const html = scriptHtml({
+      '@type': ['Thing', 'Recipe'],
+      name: 'Multi Type',
+    });
+    expect(extractRecipeJsonLd(html)?.name).toBe('Multi Type');
+  });
+});

--- a/apps/pops-worker-food/src/__tests__/fetch-html.test.ts
+++ b/apps/pops-worker-food/src/__tests__/fetch-html.test.ts
@@ -1,0 +1,116 @@
+/**
+ * PRD-127 — fetchHtml unit tests.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { fetchHtml } from '../handlers/web/fetch-html.js';
+
+function makeResponse(body: string, init: ResponseInit = {}): Response {
+  return new Response(body, {
+    status: 200,
+    headers: { 'content-type': 'text/html; charset=utf-8' },
+    ...init,
+  });
+}
+
+describe('fetchHtml', () => {
+  it('returns the body on a 200 text/html response', async () => {
+    const fetchImpl = (async () => makeResponse('<html>ok</html>')) as typeof fetch;
+    const result = await fetchHtml('https://example.test/ok', { fetchImpl });
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('unreachable');
+    expect(result.html).toBe('<html>ok</html>');
+    expect(result.status).toBe(200);
+  });
+
+  it('follows redirects and reports the final URL', async () => {
+    const calls: string[] = [];
+    const fetchImpl: typeof fetch = (async (input) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      calls.push(url);
+      if (url.endsWith('/start')) {
+        return new Response(null, {
+          status: 301,
+          headers: { location: 'https://example.test/end' },
+        });
+      }
+      return makeResponse('<html>end</html>');
+    }) as unknown as typeof fetch;
+    const result = await fetchHtml('https://example.test/start', { fetchImpl });
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('unreachable');
+    expect(result.finalUrl).toBe('https://example.test/end');
+    expect(calls).toEqual(['https://example.test/start', 'https://example.test/end']);
+  });
+
+  it('rejects when the redirect chain exceeds the cap', async () => {
+    const fetchImpl: typeof fetch = (async (input) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      const next = url + '/x';
+      return new Response(null, { status: 302, headers: { location: next } });
+    }) as unknown as typeof fetch;
+    const result = await fetchHtml('https://example.test/loop', { fetchImpl, maxRedirects: 2 });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.errorCode).toBe('FetchFailed');
+  });
+
+  it('rejects non-HTML content types', async () => {
+    const fetchImpl = (async () =>
+      new Response('{}', {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })) as typeof fetch;
+    const result = await fetchHtml('https://example.test/json', { fetchImpl });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.errorCode).toBe('NotHtml');
+  });
+
+  it('rejects 4xx as FetchFailed with the status', async () => {
+    const fetchImpl = (async () =>
+      new Response('nope', {
+        status: 404,
+        headers: { 'content-type': 'text/html' },
+      })) as typeof fetch;
+    const result = await fetchHtml('https://example.test/404', { fetchImpl });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.errorCode).toBe('FetchFailed');
+    expect(result.status).toBe(404);
+  });
+
+  it('rejects bodies larger than the configured cap', async () => {
+    const big = 'x'.repeat(2048);
+    const fetchImpl = (async () => makeResponse(big)) as typeof fetch;
+    const result = await fetchHtml('https://example.test/big', {
+      fetchImpl,
+      maxBodyBytes: 1024,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.errorCode).toBe('BodyTooLarge');
+  });
+
+  it('returns FetchTimeout when the underlying fetch times out', async () => {
+    const fetchImpl: typeof fetch = (async () => {
+      const err = new Error('signal aborted');
+      err.name = 'TimeoutError';
+      throw err;
+    }) as unknown as typeof fetch;
+    const result = await fetchHtml('https://example.test/slow', { fetchImpl });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.errorCode).toBe('FetchTimeout');
+  });
+
+  it('returns FetchFailed when fetch throws a generic error', async () => {
+    const fetchImpl: typeof fetch = (async () => {
+      throw new Error('connection reset');
+    }) as unknown as typeof fetch;
+    const result = await fetchHtml('https://example.test/boom', { fetchImpl });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.errorCode).toBe('FetchFailed');
+  });
+});

--- a/apps/pops-worker-food/src/__tests__/fixtures/web/01-classic.html
+++ b/apps/pops-worker-food/src/__tests__/fixtures/web/01-classic.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Classic Smash Burger</title>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org/",
+        "@type": "Recipe",
+        "name": "Smash Burger",
+        "description": "A juicy, crispy-edged smash burger.",
+        "image": "https://example.com/smash-burger.jpg",
+        "author": { "@type": "Person", "name": "Test Cook" },
+        "recipeYield": "4 servings",
+        "prepTime": "PT5M",
+        "cookTime": "PT10M",
+        "totalTime": "PT15M",
+        "recipeCategory": "Main",
+        "recipeCuisine": "American",
+        "recipeIngredient": [
+          "500g beef chuck mince",
+          "5g salt",
+          "2g black pepper",
+          "4 burger buns",
+          "4 slices cheddar"
+        ],
+        "recipeInstructions": [
+          { "@type": "HowToStep", "text": "Divide chuck into 4 balls." },
+          { "@type": "HowToStep", "text": "Heat pan over high heat." },
+          { "@type": "HowToStep", "text": "Smash balls flat onto hot pan; season heavily." },
+          { "@type": "HowToStep", "text": "Flip after 90 seconds; top with cheese." },
+          { "@type": "HowToStep", "text": "Build burgers on toasted buns." }
+        ]
+      }
+    </script>
+  </head>
+  <body>
+    <h1>Classic Smash Burger</h1>
+  </body>
+</html>

--- a/apps/pops-worker-food/src/__tests__/fixtures/web/02-graph-envelope.html
+++ b/apps/pops-worker-food/src/__tests__/fixtures/web/02-graph-envelope.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Weeknight Pasta</title>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org/",
+        "@graph": [
+          { "@type": "WebSite", "name": "Cooking Blog", "url": "https://cookingblog.example" },
+          { "@type": "BreadcrumbList", "itemListElement": [] },
+          {
+            "@type": "Recipe",
+            "name": "Weeknight Pasta",
+            "description": "A 20-minute pasta to feed two.",
+            "recipeYield": "2 servings",
+            "prepTime": "PT5M",
+            "cookTime": "PT15M",
+            "recipeIngredient": [
+              "200g dried pasta",
+              "2 cloves garlic",
+              "30ml olive oil",
+              "1 tin chopped tomatoes",
+              "5g chilli flakes",
+              "salt"
+            ],
+            "recipeInstructions": [
+              { "@type": "HowToStep", "text": "Boil pasta in salted water." },
+              { "@type": "HowToStep", "text": "Sweat garlic in olive oil." },
+              { "@type": "HowToStep", "text": "Add tomatoes and chilli; simmer 10 min." },
+              { "@type": "HowToStep", "text": "Toss drained pasta with sauce." }
+            ]
+          }
+        ]
+      }
+    </script>
+  </head>
+  <body>
+    <h1>Weeknight Pasta</h1>
+  </body>
+</html>

--- a/apps/pops-worker-food/src/__tests__/fixtures/web/03-howto-section.html
+++ b/apps/pops-worker-food/src/__tests__/fixtures/web/03-howto-section.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Roast Chicken</title>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org/",
+        "@type": "Recipe",
+        "name": "Sunday Roast Chicken",
+        "recipeYield": "4 servings",
+        "prepTime": "PT15M",
+        "cookTime": "PT1H30M",
+        "recipeIngredient": [
+          "1.6kg whole chicken",
+          "2 tbsp olive oil",
+          "1 lemon",
+          "4 sprigs thyme",
+          "salt",
+          "pepper"
+        ],
+        "recipeInstructions": [
+          {
+            "@type": "HowToSection",
+            "name": "Prep",
+            "itemListElement": [
+              { "@type": "HowToStep", "text": "Pat chicken dry; salt the cavity." },
+              { "@type": "HowToStep", "text": "Stuff with lemon and thyme." }
+            ]
+          },
+          {
+            "@type": "HowToSection",
+            "name": "Roast",
+            "itemListElement": [
+              { "@type": "HowToStep", "text": "Roast at 200C for 45 minutes." },
+              { "@type": "HowToStep", "text": "Lower to 180C; roast 45 more minutes." },
+              { "@type": "HowToStep", "text": "Rest 20 minutes before carving." }
+            ]
+          }
+        ]
+      }
+    </script>
+  </head>
+  <body>
+    <h1>Sunday Roast Chicken</h1>
+  </body>
+</html>

--- a/apps/pops-worker-food/src/__tests__/fixtures/web/04-unicode-fractions.html
+++ b/apps/pops-worker-food/src/__tests__/fixtures/web/04-unicode-fractions.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Chocolate Chip Cookies</title>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org/",
+        "@type": "Recipe",
+        "name": "Chocolate Chip Cookies",
+        "recipeYield": "24 cookies",
+        "prepTime": "PT15M",
+        "cookTime": "PT12M",
+        "recipeIngredient": [
+          "2¼ cups all-purpose flour",
+          "1 tsp baking soda",
+          "½ tsp salt",
+          "1 cup butter",
+          "¾ cup brown sugar",
+          "¼ cup white sugar",
+          "2 eggs",
+          "1 tsp vanilla extract",
+          "2 cups chocolate chips"
+        ],
+        "recipeInstructions": [
+          { "@type": "HowToStep", "text": "Whisk flour, baking soda, salt." },
+          { "@type": "HowToStep", "text": "Cream butter with both sugars." },
+          { "@type": "HowToStep", "text": "Beat in eggs and vanilla." },
+          { "@type": "HowToStep", "text": "Fold in dry mix and chips." },
+          { "@type": "HowToStep", "text": "Scoop and bake at 180C for 12 minutes." }
+        ]
+      }
+    </script>
+  </head>
+  <body>
+    <h1>Chocolate Chip Cookies</h1>
+  </body>
+</html>

--- a/apps/pops-worker-food/src/__tests__/fixtures/web/05-imperial-parens.html
+++ b/apps/pops-worker-food/src/__tests__/fixtures/web/05-imperial-parens.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Béchamel Sauce</title>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org/",
+        "@type": "Recipe",
+        "name": "Béchamel Sauce",
+        "description": "A creamy white sauce.",
+        "recipeYield": "1 litre",
+        "prepTime": "PT5M",
+        "cookTime": "PT15M",
+        "recipeIngredient": [
+          "1 cup (240ml) milk",
+          "2 tbsp (28g) butter",
+          "2 tbsp (16g) all-purpose flour",
+          "1 pinch nutmeg",
+          "salt"
+        ],
+        "recipeInstructions": [
+          { "@type": "HowToStep", "text": "Warm the milk." },
+          { "@type": "HowToStep", "text": "Melt butter; whisk in flour to make a roux." },
+          { "@type": "HowToStep", "text": "Slowly whisk in warm milk." },
+          { "@type": "HowToStep", "text": "Simmer until thick; season with nutmeg and salt." }
+        ]
+      }
+    </script>
+  </head>
+  <body>
+    <h1>Béchamel Sauce</h1>
+  </body>
+</html>

--- a/apps/pops-worker-food/src/__tests__/fixtures/web/06-mainentity.html
+++ b/apps/pops-worker-food/src/__tests__/fixtures/web/06-mainentity.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Banana Bread</title>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org/",
+        "@type": "WebPage",
+        "mainEntity": {
+          "@type": "Recipe",
+          "name": "Banana Bread",
+          "recipeYield": "1 loaf",
+          "prepTime": "PT10M",
+          "cookTime": "PT55M",
+          "recipeIngredient": [
+            "3 ripe bananas",
+            "75g melted butter",
+            "150g sugar",
+            "1 egg",
+            "5g vanilla extract",
+            "5g baking soda",
+            "1 pinch salt",
+            "190g all-purpose flour"
+          ],
+          "recipeInstructions": [
+            { "@type": "HowToStep", "text": "Mash bananas in a large bowl." },
+            { "@type": "HowToStep", "text": "Stir in butter, sugar, egg, and vanilla." },
+            { "@type": "HowToStep", "text": "Sprinkle baking soda and salt; stir." },
+            { "@type": "HowToStep", "text": "Add flour and fold in." },
+            { "@type": "HowToStep", "text": "Bake at 175C for 55 minutes." }
+          ]
+        }
+      }
+    </script>
+  </head>
+  <body>
+    <h1>Banana Bread</h1>
+  </body>
+</html>

--- a/apps/pops-worker-food/src/__tests__/fixtures/web/07-plain-text-duration.html
+++ b/apps/pops-worker-food/src/__tests__/fixtures/web/07-plain-text-duration.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Quick Salsa</title>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org/",
+        "@type": "Recipe",
+        "name": "Quick Tomato Salsa",
+        "recipeYield": "2 cups",
+        "prepTime": "10 minutes",
+        "cookTime": "0 minutes",
+        "recipeIngredient": [
+          "4 large tomatoes",
+          "1 onion",
+          "2 cloves garlic",
+          "1 jalapeno",
+          "1 lime",
+          "10g cilantro",
+          "salt"
+        ],
+        "recipeInstructions": [
+          { "@type": "HowToStep", "text": "Chop everything finely." },
+          { "@type": "HowToStep", "text": "Combine in a bowl." },
+          { "@type": "HowToStep", "text": "Squeeze lime juice over; salt to taste." }
+        ]
+      }
+    </script>
+  </head>
+  <body>
+    <h1>Quick Tomato Salsa</h1>
+  </body>
+</html>

--- a/apps/pops-worker-food/src/__tests__/fixtures/web/08-instructions-string.html
+++ b/apps/pops-worker-food/src/__tests__/fixtures/web/08-instructions-string.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Quick Omelette</title>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org/",
+        "@type": "Recipe",
+        "name": "Quick Omelette",
+        "recipeYield": "1 serving",
+        "prepTime": "PT2M",
+        "cookTime": "PT3M",
+        "recipeIngredient": ["3 eggs", "10g butter", "salt", "pepper"],
+        "recipeInstructions": "Whisk the eggs with salt and pepper. Melt butter in a non-stick pan over medium heat. Pour in the eggs. Pull the edges in as they set. Fold and serve."
+      }
+    </script>
+  </head>
+  <body>
+    <h1>Quick Omelette</h1>
+  </body>
+</html>

--- a/apps/pops-worker-food/src/__tests__/fixtures/web/09-html-in-steps.html
+++ b/apps/pops-worker-food/src/__tests__/fixtures/web/09-html-in-steps.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Pancakes</title>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org/",
+        "@type": "Recipe",
+        "name": "Buttermilk Pancakes",
+        "recipeYield": "8 pancakes",
+        "prepTime": "PT5M",
+        "cookTime": "PT15M",
+        "recipeIngredient": [
+          "200g flour",
+          "10g baking powder",
+          "5g salt",
+          "20g sugar",
+          "2 eggs",
+          "300ml buttermilk",
+          "30g melted butter"
+        ],
+        "recipeInstructions": [
+          { "@type": "HowToStep", "text": "Whisk <b>dry</b> ingredients in a large bowl." },
+          { "@type": "HowToStep", "text": "Whisk <i>wet</i> ingredients in a jug." },
+          { "@type": "HowToStep", "text": "Combine; don't overmix. <span>Lumps are fine.</span>" },
+          { "@type": "HowToStep", "text": "Cook 1/4 cup batches on a buttered pan." }
+        ]
+      }
+    </script>
+  </head>
+  <body>
+    <h1>Buttermilk Pancakes</h1>
+  </body>
+</html>

--- a/apps/pops-worker-food/src/__tests__/fixtures/web/10-multiple-categories.html
+++ b/apps/pops-worker-food/src/__tests__/fixtures/web/10-multiple-categories.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Pad See Ew</title>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org/",
+        "@type": "Recipe",
+        "name": "Pad See Ew",
+        "description": "Stir-fried wide noodles with chicken and broccoli.",
+        "recipeYield": "2-3 servings",
+        "prepTime": "PT15M",
+        "cookTime": "PT10M",
+        "recipeCategory": ["Main", "Dinner"],
+        "recipeCuisine": "Thai",
+        "recipeIngredient": [
+          "300g fresh wide rice noodles",
+          "200g chicken thigh",
+          "150g chinese broccoli",
+          "2 eggs",
+          "3 cloves garlic",
+          "2 tbsp dark soy sauce",
+          "1 tbsp light soy sauce",
+          "1 tbsp oyster sauce",
+          "1 tsp sugar",
+          "2 tbsp vegetable oil"
+        ],
+        "recipeInstructions": [
+          { "@type": "HowToStep", "text": "Mix the sauces and sugar." },
+          { "@type": "HowToStep", "text": "Heat oil over high heat; fry garlic 10s." },
+          { "@type": "HowToStep", "text": "Add chicken; stir-fry until cooked." },
+          { "@type": "HowToStep", "text": "Push aside; scramble the eggs." },
+          { "@type": "HowToStep", "text": "Add noodles and sauce; toss to coat." },
+          { "@type": "HowToStep", "text": "Fold in broccoli; cook 2 minutes." }
+        ]
+      }
+    </script>
+  </head>
+  <body>
+    <h1>Pad See Ew</h1>
+  </body>
+</html>

--- a/apps/pops-worker-food/src/__tests__/fixtures/web/11-no-jsonld.html
+++ b/apps/pops-worker-food/src/__tests__/fixtures/web/11-no-jsonld.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>No JSON-LD here</title>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org/",
+        "@type": "Article",
+        "headline": "Five tricks for crispier roast potatoes"
+      }
+    </script>
+  </head>
+  <body>
+    <h1>Five tricks for crispier roast potatoes</h1>
+    <p>A blog article — no Recipe JSON-LD in sight.</p>
+  </body>
+</html>

--- a/apps/pops-worker-food/src/__tests__/map-to-dsl.test.ts
+++ b/apps/pops-worker-food/src/__tests__/map-to-dsl.test.ts
@@ -1,0 +1,121 @@
+/**
+ * PRD-127 — mapJsonLdToDsl unit tests.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { parseRecipeDsl } from '@pops/app-food/src/dsl/parser';
+
+import { mapJsonLdToDsl } from '../handlers/web/map-to-dsl.js';
+
+import type { RecipeJsonLd } from '../handlers/web/extract-json-ld.js';
+
+const MINIMAL_RECIPE: RecipeJsonLd = {
+  '@type': 'Recipe',
+  name: 'Test Recipe',
+  recipeYield: '4 servings',
+  prepTime: 'PT5M',
+  cookTime: 'PT10M',
+  recipeIngredient: ['500g flour', '5g salt'],
+  recipeInstructions: [
+    { '@type': 'HowToStep', text: 'Combine the dry.' },
+    { '@type': 'HowToStep', text: 'Mix and rest.' },
+  ],
+};
+
+describe('mapJsonLdToDsl', () => {
+  it('produces a DSL that parses cleanly', () => {
+    const { dsl } = mapJsonLdToDsl(MINIMAL_RECIPE);
+    const parsed = parseRecipeDsl(dsl);
+    expect(parsed.ok).toBe(true);
+  });
+
+  it('emits the yield with the recipe slug as descriptor', () => {
+    const { dsl, slug } = mapJsonLdToDsl(MINIMAL_RECIPE);
+    expect(slug).toBe('test-recipe');
+    expect(dsl).toMatch(/^@yield\(test-recipe, /m);
+  });
+
+  it('suffixes the slug when a collision is reserved', () => {
+    const reserved = new Set(['test-recipe']);
+    const { slug } = mapJsonLdToDsl(MINIMAL_RECIPE, { reservedSlugs: reserved });
+    expect(slug).toBe('test-recipe-2');
+  });
+
+  it('walks the suffix chain when -2 is also taken', () => {
+    const reserved = new Set(['test-recipe', 'test-recipe-2']);
+    const { slug } = mapJsonLdToDsl(MINIMAL_RECIPE, { reservedSlugs: reserved });
+    expect(slug).toBe('test-recipe-3');
+  });
+
+  it('falls back to recipe-named yield default unit when not provided', () => {
+    const { dsl } = mapJsonLdToDsl({
+      '@type': 'Recipe',
+      name: 'Tiny',
+      recipeIngredient: ['1 thing'],
+      recipeInstructions: [{ '@type': 'HowToStep', text: 'Do it.' }],
+    });
+    expect(dsl).toMatch(/@yield\(tiny, 4:serving\)/);
+  });
+
+  it('drops missing prep_time / cook_time / summary cleanly', () => {
+    const { dsl } = mapJsonLdToDsl({
+      '@type': 'Recipe',
+      name: 'Bare',
+      recipeYield: '4 servings',
+      recipeIngredient: ['salt'],
+      recipeInstructions: [{ '@type': 'HowToStep', text: 'Do' }],
+    });
+    expect(dsl).not.toMatch(/prep_time=/);
+    expect(dsl).not.toMatch(/cook_time=/);
+    expect(dsl).not.toMatch(/summary=/);
+  });
+
+  it('escapes double quotes and backslashes in titles and steps', () => {
+    const { dsl } = mapJsonLdToDsl({
+      '@type': 'Recipe',
+      name: 'He said "yes" sauce',
+      recipeYield: '1 jar',
+      recipeIngredient: ['1 tbsp salt'],
+      recipeInstructions: [
+        { '@type': 'HowToStep', text: 'Say "hello" to the sauce. Use a back\\slash.' },
+      ],
+    });
+    expect(dsl).toMatch(/title="He said \\"yes\\" sauce"/);
+    expect(dsl).toMatch(/@step\("Say \\"hello\\".*back\\\\slash\."\)/);
+    const parsed = parseRecipeDsl(dsl);
+    expect(parsed.ok).toBe(true);
+  });
+
+  it('emits one ingredient block per JSON-LD ingredient line', () => {
+    const { dsl, stats } = mapJsonLdToDsl({
+      '@type': 'Recipe',
+      name: 'Pasta',
+      recipeYield: '2 servings',
+      recipeIngredient: ['200g pasta', '30ml oil', '5g salt'],
+      recipeInstructions: [{ '@type': 'HowToStep', text: 'Cook.' }],
+    });
+    expect(stats.ingredients).toBe(3);
+    const ingredientLines = dsl.split('\n').filter((line) => line.startsWith('@ingredient('));
+    expect(ingredientLines).toEqual([
+      '@ingredient(1, pasta, 200:g)',
+      '@ingredient(2, oil, 30:ml)',
+      '@ingredient(3, salt, 5:g)',
+    ]);
+  });
+
+  it('renders categories and cuisine as tag comments', () => {
+    const { dsl, stats } = mapJsonLdToDsl({
+      '@type': 'Recipe',
+      name: 'Pad See Ew',
+      recipeYield: '2 servings',
+      recipeCategory: ['Main', 'Dinner'],
+      recipeCuisine: 'Thai',
+      recipeIngredient: ['200g noodles'],
+      recipeInstructions: [{ '@type': 'HowToStep', text: 'Cook.' }],
+    });
+    expect(stats.tags).toBe(3);
+    expect(dsl).toMatch(/^\/\/ tag: main$/m);
+    expect(dsl).toMatch(/^\/\/ tag: dinner$/m);
+    expect(dsl).toMatch(/^\/\/ tag: thai$/m);
+  });
+});

--- a/apps/pops-worker-food/src/__tests__/parse-duration.test.ts
+++ b/apps/pops-worker-food/src/__tests__/parse-duration.test.ts
@@ -1,0 +1,47 @@
+/**
+ * PRD-127 — duration parsing unit tests.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { parseDurationMinutes } from '../handlers/web/parse-duration.js';
+
+describe('parseDurationMinutes', () => {
+  it.each([
+    ['PT5M', 5],
+    ['PT45M', 45],
+    ['PT1H', 60],
+    ['PT1H30M', 90],
+    ['PT2H15M', 135],
+    ['PT45S', 1],
+    ['pt5m', 5],
+  ])('parses ISO %s → %d min', (input, expected) => {
+    expect(parseDurationMinutes(input)).toBe(expected);
+  });
+
+  it.each([
+    ['5 minutes', 5],
+    ['5 mins', 5],
+    ['10 min', 10],
+    ['1 hour', 60],
+    ['1 hr 30 min', 90],
+    ['2 hrs', 120],
+  ])('parses plain text %s → %d min', (input, expected) => {
+    expect(parseDurationMinutes(input)).toBe(expected);
+  });
+
+  it('returns null for empty or zero durations', () => {
+    expect(parseDurationMinutes('')).toBeNull();
+    expect(parseDurationMinutes('0 minutes')).toBeNull();
+    expect(parseDurationMinutes('PT0M')).toBeNull();
+  });
+
+  it('returns null for non-string / non-numeric input', () => {
+    expect(parseDurationMinutes(undefined)).toBeNull();
+    expect(parseDurationMinutes(42 as unknown)).toBeNull();
+    expect(parseDurationMinutes({} as unknown)).toBeNull();
+  });
+
+  it('returns null for garbage strings', () => {
+    expect(parseDurationMinutes('forever')).toBeNull();
+  });
+});

--- a/apps/pops-worker-food/src/__tests__/parse-ingredient-line.test.ts
+++ b/apps/pops-worker-food/src/__tests__/parse-ingredient-line.test.ts
@@ -1,0 +1,83 @@
+/**
+ * PRD-127 — ingredient-line heuristic unit tests.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { parseIngredientLine } from '../handlers/web/parse-ingredient-line.js';
+
+describe('parseIngredientLine', () => {
+  it('parses sticky metric "500g beef chuck mince"', () => {
+    const r = parseIngredientLine('500g beef chuck mince');
+    expect(r.qty).toBe(500);
+    expect(r.unit).toBe('g');
+    expect(r.descriptorSlug).toBe('beef-chuck-mince');
+  });
+
+  it('parses spaced metric "30ml olive oil"', () => {
+    const r = parseIngredientLine('30ml olive oil');
+    expect(r).toMatchObject({ qty: 30, unit: 'ml', descriptorSlug: 'olive-oil' });
+  });
+
+  it('parses imperial "1 cup milk"', () => {
+    const r = parseIngredientLine('1 cup milk');
+    expect(r).toMatchObject({ qty: 1, unit: 'cup', descriptorSlug: 'milk' });
+  });
+
+  it('parses unicode fraction "½ tsp salt"', () => {
+    const r = parseIngredientLine('½ tsp salt');
+    expect(r).toMatchObject({ qty: 0.5, unit: 'tsp', descriptorSlug: 'salt' });
+  });
+
+  it('parses mixed unicode fraction "2¼ cups flour"', () => {
+    const r = parseIngredientLine('2¼ cups flour');
+    expect(r.qty).toBeCloseTo(2.25);
+    expect(r.unit).toBe('cup');
+    expect(r.descriptorSlug).toBe('flour');
+  });
+
+  it('parses ASCII fraction "1/2 tsp salt"', () => {
+    const r = parseIngredientLine('1/2 tsp salt');
+    expect(r.qty).toBe(0.5);
+    expect(r.unit).toBe('tsp');
+    expect(r.descriptorSlug).toBe('salt');
+  });
+
+  it('parses mixed ASCII fraction "1 1/2 cups water"', () => {
+    const r = parseIngredientLine('1 1/2 cups water');
+    expect(r.qty).toBe(1.5);
+    expect(r.unit).toBe('cup');
+    expect(r.descriptorSlug).toBe('water');
+  });
+
+  it('strips trailing parenthetical "1 cup (240ml) milk"', () => {
+    const r = parseIngredientLine('1 cup (240ml) milk');
+    expect(r).toMatchObject({ qty: 1, unit: 'cup', descriptorSlug: 'milk' });
+  });
+
+  it('falls back to qty=1, unit=count when no quantity', () => {
+    const r = parseIngredientLine('salt');
+    expect(r).toMatchObject({ qty: 1, unit: 'count', descriptorSlug: 'salt' });
+  });
+
+  it('strips HTML tags in descriptors', () => {
+    const r = parseIngredientLine('2 tbsp <b>olive oil</b>');
+    expect(r.qty).toBe(2);
+    expect(r.unit).toBe('tbsp');
+    expect(r.descriptorSlug).toBe('olive-oil');
+  });
+
+  it('falls back to descriptor-only when input is empty', () => {
+    const r = parseIngredientLine('');
+    expect(r).toMatchObject({ qty: 1, unit: 'count', descriptorSlug: 'ingredient' });
+  });
+
+  it('handles "4 burger buns" (no unit-word: count)', () => {
+    const r = parseIngredientLine('4 burger buns');
+    expect(r).toMatchObject({ qty: 4, unit: 'count', descriptorSlug: 'burger-buns' });
+  });
+
+  it('handles "2 cloves garlic" (cloves → clove)', () => {
+    const r = parseIngredientLine('2 cloves garlic');
+    expect(r).toMatchObject({ qty: 2, unit: 'clove', descriptorSlug: 'garlic' });
+  });
+});

--- a/apps/pops-worker-food/src/__tests__/parse-yield.test.ts
+++ b/apps/pops-worker-food/src/__tests__/parse-yield.test.ts
@@ -1,0 +1,40 @@
+/**
+ * PRD-127 — recipeYield parser unit tests.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { parseYield } from '../handlers/web/parse-yield.js';
+
+describe('parseYield', () => {
+  it('parses "4 servings"', () => {
+    expect(parseYield('4 servings')).toEqual({ qty: 4, unit: 'serving' });
+  });
+
+  it('parses "24 cookies"', () => {
+    expect(parseYield('24 cookies')).toEqual({ qty: 24, unit: 'cookies' });
+  });
+
+  it('parses "4-6 servings" → first integer', () => {
+    expect(parseYield('4-6 servings')).toEqual({ qty: 4, unit: 'serving' });
+  });
+
+  it('parses bare integer', () => {
+    expect(parseYield(8)).toEqual({ qty: 8, unit: 'serving' });
+  });
+
+  it('parses bare integer string', () => {
+    expect(parseYield('8')).toEqual({ qty: 8, unit: 'serving' });
+  });
+
+  it('parses array → picks first string', () => {
+    expect(parseYield(['6 servings', '4 burgers'])).toEqual({ qty: 6, unit: 'serving' });
+  });
+
+  it('falls back to (4, serving) when unparseable', () => {
+    expect(parseYield('a bunch')).toEqual({ qty: 4, unit: 'serving' });
+  });
+
+  it('falls back to (4, serving) on undefined', () => {
+    expect(parseYield(undefined)).toEqual({ qty: 4, unit: 'serving' });
+  });
+});

--- a/apps/pops-worker-food/src/__tests__/web-jsonld.fixtures.test.ts
+++ b/apps/pops-worker-food/src/__tests__/web-jsonld.fixtures.test.ts
@@ -1,0 +1,151 @@
+/**
+ * PRD-127 fixture suite.
+ *
+ * For each saved recipe page:
+ *   1. Run the JSON-LD extractor — assert a Recipe node was found.
+ *   2. Run the deterministic DSL mapper — assert the produced DSL parses
+ *      cleanly via PRD-114's `parseRecipeDsl` (the same parser PRD-116's
+ *      `compileRecipeVersion` consumes; a parse failure here would block
+ *      compile against a real DB downstream).
+ *   3. Smoke-check the produced DSL shape (@recipe header, @yield, ≥1
+ *      @ingredient, ≥1 @step).
+ *
+ * A separate test exercises the no-Recipe fallback path (extractor returns
+ * null → the handler emits `JsonLdMissing` which PRD-128 will replace with
+ * its LLM fallback).
+ */
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+// PRD-114 parser. Deep import is intentional — `@pops/app-food` package
+// root re-exports React components we don't want pulled into the worker
+// test harness.
+import { parseRecipeDsl } from '@pops/app-food/src/dsl/parser';
+
+import { runWebUrlIngestWith } from '../handlers/web-url.js';
+import { extractRecipeJsonLd } from '../handlers/web/extract-json-ld.js';
+import { mapJsonLdToDsl } from '../handlers/web/map-to-dsl.js';
+
+const currentFilePath = fileURLToPath(import.meta.url);
+const currentDir = dirname(currentFilePath);
+const FIXTURE_DIR = join(currentDir, 'fixtures', 'web');
+
+interface FixtureCase {
+  name: string;
+  html: string;
+  expectsRecipe: boolean;
+}
+
+function loadFixtures(): FixtureCase[] {
+  return readdirSync(FIXTURE_DIR)
+    .filter((f) => f.endsWith('.html'))
+    .toSorted()
+    .map((name) => ({
+      name,
+      html: readFileSync(join(FIXTURE_DIR, name), 'utf8'),
+      expectsRecipe: !name.includes('no-jsonld'),
+    }));
+}
+
+describe('PRD-127 — JSON-LD fixture suite', () => {
+  const fixtures = loadFixtures();
+
+  it('loads ≥10 fixtures with Recipe JSON-LD', () => {
+    const withRecipe = fixtures.filter((f) => f.expectsRecipe);
+    expect(withRecipe.length).toBeGreaterThanOrEqual(10);
+  });
+
+  it('loads a no-JSON-LD fixture so the fallback signal stays tested', () => {
+    expect(fixtures.some((f) => !f.expectsRecipe)).toBe(true);
+  });
+
+  for (const fixture of fixtures.filter((f) => f.expectsRecipe)) {
+    it(`extracts + maps + parses ${fixture.name}`, () => {
+      const jsonLd = extractRecipeJsonLd(fixture.html);
+      expect(jsonLd, 'JSON-LD Recipe node detected').not.toBeNull();
+      if (jsonLd === null) throw new Error('unreachable');
+
+      const mapped = mapJsonLdToDsl(jsonLd);
+      expect(mapped.slug.length).toBeGreaterThan(0);
+      expect(mapped.dsl).toMatch(/^@recipe\(/m);
+      expect(mapped.dsl).toMatch(/^@yield\(/m);
+      expect(mapped.dsl).toMatch(/^@ingredient\(/m);
+      expect(mapped.dsl).toMatch(/^@step\(/m);
+      expect(mapped.stats.ingredients).toBeGreaterThan(0);
+      expect(mapped.stats.steps).toBeGreaterThan(0);
+
+      const parsed = parseRecipeDsl(mapped.dsl);
+      if (!parsed.ok) {
+        throw new Error(
+          `parseRecipeDsl failed for ${fixture.name}:\n` +
+            parsed.errors.map((e) => `  ${e.code}: ${e.message}`).join('\n') +
+            `\n--- DSL ---\n${mapped.dsl}`
+        );
+      }
+    });
+  }
+});
+
+describe('PRD-127 — fallback signalling', () => {
+  it('extractor returns null when no Recipe JSON-LD is present', () => {
+    const html = readFileSync(join(FIXTURE_DIR, '11-no-jsonld.html'), 'utf8');
+    expect(extractRecipeJsonLd(html)).toBeNull();
+  });
+
+  it('handler emits JsonLdMissing when extractor finds nothing', async () => {
+    const html = readFileSync(join(FIXTURE_DIR, '11-no-jsonld.html'), 'utf8');
+    const result = await runWebUrlIngestWith(
+      { kind: 'url-web', sourceId: 999, url: 'https://example.test/no-recipe' },
+      { isCancelled: () => false },
+      {
+        fetchHtmlImpl: async () => ({
+          ok: true,
+          html,
+          finalUrl: 'https://example.test/no-recipe',
+          status: 200,
+          bytes: html.length,
+          durationMs: 5,
+        }),
+      }
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.errorCode).toBe('JsonLdMissing');
+  });
+});
+
+describe('PRD-127 — observability', () => {
+  it('no ai_inference_log row is implied — the handler never emits an LLM marker', async () => {
+    const html = readFileSync(join(FIXTURE_DIR, '01-classic.html'), 'utf8');
+    const result = await runWebUrlIngestWith(
+      { kind: 'url-web', sourceId: 1, url: 'https://example.test/classic' },
+      { isCancelled: () => false },
+      {
+        fetchHtmlImpl: async () => ({
+          ok: true,
+          html,
+          finalUrl: 'https://example.test/classic',
+          status: 200,
+          bytes: html.length,
+          durationMs: 5,
+        }),
+      }
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('unreachable');
+    expect(result.meta.total_cost_usd).toBeUndefined();
+    expect(result.meta.llm_raw_output).toBeUndefined();
+    // Every stage is deterministic — none of them write a `model` or
+    // `tokens` field. If they ever do, this assertion catches the drift.
+    for (const stage of Object.values(result.meta.stages)) {
+      if (stage !== null && typeof stage === 'object') {
+        expect(stage).not.toHaveProperty('model');
+        expect(stage).not.toHaveProperty('input_tokens');
+        expect(stage).not.toHaveProperty('output_tokens');
+      }
+    }
+  });
+});

--- a/apps/pops-worker-food/src/handlers/web-url.ts
+++ b/apps/pops-worker-food/src/handlers/web-url.ts
@@ -1,12 +1,157 @@
-import { notImplementedResult } from './not-implemented.js';
+/**
+ * PRD-127 — Web URL → JSON-LD → DSL handler.
+ *
+ * The fast path: fetch the page, look for a schema.org Recipe JSON-LD
+ * block, map it to the DSL deterministically. When JSON-LD is missing
+ * or malformed, this handler currently returns a `JsonLdMissing` failure
+ * so the dispatch shell makes the absence visible — PRD-128 will replace
+ * that branch with the LLM fallback.
+ *
+ * No LLM call lives here; no `ai_inference_log` rows are written.
+ */
+import { extractRecipeJsonLd, type RecipeJsonLd } from './web/extract-json-ld.js';
+import { fetchHtml, type FetchHtmlOptions, type FetchHtmlResult } from './web/fetch-html.js';
+import { mapJsonLdToDsl } from './web/map-to-dsl.js';
+
+import type { IngestJobResult, IngestMeta } from '@pops/food-contracts';
 
 import type { IngestHandler } from './types.js';
 
-/**
- * Web-URL ingest. Real pipeline lives in PRDs 127 (JSON-LD) + 128 (LLM
- * fallback). PRD-126 ships the dispatch shell; this stub keeps the
- * round-trip honest.
- */
-export const runWebUrlIngest: IngestHandler<'url-web'> = async (_data, _ctx) => {
-  return notImplementedResult('url-web');
+export const WEB_JSONLD_EXTRACTOR_VERSION = 'web-jsonld@1';
+
+export interface WebUrlIngestDeps {
+  fetchHtmlImpl?: typeof fetchHtml;
+  fetchHtmlOptions?: FetchHtmlOptions;
+  /** Slugs that exist in `slug_registry`; used to suffix recipe-slug collisions. */
+  reservedSlugs?: ReadonlySet<string>;
+}
+
+interface WebData {
+  kind: 'url-web';
+  sourceId: number;
+  url: string;
+}
+
+interface CancelCtx {
+  isCancelled: () => boolean | Promise<boolean>;
+}
+
+export const runWebUrlIngest: IngestHandler<'url-web'> = async (data, ctx) => {
+  return runWebUrlIngestWith(data, ctx, {});
 };
+
+export async function runWebUrlIngestWith(
+  data: WebData,
+  ctx: CancelCtx,
+  deps: WebUrlIngestDeps
+): Promise<IngestJobResult> {
+  const meta: IngestMeta = { extractor_version: WEB_JSONLD_EXTRACTOR_VERSION, stages: {} };
+  if (await ctx.isCancelled()) return cancelled(meta);
+
+  const fetched = await runFetchStage(data.url, deps, meta);
+  if (!fetched.ok) {
+    return { ok: false, errorCode: fetched.errorCode, errorMessage: fetched.errorMessage, meta };
+  }
+  if (await ctx.isCancelled()) return cancelled(meta);
+
+  const extraction = runExtractStage(fetched.html, meta);
+  if (extraction.tag === 'error') {
+    return { ok: false, errorCode: 'JsonLdParseError', errorMessage: extraction.message, meta };
+  }
+  if (extraction.tag === 'missing') {
+    return {
+      ok: false,
+      errorCode: 'JsonLdMissing',
+      errorMessage: 'Page has no schema.org Recipe JSON-LD; LLM fallback (PRD-128) not yet wired.',
+      meta,
+    };
+  }
+  if (await ctx.isCancelled()) return cancelled(meta);
+
+  return runMappingStage(extraction.recipe, deps, meta);
+}
+
+async function runFetchStage(
+  url: string,
+  deps: WebUrlIngestDeps,
+  meta: IngestMeta
+): Promise<FetchHtmlResult> {
+  const fetchImpl = deps.fetchHtmlImpl ?? fetchHtml;
+  const result = await fetchImpl(url, deps.fetchHtmlOptions ?? {});
+  meta.stages['fetch'] = result.ok
+    ? {
+        ok: true,
+        duration_ms: result.durationMs,
+        status: result.status,
+        final_url: result.finalUrl,
+        bytes: result.bytes,
+      }
+    : {
+        ok: false,
+        duration_ms: result.durationMs,
+        status: result.status,
+        final_url: result.finalUrl,
+        reason: result.errorMessage,
+      };
+  return result;
+}
+
+type ExtractStageResult =
+  | { tag: 'ok'; recipe: RecipeJsonLd }
+  | { tag: 'missing' }
+  | { tag: 'error'; message: string };
+
+function runExtractStage(html: string, meta: IngestMeta): ExtractStageResult {
+  const start = Date.now();
+  try {
+    const recipe = extractRecipeJsonLd(html);
+    if (recipe === null) {
+      meta.stages['jsonld_extract'] = {
+        ok: false,
+        duration_ms: Date.now() - start,
+        reason: 'no Recipe JSON-LD node found',
+      };
+      return { tag: 'missing' };
+    }
+    meta.stages['jsonld_extract'] = {
+      ok: true,
+      duration_ms: Date.now() - start,
+      schema_type: 'Recipe',
+    };
+    return { tag: 'ok', recipe };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    meta.stages['jsonld_extract'] = {
+      ok: false,
+      duration_ms: Date.now() - start,
+      reason: message,
+    };
+    return { tag: 'error', message };
+  }
+}
+
+function runMappingStage(
+  recipe: RecipeJsonLd,
+  deps: WebUrlIngestDeps,
+  meta: IngestMeta
+): IngestJobResult {
+  const start = Date.now();
+  const mapped = mapJsonLdToDsl(recipe, { reservedSlugs: deps.reservedSlugs });
+  meta.stages['mapping'] = {
+    ok: true,
+    duration_ms: Date.now() - start,
+    ingredients: mapped.stats.ingredients,
+    steps: mapped.stats.steps,
+    tags: mapped.stats.tags,
+  };
+  return { ok: true, dsl: mapped.dsl, meta };
+}
+
+function cancelled(meta: IngestMeta): IngestJobResult {
+  return {
+    ok: false,
+    errorCode: 'Cancelled',
+    errorMessage: 'job cancelled by orchestrator',
+    meta,
+  };
+}

--- a/apps/pops-worker-food/src/handlers/web/extract-instructions.ts
+++ b/apps/pops-worker-food/src/handlers/web/extract-instructions.ts
@@ -1,0 +1,83 @@
+/**
+ * PRD-127 — flatten the `recipeInstructions` field.
+ *
+ * Schema.org permits several shapes:
+ *   - `"recipeInstructions": "Do step one. Do step two."` (one string)
+ *   - `"recipeInstructions": ["text", "text", ...]`
+ *   - `"recipeInstructions": [{ "@type": "HowToStep", "text": "..." }, ...]`
+ *   - `"recipeInstructions": [{ "@type": "HowToSection", "itemListElement": [HowToStep, ...] }, ...]`
+ *
+ * v1 flattens HowToSection into its steps. Section names are dropped.
+ * Single-string instructions get split by sentence boundary as a coarse
+ * fallback so the user gets multiple step rows to work with.
+ */
+export function extractInstructionTexts(input: unknown): string[] {
+  const collected: string[] = [];
+  walk(input, collected);
+  // Strip HTML tags, normalise whitespace, drop empties.
+  return collected
+    .map((s) => stripHtml(s))
+    .map((s) => s.replace(/\s+/g, ' ').trim())
+    .filter((s) => s.length > 0);
+}
+
+function walk(value: unknown, out: string[]): void {
+  if (typeof value === 'string') {
+    splitFlatString(value, out);
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) walk(item, out);
+    return;
+  }
+  if (isPlainObject(value)) {
+    const type = value['@type'];
+    if (matchesType(type, 'HowToSection')) {
+      const items = value['itemListElement'] ?? value['steps'];
+      walk(items, out);
+      return;
+    }
+    // HowToStep — or an unknown object with a `text` slot.
+    const text = pickTextField(value);
+    if (text !== null) {
+      out.push(text);
+      return;
+    }
+    // Generic descent for arrays embedded under unknown keys.
+    for (const inner of Object.values(value)) {
+      if (Array.isArray(inner) || isPlainObject(inner)) walk(inner, out);
+    }
+  }
+}
+
+function pickTextField(value: Record<string, unknown>): string | null {
+  for (const key of ['text', 'description', 'name']) {
+    const candidate = value[key];
+    if (typeof candidate === 'string' && candidate.trim().length > 0) return candidate;
+  }
+  return null;
+}
+
+function splitFlatString(text: string, out: string[]): void {
+  // Coarse split on sentence-ending punctuation followed by whitespace +
+  // capital letter. Keeps short single-sentence inputs intact.
+  const parts = text.split(/(?<=[.!?])\s+(?=[A-Z])/u);
+  for (const part of parts) out.push(part);
+}
+
+function matchesType(type: unknown, target: string): boolean {
+  if (typeof type === 'string') return type === target || type.endsWith(`/${target}`);
+  if (Array.isArray(type)) return type.some((t) => matchesType(t, target));
+  return false;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function stripHtml(input: string): string {
+  return input
+    .replace(/<[^>]*>/g, '')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&');
+}

--- a/apps/pops-worker-food/src/handlers/web/extract-json-ld.ts
+++ b/apps/pops-worker-food/src/handlers/web/extract-json-ld.ts
@@ -1,0 +1,110 @@
+/**
+ * PRD-127 — JSON-LD extraction.
+ *
+ * Walks every `<script type="application/ld+json">` block in the HTML,
+ * parses each independently (a single malformed block must not poison
+ * the others), and returns the FIRST node whose `@type` is `Recipe`.
+ *
+ * Real-world recipe sites embed their JSON-LD in several wrappers:
+ *   - A single Recipe node.
+ *   - An array of typed nodes.
+ *   - A `@graph` envelope (`{ "@context": ..., "@graph": [...] }`).
+ *   - A nested `mainEntity` / `mainEntityOfPage` slot.
+ *
+ * The walker descends through all four, lazily, and stops on the first
+ * Recipe hit. Returning `null` is the signal PRD-128's LLM fallback uses
+ * to take over.
+ */
+
+const SCRIPT_RE = /<script\b[^>]*type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script\s*>/gi;
+
+export interface RecipeJsonLd {
+  '@type'?: unknown;
+  '@context'?: unknown;
+  name?: unknown;
+  description?: unknown;
+  image?: unknown;
+  author?: unknown;
+  recipeYield?: unknown;
+  prepTime?: unknown;
+  cookTime?: unknown;
+  totalTime?: unknown;
+  recipeCategory?: unknown;
+  recipeCuisine?: unknown;
+  recipeIngredient?: unknown;
+  recipeInstructions?: unknown;
+  nutrition?: unknown;
+  [key: string]: unknown;
+}
+
+export function extractRecipeJsonLd(html: string): RecipeJsonLd | null {
+  const blocks = collectScriptBlocks(html);
+  for (const block of blocks) {
+    const parsed = safeParseJson(block);
+    if (parsed === null) continue;
+    const recipe = findRecipeNode(parsed);
+    if (recipe !== null) return recipe;
+  }
+  return null;
+}
+
+function collectScriptBlocks(html: string): string[] {
+  const blocks: string[] = [];
+  const re = new RegExp(SCRIPT_RE.source, SCRIPT_RE.flags);
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(html)) !== null) {
+    const body = match[1];
+    if (body !== undefined) blocks.push(body);
+  }
+  return blocks;
+}
+
+function safeParseJson(raw: string): unknown {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return null;
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Depth-first walk over the JSON-LD tree looking for the first node whose
+ * `@type` is (or contains) "Recipe". We do NOT recurse into arbitrary keys
+ * — only the schema.org envelope slots (`@graph`, `mainEntity`,
+ * `mainEntityOfPage`, `itemReviewed`) plus raw arrays.
+ */
+function findRecipeNode(value: unknown): RecipeJsonLd | null {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const found = findRecipeNode(item);
+      if (found !== null) return found;
+    }
+    return null;
+  }
+  if (!isPlainObject(value)) return null;
+
+  if (matchesRecipeType(value['@type'])) {
+    return value as RecipeJsonLd;
+  }
+
+  for (const slot of ['@graph', 'mainEntity', 'mainEntityOfPage', 'itemReviewed'] as const) {
+    const inner = value[slot];
+    if (inner !== undefined) {
+      const found = findRecipeNode(inner);
+      if (found !== null) return found;
+    }
+  }
+  return null;
+}
+
+function matchesRecipeType(type: unknown): boolean {
+  if (typeof type === 'string') return type === 'Recipe' || type.endsWith('/Recipe');
+  if (Array.isArray(type)) return type.some((t) => matchesRecipeType(t));
+  return false;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/apps/pops-worker-food/src/handlers/web/fetch-html-body.ts
+++ b/apps/pops-worker-food/src/handlers/web/fetch-html-body.ts
@@ -1,0 +1,67 @@
+/**
+ * PRD-127 — body reader for the HTML fetcher. Streams the response body
+ * with a hard cap so a hostile server can't make us OOM. Split out of
+ * `fetch-html.ts` to keep each file under the per-file line cap.
+ */
+
+export type ReadBodyResult =
+  | { tag: 'ok'; text: string; bytes: number }
+  | { tag: 'too-large' }
+  | { tag: 'failed'; message: string };
+
+export async function readBodyWithCap(
+  response: Response,
+  maxBodyBytes: number
+): Promise<ReadBodyResult> {
+  const reader = response.body?.getReader();
+  if (!reader) return readBodyFallback(response, maxBodyBytes);
+  return readBodyStreaming(reader, maxBodyBytes);
+}
+
+async function readBodyFallback(response: Response, maxBodyBytes: number): Promise<ReadBodyResult> {
+  try {
+    const text = await response.text();
+    const bytes = new TextEncoder().encode(text).byteLength;
+    if (bytes > maxBodyBytes) return { tag: 'too-large' };
+    return { tag: 'ok', text, bytes };
+  } catch (err) {
+    return { tag: 'failed', message: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+async function readBodyStreaming(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  maxBodyBytes: number
+): Promise<ReadBodyResult> {
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    let done = false;
+    while (!done) {
+      const next = await reader.read();
+      done = next.done;
+      if (next.value === undefined) continue;
+      total += next.value.byteLength;
+      if (total > maxBodyBytes) {
+        await reader.cancel();
+        return { tag: 'too-large' };
+      }
+      chunks.push(next.value);
+    }
+  } catch (err) {
+    return { tag: 'failed', message: err instanceof Error ? err.message : String(err) };
+  }
+  const buffer = concatBuffers(chunks, total);
+  const text = new TextDecoder('utf-8', { fatal: false }).decode(buffer);
+  return { tag: 'ok', text, bytes: total };
+}
+
+function concatBuffers(chunks: readonly Uint8Array[], total: number): Uint8Array {
+  const buffer = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    buffer.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return buffer;
+}

--- a/apps/pops-worker-food/src/handlers/web/fetch-html-redirect.ts
+++ b/apps/pops-worker-food/src/handlers/web/fetch-html-redirect.ts
@@ -1,0 +1,118 @@
+/**
+ * PRD-127 — redirect-loop helpers for the HTML fetcher. Split from
+ * `fetch-html.ts` to keep each file under the line cap.
+ */
+
+const USER_AGENT = 'Mozilla/5.0 (compatible; POPS-Food-Ingest/1.0; +https://example.com)';
+
+export interface ResolvedFetchOptions {
+  fetchImpl: typeof fetch;
+  timeoutMs: number;
+  maxRedirects: number;
+  maxBodyBytes: number;
+}
+
+export interface FollowOk {
+  tag: 'ok';
+  response: Response;
+  currentUrl: string;
+}
+export interface FollowFail {
+  tag: 'failed';
+  errorCode: 'FetchFailed' | 'FetchTimeout';
+  errorMessage: string;
+  status?: number;
+  finalUrl?: string;
+  durationMs: number;
+}
+
+export type FollowResult = FollowOk | FollowFail;
+
+export async function followRedirects(
+  url: string,
+  opts: ResolvedFetchOptions,
+  start: number
+): Promise<FollowResult> {
+  let currentUrl = url;
+  for (let hop = 0; hop <= opts.maxRedirects; hop += 1) {
+    const fetched = await safeFetch(currentUrl, opts, start);
+    if (fetched.tag === 'failed') return fetched;
+    const res = fetched.response;
+    if (res.status < 300 || res.status >= 400) {
+      return { tag: 'ok', response: res, currentUrl };
+    }
+    const next = readRedirectTarget({
+      res,
+      currentUrl,
+      hop,
+      maxRedirects: opts.maxRedirects,
+      start,
+    });
+    if (next.tag === 'failed') return next;
+    currentUrl = next.url;
+  }
+  return {
+    tag: 'failed',
+    errorCode: 'FetchFailed',
+    errorMessage: 'no response after redirect chain',
+    durationMs: Date.now() - start,
+  };
+}
+
+async function safeFetch(
+  url: string,
+  opts: ResolvedFetchOptions,
+  start: number
+): Promise<{ tag: 'ok'; response: Response } | FollowFail> {
+  try {
+    const response = await opts.fetchImpl(url, {
+      redirect: 'manual',
+      headers: { 'User-Agent': USER_AGENT, Accept: 'text/html,application/xhtml+xml' },
+      signal: AbortSignal.timeout(opts.timeoutMs),
+    });
+    return { tag: 'ok', response };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    const isTimeout = err instanceof Error && err.name === 'TimeoutError';
+    return {
+      tag: 'failed',
+      errorCode: isTimeout ? 'FetchTimeout' : 'FetchFailed',
+      errorMessage: message,
+      durationMs: Date.now() - start,
+    };
+  }
+}
+
+interface RedirectTargetArgs {
+  res: Response;
+  currentUrl: string;
+  hop: number;
+  maxRedirects: number;
+  start: number;
+}
+
+function readRedirectTarget(args: RedirectTargetArgs): { tag: 'ok'; url: string } | FollowFail {
+  const { res, currentUrl, hop, maxRedirects, start } = args;
+  const location = res.headers.get('location');
+  if (location === null || location === '') {
+    return {
+      tag: 'failed',
+      errorCode: 'FetchFailed',
+      errorMessage: `redirect ${res.status} without Location header`,
+      status: res.status,
+      finalUrl: currentUrl,
+      durationMs: Date.now() - start,
+    };
+  }
+  if (hop === maxRedirects) {
+    return {
+      tag: 'failed',
+      errorCode: 'FetchFailed',
+      errorMessage: `exceeded ${maxRedirects} redirect hops`,
+      status: res.status,
+      finalUrl: currentUrl,
+      durationMs: Date.now() - start,
+    };
+  }
+  return { tag: 'ok', url: new URL(location, currentUrl).toString() };
+}

--- a/apps/pops-worker-food/src/handlers/web/fetch-html-redirect.ts
+++ b/apps/pops-worker-food/src/handlers/web/fetch-html-redirect.ts
@@ -3,7 +3,8 @@
  * `fetch-html.ts` to keep each file under the line cap.
  */
 
-const USER_AGENT = 'Mozilla/5.0 (compatible; POPS-Food-Ingest/1.0; +https://example.com)';
+const USER_AGENT =
+  'Mozilla/5.0 (compatible; POPS-Food-Ingest/1.0; +https://github.com/knoxio/pops)';
 
 export interface ResolvedFetchOptions {
   fetchImpl: typeof fetch;
@@ -48,6 +49,9 @@ export async function followRedirects(
       maxRedirects: opts.maxRedirects,
       start,
     });
+    // Drain the 3xx body so Undici can return the socket to its keep-alive
+    // pool — leaving redirect bodies unconsumed leaks connections under load.
+    await drainBody(res);
     if (next.tag === 'failed') return next;
     currentUrl = next.url;
   }
@@ -89,6 +93,14 @@ interface RedirectTargetArgs {
   hop: number;
   maxRedirects: number;
   start: number;
+}
+
+async function drainBody(res: Response): Promise<void> {
+  try {
+    await res.body?.cancel();
+  } catch {
+    /* nothing to do — the body may already be consumed or detached */
+  }
 }
 
 function readRedirectTarget(args: RedirectTargetArgs): { tag: 'ok'; url: string } | FollowFail {

--- a/apps/pops-worker-food/src/handlers/web/fetch-html.ts
+++ b/apps/pops-worker-food/src/handlers/web/fetch-html.ts
@@ -1,0 +1,144 @@
+/**
+ * PRD-127 — minimal HTML fetcher shared by the JSON-LD path and the
+ * LLM-fallback path (PRD-128). Uses the Undici `fetch` global (Node 20+):
+ *
+ *   - 15 s timeout (per-request, enforced via AbortSignal.timeout).
+ *   - Follows up to 5 redirects (Undici default 20; we cap explicitly).
+ *   - Rejects non-`text/html*` content types.
+ *   - Rejects bodies larger than 5 MB while streaming so we don't buffer
+ *     a hostile gigabyte.
+ *   - Identifiable User-Agent string.
+ */
+import { readBodyWithCap } from './fetch-html-body.js';
+import { followRedirects, type ResolvedFetchOptions } from './fetch-html-redirect.js';
+
+const FETCH_TIMEOUT_MS = 15_000;
+const MAX_REDIRECTS = 5;
+const MAX_BODY_BYTES = 5 * 1024 * 1024;
+const HTML_CT_RE = /^(?:text\/html|application\/xhtml\+xml)\b/i;
+
+export interface FetchHtmlOk {
+  ok: true;
+  html: string;
+  finalUrl: string;
+  status: number;
+  bytes: number;
+  durationMs: number;
+}
+
+export interface FetchHtmlFail {
+  ok: false;
+  errorCode: 'FetchFailed' | 'NotHtml' | 'BodyTooLarge' | 'FetchTimeout';
+  errorMessage: string;
+  status?: number;
+  finalUrl?: string;
+  durationMs: number;
+}
+
+export type FetchHtmlResult = FetchHtmlOk | FetchHtmlFail;
+
+export interface FetchHtmlOptions {
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+  maxRedirects?: number;
+  maxBodyBytes?: number;
+}
+
+export async function fetchHtml(
+  url: string,
+  options: FetchHtmlOptions = {}
+): Promise<FetchHtmlResult> {
+  const resolved: ResolvedFetchOptions = {
+    fetchImpl: options.fetchImpl ?? fetch,
+    timeoutMs: options.timeoutMs ?? FETCH_TIMEOUT_MS,
+    maxRedirects: options.maxRedirects ?? MAX_REDIRECTS,
+    maxBodyBytes: options.maxBodyBytes ?? MAX_BODY_BYTES,
+  };
+  const start = Date.now();
+
+  const followed = await followRedirects(url, resolved, start);
+  if (followed.tag === 'failed') {
+    return {
+      ok: false,
+      errorCode: followed.errorCode,
+      errorMessage: followed.errorMessage,
+      status: followed.status,
+      finalUrl: followed.finalUrl,
+      durationMs: followed.durationMs,
+    };
+  }
+  const { response, currentUrl } = followed;
+
+  const httpFail = validateStatus(response, currentUrl, start);
+  if (httpFail !== null) return httpFail;
+  const ctFail = validateContentType(response, currentUrl, start);
+  if (ctFail !== null) return ctFail;
+
+  return readBody(response, currentUrl, resolved.maxBodyBytes, start);
+}
+
+function validateStatus(response: Response, finalUrl: string, start: number): FetchHtmlFail | null {
+  if (response.status >= 200 && response.status < 300) return null;
+  return {
+    ok: false,
+    errorCode: 'FetchFailed',
+    errorMessage: `HTTP ${response.status}`,
+    status: response.status,
+    finalUrl,
+    durationMs: Date.now() - start,
+  };
+}
+
+function validateContentType(
+  response: Response,
+  finalUrl: string,
+  start: number
+): FetchHtmlFail | null {
+  const contentType = response.headers.get('content-type') ?? '';
+  if (HTML_CT_RE.test(contentType)) return null;
+  return {
+    ok: false,
+    errorCode: 'NotHtml',
+    errorMessage: `unsupported content-type: ${contentType || '<missing>'}`,
+    status: response.status,
+    finalUrl,
+    durationMs: Date.now() - start,
+  };
+}
+
+async function readBody(
+  response: Response,
+  finalUrl: string,
+  maxBodyBytes: number,
+  start: number
+): Promise<FetchHtmlResult> {
+  const result = await readBodyWithCap(response, maxBodyBytes);
+  if (result.tag === 'too-large') {
+    return {
+      ok: false,
+      errorCode: 'BodyTooLarge',
+      errorMessage: `body exceeded ${maxBodyBytes} bytes`,
+      status: response.status,
+      finalUrl,
+      durationMs: Date.now() - start,
+    };
+  }
+  if (result.tag === 'failed') {
+    return {
+      ok: false,
+      errorCode: 'FetchFailed',
+      errorMessage: result.message,
+      status: response.status,
+      finalUrl,
+      durationMs: Date.now() - start,
+    };
+  }
+  return {
+    ok: true,
+    html: result.text,
+    finalUrl,
+    status: response.status,
+    bytes: result.bytes,
+    durationMs: Date.now() - start,
+  };
+}

--- a/apps/pops-worker-food/src/handlers/web/map-to-dsl.ts
+++ b/apps/pops-worker-food/src/handlers/web/map-to-dsl.ts
@@ -1,0 +1,156 @@
+/**
+ * PRD-127 — JSON-LD → DSL mapping.
+ *
+ * Pure deterministic transformation. Given a parsed JSON-LD Recipe node
+ * and a (possibly empty) reserved-slug set, builds a DSL string that
+ * parses without errors. The reserved-slug set lets the caller wire the
+ * existing `slug_registry` for collision suffixing — when the set is
+ * empty (offline test runs) we still produce a parseable DSL.
+ */
+import { extractInstructionTexts } from './extract-instructions.js';
+import { parseDurationMinutes } from './parse-duration.js';
+import { parseIngredientLine } from './parse-ingredient-line.js';
+import { parseYield } from './parse-yield.js';
+import { disambiguateSlug, slugify } from './slugify.js';
+
+import type { RecipeJsonLd } from './extract-json-ld.js';
+
+export interface MapResult {
+  dsl: string;
+  /** Resolved recipe slug (post-collision suffixing). */
+  slug: string;
+  /** Stats for the meta JSON `mapping` stage. */
+  stats: {
+    ingredients: number;
+    steps: number;
+    tags: number;
+  };
+}
+
+export interface MapOptions {
+  /** Slugs already present in `slug_registry`; used to suffix collisions. */
+  reservedSlugs?: ReadonlySet<string>;
+}
+
+export function mapJsonLdToDsl(jsonLd: RecipeJsonLd, options: MapOptions = {}): MapResult {
+  const reserved = options.reservedSlugs ?? new Set<string>();
+  const title = pickFirstString(jsonLd.name) ?? 'Untitled Recipe';
+  const baseSlug = slugify(title);
+  const slug = disambiguateSlug(baseSlug, reserved);
+
+  const header = buildRecipeHeader({
+    slug,
+    title,
+    summary: pickFirstString(jsonLd.description),
+    servings: parseYield(jsonLd.recipeYield).qty,
+    prepMins: parseDurationMinutes(jsonLd.prepTime),
+    cookMins: parseDurationMinutes(jsonLd.cookTime),
+  });
+
+  const yieldDecl = buildYield(slug, jsonLd.recipeYield);
+
+  const ingredientLines = collectIngredientLines(jsonLd.recipeIngredient);
+  const ingredientBlocks = ingredientLines.map((line, idx) => buildIngredient(idx + 1, line));
+
+  const instructions = extractInstructionTexts(jsonLd.recipeInstructions);
+  const stepBlocks = instructions.map((text) => `@step("${escapeQuoted(text)}")`);
+
+  const tagBlocks = buildTags(jsonLd.recipeCategory, jsonLd.recipeCuisine);
+
+  const lines = [header, yieldDecl, ...ingredientBlocks, ...stepBlocks];
+  if (tagBlocks.length > 0) lines.push(...tagBlocks);
+
+  return {
+    dsl: lines.join('\n') + '\n',
+    slug,
+    stats: {
+      ingredients: ingredientBlocks.length,
+      steps: stepBlocks.length,
+      tags: tagBlocks.length,
+    },
+  };
+}
+
+interface HeaderArgs {
+  slug: string;
+  title: string;
+  summary: string | null;
+  servings: number;
+  prepMins: number | null;
+  cookMins: number | null;
+}
+
+function buildRecipeHeader(args: HeaderArgs): string {
+  const parts = [
+    `slug="${escapeQuoted(args.slug)}"`,
+    `title="${escapeQuoted(args.title)}"`,
+    `servings=${args.servings}`,
+  ];
+  if (args.prepMins !== null) parts.push(`prep_time=${args.prepMins}:min`);
+  if (args.cookMins !== null) parts.push(`cook_time=${args.cookMins}:min`);
+  if (args.summary !== null && args.summary.trim().length > 0) {
+    parts.push(`summary="${escapeQuoted(args.summary.trim())}"`);
+  }
+  return `@recipe(${parts.join(', ')})`;
+}
+
+function buildYield(slug: string, recipeYieldField: unknown): string {
+  const { qty, unit } = parseYield(recipeYieldField);
+  return `@yield(${slug}, ${qty}:${unit})`;
+}
+
+function buildIngredient(index: number, line: string): string {
+  const parsed = parseIngredientLine(line);
+  return `@ingredient(${index}, ${parsed.descriptorSlug}, ${parsed.qty}:${parsed.unit})`;
+}
+
+function buildTags(category: unknown, cuisine: unknown): string[] {
+  const out: string[] = [];
+  for (const value of [category, cuisine]) {
+    const strings = collectStrings(value);
+    for (const s of strings) {
+      const tag = slugify(s);
+      if (tag !== '') out.push(`// tag: ${tag}`);
+    }
+  }
+  return out;
+}
+
+function collectIngredientLines(value: unknown): string[] {
+  const out: string[] = [];
+  if (typeof value === 'string') {
+    out.push(value);
+  } else if (Array.isArray(value)) {
+    for (const item of value) {
+      if (typeof item === 'string') out.push(item);
+    }
+  }
+  return out.map((s) => s.trim()).filter((s) => s.length > 0);
+}
+
+function collectStrings(value: unknown): string[] {
+  if (typeof value === 'string') return [value];
+  if (Array.isArray(value)) {
+    const out: string[] = [];
+    for (const item of value) {
+      if (typeof item === 'string') out.push(item);
+    }
+    return out;
+  }
+  return [];
+}
+
+function pickFirstString(value: unknown): string | null {
+  if (typeof value === 'string') return value.trim();
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const r = pickFirstString(item);
+      if (r !== null) return r;
+    }
+  }
+  return null;
+}
+
+function escapeQuoted(input: string): string {
+  return input.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, ' ');
+}

--- a/apps/pops-worker-food/src/handlers/web/parse-duration.ts
+++ b/apps/pops-worker-food/src/handlers/web/parse-duration.ts
@@ -1,0 +1,58 @@
+/**
+ * PRD-127 — duration parsing.
+ *
+ * Recipe JSON-LD declares durations as ISO 8601 strings (`PT5M`, `PT1H30M`,
+ * `PT45S`). Real-world sites often violate the spec and emit plain text
+ * ("5 minutes", "1 hr 30 min"). We try strict ISO first, then a permissive
+ * heuristic. Output is the duration in **minutes** (rounded), which is the
+ * unit the DSL header consumes via `@recipe(prep_time=N:min)`.
+ *
+ * Returns `null` when nothing parses — the caller drops the field from the
+ * DSL rather than emitting `0:min`.
+ */
+const ISO_RE = /^P(?:T)?(?:(\d+(?:\.\d+)?)H)?(?:(\d+(?:\.\d+)?)M)?(?:(\d+(?:\.\d+)?)S)?$/i;
+
+export function parseDurationMinutes(input: unknown): number | null {
+  if (typeof input !== 'string') return null;
+  const trimmed = input.trim();
+  if (trimmed === '') return null;
+  const iso = parseIso(trimmed);
+  if (iso !== null) return iso;
+  return parseHeuristic(trimmed);
+}
+
+function parseIso(input: string): number | null {
+  const m = ISO_RE.exec(input);
+  if (m === null) return null;
+  const [, h, mm, ss] = m;
+  if (h === undefined && mm === undefined && ss === undefined) return null;
+  const hours = h === undefined ? 0 : Number(h);
+  const minutes = mm === undefined ? 0 : Number(mm);
+  const seconds = ss === undefined ? 0 : Number(ss);
+  const total = hours * 60 + minutes + seconds / 60;
+  if (!Number.isFinite(total)) return null;
+  const rounded = Math.round(total);
+  return rounded > 0 ? rounded : null;
+}
+
+const HOUR_TOKEN = /(\d+(?:\.\d+)?)\s*(?:hours?|hrs?|h)\b/i;
+const MINUTE_TOKEN = /(\d+(?:\.\d+)?)\s*(?:minutes?|mins?|m)\b/i;
+
+function parseHeuristic(input: string): number | null {
+  const hourMatch = HOUR_TOKEN.exec(input);
+  const minuteMatch = MINUTE_TOKEN.exec(input);
+  if (hourMatch === null && minuteMatch === null) {
+    const bareNumber = /^(\d+(?:\.\d+)?)$/.exec(input);
+    if (bareNumber !== null) {
+      const n = Math.round(Number(bareNumber[1]));
+      return n > 0 ? n : null;
+    }
+    return null;
+  }
+  const hours = hourMatch ? Number(hourMatch[1]) : 0;
+  const minutes = minuteMatch ? Number(minuteMatch[1]) : 0;
+  const total = hours * 60 + minutes;
+  if (!Number.isFinite(total)) return null;
+  const rounded = Math.round(total);
+  return rounded > 0 ? rounded : null;
+}

--- a/apps/pops-worker-food/src/handlers/web/parse-ingredient-line.ts
+++ b/apps/pops-worker-food/src/handlers/web/parse-ingredient-line.ts
@@ -1,0 +1,230 @@
+/**
+ * PRD-127 — ingredient-line heuristic.
+ *
+ * JSON-LD ingredient lines are free-form strings:
+ *
+ *   - "500g beef chuck mince"
+ *   - "1 cup milk"
+ *   - "½ tsp salt"
+ *   - "1 cup (240ml) milk"
+ *   - "salt"
+ *
+ * The mapping is deliberately dumb (per the PRD): split into qty + unit +
+ * descriptor; let the resolver auto-create the ingredient slug; the user
+ * cleans up the noisy descriptors from the review queue.
+ */
+import { slugify } from './slugify.js';
+
+export interface IngredientParse {
+  qty: number;
+  unit: string;
+  descriptorSlug: string;
+  /** Original descriptor text (post strip of qty/unit/parens). Used in step-text refs. */
+  descriptorRaw: string;
+}
+
+const UNICODE_FRACTIONS: Record<string, number> = {
+  '½': 0.5,
+  '⅓': 1 / 3,
+  '⅔': 2 / 3,
+  '¼': 0.25,
+  '¾': 0.75,
+  '⅕': 0.2,
+  '⅖': 0.4,
+  '⅗': 0.6,
+  '⅘': 0.8,
+  '⅙': 1 / 6,
+  '⅚': 5 / 6,
+  '⅛': 0.125,
+  '⅜': 0.375,
+  '⅝': 0.625,
+  '⅞': 0.875,
+};
+
+// Order matters: the multi-character "ml" must beat the single-letter "l", etc.
+const KNOWN_UNITS: readonly string[] = [
+  'tablespoons',
+  'tablespoon',
+  'teaspoons',
+  'teaspoon',
+  'tbsp',
+  'tsp',
+  'cups',
+  'cup',
+  'ounces',
+  'ounce',
+  'pounds',
+  'pound',
+  'grams',
+  'gram',
+  'kilograms',
+  'kilogram',
+  'litres',
+  'liters',
+  'litre',
+  'liter',
+  'millilitres',
+  'milliliters',
+  'millilitre',
+  'milliliter',
+  'pieces',
+  'piece',
+  'slices',
+  'slice',
+  'cloves',
+  'clove',
+  'sprigs',
+  'sprig',
+  'cans',
+  'can',
+  'cans',
+  'lb',
+  'lbs',
+  'oz',
+  'mg',
+  'kg',
+  'ml',
+  'cl',
+  'dl',
+  'l',
+  'g',
+];
+
+const UNIT_ALIASES: Record<string, string> = {
+  tablespoons: 'tbsp',
+  tablespoon: 'tbsp',
+  teaspoons: 'tsp',
+  teaspoon: 'tsp',
+  cups: 'cup',
+  ounces: 'oz',
+  ounce: 'oz',
+  pounds: 'lb',
+  pound: 'lb',
+  lbs: 'lb',
+  grams: 'g',
+  gram: 'g',
+  kilograms: 'kg',
+  kilogram: 'kg',
+  litres: 'l',
+  liters: 'l',
+  litre: 'l',
+  liter: 'l',
+  millilitres: 'ml',
+  milliliters: 'ml',
+  millilitre: 'ml',
+  milliliter: 'ml',
+  pieces: 'count',
+  piece: 'count',
+  slices: 'slice',
+  cloves: 'clove',
+  sprigs: 'sprig',
+  cans: 'can',
+};
+
+export function parseIngredientLine(raw: string): IngredientParse {
+  const stripped = stripHtml(raw)
+    .replace(/\s*\([^)]*\)/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (stripped === '') {
+    return { qty: 1, unit: 'count', descriptorSlug: 'ingredient', descriptorRaw: '' };
+  }
+  const { qty, rest: afterQty } = readQuantity(stripped);
+  if (qty === null) {
+    const desc = afterQty.trim();
+    return {
+      qty: 1,
+      unit: 'count',
+      descriptorSlug: slugify(desc) || 'ingredient',
+      descriptorRaw: desc,
+    };
+  }
+  const { unit, rest: afterUnit } = readUnit(afterQty);
+  const descriptor = afterUnit.replace(/^[,\s]+/, '').trim();
+  const descriptorSlug = slugify(descriptor) || 'ingredient';
+  return { qty, unit, descriptorSlug, descriptorRaw: descriptor };
+}
+
+interface QuantityRead {
+  qty: number | null;
+  rest: string;
+}
+
+function readQuantity(input: string): QuantityRead {
+  const head = input[0];
+  if (head !== undefined && head in UNICODE_FRACTIONS) {
+    const frac = UNICODE_FRACTIONS[head] ?? 0;
+    return { qty: frac, rest: input.slice(1).trim() };
+  }
+  // Mixed unicode-fraction form: `2¼` — integer then unicode fraction with
+  // no separator.
+  const mixedUnicode = /^(\d+)([½⅓⅔¼¾⅕⅖⅗⅘⅙⅚⅛⅜⅝⅞])\s*/u.exec(input);
+  if (mixedUnicode !== null) {
+    const whole = Number(mixedUnicode[1] ?? '0');
+    const fracKey = mixedUnicode[2] ?? '';
+    const fracVal = UNICODE_FRACTIONS[fracKey] ?? 0;
+    return { qty: round3(whole + fracVal), rest: input.slice(mixedUnicode[0].length) };
+  }
+  // ASCII fractions must be matched before bare digits so the regex doesn't
+  // greedily consume the numerator and leave the denominator behind.
+  const numberMatch = /^(\d+\/\d+|\d+(?:\s+\d+\/\d+)?(?:\.\d+)?)\s*/u.exec(input);
+  if (numberMatch === null) return { qty: null, rest: input };
+
+  const numberRaw = numberMatch[1] ?? '';
+  const rest = input.slice(numberMatch[0].length);
+  if (numberRaw.includes('/')) return parseAsciiFraction(numberRaw, rest, input);
+  return { qty: round3(Number(numberRaw)), rest };
+}
+
+function parseAsciiFraction(numberRaw: string, rest: string, originalInput: string): QuantityRead {
+  const parts = numberRaw.split(/\s+/);
+  let total = 0;
+  for (const part of parts) {
+    if (part.includes('/')) {
+      const [nStr, dStr] = part.split('/');
+      const n = Number(nStr);
+      const d = Number(dStr);
+      if (!Number.isFinite(n) || !Number.isFinite(d) || d === 0) {
+        return { qty: null, rest: originalInput };
+      }
+      total += n / d;
+    } else {
+      total += Number(part);
+    }
+  }
+  return { qty: round3(total), rest };
+}
+
+function round3(value: number): number {
+  return Math.round(value * 1000) / 1000;
+}
+
+interface UnitRead {
+  unit: string;
+  rest: string;
+}
+
+function readUnit(input: string): UnitRead {
+  const trimmed = input.replace(/^[\s,]+/, '');
+  // Sticky unit (e.g. "500g") — already tokenised: the qty regex ate the digits but
+  // a sticky letter cluster may now lead `trimmed`.
+  const stickyMatch = /^([a-zA-Z]+)\b/.exec(trimmed);
+  if (stickyMatch === null) {
+    return { unit: 'count', rest: trimmed };
+  }
+  const candidate = (stickyMatch[1] ?? '').toLowerCase();
+  for (const known of KNOWN_UNITS) {
+    if (candidate === known) {
+      const rest = trimmed.slice(stickyMatch[0].length);
+      const unit = UNIT_ALIASES[known] ?? known;
+      return { unit, rest };
+    }
+  }
+  // Not a known unit token — treat the whole remainder as the descriptor and
+  // default unit to `count`.
+  return { unit: 'count', rest: trimmed };
+}
+
+function stripHtml(input: string): string {
+  return input.replace(/<[^>]*>/g, '');
+}

--- a/apps/pops-worker-food/src/handlers/web/parse-ingredient-line.ts
+++ b/apps/pops-worker-food/src/handlers/web/parse-ingredient-line.ts
@@ -77,7 +77,6 @@ const KNOWN_UNITS: readonly string[] = [
   'sprig',
   'cans',
   'can',
-  'cans',
   'lb',
   'lbs',
   'oz',
@@ -132,17 +131,24 @@ export function parseIngredientLine(raw: string): IngredientParse {
   const { qty, rest: afterQty } = readQuantity(stripped);
   if (qty === null) {
     const desc = afterQty.trim();
-    return {
-      qty: 1,
-      unit: 'count',
-      descriptorSlug: slugify(desc) || 'ingredient',
-      descriptorRaw: desc,
-    };
+    return { qty: 1, unit: 'count', descriptorSlug: descriptorSlugOf(desc), descriptorRaw: desc };
   }
   const { unit, rest: afterUnit } = readUnit(afterQty);
   const descriptor = afterUnit.replace(/^[,\s]+/, '').trim();
-  const descriptorSlug = slugify(descriptor) || 'ingredient';
-  return { qty, unit, descriptorSlug, descriptorRaw: descriptor };
+  return { qty, unit, descriptorSlug: descriptorSlugOf(descriptor), descriptorRaw: descriptor };
+}
+
+/**
+ * `slugify('')` returns the recipe-level fallback `'recipe'`, which is the
+ * wrong default for an ingredient descriptor — it can collide with the
+ * recipe slug itself. For ingredient lines with a quantity/unit but no
+ * descriptor (e.g. just "2" or "2 ,"), emit the explicit `'ingredient'`
+ * sentinel instead.
+ */
+function descriptorSlugOf(descriptor: string): string {
+  if (descriptor.trim() === '') return 'ingredient';
+  const slug = slugify(descriptor);
+  return slug === 'recipe' ? 'ingredient' : slug;
 }
 
 interface QuantityRead {

--- a/apps/pops-worker-food/src/handlers/web/parse-yield.ts
+++ b/apps/pops-worker-food/src/handlers/web/parse-yield.ts
@@ -1,0 +1,64 @@
+/**
+ * PRD-127 — `recipeYield` parsing.
+ *
+ * The field is one of:
+ *   - A number: `4`.
+ *   - A short noun phrase: `"4 servings"`, `"4-6 servings"`, `"makes 12 cookies"`.
+ *   - An array of strings (rare; schema.org allows it).
+ *
+ * Returns `{ qty, unit }` where unit is a DSL slug. If only a number is
+ * present, unit defaults to `"serving"`. If no number can be extracted,
+ * we fall back to `{ qty: 4, unit: 'serving' }` per the PRD: "Pick first
+ * number (4). Fallback to 4 if unparseable."
+ */
+export interface YieldParse {
+  qty: number;
+  unit: string;
+}
+
+const NUMBER_RE = /(\d+(?:\.\d+)?)/;
+const WORD_RE = /([a-z][a-z-]*)/i;
+
+export function parseYield(input: unknown): YieldParse {
+  const raw = pickFirstString(input);
+  if (raw === null) return { qty: 4, unit: 'serving' };
+  const number = NUMBER_RE.exec(raw);
+  if (number === null) {
+    // No number anywhere → unparseable. Per PRD: fall back to 4 servings.
+    return { qty: 4, unit: 'serving' };
+  }
+  const qty = Math.max(1, Math.round(Number(number[1] ?? '0')));
+  const remainder = raw.slice(number.index + number[0].length).trim();
+  const wordMatch = WORD_RE.exec(remainder);
+  const word = wordMatch ? (wordMatch[1] ?? '').toLowerCase() : '';
+  const unit = normaliseYieldUnit(word);
+  return { qty, unit };
+}
+
+function pickFirstString(input: unknown): string | null {
+  if (typeof input === 'string') return input;
+  if (typeof input === 'number' && Number.isFinite(input)) return String(input);
+  if (Array.isArray(input)) {
+    for (const item of input) {
+      const r = pickFirstString(item);
+      if (r !== null) return r;
+    }
+  }
+  return null;
+}
+
+/**
+ * Map the noun word into a DSL-grammar slug. We keep this very small —
+ * Recipe sites mostly say "servings", sometimes "cookies", "loaves",
+ * "rolls", "burgers". Anything else collapses to the noun itself
+ * (slug-trimmed) or `serving` as the final fallback.
+ */
+function normaliseYieldUnit(word: string): string {
+  if (word === '') return 'serving';
+  if (word === 'servings' || word === 'serving' || word === 'portions' || word === 'portion') {
+    return 'serving';
+  }
+  const slug = word.replace(/[^a-z0-9-]+/g, '-').replace(/^-+|-+$/g, '');
+  if (slug === '' || !/^[a-z]/.test(slug)) return 'serving';
+  return slug;
+}

--- a/apps/pops-worker-food/src/handlers/web/slugify.ts
+++ b/apps/pops-worker-food/src/handlers/web/slugify.ts
@@ -1,0 +1,31 @@
+/**
+ * PRD-127 — slugify a human string into the DSL-grammar slug shape:
+ *
+ *   - Starts with `[a-z]`.
+ *   - Continues with `[a-z0-9-]`.
+ *
+ * Strategy: lowercase + NFKD-normalize to strip diacritics, replace any
+ * remaining non `[a-z0-9]` runs with a single hyphen, trim leading/trailing
+ * hyphens, ensure it starts with a letter (prepend `r-` if it starts with
+ * a digit), and fall back to `recipe` for the empty case.
+ */
+export function slugify(input: string): string {
+  const lower = input.toLowerCase();
+  const stripped = lower.normalize('NFKD').replace(/[̀-ͯ]/g, '');
+  const ascii = stripped.replace(/ß/g, 'ss').replace(/œ/g, 'oe').replace(/æ/g, 'ae');
+  let collapsed = ascii.replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+  if (collapsed === '') collapsed = 'recipe';
+  if (/^[0-9]/.test(collapsed)) collapsed = `r-${collapsed}`;
+  return collapsed;
+}
+
+/**
+ * Disambiguate `slug` against `existing`. Returns `slug` if free; else
+ * appends `-2`, `-3`, ... until a free name is found.
+ */
+export function disambiguateSlug(slug: string, existing: ReadonlySet<string>): string {
+  if (!existing.has(slug)) return slug;
+  let n = 2;
+  while (existing.has(`${slug}-${n}`)) n += 1;
+  return `${slug}-${n}`;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -435,6 +435,9 @@ importers:
       '@pops/api':
         specifier: workspace:*
         version: link:../pops-api
+      '@pops/app-food':
+        specifier: workspace:*
+        version: link:../../packages/app-food
       '@types/node':
         specifier: ^25.9.1
         version: 25.9.1


### PR DESCRIPTION
## Summary

- Replaces the PRD-126 `NotImplemented` stub for `url-web` with the deterministic JSON-LD path: fetch the page, walk `<script type="application/ld+json">` blocks, find the first schema.org `Recipe` node, map it to the PRD-114 DSL.
- No LLM call lives here; no `ai_inference_log` rows are written. When JSON-LD is absent or malformed, the handler returns `JsonLdMissing` so the inbox makes the gap visible until PRD-128 wires the LLM fallback.
- 100% deterministic — same HTML in, same DSL out. The PRD-114 parser is the contract; each fixture's produced DSL goes through `parseRecipeDsl` so anything that would block PRD-116's compile against a real DB is caught here.

## What changed

| Area | File(s) |
| ---- | ------- |
| Fetcher | `apps/pops-worker-food/src/handlers/web/fetch-html.ts` (+ `fetch-html-redirect.ts`, `fetch-html-body.ts`) — Undici `fetch` wrapper with 15s timeout, 5-hop redirect cap, identifiable User-Agent, content-type + 5 MB body guards. Streaming body reader is OOM-safe. |
| Extractor | `web/extract-json-ld.ts` — depth-first walk: raw arrays, `@graph`, `mainEntity`, `mainEntityOfPage`, `itemReviewed`. Skips malformed blocks; matches `Recipe` and `https://schema.org/Recipe` and array `@type`. |
| Mappers | `web/parse-duration.ts` (ISO 8601 + plain-text), `web/parse-yield.ts` (qty + unit + fallbacks), `web/parse-ingredient-line.ts` (sticky metric, unicode + ASCII fractions, parenthetical strip), `web/extract-instructions.ts` (HowToStep / HowToSection / flat string), `web/slugify.ts` (DSL grammar slug rules + diacritic strip + collision suffixing), `web/map-to-dsl.ts` (final assembly). |
| Handler | `handlers/web-url.ts` — fetch → extract → map staged with per-stage meta JSON, cancellation between stages, structured `errorCode` discriminators. |
| Tests | 10 real-world recipe HTML fixtures + 1 no-JSON-LD page; unit tests for every helper; observability drift trip-wire. 102/102 worker tests green. |
| Coordination | `@pops/app-food` added as **devDependency** so the fixture test can deep-import the PRD-114 parser without dragging the React surface in. Existing PRD-126 dispatch test trimmed: `url-web` no longer in the `NotImplemented` allowlist. |

## AC coverage (PRD-127 README)

### Fetcher
- [x] `fetchHtml(url)` handles 200/301/302/4xx/5xx; follows up to 5 redirects; 15s timeout; rejects non-HTML content-type and >5 MB body.
- [x] Identifiable User-Agent string includes the project name.

### JSON-LD extractor
- [x] Walks all `<script type="application/ld+json">` tags; parses each independently with `JSON.parse`.
- [x] Finds first node with `@type='Recipe'`; handles arrays, `@graph`, `mainEntity`, absolute `schema.org/Recipe`.
- [x] Returns null when no Recipe node found (triggers PRD-128 fallback).

### Mapper
- [x] Maps each JSON-LD field per the PRD table.
- [x] ISO 8601 duration parser handles `PT5M`, `PT1H30M`, `PT45S`; fallback heuristic for plain text.
- [x] Ingredient-line heuristic parses qty + unit + descriptor; handles unicode fractions, ASCII slashes, mixed fractions; falls back to qty=1, unit=count.
- [x] Step text stripped of HTML tags.
- [x] Yield ingredient defaults to recipe slug.

### End-to-end
- [x] Fixture suite at `apps/pops-worker-food/src/__tests__/web-jsonld.fixtures.test.ts` with **10** real-world recipe HTML samples under `apps/pops-worker-food/src/__tests__/fixtures/web/`.
- [x] Each fixture asserts: JSON-LD detected; DSL parses via PRD-114's `parseRecipeDsl` (= same parser PRD-116's compile consumes).
- [x] No-JSON-LD fixture returns null from the extractor + `JsonLdMissing` from the handler.

> Compile-against-in-memory-DB validation is satisfied at the parser layer (parse failures are what would block compile downstream). A full DB-backed integration test belongs in the cross-package layer when PRD-125's `food.ingest.workerComplete` is wired end-to-end.

### Observability
- [x] Meta JSON populated with `fetch` / `jsonld_extract` / `mapping` stage records.
- [x] No `ai_inference_log` rows on this path — asserted by a drift trip-wire test that fails if any meta stage gains a `model` / `input_tokens` / `output_tokens` field.

## Test plan

- [x] `pnpm --filter @pops/worker-food test` — 102/102 pass
- [x] `pnpm typecheck` — green
- [x] `pnpm lint` — green (no new warnings or errors)
- [x] `pnpm format:check` — green
- [x] `pnpm turbo build --continue` — 10/10 green
- [ ] Copilot review pass
- [ ] CI green