### PR TITLE
feat(core-api): GET /pillars registry endpoint (pillar core phase 3 PR 2)

### DIFF
--- a/apps/pops-core-api/package.json
+++ b/apps/pops-core-api/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@pops/core-db": "workspace:*",
+    "@pops/types": "workspace:*",
     "express": "^5.1.0",
     "pino": "^10.3.1"
   },

--- a/apps/pops-core-api/src/__tests__/health.test.ts
+++ b/apps/pops-core-api/src/__tests__/health.test.ts
@@ -31,14 +31,22 @@ afterEach(() => {
 
 describe('GET /health', () => {
   it('returns ok + pillar + version', async () => {
-    const app = createCoreApiApp({ coreDb, version: '0.0.1-test' });
+    const app = createCoreApiApp({
+      coreDb,
+      version: '0.0.1-test',
+      selfBaseUrl: 'http://localhost:3001',
+    });
     const res = await request(app).get('/health');
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ ok: true, pillar: 'core', version: '0.0.1-test' });
   });
 
   it('fails closed when the core handle is closed', async () => {
-    const app = createCoreApiApp({ coreDb, version: '0.0.1-test' });
+    const app = createCoreApiApp({
+      coreDb,
+      version: '0.0.1-test',
+      selfBaseUrl: 'http://localhost:3001',
+    });
     coreDb.raw.close();
     const res = await request(app).get('/health');
     expect(res.status).toBe(500);

--- a/apps/pops-core-api/src/__tests__/pillars.test.ts
+++ b/apps/pops-core-api/src/__tests__/pillars.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Smoke tests for the `GET /pillars` registry endpoint.
+ *
+ * Covers the synthetic-`core`-entry contract, deduplication when the
+ * env already lists `core`, and a malformed POPS_PILLARS returning 500
+ * (since the parser is strict by design).
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { openCoreDb, type OpenedCoreDb } from '@pops/core-db';
+
+import { createCoreApiApp } from '../app.js';
+import { __resetPillarRegistryCache } from '../pillars/registry.js';
+
+let tmpDir: string;
+let coreDb: OpenedCoreDb;
+const originalPillars = process.env['POPS_PILLARS'];
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'core-api-pillars-test-'));
+  coreDb = openCoreDb(join(tmpDir, 'core.db'));
+  delete process.env['POPS_PILLARS'];
+  __resetPillarRegistryCache();
+});
+
+afterEach(() => {
+  coreDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+  if (originalPillars === undefined) delete process.env['POPS_PILLARS'];
+  else process.env['POPS_PILLARS'] = originalPillars;
+  __resetPillarRegistryCache();
+});
+
+function makeApp(): ReturnType<typeof createCoreApiApp> {
+  return createCoreApiApp({
+    coreDb,
+    version: '0.0.1-test',
+    selfBaseUrl: 'http://core-api:3001',
+  });
+}
+
+describe('GET /pillars', () => {
+  it('returns the synthetic core entry when POPS_PILLARS is unset', async () => {
+    const res = await request(makeApp()).get('/pillars');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      pillars: [{ id: 'core', baseUrl: 'http://core-api:3001' }],
+    });
+  });
+
+  it('merges the synthetic core entry ahead of POPS_PILLARS-parsed siblings', async () => {
+    process.env['POPS_PILLARS'] = 'food:http://food-api:3000,finance:http://finance-api:3000';
+    const res = await request(makeApp()).get('/pillars');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      pillars: [
+        { id: 'core', baseUrl: 'http://core-api:3001' },
+        { id: 'food', baseUrl: 'http://food-api:3000' },
+        { id: 'finance', baseUrl: 'http://finance-api:3000' },
+      ],
+    });
+  });
+
+  it('overrides a POPS_PILLARS `core` entry with the live selfBaseUrl', async () => {
+    process.env['POPS_PILLARS'] = 'core:http://stale-core:9000,food:http://food-api:3000';
+    const res = await request(makeApp()).get('/pillars');
+    expect(res.body).toEqual({
+      pillars: [
+        { id: 'core', baseUrl: 'http://core-api:3001' },
+        { id: 'food', baseUrl: 'http://food-api:3000' },
+      ],
+    });
+  });
+
+  it('returns 500 on a malformed POPS_PILLARS', async () => {
+    process.env['POPS_PILLARS'] = 'no-colon-here';
+    const res = await request(makeApp()).get('/pillars');
+    expect(res.status).toBe(500);
+  });
+});

