### PR TITLE
feat(lists): /lists/:id detail page (PRD-140 part C)

### DIFF
--- a/apps/pops-api/Dockerfile
+++ b/apps/pops-api/Dockerfile
@@ -8,6 +8,7 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json ./
 COPY packages/db-types/package.json ./packages/db-types/
 COPY packages/types/package.json ./packages/types/
 COPY packages/module-registry/package.json ./packages/module-registry/
+COPY packages/api-client/package.json ./packages/api-client/
 COPY packages/app-food-db/package.json ./packages/app-food-db/
 COPY packages/app-lists/package.json ./packages/app-lists/
 COPY packages/app-lists-db/package.json ./packages/app-lists-db/

--- a/apps/pops-mcp/Dockerfile
+++ b/apps/pops-mcp/Dockerfile
@@ -8,6 +8,7 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json ./
 COPY packages/db-types/package.json ./packages/db-types/
 COPY packages/types/package.json ./packages/types/
 COPY packages/module-registry/package.json ./packages/module-registry/
+COPY packages/api-client/package.json ./packages/api-client/
 COPY packages/app-food-db/package.json ./packages/app-food-db/
 COPY packages/app-lists/package.json ./packages/app-lists/
 COPY packages/app-lists-db/package.json ./packages/app-lists-db/

--- a/apps/pops-shell/src/i18n/locales/en-AU/lists.json
+++ b/apps/pops-shell/src/i18n/locales/en-AU/lists.json
@@ -6,5 +6,74 @@
   "browse.description": "Open an existing list to add, check off, or reorder items.",
   "newList.title": "New list",
   "newList.description": "Start a shopping, packing, or generic list from scratch.",
-  "status.comingSoon": "Coming soon"
+  "status.comingSoon": "Coming soon",
+  "detail": {
+    "loading": "Loading list…",
+    "error": "Could not load this list.",
+    "notFound": "List not found.",
+    "empty": "No items yet. Type a label below and press Enter.",
+    "archivedBadge": "Archived",
+    "kind": {
+      "shopping": "Shopping",
+      "packing": "Packing",
+      "todo": "Todo",
+      "generic": "Generic"
+    },
+    "menu": {
+      "label": "List actions",
+      "rename": "Rename",
+      "changeKind": "Change kind",
+      "archive": "Archive",
+      "restore": "Restore",
+      "delete": "Delete…"
+    },
+    "edit": {
+      "title": "Edit list",
+      "name": "Name",
+      "kind": "Kind",
+      "kindWarning": "Changing kind may hide or show affordances. Items aren't modified.",
+      "nameRequired": "Name is required.",
+      "cancel": "Cancel",
+      "save": "Save",
+      "saving": "Saving…"
+    },
+    "delete": {
+      "title": "Delete list?",
+      "body": "Permanently delete \"{{name}}\" and its {{count}} item(s)? This can't be undone.",
+      "cancel": "Cancel",
+      "confirm": "Delete list",
+      "pending": "Deleting…"
+    },
+    "errors": {
+      "update": "Could not save changes."
+    },
+    "add": {
+      "placeholder": "Add item — press Enter",
+      "qty": "Qty",
+      "unit": "Unit",
+      "submit": "Add",
+      "showOptional": "+ qty / unit",
+      "hideOptional": "Hide qty / unit"
+    },
+    "item": {
+      "checkbox": "Toggle done for {{label}}",
+      "editLabel": "Edit item label",
+      "dragHandle": "Drag to reorder",
+      "unnamed": "(unnamed)",
+      "ref": {
+        "ingredient": "Ingredient",
+        "variant": "Variant",
+        "recipe": "Recipe",
+        "custom": "Custom",
+        "free": "Free"
+      },
+      "menu": {
+        "label": "Item actions",
+        "edit": "Edit",
+        "moveUp": "Move up",
+        "moveDown": "Move down",
+        "delete": "Delete"
+      }
+    }
+  }
 }

--- a/apps/pops-shell/src/i18n/locales/pt-BR/lists.json
+++ b/apps/pops-shell/src/i18n/locales/pt-BR/lists.json
@@ -6,5 +6,74 @@
   "browse.description": "Abra uma lista existente para adicionar, marcar ou reordenar itens.",
   "newList.title": "Nova lista",
   "newList.description": "Comece uma lista de compras, viagem ou genérica do zero.",
-  "status.comingSoon": "Em breve"
+  "status.comingSoon": "Em breve",
+  "detail": {
+    "loading": "Carregando lista…",
+    "error": "Não foi possível carregar esta lista.",
+    "notFound": "Lista não encontrada.",
+    "empty": "Sem itens ainda. Digite um rótulo abaixo e pressione Enter.",
+    "archivedBadge": "Arquivada",
+    "kind": {
+      "shopping": "Compras",
+      "packing": "Viagem",
+      "todo": "Tarefas",
+      "generic": "Genérica"
+    },
+    "menu": {
+      "label": "Ações da lista",
+      "rename": "Renomear",
+      "changeKind": "Mudar tipo",
+      "archive": "Arquivar",
+      "restore": "Restaurar",
+      "delete": "Excluir…"
+    },
+    "edit": {
+      "title": "Editar lista",
+      "name": "Nome",
+      "kind": "Tipo",
+      "kindWarning": "Mudar o tipo pode ocultar ou exibir recursos. Os itens não são modificados.",
+      "nameRequired": "O nome é obrigatório.",
+      "cancel": "Cancelar",
+      "save": "Salvar",
+      "saving": "Salvando…"
+    },
+    "delete": {
+      "title": "Excluir lista?",
+      "body": "Excluir permanentemente \"{{name}}\" e seus {{count}} item(ns)? Não pode ser desfeito.",
+      "cancel": "Cancelar",
+      "confirm": "Excluir lista",
+      "pending": "Excluindo…"
+    },
+    "errors": {
+      "update": "Não foi possível salvar as alterações."
+    },
+    "add": {
+      "placeholder": "Adicionar item — pressione Enter",
+      "qty": "Qtd",
+      "unit": "Unid.",
+      "submit": "Adicionar",
+      "showOptional": "+ qtd / unid.",
+      "hideOptional": "Ocultar qtd / unid."
+    },
+    "item": {
+      "checkbox": "Alternar concluído para {{label}}",
+      "editLabel": "Editar rótulo do item",
+      "dragHandle": "Arrastar para reordenar",
+      "unnamed": "(sem nome)",
+      "ref": {
+        "ingredient": "Ingrediente",
+        "variant": "Variante",
+        "recipe": "Receita",
+        "custom": "Personalizado",
+        "free": "Livre"
+      },
+      "menu": {
+        "label": "Ações do item",
+        "edit": "Editar",
+        "moveUp": "Mover para cima",
+        "moveDown": "Mover para baixo",
+        "delete": "Excluir"
+      }
+    }
+  }
 }

--- a/docs/themes/07-food/prds/140-lists-crud-ui/README.md
+++ b/docs/themes/07-food/prds/140-lists-crud-ui/README.md
@@ -244,9 +244,9 @@ Inline per theme protocol.
 
 ### Routes
 
-- [ ] All routes from the table mounted in `packages/app-lists/src/routes.tsx`.
-- [ ] Modals overlay the parent route; URL params `?new=1` and `?edit=1` work; closing returns to the parent.
-- [ ] Direct nav to a modal URL (e.g. `/lists/5?edit=1`) renders parent + modal.
+- [~] All routes from the table mounted in `packages/app-lists/src/routes.tsx`. — `/lists/:id` landed in 140-C; `/lists` is still PRD-139's placeholder until 140-B replaces it with the real index.
+- [ ] Modals overlay the parent route; URL params `?new=1` and `?edit=1` work; closing returns to the parent. — **Deferred to 140-B.** 140-C uses local component state for the edit + delete dialogs since the parent route (`/lists` index) is the modal host per the react-router-v6 nested-route plan; wiring `?edit=1` before 140-B exists would couple the detail page to a non-existent parent route. 140-B will introduce the parent layout + URL-param state and 140-C's modals will be re-wired then.
+- [ ] Direct nav to a modal URL (e.g. `/lists/5?edit=1`) renders parent + modal. — **Deferred to 140-B** (same reason).
 
 ### Index page
 
@@ -257,20 +257,20 @@ Inline per theme protocol.
 
 ### Detail page
 
-- [ ] Header shows name, kind chip, three-dot menu.
-- [ ] Item list renders ordered by `position ASC, id ASC`.
-- [ ] Inline add form: Enter submits + clears; mobile add button works.
-- [ ] Per-item: checkbox, label, optional sub-line, three-dot menu.
-- [ ] Drag-to-reorder works on desktop and mobile.
-- [ ] Inline label edit works (click → input → Enter saves; Esc cancels).
-- [ ] Polling refetches `list.get` every 60s while page is visible.
+- [x] Header shows name, kind chip, three-dot menu. (140-C)
+- [x] Item list renders ordered by `position ASC, id ASC`. (140-C — backed by `lists.list.get` which sorts via `listItemsForList`)
+- [x] Inline add form: Enter submits + clears; mobile add button works. (140-C)
+- [x] Per-item: checkbox, label, optional sub-line, three-dot menu. (140-C)
+- [x] Drag-to-reorder works on desktop and mobile. (140-C — `@dnd-kit/sortable` with PointerSensor + 200ms TouchSensor delay)
+- [x] Inline label edit works (click → input → Enter saves; Esc cancels). (140-C)
+- [x] Polling refetches `list.get` every 60s while page is visible. (140-C — `refetchInterval: 60_000, refetchIntervalInBackground: false`)
 
 ### Modals
 
-- [ ] Create modal validates non-empty name; defaults kind to `shopping`; calls `lists.list.create`.
-- [ ] Edit modal pre-fills; rename works; kind change works with warning.
-- [ ] Edit modal has Archive / Restore button.
-- [ ] Delete confirm dialog requires explicit confirm; cancels safely.
+- [ ] Create modal validates non-empty name; defaults kind to `shopping`; calls `lists.list.create`. — Lives on the index page; ships with 140-B.
+- [x] Edit modal pre-fills; rename works; kind change works with warning. (140-C — local-state modal; URL-param wiring deferred to 140-B per the Routes section above)
+- [x] Edit modal has Archive / Restore button. (140-C)
+- [x] Delete confirm dialog requires explicit confirm; cancels safely. (140-C)
 
 ### tRPC procedures
 
@@ -292,9 +292,9 @@ Inline per theme protocol.
 
 ### Tests
 
-- [ ] Vitest + RTL at `packages/app-lists/src/pages/__tests__/*.test.tsx` covers each page.
+- [~] Vitest + RTL at `packages/app-lists/src/pages/__tests__/*.test.tsx` covers each page. — Detail page covered by `ListDetailPage.test.tsx` (140-C); index page coverage lands with 140-B.
 - [x] Vitest integration at `apps/pops-api/src/modules/lists/__tests__/lists-router.test.ts` covers each procedure.
-- [ ] E2E: create list → add 3 items → check one → reorder → archive → restore.
+- [ ] E2E: create list → add 3 items → check one → reorder → archive → restore. — Spans index + detail; lands with 140-B once the index page exists.
 
 ## Out of Scope
 

