### PR TITLE
feat(inventory-db): add openInventoryDb helper (pillar inventory phase 2 PR 1)

### DIFF
--- a/packages/inventory-db/src/__tests__/open-inventory-db.test.ts
+++ b/packages/inventory-db/src/__tests__/open-inventory-db.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Smoke tests for the standalone `openInventoryDb` helper.
+ *
+ * Exercises the migration apply path against a fresh tmp file, verifies
+ * the resulting schema, and confirms the helper is idempotent when
+ * re-run against the same DB.
+ */
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { openInventoryDb } from '../open-inventory-db.js';
+import { createLocation, listLocations } from '../services/locations.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'inventory-db-test-'));
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('openInventoryDb', () => {
+  it('creates the parent directory and opens a fresh DB', () => {
+    const path = join(tmpDir, 'nested', 'sub', 'inventory.db');
+    expect(existsSync(path)).toBe(false);
+
+    const { raw } = openInventoryDb(path);
+    try {
+      expect(existsSync(path)).toBe(true);
+      expect(raw.pragma('journal_mode', { simple: true })).toBe('wal');
+      expect(raw.pragma('foreign_keys', { simple: true })).toBe(1);
+      expect(raw.pragma('busy_timeout', { simple: true })).toBe(5000);
+    } finally {
+      raw.close();
+    }
+  });
+
+  it('applies the locations migration', () => {
+    const path = join(tmpDir, 'inventory.db');
+    const { db, raw } = openInventoryDb(path);
+    try {
+      // Table exists + accepts inserts via the package service.
+      expect(listLocations(db).total).toBe(0);
+      createLocation(db, { name: 'Home' });
+      expect(listLocations(db).total).toBe(1);
+    } finally {
+      raw.close();
+    }
+  });
+
+  it('is idempotent — re-opening the same DB does not re-apply migrations', () => {
+    const path = join(tmpDir, 'inventory.db');
+    const first = openInventoryDb(path);
+    try {
+      createLocation(first.db, { name: 'persists' });
+      expect(listLocations(first.db).total).toBe(1);
+    } finally {
+      first.raw.close();
+    }
+
+    const second = openInventoryDb(path);
+    try {
+      expect(listLocations(second.db).total).toBe(1);
+    } finally {
+      second.raw.close();
+    }
+  });
+});

--- a/packages/inventory-db/src/index.ts
+++ b/packages/inventory-db/src/index.ts
@@ -16,6 +16,8 @@ export * from './schema.js';
 
 export type { InventoryDb } from './services/internal.js';
 
+export { openInventoryDb, type OpenedInventoryDb } from './open-inventory-db.js';
+
 export * as locationsService from './services/locations.js';
 
 // Public types re-exported at the package root so consumers can name

