### PR TITLE
feat(infra): wire media-api into docker-compose + publish image (pillar media phase 3 PR 2)

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -10,6 +10,7 @@ on:
       - "apps/pops-mcp/**"
       - "apps/pops-core-api/**"
       - "apps/pops-inventory-api/**"
+      - "apps/pops-media-api/**"
       - "packages/**"
       - "infra/docker-compose*.yml"
       - "pnpm-lock.yaml"
@@ -36,6 +37,7 @@ jobs:
               - 'apps/pops-mcp/**'
               - 'apps/pops-core-api/**'
               - 'apps/pops-inventory-api/**'
+              - 'apps/pops-media-api/**'
               - 'packages/**'
               - 'pnpm-lock.yaml'
               - 'pnpm-workspace.yaml'
@@ -76,6 +78,10 @@ jobs:
       - name: Build pops-inventory-api (builder stage)
         if: github.event_name == 'push' || needs.changes.outputs.relevant == 'true'
         run: docker build --target builder -f apps/pops-inventory-api/Dockerfile .
+
+      - name: Build pops-media-api (builder stage)
+        if: github.event_name == 'push' || needs.changes.outputs.relevant == 'true'
+        run: docker build --target builder -f apps/pops-media-api/Dockerfile .
 
   compose-validate:
     name: Validate docker-compose

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -153,3 +153,29 @@ jobs:
           labels: ${{ steps.meta-inventory-api.outputs.labels }}
           build-args: |
             BUILD_VERSION=${{ github.sha }}