--- a/packages/app-lists/package.json
+++ b/packages/app-lists/package.json
@@ -15,6 +15,10 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
+    "@pops/api-client": "workspace:*",
     "@pops/app-lists-db": "workspace:*",
     "@pops/db-types": "workspace:*",
     "@pops/types": "workspace:*",
@@ -23,6 +27,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/better-sqlite3": "^7.6.12",
     "@types/react": "^19.2.16",
     "@types/react-dom": "^19.0.0",

--- a/packages/app-lists/src/__tests__/manifest.test.ts
+++ b/packages/app-lists/src/__tests__/manifest.test.ts
@@ -30,6 +30,11 @@ describe('PRD-139 — app-lists module manifest', () => {
     expect(routes[0]).toMatchObject({ index: true });
   });
 
+  it('exposes a /:id route for the detail page (PRD-140-C)', () => {
+    const detail = routes.find((r) => 'path' in r && r.path === ':id');
+    expect(detail).toBeDefined();
+  });
+
   it('does NOT yet declare a backend slot (PRD-140 fills it)', () => {
     expect(manifest.backend).toBeUndefined();
   });

--- a/packages/app-lists/src/pages/ListDetailPage.tsx
+++ b/packages/app-lists/src/pages/ListDetailPage.tsx
@@ -1,0 +1,212 @@
+import { useEffect, useState, type ReactElement } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useParams } from 'react-router';
+
+import { trpc } from '@pops/api-client';
+
+import { ListDeleteDialog } from './detail/ListDeleteDialog.js';
+import { ListDetailHeader } from './detail/ListDetailHeader.js';
+import { ListEditModal } from './detail/ListEditModal.js';
+import { ListItemAddForm } from './detail/ListItemAddForm.js';
+import { ListItemsSection } from './detail/ListItemsSection.js';
+import { useDetailMutations, type DetailMutations } from './detail/useDetailMutations.js';
+import { useItemMutations, type ItemMutations } from './detail/useItemMutations.js';
+
+import type { ListItemRow, ListRow } from './detail/types.js';
+
+/**
+ * `/lists/:id` — generic list detail page (PRD-140-C).
+ *
+ * Renders any list kind via the kind-agnostic row component. Shopping-only
+ * affordances (uncheck-all, clear-checked, sort) land in PRD-141 by
+ * swapping the items section when `kind === 'shopping'`. The 60-second
+ * background poll picks up concurrent edits from other tabs and from
+ * food's "Send to shopping list" action (PRD-142).
+ */
+export function ListDetailPage(): ReactElement {
+  const { id } = useParams<{ id: string }>();
+  const parsed = id !== undefined ? Number(id) : NaN;
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    return <NotFoundShell />;
+  }
+  return <ListDetailBody listId={parsed} />;
+}
+
+interface DialogState {
+  editOpen: boolean;
+  deleteOpen: boolean;
+  openEdit: () => void;
+  closeEdit: () => void;
+  openDelete: () => void;
+  closeDelete: () => void;
+}
+
+function useDialogs(): DialogState {
+  const [editOpen, setEditOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  return {
+    editOpen,
+    deleteOpen,
+    openEdit: () => setEditOpen(true),
+    closeEdit: () => setEditOpen(false),
+    openDelete: () => setDeleteOpen(true),
+    closeDelete: () => setDeleteOpen(false),
+  };
+}
+
+function ListDetailBody({ listId }: { listId: number }): ReactElement {
+  const { t } = useTranslation('lists');
+  const query = trpc.lists.list.get.useQuery(
+    { id: listId },
+    { refetchInterval: 60_000, refetchIntervalInBackground: false }
+  );
+  const detailMx = useDetailMutations();
+  const itemMx = useItemMutations(listId);
+  const dialogs = useDialogs();
+
+  useEffect(() => {
+    if (query.error) detailMx.clearError();
+  }, [detailMx, query.error]);
+
+  if (query.isLoading) return <Status text={t('detail.loading')} />;
+  if (query.data === null) return <NotFoundShell />;
+  if (query.error !== null || query.data === undefined) {
+    return <Status text={t('detail.error')} variant="error" />;
+  }
+
+  return (
+    <DetailContent
+      list={query.data.list}
+      items={query.data.items}
+      detailMx={detailMx}
+      itemMx={itemMx}
+      dialogs={dialogs}
+    />
+  );
+}
+
+interface DetailContentProps {
+  list: ListRow;
+  items: readonly ListItemRow[];
+  detailMx: DetailMutations;
+  itemMx: ItemMutations;
+  dialogs: DialogState;
+}
+
+function useDetailHandlers({ list, detailMx, itemMx, dialogs }: DetailContentProps) {
+  return {
+    toggleChecked: (id: number, currentlyChecked: boolean) => {
+      if (currentlyChecked) itemMx.uncheck(id);
+      else itemMx.check(id);
+    },
+    archiveToggle: async () => {
+      if (list.archivedAt === null) await detailMx.archive(list.id);
+      else await detailMx.unarchive(list.id);
+    },
+    saveEdit: async (patch: { name: string; kind: typeof list.kind }) => {
+      const result = await detailMx.update(list.id, patch);
+      if (result.ok) dialogs.closeEdit();
+    },
+    confirmDelete: async () => {
+      await detailMx.remove(list.id);
+      dialogs.closeDelete();
+    },
+  };
+}
+
+function DetailContent(props: DetailContentProps): ReactElement {
+  const { list, items, detailMx, itemMx, dialogs } = props;
+  const h = useDetailHandlers(props);
+
+  return (
+    <div className="space-y-4 p-4 sm:p-6">
+      <ListDetailHeader
+        list={list}
+        onRename={dialogs.openEdit}
+        onChangeKind={dialogs.openEdit}
+        onArchiveToggle={() => void h.archiveToggle()}
+        onDelete={dialogs.openDelete}
+      />
+      <ErrorBanners detail={detailMx.errorMessage} item={itemMx.errorMessage} />
+      <ListItemsSection
+        items={items}
+        onToggleChecked={h.toggleChecked}
+        onSaveLabel={(id, label) => itemMx.update(id, { label })}
+        onReorder={itemMx.reorder}
+        onDelete={itemMx.remove}
+      />
+      <ListItemAddForm
+        isPending={false}
+        onAdd={async (input) => (await itemMx.add(input)) !== null}
+      />
+      {dialogs.editOpen ? (
+        <ListEditModal
+          list={list}
+          isSaving={detailMx.isUpdating}
+          onCancel={dialogs.closeEdit}
+          onSave={(patch) => void h.saveEdit(patch)}
+          onArchiveToggle={() => {
+            void h.archiveToggle();
+            dialogs.closeEdit();
+          }}
+        />
+      ) : null}
+      {dialogs.deleteOpen ? (
+        <ListDeleteDialog
+          name={list.name}
+          itemCount={items.length}
+          isPending={detailMx.isRemoving}
+          onCancel={dialogs.closeDelete}
+          onConfirm={() => void h.confirmDelete()}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function ErrorBanners({
+  detail,
+  item,
+}: {
+  detail: string | null;
+  item: string | null;
+}): ReactElement {
+  return (
+    <>
+      {detail !== null ? (
+        <p role="alert" className="text-sm text-destructive">
+          {detail}
+        </p>
+      ) : null}
+      {item !== null ? (
+        <p role="alert" className="text-sm text-destructive">
+          {item}
+        </p>
+      ) : null}
+    </>
+  );
+}
+
+function Status({
+  text,
+  variant = 'info',
+}: {
+  text: string;
+  variant?: 'info' | 'error';
+}): ReactElement {
+  return (
+    <p
+      className={
+        variant === 'error' ? 'p-6 text-sm text-destructive' : 'p-6 text-sm text-muted-foreground'
+      }
+      role={variant === 'error' ? 'alert' : 'status'}
+    >
+      {text}
+    </p>
+  );
+}
+
+function NotFoundShell(): ReactElement {
+  const { t } = useTranslation('lists');
+  return <Status text={t('detail.notFound')} variant="error" />;
+}

--- a/packages/app-lists/src/pages/ListDetailPage.tsx
+++ b/packages/app-lists/src/pages/ListDetailPage.tsx
@@ -94,21 +94,36 @@ interface DetailContentProps {
 }
 
 function useDetailHandlers({ list, detailMx, itemMx, dialogs }: DetailContentProps) {
+  // Each async handler swallows its rejection — failures already surface via
+  // the `detailMx.errorMessage` banner, so re-throwing here would only land
+  // in an unhandled promise rejection (Copilot R1).
   return {
     toggleChecked: (id: number, currentlyChecked: boolean) => {
       if (currentlyChecked) itemMx.uncheck(id);
       else itemMx.check(id);
     },
     archiveToggle: async () => {
-      if (list.archivedAt === null) await detailMx.archive(list.id);
-      else await detailMx.unarchive(list.id);
+      try {
+        if (list.archivedAt === null) await detailMx.archive(list.id);
+        else await detailMx.unarchive(list.id);
+      } catch {
+        /* surfaced via errorMessage */
+      }
     },
     saveEdit: async (patch: { name: string; kind: typeof list.kind }) => {
-      const result = await detailMx.update(list.id, patch);
-      if (result.ok) dialogs.closeEdit();
+      try {
+        const result = await detailMx.update(list.id, patch);
+        if (result.ok) dialogs.closeEdit();
+      } catch {
+        /* surfaced via errorMessage */
+      }
     },
     confirmDelete: async () => {
-      await detailMx.remove(list.id);
+      try {
+        await detailMx.remove(list.id);
+      } catch {
+        /* surfaced via errorMessage */
+      }
       dialogs.closeDelete();
     },
   };
@@ -136,7 +151,7 @@ function DetailContent(props: DetailContentProps): ReactElement {
         onDelete={itemMx.remove}
       />
       <ListItemAddForm
-        isPending={false}
+        isPending={itemMx.isAdding}
         onAdd={async (input) => (await itemMx.add(input)) !== null}
       />
       {dialogs.editOpen ? (

--- a/packages/app-lists/src/pages/__tests__/ListDetailPage.test.tsx
+++ b/packages/app-lists/src/pages/__tests__/ListDetailPage.test.tsx
@@ -1,0 +1,403 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createInstance } from 'i18next';
+import { useMemo, type ReactElement } from 'react';
+import { I18nextProvider, initReactI18next } from 'react-i18next';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import enAULists from '../../../../../apps/pops-shell/src/i18n/locales/en-AU/lists.json';
+
+import type { ListItemRow, ListRow } from '../detail/types.js';
+
+interface MutationCalls {
+  update: ReturnType<typeof vi.fn>;
+  archive: ReturnType<typeof vi.fn>;
+  unarchive: ReturnType<typeof vi.fn>;
+  del: ReturnType<typeof vi.fn>;
+  add: ReturnType<typeof vi.fn>;
+  check: ReturnType<typeof vi.fn>;
+  uncheck: ReturnType<typeof vi.fn>;
+  itemUpdate: ReturnType<typeof vi.fn>;
+  remove: ReturnType<typeof vi.fn>;
+  reorder: ReturnType<typeof vi.fn>;
+}
+
+const calls: MutationCalls = {
+  update: vi.fn(),
+  archive: vi.fn(),
+  unarchive: vi.fn(),
+  del: vi.fn(),
+  add: vi.fn(),
+  check: vi.fn(),
+  uncheck: vi.fn(),
+  itemUpdate: vi.fn(),
+  remove: vi.fn(),
+  reorder: vi.fn(),
+};
+
+const mockGet = vi.fn();
+
+vi.mock('@pops/api-client', () => {
+  const mkMutation = (impl: (args: unknown) => unknown) => ({
+    useMutation: () => ({
+      mutate: (args: unknown, opts?: { onSuccess?: () => void }) => {
+        impl(args);
+        opts?.onSuccess?.();
+      },
+      mutateAsync: async (args: unknown) => impl(args),
+      isPending: false,
+      error: null,
+    }),
+  });
+  return {
+    trpc: {
+      useUtils: () => ({
+        lists: { list: { get: { invalidate: vi.fn() } } },
+      }),
+      lists: {
+        list: {
+          get: { useQuery: (input: unknown) => mockGet(input) },
+          update: mkMutation((args) => {
+            calls.update(args);
+            return { ok: true };
+          }),
+          archive: mkMutation((args) => {
+            calls.archive(args);
+            return { ok: true };
+          }),
+          unarchive: mkMutation((args) => {
+            calls.unarchive(args);
+            return { ok: true };
+          }),
+          delete: mkMutation((args) => {
+            calls.del(args);
+            return { ok: true };
+          }),
+        },
+        items: {
+          add: mkMutation((args) => {
+            calls.add(args);
+            return { id: 99, position: 5 };
+          }),
+          check: mkMutation((args) => {
+            calls.check(args);
+            return { ok: true, checkedAt: '2026-06-10T00:00:00Z' };
+          }),
+          uncheck: mkMutation((args) => {
+            calls.uncheck(args);
+            return { ok: true };
+          }),
+          update: mkMutation((args) => {
+            calls.itemUpdate(args);
+            return { ok: true };
+          }),
+          remove: mkMutation((args) => {
+            calls.remove(args);
+            return { ok: true };
+          }),
+          reorder: mkMutation((args) => {
+            calls.reorder(args);
+            return { ok: true };
+          }),
+        },
+      },
+    },
+  };
+});
+
+const navigateMock = vi.fn();
+vi.mock('react-router', async (orig) => {
+  const actual = await orig<typeof import('react-router')>();
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  };
+});
+
+import { ListDetailPage } from '../ListDetailPage.js';
+
+function makeList(overrides: Partial<ListRow> = {}): ListRow {
+  return {
+    id: 7,
+    name: 'Weekend shop',
+    kind: 'shopping',
+    ownerApp: 'user',
+    archivedAt: null,
+    createdAt: '2026-06-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function makeItem(overrides: Partial<ListItemRow> = {}): ListItemRow {
+  return {
+    id: 1,
+    listId: 7,
+    position: 0,
+    label: 'Apples',
+    qty: 2,
+    unit: 'kg',
+    refKind: 'free',
+    refId: null,
+    checked: 0,
+    checkedAt: null,
+    dueAt: null,
+    notes: null,
+    createdAt: '2026-06-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function mountAt(listId: number, children: ReactElement) {
+  return (
+    <MemoryRouter initialEntries={[`/lists/${listId}`]}>
+      <Routes>
+        <Route path="/lists/:id" element={children} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+function Wrapper({ children }: { children: ReactElement }): ReactElement {
+  const i18n = useMemo(() => {
+    const instance = createInstance();
+    void instance.use(initReactI18next).init({
+      lng: 'en-AU',
+      fallbackLng: 'en-AU',
+      ns: ['lists'],
+      defaultNS: 'lists',
+      interpolation: { escapeValue: false },
+      resources: { 'en-AU': { lists: enAULists } },
+    });
+    return instance;
+  }, []);
+  return <I18nextProvider i18n={i18n}>{children}</I18nextProvider>;
+}
+
+beforeEach(() => {
+  Object.values(calls).forEach((fn) => fn.mockReset());
+  mockGet.mockReset();
+  navigateMock.mockReset();
+});
+
+describe('PRD-140-C — ListDetailPage', () => {
+  it('shows loading state then renders header + items', () => {
+    mockGet.mockReturnValue({
+      isLoading: false,
+      data: {
+        list: makeList(),
+        items: [makeItem(), makeItem({ id: 2, label: 'Bread', qty: null, unit: null })],
+      },
+      error: null,
+    });
+    render(<Wrapper>{mountAt(7, <ListDetailPage />)}</Wrapper>);
+    expect(screen.getByRole('heading', { name: 'Weekend shop' })).toBeInTheDocument();
+    expect(screen.getByTestId('list-kind-chip')).toHaveTextContent('Shopping');
+    expect(screen.getByTestId('list-item-1')).toBeInTheDocument();
+    expect(screen.getByTestId('list-item-2')).toBeInTheDocument();
+  });
+
+  it('renders the not-found shell when the query resolves to null', () => {
+    mockGet.mockReturnValue({ isLoading: false, data: null, error: null });
+    render(<Wrapper>{mountAt(7, <ListDetailPage />)}</Wrapper>);
+    expect(screen.getByRole('alert')).toHaveTextContent(/list not found/i);
+  });
+
+  it('renders the not-found shell for non-numeric route params', () => {
+    mockGet.mockReturnValue({ isLoading: false, data: null, error: null });
+    render(
+      <Wrapper>
+        <MemoryRouter initialEntries={['/lists/banana']}>
+          <Routes>
+            <Route path="/lists/:id" element={<ListDetailPage />} />
+          </Routes>
+        </MemoryRouter>
+      </Wrapper>
+    );
+    expect(screen.getByRole('alert')).toHaveTextContent(/list not found/i);
+  });
+
+  it('renders an empty state when there are no items', () => {
+    mockGet.mockReturnValue({
+      isLoading: false,
+      data: { list: makeList(), items: [] },
+      error: null,
+    });
+    render(<Wrapper>{mountAt(7, <ListDetailPage />)}</Wrapper>);
+    expect(screen.getByText(/no items yet/i)).toBeInTheDocument();
+  });
+
+  it('toggles checked state via the item checkbox', async () => {
+    mockGet.mockReturnValue({
+      isLoading: false,
+      data: { list: makeList(), items: [makeItem()] },
+      error: null,
+    });
+    render(<Wrapper>{mountAt(7, <ListDetailPage />)}</Wrapper>);
+    await userEvent.click(screen.getByLabelText(/toggle done for apples/i));
+    expect(calls.check).toHaveBeenCalledWith({ id: 1 });
+  });
+
+  it('unchecks an already-checked item', async () => {
+    mockGet.mockReturnValue({
+      isLoading: false,
+      data: {
+        list: makeList(),
+        items: [makeItem({ checked: 1, checkedAt: '2026-06-10T00:00:00Z' })],
+      },
+      error: null,
+    });
+    render(<Wrapper>{mountAt(7, <ListDetailPage />)}</Wrapper>);
+    await userEvent.click(screen.getByLabelText(/toggle done for apples/i));
+    expect(calls.uncheck).toHaveBeenCalledWith({ id: 1 });
+  });
+
+  it('submits the add-item form on Enter and clears the input', async () => {
+    mockGet.mockReturnValue({
+      isLoading: false,
+      data: { list: makeList(), items: [] },
+      error: null,
+    });
+    render(<Wrapper>{mountAt(7, <ListDetailPage />)}</Wrapper>);
+    const input = screen.getByPlaceholderText(/add item/i);
+    await userEvent.type(input, 'Onions{Enter}');
+    expect(calls.add).toHaveBeenCalledWith(
+      expect.objectContaining({ listId: 7, label: 'Onions', qty: null, unit: null })
+    );
+    expect(input).toHaveValue('');
+  });
+
+  it('opens edit modal from the action menu and saves a rename', async () => {
+    mockGet.mockReturnValue({
+      isLoading: false,
+      data: { list: makeList(), items: [] },
+      error: null,
+    });
+    render(<Wrapper>{mountAt(7, <ListDetailPage />)}</Wrapper>);
+    await userEvent.click(screen.getByRole('button', { name: /list actions/i }));
+    await userEvent.click(screen.getByRole('menuitem', { name: 'Rename' }));
+    const dialog = screen.getByRole('dialog');
+    const nameInput = screen.getByLabelText(/name/i);
+    await userEvent.clear(nameInput);
+    await userEvent.type(nameInput, 'Sunday shop');
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+    expect(calls.update).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 7, name: 'Sunday shop', kind: 'shopping' })
+    );
+    expect(dialog).not.toBeInTheDocument();
+  });
+
+  it('rejects whitespace-only rename without firing the mutation', async () => {
+    mockGet.mockReturnValue({
+      isLoading: false,
+      data: { list: makeList(), items: [] },
+      error: null,
+    });
+    render(<Wrapper>{mountAt(7, <ListDetailPage />)}</Wrapper>);
+    await userEvent.click(screen.getByRole('button', { name: /list actions/i }));
+    await userEvent.click(screen.getByRole('menuitem', { name: 'Rename' }));
+    const nameInput = screen.getByLabelText(/name/i);
+    await userEvent.clear(nameInput);
+    await userEvent.type(nameInput, '   ');
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+    expect(calls.update).not.toHaveBeenCalled();
+    expect(screen.getByText(/name is required/i)).toBeInTheDocument();
+  });
+
+  it('archives via the action menu', async () => {
+    mockGet.mockReturnValue({
+      isLoading: false,
+      data: { list: makeList(), items: [] },
+      error: null,
+    });
+    render(<Wrapper>{mountAt(7, <ListDetailPage />)}</Wrapper>);
+    await userEvent.click(screen.getByRole('button', { name: /list actions/i }));
+    await userEvent.click(screen.getByRole('menuitem', { name: 'Archive' }));
+    expect(calls.archive).toHaveBeenCalledWith({ id: 7 });
+  });
+
+  it('shows Restore + archived badge when the list is archived', async () => {
+    mockGet.mockReturnValue({
+      isLoading: false,
+      data: { list: makeList({ archivedAt: '2026-06-08T00:00:00Z' }), items: [] },
+      error: null,
+    });
+    render(<Wrapper>{mountAt(7, <ListDetailPage />)}</Wrapper>);
+    expect(screen.getByTestId('archived-badge')).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: /list actions/i }));
+    await userEvent.click(screen.getByRole('menuitem', { name: 'Restore' }));
+    expect(calls.unarchive).toHaveBeenCalledWith({ id: 7 });
+  });
+
+  it('confirms delete then fires the mutation and navigates', async () => {
+    mockGet.mockReturnValue({
+      isLoading: false,
+      data: { list: makeList(), items: [makeItem()] },
+      error: null,
+    });
+    render(<Wrapper>{mountAt(7, <ListDetailPage />)}</Wrapper>);
+    await userEvent.click(screen.getByRole('button', { name: /list actions/i }));
+    await userEvent.click(screen.getByRole('menuitem', { name: /delete/i }));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: 'Delete list' }));
+    expect(calls.del).toHaveBeenCalledWith({ id: 7 });
+    expect(navigateMock).toHaveBeenCalledWith('/lists');
+  });
+
+  it('saves an inline label edit on Enter', async () => {
+    mockGet.mockReturnValue({
+      isLoading: false,
+      data: { list: makeList(), items: [makeItem()] },
+      error: null,
+    });
+    render(<Wrapper>{mountAt(7, <ListDetailPage />)}</Wrapper>);
+    await userEvent.click(screen.getByRole('button', { name: /2kg apples/i }));
+    const input = screen.getByLabelText(/edit item label/i);
+    await userEvent.clear(input);
+    await userEvent.type(input, 'Green apples{Enter}');
+    expect(calls.itemUpdate).toHaveBeenCalledWith({ id: 1, label: 'Green apples' });
+  });
+
+  it('reorders via the Move down menu item', async () => {
+    mockGet.mockReturnValue({
+      isLoading: false,
+      data: {
+        list: makeList(),
+        items: [
+          makeItem({ id: 1, label: 'Apples', position: 0 }),
+          makeItem({ id: 2, label: 'Bread', position: 1, qty: null, unit: null }),
+        ],
+      },
+      error: null,
+    });
+    render(<Wrapper>{mountAt(7, <ListDetailPage />)}</Wrapper>);
+    const itemMenus = screen.getAllByRole('button', { name: /item actions/i });
+    await userEvent.click(itemMenus[0]!);
+    await userEvent.click(screen.getByRole('menuitem', { name: 'Move down' }));
+    expect(calls.reorder).toHaveBeenCalledWith({ listId: 7, orderedIds: [2, 1] });
+  });
+
+  it('removes an item via the item action menu', async () => {
+    mockGet.mockReturnValue({
+      isLoading: false,
+      data: { list: makeList(), items: [makeItem()] },
+      error: null,
+    });
+    render(<Wrapper>{mountAt(7, <ListDetailPage />)}</Wrapper>);
+    await userEvent.click(screen.getByRole('button', { name: /item actions/i }));
+    await userEvent.click(screen.getByRole('menuitem', { name: 'Delete' }));
+    expect(calls.remove).toHaveBeenCalledWith({ id: 1 });
+  });
+
+  it('polls every 60s via refetchInterval on the get query', () => {
+    mockGet.mockReturnValue({
+      isLoading: false,
+      data: { list: makeList(), items: [] },
+      error: null,
+    });
+    render(<Wrapper>{mountAt(7, <ListDetailPage />)}</Wrapper>);
+    expect(mockGet).toHaveBeenCalledWith({ id: 7 });
+    // The query options live alongside the input in the page; this test asserts
+    // the page reaches the body branch (proxy for the useQuery call landing).
+  });
+});

--- a/packages/app-lists/src/pages/detail/ListDeleteDialog.tsx
+++ b/packages/app-lists/src/pages/detail/ListDeleteDialog.tsx
@@ -1,0 +1,64 @@
+import { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+
+/**
+ * Hard-delete confirm dialog. The prompt mirrors PRD-140's wording so users
+ * understand the cascade ("permanently delete <name> and its N items").
+ */
+export interface ListDeleteDialogProps {
+  name: string;
+  itemCount: number;
+  isPending: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+export function ListDeleteDialog(props: ListDeleteDialogProps) {
+  const { t } = useTranslation('lists');
+
+  useEffect(() => {
+    const handle = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') props.onCancel();
+    };
+    document.addEventListener('keydown', handle);
+    return () => document.removeEventListener('keydown', handle);
+  }, [props]);
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="list-delete-title"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) props.onCancel();
+      }}
+    >
+      <div className="w-full max-w-md space-y-4 rounded-lg border bg-background p-6 shadow-lg">
+        <h2 id="list-delete-title" className="text-lg font-semibold">
+          {t('detail.delete.title')}
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          {t('detail.delete.body', { name: props.name, count: props.itemCount })}
+        </p>
+        <div className="flex justify-end gap-2 pt-2">
+          <button
+            type="button"
+            onClick={props.onCancel}
+            className="rounded-md border px-3 py-1.5 text-sm hover:bg-muted"
+          >
+            {t('detail.delete.cancel')}
+          </button>
+          <button
+            type="button"
+            onClick={props.onConfirm}
+            disabled={props.isPending}
+            className="rounded-md bg-destructive px-3 py-1.5 text-sm font-medium text-destructive-foreground hover:bg-destructive/90 disabled:opacity-50"
+          >
+            {props.isPending ? t('detail.delete.pending') : t('detail.delete.confirm')}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/app-lists/src/pages/detail/ListDeleteDialog.tsx
+++ b/packages/app-lists/src/pages/detail/ListDeleteDialog.tsx
@@ -15,14 +15,15 @@ export interface ListDeleteDialogProps {
 
 export function ListDeleteDialog(props: ListDeleteDialogProps) {
   const { t } = useTranslation('lists');
+  const { onCancel } = props;
 
   useEffect(() => {
     const handle = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') props.onCancel();
+      if (e.key === 'Escape') onCancel();
     };
     document.addEventListener('keydown', handle);
     return () => document.removeEventListener('keydown', handle);
-  }, [props]);
+  }, [onCancel]);
 
   return (
     <div

--- a/packages/app-lists/src/pages/detail/ListDetailHeader.tsx
+++ b/packages/app-lists/src/pages/detail/ListDetailHeader.tsx
@@ -1,0 +1,47 @@
+import { useTranslation } from 'react-i18next';
+
+import { ListDetailMenu } from './ListDetailMenu.js';
+import { ListKindChip } from './ListKindChip.js';
+
+import type { ListRow } from './types.js';
+
+/**
+ * Header row for the detail page. Surfaces the list name, kind chip,
+ * archived badge (when applicable), and the three-dot action menu.
+ */
+export interface ListDetailHeaderProps {
+  list: ListRow;
+  onRename: () => void;
+  onChangeKind: () => void;
+  onArchiveToggle: () => void;
+  onDelete: () => void;
+}
+
+export function ListDetailHeader(props: ListDetailHeaderProps) {
+  const { t } = useTranslation('lists');
+  const isArchived = props.list.archivedAt !== null;
+
+  return (
+    <header className="flex flex-wrap items-start justify-between gap-3 border-b pb-4">
+      <div className="flex flex-wrap items-center gap-3">
+        <h1 className="text-2xl font-bold tracking-tight">{props.list.name}</h1>
+        <ListKindChip kind={props.list.kind} />
+        {isArchived ? (
+          <span
+            className="inline-flex items-center rounded-full bg-muted px-2.5 py-0.5 text-xs font-medium text-muted-foreground"
+            data-testid="archived-badge"
+          >
+            {t('detail.archivedBadge')}
+          </span>
+        ) : null}
+      </div>
+      <ListDetailMenu
+        isArchived={isArchived}
+        onRename={props.onRename}
+        onChangeKind={props.onChangeKind}
+        onArchiveToggle={props.onArchiveToggle}
+        onDelete={props.onDelete}
+      />
+    </header>
+  );
+}

--- a/packages/app-lists/src/pages/detail/ListDetailMenu.tsx
+++ b/packages/app-lists/src/pages/detail/ListDetailMenu.tsx
@@ -1,0 +1,99 @@
+import { useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+/**
+ * Three-dot action menu shown in the detail header. Plain HTML + Tailwind so
+ * the package stays free of `@pops/ui` (same constraint as
+ * ListsLandingPage). Closes on outside click + Escape; menu items expose
+ * keyboard focus order via natural tab order.
+ */
+export interface ListDetailMenuProps {
+  isArchived: boolean;
+  onRename: () => void;
+  onChangeKind: () => void;
+  onArchiveToggle: () => void;
+  onDelete: () => void;
+}
+
+export function ListDetailMenu(props: ListDetailMenuProps) {
+  const { t } = useTranslation('lists');
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('mousedown', handleClick);
+    document.addEventListener('keydown', handleKey);
+    return () => {
+      document.removeEventListener('mousedown', handleClick);
+      document.removeEventListener('keydown', handleKey);
+    };
+  }, [open]);
+
+  const close = () => setOpen(false);
+  const run = (fn: () => void) => () => {
+    close();
+    fn();
+  };
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((prev) => !prev)}
+        className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-transparent text-lg hover:bg-muted focus:outline-none focus:ring-2 focus:ring-ring"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label={t('detail.menu.label')}
+      >
+        ⋮
+      </button>
+      {open ? (
+        <ul
+          role="menu"
+          className="absolute right-0 z-10 mt-1 min-w-44 rounded-md border bg-popover p-1 shadow-md"
+        >
+          <MenuItem onClick={run(props.onRename)}>{t('detail.menu.rename')}</MenuItem>
+          <MenuItem onClick={run(props.onChangeKind)}>{t('detail.menu.changeKind')}</MenuItem>
+          <MenuItem onClick={run(props.onArchiveToggle)}>
+            {props.isArchived ? t('detail.menu.restore') : t('detail.menu.archive')}
+          </MenuItem>
+          <MenuItem onClick={run(props.onDelete)} destructive>
+            {t('detail.menu.delete')}
+          </MenuItem>
+        </ul>
+      ) : null}
+    </div>
+  );
+}
+
+function MenuItem({
+  children,
+  onClick,
+  destructive = false,
+}: {
+  children: string;
+  onClick: () => void;
+  destructive?: boolean;
+}) {
+  return (
+    <li role="none">
+      <button
+        type="button"
+        role="menuitem"
+        onClick={onClick}
+        className={`block w-full rounded px-3 py-1.5 text-left text-sm hover:bg-muted focus:bg-muted focus:outline-none ${
+          destructive ? 'text-destructive' : ''
+        }`}
+      >
+        {children}
+      </button>
+    </li>
+  );
+}

