### PR TITLE
feat(food): PRD-138 part A — inbox listRejected + listFailed queries

### DIFF
--- a/apps/pops-api/src/modules/food/__tests__/inbox-list-rejected-failed.test.ts
+++ b/apps/pops-api/src/modules/food/__tests__/inbox-list-rejected-failed.test.ts
@@ -1,0 +1,345 @@
+/**
+ * PRD-138 part A — integration tests for the inbox list queries.
+ *
+ *   - `listRejected` — filters by reason / kind / sinceDays; excludes
+ *                       PRD-119-discarded archives (no rejections row);
+ *                       cursor pagination ordering.
+ *   - `listFailed`   — excludes sources whose latest meta is `ok: true`,
+ *                       including auth-dead partial drafts (PRD-130).
+ *
+ * Unreject coverage lives in `inbox-router.test.ts` (PRD-136). This file
+ * carries the PRD-138 surface only.
+ *
+ * In-memory SQLite seeded with the same drizzle migration set the existing
+ * food integration tests use; BullMQ is irrelevant here so no queue mocks
+ * are needed (the inbox router never touches the queue).
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import BetterSqlite3, { type Database } from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { closeDb, setDb } from '../../../db.js';
+import { createCaller } from '../../../shared/test-utils.js';
+
+const FOOD_MIGRATIONS = [
+  // PRD-138's `listRejected` joins to `ai_inference_log` for per-source
+  // cost rollup; the table lives in the ai-observability module's migration.
+  '0045_ai_inference_log.sql',
+  '0058_high_sentinel.sql',
+  '0059_useful_hiroim.sql',
+  '0060_familiar_leo.sql',
+  '0061_shocking_skreet.sql',
+  '0062_chemical_donald_blake.sql',
+  '0063_bumpy_wolverine.sql',
+  '0064_peaceful_magma.sql',
+  '0065_prd_116_recipe_compile.sql',
+  '0066_prd_123_conversions.sql',
+  '0067_prd_125_ingest_error_columns.sql',
+  '0068_prd_136_inbox_review.sql',
+];
+
+function applyMigrations(db: Database): void {
+  for (const name of FOOD_MIGRATIONS) {
+    const sql = readFileSync(join(__dirname, '../../../db/drizzle-migrations', name), 'utf8');
+    const statements = sql.split('--> statement-breakpoint');
+    for (const stmt of statements) {
+      const trimmed = stmt.trim();
+      if (trimmed.length > 0) db.exec(trimmed);
+    }
+  }
+}
+
+/* ─── fixtures ─────────────────────────────────────────────────────────── */
+
+interface SourceFixture {
+  kind: 'url-web' | 'url-instagram' | 'text' | 'screenshot';
+  url?: string;
+  ingestedAt?: string;
+  errorCode?: string;
+  errorMessage?: string;
+  extractedJson?: unknown;
+  attempts?: number;
+}
+
+function insertSource(db: Database, fx: SourceFixture): number {
+  const insert = db.prepare(`
+    INSERT INTO ingest_sources (
+      kind, url, extractor_version, extracted_json,
+      ingested_at, error_code, error_message, attempts
+    ) VALUES (
+      @kind, @url, 'v1', @extracted_json,
+      COALESCE(@ingested_at, datetime('now')),
+      @error_code, @error_message, COALESCE(@attempts, 0)
+    )
+  `);
+  const result = insert.run({
+    kind: fx.kind,
+    url: fx.url ?? null,
+    extracted_json: fx.extractedJson === undefined ? null : JSON.stringify(fx.extractedJson),
+    ingested_at: fx.ingestedAt ?? null,
+    error_code: fx.errorCode ?? null,
+    error_message: fx.errorMessage ?? null,
+    attempts: fx.attempts ?? null,
+  });
+  return Number(result.lastInsertRowid);
+}
+
+interface RejectedFixture {
+  slug: string;
+  title?: string;
+  sourceId: number | null;
+  reason: 'wrong-recipe' | 'low-quality-extraction' | 'duplicate' | 'not-a-recipe' | 'other';
+  note?: string;
+  rejectedAt?: string;
+  /** When true, archive the version without writing a rejections row
+   *  (simulates PRD-119's discard path). */
+  discardOnly?: boolean;
+}
+
+function insertRecipeAndRejectedVersion(
+  db: Database,
+  fx: RejectedFixture
+): { recipeId: number; versionId: number } {
+  const recipeRes = db
+    .prepare(`INSERT INTO recipes (slug, recipe_type) VALUES (?, 'plate')`)
+    .run(fx.slug);
+  const recipeId = Number(recipeRes.lastInsertRowid);
+  db.prepare(`INSERT INTO slug_registry (slug, kind, target_id) VALUES (?, 'recipe', ?)`).run(
+    fx.slug,
+    recipeId
+  );
+  const versionRes = db
+    .prepare(
+      `INSERT INTO recipe_versions (recipe_id, version_no, status, title, body_dsl, source_id)
+       VALUES (?, 1, 'archived', ?, '@recipe(slug=' || ? || ', title="t")', ?)`
+    )
+    .run(recipeId, fx.title ?? 'Test recipe', fx.slug, fx.sourceId);
+  const versionId = Number(versionRes.lastInsertRowid);
+  if (fx.discardOnly !== true) {
+    db.prepare(
+      `INSERT INTO recipe_version_rejections (version_id, reason, note, rejected_at)
+       VALUES (?, ?, ?, COALESCE(?, datetime('now')))`
+    ).run(versionId, fx.reason, fx.note ?? null, fx.rejectedAt ?? null);
+  }
+  return { recipeId, versionId };
+}
+
+function insertAiLog(db: Database, sourceId: number, costUsd: number): void {
+  db.prepare(
+    `INSERT INTO ai_inference_log
+       (provider, model, operation, domain, cost_usd, context_id, status, created_at)
+     VALUES ('anthropic','haiku','recipe.extract','food', ?, ?, 'success', datetime('now'))`
+  ).run(costUsd, `ingest_source:${sourceId}`);
+}
+
+/* ─── setup ────────────────────────────────────────────────────────────── */
+
+let db: Database;
+
+beforeEach(() => {
+  db = new BetterSqlite3(':memory:');
+  db.pragma('foreign_keys = ON');
+  applyMigrations(db);
+  setDb(db);
+});
+
+afterEach(() => {
+  closeDb();
+});
+
+/* ─── listRejected ─────────────────────────────────────────────────────── */
+
+describe('food.inbox.listRejected', () => {
+  it('returns the joined row shape ordered newest-first', async () => {
+    const oldId = insertSource(db, { kind: 'url-web', url: 'https://a.example/recipe' });
+    const newId = insertSource(db, { kind: 'url-instagram', url: 'https://instagram.com/p/b' });
+    insertRecipeAndRejectedVersion(db, {
+      slug: 'first-recipe',
+      title: 'First',
+      sourceId: oldId,
+      reason: 'wrong-recipe',
+      rejectedAt: '2026-06-01T10:00:00.000Z',
+    });
+    insertRecipeAndRejectedVersion(db, {
+      slug: 'second-recipe',
+      title: 'Second',
+      sourceId: newId,
+      reason: 'duplicate',
+      note: 'matches existing carbonara',
+      rejectedAt: '2026-06-05T10:00:00.000Z',
+    });
+    insertAiLog(db, oldId, 0.0123);
+
+    const caller = createCaller();
+    const result = await caller.food.inbox.listRejected({ sinceDays: null });
+
+    expect(result.items.length).toBe(2);
+    expect(result.items[0]?.title).toBe('Second');
+    expect(result.items[0]?.recipeSlug).toBe('second-recipe');
+    expect(result.items[0]?.reason).toBe('duplicate');
+    expect(result.items[0]?.note).toBe('matches existing carbonara');
+    expect(result.items[0]?.ingestKind).toBe('url-instagram');
+    expect(result.items[0]?.ingestCostUsd).toBeNull();
+    expect(result.items[1]?.title).toBe('First');
+    expect(result.items[1]?.ingestCostUsd).toBeCloseTo(0.0123);
+  });
+
+  it('excludes PRD-119-discarded versions (no rejections row)', async () => {
+    const sId = insertSource(db, { kind: 'text' });
+    const dId = insertSource(db, { kind: 'text' });
+    insertRecipeAndRejectedVersion(db, {
+      slug: 'rejected-via-inbox',
+      sourceId: sId,
+      reason: 'wrong-recipe',
+    });
+    insertRecipeAndRejectedVersion(db, {
+      slug: 'discarded-via-prd119',
+      sourceId: dId,
+      reason: 'wrong-recipe',
+      discardOnly: true,
+    });
+
+    const caller = createCaller();
+    const result = await caller.food.inbox.listRejected({ sinceDays: null });
+    expect(result.items.length).toBe(1);
+    expect(result.items[0]?.recipeSlug).toBe('rejected-via-inbox');
+  });
+
+  it('filters by reason / kind / sinceDays', async () => {
+    const recentSrc = insertSource(db, { kind: 'url-instagram' });
+    const oldSrc = insertSource(db, { kind: 'text' });
+    const sixtyDaysAgo = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000).toISOString();
+    insertRecipeAndRejectedVersion(db, {
+      slug: 'recent-instagram',
+      sourceId: recentSrc,
+      reason: 'duplicate',
+    });
+    insertRecipeAndRejectedVersion(db, {
+      slug: 'old-text',
+      sourceId: oldSrc,
+      reason: 'not-a-recipe',
+      rejectedAt: sixtyDaysAgo,
+    });
+
+    const caller = createCaller();
+
+    const byReason = await caller.food.inbox.listRejected({
+      reasons: ['duplicate'],
+      sinceDays: null,
+    });
+    expect(byReason.items.map((i) => i.recipeSlug)).toEqual(['recent-instagram']);
+
+    const byKind = await caller.food.inbox.listRejected({
+      kinds: ['text'],
+      sinceDays: null,
+    });
+    expect(byKind.items.map((i) => i.recipeSlug)).toEqual(['old-text']);
+
+    const recent30 = await caller.food.inbox.listRejected({ sinceDays: 30 });
+    expect(recent30.items.map((i) => i.recipeSlug)).toEqual(['recent-instagram']);
+  });
+
+  it('paginates with an opaque cursor', async () => {
+    for (let i = 0; i < 3; i++) {
+      const srcId = insertSource(db, { kind: 'text' });
+      insertRecipeAndRejectedVersion(db, {
+        slug: `r${i}`,
+        sourceId: srcId,
+        reason: 'other',
+        note: 'n',
+        // Strictly increasing timestamp; reverse order in results.
+        rejectedAt: `2026-06-0${i + 1}T10:00:00.000Z`,
+      });
+    }
+    const caller = createCaller();
+    const page1 = await caller.food.inbox.listRejected({ sinceDays: null, limit: 2 });
+    expect(page1.items.length).toBe(2);
+    expect(page1.items.map((i) => i.recipeSlug)).toEqual(['r2', 'r1']);
+    expect(page1.nextCursor).toBeTypeOf('string');
+    const page2 = await caller.food.inbox.listRejected({
+      sinceDays: null,
+      limit: 2,
+      cursor: page1.nextCursor!,
+    });
+    expect(page2.items.map((i) => i.recipeSlug)).toEqual(['r0']);
+    expect(page2.nextCursor).toBeUndefined();
+  });
+});
+
+/* ─── listFailed ───────────────────────────────────────────────────────── */
+
+describe('food.inbox.listFailed', () => {
+  it('returns only sources with a non-null error_code', async () => {
+    const failedId = insertSource(db, {
+      kind: 'url-instagram',
+      url: 'https://instagram.com/p/x',
+      errorCode: 'InstagramRateLimited',
+      errorMessage: 'IG returned 429',
+      attempts: 1,
+    });
+    insertSource(db, { kind: 'text' });
+
+    const caller = createCaller();
+    const result = await caller.food.inbox.listFailed({ sinceDays: null });
+    expect(result.items.length).toBe(1);
+    expect(result.items[0]?.sourceId).toBe(failedId);
+    expect(result.items[0]?.errorCode).toBe('InstagramRateLimited');
+    expect(result.items[0]?.errorMessage).toBe('IG returned 429');
+    expect(result.items[0]?.attempts).toBe(1);
+  });
+
+  it('excludes auth-dead partial drafts (they remain in Drafts tab)', async () => {
+    // PRD-130 path: ok=true + partialReason='auth-dead' → no error_code,
+    // so this source must NOT show up under the Failed tab.
+    insertSource(db, {
+      kind: 'url-instagram',
+      url: 'https://instagram.com/p/auth-dead',
+      extractedJson: {
+        extractor_version: 'v1',
+        stages: {},
+        partialReason: 'auth-dead',
+      },
+    });
+    const caller = createCaller();
+    const result = await caller.food.inbox.listFailed({ sinceDays: null });
+    expect(result.items.length).toBe(0);
+  });
+
+  it('filters by errorCodes / kinds and supports the Other bucket', async () => {
+    insertSource(db, {
+      kind: 'url-instagram',
+      errorCode: 'InstagramRateLimited',
+      errorMessage: 'IG 429',
+    });
+    insertSource(db, {
+      kind: 'url-web',
+      errorCode: 'AllExtractionPathsFailed',
+      errorMessage: 'nothing parsed',
+    });
+    insertSource(db, {
+      kind: 'screenshot',
+      errorCode: 'MysteryNewCode',
+      errorMessage: 'never seen this before',
+    });
+
+    const caller = createCaller();
+    const igOnly = await caller.food.inbox.listFailed({
+      errorCodes: ['InstagramRateLimited'],
+      sinceDays: null,
+    });
+    expect(igOnly.items.map((i) => i.errorCode)).toEqual(['InstagramRateLimited']);
+
+    const webOnly = await caller.food.inbox.listFailed({ kinds: ['url-web'], sinceDays: null });
+    expect(webOnly.items.map((i) => i.errorCode)).toEqual(['AllExtractionPathsFailed']);
+
+    // Unknown code passed through verbatim — UI's "Other" bucket is a
+    // display concern; the server matches literally.
+    const mystery = await caller.food.inbox.listFailed({
+      errorCodes: ['MysteryNewCode'],
+      sinceDays: null,
+    });
+    expect(mystery.items.map((i) => i.errorCode)).toEqual(['MysteryNewCode']);
+  });
+});

