### PR TITLE
feat(api): open the media pillar SQLite at boot (pillar media phase 2 PR 2)

### DIFF
--- a/apps/pops-api/.env.example
+++ b/apps/pops-api/.env.example
@@ -31,6 +31,11 @@ CORE_SQLITE_PATH=./data/core.db
 # inventory needs its own mount point / Litestream stream in production.
 INVENTORY_SQLITE_PATH=./data/inventory.db
 
+# Media pillar database (ADR-026). Defaults to <dirname(SQLITE_PATH)>/media.db,
+# falling back to ./data/media.db if SQLITE_PATH is unset. Set explicitly when
+# media needs its own mount point / Litestream stream in production.
+MEDIA_SQLITE_PATH=./data/media.db
+
 # Media Images
 # Directory for locally cached posters and backdrops
 MEDIA_IMAGES_DIR=./data/media/images

--- a/apps/pops-api/src/db.ts
+++ b/apps/pops-api/src/db.ts
@@ -10,6 +10,7 @@ import { createPreMigrationBackup, isFreshDatabase } from './db/backup.js';
 import { resolveCoreSqlitePath } from './db/core-sqlite-path.js';
 import { closeInventoryDb } from './db/inventory-handle.js';
 import { KNOWN_PILLARS } from './db/known-pillars.js';
