### PR TITLE
feat(food): cook/plan/fridge scaffold — unblock PRDs 143/144/145/146/147

### DIFF
--- a/apps/pops-api/src/modules/food/__tests__/cook-plan-fridge-scaffold.test.ts
+++ b/apps/pops-api/src/modules/food/__tests__/cook-plan-fridge-scaffold.test.ts
@@ -1,0 +1,151 @@
+/**
+ * I5-prep scaffold tests.
+ *
+ * Asserts the three new sub-routers (`food.batches`, `food.cook`,
+ * `food.plan`) are mounted, accept their PRD-spec'd inputs, and throw
+ * `NOT_IMPLEMENTED` at runtime. PRDs 143/144/145/146/147 swap real
+ * behaviour in without re-shaping the wire surface — this test stays
+ * green until then.
+ *
+ * Schema migrations are NOT loaded. The scaffold throws before touching
+ * the DB.
+ */
+
+import { TRPCError } from '@trpc/server';
+import { describe, expect, it } from 'vitest';
+
+import { createCaller } from '../../../shared/test-utils.js';
+
+type AnyError = unknown;
+
+function isNotImplemented(err: AnyError): boolean {
+  return err instanceof TRPCError && err.code === 'NOT_IMPLEMENTED';
+}
+
+describe('food.batches.* scaffold (PRD-145 + PRD-146)', () => {
+  const caller = createCaller();
+
+  it('rejects `create` with NOT_IMPLEMENTED', async () => {
+    await expect(
+      caller.food.batches.create({
+        variantId: 1,
+        prepStateId: null,
+        qty: 100,
+        unit: 'g',
+        location: 'fridge',
+        sourceType: 'purchase',
+      })
+    ).rejects.toSatisfy(isNotImplemented);
+  });
+
+  it('rejects `get` with NOT_IMPLEMENTED', async () => {
+    await expect(caller.food.batches.get({ id: 1 })).rejects.toSatisfy(isNotImplemented);
+  });
+
+  it('rejects `relocate` with NOT_IMPLEMENTED', async () => {
+    await expect(caller.food.batches.relocate({ id: 1, location: 'freezer' })).rejects.toSatisfy(
+      isNotImplemented
+    );
+  });
+
+  it('rejects `edit` with NOT_IMPLEMENTED', async () => {
+    await expect(caller.food.batches.edit({ id: 1, notes: 'hi' })).rejects.toSatisfy(
+      isNotImplemented
+    );
+  });
+
+  it('rejects `adjustQty` with NOT_IMPLEMENTED', async () => {
+    await expect(
+      caller.food.batches.adjustQty({ id: 1, delta: -10, reason: 'spoiled' })
+    ).rejects.toSatisfy(isNotImplemented);
+  });
+
+  it('rejects `delete` with NOT_IMPLEMENTED', async () => {
+    await expect(caller.food.batches.delete({ id: 1 })).rejects.toSatisfy(isNotImplemented);
+  });
+
+  it('rejects `searchForConsume` with NOT_IMPLEMENTED', async () => {
+    await expect(caller.food.batches.searchForConsume({ limit: 10 })).rejects.toSatisfy(
+      isNotImplemented
+    );
+  });
+});
+
+describe('food.cook.* scaffold (PRD-144)', () => {
+  const caller = createCaller();
+
+  it('rejects `prepareCook` with NOT_IMPLEMENTED', async () => {
+    await expect(
+      caller.food.cook.prepareCook({ recipeVersionId: 1, scaleFactor: 1 })
+    ).rejects.toSatisfy(isNotImplemented);
+  });
+
+  it('rejects `markCooked` with NOT_IMPLEMENTED', async () => {
+    await expect(
+      caller.food.cook.markCooked({ recipeVersionId: 1, scaleFactor: 1 })
+    ).rejects.toSatisfy(isNotImplemented);
+  });
+});
+
+describe('food.plan.* scaffold (PRD-143)', () => {
+  const caller = createCaller();
+
+  it('rejects `weekView` with NOT_IMPLEMENTED', async () => {
+    await expect(caller.food.plan.weekView({ weekStart: '2026-06-15' })).rejects.toSatisfy(
+      isNotImplemented
+    );
+  });
+
+  it('rejects `addEntry` with NOT_IMPLEMENTED', async () => {
+    await expect(
+      caller.food.plan.addEntry({
+        date: '2026-06-15',
+        slot: 'dinner',
+        recipeId: 1,
+        plannedServings: 2,
+      })
+    ).rejects.toSatisfy(isNotImplemented);
+  });
+
+  it('rejects `updateEntry` with NOT_IMPLEMENTED', async () => {
+    await expect(caller.food.plan.updateEntry({ id: 1, plannedServings: 3 })).rejects.toSatisfy(
+      isNotImplemented
+    );
+  });
+
+  it('rejects `moveEntry` with NOT_IMPLEMENTED', async () => {
+    await expect(
+      caller.food.plan.moveEntry({ id: 1, date: '2026-06-16', slot: 'lunch' })
+    ).rejects.toSatisfy(isNotImplemented);
+  });
+
+  it('rejects `reorderSlot` with NOT_IMPLEMENTED', async () => {
+    await expect(
+      caller.food.plan.reorderSlot({ date: '2026-06-15', slot: 'dinner', orderedIds: [1, 2] })
+    ).rejects.toSatisfy(isNotImplemented);
+  });
+
+  it('rejects `deleteEntry` with NOT_IMPLEMENTED', async () => {
+    await expect(caller.food.plan.deleteEntry({ id: 1 })).rejects.toSatisfy(isNotImplemented);
+  });
+
+  it('rejects `listSlots` with NOT_IMPLEMENTED', async () => {
+    await expect(caller.food.plan.listSlots()).rejects.toSatisfy(isNotImplemented);
+  });
+
+  it('rejects `addSlot` with NOT_IMPLEMENTED', async () => {
+    await expect(caller.food.plan.addSlot({ slug: 'tea', name: 'Tea' })).rejects.toSatisfy(
+      isNotImplemented
+    );
+  });
+
+  it('rejects `updateSlot` with NOT_IMPLEMENTED', async () => {
+    await expect(caller.food.plan.updateSlot({ slug: 'tea', name: 'High tea' })).rejects.toSatisfy(
+      isNotImplemented
+    );
+  });
+
+  it('rejects `deleteSlot` with NOT_IMPLEMENTED', async () => {
+    await expect(caller.food.plan.deleteSlot({ slug: 'tea' })).rejects.toSatisfy(isNotImplemented);
+  });
+});

