### PR TITLE
feat(api): flip wish-list to the finance pillar handle + backfill (pillar finance phase 2 PR 3)

### DIFF
--- a/apps/pops-api/src/db/backfill-finance-from-shared.test.ts
+++ b/apps/pops-api/src/db/backfill-finance-from-shared.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Boot-time backfill tests for `backfillFinanceFromShared` (phase 2 PR 3).
+ *
+ * Exercises the ATTACH-based copy from the shared `pops.db` to the
+ * pillar's `finance.db` against on-disk SQLite files (in-memory DBs
+ * can't be ATTACHed). Confirms:
+ *   - first run carries existing rows across,
+ *   - second run is a no-op (idempotent — the per-table WHERE filter dedupes),
+ *   - mixed state (some rows already in finance) only inserts the missing ones,
+ *   - missing source table is tolerated without throwing.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import BetterSqlite3 from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { openFinanceDb } from '@pops/finance-db';
+
+import { backfillFinanceFromShared } from './backfill-finance-from-shared.js';
+import { WISH_LIST_TABLE_SQL } from './backfill-test-fixtures.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'finance-backfill-'));
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function openSharedWithSeed(seed: (raw: BetterSqlite3.Database) => void): string {
+  const path = join(tmpDir, 'pops.db');
+  const raw = new BetterSqlite3(path);
+  raw.exec(WISH_LIST_TABLE_SQL);
+  seed(raw);
+  raw.close();
+  return path;
+}
+
+describe('backfillFinanceFromShared', () => {
+  it('copies wish_list rows from the shared DB on first run', () => {
+    const sharedPath = openSharedWithSeed((raw) => {
+      raw.exec(
+        `INSERT INTO wish_list (id, item, last_edited_time) VALUES ('wish-1', 'Espresso machine', '2026-06-10T00:00:00Z')`
+      );
+      raw.exec(
+        `INSERT INTO wish_list (id, item, last_edited_time) VALUES ('wish-2', 'Headphones', '2026-06-10T00:00:00Z')`
+      );
+    });
+
+    const finance = openFinanceDb(join(tmpDir, 'finance.db'));
+    try {
+      backfillFinanceFromShared(finance, sharedPath);
+      const rows = finance.raw.prepare('SELECT id, item FROM wish_list ORDER BY id').all() as {
+        id: string;
+        item: string;
+      }[];
+      expect(rows).toEqual([
+        { id: 'wish-1', item: 'Espresso machine' },
+        { id: 'wish-2', item: 'Headphones' },
+      ]);
+    } finally {
+      finance.raw.close();
+    }
+  });
+
+  it('is idempotent — a second run does not duplicate rows', () => {
+    const sharedPath = openSharedWithSeed((raw) => {
+      raw.exec(
+        `INSERT INTO wish_list (id, item, last_edited_time) VALUES ('wish-1', 'Espresso machine', '2026-06-10T00:00:00Z')`
+      );
+    });
+
+    const finance = openFinanceDb(join(tmpDir, 'finance.db'));
+    try {
+      backfillFinanceFromShared(finance, sharedPath);
+      backfillFinanceFromShared(finance, sharedPath);
+      const count = finance.raw.prepare('SELECT count(*) AS n FROM wish_list').get() as {
+        n: number;
+      };
+      expect(count.n).toBe(1);
+    } finally {
+      finance.raw.close();
+    }
+  });
+
+  it('only inserts rows missing from the finance copy (mixed state)', () => {
+    const sharedPath = openSharedWithSeed((raw) => {
+      raw.exec(
+        `INSERT INTO wish_list (id, item, last_edited_time) VALUES ('wish-shared-only', 'Bike rack', '2026-06-10T00:00:00Z')`
+      );
+      raw.exec(
+        `INSERT INTO wish_list (id, item, last_edited_time) VALUES ('wish-both', 'Espresso machine', '2026-06-10T00:00:00Z')`
+      );
+    });
+
+    const finance = openFinanceDb(join(tmpDir, 'finance.db'));
+    try {
+      // Pre-seed the finance.db with one of the rows that also lives in
+      // the shared DB; the backfill must skip it but pick up the other.
+      finance.raw.exec(
+        `INSERT INTO wish_list (id, item, last_edited_time) VALUES ('wish-both', 'Espresso machine', '2026-06-10T00:00:00Z')`
+      );
+      backfillFinanceFromShared(finance, sharedPath);
+      const rows = finance.raw.prepare('SELECT id FROM wish_list ORDER BY id').all() as {
+        id: string;
+      }[];
+      expect(rows.map((r) => r.id)).toEqual(['wish-both', 'wish-shared-only']);
+    } finally {
+      finance.raw.close();
+    }
+  });
+
+  it('tolerates a shared DB with no wish_list table (post-PR-4 drop scenario)', () => {
+    // Shared DB exists but doesn't have wish_list.
+    const sharedPath = join(tmpDir, 'pops.db');
+    const raw = new BetterSqlite3(sharedPath);
+    raw.exec(`CREATE TABLE other_table (id integer PRIMARY KEY)`);
+    raw.close();
+
+    const finance = openFinanceDb(join(tmpDir, 'finance.db'));
+    try {
+      expect(() => backfillFinanceFromShared(finance, sharedPath)).not.toThrow();
+      const count = finance.raw.prepare('SELECT count(*) AS n FROM wish_list').get() as {
+        n: number;
+      };
+      expect(count.n).toBe(0);
+    } finally {
+      finance.raw.close();
+    }
+  });
+});

