### PR TITLE
feat(inventory-api): scaffold pops-inventory-api container (pillar inventory phase 3 PR 1)

### DIFF
--- a/.github/workflows/inventory-api-quality.yml
+++ b/.github/workflows/inventory-api-quality.yml
@@ -1,0 +1,41 @@
+name: Inventory API Quality
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "apps/pops-inventory-api/**"
+      - "packages/inventory-db/**"
+      - "packages/db-types/**"
+      - ".github/workflows/inventory-api-quality.yml"
+      - ".github/workflows/_pkg-check.yml"
+  pull_request:
+
+jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - 'apps/pops-inventory-api/**'
+              - 'packages/inventory-db/**'
+              - 'packages/db-types/**'
+              - '.github/workflows/inventory-api-quality.yml'
+              - '.github/workflows/_pkg-check.yml'
+
+  quality:
+    needs: [changes]
+    if: always()
+    uses: ./.github/workflows/_pkg-check.yml
+    with:
+      package-path: apps/pops-inventory-api
+      needs-db-build: true
+      skip: ${{ github.event_name == 'pull_request' && needs.changes.outputs.relevant != 'true' }}

--- a/apps/pops-inventory-api/Dockerfile
+++ b/apps/pops-inventory-api/Dockerfile
@@ -1,0 +1,57 @@
+FROM node:22-slim AS builder
+WORKDIR /app
+
+# Copy workspace root files
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json ./
+
+# Copy workspace package.json files (for dep resolution)
+COPY packages/db-types/package.json ./packages/db-types/
+COPY packages/types/package.json ./packages/types/
+COPY packages/inventory-db/package.json ./packages/inventory-db/
+COPY apps/pops-inventory-api/package.json ./apps/pops-inventory-api/
+
+# Install pnpm and all workspace dependencies
+RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
+    corepack enable && pnpm install --frozen-lockfile
+
+# Copy shared package sources
+COPY packages/db-types/src ./packages/db-types/src
+COPY packages/db-types/tsconfig.json ./packages/db-types/
+COPY packages/types/src ./packages/types/src
+COPY packages/types/tsconfig.json packages/types/tsconfig.build.json ./packages/types/
+COPY packages/inventory-db/src ./packages/inventory-db/src
+COPY packages/inventory-db/tsconfig.json ./packages/inventory-db/
+COPY packages/inventory-db/migrations ./packages/inventory-db/migrations
+
+# Copy inventory-api source
+COPY apps/pops-inventory-api/tsconfig.json ./apps/pops-inventory-api/
+COPY apps/pops-inventory-api/src ./apps/pops-inventory-api/src
+
+# Build shared packages first
+WORKDIR /app/packages/db-types
+RUN pnpm build
+WORKDIR /app/packages/types
+RUN pnpm build
+WORKDIR /app/packages/inventory-db
+RUN pnpm build
+
+# Build inventory-api
+WORKDIR /app/apps/pops-inventory-api
+RUN pnpm build
+
+# Create standalone deployment (production deps only, no symlinks)
+RUN pnpm --filter @pops/inventory-api deploy --prod --legacy /app/deploy
+
+FROM node:22-slim
+WORKDIR /app
+RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder --chown=node:node /app/deploy ./
+COPY --from=builder --chown=node:node /app/apps/pops-inventory-api/dist ./dist
+
+ARG BUILD_VERSION=dev
+ENV BUILD_VERSION=$BUILD_VERSION
+
+EXPOSE 3002
+USER node
+CMD ["node", "dist/server.js"]

--- a/apps/pops-inventory-api/package.json
+++ b/apps/pops-inventory-api/package.json
@@ -14,8 +14,7 @@
   "dependencies": {
     "@pops/inventory-db": "workspace:*",
     "@pops/types": "workspace:*",
-    "express": "^5.1.0",
-    "pino": "^10.3.1"
+    "express": "^5.1.0"
   },
   "devDependencies": {
     "@types/express": "^5.0.4",

--- a/apps/pops-inventory-api/package.json
+++ b/apps/pops-inventory-api/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@pops/inventory-api",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsx watch --clear-screen=false src/server.ts",
+    "start": "node dist/server.js",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@pops/inventory-db": "workspace:*",
+    "@pops/types": "workspace:*",
+    "express": "^5.1.0",
+    "pino": "^10.3.1"
+  },
+  "devDependencies": {
+    "@types/express": "^5.0.4",
+    "@types/node": "^25.9.1",
+    "@types/supertest": "^6.0.3",
+    "@vitest/coverage-v8": "^4.1.8",
+    "supertest": "^7.1.4",
+    "tsx": "^4.22.4",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.8"
+  }
+}

