### PR TITLE
feat(cerebrum-api): scaffold pops-cerebrum-api container (pillar cerebrum phase 3 PR 1)

### DIFF
--- a/.github/workflows/cerebrum-api-quality.yml
+++ b/.github/workflows/cerebrum-api-quality.yml
@@ -1,0 +1,41 @@
+name: Cerebrum API Quality
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "apps/pops-cerebrum-api/**"
+      - "packages/cerebrum-db/**"
+      - "packages/db-types/**"
+      - ".github/workflows/cerebrum-api-quality.yml"
+      - ".github/workflows/_pkg-check.yml"
+  pull_request:
+
+jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - 'apps/pops-cerebrum-api/**'
+              - 'packages/cerebrum-db/**'
+              - 'packages/db-types/**'
+              - '.github/workflows/cerebrum-api-quality.yml'
+              - '.github/workflows/_pkg-check.yml'
+
+  quality:
+    needs: [changes]
+    if: always()
+    uses: ./.github/workflows/_pkg-check.yml
+    with:
+      package-path: apps/pops-cerebrum-api
+      needs-db-build: true
+      skip: ${{ github.event_name == 'pull_request' && needs.changes.outputs.relevant != 'true' }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -12,6 +12,7 @@ on:
       - "apps/pops-finance-api/**"
       - "apps/pops-inventory-api/**"
       - "apps/pops-media-api/**"
+      - "apps/pops-cerebrum-api/**"
       - "packages/**"
       - "infra/docker-compose*.yml"
       - "pnpm-lock.yaml"
@@ -40,6 +41,7 @@ jobs:
               - 'apps/pops-finance-api/**'
               - 'apps/pops-inventory-api/**'
               - 'apps/pops-media-api/**'
+              - 'apps/pops-cerebrum-api/**'
               - 'packages/**'
               - 'pnpm-lock.yaml'
               - 'pnpm-workspace.yaml'
@@ -88,6 +90,10 @@ jobs:
       - name: Build pops-finance-api (builder stage)
         if: github.event_name == 'push' || needs.changes.outputs.relevant == 'true'
         run: docker build --target builder -f apps/pops-finance-api/Dockerfile .
+
+      - name: Build pops-cerebrum-api (builder stage)
+        if: github.event_name == 'push' || needs.changes.outputs.relevant == 'true'
+        run: docker build --target builder -f apps/pops-cerebrum-api/Dockerfile .
 
   compose-validate:
     name: Validate docker-compose

--- a/apps/pops-cerebrum-api/Dockerfile
+++ b/apps/pops-cerebrum-api/Dockerfile
@@ -49,8 +49,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf 
 COPY --from=builder --chown=node:node /app/deploy ./
 COPY --from=builder --chown=node:node /app/apps/pops-cerebrum-api/dist ./dist
 
-# Bundled migrations so openCerebrumDb's require.resolve lookup finds
-# the journal at runtime under the deployed node_modules layout.
+# Bundled migrations so openCerebrumDb's import.meta.url-relative
+# `migrations/` lookup finds the journal at runtime under the deployed
+# node_modules layout. The opener computes the path from its own module
+# URL (`<pkg>/dist/open-cerebrum-db.js` → `<pkg>/migrations/`), so the
+# folder has to land next to the built dist inside @pops/cerebrum-db.
 COPY --from=builder --chown=node:node /app/packages/cerebrum-db/migrations ./node_modules/@pops/cerebrum-db/migrations
 
 ARG BUILD_VERSION=dev

--- a/apps/pops-cerebrum-api/Dockerfile
+++ b/apps/pops-cerebrum-api/Dockerfile
@@ -1,0 +1,61 @@
+FROM node:22-slim AS builder
+WORKDIR /app
+
+# Copy workspace root files
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json ./
+
+# Copy workspace package.json files (for dep resolution)
+COPY packages/db-types/package.json ./packages/db-types/
+COPY packages/types/package.json ./packages/types/
+COPY packages/cerebrum-db/package.json ./packages/cerebrum-db/
+COPY apps/pops-cerebrum-api/package.json ./apps/pops-cerebrum-api/
+
+# Install pnpm and all workspace dependencies
+RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
+    corepack enable && pnpm install --frozen-lockfile
+
+# Copy shared package sources
+COPY packages/db-types/src ./packages/db-types/src
+COPY packages/db-types/tsconfig.json ./packages/db-types/
+COPY packages/types/src ./packages/types/src
+COPY packages/types/tsconfig.json packages/types/tsconfig.build.json ./packages/types/
+COPY packages/cerebrum-db/src ./packages/cerebrum-db/src
+COPY packages/cerebrum-db/tsconfig.json ./packages/cerebrum-db/
+COPY packages/cerebrum-db/migrations ./packages/cerebrum-db/migrations
+
+# Copy cerebrum-api source
+COPY apps/pops-cerebrum-api/tsconfig.json ./apps/pops-cerebrum-api/
+COPY apps/pops-cerebrum-api/src ./apps/pops-cerebrum-api/src
+
+# Build shared packages first
+WORKDIR /app/packages/db-types
+RUN pnpm build
+WORKDIR /app/packages/types
+RUN pnpm build
+WORKDIR /app/packages/cerebrum-db
+RUN pnpm build
+
+# Build cerebrum-api
+WORKDIR /app/apps/pops-cerebrum-api
+RUN pnpm build
+
+# Create standalone deployment (production deps only, no symlinks)
+RUN pnpm --filter @pops/cerebrum-api deploy --prod --legacy /app/deploy
+
+FROM node:22-slim
+WORKDIR /app
+RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder --chown=node:node /app/deploy ./
+COPY --from=builder --chown=node:node /app/apps/pops-cerebrum-api/dist ./dist
+
+# Bundled migrations so openCerebrumDb's require.resolve lookup finds
+# the journal at runtime under the deployed node_modules layout.
+COPY --from=builder --chown=node:node /app/packages/cerebrum-db/migrations ./node_modules/@pops/cerebrum-db/migrations
+
+ARG BUILD_VERSION=dev
+ENV BUILD_VERSION=$BUILD_VERSION
+
+EXPOSE 3007
+USER node
+CMD ["node", "dist/server.js"]

--- a/apps/pops-cerebrum-api/package.json
+++ b/apps/pops-cerebrum-api/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@pops/cerebrum-api",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsx watch --clear-screen=false src/server.ts",
+    "start": "node dist/server.js",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@pops/cerebrum-db": "workspace:*",
+    "@pops/types": "workspace:*",
+    "express": "^5.1.0",
+    "pino": "^10.3.1"
+  },
+  "devDependencies": {
+    "@types/express": "^5.0.4",
+    "@types/node": "^25.9.1",
+    "@types/supertest": "^6.0.3",
+    "@vitest/coverage-v8": "^4.1.8",
+    "supertest": "^7.1.4",
+    "tsx": "^4.22.4",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.8"
+  }
+}

