### PR TITLE
feat(food): PRD-130 — Instagram STT + vision pipeline

### DIFF
--- a/apps/pops-worker-food/package.json
+++ b/apps/pops-worker-food/package.json
@@ -24,7 +24,6 @@
   },
   "devDependencies": {
     "@pops/api": "workspace:*",
-    "@pops/app-food": "workspace:*",
     "@pops/app-food-db": "workspace:*",
     "@types/jsdom": "^21.1.7",
     "@types/node": "^25.9.1",

--- a/apps/pops-worker-food/src/__tests__/dispatch.test.ts
+++ b/apps/pops-worker-food/src/__tests__/dispatch.test.ts
@@ -134,22 +134,23 @@ describe('runIngestJob', () => {
 });
 
 describe('default handler stubs', () => {
-  it('remaining stub kinds resolve to NotImplemented failures with the stub version', async () => {
-    // Real handlers ship per-kind:
-    //   - PRD-127 → `url-web`
-    //   - PRD-131 → `screenshot`
-    //   - PRD-132 → `text`
-    // PRDs 128/129/130 will pop `url-instagram` off this list when they
-    // land.
+  it('no kinds are still routed to the NotImplemented stub', async () => {
+    // PRDs 127 (`url-web`), 130 (`url-instagram`), 131 (`screenshot`), and
+    // 132 (`text`) have all replaced their stubs with real pipelines.
+    // The PRD-126 `NotImplemented` extractor-version should never surface
+    // from a default-handler dispatch anymore. The stub utility is
+    // preserved in `not-implemented.ts` so the next per-kind PRD can
+    // bootstrap a follow-up handler.
     const kinds: IngestJobData[] = [
+      { kind: 'url-web', sourceId: 1, url: 'https://example.test/recipe' },
       { kind: 'url-instagram', sourceId: 2, url: 'https://instagram.com/r/abc' },
+      { kind: 'screenshot', sourceId: 3, mimeType: 'image/png', contentPath: '/tmp/x.png' },
+      { kind: 'text', sourceId: 4, body: 'hi' },
     ];
     for (const data of kinds) {
       const result = await runIngestJob(data, ctx, defaultHandlers);
-      expect(result.ok).toBe(false);
-      if (result.ok) throw new Error('unreachable');
-      expect(result.errorCode).toBe('NotImplemented');
-      expect(result.meta.extractor_version).toBe(NOT_IMPLEMENTED_EXTRACTOR_VERSION);
+      if (result.ok) continue;
+      expect(result.meta.extractor_version).not.toBe(NOT_IMPLEMENTED_EXTRACTOR_VERSION);
     }
   });
 });

--- a/apps/pops-worker-food/src/__tests__/instagram-build-dsl.test.ts
+++ b/apps/pops-worker-food/src/__tests__/instagram-build-dsl.test.ts
@@ -1,0 +1,98 @@
+/**
+ * PRD-130 — local build-dsl unit tests. Asserts the DSL output is
+ * parseable by the PRD-114 parser and that the descriptor + tail rules
+ * match the PRD.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { parseRecipeDsl } from '@pops/app-food-db';
+
+import { buildDsl } from '../handlers/instagram/build-dsl.js';
+
+import type { ExtractedRecipe } from '../handlers/instagram/extracted-recipe.js';
+
+const HAPPY: ExtractedRecipe = {
+  title: 'Smash Burger',
+  summary: 'Crispy edges, melty cheese.',
+  servings: 4,
+  prep_time_min: 5,
+  cook_time_min: 10,
+  ingredients: [
+    {
+      ingredient_slug: 'beef-chuck',
+      variant_slug: null,
+      prep_state_slug: 'minced',
+      qty: 500,
+      unit: 'g',
+      notes: null,
+    },
+    {
+      ingredient_slug: 'salt',
+      variant_slug: null,
+      prep_state_slug: null,
+      qty: 5,
+      unit: 'g',
+      notes: null,
+    },
+    {
+      ingredient_slug: 'buns',
+      variant_slug: 'brioche',
+      prep_state_slug: null,
+      qty: 4,
+      unit: 'count',
+      notes: 'toasted',
+    },
+  ],
+  steps: [
+    { body: 'Divide beef into 4 balls.', duration_min: null, temperature_c: null },
+    { body: 'Sear on a hot pan.', duration_min: 2, temperature_c: 200 },
+  ],
+};
+
+describe('buildDsl (Instagram)', () => {
+  it('produces a parseable DSL string', () => {
+    const { dsl } = buildDsl(HAPPY);
+    const parsed = parseRecipeDsl(dsl);
+    if (!parsed.ok) throw new Error(parsed.errors.map((e) => e.message).join('\n'));
+  });
+
+  it('disambiguates the recipe slug against the reserved set', () => {
+    const reserved = new Set(['smash-burger']);
+    const { slug } = buildDsl(HAPPY, { reservedSlugs: reserved });
+    expect(slug).toBe('smash-burger-2');
+  });
+
+  it('drops a non-curated prep_state into ingredient notes path (skipped via sanitiser)', () => {
+    const recipe: ExtractedRecipe = {
+      ...HAPPY,
+      ingredients: [
+        {
+          ingredient_slug: 'tomato',
+          variant_slug: null,
+          prep_state_slug: 'frenched',
+          qty: 1,
+          unit: 'count',
+          notes: null,
+        },
+      ],
+      steps: [{ body: 'Add tomato.', duration_min: null, temperature_c: null }],
+    };
+    const { dsl } = buildDsl(recipe);
+    // Non-curated prep slug omitted from descriptor.
+    expect(dsl).toContain('@ingredient(1, tomato, 1:count)');
+  });
+
+  it('emits duration + temperature when present on a step', () => {
+    const { dsl } = buildDsl(HAPPY);
+    expect(dsl).toMatch(/@step\("Sear on a hot pan\.", duration=2:min, temperature=200:c\)/);
+  });
+
+  it('falls back to servings=4 when LLM omits it', () => {
+    const recipe: ExtractedRecipe = {
+      ...HAPPY,
+      servings: null,
+    };
+    const { dsl } = buildDsl(recipe);
+    expect(dsl).toContain('servings=4');
+  });
+});

--- a/apps/pops-worker-food/src/__tests__/instagram-caption-heuristic.test.ts
+++ b/apps/pops-worker-food/src/__tests__/instagram-caption-heuristic.test.ts
@@ -1,0 +1,54 @@
+/**
+ * PRD-130 — caption-heuristic boundary tests.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { isStructuredCaption } from '../handlers/instagram/caption-heuristic.js';
+
+describe('isStructuredCaption', () => {
+  it('returns false for null', () => {
+    expect(isStructuredCaption(null)).toBe(false);
+  });
+
+  it('returns false for short captions', () => {
+    expect(isStructuredCaption('Yum!')).toBe(false);
+  });
+
+  it('returns true when bullets + measurement units appear', () => {
+    const caption = [
+      'Weeknight pancakes',
+      '- 2 cups flour',
+      '- 1 tbsp baking powder',
+      '- 1 tsp salt',
+      '- 1 cup milk',
+      '- 2 tbsp butter',
+      'Whisk dry. Whisk wet. Cook on a hot pan.',
+    ].join('\n');
+    expect(isStructuredCaption(caption)).toBe(true);
+  });
+
+  it('returns true when ingredients + steps headers appear together', () => {
+    const caption = ['INGREDIENTS', 'Whatever you have', 'METHOD', 'Cook it']
+      .join('\n')
+      .padEnd(120, 'x');
+    expect(isStructuredCaption(caption)).toBe(true);
+  });
+
+  it('returns false when bullets are present but no measurement units', () => {
+    const caption = [
+      'My thoughts on dinner',
+      '- It was good',
+      '- It was filling',
+      '- I ate too much',
+      '- The dog stared at me',
+      '- Bedtime now',
+    ].join('\n');
+    expect(isStructuredCaption(caption)).toBe(false);
+  });
+
+  it('returns false when measurement units appear but no bullets and no headers', () => {
+    const caption =
+      'I cooked some pasta tonight with 200g of penne and 100ml of sauce. It was nice.';
+    expect(isStructuredCaption(caption)).toBe(false);
+  });
+});

--- a/apps/pops-worker-food/src/__tests__/instagram-convert-acquisition-failure.test.ts
+++ b/apps/pops-worker-food/src/__tests__/instagram-convert-acquisition-failure.test.ts
@@ -1,0 +1,65 @@
+/**
+ * PRD-130 — acquisition-failure conversion tests. Covers each of the
+ * five `AcquisitionResult & { ok: false }` kinds.
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildAuthDeadPlaceholderDsl,
+  convertAcquisitionFailure,
+} from '../handlers/instagram/convert-acquisition-failure.js';
+
+const OPTS = { sourceId: 42, extractorVersion: 'ig-stt-vision@test' };
+
+describe('convertAcquisitionFailure', () => {
+  it('auth-dead surfaces as a partial draft with placeholder DSL', () => {
+    const result = convertAcquisitionFailure({ ok: false, kind: 'auth-dead', stderr: '' }, OPTS);
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('unreachable');
+    expect(result.partialReason).toBe('auth-dead');
+    expect(result.dsl).toContain('Instagram ingest pending');
+    expect(result.dsl).toContain('ig-pending-42');
+  });
+
+  it('rate-limited propagates retryAfter', () => {
+    const result = convertAcquisitionFailure(
+      { ok: false, kind: 'rate-limited', retryAfter: 600 },
+      OPTS
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.errorCode).toBe('InstagramRateLimited');
+    expect(result.retryAfterSec).toBe(600);
+  });
+
+  it('generic-failure carries the truncated stderr in the message', () => {
+    const result = convertAcquisitionFailure(
+      { ok: false, kind: 'generic-failure', exitCode: 1, stderr: 'x'.repeat(500) },
+      OPTS
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.errorCode).toBe('InstagramAcquisitionFailed');
+    expect(result.errorMessage.length).toBeLessThan(260);
+  });
+
+  it('missing-artifacts is a structured failure', () => {
+    const result = convertAcquisitionFailure({ ok: false, kind: 'missing-artifacts' }, OPTS);
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.errorCode).toBe('InstagramArtifactsMissing');
+  });
+
+  it('cancelled propagates as the worker shell Cancelled errorCode', () => {
+    const result = convertAcquisitionFailure({ ok: false, kind: 'cancelled' }, OPTS);
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.errorCode).toBe('Cancelled');
+  });
+
+  it('buildAuthDeadPlaceholderDsl produces a parseable header + yield', () => {
+    const dsl = buildAuthDeadPlaceholderDsl(99);
+    expect(dsl).toContain('@recipe(slug="ig-pending-99"');
+    expect(dsl).toContain('@yield(ig-pending-99, 1:count)');
+  });
+});

--- a/apps/pops-worker-food/src/__tests__/instagram-degradation.test.ts
+++ b/apps/pops-worker-food/src/__tests__/instagram-degradation.test.ts
@@ -1,0 +1,69 @@
+/**
+ * PRD-130 — degradation truth-table tests, one assertion per documented
+ * row of the §Degradation table.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { derivePartialReason } from '../handlers/instagram/degradation.js';
+
+describe('derivePartialReason', () => {
+  it('row 1: caption structured, STT skipped, vision ok → no partialReason', () => {
+    expect(
+      derivePartialReason({
+        captionStructured: true,
+        transcriptOk: true,
+        visionOk: true,
+        keyframesOk: true,
+        textFallbackUsed: false,
+      })
+    ).toBeUndefined();
+  });
+
+  it('row 2: caption unstructured, STT ok, vision ok → no partialReason', () => {
+    expect(
+      derivePartialReason({
+        captionStructured: false,
+        transcriptOk: true,
+        visionOk: true,
+        keyframesOk: true,
+        textFallbackUsed: false,
+      })
+    ).toBeUndefined();
+  });
+
+  it('row 3: caption unstructured, STT failed, vision ok → stt-failed', () => {
+    expect(
+      derivePartialReason({
+        captionStructured: false,
+        transcriptOk: false,
+        visionOk: true,
+        keyframesOk: true,
+        textFallbackUsed: false,
+      })
+    ).toBe('stt-failed');
+  });
+
+  it('row 4: vision failed but text-fallback succeeded → caption-only-fallback', () => {
+    expect(
+      derivePartialReason({
+        captionStructured: false,
+        transcriptOk: true,
+        visionOk: false,
+        keyframesOk: false,
+        textFallbackUsed: true,
+      })
+    ).toBe('caption-only-fallback');
+  });
+
+  it('row 5 (when reached): vision failed AND no fallback → vision-failed sentinel', () => {
+    expect(
+      derivePartialReason({
+        captionStructured: false,
+        transcriptOk: true,
+        visionOk: false,
+        keyframesOk: true,
+        textFallbackUsed: false,
+      })
+    ).toBe('vision-failed');
+  });
+});

--- a/apps/pops-worker-food/src/__tests__/instagram-degradation.test.ts
+++ b/apps/pops-worker-food/src/__tests__/instagram-degradation.test.ts
@@ -43,7 +43,19 @@ describe('derivePartialReason', () => {
     ).toBe('stt-failed');
   });
 
-  it('row 4: vision failed but text-fallback succeeded → caption-only-fallback', () => {
+  it('row 4: vision failed (keyframes had been available), text-fallback used → vision-failed', () => {
+    expect(
+      derivePartialReason({
+        captionStructured: false,
+        transcriptOk: true,
+        visionOk: false,
+        keyframesOk: true,
+        textFallbackUsed: true,
+      })
+    ).toBe('vision-failed');
+  });
+
+  it('row 5: keyframes failed (no vision path), text-fallback used → caption-only-fallback', () => {
     expect(
       derivePartialReason({
         captionStructured: false,
@@ -55,7 +67,7 @@ describe('derivePartialReason', () => {
     ).toBe('caption-only-fallback');
   });
 
-  it('row 5 (when reached): vision failed AND no fallback → vision-failed sentinel', () => {
+  it('row 6 (sentinel): vision failed AND no fallback used → vision-failed sentinel', () => {
     expect(
       derivePartialReason({
         captionStructured: false,

--- a/apps/pops-worker-food/src/__tests__/instagram-dispatcher.test.ts
+++ b/apps/pops-worker-food/src/__tests__/instagram-dispatcher.test.ts
@@ -1,0 +1,37 @@
+/**
+ * PRD-130 — dispatcher entry-point tests. Exercises the `runInstagramIngest`
+ * shell that lives at `handlers/instagram.ts` and is what the dispatch
+ * table registers.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { runInstagramIngest } from '../handlers/instagram.js';
+import { setAnthropicClient } from '../handlers/instagram/anthropic-client.js';
+
+describe('runInstagramIngest dispatcher', () => {
+  const originalKey = process.env['ANTHROPIC_API_KEY'];
+
+  beforeEach(() => {
+    setAnthropicClient(null);
+  });
+
+  afterEach(() => {
+    setAnthropicClient(null);
+    if (originalKey === undefined) {
+      delete process.env['ANTHROPIC_API_KEY'];
+    } else {
+      process.env['ANTHROPIC_API_KEY'] = originalKey;
+    }
+  });
+
+  it('returns MissingApiKey when ANTHROPIC_API_KEY is unset', async () => {
+    delete process.env['ANTHROPIC_API_KEY'];
+    const result = await runInstagramIngest(
+      { kind: 'url-instagram', sourceId: 1, url: 'https://instagram.com/reel/abc' },
+      { isCancelled: () => false }
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.errorCode).toBe('MissingApiKey');
+  });
+});

--- a/apps/pops-worker-food/src/__tests__/instagram-orchestrator.test.ts
+++ b/apps/pops-worker-food/src/__tests__/instagram-orchestrator.test.ts
@@ -1,0 +1,300 @@
+/**
+ * PRD-130 — orchestrator tests. Mocks acquisition / STT / ffmpeg / vision
+ * / text-fallback and walks the documented degradation truth table end
+ * to end.
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  PIPELINE_VERSION,
+  runInstagramPipeline,
+  type InstagramIngestDeps,
+} from '../handlers/instagram/orchestrator.js';
+
+import type { AcquisitionResult } from '../handlers/instagram-acquisition.js';
+import type { AnthropicLike } from '../handlers/instagram/anthropic-client.js';
+import type { ExtractedRecipe } from '../handlers/instagram/extracted-recipe.js';
+import type { HandlerContext } from '../handlers/types.js';
+
+const STRUCTURED_CAPTION = [
+  'Weeknight pancakes',
+  '- 2 cups flour',
+  '- 1 tbsp baking powder',
+  '- 1 tsp salt',
+  '- 1 cup milk',
+  '- 2 tbsp butter',
+  'Whisk dry. Whisk wet. Cook on a hot pan.',
+].join('\n');
+
+const NON_STRUCTURED_CAPTION =
+  'A reel about smash burgers and how juicy they get on a hot pan. Try it at home!';
+
+const HAPPY_PARSED: ExtractedRecipe = {
+  title: 'Smash Burger',
+  summary: null,
+  servings: 4,
+  prep_time_min: 5,
+  cook_time_min: 10,
+  ingredients: [
+    {
+      ingredient_slug: 'beef',
+      variant_slug: null,
+      prep_state_slug: null,
+      qty: 500,
+      unit: 'g',
+      notes: null,
+    },
+  ],
+  steps: [{ body: 'Smash and sear.', duration_min: null, temperature_c: null }],
+};
+
+function noopClient(): AnthropicLike {
+  return { messages: { create: vi.fn() } };
+}
+
+function ctx(isCancelled = false): HandlerContext {
+  return { isCancelled: () => isCancelled };
+}
+
+function acqOk(caption: string | null): Extract<AcquisitionResult, { ok: true }> {
+  return {
+    ok: true,
+    workDir: '/tmp/ig/1',
+    videoPath: '/tmp/ig/1/video.mp4',
+    infoJsonPath: '/tmp/ig/1/info.json',
+    thumbnailPath: null,
+    caption,
+  };
+}
+
+function whisperOk(transcript: string) {
+  return vi.fn(async () => ({
+    transcript,
+    model: 'distil-large-v3',
+    durationMs: 1234,
+    vttPath: '/tmp/ig/1/transcript.vtt',
+  }));
+}
+
+function ffmpegOk(paths: string[]) {
+  return vi.fn(async () => ({ paths, durationMs: 100, usedFallback: false }));
+}
+
+function visionOk(parsed: ExtractedRecipe) {
+  return vi.fn(async () => ({
+    parsed,
+    model: 'claude-haiku-4-5-20251001',
+    promptVersion: 'ig-vision-v1.0',
+    inputTokens: 1000,
+    outputTokens: 500,
+    keyframesSent: 5,
+    durationMs: 500,
+  }));
+}
+
+function textFallbackOk(parsed: ExtractedRecipe) {
+  return vi.fn(async () => ({
+    parsed,
+    model: 'claude-haiku-4-5-20251001',
+    promptVersion: 'web-llm-v1.0',
+    operation: 'recipe-extract-ig-text-fallback',
+    inputTokens: 800,
+    outputTokens: 400,
+    durationMs: 400,
+  }));
+}
+
+function deps(overrides: Partial<InstagramIngestDeps> = {}): InstagramIngestDeps {
+  return {
+    anthropicClient: noopClient(),
+    runAcquisitionImpl: vi.fn(async () => acqOk(STRUCTURED_CAPTION)),
+    runWhisperImpl: whisperOk('transcript text'),
+    extractKeyframesImpl: ffmpegOk(['/tmp/k1.jpg', '/tmp/k2.jpg']),
+    extractWithVisionImpl: visionOk(HAPPY_PARSED),
+    extractWithTextFallbackImpl: textFallbackOk(HAPPY_PARSED),
+    ...overrides,
+  };
+}
+
+const DATA = { kind: 'url-instagram' as const, sourceId: 1, url: 'https://instagram.com/reel/abc' };
+
+describe('runInstagramPipeline — happy path', () => {
+  it('skips STT when the caption is structured', async () => {
+    const whisper = whisperOk('');
+    const result = await runInstagramPipeline(DATA, ctx(), deps({ runWhisperImpl: whisper }));
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('unreachable');
+    expect(whisper).not.toHaveBeenCalled();
+    expect(result.partialReason).toBeUndefined();
+    expect(result.meta.extractor_version).toBe(PIPELINE_VERSION);
+    const sttStage = result.meta.stages['stt'] as { skipped?: boolean } | undefined;
+    expect(sttStage?.skipped).toBe(true);
+  });
+
+  it('runs STT when the caption is unstructured', async () => {
+    const whisper = whisperOk('words');
+    const result = await runInstagramPipeline(
+      DATA,
+      ctx(),
+      deps({
+        runAcquisitionImpl: vi.fn(async () => acqOk(NON_STRUCTURED_CAPTION)),
+        runWhisperImpl: whisper,
+      })
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('unreachable');
+    expect(whisper).toHaveBeenCalledOnce();
+    expect(result.partialReason).toBeUndefined();
+  });
+});
+
+describe('runInstagramPipeline — degradation truth table', () => {
+  it('STT fails but vision succeeds → partialReason=stt-failed', async () => {
+    const result = await runInstagramPipeline(
+      DATA,
+      ctx(),
+      deps({
+        runAcquisitionImpl: vi.fn(async () => acqOk(NON_STRUCTURED_CAPTION)),
+        runWhisperImpl: vi.fn(async () => {
+          throw new Error('whisper crashed');
+        }),
+      })
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('unreachable');
+    expect(result.partialReason).toBe('stt-failed');
+  });
+
+  it('vision fails + caption available → text fallback → partialReason=caption-only-fallback', async () => {
+    const result = await runInstagramPipeline(
+      DATA,
+      ctx(),
+      deps({
+        runAcquisitionImpl: vi.fn(async () => acqOk(NON_STRUCTURED_CAPTION)),
+        extractWithVisionImpl: vi.fn(async () => {
+          throw new Error('vision down');
+        }),
+      })
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('unreachable');
+    expect(result.partialReason).toBe('caption-only-fallback');
+  });
+
+  it('vision fails + caption too short → AllExtractionPathsFailed', async () => {
+    const result = await runInstagramPipeline(
+      DATA,
+      ctx(),
+      deps({
+        runAcquisitionImpl: vi.fn(async () => acqOk('tiny')),
+        extractWithVisionImpl: vi.fn(async () => {
+          throw new Error('vision down');
+        }),
+      })
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.errorCode).toBe('AllExtractionPathsFailed');
+  });
+
+  it('vision fails + text fallback also fails → AllExtractionPathsFailed', async () => {
+    const result = await runInstagramPipeline(
+      DATA,
+      ctx(),
+      deps({
+        runAcquisitionImpl: vi.fn(async () => acqOk(NON_STRUCTURED_CAPTION)),
+        extractWithVisionImpl: vi.fn(async () => {
+          throw new Error('vision');
+        }),
+        extractWithTextFallbackImpl: vi.fn(async () => {
+          throw new Error('text');
+        }),
+      })
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.errorCode).toBe('AllExtractionPathsFailed');
+  });
+
+  it('keyframes fail but vision still succeeds → no partialReason', async () => {
+    const result = await runInstagramPipeline(
+      DATA,
+      ctx(),
+      deps({
+        extractKeyframesImpl: vi.fn(async () => {
+          throw new Error('ffmpeg missing');
+        }),
+      })
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('unreachable');
+    const keyframes = result.meta.stages['keyframes'] as { ok?: boolean };
+    expect(keyframes.ok).toBe(false);
+  });
+});
+
+describe('runInstagramPipeline — acquisition failures', () => {
+  it('auth-dead returns partial draft with placeholder DSL', async () => {
+    const result = await runInstagramPipeline(
+      DATA,
+      ctx(),
+      deps({
+        runAcquisitionImpl: vi.fn(async () => ({
+          ok: false,
+          kind: 'auth-dead',
+          stderr: '',
+        })),
+      })
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('unreachable');
+    expect(result.partialReason).toBe('auth-dead');
+    expect(result.dsl).toContain('ig-pending-1');
+  });
+
+  it('rate-limited propagates retryAfter to BullMQ', async () => {
+    const result = await runInstagramPipeline(
+      DATA,
+      ctx(),
+      deps({
+        runAcquisitionImpl: vi.fn(async () => ({
+          ok: false,
+          kind: 'rate-limited',
+          retryAfter: 600,
+        })),
+      })
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.retryAfterSec).toBe(600);
+  });
+});
+
+describe('runInstagramPipeline — cancellation', () => {
+  it('returns Cancelled when the orchestrator polls before acquisition', async () => {
+    const result = await runInstagramPipeline(DATA, ctx(true), deps());
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.errorCode).toBe('Cancelled');
+  });
+});
+
+describe('runInstagramPipeline — vision payload cap', () => {
+  it('passes the keyframes the orchestrator received into the vision call', async () => {
+    const visionMock = visionOk(HAPPY_PARSED);
+    const tenPaths = Array.from({ length: 10 }, (_, i) => `/tmp/k${i}.jpg`);
+    await runInstagramPipeline(
+      DATA,
+      ctx(),
+      deps({
+        extractKeyframesImpl: ffmpegOk(tenPaths),
+        extractWithVisionImpl: visionMock,
+      })
+    );
+    expect(visionMock).toHaveBeenCalledOnce();
+    const args = visionMock.mock.calls[0]?.[0];
+    expect(args?.keyframePaths.length).toBe(10);
+    // The cap to 5 happens inside `extractWithClaudeVision` itself; see
+    // its own unit test for that boundary.
+  });
+});

--- a/apps/pops-worker-food/src/__tests__/instagram-orchestrator.test.ts
+++ b/apps/pops-worker-food/src/__tests__/instagram-orchestrator.test.ts
@@ -165,12 +165,31 @@ describe('runInstagramPipeline — degradation truth table', () => {
     expect(result.partialReason).toBe('stt-failed');
   });
 
-  it('vision fails + caption available → text fallback → partialReason=caption-only-fallback', async () => {
+  it('vision fails + keyframes available + text-fallback succeeds → partialReason=vision-failed', async () => {
     const result = await runInstagramPipeline(
       DATA,
       ctx(),
       deps({
         runAcquisitionImpl: vi.fn(async () => acqOk(NON_STRUCTURED_CAPTION)),
+        extractWithVisionImpl: vi.fn(async () => {
+          throw new Error('vision down');
+        }),
+      })
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('unreachable');
+    expect(result.partialReason).toBe('vision-failed');
+  });
+
+  it('vision fails + keyframes missing + text-fallback succeeds → partialReason=caption-only-fallback', async () => {
+    const result = await runInstagramPipeline(
+      DATA,
+      ctx(),
+      deps({
+        runAcquisitionImpl: vi.fn(async () => acqOk(NON_STRUCTURED_CAPTION)),
+        extractKeyframesImpl: vi.fn(async () => {
+          throw new Error('ffmpeg missing');
+        }),
         extractWithVisionImpl: vi.fn(async () => {
           throw new Error('vision down');
         }),

--- a/apps/pops-worker-food/src/__tests__/instagram-stt-vtt.test.ts
+++ b/apps/pops-worker-food/src/__tests__/instagram-stt-vtt.test.ts
@@ -1,0 +1,39 @@
+/**
+ * PRD-130 — VTT parser unit tests for the faster-whisper output.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { parseVtt } from '../handlers/instagram/stt-whisper.js';
+
+describe('parseVtt', () => {
+  it('concatenates cues, dropping timestamps + cue identifiers', () => {
+    const raw = [
+      'WEBVTT',
+      '',
+      '1',
+      '00:00:00.000 --> 00:00:02.000',
+      'Hello there.',
+      '',
+      '2',
+      '00:00:02.000 --> 00:00:05.000',
+      'Welcome to the kitchen.',
+      'Today we make pasta.',
+      '',
+    ].join('\n');
+    expect(parseVtt(raw)).toBe('Hello there.\nWelcome to the kitchen. Today we make pasta.');
+  });
+
+  it('handles an empty transcript', () => {
+    expect(parseVtt('WEBVTT\n')).toBe('');
+  });
+
+  it('handles cues without numeric identifiers', () => {
+    const raw = ['WEBVTT', '', '00:00:00.000 --> 00:00:02.000', 'Just one line.'].join('\n');
+    expect(parseVtt(raw)).toBe('Just one line.');
+  });
+
+  it('handles Windows line endings', () => {
+    const raw = 'WEBVTT\r\n\r\n00:00:00.000 --> 00:00:02.000\r\nA line.\r\n';
+    expect(parseVtt(raw)).toBe('A line.');
+  });
+});

--- a/apps/pops-worker-food/src/__tests__/instagram-vision.test.ts
+++ b/apps/pops-worker-food/src/__tests__/instagram-vision.test.ts
@@ -1,0 +1,88 @@
+/**
+ * PRD-130 — vision unit tests. Asserts the keyframe cap, the schema
+ * validation, and the markdown-fence rejection.
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  extractWithClaudeVision,
+  MAX_KEYFRAMES_TO_VISION,
+  VisionExtractError,
+} from '../handlers/instagram/vision.js';
+
+import type { AnthropicLike, AnthropicMessage } from '../handlers/instagram/anthropic-client.js';
+
+function clientReturning(
+  jsonText: string,
+  usage = { input_tokens: 100, output_tokens: 50 }
+): {
+  client: AnthropicLike;
+  createSpy: ReturnType<typeof vi.fn>;
+} {
+  const message: AnthropicMessage = {
+    content: [{ type: 'text', text: jsonText }],
+    usage,
+  };
+  const createSpy = vi.fn(async () => message);
+  return { client: { messages: { create: createSpy } }, createSpy };
+}
+
+const VALID_JSON = JSON.stringify({
+  title: 'Test Recipe',
+  servings: 2,
+  ingredients: [
+    {
+      ingredient_slug: 'flour',
+      variant_slug: null,
+      prep_state_slug: null,
+      qty: 200,
+      unit: 'g',
+      notes: null,
+    },
+  ],
+  steps: [{ body: 'Mix everything.', duration_min: null, temperature_c: null }],
+});
+
+describe('extractWithClaudeVision', () => {
+  it('caps keyframes sent to vision at MAX_KEYFRAMES_TO_VISION (5)', async () => {
+    const { client, createSpy } = clientReturning(VALID_JSON);
+    const tenPaths = Array.from(
+      { length: 10 },
+      (_, i) => `/tmp/${i.toString().padStart(3, '0')}.jpg`
+    );
+    const readImpl = vi.fn(async () => Buffer.from('fakebytes'));
+    const result = await extractWithClaudeVision(
+      { caption: 'cap', transcript: null, keyframePaths: tenPaths },
+      { client, readFileImpl: readImpl }
+    );
+    expect(result.keyframesSent).toBe(MAX_KEYFRAMES_TO_VISION);
+    expect(readImpl).toHaveBeenCalledTimes(MAX_KEYFRAMES_TO_VISION);
+    expect(createSpy).toHaveBeenCalledOnce();
+  });
+
+  it('rejects markdown-fenced responses', async () => {
+    const { client } = clientReturning('```json\n' + VALID_JSON + '\n```');
+    await expect(
+      extractWithClaudeVision({ caption: 'cap', transcript: null, keyframePaths: [] }, { client })
+    ).rejects.toBeInstanceOf(VisionExtractError);
+  });
+
+  it('rejects schema-invalid responses', async () => {
+    const { client } = clientReturning('{"title": "x"}');
+    await expect(
+      extractWithClaudeVision({ caption: 'cap', transcript: null, keyframePaths: [] }, { client })
+    ).rejects.toBeInstanceOf(VisionExtractError);
+  });
+
+  it('returns the documented telemetry fields', async () => {
+    const { client } = clientReturning(VALID_JSON);
+    const result = await extractWithClaudeVision(
+      { caption: 'cap', transcript: 'transcript text', keyframePaths: [] },
+      { client }
+    );
+    expect(result.model).toBeTruthy();
+    expect(result.promptVersion).toBe('ig-vision-v1.0');
+    expect(result.inputTokens).toBe(100);
+    expect(result.outputTokens).toBe(50);
+  });
+});

--- a/apps/pops-worker-food/src/handlers/instagram.ts
+++ b/apps/pops-worker-food/src/handlers/instagram.ts
@@ -1,11 +1,32 @@
-import { notImplementedResult } from './not-implemented.js';
+/**
+ * Instagram ingest dispatcher. Acquisition lives in PRD-129
+ * (`instagram-acquisition.ts`); the STT + vision pipeline (PRD-130)
+ * lives in `instagram/orchestrator.ts`. This file wires runtime config
+ * (env-driven model overrides, lazy Anthropic client) into the
+ * orchestrator and adapts the result to the dispatch `IngestHandler`
+ * signature.
+ */
+import { getAnthropicClient } from './instagram/anthropic-client.js';
+import { PIPELINE_VERSION, runInstagramPipeline } from './instagram/orchestrator.js';
 
 import type { IngestHandler } from './types.js';
 
-/**
- * Instagram ingest. Real pipeline lives in PRDs 129 (yt-dlp + cookies +
- * auth-dead detection) + 130 (STT + vision). Stub for PRD-126.
- */
-export const runInstagramIngest: IngestHandler<'url-instagram'> = async (_data, _ctx) => {
-  return notImplementedResult('url-instagram');
+export const runInstagramIngest: IngestHandler<'url-instagram'> = async (data, ctx) => {
+  const apiKey = process.env['ANTHROPIC_API_KEY'];
+  if (apiKey === undefined || apiKey === '') {
+    return {
+      ok: false,
+      errorCode: 'MissingApiKey',
+      errorMessage: 'ANTHROPIC_API_KEY is required for the Instagram pipeline',
+      meta: { extractor_version: PIPELINE_VERSION, stages: {} },
+    };
+  }
+  const visionModel = process.env['FOOD_IG_VISION_MODEL'];
+  const whisperModel = process.env['FOOD_WHISPER_MODEL'];
+  const anthropicClient = await getAnthropicClient(apiKey);
+  return runInstagramPipeline(data, ctx, {
+    anthropicClient,
+    ...(visionModel ? { visionModel } : {}),
+    ...(whisperModel ? { whisperModel } : {}),
+  });
 };

--- a/apps/pops-worker-food/src/handlers/instagram/anthropic-client.ts
+++ b/apps/pops-worker-food/src/handlers/instagram/anthropic-client.ts
@@ -1,0 +1,93 @@
+/**
+ * PRD-130 — lazy Anthropic SDK client + the narrow structural subset
+ * worker handlers consume.
+ *
+ * The SDK's `Anthropic` class carries dozens of overloads on
+ * `messages.create`. Worker handlers only need a tiny structural slice
+ * (one call, JSON response), so the seam exposes `AnthropicLike`. Tests
+ * pass a plain object satisfying that interface — the runtime cache is
+ * populated lazily from the real SDK in production, or directly via
+ * `setAnthropicClient` in tests.
+ */
+import type Anthropic from '@anthropic-ai/sdk';
+
+export interface AnthropicUsage {
+  input_tokens?: number;
+  output_tokens?: number;
+}
+
+export interface AnthropicTextBlock {
+  type: 'text';
+  text: string;
+}
+
+export interface AnthropicMessage {
+  id?: string;
+  model?: string;
+  content: AnthropicTextBlock[];
+  usage?: AnthropicUsage;
+}
+
+export type AnthropicCreateParams = Parameters<Anthropic['messages']['create']>[0];
+
+export interface AnthropicLike {
+  messages: {
+    create: (params: AnthropicCreateParams) => Promise<AnthropicMessage>;
+  };
+}
+
+let cachedClient: AnthropicLike | null = null;
+
+export function setAnthropicClient(client: AnthropicLike | null): void {
+  cachedClient = client;
+}
+
+export async function getAnthropicClient(apiKey: string): Promise<AnthropicLike> {
+  if (cachedClient !== null) return cachedClient;
+  const sdkModule = await import('@anthropic-ai/sdk');
+  const sdkInstance = new sdkModule.default({ apiKey });
+  cachedClient = adaptSdk(sdkInstance);
+  return cachedClient;
+}
+
+function adaptSdk(sdkInstance: Anthropic): AnthropicLike {
+  return {
+    messages: {
+      create: async (params) => {
+        const response = await sdkInstance.messages.create(params);
+        return normaliseMessage(response);
+      },
+    },
+  };
+}
+
+function normaliseMessage(response: unknown): AnthropicMessage {
+  if (typeof response !== 'object' || response === null) {
+    throw new Error('Anthropic response was not an object');
+  }
+  const obj = response as Record<string, unknown>;
+  return {
+    id: typeof obj['id'] === 'string' ? obj['id'] : undefined,
+    model: typeof obj['model'] === 'string' ? obj['model'] : undefined,
+    content: normaliseContent(obj['content']),
+    usage: normaliseUsage(obj['usage']),
+  };
+}
+
+function normaliseContent(rawContent: unknown): AnthropicTextBlock[] {
+  if (!Array.isArray(rawContent)) return [];
+  const content: AnthropicTextBlock[] = [];
+  for (const block of rawContent) {
+    if (typeof block !== 'object' || block === null) continue;
+    const obj = block as { type?: unknown; text?: unknown };
+    if (obj.type === 'text' && typeof obj.text === 'string') {
+      content.push({ type: 'text', text: obj.text });
+    }
+  }
+  return content;
+}
+
+function normaliseUsage(rawUsage: unknown): AnthropicUsage | undefined {
+  if (typeof rawUsage !== 'object' || rawUsage === null) return undefined;
+  return rawUsage as AnthropicUsage;
+}

--- a/apps/pops-worker-food/src/handlers/instagram/build-dsl.ts
+++ b/apps/pops-worker-food/src/handlers/instagram/build-dsl.ts
@@ -1,0 +1,135 @@
+import { disambiguateSlug, slugify } from '../web/slugify.js';
+
+/**
+ * PRD-130 — pure ExtractedRecipe → PRD-114 DSL assembly.
+ *
+ * Local copy until PRD-132's `buildDsl` lands. The output shape is
+ * deliberately compatible: slug from title with `-2`/`-3`/... collision
+ * suffixes against the reserved set, yield ingredient = recipe slug,
+ * one `@ingredient` block per parsed entry, one `@step` per parsed step.
+ */
+import type { ExtractedIngredient, ExtractedRecipe, ExtractedStep } from './extracted-recipe.js';
+
+export interface BuildDslResult {
+  dsl: string;
+  slug: string;
+  stats: { ingredients: number; steps: number };
+}
+
+export interface BuildDslOptions {
+  reservedSlugs?: ReadonlySet<string>;
+}
+
+const VALID_SLUG_RE = /^[a-z][a-z0-9-]*$/;
+const CURATED_PREP_STATES: ReadonlySet<string> = new Set([
+  'raw',
+  'cooked',
+  'roasted',
+  'grilled',
+  'fried',
+  'boiled',
+  'steamed',
+  'baked',
+  'minced',
+  'diced',
+  'chopped',
+  'sliced',
+  'whole',
+  'mashed',
+  'ground',
+]);
+
+export function buildDsl(parsed: ExtractedRecipe, opts: BuildDslOptions = {}): BuildDslResult {
+  const reserved = opts.reservedSlugs ?? new Set<string>();
+  const baseSlug = slugify(parsed.title);
+  const slug = disambiguateSlug(baseSlug, reserved);
+
+  const lines: string[] = [];
+  lines.push(buildRecipeHeader(parsed, slug));
+  lines.push(`@yield(${slug}, ${parsed.servings ?? 4}:serving)`);
+  parsed.ingredients.forEach((ing, idx) => {
+    lines.push(buildIngredient(idx + 1, ing));
+  });
+  parsed.steps.forEach((step) => {
+    lines.push(buildStep(step));
+  });
+
+  return {
+    dsl: lines.join('\n') + '\n',
+    slug,
+    stats: { ingredients: parsed.ingredients.length, steps: parsed.steps.length },
+  };
+}
+
+function buildRecipeHeader(parsed: ExtractedRecipe, slug: string): string {
+  const parts = [`slug="${escapeQuoted(slug)}"`, `title="${escapeQuoted(parsed.title)}"`];
+  if (parsed.servings != null) parts.push(`servings=${parsed.servings}`);
+  else parts.push('servings=4');
+  if (parsed.prep_time_min != null && parsed.prep_time_min > 0) {
+    parts.push(`prep_time=${Math.round(parsed.prep_time_min)}:min`);
+  }
+  if (parsed.cook_time_min != null && parsed.cook_time_min > 0) {
+    parts.push(`cook_time=${Math.round(parsed.cook_time_min)}:min`);
+  }
+  if (parsed.summary != null && parsed.summary.trim().length > 0) {
+    parts.push(`summary="${escapeQuoted(parsed.summary.trim())}"`);
+  }
+  return `@recipe(${parts.join(', ')})`;
+}
+
+function buildIngredient(index: number, ing: ExtractedIngredient): string {
+  const descriptor = buildDescriptor(ing);
+  const qty = formatNumber(ing.qty);
+  const unit = sanitiseSlug(ing.unit) ?? 'count';
+  const tail =
+    ing.notes != null && ing.notes.trim().length > 0
+      ? `, notes="${escapeQuoted(ing.notes.trim())}"`
+      : '';
+  return `@ingredient(${index}, ${descriptor}, ${qty}:${unit}${tail})`;
+}
+
+function buildDescriptor(ing: ExtractedIngredient): string {
+  const head = sanitiseSlug(ing.ingredient_slug) ?? 'ingredient';
+  const variantSeg = ing.variant_slug != null ? sanitiseSlug(ing.variant_slug) : null;
+  const prepSeg = ing.prep_state_slug != null ? sanitiseCuratedPrep(ing.prep_state_slug) : null;
+  if (variantSeg == null && prepSeg == null) return head;
+  const variant = variantSeg ?? '_';
+  if (prepSeg == null) return `${head}:${variant}`;
+  return `${head}:${variant}:${prepSeg}`;
+}
+
+function buildStep(step: ExtractedStep): string {
+  const body = escapeQuoted(step.body.trim());
+  const tail: string[] = [];
+  if (step.duration_min != null && step.duration_min > 0) {
+    tail.push(`duration=${formatNumber(step.duration_min)}:min`);
+  }
+  if (step.temperature_c != null) {
+    tail.push(`temperature=${formatNumber(step.temperature_c)}:c`);
+  }
+  return tail.length > 0 ? `@step("${body}", ${tail.join(', ')})` : `@step("${body}")`;
+}
+
+function sanitiseSlug(value: string): string | null {
+  const trimmed = value.trim().toLowerCase();
+  if (trimmed === '') return null;
+  if (VALID_SLUG_RE.test(trimmed)) return trimmed;
+  const slug = slugify(trimmed);
+  return slug === '' ? null : slug;
+}
+
+function sanitiseCuratedPrep(value: string): string | null {
+  const slug = sanitiseSlug(value);
+  if (slug === null) return null;
+  return CURATED_PREP_STATES.has(slug) ? slug : null;
+}
+
+function formatNumber(value: number): string {
+  if (!Number.isFinite(value)) return '0';
+  if (Number.isInteger(value)) return String(value);
+  return String(Math.round(value * 1000) / 1000);
+}
+
+function escapeQuoted(input: string): string {
+  return input.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, ' ');
+}

--- a/apps/pops-worker-food/src/handlers/instagram/caption-heuristic.ts
+++ b/apps/pops-worker-food/src/handlers/instagram/caption-heuristic.ts
@@ -1,0 +1,27 @@
+/**
+ * PRD-130 — `isStructuredCaption(caption)` returns true when a reel caption
+ * already contains a recipe in a parseable shape, letting the pipeline skip
+ * the ~30-60s `faster-whisper` STT stage.
+ *
+ * Tuned conservatively per the PRD — false negatives (running STT
+ * unnecessarily) are cheaper than false positives (skipping STT and
+ * missing recipe content).
+ */
+const MIN_LENGTH = 100;
+const MIN_BULLET_LINES = 5;
+const BULLET_OR_NUMBER_RE = /^[-•*\d]/;
+const INGREDIENT_HEADER_RE = /ingredient(s|\b)/i;
+const STEP_HEADER_RE = /(method|steps|directions|instructions)/i;
+const MEASUREMENT_RE = /\b(g|kg|ml|l|cup|tbsp|tsp|oz|lb)\b/i;
+
+export function isStructuredCaption(caption: string | null | undefined): boolean {
+  if (caption == null) return false;
+  if (caption.length < MIN_LENGTH) return false;
+  const lines = caption.split('\n');
+  const bulletCount = lines.filter((l) => BULLET_OR_NUMBER_RE.test(l.trim())).length;
+  const hasBulletsOrNumbers = bulletCount >= MIN_BULLET_LINES;
+  const hasIngredientsHeader = INGREDIENT_HEADER_RE.test(caption);
+  const hasStepsHeader = STEP_HEADER_RE.test(caption);
+  const hasMeasurementUnits = MEASUREMENT_RE.test(caption);
+  return (hasBulletsOrNumbers && hasMeasurementUnits) || (hasIngredientsHeader && hasStepsHeader);
+}

--- a/apps/pops-worker-food/src/handlers/instagram/convert-acquisition-failure.ts
+++ b/apps/pops-worker-food/src/handlers/instagram/convert-acquisition-failure.ts
@@ -1,0 +1,85 @@
+import type { IngestJobResult, IngestMeta } from '@pops/food-contracts';
+
+/**
+ * PRD-130 — convert PRD-129's `AcquisitionResult` failure variants into
+ * the `IngestJobResult` shape the worker shell hands back to pops-api.
+ *
+ * `auth-dead` is the special case: surfaced as `ok: true` with a
+ * placeholder DSL and `partialReason='auth-dead'` so the review queue
+ * shows the cookie-refresh prompt instead of treating it as a failure.
+ * Rate-limited propagates `retryAfterSec` to BullMQ.
+ */
+import type { AcquisitionResult } from '../instagram-acquisition.js';
+
+export interface ConvertOptions {
+  sourceId: number;
+  extractorVersion: string;
+}
+
+type AcquisitionFailure = Extract<AcquisitionResult, { ok: false }>;
+
+export function convertAcquisitionFailure(
+  acq: AcquisitionFailure,
+  opts: ConvertOptions
+): IngestJobResult {
+  const meta: IngestMeta = {
+    extractor_version: opts.extractorVersion,
+    stages: { acquisition: { ok: false, kind: acq.kind } },
+  };
+
+  switch (acq.kind) {
+    case 'auth-dead':
+      return {
+        ok: true,
+        dsl: buildAuthDeadPlaceholderDsl(opts.sourceId),
+        meta,
+        partialReason: 'auth-dead',
+      };
+    case 'rate-limited':
+      return {
+        ok: false,
+        errorCode: 'InstagramRateLimited',
+        errorMessage: 'IG rate-limited; will retry',
+        meta,
+        retryAfterSec: acq.retryAfter,
+      };
+    case 'generic-failure':
+      return {
+        ok: false,
+        errorCode: 'InstagramAcquisitionFailed',
+        errorMessage: `yt-dlp exit ${acq.exitCode}: ${truncate(acq.stderr, 200)}`,
+        meta,
+      };
+    case 'missing-artifacts':
+      return {
+        ok: false,
+        errorCode: 'InstagramArtifactsMissing',
+        errorMessage: 'yt-dlp succeeded but expected files not present',
+        meta,
+      };
+    case 'cancelled':
+      return {
+        ok: false,
+        errorCode: 'Cancelled',
+        errorMessage: 'Instagram acquisition cancelled',
+        meta,
+      };
+    default: {
+      const exhaustive: never = acq;
+      throw new Error(`Unhandled acquisition failure kind: ${JSON.stringify(exhaustive)}`);
+    }
+  }
+}
+
+export function buildAuthDeadPlaceholderDsl(sourceId: number): string {
+  const slug = `ig-pending-${sourceId}`;
+  return [
+    `@recipe(slug="${slug}", title="Instagram ingest pending — cookies need refresh", servings=1)`,
+    `@yield(${slug}, 1:count)`,
+    '',
+  ].join('\n');
+}
+
+function truncate(input: string, max: number): string {
+  return input.length > max ? `${input.slice(0, max)}…` : input;
+}

--- a/apps/pops-worker-food/src/handlers/instagram/degradation.ts
+++ b/apps/pops-worker-food/src/handlers/instagram/degradation.ts
@@ -1,0 +1,29 @@
+/**
+ * PRD-130 — degradation truth table.
+ *
+ * Maps the per-stage outcomes onto `partialReason` per the table in the
+ * PRD's §Degradation section. Encapsulated here so the orchestrator
+ * stays readable and the table is unit-testable in isolation.
+ */
+import type { PartialReason } from '@pops/food-contracts';
+
+export interface DegradationInputs {
+  captionStructured: boolean;
+  transcriptOk: boolean;
+  /** True when the vision call produced a parseable recipe. */
+  visionOk: boolean;
+  keyframesOk: boolean;
+  /** True when the text-LLM fallback was used (vision failed but caption did). */
+  textFallbackUsed: boolean;
+}
+
+export function derivePartialReason(inputs: DegradationInputs): PartialReason | undefined {
+  if (inputs.visionOk) {
+    if (!inputs.captionStructured && !inputs.transcriptOk) return 'stt-failed';
+    return undefined;
+  }
+  if (inputs.textFallbackUsed) return 'caption-only-fallback';
+  // Vision failed and no fallback used — caller treats this as failed; this
+  // branch should not appear in a success-path result.
+  return 'vision-failed';
+}

--- a/apps/pops-worker-food/src/handlers/instagram/degradation.ts
+++ b/apps/pops-worker-food/src/handlers/instagram/degradation.ts
@@ -1,9 +1,11 @@
 /**
  * PRD-130 — degradation truth table.
  *
- * Maps the per-stage outcomes onto `partialReason` per the table in the
- * PRD's §Degradation section. Encapsulated here so the orchestrator
- * stays readable and the table is unit-testable in isolation.
+ * Maps per-stage outcomes onto `partialReason` per the table in the
+ * PRD's §Degradation section. The vision-vs-text-fallback distinction
+ * matters for the inbox UX: a `vision-failed` partial signals "rerun
+ * once the vision API recovers" whereas `caption-only-fallback` signals
+ * "no recoverable signal beyond the caption".
  */
 import type { PartialReason } from '@pops/food-contracts';
 
@@ -22,8 +24,11 @@ export function derivePartialReason(inputs: DegradationInputs): PartialReason | 
     if (!inputs.captionStructured && !inputs.transcriptOk) return 'stt-failed';
     return undefined;
   }
-  if (inputs.textFallbackUsed) return 'caption-only-fallback';
-  // Vision failed and no fallback used — caller treats this as failed; this
-  // branch should not appear in a success-path result.
-  return 'vision-failed';
+  // Vision failed. Two flavours of recovery: keyframes were available
+  // (so we DID try the multimodal path and it failed → `vision-failed`)
+  // vs keyframes never produced (so we never had a vision path at all
+  // → `caption-only-fallback`). Both presume `textFallbackUsed=true`;
+  // callers don't reach this branch when the fallback also failed.
+  if (!inputs.textFallbackUsed) return 'vision-failed';
+  return inputs.keyframesOk ? 'vision-failed' : 'caption-only-fallback';
 }

--- a/apps/pops-worker-food/src/handlers/instagram/extracted-recipe.ts
+++ b/apps/pops-worker-food/src/handlers/instagram/extracted-recipe.ts
@@ -1,0 +1,37 @@
+/**
+ * PRD-130 — zod schema for the LLM JSON output (vision + text-fallback).
+ *
+ * Local copy until PRD-132's `extractedRecipeSchema` lands and PRD-130
+ * can dedupe. The shape matches PRD-128's schema exactly so swapping is
+ * a one-import change.
+ */
+import { z } from 'zod';
+
+export const ingredientSchema = z.object({
+  ingredient_slug: z.string().min(1),
+  variant_slug: z.string().nullable().optional(),
+  prep_state_slug: z.string().nullable().optional(),
+  qty: z.number().nonnegative(),
+  unit: z.string().min(1),
+  notes: z.string().nullable().optional(),
+});
+
+export const stepSchema = z.object({
+  body: z.string().min(1),
+  duration_min: z.number().nonnegative().nullable().optional(),
+  temperature_c: z.number().nullable().optional(),
+});
+
+export const extractedRecipeSchema = z.object({
+  title: z.string().min(1),
+  summary: z.string().nullable().optional(),
+  servings: z.number().int().positive().nullable().optional(),
+  prep_time_min: z.number().nonnegative().nullable().optional(),
+  cook_time_min: z.number().nonnegative().nullable().optional(),
+  ingredients: z.array(ingredientSchema),
+  steps: z.array(stepSchema),
+});
+
+export type ExtractedRecipe = z.infer<typeof extractedRecipeSchema>;
+export type ExtractedIngredient = z.infer<typeof ingredientSchema>;
+export type ExtractedStep = z.infer<typeof stepSchema>;

--- a/apps/pops-worker-food/src/handlers/instagram/extraction.ts
+++ b/apps/pops-worker-food/src/handlers/instagram/extraction.ts
@@ -1,0 +1,101 @@
+import { extractWithTextFallback, MIN_CAPTION_LENGTH_FOR_FALLBACK } from './text-fallback.js';
+/**
+ * PRD-130 — the "extract a recipe" half of the orchestrator. Split out
+ * of `orchestrator.ts` to keep each file under the per-file lint cap.
+ *
+ * Tries the Claude vision call first; on any failure, falls through to
+ * the text-LLM fallback when the caption is long enough; if neither
+ * produces a recipe, the orchestrator returns
+ * `errorCode='AllExtractionPathsFailed'`.
+ */
+import { extractWithClaudeVision } from './vision.js';
+
+import type { IngestMeta } from '@pops/food-contracts';
+
+import type { AnthropicLike } from './anthropic-client.js';
+import type { ExtractedRecipe } from './extracted-recipe.js';
+
+export interface ExtractionDeps {
+  anthropicClient: AnthropicLike;
+  visionModel?: string;
+  textFallbackModel?: string;
+  extractWithVisionImpl?: typeof extractWithClaudeVision;
+  extractWithTextFallbackImpl?: typeof extractWithTextFallback;
+}
+
+export interface ExtractionInputs {
+  caption: string | null;
+  transcript: string | null;
+  keyframes: readonly string[];
+}
+
+export type ExtractionResult =
+  | { tag: 'vision'; parsed: ExtractedRecipe }
+  | { tag: 'text-fallback'; parsed: ExtractedRecipe }
+  | { tag: 'failed' };
+
+export async function attemptVision(
+  inputs: ExtractionInputs,
+  deps: ExtractionDeps,
+  meta: IngestMeta
+): Promise<ExtractedRecipe | null> {
+  try {
+    const result = await (deps.extractWithVisionImpl ?? extractWithClaudeVision)(
+      {
+        caption: inputs.caption,
+        transcript: inputs.transcript,
+        keyframePaths: inputs.keyframes,
+      },
+      { client: deps.anthropicClient, model: deps.visionModel }
+    );
+    meta.stages['vision'] = {
+      ok: true,
+      duration_ms: result.durationMs,
+      model: result.model,
+      prompt_version: result.promptVersion,
+      keyframes_sent: result.keyframesSent,
+      input_tokens: result.inputTokens,
+      output_tokens: result.outputTokens,
+    };
+    return result.parsed;
+  } catch (err) {
+    meta.stages['vision'] = {
+      ok: false,
+      reason: err instanceof Error ? err.message : String(err),
+    };
+    return null;
+  }
+}
+
+export async function attemptTextFallback(
+  caption: string | null,
+  deps: ExtractionDeps,
+  meta: IngestMeta
+): Promise<ExtractedRecipe | null> {
+  if (caption === null || caption.length < MIN_CAPTION_LENGTH_FOR_FALLBACK) {
+    meta.stages['text_fallback'] = { skipped: true, reason: 'caption too short or missing' };
+    return null;
+  }
+  try {
+    const result = await (deps.extractWithTextFallbackImpl ?? extractWithTextFallback)(
+      { caption },
+      { client: deps.anthropicClient, model: deps.textFallbackModel }
+    );
+    meta.stages['text_fallback'] = {
+      ok: true,
+      duration_ms: result.durationMs,
+      model: result.model,
+      operation: result.operation,
+      prompt_version: result.promptVersion,
+      input_tokens: result.inputTokens,
+      output_tokens: result.outputTokens,
+    };
+    return result.parsed;
+  } catch (err) {
+    meta.stages['text_fallback'] = {
+      ok: false,
+      reason: err instanceof Error ? err.message : String(err),
+    };
+    return null;
+  }
+}

--- a/apps/pops-worker-food/src/handlers/instagram/ffmpeg-keyframes.ts
+++ b/apps/pops-worker-food/src/handlers/instagram/ffmpeg-keyframes.ts
@@ -12,6 +12,8 @@ import { spawn } from 'node:child_process';
 import { mkdir, readdir } from 'node:fs/promises';
 import { join } from 'node:path';
 
+import { runSubprocess } from './subprocess.js';
+
 const DEFAULT_TIMEOUT_MS = 60_000;
 const DEFAULT_BIN = 'ffmpeg';
 const SCENE_THRESHOLD = 0.3;
@@ -46,24 +48,53 @@ export async function extractKeyframes(opts: ExtractKeyframesOptions): Promise<K
 
   const start = Date.now();
   const sceneArgs = sceneDetectionArgs(opts.videoPath, keyframesDir);
-  const sceneExit = await spawnAndWait(spawnImpl, ffmpegBin, sceneArgs, timeoutMs);
-  if (sceneExit !== 0) {
-    throw new FfmpegError(`ffmpeg scene-detection exited with code ${sceneExit}`);
-  }
+  await runFfmpeg({ spawnImpl, ffmpegBin, args: sceneArgs, timeoutMs, stage: 'scene-detection' });
   let paths = await listKeyframes(keyframesDir, readdirImpl);
 
   let usedFallback = false;
   if (paths.length === 0) {
     const fallbackArgs = fallbackArgsAt(opts.videoPath, keyframesDir);
-    const fallbackExit = await spawnAndWait(spawnImpl, ffmpegBin, fallbackArgs, timeoutMs);
-    if (fallbackExit !== 0) {
-      throw new FfmpegError(`ffmpeg fallback frame exited with code ${fallbackExit}`);
-    }
+    await runFfmpeg({
+      spawnImpl,
+      ffmpegBin,
+      args: fallbackArgs,
+      timeoutMs,
+      stage: 'fallback frame',
+    });
     usedFallback = true;
     paths = await listKeyframes(keyframesDir, readdirImpl);
   }
 
   return { paths, durationMs: Date.now() - start, usedFallback };
+}
+
+interface RunFfmpegArgs {
+  spawnImpl: typeof spawn;
+  ffmpegBin: string;
+  args: readonly string[];
+  timeoutMs: number;
+  stage: string;
+}
+
+async function runFfmpeg(args: RunFfmpegArgs): Promise<void> {
+  const result = await runSubprocess({
+    bin: args.ffmpegBin,
+    args: args.args,
+    timeoutMs: args.timeoutMs,
+    spawnImpl: args.spawnImpl,
+  });
+  if (result.timedOut) {
+    throw new FfmpegError(`ffmpeg ${args.stage} exceeded ${args.timeoutMs}ms`);
+  }
+  if (result.exitCode !== 0) {
+    throw new FfmpegError(
+      `ffmpeg ${args.stage} exited with code ${result.exitCode}: ${truncateStderr(result.stderr)}`
+    );
+  }
+}
+
+function truncateStderr(stderr: string): string {
+  return stderr.length > 200 ? `${stderr.slice(0, 200)}…` : stderr;
 }
 
 function sceneDetectionArgs(videoPath: string, outDir: string): string[] {
@@ -105,30 +136,6 @@ async function listKeyframes(
     .filter((n) => n.endsWith('.jpg'))
     .toSorted()
     .map((n) => join(dir, n));
-}
-
-function spawnAndWait(
-  spawnImpl: typeof spawn,
-  bin: string,
-  args: readonly string[],
-  timeoutMs: number
-): Promise<number> {
-  return new Promise<number>((resolve, reject) => {
-    const child = spawnImpl(bin, [...args], { stdio: ['ignore', 'pipe', 'pipe'] });
-    let settled = false;
-    const timer = setTimeout(() => {
-      child.kill('SIGTERM');
-      finish(() => reject(new FfmpegError(`ffmpeg exceeded ${timeoutMs}ms`)));
-    }, timeoutMs);
-    function finish(fn: () => void): void {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      fn();
-    }
-    child.on('error', (err) => finish(() => reject(err)));
-    child.on('close', (code) => finish(() => resolve(code ?? -1)));
-  });
 }
 
 export class FfmpegError extends Error {

--- a/apps/pops-worker-food/src/handlers/instagram/ffmpeg-keyframes.ts
+++ b/apps/pops-worker-food/src/handlers/instagram/ffmpeg-keyframes.ts
@@ -1,0 +1,139 @@
+/**
+ * PRD-130 — ffmpeg keyframe extraction.
+ *
+ * Scene-detection pass (`select='gt(scene,0.3)'`) writes ≤10 720p JPEGs
+ * to `${workDir}/keyframes/%03d.jpg`. If scene detection returns no
+ * frames (very short reel, no scene changes), a single fallback frame is
+ * extracted at the 2-second mark. Failures (non-zero exit, timeout,
+ * keyframes dir missing afterwards) raise — the orchestrator's try/catch
+ * routes them to `keyframesOk=false`.
+ */
+import { spawn } from 'node:child_process';
+import { mkdir, readdir } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const DEFAULT_TIMEOUT_MS = 60_000;
+const DEFAULT_BIN = 'ffmpeg';
+const SCENE_THRESHOLD = 0.3;
+const MAX_FRAMES = 10;
+const FALLBACK_FRAME_SECONDS = 2;
+
+export interface ExtractKeyframesOptions {
+  videoPath: string;
+  workDir: string;
+  ffmpegBin?: string;
+  timeoutMs?: number;
+  spawnImpl?: typeof spawn;
+  mkdirImpl?: (path: string) => Promise<unknown>;
+  readdirImpl?: (path: string) => Promise<string[]>;
+}
+
+export interface KeyframesResult {
+  paths: string[];
+  durationMs: number;
+  usedFallback: boolean;
+}
+
+export async function extractKeyframes(opts: ExtractKeyframesOptions): Promise<KeyframesResult> {
+  const ffmpegBin = opts.ffmpegBin ?? DEFAULT_BIN;
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const spawnImpl = opts.spawnImpl ?? spawn;
+  const mkdirImpl = opts.mkdirImpl ?? ((p) => mkdir(p, { recursive: true }));
+  const readdirImpl = opts.readdirImpl ?? ((p) => readdir(p));
+
+  const keyframesDir = join(opts.workDir, 'keyframes');
+  await mkdirImpl(keyframesDir);
+
+  const start = Date.now();
+  const sceneArgs = sceneDetectionArgs(opts.videoPath, keyframesDir);
+  const sceneExit = await spawnAndWait(spawnImpl, ffmpegBin, sceneArgs, timeoutMs);
+  if (sceneExit !== 0) {
+    throw new FfmpegError(`ffmpeg scene-detection exited with code ${sceneExit}`);
+  }
+  let paths = await listKeyframes(keyframesDir, readdirImpl);
+
+  let usedFallback = false;
+  if (paths.length === 0) {
+    const fallbackArgs = fallbackArgsAt(opts.videoPath, keyframesDir);
+    const fallbackExit = await spawnAndWait(spawnImpl, ffmpegBin, fallbackArgs, timeoutMs);
+    if (fallbackExit !== 0) {
+      throw new FfmpegError(`ffmpeg fallback frame exited with code ${fallbackExit}`);
+    }
+    usedFallback = true;
+    paths = await listKeyframes(keyframesDir, readdirImpl);
+  }
+
+  return { paths, durationMs: Date.now() - start, usedFallback };
+}
+
+function sceneDetectionArgs(videoPath: string, outDir: string): string[] {
+  return [
+    '-i',
+    videoPath,
+    '-vf',
+    `select='gt(scene,${SCENE_THRESHOLD})',scale=720:-2`,
+    '-vsync',
+    'vfr',
+    '-q:v',
+    '2',
+    '-frames:v',
+    String(MAX_FRAMES),
+    join(outDir, '%03d.jpg'),
+  ];
+}
+
+function fallbackArgsAt(videoPath: string, outDir: string): string[] {
+  return [
+    '-ss',
+    String(FALLBACK_FRAME_SECONDS),
+    '-i',
+    videoPath,
+    '-frames:v',
+    '1',
+    '-q:v',
+    '2',
+    join(outDir, '000.jpg'),
+  ];
+}
+
+async function listKeyframes(
+  dir: string,
+  readdirImpl: (path: string) => Promise<string[]>
+): Promise<string[]> {
+  const names = await readdirImpl(dir);
+  return names
+    .filter((n) => n.endsWith('.jpg'))
+    .toSorted()
+    .map((n) => join(dir, n));
+}
+
+function spawnAndWait(
+  spawnImpl: typeof spawn,
+  bin: string,
+  args: readonly string[],
+  timeoutMs: number
+): Promise<number> {
+  return new Promise<number>((resolve, reject) => {
+    const child = spawnImpl(bin, [...args], { stdio: ['ignore', 'pipe', 'pipe'] });
+    let settled = false;
+    const timer = setTimeout(() => {
+      child.kill('SIGTERM');
+      finish(() => reject(new FfmpegError(`ffmpeg exceeded ${timeoutMs}ms`)));
+    }, timeoutMs);
+    function finish(fn: () => void): void {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      fn();
+    }
+    child.on('error', (err) => finish(() => reject(err)));
+    child.on('close', (code) => finish(() => resolve(code ?? -1)));
+  });
+}
+
+export class FfmpegError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'FfmpegError';
+  }
+}

