### PR TITLE
feat(media): scaffold @pops/media-db + shelf-impressions slice (pillar media phase 1 PR 1)

### DIFF
--- a/.github/workflows/media-db-quality.yml
+++ b/.github/workflows/media-db-quality.yml
@@ -1,0 +1,65 @@
+name: Media DB Quality
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/media-db/**"
+      - "packages/db-types/**"
+      - "apps/pops-api/src/db/drizzle-migrations/0021_spooky_lockheed.sql"
+      - ".github/workflows/media-db-quality.yml"
+      - ".github/workflows/_pkg-check.yml"
+  pull_request:
+
+jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - 'packages/media-db/**'
+              - 'packages/db-types/**'
+              - 'apps/pops-api/src/db/drizzle-migrations/0021_spooky_lockheed.sql'
+              - '.github/workflows/media-db-quality.yml'
+              - '.github/workflows/_pkg-check.yml'
+
+  migration-drift-guard:
+    name: Migration drift (shared vs media-db)
+    needs: [changes]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Skip — no relevant changes"
+        if: github.event_name == 'pull_request' && needs.changes.outputs.relevant != 'true'
+        run: echo "Skipping — no relevant changes"
+      - uses: actions/checkout@v6
+        if: github.event_name != 'pull_request' || needs.changes.outputs.relevant == 'true'
+      - name: Diff media-db copy against shared journal copy
+        if: github.event_name != 'pull_request' || needs.changes.outputs.relevant == 'true'
+        run: |
+          set -euo pipefail
+          shared='apps/pops-api/src/db/drizzle-migrations/0021_spooky_lockheed.sql'
+          pillar='packages/media-db/migrations/0021_spooky_lockheed.sql'
+          if ! diff -q "$shared" "$pillar"; then
+            echo "::error::Migration drift detected: $shared and $pillar must be byte-identical during the transitional release cycle (media pillar phase 1)."
+            diff "$shared" "$pillar" || true
+            exit 1
+          fi
+          echo "OK — both 0021_spooky_lockheed.sql copies are byte-identical."
+
+  quality:
+    needs: [changes]
+    if: always()
+    uses: ./.github/workflows/_pkg-check.yml
+    with:
+      package-path: packages/media-db
+      needs-db-build: true
+      skip: ${{ github.event_name == 'pull_request' && needs.changes.outputs.relevant != 'true' }}

--- a/packages/media-db/migrations/0021_spooky_lockheed.sql
+++ b/packages/media-db/migrations/0021_spooky_lockheed.sql
@@ -1,0 +1,7 @@
+CREATE TABLE `shelf_impressions` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`shelf_id` text NOT NULL,
+	`shown_at` text DEFAULT (datetime('now')) NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `idx_shelf_impressions_shelf_id` ON `shelf_impressions` (`shelf_id`);

--- a/packages/media-db/package.json
+++ b/packages/media-db/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@pops/media-db",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@pops/db-types": "workspace:*",
+    "better-sqlite3": "^12.10.0",
+    "drizzle-orm": "^0.45.2"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.12",
+    "@vitest/coverage-v8": "^4.1.8",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.8"
+  }
+}

--- a/packages/media-db/src/__tests__/shelf-impressions.test.ts
+++ b/packages/media-db/src/__tests__/shelf-impressions.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Invariant tests for the shelf-impressions service against an in-memory
+ * SQLite seeded with the canonical `shelf_impressions` migration. Pure DB +
+ * service layer — no tRPC, no Express, no media-discovery selection logic.
+ *
+ * Higher-level discovery-session integration coverage lives in pops-api's
+ * own suite and exercises the same service via the pops-api wrapper.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { shelfImpressions } from '../schema.js';
+import {
+  cleanupOldImpressions,
+  getRecentImpressions,
+  getShelfFreshness,
+  initImpressionsService,
+  recordImpressions,
+} from '../services/shelf-impressions.js';
+
+import type { MediaDb } from '../services/internal.js';
+
+const MIGRATION_PATH = join(__dirname, '../../migrations/0021_spooky_lockheed.sql');
+
+function freshDb(): { db: MediaDb; raw: Database.Database } {
+  const raw = new Database(':memory:');
+  raw.pragma('foreign_keys = ON');
+  const sql = readFileSync(MIGRATION_PATH, 'utf8');
+  for (const stmt of sql.split('--> statement-breakpoint')) {
+    const trimmed = stmt.trim();
+    if (trimmed.length > 0) raw.exec(trimmed);
+  }
+  return { db: drizzle(raw), raw };
+}
+
+/** Insert a row with an explicit `shown_at` for deterministic window tests. */
+function insertImpression(raw: Database.Database, shelfId: string, shownAt: string): void {
+  raw
+    .prepare('INSERT INTO shelf_impressions (shelf_id, shown_at) VALUES (?, ?)')
+    .run(shelfId, shownAt);
+}
+
+function sqliteFormat(date: Date): string {
+  return date.toISOString().replace('T', ' ').slice(0, 19);
+}
+
+function daysAgo(days: number): string {
+  return sqliteFormat(new Date(Date.now() - days * 24 * 60 * 60 * 1000));
+}
+
+describe('recordImpressions', () => {
+  let db: MediaDb;
+  let raw: Database.Database;
+  beforeEach(() => {
+    ({ db, raw } = freshDb());
+  });
+
+  it('is a no-op when given an empty list', () => {
+    recordImpressions(db, []);
+    const rows = db.select().from(shelfImpressions).all();
+    expect(rows).toHaveLength(0);
+  });
+
+  it('inserts one row per shelf id', () => {
+    recordImpressions(db, ['trending', 'because-you-watched:42']);
+    const rows = raw.prepare('SELECT shelf_id FROM shelf_impressions ORDER BY id').all() as {
+      shelf_id: string;
+    }[];
+    expect(rows.map((r) => r.shelf_id)).toEqual(['trending', 'because-you-watched:42']);
+  });
+
+  it('inserts a row for each call (no dedup)', () => {
+    recordImpressions(db, ['trending']);
+    recordImpressions(db, ['trending']);
+    recordImpressions(db, ['trending']);
+    const [{ total }] = raw
+      .prepare('SELECT COUNT(*) AS total FROM shelf_impressions WHERE shelf_id = ?')
+      .all('trending') as { total: number }[];
+    expect(total).toBe(3);
+  });
+
+  it('stamps `shown_at` via the table default when not provided', () => {
+    recordImpressions(db, ['trending']);
+    const [row] = raw
+      .prepare('SELECT shown_at FROM shelf_impressions WHERE shelf_id = ?')
+      .all('trending') as { shown_at: string }[];
+    expect(row.shown_at).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
+  });
+});
+
+describe('getRecentImpressions', () => {
+  let db: MediaDb;
+  let raw: Database.Database;
+  beforeEach(() => {
+    ({ db, raw } = freshDb());
+  });
+
+  it('returns an empty map when the table is empty', () => {
+    expect(getRecentImpressions(db).size).toBe(0);
+  });
+
+  it('groups counts by shelf id within the window', () => {
+    insertImpression(raw, 'trending', daysAgo(1));
+    insertImpression(raw, 'trending', daysAgo(2));
+    insertImpression(raw, 'trending', daysAgo(3));
+    insertImpression(raw, 'because-you-watched:42', daysAgo(1));
+
+    const result = getRecentImpressions(db, 7);
+    expect(result.size).toBe(2);
+    expect(result.get('trending')).toBe(3);
+    expect(result.get('because-you-watched:42')).toBe(1);
+  });
+
+  it('excludes impressions outside the lookback window', () => {
+    insertImpression(raw, 'trending', daysAgo(1));
+    insertImpression(raw, 'trending', daysAgo(8));
+    insertImpression(raw, 'stale', daysAgo(20));
+
+    const result = getRecentImpressions(db, 7);
+    expect(result.get('trending')).toBe(1);
+    expect(result.has('stale')).toBe(false);
+  });
+
+  it('defaults the window to 7 days', () => {
+    insertImpression(raw, 'trending', daysAgo(6));
+    insertImpression(raw, 'trending', daysAgo(8));
+    expect(getRecentImpressions(db).get('trending')).toBe(1);
+  });
+
+  it('treats `days = 0` as "everything strictly newer than now" — nothing matches', () => {
+    insertImpression(raw, 'trending', daysAgo(1));
+    expect(getRecentImpressions(db, 0).size).toBe(0);
+  });
+});
+
+describe('getShelfFreshness', () => {
+  it('returns 1.0 for a shelf never shown', () => {
+    expect(getShelfFreshness(0)).toBe(1);
+  });
+
+  it('returns 0.5 after one impression', () => {
+    expect(getShelfFreshness(1)).toBeCloseTo(0.5);
+  });
+
+  it('is monotonically non-increasing as the count rises', () => {
+    expect(getShelfFreshness(0)).toBeGreaterThan(getShelfFreshness(1));
+    expect(getShelfFreshness(1)).toBeGreaterThan(getShelfFreshness(2));
+    expect(getShelfFreshness(2)).toBeGreaterThan(getShelfFreshness(5));
+  });
+
+  it('hits the 0.1 floor at the formula boundary (count = 9)', () => {
+    expect(getShelfFreshness(9)).toBeCloseTo(0.1);
+  });
+
+  it('clamps to the 0.1 floor for any count past the boundary', () => {
+    expect(getShelfFreshness(10)).toBe(0.1);
+    expect(getShelfFreshness(100)).toBe(0.1);
+    expect(getShelfFreshness(9_999)).toBe(0.1);
+  });
+});
+
+describe('cleanupOldImpressions', () => {
+  let db: MediaDb;
+  let raw: Database.Database;
+  beforeEach(() => {
+    ({ db, raw } = freshDb());
+  });
+
+  it('deletes rows older than the 30-day retention window', () => {
+    insertImpression(raw, 'recent', daysAgo(5));
+    insertImpression(raw, 'borderline', daysAgo(29));
+    insertImpression(raw, 'ancient', daysAgo(45));
+    insertImpression(raw, 'really-ancient', daysAgo(365));
+
+    cleanupOldImpressions(db);
+
+    const remaining = raw
+      .prepare('SELECT shelf_id FROM shelf_impressions ORDER BY shelf_id')
+      .all() as { shelf_id: string }[];
+    expect(remaining.map((r) => r.shelf_id).toSorted()).toEqual(['borderline', 'recent']);
+  });
+
+  it('is idempotent (re-running deletes nothing more)', () => {
+    insertImpression(raw, 'ancient', daysAgo(45));
+    cleanupOldImpressions(db);
+    cleanupOldImpressions(db);
+    const [{ total }] = raw.prepare('SELECT COUNT(*) AS total FROM shelf_impressions').all() as {
+      total: number;
+    }[];
+    expect(total).toBe(0);
+  });
+
+  it('leaves a fresh table untouched', () => {
+    insertImpression(raw, 'recent', daysAgo(1));
+    cleanupOldImpressions(db);
+    const [{ total }] = raw.prepare('SELECT COUNT(*) AS total FROM shelf_impressions').all() as {
+      total: number;
+    }[];
+    expect(total).toBe(1);
+  });
+});
+
+describe('initImpressionsService', () => {
+  let db: MediaDb;
+  let raw: Database.Database;
+  beforeEach(() => {
+    ({ db, raw } = freshDb());
+  });
+
+  it('cleans up old impressions on init', () => {
+    insertImpression(raw, 'recent', daysAgo(5));
+    insertImpression(raw, 'ancient', daysAgo(60));
+
+    initImpressionsService(db);
+
+    const remaining = raw.prepare('SELECT shelf_id FROM shelf_impressions').all() as {
+      shelf_id: string;
+    }[];
+    expect(remaining.map((r) => r.shelf_id)).toEqual(['recent']);
+  });
+});