+import { closeMediaDb } from './db/media-db-handle.js';
 import { migrationOwners } from './db/migration-ownership.js';
 import {
   getPendingMigrations,
@@ -234,6 +235,7 @@ export function closeDb(): void {
   }
   closeCoreDb();
   closeInventoryDb();
+  closeMediaDb();
 }
 
 /**
@@ -272,6 +274,11 @@ export function setCoreDb(next: OpenedCoreDb | null): OpenedCoreDb | null {
   coreDb = next;
   return prev;
 }
+
+// `getMediaDrizzle` / `closeMediaDb` / `setMediaDb` live in
+// `./db/media-db-handle.ts` so this file stays under the eslint(max-lines)
+// cap. `closeDb` calls the close helper at shutdown; the rest are imported
+// directly by their consumers.
 
 /**
  * One-shot backfill copying service-account rows from the shared

--- a/apps/pops-api/src/db.ts
+++ b/apps/pops-api/src/db.ts
@@ -7,6 +7,7 @@ import { type BetterSQLite3Database, drizzle } from 'drizzle-orm/better-sqlite3'
 import { openCoreDb, type CoreDb, type OpenedCoreDb } from '@pops/core-db';
 
 import { createPreMigrationBackup, isFreshDatabase } from './db/backup.js';
+import { backfillCoreFromShared as backfillCoreImpl } from './db/core-backfill.js';
 import { resolveCoreSqlitePath } from './db/core-sqlite-path.js';
 import { closeInventoryDb } from './db/inventory-handle.js';
 import { KNOWN_PILLARS } from './db/known-pillars.js';
@@ -281,54 +282,12 @@ export function setCoreDb(next: OpenedCoreDb | null): OpenedCoreDb | null {
 // directly by their consumers.
 
 /**
- * One-shot backfill copying service-account rows from the shared
- * `pops.db` into the core pillar's `core.db`. Idempotent — the
- * `WHERE id NOT IN (...)` filter means re-running after a partial
- * failure picks up where it left off without duplicating rows.
- *
- * Boot-time contract: PR 2 of phase 2 opened the core DB but did not
- * yet consume it. PR 3 (this entry point) flips service-accounts
- * traffic to the core handle, so the first deploy after PR 3 needs to
- * carry the existing rows across before any reads come from the new
- * file. Subsequent boots find the core copy already populated and
- * become a no-op via the existence filter.
- *
- * Non-fatal: ATTACH or INSERT failures are logged and swallowed so a
- * stale on-disk pops.db never bricks the boot path. Failures here
- * leave the core copy empty for that boot; the next deploy retries.
+ * Re-exported convenience wrapper around the standalone backfill in
+ * `./db/core-backfill.ts`. Resolves the singleton's raw handle and
+ * forwards. See {@link backfillCoreImpl} for the documented contract.
  */
 export function backfillCoreFromShared(): void {
-  if (!coreDb) return;
-  const sharedPath = resolveSqlitePath();
-  try {
-    coreDb.raw.prepare('ATTACH DATABASE ? AS pops').run(sharedPath);
-    try {
-      const hasTable = coreDb.raw
-        .prepare("SELECT 1 FROM pops.sqlite_master WHERE type='table' AND name='service_accounts'")
-        .get();
-      if (hasTable) {
-        // Enumerate columns explicitly so a future migration that
-        // widens the core table won't break the backfill against a
-        // stale on-disk pops.db that still has the older shape. Order
-        // matches the 0054_service_accounts.sql DDL byte-for-byte.
-        coreDb.raw.exec(`
-          INSERT INTO service_accounts (
-            id, name, key_prefix, key_hash, scopes,
-            created_at, last_used_at, revoked_at, created_by
-          )
-          SELECT
-            id, name, key_prefix, key_hash, scopes,
-            created_at, last_used_at, revoked_at, created_by
-          FROM pops.service_accounts
-          WHERE id NOT IN (SELECT id FROM service_accounts)
-        `);
-      }
-    } finally {
-      coreDb.raw.exec('DETACH DATABASE pops');
-    }
-  } catch (err) {
-    console.warn('[db] Core service-accounts backfill failed (non-fatal):', err);
-  }
+  backfillCoreImpl(coreDb?.raw ?? null);
 }
 
 export function setDb(newDb: BetterSqlite3.Database): BetterSqlite3.Database | null {

--- a/apps/pops-api/src/db/core-backfill.ts
+++ b/apps/pops-api/src/db/core-backfill.ts
@@ -1,0 +1,62 @@
+import { resolveSqlitePath } from './sqlite-path.js';
+
+/**
+ * One-shot core-pillar backfill — copies service-account rows from the
+ * shared `pops.db` into `core.db` via ATTACH.
+ *
+ * Lifted out of `db.ts` so that file stays under the eslint(max-lines) cap
+ * once the core + inventory + media pillar handles + the closes all
+ * landed there. The behaviour is unchanged.
+ *
+ * Boot-time contract: Phase 2 PR 2 opened the core DB but did not yet
+ * consume it. PR 3 (this entry point) flipped service-accounts traffic
+ * to the core handle, so the first deploy after PR 3 carried the existing
+ * rows across before any reads came from the new file. Subsequent boots
+ * find the core copy already populated and become a no-op via the
+ * `WHERE id NOT IN (...)` existence filter.
+ *
+ * Non-fatal: ATTACH or INSERT failures are logged and swallowed so a
+ * stale on-disk pops.db never bricks the boot path. Failures here leave
+ * the core copy empty for that boot; the next deploy retries.
+ */
+import type Database from 'better-sqlite3';
+
+/**
+ * Run the idempotent backfill against the open core SQLite handle. The
+ * caller resolves the raw better-sqlite3 handle (typically
+ * `getCoreDrizzle()`'s sibling `OpenedCoreDb.raw`) and passes it in so
+ * this module stays decoupled from the singleton in `db.ts`.
+ */
+export function backfillCoreFromShared(coreRaw: Database.Database | null): void {
+  if (!coreRaw) return;
+  const sharedPath = resolveSqlitePath();
+  try {
+    coreRaw.prepare('ATTACH DATABASE ? AS pops').run(sharedPath);
+    try {
+      const hasTable = coreRaw
+        .prepare("SELECT 1 FROM pops.sqlite_master WHERE type='table' AND name='service_accounts'")
+        .get();
+      if (hasTable) {
+        // Enumerate columns explicitly so a future migration that
+        // widens the core table won't break the backfill against a
+        // stale on-disk pops.db that still has the older shape. Order
+        // matches the 0054_service_accounts.sql DDL byte-for-byte.
+        coreRaw.exec(`
+          INSERT INTO service_accounts (
+            id, name, key_prefix, key_hash, scopes,
+            created_at, last_used_at, revoked_at, created_by
+          )
+          SELECT
+            id, name, key_prefix, key_hash, scopes,
+            created_at, last_used_at, revoked_at, created_by
+          FROM pops.service_accounts
+          WHERE id NOT IN (SELECT id FROM service_accounts)
+        `);
+      }
+    } finally {
+      coreRaw.exec('DETACH DATABASE pops');
+    }
+  } catch (err) {
+    console.warn('[db] Core service-accounts backfill failed (non-fatal):', err);
+  }
+}

--- a/apps/pops-api/src/db/media-db-handle.ts
+++ b/apps/pops-api/src/db/media-db-handle.ts
@@ -6,11 +6,12 @@
  * mirrors the core counterpart in shape (lazy open, idempotent close,
  * test-only swap).
  *
- * Phase 2 PR 2 of the media pillar migration: the handle is opened at
- * first call but production traffic still flows through the shared
- * singleton in `db.ts`. PR 3 of phase 2 flips shelf-impressions traffic
- * over to this handle; PR 4 drops the table from the shared journal +
- * adds the Litestream config.
+ * Phase 2 PR 2 of the media pillar migration: `apps/pops-api/src/index.ts`
+ * eagerly calls `getMediaDrizzle` at boot so the per-pillar migrations land
+ * before any request hits the API. Production traffic still flows through
+ * the shared singleton in `db.ts` — PR 3 of phase 2 flips shelf-impressions
+ * traffic over to this handle; PR 4 drops the table from the shared journal
+ * + adds the Litestream config.
  */
 import { openMediaDb, type MediaDb, type OpenedMediaDb } from '@pops/media-db';
 
@@ -45,9 +46,10 @@ export function closeMediaDb(): void {
 }
 
 /**
- * Test-only: swap the media pillar handle. Used by `setupTestContext`
- * to inject an in-memory DB so test suites don't write to the dev
- * `data/media.db` file. Returns the previous handle (or null).
+ * Test-only: swap the media pillar handle. Called from `setupTestContext`
+ * alongside `setCoreDb` to route both pillar handles at the same in-memory
+ * DB, so test suites don't write to the dev `data/media.db` file. Returns
+ * the previous handle (or null).
  */
 export function setMediaDb(next: OpenedMediaDb | null): OpenedMediaDb | null {
   const prev = mediaDb;

--- a/apps/pops-api/src/db/media-db-handle.ts
+++ b/apps/pops-api/src/db/media-db-handle.ts
@@ -1,0 +1,56 @@
+/**
+ * Media pillar SQLite handle — lazy singleton + lifecycle.
+ *
+ * Lifted out of `db.ts` to keep that file under the eslint(max-lines) cap
+ * once the core + media pillar handles both lived there. The behaviour
+ * mirrors the core counterpart in shape (lazy open, idempotent close,
+ * test-only swap).
+ *
+ * Phase 2 PR 2 of the media pillar migration: the handle is opened at
+ * first call but production traffic still flows through the shared
+ * singleton in `db.ts`. PR 3 of phase 2 flips shelf-impressions traffic
+ * over to this handle; PR 4 drops the table from the shared journal +
+ * adds the Litestream config.
+ */
+import { openMediaDb, type MediaDb, type OpenedMediaDb } from '@pops/media-db';
+
+import { resolveMediaSqlitePath } from './media-sqlite-path.js';
+
+let mediaDb: OpenedMediaDb | null = null;
+
+/**
+ * Lazily open the media pillar's SQLite file and return the drizzle
+ * handle. Phase 2 PR 2 wires the connection up at boot but does NOT
+ * yet route any production traffic through it — the existing shared
+ * singleton continues to serve every read/write. The handle is here so
+ * PR 3 can flip shelf-impressions callers over with a one-line edit.
+ */
+export function getMediaDrizzle(): MediaDb {
+  if (!mediaDb) {
+    mediaDb = openMediaDb(resolveMediaSqlitePath());
+  }
+  return mediaDb.db;
+}
+
+/**
+ * Close the media pillar's connection if it was opened. Idempotent —
+ * safe to call from `closeDb()` on shutdown even when the media handle
+ * was never resolved.
+ */
+export function closeMediaDb(): void {
+  if (mediaDb) {
+    mediaDb.raw.close();
+    mediaDb = null;
+  }
+}
+
+/**
+ * Test-only: swap the media pillar handle. Used by `setupTestContext`
+ * to inject an in-memory DB so test suites don't write to the dev
+ * `data/media.db` file. Returns the previous handle (or null).
+ */
+export function setMediaDb(next: OpenedMediaDb | null): OpenedMediaDb | null {
+  const prev = mediaDb;
+  mediaDb = next;
+  return prev;
+}

--- a/apps/pops-api/src/db/media-sqlite-path.test.ts
+++ b/apps/pops-api/src/db/media-sqlite-path.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Resolver tests for the media pillar's SQLite path.
+ *
+ * Covers the precedence chain: MEDIA_SQLITE_PATH > <dirname(SQLITE_PATH)>/media.db > fallback.
+ *
+ * Mirrors core-sqlite-path.test.ts.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DEFAULT_MEDIA_SQLITE_PATH, resolveMediaSqlitePath } from './media-sqlite-path.js';
+
+const originalMediaPath = process.env['MEDIA_SQLITE_PATH'];
+const originalSharedPath = process.env['SQLITE_PATH'];
+
+beforeEach(() => {
+  delete process.env['MEDIA_SQLITE_PATH'];
+  delete process.env['SQLITE_PATH'];
+});
+
+afterEach(() => {
+  if (originalMediaPath === undefined) delete process.env['MEDIA_SQLITE_PATH'];
+  else process.env['MEDIA_SQLITE_PATH'] = originalMediaPath;
+  if (originalSharedPath === undefined) delete process.env['SQLITE_PATH'];
+  else process.env['SQLITE_PATH'] = originalSharedPath;
+});
+
+describe('resolveMediaSqlitePath', () => {
+  it('returns MEDIA_SQLITE_PATH verbatim when set', () => {
+    process.env['MEDIA_SQLITE_PATH'] = '/abs/path/media.db';
+    expect(resolveMediaSqlitePath()).toBe('/abs/path/media.db');
+  });
+
+  it('derives the path from the shared SQLITE_PATH when MEDIA_SQLITE_PATH is unset', () => {
+    process.env['SQLITE_PATH'] = '/opt/pops/data/pops.db';
+    expect(resolveMediaSqlitePath()).toBe('/opt/pops/data/media.db');
+  });
+
+  it('handles relative SQLITE_PATH values', () => {
+    process.env['SQLITE_PATH'] = './data/pops.db';
+    expect(resolveMediaSqlitePath()).toBe('data/media.db');
+  });
+
+  it('falls back to ./data/media.db when neither env is set', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      expect(resolveMediaSqlitePath()).toBe(DEFAULT_MEDIA_SQLITE_PATH);
+      expect(warn).toHaveBeenCalledOnce();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});

--- a/apps/pops-api/src/db/media-sqlite-path.ts
+++ b/apps/pops-api/src/db/media-sqlite-path.ts
@@ -1,0 +1,35 @@
+import { dirname, join } from 'node:path';
+
+import { DEFAULT_SQLITE_PATH } from './sqlite-path.js';
+
+/**
+ * Default location of the media pillar's SQLite file.
+ *
+ * Per the ADR-026 pillar architecture each pillar owns its own SQLite
+ * file alongside the shared pops.db. The default places `media.db` in
+ * the same directory the shared singleton resolves to so dev setups
+ * that already have a writable data dir don't need extra configuration.
+ * Production deployments set `MEDIA_SQLITE_PATH` explicitly; the
+ * fallback here is local-dev-only and matches `resolveSqlitePath`'s
+ * default-path convention (`./data/<file>.db`).
+ *
+ * Resolution order:
+ *   1. `MEDIA_SQLITE_PATH` env (absolute or relative).
+ *   2. `<dirname(SQLITE_PATH)>/media.db` if the shared path is set.
+ *   3. `./data/media.db` (matches the shared default's `./data/pops.db`).
+ *
+ * Mirrors `resolveCoreSqlitePath`.
+ */
+export const DEFAULT_MEDIA_SQLITE_PATH = './data/media.db';
+
+export function resolveMediaSqlitePath(): string {
+  const envPath = process.env['MEDIA_SQLITE_PATH'];
+  if (envPath) return envPath;
+  const sharedPath = process.env['SQLITE_PATH'];
+  if (sharedPath) return join(dirname(sharedPath), 'media.db');
+  console.warn(
+    `[db] MEDIA_SQLITE_PATH not set — using fallback: ${DEFAULT_MEDIA_SQLITE_PATH} ` +
+      `(co-located with the shared singleton default '${DEFAULT_SQLITE_PATH}')`
+  );
+  return DEFAULT_MEDIA_SQLITE_PATH;
+}

--- a/apps/pops-api/src/index.ts
+++ b/apps/pops-api/src/index.ts
@@ -8,6 +8,7 @@ config({ path: '../../.env', override: false }); // loads root .env without over
 import { createApp } from './app.js';
 import { backfillCoreFromShared, closeDb, getCoreDrizzle } from './db.js';
 import { getInventoryDrizzle } from './db/inventory-handle.js';
+import { getMediaDrizzle } from './db/media-db-handle.js';
 import { closeQueues } from './jobs/queues.js';
 import { startThalamus, stopThalamus } from './modules/cerebrum/thalamus/instance.js';
 import {
@@ -61,6 +62,18 @@ try {
   getInventoryDrizzle();
 } catch (err) {
   console.error('[db] Failed to bootstrap the inventory pillar SQLite:', err);
+  throw err;
+}
+
+// Eagerly open the media pillar's SQLite + apply its journal at boot so
+// the per-pillar migrations land before any request hits the API. Phase 2
+// PR 2 only opens the handle — no production traffic routes here yet.
+// PR 3 of phase 2 adds `backfillMediaFromShared()` and flips
+// shelf-impressions traffic over.
+try {
+  getMediaDrizzle();
+} catch (err) {
+  console.error('[db] Failed to bootstrap the media pillar SQLite:', err);
   throw err;
 }
 

--- a/apps/pops-api/src/shared/test-utils.ts
+++ b/apps/pops-api/src/shared/test-utils.ts
@@ -2,6 +2,7 @@ import BetterSqlite3 from 'better-sqlite3';
 import { drizzle } from 'drizzle-orm/better-sqlite3';
 
 import { closeDb, setCoreDb, setDb } from '../db.js';
+import { setMediaDb } from '../db/media-db-handle.js';
 import { appRouter } from '../router.js';
 import { TAG_VOCABULARY_V1 } from './tag-vocabulary.js';
 
@@ -1472,19 +1473,22 @@ export function setupTestContext() {
   function setup(): { db: Database; caller: ReturnType<typeof createCaller> } {
     db = createTestDb();
     setDb(db);
-    // Route the core pillar handle at the same in-memory DB so the
-    // post-PR3 service-accounts call sites (which read/write via
-    // getCoreDrizzle()) keep operating on the test fixture without
-    // each suite having to seed a separate core.db. The shared
-    // `service_accounts` table lives in `createTestDb()` and is
-    // populated/queried through both connections transparently.
+    // Route the core + media pillar handles at the same in-memory DB so
+    // the post-cutover call sites (which read/write via
+    // getCoreDrizzle() / getMediaDrizzle()) keep operating on the test
+    // fixture without each suite having to seed a separate per-pillar
+    // file. The shared `service_accounts` + `shelf_impressions` tables
+    // live in `createTestDb()` and are populated/queried through all
+    // three connections transparently.
     setCoreDb({ db: drizzle(db), raw: db });
+    setMediaDb({ db: drizzle(db), raw: db });
 
     return { db, caller: createCaller(true) };
   }
 
   function teardown() {
     setCoreDb(null);
+    setMediaDb(null);
     closeDb();
   }
 


### PR DESCRIPTION
## Summary

Second PR of the media pillar **Phase 2 — extract media's SQLite** sequence (pillar-migration-roadmap.md Track F · Phase 2 PR 2 of 4). Mirrors core's PR 2 (#2751).

Wires up the per-pillar SQLite connection from PR 1 inside pops-api at boot. **Strictly additive — the handle is opened and migrations apply, but production traffic still flows through the existing shared singleton.** PR 3 of phase 2 flips shelf-impressions callers over to the new handle; PR 4 drops the table from the shared journal + adds the Litestream config.

## What changed

- \`apps/pops-api/src/db/media-sqlite-path.ts\` — resolver with precedence: \`MEDIA_SQLITE_PATH\` env > \`<dirname(SQLITE_PATH)>/media.db\` > \`./data/media.db\` fallback.
- \`apps/pops-api/src/db/media-sqlite-path.test.ts\` — 4 cases covering each branch (env, derived, relative-shared, fallback).
- \`apps/pops-api/src/db/media-db-handle.ts\` — new module hosting the lazy singleton + \`getMediaDrizzle\` / \`closeMediaDb\` / \`setMediaDb\`. Lifted out of \`db.ts\` so that file stays under \`eslint(max-lines)\` once both core and media handles co-exist there.
- \`apps/pops-api/src/db.ts\` — imports \`closeMediaDb\` and calls it from \`closeDb()\` so shutdown takes all handles down.
- \`apps/pops-api/.env.example\` — documents \`MEDIA_SQLITE_PATH\` alongside \`CORE_SQLITE_PATH\`.

## Verification

- \`pnpm typecheck\` — 39/39 packages green
- \`pnpm --filter @pops/api test src/db/media-sqlite-path.test.ts\` — 4/4 cases pass
- \`pnpm --filter @pops/media-db test\` — 21/21 cases pass
- \`pnpm format:check\` — clean

## Test plan

- [ ] CI green on \`api-quality\` + \`api-test\` (new env var integrated without affecting any live code path)
- [ ] CI green on \`media-db-quality\` (drift guard still active)
- [ ] Copilot review pass