--- a/apps/pops-worker-food/src/handlers/instagram/orchestrator.ts
+++ b/apps/pops-worker-food/src/handlers/instagram/orchestrator.ts
@@ -1,0 +1,180 @@
+/**
+ * PRD-130 — orchestrator for `url-instagram` ingest. Wires acquisition
+ * (PRD-129) → caption-heuristic → STT → keyframes → vision →
+ * text-fallback with the hierarchical-degradation truth table the PRD
+ * prescribes. Per-stage helpers live in `stages.ts` + `extraction.ts`.
+ *
+ * The orchestrator never throws — every native subprocess + LLM call is
+ * wrapped in try/catch downstream, and the result is always a
+ * structured `IngestJobResult`.
+ */
+import { runInstagramAcquisition, type AcquisitionResult } from '../instagram-acquisition.js';
+import { buildDsl } from './build-dsl.js';
+import { isStructuredCaption } from './caption-heuristic.js';
+import { convertAcquisitionFailure } from './convert-acquisition-failure.js';
+import { derivePartialReason } from './degradation.js';
+import { attemptTextFallback, attemptVision, type ExtractionDeps } from './extraction.js';
+import { runKeyframesStage, runSttStage, type KeyframesDeps, type SttDeps } from './stages.js';
+
+import type { IngestJobData, IngestJobResult, IngestMeta } from '@pops/food-contracts';
+
+import type { HandlerContext } from '../types.js';
+import type { ExtractedRecipe } from './extracted-recipe.js';
+
+export const PIPELINE_VERSION = 'ig-stt-vision@1';
+
+export interface InstagramIngestDeps extends ExtractionDeps, SttDeps, KeyframesDeps {
+  runAcquisitionImpl?: typeof runInstagramAcquisition;
+  extractorVersion?: string;
+}
+
+type WebData = Extract<IngestJobData, { kind: 'url-instagram' }>;
+
+interface PipelineState {
+  acq: Extract<AcquisitionResult, { ok: true }>;
+  captionStructured: boolean;
+  transcript: string | null;
+  transcriptOk: boolean;
+  keyframes: string[];
+  keyframesOk: boolean;
+}
+
+export async function runInstagramPipeline(
+  data: WebData,
+  ctx: HandlerContext,
+  deps: InstagramIngestDeps
+): Promise<IngestJobResult> {
+  const extractorVersion = deps.extractorVersion ?? PIPELINE_VERSION;
+  const meta: IngestMeta = { extractor_version: extractorVersion, stages: {} };
+
+  if (await ctx.isCancelled()) return cancelled(meta);
+
+  const acq = await (deps.runAcquisitionImpl ?? runInstagramAcquisition)(data, ctx);
+  meta.stages['acquisition'] = acqStage(acq);
+  if (!acq.ok) {
+    return convertAcquisitionFailure(acq, { sourceId: data.sourceId, extractorVersion });
+  }
+  if (await ctx.isCancelled()) return cancelled(meta);
+
+  const state = await prepareInputs(acq, ctx, deps, meta);
+  if (state === 'cancelled') return cancelled(meta);
+
+  return runExtraction({ state, deps, meta });
+}
+
+async function prepareInputs(
+  acq: Extract<AcquisitionResult, { ok: true }>,
+  ctx: HandlerContext,
+  deps: InstagramIngestDeps,
+  meta: IngestMeta
+): Promise<PipelineState | 'cancelled'> {
+  const captionStructured = isStructuredCaption(acq.caption);
+  meta.stages['caption_heuristic'] = {
+    structured: captionStructured,
+    length: acq.caption?.length ?? 0,
+  };
+
+  const sttOutcome = await runSttStage({ acq, captionStructured, deps, meta });
+  if (await ctx.isCancelled()) return 'cancelled';
+
+  const kfOutcome = await runKeyframesStage({ acq, deps, meta });
+  if (await ctx.isCancelled()) return 'cancelled';
+
+  return {
+    acq,
+    captionStructured,
+    transcript: sttOutcome.transcript,
+    transcriptOk: sttOutcome.ok,
+    keyframes: kfOutcome.keyframes,
+    keyframesOk: kfOutcome.ok,
+  };
+}
+
+interface RunExtractionArgs {
+  state: PipelineState;
+  deps: InstagramIngestDeps;
+  meta: IngestMeta;
+}
+
+async function runExtraction(args: RunExtractionArgs): Promise<IngestJobResult> {
+  const visionParsed = await attemptVision(
+    {
+      caption: args.state.acq.caption,
+      transcript: args.state.transcript,
+      keyframes: args.state.keyframes,
+    },
+    args.deps,
+    args.meta
+  );
+  if (visionParsed !== null) {
+    return successResult({
+      parsed: visionParsed,
+      state: args.state,
+      meta: args.meta,
+      textFallbackUsed: false,
+    });
+  }
+  const fallbackParsed = await attemptTextFallback(args.state.acq.caption, args.deps, args.meta);
+  if (fallbackParsed !== null) {
+    return successResult({
+      parsed: fallbackParsed,
+      state: args.state,
+      meta: args.meta,
+      textFallbackUsed: true,
+    });
+  }
+  return {
+    ok: false,
+    errorCode: 'AllExtractionPathsFailed',
+    errorMessage: 'No extraction path produced a result',
+    meta: args.meta,
+  };
+}
+
+interface SuccessArgs {
+  parsed: ExtractedRecipe;
+  state: PipelineState;
+  meta: IngestMeta;
+  textFallbackUsed: boolean;
+}
+
+function successResult(args: SuccessArgs): IngestJobResult {
+  const start = Date.now();
+  const mapped = buildDsl(args.parsed);
+  args.meta.stages['dsl_build'] = {
+    ok: true,
+    duration_ms: Date.now() - start,
+    ingredients: mapped.stats.ingredients,
+    steps: mapped.stats.steps,
+  };
+  const partialReason = derivePartialReason({
+    captionStructured: args.state.captionStructured,
+    transcriptOk: args.state.transcriptOk,
+    visionOk: !args.textFallbackUsed,
+    keyframesOk: args.state.keyframesOk,
+    textFallbackUsed: args.textFallbackUsed,
+  });
+  const base = { ok: true as const, dsl: mapped.dsl, meta: args.meta };
+  return partialReason !== undefined ? { ...base, partialReason } : base;
+}
+
+function acqStage(acq: AcquisitionResult): Record<string, unknown> {
+  if (acq.ok) {
+    return {
+      ok: true,
+      video_path: acq.videoPath,
+      thumbnail_path: acq.thumbnailPath ?? null,
+      caption_length: acq.caption?.length ?? 0,
+    };
+  }
+  return { ok: false, kind: acq.kind };
+}
+
+function cancelled(meta: IngestMeta): IngestJobResult {
+  return {
+    ok: false,
+    errorCode: 'Cancelled',
+    errorMessage: 'Instagram ingest cancelled',
+    meta,
+  };
+}