--- a/apps/pops-api/src/modules/food/inbox/list-failed.ts
+++ b/apps/pops-api/src/modules/food/inbox/list-failed.ts
@@ -1,0 +1,91 @@
+/**
+ * PRD-138 — `food.inbox.listFailed` query.
+ *
+ * Returns `ingest_sources` rows whose latest meta represents a worker
+ * failure. The single predicate `error_code IS NOT NULL` covers PRD-138's
+ * "no successful retry" rule because PRD-125's `workerComplete` clears
+ * `error_code` / `error_message` on the next successful attempt.
+ *
+ * Auth-dead Instagram reels (PRD-130) do NOT appear here — they ship as
+ * `ok: true` partial drafts with `partialReason='auth-dead'`, so
+ * `error_code` stays NULL and they live in the Drafts tab instead.
+ */
+import { and, desc, eq, gte, inArray, isNotNull, lt, or, type SQL } from 'drizzle-orm';
+
+import { ingestSources } from '@pops/db-types';
+
+import { decodeCursor, encodeCursor, sinceCutoffIso } from './list-shared.js';
+
+import type { FoodDb } from '@pops/app-food-db';
+
+import type { FailedRow, IngestKind } from './list-schemas.js';
+
+export interface FailedListInput {
+  errorCodes?: string[];
+  kinds?: IngestKind[];
+  sinceDays: 7 | 30 | 90 | null;
+  cursor?: string;
+  limit: number;
+}
+
+function buildConditions(input: FailedListInput): SQL[] {
+  const conditions: SQL[] = [isNotNull(ingestSources.errorCode)];
+  if (input.errorCodes !== undefined && input.errorCodes.length > 0) {
+    conditions.push(inArray(ingestSources.errorCode, input.errorCodes));
+  }
+  if (input.kinds !== undefined && input.kinds.length > 0) {
+    conditions.push(inArray(ingestSources.kind, input.kinds));
+  }
+  const cutoff = sinceCutoffIso(input.sinceDays);
+  if (cutoff !== null) conditions.push(gte(ingestSources.ingestedAt, cutoff));
+
+  const decoded = decodeCursor(input.cursor);
+  if (decoded !== null) {
+    conditions.push(
+      or(
+        lt(ingestSources.ingestedAt, decoded.ts),
+        and(eq(ingestSources.ingestedAt, decoded.ts), lt(ingestSources.id, decoded.id))
+      ) as SQL
+    );
+  }
+  return conditions;
+}
+
+export async function listFailed(
+  db: FoodDb,
+  input: FailedListInput
+): Promise<{ items: FailedRow[]; nextCursor?: string }> {
+  const rows = await db
+    .select({
+      sourceId: ingestSources.id,
+      ingestKind: ingestSources.kind,
+      sourceUrl: ingestSources.url,
+      errorCode: ingestSources.errorCode,
+      errorMessage: ingestSources.errorMessage,
+      ingestedAt: ingestSources.ingestedAt,
+      attempts: ingestSources.attempts,
+    })
+    .from(ingestSources)
+    .where(and(...buildConditions(input)))
+    .orderBy(desc(ingestSources.ingestedAt), desc(ingestSources.id))
+    .limit(input.limit + 1)
+    .all();
+
+  const hasMore = rows.length > input.limit;
+  const sliced = hasMore ? rows.slice(0, input.limit) : rows;
+  const items: FailedRow[] = sliced.map((r) => ({
+    sourceId: r.sourceId,
+    ingestKind: r.ingestKind,
+    sourceUrl: r.sourceUrl,
+    // `error_code` / `error_message` are filtered non-null at the SQL
+    // layer (`isNotNull(errorCode)`); the column type stays nullable so
+    // the ?? satisfies TS without an `as` cast.
+    errorCode: r.errorCode ?? '',
+    errorMessage: r.errorMessage ?? '',
+    ingestedAt: r.ingestedAt,
+    attempts: r.attempts,
+  }));
+  const last = sliced[sliced.length - 1];
+  if (!hasMore || last === undefined) return { items };
+  return { items, nextCursor: encodeCursor(last.ingestedAt, last.sourceId) };
+}

