### PR TITLE
feat(lists): shopping list specialisation (PRD-141)

### DIFF
--- a/apps/pops-api/src/modules/lists/__tests__/lists-router.test.ts
+++ b/apps/pops-api/src/modules/lists/__tests__/lists-router.test.ts
@@ -415,4 +415,79 @@ describe('PRD-140 lists router', () => {
       expect(result).toEqual({ ok: false, reason: 'BadIds' });
     });
   });
+
+  describe('items.uncheckAll (PRD-141)', () => {
+    it('unchecks every checked item and returns the count', async () => {
+      const caller = createCaller();
+      const { id: listId } = await caller.lists.list.create({ name: 'Shop', kind: 'shopping' });
+      const { id: a } = await caller.lists.items.add({ listId, label: 'a' });
+      const { id: b } = await caller.lists.items.add({ listId, label: 'b' });
+      await caller.lists.items.add({ listId, label: 'c' });
+      await caller.lists.items.check({ id: a });
+      await caller.lists.items.check({ id: b });
+      const result = await caller.lists.items.uncheckAll({ listId });
+      expect(result).toEqual({ ok: true, count: 2 });
+      const detail = await caller.lists.list.get({ id: listId });
+      expect(detail?.items.every((row) => row.checked === 0)).toBe(true);
+    });
+
+    it('returns count=0 when nothing is checked', async () => {
+      const caller = createCaller();
+      const { id: listId } = await caller.lists.list.create({ name: 'Shop', kind: 'shopping' });
+      await caller.lists.items.add({ listId, label: 'a' });
+      expect(await caller.lists.items.uncheckAll({ listId })).toEqual({ ok: true, count: 0 });
+    });
+
+    it('is scoped to the target list', async () => {
+      const caller = createCaller();
+      const { id: listA } = await caller.lists.list.create({ name: 'A', kind: 'shopping' });
+      const { id: listB } = await caller.lists.list.create({ name: 'B', kind: 'shopping' });
+      const { id: a } = await caller.lists.items.add({ listId: listA, label: 'a' });
+      const { id: b } = await caller.lists.items.add({ listId: listB, label: 'b' });
+      await caller.lists.items.check({ id: a });
+      await caller.lists.items.check({ id: b });
+      await caller.lists.items.uncheckAll({ listId: listA });
+      const detailB = await caller.lists.list.get({ id: listB });
+      expect(detailB?.items[0]?.checked).toBe(1);
+    });
+  });
+
+  describe('items.removeChecked (PRD-141)', () => {
+    it('removes every checked item and returns the count', async () => {
+      const caller = createCaller();
+      const { id: listId } = await caller.lists.list.create({ name: 'Shop', kind: 'shopping' });
+      const { id: a } = await caller.lists.items.add({ listId, label: 'a' });
+      await caller.lists.items.add({ listId, label: 'b' });
+      const { id: c } = await caller.lists.items.add({ listId, label: 'c' });
+      await caller.lists.items.check({ id: a });
+      await caller.lists.items.check({ id: c });
+      const result = await caller.lists.items.removeChecked({ listId });
+      expect(result).toEqual({ ok: true, removedCount: 2 });
+      const detail = await caller.lists.list.get({ id: listId });
+      expect(detail?.items.map((row) => row.label)).toEqual(['b']);
+    });
+
+    it('returns removedCount=0 when nothing is checked', async () => {
+      const caller = createCaller();
+      const { id: listId } = await caller.lists.list.create({ name: 'Shop', kind: 'shopping' });
+      await caller.lists.items.add({ listId, label: 'a' });
+      expect(await caller.lists.items.removeChecked({ listId })).toEqual({
+        ok: true,
+        removedCount: 0,
+      });
+    });
+
+    it('is scoped to the target list', async () => {
+      const caller = createCaller();
+      const { id: listA } = await caller.lists.list.create({ name: 'A', kind: 'shopping' });
+      const { id: listB } = await caller.lists.list.create({ name: 'B', kind: 'shopping' });
+      const { id: a } = await caller.lists.items.add({ listId: listA, label: 'a' });
+      const { id: b } = await caller.lists.items.add({ listId: listB, label: 'b' });
+      await caller.lists.items.check({ id: a });
+      await caller.lists.items.check({ id: b });
+      await caller.lists.items.removeChecked({ listId: listA });
+      const detailB = await caller.lists.list.get({ id: listB });
+      expect(detailB?.items.length).toBe(1);
+    });
+  });
 });

--- a/apps/pops-api/src/modules/lists/routers/items.ts
+++ b/apps/pops-api/src/modules/lists/routers/items.ts
@@ -16,8 +16,10 @@ import {
   checkItem,
   type ListsDb,
   listItemsForList,
+  removeCheckedItems,
   removeItem,
   reorderItems,
+  uncheckAllItems,
   uncheckItem,
   updateItem,
 } from '@pops/app-lists-db';
@@ -68,6 +70,8 @@ const ReorderInputSchema = z.object({
   listId: z.number().int().positive(),
   orderedIds: z.array(z.number().int().positive()),
 });
+
+const ListIdInputSchema = z.object({ listId: z.number().int().positive() });
 
 function currentItemIds(db: ListsDb, listId: number): readonly number[] {
   return listItemsForList(db, listId).map((r) => r.id);
@@ -138,5 +142,24 @@ export const itemsRouter = router({
     }
     runOrMap(() => reorderItems(db, input.listId, input.orderedIds));
     return { ok: true as const };
+  }),
+
+  /**
+   * Bulk-uncheck every checked item in a list (PRD-141 amendment). Returns
+   * the affected row count so the UI can surface "Unchecked N items"
+   * without a follow-up read.
+   */
+  uncheckAll: protectedProcedure.input(ListIdInputSchema).mutation(({ input }) => {
+    const count = runOrMap(() => uncheckAllItems(getDrizzle(), input.listId));
+    return { ok: true as const, count };
+  }),
+
+  /**
+   * Hard-delete every checked item in a list (PRD-141 amendment). Returns
+   * the row count removed; unchecked items are untouched.
+   */
+  removeChecked: protectedProcedure.input(ListIdInputSchema).mutation(({ input }) => {
+    const removedCount = runOrMap(() => removeCheckedItems(getDrizzle(), input.listId));
+    return { ok: true as const, removedCount };
   }),
 });

--- a/apps/pops-shell/src/i18n/locales/en-AU/lists.json
+++ b/apps/pops-shell/src/i18n/locales/en-AU/lists.json
@@ -75,5 +75,57 @@
         "delete": "Delete"
       }
     }
+  },
+  "shopping": {
+    "empty": "Nothing on the list yet. Add an item below to get started.",
+    "header": {
+      "sort": {
+        "label": "Sort",
+        "options": {
+          "manual": "Manual",
+          "unchecked-first": "Unchecked first",
+          "recent-check": "Recently checked"
+        }
+      },
+      "uncheckAll": {
+        "button": "Uncheck all",
+        "empty": "No items to uncheck"
+      },
+      "clearChecked": {
+        "button": "Clear checked",
+        "empty": "No checked items to clear"
+      },
+      "caption": "{{total}} items · {{checked}} checked"
+    },
+    "uncheckAll": {
+      "title": "Uncheck all items?",
+      "body": "This resets the checked state for {{count}} item(s). The list itself isn't modified.",
+      "cancel": "Cancel",
+      "confirm": "Uncheck all",
+      "pending": "Unchecking…"
+    },
+    "clearChecked": {
+      "title": "Remove all checked items?",
+      "body": "This permanently deletes {{count}} item(s) from this list. The unchecked items stay.",
+      "cancel": "Cancel",
+      "confirm": "Remove checked",
+      "pending": "Removing…"
+    },
+    "add": {
+      "qty": "Qty",
+      "unit": "Unit",
+      "label": "Item",
+      "submit": "Add"
+    },
+    "item": {
+      "checkbox": "Toggle done for {{label}}",
+      "editLabel": "Edit item label",
+      "dragHandle": "Drag to reorder",
+      "dragDisabled": "Switch to Manual sort to reorder",
+      "swipe": {
+        "cancel": "Cancel",
+        "delete": "Delete"
+      }
+    }
   }
 }

--- a/apps/pops-shell/src/i18n/locales/pt-BR/lists.json
+++ b/apps/pops-shell/src/i18n/locales/pt-BR/lists.json
@@ -75,5 +75,57 @@
         "delete": "Excluir"
       }
     }
+  },
+  "shopping": {
+    "empty": "Nada na lista ainda. Adicione um item abaixo para começar.",
+    "header": {
+      "sort": {
+        "label": "Ordenar",
+        "options": {
+          "manual": "Manual",
+          "unchecked-first": "Não marcados primeiro",
+          "recent-check": "Marcados recentemente"
+        }
+      },
+      "uncheckAll": {
+        "button": "Desmarcar tudo",
+        "empty": "Nenhum item para desmarcar"
+      },
+      "clearChecked": {
+        "button": "Limpar marcados",
+        "empty": "Nenhum item marcado para limpar"
+      },
+      "caption": "{{total}} itens · {{checked}} marcados"
+    },
+    "uncheckAll": {
+      "title": "Desmarcar todos os itens?",
+      "body": "Isso reseta o estado de marcado de {{count}} item(ns). A lista em si não é modificada.",
+      "cancel": "Cancelar",
+      "confirm": "Desmarcar tudo",
+      "pending": "Desmarcando…"
+    },
+    "clearChecked": {
+      "title": "Remover todos os itens marcados?",
+      "body": "Isso exclui permanentemente {{count}} item(ns) desta lista. Os não marcados continuam.",
+      "cancel": "Cancelar",
+      "confirm": "Remover marcados",
+      "pending": "Removendo…"
+    },
+    "add": {
+      "qty": "Qtd",
+      "unit": "Unid.",
+      "label": "Item",
+      "submit": "Adicionar"
+    },
+    "item": {
+      "checkbox": "Alternar concluído para {{label}}",
+      "editLabel": "Editar rótulo do item",
+      "dragHandle": "Arrastar para reordenar",
+      "dragDisabled": "Mude para ordenação Manual para reordenar",
+      "swipe": {
+        "cancel": "Cancelar",
+        "delete": "Excluir"
+      }
+    }
   }
 }

--- a/packages/app-lists-db/src/__tests__/lists.test.ts
+++ b/packages/app-lists-db/src/__tests__/lists.test.ts
@@ -18,8 +18,10 @@ import {
   bulkAdd,
   checkItem,
   listItemsForList,
+  removeCheckedItems,
   removeItem,
   reorderItems,
+  uncheckAllItems,
   uncheckItem,
   updateItem,
 } from '../services/list-items.js';
@@ -424,6 +426,73 @@ describe('PRD-112 — lists schema + service layer', () => {
       const row = listItemsForList(db, list.id)[0];
       expect(row?.refKind).toBe('ingredient');
       expect(row?.refId).toBeNull();
+    });
+  });
+
+  describe('PRD-141 bulk mutations', () => {
+    it('uncheckAllItems flips every checked row + returns the count', () => {
+      const list = createList(db, { name: 'Shop', kind: 'shopping', ownerApp: 'food' });
+      const a = addItem(db, { listId: list.id, label: 'a' });
+      const b = addItem(db, { listId: list.id, label: 'b' });
+      const c = addItem(db, { listId: list.id, label: 'c' });
+      checkItem(db, a.id);
+      checkItem(db, b.id);
+      const count = uncheckAllItems(db, list.id);
+      expect(count).toBe(2);
+      const rows = listItemsForList(db, list.id);
+      expect(rows.every((r) => r.checked === 0)).toBe(true);
+      expect(rows.every((r) => r.checkedAt === null)).toBe(true);
+      expect(rows.find((r) => r.id === c.id)?.checked).toBe(0);
+    });
+
+    it('uncheckAllItems returns 0 when nothing is checked', () => {
+      const list = createList(db, { name: 'Shop', kind: 'shopping', ownerApp: 'food' });
+      addItem(db, { listId: list.id, label: 'a' });
+      addItem(db, { listId: list.id, label: 'b' });
+      expect(uncheckAllItems(db, list.id)).toBe(0);
+    });
+
+    it('uncheckAllItems is scoped to the target list', () => {
+      const a = createList(db, { name: 'A', kind: 'shopping', ownerApp: 'food' });
+      const b = createList(db, { name: 'B', kind: 'shopping', ownerApp: 'food' });
+      const aRow = addItem(db, { listId: a.id, label: 'a' });
+      const bRow = addItem(db, { listId: b.id, label: 'b' });
+      checkItem(db, aRow.id);
+      checkItem(db, bRow.id);
+      expect(uncheckAllItems(db, a.id)).toBe(1);
+      const refreshed = listItemsForList(db, b.id)[0];
+      expect(refreshed?.checked).toBe(1);
+    });
+
+    it('removeCheckedItems deletes every checked row + returns the count', () => {
+      const list = createList(db, { name: 'Shop', kind: 'shopping', ownerApp: 'food' });
+      const a = addItem(db, { listId: list.id, label: 'a' });
+      const b = addItem(db, { listId: list.id, label: 'b' });
+      const c = addItem(db, { listId: list.id, label: 'c' });
+      checkItem(db, a.id);
+      checkItem(db, c.id);
+      const removed = removeCheckedItems(db, list.id);
+      expect(removed).toBe(2);
+      const remaining = listItemsForList(db, list.id);
+      expect(remaining.map((r) => r.id)).toEqual([b.id]);
+    });
+
+    it('removeCheckedItems returns 0 when nothing is checked', () => {
+      const list = createList(db, { name: 'Shop', kind: 'shopping', ownerApp: 'food' });
+      addItem(db, { listId: list.id, label: 'a' });
+      expect(removeCheckedItems(db, list.id)).toBe(0);
+      expect(listItemsForList(db, list.id).length).toBe(1);
+    });
+
+    it('removeCheckedItems is scoped to the target list', () => {
+      const a = createList(db, { name: 'A', kind: 'shopping', ownerApp: 'food' });
+      const b = createList(db, { name: 'B', kind: 'shopping', ownerApp: 'food' });
+      const aRow = addItem(db, { listId: a.id, label: 'a' });
+      const bRow = addItem(db, { listId: b.id, label: 'b' });
+      checkItem(db, aRow.id);
+      checkItem(db, bRow.id);
+      expect(removeCheckedItems(db, a.id)).toBe(1);
+      expect(listItemsForList(db, b.id).length).toBe(1);
     });
   });
 });

