### PR TITLE
feat(api): open the finance pillar SQLite at boot (pillar finance phase 2 PR 2)

### DIFF
--- a/apps/pops-api/.env.example
+++ b/apps/pops-api/.env.example
@@ -26,6 +26,11 @@ SQLITE_PATH=./data/pops.db
 # core needs its own mount point / Litestream stream in production.
 CORE_SQLITE_PATH=./data/core.db
 
+# Finance pillar database (ADR-026). Defaults to <dirname(SQLITE_PATH)>/finance.db,
+# falling back to ./data/finance.db if SQLITE_PATH is unset. Set explicitly when
+# finance needs its own mount point / Litestream stream in production.
+FINANCE_SQLITE_PATH=./data/finance.db
+
 # Inventory pillar database (ADR-026). Defaults to <dirname(SQLITE_PATH)>/inventory.db,
 # falling back to ./data/inventory.db if SQLITE_PATH is unset. Set explicitly when
 # inventory needs its own mount point / Litestream stream in production.

--- a/apps/pops-api/src/db.ts
+++ b/apps/pops-api/src/db.ts
@@ -9,6 +9,7 @@ import { openCoreDb, type CoreDb, type OpenedCoreDb } from '@pops/core-db';
 import { createPreMigrationBackup, isFreshDatabase } from './db/backup.js';
 import { backfillCoreFromShared as backfillCoreImpl } from './db/core-backfill.js';
 import { resolveCoreSqlitePath } from './db/core-sqlite-path.js';
+import { closeFinanceDb } from './db/finance-handle.js';
 import { closeInventoryDb } from './db/inventory-handle.js';
 import { KNOWN_PILLARS } from './db/known-pillars.js';
 import { closeMediaDb } from './db/media-db-handle.js';
@@ -235,6 +236,7 @@ export function closeDb(): void {
     prodDb = null;
   }
   closeCoreDb();
+  closeFinanceDb();
   closeInventoryDb();
   closeMediaDb();
 }

--- a/apps/pops-api/src/db/finance-handle.ts
+++ b/apps/pops-api/src/db/finance-handle.ts
@@ -1,0 +1,60 @@
+/**
+ * Lazily-initialised handle to the finance pillar's SQLite file.
+ *
+ * Phase 2 PR 2 of the finance pillar migration: opens the connection
+ * (and applies the in-package migrations journal, with the new
+ * `0053_finance_pillar_baseline` ahead of 0025/0026/0027/0052) at boot
+ * but does NOT yet route any production traffic through it. PR 3 of
+ * phase 2 flips the wish-list slice over with a single edit to
+ * `getDrizzle()` → `getFinanceDrizzle()` and adds the ATTACH-based
+ * backfill from the legacy shared pops.db.
+ *
+ * Lives in its own module so `db.ts` stays under the lint cap as more
+ * pillars come online. Mirrors `core-handle.ts` and `inventory-handle.ts`.
+ */
+import { openFinanceDb, type FinanceDb, type OpenedFinanceDb } from '@pops/finance-db';
+
+import { resolveFinanceSqlitePath } from './finance-sqlite-path.js';
+
+let financeDb: OpenedFinanceDb | null = null;
+
+/**
+ * Resolve (and lazily open) the finance pillar's drizzle handle.
+ *
+ * The handle is opened here on first call so the per-pillar migrations
+ * apply at boot. Phase 2 PR 2 does NOT yet route any production traffic
+ * through it — the existing shared singleton continues to serve every
+ * read/write. The handle is here so PR 3 can flip the wish-list slice
+ * over with a one-line edit.
+ */
+export function getFinanceDrizzle(): FinanceDb {
+  if (!financeDb) {
+    financeDb = openFinanceDb(resolveFinanceSqlitePath());
+  }
+  return financeDb.db;
+}
+
+/**
+ * Close the finance pillar's connection if it was opened. Idempotent —
+ * safe to call from `closeDb()` on shutdown even when the finance
+ * handle was never resolved.
+ */
+export function closeFinanceDb(): void {
+  if (financeDb) {
+    financeDb.raw.close();
+    financeDb = null;
+  }
+}
+
+/**
+ * Test-only: swap the finance pillar handle. Phase 2 PR 3 of this
+ * pillar wires `setupTestContext` (in `shared/test-utils.ts`) up to
+ * call this hook so test suites can inject an in-memory DB and avoid
+ * writing to the dev `data/finance.db` file. Returns the previous
+ * handle (or null).
+ */
+export function setFinanceDb(next: OpenedFinanceDb | null): OpenedFinanceDb | null {
+  const prev = financeDb;
+  financeDb = next;
+  return prev;
+}