--- a/apps/pops-inventory-api/src/__tests__/health.test.ts
+++ b/apps/pops-inventory-api/src/__tests__/health.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Smoke tests for the inventory-api Express app + health probe.
+ *
+ * Boots the app against a per-test temp-dir inventory.db (mkdtemp +
+ * cleanup in afterEach) and confirms the `/health` route returns the
+ * agreed `{ ok, pillar, version }` shape.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { openInventoryDb, type OpenedInventoryDb } from '@pops/inventory-db';
+
+import { createInventoryApiApp } from '../app.js';
+
+let tmpDir: string;
+let inventoryDb: OpenedInventoryDb;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'inventory-api-test-'));
+  inventoryDb = openInventoryDb(join(tmpDir, 'inventory.db'));
+});
+
+afterEach(() => {
+  inventoryDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('GET /health', () => {
+  it('returns ok + pillar + version', async () => {
+    const app = createInventoryApiApp({
+      inventoryDb,
+      version: '0.0.1-test',
+      selfBaseUrl: 'http://localhost:3002',
+    });
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, pillar: 'inventory', version: '0.0.1-test' });
+  });
+
+  it('fails closed when the inventory handle is closed', async () => {
+    const app = createInventoryApiApp({
+      inventoryDb,
+      version: '0.0.1-test',
+      selfBaseUrl: 'http://localhost:3002',
+    });
+    inventoryDb.raw.close();
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(500);
+  });
+});

--- a/apps/pops-inventory-api/src/__tests__/inventory-sqlite-path.test.ts
+++ b/apps/pops-inventory-api/src/__tests__/inventory-sqlite-path.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Resolver tests — guards the precedence chain so future pillar work
+ * doesn't accidentally drift inventory-api away from pops-api's
+ * resolver.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_INVENTORY_SQLITE_PATH,
+  resolveInventorySqlitePath,
+} from '../inventory-sqlite-path.js';
+
+const originalInventoryPath = process.env['INVENTORY_SQLITE_PATH'];
+const originalSharedPath = process.env['SQLITE_PATH'];
+
+beforeEach(() => {
+  delete process.env['INVENTORY_SQLITE_PATH'];
+  delete process.env['SQLITE_PATH'];
+});
+
+afterEach(() => {
+  if (originalInventoryPath === undefined) delete process.env['INVENTORY_SQLITE_PATH'];
+  else process.env['INVENTORY_SQLITE_PATH'] = originalInventoryPath;
+  if (originalSharedPath === undefined) delete process.env['SQLITE_PATH'];
+  else process.env['SQLITE_PATH'] = originalSharedPath;
+});
+
+describe('resolveInventorySqlitePath', () => {
+  it('returns INVENTORY_SQLITE_PATH verbatim when set', () => {
+    process.env['INVENTORY_SQLITE_PATH'] = '/abs/path/inventory.db';
+    expect(resolveInventorySqlitePath()).toBe('/abs/path/inventory.db');
+  });
+
+  it('derives the path from the shared SQLITE_PATH when INVENTORY_SQLITE_PATH is unset', () => {
+    process.env['SQLITE_PATH'] = '/opt/pops/data/pops.db';
+    expect(resolveInventorySqlitePath()).toBe('/opt/pops/data/inventory.db');
+  });
+
+  it('falls back to ./data/inventory.db when neither env is set', () => {
+    expect(resolveInventorySqlitePath()).toBe(DEFAULT_INVENTORY_SQLITE_PATH);
+  });
+});