--- a/apps/pops-worker-food/src/handlers/instagram/stages.ts
+++ b/apps/pops-worker-food/src/handlers/instagram/stages.ts
@@ -1,0 +1,89 @@
+/**
+ * PRD-130 — per-stage runners (STT, keyframes) split out of the
+ * orchestrator to keep each file under the per-file lint cap. Pure
+ * functions: they only know how to run one subprocess, populate the
+ * per-stage meta record, and report `ok`/`skipped`.
+ */
+import { extractKeyframes } from './ffmpeg-keyframes.js';
+import { runWhisper } from './stt-whisper.js';
+
+import type { IngestMeta } from '@pops/food-contracts';
+
+import type { AcquisitionResult } from '../instagram-acquisition.js';
+
+export interface SttOutcome {
+  transcript: string | null;
+  ok: boolean;
+}
+
+export interface KeyframesOutcome {
+  keyframes: string[];
+  ok: boolean;
+}
+
+export interface SttDeps {
+  whisperModel?: string;
+  runWhisperImpl?: typeof runWhisper;
+}
+
+export interface KeyframesDeps {
+  extractKeyframesImpl?: typeof extractKeyframes;
+}
+
+export async function runSttStage(args: {
+  acq: Extract<AcquisitionResult, { ok: true }>;
+  captionStructured: boolean;
+  deps: SttDeps;
+  meta: IngestMeta;
+}): Promise<SttOutcome> {
+  if (args.captionStructured) {
+    args.meta.stages['stt'] = { ok: true, skipped: true, reason: 'caption structured' };
+    return { transcript: null, ok: true };
+  }
+  try {
+    const result = await (args.deps.runWhisperImpl ?? runWhisper)({
+      videoPath: args.acq.videoPath,
+      workDir: args.acq.workDir,
+      model: args.deps.whisperModel,
+    });
+    args.meta.stages['stt'] = {
+      ok: true,
+      duration_ms: result.durationMs,
+      model: result.model,
+      transcript_chars: result.transcript.length,
+    };
+    return { transcript: result.transcript, ok: true };
+  } catch (err) {
+    args.meta.stages['stt'] = {
+      ok: false,
+      reason: err instanceof Error ? err.message : String(err),
+    };
+    return { transcript: null, ok: false };
+  }
+}
+
+export async function runKeyframesStage(args: {
+  acq: Extract<AcquisitionResult, { ok: true }>;
+  deps: KeyframesDeps;
+  meta: IngestMeta;
+}): Promise<KeyframesOutcome> {
+  try {
+    const result = await (args.deps.extractKeyframesImpl ?? extractKeyframes)({
+      videoPath: args.acq.videoPath,
+      workDir: args.acq.workDir,
+    });
+    args.meta.stages['keyframes'] = {
+      ok: true,
+      duration_ms: result.durationMs,
+      count: result.paths.length,
+      used_fallback: result.usedFallback,
+    };
+    return { keyframes: result.paths, ok: true };
+  } catch (err) {
+    args.meta.stages['keyframes'] = {
+      ok: false,
+      reason: err instanceof Error ? err.message : String(err),
+    };
+    return { keyframes: [], ok: false };
+  }
+}