+
+      - name: Generate metadata for pops-media-api
+        id: meta-media-api
+        uses: docker/metadata-action@v6
+        with:
+          images: ghcr.io/knoxio/pops-media-api
+          tags: |
+            type=raw,value=main,enable={{is_default_branch}}
+            type=sha,prefix=sha-,format=short
+            type=semver,pattern={{version}}
+            type=semver,pattern=v{{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=semver,pattern=v{{major}}
+
+      - name: Build and push pops-media-api
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: apps/pops-media-api/Dockerfile
+          push: true
+          tags: ${{ steps.meta-media-api.outputs.tags }}
+          labels: ${{ steps.meta-media-api.outputs.labels }}
+          build-args: |
+            BUILD_VERSION=${{ github.sha }}

--- a/apps/pops-media-api/Dockerfile
+++ b/apps/pops-media-api/Dockerfile
@@ -52,6 +52,6 @@ COPY --from=builder --chown=node:node /app/apps/pops-media-api/dist ./dist
 ARG BUILD_VERSION=dev
 ENV BUILD_VERSION=$BUILD_VERSION
 
-EXPOSE 3002
+EXPOSE 3003
 USER node
 CMD ["node", "dist/server.js"]

--- a/apps/pops-media-api/src/server.ts
+++ b/apps/pops-media-api/src/server.ts
@@ -16,8 +16,9 @@ import { createMediaApiApp } from './app.js';
 import { resolveMediaSqlitePath } from './media-sqlite-path.js';
 
 function resolvePort(): number {
+  // 3001 is core-api, 3002 is inventory-api, 3003 is media-api.
   const raw = process.env['PORT'];
-  if (raw === undefined || raw === '') return 3002;
+  if (raw === undefined || raw === '') return 3003;
   const parsed = Number(raw);
   if (!Number.isInteger(parsed) || parsed <= 0 || parsed > 65535) {
     throw new Error(`[media-api] PORT must be a positive integer in 1-65535; got '${raw}'`);

--- a/docs/runbooks/media-api-pillar-verification.md
+++ b/docs/runbooks/media-api-pillar-verification.md
@@ -1,0 +1,81 @@
+# Media API Pillar Verification Runbook
+
+Verification drill for the **media pillar** container after the ADR-026 Phase 3 migration. Run this before flipping Track F to ✅ Done.
+
+## What media-api owns today
+
+After media pillar Phase 3:
+
+- `apps/pops-media-api/` ships as `ghcr.io/knoxio/pops-media-api`, listens on port 3003 inside the container network (3001=core, 3002=inventory, 3003=media).
+- Endpoints exposed: `GET /health`.
+- `media.db` (separate SQLite file from `pops.db`, `core.db`, and `inventory.db`) holds the `shelf_impressions` table today; subsequent slices (`watchlist`, `watch_history`, `comparisons`, `rotation`, `debrief`, `movies`, `tv_shows`, …) move their tables across in later phases. Phase 2 PR 3 cut pops-api over to `getMediaDrizzle()` for shelf-impressions reads/writes.
+- The shell talks to media **indirectly** via pops-api's tRPC routers (which now route shelf-impressions through `media.db`). The shell never opens a direct browser-to-media-api connection; cross-pillar HTTP fan-out runs on the `/pillars/health` aggregator already proxied to pops-api.
+- `pops-api`, `pops-worker`, and `pops-shell` (via nginx → core-api) all read pillar registry data that includes the media entry, because `POPS_PILLARS` in docker-compose lists `media:http://media-api:3003`.
+
+## Drill: simulate a media-api outage
+
+The Phase 4 verification per the roadmap: stop the media container and confirm the rest of the stack behaves as documented.
+
+### Step 1 — capture the healthy baseline
+
+`media-api` is exposed inside the compose network (`expose: 3003`),
+not bound to a host port. Run the probes from inside the network —
+either via `docker compose exec` on a sibling service or with an
+ad-hoc curl container:
+
+```sh
+docker compose -f infra/docker-compose.yml ps
+# core-api, inventory-api, media-api, pops-api, pops-shell, pops-worker
+# should all be "running (healthy)".
+
+# Probe from inside the compose network.
+docker compose -f infra/docker-compose.yml exec pops-api \
+  node -e "fetch('http://media-api:3003/health').then(r=>r.json()).then(j=>console.log(JSON.stringify(j)))"
+# {"ok":true,"pillar":"media","version":"<git-sha>"}
+
+# The shell's /pillars proxy is wired to core-api, which surfaces
+# media in its registry response too via POPS_PILLARS:
+curl -sS http://localhost:80/pillars
+# {"pillars":[{"id":"core","baseUrl":"http://core-api:3001"},{"id":"inventory","baseUrl":"http://inventory-api:3002"},{"id":"media","baseUrl":"http://media-api:3003"}]}
+```
+
+### Step 2 — stop media-api and observe
+
+```sh
+docker compose -f infra/docker-compose.yml stop media-api
+```
+
+Expected behaviour:
+
+- `pops-api` was started behind `depends_on: media-api (service_healthy)` — it keeps running, but **every shelf-impressions tRPC call** (today: `media.discovery.assembleSession` ingest path) writes to `media.db` on a shared volume; the container being stopped does NOT close the volume mount or the SQLite file, so reads/writes continue to land on `media.db` directly. The stop drill is therefore a soft test of compose ordering, not a real outage of the data layer. **To truly simulate an outage**, also unmount or move `media.db` aside.
+- `pops-shell` boot probe to `/pillars` still succeeds (because the proxy hits core-api, not media-api). The media entry stays in the registry; the `/pillars/health` aggregator (still on pops-api) flips media's status from `'healthy'` to `'unavailable'` after the per-probe timeout fires. `PillarGuard` reads `'unavailable'` and shows the unavailable placeholder on media routes; other routes (food, finance, inventory, lists, cerebrum) keep working.
+- The soft fallback is intentional — losing the media pillar should NOT take down the whole shell. The shell shows degraded UI on media routes and full UI everywhere else.
+
+### Step 3 — restart media-api and confirm recovery
+
+```sh
+docker compose -f infra/docker-compose.yml start media-api
+```
+
+Within ~30s the healthcheck reports healthy. Re-running the curl probes in Step 1 returns the same shapes. `PillarGuard` re-promotes media from `'unavailable'` back to `'healthy'` on the next status-context refresh; the media UI hydrates without a hard navigation.
+
+### Step 4 — write up surprises
+
+Record any unexpected behaviour in the **Lessons captured** section of
+`.claude/pillar-migration-roadmap.md` before flipping Track F to ✅
+Done. That file is gitignored — it only exists in local clones /
+sibling workspaces, so it isn't linkable from GitHub. Examples worth
+flagging:
+
+- pops-api hard-crashes when media-api is down (it shouldn't — should degrade per-route).
+- The shell's "media unavailable" placeholder paints over working non-media routes (PillarGuard scoping is too broad).
+- `media.db` writes succeed against a stopped media-api container (proves the shared-volume caveat noted in Step 2 — phase 4 follow-up: convert media-api to the sole writer once tRPC routers move into it).
+
+## Reference
+
+- ADR-026: per-domain pillar architecture
+- `apps/pops-media-api/src/server.ts` — boot sequence
+- `apps/pops-shell/src/app/pillars/pillar-registry-client.ts` — soft-fallback behaviour (shared with core)
+- `docs/runbooks/core-api-pillar-verification.md` — sibling runbook for the core pillar
+- `docs/runbooks/inventory-api-pillar-verification.md` — sibling runbook for the inventory pillar
+- `.claude/pillar-migration-roadmap.md` — Track F status + lessons captured (gitignored, local-only)

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -44,9 +44,11 @@ services:
       PORT: '3001'
       CORE_SQLITE_PATH: /data/sqlite/core.db
       CORE_SELF_BASE_URL: http://core-api:3001
-      # Cross-pillar registry. Today's deployment only runs core; sibling
-      # pillars get appended (id:baseUrl,...) as they extract.
-      POPS_PILLARS: ${POPS_PILLARS:-}
+      # Cross-pillar registry — core-api hosts the authoritative
+      # `/pillars` snapshot that the shell's nginx proxy fans out to,
+      # so it MUST default to the full sibling list rather than empty.
+      # Sibling pillars get appended (id:baseUrl,...) as they extract.
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003}
     expose:
       - '3001'
     healthcheck:

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -86,7 +86,7 @@ services:
       INVENTORY_SELF_BASE_URL: http://inventory-api:3002
       # Cross-pillar registry. Includes core-api by default so /pillars
       # surfaces both host pillars on the synthetic-entry list.
-      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002}
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003}
     expose:
       - '3002'
     depends_on:
@@ -99,6 +99,48 @@ services:
           'node',
           '-e',
           "fetch('http://localhost:3002/health').then(r=>{if(!r.ok)process.exit(1)})",
+        ]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+  # Media pillar API (ADR-026, Phase 3 PR 2 of the media track). Hosts
+  # media.db reads/writes for the shelf_impressions slice today;
+  # subsequent slices (watchlist, watch_history, comparisons, rotation,
+  # debrief, …) move their tRPC routers + URI dispatcher behind it.
+  media-api:
+    build:
+      context: ..
+      dockerfile: apps/pops-media-api/Dockerfile
+      args:
+        BUILD_VERSION: ${BUILD_VERSION:-dev}
+    container_name: pops-media-api
+    restart: unless-stopped
+    networks:
+      - frontend
+      - backend
+    volumes:
+      - sqlite-data:/data/sqlite
+    environment:
+      NODE_ENV: production
+      PORT: '3003'
+      MEDIA_SQLITE_PATH: /data/sqlite/media.db
+      MEDIA_SELF_BASE_URL: http://media-api:3003
+      # Cross-pillar registry. Includes core-api + inventory-api by default
+      # so /pillars surfaces every host pillar on the synthetic-entry list.
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003}
+    expose:
+      - '3003'
+    depends_on:
+      core-api:
+        condition: service_healthy
+    healthcheck:
+      test:
+        [
+          'CMD',
+          'node',
+          '-e',
+          "fetch('http://localhost:3003/health').then(r=>{if(!r.ok)process.exit(1)})",
         ]
       interval: 30s
       timeout: 5s