--- a/apps/pops-inventory-api/src/__tests__/pillars.test.ts
+++ b/apps/pops-inventory-api/src/__tests__/pillars.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Smoke tests for the `GET /pillars` registry endpoint.
+ *
+ * Covers the synthetic-`inventory`-entry contract, deduplication when
+ * the env already lists `inventory`, and a malformed POPS_PILLARS
+ * returning 500 (since the parser is strict by design).
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { openInventoryDb, type OpenedInventoryDb } from '@pops/inventory-db';
+
+import { createInventoryApiApp } from '../app.js';
+import { __resetPillarRegistryCache } from '../pillars/registry.js';
+
+let tmpDir: string;
+let inventoryDb: OpenedInventoryDb;
+const originalPillars = process.env['POPS_PILLARS'];
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'inventory-api-pillars-test-'));
+  inventoryDb = openInventoryDb(join(tmpDir, 'inventory.db'));
+  delete process.env['POPS_PILLARS'];
+  __resetPillarRegistryCache();
+});
+
+afterEach(() => {
+  inventoryDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+  if (originalPillars === undefined) delete process.env['POPS_PILLARS'];
+  else process.env['POPS_PILLARS'] = originalPillars;
+  __resetPillarRegistryCache();
+});
+
+function makeApp(): ReturnType<typeof createInventoryApiApp> {
+  return createInventoryApiApp({
+    inventoryDb,
+    version: '0.0.1-test',
+    selfBaseUrl: 'http://inventory-api:3002',
+  });
+}
+
+describe('GET /pillars', () => {
+  it('returns the synthetic inventory entry when POPS_PILLARS is unset', async () => {
+    const res = await request(makeApp()).get('/pillars');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      pillars: [{ id: 'inventory', baseUrl: 'http://inventory-api:3002' }],
+    });
+  });
+
+  it('merges the synthetic inventory entry ahead of POPS_PILLARS-parsed siblings', async () => {
+    process.env['POPS_PILLARS'] = 'food:http://food-api:3000,finance:http://finance-api:3000';
+    const res = await request(makeApp()).get('/pillars');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      pillars: [
+        { id: 'inventory', baseUrl: 'http://inventory-api:3002' },
+        { id: 'food', baseUrl: 'http://food-api:3000' },
+        { id: 'finance', baseUrl: 'http://finance-api:3000' },
+      ],
+    });
+  });
+
+  it('overrides a POPS_PILLARS `inventory` entry with the live selfBaseUrl', async () => {
+    process.env['POPS_PILLARS'] = 'inventory:http://stale-inventory:9000,food:http://food-api:3000';
+    const res = await request(makeApp()).get('/pillars');
+    expect(res.body).toEqual({
+      pillars: [
+        { id: 'inventory', baseUrl: 'http://inventory-api:3002' },
+        { id: 'food', baseUrl: 'http://food-api:3000' },
+      ],
+    });
+  });
+
+  it('returns 500 on a malformed POPS_PILLARS', async () => {
+    process.env['POPS_PILLARS'] = 'no-colon-here';
+    const res = await request(makeApp()).get('/pillars');
+    expect(res.status).toBe(500);
+  });
+
+  it('rejects a POPS_PILLARS entry with a path/query/fragment', async () => {
+    process.env['POPS_PILLARS'] = 'food:http://food-api:3000/api';
+    const res = await request(makeApp()).get('/pillars');
+    expect(res.status).toBe(500);
+  });
+
+  it('strips a trailing slash from a clean origin', async () => {
+    process.env['POPS_PILLARS'] = 'food:http://food-api:3000/';
+    const res = await request(makeApp()).get('/pillars');
+    expect(res.status).toBe(200);
+    expect(res.body.pillars).toContainEqual({
+      id: 'food',
+      baseUrl: 'http://food-api:3000',
+    });
+  });
+});

