### PR TITLE
feat(media-db): split migration journal — 0021_spooky_lockheed (pillar media phase 1 PR 2)

### DIFF
--- a/apps/pops-api/src/db/per-pillar-migrations.test.ts
+++ b/apps/pops-api/src/db/per-pillar-migrations.test.ts
@@ -202,18 +202,22 @@ describe('runPerPillarMigrations', () => {
   it('falls back to the real repo root when no override is supplied', async () => {
     // Smoke check: importing the runner under the real layout exercises
     // the workspace fallback path against an actual on-disk pillar dir.
-    // `core` now owns its journal at `packages/core-db/migrations/` (core
-    // pillar Phase 1 PR 2) so the runner discovers + applies the
-    // 0054_service_accounts entry. Pillars without their own journal yet
-    // still skip cleanly.
+    // `core` owns `packages/core-db/migrations/` with 0054_service_accounts
+    // (core pillar Phase 1 PR 2) and `media` owns `packages/media-db/migrations/`
+    // with 0021_spooky_lockheed (media pillar Phase 1 PR 2). Pillars without
+    // their own journal yet still skip cleanly.
     await withDb((db) => {
       const realPillars: PillarDescriptor[] = [
         { id: 'core', dbPackageDir: 'packages/core-db' },
+        { id: 'media', dbPackageDir: 'packages/media-db' },
         { id: 'unmigrated', dbPackageDir: 'packages/this-dir-does-not-exist-db' },
       ];
       const result = runPerPillarMigrations(db, realPillars);
-      expect(result.applied).toEqual(['0054_service_accounts']);
-      expect(result.pillarsApplied).toEqual(['core']);
+      expect([...result.applied].toSorted()).toEqual([
+        '0021_spooky_lockheed',
+        '0054_service_accounts',
+      ]);
+      expect([...result.pillarsApplied].toSorted()).toEqual(['core', 'media']);
       expect(result.pillarsSkipped).toEqual(['unmigrated']);
     });
   });

--- a/packages/media-db/migrations/meta/_journal.json
+++ b/packages/media-db/migrations/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "6",
+      "when": 1775359502281,
+      "tag": "0021_spooky_lockheed",
+      "breakpoints": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Second PR of the **media pillar migration** (pillar-migration-roadmap.md Track F · Phase 1 PR 2 of 4). Mirrors the core pilot's PR 2 (#2733).

Moves the media pillar's first migration into its own drizzle journal at \`packages/media-db/migrations/\`. The shared journal entry stays intact for one release cycle per the CI-never-breaks pattern (\"old shared-journal entries become documented no-ops for one release cycle, then deleted in step 4\").

## How both runners stay sane

Both the shared (\`runPerModuleMigrationsByOwner\`) and per-pillar (\`runPerPillarMigrations\`) runners now see a journal entry with tag \`0021_spooky_lockheed\` and byte-identical SQL.

- **Existing production DBs:** \`__drizzle_migrations\` already has the hash. Both runners hit \`alreadyApplied\` on the existing-hash branch.
- **Fresh installs:** Shared runner runs first (P1's runtime contract). It applies 0021 and records the hash + tag. Per-pillar runner walks the pillar journal, sees the recorded tag with matching hash, returns \`alreadyApplied\`.
- **No drift:** Files are byte-for-byte identical, so the hash-drift warning in \`classifyOrApply\` never fires. PR 1's drift-guard CI job keeps that invariant.

## What's in this PR

- \`packages/media-db/migrations/meta/_journal.json\` — single entry; the \`when\` timestamp (1775359502281) is carried over from the shared journal entry verbatim, so future migration generations slot in cleanly.
- \`apps/pops-api/src/db/per-pillar-migrations.test.ts\` — the real-repo-root smoke test now includes a media pillar descriptor; the assertion expects both \`0054_service_accounts\` (core) and \`0021_spooky_lockheed\` (media) to apply.

## Not touched in this PR (next 2 PRs)

- \`apps/pops-api/src/db/migration-ownership.ts\` — \`0021_spooky_lockheed → media\` entry stays for the release cycle
- \`apps/pops-api/src/modules/media/migrations.ts\` — module migration tag entry stays (until PR 4)
- \`apps/pops-api/src/db/drizzle-migrations/0021_spooky_lockheed.sql\` — original file stays
- \`apps/pops-api/src/db/drizzle-migrations/meta/_journal.json\` — shared journal entry stays

PR 3 (cutover) flips pops-api callers from the in-tree shelf-impressions service to \`@pops/media-db\`. PR 4 (deletion) removes everything above.

## Verification

- \`pnpm typecheck\` — 34/34 packages green
- \`pnpm --filter @pops/api test src/db/per-pillar-migrations.test.ts\` — 7/7 pass
- \`pnpm --filter @pops/media-db test\` — 18/18 pass
- \`pnpm format:check\` — clean
- The 18 pre-existing food/recipes-router failures are unrelated (reproduce on main; not introduced by this branch).

## Test plan

- [ ] CI green on \`media-db-quality\` (uses new in-package migration path)
- [ ] CI green on \`api-quality\` (per-pillar runner smoke test updated)
- [ ] Copilot review pass