### PR TITLE
fix(food): listFailed requires error_message IS NOT NULL + de-flake OverlayHost test

### DIFF
--- a/apps/pops-api/src/modules/food/__tests__/inbox-rejected-failed.test.ts
+++ b/apps/pops-api/src/modules/food/__tests__/inbox-rejected-failed.test.ts
@@ -26,7 +26,7 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import BetterSqlite3, { type Database } from 'better-sqlite3';
-import { sql } from 'drizzle-orm';
+import { eq, sql } from 'drizzle-orm';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import {
@@ -35,6 +35,7 @@ import {
   recipesService,
   variantsService,
 } from '@pops/app-food-db';
+import { ingestSources } from '@pops/db-types';
 
 import { closeDb, getDrizzle, setDb } from '../../../db.js';
 import { createCaller } from '../../../shared/test-utils.js';
@@ -158,13 +159,15 @@ function seedFailedSource(opts: {
   // every "this is a failed source" fixture is realistic; the legacy
   // half-null case is exercised explicitly by the regression test below.
   const errorMessage = opts.errorMessage ?? `seeded: ${opts.errorCode}`;
-  const updates: string[] = [
-    `error_code = '${opts.errorCode.replace(/'/g, "''")}'`,
-    `error_message = '${errorMessage.replace(/'/g, "''")}'`,
-    `attempts = ${opts.attempts ?? 1}`,
-  ];
-  if (opts.ingestedAt !== undefined) updates.push(`ingested_at = '${opts.ingestedAt}'`);
-  db.run(sql.raw(`UPDATE ingest_sources SET ${updates.join(', ')} WHERE id = ${source.id}`));
+  db.update(ingestSources)
+    .set({
+      errorCode: opts.errorCode,
+      errorMessage,
+      attempts: opts.attempts ?? 1,
+      ...(opts.ingestedAt !== undefined ? { ingestedAt: opts.ingestedAt } : {}),
+    })
+    .where(eq(ingestSources.id, source.id))
+    .run();
   return { sourceId: source.id };
 }
 
@@ -336,20 +339,18 @@ describe('food.inbox.listFailed — PRD-138', () => {
       kind: 'text',
       extractorVersion: 'test-v1',
     });
-    db.run(
-      sql.raw(
-        `UPDATE ingest_sources SET error_code = 'CodeOnlyNoMessage', error_message = NULL, attempts = 1 WHERE id = ${codeOnly.id}`
-      )
-    );
+    db.update(ingestSources)
+      .set({ errorCode: 'CodeOnlyNoMessage', errorMessage: null, attempts: 1 })
+      .where(eq(ingestSources.id, codeOnly.id))
+      .run();
     const messageOnly = ingestSourcesService.createIngestSource(db, {
       kind: 'text',
       extractorVersion: 'test-v1',
     });
-    db.run(
-      sql.raw(
-        `UPDATE ingest_sources SET error_code = NULL, error_message = 'msg without code', attempts = 1 WHERE id = ${messageOnly.id}`
-      )
-    );
+    db.update(ingestSources)
+      .set({ errorCode: null, errorMessage: 'msg without code', attempts: 1 })
+      .where(eq(ingestSources.id, messageOnly.id))
+      .run();
     const result = await caller.food.inbox.listFailed({});
     expect(result.items).toHaveLength(0);
   });

--- a/apps/pops-api/src/modules/food/__tests__/inbox-rejected-failed.test.ts
+++ b/apps/pops-api/src/modules/food/__tests__/inbox-rejected-failed.test.ts
@@ -153,9 +153,14 @@ function seedFailedSource(opts: {
     extractorVersion: 'test-v1',
     url: opts.url ?? null,
   });
