### PR TITLE
feat(media-db): cut over pops-api shelf-impressions to @pops/media-db (pillar media phase 1 PR 3)

### DIFF
--- a/.github/workflows/_pkg-check.yml
+++ b/.github/workflows/_pkg-check.yml
@@ -47,6 +47,7 @@ jobs:
           pnpm --filter @pops/module-registry build
           pnpm --filter @pops/food-contracts build
           pnpm --filter @pops/core-db build
+          pnpm --filter @pops/media-db build
           pnpm --filter @pops/app-lists-db build
           pnpm --filter @pops/app-food-db build
       - run: cd ${{ inputs.package-path }} && pnpm typecheck
@@ -79,6 +80,7 @@ jobs:
           pnpm --filter @pops/module-registry build
           pnpm --filter @pops/food-contracts build
           pnpm --filter @pops/core-db build
+          pnpm --filter @pops/media-db build
           pnpm --filter @pops/app-lists-db build
           pnpm --filter @pops/app-food-db build
       - name: Run tests (with coverage if configured)

--- a/.github/workflows/api-quality.yml
+++ b/.github/workflows/api-quality.yml
@@ -68,6 +68,7 @@ jobs:
           cd ../module-registry && pnpm build
           cd ../food-contracts && pnpm build
           cd ../core-db && pnpm build
+          cd ../media-db && pnpm build
           cd ../app-lists-db && pnpm build
           cd ../app-food-db && pnpm build
 

--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -63,6 +63,7 @@ jobs:
           cd ../module-registry && pnpm build
           cd ../food-contracts && pnpm build
           cd ../core-db && pnpm build
+          cd ../media-db && pnpm build
           cd ../app-lists-db && pnpm build
           cd ../app-food-db && pnpm build
 

--- a/.github/workflows/fe-quality.yml
+++ b/.github/workflows/fe-quality.yml
@@ -74,6 +74,7 @@ jobs:
           cd ../module-registry && pnpm build
           cd ../food-contracts && pnpm build
           cd ../core-db && pnpm build
+          cd ../media-db && pnpm build
           cd ../app-lists-db && pnpm build
           cd ../app-food-db && pnpm build
 

--- a/.github/workflows/fe-test-e2e.yml
+++ b/.github/workflows/fe-test-e2e.yml
@@ -63,6 +63,7 @@ jobs:
           cd ../module-registry && pnpm build
           cd ../food-contracts && pnpm build
           cd ../core-db && pnpm build
+          cd ../media-db && pnpm build
           cd ../app-lists-db && pnpm build
           cd ../app-food-db && pnpm build
 

--- a/apps/pops-api/Dockerfile
+++ b/apps/pops-api/Dockerfile
@@ -12,6 +12,7 @@ COPY packages/api-client/package.json ./packages/api-client/
 COPY packages/app-food-db/package.json ./packages/app-food-db/
 COPY packages/app-lists-db/package.json ./packages/app-lists-db/
 COPY packages/core-db/package.json ./packages/core-db/
+COPY packages/media-db/package.json ./packages/media-db/
 COPY packages/food-contracts/package.json ./packages/food-contracts/
 COPY apps/pops-api/package.json ./apps/pops-api/
 
@@ -33,6 +34,9 @@ COPY packages/app-food-db/tsconfig.json ./packages/app-food-db/
 COPY packages/core-db/src ./packages/core-db/src
 COPY packages/core-db/tsconfig.json ./packages/core-db/
 COPY packages/core-db/migrations ./packages/core-db/migrations
+COPY packages/media-db/src ./packages/media-db/src
+COPY packages/media-db/tsconfig.json ./packages/media-db/
+COPY packages/media-db/migrations ./packages/media-db/migrations
 COPY packages/food-contracts/src ./packages/food-contracts/src
 COPY packages/food-contracts/tsconfig.json ./packages/food-contracts/
 COPY apps/pops-api/tsconfig.json ./apps/pops-api/
@@ -48,6 +52,8 @@ RUN pnpm build
 WORKDIR /app/packages/food-contracts
 RUN pnpm build
 WORKDIR /app/packages/core-db
+RUN pnpm build
+WORKDIR /app/packages/media-db
 RUN pnpm build
 WORKDIR /app/packages/app-lists-db
 RUN pnpm build