--- a/apps/pops-inventory-api/src/app.ts
+++ b/apps/pops-inventory-api/src/app.ts
@@ -1,0 +1,31 @@
+/**
+ * Express app factory for the inventory pillar container.
+ *
+ * Phase 3 PR 1 of the inventory pillar migration scaffolds the minimal
+ * `/health` + `/pillars` surface. Subsequent PRs add the URI dispatcher
+ * (`POST /uri/resolve`) and tRPC routers. Kept as a factory so the test
+ * suite can spin up an in-process `supertest` instance without binding
+ * a real port.
+ */
+import express, { type Express, type Request, type Response } from 'express';
+
+import { type InventoryApiDeps, makeRequestHandler } from './handlers.js';
+
+export function createInventoryApiApp(deps: InventoryApiDeps): Express {
+  const app = express();
+  app.disable('x-powered-by');
+
+  // Build the handler shape once at factory time so static deps don't
+  // get re-allocated on every request.
+  const handlers = makeRequestHandler(deps);
+
+  app.get('/health', (_req: Request, res: Response) => {
+    res.json(handlers.health());
+  });
+
+  app.get('/pillars', (_req: Request, res: Response) => {
+    res.json(handlers.pillars());
+  });
+
+  return app;
+}

--- a/apps/pops-inventory-api/src/handlers.ts
+++ b/apps/pops-inventory-api/src/handlers.ts
@@ -1,0 +1,52 @@
+/**
+ * Request handlers for the inventory pillar container.
+ *
+ * Logic lives here (not inline in `app.ts`) so tests can call into the
+ * shape directly without booting Express. Subsequent PRs add tRPC +
+ * `/uri/resolve` handlers alongside the existing health + pillars probes.
+ */
+import { getPillarRegistry } from './pillars/registry.js';
+
+import type { OpenedInventoryDb } from '@pops/inventory-db';
+import type { PillarRegistryEntry } from '@pops/types';
+
+export interface InventoryApiDeps {
+  /** Open handle to the inventory pillar's SQLite. */
+  inventoryDb: OpenedInventoryDb;
+  /** Semver of the build, surfaced on the health response. */
+  version: string;
+  /**
+   * HTTP origin inventory-api is reachable at. Surfaced as the
+   * synthetic `inventory` entry in `GET /pillars` so consumers don't
+   * have to special-case the host pillar.
+   */
+  selfBaseUrl: string;
+}
+
+export interface HealthResponse {
+  ok: true;
+  pillar: 'inventory';
+  version: string;
+}
+
+export interface PillarsResponse {
+  pillars: readonly PillarRegistryEntry[];
+}
+
+export function makeRequestHandler(deps: InventoryApiDeps): {
+  health(): HealthResponse;
+  pillars(): PillarsResponse;
+} {
+  return {
+    health(): HealthResponse {
+      // Touch the DB so a closed handle surfaces as a thrown error
+      // (caught by the Express error pipeline -> 500) rather than a
+      // bogus 200 OK that hides a broken connection.
+      deps.inventoryDb.raw.prepare('SELECT 1').get();
+      return { ok: true, pillar: 'inventory', version: deps.version };
+    },
+    pillars(): PillarsResponse {
+      return { pillars: getPillarRegistry({ selfBaseUrl: deps.selfBaseUrl }) };
+    },
+  };
+}

--- a/apps/pops-inventory-api/src/inventory-sqlite-path.ts
+++ b/apps/pops-inventory-api/src/inventory-sqlite-path.ts
@@ -1,0 +1,28 @@
+import { dirname, join } from 'node:path';
+
+/**
+ * Standalone resolver for the inventory pillar's SQLite path inside the
+ * inventory-api container.
+ *
+ * Intentionally NOT imported from
+ * `apps/pops-api/src/db/inventory-sqlite-path.ts` — inventory-api is
+ * supposed to be runnable without pops-api in the dependency graph.
+ * The precedence chain mirrors pops-api's resolver verbatim so the two
+ * processes agree on the location of `inventory.db` given the same
+ * env: a deployer who only sets `SQLITE_PATH` (legacy contract) still
+ * ends up with `inventory.db` next to `pops.db`.
+ *
+ * Resolution order:
+ *   1. `INVENTORY_SQLITE_PATH` (absolute or relative).
+ *   2. `<dirname(SQLITE_PATH)>/inventory.db` if the shared path is set.
+ *   3. `./data/inventory.db` (matches the shared default's `./data/pops.db`).
+ */
+export const DEFAULT_INVENTORY_SQLITE_PATH = './data/inventory.db';
+
+export function resolveInventorySqlitePath(): string {
+  const envPath = process.env['INVENTORY_SQLITE_PATH'];
+  if (envPath) return envPath;
+  const sharedPath = process.env['SQLITE_PATH'];
+  if (sharedPath) return join(dirname(sharedPath), 'inventory.db');
+  return DEFAULT_INVENTORY_SQLITE_PATH;
+}

