### PR TITLE
chore(pillar): fold ai into core (Track I decision)

### DIFF
--- a/apps/pops-api/src/db/known-pillars.ts
+++ b/apps/pops-api/src/db/known-pillars.ts
@@ -16,11 +16,17 @@
  * single source of truth so it stays consistent with the runtime story
  * documented in ADR-026).
  *
- * `ai` is included for completeness; the ADR notes it may fold into core
- * during Phase γ. Removing it here when that fold happens is a one-line
- * change.
+ * **`ai` was folded into core** during Phase γ (2026-06-10). `packages/app-ai/`
+ * remains as a UI shell — admin/observability for AI Ops — but its backend
+ * services (`apps/pops-api/src/modules/core/{ai-budgets,ai-observability,
+ * ai-alerts,ai-usage,ai-providers}`) and every AI migration
+ * (`0034_ai_observability` through `0056_ai_observability_repair`) already
+ * live in the core pillar's domain. There is no `packages/ai-db/` to build
+ * and no `pops-ai-api` container to scaffold; the entry is dropped here so
+ * the per-pillar runner doesn't probe for a non-existent package. The
+ * shell's `pillarIdForModule('ai')` returns `'core'` (default behaviour).
  *
- * @see .claude/pillar-migration-roadmap.md
+ * @see .claude/pillar-migration-roadmap.md (Track I — ai folds into core)
  */
 
 /** A single pillar's static metadata. */