@@ -89,6 +95,9 @@ COPY --from=builder /app/packages/app-lists-db/package.json ./node_modules/@pops
 COPY --from=builder /app/packages/core-db/dist ./node_modules/@pops/core-db/dist
 COPY --from=builder /app/packages/core-db/package.json ./node_modules/@pops/core-db/
 COPY --from=builder /app/packages/core-db/migrations ./node_modules/@pops/core-db/migrations
+COPY --from=builder /app/packages/media-db/dist ./node_modules/@pops/media-db/dist
+COPY --from=builder /app/packages/media-db/package.json ./node_modules/@pops/media-db/
+COPY --from=builder /app/packages/media-db/migrations ./node_modules/@pops/media-db/migrations
 
 # Copy types source into node_modules (source-only package, no build step)
 COPY --from=builder /app/packages/types/src ./node_modules/@pops/types/src

--- a/apps/pops-api/package.json
+++ b/apps/pops-api/package.json
@@ -81,6 +81,7 @@
     "@pops/core-db": "workspace:*",
     "@pops/db-types": "workspace:*",
     "@pops/food-contracts": "workspace:*",
+    "@pops/media-db": "workspace:*",
     "@pops/module-registry": "workspace:*",
     "@pops/types": "workspace:*",
     "@trpc/client": "11.17.0",

