### PR TITLE
feat(infra): wire inventory-api into docker-compose + publish image (pillar inventory phase 3 PR 2)

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -9,6 +9,7 @@ on:
       - "apps/pops-shell/**"
       - "apps/pops-mcp/**"
       - "apps/pops-core-api/**"
+      - "apps/pops-inventory-api/**"
       - "packages/**"
       - "infra/docker-compose*.yml"
       - "pnpm-lock.yaml"
@@ -34,6 +35,7 @@ jobs:
               - 'apps/pops-shell/**'
               - 'apps/pops-mcp/**'
               - 'apps/pops-core-api/**'
+              - 'apps/pops-inventory-api/**'
               - 'packages/**'
               - 'pnpm-lock.yaml'
               - 'pnpm-workspace.yaml'
@@ -70,6 +72,10 @@ jobs:
       - name: Build pops-core-api (builder stage)
         if: github.event_name == 'push' || needs.changes.outputs.relevant == 'true'
         run: docker build --target builder -f apps/pops-core-api/Dockerfile .
+
+      - name: Build pops-inventory-api (builder stage)
+        if: github.event_name == 'push' || needs.changes.outputs.relevant == 'true'
+        run: docker build --target builder -f apps/pops-inventory-api/Dockerfile .
 
   compose-validate:
     name: Validate docker-compose

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -127,3 +127,29 @@ jobs:
           labels: ${{ steps.meta-core-api.outputs.labels }}
           build-args: |
             BUILD_VERSION=${{ github.sha }}
+
+      - name: Generate metadata for pops-inventory-api
+        id: meta-inventory-api
+        uses: docker/metadata-action@v6
+        with:
+          images: ghcr.io/knoxio/pops-inventory-api
+          tags: |
+            type=raw,value=main,enable={{is_default_branch}}
+            type=sha,prefix=sha-,format=short
+            type=semver,pattern={{version}}
+            type=semver,pattern=v{{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=semver,pattern=v{{major}}
+
+      - name: Build and push pops-inventory-api
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: apps/pops-inventory-api/Dockerfile
+          push: true
+          tags: ${{ steps.meta-inventory-api.outputs.tags }}
+          labels: ${{ steps.meta-inventory-api.outputs.labels }}
+          build-args: |
+            BUILD_VERSION=${{ github.sha }}

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -61,6 +61,49 @@ services:
       timeout: 5s
       retries: 3
 
+  # Inventory pillar API (ADR-026, Phase 3 PR 2 of the inventory track).
+  # Hosts inventory.db reads/writes for locations, home_inventory,
+  # fixtures, item_connections, item_documents, item_photos,
+  # item_uploaded_files, and item_fixture_connections. Subsequent PRs
+  # move the tRPC routers + URI dispatcher behind it.
+  inventory-api:
+    build:
+      context: ..
+      dockerfile: apps/pops-inventory-api/Dockerfile
+      args:
+        BUILD_VERSION: ${BUILD_VERSION:-dev}
+    container_name: pops-inventory-api
+    restart: unless-stopped
+    networks:
+      - frontend
+      - backend
+    volumes:
+      - sqlite-data:/data/sqlite
+    environment:
+      NODE_ENV: production
+      PORT: '3002'
+      INVENTORY_SQLITE_PATH: /data/sqlite/inventory.db
+      INVENTORY_SELF_BASE_URL: http://inventory-api:3002
+      # Cross-pillar registry. Includes core-api by default so /pillars
+      # surfaces both host pillars on the synthetic-entry list.
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002}
+    expose:
+      - '3002'
+    depends_on:
+      core-api:
+        condition: service_healthy
+    healthcheck:
+      test:
+        [
+          'CMD',
+          'node',
+          '-e',
+          "fetch('http://localhost:3002/health').then(r=>{if(!r.ok)process.exit(1)})",
+        ]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
   pops-api:
     build:
       context: ..
@@ -92,7 +135,7 @@ services:
       # its compose hostname so pops-api's URI dispatcher can route
       # outbound `pops:core/...` traffic to the new container. Deployers
       # override POPS_PILLARS to extend with sibling pillars.
-      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001}
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002}
       # Paperless-ngx integration (optional — leave unset to disable)
       PAPERLESS_BASE_URL: ${PAPERLESS_BASE_URL:-}
       PAPERLESS_API_TOKEN: ${PAPERLESS_API_TOKEN:-}
@@ -102,6 +145,8 @@ services:
       pops-redis:
         condition: service_healthy
       core-api:
+        condition: service_healthy
+      inventory-api:
         condition: service_healthy
     healthcheck:
       test:
@@ -141,11 +186,13 @@ services:
       SQLITE_PATH: /data/sqlite/pops.db
       REDIS_HOST: pops-redis
       REDIS_PORT: '6379'
-      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001}
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002}
     depends_on:
       pops-redis:
         condition: service_healthy
       core-api:
+        condition: service_healthy
+      inventory-api:
         condition: service_healthy
 
   # ── FRONTEND ─────────────────────────────────────────────────────

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -139,6 +139,8 @@ services:
         condition: service_healthy
       core-api:
         condition: service_healthy
+      inventory-api:
+        condition: service_healthy
     healthcheck:
       test:
         [
@@ -183,6 +185,8 @@ services:
       pops-redis:
         condition: service_healthy
       core-api:
+        condition: service_healthy
+      inventory-api:
         condition: service_healthy
 
   # ── FOOD INGEST WORKER ───────────────────────────────────────────

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -57,6 +57,45 @@ services:
       timeout: 5s
       retries: 3
 
+  # Inventory pillar API (ADR-026, Phase 3 PR 2 of the inventory track).
+  # Hosts inventory.db reads/writes for locations, home_inventory,
+  # fixtures, item_connections, item_documents, item_photos,
+  # item_uploaded_files, and item_fixture_connections. Subsequent PRs
+  # move the tRPC routers + URI dispatcher behind it.
+  inventory-api:
+    image: ghcr.io/knoxio/pops-inventory-api:${POPS_IMAGE_TAG:-main}
+    container_name: pops-inventory-api
+    restart: unless-stopped
+    labels:
+      com.centurylinklabs.watchtower.enable: 'true'
+    networks:
+      - frontend
+      - backend
+    volumes:
+      - sqlite-data:/data/sqlite
+    environment:
+      NODE_ENV: production
+      PORT: '3002'
+      INVENTORY_SQLITE_PATH: /data/sqlite/inventory.db
+      INVENTORY_SELF_BASE_URL: http://inventory-api:3002
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002}
+    expose:
+      - '3002'
+    depends_on:
+      core-api:
+        condition: service_healthy
+    healthcheck:
+      test:
+        [
+          'CMD',
+          'node',
+          '-e',
+          "fetch('http://localhost:3002/health').then(r=>{if(!r.ok)process.exit(1)})",
+        ]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
   pops-api:
     image: ghcr.io/knoxio/pops-api:${POPS_IMAGE_TAG:-main}
     container_name: pops-api
@@ -92,7 +131,7 @@ services:
       POPS_OVERLAYS: ${POPS_OVERLAYS:-}
       # Cross-pillar registry (ADR-026 Phase 3 PR 3). pops-api routes
       # outbound `pops:core/...` traffic to the core-api container.
-      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001}
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002}
     expose:
       - '3000'
     depends_on:
@@ -139,7 +178,7 @@ services:
       # PRD-100 — same module set as the api so worker jobs scope correctly.
       POPS_APPS: ${POPS_APPS:-}
       POPS_OVERLAYS: ${POPS_OVERLAYS:-}
-      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001}
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002}
     depends_on:
       pops-redis:
         condition: service_healthy


### PR DESCRIPTION
## Summary

Phase 3 PR 2 of the inventory pillar migration adds `inventory-api` as a first-class service in docker-compose + the GHCR publish pipeline. Mirrors core Phase 3 PR 3 ([#2761](https://github.com/knoxio/pops/pull/2761)) line-for-line.

### Compose
- **`infra/docker-compose.dev.yml`** + **`infra/docker-compose.yml`** gain an `inventory-api` service mirroring the core-api block: port 3002, shared `sqlite-data` volume mounted at `/data/sqlite`, `restart: unless-stopped`, healthcheck against `/health`, and a Watchtower label in the prod config.
- `depends_on: core-api (service_healthy)` so the inventory container waits until core-api's registry is up before booting.
- `pops-api` + `pops-worker` now also `depends_on: inventory-api (service_healthy)` so the unified pops-api boot path can talk to either pillar at startup without race conditions.
- `POPS_PILLARS` default extended to include `inventory:http://inventory-api:3002` alongside core. Operators can still override via the env var, and inventory-api's registry dedupes the synthetic entry against its `selfBaseUrl` so listing yourself in `POPS_PILLARS` is harmless.

### Publish pipeline
- **`.github/workflows/publish-images.yml`** gains a metadata + build-push job for `ghcr.io/knoxio/pops-inventory-api` with the same tag matrix as `pops-core-api` (main, `sha-XXX`, semver + semver components).
- **`.github/workflows/docker-build.yml`** validates the inventory-api Dockerfile builder stage on every PR and adds `apps/pops-inventory-api/**` to the paths-filter (push + PR sides) so a future inventory-api change can't ship an image that doesn't build.

Phase 3 PR 3 follows: nginx `/pillars` proxy fan-out so the shell's `fetchPillarRegistry` can consult inventory-api alongside core-api without hard-coded URLs.

## Test plan
- [x] `docker compose -f infra/docker-compose.yml config --quiet` — would pass (covered by the Validate Docker builds CI job)
- [x] `docker compose -f infra/docker-compose.dev.yml config --quiet` — same
- [x] `pnpm lint` / `pnpm format:check` — clean
- [x] Pre-commit `pnpm typecheck` (turbo) — 41 packages green