### PR TITLE
feat(core-api): scaffold pops-core-api container (pillar core phase 3 PR 1)

### DIFF
--- a/.github/workflows/core-api-quality.yml
+++ b/.github/workflows/core-api-quality.yml
@@ -1,0 +1,41 @@
+name: Core API Quality
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "apps/pops-core-api/**"
+      - "packages/core-db/**"
+      - "packages/db-types/**"
+      - ".github/workflows/core-api-quality.yml"
+      - ".github/workflows/_pkg-check.yml"
+  pull_request:
+
+jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - 'apps/pops-core-api/**'
+              - 'packages/core-db/**'
+              - 'packages/db-types/**'
+              - '.github/workflows/core-api-quality.yml'
+              - '.github/workflows/_pkg-check.yml'
+
+  quality:
+    needs: [changes]
+    if: always()
+    uses: ./.github/workflows/_pkg-check.yml
+    with:
+      package-path: apps/pops-core-api
+      needs-db-build: true
+      skip: ${{ github.event_name == 'pull_request' && needs.changes.outputs.relevant != 'true' }}

--- a/apps/pops-core-api/Dockerfile
+++ b/apps/pops-core-api/Dockerfile
@@ -46,11 +46,12 @@ FROM node:22-slim
 WORKDIR /app
 RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder /app/deploy ./
-COPY --from=builder /app/apps/pops-core-api/dist ./dist
+COPY --from=builder --chown=node:node /app/deploy ./
+COPY --from=builder --chown=node:node /app/apps/pops-core-api/dist ./dist
 
 ARG BUILD_VERSION=dev
 ENV BUILD_VERSION=$BUILD_VERSION
 
 EXPOSE 3001
+USER node
 CMD ["node", "dist/server.js"]

--- a/apps/pops-core-api/Dockerfile
+++ b/apps/pops-core-api/Dockerfile
@@ -1,0 +1,56 @@
+FROM node:22-slim AS builder
+WORKDIR /app
+
+# Copy workspace root files
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json ./
+
+# Copy workspace package.json files (for dep resolution)
+COPY packages/db-types/package.json ./packages/db-types/
+COPY packages/types/package.json ./packages/types/
+COPY packages/core-db/package.json ./packages/core-db/
+COPY apps/pops-core-api/package.json ./apps/pops-core-api/
+
+# Install pnpm and all workspace dependencies
+RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
+    corepack enable && pnpm install --frozen-lockfile
+
+# Copy shared package sources
+COPY packages/db-types/src ./packages/db-types/src
+COPY packages/db-types/tsconfig.json ./packages/db-types/
+COPY packages/types/src ./packages/types/src
+COPY packages/types/tsconfig.json packages/types/tsconfig.build.json ./packages/types/
+COPY packages/core-db/src ./packages/core-db/src
+COPY packages/core-db/tsconfig.json ./packages/core-db/
+COPY packages/core-db/migrations ./packages/core-db/migrations
+
+# Copy core-api source
+COPY apps/pops-core-api/tsconfig.json ./apps/pops-core-api/
+COPY apps/pops-core-api/src ./apps/pops-core-api/src
+
+# Build shared packages first
+WORKDIR /app/packages/db-types
+RUN pnpm build
+WORKDIR /app/packages/types
+RUN pnpm build
+WORKDIR /app/packages/core-db
+RUN pnpm build
+
+# Build core-api
+WORKDIR /app/apps/pops-core-api
+RUN pnpm build
+
+# Create standalone deployment (production deps only, no symlinks)
+RUN pnpm --filter @pops/core-api deploy --prod --legacy /app/deploy
+
+FROM node:22-slim
+WORKDIR /app
+RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /app/deploy ./
+COPY --from=builder /app/apps/pops-core-api/dist ./dist
+
+ARG BUILD_VERSION=dev
+ENV BUILD_VERSION=$BUILD_VERSION
+
+EXPOSE 3001
+CMD ["node", "dist/server.js"]