--- a/apps/pops-api/src/db/backfill-finance-from-shared.ts
+++ b/apps/pops-api/src/db/backfill-finance-from-shared.ts
@@ -1,0 +1,98 @@
+/**
+ * Boot-time backfill from the legacy shared `pops.db` into the finance
+ * pillar's `finance.db`.
+ *
+ * Phase 2 PR 3 of the finance pillar flips the wish-list slice to the
+ * finance handle. The first deploy after PR 3 needs to carry the
+ * existing rows from the shared DB across before any reads come from
+ * the new file. Subsequent boots find the finance copy already
+ * populated and become a no-op via the `WHERE id NOT IN (...)`
+ * existence filter on every table.
+ *
+ * Only `wish_list` is copied today. Future cutover PRs (budgets,
+ * transactions, imports, tag rules, tag vocabulary) extend the
+ * `TABLE_COPIES` list; FK-safe ordering is enforced here.
+ *
+ * Each table is wrapped in `tryCopyTable` so a missing source table
+ * (post-PR-4 drop scenario, or a stale on-disk pops.db) doesn't bring
+ * the whole backfill down. Failures are logged + swallowed; the
+ * remaining tables still attempt.
+ *
+ * Non-fatal: ATTACH or INSERT failures are logged and swallowed so a
+ * stale on-disk pops.db never bricks the boot path. Failures here
+ * leave the finance copy partially populated for that boot; the next
+ * deploy retries and the idempotent filter picks up only the
+ * still-missing rows.
+ */
+import type Database from 'better-sqlite3';
+
+import type { OpenedFinanceDb } from '@pops/finance-db';
+
+interface TableCopy {
+  readonly table: string;
+  /** Explicit column list keeps the backfill robust against a stale
+   * on-disk pops.db that already widened or narrowed since the boot
+   * image was built. */
+  readonly columns: readonly string[];
+  /** Identifier column used in the existence filter. */
+  readonly idColumn: string;
+}
+
+const TABLE_COPIES: readonly TableCopy[] = [
+  {
+    table: 'wish_list',
+    idColumn: 'id',
+    columns: [
+      'id',
+      'notion_id',
+      'item',
+      'target_amount',
+      'saved',
+      'priority',
+      'url',
+      'notes',
+      'last_edited_time',
+    ],
+  },
+];
+
+function tryCopyTable(raw: Database.Database, copy: TableCopy): void {
+  try {
+    const hasTable = raw
+      .prepare(`SELECT 1 FROM pops.sqlite_master WHERE type='table' AND name='${copy.table}'`)
+      .get();
+    if (!hasTable) return;
+    const cols = copy.columns.join(', ');
+    raw.exec(`
+      INSERT INTO ${copy.table} (${cols})
+      SELECT ${cols}
+      FROM pops.${copy.table}
+      WHERE ${copy.idColumn} NOT IN (SELECT ${copy.idColumn} FROM ${copy.table})
+    `);
+  } catch (err) {
+    console.warn(`[db] Finance backfill of ${copy.table} failed (non-fatal):`, err);
+  }
+}
+
+/**
+ * Copy every finance-owned table's rows from `pops.db` into
+ * `finance.db`, in FK-safe order, idempotent against re-runs.
+ *
+ * Caller is responsible for supplying the finance handle (so this
+ * module stays decoupled from the lazy singleton in
+ * `db/finance-handle.ts`). Production wiring passes the result of
+ * `getFinanceDrizzle()` after the eager-open block; tests pass an
+ * in-memory handle with a tmpdir copy of the shared DB pre-populated.
+ */
+export function backfillFinanceFromShared(finance: OpenedFinanceDb, sharedPath: string): void {
+  try {
+    finance.raw.prepare('ATTACH DATABASE ? AS pops').run(sharedPath);
+    try {
+      for (const copy of TABLE_COPIES) tryCopyTable(finance.raw, copy);
+    } finally {
+      finance.raw.exec('DETACH DATABASE pops');
+    }
+  } catch (err) {
+    console.warn('[db] Finance backfill ATTACH failed (non-fatal):', err);
+  }
+}