--- a/apps/pops-worker-food/src/handlers/instagram/stt-whisper.ts
+++ b/apps/pops-worker-food/src/handlers/instagram/stt-whisper.ts
@@ -15,6 +15,8 @@ import { spawn } from 'node:child_process';
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
+import { runSubprocess } from './subprocess.js';
+
 const DEFAULT_TIMEOUT_MS = 120_000;
 const DEFAULT_MODEL = 'distil-large-v3';
 const DEFAULT_BIN = 'python3';
@@ -70,9 +72,14 @@ export async function runWhisper(opts: RunWhisperOptions): Promise<WhisperResult
   ];
 
   const start = Date.now();
-  const exitCode = await spawnAndWait(spawnImpl, pythonBin, args, timeoutMs);
-  if (exitCode !== 0) {
-    throw new WhisperError(`faster-whisper exited with code ${exitCode}`);
+  const result = await runSubprocess({ bin: pythonBin, args, timeoutMs, spawnImpl });
+  if (result.timedOut) {
+    throw new WhisperError(`faster-whisper exceeded ${timeoutMs}ms`);
+  }
+  if (result.exitCode !== 0) {
+    throw new WhisperError(
+      `faster-whisper exited with code ${result.exitCode}: ${truncateStderr(result.stderr)}`
+    );
   }
   const vttPath = join(opts.workDir, DEFAULT_OUTPUT_NAME);
   const raw = await readImpl(vttPath);
@@ -84,31 +91,8 @@ export async function runWhisper(opts: RunWhisperOptions): Promise<WhisperResult
   };
 }
 