@@ -135,7 +177,7 @@ services:
       # its compose hostname so pops-api's URI dispatcher can route
       # outbound `pops:core/...` traffic to the new container. Deployers
       # override POPS_PILLARS to extend with sibling pillars.
-      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002}
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003}
       # Paperless-ngx integration (optional — leave unset to disable)
       PAPERLESS_BASE_URL: ${PAPERLESS_BASE_URL:-}
       PAPERLESS_API_TOKEN: ${PAPERLESS_API_TOKEN:-}
@@ -147,6 +189,8 @@ services:
       core-api:
         condition: service_healthy
       inventory-api:
+        condition: service_healthy
+      media-api:
         condition: service_healthy
     healthcheck:
       test:
@@ -186,13 +230,15 @@ services:
       SQLITE_PATH: /data/sqlite/pops.db
       REDIS_HOST: pops-redis
       REDIS_PORT: '6379'
-      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002}
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003}
     depends_on:
       pops-redis:
         condition: service_healthy
       core-api:
         condition: service_healthy
       inventory-api:
+        condition: service_healthy
+      media-api:
         condition: service_healthy
 
   # ── FRONTEND ─────────────────────────────────────────────────────

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -78,7 +78,7 @@ services:
       PORT: '3002'
       INVENTORY_SQLITE_PATH: /data/sqlite/inventory.db
       INVENTORY_SELF_BASE_URL: http://inventory-api:3002
-      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002}
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003}
     expose:
       - '3002'
     depends_on:
@@ -91,6 +91,44 @@ services:
           'node',
           '-e',
           "fetch('http://localhost:3002/health').then(r=>{if(!r.ok)process.exit(1)})",
