### PR TITLE
feat(api): flip service-accounts to the core pillar handle + backfill (phase 2 PR 3)

### DIFF
--- a/apps/pops-api/src/db.ts
+++ b/apps/pops-api/src/db.ts
@@ -298,10 +298,20 @@ export function backfillCoreFromShared(): void {
         .prepare("SELECT 1 FROM pops.sqlite_master WHERE type='table' AND name='service_accounts'")
         .get();
       if (hasTable) {
+        // Enumerate columns explicitly so a future migration that
+        // widens the core table won't break the backfill against a
+        // stale on-disk pops.db that still has the older shape. Order
+        // matches the 0054_service_accounts.sql DDL byte-for-byte.
         coreDb.raw.exec(`
-          INSERT INTO service_accounts
-            SELECT * FROM pops.service_accounts
-            WHERE id NOT IN (SELECT id FROM service_accounts)
+          INSERT INTO service_accounts (
+            id, name, key_prefix, key_hash, scopes,
+            created_at, last_used_at, revoked_at, created_by
+          )
+          SELECT
+            id, name, key_prefix, key_hash, scopes,
+            created_at, last_used_at, revoked_at, created_by
+          FROM pops.service_accounts
+          WHERE id NOT IN (SELECT id FROM service_accounts)
         `);
       }
     } finally {

--- a/apps/pops-api/src/db.ts
+++ b/apps/pops-api/src/db.ts
@@ -271,6 +271,47 @@ export function setCoreDb(next: OpenedCoreDb | null): OpenedCoreDb | null {
   return prev;
 }
 
+/**
+ * One-shot backfill copying service-account rows from the shared
+ * `pops.db` into the core pillar's `core.db`. Idempotent — the
+ * `WHERE id NOT IN (...)` filter means re-running after a partial
+ * failure picks up where it left off without duplicating rows.
+ *
+ * Boot-time contract: PR 2 of phase 2 opened the core DB but did not
+ * yet consume it. PR 3 (this entry point) flips service-accounts
+ * traffic to the core handle, so the first deploy after PR 3 needs to
+ * carry the existing rows across before any reads come from the new
+ * file. Subsequent boots find the core copy already populated and
+ * become a no-op via the existence filter.
+ *
+ * Non-fatal: ATTACH or INSERT failures are logged and swallowed so a
+ * stale on-disk pops.db never bricks the boot path. Failures here
+ * leave the core copy empty for that boot; the next deploy retries.
+ */
+export function backfillCoreFromShared(): void {
+  if (!coreDb) return;
+  const sharedPath = resolveSqlitePath();
+  try {
+    coreDb.raw.prepare('ATTACH DATABASE ? AS pops').run(sharedPath);
+    try {
+      const hasTable = coreDb.raw
+        .prepare("SELECT 1 FROM pops.sqlite_master WHERE type='table' AND name='service_accounts'")
+        .get();
+      if (hasTable) {
+        coreDb.raw.exec(`
+          INSERT INTO service_accounts
+            SELECT * FROM pops.service_accounts
+            WHERE id NOT IN (SELECT id FROM service_accounts)
+        `);
+      }
+    } finally {
+      coreDb.raw.exec('DETACH DATABASE pops');
+    }
+  } catch (err) {
+    console.warn('[db] Core service-accounts backfill failed (non-fatal):', err);
+  }
+}
+
 export function setDb(newDb: BetterSqlite3.Database): BetterSqlite3.Database | null {
   const prev = prodDb;
   prodDb = newDb;

--- a/apps/pops-api/src/db/backfill-core-from-shared.test.ts
+++ b/apps/pops-api/src/db/backfill-core-from-shared.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Boot-time backfill tests for `backfillCoreFromShared` (phase 2 PR 3).
+ *
+ * Exercises the ATTACH-based copy from the shared `pops.db` to the
+ * pillar's `core.db` against on-disk SQLite files (in-memory DBs can't
+ * be ATTACHed). Confirms:
+ *   - first run carries existing rows across,
+ *   - second run is a no-op (idempotent — the WHERE filter dedupes),
+ *   - mixed state (some rows already in core) only inserts the missing ones,
+ *   - missing source table is tolerated without throwing.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import BetterSqlite3 from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { openCoreDb } from '@pops/core-db';
+
+import { backfillCoreFromShared, closeCoreDb, setCoreDb } from '../db.js';
+import { SERVICE_ACCOUNTS_TABLE_SQL } from './backfill-test-fixtures.js';
+
+let tmpDir: string;
+
+const originalSharedPath = process.env['SQLITE_PATH'];
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'core-backfill-'));
+});
+
+afterEach(() => {
+  closeCoreDb();
+  rmSync(tmpDir, { recursive: true, force: true });
+  if (originalSharedPath === undefined) delete process.env['SQLITE_PATH'];
+  else process.env['SQLITE_PATH'] = originalSharedPath;
+});
+
+function openSharedWithRows(rows: { id: string; name: string }[]): string {
+  const path = join(tmpDir, 'pops.db');
+  // Create the shared file via openCoreDb's helper would conflict because
+  // openCoreDb applies the core migrations; instead seed a raw SQLite
+  // with the canonical service_accounts DDL + the test rows.
+  const raw = new BetterSqlite3(path);
+  raw.exec(SERVICE_ACCOUNTS_TABLE_SQL);
+  const insert = raw.prepare(
+    `INSERT INTO service_accounts (id, name, key_prefix, key_hash) VALUES (?, ?, ?, ?)`
+  );
+  for (const row of rows) {
+    insert.run(row.id, row.name, `pfx${row.id.slice(0, 5)}`, 'scrypt$x$y');
+  }
+  raw.close();
+  process.env['SQLITE_PATH'] = path;
+  return path;
+}
+
+describe('backfillCoreFromShared', () => {
+  it('returns silently when the core handle is closed', () => {
+    setCoreDb(null);
+    expect(() => backfillCoreFromShared()).not.toThrow();
+  });
+
+  it('copies fresh rows on first run and is a no-op on the second', () => {
+    openSharedWithRows([
+      { id: 'sa_a', name: 'alpha' },
+      { id: 'sa_b', name: 'beta' },
+    ]);
+    const core = openCoreDb(join(tmpDir, 'core.db'));
+    setCoreDb(core);
+
+    backfillCoreFromShared();
+    const after = core.raw.prepare('SELECT id, name FROM service_accounts ORDER BY id').all() as {
+      id: string;
+      name: string;
+    }[];
+    expect(after.map((r) => r.id)).toEqual(['sa_a', 'sa_b']);
+
+    backfillCoreFromShared();
+    const second = core.raw.prepare('SELECT count(*) AS n FROM service_accounts').get() as {
+      n: number;
+    };
+    expect(second.n).toBe(2);
+  });
+
+  it('only inserts rows missing from the core copy', () => {
+    openSharedWithRows([
+      { id: 'sa_a', name: 'alpha' },
+      { id: 'sa_b', name: 'beta' },
+    ]);
+    const core = openCoreDb(join(tmpDir, 'core.db'));
+    setCoreDb(core);
+    core.raw
+      .prepare(`INSERT INTO service_accounts (id, name, key_prefix, key_hash) VALUES (?, ?, ?, ?)`)
+      .run('sa_b', 'beta-old', 'pfxBB', 'scrypt$x$y');
+
+    backfillCoreFromShared();
+    const rows = core.raw.prepare('SELECT id, name FROM service_accounts ORDER BY id').all() as {
+      id: string;
+      name: string;
+    }[];
+    expect(rows).toEqual([
+      { id: 'sa_a', name: 'alpha' },
+      { id: 'sa_b', name: 'beta-old' },
+    ]);
+  });
+
+  it('tolerates a shared DB without the service_accounts table', () => {
+    const path = join(tmpDir, 'pops.db');
+    const raw = new BetterSqlite3(path);
+    raw.close();
+    process.env['SQLITE_PATH'] = path;
+
+    const core = openCoreDb(join(tmpDir, 'core.db'));
+    setCoreDb(core);
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      expect(() => backfillCoreFromShared()).not.toThrow();
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+    const count = core.raw.prepare('SELECT count(*) AS n FROM service_accounts').get() as {
+      n: number;
+    };
+    expect(count.n).toBe(0);
+  });
+});

