### PR TITLE
feat(media-db): add openMediaDb helper (pillar media phase 2 PR 1)

### DIFF
--- a/packages/media-db/src/__tests__/open-media-db.test.ts
+++ b/packages/media-db/src/__tests__/open-media-db.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Smoke tests for the standalone `openMediaDb` helper.
+ *
+ * Exercises the migration apply path against a fresh tmp file, verifies
+ * the resulting schema, and confirms the helper is idempotent when
+ * re-run against the same DB.
+ *
+ * Mirrors `@pops/core-db`'s open-core-db.test.ts.
+ */
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { openMediaDb } from '../open-media-db.js';
+import { shelfImpressions } from '../schema.js';
+import { getRecentImpressions, recordImpressions } from '../services/shelf-impressions.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'media-db-test-'));
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('openMediaDb', () => {
+  it('creates the parent directory and opens a fresh DB with the right pragmas', () => {
+    const path = join(tmpDir, 'nested', 'sub', 'media.db');
+    expect(existsSync(path)).toBe(false);
+
+    const { raw } = openMediaDb(path);
+    try {
+      expect(existsSync(path)).toBe(true);
+      expect(raw.pragma('journal_mode', { simple: true })).toBe('wal');
+      expect(raw.pragma('foreign_keys', { simple: true })).toBe(1);
+      expect(raw.pragma('busy_timeout', { simple: true })).toBe(5000);
+    } finally {
+      raw.close();
+    }
+  });
+
+  it('applies the shelf_impressions migration', () => {
+    const path = join(tmpDir, 'media.db');
+    const { db, raw } = openMediaDb(path);
+    try {
+      // Table exists + accepts the package service end-to-end.
+      recordImpressions(db, ['trending']);
+      const rows = db.select().from(shelfImpressions).all();
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.shelfId).toBe('trending');
+    } finally {
+      raw.close();
+    }
+  });
+
+  it('is idempotent — re-opening the same DB does not re-apply migrations or wipe rows', () => {
+    const path = join(tmpDir, 'media.db');
+    const first = openMediaDb(path);
+    try {
+      recordImpressions(first.db, ['trending', 'because-you-watched:42']);
+      expect(getRecentImpressions(first.db, 7).size).toBe(2);
+    } finally {
+      first.raw.close();
+    }
+
+    const second = openMediaDb(path);
+    try {
+      // Migration apply is hash-checked + no-op'd; rows persist across opens.
+      expect(getRecentImpressions(second.db, 7).size).toBe(2);
+      expect(second.raw.pragma('journal_mode', { simple: true })).toBe('wal');
+    } finally {
+      second.raw.close();
+    }
+  });
+});

--- a/packages/media-db/src/index.ts
+++ b/packages/media-db/src/index.ts
@@ -15,4 +15,6 @@ export * from './schema.js';
 
 export type { MediaDb } from './services/internal.js';
 
+export { openMediaDb, type OpenedMediaDb } from './open-media-db.js';
+
 export * as shelfImpressionsService from './services/shelf-impressions.js';

