### PR TITLE
feat(cerebrum-db): split migration journal — 0039 + 0044 (pillar cerebrum phase 1 PR 2)

### DIFF
--- a/.github/workflows/cerebrum-db-quality.yml
+++ b/.github/workflows/cerebrum-db-quality.yml
@@ -7,6 +7,7 @@ on:
       - "packages/cerebrum-db/**"
       - "packages/db-types/**"
       - "apps/pops-api/src/db/drizzle-migrations/0039_dry_fabian_cortez.sql"
+      - "apps/pops-api/src/db/drizzle-migrations/0044_nudge_log.sql"
       - ".github/workflows/cerebrum-db-quality.yml"
       - ".github/workflows/_pkg-check.yml"
   pull_request:
@@ -28,8 +29,35 @@ jobs:
               - 'packages/cerebrum-db/**'
               - 'packages/db-types/**'
               - 'apps/pops-api/src/db/drizzle-migrations/0039_dry_fabian_cortez.sql'
+              - 'apps/pops-api/src/db/drizzle-migrations/0044_nudge_log.sql'
               - '.github/workflows/cerebrum-db-quality.yml'
               - '.github/workflows/_pkg-check.yml'
+
+  migration-drift-guard:
+    name: Migration drift (shared vs cerebrum-db)
+    needs: [changes]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Skip — no relevant changes"
+        if: github.event_name == 'pull_request' && needs.changes.outputs.relevant != 'true'
+        run: echo "Skipping — no relevant changes"
+      - uses: actions/checkout@v6
+        if: github.event_name != 'pull_request' || needs.changes.outputs.relevant == 'true'
+      - name: Diff cerebrum-db copies against shared journal copies
+        if: github.event_name != 'pull_request' || needs.changes.outputs.relevant == 'true'
+        run: |
+          set -euo pipefail
+          for tag in 0039_dry_fabian_cortez 0044_nudge_log; do
+            shared="apps/pops-api/src/db/drizzle-migrations/${tag}.sql"
+            pillar="packages/cerebrum-db/migrations/${tag}.sql"
+            if ! diff -q "$shared" "$pillar"; then
+              echo "::error::Migration drift detected: $shared and $pillar must be byte-identical during the transitional release cycle (cerebrum pillar phase 1)."
+              diff "$shared" "$pillar" || true
+              exit 1
+            fi
+            echo "OK — both ${tag}.sql copies are byte-identical."
+          done
 
   quality:
     needs: [changes]

--- a/apps/pops-api/src/db/per-pillar-migrations.test.ts
+++ b/apps/pops-api/src/db/per-pillar-migrations.test.ts
@@ -208,13 +208,16 @@ describe('runPerPillarMigrations', () => {
     // owns `packages/inventory-db/migrations/` with 0005_fancy_crystal
     // (inventory pillar Phase 1 PR 2) AND 0006_inventory_pillar_baseline
     // (inventory pillar Phase 2 PR 3 — comprehensive home_inventory +
-    // fixtures + item_* baseline ahead of the cutover). Pillars without
-    // their own journal yet still skip cleanly.
+    // fixtures + item_* baseline ahead of the cutover); `cerebrum` owns
+    // `packages/cerebrum-db/migrations/` with 0039_dry_fabian_cortez and
+    // 0044_nudge_log (cerebrum pillar Phase 1 PR 2 — nudge_log slice).
+    // Pillars without their own journal yet still skip cleanly.
     await withDb((db) => {
       const realPillars: PillarDescriptor[] = [
         { id: 'core', dbPackageDir: 'packages/core-db' },
         { id: 'media', dbPackageDir: 'packages/media-db' },
         { id: 'inventory', dbPackageDir: 'packages/inventory-db' },
+        { id: 'cerebrum', dbPackageDir: 'packages/cerebrum-db' },
         { id: 'unmigrated', dbPackageDir: 'packages/this-dir-does-not-exist-db' },
       ];
       const result = runPerPillarMigrations(db, realPillars);
@@ -222,9 +225,16 @@ describe('runPerPillarMigrations', () => {
         '0005_fancy_crystal',
         '0006_inventory_pillar_baseline',
         '0021_spooky_lockheed',
+        '0039_dry_fabian_cortez',
+        '0044_nudge_log',
         '0054_service_accounts',
       ]);
-      expect([...result.pillarsApplied].toSorted()).toEqual(['core', 'inventory', 'media']);
+      expect([...result.pillarsApplied].toSorted()).toEqual([
+        'cerebrum',
+        'core',
+        'inventory',
+        'media',
+      ]);
       expect(result.pillarsSkipped).toEqual(['unmigrated']);
     });
   });

--- a/packages/cerebrum-db/migrations/0044_nudge_log.sql
+++ b/packages/cerebrum-db/migrations/0044_nudge_log.sql
@@ -1,0 +1,24 @@
+-- Nudge log table (PRD-084). Safety migration: creates the table if it was
+-- missed during fresh-database initialisation before schema.ts was updated.
+-- Uses CREATE TABLE IF NOT EXISTS so it is safe to run against databases
+-- that already have the table (created by migration 0039).
+CREATE TABLE IF NOT EXISTS `nudge_log` (
+	`id` text PRIMARY KEY NOT NULL,
+	`type` text NOT NULL,
+	`title` text NOT NULL,
+	`body` text NOT NULL,
+	`engram_ids` text NOT NULL,
+	`priority` text NOT NULL,
+	`status` text NOT NULL,
+	`created_at` text NOT NULL,
+	`expires_at` text,
+	`acted_at` text,
+	`action_type` text,
+	`action_label` text,
+	`action_params` text
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_nudge_log_type` ON `nudge_log` (`type`);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_nudge_log_status` ON `nudge_log` (`status`);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_nudge_log_priority` ON `nudge_log` (`priority`);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_nudge_log_created_at` ON `nudge_log` (`created_at`);

--- a/packages/cerebrum-db/migrations/meta/_journal.json
+++ b/packages/cerebrum-db/migrations/meta/_journal.json
@@ -1,0 +1,20 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "6",
+      "when": 1777334137968,
+      "tag": "0039_dry_fabian_cortez",
+      "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1777633800000,
+      "tag": "0044_nudge_log",
+      "breakpoints": true
+    }
+  ]
+}

