### PR TITLE
feat(inventory): scaffold @pops/inventory-db + locations slice (pillar inventory phase 1 PR 1)

### DIFF
--- a/.github/workflows/inventory-db-quality.yml
+++ b/.github/workflows/inventory-db-quality.yml
@@ -1,0 +1,41 @@
+name: Inventory DB Quality
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/inventory-db/**"
+      - "packages/db-types/**"
+      - "apps/pops-api/src/db/drizzle-migrations/0005_fancy_crystal.sql"
+      - ".github/workflows/inventory-db-quality.yml"
+      - ".github/workflows/_pkg-check.yml"
+  pull_request:
+
+jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - 'packages/inventory-db/**'
+              - 'packages/db-types/**'
+              - 'apps/pops-api/src/db/drizzle-migrations/0005_fancy_crystal.sql'
+              - '.github/workflows/inventory-db-quality.yml'
+              - '.github/workflows/_pkg-check.yml'
+
+  quality:
+    needs: [changes]
+    if: always()
+    uses: ./.github/workflows/_pkg-check.yml
+    with:
+      package-path: packages/inventory-db
+      needs-db-build: true
+      skip: ${{ github.event_name == 'pull_request' && needs.changes.outputs.relevant != 'true' }}

--- a/packages/inventory-db/package.json
+++ b/packages/inventory-db/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@pops/inventory-db",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@pops/db-types": "workspace:*",
+    "better-sqlite3": "^12.10.0",
+    "drizzle-orm": "^0.45.2"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.12",
+    "@vitest/coverage-v8": "^4.1.8",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.8"
+  }
+}

--- a/packages/inventory-db/src/__tests__/locations.test.ts
+++ b/packages/inventory-db/src/__tests__/locations.test.ts
@@ -1,0 +1,461 @@
+/**
+ * Invariant tests for the locations service against an in-memory SQLite
+ * seeded with the canonical `locations` migration. Pure DB + service
+ * layer — no tRPC, no Express, no auth middleware.
+ *
+ * Higher-level tRPC coverage lives in pops-api's own integration suite
+ * (until the cutover PR routes it through this package).
+ *
+ * The locations CREATE TABLE is read from the shared drizzle journal so
+ * the test catches drift between the production migration and the
+ * schema; `home_inventory` is inlined with just the columns this slice
+ * exercises (`id`, `item_name`, `location_id`) because its canonical
+ * migration (`0000_naive_chameleon`) bundles unrelated FK tables — the
+ * items slice will read its own SQL file when it lands.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  LocationCycleError,
+  LocationNotFoundError,
+  LocationSelfParentError,
+  ParentLocationNotFoundError,
+} from '../errors.js';
+import { homeInventory } from '../schema.js';
+import {
+  getDeleteStats,
+  getDescendantLocationIds,
+  getLocationItems,
+  getLocationPath,
+} from '../services/locations-queries.js';
+import {
+  createLocation,
+  deleteLocation,
+  getChildren,
+  getLocation,
+  getLocationTree,
+  listLocations,
+  updateLocation,
+} from '../services/locations.js';
+
+import type { InventoryDb } from '../services/internal.js';
+
+const LOCATIONS_MIGRATION = join(
+  __dirname,
+  '../../../../apps/pops-api/src/db/drizzle-migrations/0005_fancy_crystal.sql'
+);
+
+const HOME_INVENTORY_DDL = `
+CREATE TABLE home_inventory (
+  id text PRIMARY KEY NOT NULL,
+  notion_id text UNIQUE,
+  item_name text NOT NULL,
+  brand text,
+  model text,
+  item_id text,
+  room text,
+  location text,
+  type text,
+  condition text DEFAULT 'good',
+  in_use integer,
+  deductible integer,
+  purchase_date text,
+  warranty_expires text,
+  replacement_value real,
+  resale_value real,
+  purchase_transaction_id text,
+  purchased_from_id text,
+  purchased_from_name text,
+  purchase_price real,
+  asset_id text UNIQUE,
+  notes text,
+  location_id text REFERENCES locations(id) ON DELETE set null,
+  created_at text NOT NULL DEFAULT (datetime('now')),
+  updated_at text NOT NULL DEFAULT (datetime('now')),
+  last_edited_time text NOT NULL
+);
+CREATE INDEX idx_inventory_location ON home_inventory (location_id);
+CREATE INDEX idx_inventory_name ON home_inventory (item_name);
+`;
+
+function freshDb(): InventoryDb {
+  const raw = new Database(':memory:');
+  raw.pragma('foreign_keys = ON');
+  const sql = readFileSync(LOCATIONS_MIGRATION, 'utf8');
+  for (const stmt of sql.split('--> statement-breakpoint')) {
+    const trimmed = stmt.trim();
+    if (trimmed.length > 0) raw.exec(trimmed);
+  }
+  raw.exec(HOME_INVENTORY_DDL);
+  return drizzle(raw);
+}
+
+function seedItem(
+  db: InventoryDb,
+  name: string,
+  locationId: string | null
+): { id: string; locationId: string | null } {
+  const id = crypto.randomUUID();
+  const now = new Date().toISOString();
+  db.insert(homeInventory).values({ id, itemName: name, locationId, lastEditedTime: now }).run();
+  return { id, locationId };
+}
+
+describe('listLocations', () => {
+  let db: InventoryDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('returns empty result when no rows', () => {
+    expect(listLocations(db)).toEqual({ rows: [], total: 0 });
+  });
+
+  it('orders by sortOrder then name', () => {
+    createLocation(db, { name: 'Bedroom', sortOrder: 1 });
+    createLocation(db, { name: 'Kitchen', sortOrder: 0 });
+    createLocation(db, { name: 'Living Room', sortOrder: 0 });
+
+    const result = listLocations(db);
+    expect(result.total).toBe(3);
+    expect(result.rows.map((r) => r.name)).toEqual(['Kitchen', 'Living Room', 'Bedroom']);
+  });
+});
+
+describe('getLocation', () => {
+  let db: InventoryDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('returns the row when present', () => {
+    const created = createLocation(db, { name: 'Home' });
+    const row = getLocation(db, created.id);
+    expect(row.id).toBe(created.id);
+    expect(row.name).toBe('Home');
+    expect(row.parentId).toBeNull();
+  });
+
+  it('throws LocationNotFoundError when missing', () => {
+    expect(() => getLocation(db, 'nope')).toThrowError(LocationNotFoundError);
+  });
+});
+
+describe('getLocationTree', () => {
+  let db: InventoryDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('returns empty tree when no rows', () => {
+    expect(getLocationTree(db)).toEqual([]);
+  });
+
+  it('returns flat root list when no parent links', () => {
+    createLocation(db, { name: 'Home' });
+    createLocation(db, { name: 'Car' });
+    const tree = getLocationTree(db);
+    expect(tree).toHaveLength(2);
+    expect(tree.every((n) => n.children.length === 0)).toBe(true);
+  });
+
+  it('nests children under parents', () => {
+    const home = createLocation(db, { name: 'Home' });
+    const kitchen = createLocation(db, { name: 'Kitchen', parentId: home.id });
+    createLocation(db, { name: 'Pantry', parentId: kitchen.id });
+    createLocation(db, { name: 'Bedroom', parentId: home.id });
+
+    const tree = getLocationTree(db);
+    expect(tree).toHaveLength(1);
+    const root = tree[0]!;
+    expect(root.name).toBe('Home');
+    expect(root.children).toHaveLength(2);
+    const kitchenNode = root.children.find((c) => c.name === 'Kitchen')!;
+    expect(kitchenNode.children).toHaveLength(1);
+    expect(kitchenNode.children[0]!.name).toBe('Pantry');
+  });
+});
+
+describe('getChildren', () => {
+  let db: InventoryDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('returns only direct children', () => {
+    const home = createLocation(db, { name: 'Home' });
+    createLocation(db, { name: 'Kitchen', parentId: home.id });
+    createLocation(db, { name: 'Bedroom', parentId: home.id });
+    createLocation(db, { name: 'Car' });
+
+    expect(getChildren(db, home.id)).toHaveLength(2);
+  });
+});
+
+describe('getLocationPath', () => {
+  let db: InventoryDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('returns root-first breadcrumb', () => {
+    const home = createLocation(db, { name: 'Home' });
+    const kitchen = createLocation(db, { name: 'Kitchen', parentId: home.id });
+    const pantry = createLocation(db, { name: 'Pantry', parentId: kitchen.id });
+
+    const path = getLocationPath(db, pantry.id);
+    expect(path.map((r) => r.name)).toEqual(['Home', 'Kitchen', 'Pantry']);
+  });
+
+  it('throws LocationNotFoundError when location is missing', () => {
+    expect(() => getLocationPath(db, 'nope')).toThrowError(LocationNotFoundError);
+  });
+});
+
+describe('createLocation', () => {
+  let db: InventoryDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('creates a root location with defaults', () => {
+    const row = createLocation(db, { name: 'Home' });
+    expect(row.name).toBe('Home');
+    expect(row.parentId).toBeNull();
+    expect(row.sortOrder).toBe(0);
+  });
+
+  it('creates a child location under an existing parent', () => {
+    const parent = createLocation(db, { name: 'Home' });
+    const child = createLocation(db, { name: 'Kitchen', parentId: parent.id });
+    expect(child.parentId).toBe(parent.id);
+  });
+
+  it('respects an explicit sortOrder', () => {
+    const row = createLocation(db, { name: 'Garage', sortOrder: 5 });
+    expect(row.sortOrder).toBe(5);
+  });
+
+  it('throws ParentLocationNotFoundError when parent is missing', () => {
+    expect(() => createLocation(db, { name: 'Orphan', parentId: 'nope' })).toThrowError(
+      ParentLocationNotFoundError
+    );
+  });
+});
+
+describe('updateLocation', () => {
+  let db: InventoryDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('renames a location', () => {
+    const created = createLocation(db, { name: 'Bedoom' });
+    const renamed = updateLocation(db, created.id, { name: 'Bedroom' });
+    expect(renamed.name).toBe('Bedroom');
+  });
+
+  it('moves a location to a new parent', () => {
+    const home = createLocation(db, { name: 'Home' });
+    const garage = createLocation(db, { name: 'Garage' });
+    const shelf = createLocation(db, { name: 'Shelf', parentId: home.id });
+
+    const moved = updateLocation(db, shelf.id, { parentId: garage.id });
+    expect(moved.parentId).toBe(garage.id);
+  });
+
+  it('moves a location to root', () => {
+    const home = createLocation(db, { name: 'Home' });
+    const room = createLocation(db, { name: 'Room', parentId: home.id });
+
+    const moved = updateLocation(db, room.id, { parentId: null });
+    expect(moved.parentId).toBeNull();
+  });
+
+  it('rejects making a location its own parent', () => {
+    const home = createLocation(db, { name: 'Home' });
+    expect(() => updateLocation(db, home.id, { parentId: home.id })).toThrowError(
+      LocationSelfParentError
+    );
+  });
+
+  it('rejects circular reference', () => {
+    const parent = createLocation(db, { name: 'Parent' });
+    const child = createLocation(db, { name: 'Child', parentId: parent.id });
+    expect(() => updateLocation(db, parent.id, { parentId: child.id })).toThrowError(
+      LocationCycleError
+    );
+  });
+
+  it('throws LocationNotFoundError for missing id', () => {
+    expect(() => updateLocation(db, 'nope', { name: 'X' })).toThrowError(LocationNotFoundError);
+  });
+
+  it('throws ParentLocationNotFoundError for missing parent', () => {
+    const home = createLocation(db, { name: 'Home' });
+    expect(() => updateLocation(db, home.id, { parentId: 'nope' })).toThrowError(
+      ParentLocationNotFoundError
+    );
+  });
+});
+
+describe('deleteLocation', () => {
+  let db: InventoryDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('deletes an existing row', () => {
+    const created = createLocation(db, { name: 'Temp' });
+    deleteLocation(db, created.id);
+    expect(() => getLocation(db, created.id)).toThrowError(LocationNotFoundError);
+  });
+
+  it('throws LocationNotFoundError when missing', () => {
+    expect(() => deleteLocation(db, 'nope')).toThrowError(LocationNotFoundError);
+  });
+});
+
+describe('getDescendantLocationIds', () => {
+  let db: InventoryDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('returns empty array for a leaf', () => {
+    const leaf = createLocation(db, { name: 'Leaf' });
+    expect(getDescendantLocationIds(db, leaf.id)).toEqual([]);
+  });
+
+  it('returns transitive descendants', () => {
+    const home = createLocation(db, { name: 'Home' });
+    const kitchen = createLocation(db, { name: 'Kitchen', parentId: home.id });
+    const pantry = createLocation(db, { name: 'Pantry', parentId: kitchen.id });
+    const bedroom = createLocation(db, { name: 'Bedroom', parentId: home.id });
+
+    const ids = getDescendantLocationIds(db, home.id);
+    expect(new Set(ids)).toEqual(new Set([kitchen.id, pantry.id, bedroom.id]));
+  });
+});
+
+describe('getDeleteStats', () => {
+  let db: InventoryDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('returns zeros for an empty leaf', () => {
+    const leaf = createLocation(db, { name: 'Empty' });
+    expect(getDeleteStats(db, leaf.id)).toEqual({
+      childCount: 0,
+      descendantCount: 0,
+      itemCount: 0,
+      totalItemCount: 0,
+    });
+  });
+
+  it('counts direct children and transitive descendants', () => {
+    const home = createLocation(db, { name: 'Home' });
+    const kitchen = createLocation(db, { name: 'Kitchen', parentId: home.id });
+    createLocation(db, { name: 'Pantry', parentId: kitchen.id });
+    createLocation(db, { name: 'Bedroom', parentId: home.id });
+
+    const stats = getDeleteStats(db, home.id);
+    expect(stats.childCount).toBe(2);
+    expect(stats.descendantCount).toBe(3);
+  });
+
+  it('counts items in this location and descendants', () => {
+    const home = createLocation(db, { name: 'Home' });
+    const kitchen = createLocation(db, { name: 'Kitchen', parentId: home.id });
+
+    seedItem(db, 'Fridge', kitchen.id);
+    seedItem(db, 'Oven', kitchen.id);
+    seedItem(db, 'Couch', home.id);
+
+    const stats = getDeleteStats(db, home.id);
+    expect(stats.itemCount).toBe(1);
+    expect(stats.totalItemCount).toBe(3);
+  });
+
+  it('throws LocationNotFoundError for missing id', () => {
+    expect(() => getDeleteStats(db, 'nope')).toThrowError(LocationNotFoundError);
+  });
+});
+
+describe('getLocationItems', () => {
+  let db: InventoryDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('returns items directly in the location', () => {
+    const kitchen = createLocation(db, { name: 'Kitchen' });
+    seedItem(db, 'Fridge', kitchen.id);
+    seedItem(db, 'Oven', kitchen.id);
+    seedItem(db, 'Couch', null);
+
+    const result = getLocationItems(db, {
+      locationId: kitchen.id,
+      includeChildren: false,
+      limit: 50,
+      offset: 0,
+    });
+    expect(result.total).toBe(2);
+    expect(result.rows.map((r) => r.itemName).toSorted()).toEqual(['Fridge', 'Oven']);
+  });
+
+  it('includes descendant items when includeChildren is true', () => {
+    const home = createLocation(db, { name: 'Home' });
+    const kitchen = createLocation(db, { name: 'Kitchen', parentId: home.id });
+    seedItem(db, 'Couch', home.id);
+    seedItem(db, 'Fridge', kitchen.id);
+
+    const result = getLocationItems(db, {
+      locationId: home.id,
+      includeChildren: true,
+      limit: 50,
+      offset: 0,
+    });
+    expect(result.total).toBe(2);
+  });
+
+  it('respects limit + offset', () => {
+    const kitchen = createLocation(db, { name: 'Kitchen' });
+    for (let i = 0; i < 5; i++) seedItem(db, `Item ${i}`, kitchen.id);
+
+    const page1 = getLocationItems(db, {
+      locationId: kitchen.id,
+      includeChildren: false,
+      limit: 2,
+      offset: 0,
+    });
+    expect(page1.rows).toHaveLength(2);
+    expect(page1.total).toBe(5);
+
+    const page2 = getLocationItems(db, {
+      locationId: kitchen.id,
+      includeChildren: false,
+      limit: 2,
+      offset: 2,
+    });
+    expect(page2.rows).toHaveLength(2);
+    expect(page2.rows[0]!.itemName).not.toBe(page1.rows[0]!.itemName);
+  });
+
+  it('throws LocationNotFoundError when location missing', () => {
+    expect(() =>
+      getLocationItems(db, {
+        locationId: 'nope',
+        includeChildren: false,
+        limit: 50,
+        offset: 0,
+      })
+    ).toThrowError(LocationNotFoundError);
+  });
+});

--- a/packages/inventory-db/src/errors.ts
+++ b/packages/inventory-db/src/errors.ts
@@ -1,0 +1,49 @@
+/**
+ * Typed errors raised by the inventory domain service layer.
+ *
+ * Plain Error subclasses — the service layer doesn't know about HTTP.
+ * Pops-api routers map them to the appropriate tRPC codes when surfacing
+ * to clients. Mirrors `@pops/core-db`'s error pattern.
+ */
+
+export class LocationNotFoundError extends Error {
+  override readonly name = 'LocationNotFoundError' as const;
+  readonly id: string;
+
+  constructor(id: string) {
+    super(`Location '${id}' not found`);
+    this.id = id;
+  }
+}
+
+export class ParentLocationNotFoundError extends Error {
+  override readonly name = 'ParentLocationNotFoundError' as const;
+  readonly id: string;
+
+  constructor(id: string) {
+    super(`Parent location '${id}' not found`);
+    this.id = id;
+  }
+}
+
+export class LocationSelfParentError extends Error {
+  override readonly name = 'LocationSelfParentError' as const;
+  readonly id: string;
+
+  constructor(id: string) {
+    super('A location cannot be its own parent');
+    this.id = id;
+  }
+}
+
+export class LocationCycleError extends Error {
+  override readonly name = 'LocationCycleError' as const;
+  readonly id: string;
+  readonly newParentId: string;
+
+  constructor(id: string, newParentId: string) {
+    super('Moving this location would create a circular reference');
+    this.id = id;
+    this.newParentId = newParentId;
+  }
+}