--- a/apps/pops-api/src/modules/food/inbox/list-rejected.ts
+++ b/apps/pops-api/src/modules/food/inbox/list-rejected.ts
@@ -1,0 +1,143 @@
+/**
+ * PRD-138 — `food.inbox.listRejected` query.
+ *
+ * Joins archived-and-rejected versions with their `ingest_sources`, the
+ * parent recipe (for the slug), and a correlated subquery against
+ * `ai_inference_log` for the per-source cost rollup. PRD-119's manual
+ * discard path lands on `status='archived'` too but writes no rejections
+ * row — the INNER JOIN against `recipe_version_rejections` filters those
+ * out implicitly.
+ */
+import { and, desc, eq, gte, inArray, isNotNull, lt, or, sql, type SQL } from 'drizzle-orm';
+
+import {
+  aiInferenceLog,
+  ingestSources,
+  recipes,
+  recipeVersionRejections,
+  recipeVersions,
+} from '@pops/db-types';
+
+import { decodeCursor, encodeCursor, sinceCutoffIso } from './list-shared.js';
+
+import type { FoodDb } from '@pops/app-food-db';
+
+import type { IngestKind, RejectedRow, RejectionReason } from './list-schemas.js';
+
+export interface RejectedListInput {
+  reasons?: RejectionReason[];
+  kinds?: IngestKind[];
+  sinceDays: 7 | 30 | 90 | null;
+  cursor?: string;
+  limit: number;
+}
+
+/** Aggregated ingest-cost as a correlated subquery — avoids a JOIN+GROUP BY
+ *  that would couple this query to PRD-133's row shape, and scales fine at
+ *  the inbox's page size. PRD-133 uses the string-namespaced
+ *  `ingest_source:<id>` context_id rather than a numeric FK. */
+const INGEST_COST_SUBQUERY = sql<number | null>`(
+  SELECT COALESCE(SUM(${aiInferenceLog.costUsd}), 0)
+  FROM ${aiInferenceLog}
+  WHERE ${aiInferenceLog.contextId} = 'ingest_source:' || ${ingestSources.id}
+)`;
+
+function buildConditions(input: RejectedListInput): SQL[] {
+  const conditions: SQL[] = [
+    // PRD-136's `NotIngestOriginated` rule. The INNER JOIN on `ingest_sources`
+    // would already filter this, but the explicit predicate is cheaper to
+    // reason about than reading the JOIN graph.
+    isNotNull(recipeVersions.sourceId),
+  ];
+  if (input.reasons !== undefined && input.reasons.length > 0) {
+    conditions.push(inArray(recipeVersionRejections.reason, input.reasons));
+  }
+  if (input.kinds !== undefined && input.kinds.length > 0) {
+    conditions.push(inArray(ingestSources.kind, input.kinds));
+  }
+  const cutoff = sinceCutoffIso(input.sinceDays);
+  if (cutoff !== null) conditions.push(gte(recipeVersionRejections.rejectedAt, cutoff));
+
+  const decoded = decodeCursor(input.cursor);
+  if (decoded !== null) {
+    // (rejectedAt, versionId) DESC tiebreak — mirrors the ORDER BY.
+    conditions.push(
+      or(
+        lt(recipeVersionRejections.rejectedAt, decoded.ts),
+        and(
+          eq(recipeVersionRejections.rejectedAt, decoded.ts),
+          lt(recipeVersionRejections.versionId, decoded.id)
+        )
+      ) as SQL
+    );
+  }
+  return conditions;
+}
+
+interface QueryRow {
+  versionId: number;
+  recipeSlug: string;
+  sourceId: number;
+  title: string | null;
+  reason: string;
+  note: string | null;
+  rejectedAt: string;
+  ingestKind: IngestKind;
+  sourceUrl: string | null;
+  ingestCostUsd: number | null;
+}
+
+function rowToView(r: QueryRow): RejectedRow {
+  let title: string | null = r.title;
+  if (title !== null && title.length === 0) title = null;
+  // `COALESCE(SUM(...), 0)` returns 0 when no logs reference this source;
+  // normalise that to `null` so the UI distinguishes "no cost data" from
+  // a genuinely-$0 cost (degenerate — same UI treatment is acceptable).
+  const ingestCostUsd = r.ingestCostUsd === 0 || r.ingestCostUsd === null ? null : r.ingestCostUsd;
+  return {
+    versionId: r.versionId,
+    recipeSlug: r.recipeSlug,
+    sourceId: r.sourceId,
+    title,
+    reason: r.reason as RejectionReason,
+    note: r.note,
+    rejectedAt: r.rejectedAt,
+    ingestKind: r.ingestKind,
+    sourceUrl: r.sourceUrl,
+    ingestCostUsd,
+  };
+}
+
+export async function listRejected(
+  db: FoodDb,
+  input: RejectedListInput
+): Promise<{ items: RejectedRow[]; nextCursor?: string }> {
+  const rows = await db
+    .select({
+      versionId: recipeVersions.id,
+      recipeSlug: recipes.slug,
+      sourceId: ingestSources.id,
+      title: recipeVersions.title,
+      reason: recipeVersionRejections.reason,
+      note: recipeVersionRejections.note,
+      rejectedAt: recipeVersionRejections.rejectedAt,
+      ingestKind: ingestSources.kind,
+      sourceUrl: ingestSources.url,
+      ingestCostUsd: INGEST_COST_SUBQUERY,
+    })
+    .from(recipeVersions)
+    .innerJoin(recipeVersionRejections, eq(recipeVersionRejections.versionId, recipeVersions.id))
+    .innerJoin(ingestSources, eq(ingestSources.id, recipeVersions.sourceId))
+    .innerJoin(recipes, eq(recipes.id, recipeVersions.recipeId))
+    .where(and(...buildConditions(input)))
+    .orderBy(desc(recipeVersionRejections.rejectedAt), desc(recipeVersionRejections.versionId))
+    .limit(input.limit + 1)
+    .all();
+
+  const hasMore = rows.length > input.limit;
+  const sliced = hasMore ? rows.slice(0, input.limit) : rows;
+  const items = sliced.map(rowToView);
+  const last = sliced[sliced.length - 1];
+  if (!hasMore || last === undefined) return { items };
+  return { items, nextCursor: encodeCursor(last.rejectedAt, last.versionId) };
+}