--- a/packages/media-db/src/index.ts
+++ b/packages/media-db/src/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Backend-safe barrel for the media domain's persistence layer.
+ *
+ * Hosts the media pillar's tables (rotation, comparisons, watchlist, watch
+ * history, movies, tv shows, discovery, debrief, shelf impressions, …)
+ * extracted from `apps/pops-api/src/modules/media/` per ADR-026 / Track F
+ * of `.claude/pillar-migration-roadmap.md`.
+ *
+ * Per the CI-never-breaks pattern the migration is incremental — this PR
+ * scaffolds the package and moves only the `shelf-impressions` slice. The
+ * remaining slices (watchlist, watch history, comparisons, rotation,
+ * discovery, debrief, movies, tv shows, …) follow in subsequent PRs.
+ */
+export * from './schema.js';
+
+export type { MediaDb } from './services/internal.js';
+
+export * as shelfImpressionsService from './services/shelf-impressions.js';

--- a/packages/media-db/src/schema.ts
+++ b/packages/media-db/src/schema.ts
@@ -1,0 +1,14 @@
+/**
+ * Local re-export of the media domain tables.
+ *
+ * Canonical definitions live in `@pops/db-types/src/schema/*.ts` so the
+ * drizzle-kit config (which globs `packages/db-types/src/schema/*`) picks
+ * them up and the rest of the platform sees a single schema barrel.
+ *
+ * Services in this package import from here for ergonomics and so that
+ * the media module's read surface stays self-describing.
+ *
+ * Mirrors the `@pops/core-db` schema re-export pattern. The shape grows as
+ * subsequent Phase 1 PRs migrate additional media tables into this package.
+ */
+export { shelfImpressions } from '@pops/db-types';