--- a/packages/inventory-db/src/index.ts
+++ b/packages/inventory-db/src/index.ts
@@ -1,0 +1,33 @@
+/**
+ * Backend-safe barrel for the inventory domain's persistence layer.
+ *
+ * Hosts inventory pillar tables (locations, home_inventory, fixtures,
+ * item_connections, item_documents, item_photos, item_uploaded_files,
+ * item_fixture_connections). Extracted from
+ * `apps/pops-api/src/modules/inventory/` per ADR-026.
+ *
+ * Per the CI-never-breaks pattern the migration is incremental — this PR
+ * scaffolds the package and moves only the `locations` slice. The other
+ * slices (items, connections, documents, photos, fixtures, document-files,
+ * paperless) follow in subsequent PRs.
+ */
+export * from './errors.js';
+export * from './schema.js';
+
+export type { InventoryDb } from './services/internal.js';
+
+export * as locationsService from './services/locations.js';
+
+// Public types re-exported at the package root so consumers can name
+// them without reaching into the namespaces.
+export type {
+  CreateLocationInput,
+  DeleteLocationStats,
+  Location,
+  LocationItemsResult,
+  LocationListResult,
+  LocationTreeNode,
+  UpdateLocationInput,
+} from './services/locations.js';
+
+export { toLocation } from './services/locations.js';

