### PR TITLE
feat(finance-api): scaffold pops-finance-api container (pillar finance phase 3 PR 1)

### DIFF
--- a/.github/workflows/finance-api-quality.yml
+++ b/.github/workflows/finance-api-quality.yml
@@ -1,0 +1,41 @@
+name: Finance API Quality
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "apps/pops-finance-api/**"
+      - "packages/finance-db/**"
+      - "packages/db-types/**"
+      - ".github/workflows/finance-api-quality.yml"
+      - ".github/workflows/_pkg-check.yml"
+  pull_request:
+
+jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - 'apps/pops-finance-api/**'
+              - 'packages/finance-db/**'
+              - 'packages/db-types/**'
+              - '.github/workflows/finance-api-quality.yml'
+              - '.github/workflows/_pkg-check.yml'
+
+  quality:
+    needs: [changes]
+    if: always()
+    uses: ./.github/workflows/_pkg-check.yml
+    with:
+      package-path: apps/pops-finance-api
+      needs-db-build: true
+      skip: ${{ github.event_name == 'pull_request' && needs.changes.outputs.relevant != 'true' }}

--- a/apps/pops-finance-api/Dockerfile
+++ b/apps/pops-finance-api/Dockerfile
@@ -1,0 +1,57 @@
+FROM node:22-slim AS builder
+WORKDIR /app
+
+# Copy workspace root files
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json ./
+
+# Copy workspace package.json files (for dep resolution)
+COPY packages/db-types/package.json ./packages/db-types/
+COPY packages/types/package.json ./packages/types/
+COPY packages/finance-db/package.json ./packages/finance-db/
+COPY apps/pops-finance-api/package.json ./apps/pops-finance-api/
+
+# Install pnpm and all workspace dependencies
+RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
+    corepack enable && pnpm install --frozen-lockfile
+
+# Copy shared package sources
+COPY packages/db-types/src ./packages/db-types/src
+COPY packages/db-types/tsconfig.json ./packages/db-types/
+COPY packages/types/src ./packages/types/src
+COPY packages/types/tsconfig.json packages/types/tsconfig.build.json ./packages/types/
+COPY packages/finance-db/src ./packages/finance-db/src
+COPY packages/finance-db/tsconfig.json ./packages/finance-db/
+COPY packages/finance-db/migrations ./packages/finance-db/migrations
+
+# Copy finance-api source
+COPY apps/pops-finance-api/tsconfig.json ./apps/pops-finance-api/
+COPY apps/pops-finance-api/src ./apps/pops-finance-api/src
+
+# Build shared packages first
+WORKDIR /app/packages/db-types
+RUN pnpm build
+WORKDIR /app/packages/types
+RUN pnpm build
+WORKDIR /app/packages/finance-db
+RUN pnpm build
+
+# Build finance-api
+WORKDIR /app/apps/pops-finance-api
+RUN pnpm build
+
+# Create standalone deployment (production deps only, no symlinks)
+RUN pnpm --filter @pops/finance-api deploy --prod --legacy /app/deploy
+
+FROM node:22-slim
+WORKDIR /app
+RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder --chown=node:node /app/deploy ./
+COPY --from=builder --chown=node:node /app/apps/pops-finance-api/dist ./dist
+
+ARG BUILD_VERSION=dev
+ENV BUILD_VERSION=$BUILD_VERSION
+
+EXPOSE 3004
+USER node
+CMD ["node", "dist/server.js"]

--- a/apps/pops-finance-api/package.json
+++ b/apps/pops-finance-api/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@pops/finance-api",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsx watch --clear-screen=false src/server.ts",
+    "start": "node dist/server.js",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@pops/finance-db": "workspace:*",
+    "@pops/types": "workspace:*",
+    "express": "^5.1.0",
+    "pino": "^10.3.1"
+  },
+  "devDependencies": {
+    "@types/express": "^5.0.4",
+    "@types/node": "^25.9.1",
+    "@types/supertest": "^6.0.3",
+    "@vitest/coverage-v8": "^4.1.8",
+    "supertest": "^7.1.4",
+    "tsx": "^4.22.4",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.8"
+  }
+}