--- a/apps/pops-core-api/package.json
+++ b/apps/pops-core-api/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@pops/core-api",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsx watch --clear-screen=false src/server.ts",
+    "start": "node dist/server.js",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@pops/core-db": "workspace:*",
+    "express": "^5.1.0",
+    "pino": "^10.3.1"
+  },
+  "devDependencies": {
+    "@types/express": "^5.0.4",
+    "@types/node": "^25.9.1",
+    "@types/supertest": "^6.0.3",
+    "@vitest/coverage-v8": "^4.1.8",
+    "supertest": "^7.1.4",
+    "tsx": "^4.22.4",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.8"
+  }
+}

--- a/apps/pops-core-api/src/__tests__/core-sqlite-path.test.ts
+++ b/apps/pops-core-api/src/__tests__/core-sqlite-path.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Resolver tests — guards the precedence chain so future pillar work
+ * doesn't accidentally drift core-api away from pops-api's resolver.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { DEFAULT_CORE_SQLITE_PATH, resolveCoreSqlitePath } from '../core-sqlite-path.js';
+
+const originalCorePath = process.env['CORE_SQLITE_PATH'];
+const originalSharedPath = process.env['SQLITE_PATH'];
+
+beforeEach(() => {
+  delete process.env['CORE_SQLITE_PATH'];
+  delete process.env['SQLITE_PATH'];
+});
+
+afterEach(() => {
+  if (originalCorePath === undefined) delete process.env['CORE_SQLITE_PATH'];
+  else process.env['CORE_SQLITE_PATH'] = originalCorePath;
+  if (originalSharedPath === undefined) delete process.env['SQLITE_PATH'];
+  else process.env['SQLITE_PATH'] = originalSharedPath;
+});
+
+describe('resolveCoreSqlitePath', () => {
+  it('returns CORE_SQLITE_PATH verbatim when set', () => {
+    process.env['CORE_SQLITE_PATH'] = '/abs/path/core.db';
+    expect(resolveCoreSqlitePath()).toBe('/abs/path/core.db');
+  });
+
+  it('derives <dirname(SQLITE_PATH)>/core.db when CORE_SQLITE_PATH is unset', () => {
+    process.env['SQLITE_PATH'] = '/opt/pops/data/pops.db';
+    expect(resolveCoreSqlitePath()).toBe('/opt/pops/data/core.db');
+  });
+
+  it('handles a relative SQLITE_PATH', () => {
+    process.env['SQLITE_PATH'] = './data/pops.db';
+    expect(resolveCoreSqlitePath()).toBe('data/core.db');
+  });
+
+  it('falls back to ./data/core.db when neither env is set', () => {
+    expect(resolveCoreSqlitePath()).toBe(DEFAULT_CORE_SQLITE_PATH);
+  });
+});

--- a/apps/pops-core-api/src/__tests__/health.test.ts
+++ b/apps/pops-core-api/src/__tests__/health.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Smoke tests for the core-api Express app + health probe.
+ *
+ * Boots the app against an in-memory core.db so the suite doesn't
+ * write to disk and confirms the `/health` route returns the agreed
+ * `{ ok, pillar, version }` shape.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { openCoreDb, type OpenedCoreDb } from '@pops/core-db';
+
+import { createCoreApiApp } from '../app.js';
+
+let tmpDir: string;
+let coreDb: OpenedCoreDb;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'core-api-test-'));
+  coreDb = openCoreDb(join(tmpDir, 'core.db'));
+});
+
+afterEach(() => {
+  coreDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('GET /health', () => {
+  it('returns ok + pillar + version', async () => {
+    const app = createCoreApiApp({ coreDb, version: '0.0.1-test' });
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, pillar: 'core', version: '0.0.1-test' });
+  });
+
+  it('fails closed when the core handle is closed', async () => {
+    const app = createCoreApiApp({ coreDb, version: '0.0.1-test' });
+    coreDb.raw.close();
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(500);
+  });
+});

--- a/apps/pops-core-api/src/__tests__/health.test.ts
+++ b/apps/pops-core-api/src/__tests__/health.test.ts
@@ -1,8 +1,8 @@
 /**
  * Smoke tests for the core-api Express app + health probe.
  *
- * Boots the app against an in-memory core.db so the suite doesn't
- * write to disk and confirms the `/health` route returns the agreed
+ * Boots the app against a per-test temp-dir core.db (mkdtemp + cleanup
+ * in afterEach) and confirms the `/health` route returns the agreed
  * `{ ok, pillar, version }` shape.
  */
 import { mkdtempSync, rmSync } from 'node:fs';