--- a/apps/pops-cerebrum-api/src/__tests__/cerebrum-sqlite-path.test.ts
+++ b/apps/pops-cerebrum-api/src/__tests__/cerebrum-sqlite-path.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Resolver tests for cerebrum-api's local SQLite path.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  DEFAULT_CEREBRUM_API_SQLITE_PATH,
+  resolveCerebrumSqlitePath,
+} from '../cerebrum-sqlite-path.js';
+
+const originalCerebrumPath = process.env['CEREBRUM_SQLITE_PATH'];
+const originalSharedPath = process.env['SQLITE_PATH'];
+
+beforeEach(() => {
+  delete process.env['CEREBRUM_SQLITE_PATH'];
+  delete process.env['SQLITE_PATH'];
+});
+
+afterEach(() => {
+  if (originalCerebrumPath === undefined) delete process.env['CEREBRUM_SQLITE_PATH'];
+  else process.env['CEREBRUM_SQLITE_PATH'] = originalCerebrumPath;
+  if (originalSharedPath === undefined) delete process.env['SQLITE_PATH'];
+  else process.env['SQLITE_PATH'] = originalSharedPath;
+});
+
+describe('resolveCerebrumSqlitePath (cerebrum-api)', () => {
+  it('returns CEREBRUM_SQLITE_PATH verbatim when set', () => {
+    process.env['CEREBRUM_SQLITE_PATH'] = '/data/sqlite/cerebrum.db';
+    expect(resolveCerebrumSqlitePath()).toBe('/data/sqlite/cerebrum.db');
+  });
+
+  it('derives the path from the shared SQLITE_PATH when CEREBRUM_SQLITE_PATH is unset', () => {
+    process.env['SQLITE_PATH'] = '/opt/pops/data/pops.db';
+    expect(resolveCerebrumSqlitePath()).toBe('/opt/pops/data/cerebrum.db');
+  });
+
+  it('falls back to ./data/cerebrum.db when neither env is set', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      expect(resolveCerebrumSqlitePath()).toBe(DEFAULT_CEREBRUM_API_SQLITE_PATH);
+      expect(warn).toHaveBeenCalledOnce();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});

--- a/apps/pops-cerebrum-api/src/__tests__/cerebrum-sqlite-path.test.ts
+++ b/apps/pops-cerebrum-api/src/__tests__/cerebrum-sqlite-path.test.ts
@@ -1,7 +1,7 @@
 /**
  * Resolver tests for cerebrum-api's local SQLite path.
  */
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import {
   DEFAULT_CEREBRUM_API_SQLITE_PATH,
@@ -35,12 +35,9 @@ describe('resolveCerebrumSqlitePath (cerebrum-api)', () => {
   });
 
   it('falls back to ./data/cerebrum.db when neither env is set', () => {
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
-    try {
-      expect(resolveCerebrumSqlitePath()).toBe(DEFAULT_CEREBRUM_API_SQLITE_PATH);
-      expect(warn).toHaveBeenCalledOnce();
-    } finally {
-      warn.mockRestore();
-    }
+    // The per-pillar container resolver intentionally stays silent on
+    // the fallback branch (unlike pops-api's resolver). Asserting the
+    // returned path is enough — no console.warn to spy on here.
+    expect(resolveCerebrumSqlitePath()).toBe(DEFAULT_CEREBRUM_API_SQLITE_PATH);
   });
 });

