### PR TITLE
feat(api): flip nudge_log to the cerebrum pillar handle (pillar cerebrum phase 1 PR 3)

### DIFF
--- a/.github/workflows/api-quality.yml
+++ b/.github/workflows/api-quality.yml
@@ -7,6 +7,7 @@ on:
       - main
     paths:
       - "apps/pops-api/**"
+      - "packages/cerebrum-db/**"
       - "packages/db-types/**"
       - "packages/finance-db/**"
       - "packages/inventory-db/**"
@@ -28,6 +29,7 @@ jobs:
           filters: |
             api:
               - 'apps/pops-api/**'
+              - 'packages/cerebrum-db/**'
               - 'packages/db-types/**'
               - 'packages/finance-db/**'
               - 'packages/inventory-db/**'
@@ -75,6 +77,7 @@ jobs:
           cd ../finance-db && pnpm build
           cd ../inventory-db && pnpm build
           cd ../media-db && pnpm build
+          cd ../cerebrum-db && pnpm build
           cd ../app-lists-db && pnpm build
           cd ../app-food-db && pnpm build
 

--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -3,6 +3,15 @@ name: API Tests
 on:
   push:
     branches: [main, develop]
+    paths:
+      - "apps/pops-api/**"
+      - "packages/cerebrum-db/**"
+      - "packages/db-types/**"
+      - "packages/finance-db/**"
+      - "packages/inventory-db/**"
+      - "packages/types/**"
+      - "packages/auth/**"
+      - ".github/workflows/api-test.yml"
   pull_request:
 
 jobs:

--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -20,6 +20,7 @@ jobs:
           filters: |
             backend:
               - 'apps/pops-api/**'
+              - 'packages/cerebrum-db/**'
               - 'packages/db-types/**'
               - 'packages/finance-db/**'
               - 'packages/inventory-db/**'
@@ -68,6 +69,7 @@ jobs:
           cd ../finance-db && pnpm build
           cd ../inventory-db && pnpm build
           cd ../media-db && pnpm build
+          cd ../cerebrum-db && pnpm build
           cd ../app-lists-db && pnpm build
           cd ../app-food-db && pnpm build
 

--- a/.github/workflows/fe-quality.yml
+++ b/.github/workflows/fe-quality.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "apps/pops-shell/**"
       - "packages/app-*/**"
+      - "packages/cerebrum-db/**"
       - "packages/db-types/**"
       - "packages/inventory-db/**"
       - "packages/ui/**"
@@ -32,6 +33,7 @@ jobs:
             shell:
               - 'apps/pops-shell/**'
               - 'packages/app-*/**'
+              - 'packages/cerebrum-db/**'
               - 'packages/db-types/**'
               - 'packages/inventory-db/**'
               - 'packages/ui/**'
@@ -79,6 +81,7 @@ jobs:
           cd ../finance-db && pnpm build
           cd ../inventory-db && pnpm build
           cd ../media-db && pnpm build
+          cd ../cerebrum-db && pnpm build
           cd ../app-lists-db && pnpm build
           cd ../app-food-db && pnpm build
 

--- a/.github/workflows/fe-test-e2e.yml
+++ b/.github/workflows/fe-test-e2e.yml
@@ -66,6 +66,7 @@ jobs:
           cd ../finance-db && pnpm build
           cd ../inventory-db && pnpm build
           cd ../media-db && pnpm build
+          cd ../cerebrum-db && pnpm build
           cd ../app-lists-db && pnpm build
           cd ../app-food-db && pnpm build
 

--- a/apps/pops-api/Dockerfile
+++ b/apps/pops-api/Dockerfile
@@ -16,6 +16,7 @@ COPY packages/finance-db/package.json ./packages/finance-db/
 COPY packages/media-db/package.json ./packages/media-db/
 COPY packages/food-contracts/package.json ./packages/food-contracts/
 COPY packages/inventory-db/package.json ./packages/inventory-db/