--- a/apps/pops-api/src/modules/food/batches/inputs.ts
+++ b/apps/pops-api/src/modules/food/batches/inputs.ts
@@ -1,0 +1,68 @@
+/**
+ * Input Zod schemas for `food.batches.*` procedures.
+ *
+ * Shapes match PRD-145 (CRUD lifecycle) + PRD-146 (`searchForConsume`).
+ * Output types are inferred in the router via the cross-PRD contracts
+ * exported from `@pops/app-food-db/types/batches.ts`.
+ */
+
+import { z } from 'zod';
+
+const LOCATION = z.enum(['pantry', 'fridge', 'freezer', 'other']);
+const UNIT = z.enum(['g', 'ml', 'count']);
+const MANUAL_SOURCE_TYPE = z.enum(['purchase', 'gift', 'other']);
+const ADJUST_REASON = z.enum(['spoiled', 'wasted', 'correction']);
+
+export const CreateBatchInputSchema = z.object({
+  variantId: z.number().int().positive(),
+  prepStateId: z.number().int().positive().nullable(),
+  qty: z.number().finite().nonnegative(),
+  unit: UNIT,
+  location: LOCATION,
+  sourceType: MANUAL_SOURCE_TYPE,
+  producedAt: z.string().optional(),
+  expiresAt: z.string().optional(),
+  notes: z.string().max(1000).optional(),
+});
+
+export const GetBatchInputSchema = z.object({
+  id: z.number().int().positive(),
+});
+
+export const RelocateBatchInputSchema = z.object({
+  id: z.number().int().positive(),
+  location: LOCATION,
+});
+
+export const EditBatchInputSchema = z.object({
+  id: z.number().int().positive(),
+  expiresAt: z.string().nullable().optional(),
+  notes: z.string().max(1000).nullable().optional(),
+  prepStateId: z.number().int().positive().nullable().optional(),
+});
+
+export const AdjustBatchQtyInputSchema = z.object({
+  id: z.number().int().positive(),
+  delta: z.number().finite(),
+  reason: ADJUST_REASON,
+});
+
+export const DeleteBatchInputSchema = z.object({
+  id: z.number().int().positive(),
+});
+
+export const SearchForConsumeInputSchema = z.object({
+  ingredientId: z.number().int().positive().optional(),
+  variantId: z.number().int().positive().optional(),
+  location: LOCATION.optional(),
+  qtyGreaterThan: z.number().finite().nonnegative().optional(),
+  limit: z.number().int().positive().max(100).optional(),
+});
+
+export type CreateBatchInput = z.infer<typeof CreateBatchInputSchema>;
+export type GetBatchInput = z.infer<typeof GetBatchInputSchema>;
+export type RelocateBatchInput = z.infer<typeof RelocateBatchInputSchema>;
+export type EditBatchInput = z.infer<typeof EditBatchInputSchema>;
+export type AdjustBatchQtyInput = z.infer<typeof AdjustBatchQtyInputSchema>;
+export type DeleteBatchInput = z.infer<typeof DeleteBatchInputSchema>;
+export type SearchForConsumeInput = z.infer<typeof SearchForConsumeInputSchema>;

--- a/apps/pops-api/src/modules/food/batches/inputs.ts
+++ b/apps/pops-api/src/modules/food/batches/inputs.ts
@@ -13,6 +13,15 @@ const UNIT = z.enum(['g', 'ml', 'count']);
 const MANUAL_SOURCE_TYPE = z.enum(['purchase', 'gift', 'other']);
 const ADJUST_REASON = z.enum(['spoiled', 'wasted', 'correction']);
 