--- a/apps/pops-api/src/modules/food/inbox/list-schemas.ts
+++ b/apps/pops-api/src/modules/food/inbox/list-schemas.ts
@@ -1,0 +1,85 @@
+/**
+ * PRD-138 — Zod schemas for the inbox-list queries (`food.inbox.listRejected`
+ * and `food.inbox.listFailed`).
+ *
+ * Kept in a sibling file so `inputs.ts` (PRD-136's approve/reject/unreject)
+ * stays tight.
+ */
+import { z } from 'zod';
+
+export const RejectionReasonSchema = z.enum([
+  'wrong-recipe',
+  'low-quality-extraction',
+  'duplicate',
+  'not-a-recipe',
+  'other',
+]);
+export type RejectionReason = z.infer<typeof RejectionReasonSchema>;
+
+export const IngestKindSchema = z.enum(['url-web', 'url-instagram', 'text', 'screenshot']);
+export type IngestKind = z.infer<typeof IngestKindSchema>;
+
+/** Allowed `sinceDays` chip values. `null` ⇒ "all time". */
+export const SinceDaysSchema = z
+  .union([z.literal(7), z.literal(30), z.literal(90), z.null()])
+  .default(30);
+
+export const CursorSchema = z.string().optional();
+const ListLimit = z.coerce.number().int().positive().max(100).default(20);
+
+/* ─── listRejected ─────────────────────────────────────────────────────── */
+
+export const ListRejectedInput = z.object({
+  reasons: z.array(RejectionReasonSchema).optional(),
+  kinds: z.array(IngestKindSchema).optional(),
+  sinceDays: SinceDaysSchema,
+  cursor: CursorSchema,
+  limit: ListLimit,
+});
+export type ListRejectedInput = z.infer<typeof ListRejectedInput>;
+
+export const RejectedRowSchema = z.object({
+  versionId: z.number().int().positive(),
+  recipeSlug: z.string(),
+  sourceId: z.number().int().positive(),
+  title: z.string().nullable(),
+  reason: RejectionReasonSchema,
+  note: z.string().nullable(),
+  rejectedAt: z.string(),
+  ingestKind: IngestKindSchema,
+  sourceUrl: z.string().nullable(),
+  ingestCostUsd: z.number().nullable(),
+});
+export type RejectedRow = z.infer<typeof RejectedRowSchema>;
+
+export const ListRejectedOutput = z.object({
+  items: z.array(RejectedRowSchema),
+  nextCursor: z.string().optional(),
+});
+
+/* ─── listFailed ───────────────────────────────────────────────────────── */
+
+export const ListFailedInput = z.object({
+  errorCodes: z.array(z.string().min(1)).optional(),
+  kinds: z.array(IngestKindSchema).optional(),
+  sinceDays: SinceDaysSchema,
+  cursor: CursorSchema,
+  limit: ListLimit,
+});
+export type ListFailedInput = z.infer<typeof ListFailedInput>;
+
+export const FailedRowSchema = z.object({
+  sourceId: z.number().int().positive(),
+  ingestKind: IngestKindSchema,
+  sourceUrl: z.string().nullable(),
+  errorCode: z.string(),
+  errorMessage: z.string(),
+  ingestedAt: z.string(),
+  attempts: z.number().int().nonnegative(),
+});
+export type FailedRow = z.infer<typeof FailedRowSchema>;
+
+export const ListFailedOutput = z.object({
+  items: z.array(FailedRowSchema),
+  nextCursor: z.string().optional(),
+});