+COPY packages/cerebrum-db/package.json ./packages/cerebrum-db/
 COPY apps/pops-api/package.json ./apps/pops-api/
 
 # Install pnpm and dependencies (cached across builds)
@@ -47,6 +48,9 @@ COPY packages/food-contracts/tsconfig.json ./packages/food-contracts/
 COPY packages/inventory-db/src ./packages/inventory-db/src
 COPY packages/inventory-db/tsconfig.json ./packages/inventory-db/
 COPY packages/inventory-db/migrations ./packages/inventory-db/migrations
+COPY packages/cerebrum-db/src ./packages/cerebrum-db/src
+COPY packages/cerebrum-db/tsconfig.json ./packages/cerebrum-db/
+COPY packages/cerebrum-db/migrations ./packages/cerebrum-db/migrations
 COPY apps/pops-api/tsconfig.json ./apps/pops-api/
 COPY apps/pops-api/src ./apps/pops-api/src
 
@@ -66,6 +70,8 @@ RUN pnpm build
 WORKDIR /app/packages/inventory-db
 RUN pnpm build
 WORKDIR /app/packages/media-db
+RUN pnpm build
+WORKDIR /app/packages/cerebrum-db
 RUN pnpm build
 WORKDIR /app/packages/app-lists-db
 RUN pnpm build
@@ -116,6 +122,9 @@ COPY --from=builder /app/packages/inventory-db/migrations ./node_modules/@pops/i
 COPY --from=builder /app/packages/media-db/dist ./node_modules/@pops/media-db/dist
 COPY --from=builder /app/packages/media-db/package.json ./node_modules/@pops/media-db/
 COPY --from=builder /app/packages/media-db/migrations ./node_modules/@pops/media-db/migrations
+COPY --from=builder /app/packages/cerebrum-db/dist ./node_modules/@pops/cerebrum-db/dist
+COPY --from=builder /app/packages/cerebrum-db/package.json ./node_modules/@pops/cerebrum-db/
+COPY --from=builder /app/packages/cerebrum-db/migrations ./node_modules/@pops/cerebrum-db/migrations
 
 # Copy types source into node_modules (source-only package, no build step)
 COPY --from=builder /app/packages/types/src ./node_modules/@pops/types/src

--- a/apps/pops-api/package.json
+++ b/apps/pops-api/package.json
@@ -78,6 +78,7 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@pops/app-food-db": "workspace:*",
     "@pops/app-lists-db": "workspace:*",
+    "@pops/cerebrum-db": "workspace:*",
     "@pops/core-db": "workspace:*",
     "@pops/db-types": "workspace:*",
     "@pops/finance-db": "workspace:*",

--- a/apps/pops-api/src/modules/cerebrum/nudges/nudge-helpers.ts
+++ b/apps/pops-api/src/modules/cerebrum/nudges/nudge-helpers.ts
@@ -1,50 +1,10 @@
 /**
- * Nudge persistence and data-mapping helpers (PRD-084).
+ * Re-exports of the nudge_log row-mapping helpers.
  *
- * Extracted from NudgeService to keep the service file within line limits.
+ * The canonical implementations live in `@pops/cerebrum-db`. This file
+ * preserves the existing import path that the rest of the cerebrum
+ * module reaches for, so the cutover is mechanical. Once every caller
+ * has been redirected to import from the package directly (PR 4
+ * onwards), this file is deleted.
  */