--- a/apps/pops-api/src/db/backfill-test-fixtures.ts
+++ b/apps/pops-api/src/db/backfill-test-fixtures.ts
@@ -1,0 +1,27 @@
+/**
+ * SQL fixture for the `backfill-core-from-shared.test.ts` suite.
+ *
+ * Inlined here (rather than reading the canonical drizzle-migration
+ * `0054_service_accounts.sql`) so the test stays robust against the
+ * eventual phase-2-PR4 deletion of that shared-journal copy. The DDL
+ * matches the byte-identical migration that lands in both
+ * `apps/pops-api/src/db/drizzle-migrations/` and
+ * `packages/core-db/migrations/`.
+ */
+export const SERVICE_ACCOUNTS_TABLE_SQL = `
+CREATE TABLE service_accounts (
+  id text PRIMARY KEY NOT NULL,
+  name text NOT NULL,
+  key_prefix text NOT NULL,
+  key_hash text NOT NULL,
+  scopes text DEFAULT '[]' NOT NULL,
+  created_at text DEFAULT (datetime('now')) NOT NULL,
+  last_used_at text,
+  revoked_at text,
+  created_by text
+);
+CREATE UNIQUE INDEX service_accounts_name_unique ON service_accounts (name);
+CREATE UNIQUE INDEX service_accounts_key_prefix_unique ON service_accounts (key_prefix);
+CREATE INDEX idx_service_accounts_key_prefix ON service_accounts (key_prefix);
+CREATE INDEX idx_service_accounts_revoked_at ON service_accounts (revoked_at);
+`;

