### PR TITLE
feat(core-db): cut over pops-api service-accounts to @pops/core-db (pillar core phase 1 PR 3)

### DIFF
--- a/.github/workflows/_pkg-check.yml
+++ b/.github/workflows/_pkg-check.yml
@@ -46,6 +46,7 @@ jobs:
           pnpm --filter @pops/types build
           pnpm --filter @pops/module-registry build
           pnpm --filter @pops/food-contracts build
+          pnpm --filter @pops/core-db build
           pnpm --filter @pops/app-lists-db build
           pnpm --filter @pops/app-food-db build
       - run: cd ${{ inputs.package-path }} && pnpm typecheck
@@ -77,6 +78,7 @@ jobs:
           pnpm --filter @pops/types build
           pnpm --filter @pops/module-registry build
           pnpm --filter @pops/food-contracts build
+          pnpm --filter @pops/core-db build
           pnpm --filter @pops/app-lists-db build
           pnpm --filter @pops/app-food-db build
       - name: Run tests (with coverage if configured)

--- a/.github/workflows/api-quality.yml
+++ b/.github/workflows/api-quality.yml
@@ -67,6 +67,7 @@ jobs:
           cd ../types && pnpm build
           cd ../module-registry && pnpm build
           cd ../food-contracts && pnpm build
+          cd ../core-db && pnpm build
           cd ../app-lists-db && pnpm build
           cd ../app-food-db && pnpm build
 

--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -62,6 +62,7 @@ jobs:
           cd ../types && pnpm build
           cd ../module-registry && pnpm build
           cd ../food-contracts && pnpm build
+          cd ../core-db && pnpm build
           cd ../app-lists-db && pnpm build
           cd ../app-food-db && pnpm build
 

--- a/.github/workflows/fe-quality.yml
+++ b/.github/workflows/fe-quality.yml
@@ -73,6 +73,7 @@ jobs:
           cd ../types && pnpm build
           cd ../module-registry && pnpm build
           cd ../food-contracts && pnpm build
+          cd ../core-db && pnpm build
           cd ../app-lists-db && pnpm build
           cd ../app-food-db && pnpm build
 

--- a/.github/workflows/fe-test-e2e.yml
+++ b/.github/workflows/fe-test-e2e.yml
@@ -62,6 +62,7 @@ jobs:
           cd ../types && pnpm build
           cd ../module-registry && pnpm build
           cd ../food-contracts && pnpm build
+          cd ../core-db && pnpm build
           cd ../app-lists-db && pnpm build
           cd ../app-food-db && pnpm build
 

--- a/apps/pops-api/Dockerfile
+++ b/apps/pops-api/Dockerfile
@@ -11,6 +11,7 @@ COPY packages/module-registry/package.json ./packages/module-registry/
 COPY packages/app-food-db/package.json ./packages/app-food-db/
 COPY packages/app-lists/package.json ./packages/app-lists/
 COPY packages/app-lists-db/package.json ./packages/app-lists-db/
+COPY packages/core-db/package.json ./packages/core-db/
 COPY packages/food-contracts/package.json ./packages/food-contracts/
 COPY apps/pops-api/package.json ./apps/pops-api/
 
@@ -30,6 +31,9 @@ COPY packages/app-lists-db/src ./packages/app-lists-db/src
 COPY packages/app-lists-db/tsconfig.json ./packages/app-lists-db/
 COPY packages/app-food-db/src ./packages/app-food-db/src
 COPY packages/app-food-db/tsconfig.json ./packages/app-food-db/
+COPY packages/core-db/src ./packages/core-db/src
+COPY packages/core-db/tsconfig.json ./packages/core-db/
+COPY packages/core-db/migrations ./packages/core-db/migrations
 COPY packages/food-contracts/src ./packages/food-contracts/src
 COPY packages/food-contracts/tsconfig.json ./packages/food-contracts/
 COPY apps/pops-api/tsconfig.json ./apps/pops-api/
@@ -43,6 +47,8 @@ RUN pnpm build
 WORKDIR /app/packages/module-registry
 RUN pnpm build
 WORKDIR /app/packages/food-contracts
+RUN pnpm build
+WORKDIR /app/packages/core-db
 RUN pnpm build
 WORKDIR /app/packages/app-lists-db
 RUN pnpm build