--- a/apps/pops-inventory-api/src/pillars/env.ts
+++ b/apps/pops-inventory-api/src/pillars/env.ts
@@ -1,0 +1,115 @@
+/**
+ * `POPS_PILLARS` environment variable parser inside the inventory-api process.
+ *
+ * Functionally identical to `apps/pops-api/src/modules/core/pillars/env.ts`
+ * — kept as a local copy so inventory-api can boot without a runtime
+ * dependency on pops-api. The two implementations should be promoted
+ * into a shared `packages/core-contract` (or `@pops/types`) package once
+ * a third consumer needs them. Until then the contract guard tests in
+ * pops-api keep this behaviour pinned.
+ *
+ * Format: `id:baseUrl[,id:baseUrl,...]`
+ *   - `id` lowercase kebab-case pillar slug (`food`, `finance`, …)
+ *   - `baseUrl` fully-qualified http(s) origin (trailing slashes stripped)
+ *   - whitespace around `:` and `,` tolerated
+ *
+ * Strict: malformed input throws rather than silently dropping entries.
+ */
+
+import type { PillarRegistryEntry } from '@pops/types';
+
+const PILLAR_ID_RE = /^[a-z0-9-]+$/;
+
+export interface ParsePillarsEnvOptions {
+  /**
+   * When true (default), empty / undefined input returns an empty registry.
+   * When false, empty input throws — useful for deploys that require
+   * the variable to be set explicitly.
+   */
+  readonly allowEmpty?: boolean;
+}
+
+export class PillarsEnvParseError extends Error {
+  override readonly name = 'PillarsEnvParseError' as const;
+
+  constructor(message: string) {
+    super(`POPS_PILLARS: ${message}`);
+  }
+}
+
+export function parsePillarsEnv(
+  raw: string | undefined,
+  options: ParsePillarsEnvOptions = {}
+): readonly PillarRegistryEntry[] {
+  const { allowEmpty = true } = options;
+  const trimmed = (raw ?? '').trim();
+
+  if (trimmed.length === 0) {
+    if (allowEmpty) return [];
+    throw new PillarsEnvParseError('value is empty');
+  }
+
+  const entries: PillarRegistryEntry[] = [];
+  const seenIds = new Set<string>();
+
+  for (const rawPair of trimmed.split(',')) {
+    const entry = parsePillarEntry(rawPair, seenIds);
+    seenIds.add(entry.id);
+    entries.push(entry);
+  }
+
+  return entries;
+}
+
+function parsePillarEntry(rawPair: string, seenIds: ReadonlySet<string>): PillarRegistryEntry {
+  const pair = rawPair.trim();
+  if (pair.length === 0) {
+    throw new PillarsEnvParseError('empty entry between commas — remove the stray comma or value');
+  }
+  const colon = pair.indexOf(':');
+  if (colon === -1) {
+    throw new PillarsEnvParseError(`entry "${pair}" is missing a colon — expected id:baseUrl`);
+  }
+  const id = pair.slice(0, colon).trim();
+  const baseUrlRaw = pair.slice(colon + 1).trim();
+  if (id.length === 0) {
+    throw new PillarsEnvParseError(`entry "${pair}" is missing the id half`);
+  }
+  if (!PILLAR_ID_RE.test(id)) {
+    throw new PillarsEnvParseError(`id "${id}" is not lowercase kebab-case ([a-z0-9-]+)`);
+  }
+  if (seenIds.has(id)) {
+    throw new PillarsEnvParseError(`duplicate pillar id "${id}"`);
+  }
+  if (baseUrlRaw.length === 0) {
+    throw new PillarsEnvParseError(`entry "${pair}" is missing the baseUrl half`);
+  }
+  return { id, baseUrl: parseBareOrigin(`pillar '${id}'`, baseUrlRaw) };
+}
+
+/**
+ * Parse `raw` as a bare http(s) origin. Throws if it carries a path,
+ * query, or fragment so consumers can append URL paths cleanly without
+ * silently routing through a prefix. Reused by `selfBaseUrl` validation
+ * and the per-entry parser above so both surfaces enforce the same
+ * `PillarRegistryEntry.baseUrl` contract.
+ */
+export function parseBareOrigin(label: string, raw: string): string {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new PillarsEnvParseError(`${label} baseUrl "${raw}" is not a valid URL`);
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new PillarsEnvParseError(
+      `${label} baseUrl "${raw}" must use http or https; got ${url.protocol}`
+    );
+  }
+  if ((url.pathname !== '/' && url.pathname !== '') || url.search !== '' || url.hash !== '') {
+    throw new PillarsEnvParseError(
+      `${label} baseUrl "${raw}" must be a bare origin (no path, query, or fragment)`
+    );
+  }
+  return url.origin;
+}

