### PR TITLE
feat(api): flip inventory module to inventory.db + ATTACH backfill (pillar inventory phase 2 PR 3)

### DIFF
--- a/apps/pops-api/src/db/backfill-inventory-from-shared.test.ts
+++ b/apps/pops-api/src/db/backfill-inventory-from-shared.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Boot-time backfill tests for `backfillInventoryFromShared` (phase 2 PR 3).
+ *
+ * Exercises the ATTACH-based copy from the shared `pops.db` to the
+ * pillar's `inventory.db` against on-disk SQLite files (in-memory DBs
+ * can't be ATTACHed). Confirms:
+ *   - first run carries existing rows across,
+ *   - second run is a no-op (idempotent — the per-table WHERE filter dedupes),
+ *   - mixed state (some rows already in inventory) only inserts the missing ones,
+ *   - missing source table is tolerated without throwing.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import BetterSqlite3 from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { openInventoryDb } from '@pops/inventory-db';
+
+import { backfillInventoryFromShared } from './backfill-inventory-from-shared.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'inventory-backfill-'));
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+const LOCATIONS_SQL = `
+CREATE TABLE locations (
+  id text PRIMARY KEY NOT NULL,
+  name text NOT NULL,
+  parent_id text,
+  sort_order integer DEFAULT 0 NOT NULL,
+  last_edited_time text NOT NULL
+);
+`;
+
+const HOME_INVENTORY_SQL = `
+CREATE TABLE home_inventory (
+  id text PRIMARY KEY NOT NULL,
+  notion_id text,
+  item_name text NOT NULL,
+  brand text,
+  model text,
+  item_id text,
+  room text,
+  location text,
+  type text,
+  condition text DEFAULT 'good',
+  in_use integer,
+  deductible integer,
+  purchase_date text,
+  warranty_expires text,
+  replacement_value real,
+  resale_value real,
+  purchase_transaction_id text,
+  purchased_from_id text,
+  purchased_from_name text,
+  purchase_price real,
+  asset_id text,
+  notes text,
+  location_id text,
+  created_at text DEFAULT (datetime('now')) NOT NULL,
+  updated_at text DEFAULT (datetime('now')) NOT NULL,
+  last_edited_time text NOT NULL
+);
+`;
+
+function openSharedWithSeed(seed: (raw: BetterSqlite3.Database) => void): string {
+  const path = join(tmpDir, 'pops.db');
+  const raw = new BetterSqlite3(path);
+  raw.exec(LOCATIONS_SQL);
+  raw.exec(HOME_INVENTORY_SQL);
+  seed(raw);
+  raw.close();
+  return path;
+}
+
+describe('backfillInventoryFromShared', () => {
+  it('copies locations + home_inventory rows from the shared DB on first run', () => {
+    const sharedPath = openSharedWithSeed((raw) => {
+      raw.exec(
+        `INSERT INTO locations (id, name, sort_order, last_edited_time) VALUES ('loc-1', 'Home', 0, '2026-06-10T00:00:00Z')`
+      );
+      raw.exec(
+        `INSERT INTO home_inventory (id, item_name, location_id, last_edited_time) VALUES ('item-1', 'Couch', 'loc-1', '2026-06-10T00:00:00Z')`
+      );
+    });
+
+    const inventory = openInventoryDb(join(tmpDir, 'inventory.db'));
+    try {
+      backfillInventoryFromShared(inventory, sharedPath);
+      const locCount = inventory.raw.prepare('SELECT count(*) AS n FROM locations').get() as {
+        n: number;
+      };
+      const itemCount = inventory.raw.prepare('SELECT count(*) AS n FROM home_inventory').get() as {
+        n: number;
+      };
+      expect(locCount.n).toBe(1);
+      expect(itemCount.n).toBe(1);
+    } finally {
+      inventory.raw.close();
+    }
+  });
+
+  it('is idempotent — a second run does not duplicate rows', () => {
+    const sharedPath = openSharedWithSeed((raw) => {
+      raw.exec(
+        `INSERT INTO locations (id, name, sort_order, last_edited_time) VALUES ('loc-1', 'Home', 0, '2026-06-10T00:00:00Z')`
+      );
+    });
+
+    const inventory = openInventoryDb(join(tmpDir, 'inventory.db'));
+    try {
+      backfillInventoryFromShared(inventory, sharedPath);
+      backfillInventoryFromShared(inventory, sharedPath);
+      const locCount = inventory.raw.prepare('SELECT count(*) AS n FROM locations').get() as {
+        n: number;
+      };
+      expect(locCount.n).toBe(1);
+    } finally {
+      inventory.raw.close();
+    }
+  });
+
+  it('only inserts rows missing from the inventory copy (mixed state)', () => {
+    const sharedPath = openSharedWithSeed((raw) => {
+      raw.exec(
+        `INSERT INTO locations (id, name, sort_order, last_edited_time) VALUES ('loc-shared-only', 'Garage', 0, '2026-06-10T00:00:00Z')`
+      );
+      raw.exec(
+        `INSERT INTO locations (id, name, sort_order, last_edited_time) VALUES ('loc-both', 'Home', 0, '2026-06-10T00:00:00Z')`
+      );
+    });
+
+    const inventory = openInventoryDb(join(tmpDir, 'inventory.db'));
+    try {
+      // Pre-seed the inventory.db with one of the rows that also lives
+      // in the shared DB; the backfill must skip it but pick up the other.
+      inventory.raw.exec(
+        `INSERT INTO locations (id, name, sort_order, last_edited_time) VALUES ('loc-both', 'Home', 0, '2026-06-10T00:00:00Z')`
+      );
+      backfillInventoryFromShared(inventory, sharedPath);
+      const rows = inventory.raw.prepare('SELECT id FROM locations ORDER BY id').all() as {
+        id: string;
+      }[];
+      expect(rows.map((r) => r.id)).toEqual(['loc-both', 'loc-shared-only']);
+    } finally {
+      inventory.raw.close();
+    }
+  });
+
+  it('tolerates a shared DB with no inventory tables (post-PR-4 drop scenario)', () => {
+    // Shared DB exists but doesn't have any inventory tables.
+    const sharedPath = join(tmpDir, 'pops.db');
+    const raw = new BetterSqlite3(sharedPath);
+    raw.exec(`CREATE TABLE other_table (id integer PRIMARY KEY)`);
+    raw.close();
+
+    const inventory = openInventoryDb(join(tmpDir, 'inventory.db'));
+    try {
+      expect(() => backfillInventoryFromShared(inventory, sharedPath)).not.toThrow();
+      const locCount = inventory.raw.prepare('SELECT count(*) AS n FROM locations').get() as {
+        n: number;
+      };
+      expect(locCount.n).toBe(0);
+    } finally {
+      inventory.raw.close();
+    }
+  });
+});