--- a/apps/pops-api/src/index.ts
+++ b/apps/pops-api/src/index.ts
@@ -6,7 +6,7 @@ config(); // loads apps/pops-api/.env if it exists
 config({ path: '../../.env', override: false }); // loads root .env without overriding
 
 import { createApp } from './app.js';
-import { closeDb, getCoreDrizzle } from './db.js';
+import { backfillCoreFromShared, closeDb, getCoreDrizzle } from './db.js';
 import { closeQueues } from './jobs/queues.js';
 import { startThalamus, stopThalamus } from './modules/cerebrum/thalamus/instance.js';
 import {
@@ -36,13 +36,16 @@ const port = Number(process.env['PORT'] ?? 3000);
 const app = createApp();
 
 // Eagerly open the core pillar's SQLite + apply its journal at boot so
-// the per-pillar migrations land before any request hits the API. The
-// handle itself is not yet consumed for production traffic — PR 3 of
-// phase 2 flips service-accounts callers to `getCoreDrizzle()`.
+// the per-pillar migrations land before any request hits the API.
+// service-accounts traffic now reads/writes against this handle (phase 2
+// PR 3); the one-shot `backfillCoreFromShared` carries any rows that
+// still live in the legacy pops.db across. The backfill is idempotent
+// and non-fatal — partial failure logs and continues.
 try {
   getCoreDrizzle();
+  backfillCoreFromShared();
 } catch (err) {
-  console.error('[db] Failed to open the core pillar SQLite:', err);
+  console.error('[db] Failed to bootstrap the core pillar SQLite:', err);
   throw err;
 }
 

--- a/apps/pops-api/src/modules/core/service-accounts/router.ts
+++ b/apps/pops-api/src/modules/core/service-accounts/router.ts
@@ -22,7 +22,7 @@ import {
   serviceAccountsService,
 } from '@pops/core-db';
 
-import { getDrizzle } from '../../../db.js';
+import { getCoreDrizzle } from '../../../db.js';
 import { ConflictError, NotFoundError, ValidationError } from '../../../shared/errors.js';
 import { mapDomainErrors, mapDomainErrorsAsync } from '../../../shared/trpc-error-mapper.js';
 import { router, userOnlyProcedure } from '../../../trpc.js';
@@ -34,7 +34,7 @@ import {
 
 export const serviceAccountsRouter = router({
   list: userOnlyProcedure.output(z.array(ServiceAccountSchema)).query(() => {
-    return serviceAccountsService.listServiceAccounts(getDrizzle());
+    return serviceAccountsService.listServiceAccounts(getCoreDrizzle());
   }),
 
   create: userOnlyProcedure
@@ -44,7 +44,7 @@ export const serviceAccountsRouter = router({
       mapDomainErrorsAsync(async () => {
         try {
           return await serviceAccountsService.createServiceAccount(
-            getDrizzle(),
+            getCoreDrizzle(),
             input,
             ctx.user.email
           );
@@ -63,7 +63,7 @@ export const serviceAccountsRouter = router({
     .mutation(({ input }) =>
       mapDomainErrors(() => {
         try {
-          serviceAccountsService.revokeServiceAccount(getDrizzle(), input.id);
+          serviceAccountsService.revokeServiceAccount(getCoreDrizzle(), input.id);
         } catch (err) {
           if (err instanceof ServiceAccountNotFoundError) {
             throw new NotFoundError('ServiceAccount', input.id);

--- a/apps/pops-api/src/shared/test-utils.ts
+++ b/apps/pops-api/src/shared/test-utils.ts
@@ -1,6 +1,7 @@
 import BetterSqlite3 from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
 
-import { closeDb, setDb } from '../db.js';
+import { closeDb, setCoreDb, setDb } from '../db.js';
 import { appRouter } from '../router.js';
 import { TAG_VOCABULARY_V1 } from './tag-vocabulary.js';
 
@@ -1471,11 +1472,19 @@ export function setupTestContext() {
   function setup(): { db: Database; caller: ReturnType<typeof createCaller> } {
     db = createTestDb();
     setDb(db);
+    // Route the core pillar handle at the same in-memory DB so the
+    // post-PR3 service-accounts call sites (which read/write via
+    // getCoreDrizzle()) keep operating on the test fixture without
+    // each suite having to seed a separate core.db. The shared
+    // `service_accounts` table lives in `createTestDb()` and is
+    // populated/queried through both connections transparently.
+    setCoreDb({ db: drizzle(db), raw: db });
 
     return { db, caller: createCaller(true) };
   }
 
   function teardown() {
+    setCoreDb(null);
     closeDb();
   }
 

--- a/apps/pops-api/src/trpc.ts
+++ b/apps/pops-api/src/trpc.ts
@@ -10,7 +10,7 @@ import {
   serviceAccountsService,
 } from '@pops/core-db';
 
-import { getDrizzle } from './db.js';
+import { getCoreDrizzle } from './db.js';
 import { verifyCloudflareJWT } from './middleware/cloudflare-jwt.js';
 import { KNOWN_APPS, KNOWN_OVERLAYS, readInstalledModules } from './modules/env-modules.js';
 
@@ -60,7 +60,7 @@ async function tryServiceAccountAuth(
   const parsed = serviceAccountKeys.parseApiKey(header);
   if (!parsed) return null;
   return serviceAccountsService.authenticateServiceAccount(
-    getDrizzle(),
+    getCoreDrizzle(),
     parsed.prefix,
     parsed.secret
   );


### PR DESCRIPTION
## Summary

Third PR of the core pillar **Phase 2 — extract core's SQLite** sequence (pillar-migration-roadmap.md Track D · Phase 2 PR 3 of 4).

Flips the service-accounts slice off the shared \`pops.db\` singleton onto the new \`core.db\` handle opened in PR 2, and adds a boot-time backfill that carries existing rows across.

## Cutover

- \`trpc.ts\` service-account auth path now resolves \`getCoreDrizzle()\`.
- \`modules/core/service-accounts/router.ts\` \`list\` / \`create\` / \`revoke\` procedures resolve \`getCoreDrizzle()\` instead of \`getDrizzle()\`.
- \`shared/test-utils.ts\` \`setupTestContext\` installs the in-memory test DB on BOTH the shared and the core handles so existing suites (4640 cases) keep operating on a single SQLite fixture transparently through both connections.

## Boot-time backfill

- New \`backfillCoreFromShared()\` in \`db.ts\`: \`ATTACH pops.db AS pops\` → copy rows whose \`id\` is missing from \`core.service_accounts\` → \`DETACH\`. The \`WHERE id NOT IN (...)\` filter makes the call idempotent so a partial failure retries cleanly on the next boot.
- Handles a shared DB with no \`service_accounts\` table gracefully (post-phase-2-PR4 drop scenario) via a \`sqlite_master\` existence probe.
- Non-fatal: ATTACH / INSERT errors are logged and swallowed so a stale on-disk \`pops.db\` never bricks startup.
- Wired into \`index.ts\` immediately after the eager \`getCoreDrizzle()\` call so migrations + backfill complete before the HTTP server starts listening.

## Test coverage

- \`src/db/backfill-core-from-shared.test.ts\` — 4 cases: fresh copy, idempotent re-run, mixed state (only missing rows inserted), missing source table tolerated.
- \`src/db/backfill-test-fixtures.ts\` — inlined \`service_accounts\` DDL so the test stays valid after phase 2 PR 4 deletes the shared-journal copy.
- pops-api workspace tests — 4640 / 4640 still green; the test-utils route both handles at the same fixture so the service-accounts integration tests cover the new code path.

## Phase 2 status

- ✅ PR 1 — \`openCoreDb\` helper (#2747)
- ✅ PR 2 — boot-time open + env resolver (#2751)
- 🔄 PR 3 — cutover + backfill (this)
- ⏳ PR 4 — drop shared journal entry + \`infra/litestream/core.yml\`

## Test plan

- [ ] CI green on \`api-quality\` + \`api-test\` (workspace tests + backfill suite)
- [ ] CI green on \`core-quality\` (drift guard still active)
- [ ] Copilot review pass