--- a/apps/pops-api/src/db/backfill-test-fixtures.ts
+++ b/apps/pops-api/src/db/backfill-test-fixtures.ts
@@ -34,3 +34,18 @@ CREATE TABLE shelf_impressions (
 );
 CREATE INDEX idx_shelf_impressions_shelf_id ON shelf_impressions (shelf_id);
 `;
+
+export const WISH_LIST_TABLE_SQL = `
+CREATE TABLE wish_list (
+  id text PRIMARY KEY NOT NULL,
+  notion_id text,
+  item text NOT NULL,
+  target_amount real,
+  saved real,
+  priority text,
+  url text,
+  notes text,
+  last_edited_time text NOT NULL
+);
+CREATE UNIQUE INDEX wish_list_notion_id_unique ON wish_list (notion_id);
+`;

--- a/apps/pops-api/src/db/finance-handle.ts
+++ b/apps/pops-api/src/db/finance-handle.ts
@@ -1,19 +1,21 @@
 /**
  * Lazily-initialised handle to the finance pillar's SQLite file.
  *
- * Phase 2 PR 2 of the finance pillar migration: opens the connection
- * (and applies the in-package migrations journal, with the new
- * `0053_finance_pillar_baseline` ahead of 0025/0026/0027/0052) at boot
- * but does NOT yet route any production traffic through it. PR 3 of
- * phase 2 flips the wish-list slice over with a single edit to
- * `getDrizzle()` → `getFinanceDrizzle()` and adds the ATTACH-based
- * backfill from the legacy shared pops.db.
+ * Phase 2 PR 3 of the finance pillar migration: the wish-list slice
+ * now reads/writes through this handle (boot eagerly opens the file
+ * in PR 2; this PR adds the cutover + the ATTACH-based backfill that
+ * carries any rows still living in the legacy pops.db across).
  *
  * Lives in its own module so `db.ts` stays under the lint cap as more
- * pillars come online. Mirrors `core-handle.ts` and `inventory-handle.ts`.
+ * pillars come online. Mirrors `core-handle.ts` / `inventory-handle.ts`
+ * / `media-db-handle.ts`.
  */
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+
 import { openFinanceDb, type FinanceDb, type OpenedFinanceDb } from '@pops/finance-db';
 
+import { getDb, isNamedEnvContext } from '../db.js';
+import { backfillFinanceFromShared } from './backfill-finance-from-shared.js';
 import { resolveFinanceSqlitePath } from './finance-sqlite-path.js';
 
 let financeDb: OpenedFinanceDb | null = null;
@@ -21,13 +23,20 @@ let financeDb: OpenedFinanceDb | null = null;
 /**
  * Resolve (and lazily open) the finance pillar's drizzle handle.
  *
- * The handle is opened here on first call so the per-pillar migrations
- * apply at boot. Phase 2 PR 2 does NOT yet route any production traffic
- * through it — the existing shared singleton continues to serve every
- * read/write. The handle is here so PR 3 can flip the wish-list slice
- * over with a one-line edit.
+ * **Env-aware**: inside a `withEnvDb()` scope (PRD-101 named environments —
+ * each E2E test fixture creates a per-test pops.db with its own seeded
+ * finance tables) the env DB takes precedence. The env DB already
+ * contains the wish_list / entities / etc tables because
+ * `seedDatabase()` writes them there, so a single fixture stays
+ * self-contained without a background backfill into the global
+ * `finance.db`. Outside an env scope (real production boot, dev),
+ * the pillar's `finance.db` is resolved + lazily opened so the
+ * in-package migrations apply.
+ *
+ * Phase 2 PR 3 routes wish-list reads/writes through this getter.
  */
 export function getFinanceDrizzle(): FinanceDb {
+  if (isNamedEnvContext()) return drizzle(getDb()) as FinanceDb;
   if (!financeDb) {
     financeDb = openFinanceDb(resolveFinanceSqlitePath());
   }
@@ -47,14 +56,25 @@ export function closeFinanceDb(): void {
 }
 
 /**
- * Test-only: swap the finance pillar handle. Phase 2 PR 3 of this
- * pillar wires `setupTestContext` (in `shared/test-utils.ts`) up to
- * call this hook so test suites can inject an in-memory DB and avoid
- * writing to the dev `data/finance.db` file. Returns the previous
- * handle (or null).
+ * Test-only: swap the finance pillar handle. `setupTestContext` in
+ * `shared/test-utils.ts` calls this hook so test suites can inject an
+ * in-memory DB and avoid writing to the dev `data/finance.db` file.
+ * Returns the previous handle (or null).
  */
 export function setFinanceDb(next: OpenedFinanceDb | null): OpenedFinanceDb | null {
   const prev = financeDb;
   financeDb = next;
   return prev;
+}
+
+/**
+ * Run the one-shot ATTACH backfill from the legacy shared pops.db into
+ * the finance pillar's finance.db. No-op if the finance handle isn't
+ * open (e.g. boot still resolving). Idempotent against repeated boots
+ * via per-table `WHERE id NOT IN (...)` filters. See
+ * `backfill-finance-from-shared.ts` for table-by-table behaviour.
+ */
+export function backfillFinanceFromSharedDb(sharedPath: string): void {
+  if (!financeDb) return;
+  backfillFinanceFromShared(financeDb, sharedPath);
 }

--- a/apps/pops-api/src/index.ts
+++ b/apps/pops-api/src/index.ts
@@ -7,7 +7,7 @@ config({ path: '../../.env', override: false }); // loads root .env without over
 
 import { createApp } from './app.js';
 import { backfillCoreFromShared, closeDb, getCoreDrizzle } from './db.js';
-import { getFinanceDrizzle } from './db/finance-handle.js';
+import { backfillFinanceFromSharedDb, getFinanceDrizzle } from './db/finance-handle.js';
 import { backfillInventoryFromSharedDb, getInventoryDrizzle } from './db/inventory-handle.js';
 import { backfillMediaFromShared, getMediaDrizzle } from './db/media-db-handle.js';
 import { resolveSqlitePath } from './db/sqlite-path.js';
@@ -68,14 +68,14 @@ try {
 }
 
 // Eagerly open the finance pillar's SQLite + apply its journal at
-// boot. Phase 2 PR 2 of the finance pillar: the handle is opened so
-// the per-pillar migrations land before any request hits the API, but
-// no production traffic flips over yet — PR 3 of phase 2 cuts over the
-// wish-list slice with a single `getDrizzle()` → `getFinanceDrizzle()`
-// swap and adds the one-shot ATTACH-based backfill from the legacy
-// shared pops.db.
+// boot. The wish-list slice now reads/writes against this handle
+// (phase 2 PR 3); the one-shot `backfillFinanceFromSharedDb` carries
+// any rows that still live in the legacy pops.db across. The backfill
+// is idempotent (per-table `WHERE id NOT IN (...)` filters) and
+// non-fatal (partial failure logs + continues).
 try {
   getFinanceDrizzle();
+  backfillFinanceFromSharedDb(resolveSqlitePath());
 } catch (err) {
   console.error('[db] Failed to bootstrap the finance pillar SQLite:', err);
   throw err;

--- a/apps/pops-api/src/modules/finance/wishlist/router.ts
+++ b/apps/pops-api/src/modules/finance/wishlist/router.ts
@@ -21,7 +21,7 @@ import {
   type WishListPriority,
 } from '@pops/finance-db';
 
-import { getDrizzle } from '../../../db.js';
+import { getFinanceDrizzle } from '../../../db/finance-handle.js';
 import { NotFoundError } from '../../../shared/errors.js';
 import { paginationMeta } from '../../../shared/pagination.js';
 import { mapDomainErrors } from '../../../shared/trpc-error-mapper.js';
@@ -69,7 +69,7 @@ export const wishlistRouter = router({
       };
     }
 
-    const { rows, total } = wishListService.listWishListItems(getDrizzle(), {
+    const { rows, total } = wishListService.listWishListItems(getFinanceDrizzle(), {
       search: input.search,
       priority: typed,
       limit,
@@ -86,7 +86,7 @@ export const wishlistRouter = router({
   get: protectedProcedure.input(z.object({ id: z.string() })).query(({ input }) =>
     mapDomainErrors(() => {
       try {
-        const row = wishListService.getWishListItem(getDrizzle(), input.id);
+        const row = wishListService.getWishListItem(getFinanceDrizzle(), input.id);
         return { data: toWishListItem(row) };
       } catch (err) {
         if (err instanceof WishListItemNotFoundError) {
@@ -99,7 +99,7 @@ export const wishlistRouter = router({
 
   /** Create a new wish list item. */
   create: protectedProcedure.input(CreateWishListItemSchema).mutation(({ input }) => {
-    const row = wishListService.createWishListItem(getDrizzle(), input);
+    const row = wishListService.createWishListItem(getFinanceDrizzle(), input);
     return {
       data: toWishListItem(row),
       message: 'Wish list item created',
@@ -117,7 +117,7 @@ export const wishlistRouter = router({
     .mutation(({ input }) =>
       mapDomainErrors(() => {
         try {
-          const row = wishListService.updateWishListItem(getDrizzle(), input.id, input.data);
+          const row = wishListService.updateWishListItem(getFinanceDrizzle(), input.id, input.data);
           return {
             data: toWishListItem(row),
             message: 'Wish list item updated',
@@ -135,7 +135,7 @@ export const wishlistRouter = router({
   delete: protectedProcedure.input(z.object({ id: z.string() })).mutation(({ input }) =>
     mapDomainErrors(() => {
       try {
-        wishListService.deleteWishListItem(getDrizzle(), input.id);
+        wishListService.deleteWishListItem(getFinanceDrizzle(), input.id);
         return { message: 'Wish list item deleted' };
       } catch (err) {
         if (err instanceof WishListItemNotFoundError) {

--- a/apps/pops-api/src/modules/finance/wishlist/search-adapter.ts
+++ b/apps/pops-api/src/modules/finance/wishlist/search-adapter.ts
@@ -2,7 +2,7 @@ import { and, like, sql } from 'drizzle-orm';
 
 import { wishList } from '@pops/db-types';
 
-import { getDrizzle } from '../../../db.js';
+import { getFinanceDrizzle } from '../../../db/finance-handle.js';
 
 import type { Query, SearchAdapter, SearchContext, SearchHit } from '../../core/search/index.js';
 
@@ -39,7 +39,7 @@ export const wishlistSearchAdapter: SearchAdapter<WishlistHitData> = {
     const text = query.text.trim();
     if (!text) return [];
 
-    const db = getDrizzle();
+    const db = getFinanceDrizzle();
     const lowerText = text.toLowerCase();
 
     // Exclude already-purchased items (saved >= target_amount). Items with no

--- a/apps/pops-api/src/shared/test-utils.ts
+++ b/apps/pops-api/src/shared/test-utils.ts
@@ -2,6 +2,7 @@ import BetterSqlite3 from 'better-sqlite3';
 import { drizzle } from 'drizzle-orm/better-sqlite3';
 
 import { closeDb, setCoreDb, setDb } from '../db.js';
+import { setFinanceDb } from '../db/finance-handle.js';
 import { setInventoryDb } from '../db/inventory-handle.js';
 import { setMediaDb } from '../db/media-db-handle.js';
 import { appRouter } from '../router.js';
@@ -1490,11 +1491,17 @@ export function setupTestContext() {
     // home_inventory, fixtures, item_*) on the inventory handle too.
     setInventoryDb({ db: drizzle(db), raw: db });
 
+    // Same for the finance pillar handle (phase 2 PR 3): wish-list
+    // module reads/writes now resolve getFinanceDrizzle(), so the
+    // test fixture has to surface its tables on the finance handle.
+    setFinanceDb({ db: drizzle(db), raw: db });
+
     return { db, caller: createCaller(true) };
   }
 
   function teardown() {
     setCoreDb(null);
+    setFinanceDb(null);
     setInventoryDb(null);
     setMediaDb(null);
     closeDb();


### PR DESCRIPTION
## Summary

Moves the wish-list slice off the shared `pops.db` singleton onto the new `finance.db` handle opened in PR 2.

## Cutover

- `modules/finance/wishlist/router.ts` — every procedure (`list/get/create/update/delete`) resolves `getFinanceDrizzle()` instead of `getDrizzle()`.
- `modules/finance/wishlist/search-adapter.ts` — the cross-domain search surface for wish-list rows resolves `getFinanceDrizzle()` too so the search results match the canonical reads.
- `shared/test-utils.ts` `setupTestContext` installs the in-memory test DB on BOTH the shared and the finance handles so existing suites keep operating on a single SQLite fixture transparently (mirror of the core/inventory wiring).

## Backfill (ATTACH-based, idempotent, non-fatal)

- `src/db/backfill-finance-from-shared.ts` — copies `wish_list` rows with explicit column enumeration so a future schema widen doesn't silently rely on column-order parity. Wrapped in a `tryCopyTable` helper that tolerates a missing source table (post-PR-4 drop scenario, or a stale on-disk `pops.db`).
- 4 test cases: fresh copy, idempotent re-run, mixed state, missing source table tolerated.
- `WISH_LIST_TABLE_SQL` added to `backfill-test-fixtures.ts` so the test stays valid after phase 2 PR 4 deletes the shared-journal copy.

## Handle wiring (mirrors inventory-handle.ts)

- `src/db/finance-handle.ts` gains an env-aware `getFinanceDrizzle()` that yields the env DB inside a `withEnvDb()` scope (PRD-101 named environments) and the per-pillar handle otherwise, plus a `backfillFinanceFromSharedDb` wrapper.
- `src/index.ts` bootstrap block runs the backfill after the eager open.

## Test plan

- [x] `pops-api`'s `wishlist/*.test.ts` — 56/56 (unchanged, now exercising the package end-to-end via `getFinanceDrizzle()`)
- [x] `pops-api`'s `backfill-finance-from-shared.test.ts` — 4/4
- [x] `pops-api`'s `finance-sqlite-path.test.ts` — 4/4 (unchanged)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (pre-existing food/inventory-api errors are out of scope)