### PR TITLE
feat(food): PRD-145 — batch lifecycle services + food.batches.* behaviour

### DIFF
--- a/apps/pops-api/src/db/drizzle-migrations/0069_prd_145_batches_deleted_at.sql
+++ b/apps/pops-api/src/db/drizzle-migrations/0069_prd_145_batches_deleted_at.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `batches` ADD `deleted_at` text;

--- a/apps/pops-api/src/db/drizzle-migrations/meta/0069_snapshot.json
+++ b/apps/pops-api/src/db/drizzle-migrations/meta/0069_snapshot.json
@@ -1,0 +1,7905 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "29473271-aa9f-44fb-b282-db229db2b0ba",
+  "prevId": "7495771f-3339-4d01-aa39-8698721457ef",
+  "tables": {
+    "ai_alert_rules": {
+      "name": "ai_alert_rules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope_provider": {
+          "name": "scope_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope_model": {
+          "name": "scope_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "threshold_value": {
+          "name": "threshold_value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window_minutes": {
+          "name": "window_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_ai_alert_rules_type": {
+          "name": "idx_ai_alert_rules_type",
+          "columns": ["type"],
+          "isUnique": false
+        },
+        "idx_ai_alert_rules_enabled": {
+          "name": "idx_ai_alert_rules_enabled",
+          "columns": ["enabled"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ai_alerts": {
+      "name": "ai_alerts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope_detail": {
+          "name": "scope_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metric_value": {
+          "name": "metric_value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "threshold_value": {
+          "name": "threshold_value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "acknowledged": {
+          "name": "acknowledged",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "acknowledged_at": {
+          "name": "acknowledged_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_ai_alerts_created_at": {
+          "name": "idx_ai_alerts_created_at",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "idx_ai_alerts_type": {
+          "name": "idx_ai_alerts_type",
+          "columns": ["type"],
+          "isUnique": false
+        },
+        "idx_ai_alerts_severity": {
+          "name": "idx_ai_alerts_severity",
+          "columns": ["severity"],
+          "isUnique": false
+        },
+        "idx_ai_alerts_acknowledged": {
+          "name": "idx_ai_alerts_acknowledged",
+          "columns": ["acknowledged"],
+          "isUnique": false
+        },
+        "idx_ai_alerts_dedupe": {
+          "name": "idx_ai_alerts_dedupe",
+          "columns": ["type", "scope_detail", "created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "ai_alerts_rule_id_ai_alert_rules_id_fk": {
+          "name": "ai_alerts_rule_id_ai_alert_rules_id_fk",
+          "tableFrom": "ai_alerts",
+          "tableTo": "ai_alert_rules",
+          "columnsFrom": ["rule_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ai_budgets": {
+      "name": "ai_budgets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope_value": {
+          "name": "scope_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "monthly_token_limit": {
+          "name": "monthly_token_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "monthly_cost_limit": {
+          "name": "monthly_cost_limit",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'warn'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ai_inference_daily": {
+      "name": "ai_inference_daily",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_calls": {
+          "name": "total_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_input_tokens": {
+          "name": "total_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_output_tokens": {
+          "name": "total_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_cost_usd": {
+          "name": "total_cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "avg_latency_ms": {
+          "name": "avg_latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "timeout_count": {
+          "name": "timeout_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cache_hit_count": {
+          "name": "cache_hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "budget_blocked_count": {
+          "name": "budget_blocked_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_ai_inference_daily_key": {
+          "name": "idx_ai_inference_daily_key",
+          "columns": ["date", "provider", "model", "operation", "domain"],
+          "isUnique": true
+        },
+        "idx_ai_inference_daily_date": {
+          "name": "idx_ai_inference_daily_date",
+          "columns": ["date"],
+          "isUnique": false
+        },
+        "idx_ai_inference_daily_provider_model": {
+          "name": "idx_ai_inference_daily_provider_model",
+          "columns": ["provider", "model"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ai_inference_log": {
+      "name": "ai_inference_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'success'"
+        },
+        "cached": {
+          "name": "cached",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "context_id": {
+          "name": "context_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_ai_inference_log_created_at": {
+          "name": "idx_ai_inference_log_created_at",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "idx_ai_inference_log_provider_model": {
+          "name": "idx_ai_inference_log_provider_model",
+          "columns": ["provider", "model"],
+          "isUnique": false
+        },
+        "idx_ai_inference_log_operation": {
+          "name": "idx_ai_inference_log_operation",
+          "columns": ["operation"],
+          "isUnique": false
+        },
+        "idx_ai_inference_log_domain": {
+          "name": "idx_ai_inference_log_domain",
+          "columns": ["domain"],
+          "isUnique": false
+        },
+        "idx_ai_inference_log_context_id": {
+          "name": "idx_ai_inference_log_context_id",
+          "columns": ["context_id"],
+          "isUnique": false
+        },
+        "idx_ai_inference_log_status": {
+          "name": "idx_ai_inference_log_status",
+          "columns": ["status"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ai_model_pricing": {
+      "name": "ai_model_pricing",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_cost_per_mtok": {
+          "name": "input_cost_per_mtok",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "output_cost_per_mtok": {
+          "name": "output_cost_per_mtok",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "context_window": {
+          "name": "context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_ai_model_pricing_provider_model": {
+          "name": "uq_ai_model_pricing_provider_model",
+          "columns": ["provider_id", "model_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ai_providers": {
+      "name": "ai_providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key_ref": {
+          "name": "api_key_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "last_health_check": {
+          "name": "last_health_check",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_latency_ms": {
+          "name": "last_latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ai_usage": {
+      "name": "ai_usage",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_name": {
+          "name": "entity_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cached": {
+          "name": "cached",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "import_batch_id": {
+          "name": "import_batch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_ai_usage_created_at": {
+          "name": "idx_ai_usage_created_at",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "idx_ai_usage_batch": {
+          "name": "idx_ai_usage_batch",
+          "columns": ["import_batch_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "budgets": {
+      "name": "budgets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notion_id": {
+          "name": "notion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "period": {
+          "name": "period",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_edited_time": {
+          "name": "last_edited_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "budgets_notion_id_unique": {
+          "name": "budgets_notion_id_unique",
+          "columns": ["notion_id"],
+          "isUnique": true
+        },
+        "idx_budgets_category_period": {
+          "name": "idx_budgets_category_period",
+          "columns": ["category", "COALESCE(\"period\", char(0))"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comparison_dimensions": {
+      "name": "comparison_dimensions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_comparison_dimensions_name": {
+          "name": "idx_comparison_dimensions_name",
+          "columns": ["name"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comparison_skip_cooloffs": {
+      "name": "comparison_skip_cooloffs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "dimension_id": {
+          "name": "dimension_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_a_type": {
+          "name": "media_a_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_a_id": {
+          "name": "media_a_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_b_type": {
+          "name": "media_b_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_b_id": {
+          "name": "media_b_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skip_until": {
+          "name": "skip_until",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_comparison_skip_cooloffs_pair": {
+          "name": "idx_comparison_skip_cooloffs_pair",
+          "columns": ["dimension_id", "media_a_type", "media_a_id", "media_b_type", "media_b_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "comparison_skip_cooloffs_dimension_id_comparison_dimensions_id_fk": {
+          "name": "comparison_skip_cooloffs_dimension_id_comparison_dimensions_id_fk",
+          "tableFrom": "comparison_skip_cooloffs",
+          "tableTo": "comparison_dimensions",
+          "columnsFrom": ["dimension_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comparison_staleness": {
+      "name": "comparison_staleness",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "staleness": {
+          "name": "staleness",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_comparison_staleness_unique": {
+          "name": "idx_comparison_staleness_unique",
+          "columns": ["media_type", "media_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comparisons": {
+      "name": "comparisons",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "dimension_id": {
+          "name": "dimension_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_a_type": {
+          "name": "media_a_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_a_id": {
+          "name": "media_a_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_b_type": {
+          "name": "media_b_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_b_id": {
+          "name": "media_b_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "winner_type": {
+          "name": "winner_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "winner_id": {
+          "name": "winner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "draw_tier": {
+          "name": "draw_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delta_a": {
+          "name": "delta_a",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delta_b": {
+          "name": "delta_b",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "compared_at": {
+          "name": "compared_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_comparisons_dimension_id": {
+          "name": "idx_comparisons_dimension_id",
+          "columns": ["dimension_id"],
+          "isUnique": false
+        },
+        "idx_comparisons_media_a": {
+          "name": "idx_comparisons_media_a",
+          "columns": ["media_a_type", "media_a_id"],
+          "isUnique": false
+        },
+        "idx_comparisons_media_b": {
+          "name": "idx_comparisons_media_b",
+          "columns": ["media_b_type", "media_b_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "comparisons_dimension_id_comparison_dimensions_id_fk": {
+          "name": "comparisons_dimension_id_comparison_dimensions_id_fk",
+          "tableFrom": "comparisons",
+          "tableTo": "comparison_dimensions",
+          "columnsFrom": ["dimension_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "embeddings": {
+      "name": "embeddings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_preview": {
+          "name": "content_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dimensions": {
+          "name": "dimensions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_embeddings_source_chunk": {
+          "name": "uq_embeddings_source_chunk",
+          "columns": ["source_type", "source_id", "chunk_index"],
+          "isUnique": true
+        },
+        "idx_embeddings_source_type": {
+          "name": "idx_embeddings_source_type",
+          "columns": ["source_type"],
+          "isUnique": false
+        },
+        "idx_embeddings_content_hash": {
+          "name": "idx_embeddings_content_hash",
+          "columns": ["content_hash"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "transaction_corrections": {
+      "name": "transaction_corrections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description_pattern": {
+          "name": "description_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "match_type": {
+          "name": "match_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'exact'"
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "entity_name": {
+          "name": "entity_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "transaction_type": {
+          "name": "transaction_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.5
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "times_applied": {
+          "name": "times_applied",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_corrections_pattern": {
+          "name": "idx_corrections_pattern",
+          "columns": ["description_pattern"],
+          "isUnique": false
+        },
+        "idx_corrections_priority": {
+          "name": "idx_corrections_priority",
+          "columns": ["priority"],
+          "isUnique": false
+        },
+        "idx_corrections_confidence": {
+          "name": "idx_corrections_confidence",
+          "columns": ["confidence"],
+          "isUnique": false
+        },
+        "idx_corrections_times_applied": {
+          "name": "idx_corrections_times_applied",
+          "columns": ["times_applied"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "transaction_corrections_entity_id_entities_id_fk": {
+          "name": "transaction_corrections_entity_id_entities_id_fk",
+          "tableFrom": "transaction_corrections",
+          "tableTo": "entities",
+          "columnsFrom": ["entity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "debrief_results": {
+      "name": "debrief_results",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dimension_id": {
+          "name": "dimension_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comparison_id": {
+          "name": "comparison_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "debrief_results_session_id_debrief_sessions_id_fk": {
+          "name": "debrief_results_session_id_debrief_sessions_id_fk",
+          "tableFrom": "debrief_results",
+          "tableTo": "debrief_sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "debrief_results_dimension_id_comparison_dimensions_id_fk": {
+          "name": "debrief_results_dimension_id_comparison_dimensions_id_fk",
+          "tableFrom": "debrief_results",
+          "tableTo": "comparison_dimensions",
+          "columnsFrom": ["dimension_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "debrief_results_comparison_id_comparisons_id_fk": {
+          "name": "debrief_results_comparison_id_comparisons_id_fk",
+          "tableFrom": "debrief_results",
+          "tableTo": "comparisons",
+          "columnsFrom": ["comparison_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "debrief_sessions": {
+      "name": "debrief_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "watch_history_id": {
+          "name": "watch_history_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "debrief_sessions_watch_history_id_watch_history_id_fk": {
+          "name": "debrief_sessions_watch_history_id_watch_history_id_fk",
+          "tableFrom": "debrief_sessions",
+          "tableTo": "watch_history",
+          "columnsFrom": ["watch_history_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "debrief_status": {
+      "name": "debrief_status",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dimension_id": {
+          "name": "dimension_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "debriefed": {
+          "name": "debriefed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "dismissed": {
+          "name": "dismissed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "debrief_status_media_dimension_idx": {
+          "name": "debrief_status_media_dimension_idx",
+          "columns": ["media_type", "media_id", "dimension_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "debrief_status_dimension_id_comparison_dimensions_id_fk": {
+          "name": "debrief_status_dimension_id_comparison_dimensions_id_fk",
+          "tableFrom": "debrief_status",
+          "tableTo": "comparison_dimensions",
+          "columnsFrom": ["dimension_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "dismissed_discover": {
+      "name": "dismissed_discover",
+      "columns": {
+        "tmdb_id": {
+          "name": "tmdb_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dismissed_at": {
+          "name": "dismissed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "conversation_context": {
+      "name": "conversation_context",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "engram_id": {
+          "name": "engram_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "relevance_score": {
+          "name": "relevance_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "loaded_at": {
+          "name": "loaded_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_conversation_context_conversation": {
+          "name": "idx_conversation_context_conversation",
+          "columns": ["conversation_id"],
+          "isUnique": false
+        },
+        "idx_conversation_context_engram": {
+          "name": "idx_conversation_context_engram",
+          "columns": ["engram_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "conversation_context_conversation_id_conversations_id_fk": {
+          "name": "conversation_context_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_context",
+          "tableTo": "conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "conversation_context_conversation_id_engram_id_pk": {
+          "columns": ["conversation_id", "engram_id"],
+          "name": "conversation_context_conversation_id_engram_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "conversations": {
+      "name": "conversations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_scopes": {
+          "name": "active_scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "app_context": {
+          "name": "app_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_conversations_created_at": {
+          "name": "idx_conversations_created_at",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "idx_conversations_updated_at": {
+          "name": "idx_conversations_updated_at",
+          "columns": ["updated_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "citations": {
+          "name": "citations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_calls": {
+          "name": "tool_calls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_in": {
+          "name": "tokens_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_out": {
+          "name": "tokens_out",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_messages_conversation_created": {
+          "name": "idx_messages_conversation_created",
+          "columns": ["conversation_id", "created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "messages_conversation_id_conversations_id_fk": {
+          "name": "messages_conversation_id_conversations_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "engram_index": {
+      "name": "engram_index",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "template": {
+          "name": "template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "modified_at": {
+          "name": "modified_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body_hash": {
+          "name": "body_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "word_count": {
+          "name": "word_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "custom_fields": {
+          "name": "custom_fields",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "engram_index_file_path_unique": {
+          "name": "engram_index_file_path_unique",
+          "columns": ["file_path"],
+          "isUnique": true
+        },
+        "idx_engram_index_type": {
+          "name": "idx_engram_index_type",
+          "columns": ["type"],
+          "isUnique": false
+        },
+        "idx_engram_index_source": {
+          "name": "idx_engram_index_source",
+          "columns": ["source"],
+          "isUnique": false
+        },
+        "idx_engram_index_status": {
+          "name": "idx_engram_index_status",
+          "columns": ["status"],
+          "isUnique": false
+        },
+        "idx_engram_index_created_at": {
+          "name": "idx_engram_index_created_at",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "idx_engram_index_content_hash": {
+          "name": "idx_engram_index_content_hash",
+          "columns": ["content_hash"],
+          "isUnique": false
+        },
+        "idx_engram_index_body_hash": {
+          "name": "idx_engram_index_body_hash",
+          "columns": ["body_hash"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "engram_links": {
+      "name": "engram_links",
+      "columns": {
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_engram_links_target": {
+          "name": "idx_engram_links_target",
+          "columns": ["target_id"],
+          "isUnique": false
+        },
+        "uq_engram_links_pair": {
+          "name": "uq_engram_links_pair",
+          "columns": ["source_id", "target_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "engram_links_source_id_engram_index_id_fk": {
+          "name": "engram_links_source_id_engram_index_id_fk",
+          "tableFrom": "engram_links",
+          "tableTo": "engram_index",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "engram_scopes": {
+      "name": "engram_scopes",
+      "columns": {
+        "engram_id": {
+          "name": "engram_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_engram_scopes_scope": {
+          "name": "idx_engram_scopes_scope",
+          "columns": ["scope"],
+          "isUnique": false
+        },
+        "uq_engram_scopes_pair": {
+          "name": "uq_engram_scopes_pair",
+          "columns": ["engram_id", "scope"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "engram_scopes_engram_id_engram_index_id_fk": {
+          "name": "engram_scopes_engram_id_engram_index_id_fk",
+          "tableFrom": "engram_scopes",
+          "tableTo": "engram_index",
+          "columnsFrom": ["engram_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "engram_tags": {
+      "name": "engram_tags",
+      "columns": {
+        "engram_id": {
+          "name": "engram_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_engram_tags_tag": {
+          "name": "idx_engram_tags_tag",
+          "columns": ["tag"],
+          "isUnique": false
+        },
+        "uq_engram_tags_pair": {
+          "name": "uq_engram_tags_pair",
+          "columns": ["engram_id", "tag"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "engram_tags_engram_id_engram_index_id_fk": {
+          "name": "engram_tags_engram_id_engram_index_id_fk",
+          "tableFrom": "engram_tags",
+          "tableTo": "engram_index",
+          "columnsFrom": ["engram_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "entities": {
+      "name": "entities",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notion_id": {
+          "name": "notion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'company'"
+        },
+        "abn": {
+          "name": "abn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "aliases": {
+          "name": "aliases",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_transaction_type": {
+          "name": "default_transaction_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_tags": {
+          "name": "default_tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_edited_time": {
+          "name": "last_edited_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "entities_notion_id_unique": {
+          "name": "entities_notion_id_unique",
+          "columns": ["notion_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "environments": {
+      "name": "environments",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "db_path": {
+          "name": "db_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "seed_type": {
+          "name": "seed_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "ttl_seconds": {
+          "name": "ttl_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_environments_expires_at": {
+          "name": "idx_environments_expires_at",
+          "columns": ["expires_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "episodes": {
+      "name": "episodes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tvdb_id": {
+          "name": "tvdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "episode_number": {
+          "name": "episode_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "air_date": {
+          "name": "air_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "still_path": {
+          "name": "still_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vote_average": {
+          "name": "vote_average",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "runtime": {
+          "name": "runtime",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_episodes_tvdb_id": {
+          "name": "idx_episodes_tvdb_id",
+          "columns": ["tvdb_id"],
+          "isUnique": true
+        },
+        "idx_episodes_season_number": {
+          "name": "idx_episodes_season_number",
+          "columns": ["season_id", "episode_number"],
+          "isUnique": true
+        },
+        "idx_episodes_season_id": {
+          "name": "idx_episodes_season_id",
+          "columns": ["season_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "episodes_season_id_seasons_id_fk": {
+          "name": "episodes_season_id_seasons_id_fk",
+          "tableFrom": "episodes",
+          "tableTo": "seasons",
+          "columnsFrom": ["season_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "fixtures": {
+      "name": "fixtures",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "last_edited_time": {
+          "name": "last_edited_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_fixtures_location": {
+          "name": "idx_fixtures_location",
+          "columns": ["location_id"],
+          "isUnique": false
+        },
+        "idx_fixtures_type": {
+          "name": "idx_fixtures_type",
+          "columns": ["type"],
+          "isUnique": false
+        },
+        "idx_fixtures_name": {
+          "name": "idx_fixtures_name",
+          "columns": ["name"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "fixtures_location_id_locations_id_fk": {
+          "name": "fixtures_location_id_locations_id_fk",
+          "tableFrom": "fixtures",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "batch_consumptions": {
+      "name": "batch_consumptions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "recipe_run_id": {
+          "name": "recipe_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "qty_consumed": {
+          "name": "qty_consumed",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_batch_consumptions_run": {
+          "name": "idx_batch_consumptions_run",
+          "columns": ["recipe_run_id"],
+          "isUnique": false
+        },
+        "idx_batch_consumptions_batch": {
+          "name": "idx_batch_consumptions_batch",
+          "columns": ["batch_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "batch_consumptions_recipe_run_id_recipe_runs_id_fk": {
+          "name": "batch_consumptions_recipe_run_id_recipe_runs_id_fk",
+          "tableFrom": "batch_consumptions",
+          "tableTo": "recipe_runs",
+          "columnsFrom": ["recipe_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "batch_consumptions_batch_id_batches_id_fk": {
+          "name": "batch_consumptions_batch_id_batches_id_fk",
+          "tableFrom": "batch_consumptions",
+          "tableTo": "batches",
+          "columnsFrom": ["batch_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "batches": {
+      "name": "batches",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prep_state_id": {
+          "name": "prep_state_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "qty_remaining": {
+          "name": "qty_remaining",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "produced_at": {
+          "name": "produced_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_batches_variant_prep": {
+          "name": "idx_batches_variant_prep",
+          "columns": ["variant_id", "prep_state_id"],
+          "isUnique": false
+        },
+        "idx_batches_location_expiry": {
+          "name": "idx_batches_location_expiry",
+          "columns": ["location", "expires_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "batches_variant_id_ingredient_variants_id_fk": {
+          "name": "batches_variant_id_ingredient_variants_id_fk",
+          "tableFrom": "batches",
+          "tableTo": "ingredient_variants",
+          "columnsFrom": ["variant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "batches_prep_state_id_prep_states_id_fk": {
+          "name": "batches_prep_state_id_prep_states_id_fk",
+          "tableFrom": "batches",
+          "tableTo": "prep_states",
+          "columnsFrom": ["prep_state_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "recipe_runs": {
+      "name": "recipe_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "recipe_version_id": {
+          "name": "recipe_version_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scale_factor": {
+          "name": "scale_factor",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "yielded_batch_id": {
+          "name": "yielded_batch_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_recipe_runs_version": {
+          "name": "idx_recipe_runs_version",
+          "columns": ["recipe_version_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "recipe_runs_recipe_version_id_recipe_versions_id_fk": {
+          "name": "recipe_runs_recipe_version_id_recipe_versions_id_fk",
+          "tableFrom": "recipe_runs",
+          "tableTo": "recipe_versions",
+          "columnsFrom": ["recipe_version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "recipe_runs_yielded_batch_id_batches_id_fk": {
+          "name": "recipe_runs_yielded_batch_id_batches_id_fk",
+          "tableFrom": "recipe_runs",
+          "tableTo": "batches",
+          "columnsFrom": ["yielded_batch_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "recipe_lines": {
+      "name": "recipe_lines",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "recipe_version_id": {
+          "name": "recipe_version_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ingredient_id": {
+          "name": "ingredient_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prep_state_id": {
+          "name": "prep_state_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_recipe_ref": {
+          "name": "is_recipe_ref",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "recipe_ref_id": {
+          "name": "recipe_ref_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "original_text": {
+          "name": "original_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_qty": {
+          "name": "original_qty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_unit": {
+          "name": "original_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "qty_g": {
+          "name": "qty_g",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "qty_ml": {
+          "name": "qty_ml",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "qty_count": {
+          "name": "qty_count",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "canonical_unit": {
+          "name": "canonical_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "optional": {
+          "name": "optional",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_recipe_lines_ingredient": {
+          "name": "idx_recipe_lines_ingredient",
+          "columns": ["ingredient_id"],
+          "isUnique": false
+        },
+        "uq_recipe_lines_version_position": {
+          "name": "uq_recipe_lines_version_position",
+          "columns": ["recipe_version_id", "position"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "recipe_lines_recipe_version_id_recipe_versions_id_fk": {
+          "name": "recipe_lines_recipe_version_id_recipe_versions_id_fk",
+          "tableFrom": "recipe_lines",
+          "tableTo": "recipe_versions",
+          "columnsFrom": ["recipe_version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "recipe_lines_ingredient_id_ingredients_id_fk": {
+          "name": "recipe_lines_ingredient_id_ingredients_id_fk",
+          "tableFrom": "recipe_lines",
+          "tableTo": "ingredients",
+          "columnsFrom": ["ingredient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "recipe_lines_variant_id_ingredient_variants_id_fk": {
+          "name": "recipe_lines_variant_id_ingredient_variants_id_fk",
+          "tableFrom": "recipe_lines",
+          "tableTo": "ingredient_variants",
+          "columnsFrom": ["variant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "recipe_lines_prep_state_id_prep_states_id_fk": {
+          "name": "recipe_lines_prep_state_id_prep_states_id_fk",
+          "tableFrom": "recipe_lines",
+          "tableTo": "prep_states",
+          "columnsFrom": ["prep_state_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "recipe_lines_recipe_ref_id_recipes_id_fk": {
+          "name": "recipe_lines_recipe_ref_id_recipes_id_fk",
+          "tableFrom": "recipe_lines",
+          "tableTo": "recipes",
+          "columnsFrom": ["recipe_ref_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "recipe_steps": {
+      "name": "recipe_steps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "recipe_version_id": {
+          "name": "recipe_version_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body_md": {
+          "name": "body_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body_resolved_json": {
+          "name": "body_resolved_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "temperature_value": {
+          "name": "temperature_value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "temperature_unit": {
+          "name": "temperature_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_recipe_steps_version_position": {
+          "name": "uq_recipe_steps_version_position",
+          "columns": ["recipe_version_id", "position"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "recipe_steps_recipe_version_id_recipe_versions_id_fk": {
+          "name": "recipe_steps_recipe_version_id_recipe_versions_id_fk",
+          "tableFrom": "recipe_steps",
+          "tableTo": "recipe_versions",
+          "columnsFrom": ["recipe_version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "recipe_version_proposed_slugs": {
+      "name": "recipe_version_proposed_slugs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "recipe_version_id": {
+          "name": "recipe_version_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "suggested_kind": {
+          "name": "suggested_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "from_loc_json": {
+          "name": "from_loc_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_proposed_slugs_version": {
+          "name": "idx_proposed_slugs_version",
+          "columns": ["recipe_version_id"],
+          "isUnique": false
+        },
+        "idx_proposed_slugs_slug": {
+          "name": "idx_proposed_slugs_slug",
+          "columns": ["slug"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "recipe_version_proposed_slugs_recipe_version_id_recipe_versions_id_fk": {
+          "name": "recipe_version_proposed_slugs_recipe_version_id_recipe_versions_id_fk",
+          "tableFrom": "recipe_version_proposed_slugs",
+          "tableTo": "recipe_versions",
+          "columnsFrom": ["recipe_version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ingredient_weights": {
+      "name": "ingredient_weights",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "ingredient_id": {
+          "name": "ingredient_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "grams": {
+          "name": "grams",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_seeded": {
+          "name": "is_seeded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_ingredient_weights_ingredient": {
+          "name": "idx_ingredient_weights_ingredient",
+          "columns": ["ingredient_id"],
+          "isUnique": false
+        },
+        "uq_ingredient_weights_ing_var_unit": {
+          "name": "uq_ingredient_weights_ing_var_unit",
+          "columns": ["ingredient_id", "variant_id", "unit"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "ingredient_weights_ingredient_id_ingredients_id_fk": {
+          "name": "ingredient_weights_ingredient_id_ingredients_id_fk",
+          "tableFrom": "ingredient_weights",
+          "tableTo": "ingredients",
+          "columnsFrom": ["ingredient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ingredient_weights_variant_id_ingredient_variants_id_fk": {
+          "name": "ingredient_weights_variant_id_ingredient_variants_id_fk",
+          "tableFrom": "ingredient_weights",
+          "tableTo": "ingredient_variants",
+          "columnsFrom": ["variant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "unit_conversions": {
+      "name": "unit_conversions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "from_unit": {
+          "name": "from_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "to_unit": {
+          "name": "to_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ratio": {
+          "name": "ratio",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_seeded": {
+          "name": "is_seeded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_unit_conversions_from": {
+          "name": "idx_unit_conversions_from",
+          "columns": ["from_unit"],
+          "isUnique": false
+        },
+        "uq_unit_conversions_from_to": {
+          "name": "uq_unit_conversions_from_to",
+          "columns": ["from_unit", "to_unit"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ingest_sources": {
+      "name": "ingest_sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transcript_path": {
+          "name": "transcript_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "keyframes_dir": {
+          "name": "keyframes_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "video_path": {
+          "name": "video_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "extracted_json": {
+          "name": "extracted_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "extractor_version": {
+          "name": "extractor_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "draft_recipe_id": {
+          "name": "draft_recipe_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ingested_at": {
+          "name": "ingested_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_ingest_sources_kind": {
+          "name": "idx_ingest_sources_kind",
+          "columns": ["kind"],
+          "isUnique": false
+        },
+        "idx_ingest_sources_recipe": {
+          "name": "idx_ingest_sources_recipe",
+          "columns": ["draft_recipe_id"],
+          "isUnique": false
+        },
+        "idx_ingest_sources_ingested": {
+          "name": "idx_ingest_sources_ingested",
+          "columns": ["ingested_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "ingest_sources_draft_recipe_id_recipes_id_fk": {
+          "name": "ingest_sources_draft_recipe_id_recipes_id_fk",
+          "tableFrom": "ingest_sources",
+          "tableTo": "recipes",
+          "columnsFrom": ["draft_recipe_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ingredient_aliases": {
+      "name": "ingredient_aliases",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "ingredient_id": {
+          "name": "ingredient_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_aliases_alias": {
+          "name": "idx_aliases_alias",
+          "columns": ["alias"],
+          "isUnique": false
+        },
+        "uq_aliases_alias_target": {
+          "name": "uq_aliases_alias_target",
+          "columns": ["alias", "ingredient_id", "variant_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "ingredient_aliases_ingredient_id_ingredients_id_fk": {
+          "name": "ingredient_aliases_ingredient_id_ingredients_id_fk",
+          "tableFrom": "ingredient_aliases",
+          "tableTo": "ingredients",
+          "columnsFrom": ["ingredient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ingredient_aliases_variant_id_ingredient_variants_id_fk": {
+          "name": "ingredient_aliases_variant_id_ingredient_variants_id_fk",
+          "tableFrom": "ingredient_aliases",
+          "tableTo": "ingredient_variants",
+          "columnsFrom": ["variant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "ck_aliases_xor_target": {
+          "name": "ck_aliases_xor_target",
+          "value": "(\"ingredient_aliases\".\"ingredient_id\" IS NOT NULL) <> (\"ingredient_aliases\".\"variant_id\" IS NOT NULL)"
+        }
+      }
+    },
+    "ingredient_variants": {
+      "name": "ingredient_variants",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "ingredient_id": {
+          "name": "ingredient_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "default_unit": {
+          "name": "default_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "package_size_g": {
+          "name": "package_size_g",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_shelf_life_days_fridge": {
+          "name": "default_shelf_life_days_fridge",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_shelf_life_days_freezer": {
+          "name": "default_shelf_life_days_freezer",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_variants_ingredient": {
+          "name": "idx_variants_ingredient",
+          "columns": ["ingredient_id"],
+          "isUnique": false
+        },
+        "idx_variants_name": {
+          "name": "idx_variants_name",
+          "columns": ["name"],
+          "isUnique": false
+        },
+        "uq_variants_ingredient_slug": {
+          "name": "uq_variants_ingredient_slug",
+          "columns": ["ingredient_id", "slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "ingredient_variants_ingredient_id_ingredients_id_fk": {
+          "name": "ingredient_variants_ingredient_id_ingredients_id_fk",
+          "tableFrom": "ingredient_variants",
+          "tableTo": "ingredients",
+          "columnsFrom": ["ingredient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ingredients": {
+      "name": "ingredients",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "default_unit": {
+          "name": "default_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "density_g_per_ml": {
+          "name": "density_g_per_ml",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "ingredients_slug_unique": {
+          "name": "ingredients_slug_unique",
+          "columns": ["slug"],
+          "isUnique": true
+        },
+        "idx_ingredients_parent": {
+          "name": "idx_ingredients_parent",
+          "columns": ["parent_id"],
+          "isUnique": false
+        },
+        "idx_ingredients_name": {
+          "name": "idx_ingredients_name",
+          "columns": ["name"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "ingredients_parent_id_ingredients_id_fk": {
+          "name": "ingredients_parent_id_ingredients_id_fk",
+          "tableFrom": "ingredients",
+          "tableTo": "ingredients",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prep_states": {
+      "name": "prep_states",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "prep_states_name_unique": {
+          "name": "prep_states_name_unique",
+          "columns": ["name"],
+          "isUnique": true
+        },
+        "prep_states_slug_unique": {
+          "name": "prep_states_slug_unique",
+          "columns": ["slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "slug_registry": {
+      "name": "slug_registry",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_slug_registry_kind_target": {
+          "name": "idx_slug_registry_kind_target",
+          "columns": ["kind", "target_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plan_entries": {
+      "name": "plan_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slot": {
+          "name": "slot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recipe_version_id": {
+          "name": "recipe_version_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "planned_servings": {
+          "name": "planned_servings",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "recipe_run_id": {
+          "name": "recipe_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_plan_entries_date": {
+          "name": "idx_plan_entries_date",
+          "columns": ["date"],
+          "isUnique": false
+        },
+        "idx_plan_entries_date_slot": {
+          "name": "idx_plan_entries_date_slot",
+          "columns": ["date", "slot"],
+          "isUnique": false
+        },
+        "idx_plan_entries_recipe": {
+          "name": "idx_plan_entries_recipe",
+          "columns": ["recipe_id"],
+          "isUnique": false
+        },
+        "idx_plan_entries_unscheduled": {
+          "name": "idx_plan_entries_unscheduled",
+          "columns": ["recipe_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "plan_entries_slot_plan_slots_slug_fk": {
+          "name": "plan_entries_slot_plan_slots_slug_fk",
+          "tableFrom": "plan_entries",
+          "tableTo": "plan_slots",
+          "columnsFrom": ["slot"],
+          "columnsTo": ["slug"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "plan_entries_recipe_id_recipes_id_fk": {
+          "name": "plan_entries_recipe_id_recipes_id_fk",
+          "tableFrom": "plan_entries",
+          "tableTo": "recipes",
+          "columnsFrom": ["recipe_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "plan_entries_recipe_version_id_recipe_versions_id_fk": {
+          "name": "plan_entries_recipe_version_id_recipe_versions_id_fk",
+          "tableFrom": "plan_entries",
+          "tableTo": "recipe_versions",
+          "columnsFrom": ["recipe_version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "plan_entries_recipe_run_id_recipe_runs_id_fk": {
+          "name": "plan_entries_recipe_run_id_recipe_runs_id_fk",
+          "tableFrom": "plan_entries",
+          "tableTo": "recipe_runs",
+          "columnsFrom": ["recipe_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "ck_plan_entries_planned_servings": {
+          "name": "ck_plan_entries_planned_servings",
+          "value": "\"plan_entries\".\"planned_servings\" > 0"
+        }
+      }
+    },
+    "plan_slots": {
+      "name": "plan_slots",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "recipe_tags": {
+      "name": "recipe_tags",
+      "columns": {
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_recipe_tags_tag": {
+          "name": "idx_recipe_tags_tag",
+          "columns": ["tag"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "recipe_tags_recipe_id_recipes_id_fk": {
+          "name": "recipe_tags_recipe_id_recipes_id_fk",
+          "tableFrom": "recipe_tags",
+          "tableTo": "recipes",
+          "columnsFrom": ["recipe_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "recipe_tags_recipe_id_tag_pk": {
+          "columns": ["recipe_id", "tag"],
+          "name": "recipe_tags_recipe_id_tag_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "recipe_versions": {
+      "name": "recipe_versions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version_no": {
+          "name": "version_no",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body_dsl": {
+          "name": "body_dsl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "yield_ingredient_id": {
+          "name": "yield_ingredient_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "yield_variant_id": {
+          "name": "yield_variant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "yield_prep_state_id": {
+          "name": "yield_prep_state_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "yield_qty": {
+          "name": "yield_qty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "yield_unit": {
+          "name": "yield_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "servings": {
+          "name": "servings",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prep_minutes": {
+          "name": "prep_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cook_minutes": {
+          "name": "cook_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "compile_status": {
+          "name": "compile_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'uncompiled'"
+        },
+        "compile_error": {
+          "name": "compile_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "compiled_at": {
+          "name": "compiled_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_recipe_versions_recipe": {
+          "name": "idx_recipe_versions_recipe",
+          "columns": ["recipe_id"],
+          "isUnique": false
+        },
+        "idx_recipe_versions_status": {
+          "name": "idx_recipe_versions_status",
+          "columns": ["status"],
+          "isUnique": false
+        },
+        "idx_recipe_versions_compile": {
+          "name": "idx_recipe_versions_compile",
+          "columns": ["compile_status"],
+          "isUnique": false
+        },
+        "uq_recipe_versions_recipe_no": {
+          "name": "uq_recipe_versions_recipe_no",
+          "columns": ["recipe_id", "version_no"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "recipe_versions_recipe_id_recipes_id_fk": {
+          "name": "recipe_versions_recipe_id_recipes_id_fk",
+          "tableFrom": "recipe_versions",
+          "tableTo": "recipes",
+          "columnsFrom": ["recipe_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "recipe_versions_yield_ingredient_id_ingredients_id_fk": {
+          "name": "recipe_versions_yield_ingredient_id_ingredients_id_fk",
+          "tableFrom": "recipe_versions",
+          "tableTo": "ingredients",
+          "columnsFrom": ["yield_ingredient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "recipe_versions_yield_variant_id_ingredient_variants_id_fk": {
+          "name": "recipe_versions_yield_variant_id_ingredient_variants_id_fk",
+          "tableFrom": "recipe_versions",
+          "tableTo": "ingredient_variants",
+          "columnsFrom": ["yield_variant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "recipe_versions_yield_prep_state_id_prep_states_id_fk": {
+          "name": "recipe_versions_yield_prep_state_id_prep_states_id_fk",
+          "tableFrom": "recipe_versions",
+          "tableTo": "prep_states",
+          "columnsFrom": ["yield_prep_state_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "recipes": {
+      "name": "recipes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recipe_type": {
+          "name": "recipe_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'plate'"
+        },
+        "current_version_id": {
+          "name": "current_version_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hero_image_path": {
+          "name": "hero_image_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "recipes_slug_unique": {
+          "name": "recipes_slug_unique",
+          "columns": ["slug"],
+          "isUnique": true
+        },
+        "idx_recipes_type": {
+          "name": "idx_recipes_type",
+          "columns": ["recipe_type"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "recipes_current_version_id_recipe_versions_id_fk": {
+          "name": "recipes_current_version_id_recipe_versions_id_fk",
+          "tableFrom": "recipes",
+          "tableTo": "recipe_versions",
+          "columnsFrom": ["current_version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "recipe_version_rejections": {
+      "name": "recipe_version_rejections",
+      "columns": {
+        "version_id": {
+          "name": "version_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rejected_at": {
+          "name": "rejected_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "recipe_version_rejections_version_id_recipe_versions_id_fk": {
+          "name": "recipe_version_rejections_version_id_recipe_versions_id_fk",
+          "tableFrom": "recipe_version_rejections",
+          "tableTo": "recipe_versions",
+          "columnsFrom": ["version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "substitutions": {
+      "name": "substitutions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "from_ingredient_id": {
+          "name": "from_ingredient_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "from_variant_id": {
+          "name": "from_variant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "to_ingredient_id": {
+          "name": "to_ingredient_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "to_variant_id": {
+          "name": "to_variant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ratio": {
+          "name": "ratio",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "context_tags": {
+          "name": "context_tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'global'"
+        },
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_subs_from_ing": {
+          "name": "idx_subs_from_ing",
+          "columns": ["from_ingredient_id"],
+          "isUnique": false
+        },
+        "idx_subs_from_var": {
+          "name": "idx_subs_from_var",
+          "columns": ["from_variant_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "substitutions_from_ingredient_id_ingredients_id_fk": {
+          "name": "substitutions_from_ingredient_id_ingredients_id_fk",
+          "tableFrom": "substitutions",
+          "tableTo": "ingredients",
+          "columnsFrom": ["from_ingredient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "substitutions_from_variant_id_ingredient_variants_id_fk": {
+          "name": "substitutions_from_variant_id_ingredient_variants_id_fk",
+          "tableFrom": "substitutions",
+          "tableTo": "ingredient_variants",
+          "columnsFrom": ["from_variant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "substitutions_to_ingredient_id_ingredients_id_fk": {
+          "name": "substitutions_to_ingredient_id_ingredients_id_fk",
+          "tableFrom": "substitutions",
+          "tableTo": "ingredients",
+          "columnsFrom": ["to_ingredient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "substitutions_to_variant_id_ingredient_variants_id_fk": {
+          "name": "substitutions_to_variant_id_ingredient_variants_id_fk",
+          "tableFrom": "substitutions",
+          "tableTo": "ingredient_variants",
+          "columnsFrom": ["to_variant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "substitutions_recipe_id_recipes_id_fk": {
+          "name": "substitutions_recipe_id_recipes_id_fk",
+          "tableFrom": "substitutions",
+          "tableTo": "recipes",
+          "columnsFrom": ["recipe_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "ck_subs_xor_from": {
+          "name": "ck_subs_xor_from",
+          "value": "(\"substitutions\".\"from_ingredient_id\" IS NOT NULL) <> (\"substitutions\".\"from_variant_id\" IS NOT NULL)"
+        },
+        "ck_subs_xor_to": {
+          "name": "ck_subs_xor_to",
+          "value": "(\"substitutions\".\"to_ingredient_id\" IS NOT NULL) <> (\"substitutions\".\"to_variant_id\" IS NOT NULL)"
+        },
+        "ck_subs_scope_recipe": {
+          "name": "ck_subs_scope_recipe",
+          "value": "(\"substitutions\".\"scope\" = 'recipe' AND \"substitutions\".\"recipe_id\" IS NOT NULL) OR (\"substitutions\".\"scope\" = 'global' AND \"substitutions\".\"recipe_id\" IS NULL)"
+        },
+        "ck_subs_scope": {
+          "name": "ck_subs_scope",
+          "value": "\"substitutions\".\"scope\" IN ('global','recipe')"
+        },
+        "ck_subs_ratio_positive": {
+          "name": "ck_subs_ratio_positive",
+          "value": "\"substitutions\".\"ratio\" > 0"
+        }
+      }
+    },
+    "glia_actions": {
+      "name": "glia_actions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "affected_ids": {
+          "name": "affected_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rationale": {
+          "name": "rationale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_decision": {
+          "name": "user_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_note": {
+          "name": "user_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reverted_at": {
+          "name": "reverted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_glia_actions_action_type": {
+          "name": "idx_glia_actions_action_type",
+          "columns": ["action_type"],
+          "isUnique": false
+        },
+        "idx_glia_actions_status": {
+          "name": "idx_glia_actions_status",
+          "columns": ["status"],
+          "isUnique": false
+        },
+        "idx_glia_actions_phase": {
+          "name": "idx_glia_actions_phase",
+          "columns": ["phase"],
+          "isUnique": false
+        },
+        "idx_glia_actions_created_at": {
+          "name": "idx_glia_actions_created_at",
+          "columns": ["created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "glia_trust_state": {
+      "name": "glia_trust_state",
+      "columns": {
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_phase": {
+          "name": "current_phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "approved_count": {
+          "name": "approved_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "rejected_count": {
+          "name": "rejected_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "reverted_count": {
+          "name": "reverted_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "autonomous_since": {
+          "name": "autonomous_since",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_revert_at": {
+          "name": "last_revert_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "graduated_at": {
+          "name": "graduated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "home_inventory": {
+      "name": "home_inventory",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notion_id": {
+          "name": "notion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "item_name": {
+          "name": "item_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "brand": {
+          "name": "brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "room": {
+          "name": "room",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "condition": {
+          "name": "condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'good'"
+        },
+        "in_use": {
+          "name": "in_use",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deductible": {
+          "name": "deductible",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "purchase_date": {
+          "name": "purchase_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "warranty_expires": {
+          "name": "warranty_expires",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "replacement_value": {
+          "name": "replacement_value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resale_value": {
+          "name": "resale_value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "purchase_transaction_id": {
+          "name": "purchase_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "purchased_from_id": {
+          "name": "purchased_from_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "purchased_from_name": {
+          "name": "purchased_from_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "purchase_price": {
+          "name": "purchase_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "last_edited_time": {
+          "name": "last_edited_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "home_inventory_notion_id_unique": {
+          "name": "home_inventory_notion_id_unique",
+          "columns": ["notion_id"],
+          "isUnique": true
+        },
+        "home_inventory_asset_id_unique": {
+          "name": "home_inventory_asset_id_unique",
+          "columns": ["asset_id"],
+          "isUnique": true
+        },
+        "idx_inventory_asset_id": {
+          "name": "idx_inventory_asset_id",
+          "columns": ["asset_id"],
+          "isUnique": true
+        },
+        "idx_inventory_name": {
+          "name": "idx_inventory_name",
+          "columns": ["item_name"],
+          "isUnique": false
+        },
+        "idx_inventory_location": {
+          "name": "idx_inventory_location",
+          "columns": ["location_id"],
+          "isUnique": false
+        },
+        "idx_inventory_type": {
+          "name": "idx_inventory_type",
+          "columns": ["type"],
+          "isUnique": false
+        },
+        "idx_inventory_warranty": {
+          "name": "idx_inventory_warranty",
+          "columns": ["warranty_expires"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "home_inventory_purchase_transaction_id_transactions_id_fk": {
+          "name": "home_inventory_purchase_transaction_id_transactions_id_fk",
+          "tableFrom": "home_inventory",
+          "tableTo": "transactions",
+          "columnsFrom": ["purchase_transaction_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "home_inventory_purchased_from_id_entities_id_fk": {
+          "name": "home_inventory_purchased_from_id_entities_id_fk",
+          "tableFrom": "home_inventory",
+          "tableTo": "entities",
+          "columnsFrom": ["purchased_from_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "home_inventory_location_id_locations_id_fk": {
+          "name": "home_inventory_location_id_locations_id_fk",
+          "tableFrom": "home_inventory",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "item_connections": {
+      "name": "item_connections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "item_a_id": {
+          "name": "item_a_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_b_id": {
+          "name": "item_b_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_item_connections_a": {
+          "name": "idx_item_connections_a",
+          "columns": ["item_a_id"],
+          "isUnique": false
+        },
+        "idx_item_connections_b": {
+          "name": "idx_item_connections_b",
+          "columns": ["item_b_id"],
+          "isUnique": false
+        },
+        "uq_item_connections_pair": {
+          "name": "uq_item_connections_pair",
+          "columns": ["item_a_id", "item_b_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "item_connections_item_a_id_home_inventory_id_fk": {
+          "name": "item_connections_item_a_id_home_inventory_id_fk",
+          "tableFrom": "item_connections",
+          "tableTo": "home_inventory",
+          "columnsFrom": ["item_a_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "item_connections_item_b_id_home_inventory_id_fk": {
+          "name": "item_connections_item_b_id_home_inventory_id_fk",
+          "tableFrom": "item_connections",
+          "tableTo": "home_inventory",
+          "columnsFrom": ["item_b_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chk_item_connections_order": {
+          "name": "chk_item_connections_order",
+          "value": "\"item_connections\".\"item_a_id\" < \"item_connections\".\"item_b_id\""
+        }
+      }
+    },
+    "item_documents": {
+      "name": "item_documents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "paperless_document_id": {
+          "name": "paperless_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_type": {
+          "name": "document_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_item_documents_item": {
+          "name": "idx_item_documents_item",
+          "columns": ["item_id"],
+          "isUnique": false
+        },
+        "idx_item_documents_doc": {
+          "name": "idx_item_documents_doc",
+          "columns": ["paperless_document_id"],
+          "isUnique": false
+        },
+        "uq_item_documents_pair": {
+          "name": "uq_item_documents_pair",
+          "columns": ["item_id", "paperless_document_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "item_documents_item_id_home_inventory_id_fk": {
+          "name": "item_documents_item_id_home_inventory_id_fk",
+          "tableFrom": "item_documents",
+          "tableTo": "home_inventory",
+          "columnsFrom": ["item_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "item_fixture_connections": {
+      "name": "item_fixture_connections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fixture_id": {
+          "name": "fixture_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_item_fixture_conn_item": {
+          "name": "idx_item_fixture_conn_item",
+          "columns": ["item_id"],
+          "isUnique": false
+        },
+        "idx_item_fixture_conn_fixture": {
+          "name": "idx_item_fixture_conn_fixture",
+          "columns": ["fixture_id"],
+          "isUnique": false
+        },
+        "uq_item_fixture_connections_pair": {
+          "name": "uq_item_fixture_connections_pair",
+          "columns": ["item_id", "fixture_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "item_fixture_connections_item_id_home_inventory_id_fk": {
+          "name": "item_fixture_connections_item_id_home_inventory_id_fk",
+          "tableFrom": "item_fixture_connections",
+          "tableTo": "home_inventory",
+          "columnsFrom": ["item_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "item_fixture_connections_fixture_id_fixtures_id_fk": {
+          "name": "item_fixture_connections_fixture_id_fixtures_id_fk",
+          "tableFrom": "item_fixture_connections",
+          "tableTo": "fixtures",
+          "columnsFrom": ["fixture_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "item_photos": {
+      "name": "item_photos",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_item_photos_item": {
+          "name": "idx_item_photos_item",
+          "columns": ["item_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "item_photos_item_id_home_inventory_id_fk": {
+          "name": "item_photos_item_id_home_inventory_id_fk",
+          "tableFrom": "item_photos",
+          "tableTo": "home_inventory",
+          "columnsFrom": ["item_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "item_uploaded_files": {
+      "name": "item_uploaded_files",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_item_uploaded_files_item": {
+          "name": "idx_item_uploaded_files_item",
+          "columns": ["item_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "item_uploaded_files_item_id_home_inventory_id_fk": {
+          "name": "item_uploaded_files_item_id_home_inventory_id_fk",
+          "tableFrom": "item_uploaded_files",
+          "tableTo": "home_inventory",
+          "columnsFrom": ["item_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "list_items": {
+      "name": "list_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "list_id": {
+          "name": "list_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "qty": {
+          "name": "qty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ref_kind": {
+          "name": "ref_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'free'"
+        },
+        "ref_id": {
+          "name": "ref_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checked": {
+          "name": "checked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_list_items_list": {
+          "name": "idx_list_items_list",
+          "columns": ["list_id"],
+          "isUnique": false
+        },
+        "idx_list_items_checked": {
+          "name": "idx_list_items_checked",
+          "columns": ["list_id", "checked"],
+          "isUnique": false
+        },
+        "idx_list_items_ref": {
+          "name": "idx_list_items_ref",
+          "columns": ["ref_kind", "ref_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "list_items_list_id_lists_id_fk": {
+          "name": "list_items_list_id_lists_id_fk",
+          "tableFrom": "list_items",
+          "tableTo": "lists",
+          "columnsFrom": ["list_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "lists": {
+      "name": "lists",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_app": {
+          "name": "owner_app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_lists_kind": {
+          "name": "idx_lists_kind",
+          "columns": ["kind"],
+          "isUnique": false
+        },
+        "idx_lists_owner_app": {
+          "name": "idx_lists_owner_app",
+          "columns": ["owner_app"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "locations": {
+      "name": "locations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_edited_time": {
+          "name": "last_edited_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_locations_parent": {
+          "name": "idx_locations_parent",
+          "columns": ["parent_id"],
+          "isUnique": false
+        },
+        "idx_locations_name": {
+          "name": "idx_locations_name",
+          "columns": ["name"],
+          "isUnique": false
+        },
+        "idx_locations_parent_sort": {
+          "name": "idx_locations_parent_sort",
+          "columns": ["parent_id", "sort_order"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media_scores": {
+      "name": "media_scores",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dimension_id": {
+          "name": "dimension_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1500
+        },
+        "comparison_count": {
+          "name": "comparison_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "excluded": {
+          "name": "excluded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_media_scores_unique": {
+          "name": "idx_media_scores_unique",
+          "columns": ["media_type", "media_id", "dimension_id"],
+          "isUnique": true
+        },
+        "idx_media_scores_dimension": {
+          "name": "idx_media_scores_dimension",
+          "columns": ["dimension_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "media_scores_dimension_id_comparison_dimensions_id_fk": {
+          "name": "media_scores_dimension_id_comparison_dimensions_id_fk",
+          "tableFrom": "media_scores",
+          "tableTo": "comparison_dimensions",
+          "columnsFrom": ["dimension_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "watchlist": {
+      "name": "watchlist",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "plex_rating_key": {
+          "name": "plex_rating_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_watchlist_media": {
+          "name": "idx_watchlist_media",
+          "columns": ["media_type", "media_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "movies": {
+      "name": "movies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "tmdb_id": {
+          "name": "tmdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "imdb_id": {
+          "name": "imdb_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_title": {
+          "name": "original_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "release_date": {
+          "name": "release_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "runtime": {
+          "name": "runtime",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "original_language": {
+          "name": "original_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "budget": {
+          "name": "budget",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revenue": {
+          "name": "revenue",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "poster_path": {
+          "name": "poster_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "backdrop_path": {
+          "name": "backdrop_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "logo_path": {
+          "name": "logo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "poster_override_path": {
+          "name": "poster_override_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discover_rating_key": {
+          "name": "discover_rating_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vote_average": {
+          "name": "vote_average",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vote_count": {
+          "name": "vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "rotation_status": {
+          "name": "rotation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rotation_expires_at": {
+          "name": "rotation_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rotation_marked_at": {
+          "name": "rotation_marked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_movies_rotation_status": {
+          "name": "idx_movies_rotation_status",
+          "columns": ["rotation_status"],
+          "isUnique": false
+        },
+        "idx_movies_tmdb_id": {
+          "name": "idx_movies_tmdb_id",
+          "columns": ["tmdb_id"],
+          "isUnique": true
+        },
+        "idx_movies_title": {
+          "name": "idx_movies_title",
+          "columns": ["title"],
+          "isUnique": false
+        },
+        "idx_movies_release_date": {
+          "name": "idx_movies_release_date",
+          "columns": ["release_date"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "nudge_log": {
+      "name": "nudge_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "engram_ids": {
+          "name": "engram_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "acted_at": {
+          "name": "acted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action_label": {
+          "name": "action_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action_params": {
+          "name": "action_params",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_nudge_log_type": {
+          "name": "idx_nudge_log_type",
+          "columns": ["type"],
+          "isUnique": false
+        },
+        "idx_nudge_log_status": {
+          "name": "idx_nudge_log_status",
+          "columns": ["status"],
+          "isUnique": false
+        },
+        "idx_nudge_log_priority": {
+          "name": "idx_nudge_log_priority",
+          "columns": ["priority"],
+          "isUnique": false
+        },
+        "idx_nudge_log_created_at": {
+          "name": "idx_nudge_log_created_at",
+          "columns": ["created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reflex_executions": {
+      "name": "reflex_executions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reflex_name": {
+          "name": "reflex_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trigger_data": {
+          "name": "trigger_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_verb": {
+          "name": "action_verb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "triggered_at": {
+          "name": "triggered_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_reflex_exec_name": {
+          "name": "idx_reflex_exec_name",
+          "columns": ["reflex_name"],
+          "isUnique": false
+        },
+        "idx_reflex_exec_trigger_type": {
+          "name": "idx_reflex_exec_trigger_type",
+          "columns": ["trigger_type"],
+          "isUnique": false
+        },
+        "idx_reflex_exec_status": {
+          "name": "idx_reflex_exec_status",
+          "columns": ["status"],
+          "isUnique": false
+        },
+        "idx_reflex_exec_triggered_at": {
+          "name": "idx_reflex_exec_triggered_at",
+          "columns": ["triggered_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rotation_candidates": {
+      "name": "rotation_candidates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tmdb_id": {
+          "name": "tmdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "poster_path": {
+          "name": "poster_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "discovered_at": {
+          "name": "discovered_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_rotation_candidates_tmdb_id": {
+          "name": "idx_rotation_candidates_tmdb_id",
+          "columns": ["tmdb_id"],
+          "isUnique": true
+        },
+        "idx_rotation_candidates_source_id": {
+          "name": "idx_rotation_candidates_source_id",
+          "columns": ["source_id"],
+          "isUnique": false
+        },
+        "idx_rotation_candidates_status": {
+          "name": "idx_rotation_candidates_status",
+          "columns": ["status"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "rotation_candidates_source_id_rotation_sources_id_fk": {
+          "name": "rotation_candidates_source_id_rotation_sources_id_fk",
+          "tableFrom": "rotation_candidates",
+          "tableTo": "rotation_sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rotation_exclusions": {
+      "name": "rotation_exclusions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "tmdb_id": {
+          "name": "tmdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "excluded_at": {
+          "name": "excluded_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_rotation_exclusions_tmdb_id": {
+          "name": "idx_rotation_exclusions_tmdb_id",
+          "columns": ["tmdb_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rotation_log": {
+      "name": "rotation_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "movies_marked_leaving": {
+          "name": "movies_marked_leaving",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "movies_removed": {
+          "name": "movies_removed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "movies_added": {
+          "name": "movies_added",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "removals_failed": {
+          "name": "removals_failed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "free_space_gb": {
+          "name": "free_space_gb",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_free_gb": {
+          "name": "target_free_gb",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skipped_reason": {
+          "name": "skipped_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rotation_sources": {
+      "name": "rotation_sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 5
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sync_interval_hours": {
+          "name": "sync_interval_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 24
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_rotation_sources_type": {
+          "name": "idx_rotation_sources_type",
+          "columns": ["type"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "seasons": {
+      "name": "seasons",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "tv_show_id": {
+          "name": "tv_show_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tvdb_id": {
+          "name": "tvdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "season_number": {
+          "name": "season_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "poster_path": {
+          "name": "poster_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "air_date": {
+          "name": "air_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "episode_count": {
+          "name": "episode_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_seasons_tvdb_id": {
+          "name": "idx_seasons_tvdb_id",
+          "columns": ["tvdb_id"],
+          "isUnique": true
+        },
+        "idx_seasons_show_number": {
+          "name": "idx_seasons_show_number",
+          "columns": ["tv_show_id", "season_number"],
+          "isUnique": true
+        },
+        "idx_seasons_tv_show_id": {
+          "name": "idx_seasons_tv_show_id",
+          "columns": ["tv_show_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "seasons_tv_show_id_tv_shows_id_fk": {
+          "name": "seasons_tv_show_id_tv_shows_id_fk",
+          "tableFrom": "seasons",
+          "tableTo": "tv_shows",
+          "columnsFrom": ["tv_show_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "service_accounts": {
+      "name": "service_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "service_accounts_name_unique": {
+          "name": "service_accounts_name_unique",
+          "columns": ["name"],
+          "isUnique": true
+        },
+        "service_accounts_key_prefix_unique": {
+          "name": "service_accounts_key_prefix_unique",
+          "columns": ["key_prefix"],
+          "isUnique": true
+        },
+        "idx_service_accounts_key_prefix": {
+          "name": "idx_service_accounts_key_prefix",
+          "columns": ["key_prefix"],
+          "isUnique": false
+        },
+        "idx_service_accounts_revoked_at": {
+          "name": "idx_service_accounts_revoked_at",
+          "columns": ["revoked_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "shelf_impressions": {
+      "name": "shelf_impressions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "shelf_id": {
+          "name": "shelf_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "shown_at": {
+          "name": "shown_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_shelf_impressions_shelf_id": {
+          "name": "idx_shelf_impressions_shelf_id",
+          "columns": ["shelf_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sync_job_results": {
+      "name": "sync_job_results",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "job_type": {
+          "name": "job_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "progress": {
+          "name": "progress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_sync_job_results_type_completed": {
+          "name": "idx_sync_job_results_type_completed",
+          "columns": ["job_type", "completed_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sync_logs": {
+      "name": "sync_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "movies_synced": {
+          "name": "movies_synced",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "tv_shows_synced": {
+          "name": "tv_shows_synced",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "errors": {
+          "name": "errors",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tag_vocabulary": {
+      "name": "tag_vocabulary",
+      "columns": {
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'seed'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_tag_vocabulary_active": {
+          "name": "idx_tag_vocabulary_active",
+          "columns": ["is_active"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tier_overrides": {
+      "name": "tier_overrides",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dimension_id": {
+          "name": "dimension_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_tier_overrides_unique": {
+          "name": "idx_tier_overrides_unique",
+          "columns": ["media_type", "media_id", "dimension_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "tier_overrides_dimension_id_comparison_dimensions_id_fk": {
+          "name": "tier_overrides_dimension_id_comparison_dimensions_id_fk",
+          "tableFrom": "tier_overrides",
+          "tableTo": "comparison_dimensions",
+          "columnsFrom": ["dimension_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "transaction_tag_rules": {
+      "name": "transaction_tag_rules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description_pattern": {
+          "name": "description_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "match_type": {
+          "name": "match_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'exact'"
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.5
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "times_applied": {
+          "name": "times_applied",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_tag_rules_pattern": {
+          "name": "idx_tag_rules_pattern",
+          "columns": ["description_pattern"],
+          "isUnique": false
+        },
+        "idx_tag_rules_entity_id": {
+          "name": "idx_tag_rules_entity_id",
+          "columns": ["entity_id"],
+          "isUnique": false
+        },
+        "idx_tag_rules_priority": {
+          "name": "idx_tag_rules_priority",
+          "columns": ["priority"],
+          "isUnique": false
+        },
+        "idx_tag_rules_confidence": {
+          "name": "idx_tag_rules_confidence",
+          "columns": ["confidence"],
+          "isUnique": false
+        },
+        "idx_tag_rules_times_applied": {
+          "name": "idx_tag_rules_times_applied",
+          "columns": ["times_applied"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "transaction_tag_rules_entity_id_entities_id_fk": {
+          "name": "transaction_tag_rules_entity_id_entities_id_fk",
+          "tableFrom": "transaction_tag_rules",
+          "tableTo": "entities",
+          "columnsFrom": ["entity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "transactions": {
+      "name": "transactions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notion_id": {
+          "name": "notion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account": {
+          "name": "account",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "entity_name": {
+          "name": "entity_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "related_transaction_id": {
+          "name": "related_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_row": {
+          "name": "raw_row",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_edited_time": {
+          "name": "last_edited_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "transactions_notion_id_unique": {
+          "name": "transactions_notion_id_unique",
+          "columns": ["notion_id"],
+          "isUnique": true
+        },
+        "idx_transactions_date": {
+          "name": "idx_transactions_date",
+          "columns": ["date"],
+          "isUnique": false
+        },
+        "idx_transactions_account": {
+          "name": "idx_transactions_account",
+          "columns": ["account"],
+          "isUnique": false
+        },
+        "idx_transactions_entity": {
+          "name": "idx_transactions_entity",
+          "columns": ["entity_id"],
+          "isUnique": false
+        },
+        "idx_transactions_last_edited": {
+          "name": "idx_transactions_last_edited",
+          "columns": ["last_edited_time"],
+          "isUnique": false
+        },
+        "idx_transactions_notion_id": {
+          "name": "idx_transactions_notion_id",
+          "columns": ["notion_id"],
+          "isUnique": false
+        },
+        "idx_transactions_checksum": {
+          "name": "idx_transactions_checksum",
+          "columns": ["checksum"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "transactions_entity_id_entities_id_fk": {
+          "name": "transactions_entity_id_entities_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "entities",
+          "columnsFrom": ["entity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tv_shows": {
+      "name": "tv_shows",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "tvdb_id": {
+          "name": "tvdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_air_date": {
+          "name": "first_air_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_air_date": {
+          "name": "last_air_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "original_language": {
+          "name": "original_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "number_of_seasons": {
+          "name": "number_of_seasons",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "number_of_episodes": {
+          "name": "number_of_episodes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "episode_run_time": {
+          "name": "episode_run_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "poster_path": {
+          "name": "poster_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "backdrop_path": {
+          "name": "backdrop_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "logo_path": {
+          "name": "logo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "poster_override_path": {
+          "name": "poster_override_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discover_rating_key": {
+          "name": "discover_rating_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vote_average": {
+          "name": "vote_average",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vote_count": {
+          "name": "vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "networks": {
+          "name": "networks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_tv_shows_tvdb_id": {
+          "name": "idx_tv_shows_tvdb_id",
+          "columns": ["tvdb_id"],
+          "isUnique": true
+        },
+        "idx_tv_shows_name": {
+          "name": "idx_tv_shows_name",
+          "columns": ["name"],
+          "isUnique": false
+        },
+        "idx_tv_shows_first_air_date": {
+          "name": "idx_tv_shows_first_air_date",
+          "columns": ["first_air_date"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_settings": {
+      "name": "user_settings",
+      "columns": {
+        "user_email": {
+          "name": "user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_user_settings_user": {
+          "name": "idx_user_settings_user",
+          "columns": ["user_email"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "user_settings_user_email_key_pk": {
+          "columns": ["user_email", "key"],
+          "name": "user_settings_user_email_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "watch_history": {
+      "name": "watch_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "watched_at": {
+          "name": "watched_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "completed": {
+          "name": "completed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "blacklisted": {
+          "name": "blacklisted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_watch_history_media": {
+          "name": "idx_watch_history_media",
+          "columns": ["media_type", "media_id"],
+          "isUnique": false
+        },
+        "idx_watch_history_watched_at": {
+          "name": "idx_watch_history_watched_at",
+          "columns": ["watched_at"],
+          "isUnique": false
+        },
+        "idx_watch_history_unique": {
+          "name": "idx_watch_history_unique",
+          "columns": ["media_type", "media_id", "watched_at"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "wish_list": {
+      "name": "wish_list",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notion_id": {
+          "name": "notion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "item": {
+          "name": "item",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_amount": {
+          "name": "target_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "saved": {
+          "name": "saved",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_edited_time": {
+          "name": "last_edited_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "wish_list_notion_id_unique": {
+          "name": "wish_list_notion_id_unique",
+          "columns": ["notion_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "idx_budgets_category_period": {
+        "columns": {
+          "COALESCE(\"period\", char(0))": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/apps/pops-api/src/db/drizzle-migrations/meta/_journal.json
+++ b/apps/pops-api/src/db/drizzle-migrations/meta/_journal.json
@@ -484,6 +484,13 @@
       "when": 1781045142538,
       "tag": "0068_prd_136_inbox_review",
       "breakpoints": true
+    },
+    {
+      "idx": 69,
+      "version": "6",
+      "when": 1781079634155,
+      "tag": "0069_prd_145_batches_deleted_at",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/pops-api/src/db/migration-ownership.ts
+++ b/apps/pops-api/src/db/migration-ownership.ts
@@ -111,6 +111,9 @@ export const MIGRATION_OWNERS: Readonly<Record<string, string>> = {
   // PRD-136 — recipe_version_rejections + ingest_sources.reviewed_at for the
   // inbox approve/reject flow.
   '0068_prd_136_inbox_review': 'food',
+  // PRD-145 — batches.deleted_at soft-delete column (service-enforced invariant
+  // deleted_at IS NOT NULL → qty_remaining = 0).
+  '0069_prd_145_batches_deleted_at': 'food',
 };
 
 /** Materialised as a Map for O(1) lookup by the runner. */

--- a/apps/pops-api/src/modules/food/__tests__/batches-router.test.ts
+++ b/apps/pops-api/src/modules/food/__tests__/batches-router.test.ts
@@ -1,0 +1,441 @@
+/**
+ * PRD-145 — integration tests for `food.batches.*`.
+ *
+ * Mirrors the service-layer Vitest suite (`batches-lifecycle.test.ts`)
+ * at the tRPC boundary so any router-level breakage (input parsing,
+ * error shape, mutation routing) surfaces here.
+ *
+ * Coverage per PRD-145 §Acceptance Criteria:
+ *   - food.batches.create — manual entry happy path + BadExpiry + default
+ *     expiry from variant shelf-life
+ *   - food.batches.get — joined BatchDetail; null for missing
+ *   - food.batches.relocate — auto-default recompute + user-override preserve
+ *   - food.batches.edit — CannotEditFromRun on cook-yielded batches +
+ *     BadExpiry guard + null clears
+ *   - food.batches.adjustQty — every reason path + BadAdjustment + NegativeQty
+ *   - food.batches.delete — soft-delete invariant + idempotent rejection
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import BetterSqlite3, { type Database } from 'better-sqlite3';
+import { eq } from 'drizzle-orm';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  batchesLifecycleService,
+  batches,
+  ingredientsService,
+  ingredientVariants,
+  recipesService,
+  recipeRunsService,
+  recipeVersions,
+  variantsService,
+} from '@pops/app-food-db';
+
+import { closeDb, getDrizzle, setDb } from '../../../db.js';
+import { createCaller } from '../../../shared/test-utils.js';
+
+const MIGRATION_FILES = [
+  '0058_high_sentinel.sql',
+  '0059_useful_hiroim.sql',
+  '0060_familiar_leo.sql',
+  '0061_shocking_skreet.sql',
+  '0062_chemical_donald_blake.sql',
+  '0063_bumpy_wolverine.sql',
+  '0064_peaceful_magma.sql',
+  '0065_prd_116_recipe_compile.sql',
+  '0066_prd_123_conversions.sql',
+  '0067_prd_125_ingest_error_columns.sql',
+  '0068_prd_136_inbox_review.sql',
+  '0069_prd_145_batches_deleted_at.sql',
+];
+
+function applyMigration(db: Database, filename: string): void {
+  const text = readFileSync(join(__dirname, '../../../db/drizzle-migrations', filename), 'utf8');
+  for (const stmt of text.split('--> statement-breakpoint')) {
+    const trimmed = stmt.trim();
+    if (trimmed.length > 0) db.exec(trimmed);
+  }
+}
+
+function createFoodTestDb(): Database {
+  const db = new BetterSqlite3(':memory:');
+  db.pragma('journal_mode = WAL');
+  db.pragma('foreign_keys = ON');
+  for (const name of MIGRATION_FILES) applyMigration(db, name);
+  return db;
+}
+
+interface SeedResult {
+  ingredientId: number;
+  variantId: number;
+  recipeVersionId: number;
+}
+
+function seedVariantAndRecipe(slug: string): SeedResult {
+  const db = getDrizzle();
+  const ing = ingredientsService.createIngredient(db, {
+    name: 'Tomato',
+    slug: `${slug}-tomato`,
+    defaultUnit: 'g',
+  });
+  const variant = variantsService.createVariant(db, {
+    ingredientId: ing.id,
+    name: 'Diced',
+    slug: 'diced',
+    defaultUnit: 'g',
+  });
+  db.update(ingredientVariants)
+    .set({ defaultShelfLifeDaysFridge: 5, defaultShelfLifeDaysFreezer: 90 })
+    .where(eq(ingredientVariants.id, variant.id))
+    .run();
+  const { recipe, version } = recipesService.createRecipe(db, {
+    slug,
+    firstVersion: { title: `Test ${slug}`, bodyDsl: `@recipe(slug="${slug}", title="Test")` },
+  });
+  void recipe;
+  db.update(recipeVersions)
+    .set({ compileStatus: 'compiled' })
+    .where(eq(recipeVersions.id, version.id))
+    .run();
+  return { ingredientId: ing.id, variantId: variant.id, recipeVersionId: version.id };
+}
+
+describe('food.batches router — PRD-145', () => {
+  let sqlite: Database;
+  let caller: ReturnType<typeof createCaller>;
+
+  beforeEach(() => {
+    sqlite = createFoodTestDb();
+    setDb(sqlite);
+    caller = createCaller();
+  });
+
+  afterEach(() => {
+    closeDb();
+    sqlite.close();
+  });
+
+  describe('create', () => {
+    it('inserts a manual batch with explicit expiresAt', async () => {
+      const { variantId } = seedVariantAndRecipe('create-happy');
+      const result = await caller.food.batches.create({
+        variantId,
+        prepStateId: null,
+        qty: 500,
+        unit: 'g',
+        location: 'fridge',
+        sourceType: 'purchase',
+        producedAt: '2026-06-01T00:00:00.000Z',
+        expiresAt: '2026-06-10T00:00:00.000Z',
+      });
+      expect(result.batchId).toBeGreaterThan(0);
+    });
+
+    it('defaults expiresAt from variant shelf-life days', async () => {
+      const { variantId } = seedVariantAndRecipe('create-default');
+      const { batchId } = await caller.food.batches.create({
+        variantId,
+        prepStateId: null,
+        qty: 200,
+        unit: 'g',
+        location: 'fridge',
+        sourceType: 'purchase',
+        producedAt: '2026-06-01T00:00:00.000Z',
+      });
+      const detail = await caller.food.batches.get({ id: batchId });
+      expect(detail?.expiresAt).toBe('2026-06-06T00:00:00.000Z');
+    });
+
+    it('throws BAD_REQUEST when expiresAt precedes producedAt', async () => {
+      const { variantId } = seedVariantAndRecipe('create-badexpiry');
+      await expect(
+        caller.food.batches.create({
+          variantId,
+          prepStateId: null,
+          qty: 200,
+          unit: 'g',
+          location: 'fridge',
+          sourceType: 'purchase',
+          producedAt: '2026-06-10T00:00:00.000Z',
+          expiresAt: '2026-06-01T00:00:00.000Z',
+        })
+      ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+    });
+  });
+
+  describe('get', () => {
+    it('returns the joined BatchDetail for an existing batch', async () => {
+      const { variantId, ingredientId } = seedVariantAndRecipe('get-happy');
+      const { batchId } = await caller.food.batches.create({
+        variantId,
+        prepStateId: null,
+        qty: 200,
+        unit: 'g',
+        location: 'fridge',
+        sourceType: 'purchase',
+      });
+      const detail = await caller.food.batches.get({ id: batchId });
+      expect(detail).toMatchObject({
+        id: batchId,
+        variantId,
+        variantName: 'Diced',
+        variantSlug: 'diced',
+        ingredientId,
+        ingredientName: 'Tomato',
+        sourceType: 'purchase',
+        sourceRecipeRunId: null,
+        sourceRecipeSlug: null,
+        deletedAt: null,
+      });
+    });
+
+    it('returns null for a missing id', async () => {
+      const detail = await caller.food.batches.get({ id: 99999 });
+      expect(detail).toBeNull();
+    });
+
+    it('resolves sourceRecipeSlug for a cook-yielded batch', async () => {
+      const seed = seedVariantAndRecipe('get-cook');
+      const db = getDrizzle();
+      const run = recipeRunsService.createRun(db, { recipeVersionId: seed.recipeVersionId });
+      const yielded = batchesLifecycleService.createBatchFromRun(db, run.id, {
+        variantId: seed.variantId,
+        prepStateId: null,
+        qty: 800,
+        unit: 'g',
+        location: 'fridge',
+      });
+      expect(yielded.batchId).not.toBeNull();
+      const detail = await caller.food.batches.get({ id: yielded.batchId ?? -1 });
+      expect(detail?.sourceType).toBe('recipe_run');
+      expect(detail?.sourceRecipeRunId).toBe(run.id);
+      expect(detail?.sourceRecipeSlug).toBe('get-cook');
+    });
+  });
+
+  describe('relocate', () => {
+    it('recomputes auto-default expiry on relocate', async () => {
+      const { variantId } = seedVariantAndRecipe('relocate-auto');
+      const { batchId } = await caller.food.batches.create({
+        variantId,
+        prepStateId: null,
+        qty: 200,
+        unit: 'g',
+        location: 'fridge',
+        sourceType: 'purchase',
+        producedAt: '2026-06-01T00:00:00.000Z',
+      });
+      const result = await caller.food.batches.relocate({ id: batchId, location: 'freezer' });
+      expect(result).toEqual({ ok: true });
+      const detail = await caller.food.batches.get({ id: batchId });
+      expect(detail?.location).toBe('freezer');
+      expect(detail?.expiresAt).toBe('2026-08-30T00:00:00.000Z');
+    });
+
+    it('preserves user-overridden expiry on relocate', async () => {
+      const { variantId } = seedVariantAndRecipe('relocate-override');
+      const { batchId } = await caller.food.batches.create({
+        variantId,
+        prepStateId: null,
+        qty: 200,
+        unit: 'g',
+        location: 'fridge',
+        sourceType: 'purchase',
+        producedAt: '2026-06-01T00:00:00.000Z',
+        expiresAt: '2026-06-15T00:00:00.000Z',
+      });
+      await caller.food.batches.relocate({ id: batchId, location: 'freezer' });
+      const detail = await caller.food.batches.get({ id: batchId });
+      expect(detail?.expiresAt).toBe('2026-06-15T00:00:00.000Z');
+    });
+
+    it('returns BatchDeleted when relocating a soft-deleted batch', async () => {
+      const { variantId } = seedVariantAndRecipe('relocate-deleted');
+      const { batchId } = await caller.food.batches.create({
+        variantId,
+        prepStateId: null,
+        qty: 200,
+        unit: 'g',
+        location: 'fridge',
+        sourceType: 'purchase',
+      });
+      await caller.food.batches.delete({ id: batchId });
+      const result = await caller.food.batches.relocate({ id: batchId, location: 'freezer' });
+      expect(result).toEqual({ ok: false, reason: 'BatchDeleted' });
+    });
+  });
+
+  describe('edit', () => {
+    it('rejects CannotEditFromRun for prepStateId edits on cook-yielded batches', async () => {
+      const seed = seedVariantAndRecipe('edit-cook');
+      const db = getDrizzle();
+      const run = recipeRunsService.createRun(db, { recipeVersionId: seed.recipeVersionId });
+      const yielded = batchesLifecycleService.createBatchFromRun(db, run.id, {
+        variantId: seed.variantId,
+        prepStateId: null,
+        qty: 500,
+        unit: 'g',
+        location: 'fridge',
+      });
+      const result = await caller.food.batches.edit({
+        id: yielded.batchId ?? -1,
+        prepStateId: null,
+      });
+      expect(result).toEqual({ ok: false, reason: 'CannotEditFromRun' });
+    });
+
+    it('rejects BadExpiry when patch expiry precedes producedAt', async () => {
+      const { variantId } = seedVariantAndRecipe('edit-badexpiry');
+      const { batchId } = await caller.food.batches.create({
+        variantId,
+        prepStateId: null,
+        qty: 200,
+        unit: 'g',
+        location: 'fridge',
+        sourceType: 'purchase',
+        producedAt: '2026-06-05T00:00:00.000Z',
+      });
+      const result = await caller.food.batches.edit({
+        id: batchId,
+        expiresAt: '2026-06-01T00:00:00.000Z',
+      });
+      expect(result).toEqual({ ok: false, reason: 'BadExpiry' });
+    });
+
+    it('allows clearing expiresAt to null', async () => {
+      const { variantId } = seedVariantAndRecipe('edit-clear');
+      const { batchId } = await caller.food.batches.create({
+        variantId,
+        prepStateId: null,
+        qty: 200,
+        unit: 'g',
+        location: 'fridge',
+        sourceType: 'purchase',
+        producedAt: '2026-06-05T00:00:00.000Z',
+      });
+      const result = await caller.food.batches.edit({ id: batchId, expiresAt: null });
+      expect(result).toEqual({ ok: true });
+      const detail = await caller.food.batches.get({ id: batchId });
+      expect(detail?.expiresAt).toBeNull();
+    });
+  });
+
+  describe('adjustQty', () => {
+    it('decrements with spoiled + negative delta', async () => {
+      const { variantId } = seedVariantAndRecipe('adjust-spoiled');
+      const { batchId } = await caller.food.batches.create({
+        variantId,
+        prepStateId: null,
+        qty: 500,
+        unit: 'g',
+        location: 'fridge',
+        sourceType: 'purchase',
+      });
+      const result = await caller.food.batches.adjustQty({
+        id: batchId,
+        delta: -200,
+        reason: 'spoiled',
+      });
+      expect(result).toEqual({ ok: true, newQty: 300 });
+    });
+
+    it('rejects BadAdjustment for positive delta with reason=spoiled', async () => {
+      const { variantId } = seedVariantAndRecipe('adjust-badadj');
+      const { batchId } = await caller.food.batches.create({
+        variantId,
+        prepStateId: null,
+        qty: 500,
+        unit: 'g',
+        location: 'fridge',
+        sourceType: 'purchase',
+      });
+      const result = await caller.food.batches.adjustQty({
+        id: batchId,
+        delta: 50,
+        reason: 'spoiled',
+      });
+      expect(result).toEqual({ ok: false, reason: 'BadAdjustment' });
+    });
+
+    it('accepts positive correction', async () => {
+      const { variantId } = seedVariantAndRecipe('adjust-correct');
+      const { batchId } = await caller.food.batches.create({
+        variantId,
+        prepStateId: null,
+        qty: 500,
+        unit: 'g',
+        location: 'fridge',
+        sourceType: 'purchase',
+      });
+      const result = await caller.food.batches.adjustQty({
+        id: batchId,
+        delta: 50,
+        reason: 'correction',
+      });
+      expect(result).toEqual({ ok: true, newQty: 550 });
+    });
+
+    it('rejects NegativeQty when delta would push below zero', async () => {
+      const { variantId } = seedVariantAndRecipe('adjust-neg');
+      const { batchId } = await caller.food.batches.create({
+        variantId,
+        prepStateId: null,
+        qty: 100,
+        unit: 'g',
+        location: 'fridge',
+        sourceType: 'purchase',
+      });
+      const result = await caller.food.batches.adjustQty({
+        id: batchId,
+        delta: -200,
+        reason: 'wasted',
+      });
+      expect(result).toEqual({ ok: false, reason: 'NegativeQty' });
+    });
+  });
+
+  describe('delete', () => {
+    it('soft-deletes with qty_remaining=0 + deleted_at set', async () => {
+      const { variantId } = seedVariantAndRecipe('delete-happy');
+      const { batchId } = await caller.food.batches.create({
+        variantId,
+        prepStateId: null,
+        qty: 250,
+        unit: 'g',
+        location: 'fridge',
+        sourceType: 'purchase',
+      });
+      const result = await caller.food.batches.delete({ id: batchId });
+      expect(result).toEqual({ ok: true });
+      const db = getDrizzle();
+      const row = db.select().from(batches).where(eq(batches.id, batchId)).get();
+      expect(row?.qtyRemaining).toBe(0);
+      expect(row?.deletedAt).not.toBeNull();
+    });
+
+    it('rejects BatchDeleted on second delete', async () => {
+      const { variantId } = seedVariantAndRecipe('delete-idempotent');
+      const { batchId } = await caller.food.batches.create({
+        variantId,
+        prepStateId: null,
+        qty: 100,
+        unit: 'g',
+        location: 'fridge',
+        sourceType: 'purchase',
+      });
+      await caller.food.batches.delete({ id: batchId });
+      const result = await caller.food.batches.delete({ id: batchId });
+      expect(result).toEqual({ ok: false, reason: 'BatchDeleted' });
+    });
+  });
+
+  describe('searchForConsume scaffold (PRD-146)', () => {
+    it('still throws NOT_IMPLEMENTED', async () => {
+      await expect(caller.food.batches.searchForConsume({})).rejects.toMatchObject({
+        code: 'NOT_IMPLEMENTED',
+      });
+    });
+  });
+});

--- a/apps/pops-api/src/modules/food/__tests__/cook-plan-fridge-scaffold.test.ts
+++ b/apps/pops-api/src/modules/food/__tests__/cook-plan-fridge-scaffold.test.ts
@@ -22,48 +22,12 @@ function isNotImplemented(err: AnyError): boolean {
   return err instanceof TRPCError && err.code === 'NOT_IMPLEMENTED';
 }
 
-describe('food.batches.* scaffold (PRD-145 + PRD-146)', () => {
+describe('food.batches.* scaffold (PRD-146)', () => {
   const caller = createCaller();
 
-  it('rejects `create` with NOT_IMPLEMENTED', async () => {
-    await expect(
-      caller.food.batches.create({
-        variantId: 1,
-        prepStateId: null,
-        qty: 100,
-        unit: 'g',
-        location: 'fridge',
-        sourceType: 'purchase',
-      })
-    ).rejects.toSatisfy(isNotImplemented);
-  });
-
-  it('rejects `get` with NOT_IMPLEMENTED', async () => {
-    await expect(caller.food.batches.get({ id: 1 })).rejects.toSatisfy(isNotImplemented);
-  });
-
-  it('rejects `relocate` with NOT_IMPLEMENTED', async () => {
-    await expect(caller.food.batches.relocate({ id: 1, location: 'freezer' })).rejects.toSatisfy(
-      isNotImplemented
-    );
-  });
-
-  it('rejects `edit` with NOT_IMPLEMENTED', async () => {
-    await expect(caller.food.batches.edit({ id: 1, notes: 'hi' })).rejects.toSatisfy(
-      isNotImplemented
-    );
-  });
-
-  it('rejects `adjustQty` with NOT_IMPLEMENTED', async () => {
-    await expect(
-      caller.food.batches.adjustQty({ id: 1, delta: -10, reason: 'spoiled' })
-    ).rejects.toSatisfy(isNotImplemented);
-  });
-
-  it('rejects `delete` with NOT_IMPLEMENTED', async () => {
-    await expect(caller.food.batches.delete({ id: 1 })).rejects.toSatisfy(isNotImplemented);
-  });
-
+  // PRD-145 wired create/get/relocate/edit/adjustQty/delete — see
+  // `batches-router.test.ts` for the behaviour suite. Only PRD-146's
+  // `searchForConsume` remains a scaffold.
   it('rejects `searchForConsume` with NOT_IMPLEMENTED', async () => {
     await expect(caller.food.batches.searchForConsume({ limit: 10 })).rejects.toSatisfy(
       isNotImplemented

--- a/apps/pops-api/src/modules/food/__tests__/inbox-router.test.ts
+++ b/apps/pops-api/src/modules/food/__tests__/inbox-router.test.ts
@@ -51,6 +51,7 @@ const MIGRATION_FILES = [
   '0066_prd_123_conversions.sql',
   '0067_prd_125_ingest_error_columns.sql',
   '0068_prd_136_inbox_review.sql',
+  '0069_prd_145_batches_deleted_at.sql',
 ];
 
 function applyMigration(db: Database, filename: string): void {

--- a/apps/pops-api/src/modules/food/__tests__/ingest-router.test.ts
+++ b/apps/pops-api/src/modules/food/__tests__/ingest-router.test.ts
@@ -73,6 +73,7 @@ const FOOD_MIGRATIONS = [
   '0066_prd_123_conversions.sql',
   '0067_prd_125_ingest_error_columns.sql',
   '0068_prd_136_inbox_review.sql',
+  '0069_prd_145_batches_deleted_at.sql',
 ];
 
 function applyMigrations(db: Database): void {

--- a/apps/pops-api/src/modules/food/batches/get.ts
+++ b/apps/pops-api/src/modules/food/batches/get.ts
@@ -1,0 +1,77 @@
+/**
+ * `food.batches.get` resolver — composes `BatchDetail` with joined
+ * ingredient / variant / prep-state / recipe-slug names.
+ *
+ * Kept here (not in `@pops/app-food-db`) because the join is
+ * read-projection only — the service layer's mutations operate on the
+ * batches table alone. Future fridge-view / picker queries that need
+ * similar joins can promote this into the package if a second caller
+ * appears.
+ */
+import { eq } from 'drizzle-orm';
+
+import {
+  batches,
+  ingredients,
+  ingredientVariants,
+  prepStates,
+  recipeRuns,
+  recipes,
+  recipeVersions,
+  type FoodDb,
+} from '@pops/app-food-db';
+
+import type { BatchDetail } from '@pops/app-food-db';
+
+export function getBatchDetail(db: FoodDb, id: number): BatchDetail | null {
+  const rows = db
+    .select({
+      id: batches.id,
+      variantId: batches.variantId,
+      variantName: ingredientVariants.name,
+      variantSlug: ingredientVariants.slug,
+      ingredientId: ingredients.id,
+      ingredientName: ingredients.name,
+      ingredientSlug: ingredients.slug,
+      prepStateId: batches.prepStateId,
+      prepStateLabel: prepStates.name,
+      qtyRemaining: batches.qtyRemaining,
+      unit: batches.unit,
+      sourceType: batches.sourceType,
+      sourceId: batches.sourceId,
+      location: batches.location,
+      producedAt: batches.producedAt,
+      expiresAt: batches.expiresAt,
+      notes: batches.notes,
+      deletedAt: batches.deletedAt,
+      createdAt: batches.createdAt,
+    })
+    .from(batches)
+    .innerJoin(ingredientVariants, eq(ingredientVariants.id, batches.variantId))
+    .innerJoin(ingredients, eq(ingredients.id, ingredientVariants.ingredientId))
+    .leftJoin(prepStates, eq(prepStates.id, batches.prepStateId))
+    .where(eq(batches.id, id))
+    .all();
+  const row = rows[0];
+  if (row === undefined) return null;
+
+  const recipeInfo = row.sourceType === 'recipe_run' ? resolveRecipeRun(db, row.sourceId) : null;
+
+  return {
+    ...row,
+    sourceRecipeRunId: row.sourceType === 'recipe_run' ? row.sourceId : null,
+    sourceRecipeSlug: recipeInfo?.slug ?? null,
+  };
+}
+
+function resolveRecipeRun(db: FoodDb, runId: number | null): { slug: string } | null {
+  if (runId === null) return null;
+  const rows = db
+    .select({ slug: recipes.slug })
+    .from(recipeRuns)
+    .innerJoin(recipeVersions, eq(recipeVersions.id, recipeRuns.recipeVersionId))
+    .innerJoin(recipes, eq(recipes.id, recipeVersions.recipeId))
+    .where(eq(recipeRuns.id, runId))
+    .all();
+  return rows[0] ?? null;
+}

--- a/apps/pops-api/src/modules/food/batches/router.ts
+++ b/apps/pops-api/src/modules/food/batches/router.ts
@@ -1,17 +1,17 @@
 /**
- * `food.batches.*` tRPC router — scaffold for PRD-145 + PRD-146.
+ * `food.batches.*` tRPC router — PRD-145 behaviour + PRD-146 scaffold.
  *
- * Every procedure throws `NotImplemented` at runtime. Inputs are the
- * real PRD-spec'd Zod schemas; outputs are typed against the contracts
- * exported from `@pops/app-food-db`. PRDs 145 + 146 swap each
- * implementation in turn without re-shaping the wire surface.
- *
- * `searchForConsume` is owned by PRD-146; the rest by PRD-145.
+ * Six lifecycle procedures wired to `batchesLifecycleService` from
+ * `@pops/app-food-db`. `searchForConsume` remains a PRD-146 stub.
  */
 
 import { TRPCError } from '@trpc/server';
 
+import { batchesLifecycleService } from '@pops/app-food-db';
+
+import { getDrizzle } from '../../../db.js';
 import { protectedProcedure, router } from '../../../trpc.js';
+import { getBatchDetail } from './get.js';
 import {
   AdjustBatchQtyInputSchema,
   CreateBatchInputSchema,
@@ -29,8 +29,7 @@ import type {
   BatchMutationResult,
 } from '@pops/app-food-db';
 
-const NOT_IMPLEMENTED_MESSAGE =
-  'food.batches.* is a scaffold; PRD-145 + PRD-146 wire real behaviour';
+const NOT_IMPLEMENTED_MESSAGE = 'food.batches.searchForConsume is a scaffold; PRD-146 wires it';
 
 function notImplemented(): never {
   throw new TRPCError({
@@ -42,27 +41,63 @@ function notImplemented(): never {
 export const batchesRouter = router({
   create: protectedProcedure
     .input(CreateBatchInputSchema)
-    .mutation((): { batchId: number } => notImplemented()),
+    .mutation(({ input }): { batchId: number } => {
+      const result = batchesLifecycleService.createBatchManual(getDrizzle(), {
+        variantId: input.variantId,
+        prepStateId: input.prepStateId,
+        qty: input.qty,
+        unit: input.unit,
+        location: input.location,
+        sourceType: input.sourceType,
+        producedAt: input.producedAt,
+        expiresAt: input.expiresAt,
+        notes: input.notes,
+      });
+      if (result.ok === false) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: `createBatchManual rejected: ${result.reason}`,
+        });
+      }
+      return { batchId: result.batchId };
+    }),
 
-  get: protectedProcedure
-    .input(GetBatchInputSchema)
-    .query((): BatchDetail | null => notImplemented()),
+  get: protectedProcedure.input(GetBatchInputSchema).query(({ input }): BatchDetail | null => {
+    return getBatchDetail(getDrizzle(), input.id);
+  }),
 
   relocate: protectedProcedure
     .input(RelocateBatchInputSchema)
-    .mutation((): BatchMutationResult => notImplemented()),
+    .mutation(({ input }): BatchMutationResult => {
+      return batchesLifecycleService.relocateBatch(getDrizzle(), input.id, input.location);
+    }),
 
   edit: protectedProcedure
     .input(EditBatchInputSchema)
-    .mutation((): BatchMutationResult => notImplemented()),
+    .mutation(({ input }): BatchMutationResult => {
+      return batchesLifecycleService.editBatch(getDrizzle(), input.id, {
+        expiresAt: input.expiresAt,
+        notes: input.notes,
+        prepStateId: input.prepStateId,
+      });
+    }),
 
   adjustQty: protectedProcedure
     .input(AdjustBatchQtyInputSchema)
-    .mutation((): BatchAdjustResult => notImplemented()),
+    .mutation(({ input }): BatchAdjustResult => {
+      return batchesLifecycleService.adjustBatchQty(
+        getDrizzle(),
+        input.id,
+        input.delta,
+        input.reason
+      );
+    }),
 
   delete: protectedProcedure
     .input(DeleteBatchInputSchema)
-    .mutation((): BatchMutationResult => notImplemented()),
+    .mutation(({ input }): BatchMutationResult => {
+      return batchesLifecycleService.deleteBatch(getDrizzle(), input.id);
+    }),
 
   searchForConsume: protectedProcedure
     .input(SearchForConsumeInputSchema)

--- a/apps/pops-api/src/modules/food/migrations.ts
+++ b/apps/pops-api/src/modules/food/migrations.ts
@@ -21,6 +21,8 @@ export const foodMigrationTags: readonly string[] = [
   // PRD-136 — recipe_version_rejections + ingest_sources.reviewed_at for the
   // inbox approve/reject flow.
   '0068_prd_136_inbox_review',
+  // PRD-145 — batches.deleted_at soft-delete column.
+  '0069_prd_145_batches_deleted_at',
 ];
 
 export const foodMigrations: readonly MigrationDescriptor[] = drizzleMigrations(foodMigrationTags);

--- a/packages/app-food-db/src/__tests__/batches-lifecycle.test.ts
+++ b/packages/app-food-db/src/__tests__/batches-lifecycle.test.ts
@@ -1,0 +1,585 @@
+/**
+ * PRD-145 — batch lifecycle integration tests.
+ *
+ * Covers every service entry point + every error branch + the
+ * service-enforced `deleted_at IS NOT NULL → qty_remaining = 0`
+ * invariant (final `afterAll` scan).
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import Database from 'better-sqlite3';
+import { eq } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { afterAll, beforeEach, describe, expect, it } from 'vitest';
+
+import { batches, ingredientVariants, recipeVersions } from '../schema.js';
+import {
+  adjustBatchQty,
+  countDeletedInvariantViolations,
+  createBatchFromRun,
+  createBatchManual,
+  deleteBatch,
+  editBatch,
+  relocateBatch,
+} from '../services/batches-lifecycle.js';
+import { consumeForRun } from '../services/batches.js';
+import { createIngredient } from '../services/ingredients.js';
+import { type FoodDb } from '../services/internal.js';
+import { createRun } from '../services/recipe-runs.js';
+import { createRecipe } from '../services/recipes.js';
+import { createVariant } from '../services/variants.js';
+
+const MIGRATIONS = [
+  '0058_high_sentinel.sql',
+  '0059_useful_hiroim.sql',
+  '0060_familiar_leo.sql',
+  '0069_prd_145_batches_deleted_at.sql',
+].map((name) =>
+  readFileSync(join(__dirname, '../../../../apps/pops-api/src/db/drizzle-migrations', name), 'utf8')
+);
+
+let lastDb: FoodDb | null = null;
+
+function freshDb(): FoodDb {
+  const raw = new Database(':memory:');
+  raw.pragma('foreign_keys = ON');
+  for (const migration of MIGRATIONS) {
+    const stmts = migration.split('--> statement-breakpoint');
+    for (const stmt of stmts) {
+      const trimmed = stmt.trim();
+      if (trimmed.length > 0) raw.exec(trimmed);
+    }
+  }
+  const db = drizzle(raw);
+  lastDb = db;
+  return db;
+}
+
+interface SeedResult {
+  variantId: number;
+  recipeVersionId: number;
+}
+
+function seedFridgeFreezerVariant(
+  db: FoodDb,
+  shelfLife: { fridge: number | null; freezer: number | null } = { fridge: 5, freezer: 90 }
+): SeedResult {
+  const ing = createIngredient(db, { name: 'Tomato', slug: 'tomato', defaultUnit: 'g' });
+  const variant = createVariant(db, {
+    ingredientId: ing.id,
+    name: 'Diced',
+    slug: 'diced',
+    defaultUnit: 'g',
+  });
+  db.update(ingredientVariants)
+    .set({
+      defaultShelfLifeDaysFridge: shelfLife.fridge,
+      defaultShelfLifeDaysFreezer: shelfLife.freezer,
+    })
+    .where(eq(ingredientVariants.id, variant.id))
+    .run();
+  const { version } = createRecipe(db, {
+    slug: 'tomato-sauce',
+    firstVersion: { title: 'Tomato sauce', bodyDsl: '@recipe(tomato-sauce)' },
+  });
+  db.update(recipeVersions)
+    .set({ compileStatus: 'compiled' })
+    .where(eq(recipeVersions.id, version.id))
+    .run();
+  return { variantId: variant.id, recipeVersionId: version.id };
+}
+
+describe('PRD-145 — createBatchManual', () => {
+  let db: FoodDb;
+  let variantId: number;
+
+  beforeEach(() => {
+    db = freshDb();
+    ({ variantId } = seedFridgeFreezerVariant(db));
+  });
+
+  it('inserts a batch with explicit producedAt + expiresAt', () => {
+    const result = createBatchManual(db, {
+      variantId,
+      prepStateId: null,
+      qty: 500,
+      unit: 'g',
+      location: 'fridge',
+      sourceType: 'purchase',
+      producedAt: '2026-06-01T00:00:00.000Z',
+      expiresAt: '2026-06-10T00:00:00.000Z',
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const row = db.select().from(batches).where(eq(batches.id, result.batchId)).get();
+    expect(row?.qtyRemaining).toBe(500);
+    expect(row?.sourceType).toBe('purchase');
+    expect(row?.sourceId).toBeNull();
+    expect(row?.expiresAt).toBe('2026-06-10T00:00:00.000Z');
+  });
+
+  it('defaults expiresAt from variant.default_shelf_life_days_fridge', () => {
+    const producedAt = '2026-06-01T00:00:00.000Z';
+    const result = createBatchManual(db, {
+      variantId,
+      prepStateId: null,
+      qty: 200,
+      unit: 'g',
+      location: 'fridge',
+      sourceType: 'purchase',
+      producedAt,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const row = db.select().from(batches).where(eq(batches.id, result.batchId)).get();
+    expect(row?.expiresAt).toBe('2026-06-06T00:00:00.000Z');
+  });
+
+  it('returns null expiresAt for shelf-stable pantry batches', () => {
+    const result = createBatchManual(db, {
+      variantId,
+      prepStateId: null,
+      qty: 200,
+      unit: 'g',
+      location: 'pantry',
+      sourceType: 'purchase',
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const row = db.select().from(batches).where(eq(batches.id, result.batchId)).get();
+    expect(row?.expiresAt).toBeNull();
+  });
+
+  it('returns null expiresAt when variant has no shelf-life days for the location', () => {
+    const freshDbInstance = freshDb();
+    const { variantId: v } = seedFridgeFreezerVariant(freshDbInstance, {
+      fridge: null,
+      freezer: null,
+    });
+    db = freshDbInstance;
+    const result = createBatchManual(db, {
+      variantId: v,
+      prepStateId: null,
+      qty: 200,
+      unit: 'g',
+      location: 'fridge',
+      sourceType: 'purchase',
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const row = db.select().from(batches).where(eq(batches.id, result.batchId)).get();
+    expect(row?.expiresAt).toBeNull();
+  });
+
+  it('rejects BadExpiry when expiresAt precedes producedAt', () => {
+    const result = createBatchManual(db, {
+      variantId,
+      prepStateId: null,
+      qty: 200,
+      unit: 'g',
+      location: 'fridge',
+      sourceType: 'purchase',
+      producedAt: '2026-06-05T00:00:00.000Z',
+      expiresAt: '2026-06-01T00:00:00.000Z',
+    });
+    expect(result).toEqual({ ok: false, reason: 'BadExpiry' });
+  });
+
+  it('addDays handles midnight UTC boundary deterministically', () => {
+    const result = createBatchManual(db, {
+      variantId,
+      prepStateId: null,
+      qty: 1,
+      unit: 'g',
+      location: 'fridge',
+      sourceType: 'gift',
+      producedAt: '2026-06-30T23:59:59.999Z',
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const row = db.select().from(batches).where(eq(batches.id, result.batchId)).get();
+    // 5 fridge days from 2026-06-30T23:59:59.999Z = 2026-07-05T23:59:59.999Z (UTC).
+    expect(row?.expiresAt).toBe('2026-07-05T23:59:59.999Z');
+  });
+});
+
+describe('PRD-145 — createBatchFromRun', () => {
+  it('wraps markRunComplete and writes yielded_batch_id', () => {
+    const db = freshDb();
+    const { variantId, recipeVersionId } = seedFridgeFreezerVariant(db);
+    const run = createRun(db, { recipeVersionId });
+
+    const result = createBatchFromRun(db, run.id, {
+      variantId,
+      prepStateId: null,
+      qty: 800,
+      unit: 'g',
+      location: 'fridge',
+    });
+    expect(result.batchId).not.toBeNull();
+    const batch = db
+      .select()
+      .from(batches)
+      .where(eq(batches.id, result.batchId ?? -1))
+      .get();
+    expect(batch?.sourceType).toBe('recipe_run');
+    expect(batch?.sourceId).toBe(run.id);
+  });
+
+  it('handles yieldless cooks without creating a batch', () => {
+    const db = freshDb();
+    const { recipeVersionId } = seedFridgeFreezerVariant(db);
+    const run = createRun(db, { recipeVersionId });
+    const result = createBatchFromRun(db, run.id, null);
+    expect(result.batchId).toBeNull();
+  });
+});
+
+describe('PRD-145 — relocateBatch', () => {
+  let db: FoodDb;
+  let variantId: number;
+
+  beforeEach(() => {
+    db = freshDb();
+    ({ variantId } = seedFridgeFreezerVariant(db, { fridge: 5, freezer: 90 }));
+  });
+
+  it('recomputes expiresAt when the previous value matched the auto-default', () => {
+    const created = createBatchManual(db, {
+      variantId,
+      prepStateId: null,
+      qty: 200,
+      unit: 'g',
+      location: 'fridge',
+      sourceType: 'purchase',
+      producedAt: '2026-06-01T00:00:00.000Z',
+    });
+    if (!created.ok) throw new Error('seed failed');
+    const result = relocateBatch(db, created.batchId, 'freezer');
+    expect(result).toEqual({ ok: true });
+    const row = db.select().from(batches).where(eq(batches.id, created.batchId)).get();
+    expect(row?.location).toBe('freezer');
+    expect(row?.expiresAt).toBe('2026-08-30T00:00:00.000Z');
+  });
+
+  it('preserves user-overridden expiresAt on relocate', () => {
+    const created = createBatchManual(db, {
+      variantId,
+      prepStateId: null,
+      qty: 200,
+      unit: 'g',
+      location: 'fridge',
+      sourceType: 'purchase',
+      producedAt: '2026-06-01T00:00:00.000Z',
+      expiresAt: '2026-06-15T00:00:00.000Z',
+    });
+    if (!created.ok) throw new Error('seed failed');
+    relocateBatch(db, created.batchId, 'freezer');
+    const row = db.select().from(batches).where(eq(batches.id, created.batchId)).get();
+    expect(row?.expiresAt).toBe('2026-06-15T00:00:00.000Z');
+  });
+
+  it('appends a relocation audit line to notes', () => {
+    const created = createBatchManual(db, {
+      variantId,
+      prepStateId: null,
+      qty: 200,
+      unit: 'g',
+      location: 'fridge',
+      sourceType: 'purchase',
+      producedAt: '2026-06-01T00:00:00.000Z',
+    });
+    if (!created.ok) throw new Error('seed failed');
+    relocateBatch(db, created.batchId, 'freezer');
+    const row = db.select().from(batches).where(eq(batches.id, created.batchId)).get();
+    expect(row?.notes).toMatch(/^Moved to freezer on \d{4}-\d{2}-\d{2}$/);
+  });
+
+  it('rejects relocate on a soft-deleted batch', () => {
+    const created = createBatchManual(db, {
+      variantId,
+      prepStateId: null,
+      qty: 200,
+      unit: 'g',
+      location: 'fridge',
+      sourceType: 'purchase',
+    });
+    if (!created.ok) throw new Error('seed failed');
+    deleteBatch(db, created.batchId);
+    const result = relocateBatch(db, created.batchId, 'freezer');
+    expect(result).toEqual({ ok: false, reason: 'BatchDeleted' });
+  });
+
+  it('returns BatchNotFound for missing ids', () => {
+    expect(relocateBatch(db, 99999, 'freezer')).toEqual({ ok: false, reason: 'BatchNotFound' });
+  });
+});
+
+describe('PRD-145 — editBatch', () => {
+  let db: FoodDb;
+  let variantId: number;
+  let recipeVersionId: number;
+
+  beforeEach(() => {
+    db = freshDb();
+    ({ variantId, recipeVersionId } = seedFridgeFreezerVariant(db));
+  });
+
+  it('rejects prepStateId edit on recipe_run-sourced batches', () => {
+    const run = createRun(db, { recipeVersionId });
+    const yielded = createBatchFromRun(db, run.id, {
+      variantId,
+      prepStateId: null,
+      qty: 500,
+      unit: 'g',
+      location: 'fridge',
+    });
+    expect(yielded.batchId).not.toBeNull();
+    const result = editBatch(db, yielded.batchId ?? -1, { prepStateId: null });
+    expect(result).toEqual({ ok: false, reason: 'CannotEditFromRun' });
+  });
+
+  it('allows expiresAt edit on recipe_run-sourced batches', () => {
+    const run = createRun(db, { recipeVersionId });
+    const yielded = createBatchFromRun(db, run.id, {
+      variantId,
+      prepStateId: null,
+      qty: 500,
+      unit: 'g',
+      location: 'fridge',
+    });
+    const batchId = yielded.batchId ?? -1;
+    const stored = db.select().from(batches).where(eq(batches.id, batchId)).get();
+    const newExpiry = new Date(
+      new Date(stored?.producedAt ?? '').getTime() + 10 * 86_400_000
+    ).toISOString();
+    const result = editBatch(db, batchId, { expiresAt: newExpiry });
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('rejects BadExpiry when patch expiry precedes producedAt', () => {
+    const created = createBatchManual(db, {
+      variantId,
+      prepStateId: null,
+      qty: 200,
+      unit: 'g',
+      location: 'fridge',
+      sourceType: 'purchase',
+      producedAt: '2026-06-05T00:00:00.000Z',
+    });
+    if (!created.ok) throw new Error('seed failed');
+    const result = editBatch(db, created.batchId, { expiresAt: '2026-06-01T00:00:00.000Z' });
+    expect(result).toEqual({ ok: false, reason: 'BadExpiry' });
+  });
+
+  it('allows clearing expiresAt to null', () => {
+    const created = createBatchManual(db, {
+      variantId,
+      prepStateId: null,
+      qty: 200,
+      unit: 'g',
+      location: 'fridge',
+      sourceType: 'purchase',
+      producedAt: '2026-06-05T00:00:00.000Z',
+    });
+    if (!created.ok) throw new Error('seed failed');
+    editBatch(db, created.batchId, { expiresAt: null });
+    const row = db.select().from(batches).where(eq(batches.id, created.batchId)).get();
+    expect(row?.expiresAt).toBeNull();
+  });
+
+  it('overwrites notes verbatim (no audit append)', () => {
+    const created = createBatchManual(db, {
+      variantId,
+      prepStateId: null,
+      qty: 200,
+      unit: 'g',
+      location: 'fridge',
+      sourceType: 'purchase',
+      notes: 'first',
+    });
+    if (!created.ok) throw new Error('seed failed');
+    editBatch(db, created.batchId, { notes: 'second' });
+    const row = db.select().from(batches).where(eq(batches.id, created.batchId)).get();
+    expect(row?.notes).toBe('second');
+  });
+});
+
+describe('PRD-145 — adjustBatchQty', () => {
+  let db: FoodDb;
+  let variantId: number;
+
+  beforeEach(() => {
+    db = freshDb();
+    ({ variantId } = seedFridgeFreezerVariant(db));
+  });
+
+  function seedBatch(qty: number): number {
+    const result = createBatchManual(db, {
+      variantId,
+      prepStateId: null,
+      qty,
+      unit: 'g',
+      location: 'fridge',
+      sourceType: 'purchase',
+    });
+    if (!result.ok) throw new Error('seed failed');
+    return result.batchId;
+  }
+
+  it('decrements qty for spoiled with negative delta', () => {
+    const id = seedBatch(500);
+    const result = adjustBatchQty(db, id, -200, 'spoiled');
+    expect(result).toEqual({ ok: true, newQty: 300 });
+    const row = db.select().from(batches).where(eq(batches.id, id)).get();
+    expect(row?.notes).toMatch(/Spoiled 200g/);
+  });
+
+  it('rejects BadAdjustment when spoiled paired with positive delta', () => {
+    const id = seedBatch(500);
+    expect(adjustBatchQty(db, id, 50, 'spoiled')).toEqual({
+      ok: false,
+      reason: 'BadAdjustment',
+    });
+  });
+
+  it('rejects BadAdjustment when wasted paired with zero delta', () => {
+    const id = seedBatch(500);
+    expect(adjustBatchQty(db, id, 0, 'wasted')).toEqual({
+      ok: false,
+      reason: 'BadAdjustment',
+    });
+  });
+
+  it('accepts positive correction (found more in the back)', () => {
+    const id = seedBatch(500);
+    const result = adjustBatchQty(db, id, 50, 'correction');
+    expect(result).toEqual({ ok: true, newQty: 550 });
+  });
+
+  it('rejects NegativeQty when delta would push below zero', () => {
+    const id = seedBatch(200);
+    expect(adjustBatchQty(db, id, -300, 'wasted')).toEqual({
+      ok: false,
+      reason: 'NegativeQty',
+    });
+  });
+
+  it('handles zero delta as a no-op', () => {
+    const id = seedBatch(200);
+    const result = adjustBatchQty(db, id, 0, 'correction');
+    expect(result).toEqual({ ok: true, newQty: 200 });
+  });
+
+  it('rejects BatchDeleted for soft-deleted batches', () => {
+    const id = seedBatch(200);
+    deleteBatch(db, id);
+    expect(adjustBatchQty(db, id, -50, 'spoiled')).toEqual({
+      ok: false,
+      reason: 'BatchDeleted',
+    });
+  });
+});
+
+describe('PRD-145 — deleteBatch + invariant', () => {
+  let db: FoodDb;
+
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('sets qty_remaining=0 and deleted_at atomically', () => {
+    const { variantId } = seedFridgeFreezerVariant(db);
+    const created = createBatchManual(db, {
+      variantId,
+      prepStateId: null,
+      qty: 250,
+      unit: 'g',
+      location: 'fridge',
+      sourceType: 'purchase',
+    });
+    if (!created.ok) throw new Error('seed failed');
+    const result = deleteBatch(db, created.batchId);
+    expect(result).toEqual({ ok: true });
+    const row = db.select().from(batches).where(eq(batches.id, created.batchId)).get();
+    expect(row?.qtyRemaining).toBe(0);
+    expect(row?.deletedAt).not.toBeNull();
+  });
+
+  it('subsequent FIFO consumption skips a deleted batch', () => {
+    const { variantId, recipeVersionId } = seedFridgeFreezerVariant(db);
+    const a = createBatchManual(db, {
+      variantId,
+      prepStateId: null,
+      qty: 300,
+      unit: 'g',
+      location: 'fridge',
+      sourceType: 'purchase',
+      producedAt: '2026-06-01T00:00:00.000Z',
+      expiresAt: '2026-06-05T00:00:00.000Z',
+    });
+    const b = createBatchManual(db, {
+      variantId,
+      prepStateId: null,
+      qty: 300,
+      unit: 'g',
+      location: 'fridge',
+      sourceType: 'purchase',
+      producedAt: '2026-06-02T00:00:00.000Z',
+      expiresAt: '2026-06-06T00:00:00.000Z',
+    });
+    if (!a.ok || !b.ok) throw new Error('seed failed');
+    deleteBatch(db, a.batchId);
+    const run = createRun(db, { recipeVersionId });
+    const result = consumeForRun(db, run.id, [
+      { variantId, prepStateId: null, qty: 200, canonicalUnit: 'g' },
+    ]);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // The single consumption row should target the non-deleted batch b.
+    expect(result.consumptions.map((c) => c.batchId)).toEqual([b.batchId]);
+  });
+
+  it('rejects subsequent delete on an already-deleted batch', () => {
+    const { variantId } = seedFridgeFreezerVariant(db);
+    const created = createBatchManual(db, {
+      variantId,
+      prepStateId: null,
+      qty: 100,
+      unit: 'g',
+      location: 'fridge',
+      sourceType: 'purchase',
+    });
+    if (!created.ok) throw new Error('seed failed');
+    deleteBatch(db, created.batchId);
+    expect(deleteBatch(db, created.batchId)).toEqual({ ok: false, reason: 'BatchDeleted' });
+  });
+});
+
+describe('PRD-145 — notes audit-trail truncation', () => {
+  it('front-truncates to 500 chars with leading ellipsis when overflowing', () => {
+    const db = freshDb();
+    const { variantId } = seedFridgeFreezerVariant(db);
+    const created = createBatchManual(db, {
+      variantId,
+      prepStateId: null,
+      qty: 1000,
+      unit: 'g',
+      location: 'fridge',
+      sourceType: 'purchase',
+      notes: 'x'.repeat(490),
+    });
+    if (!created.ok) throw new Error('seed failed');
+    relocateBatch(db, created.batchId, 'freezer');
+    relocateBatch(db, created.batchId, 'pantry');
+    const row = db.select().from(batches).where(eq(batches.id, created.batchId)).get();
+    expect(row?.notes ?? '').toHaveLength(500);
+    expect(row?.notes?.startsWith('…')).toBe(true);
+  });
+});
+
+afterAll(() => {
+  if (lastDb === null) return;
+  expect(countDeletedInvariantViolations(lastDb)).toBe(0);
+});

--- a/packages/app-food-db/src/__tests__/batches.test.ts
+++ b/packages/app-food-db/src/__tests__/batches.test.ts
@@ -25,6 +25,7 @@ const MIGRATIONS = [
   '0058_high_sentinel.sql',
   '0059_useful_hiroim.sql',
   '0060_familiar_leo.sql',
+  '0069_prd_145_batches_deleted_at.sql',
 ].map((name) =>
   readFileSync(join(__dirname, '../../../../apps/pops-api/src/db/drizzle-migrations', name), 'utf8')
 );

--- a/packages/app-food-db/src/__tests__/ingest-sources-model.test.ts
+++ b/packages/app-food-db/src/__tests__/ingest-sources-model.test.ts
@@ -28,6 +28,8 @@ const MIGRATIONS = [
   '0067_prd_125_ingest_error_columns.sql',
   // PRD-136 amendment — reviewed_at column on ingest_sources.
   '0068_prd_136_inbox_review.sql',
+  // PRD-145 — batches.deleted_at soft-delete column.
+  '0069_prd_145_batches_deleted_at.sql',
 ].map((name) =>
   readFileSync(join(__dirname, '../../../../apps/pops-api/src/db/drizzle-migrations', name), 'utf8')
 );

--- a/packages/app-food-db/src/__tests__/seed.test.ts
+++ b/packages/app-food-db/src/__tests__/seed.test.ts
@@ -51,6 +51,7 @@ const MIGRATIONS = [
   '0066_prd_123_conversions.sql', // PRD-123 unit_conversions + ingredient_weights
   '0067_prd_125_ingest_error_columns.sql', // PRD-125 error_code/message/attempts on ingest_sources
   '0068_prd_136_inbox_review.sql', // PRD-136 recipe_version_rejections + ingest_sources.reviewed_at
+  '0069_prd_145_batches_deleted_at.sql', // PRD-145 batches.deleted_at soft-delete column
 ].map((name) =>
   readFileSync(join(__dirname, '../../../../apps/pops-api/src/db/drizzle-migrations', name), 'utf8')
 );

--- a/packages/app-food-db/src/index.ts
+++ b/packages/app-food-db/src/index.ts
@@ -24,6 +24,7 @@ export { MAX_INGREDIENT_DEPTH } from './services/internal.js';
 export * as aliasesService from './services/aliases.js';
 export * as aliasesQueries from './services/aliases-queries.js';
 export * as batchesService from './services/batches.js';
+export * as batchesLifecycleService from './services/batches-lifecycle.js';
 export * as ingestSourcesService from './services/ingest-sources.js';
 export * as inboxService from './services/inbox.js';
 export * as ingredientsService from './services/ingredients.js';

--- a/packages/app-food-db/src/services/batches-lifecycle-helpers.ts
+++ b/packages/app-food-db/src/services/batches-lifecycle-helpers.ts
@@ -1,0 +1,90 @@
+/**
+ * PRD-145 internal helpers split out of `batches-lifecycle.ts` to keep
+ * the main service file under the 200-line per-file lint cap. Not part
+ * of the public surface — re-export via the package barrel is
+ * intentionally absent.
+ */
+import { eq } from 'drizzle-orm';
+
+import { ingredientVariants } from '../schema.js';
+import { type FoodDb } from './internal.js';
+
+import type { BatchAdjustReason, BatchLocation, BatchUnit } from '../types/batches.js';
+
+/** Max length of the `notes` column we preserve before front-truncating. */
+const NOTES_MAX_CHARS = 500;
+
+/**
+ * Resolve the auto-default `expires_at` for a (variant, location) pair.
+ * Returns null when the variant has no shelf-life days configured for
+ * that location (shelf-stable) or when the variant doesn't exist.
+ *
+ * Shared between `createBatchManual` and `relocateBatch`'s override
+ * detection.
+ */
+export function deriveAutoDefaultExpiry(
+  db: FoodDb,
+  variantId: number,
+  location: BatchLocation,
+  producedAt: string
+): string | null {
+  if (location === 'pantry' || location === 'other') return null;
+  const variantRows = db
+    .select({
+      fridge: ingredientVariants.defaultShelfLifeDaysFridge,
+      freezer: ingredientVariants.defaultShelfLifeDaysFreezer,
+    })
+    .from(ingredientVariants)
+    .where(eq(ingredientVariants.id, variantId))
+    .all();
+  const variant = variantRows[0];
+  if (variant === undefined) return null;
+  const days = location === 'fridge' ? variant.fridge : variant.freezer;
+  if (days === null) return null;
+  return addDays(producedAt, days);
+}
+
+/**
+ * Add whole days to an ISO timestamp. Uses UTC arithmetic so the
+ * midnight-boundary tests pin deterministically across timezones.
+ */
+function addDays(iso: string, days: number): string {
+  const base = new Date(iso);
+  base.setUTCDate(base.getUTCDate() + days);
+  return base.toISOString();
+}
+
+/**
+ * Today's date as `YYYY-MM-DD`. Used in audit-trail notes appended by
+ * relocate / adjust. Date-only (no time) keeps the trail readable.
+ */
+export function today(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+/**
+ * Append `line` to `existing` notes, separated by a newline, then
+ * truncate from the front (so the most recent audit line is preserved)
+ * if the combined length exceeds the 500-char cap. Front-truncation is
+ * signalled with a leading `…`.
+ */
+export function appendAuditNote(existing: string | null, line: string): string {
+  const combined = existing === null || existing.length === 0 ? line : `${existing}\n${line}`;
+  if (combined.length <= NOTES_MAX_CHARS) return combined;
+  const overflow = combined.length - NOTES_MAX_CHARS + 1;
+  return `…${combined.slice(overflow)}`;
+}
+
+export function describeAdjust(reason: BatchAdjustReason, delta: number, unit: BatchUnit): string {
+  const abs = Math.abs(delta);
+  switch (reason) {
+    case 'spoiled':
+      return `Spoiled ${abs}${unit} on ${today()}`;
+    case 'wasted':
+      return `Wasted ${abs}${unit} on ${today()} (e.g. burnt, dropped)`;
+    case 'correction': {
+      const sign = delta >= 0 ? '+' : '-';
+      return `Adjusted by ${sign}${abs}${unit} on ${today()} (correction)`;
+    }
+  }
+}

--- a/packages/app-food-db/src/services/batches-lifecycle-helpers.ts
+++ b/packages/app-food-db/src/services/batches-lifecycle-helpers.ts
@@ -45,13 +45,42 @@ export function deriveAutoDefaultExpiry(
 }
 
 /**
- * Add whole days to an ISO timestamp. Uses UTC arithmetic so the
- * midnight-boundary tests pin deterministically across timezones.
+ * Add whole days to an ISO timestamp. UTC arithmetic — the service
+ * trades in instants, not local-zone calendar dates; the UI is
+ * responsible for any presentation-time zone conversion. Pinned by
+ * the midnight-UTC boundary test in `batches-lifecycle.test.ts`.
+ *
+ * (PRD-145 originally mentioned `date-fns` + local-zone math; the
+ * implementation follows PRD-108's existing UTC contract so all
+ * shelf-life-derived expiries stay consistent across services.)
  */
 function addDays(iso: string, days: number): string {
   const base = new Date(iso);
   base.setUTCDate(base.getUTCDate() + days);
   return base.toISOString();
+}
+
+/**
+ * `a < b` for two ISO datetime strings. Parsing through `Date.parse`
+ * avoids the lexicographic-comparison footgun when one side carries
+ * milliseconds / a different offset and the other doesn't (e.g.
+ * `'2026-06-01T00:00:00Z' < '2026-06-01T00:00:00.000Z'` is true as
+ * strings but false as instants).
+ */
+export function isBefore(a: string, b: string): boolean {
+  return Date.parse(a) < Date.parse(b);
+}
+
+/**
+ * Strict-equal-as-instants. Both nulls match; one null and one ISO do
+ * not. Used by `relocateBatch` to detect a user-overridden expiry vs
+ * an auto-default value (different ISO formatting must not look like
+ * an override).
+ */
+export function isSameInstant(a: string | null, b: string | null): boolean {
+  if (a === null && b === null) return true;
+  if (a === null || b === null) return false;
+  return Date.parse(a) === Date.parse(b);
 }
 
 /**

--- a/packages/app-food-db/src/services/batches-lifecycle.ts
+++ b/packages/app-food-db/src/services/batches-lifecycle.ts
@@ -11,6 +11,8 @@ import {
   appendAuditNote,
   deriveAutoDefaultExpiry,
   describeAdjust,
+  isBefore,
+  isSameInstant,
   today,
 } from './batches-lifecycle-helpers.js';
 import { type FoodDb, expectRow } from './internal.js';
@@ -59,7 +61,7 @@ export function createBatchManual(
     input.expiresAt !== undefined
       ? input.expiresAt
       : deriveAutoDefaultExpiry(db, input.variantId, input.location, producedAt);
-  if (expiresAt !== null && expiresAt < producedAt) {
+  if (expiresAt !== null && isBefore(expiresAt, producedAt)) {
     return { ok: false, reason: 'BadExpiry' };
   }
   const rows = db
@@ -91,49 +93,52 @@ export function relocateBatch(
   batchId: number,
   newLocation: BatchLocation
 ): BatchMutationResult {
-  const batch = loadBatch(db, batchId);
-  if (batch === null) return { ok: false, reason: 'BatchNotFound' };
-  if (batch.deletedAt !== null) return { ok: false, reason: 'BatchDeleted' };
+  return db.transaction((tx) => {
+    const batch = loadBatch(tx, batchId);
+    if (batch === null) return { ok: false, reason: 'BatchNotFound' };
+    if (batch.deletedAt !== null) return { ok: false, reason: 'BatchDeleted' };
 
-  const previousAutoExpiry = deriveAutoDefaultExpiry(
-    db,
-    batch.variantId,
-    batch.location,
-    batch.producedAt
-  );
-  const nextExpiry =
-    batch.expiresAt === previousAutoExpiry
-      ? deriveAutoDefaultExpiry(db, batch.variantId, newLocation, batch.producedAt)
+    const previousAutoExpiry = deriveAutoDefaultExpiry(
+      tx,
+      batch.variantId,
+      batch.location,
+      batch.producedAt
+    );
+    const nextExpiry = isSameInstant(batch.expiresAt, previousAutoExpiry)
+      ? deriveAutoDefaultExpiry(tx, batch.variantId, newLocation, batch.producedAt)
       : batch.expiresAt;
-  const nextNotes = appendAuditNote(batch.notes, `Moved to ${newLocation} on ${today()}`);
+    const nextNotes = appendAuditNote(batch.notes, `Moved to ${newLocation} on ${today()}`);
 
-  db.update(batches)
-    .set({ location: newLocation, expiresAt: nextExpiry, notes: nextNotes })
-    .where(eq(batches.id, batchId))
-    .run();
-  return { ok: true };
+    tx.update(batches)
+      .set({ location: newLocation, expiresAt: nextExpiry, notes: nextNotes })
+      .where(eq(batches.id, batchId))
+      .run();
+    return { ok: true };
+  });
 }
 
 /** `prep_state_id` is forbidden on cook-yielded batches (pinned to recipe yield). */
 export function editBatch(db: FoodDb, batchId: number, patch: BatchEditPatch): BatchMutationResult {
-  const batch = loadBatch(db, batchId);
-  if (batch === null) return { ok: false, reason: 'BatchNotFound' };
-  if (batch.deletedAt !== null) return { ok: false, reason: 'BatchDeleted' };
-  if (patch.prepStateId !== undefined && batch.sourceType === 'recipe_run') {
-    return { ok: false, reason: 'CannotEditFromRun' };
-  }
-  if (
-    patch.expiresAt !== undefined &&
-    patch.expiresAt !== null &&
-    patch.expiresAt < batch.producedAt
-  ) {
-    return { ok: false, reason: 'BadExpiry' };
-  }
+  return db.transaction((tx) => {
+    const batch = loadBatch(tx, batchId);
+    if (batch === null) return { ok: false, reason: 'BatchNotFound' };
+    if (batch.deletedAt !== null) return { ok: false, reason: 'BatchDeleted' };
+    if (patch.prepStateId !== undefined && batch.sourceType === 'recipe_run') {
+      return { ok: false, reason: 'CannotEditFromRun' };
+    }
+    if (
+      patch.expiresAt !== undefined &&
+      patch.expiresAt !== null &&
+      isBefore(patch.expiresAt, batch.producedAt)
+    ) {
+      return { ok: false, reason: 'BadExpiry' };
+    }
 
-  const updates = buildEditUpdates(patch);
-  if (Object.keys(updates).length === 0) return { ok: true };
-  db.update(batches).set(updates).where(eq(batches.id, batchId)).run();
-  return { ok: true };
+    const updates = buildEditUpdates(patch);
+    if (Object.keys(updates).length === 0) return { ok: true };
+    tx.update(batches).set(updates).where(eq(batches.id, batchId)).run();
+    return { ok: true };
+  });
 }
 
 function buildEditUpdates(patch: BatchEditPatch): Partial<{
@@ -162,22 +167,24 @@ export function adjustBatchQty(
   delta: number,
   reason: BatchAdjustReason
 ): BatchAdjustResult {
-  const batch = loadBatch(db, batchId);
-  if (batch === null) return { ok: false, reason: 'BatchNotFound' };
-  if (batch.deletedAt !== null) return { ok: false, reason: 'BatchDeleted' };
-  if ((reason === 'spoiled' || reason === 'wasted') && delta >= 0) {
-    return { ok: false, reason: 'BadAdjustment' };
-  }
-  const newQty = batch.qtyRemaining + delta;
-  if (newQty < 0) return { ok: false, reason: 'NegativeQty' };
-  if (delta === 0) return { ok: true, newQty: batch.qtyRemaining };
+  return db.transaction((tx) => {
+    const batch = loadBatch(tx, batchId);
+    if (batch === null) return { ok: false, reason: 'BatchNotFound' };
+    if (batch.deletedAt !== null) return { ok: false, reason: 'BatchDeleted' };
+    if ((reason === 'spoiled' || reason === 'wasted') && delta >= 0) {
+      return { ok: false, reason: 'BadAdjustment' };
+    }
+    const newQty = batch.qtyRemaining + delta;
+    if (newQty < 0) return { ok: false, reason: 'NegativeQty' };
+    if (delta === 0) return { ok: true, newQty: batch.qtyRemaining };
 
-  const nextNotes = appendAuditNote(batch.notes, describeAdjust(reason, delta, batch.unit));
-  db.update(batches)
-    .set({ qtyRemaining: newQty, notes: nextNotes })
-    .where(eq(batches.id, batchId))
-    .run();
-  return { ok: true, newQty };
+    const nextNotes = appendAuditNote(batch.notes, describeAdjust(reason, delta, batch.unit));
+    tx.update(batches)
+      .set({ qtyRemaining: newQty, notes: nextNotes })
+      .where(eq(batches.id, batchId))
+      .run();
+    return { ok: true, newQty };
+  });
 }
 
 /**
@@ -185,14 +192,16 @@ export function adjustBatchQty(
  * holds at every observable point. Hard delete is never exposed.
  */
 export function deleteBatch(db: FoodDb, batchId: number): BatchMutationResult {
-  const batch = loadBatch(db, batchId);
-  if (batch === null) return { ok: false, reason: 'BatchNotFound' };
-  if (batch.deletedAt !== null) return { ok: false, reason: 'BatchDeleted' };
-  db.update(batches)
-    .set({ qtyRemaining: 0, deletedAt: new Date().toISOString() })
-    .where(eq(batches.id, batchId))
-    .run();
-  return { ok: true };
+  return db.transaction((tx) => {
+    const batch = loadBatch(tx, batchId);
+    if (batch === null) return { ok: false, reason: 'BatchNotFound' };
+    if (batch.deletedAt !== null) return { ok: false, reason: 'BatchDeleted' };
+    tx.update(batches)
+      .set({ qtyRemaining: 0, deletedAt: new Date().toISOString() })
+      .where(eq(batches.id, batchId))
+      .run();
+    return { ok: true };
+  });
 }
 
 function loadBatch(db: FoodDb, batchId: number): BatchRow | null {

--- a/packages/app-food-db/src/services/batches-lifecycle.ts
+++ b/packages/app-food-db/src/services/batches-lifecycle.ts
@@ -1,0 +1,211 @@
+/**
+ * PRD-145 — batch lifecycle services. Companion `batches.ts` owns
+ * PRD-108's `consumeForRun` (FIFO drain); this file owns every other
+ * batch mutation plus `createBatchFromRun`, which wraps PRD-108's
+ * `markRunComplete` so PRD-144 has one batch-creation entry point.
+ */
+import { and, eq, gt, isNotNull } from 'drizzle-orm';
+
+import { batches, type BatchRow } from '../schema.js';
+import {
+  appendAuditNote,
+  deriveAutoDefaultExpiry,
+  describeAdjust,
+  today,
+} from './batches-lifecycle-helpers.js';
+import { type FoodDb, expectRow } from './internal.js';
+import { markRunComplete, type YieldArgs as RecipeRunYieldArgs } from './recipe-runs.js';
+
+import type {
+  BatchAdjustReason,
+  BatchAdjustResult,
+  BatchEditPatch,
+  BatchError,
+  BatchLocation,
+  BatchMutationResult,
+  ManualBatchInput,
+  YieldArgs,
+} from '../types/batches.js';
+
+/** Yieldless cooks pass `null` and get `batchId: null` back. */
+export function createBatchFromRun(
+  db: FoodDb,
+  runId: number,
+  yieldArgs: YieldArgs | null
+): { batchId: number | null } {
+  const opts = yieldArgs === null ? {} : { yield: toRecipeRunYieldArgs(yieldArgs) };
+  const result = markRunComplete(db, runId, opts);
+  return { batchId: result.yieldedBatch?.id ?? null };
+}
+
+function toRecipeRunYieldArgs(y: YieldArgs): RecipeRunYieldArgs {
+  return {
+    variantId: y.variantId,
+    prepStateId: y.prepStateId,
+    qty: y.qty,
+    unit: y.unit,
+    location: y.location,
+    expiresAt: y.expiresAt,
+    notes: y.notes,
+  };
+}
+
+export function createBatchManual(
+  db: FoodDb,
+  input: ManualBatchInput
+): { ok: true; batchId: number } | { ok: false; reason: BatchError } {
+  const producedAt = input.producedAt ?? new Date().toISOString();
+  const expiresAt =
+    input.expiresAt !== undefined
+      ? input.expiresAt
+      : deriveAutoDefaultExpiry(db, input.variantId, input.location, producedAt);
+  if (expiresAt !== null && expiresAt < producedAt) {
+    return { ok: false, reason: 'BadExpiry' };
+  }
+  const rows = db
+    .insert(batches)
+    .values({
+      variantId: input.variantId,
+      prepStateId: input.prepStateId,
+      qtyRemaining: input.qty,
+      unit: input.unit,
+      sourceType: input.sourceType,
+      sourceId: null,
+      location: input.location,
+      producedAt,
+      expiresAt,
+      notes: input.notes ?? null,
+    })
+    .returning()
+    .all();
+  return { ok: true, batchId: expectRow(rows, 'createBatchManual').id };
+}
+
+/**
+ * Recomputes expiry only when the stored value matches the
+ * previous-location auto-default — otherwise the user's override is
+ * preserved. Appends "Moved to <location> on <date>" to notes.
+ */
+export function relocateBatch(
+  db: FoodDb,
+  batchId: number,
+  newLocation: BatchLocation
+): BatchMutationResult {
+  const batch = loadBatch(db, batchId);
+  if (batch === null) return { ok: false, reason: 'BatchNotFound' };
+  if (batch.deletedAt !== null) return { ok: false, reason: 'BatchDeleted' };
+
+  const previousAutoExpiry = deriveAutoDefaultExpiry(
+    db,
+    batch.variantId,
+    batch.location,
+    batch.producedAt
+  );
+  const nextExpiry =
+    batch.expiresAt === previousAutoExpiry
+      ? deriveAutoDefaultExpiry(db, batch.variantId, newLocation, batch.producedAt)
+      : batch.expiresAt;
+  const nextNotes = appendAuditNote(batch.notes, `Moved to ${newLocation} on ${today()}`);
+
+  db.update(batches)
+    .set({ location: newLocation, expiresAt: nextExpiry, notes: nextNotes })
+    .where(eq(batches.id, batchId))
+    .run();
+  return { ok: true };
+}
+
+/** `prep_state_id` is forbidden on cook-yielded batches (pinned to recipe yield). */
+export function editBatch(db: FoodDb, batchId: number, patch: BatchEditPatch): BatchMutationResult {
+  const batch = loadBatch(db, batchId);
+  if (batch === null) return { ok: false, reason: 'BatchNotFound' };
+  if (batch.deletedAt !== null) return { ok: false, reason: 'BatchDeleted' };
+  if (patch.prepStateId !== undefined && batch.sourceType === 'recipe_run') {
+    return { ok: false, reason: 'CannotEditFromRun' };
+  }
+  if (
+    patch.expiresAt !== undefined &&
+    patch.expiresAt !== null &&
+    patch.expiresAt < batch.producedAt
+  ) {
+    return { ok: false, reason: 'BadExpiry' };
+  }
+
+  const updates = buildEditUpdates(patch);
+  if (Object.keys(updates).length === 0) return { ok: true };
+  db.update(batches).set(updates).where(eq(batches.id, batchId)).run();
+  return { ok: true };
+}
+
+function buildEditUpdates(patch: BatchEditPatch): Partial<{
+  expiresAt: string | null;
+  notes: string | null;
+  prepStateId: number | null;
+}> {
+  const updates: Partial<{
+    expiresAt: string | null;
+    notes: string | null;
+    prepStateId: number | null;
+  }> = {};
+  if (patch.expiresAt !== undefined) updates.expiresAt = patch.expiresAt;
+  if (patch.notes !== undefined) updates.notes = patch.notes;
+  if (patch.prepStateId !== undefined) updates.prepStateId = patch.prepStateId;
+  return updates;
+}
+
+/**
+ * `spoiled` / `wasted` require `delta < 0`; `correction` accepts any
+ * sign. Rejects pushing qty below zero. Audit line appended to notes.
+ */
+export function adjustBatchQty(
+  db: FoodDb,
+  batchId: number,
+  delta: number,
+  reason: BatchAdjustReason
+): BatchAdjustResult {
+  const batch = loadBatch(db, batchId);
+  if (batch === null) return { ok: false, reason: 'BatchNotFound' };
+  if (batch.deletedAt !== null) return { ok: false, reason: 'BatchDeleted' };
+  if ((reason === 'spoiled' || reason === 'wasted') && delta >= 0) {
+    return { ok: false, reason: 'BadAdjustment' };
+  }
+  const newQty = batch.qtyRemaining + delta;
+  if (newQty < 0) return { ok: false, reason: 'NegativeQty' };
+  if (delta === 0) return { ok: true, newQty: batch.qtyRemaining };
+
+  const nextNotes = appendAuditNote(batch.notes, describeAdjust(reason, delta, batch.unit));
+  db.update(batches)
+    .set({ qtyRemaining: newQty, notes: nextNotes })
+    .where(eq(batches.id, batchId))
+    .run();
+  return { ok: true, newQty };
+}
+
+/**
+ * One UPDATE so the invariant `deleted_at IS NOT NULL → qty_remaining = 0`
+ * holds at every observable point. Hard delete is never exposed.
+ */
+export function deleteBatch(db: FoodDb, batchId: number): BatchMutationResult {
+  const batch = loadBatch(db, batchId);
+  if (batch === null) return { ok: false, reason: 'BatchNotFound' };
+  if (batch.deletedAt !== null) return { ok: false, reason: 'BatchDeleted' };
+  db.update(batches)
+    .set({ qtyRemaining: 0, deletedAt: new Date().toISOString() })
+    .where(eq(batches.id, batchId))
+    .run();
+  return { ok: true };
+}
+
+function loadBatch(db: FoodDb, batchId: number): BatchRow | null {
+  const rows = db.select().from(batches).where(eq(batches.id, batchId)).all();
+  return rows[0] ?? null;
+}
+
+/** Test-only invariant scan (PRD-145 AC: post-suite check). */
+export function countDeletedInvariantViolations(db: FoodDb): number {
+  const rows = db
+    .select({ id: batches.id })
+    .from(batches)
+    .where(and(isNotNull(batches.deletedAt), gt(batches.qtyRemaining, 0)))
+    .all();
+  return rows.length;
+}

--- a/packages/app-food/src/__tests__/seed-phase-2.test.ts
+++ b/packages/app-food/src/__tests__/seed-phase-2.test.ts
@@ -54,6 +54,8 @@ const MIGRATIONS = [
   '0067_prd_125_ingest_error_columns.sql',
   // PRD-136 amendment — reviewed_at column on ingest_sources.
   '0068_prd_136_inbox_review.sql',
+  // PRD-145 — batches.deleted_at soft-delete column.
+  '0069_prd_145_batches_deleted_at.sql',
 ].map((name) =>
   readFileSync(join(__dirname, '../../../../apps/pops-api/src/db/drizzle-migrations', name), 'utf8')
 );

--- a/packages/app-food/src/jobs/__tests__/ingest-eviction.test.ts
+++ b/packages/app-food/src/jobs/__tests__/ingest-eviction.test.ts
@@ -31,6 +31,8 @@ const MIGRATIONS = [
   '0067_prd_125_ingest_error_columns.sql',
   // PRD-136 amendment — reviewed_at column on ingest_sources.
   '0068_prd_136_inbox_review.sql',
+  // PRD-145 — batches.deleted_at soft-delete column.
+  '0069_prd_145_batches_deleted_at.sql',
 ].map((name) =>
   readFileSync(
     join(__dirname, '../../../../../apps/pops-api/src/db/drizzle-migrations', name),

--- a/packages/db-types/src/schema/food-batches.ts
+++ b/packages/db-types/src/schema/food-batches.ts
@@ -32,6 +32,13 @@ export const batches = sqliteTable(
     producedAt: text('produced_at').notNull(),
     expiresAt: text('expires_at'),
     notes: text('notes'),
+    /**
+     * PRD-145 — soft-delete timestamp. Set ONLY by `deleteBatch`; every
+     * row with `deleted_at IS NOT NULL` also has `qty_remaining = 0`
+     * (service-enforced invariant). PRD-108's FIFO `consumeForRun`
+     * naturally skips deleted rows via the `qty_remaining > 0` filter.
+     */
+    deletedAt: text('deleted_at'),
     createdAt: text('created_at')
       .notNull()
       .default(sql`(datetime('now'))`),


### PR DESCRIPTION
## Summary

First behaviour PR in the post-I5-prep cadence (145 → (144 ∥ 146) → 143 ∥ 147). Replaces the I5-prep `NOT_IMPLEMENTED` stubs for `food.batches.create` / `get` / `relocate` / `edit` / `adjustQty` / `delete` with real implementations. `searchForConsume` stays a scaffold (PRD-146).

- **Service layer** lands in `@pops/app-food-db` as `batches-lifecycle.ts` (+ `batches-lifecycle-helpers.ts` for the audit-trail + expiry-resolver helpers, keeping each file under the 200-line oxlint cap). Six entry points: `createBatchFromRun` (wraps PRD-108's `markRunComplete(opts.yield)` 1:1 so PRD-144 has one batch-creation contract), `createBatchManual`, `relocateBatch`, `editBatch`, `adjustBatchQty`, `deleteBatch`.
- **Schema delta** — migration `0069_prd_145_batches_deleted_at.sql` adds `batches.deleted_at TEXT NULL`. PRD-108's FIFO `consumeForRun` naturally skips deleted rows via the existing `qty_remaining > 0` filter; no index changes.
- **Service invariant** `deleted_at IS NOT NULL → qty_remaining = 0` enforced by `deleteBatch` setting both columns atomically + every other writer rejecting `BatchDeleted`. Pinned by a post-suite `afterAll` scan in the Vitest suite.
- **Router** — `food.batches.get` returns the joined `BatchDetail` (ingredient + variant + prep-state names + recipe slug for `recipe_run`-sourced batches) via a small `get.ts` helper.

## Acceptance criteria

- [x] Migration adds `batches.deleted_at TEXT NULL`.
- [x] Six service functions exported from `@pops/app-food-db` (`createBatchFromRun`, `createBatchManual`, `relocateBatch`, `editBatch`, `adjustBatchQty`, `deleteBatch`).
- [x] `createBatchFromRun` calls PRD-108's `markRunComplete` exactly once with the `opts.yield` shape.
- [x] `createBatchManual` resolves default expiry via the shelf-life formula; allows override; rejects `BadExpiry` when override < producedAt.
- [x] `relocateBatch` recomputes expiry only when the previous value matches the previous-location auto-default.
- [x] `editBatch` rejects `CannotEditFromRun` for `prep_state_id` edits on recipe_run-sourced batches.
- [x] `adjustBatchQty` rejects `NegativeQty` when the delta pushes below 0; `BadAdjustment` when `spoiled`/`wasted` is paired with non-negative delta.
- [x] `deleteBatch` sets `qty_remaining=0` AND `deleted_at` in one UPDATE.
- [x] tRPC procedures wired transactionally; mutation errors surfaced as discriminated `{ ok: false, reason }` (`create` throws TRPC `BAD_REQUEST` so the structured error surfaces in the toast).
- [x] `food.batches.get` returns the joined `BatchDetail` incl. resolved variant / ingredient / prep-state / recipe-slug names.
- [x] PRD-108's FIFO `consumeForRun` skips deleted batches (regression covered in `batches-lifecycle.test.ts`).
- [x] PRD-108's `recipe_runs.yielded_batch_id` set by `createBatchFromRun` the way `markRunComplete` did before (single-owner centralisation).
- [x] Vitest invariant scan asserts `deleted_at IS NOT NULL ∧ qty_remaining > 0` count is 0.

## Test plan

- [x] `packages/app-food-db/src/__tests__/batches-lifecycle.test.ts` — 29 cases covering every service entry point, every error branch, midnight-UTC boundary, 500-char notes truncation, and the post-suite `afterAll` invariant scan.
- [x] `apps/pops-api/src/modules/food/__tests__/batches-router.test.ts` — 19 cases covering the tRPC boundary for every procedure incl. joined `BatchDetail` resolution.
- [x] Migration list extended in the 8 test files PRD-136 touched.
- [x] Existing PRD-108 (`batches.test.ts`) + scaffold (`cook-plan-fridge-scaffold.test.ts`) suites updated to drop the now-implemented procedures from the `NOT_IMPLEMENTED` allowlist.
- [x] `pnpm typecheck` clean (33/33).
- [x] `pnpm -C apps/pops-api test` 4695/4695. `pnpm -C apps/pops-api test:integration` 81/81.
- [x] `pnpm -C packages/app-food-db test` 331/331.
- [x] `pnpm -C apps/pops-api build` + `openapi:validate` clean.