### PR TITLE
feat(infra): finance pillar Litestream config + AGENTS.md per-pillar note (pillar finance phase 2 PR 4)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -266,7 +266,7 @@ When a movie is added to the POPS library, automatically checks Plex Discover cl
 - **Chat:** Moltbot (Telegram)
 - **Backup:** Backblaze B2 via rclone (encrypted)
 - **Litestream exclusions:** `MEDIA_IMAGES_DIR` and `FOOD_INGEST_DIR` are regeneratable media trees and must be excluded from Litestream replication in the homelab-infra repo's Litestream config. The SQLite rows that reference these paths stay backed up; only the bytes are skipped.
-- **Per-pillar SQLite (ADR-026):** each pillar's database streams independently. The core pillar's reference config lives at `infra/litestream/core.yml`, the inventory pillar's at `infra/litestream/inventory.yml`, and the media pillar's at `infra/litestream/media.yml`; the deployer mirrors them into the homelab-infra Litestream config alongside the existing `pops.db` stream. As subsequent pillars (finance, cerebrum, …) extract their own SQLite files, each adds a sibling YAML next to `core.yml`.
+- **Per-pillar SQLite (ADR-026):** each pillar's database streams independently. The core pillar's reference config lives at `infra/litestream/core.yml`, the finance pillar's at `infra/litestream/finance.yml`, the inventory pillar's at `infra/litestream/inventory.yml`, and the media pillar's at `infra/litestream/media.yml`; the deployer mirrors them into the homelab-infra Litestream config alongside the existing `pops.db` stream. As subsequent pillars (cerebrum, …) extract their own SQLite files, each adds a sibling YAML next to `core.yml`.
 
 ## Import Pipeline
 

--- a/infra/litestream/finance.yml
+++ b/infra/litestream/finance.yml
@@ -11,7 +11,8 @@
 ## environment — leave it as a `${FINANCE_LITESTREAM_REPLICA_URL}` style
 ## placeholder here.
 ##
-## Restore drill (single line — safe to copy/paste during an incident):
+## Restore drill (safe to copy/paste during an incident — the shell
+## continuation joins the two lines into one command):
 ##   litestream restore -o /data/sqlite/finance.db \
 ##     "${FINANCE_LITESTREAM_REPLICA_URL}"
 ## Stop the finance-api container first so it isn't writing concurrently;

--- a/infra/litestream/finance.yml
+++ b/infra/litestream/finance.yml
@@ -1,0 +1,31 @@
+## Litestream replication config — finance pillar SQLite.
+##
+## Phase 2 PR 4 of the finance pillar migration (ADR-026). Mirrors the
+## per-pillar pattern so each pillar's database streams independently
+## of the shared pops.db.
+##
+## Production deployment lives in the homelab-infra repo (see AGENTS.md
+## for the deployment model); this file is the canonical reference the
+## deployer copies into its own Litestream config. The replica target
+## (S3 bucket name, region, credentials) is provided by the deployer's
+## environment — leave it as a `${FINANCE_LITESTREAM_REPLICA_URL}` style
+## placeholder here.
+##
+## Restore drill (single line — safe to copy/paste during an incident):
+##   litestream restore -o /data/sqlite/finance.db \
+##     "${FINANCE_LITESTREAM_REPLICA_URL}"
+## Stop the finance-api container first so it isn't writing concurrently;
+## the drill is exercised in Phase 4 verification.
+
+dbs:
+  - path: /data/sqlite/finance.db
+    replicas:
+      - url: ${FINANCE_LITESTREAM_REPLICA_URL}
+        # Per-pillar config so a single-pillar restore doesn't pull in
+        # the whole pops.db blob. Sync interval matches the shared
+        # singleton's existing replica config (1s by default — see
+        # homelab-infra).
+        sync-interval: 1s
+        retention: 24h
+        snapshot-interval: 1h
+        validation-interval: 12h


### PR DESCRIPTION
## Summary

Phase 2 PR 4 of the finance pillar migration. Adds the canonical Litestream reference config the deployer mirrors into the homelab-infra Litestream config so `finance.db` replicates independently of the shared `pops.db` (and `inventory.db` / `core.db` / `media.db`) blob.

Mirrors the core (#2758), inventory (#2796), and media (#2800) PR 4 patterns:

- `/data/sqlite/finance.db` replica with 1s sync, 24h retention, hourly snapshots, twice-daily validation.
- Restore drill documented in the header so an on-call agent can copy/paste the single command during an incident.
- `AGENTS.md` per-pillar SQLite note extended to list `infra/litestream/finance.yml` alongside the core/inventory/media entries.

No code changes — production runtime is unchanged; this is canonical-reference YAML for the deployer to mirror into homelab-infra.

## Test plan

- [x] `yamllint infra/litestream/finance.yml` — only the same missing-document-start warning as core.yml; no errors.
- [x] Structure matches core.yml / inventory.yml / media.yml.