### PR TITLE
feat(api): flip nudge_log to the cerebrum pillar handle + backfill (pillar cerebrum phase 2 PR 3)

### DIFF
--- a/apps/pops-api/src/db/backfill-cerebrum-from-shared.test.ts
+++ b/apps/pops-api/src/db/backfill-cerebrum-from-shared.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Boot-time backfill tests for `backfillCerebrumFromShared` (phase 2 PR 3).
+ *
+ * Exercises the ATTACH-based copy from the shared `pops.db` to the
+ * pillar's `cerebrum.db` against on-disk SQLite files (in-memory DBs
+ * can't be ATTACHed). Confirms:
+ *   - first run carries existing rows across,
+ *   - second run is a no-op (idempotent — the per-table WHERE filter dedupes),
+ *   - mixed state (some rows already in cerebrum) only inserts the missing ones,
+ *   - missing source table is tolerated without throwing.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import BetterSqlite3 from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { openCerebrumDb } from '@pops/cerebrum-db';
+
+import { backfillCerebrumFromShared } from './backfill-cerebrum-from-shared.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'cerebrum-backfill-'));
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+const NUDGE_LOG_SQL = `
+CREATE TABLE nudge_log (
+  id text PRIMARY KEY NOT NULL,
+  type text NOT NULL,
+  title text NOT NULL,
+  body text NOT NULL,
+  engram_ids text NOT NULL,
+  priority text NOT NULL,
+  status text NOT NULL,
+  created_at text NOT NULL,
+  expires_at text,
+  acted_at text,
+  action_type text,
+  action_label text,
+  action_params text
+);
+`;
+
+function openSharedWithSeed(seed: (raw: BetterSqlite3.Database) => void): string {
+  const path = join(tmpDir, 'pops.db');
+  const raw = new BetterSqlite3(path);
+  raw.exec(NUDGE_LOG_SQL);
+  seed(raw);
+  raw.close();
+  return path;
+}
+
+function insertNudge(raw: BetterSqlite3.Database, id: string): void {
+  raw
+    .prepare(
+      `INSERT INTO nudge_log
+        (id, type, title, body, engram_ids, priority, status, created_at)
+       VALUES (?, 'pattern', 'T', 'B', '[]', 'medium', 'pending', '2026-06-10T00:00:00Z')`
+    )
+    .run(id);
+}
+
+describe('backfillCerebrumFromShared', () => {
+  it('copies nudge_log rows from the shared DB on first run', () => {
+    const sharedPath = openSharedWithSeed((raw) => insertNudge(raw, 'nudge-1'));
+
+    const cerebrum = openCerebrumDb(join(tmpDir, 'cerebrum.db'));
+    try {
+      backfillCerebrumFromShared(cerebrum, sharedPath);
+      const { n } = cerebrum.raw.prepare('SELECT count(*) AS n FROM nudge_log').get() as {
+        n: number;
+      };
+      expect(n).toBe(1);
+    } finally {
+      cerebrum.raw.close();
+    }
+  });
+
+  it('is idempotent — a second run does not duplicate rows', () => {
+    const sharedPath = openSharedWithSeed((raw) => insertNudge(raw, 'nudge-1'));
+
+    const cerebrum = openCerebrumDb(join(tmpDir, 'cerebrum.db'));
+    try {
+      backfillCerebrumFromShared(cerebrum, sharedPath);
+      backfillCerebrumFromShared(cerebrum, sharedPath);
+      const { n } = cerebrum.raw.prepare('SELECT count(*) AS n FROM nudge_log').get() as {
+        n: number;
+      };
+      expect(n).toBe(1);
+    } finally {
+      cerebrum.raw.close();
+    }
+  });
+
+  it('only inserts rows missing from the cerebrum copy (mixed state)', () => {
+    const sharedPath = openSharedWithSeed((raw) => {
+      insertNudge(raw, 'nudge-shared-only');
+      insertNudge(raw, 'nudge-both');
+    });
+
+    const cerebrum = openCerebrumDb(join(tmpDir, 'cerebrum.db'));
+    try {
+      // Pre-seed the cerebrum.db with one of the rows that also lives
+      // in the shared DB; the backfill must skip it but pick up the other.
+      insertNudge(cerebrum.raw, 'nudge-both');
+      backfillCerebrumFromShared(cerebrum, sharedPath);
+      const rows = cerebrum.raw.prepare('SELECT id FROM nudge_log ORDER BY id').all() as {
+        id: string;
+      }[];
+      expect(rows.map((r) => r.id)).toEqual(['nudge-both', 'nudge-shared-only']);
+    } finally {
+      cerebrum.raw.close();
+    }
+  });
+
+  it('tolerates a shared DB with no cerebrum tables (post-PR-4 drop scenario)', () => {
+    const sharedPath = join(tmpDir, 'pops.db');
+    const raw = new BetterSqlite3(sharedPath);
+    raw.exec(`CREATE TABLE other_table (id integer PRIMARY KEY)`);
+    raw.close();
+
+    const cerebrum = openCerebrumDb(join(tmpDir, 'cerebrum.db'));
+    try {
+      expect(() => backfillCerebrumFromShared(cerebrum, sharedPath)).not.toThrow();
+      const { n } = cerebrum.raw.prepare('SELECT count(*) AS n FROM nudge_log').get() as {
+        n: number;
+      };
+      expect(n).toBe(0);
+    } finally {
+      cerebrum.raw.close();
+    }
+  });
+});