-import type { NudgeLogRow as DrizzleNudgeLogRow } from '@pops/db-types';
-
-import type { Nudge, NudgeActionType, NudgePriority, NudgeStatus, NudgeType } from './types.js';
-
-/**
- * Shape of a row read from the `nudge_log` table.
- *
- * Re-exported from the drizzle inference so the JS-side property names
- * (`engramIds`, `createdAt`, ...) match what a `db.select()` actually
- * returns. The schema's SQL-side column names use snake_case but
- * drizzle maps them to camelCase on the JS side.
- */
-export type NudgeLogRow = DrizzleNudgeLogRow;
-
-/** Map a nudge_log row to a Nudge domain object. */
-export function rowToNudge(row: NudgeLogRow): Nudge {
-  return {
-    id: row.id,
-    type: row.type as NudgeType,
-    title: row.title,
-    body: row.body,
-    engramIds: JSON.parse(row.engramIds) as string[],
-    priority: row.priority as NudgePriority,
-    status: row.status as NudgeStatus,
-    createdAt: row.createdAt,
-    expiresAt: row.expiresAt,
-    actedAt: row.actedAt,
-    action: row.actionType
-      ? {
-          type: row.actionType as NudgeActionType,
-          label: row.actionLabel ?? '',
-          params: row.actionParams ? (JSON.parse(row.actionParams) as Record<string, unknown>) : {},
-        }
-      : null,
-  };
-}
-
-/** Generate a nudge ID per PRD-084 spec: `nudge_{YYYYMMDD}_{HHmm}_{type}_{slug}`. */
-export function generateNudgeId(type: NudgeType, now: Date): string {
-  const pad = (n: number, len: number): string => String(n).padStart(len, '0');
-  const date = `${now.getFullYear()}${pad(now.getMonth() + 1, 2)}${pad(now.getDate(), 2)}`;
-  const time = `${pad(now.getHours(), 2)}${pad(now.getMinutes(), 2)}`;
-  const rand = Math.random().toString(36).slice(2, 8);
-  return `nudge_${date}_${time}_${type}_${rand}`;
-}
+export { generateNudgeId, rowToNudge, type NudgeLogRow } from '@pops/cerebrum-db';

--- a/apps/pops-api/src/modules/cerebrum/nudges/nudge-persistence.ts
+++ b/apps/pops-api/src/modules/cerebrum/nudges/nudge-persistence.ts
@@ -1,23 +1,24 @@
 /**
- * Nudge persistence helpers — extracted from NudgeService to stay under
- * the max-lines lint rule.
+ * Cross-table read helper for the nudge subsystem.
+ *
+ * Loads the active engram summaries that detectors scan over. Stays in
+ * pops-api for now — it reads `engram_index` / `engram_scopes` /
+ * `engram_tags`, all cerebrum-owned tables that move when the engrams
+ * slice migrates into `@pops/cerebrum-db` in a later PR.
+ *
+ * The nudge_log persistence functions (`persistCandidates`,
+ * `listContradictions`, `enforcePendingCap`) used to live here too;
+ * they moved to `@pops/cerebrum-db` in Phase 1 PR 1 (#2797) and the
+ * NudgeService consumes them from the package directly as of this
+ * cutover PR.
  */
-import { and, count, eq, inArray, sql } from 'drizzle-orm';
+import { inArray, sql } from 'drizzle-orm';
 
-import { engramIndex, engramScopes, engramTags, nudgeLog } from '@pops/db-types';
-
-import { logger } from '../../../lib/logger.js';
-import { generateNudgeId, rowToNudge } from './nudge-helpers.js';
+import { engramIndex, engramScopes, engramTags } from '@pops/db-types';
 
 import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 
-import type {
-  EngramSummary,
-  Nudge,
-  NudgeCandidate,
-  NudgeStatus,
-  NudgeThresholds,
-} from './types.js';
+import type { EngramSummary } from './types.js';
 
 /** Group rows by engramId into a multi-value map. */
 function buildLookup(rows: { engramId: string; val: string }[]): Map<string, string[]> {
@@ -65,138 +66,4 @@ export function loadActiveEngrams(db: BetterSQLite3Database): EngramSummary[] {
     createdAt: r.createdAt,
     modifiedAt: r.modifiedAt,
   }));