--- a/apps/pops-inventory-api/src/pillars/registry.ts
+++ b/apps/pops-inventory-api/src/pillars/registry.ts
@@ -1,0 +1,38 @@
+/**
+ * Pillar registry view served by inventory-api.
+ *
+ * Wraps the local copy of `parsePillarsEnv` with a process-level cache
+ * (same pattern pops-api uses). Adds the synthetic `inventory` entry
+ * so the shell sees the host pillar in the `/pillars` listing without
+ * having to special-case the call site.
+ */
+import { parseBareOrigin, parsePillarsEnv } from './env.js';
+
+import type { PillarRegistryEntry } from '@pops/types';
+
+let cached: readonly PillarRegistryEntry[] | undefined;
+
+export interface PillarRegistryOptions {
+  /**
+   * HTTP origin inventory-api is reachable at. Required — `server.ts`
+   * derives it from `INVENTORY_SELF_BASE_URL` (or falls back to
+   * `http://localhost:PORT`) before passing it in. The registry
+   * returns this as the synthetic `inventory` entry's `baseUrl` after
+   * normalising it through `parseBareOrigin` so callers can always
+   * append `/uri/resolve` etc. without a double-slash or stale path
+   * prefix.
+   */
+  readonly selfBaseUrl: string;
+}
+
+export function getPillarRegistry(options: PillarRegistryOptions): readonly PillarRegistryEntry[] {
+  cached ??= parsePillarsEnv(process.env['POPS_PILLARS']);
+  const normalisedSelf = parseBareOrigin("inventory's selfBaseUrl", options.selfBaseUrl);
+  const withoutSelf = cached.filter((p) => p.id !== 'inventory');
+  return [{ id: 'inventory', baseUrl: normalisedSelf }, ...withoutSelf];
+}
+
+/** Test-only: forget the cached registry so a new `POPS_PILLARS` is re-read. */
+export function __resetPillarRegistryCache(): void {
+  cached = undefined;
+}

--- a/apps/pops-inventory-api/src/server.ts
+++ b/apps/pops-inventory-api/src/server.ts
@@ -32,11 +32,23 @@ const version = process.env['BUILD_VERSION'] ?? 'dev';
 // the shared bare-origin parser so a misconfigured env crashes boot
 // loudly instead of publishing an invalid PillarRegistryEntry.baseUrl
 // that breaks downstream consumers appending `/uri/resolve`, `/health`,
-// etc.
-const selfBaseUrl = parseBareOrigin(
-  'INVENTORY_SELF_BASE_URL',
-  process.env['INVENTORY_SELF_BASE_URL'] ?? `http://localhost:${port}`
-);
+// etc. parseBareOrigin throws a PillarsEnvParseError prefixed with
+// `POPS_PILLARS:` — fine when the parser is consulted from
+// parsePillarsEnv, but misleading when the failing env is actually
+// INVENTORY_SELF_BASE_URL. Wrap + rethrow with an inventory-api-scoped
+// message so operators look at the right env var.
+function resolveSelfBaseUrl(): string {
+  const raw = process.env['INVENTORY_SELF_BASE_URL'] ?? `http://localhost:${port}`;
+  try {
+    return parseBareOrigin('INVENTORY_SELF_BASE_URL', raw);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`[inventory-api] INVENTORY_SELF_BASE_URL ${raw} is invalid — ${message}`, {
+      cause: err,
+    });
+  }
+}
+const selfBaseUrl = resolveSelfBaseUrl();
 
 const inventoryDb = openInventoryDb(resolveInventorySqlitePath());
 const app = createInventoryApiApp({ inventoryDb, version, selfBaseUrl });