--- a/apps/pops-core-api/src/__tests__/pillars.test.ts
+++ b/apps/pops-core-api/src/__tests__/pillars.test.ts
@@ -82,4 +82,20 @@ describe('GET /pillars', () => {
     const res = await request(makeApp()).get('/pillars');
     expect(res.status).toBe(500);
   });
+
+  it('rejects a POPS_PILLARS entry with a path/query/fragment', async () => {
+    process.env['POPS_PILLARS'] = 'food:http://food-api:3000/api';
+    const res = await request(makeApp()).get('/pillars');
+    expect(res.status).toBe(500);
+  });
+
+  it('strips a trailing slash from a clean origin', async () => {
+    process.env['POPS_PILLARS'] = 'food:http://food-api:3000/';
+    const res = await request(makeApp()).get('/pillars');
+    expect(res.status).toBe(200);
+    expect(res.body.pillars).toContainEqual({
+      id: 'food',
+      baseUrl: 'http://food-api:3000',
+    });
+  });
 });

--- a/apps/pops-core-api/src/app.ts
+++ b/apps/pops-core-api/src/app.ts
@@ -1,11 +1,11 @@
 /**
  * Express app factory for the core pillar container.
  *
- * Phase 3 PR 1 of the core pillar migration scaffolds the new
- * `core-api` process with just a `/health` probe; the tRPC handler,
- * pillar registry, and URI dispatcher migrate in later PRs of the
- * phase. Kept as a factory so the test suite can spin up an in-process
- * `supertest` instance without having to bind a real port.
+ * Phase 3 PR 2 of the core pillar migration adds the pillar registry
+ * snapshot endpoint (`GET /pillars`) alongside the existing `/health`
+ * probe. The dispatcher (`POST /uri/resolve`) + tRPC routers land in
+ * subsequent PRs. Kept as a factory so the test suite can spin up an
+ * in-process `supertest` instance without binding a real port.
  */
 import express, { type Express, type Request, type Response } from 'express';
 