--- a/apps/pops-api/src/modules/food/inbox/list-shared.ts
+++ b/apps/pops-api/src/modules/food/inbox/list-shared.ts
@@ -1,0 +1,38 @@
+/**
+ * PRD-138 — shared helpers for the `food.inbox.list*` queries.
+ *
+ *   - Cursor encoding: opaque base64 of `<isoTimestamp>|<id>`. Ordering-stable;
+ *     the timestamp drives the ORDER BY and the id breaks ties. Malformed
+ *     cursors decode to `null` (the caller treats this as "first page")
+ *     rather than throwing, so a client refresh on a stale cursor never
+ *     surfaces an opaque server error.
+ *
+ *   - `sinceCutoffIso`: maps the inbox's `sinceDays` filter (7/30/90/null)
+ *     to an absolute ISO timestamp the SQL `>=` predicate can use directly.
+ */
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+export function sinceCutoffIso(sinceDays: 7 | 30 | 90 | null): string | null {
+  if (sinceDays === null) return null;
+  return new Date(Date.now() - sinceDays * MS_PER_DAY).toISOString();
+}
+
+export function encodeCursor(timestamp: string, id: number): string {
+  return Buffer.from(`${timestamp}|${id}`, 'utf8').toString('base64');
+}
+
+export function decodeCursor(cursor: string | undefined): { ts: string; id: number } | null {
+  if (cursor === undefined) return null;
+  try {
+    const raw = Buffer.from(cursor, 'base64').toString('utf8');
+    const sep = raw.indexOf('|');
+    if (sep < 0) return null;
+    const ts = raw.slice(0, sep);
+    const id = Number(raw.slice(sep + 1));
+    if (!Number.isFinite(id) || ts.length === 0) return null;
+    return { ts, id };
+  } catch {
+    return null;
+  }
+}

