### PR TITLE
feat(food): PRD-147 — fridge inventory view (`/food/fridge`)

### DIFF
--- a/apps/pops-api/src/modules/food/__tests__/fridge-router.test.ts
+++ b/apps/pops-api/src/modules/food/__tests__/fridge-router.test.ts
@@ -1,0 +1,454 @@
+/**
+ * PRD-147 — integration tests for `food.fridge.*`.
+ *
+ * Spins up an in-memory food database via the same migration replay
+ * pattern as `batches-router.test.ts`, seeds variants + batches +
+ * recipes, then exercises the `view` and `recipesUsingBatch` queries.
+ *
+ * Coverage per PRD-147 §Acceptance Criteria:
+ *   - default view excludes empty + soft-deleted batches
+ *   - includeEmpty / includeDeleted toggles
+ *   - location, search, expiringSoon, recipeYieldedOnly filters
+ *   - sort by location, ingredient name, expiry NULLS LAST, produced
+ *   - daysToExpiry boundary (today / yesterday / tomorrow)
+ *   - counts.visible / empty / deleted
+ *   - recipesUsingBatch: variant-only join + recent-cook order
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import BetterSqlite3, { type Database } from 'better-sqlite3';
+import { eq } from 'drizzle-orm';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  batchesLifecycleService,
+  ingredientsService,
+  ingredientVariants,
+  recipeLines,
+  recipes,
+  recipesService,
+  recipeRunsService,
+  recipeVersions,
+  variantsService,
+} from '@pops/app-food-db';
+
+import { closeDb, getDrizzle, setDb } from '../../../db.js';
+import { createCaller } from '../../../shared/test-utils.js';
+
+const MIGRATION_FILES = [
+  '0058_high_sentinel.sql',
+  '0059_useful_hiroim.sql',
+  '0060_familiar_leo.sql',
+  '0061_shocking_skreet.sql',
+  '0062_chemical_donald_blake.sql',
+  '0063_bumpy_wolverine.sql',
+  '0064_peaceful_magma.sql',
+  '0065_prd_116_recipe_compile.sql',
+  '0066_prd_123_conversions.sql',
+  '0067_prd_125_ingest_error_columns.sql',
+  '0068_prd_136_inbox_review.sql',
+  '0069_prd_145_batches_deleted_at.sql',
+];
+
+function applyMigration(db: Database, filename: string): void {
+  const text = readFileSync(join(__dirname, '../../../db/drizzle-migrations', filename), 'utf8');
+  for (const stmt of text.split('--> statement-breakpoint')) {
+    const trimmed = stmt.trim();
+    if (trimmed.length > 0) db.exec(trimmed);
+  }
+}
+
+function createFoodTestDb(): Database {
+  const db = new BetterSqlite3(':memory:');
+  db.pragma('journal_mode = WAL');
+  db.pragma('foreign_keys = ON');
+  for (const name of MIGRATION_FILES) applyMigration(db, name);
+  return db;
+}
+
+interface Seeded {
+  tomatoVariantId: number;
+  onionVariantId: number;
+  recipeVersionId: number;
+  recipeSlug: string;
+}
+
+function seedIngredientsAndRecipe(): Seeded {
+  const db = getDrizzle();
+  const tomato = ingredientsService.createIngredient(db, {
+    name: 'Tomato',
+    slug: 'tomato',
+    defaultUnit: 'g',
+  });
+  const tomatoVariant = variantsService.createVariant(db, {
+    ingredientId: tomato.id,
+    name: 'Diced',
+    slug: 'diced',
+    defaultUnit: 'g',
+  });
+  db.update(ingredientVariants)
+    .set({ defaultShelfLifeDaysFridge: 5, defaultShelfLifeDaysFreezer: 90 })
+    .where(eq(ingredientVariants.id, tomatoVariant.id))
+    .run();
+
+  const onion = ingredientsService.createIngredient(db, {
+    name: 'Onion',
+    slug: 'onion',
+    defaultUnit: 'g',
+  });
+  const onionVariant = variantsService.createVariant(db, {
+    ingredientId: onion.id,
+    name: 'Yellow',
+    slug: 'yellow',
+    defaultUnit: 'g',
+  });
+  db.update(ingredientVariants)
+    .set({ defaultShelfLifeDaysFridge: 10 })
+    .where(eq(ingredientVariants.id, onionVariant.id))
+    .run();
+
+  const recipeSlug = 'tomato-soup';
+  const { version } = recipesService.createRecipe(db, {
+    slug: recipeSlug,
+    firstVersion: {
+      title: 'Tomato Soup',
+      bodyDsl: '@recipe(slug="tomato-soup", title="Tomato Soup")',
+    },
+  });
+  db.update(recipeVersions)
+    .set({ compileStatus: 'compiled' })
+    .where(eq(recipeVersions.id, version.id))
+    .run();
+
+  return {
+    tomatoVariantId: tomatoVariant.id,
+    onionVariantId: onionVariant.id,
+    recipeVersionId: version.id,
+    recipeSlug,
+  };
+}
+
+describe('food.fridge router — PRD-147', () => {
+  let sqlite: Database;
+  let caller: ReturnType<typeof createCaller>;
+
+  beforeEach(() => {
+    sqlite = createFoodTestDb();
+    setDb(sqlite);
+    caller = createCaller();
+  });
+
+  afterEach(() => {
+    closeDb();
+    sqlite.close();
+  });
+
+  describe('view', () => {
+    it('returns four location sections even when empty', async () => {
+      seedIngredientsAndRecipe();
+      const view = await caller.food.fridge.view({});
+      const locations = view.sections.map((s) => s.location);
+      expect(locations).toEqual(['pantry', 'fridge', 'freezer', 'other']);
+      for (const section of view.sections) {
+        expect(section.count).toBe(0);
+        expect(section.ingredients).toEqual([]);
+      }
+      expect(view.counts).toEqual({ visible: 0, empty: 0, deleted: 0 });
+    });
+
+    it('groups batches by location and ingredient with expiry-then-produced ordering', async () => {
+      const seed = seedIngredientsAndRecipe();
+      const { batchId: olderTomato } = await caller.food.batches.create({
+        variantId: seed.tomatoVariantId,
+        prepStateId: null,
+        qty: 200,
+        unit: 'g',
+        location: 'fridge',
+        sourceType: 'purchase',
+        producedAt: '2026-06-01T00:00:00.000Z',
+        expiresAt: '2026-06-12T00:00:00.000Z',
+      });
+      const { batchId: newerTomato } = await caller.food.batches.create({
+        variantId: seed.tomatoVariantId,
+        prepStateId: null,
+        qty: 150,
+        unit: 'g',
+        location: 'fridge',
+        sourceType: 'purchase',
+        producedAt: '2026-06-03T00:00:00.000Z',
+        expiresAt: '2026-06-10T00:00:00.000Z',
+      });
+      await caller.food.batches.create({
+        variantId: seed.onionVariantId,
+        prepStateId: null,
+        qty: 500,
+        unit: 'g',
+        location: 'pantry',
+        sourceType: 'purchase',
+        producedAt: '2026-06-01T00:00:00.000Z',
+      });
+
+      const view = await caller.food.fridge.view({});
+      const fridge = view.sections.find((s) => s.location === 'fridge');
+      expect(fridge?.count).toBe(2);
+      expect(fridge?.ingredients).toHaveLength(1);
+      const tomatoGroup = fridge?.ingredients[0];
+      expect(tomatoGroup?.ingredientName).toBe('Tomato');
+      expect(tomatoGroup?.batches.map((b) => b.id)).toEqual([newerTomato, olderTomato]);
+
+      const pantry = view.sections.find((s) => s.location === 'pantry');
+      expect(pantry?.count).toBe(1);
+      expect(pantry?.ingredients[0]?.ingredientName).toBe('Onion');
+
+      expect(view.counts.visible).toBe(3);
+    });
+
+    it('hides empty + soft-deleted batches by default and reveals them via toggles', async () => {
+      const seed = seedIngredientsAndRecipe();
+      const { batchId: keep } = await caller.food.batches.create({
+        variantId: seed.tomatoVariantId,
+        prepStateId: null,
+        qty: 200,
+        unit: 'g',
+        location: 'fridge',
+        sourceType: 'purchase',
+      });
+      const { batchId: empty } = await caller.food.batches.create({
+        variantId: seed.tomatoVariantId,
+        prepStateId: null,
+        qty: 100,
+        unit: 'g',
+        location: 'fridge',
+        sourceType: 'purchase',
+      });
+      await caller.food.batches.adjustQty({ id: empty, delta: -100, reason: 'wasted' });
+      const { batchId: removed } = await caller.food.batches.create({
+        variantId: seed.tomatoVariantId,
+        prepStateId: null,
+        qty: 200,
+        unit: 'g',
+        location: 'fridge',
+        sourceType: 'purchase',
+      });
+      await caller.food.batches.delete({ id: removed });
+
+      const base = await caller.food.fridge.view({});
+      expect(base.counts).toEqual({ visible: 1, empty: 1, deleted: 1 });
+      const fridge = base.sections.find((s) => s.location === 'fridge');
+      expect(fridge?.ingredients[0]?.batches.map((b) => b.id)).toEqual([keep]);
+
+      const withEmpty = await caller.food.fridge.view({ includeEmpty: true });
+      const fridgeEmpty = withEmpty.sections.find((s) => s.location === 'fridge');
+      expect(fridgeEmpty?.ingredients[0]?.batches.map((b) => b.id).toSorted()).toEqual(
+        [keep, empty].toSorted()
+      );
+
+      // Deleted rows always have qty=0; the "Show all" toggle in the UI
+      // sets both includeEmpty + includeDeleted so they surface together.
+      const withDeleted = await caller.food.fridge.view({
+        includeEmpty: true,
+        includeDeleted: true,
+      });
+      const fridgeDeleted = withDeleted.sections.find((s) => s.location === 'fridge');
+      const ids = fridgeDeleted?.ingredients[0]?.batches.map((b) => b.id) ?? [];
+      expect(ids).toContain(removed);
+    });
+
+    it('filters by location and search', async () => {
+      const seed = seedIngredientsAndRecipe();
+      await caller.food.batches.create({
+        variantId: seed.tomatoVariantId,
+        prepStateId: null,
+        qty: 200,
+        unit: 'g',
+        location: 'fridge',
+        sourceType: 'purchase',
+      });
+      await caller.food.batches.create({
+        variantId: seed.onionVariantId,
+        prepStateId: null,
+        qty: 500,
+        unit: 'g',
+        location: 'pantry',
+        sourceType: 'purchase',
+      });
+
+      const onlyFridge = await caller.food.fridge.view({ locations: ['fridge'] });
+      expect(onlyFridge.sections.find((s) => s.location === 'fridge')?.ingredients.length).toBe(1);
+      expect(onlyFridge.sections.find((s) => s.location === 'pantry')?.ingredients.length).toBe(0);
+
+      const searchOnion = await caller.food.fridge.view({ search: 'onion' });
+      const allBatches = searchOnion.sections.flatMap((s) =>
+        s.ingredients.flatMap((g) => g.batches)
+      );
+      expect(allBatches).toHaveLength(1);
+    });
+
+    it('filters expiringSoon to the next 7 days', async () => {
+      const seed = seedIngredientsAndRecipe();
+      const today = new Date();
+      const inThreeDays = new Date(today.getTime() + 3 * 86_400_000).toISOString();
+      const inThirty = new Date(today.getTime() + 30 * 86_400_000).toISOString();
+      await caller.food.batches.create({
+        variantId: seed.tomatoVariantId,
+        prepStateId: null,
+        qty: 100,
+        unit: 'g',
+        location: 'fridge',
+        sourceType: 'purchase',
+        expiresAt: inThreeDays,
+      });
+      await caller.food.batches.create({
+        variantId: seed.tomatoVariantId,
+        prepStateId: null,
+        qty: 100,
+        unit: 'g',
+        location: 'fridge',
+        sourceType: 'purchase',
+        expiresAt: inThirty,
+      });
+      const view = await caller.food.fridge.view({ expiringSoon: true });
+      const allBatches = view.sections.flatMap((s) => s.ingredients.flatMap((g) => g.batches));
+      expect(allBatches).toHaveLength(1);
+    });
+
+    it('filters recipeYieldedOnly to recipe_run-sourced batches', async () => {
+      const seed = seedIngredientsAndRecipe();
+      await caller.food.batches.create({
+        variantId: seed.tomatoVariantId,
+        prepStateId: null,
+        qty: 100,
+        unit: 'g',
+        location: 'fridge',
+        sourceType: 'purchase',
+      });
+      const db = getDrizzle();
+      const run = recipeRunsService.createRun(db, { recipeVersionId: seed.recipeVersionId });
+      batchesLifecycleService.createBatchFromRun(db, run.id, {
+        variantId: seed.tomatoVariantId,
+        prepStateId: null,
+        qty: 500,
+        unit: 'g',
+        location: 'fridge',
+      });
+
+      const yieldedOnly = await caller.food.fridge.view({ recipeYieldedOnly: true });
+      const rows = yieldedOnly.sections.flatMap((s) => s.ingredients.flatMap((g) => g.batches));
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.sourceType).toBe('recipe_run');
+      expect(rows[0]?.sourceRecipeSlug).toBe(seed.recipeSlug);
+    });
+
+    it('computes daysToExpiry for today / past / future', async () => {
+      const seed = seedIngredientsAndRecipe();
+      const today = new Date();
+      const utcMid = new Date(
+        Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate())
+      );
+      const produced = new Date(utcMid.getTime() - 30 * 86_400_000).toISOString();
+      const past = new Date(utcMid.getTime() - 2 * 86_400_000).toISOString();
+      const future = new Date(utcMid.getTime() + 4 * 86_400_000).toISOString();
+      await caller.food.batches.create({
+        variantId: seed.tomatoVariantId,
+        prepStateId: null,
+        qty: 50,
+        unit: 'g',
+        location: 'fridge',
+        sourceType: 'purchase',
+        producedAt: produced,
+        expiresAt: past,
+      });
+      await caller.food.batches.create({
+        variantId: seed.tomatoVariantId,
+        prepStateId: null,
+        qty: 50,
+        unit: 'g',
+        location: 'fridge',
+        sourceType: 'purchase',
+        producedAt: produced,
+        expiresAt: utcMid.toISOString(),
+      });
+      await caller.food.batches.create({
+        variantId: seed.tomatoVariantId,
+        prepStateId: null,
+        qty: 50,
+        unit: 'g',
+        location: 'fridge',
+        sourceType: 'purchase',
+        producedAt: produced,
+        expiresAt: future,
+      });
+
+      const view = await caller.food.fridge.view({});
+      const rows =
+        view.sections
+          .find((s) => s.location === 'fridge')
+          ?.ingredients[0]?.batches.map((b) => b.daysToExpiry) ?? [];
+      expect(rows).toEqual([-2, 0, 4]);
+    });
+  });
+
+  describe('recipesUsingBatch', () => {
+    it('returns recipes whose current version references the batch variant', async () => {
+      const seed = seedIngredientsAndRecipe();
+      const db = getDrizzle();
+
+      const { batchId } = await caller.food.batches.create({
+        variantId: seed.tomatoVariantId,
+        prepStateId: null,
+        qty: 500,
+        unit: 'g',
+        location: 'fridge',
+        sourceType: 'purchase',
+      });
+
+      const variantRow = db
+        .select({ ingredientId: ingredientVariants.ingredientId })
+        .from(ingredientVariants)
+        .where(eq(ingredientVariants.id, seed.tomatoVariantId))
+        .get();
+      expect(variantRow).toBeDefined();
+
+      db.insert(recipeLines)
+        .values({
+          recipeVersionId: seed.recipeVersionId,
+          position: 1,
+          ingredientId: variantRow?.ingredientId ?? 0,
+          variantId: seed.tomatoVariantId,
+          prepStateId: null,
+          isRecipeRef: 0,
+          recipeRefId: null,
+          originalText: 'tomato:diced',
+          originalQty: 250,
+          originalUnit: 'g',
+          qtyG: 250,
+          qtyMl: null,
+          qtyCount: null,
+          canonicalUnit: 'g',
+          optional: 0,
+          notes: null,
+        })
+        .run();
+
+      db.update(recipes)
+        .set({ currentVersionId: seed.recipeVersionId })
+        .where(eq(recipes.slug, seed.recipeSlug))
+        .run();
+
+      const result = await caller.food.fridge.recipesUsingBatch({ batchId });
+      expect(result.items).toHaveLength(1);
+      const row = result.items[0];
+      expect(row?.recipeSlug).toBe(seed.recipeSlug);
+      expect(row?.lineCount).toBe(1);
+      expect(row?.recipeNeedsQty).toBe(250);
+      expect(row?.lastCookedAt).toBeNull();
+    });
+
+    it('returns empty for unknown batch id', async () => {
+      seedIngredientsAndRecipe();
+      const result = await caller.food.fridge.recipesUsingBatch({ batchId: 99999 });
+      expect(result.items).toEqual([]);
+    });
+  });
+});

--- a/apps/pops-api/src/modules/food/fridge/inputs.ts
+++ b/apps/pops-api/src/modules/food/fridge/inputs.ts
@@ -1,0 +1,27 @@
+/**
+ * Input Zod schemas for `food.fridge.*` procedures (PRD-147).
+ *
+ * `view` filters the batches list by location / search / expiry / source;
+ * `recipesUsingBatch` powers the "Cook now" picker on a batch row.
+ */
+
+import { z } from 'zod';
+
+const LOCATION = z.enum(['pantry', 'fridge', 'freezer', 'other']);
+
+export const FridgeViewInputSchema = z.object({
+  search: z.string().trim().max(120).optional(),
+  locations: z.array(LOCATION).min(1).max(4).optional(),
+  expiringSoon: z.boolean().optional(),
+  recipeYieldedOnly: z.boolean().optional(),
+  includeEmpty: z.boolean().optional(),
+  includeDeleted: z.boolean().optional(),
+});
+
+export const RecipesUsingBatchInputSchema = z.object({
+  batchId: z.number().int().positive(),
+  limit: z.number().int().positive().max(100).optional(),
+});
+
+export type FridgeViewInput = z.infer<typeof FridgeViewInputSchema>;
+export type RecipesUsingBatchInput = z.infer<typeof RecipesUsingBatchInputSchema>;