-function spawnAndWait(
-  spawnImpl: typeof spawn,
-  bin: string,
-  args: readonly string[],
-  timeoutMs: number
-): Promise<number> {
-  return new Promise<number>((resolve, reject) => {
-    const child = spawnImpl(bin, [...args], { stdio: ['ignore', 'pipe', 'pipe'] });
-    let timer: NodeJS.Timeout | undefined;
-    let settled = false;
-    const finalise = (fn: () => void): void => {
-      if (settled) return;
-      settled = true;
-      if (timer) clearTimeout(timer);
-      fn();
-    };
-    timer = setTimeout(() => {
-      child.kill('SIGTERM');
-      finalise((): void => reject(new WhisperError(`faster-whisper exceeded ${timeoutMs}ms`)));
-    }, timeoutMs);
-    child.on('error', (err) => finalise((): void => reject(err)));
-    child.on('close', (code) => {
-      finalise((): void => resolve(code ?? -1));
-    });
-  });
+function truncateStderr(stderr: string): string {
+  return stderr.length > 200 ? `${stderr.slice(0, 200)}…` : stderr;
 }
 
 export class WhisperError extends Error {

--- a/apps/pops-worker-food/src/handlers/instagram/stt-whisper.ts
+++ b/apps/pops-worker-food/src/handlers/instagram/stt-whisper.ts
@@ -1,0 +1,153 @@
+/**
+ * PRD-130 — `faster-whisper` subprocess wrapper.
+ *
+ * Spawns `python3 -m faster_whisper.cli` with the flags called out in the
+ * PRD, parses the resulting `transcript.vtt`, and returns the concatenated
+ * cues as a flat transcript string. Failures (non-zero exit, timeout,
+ * missing output) raise — the orchestrator's try/catch routes them to the
+ * `transcriptOk=false` degradation branch.
+ *
+ * Mid-spawn cancellation: the same `AbortController` pattern PRD-129's
+ * yt-dlp wrapper uses. The orchestrator polls `ctx.isCancelled()` between
+ * stages; we don't need a poll inside the subprocess.
+ */
+import { spawn } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const DEFAULT_TIMEOUT_MS = 120_000;
+const DEFAULT_MODEL = 'distil-large-v3';
+const DEFAULT_BIN = 'python3';
+const DEFAULT_OUTPUT_NAME = 'transcript.vtt';
+
+export interface RunWhisperOptions {
+  videoPath: string;
+  workDir: string;
+  /** Override model (default `distil-large-v3`). */
+  model?: string;
+  /** Override executable (default `python3`). */
+  pythonBin?: string;
+  /** Override timeout (default 120s). */
+  timeoutMs?: number;
+  /** Test seam: substitute the spawn implementation. */
+  spawnImpl?: typeof spawn;
+  /** Test seam: substitute the file reader for the produced VTT. */
+  readFileImpl?: (path: string) => Promise<string>;
+}
+
+export interface WhisperResult {
+  transcript: string;
+  model: string;
+  durationMs: number;
+  vttPath: string;
+}
+
+export async function runWhisper(opts: RunWhisperOptions): Promise<WhisperResult> {
+  const model = opts.model ?? DEFAULT_MODEL;
+  const pythonBin = opts.pythonBin ?? DEFAULT_BIN;
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const spawnImpl = opts.spawnImpl ?? spawn;
+  const readImpl = opts.readFileImpl ?? ((p) => readFile(p, 'utf-8'));
+
+  const args = [
+    '-m',
+    'faster_whisper.cli',
+    '--model',
+    model,
+    '--device',
+    'cpu',
+    '--compute_type',
+    'int8',
+    '--output_format',
+    'vtt',
+    '--output_dir',
+    opts.workDir,
+    '--beam_size',
+    '5',
+    '--language',
+    'auto',
+    opts.videoPath,
+  ];
+
+  const start = Date.now();
+  const exitCode = await spawnAndWait(spawnImpl, pythonBin, args, timeoutMs);
+  if (exitCode !== 0) {
+    throw new WhisperError(`faster-whisper exited with code ${exitCode}`);
+  }
+  const vttPath = join(opts.workDir, DEFAULT_OUTPUT_NAME);
+  const raw = await readImpl(vttPath);
+  return {
+    transcript: parseVtt(raw),
+    model,
+    durationMs: Date.now() - start,
+    vttPath,
+  };
+}
+
+function spawnAndWait(
+  spawnImpl: typeof spawn,
+  bin: string,
+  args: readonly string[],
+  timeoutMs: number
+): Promise<number> {
+  return new Promise<number>((resolve, reject) => {
+    const child = spawnImpl(bin, [...args], { stdio: ['ignore', 'pipe', 'pipe'] });
+    let timer: NodeJS.Timeout | undefined;
+    let settled = false;
+    const finalise = (fn: () => void): void => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      fn();
+    };
+    timer = setTimeout(() => {
+      child.kill('SIGTERM');
+      finalise((): void => reject(new WhisperError(`faster-whisper exceeded ${timeoutMs}ms`)));
+    }, timeoutMs);
+    child.on('error', (err) => finalise((): void => reject(err)));
+    child.on('close', (code) => {
+      finalise((): void => resolve(code ?? -1));
+    });
+  });
+}
+
+export class WhisperError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'WhisperError';
+  }
+}
+
+/**
+ * Concatenate the spoken cues from a WebVTT file. Strips timestamps,
+ * blank lines, and the `WEBVTT` header. Cues may be multi-line; we join
+ * them with a single space and the cues themselves with a newline.
+ */
+export function parseVtt(raw: string): string {
+  const lines = raw.split(/\r?\n/);
+  const cues: string[] = [];
+  let buffer: string[] = [];
+  const flush = (): void => {
+    if (buffer.length === 0) return;
+    cues.push(buffer.join(' ').trim());
+    buffer = [];
+  };
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+    if (line === '' || line === 'WEBVTT') {
+      flush();
+      continue;
+    }
+    if (/-->/.test(line)) {
+      flush();
+      continue;
+    }
+    if (/^\d+$/.test(line)) {
+      // Numeric cue identifier — skip.
+      continue;
+    }
+    buffer.push(line);
+  }
+  flush();
+  return cues.filter((c) => c.length > 0).join('\n');
+}

