### PR TITLE
feat(api): open the cerebrum pillar SQLite at boot (pillar cerebrum phase 2 PR 2)

### DIFF
--- a/apps/pops-api/.env.example
+++ b/apps/pops-api/.env.example
@@ -41,6 +41,11 @@ INVENTORY_SQLITE_PATH=./data/inventory.db
 # media needs its own mount point / Litestream stream in production.
 MEDIA_SQLITE_PATH=./data/media.db
 
+# Cerebrum pillar database (ADR-026). Defaults to <dirname(SQLITE_PATH)>/cerebrum.db,
+# falling back to ./data/cerebrum.db if SQLITE_PATH is unset. Set explicitly when
+# cerebrum needs its own mount point / Litestream stream in production.
+CEREBRUM_SQLITE_PATH=./data/cerebrum.db
+
 # Media Images
 # Directory for locally cached posters and backdrops
 MEDIA_IMAGES_DIR=./data/media/images

--- a/apps/pops-api/src/db.ts
+++ b/apps/pops-api/src/db.ts
@@ -7,6 +7,7 @@ import { type BetterSQLite3Database, drizzle } from 'drizzle-orm/better-sqlite3'
 import { openCoreDb, type CoreDb, type OpenedCoreDb } from '@pops/core-db';
 
 import { createPreMigrationBackup, isFreshDatabase } from './db/backup.js';
+import { closeCerebrumDb } from './db/cerebrum-handle.js';
 import { backfillCoreFromShared as backfillCoreImpl } from './db/core-backfill.js';
 import { resolveCoreSqlitePath } from './db/core-sqlite-path.js';
 import { closeFinanceDb } from './db/finance-handle.js';
@@ -239,6 +240,7 @@ export function closeDb(): void {
   closeFinanceDb();
   closeInventoryDb();
   closeMediaDb();
+  closeCerebrumDb();
 }
 
 /**

--- a/apps/pops-api/src/db/cerebrum-handle.ts
+++ b/apps/pops-api/src/db/cerebrum-handle.ts
@@ -1,0 +1,88 @@
+/**
+ * Lazily-initialised handle to the cerebrum pillar's SQLite file.
+ *
+ * Phase 2 PR 2 of the cerebrum pillar migration: opens the connection
+ * (and applies the in-package migrations journal) at boot but does NOT
+ * yet route any production traffic through it. PR 3 of phase 2 flips
+ * the nudge_log slice (NudgeService) over with a single edit to
+ * `getDrizzle()` → `getCerebrumDrizzle()` plus an ATTACH-based
+ * backfill of any existing nudge_log rows from the shared pops.db; PR 4
+ * drops the cerebrum-owned tags from the shared journal + adds the
+ * Litestream config.
+ *
+ * Lives in its own module so `db.ts` stays under the lint cap as more
+ * pillars come online. Mirrors `core-handle.ts` / `inventory-handle.ts` /
+ * `finance-handle.ts` / `media-db-handle.ts`.
+ */
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+
+import { openCerebrumDb, type CerebrumDb, type OpenedCerebrumDb } from '@pops/cerebrum-db';
+
+import { getDb, isNamedEnvContext } from '../db.js';
+import { resolveCerebrumSqlitePath } from './cerebrum-sqlite-path.js';
+
+let cerebrumDb: OpenedCerebrumDb | null = null;
+
+/**
+ * Resolve (and lazily open) the cerebrum pillar's drizzle handle.
+ *
+ * **Env-aware**: inside a `withEnvDb()` scope (PRD-101 named environments —
+ * each E2E test fixture creates a per-test pops.db with its own seeded
+ * cerebrum tables) the env DB takes precedence. The env DB already
+ * contains every cerebrum-owned table because `seedDatabase()` writes
+ * them there, so a single fixture stays self-contained without a
+ * background backfill into the global `cerebrum.db`. Outside an env
+ * scope (real production boot, dev), the pillar's `cerebrum.db` is
+ * resolved + lazily opened so the in-package migrations apply.
+ *
+ * The handle is opened on first call so per-pillar migrations land
+ * before any request hits the API. Phase 2 PR 3 routes the nudge_log
+ * slice's reads/writes through this getter.
+ */
+export function getCerebrumDrizzle(): CerebrumDb {
+  if (isNamedEnvContext()) return drizzle(getDb()) as CerebrumDb;
+  if (!cerebrumDb) {
+    cerebrumDb = openCerebrumDb(resolveCerebrumSqlitePath());
+  }
+  return cerebrumDb.db;
+}
+
+/**
+ * Resolve the cerebrum pillar's raw better-sqlite3 handle. Same lazy
+ * open + env-aware behaviour as `getCerebrumDrizzle()` — exposed for
+ * the same lower-level needs (`.transaction()`, `.prepare()`,
+ * `.pragma()`) that the drizzle wrapper hides. Prefer
+ * `getCerebrumDrizzle()` for everything that doesn't need it.
+ */
+export function getCerebrumRawDb(): OpenedCerebrumDb['raw'] {
+  if (isNamedEnvContext()) return getDb();
+  if (!cerebrumDb) {
+    cerebrumDb = openCerebrumDb(resolveCerebrumSqlitePath());
+  }
+  return cerebrumDb.raw;
+}
+
+/**
+ * Close the cerebrum pillar's connection if it was opened. Idempotent
+ * — safe to call from `closeDb()` on shutdown even when the cerebrum
+ * handle was never resolved.
+ */
+export function closeCerebrumDb(): void {
+  if (cerebrumDb) {
+    cerebrumDb.raw.close();
+    cerebrumDb = null;
+  }
+}
+
+/**
+ * Test-only: swap the cerebrum pillar handle. Phase 2 PR 3 of this
+ * pillar wires `setupTestContext` (in `shared/test-utils.ts`) up to
+ * call this hook so test suites can inject an in-memory DB and avoid
+ * writing to the dev `data/cerebrum.db` file. Returns the previous
+ * handle (or null).
+ */
+export function setCerebrumDb(next: OpenedCerebrumDb | null): OpenedCerebrumDb | null {
+  const prev = cerebrumDb;
+  cerebrumDb = next;
+  return prev;
+}

