### PR TITLE
feat(infra): wire cerebrum-api into docker-compose + publish image (pillar cerebrum phase 3 PR 2)

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -205,3 +205,29 @@ jobs:
           labels: ${{ steps.meta-finance-api.outputs.labels }}
           build-args: |
             BUILD_VERSION=${{ github.sha }}
+
+      - name: Generate metadata for pops-cerebrum-api
+        id: meta-cerebrum-api
+        uses: docker/metadata-action@v6
+        with:
+          images: ghcr.io/knoxio/pops-cerebrum-api
+          tags: |
+            type=raw,value=main,enable={{is_default_branch}}
+            type=sha,prefix=sha-,format=short
+            type=semver,pattern={{version}}
+            type=semver,pattern=v{{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=semver,pattern=v{{major}}
+
+      - name: Build and push pops-cerebrum-api
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: apps/pops-cerebrum-api/Dockerfile
+          push: true
+          tags: ${{ steps.meta-cerebrum-api.outputs.tags }}
+          labels: ${{ steps.meta-cerebrum-api.outputs.labels }}
+          build-args: |
+            BUILD_VERSION=${{ github.sha }}

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -48,7 +48,7 @@ services:
       # `/pillars` snapshot that the shell's nginx proxy fans out to,
       # so it MUST default to the full sibling list rather than empty.
       # Sibling pillars get appended (id:baseUrl,...) as they extract.
-      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004}
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,cerebrum:http://cerebrum-api:3007}
     expose:
       - '3001'
     healthcheck:
@@ -88,7 +88,7 @@ services:
       INVENTORY_SELF_BASE_URL: http://inventory-api:3002
       # Cross-pillar registry. Includes core-api by default so /pillars
       # surfaces both host pillars on the synthetic-entry list.
-      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004}
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,cerebrum:http://cerebrum-api:3007}
     expose:
       - '3002'
     depends_on:
@@ -130,7 +130,7 @@ services:
       FINANCE_SELF_BASE_URL: http://finance-api:3004
       # Cross-pillar registry — included for parity with siblings even
       # though finance-api today only exposes /health.
-      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004}
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,cerebrum:http://cerebrum-api:3007}
     expose:
       - '3004'
     depends_on:
@@ -172,7 +172,7 @@ services:
       MEDIA_SELF_BASE_URL: http://media-api:3003
       # Cross-pillar registry. Includes core-api + inventory-api by default
       # so /pillars surfaces every host pillar on the synthetic-entry list.
-      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004}
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,cerebrum:http://cerebrum-api:3007}
     expose:
       - '3003'
     depends_on:
@@ -185,6 +185,48 @@ services:
           'node',
           '-e',
           "fetch('http://localhost:3003/health').then(r=>{if(!r.ok)process.exit(1)})",
+        ]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+  # Cerebrum pillar API (ADR-026, Phase 3 PR 2 of the cerebrum track).
+  # Hosts cerebrum.db reads/writes for the nudge_log slice today;
+  # subsequent slices (engrams, embeddings, conversations, glia,
+  # plexus, URI dispatcher) move their tRPC routers behind it.
+  cerebrum-api:
+    build:
+      context: ..
+      dockerfile: apps/pops-cerebrum-api/Dockerfile
+      args:
+        BUILD_VERSION: ${BUILD_VERSION:-dev}
+    container_name: pops-cerebrum-api
+    restart: unless-stopped
+    networks:
+      - frontend
+      - backend
+    volumes:
+      - sqlite-data:/data/sqlite
+    environment:
+      NODE_ENV: production
+      PORT: '3007'
+      CEREBRUM_SQLITE_PATH: /data/sqlite/cerebrum.db
+      CEREBRUM_SELF_BASE_URL: http://cerebrum-api:3007
+      # Cross-pillar registry — included for parity with siblings even
+      # though cerebrum-api today only exposes /health.
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,cerebrum:http://cerebrum-api:3007}
+    expose:
+      - '3007'
+    depends_on:
+      core-api:
+        condition: service_healthy
+    healthcheck:
+      test:
+        [
+          'CMD',
+          'node',
+          '-e',
+          "fetch('http://localhost:3007/health').then(r=>{if(!r.ok)process.exit(1)})",
         ]
       interval: 30s
       timeout: 5s
