### PR TITLE
feat(finance-db): cut over pops-api wish-list to @pops/finance-db (pillar finance phase 1 PR 3)

### DIFF
--- a/.github/workflows/_pkg-check.yml
+++ b/.github/workflows/_pkg-check.yml
@@ -47,6 +47,7 @@ jobs:
           pnpm --filter @pops/module-registry build
           pnpm --filter @pops/food-contracts build
           pnpm --filter @pops/core-db build
+          pnpm --filter @pops/finance-db build
           pnpm --filter @pops/inventory-db build
           pnpm --filter @pops/media-db build
           pnpm --filter @pops/app-lists-db build
@@ -81,6 +82,7 @@ jobs:
           pnpm --filter @pops/module-registry build
           pnpm --filter @pops/food-contracts build
           pnpm --filter @pops/core-db build
+          pnpm --filter @pops/finance-db build
           pnpm --filter @pops/inventory-db build
           pnpm --filter @pops/media-db build
           pnpm --filter @pops/app-lists-db build

--- a/.github/workflows/api-quality.yml
+++ b/.github/workflows/api-quality.yml
@@ -70,6 +70,7 @@ jobs:
           cd ../module-registry && pnpm build
           cd ../food-contracts && pnpm build
           cd ../core-db && pnpm build
+          cd ../finance-db && pnpm build
           cd ../inventory-db && pnpm build
           cd ../media-db && pnpm build
           cd ../app-lists-db && pnpm build

--- a/.github/workflows/api-quality.yml
+++ b/.github/workflows/api-quality.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - "apps/pops-api/**"
       - "packages/db-types/**"
+      - "packages/finance-db/**"
       - "packages/inventory-db/**"
       - "packages/types/**"
       - ".github/workflows/api-quality.yml"
@@ -28,6 +29,7 @@ jobs:
             api:
               - 'apps/pops-api/**'
               - 'packages/db-types/**'
+              - 'packages/finance-db/**'
               - 'packages/inventory-db/**'
               - 'packages/types/**'
               - '.github/workflows/api-quality.yml'

--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -21,6 +21,7 @@ jobs:
             backend:
               - 'apps/pops-api/**'
               - 'packages/db-types/**'
+              - 'packages/finance-db/**'
               - 'packages/inventory-db/**'
               - 'packages/types/**'
               - 'packages/auth/**'

--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -64,6 +64,7 @@ jobs:
           cd ../module-registry && pnpm build
           cd ../food-contracts && pnpm build
           cd ../core-db && pnpm build
+          cd ../finance-db && pnpm build
           cd ../inventory-db && pnpm build
           cd ../media-db && pnpm build
           cd ../app-lists-db && pnpm build

--- a/.github/workflows/fe-quality.yml
+++ b/.github/workflows/fe-quality.yml
@@ -76,6 +76,7 @@ jobs:
           cd ../module-registry && pnpm build
           cd ../food-contracts && pnpm build
           cd ../core-db && pnpm build
+          cd ../finance-db && pnpm build
           cd ../inventory-db && pnpm build
           cd ../media-db && pnpm build
           cd ../app-lists-db && pnpm build

--- a/.github/workflows/fe-test-e2e.yml
+++ b/.github/workflows/fe-test-e2e.yml
@@ -63,6 +63,7 @@ jobs:
           cd ../module-registry && pnpm build
           cd ../food-contracts && pnpm build
           cd ../core-db && pnpm build
+          cd ../finance-db && pnpm build
           cd ../inventory-db && pnpm build
           cd ../media-db && pnpm build
           cd ../app-lists-db && pnpm build

--- a/apps/pops-api/Dockerfile
+++ b/apps/pops-api/Dockerfile
@@ -12,6 +12,7 @@ COPY packages/api-client/package.json ./packages/api-client/
 COPY packages/app-food-db/package.json ./packages/app-food-db/
 COPY packages/app-lists-db/package.json ./packages/app-lists-db/
 COPY packages/core-db/package.json ./packages/core-db/
+COPY packages/finance-db/package.json ./packages/finance-db/
 COPY packages/media-db/package.json ./packages/media-db/
 COPY packages/food-contracts/package.json ./packages/food-contracts/
 COPY packages/inventory-db/package.json ./packages/inventory-db/
