### PR TITLE
feat(api): flip shelf-impressions to the media pillar handle + backfill (phase 2 PR 3)

### DIFF
--- a/apps/pops-api/src/db/backfill-media-from-shared.test.ts
+++ b/apps/pops-api/src/db/backfill-media-from-shared.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Boot-time backfill tests for `backfillMediaFromShared` (phase 2 PR 3).
+ *
+ * Exercises the ATTACH-based copy from the shared `pops.db` to the
+ * pillar's `media.db` against on-disk SQLite files (in-memory DBs can't
+ * be ATTACHed). Confirms:
+ *   - first run carries existing rows across,
+ *   - second run is a no-op (idempotent — the WHERE filter dedupes),
+ *   - mixed state (some rows already in media) only inserts the missing ones,
+ *   - missing source table is tolerated without throwing.
+ *
+ * Mirrors `backfill-core-from-shared.test.ts`.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import BetterSqlite3 from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { openMediaDb } from '@pops/media-db';
+
+import { backfillMediaFromShared, closeMediaDb, setMediaDb } from '../db/media-db-handle.js';
+import { SHELF_IMPRESSIONS_TABLE_SQL } from './backfill-test-fixtures.js';
+
+let tmpDir: string;
+
+const originalSharedPath = process.env['SQLITE_PATH'];
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'media-backfill-'));
+});
+
+afterEach(() => {
+  closeMediaDb();
+  rmSync(tmpDir, { recursive: true, force: true });
+  if (originalSharedPath === undefined) delete process.env['SQLITE_PATH'];
+  else process.env['SQLITE_PATH'] = originalSharedPath;
+});
+
+function openSharedWithRows(rows: { shelfId: string; shownAt: string }[]): string {
+  const path = join(tmpDir, 'pops.db');
+  const raw = new BetterSqlite3(path);
+  raw.exec(SHELF_IMPRESSIONS_TABLE_SQL);
+  const insert = raw.prepare('INSERT INTO shelf_impressions (shelf_id, shown_at) VALUES (?, ?)');
+  for (const row of rows) {
+    insert.run(row.shelfId, row.shownAt);
+  }
+  raw.close();
+  process.env['SQLITE_PATH'] = path;
+  return path;
+}
+
+describe('backfillMediaFromShared', () => {
+  it('returns silently when the media handle is closed', () => {
+    setMediaDb(null);
+    expect(() => backfillMediaFromShared()).not.toThrow();
+  });
+
+  it('copies fresh rows on first run and is a no-op on the second', () => {
+    openSharedWithRows([
+      { shelfId: 'trending', shownAt: '2026-06-09 12:00:00' },
+      { shelfId: 'because-you-watched:42', shownAt: '2026-06-09 12:00:01' },
+    ]);
+    const media = openMediaDb(join(tmpDir, 'media.db'));
+    setMediaDb(media);
+
+    backfillMediaFromShared();
+    const after = media.raw
+      .prepare('SELECT id, shelf_id FROM shelf_impressions ORDER BY id')
+      .all() as { id: number; shelf_id: string }[];
+    expect(after.map((r) => r.shelf_id)).toEqual(['trending', 'because-you-watched:42']);
+
+    backfillMediaFromShared();
+    const second = media.raw.prepare('SELECT count(*) AS n FROM shelf_impressions').get() as {
+      n: number;
+    };
+    expect(second.n).toBe(2);
+  });
+
+  it('only inserts rows missing from the media copy', () => {
+    openSharedWithRows([
+      { shelfId: 'trending', shownAt: '2026-06-09 12:00:00' },
+      { shelfId: 'because-you-watched:42', shownAt: '2026-06-09 12:00:01' },
+    ]);
+    const media = openMediaDb(join(tmpDir, 'media.db'));
+    setMediaDb(media);
+    // Pre-seed id=1 in media so the backfill should skip it and only carry id=2 across.
+    media.raw
+      .prepare('INSERT INTO shelf_impressions (id, shelf_id, shown_at) VALUES (?, ?, ?)')
+      .run(1, 'pre-existing', '2026-06-08 09:00:00');
+
+    backfillMediaFromShared();
+    const rows = media.raw
+      .prepare('SELECT id, shelf_id FROM shelf_impressions ORDER BY id')
+      .all() as { id: number; shelf_id: string }[];
+    expect(rows).toEqual([
+      { id: 1, shelf_id: 'pre-existing' },
+      { id: 2, shelf_id: 'because-you-watched:42' },
+    ]);
+  });
+
+  it('tolerates a shared DB without the shelf_impressions table', () => {
+    const path = join(tmpDir, 'pops.db');
+    const raw = new BetterSqlite3(path);
+    raw.close();
+    process.env['SQLITE_PATH'] = path;
+
+    const media = openMediaDb(join(tmpDir, 'media.db'));
+    setMediaDb(media);
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      expect(() => backfillMediaFromShared()).not.toThrow();
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+    const count = media.raw.prepare('SELECT count(*) AS n FROM shelf_impressions').get() as {
+      n: number;
+    };
+    expect(count.n).toBe(0);
+  });
+});