@@ -221,7 +263,7 @@ services:
       # its compose hostname so pops-api's URI dispatcher can route
       # outbound `pops:core/...` traffic to the new container. Deployers
       # override POPS_PILLARS to extend with sibling pillars.
-      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004}
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,cerebrum:http://cerebrum-api:3007}
       # Paperless-ngx integration (optional — leave unset to disable)
       PAPERLESS_BASE_URL: ${PAPERLESS_BASE_URL:-}
       PAPERLESS_API_TOKEN: ${PAPERLESS_API_TOKEN:-}
@@ -237,6 +279,8 @@ services:
       media-api:
         condition: service_healthy
       finance-api:
+        condition: service_healthy
+      cerebrum-api:
         condition: service_healthy
     healthcheck:
       test:
@@ -276,7 +320,7 @@ services:
       SQLITE_PATH: /data/sqlite/pops.db
       REDIS_HOST: pops-redis
       REDIS_PORT: '6379'
-      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004}
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,cerebrum:http://cerebrum-api:3007}
     depends_on:
       pops-redis:
         condition: service_healthy
@@ -287,6 +331,8 @@ services:
       media-api:
         condition: service_healthy
       finance-api:
+        condition: service_healthy
+      cerebrum-api:
         condition: service_healthy
 
   # ── FRONTEND ─────────────────────────────────────────────────────

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       # Cross-pillar registry — core-api hosts the authoritative
       # `/pillars` snapshot that the shell's nginx proxy fans out to,
       # so it MUST default to the full sibling list rather than empty.
-      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004}
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,cerebrum:http://cerebrum-api:3007}
     expose:
       - '3001'
     healthcheck:
@@ -81,7 +81,7 @@ services:
       PORT: '3002'
       INVENTORY_SQLITE_PATH: /data/sqlite/inventory.db
       INVENTORY_SELF_BASE_URL: http://inventory-api:3002
-      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004}
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,cerebrum:http://cerebrum-api:3007}
     expose:
       - '3002'
     depends_on:
@@ -119,7 +119,7 @@ services:
       PORT: '3004'
       FINANCE_SQLITE_PATH: /data/sqlite/finance.db
       FINANCE_SELF_BASE_URL: http://finance-api:3004
-      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004}
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,cerebrum:http://cerebrum-api:3007}
     expose:
       - '3004'
     depends_on:
@@ -157,7 +157,7 @@ services:
       PORT: '3003'
       MEDIA_SQLITE_PATH: /data/sqlite/media.db
       MEDIA_SELF_BASE_URL: http://media-api:3003
-      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004}
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,cerebrum:http://cerebrum-api:3007}
     expose:
       - '3003'
     depends_on:
@@ -170,6 +170,44 @@ services:
           'node',
           '-e',
           "fetch('http://localhost:3003/health').then(r=>{if(!r.ok)process.exit(1)})",
+        ]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+  # Cerebrum pillar API (ADR-026, Phase 3 PR 2 of the cerebrum track).
+  # Hosts cerebrum.db reads/writes for the nudge_log slice today;
+  # subsequent slices (engrams, embeddings, conversations, glia,
+  # plexus, URI dispatcher) move their tRPC routers behind it.
+  cerebrum-api:
+    image: ghcr.io/knoxio/pops-cerebrum-api:${POPS_IMAGE_TAG:-main}
+    container_name: pops-cerebrum-api
+    restart: unless-stopped
+    labels:
+      com.centurylinklabs.watchtower.enable: 'true'
+    networks:
+      - frontend
+      - backend
+    volumes:
+      - sqlite-data:/data/sqlite
+    environment:
+      NODE_ENV: production
+      PORT: '3007'
+      CEREBRUM_SQLITE_PATH: /data/sqlite/cerebrum.db
+      CEREBRUM_SELF_BASE_URL: http://cerebrum-api:3007
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,cerebrum:http://cerebrum-api:3007}
+    expose:
+      - '3007'
+    depends_on:
+      core-api:
+        condition: service_healthy
+    healthcheck:
+      test:
+        [
+          'CMD',
+          'node',
+          '-e',
+          "fetch('http://localhost:3007/health').then(r=>{if(!r.ok)process.exit(1)})",
         ]
       interval: 30s
       timeout: 5s
