### PR TITLE
feat(finance-db): scaffold tag_vocabulary slice + re-export shim (Track N5 phase 1 PR 1)

### DIFF
--- a/packages/finance-db/src/__tests__/tag-vocabulary.test.ts
+++ b/packages/finance-db/src/__tests__/tag-vocabulary.test.ts
@@ -7,9 +7,11 @@
  * `migrations/0026_little_frank_castle.sql` because that file mixes the
  * `tag_vocabulary` CREATE with the `transaction_tag_rules` CREATE +
  * seed inserts — the test owns its own fixtures so it can exercise the
- * service contract in isolation. Drift between the test DDL and the
- * shipped migration is caught at integration level by
- * `open-finance-db.test.ts`, which applies the real package journal.
+ * service contract in isolation. `open-finance-db.test.ts` currently
+ * only asserts that `tag_vocabulary` exists after migrations run, so it
+ * does NOT catch DDL drift between this inlined schema and the shipped
+ * migration. A schema-level assertion (column types, defaults) is left
+ * as a follow-up.
  */
 import Database from 'better-sqlite3';
 import { eq } from 'drizzle-orm';

--- a/packages/finance-db/src/__tests__/tag-vocabulary.test.ts
+++ b/packages/finance-db/src/__tests__/tag-vocabulary.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Invariant tests for the tag-vocabulary service against an in-memory
+ * SQLite seeded with the canonical `tag_vocabulary` DDL. Pure DB +
+ * service layer — no tRPC, no Express, no auth middleware.
+ *
+ * The DDL is inlined rather than read from the package's own
+ * `migrations/0026_little_frank_castle.sql` because that file mixes the
+ * `tag_vocabulary` CREATE with the `transaction_tag_rules` CREATE +
+ * seed inserts — the test owns its own fixtures so it can exercise the
+ * service contract in isolation. Drift between the test DDL and the
+ * shipped migration is caught at integration level by
+ * `open-finance-db.test.ts`, which applies the real package journal.
+ */
+import Database from 'better-sqlite3';
+import { eq } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { tagVocabulary } from '../schema.js';
+import { listVocabularyTags, upsertVocabularyTag } from '../services/tag-vocabulary.js';
+
+import type { FinanceDb } from '../services/internal.js';
+
+const TAG_VOCABULARY_DDL = `
+CREATE TABLE tag_vocabulary (
+  tag text PRIMARY KEY NOT NULL,
+  source text DEFAULT 'seed' NOT NULL,
+  is_active integer DEFAULT 1 NOT NULL,
+  created_at text DEFAULT (datetime('now')) NOT NULL
+);
+CREATE INDEX idx_tag_vocabulary_active ON tag_vocabulary (is_active);
+`;
+
+interface TestHarness {
+  db: FinanceDb;
+  raw: Database.Database;
+}
+
+function freshDb(): TestHarness {
+  const raw = new Database(':memory:');
+  raw.pragma('foreign_keys = ON');
+  raw.exec(TAG_VOCABULARY_DDL);
+  return { db: drizzle(raw), raw };
+}
+
+describe('listVocabularyTags', () => {
+  let harness: TestHarness;
+  beforeEach(() => {
+    harness = freshDb();
+  });
+
+  it('returns an empty array when the vocabulary is empty', () => {
+    expect(listVocabularyTags(harness.db)).toEqual([]);
+  });
+
+  it('returns every active tag in the table', () => {
+    upsertVocabularyTag(harness.db, 'Groceries', 'seed');
+    upsertVocabularyTag(harness.db, 'Coffee', 'seed');
+    upsertVocabularyTag(harness.db, 'Rent', 'user');
+
+    const tags = listVocabularyTags(harness.db);
+    expect(tags).toHaveLength(3);
+    expect(new Set(tags)).toEqual(new Set(['Groceries', 'Coffee', 'Rent']));
+  });
+
+  it('honours is_active=false rows by hiding them', () => {
+    upsertVocabularyTag(harness.db, 'Active', 'seed');
+    upsertVocabularyTag(harness.db, 'Retired', 'seed');
+
+    harness.raw.prepare(`UPDATE tag_vocabulary SET is_active = 0 WHERE tag = ?`).run('Retired');
+
+    expect(listVocabularyTags(harness.db)).toEqual(['Active']);
+  });
+});
+
+describe('upsertVocabularyTag — insert path', () => {
+  let harness: TestHarness;
+  beforeEach(() => {
+    harness = freshDb();
+  });
+
+  it('creates a row with the supplied source and is_active=true', () => {
+    upsertVocabularyTag(harness.db, 'Subscriptions', 'user');
+
+    const rows = harness.db.select().from(tagVocabulary).all();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      tag: 'Subscriptions',
+      source: 'user',
+      isActive: true,
+    });
+  });
+
+  it('persists distinct rows for distinct tags', () => {
+    upsertVocabularyTag(harness.db, 'Subscriptions', 'user');
+    upsertVocabularyTag(harness.db, 'Donations', 'user');
+
+    expect(new Set(listVocabularyTags(harness.db))).toEqual(
+      new Set(['Subscriptions', 'Donations'])
+    );
+  });
+
+  it('records the supplied source on first insert', () => {
+    upsertVocabularyTag(harness.db, 'Seeded', 'seed');
+    upsertVocabularyTag(harness.db, 'UserAdded', 'user');
+
+    const seededRow = harness.db
+      .select()
+      .from(tagVocabulary)
+      .where(eq(tagVocabulary.tag, 'Seeded'))
+      .get();
+    const userRow = harness.db
+      .select()
+      .from(tagVocabulary)
+      .where(eq(tagVocabulary.tag, 'UserAdded'))
+      .get();
+    expect(seededRow?.source).toBe('seed');
+    expect(userRow?.source).toBe('user');
+  });
+});
+
+describe('upsertVocabularyTag — conflict path', () => {
+  let harness: TestHarness;
+  beforeEach(() => {
+    harness = freshDb();
+  });
+
+  it('is idempotent — repeated upsert of the same tag does not duplicate', () => {
+    upsertVocabularyTag(harness.db, 'Coffee', 'seed');
+    upsertVocabularyTag(harness.db, 'Coffee', 'seed');
+    upsertVocabularyTag(harness.db, 'Coffee', 'user');
+
+    const rows = harness.db.select().from(tagVocabulary).all();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.tag).toBe('Coffee');
+  });
+
+  it('flips is_active back to true on conflict', () => {
+    upsertVocabularyTag(harness.db, 'Coffee', 'seed');
+    harness.raw.prepare(`UPDATE tag_vocabulary SET is_active = 0 WHERE tag = ?`).run('Coffee');
+    expect(listVocabularyTags(harness.db)).toEqual([]);
+
+    upsertVocabularyTag(harness.db, 'Coffee', 'user');
+    expect(listVocabularyTags(harness.db)).toEqual(['Coffee']);
+  });
+
+  it('leaves source untouched on conflict — seed tag reactivated by a user keeps source=seed', () => {
+    upsertVocabularyTag(harness.db, 'Coffee', 'seed');
+    harness.raw.prepare(`UPDATE tag_vocabulary SET is_active = 0 WHERE tag = ?`).run('Coffee');
+    upsertVocabularyTag(harness.db, 'Coffee', 'user');
+
+    const row = harness.db
+      .select()
+      .from(tagVocabulary)
+      .where(eq(tagVocabulary.tag, 'Coffee'))
+      .get();
+    expect(row?.source).toBe('seed');
+    expect(row?.isActive).toBe(true);
+  });
+
+  it('preserves created_at on conflict', () => {
+    upsertVocabularyTag(harness.db, 'Coffee', 'seed');
+    const beforeRow = harness.db
+      .select()
+      .from(tagVocabulary)
+      .where(eq(tagVocabulary.tag, 'Coffee'))
+      .get();
+
+    upsertVocabularyTag(harness.db, 'Coffee', 'user');
+    const afterRow = harness.db
+      .select()
+      .from(tagVocabulary)
+      .where(eq(tagVocabulary.tag, 'Coffee'))
+      .get();
+
+    expect(afterRow?.createdAt).toBe(beforeRow?.createdAt);
+  });
+});