--- a/packages/media-db/src/services/internal.ts
+++ b/packages/media-db/src/services/internal.ts
@@ -1,0 +1,11 @@
+/**
+ * Shared helpers for the media schema service layer.
+ *
+ * Only `MediaDb` is re-exported from the package barrel so callers can type
+ * the handle they pass in; any additional helpers added here stay internal
+ * to `src/services/*.ts`. Mirrors `@pops/core-db`'s `CoreDb` alias.
+ */
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+
+/** A drizzle handle — either the top-level db or a transaction. */
+export type MediaDb = BetterSQLite3Database<Record<string, unknown>>;

--- a/packages/media-db/src/services/shelf-impressions.ts
+++ b/packages/media-db/src/services/shelf-impressions.ts
@@ -1,0 +1,83 @@
+/**
+ * Shelf impressions service — tracks how often each shelf has been shown so
+ * that freshness scores can down-rank recently-surfaced shelves.
+ *
+ * Services take a `MediaDb` handle as their first argument; the calling
+ * layer (pops-api modules) is responsible for resolving the singleton or
+ * transaction handle to pass in. Mirrors `@pops/core-db`'s service
+ * signature pattern.
+ */
+import { count, gte, lt } from 'drizzle-orm';
+
+import { shelfImpressions } from '../schema.js';
+
+import type { MediaDb } from './internal.js';
+
+const RECENT_WINDOW_DAYS_DEFAULT = 7;
+const RETENTION_DAYS = 30;
+const FRESHNESS_FLOOR = 0.1;
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * SQLite's `datetime('now')` returns `YYYY-MM-DD HH:MM:SS` (space-delimited,
+ * second precision). Match that format when comparing against `shown_at`
+ * values that were written by the table default expression.
+ */
+function sqliteTimestamp(date: Date): string {
+  return date.toISOString().replace('T', ' ').slice(0, 19);
+}
+
+/** Insert one impression row per shelf id shown in a session. No-op on empty input. */
+export function recordImpressions(db: MediaDb, shelfIds: string[]): void {
+  if (shelfIds.length === 0) return;
+  db.insert(shelfImpressions)
+    .values(shelfIds.map((shelfId) => ({ shelfId })))
+    .run();
+}
+
+/**
+ * Map of `shelfId → impressionCount` for the last `days` days. Only shelf
+ * ids with at least one impression in the window are included.
+ */
+export function getRecentImpressions(
+  db: MediaDb,
+  days: number = RECENT_WINDOW_DAYS_DEFAULT
+): Map<string, number> {
+  const cutoff = sqliteTimestamp(new Date(Date.now() - days * MS_PER_DAY));
+  const rows = db
+    .select({ shelfId: shelfImpressions.shelfId, impressionCount: count() })
+    .from(shelfImpressions)
+    .where(gte(shelfImpressions.shownAt, cutoff))
+    .groupBy(shelfImpressions.shelfId)
+    .all();
+
+  const map = new Map<string, number>();
+  for (const row of rows) {
+    map.set(row.shelfId, row.impressionCount);
+  }
+  return map;
+}
+
+/**
+ * Freshness multiplier for a shelf: `1 / (1 + countInLastWindow)`, floored
+ * at {@link FRESHNESS_FLOOR}. Higher impression counts produce lower scores;
+ * the score never decays past the floor so a shelf can't be permanently
+ * suppressed by historical over-exposure.
+ *
+ * Pure function — kept here so callers can compute scores without a DB
+ * handle, and so the formula has a single source of truth.
+ */
+export function getShelfFreshness(countInLastWindow: number): number {
+  return Math.max(FRESHNESS_FLOOR, 1 / (1 + countInLastWindow));
+}
+
+/** Delete impression rows older than the retention window. */
+export function cleanupOldImpressions(db: MediaDb): void {
+  const cutoff = sqliteTimestamp(new Date(Date.now() - RETENTION_DAYS * MS_PER_DAY));
+  db.delete(shelfImpressions).where(lt(shelfImpressions.shownAt, cutoff)).run();
+}
+
+/** Init hook — runs {@link cleanupOldImpressions} once at module/server startup. */
+export function initImpressionsService(db: MediaDb): void {
+  cleanupOldImpressions(db);
+}

