### PR TITLE
feat(food): PRD-128 — web URL LLM fallback (readability + Claude)

### DIFF
--- a/apps/pops-worker-food/package.json
+++ b/apps/pops-worker-food/package.json
@@ -13,10 +13,12 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.100.1",
+    "@mozilla/readability": "^0.6.0",
     "@pops/food-contracts": "workspace:*",
     "@trpc/client": "11.17.0",
     "bullmq": "^5.78.0",
     "ioredis": "^5.11.0",
+    "jsdom": "^25.0.1",
     "pino": "^10.3.1",
     "zod": "^4.4.3"
   },
@@ -24,6 +26,7 @@
     "@pops/api": "workspace:*",
     "@pops/app-food": "workspace:*",
     "@pops/app-food-db": "workspace:*",
+    "@types/jsdom": "^21.1.7",
     "@types/node": "^25.9.1",
     "tsx": "^4.22.4",
     "typescript": "^6.0.3",

--- a/apps/pops-worker-food/src/ai/web-llm-anthropic.ts
+++ b/apps/pops-worker-food/src/ai/web-llm-anthropic.ts
@@ -1,0 +1,61 @@
+/**
+ * PRD-128 — Anthropic SDK wrapper scoped to the web-llm handler.
+ *
+ * Parallel branch coordination: PRD-132's `ai/anthropic.ts` introduces
+ * the canonical wrapper. To avoid path collision while both PRDs are
+ * in flight, this file ships a self-contained equivalent here; the
+ * post-merge dedup task (recorded in the roadmap claim) collapses them.
+ *
+ * The structural `AnthropicLike` subset lets handlers + tests pass
+ * fakes without depending on the SDK's full `Anthropic` type, which is
+ * a class and cannot be subtyped without the unsafe-cast dance.
+ */
+import Anthropic from '@anthropic-ai/sdk';
+
+export interface AnthropicTextBlock {
+  type: 'text';
+  text: string;
+}
+
+export interface AnthropicMessage {
+  content: AnthropicTextBlock[] | { type: string; text?: string }[];
+  usage: { input_tokens: number; output_tokens: number };
+  model: string;
+}
+
+export interface AnthropicLike {
+  messages: {
+    create: (params: {
+      model: string;
+      max_tokens: number;
+      messages: { role: 'user'; content: string }[];
+    }) => Promise<AnthropicMessage>;
+  };
+}
+
+let cachedClient: AnthropicLike | null = null;
+
+export function getAnthropicClient(): AnthropicLike {
+  if (cachedClient != null) return cachedClient;
+  const apiKey = process.env['ANTHROPIC_API_KEY'];
+  if (apiKey == null || apiKey === '') {
+    throw new Error('ANTHROPIC_API_KEY is not set');
+  }
+  cachedClient = new Anthropic({ apiKey }) as unknown as AnthropicLike;
+  return cachedClient;
+}
+
+/** Test seam: replace the cached SDK client with a fake. */
+export function setAnthropicClientForTests(fake: AnthropicLike | null): void {
+  cachedClient = fake;
+}
+
+export function extractTextFromMessage(message: AnthropicMessage): string {
+  let text = '';
+  for (const block of message.content) {
+    if (block.type === 'text' && typeof block.text === 'string') {
+      text += block.text;
+    }
+  }
+  return text;
+}

--- a/apps/pops-worker-food/src/ai/web-llm-log.ts
+++ b/apps/pops-worker-food/src/ai/web-llm-log.ts
@@ -1,0 +1,131 @@
+/**
+ * PRD-128 — local shim for PRD-133's `callClaudeWithLogging`.
+ *
+ * PRD-133 lives in `packages/app-food/src/ai/log-inference.ts` which
+ * has a React dependency tree the worker doesn't want to pull in. This
+ * shim records the same telemetry shape and emits a pino line; the
+ * post-merge follow-up (recorded in the roadmap claim) extracts the
+ * canonical wrapper into a worker-friendly package and swaps this for
+ * a one-line import.
+ *
+ * Operation strings mirror PRD-133's `FoodOperationSchema` literals so
+ * the swap-in is a no-op at the call site.
+ */
+import pino from 'pino';
+
+const logger = pino({ name: 'pops-worker-food.web-llm' });
+
+export type WebLlmOperation = 'recipe-extract-web-llm';
+
+export interface CallClaudeArgs<T> {
+  operation: WebLlmOperation;
+  contextId: string;
+  promptVersion: string;
+  model: string;
+  call: () => Promise<{
+    parsed: T;
+    inputTokens: number;
+    outputTokens: number;
+    raw: string;
+  }>;
+  /** Test seam — receives the log payload that would be persisted. */
+  onLog?: (payload: CallClaudeLogPayload) => void;
+}
+
+export interface CallClaudeLogPayload {
+  operation: WebLlmOperation;
+  contextId: string;
+  promptVersion: string;
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  costUsd: number;
+  latencyMs: number;
+  ok: boolean;
+  errorMessage?: string;
+}
+
+export interface CallClaudeResult<T> {
+  parsed: T;
+  inputTokens: number;
+  outputTokens: number;
+  costUsd: number;
+  latencyMs: number;
+  raw: string;
+}
+
+const HAIKU_INPUT_USD_PER_MTOK = 0.25;
+const HAIKU_OUTPUT_USD_PER_MTOK = 1.25;
+
+function computeCostUsd(inputTokens: number, outputTokens: number): number {
+  return (
+    (inputTokens * HAIKU_INPUT_USD_PER_MTOK + outputTokens * HAIKU_OUTPUT_USD_PER_MTOK) / 1_000_000
+  );
+}
+
+/**
+ * Wraps the inner Claude call so the caller doesn't worry about
+ * timings, cost, or log payload shape. Errors propagate; the log line
+ * captures them as `ok=false` before re-throwing.
+ */
+export async function callClaudeWithLogging<T>(
+  args: CallClaudeArgs<T>
+): Promise<CallClaudeResult<T>> {
+  const startedAt = Date.now();
+  try {
+    const inner = await args.call();
+    const latencyMs = Date.now() - startedAt;
+    const costUsd = computeCostUsd(inner.inputTokens, inner.outputTokens);
+    const payload: CallClaudeLogPayload = {
+      operation: args.operation,
+      contextId: args.contextId,
+      promptVersion: args.promptVersion,
+      model: args.model,
+      inputTokens: inner.inputTokens,
+      outputTokens: inner.outputTokens,
+      costUsd,
+      latencyMs,
+      ok: true,
+    };
+    emit(payload, args.onLog);
+    return {
+      parsed: inner.parsed,
+      inputTokens: inner.inputTokens,
+      outputTokens: inner.outputTokens,
+      costUsd,
+      latencyMs,
+      raw: inner.raw,
+    };
+  } catch (err) {
+    const latencyMs = Date.now() - startedAt;
+    const message = err instanceof Error ? err.message : String(err);
+    emit(
+      {
+        operation: args.operation,
+        contextId: args.contextId,
+        promptVersion: args.promptVersion,
+        model: args.model,
+        inputTokens: 0,
+        outputTokens: 0,
+        costUsd: 0,
+        latencyMs,
+        ok: false,
+        errorMessage: message,
+      },
+      args.onLog
+    );
+    throw err;
+  }
+}
+
+function emit(payload: CallClaudeLogPayload, sink?: (p: CallClaudeLogPayload) => void): void {
+  if (sink != null) {
+    try {
+      sink(payload);
+    } catch {
+      // Logging must never break the call site.
+    }
+    return;
+  }
+  logger.info(payload, 'claude-call');
+}