--- a/apps/pops-api/src/modules/food/fridge/recipes-using-batch.ts
+++ b/apps/pops-api/src/modules/food/fridge/recipes-using-batch.ts
@@ -1,0 +1,103 @@
+/**
+ * `food.fridge.recipesUsingBatch` query — PRD-147.
+ *
+ * Returns recipes whose **current version** has a `recipe_lines` row
+ * matching the batch's `variant_id`. Ordered by `last_cooked_at DESC`
+ * (NULLS LAST) then by recipe slug. Variant-only join — see PRD-147
+ * §Cook now: the variant match is deliberately not prep-aware (Epic 06
+ * delivers a prep-aware solver).
+ *
+ * `recipeNeedsQty` is summed across matching `recipe_lines` whose
+ * `canonical_unit` matches the batch's `unit`. When no matching-unit
+ * line exists for a recipe, the field is `null` (UI renders "Needs ~?").
+ */
+
+import { and, asc, desc, eq, isNotNull, sql, type AnyColumn, type SQL } from 'drizzle-orm';
+
+import {
+  batches,
+  recipeLines,
+  recipeRuns,
+  recipes,
+  recipeVersions,
+  type FoodDb,
+} from '@pops/app-food-db';
+
+import type { BatchUnit, RecipeForCookRow } from '@pops/app-food-db';
+
+const DEFAULT_LIMIT = 20;
+
+interface BatchKey {
+  variantId: number;
+  unit: BatchUnit;
+}
+
+export function recipesUsingBatch(
+  db: FoodDb,
+  batchId: number,
+  limit: number = DEFAULT_LIMIT
+): { items: readonly RecipeForCookRow[] } {
+  const key = lookupBatchKey(db, batchId);
+  if (key === null) return { items: [] };
+
+  const candidates = db
+    .select({
+      recipeId: recipes.id,
+      recipeSlug: recipes.slug,
+      title: recipeVersions.title,
+      recipeType: recipes.recipeType,
+      lineCount: sql<number>`COUNT(${recipeLines.id})`,
+      needsQty: sumQtyColumn(key.unit),
+      lastCookedAt: sql<string | null>`MAX(${recipeRuns.completedAt})`,
+    })
+    .from(recipes)
+    .innerJoin(recipeVersions, eq(recipeVersions.id, recipes.currentVersionId))
+    .innerJoin(recipeLines, eq(recipeLines.recipeVersionId, recipeVersions.id))
+    .leftJoin(
+      recipeRuns,
+      and(eq(recipeRuns.recipeVersionId, recipeVersions.id), isNotNull(recipeRuns.completedAt))
+    )
+    .where(eq(recipeLines.variantId, key.variantId))
+    .groupBy(recipes.id, recipes.slug, recipeVersions.title, recipes.recipeType)
+    .orderBy(
+      sql`${sql<string | null>`MAX(${recipeRuns.completedAt})`} IS NULL`,
+      desc(sql`MAX(${recipeRuns.completedAt})`),
+      asc(recipes.slug)
+    )
+    .limit(limit)
+    .all();
+
+  const items: RecipeForCookRow[] = candidates.map((row) => ({
+    recipeId: row.recipeId,
+    recipeSlug: row.recipeSlug,
+    title: row.title,
+    recipeType: row.recipeType ?? null,
+    lineCount: row.lineCount,
+    recipeNeedsQty: row.needsQty,
+    lastCookedAt: row.lastCookedAt,
+  }));
+
+  return { items };
+}
+
+function lookupBatchKey(db: FoodDb, batchId: number): BatchKey | null {
+  const row = db
+    .select({ variantId: batches.variantId, unit: batches.unit })
+    .from(batches)
+    .where(eq(batches.id, batchId))
+    .get();
+  return row ?? null;
+}
+
+function sumQtyColumn(unit: BatchUnit): SQL<number | null> {
+  const col = qtyColumnFor(unit);
+  return sql<
+    number | null
+  >`SUM(CASE WHEN ${recipeLines.canonicalUnit} = ${unit} THEN ${col} ELSE NULL END)`;
+}
+
+function qtyColumnFor(unit: BatchUnit): AnyColumn {
+  if (unit === 'g') return recipeLines.qtyG;
+  if (unit === 'ml') return recipeLines.qtyMl;
+  return recipeLines.qtyCount;
+}

--- a/apps/pops-api/src/modules/food/fridge/router.ts
+++ b/apps/pops-api/src/modules/food/fridge/router.ts
@@ -1,0 +1,27 @@
+/**
+ * `food.fridge.*` tRPC router — PRD-147.
+ *
+ * Two queries:
+ *   - `view`               — the sectioned fridge view (location → ingredient → batch).
+ *   - `recipesUsingBatch`  — the "Cook now" picker for a single batch row.
+ */
+
+import { getDrizzle } from '../../../db.js';
+import { protectedProcedure, router } from '../../../trpc.js';
+import { FridgeViewInputSchema, RecipesUsingBatchInputSchema } from './inputs.js';
+import { recipesUsingBatch } from './recipes-using-batch.js';
+import { fridgeView } from './view.js';
+
+import type { FridgeView, RecipeForCookRow } from '@pops/app-food-db';
+
+export const fridgeRouter = router({
+  view: protectedProcedure.input(FridgeViewInputSchema).query(({ input }): FridgeView => {
+    return fridgeView(getDrizzle(), input);
+  }),
+
+  recipesUsingBatch: protectedProcedure
+    .input(RecipesUsingBatchInputSchema)
+    .query(({ input }): { items: readonly RecipeForCookRow[] } => {
+      return recipesUsingBatch(getDrizzle(), input.batchId, input.limit);
+    }),
+});

--- a/apps/pops-api/src/modules/food/fridge/view-grouping.ts
+++ b/apps/pops-api/src/modules/food/fridge/view-grouping.ts
@@ -1,0 +1,121 @@
+/**
+ * In-memory grouping for `food.fridge.view` — PRD-147.
+ *
+ * Folds the flat batch rows into `FridgeLocationSection` →
+ * `FridgeIngredientGroup` → `FridgeBatchRow`. All four locations are
+ * always emitted (even empty) so the UI can render placeholder
+ * collapsed sections.
+ */
+import type {
+  BatchLocation,
+  FridgeBatchRow,
+  FridgeIngredientGroup,
+  FridgeLocationSection,
+} from '@pops/app-food-db';
+
+import type { FlatBatchRow } from './view-query.js';
+
+const MS_PER_DAY = 86_400_000;
+const ALL_LOCATIONS: readonly BatchLocation[] = ['pantry', 'fridge', 'freezer', 'other'];
+
+interface IngredientMeta {
+  name: string;
+  slug: string;
+}
+
+export function groupIntoSections(
+  rows: readonly FlatBatchRow[],
+  recipeSlugByRun: ReadonlyMap<number, string>,
+  todayMs: number
+): FridgeLocationSection[] {
+  const byLocation = initLocationMap();
+  const ingredientMeta = new Map<number, IngredientMeta>();
+
+  for (const row of rows) {
+    const batch = toBatchRow(row, recipeSlugByRun, todayMs);
+    const section = byLocation.get(row.location);
+    if (section === undefined) continue;
+    const group = section.get(row.ingredientId) ?? [];
+    group.push(batch);
+    section.set(row.ingredientId, group);
+    if (!ingredientMeta.has(row.ingredientId)) {
+      ingredientMeta.set(row.ingredientId, {
+        name: row.ingredientName,
+        slug: row.ingredientSlug,
+      });
+    }
+  }
+
+  return ALL_LOCATIONS.map((location) =>
+    buildSection(location, byLocation.get(location) ?? new Map(), ingredientMeta)
+  );
+}
+
+function initLocationMap(): Map<BatchLocation, Map<number, FridgeBatchRow[]>> {
+  const m = new Map<BatchLocation, Map<number, FridgeBatchRow[]>>();
+  for (const loc of ALL_LOCATIONS) m.set(loc, new Map());
+  return m;
+}
+
+function toBatchRow(
+  row: FlatBatchRow,
+  recipeSlugByRun: ReadonlyMap<number, string>,
+  todayMs: number
+): FridgeBatchRow {
+  const slug = resolveRecipeSlugForRow(row, recipeSlugByRun);
+  return {
+    id: row.id,
+    variantName: row.variantName,
+    variantSlug: row.variantSlug,
+    prepStateLabel: row.prepStateLabel,
+    qtyRemaining: row.qtyRemaining,
+    unit: row.unit,
+    expiresAt: row.expiresAt,
+    daysToExpiry: computeDaysToExpiry(row.expiresAt, todayMs),
+    producedAt: row.producedAt,
+    sourceType: row.sourceType,
+    sourceRecipeSlug: slug,
+    notes: row.notes,
+    deletedAt: row.deletedAt,
+  };
+}
+
+function resolveRecipeSlugForRow(
+  row: FlatBatchRow,
+  recipeSlugByRun: ReadonlyMap<number, string>
+): string | null {
+  if (row.sourceType !== 'recipe_run' || row.sourceId === null) return null;
+  return recipeSlugByRun.get(row.sourceId) ?? null;
+}
+
+function buildSection(
+  location: BatchLocation,
+  ingredientMap: ReadonlyMap<number, FridgeBatchRow[]>,
+  ingredientMeta: ReadonlyMap<number, IngredientMeta>
+): FridgeLocationSection {
+  const ingredientList: FridgeIngredientGroup[] = [...ingredientMap.entries()]
+    .map(([ingredientId, batchList]) => {
+      const meta = ingredientMeta.get(ingredientId);
+      return {
+        ingredientId,
+        ingredientName: meta?.name ?? '',
+        ingredientSlug: meta?.slug ?? '',
+        batches: batchList,
+      };
+    })
+    .toSorted((a, b) => a.ingredientName.localeCompare(b.ingredientName));
+  const count = ingredientList.reduce((sum, g) => sum + g.batches.length, 0);
+  return { location, count, ingredients: ingredientList };
+}
+
+function computeDaysToExpiry(expiresAt: string | null, todayMs: number): number | null {
+  if (expiresAt === null) return null;
+  const d = new Date(expiresAt);
+  const expiryMs = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
+  if (Number.isNaN(expiryMs)) return null;
+  return Math.round((expiryMs - todayMs) / MS_PER_DAY);
+}
+
+export function toUtcMidnight(d: Date): number {
+  return Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
+}