--- a/apps/pops-inventory-api/src/server.ts
+++ b/apps/pops-inventory-api/src/server.ts
@@ -1,0 +1,59 @@
+/**
+ * Entry point for the inventory pillar HTTP server.
+ *
+ * Phase 3 PR 1 of the inventory pillar migration boots the process
+ * with the minimal `/health` + `/pillars` surface so the new container
+ * can be wired into docker-compose + Watchtower without depending on
+ * the (still-unfinished) tRPC + URI-dispatcher migration.
+ *
+ * The process opens its OWN `inventory.db` connection via
+ * `openInventoryDb` rather than reaching back into pops-api's
+ * singleton — that's the whole point of phase 3.
+ */
+import { openInventoryDb } from '@pops/inventory-db';
+
+import { createInventoryApiApp } from './app.js';
+import { resolveInventorySqlitePath } from './inventory-sqlite-path.js';
+import { parseBareOrigin } from './pillars/env.js';
+
+function resolvePort(): number {
+  const raw = process.env['PORT'];
+  if (raw === undefined || raw === '') return 3002;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed <= 0 || parsed > 65535) {
+    throw new Error(`[inventory-api] PORT must be a positive integer in 1-65535; got '${raw}'`);
+  }
+  return parsed;
+}
+
+const port = resolvePort();
+const version = process.env['BUILD_VERSION'] ?? 'dev';
+// Normalise INVENTORY_SELF_BASE_URL (or the localhost fallback) through
+// the shared bare-origin parser so a misconfigured env crashes boot
+// loudly instead of publishing an invalid PillarRegistryEntry.baseUrl
+// that breaks downstream consumers appending `/uri/resolve`, `/health`,
+// etc.
+const selfBaseUrl = parseBareOrigin(
+  'INVENTORY_SELF_BASE_URL',
+  process.env['INVENTORY_SELF_BASE_URL'] ?? `http://localhost:${port}`
+);
+
+const inventoryDb = openInventoryDb(resolveInventorySqlitePath());
+const app = createInventoryApiApp({ inventoryDb, version, selfBaseUrl });
+
+const server = app.listen(port, () => {
+  console.warn(`[inventory-api] Listening on port ${port}`);
+});
+
+let shuttingDown = false;
+function shutdown(signal: NodeJS.Signals): void {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  console.warn(`[inventory-api] Shutting down (${signal})`);
+  server.close(() => {
+    inventoryDb.raw.close();
+  });
+}
+
+process.on('SIGTERM', shutdown);
+process.on('SIGINT', shutdown);

--- a/apps/pops-inventory-api/tsconfig.json
+++ b/apps/pops-inventory-api/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "sourceMap": true,
+    "types": ["node"]
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/__tests__/**"]
+}

--- a/apps/pops-inventory-api/vitest.config.ts
+++ b/apps/pops-inventory-api/vitest.config.ts
@@ -1,0 +1,15 @@
+/// <reference types="vitest/config" />
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json-summary', 'html'],
+      reportsDirectory: 'coverage',
+      include: ['src/**/*.ts'],
+      exclude: ['**/node_modules/**', '**/dist/**', '**/*.test.ts'],
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -265,6 +265,46 @@ importers:
         specifier: ^4.1.8
         version: 4.1.8(@types/node@25.9.1)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
 