--- a/packages/inventory-db/src/schema.ts
+++ b/packages/inventory-db/src/schema.ts
@@ -1,0 +1,17 @@
+/**
+ * Local re-export of inventory-domain tables.
+ *
+ * Canonical definitions live in `@pops/db-types/src/schema/*.ts` so the
+ * drizzle-kit config (which globs `packages/db-types/src/schema/*`) picks
+ * them up and the rest of the platform sees a single schema barrel.
+ *
+ * Services in this package import from here for ergonomics and so the
+ * inventory pillar's read surface stays self-describing. Mirrors the
+ * `@pops/core-db` / `@pops/app-food-db` schema re-export pattern.
+ *
+ * `homeInventory` is included here even though the items service is not
+ * yet extracted — the locations service reads from it for
+ * `getLocationItems` / `getDeleteStats`, and downstream slice PRs (items,
+ * connections, documents, photos, fixtures) will need it too.
+ */
+export { homeInventory, locations } from '@pops/db-types';

--- a/packages/inventory-db/src/services/internal.ts
+++ b/packages/inventory-db/src/services/internal.ts
@@ -1,0 +1,11 @@
+/**
+ * Shared helpers for the inventory schema service layer.
+ *
+ * `InventoryDb` is re-exported from the package barrel so callers can type
+ * the handle they pass in. Any additional helpers added here stay internal
+ * to `src/services/*.ts`.
+ */
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+
+/** A drizzle handle — either the top-level db or a transaction. */
+export type InventoryDb = BetterSQLite3Database<Record<string, unknown>>;