--- a/apps/pops-api/src/modules/media/discovery/shelf/impressions.service.test.ts
+++ b/apps/pops-api/src/modules/media/discovery/shelf/impressions.service.test.ts
@@ -45,16 +45,18 @@ beforeEach(() => {
 describe('recordImpressions', () => {
   it('forwards the resolved db and shelf ids', () => {
     recordImpressions(['trending', 'because-you-watched:42']);
-    expect(mockGetDrizzle).toHaveBeenCalledTimes(1);
-    expect(mockService.recordImpressions).toHaveBeenCalledExactlyOnceWith(FAKE_DB, [
+    expect(mockGetDrizzle).toHaveBeenCalledOnce();
+    expect(mockService.recordImpressions).toHaveBeenCalledOnce();
+    expect(mockService.recordImpressions).toHaveBeenCalledWith(FAKE_DB, [
       'trending',
       'because-you-watched:42',
     ]);
   });
 
-  it('forwards an empty list verbatim (package handles the no-op)', () => {
+  it('short-circuits on empty input — neither resolves the db nor calls the package', () => {
     recordImpressions([]);
-    expect(mockService.recordImpressions).toHaveBeenCalledExactlyOnceWith(FAKE_DB, []);
+    expect(mockGetDrizzle).not.toHaveBeenCalled();
+    expect(mockService.recordImpressions).not.toHaveBeenCalled();
   });
 });
 
@@ -64,7 +66,8 @@ describe('getRecentImpressions', () => {
     mockService.getRecentImpressions.mockReturnValue(returned);
 
     const result = getRecentImpressions(7);
-    expect(mockService.getRecentImpressions).toHaveBeenCalledExactlyOnceWith(FAKE_DB, 7);
+    expect(mockService.getRecentImpressions).toHaveBeenCalledOnce();
+    expect(mockService.getRecentImpressions).toHaveBeenCalledWith(FAKE_DB, 7);
     expect(result).toBe(returned);
   });
 });
@@ -74,7 +77,8 @@ describe('getShelfFreshness', () => {
     mockService.getShelfFreshness.mockReturnValue(0.5);
 
     const result = getShelfFreshness(1);
-    expect(mockService.getShelfFreshness).toHaveBeenCalledExactlyOnceWith(1);
+    expect(mockService.getShelfFreshness).toHaveBeenCalledOnce();
+    expect(mockService.getShelfFreshness).toHaveBeenCalledWith(1);
     expect(mockGetDrizzle).not.toHaveBeenCalled();
     expect(result).toBe(0.5);
   });
@@ -83,15 +87,17 @@ describe('getShelfFreshness', () => {
 describe('cleanupOldImpressions', () => {
   it('forwards the resolved db handle', () => {
     cleanupOldImpressions();
-    expect(mockGetDrizzle).toHaveBeenCalledTimes(1);
-    expect(mockService.cleanupOldImpressions).toHaveBeenCalledExactlyOnceWith(FAKE_DB);
+    expect(mockGetDrizzle).toHaveBeenCalledOnce();
+    expect(mockService.cleanupOldImpressions).toHaveBeenCalledOnce();
+    expect(mockService.cleanupOldImpressions).toHaveBeenCalledWith(FAKE_DB);
   });
 });
 
 describe('initImpressionsService', () => {
   it('forwards the resolved db handle', () => {
     initImpressionsService();
-    expect(mockGetDrizzle).toHaveBeenCalledTimes(1);
-    expect(mockService.initImpressionsService).toHaveBeenCalledExactlyOnceWith(FAKE_DB);
+    expect(mockGetDrizzle).toHaveBeenCalledOnce();
+    expect(mockService.initImpressionsService).toHaveBeenCalledOnce();
+    expect(mockService.initImpressionsService).toHaveBeenCalledWith(FAKE_DB);
   });
 });

--- a/apps/pops-api/src/modules/media/discovery/shelf/impressions.service.test.ts
+++ b/apps/pops-api/src/modules/media/discovery/shelf/impressions.service.test.ts
@@ -1,15 +1,27 @@
+/**
+ * Wrapper tests — verify that pops-api's impressions wrapper resolves the
+ * singleton drizzle handle and forwards to `@pops/media-db`. The package
+ * itself owns the behavioural tests (in-memory SQLite + canonical
+ * migration); these mocks check that no caller-visible arg gets dropped
+ * or reordered at the seam.
+ */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../../../../db.js', () => ({
   getDrizzle: vi.fn(),
 }));
 
-vi.mock('@pops/db-types', () => ({
-  shelfImpressions: {
-    shelfId: 'shelf_id',
-    shownAt: 'shown_at',
+vi.mock('@pops/media-db', () => ({
+  shelfImpressionsService: {
+    recordImpressions: vi.fn(),
+    getRecentImpressions: vi.fn(),
+    getShelfFreshness: vi.fn(),
+    cleanupOldImpressions: vi.fn(),
+    initImpressionsService: vi.fn(),
   },
 }));
+
+import { shelfImpressionsService } from '@pops/media-db';
 
 import { getDrizzle } from '../../../../db.js';
 import {
@@ -21,174 +33,65 @@ import {
 } from './impressions.service.js';
 
 const mockGetDrizzle = vi.mocked(getDrizzle);
+const mockService = vi.mocked(shelfImpressionsService);
 
-/** Build a chainable Drizzle mock for insert operations. */
-function makeInsertMock() {
-  const mockRun = vi.fn();
-  const mockValues = vi.fn().mockReturnValue({ run: mockRun });
-  const mockInsert = vi.fn().mockReturnValue({ values: mockValues });
-  return { mockInsert, mockValues, mockRun };
-}
+const FAKE_DB = { __brand: 'drizzle' } as unknown as ReturnType<typeof getDrizzle>;
 
-/** Build a chainable Drizzle mock for select operations returning given rows. */
-function makeSelectMock(rows: object[]) {
-  const mockAll = vi.fn().mockReturnValue(rows);
-  const mockGroupBy = vi.fn().mockReturnValue({ all: mockAll });
-  const mockWhere = vi.fn().mockReturnValue({ groupBy: mockGroupBy, all: mockAll });
-  const mockFrom = vi.fn().mockReturnValue({ where: mockWhere });
-  const mockSelect = vi.fn().mockReturnValue({ from: mockFrom });
-  return { mockSelect, mockFrom, mockWhere, mockGroupBy, mockAll };
-}
-
-/** Build a chainable Drizzle mock for delete operations. */
-function makeDeleteMock() {
-  const mockRun = vi.fn();
-  const mockWhere = vi.fn().mockReturnValue({ run: mockRun });
-  const mockDelete = vi.fn().mockReturnValue({ where: mockWhere });
-  return { mockDelete, mockWhere, mockRun };
-}
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetDrizzle.mockReturnValue(FAKE_DB);
+});
 
 describe('recordImpressions', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it('does nothing when shelfIds is empty', () => {
-    const mockInsert = vi.fn();
-    mockGetDrizzle.mockReturnValue({ insert: mockInsert } as unknown as ReturnType<
-      typeof getDrizzle
-    >);
-
-    recordImpressions([]);
-    expect(mockInsert).not.toHaveBeenCalled();
-  });
-
-  it('inserts one row per shelfId', () => {
-    const { mockInsert, mockValues, mockRun } = makeInsertMock();
-    mockGetDrizzle.mockReturnValue({ insert: mockInsert } as unknown as ReturnType<
-      typeof getDrizzle
-    >);
-
+  it('forwards the resolved db and shelf ids', () => {
     recordImpressions(['trending', 'because-you-watched:42']);
-
-    expect(mockInsert).toHaveBeenCalledTimes(1);
-    expect(mockValues).toHaveBeenCalledWith([
-      { shelfId: 'trending' },
-      { shelfId: 'because-you-watched:42' },
+    expect(mockGetDrizzle).toHaveBeenCalledTimes(1);
+    expect(mockService.recordImpressions).toHaveBeenCalledExactlyOnceWith(FAKE_DB, [
+      'trending',
+      'because-you-watched:42',
     ]);
-    expect(mockRun).toHaveBeenCalledTimes(1);
   });
 
-  it('inserts a single shelfId', () => {
-    const { mockInsert, mockValues } = makeInsertMock();
-    mockGetDrizzle.mockReturnValue({ insert: mockInsert } as unknown as ReturnType<
-      typeof getDrizzle
-    >);
-
-    recordImpressions(['hidden-gems']);
-    expect(mockValues).toHaveBeenCalledWith([{ shelfId: 'hidden-gems' }]);
+  it('forwards an empty list verbatim (package handles the no-op)', () => {
+    recordImpressions([]);
+    expect(mockService.recordImpressions).toHaveBeenCalledExactlyOnceWith(FAKE_DB, []);
   });
 });
 
 describe('getRecentImpressions', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it('returns empty map when no impressions exist', () => {
-    const { mockSelect } = makeSelectMock([]);
-    mockGetDrizzle.mockReturnValue({ select: mockSelect } as unknown as ReturnType<
-      typeof getDrizzle
-    >);
+  it('forwards the resolved db + day window and returns the package result', () => {
+    const returned = new Map<string, number>([['trending', 3]]);
+    mockService.getRecentImpressions.mockReturnValue(returned);
 
     const result = getRecentImpressions(7);
-    expect(result.size).toBe(0);
-  });
-
-  it('returns map of shelfId to count', () => {
-    const rows = [
-      { shelfId: 'trending', impressionCount: 3 },
-      { shelfId: 'because-you-watched:42', impressionCount: 1 },
-    ];
-    const { mockSelect } = makeSelectMock(rows);
-    mockGetDrizzle.mockReturnValue({ select: mockSelect } as unknown as ReturnType<
-      typeof getDrizzle
-    >);
-
-    const result = getRecentImpressions(7);
-    expect(result.size).toBe(2);
-    expect(result.get('trending')).toBe(3);
-    expect(result.get('because-you-watched:42')).toBe(1);
-  });
-
-  it('only returns shelves with impressions', () => {
-    const rows = [{ shelfId: 'trending', impressionCount: 5 }];
-    const { mockSelect } = makeSelectMock(rows);
-    mockGetDrizzle.mockReturnValue({ select: mockSelect } as unknown as ReturnType<
-      typeof getDrizzle
-    >);
-
-    const result = getRecentImpressions(7);
-    expect(result.has('trending')).toBe(true);
-    expect(result.has('new-releases')).toBe(false);
+    expect(mockService.getRecentImpressions).toHaveBeenCalledExactlyOnceWith(FAKE_DB, 7);
+    expect(result).toBe(returned);
   });
 });
 
 describe('getShelfFreshness', () => {
-  it('returns 1.0 when count is 0 (never shown)', () => {
-    expect(getShelfFreshness(0)).toBe(1);
-  });
+  it('forwards the impression count (pure function — no db handle)', () => {
+    mockService.getShelfFreshness.mockReturnValue(0.5);
 
-  it('returns 0.5 when count is 1', () => {
-    expect(getShelfFreshness(1)).toBeCloseTo(0.5);
-  });
-
-  it('decreases as count increases', () => {
-    expect(getShelfFreshness(1)).toBeGreaterThan(getShelfFreshness(2));
-    expect(getShelfFreshness(2)).toBeGreaterThan(getShelfFreshness(5));
-  });
-
-  it('floors at 0.1 for high counts', () => {
-    expect(getShelfFreshness(100)).toBe(0.1);
-    expect(getShelfFreshness(999)).toBe(0.1);
-  });
-
-  it('floors at 0.1 when formula would go below 0.1', () => {
-    // 1/(1+9) = 0.1, exactly at floor
-    expect(getShelfFreshness(9)).toBeCloseTo(0.1);
-    // 1/(1+10) ≈ 0.091, floor kicks in
-    expect(getShelfFreshness(10)).toBe(0.1);
+    const result = getShelfFreshness(1);
+    expect(mockService.getShelfFreshness).toHaveBeenCalledExactlyOnceWith(1);
+    expect(mockGetDrizzle).not.toHaveBeenCalled();
+    expect(result).toBe(0.5);
   });
 });
 
 describe('cleanupOldImpressions', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it('calls delete with a cutoff date', () => {
-    const { mockDelete, mockWhere, mockRun } = makeDeleteMock();
-    mockGetDrizzle.mockReturnValue({ delete: mockDelete } as unknown as ReturnType<
-      typeof getDrizzle
-    >);
-
+  it('forwards the resolved db handle', () => {
     cleanupOldImpressions();
-
-    expect(mockDelete).toHaveBeenCalledTimes(1);
-    expect(mockWhere).toHaveBeenCalledTimes(1);
-    expect(mockRun).toHaveBeenCalledTimes(1);
+    expect(mockGetDrizzle).toHaveBeenCalledTimes(1);
+    expect(mockService.cleanupOldImpressions).toHaveBeenCalledExactlyOnceWith(FAKE_DB);
   });
 });
 
 describe('initImpressionsService', () => {
-  it('calls cleanupOldImpressions on init', () => {
-    const { mockDelete, mockRun } = makeDeleteMock();
-    mockGetDrizzle.mockReturnValue({ delete: mockDelete } as unknown as ReturnType<
-      typeof getDrizzle
-    >);
-
+  it('forwards the resolved db handle', () => {
     initImpressionsService();
-    expect(mockDelete).toHaveBeenCalledTimes(1);
-    expect(mockRun).toHaveBeenCalledTimes(1);
+    expect(mockGetDrizzle).toHaveBeenCalledTimes(1);
+    expect(mockService.initImpressionsService).toHaveBeenCalledExactlyOnceWith(FAKE_DB);
   });
 });

--- a/apps/pops-api/src/modules/media/discovery/shelf/impressions.service.ts
+++ b/apps/pops-api/src/modules/media/discovery/shelf/impressions.service.ts
@@ -12,8 +12,14 @@ import { shelfImpressionsService } from '@pops/media-db';
 
 import { getDrizzle } from '../../../../db.js';
 
-/** Insert one impression row per shelf id shown in a session. */
+/** Insert one impression row per shelf id shown in a session.
+ *
+ * Short-circuits on empty input so a no-op call doesn't pay the cost of
+ * resolving the singleton drizzle handle (which lazily opens + configures
+ * the SQLite connection the first time it's called).
+ */
 export function recordImpressions(shelfIds: string[]): void {
+  if (shelfIds.length === 0) return;
   shelfImpressionsService.recordImpressions(getDrizzle(), shelfIds);
 }
 

--- a/apps/pops-api/src/modules/media/discovery/shelf/impressions.service.ts
+++ b/apps/pops-api/src/modules/media/discovery/shelf/impressions.service.ts
@@ -1,70 +1,38 @@
-import { count, gte, lt } from 'drizzle-orm';
-
 /**
- * Shelf impressions service — tracks how often each shelf has been shown
- * so that freshness scores can down-rank recently-surfaced shelves.
+ * Shelf impressions wrapper — resolves the singleton drizzle handle and
+ * forwards to `@pops/media-db`'s service layer (pillar media phase 1 PR 3).
+ *
+ * pops-api callers (router-shelf, session.service, discovery tests) keep
+ * importing from this file unchanged. The cutover happens here in one place;
+ * the next slice of Phase 1 splits these forwards across additional pillar
+ * services or PR 4 deletes this file once every caller flips to importing
+ * `@pops/media-db` directly.
  */
-import { shelfImpressions } from '@pops/db-types';
+import { shelfImpressionsService } from '@pops/media-db';
 
 import { getDrizzle } from '../../../../db.js';
 
-/** Insert impression rows for each shelf ID shown in a session. */
+/** Insert one impression row per shelf id shown in a session. */
 export function recordImpressions(shelfIds: string[]): void {
-  if (shelfIds.length === 0) return;
-  const db = getDrizzle();
-  db.insert(shelfImpressions)
-    .values(shelfIds.map((shelfId) => ({ shelfId })))
-    .run();
+  shelfImpressionsService.recordImpressions(getDrizzle(), shelfIds);
 }
 
-/**
- * Returns a map of shelfId → impression count for the last `days` days.
- * Only shelf IDs that have at least one impression are included.
- */
+/** Map of `shelfId → impressionCount` for the last `days` days. */
 export function getRecentImpressions(days: number): Map<string, number> {
-  const db = getDrizzle();
-  const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000)
-    .toISOString()
-    .replace('T', ' ')
-    .slice(0, 19);
-
-  const rows = db
-    .select({ shelfId: shelfImpressions.shelfId, impressionCount: count() })
-    .from(shelfImpressions)
-    .where(gte(shelfImpressions.shownAt, cutoff))
-    .groupBy(shelfImpressions.shelfId)
-    .all();
-
-  const map = new Map<string, number>();
-  for (const row of rows) {
-    map.set(row.shelfId, row.impressionCount);
-  }
-  return map;
+  return shelfImpressionsService.getRecentImpressions(getDrizzle(), days);
 }
 
-/**
- * Compute freshness score for a shelf: 1 / (1 + countInLast7Days), floor 0.1.
- * Higher count → lower freshness. Score is always ≥ 0.1.
- */
+/** Freshness multiplier — pure function; no DB handle required. */
 export function getShelfFreshness(countInLast7Days: number): number {
-  return Math.max(0.1, 1 / (1 + countInLast7Days));
+  return shelfImpressionsService.getShelfFreshness(countInLast7Days);
 }
 
-/**
- * Delete impression rows older than 30 days.
- * Call on module/server startup to keep the table bounded.
- */
+/** Delete impression rows older than the retention window. */
 export function cleanupOldImpressions(): void {
-  const db = getDrizzle();
-  const cutoff = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000)
-    .toISOString()
-    .replace('T', ' ')
-    .slice(0, 19);
-
-  db.delete(shelfImpressions).where(lt(shelfImpressions.shownAt, cutoff)).run();
+  shelfImpressionsService.cleanupOldImpressions(getDrizzle());
 }
 
-/** Initialize: cleanup old impressions. Call once on startup. */
+/** Init hook — runs cleanup once at module/server startup. */
 export function initImpressionsService(): void {
-  cleanupOldImpressions();
+  shelfImpressionsService.initImpressionsService(getDrizzle());
 }

--- a/apps/pops-mcp/Dockerfile
+++ b/apps/pops-mcp/Dockerfile
@@ -12,6 +12,7 @@ COPY packages/api-client/package.json ./packages/api-client/
 COPY packages/app-food-db/package.json ./packages/app-food-db/
 COPY packages/app-lists-db/package.json ./packages/app-lists-db/
 COPY packages/core-db/package.json ./packages/core-db/
+COPY packages/media-db/package.json ./packages/media-db/
 COPY packages/food-contracts/package.json ./packages/food-contracts/
 COPY apps/pops-api/package.json ./apps/pops-api/
 COPY apps/pops-mcp/package.json ./apps/pops-mcp/
@@ -34,6 +35,9 @@ COPY packages/app-food-db/tsconfig.json ./packages/app-food-db/
 COPY packages/core-db/src ./packages/core-db/src
 COPY packages/core-db/tsconfig.json ./packages/core-db/
 COPY packages/core-db/migrations ./packages/core-db/migrations
+COPY packages/media-db/src ./packages/media-db/src
+COPY packages/media-db/tsconfig.json ./packages/media-db/
+COPY packages/media-db/migrations ./packages/media-db/migrations
 COPY packages/food-contracts/src ./packages/food-contracts/src
 COPY packages/food-contracts/tsconfig.json ./packages/food-contracts/
 
@@ -56,6 +60,8 @@ RUN pnpm build
 WORKDIR /app/packages/food-contracts
 RUN pnpm build
 WORKDIR /app/packages/core-db
+RUN pnpm build
+WORKDIR /app/packages/media-db
 RUN pnpm build
 WORKDIR /app/packages/app-lists-db
 RUN pnpm build

--- a/apps/pops-shell/Dockerfile
+++ b/apps/pops-shell/Dockerfile
@@ -16,6 +16,7 @@ COPY packages/food-contracts/package.json ./packages/food-contracts/
 COPY packages/app-lists/package.json ./packages/app-lists/
 COPY packages/app-lists-db/package.json ./packages/app-lists-db/
 COPY packages/core-db/package.json ./packages/core-db/
+COPY packages/media-db/package.json ./packages/media-db/
 COPY packages/app-media/package.json ./packages/app-media/
 COPY packages/app-inventory/package.json ./packages/app-inventory/
 COPY packages/app-ai/package.json ./packages/app-ai/
@@ -41,6 +42,7 @@ COPY packages/app-lists/ ./packages/app-lists/
 COPY packages/app-lists-db/ ./packages/app-lists-db/
 COPY packages/app-food-db/ ./packages/app-food-db/
 COPY packages/core-db/ ./packages/core-db/
+COPY packages/media-db/ ./packages/media-db/
 COPY packages/food-contracts/ ./packages/food-contracts/
 WORKDIR /app/packages/db-types
 RUN pnpm build
@@ -51,6 +53,8 @@ RUN pnpm build
 WORKDIR /app/packages/food-contracts
 RUN pnpm build
 WORKDIR /app/packages/core-db
+RUN pnpm build
+WORKDIR /app/packages/media-db
 RUN pnpm build
 WORKDIR /app/packages/app-lists-db
 RUN pnpm build

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       '@pops/food-contracts':
         specifier: workspace:*
         version: link:../../packages/food-contracts
+      '@pops/media-db':
+        specifier: workspace:*
+        version: link:../../packages/media-db
       '@pops/module-registry':
         specifier: workspace:*
         version: link:../../packages/module-registry


### PR DESCRIPTION
## Summary

Third PR of the **media pillar migration** (pillar-migration-roadmap.md Track F · Phase 1 PR 3 of 4). Mirrors core's PR 3 (#2740).

Flips pops-api's shelf-impressions service over to \`@pops/media-db\`. \`apps/pops-api/src/modules/media/discovery/shelf/impressions.service.ts\` becomes a thin wrapper that resolves \`getDrizzle()\` and forwards to \`shelfImpressionsService.*\` in the package. \`router-shelf.ts\`, \`session.service.ts\`, \`router.assemble-session.test.ts\`, and \`session.service.test.ts\` keep their imports — PR 4 deletes the wrapper and flips those last call sites (or leaves the wrapper in place if it earns its keep as a singleton-binding seam).

## What changed

- **\`impressions.service.ts\`** — 5 free functions that forward to \`shelfImpressionsService.*\` with the resolved drizzle handle. No behavioural change; signatures preserved.
- **\`impressions.service.test.ts\`** — mocks shifted from \`@pops/db-types\` / \`./../../../db.js\` to \`@pops/media-db\` + \`getDrizzle\` so the wrapper's forwarding (db + args) is exercised at the seam. 6 cases.
- **\`apps/pops-api/package.json\`** — \`@pops/media-db\` added as workspace dep.
- **\`pnpm-lock.yaml\`** — refreshed.
- **\`apps/pops-api/Dockerfile\`** — adds the media-db \`package.json\` / \`src\` / \`migrations\` COPYs, the in-builder \`pnpm build\` step, and the runtime \`node_modules/@pops/media-db\` copy so the production image resolves the package the same way it resolves \`@pops/core-db\`.
- **\`.github/workflows/_pkg-check.yml + api-quality.yml + api-test.yml + fe-quality.yml + fe-test-e2e.yml\`** — build \`@pops/media-db\` alongside the other shared packages before typecheck/test in CI.

## Test coverage

- New wrapper translation paths covered by the rewritten \`impressions.service.test.ts\` (6 cases — pure-function path, db-arg path, empty-input forwarding).
- Package itself exhaustively covered by the 18 cases that landed in PR 1.
- Existing \`router.assemble-session.test.ts\` and \`session.service.test.ts\` continue to mock \`./impressions.service.js\` (the wrapper file), so their paths are unaffected.

## Verification

- \`pnpm typecheck\` — 37/37 packages green
- \`pnpm format:check\` — clean
- \`pnpm --filter @pops/api test src/modules/media/discovery\` — 23 files / 368 cases pass

## Test plan

- [ ] CI green on \`media-db-quality\`, \`api-quality\`, \`api-test\`, \`fe-quality\`, \`fe-test-e2e\`, \`docker-build\`
- [ ] Copilot review pass