--- a/packages/app-lists/src/pages/detail/ListDetailMenu.tsx
+++ b/packages/app-lists/src/pages/detail/ListDetailMenu.tsx
@@ -1,11 +1,14 @@
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { useMenuKeyboard } from './useMenuKeyboard.js';
+
 /**
  * Three-dot action menu shown in the detail header. Plain HTML + Tailwind so
  * the package stays free of `@pops/ui` (same constraint as
- * ListsLandingPage). Closes on outside click + Escape; menu items expose
- * keyboard focus order via natural tab order.
+ * ListsLandingPage). Closes on outside click + Escape; focus lands on the
+ * first item when the menu opens; ArrowUp/ArrowDown/Home/End cycle through
+ * items per the ARIA menu keyboard model (see `useMenuKeyboard`).
  */
 export interface ListDetailMenuProps {
   isArchived: boolean;
@@ -19,6 +22,7 @@ export function ListDetailMenu(props: ListDetailMenuProps) {
   const { t } = useTranslation('lists');
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
+  const { menuRef, onMenuKeyDown } = useMenuKeyboard(open);
 
   useEffect(() => {
     if (!open) return;
@@ -56,7 +60,9 @@ export function ListDetailMenu(props: ListDetailMenuProps) {
       </button>
       {open ? (
         <ul
+          ref={menuRef}
           role="menu"
+          onKeyDown={onMenuKeyDown}
           className="absolute right-0 z-10 mt-1 min-w-44 rounded-md border bg-popover p-1 shadow-md"
         >
           <MenuItem onClick={run(props.onRename)}>{t('detail.menu.rename')}</MenuItem>

--- a/packages/app-lists/src/pages/detail/ListEditModal.tsx
+++ b/packages/app-lists/src/pages/detail/ListEditModal.tsx
@@ -1,0 +1,215 @@
+import { useEffect, useState, type FormEvent } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { LIST_KINDS, type ListKind, type ListRow } from './types.js';
+
+/**
+ * Edit modal: rename + change kind. Implements the "+ Archive / Restore"
+ * button at the bottom per PRD-140 §Edit modal. The kind-change warning
+ * surfaces when the user picks a kind different from the current one.
+ *
+ * No URL params here — the modal is controlled by the page's local state
+ * (the `?edit=1` route convention from the PRD will land alongside 140-B
+ * when the index page introduces the parent route shape).
+ */
+export interface ListEditModalProps {
+  list: ListRow;
+  isSaving: boolean;
+  onCancel: () => void;
+  onSave: (patch: { name: string; kind: ListKind }) => void;
+  onArchiveToggle: () => void;
+}
+
+function useEditFormState(list: ListRow) {
+  const [name, setName] = useState(list.name);
+  const [kind, setKind] = useState<ListKind>(list.kind);
+  const [nameError, setNameError] = useState<string | null>(null);
+  useEffect(() => {
+    setName(list.name);
+    setKind(list.kind);
+  }, [list]);
+  return { name, setName, kind, setKind, nameError, setNameError };
+}
+
+export function ListEditModal(props: ListEditModalProps): React.ReactElement {
+  const { t } = useTranslation('lists');
+  const state = useEditFormState(props.list);
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    const trimmed = state.name.trim();
+    if (trimmed.length === 0) {
+      state.setNameError(t('detail.edit.nameRequired'));
+      return;
+    }
+    props.onSave({ name: trimmed, kind: state.kind });
+  };
+
+  return (
+    <Dialog labelledBy="list-edit-title" onCancel={props.onCancel}>
+      <h2 id="list-edit-title" className="text-lg font-semibold">
+        {t('detail.edit.title')}
+      </h2>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <NameField
+          value={state.name}
+          error={state.nameError}
+          onChange={(value) => {
+            state.setName(value);
+            if (state.nameError !== null) state.setNameError(null);
+          }}
+        />
+        <KindField current={props.list.kind} value={state.kind} onChange={state.setKind} />
+        <EditActions
+          isArchived={props.list.archivedAt !== null}
+          isSaving={props.isSaving}
+          onCancel={props.onCancel}
+          onArchiveToggle={props.onArchiveToggle}
+        />
+      </form>
+    </Dialog>
+  );
+}
+
+function NameField({
+  value,
+  error,
+  onChange,
+}: {
+  value: string;
+  error: string | null;
+  onChange: (value: string) => void;
+}) {
+  const { t } = useTranslation('lists');
+  return (
+    <div className="space-y-1">
+      <label htmlFor="list-edit-name" className="block text-sm font-medium">
+        {t('detail.edit.name')}
+      </label>
+      <input
+        id="list-edit-name"
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        maxLength={200}
+        className="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+        autoFocus
+      />
+      {error !== null ? <p className="text-xs text-destructive">{error}</p> : null}
+    </div>
+  );
+}
+
+function KindField({
+  current,
+  value,
+  onChange,
+}: {
+  current: ListKind;
+  value: ListKind;
+  onChange: (kind: ListKind) => void;
+}) {
+  const { t } = useTranslation('lists');
+  const kindChanged = value !== current;
+  return (
+    <fieldset className="space-y-2">
+      <legend className="text-sm font-medium">{t('detail.edit.kind')}</legend>
+      <div className="grid grid-cols-2 gap-2">
+        {LIST_KINDS.map((option) => (
+          <label
+            key={option}
+            className="flex items-center gap-2 rounded-md border p-2 text-sm hover:bg-muted"
+          >
+            <input
+              type="radio"
+              name="kind"
+              value={option}
+              checked={value === option}
+              onChange={() => onChange(option)}
+            />
+            {t(`detail.kind.${option}`)}
+          </label>
+        ))}
+      </div>
+      {kindChanged ? (
+        <p className="text-xs text-muted-foreground" role="status">
+          {t('detail.edit.kindWarning')}
+        </p>
+      ) : null}
+    </fieldset>
+  );
+}
+
+function EditActions({
+  isArchived,
+  isSaving,
+  onCancel,
+  onArchiveToggle,
+}: {
+  isArchived: boolean;
+  isSaving: boolean;
+  onCancel: () => void;
+  onArchiveToggle: () => void;
+}) {
+  const { t } = useTranslation('lists');
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-2 pt-2">
+      <button
+        type="button"
+        onClick={onArchiveToggle}
+        className="rounded-md border px-3 py-1.5 text-sm hover:bg-muted"
+      >
+        {isArchived ? t('detail.menu.restore') : t('detail.menu.archive')}
+      </button>
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="rounded-md border px-3 py-1.5 text-sm hover:bg-muted"
+        >
+          {t('detail.edit.cancel')}
+        </button>
+        <button
+          type="submit"
+          disabled={isSaving}
+          className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+        >
+          {isSaving ? t('detail.edit.saving') : t('detail.edit.save')}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function Dialog({
+  children,
+  labelledBy,
+  onCancel,
+}: {
+  children: React.ReactNode;
+  labelledBy: string;
+  onCancel: () => void;
+}) {
+  useEffect(() => {
+    const handle = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onCancel();
+    };
+    document.addEventListener('keydown', handle);
+    return () => document.removeEventListener('keydown', handle);
+  }, [onCancel]);
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={labelledBy}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onCancel();
+      }}
+    >
+      <div className="w-full max-w-md space-y-4 rounded-lg border bg-background p-6 shadow-lg sm:max-w-md">
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/packages/app-lists/src/pages/detail/ListItemAddForm.tsx
+++ b/packages/app-lists/src/pages/detail/ListItemAddForm.tsx
@@ -1,0 +1,153 @@
+import { useState, type FormEvent } from 'react';
+import { useTranslation } from 'react-i18next';
+
+/**
+ * Inline add-item form rendered at the bottom of the list. Pressing Enter in
+ * the label input fires the mutation and clears for the next item. The
+ * optional qty + unit inputs collapse by default (PRD-140 line 53) and
+ * expand on click.
+ */
+export interface ListItemAddFormProps {
+  isPending: boolean;
+  onAdd: (input: { label: string; qty: number | null; unit: string | null }) => Promise<boolean>;
+}
+
+interface FormState {
+  label: string;
+  qty: string;
+  unit: string;
+}
+
+const EMPTY_FORM: FormState = { label: '', qty: '', unit: '' };
+
+function parseForm(
+  state: FormState
+): { label: string; qty: number | null; unit: string | null } | null {
+  const trimmedLabel = state.label.trim();
+  if (trimmedLabel.length === 0) return null;
+  const parsedQty = state.qty.trim().length === 0 ? null : Number(state.qty);
+  if (parsedQty !== null && !Number.isFinite(parsedQty)) return null;
+  const trimmedUnit = state.unit.trim().length === 0 ? null : state.unit.trim();
+  return { label: trimmedLabel, qty: parsedQty, unit: trimmedUnit };
+}
+
+export function ListItemAddForm(props: ListItemAddFormProps): React.ReactElement {
+  const { t } = useTranslation('lists');
+  const [state, setState] = useState<FormState>(EMPTY_FORM);
+  const [expanded, setExpanded] = useState(false);
+
+  const submit = async () => {
+    const parsed = parseForm(state);
+    if (parsed === null) return;
+    const ok = await props.onAdd(parsed);
+    if (ok) setState(EMPTY_FORM);
+  };
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    void submit();
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2 rounded-md border border-dashed p-3">
+      <LabelRow
+        label={state.label}
+        onChange={(label) => setState({ ...state, label })}
+        isPending={props.isPending || state.label.trim().length === 0}
+        placeholder={t('detail.add.placeholder')}
+        submitText={t('detail.add.submit')}
+      />
+      {expanded ? (
+        <ExpandedFields
+          state={state}
+          setState={setState}
+          onCollapse={() => setExpanded(false)}
+          t={t}
+        />
+      ) : (
+        <button
+          type="button"
+          onClick={() => setExpanded(true)}
+          className="text-xs text-muted-foreground hover:underline"
+        >
+          {t('detail.add.showOptional')}
+        </button>
+      )}
+    </form>
+  );
+}
+
+function LabelRow({
+  label,
+  onChange,
+  isPending,
+  placeholder,
+  submitText,
+}: {
+  label: string;
+  onChange: (value: string) => void;
+  isPending: boolean;
+  placeholder: string;
+  submitText: string;
+}) {
+  return (
+    <div className="flex gap-2">
+      <input
+        type="text"
+        value={label}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        aria-label={placeholder}
+        className="flex-1 rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+      />
+      <button
+        type="submit"
+        disabled={isPending}
+        className="rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground disabled:opacity-50"
+      >
+        {submitText}
+      </button>
+    </div>
+  );
+}
+
+function ExpandedFields({
+  state,
+  setState,
+  onCollapse,
+  t,
+}: {
+  state: FormState;
+  setState: (next: FormState) => void;
+  onCollapse: () => void;
+  t: (key: string) => string;
+}) {
+  return (
+    <div className="flex gap-2">
+      <input
+        type="number"
+        inputMode="decimal"
+        step="any"
+        value={state.qty}
+        onChange={(e) => setState({ ...state, qty: e.target.value })}
+        placeholder={t('detail.add.qty')}
+        aria-label={t('detail.add.qty')}
+        className="w-24 rounded-md border bg-background px-2 py-1 text-sm"
+      />
+      <input
+        type="text"
+        value={state.unit}
+        onChange={(e) => setState({ ...state, unit: e.target.value })}
+        placeholder={t('detail.add.unit')}
+        aria-label={t('detail.add.unit')}
+        className="w-28 rounded-md border bg-background px-2 py-1 text-sm"
+      />
+      <button
+        type="button"
+        onClick={onCollapse}
+        className="text-xs text-muted-foreground hover:underline"
+      >
+        {t('detail.add.hideOptional')}
+      </button>
+    </div>
+  );
+}

--- a/packages/app-lists/src/pages/detail/ListItemMenu.tsx
+++ b/packages/app-lists/src/pages/detail/ListItemMenu.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+/**
+ * Three-dot menu surfaced per item row: Edit / Move up / Move down / Delete.
+ * Move up/down are also accessible via drag, but the menu is the keyboard +
+ * mobile-fallback path (PRD-140 line 95).
+ */
+export interface ListItemMenuProps {
+  canMoveUp: boolean;
+  canMoveDown: boolean;
+  onEdit: () => void;
+  onMoveUp: () => void;
+  onMoveDown: () => void;
+  onDelete: () => void;
+}
+
+export function ListItemMenu(props: ListItemMenuProps) {
+  const { t } = useTranslation('lists');
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handle = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('mousedown', handle);
+    document.addEventListener('keydown', handleKey);
+    return () => {
+      document.removeEventListener('mousedown', handle);
+      document.removeEventListener('keydown', handleKey);
+    };
+  }, [open]);
+
+  const close = () => setOpen(false);
+  const run = (fn: () => void) => () => {
+    close();
+    fn();
+  };
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((p) => !p)}
+        className="inline-flex h-8 w-8 items-center justify-center rounded-md hover:bg-muted focus:outline-none focus:ring-2 focus:ring-ring"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label={t('detail.item.menu.label')}
+      >
+        ⋮
+      </button>
+      {open ? (
+        <ul
+          role="menu"
+          className="absolute right-0 z-10 mt-1 min-w-40 rounded-md border bg-popover p-1 shadow-md"
+        >
+          <Item onClick={run(props.onEdit)}>{t('detail.item.menu.edit')}</Item>
+          <Item onClick={run(props.onMoveUp)} disabled={!props.canMoveUp}>
+            {t('detail.item.menu.moveUp')}
+          </Item>
+          <Item onClick={run(props.onMoveDown)} disabled={!props.canMoveDown}>
+            {t('detail.item.menu.moveDown')}
+          </Item>
+          <Item onClick={run(props.onDelete)} destructive>
+            {t('detail.item.menu.delete')}
+          </Item>
+        </ul>
+      ) : null}
+    </div>
+  );
+}
+
+function Item({
+  children,
+  onClick,
+  destructive = false,
+  disabled = false,
+}: {
+  children: string;
+  onClick: () => void;
+  destructive?: boolean;
+  disabled?: boolean;
+}) {
+  return (
+    <li role="none">
+      <button
+        type="button"
+        role="menuitem"
+        onClick={onClick}
+        disabled={disabled}
+        className={`block w-full rounded px-3 py-1.5 text-left text-sm hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50 focus:bg-muted focus:outline-none ${
+          destructive ? 'text-destructive' : ''
+        }`}
+      >
+        {children}
+      </button>
+    </li>
+  );
+}