--- a/apps/pops-core-api/src/app.ts
+++ b/apps/pops-core-api/src/app.ts
@@ -15,8 +15,12 @@ export function createCoreApiApp(deps: CoreApiDeps): Express {
   const app = express();
   app.disable('x-powered-by');
 
+  // Build the handler shape once at factory time so static deps don't
+  // get re-allocated on every request.
+  const handlers = makeRequestHandler(deps);
+
   app.get('/health', (_req: Request, res: Response) => {
-    res.json(makeRequestHandler(deps).health());
+    res.json(handlers.health());
   });
 
   return app;

--- a/apps/pops-core-api/src/app.ts
+++ b/apps/pops-core-api/src/app.ts
@@ -1,0 +1,23 @@
+/**
+ * Express app factory for the core pillar container.
+ *
+ * Phase 3 PR 1 of the core pillar migration scaffolds the new
+ * `core-api` process with just a `/health` probe; the tRPC handler,
+ * pillar registry, and URI dispatcher migrate in later PRs of the
+ * phase. Kept as a factory so the test suite can spin up an in-process
+ * `supertest` instance without having to bind a real port.
+ */
+import express, { type Express, type Request, type Response } from 'express';
+
+import { type CoreApiDeps, makeRequestHandler } from './handlers.js';
+
+export function createCoreApiApp(deps: CoreApiDeps): Express {
+  const app = express();
+  app.disable('x-powered-by');
+
+  app.get('/health', (_req: Request, res: Response) => {
+    res.json(makeRequestHandler(deps).health());
+  });
+
+  return app;
+}

--- a/apps/pops-core-api/src/core-sqlite-path.ts
+++ b/apps/pops-core-api/src/core-sqlite-path.ts
@@ -1,0 +1,17 @@
+/**
+ * Standalone resolver for the core pillar's SQLite path inside the
+ * core-api container.
+ *
+ * Intentionally NOT imported from `apps/pops-api/src/db/core-sqlite-path.ts`
+ * — core-api is supposed to be runnable without pops-api in the
+ * dependency graph. The shared default is the same (`./data/core.db`)
+ * and the env var name (`CORE_SQLITE_PATH`) matches, so an operator
+ * who points both processes at the same path gets a consistent view.
+ */
+export const DEFAULT_CORE_SQLITE_PATH = './data/core.db';
+
+export function resolveCoreSqlitePath(): string {
+  const envPath = process.env['CORE_SQLITE_PATH'];
+  if (envPath) return envPath;
+  return DEFAULT_CORE_SQLITE_PATH;
+}

--- a/apps/pops-core-api/src/core-sqlite-path.ts
+++ b/apps/pops-core-api/src/core-sqlite-path.ts
@@ -1,17 +1,27 @@
+import { dirname, join } from 'node:path';
+
 /**
  * Standalone resolver for the core pillar's SQLite path inside the
  * core-api container.
  *
  * Intentionally NOT imported from `apps/pops-api/src/db/core-sqlite-path.ts`
  * — core-api is supposed to be runnable without pops-api in the
- * dependency graph. The shared default is the same (`./data/core.db`)
- * and the env var name (`CORE_SQLITE_PATH`) matches, so an operator
- * who points both processes at the same path gets a consistent view.
+ * dependency graph. The precedence chain mirrors pops-api's resolver
+ * verbatim so the two processes agree on the location of `core.db`
+ * given the same env: a deployer who only sets `SQLITE_PATH`
+ * (legacy contract) still ends up with `core.db` next to `pops.db`.
+ *
+ * Resolution order:
+ *   1. `CORE_SQLITE_PATH` (absolute or relative).
+ *   2. `<dirname(SQLITE_PATH)>/core.db` if the shared path is set.
+ *   3. `./data/core.db` (matches the shared default's `./data/pops.db`).
  */
 export const DEFAULT_CORE_SQLITE_PATH = './data/core.db';
 
 export function resolveCoreSqlitePath(): string {
   const envPath = process.env['CORE_SQLITE_PATH'];
   if (envPath) return envPath;
+  const sharedPath = process.env['SQLITE_PATH'];
+  if (sharedPath) return join(dirname(sharedPath), 'core.db');
   return DEFAULT_CORE_SQLITE_PATH;
 }

--- a/apps/pops-core-api/src/handlers.ts
+++ b/apps/pops-core-api/src/handlers.ts
@@ -1,0 +1,35 @@
+/**
+ * Request handlers for the core pillar container.
+ *
+ * Logic lives here (not inline in `app.ts`) so tests can call into the
+ * shape directly without booting Express. Subsequent PRs add tRPC +
+ * `/uri/resolve` + `/pillars` handlers alongside the health probe.
+ */
+import type { OpenedCoreDb } from '@pops/core-db';
+
+export interface CoreApiDeps {
+  /** Open handle to the core pillar's SQLite. */
+  coreDb: OpenedCoreDb;
+  /** Semver of the build, surfaced on the health response. */
+  version: string;
+}
+
+export interface HealthResponse {
+  ok: true;
+  pillar: 'core';
+  version: string;
+}
+
+export function makeRequestHandler(deps: CoreApiDeps): {
+  health(): HealthResponse;
+} {
+  return {
+    health(): HealthResponse {
+      // Touch the DB so a closed handle surfaces as a thrown error
+      // (caught by the Express error pipeline -> 500) rather than a
+      // bogus 200 OK that hides a broken connection.
+      deps.coreDb.raw.prepare('SELECT 1').get();
+      return { ok: true, pillar: 'core', version: deps.version };
+    },
+  };
+}

--- a/apps/pops-core-api/src/server.ts
+++ b/apps/pops-core-api/src/server.ts
@@ -1,0 +1,36 @@
+/**
+ * Entry point for the core pillar HTTP server.
+ *
+ * Phase 3 PR 1 of the core pillar migration boots the process with the
+ * minimal `/health` surface so the new container can be wired into
+ * docker-compose + Watchtower without depending on the (still-unfinished)
+ * tRPC + URI-dispatcher migration.
+ *
+ * The process opens its OWN core.db connection via `openCoreDb` rather
+ * than reaching back into pops-api's singleton — that's the whole point
+ * of phase 3.
+ */
+import { openCoreDb } from '@pops/core-db';
+
+import { createCoreApiApp } from './app.js';
+import { resolveCoreSqlitePath } from './core-sqlite-path.js';
+
+const port = Number(process.env['PORT'] ?? 3001);
+const version = process.env['BUILD_VERSION'] ?? 'dev';
+
+const coreDb = openCoreDb(resolveCoreSqlitePath());
+const app = createCoreApiApp({ coreDb, version });
+
+const server = app.listen(port, () => {
+  console.warn(`[core-api] Listening on port ${port}`);
+});
+
+function shutdown(): void {
+  console.warn('[core-api] Shutting down');
+  server.close(() => {
+    coreDb.raw.close();
+  });
+}
+
+process.on('SIGTERM', shutdown);
+process.on('SIGINT', shutdown);

--- a/apps/pops-core-api/src/server.ts
+++ b/apps/pops-core-api/src/server.ts
@@ -15,7 +15,17 @@ import { openCoreDb } from '@pops/core-db';
 import { createCoreApiApp } from './app.js';
 import { resolveCoreSqlitePath } from './core-sqlite-path.js';
 
-const port = Number(process.env['PORT'] ?? 3001);
+function resolvePort(): number {
+  const raw = process.env['PORT'];
+  if (raw === undefined || raw === '') return 3001;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed <= 0 || parsed > 65535) {
+    throw new Error(`[core-api] PORT must be a positive integer in 1-65535; got '${raw}'`);
+  }
+  return parsed;
+}
+
+const port = resolvePort();
 const version = process.env['BUILD_VERSION'] ?? 'dev';
 
 const coreDb = openCoreDb(resolveCoreSqlitePath());
