### PR TITLE
test(food): PRD-146 — cook-overrides server integration tests (#2787)

### DIFF
--- a/apps/pops-api/src/modules/food/__tests__/cook-overrides.test.ts
+++ b/apps/pops-api/src/modules/food/__tests__/cook-overrides.test.ts
@@ -4,13 +4,11 @@
  *
  * Mirrors the spec in [PRD-146 §"Integration with PRD-144's cook
  * mutation"](docs/themes/07-food/prds/146-fifo-consumption-ui/README.md):
- * one test per row in the contract table — `batch-override`, `external`,
- * `partial`, optional-line silent skip, and the depleted-batch shortfall
- * roll-back.
- *
- * Reject-shape assertions (zero-qty bypass, wrong-variant guard) live in
- * `cook-router.test.ts` alongside the broader `MarkCookedError` matrix —
- * keeping this file focused on the happy-path persistence contract.
+ * the happy-path persistence contract (one test per row of the override
+ * matrix: `batch-override`, `external`, `partial`, optional-line silent
+ * skip, depleted-batch shortfall) plus the reject guards that stop
+ * overrides from bypassing FIFO (zero-qty, wrong variant, qty mismatch
+ * vs the scaled line need).
  */
 import { type Database } from 'better-sqlite3';
 import { eq } from 'drizzle-orm';
@@ -239,5 +237,99 @@ describe('food.cook.markCooked — PRD-146 consumption overrides', () => {
     expect(depleted?.qtyRemaining).toBe(50);
     const consumptions = db.select().from(batchConsumptions).all();
     expect(consumptions).toEqual([]);
+  });
+
+  it('rejects a zero-qty batch-override so it cannot mask the line from FIFO', async () => {
+    const seed = seedCompiledRecipe('override-zero-qty');
+    seedBatch(seed.variantId, 1000);
+    const overrideBatchId = seedBatch(seed.variantId, 500);
+    const result = await caller.food.cook.markCooked({
+      recipeVersionId: seed.versionId,
+      scaleFactor: 1,
+      yield: { qty: 800, unit: 'g', location: 'fridge' },
+      consumptionOverrides: [
+        {
+          lineIndex: 1,
+          kind: 'batch-override',
+          batchId: overrideBatchId,
+          consumeQty: 0,
+          unit: 'g',
+        },
+      ],
+    });
+    expect(result).toMatchObject({ ok: false, reason: 'ShortfallUnresolved' });
+  });
+
+  it('rejects a batch-override pointing at a batch with a different variant', async () => {
+    const seed = seedCompiledRecipe('override-wrong-variant');
+    seedBatch(seed.variantId, 1000);
+    // Seed a batch on the yield-side variant (unrelated to the recipe line).
+    const wrongBatchId = seedBatch(seed.yieldVariantId, 500);
+    const result = await caller.food.cook.markCooked({
+      recipeVersionId: seed.versionId,
+      scaleFactor: 1,
+      yield: { qty: 800, unit: 'g', location: 'fridge' },
+      consumptionOverrides: [
+        {
+          lineIndex: 1,
+          kind: 'batch-override',
+          batchId: wrongBatchId,
+          consumeQty: 200,
+          unit: 'g',
+        },
+      ],
+    });
+    expect(result).toMatchObject({ ok: false, reason: 'ShortfallUnresolved' });
+  });
+
+  it('rejects an override whose qty does not cover the full scaled line need', async () => {
+    // The line needs 200g × 1.5 = 300g. A `consumeQty: 100` override
+    // would otherwise mark the line "covered" and silently skip FIFO
+    // for the remaining 200g — that is the bug the qty-coverage guard
+    // exists to stop.
+    const seed = seedCompiledRecipe('override-qty-mismatch');
+    seedBatch(seed.variantId, 1000);
+    const overrideBatchId = seedBatch(seed.variantId, 1000);
+    const result = await caller.food.cook.markCooked({
+      recipeVersionId: seed.versionId,
+      scaleFactor: 1.5,
+      yield: { qty: 800, unit: 'g', location: 'fridge' },
+      consumptionOverrides: [
+        {
+          lineIndex: 1,
+          kind: 'batch-override',
+          batchId: overrideBatchId,
+          consumeQty: 100,
+          unit: 'g',
+        },
+      ],
+    });
+    expect(result).toMatchObject({ ok: false, reason: 'ShortfallUnresolved' });
+
+    // Roll-back invariant: no partial draw should have landed.
+    const db = getDrizzle();
+    const override = db.select().from(batches).where(eq(batches.id, overrideBatchId)).all()[0];
+    expect(override?.qtyRemaining).toBe(1000);
+    const consumptions = db.select().from(batchConsumptions).all();
+    expect(consumptions).toEqual([]);
+  });
+
+  it('rejects an external override whose unit does not match the line canonical unit', async () => {
+    const seed = seedCompiledRecipe('override-unit-mismatch');
+    seedBatch(seed.variantId, 1000);
+    const result = await caller.food.cook.markCooked({
+      recipeVersionId: seed.versionId,
+      scaleFactor: 1,
+      yield: { qty: 800, unit: 'g', location: 'fridge' },
+      consumptionOverrides: [
+        {
+          lineIndex: 1,
+          kind: 'external',
+          externalQty: 200,
+          externalUnit: 'ml',
+        },
+      ],
+    });
+    expect(result).toMatchObject({ ok: false, reason: 'ShortfallUnresolved' });
   });
 });

