### PR TITLE
feat(finance-db): scaffold transaction_tag_rules slice (Track N4 phase 1 PR 1)

### DIFF
--- a/packages/finance-db/src/__tests__/transaction-tag-rules.test.ts
+++ b/packages/finance-db/src/__tests__/transaction-tag-rules.test.ts
@@ -106,9 +106,7 @@ function freshDb(): TestHarness {
 
 function seedEntity(harness: TestHarness, id: string, name: string): void {
   harness.raw
-    .prepare(
-      `INSERT INTO entities (id, name, type, last_edited_time) VALUES (?, ?, 'company', ?)`
-    )
+    .prepare(`INSERT INTO entities (id, name, type, last_edited_time) VALUES (?, ?, 'company', ?)`)
     .run(id, name, new Date().toISOString());
 }
 
@@ -333,9 +331,9 @@ describe('updateTransactionTagRule', () => {
       matchType: 'exact',
       tags: ['x'],
     });
-    expect(() =>
-      updateTransactionTagRule(harness.db, created.id, { entityId: 'phantom' })
-    ).toThrow(/FOREIGN KEY constraint failed/);
+    expect(() => updateTransactionTagRule(harness.db, created.id, { entityId: 'phantom' })).toThrow(
+      /FOREIGN KEY constraint failed/
+    );
   });
 
   it('throws TransactionTagRuleNotFoundError for an unknown id', () => {

--- a/packages/finance-db/src/__tests__/transaction-tag-rules.test.ts
+++ b/packages/finance-db/src/__tests__/transaction-tag-rules.test.ts
@@ -1,0 +1,438 @@
+/**
+ * Invariant tests for the transaction-tag-rules service against an
+ * in-memory SQLite seeded with the canonical `transaction_tag_rules`,
+ * `tag_vocabulary`, and `entities` DDL. Pure DB + service layer — no tRPC,
+ * no Express, no auth middleware.
+ *
+ * Three foreign-key dimensions are exercised:
+ *   (1) `entity_id` -> `entities(id)` is the only SQL-level FK on the table
+ *       and must be honoured when `foreign_keys = ON`. A bad `entityId`
+ *       must be rejected by SQLite, not silently accepted.
+ *   (2) `tags` JSON references against `tag_vocabulary.tag` are a logical
+ *       relationship only — there is no SQL FK, so the table accepts tags
+ *       that are not in the vocabulary. We assert that explicitly so the
+ *       cutover (PR 3) does not surprise the in-tree consumer, which
+ *       enforces the relationship at the preview layer.
+ *   (3) `tag_vocabulary` itself is co-seeded so the sibling-table fixture
+ *       proves the package's barrel re-export from N5 is functional and
+ *       so future PRs that wire the preview layer here have a reference
+ *       harness.
+ *
+ * The DDL is inlined for the same reason as the wish-list and
+ * tag-vocabulary suites: the package's own `0026_little_frank_castle.sql`
+ * mixes table creation with `INSERT OR IGNORE` seed data we do not want
+ * leaking into these unit tests.
+ */
+import Database from 'better-sqlite3';
+import { eq } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { TransactionTagRuleNotFoundError } from '../errors.js';
+import { tagVocabulary, transactionTagRules } from '../schema.js';
+import { upsertVocabularyTag } from '../services/tag-vocabulary.js';
+import {
+  createTransactionTagRule,
+  deleteTransactionTagRule,
+  disableTransactionTagRule,
+  getTransactionTagRule,
+  listTransactionTagRules,
+  updateTransactionTagRule,
+} from '../services/transaction-tag-rules.js';
+
+import type { FinanceDb } from '../services/internal.js';
+
+const ENTITIES_DDL = `
+CREATE TABLE entities (
+  id text PRIMARY KEY NOT NULL,
+  notion_id text,
+  name text NOT NULL,
+  type text DEFAULT 'company' NOT NULL,
+  abn text,
+  aliases text,
+  default_transaction_type text,
+  default_tags text,
+  notes text,
+  last_edited_time text NOT NULL
+);
+CREATE UNIQUE INDEX entities_notion_id_unique ON entities (notion_id);
+`;
+
+const TAG_VOCABULARY_DDL = `
+CREATE TABLE tag_vocabulary (
+  tag text PRIMARY KEY NOT NULL,
+  source text DEFAULT 'seed' NOT NULL,
+  is_active integer DEFAULT 1 NOT NULL,
+  created_at text DEFAULT (datetime('now')) NOT NULL
+);
+CREATE INDEX idx_tag_vocabulary_active ON tag_vocabulary (is_active);
+`;
+
+const TRANSACTION_TAG_RULES_DDL = `
+CREATE TABLE transaction_tag_rules (
+  id text PRIMARY KEY NOT NULL,
+  description_pattern text NOT NULL,
+  match_type text DEFAULT 'exact' NOT NULL,
+  entity_id text,
+  tags text DEFAULT '[]' NOT NULL,
+  is_active integer DEFAULT 1 NOT NULL,
+  confidence real DEFAULT 0.5 NOT NULL,
+  priority integer DEFAULT 0 NOT NULL,
+  times_applied integer DEFAULT 0 NOT NULL,
+  created_at text DEFAULT (datetime('now')) NOT NULL,
+  last_used_at text,
+  FOREIGN KEY (entity_id) REFERENCES entities(id) ON UPDATE no action ON DELETE set null
+);
+CREATE INDEX idx_tag_rules_pattern ON transaction_tag_rules (description_pattern);
+CREATE INDEX idx_tag_rules_entity_id ON transaction_tag_rules (entity_id);
+CREATE INDEX idx_tag_rules_priority ON transaction_tag_rules (priority);
+CREATE INDEX idx_tag_rules_confidence ON transaction_tag_rules (confidence);
+CREATE INDEX idx_tag_rules_times_applied ON transaction_tag_rules (times_applied);
+`;
+
+interface TestHarness {
+  db: FinanceDb;
+  raw: Database.Database;
+}
+
+function freshDb(): TestHarness {
+  const raw = new Database(':memory:');
+  raw.pragma('foreign_keys = ON');
+  raw.exec(ENTITIES_DDL);
+  raw.exec(TAG_VOCABULARY_DDL);
+  raw.exec(TRANSACTION_TAG_RULES_DDL);
+  return { db: drizzle(raw), raw };
+}
+
+function seedEntity(harness: TestHarness, id: string, name: string): void {
+  harness.raw
+    .prepare(
+      `INSERT INTO entities (id, name, type, last_edited_time) VALUES (?, ?, 'company', ?)`
+    )
+    .run(id, name, new Date().toISOString());
+}
+
+describe('createTransactionTagRule', () => {
+  let harness: TestHarness;
+  beforeEach(() => {
+    harness = freshDb();
+  });
+
+  it('inserts a row with the supplied fields, JSON-encoded tags, and a generated UUID', () => {
+    const created = createTransactionTagRule(harness.db, {
+      descriptionPattern: 'UBER',
+      matchType: 'contains',
+      tags: ['Transport', 'Eat Out'],
+      confidence: 0.8,
+      priority: 5,
+    });
+
+    expect(created.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+    expect(created.descriptionPattern).toBe('UBER');
+    expect(created.matchType).toBe('contains');
+    expect(created.tags).toBe(JSON.stringify(['Transport', 'Eat Out']));
+    expect(created.confidence).toBe(0.8);
+    expect(created.priority).toBe(5);
+    expect(created.timesApplied).toBe(0);
+    expect(created.isActive).toBe(true);
+    expect(created.entityId).toBeNull();
+  });
+
+  it('applies legacy defaults: confidence=0.95, isActive=true, priority=0', () => {
+    const created = createTransactionTagRule(harness.db, {
+      descriptionPattern: 'COLES',
+      matchType: 'exact',
+      tags: ['Groceries'],
+    });
+
+    expect(created.confidence).toBe(0.95);
+    expect(created.isActive).toBe(true);
+    expect(created.priority).toBe(0);
+  });
+
+  it('honours the entity_id FK when the referenced entity exists', () => {
+    seedEntity(harness, 'ent-1', 'Acme');
+    const created = createTransactionTagRule(harness.db, {
+      descriptionPattern: 'ACME',
+      matchType: 'exact',
+      entityId: 'ent-1',
+      tags: ['Subscriptions'],
+    });
+    expect(created.entityId).toBe('ent-1');
+  });
+
+  it('rejects an insert that references a non-existent entity (SQLite FK)', () => {
+    expect(() =>
+      createTransactionTagRule(harness.db, {
+        descriptionPattern: 'GHOST',
+        matchType: 'exact',
+        entityId: 'does-not-exist',
+        tags: ['Unknown'],
+      })
+    ).toThrow(/FOREIGN KEY constraint failed/);
+  });
+
+  it('accepts tags not present in tag_vocabulary — there is no SQL FK on tags', () => {
+    upsertVocabularyTag(harness.db, 'Groceries', 'seed');
+    const created = createTransactionTagRule(harness.db, {
+      descriptionPattern: 'WEIRDPATTERN',
+      matchType: 'exact',
+      tags: ['NotInVocabulary'],
+    });
+    expect(JSON.parse(created.tags)).toEqual(['NotInVocabulary']);
+  });
+});
+
+describe('getTransactionTagRule', () => {
+  let harness: TestHarness;
+  beforeEach(() => {
+    harness = freshDb();
+  });
+
+  it('returns the row when present', () => {
+    const created = createTransactionTagRule(harness.db, {
+      descriptionPattern: 'STARBUCKS',
+      matchType: 'contains',
+      tags: ['Coffee'],
+    });
+    const fetched = getTransactionTagRule(harness.db, created.id);
+    expect(fetched.id).toBe(created.id);
+    expect(fetched.descriptionPattern).toBe('STARBUCKS');
+  });
+
+  it('throws TransactionTagRuleNotFoundError when the id is unknown', () => {
+    expect(() => getTransactionTagRule(harness.db, 'no-such-id')).toThrow(
+      TransactionTagRuleNotFoundError
+    );
+  });
+
+  it('attaches the id to the typed error', () => {
+    try {
+      getTransactionTagRule(harness.db, 'missing-id');
+      expect.fail('expected TransactionTagRuleNotFoundError');
+    } catch (err) {
+      expect(err).toBeInstanceOf(TransactionTagRuleNotFoundError);
+      if (err instanceof TransactionTagRuleNotFoundError) {
+        expect(err.id).toBe('missing-id');
+      }
+    }
+  });
+});
+
+describe('listTransactionTagRules', () => {
+  let harness: TestHarness;
+  beforeEach(() => {
+    harness = freshDb();
+  });
+
+  it('returns an empty array when the table is empty', () => {
+    expect(listTransactionTagRules(harness.db)).toEqual([]);
+  });
+
+  it('orders by (confidence DESC, times_applied DESC) to match the legacy router', () => {
+    const lowConf = createTransactionTagRule(harness.db, {
+      descriptionPattern: 'A',
+      matchType: 'exact',
+      tags: ['x'],
+      confidence: 0.3,
+    });
+    const midConf = createTransactionTagRule(harness.db, {
+      descriptionPattern: 'B',
+      matchType: 'exact',
+      tags: ['x'],
+      confidence: 0.7,
+    });
+    const highConf = createTransactionTagRule(harness.db, {
+      descriptionPattern: 'C',
+      matchType: 'exact',
+      tags: ['x'],
+      confidence: 0.95,
+    });
+    harness.raw
+      .prepare(`UPDATE transaction_tag_rules SET times_applied = 50 WHERE id = ?`)
+      .run(midConf.id);
+
+    const ordered = listTransactionTagRules(harness.db);
+    expect(ordered.map((r) => r.id)).toEqual([highConf.id, midConf.id, lowConf.id]);
+  });
+
+  it('breaks confidence ties by times_applied DESC', () => {
+    const first = createTransactionTagRule(harness.db, {
+      descriptionPattern: 'A',
+      matchType: 'exact',
+      tags: ['x'],
+      confidence: 0.5,
+    });
+    const second = createTransactionTagRule(harness.db, {
+      descriptionPattern: 'B',
+      matchType: 'exact',
+      tags: ['x'],
+      confidence: 0.5,
+    });
+    harness.raw
+      .prepare(`UPDATE transaction_tag_rules SET times_applied = 99 WHERE id = ?`)
+      .run(second.id);
+
+    const ordered = listTransactionTagRules(harness.db);
+    expect(ordered.map((r) => r.id)).toEqual([second.id, first.id]);
+  });
+});
+
+describe('updateTransactionTagRule', () => {
+  let harness: TestHarness;
+  beforeEach(() => {
+    harness = freshDb();
+  });
+
+  it('patches only the supplied fields, JSON-re-encoding tags on the way through', () => {
+    const created = createTransactionTagRule(harness.db, {
+      descriptionPattern: 'X',
+      matchType: 'exact',
+      tags: ['old'],
+      confidence: 0.5,
+    });
+
+    const updated = updateTransactionTagRule(harness.db, created.id, {
+      tags: ['new', 'tags'],
+      confidence: 0.9,
+    });
+
+    expect(updated.tags).toBe(JSON.stringify(['new', 'tags']));
+    expect(updated.confidence).toBe(0.9);
+    expect(updated.descriptionPattern).toBe('X');
+    expect(updated.matchType).toBe('exact');
+  });
+
+  it('treats an empty patch as a no-op but still returns the current row', () => {
+    const created = createTransactionTagRule(harness.db, {
+      descriptionPattern: 'Y',
+      matchType: 'exact',
+      tags: ['a'],
+    });
+    const result = updateTransactionTagRule(harness.db, created.id, {});
+    expect(result.id).toBe(created.id);
+    expect(result.tags).toBe(JSON.stringify(['a']));
+  });
+
+  it('clears entity_id when passed null', () => {
+    seedEntity(harness, 'ent-2', 'Beta');
+    const created = createTransactionTagRule(harness.db, {
+      descriptionPattern: 'BETA',
+      matchType: 'exact',
+      entityId: 'ent-2',
+      tags: ['x'],
+    });
+
+    const cleared = updateTransactionTagRule(harness.db, created.id, { entityId: null });
+    expect(cleared.entityId).toBeNull();
+  });
+
+  it('rejects an update that points entity_id at a non-existent entity', () => {
+    const created = createTransactionTagRule(harness.db, {
+      descriptionPattern: 'Z',
+      matchType: 'exact',
+      tags: ['x'],
+    });
+    expect(() =>
+      updateTransactionTagRule(harness.db, created.id, { entityId: 'phantom' })
+    ).toThrow(/FOREIGN KEY constraint failed/);
+  });
+
+  it('throws TransactionTagRuleNotFoundError for an unknown id', () => {
+    expect(() => updateTransactionTagRule(harness.db, 'missing', { confidence: 0.1 })).toThrow(
+      TransactionTagRuleNotFoundError
+    );
+  });
+});
+
+describe('disableTransactionTagRule', () => {
+  let harness: TestHarness;
+  beforeEach(() => {
+    harness = freshDb();
+  });
+
+  it('flips is_active to false and leaves the row in place', () => {
+    const created = createTransactionTagRule(harness.db, {
+      descriptionPattern: 'D',
+      matchType: 'exact',
+      tags: ['x'],
+    });
+
+    disableTransactionTagRule(harness.db, created.id);
+
+    const row = harness.db
+      .select()
+      .from(transactionTagRules)
+      .where(eq(transactionTagRules.id, created.id))
+      .get();
+    expect(row?.isActive).toBe(false);
+  });
+
+  it('throws when the id is unknown', () => {
+    expect(() => disableTransactionTagRule(harness.db, 'missing')).toThrow(
+      TransactionTagRuleNotFoundError
+    );
+  });
+});
+
+describe('deleteTransactionTagRule', () => {
+  let harness: TestHarness;
+  beforeEach(() => {
+    harness = freshDb();
+  });
+
+  it('hard-deletes the row', () => {
+    const created = createTransactionTagRule(harness.db, {
+      descriptionPattern: 'E',
+      matchType: 'exact',
+      tags: ['x'],
+    });
+
+    deleteTransactionTagRule(harness.db, created.id);
+    expect(listTransactionTagRules(harness.db)).toEqual([]);
+  });
+
+  it('throws when the id is unknown', () => {
+    expect(() => deleteTransactionTagRule(harness.db, 'ghost')).toThrow(
+      TransactionTagRuleNotFoundError
+    );
+  });
+});
+
+describe('tag_vocabulary sibling-table integration', () => {
+  let harness: TestHarness;
+  beforeEach(() => {
+    harness = freshDb();
+  });
+
+  it('exposes both schemas from the package barrel — tagVocabulary and transactionTagRules are wired', () => {
+    upsertVocabularyTag(harness.db, 'Coffee', 'seed');
+    upsertVocabularyTag(harness.db, 'Transport', 'seed');
+
+    const created = createTransactionTagRule(harness.db, {
+      descriptionPattern: 'UBER',
+      matchType: 'contains',
+      tags: ['Transport'],
+    });
+
+    const vocabRows = harness.db.select({ tag: tagVocabulary.tag }).from(tagVocabulary).all();
+    const ruleRow = harness.db
+      .select()
+      .from(transactionTagRules)
+      .where(eq(transactionTagRules.id, created.id))
+      .get();
+    expect(new Set(vocabRows.map((r) => r.tag))).toEqual(new Set(['Coffee', 'Transport']));
+    expect(JSON.parse(ruleRow?.tags ?? '[]')).toEqual(['Transport']);
+  });
+
+  it('does NOT reject a rule whose tags reference a missing vocabulary entry (no SQL FK on tags)', () => {
+    upsertVocabularyTag(harness.db, 'Coffee', 'seed');
+    expect(() =>
+      createTransactionTagRule(harness.db, {
+        descriptionPattern: 'X',
+        matchType: 'exact',
+        tags: ['DefinitelyNotSeeded'],
+      })
+    ).not.toThrow();
+  });
+});

--- a/packages/finance-db/src/errors.ts
+++ b/packages/finance-db/src/errors.ts
@@ -15,3 +15,13 @@ export class WishListItemNotFoundError extends Error {
     this.id = id;
   }
 }
+
+export class TransactionTagRuleNotFoundError extends Error {
+  override readonly name = 'TransactionTagRuleNotFoundError' as const;
+  readonly id: string;
+
+  constructor(id: string) {
+    super(`Transaction tag rule '${id}' not found`);
+    this.id = id;
+  }
+}

--- a/packages/finance-db/src/index.ts
+++ b/packages/finance-db/src/index.ts
@@ -6,10 +6,11 @@
  * `apps/pops-api/src/modules/finance/` as the first mature-pillar migration
  * following the core pilot, per ADR-026.
  *
- * Per the CI-never-breaks pattern the migration is incremental — this PR
- * scaffolds the package and moves only the `wish-list` slice. The other
- * slices (budgets, transactions, imports, tag rules, tag vocabulary, URI
- * dispatcher) follow in subsequent PRs.
+ * Per the CI-never-breaks pattern the migration is incremental. The
+ * shipped slices so far are wish-list, tag-vocabulary, and
+ * transaction-tag-rules (all scaffolded — cutover lands in later PRs).
+ * The remaining slices (budgets, transactions, transaction_corrections,
+ * imports, URI dispatcher) follow in subsequent PRs.
  */
 export * from './errors.js';
 export * from './schema.js';
@@ -33,3 +34,12 @@ export {
 export * as tagVocabularyService from './services/tag-vocabulary.js';
 
 export { type TagVocabularyRow, type TagVocabularySource } from './services/tag-vocabulary.js';
+
+export * as transactionTagRulesService from './services/transaction-tag-rules.js';
+
+export {
+  type TransactionTagRuleRow,
+  type TagRuleMatchType,
+  type CreateTransactionTagRuleInput,
+  type UpdateTransactionTagRuleInput,
+} from './services/transaction-tag-rules.js';

--- a/packages/finance-db/src/schema.ts
+++ b/packages/finance-db/src/schema.ts
@@ -10,4 +10,4 @@
  *
  * Mirrors the `@pops/core-db` schema re-export pattern.
  */
-export { tagVocabulary, wishList } from '@pops/db-types';
+export { tagVocabulary, transactionTagRules, wishList } from '@pops/db-types';

--- a/packages/finance-db/src/services/transaction-tag-rules.ts
+++ b/packages/finance-db/src/services/transaction-tag-rules.ts
@@ -41,10 +41,14 @@ export interface CreateTransactionTagRuleInput {
   priority?: number;
 }
 
-/** PATCH-style update — every field optional, `tags` still in parsed form. */
+/**
+ * PATCH-style update. Mirrors the legacy in-tree `TagRuleUpdateSchema`
+ * (`apps/pops-api/src/modules/core/tag-rules/types.ts`) which deliberately
+ * omits `descriptionPattern` and `matchType` — those fields define the
+ * rule's identity and are immutable post-create. To replace a pattern the
+ * caller deletes the old rule and creates a new one.
+ */
 export interface UpdateTransactionTagRuleInput {
-  descriptionPattern?: string;
-  matchType?: TagRuleMatchType;
   entityId?: string | null;
   tags?: string[];
   confidence?: number;
@@ -105,8 +109,6 @@ function buildTagRuleUpdates(
   input: UpdateTransactionTagRuleInput
 ): Partial<typeof transactionTagRules.$inferInsert> {
   const updates: Partial<typeof transactionTagRules.$inferInsert> = {};
-  if (input.descriptionPattern !== undefined) updates.descriptionPattern = input.descriptionPattern;
-  if (input.matchType !== undefined) updates.matchType = input.matchType;
   if (input.entityId !== undefined) updates.entityId = input.entityId ?? null;
   if (input.tags !== undefined) updates.tags = JSON.stringify(input.tags);
   if (input.confidence !== undefined) updates.confidence = input.confidence;

--- a/packages/finance-db/src/services/transaction-tag-rules.ts
+++ b/packages/finance-db/src/services/transaction-tag-rules.ts
@@ -68,11 +68,7 @@ export function listTransactionTagRules(db: FinanceDb): TransactionTagRuleRow[] 
 
 /** Get a single rule by id. Throws `TransactionTagRuleNotFoundError` if missing. */
 export function getTransactionTagRule(db: FinanceDb, id: string): TransactionTagRuleRow {
-  const row = db
-    .select()
-    .from(transactionTagRules)
-    .where(eq(transactionTagRules.id, id))
-    .get();
+  const row = db.select().from(transactionTagRules).where(eq(transactionTagRules.id, id)).get();
   if (!row) throw new TransactionTagRuleNotFoundError(id);
   return row;
 }
@@ -134,10 +130,7 @@ export function updateTransactionTagRule(
 
   const updates = buildTagRuleUpdates(input);
   if (Object.keys(updates).length > 0) {
-    db.update(transactionTagRules)
-      .set(updates)
-      .where(eq(transactionTagRules.id, id))
-      .run();
+    db.update(transactionTagRules).set(updates).where(eq(transactionTagRules.id, id)).run();
   }
 
   return getTransactionTagRule(db, id);
@@ -159,9 +152,6 @@ export function disableTransactionTagRule(db: FinanceDb, id: string): void {
 
 /** Hard-delete a rule. Throws if the id is unknown. */
 export function deleteTransactionTagRule(db: FinanceDb, id: string): void {
-  const result = db
-    .delete(transactionTagRules)
-    .where(eq(transactionTagRules.id, id))
-    .run();
+  const result = db.delete(transactionTagRules).where(eq(transactionTagRules.id, id)).run();
   if (result.changes === 0) throw new TransactionTagRuleNotFoundError(id);
 }

--- a/packages/finance-db/src/services/transaction-tag-rules.ts
+++ b/packages/finance-db/src/services/transaction-tag-rules.ts
@@ -1,0 +1,167 @@
+/**
+ * Transaction tag rule persistence for the finance domain.
+ *
+ * The `transaction_tag_rules` table holds the user's tag-suggestion rules:
+ * each row maps a description pattern (exact/contains/regex) to a list of
+ * suggested tags, optionally scoped to an entity. The `tags` column is a
+ * JSON-encoded `string[]` — there is no SQL foreign key from `tags` to
+ * `tag_vocabulary.tag` (the only schema-level FK is `entity_id` →
+ * `entities.id`). The logical relationship to the vocabulary is enforced
+ * at the application layer (see `preview.ts` in the in-tree consumer).
+ *
+ * The in-tree service at `apps/pops-api/src/modules/core/tag-rules/service.ts`
+ * still uses `getDrizzle()`; this package version takes a `FinanceDb` handle
+ * as its first argument so callers control the connection (and can pass a
+ * transaction). PR 3 of phase 1 flips the router to call into here.
+ *
+ * Mirrors the wish-list and tag-vocabulary patterns: db-arg services, plain
+ * functions, typed domain errors, no HTTP or tRPC concerns.
+ */
+import { desc, eq } from 'drizzle-orm';
+
+import { TransactionTagRuleNotFoundError } from '../errors.js';
+import { transactionTagRules } from '../schema.js';
+
+import type { FinanceDb } from './internal.js';
+
+/** Raw drizzle row shape. */
+export type TransactionTagRuleRow = typeof transactionTagRules.$inferSelect;
+
+/** Match strategy for the rule's description pattern. */
+export type TagRuleMatchType = 'exact' | 'contains' | 'regex';
+
+/** Mutable subset accepted on create. `tags` is the parsed `string[]` form. */
+export interface CreateTransactionTagRuleInput {
+  descriptionPattern: string;
+  matchType: TagRuleMatchType;
+  entityId?: string | null;
+  tags: string[];
+  confidence?: number;
+  isActive?: boolean;
+  priority?: number;
+}
+
+/** PATCH-style update — every field optional, `tags` still in parsed form. */
+export interface UpdateTransactionTagRuleInput {
+  descriptionPattern?: string;
+  matchType?: TagRuleMatchType;
+  entityId?: string | null;
+  tags?: string[];
+  confidence?: number;
+  isActive?: boolean;
+  priority?: number;
+}
+
+/**
+ * List every rule, ordered by `(confidence DESC, times_applied DESC)`.
+ *
+ * Matches the legacy in-tree ordering so the cutover (PR 3) does not
+ * change observed router behaviour.
+ */
+export function listTransactionTagRules(db: FinanceDb): TransactionTagRuleRow[] {
+  return db
+    .select()
+    .from(transactionTagRules)
+    .orderBy(desc(transactionTagRules.confidence), desc(transactionTagRules.timesApplied))
+    .all();
+}
+
+/** Get a single rule by id. Throws `TransactionTagRuleNotFoundError` if missing. */
+export function getTransactionTagRule(db: FinanceDb, id: string): TransactionTagRuleRow {
+  const row = db
+    .select()
+    .from(transactionTagRules)
+    .where(eq(transactionTagRules.id, id))
+    .get();
+  if (!row) throw new TransactionTagRuleNotFoundError(id);
+  return row;
+}
+
+/**
+ * Create a new tag rule. `tags` is JSON-encoded before insert.
+ *
+ * Defaults mirror the legacy in-tree `addTagRule` path: `confidence=0.95`,
+ * `isActive=true`, `priority=0`, `timesApplied=0`. The generated `id` is a
+ * UUID from drizzle's `$defaultFn`.
+ */
+export function createTransactionTagRule(
+  db: FinanceDb,
+  input: CreateTransactionTagRuleInput
+): TransactionTagRuleRow {
+  const inserted = db
+    .insert(transactionTagRules)
+    .values({
+      descriptionPattern: input.descriptionPattern,
+      matchType: input.matchType,
+      entityId: input.entityId ?? null,
+      tags: JSON.stringify(input.tags),
+      confidence: input.confidence ?? 0.95,
+      isActive: input.isActive ?? true,
+      priority: input.priority ?? 0,
+      timesApplied: 0,
+    })
+    .returning()
+    .get();
+  return inserted;
+}
+
+function buildTagRuleUpdates(
+  input: UpdateTransactionTagRuleInput
+): Partial<typeof transactionTagRules.$inferInsert> {
+  const updates: Partial<typeof transactionTagRules.$inferInsert> = {};
+  if (input.descriptionPattern !== undefined) updates.descriptionPattern = input.descriptionPattern;
+  if (input.matchType !== undefined) updates.matchType = input.matchType;
+  if (input.entityId !== undefined) updates.entityId = input.entityId ?? null;
+  if (input.tags !== undefined) updates.tags = JSON.stringify(input.tags);
+  if (input.confidence !== undefined) updates.confidence = input.confidence;
+  if (input.isActive !== undefined) updates.isActive = input.isActive;
+  if (input.priority !== undefined) updates.priority = input.priority;
+  return updates;
+}
+
+/**
+ * Patch a tag rule. Throws `TransactionTagRuleNotFoundError` if missing.
+ *
+ * An empty `input` is a no-op that still re-reads and returns the row, so
+ * callers can use this as a "fetch with optional patch" without branching.
+ */
+export function updateTransactionTagRule(
+  db: FinanceDb,
+  id: string,
+  input: UpdateTransactionTagRuleInput
+): TransactionTagRuleRow {
+  getTransactionTagRule(db, id);
+
+  const updates = buildTagRuleUpdates(input);
+  if (Object.keys(updates).length > 0) {
+    db.update(transactionTagRules)
+      .set(updates)
+      .where(eq(transactionTagRules.id, id))
+      .run();
+  }
+
+  return getTransactionTagRule(db, id);
+}
+
+/**
+ * Soft-delete: flip `is_active` to `false`. Throws if the id is unknown.
+ *
+ * The legacy in-tree path uses this for the changeSet `disable` op.
+ */
+export function disableTransactionTagRule(db: FinanceDb, id: string): void {
+  const result = db
+    .update(transactionTagRules)
+    .set({ isActive: false })
+    .where(eq(transactionTagRules.id, id))
+    .run();
+  if (result.changes === 0) throw new TransactionTagRuleNotFoundError(id);
+}
+
+/** Hard-delete a rule. Throws if the id is unknown. */
+export function deleteTransactionTagRule(db: FinanceDb, id: string): void {
+  const result = db
+    .delete(transactionTagRules)
+    .where(eq(transactionTagRules.id, id))
+    .run();
+  if (result.changes === 0) throw new TransactionTagRuleNotFoundError(id);
+}


### PR DESCRIPTION
Deferred-backlog row [N4](https://github.com/knoxio/pops/blob/main/.claude/pillar-migration-roadmap.md) — `transaction_tag_rules` slice migration into `@pops/finance-db`. Tracked as #2840. This is **phase 1 PR 1 of 4** — scaffold + tests only, no router cutover.

## What

- New service module at `packages/finance-db/src/services/transaction-tag-rules.ts` — `FinanceDb`-arg functions (`list`, `get`, `create`, `update`, `disable`, `delete`) mirroring the legacy in-tree `apps/pops-api/src/modules/core/tag-rules/service.ts` shape, including the legacy `(confidence DESC, times_applied DESC)` ordering and the default `confidence=0.95 / isActive=true / priority=0` insert path.
- Typed domain error `TransactionTagRuleNotFoundError` in `packages/finance-db/src/errors.ts`, mapped on miss-by-id paths. No HTTP awareness in the package.
- `transactionTagRules` re-exported from the package's schema barrel alongside `tagVocabulary` (the N5 re-export from #2852).
- New `transactionTagRulesService` namespace + `TransactionTagRuleRow` / `TagRuleMatchType` / `CreateTransactionTagRuleInput` / `UpdateTransactionTagRuleInput` exported from the package's top-level barrel.
- Vitest suite at `packages/finance-db/src/__tests__/transaction-tag-rules.test.ts` (22 tests / 7 describes) covering:
  - generated-UUID + JSON-encoded `tags` on insert;
  - legacy defaults (confidence 0.95, isActive true, priority 0);
  - `entity_id` FK honoured (`foreign_keys = ON`) — both insert and update reject phantom entity ids with `FOREIGN KEY constraint failed`;
  - `entityId: null` patch path clears the FK;
  - the **logical** `tags` ↔ `tag_vocabulary` relationship — no SQL FK exists on the JSON `tags` column, and the service correctly accepts tags that are not in the vocabulary (the in-tree consumer enforces this at the preview layer, not the schema layer);
  - sibling-table fixture proves both `tagVocabulary` and `transactionTagRules` are wired from the package barrel — co-seeded vocabulary and rule round-trip through the package's exports;
  - typed-error round-trip on every miss path (`get`, `update`, `disable`, `delete`).

## Where the in-tree consumer actually lives

`apps/pops-api/src/modules/core/tag-rules/service.ts` — **under `modules/core/tag-rules/`, not `modules/finance/`**. Same directory as N5's `vocabulary.ts`. The audit classified both N5 and N4 as finance slices because the **tables** are owned by finance (DDL in 0026 / 0027), but the **consumer modules** live under `modules/core/tag-rules/`. Phase 1 PR 3 will face the same scoping decision N5's PR 3 will: route the consumer through `@pops/finance-db` (keeping the slice "finance-owned") vs reclassify the slice as core. Decision deferred to PR 3.

## FK to tag_vocabulary

The task brief said `transaction_tag_rules` has a sibling-table FK to `tag_vocabulary.tag`. Reading the schema and `packages/finance-db/migrations/0026_little_frank_castle.sql`, that is not actually true at the SQL layer:

- The only SQL FK on `transaction_tag_rules` is `entity_id` → `entities(id) ON DELETE SET NULL`.
- The `tags` column is `text NOT NULL DEFAULT '[]'` storing a JSON-encoded `string[]`. There is no `FOREIGN KEY (tags) REFERENCES tag_vocabulary(tag)` clause.
- The relationship to the vocabulary is enforced at the application layer (`apps/pops-api/src/modules/core/tag-rules/preview.ts` reads `listVocabulary()` and marks `isNew` on suggestions).

The test suite documents this explicitly: one test asserts the entity FK is rejected, another asserts the tag-vocabulary "FK" is NOT enforced. The N5 PR 1 [#2852](https://github.com/knoxio/pops/pull/2852) re-export from the package barrel is still useful because the preview layer will need it when it migrates in a later PR — the sibling-table integration test exercises that wiring today.

## Deferred to later PRs

- **PR 2** — migration journal copy review. Per the N5 PR 1 lessons (see roadmap), 0026 / 0027 already shipped to the package journal as part of Track E's wish-list PR 2, so the table DDL and the priority ALTER are already byte-identical in the package. PR 2 may collapse to a no-op (re-confirm before opening) — same situation N5 ran into.
- **PR 3** — cutover. Flip `apps/pops-api/src/modules/core/tag-rules/service.ts` (and `tag-rules.test.ts`) to call `transactionTagRulesService.*` against `getFinanceDrizzle()`. Decide on the modules/core scoping at the same time N5 PR 3 does (likely the same call for both — they share the directory).
- **PR 4** — delete the in-tree service module after one release-cycle window per the wish-list lesson.

## Test plan

- [x] `pnpm --filter @pops/finance-db test` — 4 files / 50 tests, all green (22 new).
- [x] `pnpm typecheck` — 45 packages, all green.
- [x] `pnpm --filter @pops/api test` — 299 files / 4842 tests, all green.
- [x] `pnpm lint` — only pre-existing warnings (none from this PR's diff).
- [x] `pnpm build` — all green.

## Refs

- Pattern reference: PR #2766 (wish-list pilot — phase 1 PR 1).
- Sibling slice: PR #2852 (N5 tag_vocabulary phase 1 PR 1, merged `e54e3f7d`). N4 depends on the N5 schema re-export from #2852 to seed `tag_vocabulary` in its sibling-table test — that dep is already on `main`.
- Tracking issue: #2840.
