### PR TITLE
feat(core-db): add openCoreDb helper (pillar core phase 2 PR 1)

### DIFF
--- a/packages/core-db/package.json
+++ b/packages/core-db/package.json
@@ -21,12 +21,12 @@
   },
   "dependencies": {
     "@pops/db-types": "workspace:*",
+    "better-sqlite3": "^12.10.0",
     "drizzle-orm": "^0.45.2"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.12",
     "@vitest/coverage-v8": "^4.1.8",
-    "better-sqlite3": "^12.10.0",
     "typescript": "^6.0.3",
     "vitest": "^4.1.8"
   }

--- a/packages/core-db/src/__tests__/open-core-db.test.ts
+++ b/packages/core-db/src/__tests__/open-core-db.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Smoke tests for the standalone `openCoreDb` helper.
+ *
+ * Exercises the migration apply path against a fresh tmp file, verifies
+ * the resulting schema, and confirms the helper is idempotent when
+ * re-run against the same DB.
+ */
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { openCoreDb } from '../open-core-db.js';
+import { countActiveServiceAccounts, createServiceAccount } from '../services/service-accounts.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'core-db-test-'));
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('openCoreDb', () => {
+  it('creates the parent directory and opens a fresh DB', () => {
+    const path = join(tmpDir, 'nested', 'sub', 'core.db');
+    expect(existsSync(path)).toBe(false);
+
+    const { raw } = openCoreDb(path);
+    try {
+      expect(existsSync(path)).toBe(true);
+      expect(raw.pragma('journal_mode', { simple: true })).toBe('wal');
+      expect(raw.pragma('foreign_keys', { simple: true })).toBe(1);
+    } finally {
+      raw.close();
+    }
+  });
+
+  it('applies the service_accounts migration', () => {
+    const path = join(tmpDir, 'core.db');
+    const { db, raw } = openCoreDb(path);
+    try {
+      // Table exists + accepts inserts via the package service.
+      expect(countActiveServiceAccounts(db)).toBe(0);
+    } finally {
+      raw.close();
+    }
+  });
+
+  it('is idempotent — re-opening the same DB does not re-apply migrations', async () => {
+    const path = join(tmpDir, 'core.db');
+    const first = openCoreDb(path);
+    try {
+      await createServiceAccount(first.db, { name: 'persists', scopes: ['x'] }, null);
+      expect(countActiveServiceAccounts(first.db)).toBe(1);
+    } finally {
+      first.raw.close();
+    }
+
+    const second = openCoreDb(path);
+    try {
+      expect(countActiveServiceAccounts(second.db)).toBe(1);
+    } finally {
+      second.raw.close();
+    }
+  });
+});

