### PR TITLE
fix(storybook): declare @codemirror/* + @lezer/* deps pulled in from app-food source

### DIFF
--- a/apps/pops-storybook/package.json
+++ b/apps/pops-storybook/package.json
@@ -10,6 +10,13 @@
     "test": "echo \"(no tests in @pops/storybook)\""
   },
   "dependencies": {
+    "@codemirror/autocomplete": "^6.18.7",
+    "@codemirror/commands": "^6.10.3",
+    "@codemirror/language": "^6.12.3",
+    "@codemirror/state": "^6.6.0",
+    "@codemirror/view": "^6.43.1",
+    "@lezer/highlight": "^1.2.3",
+    "@lezer/lr": "^1.4.10",
     "@pops/app-finance": "workspace:*",
     "@pops/app-food": "workspace:*",
     "@pops/app-inventory": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -576,6 +576,27 @@ importers:
 
   apps/pops-storybook:
     dependencies:
+      '@codemirror/autocomplete':
+        specifier: ^6.18.7
+        version: 6.20.3
+      '@codemirror/commands':
+        specifier: ^6.10.3
+        version: 6.10.3
+      '@codemirror/language':
+        specifier: ^6.12.3
+        version: 6.12.3
+      '@codemirror/state':
+        specifier: ^6.6.0
+        version: 6.6.0
+      '@codemirror/view':
+        specifier: ^6.43.1
+        version: 6.43.1
+      '@lezer/highlight':
+        specifier: ^1.2.3
+        version: 1.2.3
+      '@lezer/lr':
+        specifier: ^1.4.10
+        version: 1.4.10
       '@pops/app-finance':
         specifier: workspace:*
         version: link:../../packages/app-finance


### PR DESCRIPTION
## Summary

Resolves #2848.

`apps/pops-storybook/.storybook/main.ts` aliases `@pops/app-food` to the package source via `viteFinal`. That source transitively imports `@codemirror/autocomplete`, `@codemirror/commands`, `@codemirror/language`, `@codemirror/state`, `@codemirror/view`, `@lezer/highlight`, and `@lezer/lr` (see `packages/app-food/src/components/dsl-editor/*`, `useDslEditorView.ts`, and `packages/app-food/src/dsl/*`). pnpm only symlinks declared dependencies into a package's `node_modules`, so when the Storybook bundle resolves these imports from app-food source, the resolver looks in `apps/pops-storybook/node_modules/@codemirror/*` — which did not exist — and the build fails.

Declares the codemirror + lezer deps directly on `@pops/storybook`, version-matched to `@pops/app-food`. Symlinks now exist under `apps/pops-storybook/node_modules/{@codemirror,@lezer}` and the resolver is happy.

## Test plan

- [x] `pnpm install` — clean, no warnings introduced.
- [x] `ls apps/pops-storybook/node_modules/@codemirror apps/pops-storybook/node_modules/@lezer` resolves all seven packages.
- [x] `pnpm --filter @pops/storybook typecheck` passes.
- [x] `turbo typecheck` (run via husky) passes across all 45 packages.
- [ ] Full `storybook build` end-to-end gating still blocked by #2847 (`@pops/ui/theme` resolver bug) — close-out of #2706 + Storybook CI gating tracked there.