--- a/packages/cerebrum-db/src/__tests__/nudge-log.test.ts
+++ b/packages/cerebrum-db/src/__tests__/nudge-log.test.ts
@@ -8,10 +8,10 @@
  *
  * The nudge_log CREATE TABLE is read from the package-local migration
  * copy at `packages/cerebrum-db/migrations/0039_dry_fabian_cortez.sql`.
- * That file is intentionally byte-identical to the shared journal copy
- * at `apps/pops-api/src/db/drizzle-migrations/0039_dry_fabian_cortez.sql`
- * during the transitional release cycle (PR 2 adds the drift-guard CI
- * job that enforces the byte-identity invariant). The safety re-creation
+ * A drift guard in `cerebrum-db-quality.yml` keeps that file
+ * byte-identical to the shared journal copy at
+ * `apps/pops-api/src/db/drizzle-migrations/0039_dry_fabian_cortez.sql`
+ * until the deletion PR retires the shared one. The safety re-creation
  * tag (`0044_nudge_log`) does not need to be applied here — it would be
  * idempotent against an already-seeded DB and adds no schema state.
  */


### PR DESCRIPTION
## Summary

Phase 1 PR 2 of Track H (cerebrum pillar migration, `.claude/pillar-migration-roadmap.md`). Splits the nudge_log slice's migration journal off the shared journal into `packages/cerebrum-db/migrations/` and wires up the byte-identity drift guard. Builds directly on PR #2797 — `0039_dry_fabian_cortez.sql` was already copied there (one cycle earlier than the inventory pattern); this PR copies `0044_nudge_log.sql`, adds the `_journal.json`, and lights up the drift-guard CI job.

**Strictly additive.** The pops-api nudges module is unchanged so all existing callers (NudgeService, router, the in-tree nudge tests) keep working. PR 3 of Phase 1 flips pops-api to import `@pops/cerebrum-db`; PR 4 deletes the in-tree shim AND retires the shared journal entries.

### Highlights

- `packages/cerebrum-db/migrations/0044_nudge_log.sql` — byte-identical copy of the shared journal's safety re-creation tag (idempotent `CREATE TABLE IF NOT EXISTS`).
- `packages/cerebrum-db/migrations/meta/_journal.json` — two entries (0039 + 0044) with the original `when` timestamps from the shared journal, so drizzle-kit's hash-based tracking stays consistent.
- `.github/workflows/cerebrum-db-quality.yml` — adds the `migration-drift-guard` job (loops over both tags, fails on any byte divergence). Also extends `push.paths` AND the paths-filter with `0044_nudge_log.sql` so the workflow fires whenever either shared copy changes.
- `apps/pops-api/src/db/per-pillar-migrations.test.ts` — adds the `cerebrum` descriptor to the smoke test's real-layout fallback so the per-pillar runner exercises the new journal end-to-end against a fresh in-memory DB. Both tags land in `applied` (0039 creates the table; 0044 is `IF NOT EXISTS` and succeeds without error, so still classified `applied` rather than `backfilled`).
- `packages/cerebrum-db/src/__tests__/nudge-log.test.ts` — updates the file-header docstring to describe the drift guard as already-live in this PR's workflow, not a PR-2 forward reference.

### Shared journal stays in place

The shared journal still owns the 0039/0044 entries this release cycle:

- `MIGRATION_OWNERS` map keeps `'0039_dry_fabian_cortez': 'cerebrum'` and `'0044_nudge_log': 'cerebrum'`.
- `cerebrumMigrationTags` in `apps/pops-api/src/modules/cerebrum/migrations.ts` keeps both tags.
- `apps/pops-api/src/db/drizzle-migrations/{0039,0044}.sql` stay byte-identical to the package copies, guarded by the new drift-guard job.

At boot the shared runner applies them; the per-pillar runner then re-runs against the same DB and lands in the "already-applied / IF NOT EXISTS" no-op path — same shape inventory and core use today. Migration-ownership contract guard stays green because the static map, manifest, and shared journal remain in lockstep.

### Roadmap notes

- Row H still claimed by `pops5 · 2026-06-10T12:12Z` (Phase 1 PR 1 row entry updated when #2797 merged; PR 2 row update on merge of this PR).
- pops-api does NOT depend on `@pops/cerebrum-db` yet — all Dockerfile / `api-quality` / `api-test` / `fe-quality` / `fe-test-e2e` paths-filter + build-step updates land in PR 3 (cutover), per the inventory lesson logged on 2026-06-10.

## Test plan

- [x] `pnpm --filter @pops/cerebrum-db test` — 16/16 pass against the package-local migration copies.
- [x] `pnpm vitest run src/db/per-pillar-migrations.test.ts` (in `apps/pops-api`) — 7/7 pass; the real-layout smoke test now applies cerebrum's 0039 + 0044 alongside the existing core/media/inventory journals.
- [x] `pnpm typecheck` (full workspace turbo) — 40/40 packages green.
- [x] `pnpm format:check` — clean.
- [x] `diff -q` both shared/pillar pairs — byte-identical (the drift-guard logic, run locally).
