### PR TITLE
feat(infra): wire core-api into docker-compose + publish image (phase 3 PR 3)

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -8,6 +8,7 @@ on:
       - "apps/pops-api/**"
       - "apps/pops-shell/**"
       - "apps/pops-mcp/**"
+      - "apps/pops-core-api/**"
       - "packages/**"
       - "infra/docker-compose*.yml"
       - "pnpm-lock.yaml"
@@ -32,6 +33,7 @@ jobs:
               - 'apps/pops-api/**'
               - 'apps/pops-shell/**'
               - 'apps/pops-mcp/**'
+              - 'apps/pops-core-api/**'
               - 'packages/**'
               - 'pnpm-lock.yaml'
               - 'pnpm-workspace.yaml'
@@ -64,6 +66,10 @@ jobs:
       - name: Build pops-mcp (builder stage)
         if: github.event_name == 'push' || needs.changes.outputs.relevant == 'true'
         run: docker build --target builder -f apps/pops-mcp/Dockerfile .
+
+      - name: Build pops-core-api (builder stage)
+        if: github.event_name == 'push' || needs.changes.outputs.relevant == 'true'
+        run: docker build --target builder -f apps/pops-core-api/Dockerfile .
 
   compose-validate:
     name: Validate docker-compose

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -101,3 +101,29 @@ jobs:
           labels: ${{ steps.meta-mcp.outputs.labels }}
           build-args: |
             BUILD_VERSION=${{ github.sha }}
+
+      - name: Generate metadata for pops-core-api
+        id: meta-core-api
+        uses: docker/metadata-action@v6
+        with:
+          images: ghcr.io/knoxio/pops-core-api
+          tags: |
+            type=raw,value=main,enable={{is_default_branch}}
+            type=sha,prefix=sha-,format=short
+            type=semver,pattern={{version}}
+            type=semver,pattern=v{{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=semver,pattern=v{{major}}
+
+      - name: Build and push pops-core-api
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: apps/pops-core-api/Dockerfile
+          push: true
+          tags: ${{ steps.meta-core-api.outputs.tags }}
+          labels: ${{ steps.meta-core-api.outputs.labels }}
+          build-args: |
+            BUILD_VERSION=${{ github.sha }}

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -18,10 +18,14 @@ services:
 
   # ── BACKEND ──────────────────────────────────────────────────────
 
-  # Core pillar API (ADR-026, Phase 3 PR 3). MUST be the first compose-up
-  # because other pillars register against its `/pillars` listing on boot.
-  # Today it only exposes /health + /pillars; subsequent pillar splits
-  # move settings, AI Ops, and URI dispatch behind this same container.
+  # Core pillar API (ADR-026, Phase 3 PR 3). Sibling pillars treat the
+  # core container as the authoritative pillar registry: `GET /pillars`
+  # returns a snapshot derived from the `POPS_PILLARS` env plus a
+  # synthetic `core` entry — there is no dynamic register-on-boot step.
+  # Startup ordering is enforced by `depends_on: core-api` (below) so
+  # consumers can rely on the snapshot being available when they boot.
+  # Today the container only exposes /health + /pillars; subsequent
+  # pillar splits move settings, AI Ops, and URI dispatch behind it.
   core-api:
     build:
       context: ..

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -18,6 +18,45 @@ services:
 
   # ── BACKEND ──────────────────────────────────────────────────────
 
+  # Core pillar API (ADR-026, Phase 3 PR 3). MUST be the first compose-up
+  # because other pillars register against its `/pillars` listing on boot.
+  # Today it only exposes /health + /pillars; subsequent pillar splits
+  # move settings, AI Ops, and URI dispatch behind this same container.
+  core-api:
+    build:
+      context: ..
+      dockerfile: apps/pops-core-api/Dockerfile
+      args:
+        BUILD_VERSION: ${BUILD_VERSION:-dev}
+    container_name: pops-core-api
+    restart: unless-stopped
+    networks:
+      - frontend
+      - backend
+    volumes:
+      - sqlite-data:/data/sqlite
+    environment:
+      NODE_ENV: production
+      PORT: '3001'
+      CORE_SQLITE_PATH: /data/sqlite/core.db
+      CORE_SELF_BASE_URL: http://core-api:3001
+      # Cross-pillar registry. Today's deployment only runs core; sibling
+      # pillars get appended (id:baseUrl,...) as they extract.
+      POPS_PILLARS: ${POPS_PILLARS:-}
+    expose:
+      - '3001'
+    healthcheck:
+      test:
+        [
+          'CMD',
+          'node',
+          '-e',
+          "fetch('http://localhost:3001/health').then(r=>{if(!r.ok)process.exit(1)})",
+        ]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
   pops-api:
     build:
       context: ..
@@ -45,6 +84,11 @@ services:
       PORT: '3000'
       REDIS_HOST: pops-redis
       REDIS_PORT: '6379'
+      # Cross-pillar registry (ADR-026 Phase 3 PR 3). Names core-api by
+      # its compose hostname so pops-api's URI dispatcher can route
+      # outbound `pops:core/...` traffic to the new container. Deployers
+      # override POPS_PILLARS to extend with sibling pillars.
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001}
       # Paperless-ngx integration (optional — leave unset to disable)
       PAPERLESS_BASE_URL: ${PAPERLESS_BASE_URL:-}
       PAPERLESS_API_TOKEN: ${PAPERLESS_API_TOKEN:-}
@@ -52,6 +96,8 @@ services:
       - '3000'
     depends_on:
       pops-redis:
+        condition: service_healthy
+      core-api:
         condition: service_healthy
     healthcheck:
       test:
@@ -91,8 +137,11 @@ services:
       SQLITE_PATH: /data/sqlite/pops.db
       REDIS_HOST: pops-redis
       REDIS_PORT: '6379'
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001}
     depends_on:
       pops-redis:
+        condition: service_healthy
+      core-api:
         condition: service_healthy
 
   # ── FRONTEND ─────────────────────────────────────────────────────

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -18,6 +18,41 @@ services:
 
   # ── BACKEND ──────────────────────────────────────────────────────
 
+  # Core pillar API (ADR-026, Phase 3 PR 3). MUST be the first compose-up
+  # because other pillars register against its `/pillars` listing on boot.
+  # Today it only exposes /health + /pillars; subsequent pillar splits
+  # move settings, AI Ops, and URI dispatch behind this same container.
+  core-api:
+    image: ghcr.io/knoxio/pops-core-api:${POPS_IMAGE_TAG:-main}
+    container_name: pops-core-api
+    restart: unless-stopped
+    labels:
+      com.centurylinklabs.watchtower.enable: 'true'
+    networks:
+      - frontend
+      - backend
+    volumes:
+      - sqlite-data:/data/sqlite
+    environment:
+      NODE_ENV: production
+      PORT: '3001'
+      CORE_SQLITE_PATH: /data/sqlite/core.db
+      CORE_SELF_BASE_URL: http://core-api:3001
+      POPS_PILLARS: ${POPS_PILLARS:-}
+    expose:
+      - '3001'
+    healthcheck:
+      test:
+        [
+          'CMD',
+          'node',
+          '-e',
+          "fetch('http://localhost:3001/health').then(r=>{if(!r.ok)process.exit(1)})",
+        ]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
   pops-api:
     image: ghcr.io/knoxio/pops-api:${POPS_IMAGE_TAG:-main}
     container_name: pops-api
@@ -51,10 +86,15 @@ services:
       # (ai surfaces are mounted under /cerebrum/admin/*, not as a separate app.)
       POPS_APPS: ${POPS_APPS:-}
       POPS_OVERLAYS: ${POPS_OVERLAYS:-}