@@ -21,6 +21,10 @@ export function createCoreApiApp(deps: CoreApiDeps): Express {
 
   app.get('/health', (_req: Request, res: Response) => {
     res.json(handlers.health());
+  });
+
+  app.get('/pillars', (_req: Request, res: Response) => {
+    res.json(handlers.pillars());
   });
 
   return app;

--- a/apps/pops-core-api/src/handlers.ts
+++ b/apps/pops-core-api/src/handlers.ts
@@ -3,15 +3,24 @@
  *
  * Logic lives here (not inline in `app.ts`) so tests can call into the
  * shape directly without booting Express. Subsequent PRs add tRPC +
- * `/uri/resolve` + `/pillars` handlers alongside the health probe.
+ * `/uri/resolve` handlers alongside the existing health + pillars probes.
  */
+import { getPillarRegistry } from './pillars/registry.js';
+
 import type { OpenedCoreDb } from '@pops/core-db';
+import type { PillarRegistryEntry } from '@pops/types';
 
 export interface CoreApiDeps {
   /** Open handle to the core pillar's SQLite. */
   coreDb: OpenedCoreDb;
   /** Semver of the build, surfaced on the health response. */
   version: string;
+  /**
+   * HTTP origin core-api is reachable at. Surfaced as the synthetic
+   * `core` entry in `GET /pillars` so consumers don't have to special-
+   * case the host pillar.
+   */
+  selfBaseUrl: string;
 }
 
 export interface HealthResponse {
@@ -20,8 +29,13 @@ export interface HealthResponse {
   version: string;
 }
 
+export interface PillarsResponse {
+  pillars: readonly PillarRegistryEntry[];
+}
+
 export function makeRequestHandler(deps: CoreApiDeps): {
   health(): HealthResponse;
+  pillars(): PillarsResponse;
 } {
   return {
     health(): HealthResponse {
@@ -30,6 +44,9 @@ export function makeRequestHandler(deps: CoreApiDeps): {
       // bogus 200 OK that hides a broken connection.
       deps.coreDb.raw.prepare('SELECT 1').get();
       return { ok: true, pillar: 'core', version: deps.version };
+    },
+    pillars(): PillarsResponse {
+      return { pillars: getPillarRegistry({ selfBaseUrl: deps.selfBaseUrl }) };
     },
   };
 }

--- a/apps/pops-core-api/src/pillars/env.ts
+++ b/apps/pops-core-api/src/pillars/env.ts
@@ -84,15 +84,32 @@ function parsePillarEntry(rawPair: string, seenIds: ReadonlySet<string>): Pillar
   if (baseUrlRaw.length === 0) {
     throw new PillarsEnvParseError(`entry "${pair}" is missing the baseUrl half`);
   }
+  return { id, baseUrl: parseBareOrigin(`pillar '${id}'`, baseUrlRaw) };
+}
+
+/**
+ * Parse `raw` as a bare http(s) origin. Throws if it carries a path,
+ * query, or fragment so consumers can append URL paths cleanly without
+ * silently routing through a prefix. Reused by `selfBaseUrl` validation
+ * and the per-entry parser above so both surfaces enforce the same
+ * `PillarRegistryEntry.baseUrl` contract.
+ */
+export function parseBareOrigin(label: string, raw: string): string {
   let url: URL;
   try {
-    url = new URL(baseUrlRaw);
+    url = new URL(raw);
   } catch {
-    throw new PillarsEnvParseError(`baseUrl "${baseUrlRaw}" is not a valid URL`);
+    throw new PillarsEnvParseError(`${label} baseUrl "${raw}" is not a valid URL`);
   }
   if (url.protocol !== 'http:' && url.protocol !== 'https:') {
-    throw new PillarsEnvParseError(`baseUrl "${baseUrlRaw}" must use http(s); got ${url.protocol}`);
+    throw new PillarsEnvParseError(
+      `${label} baseUrl "${raw}" must use http or https; got ${url.protocol}`
+    );
   }
-  const baseUrl = `${url.origin}${url.pathname === '/' ? '' : url.pathname.replace(/\/$/, '')}`;
-  return { id, baseUrl };
+  if ((url.pathname !== '/' && url.pathname !== '') || url.search !== '' || url.hash !== '') {
+    throw new PillarsEnvParseError(
+      `${label} baseUrl "${raw}" must be a bare origin (no path, query, or fragment)`
+    );
+  }
+  return url.origin;
 }

--- a/apps/pops-core-api/src/pillars/env.ts
+++ b/apps/pops-core-api/src/pillars/env.ts
@@ -1,0 +1,98 @@
+/**
+ * `POPS_PILLARS` environment variable parser inside the core-api process.
+ *
+ * Functionally identical to `apps/pops-api/src/modules/core/pillars/env.ts`
+ * — kept as a local copy so core-api can boot without a runtime
+ * dependency on pops-api. The two implementations should be promoted
+ * into a shared `packages/core-contract` (or `@pops/types`) package once
+ * a third consumer needs them. Until then the contract guard tests in
+ * pops-api keep this behaviour pinned.
+ *
+ * Format: `id:baseUrl[,id:baseUrl,...]`
+ *   - `id` lowercase kebab-case pillar slug (`food`, `finance`, …)
+ *   - `baseUrl` fully-qualified http(s) origin (trailing slashes stripped)
+ *   - whitespace around `:` and `,` tolerated
+ *
+ * Strict: malformed input throws rather than silently dropping entries.
+ */
+
+import type { PillarRegistryEntry } from '@pops/types';
+
+const PILLAR_ID_RE = /^[a-z0-9-]+$/;
+
+export interface ParsePillarsEnvOptions {
+  /**
+   * When true (default), empty / undefined input returns an empty registry.
+   * When false, empty input throws — useful for deploys that require
+   * the variable to be set explicitly.
+   */
+  readonly allowEmpty?: boolean;
+}
+
+export class PillarsEnvParseError extends Error {
+  override readonly name = 'PillarsEnvParseError' as const;
+
+  constructor(message: string) {
+    super(`POPS_PILLARS: ${message}`);
+  }
+}
+
+export function parsePillarsEnv(
+  raw: string | undefined,
+  options: ParsePillarsEnvOptions = {}
+): readonly PillarRegistryEntry[] {
+  const { allowEmpty = true } = options;
+  const trimmed = (raw ?? '').trim();
+
+  if (trimmed.length === 0) {
+    if (allowEmpty) return [];
+    throw new PillarsEnvParseError('value is empty');
+  }
+
+  const entries: PillarRegistryEntry[] = [];
+  const seenIds = new Set<string>();
+
+  for (const rawPair of trimmed.split(',')) {
+    const entry = parsePillarEntry(rawPair, seenIds);
+    seenIds.add(entry.id);
+    entries.push(entry);
+  }
+
+  return entries;
+}
+
+function parsePillarEntry(rawPair: string, seenIds: ReadonlySet<string>): PillarRegistryEntry {
+  const pair = rawPair.trim();
+  if (pair.length === 0) {
+    throw new PillarsEnvParseError('empty entry between commas — remove the stray comma or value');
+  }
+  const colon = pair.indexOf(':');
+  if (colon === -1) {
+    throw new PillarsEnvParseError(`entry "${pair}" is missing a colon — expected id:baseUrl`);
+  }
+  const id = pair.slice(0, colon).trim();
+  const baseUrlRaw = pair.slice(colon + 1).trim();
+  if (id.length === 0) {
+    throw new PillarsEnvParseError(`entry "${pair}" is missing the id half`);
+  }
+  if (!PILLAR_ID_RE.test(id)) {
+    throw new PillarsEnvParseError(`id "${id}" is not lowercase kebab-case ([a-z0-9-]+)`);
+  }
+  if (seenIds.has(id)) {
+    throw new PillarsEnvParseError(`duplicate pillar id "${id}"`);
+  }
+  if (baseUrlRaw.length === 0) {
+    throw new PillarsEnvParseError(`entry "${pair}" is missing the baseUrl half`);
+  }
+  let url: URL;
+  try {
+    url = new URL(baseUrlRaw);
+  } catch {
+    throw new PillarsEnvParseError(`baseUrl "${baseUrlRaw}" is not a valid URL`);
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new PillarsEnvParseError(`baseUrl "${baseUrlRaw}" must use http(s); got ${url.protocol}`);
+  }
+  const baseUrl = `${url.origin}${url.pathname === '/' ? '' : url.pathname.replace(/\/$/, '')}`;
+  return { id, baseUrl };
+}

--- a/apps/pops-core-api/src/pillars/registry.ts
+++ b/apps/pops-core-api/src/pillars/registry.ts
@@ -1,5 +1,3 @@
-import { parsePillarsEnv } from './env.js';
-
 /**
  * Pillar registry view served by core-api.
  *
@@ -8,25 +6,29 @@ import { parsePillarsEnv } from './env.js';
  * shell sees the host pillar in the `/pillars` listing without having
  * to special-case the call site.
  */
+import { parseBareOrigin, parsePillarsEnv } from './env.js';
+
 import type { PillarRegistryEntry } from '@pops/types';
 
 let cached: readonly PillarRegistryEntry[] | undefined;
 
 export interface PillarRegistryOptions {
   /**
-   * The HTTP origin core-api is reachable at. Surfaced as the synthetic
-   * `core` entry's `baseUrl`. Defaults to `http://localhost:${port}` for
-   * tests; production callers should pass the same URL the deployer
-   * gave the shell + sibling pillars (via the `POPS_PILLARS` `core:`
-   * entry).
+   * HTTP origin core-api is reachable at. Required — `server.ts` derives
+   * it from `CORE_SELF_BASE_URL` (or falls back to `http://localhost:PORT`)
+   * before passing it in. The registry returns this as the synthetic
+   * `core` entry's `baseUrl` after normalising it through
+   * `parseBareOrigin` so callers can always append `/uri/resolve` etc.
+   * without a double-slash or stale path prefix.
    */
   readonly selfBaseUrl: string;
 }
 
 export function getPillarRegistry(options: PillarRegistryOptions): readonly PillarRegistryEntry[] {
   cached ??= parsePillarsEnv(process.env['POPS_PILLARS']);
+  const normalisedSelf = parseBareOrigin("core's selfBaseUrl", options.selfBaseUrl);
   const withoutSelf = cached.filter((p) => p.id !== 'core');
-  return [{ id: 'core', baseUrl: options.selfBaseUrl }, ...withoutSelf];
+  return [{ id: 'core', baseUrl: normalisedSelf }, ...withoutSelf];
 }
 
 /** Test-only: forget the cached registry so a new `POPS_PILLARS` is re-read. */

--- a/apps/pops-core-api/src/pillars/registry.ts
+++ b/apps/pops-core-api/src/pillars/registry.ts
@@ -1,0 +1,35 @@
+import { parsePillarsEnv } from './env.js';
+
+/**
+ * Pillar registry view served by core-api.
+ *
+ * Wraps the local copy of `parsePillarsEnv` with a process-level cache
+ * (same pattern pops-api uses). Adds the synthetic `core` entry so the
+ * shell sees the host pillar in the `/pillars` listing without having
+ * to special-case the call site.
+ */
+import type { PillarRegistryEntry } from '@pops/types';
+
+let cached: readonly PillarRegistryEntry[] | undefined;
+
+export interface PillarRegistryOptions {
+  /**
+   * The HTTP origin core-api is reachable at. Surfaced as the synthetic
+   * `core` entry's `baseUrl`. Defaults to `http://localhost:${port}` for
+   * tests; production callers should pass the same URL the deployer
+   * gave the shell + sibling pillars (via the `POPS_PILLARS` `core:`
+   * entry).
+   */
+  readonly selfBaseUrl: string;
+}
+
+export function getPillarRegistry(options: PillarRegistryOptions): readonly PillarRegistryEntry[] {
+  cached ??= parsePillarsEnv(process.env['POPS_PILLARS']);
+  const withoutSelf = cached.filter((p) => p.id !== 'core');
+  return [{ id: 'core', baseUrl: options.selfBaseUrl }, ...withoutSelf];
+}
+
+/** Test-only: forget the cached registry so a new `POPS_PILLARS` is re-read. */
+export function __resetPillarRegistryCache(): void {
+  cached = undefined;
+}

--- a/apps/pops-core-api/src/server.ts
+++ b/apps/pops-core-api/src/server.ts
@@ -14,6 +14,7 @@ import { openCoreDb } from '@pops/core-db';
 
 import { createCoreApiApp } from './app.js';
 import { resolveCoreSqlitePath } from './core-sqlite-path.js';
+import { parseBareOrigin } from './pillars/env.js';
 
 function resolvePort(): number {
   const raw = process.env['PORT'];
@@ -27,7 +28,14 @@ function resolvePort(): number {
 
 const port = resolvePort();
 const version = process.env['BUILD_VERSION'] ?? 'dev';
-const selfBaseUrl = process.env['CORE_SELF_BASE_URL'] ?? `http://localhost:${port}`;
+// Normalise CORE_SELF_BASE_URL (or the localhost fallback) through the
+// shared bare-origin parser so a misconfigured env crashes boot loudly
+// instead of publishing an invalid PillarRegistryEntry.baseUrl that
+// breaks downstream consumers appending `/uri/resolve`, `/health`, etc.
+const selfBaseUrl = parseBareOrigin(
+  'CORE_SELF_BASE_URL',
+  process.env['CORE_SELF_BASE_URL'] ?? `http://localhost:${port}`
+);
 
 const coreDb = openCoreDb(resolveCoreSqlitePath());
 const app = createCoreApiApp({ coreDb, version, selfBaseUrl });

--- a/apps/pops-core-api/src/server.ts
+++ b/apps/pops-core-api/src/server.ts
@@ -27,9 +27,10 @@ function resolvePort(): number {
 
 const port = resolvePort();
 const version = process.env['BUILD_VERSION'] ?? 'dev';
+const selfBaseUrl = process.env['CORE_SELF_BASE_URL'] ?? `http://localhost:${port}`;
 
 const coreDb = openCoreDb(resolveCoreSqlitePath());
-const app = createCoreApiApp({ coreDb, version });
+const app = createCoreApiApp({ coreDb, version, selfBaseUrl });
 
 const server = app.listen(port, () => {
   console.warn(`[core-api] Listening on port ${port}`);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -221,6 +221,9 @@ importers:
       '@pops/core-db':
         specifier: workspace:*
         version: link:../../packages/core-db
+      '@pops/types':
+        specifier: workspace:*
+        version: link:../../packages/types
       express:
         specifier: ^5.1.0
         version: 5.2.1


### PR DESCRIPTION
## Summary

Second PR of the core pillar **Phase 3 — core-api container** sequence (pillar-migration-roadmap.md Track D · Phase 3 PR 2 of 4).

Adds the pillar registry snapshot endpoint to core-api. **Strictly additive — no production caller flips to it yet.** The shell + cross-pillar dispatcher still talk to pops-api's identical endpoint; PR 3 wires docker-compose so the shell can probe both and PR 4 flips the shell over.

## What changed

- \`src/pillars/env.ts\` — local copy of \`parsePillarsEnv\` + \`PillarsEnvParseError\` (functionally identical to pops-api's; tagged for promotion into a shared package once a third consumer needs them). Strict — malformed \`POPS_PILLARS\` throws.
- \`src/pillars/registry.ts\` — process-level cached \`getPillarRegistry()\` with the synthetic \`core\` entry. A \`POPS_PILLARS\`-declared \`core\` entry is overridden by the live \`selfBaseUrl\` so the registry never lies about the host pillar's address.
- \`src/handlers.ts\` — new \`pillars()\` factory wires the registry view through the same handler pattern as \`health()\`.
- \`src/app.ts\` — mounts \`GET /pillars\`.
- \`src/server.ts\` — resolves \`selfBaseUrl\` from \`CORE_SELF_BASE_URL\` with a \`http://localhost:\${port}\` fallback so dev mode just works.
- \`@pops/types\` added as a runtime dep for \`PillarRegistryEntry\`.

## Tests (10/10 in core-api)

- existing \`/health\` cases updated with the new \`selfBaseUrl\` arg
- 4 new \`/pillars\` cases: empty \`POPS_PILLARS\` returns synthetic \`core\` only; populated env merges \`core\` ahead of siblings; stale \`POPS_PILLARS\` \`core\` entry is overridden by the live \`selfBaseUrl\`; malformed env returns 500

## Verification

- \`pnpm typecheck\` — 33/33 green
- \`pnpm --filter @pops/core-api test\` — 10/10 cases pass

## Test plan

- [ ] CI green on \`core-api-quality\` (typecheck + 10 supertest cases)
- [ ] Copilot review pass