--- a/apps/pops-worker-food/src/handlers/instagram/subprocess.ts
+++ b/apps/pops-worker-food/src/handlers/instagram/subprocess.ts
@@ -1,0 +1,107 @@
+/**
+ * PRD-130 — shared subprocess runner used by both the faster-whisper
+ * (`stt-whisper.ts`) and ffmpeg (`ffmpeg-keyframes.ts`) wrappers.
+ *
+ * Behaviour matches PRD-129's `runYtDlp`:
+ *
+ *   - stdout/stderr are piped and **drained** to in-memory buffers so a
+ *     chatty child (ffmpeg writes a lot to stderr) can't deadlock on a
+ *     full pipe.
+ *   - On timeout we send SIGTERM, then SIGKILL after `sigkillGraceMs` if
+ *     the child is still alive. A SIGTERM-swallowing binary can't stall
+ *     a BullMQ worker slot indefinitely.
+ *   - The returned `exitCode=-1` whenever the child is killed by a
+ *     signal (timeout or abort). Callers distinguish "real exit non-zero"
+ *     from "forcefully terminated" via the boolean tuple element.
+ */
+import { spawn, type ChildProcess } from 'node:child_process';
+
+export const DEFAULT_SIGKILL_GRACE_MS = 5_000;
+
+export interface RunSubprocessOptions {
+  bin: string;
+  args: readonly string[];
+  timeoutMs: number;
+  /** Override the SIGTERM → SIGKILL escalation window. */
+  sigkillGraceMs?: number;
+  /** Test seam — defaults to `spawn` from `node:child_process`. */
+  spawnImpl?: typeof spawn;
+}
+
+export interface SubprocessResult {
+  exitCode: number;
+  stderr: string;
+  /** True when the child was killed by SIGTERM/SIGKILL after the timeout. */
+  timedOut: boolean;
+}
+
+interface KillSwitch {
+  forceKill: () => void;
+  clear: () => void;
+}
+
+export function runSubprocess(opts: RunSubprocessOptions): Promise<SubprocessResult> {
+  const spawnImpl = opts.spawnImpl ?? spawn;
+  const sigkillGraceMs = opts.sigkillGraceMs ?? DEFAULT_SIGKILL_GRACE_MS;
+  return new Promise<SubprocessResult>((resolve, reject) => {
+    const child = spawnImpl(opts.bin, [...opts.args], { stdio: ['ignore', 'pipe', 'pipe'] });
+    const stderrChunks: Buffer[] = [];
+    drain(child, stderrChunks);
+
+    const kill = makeKillSwitch(child, sigkillGraceMs);
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      kill.forceKill();
+    }, opts.timeoutMs);
+    let settled = false;
+    const finish = (fn: () => void): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      kill.clear();
+      fn();
+    };
+    child.on('error', (err) => finish((): void => reject(err)));
+    child.on('close', (code, signal) => {
+      const exitCode = signal !== null || timedOut ? -1 : (code ?? -1);
+      finish((): void =>
+        resolve({
+          exitCode,
+          stderr: Buffer.concat(stderrChunks).toString('utf-8'),
+          timedOut,
+        })
+      );
+    });
+  });
+}
+
+function drain(child: ChildProcess, stderrChunks: Buffer[]): void {
+  child.stderr?.on('data', (chunk: Buffer) => {
+    stderrChunks.push(chunk);
+  });
+  child.stdout?.on('data', () => {
+    // The chatty processes (ffmpeg, whisper) write progress info to
+    // stderr. stdout is rarely used, but read-and-discard so the pipe
+    // doesn't back up either.
+  });
+}
+
+function makeKillSwitch(child: ChildProcess, graceMs: number): KillSwitch {
+  let sigkillTimer: NodeJS.Timeout | null = null;
+  return {
+    forceKill: () => {
+      if (sigkillTimer !== null) return;
+      child.kill('SIGTERM');
+      sigkillTimer = setTimeout(() => {
+        child.kill('SIGKILL');
+      }, graceMs);
+    },
+    clear: () => {
+      if (sigkillTimer !== null) {
+        clearTimeout(sigkillTimer);
+        sigkillTimer = null;
+      }
+    },
+  };
+}