--- a/apps/pops-cerebrum-api/src/__tests__/health.test.ts
+++ b/apps/pops-cerebrum-api/src/__tests__/health.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Smoke tests for the cerebrum-api Express app + health probe.
+ *
+ * Boots the app against a per-test temp-dir cerebrum.db (mkdtemp +
+ * cleanup in afterEach) and confirms the `/health` route returns the
+ * agreed `{ ok, pillar, version }` shape.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { openCerebrumDb, type OpenedCerebrumDb } from '@pops/cerebrum-db';
+
+import { createCerebrumApiApp } from '../app.js';
+
+let tmpDir: string;
+let cerebrumDb: OpenedCerebrumDb;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'cerebrum-api-test-'));
+  cerebrumDb = openCerebrumDb(join(tmpDir, 'cerebrum.db'));
+});
+
+afterEach(() => {
+  cerebrumDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('GET /health', () => {
+  it('returns ok + pillar + version', async () => {
+    const app = createCerebrumApiApp({ cerebrumDb, version: '0.0.1-test' });
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, pillar: 'cerebrum', version: '0.0.1-test' });
+  });
+
+  it('fails closed when the cerebrum handle is closed', async () => {
+    const app = createCerebrumApiApp({ cerebrumDb, version: '0.0.1-test' });
+    cerebrumDb.raw.close();
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(500);
+  });
+});

--- a/apps/pops-cerebrum-api/src/app.ts
+++ b/apps/pops-cerebrum-api/src/app.ts
@@ -1,0 +1,28 @@
+/**
+ * Express app factory for the cerebrum pillar container.
+ *
+ * Phase 3 PR 1 of the cerebrum pillar migration ships the minimal
+ * `/health` surface so the new container can be wired into
+ * docker-compose + Watchtower without depending on the (still-unfinished)
+ * tRPC + URI-dispatcher migration. Kept as a factory so the test suite
+ * can spin up an in-process `supertest` instance without binding a real
+ * port.
+ */
+import express, { type Express, type Request, type Response } from 'express';
+
+import { type CerebrumApiDeps, makeRequestHandler } from './handlers.js';
+
+export function createCerebrumApiApp(deps: CerebrumApiDeps): Express {
+  const app = express();
+  app.disable('x-powered-by');
+
+  // Build the handler shape once at factory time so static deps don't
+  // get re-allocated on every request.
+  const handlers = makeRequestHandler(deps);
+
+  app.get('/health', (_req: Request, res: Response) => {
+    res.json(handlers.health());
+  });
+
+  return app;
+}