+/**
+ * ISO 8601 datetime. PRD-145 services parse `producedAt` / `expiresAt`
+ * as real timestamps (FIFO ordering, default-shelf-life arithmetic);
+ * validating here means invalid values fail at the API boundary rather
+ * than slipping into the DB. Same convention as
+ * `apps/pops-api/src/modules/food/routers/ingest-schemas.ts`.
+ */
+const IsoDateTime = z.string().datetime();
+
 export const CreateBatchInputSchema = z.object({
   variantId: z.number().int().positive(),
   prepStateId: z.number().int().positive().nullable(),
@@ -20,8 +29,8 @@ export const CreateBatchInputSchema = z.object({
   unit: UNIT,
   location: LOCATION,
   sourceType: MANUAL_SOURCE_TYPE,
-  producedAt: z.string().optional(),
-  expiresAt: z.string().optional(),
+  producedAt: IsoDateTime.optional(),
+  expiresAt: IsoDateTime.optional(),
   notes: z.string().max(1000).optional(),
 });
 
@@ -36,7 +45,7 @@ export const RelocateBatchInputSchema = z.object({
 
 export const EditBatchInputSchema = z.object({
   id: z.number().int().positive(),
-  expiresAt: z.string().nullable().optional(),
+  expiresAt: IsoDateTime.nullable().optional(),
   notes: z.string().max(1000).nullable().optional(),
   prepStateId: z.number().int().positive().nullable().optional(),
 });

--- a/apps/pops-api/src/modules/food/batches/router.ts
+++ b/apps/pops-api/src/modules/food/batches/router.ts
@@ -1,0 +1,70 @@
+/**
+ * `food.batches.*` tRPC router — scaffold for PRD-145 + PRD-146.
+ *
+ * Every procedure throws `NotImplemented` at runtime. Inputs are the
+ * real PRD-spec'd Zod schemas; outputs are typed against the contracts
+ * exported from `@pops/app-food-db`. PRDs 145 + 146 swap each
+ * implementation in turn without re-shaping the wire surface.
+ *
+ * `searchForConsume` is owned by PRD-146; the rest by PRD-145.
+ */
+
+import { TRPCError } from '@trpc/server';
+
+import { protectedProcedure, router } from '../../../trpc.js';
+import {
+  AdjustBatchQtyInputSchema,
+  CreateBatchInputSchema,
+  DeleteBatchInputSchema,
+  EditBatchInputSchema,
+  GetBatchInputSchema,
+  RelocateBatchInputSchema,
+  SearchForConsumeInputSchema,
+} from './inputs.js';
+
+import type {
+  BatchAdjustResult,
+  BatchDetail,
+  BatchForConsumeRow,
+  BatchMutationResult,
+} from '@pops/app-food-db';
+
+const NOT_IMPLEMENTED_MESSAGE =
+  'food.batches.* is a scaffold; PRD-145 + PRD-146 wire real behaviour';
+
+function notImplemented(): never {
+  throw new TRPCError({
+    code: 'NOT_IMPLEMENTED',
+    message: NOT_IMPLEMENTED_MESSAGE,
+  });
+}
+
+export const batchesRouter = router({
+  create: protectedProcedure
+    .input(CreateBatchInputSchema)
+    .mutation((): { batchId: number } => notImplemented()),
+
+  get: protectedProcedure
+    .input(GetBatchInputSchema)
+    .query((): BatchDetail | null => notImplemented()),
+
+  relocate: protectedProcedure
+    .input(RelocateBatchInputSchema)
+    .mutation((): BatchMutationResult => notImplemented()),
+
+  edit: protectedProcedure
+    .input(EditBatchInputSchema)
+    .mutation((): BatchMutationResult => notImplemented()),
+
+  adjustQty: protectedProcedure
+    .input(AdjustBatchQtyInputSchema)
+    .mutation((): BatchAdjustResult => notImplemented()),
+
+  delete: protectedProcedure
+    .input(DeleteBatchInputSchema)
+    .mutation((): BatchMutationResult => notImplemented()),
+
+  searchForConsume: protectedProcedure
+    .input(SearchForConsumeInputSchema)
+    .query((): { items: readonly BatchForConsumeRow[] } => notImplemented()),
+});

--- a/apps/pops-api/src/modules/food/cook/inputs.ts
+++ b/apps/pops-api/src/modules/food/cook/inputs.ts
@@ -41,7 +41,12 @@ const CookYieldInputSchema = z.object({
   qty: z.number().finite().nonnegative(),
   unit: UNIT,
   location: LOCATION,
-  expiresAt: z.string().optional(),
+  /**
+   * ISO 8601 datetime. Validated at the API boundary so invalid
+   * timestamps fail before `markCooked` opens its transaction.
+   * Same convention as `apps/pops-api/src/modules/food/routers/ingest-schemas.ts`.
+   */
+  expiresAt: z.string().datetime().optional(),
   notes: z.string().max(1000).optional(),
 });
 

--- a/apps/pops-api/src/modules/food/cook/inputs.ts
+++ b/apps/pops-api/src/modules/food/cook/inputs.ts
@@ -1,0 +1,65 @@
+/**
+ * Input Zod schemas for `food.cook.*` procedures.
+ *
+ * Shapes match PRD-144. `consumptionOverrides[]` shape is PRD-146's
+ * `ConsumptionOverride` discriminated union — kept here as a Zod schema
+ * so the wire boundary validates at the API edge.
+ */
+
+import { z } from 'zod';
+
+const UNIT = z.enum(['g', 'ml', 'count']);
+const LOCATION = z.enum(['pantry', 'fridge', 'freezer', 'other']);
+
+const LineIndex = z.number().int().positive();
+
+const ConsumptionOverrideSchema = z.discriminatedUnion('kind', [
+  z.object({
+    lineIndex: LineIndex,
+    kind: z.literal('batch-override'),
+    batchId: z.number().int().positive(),
+    consumeQty: z.number().finite().nonnegative(),
+    unit: UNIT,
+  }),
+  z.object({
+    lineIndex: LineIndex,
+    kind: z.literal('external'),
+    externalQty: z.number().finite().nonnegative(),
+    externalUnit: UNIT,
+  }),
+  z.object({
+    lineIndex: LineIndex,
+    kind: z.literal('partial'),
+    batchId: z.number().int().positive(),
+    consumeQty: z.number().finite().nonnegative(),
+    externalQty: z.number().finite().nonnegative(),
+    unit: UNIT,
+  }),
+]);
+
+const CookYieldInputSchema = z.object({
+  qty: z.number().finite().nonnegative(),
+  unit: UNIT,
+  location: LOCATION,
+  expiresAt: z.string().optional(),
+  notes: z.string().max(1000).optional(),
+});
+
+export const PrepareCookInputSchema = z.object({
+  recipeVersionId: z.number().int().positive(),
+  scaleFactor: z.number().finite().positive(),
+  planEntryId: z.number().int().positive().optional(),
+});
+
+export const MarkCookedInputSchema = z.object({
+  recipeVersionId: z.number().int().positive(),
+  scaleFactor: z.number().finite().positive(),
+  planEntryId: z.number().int().positive().optional(),
+  yield: CookYieldInputSchema.optional(),
+  rating: z.number().int().min(1).max(5).optional(),
+  notes: z.string().max(1000).optional(),
+  consumptionOverrides: z.array(ConsumptionOverrideSchema).optional(),
+});
+
+export type PrepareCookInput = z.infer<typeof PrepareCookInputSchema>;
+export type MarkCookedInput = z.infer<typeof MarkCookedInputSchema>;

--- a/apps/pops-api/src/modules/food/cook/router.ts
+++ b/apps/pops-api/src/modules/food/cook/router.ts
@@ -1,0 +1,34 @@
+/**
+ * `food.cook.*` tRPC router — scaffold for PRD-144.
+ *
+ * Two procedures. `prepareCook` is the modal-open query; `markCooked`
+ * is the transactional mutation that wraps PRD-108's `consumeForRun`
+ * + PRD-145's `createBatchFromRun`. Both throw `NotImplemented` here;
+ * PRD-144 swaps real bodies in without re-shaping the wire surface.
+ */
+
+import { TRPCError } from '@trpc/server';
+
+import { protectedProcedure, router } from '../../../trpc.js';
+import { MarkCookedInputSchema, PrepareCookInputSchema } from './inputs.js';
+
+import type { CookPreparation, MarkCookedResult } from '@pops/app-food-db';
+
+const NOT_IMPLEMENTED_MESSAGE = 'food.cook.* is a scaffold; PRD-144 wires real behaviour';
+
+function notImplemented(): never {
+  throw new TRPCError({
+    code: 'NOT_IMPLEMENTED',
+    message: NOT_IMPLEMENTED_MESSAGE,
+  });
+}
+
+export const cookRouter = router({
+  prepareCook: protectedProcedure
+    .input(PrepareCookInputSchema)
+    .query((): CookPreparation => notImplemented()),
+
+  markCooked: protectedProcedure
+    .input(MarkCookedInputSchema)
+    .mutation((): MarkCookedResult => notImplemented()),
+});

--- a/apps/pops-api/src/modules/food/index.ts
+++ b/apps/pops-api/src/modules/food/index.ts
@@ -1,8 +1,11 @@
 import { router } from '../../trpc.js';
+import { batchesRouter } from './batches/router.js';
 import { conversionsRouter } from './conversions/router.js';
+import { cookRouter } from './cook/router.js';
 import { heroImageRouter } from './hero-image/router.js';
 import { inboxRouter } from './inbox/router.js';
 import { foodMigrations } from './migrations.js';
+import { planRouter } from './plan/router.js';
 import { recipesRouter } from './recipes/router.js';
 import { aiRouter } from './routers/ai.js';
 import { aliasesRouter } from './routers/aliases.js';
@@ -28,6 +31,9 @@ export const foodRouter = router({
   ai: aiRouter,
   recipes: recipesRouter,
   inbox: inboxRouter,
+  batches: batchesRouter,
+  cook: cookRouter,
+  plan: planRouter,
 });
 
 export const manifest: ModuleManifest<typeof foodRouter> = {

--- a/apps/pops-api/src/modules/food/plan/inputs.ts
+++ b/apps/pops-api/src/modules/food/plan/inputs.ts
@@ -9,11 +9,19 @@
 import { z } from 'zod';
 
 const IsoDate = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'YYYY-MM-DD');
+
+/**
+ * Canonical food-domain slug grammar — lowercase ASCII kebab-case, no
+ * double hyphens, no leading/trailing hyphens. Mirrors
+ * `@pops/app-food-db/src/slug.ts`'s `SLUG_RE` so the API boundary
+ * rejects the same values the service layer rejects (lowercase only,
+ * `[a-z0-9]+(-[a-z0-9]+)*`).
+ */
 const SlugLike = z
   .string()
   .min(1)
   .max(64)
-  .regex(/^[a-z0-9][a-z0-9-]*$/i, 'slug-format');
+  .regex(/^[a-z0-9]+(-[a-z0-9]+)*$/, 'lowercase-kebab-case');
 
 export const WeekViewInputSchema = z.object({
   weekStart: IsoDate,

--- a/apps/pops-api/src/modules/food/plan/inputs.ts
+++ b/apps/pops-api/src/modules/food/plan/inputs.ts
@@ -1,0 +1,80 @@
+/**
+ * Input Zod schemas for `food.plan.*` procedures.
+ *
+ * Shapes match PRD-143. PRD-111's plan-slot service amendments
+ * (`addSlot`/`updateSlot`/`deleteSlot`) already shipped — the tRPC
+ * surface here adds the matching procedures.
+ */
+
+import { z } from 'zod';
+
+const IsoDate = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'YYYY-MM-DD');
+const SlugLike = z
+  .string()
+  .min(1)
+  .max(64)
+  .regex(/^[a-z0-9][a-z0-9-]*$/i, 'slug-format');
+
+export const WeekViewInputSchema = z.object({
+  weekStart: IsoDate,
+});
+
+export const AddPlanEntryInputSchema = z.object({
+  date: IsoDate,
+  slot: SlugLike,
+  recipeId: z.number().int().positive(),
+  plannedServings: z.number().int().positive(),
+  recipeVersionId: z.number().int().positive().optional(),
+  notes: z.string().max(1000).optional(),
+});
+
+export const UpdatePlanEntryInputSchema = z.object({
+  id: z.number().int().positive(),
+  plannedServings: z.number().int().positive().optional(),
+  recipeVersionId: z.number().int().positive().nullable().optional(),
+  notes: z.string().max(1000).nullable().optional(),
+});
+
+export const MovePlanEntryInputSchema = z.object({
+  id: z.number().int().positive(),
+  date: IsoDate,
+  slot: SlugLike,
+  position: z.number().int().nonnegative().optional(),
+});
+
+export const ReorderSlotInputSchema = z.object({
+  date: IsoDate,
+  slot: SlugLike,
+  orderedIds: z.array(z.number().int().positive()).min(1),
+});
+
+export const DeletePlanEntryInputSchema = z.object({
+  id: z.number().int().positive(),
+});
+
+export const ListSlotsInputSchema = z.object({}).optional();
+
+export const AddSlotInputSchema = z.object({
+  slug: SlugLike,
+  name: z.string().min(1).max(64),
+});
+
+export const UpdateSlotInputSchema = z.object({
+  slug: SlugLike,
+  name: z.string().min(1).max(64).optional(),
+  displayOrder: z.number().int().nonnegative().optional(),
+});
+
+export const DeleteSlotInputSchema = z.object({
+  slug: SlugLike,
+});
+
+export type WeekViewInput = z.infer<typeof WeekViewInputSchema>;
+export type AddPlanEntryInput = z.infer<typeof AddPlanEntryInputSchema>;
+export type UpdatePlanEntryInput = z.infer<typeof UpdatePlanEntryInputSchema>;
+export type MovePlanEntryInput = z.infer<typeof MovePlanEntryInputSchema>;
+export type ReorderSlotInput = z.infer<typeof ReorderSlotInputSchema>;
+export type DeletePlanEntryInput = z.infer<typeof DeletePlanEntryInputSchema>;
+export type AddSlotInput = z.infer<typeof AddSlotInputSchema>;
+export type UpdateSlotInput = z.infer<typeof UpdateSlotInputSchema>;
+export type DeleteSlotInput = z.infer<typeof DeleteSlotInputSchema>;

--- a/apps/pops-api/src/modules/food/plan/router.ts
+++ b/apps/pops-api/src/modules/food/plan/router.ts
@@ -1,0 +1,83 @@
+/**
+ * `food.plan.*` tRPC router — scaffold for PRD-143.
+ *
+ * 10 procedures matching the planning-page spec. Every procedure
+ * throws `NotImplemented` here; PRD-143 swaps real bodies in without
+ * re-shaping the wire surface.
+ *
+ * Slot management procedures (`addSlot`/`updateSlot`/`deleteSlot`)
+ * delegate to PRD-111's existing `planService` once wired — the
+ * underlying service amendments already shipped.
+ */
+
+import { TRPCError } from '@trpc/server';
+
+import { protectedProcedure, router } from '../../../trpc.js';
+import {
+  AddPlanEntryInputSchema,
+  AddSlotInputSchema,
+  DeletePlanEntryInputSchema,
+  DeleteSlotInputSchema,
+  MovePlanEntryInputSchema,
+  ReorderSlotInputSchema,
+  UpdatePlanEntryInputSchema,
+  UpdateSlotInputSchema,
+  WeekViewInputSchema,
+} from './inputs.js';
+
+import type {
+  PlanEntryMutationResult,
+  PlanSlotDeleteResult,
+  PlanSlotMutationResult,
+  PlanSlotRow,
+  PlanSlotUpdateResult,
+  ReorderSlotResult,
+  WeekView,
+} from '@pops/app-food-db';
+
+const NOT_IMPLEMENTED_MESSAGE = 'food.plan.* is a scaffold; PRD-143 wires real behaviour';
+
+function notImplemented(): never {
+  throw new TRPCError({
+    code: 'NOT_IMPLEMENTED',
+    message: NOT_IMPLEMENTED_MESSAGE,
+  });
+}
+
+export const planRouter = router({
+  weekView: protectedProcedure.input(WeekViewInputSchema).query((): WeekView => notImplemented()),
+
+  addEntry: protectedProcedure
+    .input(AddPlanEntryInputSchema)
+    .mutation((): { id: number; position: number } => notImplemented()),
+
+  updateEntry: protectedProcedure
+    .input(UpdatePlanEntryInputSchema)
+    .mutation((): PlanEntryMutationResult => notImplemented()),
+
+  moveEntry: protectedProcedure
+    .input(MovePlanEntryInputSchema)
+    .mutation((): PlanEntryMutationResult => notImplemented()),
+
+  reorderSlot: protectedProcedure
+    .input(ReorderSlotInputSchema)
+    .mutation((): ReorderSlotResult => notImplemented()),
+
+  deleteEntry: protectedProcedure
+    .input(DeletePlanEntryInputSchema)
+    .mutation((): PlanEntryMutationResult => notImplemented()),
+
+  listSlots: protectedProcedure.query((): { slots: readonly PlanSlotRow[] } => notImplemented()),
+
+  addSlot: protectedProcedure
+    .input(AddSlotInputSchema)
+    .mutation((): PlanSlotMutationResult => notImplemented()),
+
+  updateSlot: protectedProcedure
+    .input(UpdateSlotInputSchema)
+    .mutation((): PlanSlotUpdateResult => notImplemented()),
+
+  deleteSlot: protectedProcedure
+    .input(DeleteSlotInputSchema)
+    .mutation((): PlanSlotDeleteResult => notImplemented()),
+});

--- a/apps/pops-shell/src/i18n/locales/en-AU/navigation.json
+++ b/apps/pops-shell/src/i18n/locales/en-AU/navigation.json
@@ -20,6 +20,8 @@
   "food": "Food",
   "food.home": "Home",
   "food.recipes": "Recipes",
+  "food.plan": "Plan",
+  "food.fridge": "Fridge",
   "food.data": "Manage data",
   "food.prompts": "Prompts",
   "lists": "Lists",

--- a/apps/pops-shell/src/i18n/locales/pt-BR/navigation.json
+++ b/apps/pops-shell/src/i18n/locales/pt-BR/navigation.json
@@ -20,6 +20,8 @@
   "food": "Comida",
   "food.home": "Início",
   "food.recipes": "Receitas",
+  "food.plan": "Planejamento",
+  "food.fridge": "Geladeira",
   "food.data": "Gerenciar dados",
   "food.prompts": "Prompts",
   "lists": "Listas",

--- a/packages/app-food-db/src/index.ts
+++ b/packages/app-food-db/src/index.ts
@@ -151,3 +151,56 @@ export type {
   RecipeRendererVariant,
   RecipeVersionWithCompiledData,
 } from './recipe-renderer-types.js';
+
+// Cross-PRD type contracts for the cook / plan / fridge feature set
+// (PRDs 143-147). Split by domain so each downstream PRD owns one file.
+// PRD-146 shares `batches.ts` with PRD-145.
+export type {
+  ConsumptionNeed,
+  ConsumptionOverride,
+  CookPreparation,
+  CookYieldDefault,
+  CookYieldInput,
+  MarkCookedError,
+  MarkCookedResult,
+  Shortfall,
+} from './types/cook.js';
+export type {
+  PlanEntryError,
+  PlanEntryMutationResult,
+  PlanEntryRow,
+  PlanSlotDeleteError,
+  PlanSlotDeleteResult,
+  PlanSlotError,
+  PlanSlotMutationResult,
+  PlanSlotRow,
+  PlanSlotUpdateError,
+  PlanSlotUpdateResult,
+  ReorderSlotError,
+  ReorderSlotResult,
+  WeekView,
+} from './types/plan.js';
+export type {
+  BatchAdjustReason,
+  BatchAdjustResult,
+  BatchDetail,
+  BatchEditPatch,
+  BatchError,
+  BatchForConsumeRow,
+  BatchLocation,
+  BatchMutationResult,
+  BatchSourceType,
+  BatchUnit,
+  LineResolution,
+  ManualBatchInput,
+  ManualBatchSourceType,
+  YieldArgs,
+} from './types/batches.js';
+export type {
+  FridgeBatchRow,
+  FridgeIngredientGroup,
+  FridgeLocationSection,
+  FridgeView,
+  FridgeViewCounts,
+  RecipeForCookRow,
+} from './types/fridge.js';

--- a/packages/app-food-db/src/types/batches.ts
+++ b/packages/app-food-db/src/types/batches.ts
@@ -1,0 +1,123 @@
+/**
+ * Cross-PRD type contracts for batch lifecycle (PRD-145) + FIFO
+ * consumption UI (PRD-146).
+ *
+ * Owned jointly by PRD-145 (CRUD + lifecycle types) and PRD-146
+ * (`BatchForConsumeRow`, `LineResolution`). The tRPC `food.batches.*`
+ * router and the cook-modal components consume this file.
+ *
+ * Note: PRD-145 also ships the `batches.deleted_at` SQL migration —
+ * that's NOT in scope for the prep PR that originally landed this
+ * file. The `deletedAt` column on `BatchDetail` reflects the post-145
+ * schema; reads will return `null` until 145's ALTER TABLE merges.
+ */
+
+export type BatchLocation = 'pantry' | 'fridge' | 'freezer' | 'other';
+export type BatchUnit = 'g' | 'ml' | 'count';
+export type BatchSourceType = 'purchase' | 'recipe_run' | 'gift' | 'other';
+export type ManualBatchSourceType = 'purchase' | 'gift' | 'other';
+
+export interface BatchDetail {
+  id: number;
+  variantId: number;
+  variantName: string;
+  variantSlug: string;
+  ingredientId: number;
+  ingredientName: string;
+  ingredientSlug: string;
+  prepStateId: number | null;
+  prepStateLabel: string | null;
+  qtyRemaining: number;
+  unit: BatchUnit;
+  sourceType: BatchSourceType;
+  sourceId: number | null;
+  sourceRecipeRunId: number | null;
+  sourceRecipeSlug: string | null;
+  location: BatchLocation;
+  producedAt: string;
+  expiresAt: string | null;
+  notes: string | null;
+  deletedAt: string | null;
+  createdAt: string;
+}
+
+export interface YieldArgs {
+  variantId: number;
+  prepStateId: number | null;
+  qty: number;
+  unit: BatchUnit;
+  location: BatchLocation;
+  expiresAt?: string;
+  notes?: string;
+}
+
+export interface ManualBatchInput {
+  variantId: number;
+  prepStateId: number | null;
+  qty: number;
+  unit: BatchUnit;
+  location: BatchLocation;
+  sourceType: ManualBatchSourceType;
+  producedAt?: string;
+  expiresAt?: string;
+  notes?: string;
+}
+
+export interface BatchEditPatch {
+  expiresAt?: string | null;
+  notes?: string | null;
+  prepStateId?: number | null;
+}
+
+export type BatchAdjustReason = 'spoiled' | 'wasted' | 'correction';
+
+export type BatchError =
+  | 'BatchNotFound'
+  | 'BatchDeleted'
+  | 'NegativeQty'
+  | 'CannotEditFromRun'
+  | 'BadExpiry'
+  | 'BadAdjustment';
+
+export type BatchMutationResult = { ok: true } | { ok: false; reason: BatchError };
+
+export type BatchAdjustResult = { ok: true; newQty: number } | { ok: false; reason: BatchError };
+
+/**
+ * PRD-146 — search result row for the `BatchOverridePicker` widget.
+ * Returned by `food.batches.searchForConsume`. FIFO-ordered server-side
+ * by `expires_at ASC NULLS LAST, produced_at ASC`.
+ */
+export interface BatchForConsumeRow {
+  id: number;
+  variantId: number;
+  variantName: string;
+  variantSlug: string;
+  ingredientId: number;
+  ingredientName: string;
+  prepStateId: number | null;
+  prepStateLabel: string | null;
+  qtyRemaining: number;
+  unit: BatchUnit;
+  location: BatchLocation;
+  expiresAt: string | null;
+  producedAt: string;
+}
+
+/**
+ * PRD-146 — per-line resolution state held by `useCookResolution`.
+ *
+ * `fifo` = accept PRD-108's default; `batch-override` = user picked a
+ * specific batch; `external` = user marks the line as consumed
+ * outside the batch system; `partial` = some FIFO + some external.
+ */
+export type LineResolution =
+  | { kind: 'fifo' }
+  | { kind: 'batch-override'; batchId: number; consumeQty: number }
+  | { kind: 'external'; reasonNote?: string }
+  | {
+      kind: 'partial';
+      batchId: number;
+      consumeQty: number;
+      externalQty: number;
+    };

--- a/packages/app-food-db/src/types/cook.ts
+++ b/packages/app-food-db/src/types/cook.ts
@@ -1,0 +1,97 @@
+/**
+ * Cross-PRD type contracts for the cook flow (PRD-144).
+ *
+ * Owned by PRD-144. Re-exported through the package barrel so the tRPC
+ * router in pops-api and the React CookModal in @pops/app-food can both
+ * import without divergence.
+ *
+ * Imports `ConsumptionNeed` + `Shortfall` from PRD-108's existing
+ * `services/batches.ts` to avoid duplicating types that already exist.
+ */
+
+import type { ConsumptionNeed, Shortfall } from '../services/batches.js';
+
+export type { ConsumptionNeed, Shortfall };
+
+/**
+ * Pre-flight data for the cook modal. Returned by `food.cook.prepareCook`.
+ * The modal renders this once on open; the consume-preview panel multiplies
+ * `consumeNeeds[].qty` by `scaleFactor` client-side as the user adjusts it.
+ */
+export interface CookPreparation {
+  recipeTitle: string;
+  recipeSlug: string;
+  versionNo: number;
+  defaultScaleFactor: number;
+  yieldsBatch: boolean;
+  yieldDefault: CookYieldDefault | null;
+  consumeNeeds: readonly ConsumptionNeed[];
+  alreadyCooked: boolean;
+}
+
+export interface CookYieldDefault {
+  qty: number;
+  unit: 'g' | 'ml' | 'count';
+  variantName: string | null;
+  prepStateLabel: string | null;
+  shelfLifeFridgeDays: number | null;
+  shelfLifeFreezerDays: number | null;
+}
+
+/**
+ * Yield arguments supplied to `food.cook.markCooked` when the recipe
+ * produces a batch. Omitted for yieldless recipes.
+ */
+export interface CookYieldInput {
+  qty: number;
+  unit: 'g' | 'ml' | 'count';
+  location: 'pantry' | 'fridge' | 'freezer' | 'other';
+  expiresAt?: string;
+  notes?: string;
+}
+
+/**
+ * Per-line consumption override supplied to `food.cook.markCooked` by
+ * PRD-146's shortfall-resolution UI. Empty array on the happy path.
+ *
+ * `lineIndex` matches `recipe_lines.position` (PRD-116, 1-based).
+ */
+export type ConsumptionOverride =
+  | {
+      lineIndex: number;
+      kind: 'batch-override';
+      batchId: number;
+      consumeQty: number;
+      unit: 'g' | 'ml' | 'count';
+    }
+  | {
+      lineIndex: number;
+      kind: 'external';
+      externalQty: number;
+      externalUnit: 'g' | 'ml' | 'count';
+    }
+  | {
+      lineIndex: number;
+      kind: 'partial';
+      batchId: number;
+      consumeQty: number;
+      externalQty: number;
+      unit: 'g' | 'ml' | 'count';
+    };
+
+export type MarkCookedError =
+  | 'RecipeVersionNotFound'
+  | 'RecipeNotCompiled'
+  | 'PlanEntryNotFound'
+  | 'PlanEntryAlreadyCooked'
+  | 'YieldRequired'
+  | 'YieldForbidden'
+  | 'BadScaleFactor'
+  | 'BadYieldQty'
+  | 'BadRating'
+  | 'BadExpiry'
+  | 'ShortfallUnresolved';
+
+export type MarkCookedResult =
+  | { ok: true; recipeRunId: number; yieldedBatchId: number | null }
+  | { ok: false; reason: MarkCookedError; shortfalls?: readonly Shortfall[] };

--- a/packages/app-food-db/src/types/fridge.ts
+++ b/packages/app-food-db/src/types/fridge.ts
@@ -1,0 +1,59 @@
+/**
+ * Cross-PRD type contracts for the fridge view (PRD-147).
+ *
+ * Owned by PRD-147. The tRPC router in pops-api and the
+ * `FridgePage` + sub-components in @pops/app-food share these wire
+ * shapes.
+ */
+
+import type { BatchLocation, BatchSourceType, BatchUnit } from './batches.js';
+
+export interface FridgeBatchRow {
+  id: number;
+  variantName: string | null;
+  variantSlug: string | null;
+  prepStateLabel: string | null;
+  qtyRemaining: number;
+  unit: BatchUnit;
+  expiresAt: string | null;
+  daysToExpiry: number | null;
+  producedAt: string;
+  sourceType: BatchSourceType;
+  sourceRecipeSlug: string | null;
+  notes: string | null;
+  deletedAt: string | null;
+}
+
+export interface FridgeIngredientGroup {
+  ingredientId: number;
+  ingredientName: string;
+  ingredientSlug: string;
+  batches: readonly FridgeBatchRow[];
+}
+
+export interface FridgeLocationSection {
+  location: BatchLocation;
+  count: number;
+  ingredients: readonly FridgeIngredientGroup[];
+}
+
+export interface FridgeViewCounts {
+  visible: number;
+  empty: number;
+  deleted: number;
+}
+
+export interface FridgeView {
+  sections: readonly FridgeLocationSection[];
+  counts: FridgeViewCounts;
+}
+
+export interface RecipeForCookRow {
+  recipeId: number;
+  recipeSlug: string;
+  title: string;
+  recipeType: string | null;
+  lineCount: number;
+  recipeNeedsQty: number | null;
+  lastCookedAt: string | null;
+}

--- a/packages/app-food-db/src/types/plan.ts
+++ b/packages/app-food-db/src/types/plan.ts
@@ -1,0 +1,64 @@
+/**
+ * Cross-PRD type contracts for the planning page (PRD-143).
+ *
+ * Owned by PRD-143. The tRPC router in pops-api and the planning
+ * components in @pops/app-food both import from here so the wire shape
+ * has a single source of truth.
+ */
+
+export interface PlanSlotRow {
+  slug: string;
+  name: string;
+  displayOrder: number;
+  isDefault: boolean;
+}
+
+export interface PlanEntryRow {
+  id: number;
+  date: string;
+  slot: string;
+  position: number;
+  recipeId: number;
+  recipeSlug: string;
+  recipeTitle: string;
+  recipeType: string | null;
+  heroImagePath: string | null;
+  plannedServings: number;
+  recipeVersionId: number | null;
+  recipeRunId: number | null;
+  recipeRunCookedAt: string | null;
+  notes: string | null;
+}
+
+export interface WeekView {
+  weekStart: string;
+  weekEnd: string;
+  slots: readonly PlanSlotRow[];
+  entries: readonly PlanEntryRow[];
+}
+
+export type PlanEntryError =
+  | 'NotFound'
+  | 'AlreadyCooked'
+  | 'BadDate'
+  | 'BadSlot'
+  | 'RecipeArchived'
+  | 'RecipeHasNoCurrentVersion';
+
+export type PlanSlotError = 'SlugTaken' | 'SlugInvalid';
+
+export type PlanSlotUpdateError = 'SlotNotFound' | 'CannotEditDefault';
+
+export type PlanSlotDeleteError = 'SlotNotFound' | 'CannotDeleteDefault' | 'SlotInUse';
+
+export type ReorderSlotError = 'BadIds' | 'EmptySlot';
+
+export type PlanEntryMutationResult = { ok: true } | { ok: false; reason: PlanEntryError };
+
+export type PlanSlotMutationResult = { ok: true } | { ok: false; reason: PlanSlotError };
+
+export type PlanSlotUpdateResult = { ok: true } | { ok: false; reason: PlanSlotUpdateError };
+
+export type PlanSlotDeleteResult = { ok: true } | { ok: false; reason: PlanSlotDeleteError };
+
+export type ReorderSlotResult = { ok: true } | { ok: false; reason: ReorderSlotError };

--- a/packages/app-food/src/components/cook/BatchOverridePicker.tsx
+++ b/packages/app-food/src/components/cook/BatchOverridePicker.tsx
@@ -1,0 +1,19 @@
+/**
+ * Scaffold for PRD-146's batch picker — used inside `ShortfallRow` when
+ * the user chooses `batch-override` or `partial`. Queries
+ * `food.batches.searchForConsume` once wired.
+ */
+import type { ReactNode } from 'react';
+
+import type { BatchForConsumeRow } from '@pops/app-food-db';
+
+export interface BatchOverridePickerProps {
+  ingredientId?: number;
+  variantId?: number;
+  onSelect: (batch: BatchForConsumeRow) => void;
+  onCancel: () => void;
+}
+
+export function BatchOverridePicker(_props: BatchOverridePickerProps): ReactNode {
+  return null;
+}

--- a/packages/app-food/src/components/cook/ConsumePreviewPanel.tsx
+++ b/packages/app-food/src/components/cook/ConsumePreviewPanel.tsx
@@ -1,0 +1,18 @@
+/**
+ * Scaffold for PRD-146's consume-preview panel — embeds inside
+ * PRD-144's `CookModal`. Reads resolved lines from `useCookResolution`
+ * and renders the per-line resolution outcomes.
+ */
+import type { ReactNode } from 'react';
+
+import type { ConsumptionNeed, LineResolution } from '@pops/app-food-db';
+
+export interface ConsumePreviewPanelProps {
+  consumeNeeds: readonly ConsumptionNeed[];
+  scaleFactor: number;
+  resolutionMap: ReadonlyMap<number, LineResolution>;
+}
+
+export function ConsumePreviewPanel(_props: ConsumePreviewPanelProps): ReactNode {
+  return null;
+}

--- a/packages/app-food/src/components/cook/CookModal.tsx
+++ b/packages/app-food/src/components/cook/CookModal.tsx
@@ -1,0 +1,23 @@
+/**
+ * Scaffold for PRD-144's cook modal.
+ *
+ * Returns `null` until PRD-144 wires the real shell (scale / yield /
+ * rating / notes fields + embedded PRD-146 panels). The `extraItems`
+ * slot on `RecipeActionMenu` is the canonical entry point; PRD-119-B
+ * already exposes it (`packages/app-food/src/pages/recipes/RecipeActionMenu.tsx`).
+ */
+import type { ReactNode } from 'react';
+
+export interface CookModalProps {
+  recipeVersionId: number;
+  scaleFactor?: number;
+  planEntryId?: number;
+  isOpen: boolean;
+  onClose: () => void;
+  /** Called after a successful `food.cook.markCooked`. */
+  onCookedSuccess?: (result: { recipeRunId: number; yieldedBatchId: number | null }) => void;
+}
+
+export function CookModal(_props: CookModalProps): ReactNode {
+  return null;
+}

--- a/packages/app-food/src/components/cook/ShortfallList.tsx
+++ b/packages/app-food/src/components/cook/ShortfallList.tsx
@@ -1,0 +1,18 @@
+/**
+ * Scaffold for PRD-146's shortfall list — embeds inside PRD-144's
+ * `CookModal`. Lists every unresolved-need line; gates the Mark-cooked
+ * button via the resolution map.
+ */
+import type { ReactNode } from 'react';
+
+import type { LineResolution, Shortfall } from '@pops/app-food-db';
+
+export interface ShortfallListProps {
+  shortfalls: readonly Shortfall[];
+  resolutionMap: ReadonlyMap<number, LineResolution>;
+  onResolve: (lineIndex: number, resolution: LineResolution) => void;
+}
+
+export function ShortfallList(_props: ShortfallListProps): ReactNode {
+  return null;
+}

--- a/packages/app-food/src/components/cook/ShortfallRow.tsx
+++ b/packages/app-food/src/components/cook/ShortfallRow.tsx
@@ -1,0 +1,19 @@
+/**
+ * Scaffold for PRD-146's single shortfall row. Owned by the parent
+ * `ShortfallList`; offers the three resolution options
+ * (`batch-override`, `external`, `partial`) on a single line.
+ */
+import type { ReactNode } from 'react';
+
+import type { LineResolution, Shortfall } from '@pops/app-food-db';
+
+export interface ShortfallRowProps {
+  lineIndex: number;
+  shortfall: Shortfall;
+  resolution: LineResolution | undefined;
+  onResolve: (resolution: LineResolution) => void;
+}
+
+export function ShortfallRow(_props: ShortfallRowProps): ReactNode {
+  return null;
+}

--- a/packages/app-food/src/components/cook/useCookResolution.ts
+++ b/packages/app-food/src/components/cook/useCookResolution.ts
@@ -1,0 +1,31 @@
+/**
+ * Scaffold for PRD-146's resolution-state hook. Returns an empty
+ * resolution map until the real implementation lands. PRD-146 fills in
+ * the FIFO-default seeding + shortfall reconciliation.
+ */
+import { useMemo } from 'react';
+
+import type { ConsumptionNeed, LineResolution, Shortfall } from '@pops/app-food-db';
+
+export interface UseCookResolutionArgs {
+  consumeNeeds: readonly ConsumptionNeed[];
+  scaleFactor: number;
+  shortfalls: readonly Shortfall[];
+}
+
+export interface UseCookResolutionResult {
+  resolutionMap: ReadonlyMap<number, LineResolution>;
+  unresolvedCount: number;
+  setResolution: (lineIndex: number, resolution: LineResolution) => void;
+}
+
+export function useCookResolution(_args: UseCookResolutionArgs): UseCookResolutionResult {
+  return useMemo<UseCookResolutionResult>(
+    () => ({
+      resolutionMap: new Map<number, LineResolution>(),
+      unresolvedCount: 0,
+      setResolution: () => {},
+    }),
+    []
+  );
+}

--- a/packages/app-food/src/pages/fridge/AddBatchModal.tsx
+++ b/packages/app-food/src/pages/fridge/AddBatchModal.tsx
@@ -1,0 +1,15 @@
+/**
+ * Scaffold for PRD-147's "+ Add batch" modal — manual-entry path.
+ * Calls `food.batches.create` once wired.
+ */
+import type { ReactNode } from 'react';
+
+export interface AddBatchModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onAdded?: (batchId: number) => void;
+}
+
+export function AddBatchModal(_props: AddBatchModalProps): ReactNode {
+  return null;
+}

--- a/packages/app-food/src/pages/fridge/AdjustQtyModal.tsx
+++ b/packages/app-food/src/pages/fridge/AdjustQtyModal.tsx
@@ -1,0 +1,15 @@
+/**
+ * Scaffold for PRD-147's adjust-qty modal — record waste / spoilage /
+ * corrections. Calls `food.batches.adjustQty`.
+ */
+import type { ReactNode } from 'react';
+
+export interface AdjustQtyModalProps {
+  batchId: number | null;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function AdjustQtyModal(_props: AdjustQtyModalProps): ReactNode {
+  return null;
+}

--- a/packages/app-food/src/pages/fridge/BatchRow.tsx
+++ b/packages/app-food/src/pages/fridge/BatchRow.tsx
@@ -1,0 +1,17 @@
+/**
+ * Scaffold for PRD-147's batch-row card inside the sectioned fridge
+ * list. Clicking opens `EditBatchModal`; long-press / right-click
+ * surfaces the relocate / adjust / delete actions.
+ */
+import type { ReactNode } from 'react';
+
+import type { FridgeBatchRow as FridgeBatchRowData } from '@pops/app-food-db';
+
+export interface BatchRowProps {
+  batch: FridgeBatchRowData;
+  onEdit: (batchId: number) => void;
+}
+
+export function BatchRow(_props: BatchRowProps): ReactNode {
+  return null;
+}

--- a/packages/app-food/src/pages/fridge/DeleteBatchConfirm.tsx
+++ b/packages/app-food/src/pages/fridge/DeleteBatchConfirm.tsx
@@ -1,0 +1,16 @@
+/**
+ * Scaffold for PRD-147's soft-delete confirm dialog. Calls
+ * `food.batches.delete` (soft-delete via `deleted_at`, set by PRD-145).
+ */
+import type { ReactNode } from 'react';
+
+export interface DeleteBatchConfirmProps {
+  batchId: number | null;
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirmed?: () => void;
+}
+
+export function DeleteBatchConfirm(_props: DeleteBatchConfirmProps): ReactNode {
+  return null;
+}

--- a/packages/app-food/src/pages/fridge/EditBatchModal.tsx
+++ b/packages/app-food/src/pages/fridge/EditBatchModal.tsx
@@ -1,0 +1,15 @@
+/**
+ * Scaffold for PRD-147's edit-batch modal. Edits expiry / notes /
+ * prep-state. Calls `food.batches.edit` once wired.
+ */
+import type { ReactNode } from 'react';
+
+export interface EditBatchModalProps {
+  batchId: number | null;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function EditBatchModal(_props: EditBatchModalProps): ReactNode {
+  return null;
+}

--- a/packages/app-food/src/pages/fridge/FridgePage.tsx
+++ b/packages/app-food/src/pages/fridge/FridgePage.tsx
@@ -1,0 +1,11 @@
+/**
+ * Scaffold for PRD-147's fridge view — routed at `/food/fridge`.
+ *
+ * Returns the placeholder shell until PRD-147 ships the sectioned list
+ * + filter chips + add/edit/relocate/adjust/delete modals.
+ */
+import type { ReactNode } from 'react';
+
+export function FridgePage(): ReactNode {
+  return null;
+}

--- a/packages/app-food/src/pages/fridge/RelocateBatchModal.tsx
+++ b/packages/app-food/src/pages/fridge/RelocateBatchModal.tsx
@@ -1,0 +1,15 @@
+/**
+ * Scaffold for PRD-147's relocate modal — moves a batch between
+ * pantry / fridge / freezer / other. Calls `food.batches.relocate`.
+ */
+import type { ReactNode } from 'react';
+
+export interface RelocateBatchModalProps {
+  batchId: number | null;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function RelocateBatchModal(_props: RelocateBatchModalProps): ReactNode {
+  return null;
+}

--- a/packages/app-food/src/pages/plan/AddPlanEntryModal.tsx
+++ b/packages/app-food/src/pages/plan/AddPlanEntryModal.tsx
@@ -1,0 +1,17 @@
+/**
+ * Scaffold for PRD-143's add-entry modal. Opened from a "+" affordance
+ * on each plan-week cell; calls `food.plan.addEntry` once wired.
+ */
+import type { ReactNode } from 'react';
+
+export interface AddPlanEntryModalProps {
+  date: string;
+  slot: string;
+  isOpen: boolean;
+  onClose: () => void;
+  onAdded?: (entryId: number) => void;
+}
+
+export function AddPlanEntryModal(_props: AddPlanEntryModalProps): ReactNode {
+  return null;
+}

--- a/packages/app-food/src/pages/plan/PlanEntryEditSheet.tsx
+++ b/packages/app-food/src/pages/plan/PlanEntryEditSheet.tsx
@@ -1,0 +1,16 @@
+/**
+ * Scaffold for PRD-143's plan-entry edit sheet — bottom-sheet on
+ * mobile, side-sheet on desktop. Hosts the "Mark cooked" button that
+ * opens PRD-144's `CookModal` with `planEntryId` pre-populated.
+ */
+import type { ReactNode } from 'react';
+
+export interface PlanEntryEditSheetProps {
+  entryId: number | null;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function PlanEntryEditSheet(_props: PlanEntryEditSheetProps): ReactNode {
+  return null;
+}

--- a/packages/app-food/src/pages/plan/PlanEntryRow.tsx
+++ b/packages/app-food/src/pages/plan/PlanEntryRow.tsx
@@ -1,0 +1,16 @@
+/**
+ * Scaffold for PRD-143's plan-entry card row. Renders inside the week
+ * grid; clicking opens `PlanEntryEditSheet`.
+ */
+import type { ReactNode } from 'react';
+
+import type { PlanEntryRow as PlanEntryRowData } from '@pops/app-food-db';
+
+export interface PlanEntryRowProps {
+  entry: PlanEntryRowData;
+  onEdit: (entryId: number) => void;
+}
+
+export function PlanEntryRow(_props: PlanEntryRowProps): ReactNode {
+  return null;
+}

--- a/packages/app-food/src/pages/plan/PlanPage.tsx
+++ b/packages/app-food/src/pages/plan/PlanPage.tsx
@@ -1,0 +1,11 @@
+/**
+ * Scaffold for PRD-143's planning page — routed at `/food/plan`.
+ *
+ * Returns the placeholder shell until PRD-143 ships the grid + drag /
+ * drop + entry modals. Top-level routed component, no props.
+ */
+import type { ReactNode } from 'react';
+
+export function PlanPage(): ReactNode {
+  return null;
+}

--- a/packages/app-food/src/routes.tsx
+++ b/packages/app-food/src/routes.tsx
@@ -97,6 +97,10 @@ const RecipeDraftsPage = lazy(() =>
 const RecipeDraftEditPage = lazy(() =>
   import('./pages/recipes/RecipeDraftEditPage').then((m) => ({ default: m.RecipeDraftEditPage }))
 );
+const PlanPage = lazy(() => import('./pages/plan/PlanPage').then((m) => ({ default: m.PlanPage })));
+const FridgePage = lazy(() =>
+  import('./pages/fridge/FridgePage').then((m) => ({ default: m.FridgePage }))
+);
 
 /** Local type mirror for compile-time safety (shell owns the canonical types). */
 interface AppNavConfigShape {
@@ -119,6 +123,8 @@ export const navConfig = {
   items: [
     { path: '', label: 'Home', labelKey: 'food.home', icon: 'LayoutDashboard' },
     { path: '/recipes', label: 'Recipes', labelKey: 'food.recipes', icon: 'BookOpen' },
+    { path: '/plan', label: 'Plan', labelKey: 'food.plan', icon: 'Clock' },
+    { path: '/fridge', label: 'Fridge', labelKey: 'food.fridge', icon: 'Package' },
     { path: '/data', label: 'Manage data', labelKey: 'food.data', icon: 'Database' },
     { path: '/prompts', label: 'Prompts', labelKey: 'food.prompts', icon: 'FileText' },
   ],
@@ -155,4 +161,9 @@ export const routes: RouteObject[] = [
   { path: 'recipes/:slug/drafts', element: <RecipeDraftsPage /> },
   { path: 'recipes/:slug/drafts/:draftNo', element: <RecipeDraftEditPage /> },
   { path: 'prompts', element: <PromptViewerPage /> },
+  // I5-prep scaffolds — `PlanPage` (PRD-143) + `FridgePage` (PRD-147)
+  // render `null` until their owning PRDs wire real UI. Routes mounted
+  // up-front so navConfig links + cross-PRD imports resolve today.
+  { path: 'plan', element: <PlanPage /> },
+  { path: 'fridge', element: <FridgePage /> },
 ];


### PR DESCRIPTION
## Summary

Strictly-additive scaffolding PR that breaks the I5 five-PRD circular dependency cycle so PRDs 143/144/145/146/147 can ship in parallel instead of as one giant landing.

## What lands

**tRPC routers** (every procedure throws `NotImplemented`; input Zod schemas + output TS types are real PRD-spec'd shapes):
- `food.batches.*` (PRD-145 + PRD-146 union): `create` / `get` / `relocate` / `edit` / `adjustQty` / `delete` / `searchForConsume`
- `food.cook.*` (PRD-144): `prepareCook` / `markCooked`
- `food.plan.*` (PRD-143): `weekView` / `addEntry` / `updateEntry` / `moveEntry` / `reorderSlot` / `deleteEntry` / `listSlots` / `addSlot` / `updateSlot` / `deleteSlot`

**Cross-PRD type contracts** at `packages/app-food-db/src/types/{cook,plan,batches,fridge}.ts` — split by domain so each downstream PRD owns one file. PRD-146 shares `batches.ts` with PRD-145.

**Null-render React components** with typed Props at PRD-spec'd paths:
- `packages/app-food/src/components/cook/{CookModal,ConsumePreviewPanel,ShortfallList,ShortfallRow,BatchOverridePicker}.tsx` + `useCookResolution.ts`
- `packages/app-food/src/pages/plan/{PlanPage,PlanEntryRow,PlanEntryEditSheet,AddPlanEntryModal}.tsx`
- `packages/app-food/src/pages/fridge/{FridgePage,BatchRow,AddBatchModal,EditBatchModal,RelocateBatchModal,AdjustQtyModal,DeleteBatchConfirm}.tsx`

**Route + nav additions:** `/food/plan` + `/food/fridge` placeholders in `routes.tsx`; sidebar entries in `navConfig`; en-AU + pt-BR `navigation.json` labels.

## Out of scope

- PRD-145's `batches.deleted_at` schema migration (PRD-145 owner ships it as Wave A's first move)
- Real `packages/app-food/src/services/batches.ts` implementations (PRD-145)
- Per-component i18n keys + Storybook stories (each PRD owner ships their own)
- PRD-111's plan-slot service amendments (already shipped inline)

## Cadence after merge

I5 unblocks in this order: 145 → (144 ‖ 146) → 143 ‖ 147. Effective critical path drops from 5 to 3 PRDs deep, and four workspaces can run hot.

## Test plan

- [x] `pnpm -C apps/pops-api test cook-plan-fridge` — 19/19 pass (asserts every new procedure rejects with `NOT_IMPLEMENTED`)
- [x] `pnpm -C apps/pops-api test` — 4655/4655 (no regression)
- [x] `pnpm -C packages/app-food test` — 483/483
- [x] `pnpm -C apps/pops-shell test` — 339/339 (i18n key additions)
- [x] `pnpm -r typecheck` — clean across 17 packages
- [x] `pnpm lint` — clean
- [x] `pnpm format:check` — clean
- [x] `pnpm lint:boundaries` — clean