--- a/apps/pops-api/src/db/backfill-test-fixtures.ts
+++ b/apps/pops-api/src/db/backfill-test-fixtures.ts
@@ -1,12 +1,12 @@
 /**
- * SQL fixture for the `backfill-core-from-shared.test.ts` suite.
+ * SQL fixtures for the per-pillar backfill suites.
  *
  * Inlined here (rather than reading the canonical drizzle-migration
- * `0054_service_accounts.sql`) so the test stays robust against the
- * eventual phase-2-PR4 deletion of that shared-journal copy. The DDL
- * matches the byte-identical migration that lands in both
+ * files) so the tests stay robust against the eventual phase-2-PR4
+ * deletion of those shared-journal copies. Each DDL matches the
+ * byte-identical migration that lands in both
  * `apps/pops-api/src/db/drizzle-migrations/` and
- * `packages/core-db/migrations/`.
+ * `packages/<id>-db/migrations/`.
  */
 export const SERVICE_ACCOUNTS_TABLE_SQL = `
 CREATE TABLE service_accounts (
@@ -24,4 +24,13 @@ CREATE UNIQUE INDEX service_accounts_name_unique ON service_accounts (name);
 CREATE UNIQUE INDEX service_accounts_key_prefix_unique ON service_accounts (key_prefix);
 CREATE INDEX idx_service_accounts_key_prefix ON service_accounts (key_prefix);
 CREATE INDEX idx_service_accounts_revoked_at ON service_accounts (revoked_at);
+`;
+
+export const SHELF_IMPRESSIONS_TABLE_SQL = `
+CREATE TABLE shelf_impressions (
+  id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  shelf_id text NOT NULL,
+  shown_at text DEFAULT (datetime('now')) NOT NULL
+);
+CREATE INDEX idx_shelf_impressions_shelf_id ON shelf_impressions (shelf_id);
 `;

--- a/apps/pops-api/src/db/media-backfill.ts
+++ b/apps/pops-api/src/db/media-backfill.ts
@@ -1,0 +1,56 @@
+import { resolveSqlitePath } from './sqlite-path.js';
+
+/**
+ * One-shot media-pillar backfill — copies shelf-impressions rows from the
+ * shared `pops.db` into `media.db` via ATTACH.
+ *
+ * Boot-time contract: Phase 2 PR 2 opened the media DB but did not yet
+ * consume it. PR 3 (this entry point) flipped shelf-impressions traffic
+ * to the media handle, so the first deploy after PR 3 carries the
+ * existing rows across before any reads come from the new file.
+ * Subsequent boots find the media copy already populated and become a
+ * no-op via the `WHERE id NOT IN (...)` existence filter.
+ *
+ * Non-fatal: ATTACH or INSERT failures are logged and swallowed so a
+ * stale on-disk `pops.db` never bricks the boot path. Failures here leave
+ * the media copy empty for that boot; the next deploy retries.
+ *
+ * Mirrors `./core-backfill.ts`.
+ */
+import type Database from 'better-sqlite3';
+
+/**
+ * Run the idempotent backfill against the open media SQLite handle. The
+ * caller resolves the raw better-sqlite3 handle (typically
+ * `getMediaDrizzle()`'s sibling `OpenedMediaDb.raw`) and passes it in so
+ * this module stays decoupled from the singleton in
+ * `./media-db-handle.ts`.
+ */
+export function backfillMediaFromShared(mediaRaw: Database.Database | null): void {
+  if (!mediaRaw) return;
+  const sharedPath = resolveSqlitePath();
+  try {
+    mediaRaw.prepare('ATTACH DATABASE ? AS pops').run(sharedPath);
+    try {
+      const hasTable = mediaRaw
+        .prepare("SELECT 1 FROM pops.sqlite_master WHERE type='table' AND name='shelf_impressions'")
+        .get();
+      if (hasTable) {
+        // Enumerate columns explicitly so a future migration that widens
+        // the media table won't break the backfill against a stale
+        // on-disk pops.db that still has the older shape. Order matches
+        // the 0021_spooky_lockheed.sql DDL byte-for-byte.
+        mediaRaw.exec(`
+          INSERT INTO shelf_impressions (id, shelf_id, shown_at)
+          SELECT id, shelf_id, shown_at
+          FROM pops.shelf_impressions
+          WHERE id NOT IN (SELECT id FROM shelf_impressions)
+        `);
+      }
+    } finally {
+      mediaRaw.exec('DETACH DATABASE pops');
+    }
+  } catch (err) {
+    console.warn('[db] Media shelf-impressions backfill failed (non-fatal):', err);
+  }
+}