+      # Cross-pillar registry (ADR-026 Phase 3 PR 3). pops-api routes
+      # outbound `pops:core/...` traffic to the core-api container.
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001}
     expose:
       - '3000'
     depends_on:
       pops-redis:
+        condition: service_healthy
+      core-api:
         condition: service_healthy
     healthcheck:
       test:
@@ -95,8 +135,11 @@ services:
       # PRD-100 — same module set as the api so worker jobs scope correctly.
       POPS_APPS: ${POPS_APPS:-}
       POPS_OVERLAYS: ${POPS_OVERLAYS:-}
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001}
     depends_on:
       pops-redis:
+        condition: service_healthy
+      core-api:
         condition: service_healthy
 
   # ── FOOD INGEST WORKER ───────────────────────────────────────────

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -18,10 +18,14 @@ services:
 
   # ── BACKEND ──────────────────────────────────────────────────────
 
-  # Core pillar API (ADR-026, Phase 3 PR 3). MUST be the first compose-up
-  # because other pillars register against its `/pillars` listing on boot.
-  # Today it only exposes /health + /pillars; subsequent pillar splits
-  # move settings, AI Ops, and URI dispatch behind this same container.
+  # Core pillar API (ADR-026, Phase 3 PR 3). Sibling pillars treat the
+  # core container as the authoritative pillar registry: `GET /pillars`
+  # returns a snapshot derived from the `POPS_PILLARS` env plus a
+  # synthetic `core` entry — there is no dynamic register-on-boot step.
+  # Startup ordering is enforced by `depends_on: core-api` (below) so
+  # consumers can rely on the snapshot being available when they boot.
+  # Today the container only exposes /health + /pillars; subsequent
+  # pillar splits move settings, AI Ops, and URI dispatch behind it.
   core-api:
     image: ghcr.io/knoxio/pops-core-api:${POPS_IMAGE_TAG:-main}
     container_name: pops-core-api


### PR DESCRIPTION
## Summary

Third PR of the core pillar **Phase 3 — core-api container** sequence (pillar-migration-roadmap.md Track D · Phase 3 PR 3 of 4).

Adds the core-api container to the dev and prod compose files, configures \`POPS_PILLARS\` so pops-api + pops-worker can route \`pops:core/...\` URIs to it, and adds it to the GHCR publish workflow + Docker-build validator.

## What changed

- \`infra/docker-compose.dev.yml\` — new \`core-api\` service with \`CORE_SQLITE_PATH\` pointing at the shared \`sqlite-data\` volume's \`core.db\`, \`CORE_SELF_BASE_URL\` matching the compose hostname, healthcheck on \`/health\`. \`pops-api\` + \`pops-worker\` now \`depends_on\` core-api (\`service_healthy\`) and inherit \`POPS_PILLARS=core:http://core-api:3001\` by default; the deployer can override with a fuller list as sibling pillars extract.
- \`infra/docker-compose.yml\` — same wiring under the GHCR image tag \`ghcr.io/knoxio/pops-core-api\` with the Watchtower label so auto-rollout works on push to main.
- \`.github/workflows/publish-images.yml\` — new metadata + build-push step for pops-core-api following the existing pops-mcp pattern.
- \`.github/workflows/docker-build.yml\` — path filter + builder-stage validate for \`apps/pops-core-api/\` so PR CI catches Dockerfile drift before merge.

## NOT in this PR

- pops-shell pillar-aware tRPC client (\`useCoreTrpc()\`) — Phase 3 PR 4.
- Migrating settings / AI Ops / URI dispatcher into core-api — out of scope for the pilot; subsequent pillar splits use the same container.

## Verification

- \`docker compose -f infra/docker-compose.dev.yml config --quiet\` runs clean
- \`docker compose -f infra/docker-compose.yml config --quiet\` runs clean

## Test plan

- [ ] CI green on \`docker-build\` (validates both compose files + builder stage of core-api Dockerfile)
- [ ] CI green on \`publish-images\` (push-only — verifies the new build-push step parses)
- [ ] Copilot review pass