--- a/apps/pops-api/src/modules/food/inbox/router.ts
+++ b/apps/pops-api/src/modules/food/inbox/router.ts
@@ -1,22 +1,36 @@
 /**
- * `food.inbox.*` tRPC router — PRD-136.
+ * `food.inbox.*` tRPC router.
  *
- * Three mutations (approve / reject / unreject) operating on
+ * PRD-136 mutations (approve / reject / unreject) operate on
  * ingest-originated recipe versions. Each delegates to `inboxService` in
  * `@pops/app-food-db`, which composes PRD-107's `promoteVersion` /
- * `archiveVersion` services inside a single Drizzle transaction.
+ * `archiveVersion` services inside a single Drizzle transaction. Errors are
+ * surfaced as discriminated `{ ok: false, reason: ... }` rather than thrown
+ * — the inbox UI (PRDs 134/135/138) branches on the reason to reload state
+ * / show a banner without unwrapping a TRPCError.
  *
- * Errors are surfaced as discriminated `{ ok: false, reason: ... }` rather
- * than thrown — the inbox UI (PRDs 134/135/138) branches on the reason to
- * reload state / show a banner without unwrapping a TRPCError.
+ * PRD-138 queries (listRejected / listFailed) feed the two non-default tabs
+ * inside `/food/inbox`. Both are cursor-paginated and filterable; auth-dead
+ * Instagram placeholders are intentionally excluded from `listFailed`
+ * (those ship as `ok: true` partial drafts per PRD-130 and live in the
+ * Drafts tab instead).
  *
- * See `docs/themes/07-food/prds/136-approve-reject-flow/README.md`.
+ * See `docs/themes/07-food/prds/136-approve-reject-flow/README.md` and
+ * `docs/themes/07-food/prds/138-rejected-and-failed-tabs/README.md`.
  */
 import { inboxService } from '@pops/app-food-db';
 
 import { getDrizzle } from '../../../db.js';
 import { protectedProcedure, router } from '../../../trpc.js';
 import { ApproveInputSchema, RejectInputSchema, UnrejectInputSchema } from './inputs.js';