@@ -35,6 +36,9 @@ COPY packages/app-food-db/tsconfig.json ./packages/app-food-db/
 COPY packages/core-db/src ./packages/core-db/src
 COPY packages/core-db/tsconfig.json ./packages/core-db/
 COPY packages/core-db/migrations ./packages/core-db/migrations
+COPY packages/finance-db/src ./packages/finance-db/src
+COPY packages/finance-db/tsconfig.json ./packages/finance-db/
+COPY packages/finance-db/migrations ./packages/finance-db/migrations
 COPY packages/media-db/src ./packages/media-db/src
 COPY packages/media-db/tsconfig.json ./packages/media-db/
 COPY packages/media-db/migrations ./packages/media-db/migrations
@@ -56,6 +60,8 @@ RUN pnpm build
 WORKDIR /app/packages/food-contracts
 RUN pnpm build
 WORKDIR /app/packages/core-db
+RUN pnpm build
+WORKDIR /app/packages/finance-db
 RUN pnpm build
 WORKDIR /app/packages/inventory-db
 RUN pnpm build
@@ -101,6 +107,9 @@ COPY --from=builder /app/packages/app-lists-db/package.json ./node_modules/@pops
 COPY --from=builder /app/packages/core-db/dist ./node_modules/@pops/core-db/dist
 COPY --from=builder /app/packages/core-db/package.json ./node_modules/@pops/core-db/
 COPY --from=builder /app/packages/core-db/migrations ./node_modules/@pops/core-db/migrations
+COPY --from=builder /app/packages/finance-db/dist ./node_modules/@pops/finance-db/dist
+COPY --from=builder /app/packages/finance-db/package.json ./node_modules/@pops/finance-db/
+COPY --from=builder /app/packages/finance-db/migrations ./node_modules/@pops/finance-db/migrations
 COPY --from=builder /app/packages/inventory-db/dist ./node_modules/@pops/inventory-db/dist
 COPY --from=builder /app/packages/inventory-db/package.json ./node_modules/@pops/inventory-db/
 COPY --from=builder /app/packages/inventory-db/migrations ./node_modules/@pops/inventory-db/migrations

--- a/apps/pops-api/package.json
+++ b/apps/pops-api/package.json
@@ -80,6 +80,7 @@
     "@pops/app-lists-db": "workspace:*",
     "@pops/core-db": "workspace:*",
     "@pops/db-types": "workspace:*",
+    "@pops/finance-db": "workspace:*",
     "@pops/food-contracts": "workspace:*",
     "@pops/inventory-db": "workspace:*",
     "@pops/media-db": "workspace:*",