--- a/packages/inventory-db/src/services/locations-queries.ts
+++ b/packages/inventory-db/src/services/locations-queries.ts
@@ -1,0 +1,159 @@
+/**
+ * Read-only queries for the locations slice.
+ *
+ * Functions in this file are pure reads — they take a drizzle handle and
+ * return rows (or throw a typed `LocationNotFoundError` if the lookup
+ * misses). They are intentionally separate from `locations.ts` so the
+ * mutating CRUD layer stays small and the queries can be shared with
+ * downstream slices (delete-stats walks the location tree and counts
+ * items, which the items slice will eventually need too).
+ */
+import { asc, count, eq, inArray } from 'drizzle-orm';
+
+import { LocationNotFoundError } from '../errors.js';
+import { homeInventory, locations } from '../schema.js';
+
+import type { LocationRow } from '@pops/db-types';
+
+import type { InventoryDb } from './internal.js';
+
+/** Stats returned before confirming a delete. */
+export interface DeleteLocationStats {
+  /** Number of direct child locations. */
+  childCount: number;
+  /** Total number of descendant locations (children, grandchildren, etc.). */
+  descendantCount: number;
+  /** Number of inventory items directly in this location. */
+  itemCount: number;
+  /** Number of inventory items in this location and all descendants. */
+  totalItemCount: number;
+}
+
+export interface LocationItemsResult {
+  rows: (typeof homeInventory.$inferSelect)[];
+  total: number;
+}
+
+export interface GetLocationItemsParams {
+  locationId: string;
+  includeChildren: boolean;
+  limit: number;
+  offset: number;
+}
+
+/**
+ * Collect all descendant location IDs via BFS.
+ *
+ * Fetches every (id, parentId) pair once and traverses an in-memory
+ * adjacency map, avoiding both N+1 DB queries and `Array#shift`'s O(n)
+ * cost per pop.
+ */
+export function getDescendantLocationIds(db: InventoryDb, id: string): string[] {
+  const allRows = db
+    .select({ id: locations.id, parentId: locations.parentId })
+    .from(locations)
+    .all();
+  const childrenByParent = new Map<string, string[]>();
+  for (const row of allRows) {
+    if (row.parentId === null) continue;
+    const list = childrenByParent.get(row.parentId);
+    if (list) list.push(row.id);
+    else childrenByParent.set(row.parentId, [row.id]);
+  }
+  const descendantIds: string[] = [];
+  const queue: string[] = [id];
+  for (let i = 0; i < queue.length; i++) {
+    const current = queue[i];
+    if (current === undefined) continue;
+    const children = childrenByParent.get(current);
+    if (!children) continue;
+    for (const childId of children) {
+      descendantIds.push(childId);
+      queue.push(childId);
+    }
+  }
+  return descendantIds;
+}
+
+function fetchOne(db: InventoryDb, id: string): LocationRow | undefined {
+  return db.select().from(locations).where(eq(locations.id, id)).get();
+}
+
+export function getLocationOrThrow(db: InventoryDb, id: string): LocationRow {
+  const row = fetchOne(db, id);
+  if (!row) throw new LocationNotFoundError(id);
+  return row;
+}
+
+/** Get the breadcrumb path from root to the specified location (root-first). */
+export function getLocationPath(db: InventoryDb, id: string): LocationRow[] {
+  const path: LocationRow[] = [];
+  let current: LocationRow | undefined = getLocationOrThrow(db, id);
+  while (current) {
+    path.push(current);
+    current = current.parentId ? fetchOne(db, current.parentId) : undefined;
+  }
+  return path.toReversed();
+}
+
+export function getLocationItems(
+  db: InventoryDb,
+  params: GetLocationItemsParams
+): LocationItemsResult {
+  const { locationId, includeChildren, limit, offset } = params;
+  getLocationOrThrow(db, locationId);
+  const locationIds = [locationId];
+  if (includeChildren) locationIds.push(...getDescendantLocationIds(db, locationId));
+
+  const rows = db
+    .select()
+    .from(homeInventory)
+    .where(inArray(homeInventory.locationId, locationIds))
+    .orderBy(homeInventory.itemName)
+    .limit(limit)
+    .offset(offset)
+    .all();
+
+  const [countResult] = db
+    .select({ total: count() })
+    .from(homeInventory)
+    .where(inArray(homeInventory.locationId, locationIds))
+    .all();
+
+  return { rows, total: countResult?.total ?? 0 };
+}
+
+export function getDeleteStats(db: InventoryDb, id: string): DeleteLocationStats {
+  getLocationOrThrow(db, id);
+
+  const directChildren = db.select().from(locations).where(eq(locations.parentId, id)).all();
+  const descendantIds = getDescendantLocationIds(db, id);
+
+  const [directItems] = db
+    .select({ total: count() })
+    .from(homeInventory)
+    .where(eq(homeInventory.locationId, id))
+    .all();
+  const itemCount = directItems?.total ?? 0;
+
+  let totalItemCount = itemCount;
+  if (descendantIds.length > 0) {
+    const [descAgg] = db
+      .select({ total: count() })
+      .from(homeInventory)
+      .where(inArray(homeInventory.locationId, descendantIds))
+      .all();
+    totalItemCount += descAgg?.total ?? 0;
+  }
+
+  return {
+    childCount: directChildren.length,
+    descendantCount: descendantIds.length,
+    itemCount,
+    totalItemCount,
+  };
+}
+
+export function getLocationsList(db: InventoryDb): LocationRow[] {
+  return db.select().from(locations).orderBy(asc(locations.sortOrder), asc(locations.name)).all();
+}