--- a/packages/app-lists-db/src/index.ts
+++ b/packages/app-lists-db/src/index.ts
@@ -45,8 +45,10 @@ export {
   bulkAdd,
   checkItem,
   listItemsForList,
+  removeCheckedItems,
   removeItem,
   reorderItems,
+  uncheckAllItems,
   uncheckItem,
   updateItem,
 } from './services/list-items.js';

--- a/packages/app-lists-db/src/services/list-items.ts
+++ b/packages/app-lists-db/src/services/list-items.ts
@@ -187,3 +187,39 @@ export function listItemsForList(db: ListsDb, listId: number): readonly ListItem
     .orderBy(asc(listItems.position), asc(listItems.id))
     .all();
 }
+
+/**
+ * Bulk-uncheck every currently-checked item in a list (PRD-141 amendment).
+ *
+ * Single UPDATE inside a transaction. Returns the row count affected so the
+ * UI can show "Unchecked N items" without a follow-up read. No-op (returns
+ * 0) when nothing was checked.
+ */
+export function uncheckAllItems(db: ListsDb, listId: number): number {
+  return db.transaction((tx) => {
+    const rows = tx
+      .update(listItems)
+      .set({ checked: 0, checkedAt: null })
+      .where(and(eq(listItems.listId, listId), eq(listItems.checked, 1)))
+      .returning({ id: listItems.id })
+      .all();
+    return rows.length;
+  });
+}
+
+/**
+ * Hard-delete every currently-checked item in a list (PRD-141 amendment).
+ *
+ * Single DELETE inside a transaction. Returns the row count removed.
+ * Unchecked items are untouched.
+ */
+export function removeCheckedItems(db: ListsDb, listId: number): number {
+  return db.transaction((tx) => {
+    const rows = tx
+      .delete(listItems)
+      .where(and(eq(listItems.listId, listId), eq(listItems.checked, 1)))
+      .returning({ id: listItems.id })
+      .all();
+    return rows.length;
+  });
+}

--- a/packages/app-lists/src/pages/ListDetailPage.tsx
+++ b/packages/app-lists/src/pages/ListDetailPage.tsx
@@ -4,24 +4,23 @@ import { useParams } from 'react-router';
 
 import { trpc } from '@pops/api-client';
 
-import { ListDeleteDialog } from './detail/ListDeleteDialog.js';
-import { ListDetailHeader } from './detail/ListDetailHeader.js';
-import { ListEditModal } from './detail/ListEditModal.js';
-import { ListItemAddForm } from './detail/ListItemAddForm.js';
-import { ListItemsSection } from './detail/ListItemsSection.js';
-import { useDetailMutations, type DetailMutations } from './detail/useDetailMutations.js';
-import { useItemMutations, type ItemMutations } from './detail/useItemMutations.js';
+import { ShoppingDetailContent } from './components/shopping/ShoppingDetailContent.js';
+import { GenericDetailContent } from './detail/GenericDetailContent.js';
+import { useDetailMutations } from './detail/useDetailMutations.js';
+import { useItemMutations } from './detail/useItemMutations.js';
 
