### PR TITLE
feat(finance-db): split migration journal — 0025/0026/0027/0052 (pillar finance phase 1 PR 2)

### DIFF
--- a/.github/workflows/finance-db-quality.yml
+++ b/.github/workflows/finance-db-quality.yml
@@ -6,6 +6,10 @@ on:
     paths:
       - "packages/finance-db/**"
       - "packages/db-types/**"
+      - "apps/pops-api/src/db/drizzle-migrations/0025_youthful_hulk.sql"
+      - "apps/pops-api/src/db/drizzle-migrations/0026_little_frank_castle.sql"
+      - "apps/pops-api/src/db/drizzle-migrations/0027_slow_dormammu.sql"
+      - "apps/pops-api/src/db/drizzle-migrations/0052_budgets_active_default_zero.sql"
       - ".github/workflows/finance-db-quality.yml"
       - ".github/workflows/_pkg-check.yml"
   pull_request:
@@ -26,8 +30,47 @@ jobs:
             relevant:
               - 'packages/finance-db/**'
               - 'packages/db-types/**'
+              - 'apps/pops-api/src/db/drizzle-migrations/0025_youthful_hulk.sql'
+              - 'apps/pops-api/src/db/drizzle-migrations/0026_little_frank_castle.sql'
+              - 'apps/pops-api/src/db/drizzle-migrations/0027_slow_dormammu.sql'
+              - 'apps/pops-api/src/db/drizzle-migrations/0052_budgets_active_default_zero.sql'
               - '.github/workflows/finance-db-quality.yml'
               - '.github/workflows/_pkg-check.yml'
+
+  migration-drift-guard:
+    name: Migration drift (shared vs finance-db)
+    needs: [changes]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Skip — no relevant changes"
+        if: github.event_name == 'pull_request' && needs.changes.outputs.relevant != 'true'
+        run: echo "Skipping — no relevant changes"
+      - uses: actions/checkout@v6
+        if: github.event_name != 'pull_request' || needs.changes.outputs.relevant == 'true'
+      - name: Diff finance-db copies against shared journal copies
+        if: github.event_name != 'pull_request' || needs.changes.outputs.relevant == 'true'
+        run: |
+          set -euo pipefail
+          tags=(
+            0025_youthful_hulk
+            0026_little_frank_castle
+            0027_slow_dormammu
+            0052_budgets_active_default_zero
+          )
+          fail=0
+          for tag in "${tags[@]}"; do
+            shared="apps/pops-api/src/db/drizzle-migrations/${tag}.sql"
+            pillar="packages/finance-db/migrations/${tag}.sql"
+            if ! diff -q "$shared" "$pillar"; then
+              echo "::error::Migration drift detected: $shared and $pillar must be byte-identical during the transitional release cycle (finance pillar phase 1)."
+              diff "$shared" "$pillar" || true
+              fail=1
+            else
+              echo "OK — both ${tag}.sql copies are byte-identical."
+            fi
+          done
+          exit "$fail"
 
   quality:
     needs: [changes]

--- a/docs/themes/02-finance/prds/025-budgets/README.md
+++ b/docs/themes/02-finance/prds/025-budgets/README.md
@@ -43,11 +43,11 @@ Build budget tracking — spending categories with monthly or yearly limits. Sho
 
 ## User Stories
 
-| #   | Story                                           | Summary                                               | Status  | Parallelisable   |
-| --- | ----------------------------------------------- | ----------------------------------------------------- | ------- | ---------------- |
-| 01  | [us-01-schema-api](us-01-schema-api.md)         | Budget table, unique constraint, CRUD procedures      | Partial | No (first)       |
-| 02  | [us-02-budgets-page](us-02-budgets-page.md)     | DataTable with search, period/status filters, sorting | Done    | Blocked by us-01 |
-| 03  | [us-03-budget-crud-ui](us-03-budget-crud-ui.md) | Create/edit/delete dialogs with form validation       | Done    | Blocked by us-01 |
+| #   | Story                                           | Summary                                               | Status | Parallelisable   |
+| --- | ----------------------------------------------- | ----------------------------------------------------- | ------ | ---------------- |
+| 01  | [us-01-schema-api](us-01-schema-api.md)         | Budget table, unique constraint, CRUD procedures      | Done   | No (first)       |
+| 02  | [us-02-budgets-page](us-02-budgets-page.md)     | DataTable with search, period/status filters, sorting | Done   | Blocked by us-01 |
+| 03  | [us-03-budget-crud-ui](us-03-budget-crud-ui.md) | Create/edit/delete dialogs with form validation       | Done   | Blocked by us-01 |
 
 ## Out of Scope
 

--- a/packages/finance-db/migrations/0025_youthful_hulk.sql
+++ b/packages/finance-db/migrations/0025_youthful_hulk.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `transaction_corrections` ADD `is_active` integer DEFAULT true NOT NULL;