--- a/packages/finance-db/src/index.ts
+++ b/packages/finance-db/src/index.ts
@@ -29,3 +29,7 @@ export {
   type WishListListResult,
   type WishListQuery,
 } from './services/wishlist.js';
+
+export * as tagVocabularyService from './services/tag-vocabulary.js';
+
+export { type TagVocabularyRow, type TagVocabularySource } from './services/tag-vocabulary.js';

--- a/packages/finance-db/src/schema.ts
+++ b/packages/finance-db/src/schema.ts
@@ -10,4 +10,4 @@
  *
  * Mirrors the `@pops/core-db` schema re-export pattern.
  */
-export { wishList } from '@pops/db-types';
+export { tagVocabulary, wishList } from '@pops/db-types';

--- a/packages/finance-db/src/services/tag-vocabulary.ts
+++ b/packages/finance-db/src/services/tag-vocabulary.ts
@@ -1,20 +1,18 @@
 /**
  * Tag vocabulary persistence for the finance domain.
  *
- * The `tag_vocabulary` table is the canonical set of tags the user (or
- * the seed data) considers valid for tagging transactions. Reads list
- * the active tags; writes upsert a single tag and reactivate it if it
- * had been soft-deleted.
+ * The `tag_vocabulary` table holds the canonical set of tags that the user (or
+ * the seed data) considers valid for tagging transactions. `listVocabularyTags`
+ * returns the active tags; `upsertVocabularyTag` inserts a tag or reactivates
+ * one that had been soft-deleted.
  *
- * The in-tree service in `apps/pops-api/src/modules/core/tag-rules/vocabulary.ts`
- * still uses `getDrizzle()`; this package version takes a `FinanceDb`
- * handle as its first argument. The cutover (PR 3 of phase 1) flips
- * the router to call into here.
+ * The in-tree service at `apps/pops-api/src/modules/core/tag-rules/vocabulary.ts`
+ * still uses `getDrizzle()`; this package version takes a `FinanceDb` handle as
+ * its first argument. PR 3 of phase 1 flips the router to call into here.
  *
- * Mirrors the wish-list pattern: db-arg services, plain functions, no
- * HTTP or tRPC concerns. No typed errors are exported because neither
- * function has a not-found path — listing an empty vocabulary returns
- * `[]` and upsert is idempotent.
+ * Mirrors the wish-list pattern: db-arg services, plain functions, no HTTP or
+ * tRPC concerns. No typed errors are exported because neither function has a
+ * not-found path — an empty vocabulary returns `[]` and upsert is idempotent.
  */
 import { eq } from 'drizzle-orm';
 