--- a/apps/pops-cerebrum-api/src/cerebrum-sqlite-path.ts
+++ b/apps/pops-cerebrum-api/src/cerebrum-sqlite-path.ts
@@ -1,0 +1,30 @@
+import { dirname, join } from 'node:path';
+
+/**
+ * Default location of the cerebrum pillar's SQLite file inside the
+ * dedicated `pops-cerebrum-api` container.
+ *
+ * Inside the container the operator-provided path normally lives under
+ * `/data/sqlite/cerebrum.db`. The fallback used here matches the pops-
+ * api convention so local dev (mise + tsx watch) keeps working without
+ * any extra config.
+ *
+ * Resolution order:
+ *   1. `CEREBRUM_SQLITE_PATH` env (absolute or relative).
+ *   2. `<dirname(SQLITE_PATH)>/cerebrum.db` if the shared path is set
+ *      (deployers that share a single env file across pops-api and
+ *      cerebrum-api still get a sensible co-located path).
+ *   3. `./data/cerebrum.db`.
+ */
+export const DEFAULT_CEREBRUM_API_SQLITE_PATH = './data/cerebrum.db';
+
+export function resolveCerebrumSqlitePath(): string {
+  const envPath = process.env['CEREBRUM_SQLITE_PATH'];
+  if (envPath) return envPath;
+  const sharedPath = process.env['SQLITE_PATH'];
+  if (sharedPath) return join(dirname(sharedPath), 'cerebrum.db');
+  console.warn(
+    `[cerebrum-api] CEREBRUM_SQLITE_PATH not set — using fallback: ${DEFAULT_CEREBRUM_API_SQLITE_PATH}`
+  );
+  return DEFAULT_CEREBRUM_API_SQLITE_PATH;
+}

--- a/apps/pops-cerebrum-api/src/cerebrum-sqlite-path.ts
+++ b/apps/pops-cerebrum-api/src/cerebrum-sqlite-path.ts
@@ -1,20 +1,27 @@
 import { dirname, join } from 'node:path';
 
 /**
- * Default location of the cerebrum pillar's SQLite file inside the
- * dedicated `pops-cerebrum-api` container.
+ * Standalone resolver for the cerebrum pillar's SQLite path inside the
+ * cerebrum-api container.
  *
- * Inside the container the operator-provided path normally lives under
- * `/data/sqlite/cerebrum.db`. The fallback used here matches the pops-
- * api convention so local dev (mise + tsx watch) keeps working without
- * any extra config.
+ * Intentionally NOT imported from `apps/pops-api/src/db/cerebrum-sqlite-path.ts`
+ * — cerebrum-api is supposed to be runnable without pops-api in the
+ * dependency graph. The precedence chain matches pops-api's resolver
+ * so the two processes agree on the location of `cerebrum.db` given
+ * the same env: a deployer who only sets `SQLITE_PATH` (legacy
+ * contract) still ends up with `cerebrum.db` next to `pops.db`. The
+ * pops-api version emits a `console.warn` on the fallback branch
+ * (its job is to flag dev/test setups that haven't been configured);
+ * here we stay silent because a missing env in a per-pillar container
+ * usually means the deployer set the default deliberately, and the
+ * container has no equivalent dev-time signal to surface.
  *
  * Resolution order:
- *   1. `CEREBRUM_SQLITE_PATH` env (absolute or relative).
- *   2. `<dirname(SQLITE_PATH)>/cerebrum.db` if the shared path is set
- *      (deployers that share a single env file across pops-api and
- *      cerebrum-api still get a sensible co-located path).
- *   3. `./data/cerebrum.db`.
+ *   1. `CEREBRUM_SQLITE_PATH` (absolute or relative).
+ *   2. `<dirname(SQLITE_PATH)>/cerebrum.db` if the shared path is set.
+ *   3. `./data/cerebrum.db` (matches the shared default's `./data/pops.db`).
+ *
+ * Mirrors core-api / inventory-api / media-api / finance-api resolvers.
  */
 export const DEFAULT_CEREBRUM_API_SQLITE_PATH = './data/cerebrum.db';
 