--- a/apps/pops-api/src/db/backfill-inventory-from-shared.ts
+++ b/apps/pops-api/src/db/backfill-inventory-from-shared.ts
@@ -1,0 +1,167 @@
+/**
+ * Boot-time backfill from the legacy shared `pops.db` into the inventory
+ * pillar's `inventory.db`.
+ *
+ * Phase 2 PR 3 of the inventory pillar flips locations + items +
+ * fixtures + connections + documents + photos + uploaded-files +
+ * fixture-connections traffic to the inventory handle. The first deploy
+ * after PR 3 needs to carry the existing rows from the shared DB
+ * across before any reads come from the new file. Subsequent boots
+ * find the inventory copy already populated and become a no-op via
+ * the `WHERE id NOT IN (...)` existence filter on every table.
+ *
+ * Order matters for FK enforcement (with `foreign_keys = ON`):
+ *   locations (no parent) → home_inventory → fixtures →
+ *   item_connections / item_documents / item_photos /
+ *   item_uploaded_files / item_fixture_connections.
+ *
+ * Each table is wrapped in `tryCopyTable` so a missing source table
+ * (post-PR-4 drop scenario, or a stale on-disk pops.db) doesn't bring
+ * the whole backfill down. Failures are logged + swallowed; the
+ * remaining tables still attempt.
+ *
+ * Non-fatal: ATTACH or INSERT failures are logged and swallowed so a
+ * stale on-disk pops.db never bricks the boot path. Failures here
+ * leave the inventory copy partially populated for that boot; the
+ * next deploy retries and the idempotent filter picks up only the
+ * still-missing rows.
+ */
+import type Database from 'better-sqlite3';
+
+import type { OpenedInventoryDb } from '@pops/inventory-db';
+
+interface TableCopy {
+  readonly table: string;
+  /** Explicit column list keeps the backfill robust against a stale
+   * on-disk pops.db that already widened or narrowed since the boot
+   * image was built. */
+  readonly columns: readonly string[];
+  /** Identifier column used in the existence filter. Most inventory
+   * tables key on `id`; the pair-tables (`item_connections`,
+   * `item_fixture_connections`, `item_documents`) also key on `id`
+   * because they have autoincrement PKs. */
+  readonly idColumn: string;
+}
+
+const TABLE_COPIES: readonly TableCopy[] = [
+  {
+    table: 'locations',
+    idColumn: 'id',
+    columns: ['id', 'name', 'parent_id', 'sort_order', 'last_edited_time'],
+  },
+  {
+    table: 'home_inventory',
+    idColumn: 'id',
+    columns: [
+      'id',
+      'notion_id',
+      'item_name',
+      'brand',
+      'model',
+      'item_id',
+      'room',
+      'location',
+      'type',
+      'condition',
+      'in_use',
+      'deductible',
+      'purchase_date',
+      'warranty_expires',
+      'replacement_value',
+      'resale_value',
+      'purchase_transaction_id',
+      'purchased_from_id',
+      'purchased_from_name',
+      'purchase_price',
+      'asset_id',
+      'notes',
+      'location_id',
+      'created_at',
+      'updated_at',
+      'last_edited_time',
+    ],
+  },
+  {
+    table: 'fixtures',
+    idColumn: 'id',
+    columns: ['id', 'name', 'type', 'location_id', 'notes', 'created_at', 'last_edited_time'],
+  },
+  {
+    table: 'item_connections',
+    idColumn: 'id',
+    columns: ['id', 'item_a_id', 'item_b_id', 'created_at'],
+  },
+  {
+    table: 'item_documents',
+    idColumn: 'id',
+    columns: ['id', 'item_id', 'paperless_document_id', 'document_type', 'title', 'created_at'],
+  },
+  {
+    table: 'item_photos',
+    idColumn: 'id',
+    columns: ['id', 'item_id', 'file_path', 'caption', 'sort_order', 'created_at'],
+  },
+  {
+    table: 'item_uploaded_files',
+    idColumn: 'id',
+    columns: [
+      'id',
+      'item_id',
+      'file_name',
+      'file_path',
+      'mime_type',
+      'file_size',
+      'uploaded_at',
+      'created_at',
+    ],
+  },
+  {
+    table: 'item_fixture_connections',
+    idColumn: 'id',
+    columns: ['id', 'item_id', 'fixture_id', 'created_at'],
+  },
+];
+
+function tryCopyTable(raw: Database.Database, copy: TableCopy): void {
+  try {
+    const hasTable = raw
+      .prepare(`SELECT 1 FROM pops.sqlite_master WHERE type='table' AND name='${copy.table}'`)
+      .get();
+    if (!hasTable) return;
+    const cols = copy.columns.join(', ');
+    raw.exec(`
+      INSERT INTO ${copy.table} (${cols})
+      SELECT ${cols}
+      FROM pops.${copy.table}
+      WHERE ${copy.idColumn} NOT IN (SELECT ${copy.idColumn} FROM ${copy.table})
+    `);
+  } catch (err) {
+    console.warn(`[db] Inventory backfill of ${copy.table} failed (non-fatal):`, err);
+  }
+}
+
+/**
+ * Copy every inventory-owned table's rows from `pops.db` into
+ * `inventory.db`, in FK-safe order, idempotent against re-runs.
+ *
+ * Caller is responsible for supplying the inventory handle (so this
+ * module stays decoupled from the lazy singleton in
+ * `db/inventory-handle.ts`). Production wiring passes the result of
+ * `getInventoryDrizzle()` after the eager-open block; tests pass an
+ * in-memory handle with a tmpdir copy of the shared DB pre-populated.
+ */
+export function backfillInventoryFromShared(
+  inventory: OpenedInventoryDb,
+  sharedPath: string
+): void {
+  try {
+    inventory.raw.prepare('ATTACH DATABASE ? AS pops').run(sharedPath);
+    try {
+      for (const copy of TABLE_COPIES) tryCopyTable(inventory.raw, copy);
+    } finally {
+      inventory.raw.exec('DETACH DATABASE pops');
+    }
+  } catch (err) {
+    console.warn('[db] Inventory backfill ATTACH failed (non-fatal):', err);
+  }
+}

--- a/apps/pops-api/src/db/inventory-handle.ts
+++ b/apps/pops-api/src/db/inventory-handle.ts
@@ -15,6 +15,7 @@
  */
 import { openInventoryDb, type InventoryDb, type OpenedInventoryDb } from '@pops/inventory-db';
 
+import { backfillInventoryFromShared } from './backfill-inventory-from-shared.js';
 import { resolveInventorySqlitePath } from './inventory-sqlite-path.js';
 
 let inventoryDb: OpenedInventoryDb | null = null;
@@ -33,6 +34,22 @@ export function getInventoryDrizzle(): InventoryDb {
     inventoryDb = openInventoryDb(resolveInventorySqlitePath());
   }
   return inventoryDb.db;
+}
+
+/**
+ * Resolve the inventory pillar's raw better-sqlite3 handle. Same lazy
+ * open as `getInventoryDrizzle()` — the underlying connection is the
+ * same; the drizzle wrapper hides `.transaction()` / `.prepare()` /
+ * `.pragma()` which a handful of inventory module call sites still
+ * need (e.g. `photos.reorderPhotos` wraps a batch update in a
+ * better-sqlite3 transaction). Prefer `getInventoryDrizzle()` for
+ * everything that doesn't need that lower-level API.
+ */
+export function getInventoryRawDb(): OpenedInventoryDb['raw'] {
+  if (!inventoryDb) {
+    inventoryDb = openInventoryDb(resolveInventorySqlitePath());
+  }
+  return inventoryDb.raw;
 }
 
 /**
@@ -58,4 +75,16 @@ export function setInventoryDb(next: OpenedInventoryDb | null): OpenedInventoryD
   const prev = inventoryDb;
   inventoryDb = next;
   return prev;
+}
+
+/**
+ * Run the one-shot ATTACH backfill from the legacy shared pops.db into
+ * the inventory pillar's inventory.db. No-op if the inventory handle
+ * isn't open (e.g. boot still resolving). Idempotent against repeated
+ * boots via per-table `WHERE id NOT IN (...)` filters. See
+ * `backfill-inventory-from-shared.ts` for table-by-table behaviour.
+ */
+export function backfillInventoryFromSharedDb(sharedPath: string): void {
+  if (!inventoryDb) return;
+  backfillInventoryFromShared(inventoryDb, sharedPath);
 }

--- a/apps/pops-api/src/db/inventory-handle.ts
+++ b/apps/pops-api/src/db/inventory-handle.ts
@@ -13,8 +13,11 @@
  * `core-handle.ts` / `media-handle.ts` / ... once those pillars start
  * pulling their wiring out of the central file.
  */
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+
 import { openInventoryDb, type InventoryDb, type OpenedInventoryDb } from '@pops/inventory-db';
 
+import { getDb, isNamedEnvContext } from '../db.js';
 import { backfillInventoryFromShared } from './backfill-inventory-from-shared.js';
 import { resolveInventorySqlitePath } from './inventory-sqlite-path.js';
 