--- a/packages/inventory-db/src/services/locations.ts
+++ b/packages/inventory-db/src/services/locations.ts
@@ -9,6 +9,8 @@
  * Read helpers live in `locations-queries.ts` so the mutating CRUD layer
  * stays small and the read surface can be shared with downstream slices.
  */
+import { randomUUID } from 'node:crypto';
+
 import { asc, eq } from 'drizzle-orm';
 
 import {
@@ -133,9 +135,11 @@ function assertParentExists(db: InventoryDb, parentId: string): void {
 }
 
 export function createLocation(db: InventoryDb, input: CreateLocationInput): LocationRow {
-  if (input.parentId) assertParentExists(db, input.parentId);
+  if (input.parentId !== undefined && input.parentId !== null) {
+    assertParentExists(db, input.parentId);
+  }
 
-  const id = crypto.randomUUID();
+  const id = randomUUID();
   const now = new Date().toISOString();
 
   db.insert(locations)

--- a/packages/inventory-db/src/services/locations.ts
+++ b/packages/inventory-db/src/services/locations.ts
@@ -1,0 +1,204 @@
+/**
+ * Locations CRUD service.
+ *
+ * Each function takes an `InventoryDb` handle as its first argument; the
+ * calling layer (pops-api modules, eventually `inventory-api`) resolves
+ * the singleton or transaction handle to pass in. Mirrors the
+ * `@pops/core-db` db-arg pattern.
+ *
+ * Read helpers live in `locations-queries.ts` so the mutating CRUD layer
+ * stays small and the read surface can be shared with downstream slices.
+ */
+import { asc, eq } from 'drizzle-orm';
+
+import {
+  LocationCycleError,
+  LocationNotFoundError,
+  LocationSelfParentError,
+  ParentLocationNotFoundError,
+} from '../errors.js';
+import { locations } from '../schema.js';
+import {
+  getDeleteStats,
+  getDescendantLocationIds,
+  getLocationItems,
+  getLocationOrThrow,
+  getLocationPath,
+  getLocationsList,
+  type DeleteLocationStats,
+  type GetLocationItemsParams,
+  type LocationItemsResult,
+} from './locations-queries.js';
+
+import type { LocationRow } from '@pops/db-types';
+
+import type { InventoryDb } from './internal.js';
+
+export {
+  getDeleteStats,
+  getDescendantLocationIds,
+  getLocationItems,
+  getLocationPath,
+  getLocationsList,
+  type DeleteLocationStats,
+  type GetLocationItemsParams,
+  type LocationItemsResult,
+};
+
+/** Public API shape for a location. */
+export interface Location {
+  id: string;
+  name: string;
+  parentId: string | null;
+  sortOrder: number;
+}
+
+/** Map a database row to the public API shape. */
+export function toLocation(row: LocationRow): Location {
+  return {
+    id: row.id,
+    name: row.name,
+    parentId: row.parentId,
+    sortOrder: row.sortOrder,
+  };
+}
+
+/** A location with its children, for tree responses. */
+export interface LocationTreeNode extends Location {
+  children: LocationTreeNode[];
+}
+
+export interface CreateLocationInput {
+  name: string;
+  parentId?: string | null;
+  sortOrder?: number;
+}
+
+export interface UpdateLocationInput {
+  name?: string;
+  parentId?: string | null;
+  sortOrder?: number;
+}
+
+export interface LocationListResult {
+  rows: LocationRow[];
+  total: number;
+}
+
+export function listLocations(db: InventoryDb): LocationListResult {
+  const rows = getLocationsList(db);
+  return { rows, total: rows.length };
+}
+
+export function getLocation(db: InventoryDb, id: string): LocationRow {
+  return getLocationOrThrow(db, id);
+}
+
+export function getLocationTree(db: InventoryDb): LocationTreeNode[] {
+  const allRows = getLocationsList(db);
+  const nodeMap = new Map<string, LocationTreeNode>();
+  const roots: LocationTreeNode[] = [];
+
+  for (const row of allRows) {
+    nodeMap.set(row.id, { ...toLocation(row), children: [] });
+  }
+
+  for (const row of allRows) {
+    const node = nodeMap.get(row.id);
+    if (!node) continue;
+    const parent = row.parentId ? nodeMap.get(row.parentId) : undefined;
+    if (parent) parent.children.push(node);
+    else roots.push(node);
+  }
+
+  return roots;
+}
+
+export function getChildren(db: InventoryDb, parentId: string): LocationRow[] {
+  return db
+    .select()
+    .from(locations)
+    .where(eq(locations.parentId, parentId))
+    .orderBy(asc(locations.sortOrder), asc(locations.name))
+    .all();
+}
+
+function assertParentExists(db: InventoryDb, parentId: string): void {
+  const parent = db
+    .select({ id: locations.id })
+    .from(locations)
+    .where(eq(locations.id, parentId))
+    .get();
+  if (!parent) throw new ParentLocationNotFoundError(parentId);
+}
+
+export function createLocation(db: InventoryDb, input: CreateLocationInput): LocationRow {
+  if (input.parentId) assertParentExists(db, input.parentId);
+
+  const id = crypto.randomUUID();
+  const now = new Date().toISOString();
+
+  db.insert(locations)
+    .values({
+      id,
+      name: input.name,
+      parentId: input.parentId ?? null,
+      sortOrder: input.sortOrder ?? 0,
+      lastEditedTime: now,
+    })
+    .run();
+
+  return getLocation(db, id);
+}
+
+function assertNoCycle(db: InventoryDb, id: string, newParentId: string): void {
+  let current: string | null = newParentId;
+  while (current) {
+    const ancestor: { parentId: string | null } | undefined = db
+      .select({ parentId: locations.parentId })
+      .from(locations)
+      .where(eq(locations.id, current))
+      .get();
+    if (!ancestor) break;
+    if (ancestor.parentId === id) {
+      throw new LocationCycleError(id, newParentId);
+    }
+    current = ancestor.parentId;
+  }
+}
+
+function buildLocationUpdates(input: UpdateLocationInput): Partial<LocationRow> {
+  const updates: Partial<LocationRow> = {};
+  if (input.name !== undefined) updates.name = input.name;
+  if (input.parentId !== undefined) updates.parentId = input.parentId;
+  if (input.sortOrder !== undefined) updates.sortOrder = input.sortOrder;
+  return updates;
+}
+
+export function updateLocation(
+  db: InventoryDb,
+  id: string,
+  input: UpdateLocationInput
+): LocationRow {
+  getLocation(db, id);
+
+  if (input.parentId !== undefined && input.parentId !== null) {
+    if (input.parentId === id) throw new LocationSelfParentError(id);
+    assertParentExists(db, input.parentId);
+    assertNoCycle(db, id, input.parentId);
+  }
+
+  const updates = buildLocationUpdates(input);
+  if (Object.keys(updates).length > 0) {
+    updates.lastEditedTime = new Date().toISOString();
+    db.update(locations).set(updates).where(eq(locations.id, id)).run();
+  }
+
+  return getLocation(db, id);
+}
+
+export function deleteLocation(db: InventoryDb, id: string): void {
+  getLocation(db, id);
+  const result = db.delete(locations).where(eq(locations.id, id)).run();
+  if (result.changes === 0) throw new LocationNotFoundError(id);
+}

--- a/packages/inventory-db/tsconfig.json
+++ b/packages/inventory-db/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "lib": ["ES2023"],
+    "types": [],
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/__tests__/**", "**/*.test.ts"]
+}

--- a/packages/inventory-db/vitest.config.ts
+++ b/packages/inventory-db/vitest.config.ts
@@ -1,0 +1,15 @@
+/// <reference types="vitest/config" />
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json-summary', 'html'],
+      reportsDirectory: 'coverage',
+      include: ['src/**/*.ts'],
+      exclude: ['**/node_modules/**', '**/dist/**', '**/*.test.ts'],
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1310,6 +1310,31 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
 
+  packages/inventory-db:
+    dependencies:
+      '@pops/db-types':
+        specifier: workspace:*
+        version: link:../db-types
+      better-sqlite3:
+        specifier: ^12.10.0
+        version: 12.10.0
+      drizzle-orm:
+        specifier: ^0.45.2
+        version: 0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.10.0)
+    devDependencies:
+      '@types/better-sqlite3':
+        specifier: ^7.6.12
+        version: 7.6.13
+      '@vitest/coverage-v8':
+        specifier: ^4.1.8
+        version: 4.1.8(vitest@4.1.8)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@25.9.1)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
+
   packages/media-db:
     dependencies:
       '@pops/db-types':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,6 +13,7 @@ packages:
   - 'packages/api-client'
   - 'packages/core-db'
   - 'packages/db-types'