--- a/apps/pops-worker-food/src/handlers/instagram/text-fallback.ts
+++ b/apps/pops-worker-food/src/handlers/instagram/text-fallback.ts
@@ -1,6 +1,7 @@
 /**
  * PRD-130 — text-LLM fallback used when the vision call fails AND the
- * reel has a non-trivial caption (>30 chars). Re-implements the same
+ * reel has a non-trivial caption (≥30 chars; the boundary is inclusive,
+ * matching `MIN_CAPTION_LENGTH_FOR_FALLBACK`). Re-implements the same
  * prompt shape PRD-128 will export as `PROMPT_WEB_LLM`; once PRD-128 +
  * PRD-132 land we can dedupe via a shared `extractWithClaudeText` import.
  *

--- a/apps/pops-worker-food/src/handlers/instagram/text-fallback.ts
+++ b/apps/pops-worker-food/src/handlers/instagram/text-fallback.ts
@@ -1,0 +1,120 @@
+/**
+ * PRD-130 — text-LLM fallback used when the vision call fails AND the
+ * reel has a non-trivial caption (>30 chars). Re-implements the same
+ * prompt shape PRD-128 will export as `PROMPT_WEB_LLM`; once PRD-128 +
+ * PRD-132 land we can dedupe via a shared `extractWithClaudeText` import.
+ *
+ * Operation name in observability is `recipe-extract-ig-text-fallback`
+ * to distinguish from PRD-128's `recipe-extract-web-llm`.
+ */
+import { extractedRecipeSchema, type ExtractedRecipe } from './extracted-recipe.js';
+
+import type { AnthropicLike, AnthropicMessage } from './anthropic-client.js';
+
+export const DEFAULT_TEXT_FALLBACK_MODEL = 'claude-haiku-4-5-20251001';
+export const PROMPT_VERSION_TEXT_FALLBACK = 'web-llm-v1.0';
+export const TEXT_FALLBACK_OPERATION = 'recipe-extract-ig-text-fallback';
+export const MIN_CAPTION_LENGTH_FOR_FALLBACK = 30;
+
+const MAX_TOKENS = 2_000;
+
+const SYSTEM_PROMPT = `You are extracting a recipe from free-form text. Output ONLY a JSON object matching the schema. No prose, no markdown fences.
+
+Schema:
+{
+  "title": string,
+  "summary": string | null,
+  "servings": integer | null,
+  "prep_time_min": number | null,
+  "cook_time_min": number | null,
+  "ingredients": [
+    { "ingredient_slug": string, "variant_slug": string | null, "prep_state_slug": string | null,
+      "qty": number, "unit": string, "notes": string | null }
+  ],
+  "steps": [
+    { "body": string, "duration_min": number | null, "temperature_c": number | null }
+  ]
+}
+
+Rules:
+- Use metric units when available.
+- If multiple recipes appear, extract the first one only.
+- Quantities the text doesn't supply default to qty=1, unit="count".
+`;
+
+export interface ExtractTextFallbackInput {
+  caption: string;
+}
+
+export interface ExtractTextFallbackOptions {
+  client: AnthropicLike;
+  model?: string;
+}
+
+export interface TextFallbackResult {
+  parsed: ExtractedRecipe;
+  model: string;
+  promptVersion: string;
+  operation: string;
+  inputTokens: number;
+  outputTokens: number;
+  durationMs: number;
+}
+
+export async function extractWithTextFallback(
+  input: ExtractTextFallbackInput,
+  opts: ExtractTextFallbackOptions
+): Promise<TextFallbackResult> {
+  const model = opts.model ?? DEFAULT_TEXT_FALLBACK_MODEL;
+  const start = Date.now();
+  const response = await opts.client.messages.create({
+    model,
+    max_tokens: MAX_TOKENS,
+    system: SYSTEM_PROMPT,
+    messages: [{ role: 'user', content: input.caption }],
+  });
+  const durationMs = Date.now() - start;
+
+  const text = firstTextBlock(response);
+  if (text === null) throw new TextFallbackError('Anthropic response had no text block');
+  if (/^\s*```/.test(text)) {
+    throw new TextFallbackError('Anthropic response wrapped JSON in a markdown fence');
+  }
+  let raw: unknown;
+  try {
+    raw = JSON.parse(text);
+  } catch (err) {
+    throw new TextFallbackError(
+      `Anthropic response was not valid JSON: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+  const result = extractedRecipeSchema.safeParse(raw);
+  if (!result.success) {
+    throw new TextFallbackError(
+      `Anthropic response did not match the recipe schema: ${result.error.message}`
+    );
+  }
+  return {
+    parsed: result.data,
+    model,
+    promptVersion: PROMPT_VERSION_TEXT_FALLBACK,
+    operation: TEXT_FALLBACK_OPERATION,
+    inputTokens: response.usage?.input_tokens ?? 0,
+    outputTokens: response.usage?.output_tokens ?? 0,
+    durationMs,
+  };
+}
+
+function firstTextBlock(message: AnthropicMessage): string | null {
+  for (const block of message.content) {
+    if (block.type === 'text' && block.text.trim().length > 0) return block.text;
+  }
+  return null;
+}
+
+export class TextFallbackError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'TextFallbackError';
+  }
+}

