### PR TITLE
feat(shell): route /pillars to core-api via nginx (phase 3 PR 4)

### DIFF
--- a/apps/pops-shell/nginx.conf
+++ b/apps/pops-shell/nginx.conf
@@ -52,7 +52,12 @@ server {
     # for now because the aggregator probe still depends on its internal
     # service registry; that endpoint moves to core-api when the
     # dispatcher migrates.
-    location = /pillars {
+    # Regex match so /pillars and /pillars/ both proxy to core-api
+    # (and similarly for /pillars/health). Exact-match locations would
+    # let a trailing-slash request fall through to the SPA
+    # `try_files ... /index.html`, reintroducing the silent-collapse
+    # behaviour this PR is trying to eliminate.
+    location ~ ^/pillars/?$ {
         proxy_pass http://core-api:3001/pillars;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
@@ -64,7 +69,7 @@ server {
         proxy_send_timeout 10s;
     }
 
-    location = /pillars/health {
+    location ~ ^/pillars/health/?$ {
         proxy_pass http://pops-api:3000/pillars/health;
         proxy_http_version 1.1;
         proxy_set_header Host $host;

--- a/apps/pops-shell/nginx.conf
+++ b/apps/pops-shell/nginx.conf
@@ -46,6 +46,36 @@ server {
         proxy_pass http://pops-api:3000/health;
     }
 
+    # Core pillar registry snapshot (ADR-026 phase 3 PR 4). The shell's
+    # `fetchPillarRegistry` hits `/pillars` at boot; route it to core-api
+    # which is the authoritative source. /pillars/health lives on pops-api
+    # for now because the aggregator probe still depends on its internal
+    # service registry; that endpoint moves to core-api when the
+    # dispatcher migrates.
+    location = /pillars {
+        proxy_pass http://core-api:3001/pillars;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_connect_timeout 5s;
+        proxy_read_timeout 10s;
+        proxy_send_timeout 10s;
+    }
+
+    location = /pillars/health {
+        proxy_pass http://pops-api:3000/pillars/health;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_connect_timeout 5s;
+        proxy_read_timeout 10s;
+        proxy_send_timeout 10s;
+    }
+
     # SPA fallback — serve index.html for all routes
     location / {
         try_files $uri $uri/ /index.html;

--- a/apps/pops-shell/src/app/pillars/pillar-registry-client.ts
+++ b/apps/pops-shell/src/app/pillars/pillar-registry-client.ts
@@ -10,8 +10,15 @@ import { CORE_PILLAR_ID } from './manifest-pillar';
  *   GET /pillars/health  → `{ health: Record<id, 'healthy' | 'unavailable'> }`
  *
  * Pillar `baseUrl`s are container-network addresses and are not
- * reachable from the browser; the aggregator on core-api does the
- * per-pillar HTTP fan-out. The shell consumes only the aggregated map.
+ * reachable from the browser; the aggregator does the per-pillar HTTP
+ * fan-out. The shell consumes only the aggregated map.
+ *
+ * Routing (apps/pops-shell/nginx.conf):
+ *   - `/pillars` proxies to core-api (the authoritative snapshot;
+ *     core pillar phase 3 PR 4).
+ *   - `/pillars/health` still proxies to pops-api because the
+ *     aggregator's outbound probe loop currently lives there; that
+ *     endpoint follows when the URI dispatcher migrates.
  *
  * Failures are intentionally soft. A registry fetch that errors,
  * parses to the wrong shape, or returns an empty list collapses to

--- a/apps/pops-shell/src/app/pillars/pillar-registry-client.ts
+++ b/apps/pops-shell/src/app/pillars/pillar-registry-client.ts
@@ -9,9 +9,12 @@ import { CORE_PILLAR_ID } from './manifest-pillar';
  *   GET /pillars         → `{ pillars: PillarRegistryEntry[] }`
  *   GET /pillars/health  → `{ health: Record<id, 'healthy' | 'unavailable'> }`
  *
- * Pillar `baseUrl`s are container-network addresses and are not
- * reachable from the browser; the aggregator does the per-pillar HTTP
- * fan-out. The shell consumes only the aggregated map.
+ * Pillar `baseUrl`s in the registry are container-network addresses
+ * (e.g. `http://core-api:3001`) and are NOT reachable from the
+ * browser. The shell stores them in the boot snapshot for downstream
+ * UI (status badges, ops surfaces) but never opens a browser-to-pillar
+ * connection itself; cross-pillar HTTP fan-out runs on `/pillars/health`
+ * aggregator instead.
  *
  * Routing (apps/pops-shell/nginx.conf):
  *   - `/pillars` proxies to core-api (the authoritative snapshot;


### PR DESCRIPTION
## Summary

Final PR of the core pillar **Phase 3 — core-api container** sequence (pillar-migration-roadmap.md Track D · Phase 3 PR 4 of 4). With this, **Phase 3 of 4 is complete** for the core pilot.

The shell's pillar registry snapshot now reads from core-api — the authoritative source — instead of falling through to the SPA \`index.html\` and silently collapsing to the synthetic \`core\` self-entry (the previous code path quietly hid the missing proxy).

## What changed

- \`apps/pops-shell/nginx.conf\` — new \`location = /pillars\` proxying \`http://core-api:3001/pillars\` with the same \`proxy_set_header\` + timeout pattern as \`/trpc\`. The aggregator endpoint \`/pillars/health\` gets its own explicit location pointing at \`pops-api:3000/pillars/health\` (was implicitly falling through to the SPA fallback; now explicitly routed).
- \`apps/pops-shell/src/app/pillars/pillar-registry-client.ts\` — comment block updated to document the split (\`/pillars\` → core-api; \`/pillars/health\` → pops-api until the URI dispatcher migrates).
- \`.claude/pillar-migration-roadmap.md\` row marked **Phase 3 COMPLETE** with lessons captured: shared \`parseBareOrigin\` validator; drop privileges in production Dockerfiles; passive snapshot vs register-on-boot; soft fallbacks hide deploy bugs.

## Phase 3 status

- ✅ PR 1 #2759 — \`pops-core-api\` container scaffold + Dockerfile + /health
- ✅ PR 2 #2760 — \`GET /pillars\` registry + shared \`parseBareOrigin\` contract
- ✅ PR 3 #2761 — docker-compose wiring + \`POPS_PILLARS\` + publish-images entry
- 🔄 PR 4 — nginx \`/pillars\` proxy → core-api (this)

## Test plan

- [ ] CI green on \`fe-quality\` / \`fe-test-e2e\` (shell + Playwright)
- [ ] CI green on \`docker-build\` (compose still parses)
- [ ] Copilot review pass