### PR TITLE
feat(api): open the inventory pillar SQLite at boot (pillar inventory phase 2 PR 2)

### DIFF
--- a/apps/pops-api/.env.example
+++ b/apps/pops-api/.env.example
@@ -26,6 +26,11 @@ SQLITE_PATH=./data/pops.db
 # core needs its own mount point / Litestream stream in production.
 CORE_SQLITE_PATH=./data/core.db
 
+# Inventory pillar database (ADR-026). Defaults to <dirname(SQLITE_PATH)>/inventory.db,
+# falling back to ./data/inventory.db if SQLITE_PATH is unset. Set explicitly when
+# inventory needs its own mount point / Litestream stream in production.
+INVENTORY_SQLITE_PATH=./data/inventory.db
+
 # Media Images
 # Directory for locally cached posters and backdrops
 MEDIA_IMAGES_DIR=./data/media/images

--- a/apps/pops-api/src/db.ts
+++ b/apps/pops-api/src/db.ts
@@ -8,6 +8,7 @@ import { openCoreDb, type CoreDb, type OpenedCoreDb } from '@pops/core-db';
 
 import { createPreMigrationBackup, isFreshDatabase } from './db/backup.js';
 import { resolveCoreSqlitePath } from './db/core-sqlite-path.js';
+import { closeInventoryDb } from './db/inventory-handle.js';
 import { KNOWN_PILLARS } from './db/known-pillars.js';
 import { migrationOwners } from './db/migration-ownership.js';
 import {
@@ -232,6 +233,7 @@ export function closeDb(): void {
     prodDb = null;
   }
   closeCoreDb();
+  closeInventoryDb();
 }
 
 /**

--- a/apps/pops-api/src/db/inventory-handle.ts
+++ b/apps/pops-api/src/db/inventory-handle.ts
@@ -48,9 +48,10 @@ export function closeInventoryDb(): void {
 }
 
 /**
- * Test-only: swap the inventory pillar handle. Used by
- * `setupTestContext` to inject an in-memory DB so test suites don't
- * write to the dev `data/inventory.db` file. Returns the previous
+ * Test-only: swap the inventory pillar handle. Phase 2 PR 3 of this
+ * pillar wires `setupTestContext` (in `shared/test-utils.ts`) up to
+ * call this hook so test suites can inject an in-memory DB and avoid
+ * writing to the dev `data/inventory.db` file. Returns the previous
  * handle (or null).
  */
 export function setInventoryDb(next: OpenedInventoryDb | null): OpenedInventoryDb | null {

--- a/apps/pops-api/src/db/inventory-handle.ts
+++ b/apps/pops-api/src/db/inventory-handle.ts
@@ -1,0 +1,60 @@
+/**
+ * Lazily-initialised handle to the inventory pillar's SQLite file.
+ *
+ * Phase 2 PR 2 of the inventory pillar migration: opens the connection
+ * (and applies the in-package migrations journal) at boot but does NOT
+ * yet route any production traffic through it. PR 3 of phase 2 flips
+ * locations + items + uri-handler callers over with a single edit to
+ * `getDrizzle()` → `getInventoryDrizzle()`; PR 4 drops the inventory
+ * tables from the shared journal + adds the Litestream config.
+ *
+ * Lives in its own module so `db.ts` stays under the lint cap as more
+ * pillars come online. Mirrors the eventual planned extraction of
+ * `core-handle.ts` / `media-handle.ts` / ... once those pillars start
+ * pulling their wiring out of the central file.
+ */
+import { openInventoryDb, type InventoryDb, type OpenedInventoryDb } from '@pops/inventory-db';
+
+import { resolveInventorySqlitePath } from './inventory-sqlite-path.js';
+
+let inventoryDb: OpenedInventoryDb | null = null;
+
+/**
+ * Resolve (and lazily open) the inventory pillar's drizzle handle.
+ *
+ * The handle is opened here on first call so the per-pillar migrations
+ * apply at boot. Phase 2 PR 2 does NOT yet route any production traffic
+ * through it — the existing shared singleton continues to serve every
+ * read/write. The handle is here so PR 3 can flip locations + items +
+ * uri-handler callers over with a one-line edit.
+ */
+export function getInventoryDrizzle(): InventoryDb {
+  if (!inventoryDb) {
+    inventoryDb = openInventoryDb(resolveInventorySqlitePath());
+  }
+  return inventoryDb.db;
+}
+
+/**
+ * Close the inventory pillar's connection if it was opened. Idempotent
+ * — safe to call from `closeDb()` on shutdown even when the inventory
+ * handle was never resolved.
+ */
+export function closeInventoryDb(): void {
+  if (inventoryDb) {
+    inventoryDb.raw.close();
+    inventoryDb = null;
+  }
+}
+
+/**
+ * Test-only: swap the inventory pillar handle. Used by
+ * `setupTestContext` to inject an in-memory DB so test suites don't
+ * write to the dev `data/inventory.db` file. Returns the previous
+ * handle (or null).
+ */
+export function setInventoryDb(next: OpenedInventoryDb | null): OpenedInventoryDb | null {
+  const prev = inventoryDb;
+  inventoryDb = next;
+  return prev;
+}

--- a/apps/pops-api/src/db/inventory-sqlite-path.test.ts
+++ b/apps/pops-api/src/db/inventory-sqlite-path.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Resolver tests for the inventory pillar's SQLite path.
+ *
+ * Covers the precedence chain: INVENTORY_SQLITE_PATH > <dirname(SQLITE_PATH)>/inventory.db > fallback.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  DEFAULT_INVENTORY_SQLITE_PATH,
+  resolveInventorySqlitePath,
+} from './inventory-sqlite-path.js';
+
+const originalInventoryPath = process.env['INVENTORY_SQLITE_PATH'];
+const originalSharedPath = process.env['SQLITE_PATH'];
+
+beforeEach(() => {
+  delete process.env['INVENTORY_SQLITE_PATH'];
+  delete process.env['SQLITE_PATH'];
+});
+
+afterEach(() => {
+  if (originalInventoryPath === undefined) delete process.env['INVENTORY_SQLITE_PATH'];
+  else process.env['INVENTORY_SQLITE_PATH'] = originalInventoryPath;
+  if (originalSharedPath === undefined) delete process.env['SQLITE_PATH'];
+  else process.env['SQLITE_PATH'] = originalSharedPath;
+});
+
+describe('resolveInventorySqlitePath', () => {
+  it('returns INVENTORY_SQLITE_PATH verbatim when set', () => {
+    process.env['INVENTORY_SQLITE_PATH'] = '/abs/path/inventory.db';
+    expect(resolveInventorySqlitePath()).toBe('/abs/path/inventory.db');
+  });
+
+  it('derives the path from the shared SQLITE_PATH when INVENTORY_SQLITE_PATH is unset', () => {
+    process.env['SQLITE_PATH'] = '/opt/pops/data/pops.db';
+    expect(resolveInventorySqlitePath()).toBe('/opt/pops/data/inventory.db');
+  });
+
+  it('handles relative SQLITE_PATH values', () => {
+    process.env['SQLITE_PATH'] = './data/pops.db';
+    expect(resolveInventorySqlitePath()).toBe('data/inventory.db');
+  });
+
+  it('falls back to ./data/inventory.db when neither env is set', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      expect(resolveInventorySqlitePath()).toBe(DEFAULT_INVENTORY_SQLITE_PATH);
+      expect(warn).toHaveBeenCalledOnce();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});

--- a/apps/pops-api/src/db/inventory-sqlite-path.ts
+++ b/apps/pops-api/src/db/inventory-sqlite-path.ts
@@ -1,0 +1,33 @@
+import { dirname, join } from 'node:path';
+
+import { DEFAULT_SQLITE_PATH } from './sqlite-path.js';
+
+/**
+ * Default location of the inventory pillar's SQLite file.
+ *
+ * Per the ADR-026 pillar architecture each pillar owns its own SQLite
+ * file alongside the shared pops.db. The default places `inventory.db`
+ * in the same directory the shared singleton resolves to so dev setups
+ * that already have a writable data dir don't need extra configuration.
+ * Production deployments set `INVENTORY_SQLITE_PATH` explicitly; the
+ * fallback here is local-dev-only and matches `resolveSqlitePath`'s
+ * default-path convention (`./data/<file>.db`).
+ *
+ * Resolution order:
+ *   1. `INVENTORY_SQLITE_PATH` env (absolute or relative).
+ *   2. `<dirname(SQLITE_PATH)>/inventory.db` if the shared path is set.
+ *   3. `./data/inventory.db` (matches the shared default's `./data/pops.db`).
+ */
+export const DEFAULT_INVENTORY_SQLITE_PATH = './data/inventory.db';
+
+export function resolveInventorySqlitePath(): string {
+  const envPath = process.env['INVENTORY_SQLITE_PATH'];
+  if (envPath) return envPath;
+  const sharedPath = process.env['SQLITE_PATH'];
+  if (sharedPath) return join(dirname(sharedPath), 'inventory.db');
+  console.warn(
+    `[db] INVENTORY_SQLITE_PATH not set — using fallback: ${DEFAULT_INVENTORY_SQLITE_PATH} ` +
+      `(co-located with the shared singleton default '${DEFAULT_SQLITE_PATH}')`
+  );
+  return DEFAULT_INVENTORY_SQLITE_PATH;
+}

--- a/apps/pops-api/src/index.ts
+++ b/apps/pops-api/src/index.ts
@@ -55,8 +55,8 @@ try {
 // the per-pillar migrations land before any request hits the API, but
 // no production traffic flips over yet — PR 3 of phase 2 cuts over
 // locations + items + uri-handler with a single `getDrizzle()` →
-// `getInventoryDrizzle()` swap and adds the one-shot
-// `backfillInventoryFromShared` call below.
+// `getInventoryDrizzle()` swap and adds the one-shot ATTACH-based
+// backfill from the legacy shared pops.db.
 try {
   getInventoryDrizzle();
 } catch (err) {

--- a/apps/pops-api/src/index.ts
+++ b/apps/pops-api/src/index.ts
@@ -7,6 +7,7 @@ config({ path: '../../.env', override: false }); // loads root .env without over
 
 import { createApp } from './app.js';
 import { backfillCoreFromShared, closeDb, getCoreDrizzle } from './db.js';
+import { getInventoryDrizzle } from './db/inventory-handle.js';
 import { closeQueues } from './jobs/queues.js';
 import { startThalamus, stopThalamus } from './modules/cerebrum/thalamus/instance.js';
 import {
@@ -46,6 +47,20 @@ try {
   backfillCoreFromShared();
 } catch (err) {
   console.error('[db] Failed to bootstrap the core pillar SQLite:', err);
+  throw err;
+}
+
+// Eagerly open the inventory pillar's SQLite + apply its journal at
+// boot. Phase 2 PR 2 of the inventory pillar: the handle is opened so
+// the per-pillar migrations land before any request hits the API, but
+// no production traffic flips over yet — PR 3 of phase 2 cuts over
+// locations + items + uri-handler with a single `getDrizzle()` →
+// `getInventoryDrizzle()` swap and adds the one-shot
+// `backfillInventoryFromShared` call below.
+try {
+  getInventoryDrizzle();
+} catch (err) {
+  console.error('[db] Failed to bootstrap the inventory pillar SQLite:', err);
   throw err;
 }
 


### PR DESCRIPTION
## Summary

Phase 2 PR 2 of the inventory pillar migration eagerly opens the per-pillar SQLite at process bootstrap so the in-package migrations journal lands before any request hits the API. **No production traffic flips over yet** — the existing shared singleton continues to serve every read/write. PR 3 of phase 2 cuts over `locations` + `items` + `uri-handler` callers with a single `getDrizzle()` → `getInventoryDrizzle()` swap and adds the ATTACH-based backfill from `pops.db`.

Mirrors the core Phase 2 PR 2 ([#2751](https://github.com/knoxio/pops/pull/2751)) pattern: env-driven path resolver with a three-step precedence chain, lazy `getInventoryDrizzle()` singleton, idempotent `closeInventoryDb()`, test-only `setInventoryDb()` injection point.

The inventory pillar handle wiring lives in `apps/pops-api/src/db/inventory-handle.ts` rather than in `db.ts` so the central file stays under the 200-effective-line lint cap as more pillars come online — `db.ts` only imports `closeInventoryDb` to add it to the shutdown sequence in `closeDb()`.

### Includes
- **`apps/pops-api/src/db/inventory-sqlite-path.{ts,test.ts}`** — `resolveInventorySqlitePath()` precedence chain: `INVENTORY_SQLITE_PATH` env > `<dirname(SQLITE_PATH)>/inventory.db` > `./data/inventory.db` fallback warning. 4 tests covering each branch + the warning.
- **`apps/pops-api/src/db/inventory-handle.ts`** — `inventoryDb` singleton + `getInventoryDrizzle` / `closeInventoryDb` / `setInventoryDb`. Self-contained so future pillars can copy the file as a template.
- **`apps/pops-api/src/db.ts`** — `closeDb()` now calls `closeInventoryDb()` so the shutdown sequence covers every open handle.
- **`apps/pops-api/src/index.ts`** — eagerly calls `getInventoryDrizzle()` at boot so the per-pillar migrations apply during startup. Failure logs + rethrows so a corrupt `inventory.db` crashes startup loudly instead of silently masquerading as a handle-resolution problem later.
- **`apps/pops-api/.env.example`** — gains `INVENTORY_SQLITE_PATH` example block alongside `CORE_SQLITE_PATH`.

## Test plan
- [x] `cd apps/pops-api && pnpm typecheck` — clean
- [x] `cd apps/pops-api && pnpm test src/db/inventory-sqlite-path` — 4/4 pass
- [x] `cd apps/pops-api && pnpm test src/modules/inventory` — 310/310 pass (Phase 1 tRPC integration coverage unaffected)
- [x] `pnpm lint` — clean (db.ts effective-line cap respected by extracting the handle wiring into its own module)
- [x] `pnpm format:check` / `pnpm lint:boundaries` — clean