@@ -31,10 +29,10 @@ export type TagVocabularySource = 'seed' | 'user';
 /**
  * Return the active vocabulary tags.
  *
- * Order matches the legacy in-tree implementation — no explicit ORDER BY,
- * so SQLite returns rows in storage order. The router treats the result
- * as a set so order is not observable to clients, but preserving the
- * legacy shape keeps the cutover (PR 3) a pure routing flip.
+ * No explicit ORDER BY — SQLite makes no ordering guarantee in that case,
+ * which matches the legacy in-tree implementation. The router treats the
+ * result as a set so order is not observable to clients, and preserving
+ * the unordered shape keeps the cutover (PR 3) a pure routing flip.
  */
 export function listVocabularyTags(db: FinanceDb): string[] {
   return db

--- a/packages/finance-db/src/services/tag-vocabulary.ts
+++ b/packages/finance-db/src/services/tag-vocabulary.ts
@@ -1,0 +1,64 @@
+/**
+ * Tag vocabulary persistence for the finance domain.
+ *
+ * The `tag_vocabulary` table is the canonical set of tags the user (or
+ * the seed data) considers valid for tagging transactions. Reads list
+ * the active tags; writes upsert a single tag and reactivate it if it
+ * had been soft-deleted.
+ *
+ * The in-tree service in `apps/pops-api/src/modules/core/tag-rules/vocabulary.ts`
+ * still uses `getDrizzle()`; this package version takes a `FinanceDb`
+ * handle as its first argument. The cutover (PR 3 of phase 1) flips
+ * the router to call into here.
+ *
+ * Mirrors the wish-list pattern: db-arg services, plain functions, no
+ * HTTP or tRPC concerns. No typed errors are exported because neither
+ * function has a not-found path — listing an empty vocabulary returns
+ * `[]` and upsert is idempotent.
+ */
+import { eq } from 'drizzle-orm';
+
+import { tagVocabulary } from '../schema.js';
+
+import type { FinanceDb } from './internal.js';
+
+/** Raw drizzle row shape for callers that need the full record. */
+export type TagVocabularyRow = typeof tagVocabulary.$inferSelect;
+
+/** Source field discriminant — matches the schema enum. */
+export type TagVocabularySource = 'seed' | 'user';
+
+/**
+ * Return the active vocabulary tags.
+ *
+ * Order matches the legacy in-tree implementation — no explicit ORDER BY,
+ * so SQLite returns rows in storage order. The router treats the result
+ * as a set so order is not observable to clients, but preserving the
+ * legacy shape keeps the cutover (PR 3) a pure routing flip.
+ */
+export function listVocabularyTags(db: FinanceDb): string[] {
+  return db
+    .select({ tag: tagVocabulary.tag })
+    .from(tagVocabulary)
+    .where(eq(tagVocabulary.isActive, true))
+    .all()
+    .map((row) => row.tag);
+}
+
+/**
+ * Upsert a tag into the vocabulary, marking it active.
+ *
+ * On insert the row gets `(tag, source, isActive=true)` with the
+ * default `created_at`. On conflict (same `tag` PK) the existing row's
+ * `isActive` is flipped back to true — the `source` is left untouched
+ * so a seed tag re-added by a user keeps its `seed` provenance.
+ */
+export function upsertVocabularyTag(db: FinanceDb, tag: string, source: TagVocabularySource): void {
+  db.insert(tagVocabulary)
+    .values({ tag, source, isActive: true })
+    .onConflictDoUpdate({
+      target: tagVocabulary.tag,
+      set: { isActive: true },
+    })
+    .run();
+}


### PR DESCRIPTION
## Summary

- First PR of the 4-PR sequence to migrate the finance `tag_vocabulary` slice from `apps/pops-api/src/modules/core/tag-rules/vocabulary.ts` into `@pops/finance-db` (Track N5 of the deferred-backlog tracker in `.claude/pillar-migration-roadmap.md`).
- Mirrors the wish-list pilot pattern from PR #2766 — strictly additive, no behaviour change, in-tree callers untouched.
- Adds `tagVocabularyService` (`listVocabularyTags`, `upsertVocabularyTag`) as db-arg functions on `FinanceDb`, plus the `TagVocabularyRow` / `TagVocabularySource` types and the `tagVocabulary` schema re-export.

## Scope

This is **PR 1 of 4** for the N5 slice, per the [CI-never-breaks 4×4 pattern](../../../.claude/pillar-migration-roadmap.md#ci-never-breaks-pattern).

Deferred to subsequent N5 PRs:
- **PR 2** — Migration journal split + drift-guard CI for the `tag_vocabulary` portion of `0026_little_frank_castle`. The byte-identical copy already exists at `packages/finance-db/migrations/0026_little_frank_castle.sql` (it was copied across with the wish-list pilot), but no drift guard wires it yet for this slice.
- **PR 3** — Router cutover. Flip `tagRulesRouter.listVocabulary` and the `applyTagRuleChangeSet` upsert loop in `apps/pops-api/src/modules/core/tag-rules/router.ts` to call into `@pops/finance-db`'s `tagVocabularyService`. Wire `mapDomainErrors` on procedures that surface typed errors (none expected for this slice — listing has no not-found path, upsert is idempotent).
- **PR 4** — Delete the in-tree `vocabulary.ts` shim.

## Files

- `packages/finance-db/src/services/tag-vocabulary.ts` — db-arg `listVocabularyTags` + `upsertVocabularyTag`, type exports.
- `packages/finance-db/src/schema.ts` — add `tagVocabulary` to the re-export.
- `packages/finance-db/src/index.ts` — barrel exports `tagVocabularyService` namespace + `TagVocabularyRow` / `TagVocabularySource` types.
- `packages/finance-db/src/__tests__/tag-vocabulary.test.ts` — 10 in-memory unit tests against inlined `tag_vocabulary` DDL covering empty list, active filter, insert path (source preserved, distinct rows), conflict path (idempotence, is_active flip, source preservation, created_at preservation).

## Notes

- The in-tree `apps/pops-api/src/modules/core/tag-rules/vocabulary.ts` is left untouched, so all existing callers keep working through `getDrizzle()`. Router cutover comes in PR 3.
- No typed domain errors exported — neither service function has a not-found path. If PR 3 surfaces one at the router boundary it'll be added then, per the wish-list pattern.
- CI parity already in place from the wish-list pilot: `packages/finance-db/**` is wired into `_pkg-check.yml`, `api-quality.yml`, `api-test.yml`, `fe-quality.yml`, `fe-test-e2e.yml`; all three Dockerfiles (`pops-api`, `pops-shell`, `pops-mcp`) COPY + BUILD `@pops/finance-db`.

## Test plan

- [x] `pnpm --filter @pops/finance-db typecheck`
- [x] `pnpm --filter @pops/finance-db test` (28 / 28 passing — 14 wishlist + 4 open-finance-db + 10 tag-vocabulary)
- [x] `pnpm --filter @pops/finance-db build`
- [x] `pnpm typecheck` (full repo — 41 / 41 tasks)
- [x] `pnpm --filter @pops/api test` (4772 / 4772 passing)
- [x] `pnpm build` (18 / 18 tasks)
- [x] `pnpm lint` clean