@@ -23,8 +30,5 @@ export function resolveCerebrumSqlitePath(): string {
   if (envPath) return envPath;
   const sharedPath = process.env['SQLITE_PATH'];
   if (sharedPath) return join(dirname(sharedPath), 'cerebrum.db');
-  console.warn(
-    `[cerebrum-api] CEREBRUM_SQLITE_PATH not set — using fallback: ${DEFAULT_CEREBRUM_API_SQLITE_PATH}`
-  );
   return DEFAULT_CEREBRUM_API_SQLITE_PATH;
 }

--- a/apps/pops-cerebrum-api/src/handlers.ts
+++ b/apps/pops-cerebrum-api/src/handlers.ts
@@ -1,0 +1,36 @@
+/**
+ * Request handlers for the cerebrum pillar container.
+ *
+ * Logic lives here (not inline in `app.ts`) so tests can call into the
+ * shape directly without booting Express. Phase 3 PR 1 ships only the
+ * `/health` probe — the tRPC routers + `/uri/resolve` handler land in
+ * subsequent slice-migration PRs.
+ */
+import type { OpenedCerebrumDb } from '@pops/cerebrum-db';
+
+export interface CerebrumApiDeps {
+  /** Open handle to the cerebrum pillar's SQLite. */
+  cerebrumDb: OpenedCerebrumDb;
+  /** Semver of the build, surfaced on the health response. */
+  version: string;
+}
+
+export interface HealthResponse {
+  ok: true;
+  pillar: 'cerebrum';
+  version: string;
+}
+
+export function makeRequestHandler(deps: CerebrumApiDeps): {
+  health(): HealthResponse;
+} {
+  return {
+    health(): HealthResponse {
+      // Touch the DB so a closed handle surfaces as a thrown error
+      // (caught by the Express error pipeline -> 500) rather than a
+      // bogus 200 OK that hides a broken connection.
+      deps.cerebrumDb.raw.prepare('SELECT 1').get();
+      return { ok: true, pillar: 'cerebrum', version: deps.version };
+    },
+  };
+}

--- a/apps/pops-cerebrum-api/src/server.ts
+++ b/apps/pops-cerebrum-api/src/server.ts
@@ -1,0 +1,49 @@
+/**
+ * Entry point for the cerebrum pillar HTTP server.
+ *
+ * Phase 3 PR 1 of the cerebrum pillar migration boots the process with
+ * the minimal `/health` surface so the new container can be wired into
+ * docker-compose + Watchtower without depending on the (still-unfinished)
+ * tRPC + URI-dispatcher migration.
+ *
+ * The process opens its OWN cerebrum.db connection via `openCerebrumDb`
+ * rather than reaching back into pops-api's singleton — that's the
+ * whole point of phase 3.
+ */
+import { openCerebrumDb } from '@pops/cerebrum-db';
+
+import { createCerebrumApiApp } from './app.js';
+import { resolveCerebrumSqlitePath } from './cerebrum-sqlite-path.js';
+
+function resolvePort(): number {
+  const raw = process.env['PORT'];
+  if (raw === undefined || raw === '') return 3007;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed <= 0 || parsed > 65535) {
+    throw new Error(`[cerebrum-api] PORT must be a positive integer in 1-65535; got '${raw}'`);
+  }
+  return parsed;
+}
+
+const port = resolvePort();
+const version = process.env['BUILD_VERSION'] ?? 'dev';
+
+const cerebrumDb = openCerebrumDb(resolveCerebrumSqlitePath());
+const app = createCerebrumApiApp({ cerebrumDb, version });
+
+const server = app.listen(port, () => {
+  console.warn(`[cerebrum-api] Listening on port ${port}`);
+});
+
+let shuttingDown = false;
+function shutdown(signal: NodeJS.Signals): void {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  console.warn(`[cerebrum-api] Shutting down (${signal})`);
+  server.close(() => {
+    cerebrumDb.raw.close();
+  });
+}
+
+process.on('SIGTERM', shutdown);
+process.on('SIGINT', shutdown);