--- a/packages/app-lists/src/pages/detail/ListItemMenu.tsx
+++ b/packages/app-lists/src/pages/detail/ListItemMenu.tsx
@@ -1,10 +1,14 @@
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { useMenuKeyboard } from './useMenuKeyboard.js';
+
 /**
  * Three-dot menu surfaced per item row: Edit / Move up / Move down / Delete.
  * Move up/down are also accessible via drag, but the menu is the keyboard +
- * mobile-fallback path (PRD-140 line 95).
+ * mobile-fallback path (PRD-140 line 95). Keyboard model matches
+ * `useMenuKeyboard` (arrow/Home/End across enabled items, first-item focus
+ * on open).
  */
 export interface ListItemMenuProps {
   canMoveUp: boolean;
@@ -19,6 +23,7 @@ export function ListItemMenu(props: ListItemMenuProps) {
   const { t } = useTranslation('lists');
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
+  const { menuRef, onMenuKeyDown } = useMenuKeyboard(open);
 
   useEffect(() => {
     if (!open) return;
@@ -56,7 +61,9 @@ export function ListItemMenu(props: ListItemMenuProps) {
       </button>
       {open ? (
         <ul
+          ref={menuRef}
           role="menu"
+          onKeyDown={onMenuKeyDown}
           className="absolute right-0 z-10 mt-1 min-w-40 rounded-md border bg-popover p-1 shadow-md"
         >
           <Item onClick={run(props.onEdit)}>{t('detail.item.menu.edit')}</Item>

--- a/packages/app-lists/src/pages/detail/ListItemRow.tsx
+++ b/packages/app-lists/src/pages/detail/ListItemRow.tsx
@@ -1,0 +1,193 @@
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { useState, type KeyboardEvent } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { ListItemMenu } from './ListItemMenu.js';
+
+import type { ListItemRow as ItemRow } from './types.js';
+
+/**
+ * Single row in the generic item list. Renders the checkbox, label (or
+ * inline editor when clicked), optional qty/unit + sub-line, and the
+ * three-dot menu.
+ *
+ * Drag-to-reorder is wired via `@dnd-kit/sortable` — the row's grip handle
+ * carries the listener attributes so clicking the label / checkbox doesn't
+ * start a drag.
+ */
+export interface ListItemRowProps {
+  row: ItemRow;
+  canMoveUp: boolean;
+  canMoveDown: boolean;
+  onToggleChecked: (id: number, currentlyChecked: boolean) => void;
+  onSaveLabel: (id: number, label: string) => Promise<boolean>;
+  onMoveUp: (id: number) => void;
+  onMoveDown: (id: number) => void;
+  onDelete: (id: number) => void;
+}
+
+interface InlineEditState {
+  editing: boolean;
+  draft: string;
+  begin: () => void;
+  cancel: () => void;
+  commit: () => Promise<void>;
+  setDraft: (value: string) => void;
+}
+
+function useInlineEdit(
+  row: ItemRow,
+  onSaveLabel: (id: number, label: string) => Promise<boolean>
+): InlineEditState {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(row.label);
+
+  const begin = () => {
+    setDraft(row.label);
+    setEditing(true);
+  };
+  const cancel = () => setEditing(false);
+  const commit = async () => {
+    const trimmed = draft.trim();
+    if (trimmed.length === 0 || trimmed === row.label) {
+      setEditing(false);
+      return;
+    }
+    const ok = await onSaveLabel(row.id, trimmed);
+    if (ok) setEditing(false);
+  };
+
+  return { editing, draft, begin, cancel, commit, setDraft };
+}
+
+export function ListItemRow(props: ListItemRowProps): React.ReactElement {
+  const { t } = useTranslation('lists');
+  const sortable = useSortable({ id: props.row.id });
+  const style = {
+    transform: CSS.Transform.toString(sortable.transform),
+    transition: sortable.transition,
+  };
+  const isChecked = props.row.checked === 1;
+  const edit = useInlineEdit(props.row, props.onSaveLabel);
+
+  return (
+    <li
+      ref={sortable.setNodeRef}
+      style={style}
+      data-testid={`list-item-${props.row.id}`}
+      className={`flex items-start gap-2 rounded-md border bg-card p-2 ${
+        sortable.isDragging ? 'opacity-60 shadow-lg' : ''
+      }`}
+    >
+      <button
+        type="button"
+        className="mt-1 cursor-grab text-muted-foreground hover:text-foreground"
+        aria-label={t('detail.item.dragHandle')}
+        {...sortable.attributes}
+        {...sortable.listeners}
+      >
+        ⋮⋮
+      </button>
+      <input
+        type="checkbox"
+        checked={isChecked}
+        onChange={() => props.onToggleChecked(props.row.id, isChecked)}
+        className="mt-1 h-4 w-4 cursor-pointer"
+        aria-label={t('detail.item.checkbox', { label: props.row.label })}
+      />
+      <RowBody row={props.row} isChecked={isChecked} edit={edit} />
+      <ListItemMenu
+        canMoveUp={props.canMoveUp}
+        canMoveDown={props.canMoveDown}
+        onEdit={edit.begin}
+        onMoveUp={() => props.onMoveUp(props.row.id)}
+        onMoveDown={() => props.onMoveDown(props.row.id)}
+        onDelete={() => props.onDelete(props.row.id)}
+      />
+    </li>
+  );
+}
+
+function RowBody({
+  row,
+  isChecked,
+  edit,
+}: {
+  row: ItemRow;
+  isChecked: boolean;
+  edit: InlineEditState;
+}) {
+  const { t } = useTranslation('lists');
+  const onLabelKey = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      void edit.commit();
+    } else if (e.key === 'Escape') {
+      edit.cancel();
+    }
+  };
+  const labelText = formatLabel(row, t);
+  const subline = formatSubline(row, t);
+
+  return (
+    <div className="min-w-0 flex-1">
+      {edit.editing ? (
+        <input
+          type="text"
+          value={edit.draft}
+          onChange={(e) => edit.setDraft(e.target.value)}
+          onBlur={() => void edit.commit()}
+          onKeyDown={onLabelKey}
+          className="w-full rounded border bg-background px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+          aria-label={t('detail.item.editLabel')}
+          autoFocus
+        />
+      ) : (
+        <button
+          type="button"
+          onClick={edit.begin}
+          className={`block w-full text-left text-sm ${
+            isChecked ? 'text-muted-foreground line-through' : ''
+          }`}
+        >
+          {labelText}
+        </button>
+      )}
+      {subline !== null ? (
+        <p className="truncate text-xs text-muted-foreground" title={subline}>
+          {subline}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+function formatLabel(row: ItemRow, t: (key: string, opts?: Record<string, unknown>) => string) {
+  const qtyPart = qtyUnitPrefix(row);
+  return `${qtyPart}${row.label}` || t('detail.item.unnamed');
+}
+
+function qtyUnitPrefix(row: ItemRow): string {
+  if (row.qty === null) return '';
+  const qtyStr = formatQty(row.qty);
+  if (row.unit === null) return `${qtyStr} `;
+  return `${qtyStr}${row.unit} `;
+}
+
+function formatQty(qty: number) {
+  return Number.isInteger(qty) ? String(qty) : qty.toFixed(2).replace(/\.?0+$/, '');
+}
+
+function formatSubline(row: ItemRow, t: (key: string) => string) {
+  const noteSummary = row.notes !== null && row.notes.length > 0 ? truncate(row.notes, 80) : null;
+  if (row.refKind !== 'free') {
+    const refLabel = t(`detail.item.ref.${row.refKind}`);
+    return noteSummary !== null ? `${refLabel} · ${noteSummary}` : refLabel;
+  }
+  return noteSummary;
+}
+
+function truncate(text: string, max: number) {
+  return text.length > max ? `${text.slice(0, max)}…` : text;
+}

--- a/packages/app-lists/src/pages/detail/ListItemsSection.tsx
+++ b/packages/app-lists/src/pages/detail/ListItemsSection.tsx
@@ -1,0 +1,139 @@
+import {
+  closestCenter,
+  DndContext,
+  type DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  TouchSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { ListItemRow } from './ListItemRow.js';
+
+import type { ListItemRow as ItemRow } from './types.js';
+
+/**
+ * DnD wrapper around the item list. Owns the local ordered-id state so the
+ * drag animation lands smoothly before the server confirms; on drag end we
+ * fire the reorder mutation and roll back to the server state on failure.
+ *
+ * The sensor mix matches PRD-140's "desktop HTML5 + mobile long-press"
+ * requirement: PointerSensor with a small activation distance lets clicks
+ * pass through to checkbox / menu, while TouchSensor adds the 200ms delay
+ * the spec calls for so a tap-and-hold beats single-tap interactions.
+ */
+export interface ListItemsSectionProps {
+  items: readonly ItemRow[];
+  onToggleChecked: (id: number, currentlyChecked: boolean) => void;
+  onSaveLabel: (id: number, label: string) => Promise<boolean>;
+  onReorder: (orderedIds: readonly number[]) => Promise<boolean>;
+  onDelete: (id: number) => void;
+}
+
+function useReorderSensors() {
+  return useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 200, tolerance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  );
+}
+
+function useOrderedIds(items: readonly ItemRow[]) {
+  const [orderedIds, setOrderedIds] = useState<number[]>(() => items.map((r) => r.id));
+  useEffect(() => {
+    setOrderedIds(items.map((r) => r.id));
+  }, [items]);
+  return [orderedIds, setOrderedIds] as const;
+}
+
+export function ListItemsSection(props: ListItemsSectionProps): React.ReactElement {
+  const { t } = useTranslation('lists');
+  const [orderedIds, setOrderedIds] = useOrderedIds(props.items);
+  const sensors = useReorderSensors();
+
+  const fireReorder = useCallback(
+    async (next: number[]) => {
+      const previous = orderedIds;
+      setOrderedIds(next);
+      const ok = await props.onReorder(next);
+      if (!ok) setOrderedIds(previous);
+    },
+    [orderedIds, props, setOrderedIds]
+  );
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (!over || active.id === over.id) return;
+      const oldIndex = orderedIds.indexOf(Number(active.id));
+      const newIndex = orderedIds.indexOf(Number(over.id));
+      if (oldIndex !== -1 && newIndex !== -1) {
+        void fireReorder(arrayMove(orderedIds, oldIndex, newIndex));
+      }
+    },
+    [fireReorder, orderedIds]
+  );
+
+  const moveBy = useCallback(
+    (id: number, delta: -1 | 1) => {
+      const index = orderedIds.indexOf(id);
+      if (index === -1) return;
+      const target = index + delta;
+      if (target >= 0 && target < orderedIds.length) {
+        void fireReorder(arrayMove(orderedIds, index, target));
+      }
+    },
+    [fireReorder, orderedIds]
+  );
+
+  if (props.items.length === 0) {
+    return (
+      <p className="rounded-md border border-dashed p-4 text-center text-sm text-muted-foreground">
+        {t('detail.empty')}
+      </p>
+    );
+  }
+  const byId = new Map(props.items.map((r) => [r.id, r] as const));
+  const rows = orderedIds.map((id) => byId.get(id)).filter((row): row is ItemRow => row != null);
+  return (
+    <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+      <SortableContext items={orderedIds} strategy={verticalListSortingStrategy}>
+        <RowList rows={rows} moveBy={moveBy} {...props} />
+      </SortableContext>
+    </DndContext>
+  );
+}
+
+interface RowListProps extends ListItemsSectionProps {
+  rows: ItemRow[];
+  moveBy: (id: number, delta: -1 | 1) => void;
+}
+
+function RowList(props: RowListProps): React.ReactElement {
+  return (
+    <ul className="space-y-2" data-testid="list-items">
+      {props.rows.map((row, index) => (
+        <ListItemRow
+          key={row.id}
+          row={row}
+          canMoveUp={index > 0}
+          canMoveDown={index < props.rows.length - 1}
+          onToggleChecked={props.onToggleChecked}
+          onSaveLabel={props.onSaveLabel}
+          onMoveUp={(id) => props.moveBy(id, -1)}
+          onMoveDown={(id) => props.moveBy(id, 1)}
+          onDelete={props.onDelete}
+        />
+      ))}
+    </ul>
+  );
+}

--- a/packages/app-lists/src/pages/detail/ListKindChip.tsx
+++ b/packages/app-lists/src/pages/detail/ListKindChip.tsx
@@ -1,0 +1,27 @@
+import { useTranslation } from 'react-i18next';
+
+import type { ListKind } from './types.js';
+
+/**
+ * Inline chip used in the detail header (and reused by the index card in
+ * future 140-B). Stays plain HTML on purpose — see ListsLandingPage header
+ * comment for the rationale behind keeping `app-lists` free of `@pops/ui`.
+ */
+const KIND_COLOURS: Record<ListKind, string> = {
+  shopping: 'bg-sky-100 text-sky-900 dark:bg-sky-900/40 dark:text-sky-100',
+  packing: 'bg-amber-100 text-amber-900 dark:bg-amber-900/40 dark:text-amber-100',
+  todo: 'bg-emerald-100 text-emerald-900 dark:bg-emerald-900/40 dark:text-emerald-100',
+  generic: 'bg-slate-200 text-slate-900 dark:bg-slate-700/60 dark:text-slate-100',
+};
+
+export function ListKindChip({ kind }: { kind: ListKind }) {
+  const { t } = useTranslation('lists');
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${KIND_COLOURS[kind]}`}
+      data-testid="list-kind-chip"
+    >
+      {t(`detail.kind.${kind}`)}
+    </span>
+  );
+}

--- a/packages/app-lists/src/pages/detail/types.ts
+++ b/packages/app-lists/src/pages/detail/types.ts
@@ -1,0 +1,17 @@
+/**
+ * Shared types for the `/lists/:id` detail page (PRD-140-C).
+ *
+ * Wire shapes are re-exported from `@pops/app-lists-db` so the page renders
+ * the exact rows the backend services return. The discriminated `ListKind`
+ * union mirrors the SQLite CHECK constraint on `lists.kind`.
+ */
+import type { ListItemRefKind, ListItemRow, ListKind, ListRow } from '@pops/app-lists-db';
+
+export type { ListItemRefKind, ListItemRow, ListKind, ListRow };
+
+export interface ListWithItems {
+  list: ListRow;
+  items: readonly ListItemRow[];
+}
+
+export const LIST_KINDS: readonly ListKind[] = ['shopping', 'packing', 'todo', 'generic'];

--- a/packages/app-lists/src/pages/detail/useDetailMutations.ts
+++ b/packages/app-lists/src/pages/detail/useDetailMutations.ts
@@ -1,0 +1,111 @@
+import { useCallback, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router';
+
+import { trpc } from '@pops/api-client';
+
+import type { ListKind } from './types.js';
+
+/**
+ * List-header mutations consumed by the detail page: update (rename + change
+ * kind), archive/unarchive, hard-delete. Each mutation invalidates the
+ * single-list `lists.list.get` cache so the page reflects the change without
+ * a manual refetch; delete additionally bounces back to `/lists`.
+ */
+export interface DetailMutations {
+  update: (
+    id: number,
+    patch: { name?: string; kind?: ListKind }
+  ) => Promise<{ ok: true } | { ok: false; reason: 'NotFound' | 'NameRequired' }>;
+  isUpdating: boolean;
+  archive: (id: number) => Promise<void>;
+  unarchive: (id: number) => Promise<void>;
+  remove: (id: number) => Promise<void>;
+  isRemoving: boolean;
+  errorMessage: string | null;
+  clearError: () => void;
+}
+
+function useDetailMutationHooks(onError: (message: string) => void) {
+  const handler = { onError: (err: { message: string }) => onError(err.message) };
+  return {
+    update: trpc.lists.list.update.useMutation(handler),
+    archive: trpc.lists.list.archive.useMutation(handler),
+    unarchive: trpc.lists.list.unarchive.useMutation(handler),
+    del: trpc.lists.list.delete.useMutation(handler),
+  };
+}
+
+export function useDetailMutations(): DetailMutations {
+  const { t } = useTranslation('lists');
+  const navigate = useNavigate();
+  const utils = trpc.useUtils();
+  const [errorMessage, setError] = useState<string | null>(null);
+  const clearError = useCallback(() => setError(null), []);
+  const mutations = useDetailMutationHooks(setError);
+
+  const update: DetailMutations['update'] = useCallback(
+    async (id, patch) =>
+      mapUpdate({ mutateAsync: mutations.update.mutateAsync, id, patch, utils, setError }),
+    [mutations.update, utils]
+  );
+  const archive = useCallback(
+    async (id: number) => {
+      await mutations.archive.mutateAsync({ id });
+      await utils.lists.list.get.invalidate({ id });
+    },
+    [mutations.archive, utils]
+  );
+  const unarchive = useCallback(
+    async (id: number) => {
+      await mutations.unarchive.mutateAsync({ id });
+      await utils.lists.list.get.invalidate({ id });
+    },
+    [mutations.unarchive, utils]
+  );
+  const remove = useCallback(
+    async (id: number) => {
+      await mutations.del.mutateAsync({ id });
+      await utils.lists.list.get.invalidate({ id });
+      await navigate('/lists');
+    },
+    [mutations.del, navigate, utils]
+  );
+
+  return {
+    update,
+    isUpdating: mutations.update.isPending,
+    archive,
+    unarchive,
+    remove,
+    isRemoving: mutations.del.isPending,
+    errorMessage: errorMessage ?? (mutations.update.error ? t('detail.errors.update') : null),
+    clearError,
+  };
+}
+
+type UpdateAsync = ReturnType<typeof trpc.lists.list.update.useMutation>['mutateAsync'];
+
+interface MapUpdateArgs {
+  mutateAsync: UpdateAsync;
+  id: number;
+  patch: { name?: string; kind?: ListKind };
+  utils: ReturnType<typeof trpc.useUtils>;
+  setError: (message: string) => void;
+}
+
+async function mapUpdate(
+  args: MapUpdateArgs
+): Promise<{ ok: true } | { ok: false; reason: 'NotFound' | 'NameRequired' }> {
+  const { mutateAsync, id, patch, utils, setError } = args;
+  try {
+    const result = await mutateAsync({ id, ...patch });
+    if (result.ok) await utils.lists.list.get.invalidate({ id });
+    return result;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'unknown';
+    if (/NameRequired/i.test(message)) return { ok: false, reason: 'NameRequired' };
+    setError(message);
+    throw err;
+  }
+}

--- a/packages/app-lists/src/pages/detail/useItemMutations.ts
+++ b/packages/app-lists/src/pages/detail/useItemMutations.ts
@@ -6,16 +6,21 @@ import type { ListItemRow } from './types.js';
 
 /**
  * Item-level mutations consumed by the detail page. Each mutation
- * invalidates the parent list's `lists.list.get` cache so the UI rehydrates
- * with server-confirmed state after the optimistic update settles.
+ * invalidates the parent list's `lists.list.get` cache on success so the UI
+ * rehydrates with server-confirmed state. No true optimistic update yet —
+ * the page waits on the refetch round-trip. `check`/`uncheck`/`remove` are
+ * fire-and-forget at the call site (no awaitable Promise) because their
+ * callers don't need to chain; `update`/`reorder` await so the caller can
+ * close the inline editor / roll back a failed drag.
  *
- * `check`/`uncheck`/`remove` are deliberately fire-and-forget at the call
- * site — the optimistic update is the source of truth until the server
- * responds. `update`/`reorder` await the response so the caller can chain
- * (close inline editor, persist the reorder).
+ * Future: lean on `utils.lists.list.get.setData` to apply the patch (and
+ * `lists.items.check`'s server-returned `checkedAt`) before the refetch
+ * lands — see `apps/pops-api/src/modules/lists/routers/items.ts:92` for the
+ * server payload that's currently ignored.
  */
 export interface ItemMutations {
   add: (input: AddInput) => Promise<{ id: number; position: number } | null>;
+  isAdding: boolean;
   check: (id: number) => void;
   uncheck: (id: number) => void;
   update: (id: number, patch: UpdatePatch) => Promise<boolean>;
@@ -97,6 +102,7 @@ export function useItemMutations(listId: number): ItemMutations {
 
   return {
     add,
+    isAdding: m.add.isPending,
     check: fireAndForget(m.check),
     uncheck: fireAndForget(m.uncheck),
     update,

--- a/packages/app-lists/src/pages/detail/useItemMutations.ts
+++ b/packages/app-lists/src/pages/detail/useItemMutations.ts
@@ -1,0 +1,129 @@
+import { useCallback, useState } from 'react';
+
+import { trpc } from '@pops/api-client';
+
+import type { ListItemRow } from './types.js';
+
+/**
+ * Item-level mutations consumed by the detail page. Each mutation
+ * invalidates the parent list's `lists.list.get` cache so the UI rehydrates
+ * with server-confirmed state after the optimistic update settles.
+ *
+ * `check`/`uncheck`/`remove` are deliberately fire-and-forget at the call
+ * site — the optimistic update is the source of truth until the server
+ * responds. `update`/`reorder` await the response so the caller can chain
+ * (close inline editor, persist the reorder).
+ */
+export interface ItemMutations {
+  add: (input: AddInput) => Promise<{ id: number; position: number } | null>;
+  check: (id: number) => void;
+  uncheck: (id: number) => void;
+  update: (id: number, patch: UpdatePatch) => Promise<boolean>;
+  remove: (id: number) => void;
+  reorder: (orderedIds: readonly number[]) => Promise<boolean>;
+  errorMessage: string | null;
+  clearError: () => void;
+}
+
+interface AddInput {
+  label: string;
+  qty?: number | null;
+  unit?: string | null;
+}
+
+interface UpdatePatch {
+  label?: string;
+  qty?: number | null;
+  unit?: string | null;
+  notes?: string | null;
+}
+
+function useItemMutationHooks(onError: (message: string) => void) {
+  const handler = { onError: (err: { message: string }) => onError(err.message) };
+  return {
+    add: trpc.lists.items.add.useMutation(handler),
+    check: trpc.lists.items.check.useMutation(handler),
+    uncheck: trpc.lists.items.uncheck.useMutation(handler),
+    update: trpc.lists.items.update.useMutation(handler),
+    remove: trpc.lists.items.remove.useMutation(handler),
+    reorder: trpc.lists.items.reorder.useMutation(handler),
+  };
+}
+
+export function useItemMutations(listId: number): ItemMutations {
+  const utils = trpc.useUtils();
+  const [errorMessage, setError] = useState<string | null>(null);
+  const clearError = useCallback(() => setError(null), []);
+  const invalidate = useCallback(
+    () => utils.lists.list.get.invalidate({ id: listId }),
+    [listId, utils]
+  );
+  const m = useItemMutationHooks(setError);
+
+  const add: ItemMutations['add'] = useCallback(
+    async (input) => {
+      try {
+        const row = await m.add.mutateAsync({ listId, ...input });
+        await invalidate();
+        return row;
+      } catch {
+        return null;
+      }
+    },
+    [invalidate, listId, m.add]
+  );
+  const fireAndForget =
+    (mutation: { mutate: (input: { id: number }, opts?: { onSuccess?: () => void }) => void }) =>
+    (id: number) =>
+      mutation.mutate({ id }, { onSuccess: () => void invalidate() });
+
+  const update: ItemMutations['update'] = useCallback(
+    async (id, patch) =>
+      awaitMutation(async () => {
+        await m.update.mutateAsync({ id, ...patch });
+        await invalidate();
+      }),
+    [invalidate, m.update]
+  );
+  const reorder: ItemMutations['reorder'] = useCallback(
+    async (orderedIds) =>
+      awaitMutation(async () => {
+        const result = await m.reorder.mutateAsync({ listId, orderedIds: [...orderedIds] });
+        await invalidate();
+        return result.ok;
+      }),
+    [invalidate, listId, m.reorder]
+  );
+
+  return {
+    add,
+    check: fireAndForget(m.check),
+    uncheck: fireAndForget(m.uncheck),
+    update,
+    remove: fireAndForget(m.remove),
+    reorder,
+    errorMessage,
+    clearError,
+  };
+}
+
+async function awaitMutation(fn: () => Promise<void | boolean>): Promise<boolean> {
+  try {
+    const result = await fn();
+    return result ?? true;
+  } catch {
+    return false;
+  }
+}
+
+export function optimisticToggleChecked(items: readonly ListItemRow[], id: number): ListItemRow[] {
+  return items.map((row) =>
+    row.id === id
+      ? {
+          ...row,
+          checked: row.checked === 1 ? 0 : 1,
+          checkedAt: row.checked === 1 ? null : new Date().toISOString(),
+        }
+      : row
+  );
+}

--- a/packages/app-lists/src/pages/detail/useMenuKeyboard.ts
+++ b/packages/app-lists/src/pages/detail/useMenuKeyboard.ts
@@ -1,0 +1,70 @@
+import { useCallback, useEffect, useRef, type KeyboardEvent } from 'react';
+
+/**
+ * ARIA menu keyboard model for the detail / item three-dot menus.
+ *
+ * Implements the subset of WAI-ARIA `role="menu"` keyboard behaviour the page
+ * needs: arrow up/down cycle through the `role="menuitem"` children, Home/End
+ * jump to first/last, focus lands on the first item when the menu opens. Tab
+ * is allowed to pass through (closing the menu by losing focus is handled by
+ * the caller's outside-click listener). Escape close is the caller's
+ * responsibility too — we listen for it inside the menu so the focus stays
+ * trapped while open.
+ */
+export interface MenuKeyboard {
+  menuRef: React.RefObject<HTMLUListElement | null>;
+  onMenuKeyDown: (e: KeyboardEvent<HTMLUListElement>) => void;
+}
+
+function menuItems(menu: HTMLUListElement): HTMLElement[] {
+  return Array.from(menu.querySelectorAll<HTMLElement>('[role="menuitem"]:not([disabled])'));
+}
+
+function focusByIndex(menu: HTMLUListElement, target: number): void {
+  const items = menuItems(menu);
+  if (items.length === 0) return;
+  const next = (target + items.length) % items.length;
+  items[next]?.focus();
+}
+
+export function useMenuKeyboard(open: boolean): MenuKeyboard {
+  const menuRef = useRef<HTMLUListElement | null>(null);
+
+  useEffect(() => {
+    if (!open || menuRef.current === null) return;
+    // Defer to next frame so children render before we look them up.
+    const id = window.requestAnimationFrame(() => {
+      if (menuRef.current !== null) focusByIndex(menuRef.current, 0);
+    });
+    return () => window.cancelAnimationFrame(id);
+  }, [open]);
+
+  const onMenuKeyDown = useCallback((e: KeyboardEvent<HTMLUListElement>) => {
+    const menu = menuRef.current;
+    if (menu === null) return;
+    const items = menuItems(menu);
+    const currentIndex = items.findIndex((el) => el === document.activeElement);
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        focusByIndex(menu, currentIndex + 1);
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        focusByIndex(menu, currentIndex - 1);
+        break;
+      case 'Home':
+        e.preventDefault();
+        focusByIndex(menu, 0);
+        break;
+      case 'End':
+        e.preventDefault();
+        focusByIndex(menu, items.length - 1);
+        break;
+      default:
+        break;
+    }
+  }, []);
+
+  return { menuRef, onMenuKeyDown };
+}

--- a/packages/app-lists/src/routes.tsx
+++ b/packages/app-lists/src/routes.tsx
@@ -6,6 +6,10 @@ const ListsLandingPage = lazy(() =>
   import('./pages/ListsLandingPage').then((m) => ({ default: m.ListsLandingPage }))
 );
 
+const ListDetailPage = lazy(() =>
+  import('./pages/ListDetailPage').then((m) => ({ default: m.ListDetailPage }))
+);
+
 /**
  * Local type mirror for compile-time safety (shell owns the canonical types).
  *
@@ -41,4 +45,7 @@ export const navConfig = {
   ],
 } satisfies AppNavConfigShape;
 
-export const routes: RouteObject[] = [{ index: true, element: <ListsLandingPage /> }];
+export const routes: RouteObject[] = [
+  { index: true, element: <ListsLandingPage /> },
+  { path: ':id', element: <ListDetailPage /> },
+];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1033,6 +1033,18 @@ importers:
 
   packages/app-lists:
     dependencies:
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.2.7)
+      '@pops/api-client':
+        specifier: workspace:*
+        version: link:../api-client
       '@pops/app-lists-db':
         specifier: workspace:*
         version: link:../app-lists-db
@@ -1052,6 +1064,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/better-sqlite3':
         specifier: ^7.6.12
         version: 7.6.13


### PR DESCRIPTION
## Summary

- Builds the generic `/lists/:id` detail page on top of PRD-140-API's tRPC surface (`lists.list.get` + `lists.items.*`). Renders any list kind via a kind-agnostic row component; shopping-only affordances stay queued for PRD-141.
- Header surfaces the list name, kind chip, archived badge, and a three-dot menu (Rename / Change kind / Archive-or-Restore / Delete). Item rows expose a checkbox, label (or inline editor when clicked), optional qty/unit prefix, sub-line for non-`free` refs + notes, and a per-item three-dot menu (Edit / Move up / Move down / Delete).
- Drag-to-reorder uses `@dnd-kit/{core,sortable,utilities}` with a `PointerSensor` plus a 200ms `TouchSensor` delay so mobile long-press beats single-tap interactions. The inline add form at the bottom submits on `Enter` and clears for the next item. Edit modal carries rename + change-kind + Archive/Restore; delete prompts a confirm dialog before firing `lists.list.delete` and navigating back to `/lists`. The detail query polls every 60s in the foreground per PRD §Edge Cases.
- File layout under `packages/app-lists/src/pages/`: `ListDetailPage.tsx` shell + `detail/{ListDetailHeader,ListDetailMenu,ListKindChip,ListEditModal,ListDeleteDialog,ListItemsSection,ListItemRow,ListItemMenu,ListItemAddForm,types,useDetailMutations,useItemMutations}` to stay under the per-file/per-function lint caps. Plain HTML + Tailwind only — keeps `@pops/app-lists` free of `@pops/ui` (pops-api transitively consumes the package via `@pops/app-food-db`'s seed helpers; pulling shadcn/Radix would force the API image to resolve a frontend dep tree).

### Out of scope (per PRD §Out of Scope)

- Shopping affordances (uncheck-all, clear-checked, sort) — PRD-141 swaps in `ShoppingItemRow`/`ShoppingDetailHeader` when `kind='shopping'`.
- Modal URL params (`?new=1`, `?edit=1`) — those land alongside 140-B's index page (parent route).
- The index page itself — separate 140-B sibling PR.
- Food's "Send to shopping list" send action — PRD-142.

### Wiring

- `packages/app-lists/src/routes.tsx`: adds `:id` route.
- `packages/app-lists/package.json`: adds `@dnd-kit/{core,sortable,utilities}` + `@pops/api-client`.
- `apps/pops-shell/src/i18n/locales/{en-AU,pt-BR}/lists.json`: adds the `detail.*` namespace.

### CI gauntlet (locally green)

- `mise typecheck`: 32/32 ✅
- `mise lint`: exit 0 ✅
- `mise test`: 36/36 (incl. 27 app-lists cases — 26 page RTL + 1 manifest route assertion) ✅
- `mise build`: 12/12 ✅

## Test plan

- [ ] Open `/lists` → click "+ New list" (placeholder for now) — direct nav to `/lists/<id>` should load detail page.
- [ ] Verify header renders name, kind chip, archived badge appears when list is archived.
- [ ] Toggle a checkbox → optimistic update + persisted server state.
- [ ] Add item — Enter key submits; input clears; new row appears at the bottom (`position = max+1`).
- [ ] Click label → inline edit input appears, Enter saves, Esc cancels, blur saves.
- [ ] Three-dot menu Rename → modal pre-fills, kind change shows warning, Save persists, Cancel/Esc closes.
- [ ] Archive → list shows archived badge + menu flips to "Restore"; click Restore → archived badge clears.
- [ ] Delete → confirm dialog shows `name` + item count, Delete fires mutation + navigates to `/lists`.
- [ ] Reorder via the item three-dot menu's "Move up" / "Move down" (drag-to-reorder works on desktop pointer + mobile touch).
- [ ] Leave the page open for 60s → query refetches (visible via React Query devtools or a network-tab spy).