-}
-
-/** Persist nudge candidates, enforcing cooldown dedup. */
-export function persistCandidates(
-  db: BetterSQLite3Database,
-  candidates: NudgeCandidate[],
-  thresholds: NudgeThresholds,
-  now: () => Date
-): number {
-  let created = 0;
-  for (const candidate of candidates) {
-    if (isInCooldown(db, candidate, thresholds, now)) continue;
-    db.insert(nudgeLog)
-      .values({
-        id: generateNudgeId(candidate.type, now()),
-        type: candidate.type,
-        title: candidate.title,
-        body: candidate.body,
-        engramIds: JSON.stringify(candidate.engramIds),
-        priority: candidate.priority,
-        status: 'pending',
-        createdAt: now().toISOString(),
-        expiresAt: candidate.expiresAt,
-        actionType: candidate.action?.type ?? null,
-        actionLabel: candidate.action?.label ?? null,
-        actionParams: candidate.action ? JSON.stringify(candidate.action.params) : null,
-      })
-      .run();
-    created++;
-  }
-  return created;
-}
-
-/** Check cooldown: same type + same engram IDs within the cooldown window. */
-function isInCooldown(
-  db: BetterSQLite3Database,
-  candidate: NudgeCandidate,
-  thresholds: NudgeThresholds,
-  now: () => Date
-): boolean {
-  const cooldownMs = thresholds.nudgeCooldownHours * 60 * 60 * 1000;
-  const cutoff = new Date(now().getTime() - cooldownMs).toISOString();
-  const sortedIds = JSON.stringify([...candidate.engramIds].toSorted());
-
-  const recent = db
-    .select({ engramIds: nudgeLog.engramIds })
-    .from(nudgeLog)
-    .where(and(eq(nudgeLog.type, candidate.type), sql`${nudgeLog.createdAt} >= ${cutoff}`))
-    .all();
-
-  return recent.some((row) => {
-    const existing = JSON.stringify((JSON.parse(row.engramIds) as string[]).toSorted());
-    return existing === sortedIds;
-  });
-}
-
-/**
- * List contradiction pattern nudges (PRD-084 US-03).
- *
- * Filters at the SQL layer with a `json_extract` predicate on
- * `action_params` so non-contradiction pattern nudges (recurring,
- * emerging) cannot consume page slots or inflate `total`. Pagination
- * applies after the filter, which is what makes it honest.
- */
-export function listContradictions(
-  db: BetterSQLite3Database,
-  opts: { status?: NudgeStatus | null; limit?: number; offset?: number } = {}
-): { nudges: Nudge[]; total: number } {
-  const conditions = [eq(nudgeLog.type, 'pattern')];
-  if (opts.status !== null && opts.status !== undefined) {
-    conditions.push(eq(nudgeLog.status, opts.status));
-  }
-  // Require every field that the UI projection needs so total === rows after pagination.
-  conditions.push(
-    sql`json_extract(${nudgeLog.actionParams}, '$.contradiction.engramA') IS NOT NULL`,
-    sql`json_extract(${nudgeLog.actionParams}, '$.contradiction.engramB') IS NOT NULL`,
-    sql`json_extract(${nudgeLog.actionParams}, '$.contradiction.excerptA') IS NOT NULL`,
-    sql`json_extract(${nudgeLog.actionParams}, '$.contradiction.excerptB') IS NOT NULL`,
-    sql`json_extract(${nudgeLog.actionParams}, '$.contradiction.conflict') IS NOT NULL`
-  );
-
-  const where = and(...conditions);
-  const limit = opts.limit ?? 50;
-  const offset = opts.offset ?? 0;
-
-  const rows = db
-    .select()
-    .from(nudgeLog)
-    .where(where)
-    .orderBy(sql`${nudgeLog.createdAt} desc`)
-    .limit(limit)
-    .offset(offset)
-    .all();
-
-  const [totalRow] = db.select({ total: count() }).from(nudgeLog).where(where).all();
-
-  return {
-    nudges: rows.map((r) => rowToNudge(r)),
-    total: totalRow?.total ?? 0,
-  };
-}
-
-/** Enforce the max pending nudges cap by expiring oldest. */
-export function enforcePendingCap(db: BetterSQLite3Database, maxPending: number): void {
-  const [countRow] = db
-    .select({ total: count() })
-    .from(nudgeLog)
-    .where(eq(nudgeLog.status, 'pending'))
-    .all();
-
-  const pendingCount = countRow?.total ?? 0;
-  if (pendingCount <= maxPending) return;
-
-  const excess = pendingCount - maxPending;
-  const oldest = db
-    .select({ id: nudgeLog.id })
-    .from(nudgeLog)
-    .where(eq(nudgeLog.status, 'pending'))
-    .orderBy(nudgeLog.createdAt)
-    .limit(excess)
-    .all();
-
-  if (oldest.length > 0) {
-    db.update(nudgeLog)
-      .set({ status: 'expired' })
-      .where(
-        inArray(
-          nudgeLog.id,
-          oldest.map((r) => r.id)
-        )
-      )
-      .run();
-    logger.info({ expired: oldest.length }, '[NudgeService] Expired oldest pending nudges');
-  }
 }