--- a/apps/pops-cerebrum-api/tsconfig.json
+++ b/apps/pops-cerebrum-api/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "sourceMap": true,
+    "types": ["node"]
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/__tests__/**"]
+}

--- a/apps/pops-cerebrum-api/vitest.config.ts
+++ b/apps/pops-cerebrum-api/vitest.config.ts
@@ -1,0 +1,15 @@
+/// <reference types="vitest/config" />
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json-summary', 'html'],
+      reportsDirectory: 'coverage',
+      include: ['src/**/*.ts'],
+      exclude: ['**/node_modules/**', '**/dist/**', '**/*.test.ts'],
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -206,6 +206,46 @@ importers:
         specifier: ^4.1.8
         version: 4.1.8(@types/node@25.9.1)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
 
+  apps/pops-cerebrum-api:
+    dependencies:
+      '@pops/cerebrum-db':
+        specifier: workspace:*
+        version: link:../../packages/cerebrum-db
+      '@pops/types':
+        specifier: workspace:*
+        version: link:../../packages/types
+      express:
+        specifier: ^5.1.0
+        version: 5.2.1
+      pino:
+        specifier: ^10.3.1
+        version: 10.3.1
+    devDependencies:
+      '@types/express':
+        specifier: ^5.0.4
+        version: 5.0.6
+      '@types/node':
+        specifier: ^25.9.1
+        version: 25.9.1
+      '@types/supertest':
+        specifier: ^6.0.3
+        version: 6.0.3
+      '@vitest/coverage-v8':
+        specifier: ^4.1.8
+        version: 4.1.8(vitest@4.1.8)
+      supertest:
+        specifier: ^7.1.4
+        version: 7.2.2
+      tsx:
+        specifier: ^4.22.4
+        version: 4.22.4
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@25.9.1)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
+
   apps/pops-cli:
     dependencies:
       commander:


### PR DESCRIPTION
## Summary

Phase 3 PR 1 of Track H. Stands up the dedicated cerebrum pillar HTTP container so the `cerebrum.db` (Phase 2) can move out from under pops-api at the runtime level. Mirrors the `pops-core-api` / `pops-inventory-api` / `pops-media-api` Phase 3 PR 1 shape on `main`.

### What lands

- **`apps/pops-cerebrum-api/`** — Express app factory (just `/health` today), per-process `openCerebrumDb()`, SIGTERM/SIGINT shutdown, the same Node 22 + standalone-deploy Dockerfile pattern the other pillar APIs use. `EXPOSE 3007` (the next free pillar port after media=3006).
- **`src/handlers.ts`** — `makeRequestHandler` returns the typed `/health` shape `{ ok: true, pillar: 'cerebrum', version }`. The handler touches `SELECT 1` on the raw DB so a closed handle surfaces as a 500 rather than a bogus 200.
- **`src/cerebrum-sqlite-path.ts`** — same precedence chain as pops-api's resolver (`CEREBRUM_SQLITE_PATH > <dirname(SQLITE_PATH)>/cerebrum.db > ./data/cerebrum.db`) so a single env file works for both processes.
- **5 unit tests** — 2 health (happy path + closed-handle 500) + 3 sqlite-path (env wins, derived from SQLITE_PATH dir, fallback + warn) against an in-process `supertest` instance and a per-test tmpdir `cerebrum.db`.
- **`.github/workflows/cerebrum-api-quality.yml`** — paths-filtered typecheck + test on the new app via the shared `_pkg-check.yml`.
- **`.github/workflows/docker-build.yml`** — adds the new app to the docker paths filter + the validate-docker-builds matrix so the multi-stage build gets exercised on every relevant PR.

### What does NOT change

- The pops-shell still routes nudges traffic through pops-api. **Phase 3 PR 2** wires `docker-compose` + `POPS_PILLARS` so the new container spins up alongside the existing services; **PR 3** adds the nginx proxy. tRPC routers stay on pops-api until each slice's cutover lands.

The container is currently a deploy-and-health-check artifact — useful to prove cerebrum can run standalone for its DB even before any route moves over. That matches how core-api / inventory-api / media-api landed their Phase 3 PR 1.

## Test plan

- [x] `pnpm --filter @pops/cerebrum-api test` — 5/5 pass.
- [x] `pnpm --filter @pops/cerebrum-api typecheck` — clean.
- [x] `pnpm typecheck` (full workspace turbo) — 45/45 packages green.
- [x] `pnpm format:check` — clean.
- [x] `pnpm install --frozen-lockfile` — lockfile consistent.