+  // PRD-125's `workerComplete` writes `error_code` and `error_message` as a
+  // pair on `ok:false`. The seed defaults the message to a marker string so
+  // every "this is a failed source" fixture is realistic; the legacy
+  // half-null case is exercised explicitly by the regression test below.
+  const errorMessage = opts.errorMessage ?? `seeded: ${opts.errorCode}`;
   const updates: string[] = [
     `error_code = '${opts.errorCode.replace(/'/g, "''")}'`,
-    `error_message = ${opts.errorMessage === undefined ? 'NULL' : `'${opts.errorMessage.replace(/'/g, "''")}'`}`,
+    `error_message = '${errorMessage.replace(/'/g, "''")}'`,
     `attempts = ${opts.attempts ?? 1}`,
   ];
   if (opts.ingestedAt !== undefined) updates.push(`ingested_at = '${opts.ingestedAt}'`);
@@ -315,6 +320,36 @@ describe('food.inbox.listFailed — PRD-138', () => {
     // error_code stays NULL on the source — confirms the predicate excludes it.
     const seed = seedDraft('auth-dead-placeholder', 'url-instagram', 'https://instagram.com/p/x');
     expect(seed.sourceId).toBeGreaterThan(0);
+    const result = await caller.food.inbox.listFailed({});
+    expect(result.items).toHaveLength(0);
+  });
+
+  it('excludes legacy rows where only one of error_code / error_message is set', async () => {
+    // PRD-125's `workerComplete` writes the pair atomically, but a backfill
+    // or a half-finished migration could produce rows with just one half set.
+    // Either half being null means the row can't render a useful Failed row,
+    // so `buildWhere` filters it out rather than emitting an empty error
+    // message in the UI. Build both cases by hand — the seed helper now
+    // mirrors the production-pair contract and won't produce a half-null row.
+    const db = getDrizzle();
+    const codeOnly = ingestSourcesService.createIngestSource(db, {
+      kind: 'text',
+      extractorVersion: 'test-v1',
+    });
+    db.run(
+      sql.raw(
+        `UPDATE ingest_sources SET error_code = 'CodeOnlyNoMessage', error_message = NULL, attempts = 1 WHERE id = ${codeOnly.id}`
+      )
+    );
+    const messageOnly = ingestSourcesService.createIngestSource(db, {
+      kind: 'text',
+      extractorVersion: 'test-v1',
+    });
+    db.run(
+      sql.raw(
+        `UPDATE ingest_sources SET error_code = NULL, error_message = 'msg without code', attempts = 1 WHERE id = ${messageOnly.id}`
+      )
+    );
     const result = await caller.food.inbox.listFailed({});
     expect(result.items).toHaveLength(0);
   });

--- a/apps/pops-shell/src/app/overlays/OverlayHost.test.tsx
+++ b/apps/pops-shell/src/app/overlays/OverlayHost.test.tsx
@@ -3,31 +3,57 @@ import { useUIStore } from '@/store/uiStore';
  * Tests for `OverlayHost` (PRD-101 US-07).
  *
  * Three scenarios:
- *   1. Default — ego overlay is in `installedOverlays` and declares the
- *      `assistant` slot; mounting the host for that slot results in the
- *      lazy ego component being loaded and the `aside` element rendered
- *      into the DOM after Suspense resolves.
+ *   1. Default — an installed overlay declares the `assistant` slot;
+ *      mounting the host for that slot results in the lazy component
+ *      being loaded and its rendered output appearing after Suspense
+ *      resolves.
  *   2. Non-matching slot — mounting the host for a different known slot
- *      (`notification`) must NOT render the ego overlay, proving that
+ *      (`notification`) must NOT render the overlay, proving that
  *      `chromeSlot` actually drives placement.
  *   3. Empty install set (simulates `POPS_OVERLAYS=`) — the registry module
  *      is mocked to return no overlays; the host renders nothing.
  *
