### PR TITLE
feat(infra): inventory Litestream config + AGENTS.md note (pillar inventory phase 2 PR 4)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -266,7 +266,7 @@ When a movie is added to the POPS library, automatically checks Plex Discover cl
 - **Chat:** Moltbot (Telegram)
 - **Backup:** Backblaze B2 via rclone (encrypted)
 - **Litestream exclusions:** `MEDIA_IMAGES_DIR` and `FOOD_INGEST_DIR` are regeneratable media trees and must be excluded from Litestream replication in the homelab-infra repo's Litestream config. The SQLite rows that reference these paths stay backed up; only the bytes are skipped.
-- **Per-pillar SQLite (ADR-026):** each pillar's database streams independently. The core pillar's reference config lives at `infra/litestream/core.yml`; the deployer mirrors it into the homelab-infra Litestream config alongside the existing `pops.db` stream. As subsequent pillars (finance, media, …) extract their own SQLite files, each adds a sibling YAML next to `core.yml`.
+- **Per-pillar SQLite (ADR-026):** each pillar's database streams independently. The core pillar's reference config lives at `infra/litestream/core.yml` and the inventory pillar's at `infra/litestream/inventory.yml`; the deployer mirrors them into the homelab-infra Litestream config alongside the existing `pops.db` stream. As subsequent pillars (finance, media, …) extract their own SQLite files, each adds a sibling YAML next to `core.yml`.
 
 ## Import Pipeline
 

--- a/infra/litestream/inventory.yml
+++ b/infra/litestream/inventory.yml
@@ -1,0 +1,30 @@
+## Litestream replication config — inventory pillar SQLite.
+##
+## Phase 2 PR 4 of the inventory pillar migration (ADR-026). Mirrors
+## the per-pillar pattern so each pillar's database streams
+## independently of the shared pops.db.
+##
+## Production deployment lives in the homelab-infra repo (see AGENTS.md
+## for the deployment model); this file is the canonical reference the
+## deployer copies into its own Litestream config. The replica target
+## (S3 bucket name, region, credentials) is provided by the deployer's
+## environment — leave it as a `${INVENTORY_LITESTREAM_REPLICA_URL}`
+## style placeholder here.
+##
+## Restore drill (single line — safe to copy/paste during an incident):
+##   litestream restore -o /data/sqlite/inventory.db "${INVENTORY_LITESTREAM_REPLICA_URL}"
+## Stop the inventory-api container first so it isn't writing
+## concurrently; the drill is exercised in Phase 4 verification.
+
+dbs:
+  - path: /data/sqlite/inventory.db
+    replicas:
+      - url: ${INVENTORY_LITESTREAM_REPLICA_URL}
+        # Per-pillar config so a single-pillar restore doesn't pull in
+        # the whole pops.db blob. Sync interval matches the shared
+        # singleton's existing replica config (1s by default — see
+        # homelab-infra).
+        sync-interval: 1s
+        retention: 24h
+        snapshot-interval: 1h
+        validation-interval: 12h


### PR DESCRIPTION
## Summary

Final PR of inventory pillar Phase 2. Wraps up the per-pillar SQLite extraction by giving the `inventory.db` file its own Litestream stream so the deployer can mirror it into the homelab-infra Litestream config alongside the existing `pops.db` + `core.db` streams.

Mirrors core Phase 2 PR 4 ([#2758](https://github.com/knoxio/pops/pull/2758)) line-for-line:
- **`infra/litestream/inventory.yml`** — replica URL placeholder (`${INVENTORY_LITESTREAM_REPLICA_URL}`), sync / retention / snapshot / validation intervals match the core config byte-for-byte; restore drill inlined on a single line for incident copy-paste safety.
- **`AGENTS.md`** — updates the per-pillar SQLite note to list both `infra/litestream/core.yml` and `infra/litestream/inventory.yml` as canonical references the deployer mirrors.

`.github/workflows/infra-lint.yml` already globs `infra/litestream/**` so the new file is yaml-lint-validated on every PR without workflow changes.

Phase 3 (pops-inventory-api container) follows. Phase 4 (verification runbook + Track G row flip) closes the inventory pillar.

## Test plan
- [x] `yamllint infra/litestream/inventory.yml` — valid (matches core.yml structure)
- [x] No code changes — production runtime is unchanged; this is canonical-reference YAML for the deployer to mirror into homelab-infra