### PR TITLE
feat(media-api): scaffold pops-media-api container (pillar media phase 3 PR 1)

### DIFF
--- a/.github/workflows/media-api-quality.yml
+++ b/.github/workflows/media-api-quality.yml
@@ -1,0 +1,41 @@
+name: Media API Quality
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "apps/pops-media-api/**"
+      - "packages/media-db/**"
+      - "packages/db-types/**"
+      - ".github/workflows/media-api-quality.yml"
+      - ".github/workflows/_pkg-check.yml"
+  pull_request:
+
+jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - 'apps/pops-media-api/**'
+              - 'packages/media-db/**'
+              - 'packages/db-types/**'
+              - '.github/workflows/media-api-quality.yml'
+              - '.github/workflows/_pkg-check.yml'
+
+  quality:
+    needs: [changes]
+    if: always()
+    uses: ./.github/workflows/_pkg-check.yml
+    with:
+      package-path: apps/pops-media-api
+      needs-db-build: true
+      skip: ${{ github.event_name == 'pull_request' && needs.changes.outputs.relevant != 'true' }}

--- a/apps/pops-media-api/Dockerfile
+++ b/apps/pops-media-api/Dockerfile
@@ -1,0 +1,57 @@
+FROM node:22-slim AS builder
+WORKDIR /app
+
+# Copy workspace root files
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json ./
+
+# Copy workspace package.json files (for dep resolution)
+COPY packages/db-types/package.json ./packages/db-types/
+COPY packages/types/package.json ./packages/types/
+COPY packages/media-db/package.json ./packages/media-db/
+COPY apps/pops-media-api/package.json ./apps/pops-media-api/
+
+# Install pnpm and all workspace dependencies
+RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
+    corepack enable && pnpm install --frozen-lockfile
+
+# Copy shared package sources
+COPY packages/db-types/src ./packages/db-types/src
+COPY packages/db-types/tsconfig.json ./packages/db-types/
+COPY packages/types/src ./packages/types/src
+COPY packages/types/tsconfig.json packages/types/tsconfig.build.json ./packages/types/
+COPY packages/media-db/src ./packages/media-db/src
+COPY packages/media-db/tsconfig.json ./packages/media-db/
+COPY packages/media-db/migrations ./packages/media-db/migrations
+
+# Copy media-api source
+COPY apps/pops-media-api/tsconfig.json ./apps/pops-media-api/
+COPY apps/pops-media-api/src ./apps/pops-media-api/src
+
+# Build shared packages first
+WORKDIR /app/packages/db-types
+RUN pnpm build
+WORKDIR /app/packages/types
+RUN pnpm build
+WORKDIR /app/packages/media-db
+RUN pnpm build
+
+# Build media-api
+WORKDIR /app/apps/pops-media-api
+RUN pnpm build
+
+# Create standalone deployment (production deps only, no symlinks)
+RUN pnpm --filter @pops/media-api deploy --prod --legacy /app/deploy
+
+FROM node:22-slim
+WORKDIR /app
+RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder --chown=node:node /app/deploy ./
+COPY --from=builder --chown=node:node /app/apps/pops-media-api/dist ./dist
+
+ARG BUILD_VERSION=dev
+ENV BUILD_VERSION=$BUILD_VERSION
+
+EXPOSE 3002
+USER node
+CMD ["node", "dist/server.js"]

--- a/apps/pops-media-api/package.json
+++ b/apps/pops-media-api/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@pops/media-api",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsx watch --clear-screen=false src/server.ts",
+    "start": "node dist/server.js",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@pops/media-db": "workspace:*",
+    "@pops/types": "workspace:*",
+    "express": "^5.1.0",
+    "pino": "^10.3.1"
+  },
+  "devDependencies": {
+    "@types/express": "^5.0.4",
+    "@types/node": "^25.9.1",
+    "@types/supertest": "^6.0.3",
+    "@vitest/coverage-v8": "^4.1.8",
+    "supertest": "^7.1.4",
+    "tsx": "^4.22.4",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.8"
+  }
+}