@@ -210,7 +248,7 @@ services:
       POPS_OVERLAYS: ${POPS_OVERLAYS:-}
       # Cross-pillar registry (ADR-026 Phase 3 PR 3). pops-api routes
       # outbound `pops:core/...` traffic to the core-api container.
-      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004}
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,cerebrum:http://cerebrum-api:3007}
     expose:
       - '3000'
     depends_on:
@@ -223,6 +261,8 @@ services:
       media-api:
         condition: service_healthy
       finance-api:
+        condition: service_healthy
+      cerebrum-api:
         condition: service_healthy
     healthcheck:
       test:
@@ -263,7 +303,7 @@ services:
       # PRD-100 — same module set as the api so worker jobs scope correctly.
       POPS_APPS: ${POPS_APPS:-}
       POPS_OVERLAYS: ${POPS_OVERLAYS:-}
-      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004}
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,cerebrum:http://cerebrum-api:3007}
     depends_on:
       pops-redis:
         condition: service_healthy
@@ -274,6 +314,8 @@ services:
       media-api:
         condition: service_healthy
       finance-api:
+        condition: service_healthy
+      cerebrum-api:
         condition: service_healthy
 
   # ── FOOD INGEST WORKER ───────────────────────────────────────────


### PR DESCRIPTION
## Summary

Phase 3 PR 2 of Track H. Spins up the dedicated `pops-cerebrum-api` container (PR 1 #2821) alongside the existing services, publishes its image to `ghcr.io/knoxio/pops-cerebrum-api`, and extends the default `POPS_PILLARS` registry so every host pillar surfaces cerebrum on its synthetic-entry list.

### What lands

- **`infra/docker-compose.dev.yml`** — new `cerebrum-api` service block (builds from `apps/pops-cerebrum-api/Dockerfile`, `PORT=3007`, `CEREBRUM_SQLITE_PATH=/data/sqlite/cerebrum.db`, `CEREBRUM_SELF_BASE_URL=http://cerebrum-api:3007`, extended `POPS_PILLARS` default, `depends_on: core-api: service_healthy`, `/health` probe every 30s). Adds `cerebrum-api: service_healthy` to `pops-api` + `pops-worker-food` `depends_on` so they wait for cerebrum-api at boot.
- **`infra/docker-compose.yml`** — same `cerebrum-api` block in production compose, pulling the GHCR image (`ghcr.io/knoxio/pops-cerebrum-api:${POPS_IMAGE_TAG:-main}`) instead of building. Watchtower label set so reconciliation picks up new pushes alongside the other pillar APIs.
- **`.github/workflows/publish-images.yml`** — new `docker/metadata-action` + `docker/build-push-action` steps for `pops-cerebrum-api`, mirroring the existing finance-api / media-api / inventory-api / core-api entries (same tag templates: `main`, `sha-<short>`, semver patterns).
- **`POPS_PILLARS` env defaults** — every entry across pops-api / pillar-api / pops-worker-food updated from `...,finance:http://finance-api:3004` to `...,finance:http://finance-api:3004,cerebrum:http://cerebrum-api:3007` so the synthetic `/pillars` endpoint reflects the new pillar immediately, without operators having to override the env.

### What's next

- **Phase 3 PR 3** — nginx proxy entry for cerebrum-api so the shell can reach it through the existing reverse proxy.
- **Phase 3 PR 4 / Phase 4** — verification runbook (stop/restart drill against cerebrum-api, lessons capture) and flip Track H row to ✅.

## Test plan

- [x] `docker compose -f infra/docker-compose.dev.yml config --quiet` — exit 0 (compose validation).
- [x] `docker compose -f infra/docker-compose.yml config --quiet` — exit 0.
- [x] `grep -c POPS_PILLARS infra/docker-compose.dev.yml` — same count of identical strings (no drift between entries).
- [x] `pnpm typecheck` — 45/45 packages green (unchanged; this PR only touches infra).