### PR TITLE
feat(cerebrum-db): add openCerebrumDb helper (pillar cerebrum phase 2 PR 1)

### DIFF
--- a/packages/cerebrum-db/src/__tests__/open-cerebrum-db.test.ts
+++ b/packages/cerebrum-db/src/__tests__/open-cerebrum-db.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Smoke tests for the standalone `openCerebrumDb` helper.
+ *
+ * Exercises the migration apply path against a fresh tmp file, verifies
+ * the resulting schema, and confirms the helper is idempotent when
+ * re-run against the same DB.
+ */
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { openCerebrumDb } from '../open-cerebrum-db.js';
+import { nudgeLog } from '../schema.js';
+import { persistCandidates } from '../services/nudge-log.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'cerebrum-db-test-'));
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('openCerebrumDb', () => {
+  it('creates the parent directory and opens a fresh DB', () => {
+    const path = join(tmpDir, 'nested', 'sub', 'cerebrum.db');
+    expect(existsSync(path)).toBe(false);
+
+    const { raw } = openCerebrumDb(path);
+    try {
+      expect(existsSync(path)).toBe(true);
+      expect(raw.pragma('journal_mode', { simple: true })).toBe('wal');
+      expect(raw.pragma('foreign_keys', { simple: true })).toBe(1);
+      expect(raw.pragma('busy_timeout', { simple: true })).toBe(5000);
+    } finally {
+      raw.close();
+    }
+  });
+
+  it('applies the nudge_log migration and accepts writes via the service', () => {
+    const path = join(tmpDir, 'cerebrum.db');
+    const { db, raw } = openCerebrumDb(path);
+    try {
+      expect(db.select().from(nudgeLog).all()).toHaveLength(0);
+      const created = persistCandidates(
+        db,
+        [
+          {
+            type: 'pattern',
+            title: 'T',
+            body: 'B',
+            engramIds: ['e1'],
+            priority: 'medium',
+            expiresAt: null,
+            action: null,
+          },
+        ],
+        { nudgeCooldownHours: 24 }
+      );
+      expect(created).toBe(1);
+      expect(db.select().from(nudgeLog).all()).toHaveLength(1);
+    } finally {
+      raw.close();
+    }
+  });
+
+  it('is idempotent — re-opening the same DB does not re-apply migrations', () => {
+    const path = join(tmpDir, 'cerebrum.db');
+    const first = openCerebrumDb(path);
+    try {
+      persistCandidates(
+        first.db,
+        [
+          {
+            type: 'pattern',
+            title: 'T',
+            body: 'B',
+            engramIds: ['e1'],
+            priority: 'medium',
+            expiresAt: null,
+            action: null,
+          },
+        ],
+        { nudgeCooldownHours: 24 }
+      );
+      expect(first.db.select().from(nudgeLog).all()).toHaveLength(1);
+    } finally {
+      first.raw.close();
+    }
+
+    const second = openCerebrumDb(path);
+    try {
+      expect(second.db.select().from(nudgeLog).all()).toHaveLength(1);
+    } finally {
+      second.raw.close();
+    }
+  });
+});

--- a/packages/cerebrum-db/src/index.ts
+++ b/packages/cerebrum-db/src/index.ts
@@ -22,6 +22,8 @@ export * from './schema.js';
 
 export type { CerebrumDb } from './services/internal.js';
 
+export { openCerebrumDb, type OpenedCerebrumDb } from './open-cerebrum-db.js';
+
 export * as nudgeLogService from './services/nudge-log.js';
 
 // Public types re-exported at the package root so consumers can name

