### PR TITLE
feat(finance): scaffold @pops/finance-db + wish-list slice (pillar finance phase 1 PR 1)

### DIFF
--- a/.github/workflows/finance-db-quality.yml
+++ b/.github/workflows/finance-db-quality.yml
@@ -1,0 +1,39 @@
+name: Finance DB Quality
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/finance-db/**"
+      - "packages/db-types/**"
+      - ".github/workflows/finance-db-quality.yml"
+      - ".github/workflows/_pkg-check.yml"
+  pull_request:
+
+jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - 'packages/finance-db/**'
+              - 'packages/db-types/**'
+              - '.github/workflows/finance-db-quality.yml'
+              - '.github/workflows/_pkg-check.yml'
+
+  quality:
+    needs: [changes]
+    if: always()
+    uses: ./.github/workflows/_pkg-check.yml
+    with:
+      package-path: packages/finance-db
+      needs-db-build: true
+      skip: ${{ github.event_name == 'pull_request' && needs.changes.outputs.relevant != 'true' }}

--- a/packages/finance-db/package.json
+++ b/packages/finance-db/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@pops/finance-db",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@pops/db-types": "workspace:*",
+    "better-sqlite3": "^12.10.0",
+    "drizzle-orm": "^0.45.2"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.12",
+    "@vitest/coverage-v8": "^4.1.8",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.8"
+  }
+}

--- a/packages/finance-db/src/__tests__/wishlist.test.ts
+++ b/packages/finance-db/src/__tests__/wishlist.test.ts
@@ -117,8 +117,8 @@ describe('listWishListItems', () => {
     expect(result.rows.map((r) => r.item)).toEqual(['Apple keyboard', 'Apple monitor', 'Couch']);
   });
 
-  it('filters by case-sensitive LIKE on item', () => {
-    const result = listWishListItems(db, { search: 'Apple', limit: 50, offset: 0 });
+  it('filters by LIKE on item (ASCII case-insensitive per SQLite default)', () => {
+    const result = listWishListItems(db, { search: 'apple', limit: 50, offset: 0 });
     expect(result.total).toBe(2);
     expect(result.rows.every((r) => r.item.startsWith('Apple'))).toBe(true);
   });

--- a/packages/finance-db/src/__tests__/wishlist.test.ts
+++ b/packages/finance-db/src/__tests__/wishlist.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Invariant tests for the wish-list service against an in-memory SQLite
+ * seeded with the canonical `wish_list` DDL. Pure DB + service layer —
+ * no tRPC, no Express, no auth middleware.
+ *
+ * Higher-level router coverage lives in pops-api's own integration suite
+ * and exercises the same service via the pops-api wrapper.
+ *
+ * The DDL is inlined rather than read from the shared baseline migration
+ * (`0000_naive_chameleon.sql`) because that migration creates the entire
+ * pre-modular schema (hundreds of tables) and applying it for every test
+ * here is wasted work. Phase 1 PR 2 will move the canonical statement
+ * into the package's own migration journal.
+ */
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { WishListItemNotFoundError } from '../errors.js';
+import {
+  createWishListItem,
+  deleteWishListItem,
+  getWishListItem,
+  listWishListItems,
+  updateWishListItem,
+} from '../services/wishlist.js';
+
+import type { FinanceDb } from '../services/internal.js';
+
+const WISH_LIST_DDL = `
+CREATE TABLE wish_list (
+  id text PRIMARY KEY NOT NULL,
+  notion_id text,
+  item text NOT NULL,
+  target_amount real,
+  saved real,
+  priority text,
+  url text,
+  notes text,
+  last_edited_time text NOT NULL
+);
+CREATE UNIQUE INDEX wish_list_notion_id_unique ON wish_list (notion_id);
+`;
+
+function freshDb(): FinanceDb {
+  const raw = new Database(':memory:');
+  raw.pragma('foreign_keys = ON');
+  raw.exec(WISH_LIST_DDL);
+  return drizzle(raw);
+}
+
+describe('createWishListItem', () => {
+  let db: FinanceDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('inserts a row with the supplied fields and a generated UUID', () => {
+    const created = createWishListItem(db, {
+      item: 'Espresso machine',
+      targetAmount: 1200,
+      saved: 250,
+      priority: 'Soon',
+      url: 'https://example.com/machine',
+      notes: 'Wait for sale',
+    });
+
+    expect(created.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+    expect(created.item).toBe('Espresso machine');
+    expect(created.targetAmount).toBe(1200);
+    expect(created.saved).toBe(250);
+    expect(created.priority).toBe('Soon');
+    expect(created.url).toBe('https://example.com/machine');
+    expect(created.notes).toBe('Wait for sale');
+    expect(created.lastEditedTime).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('defaults optional numeric and text fields to null', () => {
+    const created = createWishListItem(db, { item: 'Just the item' });
+    expect(created.targetAmount).toBeNull();
+    expect(created.saved).toBeNull();
+    expect(created.priority).toBeNull();
+    expect(created.url).toBeNull();
+    expect(created.notes).toBeNull();
+  });
+});
+
+describe('getWishListItem', () => {
+  let db: FinanceDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('returns the persisted row by id', () => {
+    const created = createWishListItem(db, { item: 'Bike rack' });
+    const fetched = getWishListItem(db, created.id);
+    expect(fetched).toEqual(created);
+  });
+
+  it('throws WishListItemNotFoundError for an unknown id', () => {
+    expect(() => getWishListItem(db, 'missing')).toThrow(WishListItemNotFoundError);
+  });
+});
+
+describe('listWishListItems', () => {
+  let db: FinanceDb;
+  beforeEach(() => {
+    db = freshDb();
+    createWishListItem(db, { item: 'Apple monitor', priority: 'Soon' });
+    createWishListItem(db, { item: 'Apple keyboard', priority: 'Needing' });
+    createWishListItem(db, { item: 'Couch', priority: 'One Day' });
+  });
+
+  it('returns all rows sorted by item with a total count', () => {
+    const result = listWishListItems(db, { limit: 50, offset: 0 });
+    expect(result.total).toBe(3);
+    expect(result.rows.map((r) => r.item)).toEqual(['Apple keyboard', 'Apple monitor', 'Couch']);
+  });
+
+  it('filters by case-sensitive LIKE on item', () => {
+    const result = listWishListItems(db, { search: 'Apple', limit: 50, offset: 0 });
+    expect(result.total).toBe(2);
+    expect(result.rows.every((r) => r.item.startsWith('Apple'))).toBe(true);
+  });
+
+  it('filters by priority equality', () => {
+    const result = listWishListItems(db, { priority: 'Soon', limit: 50, offset: 0 });
+    expect(result.total).toBe(1);
+    expect(result.rows[0]?.priority).toBe('Soon');
+  });
+
+  it('paginates via limit + offset and reports the unpaginated total', () => {
+    const page1 = listWishListItems(db, { limit: 2, offset: 0 });
+    const page2 = listWishListItems(db, { limit: 2, offset: 2 });
+    expect(page1.total).toBe(3);
+    expect(page1.rows).toHaveLength(2);
+    expect(page2.total).toBe(3);
+    expect(page2.rows).toHaveLength(1);
+  });
+});
+
+describe('updateWishListItem', () => {
+  let db: FinanceDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('patches only the supplied fields and bumps lastEditedTime', async () => {
+    const created = createWishListItem(db, { item: 'Tent', saved: 100 });
+    const original = created.lastEditedTime;
+    await new Promise((r) => setTimeout(r, 5));
+
+    const updated = updateWishListItem(db, created.id, { saved: 250, priority: 'Soon' });
+    expect(updated.id).toBe(created.id);
+    expect(updated.item).toBe('Tent');
+    expect(updated.saved).toBe(250);
+    expect(updated.priority).toBe('Soon');
+    expect(updated.lastEditedTime).not.toBe(original);
+  });
+
+  it('treats explicit null as a value (clears the field)', () => {
+    const created = createWishListItem(db, { item: 'Helmet', notes: 'Black, matte' });
+    const updated = updateWishListItem(db, created.id, { notes: null });
+    expect(updated.notes).toBeNull();
+  });
+
+  it('is a no-op when the patch is empty (but still returns the row)', () => {
+    const created = createWishListItem(db, { item: 'Mug' });
+    const updated = updateWishListItem(db, created.id, {});
+    expect(updated.lastEditedTime).toBe(created.lastEditedTime);
+    expect(updated.item).toBe('Mug');
+  });
+
+  it('throws WishListItemNotFoundError for an unknown id', () => {
+    expect(() => updateWishListItem(db, 'missing', { item: 'x' })).toThrow(
+      WishListItemNotFoundError
+    );
+  });
+});
+
+describe('deleteWishListItem', () => {
+  let db: FinanceDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('removes the row and subsequent get throws', () => {
+    const created = createWishListItem(db, { item: 'Backpack' });
+    deleteWishListItem(db, created.id);
+    expect(() => getWishListItem(db, created.id)).toThrow(WishListItemNotFoundError);
+  });
+
+  it('throws WishListItemNotFoundError when the row is already gone', () => {
+    expect(() => deleteWishListItem(db, 'missing')).toThrow(WishListItemNotFoundError);
+  });
+});

--- a/packages/finance-db/src/errors.ts
+++ b/packages/finance-db/src/errors.ts
@@ -1,0 +1,17 @@
+/**
+ * Typed errors raised by the finance domain service layer.
+ *
+ * These are plain Error subclasses — the service layer doesn't know about
+ * HTTP. The pops-api router/middleware maps them to the appropriate status
+ * codes when surfacing to clients. Mirrors `@pops/core-db`'s error pattern.
+ */
+
+export class WishListItemNotFoundError extends Error {
+  override readonly name = 'WishListItemNotFoundError' as const;
+  readonly id: string;
+
+  constructor(id: string) {
+    super(`Wish list item '${id}' not found`);
+    this.id = id;
+  }
+}

--- a/packages/finance-db/src/index.ts
+++ b/packages/finance-db/src/index.ts
@@ -1,0 +1,29 @@
+/**
+ * Backend-safe barrel for the finance domain's persistence layer.
+ *
+ * Hosts finance-owned tables (transactions, budgets, wish list, tag rules,
+ * tag vocabulary, corrections). Extracted from
+ * `apps/pops-api/src/modules/finance/` as the first mature-pillar migration
+ * following the core pilot, per ADR-026.
+ *
+ * Per the CI-never-breaks pattern the migration is incremental — this PR
+ * scaffolds the package and moves only the `wish-list` slice. The other
+ * slices (budgets, transactions, imports, tag rules, tag vocabulary, URI
+ * dispatcher) follow in subsequent PRs.
+ */
+export * from './errors.js';
+export * from './schema.js';
+
+export type { FinanceDb } from './services/internal.js';
+
+export * as wishListService from './services/wishlist.js';
+
+export {
+  WISH_LIST_PRIORITIES,
+  type WishListPriority,
+  type WishListRow,
+  type CreateWishListItemInput,
+  type UpdateWishListItemInput,
+  type WishListListResult,
+  type WishListQuery,
+} from './services/wishlist.js';

--- a/packages/finance-db/src/schema.ts
+++ b/packages/finance-db/src/schema.ts
@@ -1,0 +1,13 @@
+/**
+ * Local re-export of the finance domain tables.
+ *
+ * Canonical definitions live in `@pops/db-types/src/schema/*.ts` so the
+ * drizzle-kit config (which globs `packages/db-types/src/schema/*`) picks
+ * them up and the rest of the platform sees a single schema barrel.
+ *
+ * Services in this package import from here for ergonomics and so that
+ * the finance module's read surface stays self-describing.
+ *
+ * Mirrors the `@pops/core-db` schema re-export pattern.
+ */
+export { wishList } from '@pops/db-types';

--- a/packages/finance-db/src/services/internal.ts
+++ b/packages/finance-db/src/services/internal.ts
@@ -1,0 +1,11 @@
+/**
+ * Shared helpers for the finance schema service layer.
+ *
+ * Only `FinanceDb` is re-exported from the package barrel so callers can type
+ * the handle they pass in; any additional helpers added here stay internal
+ * to `src/services/*.ts`.
+ */
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+
+/** A drizzle handle — either the top-level db or a transaction. */
+export type FinanceDb = BetterSQLite3Database<Record<string, unknown>>;

--- a/packages/finance-db/src/services/wishlist.ts
+++ b/packages/finance-db/src/services/wishlist.ts
@@ -1,0 +1,148 @@
+/**
+ * Wish list CRUD against finance's SQLite via drizzle.
+ *
+ * The in-tree service in `apps/pops-api/src/modules/finance/wishlist/`
+ * still uses `getDrizzle()`; this package version takes a `FinanceDb`
+ * handle as its first argument. The cutover (PR 3 of phase 1) flips
+ * pops-api to call into here.
+ *
+ * Mirrors `@pops/core-db`'s service-account pattern: db-arg services,
+ * typed domain errors, no HTTP concerns.
+ */
+import { and, asc, count, eq, like } from 'drizzle-orm';
+
+import { WISH_LIST_PRIORITIES, type WishListPriority } from '@pops/db-types';
+
+import { WishListItemNotFoundError } from '../errors.js';
+import { wishList } from '../schema.js';
+
+import type { FinanceDb } from './internal.js';
+
+export { WISH_LIST_PRIORITIES, type WishListPriority };
+
+/** Raw drizzle row shape. */
+export type WishListRow = typeof wishList.$inferSelect;
+
+/** Mutable subset accepted on create. `notionId` stays the import/sync layer's job. */
+export interface CreateWishListItemInput {
+  item: string;
+  targetAmount?: number | null;
+  saved?: number | null;
+  priority?: WishListPriority | null;
+  url?: string | null;
+  notes?: string | null;
+}
+
+/** Same shape as create — all fields optional for PATCH semantics. */
+export interface UpdateWishListItemInput {
+  item?: string;
+  targetAmount?: number | null;
+  saved?: number | null;
+  priority?: WishListPriority | null;
+  url?: string | null;
+  notes?: string | null;
+}
+
+/** Result of a paginated `list` call. */
+export interface WishListListResult {
+  rows: WishListRow[];
+  total: number;
+}
+
+/** Filters + pagination accepted by `listWishListItems`. */
+export interface WishListQuery {
+  search?: string | undefined;
+  priority?: string | undefined;
+  limit: number;
+  offset: number;
+}
+
+/** List wish list items with optional search + priority filters and a count. */
+export function listWishListItems(db: FinanceDb, query: WishListQuery): WishListListResult {
+  const { search, priority, limit, offset } = query;
+  const conditions = [];
+  if (search) conditions.push(like(wishList.item, `%${search}%`));
+  if (priority) conditions.push(eq(wishList.priority, priority));
+  const where = conditions.length > 0 ? and(...conditions) : undefined;
+
+  const rows = db
+    .select()
+    .from(wishList)
+    .where(where)
+    .orderBy(asc(wishList.item))
+    .limit(limit)
+    .offset(offset)
+    .all();
+  const countRow = db.select({ total: count() }).from(wishList).where(where).all()[0];
+  const total = countRow?.total ?? 0;
+
+  return { rows, total };
+}
+
+/** Get a single wish list item by id. Throws `WishListItemNotFoundError` if missing. */
+export function getWishListItem(db: FinanceDb, id: string): WishListRow {
+  const row = db.select().from(wishList).where(eq(wishList.id, id)).get();
+  if (!row) throw new WishListItemNotFoundError(id);
+  return row;
+}
+
+/** Create a new wish list item. Generates a UUID and returns the persisted row. */
+export function createWishListItem(db: FinanceDb, input: CreateWishListItemInput): WishListRow {
+  const id = crypto.randomUUID();
+  const now = new Date().toISOString();
+
+  db.insert(wishList)
+    .values({
+      id,
+      item: input.item,
+      targetAmount: input.targetAmount ?? null,
+      saved: input.saved ?? null,
+      priority: input.priority ?? null,
+      url: input.url ?? null,
+      notes: input.notes ?? null,
+      lastEditedTime: now,
+    })
+    .run();
+
+  return getWishListItem(db, id);
+}
+
+function buildWishListUpdates(
+  input: UpdateWishListItemInput
+): Partial<typeof wishList.$inferInsert> {
+  const updates: Partial<typeof wishList.$inferInsert> = {};
+  if (input.item !== undefined) updates.item = input.item;
+  if (input.targetAmount !== undefined) updates.targetAmount = input.targetAmount ?? null;
+  if (input.saved !== undefined) updates.saved = input.saved ?? null;
+  if (input.priority !== undefined) updates.priority = input.priority ?? null;
+  if (input.url !== undefined) updates.url = input.url ?? null;
+  if (input.notes !== undefined) updates.notes = input.notes ?? null;
+  return updates;
+}
+
+/**
+ * Patch a wish list item. Throws `WishListItemNotFoundError` if missing.
+ * No-op writes (empty `input`) still re-read the row but skip the UPDATE.
+ */
+export function updateWishListItem(
+  db: FinanceDb,
+  id: string,
+  input: UpdateWishListItemInput
+): WishListRow {
+  getWishListItem(db, id);
+
+  const updates = buildWishListUpdates(input);
+  if (Object.keys(updates).length > 0) {
+    updates.lastEditedTime = new Date().toISOString();
+    db.update(wishList).set(updates).where(eq(wishList.id, id)).run();
+  }
+
+  return getWishListItem(db, id);
+}
+
+/** Delete a wish list item. Throws `WishListItemNotFoundError` if missing. */
+export function deleteWishListItem(db: FinanceDb, id: string): void {
+  getWishListItem(db, id);
+  const result = db.delete(wishList).where(eq(wishList.id, id)).run();
+  if (result.changes === 0) throw new WishListItemNotFoundError(id);
+}

--- a/packages/finance-db/src/services/wishlist.ts
+++ b/packages/finance-db/src/services/wishlist.ts
@@ -52,7 +52,7 @@ export interface WishListListResult {
 /** Filters + pagination accepted by `listWishListItems`. */
 export interface WishListQuery {
   search?: string | undefined;
-  priority?: string | undefined;
+  priority?: WishListPriority | undefined;
   limit: number;
   offset: number;
 }

--- a/packages/finance-db/tsconfig.json
+++ b/packages/finance-db/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "lib": ["ES2022"],
+    "types": [],
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/__tests__/**", "**/*.test.ts"]
+}

--- a/packages/finance-db/vitest.config.ts
+++ b/packages/finance-db/vitest.config.ts
@@ -1,0 +1,15 @@
+/// <reference types="vitest/config" />
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json-summary', 'html'],
+      reportsDirectory: 'coverage',
+      include: ['src/**/*.ts'],
+      exclude: ['**/node_modules/**', '**/dist/**', '**/*.test.ts'],
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1264,6 +1264,31 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
 
+  packages/finance-db:
+    dependencies:
+      '@pops/db-types':
+        specifier: workspace:*
+        version: link:../db-types
+      better-sqlite3:
+        specifier: ^12.10.0
+        version: 12.10.0
+      drizzle-orm:
+        specifier: ^0.45.2
+        version: 0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.10.0)
+    devDependencies:
+      '@types/better-sqlite3':
+        specifier: ^7.6.12
+        version: 7.6.13
+      '@vitest/coverage-v8':
+        specifier: ^4.1.8
+        version: 4.1.8(vitest@4.1.8)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@25.9.1)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
+
   packages/food-contracts:
     devDependencies:
       typescript:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,6 +12,7 @@ packages:
   - 'packages/overlay-ego'
   - 'packages/api-client'
   - 'packages/core-db'
+  - 'packages/finance-db'
   - 'packages/db-types'
   - 'packages/food-contracts'
   - 'packages/types'


### PR DESCRIPTION
## Summary

- First mature-pillar migration following the core pilot (ADR-026 / pillar-migration-roadmap Track E).
- Creates `@pops/finance-db` and moves the wish-list slice into the package with a db-arg service signature, mirroring `@pops/core-db`.
- Strictly additive — the in-tree `apps/pops-api/src/modules/finance/wishlist/` is untouched, so all existing callers keep working through `getDrizzle()`. PR 3 flips them.

## Scope

This is **PR 1 of 4** in finance Phase 1, per the [CI-never-breaks 4×4 pattern](../../../.claude/pillar-migration-roadmap.md#ci-never-breaks-pattern) the core pilot proved out.

Slices follow in their own PRs to keep blast radius bounded:
- wish-list (this PR)
- budgets
- transactions
- imports
- tag rules
- tag vocabulary
- URI dispatcher (finance's `pops:finance/...` URIs)

`finance-contract` / `finance-api` / `finance-ui` get created when their first content lands rather than as empty shells.

## Files

- `packages/finance-db/{package.json,tsconfig.json,vitest.config.ts}`
- `src/{index,schema,errors,services/internal}.ts`
- `src/services/wishlist.ts` (db-arg)
- `src/__tests__/wishlist.test.ts` — 14 cases against in-memory better-sqlite3 + inlined `wish_list` DDL
- `pnpm-workspace.yaml` entry
- `.github/workflows/finance-db-quality.yml` (no drift guard yet — PR 2 introduces it once the package owns its migration)

## Test plan

- [x] `pnpm --filter @pops/finance-db typecheck`
- [x] `pnpm --filter @pops/finance-db test` (14 / 14 passing)
- [x] `pnpm --filter @pops/finance-db build`
- [x] `pnpm typecheck` (full repo)
- [x] `pnpm lint` clean
- [x] Existing `@pops/api` test failures on main confirmed pre-existing and unrelated