--- a/packages/media-db/src/open-media-db.ts
+++ b/packages/media-db/src/open-media-db.ts
@@ -1,0 +1,82 @@
+/**
+ * Standalone opener for the media pillar's SQLite database.
+ *
+ * Phase 2 PR 1 of the media pillar migration scaffolds the per-pillar
+ * connection so subsequent PRs can flip readers/writers over without
+ * touching pops-api's existing singleton. The opener is intentionally
+ * minimal — it does NOT load the sqlite-vec extension or the
+ * vector-index helpers (those stay with pops-api's `getDrizzle()` for
+ * now) and it relies on drizzle-orm's built-in `migrate` helper to apply
+ * the in-package migrations journal at `packages/media-db/migrations/meta/_journal.json`.
+ *
+ * No production consumer wires this up yet. Subsequent PRs add the
+ * `MEDIA_SQLITE_PATH` env-var read in pops-api, the boot-time call, and
+ * the data backfill from the shared pops.db.
+ *
+ * Mirrors `@pops/core-db`'s `openCoreDb`.
+ */
+import { mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+
+import type { MediaDb } from './services/internal.js';
+
+/**
+ * Path to the migrations folder inside this package. Resolved relative
+ * to this module's location (`src/open-media-db.ts` in dev,
+ * `dist/open-media-db.js` after build) so it works both when consumed
+ * via the workspace symlink and when bundled into a Docker image's
+ * `node_modules/@pops/media-db/`.
+ */
+function migrationsDir(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  return join(here, '..', 'migrations');
+}
+
+/** Result of {@link openMediaDb}. The raw handle is exposed for callers
+ * that need lifecycle control (close on shutdown, prepared statements,
+ * pragmas the drizzle wrapper hides). */
+export interface OpenedMediaDb {
+  /** Drizzle handle — pass into any `shelfImpressionsService.*` call. */
+  db: MediaDb;
+  /** Raw better-sqlite3 handle. Call `.close()` on shutdown. */
+  raw: Database.Database;
+}
+
+/**
+ * Open the media pillar's SQLite database at `path`, configure it, apply
+ * the in-package migrations journal, and return both the drizzle wrapper
+ * and the raw handle.
+ *
+ * Side effects:
+ *   - The parent directory of `path` is created if missing (recursive).
+ *   - `journal_mode=WAL`, `foreign_keys=ON`, and `busy_timeout=5000` are
+ *     enabled to match the shared singleton in `apps/pops-api/src/db.ts`.
+ *   - Every migration in `packages/media-db/migrations/meta/_journal.json`
+ *     is applied via drizzle's built-in migrator (idempotent — re-running
+ *     against the same DB short-circuits on the `__drizzle_migrations`
+ *     hash check).
+ *
+ * If the migration apply throws (corrupt DB, malformed migration, missing
+ * folder), the raw handle is closed before the error is re-thrown so the
+ * caller can't leak a locked file descriptor.
+ */
+export function openMediaDb(path: string): OpenedMediaDb {
+  mkdirSync(dirname(path), { recursive: true });
+  const raw = new Database(path);
+  raw.pragma('journal_mode = WAL');
+  raw.pragma('foreign_keys = ON');
+  raw.pragma('busy_timeout = 5000');
+  const db = drizzle(raw) as MediaDb;
+  try {
+    migrate(db, { migrationsFolder: migrationsDir() });
+  } catch (err) {
+    raw.close();
+    throw err;
+  }
+  return { db, raw };
+}


### PR DESCRIPTION
## Summary

First PR of the **media pillar Phase 2 — extract media's SQLite** sequence (pillar-migration-roadmap.md Track F · Phase 2 PR 1 of 4). Mirrors core's PR 1 (#2747).

Scaffolds the per-pillar SQLite connection helper inside \`@pops/media-db\`. **Strictly additive — no consumer wires this up yet.**

## What changed

- \`packages/media-db/src/open-media-db.ts\` — new \`openMediaDb(path)\` helper:
  - Creates the parent directory recursively
  - Opens a fresh \`better-sqlite3\` connection
  - Enables \`journal_mode=WAL\` + \`foreign_keys=ON\` + \`busy_timeout=5000\` pragmas to match pops-api's shared singleton
  - Applies the in-package migrations journal via \`drizzle-orm/better-sqlite3/migrator\` (resolves the migrations folder relative to the compiled \`dist/\` so it works via the workspace symlink and inside Docker images)
  - Returns both the drizzle wrapper and the raw handle for lifecycle control
- \`packages/media-db/src/index.ts\` — re-exports \`openMediaDb\` + \`OpenedMediaDb\`
- 3 new vitest cases (21/21 in media-db): parent-dir creation + pragma assertions, \`shelf_impressions\` migration applies end-to-end (insert → read round-trips through both helpers), idempotency on re-open

## Roadmap context

- Phase 2 PR 2 will add the \`MEDIA_SQLITE_PATH\` env-var read in pops-api and the boot-time \`openMediaDb()\` call (still no behavioural change — the handle is opened but unused).
- PR 3 backfills shelf-impressions rows from the shared \`pops.db\` and flips reads/writes over (ATTACH-based, mirroring core PR 3 #2756).
- PR 4 drops the table from the shared journal + Litestream config at \`infra/litestream/media.yml\`.

## Verification

- \`pnpm --filter @pops/media-db typecheck\` — clean
- \`pnpm --filter @pops/media-db test\` — 21/21 cases pass
- \`pnpm typecheck\` — 38/38 packages green
- \`pnpm format:check\` — clean

## Test plan

- [ ] CI green on \`media-db-quality\` (new tests + drift guard intact)
- [ ] Copilot review pass