+import { listFailed } from './list-failed.js';
+import { listRejected } from './list-rejected.js';
+import {
+  ListFailedInput,
+  ListFailedOutput,
+  ListRejectedInput,
+  ListRejectedOutput,
+} from './list-schemas.js';
 
 export const inboxRouter = router({
   approve: protectedProcedure.input(ApproveInputSchema).mutation(({ input }) => {
@@ -34,6 +48,16 @@ export const inboxRouter = router({
   unreject: protectedProcedure.input(UnrejectInputSchema).mutation(({ input }) => {
     return inboxService.unrejectDraft(getDrizzle(), input.versionId);
   }),
+
+  listRejected: protectedProcedure
+    .input(ListRejectedInput)
+    .output(ListRejectedOutput)
+    .query(({ input }) => listRejected(getDrizzle(), input)),
+
+  listFailed: protectedProcedure
+    .input(ListFailedInput)
+    .output(ListFailedOutput)
+    .query(({ input }) => listFailed(getDrizzle(), input)),
 });
 
 export type InboxRouter = typeof inboxRouter;

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -176,11 +176,11 @@ Live status of every theme and epic. Updated as work completes.
 
 ### Phase 4 — Expansion Apps
 
-| Theme           | Status      | Notes                                                                           |
-| --------------- | ----------- | ------------------------------------------------------------------------------- |
-| Travel planner  | Not started |                                                                                 |
-| Books / Reading | Not started |                                                                                 |
-| Food (theme 07) | In progress | Epic 00 (schema) underway. See [docs/themes/07-food/](themes/07-food/README.md) |
+| Theme           | Status      | Notes                                                                                                                                                                                                                                   |
+| --------------- | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Travel planner  | Not started |                                                                                                                                                                                                                                         |
+| Books / Reading | Not started |                                                                                                                                                                                                                                         |
+| Food (theme 07) | In progress | Epic 00 (schema) underway; Epic 03 (Draft Review) opened — PRD-136 server flow shipped (approve/reject/unreject) and PRD-138 part A adds `food.inbox.listRejected` + `listFailed`. See [docs/themes/07-food/](themes/07-food/README.md) |
 
 ### Phase 5 — Mobile & Hardware
 

--- a/docs/themes/07-food/README.md
+++ b/docs/themes/07-food/README.md
@@ -20,16 +20,16 @@ The North Star: get the user cooking from their Instagram saved folder within th
 
 ## Epics
 
-| #   | Epic                                                                       | Summary                                                                                             | Status      |
-| --- | -------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- | ----------- |
-| 00  | [Schema & Foundations](epics/00-schema-and-foundations.md)                 | All food schemas with invariants enforced; `mise db:seed:food` produces a coherent fixture database | In progress |
-| 01  | [Recipe & Ingredient Management](epics/01-recipe-ingredient-management.md) | `app-food` scaffold, recipe CRUD with versions, ingredient/variant/alias management UI              | Not started |
-| 02  | [Ingestion Pipeline](epics/02-ingestion-pipeline.md)                       | BullMQ queue, `pops-worker-food` container, web/Instagram/screenshot/text ingestion to drafts       | Not started |
-| 03  | [Draft Review & Approval](epics/03-draft-review.md)                        | Review queue UI, ingredient resolution, tag confirmation, promotion to current version              | Not started |
-| 04  | [Lists & Shopping](epics/04-lists-and-shopping.md)                         | `app-lists` scaffold (generic), food → shopping integration                                         | Not started |
-| 05  | [Meal Planning & Batches](epics/05-meal-planning.md)                       | Plan entries, cook events, batch creation with expiry, FIFO consumption, fridge view                | Not started |
-| 06  | [Substitutions & Solver](epics/06-substitutions.md)                        | Substitution graph, cook-time recommendations, "what can I cook tonight" solver                     | Not started |
-| 07  | [Pantry-Aware Shopping](epics/07-pantry-aware-shopping.md)                 | Plan-derived shopping list with pantry subtraction and store-section grouping                       | Not started |
+| #   | Epic                                                                       | Summary                                                                                             | Status                                                                                |
+| --- | -------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| 00  | [Schema & Foundations](epics/00-schema-and-foundations.md)                 | All food schemas with invariants enforced; `mise db:seed:food` produces a coherent fixture database | In progress                                                                           |
+| 01  | [Recipe & Ingredient Management](epics/01-recipe-ingredient-management.md) | `app-food` scaffold, recipe CRUD with versions, ingredient/variant/alias management UI              | Not started                                                                           |
+| 02  | [Ingestion Pipeline](epics/02-ingestion-pipeline.md)                       | BullMQ queue, `pops-worker-food` container, web/Instagram/screenshot/text ingestion to drafts       | Not started                                                                           |
+| 03  | [Draft Review & Approval](epics/03-draft-review.md)                        | Review queue UI, ingredient resolution, tag confirmation, promotion to current version              | In progress (PRD-136 partial; PRD-138 part A — `listRejected` + `listFailed` queries) |
+| 04  | [Lists & Shopping](epics/04-lists-and-shopping.md)                         | `app-lists` scaffold (generic), food → shopping integration                                         | Not started                                                                           |
+| 05  | [Meal Planning & Batches](epics/05-meal-planning.md)                       | Plan entries, cook events, batch creation with expiry, FIFO consumption, fridge view                | Not started                                                                           |
+| 06  | [Substitutions & Solver](epics/06-substitutions.md)                        | Substitution graph, cook-time recommendations, "what can I cook tonight" solver                     | Not started                                                                           |
+| 07  | [Pantry-Aware Shopping](epics/07-pantry-aware-shopping.md)                 | Plan-derived shopping list with pantry subtraction and store-section grouping                       | Not started                                                                           |
 
 Epic 00 blocks 01–07. Epics 01 and 02 can proceed in parallel once schema lands. Epic 03 depends on both 01 and 02. Epics 04, 05, 06, 07 are sequential downstream slices on top of 01–03.
 

--- a/docs/themes/07-food/epics/03-draft-review.md
+++ b/docs/themes/07-food/epics/03-draft-review.md
@@ -12,13 +12,13 @@ This epic is review-loop only. The planning, batch, and cook-event surfaces that
 
 ## PRDs
 
-| #   | PRD                                                                      | Summary                                                                                                        | Status      |
-| --- | ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------- | ----------- |
-| 134 | [Review Queue Page](../prds/134-review-queue-page/README.md)             | `/food/inbox` with Drafts / Rejected / Failed tabs; heuristic-sorted rows; filter chips; cursor pagination     | Not started |
-| 135 | [Per-Draft Inspector](../prds/135-draft-inspector/README.md)             | `/food/inbox/:sourceId` three-pane view: provenance + DSL editor + approve/reject controls; auto-create banner | Not started |
-| 136 | [Approval & Rejection Flow](../prds/136-approve-reject-flow/README.md)   | Server mutations (`approve` / `reject` / `unreject`); new `recipe_version_rejections` table; FK transitions    | Partial     |
-| 137 | [Review Quality Heuristic](../prds/137-quality-heuristic/README.md)      | Deterministic scoring function over compile_status + proposedSlugs + partialReason + kind + age; four bands    | Not started |
-| 138 | [Rejected & Failed Tabs](../prds/138-rejected-and-failed-tabs/README.md) | Rejected tab with undo; Failed-ingest tab wired to PRD-125 `retry`; reject-reason capture + filter             | Not started |
+| #   | PRD                                                                      | Summary                                                                                                        | Status                                                                                     |
+| --- | ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| 134 | [Review Queue Page](../prds/134-review-queue-page/README.md)             | `/food/inbox` with Drafts / Rejected / Failed tabs; heuristic-sorted rows; filter chips; cursor pagination     | Not started                                                                                |
+| 135 | [Per-Draft Inspector](../prds/135-draft-inspector/README.md)             | `/food/inbox/:sourceId` three-pane view: provenance + DSL editor + approve/reject controls; auto-create banner | Not started                                                                                |
+| 136 | [Approval & Rejection Flow](../prds/136-approve-reject-flow/README.md)   | Server mutations (`approve` / `reject` / `unreject`); new `recipe_version_rejections` table; FK transitions    | Partial                                                                                    |
+| 137 | [Review Quality Heuristic](../prds/137-quality-heuristic/README.md)      | Deterministic scoring function over compile_status + proposedSlugs + partialReason + kind + age; four bands    | Not started                                                                                |
+| 138 | [Rejected & Failed Tabs](../prds/138-rejected-and-failed-tabs/README.md) | Rejected tab with undo; Failed-ingest tab wired to PRD-125 `retry`; reject-reason capture + filter             | In progress — part A (`food.inbox.listRejected` + `listFailed`) shipped; UI tabs in part B |
 
 ### Build order
 

--- a/docs/themes/07-food/prds/138-rejected-and-failed-tabs/README.md
+++ b/docs/themes/07-food/prds/138-rejected-and-failed-tabs/README.md
@@ -1,6 +1,8 @@
 # PRD-138: Rejected & Failed Ingest Tabs
 
 > Epic: [03 — Draft Review & Approval](../../epics/03-draft-review.md)
+>
+> Status: In progress — server-side queries (part A) ship `food.inbox.listRejected` and `food.inbox.listFailed`. UI tabs (`RejectedTab.tsx`, `FailedTab.tsx`, `ViewSourceDialog.tsx`) land in part B once PRD-134's `/food/inbox` shell exists. The PRD-136 schema delta + `food.inbox.unreject` shipped with PRD-136 itself.
 
 ## Overview
 


### PR DESCRIPTION
## Summary

Server-only slice of [PRD-138](docs/themes/07-food/prds/138-rejected-and-failed-tabs/README.md) (Rejected & Failed inbox tabs). Adds two cursor-paginated queries on top of the existing `food.inbox.*` router that PRD-136 just shipped (#2754).

- **`food.inbox.listRejected`** — archived versions joined to `recipe_version_rejections` (INNER, so PRD-119's manually-discarded archives are excluded by construction) and to `ingest_sources`. Filter chips: reason / kind / sinceDays. Per-row `ingestCostUsd` rolled up via a correlated subquery against `ai_inference_log` keyed on PRD-133's `ingest_source:<id>` context namespace. Opaque base64 cursor over `(rejectedAt, versionId)`.
- **`food.inbox.listFailed`** — `ingest_sources` where `error_code IS NOT NULL`. That single predicate is enough to enforce PRD-138's "no successful retry" rule because PRD-125's `workerComplete` clears the failure columns on the next successful attempt. Auth-dead Instagram reels (PRD-130) ship as `ok:true` partials, so they correctly fall to the Drafts tab. Filter chips: errorCodes (free-form so the UI's "Other" bucket works) / kind / sinceDays.

The UI tabs (`RejectedTab.tsx`, `FailedTab.tsx`, `ViewSourceDialog.tsx`) ship in part B once PRD-134's `/food/inbox` shell exists.

## Test plan

- [ ] Vitest integration: `apps/pops-api/src/modules/food/__tests__/inbox-list-rejected-failed.test.ts` (7 cases) covers row shape + ordering, PRD-119 discard exclusion, auth-dead exclusion, all filter dimensions, the "Other" errorCode bucket, and cursor pagination.
- [ ] `mise typecheck` + `mise lint` clean.
- [ ] Full pops-api suite (4,689 tests) passes.
- [ ] Full workspace `mise test` passes.

## Gaps (tracked)

Acceptance criteria deferred to part B (UI slice) — not blockers for this PR, will be filed as GitHub issues if not landed in the next follow-up:

- `RejectedTab.tsx` / `FailedTab.tsx` / `ViewSourceDialog.tsx` components + RTL tests.
- Auth-dead row tooltip linking to `docs/runbooks/instagram-cookie-refresh.md` (only relevant once Drafts tab exists).
- URL-query-param driven tab state + filter-chip URL-hash persistence (PRD-134 owns the route table and shell).