--- a/apps/pops-api/src/modules/cerebrum/nudges/nudge-service.ts
+++ b/apps/pops-api/src/modules/cerebrum/nudges/nudge-service.ts
@@ -7,17 +7,13 @@
  */
 import { and, count, eq, sql } from 'drizzle-orm';
 
+import { nudgeLogService } from '@pops/cerebrum-db';
 import { nudgeLog } from '@pops/db-types';
 
 import { logger } from '../../../lib/logger.js';
 import { ConcatenationSynthesizer, executeConsolidationAct } from './consolidation-act.js';
 import { rowToNudge } from './nudge-helpers.js';
-import {
-  enforcePendingCap,
-  listContradictions,
-  loadActiveEngrams,
-  persistCandidates,
-} from './nudge-persistence.js';
+import { loadActiveEngrams } from './nudge-persistence.js';
 
 import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 
@@ -82,7 +78,7 @@ export class NudgeService {
     let totalCreated = 0;
 
     if (!type || type === 'consolidation') {
-      totalCreated += persistCandidates(
+      totalCreated += nudgeLogService.persistCandidates(
         this.db,
         (await this.consolidationDetector.detect(engrams)).nudges,
         this.thresholds,
@@ -90,7 +86,7 @@ export class NudgeService {
       );
     }
     if (!type || type === 'staleness') {
-      totalCreated += persistCandidates(
+      totalCreated += nudgeLogService.persistCandidates(
         this.db,
         this.stalenessDetector.detect(engrams).nudges,
         this.thresholds,
@@ -98,7 +94,7 @@ export class NudgeService {
       );
     }
     if (!type || type === 'pattern') {
-      totalCreated += persistCandidates(
+      totalCreated += nudgeLogService.persistCandidates(
         this.db,
         (await this.patternDetector.detect(engrams)).nudges,
         this.thresholds,
@@ -106,7 +102,10 @@ export class NudgeService {
       );
     }
 
-    enforcePendingCap(this.db, this.thresholds.maxPendingNudges);
+    const expired = nudgeLogService.enforcePendingCap(this.db, this.thresholds.maxPendingNudges);
+    if (expired > 0) {
+      logger.info({ expired }, '[NudgeService] Expired oldest pending nudges');
+    }
     logger.info({ created: totalCreated, type: type ?? 'all' }, '[NudgeService] Scan complete');
     return { created: totalCreated };
   }
@@ -143,7 +142,7 @@ export class NudgeService {
     nudges: Nudge[];
     total: number;
   } {
-    return listContradictions(this.db, opts);
+    return nudgeLogService.listContradictions(this.db, opts);
   }
 
   /** Get a single nudge by ID. */

--- a/apps/pops-mcp/Dockerfile
+++ b/apps/pops-mcp/Dockerfile
@@ -16,6 +16,7 @@ COPY packages/finance-db/package.json ./packages/finance-db/
 COPY packages/media-db/package.json ./packages/media-db/
 COPY packages/food-contracts/package.json ./packages/food-contracts/
 COPY packages/inventory-db/package.json ./packages/inventory-db/
+COPY packages/cerebrum-db/package.json ./packages/cerebrum-db/
 COPY apps/pops-api/package.json ./apps/pops-api/
 COPY apps/pops-mcp/package.json ./apps/pops-mcp/
 
@@ -48,6 +49,9 @@ COPY packages/food-contracts/tsconfig.json ./packages/food-contracts/
 COPY packages/inventory-db/src ./packages/inventory-db/src
 COPY packages/inventory-db/tsconfig.json ./packages/inventory-db/
 COPY packages/inventory-db/migrations ./packages/inventory-db/migrations
+COPY packages/cerebrum-db/src ./packages/cerebrum-db/src
+COPY packages/cerebrum-db/tsconfig.json ./packages/cerebrum-db/
+COPY packages/cerebrum-db/migrations ./packages/cerebrum-db/migrations
 
 # Copy pops-api source (needed only for AppRouter type resolution at compile time)
 COPY apps/pops-api/tsconfig.json ./apps/pops-api/
@@ -74,6 +78,8 @@ RUN pnpm build
 WORKDIR /app/packages/inventory-db
 RUN pnpm build
 WORKDIR /app/packages/media-db
+RUN pnpm build
+WORKDIR /app/packages/cerebrum-db
 RUN pnpm build
 WORKDIR /app/packages/app-lists-db
 RUN pnpm build

--- a/apps/pops-shell/Dockerfile
+++ b/apps/pops-shell/Dockerfile
@@ -19,6 +19,7 @@ COPY packages/core-db/package.json ./packages/core-db/
 COPY packages/finance-db/package.json ./packages/finance-db/
 COPY packages/inventory-db/package.json ./packages/inventory-db/
 COPY packages/media-db/package.json ./packages/media-db/
+COPY packages/cerebrum-db/package.json ./packages/cerebrum-db/
 COPY packages/app-media/package.json ./packages/app-media/
 COPY packages/app-inventory/package.json ./packages/app-inventory/
 COPY packages/app-ai/package.json ./packages/app-ai/
@@ -47,6 +48,7 @@ COPY packages/core-db/ ./packages/core-db/
 COPY packages/finance-db/ ./packages/finance-db/
 COPY packages/inventory-db/ ./packages/inventory-db/
 COPY packages/media-db/ ./packages/media-db/
+COPY packages/cerebrum-db/ ./packages/cerebrum-db/
 COPY packages/food-contracts/ ./packages/food-contracts/
 WORKDIR /app/packages/db-types
 RUN pnpm build
@@ -63,6 +65,8 @@ RUN pnpm build
 WORKDIR /app/packages/inventory-db
 RUN pnpm build
 WORKDIR /app/packages/media-db
+RUN pnpm build
+WORKDIR /app/packages/cerebrum-db
 RUN pnpm build
 WORKDIR /app/packages/app-lists-db
 RUN pnpm build

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       '@pops/app-lists-db':
         specifier: workspace:*
         version: link:../../packages/app-lists-db
+      '@pops/cerebrum-db':
+        specifier: workspace:*
+        version: link:../../packages/cerebrum-db
       '@pops/core-db':
         specifier: workspace:*
         version: link:../../packages/core-db


### PR DESCRIPTION
## Summary

Phase 1 PR 3 of Track H (cerebrum pillar migration). Cuts pops-api over to `@pops/cerebrum-db` for the nudge_log persistence slice.

The contract surface stays identical: `NudgeService.scan` / `listContradictions` / `list` return the same shapes; the router and detectors are untouched. The cutover is at the call-site level — `NudgeService` now calls `nudgeLogService.persistCandidates` / `listContradictions` / `enforcePendingCap` on the package; the in-tree copies of those three functions are gone from `nudge-persistence.ts`.

`loadActiveEngrams` stays in `nudge-persistence.ts` for this PR because it reads `engram_index` / `engram_scopes` / `engram_tags` — engrams-slice tables that migrate later. PR 4 retires the in-tree shim and shared journal ownership; loadActiveEngrams will move when the engrams slice gets its own scaffold PR.

### Highlights

- **`apps/pops-api/package.json`** — adds `@pops/cerebrum-db` workspace dep.
- **`nudge-service.ts`** — imports `nudgeLogService` from `@pops/cerebrum-db`; flips three call sites in `scan()` and one in `listContradictions()`.
- **`nudge-helpers.ts`** — now a one-liner that re-exports `rowToNudge` / `generateNudgeId` / `NudgeLogRow` from the package. The file gets deleted in PR 4 once every internal import is flipped to import from the package directly.
- **`nudge-persistence.ts`** — strips `persistCandidates`, `listContradictions`, `enforcePendingCap` (now in the package). Keeps only `loadActiveEngrams`; updates the file's docstring to record the move.
- **`enforcePendingCap` contract change** — was `void` and logged via the pops-api logger; the package version returns the expired count and stays logger-agnostic. `NudgeService.scan()` now logs the count at the call site (`'[NudgeService] Expired oldest pending nudges'` — same message as before).
- **`NudgeThresholds`** structurally satisfies the package's narrower `NudgePersistenceThresholds` (`{ nudgeCooldownHours: number }`), so no type change at the boundary — pops-api keeps the wider settings-aware bundle.

### CI + Dockerfile wiring (per the Track G PR 3 lesson)

Every workflow that pre-builds the pillar `-db` packages gains `packages/cerebrum-db/**` in both `push.paths` AND the paths-filter, plus the `pnpm build` step after `media-db`:

- `.github/workflows/api-quality.yml`
- `.github/workflows/api-test.yml`
- `.github/workflows/fe-quality.yml`
- `.github/workflows/fe-test-e2e.yml` (uses `packages/**` for its paths-filter — only the build step needs the addition)

Three Dockerfiles updated:

- `apps/pops-api/Dockerfile` — install-stage `package.json` copy, build-stage `src` + `tsconfig.json` + `migrations` copy, `pnpm build` after media-db, runtime-stage `dist` + `package.json` + `migrations` copy into `node_modules/@pops/cerebrum-db/` so the per-pillar migration runner's `require.resolve('@pops/cerebrum-db/package.json')` lookup finds the migrations dir at boot.
- `apps/pops-shell/Dockerfile` — full `COPY packages/cerebrum-db/` + `pnpm build` (mandatory because shell typechecks pops-api source for AppRouter type resolution; if the package isn't built the import resolves to `undefined` and the `nudgeLogService` reference cascades into `TS18046` errors).
- `apps/pops-mcp/Dockerfile` — same `package.json` + `src` + `tsconfig.json` + `migrations` copy and build step. No runtime copy needed (mcp doesn't run migrations).

### Roadmap notes

- Row H still claimed by `pops5 · 2026-06-10T12:12Z`.
- The shared journal entries for 0039 + 0044 stay in place along with their `MIGRATION_OWNERS` map entries and `cerebrumMigrationTags` declarations. PR 4 retires them after the one-release-cycle window (per the inventory PR 4 pattern). The drift guard from PR 2 keeps both copies byte-identical until then.

## Test plan

- [x] `pnpm --filter @pops/cerebrum-db test` — 16/16 pass.
- [x] `pnpm --filter @pops/api vitest run src/modules/cerebrum/nudges/` — 9 files / 91 tests pass (unchanged after the cutover; tests exercise NudgeService via the same public methods).
- [x] `pnpm typecheck` (full workspace turbo) — 43/43 packages green.
- [x] `pnpm lint` — no new errors.
- [x] `pnpm format:check` — clean.
- [x] `pnpm lint:boundaries` — no dep-cruiser violations.
- [x] `pnpm install --frozen-lockfile` — lockfile consistent.