- * The OverlayHost does not mount the FAB; that's `RootLayout`'s job. We
- * only assert overlay presence/absence in the DOM.
+ * Each test mocks `./registry` with a synthetic overlay rather than relying
+ * on the real `@pops/overlay-ego` package. The real overlay drags Zustand,
+ * tRPC, and a large chat surface into the cold-vitest module graph; loading
+ * it on the first lazy-mount blows past the test timeout intermittently.
+ * The slot-matching + Suspense-unwrap mechanics under test are the same
+ * regardless of which component sits behind the loader.
  */
 import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-describe('OverlayHost — with ego installed (default)', () => {
-  it('lazy-loads the ego overlay into the assistant slot dialog', async () => {
-    // Leave the overlay closed. The dialog shell still renders (only the
-    // inner chat panel is conditional on `open`), so we can assert that
-    // the lazy mount happened without standing up a tRPC context just for
-    // the inner panel hooks.
-    useUIStore.setState({ overlays: { ego: false } });
+/** Synthetic overlay shaped like an `InstalledOverlay` so it satisfies the
+ *  `OverlayHost`'s mount path without pulling in any real overlay package. */
+function fakeInstalledOverlay(slot: 'assistant' | 'notification' | 'command') {
+  return {
+    moduleId: 'fake',
+    chromeSlot: slot,
+    shortcut: undefined,
+    loader: async () => ({
+      default: () => <aside aria-label="Chat overlay">fake</aside>,
+    }),
+  };
+}
 
+describe('OverlayHost — with an overlay installed in the assistant slot', () => {
+  beforeEach(() => {
+    useUIStore.setState({ overlays: { fake: false } });
+    vi.resetModules();
+    vi.doMock('./registry', () => ({
+      installedOverlays: [fakeInstalledOverlay('assistant')],
+      selectInstalledOverlays: () => [fakeInstalledOverlay('assistant')],
+      SHELL_OVERLAY_MANIFESTS: [],
+    }));
+  });
+
+  afterEach(() => {
+    vi.doUnmock('./registry');
+    vi.resetModules();
+  });
+
+  it('lazy-loads the overlay into the assistant slot', async () => {
     const { OverlayHost } = await import('./OverlayHost');
 
     const { container } = render(
@@ -36,16 +62,12 @@ describe('OverlayHost — with ego installed (default)', () => {
       </MemoryRouter>
     );
 
-    // Closed dialogs have aria-modal="false" so role-based queries skip
-    // them. Match the aside element directly to assert the lazy mount.
     await waitFor(() => {
       expect(container.querySelector('aside[aria-label="Chat overlay"]')).not.toBeNull();
     });
   });
 
-  it('does not mount the ego overlay into a non-matching slot', async () => {
-    useUIStore.setState({ overlays: { ego: false } });
-
+  it('does not mount the overlay into a non-matching slot', async () => {
     const { OverlayHost } = await import('./OverlayHost');
 
     const { container } = render(

--- a/packages/app-food-db/src/inbox/__tests__/gather-quality-inputs.test.ts
+++ b/packages/app-food-db/src/inbox/__tests__/gather-quality-inputs.test.ts
@@ -29,6 +29,10 @@ const MIGRATIONS = [
   '0065_prd_116_recipe_compile.sql',
   '0066_prd_123_conversions.sql',
   '0067_prd_125_ingest_error_columns.sql',
+  // PRD-136 adds `ingest_sources.reviewed_at` and the `recipe_version_rejections`
+  // table. PRD-137's gather helper reads `reviewed_at` so the migration must
+  // apply here too — without it the schema is missing the column.
+  '0068_prd_136_inbox_review.sql',
 ].map((name) =>
   readFileSync(
     join(__dirname, '../../../../../apps/pops-api/src/db/drizzle-migrations', name),

--- a/packages/app-food-db/src/services/inbox-queries-failed.ts
+++ b/packages/app-food-db/src/services/inbox-queries-failed.ts
@@ -2,9 +2,12 @@
  * PRD-138 — `food.inbox.listFailed` + `food.inbox.failedErrorCodes`.
  *
  * Drives the Failed-ingests tab in `/food/inbox`. The "no successful retry"
- * rule reduces to `WHERE error_code IS NOT NULL` because PRD-125's
- * `workerComplete` nulls those columns on the next success — see the PRD-125
- * amendment carried in `0067_prd_125_ingest_error_columns.sql`.
+ * rule reduces to `WHERE error_code IS NOT NULL AND error_message IS NOT NULL`
+ * — the pair is the contract PRD-125's `workerComplete` writes on
+ * `ok:false` and clears on the next success (see the amendment carried in
+ * `0067_prd_125_ingest_error_columns.sql`). Guarding on both columns
+ * defends against a half-finished backfill or a legacy row leaving one half
+ * null, which would otherwise surface as an empty `errorMessage` in the UI.
  *
  * Auth-dead Instagram reels never reach this tab: PRD-130 emits
  * `ok: true, partialReason: 'auth-dead'` so the worker writes a placeholder
@@ -34,6 +37,10 @@ export function listFailedSources(db: FoodDb, filter: ListFailedFilter): ListPag
       ingestKind: r.ingestKind,
       sourceUrl: r.sourceUrl,
       errorCode: r.errorCode,
+      // `buildWhere` enforces `error_message IS NOT NULL` so the column type
+      // is structurally nullable but the value never is. The empty-string
+      // fallback stays as defence in depth in case the predicate ever
+      // moves.
       errorMessage: r.errorMessage ?? '',
       ingestedAt: r.ingestedAt,
       attempts: r.attempts,
@@ -76,7 +83,15 @@ function selectFailedRows(db: FoodDb, filter: ListFailedFilter): JoinedFailedRow
 }
 
 function buildWhere(filter: ListFailedFilter): SQL | undefined {
-  const clauses: SQL[] = [isNotNull(ingestSources.errorCode)];
+  // PRD-125's `workerComplete` writes `error_code` and `error_message` as a
+  // pair on `ok:false` and clears them as a pair on a successful retry.
+  // Pinning both predicates keeps the Failed tab from surfacing legacy or
+  // backfilled rows where only one half is populated (which would render
+  // as an empty error message in the UI).
+  const clauses: SQL[] = [
+    isNotNull(ingestSources.errorCode),
+    isNotNull(ingestSources.errorMessage),
+  ];
   if (filter.errorCodes && filter.errorCodes.length > 0) {
     clauses.push(inArray(ingestSources.errorCode, filter.errorCodes));
   }


### PR DESCRIPTION
## Summary

Two small, independent fixes:

### 1. `food.inbox.listFailed` — guard both halves of the error pair (closes #2780)

The query was filtering on `error_code IS NOT NULL` only, but PRD-125's `workerComplete` writes `error_code` and `error_message` as a pair on `ok:false` and clears them as a pair on a successful retry. A backfill or a half-finished migration could produce rows with just one half set — the row would then surface in the Failed tab with an empty-string \`errorMessage\` (the service mapper coalesces with \`?? ''\`).

\`buildWhere\` now pins both predicates so the SQL self-documents the column-pair contract. Empty-string fallback in the row mapper stays as defence in depth. Originally surfaced by Copilot's review on the closed #2777.

### 2. De-flake \`OverlayHost.test.tsx\`

Test 1 was triggering the real \`@pops/overlay-ego\` lazy import on a cold vitest module graph. The first-mount intermittently exceeded the 5s test timeout (got hit during PRD-138 follow-up workflow runs). Replaced with the same registry-mock pattern test 3 already used + a featherweight synthetic overlay. The real ego selection path is still covered by \`registry.test.ts\`'s \`installedOverlays\` runtime case.

### 3. Drive-by

- \`seedFailedSource\` in the existing integration test now writes both error columns by default (matches PRD-125's contract; the legacy half-null case is exercised explicitly by the new regression test).
- Added the PRD-136 migration (\`0068_prd_136_inbox_review.sql\`) to \`gather-quality-inputs.test.ts\`. PRD-137's helper reads \`ingest_sources.reviewed_at\`; without the migration the four PRD-137 tests fail on \`SqliteError\`. Pre-existing breakage on main.

## Test plan

- [ ] \`mise lint\` clean.
- [ ] Full \`mise test\` workspace suite passes.
- [ ] \`OverlayHost.test.tsx\` runs cleanly across 5 consecutive invocations (verified locally).
- [ ] Inbox regression test \`excludes legacy rows where only one of error_code / error_message is set\` exercises both halves of the half-null case.