@@ -44,8 +50,11 @@ function pillar(id: string): PillarDescriptor {
 /**
  * Canonical pillar list, in boot-time migration-apply order. Adding a new
  * pillar = adding a new entry here AND creating its `<id>-db` package.
- * Removing one (e.g. ai → core fold) = removing the entry AND folding its
- * migrations into core's journal via a manual migration.
+ *
+ * Removed 2026-06-10: `ai`. AI Ops is owned by the core pillar — no
+ * separate `packages/ai-db/` was ever created and every AI migration was
+ * authored against core's shared journal. The `app-ai` UI shell continues
+ * to consume `core`'s tRPC surface unchanged.
  */
 export const KNOWN_PILLARS: readonly PillarDescriptor[] = [
   pillar('core'),
@@ -53,7 +62,6 @@ export const KNOWN_PILLARS: readonly PillarDescriptor[] = [
   pillar('media'),
   pillar('inventory'),
   pillar('cerebrum'),
-  pillar('ai'),
   pillar('food'),
   pillar('lists'),
 ];

--- a/apps/pops-shell/src/app/pillars/manifest-pillar.ts
+++ b/apps/pops-shell/src/app/pillars/manifest-pillar.ts
@@ -3,9 +3,15 @@
  *
  * Today the entire backend is the `core` pillar: every module manifest's
  * routes resolve against `pops-api`'s tRPC. As mature pillars migrate
- * (Track E/F/G/H/I in `pillar-migration-roadmap.md`), the corresponding
+ * (Track E/F/G/H in `pillar-migration-roadmap.md`), the corresponding
  * module's mapping flips to the pillar's id and routes start observing
  * its health.
+ *
+ * **`ai` is a permanent exception** — it folded into core during Phase γ
+ * (Track I, 2026-06-10). `packages/app-ai/` is a UI shell whose backend
+ * lives in `apps/pops-api/src/modules/core/{ai-*}`. `pillarIdForModule('ai')`
+ * therefore returns `'core'` and stays that way; there will never be an
+ * `ai` pillar to map to.
  *
  * Keeping the mapping in a single function rather than on the manifest
  * itself is deliberate: per-pillar migrations land in the
@@ -23,6 +29,9 @@ export const CORE_PILLAR_ID = 'core';
  * module not yet known to this mapping is the monolith case, where every
  * module's backend lives in `core-api`. The PR that migrates a module
  * to its own pillar updates this function in the same change.
+ *
+ * `'ai'` always returns `'core'` per the Track I fold (see the file
+ * header) — no future PR will change that mapping.
  */
 export function pillarIdForModule(_moduleId: string): string {
   return CORE_PILLAR_ID;

--- a/apps/pops-shell/src/app/pillars/manifest-pillar.ts
+++ b/apps/pops-shell/src/app/pillars/manifest-pillar.ts
@@ -3,9 +3,9 @@
  *
  * Today the entire backend is the `core` pillar: every module manifest's
  * routes resolve against `pops-api`'s tRPC. As mature pillars migrate
- * (Track E/F/G/H in `pillar-migration-roadmap.md`), the corresponding
- * module's mapping flips to the pillar's id and routes start observing
- * its health.
+ * (Track E/F/G/H in `.claude/pillar-migration-roadmap.md`), the
+ * corresponding module's mapping flips to the pillar's id and routes
+ * start observing its health.
  *
  * **`ai` is a permanent exception** — it folded into core during Phase γ
  * (Track I, 2026-06-10). `packages/app-ai/` is a UI shell whose backend

--- a/docs/architecture/adr-026-pillar-architecture.md
+++ b/docs/architecture/adr-026-pillar-architecture.md
@@ -154,7 +154,9 @@ The audit found **zero** cross-domain FKs in the schema today that we'd lose by 
 
 ### Migration
 
-Domain-by-domain. Pilot = food (PRD-122-API's in-flight `@pops/app-food-db` extraction folds into the wider 4-package split). Order: prepare (drizzle-zod adoption, drizzle-kit per-pillar config, pillar registry + URI dispatcher, pops-shell pillar boot, container template) → food → core → finance → media → inventory → cerebrum → lists (pairs with PRD-139 landing the lists frontend) → ai (may fold into core; decide when its turn arrives).
+Domain-by-domain. Pilot = food (PRD-122-API's in-flight `@pops/app-food-db` extraction folds into the wider 4-package split). Order: prepare (drizzle-zod adoption, drizzle-kit per-pillar config, pillar registry + URI dispatcher, pops-shell pillar boot, container template) → food → core → finance → media → inventory → cerebrum → lists (pairs with PRD-139 landing the lists frontend).
+
+`ai` does not appear as a separate pillar. AI Ops is owned by the `core` pillar: every AI migration (`0034_ai_observability` through `0056_ai_observability_repair`) was authored against core's shared journal, and all AI backend services already live under `apps/pops-api/src/modules/core/{ai-budgets,ai-observability,ai-alerts,ai-usage,ai-providers}`. The `packages/app-ai/` module is a UI shell over core's tRPC and remains as such; no `packages/ai-db/` or `pops-ai-api` will ever exist. Track I in the migration roadmap formalises this decision.
 
 The migration plan lives in the private `.claude/pillar-migration-roadmap.md` (gitignored, symlinked across pops\* sibling workspaces). Sibling agents check that file for status, ordering, and per-pillar coordination notes.
 

--- a/packages/app-ai/src/manifest.ts
+++ b/packages/app-ai/src/manifest.ts
@@ -2,7 +2,13 @@ import { navConfig, routes } from './routes';
 
 /**
  * AI Ops frontend module manifest (PRD-098).
- * Metadata-only at this point — the runtime loader (PRD-100) will read it.
+ *
+ * **UI-only module owned by the core pillar.** AI Ops has no per-pillar
+ * `@pops/ai-db` package and no `pops-ai-api` container; its backend
+ * lives in `apps/pops-api/src/modules/core/{ai-budgets,ai-observability,
+ * ai-alerts,ai-usage,ai-providers}`, and the shell's
+ * `pillarIdForModule('ai')` returns `'core'` permanently per the Track I
+ * fold (see `.claude/pillar-migration-roadmap.md`).
  */
 import type { ModuleManifest } from '@pops/types';
 


### PR DESCRIPTION
## Summary

The original pillar plan listed `ai` as Track I with a *"may fold into core. Decide at the time"* note. Investigation at Phase γ start found that the fold is the correct call by inspection. There is nothing to extract.

## Evidence

- **`packages/app-ai/` is UI-only** — `manifest.ts`, `routes.tsx`, `pages/{AiUsagePage,CacheManagementPage}.tsx`. No backend services, no schema, no DB code, no migration directory.
- **All AI backend services already live under core**: `apps/pops-api/src/modules/core/{ai-budgets, ai-observability, ai-alerts, ai-usage, ai-providers}`. There is no `apps/pops-api/src/modules/ai/` to extract.
- **Every AI migration is already tagged `'core'`** in `apps/pops-api/src/db/migration-ownership.ts`: `0034_ai_observability`, `0035_ai_inference_log_drop_legacy_columns`, `0045_ai_inference_log`, `0050_ai_model_setting_alias`, `0053_ai_inference_daily`, `0055_ai_alert_rules`, `0056_ai_observability_repair`. None is tagged `'ai'`.
- **The `known-pillars.ts` docstring already anticipated this:** *"`ai` is included for completeness; the ADR notes it may fold into core during Phase γ. Removing it here when that fold happens is a one-line change."*

Building `packages/ai-db/` would be a directory with no content. Scaffolding `pops-ai-api` would be a container that only forwards back to core.

## Changes

| File | Change |
|---|---|
| `apps/pops-api/src/db/known-pillars.ts` | Drop `pillar('ai')` from `KNOWN_PILLARS`. Rewrite header to record the fold. No behavioural change at boot — the per-pillar runner just doesn't probe for a non-existent package. |
| `apps/pops-shell/src/app/pillars/manifest-pillar.ts` | Docstring note that `pillarIdForModule('ai')` returns `'core'` permanently. No code change. |
| `packages/app-ai/src/manifest.ts` | Docstring clarifying the module is a UI shell over core's backend. |

3 files, +32 / −9.

## Implications for downstream tracks

- **Track H (cerebrum)** still waits for an actual γ row (E/F/G) to ship. The ai fold doesn't count because no `<id>-db` package landed.
- **Track J (food) start gate** (≥50% γ rows ✅) was originally 3 of 5 (E/F/G/H/I); with ai folded it's 2 of 4 (E/F/G/H) — slightly easier to clear.

## Test plan

- [x] `pnpm -C apps/pops-api typecheck` — clean
- [x] `pnpm -C apps/pops-shell typecheck` — clean
- [x] `pnpm -C packages/app-ai typecheck` — clean
- [x] `pnpm -C apps/pops-api test per-pillar-migrations` — 7/7 (the per-pillar runner test uses a synthetic pillar list, not `KNOWN_PILLARS` directly)
- [x] `pnpm -C apps/pops-api test` — 4646/4646
- [x] `pnpm -C apps/pops-shell test` — 337/337
- [x] `pnpm lint` — no new findings
- [x] `pnpm format:check` — clean
- [x] `pnpm lint:boundaries` — clean