### PR TITLE
feat(finance-db): scaffold budgets slice (Track N1 phase 1 PR 1)

### DIFF
--- a/packages/finance-db/src/__tests__/budgets.test.ts
+++ b/packages/finance-db/src/__tests__/budgets.test.ts
@@ -306,6 +306,76 @@ describe('updateBudget', () => {
   it('throws BudgetNotFoundError for an unknown id', () => {
     expect(() => updateBudget(db, 'missing', { category: 'x' })).toThrow(BudgetNotFoundError);
   });
+
+  it('throws BudgetConflictError when an update would collide with an existing budget', () => {
+    createBudget(db, { category: 'Food', period: 'Monthly', amount: 100 });
+    const second = createBudget(db, { category: 'Groceries', period: 'Monthly', amount: 50 });
+
+    let thrown: unknown;
+    try {
+      updateBudget(db, second.id, { category: 'Food' });
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toBeInstanceOf(BudgetConflictError);
+    if (thrown instanceof BudgetConflictError) {
+      expect(thrown.category).toBe('Food');
+      expect(thrown.period).toBe('Monthly');
+    }
+  });
+
+  it('uses post-patch (category, period) in the conflict error when period also changes', () => {
+    createBudget(db, { category: 'Food', period: 'Yearly', amount: 1000 });
+    const second = createBudget(db, { category: 'Groceries', period: 'Monthly', amount: 50 });
+
+    let thrown: unknown;
+    try {
+      updateBudget(db, second.id, { category: 'Food', period: 'Yearly' });
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toBeInstanceOf(BudgetConflictError);
+    if (thrown instanceof BudgetConflictError) {
+      expect(thrown.category).toBe('Food');
+      expect(thrown.period).toBe('Yearly');
+    }
+  });
+});
+
+describe('createBudget — UNIQUE constraint mapping (race-survivor)', () => {
+  let db: FinanceDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('maps a UNIQUE violation on INSERT to BudgetConflictError when the pre-check is bypassed', () => {
+    createBudget(db, { category: 'Groceries', period: 'Monthly', amount: 100 });
+
+    const raw = db.$client as Database.Database;
+    raw.exec(`
+      CREATE TRIGGER inject_duplicate
+      BEFORE INSERT ON budgets
+      WHEN NEW.category = 'RaceCategory' AND NEW.period = 'Monthly'
+      BEGIN
+        UPDATE budgets SET category = 'RaceCategory' WHERE category = 'Groceries' AND period = 'Monthly';
+      END;
+    `);
+
+    let thrown: unknown;
+    try {
+      createBudget(db, { category: 'RaceCategory', period: 'Monthly', amount: 200 });
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toBeInstanceOf(BudgetConflictError);
+    if (thrown instanceof BudgetConflictError) {
+      expect(thrown.category).toBe('RaceCategory');
+      expect(thrown.period).toBe('Monthly');
+    }
+  });
 });
 
 describe('deleteBudget', () => {

--- a/packages/finance-db/src/__tests__/budgets.test.ts
+++ b/packages/finance-db/src/__tests__/budgets.test.ts
@@ -1,0 +1,608 @@
+/**
+ * Invariant tests for the budgets service against an in-memory SQLite
+ * seeded with the canonical `budgets` + `transactions` DDL. Pure DB +
+ * service layer — no tRPC, no Express, no auth middleware.
+ *
+ * Higher-level router coverage lives in pops-api's own integration suite
+ * and exercises the same service via the pops-api wrapper (kept untouched
+ * until phase 1 PR 3 cuts over).
+ *
+ * The DDL is inlined rather than read from the shared baseline migration
+ * (`0000_naive_chameleon.sql`) because that migration creates the entire
+ * pre-modular schema (hundreds of tables) and applying it for every test
+ * here is wasted work. Phase 1 PR 2 will move the canonical statement
+ * into the package's own migration journal — the byte-identical budgets
+ * statement already exists at
+ * `packages/finance-db/migrations/0053_finance_pillar_baseline.sql`, with
+ * the `active` default flip applied via `0052_budgets_active_default_zero`
+ * and the `(category, COALESCE(period, char(0)))` unique index added in
+ * that same migration.
+ */
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { BudgetConflictError, BudgetNotFoundError } from '../errors.js';
+import {
+  computeSpent,
+  createBudget,
+  deleteBudget,
+  getBudget,
+  listBudgets,
+  periodWindowEnd,
+  periodWindowStart,
+  updateBudget,
+  withSpend,
+} from '../services/budgets.js';
+
+import type { FinanceDb } from '../services/internal.js';
+
+const BUDGETS_DDL = `
+CREATE TABLE budgets (
+  id text PRIMARY KEY NOT NULL,
+  notion_id text,
+  category text NOT NULL,
+  period text,
+  amount real,
+  active integer DEFAULT 0 NOT NULL,
+  notes text,
+  last_edited_time text NOT NULL
+);
+CREATE UNIQUE INDEX budgets_notion_id_unique ON budgets (notion_id);
+CREATE UNIQUE INDEX idx_budgets_category_period ON budgets (category, COALESCE(period, char(0)));
+
+CREATE TABLE transactions (
+  id text PRIMARY KEY NOT NULL,
+  notion_id text,
+  description text NOT NULL,
+  account text NOT NULL,
+  amount real NOT NULL,
+  date text NOT NULL,
+  type text NOT NULL,
+  tags text DEFAULT '[]' NOT NULL,
+  entity_id text,
+  entity_name text,
+  location text,
+  country text,
+  related_transaction_id text,
+  notes text,
+  checksum text,
+  raw_row text,
+  last_edited_time text NOT NULL
+);
+CREATE INDEX idx_transactions_date ON transactions (date);
+`;
+
+function freshDb(): FinanceDb {
+  const raw = new Database(':memory:');
+  raw.pragma('foreign_keys = ON');
+  raw.exec(BUDGETS_DDL);
+  return drizzle(raw);
+}
+
+interface SeedTransactionInput {
+  description: string;
+  amount: number;
+  date: string;
+  type: string;
+  tags: string[];
+  account?: string;
+}
+
+function seedTransaction(db: FinanceDb, input: SeedTransactionInput): void {
+  const raw = db.$client as Database.Database;
+  raw
+    .prepare(
+      `INSERT INTO transactions (id, description, account, amount, date, type, tags, last_edited_time)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+    )
+    .run(
+      crypto.randomUUID(),
+      input.description,
+      input.account ?? 'Test Account',
+      input.amount,
+      input.date,
+      input.type,
+      JSON.stringify(input.tags),
+      new Date().toISOString()
+    );
+}
+
+describe('createBudget', () => {
+  let db: FinanceDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('inserts a row with the supplied fields and a generated UUID', () => {
+    const created = createBudget(db, {
+      category: 'Groceries',
+      period: 'Monthly',
+      amount: 500,
+      active: true,
+      notes: 'Monthly grocery budget',
+    });
+
+    expect(created.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+    expect(created.category).toBe('Groceries');
+    expect(created.period).toBe('Monthly');
+    expect(created.amount).toBe(500);
+    expect(created.active).toBe(1);
+    expect(created.notes).toBe('Monthly grocery budget');
+    expect(created.lastEditedTime).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('defaults optional fields to null and active to 0', () => {
+    const created = createBudget(db, { category: 'Just the category' });
+    expect(created.period).toBeNull();
+    expect(created.amount).toBeNull();
+    expect(created.active).toBe(0);
+    expect(created.notes).toBeNull();
+  });
+
+  it('throws BudgetConflictError on duplicate (category, period)', () => {
+    createBudget(db, { category: 'Groceries', period: 'Monthly' });
+
+    let thrown: unknown;
+    try {
+      createBudget(db, { category: 'Groceries', period: 'Monthly' });
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toBeInstanceOf(BudgetConflictError);
+    if (thrown instanceof BudgetConflictError) {
+      expect(thrown.category).toBe('Groceries');
+      expect(thrown.period).toBe('Monthly');
+      expect(thrown.message).toContain("'Groceries'");
+      expect(thrown.message).toContain("'Monthly'");
+    }
+  });
+
+  it('throws BudgetConflictError on duplicate category with null period', () => {
+    createBudget(db, { category: 'Groceries' });
+
+    let thrown: unknown;
+    try {
+      createBudget(db, { category: 'Groceries' });
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toBeInstanceOf(BudgetConflictError);
+    if (thrown instanceof BudgetConflictError) {
+      expect(thrown.period).toBeNull();
+      expect(thrown.message).toContain('null');
+    }
+  });
+
+  it('allows the same category for different periods', () => {
+    createBudget(db, { category: 'Groceries', period: 'Monthly' });
+    const yearly = createBudget(db, { category: 'Groceries', period: 'Yearly' });
+    expect(yearly.period).toBe('Yearly');
+  });
+});
+
+describe('getBudget', () => {
+  let db: FinanceDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('returns the persisted row by id', () => {
+    const created = createBudget(db, { category: 'Books' });
+    const fetched = getBudget(db, created.id);
+    expect(fetched).toEqual(created);
+  });
+
+  it('throws BudgetNotFoundError for an unknown id', () => {
+    expect(() => getBudget(db, 'missing')).toThrow(BudgetNotFoundError);
+  });
+});
+
+describe('listBudgets', () => {
+  let db: FinanceDb;
+  beforeEach(() => {
+    db = freshDb();
+    createBudget(db, { category: 'Apple monitor', period: 'Monthly', active: true });
+    createBudget(db, { category: 'Apple keyboard', period: 'Yearly', active: false });
+    createBudget(db, { category: 'Couch', active: true });
+  });
+
+  it('returns all rows sorted by category with a total count', () => {
+    const result = listBudgets(db, { limit: 50, offset: 0 });
+    expect(result.total).toBe(3);
+    expect(result.rows.map((r) => r.category)).toEqual([
+      'Apple keyboard',
+      'Apple monitor',
+      'Couch',
+    ]);
+  });
+
+  it('filters by LIKE on category (ASCII case-insensitive per SQLite default)', () => {
+    const result = listBudgets(db, { search: 'apple', limit: 50, offset: 0 });
+    expect(result.total).toBe(2);
+    expect(result.rows.every((r) => r.category.startsWith('Apple'))).toBe(true);
+  });
+
+  it('filters by period equality', () => {
+    const result = listBudgets(db, { period: 'Monthly', limit: 50, offset: 0 });
+    expect(result.total).toBe(1);
+    expect(result.rows[0]?.period).toBe('Monthly');
+  });
+
+  it('filters by active=true', () => {
+    const result = listBudgets(db, { active: true, limit: 50, offset: 0 });
+    expect(result.total).toBe(2);
+    expect(result.rows.every((r) => r.active === 1)).toBe(true);
+  });
+
+  it('filters by active=false', () => {
+    const result = listBudgets(db, { active: false, limit: 50, offset: 0 });
+    expect(result.total).toBe(1);
+    expect(result.rows[0]?.active).toBe(0);
+  });
+
+  it('paginates via limit + offset and reports the unpaginated total', () => {
+    const page1 = listBudgets(db, { limit: 2, offset: 0 });
+    const page2 = listBudgets(db, { limit: 2, offset: 2 });
+    expect(page1.total).toBe(3);
+    expect(page1.rows).toHaveLength(2);
+    expect(page2.total).toBe(3);
+    expect(page2.rows).toHaveLength(1);
+  });
+
+  it('enriches each row with `spent` (0 by default) and `remaining`', () => {
+    const result = listBudgets(db, { limit: 50, offset: 0 });
+    for (const row of result.rows) {
+      expect(row.spent).toBe(0);
+      if (row.amount === null) {
+        expect(row.remaining).toBeNull();
+      } else {
+        expect(row.remaining).toBe(row.amount);
+      }
+    }
+  });
+});
+
+describe('updateBudget', () => {
+  let db: FinanceDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('patches only the supplied fields and bumps lastEditedTime', async () => {
+    const created = createBudget(db, { category: 'Tent', amount: 100 });
+    const original = created.lastEditedTime;
+    await new Promise((r) => setTimeout(r, 5));
+
+    const updated = updateBudget(db, created.id, { amount: 250, active: true });
+    expect(updated.id).toBe(created.id);
+    expect(updated.category).toBe('Tent');
+    expect(updated.amount).toBe(250);
+    expect(updated.active).toBe(1);
+    expect(updated.lastEditedTime).not.toBe(original);
+  });
+
+  it('treats explicit null as a value (clears the field)', () => {
+    const created = createBudget(db, { category: 'Helmet', notes: 'Black, matte' });
+    const updated = updateBudget(db, created.id, { notes: null });
+    expect(updated.notes).toBeNull();
+  });
+
+  it('toggles active true → false', () => {
+    const created = createBudget(db, { category: 'Mug', active: true });
+    const updated = updateBudget(db, created.id, { active: false });
+    expect(updated.active).toBe(0);
+  });
+
+  it('is a no-op when the patch is empty (but still returns the row)', () => {
+    const created = createBudget(db, { category: 'Empty' });
+    const updated = updateBudget(db, created.id, {});
+    expect(updated.lastEditedTime).toBe(created.lastEditedTime);
+    expect(updated.category).toBe('Empty');
+  });
+
+  it('throws BudgetNotFoundError for an unknown id', () => {
+    expect(() => updateBudget(db, 'missing', { category: 'x' })).toThrow(BudgetNotFoundError);
+  });
+});
+
+describe('deleteBudget', () => {
+  let db: FinanceDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('removes the row and subsequent get throws', () => {
+    const created = createBudget(db, { category: 'Backpack' });
+    deleteBudget(db, created.id);
+    expect(() => getBudget(db, created.id)).toThrow(BudgetNotFoundError);
+  });
+
+  it('throws BudgetNotFoundError when the row is already gone', () => {
+    expect(() => deleteBudget(db, 'missing')).toThrow(BudgetNotFoundError);
+  });
+});
+
+describe('withSpend', () => {
+  let db: FinanceDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('returns spent=0 and remaining=amount when no transactions match', () => {
+    const created = createBudget(db, { category: 'Groceries', amount: 800, period: 'Monthly' });
+    const enriched = withSpend(db, created, new Date('2026-02-15T12:00:00.000Z'));
+    expect(enriched.spent).toBe(0);
+    expect(enriched.remaining).toBe(800);
+  });
+
+  it('returns remaining=null when the budget has no amount', () => {
+    const created = createBudget(db, { category: 'Groceries', amount: null });
+    const enriched = withSpend(db, created);
+    expect(enriched.remaining).toBeNull();
+  });
+});
+
+describe('listBudgets — spend aggregation', () => {
+  let db: FinanceDb;
+  const NOW = new Date('2026-02-15T12:00:00.000Z');
+
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  function seedGroceriesBudget(amount: number, period: string | null = 'Monthly'): void {
+    createBudget(db, { category: 'Groceries', period, amount, active: true });
+  }
+
+  it('reports zero spend when no matching transactions exist', () => {
+    seedGroceriesBudget(800);
+
+    const { rows } = listBudgets(db, { limit: 10, offset: 0, now: NOW });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.spent).toBe(0);
+    expect(rows[0]?.remaining).toBe(800);
+  });
+
+  it('sums month-to-date outflows that match the budget category', () => {
+    seedGroceriesBudget(800);
+    seedTransaction(db, {
+      description: 'Woolworths',
+      amount: -100,
+      date: '2026-02-03',
+      type: 'Expense',
+      tags: ['Groceries'],
+    });
+    seedTransaction(db, {
+      description: 'Coles',
+      amount: -50.5,
+      date: '2026-02-10',
+      type: 'Expense',
+      tags: ['Groceries'],
+    });
+
+    const { rows } = listBudgets(db, { limit: 10, offset: 0, now: NOW });
+    expect(rows[0]?.spent).toBeCloseTo(150.5, 2);
+    expect(rows[0]?.remaining).toBeCloseTo(649.5, 2);
+  });
+
+  it('ignores income (positive amounts) when summing spend', () => {
+    seedGroceriesBudget(800);
+    seedTransaction(db, {
+      description: 'Refund',
+      amount: 25,
+      date: '2026-02-05',
+      type: 'Income',
+      tags: ['Groceries'],
+    });
+
+    const { rows } = listBudgets(db, { limit: 10, offset: 0, now: NOW });
+    expect(rows[0]?.spent).toBe(0);
+    expect(rows[0]?.remaining).toBe(800);
+  });
+
+  it('ignores transactions with type=Transfer', () => {
+    seedGroceriesBudget(800);
+    seedTransaction(db, {
+      description: 'Transfer to Savings',
+      amount: -500,
+      date: '2026-02-05',
+      type: 'Transfer',
+      tags: ['Groceries', 'Transfer'],
+    });
+
+    const { rows } = listBudgets(db, { limit: 10, offset: 0, now: NOW });
+    expect(rows[0]?.spent).toBe(0);
+    expect(rows[0]?.remaining).toBe(800);
+  });
+
+  it('ignores transactions tagged with other categories', () => {
+    seedGroceriesBudget(800);
+    seedTransaction(db, {
+      description: 'Netflix',
+      amount: -22.99,
+      date: '2026-02-05',
+      type: 'Expense',
+      tags: ['Entertainment'],
+    });
+
+    const { rows } = listBudgets(db, { limit: 10, offset: 0, now: NOW });
+    expect(rows[0]?.spent).toBe(0);
+  });
+
+  it('yearly window includes prior months in the same year but excludes prior year', () => {
+    seedGroceriesBudget(5000, 'Yearly');
+    seedTransaction(db, {
+      description: 'January spend',
+      amount: -200,
+      date: '2026-01-15',
+      type: 'Expense',
+      tags: ['Groceries'],
+    });
+    seedTransaction(db, {
+      description: 'February spend',
+      amount: -100,
+      date: '2026-02-10',
+      type: 'Expense',
+      tags: ['Groceries'],
+    });
+    seedTransaction(db, {
+      description: 'Last year December',
+      amount: -999,
+      date: '2025-12-28',
+      type: 'Expense',
+      tags: ['Groceries'],
+    });
+
+    const { rows } = listBudgets(db, { limit: 10, offset: 0, now: NOW });
+    expect(rows[0]?.spent).toBeCloseTo(300, 2);
+    expect(rows[0]?.remaining).toBeCloseTo(4700, 2);
+  });
+
+  it('clamps the upper bound of MTD/YTD to today (no future-dated counts)', () => {
+    seedGroceriesBudget(800);
+    seedTransaction(db, {
+      description: 'Future outflow',
+      amount: -1000,
+      date: '2026-02-28',
+      type: 'Expense',
+      tags: ['Groceries'],
+    });
+
+    const { rows } = listBudgets(db, { limit: 10, offset: 0, now: NOW });
+    expect(rows[0]?.spent).toBe(0);
+  });
+
+  it('honours the custom `now` override for the period window', () => {
+    seedGroceriesBudget(800);
+    seedTransaction(db, {
+      description: 'March spend',
+      amount: -120,
+      date: '2026-03-04',
+      type: 'Expense',
+      tags: ['Groceries'],
+    });
+
+    const febNow = new Date('2026-02-20T12:00:00.000Z');
+    const marchNow = new Date('2026-03-20T12:00:00.000Z');
+
+    const feb = listBudgets(db, { limit: 10, offset: 0, now: febNow });
+    const march = listBudgets(db, { limit: 10, offset: 0, now: marchNow });
+
+    expect(feb.rows[0]?.spent).toBe(0);
+    expect(march.rows[0]?.spent).toBeCloseTo(120, 2);
+  });
+
+  it('counts a multi-tag transaction once when it carries the budget category', () => {
+    seedGroceriesBudget(800);
+    seedTransaction(db, {
+      description: 'Groceries + bonus',
+      amount: -75,
+      date: '2026-02-04',
+      type: 'Expense',
+      tags: ['Groceries', 'Shopping', 'Essentials'],
+    });
+
+    const { rows } = listBudgets(db, { limit: 10, offset: 0, now: NOW });
+    expect(rows[0]?.spent).toBeCloseTo(75, 2);
+  });
+
+  it('produces a negative `remaining` when spend exceeds the budget amount', () => {
+    seedGroceriesBudget(100);
+    seedTransaction(db, {
+      description: 'Big shop',
+      amount: -250,
+      date: '2026-02-05',
+      type: 'Expense',
+      tags: ['Groceries'],
+    });
+
+    const { rows } = listBudgets(db, { limit: 10, offset: 0, now: NOW });
+    expect(rows[0]?.spent).toBeCloseTo(250, 2);
+    expect(rows[0]?.remaining).toBeCloseTo(-150, 2);
+  });
+
+  it('null-period budgets aggregate spend across all time', () => {
+    createBudget(db, { category: 'Groceries', period: null, amount: 1000, active: true });
+    seedTransaction(db, {
+      description: 'Last year',
+      amount: -200,
+      date: '2024-06-01',
+      type: 'Expense',
+      tags: ['Groceries'],
+    });
+    seedTransaction(db, {
+      description: 'This year',
+      amount: -300,
+      date: '2026-02-10',
+      type: 'Expense',
+      tags: ['Groceries'],
+    });
+
+    const { rows } = listBudgets(db, { limit: 10, offset: 0, now: NOW });
+    expect(rows[0]?.spent).toBeCloseTo(500, 2);
+    expect(rows[0]?.remaining).toBeCloseTo(500, 2);
+  });
+});
+
+describe('computeSpent', () => {
+  let db: FinanceDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('returns 0 against an empty transactions table', () => {
+    expect(computeSpent(db, 'Groceries', 'Monthly', new Date('2026-02-15T12:00:00.000Z'))).toBe(0);
+  });
+
+  it('aggregates only the targeted category', () => {
+    seedTransaction(db, {
+      description: 'Groceries',
+      amount: -50,
+      date: '2026-02-10',
+      type: 'Expense',
+      tags: ['Groceries'],
+    });
+    seedTransaction(db, {
+      description: 'Coffee',
+      amount: -10,
+      date: '2026-02-10',
+      type: 'Expense',
+      tags: ['Coffee'],
+    });
+
+    expect(
+      computeSpent(db, 'Groceries', 'Monthly', new Date('2026-02-15T12:00:00.000Z'))
+    ).toBeCloseTo(50, 2);
+  });
+});
+
+describe('periodWindowStart', () => {
+  it('returns the first day of the current month for "Monthly"', () => {
+    expect(periodWindowStart('Monthly', new Date('2026-02-15T12:00:00.000Z'))).toBe('2026-02-01');
+    expect(periodWindowStart('Monthly', new Date('2026-12-31T23:59:59.000Z'))).toBe('2026-12-01');
+    expect(periodWindowStart('Monthly', new Date('2026-03-04T00:00:00.000Z'))).toBe('2026-03-01');
+  });
+
+  it('returns the first day of the current year for "Yearly"', () => {
+    expect(periodWindowStart('Yearly', new Date('2026-06-15T12:00:00.000Z'))).toBe('2026-01-01');
+    expect(periodWindowStart('Yearly', new Date('2026-01-02T00:00:00.000Z'))).toBe('2026-01-01');
+  });
+
+  it('returns null for null/undefined/unknown periods (all-time)', () => {
+    expect(periodWindowStart(null)).toBeNull();
+    expect(periodWindowStart(undefined)).toBeNull();
+    expect(periodWindowStart('')).toBeNull();
+    expect(periodWindowStart('weekly')).toBeNull();
+    expect(periodWindowStart('Quarterly')).toBeNull();
+  });
+});
+
+describe('periodWindowEnd', () => {
+  it('returns the zero-padded YYYY-MM-DD of `now`', () => {
+    expect(periodWindowEnd(new Date('2026-02-05T12:00:00.000Z'))).toBe('2026-02-05');
+    expect(periodWindowEnd(new Date('2026-12-31T23:59:59.000Z'))).toBe('2026-12-31');
+  });
+});

--- a/packages/finance-db/src/errors.ts
+++ b/packages/finance-db/src/errors.ts
@@ -55,3 +55,26 @@ export class ImportTransactionPersistError extends Error {
     this.id = id;
   }
 }
+
+export class BudgetNotFoundError extends Error {
+  override readonly name = 'BudgetNotFoundError' as const;
+  readonly id: string;
+
+  constructor(id: string) {
+    super(`Budget '${id}' not found`);
+    this.id = id;
+  }
+}
+
+export class BudgetConflictError extends Error {
+  override readonly name = 'BudgetConflictError' as const;
+  readonly category: string;
+  readonly period: string | null;
+
+  constructor(category: string, period: string | null) {
+    const periodDesc = period === null ? 'null' : `'${period}'`;
+    super(`Budget with category '${category}' and period ${periodDesc} already exists`);
+    this.category = category;
+    this.period = period;
+  }
+}

--- a/packages/finance-db/src/index.ts
+++ b/packages/finance-db/src/index.ts
@@ -63,3 +63,13 @@ export type {
   ImportTransactionRow,
   CreateImportEntityResult,
 } from './services/imports.js';
+export * as budgetsService from './services/budgets.js';
+
+export type {
+  BudgetRow,
+  BudgetWithSpend,
+  BudgetListResult,
+  CreateBudgetInput,
+  UpdateBudgetInput,
+  ListBudgetsOptions,
+} from './services/budgets.js';

--- a/packages/finance-db/src/schema.ts
+++ b/packages/finance-db/src/schema.ts
@@ -11,9 +11,11 @@
  * Mirrors the `@pops/core-db` schema re-export pattern.
  */
 export {
+  budgets,
   entities,
   tagVocabulary,
   transactions,
+  transactionCorrections,
   transactionTagRules,
   wishList,
 } from '@pops/db-types';

--- a/packages/finance-db/src/services/budget-spend.ts
+++ b/packages/finance-db/src/services/budget-spend.ts
@@ -1,0 +1,94 @@
+/**
+ * Bulk spend aggregation for budget rows.
+ *
+ * Issues one `SELECT … GROUP BY tag` query per unique `period` (windows
+ * differ per period), instead of one query per budget row. Drives both
+ * the list endpoint and the per-row helpers so spend semantics stay in
+ * one place.
+ */
+import { and, sql } from 'drizzle-orm';
+
+import { transactions } from '../schema.js';
+import { periodWindowEnd, periodWindowStart } from './period-window.js';
+
+import type { FinanceDb } from './internal.js';
+
+const NULL_PERIOD_KEY = '__null__';
+
+/** Map key encoding for `(period, category)`. Null periods get a sentinel. */
+export function spendMapKey(period: string | null, category: string): string {
+  return `${period ?? NULL_PERIOD_KEY}|${category}`;
+}
+
+export interface BudgetTarget {
+  category: string;
+  period: string | null;
+}
+
+interface SpendRow {
+  category: string;
+  spent: number | null;
+}
+
+/**
+ * Aggregate per-category spend for a set of budget targets in bulk.
+ *
+ * Returns a `Map` keyed by `spendMapKey(period, category)`. Missing
+ * entries mean zero spend.
+ */
+export function bulkComputeSpend(
+  db: FinanceDb,
+  targets: ReadonlyArray<BudgetTarget>,
+  now: Date
+): Map<string, number> {
+  const result = new Map<string, number>();
+  if (targets.length === 0) return result;
+
+  const groups = new Map<string, { period: string | null; categories: Set<string> }>();
+  for (const target of targets) {
+    const groupKey = target.period ?? NULL_PERIOD_KEY;
+    const existing = groups.get(groupKey);
+    if (existing) {
+      existing.categories.add(target.category);
+    } else {
+      groups.set(groupKey, {
+        period: target.period,
+        categories: new Set([target.category]),
+      });
+    }
+  }
+
+  for (const { period, categories } of groups.values()) {
+    if (categories.size === 0) continue;
+    const categoryList = Array.from(categories);
+
+    const conditions = [
+      sql`${transactions.type} != 'Transfer'`,
+      sql`je.value IN (${sql.join(
+        categoryList.map((c) => sql`${c}`),
+        sql`, `
+      )})`,
+    ];
+
+    const windowStart = periodWindowStart(period, now);
+    if (windowStart !== null) {
+      const windowEnd = periodWindowEnd(now);
+      conditions.push(sql`${transactions.date} >= ${windowStart}`);
+      conditions.push(sql`${transactions.date} <= ${windowEnd}`);
+    }
+
+    const rows = db.all<SpendRow>(sql`
+      SELECT je.value AS category,
+             SUM(CASE WHEN ${transactions.amount} < 0 THEN -${transactions.amount} ELSE 0 END) AS spent
+      FROM ${transactions}, json_each(${transactions.tags}) AS je
+      WHERE ${and(...conditions)}
+      GROUP BY je.value
+    `);
+
+    for (const row of rows) {
+      result.set(spendMapKey(period, row.category), row.spent ?? 0);
+    }
+  }
+
+  return result;
+}

--- a/packages/finance-db/src/services/budget-unique-violation.ts
+++ b/packages/finance-db/src/services/budget-unique-violation.ts
@@ -1,0 +1,31 @@
+/**
+ * better-sqlite3 surfaces UNIQUE index violations with
+ * `code = 'SQLITE_CONSTRAINT_UNIQUE'` and a message that names the table
+ * or the index. Drizzle wraps these in a `DrizzleError` carrying the
+ * original as `.cause`, so we walk the cause chain.
+ *
+ * Accept the broader `SQLITE_CONSTRAINT` family too as a defensive fallback
+ * for older drivers that drop the suffix.
+ */
+const MAX_CAUSE_DEPTH = 5;
+
+export function isBudgetUniqueViolation(err: unknown): boolean {
+  let current: unknown = err;
+  for (let i = 0; i < MAX_CAUSE_DEPTH && current instanceof Error; i++) {
+    if (matchesBudgetsUnique(current)) return true;
+    const next: unknown = (current as { cause?: unknown }).cause;
+    if (next === current) return false;
+    current = next;
+  }
+  return false;
+}
+
+function matchesBudgetsUnique(err: Error): boolean {
+  const code: unknown = (err as { code?: unknown }).code;
+  if (typeof code !== 'string') return false;
+  if (code !== 'SQLITE_CONSTRAINT_UNIQUE' && code !== 'SQLITE_CONSTRAINT') return false;
+  return (
+    /UNIQUE constraint failed: budgets/.test(err.message) ||
+    /UNIQUE constraint failed: index 'idx_budgets_/.test(err.message)
+  );
+}

--- a/packages/finance-db/src/services/budgets.ts
+++ b/packages/finance-db/src/services/budgets.ts
@@ -13,7 +13,6 @@ import { and, asc, count, eq, isNull, like, sql } from 'drizzle-orm';
 
 import { BudgetConflictError, BudgetNotFoundError } from '../errors.js';
 import { budgets, transactions } from '../schema.js';
-
 import { periodWindowEnd, periodWindowStart } from './period-window.js';
 
 import type { FinanceDb } from './internal.js';

--- a/packages/finance-db/src/services/budgets.ts
+++ b/packages/finance-db/src/services/budgets.ts
@@ -9,11 +9,12 @@
  * Mirrors `@pops/core-db`'s service-account pattern: db-arg services,
  * typed domain errors, no HTTP concerns.
  */
-import { and, asc, count, eq, isNull, like, sql } from 'drizzle-orm';
+import { and, asc, count, eq, isNull, like } from 'drizzle-orm';
 
 import { BudgetConflictError, BudgetNotFoundError } from '../errors.js';
-import { budgets, transactions } from '../schema.js';
-import { periodWindowEnd, periodWindowStart } from './period-window.js';
+import { budgets } from '../schema.js';
+import { bulkComputeSpend, spendMapKey } from './budget-spend.js';
+import { isBudgetUniqueViolation } from './budget-unique-violation.js';
 
 import type { FinanceDb } from './internal.js';
 
@@ -68,16 +69,8 @@ export interface ListBudgetsOptions {
 
 /**
  * Compute the total spent against a budget's category, restricted to the
- * budget's period window when applicable.
- *
- * Rules:
- *   - Match `transactions.tags` (a JSON-encoded text array) against the
- *     budget's category via SQLite `json_each`.
- *   - Exclude transactions with `type = 'Transfer'`.
- *   - Sum the absolute value of negative amounts only — outflows count as
- *     spend; inflows (Income, refunds) do not.
- *   - Restrict to `date >= periodWindowStart` for Monthly/Yearly. All-time
- *     for any other period (including null).
+ * budget's period window when applicable. Delegates to {@link bulkComputeSpend}
+ * so the single-row and list paths share the same aggregation SQL.
  */
 export function computeSpent(
   db: FinanceDb,
@@ -85,27 +78,8 @@ export function computeSpent(
   period: string | null,
   now: Date = new Date()
 ): number {
-  const windowStart = periodWindowStart(period, now);
-
-  const conditions = [
-    sql`EXISTS (SELECT 1 FROM json_each(${transactions.tags}) WHERE json_each.value = ${category})`,
-    sql`${transactions.type} != 'Transfer'`,
-  ];
-  if (windowStart !== null) {
-    const windowEnd = periodWindowEnd(now);
-    conditions.push(sql`${transactions.date} >= ${windowStart}`);
-    conditions.push(sql`${transactions.date} <= ${windowEnd}`);
-  }
-
-  const row = db
-    .select({
-      total: sql<number>`COALESCE(SUM(CASE WHEN ${transactions.amount} < 0 THEN -${transactions.amount} ELSE 0 END), 0)`,
-    })
-    .from(transactions)
-    .where(and(...conditions))
-    .get();
-
-  return row?.total ?? 0;
+  const map = bulkComputeSpend(db, [{ category, period }], now);
+  return map.get(spendMapKey(period, category)) ?? 0;
 }
 
 /**
@@ -114,7 +88,8 @@ export function computeSpent(
  * shape as the list endpoint.
  */
 export function withSpend(db: FinanceDb, row: BudgetRow, now: Date = new Date()): BudgetWithSpend {
-  const spent = computeSpent(db, row.category, row.period, now);
+  const map = bulkComputeSpend(db, [{ category: row.category, period: row.period }], now);
+  const spent = map.get(spendMapKey(row.period, row.category)) ?? 0;
   const remaining = row.amount === null ? null : row.amount - spent;
   return { ...row, spent, remaining };
 }
@@ -142,8 +117,14 @@ export function listBudgets(db: FinanceDb, opts: ListBudgetsOptions): BudgetList
     .offset(opts.offset)
     .all();
 
+  const spendMap = bulkComputeSpend(
+    db,
+    rows.map((r) => ({ category: r.category, period: r.period })),
+    now
+  );
+
   const enriched: BudgetWithSpend[] = rows.map((row) => {
-    const spent = computeSpent(db, row.category, row.period, now);
+    const spent = spendMap.get(spendMapKey(row.period, row.category)) ?? 0;
     const remaining = row.amount === null ? null : row.amount - spent;
     return { ...row, spent, remaining };
   });
@@ -163,9 +144,9 @@ export function getBudget(db: FinanceDb, id: string): BudgetRow {
  * Create a new budget. Returns the persisted row.
  *
  * Throws `BudgetConflictError` if a budget with the same `(category, period)`
- * already exists. NULL periods collide with other NULL periods — the duplicate
- * check uses `IS NULL` for that case, matching the table's
- * `COALESCE(period, char(0))` unique index.
+ * already exists. The pre-check is the friendly fast path; the UNIQUE
+ * constraint mapping on the INSERT is the safety net for concurrent inserts
+ * that race past it.
  */
 export function createBudget(db: FinanceDb, input: CreateBudgetInput): BudgetRow {
   const period = input.period ?? null;
@@ -186,17 +167,24 @@ export function createBudget(db: FinanceDb, input: CreateBudgetInput): BudgetRow
   const id = crypto.randomUUID();
   const now = new Date().toISOString();
 
-  db.insert(budgets)
-    .values({
-      id,
-      category: input.category,
-      period,
-      amount: input.amount ?? null,
-      active: input.active ? 1 : 0,
-      notes: input.notes ?? null,
-      lastEditedTime: now,
-    })
-    .run();
+  try {
+    db.insert(budgets)
+      .values({
+        id,
+        category: input.category,
+        period,
+        amount: input.amount ?? null,
+        active: input.active ? 1 : 0,
+        notes: input.notes ?? null,
+        lastEditedTime: now,
+      })
+      .run();
+  } catch (err) {
+    if (isBudgetUniqueViolation(err)) {
+      throw new BudgetConflictError(input.category, period);
+    }
+    throw err;
+  }
 
   return getBudget(db, id);
 }
@@ -212,16 +200,30 @@ function buildBudgetUpdates(input: UpdateBudgetInput): Partial<typeof budgets.$i
 }
 
 /**
- * Patch a budget. Throws `BudgetNotFoundError` if missing.
- * No-op writes (empty `input`) still re-read the row but skip the UPDATE.
+ * Patch a budget. Throws `BudgetNotFoundError` if missing. No-op writes
+ * (empty `input`) still re-read the row but skip the UPDATE.
+ *
+ * Patches that would change `(category, period)` into an existing budget's
+ * slot map UNIQUE constraint violations to `BudgetConflictError`, using the
+ * post-patch values for the error.
  */
 export function updateBudget(db: FinanceDb, id: string, input: UpdateBudgetInput): BudgetRow {
-  getBudget(db, id);
+  const current = getBudget(db, id);
 
   const updates = buildBudgetUpdates(input);
   if (Object.keys(updates).length > 0) {
     updates.lastEditedTime = new Date().toISOString();
-    db.update(budgets).set(updates).where(eq(budgets.id, id)).run();
+    const effectiveCategory = input.category ?? current.category;
+    const effectivePeriod = input.period !== undefined ? (input.period ?? null) : current.period;
+
+    try {
+      db.update(budgets).set(updates).where(eq(budgets.id, id)).run();
+    } catch (err) {
+      if (isBudgetUniqueViolation(err)) {
+        throw new BudgetConflictError(effectiveCategory, effectivePeriod);
+      }
+      throw err;
+    }
   }
 
   return getBudget(db, id);

--- a/packages/finance-db/src/services/budgets.ts
+++ b/packages/finance-db/src/services/budgets.ts
@@ -1,0 +1,236 @@
+/**
+ * Budget CRUD + spend aggregation against finance's SQLite via drizzle.
+ *
+ * The in-tree service in `apps/pops-api/src/modules/finance/budgets/`
+ * still uses `getDrizzle()`; this package version takes a `FinanceDb`
+ * handle as its first argument. The cutover (PR 3 of phase 1) flips
+ * pops-api to call into here.
+ *
+ * Mirrors `@pops/core-db`'s service-account pattern: db-arg services,
+ * typed domain errors, no HTTP concerns.
+ */
+import { and, asc, count, eq, isNull, like, sql } from 'drizzle-orm';
+
+import { BudgetConflictError, BudgetNotFoundError } from '../errors.js';
+import { budgets, transactions } from '../schema.js';
+
+import { periodWindowEnd, periodWindowStart } from './period-window.js';
+
+import type { FinanceDb } from './internal.js';
+
+export { periodWindowEnd, periodWindowStart } from './period-window.js';
+
+/** Raw drizzle row shape. */
+export type BudgetRow = typeof budgets.$inferSelect;
+
+/** A budget row plus aggregated spend over its period. */
+export interface BudgetWithSpend extends BudgetRow {
+  spent: number;
+  remaining: number | null;
+}
+
+/** Result of a paginated `list` call. */
+export interface BudgetListResult {
+  rows: BudgetWithSpend[];
+  total: number;
+}
+
+/** Mutable subset accepted on create. `notionId` stays the import/sync layer's job. */
+export interface CreateBudgetInput {
+  category: string;
+  period?: string | null;
+  amount?: number | null;
+  active?: boolean;
+  notes?: string | null;
+}
+
+/** Same shape as create — all fields optional for PATCH semantics. */
+export interface UpdateBudgetInput {
+  category?: string;
+  period?: string | null;
+  amount?: number | null;
+  active?: boolean;
+  notes?: string | null;
+}
+
+/** Filters + pagination accepted by `listBudgets`. */
+export interface ListBudgetsOptions {
+  search?: string | undefined;
+  period?: string | undefined;
+  active?: boolean | undefined;
+  limit: number;
+  offset: number;
+  /**
+   * Reference timestamp used to derive the period window. Defaults to the
+   * current time. Override in tests to make the window deterministic.
+   */
+  now?: Date | undefined;
+}
+
+/**
+ * Compute the total spent against a budget's category, restricted to the
+ * budget's period window when applicable.
+ *
+ * Rules:
+ *   - Match `transactions.tags` (a JSON-encoded text array) against the
+ *     budget's category via SQLite `json_each`.
+ *   - Exclude transactions with `type = 'Transfer'`.
+ *   - Sum the absolute value of negative amounts only — outflows count as
+ *     spend; inflows (Income, refunds) do not.
+ *   - Restrict to `date >= periodWindowStart` for Monthly/Yearly. All-time
+ *     for any other period (including null).
+ */
+export function computeSpent(
+  db: FinanceDb,
+  category: string,
+  period: string | null,
+  now: Date = new Date()
+): number {
+  const windowStart = periodWindowStart(period, now);
+
+  const conditions = [
+    sql`EXISTS (SELECT 1 FROM json_each(${transactions.tags}) WHERE json_each.value = ${category})`,
+    sql`${transactions.type} != 'Transfer'`,
+  ];
+  if (windowStart !== null) {
+    const windowEnd = periodWindowEnd(now);
+    conditions.push(sql`${transactions.date} >= ${windowStart}`);
+    conditions.push(sql`${transactions.date} <= ${windowEnd}`);
+  }
+
+  const row = db
+    .select({
+      total: sql<number>`COALESCE(SUM(CASE WHEN ${transactions.amount} < 0 THEN -${transactions.amount} ELSE 0 END), 0)`,
+    })
+    .from(transactions)
+    .where(and(...conditions))
+    .get();
+
+  return row?.total ?? 0;
+}
+
+/**
+ * Enrich a raw budget row with `spent` and `remaining`. Convenience wrapper
+ * used by single-row endpoints (get/create/update) so they return the same
+ * shape as the list endpoint.
+ */
+export function withSpend(db: FinanceDb, row: BudgetRow, now: Date = new Date()): BudgetWithSpend {
+  const spent = computeSpent(db, row.category, row.period, now);
+  const remaining = row.amount === null ? null : row.amount - spent;
+  return { ...row, spent, remaining };
+}
+
+/**
+ * List budgets with optional filters. Each row is enriched with `spent`
+ * (aggregated outflow over the budget's period) and `remaining` (amount −
+ * spent, or null when the budget has no target amount).
+ */
+export function listBudgets(db: FinanceDb, opts: ListBudgetsOptions): BudgetListResult {
+  const conditions = [];
+  if (opts.search) conditions.push(like(budgets.category, `%${opts.search}%`));
+  if (opts.period) conditions.push(eq(budgets.period, opts.period));
+  if (opts.active !== undefined) conditions.push(eq(budgets.active, opts.active ? 1 : 0));
+
+  const where = conditions.length > 0 ? and(...conditions) : undefined;
+  const now = opts.now ?? new Date();
+
+  const rows = db
+    .select()
+    .from(budgets)
+    .where(where)
+    .orderBy(asc(budgets.category))
+    .limit(opts.limit)
+    .offset(opts.offset)
+    .all();
+
+  const enriched: BudgetWithSpend[] = rows.map((row) => {
+    const spent = computeSpent(db, row.category, row.period, now);
+    const remaining = row.amount === null ? null : row.amount - spent;
+    return { ...row, spent, remaining };
+  });
+
+  const countRow = db.select({ total: count() }).from(budgets).where(where).all()[0];
+  return { rows: enriched, total: countRow?.total ?? 0 };
+}
+
+/** Get a single budget by id. Throws `BudgetNotFoundError` if missing. */
+export function getBudget(db: FinanceDb, id: string): BudgetRow {
+  const row = db.select().from(budgets).where(eq(budgets.id, id)).get();
+  if (!row) throw new BudgetNotFoundError(id);
+  return row;
+}
+
+/**
+ * Create a new budget. Returns the persisted row.
+ *
+ * Throws `BudgetConflictError` if a budget with the same `(category, period)`
+ * already exists. NULL periods collide with other NULL periods — the duplicate
+ * check uses `IS NULL` for that case, matching the table's
+ * `COALESCE(period, char(0))` unique index.
+ */
+export function createBudget(db: FinanceDb, input: CreateBudgetInput): BudgetRow {
+  const period = input.period ?? null;
+
+  const existing = db
+    .select({ id: budgets.id })
+    .from(budgets)
+    .where(
+      and(
+        eq(budgets.category, input.category),
+        period !== null ? eq(budgets.period, period) : isNull(budgets.period)
+      )
+    )
+    .get();
+
+  if (existing) throw new BudgetConflictError(input.category, period);
+
+  const id = crypto.randomUUID();
+  const now = new Date().toISOString();
+
+  db.insert(budgets)
+    .values({
+      id,
+      category: input.category,
+      period,
+      amount: input.amount ?? null,
+      active: input.active ? 1 : 0,
+      notes: input.notes ?? null,
+      lastEditedTime: now,
+    })
+    .run();
+
+  return getBudget(db, id);
+}
+
+function buildBudgetUpdates(input: UpdateBudgetInput): Partial<typeof budgets.$inferInsert> {
+  const updates: Partial<typeof budgets.$inferInsert> = {};
+  if (input.category !== undefined) updates.category = input.category;
+  if (input.period !== undefined) updates.period = input.period ?? null;
+  if (input.amount !== undefined) updates.amount = input.amount ?? null;
+  if (input.active !== undefined) updates.active = input.active ? 1 : 0;
+  if (input.notes !== undefined) updates.notes = input.notes ?? null;
+  return updates;
+}
+
+/**
+ * Patch a budget. Throws `BudgetNotFoundError` if missing.
+ * No-op writes (empty `input`) still re-read the row but skip the UPDATE.
+ */
+export function updateBudget(db: FinanceDb, id: string, input: UpdateBudgetInput): BudgetRow {
+  getBudget(db, id);
+
+  const updates = buildBudgetUpdates(input);
+  if (Object.keys(updates).length > 0) {
+    updates.lastEditedTime = new Date().toISOString();
+    db.update(budgets).set(updates).where(eq(budgets.id, id)).run();
+  }
+
+  return getBudget(db, id);
+}
+
+/** Delete a budget. Throws `BudgetNotFoundError` if missing. */
+export function deleteBudget(db: FinanceDb, id: string): void {
+  getBudget(db, id);
+  const result = db.delete(budgets).where(eq(budgets.id, id)).run();
+  if (result.changes === 0) throw new BudgetNotFoundError(id);
+}

--- a/packages/finance-db/src/services/period-window.ts
+++ b/packages/finance-db/src/services/period-window.ts
@@ -1,0 +1,40 @@
+/**
+ * Period window resolution for budget spend aggregation.
+ *
+ * - Monthly  → first day of the current month at 00:00:00 UTC.
+ * - Yearly   → first day of the current year at 00:00:00 UTC.
+ * - null/anything else → null (all-time, no lower bound on transaction date).
+ *
+ * The cutoff is returned as an ISO `YYYY-MM-DD` string because
+ * `transactions.date` is stored as a `YYYY-MM-DD` text column. Inclusive
+ * comparisons (`date >= start`) work directly against this lexicographic form.
+ *
+ * Spend aggregation also clamps the upper bound to today (see
+ * {@link periodWindowEnd}) — Monthly = month-to-date, Yearly = year-to-date.
+ */
+export function periodWindowStart(
+  period: string | null | undefined,
+  now: Date = new Date()
+): string | null {
+  if (period === 'Monthly') {
+    const year = now.getUTCFullYear();
+    const month = String(now.getUTCMonth() + 1).padStart(2, '0');
+    return `${year}-${month}-01`;
+  }
+  if (period === 'Yearly') {
+    return `${now.getUTCFullYear()}-01-01`;
+  }
+  return null;
+}
+
+/**
+ * Inclusive upper bound (`YYYY-MM-DD`) for the spend window. Always clamps to
+ * today regardless of period — future-dated transactions never count toward
+ * MTD/YTD spend.
+ */
+export function periodWindowEnd(now: Date = new Date()): string {
+  const year = now.getUTCFullYear();
+  const month = String(now.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(now.getUTCDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}


### PR DESCRIPTION
## Summary

- First PR of the 4-PR sequence to migrate the finance `budgets` slice from `apps/pops-api/src/modules/finance/budgets/` into `@pops/finance-db` (Track N1 of the deferred-backlog tracker in `.claude/pillar-migration-roadmap.md`, issue #2837).
- Mirrors the wish-list pilot (#2766) and the more recent tag_vocabulary sibling (#2852) — strictly additive, no behaviour change, in-tree callers untouched.
- Adds `budgetsService` (`createBudget`, `getBudget`, `listBudgets`, `updateBudget`, `deleteBudget`, plus the `computeSpent` / `withSpend` helpers and the `periodWindowStart` / `periodWindowEnd` pure helpers) as db-arg functions on `FinanceDb`, plus `BudgetRow` / `BudgetWithSpend` / `BudgetListResult` / `CreateBudgetInput` / `UpdateBudgetInput` / `ListBudgetsOptions` types, plus the typed errors `BudgetNotFoundError` + `BudgetConflictError`, plus the `budgets` + `transactions` schema re-exports.

## Scope

This is **PR 1 of 4** for the N1 slice.

Deferred to subsequent N1 PRs:
- **PR 2** — Migration journal split + drift-guard CI for the `budgets` portion of `0000_naive_chameleon` + `0052_budgets_active_default_zero`. The byte-identical baseline copy already exists in `packages/finance-db/migrations/0053_finance_pillar_baseline.sql` (it was copied across with the wish-list pilot) and the `active` default flip lives at `packages/finance-db/migrations/0052_budgets_active_default_zero.sql`, but no drift guard wires the budgets-specific statements yet for this slice.
- **PR 3** — Router cutover. Flip `apps/pops-api/src/modules/finance/budgets/router.ts` and `search-adapter.ts` to call into `@pops/finance-db`'s `budgetsService`. Map `BudgetNotFoundError` → `NOT_FOUND` and `BudgetConflictError` → `CONFLICT` on the affected procedures.
- **PR 4** — Delete the in-tree `apps/pops-api/src/modules/finance/budgets/` shim (the index re-export, `service.ts`, `period-window.ts`, `types.ts`) once nothing inside pops-api references it.

## Files

- `packages/finance-db/src/services/budgets.ts` — db-arg CRUD + spend aggregation against `FinanceDb` (uses `transactions` for `json_each` tag-match joins, mirroring the in-tree behaviour exactly).
- `packages/finance-db/src/services/period-window.ts` — pure `periodWindowStart` / `periodWindowEnd` helpers, copied verbatim from the in-tree module.
- `packages/finance-db/src/errors.ts` — `BudgetNotFoundError` + `BudgetConflictError` typed domain errors.
- `packages/finance-db/src/schema.ts` — add `budgets` + `transactions` to the re-export. `transactions` is read-only here for spend joins; it stays owned by the future N2 slice.
- `packages/finance-db/src/index.ts` — barrel exports `budgetsService` namespace + the 6 budget input/output types.
- `packages/finance-db/src/__tests__/budgets.test.ts` — 40 in-memory unit tests against inlined `budgets` + `transactions` DDL covering CRUD happy paths, `BudgetNotFoundError` on every not-found path, `BudgetConflictError` on `(category, period)` collisions including the NULL-period sentinel collision, list filters + pagination, and full spend-aggregation parity with `apps/pops-api/src/modules/finance/budgets/budgets.test.ts` (MTD/YTD windows, future-clamp, multi-tag, Transfer exclusion, Income exclusion, negative `remaining`, null-period all-time, `now` override).

## Notes

- The in-tree `apps/pops-api/src/modules/finance/budgets/` is left untouched, so all existing callers (router + search adapter) keep working through `getDrizzle()`. Router cutover comes in PR 3, in-tree deletion in PR 4.
- Two typed domain errors exported (`BudgetNotFoundError` + `BudgetConflictError`) — the in-tree router currently maps `NotFoundError` → `NOT_FOUND` and `ConflictError` → `CONFLICT`. PR 3 will wire the new typed errors through the same TRPC mapping.
- `transactions` is re-exported from the schema barrel even though no service in this PR owns it as a writer — `computeSpent` reads it via `json_each` to aggregate spend against tags. When N2 lands it'll add writer services on top of the same schema re-export.
- CI parity already in place from the wish-list pilot: `packages/finance-db/**` is wired into `_pkg-check.yml`, `api-quality.yml`, `api-test.yml`, `fe-quality.yml`, `fe-test-e2e.yml`; all three Dockerfiles (`pops-api`, `pops-shell`, `pops-mcp`) plus `pops-finance-api` COPY + BUILD `@pops/finance-db`.

## Test plan

- [x] `pnpm --filter @pops/finance-db typecheck`
- [x] `pnpm --filter @pops/finance-db test` (68 / 68 passing — 14 wishlist + 4 open-finance-db + 10 tag-vocabulary + 40 budgets)
- [x] `pnpm --filter @pops/finance-db build`
- [x] `pnpm typecheck` (full repo — 45 / 45 tasks)
- [x] `pnpm --filter @pops/api test` (4819 / 4819 passing — pops-api untouched, no consumer cutover yet)
- [x] `pnpm build` (21 / 21 tasks)
- [x] `pnpm lint` (clean — only pre-existing warnings on unrelated files)