--- a/apps/pops-api/src/db/backfill-cerebrum-from-shared.ts
+++ b/apps/pops-api/src/db/backfill-cerebrum-from-shared.ts
@@ -1,0 +1,103 @@
+/**
+ * Boot-time backfill from the legacy shared `pops.db` into the cerebrum
+ * pillar's `cerebrum.db`.
+ *
+ * Phase 2 PR 3 of the cerebrum pillar flips NudgeService reads/writes
+ * to the cerebrum handle. The first deploy after PR 3 needs to carry
+ * the existing nudge_log rows from the shared DB across before any
+ * reads come from the new file. Subsequent boots find the cerebrum
+ * copy already populated and become a no-op via the
+ * `WHERE id NOT IN (...)` existence filter.
+ *
+ * Today the slice only covers the `nudge_log` table; the engrams +
+ * embeddings + conversations + glia + plexus slices add their entries
+ * here when their cutovers land. Order matters when FKs are introduced
+ * across cerebrum-owned tables — for the nudge_log-only slice the
+ * order is trivial.
+ *
+ * Non-fatal: ATTACH or INSERT failures are logged and swallowed so a
+ * stale on-disk pops.db never bricks the boot path. Partial failures
+ * leave the cerebrum copy partially populated; the next deploy retries
+ * and the idempotent filter picks up only the still-missing rows.
+ *
+ * Mirrors `backfill-inventory-from-shared.ts` / `backfill-finance-from-
+ * shared.ts` / `backfill-media-from-shared.ts`.
+ */
+import type Database from 'better-sqlite3';
+
+import type { OpenedCerebrumDb } from '@pops/cerebrum-db';
+
+interface TableCopy {
+  readonly table: string;
+  /**
+   * Explicit column list keeps the backfill robust against a stale
+   * on-disk pops.db that already widened or narrowed since the boot
+   * image was built.
+   */
+  readonly columns: readonly string[];
+  /** Identifier column used in the existence filter. */
+  readonly idColumn: string;
+}
+
+const TABLE_COPIES: readonly TableCopy[] = [
+  {
+    table: 'nudge_log',
+    idColumn: 'id',
+    columns: [
+      'id',
+      'type',
+      'title',
+      'body',
+      'engram_ids',
+      'priority',
+      'status',
+      'created_at',
+      'expires_at',
+      'acted_at',
+      'action_type',
+      'action_label',
+      'action_params',
+    ],
+  },
+];
+
+function tryCopyTable(raw: Database.Database, copy: TableCopy): void {
+  try {
+    const hasTable = raw
+      .prepare(`SELECT 1 FROM pops.sqlite_master WHERE type='table' AND name='${copy.table}'`)
+      .get();
+    if (!hasTable) return;
+    const cols = copy.columns.join(', ');
+    raw.exec(`
+      INSERT INTO ${copy.table} (${cols})
+      SELECT ${cols}
+      FROM pops.${copy.table}
+      WHERE ${copy.idColumn} NOT IN (SELECT ${copy.idColumn} FROM ${copy.table})
+    `);
+  } catch (err) {
+    console.warn(`[db] Cerebrum backfill of ${copy.table} failed (non-fatal):`, err);
+  }
+}
+
+/**
+ * Copy every cerebrum-owned table's rows from `pops.db` into
+ * `cerebrum.db`, idempotent against re-runs.
+ *
+ * Caller is responsible for supplying the cerebrum handle (so this
+ * module stays decoupled from the lazy singleton in
+ * `db/cerebrum-handle.ts`). Production wiring passes the result of
+ * `getCerebrumDrizzle()` after the eager-open block; tests pass an
+ * in-memory handle with a tmpdir copy of the shared DB pre-populated.
+ */
+export function backfillCerebrumFromShared(cerebrum: OpenedCerebrumDb, sharedPath: string): void {
+  try {
+    cerebrum.raw.prepare('ATTACH DATABASE ? AS pops').run(sharedPath);
+    try {
+      for (const copy of TABLE_COPIES) tryCopyTable(cerebrum.raw, copy);
+    } finally {
+      cerebrum.raw.exec('DETACH DATABASE pops');
+    }
+  } catch (err) {
+    console.warn('[db] Cerebrum backfill ATTACH failed (non-fatal):', err);
+  }
+}