--- a/apps/pops-api/src/modules/food/__tests__/cook-overrides.test.ts
+++ b/apps/pops-api/src/modules/food/__tests__/cook-overrides.test.ts
@@ -1,0 +1,243 @@
+/**
+ * PRD-146 deferred slice — consumption-override behaviour inside
+ * `food.cook.markCooked`.
+ *
+ * Mirrors the spec in [PRD-146 §"Integration with PRD-144's cook
+ * mutation"](docs/themes/07-food/prds/146-fifo-consumption-ui/README.md):
+ * one test per row in the contract table — `batch-override`, `external`,
+ * `partial`, optional-line silent skip, and the depleted-batch shortfall
+ * roll-back.
+ *
+ * Reject-shape assertions (zero-qty bypass, wrong-variant guard) live in
+ * `cook-router.test.ts` alongside the broader `MarkCookedError` matrix —
+ * keeping this file focused on the happy-path persistence contract.
+ */
+import { type Database } from 'better-sqlite3';
+import { eq } from 'drizzle-orm';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { batchConsumptions, batches, planSlots, recipeRuns } from '@pops/app-food-db';
+
+import { closeDb, getDrizzle, setDb } from '../../../db.js';
+import { createCaller } from '../../../shared/test-utils.js';
+import {
+  createFoodTestDb,
+  seedBatch,
+  seedCompiledRecipe,
+  seedExtraIngredientLine,
+} from './cook-test-helpers.js';
+
+describe('food.cook.markCooked — PRD-146 consumption overrides', () => {
+  let sqlite: Database;
+  let caller: ReturnType<typeof createCaller>;
+
+  beforeEach(() => {
+    sqlite = createFoodTestDb();
+    setDb(sqlite);
+    caller = createCaller();
+    getDrizzle()
+      .insert(planSlots)
+      .values({ slug: 'dinner', name: 'Dinner', displayOrder: 30, isDefault: 1 })
+      .run();
+  });
+
+  afterEach(() => {
+    closeDb();
+    sqlite.close();
+  });
+
+  it("kind='batch-override' writes a batch_consumptions row against the chosen batch", async () => {
+    const seed = seedCompiledRecipe('override-batch');
+    const fifoBatchId = seedBatch(seed.variantId, 1000);
+    const chosenBatchId = seedBatch(seed.variantId, 500);
+    const result = await caller.food.cook.markCooked({
+      recipeVersionId: seed.versionId,
+      scaleFactor: 1,
+      yield: { qty: 800, unit: 'g', location: 'fridge' },
+      consumptionOverrides: [
+        {
+          lineIndex: 1,
+          kind: 'batch-override',
+          batchId: chosenBatchId,
+          consumeQty: 200,
+          unit: 'g',
+        },
+      ],
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const db = getDrizzle();
+    const consumptions = db
+      .select()
+      .from(batchConsumptions)
+      .where(eq(batchConsumptions.recipeRunId, result.recipeRunId))
+      .all();
+    expect(consumptions).toHaveLength(1);
+    expect(consumptions[0]).toMatchObject({
+      batchId: chosenBatchId,
+      qtyConsumed: 200,
+      unit: 'g',
+    });
+
+    const chosen = db.select().from(batches).where(eq(batches.id, chosenBatchId)).all()[0];
+    const fifo = db.select().from(batches).where(eq(batches.id, fifoBatchId)).all()[0];
+    expect(chosen?.qtyRemaining).toBe(300);
+    expect(fifo?.qtyRemaining).toBe(1000);
+  });
+
+  it("kind='external' writes no batch_consumptions row and appends an audit line to recipe_runs.notes", async () => {
+    const seed = seedCompiledRecipe('override-external');
+    // The required line is fully covered by the external override; no
+    // FIFO batch is needed (and seeding one would let FIFO pick it up).
+    const result = await caller.food.cook.markCooked({
+      recipeVersionId: seed.versionId,
+      scaleFactor: 1,
+      yield: { qty: 800, unit: 'g', location: 'fridge' },
+      notes: 'tasted great',
+      consumptionOverrides: [
+        {
+          lineIndex: 1,
+          kind: 'external',
+          externalQty: 200,
+          externalUnit: 'g',
+        },
+      ],
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const db = getDrizzle();
+    const consumptions = db
+      .select()
+      .from(batchConsumptions)
+      .where(eq(batchConsumptions.recipeRunId, result.recipeRunId))
+      .all();
+    expect(consumptions).toEqual([]);
+
+    const run = db.select().from(recipeRuns).where(eq(recipeRuns.id, result.recipeRunId)).all()[0];
+    expect(run?.notes).toBe('tasted great\ncook-override:external line=1 qty=200 unit=g');
+  });
+
+  it("kind='partial' writes one batch_consumptions row and appends an audit line", async () => {
+    const seed = seedCompiledRecipe('override-partial');
+    const chosenBatchId = seedBatch(seed.variantId, 150);
+    const result = await caller.food.cook.markCooked({
+      recipeVersionId: seed.versionId,
+      scaleFactor: 1,
+      yield: { qty: 800, unit: 'g', location: 'fridge' },
+      consumptionOverrides: [
+        {
+          lineIndex: 1,
+          kind: 'partial',
+          batchId: chosenBatchId,
+          consumeQty: 150,
+          externalQty: 50,
+          unit: 'g',
+        },
+      ],
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const db = getDrizzle();
+    const consumptions = db
+      .select()
+      .from(batchConsumptions)
+      .where(eq(batchConsumptions.recipeRunId, result.recipeRunId))
+      .all();
+    expect(consumptions).toHaveLength(1);
+    expect(consumptions[0]).toMatchObject({
+      batchId: chosenBatchId,
+      qtyConsumed: 150,
+      unit: 'g',
+    });
+
+    const chosen = db.select().from(batches).where(eq(batches.id, chosenBatchId)).all()[0];
+    expect(chosen?.qtyRemaining).toBe(0);
+
+    const run = db.select().from(recipeRuns).where(eq(recipeRuns.id, result.recipeRunId)).all()[0];
+    expect(run?.notes).toBe('cook-override:external line=1 qty=50 unit=g');
+  });
+
+  it('silently skips overrides that target an optional line (PRD-108 contract)', async () => {
+    const seed = seedCompiledRecipe('override-optional');
+    // Required line 1 — its FIFO need is covered by the tomato batch.
+    seedBatch(seed.variantId, 1000);
+    // Optional line 2 on its own variant. The user fills out an override
+    // for it; the cook server should drop it silently per the spec.
+    const optionalVariantId = seedExtraIngredientLine({
+      slug: 'override-optional',
+      versionId: seed.versionId,
+      position: 2,
+      qtyG: 100,
+      optional: true,
+    });
+    const optionalBatchId = seedBatch(optionalVariantId, 100);
+
+    const result = await caller.food.cook.markCooked({
+      recipeVersionId: seed.versionId,
+      scaleFactor: 1,
+      yield: { qty: 800, unit: 'g', location: 'fridge' },
+      consumptionOverrides: [
+        {
+          lineIndex: 2,
+          kind: 'batch-override',
+          batchId: optionalBatchId,
+          consumeQty: 100,
+          unit: 'g',
+        },
+      ],
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const db = getDrizzle();
+    const consumptions = db
+      .select()
+      .from(batchConsumptions)
+      .where(eq(batchConsumptions.recipeRunId, result.recipeRunId))
+      .all();
+    // The only batch_consumptions row should be FIFO's draw against
+    // line 1 — the optional override must not have produced one.
+    const optionalDraws = consumptions.filter((c) => c.batchId === optionalBatchId);
+    expect(optionalDraws).toEqual([]);
+
+    const optional = db.select().from(batches).where(eq(batches.id, optionalBatchId)).all()[0];
+    expect(optional?.qtyRemaining).toBe(100);
+
+    const run = db.select().from(recipeRuns).where(eq(recipeRuns.id, result.recipeRunId)).all()[0];
+    expect(run?.notes ?? '').not.toContain('cook-override');
+  });
+
+  it('returns ShortfallUnresolved when the chosen batch was depleted between modal read and cook write', async () => {
+    const seed = seedCompiledRecipe('override-depleted');
+    // The modal showed the user a batch with 500g; by the time the cook
+    // mutation runs, a concurrent consume has drawn it down to 50g. The
+    // override request for 200g can no longer be satisfied.
+    const depletedBatchId = seedBatch(seed.variantId, 50);
+
+    const result = await caller.food.cook.markCooked({
+      recipeVersionId: seed.versionId,
+      scaleFactor: 1,
+      yield: { qty: 800, unit: 'g', location: 'fridge' },
+      consumptionOverrides: [
+        {
+          lineIndex: 1,
+          kind: 'batch-override',
+          batchId: depletedBatchId,
+          consumeQty: 200,
+          unit: 'g',
+        },
+      ],
+    });
+    expect(result).toMatchObject({ ok: false, reason: 'ShortfallUnresolved' });
+
+    // Roll-back invariant: the half-applied draw must not survive.
+    const db = getDrizzle();
+    const depleted = db.select().from(batches).where(eq(batches.id, depletedBatchId)).all()[0];
+    expect(depleted?.qtyRemaining).toBe(50);
+    const consumptions = db.select().from(batchConsumptions).all();
+    expect(consumptions).toEqual([]);
+  });
+});

--- a/apps/pops-api/src/modules/food/__tests__/cook-router.test.ts
+++ b/apps/pops-api/src/modules/food/__tests__/cook-router.test.ts
@@ -2,180 +2,27 @@
  * PRD-144 — integration tests for `food.cook.*`.
  *
  * Covers the cook event happy path, every `MarkCookedError` branch, the
- * shortfall-rollback contract, plan-entry linkage + race, and override
- * processing (PRD-146's deferred slice).
+ * shortfall-rollback contract, and plan-entry linkage + race.
+ *
+ * Consumption-override behaviour (PRD-146's deferred slice) is exercised
+ * separately in `cook-overrides.test.ts`.
  */
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
-
-import BetterSqlite3, { type Database } from 'better-sqlite3';
+import { type Database } from 'better-sqlite3';
 import { eq } from 'drizzle-orm';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import {
   batchConsumptions,
   batches,
-  ingredientsService,
-  ingredientVariants,
   planEntries,
   planSlots,
-  recipeLines,
   recipeRuns,
-  recipesService,
   recipeVersions,
-  variantsService,
 } from '@pops/app-food-db';
 
 import { closeDb, getDrizzle, setDb } from '../../../db.js';
 import { createCaller } from '../../../shared/test-utils.js';
-
-const MIGRATION_FILES = [
-  '0058_high_sentinel.sql',
-  '0059_useful_hiroim.sql',
-  '0060_familiar_leo.sql',
-  '0061_shocking_skreet.sql',
-  '0062_chemical_donald_blake.sql',
-  '0063_bumpy_wolverine.sql',
-  '0064_peaceful_magma.sql',
-  '0065_prd_116_recipe_compile.sql',
-  '0066_prd_123_conversions.sql',
-  '0067_prd_125_ingest_error_columns.sql',
-  '0068_prd_136_inbox_review.sql',
-  '0069_prd_145_batches_deleted_at.sql',
-];
-
-function applyMigration(db: Database, filename: string): void {
-  const text = readFileSync(join(__dirname, '../../../db/drizzle-migrations', filename), 'utf8');
-  for (const stmt of text.split('--> statement-breakpoint')) {
-    const trimmed = stmt.trim();
-    if (trimmed.length > 0) db.exec(trimmed);
-  }
-}
-
-function createFoodTestDb(): Database {
-  const db = new BetterSqlite3(':memory:');
-  db.pragma('journal_mode = WAL');
-  db.pragma('foreign_keys = ON');
-  for (const name of MIGRATION_FILES) applyMigration(db, name);
-  return db;
-}
-
-interface SeededRecipe {
-  recipeId: number;
-  versionId: number;
-  ingredientId: number;
-  variantId: number;
-  yieldVariantId: number;
-}
-
-function seedCompiledRecipe(slug: string, opts: { yields?: boolean } = {}): SeededRecipe {
-  const db = getDrizzle();
-  const yields = opts.yields ?? true;
-  const ing = ingredientsService.createIngredient(db, {
-    name: 'Tomato',
-    slug: `${slug}-tomato`,
-    defaultUnit: 'g',
-  });
-  const variant = variantsService.createVariant(db, {
-    ingredientId: ing.id,
-    name: 'Diced',
-    slug: `${slug}-diced`,
-    defaultUnit: 'g',
-  });
-  db.update(ingredientVariants)
-    .set({ defaultShelfLifeDaysFridge: 5, defaultShelfLifeDaysFreezer: 90 })
-    .where(eq(ingredientVariants.id, variant.id))
-    .run();
-
-  let yieldVariantId = variant.id;
-  if (yields) {
-    const yieldIng = ingredientsService.createIngredient(db, {
-      name: 'Sauce',
-      slug: `${slug}-sauce`,
-      defaultUnit: 'g',
-    });
-    const yieldVar = variantsService.createVariant(db, {
-      ingredientId: yieldIng.id,
-      name: 'Default',
-      slug: `${slug}-sauce-default`,
-      defaultUnit: 'g',
-    });
-    db.update(ingredientVariants)
-      .set({ defaultShelfLifeDaysFridge: 3, defaultShelfLifeDaysFreezer: 60 })
-      .where(eq(ingredientVariants.id, yieldVar.id))
-      .run();
-    yieldVariantId = yieldVar.id;
-  }
-
-  const { recipe, version } = recipesService.createRecipe(db, {
-    slug,
-    firstVersion: { title: `Test ${slug}`, bodyDsl: `@recipe(slug="${slug}", title="Test")` },
-  });
-  void recipe;
-  db.update(recipeVersions)
-    .set({
-      compileStatus: 'compiled',
-      compiledAt: new Date().toISOString(),
-      servings: 4,
-      yieldIngredientId: yields ? yieldVariantId : null,
-      yieldVariantId: yields ? yieldVariantId : null,
-      yieldQty: yields ? 800 : null,
-      yieldUnit: yields ? 'g' : null,
-    })
-    .where(eq(recipeVersions.id, version.id))
-    .run();
-  // Insert one canonical-g line so consumeForRun has work to do.
-  db.insert(recipeLines)
-    .values({
-      recipeVersionId: version.id,
-      position: 1,
-      ingredientId: ing.id,
-      variantId: variant.id,
-      prepStateId: null,
-      isRecipeRef: 0,
-      recipeRefId: null,
-      originalText: 'tomato',
-      originalQty: 200,
-      originalUnit: 'g',
-      qtyG: 200,
-      qtyMl: null,
-      qtyCount: null,
-      canonicalUnit: 'g',
-      optional: 0,
-      notes: null,
-    })
-    .run();
-  return {
-    recipeId: version.recipeId,
-    versionId: version.id,
-    ingredientId: ing.id,
-    variantId: variant.id,
-    yieldVariantId,
-  };
-}
-
-function seedBatch(variantId: number, qty: number): number {
-  const db = getDrizzle();
-  const rows = db
-    .insert(batches)
-    .values({
-      variantId,
-      prepStateId: null,
-      qtyRemaining: qty,
-      unit: 'g',
-      sourceType: 'purchase',
-      sourceId: null,
-      location: 'fridge',
-      producedAt: '2026-06-01T00:00:00.000Z',
-      expiresAt: null,
-      notes: null,
-    })
-    .returning()
-    .all();
-  const row = rows[0];
-  if (row === undefined) throw new Error('seedBatch failed');
-  return row.id;
-}
+import { createFoodTestDb, seedBatch, seedCompiledRecipe } from './cook-test-helpers.js';
 
 describe('food.cook router — PRD-144', () => {
   let sqlite: Database;
@@ -481,104 +328,6 @@ describe('food.cook router — PRD-144', () => {
         yield: { qty: 800, unit: 'g', location: 'fridge' },
       });
       expect(result).toEqual({ ok: false, reason: 'PlanEntryNotFound' });
-    });
-  });
-
-  describe('consumption overrides (PRD-146 deferred slice)', () => {
-    it('applies batch-override and skips FIFO for the same line', async () => {
-      const seed = seedCompiledRecipe('cook-override');
-      const fifoBatchId = seedBatch(seed.variantId, 1000);
-      const overrideBatchId = seedBatch(seed.variantId, 500);
-      const result = await caller.food.cook.markCooked({
-        recipeVersionId: seed.versionId,
-        scaleFactor: 1,
-        yield: { qty: 800, unit: 'g', location: 'fridge' },
-        consumptionOverrides: [
-          {
-            lineIndex: 1,
-            kind: 'batch-override',
-            batchId: overrideBatchId,
-            consumeQty: 200,
-            unit: 'g',
-          },
-        ],
-      });
-      expect(result.ok).toBe(true);
-      const db = getDrizzle();
-      const fifo = db.select().from(batches).where(eq(batches.id, fifoBatchId)).all()[0];
-      const overridden = db.select().from(batches).where(eq(batches.id, overrideBatchId)).all()[0];
-      expect(fifo?.qtyRemaining).toBe(1000); // untouched
-      expect(overridden?.qtyRemaining).toBe(300); // 500 - 200
-    });
-
-    it('records external overrides in recipe_runs.notes', async () => {
-      const seed = seedCompiledRecipe('cook-external');
-      const result = await caller.food.cook.markCooked({
-        recipeVersionId: seed.versionId,
-        scaleFactor: 1,
-        yield: { qty: 800, unit: 'g', location: 'fridge' },
-        consumptionOverrides: [
-          {
-            lineIndex: 1,
-            kind: 'external',
-            externalQty: 200,
-            externalUnit: 'g',
-          },
-        ],
-      });
-      expect(result.ok).toBe(true);
-      if (result.ok) {
-        const db = getDrizzle();
-        const run = db
-          .select()
-          .from(recipeRuns)
-          .where(eq(recipeRuns.id, result.recipeRunId))
-          .all()[0];
-        expect(run?.notes).toContain('cook-override:external');
-      }
-    });
-
-    it('rejects a zero-qty batch-override so it cannot bypass FIFO', async () => {
-      const seed = seedCompiledRecipe('cook-zero-qty');
-      seedBatch(seed.variantId, 1000);
-      const overrideBatchId = seedBatch(seed.variantId, 500);
-      const result = await caller.food.cook.markCooked({
-        recipeVersionId: seed.versionId,
-        scaleFactor: 1,
-        yield: { qty: 800, unit: 'g', location: 'fridge' },
-        consumptionOverrides: [
-          {
-            lineIndex: 1,
-            kind: 'batch-override',
-            batchId: overrideBatchId,
-            consumeQty: 0,
-            unit: 'g',
-          },
-        ],
-      });
-      expect(result).toMatchObject({ ok: false, reason: 'ShortfallUnresolved' });
-    });
-
-    it('rejects a batch-override pointing at a different variant', async () => {
-      const seed = seedCompiledRecipe('cook-wrong-variant');
-      seedBatch(seed.variantId, 1000);
-      // Seed a batch on the yield variant (unrelated to the recipe line).
-      const wrongBatchId = seedBatch(seed.yieldVariantId, 500);
-      const result = await caller.food.cook.markCooked({
-        recipeVersionId: seed.versionId,
-        scaleFactor: 1,
-        yield: { qty: 800, unit: 'g', location: 'fridge' },
-        consumptionOverrides: [
-          {
-            lineIndex: 1,
-            kind: 'batch-override',
-            batchId: wrongBatchId,
-            consumeQty: 200,
-            unit: 'g',
-          },
-        ],
-      });
-      expect(result).toMatchObject({ ok: false, reason: 'ShortfallUnresolved' });
     });
   });
 

--- a/apps/pops-api/src/modules/food/__tests__/cook-test-db.ts
+++ b/apps/pops-api/src/modules/food/__tests__/cook-test-db.ts
@@ -1,0 +1,40 @@
+/**
+ * In-memory food-pillar database fixture for the cook test suite.
+ * Split from `cook-test-helpers.ts` so the helper file stays under the
+ * 200-line cap.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import BetterSqlite3, { type Database } from 'better-sqlite3';
+
+const MIGRATION_FILES = [
+  '0058_high_sentinel.sql',
+  '0059_useful_hiroim.sql',
+  '0060_familiar_leo.sql',
+  '0061_shocking_skreet.sql',
+  '0062_chemical_donald_blake.sql',
+  '0063_bumpy_wolverine.sql',
+  '0064_peaceful_magma.sql',
+  '0065_prd_116_recipe_compile.sql',
+  '0066_prd_123_conversions.sql',
+  '0067_prd_125_ingest_error_columns.sql',
+  '0068_prd_136_inbox_review.sql',
+  '0069_prd_145_batches_deleted_at.sql',
+];
+
+function applyMigration(db: Database, filename: string): void {
+  const text = readFileSync(join(__dirname, '../../../db/drizzle-migrations', filename), 'utf8');
+  for (const stmt of text.split('--> statement-breakpoint')) {
+    const trimmed = stmt.trim();
+    if (trimmed.length > 0) db.exec(trimmed);
+  }
+}
+
+export function createFoodTestDb(): Database {
+  const db = new BetterSqlite3(':memory:');
+  db.pragma('journal_mode = WAL');
+  db.pragma('foreign_keys = ON');
+  for (const name of MIGRATION_FILES) applyMigration(db, name);
+  return db;
+}

--- a/apps/pops-api/src/modules/food/__tests__/cook-test-helpers.ts
+++ b/apps/pops-api/src/modules/food/__tests__/cook-test-helpers.ts
@@ -26,6 +26,7 @@ export interface SeededRecipe {
   versionId: number;
   ingredientId: number;
   variantId: number;
+  yieldIngredientId: number;
   yieldVariantId: number;
 }
 
@@ -49,7 +50,7 @@ function seedTomatoVariant(slug: string): { ingredientId: number; variantId: num
   return { ingredientId: ing.id, variantId: variant.id };
 }
 
-function seedYieldVariant(slug: string): number {
+function seedYieldVariant(slug: string): { ingredientId: number; variantId: number } {
   const db = getDrizzle();
   const yieldIng = ingredientsService.createIngredient(db, {
     name: 'Sauce',
@@ -66,19 +67,24 @@ function seedYieldVariant(slug: string): number {
     .set({ defaultShelfLifeDaysFridge: 3, defaultShelfLifeDaysFreezer: 60 })
     .where(eq(ingredientVariants.id, yieldVar.id))
     .run();
-  return yieldVar.id;
+  return { ingredientId: yieldIng.id, variantId: yieldVar.id };
 }
 
-function finaliseRecipeVersion(versionId: number, yieldVariantId: number | null): void {
-  const db = getDrizzle();
-  const yields = yieldVariantId !== null;
-  db.update(recipeVersions)
+interface YieldShape {
+  ingredientId: number;
+  variantId: number;
+}
+
+function finaliseRecipeVersion(versionId: number, yieldShape: YieldShape | null): void {
+  const yields = yieldShape !== null;
+  getDrizzle()
+    .update(recipeVersions)
     .set({
       compileStatus: 'compiled',
       compiledAt: new Date().toISOString(),
       servings: 4,
-      yieldIngredientId: yields ? yieldVariantId : null,
-      yieldVariantId: yields ? yieldVariantId : null,
+      yieldIngredientId: yields ? yieldShape.ingredientId : null,
+      yieldVariantId: yields ? yieldShape.variantId : null,
       yieldQty: yields ? 800 : null,
       yieldUnit: yields ? 'g' : null,
     })
@@ -90,12 +96,12 @@ export function seedCompiledRecipe(slug: string, opts: { yields?: boolean } = {}
   const db = getDrizzle();
   const yields = opts.yields ?? true;
   const tomato = seedTomatoVariant(slug);
-  const yieldVariantId = yields ? seedYieldVariant(slug) : tomato.variantId;
+  const yieldShape = yields ? seedYieldVariant(slug) : tomato;
   const { version } = recipesService.createRecipe(db, {
     slug,
     firstVersion: { title: `Test ${slug}`, bodyDsl: `@recipe(slug="${slug}", title="Test")` },
   });
-  finaliseRecipeVersion(version.id, yields ? yieldVariantId : null);
+  finaliseRecipeVersion(version.id, yields ? yieldShape : null);
   seedRecipeLine({
     versionId: version.id,
     position: 1,
@@ -108,17 +114,18 @@ export function seedCompiledRecipe(slug: string, opts: { yields?: boolean } = {}
     versionId: version.id,
     ingredientId: tomato.ingredientId,
     variantId: tomato.variantId,
-    yieldVariantId,
+    yieldIngredientId: yieldShape.ingredientId,
+    yieldVariantId: yieldShape.variantId,
   };
 }
 
 export interface ExtraLineArgs {
   versionId: number;
   position: number;
+  ingredientId: number;
   variantId: number;
   qtyG: number;
   optional?: boolean;
-  ingredientId?: number;
 }
 
 export function seedRecipeLine(args: ExtraLineArgs): void {
@@ -127,7 +134,7 @@ export function seedRecipeLine(args: ExtraLineArgs): void {
     .values({
       recipeVersionId: args.versionId,
       position: args.position,
-      ingredientId: args.ingredientId ?? args.variantId,
+      ingredientId: args.ingredientId,
       variantId: args.variantId,
       prepStateId: null,
       isRecipeRef: 0,

--- a/apps/pops-api/src/modules/food/__tests__/cook-test-helpers.ts
+++ b/apps/pops-api/src/modules/food/__tests__/cook-test-helpers.ts
@@ -1,0 +1,200 @@
+/**
+ * Shared cook-test fixtures used by `cook-router.test.ts` (PRD-144) and
+ * `cook-overrides.test.ts` (PRD-146 deferred slice).
+ *
+ * `createFoodTestDb` lives in `cook-test-db.ts` to keep this file under
+ * the 200-line cap.
+ */
+import { eq } from 'drizzle-orm';
+
+import {
+  batches,
+  ingredientsService,
+  ingredientVariants,
+  recipeLines,
+  recipesService,
+  recipeVersions,
+  variantsService,
+} from '@pops/app-food-db';
+
+import { getDrizzle } from '../../../db.js';
+
+export { createFoodTestDb } from './cook-test-db.js';
+
+export interface SeededRecipe {
+  recipeId: number;
+  versionId: number;
+  ingredientId: number;
+  variantId: number;
+  yieldVariantId: number;
+}
+
+function seedTomatoVariant(slug: string): { ingredientId: number; variantId: number } {
+  const db = getDrizzle();
+  const ing = ingredientsService.createIngredient(db, {
+    name: 'Tomato',
+    slug: `${slug}-tomato`,
+    defaultUnit: 'g',
+  });
+  const variant = variantsService.createVariant(db, {
+    ingredientId: ing.id,
+    name: 'Diced',
+    slug: `${slug}-diced`,
+    defaultUnit: 'g',
+  });
+  db.update(ingredientVariants)
+    .set({ defaultShelfLifeDaysFridge: 5, defaultShelfLifeDaysFreezer: 90 })
+    .where(eq(ingredientVariants.id, variant.id))
+    .run();
+  return { ingredientId: ing.id, variantId: variant.id };
+}
+
+function seedYieldVariant(slug: string): number {
+  const db = getDrizzle();
+  const yieldIng = ingredientsService.createIngredient(db, {
+    name: 'Sauce',
+    slug: `${slug}-sauce`,
+    defaultUnit: 'g',
+  });
+  const yieldVar = variantsService.createVariant(db, {
+    ingredientId: yieldIng.id,
+    name: 'Default',
+    slug: `${slug}-sauce-default`,
+    defaultUnit: 'g',
+  });
+  db.update(ingredientVariants)
+    .set({ defaultShelfLifeDaysFridge: 3, defaultShelfLifeDaysFreezer: 60 })
+    .where(eq(ingredientVariants.id, yieldVar.id))
+    .run();
+  return yieldVar.id;
+}
+
+function finaliseRecipeVersion(versionId: number, yieldVariantId: number | null): void {
+  const db = getDrizzle();
+  const yields = yieldVariantId !== null;
+  db.update(recipeVersions)
+    .set({
+      compileStatus: 'compiled',
+      compiledAt: new Date().toISOString(),
+      servings: 4,
+      yieldIngredientId: yields ? yieldVariantId : null,
+      yieldVariantId: yields ? yieldVariantId : null,
+      yieldQty: yields ? 800 : null,
+      yieldUnit: yields ? 'g' : null,
+    })
+    .where(eq(recipeVersions.id, versionId))
+    .run();
+}
+
+export function seedCompiledRecipe(slug: string, opts: { yields?: boolean } = {}): SeededRecipe {
+  const db = getDrizzle();
+  const yields = opts.yields ?? true;
+  const tomato = seedTomatoVariant(slug);
+  const yieldVariantId = yields ? seedYieldVariant(slug) : tomato.variantId;
+  const { version } = recipesService.createRecipe(db, {
+    slug,
+    firstVersion: { title: `Test ${slug}`, bodyDsl: `@recipe(slug="${slug}", title="Test")` },
+  });
+  finaliseRecipeVersion(version.id, yields ? yieldVariantId : null);
+  seedRecipeLine({
+    versionId: version.id,
+    position: 1,
+    variantId: tomato.variantId,
+    ingredientId: tomato.ingredientId,
+    qtyG: 200,
+  });
+  return {
+    recipeId: version.recipeId,
+    versionId: version.id,
+    ingredientId: tomato.ingredientId,
+    variantId: tomato.variantId,
+    yieldVariantId,
+  };
+}
+
+export interface ExtraLineArgs {
+  versionId: number;
+  position: number;
+  variantId: number;
+  qtyG: number;
+  optional?: boolean;
+  ingredientId?: number;
+}
+
+export function seedRecipeLine(args: ExtraLineArgs): void {
+  getDrizzle()
+    .insert(recipeLines)
+    .values({
+      recipeVersionId: args.versionId,
+      position: args.position,
+      ingredientId: args.ingredientId ?? args.variantId,
+      variantId: args.variantId,
+      prepStateId: null,
+      isRecipeRef: 0,
+      recipeRefId: null,
+      originalText: `line-${args.position}`,
+      originalQty: args.qtyG,
+      originalUnit: 'g',
+      qtyG: args.qtyG,
+      qtyMl: null,
+      qtyCount: null,
+      canonicalUnit: 'g',
+      optional: args.optional === true ? 1 : 0,
+      notes: null,
+    })
+    .run();
+}
+
+export function seedBatch(variantId: number, qty: number): number {
+  const rows = getDrizzle()
+    .insert(batches)
+    .values({
+      variantId,
+      prepStateId: null,
+      qtyRemaining: qty,
+      unit: 'g',
+      sourceType: 'purchase',
+      sourceId: null,
+      location: 'fridge',
+      producedAt: '2026-06-01T00:00:00.000Z',
+      expiresAt: null,
+      notes: null,
+    })
+    .returning()
+    .all();
+  const row = rows[0];
+  if (row === undefined) throw new Error('seedBatch failed');
+  return row.id;
+}
+
+export interface ExtraIngredientLineArgs {
+  slug: string;
+  versionId: number;
+  position: number;
+  qtyG: number;
+  optional?: boolean;
+}
+
+export function seedExtraIngredientLine(args: ExtraIngredientLineArgs): number {
+  const db = getDrizzle();
+  const ing = ingredientsService.createIngredient(db, {
+    name: `Extra ${args.slug}`,
+    slug: `${args.slug}-extra-${args.position}`,
+    defaultUnit: 'g',
+  });
+  const variant = variantsService.createVariant(db, {
+    ingredientId: ing.id,
+    name: 'Default',
+    slug: `${args.slug}-extra-${args.position}-default`,
+    defaultUnit: 'g',
+  });
+  seedRecipeLine({
+    versionId: args.versionId,
+    position: args.position,
+    ingredientId: ing.id,
+    variantId: variant.id,
+    qtyG: args.qtyG,
+    optional: args.optional,
+  });
+  return variant.id;
+}

--- a/apps/pops-api/src/modules/food/cook/mark-cooked-overrides.ts
+++ b/apps/pops-api/src/modules/food/cook/mark-cooked-overrides.ts
@@ -54,6 +54,13 @@ export function applyConsumptionOverrides(
     // guard a batch-override on an optional line would write a stray
     // `batch_consumptions` row that no longer maps to a tracked need.
     if (line.optional) continue;
+    // Refuse to mark a line "covered" unless the override accounts for
+    // the full scaled need (Copilot R2). Without this gate a client can
+    // send `consumeQty: 1` on a 200g line, get added to `coveredLineIndices`,
+    // and silently bypass FIFO for the remaining 199g.
+    if (!overrideCoversLine(o, line, args.scaleFactor)) {
+      return { ok: false, reason: 'ShortfallUnresolved' };
+    }
     const outcome = processOverride(tx, args.runId, o, line);
     if (!outcome.ok) return { ok: false, reason: outcome.reason };
     covered.add(o.lineIndex);
@@ -118,11 +125,18 @@ function processBatchDraw(
 
 const EMPTY_SET: ReadonlySet<number> = new Set<number>();
 
+// Float-comparison tolerance for override qty validation. SQLite stores
+// qty columns as REAL so a 1e-6 epsilon keeps us off the rounding edge
+// without admitting a meaningful shortfall.
+const QTY_EPSILON = 1e-6;
+
 interface LineDescriptor {
   position: number;
   variantId: number | null;
   prepStateId: number | null;
   optional: boolean;
+  needQty: number;
+  canonicalUnit: 'g' | 'ml' | 'count';
 }
 
 function buildLineIndex(tx: FoodDb, versionId: number): Map<number, LineDescriptor> {
@@ -132,20 +146,55 @@ function buildLineIndex(tx: FoodDb, versionId: number): Map<number, LineDescript
       variantId: recipeLines.variantId,
       prepStateId: recipeLines.prepStateId,
       optional: recipeLines.optional,
+      qtyG: recipeLines.qtyG,
+      qtyMl: recipeLines.qtyMl,
+      qtyCount: recipeLines.qtyCount,
+      canonicalUnit: recipeLines.canonicalUnit,
     })
     .from(recipeLines)
     .where(eq(recipeLines.recipeVersionId, versionId))
     .all();
   const map = new Map<number, LineDescriptor>();
   for (const r of rows) {
+    const need = canonicalQty(r);
     map.set(r.position, {
       position: r.position,
       variantId: r.variantId ?? null,
       prepStateId: r.prepStateId ?? null,
       optional: r.optional === 1,
+      needQty: need,
+      canonicalUnit: r.canonicalUnit,
     });
   }
   return map;
+}
+
+function canonicalQty(row: {
+  qtyG: number | null;
+  qtyMl: number | null;
+  qtyCount: number | null;
+  canonicalUnit: 'g' | 'ml' | 'count';
+}): number {
+  if (row.canonicalUnit === 'g') return row.qtyG ?? 0;
+  if (row.canonicalUnit === 'ml') return row.qtyMl ?? 0;
+  return row.qtyCount ?? 0;
+}
+
+function overrideCoversLine(
+  override: ConsumptionOverride,
+  line: LineDescriptor,
+  scaleFactor: number
+): boolean {
+  const required = line.needQty * scaleFactor;
+  if (required <= 0) return true; // nothing to cover — treat as covered.
+  if (override.kind === 'external') {
+    if (override.externalUnit !== line.canonicalUnit) return false;
+    return Math.abs(override.externalQty - required) <= QTY_EPSILON;
+  }
+  if (override.unit !== line.canonicalUnit) return false;
+  const supplied =
+    override.kind === 'partial' ? override.consumeQty + override.externalQty : override.consumeQty;
+  return Math.abs(supplied - required) <= QTY_EPSILON;
 }
 
 interface DrawArgs {

--- a/apps/pops-api/src/modules/food/cook/mark-cooked-overrides.ts
+++ b/apps/pops-api/src/modules/food/cook/mark-cooked-overrides.ts
@@ -48,37 +48,72 @@ export function applyConsumptionOverrides(
   for (const o of args.overrides) {
     const line = lineIndex.get(o.lineIndex);
     if (line === undefined) continue; // line position not in this version — silently skip
-    if (o.kind === 'batch-override' || o.kind === 'partial') {
-      // Reject a zero-qty batch draw outright (Copilot R1): without this
-      // gate, a client could send `consumeQty: 0` to mark a line as
-      // covered and skip FIFO consumption entirely.
-      if (o.consumeQty <= 0) return { ok: false, reason: 'ShortfallUnresolved' };
-      const draw = drawFromBatch({
-        tx,
-        runId: args.runId,
-        batchId: o.batchId,
-        qty: o.consumeQty,
-        unit: o.unit,
-        expectedVariantId: line.variantId,
-        expectedPrepStateId: line.prepStateId,
-      });
-      if (!draw.ok) return { ok: false, reason: 'ShortfallUnresolved' };
-    }
-    if (o.kind === 'external' && o.externalQty <= 0) {
-      // External overrides must report a positive qty too, else they're
-      // a no-op that hides the line from FIFO.
-      return { ok: false, reason: 'ShortfallUnresolved' };
-    }
+    // PRD-146 §"Integration with PRD-144's cook mutation": optional
+    // lines never reach FIFO (see `computeRemainingNeeds` filter) so any
+    // override the modal sent for one is silently dropped. Without this
+    // guard a batch-override on an optional line would write a stray
+    // `batch_consumptions` row that no longer maps to a tracked need.
+    if (line.optional) continue;
+    const outcome = processOverride(tx, args.runId, o, line);
+    if (!outcome.ok) return { ok: false, reason: outcome.reason };
     covered.add(o.lineIndex);
-    if (o.kind === 'external') {
-      auditLines.push(formatExternalNote(o.lineIndex, o.externalQty, o.externalUnit));
-    }
-    if (o.kind === 'partial') {
-      auditLines.push(formatExternalNote(o.lineIndex, o.externalQty, o.unit));
-    }
+    if (outcome.auditLine !== null) auditLines.push(outcome.auditLine);
   }
 
   return { ok: true, coveredLineIndices: covered, auditLines };
+}
+
+type OverrideOutcome =
+  | { ok: true; auditLine: string | null }
+  | { ok: false; reason: MarkCookedError };
+
+function processOverride(
+  tx: FoodDb,
+  runId: number,
+  override: ConsumptionOverride,
+  line: LineDescriptor
+): OverrideOutcome {
+  if (override.kind === 'external') return processExternal(override);
+  return processBatchDraw(tx, runId, override, line);
+}
+
+function processExternal(
+  override: Extract<ConsumptionOverride, { kind: 'external' }>
+): OverrideOutcome {
+  // External overrides must report a positive qty too, else they're a
+  // no-op that hides the line from FIFO.
+  if (override.externalQty <= 0) return { ok: false, reason: 'ShortfallUnresolved' };
+  return {
+    ok: true,
+    auditLine: formatExternalNote(override.lineIndex, override.externalQty, override.externalUnit),
+  };
+}
+
+function processBatchDraw(
+  tx: FoodDb,
+  runId: number,
+  override: Extract<ConsumptionOverride, { kind: 'batch-override' | 'partial' }>,
+  line: LineDescriptor
+): OverrideOutcome {
+  // Reject a zero-qty batch draw outright (Copilot R1): without this
+  // gate, a client could send `consumeQty: 0` to mark a line as covered
+  // and skip FIFO consumption entirely.
+  if (override.consumeQty <= 0) return { ok: false, reason: 'ShortfallUnresolved' };
+  const draw = drawFromBatch({
+    tx,
+    runId,
+    batchId: override.batchId,
+    qty: override.consumeQty,
+    unit: override.unit,
+    expectedVariantId: line.variantId,
+    expectedPrepStateId: line.prepStateId,
+  });
+  if (!draw.ok) return { ok: false, reason: 'ShortfallUnresolved' };
+  if (override.kind === 'batch-override') return { ok: true, auditLine: null };
+  return {
+    ok: true,
+    auditLine: formatExternalNote(override.lineIndex, override.externalQty, override.unit),
+  };
 }
 
 const EMPTY_SET: ReadonlySet<number> = new Set<number>();
@@ -87,6 +122,7 @@ interface LineDescriptor {
   position: number;
   variantId: number | null;
   prepStateId: number | null;
+  optional: boolean;
 }
 
 function buildLineIndex(tx: FoodDb, versionId: number): Map<number, LineDescriptor> {
@@ -95,6 +131,7 @@ function buildLineIndex(tx: FoodDb, versionId: number): Map<number, LineDescript
       position: recipeLines.position,
       variantId: recipeLines.variantId,
       prepStateId: recipeLines.prepStateId,
+      optional: recipeLines.optional,
     })
     .from(recipeLines)
     .where(eq(recipeLines.recipeVersionId, versionId))
@@ -105,6 +142,7 @@ function buildLineIndex(tx: FoodDb, versionId: number): Map<number, LineDescript
       position: r.position,
       variantId: r.variantId ?? null,
       prepStateId: r.prepStateId ?? null,
+      optional: r.optional === 1,
     });
   }
   return map;


### PR DESCRIPTION
## Summary

Closes #2787.

- Adds the dedicated `cook-overrides.test.ts` suite called out in the drift-check ticket: one assertion per row of the PRD-146 contract table
  - `kind='batch-override'` → `batch_consumptions` row written + batch decremented + FIFO batch untouched
  - `kind='external'` → no `batch_consumptions` row + audit line appended to `recipe_runs.notes`
  - `kind='partial'` → one `batch_consumptions` row + audit line appended
  - optional-line override → silently dropped (no row, no note, no decrement)
  - depleted-batch shortfall → `ShortfallUnresolved` + transaction rolled back
- Tightens `mark-cooked-overrides.ts` to honour the spec's *"skip optional lines silently (PRD-108 contract)"* clause — overrides targeting an optional line no longer write stray `batch_consumptions` rows.
- Splits the migration-boot + recipe/batch fixtures out of `cook-router.test.ts` into `cook-test-helpers.ts` (+ `cook-test-db.ts`) so both test files use the same shape. Removes the partial override coverage from `cook-router.test.ts` now that it lives in the dedicated file.

## Test plan

- [x] `pnpm exec vitest run src/modules/food/__tests__/cook-overrides.test.ts src/modules/food/__tests__/cook-router.test.ts` — 23 passed
- [x] `pnpm test` (full pops-api suite) — 4752 passed
- [x] `pnpm typecheck` (turbo, all 28 packages)
- [x] `pnpm lint` — clean
- [x] `pnpm format:check` — clean