--- a/packages/finance-db/migrations/0026_little_frank_castle.sql
+++ b/packages/finance-db/migrations/0026_little_frank_castle.sql
@@ -1,0 +1,66 @@
+CREATE TABLE `tag_vocabulary` (
+	`tag` text PRIMARY KEY NOT NULL,
+	`source` text DEFAULT 'seed' NOT NULL,
+	`is_active` integer DEFAULT true NOT NULL,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `idx_tag_vocabulary_active` ON `tag_vocabulary` (`is_active`);--> statement-breakpoint
+INSERT OR IGNORE INTO `tag_vocabulary` (`tag`, `source`, `is_active`) VALUES
+  ('Income', 'seed', 1),
+  ('Transfer', 'seed', 1),
+  ('Groceries', 'seed', 1),
+  ('Eat Out', 'seed', 1),
+  ('Coffee', 'seed', 1),
+  ('Transport', 'seed', 1),
+  ('Fuel', 'seed', 1),
+  ('Charging', 'seed', 1),
+  ('Novated Lease', 'seed', 1),
+  ('Parking', 'seed', 1),
+  ('Tolls', 'seed', 1),
+  ('Public Transport', 'seed', 1),
+  ('Shopping', 'seed', 1),
+  ('Home', 'seed', 1),
+  ('Online', 'seed', 1),
+  ('Utilities', 'seed', 1),
+  ('Internet', 'seed', 1),
+  ('Mobile', 'seed', 1),
+  ('Subscriptions', 'seed', 1),
+  ('Entertainment', 'seed', 1),
+  ('Pub', 'seed', 1),
+  ('Bar', 'seed', 1),
+  ('Club', 'seed', 1),
+  ('Restaurant', 'seed', 1),
+  ('Health', 'seed', 1),
+  ('Pharmacy', 'seed', 1),
+  ('Insurance', 'seed', 1),
+  ('Rent', 'seed', 1),
+  ('Mortgage', 'seed', 1),
+  ('Travel', 'seed', 1),
+  ('Education', 'seed', 1),
+  ('Gifts', 'seed', 1),
+  ('Donations', 'seed', 1),
+  ('Fees', 'seed', 1),
+  ('Interest', 'seed', 1),
+  ('Taxes', 'seed', 1),
+  ('Deductible', 'seed', 1),
+  ('Unknown', 'seed', 1);
+--> statement-breakpoint
+CREATE TABLE `transaction_tag_rules` (
+	`id` text PRIMARY KEY NOT NULL,
+	`description_pattern` text NOT NULL,
+	`match_type` text DEFAULT 'exact' NOT NULL,
+	`entity_id` text,
+	`tags` text DEFAULT '[]' NOT NULL,
+	`is_active` integer DEFAULT true NOT NULL,
+	`confidence` real DEFAULT 0.5 NOT NULL,
+	`times_applied` integer DEFAULT 0 NOT NULL,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL,
+	`last_used_at` text,
+	FOREIGN KEY (`entity_id`) REFERENCES `entities`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE INDEX `idx_tag_rules_pattern` ON `transaction_tag_rules` (`description_pattern`);--> statement-breakpoint
+CREATE INDEX `idx_tag_rules_entity_id` ON `transaction_tag_rules` (`entity_id`);--> statement-breakpoint
+CREATE INDEX `idx_tag_rules_confidence` ON `transaction_tag_rules` (`confidence`);--> statement-breakpoint
+CREATE INDEX `idx_tag_rules_times_applied` ON `transaction_tag_rules` (`times_applied`);

--- a/packages/finance-db/migrations/0027_slow_dormammu.sql
+++ b/packages/finance-db/migrations/0027_slow_dormammu.sql
@@ -1,0 +1,49 @@
+ALTER TABLE `transaction_corrections` ADD `priority` integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+CREATE INDEX `idx_corrections_priority` ON `transaction_corrections` (`priority`);--> statement-breakpoint
+ALTER TABLE `transaction_tag_rules` ADD `priority` integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+CREATE INDEX `idx_tag_rules_priority` ON `transaction_tag_rules` (`priority`);--> statement-breakpoint
+-- Backfill transaction_corrections: exact → 0-999, contains → 1000-1999, regex → 2000-2999
+-- Within each band, order by confidence DESC, times_applied DESC, gaps of 10
+UPDATE `transaction_corrections`
+SET `priority` = (
+  SELECT
+    CASE tc2.match_type
+      WHEN 'exact' THEN 0
+      WHEN 'contains' THEN 1000
+      WHEN 'regex' THEN 2000
+      ELSE 0
+    END + (row_num - 1) * 10
+  FROM (
+    SELECT
+      id,
+      match_type,
+      ROW_NUMBER() OVER (
+        PARTITION BY match_type
+        ORDER BY confidence DESC, times_applied DESC
+      ) AS row_num
+    FROM `transaction_corrections`
+  ) tc2
+  WHERE tc2.id = `transaction_corrections`.id
+);--> statement-breakpoint
+-- Backfill transaction_tag_rules: exact → 0-999, contains → 1000-1999, regex → 2000-2999
+UPDATE `transaction_tag_rules`
+SET `priority` = (
+  SELECT
+    CASE tr2.match_type
+      WHEN 'exact' THEN 0
+      WHEN 'contains' THEN 1000
+      WHEN 'regex' THEN 2000
+      ELSE 0
+    END + (row_num - 1) * 10
+  FROM (
+    SELECT
+      id,
+      match_type,
+      ROW_NUMBER() OVER (
+        PARTITION BY match_type
+        ORDER BY confidence DESC, times_applied DESC
+      ) AS row_num
+    FROM `transaction_tag_rules`
+  ) tr2
+  WHERE tr2.id = `transaction_tag_rules`.id
+);

--- a/packages/finance-db/migrations/0052_budgets_active_default_zero.sql
+++ b/packages/finance-db/migrations/0052_budgets_active_default_zero.sql
@@ -1,0 +1,23 @@
+-- PRD-025 #2550: Align budgets.active DB default with API default.
+-- The CreateBudgetSchema in apps/pops-api defaults `active` to false (0).
+-- The original schema defaulted to 1, so direct SQL inserts disagreed with API inserts.
+-- SQLite cannot ALTER COLUMN DEFAULT, so we recreate the table preserving all rows.
+
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_budgets` (
+	`id` text PRIMARY KEY NOT NULL,
+	`notion_id` text,
+	`category` text NOT NULL,
+	`period` text,
+	`amount` real,
+	`active` integer DEFAULT 0 NOT NULL,
+	`notes` text,
+	`last_edited_time` text NOT NULL
+);
+--> statement-breakpoint
+INSERT INTO `__new_budgets`("id", "notion_id", "category", "period", "amount", "active", "notes", "last_edited_time") SELECT "id", "notion_id", "category", "period", "amount", "active", "notes", "last_edited_time" FROM `budgets`;--> statement-breakpoint
+DROP TABLE `budgets`;--> statement-breakpoint
+ALTER TABLE `__new_budgets` RENAME TO `budgets`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+CREATE UNIQUE INDEX `budgets_notion_id_unique` ON `budgets` (`notion_id`);--> statement-breakpoint
+CREATE UNIQUE INDEX `idx_budgets_category_period` ON `budgets` (`category`, COALESCE(`period`, char(0)));

--- a/packages/finance-db/migrations/meta/_journal.json
+++ b/packages/finance-db/migrations/meta/_journal.json
@@ -1,0 +1,34 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "6",
+      "when": 1775569718681,
+      "tag": "0025_youthful_hulk",
+      "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1775653615416,
+      "tag": "0026_little_frank_castle",
+      "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1775998252709,
+      "tag": "0027_slow_dormammu",
+      "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1778429000000,
+      "tag": "0052_budgets_active_default_zero",
+      "breakpoints": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Moves finance's 4 owned drizzle migrations into `packages/finance-db/migrations/` with byte-identical SQL and a fresh per-package journal.
- Shared journal entries stay intact for one release cycle per the CI-never-breaks pattern. Tag dedupe wins on the second run.
- Adds a drift-guard CI job that diffs each shared vs pillar copy and fails fast on any divergence.

## Tags moved

| Tag | Description |
|---|---|
| 0025_youthful_hulk | transaction_corrections.is_active |
| 0026_little_frank_castle | tag_vocabulary + transaction_tag_rules |
| 0027_slow_dormammu | transaction_corrections + transaction_tag_rules priority columns |
| 0052_budgets_active_default_zero | PRD-025 #2550 |

## Smoke-test extension deferred

Every finance migration ALTERs or references tables created in the shared baseline (`0000_naive_chameleon`), so they can't apply standalone against an empty in-memory DB the way core's `0054_service_accounts` could. The drift guard + finance-db's wishlist test + pops-api's migration-ownership contract guard cover the equivalent correctness; per-pillar runner discovery for finance is exercised by integration tests against a fully-applied DB.

## What stays unchanged in this PR

- `MIGRATION_OWNERS` still claims all 4 tags as `'finance'` — needed during the transitional window so the shared runner still applies them.
- `financeMigrationTags` / `financeMigrations` manifest export unchanged for the same reason.
- PR 4 retires both copies in lockstep.

## Test plan

- [x] `pnpm --filter @pops/finance-db typecheck` / `test` / `build`
- [x] `pops-api`'s `migration-ownership.test.ts` (contract guard) — 4 / 4
- [x] `pops-api`'s `per-pillar-migrations.test.ts` — 7 / 7
- [x] `pnpm lint` clean
- [x] CI drift guard diff verified locally