### PR TITLE
feat(inventory-db): split migration journal — 0005_fancy_crystal (pillar inventory phase 1 PR 2)

### DIFF
--- a/.github/workflows/inventory-db-quality.yml
+++ b/.github/workflows/inventory-db-quality.yml
@@ -31,6 +31,30 @@ jobs:
               - '.github/workflows/inventory-db-quality.yml'
               - '.github/workflows/_pkg-check.yml'
 
+  migration-drift-guard:
+    name: Migration drift (shared vs inventory-db)
+    needs: [changes]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Skip — no relevant changes"
+        if: github.event_name == 'pull_request' && needs.changes.outputs.relevant != 'true'
+        run: echo "Skipping — no relevant changes"
+      - uses: actions/checkout@v6
+        if: github.event_name != 'pull_request' || needs.changes.outputs.relevant == 'true'
+      - name: Diff inventory-db copy against shared journal copy
+        if: github.event_name != 'pull_request' || needs.changes.outputs.relevant == 'true'
+        run: |
+          set -euo pipefail
+          shared='apps/pops-api/src/db/drizzle-migrations/0005_fancy_crystal.sql'
+          pillar='packages/inventory-db/migrations/0005_fancy_crystal.sql'
+          if ! diff -q "$shared" "$pillar"; then
+            echo "::error::Migration drift detected: $shared and $pillar must be byte-identical during the transitional release cycle (inventory pillar phase 1)."
+            diff "$shared" "$pillar" || true
+            exit 1
+          fi
+          echo "OK — both 0005_fancy_crystal.sql copies are byte-identical."
+
   quality:
     needs: [changes]
     if: always()

--- a/apps/pops-api/src/db/per-pillar-migrations.test.ts
+++ b/apps/pops-api/src/db/per-pillar-migrations.test.ts
@@ -203,21 +203,25 @@ describe('runPerPillarMigrations', () => {
     // Smoke check: importing the runner under the real layout exercises
     // the workspace fallback path against an actual on-disk pillar dir.
     // `core` owns `packages/core-db/migrations/` with 0054_service_accounts
-    // (core pillar Phase 1 PR 2) and `media` owns `packages/media-db/migrations/`
-    // with 0021_spooky_lockheed (media pillar Phase 1 PR 2). Pillars without
-    // their own journal yet still skip cleanly.
+    // (core pillar Phase 1 PR 2), `media` owns `packages/media-db/migrations/`
+    // with 0021_spooky_lockheed (media pillar Phase 1 PR 2), and `inventory`
+    // owns `packages/inventory-db/migrations/` with 0005_fancy_crystal
+    // (inventory pillar Phase 1 PR 2). Pillars without their own journal
+    // yet still skip cleanly.
     await withDb((db) => {
       const realPillars: PillarDescriptor[] = [
         { id: 'core', dbPackageDir: 'packages/core-db' },
         { id: 'media', dbPackageDir: 'packages/media-db' },
+        { id: 'inventory', dbPackageDir: 'packages/inventory-db' },
         { id: 'unmigrated', dbPackageDir: 'packages/this-dir-does-not-exist-db' },
       ];
       const result = runPerPillarMigrations(db, realPillars);
       expect([...result.applied].toSorted()).toEqual([
+        '0005_fancy_crystal',
         '0021_spooky_lockheed',
         '0054_service_accounts',
       ]);
-      expect([...result.pillarsApplied].toSorted()).toEqual(['core', 'media']);
+      expect([...result.pillarsApplied].toSorted()).toEqual(['core', 'inventory', 'media']);
       expect(result.pillarsSkipped).toEqual(['unmigrated']);
     });
   });

--- a/packages/inventory-db/migrations/0005_fancy_crystal.sql
+++ b/packages/inventory-db/migrations/0005_fancy_crystal.sql
@@ -1,0 +1,10 @@
+CREATE TABLE `locations` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`parent_id` text,
+	`sort_order` integer DEFAULT 0 NOT NULL,
+	`last_edited_time` text NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `idx_locations_parent` ON `locations` (`parent_id`);--> statement-breakpoint
+CREATE INDEX `idx_locations_name` ON `locations` (`name`);

--- a/packages/inventory-db/migrations/meta/_journal.json
+++ b/packages/inventory-db/migrations/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "6",
+      "when": 1773997925421,
+      "tag": "0005_fancy_crystal",
+      "breakpoints": true
+    }
+  ]
+}