--- a/apps/pops-api/src/modules/finance/wishlist/service.ts
+++ b/apps/pops-api/src/modules/finance/wishlist/service.ts
@@ -44,6 +44,14 @@ export function listWishListItems(
   limit: number,
   offset: number
 ): WishListListResult {
+  // Preserve pre-cutover wire semantics: the original SQL filter applied
+  // an `eq(priority, <any-string>)` for any non-empty value, so an
+  // unknown priority matched zero rows. The package's typed query drops
+  // invalid values entirely, which would return ALL rows — a silent
+  // behaviour change. Short-circuit here to keep the empty-page result.
+  if (priority !== undefined && priority !== '' && !PRIORITY_LOOKUP.has(priority)) {
+    return { rows: [], total: 0 };
+  }
   return wishListService.listWishListItems(getDrizzle(), {
     search,
     priority: asPriority(priority),

--- a/apps/pops-api/src/modules/finance/wishlist/service.ts
+++ b/apps/pops-api/src/modules/finance/wishlist/service.ts
@@ -1,127 +1,90 @@
-import { and, asc, count, eq, like } from 'drizzle-orm';
-
 /**
- * Wish list service — CRUD operations against SQLite via Drizzle ORM.
- * SQLite is the source of truth. All operations are local.
+ * Thin wrapper around `@pops/finance-db`'s wish-list service.
+ *
+ * Resolves the singleton `getDrizzle()` handle and forwards. Translates
+ * the package's typed errors to the HTTP-layer error variants the rest
+ * of pops-api still expects (`NotFoundError`) so the global error handler
+ * keeps producing the same status codes and i18n keys it did before the
+ * finance pillar Phase 1 split.
+ *
+ * This shim is deleted in Phase 1 PR 4. Existing callers (`router.ts`,
+ * `wishlist.test.ts`) keep importing from here unchanged; the deletion
+ * PR also flips them to the package directly and drops this file.
  */
-import { wishList } from '@pops/db-types';
+import {
+  wishListService,
+  WishListItemNotFoundError,
+  type WishListPriority,
+  WISH_LIST_PRIORITIES,
+} from '@pops/finance-db';
 
 import { getDrizzle } from '../../../db.js';
 import { NotFoundError } from '../../../shared/errors.js';
 
-import type { CreateWishListItemInput, UpdateWishListItemInput, WishListRow } from './types.js';
+import type {
+  CreateWishListItemInput,
+  UpdateWishListItemInput,
+  WishListListResult,
+  WishListRow,
+} from '@pops/finance-db';
 
-/** Count + rows for a paginated list. */
-export interface WishListListResult {
-  rows: WishListRow[];
-  total: number;
+export type { WishListListResult, WishListRow };
+
+const PRIORITY_LOOKUP: ReadonlySet<string> = new Set(WISH_LIST_PRIORITIES);
+
+/** Type-guard: turn an opaque string filter into the package's typed priority. */
+function asPriority(value: string | undefined): WishListPriority | undefined {
+  if (value === undefined || !PRIORITY_LOOKUP.has(value)) return undefined;
+  return value as WishListPriority;
 }
 
-/** List wish list items with optional search and priority filters. */
 export function listWishListItems(
   search: string | undefined,
   priority: string | undefined,
   limit: number,
   offset: number
 ): WishListListResult {
-  const db = getDrizzle();
-  const conditions = [];
-
-  if (search) {
-    conditions.push(like(wishList.item, `%${search}%`));
-  }
-  if (priority) {
-    conditions.push(eq(wishList.priority, priority));
-  }
-
-  const where = conditions.length > 0 ? and(...conditions) : undefined;
-
-  const rows = db
-    .select()
-    .from(wishList)
-    .where(where)
-    .orderBy(asc(wishList.item))
-    .limit(limit)
-    .offset(offset)
-    .all();
-  const countRow = db.select({ total: count() }).from(wishList).where(where).all()[0];
-  const total = countRow?.total ?? 0;
-
-  return { rows, total };
+  return wishListService.listWishListItems(getDrizzle(), {
+    search,
+    priority: asPriority(priority),
+    limit,
+    offset,
+  });
 }
 
-/** Get a single wish list item by id. Throws NotFoundError if missing. */
 export function getWishListItem(id: string): WishListRow {
-  const db = getDrizzle();
-  const row = db.select().from(wishList).where(eq(wishList.id, id)).get();
-
-  if (!row) throw new NotFoundError('Wish list item', id);
-  return row;
+  try {
+    return wishListService.getWishListItem(getDrizzle(), id);
+  } catch (err) {
+    if (err instanceof WishListItemNotFoundError) {
+      throw new NotFoundError('Wish list item', id);
+    }
+    throw err;
+  }
 }
 
-/**
- * Create a new wish list item. Returns the created row.
- * Generates a local UUID and inserts directly into SQLite.
- */
 export function createWishListItem(input: CreateWishListItemInput): WishListRow {
-  const db = getDrizzle();
-  const id = crypto.randomUUID();
-  const now = new Date().toISOString();
-
-  db.insert(wishList)
-    .values({
-      id,
-      item: input.item,
-      targetAmount: input.targetAmount ?? null,
-      saved: input.saved ?? null,
-      priority: input.priority ?? null,
-      url: input.url ?? null,
-      notes: input.notes ?? null,
-      lastEditedTime: now,
-    })
-    .run();
-
-  return getWishListItem(id);
-}
-
-/**
- * Update an existing wish list item. Returns the updated row.
- * Updates directly in SQLite.
- */
-function buildWishListUpdates(
-  input: UpdateWishListItemInput
-): Partial<typeof wishList.$inferInsert> {
-  const updates: Partial<typeof wishList.$inferInsert> = {};
-  if (input.item !== undefined) updates.item = input.item;
-  if (input.targetAmount !== undefined) updates.targetAmount = input.targetAmount ?? null;
-  if (input.saved !== undefined) updates.saved = input.saved ?? null;
-  if (input.priority !== undefined) updates.priority = input.priority ?? null;
-  if (input.url !== undefined) updates.url = input.url ?? null;
-  if (input.notes !== undefined) updates.notes = input.notes ?? null;
-  return updates;
+  return wishListService.createWishListItem(getDrizzle(), input);
 }
 
 export function updateWishListItem(id: string, input: UpdateWishListItemInput): WishListRow {
-  getWishListItem(id);
-
-  const updates = buildWishListUpdates(input);
-  if (Object.keys(updates).length > 0) {
-    updates.lastEditedTime = new Date().toISOString();
-    getDrizzle().update(wishList).set(updates).where(eq(wishList.id, id)).run();
+  try {
+    return wishListService.updateWishListItem(getDrizzle(), id, input);
+  } catch (err) {
+    if (err instanceof WishListItemNotFoundError) {
+      throw new NotFoundError('Wish list item', id);
+    }
+    throw err;
   }
-
-  return getWishListItem(id);
 }
 
-/**
- * Delete a wish list item by ID. Throws NotFoundError if missing.
- * Deletes directly from SQLite.
- */
 export function deleteWishListItem(id: string): void {
-  // Verify it exists first
-  getWishListItem(id);
-
-  const db = getDrizzle();
-  const result = db.delete(wishList).where(eq(wishList.id, id)).run();
-  if (result.changes === 0) throw new NotFoundError('Wish list item', id);
+  try {
+    wishListService.deleteWishListItem(getDrizzle(), id);
+  } catch (err) {
+    if (err instanceof WishListItemNotFoundError) {
+      throw new NotFoundError('Wish list item', id);
+    }
+    throw err;
+  }
 }

--- a/apps/pops-api/src/modules/finance/wishlist/wishlist.test.ts
+++ b/apps/pops-api/src/modules/finance/wishlist/wishlist.test.ts
@@ -111,6 +111,19 @@ describe('wishlist.list', () => {
     expect(result.data[0]!.item).toBe('AirPods Max');
   });
 
+  it('returns an empty page when priority is a non-empty unknown value', async () => {
+    seedWishListItem(db, { item: 'MacBook Pro', priority: 'Needing' });
+    seedWishListItem(db, { item: 'AirPods Max', priority: 'Dreaming' });
+
+    // Pre-cutover the SQL filter applied eq(priority, '<any-string>') so an
+    // unknown value matched zero rows. Lock that wire behaviour against the
+    // pillar-finance Phase 1 cutover regression where the package's typed
+    // query would drop unknown values and return all rows.
+    const result = await caller.finance.wishlist.list({ priority: 'NotARealPriority' });
+    expect(result.data).toEqual([]);
+    expect(result.pagination.total).toBe(0);
+  });
+
   it('combines search and priority filters', async () => {
     seedWishListItem(db, { item: 'MacBook Pro', priority: 'Needing' });
     seedWishListItem(db, { item: 'MacBook Air', priority: 'Dreaming' });

--- a/apps/pops-mcp/Dockerfile
+++ b/apps/pops-mcp/Dockerfile
@@ -12,6 +12,7 @@ COPY packages/api-client/package.json ./packages/api-client/
 COPY packages/app-food-db/package.json ./packages/app-food-db/
 COPY packages/app-lists-db/package.json ./packages/app-lists-db/
 COPY packages/core-db/package.json ./packages/core-db/
+COPY packages/finance-db/package.json ./packages/finance-db/
 COPY packages/media-db/package.json ./packages/media-db/
 COPY packages/food-contracts/package.json ./packages/food-contracts/
 COPY packages/inventory-db/package.json ./packages/inventory-db/
@@ -36,6 +37,9 @@ COPY packages/app-food-db/tsconfig.json ./packages/app-food-db/
 COPY packages/core-db/src ./packages/core-db/src
 COPY packages/core-db/tsconfig.json ./packages/core-db/
 COPY packages/core-db/migrations ./packages/core-db/migrations
+COPY packages/finance-db/src ./packages/finance-db/src
+COPY packages/finance-db/tsconfig.json ./packages/finance-db/
+COPY packages/finance-db/migrations ./packages/finance-db/migrations
 COPY packages/media-db/src ./packages/media-db/src
 COPY packages/media-db/tsconfig.json ./packages/media-db/
 COPY packages/media-db/migrations ./packages/media-db/migrations
@@ -64,6 +68,8 @@ RUN pnpm build
 WORKDIR /app/packages/food-contracts
 RUN pnpm build
 WORKDIR /app/packages/core-db
+RUN pnpm build
+WORKDIR /app/packages/finance-db
 RUN pnpm build
 WORKDIR /app/packages/inventory-db
 RUN pnpm build

--- a/apps/pops-shell/Dockerfile
+++ b/apps/pops-shell/Dockerfile
@@ -16,6 +16,7 @@ COPY packages/food-contracts/package.json ./packages/food-contracts/
 COPY packages/app-lists/package.json ./packages/app-lists/
 COPY packages/app-lists-db/package.json ./packages/app-lists-db/
 COPY packages/core-db/package.json ./packages/core-db/
+COPY packages/finance-db/package.json ./packages/finance-db/
 COPY packages/inventory-db/package.json ./packages/inventory-db/
 COPY packages/media-db/package.json ./packages/media-db/
 COPY packages/app-media/package.json ./packages/app-media/
@@ -43,6 +44,7 @@ COPY packages/app-lists/ ./packages/app-lists/
 COPY packages/app-lists-db/ ./packages/app-lists-db/
 COPY packages/app-food-db/ ./packages/app-food-db/
 COPY packages/core-db/ ./packages/core-db/
+COPY packages/finance-db/ ./packages/finance-db/
 COPY packages/inventory-db/ ./packages/inventory-db/
 COPY packages/media-db/ ./packages/media-db/
 COPY packages/food-contracts/ ./packages/food-contracts/
@@ -55,6 +57,8 @@ RUN pnpm build
 WORKDIR /app/packages/food-contracts
 RUN pnpm build
 WORKDIR /app/packages/core-db
+RUN pnpm build
+WORKDIR /app/packages/finance-db
 RUN pnpm build
 WORKDIR /app/packages/inventory-db
 RUN pnpm build

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       '@pops/db-types':
         specifier: workspace:*
         version: link:../../packages/db-types
+      '@pops/finance-db':
+        specifier: workspace:*
+        version: link:../../packages/finance-db
       '@pops/food-contracts':
         specifier: workspace:*
         version: link:../../packages/food-contracts


### PR DESCRIPTION
## Summary

- Flips the only consumer of the in-tree wish-list service over to `@pops/finance-db`.
- `apps/pops-api/src/modules/finance/wishlist/service.ts` becomes a thin shim that resolves `getDrizzle()` and forwards.
- `WishListItemNotFoundError` is translated to `NotFoundError` so the global error handler keeps producing the same status codes and i18n keys.

## What the shim does

- Five free functions matching the original surface (`listWishListItems`, `getWishListItem`, `createWishListItem`, `updateWishListItem`, `deleteWishListItem`).
- Narrows the router's opaque `priority` filter (any string) to the package's `WishListPriority` union via a Set membership check — keeps the lenient external behaviour while staying type-safe at the package boundary. No router signature changes.

Existing callers in `router.ts` and `wishlist.test.ts` are unchanged. **PR 4** of phase 1 deletes the shim and flips those last imports to the package directly.

## CI / Docker wiring

Mirrors core PR 3 and media PR 3 patterns:

- `.github/workflows/{_pkg-check,api-quality,api-test,fe-quality,fe-test-e2e}.yml` build `@pops/finance-db` before pops-api consumers.
- `apps/pops-{api,shell,mcp}/Dockerfile` copy `packages/finance-db`'s `package.json` + `src` + `tsconfig` + `migrations` into the workspace, build it after `core-db`, and (pops-api) copy the built `dist` + `package.json` + `migrations` into `node_modules/@pops/finance-db` so the runtime resolver finds it.

## Test plan

- [x] `pnpm --filter @pops/finance-db build` / `typecheck` / `test` (14/14)
- [x] `apps/pops-api`'s `wishlist/*.test.ts` (55/55 passing — covers the wrapper end-to-end via tRPC caller)
- [x] `pnpm typecheck` (pops-api compiles cleanly through the shim)
- [x] `pnpm lint` clean
- [x] Local Docker build sanity: package.json + Dockerfile diff symmetric with the existing `core-db` / `media-db` blocks