--- a/packages/core-db/src/__tests__/open-core-db.test.ts
+++ b/packages/core-db/src/__tests__/open-core-db.test.ts
@@ -34,6 +34,7 @@ describe('openCoreDb', () => {
       expect(existsSync(path)).toBe(true);
       expect(raw.pragma('journal_mode', { simple: true })).toBe('wal');
       expect(raw.pragma('foreign_keys', { simple: true })).toBe(1);
+      expect(raw.pragma('busy_timeout', { simple: true })).toBe(5000);
     } finally {
       raw.close();
     }

--- a/packages/core-db/src/index.ts
+++ b/packages/core-db/src/index.ts
@@ -15,6 +15,8 @@ export * from './schema.js';
 
 export type { CoreDb } from './services/internal.js';
 
+export { openCoreDb, type OpenedCoreDb } from './open-core-db.js';
+
 export * as serviceAccountsService from './services/service-accounts.js';
 export * as serviceAccountKeys from './services/service-account-keys.js';
 

--- a/packages/core-db/src/open-core-db.ts
+++ b/packages/core-db/src/open-core-db.ts
@@ -1,0 +1,68 @@
+/**
+ * Standalone opener for the core pillar's SQLite database.
+ *
+ * Phase 2 PR 1 of the core pillar migration scaffolds the per-pillar
+ * connection so subsequent PRs can flip readers/writers over without
+ * touching pops-api's existing singleton. The opener is intentionally
+ * minimal — it does NOT load the sqlite-vec extension or the
+ * vector-index helpers (those stay with pops-api's `getDrizzle()` for
+ * now) and it relies on drizzle-orm's built-in `migrate` helper to apply
+ * the in-package migrations journal at `packages/core-db/migrations/`.
+ *
+ * No production consumer wires this up yet. Subsequent PRs add the
+ * `CORE_SQLITE_PATH` env-var read in pops-api, the boot-time call, and
+ * the data backfill from the shared pops.db.
+ */
+import { mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+
+import type { CoreDb } from './services/internal.js';
+
+/**
+ * Path to the migrations folder inside this package. Resolved relative to
+ * the compiled `dist/index.js` (or `src/open-core-db.ts` in dev) so it
+ * works both when consumed via the workspace symlink and when bundled
+ * into a Docker image's `node_modules/@pops/core-db/`.
+ */
+function migrationsDir(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  return join(here, '..', 'migrations');
+}
+
+/** Result of {@link openCoreDb}. The raw handle is exposed for callers
+ * that need lifecycle control (close on shutdown, prepared statements,
+ * pragmas the drizzle wrapper hides). */
+export interface OpenedCoreDb {
+  /** Drizzle handle — pass into any `serviceAccountsService.*` call. */
+  db: CoreDb;
+  /** Raw better-sqlite3 handle. Call `.close()` on shutdown. */
+  raw: Database.Database;
+}
+
+/**
+ * Open the core pillar's SQLite database at `path`, configure it, apply
+ * the in-package migrations journal, and return both the drizzle wrapper
+ * and the raw handle.
+ *
+ * Side effects:
+ *   - The parent directory of `path` is created if missing (recursive).
+ *   - `journal_mode=WAL` and `foreign_keys=ON` are enabled.
+ *   - Every migration in `packages/core-db/migrations/_journal.json` is
+ *     applied via drizzle's built-in migrator (idempotent — re-running
+ *     against the same DB short-circuits on the `__drizzle_migrations`
+ *     hash check).
+ */
+export function openCoreDb(path: string): OpenedCoreDb {
+  mkdirSync(dirname(path), { recursive: true });
+  const raw = new Database(path);
+  raw.pragma('journal_mode = WAL');
+  raw.pragma('foreign_keys = ON');
+  const db = drizzle(raw) as CoreDb;
+  migrate(db, { migrationsFolder: migrationsDir() });
+  return { db, raw };
+}

--- a/packages/core-db/src/open-core-db.ts
+++ b/packages/core-db/src/open-core-db.ts
@@ -7,7 +7,7 @@
  * minimal — it does NOT load the sqlite-vec extension or the
  * vector-index helpers (those stay with pops-api's `getDrizzle()` for
  * now) and it relies on drizzle-orm's built-in `migrate` helper to apply
- * the in-package migrations journal at `packages/core-db/migrations/`.
+ * the in-package migrations journal at `packages/core-db/migrations/meta/_journal.json`.
  *
  * No production consumer wires this up yet. Subsequent PRs add the
  * `CORE_SQLITE_PATH` env-var read in pops-api, the boot-time call, and
@@ -24,10 +24,11 @@ import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
 import type { CoreDb } from './services/internal.js';
 
 /**
- * Path to the migrations folder inside this package. Resolved relative to
- * the compiled `dist/index.js` (or `src/open-core-db.ts` in dev) so it
- * works both when consumed via the workspace symlink and when bundled
- * into a Docker image's `node_modules/@pops/core-db/`.
+ * Path to the migrations folder inside this package. Resolved relative
+ * to this module's location (`src/open-core-db.ts` in dev,
+ * `dist/open-core-db.js` after build) so it works both when consumed
+ * via the workspace symlink and when bundled into a Docker image's
+ * `node_modules/@pops/core-db/`.
  */
 function migrationsDir(): string {
   const here = dirname(fileURLToPath(import.meta.url));
@@ -51,18 +52,29 @@ export interface OpenedCoreDb {
  *
  * Side effects:
  *   - The parent directory of `path` is created if missing (recursive).
- *   - `journal_mode=WAL` and `foreign_keys=ON` are enabled.
- *   - Every migration in `packages/core-db/migrations/_journal.json` is
- *     applied via drizzle's built-in migrator (idempotent — re-running
+ *   - `journal_mode=WAL`, `foreign_keys=ON`, and `busy_timeout=5000` are
+ *     enabled to match the shared singleton in `apps/pops-api/src/db.ts`.
+ *   - Every migration in `packages/core-db/migrations/meta/_journal.json`
+ *     is applied via drizzle's built-in migrator (idempotent — re-running
  *     against the same DB short-circuits on the `__drizzle_migrations`
  *     hash check).
+ *
+ * If the migration apply throws (corrupt DB, malformed migration, missing
+ * folder), the raw handle is closed before the error is re-thrown so the
+ * caller can't leak a locked file descriptor.
  */
 export function openCoreDb(path: string): OpenedCoreDb {
   mkdirSync(dirname(path), { recursive: true });
   const raw = new Database(path);
   raw.pragma('journal_mode = WAL');
   raw.pragma('foreign_keys = ON');
+  raw.pragma('busy_timeout = 5000');
   const db = drizzle(raw) as CoreDb;
-  migrate(db, { migrationsFolder: migrationsDir() });
+  try {
+    migrate(db, { migrationsFolder: migrationsDir() });
+  } catch (err) {
+    raw.close();
+    throw err;
+  }
   return { db, raw };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1201,6 +1201,9 @@ importers:
       '@pops/db-types':
         specifier: workspace:*
         version: link:../db-types
+      better-sqlite3:
+        specifier: ^12.10.0
+        version: 12.10.0
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.10.0)
@@ -1211,9 +1214,6 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^4.1.8
         version: 4.1.8(vitest@4.1.8)
-      better-sqlite3:
-        specifier: ^12.10.0
-        version: 12.10.0
       typescript:
         specifier: ^6.0.3
         version: 6.0.3


### PR DESCRIPTION
## Summary

First PR of the **core pillar Phase 2 — extract core's SQLite** sequence (pillar-migration-roadmap.md Track D · Phase 2 PR 1 of 4).

Scaffolds the per-pillar SQLite connection helper inside \`@pops/core-db\`. **Strictly additive — no consumer wires this up yet.**

## What changed

- \`packages/core-db/src/open-core-db.ts\` — new \`openCoreDb(path)\` helper:
  - Creates the parent directory recursively
  - Opens a fresh \`better-sqlite3\` connection
  - Enables WAL + foreign-keys pragmas to match pops-api's shared singleton
  - Applies the in-package migrations journal via \`drizzle-orm/better-sqlite3/migrator\` (resolves the migrations folder relative to the compiled \`dist/\` so it works via the workspace symlink and inside Docker images)
  - Returns both the drizzle wrapper and the raw handle for lifecycle control
- \`packages/core-db/src/index.ts\` — re-exports \`openCoreDb\` + \`OpenedCoreDb\`
- 3 new vitest cases (30/30 in core-db): parent-dir creation + pragma assertions, schema present after open, idempotency on re-open

## Roadmap context

- Phase 2 PR 2 will add the \`CORE_SQLITE_PATH\` env-var read in pops-api and the boot-time \`openCoreDb()\` call (still no behavioural change — the handle is opened but unused).
- PR 3 backfills service-accounts rows from the shared \`pops.db\` and flips reads/writes over.
- PR 4 drops the table from the shared journal + Litestream config at \`infra/litestream/core.yml\`.

## Verification

- \`pnpm typecheck\` — 32/32 green
- \`pnpm --filter @pops/core-db test\` — 30/30 cases pass

## Test plan

- [ ] CI green on \`core-quality\` (new test cases + drift guard intact)
- [ ] Copilot review pass