--- a/packages/media-db/tsconfig.json
+++ b/packages/media-db/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "lib": ["ES2022"],
+    "types": [],
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/__tests__/**", "**/*.test.ts"]
+}

--- a/packages/media-db/vitest.config.ts
+++ b/packages/media-db/vitest.config.ts
@@ -1,0 +1,15 @@
+/// <reference types="vitest/config" />
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json-summary', 'html'],
+      reportsDirectory: 'coverage',
+      include: ['src/**/*.ts'],
+      exclude: ['**/node_modules/**', '**/dist/**', '**/*.test.ts'],
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1310,6 +1310,31 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
 
+  packages/media-db:
+    dependencies:
+      '@pops/db-types':
+        specifier: workspace:*
+        version: link:../db-types
+      better-sqlite3:
+        specifier: ^12.10.0
+        version: 12.10.0
+      drizzle-orm:
+        specifier: ^0.45.2
+        version: 0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.10.0)
+    devDependencies:
+      '@types/better-sqlite3':
+        specifier: ^7.6.12
+        version: 7.6.13
+      '@vitest/coverage-v8':
+        specifier: ^4.1.8
+        version: 4.1.8(vitest@4.1.8)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@25.9.1)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
+
   packages/module-registry:
     dependencies:
       '@pops/types':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,6 +13,7 @@ packages:
   - 'packages/api-client'
   - 'packages/core-db'
   - 'packages/db-types'