@@ -83,6 +89,9 @@ COPY --from=builder /app/packages/app-lists-db/dist ./node_modules/@pops/app-lis
 COPY --from=builder /app/packages/app-lists-db/package.json ./node_modules/@pops/app-lists-db/
 COPY --from=builder /app/packages/app-lists/src ./node_modules/@pops/app-lists/src
 COPY --from=builder /app/packages/app-lists/package.json ./node_modules/@pops/app-lists/
+COPY --from=builder /app/packages/core-db/dist ./node_modules/@pops/core-db/dist
+COPY --from=builder /app/packages/core-db/package.json ./node_modules/@pops/core-db/
+COPY --from=builder /app/packages/core-db/migrations ./node_modules/@pops/core-db/migrations
 
 # Copy types source into node_modules (source-only package, no build step)
 COPY --from=builder /app/packages/types/src ./node_modules/@pops/types/src

--- a/apps/pops-api/package.json
+++ b/apps/pops-api/package.json
@@ -78,6 +78,7 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@pops/app-food-db": "workspace:*",
     "@pops/app-lists-db": "workspace:*",
+    "@pops/core-db": "workspace:*",
     "@pops/db-types": "workspace:*",
     "@pops/food-contracts": "workspace:*",
     "@pops/module-registry": "workspace:*",

--- a/apps/pops-api/src/modules/core/service-accounts/key.ts
+++ b/apps/pops-api/src/modules/core/service-accounts/key.ts
@@ -1,89 +1,15 @@
 /**
- * Service-account API key generation, parsing, hashing and verification.
+ * Re-export shim for the service-account key primitives.
  *
- * Wire format: `pops_sa_<prefix>.<secret>`
- *   - `pops_sa_` is a literal marker so leaked keys are easy to detect by
- *     pattern (similar to GitHub's `ghp_` / `ghs_` convention).
- *   - `<prefix>` is 8 url-safe base64 characters (~48 bits of entropy)
- *     used as a fast O(1) DB lookup. Stored in the clear.
- *   - `<secret>` is 32 url-safe base64 characters (~192 bits of entropy)
- *     hashed with scrypt before storage.
- *
- * Why scrypt: it ships with Node, no native deps to compile in CI / Alpine
- * containers, and is good enough for a key with 192 bits of entropy where
- * brute-force is not the threat model.
+ * Canonical implementation lives in `@pops/core-db`'s
+ * `serviceAccountKeys` namespace. This shim preserves the existing
+ * `./key.js` import path during the core pillar Phase 1 cutover; PR 4 of
+ * the phase replaces these imports with the package directly and deletes
+ * this file.
  */
-import { randomBytes, scrypt, timingSafeEqual } from 'node:crypto';
-import { promisify } from 'node:util';
+import { serviceAccountKeys } from '@pops/core-db';
 