--- a/apps/pops-finance-api/src/__tests__/health.test.ts
+++ b/apps/pops-finance-api/src/__tests__/health.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Smoke tests for the finance-api Express app + health probe.
+ *
+ * Boots the app against a per-test temp-dir finance.db (mkdtemp +
+ * cleanup in afterEach) and confirms the `/health` route returns the
+ * agreed `{ ok, pillar, version }` shape.
+ *
+ * Mirrors `apps/pops-media-api/src/__tests__/health.test.ts`.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { openFinanceDb, type OpenedFinanceDb } from '@pops/finance-db';
+
+import { createFinanceApiApp } from '../app.js';
+
+let tmpDir: string;
+let financeDb: OpenedFinanceDb;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'finance-api-test-'));
+  financeDb = openFinanceDb(join(tmpDir, 'finance.db'));
+});
+
+afterEach(() => {
+  financeDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('GET /health', () => {
+  it('returns ok + pillar + version', async () => {
+    const app = createFinanceApiApp({ financeDb, version: '0.0.1-test' });
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, pillar: 'finance', version: '0.0.1-test' });
+  });
+
+  it('fails closed when the finance handle is closed', async () => {
+    const app = createFinanceApiApp({ financeDb, version: '0.0.1-test' });
+    financeDb.raw.close();
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(500);
+  });
+});

--- a/apps/pops-finance-api/src/app.ts
+++ b/apps/pops-finance-api/src/app.ts
@@ -1,0 +1,30 @@
+/**
+ * Express app factory for the finance pillar container.
+ *
+ * Phase 3 PR 1 of the finance pillar migration boots the minimal
+ * surface (`/health`) so the new container can be wired into
+ * docker-compose and Watchtower without depending on the (still-
+ * unfinished) tRPC migration. Subsequent PRs mount additional routes.
+ * Kept as a factory so the test suite can spin up an in-process
+ * `supertest` instance without binding a real port.
+ *
+ * Mirrors `apps/pops-media-api/src/app.ts`.
+ */
+import express, { type Express, type Request, type Response } from 'express';
+
+import { type FinanceApiDeps, makeRequestHandler } from './handlers.js';
+
+export function createFinanceApiApp(deps: FinanceApiDeps): Express {
+  const app = express();
+  app.disable('x-powered-by');
+
+  // Build the handler shape once at factory time so static deps don't
+  // get re-allocated on every request.
+  const handlers = makeRequestHandler(deps);
+
+  app.get('/health', (_req: Request, res: Response) => {
+    res.json(handlers.health());
+  });
+
+  return app;
+}

--- a/apps/pops-finance-api/src/finance-sqlite-path.ts
+++ b/apps/pops-finance-api/src/finance-sqlite-path.ts
@@ -6,10 +6,15 @@ import { dirname, join } from 'node:path';
  *
  * Intentionally NOT imported from `apps/pops-api/src/db/finance-sqlite-path.ts`
  * — finance-api is supposed to be runnable without pops-api in the