-import type { ListItemRow, ListRow } from './detail/types.js';
+import type { DetailContentProps, DialogState } from './detail/detail-handlers.js';
 
 /**
- * `/lists/:id` — generic list detail page (PRD-140-C).
+ * `/lists/:id` — generic list detail page (PRD-140-C) with PRD-141's
+ * shopping dispatch.
  *
- * Renders any list kind via the kind-agnostic row component. Shopping-only
- * affordances (uncheck-all, clear-checked, sort) land in PRD-141 by
- * swapping the items section when `kind === 'shopping'`. The 60-second
- * background poll picks up concurrent edits from other tabs and from
- * food's "Send to shopping list" action (PRD-142).
+ * The page shell fetches `lists.list.get` (polling every 60s while
+ * visible) and owns the edit + delete dialog state. The body branches
+ * by `list.kind`: `shopping` → `ShoppingDetailContent` (sort dropdown,
+ * uncheck-all / clear-checked, denser rows, swipe-to-delete); every
+ * other kind → `GenericDetailContent`. Future kind-specific paths
+ * (todo, packing) layer in the same way without touching this file.
  */
 export function ListDetailPage(): ReactElement {
   const { id } = useParams<{ id: string }>();
@@ -30,15 +29,6 @@ export function ListDetailPage(): ReactElement {
     return <NotFoundShell />;
   }
   return <ListDetailBody listId={parsed} />;
-}
-
-interface DialogState {
-  editOpen: boolean;
-  deleteOpen: boolean;
-  openEdit: () => void;
-  closeEdit: () => void;
-  openDelete: () => void;
-  closeDelete: () => void;
 }
 
 function useDialogs(): DialogState {
@@ -74,132 +64,15 @@ function ListDetailBody({ listId }: { listId: number }): ReactElement {
     return <Status text={t('detail.error')} variant="error" />;
   }
 
-  return (
-    <DetailContent
-      list={query.data.list}
-      items={query.data.items}
-      detailMx={detailMx}
-      itemMx={itemMx}
-      dialogs={dialogs}
-    />
-  );
-}
-
-interface DetailContentProps {
-  list: ListRow;
-  items: readonly ListItemRow[];
-  detailMx: DetailMutations;
-  itemMx: ItemMutations;
-  dialogs: DialogState;
-}
-
-function useDetailHandlers({ list, detailMx, itemMx, dialogs }: DetailContentProps) {
-  // Each async handler swallows its rejection — failures already surface via
-  // the `detailMx.errorMessage` banner, so re-throwing here would only land
-  // in an unhandled promise rejection (Copilot R1).
-  return {
-    toggleChecked: (id: number, currentlyChecked: boolean) => {
-      if (currentlyChecked) itemMx.uncheck(id);
-      else itemMx.check(id);
-    },
-    archiveToggle: async () => {
-      try {
-        if (list.archivedAt === null) await detailMx.archive(list.id);
-        else await detailMx.unarchive(list.id);
-      } catch {
-        /* surfaced via errorMessage */
-      }
-    },
-    saveEdit: async (patch: { name: string; kind: typeof list.kind }) => {
-      try {
-        const result = await detailMx.update(list.id, patch);
-        if (result.ok) dialogs.closeEdit();
-      } catch {
-        /* surfaced via errorMessage */
-      }
-    },
-    confirmDelete: async () => {
-      try {
-        await detailMx.remove(list.id);
-      } catch {
-        /* surfaced via errorMessage */
-      }
-      dialogs.closeDelete();
-    },
+  const props: DetailContentProps = {
+    list: query.data.list,
+    items: query.data.items,
+    detailMx,
+    itemMx,
+    dialogs,
   };
-}
-
-function DetailContent(props: DetailContentProps): ReactElement {
-  const { list, items, detailMx, itemMx, dialogs } = props;
-  const h = useDetailHandlers(props);
-
-  return (
-    <div className="space-y-4 p-4 sm:p-6">
-      <ListDetailHeader
-        list={list}
-        onRename={dialogs.openEdit}
-        onChangeKind={dialogs.openEdit}
-        onArchiveToggle={() => void h.archiveToggle()}
-        onDelete={dialogs.openDelete}
-      />
-      <ErrorBanners detail={detailMx.errorMessage} item={itemMx.errorMessage} />
-      <ListItemsSection
-        items={items}
-        onToggleChecked={h.toggleChecked}
-        onSaveLabel={(id, label) => itemMx.update(id, { label })}
-        onReorder={itemMx.reorder}
-        onDelete={itemMx.remove}
-      />
-      <ListItemAddForm
-        isPending={itemMx.isAdding}
-        onAdd={async (input) => (await itemMx.add(input)) !== null}
-      />
-      {dialogs.editOpen ? (
-        <ListEditModal
-          list={list}
-          isSaving={detailMx.isUpdating}
-          onCancel={dialogs.closeEdit}
-          onSave={(patch) => void h.saveEdit(patch)}
-          onArchiveToggle={() => {
-            void h.archiveToggle();
-            dialogs.closeEdit();
-          }}
-        />
-      ) : null}
-      {dialogs.deleteOpen ? (
-        <ListDeleteDialog
-          name={list.name}
-          itemCount={items.length}
-          isPending={detailMx.isRemoving}
-          onCancel={dialogs.closeDelete}
-          onConfirm={() => void h.confirmDelete()}
-        />
-      ) : null}
-    </div>
-  );
-}
-
-function ErrorBanners({
-  detail,
-  item,
-}: {
-  detail: string | null;
-  item: string | null;
-}): ReactElement {
-  return (
-    <>
-      {detail !== null ? (
-        <p role="alert" className="text-sm text-destructive">
-          {detail}
-        </p>
-      ) : null}
-      {item !== null ? (
-        <p role="alert" className="text-sm text-destructive">
-          {item}
-        </p>
-      ) : null}
-    </>
-  );
+  if (props.list.kind === 'shopping') return <ShoppingDetailContent {...props} />;
+  return <GenericDetailContent {...props} />;
 }
 
 function Status({

--- a/packages/app-lists/src/pages/__tests__/ListDetailPage.test.tsx
+++ b/packages/app-lists/src/pages/__tests__/ListDetailPage.test.tsx
@@ -121,7 +121,11 @@ function makeList(overrides: Partial<ListRow> = {}): ListRow {
   return {
     id: 7,
     name: 'Weekend shop',
-    kind: 'shopping',
+    // PRD-141 dispatches `shopping` to the specialised body; the generic-path
+    // test suite uses `todo` so it keeps exercising `GenericDetailContent`.
+    // ShoppingDetailContent has its own RTL coverage in
+    // `components/shopping/__tests__/ShoppingDetailContent.test.tsx`.
+    kind: 'todo',
     ownerApp: 'user',
     archivedAt: null,
     createdAt: '2026-06-01T00:00:00Z',
@@ -192,7 +196,7 @@ describe('PRD-140-C — ListDetailPage', () => {
     });
     render(<Wrapper>{mountAt(7, <ListDetailPage />)}</Wrapper>);
     expect(screen.getByRole('heading', { name: 'Weekend shop' })).toBeInTheDocument();
-    expect(screen.getByTestId('list-kind-chip')).toHaveTextContent('Shopping');
+    expect(screen.getByTestId('list-kind-chip')).toHaveTextContent('Todo');
     expect(screen.getByTestId('list-item-1')).toBeInTheDocument();
     expect(screen.getByTestId('list-item-2')).toBeInTheDocument();
   });
@@ -282,7 +286,7 @@ describe('PRD-140-C — ListDetailPage', () => {
     await userEvent.type(nameInput, 'Sunday shop');
     await userEvent.click(screen.getByRole('button', { name: 'Save' }));
     expect(calls.update).toHaveBeenCalledWith(
-      expect.objectContaining({ id: 7, name: 'Sunday shop', kind: 'shopping' })
+      expect.objectContaining({ id: 7, name: 'Sunday shop', kind: 'todo' })
     );
     expect(dialog).not.toBeInTheDocument();
   });

--- a/packages/app-lists/src/pages/components/shopping/ClearCheckedDialog.tsx
+++ b/packages/app-lists/src/pages/components/shopping/ClearCheckedDialog.tsx
@@ -1,0 +1,66 @@
+import { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+
+/**
+ * Confirm dialog for PRD-141's "Clear checked" action. Same dialog shell
+ * as `UncheckAllDialog` — destructive variant of the confirm button.
+ */
+export interface ClearCheckedDialogProps {
+  checkedCount: number;
+  isPending: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+export function ClearCheckedDialog(props: ClearCheckedDialogProps) {
+  const { t } = useTranslation('lists');
+  const { onCancel } = props;
+
+  useEffect(() => {
+    const handle = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onCancel();
+    };
+    document.addEventListener('keydown', handle);
+    return () => document.removeEventListener('keydown', handle);
+  }, [onCancel]);
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="shopping-clear-checked-title"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onCancel();
+      }}
+    >
+      <div className="w-full max-w-md space-y-4 rounded-lg border bg-background p-6 shadow-lg">
+        <h2 id="shopping-clear-checked-title" className="text-lg font-semibold">
+          {t('shopping.clearChecked.title')}
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          {t('shopping.clearChecked.body', { count: props.checkedCount })}
+        </p>
+        <div className="flex justify-end gap-2 pt-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded-md border px-3 py-1.5 text-sm hover:bg-muted"
+          >
+            {t('shopping.clearChecked.cancel')}
+          </button>
+          <button
+            type="button"
+            onClick={props.onConfirm}
+            disabled={props.isPending}
+            className="rounded-md bg-destructive px-3 py-1.5 text-sm font-medium text-destructive-foreground hover:bg-destructive/90 disabled:opacity-50"
+          >
+            {props.isPending
+              ? t('shopping.clearChecked.pending')
+              : t('shopping.clearChecked.confirm')}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/app-lists/src/pages/components/shopping/ShoppingAddForm.tsx
+++ b/packages/app-lists/src/pages/components/shopping/ShoppingAddForm.tsx
@@ -1,0 +1,147 @@
+import { useRef, useState, type FormEvent } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { SHOPPING_UNIT_SUGGESTIONS } from './unit-suggestions.js';
+
+/**
+ * Shopping add form (PRD-141 §ShoppingAddForm).
+ *
+ * Differences vs the generic `ListItemAddForm`:
+ *   - `[qty] [unit] [label]` ordering (qty first — most common
+ *     starting point).
+ *   - Unit field is backed by a `<datalist>` of common units so the
+ *     mobile keyboard surfaces suggestions; free-text entry still works.
+ *   - On submit, focus returns to the qty field for fast multi-item
+ *     entry.
+ */
+export interface ShoppingAddFormProps {
+  isPending: boolean;
+  onAdd: (input: { label: string; qty: number | null; unit: string | null }) => Promise<boolean>;
+}
+
+interface FormState {
+  qty: string;
+  unit: string;
+  label: string;
+}
+
+const EMPTY_FORM: FormState = { qty: '', unit: '', label: '' };
+
+function parseForm(
+  state: FormState
+): { qty: number | null; unit: string | null; label: string } | null {
+  const label = state.label.trim();
+  if (label.length === 0) return null;
+  const qty = state.qty.trim().length === 0 ? null : Number(state.qty);
+  if (qty !== null && !Number.isFinite(qty)) return null;
+  const unit = state.unit.trim().length === 0 ? null : state.unit.trim();
+  return { qty, unit, label };
+}
+
+function useShoppingAddState(onAdd: ShoppingAddFormProps['onAdd']) {
+  const [state, setState] = useState<FormState>(EMPTY_FORM);
+  const qtyRef = useRef<HTMLInputElement>(null);
+  const submit = async () => {
+    const parsed = parseForm(state);
+    if (parsed === null) return;
+    const ok = await onAdd(parsed);
+    if (ok) {
+      setState(EMPTY_FORM);
+      qtyRef.current?.focus();
+    }
+  };
+  return { state, setState, qtyRef, submit };
+}
+
+export function ShoppingAddForm(props: ShoppingAddFormProps): React.ReactElement {
+  const { t } = useTranslation('lists');
+  const { state, setState, qtyRef, submit } = useShoppingAddState(props.onAdd);
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    void submit();
+  };
+  const disabled = props.isPending || state.label.trim().length === 0;
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="flex flex-wrap items-center gap-2 rounded-md border border-dashed p-3"
+    >
+      <QtyUnitInputs state={state} setState={setState} qtyRef={qtyRef} t={t} />
+      <LabelSubmit state={state} setState={setState} disabled={disabled} t={t} />
+    </form>
+  );
+}
+
+function QtyUnitInputs({
+  state,
+  setState,
+  qtyRef,
+  t,
+}: {
+  state: FormState;
+  setState: (next: FormState) => void;
+  qtyRef: React.RefObject<HTMLInputElement | null>;
+  t: (key: string) => string;
+}) {
+  return (
+    <>
+      <input
+        ref={qtyRef}
+        type="number"
+        inputMode="decimal"
+        step="any"
+        value={state.qty}
+        onChange={(e) => setState({ ...state, qty: e.target.value })}
+        placeholder={t('shopping.add.qty')}
+        aria-label={t('shopping.add.qty')}
+        className="w-20 rounded-md border bg-background px-2 py-2 text-sm"
+      />
+      <input
+        type="text"
+        list="shopping-unit-suggestions"
+        value={state.unit}
+        onChange={(e) => setState({ ...state, unit: e.target.value })}
+        placeholder={t('shopping.add.unit')}
+        aria-label={t('shopping.add.unit')}
+        className="w-24 rounded-md border bg-background px-2 py-2 text-sm"
+      />
+      <datalist id="shopping-unit-suggestions">
+        {SHOPPING_UNIT_SUGGESTIONS.map((value) => (
+          <option key={value} value={value} />
+        ))}
+      </datalist>
+    </>
+  );
+}
+
+function LabelSubmit({
+  state,
+  setState,
+  disabled,
+  t,
+}: {
+  state: FormState;
+  setState: (next: FormState) => void;
+  disabled: boolean;
+  t: (key: string) => string;
+}) {
+  return (
+    <>
+      <input
+        type="text"
+        value={state.label}
+        onChange={(e) => setState({ ...state, label: e.target.value })}
+        placeholder={t('shopping.add.label')}
+        aria-label={t('shopping.add.label')}
+        className="min-w-[8rem] flex-1 rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+      />
+      <button
+        type="submit"
+        disabled={disabled}
+        className="rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground disabled:opacity-50"
+      >
+        {t('shopping.add.submit')}
+      </button>
+    </>
+  );
+}

--- a/packages/app-lists/src/pages/components/shopping/ShoppingAddForm.tsx
+++ b/packages/app-lists/src/pages/components/shopping/ShoppingAddForm.tsx
@@ -133,7 +133,7 @@ function LabelSubmit({
         onChange={(e) => setState({ ...state, label: e.target.value })}
         placeholder={t('shopping.add.label')}
         aria-label={t('shopping.add.label')}
-        className="min-w-[8rem] flex-1 rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+        className="min-w-32 flex-1 rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
       />
       <button
         type="submit"

--- a/packages/app-lists/src/pages/components/shopping/ShoppingDetailContent.tsx
+++ b/packages/app-lists/src/pages/components/shopping/ShoppingDetailContent.tsx
@@ -1,0 +1,187 @@
+import { useState, type ReactElement } from 'react';
+
+import { useDetailHandlers, type DetailContentProps } from '../../detail/detail-handlers.js';
+import { ErrorBanners } from '../../detail/GenericDetailContent.js';
+import { ListDeleteDialog } from '../../detail/ListDeleteDialog.js';
+import { ListEditModal } from '../../detail/ListEditModal.js';
+import { ClearCheckedDialog } from './ClearCheckedDialog.js';
+import { ShoppingAddForm } from './ShoppingAddForm.js';
+import { ShoppingDetailHeader } from './ShoppingDetailHeader.js';
+import { ShoppingItemsSection } from './ShoppingItemsSection.js';
+import { UncheckAllDialog } from './UncheckAllDialog.js';
+import {
+  useShoppingBulkMutations,
+  type ShoppingBulkMutations,
+} from './useShoppingBulkMutations.js';
+import { useShoppingSort, type ShoppingSort } from './useShoppingSort.js';
+
+/**
+ * `/lists/:id` rendered for `kind === 'shopping'` (PRD-141). Composes the
+ * shopping header (sort dropdown + bulk actions), shopping items section
+ * (denser rows + drag-disabled when sort != Manual), and shopping add
+ * form on top of the same edit/delete dialogs used by the generic body
+ * (PRD-140-C — those modals are kind-agnostic).
+ */
+export function ShoppingDetailContent(props: DetailContentProps): ReactElement {
+  const { list, items, detailMx, itemMx } = props;
+  const h = useDetailHandlers(props);
+  const sort = useShoppingSort(items);
+  const bulk = useShoppingBulkMutations(list.id);
+  const [uncheckAllOpen, setUncheckAllOpen] = useState(false);
+  const [clearCheckedOpen, setClearCheckedOpen] = useState(false);
+
+  return (
+    <div className="space-y-4 p-4 sm:p-6">
+      <ShoppingHeaderRow
+        props={props}
+        sort={sort}
+        h={h}
+        onUncheckAll={() => setUncheckAllOpen(true)}
+        onClearChecked={() => setClearCheckedOpen(true)}
+      />
+      <ErrorBanners
+        detail={detailMx.errorMessage ?? bulk.errorMessage}
+        item={itemMx.errorMessage}
+      />
+      <ShoppingItemsSection
+        items={sort.sortedItems}
+        isDragDisabled={sort.isDragDisabled}
+        onToggleChecked={h.toggleChecked}
+        onSaveLabel={(id, label) => itemMx.update(id, { label })}
+        onReorder={itemMx.reorder}
+        onDelete={itemMx.remove}
+      />
+      <ShoppingAddForm
+        isPending={itemMx.isAdding}
+        onAdd={async (input) => (await itemMx.add(input)) !== null}
+      />
+      <ShoppingDialogs
+        props={props}
+        h={h}
+        bulk={bulk}
+        uncheckAllOpen={uncheckAllOpen}
+        clearCheckedOpen={clearCheckedOpen}
+        onCloseUncheckAll={() => setUncheckAllOpen(false)}
+        onCloseClearChecked={() => setClearCheckedOpen(false)}
+      />
+    </div>
+  );
+}
+
+function ShoppingHeaderRow({
+  props,
+  sort,
+  h,
+  onUncheckAll,
+  onClearChecked,
+}: {
+  props: DetailContentProps;
+  sort: ShoppingSort;
+  h: ReturnType<typeof useDetailHandlers>;
+  onUncheckAll: () => void;
+  onClearChecked: () => void;
+}) {
+  return (
+    <ShoppingDetailHeader
+      list={props.list}
+      items={props.items}
+      sortMode={sort.mode}
+      onSortChange={sort.setMode}
+      onUncheckAll={onUncheckAll}
+      onClearChecked={onClearChecked}
+      onRename={props.dialogs.openEdit}
+      onChangeKind={props.dialogs.openEdit}
+      onArchiveToggle={() => void h.archiveToggle()}
+      onDelete={props.dialogs.openDelete}
+    />
+  );
+}
+
+interface ShoppingDialogsProps {
+  props: DetailContentProps;
+  h: ReturnType<typeof useDetailHandlers>;
+  bulk: ShoppingBulkMutations;
+  uncheckAllOpen: boolean;
+  clearCheckedOpen: boolean;
+  onCloseUncheckAll: () => void;
+  onCloseClearChecked: () => void;
+}
+
+function ShoppingDialogs(args: ShoppingDialogsProps) {
+  const checkedCount = args.props.items.filter((row) => row.checked === 1).length;
+  return (
+    <>
+      <CoreModals args={args} />
+      <BulkConfirmModals args={args} checkedCount={checkedCount} />
+    </>
+  );
+}
+
+function CoreModals({ args }: { args: ShoppingDialogsProps }) {
+  const { props, h } = args;
+  const { list, items, detailMx, dialogs } = props;
+  if (dialogs.editOpen) {
+    return (
+      <ListEditModal
+        list={list}
+        isSaving={detailMx.isUpdating}
+        onCancel={dialogs.closeEdit}
+        onSave={(patch) => void h.saveEdit(patch)}
+        onArchiveToggle={() => {
+          void h.archiveToggle();
+          dialogs.closeEdit();
+        }}
+      />
+    );
+  }
+  if (dialogs.deleteOpen) {
+    return (
+      <ListDeleteDialog
+        name={list.name}
+        itemCount={items.length}
+        isPending={detailMx.isRemoving}
+        onCancel={dialogs.closeDelete}
+        onConfirm={() => void h.confirmDelete()}
+      />
+    );
+  }
+  return null;
+}
+
+function BulkConfirmModals({
+  args,
+  checkedCount,
+}: {
+  args: ShoppingDialogsProps;
+  checkedCount: number;
+}) {
+  const { bulk, uncheckAllOpen, clearCheckedOpen, onCloseUncheckAll, onCloseClearChecked } = args;
+  const onConfirmUncheckAll = async () => {
+    await bulk.uncheckAll();
+    onCloseUncheckAll();
+  };
+  const onConfirmClearChecked = async () => {
+    await bulk.removeChecked();
+    onCloseClearChecked();
+  };
+  return (
+    <>
+      {uncheckAllOpen ? (
+        <UncheckAllDialog
+          checkedCount={checkedCount}
+          isPending={bulk.isUnchecking}
+          onCancel={onCloseUncheckAll}
+          onConfirm={() => void onConfirmUncheckAll()}
+        />
+      ) : null}
+      {clearCheckedOpen ? (
+        <ClearCheckedDialog
+          checkedCount={checkedCount}
+          isPending={bulk.isRemoving}
+          onCancel={onCloseClearChecked}
+          onConfirm={() => void onConfirmClearChecked()}
+        />
+      ) : null}
+    </>
+  );
+}

--- a/packages/app-lists/src/pages/components/shopping/ShoppingDetailHeader.tsx
+++ b/packages/app-lists/src/pages/components/shopping/ShoppingDetailHeader.tsx
@@ -1,0 +1,79 @@
+import { useTranslation } from 'react-i18next';
+
+import { ListDetailHeader } from '../../detail/ListDetailHeader.js';
+import { ShoppingSortDropdown } from './ShoppingSortDropdown.js';
+
+import type { ListItemRow, ListRow } from '../../detail/types.js';
+import type { ShoppingSortMode } from './types.js';
+
+/**
+ * Shopping-specific header (PRD-141 §ShoppingDetailHeader). Wraps the
+ * generic `ListDetailHeader` so the title + kind chip + archived badge +
+ * three-dot Rename/Change kind/Archive/Delete menu render identically to
+ * the generic kind paths — then layers the shopping bulk-action row above
+ * (sort dropdown + Uncheck all + Clear checked + caption).
+ *
+ * The sort dropdown collapses to icon-only via `compact` on mobile (CSS
+ * controls the visibility classes); the bulk buttons get smaller padding
+ * but stay visible so the touch target remains usable.
+ */
+export interface ShoppingDetailHeaderProps {
+  list: ListRow;
+  items: readonly ListItemRow[];
+  sortMode: ShoppingSortMode;
+  onSortChange: (mode: ShoppingSortMode) => void;
+  onUncheckAll: () => void;
+  onClearChecked: () => void;
+  onRename: () => void;
+  onChangeKind: () => void;
+  onArchiveToggle: () => void;
+  onDelete: () => void;
+}
+
+export function ShoppingDetailHeader(props: ShoppingDetailHeaderProps) {
+  const { t } = useTranslation('lists');
+  const total = props.items.length;
+  const checked = props.items.filter((row) => row.checked === 1).length;
+  const hasChecked = checked > 0;
+
+  return (
+    <div className="space-y-3">
+      <ListDetailHeader
+        list={props.list}
+        onRename={props.onRename}
+        onChangeKind={props.onChangeKind}
+        onArchiveToggle={props.onArchiveToggle}
+        onDelete={props.onDelete}
+      />
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="hidden sm:block">
+          <ShoppingSortDropdown mode={props.sortMode} onChange={props.onSortChange} />
+        </div>
+        <div className="sm:hidden">
+          <ShoppingSortDropdown mode={props.sortMode} onChange={props.onSortChange} compact />
+        </div>
+        <button
+          type="button"
+          onClick={props.onUncheckAll}
+          disabled={!hasChecked}
+          title={hasChecked ? '' : t('shopping.header.uncheckAll.empty')}
+          className="rounded-md border px-3 py-1.5 text-sm hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {t('shopping.header.uncheckAll.button')}
+        </button>
+        <button
+          type="button"
+          onClick={props.onClearChecked}
+          disabled={!hasChecked}
+          title={hasChecked ? '' : t('shopping.header.clearChecked.empty')}
+          className="rounded-md border px-3 py-1.5 text-sm hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {t('shopping.header.clearChecked.button')}
+        </button>
+        <span className="ml-auto text-xs text-muted-foreground" data-testid="shopping-caption">
+          {t('shopping.header.caption', { total, checked })}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/packages/app-lists/src/pages/components/shopping/ShoppingItemRow.tsx
+++ b/packages/app-lists/src/pages/components/shopping/ShoppingItemRow.tsx
@@ -1,0 +1,162 @@
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { type KeyboardEvent } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { ListItemMenu } from '../../detail/ListItemMenu.js';
+import { ShoppingRowBody } from './ShoppingRowBody.js';
+import { SwipeDeleteAction } from './SwipeDeleteAction.js';
+import { useShoppingEdit } from './useShoppingEdit.js';
+import { useSwipeDelete } from './useSwipeDelete.js';
+
+import type { ListItemRow as ItemRow } from '../../detail/types.js';
+
+/**
+ * Shopping-tuned row (PRD-141 §ShoppingItemRow). 32×32px checkbox + 44×44
+ * hit area, always-visible qty/unit prefix, notes-as-subline, touch
+ * swipe-left to reveal an explicit Delete button, long-press drag handle
+ * (disabled when sort mode != Manual).
+ */
+export interface ShoppingItemRowProps {
+  row: ItemRow;
+  canMoveUp: boolean;
+  canMoveDown: boolean;
+  isDragDisabled: boolean;
+  onToggleChecked: (id: number, currentlyChecked: boolean) => void;
+  onSaveLabel: (id: number, label: string) => Promise<boolean>;
+  onMoveUp: (id: number) => void;
+  onMoveDown: (id: number) => void;
+  onDelete: (id: number) => void;
+}
+
+export function ShoppingItemRow(props: ShoppingItemRowProps): React.ReactElement {
+  const sortable = useSortable({ id: props.row.id, disabled: props.isDragDisabled });
+  const swipe = useSwipeDelete();
+  const edit = useShoppingEdit(props.row, props.onSaveLabel);
+  const isChecked = props.row.checked === 1;
+  const onLabelKey = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      void edit.commit();
+    } else if (e.key === 'Escape') edit.cancel();
+  };
+  const style = {
+    transform: CSS.Transform.toString(sortable.transform),
+    transition: sortable.transition,
+  };
+  return (
+    <li
+      ref={sortable.setNodeRef}
+      style={style}
+      data-testid={`shopping-item-${props.row.id}`}
+      onTouchStart={swipe.onTouchStart}
+      onTouchMove={swipe.onTouchMove}
+      onTouchEnd={swipe.onTouchEnd}
+      className={`relative flex min-h-11 items-center gap-3 rounded-md border bg-card p-2 ${
+        sortable.isDragging ? 'opacity-60 shadow-lg' : ''
+      }`}
+    >
+      <DragHandle sortable={sortable} disabled={props.isDragDisabled} />
+      <Checkbox row={props.row} isChecked={isChecked} onToggleChecked={props.onToggleChecked} />
+      <ShoppingRowBody row={props.row} isChecked={isChecked} edit={edit} onLabelKey={onLabelKey} />
+      <RowTrailing
+        canMoveUp={props.canMoveUp}
+        canMoveDown={props.canMoveDown}
+        swipeOpen={swipe.isOpen}
+        onSwipeReset={swipe.reset}
+        onEdit={edit.begin}
+        onMoveUp={() => props.onMoveUp(props.row.id)}
+        onMoveDown={() => props.onMoveDown(props.row.id)}
+        onDelete={() => props.onDelete(props.row.id)}
+      />
+    </li>
+  );
+}
+
+function DragHandle({
+  sortable,
+  disabled,
+}: {
+  sortable: ReturnType<typeof useSortable>;
+  disabled: boolean;
+}) {
+  const { t } = useTranslation('lists');
+  return (
+    <button
+      type="button"
+      className={`flex h-8 w-8 items-center justify-center text-muted-foreground hover:text-foreground ${
+        disabled ? 'cursor-not-allowed opacity-40' : 'cursor-grab'
+      }`}
+      aria-label={t('shopping.item.dragHandle')}
+      title={disabled ? t('shopping.item.dragDisabled') : t('shopping.item.dragHandle')}
+      disabled={disabled}
+      {...sortable.attributes}
+      {...sortable.listeners}
+    >
+      ⋮⋮
+    </button>
+  );
+}
+
+function Checkbox({
+  row,
+  isChecked,
+  onToggleChecked,
+}: {
+  row: ItemRow;
+  isChecked: boolean;
+  onToggleChecked: (id: number, currentlyChecked: boolean) => void;
+}) {
+  const { t } = useTranslation('lists');
+  return (
+    <input
+      type="checkbox"
+      checked={isChecked}
+      onChange={() => onToggleChecked(row.id, isChecked)}
+      className="h-8 w-8 cursor-pointer"
+      aria-label={t('shopping.item.checkbox', { label: row.label })}
+    />
+  );
+}
+
+function RowTrailing({
+  canMoveUp,
+  canMoveDown,
+  swipeOpen,
+  onSwipeReset,
+  onEdit,
+  onMoveUp,
+  onMoveDown,
+  onDelete,
+}: {
+  canMoveUp: boolean;
+  canMoveDown: boolean;
+  swipeOpen: boolean;
+  onSwipeReset: () => void;
+  onEdit: () => void;
+  onMoveUp: () => void;
+  onMoveDown: () => void;
+  onDelete: () => void;
+}) {
+  if (swipeOpen) {
+    return (
+      <SwipeDeleteAction
+        onCancel={onSwipeReset}
+        onDelete={() => {
+          onSwipeReset();
+          onDelete();
+        }}
+      />
+    );
+  }
+  return (
+    <ListItemMenu
+      canMoveUp={canMoveUp}
+      canMoveDown={canMoveDown}
+      onEdit={onEdit}
+      onMoveUp={onMoveUp}
+      onMoveDown={onMoveDown}
+      onDelete={onDelete}
+    />
+  );
+}

--- a/packages/app-lists/src/pages/components/shopping/ShoppingItemsSection.tsx
+++ b/packages/app-lists/src/pages/components/shopping/ShoppingItemsSection.tsx
@@ -1,0 +1,142 @@
+import {
+  closestCenter,
+  DndContext,
+  type DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  TouchSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { ShoppingItemRow } from './ShoppingItemRow.js';
+
+import type { ListItemRow as ItemRow } from '../../detail/types.js';
+
+/**
+ * DnD wrapper around the shopping item list. Mirrors PRD-140's generic
+ * `ListItemsSection` but renders `ShoppingItemRow` (the denser, swipe-aware
+ * row) and respects `isDragDisabled` from `useShoppingSort` so the drag
+ * gesture is suppressed when sort mode != Manual (PRD-141 §Edge Cases —
+ * drag in a non-Manual sort would visibly snap back).
+ */
+export interface ShoppingItemsSectionProps {
+  items: readonly ItemRow[];
+  isDragDisabled: boolean;
+  onToggleChecked: (id: number, currentlyChecked: boolean) => void;
+  onSaveLabel: (id: number, label: string) => Promise<boolean>;
+  onReorder: (orderedIds: readonly number[]) => Promise<boolean>;
+  onDelete: (id: number) => void;
+}
+
+function useReorderSensors() {
+  return useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 200, tolerance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  );
+}
+
+function useOrderedIds(items: readonly ItemRow[]) {
+  const [orderedIds, setOrderedIds] = useState<number[]>(() => items.map((r) => r.id));
+  useEffect(() => {
+    setOrderedIds(items.map((r) => r.id));
+  }, [items]);
+  return [orderedIds, setOrderedIds] as const;
+}
+
+export function ShoppingItemsSection(props: ShoppingItemsSectionProps): React.ReactElement {
+  const { t } = useTranslation('lists');
+  const [orderedIds, setOrderedIds] = useOrderedIds(props.items);
+  const sensors = useReorderSensors();
+
+  const fireReorder = useCallback(
+    async (next: number[]) => {
+      const previous = orderedIds;
+      setOrderedIds(next);
+      const ok = await props.onReorder(next);
+      if (!ok) setOrderedIds(previous);
+    },
+    [orderedIds, props, setOrderedIds]
+  );
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      if (props.isDragDisabled) return;
+      const { active, over } = event;
+      if (!over || active.id === over.id) return;
+      const oldIndex = orderedIds.indexOf(Number(active.id));
+      const newIndex = orderedIds.indexOf(Number(over.id));
+      if (oldIndex !== -1 && newIndex !== -1) {
+        void fireReorder(arrayMove(orderedIds, oldIndex, newIndex));
+      }
+    },
+    [fireReorder, orderedIds, props.isDragDisabled]
+  );
+
+  const moveBy = useCallback(
+    (id: number, delta: -1 | 1) => {
+      const index = orderedIds.indexOf(id);
+      if (index === -1) return;
+      const target = index + delta;
+      if (target >= 0 && target < orderedIds.length) {
+        void fireReorder(arrayMove(orderedIds, index, target));
+      }
+    },
+    [fireReorder, orderedIds]
+  );
+
+  if (props.items.length === 0) {
+    return (
+      <p className="rounded-md border border-dashed p-4 text-center text-sm text-muted-foreground">
+        {t('shopping.empty')}
+      </p>
+    );
+  }
+
+  return (
+    <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+      <SortableContext items={orderedIds} strategy={verticalListSortingStrategy}>
+        <RowList orderedIds={orderedIds} moveBy={moveBy} {...props} />
+      </SortableContext>
+    </DndContext>
+  );
+}
+
+interface RowListProps extends ShoppingItemsSectionProps {
+  orderedIds: number[];
+  moveBy: (id: number, delta: -1 | 1) => void;
+}
+
+function RowList(props: RowListProps): React.ReactElement {
+  const byId = new Map(props.items.map((r) => [r.id, r] as const));
+  const rows = props.orderedIds
+    .map((id) => byId.get(id))
+    .filter((row): row is ItemRow => row != null);
+  return (
+    <ul className="space-y-2" data-testid="shopping-items">
+      {rows.map((row, index) => (
+        <ShoppingItemRow
+          key={row.id}
+          row={row}
+          canMoveUp={index > 0}
+          canMoveDown={index < rows.length - 1}
+          isDragDisabled={props.isDragDisabled}
+          onToggleChecked={props.onToggleChecked}
+          onSaveLabel={props.onSaveLabel}
+          onMoveUp={(id) => props.moveBy(id, -1)}
+          onMoveDown={(id) => props.moveBy(id, 1)}
+          onDelete={props.onDelete}
+        />
+      ))}
+    </ul>
+  );
+}

--- a/packages/app-lists/src/pages/components/shopping/ShoppingRowBody.tsx
+++ b/packages/app-lists/src/pages/components/shopping/ShoppingRowBody.tsx
@@ -28,7 +28,7 @@ export function ShoppingRowBody(props: ShoppingRowBodyProps): React.ReactElement
     <div className="min-w-0 flex-1">
       <div className="flex items-baseline gap-2">
         <span
-          className={`min-w-[3.5rem] text-sm tabular-nums ${
+          className={`min-w-14 text-sm tabular-nums ${
             isChecked ? 'text-muted-foreground' : 'text-foreground'
           }`}
           data-testid="qty-unit"

--- a/packages/app-lists/src/pages/components/shopping/ShoppingRowBody.tsx
+++ b/packages/app-lists/src/pages/components/shopping/ShoppingRowBody.tsx
@@ -1,0 +1,85 @@
+import { type KeyboardEvent } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import type { ListItemRow as ItemRow } from '../../detail/types.js';
+
+/**
+ * Body of a `ShoppingItemRow` — qty/unit prefix (always visible per
+ * PRD-141 §ShoppingItemRow), inline label editor when active, and the
+ * notes-as-subline.
+ */
+export interface ShoppingRowBodyProps {
+  row: ItemRow;
+  isChecked: boolean;
+  edit: {
+    editing: boolean;
+    draft: string;
+    setDraft: (value: string) => void;
+    begin: () => void;
+    commit: () => Promise<void>;
+  };
+  onLabelKey: (e: KeyboardEvent<HTMLInputElement>) => void;
+}
+
+export function ShoppingRowBody(props: ShoppingRowBodyProps): React.ReactElement {
+  const { t } = useTranslation('lists');
+  const { row, isChecked, edit, onLabelKey } = props;
+  return (
+    <div className="min-w-0 flex-1">
+      <div className="flex items-baseline gap-2">
+        <span
+          className={`min-w-[3.5rem] text-sm tabular-nums ${
+            isChecked ? 'text-muted-foreground' : 'text-foreground'
+          }`}
+          data-testid="qty-unit"
+        >
+          {formatQtyUnit(row)}
+        </span>
+        {edit.editing ? (
+          <input
+            type="text"
+            value={edit.draft}
+            onChange={(e) => edit.setDraft(e.target.value)}
+            onBlur={() => void edit.commit()}
+            onKeyDown={onLabelKey}
+            className="flex-1 rounded border bg-background px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+            aria-label={t('shopping.item.editLabel')}
+            autoFocus
+          />
+        ) : (
+          <button
+            type="button"
+            onClick={edit.begin}
+            className={`flex-1 text-left text-sm ${
+              isChecked ? 'text-muted-foreground line-through opacity-60' : ''
+            }`}
+          >
+            {row.label}
+          </button>
+        )}
+      </div>
+      <Subline notes={row.notes} />
+    </div>
+  );
+}
+
+function Subline({ notes }: { notes: string | null }) {
+  if (notes === null || notes.length === 0) return null;
+  return (
+    <p className="truncate text-xs text-muted-foreground" title={notes}>
+      {notes}
+    </p>
+  );
+}
+
+function formatQtyUnit(row: ItemRow): string {
+  const qty = row.qty;
+  const unit = row.unit;
+  if (qty === null && unit === null) return '—';
+  const qtyText = qty === null ? '' : formatQty(qty);
+  return unit === null ? qtyText : `${qtyText} ${unit}`.trim();
+}
+
+function formatQty(qty: number): string {
+  return Number.isInteger(qty) ? String(qty) : qty.toFixed(2).replace(/\.?0+$/, '');
+}

--- a/packages/app-lists/src/pages/components/shopping/ShoppingSortDropdown.tsx
+++ b/packages/app-lists/src/pages/components/shopping/ShoppingSortDropdown.tsx
@@ -1,0 +1,44 @@
+import { useTranslation } from 'react-i18next';
+
+import { SHOPPING_SORT_MODES, type ShoppingSortMode } from './types.js';
+
+/**
+ * Native `<select>` for the sort mode (PRD-141 §Sort behaviours). Native is
+ * deliberate: zero deps + mobile OS picker UI + collapsing to an icon-only
+ * trigger when the container is narrow is a CSS concern, not a JS one.
+ */
+export interface ShoppingSortDropdownProps {
+  mode: ShoppingSortMode;
+  onChange: (mode: ShoppingSortMode) => void;
+  /**
+   * When true (mobile), the label is hidden visually but kept on a
+   * `sr-only` span so screen readers still announce the control.
+   */
+  compact?: boolean;
+}
+
+export function ShoppingSortDropdown(props: ShoppingSortDropdownProps) {
+  const { t } = useTranslation('lists');
+  const labelText = t('shopping.header.sort.label');
+
+  return (
+    <label className="flex items-center gap-2 text-sm">
+      <span className={props.compact === true ? 'sr-only' : 'text-muted-foreground'}>
+        {labelText}
+      </span>
+      <select
+        value={props.mode}
+        onChange={(e) => props.onChange(e.target.value as ShoppingSortMode)}
+        className="rounded-md border bg-background px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+        aria-label={labelText}
+        data-testid="shopping-sort-dropdown"
+      >
+        {SHOPPING_SORT_MODES.map((value) => (
+          <option key={value} value={value}>
+            {t(`shopping.header.sort.options.${value}`)}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}

--- a/packages/app-lists/src/pages/components/shopping/SwipeDeleteAction.tsx
+++ b/packages/app-lists/src/pages/components/shopping/SwipeDeleteAction.tsx
@@ -1,0 +1,33 @@
+import { useTranslation } from 'react-i18next';
+
+/**
+ * Swipe-revealed action pair (Cancel + Delete) for a shopping row.
+ * Extracted so `ShoppingItemRow` stays under the per-file lint cap and
+ * so the buttons can be unit-tested independently.
+ */
+export interface SwipeDeleteActionProps {
+  onCancel: () => void;
+  onDelete: () => void;
+}
+
+export function SwipeDeleteAction(props: SwipeDeleteActionProps): React.ReactElement {
+  const { t } = useTranslation('lists');
+  return (
+    <div className="flex gap-2" data-testid="swipe-actions">
+      <button
+        type="button"
+        onClick={props.onCancel}
+        className="rounded-md border px-3 py-1.5 text-xs"
+      >
+        {t('shopping.item.swipe.cancel')}
+      </button>
+      <button
+        type="button"
+        onClick={props.onDelete}
+        className="rounded-md bg-destructive px-3 py-1.5 text-xs font-medium text-destructive-foreground"
+      >
+        {t('shopping.item.swipe.delete')}
+      </button>
+    </div>
+  );
+}

--- a/packages/app-lists/src/pages/components/shopping/UncheckAllDialog.tsx
+++ b/packages/app-lists/src/pages/components/shopping/UncheckAllDialog.tsx
@@ -1,0 +1,65 @@
+import { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+
+/**
+ * Confirm dialog for PRD-141's "Uncheck all" action. Mirrors the
+ * generic `ListDeleteDialog` shape so the keyboard a11y model
+ * (Escape closes, outside-click closes) stays consistent.
+ */
+export interface UncheckAllDialogProps {
+  checkedCount: number;
+  isPending: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+export function UncheckAllDialog(props: UncheckAllDialogProps) {
+  const { t } = useTranslation('lists');
+  const { onCancel } = props;
+
+  useEffect(() => {
+    const handle = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onCancel();
+    };
+    document.addEventListener('keydown', handle);
+    return () => document.removeEventListener('keydown', handle);
+  }, [onCancel]);
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="shopping-uncheck-all-title"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onCancel();
+      }}
+    >
+      <div className="w-full max-w-md space-y-4 rounded-lg border bg-background p-6 shadow-lg">
+        <h2 id="shopping-uncheck-all-title" className="text-lg font-semibold">
+          {t('shopping.uncheckAll.title')}
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          {t('shopping.uncheckAll.body', { count: props.checkedCount })}
+        </p>
+        <div className="flex justify-end gap-2 pt-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded-md border px-3 py-1.5 text-sm hover:bg-muted"
+          >
+            {t('shopping.uncheckAll.cancel')}
+          </button>
+          <button
+            type="button"
+            onClick={props.onConfirm}
+            disabled={props.isPending}
+            className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+          >
+            {props.isPending ? t('shopping.uncheckAll.pending') : t('shopping.uncheckAll.confirm')}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/app-lists/src/pages/components/shopping/__tests__/ShoppingDetailContent.test.tsx
+++ b/packages/app-lists/src/pages/components/shopping/__tests__/ShoppingDetailContent.test.tsx
@@ -1,0 +1,269 @@
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createInstance } from 'i18next';
+import { useMemo, type ReactElement } from 'react';
+import { I18nextProvider, initReactI18next } from 'react-i18next';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import enAULists from '../../../../../../../apps/pops-shell/src/i18n/locales/en-AU/lists.json';
+
+import type { ListItemRow, ListRow } from '../../../detail/types.js';
+
+interface BulkCalls {
+  uncheckAll: ReturnType<typeof vi.fn>;
+  removeChecked: ReturnType<typeof vi.fn>;
+  update: ReturnType<typeof vi.fn>;
+}
+const bulk: BulkCalls = {
+  uncheckAll: vi.fn(),
+  removeChecked: vi.fn(),
+  update: vi.fn(),
+};
+const mockGet = vi.fn();
+
+let cachedData: { list: ListRow; items: ListItemRow[] } | null = null;
+
+vi.mock('@pops/api-client', () => {
+  const mkMutation = (impl: (args: unknown) => unknown) => ({
+    useMutation: () => ({
+      mutate: (args: unknown, opts?: { onSuccess?: () => void }) => {
+        impl(args);
+        opts?.onSuccess?.();
+      },
+      mutateAsync: async (args: unknown) => impl(args),
+      isPending: false,
+      error: null,
+    }),
+  });
+  return {
+    trpc: {
+      useUtils: () => ({
+        lists: {
+          list: {
+            get: {
+              invalidate: vi.fn(),
+              getData: () => cachedData,
+              setData: (_input: unknown, data: typeof cachedData) => {
+                cachedData = data;
+              },
+            },
+          },
+        },
+      }),
+      lists: {
+        list: {
+          get: { useQuery: (input: unknown) => mockGet(input) },
+          update: mkMutation((args) => {
+            bulk.update(args);
+            return { ok: true };
+          }),
+          archive: mkMutation(() => ({ ok: true })),
+          unarchive: mkMutation(() => ({ ok: true })),
+          delete: mkMutation(() => ({ ok: true })),
+        },
+        items: {
+          add: mkMutation(() => ({ id: 99, position: 5 })),
+          check: mkMutation(() => ({ ok: true, checkedAt: '2026-06-10T00:00:00Z' })),
+          uncheck: mkMutation(() => ({ ok: true })),
+          update: mkMutation(() => ({ ok: true })),
+          remove: mkMutation(() => ({ ok: true })),
+          reorder: mkMutation(() => ({ ok: true })),
+          uncheckAll: mkMutation((args) => {
+            bulk.uncheckAll(args);
+            return { ok: true, count: 2 };
+          }),
+          removeChecked: mkMutation((args) => {
+            bulk.removeChecked(args);
+            return { ok: true, removedCount: 2 };
+          }),
+        },
+      },
+    },
+  };
+});
+
+vi.mock('react-router', async (orig) => {
+  const actual = await orig<typeof import('react-router')>();
+  return { ...actual, useNavigate: () => vi.fn() };
+});
+
+import { ListDetailPage } from '../../../ListDetailPage.js';
+
+function makeList(overrides: Partial<ListRow> = {}): ListRow {
+  return {
+    id: 7,
+    name: 'Weekend shop',
+    kind: 'shopping',
+    ownerApp: 'user',
+    archivedAt: null,
+    createdAt: '2026-06-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function makeItem(overrides: Partial<ListItemRow> = {}): ListItemRow {
+  return {
+    id: 1,
+    listId: 7,
+    position: 0,
+    label: 'Apples',
+    qty: 2,
+    unit: 'kg',
+    refKind: 'free',
+    refId: null,
+    checked: 0,
+    checkedAt: null,
+    dueAt: null,
+    notes: null,
+    createdAt: '2026-06-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function mountAt(listId: number, children: ReactElement) {
+  return (
+    <MemoryRouter initialEntries={[`/lists/${listId}`]}>
+      <Routes>
+        <Route path="/lists/:id" element={children} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+function Wrapper({ children }: { children: ReactElement }): ReactElement {
+  const i18n = useMemo(() => {
+    const instance = createInstance();
+    void instance.use(initReactI18next).init({
+      lng: 'en-AU',
+      fallbackLng: 'en-AU',
+      ns: ['lists'],
+      defaultNS: 'lists',
+      interpolation: { escapeValue: false },
+      resources: { 'en-AU': { lists: enAULists } },
+    });
+    return instance;
+  }, []);
+  return <I18nextProvider i18n={i18n}>{children}</I18nextProvider>;
+}
+
+beforeEach(() => {
+  bulk.uncheckAll.mockReset();
+  bulk.removeChecked.mockReset();
+  bulk.update.mockReset();
+  mockGet.mockReset();
+  cachedData = null;
+});
+
+describe('PRD-141 — ShoppingDetailContent', () => {
+  it('renders the sort dropdown + caption + bulk buttons for kind=shopping', () => {
+    const data = {
+      list: makeList(),
+      items: [
+        makeItem(),
+        makeItem({ id: 2, label: 'Bread', checked: 1, checkedAt: '2026-06-09T00:00:00Z' }),
+      ],
+    };
+    cachedData = data;
+    mockGet.mockReturnValue({ isLoading: false, data, error: null });
+    render(<Wrapper>{mountAt(7, <ListDetailPage />)}</Wrapper>);
+    expect(screen.getAllByTestId('shopping-sort-dropdown').length).toBeGreaterThan(0);
+    expect(screen.getByTestId('shopping-caption')).toHaveTextContent(/2 items.*1 checked/i);
+    expect(screen.getByRole('button', { name: 'Uncheck all' })).not.toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Clear checked' })).not.toBeDisabled();
+  });
+
+  it('disables Uncheck all + Clear checked when nothing is checked', () => {
+    const data = { list: makeList(), items: [makeItem()] };
+    cachedData = data;
+    mockGet.mockReturnValue({ isLoading: false, data, error: null });
+    render(<Wrapper>{mountAt(7, <ListDetailPage />)}</Wrapper>);
+    expect(screen.getByRole('button', { name: 'Uncheck all' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Clear checked' })).toBeDisabled();
+  });
+
+  it('confirms uncheck-all and fires the mutation', async () => {
+    const data = {
+      list: makeList(),
+      items: [makeItem({ checked: 1, checkedAt: '2026-06-09T00:00:00Z' })],
+    };
+    cachedData = data;
+    mockGet.mockReturnValue({ isLoading: false, data, error: null });
+    render(<Wrapper>{mountAt(7, <ListDetailPage />)}</Wrapper>);
+    await userEvent.click(screen.getByRole('button', { name: 'Uncheck all' }));
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toBeInTheDocument();
+    await userEvent.click(within(dialog).getByRole('button', { name: /^uncheck all$/i }));
+    expect(bulk.uncheckAll).toHaveBeenCalledWith({ listId: 7 });
+  });
+
+  it('confirms clear-checked and fires the mutation', async () => {
+    const data = {
+      list: makeList(),
+      items: [makeItem({ checked: 1, checkedAt: '2026-06-09T00:00:00Z' })],
+    };
+    cachedData = data;
+    mockGet.mockReturnValue({ isLoading: false, data, error: null });
+    render(<Wrapper>{mountAt(7, <ListDetailPage />)}</Wrapper>);
+    await userEvent.click(screen.getByRole('button', { name: 'Clear checked' }));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: /remove checked/i }));
+    expect(bulk.removeChecked).toHaveBeenCalledWith({ listId: 7 });
+  });
+
+  it('changing sort to "unchecked-first" puts checked items at the bottom', async () => {
+    const data = {
+      list: makeList(),
+      items: [
+        makeItem({ id: 1, label: 'Apples', position: 0, checked: 1 }),
+        makeItem({ id: 2, label: 'Bread', position: 1, checked: 0 }),
+      ],
+    };
+    cachedData = data;
+    mockGet.mockReturnValue({ isLoading: false, data, error: null });
+    render(<Wrapper>{mountAt(7, <ListDetailPage />)}</Wrapper>);
+    const select = screen.getAllByTestId('shopping-sort-dropdown')[0];
+    if (!select) throw new Error('sort dropdown missing');
+    await userEvent.selectOptions(select, 'unchecked-first');
+    const ids = screen
+      .getAllByTestId(/^shopping-item-/)
+      .map((node) => node.getAttribute('data-testid'));
+    expect(ids[0]).toBe('shopping-item-2');
+    expect(ids[1]).toBe('shopping-item-1');
+  });
+
+  it('renders qty/unit always — dash for null', () => {
+    const data = {
+      list: makeList(),
+      items: [makeItem({ qty: null, unit: null, label: 'Eggs' })],
+    };
+    cachedData = data;
+    mockGet.mockReturnValue({ isLoading: false, data, error: null });
+    render(<Wrapper>{mountAt(7, <ListDetailPage />)}</Wrapper>);
+    expect(screen.getByTestId('qty-unit')).toHaveTextContent('—');
+  });
+
+  it('renders notes as the sub-line content', () => {
+    const data = {
+      list: makeList(),
+      items: [makeItem({ notes: 'From Brownies, Pancakes' })],
+    };
+    cachedData = data;
+    mockGet.mockReturnValue({ isLoading: false, data, error: null });
+    render(<Wrapper>{mountAt(7, <ListDetailPage />)}</Wrapper>);
+    expect(screen.getByText('From Brownies, Pancakes')).toBeInTheDocument();
+  });
+
+  it('submits via ShoppingAddForm with [qty][unit][label] order', async () => {
+    const data = { list: makeList(), items: [] };
+    cachedData = data;
+    mockGet.mockReturnValue({ isLoading: false, data, error: null });
+    render(<Wrapper>{mountAt(7, <ListDetailPage />)}</Wrapper>);
+    await userEvent.type(screen.getByLabelText('Qty'), '3');
+    await userEvent.type(screen.getByLabelText('Unit'), 'kg');
+    await userEvent.type(screen.getByLabelText('Item'), 'Onions');
+    await userEvent.click(screen.getByRole('button', { name: 'Add' }));
+    // The add form clears its inputs on success; qty regains focus.
+    expect((screen.getByLabelText('Qty') as HTMLInputElement).value).toBe('');
+  });
+});

--- a/packages/app-lists/src/pages/components/shopping/__tests__/useShoppingSort.test.ts
+++ b/packages/app-lists/src/pages/components/shopping/__tests__/useShoppingSort.test.ts
@@ -1,0 +1,63 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { useShoppingSort } from '../useShoppingSort.js';
+
+import type { ListItemRow } from '../../../detail/types.js';
+
+function row(overrides: Partial<ListItemRow>): ListItemRow {
+  return {
+    id: 0,
+    listId: 1,
+    position: 0,
+    label: 'x',
+    qty: null,
+    unit: null,
+    refKind: 'free',
+    refId: null,
+    checked: 0,
+    checkedAt: null,
+    dueAt: null,
+    notes: null,
+    createdAt: '2026-06-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('PRD-141 — useShoppingSort', () => {
+  const items: readonly ListItemRow[] = [
+    row({ id: 1, position: 0, checked: 1, checkedAt: '2026-06-02T00:00:00Z' }),
+    row({ id: 2, position: 1, checked: 0 }),
+    row({ id: 3, position: 2, checked: 1, checkedAt: '2026-06-03T00:00:00Z' }),
+  ];
+
+  it('defaults to manual + drag-enabled', () => {
+    const { result } = renderHook(() => useShoppingSort(items));
+    expect(result.current.mode).toBe('manual');
+    expect(result.current.isDragDisabled).toBe(false);
+    expect(result.current.sortedItems.map((r) => r.id)).toEqual([1, 2, 3]);
+  });
+
+  it('switches to unchecked-first ordering', () => {
+    const { result } = renderHook(() => useShoppingSort(items));
+    act(() => result.current.setMode('unchecked-first'));
+    expect(result.current.sortedItems.map((r) => r.id)).toEqual([2, 1, 3]);
+    expect(result.current.isDragDisabled).toBe(true);
+  });
+
+  it('switches to recent-check ordering (most recent first)', () => {
+    const { result } = renderHook(() => useShoppingSort(items));
+    act(() => result.current.setMode('recent-check'));
+    expect(result.current.sortedItems.map((r) => r.id)).toEqual([3, 1, 2]);
+  });
+
+  it('treats null checkedAt as oldest in recent-check', () => {
+    const sample: readonly ListItemRow[] = [
+      row({ id: 1, checked: 1, checkedAt: null }),
+      row({ id: 2, checked: 1, checkedAt: '2026-06-02T00:00:00Z' }),
+    ];
+    const { result } = renderHook(() => useShoppingSort(sample));
+    act(() => result.current.setMode('recent-check'));
+    expect(result.current.sortedItems.map((r) => r.id)).toEqual([2, 1]);
+  });
+});

--- a/packages/app-lists/src/pages/components/shopping/types.ts
+++ b/packages/app-lists/src/pages/components/shopping/types.ts
@@ -1,0 +1,25 @@
+import type { ListItemRow } from '../../detail/types.js';
+
+/**
+ * Client-side sort modes the shopping detail page exposes (PRD-141 §Sort
+ * behaviours). Sort is a render-time transform; the server keeps
+ * `position` as the canonical order so drag-to-reorder still works after
+ * switching back to Manual.
+ */
+export type ShoppingSortMode = 'manual' | 'unchecked-first' | 'recent-check';
+
+export const SHOPPING_SORT_MODES: readonly ShoppingSortMode[] = [
+  'manual',
+  'unchecked-first',
+  'recent-check',
+];
+
+export interface ShoppingItemHandlers {
+  onToggleChecked: (id: number, currentlyChecked: boolean) => void;
+  onSaveLabel: (id: number, label: string) => Promise<boolean>;
+  onMoveUp: (id: number) => void;
+  onMoveDown: (id: number) => void;
+  onDelete: (id: number) => void;
+}
+
+export type { ListItemRow };

--- a/packages/app-lists/src/pages/components/shopping/unit-suggestions.ts
+++ b/packages/app-lists/src/pages/components/shopping/unit-suggestions.ts
@@ -1,0 +1,16 @@
+/**
+ * Suggestions surfaced in the unit `<datalist>` for the shopping add form
+ * (PRD-141 §ShoppingAddForm). Free-text entry is still allowed; this list
+ * just speeds up the common cases. Kept short — long suggestion lists
+ * defeat the purpose on mobile.
+ */
+export const SHOPPING_UNIT_SUGGESTIONS: readonly string[] = [
+  'g',
+  'kg',
+  'ml',
+  'l',
+  'count',
+  'bunch',
+  'pack',
+  'box',
+];

--- a/packages/app-lists/src/pages/components/shopping/useShoppingBulkMutations.ts
+++ b/packages/app-lists/src/pages/components/shopping/useShoppingBulkMutations.ts
@@ -2,14 +2,13 @@ import { useCallback, useState } from 'react';
 
 import { trpc } from '@pops/api-client';
 
-import type { ListItemRow } from './types.js';
-
 /**
  * Optimistic wrappers for PRD-141's `uncheckAll` + `removeChecked`
- * mutations. Both use `utils.lists.list.get.setData` to patch the cached
- * detail payload before the server round-trip lands — same pattern the
- * PRD-140-C review recommended for `lists.items.check`. Rollback restores
- * the pre-mutation snapshot if the server rejects.
+ * mutations. Both use `utils.lists.list.get.setData`'s updater form to
+ * patch the cached detail payload before the server round-trip lands;
+ * `setData` infers the wire shape from the tRPC router so we don't need
+ * any structural casts. Rollback restores the pre-mutation snapshot if
+ * the server rejects.
  */
 export interface ShoppingBulkMutations {
   uncheckAll: () => Promise<{ ok: boolean; count: number }>;
@@ -20,34 +19,54 @@ export interface ShoppingBulkMutations {
   clearError: () => void;
 }
 
-interface CachedDetail {
-  list: { id: number; archivedAt: string | null } & Record<string, unknown>;
-  items: ListItemRow[];
-}
+type DetailQueryUtils = ReturnType<typeof trpc.useUtils>['lists']['list']['get'];
+type DetailSnapshot = ReturnType<DetailQueryUtils['getData']>;
 
 function useCache(listId: number) {
   const utils = trpc.useUtils();
-  const snapshot = useCallback((): CachedDetail | undefined => {
-    const data = utils.lists.list.get.getData({ id: listId });
-    return data === null ? undefined : (data as unknown as CachedDetail | undefined);
-  }, [listId, utils]);
-  const setCache = useCallback(
-    (next: CachedDetail) => {
-      utils.lists.list.get.setData({ id: listId }, next as unknown as never);
-    },
-    [listId, utils]
-  );
+  const get = utils.lists.list.get;
+  const snapshot = useCallback((): DetailSnapshot => get.getData({ id: listId }), [get, listId]);
   const restore = useCallback(
-    (previous: CachedDetail | undefined) => {
-      if (previous !== undefined) setCache(previous);
+    (previous: DetailSnapshot) => {
+      if (previous !== undefined) get.setData({ id: listId }, previous);
     },
-    [setCache]
+    [get, listId]
   );
-  const invalidate = useCallback(
-    () => utils.lists.list.get.invalidate({ id: listId }),
-    [listId, utils]
+  const update = useCallback(
+    (mapItem: (item: ItemOf<DetailSnapshot>) => ItemOf<DetailSnapshot>): void => {
+      get.setData({ id: listId }, (prev) => mapDetail(prev, mapItem));
+    },
+    [get, listId]
   );
-  return { snapshot, setCache, restore, invalidate };
+  const filter = useCallback(
+    (predicate: (item: ItemOf<DetailSnapshot>) => boolean): void => {
+      get.setData({ id: listId }, (prev) => filterDetail(prev, predicate));
+    },
+    [get, listId]
+  );
+  const invalidate = useCallback(() => get.invalidate({ id: listId }), [get, listId]);
+  return { snapshot, restore, update, filter, invalidate };
+}
+
+type NonNullPayload = Exclude<DetailSnapshot, null | undefined>;
+type ItemOf<T> = T extends { items: readonly (infer U)[] } ? U : never;
+
+function mapDetail(
+  prev: DetailSnapshot,
+  mapItem: (item: ItemOf<DetailSnapshot>) => ItemOf<DetailSnapshot>
+): DetailSnapshot {
+  if (prev === undefined || prev === null) return prev;
+  const next: NonNullPayload = { ...prev, items: prev.items.map(mapItem) };
+  return next;
+}
+
+function filterDetail(
+  prev: DetailSnapshot,
+  predicate: (item: ItemOf<DetailSnapshot>) => boolean
+): DetailSnapshot {
+  if (prev === undefined || prev === null) return prev;
+  const next: NonNullPayload = { ...prev, items: prev.items.filter(predicate) };
+  return next;
 }
 
 export function useShoppingBulkMutations(listId: number): ShoppingBulkMutations {
@@ -58,59 +77,38 @@ export function useShoppingBulkMutations(listId: number): ShoppingBulkMutations 
   const uncheckMx = trpc.lists.items.uncheckAll.useMutation(handler);
   const removeMx = trpc.lists.items.removeChecked.useMutation(handler);
 
-  const uncheckAll = useCallback(
-    () => runWithRollback(cache, () => uncheckMx.mutateAsync({ listId }), uncheckedPatch, 'count'),
-    [cache, listId, uncheckMx]
-  );
-  const removeChecked = useCallback(
-    () =>
-      runWithRollback(cache, () => removeMx.mutateAsync({ listId }), removedPatch, 'removedCount'),
-    [cache, listId, removeMx]
-  );
+  const uncheckAll = useCallback(async () => {
+    const previous = cache.snapshot();
+    cache.update((row) => (row.checked === 1 ? { ...row, checked: 0, checkedAt: null } : row));
+    try {
+      const result = await uncheckMx.mutateAsync({ listId });
+      await cache.invalidate();
+      return { ok: true, count: result.count };
+    } catch {
+      cache.restore(previous);
+      return { ok: false, count: 0 };
+    }
+  }, [cache, listId, uncheckMx]);
+
+  const removeChecked = useCallback(async () => {
+    const previous = cache.snapshot();
+    cache.filter((row) => row.checked !== 1);
+    try {
+      const result = await removeMx.mutateAsync({ listId });
+      await cache.invalidate();
+      return { ok: true, removedCount: result.removedCount };
+    } catch {
+      cache.restore(previous);
+      return { ok: false, removedCount: 0 };
+    }
+  }, [cache, listId, removeMx]);
 
   return {
-    uncheckAll: uncheckAll as ShoppingBulkMutations['uncheckAll'],
+    uncheckAll,
     isUnchecking: uncheckMx.isPending,
-    removeChecked: removeChecked as ShoppingBulkMutations['removeChecked'],
+    removeChecked,
     isRemoving: removeMx.isPending,
     errorMessage,
     clearError,
-  };
-}
-
-type CacheHandles = ReturnType<typeof useCache>;
-
-async function runWithRollback<K extends 'count' | 'removedCount'>(
-  cache: CacheHandles,
-  call: () => Promise<{ ok: true; count?: number; removedCount?: number }>,
-  patch: (previous: CachedDetail) => CachedDetail,
-  resultKey: K
-): Promise<{ ok: boolean } & Record<K, number>> {
-  const previous = cache.snapshot();
-  if (previous !== undefined) cache.setCache(patch(previous));
-  try {
-    const result = await call();
-    await cache.invalidate();
-    const value = resultKey === 'count' ? (result.count ?? 0) : (result.removedCount ?? 0);
-    return { ok: true, [resultKey]: value } as { ok: boolean } & Record<K, number>;
-  } catch {
-    cache.restore(previous);
-    return { ok: false, [resultKey]: 0 } as { ok: boolean } & Record<K, number>;
-  }
-}
-
-function uncheckedPatch(previous: CachedDetail): CachedDetail {
-  return {
-    ...previous,
-    items: previous.items.map((row) =>
-      row.checked === 1 ? { ...row, checked: 0, checkedAt: null } : row
-    ),
-  };
-}
-
-function removedPatch(previous: CachedDetail): CachedDetail {
-  return {
-    ...previous,
-    items: previous.items.filter((row) => row.checked !== 1),
   };
 }

--- a/packages/app-lists/src/pages/components/shopping/useShoppingBulkMutations.ts
+++ b/packages/app-lists/src/pages/components/shopping/useShoppingBulkMutations.ts
@@ -1,0 +1,116 @@
+import { useCallback, useState } from 'react';
+
+import { trpc } from '@pops/api-client';
+
+import type { ListItemRow } from './types.js';
+
+/**
+ * Optimistic wrappers for PRD-141's `uncheckAll` + `removeChecked`
+ * mutations. Both use `utils.lists.list.get.setData` to patch the cached
+ * detail payload before the server round-trip lands — same pattern the
+ * PRD-140-C review recommended for `lists.items.check`. Rollback restores
+ * the pre-mutation snapshot if the server rejects.
+ */
+export interface ShoppingBulkMutations {
+  uncheckAll: () => Promise<{ ok: boolean; count: number }>;
+  isUnchecking: boolean;
+  removeChecked: () => Promise<{ ok: boolean; removedCount: number }>;
+  isRemoving: boolean;
+  errorMessage: string | null;
+  clearError: () => void;
+}
+
+interface CachedDetail {
+  list: { id: number; archivedAt: string | null } & Record<string, unknown>;
+  items: ListItemRow[];
+}
+
+function useCache(listId: number) {
+  const utils = trpc.useUtils();
+  const snapshot = useCallback((): CachedDetail | undefined => {
+    const data = utils.lists.list.get.getData({ id: listId });
+    return data === null ? undefined : (data as unknown as CachedDetail | undefined);
+  }, [listId, utils]);
+  const setCache = useCallback(
+    (next: CachedDetail) => {
+      utils.lists.list.get.setData({ id: listId }, next as unknown as never);
+    },
+    [listId, utils]
+  );
+  const restore = useCallback(
+    (previous: CachedDetail | undefined) => {
+      if (previous !== undefined) setCache(previous);
+    },
+    [setCache]
+  );
+  const invalidate = useCallback(
+    () => utils.lists.list.get.invalidate({ id: listId }),
+    [listId, utils]
+  );
+  return { snapshot, setCache, restore, invalidate };
+}
+
+export function useShoppingBulkMutations(listId: number): ShoppingBulkMutations {
+  const cache = useCache(listId);
+  const [errorMessage, setError] = useState<string | null>(null);
+  const clearError = useCallback(() => setError(null), []);
+  const handler = { onError: (err: { message: string }) => setError(err.message) };
+  const uncheckMx = trpc.lists.items.uncheckAll.useMutation(handler);
+  const removeMx = trpc.lists.items.removeChecked.useMutation(handler);
+
+  const uncheckAll = useCallback(
+    () => runWithRollback(cache, () => uncheckMx.mutateAsync({ listId }), uncheckedPatch, 'count'),
+    [cache, listId, uncheckMx]
+  );
+  const removeChecked = useCallback(
+    () =>
+      runWithRollback(cache, () => removeMx.mutateAsync({ listId }), removedPatch, 'removedCount'),
+    [cache, listId, removeMx]
+  );
+
+  return {
+    uncheckAll: uncheckAll as ShoppingBulkMutations['uncheckAll'],
+    isUnchecking: uncheckMx.isPending,
+    removeChecked: removeChecked as ShoppingBulkMutations['removeChecked'],
+    isRemoving: removeMx.isPending,
+    errorMessage,
+    clearError,
+  };
+}
+
+type CacheHandles = ReturnType<typeof useCache>;
+
+async function runWithRollback<K extends 'count' | 'removedCount'>(
+  cache: CacheHandles,
+  call: () => Promise<{ ok: true; count?: number; removedCount?: number }>,
+  patch: (previous: CachedDetail) => CachedDetail,
+  resultKey: K
+): Promise<{ ok: boolean } & Record<K, number>> {
+  const previous = cache.snapshot();
+  if (previous !== undefined) cache.setCache(patch(previous));
+  try {
+    const result = await call();
+    await cache.invalidate();
+    const value = resultKey === 'count' ? (result.count ?? 0) : (result.removedCount ?? 0);
+    return { ok: true, [resultKey]: value } as { ok: boolean } & Record<K, number>;
+  } catch {
+    cache.restore(previous);
+    return { ok: false, [resultKey]: 0 } as { ok: boolean } & Record<K, number>;
+  }
+}
+
+function uncheckedPatch(previous: CachedDetail): CachedDetail {
+  return {
+    ...previous,
+    items: previous.items.map((row) =>
+      row.checked === 1 ? { ...row, checked: 0, checkedAt: null } : row
+    ),
+  };
+}
+
+function removedPatch(previous: CachedDetail): CachedDetail {
+  return {
+    ...previous,
+    items: previous.items.filter((row) => row.checked !== 1),
+  };
+}

--- a/packages/app-lists/src/pages/components/shopping/useShoppingEdit.ts
+++ b/packages/app-lists/src/pages/components/shopping/useShoppingEdit.ts
@@ -1,0 +1,40 @@
+import { useState } from 'react';
+
+import type { ListItemRow } from '../../detail/types.js';
+
+/**
+ * Inline-edit state for a shopping row's label. Mirrors the generic
+ * `ListItemRow`'s inline editor: click → editor visible, Enter commits,
+ * Esc cancels, blur commits.
+ */
+export interface ShoppingEdit {
+  editing: boolean;
+  draft: string;
+  setDraft: (value: string) => void;
+  begin: () => void;
+  cancel: () => void;
+  commit: () => Promise<void>;
+}
+
+export function useShoppingEdit(
+  row: ListItemRow,
+  onSave: (id: number, label: string) => Promise<boolean>
+): ShoppingEdit {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(row.label);
+  const begin = () => {
+    setDraft(row.label);
+    setEditing(true);
+  };
+  const cancel = () => setEditing(false);
+  const commit = async () => {
+    const trimmed = draft.trim();
+    if (trimmed.length === 0 || trimmed === row.label) {
+      setEditing(false);
+      return;
+    }
+    const ok = await onSave(row.id, trimmed);
+    if (ok) setEditing(false);
+  };
+  return { editing, draft, setDraft, begin, cancel, commit };
+}

--- a/packages/app-lists/src/pages/components/shopping/useShoppingSort.ts
+++ b/packages/app-lists/src/pages/components/shopping/useShoppingSort.ts
@@ -1,0 +1,57 @@
+import { useMemo, useState } from 'react';
+
+import type { ListItemRow, ShoppingSortMode } from './types.js';
+
+/**
+ * Owns the client-side sort state for a shopping list and projects the
+ * underlying items into the order the UI should render. Sort is **never**
+ * persisted — fresh page load defaults to Manual (PRD-141 §Sort behaviours).
+ *
+ * `sortedItems` is memoised so the items section's identity-sensitive
+ * downstream (DnD ordered ids, optimistic updates) doesn't churn unless the
+ * source data or sort mode changes.
+ */
+export interface ShoppingSort {
+  mode: ShoppingSortMode;
+  setMode: (mode: ShoppingSortMode) => void;
+  sortedItems: readonly ListItemRow[];
+  /** Drag-to-reorder is disabled unless `mode === 'manual'` (PRD-141 §Edge Cases). */
+  isDragDisabled: boolean;
+}
+
+export function useShoppingSort(items: readonly ListItemRow[]): ShoppingSort {
+  const [mode, setMode] = useState<ShoppingSortMode>('manual');
+
+  const sortedItems = useMemo(() => projectByMode(items, mode), [items, mode]);
+
+  return { mode, setMode, sortedItems, isDragDisabled: mode !== 'manual' };
+}
+
+function projectByMode(
+  items: readonly ListItemRow[],
+  mode: ShoppingSortMode
+): readonly ListItemRow[] {
+  switch (mode) {
+    case 'manual':
+      return items;
+    case 'unchecked-first':
+      return [...items].toSorted((a, b) => {
+        if (a.checked !== b.checked) return a.checked - b.checked;
+        return a.position - b.position;
+      });
+    case 'recent-check':
+      return [...items].toSorted((a, b) => {
+        if (a.checked !== b.checked) return b.checked - a.checked;
+        return checkedAtComparator(a.checkedAt, b.checkedAt);
+      });
+    default:
+      return items;
+  }
+}
+
+function checkedAtComparator(left: string | null, right: string | null): number {
+  if (left === right) return 0;
+  if (left === null) return 1;
+  if (right === null) return -1;
+  return right.localeCompare(left);
+}

--- a/packages/app-lists/src/pages/components/shopping/useSwipeDelete.ts
+++ b/packages/app-lists/src/pages/components/shopping/useSwipeDelete.ts
@@ -1,0 +1,64 @@
+import { useCallback, useState, type TouchEvent } from 'react';
+
+/**
+ * Lightweight swipe-left-to-reveal-delete state for touch devices
+ * (PRD-141 §ShoppingItemRow). The PRD calls out that swipe should NOT
+ * trigger deletion on its own — single-stroke gestures don't delete to
+ * prevent accidents. The user has to explicitly tap the revealed Delete
+ * button.
+ *
+ * Threshold + axis-lock match the conventions Android Material List rows
+ * use: trigger only on a primarily-horizontal drag of 48px+ left. Vertical
+ * scrolls are ignored so the page still scrolls through the list normally.
+ */
+export interface SwipeDeleteState {
+  isOpen: boolean;
+  reset: () => void;
+  onTouchStart: (e: TouchEvent<HTMLElement>) => void;
+  onTouchMove: (e: TouchEvent<HTMLElement>) => void;
+  onTouchEnd: () => void;
+}
+
+const SWIPE_THRESHOLD_PX = 48;
+
+export function useSwipeDelete(): SwipeDeleteState {
+  const [isOpen, setOpen] = useState(false);
+  const [start, setStart] = useState<{ x: number; y: number } | null>(null);
+  const [axisLocked, setAxisLocked] = useState<'x' | 'y' | null>(null);
+
+  const reset = useCallback(() => {
+    setOpen(false);
+    setStart(null);
+    setAxisLocked(null);
+  }, []);
+
+  const onTouchStart = useCallback((e: TouchEvent<HTMLElement>) => {
+    const touch = e.touches[0];
+    if (touch === undefined) return;
+    setStart({ x: touch.clientX, y: touch.clientY });
+    setAxisLocked(null);
+  }, []);
+
+  const onTouchMove = useCallback(
+    (e: TouchEvent<HTMLElement>) => {
+      if (start === null) return;
+      const touch = e.touches[0];
+      if (touch === undefined) return;
+      const dx = touch.clientX - start.x;
+      const dy = touch.clientY - start.y;
+      if (axisLocked === null && Math.max(Math.abs(dx), Math.abs(dy)) >= 8) {
+        setAxisLocked(Math.abs(dx) > Math.abs(dy) ? 'x' : 'y');
+      }
+      if (axisLocked === 'x' && dx <= -SWIPE_THRESHOLD_PX) setOpen(true);
+      if (axisLocked === 'x' && dx >= 0) setOpen(false);
+    },
+    [axisLocked, start]
+  );
+
+  const onTouchEnd = useCallback(() => {
+    setStart(null);
+    setAxisLocked(null);
+  }, []);
+
+  return { isOpen, reset, onTouchStart, onTouchMove, onTouchEnd };
+}

--- a/packages/app-lists/src/pages/detail/GenericDetailContent.tsx
+++ b/packages/app-lists/src/pages/detail/GenericDetailContent.tsx
@@ -1,0 +1,87 @@
+import { type ReactElement } from 'react';
+
+import { useDetailHandlers, type DetailContentProps } from './detail-handlers.js';
+import { ListDeleteDialog } from './ListDeleteDialog.js';
+import { ListDetailHeader } from './ListDetailHeader.js';
+import { ListEditModal } from './ListEditModal.js';
+import { ListItemAddForm } from './ListItemAddForm.js';
+import { ListItemsSection } from './ListItemsSection.js';
+
+/**
+ * Generic kind path for `/lists/:id` — every kind that isn't `shopping`
+ * (PRD-141 dispatches `shopping` to its specialised content). Owns the
+ * page body, the edit + delete dialogs, and the error banners shared
+ * with the shopping path.
+ */
+export function GenericDetailContent(props: DetailContentProps): ReactElement {
+  const { list, items, detailMx, itemMx, dialogs } = props;
+  const h = useDetailHandlers(props);
+
+  return (
+    <div className="space-y-4 p-4 sm:p-6">
+      <ListDetailHeader
+        list={list}
+        onRename={dialogs.openEdit}
+        onChangeKind={dialogs.openEdit}
+        onArchiveToggle={() => void h.archiveToggle()}
+        onDelete={dialogs.openDelete}
+      />
+      <ErrorBanners detail={detailMx.errorMessage} item={itemMx.errorMessage} />
+      <ListItemsSection
+        items={items}
+        onToggleChecked={h.toggleChecked}
+        onSaveLabel={(id, label) => itemMx.update(id, { label })}
+        onReorder={itemMx.reorder}
+        onDelete={itemMx.remove}
+      />
+      <ListItemAddForm
+        isPending={itemMx.isAdding}
+        onAdd={async (input) => (await itemMx.add(input)) !== null}
+      />
+      {dialogs.editOpen ? (
+        <ListEditModal
+          list={list}
+          isSaving={detailMx.isUpdating}
+          onCancel={dialogs.closeEdit}
+          onSave={(patch) => void h.saveEdit(patch)}
+          onArchiveToggle={() => {
+            void h.archiveToggle();
+            dialogs.closeEdit();
+          }}
+        />
+      ) : null}
+      {dialogs.deleteOpen ? (
+        <ListDeleteDialog
+          name={list.name}
+          itemCount={items.length}
+          isPending={detailMx.isRemoving}
+          onCancel={dialogs.closeDelete}
+          onConfirm={() => void h.confirmDelete()}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+export function ErrorBanners({
+  detail,
+  item,
+}: {
+  detail: string | null;
+  item: string | null;
+}): ReactElement {
+  return (
+    <>
+      {detail !== null ? (
+        <p role="alert" className="text-sm text-destructive">
+          {detail}
+        </p>
+      ) : null}
+      {item !== null ? (
+        <p role="alert" className="text-sm text-destructive">
+          {item}
+        </p>
+      ) : null}
+    </>
+  );
+}

--- a/packages/app-lists/src/pages/detail/detail-handlers.ts
+++ b/packages/app-lists/src/pages/detail/detail-handlers.ts
@@ -1,0 +1,63 @@
+import type { ListItemRow, ListRow } from './types.js';
+import type { DetailMutations } from './useDetailMutations.js';
+import type { ItemMutations } from './useItemMutations.js';
+
+/**
+ * Shared dialog state + DetailContent prop shape consumed by both the
+ * generic and shopping detail bodies.
+ */
+export interface DialogState {
+  editOpen: boolean;
+  deleteOpen: boolean;
+  openEdit: () => void;
+  closeEdit: () => void;
+  openDelete: () => void;
+  closeDelete: () => void;
+}
+
+export interface DetailContentProps {
+  list: ListRow;
+  items: readonly ListItemRow[];
+  detailMx: DetailMutations;
+  itemMx: ItemMutations;
+  dialogs: DialogState;
+}
+
+/**
+ * Detail-page-level action handlers wrapping the list mutations. Each
+ * async handler swallows its rejection — failures already surface via
+ * the `detailMx.errorMessage` banner, so re-throwing here would only
+ * land in an unhandled promise rejection (PRD-140-C Copilot R1).
+ */
+export function useDetailHandlers({ list, detailMx, dialogs, itemMx }: DetailContentProps) {
+  return {
+    toggleChecked: (id: number, currentlyChecked: boolean) => {
+      if (currentlyChecked) itemMx.uncheck(id);
+      else itemMx.check(id);
+    },
+    archiveToggle: async () => {
+      try {
+        if (list.archivedAt === null) await detailMx.archive(list.id);
+        else await detailMx.unarchive(list.id);
+      } catch {
+        /* surfaced via errorMessage */
+      }
+    },
+    saveEdit: async (patch: { name: string; kind: typeof list.kind }) => {
+      try {
+        const result = await detailMx.update(list.id, patch);
+        if (result.ok) dialogs.closeEdit();
+      } catch {
+        /* surfaced via errorMessage */
+      }
+    },
+    confirmDelete: async () => {
+      try {
+        await detailMx.remove(list.id);
+      } catch {
+        /* surfaced via errorMessage */
+      }
+      dialogs.closeDelete();
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- Layers PRD-141's shopping specialisation on top of PRD-140-C's now-live detail page. `ListDetailPage` dispatches by `list.kind`: `shopping` → new `ShoppingDetailContent`, other kinds → the existing `GenericDetailContent` (extracted from the inline body for the dispatch).
- Backend (PRD-140 router extension declared in PRD-141): two new procedures on `lists.items` — `uncheckAll` (single UPDATE, returns `{ ok, count }`) and `removeChecked` (single DELETE, returns `{ ok, removedCount }`). Backed by `uncheckAllItems(listId)` + `removeCheckedItems(listId)` services in `@pops/app-lists-db`. Each runs inside a transaction and returns the affected row count.
- Frontend additions under `packages/app-lists/src/pages/components/shopping/`: `ShoppingDetailHeader` (sort dropdown + Uncheck all + Clear checked + caption `"N items · M checked"`; sort collapses to icon-only on `< sm`), `ShoppingItemRow` (32×32 checkbox + always-visible qty/unit prefix + notes-as-subline + swipe-left-to-reveal-Delete on touch + long-press drag), `ShoppingItemsSection` (DnD wrapper + disables drag when sort != Manual), `ShoppingAddForm` (`[qty][unit][label]` order + `<datalist>` unit suggestions + focus returns to qty for fast multi-item entry), `UncheckAllDialog` + `ClearCheckedDialog` (confirms with PRD's exact wording).
- Optimistic updates for both bulk mutations: `useShoppingBulkMutations` snapshots the `lists.list.get` cache, patches it (uncheckAll flips checked→0/checkedAt→null; removeChecked filters checked rows out), then invalidates on success / restores on failure. True optimistic per the PRD-140-C Copilot R1 lesson.
- Client-side sort modes (`Manual` / `Unchecked first` / `Recently checked`) live in `useShoppingSort`; session-local only (PRD §Business Rules). Drag is disabled when sort != Manual so the gesture isn't surprising (PRD §Edge Cases).

### i18n

- new `shopping.*` namespace added to `apps/pops-shell/src/i18n/locales/{en-AU,pt-BR}/lists.json` (header, sort options, dialogs, item labels, swipe action labels).

### Refactor for the dispatch

- Extracted the existing inline detail body into `pages/detail/GenericDetailContent.tsx`; shared `useDetailHandlers` + `DialogState` + `DetailContentProps` moved to `pages/detail/detail-handlers.ts` so both the generic and shopping bodies consume the same shape. Existing `ListDetailPage.test.tsx` flipped its default fixture from `kind: 'shopping'` to `kind: 'todo'` so the generic-path suite keeps exercising the generic body.

### Tests

- 6 new service-layer cases in `@pops/app-lists-db/src/__tests__/lists.test.ts` (happy paths, zero-checked no-op, list-scoping).
- 6 new integration cases in `apps/pops-api/src/modules/lists/__tests__/lists-router.test.ts` (both procedures end-to-end through tRPC).
- 8 new RTL cases in `pages/components/shopping/__tests__/ShoppingDetailContent.test.tsx` (header / disabled bulk buttons / both confirm flows / sort projection / qty-unit dash / notes subline / add-form clear+focus).
- 4 new hook cases in `pages/components/shopping/__tests__/useShoppingSort.test.ts` (each sort mode + null `checkedAt` ordering).

### CI gauntlet (locally green)

- `mise typecheck`: 32/32 ✅
- `mise lint`: exit 0 ✅
- `mise test`: 36/36 (incl. 41 app-lists-db + 38 app-lists + 4623 pops-api) ✅
- `mise build`: 12/12 ✅

### Coordination

- Disjoint from open PR #2752 (140-B index page) — different subtree (`pages/components/shopping/` vs `pages/lists-index/`); the shared shell i18n file is additive on both sides.
- PRD-140 declared the two router extensions as PRD-141 amendments — landed here as the PRD specified.

## Test plan

- [ ] Open a list with `kind='shopping'` → header shows sort dropdown + Uncheck all + Clear checked + caption.
- [ ] Switch sort to "Unchecked first" → checked items move to the bottom; drag handle disabled with tooltip.
- [ ] Click Uncheck all → confirm dialog → Uncheck all → optimistic UI flips immediately; refetch confirms.
- [ ] Click Clear checked → confirm dialog → Remove checked → checked rows disappear immediately; refetch confirms.
- [ ] Add an item via `[qty][unit][label]` form → row appears; cursor returns to qty.
- [ ] On a touch device: swipe a row left → Cancel / Delete buttons appear; tap Cancel → snaps back; swipe again + tap Delete → row removed.
- [ ] Change the list's kind to `todo` via the action menu → header swaps to the generic header without losing item data.