-const scryptAsync = promisify(scrypt);
-
-const KEY_MARKER = 'pops_sa_';
-const PREFIX_BYTES = 6; // 8 base64 chars after url-safe encode without padding
-const SECRET_BYTES = 24; // 32 base64 chars after url-safe encode without padding
-const SCRYPT_KEYLEN = 64;
-const SALT_BYTES = 16;
-const HASH_FORMAT_VERSION = 'scrypt';
-
-function urlSafeBase64(buf: Buffer): string {
-  return buf.toString('base64').replaceAll('+', '-').replaceAll('/', '_').replaceAll('=', '');
-}
-
-export interface IssuedKey {
-  /** The full plaintext key. Show to operator once, never persist. */
-  plaintext: string;
-  /** The 8-char prefix to store in the DB for fast lookup. */
-  prefix: string;
-  /** scrypt-encoded hash of the secret half, ready to persist. */
-  hash: string;
-}
-
-/** Generate a fresh API key plus its persistable prefix and hash. */
-export async function generateApiKey(): Promise<IssuedKey> {
-  const prefix = urlSafeBase64(randomBytes(PREFIX_BYTES)).slice(0, 8);
-  const secret = urlSafeBase64(randomBytes(SECRET_BYTES)).slice(0, 32);
-  const plaintext = `${KEY_MARKER}${prefix}.${secret}`;
-  const hash = await hashSecret(secret);
-  return { plaintext, prefix, hash };
-}
-
-/**
- * Parse a presented header value into its prefix + secret components.
- * Returns null if the input is malformed (caller should reject with 401).
- */
-export function parseApiKey(header: string): { prefix: string; secret: string } | null {
-  if (!header.startsWith(KEY_MARKER)) return null;
-  const body = header.slice(KEY_MARKER.length);
-  const dot = body.indexOf('.');
-  if (dot !== 8) return null; // prefix must be exactly 8 chars
-  const prefix = body.slice(0, 8);
-  const secret = body.slice(9);
-  if (secret.length === 0) return null;
-  return { prefix, secret };
-}
-
-async function hashSecret(secret: string): Promise<string> {
-  const salt = randomBytes(SALT_BYTES);
-  const derived = (await scryptAsync(secret, salt, SCRYPT_KEYLEN)) as Buffer;
-  return `${HASH_FORMAT_VERSION}$${urlSafeBase64(salt)}$${urlSafeBase64(derived)}`;
-}
-
-/**
- * Constant-time verify a presented secret against a stored hash. Returns
- * false on any malformed input (never throws on bad data).
- */
-export async function verifySecret(secret: string, stored: string): Promise<boolean> {
-  const [version, saltB64, hashB64] = stored.split('$');
-  if (version !== HASH_FORMAT_VERSION || !saltB64 || !hashB64) return false;
-  let salt: Buffer;
-  let expected: Buffer;
-  try {
-    salt = Buffer.from(saltB64.replaceAll('-', '+').replaceAll('_', '/'), 'base64');
-    expected = Buffer.from(hashB64.replaceAll('-', '+').replaceAll('_', '/'), 'base64');
-  } catch {
-    return false;
-  }
-  if (expected.length !== SCRYPT_KEYLEN) return false;
-  const derived = (await scryptAsync(secret, salt, SCRYPT_KEYLEN)) as Buffer;
-  return timingSafeEqual(derived, expected);
-}
+export const generateApiKey = serviceAccountKeys.generateApiKey;
+export const parseApiKey = serviceAccountKeys.parseApiKey;
+export const verifySecret = serviceAccountKeys.verifySecret;
+export type IssuedKey = Awaited<ReturnType<typeof serviceAccountKeys.generateApiKey>>;

--- a/apps/pops-api/src/modules/core/service-accounts/service.ts
+++ b/apps/pops-api/src/modules/core/service-accounts/service.ts
@@ -1,185 +1,84 @@
 /**
- * Service-account CRUD + verification.
+ * Thin wrapper around `@pops/core-db`'s service-accounts service.
  *
- * Verification path is hot — every authenticated machine call hits it once.
- * It is intentionally a single indexed read on `key_prefix`, then one scrypt
- * compare. Revoked rows return null without doing the scrypt work.
+ * Resolves the singleton `getDrizzle()` handle and forwards. Translates
+ * the package's typed errors to the HTTP-layer error variants the rest of
+ * pops-api still expects (`NotFoundError`, `ValidationError`, `HttpError`)
+ * so the global error handler keeps producing the same status codes and
+ * i18n keys it did before the core pillar Phase 1 split.
+ *
+ * This shim is deleted in Phase 1 PR 4. Existing callers (`trpc.ts`,
+ * `router.ts`, `service.test.ts`) keep importing from here unchanged; the
+ * deletion PR also flips them to the package directly and drops this file.
  */
-import { randomUUID } from 'node:crypto';
-
-import { eq, isNull, sql } from 'drizzle-orm';
-
-import { serviceAccounts } from '@pops/db-types';
+import {
+  serviceAccountsService,
+  ServiceAccountAlreadyRevokedError,
+  ServiceAccountNameAlreadyExistsError,
+  ServiceAccountNotFoundError,
+} from '@pops/core-db';
 
 import { getDrizzle } from '../../../db.js';
 import { HttpError, NotFoundError, ValidationError } from '../../../shared/errors.js';
-import { generateApiKey, verifySecret } from './key.js';
 
-import type { CreateServiceAccountInput, CreatedServiceAccount, ServiceAccount } from './types.js';
+import type {
+  AuthenticatedServiceAccount as PackageAuthenticatedServiceAccount,
+  CreateServiceAccountInput as PackageCreateServiceAccountInput,
+  CreatedServiceAccount as PackageCreatedServiceAccount,
+  ServiceAccount as PackageServiceAccount,
+} from '@pops/core-db';
 