--- a/apps/pops-api/src/db/cerebrum-handle.ts
+++ b/apps/pops-api/src/db/cerebrum-handle.ts
@@ -19,6 +19,7 @@ import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { openCerebrumDb, type CerebrumDb, type OpenedCerebrumDb } from '@pops/cerebrum-db';
 
 import { getDb, isNamedEnvContext } from '../db.js';
+import { backfillCerebrumFromShared } from './backfill-cerebrum-from-shared.js';
 import { resolveCerebrumSqlitePath } from './cerebrum-sqlite-path.js';
 
 let cerebrumDb: OpenedCerebrumDb | null = null;
@@ -85,4 +86,16 @@ export function setCerebrumDb(next: OpenedCerebrumDb | null): OpenedCerebrumDb |
   const prev = cerebrumDb;
   cerebrumDb = next;
   return prev;
+}
+
+/**
+ * Run the one-shot ATTACH backfill from the legacy shared pops.db into
+ * the cerebrum pillar's cerebrum.db. No-op if the cerebrum handle isn't
+ * open (e.g. boot still resolving). Idempotent against repeated boots
+ * via per-table `WHERE id NOT IN (...)` filters. See
+ * `backfill-cerebrum-from-shared.ts` for the table-by-table behaviour.
+ */
+export function backfillCerebrumFromSharedDb(sharedPath: string): void {
+  if (!cerebrumDb) return;
+  backfillCerebrumFromShared(cerebrumDb, sharedPath);
 }

--- a/apps/pops-api/src/index.ts
+++ b/apps/pops-api/src/index.ts
@@ -7,7 +7,7 @@ config({ path: '../../.env', override: false }); // loads root .env without over
 
 import { createApp } from './app.js';
 import { backfillCoreFromShared, closeDb, getCoreDrizzle } from './db.js';
-import { getCerebrumDrizzle } from './db/cerebrum-handle.js';
+import { backfillCerebrumFromSharedDb, getCerebrumDrizzle } from './db/cerebrum-handle.js';
 import { backfillFinanceFromSharedDb, getFinanceDrizzle } from './db/finance-handle.js';
 import { backfillInventoryFromSharedDb, getInventoryDrizzle } from './db/inventory-handle.js';
 import { backfillMediaFromShared, getMediaDrizzle } from './db/media-db-handle.js';
@@ -97,16 +97,14 @@ try {
 }
 
 // Eagerly open the cerebrum pillar's SQLite + apply its journal at