--- a/apps/pops-worker-food/src/handlers/__tests__/web-llm.test.ts
+++ b/apps/pops-worker-food/src/handlers/__tests__/web-llm.test.ts
@@ -1,0 +1,369 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { setAnthropicClientForTests } from '../../ai/web-llm-anthropic.js';
+import { buildWebLlmDsl, slugify } from '../web-llm-dsl.js';
+import { extractReadable } from '../web-llm-readability.js';
+import { processWithLlm } from '../web-llm.js';
+
+import type { IngestJobData } from '@pops/food-contracts';
+
+import type { AnthropicLike, AnthropicMessage } from '../../ai/web-llm-anthropic.js';
+import type { ExtractedRecipe } from '../web-llm-recipe.js';
+
+const WEB_JOB = {
+  kind: 'url-web',
+  sourceId: 9001,
+  url: 'https://blog.example.com/pasta',
+} as const satisfies IngestJobData;
+
+const SAMPLE_RECIPE: ExtractedRecipe = {
+  title: 'Weeknight Tomato Pasta',
+  summary: 'Quick weeknight pasta with canned tomatoes and basil.',
+  servings: 4,
+  prep_time_minutes: 10,
+  cook_time_minutes: 25,
+  yield_slug: 'tomato-pasta-plate',
+  yield_qty: 4,
+  yield_unit: 'count',
+  tags: ['italian', 'weeknight'],
+  ingredients: [
+    { qty: 400, unit: 'g', ingredient_slug: 'pasta', variant_slug: 'spaghetti', optional: false },
+    {
+      qty: 800,
+      unit: 'g',
+      ingredient_slug: 'tomato',
+      variant_slug: 'canned-whole',
+      prep_state_slug: 'crushed',
+      optional: false,
+    },
+    {
+      qty: 30,
+      unit: 'ml',
+      ingredient_slug: 'olive-oil',
+      prep_state_slug: 'spiralised',
+      optional: false,
+    },
+    { qty: 4, unit: 'count', ingredient_slug: 'garlic', notes: 'fresh if possible' },
+  ],
+  steps: [
+    { body: 'Boil @1 in salted water until al dente.', duration_minutes: 10 },
+    { body: 'Crush @4 and bloom in @3 over low heat.' },
+    { body: 'Add @2 and simmer.' },
+  ],
+};
+
+function fakeClient(
+  content: string,
+  usage = { input_tokens: 1200, output_tokens: 400 }
+): AnthropicLike {
+  const message: AnthropicMessage = {
+    model: 'claude-haiku-4-5-20251001',
+    content: [{ type: 'text', text: content }],
+    usage,
+  };
+  return {
+    messages: {
+      create: vi.fn(async () => message) as AnthropicLike['messages']['create'],
+    },
+  };
+}
+
+const SMALL_HTML = `<!doctype html><html><body><nav>menu</nav><main><h1>${SAMPLE_RECIPE.title}</h1>${'<p>This is a recipe blog post about tomato pasta. '.repeat(20)}</p></main></body></html>`;
+
+describe('slugify', () => {
+  it.each([
+    ['Weeknight Tomato Pasta', 'weeknight-tomato-pasta'],
+    ['  spaced   out  ', 'spaced-out'],
+    ['Café Naïve', 'cafe-naive'],
+    ['Spicy 🌶️ Pasta', 'spicy-pasta'],
+    ['___under_score___', 'under-score'],
+    ['', ''],
+  ])('slugifies %p → %p', (input, expected) => {
+    expect(slugify(input)).toBe(expected);
+  });
+});
+
+describe('extractReadable', () => {
+  it('returns null when content is below the 200-char minimum', () => {
+    const html = '<!doctype html><html><body><main><p>tiny</p></main></body></html>';
+    expect(extractReadable(html, 'https://example.com/')).toBeNull();
+  });
+
+  it('truncates content above 15K chars and flags truncated=true', () => {
+    const long = '<p>recipe text. </p>'.repeat(2000);
+    const html = `<!doctype html><html><body><main><h1>Long Recipe</h1>${long}</main></body></html>`;
+    const article = extractReadable(html, 'https://example.com/');
+    expect(article).not.toBeNull();
+    if (article == null) return;
+    expect(article.truncated).toBe(true);
+    expect(article.textContent.length).toBeLessThanOrEqual(15_000);
+  });
+
+  it('returns title and textContent on a typical recipe blog post', () => {
+    const article = extractReadable(SMALL_HTML, WEB_JOB.url);
+    expect(article).not.toBeNull();
+    if (article == null) return;
+    expect(article.textLength).toBeGreaterThan(200);
+    expect(article.textContent).toContain('tomato pasta');
+  });
+});
+
+describe('buildWebLlmDsl', () => {
+  it('renders the @recipe header with title-derived slug + servings + times', () => {
+    const result = buildWebLlmDsl(SAMPLE_RECIPE, { source: 'url-web', url: WEB_JOB.url });
+    expect(result.slug).toBe('weeknight-tomato-pasta');
+    expect(result.dsl).toMatch(/@recipe\(/);
+    expect(result.dsl).toContain('slug="weeknight-tomato-pasta"');
+    expect(result.dsl).toContain('title="Weeknight Tomato Pasta"');
+    expect(result.dsl).toContain('servings=4');
+    expect(result.dsl).toContain('prep_time=10:min');
+    expect(result.dsl).toContain('cook_time=25:min');
+  });
+
+  it('emits @yield + numbered @ingredient lines', () => {
+    const result = buildWebLlmDsl(SAMPLE_RECIPE, { source: 'url-web', url: WEB_JOB.url });
+    expect(result.dsl).toMatch(/@yield\(tomato-pasta-plate, 4:count\)/);
+    expect(result.dsl).toMatch(/@ingredient\(1, pasta, variant="spaghetti", qty=400, unit="g"\)/);
+    expect(result.dsl).toMatch(
+      /@ingredient\(2, tomato, variant="canned-whole", prep="crushed", qty=800, unit="g"\)/
+    );
+  });
+
+  it('redirects invalid prep_state_slug values to the notes field and counts them', () => {
+    const result = buildWebLlmDsl(SAMPLE_RECIPE, { source: 'url-web', url: WEB_JOB.url });
+    expect(result.prepFallbackCount).toBe(1);
+    expect(result.dsl).toMatch(
+      /@ingredient\(3, olive-oil, qty=30, unit="ml", notes="prep: spiralised"\)/
+    );
+  });
+
+  it('preserves explicit notes alongside prep-fallback notes', () => {
+    const recipe: ExtractedRecipe = {
+      ...SAMPLE_RECIPE,
+      ingredients: [
+        {
+          qty: 1,
+          unit: 'count',
+          ingredient_slug: 'onion',
+          prep_state_slug: 'spiralised',
+          notes: 'red if possible',
+          optional: false,
+        },
+      ],
+    };
+    const result = buildWebLlmDsl(recipe, { source: 'url-web', url: WEB_JOB.url });
+    expect(result.dsl).toContain('notes="prep: spiralised; red if possible"');
+  });
+
+  it('passes @<slug> step refs through verbatim and keeps numeric refs intact', () => {
+    const result = buildWebLlmDsl(SAMPLE_RECIPE, { source: 'url-web', url: WEB_JOB.url });
+    expect(result.dsl).toMatch(/@step\("Boil @1 in salted water until al dente\."\)/);
+    const slugStep: ExtractedRecipe = {
+      ...SAMPLE_RECIPE,
+      steps: [{ body: 'Toss @pasta into the @sauce.' }],
+    };
+    expect(buildWebLlmDsl(slugStep, { source: 'url-web', url: WEB_JOB.url }).dsl).toContain(
+      '@step("Toss @pasta into the @sauce.")'
+    );
+  });
+
+  it('escapes embedded double quotes and backslashes in step bodies', () => {
+    const recipe: ExtractedRecipe = {
+      ...SAMPLE_RECIPE,
+      steps: [{ body: 'Press "smash" patties with a 1\\2 spatula.' }],
+    };
+    const result = buildWebLlmDsl(recipe, { source: 'url-web', url: WEB_JOB.url });
+    expect(result.dsl).toContain('"Press \\"smash\\" patties with a 1\\\\2 spatula."');
+  });
+
+  it('falls back to "untitled-recipe" when the title slugifies to empty', () => {
+    const recipe: ExtractedRecipe = { ...SAMPLE_RECIPE, title: '🍝🍝🍝' };
+    expect(buildWebLlmDsl(recipe, { source: 'url-web', url: WEB_JOB.url }).slug).toBe(
+      'untitled-recipe'
+    );
+  });
+});
+
+describe('processWithLlm', () => {
+  it('returns ok=true with DSL + meta on the happy path', async () => {
+    const onLog = vi.fn();
+    const client = fakeClient(JSON.stringify(SAMPLE_RECIPE));
+
+    const result = await processWithLlm(SMALL_HTML, WEB_JOB, WEB_JOB.url, {
+      client,
+      onLog,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.dsl).toContain('@recipe(');
+    expect(result.dsl).toContain('@ingredient(1, pasta');
+    expect(result.partialReason).toBeUndefined();
+
+    expect(result.meta.stages['readability']).toMatchObject({ ok: true });
+    expect(result.meta.stages['llm_extract']).toMatchObject({
+      ok: true,
+      model: 'claude-haiku-4-5-20251001',
+      prompt_version: 'web-llm-v1.0',
+    });
+    expect(result.meta.stages['dsl_build']).toMatchObject({ ok: true });
+    expect(result.meta.total_cost_usd).toBeGreaterThan(0);
+
+    expect(onLog).toHaveBeenCalledTimes(1);
+    const logged = onLog.mock.calls[0]?.[0];
+    expect(logged).toMatchObject({
+      operation: 'recipe-extract-web-llm',
+      contextId: `ingest_source:${WEB_JOB.sourceId}`,
+      ok: true,
+    });
+  });
+
+  it('returns NoExtractableContent when readability bottoms out', async () => {
+    const client = fakeClient(JSON.stringify(SAMPLE_RECIPE));
+    const result = await processWithLlm(
+      '<html><body><p>too short</p></body></html>',
+      WEB_JOB,
+      WEB_JOB.url,
+      { client }
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errorCode).toBe('NoExtractableContent');
+    expect(result.meta.stages['readability']).toMatchObject({ ok: false });
+    expect(
+      (client.messages.create as unknown as { mock: { calls: unknown[] } }).mock.calls
+    ).toHaveLength(0);
+  });
+
+  it('rejects markdown-fenced LLM responses as malformed JSON', async () => {
+    const fenced = `\`\`\`json\n${JSON.stringify(SAMPLE_RECIPE)}\n\`\`\``;
+    const result = await processWithLlm(SMALL_HTML, WEB_JOB, WEB_JOB.url, {
+      client: fakeClient(fenced),
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errorCode).toBe('LlmExtractFailed');
+    expect(result.errorMessage).toMatch(/malformed-json/);
+    expect(result.meta.llm_raw_output).toBe(fenced);
+  });
+
+  it('rejects zod-shaped violations and surfaces the raw response in meta', async () => {
+    const broken = JSON.stringify({ ...SAMPLE_RECIPE, ingredients: [{ qty: 1 }] });
+    const result = await processWithLlm(SMALL_HTML, WEB_JOB, WEB_JOB.url, {
+      client: fakeClient(broken),
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errorMessage).toMatch(/schema-violation/);
+    expect(result.meta.llm_raw_output).toBe(broken);
+  });
+
+  it('flags 0-ingredient outputs as partial=empty-extraction', async () => {
+    const emptyIng: ExtractedRecipe = { ...SAMPLE_RECIPE, ingredients: [] };
+    const result = await processWithLlm(SMALL_HTML, WEB_JOB, WEB_JOB.url, {
+      client: fakeClient(JSON.stringify(emptyIng)),
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.partialReason).toBe('empty-extraction');
+  });
+
+  it('flags 0-step outputs as partial=empty-extraction', async () => {
+    const emptySteps: ExtractedRecipe = { ...SAMPLE_RECIPE, steps: [] };
+    const result = await processWithLlm(SMALL_HTML, WEB_JOB, WEB_JOB.url, {
+      client: fakeClient(JSON.stringify(emptySteps)),
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.partialReason).toBe('empty-extraction');
+  });
+
+  it('classifies SDK rejections as sdk-error LlmExtractFailed', async () => {
+    const client: AnthropicLike = {
+      messages: {
+        create: vi.fn(async () => {
+          throw new Error('network unreachable');
+        }) as AnthropicLike['messages']['create'],
+      },
+    };
+    const onLog = vi.fn();
+    const result = await processWithLlm(SMALL_HTML, WEB_JOB, WEB_JOB.url, {
+      client,
+      onLog,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errorMessage).toMatch(/sdk-error/);
+    expect(onLog).toHaveBeenCalledWith(expect.objectContaining({ ok: false }));
+  });
+
+  it('returns Cancelled before invoking readability or the LLM when cancelled up-front', async () => {
+    const createSpy = vi.fn();
+    const result = await processWithLlm(SMALL_HTML, WEB_JOB, WEB_JOB.url, {
+      ctx: { isCancelled: () => true },
+      client: { messages: { create: createSpy as AnthropicLike['messages']['create'] } },
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errorCode).toBe('Cancelled');
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns Cancelled after readability when cancellation flips mid-pipeline', async () => {
+    let calls = 0;
+    const createSpy = vi.fn();
+    const result = await processWithLlm(SMALL_HTML, WEB_JOB, WEB_JOB.url, {
+      ctx: {
+        isCancelled: () => {
+          calls += 1;
+          return calls > 1; // false on the pre-readability check, true after.
+        },
+      },
+      client: { messages: { create: createSpy as AnthropicLike['messages']['create'] } },
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errorCode).toBe('Cancelled');
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+
+  it('respects the FOOD_WEB_LLM_MODEL env override', async () => {
+    const prev = process.env['FOOD_WEB_LLM_MODEL'];
+    process.env['FOOD_WEB_LLM_MODEL'] = 'claude-test-model';
+    const created: { model?: string } = {};
+    const client: AnthropicLike = {
+      messages: {
+        create: vi.fn(async (params) => {
+          created.model = params.model;
+          return {
+            model: params.model,
+            content: [{ type: 'text', text: JSON.stringify(SAMPLE_RECIPE) }],
+            usage: { input_tokens: 100, output_tokens: 100 },
+          };
+        }) as AnthropicLike['messages']['create'],
+      },
+    };
+    try {
+      const result = await processWithLlm(SMALL_HTML, WEB_JOB, WEB_JOB.url, { client });
+      expect(result.ok).toBe(true);
+      expect(created.model).toBe('claude-test-model');
+    } finally {
+      if (prev == null) delete process.env['FOOD_WEB_LLM_MODEL'];
+      else process.env['FOOD_WEB_LLM_MODEL'] = prev;
+    }
+  });
+});
+
+describe('getAnthropicClient', () => {
+  it('throws when ANTHROPIC_API_KEY is not set', async () => {
+    const { getAnthropicClient } = await import('../../ai/web-llm-anthropic.js');
+    setAnthropicClientForTests(null);
+    const prev = process.env['ANTHROPIC_API_KEY'];
+    delete process.env['ANTHROPIC_API_KEY'];
+    try {
+      expect(() => getAnthropicClient()).toThrow(/ANTHROPIC_API_KEY/);
+    } finally {
+      if (prev != null) process.env['ANTHROPIC_API_KEY'] = prev;
+    }
+  });
+});

--- a/apps/pops-worker-food/src/handlers/web-llm-dsl.ts
+++ b/apps/pops-worker-food/src/handlers/web-llm-dsl.ts
@@ -1,0 +1,127 @@
+/**
+ * PRD-128 — DSL builder for the LLM-extracted recipe.
+ *
+ * Pure function: `ExtractedRecipe` → PRD-114 DSL string. Scoped to the
+ * web-llm handler to avoid colliding with PRD-132's concurrent
+ * `build-dsl.ts` (same shape, parallel branches — post-merge dedup
+ * task is in the roadmap claim).
+ *
+ * Invariants worth knowing:
+ *   - Slug derivation is best-effort kebab-case; collision is the
+ *     compiler's problem (PRD-115/-116 propose suffixes for unknowns).
+ *   - `prep_state_slug` outside the curated list is pushed to `notes`,
+ *     original preserved per PRD-128 edge-case table.
+ *   - Step bodies that contain `@<slug>` references pass through
+ *     verbatim — PRD-114's grammar accepts both `@N` and `@slug`.
+ */
+import { isCuratedPrepState } from './web-llm-recipe.js';
+
+import type { ExtractedIngredient, ExtractedRecipe } from './web-llm-recipe.js';
+
+export interface BuildWebLlmDslOptions {
+  source: 'url-web';
+  url: string;
+}
+
+export interface BuildWebLlmDslResult {
+  dsl: string;
+  slug: string;
+  prepFallbackCount: number;
+}
+
+const NON_KEBAB_RE = /[^a-z0-9-]+/g;
+const DUP_DASH_RE = /-+/g;
+const EDGE_DASH_RE = /^-+|-+$/g;
+
+export function slugify(input: string): string {
+  return input
+    .normalize('NFKD')
+    .replace(/[̀-ͯ]/g, '')
+    .toLowerCase()
+    .replace(/[\s_]+/g, '-')
+    .replace(NON_KEBAB_RE, '')
+    .replace(DUP_DASH_RE, '-')
+    .replace(EDGE_DASH_RE, '');
+}
+
+function escapeQuoted(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+function formatNumber(value: number): string {
+  if (Number.isInteger(value)) return String(value);
+  return value.toFixed(3).replace(/0+$/, '').replace(/\.$/, '');
+}
+
+interface RenderedIngredient {
+  line: string;
+  prepFallback: boolean;
+}
+
+function renderIngredient(idx: number, ing: ExtractedIngredient): RenderedIngredient {
+  const args: string[] = [String(idx), ing.ingredient_slug];
+  if (ing.variant_slug != null && ing.variant_slug !== '') {
+    args.push(`variant="${escapeQuoted(ing.variant_slug)}"`);
+  }
+  let prepFallback = false;
+  const notesParts: string[] = [];
+  if (ing.prep_state_slug != null && ing.prep_state_slug !== '') {
+    if (isCuratedPrepState(ing.prep_state_slug)) {
+      args.push(`prep="${escapeQuoted(ing.prep_state_slug)}"`);
+    } else {
+      prepFallback = true;
+      notesParts.push(`prep: ${ing.prep_state_slug}`);
+    }
+  }
+  args.push(`qty=${formatNumber(ing.qty)}`);
+  args.push(`unit="${escapeQuoted(ing.unit)}"`);
+  if (ing.optional === true) args.push('optional=true');
+  if (ing.notes != null && ing.notes !== '') notesParts.push(ing.notes);
+  if (notesParts.length > 0) {
+    args.push(`notes="${escapeQuoted(notesParts.join('; '))}"`);
+  }
+  return { line: `@ingredient(${args.join(', ')})`, prepFallback };
+}
+
+function renderRecipeHeader(recipe: ExtractedRecipe, slug: string): string {
+  const args: string[] = [
+    `slug="${escapeQuoted(slug)}"`,
+    `title="${escapeQuoted(recipe.title)}"`,
+    `servings=${formatNumber(recipe.servings)}`,
+  ];
+  if (recipe.prep_time_minutes != null && recipe.prep_time_minutes > 0) {
+    args.push(`prep_time=${formatNumber(recipe.prep_time_minutes)}:min`);
+  }
+  if (recipe.cook_time_minutes != null && recipe.cook_time_minutes > 0) {
+    args.push(`cook_time=${formatNumber(recipe.cook_time_minutes)}:min`);
+  }
+  return `@recipe(\n  ${args.join(',\n  ')}\n)`;
+}
+
+/**
+ * Builds the PRD-114 DSL string for a Claude-extracted recipe. Returns
+ * the DSL plus the derived slug + a count of how many ingredients had
+ * their `prep_state_slug` rewritten into `notes` (surfaced in meta JSON
+ * so the review queue can show the operator what was rerouted).
+ */
+export function buildWebLlmDsl(
+  recipe: ExtractedRecipe,
+  _opts: BuildWebLlmDslOptions
+): BuildWebLlmDslResult {
+  const slug = slugify(recipe.title) || 'untitled-recipe';
+  const lines: string[] = [];
+  lines.push(renderRecipeHeader(recipe, slug));
+  lines.push(
+    `@yield(${recipe.yield_slug}, ${formatNumber(recipe.yield_qty)}:${recipe.yield_unit})`
+  );
+  let prepFallbackCount = 0;
+  recipe.ingredients.forEach((ing, i) => {
+    const rendered = renderIngredient(i + 1, ing);
+    lines.push(rendered.line);
+    if (rendered.prepFallback) prepFallbackCount += 1;
+  });
+  for (const step of recipe.steps) {
+    lines.push(`@step("${escapeQuoted(step.body)}")`);
+  }
+  return { dsl: `${lines.join('\n')}\n`, slug, prepFallbackCount };
+}

--- a/apps/pops-worker-food/src/handlers/web-llm-extract.ts
+++ b/apps/pops-worker-food/src/handlers/web-llm-extract.ts
@@ -1,0 +1,191 @@
+/**
+ * PRD-128 — Claude extraction + strict JSON validation for the web-llm
+ * fallback. Single call per ingest. Markdown-fenced output is rejected
+ * (the prompt explicitly says "Output ONLY the JSON"); zod violations
+ * surface as `LlmExtractFailed` with the raw response preserved in
+ * `meta.json.llm_raw_output` for the review queue.
+ */
+import { ZodError } from 'zod';
+
+import { extractTextFromMessage, getAnthropicClient } from '../ai/web-llm-anthropic.js';
+import { callClaudeWithLogging } from '../ai/web-llm-log.js';
+import {
+  PROMPT_VERSION_WEB_LLM,
+  WEB_LLM_DEFAULT_MODEL,
+  WEB_LLM_MAX_OUTPUT_TOKENS,
+  buildWebLlmPrompt,
+} from '../prompts/web-llm.js';
+import { extractedRecipeSchema } from './web-llm-recipe.js';
+
+import type { AnthropicLike } from '../ai/web-llm-anthropic.js';
+import type { CallClaudeLogPayload } from '../ai/web-llm-log.js';
+import type { ExtractedRecipe } from './web-llm-recipe.js';
+
+export interface WebLlmExtractInputs {
+  title: string;
+  bodyText: string;
+  url: string;
+  sourceId: number;
+  /** Test seam — overrides the lazy SDK client. */
+  client?: AnthropicLike;
+  /** Test seam — receives the inference-log payload. */
+  onLog?: (payload: CallClaudeLogPayload) => void;
+  /** Test seam — overrides the env-derived model name. */
+  model?: string;
+}
+
+export interface WebLlmExtractSuccess {
+  ok: true;
+  parsed: ExtractedRecipe;
+  raw: string;
+  promptVersion: string;
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  costUsd: number;
+  latencyMs: number;
+}
+
+export interface WebLlmExtractFailure {
+  ok: false;
+  reason: 'malformed-json' | 'schema-violation' | 'empty-response' | 'sdk-error';
+  message: string;
+  raw: string;
+  model: string;
+  promptVersion: string;
+  latencyMs: number;
+}
+
+const FENCED_RE = /^\s*```/;
+
+function parseLlmJson(
+  raw: string
+): { ok: true; value: unknown } | { ok: false; reason: 'fenced' | 'invalid'; message: string } {
+  const trimmed = raw.trim();
+  if (trimmed === '') return { ok: false, reason: 'invalid', message: 'empty response' };
+  if (FENCED_RE.test(trimmed)) {
+    return { ok: false, reason: 'fenced', message: 'response wrapped in markdown fence' };
+  }
+  try {
+    return { ok: true, value: JSON.parse(trimmed) };
+  } catch (err) {
+    return {
+      ok: false,
+      reason: 'invalid',
+      message: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+function resolveModel(override?: string): string {
+  if (override != null && override !== '') return override;
+  const envModel = process.env['FOOD_WEB_LLM_MODEL'];
+  if (envModel != null && envModel !== '') return envModel;
+  return WEB_LLM_DEFAULT_MODEL;
+}
+
+/**
+ * Runs the single Claude call + strict parsing + zod validation. Never
+ * throws on extraction-shape problems; surfaces them as
+ * `WebLlmExtractFailure` so the caller can decide whether to fail the
+ * ingest or fall back further. SDK / network errors propagate via the
+ * `sdk-error` branch (caught + wrapped to keep the contract uniform).
+ */
+export async function extractWithClaudeWebLlm(
+  inputs: WebLlmExtractInputs
+): Promise<WebLlmExtractSuccess | WebLlmExtractFailure> {
+  const model = resolveModel(inputs.model);
+  const prompt = buildWebLlmPrompt({
+    title: inputs.title,
+    url: inputs.url,
+    bodyText: inputs.bodyText,
+  });
+  try {
+    const wrapped = await callClaudeWithLogging({
+      operation: 'recipe-extract-web-llm',
+      contextId: `ingest_source:${inputs.sourceId}`,
+      promptVersion: PROMPT_VERSION_WEB_LLM,
+      model,
+      onLog: inputs.onLog,
+      call: async () => {
+        const client = inputs.client ?? getAnthropicClient();
+        const message = await client.messages.create({
+          model,
+          max_tokens: WEB_LLM_MAX_OUTPUT_TOKENS,
+          messages: [{ role: 'user', content: prompt }],
+        });
+        const text = extractTextFromMessage(message);
+        const parsed = parseLlmJson(text);
+        if (!parsed.ok) {
+          throw Object.assign(new Error(parsed.message), {
+            __webLlm: { kind: 'parse', reason: parsed.reason, raw: text },
+          });
+        }
+        const validated = extractedRecipeSchema.safeParse(parsed.value);
+        if (!validated.success) {
+          throw Object.assign(new Error(validated.error.message), {
+            __webLlm: { kind: 'schema', raw: text },
+          });
+        }
+        return {
+          parsed: validated.data,
+          inputTokens: message.usage.input_tokens,
+          outputTokens: message.usage.output_tokens,
+          raw: text,
+        };
+      },
+    });
+    return {
+      ok: true,
+      parsed: wrapped.parsed,
+      raw: wrapped.raw,
+      promptVersion: PROMPT_VERSION_WEB_LLM,
+      model,
+      inputTokens: wrapped.inputTokens,
+      outputTokens: wrapped.outputTokens,
+      costUsd: wrapped.costUsd,
+      latencyMs: wrapped.latencyMs,
+    };
+  } catch (err) {
+    return classifyExtractError(err, model);
+  }
+}
+
+interface WebLlmErrorTag {
+  __webLlm?: { kind: 'parse' | 'schema'; reason?: 'fenced' | 'invalid'; raw: string };
+}
+
+function classifyExtractError(err: unknown, model: string): WebLlmExtractFailure {
+  const message = err instanceof Error ? err.message : String(err);
+  const tag = (err as WebLlmErrorTag).__webLlm;
+  if (tag != null) {
+    if (tag.kind === 'schema') {
+      return makeFailure('schema-violation', message, tag.raw, model);
+    }
+    if (tag.reason === 'fenced') {
+      return makeFailure('malformed-json', message, tag.raw, model);
+    }
+    return makeFailure('malformed-json', message, tag.raw, model);
+  }
+  if (err instanceof ZodError) {
+    return makeFailure('schema-violation', err.message, '', model);
+  }
+  return makeFailure('sdk-error', message, '', model);
+}
+
+function makeFailure(
+  reason: WebLlmExtractFailure['reason'],
+  message: string,
+  raw: string,
+  model: string
+): WebLlmExtractFailure {
+  return {
+    ok: false,
+    reason,
+    message,
+    raw,
+    model,
+    promptVersion: PROMPT_VERSION_WEB_LLM,
+    latencyMs: 0,
+  };
+}

--- a/apps/pops-worker-food/src/handlers/web-llm-readability.ts
+++ b/apps/pops-worker-food/src/handlers/web-llm-readability.ts
@@ -1,0 +1,46 @@
+/**
+ * PRD-128 — readability extraction.
+ *
+ * Wraps Mozilla Readability in a JSDOM container, returns the cleaned
+ * article body or null when the page doesn't have enough content to be
+ * worth handing to the LLM. Pure: caller owns the HTML; this module
+ * never fetches.
+ */
+import { Readability } from '@mozilla/readability';
+import { JSDOM } from 'jsdom';
+
+import { WEB_LLM_MAX_INPUT_CHARS, WEB_LLM_MIN_READABLE_CHARS } from '../prompts/web-llm.js';
+
+export interface ReadableArticle {
+  title: string;
+  textContent: string;
+  textLength: number;
+  truncated: boolean;
+}
+
+/**
+ * Returns a readable article extracted from `html` rooted at `baseUrl`,
+ * or null when Readability finds no article body or the body is too
+ * short to be useful (PRD-128 §Acceptance: reject below 200 chars).
+ *
+ * Long extractions (>15K chars) are truncated to the first 15K so the
+ * downstream Claude prompt stays under a sensible token budget — the
+ * meta-JSON `truncated` flag surfaces this to the review queue.
+ */
+export function extractReadable(html: string, baseUrl: string): ReadableArticle | null {
+  const dom = new JSDOM(html, { url: baseUrl });
+  const reader = new Readability(dom.window.document);
+  const parsed = reader.parse();
+  if (parsed == null) return null;
+  const text = (parsed.textContent ?? '').trim();
+  if (text.length < WEB_LLM_MIN_READABLE_CHARS) return null;
+  const truncated = text.length > WEB_LLM_MAX_INPUT_CHARS;
+  const sliced = truncated ? text.slice(0, WEB_LLM_MAX_INPUT_CHARS) : text;
+  const title = parsed.title?.trim() ?? '';
+  return {
+    title,
+    textContent: sliced,
+    textLength: text.length,
+    truncated,
+  };
+}

--- a/apps/pops-worker-food/src/handlers/web-llm-recipe.ts
+++ b/apps/pops-worker-food/src/handlers/web-llm-recipe.ts
@@ -1,0 +1,68 @@
+/**
+ * PRD-128 — zod schema for the Claude-extracted recipe JSON.
+ *
+ * Scoped to the web-llm handler to avoid colliding with PRD-132's
+ * concurrent `extracted-recipe.ts` (same shape, parallel branches —
+ * post-merge dedup task is in the roadmap claim). The schema is strict
+ * about required fields and lenient about strings (any plain-text unit
+ * is accepted; alias reconciliation happens in the review queue).
+ */
+import { z } from 'zod';
+
+export const CURATED_PREP_STATES = [
+  'whole',
+  'diced',
+  'sliced',
+  'chopped',
+  'shredded',
+  'minced',
+  'julienned',
+  'grated',
+  'crushed',
+  'zested',
+  'juiced',
+  'melted',
+  'softened',
+  'mashed',
+  'roughly-chopped',
+] as const;
+
+export type CuratedPrepState = (typeof CURATED_PREP_STATES)[number];
+
+const ingredientSchema = z.object({
+  qty: z.number().positive(),
+  unit: z.string().min(1),
+  ingredient_slug: z.string().min(1),
+  variant_slug: z.string().optional(),
+  prep_state_slug: z.string().optional(),
+  original_text: z.string().optional(),
+  optional: z.boolean().optional().default(false),
+  notes: z.string().optional(),
+});
+
+const stepSchema = z.object({
+  body: z.string().min(1),
+  duration_minutes: z.number().nonnegative().optional(),
+});
+
+export const extractedRecipeSchema = z.object({
+  title: z.string().min(1),
+  summary: z.string().optional(),
+  servings: z.number().positive(),
+  prep_time_minutes: z.number().nonnegative().optional(),
+  cook_time_minutes: z.number().nonnegative().optional(),
+  yield_slug: z.string().min(1),
+  yield_qty: z.number().positive(),
+  yield_unit: z.string().min(1),
+  tags: z.array(z.string()).optional().default([]),
+  ingredients: z.array(ingredientSchema),
+  steps: z.array(stepSchema),
+});
+
+export type ExtractedRecipe = z.infer<typeof extractedRecipeSchema>;
+export type ExtractedIngredient = z.infer<typeof ingredientSchema>;
+export type ExtractedStep = z.infer<typeof stepSchema>;
+
+export function isCuratedPrepState(value: string): value is CuratedPrepState {
+  return (CURATED_PREP_STATES as readonly string[]).includes(value);
+}

--- a/apps/pops-worker-food/src/handlers/web-llm.ts
+++ b/apps/pops-worker-food/src/handlers/web-llm.ts
@@ -1,0 +1,168 @@
+import { buildWebLlmDsl } from './web-llm-dsl.js';
+/**
+ * PRD-128 — Web URL LLM-fallback handler.
+ *
+ * PRD-127 owns the JSON-LD primary path and the `url-web` dispatch
+ * stub at `handlers/web-url.ts`; this module ships `processWithLlm`
+ * which 127 will plug in as the JSON-LD-miss fallback once both PRDs
+ * land. The post-merge wiring is a single-line dispatcher edit + a
+ * helper-import dedup; both are tracked in the roadmap claim.
+ */
+import { extractWithClaudeWebLlm } from './web-llm-extract.js';
+import { extractReadable } from './web-llm-readability.js';
+
+import type { IngestJobData, IngestJobResult, IngestMeta } from '@pops/food-contracts';
+
+import type { AnthropicLike } from '../ai/web-llm-anthropic.js';
+import type { CallClaudeLogPayload } from '../ai/web-llm-log.js';
+import type { HandlerContext } from './types.js';
+import type { WebLlmExtractFailure, WebLlmExtractSuccess } from './web-llm-extract.js';
+import type { ReadableArticle } from './web-llm-readability.js';
+
+export const WEB_LLM_EXTRACTOR_VERSION = 'pops-worker-food/web-llm@0.1.0';
+
+const NEVER_CANCELLED: HandlerContext = { isCancelled: () => false };
+
+export interface ProcessWithLlmOptions {
+  /** Cancellation context; defaults to a never-cancelled shim. */
+  ctx?: HandlerContext;
+  /** Test seam — replaces the SDK call. */
+  client?: AnthropicLike;
+  /** Test seam — observes the inference-log payload. */
+  onLog?: (payload: CallClaudeLogPayload) => void;
+  /** Test seam — overrides the env-derived model. */
+  model?: string;
+}
+
+type WebUrlJobData = Extract<IngestJobData, { kind: 'url-web' }>;
+
+function cancelledResult(): IngestJobResult {
+  return {
+    ok: false,
+    errorCode: 'Cancelled',
+    errorMessage: 'job cancelled before completion',
+    meta: { extractor_version: WEB_LLM_EXTRACTOR_VERSION, stages: {} },
+  };
+}
+
+function failure(errorCode: string, errorMessage: string, meta: IngestMeta): IngestJobResult {
+  return { ok: false, errorCode, errorMessage, meta };
+}
+
+function recordReadabilityStage(
+  meta: IngestMeta,
+  article: ReadableArticle | null,
+  startedAt: number
+): void {
+  meta.stages['readability'] =
+    article == null
+      ? { ok: false, reason: 'no-extractable-content', duration_ms: Date.now() - startedAt }
+      : {
+          ok: true,
+          duration_ms: Date.now() - startedAt,
+          text_length: article.textLength,
+          truncated: article.truncated,
+          title: article.title,
+        };
+}
+
+function recordExtractStage(
+  meta: IngestMeta,
+  llmResult: WebLlmExtractSuccess | WebLlmExtractFailure
+): void {
+  meta.stages['llm_extract'] = llmResult.ok
+    ? llmExtractSuccessStage(llmResult)
+    : llmExtractFailureStage(llmResult);
+  meta.llm_raw_output = llmResult.raw;
+  if (llmResult.ok) meta.total_cost_usd = llmResult.costUsd;
+}
+
+/**
+ * Reads the already-fetched HTML (PRD-127 owns the fetch step + share
+ * of `fetchHtml`), runs readability → Claude → DSL, returns the final
+ * `IngestJobResult`. `finalUrl` is the post-redirect URL the dispatcher
+ * captured during fetch; passed through to `extractReadable` so
+ * relative links resolve.
+ */
+export async function processWithLlm(
+  html: string,
+  data: WebUrlJobData,
+  finalUrl: string,
+  opts: ProcessWithLlmOptions = {}
+): Promise<IngestJobResult> {
+  const ctx = opts.ctx ?? NEVER_CANCELLED;
+  const meta: IngestMeta = { extractor_version: WEB_LLM_EXTRACTOR_VERSION, stages: {} };
+
+  if (await ctx.isCancelled()) return cancelledResult();
+
+  const readableStart = Date.now();
+  const article = extractReadable(html, finalUrl);
+  recordReadabilityStage(meta, article, readableStart);
+  if (article == null) {
+    return failure('NoExtractableContent', 'readability returned no usable article body', meta);
+  }
+
+  if (await ctx.isCancelled()) return cancelledResult();
+
+  const llmResult = await extractWithClaudeWebLlm({
+    title: article.title,
+    bodyText: article.textContent,
+    url: finalUrl,
+    sourceId: data.sourceId,
+    client: opts.client,
+    onLog: opts.onLog,
+    model: opts.model,
+  });
+  recordExtractStage(meta, llmResult);
+  if (!llmResult.ok) {
+    return failure('LlmExtractFailed', `${llmResult.reason}: ${llmResult.message}`, meta);
+  }
+
+  if (await ctx.isCancelled()) return cancelledResult();
+  return finaliseDsl(llmResult, finalUrl, meta);
+}
+
+function finaliseDsl(
+  llmResult: WebLlmExtractSuccess,
+  finalUrl: string,
+  meta: IngestMeta
+): IngestJobResult {
+  const dslStart = Date.now();
+  const built = buildWebLlmDsl(llmResult.parsed, { source: 'url-web', url: finalUrl });
+  meta.stages['dsl_build'] = {
+    ok: true,
+    duration_ms: Date.now() - dslStart,
+    slug: built.slug,
+    prep_fallback_count: built.prepFallbackCount,
+  };
+  const partialReason =
+    llmResult.parsed.ingredients.length === 0 || llmResult.parsed.steps.length === 0
+      ? 'empty-extraction'
+      : undefined;
+  return partialReason != null
+    ? { ok: true, dsl: built.dsl, meta, partialReason }
+    : { ok: true, dsl: built.dsl, meta };
+}
+
+function llmExtractSuccessStage(r: WebLlmExtractSuccess): Record<string, unknown> {
+  return {
+    ok: true,
+    duration_ms: r.latencyMs,
+    model: r.model,
+    prompt_version: r.promptVersion,
+    input_tokens: r.inputTokens,
+    output_tokens: r.outputTokens,
+    cost_usd: r.costUsd,
+  };
+}
+
+function llmExtractFailureStage(r: WebLlmExtractFailure): Record<string, unknown> {
+  return {
+    ok: false,
+    duration_ms: r.latencyMs,
+    model: r.model,
+    prompt_version: r.promptVersion,
+    reason: r.reason,
+    message: r.message,
+  };
+}

--- a/apps/pops-worker-food/src/prompts/web-llm.ts
+++ b/apps/pops-worker-food/src/prompts/web-llm.ts
@@ -1,0 +1,70 @@
+/**
+ * PRD-128 — web-llm prompt template.
+ *
+ * Versioned: change the template = bump `PROMPT_VERSION_WEB_LLM`. The
+ * version flows through `meta.json.stages.llm_extract.prompt_version`
+ * and PRD-133's `ai_inference_log.metadata`, so old extractions can be
+ * surfaced in the review queue with a "from prompt vX.Y" badge.
+ */
+export const PROMPT_VERSION_WEB_LLM = 'web-llm-v1.0';
+export const WEB_LLM_DEFAULT_MODEL = 'claude-haiku-4-5-20251001';
+export const WEB_LLM_MAX_INPUT_CHARS = 15_000;
+export const WEB_LLM_MIN_READABLE_CHARS = 200;
+export const WEB_LLM_MAX_OUTPUT_TOKENS = 2_048;
+
+export interface WebLlmPromptInputs {
+  title: string;
+  url: string;
+  bodyText: string;
+}
+
+const SCHEMA_BLOCK = `{
+  "title": "string — the recipe name",
+  "summary": "string — one or two sentences describing the dish (optional)",
+  "servings": number,
+  "prep_time_minutes": number (optional),
+  "cook_time_minutes": number (optional),
+  "yield_slug": "string — kebab-case slug for the produced ingredient (e.g. 'smash-burger')",
+  "yield_qty": number,
+  "yield_unit": "count | serving | g | ml",
+  "tags": ["string", ...] (cuisine, meal type, dietary — short list),
+  "ingredients": [
+    {
+      "qty": number,
+      "unit": "string — g, ml, count, cup, tbsp, tsp, oz, lb (any plain-text unit; conversion happens later)",
+      "ingredient_slug": "string — kebab-case slug for the ingredient (e.g. 'beef-chuck')",
+      "variant_slug": "string (optional) — kebab-case slug for variant (e.g. 'ground', 'fresh', 'canned')",
+      "prep_state_slug": "string (optional) — one of: whole, diced, sliced, chopped, shredded, minced, julienned, grated, crushed, zested, juiced, melted, softened, mashed, roughly-chopped",
+      "original_text": "string — the ingredient as it appeared in the source",
+      "optional": boolean (default false),
+      "notes": "string (optional)"
+    }
+  ],
+  "steps": [
+    {
+      "body": "string — the step instruction; may reference ingredients by slug like @beef-chuck",
+      "duration_minutes": number (optional)
+    }
+  ]
+}`;
+
+export function buildWebLlmPrompt(inputs: WebLlmPromptInputs): string {
+  return `You are extracting a structured recipe from a webpage. The text below is the readable content of the page after stripping navigation and chrome.
+
+Page title: ${inputs.title}
+Page URL: ${inputs.url}
+
+CONTENT:
+${inputs.bodyText}
+
+Extract a recipe as JSON. Use this exact schema:
+
+${SCHEMA_BLOCK}
+
+Rules:
+- Prefer the actual ingredient slug from the source. If the source says "rocket", use 'rocket'. The system will reconcile aliases later.
+- Use metric units when both are listed. Drop the imperial parenthetical.
+- prep_state_slug MUST be one of the listed values. If the source describes a prep that doesn't match (e.g. "spiralised"), put it in notes instead.
+- Step bodies may reference ingredients by slug with @-prefix; the system resolves these.
+- Output ONLY the JSON. No markdown, no explanation.`;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -422,6 +422,9 @@ importers:
       '@anthropic-ai/sdk':
         specifier: ^0.100.1
         version: 0.100.1(zod@4.4.3)
+      '@mozilla/readability':
+        specifier: ^0.6.0
+        version: 0.6.0
       '@pops/food-contracts':
         specifier: workspace:*
         version: link:../../packages/food-contracts
@@ -434,6 +437,9 @@ importers:
       ioredis:
         specifier: 5.11.0
         version: 5.11.0
+      jsdom:
+        specifier: ^25.0.1
+        version: 25.0.1
       pino:
         specifier: ^10.3.1
         version: 10.3.1
@@ -450,6 +456,9 @@ importers:
       '@pops/app-food-db':
         specifier: workspace:*
         version: link:../../packages/app-food-db
+      '@types/jsdom':
+        specifier: ^21.1.7
+        version: 21.1.7
       '@types/node':
         specifier: ^25.9.1
         version: 25.9.1
@@ -461,7 +470,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@25.9.1)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@types/node@25.9.1)(@vitest/coverage-v8@4.1.8)(jsdom@25.0.1)(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/api-client:
     dependencies:
@@ -1545,6 +1554,9 @@ packages:
     peerDependenciesMeta:
       zod:
         optional: true
+
+  '@asamuzakjp/css-color@4.1.2':
+    resolution: {integrity: sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==}
 
   '@asamuzakjp/css-color@5.1.11':
     resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
@@ -2706,6 +2718,10 @@ packages:
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
+
+  '@mozilla/readability@0.6.0':
+    resolution: {integrity: sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ==}
+    engines: {node: '>=14.0.0'}
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4':
     resolution: {integrity: sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==}
@@ -4581,6 +4597,9 @@ packages:
   '@types/js-yaml@4.0.9':
     resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
 
+  '@types/jsdom@21.1.7':
+    resolution: {integrity: sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==}
+
   '@types/jsonwebtoken@9.0.10':
     resolution: {integrity: sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==}
 
@@ -4642,6 +4661,9 @@ packages:
 
   '@types/swagger-ui-express@4.1.8':
     resolution: {integrity: sha512-AhZV8/EIreHFmBV5wAs0gzJUNq9JbbSXgJLQubCC0jtIo6prnI9MIRRxnU4MZX9RB9yXxF1V4R7jtLl/Wcj31g==}
+
+  '@types/tough-cookie@4.0.5':
+    resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
 
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
@@ -5142,6 +5164,10 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
+  cssstyle@6.0.2:
+    resolution: {integrity: sha512-B5xvQYh7n+s/elmwhMOthufrO+QaORHuUoSJGhmogxPz9LNT6HMbou3fUeieOOFogKP84SYryyLC405QvyFvaA==}
+    engines: {node: '>=20'}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
@@ -5236,6 +5262,10 @@ packages:
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
+
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
 
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
@@ -5510,6 +5540,10 @@ packages:
   enquirer@2.4.1:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
 
   entities@8.0.0:
     resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
@@ -5873,6 +5907,10 @@ packages:
     resolution: {integrity: sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==}
     engines: {node: '>=16.9.0'}
 
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -5889,6 +5927,10 @@ packages:
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
 
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
@@ -5917,6 +5959,10 @@ packages:
 
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
+    engines: {node: '>=0.10.0'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
 
   iconv-lite@0.7.2:
@@ -6149,6 +6195,15 @@ packages:
   js-yaml@4.2.0:
     resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
     hasBin: true
+
+  jsdom@25.0.1:
+    resolution: {integrity: sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^2.11.2
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsdom@29.1.1:
     resolution: {integrity: sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==}
@@ -6626,6 +6681,9 @@ packages:
     resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
     engines: {node: '>=18'}
 
+  nwsapi@2.2.24:
+    resolution: {integrity: sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -6732,6 +6790,9 @@ packages:
   parse-ms@4.0.0:
     resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
     engines: {node: '>=18'}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
   parse5@8.0.1:
     resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
@@ -7141,6 +7202,9 @@ packages:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
 
+  rrweb-cssom@0.7.1:
+    resolution: {integrity: sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==}
+
   run-applescript@7.1.0:
     resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
     engines: {node: '>=18'}
@@ -7536,8 +7600,15 @@ packages:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
   tldts-core@7.0.30:
     resolution: {integrity: sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==}
+
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
 
   tldts@7.0.30:
     resolution: {integrity: sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==}
@@ -7551,9 +7622,17 @@ packages:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
+
   tough-cookie@6.0.1:
     resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
     engines: {node: '>=16'}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
 
   tr46@6.0.0:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
@@ -7833,6 +7912,10 @@ packages:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
 
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
   webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
@@ -7840,9 +7923,22 @@ packages:
   webpack-virtual-modules@0.6.2:
     resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
 
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
   whatwg-mimetype@5.0.0:
     resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
     engines: {node: '>=20'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
 
   whatwg-url@16.0.1:
     resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
@@ -7981,6 +8077,14 @@ snapshots:
       standardwebhooks: 1.0.0
     optionalDependencies:
       zod: 4.4.3
+
+  '@asamuzakjp/css-color@4.1.2':
+    dependencies:
+      '@csstools/css-calc': 3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+      lru-cache: 11.5.1
 
   '@asamuzakjp/css-color@5.1.11':
     dependencies:
@@ -8902,6 +9006,8 @@ snapshots:
       zod-to-json-schema: 3.25.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
+
+  '@mozilla/readability@0.6.0': {}
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4':
     optional: true
@@ -10367,6 +10473,12 @@ snapshots:
 
   '@types/js-yaml@4.0.9': {}
 
+  '@types/jsdom@21.1.7':
+    dependencies:
+      '@types/node': 25.9.1
+      '@types/tough-cookie': 4.0.5
+      parse5: 7.3.0
+
   '@types/jsonwebtoken@9.0.10':
     dependencies:
       '@types/ms': 2.1.0
@@ -10439,6 +10551,8 @@ snapshots:
     dependencies:
       '@types/express': 5.0.6
       '@types/serve-static': 2.2.0
+
+  '@types/tough-cookie@4.0.5': {}
 
   '@types/unist@2.0.11': {}
 
@@ -10904,6 +11018,13 @@ snapshots:
 
   cssesc@3.0.0: {}
 
+  cssstyle@6.0.2:
+    dependencies:
+      '@asamuzakjp/css-color': 4.1.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.3(css-tree@3.2.1)
+      css-tree: 3.2.1
+      lru-cache: 11.5.1
+
   csstype@3.2.3: {}
 
   d3-array@3.2.4:
@@ -10996,6 +11117,11 @@ snapshots:
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
   data-uri-to-buffer@4.0.1: {}
+
+  data-urls@5.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
 
   data-urls@7.0.0(@noble/hashes@1.8.0):
     dependencies:
@@ -11165,6 +11291,8 @@ snapshots:
     dependencies:
       ansi-colors: 4.1.3
       strip-ansi: 6.0.1
+
+  entities@6.0.1: {}
 
   entities@8.0.0: {}
 
@@ -11675,6 +11803,10 @@ snapshots:
 
   hono@4.12.14: {}
 
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
   html-encoding-sniffer@6.0.0(@noble/hashes@1.8.0):
     dependencies:
       '@exodus/bytes': 1.15.0(@noble/hashes@1.8.0)
@@ -11697,6 +11829,13 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
@@ -11715,6 +11854,10 @@ snapshots:
       typescript: 6.0.3
 
   iconv-lite@0.4.24:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
 
@@ -11884,6 +12027,34 @@ snapshots:
   js-yaml@4.2.0:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@25.0.1:
+    dependencies:
+      cssstyle: 6.0.2
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      form-data: 4.0.5
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.24
+      parse5: 7.3.0
+      rrweb-cssom: 0.7.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 5.1.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.21.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   jsdom@29.1.1(@noble/hashes@1.8.0):
     dependencies:
@@ -12466,6 +12637,8 @@ snapshots:
       path-key: 4.0.0
       unicorn-magic: 0.3.0
 
+  nwsapi@2.2.24: {}
+
   object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
@@ -12653,6 +12826,10 @@ snapshots:
       lines-and-columns: 1.2.4
 
   parse-ms@4.0.0: {}
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
 
   parse5@8.0.1:
     dependencies:
@@ -13144,6 +13321,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  rrweb-cssom@0.7.1: {}
+
   run-applescript@7.1.0: {}
 
   run-parallel@1.2.0:
@@ -13604,7 +13783,13 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
+  tldts-core@6.1.86: {}
+
   tldts-core@7.0.30: {}
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
 
   tldts@7.0.30:
     dependencies:
@@ -13616,9 +13801,17 @@ snapshots:
 
   toidentifier@1.0.1: {}
 
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
+
   tough-cookie@6.0.1:
     dependencies:
       tldts: 7.0.30
+
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
 
   tr46@6.0.0:
     dependencies:
@@ -13833,6 +14026,35 @@ snapshots:
       tsx: 4.22.4
       yaml: 2.9.0
 
+  vitest@4.1.8(@types/node@25.9.1)(@vitest/coverage-v8@4.1.8)(jsdom@25.0.1)(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.8
+      '@vitest/mocker': 4.1.8(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/runner': 4.1.8
+      '@vitest/snapshot': 4.1.8
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.9.1
+      '@vitest/coverage-v8': 4.1.8(vitest@4.1.8)
+      jsdom: 25.0.1
+    transitivePeerDependencies:
+      - msw
+
   vitest@4.1.8(@types/node@25.9.1)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.8
@@ -13874,11 +14096,24 @@ snapshots:
 
   web-streams-polyfill@3.3.3: {}
 
+  webidl-conversions@7.0.0: {}
+
   webidl-conversions@8.0.1: {}
 
   webpack-virtual-modules@0.6.2: {}
 
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
   whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
 
   whatwg-url@16.0.1(@noble/hashes@1.8.0):
     dependencies:


### PR DESCRIPTION
## Summary

- When PRD-127's JSON-LD path returns null, this handler takes over: strip nav/footer via Mozilla Readability, hand the article body to Claude with a structured-extraction prompt, parse + zod-validate the response, build a PRD-114 DSL string. One Claude API call per ingest.
- Exports `processWithLlm(html, data, finalUrl, opts?)` from `apps/pops-worker-food/src/handlers/web-llm.ts`. Per PRD-128 §Pipeline the `url-web` dispatch stub is owned by PRD-127 (already merged); a follow-up rebase will wire `processWithLlm` in as the JSON-LD-miss fallback inside `runWebUrlIngest` and dedupe shared helpers with PRD-132's text path that also just landed.
- Drive-by: PRD-127's test fixture suite + map-to-dsl test still imported from the pre-PRD-119 path `@pops/app-food/src/dsl/parser` (file no longer exists after the DSL refactor). Two-line fix to point at `@pops/app-food-db` + an explanatory comment update. Also adds `@pops/app-food-db` as a workspace devDep on the worker package so the import actually resolves.

## Pipeline

1. **Readability** — `extractReadable(html, finalUrl)` runs `@mozilla/readability` in JSDOM, returns `null` below 200 chars (PRD AC), truncates above 15K with `truncated=true` recorded in `meta.stages.readability`.
2. **Claude call** — `extractWithClaudeWebLlm` lazy-loads `Anthropic`, sends the PRD-128 prompt (versioned `web-llm-v1.0`) to `claude-haiku-4-5-20251001` (override: `FOOD_WEB_LLM_MODEL`). Strict `JSON.parse` — markdown-fenced output is rejected. Output validated by zod; violations surface as `LlmExtractFailed` with the raw response in `meta.llm_raw_output`.
3. **DSL build** — `buildWebLlmDsl` emits a PRD-114-grammar string. Invalid `prep_state_slug` values are rewritten into ingredient `notes` (count surfaced in meta); `@<slug>` step refs pass through verbatim per ADR-023.
4. **Result** — `{ ok: true, dsl, meta }` with `partialReason='empty-extraction'` when 0 ingredients OR 0 steps.

Cancellation is checked before readability, before the LLM call, and before DSL build.

## Files (strictly additive)

- `handlers/web-llm.ts` — orchestrator
- `handlers/web-llm-readability.ts` — JSDOM + Mozilla Readability
- `handlers/web-llm-extract.ts` — single Claude call + strict JSON / zod
- `handlers/web-llm-dsl.ts` — pure `ExtractedRecipe → DSL` builder
- `handlers/web-llm-recipe.ts` — zod schema + curated prep-state list
- `prompts/web-llm.ts` — `PROMPT_VERSION_WEB_LLM='web-llm-v1.0'` + the schema-block prompt
- `ai/web-llm-anthropic.ts` — lazy SDK client + `AnthropicLike` structural subset
- `ai/web-llm-log.ts` — local shim of PRD-133's `callClaudeWithLogging`; operation name `'recipe-extract-web-llm'` matches PRD-133's `FoodOperationSchema` literal so the swap-in is a one-line change

Paths deliberately scoped under `web-llm-*` to avoid collision with PRD-132's concurrent (now-merged) shared surface (`build-dsl.ts`, `extract-with-claude.ts`, `extracted-recipe.ts`, `ai/anthropic.ts`, `ai/log-inference.ts`). Post-merge dedup is tracked in the roadmap claim.

## Tests

`apps/pops-worker-food/src/handlers/__tests__/web-llm.test.ts` — 27 cases:
- `slugify` edge cases (spaces, accents, emojis, underscores, empty)
- Readability: too-short → null, truncate above 15K, happy path
- `buildWebLlmDsl`: @recipe header, @yield + @ingredient, invalid prep → notes (counted), explicit + fallback notes merged, @slug step refs, escape quoting, empty-slug fallback to `untitled-recipe`
- `processWithLlm`: happy path with onLog spy, NoExtractableContent, markdown-fenced rejection, zod violation, 0-ingredient partial, 0-step partial, SDK error → sdk-error, cancellation pre-pipeline, cancellation mid-pipeline, `FOOD_WEB_LLM_MODEL` override
- `getAnthropicClient`: throws when `ANTHROPIC_API_KEY` unset

Full worker test suite: 183 / 183 passing.

## Test plan

- [x] `pnpm -C apps/pops-worker-food test` → 15 files / 183 tests pass.
- [x] `pnpm -C apps/pops-worker-food typecheck` → green.
- [x] `pnpm -C apps/pops-worker-food build` → green.
- [x] `pnpm lint` → green (warnings only).
- [x] `pnpm format:check` → green.

(Aside: `pnpm typecheck` repo-wide currently hits a pre-existing error in `apps/pops-api/src/modules/core/service-accounts/service.ts` introduced by today's merged PR #2740 / 771c0f6c — unrelated to this PR's code paths and the worker package's typecheck still passes cleanly.)