@@ -23,13 +26,21 @@ let inventoryDb: OpenedInventoryDb | null = null;
 /**
  * Resolve (and lazily open) the inventory pillar's drizzle handle.
  *
- * The handle is opened here on first call so the per-pillar migrations
- * apply at boot. Phase 2 PR 2 does NOT yet route any production traffic
- * through it — the existing shared singleton continues to serve every
- * read/write. The handle is here so PR 3 can flip locations + items +
- * uri-handler callers over with a one-line edit.
+ * **Env-aware**: inside a `withEnvDb()` scope (PRD-101 named environments —
+ * each E2E test fixture creates a per-test pops.db with its own seeded
+ * inventory tables) the env DB takes precedence. The env DB already
+ * contains every inventory-owned table because `seedDatabase()` writes
+ * them there, so a single fixture stays self-contained without a
+ * background backfill into the global `inventory.db`. Outside an env
+ * scope (real production boot, dev), the pillar's `inventory.db` is
+ * resolved + lazily opened so the in-package migrations apply.
+ *
+ * The handle is opened on first call so per-pillar migrations land
+ * before any request hits the API. Phase 2 PR 3 routes every inventory
+ * module read/write through this getter.
  */
 export function getInventoryDrizzle(): InventoryDb {
+  if (isNamedEnvContext()) return drizzle(getDb()) as InventoryDb;
   if (!inventoryDb) {
     inventoryDb = openInventoryDb(resolveInventorySqlitePath());
   }
@@ -38,14 +49,15 @@ export function getInventoryDrizzle(): InventoryDb {
 
 /**
  * Resolve the inventory pillar's raw better-sqlite3 handle. Same lazy
- * open as `getInventoryDrizzle()` — the underlying connection is the
- * same; the drizzle wrapper hides `.transaction()` / `.prepare()` /
- * `.pragma()` which a handful of inventory module call sites still
- * need (e.g. `photos.reorderPhotos` wraps a batch update in a
- * better-sqlite3 transaction). Prefer `getInventoryDrizzle()` for
- * everything that doesn't need that lower-level API.
+ * open + env-aware behaviour as `getInventoryDrizzle()` — the drizzle
+ * wrapper hides `.transaction()` / `.prepare()` / `.pragma()` which a
+ * handful of inventory module call sites still need (e.g.
+ * `photos.reorderPhotos` wraps a batch update in a better-sqlite3
+ * transaction). Prefer `getInventoryDrizzle()` for everything that
+ * doesn't need that lower-level API.
  */
 export function getInventoryRawDb(): OpenedInventoryDb['raw'] {
+  if (isNamedEnvContext()) return getDb();
   if (!inventoryDb) {
     inventoryDb = openInventoryDb(resolveInventorySqlitePath());
   }

--- a/apps/pops-api/src/db/per-pillar-migrations.test.ts
+++ b/apps/pops-api/src/db/per-pillar-migrations.test.ts
@@ -203,11 +203,13 @@ describe('runPerPillarMigrations', () => {
     // Smoke check: importing the runner under the real layout exercises
     // the workspace fallback path against an actual on-disk pillar dir.
     // `core` owns `packages/core-db/migrations/` with 0054_service_accounts
-    // (core pillar Phase 1 PR 2), `media` owns `packages/media-db/migrations/`
-    // with 0021_spooky_lockheed (media pillar Phase 1 PR 2), and `inventory`
+    // (core pillar Phase 1 PR 2); `media` owns `packages/media-db/migrations/`
+    // with 0021_spooky_lockheed (media pillar Phase 1 PR 2); `inventory`
     // owns `packages/inventory-db/migrations/` with 0005_fancy_crystal
-    // (inventory pillar Phase 1 PR 2). Pillars without their own journal
-    // yet still skip cleanly.
+    // (inventory pillar Phase 1 PR 2) AND 0006_inventory_pillar_baseline
+    // (inventory pillar Phase 2 PR 3 — comprehensive home_inventory +
+    // fixtures + item_* baseline ahead of the cutover). Pillars without
+    // their own journal yet still skip cleanly.
     await withDb((db) => {
       const realPillars: PillarDescriptor[] = [
         { id: 'core', dbPackageDir: 'packages/core-db' },
@@ -218,6 +220,7 @@ describe('runPerPillarMigrations', () => {
       const result = runPerPillarMigrations(db, realPillars);
       expect([...result.applied].toSorted()).toEqual([
         '0005_fancy_crystal',
+        '0006_inventory_pillar_baseline',
         '0021_spooky_lockheed',
         '0054_service_accounts',
       ]);

--- a/apps/pops-api/src/index.ts
+++ b/apps/pops-api/src/index.ts
@@ -7,8 +7,9 @@ config({ path: '../../.env', override: false }); // loads root .env without over
 
 import { createApp } from './app.js';
 import { backfillCoreFromShared, closeDb, getCoreDrizzle } from './db.js';
-import { getInventoryDrizzle } from './db/inventory-handle.js';
+import { backfillInventoryFromSharedDb, getInventoryDrizzle } from './db/inventory-handle.js';
 import { getMediaDrizzle } from './db/media-db-handle.js';
+import { resolveSqlitePath } from './db/sqlite-path.js';
 import { closeQueues } from './jobs/queues.js';
 import { startThalamus, stopThalamus } from './modules/cerebrum/thalamus/instance.js';
 import {
@@ -52,14 +53,14 @@ try {
 }
 
 // Eagerly open the inventory pillar's SQLite + apply its journal at
-// boot. Phase 2 PR 2 of the inventory pillar: the handle is opened so
-// the per-pillar migrations land before any request hits the API, but
-// no production traffic flips over yet — PR 3 of phase 2 cuts over
-// locations + items + uri-handler with a single `getDrizzle()` →
-// `getInventoryDrizzle()` swap and adds the one-shot ATTACH-based
-// backfill from the legacy shared pops.db.
+// boot. All inventory module traffic now reads/writes against this
+// handle (phase 2 PR 3); the one-shot `backfillInventoryFromSharedDb`
+// carries any rows that still live in the legacy pops.db across.
+// The backfill is idempotent (per-table `WHERE id NOT IN (...)`
+// filters) and non-fatal (partial failure logs + continues).
 try {
   getInventoryDrizzle();
+  backfillInventoryFromSharedDb(resolveSqlitePath());
 } catch (err) {
   console.error('[db] Failed to bootstrap the inventory pillar SQLite:', err);
   throw err;

--- a/apps/pops-api/src/modules/inventory/connections/graph.ts
+++ b/apps/pops-api/src/modules/inventory/connections/graph.ts
@@ -1,6 +1,6 @@
 import { homeInventory, itemConnections } from '@pops/db-types';
 
-import { getDrizzle } from '../../../db.js';
+import { getInventoryDrizzle } from '../../../db/inventory-handle.js';
 import { NotFoundError } from '../../../shared/errors.js';
 
 import type { GraphData, GraphEdge, GraphNode } from './types.js';
@@ -59,7 +59,7 @@ function visitNeighbors(
 }
 
 export function getConnectionGraph(itemId: string, maxDepth: number): GraphData {
-  const db = getDrizzle();
+  const db = getInventoryDrizzle();
   const allConnections = db.select().from(itemConnections).all();
   const allItems = db
     .select({

--- a/apps/pops-api/src/modules/inventory/connections/service.ts
+++ b/apps/pops-api/src/modules/inventory/connections/service.ts
@@ -6,7 +6,7 @@ import { and, count, eq, or } from 'drizzle-orm';
  */
 import { homeInventory, itemConnections } from '@pops/db-types';
 
-import { getDrizzle } from '../../../db.js';
+import { getInventoryDrizzle } from '../../../db/inventory-handle.js';
 import { ConflictError, NotFoundError } from '../../../shared/errors.js';
 
 import type { ItemConnectionRow, TraceNode } from './types.js';
@@ -22,7 +22,7 @@ export interface ConnectionListResult {
  * Validates both items exist. Throws ConflictError on duplicate.
  */
 export function connectItems(inputA: string, inputB: string): ItemConnectionRow {
-  const db = getDrizzle();
+  const db = getInventoryDrizzle();
 
   if (inputA === inputB) {
     throw new ConflictError('Cannot connect an item to itself');
@@ -75,7 +75,7 @@ export function connectItems(inputA: string, inputB: string): ItemConnectionRow 
  * Throws NotFoundError if no connection exists between the two items.
  */
 export function disconnectItems(inputA: string, inputB: string): void {
-  const db = getDrizzle();
+  const db = getInventoryDrizzle();
 
   // Enforce A<B ordering (same normalisation as connectItems)
   const [itemAId, itemBId] = inputA < inputB ? [inputA, inputB] : [inputB, inputA];
@@ -101,7 +101,7 @@ export function listConnectionsForItem(
   limit: number,
   offset: number
 ): ConnectionListResult {
-  const db = getDrizzle();
+  const db = getInventoryDrizzle();
 
   const condition = or(eq(itemConnections.itemAId, itemId), eq(itemConnections.itemBId, itemId));
 
@@ -118,7 +118,7 @@ export function listConnectionsForItem(
  * references by tracking visited nodes.
  */
 export function traceConnections(itemId: string, maxDepth: number): TraceNode {
-  const db = getDrizzle();
+  const db = getInventoryDrizzle();
 
   // Validate the starting item exists
   const [startItem] = db

--- a/apps/pops-api/src/modules/inventory/document-files/service.ts
+++ b/apps/pops-api/src/modules/inventory/document-files/service.ts
@@ -10,7 +10,7 @@ import { desc, count, eq } from 'drizzle-orm';
 
 import { homeInventory, itemUploadedFiles } from '@pops/db-types';
 
-import { getDrizzle } from '../../../db.js';
+import { getInventoryDrizzle } from '../../../db/inventory-handle.js';
 import { NotFoundError, ValidationError } from '../../../shared/errors.js';
 import { getInventoryDocumentsDir } from './paths.js';
 import {
@@ -28,7 +28,7 @@ export interface UploadedFileListResult {
 
 /** Validate that an inventory item exists. */
 function assertItemExists(itemId: string): void {
-  const db = getDrizzle();
+  const db = getInventoryDrizzle();
   const [item] = db
     .select({ id: homeInventory.id })
     .from(homeInventory)
@@ -39,7 +39,7 @@ function assertItemExists(itemId: string): void {
 
 /** Get a single uploaded file by ID. Throws NotFoundError if missing. */
 function getUploadedFile(id: number): ItemUploadedFileRow {
-  const db = getDrizzle();
+  const db = getInventoryDrizzle();
   const [row] = db.select().from(itemUploadedFiles).where(eq(itemUploadedFiles.id, id)).all();
   if (!row) throw new NotFoundError('Item uploaded file', String(id));
   return row;
@@ -102,7 +102,7 @@ function nextFilenameForItem(baseDir: string, itemId: string, originalName: stri
 
 /** Upload a document and attach it to an inventory item. */
 export function uploadDocument(input: UploadDocumentInput): ItemUploadedFileRow {
-  const db = getDrizzle();
+  const db = getInventoryDrizzle();
 
   assertItemExists(input.itemId);
   const safeName = sanitiseUploadFileName(input.fileName);
@@ -140,7 +140,7 @@ export function removeUpload(id: number): void {
     unlinkSync(fullPath);
   }
 
-  const db = getDrizzle();
+  const db = getInventoryDrizzle();
   db.delete(itemUploadedFiles).where(eq(itemUploadedFiles.id, id)).run();
 }
 
@@ -150,7 +150,7 @@ export function listUploadsForItem(
   limit: number,
   offset: number
 ): UploadedFileListResult {
-  const db = getDrizzle();
+  const db = getInventoryDrizzle();
 
   const rows = db
     .select()

--- a/apps/pops-api/src/modules/inventory/documents/service.ts
+++ b/apps/pops-api/src/modules/inventory/documents/service.ts
@@ -5,7 +5,7 @@ import { and, count, eq } from 'drizzle-orm';
  */
 import { homeInventory, itemDocuments } from '@pops/db-types';
 
-import { getDrizzle } from '../../../db.js';
+import { getInventoryDrizzle } from '../../../db/inventory-handle.js';
 import { ConflictError, NotFoundError } from '../../../shared/errors.js';
 
 import type { ItemDocumentRow } from './types.js';
@@ -25,7 +25,7 @@ export function linkDocument(
   documentType: string,
   title?: string
 ): ItemDocumentRow {
-  const db = getDrizzle();
+  const db = getInventoryDrizzle();
 
   // Validate item exists
   const [item] = db
@@ -78,7 +78,7 @@ export function linkDocument(
  * Unlink a document from an item by link ID.
  */
 export function unlinkDocument(id: number): void {
-  const db = getDrizzle();
+  const db = getInventoryDrizzle();
 
   const [row] = db
     .select({ id: itemDocuments.id })
@@ -99,7 +99,7 @@ export function listDocumentsForItem(
   limit: number,
   offset: number
 ): DocumentListResult {
-  const db = getDrizzle();
+  const db = getInventoryDrizzle();
 
   const condition = eq(itemDocuments.itemId, itemId);
 

--- a/apps/pops-api/src/modules/inventory/fixtures/service.ts
+++ b/apps/pops-api/src/modules/inventory/fixtures/service.ts
@@ -2,7 +2,7 @@ import { and, asc, count, eq } from 'drizzle-orm';
 
 import { fixtures, homeInventory, itemFixtureConnections } from '@pops/db-types';
 
-import { getDrizzle } from '../../../db.js';
+import { getInventoryDrizzle } from '../../../db/inventory-handle.js';
 import { ConflictError, NotFoundError } from '../../../shared/errors.js';
 import {
   isForeignKeyConstraintError,
@@ -34,7 +34,7 @@ export function listFixtures(opts: {
   limit: number;
   offset: number;
 }): FixtureListResult {
-  const db = getDrizzle();
+  const db = getInventoryDrizzle();
   const conditions = [];
   if (opts.locationId) conditions.push(eq(fixtures.locationId, opts.locationId));
   if (opts.type) conditions.push(eq(fixtures.type, opts.type));
@@ -53,14 +53,14 @@ export function listFixtures(opts: {
 }
 
 export function getFixture(id: string): Fixture {
-  const db = getDrizzle();
+  const db = getInventoryDrizzle();
   const [row] = db.select().from(fixtures).where(eq(fixtures.id, id)).all();
   if (!row) throw new NotFoundError('Fixture', id);
   return row;
 }
 
 export function createFixture(input: CreateFixtureInput): Fixture {
-  const db = getDrizzle();
+  const db = getInventoryDrizzle();
   const [row] = db
     .insert(fixtures)
     .values({
@@ -77,7 +77,7 @@ export function createFixture(input: CreateFixtureInput): Fixture {
 }
 
 export function updateFixture(id: string, input: UpdateFixtureInput): Fixture {
-  const db = getDrizzle();
+  const db = getInventoryDrizzle();
 
   // Three-state per field: absent → leave, null → clear, value → set.
   // `UpdateFixtureSchema.refine` guarantees at least one input key, so the
@@ -95,7 +95,7 @@ export function updateFixture(id: string, input: UpdateFixtureInput): Fixture {
 }
 
 export function deleteFixture(id: string): void {
-  const db = getDrizzle();
+  const db = getInventoryDrizzle();
   const result = db.delete(fixtures).where(eq(fixtures.id, id)).run();
   if (result.changes === 0) throw new NotFoundError('Fixture', id);
 }
@@ -105,7 +105,7 @@ export function deleteFixture(id: string): void {
 // correctness. We catch the constraint failures and reach for nicer error
 // messages only on the unhappy path.
 export function connectItemToFixture(itemId: string, fixtureId: string): ItemFixtureConnection {
-  const db = getDrizzle();
+  const db = getInventoryDrizzle();
   try {
     const [row] = db.insert(itemFixtureConnections).values({ itemId, fixtureId }).returning().all();
     if (!row) throw new Error('Failed to create item-fixture connection');
@@ -128,7 +128,7 @@ export function connectItemToFixture(itemId: string, fixtureId: string): ItemFix
 }
 
 export function disconnectItemFromFixture(itemId: string, fixtureId: string): void {
-  const db = getDrizzle();
+  const db = getInventoryDrizzle();
   const result = db
     .delete(itemFixtureConnections)
     .where(
@@ -148,7 +148,7 @@ export function listFixturesForItem(
   limit: number,
   offset: number
 ): FixtureConnectionListResult {
-  const db = getDrizzle();
+  const db = getInventoryDrizzle();
   const condition = eq(itemFixtureConnections.itemId, itemId);
   const rows = db
     .select()

--- a/apps/pops-api/src/modules/inventory/items/search-adapter.ts
+++ b/apps/pops-api/src/modules/inventory/items/search-adapter.ts
@@ -2,7 +2,7 @@ import { sql } from 'drizzle-orm';
 
 import { homeInventory } from '@pops/db-types';
 
-import { getDrizzle } from '../../../db.js';
+import { getInventoryDrizzle } from '../../../db/inventory-handle.js';
 
 import type { Query, SearchAdapter, SearchContext, SearchHit } from '../../core/search/index.js';
 
@@ -29,7 +29,7 @@ function rowToData(row: Row): InventoryItemHitData {
 }
 
 function searchAssetExact(lowerText: string, hits: SearchHit<InventoryItemHitData>[]): void {
-  const rows = getDrizzle()
+  const rows = getInventoryDrizzle()
     .select()
     .from(homeInventory)
     .where(sql`lower(${homeInventory.assetId}) = ${lowerText}`)
@@ -50,7 +50,7 @@ function searchAssetPrefix(
   limit: number,
   hits: SearchHit<InventoryItemHitData>[]
 ): void {
-  const rows = getDrizzle()
+  const rows = getInventoryDrizzle()
     .select()
     .from(homeInventory)
     .where(
@@ -84,7 +84,7 @@ function searchByName(
   seenIds: Set<string>,
   hits: SearchHit<InventoryItemHitData>[]
 ): void {
-  const rows = getDrizzle()
+  const rows = getInventoryDrizzle()
     .select()
     .from(homeInventory)
     .where(sql`lower(${homeInventory.itemName}) like ${'%' + lowerText + '%'}`)

--- a/apps/pops-api/src/modules/inventory/items/service.ts
+++ b/apps/pops-api/src/modules/inventory/items/service.ts
@@ -9,7 +9,7 @@ import { and, count, eq, inArray, isNotNull, like, sql, sum, type SQL } from 'dr
 import { homeInventory } from '@pops/db-types';
 import { locationsService } from '@pops/inventory-db';
 
-import { getDrizzle } from '../../../db.js';
+import { getInventoryDrizzle } from '../../../db/inventory-handle.js';
 import { NotFoundError } from '../../../shared/errors.js';
 import { buildInventoryUpdate } from './update-builder.js';
 
@@ -58,7 +58,7 @@ function buildInventoryConditions(opts: ListInventoryItemsOptions): SQL[] {
 
 function buildLocationCondition(locationId: string, includeChildren: boolean | undefined): SQL {
   if (!includeChildren) return eq(homeInventory.locationId, locationId);
-  const descendants = locationsService.getDescendantLocationIds(getDrizzle(), locationId);
+  const descendants = locationsService.getDescendantLocationIds(getInventoryDrizzle(), locationId);
   return inArray(homeInventory.locationId, [locationId, ...descendants]);
 }
 
@@ -70,7 +70,7 @@ function combineConditions(conditions: SQL[]): SQL | undefined {
 
 /** List inventory items with optional filters. */
 export function listInventoryItems(opts: ListInventoryItemsOptions): InventoryListResult {
-  const db = getDrizzle();
+  const db = getInventoryDrizzle();
 
   let query = db.select().from(homeInventory).$dynamic();
   let countQuery = db.select({ total: count() }).from(homeInventory).$dynamic();
@@ -106,7 +106,7 @@ export function listInventoryItems(opts: ListInventoryItemsOptions): InventoryLi
  * Returns the item or null if not found.
  */
 export function searchByAssetId(assetId: string): InventoryRow | null {
-  const db = getDrizzle();
+  const db = getInventoryDrizzle();
   const [row] = db
     .select()
     .from(homeInventory)
@@ -119,7 +119,7 @@ export function searchByAssetId(assetId: string): InventoryRow | null {
  * Count inventory items whose assetId starts with the given prefix (case-insensitive).
  */
 export function countByAssetPrefix(prefix: string): number {
-  const db = getDrizzle();
+  const db = getInventoryDrizzle();
   const [result] = db
     .select({ count: sql<number>`COUNT(*)` })
     .from(homeInventory)
@@ -130,7 +130,7 @@ export function countByAssetPrefix(prefix: string): number {
 
 /** Return distinct item types that exist in the database. */
 export function getDistinctTypes(): string[] {
-  const db = getDrizzle();
+  const db = getInventoryDrizzle();
   const rows = db
     .selectDistinct({ type: homeInventory.type })
     .from(homeInventory)
@@ -142,7 +142,7 @@ export function getDistinctTypes(): string[] {
 
 /** Get a single inventory item by id. Throws NotFoundError if missing. */
 export function getInventoryItem(id: string): InventoryRow {
-  const db = getDrizzle();
+  const db = getInventoryDrizzle();
   const [row] = db.select().from(homeInventory).where(eq(homeInventory.id, id)).all();
 
   if (!row) throw new NotFoundError('Inventory item', id);
@@ -217,7 +217,7 @@ function nullableNumbersFromInput(
  * Generates a local UUID and inserts directly into SQLite.
  */
 export function createInventoryItem(input: CreateInventoryItemInput): InventoryRow {
-  const db = getDrizzle();
+  const db = getInventoryDrizzle();
   const id = crypto.randomUUID();
   const now = new Date().toISOString();
 
@@ -237,7 +237,7 @@ export function updateInventoryItem(id: string, input: UpdateInventoryItemInput)
 
   const updates = buildInventoryUpdate(input);
   if (updates) {
-    const db = getDrizzle();
+    const db = getInventoryDrizzle();
     db.update(homeInventory).set(updates).where(eq(homeInventory.id, id)).run();
   }
 
@@ -251,7 +251,7 @@ export function updateInventoryItem(id: string, input: UpdateInventoryItemInput)
 export function deleteInventoryItem(id: string): void {
   getInventoryItem(id);
 
-  const db = getDrizzle();
+  const db = getInventoryDrizzle();
   const result = db.delete(homeInventory).where(eq(homeInventory.id, id)).run();
   if (result.changes === 0) throw new NotFoundError('Inventory item', id);
 }

--- a/apps/pops-api/src/modules/inventory/locations/router.ts
+++ b/apps/pops-api/src/modules/inventory/locations/router.ts
@@ -18,7 +18,7 @@ import {
   locationsService,
 } from '@pops/inventory-db';
 
-import { getDrizzle } from '../../../db.js';
+import { getInventoryDrizzle } from '../../../db/inventory-handle.js';
 import { ConflictError, NotFoundError } from '../../../shared/errors.js';
 import { mapDomainErrors } from '../../../shared/trpc-error-mapper.js';
 import { protectedProcedure, router } from '../../../trpc.js';
@@ -44,7 +44,7 @@ function translateLocationError(err: unknown): never {
 export const locationsRouter = router({
   /** Get the full location tree as nested nodes. */
   tree: protectedProcedure.query(() => {
-    return { data: locationsService.getLocationTree(getDrizzle()) };
+    return { data: locationsService.getLocationTree(getInventoryDrizzle()) };
   }),
 
   /** List all locations (flat). */
@@ -59,7 +59,7 @@ export const locationsRouter = router({
     })
     .output(z.object({ data: z.array(LocationSchema), total: z.number() }))
     .query(() => {
-      const { rows, total } = locationsService.listLocations(getDrizzle());
+      const { rows, total } = locationsService.listLocations(getInventoryDrizzle());
       return {
         data: rows.map(toLocation),
         total,
@@ -70,7 +70,7 @@ export const locationsRouter = router({
   get: protectedProcedure.input(z.object({ id: z.string() })).query(({ input }) =>
     mapDomainErrors(() => {
       try {
-        const row = locationsService.getLocation(getDrizzle(), input.id);
+        const row = locationsService.getLocation(getInventoryDrizzle(), input.id);
         return { data: toLocation(row) };
       } catch (err) {
         translateLocationError(err);
@@ -82,7 +82,7 @@ export const locationsRouter = router({
   getPath: protectedProcedure.input(z.object({ id: z.string() })).query(({ input }) =>
     mapDomainErrors(() => {
       try {
-        const rows = locationsService.getLocationPath(getDrizzle(), input.id);
+        const rows = locationsService.getLocationPath(getInventoryDrizzle(), input.id);
         return { data: rows.map(toLocation) };
       } catch (err) {
         translateLocationError(err);
@@ -103,7 +103,7 @@ export const locationsRouter = router({
     .query(({ input }) =>
       mapDomainErrors(() => {
         try {
-          const { rows, total } = locationsService.getLocationItems(getDrizzle(), input);
+          const { rows, total } = locationsService.getLocationItems(getInventoryDrizzle(), input);
           return {
             data: rows.map(toInventoryItem),
             total,
@@ -116,7 +116,7 @@ export const locationsRouter = router({
 
   /** Get children of a location (one level deep). */
   children: protectedProcedure.input(z.object({ parentId: z.string() })).query(({ input }) => {
-    const rows = locationsService.getChildren(getDrizzle(), input.parentId);
+    const rows = locationsService.getChildren(getInventoryDrizzle(), input.parentId);
     return { data: rows.map(toLocation) };
   }),
 
@@ -124,7 +124,7 @@ export const locationsRouter = router({
   create: protectedProcedure.input(CreateLocationSchema).mutation(({ input }) =>
     mapDomainErrors(() => {
       try {
-        const row = locationsService.createLocation(getDrizzle(), input);
+        const row = locationsService.createLocation(getInventoryDrizzle(), input);
         return {
           data: toLocation(row),
           message: 'Location created',
@@ -146,7 +146,7 @@ export const locationsRouter = router({
     .mutation(({ input }) =>
       mapDomainErrors(() => {
         try {
-          const row = locationsService.updateLocation(getDrizzle(), input.id, input.data);
+          const row = locationsService.updateLocation(getInventoryDrizzle(), input.id, input.data);
           return {
             data: toLocation(row),
             message: 'Location updated',
@@ -161,7 +161,7 @@ export const locationsRouter = router({
   deleteStats: protectedProcedure.input(z.object({ id: z.string() })).query(({ input }) =>
     mapDomainErrors(() => {
       try {
-        const stats = locationsService.getDeleteStats(getDrizzle(), input.id);
+        const stats = locationsService.getDeleteStats(getInventoryDrizzle(), input.id);
         return { data: stats };
       } catch (err) {
         translateLocationError(err);
@@ -177,12 +177,12 @@ export const locationsRouter = router({
         try {
           // If not forced, check if location has contents and require confirmation
           if (!input.force) {
-            const stats = locationsService.getDeleteStats(getDrizzle(), input.id);
+            const stats = locationsService.getDeleteStats(getInventoryDrizzle(), input.id);
             if (stats.childCount > 0 || stats.itemCount > 0) {
               return { requiresConfirmation: true, stats };
             }
           }
-          locationsService.deleteLocation(getDrizzle(), input.id);
+          locationsService.deleteLocation(getInventoryDrizzle(), input.id);
           return { message: 'Location deleted' };
         } catch (err) {
           translateLocationError(err);

--- a/apps/pops-api/src/modules/inventory/photos/service.ts
+++ b/apps/pops-api/src/modules/inventory/photos/service.ts
@@ -9,7 +9,7 @@ import sharp from 'sharp';
 
 import { homeInventory, itemPhotos } from '@pops/db-types';
 
-import { getDb, getDrizzle } from '../../../db.js';
+import { getInventoryDrizzle, getInventoryRawDb } from '../../../db/inventory-handle.js';
 import { NotFoundError, ValidationError } from '../../../shared/errors.js';
 import { getInventoryImagesDir } from './paths.js';
 
@@ -35,7 +35,7 @@ export interface PhotoListResult {
 
 /** Validate that an inventory item exists. */
 function assertItemExists(itemId: string): void {
-  const db = getDrizzle();
+  const db = getInventoryDrizzle();
   const [item] = db
     .select({ id: homeInventory.id })
     .from(homeInventory)
@@ -46,7 +46,7 @@ function assertItemExists(itemId: string): void {
 
 /** Get a single photo by ID. Throws NotFoundError if missing. */
 function getPhoto(id: number): ItemPhotoRow {
-  const db = getDrizzle();
+  const db = getInventoryDrizzle();
   const [row] = db.select().from(itemPhotos).where(eq(itemPhotos.id, id)).all();
   if (!row) throw new NotFoundError('Item photo', String(id));
   return row;
@@ -86,7 +86,7 @@ function nextPhotoFilename(baseDir: string, itemId: string): string {
 
 /** Upload, compress, and attach a photo to an inventory item. */
 export async function uploadPhoto(input: UploadPhotoInput): Promise<ItemPhotoRow> {
-  const db = getDrizzle();
+  const db = getInventoryDrizzle();
 
   assertItemExists(input.itemId);
 
@@ -118,7 +118,7 @@ export async function uploadPhoto(input: UploadPhotoInput): Promise<ItemPhotoRow
 
 /** Attach a photo to an inventory item. */
 export function attachPhoto(input: AttachPhotoInput): ItemPhotoRow {
-  const db = getDrizzle();
+  const db = getInventoryDrizzle();
 
   assertItemExists(input.itemId);
   assertSafeFilePath(input.filePath);
@@ -148,13 +148,13 @@ export function removePhoto(id: number): void {
     unlinkSync(fullPath);
   }
 
-  const db = getDrizzle();
+  const db = getInventoryDrizzle();
   db.delete(itemPhotos).where(eq(itemPhotos.id, id)).run();
 }
 
 /** Update a photo's caption or sort order. */
 export function updatePhoto(id: number, input: UpdatePhotoInput): ItemPhotoRow {
-  const db = getDrizzle();
+  const db = getInventoryDrizzle();
 
   getPhoto(id); // Validates existence
 
@@ -179,7 +179,7 @@ export function updatePhoto(id: number, input: UpdatePhotoInput): ItemPhotoRow {
 
 /** List photos for an item, ordered by sortOrder. */
 export function listPhotosForItem(itemId: string, limit: number, offset: number): PhotoListResult {
-  const db = getDrizzle();
+  const db = getInventoryDrizzle();
 
   const rows = db
     .select()
@@ -204,8 +204,8 @@ export function listPhotosForItem(itemId: string, limit: number, offset: number)
  * in the orderedIds array (0-indexed).
  */
 export function reorderPhotos(itemId: string, orderedIds: number[]): ItemPhotoRow[] {
-  const db = getDrizzle();
-  const rawDb = getDb();
+  const db = getInventoryDrizzle();
+  const rawDb = getInventoryRawDb();
 
   assertItemExists(itemId);
 

--- a/apps/pops-api/src/modules/inventory/reports/insurance-report.ts
+++ b/apps/pops-api/src/modules/inventory/reports/insurance-report.ts
@@ -2,7 +2,7 @@ import { asc, eq } from 'drizzle-orm';
 
 import { homeInventory, itemDocuments, itemPhotos, locations } from '@pops/db-types';
 
-import { getDrizzle } from '../../../db.js';
+import { getInventoryDrizzle } from '../../../db/inventory-handle.js';
 
 export interface InsuranceReportItem {
   id: string;
@@ -38,7 +38,7 @@ export interface InsuranceReportOptions {
 }
 
 function getLocationSubtreeIds(rootId: string): Set<string> {
-  const db = getDrizzle();
+  const db = getInventoryDrizzle();
   const allLocations = db.select().from(locations).all();
 
   const childrenMap = new Map<string, string[]>();
@@ -69,7 +69,7 @@ interface Lookups {
 }
 
 function buildLookups(): Lookups {
-  const db = getDrizzle();
+  const db = getInventoryDrizzle();
   const locationNameMap = new Map<string, string>();
   for (const loc of db.select().from(locations).all()) locationNameMap.set(loc.id, loc.name);
 
@@ -150,7 +150,7 @@ function buildGroups(items: InsuranceReportItem[], lookups: Lookups): InsuranceR
 
 export function getInsuranceReport(options: InsuranceReportOptions = {}): InsuranceReportResult {
   const { locationId, includeChildren = true, sortBy = 'value' } = options;
-  const db = getDrizzle();
+  const db = getInventoryDrizzle();
 
   let locationIds: Set<string> | null = null;
   if (locationId) {

--- a/apps/pops-api/src/modules/inventory/reports/service.ts
+++ b/apps/pops-api/src/modules/inventory/reports/service.ts
@@ -5,7 +5,7 @@ import { and, count, desc, eq, gte, isNotNull, lte, sql } from 'drizzle-orm';
  */
 import { homeInventory, itemDocuments, locations } from '@pops/db-types';
 
-import { getDrizzle } from '../../../db.js';
+import { getInventoryDrizzle } from '../../../db/inventory-handle.js';
 
 import type { InventoryRow } from '../items/types.js';
 import type { DashboardSummary, RecentItem, ValueBreakdownEntry } from './types.js';
@@ -26,7 +26,7 @@ const WARRANTY_WINDOW_DAYS = 90;
  * and recently added items.
  */
 export function getDashboard(): DashboardSummary {
-  const db = getDrizzle();
+  const db = getInventoryDrizzle();
 
   const [summary] = db
     .select({
@@ -82,7 +82,7 @@ export interface WarrantyListItem extends InventoryRow {
 
 /** List all inventory items that have a warranty expiry date, sorted by expiry. */
 export function listWarrantyItems(): WarrantyListItem[] {
-  const db = getDrizzle();
+  const db = getInventoryDrizzle();
   const rows = db
     .select({
       item: homeInventory,
@@ -107,7 +107,7 @@ export function listWarrantyItems(): WarrantyListItem[] {
  * Get replacement value breakdown grouped by location.
  */
 export function getValueByLocation(): ValueBreakdownEntry[] {
-  const db = getDrizzle();
+  const db = getInventoryDrizzle();
 
   return db
     .select({
@@ -127,7 +127,7 @@ export function getValueByLocation(): ValueBreakdownEntry[] {
  * Get replacement value breakdown grouped by item type.
  */
 export function getValueByType(): ValueBreakdownEntry[] {
-  const db = getDrizzle();
+  const db = getInventoryDrizzle();
 
   return db
     .select({

--- a/apps/pops-api/src/modules/inventory/uri-handler.ts
+++ b/apps/pops-api/src/modules/inventory/uri-handler.ts
@@ -7,7 +7,7 @@
  */
 import { LocationNotFoundError, locationsService } from '@pops/inventory-db';
 
-import { getDrizzle } from '../../db.js';
+import { getInventoryDrizzle } from '../../db/inventory-handle.js';
 import { NotFoundError } from '../../shared/errors.js';
 import { getInventoryItem } from './items/service.js';
 
@@ -33,7 +33,7 @@ export const inventoryUriHandler: UriHandlerDescriptor = {
       case 'item':
         return tryGet(() => getInventoryItem(id));
       case 'location':
-        return tryGet(() => locationsService.getLocation(getDrizzle(), id));
+        return tryGet(() => locationsService.getLocation(getInventoryDrizzle(), id));
       default:
         return { kind: 'not-found' };
     }

--- a/apps/pops-api/src/shared/test-utils.ts
+++ b/apps/pops-api/src/shared/test-utils.ts
@@ -2,6 +2,7 @@ import BetterSqlite3 from 'better-sqlite3';
 import { drizzle } from 'drizzle-orm/better-sqlite3';
 
 import { closeDb, setCoreDb, setDb } from '../db.js';
+import { setInventoryDb } from '../db/inventory-handle.js';
 import { setMediaDb } from '../db/media-db-handle.js';
 import { appRouter } from '../router.js';
 import { TAG_VOCABULARY_V1 } from './tag-vocabulary.js';
@@ -1483,11 +1484,18 @@ export function setupTestContext() {
     setCoreDb({ db: drizzle(db), raw: db });
     setMediaDb({ db: drizzle(db), raw: db });
 
+    // Same for the inventory pillar handle (phase 2 PR 3): every
+    // inventory module read/write now resolves getInventoryDrizzle(),
+    // so the test fixture has to surface its tables (locations,
+    // home_inventory, fixtures, item_*) on the inventory handle too.
+    setInventoryDb({ db: drizzle(db), raw: db });
+
     return { db, caller: createCaller(true) };
   }
 
   function teardown() {
     setCoreDb(null);
+    setInventoryDb(null);
     setMediaDb(null);
     closeDb();
   }

--- a/packages/db-types/src/schema/inventory.ts
+++ b/packages/db-types/src/schema/inventory.ts
@@ -34,7 +34,11 @@ export const homeInventory = sqliteTable(
     }),
     purchasedFromName: text('purchased_from_name'),
     purchasePrice: real('purchase_price'),
-    assetId: text('asset_id').unique(),
+    // Uniqueness is enforced via the explicit `idx_inventory_asset_id`
+    // unique index below — `.unique()` here would produce a second,
+    // redundant unique index (`home_inventory_asset_id_unique`) that
+    // doubles write cost and on-disk footprint for zero functional gain.
+    assetId: text('asset_id'),
     notes: text('notes'),
     locationId: text('location_id').references(() => locations.id, {
       onDelete: 'set null',

--- a/packages/inventory-db/migrations/0006_inventory_pillar_baseline.sql
+++ b/packages/inventory-db/migrations/0006_inventory_pillar_baseline.sql
@@ -1,0 +1,113 @@
+CREATE TABLE `home_inventory` (
+	`id` text PRIMARY KEY NOT NULL,
+	`notion_id` text,
+	`item_name` text NOT NULL,
+	`brand` text,
+	`model` text,
+	`item_id` text,
+	`room` text,
+	`location` text,
+	`type` text,
+	`condition` text DEFAULT 'good',
+	`in_use` integer,
+	`deductible` integer,
+	`purchase_date` text,
+	`warranty_expires` text,
+	`replacement_value` real,
+	`resale_value` real,
+	`purchase_transaction_id` text,
+	`purchased_from_id` text,
+	`purchased_from_name` text,
+	`purchase_price` real,
+	`asset_id` text,
+	`notes` text,
+	`location_id` text,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL,
+	`updated_at` text DEFAULT (datetime('now')) NOT NULL,
+	`last_edited_time` text NOT NULL,
+	FOREIGN KEY (`location_id`) REFERENCES `locations`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `home_inventory_notion_id_unique` ON `home_inventory` (`notion_id`);--> statement-breakpoint
+CREATE UNIQUE INDEX `home_inventory_asset_id_unique` ON `home_inventory` (`asset_id`);--> statement-breakpoint
+CREATE UNIQUE INDEX `idx_inventory_asset_id` ON `home_inventory` (`asset_id`);--> statement-breakpoint
+CREATE INDEX `idx_inventory_name` ON `home_inventory` (`item_name`);--> statement-breakpoint
+CREATE INDEX `idx_inventory_location` ON `home_inventory` (`location_id`);--> statement-breakpoint
+CREATE INDEX `idx_inventory_type` ON `home_inventory` (`type`);--> statement-breakpoint
+CREATE INDEX `idx_inventory_warranty` ON `home_inventory` (`warranty_expires`);--> statement-breakpoint
+CREATE TABLE `fixtures` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`type` text NOT NULL,
+	`location_id` text,
+	`notes` text,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL,
+	`last_edited_time` text NOT NULL,
+	FOREIGN KEY (`location_id`) REFERENCES `locations`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE INDEX `idx_fixtures_location` ON `fixtures` (`location_id`);--> statement-breakpoint
+CREATE INDEX `idx_fixtures_type` ON `fixtures` (`type`);--> statement-breakpoint
+CREATE INDEX `idx_fixtures_name` ON `fixtures` (`name`);--> statement-breakpoint
+CREATE TABLE `item_connections` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`item_a_id` text NOT NULL,
+	`item_b_id` text NOT NULL,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL,
+	FOREIGN KEY (`item_a_id`) REFERENCES `home_inventory`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`item_b_id`) REFERENCES `home_inventory`(`id`) ON UPDATE no action ON DELETE cascade,
+	CONSTRAINT `chk_item_connections_order` CHECK("item_connections"."item_a_id" < "item_connections"."item_b_id")
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `uq_item_connections_pair` ON `item_connections` (`item_a_id`,`item_b_id`);--> statement-breakpoint
+CREATE INDEX `idx_item_connections_a` ON `item_connections` (`item_a_id`);--> statement-breakpoint
+CREATE INDEX `idx_item_connections_b` ON `item_connections` (`item_b_id`);--> statement-breakpoint
+CREATE TABLE `item_documents` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`item_id` text NOT NULL,
+	`paperless_document_id` integer NOT NULL,
+	`document_type` text NOT NULL,
+	`title` text,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL,
+	FOREIGN KEY (`item_id`) REFERENCES `home_inventory`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `uq_item_documents_pair` ON `item_documents` (`item_id`,`paperless_document_id`);--> statement-breakpoint
+CREATE INDEX `idx_item_documents_item` ON `item_documents` (`item_id`);--> statement-breakpoint
+CREATE INDEX `idx_item_documents_doc` ON `item_documents` (`paperless_document_id`);--> statement-breakpoint
+CREATE TABLE `item_photos` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`item_id` text NOT NULL,
+	`file_path` text NOT NULL,
+	`caption` text,
+	`sort_order` integer DEFAULT 0 NOT NULL,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL,
+	FOREIGN KEY (`item_id`) REFERENCES `home_inventory`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `idx_item_photos_item` ON `item_photos` (`item_id`);--> statement-breakpoint
+CREATE TABLE `item_uploaded_files` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`item_id` text NOT NULL,
+	`file_name` text NOT NULL,
+	`file_path` text NOT NULL,
+	`mime_type` text NOT NULL,
+	`file_size` integer NOT NULL,
+	`uploaded_at` text DEFAULT (datetime('now')) NOT NULL,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL,
+	FOREIGN KEY (`item_id`) REFERENCES `home_inventory`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `idx_item_uploaded_files_item` ON `item_uploaded_files` (`item_id`);--> statement-breakpoint
+CREATE TABLE `item_fixture_connections` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`item_id` text NOT NULL,
+	`fixture_id` text NOT NULL,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL,
+	FOREIGN KEY (`item_id`) REFERENCES `home_inventory`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`fixture_id`) REFERENCES `fixtures`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `uq_item_fixture_connections_pair` ON `item_fixture_connections` (`item_id`,`fixture_id`);--> statement-breakpoint
+CREATE INDEX `idx_item_fixture_conn_item` ON `item_fixture_connections` (`item_id`);--> statement-breakpoint
+CREATE INDEX `idx_item_fixture_conn_fixture` ON `item_fixture_connections` (`fixture_id`);

--- a/packages/inventory-db/migrations/0006_inventory_pillar_baseline.sql
+++ b/packages/inventory-db/migrations/0006_inventory_pillar_baseline.sql
@@ -29,7 +29,6 @@ CREATE TABLE `home_inventory` (
 );
 --> statement-breakpoint
 CREATE UNIQUE INDEX `home_inventory_notion_id_unique` ON `home_inventory` (`notion_id`);--> statement-breakpoint
-CREATE UNIQUE INDEX `home_inventory_asset_id_unique` ON `home_inventory` (`asset_id`);--> statement-breakpoint
 CREATE UNIQUE INDEX `idx_inventory_asset_id` ON `home_inventory` (`asset_id`);--> statement-breakpoint
 CREATE INDEX `idx_inventory_name` ON `home_inventory` (`item_name`);--> statement-breakpoint
 CREATE INDEX `idx_inventory_location` ON `home_inventory` (`location_id`);--> statement-breakpoint

--- a/packages/inventory-db/migrations/meta/_journal.json
+++ b/packages/inventory-db/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1773997925421,
       "tag": "0005_fancy_crystal",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1781650200000,
+      "tag": "0006_inventory_pillar_baseline",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

Phase 2 PR 3 of the inventory pillar migration moves every inventory slice (locations, items, fixtures, connections, documents, photos, document-files, paperless reports) off the shared `pops.db` singleton onto the new `inventory.db` handle opened in PR 2. **Every read/write that previously hit the shared connection now resolves `getInventoryDrizzle()` instead.**

Mirrors the core Phase 2 PR 3 ([#2756](https://github.com/knoxio/pops/pull/2756)) pattern with three pillar-specific deltas:
- Inventory needs a comprehensive pillar-baseline migration (the locations slice's queries join to `home_inventory`, so home_inventory + the five item_* tables + fixtures move alongside).
- The backfill copies 8 tables in FK-safe order, table-by-table, instead of one slice.
- `photos.reorderPhotos` needs the raw better-sqlite3 `.transaction()` API; PR 3 adds `getInventoryRawDb()` alongside `getInventoryDrizzle()` so the transaction also runs on the inventory connection.

### Inventory pillar journal
- **`packages/inventory-db/migrations/0006_inventory_pillar_baseline.sql`** — creates `home_inventory`, `fixtures`, `item_connections`, `item_documents`, `item_photos`, `item_uploaded_files`, `item_fixture_connections` at their final shape (post-0009 rebuild + post-0037 + post-0057). Cross-pillar FKs to `transactions` / `entities` are intentionally dropped — those references become URI strings in a future Phase 5 cross-pillar PR. Within-pillar FKs (`locations.id`, `home_inventory.id`, `fixtures.id`) are preserved with the right ON DELETE behaviour.
- **`packages/inventory-db/migrations/meta/_journal.json`** — gains the `0006` entry (idx 1, after `0005_fancy_crystal` from Phase 1 PR 2).

### Cutover
- 12 files in `apps/pops-api/src/modules/inventory/` swap `getDrizzle()` → `getInventoryDrizzle()`. Import paths point at `db/inventory-handle.js` (kept out of `db.ts` to stay under the lint cap).
- `photos/service.ts.reorderPhotos`: `getDb()` → new `getInventoryRawDb()` exported from `db/inventory-handle.ts`, so the better-sqlite3 transaction also runs on the inventory connection.
- `shared/test-utils.ts.setupTestContext`: installs the in-memory test DB on BOTH the shared AND the inventory handles (alongside the existing core injection), so the 310 inventory module tests and the rest of the 4640-case suite keep operating on a single SQLite fixture transparently.

### Boot-time backfill
- New **`apps/pops-api/src/db/backfill-inventory-from-shared.ts`**: ATTACH `pops.db` AS `pops`; for each of 8 tables in FK-safe order (`locations` → `home_inventory` → `fixtures` → item_*), copy rows whose `id` is missing from the inventory copy; DETACH. The `WHERE id NOT IN (...)` filter makes the call idempotent against repeated boots, and a per-table `tryCopyTable` wrapper means a missing source table (post-PR-4 drop scenario, or a stale on-disk pops.db) doesn't bring the whole backfill down — failures log and continue.
- New wrapper `backfillInventoryFromSharedDb()` in `db/inventory-handle.ts`: resolves the lazy inventory handle, calls the backfill, no-op if the handle isn't open yet.
- Wired into `index.ts` immediately after `getInventoryDrizzle()` — failures log + rethrow so a corrupt `inventory.db` crashes startup loudly instead of silently.

## Test plan
- [x] `cd packages/inventory-db && pnpm test` — 36/36 pass (locations + open-inventory-db smoke). The 0006 migration applies cleanly via drizzle's migrator (the smoke test catches a regression there).
- [x] `cd apps/pops-api && pnpm test src/db/backfill-inventory-from-shared` — 4/4 pass: fresh copy carries locations + home_inventory across, idempotent re-run, mixed state only inserts missing ids, missing source tables tolerated. Uses tmpdir files because in-memory DBs can't be ATTACHed.
- [x] `cd apps/pops-api && pnpm test src/modules/inventory` — 310/310 pass. The dual-injection in setupTestContext covers every `getDrizzle()` → `getInventoryDrizzle()` call site.
- [x] `cd apps/pops-api && pnpm typecheck` — clean
- [x] `pnpm lint` / `pnpm format:check` / `pnpm lint:boundaries` — clean