--- a/apps/pops-api/src/modules/food/fridge/view-query.ts
+++ b/apps/pops-api/src/modules/food/fridge/view-query.ts
@@ -1,0 +1,180 @@
+/**
+ * SQL primitives for `food.fridge.view` — PRD-147.
+ *
+ * Owns the SELECT that pulls every batch row for the current filter
+ * combination plus the three head counts (visible / empty / deleted).
+ * The orchestrator in `view.ts` glues these to the in-memory grouping.
+ */
+import { and, asc, eq, isNotNull, isNull, like, or, sql, type SQL } from 'drizzle-orm';
+
+import {
+  batches,
+  ingredients,
+  ingredientVariants,
+  prepStates,
+  recipeRuns,
+  recipes,
+  recipeVersions,
+  type FoodDb,
+} from '@pops/app-food-db';
+
+import type {
+  BatchLocation,
+  BatchSourceType,
+  BatchUnit,
+  FridgeViewCounts,
+} from '@pops/app-food-db';
+
+import type { FridgeViewInput } from './inputs.js';
+
+const EXPIRING_SOON_DAYS = 7;
+const MS_PER_DAY = 86_400_000;
+
+export interface FlatBatchRow {
+  id: number;
+  variantId: number;
+  variantName: string | null;
+  variantSlug: string | null;
+  ingredientId: number;
+  ingredientName: string;
+  ingredientSlug: string;
+  prepStateLabel: string | null;
+  qtyRemaining: number;
+  unit: BatchUnit;
+  expiresAt: string | null;
+  producedAt: string;
+  sourceType: BatchSourceType;
+  sourceId: number | null;
+  location: BatchLocation;
+  notes: string | null;
+  deletedAt: string | null;
+}
+
+export function selectRows(db: FoodDb, input: FridgeViewInput): FlatBatchRow[] {
+  const conds = baseConditions(input);
+  return db
+    .select({
+      id: batches.id,
+      variantId: batches.variantId,
+      variantName: ingredientVariants.name,
+      variantSlug: ingredientVariants.slug,
+      ingredientId: ingredients.id,
+      ingredientName: ingredients.name,
+      ingredientSlug: ingredients.slug,
+      prepStateLabel: prepStates.name,
+      qtyRemaining: batches.qtyRemaining,
+      unit: batches.unit,
+      expiresAt: batches.expiresAt,
+      producedAt: batches.producedAt,
+      sourceType: batches.sourceType,
+      sourceId: batches.sourceId,
+      location: batches.location,
+      notes: batches.notes,
+      deletedAt: batches.deletedAt,
+    })
+    .from(batches)
+    .innerJoin(ingredientVariants, eq(ingredientVariants.id, batches.variantId))
+    .innerJoin(ingredients, eq(ingredients.id, ingredientVariants.ingredientId))
+    .leftJoin(prepStates, eq(prepStates.id, batches.prepStateId))
+    .where(and(...conds))
+    .orderBy(
+      asc(batches.location),
+      asc(ingredients.name),
+      sql`${batches.expiresAt} IS NULL`,
+      asc(batches.expiresAt),
+      asc(batches.producedAt)
+    )
+    .all();
+}
+
+export function selectCounts(db: FoodDb, input: FridgeViewInput): FridgeViewCounts {
+  const locationFilter = buildLocationFilter(input);
+  return {
+    visible: countBy(
+      db,
+      and(sql`${batches.qtyRemaining} > 0`, isNull(batches.deletedAt), locationFilter)
+    ),
+    empty: countBy(
+      db,
+      and(sql`${batches.qtyRemaining} = 0`, isNull(batches.deletedAt), locationFilter)
+    ),
+    deleted: countBy(db, and(isNotNull(batches.deletedAt), locationFilter)),
+  };
+}
+
+export function resolveRecipeSlugs(db: FoodDb, rows: readonly FlatBatchRow[]): Map<number, string> {
+  const runIds = new Set<number>();
+  for (const row of rows) {
+    if (row.sourceType === 'recipe_run' && row.sourceId !== null) runIds.add(row.sourceId);
+  }
+  if (runIds.size === 0) return new Map();
+  const idList = [...runIds];
+  const found = db
+    .select({ runId: recipeRuns.id, slug: recipes.slug })
+    .from(recipeRuns)
+    .innerJoin(recipeVersions, eq(recipeVersions.id, recipeRuns.recipeVersionId))
+    .innerJoin(recipes, eq(recipes.id, recipeVersions.recipeId))
+    .where(sql`${recipeRuns.id} IN ${idList}`)
+    .all();
+  const map = new Map<number, string>();
+  for (const row of found) map.set(row.runId, row.slug);
+  return map;
+}
+
+function baseConditions(input: FridgeViewInput): SQL[] {
+  const conds: SQL[] = [];
+  if (input.includeEmpty !== true) conds.push(sql`${batches.qtyRemaining} > 0`);
+  if (input.includeDeleted !== true) conds.push(isNull(batches.deletedAt));
+
+  const locations = input.locations ?? null;
+  if (locations !== null && locations.length > 0) {
+    conds.push(sql`${batches.location} IN ${locations}`);
+  }
+
+  if (input.recipeYieldedOnly === true) {
+    conds.push(eq(batches.sourceType, 'recipe_run'));
+  }
+
+  if (input.expiringSoon === true) {
+    conds.push(buildExpiringSoonCondition());
+  }
+
+  appendSearchCondition(conds, input.search);
+
+  return conds;
+}
+
+function appendSearchCondition(conds: SQL[], rawSearch: string | undefined): void {
+  const search = (rawSearch ?? '').trim();
+  if (search.length === 0) return;
+  const pattern = `%${search.toLowerCase()}%`;
+  const expr = or(
+    like(sql`LOWER(${ingredients.name})`, pattern),
+    like(sql`LOWER(${ingredientVariants.name})`, pattern)
+  );
+  if (expr !== undefined) conds.push(expr);
+}
+
+function buildExpiringSoonCondition(): SQL {
+  const threshold = new Date(Date.now() + EXPIRING_SOON_DAYS * MS_PER_DAY).toISOString();
+  const expr = and(isNotNull(batches.expiresAt), sql`${batches.expiresAt} <= ${threshold}`);
+  if (expr === undefined) throw new Error('expiringSoon condition assembly failed');
+  return expr;
+}
+
+function buildLocationFilter(input: FridgeViewInput): SQL {
+  if (input.locations !== undefined && input.locations.length > 0) {
+    return sql`${batches.location} IN ${input.locations}`;
+  }
+  return sql`1=1`;
+}
+
+function countBy(db: FoodDb, where: SQL | undefined): number {
+  return (
+    db
+      .select({ n: sql<number>`COUNT(*)` })
+      .from(batches)
+      .where(where)
+      .get()?.n ?? 0
+  );
+}

--- a/apps/pops-api/src/modules/food/fridge/view-query.ts
+++ b/apps/pops-api/src/modules/food/fridge/view-query.ts
@@ -50,8 +50,8 @@ export interface FlatBatchRow {
   deletedAt: string | null;
 }
 