--- a/packages/cerebrum-db/src/open-cerebrum-db.ts
+++ b/packages/cerebrum-db/src/open-cerebrum-db.ts
@@ -1,0 +1,86 @@
+/**
+ * Standalone opener for the cerebrum pillar's SQLite database.
+ *
+ * Phase 2 PR 1 of the cerebrum pillar migration scaffolds the
+ * per-pillar connection so subsequent PRs can flip readers/writers
+ * over without touching pops-api's existing singleton. The opener is
+ * intentionally minimal — it relies on drizzle-orm's built-in
+ * `migrate` helper to apply the in-package migrations journal at
+ * `packages/cerebrum-db/migrations/meta/_journal.json`.
+ *
+ * No production consumer wires this up yet. Subsequent PRs add the
+ * `CEREBRUM_SQLITE_PATH` env-var read in pops-api, the boot-time
+ * call, and the ATTACH-based backfill of nudge_log rows from the
+ * shared pops.db.
+ */
+import { mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+
+import type { CerebrumDb } from './services/internal.js';
+
+/**
+ * Path to the migrations folder inside this package. Resolved relative
+ * to this module's location (`src/open-cerebrum-db.ts` in dev,
+ * `dist/open-cerebrum-db.js` after build) so it works both when
+ * consumed via the workspace symlink and when bundled into a Docker
+ * image's `node_modules/@pops/cerebrum-db/`.
+ */
+function migrationsDir(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  return join(here, '..', 'migrations');
+}
+
+/**
+ * Result of {@link openCerebrumDb}. The raw handle is exposed for callers
+ * that need lifecycle control (close on shutdown, prepared statements,
+ * pragmas the drizzle wrapper hides).
+ */
+export interface OpenedCerebrumDb {
+  /** Drizzle handle — pass into any `nudgeLogService.*` call. */
+  db: CerebrumDb;
+  /** Raw better-sqlite3 handle. Call `.close()` on shutdown. */
+  raw: Database.Database;
+}
+
+/**
+ * Open the cerebrum pillar's SQLite database at `path`, configure
+ * it, apply the in-package migrations journal, and return both the
+ * drizzle wrapper and the raw handle.
+ *
+ * Side effects:
+ *   - The parent directory of `path` is created if missing (recursive).
+ *   - `journal_mode=WAL`, `foreign_keys=ON`, and `busy_timeout=5000`
+ *     are enabled to match the shared singleton in
+ *     `apps/pops-api/src/db.ts`.
+ *   - Every migration in
+ *     `packages/cerebrum-db/migrations/meta/_journal.json` is applied
+ *     via drizzle's built-in migrator (idempotent — re-running against
+ *     the same DB short-circuits on the `__drizzle_migrations` hash
+ *     check). Today that's `0039_dry_fabian_cortez` (creates
+ *     `nudge_log`) and `0044_nudge_log` (the idempotent safety
+ *     re-creation).
+ *
+ * If the migration apply throws (corrupt DB, malformed migration,
+ * missing folder), the raw handle is closed before the error is
+ * re-thrown so the caller can't leak a locked file descriptor.
+ */
+export function openCerebrumDb(path: string): OpenedCerebrumDb {
+  mkdirSync(dirname(path), { recursive: true });
+  const raw = new Database(path);
+  raw.pragma('journal_mode = WAL');
+  raw.pragma('foreign_keys = ON');
+  raw.pragma('busy_timeout = 5000');
+  const db = drizzle(raw) as CerebrumDb;
+  try {
+    migrate(db, { migrationsFolder: migrationsDir() });
+  } catch (err) {
+    raw.close();
+    throw err;
+  }
+  return { db, raw };
+}


### PR DESCRIPTION
## Summary

Phase 2 PR 1 of Track H. Scaffolds the standalone per-pillar SQLite opener for the cerebrum pillar so subsequent PRs can wire pops-api's boot path and the nudge_log slice cutover without re-deriving the migration apply logic.

Mirrors the same opener pattern already on `main` for the other pillars: `openCoreDb`, `openFinanceDb`, `openInventoryDb`, `openMediaDb`.

### Highlights

- `packages/cerebrum-db/src/open-cerebrum-db.ts` — opener resolves the package-local migrations folder relative to its own module URL so it works both under the workspace symlink AND from inside `node_modules/@pops/cerebrum-db/` after a Docker build. Sets `journal_mode=WAL`, `foreign_keys=ON`, `busy_timeout=5000` to match the shared pops-api singleton. Creates parent directories if missing. Closes the raw handle if migration apply throws so a corrupt DB doesn't leak an open file descriptor.
- `packages/cerebrum-db/src/__tests__/open-cerebrum-db.test.ts` — 3 smoke tests against a tmpdir DB (fresh open + pragmas; `persistCandidates` round-trip through `nudgeLogService` to prove the schema is queryable; re-open idempotence preserving previously-persisted rows).
- `packages/cerebrum-db/src/index.ts` — barrel exports `openCerebrumDb` + `OpenedCerebrumDb`.

### What's NOT in this PR

No production wiring. pops-api still uses its shared `pops.db` for the nudge_log table. Subsequent PRs add:

- **PR 2** — `CEREBRUM_SQLITE_PATH` env-var read in pops-api, the boot-time `openCerebrumDb` call, the `closeCerebrumDb` shutdown hook, and the `getCerebrumDrizzle` accessor that NudgeService will switch to in PR 3.
- **PR 3** — flip the nudge_log readers/writers to the per-pillar handle + ATTACH-based backfill from `pops.db` so existing rows carry across at boot.
- **PR 4** — Litestream config at `infra/litestream/cerebrum.yml` + per-pillar AGENTS.md note.

## Test plan

- [x] `pnpm --filter @pops/cerebrum-db test` — 19/19 pass (3 new for the opener + 16 from the nudge_log slice).
- [x] `pnpm typecheck` (full workspace turbo) — 43/43 packages green.
- [x] `pnpm format:check` — clean.
- [x] `pnpm install --frozen-lockfile` — lockfile unchanged.
