### PR TITLE
feat(finance-db): add openFinanceDb helper (pillar finance phase 2 PR 1)

### DIFF
--- a/packages/finance-db/src/__tests__/open-finance-db.test.ts
+++ b/packages/finance-db/src/__tests__/open-finance-db.test.ts
@@ -14,7 +14,7 @@
  * something to ALTER. Once the baseline split lands, this seeding can
  * be retired.
  */
-import { existsSync, mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 
@@ -37,8 +37,13 @@ afterEach(() => {
  * Minimum baseline DDL required for the package's journal to apply
  * cleanly: `entities` (FK target of `transaction_tag_rules` created by
  * 0026), `transaction_corrections` (ALTERed by 0025 + 0027), and
- * `budgets` (recreated by 0052). Schema lifted byte-for-byte from
- * `apps/pops-api/src/db/drizzle-migrations/0000_naive_chameleon.sql`.
+ * `budgets` (recreated by 0052). Only the three `CREATE TABLE`
+ * statements are copied from
+ * `apps/pops-api/src/db/drizzle-migrations/0000_naive_chameleon.sql`
+ * — the baseline indexes (e.g. `*_notion_id_unique`,
+ * `idx_corrections_*`) are intentionally omitted because nothing in
+ * the package journal queries them, and dropping them keeps the test
+ * fixture tight.
  */
 function seedBaseline(path: string): void {
   mkdirSync(dirname(path), { recursive: true });
@@ -89,14 +94,16 @@ function seedBaseline(path: string): void {
 }
 
 describe('openFinanceDb', () => {
-  it('creates the parent directory and applies PRAGMAs', () => {
-    const path = join(tmpDir, 'nested', 'sub', 'finance.db');
-    expect(existsSync(path)).toBe(false);
+  it('applies the configured PRAGMAs on an existing DB file', () => {
+    // seedBaseline pre-creates the file (and its parent dir) so the
+    // package journal has tables to ALTER; this test asserts the
+    // PRAGMAs openFinanceDb sets on the existing handle, not the
+    // mkdir-if-missing path (covered separately below).
+    const path = join(tmpDir, 'finance.db');
     seedBaseline(path);
 
     const { raw } = openFinanceDb(path);
     try {
-      expect(existsSync(path)).toBe(true);
       expect(raw.pragma('journal_mode', { simple: true })).toBe('wal');
       expect(raw.pragma('foreign_keys', { simple: true })).toBe(1);
       expect(raw.pragma('busy_timeout', { simple: true })).toBe(5000);

--- a/packages/finance-db/src/__tests__/open-finance-db.test.ts
+++ b/packages/finance-db/src/__tests__/open-finance-db.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Smoke tests for the standalone `openFinanceDb` helper.
+ *
+ * Exercises the migration apply path against a fresh tmp file, verifies
+ * the resulting schema, and confirms the helper is idempotent when
+ * re-run against the same DB.
+ *
+ * Unlike `@pops/core-db`/`@pops/media-db`, finance's package journal
+ * (0025/0026/0027/0052) is NOT self-bootstrapping — every entry ALTERs
+ * or recreates a table created in the pre-modular baseline
+ * (`0000_naive_chameleon.sql`). The tests pre-seed the three required
+ * baseline tables (`entities`, `transaction_corrections`, `budgets`)
+ * into the file before calling `openFinanceDb` so the migrate step has
+ * something to ALTER. Once the baseline split lands, this seeding can
+ * be retired.
+ */
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import Database from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { openFinanceDb } from '../open-finance-db.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'finance-db-test-'));
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+/**
+ * Minimum baseline DDL required for the package's journal to apply
+ * cleanly: `entities` (FK target of `transaction_tag_rules` created by
+ * 0026), `transaction_corrections` (ALTERed by 0025 + 0027), and
+ * `budgets` (recreated by 0052). Schema lifted byte-for-byte from
+ * `apps/pops-api/src/db/drizzle-migrations/0000_naive_chameleon.sql`.
+ */
+function seedBaseline(path: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+  const raw = new Database(path);
+  try {
+    raw.exec(`
+      CREATE TABLE \`entities\` (
+        \`id\` text PRIMARY KEY NOT NULL,
+        \`notion_id\` text,
+        \`name\` text NOT NULL,
+        \`type\` text DEFAULT 'company' NOT NULL,
+        \`abn\` text,
+        \`aliases\` text,
+        \`default_transaction_type\` text,
+        \`default_tags\` text,
+        \`notes\` text,
+        \`last_edited_time\` text NOT NULL
+      );
+      CREATE TABLE \`transaction_corrections\` (
+        \`id\` text PRIMARY KEY NOT NULL,
+        \`description_pattern\` text NOT NULL,
+        \`match_type\` text DEFAULT 'exact' NOT NULL,
+        \`entity_id\` text,
+        \`entity_name\` text,
+        \`location\` text,
+        \`tags\` text DEFAULT '[]' NOT NULL,
+        \`transaction_type\` text,
+        \`confidence\` real DEFAULT 0.5 NOT NULL,
+        \`times_applied\` integer DEFAULT 0 NOT NULL,
+        \`created_at\` text DEFAULT (datetime('now')) NOT NULL,
+        \`last_used_at\` text,
+        FOREIGN KEY (\`entity_id\`) REFERENCES \`entities\`(\`id\`) ON UPDATE no action ON DELETE set null
+      );
+      CREATE TABLE \`budgets\` (
+        \`id\` text PRIMARY KEY NOT NULL,
+        \`notion_id\` text,
+        \`category\` text NOT NULL,
+        \`period\` text,
+        \`amount\` real,
+        \`active\` integer DEFAULT 1 NOT NULL,
+        \`notes\` text,
+        \`last_edited_time\` text NOT NULL
+      );
+    `);
+  } finally {
+    raw.close();
+  }
+}
+
+describe('openFinanceDb', () => {
+  it('creates the parent directory and applies PRAGMAs', () => {
+    const path = join(tmpDir, 'nested', 'sub', 'finance.db');
+    expect(existsSync(path)).toBe(false);
+    seedBaseline(path);
+
+    const { raw } = openFinanceDb(path);
+    try {
+      expect(existsSync(path)).toBe(true);
+      expect(raw.pragma('journal_mode', { simple: true })).toBe('wal');
+      expect(raw.pragma('foreign_keys', { simple: true })).toBe(1);
+      expect(raw.pragma('busy_timeout', { simple: true })).toBe(5000);
+    } finally {
+      raw.close();
+    }
+  });
+
+  it('applies the package journal — tag_vocabulary table exists post-open', () => {
+    const path = join(tmpDir, 'finance.db');
+    seedBaseline(path);
+
+    const { raw } = openFinanceDb(path);
+    try {
+      const row = raw
+        .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='tag_vocabulary'")
+        .get() as { name: string } | undefined;
+      expect(row?.name).toBe('tag_vocabulary');
+    } finally {
+      raw.close();
+    }
+  });
+
+  it('is idempotent — re-opening the same DB does not re-apply migrations', () => {
+    const path = join(tmpDir, 'finance.db');
+    seedBaseline(path);
+
+    const first = openFinanceDb(path);
+    let firstCount: number;
+    try {
+      // Seed a tag vocabulary row to prove state persists across re-opens.
+      first.raw
+        .prepare("INSERT INTO tag_vocabulary (tag, source, is_active) VALUES ('Custom', 'test', 1)")
+        .run();
+      firstCount = (
+        first.raw.prepare('SELECT COUNT(*) AS n FROM tag_vocabulary').get() as { n: number }
+      ).n;
+    } finally {
+      first.raw.close();
+    }
+
+    const second = openFinanceDb(path);
+    try {
+      const secondCount = (
+        second.raw.prepare('SELECT COUNT(*) AS n FROM tag_vocabulary').get() as { n: number }
+      ).n;
+      expect(secondCount).toBe(firstCount);
+    } finally {
+      second.raw.close();
+    }
+  });
+});

--- a/packages/finance-db/src/index.ts
+++ b/packages/finance-db/src/index.ts
@@ -16,6 +16,8 @@ export * from './schema.js';
 
 export type { FinanceDb } from './services/internal.js';
 
+export { openFinanceDb, type OpenedFinanceDb } from './open-finance-db.js';
+
 export * as wishListService from './services/wishlist.js';
 
 export {

--- a/packages/finance-db/src/open-finance-db.ts
+++ b/packages/finance-db/src/open-finance-db.ts
@@ -1,0 +1,91 @@
+/**
+ * Standalone opener for the finance pillar's SQLite database.
+ *
+ * Phase 2 PR 1 of the finance pillar migration scaffolds the per-pillar
+ * connection so subsequent PRs can flip readers/writers over without
+ * touching pops-api's existing singleton. The opener is intentionally
+ * minimal — it does NOT load the sqlite-vec extension (finance doesn't
+ * use vector indexes) and relies on drizzle-orm's built-in `migrate`
+ * helper to apply the in-package migrations journal at
+ * `packages/finance-db/migrations/meta/_journal.json`.
+ *
+ * No production consumer wires this up yet. Subsequent PRs add the
+ * `FINANCE_SQLITE_PATH` env-var read in pops-api, the boot-time call,
+ * and the data backfill from the shared pops.db.
+ */
+import { mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+
+import type { FinanceDb } from './services/internal.js';
+
+/**
+ * Path to the migrations folder inside this package. Resolved relative
+ * to this module's location (`src/open-finance-db.ts` in dev,
+ * `dist/open-finance-db.js` after build) so it works both when consumed
+ * via the workspace symlink and when bundled into a Docker image's
+ * `node_modules/@pops/finance-db/`.
+ */
+function migrationsDir(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  return join(here, '..', 'migrations');
+}
+
+/** Result of {@link openFinanceDb}. The raw handle is exposed for callers
+ * that need lifecycle control (close on shutdown, prepared statements,
+ * pragmas the drizzle wrapper hides). */
+export interface OpenedFinanceDb {
+  /** Drizzle handle — pass into any `wishListService.*` call. */
+  db: FinanceDb;
+  /** Raw better-sqlite3 handle. Call `.close()` on shutdown. */
+  raw: Database.Database;
+}
+
+/**
+ * Open the finance pillar's SQLite database at `path`, configure it,
+ * apply the in-package migrations journal, and return both the drizzle
+ * wrapper and the raw handle.
+ *
+ * Side effects:
+ *   - The parent directory of `path` is created if missing (recursive).
+ *   - `journal_mode=WAL`, `foreign_keys=ON`, and `busy_timeout=5000`
+ *     are enabled to match the shared singleton in
+ *     `apps/pops-api/src/db.ts`.
+ *   - Every migration in
+ *     `packages/finance-db/migrations/meta/_journal.json` is applied
+ *     via drizzle's built-in migrator (idempotent — re-running against
+ *     the same DB short-circuits on the `__drizzle_migrations` hash
+ *     check).
+ *
+ * If the migration apply throws (corrupt DB, malformed migration,
+ * missing folder), the raw handle is closed before the error is
+ * re-thrown so the caller can't leak a locked file descriptor.
+ *
+ * Note: every finance migration in the package's journal so far
+ * (0025/0026/0027/0052) ALTERs or recreates tables created in the
+ * pre-modular baseline (`0000_naive_chameleon.sql`). The opener does
+ * not apply that baseline — callers that need a fresh, fully-seeded
+ * finance.db must run the shared journal first OR include the relevant
+ * baseline DDL out of band (the existing tests inline the
+ * `wish_list` DDL for this reason). Once the baseline split lands,
+ * the package's journal will be self-sufficient.
+ */
+export function openFinanceDb(path: string): OpenedFinanceDb {
+  mkdirSync(dirname(path), { recursive: true });
+  const raw = new Database(path);
+  raw.pragma('journal_mode = WAL');
+  raw.pragma('foreign_keys = ON');
+  raw.pragma('busy_timeout = 5000');
+  const db = drizzle(raw) as FinanceDb;
+  try {
+    migrate(db, { migrationsFolder: migrationsDir() });
+  } catch (err) {
+    raw.close();
+    throw err;
+  }
+  return { db, raw };
+}


### PR DESCRIPTION
## Summary

- Standalone opener for the finance pillar's SQLite database.
- Mirrors `@pops/core-db`'s `openCoreDb` / `@pops/media-db`'s `openMediaDb`.
- Sets `journal_mode=WAL`, `foreign_keys=ON`, `busy_timeout=5000` (matches the shared singleton in `apps/pops-api/src/db.ts`), creates the parent directory if missing, and applies the package's migrations journal via drizzle-orm's built-in `migrate` helper.

No production consumer wires this up yet — Phase 2 PR 2 adds the `FINANCE_SQLITE_PATH` env-var read in pops-api, the boot-time call, and the closeFinanceDb wiring.

## Why finance is slightly different

Unlike core (0054_service_accounts is a clean CREATE TABLE) and media (0021_spooky_lockheed is a clean CREATE TABLE), every entry in finance's package journal (0025/0026/0027/0052) ALTERs or recreates a table created in the pre-modular baseline (0000_naive_chameleon.sql).

The opener tries to apply as-is; the tests pre-seed the three required baseline tables (`entities`, `transaction_corrections`, `budgets`) before calling `openFinanceDb` so the `migrate` step has something to ALTER. Once the baseline split lands, the test pre-seeding can be retired.

## Test plan

- [x] `pnpm --filter @pops/finance-db typecheck`
- [x] `pnpm --filter @pops/finance-db test` (17/17 — 3 new opener tests + the existing 14 wishlist tests)
- [x] `pnpm --filter @pops/finance-db build`
- [x] `pnpm typecheck` (full repo)
- [x] `pnpm lint` clean