--- a/apps/pops-api/src/db/finance-sqlite-path.test.ts
+++ b/apps/pops-api/src/db/finance-sqlite-path.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Resolver tests for the finance pillar's SQLite path.
+ *
+ * Covers the precedence chain: FINANCE_SQLITE_PATH > <dirname(SQLITE_PATH)>/finance.db > fallback.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DEFAULT_FINANCE_SQLITE_PATH, resolveFinanceSqlitePath } from './finance-sqlite-path.js';
+
+const originalFinancePath = process.env['FINANCE_SQLITE_PATH'];
+const originalSharedPath = process.env['SQLITE_PATH'];
+
+beforeEach(() => {
+  delete process.env['FINANCE_SQLITE_PATH'];
+  delete process.env['SQLITE_PATH'];
+});
+
+afterEach(() => {
+  if (originalFinancePath === undefined) delete process.env['FINANCE_SQLITE_PATH'];
+  else process.env['FINANCE_SQLITE_PATH'] = originalFinancePath;
+  if (originalSharedPath === undefined) delete process.env['SQLITE_PATH'];
+  else process.env['SQLITE_PATH'] = originalSharedPath;
+});
+
+describe('resolveFinanceSqlitePath', () => {
+  it('returns FINANCE_SQLITE_PATH verbatim when set', () => {
+    process.env['FINANCE_SQLITE_PATH'] = '/abs/path/finance.db';
+    expect(resolveFinanceSqlitePath()).toBe('/abs/path/finance.db');
+  });
+
+  it('derives the path from the shared SQLITE_PATH when FINANCE_SQLITE_PATH is unset', () => {
+    process.env['SQLITE_PATH'] = '/opt/pops/data/pops.db';
+    expect(resolveFinanceSqlitePath()).toBe('/opt/pops/data/finance.db');
+  });
+
+  it('handles relative SQLITE_PATH values', () => {
+    process.env['SQLITE_PATH'] = './data/pops.db';
+    expect(resolveFinanceSqlitePath()).toBe('data/finance.db');
+  });
+
+  it('falls back to ./data/finance.db when neither env is set', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      expect(resolveFinanceSqlitePath()).toBe(DEFAULT_FINANCE_SQLITE_PATH);
+      expect(warn).toHaveBeenCalledOnce();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});

--- a/apps/pops-api/src/db/finance-sqlite-path.ts
+++ b/apps/pops-api/src/db/finance-sqlite-path.ts
@@ -1,0 +1,33 @@
+import { dirname, join } from 'node:path';
+
+import { DEFAULT_SQLITE_PATH } from './sqlite-path.js';
+
+/**
+ * Default location of the finance pillar's SQLite file.
+ *
+ * Per the ADR-026 pillar architecture each pillar owns its own SQLite
+ * file alongside the shared pops.db. The default places `finance.db`
+ * in the same directory the shared singleton resolves to so dev setups
+ * that already have a writable data dir don't need extra configuration.
+ * Production deployments set `FINANCE_SQLITE_PATH` explicitly; the
+ * fallback here is local-dev-only and matches `resolveSqlitePath`'s
+ * default-path convention (`./data/<file>.db`).
+ *
+ * Resolution order:
+ *   1. `FINANCE_SQLITE_PATH` env (absolute or relative).
+ *   2. `<dirname(SQLITE_PATH)>/finance.db` if the shared path is set.
+ *   3. `./data/finance.db` (matches the shared default's `./data/pops.db`).
+ */
+export const DEFAULT_FINANCE_SQLITE_PATH = './data/finance.db';
+
+export function resolveFinanceSqlitePath(): string {
+  const envPath = process.env['FINANCE_SQLITE_PATH'];
+  if (envPath) return envPath;
+  const sharedPath = process.env['SQLITE_PATH'];
+  if (sharedPath) return join(dirname(sharedPath), 'finance.db');
+  console.warn(
+    `[db] FINANCE_SQLITE_PATH not set — using fallback: ${DEFAULT_FINANCE_SQLITE_PATH} ` +
+      `(co-located with the shared singleton default '${DEFAULT_SQLITE_PATH}')`
+  );
+  return DEFAULT_FINANCE_SQLITE_PATH;
+}

--- a/apps/pops-api/src/index.ts
+++ b/apps/pops-api/src/index.ts
@@ -7,6 +7,7 @@ config({ path: '../../.env', override: false }); // loads root .env without over
 
 import { createApp } from './app.js';
 import { backfillCoreFromShared, closeDb, getCoreDrizzle } from './db.js';
+import { getFinanceDrizzle } from './db/finance-handle.js';
 import { backfillInventoryFromSharedDb, getInventoryDrizzle } from './db/inventory-handle.js';
 import { getMediaDrizzle } from './db/media-db-handle.js';
 import { resolveSqlitePath } from './db/sqlite-path.js';
@@ -63,6 +64,20 @@ try {
   backfillInventoryFromSharedDb(resolveSqlitePath());
 } catch (err) {
   console.error('[db] Failed to bootstrap the inventory pillar SQLite:', err);
+  throw err;
+}
+
+// Eagerly open the finance pillar's SQLite + apply its journal at
+// boot. Phase 2 PR 2 of the finance pillar: the handle is opened so
+// the per-pillar migrations land before any request hits the API, but
+// no production traffic flips over yet — PR 3 of phase 2 cuts over the
+// wish-list slice with a single `getDrizzle()` → `getFinanceDrizzle()`
+// swap and adds the one-shot ATTACH-based backfill from the legacy
+// shared pops.db.
+try {
+  getFinanceDrizzle();
+} catch (err) {
+  console.error('[db] Failed to bootstrap the finance pillar SQLite:', err);
   throw err;
 }
 

--- a/packages/finance-db/migrations/0053_finance_pillar_baseline.sql
+++ b/packages/finance-db/migrations/0053_finance_pillar_baseline.sql
@@ -14,9 +14,12 @@
 -- recorded — same backfill mechanic inventory's `0006_inventory_pillar_baseline`
 -- relies on (#2792).
 --
--- DDL copied byte-for-byte from
--- `apps/pops-api/src/db/drizzle-migrations/0000_naive_chameleon.sql`
--- so the resulting schema is identical to the shared baseline.
+-- Statements are sourced from
+-- `apps/pops-api/src/db/drizzle-migrations/0000_naive_chameleon.sql`.
+-- File-level layout differs (statement-breakpoint placement, table
+-- ordering scoped to the finance-owned set) but each CREATE TABLE /
+-- CREATE INDEX body matches the shared baseline so the resulting
+-- schema is identical.
 
 CREATE TABLE `entities` (
 	`id` text PRIMARY KEY NOT NULL,

--- a/packages/finance-db/migrations/0053_finance_pillar_baseline.sql
+++ b/packages/finance-db/migrations/0053_finance_pillar_baseline.sql
@@ -1,0 +1,83 @@
+-- Finance pillar baseline (synthetic — not in the shared journal).
+--
+-- The 4 existing finance migrations (0025/0026/0027/0052) ALTER or
+-- recreate tables created in the pre-modular baseline
+-- `0000_naive_chameleon.sql`. When the package journal applies to a
+-- fresh finance.db (per-pillar runner, no shared baseline available),
+-- those ALTERs fail because the dependent tables don't exist yet.
+--
+-- This entry creates the four required tables ahead of 0025 so the
+-- package journal is self-bootstrapping for a fresh per-pillar file.
+-- When the shared runner applies the same package journal against the
+-- legacy shared pops.db (transitional release-cycle window), the
+-- CREATE statements no-op via `isAlreadyAppliedError` and the hash is
+-- recorded — same backfill mechanic inventory's `0006_inventory_pillar_baseline`
+-- relies on (#2792).
+--
+-- DDL copied byte-for-byte from
+-- `apps/pops-api/src/db/drizzle-migrations/0000_naive_chameleon.sql`
+-- so the resulting schema is identical to the shared baseline.
+
+CREATE TABLE `entities` (
+	`id` text PRIMARY KEY NOT NULL,
+	`notion_id` text,
+	`name` text NOT NULL,
+	`type` text DEFAULT 'company' NOT NULL,
+	`abn` text,
+	`aliases` text,
+	`default_transaction_type` text,
+	`default_tags` text,
+	`notes` text,
+	`last_edited_time` text NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `entities_notion_id_unique` ON `entities` (`notion_id`);
+--> statement-breakpoint
+CREATE TABLE `transaction_corrections` (
+	`id` text PRIMARY KEY NOT NULL,
+	`description_pattern` text NOT NULL,
+	`match_type` text DEFAULT 'exact' NOT NULL,
+	`entity_id` text,
+	`entity_name` text,
+	`location` text,
+	`tags` text DEFAULT '[]' NOT NULL,
+	`transaction_type` text,
+	`confidence` real DEFAULT 0.5 NOT NULL,
+	`times_applied` integer DEFAULT 0 NOT NULL,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL,
+	`last_used_at` text,
+	FOREIGN KEY (`entity_id`) REFERENCES `entities`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE INDEX `idx_corrections_pattern` ON `transaction_corrections` (`description_pattern`);
+--> statement-breakpoint
+CREATE INDEX `idx_corrections_confidence` ON `transaction_corrections` (`confidence`);
+--> statement-breakpoint
+CREATE INDEX `idx_corrections_times_applied` ON `transaction_corrections` (`times_applied`);
+--> statement-breakpoint
+CREATE TABLE `budgets` (
+	`id` text PRIMARY KEY NOT NULL,
+	`notion_id` text,
+	`category` text NOT NULL,
+	`period` text,
+	`amount` real,
+	`active` integer DEFAULT 1 NOT NULL,
+	`notes` text,
+	`last_edited_time` text NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `budgets_notion_id_unique` ON `budgets` (`notion_id`);
+--> statement-breakpoint
+CREATE TABLE `wish_list` (
+	`id` text PRIMARY KEY NOT NULL,
+	`notion_id` text,
+	`item` text NOT NULL,
+	`target_amount` real,
+	`saved` real,
+	`priority` text,
+	`url` text,
+	`notes` text,
+	`last_edited_time` text NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `wish_list_notion_id_unique` ON `wish_list` (`notion_id`);

--- a/packages/finance-db/migrations/meta/_journal.json
+++ b/packages/finance-db/migrations/meta/_journal.json
@@ -4,27 +4,34 @@
   "entries": [
     {
       "idx": 0,
+      "version": "7",
+      "when": 1778500000000,
+      "tag": "0053_finance_pillar_baseline",
+      "breakpoints": true
+    },
+    {
+      "idx": 1,
       "version": "6",
       "when": 1775569718681,
       "tag": "0025_youthful_hulk",
       "breakpoints": true
     },
     {
-      "idx": 1,
+      "idx": 2,
       "version": "6",
       "when": 1775653615416,
       "tag": "0026_little_frank_castle",
       "breakpoints": true
     },
     {
-      "idx": 2,
+      "idx": 3,
       "version": "6",
       "when": 1775998252709,
       "tag": "0027_slow_dormammu",
       "breakpoints": true
     },
     {
-      "idx": 3,
+      "idx": 4,
       "version": "7",
       "when": 1778429000000,
       "tag": "0052_budgets_active_default_zero",

--- a/packages/finance-db/src/__tests__/open-finance-db.test.ts
+++ b/packages/finance-db/src/__tests__/open-finance-db.test.ts
@@ -5,20 +5,17 @@
  * the resulting schema, and confirms the helper is idempotent when
  * re-run against the same DB.
  *
- * Unlike `@pops/core-db`/`@pops/media-db`, finance's package journal
- * (0025/0026/0027/0052) is NOT self-bootstrapping — every entry ALTERs
- * or recreates a table created in the pre-modular baseline
- * (`0000_naive_chameleon.sql`). The tests pre-seed the three required
- * baseline tables (`entities`, `transaction_corrections`, `budgets`)
- * into the file before calling `openFinanceDb` so the migrate step has
- * something to ALTER. Once the baseline split lands, this seeding can
- * be retired.
+ * Finance's package journal is now self-bootstrapping —
+ * `0053_finance_pillar_baseline` creates the four tables the existing
+ * 0025/0026/0027/0052 entries ALTER or recreate, mirroring inventory's
+ * `0006_inventory_pillar_baseline` mechanism. Against a fresh per-pillar
+ * file the baseline runs first; against the legacy shared pops.db the
+ * runner backfills the no-op via `isAlreadyAppliedError`.
  */
-import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { join } from 'node:path';
 
-import Database from 'better-sqlite3';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { openFinanceDb } from '../open-finance-db.js';
@@ -33,77 +30,14 @@ afterEach(() => {
   rmSync(tmpDir, { recursive: true, force: true });
 });
 
-/**
- * Minimum baseline DDL required for the package's journal to apply
- * cleanly: `entities` (FK target of `transaction_tag_rules` created by
- * 0026), `transaction_corrections` (ALTERed by 0025 + 0027), and
- * `budgets` (recreated by 0052). Only the three `CREATE TABLE`
- * statements are copied from
- * `apps/pops-api/src/db/drizzle-migrations/0000_naive_chameleon.sql`
- * — the baseline indexes (e.g. `*_notion_id_unique`,
- * `idx_corrections_*`) are intentionally omitted because nothing in
- * the package journal queries them, and dropping them keeps the test
- * fixture tight.
- */
-function seedBaseline(path: string): void {
-  mkdirSync(dirname(path), { recursive: true });
-  const raw = new Database(path);
-  try {
-    raw.exec(`
-      CREATE TABLE \`entities\` (
-        \`id\` text PRIMARY KEY NOT NULL,
-        \`notion_id\` text,
-        \`name\` text NOT NULL,
-        \`type\` text DEFAULT 'company' NOT NULL,
-        \`abn\` text,
-        \`aliases\` text,
-        \`default_transaction_type\` text,
-        \`default_tags\` text,
-        \`notes\` text,
-        \`last_edited_time\` text NOT NULL
-      );
-      CREATE TABLE \`transaction_corrections\` (
-        \`id\` text PRIMARY KEY NOT NULL,
-        \`description_pattern\` text NOT NULL,
-        \`match_type\` text DEFAULT 'exact' NOT NULL,
-        \`entity_id\` text,
-        \`entity_name\` text,
-        \`location\` text,
-        \`tags\` text DEFAULT '[]' NOT NULL,
-        \`transaction_type\` text,
-        \`confidence\` real DEFAULT 0.5 NOT NULL,
-        \`times_applied\` integer DEFAULT 0 NOT NULL,
-        \`created_at\` text DEFAULT (datetime('now')) NOT NULL,
-        \`last_used_at\` text,
-        FOREIGN KEY (\`entity_id\`) REFERENCES \`entities\`(\`id\`) ON UPDATE no action ON DELETE set null
-      );
-      CREATE TABLE \`budgets\` (
-        \`id\` text PRIMARY KEY NOT NULL,
-        \`notion_id\` text,
-        \`category\` text NOT NULL,
-        \`period\` text,
-        \`amount\` real,
-        \`active\` integer DEFAULT 1 NOT NULL,
-        \`notes\` text,
-        \`last_edited_time\` text NOT NULL
-      );
-    `);
-  } finally {
-    raw.close();
-  }
-}
-
 describe('openFinanceDb', () => {
-  it('applies the configured PRAGMAs on an existing DB file', () => {
-    // seedBaseline pre-creates the file (and its parent dir) so the
-    // package journal has tables to ALTER; this test asserts the
-    // PRAGMAs openFinanceDb sets on the existing handle, not the
-    // mkdir-if-missing path (covered separately below).
-    const path = join(tmpDir, 'finance.db');
-    seedBaseline(path);
+  it('creates the parent directory and applies PRAGMAs', () => {
+    const path = join(tmpDir, 'nested', 'sub', 'finance.db');
+    expect(existsSync(path)).toBe(false);
 
     const { raw } = openFinanceDb(path);
     try {
+      expect(existsSync(path)).toBe(true);
       expect(raw.pragma('journal_mode', { simple: true })).toBe('wal');
       expect(raw.pragma('foreign_keys', { simple: true })).toBe(1);
       expect(raw.pragma('busy_timeout', { simple: true })).toBe(5000);
@@ -112,16 +46,42 @@ describe('openFinanceDb', () => {
     }
   });
 
-  it('applies the package journal — tag_vocabulary table exists post-open', () => {
+  it('applies the package journal — finance tables exist post-open', () => {
     const path = join(tmpDir, 'finance.db');
-    seedBaseline(path);
-
     const { raw } = openFinanceDb(path);
     try {
-      const row = raw
-        .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='tag_vocabulary'")
-        .get() as { name: string } | undefined;
-      expect(row?.name).toBe('tag_vocabulary');
+      const tables = raw
+        .prepare(
+          "SELECT name FROM sqlite_master WHERE type='table' AND name IN ('wish_list', 'entities', 'transaction_corrections', 'budgets', 'tag_vocabulary', 'transaction_tag_rules') ORDER BY name"
+        )
+        .all() as { name: string }[];
+      expect(tables.map((t) => t.name)).toEqual([
+        'budgets',
+        'entities',
+        'tag_vocabulary',
+        'transaction_corrections',
+        'transaction_tag_rules',
+        'wish_list',
+      ]);
+    } finally {
+      raw.close();
+    }
+  });
+
+  it('applies the 0027 priority ALTERs cleanly on top of the baseline', () => {
+    const path = join(tmpDir, 'finance.db');
+    const { raw } = openFinanceDb(path);
+    try {
+      // 0027 adds `priority integer DEFAULT 0 NOT NULL` to both tables
+      // ALTERed on top of the baseline. Confirm the column lands.
+      const correctionsCols = raw.prepare('PRAGMA table_info(transaction_corrections)').all() as {
+        name: string;
+      }[];
+      const rulesCols = raw.prepare('PRAGMA table_info(transaction_tag_rules)').all() as {
+        name: string;
+      }[];
+      expect(correctionsCols.map((c) => c.name)).toContain('priority');
+      expect(rulesCols.map((c) => c.name)).toContain('priority');
     } finally {
       raw.close();
     }
@@ -129,12 +89,10 @@ describe('openFinanceDb', () => {
 
   it('is idempotent — re-opening the same DB does not re-apply migrations', () => {
     const path = join(tmpDir, 'finance.db');
-    seedBaseline(path);
 
     const first = openFinanceDb(path);
     let firstCount: number;
     try {
-      // Seed a tag vocabulary row to prove state persists across re-opens.
       first.raw
         .prepare("INSERT INTO tag_vocabulary (tag, source, is_active) VALUES ('Custom', 'test', 1)")
         .run();

--- a/packages/finance-db/src/open-finance-db.ts
+++ b/packages/finance-db/src/open-finance-db.ts
@@ -65,14 +65,13 @@ export interface OpenedFinanceDb {
  * missing folder), the raw handle is closed before the error is
  * re-thrown so the caller can't leak a locked file descriptor.
  *
- * Note: every finance migration in the package's journal so far
- * (0025/0026/0027/0052) ALTERs or recreates tables created in the
- * pre-modular baseline (`0000_naive_chameleon.sql`). The opener does
- * not apply that baseline — callers that need a fresh, fully-seeded
- * finance.db must run the shared journal first OR include the relevant
- * baseline DDL out of band (the existing tests inline the
- * `wish_list` DDL for this reason). Once the baseline split lands,
- * the package's journal will be self-sufficient.
+ * The package journal is self-bootstrapping: idx 0 is
+ * `0053_finance_pillar_baseline` which CREATEs the four tables the
+ * existing 0025/0026/0027/0052 entries ALTER/recreate (mirrors
+ * inventory's `0006_inventory_pillar_baseline`). Against a fresh
+ * finance.db the baseline runs first; against the legacy shared
+ * pops.db the per-pillar runner backfills the no-op via
+ * `isAlreadyAppliedError`.
  */
 export function openFinanceDb(path: string): OpenedFinanceDb {
   mkdirSync(dirname(path), { recursive: true });


### PR DESCRIPTION
## Summary

Phase 2 PR 2 of the finance pillar migration: eagerly opens the per-pillar SQLite at process bootstrap so the in-package migrations journal lands before any request hits the API. No production traffic flips over yet — PR 3 of phase 2 cuts the wish-list slice with a single `getDrizzle()` → `getFinanceDrizzle()` swap and adds the ATTACH-based backfill.

Mirrors the core (#2751) and inventory (#2792) Phase 2 PR 2 pattern.

## What's in this PR

- `apps/pops-api/src/db/finance-sqlite-path.{ts,test.ts}` — `FINANCE_SQLITE_PATH > <dirname(SQLITE_PATH)>/finance.db > ./data/finance.db` precedence chain.
- `apps/pops-api/src/db/finance-handle.ts` — lazy `getFinanceDrizzle()` + `closeFinanceDb()` + test-only `setFinanceDb()`.
- `apps/pops-api/src/db.ts` wires `closeFinanceDb` into `closeDb()`.
- `apps/pops-api/src/index.ts` boot block opens the handle.
- `apps/pops-api/.env.example` documents `FINANCE_SQLITE_PATH`.
- `packages/finance-db/migrations/0053_finance_pillar_baseline.sql` — new synthetic baseline at idx 0 of the package journal that CREATEs the four tables (`entities`, `transaction_corrections`, `budgets`, `wish_list`) the existing 0025/0026/0027/0052 entries ALTER/recreate. Mirrors inventory's `0006_inventory_pillar_baseline`. DDL byte-identical to `0000_naive_chameleon.sql`.
- The per-pillar runner's `isAlreadyAppliedError` mechanism backfills the no-op when the baseline applies against the legacy shared `pops.db`; the SQL runs cleanly against a fresh per-pillar file.
- Test pre-seeding in `open-finance-db.test.ts` is retired (the package journal now bootstraps itself).

## Test plan

- [x] `pnpm --filter @pops/finance-db test` — 18/18 (4 opener tests + 14 wishlist)
- [x] `pops-api` `finance-sqlite-path.test.ts` — 4/4
- [x] `pops-api` `per-pillar-migrations.test.ts` — 7/7 (unchanged)
- [x] `pops-api` `migration-ownership.test.ts` — 4/4 (no new entry in shared MIGRATION_OWNERS, contract holds)
- [x] Lint — clean (pre-existing food module errors are out of scope)