@@ -25,8 +35,11 @@ const server = app.listen(port, () => {
   console.warn(`[core-api] Listening on port ${port}`);
 });
 
-function shutdown(): void {
-  console.warn('[core-api] Shutting down');
+let shuttingDown = false;
+function shutdown(signal: NodeJS.Signals): void {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  console.warn(`[core-api] Shutting down (${signal})`);
   server.close(() => {
     coreDb.raw.close();
   });

--- a/apps/pops-core-api/tsconfig.json
+++ b/apps/pops-core-api/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "sourceMap": true,
+    "types": ["node"]
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/__tests__/**"]
+}

--- a/apps/pops-core-api/vitest.config.ts
+++ b/apps/pops-core-api/vitest.config.ts
@@ -1,0 +1,15 @@
+/// <reference types="vitest/config" />
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json-summary', 'html'],
+      reportsDirectory: 'coverage',
+      include: ['src/**/*.ts'],
+      exclude: ['**/node_modules/**', '**/dist/**', '**/*.test.ts'],
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -216,6 +216,43 @@ importers:
         specifier: ^4.1.8
         version: 4.1.8(@types/node@25.9.1)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
 
+  apps/pops-core-api:
+    dependencies:
+      '@pops/core-db':
+        specifier: workspace:*
+        version: link:../../packages/core-db
+      express:
+        specifier: ^5.1.0
+        version: 5.2.1
+      pino:
+        specifier: ^10.3.1
+        version: 10.3.1
+    devDependencies:
+      '@types/express':
+        specifier: ^5.0.4
+        version: 5.0.6
+      '@types/node':
+        specifier: ^25.9.1
+        version: 25.9.1
+      '@types/supertest':
+        specifier: ^6.0.3
+        version: 6.0.3
+      '@vitest/coverage-v8':
+        specifier: ^4.1.8
+        version: 4.1.8(vitest@4.1.8)
+      supertest:
+        specifier: ^7.1.4
+        version: 7.2.2
+      tsx:
+        specifier: ^4.22.4
+        version: 4.22.4
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@25.9.1)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
+
   apps/pops-mcp:
     dependencies:
       '@modelcontextprotocol/sdk':


### PR DESCRIPTION
## Summary

First PR of the core pillar **Phase 3 — core-api container** sequence (pillar-migration-roadmap.md Track D · Phase 3 PR 1 of 4).

Scaffolds the new \`pops-core-api\` process — a standalone container that owns the core pillar's HTTP surface. **Strictly additive — no existing pops-api callers depend on it yet.** Subsequent PRs migrate the tRPC handler + service-accounts router, then wire docker-compose, then point the shell at the new base URL.

## What changed

- \`apps/pops-core-api/\`:
  - \`package.json\` / \`tsconfig.json\` / \`vitest.config.ts\` (deps: \`@pops/core-db\`, express 5, pino, supertest)
  - \`src/server.ts\` — process entrypoint binds \`PORT\` (default 3001), opens the core pillar SQLite directly via \`openCoreDb\`, SIGTERM / SIGINT graceful shutdown closes the handle
  - \`src/app.ts\` — Express factory exposing \`/health\`
  - \`src/handlers.ts\` — pure handler shape; touches the DB so a closed handle surfaces as 500 instead of a bogus 200 OK
  - \`src/core-sqlite-path.ts\` — standalone resolver so core-api doesn't reach into pops-api's tree (same env name + default as pops-api)
  - \`src/__tests__/health.test.ts\` — supertest covers happy + fail-closed
  - \`Dockerfile\` — multi-stage build mirroring pops-mcp (deploy --prod --legacy, no symlinks at runtime)
- \`.github/workflows/core-api-quality.yml\` — PR-paths-filtered typecheck + test via the shared \`_pkg-check\` workflow

## Verification

- \`pnpm typecheck\` — 33/33 green
- \`pnpm --filter @pops/core-api test\` — 2/2 cases pass

## Subsequent PRs

- PR 2 — mount tRPC + service-accounts router under \`/trpc\`
- PR 3 — wire core-api into \`docker-compose.dev.yml\` + \`POPS_PILLARS\`
- PR 4 — \`pops-shell\` creates \`useCoreTrpc()\` against the new base URL

## Test plan

- [ ] CI green on \`core-api-quality\` (typecheck + 2 supertest cases)
- [ ] Workspace \`typecheck\` / \`api-quality\` unaffected (strictly additive)
- [ ] Copilot review pass