### PR TITLE
fix(storybook): resolve @pops/ui/theme via dedicated alias (#2847)

### DIFF
--- a/apps/pops-storybook/.storybook/main.ts
+++ b/apps/pops-storybook/.storybook/main.ts
@@ -22,13 +22,33 @@ const config: StorybookConfig = {
     return mergeConfig(config, {
       plugins: [tailwindcss()],
       resolve: {
-        alias: {
-          '@pops/ui': path.resolve(__dirname, '../../../packages/ui/src'),
-          '@pops/app-media': path.resolve(__dirname, '../../../packages/app-media/src'),
-          '@pops/app-finance': path.resolve(__dirname, '../../../packages/app-finance/src'),
-          '@pops/app-food': path.resolve(__dirname, '../../../packages/app-food/src'),
-          '@pops/app-inventory': path.resolve(__dirname, '../../../packages/app-inventory/src'),
-        },
+        alias: [
+          {
+            find: '@pops/ui/theme/graph-colors',
+            replacement: path.resolve(__dirname, '../../../packages/ui/src/theme/graph-colors.ts'),
+          },
+          {
+            find: '@pops/ui/theme',
+            replacement: path.resolve(__dirname, '../../../packages/ui/src/theme/globals.css'),
+          },
+          { find: '@pops/ui', replacement: path.resolve(__dirname, '../../../packages/ui/src') },
+          {
+            find: '@pops/app-media',
+            replacement: path.resolve(__dirname, '../../../packages/app-media/src'),
+          },
+          {
+            find: '@pops/app-finance',
+            replacement: path.resolve(__dirname, '../../../packages/app-finance/src'),
+          },
+          {
+            find: '@pops/app-food',
+            replacement: path.resolve(__dirname, '../../../packages/app-food/src'),
+          },
+          {
+            find: '@pops/app-inventory',
+            replacement: path.resolve(__dirname, '../../../packages/app-inventory/src'),
+          },
+        ],
       },
     });
   },


### PR DESCRIPTION
Closes #2847.

## Summary

- The Storybook viteFinal alias mapped `@pops/ui` → `packages/ui/src`, which shadowed the `@pops/ui/theme` subpath export and resolved it to the theme **directory** instead of `globals.css`. Rolldown then failed with `Is a directory (os error 21)`.
- Switched the alias map from object form to array form and added two specific entries before the catch-all `@pops/ui`:
  - `@pops/ui/theme/graph-colors` → `packages/ui/src/theme/graph-colors.ts` (used by `packages/app-inventory/src/components/connection-graph/draw.ts`)
  - `@pops/ui/theme` → `packages/ui/src/theme/globals.css`
- Order matters because `@rollup/plugin-alias` does prefix matching with `/` boundary, so `@pops/ui/theme` would also match `@pops/ui/theme/graph-colors` if it came first.

The fix preserves the existing package contract (`@pops/ui` exports map is unchanged) and only touches the Storybook-local resolver.

## Test plan

- [x] `pnpm --filter @pops/storybook exec storybook build` — clean (was failing on `preview.tsx:1`)
- [x] `pnpm --filter @pops/storybook typecheck` — clean
- [x] `pnpm typecheck` (monorepo) — clean
- [ ] CI green

## Follow-up

- #2848 (codemirror autocomplete dep) did not re-surface in this build — the source alias correctly walks `packages/app-food/node_modules` for transitive deps. Will re-check on that ticket separately.
- CI gating of `storybook build` is still missing (mentioned in both #2847 and #2848); not addressed here.