--- a/packages/inventory-db/src/open-inventory-db.ts
+++ b/packages/inventory-db/src/open-inventory-db.ts
@@ -1,0 +1,81 @@
+/**
+ * Standalone opener for the inventory pillar's SQLite database.
+ *
+ * Phase 2 PR 1 of the inventory pillar migration scaffolds the
+ * per-pillar connection so subsequent PRs can flip readers/writers
+ * over without touching pops-api's existing singleton. The opener is
+ * intentionally minimal — it relies on drizzle-orm's built-in
+ * `migrate` helper to apply the in-package migrations journal at
+ * `packages/inventory-db/migrations/meta/_journal.json`.
+ *
+ * No production consumer wires this up yet. Subsequent PRs add the
+ * `INVENTORY_SQLITE_PATH` env-var read in pops-api, the boot-time
+ * call, and the data backfill from the shared pops.db.
+ */
+import { mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+
+import type { InventoryDb } from './services/internal.js';
+
+/**
+ * Path to the migrations folder inside this package. Resolved relative
+ * to this module's location (`src/open-inventory-db.ts` in dev,
+ * `dist/open-inventory-db.js` after build) so it works both when
+ * consumed via the workspace symlink and when bundled into a Docker
+ * image's `node_modules/@pops/inventory-db/`.
+ */
+function migrationsDir(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  return join(here, '..', 'migrations');
+}
+
+/** Result of {@link openInventoryDb}. The raw handle is exposed for callers
+ * that need lifecycle control (close on shutdown, prepared statements,
+ * pragmas the drizzle wrapper hides). */
+export interface OpenedInventoryDb {
+  /** Drizzle handle — pass into any `locationsService.*` call. */
+  db: InventoryDb;
+  /** Raw better-sqlite3 handle. Call `.close()` on shutdown. */
+  raw: Database.Database;
+}
+
+/**
+ * Open the inventory pillar's SQLite database at `path`, configure
+ * it, apply the in-package migrations journal, and return both the
+ * drizzle wrapper and the raw handle.
+ *
+ * Side effects:
+ *   - The parent directory of `path` is created if missing (recursive).
+ *   - `journal_mode=WAL`, `foreign_keys=ON`, and `busy_timeout=5000`
+ *     are enabled to match the shared singleton in
+ *     `apps/pops-api/src/db.ts`.
+ *   - Every migration in
+ *     `packages/inventory-db/migrations/meta/_journal.json` is applied
+ *     via drizzle's built-in migrator (idempotent — re-running against
+ *     the same DB short-circuits on the `__drizzle_migrations` hash
+ *     check).
+ *
+ * If the migration apply throws (corrupt DB, malformed migration,
+ * missing folder), the raw handle is closed before the error is
+ * re-thrown so the caller can't leak a locked file descriptor.
+ */
+export function openInventoryDb(path: string): OpenedInventoryDb {
+  mkdirSync(dirname(path), { recursive: true });
+  const raw = new Database(path);
+  raw.pragma('journal_mode = WAL');
+  raw.pragma('foreign_keys = ON');
+  raw.pragma('busy_timeout = 5000');
+  const db = drizzle(raw) as InventoryDb;
+  try {
+    migrate(db, { migrationsFolder: migrationsDir() });
+  } catch (err) {
+    raw.close();
+    throw err;
+  }
+  return { db, raw };
+}


### PR DESCRIPTION
## Summary

Phase 2 PR 1 of the inventory pillar migration scaffolds the per-pillar SQLite connection so subsequent PRs can flip readers/writers over without touching pops-api's existing singleton. Mirrors the `openCoreDb` helper landed for the core pilot in [#2747](https://github.com/knoxio/pops/pull/2747).

The helper:
- Creates the parent directory of the target path if missing (recursive).
- Opens better-sqlite3 with `journal_mode=WAL` + `foreign_keys=ON` + `busy_timeout=5000` to match the shared singleton in `apps/pops-api/src/db.ts`.
- Applies the in-package migrations journal via drizzle-orm's `migrate()` (idempotent against the same DB — re-running short-circuits on the `__drizzle_migrations` hash check).
- Closes the raw handle if the migration apply throws so the caller can't leak a locked file descriptor.

**No production consumer wires it up yet.** Subsequent PRs add the `INVENTORY_SQLITE_PATH` env-var read in pops-api, the boot-time call, the data backfill from the shared `pops.db`, the Litestream config at `infra/litestream/inventory.yml`, and the verification runbook.

### Includes
- `packages/inventory-db/src/open-inventory-db.ts` — the helper (mirrors `open-core-db.ts` line-for-line).
- `packages/inventory-db/src/__tests__/open-inventory-db.test.ts` — 3 cases: fresh open + pragmas, locations migration applied via `createLocation` round-trip, idempotency across re-opens (data persists, no double-apply).
- `packages/inventory-db/src/index.ts` re-exports `openInventoryDb` + `OpenedInventoryDb` type at the package root.

## Test plan
- [x] `cd packages/inventory-db && pnpm typecheck` — clean
- [x] `cd packages/inventory-db && pnpm test` — 36/36 pass (33 existing + 3 new for the opener)
- [x] `cd apps/pops-api && pnpm typecheck` — clean (after `pnpm install` to pick up freshly-merged finance-db symlink + `pnpm --filter @pops/finance-db build` against the rebuilt db-types)
- [x] `pnpm lint` / `pnpm format:check` / `pnpm lint:boundaries` — clean