--- a/apps/pops-media-api/src/__tests__/health.test.ts
+++ b/apps/pops-media-api/src/__tests__/health.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Smoke tests for the media-api Express app + health probe.
+ *
+ * Boots the app against a per-test temp-dir media.db (mkdtemp + cleanup
+ * in afterEach) and confirms the `/health` route returns the agreed
+ * `{ ok, pillar, version }` shape.
+ *
+ * Mirrors `apps/pops-core-api/src/__tests__/health.test.ts`.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { openMediaDb, type OpenedMediaDb } from '@pops/media-db';
+
+import { createMediaApiApp } from '../app.js';
+
+let tmpDir: string;
+let mediaDb: OpenedMediaDb;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'media-api-test-'));
+  mediaDb = openMediaDb(join(tmpDir, 'media.db'));
+});
+
+afterEach(() => {
+  mediaDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('GET /health', () => {
+  it('returns ok + pillar + version', async () => {
+    const app = createMediaApiApp({ mediaDb, version: '0.0.1-test' });
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, pillar: 'media', version: '0.0.1-test' });
+  });
+
+  it('fails closed when the media handle is closed', async () => {
+    const app = createMediaApiApp({ mediaDb, version: '0.0.1-test' });
+    mediaDb.raw.close();
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(500);
+  });
+});

--- a/apps/pops-media-api/src/app.ts
+++ b/apps/pops-media-api/src/app.ts
@@ -1,0 +1,30 @@
+/**
+ * Express app factory for the media pillar container.
+ *
+ * Phase 3 PR 1 of the media pillar migration boots the minimal surface
+ * (`/health`) so the new container can be wired into docker-compose and
+ * Watchtower without depending on the (still-unfinished) tRPC migration.
+ * Subsequent PRs mount additional routes. Kept as a factory so the test
+ * suite can spin up an in-process `supertest` instance without binding a
+ * real port.
+ *
+ * Mirrors `apps/pops-core-api/src/app.ts`.
+ */
+import express, { type Express, type Request, type Response } from 'express';
+
+import { type MediaApiDeps, makeRequestHandler } from './handlers.js';
+
+export function createMediaApiApp(deps: MediaApiDeps): Express {
+  const app = express();
+  app.disable('x-powered-by');
+
+  // Build the handler shape once at factory time so static deps don't
+  // get re-allocated on every request.
+  const handlers = makeRequestHandler(deps);
+
+  app.get('/health', (_req: Request, res: Response) => {
+    res.json(handlers.health());
+  });
+
+  return app;
+}

--- a/apps/pops-media-api/src/handlers.ts
+++ b/apps/pops-media-api/src/handlers.ts
@@ -1,0 +1,39 @@
+/**
+ * Request handlers for the media pillar container.
+ *
+ * Logic lives here (not inline in `app.ts`) so tests can call into the
+ * shape directly without booting Express. Subsequent PRs add tRPC +
+ * domain-specific handlers alongside the existing health probe.
+ *
+ * Mirrors `apps/pops-core-api/src/handlers.ts` minus the pillar-registry
+ * surface (the registry is hosted by core-api only).
+ */
+
+import type { OpenedMediaDb } from '@pops/media-db';
+
+export interface MediaApiDeps {
+  /** Open handle to the media pillar's SQLite. */
+  mediaDb: OpenedMediaDb;
+  /** Semver of the build, surfaced on the health response. */
+  version: string;
+}
+
+export interface HealthResponse {
+  ok: true;
+  pillar: 'media';
+  version: string;
+}
+
+export function makeRequestHandler(deps: MediaApiDeps): {
+  health(): HealthResponse;
+} {
+  return {
+    health(): HealthResponse {
+      // Touch the DB so a closed handle surfaces as a thrown error
+      // (caught by the Express error pipeline -> 500) rather than a
+      // bogus 200 OK that hides a broken connection.
+      deps.mediaDb.raw.prepare('SELECT 1').get();
+      return { ok: true, pillar: 'media', version: deps.version };
+    },
+  };
+}