--- a/apps/pops-api/src/db/cerebrum-sqlite-path.test.ts
+++ b/apps/pops-api/src/db/cerebrum-sqlite-path.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Resolver tests for the cerebrum pillar's SQLite path.
+ *
+ * Covers the precedence chain: CEREBRUM_SQLITE_PATH > <dirname(SQLITE_PATH)>/cerebrum.db > fallback.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DEFAULT_CEREBRUM_SQLITE_PATH, resolveCerebrumSqlitePath } from './cerebrum-sqlite-path.js';
+
+const originalCerebrumPath = process.env['CEREBRUM_SQLITE_PATH'];
+const originalSharedPath = process.env['SQLITE_PATH'];
+
+beforeEach(() => {
+  delete process.env['CEREBRUM_SQLITE_PATH'];
+  delete process.env['SQLITE_PATH'];
+});
+
+afterEach(() => {
+  if (originalCerebrumPath === undefined) delete process.env['CEREBRUM_SQLITE_PATH'];
+  else process.env['CEREBRUM_SQLITE_PATH'] = originalCerebrumPath;
+  if (originalSharedPath === undefined) delete process.env['SQLITE_PATH'];
+  else process.env['SQLITE_PATH'] = originalSharedPath;
+});
+
+describe('resolveCerebrumSqlitePath', () => {
+  it('returns CEREBRUM_SQLITE_PATH verbatim when set', () => {
+    process.env['CEREBRUM_SQLITE_PATH'] = '/abs/path/cerebrum.db';
+    expect(resolveCerebrumSqlitePath()).toBe('/abs/path/cerebrum.db');
+  });
+
+  it('derives the path from the shared SQLITE_PATH when CEREBRUM_SQLITE_PATH is unset', () => {
+    process.env['SQLITE_PATH'] = '/opt/pops/data/pops.db';
+    expect(resolveCerebrumSqlitePath()).toBe('/opt/pops/data/cerebrum.db');
+  });
+
+  it('handles relative SQLITE_PATH values', () => {
+    process.env['SQLITE_PATH'] = './data/pops.db';
+    expect(resolveCerebrumSqlitePath()).toBe('data/cerebrum.db');
+  });
+
+  it('falls back to ./data/cerebrum.db when neither env is set', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      expect(resolveCerebrumSqlitePath()).toBe(DEFAULT_CEREBRUM_SQLITE_PATH);
+      expect(warn).toHaveBeenCalledOnce();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});

--- a/apps/pops-api/src/db/cerebrum-sqlite-path.ts
+++ b/apps/pops-api/src/db/cerebrum-sqlite-path.ts
@@ -1,0 +1,33 @@
+import { dirname, join } from 'node:path';
+
+import { DEFAULT_SQLITE_PATH } from './sqlite-path.js';
+
+/**
+ * Default location of the cerebrum pillar's SQLite file.
+ *
+ * Per the ADR-026 pillar architecture each pillar owns its own SQLite
+ * file alongside the shared pops.db. The default places `cerebrum.db`
+ * in the same directory the shared singleton resolves to so dev setups
+ * that already have a writable data dir don't need extra configuration.
+ * Production deployments set `CEREBRUM_SQLITE_PATH` explicitly; the
+ * fallback here is local-dev-only and matches `resolveSqlitePath`'s
+ * default-path convention (`./data/<file>.db`).
+ *
+ * Resolution order:
+ *   1. `CEREBRUM_SQLITE_PATH` env (absolute or relative).
+ *   2. `<dirname(SQLITE_PATH)>/cerebrum.db` if the shared path is set.
+ *   3. `./data/cerebrum.db` (matches the shared default's `./data/pops.db`).
+ */
+export const DEFAULT_CEREBRUM_SQLITE_PATH = './data/cerebrum.db';
+
+export function resolveCerebrumSqlitePath(): string {
+  const envPath = process.env['CEREBRUM_SQLITE_PATH'];
+  if (envPath) return envPath;
+  const sharedPath = process.env['SQLITE_PATH'];
+  if (sharedPath) return join(dirname(sharedPath), 'cerebrum.db');
+  console.warn(
+    `[db] CEREBRUM_SQLITE_PATH not set — using fallback: ${DEFAULT_CEREBRUM_SQLITE_PATH} ` +
+      `(co-located with the shared singleton default '${DEFAULT_SQLITE_PATH}')`
+  );
+  return DEFAULT_CEREBRUM_SQLITE_PATH;
+}

--- a/apps/pops-api/src/index.ts
+++ b/apps/pops-api/src/index.ts
@@ -7,6 +7,7 @@ config({ path: '../../.env', override: false }); // loads root .env without over
 
 import { createApp } from './app.js';
 import { backfillCoreFromShared, closeDb, getCoreDrizzle } from './db.js';
+import { getCerebrumDrizzle } from './db/cerebrum-handle.js';
 import { backfillFinanceFromSharedDb, getFinanceDrizzle } from './db/finance-handle.js';
 import { backfillInventoryFromSharedDb, getInventoryDrizzle } from './db/inventory-handle.js';
 import { backfillMediaFromShared, getMediaDrizzle } from './db/media-db-handle.js';
@@ -92,6 +93,22 @@ try {
   backfillMediaFromShared();
 } catch (err) {
   console.error('[db] Failed to bootstrap the media pillar SQLite:', err);
+  throw err;
+}
+
+// Eagerly open the cerebrum pillar's SQLite + apply its journal at
+// boot so the in-package migrations land before any request hits the
+// API. Phase 2 PR 2 only opens the handle — no production traffic is
+// routed through it yet; the nudge_log slice still reads/writes against
+// the shared pops.db. Phase 2 PR 3 flips the nudge_log slice over with
+// an ATTACH-based backfill from pops.db (matching the inventory /
+// finance / media / core PR-3 pattern); PR 4 adds the Litestream
+// config. Opening early surfaces migration failures during boot rather
+// than on first nudge-log write.
+try {
+  getCerebrumDrizzle();
+} catch (err) {
+  console.error('[db] Failed to bootstrap the cerebrum pillar SQLite:', err);
   throw err;
 }
 


### PR DESCRIPTION
## Summary

Phase 2 PR 2 of Track H. Wires `getCerebrumDrizzle()` into the pops-api boot path so the cerebrum pillar's `cerebrum.db` opens (and its in-package migrations apply) before any request hits the API. Mirrors the same Phase 2 PR 2 pattern core / inventory / finance / media already use on `main`.

### What lands

- **`apps/pops-api/src/db/cerebrum-sqlite-path.ts`** — resolver for `CEREBRUM_SQLITE_PATH` with the documented precedence chain (env > `<dirname(SQLITE_PATH)>/cerebrum.db` > `./data/cerebrum.db`).
- **`apps/pops-api/src/db/cerebrum-handle.ts`** — `getCerebrumDrizzle` / `getCerebrumRawDb` / `closeCerebrumDb` / `setCerebrumDb`. Env-aware: inside a `withEnvDb()` scope (PRD-101 named environments) the per-test env DB takes precedence — fixtures already seed cerebrum tables into the per-test `pops.db`, so this keeps the test environment self-contained.
- **`apps/pops-api/src/index.ts`** — eager `getCerebrumDrizzle()` call at boot, after media and before the env cleanup. A corrupt or unwritable `cerebrum.db` now surfaces during boot rather than on first nudge-log write.
- **`apps/pops-api/src/db.ts`** — `closeCerebrumDb()` added to `closeDb()` shutdown.

### What does NOT change

- `NudgeService` still reads/writes against the shared `pops.db`. The switchover lands in **Phase 2 PR 3** along with the ATTACH-based backfill from `pops.db` so existing nudge_log rows carry across at boot.
- No new env var is required at runtime — the resolver falls back to `./data/cerebrum.db` with a `console.warn` if both `CEREBRUM_SQLITE_PATH` and `SQLITE_PATH` are unset, matching the inventory / finance / media patterns.

### Tests

4 resolver unit tests cover the precedence chain (env wins, derived from `SQLITE_PATH` dir, relative path handling, fallback + warn).

The per-pillar-migrations smoke test (added in Phase 1 PR 2) continues to exercise cerebrum's `_journal.json` against an in-memory DB through `runPerPillarMigrations` — no further work needed here.

## Test plan

- [x] `pnpm --filter @pops/api vitest run src/db/cerebrum-sqlite-path.test.ts` — 4/4 pass.
- [x] `pnpm --filter @pops/api typecheck` — clean.
- [x] `pnpm --filter @pops/api vitest run src/modules/cerebrum/nudges/` — 91/91 pass (unchanged; NudgeService still on `pops.db`).
- [x] `pnpm typecheck` (full workspace turbo) — 43/43 packages green.
- [x] `pnpm format:check` — clean.
- [x] `pnpm install --frozen-lockfile` — lockfile unchanged.