--- a/apps/pops-worker-food/src/handlers/instagram/vision.ts
+++ b/apps/pops-worker-food/src/handlers/instagram/vision.ts
@@ -1,0 +1,154 @@
+/**
+ * PRD-130 — Claude vision call.
+ *
+ * One multimodal `messages.create` request: caption + transcript text +
+ * up to 5 base64-encoded keyframes (the highest-scoring scene-detection
+ * picks by ffmpeg ordering). Response is strict-parsed via `JSON.parse`
+ * and validated with the local zod schema; anything else raises.
+ *
+ * Keyframes beyond `MAX_KEYFRAMES_TO_VISION` are dropped — the PRD caps
+ * the vision payload at 5 even when ffmpeg produced 10.
+ */
+import { readFile } from 'node:fs/promises';
+import { extname } from 'node:path';
+
+import { PROMPT_VERSION_IG_VISION, renderIgVisionPrompt } from '../../prompts/ig-vision.js';
+import { extractedRecipeSchema, type ExtractedRecipe } from './extracted-recipe.js';
+
+import type { AnthropicLike, AnthropicMessage } from './anthropic-client.js';
+
+export const MAX_KEYFRAMES_TO_VISION = 5;
+export const DEFAULT_IG_VISION_MODEL = 'claude-haiku-4-5-20251001';
+
+const MAX_TOKENS = 2_000;
+
+export interface ExtractWithVisionInput {
+  caption: string | null;
+  transcript: string | null;
+  keyframePaths: readonly string[];
+}
+
+export interface ExtractWithVisionOptions {
+  client: AnthropicLike;
+  model?: string;
+  /** Test seam: substitute the file reader for keyframe images. */
+  readFileImpl?: (path: string) => Promise<Buffer>;
+}
+
+export interface VisionResult {
+  parsed: ExtractedRecipe;
+  model: string;
+  promptVersion: string;
+  inputTokens: number;
+  outputTokens: number;
+  keyframesSent: number;
+  durationMs: number;
+}
+
+export async function extractWithClaudeVision(
+  input: ExtractWithVisionInput,
+  opts: ExtractWithVisionOptions
+): Promise<VisionResult> {
+  const model = opts.model ?? DEFAULT_IG_VISION_MODEL;
+  const readImpl = opts.readFileImpl ?? readFile;
+  const selected = input.keyframePaths.slice(0, MAX_KEYFRAMES_TO_VISION);
+  const imageBlocks = await Promise.all(selected.map((p) => imageBlock(p, readImpl)));
+  const prompt = renderIgVisionPrompt({
+    caption: input.caption,
+    transcript: input.transcript,
+    keyframeCount: selected.length,
+  });
+
+  const start = Date.now();
+  const response = await opts.client.messages.create({
+    model,
+    max_tokens: MAX_TOKENS,
+    messages: [
+      {
+        role: 'user',
+        content: [...imageBlocks, { type: 'text', text: prompt }],
+      },
+    ],
+  });
+  const durationMs = Date.now() - start;
+
+  const text = firstTextBlock(response);
+  if (text === null) throw new VisionExtractError('Anthropic response had no text block');
+  const parsed = parseAndValidate(text);
+  return {
+    parsed,
+    model,
+    promptVersion: PROMPT_VERSION_IG_VISION,
+    inputTokens: response.usage?.input_tokens ?? 0,
+    outputTokens: response.usage?.output_tokens ?? 0,
+    keyframesSent: selected.length,
+    durationMs,
+  };
+}
+
+function firstTextBlock(message: AnthropicMessage): string | null {
+  for (const block of message.content) {
+    if (block.type === 'text' && block.text.trim().length > 0) return block.text;
+  }
+  return null;
+}
+
+function parseAndValidate(text: string): ExtractedRecipe {
+  if (/^\s*```/.test(text)) {
+    throw new VisionExtractError('Anthropic response wrapped JSON in a markdown fence');
+  }
+  let raw: unknown;
+  try {
+    raw = JSON.parse(text);
+  } catch (err) {
+    throw new VisionExtractError(
+      `Anthropic response was not valid JSON: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+  const result = extractedRecipeSchema.safeParse(raw);
+  if (!result.success) {
+    throw new VisionExtractError(
+      `Anthropic response did not match the recipe schema: ${result.error.message}`
+    );
+  }
+  return result.data;
+}
+
+type SupportedMediaType = 'image/jpeg' | 'image/png' | 'image/webp' | 'image/gif';
+
+interface ImageBlock {
+  type: 'image';
+  source: { type: 'base64'; media_type: SupportedMediaType; data: string };
+}
+
+async function imageBlock(
+  path: string,
+  readImpl: (path: string) => Promise<Buffer>
+): Promise<ImageBlock> {
+  const buffer = await readImpl(path);
+  const mediaType = mediaTypeFor(path);
+  return {
+    type: 'image',
+    source: { type: 'base64', media_type: mediaType, data: buffer.toString('base64') },
+  };
+}
+
+function mediaTypeFor(path: string): SupportedMediaType {
+  switch (extname(path).toLowerCase()) {
+    case '.png':
+      return 'image/png';
+    case '.webp':
+      return 'image/webp';
+    case '.gif':
+      return 'image/gif';
+    default:
+      return 'image/jpeg';
+  }
+}
+
+export class VisionExtractError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'VisionExtractError';
+  }
+}

--- a/apps/pops-worker-food/src/prompts/ig-vision.ts
+++ b/apps/pops-worker-food/src/prompts/ig-vision.ts
@@ -1,0 +1,71 @@
+/**
+ * PRD-130 — Instagram vision prompt template + version constant.
+ *
+ * Surface mirrors PRD-133's prompt-registry expectations: every change to
+ * the body MUST bump `PROMPT_VERSION_IG_VISION`. The viewer at
+ * `/food/prompts` reads both literals.
+ */
+
+export const PROMPT_VERSION_IG_VISION = 'ig-vision-v1.0';
+
+export const IG_VISION_PROMPT = `You are extracting a recipe from an Instagram reel.
+
+The source has three components:
+1. CAPTION (the post's text, often contains ingredient lists)
+2. TRANSCRIPT (auto-generated from the audio; may be noisy)
+3. KEYFRAMES (frames from the video; may contain on-screen text overlays with ingredients and quantities — VERY IMPORTANT, often the only place quantities appear)
+
+CAPTION:
+{caption}
+
+TRANSCRIPT:
+{transcript}
+
+KEYFRAMES:
+{N images attached}
+
+Extract a recipe as JSON. Use this exact schema:
+
+{
+  "title": string,
+  "summary": string | null,
+  "servings": integer | null,
+  "prep_time_min": number | null,
+  "cook_time_min": number | null,
+  "ingredients": [
+    {
+      "ingredient_slug": string,
+      "variant_slug": string | null,
+      "prep_state_slug": string | null,
+      "qty": number,
+      "unit": string,
+      "notes": string | null
+    }
+  ],
+  "steps": [
+    {
+      "body": string,
+      "duration_min": number | null,
+      "temperature_c": number | null
+    }
+  ]
+}
+
+Rules:
+- Read on-screen text in keyframes carefully — recipe reels often display ingredients with quantities as overlays that are NEVER spoken aloud. These overlays are the most reliable source of quantities.
+- Prefer caption + on-screen text quantities over transcript quantities (transcript is noisy).
+- If caption is structured (has ingredient list + steps), trust it most.
+- Use metric units when available.
+- If keyframes contradict caption, prefer keyframes for quantities.
+- Output ONLY the JSON. No markdown, no explanation.
+`;
+
+export function renderIgVisionPrompt(args: {
+  caption: string | null;
+  transcript: string | null;
+  keyframeCount: number;
+}): string {
+  return IG_VISION_PROMPT.replace('{caption}', args.caption ?? '(none)')
+    .replace('{transcript}', args.transcript ?? '(skipped — caption was structured enough)')
+    .replace('{N images attached}', `${args.keyframeCount} images attached`);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -450,9 +450,6 @@ importers:
       '@pops/api':
         specifier: workspace:*
         version: link:../pops-api
-      '@pops/app-food':
-        specifier: workspace:*
-        version: link:../../packages/app-food
       '@pops/app-food-db':
         specifier: workspace:*
         version: link:../../packages/app-food-db


### PR DESCRIPTION
## Summary

- Replaces the PRD-126 `NotImplemented` stub for `url-instagram` with the hierarchical-degradation pipeline the PRD specifies. Consumes PRD-129's `runInstagramAcquisition` (already merged) and degrades gracefully when STT, keyframe extraction, or the vision call fail.
- Acquisition failures from PRD-129 are converted onto `IngestJobResult`: `auth-dead` surfaces as a partial draft with placeholder DSL, `rate-limited` propagates `retryAfterSec` to BullMQ, the other three become structured `errorCode`s.
- 237/237 worker tests green; lint, typecheck, format, build all clean.

## Pipeline (apps/pops-worker-food/src/handlers/instagram/)

| Stage | File | Notes |
| --- | --- | --- |
| Caption heuristic | `caption-heuristic.ts` | Skips STT when caption has 5+ bullets + measurement units OR ingredients + steps headers. |
| STT | `stt-whisper.ts` | `python3 -m faster_whisper.cli --model distil-large-v3` subprocess + small VTT parser. 120s timeout. |
| Keyframes | `ffmpeg-keyframes.ts` | Scene-detection ffmpeg pass (≤10 720p frames, threshold 0.3) with a single-frame fallback at the 2s mark. 60s timeout. |
| Vision | `vision.ts` | One multimodal `messages.create`, top-5 keyframes base64-encoded with correct media types, strict JSON parse + zod validation, markdown-fence rejection. |
| Text fallback | `text-fallback.ts` | Same shape as PRD-128's `PROMPT_WEB_LLM`, operation `recipe-extract-ig-text-fallback`, triggered when vision fails AND the caption is ≥30 chars. |
| Acquisition-failure conversion | `convert-acquisition-failure.ts` | Maps PRD-129's 5 failure kinds; `auth-dead` → `partialReason='auth-dead'` + placeholder DSL; `rate-limited` → `retryAfterSec`. |
| Degradation | `degradation.ts` | `derivePartialReason()` consolidates per-stage outcomes per the §Degradation truth table. |
| DSL | `build-dsl.ts` | Local copy until PRD-132's `buildDsl` lands; reuses PRD-127's `slugify` + collision suffixing. Drops non-curated `prep_state_slug`. |
| Orchestrator | `orchestrator.ts` | Flow control + meta JSON. Per-stage helpers split into `stages.ts` + `extraction.ts` to stay under the per-file lint cap. |
| Anthropic seam | `anthropic-client.ts` | Lazy SDK init + narrow `AnthropicLike` interface so tests inject a plain mock. `normaliseMessage` shim narrows the SDK's `Message` to the structural slice we consume. |

`prompts/ig-vision.ts` exports `PROMPT_VERSION_IG_VISION='ig-vision-v1.0'` + renderer.

Dispatcher (`handlers/instagram.ts`) reads `ANTHROPIC_API_KEY` (returns `MissingApiKey` when unset) and `FOOD_IG_VISION_MODEL` / `FOOD_WHISPER_MODEL` env overrides, then hands work to the orchestrator.

## AC coverage (PRD-130 README)

### Pipeline orchestration
- [x] `runInstagramPipeline` exported from `instagram/orchestrator.ts` (the dispatch shell at `handlers/instagram.ts` wires runtime config in).
- [x] Calls `runInstagramAcquisition`; converts failures via `convertAcquisitionFailure`.
- [x] Caption heuristic decides STT skip per the documented logic.
- [x] STT, keyframes, vision wrapped in try/catch; failures route to degradation paths.
- [x] Final `partialReason` derived per the truth table.

### faster-whisper
- [x] CLI invocation with documented flags (`--model distil-large-v3 --device cpu --compute_type int8 --output_format vtt --output_dir … --beam_size 5 --language auto`).
- [x] Output `transcript.vtt` parsed into a flat transcript string.
- [x] Timeout 120s; treated as STT failure on exceed.
- [x] Vitest with `spawnImpl` + VTT-parse seam.

### ffmpeg keyframes
- [x] Scene-detection invocation produces up to 10 frames; `select='gt(scene,0.3)',scale=720:-2 -frames:v 10`.
- [x] Fallback single-frame extraction at 2s when zero frames detected.
- [x] Top-5 keyframes sent to vision (cap enforced inside `extractWithClaudeVision`).
- [x] Timeout 60s.

### Claude vision
- [x] Single multimodal call per ingest (≤5 base64 images + text).
- [x] Prompt template exported from `prompts/ig-vision.ts` with `PROMPT_VERSION_IG_VISION`.
- [x] Model configurable via `FOOD_IG_VISION_MODEL`; default `claude-haiku-4-5-20251001`.
- [x] Response strict-parsed + zod-validated; markdown fences rejected.

### Text-LLM fallback
- [x] Triggered when vision fails AND caption ≥30 chars. Operation name `recipe-extract-ig-text-fallback`.
- [ ] `ai_inference_log` row write — deferred: PRD-133's `callClaudeWithLogging` lives in `@pops/app-food` (React-coupled); the same TODO marker PRD-128 / PRD-131 / PRD-132 use applies. Per-stage meta still captures the same telemetry until the swap.

### Meta & logging
- [x] Meta JSON populated with all stages per the documented shape.
- [ ] `ai_inference_log` rows — see fallback note above.

### Tests
- [x] Vitest unit tests cover happy path + each degradation branch.
- [x] Acquisition, STT, ffmpeg, vision, text-fallback all mocked.
- [x] Truth-table test verifies each documented row.
- [x] Vitest assertion: oversized keyframe set capped at 5 before vision (`MAX_KEYFRAMES_TO_VISION`).
- [ ] Integration test against a real reel — gated; out of scope for this PR per PRD.

## Drive-bys
- PRD-127's parser deep-import is now `@pops/app-food-db` (top-level, no React surface), tracking PRD-119-API's DSL pipeline extraction.
- `@pops/app-food-db` replaces `@pops/app-food` in the worker devDeps.
- PRD-126 dispatch test trimmed: every kind now has a real handler; the `default handler stubs` assertion flips to "no kinds hit the stub".

## Coordination
- Strictly additive within the worker package. New helper files under `handlers/instagram/`; only edits the PRD-126 instagram dispatch stub + the existing dispatch test allowlist.
- Adds `@anthropic-ai/sdk` + `zod` workspace deps (matches versions pops-api already pins).
- Native runtime deps (`faster-whisper`, `ffmpeg`) NOT installed in this PR — Docker image hooks are PRD-126's responsibility; the JS pipeline ships here with a swap-in marker for the Dockerfile patch.
- Dedupe against PRD-128 (now merged: `PROMPT_WEB_LLM`, readability), PRD-131 (now merged: `extractWithClaudeVision`), and PRD-132 (now merged: `extractWithClaudeText`, `buildDsl`, `extractedRecipeSchema`) tracked as a follow-up rebase — out of scope for this PR to keep the diff focused on the IG pipeline.

## Test plan

- [x] `pnpm --filter @pops/worker-food test` — 237/237 pass
- [x] `pnpm typecheck` — green
- [x] `pnpm lint` — green
- [x] `pnpm format:check` — green
- [x] `pnpm turbo build --continue` — green
- [ ] Copilot review pass
- [ ] CI green