### PR TITLE
feat(food): mount HeroImageUploader on PRD-119 recipe pages (PRD-124 follow-up)

### DIFF
--- a/docs/themes/07-food/prds/124-hero-image-upload/README.md
+++ b/docs/themes/07-food/prds/124-hero-image-upload/README.md
@@ -206,7 +206,7 @@ Inline per theme protocol.
 - [x] Replace and Remove buttons work.
 - [x] Progress indicator during upload.
 - [x] Mobile-friendly tap targets (44px min).
-- [ ] PRD-119's edit page mounts this component in a side panel. — _Deferred: PRD-119 is not yet implemented; the component is ready and `HeroImageUploader` is exported from `@pops/app-food` for PRD-119 to mount._
+- [x] PRD-119's edit page mounts this component. Mounted in `RecipeEditShell` between the auto-created banner and the DSL editor. Upload and remove callbacks invalidate `food.recipes.getForRendering` (keyed on slug + versionNo) and `food.recipes.list` so the edit shell sees the new `heroImagePath` immediately. The original wording said "side panel"; the implemented layout is an inline column section because PRD-119's recipe edit page is a stacked layout rather than a split pane.
 
 ### Remove
 

--- a/packages/app-food/src/pages/recipes/RecipeEditPage.tsx
+++ b/packages/app-food/src/pages/recipes/RecipeEditPage.tsx
@@ -94,7 +94,10 @@ export function RecipeEditShell({
 
   const recipe = renderingQuery.data.recipe;
   const refreshHero = (): void => {
-    void utils.food.recipes.getForRendering.invalidate({ slug });
+    void utils.food.recipes.getForRendering.invalidate({
+      slug,
+      versionNo: versionNo ?? undefined,
+    });
     void utils.food.recipes.list.invalidate();
   };
 

--- a/packages/app-food/src/pages/recipes/RecipeEditPage.tsx
+++ b/packages/app-food/src/pages/recipes/RecipeEditPage.tsx
@@ -7,6 +7,7 @@ import { trpc } from '@pops/api-client';
 import { Button } from '@pops/ui';
 
 import { DslEditor } from '../../components/DslEditor.js';
+import { HeroImageUploader } from '../../components/HeroImageUploader.js';
 import { AutoCreatedBanner } from './AutoCreatedBanner.js';
 import { buildEditorIssues } from './compile-result-issues.js';
 import { useRecipeEditMutations } from './useRecipeEditMutations.js';
@@ -64,6 +65,7 @@ export function RecipeEditShell({
   const [dsl, setDsl] = useState<string>('');
   const dslSeeded = useRef(false);
   const [latestCompile, setLatestCompile] = useState<CompileResult | null>(null);
+  const utils = trpc.useUtils();
 
   const renderingQuery = trpc.food.recipes.getForRendering.useQuery(
     { slug, versionNo: versionNo ?? undefined },
@@ -86,14 +88,26 @@ export function RecipeEditShell({
   const issues = buildEditorIssues(latestCompile, proposedRows);
   const canPromote = latestCompile !== null && latestCompile.ok === true && !actions.isSaving;
 
-  if (versionId === null || !dslSeeded.current) {
+  if (versionId === null || !dslSeeded.current || !renderingQuery.data) {
     return <Status text={t('recipes.edit.opening')} />;
   }
+
+  const recipe = renderingQuery.data.recipe;
+  const refreshHero = (): void => {
+    void utils.food.recipes.getForRendering.invalidate({ slug });
+    void utils.food.recipes.list.invalidate();
+  };
 
   return (
     <div className="space-y-4 p-6">
       <EditHeader slug={slug} canPromote={canPromote} actions={actions} />
       <AutoCreatedBanner slugs={proposedRows.map((r) => r.slug)} />
+      <HeroImageUploader
+        recipeId={recipe.id}
+        currentPath={recipe.heroImagePath}
+        onUploaded={refreshHero}
+        onRemoved={refreshHero}
+      />
       <DslEditor initialValue={dsl} onChange={setDsl} issues={issues} />
     </div>
   );

--- a/packages/app-food/src/pages/recipes/__tests__/RecipeEditPage.test.tsx
+++ b/packages/app-food/src/pages/recipes/__tests__/RecipeEditPage.test.tsx
@@ -1,0 +1,187 @@
+/**
+ * PRD-124 follow-up — verifies the `RecipeEditPage` recipe edit shell
+ * mounts the `HeroImageUploader` with the recipe's id + heroImagePath,
+ * and that the upload/remove callbacks invalidate the rendering query
+ * so the new path round-trips into the editor surface.
+ */
+import { act, render, screen } from '@testing-library/react';
+import { createInstance } from 'i18next';
+import { useMemo, type ReactElement } from 'react';
+import { I18nextProvider, initReactI18next } from 'react-i18next';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import enAUFood from '../../../../../../apps/pops-shell/src/i18n/locales/en-AU/food.json';
+
+const createDraftMutate = vi.fn();
+let createDraftOnSuccess: ((res: { versionId: number; versionNo: number }) => void) | undefined;
+
+const getForRenderingInvalidate = vi.fn();
+const listInvalidate = vi.fn();
+
+interface RenderingResponse {
+  recipe: { id: number; heroImagePath: string | null };
+  version: { bodyDsl: string };
+}
+
+let renderingData: RenderingResponse | undefined;
+
+vi.mock('@pops/api-client', () => ({
+  trpc: {
+    useUtils: () => ({
+      food: {
+        recipes: {
+          getForRendering: { invalidate: getForRenderingInvalidate },
+          list: { invalidate: listInvalidate },
+        },
+      },
+    }),
+    food: {
+      recipes: {
+        createNewDraft: {
+          useMutation: (opts: {
+            onSuccess?: (res: { versionId: number; versionNo: number }) => void;
+          }) => {
+            createDraftOnSuccess = opts.onSuccess;
+            return { mutate: createDraftMutate };
+          },
+        },
+        getForRendering: {
+          useQuery: () => ({ data: renderingData }),
+        },
+        listProposedSlugs: {
+          useQuery: () => ({ data: { items: [] } }),
+        },
+        saveDraft: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
+        promote: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
+        archiveVersion: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
+      },
+    },
+  },
+}));
+
+vi.mock('../../../components/DslEditor.js', () => ({
+  DslEditor: (props: { initialValue: string }) => (
+    <div data-testid="dsl-editor" data-initial={props.initialValue} />
+  ),
+}));
+
+let heroUploaderProps:
+  | {
+      recipeId: number;
+      currentPath: string | null;
+      onUploaded: (path: string) => void;
+      onRemoved: () => void;
+    }
+  | undefined;
+
+vi.mock('../../../components/HeroImageUploader.js', () => ({
+  HeroImageUploader: (props: {
+    recipeId: number;
+    currentPath: string | null;
+    onUploaded: (path: string) => void;
+    onRemoved: () => void;
+  }) => {
+    heroUploaderProps = props;
+    return (
+      <div
+        data-testid="hero-uploader-stub"
+        data-recipe-id={String(props.recipeId)}
+        data-current-path={props.currentPath ?? ''}
+      />
+    );
+  },
+}));
+
+vi.mock('react-router', async (orig) => {
+  const actual = await orig<typeof import('react-router')>();
+  return {
+    ...actual,
+    useParams: () => ({ slug: 'pancakes' }),
+  };
+});
+
+import { RecipeEditPage } from '../RecipeEditPage.js';
+
+function Wrapper({ children }: { children: ReactElement }): ReactElement {
+  const i18n = useMemo(() => {
+    const instance = createInstance();
+    void instance.use(initReactI18next).init({
+      lng: 'en-AU',
+      fallbackLng: 'en-AU',
+      ns: ['food'],
+      defaultNS: 'food',
+      interpolation: { escapeValue: false },
+      resources: { 'en-AU': { food: enAUFood } },
+    });
+    return instance;
+  }, []);
+  return (
+    <I18nextProvider i18n={i18n}>
+      <MemoryRouter>{children}</MemoryRouter>
+    </I18nextProvider>
+  );
+}
+
+beforeEach(() => {
+  createDraftMutate.mockReset();
+  getForRenderingInvalidate.mockReset();
+  listInvalidate.mockReset();
+  createDraftOnSuccess = undefined;
+  heroUploaderProps = undefined;
+  renderingData = {
+    recipe: { id: 42, heroImagePath: '42/hero.jpg' },
+    version: { bodyDsl: '@recipe(slug="pancakes")\n' },
+  };
+});
+
+describe('PRD-124 follow-up — RecipeEditPage hero uploader mount', () => {
+  it('mounts HeroImageUploader with recipe.id + heroImagePath once the draft opens', () => {
+    render(
+      <Wrapper>
+        <RecipeEditPage />
+      </Wrapper>
+    );
+    act(() => {
+      createDraftOnSuccess?.({ versionId: 100, versionNo: 3 });
+    });
+    const stub = screen.getByTestId('hero-uploader-stub');
+    expect(stub).toHaveAttribute('data-recipe-id', '42');
+    expect(stub).toHaveAttribute('data-current-path', '42/hero.jpg');
+  });
+
+  it('invalidates the rendering and list queries when upload and remove fire', () => {
+    render(
+      <Wrapper>
+        <RecipeEditPage />
+      </Wrapper>
+    );
+    act(() => {
+      createDraftOnSuccess?.({ versionId: 100, versionNo: 3 });
+    });
+    expect(heroUploaderProps).toBeDefined();
+    heroUploaderProps?.onUploaded('42/hero.png');
+    heroUploaderProps?.onRemoved();
+    expect(getForRenderingInvalidate).toHaveBeenCalledTimes(2);
+    expect(getForRenderingInvalidate).toHaveBeenCalledWith({ slug: 'pancakes' });
+    expect(listInvalidate).toHaveBeenCalledTimes(2);
+  });
+
+  it('passes a null currentPath when the recipe has no hero yet', () => {
+    renderingData = {
+      recipe: { id: 7, heroImagePath: null },
+      version: { bodyDsl: '@recipe(slug="x")\n' },
+    };
+    render(
+      <Wrapper>
+        <RecipeEditPage />
+      </Wrapper>
+    );
+    act(() => {
+      createDraftOnSuccess?.({ versionId: 1, versionNo: 1 });
+    });
+    const stub = screen.getByTestId('hero-uploader-stub');
+    expect(stub).toHaveAttribute('data-recipe-id', '7');
+    expect(stub).toHaveAttribute('data-current-path', '');
+  });
+});

--- a/packages/app-food/src/pages/recipes/__tests__/RecipeEditPage.test.tsx
+++ b/packages/app-food/src/pages/recipes/__tests__/RecipeEditPage.test.tsx
@@ -163,7 +163,7 @@ describe('PRD-124 follow-up — RecipeEditPage hero uploader mount', () => {
     heroUploaderProps?.onUploaded('42/hero.png');
     heroUploaderProps?.onRemoved();
     expect(getForRenderingInvalidate).toHaveBeenCalledTimes(2);
-    expect(getForRenderingInvalidate).toHaveBeenCalledWith({ slug: 'pancakes' });
+    expect(getForRenderingInvalidate).toHaveBeenCalledWith({ slug: 'pancakes', versionNo: 3 });
     expect(listInvalidate).toHaveBeenCalledTimes(2);
   });
 


### PR DESCRIPTION
## Summary

- Mounts `HeroImageUploader` on PRD-119's recipe edit page (`RecipeEditShell`), closing the open AC PRD-124 deferred because the edit page did not yet exist when 124 shipped.
- Wires upload + remove through `trpc.useUtils()` so `food.recipes.getForRendering` (keyed on slug + versionNo) and `food.recipes.list` invalidate — new hero paths round-trip into the edit surface and list cards refresh their thumbnails.
- Uses the existing `food.heroImage.upload` / `food.heroImage.remove` procedures shipped in PRD-124.

## Why this surface, why this shape

- PRD-124 (`apps/pops-api` + `@pops/app-food` hero pipeline) shipped under PR #2704 with two ACs intentionally left open in its body — Litestream exclusion (out-of-tree) and "PRD-119's recipe edit page mounts `HeroImageUploader`". PRD-119 (parts API/A/B/C/D/E) merged across #2741–#2750 without picking up that mount.
- The uploader requires `recipeId: number`, which only exists after the recipe row is created. `RecipeNewPage` redirects to `/edit` on save, so the only sensible mount point is the shared `RecipeEditShell` (which both `/edit` and `/drafts/:draftNo` reuse). One mount covers both routes.
- Placed between `AutoCreatedBanner` and `DslEditor` to match the existing visual hierarchy (header → status banner → media → editor). PRD-124's original AC said "side panel"; the implemented layout is inline because the edit page is a stacked column rather than a split pane — PRD-124's README has been updated to reflect this.

## Test plan

- [x] `mise typecheck` — clean
- [x] `mise lint` — no new errors
- [x] `mise test` — 614 app-food tests pass (3 new in `RecipeEditPage.test.tsx`, asserting full-key invalidation including `versionNo` after Copilot R1)
- [x] Pre-commit hook (typecheck) passes

The new RTL suite covers:
1. Mount with `recipe.id` + `heroImagePath` once the draft opens
2. `null` currentPath when the recipe has no hero yet
3. Invalidation of `getForRendering` (full key: slug + versionNo) + `list` on both `onUploaded` and `onRemoved`

## Tracker

- Closes the PRD-124 "PRD-119's edit page mounts this component" AC in `docs/themes/07-food/prds/124-hero-image-upload/README.md` (this PR ticks the box and documents the inline-vs-side-panel layout choice).