-interface ServiceAccountRow {
-  id: string;
-  name: string;
-  keyPrefix: string;
-  keyHash: string;
-  scopes: string;
-  createdAt: string;
-  lastUsedAt: string | null;
-  revokedAt: string | null;
-  createdBy: string | null;
-}
-
-function rowToPublic(row: ServiceAccountRow): ServiceAccount {
-  let parsedScopes: string[];
-  try {
-    const parsed: unknown = JSON.parse(row.scopes);
-    parsedScopes = Array.isArray(parsed)
-      ? parsed.filter((s): s is string => typeof s === 'string')
-      : [];
-  } catch {
-    parsedScopes = [];
-  }
-  return {
-    id: row.id,
-    name: row.name,
-    keyPrefix: row.keyPrefix,
-    scopes: parsedScopes,
-    createdAt: row.createdAt,
-    lastUsedAt: row.lastUsedAt,
-    revokedAt: row.revokedAt,
-    createdBy: row.createdBy,
-  };
-}
+export type AuthenticatedServiceAccount = PackageAuthenticatedServiceAccount;
+export type ServiceAccount = PackageServiceAccount;
+export type CreatedServiceAccount = PackageCreatedServiceAccount;
 
 export async function createServiceAccount(
-  input: CreateServiceAccountInput,
+  input: PackageCreateServiceAccountInput,
   createdBy: string | null
 ): Promise<CreatedServiceAccount> {
-  const db = getDrizzle();
-  const existing = db
-    .select()
-    .from(serviceAccounts)
-    .where(eq(serviceAccounts.name, input.name))
-    .all();
-  if (existing.length > 0) {
-    throw new ValidationError({
-      message: `Service account '${input.name}' already exists`,
-    });
+  try {
+    return await serviceAccountsService.createServiceAccount(getDrizzle(), input, createdBy);
+  } catch (err) {
+    if (err instanceof ServiceAccountNameAlreadyExistsError) {
+      throw new ValidationError({ message: err.message });
+    }
+    throw err;
   }
-  const issued = await generateApiKey();
-  const id = `sa_${randomUUID()}`;
-  const now = new Date().toISOString();
-  db.insert(serviceAccounts)
-    .values({
-      id,
-      name: input.name,
-      keyPrefix: issued.prefix,
-      keyHash: issued.hash,
-      scopes: JSON.stringify(input.scopes),
-      createdAt: now,
-      createdBy,
-    })
-    .run();
-  return {
-    id,
-    name: input.name,
-    keyPrefix: issued.prefix,
-    scopes: input.scopes,
-    createdAt: now,
-    lastUsedAt: null,
-    revokedAt: null,
-    createdBy,
-    plaintextKey: issued.plaintext,
-  };
 }
 
 export function listServiceAccounts(): ServiceAccount[] {
-  const db = getDrizzle();
-  const rows = db.select().from(serviceAccounts).orderBy(serviceAccounts.createdAt).all();
-  return rows.map((r): ServiceAccount => rowToPublic(r));
+  return serviceAccountsService.listServiceAccounts(getDrizzle());
 }
 
 export function revokeServiceAccount(id: string): void {
-  const db = getDrizzle();
-  const [row] = db.select().from(serviceAccounts).where(eq(serviceAccounts.id, id)).all();
-  if (!row) throw new NotFoundError('ServiceAccount', id);
-  if (row.revokedAt !== null) {
-    throw new HttpError(409, `Service account '${id}' is already revoked`);
+  try {
+    serviceAccountsService.revokeServiceAccount(getDrizzle(), id);
+  } catch (err) {
+    if (err instanceof ServiceAccountNotFoundError) {
+      throw new NotFoundError('ServiceAccount', id);
+    }
+    if (err instanceof ServiceAccountAlreadyRevokedError) {
+      throw new HttpError(409, err.message);
+    }
+    throw err;
   }
-  db.update(serviceAccounts)
-    .set({ revokedAt: new Date().toISOString() })
-    .where(eq(serviceAccounts.id, id))
-    .run();
 }
 
-/** Result of a successful service-account authentication. */
-export interface AuthenticatedServiceAccount {
-  id: string;
-  name: string;
-  scopes: string[];
-}
-
-/**
- * Verify a presented prefix + secret against the database. Returns the
- * authenticated principal on success or null on any failure path. Updates
- * `last_used_at` opportunistically on success — failures never write.
- */
 export async function authenticateServiceAccount(
   prefix: string,
   secret: string
 ): Promise<AuthenticatedServiceAccount | null> {
-  const db = getDrizzle();
-  const [row] = db
-    .select()
-    .from(serviceAccounts)
-    .where(eq(serviceAccounts.keyPrefix, prefix))
-    .all();
-  if (!row || row.revokedAt !== null) return null;
-  const ok = await verifySecret(secret, row.keyHash);
-  if (!ok) return null;
-
-  // Touch last_used_at — best-effort, errors non-fatal.
-  try {
-    db.update(serviceAccounts)
-      .set({ lastUsedAt: sql`(datetime('now'))` })
-      .where(eq(serviceAccounts.id, row.id))
-      .run();
-  } catch (err) {
-    console.warn('[service-accounts] failed to touch last_used_at:', err);
-  }
-
-  const publicRow = rowToPublic(row);
-  return { id: publicRow.id, name: publicRow.name, scopes: publicRow.scopes };
+  return serviceAccountsService.authenticateServiceAccount(getDrizzle(), prefix, secret);
 }
 
-/**
- * Returns true if the procedure path falls under any of the granted scope
- * prefixes. Scopes use dot-prefix matching: a granted scope `cerebrum.ingest`
- * authorises `cerebrum.ingest.quickCapture` but not `cerebrum.query.ask`.
- */
 export function hasScopeFor(grantedScopes: string[], procedurePath: string): boolean {
-  for (const scope of grantedScopes) {
-    if (scope === procedurePath) return true;
-    if (procedurePath.startsWith(`${scope}.`)) return true;
-  }
-  return false;
+  return serviceAccountsService.hasScopeFor(grantedScopes, procedurePath);
 }
 
-/** Convenience for tests that need a quick lookup. */
 export function getActiveServiceAccountByPrefix(prefix: string): ServiceAccount | null {
-  const db = getDrizzle();
-  const [row] = db
-    .select()
-    .from(serviceAccounts)
-    .where(eq(serviceAccounts.keyPrefix, prefix))
-    .all();
-  if (!row || row.revokedAt !== null) return null;
-  return rowToPublic(row);
+  return serviceAccountsService.getActiveServiceAccountByPrefix(getDrizzle(), prefix);
 }
 
-/** Internal: count active accounts (used by health/admin tooling). */
 export function countActiveServiceAccounts(): number {
-  const db = getDrizzle();
-  const rows = db.select().from(serviceAccounts).where(isNull(serviceAccounts.revokedAt)).all();
-  return rows.length;
+  return serviceAccountsService.countActiveServiceAccounts(getDrizzle());
 }

--- a/apps/pops-mcp/Dockerfile
+++ b/apps/pops-mcp/Dockerfile
@@ -11,6 +11,7 @@ COPY packages/module-registry/package.json ./packages/module-registry/
 COPY packages/app-food-db/package.json ./packages/app-food-db/
 COPY packages/app-lists/package.json ./packages/app-lists/
 COPY packages/app-lists-db/package.json ./packages/app-lists-db/
+COPY packages/core-db/package.json ./packages/core-db/
 COPY packages/food-contracts/package.json ./packages/food-contracts/
 COPY apps/pops-api/package.json ./apps/pops-api/
 COPY apps/pops-mcp/package.json ./apps/pops-mcp/
@@ -31,6 +32,9 @@ COPY packages/app-lists-db/src ./packages/app-lists-db/src
 COPY packages/app-lists-db/tsconfig.json ./packages/app-lists-db/
 COPY packages/app-food-db/src ./packages/app-food-db/src
 COPY packages/app-food-db/tsconfig.json ./packages/app-food-db/
+COPY packages/core-db/src ./packages/core-db/src
+COPY packages/core-db/tsconfig.json ./packages/core-db/
+COPY packages/core-db/migrations ./packages/core-db/migrations
 COPY packages/food-contracts/src ./packages/food-contracts/src
 COPY packages/food-contracts/tsconfig.json ./packages/food-contracts/
 
@@ -51,6 +55,8 @@ RUN pnpm build
 WORKDIR /app/packages/module-registry
 RUN pnpm build
 WORKDIR /app/packages/food-contracts
+RUN pnpm build
+WORKDIR /app/packages/core-db
 RUN pnpm build
 WORKDIR /app/packages/app-lists-db
 RUN pnpm build

--- a/apps/pops-shell/Dockerfile
+++ b/apps/pops-shell/Dockerfile
@@ -15,6 +15,7 @@ COPY packages/app-food-db/package.json ./packages/app-food-db/
 COPY packages/food-contracts/package.json ./packages/food-contracts/
 COPY packages/app-lists/package.json ./packages/app-lists/
 COPY packages/app-lists-db/package.json ./packages/app-lists-db/
+COPY packages/core-db/package.json ./packages/core-db/
 COPY packages/app-media/package.json ./packages/app-media/
 COPY packages/app-inventory/package.json ./packages/app-inventory/
 COPY packages/app-ai/package.json ./packages/app-ai/
@@ -39,6 +40,7 @@ COPY packages/module-registry/tsconfig.json packages/module-registry/tsconfig.bu
 COPY packages/app-lists/ ./packages/app-lists/
 COPY packages/app-lists-db/ ./packages/app-lists-db/
 COPY packages/app-food-db/ ./packages/app-food-db/
+COPY packages/core-db/ ./packages/core-db/
 COPY packages/food-contracts/ ./packages/food-contracts/
 WORKDIR /app/packages/db-types
 RUN pnpm build
@@ -47,6 +49,8 @@ RUN pnpm build
 WORKDIR /app/packages/module-registry
 RUN pnpm build
 WORKDIR /app/packages/food-contracts
+RUN pnpm build
+WORKDIR /app/packages/core-db
 RUN pnpm build
 WORKDIR /app/packages/app-lists-db
 RUN pnpm build

--- a/packages/core-db/src/index.ts
+++ b/packages/core-db/src/index.ts
@@ -17,3 +17,14 @@ export type { CoreDb } from './services/internal.js';
 
 export * as serviceAccountsService from './services/service-accounts.js';
 export * as serviceAccountKeys from './services/service-account-keys.js';
+
+// Public types — re-exported at the package root so consumers can name
+// them without reaching into the namespaces.
+export type {
+  AuthenticatedServiceAccount,
+  CreateServiceAccountInput,
+  CreatedServiceAccount,
+  ServiceAccount,
+} from './services/service-accounts.js';
+
+export type { IssuedKey } from './services/service-account-keys.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       '@pops/app-lists-db':
         specifier: workspace:*
         version: link:../../packages/app-lists-db
+      '@pops/core-db':
+        specifier: workspace:*
+        version: link:../../packages/core-db
       '@pops/db-types':
         specifier: workspace:*
         version: link:../../packages/db-types


### PR DESCRIPTION
## Summary

Third PR of the **core pillar migration** (pillar-migration-roadmap.md Track D · Phase 1 PR 3 of 4).

Flips the sole consumer of the in-tree service-accounts service over to \`@pops/core-db\`. \`apps/pops-api/src/modules/core/service-accounts/{service,key}.ts\` become thin shims that resolve \`getDrizzle()\` and forward to the package. trpc.ts, router.ts, and service.test.ts keep their imports — PR 4 deletes the shims and flips those last call sites.

## What changed

- **\`service.ts\`** — 8 free functions that forward to \`serviceAccountsService.*\`. Typed errors (\`ServiceAccountNameAlreadyExistsError\`, \`ServiceAccountNotFoundError\`, \`ServiceAccountAlreadyRevokedError\`) are translated to the existing \`HttpError\` / \`NotFoundError\` / \`ValidationError\` variants so the global error handler keeps producing the same status codes and i18n keys.
- **\`key.ts\`** — re-exports \`generateApiKey\` / \`parseApiKey\` / \`verifySecret\` + \`IssuedKey\` from \`@pops/core-db\`'s \`serviceAccountKeys\` namespace.
- **\`packages/core-db/src/index.ts\`** — public types (\`AuthenticatedServiceAccount\`, \`CreateServiceAccountInput\`, \`CreatedServiceAccount\`, \`ServiceAccount\`, \`IssuedKey\`) re-exported at the package root so consumers don't have to reach into the namespaces.
- **\`apps/pops-api/package.json\`** — \`@pops/core-db\` added as workspace dep.

## Test coverage

- Wrapper translation paths covered by the existing \`apps/pops-api/src/modules/core/service-accounts/service.test.ts\` suite (28/28 green).
- Package itself is exhaustively covered by the 27 cases that landed in PRs 1 + 2.

## Verification

- \`pnpm test\` (workspace) — 36/36 green
- \`pnpm typecheck\` — 32/32 green
- \`pnpm lint\` / \`pnpm format:check\` — clean

## Test plan

- [ ] CI green on \`core-quality\` (drift guard + package tests)
- [ ] CI green on \`api-quality\` + \`api-test\` (wrapper exercised end-to-end)
- [ ] Copilot review pass