--- a/apps/pops-media-api/src/media-sqlite-path.ts
+++ b/apps/pops-media-api/src/media-sqlite-path.ts
@@ -1,0 +1,29 @@
+import { dirname, join } from 'node:path';
+
+/**
+ * Standalone resolver for the media pillar's SQLite path inside the
+ * media-api container.
+ *
+ * Intentionally NOT imported from `apps/pops-api/src/db/media-sqlite-path.ts`
+ * — media-api is supposed to be runnable without pops-api in the
+ * dependency graph. The precedence chain mirrors pops-api's resolver
+ * verbatim so the two processes agree on the location of `media.db`
+ * given the same env: a deployer who only sets `SQLITE_PATH`
+ * (legacy contract) still ends up with `media.db` next to `pops.db`.
+ *
+ * Resolution order:
+ *   1. `MEDIA_SQLITE_PATH` (absolute or relative).
+ *   2. `<dirname(SQLITE_PATH)>/media.db` if the shared path is set.
+ *   3. `./data/media.db` (matches the shared default's `./data/pops.db`).
+ *
+ * Mirrors core-api's `resolveCoreSqlitePath`.
+ */
+export const DEFAULT_MEDIA_SQLITE_PATH = './data/media.db';
+
+export function resolveMediaSqlitePath(): string {
+  const envPath = process.env['MEDIA_SQLITE_PATH'];
+  if (envPath) return envPath;
+  const sharedPath = process.env['SQLITE_PATH'];
+  if (sharedPath) return join(dirname(sharedPath), 'media.db');
+  return DEFAULT_MEDIA_SQLITE_PATH;
+}

--- a/apps/pops-media-api/src/server.ts
+++ b/apps/pops-media-api/src/server.ts
@@ -1,0 +1,49 @@
+/**
+ * Entry point for the media pillar HTTP server.
+ *
+ * Phase 3 PR 1 of the media pillar migration boots the process with the
+ * minimal `/health` surface so the new container can be wired into
+ * docker-compose + Watchtower without depending on the (still-unfinished)
+ * tRPC + URI-dispatcher migration.
+ *
+ * The process opens its OWN `media.db` connection via `openMediaDb`
+ * rather than reaching back into pops-api's singleton — that's the whole
+ * point of phase 3. Mirrors `apps/pops-core-api/src/server.ts`.
+ */
+import { openMediaDb } from '@pops/media-db';
+
+import { createMediaApiApp } from './app.js';
+import { resolveMediaSqlitePath } from './media-sqlite-path.js';
+
+function resolvePort(): number {
+  const raw = process.env['PORT'];
+  if (raw === undefined || raw === '') return 3002;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed <= 0 || parsed > 65535) {
+    throw new Error(`[media-api] PORT must be a positive integer in 1-65535; got '${raw}'`);
+  }
+  return parsed;
+}
+
+const port = resolvePort();
+const version = process.env['BUILD_VERSION'] ?? 'dev';
+
+const mediaDb = openMediaDb(resolveMediaSqlitePath());
+const app = createMediaApiApp({ mediaDb, version });
+
+const server = app.listen(port, () => {
+  console.warn(`[media-api] Listening on port ${port}`);
+});
+
+let shuttingDown = false;
+function shutdown(signal: NodeJS.Signals): void {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  console.warn(`[media-api] Shutting down (${signal})`);
+  server.close(() => {
+    mediaDb.raw.close();
+  });
+}
+
+process.on('SIGTERM', shutdown);
+process.on('SIGINT', shutdown);

--- a/apps/pops-media-api/tsconfig.json
+++ b/apps/pops-media-api/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "sourceMap": true,
+    "types": ["node"]
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/__tests__/**"]
+}

--- a/apps/pops-media-api/vitest.config.ts
+++ b/apps/pops-media-api/vitest.config.ts
@@ -1,0 +1,15 @@
+/// <reference types="vitest/config" />
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json-summary', 'html'],
+      reportsDirectory: 'coverage',
+      include: ['src/**/*.ts'],
+      exclude: ['**/node_modules/**', '**/dist/**', '**/*.test.ts'],
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -336,6 +336,46 @@ importers:
         specifier: ^4.1.8
         version: 4.1.8(@types/node@25.9.1)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
 