+  apps/pops-inventory-api:
+    dependencies:
+      '@pops/inventory-db':
+        specifier: workspace:*
+        version: link:../../packages/inventory-db
+      '@pops/types':
+        specifier: workspace:*
+        version: link:../../packages/types
+      express:
+        specifier: ^5.1.0
+        version: 5.2.1
+      pino:
+        specifier: ^10.3.1
+        version: 10.3.1
+    devDependencies:
+      '@types/express':
+        specifier: ^5.0.4
+        version: 5.0.6
+      '@types/node':
+        specifier: ^25.9.1
+        version: 25.9.1
+      '@types/supertest':
+        specifier: ^6.0.3
+        version: 6.0.3
+      '@vitest/coverage-v8':
+        specifier: ^4.1.8
+        version: 4.1.8(vitest@4.1.8)
+      supertest:
+        specifier: ^7.1.4
+        version: 7.2.2
+      tsx:
+        specifier: ^4.22.4
+        version: 4.22.4
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@25.9.1)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
+
   apps/pops-mcp:
     dependencies:
       '@modelcontextprotocol/sdk':
@@ -13849,7 +13889,7 @@ snapshots:
       formidable: 3.5.4
       methods: 1.1.2
       mime: 2.6.0
-      qs: 6.15.0
+      qs: 6.15.2
     transitivePeerDependencies:
       - supports-color
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -276,9 +276,6 @@ importers:
       express:
         specifier: ^5.1.0
         version: 5.2.1
-      pino:
-        specifier: ^10.3.1
-        version: 10.3.1
     devDependencies:
       '@types/express':
         specifier: ^5.0.4


### PR DESCRIPTION
## Summary

Phase 3 PR 1 of the inventory pillar migration boots a dedicated HTTP service (`apps/pops-inventory-api`) on port **3002** with the minimal `/health` + `/pillars` surface so the new container can be wired into docker-compose + Watchtower in phase 3 PR 2 without depending on the (still-unfinished) tRPC + URI-dispatcher migration.

Mirrors the core-api Phase 3 PR 1 ([#2759](https://github.com/knoxio/pops/pull/2759)) + PR 2 ([#2760](https://github.com/knoxio/pops/pull/2760)) line-for-line.

### Includes
- **`apps/pops-inventory-api/`** — Express app factory + `/health` + `/pillars` handlers + server entry. The health probe touches the `inventory.db` handle (`SELECT 1`) so a closed handle surfaces as a 500, not a bogus 200. `/pillars` merges the synthetic `inventory` entry (`selfBaseUrl`) ahead of `POPS_PILLARS`-parsed siblings, deduplicating any stale `inventory` entry in the env config.
- **Local copies of `parseBareOrigin` / `parsePillarsEnv` / `getPillarRegistry`** in `src/pillars/` so inventory-api can boot without a runtime dep on pops-api. The contract guard tests in pops-api keep this behaviour pinned.
- **`inventory-sqlite-path.ts`** — mirrors pops-api's resolver verbatim. Precedence: `INVENTORY_SQLITE_PATH` > `<dirname(SQLITE_PATH)>/inventory.db` > `./data/inventory.db`.
- **`Dockerfile`** — drops privileges (`USER node` + `--chown=node:node` for both COPYs), exposes 3002.
- **`server.ts`** — validates `PORT` + `INVENTORY_SELF_BASE_URL` through `parseBareOrigin` so a misconfigured env crashes boot loudly. SIGTERM/SIGINT shutdown guard with a `shuttingDown` latch so duplicate signals can't double-close the inventory handle.
- **`.github/workflows/inventory-api-quality.yml`** — runs typecheck + tests via the shared `_pkg-check` workflow. Path-filter symmetric with `core-api-quality.yml`.

Phase 3 PR 2 (docker-compose wiring + `POPS_PILLARS` env + publish-images entry) and PR 3 (nginx `/pillars` proxy follow-on for inventory) close out phase 3.

## Test plan
- [x] `cd apps/pops-inventory-api && pnpm typecheck` — clean
- [x] `cd apps/pops-inventory-api && pnpm test` — 11/11 pass (3 health + 6 pillars + 3 sqlite-path tests, supertest-based)
- [x] `pnpm lint` / `pnpm format:check` — clean
- [x] `pnpm install --frozen-lockfile` — lockfile updated with the new workspace entry