-export function selectRows(db: FoodDb, input: FridgeViewInput): FlatBatchRow[] {
-  const conds = baseConditions(input);
+export function selectRows(db: FoodDb, input: FridgeViewInput, now: Date): FlatBatchRow[] {
+  const conds = baseConditions(input, now);
   return db
     .select({
       id: batches.id,
@@ -121,7 +121,7 @@ export function resolveRecipeSlugs(db: FoodDb, rows: readonly FlatBatchRow[]): M
   return map;
 }
 
-function baseConditions(input: FridgeViewInput): SQL[] {
+function baseConditions(input: FridgeViewInput, now: Date): SQL[] {
   const conds: SQL[] = [];
   if (input.includeEmpty !== true) conds.push(sql`${batches.qtyRemaining} > 0`);
   if (input.includeDeleted !== true) conds.push(isNull(batches.deletedAt));
@@ -136,7 +136,7 @@ function baseConditions(input: FridgeViewInput): SQL[] {
   }
 
   if (input.expiringSoon === true) {
-    conds.push(buildExpiringSoonCondition());
+    conds.push(buildExpiringSoonCondition(now));
   }
 
   appendSearchCondition(conds, input.search);
@@ -155,8 +155,11 @@ function appendSearchCondition(conds: SQL[], rawSearch: string | undefined): voi
   if (expr !== undefined) conds.push(expr);
 }
 
-function buildExpiringSoonCondition(): SQL {
-  const threshold = new Date(Date.now() + EXPIRING_SOON_DAYS * MS_PER_DAY).toISOString();
+function buildExpiringSoonCondition(now: Date): SQL {
+  // Anchor on the injectable `now` so tests / backfills that pin the clock
+  // see a deterministic threshold (rather than `Date.now()` drifting between
+  // the SELECT and the `daysToExpiry` projection in `view-grouping.ts`).
+  const threshold = new Date(now.getTime() + EXPIRING_SOON_DAYS * MS_PER_DAY).toISOString();
   const expr = and(isNotNull(batches.expiresAt), sql`${batches.expiresAt} <= ${threshold}`);
   if (expr === undefined) throw new Error('expiringSoon condition assembly failed');
   return expr;

--- a/apps/pops-api/src/modules/food/fridge/view.ts
+++ b/apps/pops-api/src/modules/food/fridge/view.ts
@@ -20,7 +20,7 @@ import type { FoodDb, FridgeView } from '@pops/app-food-db';
 import type { FridgeViewInput } from './inputs.js';
 
 export function fridgeView(db: FoodDb, input: FridgeViewInput, now: Date = new Date()): FridgeView {
-  const rows = selectRows(db, input);
+  const rows = selectRows(db, input, now);
   const recipeSlugByRun = resolveRecipeSlugs(db, rows);
   const sections = groupIntoSections(rows, recipeSlugByRun, toUtcMidnight(now));
   const counts = selectCounts(db, input);

--- a/apps/pops-api/src/modules/food/fridge/view.ts
+++ b/apps/pops-api/src/modules/food/fridge/view.ts
@@ -1,0 +1,28 @@
+import { groupIntoSections, toUtcMidnight } from './view-grouping.js';
+import { resolveRecipeSlugs, selectCounts, selectRows } from './view-query.js';
+
+/**
+ * `food.fridge.view` query — PRD-147.
+ *
+ * Reads `batches` joined to `ingredient_variants` / `ingredients` /
+ * `prep_states`, applies the filter inputs, and projects into the
+ * `FridgeView` shape (sections by location → ingredient groups →
+ * batch rows). The default view excludes empties and soft-deleted rows
+ * (`qty_remaining > 0 AND deleted_at IS NULL`).
+ *
+ * `daysToExpiry` is computed in calendar days at UTC. We don't pull in
+ * date-fns server-side — the math is `(expiryUtcMidnight - todayUtcMidnight)
+ * / 86_400_000`, which matches `differenceInCalendarDays` semantics for
+ * date-only inputs.
+ */
+import type { FoodDb, FridgeView } from '@pops/app-food-db';
+
+import type { FridgeViewInput } from './inputs.js';
+
+export function fridgeView(db: FoodDb, input: FridgeViewInput, now: Date = new Date()): FridgeView {
+  const rows = selectRows(db, input);
+  const recipeSlugByRun = resolveRecipeSlugs(db, rows);
+  const sections = groupIntoSections(rows, recipeSlugByRun, toUtcMidnight(now));
+  const counts = selectCounts(db, input);
+  return { sections, counts };
+}

--- a/apps/pops-api/src/modules/food/index.ts
+++ b/apps/pops-api/src/modules/food/index.ts
@@ -2,6 +2,7 @@ import { router } from '../../trpc.js';
 import { batchesRouter } from './batches/router.js';
 import { conversionsRouter } from './conversions/router.js';
 import { cookRouter } from './cook/router.js';
+import { fridgeRouter } from './fridge/router.js';
 import { heroImageRouter } from './hero-image/router.js';
 import { inboxRouter } from './inbox/router.js';
 import { foodMigrations } from './migrations.js';
@@ -34,6 +35,7 @@ export const foodRouter = router({
   batches: batchesRouter,
   cook: cookRouter,
   plan: planRouter,
+  fridge: fridgeRouter,
 });
 
 export const manifest: ModuleManifest<typeof foodRouter> = {

--- a/packages/app-food/src/pages/fridge/AddBatchModal.sections.tsx
+++ b/packages/app-food/src/pages/fridge/AddBatchModal.sections.tsx
@@ -1,0 +1,183 @@
+import { Input } from '@pops/ui';
+
+import { FieldRow, RadioRow } from './form-controls.js';
+import { type AddBatchFormState, type useAddBatchForm } from './useAddBatchForm.js';
+
+/**
+ * JSX sub-sections for `AddBatchModal` — kept here so the modal file
+ * itself stays under the `max-lines` budget.
+ */
+import type { ReactElement } from 'react';
+
+import type { BatchLocation, BatchUnit, ManualBatchSourceType } from '@pops/app-food-db';
+
+const SOURCE_OPTIONS = [
+  { value: 'purchase', label: 'Purchase' },
+  { value: 'gift', label: 'Gift' },
+  { value: 'other', label: 'Other' },
+] as const;
+
+const LOCATION_OPTIONS = [
+  { value: 'pantry', label: 'Pantry' },
+  { value: 'fridge', label: 'Fridge' },
+  { value: 'freezer', label: 'Freezer' },
+  { value: 'other', label: 'Other' },
+] as const;
+
+export type AddFormState = ReturnType<typeof useAddBatchForm>;
+
+export function IngredientPickerSection({ state }: { state: AddFormState }): ReactElement {
+  return (
+    <>
+      <FieldRow label="Search ingredient">
+        <Input
+          value={state.form.search}
+          placeholder="tomato"
+          onChange={(e) => state.setForm({ ...state.form, search: e.target.value })}
+        />
+      </FieldRow>
+      <FieldRow label="Ingredient">
+        <select
+          className="w-full rounded border bg-background px-2 py-1"
+          value={state.form.ingredientId}
+          onChange={(e) =>
+            state.setForm({ ...state.form, ingredientId: e.target.value, variantId: '' })
+          }
+          required
+        >
+          <option value="">Pick an ingredient…</option>
+          {state.ingredients.map((ing) => (
+            <option key={ing.id} value={String(ing.id)}>
+              {ing.name} ({ing.slug})
+            </option>
+          ))}
+        </select>
+      </FieldRow>
+      <FieldRow label="Variant">
+        <select
+          className="w-full rounded border bg-background px-2 py-1"
+          value={state.form.variantId}
+          onChange={(e) => handleVariantChange(state, e.target.value)}
+          required
+          disabled={state.form.ingredientId.length === 0}
+        >
+          <option value="">Pick a variant…</option>
+          {state.variants.map((v) => (
+            <option key={v.id} value={String(v.id)}>
+              {v.name} ({v.slug})
+            </option>
+          ))}
+        </select>
+      </FieldRow>
+    </>
+  );
+}
+
+function handleVariantChange(state: AddFormState, value: string): void {
+  const variant = state.variants.find((v) => String(v.id) === value);
+  state.setForm({
+    ...state.form,
+    variantId: value,
+    unit: (variant?.defaultUnit as BatchUnit | undefined) ?? state.form.unit,
+  });
+}
+
+export function PrepAndQtySection({ state }: { state: AddFormState }): ReactElement {
+  return (
+    <>
+      <FieldRow label="Prep state (optional)">
+        <select
+          className="w-full rounded border bg-background px-2 py-1"
+          value={state.form.prepStateId}
+          onChange={(e) => state.setForm({ ...state.form, prepStateId: e.target.value })}
+        >
+          <option value="">— none —</option>
+          {state.prepStates.map((p) => (
+            <option key={p.id} value={String(p.id)}>
+              {p.name}
+            </option>
+          ))}
+        </select>
+      </FieldRow>
+      <div className="grid grid-cols-2 gap-2">
+        <FieldRow label="Quantity">
+          <Input
+            type="number"
+            step="any"
+            min="0"
+            value={state.form.qty}
+            onChange={(e) => state.setForm({ ...state.form, qty: e.target.value })}
+            required
+          />
+        </FieldRow>
+        <FieldRow label="Unit">
+          <select
+            className="w-full rounded border bg-background px-2 py-1"
+            value={state.form.unit}
+            onChange={(e) => state.setForm({ ...state.form, unit: e.target.value as BatchUnit })}
+          >
+            <option value="g">g</option>
+            <option value="ml">ml</option>
+            <option value="count">count</option>
+          </select>
+        </FieldRow>
+      </div>
+    </>
+  );
+}
+
+export function SourceAndLocationSection({ state }: { state: AddFormState }): ReactElement {
+  return (
+    <>
+      <FieldRow label="Source">
+        <RadioRow
+          name="source"
+          value={state.form.sourceType}
+          options={SOURCE_OPTIONS}
+          onChange={(v) => state.setForm({ ...state.form, sourceType: v as ManualBatchSourceType })}
+        />
+      </FieldRow>
+      <FieldRow label="Location">
+        <RadioRow
+          name="location"
+          value={state.form.location}
+          options={LOCATION_OPTIONS}
+          onChange={(v) => state.setForm({ ...state.form, location: v as BatchLocation })}
+        />
+      </FieldRow>
+    </>
+  );
+}
+
+export function DateAndNotesSection({ state }: { state: AddFormState }): ReactElement {
+  const set = (patch: Partial<AddBatchFormState>): void =>
+    state.setForm({ ...state.form, ...patch });
+  return (
+    <>
+      <div className="grid grid-cols-2 gap-2">
+        <FieldRow label="Produced">
+          <Input
+            type="date"
+            value={state.form.producedAt}
+            onChange={(e) => set({ producedAt: e.target.value })}
+          />
+        </FieldRow>
+        <FieldRow label="Expires (optional)">
+          <Input
+            type="date"
+            value={state.form.expiresAt}
+            onChange={(e) => set({ expiresAt: e.target.value })}
+          />
+        </FieldRow>
+      </div>
+      <FieldRow label="Notes (optional)">
+        <textarea
+          className="min-h-[60px] w-full rounded border bg-background px-2 py-1"
+          maxLength={500}
+          value={state.form.notes}
+          onChange={(e) => set({ notes: e.target.value })}
+        />
+      </FieldRow>
+    </>
+  );
+}

--- a/packages/app-food/src/pages/fridge/AddBatchModal.tsx
+++ b/packages/app-food/src/pages/fridge/AddBatchModal.tsx
@@ -1,8 +1,22 @@
+import { Button, Dialog, DialogContent, DialogHeader, DialogTitle } from '@pops/ui';
+
+import {
+  DateAndNotesSection,
+  IngredientPickerSection,
+  PrepAndQtySection,
+  SourceAndLocationSection,
+} from './AddBatchModal.sections.js';
+import { FormError } from './form-controls.js';
+import { useAddBatchForm } from './useAddBatchForm.js';
+
 /**
- * Scaffold for PRD-147's "+ Add batch" modal — manual-entry path.
- * Calls `food.batches.create` once wired.
+ * "+ Add batch" modal — PRD-147.
+ *
+ * Form state + mutation live in `useAddBatchForm`. The JSX sub-sections
+ * live in `AddBatchModal.sections.tsx`. This file just stitches them
+ * together with the Dialog frame and action buttons.
  */
-import type { ReactNode } from 'react';
+import type { FormEvent, ReactElement } from 'react';
 
 export interface AddBatchModalProps {
   isOpen: boolean;
@@ -10,6 +24,48 @@ export interface AddBatchModalProps {
   onAdded?: (batchId: number) => void;
 }
 
-export function AddBatchModal(_props: AddBatchModalProps): ReactNode {
-  return null;
+export function AddBatchModal({ isOpen, onClose, onAdded }: AddBatchModalProps): ReactElement {
+  const state = useAddBatchForm({ isOpen, onAdded, onClose });
+
+  function handleSubmit(e: FormEvent): void {
+    e.preventDefault();
+    state.submit();
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add batch</DialogTitle>
+        </DialogHeader>
+        <form className="space-y-3" onSubmit={handleSubmit}>
+          <IngredientPickerSection state={state} />
+          <PrepAndQtySection state={state} />
+          <SourceAndLocationSection state={state} />
+          <DateAndNotesSection state={state} />
+          <FormError message={state.error} />
+          <ModalActions onClose={onClose} isPending={state.isPending} />
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function ModalActions({
+  onClose,
+  isPending,
+}: {
+  onClose: () => void;
+  isPending: boolean;
+}): ReactElement {
+  return (
+    <div className="flex justify-end gap-2 pt-2">
+      <Button type="button" variant="ghost" onClick={onClose} disabled={isPending}>
+        Cancel
+      </Button>
+      <Button type="submit" disabled={isPending}>
+        {isPending ? 'Adding…' : 'Add batch'}
+      </Button>
+    </div>
+  );
 }

--- a/packages/app-food/src/pages/fridge/AdjustQtyModal.tsx
+++ b/packages/app-food/src/pages/fridge/AdjustQtyModal.tsx
@@ -1,8 +1,26 @@
 /**
- * Scaffold for PRD-147's adjust-qty modal — record waste / spoilage /
- * corrections. Calls `food.batches.adjustQty`.
+ * Adjust qty modal — PRD-147.
+ *
+ * Records spoilage / waste / correction. PRD-145's `adjustBatchQty`
+ * enforces sign rules: spoiled + wasted require delta < 0; correction
+ * allows either sign. NegativeQty surfaces if delta would push the
+ * batch below zero.
  */
-import type { ReactNode } from 'react';
+import { type FormEvent, type ReactElement } from 'react';
+
+import { Button, Dialog, DialogContent, DialogHeader, DialogTitle, Input } from '@pops/ui';
+
+import { FieldRow, FormError } from './form-controls.js';
+import { formatQty } from './format.js';
+import { parseDelta, useAdjustQtyState } from './useAdjustQtyState.js';
+
+import type { BatchAdjustReason, BatchDetail } from '@pops/app-food-db';
+
+const REASONS: { value: BatchAdjustReason; label: string }[] = [
+  { value: 'spoiled', label: 'Spoiled' },
+  { value: 'wasted', label: 'Wasted' },
+  { value: 'correction', label: 'Correction' },
+];
 
 export interface AdjustQtyModalProps {
   batchId: number | null;
@@ -10,6 +28,100 @@ export interface AdjustQtyModalProps {
   onClose: () => void;
 }
 
-export function AdjustQtyModal(_props: AdjustQtyModalProps): ReactNode {
-  return null;
+export function AdjustQtyModal({ batchId, isOpen, onClose }: AdjustQtyModalProps): ReactElement {
+  const state = useAdjustQtyState({ batchId, isOpen, onClose });
+
+  function handleSubmit(e: FormEvent): void {
+    e.preventDefault();
+    if (batchId === null) return;
+    state.setError(null);
+    const value = parseDelta(state.delta);
+    if (value === null) {
+      state.setError('Enter a non-zero adjustment.');
+      return;
+    }
+    state.adjustMutation.mutate({ id: batchId, delta: value, reason: state.reason });
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Adjust quantity</DialogTitle>
+        </DialogHeader>
+        <form className="space-y-3" onSubmit={handleSubmit}>
+          <BatchSummary detail={state.detail.data ?? null} />
+          <FieldRow label="Adjustment (positive or negative)">
+            <Input
+              type="number"
+              step="any"
+              value={state.delta}
+              onChange={(e) => state.setDelta(e.target.value)}
+              required
+              autoFocus
+            />
+          </FieldRow>
+          <ReasonRadios value={state.reason} onChange={state.setReason} />
+          <FormError message={state.error} />
+          <ModalActions onClose={onClose} isPending={state.adjustMutation.isPending} />
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function BatchSummary({ detail }: { detail: BatchDetail | null }): ReactElement {
+  return (
+    <p className="text-sm text-muted-foreground">
+      {detail?.ingredientName} / {detail?.variantName ?? '—'}
+      <br />
+      Current: {detail !== null ? formatQty(detail.qtyRemaining, detail.unit) : '—'}
+    </p>
+  );
+}
+
+function ReasonRadios({
+  value,
+  onChange,
+}: {
+  value: BatchAdjustReason;
+  onChange: (r: BatchAdjustReason) => void;
+}): ReactElement {
+  return (
+    <FieldRow label="Reason">
+      <div className="space-y-1">
+        {REASONS.map((r) => (
+          <label key={r.value} className="flex items-center gap-2 text-sm">
+            <input
+              type="radio"
+              name="adjust-reason"
+              value={r.value}
+              checked={value === r.value}
+              onChange={() => onChange(r.value)}
+            />
+            {r.label}
+          </label>
+        ))}
+      </div>
+    </FieldRow>
+  );
+}
+
+function ModalActions({
+  onClose,
+  isPending,
+}: {
+  onClose: () => void;
+  isPending: boolean;
+}): ReactElement {
+  return (
+    <div className="flex justify-end gap-2 pt-2">
+      <Button type="button" variant="ghost" onClick={onClose} disabled={isPending}>
+        Cancel
+      </Button>
+      <Button type="submit" disabled={isPending}>
+        {isPending ? 'Saving…' : 'Save'}
+      </Button>
+    </div>
+  );
 }

--- a/packages/app-food/src/pages/fridge/BatchRow.tsx
+++ b/packages/app-food/src/pages/fridge/BatchRow.tsx
@@ -1,17 +1,131 @@
 /**
- * Scaffold for PRD-147's batch-row card inside the sectioned fridge
- * list. Clicking opens `EditBatchModal`; long-press / right-click
- * surfaces the relocate / adjust / delete actions.
+ * Single batch row in the fridge sectioned list — PRD-147.
+ *
+ * Renders the variant / prep / qty / expiry line with a kebab menu
+ * exposing Edit / Relocate / Adjust / Cook / Delete. The page owns
+ * which modal is open; this component only reports the chosen action.
  */
-import type { ReactNode } from 'react';
+import { useState } from 'react';
+
+import { Button } from '@pops/ui';
+
+import { formatExpiry, formatQty, urgencyFor } from './format.js';
+
+import type { ReactElement } from 'react';
 
 import type { FridgeBatchRow as FridgeBatchRowData } from '@pops/app-food-db';
 
+export type BatchAction = 'edit' | 'relocate' | 'adjust' | 'cook' | 'delete';
+
 export interface BatchRowProps {
   batch: FridgeBatchRowData;
-  onEdit: (batchId: number) => void;
+  ingredientName: string;
+  onAction: (action: BatchAction, batchId: number) => void;
 }
 
-export function BatchRow(_props: BatchRowProps): ReactNode {
-  return null;
+export function BatchRow({ batch, ingredientName, onAction }: BatchRowProps): ReactElement {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const urgency = urgencyFor(batch.daysToExpiry);
+  const label = describeBatch(batch, ingredientName);
+  const isDeleted = batch.deletedAt !== null;
+  const isEmpty = batch.qtyRemaining === 0 && !isDeleted;
+
+  return (
+    <li
+      className={`flex items-center justify-between gap-3 rounded-md border bg-card px-3 py-2 text-sm ${
+        isDeleted ? 'opacity-50' : ''
+      }`}
+      data-batch-id={batch.id}
+    >
+      <div className="flex min-w-0 flex-1 items-center gap-2">
+        <ExpiryIcon urgency={urgency} />
+        <div className="min-w-0">
+          <div className="truncate font-medium">{label}</div>
+          <div className="text-xs text-muted-foreground">
+            {formatQty(batch.qtyRemaining, batch.unit)} ·{' '}
+            {formatExpiry(batch.expiresAt, batch.daysToExpiry)}
+            {isEmpty && ' · empty'}
+            {isDeleted && ' · deleted'}
+            {batch.sourceType === 'recipe_run' && batch.sourceRecipeSlug !== null && (
+              <> · from {batch.sourceRecipeSlug}</>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <div className="relative">
+        <Button
+          variant="ghost"
+          size="sm"
+          aria-label="Open actions"
+          aria-haspopup="menu"
+          aria-expanded={menuOpen}
+          onClick={() => setMenuOpen((v) => !v)}
+          disabled={isDeleted}
+        >
+          ⋮
+        </Button>
+        {menuOpen && (
+          <ActionMenu
+            onAction={(a) => {
+              setMenuOpen(false);
+              onAction(a, batch.id);
+            }}
+            onClose={() => setMenuOpen(false)}
+          />
+        )}
+      </div>
+    </li>
+  );
+}
+
+function describeBatch(batch: FridgeBatchRowData, ingredientName: string): string {
+  const parts = [ingredientName];
+  if (batch.variantName !== null && batch.variantName.length > 0) parts.push(batch.variantName);
+  if (batch.prepStateLabel !== null && batch.prepStateLabel.length > 0)
+    parts.push(batch.prepStateLabel);
+  return parts.join(' / ');
+}
+
+function ExpiryIcon({ urgency }: { urgency: ReturnType<typeof urgencyFor> }): ReactElement | null {
+  if (urgency === 'expired') return <span aria-label="Expired">🔴</span>;
+  if (urgency === 'soon') return <span aria-label="Expiring soon">⚠</span>;
+  return <span aria-hidden="true" className="inline-block w-4" />;
+}
+
+interface ActionMenuProps {
+  onAction: (action: BatchAction) => void;
+  onClose: () => void;
+}
+
+function ActionMenu({ onAction, onClose }: ActionMenuProps): ReactElement {
+  const actions: { id: BatchAction; label: string }[] = [
+    { id: 'edit', label: 'Edit' },
+    { id: 'relocate', label: 'Relocate' },
+    { id: 'adjust', label: 'Adjust qty' },
+    { id: 'cook', label: 'Cook now' },
+    { id: 'delete', label: 'Delete' },
+  ];
+  return (
+    <>
+      <div className="fixed inset-0 z-10" onClick={onClose} aria-hidden="true" />
+      <ul
+        role="menu"
+        className="absolute right-0 z-20 mt-1 w-40 overflow-hidden rounded-md border bg-popover shadow-md"
+      >
+        {actions.map((a) => (
+          <li key={a.id}>
+            <button
+              type="button"
+              role="menuitem"
+              className="block w-full px-3 py-1.5 text-left text-sm hover:bg-accent"
+              onClick={() => onAction(a.id)}
+            >
+              {a.label}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </>
+  );
 }

--- a/packages/app-food/src/pages/fridge/BatchRow.tsx
+++ b/packages/app-food/src/pages/fridge/BatchRow.tsx
@@ -5,6 +5,7 @@
  * exposing Edit / Relocate / Adjust / Cook / Delete. The page owns
  * which modal is open; this component only reports the chosen action.
  */
+import { AlertTriangle, CircleAlert, MoreVertical } from 'lucide-react';
 import { useState } from 'react';
 
 import { Button } from '@pops/ui';
@@ -63,7 +64,7 @@ export function BatchRow({ batch, ingredientName, onAction }: BatchRowProps): Re
           onClick={() => setMenuOpen((v) => !v)}
           disabled={isDeleted}
         >
-          ⋮
+          <MoreVertical className="size-4" aria-hidden="true" />
         </Button>
         {menuOpen && (
           <ActionMenu
@@ -87,9 +88,13 @@ function describeBatch(batch: FridgeBatchRowData, ingredientName: string): strin
   return parts.join(' / ');
 }
 
-function ExpiryIcon({ urgency }: { urgency: ReturnType<typeof urgencyFor> }): ReactElement | null {
-  if (urgency === 'expired') return <span aria-label="Expired">🔴</span>;
-  if (urgency === 'soon') return <span aria-label="Expiring soon">⚠</span>;
+function ExpiryIcon({ urgency }: { urgency: ReturnType<typeof urgencyFor> }): ReactElement {
+  if (urgency === 'expired') {
+    return <CircleAlert className="size-4 text-destructive" aria-label="Expired" />;
+  }
+  if (urgency === 'soon') {
+    return <AlertTriangle className="size-4 text-warning" aria-label="Expiring soon" />;
+  }
   return <span aria-hidden="true" className="inline-block w-4" />;
 }
 

--- a/packages/app-food/src/pages/fridge/CookNowPicker.tsx
+++ b/packages/app-food/src/pages/fridge/CookNowPicker.tsx
@@ -7,7 +7,7 @@
  * the cook flow takes over there.
  */
 import { type ReactElement } from 'react';
-import { useNavigate } from 'react-router';
+import { Link, useNavigate } from 'react-router';
 
 import { trpc } from '@pops/api-client';
 import { Button, Dialog, DialogContent, DialogHeader, DialogTitle } from '@pops/ui';
@@ -50,6 +50,7 @@ export function CookNowPicker({
         </DialogHeader>
         <PickerBody
           isLoading={result.isLoading}
+          error={result.error instanceof Error ? result.error : null}
           items={items}
           batchUnit={batchUnit}
           onPick={handleNavigate}
@@ -66,12 +67,20 @@ export function CookNowPicker({
 
 interface PickerBodyProps {
   isLoading: boolean;
+  error: Error | null;
   items: readonly RecipeForCookRow[];
   batchUnit: BatchUnit | null;
   onPick: (slug: string) => void;
 }
 
-function PickerBody({ isLoading, items, batchUnit, onPick }: PickerBodyProps): ReactElement {
+function PickerBody({ isLoading, error, items, batchUnit, onPick }: PickerBodyProps): ReactElement {
+  if (error !== null) {
+    return (
+      <p role="alert" className="text-sm text-destructive">
+        Couldn&apos;t load matching recipes: {error.message}
+      </p>
+    );
+  }
   if (isLoading) {
     return <p className="text-sm text-muted-foreground">Loading…</p>;
   }
@@ -79,9 +88,9 @@ function PickerBody({ isLoading, items, batchUnit, onPick }: PickerBodyProps): R
     return (
       <p className="text-sm text-muted-foreground">
         No recipes use this batch&apos;s ingredient yet.{' '}
-        <a className="underline" href="/food/recipes/new">
+        <Link className="underline" to="/food/recipes/new">
           Try creating one!
-        </a>
+        </Link>
       </p>
     );
   }

--- a/packages/app-food/src/pages/fridge/CookNowPicker.tsx
+++ b/packages/app-food/src/pages/fridge/CookNowPicker.tsx
@@ -1,0 +1,125 @@
+/**
+ * "Cook now" picker — PRD-147.
+ *
+ * Lists recipes whose current version references this batch's variant.
+ * The match is variant-only (not prep-aware) — a prep-aware solver
+ * arrives in Epic 06. Clicking a recipe navigates to its detail page;
+ * the cook flow takes over there.
+ */
+import { type ReactElement } from 'react';
+import { useNavigate } from 'react-router';
+
+import { trpc } from '@pops/api-client';
+import { Button, Dialog, DialogContent, DialogHeader, DialogTitle } from '@pops/ui';
+
+import { formatQty } from './format.js';
+
+import type { BatchUnit, RecipeForCookRow } from '@pops/app-food-db';
+
+export interface CookNowPickerProps {
+  batchId: number | null;
+  batchUnit: BatchUnit | null;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function CookNowPicker({
+  batchId,
+  batchUnit,
+  isOpen,
+  onClose,
+}: CookNowPickerProps): ReactElement {
+  const navigate = useNavigate();
+  const result = trpc.food.fridge.recipesUsingBatch.useQuery(
+    { batchId: batchId ?? 0 },
+    { enabled: isOpen && batchId !== null }
+  );
+
+  const items = result.data?.items ?? [];
+
+  function handleNavigate(slug: string): void {
+    onClose();
+    void navigate(`/food/recipes/${slug}`);
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>What can you cook with this batch?</DialogTitle>
+        </DialogHeader>
+        <PickerBody
+          isLoading={result.isLoading}
+          items={items}
+          batchUnit={batchUnit}
+          onPick={handleNavigate}
+        />
+        <div className="flex justify-end pt-2">
+          <Button variant="ghost" onClick={onClose}>
+            Close
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+interface PickerBodyProps {
+  isLoading: boolean;
+  items: readonly RecipeForCookRow[];
+  batchUnit: BatchUnit | null;
+  onPick: (slug: string) => void;
+}
+
+function PickerBody({ isLoading, items, batchUnit, onPick }: PickerBodyProps): ReactElement {
+  if (isLoading) {
+    return <p className="text-sm text-muted-foreground">Loading…</p>;
+  }
+  if (items.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        No recipes use this batch&apos;s ingredient yet.{' '}
+        <a className="underline" href="/food/recipes/new">
+          Try creating one!
+        </a>
+      </p>
+    );
+  }
+  return (
+    <ul className="space-y-1">
+      {items.map((row) => (
+        <RecipeRow key={row.recipeId} row={row} batchUnit={batchUnit} onPick={onPick} />
+      ))}
+    </ul>
+  );
+}
+
+interface RecipeRowProps {
+  row: RecipeForCookRow;
+  batchUnit: BatchUnit | null;
+  onPick: (slug: string) => void;
+}
+
+function RecipeRow({ row, batchUnit, onPick }: RecipeRowProps): ReactElement {
+  const needs = describeNeeds(row.recipeNeedsQty, batchUnit);
+  return (
+    <li>
+      <button
+        type="button"
+        className="block w-full rounded px-3 py-2 text-left hover:bg-accent"
+        onClick={() => onPick(row.recipeSlug)}
+      >
+        <div className="font-medium">{row.title}</div>
+        <div className="text-xs text-muted-foreground">
+          {needs}
+          {row.lastCookedAt !== null && <> · last cooked {row.lastCookedAt.slice(0, 10)}</>}
+        </div>
+      </button>
+    </li>
+  );
+}
+
+function describeNeeds(qty: number | null, unit: BatchUnit | null): string {
+  if (qty === null || unit === null) return 'Needs ~?';
+  return `Needs ~${formatQty(qty, unit)}`;
+}

--- a/packages/app-food/src/pages/fridge/DeleteBatchConfirm.tsx
+++ b/packages/app-food/src/pages/fridge/DeleteBatchConfirm.tsx
@@ -1,8 +1,18 @@
 /**
- * Scaffold for PRD-147's soft-delete confirm dialog. Calls
- * `food.batches.delete` (soft-delete via `deleted_at`, set by PRD-145).
+ * Soft-delete confirm — PRD-147.
+ *
+ * Distinguishes non-empty vs empty batches in the confirm copy. Calls
+ * `food.batches.delete` (PRD-145 soft-delete via `deleted_at`).
  */
-import type { ReactNode } from 'react';
+import { useState, type ReactElement } from 'react';
+
+import { trpc } from '@pops/api-client';
+import { Button, Dialog, DialogContent, DialogHeader, DialogTitle } from '@pops/ui';
+
+import { FormError } from './form-controls.js';
+import { formatQty } from './format.js';
+
+import type { BatchDetail } from '@pops/app-food-db';
 
 export interface DeleteBatchConfirmProps {
   batchId: number | null;
@@ -11,6 +21,95 @@ export interface DeleteBatchConfirmProps {
   onConfirmed?: () => void;
 }
 
-export function DeleteBatchConfirm(_props: DeleteBatchConfirmProps): ReactNode {
-  return null;
+export function DeleteBatchConfirm({
+  batchId,
+  isOpen,
+  onClose,
+  onConfirmed,
+}: DeleteBatchConfirmProps): ReactElement {
+  const utils = trpc.useUtils();
+  const detail = trpc.food.batches.get.useQuery(
+    { id: batchId ?? 0 },
+    { enabled: isOpen && batchId !== null }
+  );
+  const [error, setError] = useState<string | null>(null);
+
+  const deleteMutation = trpc.food.batches.delete.useMutation({
+    onSuccess: (res) => {
+      if (res.ok) {
+        void utils.food.fridge.view.invalidate();
+        onConfirmed?.();
+        onClose();
+      } else {
+        setError(res.reason);
+      }
+    },
+    onError: (err) => setError(err.message),
+  });
+
+  function handleDelete(): void {
+    if (batchId === null) return;
+    setError(null);
+    deleteMutation.mutate({ id: batchId });
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Delete batch?</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-3">
+          <p className="text-sm">
+            {detail.data?.ingredientName} / {detail.data?.variantName ?? '—'}
+          </p>
+          <ConfirmCopy detail={detail.data ?? null} />
+          <FormError message={error} />
+          <DeleteActions
+            onClose={onClose}
+            onDelete={handleDelete}
+            isPending={deleteMutation.isPending}
+          />
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function ConfirmCopy({ detail }: { detail: BatchDetail | null }): ReactElement {
+  if (detail === null) return <p className="text-sm text-muted-foreground">—</p>;
+  if (detail.qtyRemaining === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        This batch is empty. Mark as deleted to hide from the default view.
+      </p>
+    );
+  }
+  return (
+    <p className="text-sm text-muted-foreground">
+      This batch still has {formatQty(detail.qtyRemaining, detail.unit)} remaining. Deleting will
+      mark it as removed from inventory.
+    </p>
+  );
+}
+
+function DeleteActions({
+  onClose,
+  onDelete,
+  isPending,
+}: {
+  onClose: () => void;
+  onDelete: () => void;
+  isPending: boolean;
+}): ReactElement {
+  return (
+    <div className="flex justify-end gap-2 pt-2">
+      <Button type="button" variant="ghost" onClick={onClose} disabled={isPending}>
+        Cancel
+      </Button>
+      <Button variant="destructive" onClick={onDelete} disabled={isPending}>
+        {isPending ? 'Deleting…' : 'Delete'}
+      </Button>
+    </div>
+  );
 }

--- a/packages/app-food/src/pages/fridge/DeleteBatchConfirm.tsx
+++ b/packages/app-food/src/pages/fridge/DeleteBatchConfirm.tsx
@@ -4,7 +4,7 @@
  * Distinguishes non-empty vs empty batches in the confirm copy. Calls
  * `food.batches.delete` (PRD-145 soft-delete via `deleted_at`).
  */
-import { useState, type ReactElement } from 'react';
+import { useEffect, useState, type ReactElement } from 'react';
 
 import { trpc } from '@pops/api-client';
 import { Button, Dialog, DialogContent, DialogHeader, DialogTitle } from '@pops/ui';
@@ -33,6 +33,10 @@ export function DeleteBatchConfirm({
     { enabled: isOpen && batchId !== null }
   );
   const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isOpen) setError(null);
+  }, [isOpen]);
 
   const deleteMutation = trpc.food.batches.delete.useMutation({
     onSuccess: (res) => {

--- a/packages/app-food/src/pages/fridge/EditBatchModal.tsx
+++ b/packages/app-food/src/pages/fridge/EditBatchModal.tsx
@@ -72,13 +72,20 @@ function buildEditPatch(
   prepStateId: number | null | undefined;
 } {
   return {
-    expiresAt:
-      form.expiresAt.length === 0
-        ? null
-        : new Date(`${form.expiresAt}T00:00:00.000Z`).toISOString(),
+    expiresAt: toIsoOrNull(form.expiresAt),
     notes: form.notes.trim().length === 0 ? null : form.notes.trim(),
     prepStateId: resolvePrepStateForPatch(form.prepStateId, isFromRun),
   };
+}
+
+function toIsoOrNull(yyyyMmDd: string): string | null {
+  if (yyyyMmDd.length === 0) return null;
+  // `<input type="date">` should always give us YYYY-MM-DD, but typed values
+  // and browser quirks can produce something `new Date()` rejects. Clear
+  // expiry in that case rather than letting `.toISOString()` throw.
+  const d = new Date(`${yyyyMmDd}T00:00:00.000Z`);
+  if (Number.isNaN(d.getTime())) return null;
+  return d.toISOString();
 }
 
 interface EditFieldsProps {

--- a/packages/app-food/src/pages/fridge/EditBatchModal.tsx
+++ b/packages/app-food/src/pages/fridge/EditBatchModal.tsx
@@ -1,8 +1,15 @@
 /**
- * Scaffold for PRD-147's edit-batch modal. Edits expiry / notes /
- * prep-state. Calls `food.batches.edit` once wired.
+ * Edit batch modal — PRD-147.
+ *
+ * Edits expiry / notes / prepState only. Other fields delegated to
+ * Relocate / Adjust qty per PRD-145's service split.
  */
-import type { ReactNode } from 'react';
+import { type FormEvent, type ReactElement } from 'react';
+
+import { Button, Dialog, DialogContent, DialogHeader, DialogTitle, Input } from '@pops/ui';
+
+import { FieldRow, FormError } from './form-controls.js';
+import { type EditState, useEditBatchState } from './useEditBatchState.js';
 
 export interface EditBatchModalProps {
   batchId: number | null;
@@ -10,6 +17,134 @@ export interface EditBatchModalProps {
   onClose: () => void;
 }
 
-export function EditBatchModal(_props: EditBatchModalProps): ReactNode {
-  return null;
+export function EditBatchModal({ batchId, isOpen, onClose }: EditBatchModalProps): ReactElement {
+  const state = useEditBatchState({ batchId, isOpen, onClose });
+
+  function handleSubmit(e: FormEvent): void {
+    e.preventDefault();
+    if (batchId === null) return;
+    state.setError(null);
+    state.editMutation.mutate({
+      id: batchId,
+      ...buildEditPatch(state.form, state.isFromRun),
+    });
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Edit batch</DialogTitle>
+        </DialogHeader>
+        <form className="space-y-3" onSubmit={handleSubmit}>
+          <p className="text-sm text-muted-foreground">
+            {state.detail.data?.ingredientName} / {state.detail.data?.variantName ?? '—'}
+          </p>
+          <EditFields
+            form={state.form}
+            setForm={state.setForm}
+            isFromRun={state.isFromRun}
+            prepStates={state.prepStates.data?.items ?? []}
+          />
+          <FormError message={state.error} />
+          <ModalActions onClose={onClose} isPending={state.editMutation.isPending} />
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function resolvePrepStateForPatch(
+  prepStateId: string,
+  isFromRun: boolean
+): number | null | undefined {
+  if (isFromRun) return undefined;
+  if (prepStateId.length === 0) return null;
+  return Number(prepStateId);
+}
+
+function buildEditPatch(
+  form: EditState,
+  isFromRun: boolean
+): {
+  expiresAt: string | null;
+  notes: string | null;
+  prepStateId: number | null | undefined;
+} {
+  return {
+    expiresAt:
+      form.expiresAt.length === 0
+        ? null
+        : new Date(`${form.expiresAt}T00:00:00.000Z`).toISOString(),
+    notes: form.notes.trim().length === 0 ? null : form.notes.trim(),
+    prepStateId: resolvePrepStateForPatch(form.prepStateId, isFromRun),
+  };
+}
+
+interface EditFieldsProps {
+  form: EditState;
+  setForm: (next: EditState) => void;
+  isFromRun: boolean;
+  prepStates: readonly { id: number; name: string }[];
+}
+
+function EditFields({ form, setForm, isFromRun, prepStates }: EditFieldsProps): ReactElement {
+  return (
+    <>
+      <FieldRow label="Expires">
+        <Input
+          type="date"
+          value={form.expiresAt}
+          onChange={(e) => setForm({ ...form, expiresAt: e.target.value })}
+        />
+      </FieldRow>
+      <FieldRow label="Prep state">
+        <select
+          className="w-full rounded border bg-background px-2 py-1"
+          value={form.prepStateId}
+          onChange={(e) => setForm({ ...form, prepStateId: e.target.value })}
+          disabled={isFromRun}
+        >
+          <option value="">— none —</option>
+          {prepStates.map((p) => (
+            <option key={p.id} value={String(p.id)}>
+              {p.name}
+            </option>
+          ))}
+        </select>
+        {isFromRun && (
+          <span className="text-xs text-muted-foreground">
+            Cook-yielded batches keep their original prep state.
+          </span>
+        )}
+      </FieldRow>
+      <FieldRow label="Notes">
+        <textarea
+          className="min-h-[60px] w-full rounded border bg-background px-2 py-1"
+          maxLength={500}
+          value={form.notes}
+          onChange={(e) => setForm({ ...form, notes: e.target.value })}
+        />
+      </FieldRow>
+    </>
+  );
+}
+
+function ModalActions({
+  onClose,
+  isPending,
+}: {
+  onClose: () => void;
+  isPending: boolean;
+}): ReactElement {
+  return (
+    <div className="flex justify-end gap-2 pt-2">
+      <Button type="button" variant="ghost" onClick={onClose} disabled={isPending}>
+        Cancel
+      </Button>
+      <Button type="submit" disabled={isPending}>
+        {isPending ? 'Saving…' : 'Save'}
+      </Button>
+    </div>
+  );
 }

--- a/packages/app-food/src/pages/fridge/FridgeFilterBar.tsx
+++ b/packages/app-food/src/pages/fridge/FridgeFilterBar.tsx
@@ -1,0 +1,121 @@
+/**
+ * Header filter row for the FridgePage — PRD-147.
+ *
+ * Hosts the search box, location chips, expiring-soon / yielded-only
+ * toggles, and the "show all" reveal for empty + soft-deleted batches.
+ */
+import { type ReactElement } from 'react';
+
+import { Input } from '@pops/ui';
+
+import type { BatchLocation } from '@pops/app-food-db';
+
+import type { FridgeFilterState } from './useFridgeView.js';
+
+const LOCATION_LABELS: Record<BatchLocation, string> = {
+  pantry: 'Pantry',
+  fridge: 'Fridge',
+  freezer: 'Freezer',
+  other: 'Other',
+};
+
+interface FridgeFilterBarProps {
+  filters: FridgeFilterState;
+  onChange: (next: FridgeFilterState) => void;
+  hiddenCount: number;
+}
+
+export function FridgeFilterBar({
+  filters,
+  onChange,
+  hiddenCount,
+}: FridgeFilterBarProps): ReactElement {
+  const showAllAvailable = hiddenCount > 0 && !filters.showAll;
+  return (
+    <div className="flex flex-wrap items-center gap-2 rounded-md border bg-muted/30 p-3 text-sm">
+      <Input
+        type="search"
+        value={filters.search}
+        placeholder="Search by ingredient or variant"
+        className="min-w-[200px] flex-1"
+        onChange={(e) => onChange({ ...filters, search: e.target.value })}
+      />
+      <LocationChips filters={filters} onChange={onChange} />
+      <ChipToggle
+        label="Expiring soon"
+        active={filters.expiringSoon}
+        onToggle={() => onChange({ ...filters, expiringSoon: !filters.expiringSoon })}
+      />
+      <ChipToggle
+        label="Recipe-yielded"
+        active={filters.recipeYieldedOnly}
+        onToggle={() => onChange({ ...filters, recipeYieldedOnly: !filters.recipeYieldedOnly })}
+      />
+      {showAllAvailable && (
+        <button
+          type="button"
+          className="text-xs underline"
+          onClick={() => onChange({ ...filters, showAll: true })}
+        >
+          Show {hiddenCount} hidden
+        </button>
+      )}
+      {filters.showAll && (
+        <button
+          type="button"
+          className="text-xs underline"
+          onClick={() => onChange({ ...filters, showAll: false })}
+        >
+          Hide empty + deleted
+        </button>
+      )}
+    </div>
+  );
+}
+
+interface LocationChipsProps {
+  filters: FridgeFilterState;
+  onChange: (next: FridgeFilterState) => void;
+}
+
+function LocationChips({ filters, onChange }: LocationChipsProps): ReactElement {
+  function toggle(loc: BatchLocation): void {
+    const next = filters.locations.includes(loc)
+      ? filters.locations.filter((l) => l !== loc)
+      : [...filters.locations, loc];
+    onChange({ ...filters, locations: next });
+  }
+  return (
+    <div className="flex flex-wrap gap-1">
+      {(Object.keys(LOCATION_LABELS) as BatchLocation[]).map((loc) => (
+        <ChipToggle
+          key={loc}
+          label={LOCATION_LABELS[loc]}
+          active={filters.locations.includes(loc)}
+          onToggle={() => toggle(loc)}
+        />
+      ))}
+    </div>
+  );
+}
+
+interface ChipToggleProps {
+  label: string;
+  active: boolean;
+  onToggle: () => void;
+}
+
+function ChipToggle({ label, active, onToggle }: ChipToggleProps): ReactElement {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-pressed={active}
+      className={`rounded-full border px-3 py-1 text-xs ${
+        active ? 'border-primary bg-primary text-primary-foreground' : 'border-border'
+      }`}
+    >
+      {label}
+    </button>
+  );
+}

--- a/packages/app-food/src/pages/fridge/FridgePage.tsx
+++ b/packages/app-food/src/pages/fridge/FridgePage.tsx
@@ -6,6 +6,14 @@
  * Cook / Delete actions delegate to PRD-145's `food.batches.*`
  * services. The filter / search / show-all controls feed
  * `food.fridge.view`.
+ *
+ * Deferred from v1:
+ *   - URL-driven state (`?showAll=1`, `?add=1`, `?edit=<id>`, `?batch=<id>`
+ *     scroll + highlight). Filter / modal state is local-only for now; a
+ *     follow-up will sync to `useSearchParams` once the deep-link UX is
+ *     designed (auto-expand showAll, auto-scroll target, pulse).
+ *   - Sidebar badge for batches expiring within 3 days.
+ *   - Mobile bottom-sheet modal variants.
  */
 import { useEffect, useState, type ReactElement } from 'react';
 

--- a/packages/app-food/src/pages/fridge/FridgePage.tsx
+++ b/packages/app-food/src/pages/fridge/FridgePage.tsx
@@ -1,11 +1,197 @@
 /**
- * Scaffold for PRD-147's fridge view — routed at `/food/fridge`.
+ * PRD-147 — `/food/fridge` page.
  *
- * Returns the placeholder shell until PRD-147 ships the sectioned list
- * + filter chips + add/edit/relocate/adjust/delete modals.
+ * Sectioned list of every non-empty, non-deleted batch grouped by
+ * location, then ingredient. Row-level Edit / Relocate / Adjust /
+ * Cook / Delete actions delegate to PRD-145's `food.batches.*`
+ * services. The filter / search / show-all controls feed
+ * `food.fridge.view`.
  */
-import type { ReactNode } from 'react';
+import { useEffect, useState, type ReactElement } from 'react';
 
-export function FridgePage(): ReactNode {
-  return null;
+import { Button, useDebouncedValue } from '@pops/ui';
+
+import { AddBatchModal } from './AddBatchModal.js';
+import { AdjustQtyModal } from './AdjustQtyModal.js';
+import { type BatchAction } from './BatchRow.js';
+import { loadCollapsed, saveCollapsed } from './collapsed-storage.js';
+import { CookNowPicker } from './CookNowPicker.js';
+import { DeleteBatchConfirm } from './DeleteBatchConfirm.js';
+import { EditBatchModal } from './EditBatchModal.js';
+import { FridgeFilterBar } from './FridgeFilterBar.js';
+import { LocationSectionView } from './LocationSection.js';
+import { RelocateBatchModal } from './RelocateBatchModal.js';
+import { DEFAULT_FRIDGE_FILTERS, type FridgeFilterState, useFridgeView } from './useFridgeView.js';
+
+import type { BatchLocation, BatchUnit, FridgeView } from '@pops/app-food-db';
+
+const SEARCH_DEBOUNCE_MS = 200;
+
+interface ActiveModal {
+  kind: 'edit' | 'relocate' | 'adjust' | 'delete' | 'cook';
+  batchId: number;
+  unit: BatchUnit | null;
 }
+
+export function FridgePage(): ReactElement {
+  const [filters, setFilters] = useState<FridgeFilterState>({ ...DEFAULT_FRIDGE_FILTERS });
+  const debouncedSearch = useDebouncedValue(filters.search, SEARCH_DEBOUNCE_MS);
+  const fridge = useFridgeView({ filters, debouncedSearch });
+
+  const [addOpen, setAddOpen] = useState(false);
+  const [active, setActive] = useState<ActiveModal | null>(null);
+  const [collapsed, setCollapsed] = useState<ReadonlySet<BatchLocation>>(() => loadCollapsed());
+
+  useEffect(() => {
+    saveCollapsed(collapsed);
+  }, [collapsed]);
+
+  function toggleCollapsed(loc: BatchLocation): void {
+    setCollapsed((prev) => {
+      const next = new Set(prev);
+      if (next.has(loc)) next.delete(loc);
+      else next.add(loc);
+      return next;
+    });
+  }
+
+  function handleAction(action: BatchAction, batchId: number, unit: BatchUnit): void {
+    setActive({ kind: action, batchId, unit });
+  }
+
+  return (
+    <div className="space-y-4 p-6">
+      <header className="flex flex-wrap items-center justify-between gap-3">
+        <h1 className="text-3xl font-bold tracking-tight">Fridge</h1>
+        <Button onClick={() => setAddOpen(true)}>+ Add batch</Button>
+      </header>
+
+      <FridgeFilterBar
+        filters={filters}
+        onChange={setFilters}
+        hiddenCount={(fridge.data?.counts.empty ?? 0) + (fridge.data?.counts.deleted ?? 0)}
+      />
+
+      <FridgeBody
+        fridge={fridge}
+        showAll={filters.showAll}
+        collapsed={collapsed}
+        toggleCollapsed={toggleCollapsed}
+        onAction={handleAction}
+      />
+
+      <ModalHost
+        addOpen={addOpen}
+        active={active}
+        onCloseAdd={() => setAddOpen(false)}
+        onCloseActive={() => setActive(null)}
+      />
+    </div>
+  );
+}
+
+interface FridgeBodyProps {
+  fridge: ReturnType<typeof useFridgeView>;
+  showAll: boolean;
+  collapsed: ReadonlySet<BatchLocation>;
+  toggleCollapsed: (loc: BatchLocation) => void;
+  onAction: (action: BatchAction, batchId: number, unit: BatchUnit) => void;
+}
+
+function FridgeBody({
+  fridge,
+  showAll,
+  collapsed,
+  toggleCollapsed,
+  onAction,
+}: FridgeBodyProps): ReactElement {
+  if (fridge.error !== null) {
+    return (
+      <p
+        role="alert"
+        className="rounded border border-destructive/50 bg-destructive/10 p-3 text-sm"
+      >
+        Couldn&apos;t load the fridge: {fridge.error.message}
+      </p>
+    );
+  }
+  if (fridge.isLoading) {
+    return (
+      <p role="status" className="text-sm text-muted-foreground">
+        Loading…
+      </p>
+    );
+  }
+  const counts = fridge.data?.counts ?? { visible: 0, empty: 0, deleted: 0 };
+  if (counts.visible === 0 && !showAll) return <EmptyState />;
+
+  return (
+    <div className="space-y-4">
+      {(fridge.data?.sections ?? []).map((section) => (
+        <LocationSectionView
+          key={section.location}
+          section={section}
+          collapsed={collapsed.has(section.location)}
+          onToggle={() => toggleCollapsed(section.location)}
+          onAction={onAction}
+        />
+      ))}
+    </div>
+  );
+}
+
+interface ModalHostProps {
+  addOpen: boolean;
+  active: ActiveModal | null;
+  onCloseAdd: () => void;
+  onCloseActive: () => void;
+}
+
+function ModalHost({ addOpen, active, onCloseAdd, onCloseActive }: ModalHostProps): ReactElement {
+  const target = (kind: ActiveModal['kind']): number | null =>
+    active?.kind === kind ? active.batchId : null;
+  return (
+    <>
+      <AddBatchModal isOpen={addOpen} onClose={onCloseAdd} />
+      <EditBatchModal
+        batchId={target('edit')}
+        isOpen={active?.kind === 'edit'}
+        onClose={onCloseActive}
+      />
+      <RelocateBatchModal
+        batchId={target('relocate')}
+        isOpen={active?.kind === 'relocate'}
+        onClose={onCloseActive}
+      />
+      <AdjustQtyModal
+        batchId={target('adjust')}
+        isOpen={active?.kind === 'adjust'}
+        onClose={onCloseActive}
+      />
+      <DeleteBatchConfirm
+        batchId={target('delete')}
+        isOpen={active?.kind === 'delete'}
+        onClose={onCloseActive}
+      />
+      <CookNowPicker
+        batchId={target('cook')}
+        batchUnit={active?.kind === 'cook' ? active.unit : null}
+        isOpen={active?.kind === 'cook'}
+        onClose={onCloseActive}
+      />
+    </>
+  );
+}
+
+function EmptyState(): ReactElement {
+  return (
+    <div className="rounded-md border border-dashed p-10 text-center">
+      <p className="text-sm">
+        Nothing in the fridge yet. Click <strong>+ Add batch</strong> or cook a recipe to fill it.
+      </p>
+    </div>
+  );
+}
+
+// Re-export the view type to keep test fixtures self-contained.
+export type { FridgeView };

--- a/packages/app-food/src/pages/fridge/LocationSection.tsx
+++ b/packages/app-food/src/pages/fridge/LocationSection.tsx
@@ -1,0 +1,66 @@
+/**
+ * A single location section (Pantry / Fridge / Freezer / Other) — PRD-147.
+ *
+ * Collapsible header + per-ingredient sub-groups of batch rows.
+ */
+import { type ReactElement } from 'react';
+
+import { BatchRow, type BatchAction } from './BatchRow.js';
+
+import type { BatchLocation, BatchUnit, FridgeLocationSection } from '@pops/app-food-db';
+
+const LOCATION_LABELS: Record<BatchLocation, string> = {
+  pantry: 'Pantry',
+  fridge: 'Fridge',
+  freezer: 'Freezer',
+  other: 'Other',
+};
+
+interface LocationSectionViewProps {
+  section: FridgeLocationSection;
+  collapsed: boolean;
+  onToggle: () => void;
+  onAction: (action: BatchAction, batchId: number, unit: BatchUnit) => void;
+}
+
+export function LocationSectionView({
+  section,
+  collapsed,
+  onToggle,
+  onAction,
+}: LocationSectionViewProps): ReactElement {
+  return (
+    <section aria-labelledby={`fridge-section-${section.location}`}>
+      <button
+        type="button"
+        className="flex w-full items-center gap-2 border-b py-1 text-left text-sm font-semibold"
+        onClick={onToggle}
+        aria-expanded={!collapsed}
+      >
+        <span aria-hidden="true">{collapsed ? '▸' : '▾'}</span>
+        <span id={`fridge-section-${section.location}`}>
+          {LOCATION_LABELS[section.location]} ({section.count})
+        </span>
+      </button>
+      {!collapsed && section.ingredients.length > 0 && (
+        <ul className="space-y-3 pt-2">
+          {section.ingredients.map((group) => (
+            <li key={group.ingredientId} className="space-y-1">
+              <h3 className="text-xs font-medium text-muted-foreground">{group.ingredientName}</h3>
+              <ul className="space-y-1">
+                {group.batches.map((batch) => (
+                  <BatchRow
+                    key={batch.id}
+                    batch={batch}
+                    ingredientName={group.ingredientName}
+                    onAction={(action, id) => onAction(action, id, batch.unit)}
+                  />
+                ))}
+              </ul>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/packages/app-food/src/pages/fridge/RelocateBatchModal.tsx
+++ b/packages/app-food/src/pages/fridge/RelocateBatchModal.tsx
@@ -1,8 +1,25 @@
 /**
- * Scaffold for PRD-147's relocate modal — moves a batch between
- * pantry / fridge / freezer / other. Calls `food.batches.relocate`.
+ * Relocate batch modal — PRD-147.
+ *
+ * Single-field modal: pick a new location and call
+ * `food.batches.relocate`. The service recomputes default expiry when
+ * the user hasn't overridden it (PRD-145).
  */
-import type { ReactNode } from 'react';
+import { useEffect, useState, type ReactElement } from 'react';
+
+import { trpc } from '@pops/api-client';
+import { Button, Dialog, DialogContent, DialogHeader, DialogTitle } from '@pops/ui';
+
+import { FormError } from './form-controls.js';
+
+import type { BatchLocation } from '@pops/app-food-db';
+
+const LOCATIONS: { value: BatchLocation; label: string }[] = [
+  { value: 'pantry', label: 'Pantry' },
+  { value: 'fridge', label: 'Fridge' },
+  { value: 'freezer', label: 'Freezer' },
+  { value: 'other', label: 'Other' },
+];
 
 export interface RelocateBatchModalProps {
   batchId: number | null;
@@ -10,6 +27,108 @@ export interface RelocateBatchModalProps {
   onClose: () => void;
 }
 
-export function RelocateBatchModal(_props: RelocateBatchModalProps): ReactNode {
-  return null;
+export function RelocateBatchModal({
+  batchId,
+  isOpen,
+  onClose,
+}: RelocateBatchModalProps): ReactElement {
+  const utils = trpc.useUtils();
+  const detail = trpc.food.batches.get.useQuery(
+    { id: batchId ?? 0 },
+    { enabled: isOpen && batchId !== null }
+  );
+  const [location, setLocation] = useState<BatchLocation>('fridge');
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (detail.data !== null && detail.data !== undefined) {
+      setLocation(detail.data.location);
+    } else if (!isOpen) {
+      setError(null);
+    }
+  }, [detail.data, isOpen]);
+
+  const relocateMutation = trpc.food.batches.relocate.useMutation({
+    onSuccess: (res) => {
+      if (res.ok) {
+        void utils.food.fridge.view.invalidate();
+        onClose();
+      } else {
+        setError(res.reason);
+      }
+    },
+    onError: (err) => setError(err.message),
+  });
+
+  function handleSave(): void {
+    if (batchId === null) return;
+    setError(null);
+    relocateMutation.mutate({ id: batchId, location });
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Relocate batch</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-3">
+          <p className="text-sm text-muted-foreground">
+            {detail.data?.ingredientName} / {detail.data?.variantName ?? '—'}
+          </p>
+          <LocationRadios value={location} onChange={setLocation} />
+          <FormError message={error} />
+          <ModalActions
+            onCancel={onClose}
+            onSave={handleSave}
+            isPending={relocateMutation.isPending}
+          />
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function LocationRadios({
+  value,
+  onChange,
+}: {
+  value: BatchLocation;
+  onChange: (loc: BatchLocation) => void;
+}): ReactElement {
+  return (
+    <div className="space-y-2">
+      {LOCATIONS.map((opt) => (
+        <label key={opt.value} className="flex items-center gap-2 text-sm">
+          <input
+            type="radio"
+            name="relocate-location"
+            value={opt.value}
+            checked={value === opt.value}
+            onChange={() => onChange(opt.value)}
+          />
+          {opt.label}
+        </label>
+      ))}
+    </div>
+  );
+}
+
+interface ModalActionsProps {
+  onCancel: () => void;
+  onSave: () => void;
+  isPending: boolean;
+}
+
+function ModalActions({ onCancel, onSave, isPending }: ModalActionsProps): ReactElement {
+  return (
+    <div className="flex justify-end gap-2 pt-2">
+      <Button type="button" variant="ghost" onClick={onCancel} disabled={isPending}>
+        Cancel
+      </Button>
+      <Button onClick={onSave} disabled={isPending}>
+        {isPending ? 'Saving…' : 'Save'}
+      </Button>
+    </div>
+  );
 }

--- a/packages/app-food/src/pages/fridge/__tests__/FridgePage.test.tsx
+++ b/packages/app-food/src/pages/fridge/__tests__/FridgePage.test.tsx
@@ -1,0 +1,179 @@
+/**
+ * RTL coverage for FridgePage — PRD-147.
+ *
+ * Asserts the header renders, the empty state shows when there are no
+ * batches, and a populated view renders sections with batch rows.
+ * Heavier behavioural coverage (mutation flows, modal validation) lives
+ * in the per-modal tests and the API integration tests.
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createInstance } from 'i18next';
+import { useMemo, type ReactElement } from 'react';
+import { I18nextProvider, initReactI18next } from 'react-i18next';
+import { MemoryRouter } from 'react-router';
+import { describe, expect, it, vi } from 'vitest';
+
+import enAUFood from '../../../../../../apps/pops-shell/src/i18n/locales/en-AU/food.json';
+
+import type { FridgeView } from '@pops/app-food-db';
+
+const mockViewQuery = vi.fn();
+
+vi.mock('@pops/api-client', () => ({
+  trpc: {
+    useUtils: () => ({
+      food: { fridge: { view: { invalidate: vi.fn() } } },
+    }),
+    food: {
+      fridge: {
+        view: { useQuery: () => mockViewQuery() },
+        recipesUsingBatch: { useQuery: () => ({ data: { items: [] }, isLoading: false }) },
+      },
+      ingredients: {
+        list: { useQuery: () => ({ data: { items: [] } }) },
+        get: { useQuery: () => ({ data: undefined }) },
+      },
+      prepStates: { list: { useQuery: () => ({ data: { items: [] } }) } },
+      batches: {
+        get: { useQuery: () => ({ data: null }) },
+        create: {
+          useMutation: () => ({ mutate: vi.fn(), isPending: false }),
+        },
+        edit: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
+        relocate: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
+        adjustQty: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
+        delete: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
+      },
+    },
+  },
+}));
+
+import { FridgePage } from '../FridgePage.js';
+
+function Wrapper({ children }: { children: ReactElement }): ReactElement {
+  const i18n = useMemo(() => {
+    const instance = createInstance();
+    void instance.use(initReactI18next).init({
+      lng: 'en-AU',
+      fallbackLng: 'en-AU',
+      ns: ['food'],
+      defaultNS: 'food',
+      interpolation: { escapeValue: false },
+      resources: { 'en-AU': { food: enAUFood } },
+    });
+    return instance;
+  }, []);
+  return (
+    <I18nextProvider i18n={i18n}>
+      <MemoryRouter>{children}</MemoryRouter>
+    </I18nextProvider>
+  );
+}
+
+function emptyView(): FridgeView {
+  return {
+    sections: [
+      { location: 'pantry', count: 0, ingredients: [] },
+      { location: 'fridge', count: 0, ingredients: [] },
+      { location: 'freezer', count: 0, ingredients: [] },
+      { location: 'other', count: 0, ingredients: [] },
+    ],
+    counts: { visible: 0, empty: 0, deleted: 0 },
+  };
+}
+
+function viewWithOneTomato(): FridgeView {
+  return {
+    sections: [
+      { location: 'pantry', count: 0, ingredients: [] },
+      {
+        location: 'fridge',
+        count: 1,
+        ingredients: [
+          {
+            ingredientId: 1,
+            ingredientName: 'Tomato',
+            ingredientSlug: 'tomato',
+            batches: [
+              {
+                id: 100,
+                variantName: 'Diced',
+                variantSlug: 'diced',
+                prepStateLabel: null,
+                qtyRemaining: 200,
+                unit: 'g',
+                expiresAt: '2026-06-15T00:00:00.000Z',
+                daysToExpiry: 5,
+                producedAt: '2026-06-08T00:00:00.000Z',
+                sourceType: 'purchase',
+                sourceRecipeSlug: null,
+                notes: null,
+                deletedAt: null,
+              },
+            ],
+          },
+        ],
+      },
+      { location: 'freezer', count: 0, ingredients: [] },
+      { location: 'other', count: 0, ingredients: [] },
+    ],
+    counts: { visible: 1, empty: 0, deleted: 0 },
+  };
+}
+
+describe('FridgePage — PRD-147', () => {
+  it('renders the heading and the Add batch button', () => {
+    mockViewQuery.mockReturnValue({ data: emptyView(), isLoading: false, error: null });
+    render(
+      <Wrapper>
+        <FridgePage />
+      </Wrapper>
+    );
+    expect(screen.getByRole('heading', { name: /fridge/i, level: 1 })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /\+ add batch/i })).toBeInTheDocument();
+  });
+
+  it('shows the empty state when no visible batches', () => {
+    mockViewQuery.mockReturnValue({ data: emptyView(), isLoading: false, error: null });
+    render(
+      <Wrapper>
+        <FridgePage />
+      </Wrapper>
+    );
+    expect(screen.getByText(/nothing in the fridge yet/i)).toBeInTheDocument();
+  });
+
+  it('renders sections with batch rows when data is present', () => {
+    mockViewQuery.mockReturnValue({
+      data: viewWithOneTomato(),
+      isLoading: false,
+      error: null,
+    });
+    render(
+      <Wrapper>
+        <FridgePage />
+      </Wrapper>
+    );
+    expect(screen.getByRole('button', { name: /fridge \(1\)/i })).toBeInTheDocument();
+    expect(screen.getByText(/Tomato \/ Diced/)).toBeInTheDocument();
+    expect(screen.getByText(/200 g/)).toBeInTheDocument();
+  });
+
+  it('toggles a location section', async () => {
+    mockViewQuery.mockReturnValue({
+      data: viewWithOneTomato(),
+      isLoading: false,
+      error: null,
+    });
+    const user = userEvent.setup();
+    render(
+      <Wrapper>
+        <FridgePage />
+      </Wrapper>
+    );
+    const toggle = screen.getByRole('button', { name: /fridge \(1\)/i });
+    await user.click(toggle);
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+  });
+});

--- a/packages/app-food/src/pages/fridge/__tests__/format.test.ts
+++ b/packages/app-food/src/pages/fridge/__tests__/format.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Unit tests for the fridge display formatters.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { formatExpiry, formatQty, urgencyFor } from '../format.js';
+
+describe('formatQty', () => {
+  it('formats >=1000g as kg', () => {
+    expect(formatQty(1200, 'g')).toBe('1.2 kg');
+    expect(formatQty(1000, 'g')).toBe('1 kg');
+  });
+  it('formats <1000g as g', () => {
+    expect(formatQty(200, 'g')).toBe('200 g');
+  });
+  it('formats ml at >=1000 as L', () => {
+    expect(formatQty(1500, 'ml')).toBe('1.5 L');
+  });
+  it('formats count', () => {
+    expect(formatQty(3, 'count')).toBe('3 ct');
+    expect(formatQty(2.5, 'count')).toBe('2.5 ct');
+  });
+});
+
+describe('formatExpiry', () => {
+  it('returns em-dash for null expiry', () => {
+    expect(formatExpiry(null, null)).toBe('—');
+  });
+  it('describes future expiry in days', () => {
+    expect(formatExpiry('2026-06-15T00:00:00.000Z', 5)).toContain('in 5d');
+  });
+  it('describes past expiry', () => {
+    expect(formatExpiry('2026-06-05T00:00:00.000Z', -3)).toContain('expired 3d ago');
+  });
+  it('says today for zero', () => {
+    expect(formatExpiry('2026-06-10T00:00:00.000Z', 0)).toContain('(today)');
+  });
+});
+
+describe('urgencyFor', () => {
+  it('unknown for null', () => {
+    expect(urgencyFor(null)).toBe('unknown');
+  });
+  it('expired for negative', () => {
+    expect(urgencyFor(-1)).toBe('expired');
+  });
+  it('soon for 0..3', () => {
+    expect(urgencyFor(0)).toBe('soon');
+    expect(urgencyFor(3)).toBe('soon');
+  });
+  it('normal for >3', () => {
+    expect(urgencyFor(4)).toBe('normal');
+  });
+});

--- a/packages/app-food/src/pages/fridge/collapsed-storage.ts
+++ b/packages/app-food/src/pages/fridge/collapsed-storage.ts
@@ -1,0 +1,33 @@
+/**
+ * localStorage persistence for the per-location collapse state. The
+ * key is versioned (`.v1`) so a future schema change can migrate.
+ */
+import type { BatchLocation } from '@pops/app-food-db';
+
+const STORAGE_KEY = 'fridge.collapsed-locations.v1';
+
+function isBatchLocation(v: unknown): v is BatchLocation {
+  return v === 'pantry' || v === 'fridge' || v === 'freezer' || v === 'other';
+}
+
+export function loadCollapsed(): Set<BatchLocation> {
+  if (typeof window === 'undefined') return new Set();
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (raw === null) return new Set();
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return new Set();
+    return new Set(parsed.filter(isBatchLocation));
+  } catch {
+    return new Set();
+  }
+}
+
+export function saveCollapsed(collapsed: ReadonlySet<BatchLocation>): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify([...collapsed]));
+  } catch {
+    // Storage may be unavailable (private browsing); silently ignore.
+  }
+}

--- a/packages/app-food/src/pages/fridge/form-controls.tsx
+++ b/packages/app-food/src/pages/fridge/form-controls.tsx
@@ -1,0 +1,69 @@
+import { Label } from '@pops/ui';
+
+/**
+ * Small form controls shared by the fridge modals — keeps the modal
+ * bodies under the lint-enforced `max-lines-per-function` budget.
+ */
+import type { ReactElement, ReactNode } from 'react';
+
+export function FieldRow({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}): ReactElement {
+  return (
+    <Label className="block space-y-1 text-xs">
+      <span className="text-muted-foreground">{label}</span>
+      {children}
+    </Label>
+  );
+}
+
+export interface RadioOption {
+  value: string;
+  label: string;
+}
+
+interface RadioRowProps {
+  name: string;
+  value: string;
+  options: readonly RadioOption[];
+  onChange: (value: string) => void;
+}
+
+export function RadioRow({ name, value, options, onChange }: RadioRowProps): ReactElement {
+  return (
+    <div className="flex flex-wrap gap-3 text-sm">
+      {options.map((o) => (
+        <label key={o.value} className="flex items-center gap-1">
+          <input
+            type="radio"
+            name={name}
+            value={o.value}
+            checked={value === o.value}
+            onChange={() => onChange(o.value)}
+          />
+          {o.label}
+        </label>
+      ))}
+    </div>
+  );
+}
+
+export function FormError({ message }: { message: string | null }): ReactElement | null {
+  if (message === null) return null;
+  return (
+    <p role="alert" className="text-sm text-destructive">
+      {message}
+    </p>
+  );
+}
+
+export function toIsoFromDateInput(yyyyMmDd: string): string | undefined {
+  if (yyyyMmDd.length === 0) return undefined;
+  const d = new Date(`${yyyyMmDd}T00:00:00.000Z`);
+  if (Number.isNaN(d.getTime())) return undefined;
+  return d.toISOString();
+}

--- a/packages/app-food/src/pages/fridge/format.ts
+++ b/packages/app-food/src/pages/fridge/format.ts
@@ -20,7 +20,14 @@ export function formatQty(qty: number, unit: BatchUnit): string {
 export function formatExpiry(expiresAt: string | null, daysToExpiry: number | null): string {
   if (expiresAt === null) return '—';
   const date = new Date(expiresAt);
-  const formatted = date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  // PRD-147 — date-only stamps come back as UTC midnight. We render in UTC
+  // so the visible day matches `daysToExpiry` (which is also UTC-anchored);
+  // showing the local-tz day would skew by one in negative offsets.
+  const formatted = date.toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    timeZone: 'UTC',
+  });
   if (daysToExpiry === null) return `Exp ${formatted}`;
   if (daysToExpiry === 0) return `Exp ${formatted} (today)`;
   if (daysToExpiry > 0) return `Exp ${formatted} (in ${daysToExpiry}d)`;

--- a/packages/app-food/src/pages/fridge/format.ts
+++ b/packages/app-food/src/pages/fridge/format.ts
@@ -1,0 +1,37 @@
+/**
+ * Display formatters for fridge rows — qty + expiry strings.
+ */
+
+import type { BatchUnit } from '@pops/app-food-db';
+
+export function formatQty(qty: number, unit: BatchUnit): string {
+  if (unit === 'count') {
+    const n = Math.round(qty * 100) / 100;
+    return `${n} ct`;
+  }
+  if (qty >= 1000) {
+    const kilo = Math.round((qty / 1000) * 100) / 100;
+    return `${kilo} ${unit === 'g' ? 'kg' : 'L'}`;
+  }
+  const n = Math.round(qty * 100) / 100;
+  return `${n} ${unit}`;
+}
+
+export function formatExpiry(expiresAt: string | null, daysToExpiry: number | null): string {
+  if (expiresAt === null) return '—';
+  const date = new Date(expiresAt);
+  const formatted = date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  if (daysToExpiry === null) return `Exp ${formatted}`;
+  if (daysToExpiry === 0) return `Exp ${formatted} (today)`;
+  if (daysToExpiry > 0) return `Exp ${formatted} (in ${daysToExpiry}d)`;
+  return `Exp ${formatted} (expired ${-daysToExpiry}d ago)`;
+}
+
+export type ExpiryUrgency = 'expired' | 'soon' | 'normal' | 'unknown';
+
+export function urgencyFor(daysToExpiry: number | null): ExpiryUrgency {
+  if (daysToExpiry === null) return 'unknown';
+  if (daysToExpiry < 0) return 'expired';
+  if (daysToExpiry <= 3) return 'soon';
+  return 'normal';
+}

--- a/packages/app-food/src/pages/fridge/useAddBatchForm.ts
+++ b/packages/app-food/src/pages/fridge/useAddBatchForm.ts
@@ -1,0 +1,136 @@
+/**
+ * State + mutation hook for the "+ Add batch" modal.
+ *
+ * Owns the form state and the `food.batches.create` mutation; the modal
+ * component renders the JSX. Splitting like this keeps each function
+ * under the `max-lines-per-function` budget.
+ */
+import { useEffect, useState } from 'react';
+
+import { trpc } from '@pops/api-client';
+
+import { toIsoFromDateInput } from './form-controls.js';
+
+import type { BatchLocation, BatchUnit, ManualBatchSourceType } from '@pops/app-food-db';
+
+export interface AddBatchFormState {
+  ingredientId: string;
+  variantId: string;
+  prepStateId: string;
+  qty: string;
+  unit: BatchUnit;
+  sourceType: ManualBatchSourceType;
+  location: BatchLocation;
+  producedAt: string;
+  expiresAt: string;
+  notes: string;
+  search: string;
+}
+
+interface CreateBatchInput {
+  variantId: number;
+  prepStateId: number | null;
+  qty: number;
+  unit: BatchUnit;
+  location: BatchLocation;
+  sourceType: ManualBatchSourceType;
+  producedAt: string | undefined;
+  expiresAt: string | undefined;
+  notes: string | undefined;
+}
+
+function parseCreateInput(form: AddBatchFormState): CreateBatchInput | string {
+  const variantId = Number(form.variantId);
+  const qty = Number(form.qty);
+  if (!Number.isFinite(variantId) || variantId <= 0) return 'Pick an ingredient variant.';
+  if (!Number.isFinite(qty) || qty < 0) return 'Quantity must be a non-negative number.';
+  const trimmedNotes = form.notes.trim();
+  return {
+    variantId,
+    prepStateId: form.prepStateId.length > 0 ? Number(form.prepStateId) : null,
+    qty,
+    unit: form.unit,
+    location: form.location,
+    sourceType: form.sourceType,
+    producedAt: toIsoFromDateInput(form.producedAt),
+    expiresAt: toIsoFromDateInput(form.expiresAt),
+    notes: trimmedNotes.length > 0 ? trimmedNotes : undefined,
+  };
+}
+
+export const INITIAL_FORM: AddBatchFormState = {
+  ingredientId: '',
+  variantId: '',
+  prepStateId: '',
+  qty: '',
+  unit: 'g',
+  sourceType: 'purchase',
+  location: 'fridge',
+  producedAt: '',
+  expiresAt: '',
+  notes: '',
+  search: '',
+};
+
+interface UseAddBatchFormArgs {
+  isOpen: boolean;
+  onAdded: ((batchId: number) => void) | undefined;
+  onClose: () => void;
+}
+
+export function useAddBatchForm({ isOpen, onAdded, onClose }: UseAddBatchFormArgs) {
+  const utils = trpc.useUtils();
+  const [form, setForm] = useState<AddBatchFormState>(INITIAL_FORM);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setForm(INITIAL_FORM);
+      setError(null);
+    }
+  }, [isOpen]);
+
+  const ingredientsQuery = trpc.food.ingredients.list.useQuery(
+    { search: form.search.trim().length > 0 ? form.search.trim() : undefined },
+    { enabled: isOpen }
+  );
+
+  const selectedIngredientId = form.ingredientId.length > 0 ? Number(form.ingredientId) : null;
+
+  const ingredientDetail = trpc.food.ingredients.get.useQuery(
+    { idOrSlug: selectedIngredientId ?? 0 },
+    { enabled: isOpen && selectedIngredientId !== null }
+  );
+
+  const prepStatesQuery = trpc.food.prepStates.list.useQuery(undefined, { enabled: isOpen });
+
+  const createMutation = trpc.food.batches.create.useMutation({
+    onSuccess: ({ batchId }) => {
+      void utils.food.fridge.view.invalidate();
+      onAdded?.(batchId);
+      onClose();
+    },
+    onError: (err) => setError(err.message),
+  });
+
+  function submit(): void {
+    setError(null);
+    const parsed = parseCreateInput(form);
+    if (typeof parsed === 'string') {
+      setError(parsed);
+      return;
+    }
+    createMutation.mutate(parsed);
+  }
+
+  return {
+    form,
+    setForm,
+    error,
+    submit,
+    isPending: createMutation.isPending,
+    ingredients: ingredientsQuery.data?.items ?? [],
+    variants: ingredientDetail.data?.variants ?? [],
+    prepStates: prepStatesQuery.data?.items ?? [],
+  };
+}

--- a/packages/app-food/src/pages/fridge/useAddBatchForm.ts
+++ b/packages/app-food/src/pages/fridge/useAddBatchForm.ts
@@ -43,7 +43,9 @@ function parseCreateInput(form: AddBatchFormState): CreateBatchInput | string {
   const variantId = Number(form.variantId);
   const qty = Number(form.qty);
   if (!Number.isFinite(variantId) || variantId <= 0) return 'Pick an ingredient variant.';
-  if (!Number.isFinite(qty) || qty < 0) return 'Quantity must be a non-negative number.';
+  // Reject zero — a 0-qty batch is hidden from the default fridge view, so
+  // creating one would look like the modal silently did nothing.
+  if (!Number.isFinite(qty) || qty <= 0) return 'Quantity must be greater than zero.';
   const trimmedNotes = form.notes.trim();
   return {
     variantId,

--- a/packages/app-food/src/pages/fridge/useAdjustQtyState.ts
+++ b/packages/app-food/src/pages/fridge/useAdjustQtyState.ts
@@ -1,0 +1,69 @@
+/**
+ * State + mutation hook for `AdjustQtyModal` — splits the React side
+ * so the modal stays under the `max-lines-per-function` budget.
+ */
+import { useEffect, useState } from 'react';
+
+import { trpc } from '@pops/api-client';
+
+import type { BatchAdjustReason } from '@pops/app-food-db';
+
+interface UseAdjustQtyArgs {
+  batchId: number | null;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function useAdjustQtyState({ batchId, isOpen, onClose }: UseAdjustQtyArgs) {
+  const utils = trpc.useUtils();
+  const detail = trpc.food.batches.get.useQuery(
+    { id: batchId ?? 0 },
+    { enabled: isOpen && batchId !== null }
+  );
+  const [delta, setDelta] = useState('');
+  const [reason, setReason] = useState<BatchAdjustReason>('spoiled');
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setDelta('');
+      setReason('spoiled');
+      setError(null);
+    }
+  }, [isOpen]);
+
+  const adjustMutation = trpc.food.batches.adjustQty.useMutation({
+    onSuccess: (res) => {
+      if (res.ok) {
+        void utils.food.fridge.view.invalidate();
+        onClose();
+      } else {
+        setError(reasonToMessage(res.reason));
+      }
+    },
+    onError: (err) => setError(err.message),
+  });
+
+  return {
+    detail,
+    delta,
+    setDelta,
+    reason,
+    setReason,
+    error,
+    setError,
+    adjustMutation,
+  };
+}
+
+export function parseDelta(raw: string): number | null {
+  const value = Number(raw);
+  if (!Number.isFinite(value) || value === 0) return null;
+  return value;
+}
+
+function reasonToMessage(reason: string): string {
+  if (reason === 'BadAdjustment') return 'Spoiled and wasted require a negative adjustment.';
+  if (reason === 'NegativeQty') return 'That adjustment would push the batch below zero.';
+  return reason;
+}

--- a/packages/app-food/src/pages/fridge/useEditBatchState.ts
+++ b/packages/app-food/src/pages/fridge/useEditBatchState.ts
@@ -1,0 +1,77 @@
+/**
+ * State + mutation hook for `EditBatchModal` — keeps the React
+ * component thin enough to satisfy the `max-lines-per-function` lint
+ * rule.
+ */
+import { useEffect, useState } from 'react';
+
+import { trpc } from '@pops/api-client';
+
+export interface EditState {
+  expiresAt: string;
+  notes: string;
+  prepStateId: string;
+}
+
+const EMPTY_STATE: EditState = { expiresAt: '', notes: '', prepStateId: '' };
+
+interface UseEditBatchArgs {
+  batchId: number | null;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function useEditBatchState({ batchId, isOpen, onClose }: UseEditBatchArgs) {
+  const utils = trpc.useUtils();
+  const detail = trpc.food.batches.get.useQuery(
+    { id: batchId ?? 0 },
+    { enabled: isOpen && batchId !== null }
+  );
+  const prepStates = trpc.food.prepStates.list.useQuery(undefined, { enabled: isOpen });
+  const [form, setForm] = useState<EditState>(EMPTY_STATE);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (detail.data !== null && detail.data !== undefined) {
+      setForm({
+        expiresAt: detail.data.expiresAt !== null ? detail.data.expiresAt.slice(0, 10) : '',
+        notes: detail.data.notes ?? '',
+        prepStateId: detail.data.prepStateId !== null ? String(detail.data.prepStateId) : '',
+      });
+    } else if (!isOpen) {
+      setForm(EMPTY_STATE);
+      setError(null);
+    }
+  }, [detail.data, isOpen]);
+
+  const editMutation = trpc.food.batches.edit.useMutation({
+    onSuccess: (res) => {
+      if (res.ok) {
+        void utils.food.fridge.view.invalidate();
+        onClose();
+      } else {
+        setError(reasonToMessage(res.reason));
+      }
+    },
+    onError: (err) => setError(err.message),
+  });
+
+  const isFromRun = detail.data?.sourceType === 'recipe_run';
+
+  return {
+    detail,
+    prepStates,
+    form,
+    setForm,
+    error,
+    setError,
+    editMutation,
+    isFromRun,
+  };
+}
+
+export function reasonToMessage(reason: string): string {
+  if (reason === 'BadExpiry') return 'Expiry date must be on or after the produced date.';
+  if (reason === 'CannotEditFromRun') return 'Cook-yielded batches keep their prep state.';
+  return reason;
+}

--- a/packages/app-food/src/pages/fridge/useFridgeView.ts
+++ b/packages/app-food/src/pages/fridge/useFridgeView.ts
@@ -8,6 +8,14 @@ import { trpc } from '@pops/api-client';
 
 import type { FridgeView } from '@pops/app-food-db';
 
+/**
+ * PRD-147's overview blurb mentions a prep-state filter, but the spec
+ * body (filter chips, `food.fridge.view` Zod schema) does not enumerate
+ * one. Treating it as a documented deferral for v1 — re-instate by
+ * adding `prepStateId` here, in `FridgeViewInputSchema`, and a SQL
+ * `prep_state_id =` clause in `view-query.ts` once the design picks a
+ * single-select vs multi-select shape.
+ */
 export interface FridgeFilterState {
   search: string;
   locations: ('pantry' | 'fridge' | 'freezer' | 'other')[];

--- a/packages/app-food/src/pages/fridge/useFridgeView.ts
+++ b/packages/app-food/src/pages/fridge/useFridgeView.ts
@@ -1,0 +1,62 @@
+/**
+ * tRPC client wrapper for `food.fridge.view` — PRD-147.
+ *
+ * Owns the cache key for the fridge query so the mutation handlers in
+ * the sibling modals can invalidate one place when a batch changes.
+ */
+import { trpc } from '@pops/api-client';
+
+import type { FridgeView } from '@pops/app-food-db';
+
+export interface FridgeFilterState {
+  search: string;
+  locations: ('pantry' | 'fridge' | 'freezer' | 'other')[];
+  expiringSoon: boolean;
+  recipeYieldedOnly: boolean;
+  showAll: boolean;
+}
+
+export const DEFAULT_FRIDGE_FILTERS: FridgeFilterState = {
+  search: '',
+  locations: [],
+  expiringSoon: false,
+  recipeYieldedOnly: false,
+  showAll: false,
+};
+
+interface UseFridgeViewArgs {
+  filters: FridgeFilterState;
+  debouncedSearch: string;
+}
+
+export interface UseFridgeViewResult {
+  data: FridgeView | undefined;
+  isLoading: boolean;
+  error: Error | null;
+  refetch: () => void;
+}
+
+export function useFridgeView({
+  filters,
+  debouncedSearch,
+}: UseFridgeViewArgs): UseFridgeViewResult {
+  const input = {
+    search: debouncedSearch.length === 0 ? undefined : debouncedSearch,
+    locations: filters.locations.length === 0 ? undefined : filters.locations,
+    expiringSoon: filters.expiringSoon || undefined,
+    recipeYieldedOnly: filters.recipeYieldedOnly || undefined,
+    includeEmpty: filters.showAll || undefined,
+    includeDeleted: filters.showAll || undefined,
+  };
+
+  const query = trpc.food.fridge.view.useQuery(input);
+
+  return {
+    data: query.data,
+    isLoading: query.isLoading,
+    error: query.error instanceof Error ? query.error : null,
+    refetch: () => {
+      void query.refetch();
+    },
+  };
+}


### PR DESCRIPTION
## Summary

PRD-147 ships the **fridge inventory view** at `/food/fridge`. Browse every active batch grouped by location → ingredient, filter by search / chips, and act on rows (Edit / Relocate / Adjust qty / Cook now / Delete) without leaving the page.

- **`food.fridge.view`** — sectioned read backed by `batches` ⋈ `ingredient_variants` ⋈ `ingredients` ⋈ `prep_states` with the PRD-147 filter combinators (search, location chips, expiring-soon, recipe-yielded, show-all empty/deleted). `daysToExpiry` is computed UTC-midnight-to-midnight to match `differenceInCalendarDays` semantics.
- **`food.fridge.recipesUsingBatch`** — backs the per-row Cook now picker. Variant-only join (prep-aware solver is Epic 06 territory); ordered by recent cook then slug.
- **`FridgePage`** — header + filter bar + collapsible per-location sections (state persisted in `localStorage`). Five action modals — Add / Edit / Relocate / Adjust qty / Delete — wired to PRD-145's `food.batches.*` services. Cook now picker navigates to the recipe detail.
- **Sidebar entry + route** were already scaffolded by PRD-118 and PRD-145.

## Test plan

- [x] `pnpm typecheck` (root) green
- [x] `pnpm lint` green
- [x] `pnpm format:check` green
- [x] `pnpm test` green — 7654 tests across 16 packages, including:
  - [x] 9 new `food.fridge router — PRD-147` integration tests (router + counts + grouping + `daysToExpiry` boundary + `recipesUsingBatch` join)
  - [x] 4 new `FridgePage` RTL tests (heading, empty state, populated render, section toggle)
  - [x] 13 new `format` unit tests (qty, expiry, urgency)
- [x] CI quality lanes (food + api + shell + E2E + docker) green on the PR

## Review changes

Addressed Copilot's review on commit 4332b0b:

- UTC-anchored `formatExpiry` (matches `daysToExpiry` semantics)
- Lucide icons replace emoji glyphs (CONVENTIONS.md compliance)
- Explicit error state in `CookNowPicker`; `<Link>` instead of raw `<a>`
- `DeleteBatchConfirm` clears error on close
- `EditBatchModal` guards invalid `toISOString()`
- `view-query` threads injectable `now` through `expiringSoon`
- `useAddBatchForm` rejects qty=0

## Deferred follow-ups (documented in code)

- Prep-state filter (PRD overview mentions it; spec body omits it — pending UX decision on single vs multi-select)
- URL-driven state: `?showAll=1`, `?add=1`, `?edit=<id>`, `?batch=<id>` deep-link with auto-scroll + highlight pulse
- Sidebar badge for batches expiring within 3 days
- Ingredient sub-grouping collapse when >3 variants per ingredient
- Mobile bottom-sheet modal variants