### PR TITLE
fix(storybook): enumerate all frontend app-* packages (#2706)

### DIFF
--- a/.github/workflows/storybook-quality.yml
+++ b/.github/workflows/storybook-quality.yml
@@ -1,0 +1,39 @@
+name: Storybook Quality
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "apps/pops-storybook/**"
+      - "packages/app-*/package.json"
+      - ".github/workflows/storybook-quality.yml"
+      - ".github/workflows/_pkg-check.yml"
+  pull_request:
+
+jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - 'apps/pops-storybook/**'
+              - 'packages/app-*/package.json'
+              - '.github/workflows/storybook-quality.yml'
+              - '.github/workflows/_pkg-check.yml'
+
+  quality:
+    needs: [changes]
+    if: always()
+    uses: ./.github/workflows/_pkg-check.yml
+    with:
+      package-path: apps/pops-storybook
+      needs-db-build: false
+      skip: ${{ github.event_name == 'pull_request' && needs.changes.outputs.relevant != 'true' }}

--- a/apps/pops-storybook/.storybook/main.ts
+++ b/apps/pops-storybook/.storybook/main.ts
@@ -33,8 +33,12 @@ const config: StorybookConfig = {
           },
           { find: '@pops/ui', replacement: path.resolve(__dirname, '../../../packages/ui/src') },
           {
-            find: '@pops/app-media',
-            replacement: path.resolve(__dirname, '../../../packages/app-media/src'),
+            find: '@pops/app-ai',
+            replacement: path.resolve(__dirname, '../../../packages/app-ai/src'),
+          },
+          {
+            find: '@pops/app-cerebrum',
+            replacement: path.resolve(__dirname, '../../../packages/app-cerebrum/src'),
           },
           {
             find: '@pops/app-finance',
@@ -47,6 +51,14 @@ const config: StorybookConfig = {
           {
             find: '@pops/app-inventory',
             replacement: path.resolve(__dirname, '../../../packages/app-inventory/src'),
+          },
+          {
+            find: '@pops/app-lists',
+            replacement: path.resolve(__dirname, '../../../packages/app-lists/src'),
+          },
+          {
+            find: '@pops/app-media',
+            replacement: path.resolve(__dirname, '../../../packages/app-media/src'),
           },
         ],
       },

--- a/apps/pops-storybook/package.json
+++ b/apps/pops-storybook/package.json
@@ -7,7 +7,7 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "typecheck": "tsc --noEmit",
-    "test": "echo \"(no tests in @pops/storybook)\""
+    "test": "node scripts/check-app-package-coverage.mjs"
   },
   "dependencies": {
     "@codemirror/autocomplete": "^6.18.7",
@@ -17,9 +17,12 @@
     "@codemirror/view": "^6.43.1",
     "@lezer/highlight": "^1.2.3",
     "@lezer/lr": "^1.4.10",
+    "@pops/app-ai": "workspace:*",
+    "@pops/app-cerebrum": "workspace:*",
     "@pops/app-finance": "workspace:*",
     "@pops/app-food": "workspace:*",
     "@pops/app-inventory": "workspace:*",
+    "@pops/app-lists": "workspace:*",
     "@pops/app-media": "workspace:*",
     "@pops/ui": "workspace:*",
     "react": "^19.2.7",

--- a/apps/pops-storybook/scripts/check-app-package-coverage.mjs
+++ b/apps/pops-storybook/scripts/check-app-package-coverage.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+/**
+ * Asserts that every frontend `@pops/app-*` workspace package is enumerated
+ * both as a dependency of `apps/pops-storybook` and as a Vite alias in
+ * `.storybook/main.ts`.
+ *
+ * A package is considered a frontend surface (and therefore eligible for
+ * Storybook) if it has `src/routes.tsx`. Server-only siblings such as
+ * `@pops/app-food-db` / `@pops/app-lists-db` are excluded by that filter.
+ *
+ * Fails (exit 1) on any missing dep or alias so future drift surfaces in CI
+ * instead of waiting for someone to file a story and find the dep missing
+ * (issue #2706).
+ */
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '../../..');
+const PACKAGES_DIR = resolve(REPO_ROOT, 'packages');
+const STORYBOOK_PKG = resolve(__dirname, '../package.json');
+const STORYBOOK_MAIN = resolve(__dirname, '../.storybook/main.ts');
+
+function listFrontendAppPackages() {
+  return readdirSync(PACKAGES_DIR)
+    .filter((name) => name.startsWith('app-'))
+    .filter((name) => {
+      const pkgDir = resolve(PACKAGES_DIR, name);
+      try {
+        statSync(resolve(pkgDir, 'src/routes.tsx'));
+        return true;
+      } catch {
+        return false;
+      }
+    })
+    .map((name) => `@pops/${name}`)
+    .toSorted();
+}
+
+function readDeps() {
+  const pkg = JSON.parse(readFileSync(STORYBOOK_PKG, 'utf8'));
+  return Object.keys(pkg.dependencies ?? {});
+}
+
+function readAliases() {
+  const source = readFileSync(STORYBOOK_MAIN, 'utf8');
+  const matches = source.matchAll(/find:\s*'(@pops\/app-[a-z0-9-]+)'/g);
+  return [...matches].map((m) => m[1]);
+}
+
+const expected = listFrontendAppPackages();
+const deps = new Set(readDeps());
+const aliases = new Set(readAliases());
+
+const missingDeps = expected.filter((name) => !deps.has(name));
+const missingAliases = expected.filter((name) => !aliases.has(name));
+
+if (missingDeps.length === 0 && missingAliases.length === 0) {
+  process.stdout.write(
+    `pops-storybook covers all ${expected.length} frontend @pops/app-* packages.\n`
+  );
+  process.exit(0);
+}
+
+if (missingDeps.length > 0) {
+  console.error('Missing dependencies in apps/pops-storybook/package.json:');
+  for (const name of missingDeps) console.error(`  - ${name}`);
+}
+if (missingAliases.length > 0) {
+  console.error('Missing Vite aliases in apps/pops-storybook/.storybook/main.ts:');
+  for (const name of missingAliases) console.error(`  - ${name}`);
+}
+console.error('\nAdd the package above to both places so its stories load in Storybook.');
+process.exit(1);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -597,6 +597,12 @@ importers:
       '@lezer/lr':
         specifier: ^1.4.10
         version: 1.4.10