-// boot so the in-package migrations land before any request hits the
-// API. Phase 2 PR 2 only opens the handle — no production traffic is
-// routed through it yet; the nudge_log slice still reads/writes against
-// the shared pops.db. Phase 2 PR 3 flips the nudge_log slice over with
-// an ATTACH-based backfill from pops.db (matching the inventory /
-// finance / media / core PR-3 pattern); PR 4 adds the Litestream
-// config. Opening early surfaces migration failures during boot rather
-// than on first nudge-log write.
+// boot. The nudge_log slice now reads/writes against this handle
+// (phase 2 PR 3); the one-shot `backfillCerebrumFromSharedDb` carries
+// any rows that still live in the legacy pops.db across. The backfill
+// is idempotent (per-table `WHERE id NOT IN (...)` filters) and
+// non-fatal (partial failure logs + continues).
 try {
   getCerebrumDrizzle();
+  backfillCerebrumFromSharedDb(resolveSqlitePath());
 } catch (err) {
   console.error('[db] Failed to bootstrap the cerebrum pillar SQLite:', err);
   throw err;

--- a/apps/pops-api/src/modules/cerebrum/nudges/nudge-persistence.ts
+++ b/apps/pops-api/src/modules/cerebrum/nudges/nudge-persistence.ts
@@ -20,6 +20,16 @@ import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 
 import type { EngramSummary } from './types.js';
 
+/**
+ * Engrams source handle. Today this is the shared pops.db until the
+ * engrams slice migrates into `@pops/cerebrum-db`. Widened to
+ * `Record<string, unknown>` so the same type works for both the bare
+ * pops.db handle (`getDrizzle()`) and the pillar handles
+ * (`getCerebrumDrizzle()`) — the runtime is a no-op but TS's invariant
+ * default schema parameter forces this dance.
+ */
+type EngramsDb = BetterSQLite3Database<Record<string, unknown>>;
+
 /** Group rows by engramId into a multi-value map. */
 function buildLookup(rows: { engramId: string; val: string }[]): Map<string, string[]> {
   const map = new Map<string, string[]>();
@@ -32,7 +42,7 @@ function buildLookup(rows: { engramId: string; val: string }[]): Map<string, str
 }
 
 /** Load active engrams from the index for detector input. */
-export function loadActiveEngrams(db: BetterSQLite3Database): EngramSummary[] {
+export function loadActiveEngrams(db: EngramsDb): EngramSummary[] {
   const rows = db
     .select()
     .from(engramIndex)

--- a/apps/pops-api/src/modules/cerebrum/nudges/nudge-service.ts
+++ b/apps/pops-api/src/modules/cerebrum/nudges/nudge-service.ts
@@ -7,14 +7,12 @@
  */
 import { and, count, eq, sql } from 'drizzle-orm';
 
-import { nudgeLogService, rowToNudge } from '@pops/cerebrum-db';
+import { nudgeLogService, rowToNudge, type CerebrumDb } from '@pops/cerebrum-db';
 import { nudgeLog } from '@pops/db-types';
 
 import { logger } from '../../../lib/logger.js';
 import { ConcatenationSynthesizer, executeConsolidationAct } from './consolidation-act.js';
 import { loadActiveEngrams } from './nudge-persistence.js';
-
-import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 
 import type { EngramService } from '../engrams/service.js';
 import type { HybridSearchService } from '../retrieval/hybrid-search.js';
@@ -25,7 +23,25 @@ import type { StalenessDetector } from './detectors/staleness.js';
 import type { Nudge, NudgeStatus, NudgeThresholds, NudgeType } from './types.js';
 
 export interface NudgeServiceDeps {
-  db: BetterSQLite3Database;
+  /**
+   * Cerebrum pillar drizzle handle. Owns `nudge_log` reads/writes after
+   * the Phase 2 PR 3 cutover. The shared pops.db copy stays populated
+   * during the transitional release cycle (the drift guard + the
+   * idempotent boot-time backfill keep both in lockstep) until the
+   * deletion PR retires the cerebrum-owned tags from the shared journal.
+   */
+  db: CerebrumDb;
+  /**
+   * Engrams-source drizzle handle. Today this is the shared pops.db
+   * because `loadActiveEngrams` reads `engram_index` / `engram_scopes` /
+   * `engram_tags` — cerebrum-owned tables that have not yet migrated to
+   * `cerebrum.db`. When the engrams slice migrates this collapses back
+   * to a single handle and this field is removed.
+   *
+   * Defaults to `db` so callers that do not split (tests, single-DB
+   * fixtures) keep working without code changes.
+   */
+  engramsDb?: CerebrumDb;
   searchService: HybridSearchService;
   consolidationDetector: ConsolidationDetector;
   stalenessDetector: StalenessDetector;
@@ -51,7 +67,8 @@ export interface ListNudgesOptions {
 }
 
 export class NudgeService {
-  private readonly db: BetterSQLite3Database;
+  private readonly db: CerebrumDb;
+  private readonly engramsDb: CerebrumDb;
   private readonly consolidationDetector: ConsolidationDetector;
   private readonly stalenessDetector: StalenessDetector;
   private readonly patternDetector: PatternDetector;
@@ -62,6 +79,7 @@ export class NudgeService {
 
   constructor(deps: NudgeServiceDeps) {
     this.db = deps.db;
+    this.engramsDb = deps.engramsDb ?? deps.db;
     this.consolidationDetector = deps.consolidationDetector;
     this.stalenessDetector = deps.stalenessDetector;
     this.patternDetector = deps.patternDetector;
@@ -73,7 +91,7 @@ export class NudgeService {
 
   /** Run a full nudge scan, optionally filtered by type. */
   async scan(type?: NudgeType): Promise<{ created: number }> {
-    const engrams = loadActiveEngrams(this.db);
+    const engrams = loadActiveEngrams(this.engramsDb);
     let totalCreated = 0;
 
     if (!type || type === 'consolidation') {

--- a/apps/pops-api/src/modules/cerebrum/nudges/router.ts
+++ b/apps/pops-api/src/modules/cerebrum/nudges/router.ts
@@ -12,6 +12,7 @@
 import { z } from 'zod';
 
 import { getDrizzle } from '../../../db.js';
+import { getCerebrumDrizzle } from '../../../db/cerebrum-handle.js';
 import { logger } from '../../../lib/logger.js';
 import { trpcError } from '../../../shared/trpc-error.js';
 import { protectedProcedure, router } from '../../../trpc.js';
@@ -31,8 +32,13 @@ let activeThresholds: NudgeThresholds = getDefaultNudgeThresholds();
 
 /** Build a NudgeService for the current request context. */
 function getService(): NudgeService {
-  const db = getDrizzle();
-  const searchService = new HybridSearchService(db);
+  // Post-cutover (Phase 2 PR 3): nudge_log lives on the cerebrum pillar
+  // handle; engrams reads still come from the shared pops.db until the
+  // engrams slice migrates. `searchService` reads against the shared DB
+  // (same engrams source) so it stays on `getDrizzle()`.
+  const db = getCerebrumDrizzle();
+  const engramsDb = getDrizzle();
+  const searchService = new HybridSearchService(engramsDb);
   const engramService = getEngramService();
   const patternDetector = new PatternDetector({
     thresholds: activeThresholds,
@@ -52,6 +58,7 @@ function getService(): NudgeService {
   });
   return new NudgeService({
     db,
+    engramsDb,
     searchService,
     consolidationDetector: new ConsolidationDetector(searchService, activeThresholds),
     stalenessDetector: new StalenessDetector(activeThresholds),

--- a/apps/pops-api/src/shared/test-utils.ts
+++ b/apps/pops-api/src/shared/test-utils.ts
@@ -2,6 +2,7 @@ import BetterSqlite3 from 'better-sqlite3';
 import { drizzle } from 'drizzle-orm/better-sqlite3';
 
 import { closeDb, setCoreDb, setDb } from '../db.js';
+import { setCerebrumDb } from '../db/cerebrum-handle.js';
 import { setFinanceDb } from '../db/finance-handle.js';
 import { setInventoryDb } from '../db/inventory-handle.js';
 import { setMediaDb } from '../db/media-db-handle.js';
@@ -1496,6 +1497,11 @@ export function setupTestContext() {
     // test fixture has to surface its tables on the finance handle.
     setFinanceDb({ db: drizzle(db), raw: db });
 
+    // Same for the cerebrum pillar handle (phase 2 PR 3): nudge_log
+    // reads/writes now resolve getCerebrumDrizzle(), so the test
+    // fixture has to surface that table on the cerebrum handle too.
+    setCerebrumDb({ db: drizzle(db), raw: db });
+
     return { db, caller: createCaller(true) };
   }
 
@@ -1504,6 +1510,7 @@ export function setupTestContext() {
     setFinanceDb(null);
     setInventoryDb(null);
     setMediaDb(null);
+    setCerebrumDb(null);
     closeDb();
   }
 


### PR DESCRIPTION
## Summary

Phase 2 PR 3 of Track H. Routes all nudge_log reads/writes through `getCerebrumDrizzle()` now that the cerebrum pillar's SQLite is opened at boot (#2817). The first deploy carries the existing rows from the shared `pops.db` across via an ATTACH-based backfill; subsequent boots find the cerebrum copy already populated and the per-table `WHERE id NOT IN (...)` filter makes the run a no-op.

Mirrors the same Phase 2 PR 3 pattern core / inventory / finance / media already use on `main`.

### Engrams reads stay on pops.db (for now)

The interesting wrinkle vs the other pillars: cerebrum's `NudgeService` reads BOTH `nudge_log` (cerebrum-owned slice) AND `engram_index` / `engram_scopes` / `engram_tags` (engrams slice — cerebrum-owned tables that have not yet migrated). After the cutover those engrams tables still live in the shared `pops.db`.

To keep the cutover surgical, `NudgeServiceDeps` gains an `engramsDb` field that defaults to `db` for backward compatibility:

- **Production wiring** (`router.ts`): `db = getCerebrumDrizzle()`, `engramsDb = getDrizzle()`. Nudge log work hits `cerebrum.db`; `loadActiveEngrams` keeps reading `pops.db`.
- **Tests** (any existing `new NudgeService({ db: testDb, ... })` call): the default makes `engramsDb` fall back to `db`. Existing tests seed both `nudge_log` AND engrams tables into one in-memory DB, so the unified handle still works.

When the engrams slice migrates into `@pops/cerebrum-db` the split collapses and `engramsDb` goes away (it's documented as transitional on the deps interface).

### Highlights

- `apps/pops-api/src/db/backfill-cerebrum-from-shared.ts` — ATTACH `pops` → per-table column-explicit `INSERT WHERE id NOT IN (...)` for `nudge_log` (today the only cerebrum-owned table on `cerebrum.db`; the engrams + embeddings + conversations + glia + plexus slices add their entries here when their cutovers land). Non-fatal on missing tables or ATTACH failure so a stale `pops.db` never bricks boot. Mirrors `backfill-inventory-from-shared.ts`.
- `apps/pops-api/src/db/cerebrum-handle.ts` — `backfillCerebrumFromSharedDb(sharedPath)` helper that no-ops when the cerebrum handle isn't open.
- `apps/pops-api/src/index.ts` — backfill call after the eager `getCerebrumDrizzle()` so a fresh deploy carries state across before the first request.
- `apps/pops-api/src/modules/cerebrum/nudges/nudge-service.ts` — `NudgeServiceDeps.db` is now typed as `CerebrumDb` from `@pops/cerebrum-db`; new `engramsDb` field defaults to `db`. The constructor stores both. `scan()` reads engrams via `this.engramsDb`; everything else uses `this.db`.
- `apps/pops-api/src/modules/cerebrum/nudges/router.ts` — builds `NudgeService` with the split handles. `HybridSearchService` stays on `getDrizzle()` (its reads target engrams + ai-related tables).
- `apps/pops-api/src/modules/cerebrum/nudges/nudge-persistence.ts` — `loadActiveEngrams`'s `db` param widens to `BetterSQLite3Database<Record<string, unknown>>` (alias `EngramsDb`) so the `CerebrumDb` + pops-api default handles both fit; runtime is unchanged.
- `apps/pops-api/src/shared/test-utils.ts` — injects the same in-memory DB into the cerebrum handle through `setCerebrumDb` so the existing integration suite (and every cerebrum slice test that runs under `setupTestContext`) still routes through one shared connection.

### Tests

- 4 backfill unit tests against tmpdir on-disk DBs (ATTACH requires files, not `:memory:`): first-run copy, idempotent re-run, mixed-state (only insert missing rows), tolerates a shared DB with no cerebrum tables (post-PR-4 drop scenario).
- The full nudges test suite (9 files / 91 tests) keeps passing without modification — the `engramsDb ?? db` fallback preserves the existing single-handle behaviour.

## Test plan

- [x] `pnpm --filter @pops/api vitest run src/db/backfill-cerebrum-from-shared.test.ts src/db/cerebrum-sqlite-path.test.ts src/modules/cerebrum/nudges/` — 11 files / 99 tests pass.
- [x] `pnpm typecheck` (full workspace turbo) — 43/43 packages green.
- [x] `pnpm format:check` — clean.
- [x] `pnpm install --frozen-lockfile` — lockfile unchanged.