- * dependency graph. The precedence chain mirrors pops-api's resolver
- * verbatim so the two processes agree on the location of `finance.db`
- * given the same env: a deployer who only sets `SQLITE_PATH`
- * (legacy contract) still ends up with `finance.db` next to `pops.db`.
+ * dependency graph. The precedence chain matches pops-api's resolver
+ * so the two processes agree on the location of `finance.db` given
+ * the same env: a deployer who only sets `SQLITE_PATH` (legacy
+ * contract) still ends up with `finance.db` next to `pops.db`. The
+ * pops-api version emits a `console.warn` on the fallback branch
+ * (its job is to flag dev/test setups that haven't been configured);
+ * here we stay silent because a missing env in a per-pillar container
+ * usually means the deployer set the default deliberately, and the
+ * container has no equivalent dev-time signal to surface.
  *
  * Resolution order:
  *   1. `FINANCE_SQLITE_PATH` (absolute or relative).

--- a/apps/pops-finance-api/src/finance-sqlite-path.ts
+++ b/apps/pops-finance-api/src/finance-sqlite-path.ts
@@ -1,0 +1,29 @@
+import { dirname, join } from 'node:path';
+
+/**
+ * Standalone resolver for the finance pillar's SQLite path inside the
+ * finance-api container.
+ *
+ * Intentionally NOT imported from `apps/pops-api/src/db/finance-sqlite-path.ts`
+ * — finance-api is supposed to be runnable without pops-api in the
+ * dependency graph. The precedence chain mirrors pops-api's resolver
+ * verbatim so the two processes agree on the location of `finance.db`
+ * given the same env: a deployer who only sets `SQLITE_PATH`
+ * (legacy contract) still ends up with `finance.db` next to `pops.db`.
+ *
+ * Resolution order:
+ *   1. `FINANCE_SQLITE_PATH` (absolute or relative).
+ *   2. `<dirname(SQLITE_PATH)>/finance.db` if the shared path is set.
+ *   3. `./data/finance.db` (matches the shared default's `./data/pops.db`).
+ *
+ * Mirrors core-api / inventory-api / media-api resolvers.
+ */
+export const DEFAULT_FINANCE_SQLITE_PATH = './data/finance.db';
+
+export function resolveFinanceSqlitePath(): string {
+  const envPath = process.env['FINANCE_SQLITE_PATH'];
+  if (envPath) return envPath;
+  const sharedPath = process.env['SQLITE_PATH'];
+  if (sharedPath) return join(dirname(sharedPath), 'finance.db');
+  return DEFAULT_FINANCE_SQLITE_PATH;
+}

--- a/apps/pops-finance-api/src/handlers.ts
+++ b/apps/pops-finance-api/src/handlers.ts
@@ -1,0 +1,39 @@
+/**
+ * Request handlers for the finance pillar container.
+ *
+ * Logic lives here (not inline in `app.ts`) so tests can call into the
+ * shape directly without booting Express. Subsequent PRs add tRPC +
+ * domain-specific handlers alongside the existing health probe.
+ *
+ * Mirrors `apps/pops-media-api/src/handlers.ts` minus any pillar-specific
+ * surface.
+ */
+
+import type { OpenedFinanceDb } from '@pops/finance-db';
+
+export interface FinanceApiDeps {
+  /** Open handle to the finance pillar's SQLite. */
+  financeDb: OpenedFinanceDb;
+  /** Semver of the build, surfaced on the health response. */
+  version: string;
+}
+
+export interface HealthResponse {
+  ok: true;
+  pillar: 'finance';
+  version: string;
+}
+
+export function makeRequestHandler(deps: FinanceApiDeps): {
+  health(): HealthResponse;
+} {
+  return {
+    health(): HealthResponse {
+      // Touch the DB so a closed handle surfaces as a thrown error
+      // (caught by the Express error pipeline -> 500) rather than a
+      // bogus 200 OK that hides a broken connection.
+      deps.financeDb.raw.prepare('SELECT 1').get();
+      return { ok: true, pillar: 'finance', version: deps.version };
+    },
+  };
+}

--- a/apps/pops-finance-api/src/server.ts
+++ b/apps/pops-finance-api/src/server.ts
@@ -1,0 +1,51 @@
+/**
+ * Entry point for the finance pillar HTTP server.
+ *
+ * Phase 3 PR 1 of the finance pillar migration boots the process with
+ * the minimal `/health` surface so the new container can be wired into
+ * docker-compose + Watchtower without depending on the (still-
+ * unfinished) tRPC + URI-dispatcher migration.
+ *
+ * The process opens its OWN `finance.db` connection via `openFinanceDb`
+ * rather than reaching back into pops-api's singleton — that's the
+ * whole point of phase 3. Mirrors `apps/pops-media-api/src/server.ts`.
+ */
+import { openFinanceDb } from '@pops/finance-db';
+
+import { createFinanceApiApp } from './app.js';
+import { resolveFinanceSqlitePath } from './finance-sqlite-path.js';
+
+function resolvePort(): number {
+  // 3001 is core-api, 3002 is inventory-api, 3003 is media-api,
+  // 3004 is finance-api.
+  const raw = process.env['PORT'];
+  if (raw === undefined || raw === '') return 3004;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed <= 0 || parsed > 65535) {
+    throw new Error(`[finance-api] PORT must be a positive integer in 1-65535; got '${raw}'`);
+  }
+  return parsed;
+}
+
+const port = resolvePort();
+const version = process.env['BUILD_VERSION'] ?? 'dev';
+
+const financeDb = openFinanceDb(resolveFinanceSqlitePath());
+const app = createFinanceApiApp({ financeDb, version });
+
+const server = app.listen(port, () => {
+  console.warn(`[finance-api] Listening on port ${port}`);
+});
+
+let shuttingDown = false;
+function shutdown(signal: NodeJS.Signals): void {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  console.warn(`[finance-api] Shutting down (${signal})`);
+  server.close(() => {
+    financeDb.raw.close();
+  });
+}
+
+process.on('SIGTERM', shutdown);
+process.on('SIGINT', shutdown);

