### PR TITLE
feat(infra): media Litestream config + AGENTS.md note (pillar media phase 2 PR 4)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -266,7 +266,7 @@ When a movie is added to the POPS library, automatically checks Plex Discover cl
 - **Chat:** Moltbot (Telegram)
 - **Backup:** Backblaze B2 via rclone (encrypted)
 - **Litestream exclusions:** `MEDIA_IMAGES_DIR` and `FOOD_INGEST_DIR` are regeneratable media trees and must be excluded from Litestream replication in the homelab-infra repo's Litestream config. The SQLite rows that reference these paths stay backed up; only the bytes are skipped.
-- **Per-pillar SQLite (ADR-026):** each pillar's database streams independently. The core pillar's reference config lives at `infra/litestream/core.yml` and the inventory pillar's at `infra/litestream/inventory.yml`; the deployer mirrors them into the homelab-infra Litestream config alongside the existing `pops.db` stream. As subsequent pillars (finance, media, …) extract their own SQLite files, each adds a sibling YAML next to `core.yml`.
+- **Per-pillar SQLite (ADR-026):** each pillar's database streams independently. The core pillar's reference config lives at `infra/litestream/core.yml`, the inventory pillar's at `infra/litestream/inventory.yml`, and the media pillar's at `infra/litestream/media.yml`; the deployer mirrors them into the homelab-infra Litestream config alongside the existing `pops.db` stream. As subsequent pillars (finance, cerebrum, …) extract their own SQLite files, each adds a sibling YAML next to `core.yml`.
 
 ## Import Pipeline
 

--- a/infra/litestream/media.yml
+++ b/infra/litestream/media.yml
@@ -1,0 +1,30 @@
+## Litestream replication config — media pillar SQLite.
+##
+## Phase 2 PR 4 of the media pillar migration (ADR-026). Mirrors
+## the per-pillar pattern so each pillar's database streams
+## independently of the shared pops.db.
+##
+## Production deployment lives in the homelab-infra repo (see AGENTS.md
+## for the deployment model); this file is the canonical reference the
+## deployer copies into its own Litestream config. The replica target
+## (S3 bucket name, region, credentials) is provided by the deployer's
+## environment — leave it as a `${MEDIA_LITESTREAM_REPLICA_URL}`
+## style placeholder here.
+##
+## Restore drill (single line — safe to copy/paste during an incident):
+##   litestream restore -o /data/sqlite/media.db "${MEDIA_LITESTREAM_REPLICA_URL}"
+## Stop the media-api container first so it isn't writing
+## concurrently; the drill is exercised in Phase 4 verification.
+
+dbs:
+  - path: /data/sqlite/media.db
+    replicas:
+      - url: ${MEDIA_LITESTREAM_REPLICA_URL}
+        # Per-pillar config so a single-pillar restore doesn't pull in
+        # the whole pops.db blob. Sync interval matches the shared
+        # singleton's existing replica config (1s by default — see
+        # homelab-infra).
+        sync-interval: 1s
+        retention: 24h
+        snapshot-interval: 1h
+        validation-interval: 12h


### PR DESCRIPTION
## Summary

Final PR of media pillar Phase 2. Wraps up the per-pillar SQLite extraction by giving the \`media.db\` file its own Litestream stream so the deployer can mirror it into the homelab-infra Litestream config alongside the existing \`pops.db\` + \`core.db\` + \`inventory.db\` streams.

Mirrors inventory Phase 2 PR 4 (#2796) line-for-line, which itself mirrored core Phase 2 PR 4 (#2758):

- **\`infra/litestream/media.yml\`** — replica URL placeholder (\`\${MEDIA_LITESTREAM_REPLICA_URL}\`), sync / retention / snapshot / validation intervals match \`core.yml\` byte-for-byte; restore drill inlined on a single line for incident copy-paste safety.
- **\`AGENTS.md\`** — updates the per-pillar SQLite note to list \`infra/litestream/core.yml\`, \`inventory.yml\`, and \`media.yml\` as the canonical references the deployer mirrors.

\`.github/workflows/infra-lint.yml\` already globs \`infra/litestream/**\` so the new file is yaml-lint-validated on every PR without workflow changes.

Phase 3 (\`pops-media-api\` container) follows. Phase 4 (verification runbook + Track F row flip) closes the media pillar.

## Test plan

- [x] \`npx yaml-lint infra/litestream/*.yml\` — valid (matches \`core.yml\` / \`inventory.yml\` structure)
- [x] No code changes — production runtime is unchanged; this is canonical-reference YAML for the deployer to mirror into homelab-infra