--- a/packages/inventory-db/src/__tests__/locations.test.ts
+++ b/packages/inventory-db/src/__tests__/locations.test.ts
@@ -6,12 +6,14 @@
  * Higher-level tRPC coverage lives in pops-api's own integration suite
  * (until the cutover PR routes it through this package).
  *
- * The locations CREATE TABLE is read from the shared drizzle journal so
- * the test catches drift between the production migration and the
- * schema; `home_inventory` is inlined with just the columns this slice
- * exercises (`id`, `item_name`, `location_id`) because its canonical
- * migration (`0000_naive_chameleon`) bundles unrelated FK tables — the
- * items slice will read its own SQL file when it lands.
+ * The locations CREATE TABLE is read from the package's own journal at
+ * `packages/inventory-db/migrations/0005_fancy_crystal.sql`. A drift
+ * guard in `inventory-db-quality.yml` keeps that file byte-identical to
+ * the shared journal copy until the deletion PR retires the shared one.
+ * `home_inventory` is inlined with the columns this slice exercises
+ * because its canonical migration (`0000_naive_chameleon`) bundles
+ * unrelated FK tables — the items slice will read its own SQL file when
+ * it lands.
  */
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
@@ -45,10 +47,7 @@ import {
 
 import type { InventoryDb } from '../services/internal.js';
 
-const LOCATIONS_MIGRATION = join(
-  __dirname,
-  '../../../../apps/pops-api/src/db/drizzle-migrations/0005_fancy_crystal.sql'
-);
+const LOCATIONS_MIGRATION = join(__dirname, '../../migrations/0005_fancy_crystal.sql');
 
 const HOME_INVENTORY_DDL = `
 CREATE TABLE home_inventory (


### PR DESCRIPTION
## Summary

Moves the inventory pillar's first migration (`0005_fancy_crystal`) into its own drizzle journal at `packages/inventory-db/migrations/`. The shared journal entry stays intact for one release cycle per the CI-never-breaks pattern; both runners now see the same tag with byte-identical SQL, the shared one applies first (tag dedupe wins on the second), and the recorded hash matches in both paths.

Per-pillar runner discovers the pillar dir via `require.resolve('@pops/inventory-db/package.json')` (Docker image) and the workspace fallback (dev). Drizzle SQL is a byte-for-byte copy of the canonical migration so the hash drift warning never fires.

PR 3 of phase 1 flips pops-api callers to import locations from `@pops/inventory-db`. PR 4 removes the shared journal entry + `migration-ownership.ts` row + the in-tree locations module.

### Includes
- `packages/inventory-db/migrations/0005_fancy_crystal.sql` — byte-identical copy of the shared journal file.
- `packages/inventory-db/migrations/meta/_journal.json` — single entry (`idx: 0`, `tag: "0005_fancy_crystal"`, `when` copied from the shared journal at idx 5).
- `packages/inventory-db/src/__tests__/locations.test.ts` — reads the SQL from the package's own migrations dir; header comment updated to reflect the new source + drift guard.
- `apps/pops-api/src/db/per-pillar-migrations.test.ts` — smoke test extended: workspace-fallback run now applies `core` + `inventory` + `media` (was: `core` + `media`).
- `.github/workflows/inventory-db-quality.yml` — gains a `migration-drift-guard` job that diffs the two byte-identical 0005 SQL copies and fails fast if they differ. Mirrors the guard core PR 2 ([#2733](https://github.com/knoxio/pops/pull/2733)) added after Copilot R1 — without it, a change to the pops-api copy could land without inventory-quality running and silently drift during the release-cycle window. Self-removes when PR 4 deletes the shared copy.

## Test plan
- [x] `cd packages/inventory-db && pnpm typecheck` — passes
- [x] `cd packages/inventory-db && pnpm test` — 33/33 pass (reading from local migrations dir)
- [x] `cd apps/pops-api && pnpm test src/db/per-pillar-migrations.test.ts` — 7/7 pass (smoke now exercises core + inventory + media end-to-end)
- [x] `cd apps/pops-api && pnpm typecheck` — clean (after rebuilding shared db packages)
- [x] `pnpm lint` / `pnpm format:check` / `pnpm lint:boundaries` — clean
- [x] `pnpm install --frozen-lockfile` — lockfile unchanged (no dependency moves in this PR)
- [x] `diff -q apps/pops-api/src/db/drizzle-migrations/0005_fancy_crystal.sql packages/inventory-db/migrations/0005_fancy_crystal.sql` — byte-identical (drift guard would catch this anyway)