--- a/apps/pops-finance-api/tsconfig.json
+++ b/apps/pops-finance-api/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "sourceMap": true,
+    "types": ["node"]
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/__tests__/**"]
+}

--- a/apps/pops-finance-api/vitest.config.ts
+++ b/apps/pops-finance-api/vitest.config.ts
@@ -1,0 +1,15 @@
+/// <reference types="vitest/config" />
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json-summary', 'html'],
+      reportsDirectory: 'coverage',
+      include: ['src/**/*.ts'],
+      exclude: ['**/node_modules/**', '**/dist/**', '**/*.test.ts'],
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -268,6 +268,46 @@ importers:
         specifier: ^4.1.8
         version: 4.1.8(@types/node@25.9.1)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
 
+  apps/pops-finance-api:
+    dependencies:
+      '@pops/finance-db':
+        specifier: workspace:*
+        version: link:../../packages/finance-db
+      '@pops/types':
+        specifier: workspace:*
+        version: link:../../packages/types
+      express:
+        specifier: ^5.1.0
+        version: 5.2.1
+      pino:
+        specifier: ^10.3.1
+        version: 10.3.1
+    devDependencies:
+      '@types/express':
+        specifier: ^5.0.4
+        version: 5.0.6
+      '@types/node':
+        specifier: ^25.9.1
+        version: 25.9.1
+      '@types/supertest':
+        specifier: ^6.0.3
+        version: 6.0.3
+      '@vitest/coverage-v8':
+        specifier: ^4.1.8
+        version: 4.1.8(vitest@4.1.8)
+      supertest:
+        specifier: ^7.1.4
+        version: 7.2.2
+      tsx:
+        specifier: ^4.22.4
+        version: 4.22.4
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@25.9.1)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
+
   apps/pops-inventory-api:
     dependencies:
       '@pops/inventory-db':
@@ -7194,10 +7234,6 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  qs@6.15.0:
-    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
-    engines: {node: '>=0.6'}
-
   qs@6.15.2:
     resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
@@ -11032,7 +11068,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.15.0
+      qs: 6.15.2
       raw-body: 3.0.2
       type-is: 2.0.1
     transitivePeerDependencies:
@@ -11775,7 +11811,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.0
+      qs: 6.15.2
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
@@ -13244,10 +13280,6 @@ snapshots:
       once: 1.4.0
 
   punycode@2.3.1: {}
-
-  qs@6.15.0:
-    dependencies:
-      side-channel: 1.1.0
 
   qs@6.15.2:
     dependencies:


### PR DESCRIPTION
## Summary

Phase 3 PR 1 of the finance pillar migration: scaffolds a standalone Express container that owns the finance pillar's HTTP surface. Boots the minimal `/health` probe so the new image can be wired into docker-compose + Watchtower without depending on the (still-unfinished) tRPC migration.

Mirrors the inventory (#2798) and media (#2803) Phase 3 PR 1 patterns.

## What's in this PR

- `apps/pops-finance-api/{package.json,tsconfig.json,vitest.config.ts}`
- `src/app.ts` — Express app factory.
- `src/server.ts` — entry point: opens `finance.db` via `openFinanceDb`, binds port 3004 (after core-api/inventory-api/media-api).
- `src/handlers.ts` — `/health` returns `{ ok, pillar: 'finance', version }` and touches the DB so a closed handle surfaces as 500.
- `src/finance-sqlite-path.ts` — standalone resolver (NOT imported from `apps/pops-api/src/db/finance-sqlite-path.ts` — `finance-api` must be runnable without pops-api in the graph).
- `src/__tests__/health.test.ts` — supertest cases (`200` + closed-handle `500`).
- `Dockerfile` — multi-stage build: turbo-prune-style copy of finance-db + types, build, `pnpm deploy --prod`, `USER node`, `EXPOSE 3004`.
- `.github/workflows/finance-api-quality.yml` — CI workflow.

## Test plan

- [x] `pnpm typecheck` — green
- [x] `pnpm --filter @pops/finance-api test` — 2/2 supertest cases pass
- [x] `pnpm --filter @pops/finance-api build` — green
- [x] No code changes to pops-api / pops-shell — Phase 3 PR 2 wires the container into compose.