+  apps/pops-media-api:
+    dependencies:
+      '@pops/media-db':
+        specifier: workspace:*
+        version: link:../../packages/media-db
+      '@pops/types':
+        specifier: workspace:*
+        version: link:../../packages/types
+      express:
+        specifier: ^5.1.0
+        version: 5.2.1
+      pino:
+        specifier: ^10.3.1
+        version: 10.3.1
+    devDependencies:
+      '@types/express':
+        specifier: ^5.0.4
+        version: 5.0.6
+      '@types/node':
+        specifier: ^25.9.1
+        version: 25.9.1
+      '@types/supertest':
+        specifier: ^6.0.3
+        version: 6.0.3
+      '@vitest/coverage-v8':
+        specifier: ^4.1.8
+        version: 4.1.8(vitest@4.1.8)
+      supertest:
+        specifier: ^7.1.4
+        version: 7.2.2
+      tsx:
+        specifier: ^4.22.4
+        version: 4.22.4
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@25.9.1)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
+
   apps/pops-shell:
     dependencies:
       '@pops/api-client':


### PR DESCRIPTION
## Summary

First PR of the media pillar **Phase 3 — media-api container** sequence (pillar-migration-roadmap.md Track F · Phase 3 PR 1 of 4). Mirrors core's PR 1 (#2759) and the parallel inventory scaffold.

Scaffolds the new \`pops-media-api\` process — a standalone container that owns the media pillar's HTTP surface. **Strictly additive — no existing pops-api callers depend on it yet.** Subsequent PRs add tRPC + routes, wire docker-compose, then point the shell at the new base URL.

## What changed

- \`apps/pops-media-api/\`:
  - \`package.json\` / \`tsconfig.json\` / \`vitest.config.ts\` (deps: \`@pops/media-db\`, express 5, pino, supertest)
  - \`src/server.ts\` — process entrypoint binds \`PORT\` (default 3002), opens the media pillar SQLite directly via \`openMediaDb\`, SIGTERM / SIGINT graceful shutdown closes the handle
  - \`src/app.ts\` — Express factory exposing \`/health\`
  - \`src/handlers.ts\` — pure handler shape; touches the DB so a closed handle surfaces as 500 instead of a bogus 200 OK
  - \`src/media-sqlite-path.ts\` — standalone resolver so media-api doesn't reach into pops-api's tree (same env name + default as pops-api)
  - \`src/__tests__/health.test.ts\` — supertest covers happy + fail-closed
  - \`Dockerfile\` — multi-stage build mirroring \`pops-core-api\` (\`deploy --prod --legacy\`, non-root \`USER node\` at runtime, \`EXPOSE 3002\`)
- \`.github/workflows/media-api-quality.yml\` — PR-paths-filtered typecheck + test via the shared \`_pkg-check\` workflow
- \`pnpm-lock.yaml\` refreshed

## Subsequent PRs

- PR 2 — mount tRPC routes for shelf-impressions
- PR 3 — wire media-api into \`docker-compose.dev.yml\` + \`POPS_PILLARS\` + publish-images entry
- PR 4 — \`pops-shell\` creates \`useMediaTrpc()\` against the new base URL OR pops-api proxies media-specific routes

## Verification

- \`pnpm typecheck\` — 42/42 packages green
- \`pnpm --filter @pops/media-api test\` — 2/2 supertest cases pass
- \`pnpm format:check\` — clean

## Test plan

- [ ] CI green on \`media-api-quality\` (typecheck + 2 supertest cases)
- [ ] Workspace \`typecheck\` / \`api-quality\` unaffected (strictly additive)
- [ ] Copilot review pass