+      '@pops/app-ai':
+        specifier: workspace:*
+        version: link:../../packages/app-ai
+      '@pops/app-cerebrum':
+        specifier: workspace:*
+        version: link:../../packages/app-cerebrum
       '@pops/app-finance':
         specifier: workspace:*
         version: link:../../packages/app-finance
@@ -606,6 +612,9 @@ importers:
       '@pops/app-inventory':
         specifier: workspace:*
         version: link:../../packages/app-inventory
+      '@pops/app-lists':
+        specifier: workspace:*
+        version: link:../../packages/app-lists
       '@pops/app-media':
         specifier: workspace:*
         version: link:../../packages/app-media


### PR DESCRIPTION
## Summary

- Add `@pops/app-ai`, `@pops/app-cerebrum`, `@pops/app-lists` to `apps/pops-storybook` deps and Vite aliases. The stories glob already covered every `packages/*/src/**/*.stories.*`; the actual gap was the missing dep declarations.
- Add `scripts/check-app-package-coverage.mjs` (wired to `pnpm test`) that discovers frontend app packages by presence of `src/routes.tsx` and asserts each is enumerated in both `package.json` deps and `.storybook/main.ts` aliases. Server-only `*-db` siblings are excluded.
- Add `storybook-quality.yml` so the guard runs in CI on every PR that touches `apps/pops-storybook/**` or any `packages/app-*/package.json`.

Closes #2706.

## Test plan

- [x] `pnpm install` updates lockfile with the three new workspace links
- [x] `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm lint:boundaries` all clean
- [x] `cd apps/pops-storybook && pnpm test` exits 0 with `covers all 7 frontend @pops/app-* packages`
- [ ] CI runs `storybook-quality.yml` and surfaces the guard