+  - 'packages/inventory-db'
   - 'packages/media-db'
   - 'packages/food-contracts'
   - 'packages/types'


### PR DESCRIPTION
## Summary

Scaffold for the ADR-026 inventory-pillar migration (track G of `.claude/pillar-migration-roadmap.md`). Creates the backend-safe `@pops/inventory-db` package and moves the first slice — locations CRUD + queries — out of `apps/pops-api/src/modules/inventory/locations/` with a db-arg service signature. Mirrors the `@pops/core-db` pilot shape.

**Strictly additive.** The pops-api locations module is unchanged in this PR so all existing callers (router, items module's `getDescendantLocationIds` import) keep working. PR 3 of phase 1 flips pops-api to import the new package; PR 4 deletes the old in-tree service.

Subsequent inventory slices (items, connections, documents, photos, fixtures, document-files, paperless) follow in their own per-slice PR sequences. The other three pillar packages (`inventory-contract`, `inventory-api`, `inventory-ui`) are deferred until their first content lands rather than scaffolded empty.

### Highlights
- `packages/inventory-db/` — `package.json`, `tsconfig.json`, `vitest.config.ts`, `src/{index,schema,errors}.ts`, `src/services/{internal,locations,locations-queries}.ts`.
- Schema barrel re-exports `locations` + `homeInventory` from `@pops/db-types`; canonical drizzle definitions stay there so `drizzle-kit` keeps globbing them.
- Typed errors: `LocationNotFoundError`, `ParentLocationNotFoundError`, `LocationSelfParentError`, `LocationCycleError`. Plain `Error` subclasses — the package doesn't know about HTTP.
- Services take `InventoryDb` (drizzle handle) as the first arg; the calling layer resolves the singleton or transaction handle to pass in.
- `getLocationItems` signature uses an options object (`{ locationId, includeChildren, limit, offset }`) to stay under the `max-params` lint cap.
- 33 unit tests against an in-memory better-sqlite3 — read `0005_fancy_crystal.sql` from the shared journal for locations (catches drift), inline a minimal `home_inventory` DDL for the cross-table queries (the items slice will read its own SQL when it lands).
- `.github/workflows/inventory-db-quality.yml` — paths-filtered typecheck + test on the new package. No migration-drift guard yet; that lands in PR 2 when the journal split copies `0005_fancy_crystal.sql` into `packages/inventory-db/migrations/`.

### Roadmap notes
- Row claimed in `.claude/pillar-migration-roadmap.md` (track G).
- `known-pillars.ts` already lists `inventory`; the per-pillar migration runner will see the package via `require.resolve('@pops/inventory-db/package.json')` (subpath exposed) but find no `migrations/` dir yet and skip — runtime is unchanged.
- pops-api does NOT depend on `@pops/inventory-db` yet, so no Dockerfile / `_pkg-check.yml` shared-build-list updates are needed in this PR. Both land in PR 3 (cutover).

## Test plan
- [x] `cd packages/inventory-db && pnpm typecheck` — passes
- [x] `cd packages/inventory-db && pnpm test` — 33/33 pass
- [x] `cd apps/pops-api && pnpm typecheck` — unchanged (strictly additive)
- [x] `pnpm typecheck` (full workspace turbo) — all 33 packages green
- [x] `pnpm lint` — clean
- [x] `pnpm format:check` — clean
- [x] `pnpm lint:boundaries` — no dep-cruiser violations
- [x] `pnpm install --frozen-lockfile` — lockfile consistent