### PR TITLE
feat(infra): core pillar Litestream config + AGENTS.md per-pillar note (phase 2 PR 4)

### DIFF
--- a/.github/workflows/infra-lint.yml
+++ b/.github/workflows/infra-lint.yml
@@ -1,0 +1,41 @@
+name: Infra Lint
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "infra/litestream/**"
+      - ".github/workflows/infra-lint.yml"
+  pull_request:
+
+jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - 'infra/litestream/**'
+              - '.github/workflows/infra-lint.yml'
+
+  yaml-lint:
+    name: YAML Lint (infra)
+    runs-on: ubuntu-latest
+    needs: [changes]
+    if: always()
+    steps:
+      - name: "Skip — no relevant changes"
+        if: github.event_name == 'pull_request' && needs.changes.outputs.relevant != 'true'
+        run: echo "Skipping — no infra changes"
+      - uses: actions/checkout@v6
+        if: github.event_name == 'push' || needs.changes.outputs.relevant == 'true'
+      - name: Lint Litestream YAML
+        if: github.event_name == 'push' || needs.changes.outputs.relevant == 'true'
+        run: npx yaml-lint infra/litestream/*.yml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -266,6 +266,7 @@ When a movie is added to the POPS library, automatically checks Plex Discover cl
 - **Chat:** Moltbot (Telegram)
 - **Backup:** Backblaze B2 via rclone (encrypted)
 - **Litestream exclusions:** `MEDIA_IMAGES_DIR` and `FOOD_INGEST_DIR` are regeneratable media trees and must be excluded from Litestream replication in the homelab-infra repo's Litestream config. The SQLite rows that reference these paths stay backed up; only the bytes are skipped.
+- **Per-pillar SQLite (ADR-026):** each pillar's database streams independently. The core pillar's reference config lives at `infra/litestream/core.yml`; the deployer mirrors it into the homelab-infra Litestream config alongside the existing `pops.db` stream. As subsequent pillars (finance, media, …) extract their own SQLite files, each adds a sibling YAML next to `core.yml`.
 
 ## Import Pipeline
 

--- a/infra/litestream/core.yml
+++ b/infra/litestream/core.yml
@@ -1,0 +1,30 @@
+## Litestream replication config — core pillar SQLite.
+##
+## Phase 2 PR 4 of the core pillar migration (ADR-026). Mirrors the
+## per-pillar pattern so each pillar's database streams independently
+## of the shared pops.db.
+##
+## Production deployment lives in the homelab-infra repo (see AGENTS.md
+## for the deployment model); this file is the canonical reference the
+## deployer copies into its own Litestream config. The replica target
+## (S3 bucket name, region, credentials) is provided by the deployer's
+## environment — leave it as a `${CORE_LITESTREAM_REPLICA_URL}` style
+## placeholder here.
+##
+## Restore drill: stop the core-api container, point `core.db` at an
+## empty path, and run `litestream restore -o /data/sqlite/core.db
+## ${CORE_LITESTREAM_REPLICA_URL}`. The drill is exercised in Phase 4
+## verification.
+
+dbs:
+  - path: /data/sqlite/core.db
+    replicas:
+      - url: ${CORE_LITESTREAM_REPLICA_URL}
+        # Per-pillar config so a single-pillar restore doesn't pull in
+        # the whole pops.db blob. Sync interval matches the shared
+        # singleton's existing replica config (1s by default — see
+        # homelab-infra).
+        sync-interval: 1s
+        retention: 24h
+        snapshot-interval: 1h
+        validation-interval: 12h

--- a/infra/litestream/core.yml
+++ b/infra/litestream/core.yml
@@ -11,10 +11,10 @@
 ## environment — leave it as a `${CORE_LITESTREAM_REPLICA_URL}` style
 ## placeholder here.
 ##
-## Restore drill: stop the core-api container, point `core.db` at an
-## empty path, and run `litestream restore -o /data/sqlite/core.db
-## ${CORE_LITESTREAM_REPLICA_URL}`. The drill is exercised in Phase 4
-## verification.
+## Restore drill (single line — safe to copy/paste during an incident):
+##   litestream restore -o /data/sqlite/core.db "${CORE_LITESTREAM_REPLICA_URL}"
+## Stop the core-api container first so it isn't writing concurrently;
+## the drill is exercised in Phase 4 verification.
 
 dbs:
   - path: /data/sqlite/core.db


### PR DESCRIPTION
## Summary

Final PR of the core pillar **Phase 2 — extract core's SQLite** sequence (pillar-migration-roadmap.md Track D · Phase 2 PR 4 of 4).

Adds the deployer reference Litestream config for the per-pillar SQLite + documents the pattern in AGENTS.md. With this, **Phase 2 of 4 is complete** for the core pilot.

## What changed

- \`infra/litestream/core.yml\` — stream + retention + snapshot config for \`/data/sqlite/core.db\`, parameterised on a \`CORE_LITESTREAM_REPLICA_URL\` placeholder the homelab-infra repo fills in. Sibling YAMLs land next to it as subsequent pillars (finance, media, …) extract their own SQLite files in Phase γ.
- \`AGENTS.md\` — adds a bullet under the Operations section calling out the per-pillar Litestream pattern + pointing at \`infra/litestream/core.yml\` as the canonical reference the deployer mirrors.

## NOT in this PR (deferred, with rationale)

- **Dropping the legacy \`pops.db.service_accounts\` table** — adding a new drizzle-kit migration requires a paired snapshot.json that's awkward to hand-author; a future cleanup PR with proper drizzle-kit tooling will handle it. The table is harmless dead data on existing prod DBs (backfilled rows are read from core.db now) and the backfill's existence probe gracefully handles its eventual removal.
- **Phase-1 shared-journal cleanup of \`0054_service_accounts\`** — the drift guard in \`core-quality.yml\` continues to enforce byte-identical lockstep until both cleanups land together.

## Phase 2 status

- ✅ PR 1 #2747 — \`openCoreDb\` helper
- ✅ PR 2 #2751 — boot-time open + \`CORE_SQLITE_PATH\` env + \`closeCoreDb\` wiring
- ✅ PR 3 #2756 — service-accounts cutover + ATTACH-based backfill
- 🔄 PR 4 — Litestream config + AGENTS.md docs (this)

Roadmap row updated with Phase 2 completion + lessons captured (openCoreDb uses drizzle-orm's migrate primitive; backfill enumerates columns explicitly; cross-DB ops need ATTACH so backfill tests use tmpdir files; test-utils must inject the same handle on both singletons during the cutover window).

## Test plan

- [ ] CI green on \`api-quality\` (no code changes)
- [ ] CI green on \`workflows-quality\` (YAML lint catches Litestream config typos)
- [ ] Copilot review pass