--- a/apps/pops-api/src/db/media-db-handle.ts
+++ b/apps/pops-api/src/db/media-db-handle.ts
@@ -6,25 +6,25 @@
  * mirrors the core counterpart in shape (lazy open, idempotent close,
  * test-only swap).
  *
- * Phase 2 PR 2 of the media pillar migration: `apps/pops-api/src/index.ts`
+ * Phase 2 PR 3 of the media pillar migration: `apps/pops-api/src/index.ts`
  * eagerly calls `getMediaDrizzle` at boot so the per-pillar migrations land
- * before any request hits the API. Production traffic still flows through
- * the shared singleton in `db.ts` — PR 3 of phase 2 flips shelf-impressions
- * traffic over to this handle; PR 4 drops the table from the shared journal
- * + adds the Litestream config.
+ * before any request hits the API, and `backfillMediaFromShared` carries
+ * existing shelf-impressions rows across from the legacy `pops.db` via
+ * ATTACH. PR 4 drops the shelf_impressions table from the shared journal +
+ * adds the Litestream config.
  */
 import { openMediaDb, type MediaDb, type OpenedMediaDb } from '@pops/media-db';
 
+import { backfillMediaFromShared as backfillMediaImpl } from './media-backfill.js';
 import { resolveMediaSqlitePath } from './media-sqlite-path.js';
 
 let mediaDb: OpenedMediaDb | null = null;
 
 /**
  * Lazily open the media pillar's SQLite file and return the drizzle
- * handle. Phase 2 PR 2 wires the connection up at boot but does NOT
- * yet route any production traffic through it — the existing shared
- * singleton continues to serve every read/write. The handle is here so
- * PR 3 can flip shelf-impressions callers over with a one-line edit.
+ * handle. shelf-impressions traffic reads/writes against this handle as
+ * of Phase 2 PR 3. The shared singleton in `db.ts` continues to serve the
+ * rest of the media pillar's tables until subsequent slices migrate.
  */
 export function getMediaDrizzle(): MediaDb {
   if (!mediaDb) {
@@ -55,4 +55,13 @@ export function setMediaDb(next: OpenedMediaDb | null): OpenedMediaDb | null {
   const prev = mediaDb;
   mediaDb = next;
   return prev;
+}
+
+/**
+ * Re-exported convenience wrapper around the standalone backfill in
+ * `./media-backfill.ts`. Resolves the singleton's raw handle and
+ * forwards. See `backfillMediaFromShared` for the documented contract.
+ */
+export function backfillMediaFromShared(): void {
+  backfillMediaImpl(mediaDb?.raw ?? null);
 }

--- a/apps/pops-api/src/index.ts
+++ b/apps/pops-api/src/index.ts
@@ -8,7 +8,7 @@ config({ path: '../../.env', override: false }); // loads root .env without over
 import { createApp } from './app.js';
 import { backfillCoreFromShared, closeDb, getCoreDrizzle } from './db.js';
 import { backfillInventoryFromSharedDb, getInventoryDrizzle } from './db/inventory-handle.js';
-import { getMediaDrizzle } from './db/media-db-handle.js';
+import { backfillMediaFromShared, getMediaDrizzle } from './db/media-db-handle.js';
 import { resolveSqlitePath } from './db/sqlite-path.js';
 import { closeQueues } from './jobs/queues.js';
 import { startThalamus, stopThalamus } from './modules/cerebrum/thalamus/instance.js';
@@ -67,12 +67,14 @@ try {
 }
 
 // Eagerly open the media pillar's SQLite + apply its journal at boot so
-// the per-pillar migrations land before any request hits the API. Phase 2
-// PR 2 only opens the handle — no production traffic routes here yet.
-// PR 3 of phase 2 adds `backfillMediaFromShared()` and flips
-// shelf-impressions traffic over.
+// the per-pillar migrations land before any request hits the API.
+// shelf-impressions traffic now reads/writes against this handle (phase 2
+// PR 3); the one-shot `backfillMediaFromShared` carries any rows that
+// still live in the legacy pops.db across. The backfill is idempotent
+// and non-fatal — partial failure logs and continues.
 try {
   getMediaDrizzle();
+  backfillMediaFromShared();
 } catch (err) {
   console.error('[db] Failed to bootstrap the media pillar SQLite:', err);
   throw err;

--- a/apps/pops-api/src/modules/media/discovery/router-shelf.ts
+++ b/apps/pops-api/src/modules/media/discovery/router-shelf.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 
 import { shelfImpressionsService } from '@pops/media-db';
 
-import { getDrizzle } from '../../../db.js';
+import { getMediaDrizzle } from '../../../db/media-db-handle.js';
 import { protectedProcedure } from '../../../trpc.js';
 import { withTrpcInternalError } from './router-helpers.js';
 import * as service from './service.js';
@@ -62,7 +62,7 @@ export const sessionAndShelfProcedures = {
    */
   assembleSession: protectedProcedure.query(async () => {
     return withTrpcInternalError('Unknown error assembling discover session', async () => {
-      const db = getDrizzle();
+      const db = getMediaDrizzle();
       const profile = service.getPreferenceProfile();
       const impressions = shelfImpressionsService.getRecentImpressions(db, 7);
       const selectedShelves = assembleSession(profile, impressions);


### PR DESCRIPTION
## Summary

Third PR of the media pillar **Phase 2 — extract media's SQLite** sequence (pillar-migration-roadmap.md Track F · Phase 2 PR 3 of 4). Mirrors core's PR 3 (#2756).

Flips the shelf-impressions slice off the shared \`pops.db\` singleton onto the new \`media.db\` handle opened in PR 2, and adds a boot-time backfill that carries existing rows across.

## Cutover

- \`apps/pops-api/src/modules/media/discovery/router-shelf.ts\` \`assembleSession\` query now resolves \`getMediaDrizzle()\` instead of \`getDrizzle()\`. \`session.service.ts\` is unchanged — it only consumes \`getShelfFreshness\` which is pure.

## Boot-time backfill

- New \`apps/pops-api/src/db/media-backfill.ts\`: \`ATTACH pops.db AS pops\` → copy rows whose \`id\` is missing from \`media.shelf_impressions\` → \`DETACH\`. The \`WHERE id NOT IN (...)\` filter makes the call idempotent so a partial failure retries cleanly on the next boot.
- Handles a shared DB with no \`shelf_impressions\` table gracefully (post-phase-2-PR4 drop scenario) via a \`sqlite_master\` existence probe.
- Non-fatal: ATTACH / INSERT errors are logged and swallowed so a stale on-disk \`pops.db\` never bricks startup.
- Wrapped in \`media-db-handle.ts\`'s \`backfillMediaFromShared()\` which resolves the singleton's raw handle and forwards. Wired into \`apps/pops-api/src/index.ts\` immediately after the eager \`getMediaDrizzle()\` call so migrations + backfill complete before the HTTP server starts listening.

## Test coverage

- \`apps/pops-api/src/db/backfill-media-from-shared.test.ts\` — 4 cases: fresh copy, idempotent re-run, mixed state (only missing rows inserted), missing source table tolerated.
- \`apps/pops-api/src/db/backfill-test-fixtures.ts\` — inlined \`shelf_impressions\` DDL so the test stays valid after phase 2 PR 4 deletes the shared-journal copy.
- \`setupTestContext\` (already wired in phase 2 PR 2) routes both core + media handles at the same in-memory fixture, so the existing discovery integration tests continue to exercise the new code path.

## Phase 2 status

- ✅ PR 1 — \`openMediaDb\` helper (#2785)
- ✅ PR 2 — boot-time open + env resolver (#2791)
- 🔄 PR 3 — cutover + backfill (this)
- ⏳ PR 4 — drop shared journal entry + \`infra/litestream/media.yml\`

## Verification

- \`pnpm typecheck\` — 39/39 packages green
- \`pnpm --filter @pops/api test\` on the relevant suites — 34/34 cases pass
- \`pnpm format:check\` — clean

## Test plan

- [ ] CI green on \`api-quality\` + \`api-test\` (workspace tests + backfill suite)
- [ ] CI green on \`media-db-quality\` (drift guard still active)
- [ ] Copilot review pass