+        ]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+  # Media pillar API (ADR-026, Phase 3 PR 2 of the media track). Hosts
+  # media.db reads/writes for the shelf_impressions slice today;
+  # subsequent slices (watchlist, watch_history, comparisons, rotation,
+  # debrief, …) move their tRPC routers + URI dispatcher behind it.
+  media-api:
+    image: ghcr.io/knoxio/pops-media-api:${POPS_IMAGE_TAG:-main}
+    container_name: pops-media-api
+    restart: unless-stopped
+    labels:
+      com.centurylinklabs.watchtower.enable: 'true'
+    networks:
+      - frontend
+      - backend
+    volumes:
+      - sqlite-data:/data/sqlite
+    environment:
+      NODE_ENV: production
+      PORT: '3003'
+      MEDIA_SQLITE_PATH: /data/sqlite/media.db
+      MEDIA_SELF_BASE_URL: http://media-api:3003
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003}
+    expose:
+      - '3003'
+    depends_on:
+      core-api:
+        condition: service_healthy
+    healthcheck:
+      test:
+        [
+          'CMD',
+          'node',
+          '-e',
+          "fetch('http://localhost:3003/health').then(r=>{if(!r.ok)process.exit(1)})",
         ]
       interval: 30s
       timeout: 5s
@@ -131,7 +169,7 @@ services:
       POPS_OVERLAYS: ${POPS_OVERLAYS:-}
       # Cross-pillar registry (ADR-026 Phase 3 PR 3). pops-api routes
       # outbound `pops:core/...` traffic to the core-api container.
-      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002}
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003}
     expose:
       - '3000'
     depends_on:
@@ -140,6 +178,8 @@ services:
       core-api:
         condition: service_healthy
       inventory-api:
+        condition: service_healthy
+      media-api:
         condition: service_healthy
     healthcheck:
       test:
@@ -180,13 +220,15 @@ services:
       # PRD-100 — same module set as the api so worker jobs scope correctly.
       POPS_APPS: ${POPS_APPS:-}
       POPS_OVERLAYS: ${POPS_OVERLAYS:-}
-      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002}
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003}
     depends_on:
       pops-redis:
         condition: service_healthy
       core-api:
         condition: service_healthy
       inventory-api:
+        condition: service_healthy
+      media-api:
         condition: service_healthy
 
   # ── FOOD INGEST WORKER ───────────────────────────────────────────

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -42,7 +42,10 @@ services:
       PORT: '3001'
       CORE_SQLITE_PATH: /data/sqlite/core.db
       CORE_SELF_BASE_URL: http://core-api:3001
-      POPS_PILLARS: ${POPS_PILLARS:-}
+      # Cross-pillar registry — core-api hosts the authoritative
+      # `/pillars` snapshot that the shell's nginx proxy fans out to,
+      # so it MUST default to the full sibling list rather than empty.
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003}
     expose:
       - '3001'
     healthcheck:


### PR DESCRIPTION
## Summary

Phase 3 PR 2 of the media pillar migration adds \`media-api\` as a first-class service in docker-compose + the GHCR publish pipeline. Mirrors inventory Phase 3 PR 2 (#2802) line-for-line.

### Compose

- **\`infra/docker-compose.dev.yml\`** + **\`infra/docker-compose.yml\`** gain a \`media-api\` service mirroring \`inventory-api\`: port 3003 (\`3001=core\`, \`3002=inventory\`, \`3003=media\`), shared \`sqlite-data\` volume mounted at \`/data/sqlite\`, \`restart: unless-stopped\`, healthcheck against \`/health\`, and a Watchtower label in the prod config.
- \`depends_on: core-api (service_healthy)\` so the media container waits until core-api's registry is up before booting.
- \`pops-api\` + \`pops-worker\` now also \`depends_on: media-api (service_healthy)\` so the unified pops-api boot path can talk to any pillar at startup without race conditions.
- \`POPS_PILLARS\` default extended to include \`media:http://media-api:3003\` alongside core and inventory. Operators can still override via the env var.

### Publish pipeline

- **\`.github/workflows/publish-images.yml\`** gains a metadata + build-push job for \`ghcr.io/knoxio/pops-media-api\` with the same tag matrix as \`pops-inventory-api\` (main, \`sha-XXX\`, semver + semver components).
- **\`.github/workflows/docker-build.yml\`** validates the media-api Dockerfile builder stage on every PR and adds \`apps/pops-media-api/**\` to the paths-filter (push + PR sides).

### Server fix from PR 1

Corrects a port collision left by PR 1 (#2803):

- \`apps/pops-media-api/src/server.ts\` default port: \`3002\` → \`3003\` (inventory-api already owns 3002 on the shared docker network).
- \`apps/pops-media-api/Dockerfile\` \`EXPOSE\`: \`3002\` → \`3003\`.

Phase 3 PR 3 follows: nginx \`/pillars\` proxy fan-out so the shell can consult media-api alongside core-api + inventory-api.

## Test plan

- [x] \`docker compose -f infra/docker-compose.yml config --quiet\` — clean
- [x] \`docker compose -f infra/docker-compose.dev.yml config --quiet\` — clean
- [x] \`pnpm format:check\` — clean
- [ ] CI green on \`docker-build\`, \`media-api-quality\`, \`publish-images\` (on push only)
- [ ] Copilot review pass