+  - 'packages/media-db'
   - 'packages/food-contracts'
   - 'packages/types'
   - 'packages/module-registry'


### PR DESCRIPTION
## Summary

First PR of the **media pillar migration** ([ADR-026](https://github.com/knoxio/pops/blob/main/docs/architecture/adr-026-pillar-architecture.md), pillar-migration-roadmap.md Track F · Phase 1 PR 1 of 4).

Scaffolds the backend-safe `@pops/media-db` package and moves the first slice — shelf-impressions tracking + freshness scoring — out of `apps/pops-api/src/modules/media/discovery/shelf/` into the package with db-arg service signatures. Mirrors the core pilot (#2730).

**Strictly additive.** pops-api is unchanged in this PR; all existing callers keep resolving the old service path. The cutover (PR 3 of phase 1) flips pops-api to import the package and the deletion PR (PR 4) removes the old in-tree service.

## Scope decisions

- **shelf-impressions first.** Its schema lives in a single dedicated migration file (`0021_spooky_lockheed.sql`), the service is drizzle-only (no raw SQL or cross-table reads), all 4 callers are internal to media, and there are no error paths to retrofit. Minimal blast radius for the pilot of the largest mature pillar.
- **No empty `media-contract` / `media-api` / `media-ui` shells.** Those packages get created when their first content lands, matching the precedent set by `@pops/core-db` and `@pops/app-food-db`.
- **Migrations stay in the shared journal.** PR 2 of Phase 1 (migration journal split) moves `0021_spooky_lockheed.sql` into `packages/media-db/migrations/` with its own journal. This PR ships a byte-identical copy + drift guard.

## What's in this PR

- `packages/media-db/{package.json,tsconfig.json,vitest.config.ts}`
- `src/{index,schema}.ts` + `src/services/internal.ts` — barrel + re-exported schema + `MediaDb` handle type
- `src/services/shelf-impressions.ts` — db-arg signatures; the pops-api wrapper (next PR) resolves `getDrizzle()` and forwards
- `src/__tests__/shelf-impressions.test.ts` — 18 cases against in-memory `better-sqlite3` + the canonical `0021_spooky_lockheed.sql` migration. Real SQL + drizzle, not mocks, so timestamp comparisons and grouping land for real.
- `migrations/0021_spooky_lockheed.sql` — byte-identical copy guarded by the drift workflow
- `pnpm-workspace.yaml` entry + `pnpm-lock.yaml` refresh
- `.github/workflows/media-db-quality.yml` — mirrors `core-quality.yml` with a 0021 drift guard. The existing `media-quality.yml` continues to cover `app-media` (UI) untouched.

## Verification

- `pnpm typecheck` — 34/34 packages green
- `pnpm --filter @pops/media-db test` — 18/18 cases pass
- `pnpm format:check` — clean
- `pnpm lint` — no new warnings (only pre-existing ones in unrelated files)

## Roadmap status

Updated `.claude/pillar-migration-roadmap.md` Track F row: \`⏳ Not started\` → \`🔄 In progress\` (pops6 · 2026-06-10T01:58Z).

## Test plan

- [ ] CI green on \`media-db-quality\` (typecheck + 18 tests + 0021 drift guard)
- [ ] Workspace \`typecheck\` / \`api-quality\` / other pillar workflows unaffected (no behavioural changes)
- [ ] Copilot review pass