### PR TITLE
feat(finance-db): scaffold transaction_corrections slice (Track N3 phase 1 PR 1)

### DIFF
--- a/packages/finance-db/src/__tests__/transaction-corrections.test.ts
+++ b/packages/finance-db/src/__tests__/transaction-corrections.test.ts
@@ -233,6 +233,21 @@ describe('createOrUpdateTransactionCorrection — conflict path', () => {
     expect(after.confidence).toBe(1.0);
   });
 
+  it('overwrites tags with [] on the conflict path when input.tags is omitted (in-tree fidelity)', () => {
+    const id = seedCorrection(harness.raw, {
+      descriptionPattern: 'COFFEE',
+      matchType: 'exact',
+      tags: JSON.stringify(['old-tag']),
+    });
+
+    const after = createOrUpdateTransactionCorrection(harness.db, {
+      descriptionPattern: 'coffee',
+      matchType: 'exact',
+    });
+    expect(after.id).toBe(id);
+    expect(after.tags).toBe('[]');
+  });
+
   it('preserves existing entity fields when input fields are undefined', () => {
     const id = seedCorrection(harness.raw, {
       descriptionPattern: 'COFFEE',

--- a/packages/finance-db/src/__tests__/transaction-corrections.test.ts
+++ b/packages/finance-db/src/__tests__/transaction-corrections.test.ts
@@ -1,0 +1,758 @@
+/**
+ * Invariant tests for the transaction-corrections service against an
+ * in-memory SQLite seeded with the canonical `transaction_corrections`
+ * DDL. Pure DB + service layer — no tRPC, no Express, no auth middleware.
+ *
+ * The DDL inlined here is the post-baseline shape — i.e. the table after
+ * 0000 (baseline), 0025 (`is_active`), 0026 (mid-2025 columns), and 0027
+ * (`priority`) have all been applied. The full migration journal already
+ * has package coverage in `open-finance-db.test.ts`; this suite owns the
+ * narrower service-contract invariants and keeps the fixture lean so each
+ * test can run against a fresh table without paying the
+ * hundreds-of-tables baseline cost.
+ *
+ * Note: `entity_id` is intentionally NOT given a FK constraint in this
+ * inlined DDL — the production schema's `references(entities.id)` is
+ * outside the scope of this slice's service contract and dragging the
+ * `entities` table in would make the fixture brittle. The service does
+ * not depend on FK enforcement for correctness.
+ */
+import Database from 'better-sqlite3';
+import { eq } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { TransactionCorrectionNotFoundError } from '../errors.js';
+import { transactionCorrections } from '../schema.js';
+import {
+  adjustTransactionCorrectionConfidence,
+  createOrUpdateTransactionCorrection,
+  deleteTransactionCorrection,
+  findAllMatchingTransactionCorrections,
+  findAllMatchingTransactionCorrectionsFromDb,
+  getTransactionCorrection,
+  incrementTransactionCorrectionUsage,
+  listTransactionCorrections,
+  normalizeDescription,
+  updateTransactionCorrection,
+} from '../services/transaction-corrections.js';
+
+import type { FinanceDb } from '../services/internal.js';
+
+const TRANSACTION_CORRECTIONS_DDL = `
+CREATE TABLE transaction_corrections (
+  id text PRIMARY KEY NOT NULL,
+  description_pattern text NOT NULL,
+  match_type text DEFAULT 'exact' NOT NULL,
+  entity_id text,
+  entity_name text,
+  location text,
+  tags text DEFAULT '[]' NOT NULL,
+  transaction_type text,
+  is_active integer DEFAULT 1 NOT NULL,
+  confidence real DEFAULT 0.5 NOT NULL,
+  priority integer DEFAULT 0 NOT NULL,
+  times_applied integer DEFAULT 0 NOT NULL,
+  created_at text DEFAULT (datetime('now')) NOT NULL,
+  last_used_at text
+);
+CREATE INDEX idx_corrections_pattern ON transaction_corrections (description_pattern);
+CREATE INDEX idx_corrections_priority ON transaction_corrections (priority);
+CREATE INDEX idx_corrections_confidence ON transaction_corrections (confidence);
+CREATE INDEX idx_corrections_times_applied ON transaction_corrections (times_applied);
+`;
+
+interface TestHarness {
+  db: FinanceDb;
+  raw: Database.Database;
+}
+
+function freshDb(): TestHarness {
+  const raw = new Database(':memory:');
+  raw.pragma('foreign_keys = ON');
+  raw.exec(TRANSACTION_CORRECTIONS_DDL);
+  return { db: drizzle(raw), raw };
+}
+
+function seedCorrection(
+  raw: Database.Database,
+  overrides: Partial<{
+    id: string;
+    descriptionPattern: string;
+    matchType: 'exact' | 'contains' | 'regex';
+    entityId: string | null;
+    entityName: string | null;
+    location: string | null;
+    tags: string;
+    transactionType: 'purchase' | 'transfer' | 'income' | null;
+    isActive: 0 | 1;
+    confidence: number;
+    priority: number;
+    timesApplied: number;
+    lastUsedAt: string | null;
+  }> = {}
+): string {
+  const id = overrides.id ?? crypto.randomUUID();
+  raw
+    .prepare(
+      `INSERT INTO transaction_corrections (
+        id, description_pattern, match_type, entity_id, entity_name, location,
+        tags, transaction_type, is_active, confidence, priority, times_applied,
+        last_used_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    )
+    .run(
+      id,
+      overrides.descriptionPattern ?? 'COFFEE SHOP',
+      overrides.matchType ?? 'exact',
+      overrides.entityId ?? null,
+      overrides.entityName ?? null,
+      overrides.location ?? null,
+      overrides.tags ?? '[]',
+      overrides.transactionType ?? null,
+      overrides.isActive ?? 1,
+      overrides.confidence ?? 0.5,
+      overrides.priority ?? 0,
+      overrides.timesApplied ?? 0,
+      overrides.lastUsedAt ?? null
+    );
+  return id;
+}
+
+describe('normalizeDescription', () => {
+  it('uppercases, strips digits, collapses whitespace, and trims', () => {
+    expect(normalizeDescription('  starbucks   42  store 7 ')).toBe('STARBUCKS STORE');
+  });
+
+  it('returns an empty string when the input is digits + whitespace only', () => {
+    expect(normalizeDescription('   123  456  ')).toBe('');
+  });
+
+  it('is idempotent — passing a normalised value through is a no-op', () => {
+    const once = normalizeDescription('Café Latte 12');
+    expect(normalizeDescription(once)).toBe(once);
+  });
+});
+
+describe('createOrUpdateTransactionCorrection — insert path', () => {
+  let harness: TestHarness;
+  beforeEach(() => {
+    harness = freshDb();
+  });
+
+  it('normalises descriptionPattern and persists the row with defaults', () => {
+    const created = createOrUpdateTransactionCorrection(harness.db, {
+      descriptionPattern: 'Coffee  Shop 42',
+      matchType: 'exact',
+    });
+
+    expect(created.descriptionPattern).toBe('COFFEE SHOP');
+    expect(created.matchType).toBe('exact');
+    expect(created.entityId).toBeNull();
+    expect(created.entityName).toBeNull();
+    expect(created.location).toBeNull();
+    expect(created.tags).toBe('[]');
+    expect(created.transactionType).toBeNull();
+    expect(created.isActive).toBe(true);
+    expect(created.confidence).toBe(0.5);
+    expect(created.priority).toBe(0);
+    expect(created.timesApplied).toBe(0);
+    expect(created.lastUsedAt).toBeNull();
+    expect(created.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+  });
+
+  it('serialises tags into the on-disk JSON string', () => {
+    const created = createOrUpdateTransactionCorrection(harness.db, {
+      descriptionPattern: 'Foo',
+      matchType: 'exact',
+      tags: ['groceries', 'fresh'],
+    });
+    expect(created.tags).toBe(JSON.stringify(['groceries', 'fresh']));
+  });
+
+  it('honours caller-supplied entity / location / priority on insert', () => {
+    const created = createOrUpdateTransactionCorrection(harness.db, {
+      descriptionPattern: 'Foo',
+      matchType: 'contains',
+      entityId: 'entity-1',
+      entityName: 'Foo Bar',
+      location: 'Sydney',
+      transactionType: 'purchase',
+      priority: 5,
+    });
+    expect(created.matchType).toBe('contains');
+    expect(created.entityId).toBe('entity-1');
+    expect(created.entityName).toBe('Foo Bar');
+    expect(created.location).toBe('Sydney');
+    expect(created.transactionType).toBe('purchase');
+    expect(created.priority).toBe(5);
+  });
+});
+
+describe('createOrUpdateTransactionCorrection — conflict path', () => {
+  let harness: TestHarness;
+  beforeEach(() => {
+    harness = freshDb();
+  });
+
+  it('reinforces the existing row when (normalised pattern, matchType) collides', () => {
+    const first = createOrUpdateTransactionCorrection(harness.db, {
+      descriptionPattern: 'Foo Bar 1',
+      matchType: 'exact',
+      entityName: 'Original',
+    });
+    expect(first.confidence).toBe(0.5);
+    expect(first.timesApplied).toBe(0);
+    expect(first.lastUsedAt).toBeNull();
+
+    const second = createOrUpdateTransactionCorrection(harness.db, {
+      descriptionPattern: 'foo bar 999',
+      matchType: 'exact',
+      entityName: 'Updated',
+    });
+
+    expect(second.id).toBe(first.id);
+    expect(second.confidence).toBeCloseTo(0.6, 5);
+    expect(second.timesApplied).toBe(1);
+    expect(second.lastUsedAt).not.toBeNull();
+    expect(second.entityName).toBe('Updated');
+  });
+
+  it('caps confidence at 1.0 on the conflict path', () => {
+    const id = seedCorrection(harness.raw, {
+      descriptionPattern: 'COFFEE',
+      matchType: 'exact',
+      confidence: 0.95,
+    });
+
+    const after = createOrUpdateTransactionCorrection(harness.db, {
+      descriptionPattern: 'coffee',
+      matchType: 'exact',
+    });
+    expect(after.id).toBe(id);
+    expect(after.confidence).toBe(1.0);
+  });
+
+  it('preserves existing entity fields when input fields are undefined', () => {
+    const id = seedCorrection(harness.raw, {
+      descriptionPattern: 'COFFEE',
+      matchType: 'exact',
+      entityId: 'kept-entity',
+      entityName: 'Kept Name',
+      location: 'Kept Loc',
+      transactionType: 'income',
+      priority: 7,
+    });
+
+    const after = createOrUpdateTransactionCorrection(harness.db, {
+      descriptionPattern: 'coffee',
+      matchType: 'exact',
+    });
+    expect(after.id).toBe(id);
+    expect(after.entityId).toBe('kept-entity');
+    expect(after.entityName).toBe('Kept Name');
+    expect(after.location).toBe('Kept Loc');
+    expect(after.transactionType).toBe('income');
+    expect(after.priority).toBe(7);
+  });
+
+  it('reactivates a soft-deleted row on conflict (isActive flips back to true)', () => {
+    seedCorrection(harness.raw, {
+      descriptionPattern: 'COFFEE',
+      matchType: 'exact',
+      isActive: 0,
+    });
+
+    const after = createOrUpdateTransactionCorrection(harness.db, {
+      descriptionPattern: 'coffee',
+      matchType: 'exact',
+    });
+    expect(after.isActive).toBe(true);
+  });
+
+  it('treats matchType as part of the key — same pattern, different type, inserts a new row', () => {
+    const first = createOrUpdateTransactionCorrection(harness.db, {
+      descriptionPattern: 'Foo',
+      matchType: 'exact',
+    });
+    const second = createOrUpdateTransactionCorrection(harness.db, {
+      descriptionPattern: 'Foo',
+      matchType: 'contains',
+    });
+
+    expect(second.id).not.toBe(first.id);
+    expect(harness.db.select().from(transactionCorrections).all()).toHaveLength(2);
+  });
+});
+
+describe('getTransactionCorrection', () => {
+  let harness: TestHarness;
+  beforeEach(() => {
+    harness = freshDb();
+  });
+
+  it('returns the row by id', () => {
+    const id = seedCorrection(harness.raw);
+    const row = getTransactionCorrection(harness.db, id);
+    expect(row.id).toBe(id);
+  });
+
+  it('throws TransactionCorrectionNotFoundError for an unknown id', () => {
+    expect(() => getTransactionCorrection(harness.db, 'missing')).toThrow(
+      TransactionCorrectionNotFoundError
+    );
+  });
+
+  it('carries the offending id on the thrown error', () => {
+    try {
+      getTransactionCorrection(harness.db, 'bad-id');
+      expect.fail('expected throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(TransactionCorrectionNotFoundError);
+      if (err instanceof TransactionCorrectionNotFoundError) {
+        expect(err.id).toBe('bad-id');
+      }
+    }
+  });
+});
+
+describe('listTransactionCorrections', () => {
+  let harness: TestHarness;
+  beforeEach(() => {
+    harness = freshDb();
+    seedCorrection(harness.raw, {
+      descriptionPattern: 'A',
+      matchType: 'exact',
+      confidence: 0.6,
+      timesApplied: 3,
+    });
+    seedCorrection(harness.raw, {
+      descriptionPattern: 'B',
+      matchType: 'contains',
+      confidence: 0.9,
+      timesApplied: 1,
+    });
+    seedCorrection(harness.raw, {
+      descriptionPattern: 'C',
+      matchType: 'regex',
+      confidence: 0.9,
+      timesApplied: 10,
+    });
+  });
+
+  it('orders rows by confidence DESC then timesApplied DESC and reports total', () => {
+    const result = listTransactionCorrections(harness.db, { limit: 50, offset: 0 });
+    expect(result.total).toBe(3);
+    expect(result.rows.map((r) => r.descriptionPattern)).toEqual(['C', 'B', 'A']);
+  });
+
+  it('filters by minConfidence (inclusive lower bound)', () => {
+    const result = listTransactionCorrections(harness.db, {
+      minConfidence: 0.9,
+      limit: 50,
+      offset: 0,
+    });
+    expect(result.total).toBe(2);
+    expect(result.rows.every((r) => r.confidence >= 0.9)).toBe(true);
+  });
+
+  it('filters by matchType equality', () => {
+    const result = listTransactionCorrections(harness.db, {
+      matchType: 'contains',
+      limit: 50,
+      offset: 0,
+    });
+    expect(result.total).toBe(1);
+    expect(result.rows[0]?.matchType).toBe('contains');
+  });
+
+  it('paginates via limit + offset and reports the unpaginated total', () => {
+    const page1 = listTransactionCorrections(harness.db, { limit: 2, offset: 0 });
+    const page2 = listTransactionCorrections(harness.db, { limit: 2, offset: 2 });
+    expect(page1.total).toBe(3);
+    expect(page1.rows).toHaveLength(2);
+    expect(page2.total).toBe(3);
+    expect(page2.rows).toHaveLength(1);
+  });
+
+  it('returns an empty result when nothing matches the filters', () => {
+    const result = listTransactionCorrections(harness.db, {
+      minConfidence: 0.999,
+      limit: 50,
+      offset: 0,
+    });
+    expect(result.total).toBe(0);
+    expect(result.rows).toEqual([]);
+  });
+});
+
+describe('updateTransactionCorrection', () => {
+  let harness: TestHarness;
+  beforeEach(() => {
+    harness = freshDb();
+  });
+
+  it('patches only the supplied fields', () => {
+    const id = seedCorrection(harness.raw, {
+      descriptionPattern: 'OLD',
+      matchType: 'exact',
+      confidence: 0.6,
+    });
+
+    const updated = updateTransactionCorrection(harness.db, id, {
+      confidence: 0.95,
+      isActive: false,
+      location: 'Melbourne',
+    });
+    expect(updated.confidence).toBe(0.95);
+    expect(updated.isActive).toBe(false);
+    expect(updated.location).toBe('Melbourne');
+    expect(updated.descriptionPattern).toBe('OLD');
+    expect(updated.matchType).toBe('exact');
+  });
+
+  it('normalises descriptionPattern on edit', () => {
+    const id = seedCorrection(harness.raw);
+    const updated = updateTransactionCorrection(harness.db, id, {
+      descriptionPattern: '  new   pattern 42 ',
+    });
+    expect(updated.descriptionPattern).toBe('NEW PATTERN');
+  });
+
+  it('treats explicit null as a value (clears the field)', () => {
+    const id = seedCorrection(harness.raw, { location: 'Sydney', entityId: 'e-1' });
+    const updated = updateTransactionCorrection(harness.db, id, {
+      location: null,
+      entityId: null,
+    });
+    expect(updated.location).toBeNull();
+    expect(updated.entityId).toBeNull();
+  });
+
+  it('serialises tags into JSON on update', () => {
+    const id = seedCorrection(harness.raw);
+    const updated = updateTransactionCorrection(harness.db, id, { tags: ['x', 'y'] });
+    expect(updated.tags).toBe(JSON.stringify(['x', 'y']));
+  });
+
+  it('is a no-op when the patch is empty — returns the row unchanged', () => {
+    const id = seedCorrection(harness.raw, { confidence: 0.42, priority: 3 });
+    const before = getTransactionCorrection(harness.db, id);
+    const after = updateTransactionCorrection(harness.db, id, {});
+    expect(after).toEqual(before);
+  });
+
+  it('throws TransactionCorrectionNotFoundError when the row is missing', () => {
+    expect(() => updateTransactionCorrection(harness.db, 'missing', { confidence: 0.5 })).toThrow(
+      TransactionCorrectionNotFoundError
+    );
+  });
+});
+
+describe('deleteTransactionCorrection', () => {
+  let harness: TestHarness;
+  beforeEach(() => {
+    harness = freshDb();
+  });
+
+  it('removes the row and subsequent get throws', () => {
+    const id = seedCorrection(harness.raw);
+    deleteTransactionCorrection(harness.db, id);
+    expect(() => getTransactionCorrection(harness.db, id)).toThrow(
+      TransactionCorrectionNotFoundError
+    );
+  });
+
+  it('throws TransactionCorrectionNotFoundError when the row is already gone', () => {
+    expect(() => deleteTransactionCorrection(harness.db, 'missing')).toThrow(
+      TransactionCorrectionNotFoundError
+    );
+  });
+});
+
+describe('incrementTransactionCorrectionUsage', () => {
+  let harness: TestHarness;
+  beforeEach(() => {
+    harness = freshDb();
+  });
+
+  it('bumps timesApplied by 1 and stamps lastUsedAt', () => {
+    const id = seedCorrection(harness.raw, { timesApplied: 7 });
+    incrementTransactionCorrectionUsage(harness.db, id);
+
+    const row = getTransactionCorrection(harness.db, id);
+    expect(row.timesApplied).toBe(8);
+    expect(row.lastUsedAt).not.toBeNull();
+  });
+
+  it('does not touch other rows', () => {
+    const targetId = seedCorrection(harness.raw, {
+      descriptionPattern: 'A',
+      matchType: 'exact',
+      timesApplied: 1,
+    });
+    const otherId = seedCorrection(harness.raw, {
+      descriptionPattern: 'B',
+      matchType: 'exact',
+      timesApplied: 5,
+    });
+    incrementTransactionCorrectionUsage(harness.db, targetId);
+
+    const target = getTransactionCorrection(harness.db, targetId);
+    const other = getTransactionCorrection(harness.db, otherId);
+    expect(target.timesApplied).toBe(2);
+    expect(other.timesApplied).toBe(5);
+    expect(other.lastUsedAt).toBeNull();
+  });
+
+  it('silently no-ops when the id does not exist', () => {
+    expect(() => incrementTransactionCorrectionUsage(harness.db, 'missing')).not.toThrow();
+  });
+});
+
+describe('adjustTransactionCorrectionConfidence', () => {
+  let harness: TestHarness;
+  beforeEach(() => {
+    harness = freshDb();
+  });
+
+  it('adds delta to the existing confidence', () => {
+    const id = seedCorrection(harness.raw, { confidence: 0.5 });
+    adjustTransactionCorrectionConfidence(harness.db, id, 0.2);
+    expect(getTransactionCorrection(harness.db, id).confidence).toBeCloseTo(0.7, 5);
+  });
+
+  it('clamps the new confidence to [0, 1]', () => {
+    const id = seedCorrection(harness.raw, { confidence: 0.9 });
+    adjustTransactionCorrectionConfidence(harness.db, id, 0.5);
+    expect(getTransactionCorrection(harness.db, id).confidence).toBe(1);
+  });
+
+  it('deletes the row when the new confidence drops below 0.3', () => {
+    const id = seedCorrection(harness.raw, { confidence: 0.4 });
+    adjustTransactionCorrectionConfidence(harness.db, id, -0.2);
+    expect(() => getTransactionCorrection(harness.db, id)).toThrow(
+      TransactionCorrectionNotFoundError
+    );
+  });
+
+  it('keeps the row when the new confidence is exactly 0.3', () => {
+    const id = seedCorrection(harness.raw, { confidence: 0.5 });
+    adjustTransactionCorrectionConfidence(harness.db, id, -0.2);
+    expect(getTransactionCorrection(harness.db, id).confidence).toBeCloseTo(0.3, 5);
+  });
+
+  it('throws TransactionCorrectionNotFoundError when the row is missing', () => {
+    expect(() => adjustTransactionCorrectionConfidence(harness.db, 'missing', 0.1)).toThrow(
+      TransactionCorrectionNotFoundError
+    );
+  });
+});
+
+describe('findAllMatchingTransactionCorrectionsFromDb', () => {
+  let harness: TestHarness;
+  beforeEach(() => {
+    harness = freshDb();
+  });
+
+  it('returns active matches ordered by priority ASC then id ASC', () => {
+    seedCorrection(harness.raw, {
+      id: 'rule-z',
+      descriptionPattern: 'COFFEE',
+      matchType: 'exact',
+      confidence: 0.9,
+      priority: 5,
+    });
+    seedCorrection(harness.raw, {
+      id: 'rule-a',
+      descriptionPattern: 'COFFEE',
+      matchType: 'exact',
+      confidence: 0.9,
+      priority: 1,
+    });
+    seedCorrection(harness.raw, {
+      id: 'rule-b',
+      descriptionPattern: 'COFFEE',
+      matchType: 'exact',
+      confidence: 0.9,
+      priority: 1,
+    });
+
+    const matches = findAllMatchingTransactionCorrectionsFromDb(harness.db, 'Coffee 42');
+    expect(matches.map((m) => m.id)).toEqual(['rule-a', 'rule-b', 'rule-z']);
+  });
+
+  it('honours minConfidence as an inclusive lower bound', () => {
+    seedCorrection(harness.raw, {
+      descriptionPattern: 'COFFEE',
+      matchType: 'exact',
+      confidence: 0.7,
+    });
+    seedCorrection(harness.raw, {
+      descriptionPattern: 'COFFEE',
+      matchType: 'exact',
+      confidence: 0.65,
+    });
+
+    expect(findAllMatchingTransactionCorrectionsFromDb(harness.db, 'coffee', 0.7)).toHaveLength(1);
+    expect(findAllMatchingTransactionCorrectionsFromDb(harness.db, 'coffee', 0.6)).toHaveLength(2);
+  });
+
+  it('ignores inactive rules', () => {
+    seedCorrection(harness.raw, {
+      descriptionPattern: 'COFFEE',
+      matchType: 'exact',
+      confidence: 0.9,
+      isActive: 0,
+    });
+    expect(findAllMatchingTransactionCorrectionsFromDb(harness.db, 'coffee')).toEqual([]);
+  });
+
+  it('honours contains and regex matchType semantics', () => {
+    seedCorrection(harness.raw, {
+      id: 'contains-rule',
+      descriptionPattern: 'COFFEE',
+      matchType: 'contains',
+      confidence: 0.9,
+    });
+    seedCorrection(harness.raw, {
+      id: 'regex-rule',
+      descriptionPattern: '^STAR.*BUCKS$',
+      matchType: 'regex',
+      confidence: 0.9,
+    });
+
+    const containsHit = findAllMatchingTransactionCorrectionsFromDb(
+      harness.db,
+      'morning coffee at home'
+    );
+    expect(containsHit.map((r) => r.id)).toEqual(['contains-rule']);
+
+    const regexHit = findAllMatchingTransactionCorrectionsFromDb(harness.db, 'Starbucks');
+    expect(regexHit.map((r) => r.id)).toEqual(['regex-rule']);
+  });
+
+  it('silently drops regex rules with invalid patterns', () => {
+    seedCorrection(harness.raw, {
+      descriptionPattern: '[invalid(',
+      matchType: 'regex',
+      confidence: 0.9,
+    });
+    expect(findAllMatchingTransactionCorrectionsFromDb(harness.db, 'anything')).toEqual([]);
+  });
+
+  it('returns an empty array when nothing matches', () => {
+    seedCorrection(harness.raw, {
+      descriptionPattern: 'COFFEE',
+      matchType: 'exact',
+      confidence: 0.9,
+    });
+    expect(findAllMatchingTransactionCorrectionsFromDb(harness.db, 'restaurant')).toEqual([]);
+  });
+});
+
+describe('findAllMatchingTransactionCorrections', () => {
+  let harness: TestHarness;
+  beforeEach(() => {
+    harness = freshDb();
+  });
+
+  it('groups results as [exact, contains, regex] in matchType order', () => {
+    seedCorrection(harness.raw, {
+      id: 'exact-rule',
+      descriptionPattern: 'COFFEE',
+      matchType: 'exact',
+      confidence: 0.7,
+    });
+    seedCorrection(harness.raw, {
+      id: 'contains-rule',
+      descriptionPattern: 'COFFEE',
+      matchType: 'contains',
+      confidence: 0.95,
+    });
+    seedCorrection(harness.raw, {
+      id: 'regex-rule',
+      descriptionPattern: 'COFFEE',
+      matchType: 'regex',
+      confidence: 0.99,
+    });
+
+    const matches = findAllMatchingTransactionCorrections(harness.db, 'coffee');
+    expect(matches.map((m) => m.id)).toEqual(['exact-rule', 'contains-rule', 'regex-rule']);
+  });
+
+  it('sorts within each group by confidence DESC then timesApplied DESC', () => {
+    seedCorrection(harness.raw, {
+      id: 'low-conf',
+      descriptionPattern: 'COFFEE',
+      matchType: 'contains',
+      confidence: 0.7,
+      timesApplied: 10,
+    });
+    seedCorrection(harness.raw, {
+      id: 'high-conf-low-uses',
+      descriptionPattern: 'COFFEE',
+      matchType: 'contains',
+      confidence: 0.95,
+      timesApplied: 1,
+    });
+    seedCorrection(harness.raw, {
+      id: 'high-conf-high-uses',
+      descriptionPattern: 'COFFEE',
+      matchType: 'contains',
+      confidence: 0.95,
+      timesApplied: 5,
+    });
+
+    const matches = findAllMatchingTransactionCorrections(harness.db, 'coffee');
+    expect(matches.map((m) => m.id)).toEqual([
+      'high-conf-high-uses',
+      'high-conf-low-uses',
+      'low-conf',
+    ]);
+  });
+
+  it('ignores inactive rules across all match types', () => {
+    seedCorrection(harness.raw, {
+      descriptionPattern: 'COFFEE',
+      matchType: 'exact',
+      isActive: 0,
+    });
+    seedCorrection(harness.raw, {
+      descriptionPattern: 'COFFEE',
+      matchType: 'contains',
+      isActive: 0,
+    });
+    seedCorrection(harness.raw, {
+      descriptionPattern: 'COFFEE',
+      matchType: 'regex',
+      isActive: 0,
+    });
+    expect(findAllMatchingTransactionCorrections(harness.db, 'coffee')).toEqual([]);
+  });
+
+  it('silently drops regex rules with invalid patterns', () => {
+    seedCorrection(harness.raw, {
+      descriptionPattern: '[invalid(',
+      matchType: 'regex',
+    });
+    expect(findAllMatchingTransactionCorrections(harness.db, 'anything')).toEqual([]);
+  });
+
+  it('returns an empty array when nothing matches', () => {
+    expect(findAllMatchingTransactionCorrections(harness.db, 'restaurant')).toEqual([]);
+  });
+});
+
+describe('row type sanity', () => {
+  it('select round-trips boolean isActive correctly', () => {
+    const harness = freshDb();
+    const id = seedCorrection(harness.raw, { isActive: 1 });
+    const row = harness.db
+      .select()
+      .from(transactionCorrections)
+      .where(eq(transactionCorrections.id, id))
+      .get();
+    expect(row?.isActive).toBe(true);
+  });
+});

--- a/packages/finance-db/src/errors.ts
+++ b/packages/finance-db/src/errors.ts
@@ -78,3 +78,13 @@ export class BudgetConflictError extends Error {
     this.period = period;
   }
 }
+
+export class TransactionCorrectionNotFoundError extends Error {
+  override readonly name = 'TransactionCorrectionNotFoundError' as const;
+  readonly id: string;
+
+  constructor(id: string) {
+    super(`Transaction correction '${id}' not found`);
+    this.id = id;
+  }
+}

--- a/packages/finance-db/src/index.ts
+++ b/packages/finance-db/src/index.ts
@@ -7,10 +7,10 @@
  * following the core pilot, per ADR-026.
  *
  * Per the CI-never-breaks pattern the migration is incremental. The
- * shipped slices so far are wish-list, tag-vocabulary, and
- * transaction-tag-rules (all scaffolded — cutover lands in later PRs).
- * The remaining slices (budgets, transactions, transaction_corrections,
- * imports, URI dispatcher) follow in subsequent PRs.
+ * shipped slices so far are wish-list, tag-vocabulary, transaction-tag-rules,
+ * and transaction-corrections (all scaffolded — cutover lands in later PRs).
+ * The remaining slices (budgets, transactions, imports, URI dispatcher)
+ * follow in subsequent PRs.
  */
 export * from './errors.js';
 export * from './schema.js';
@@ -63,6 +63,7 @@ export type {
   ImportTransactionRow,
   CreateImportEntityResult,
 } from './services/imports.js';
+<<<<<<< HEAD
 export * as budgetsService from './services/budgets.js';
 
 export type {
@@ -73,3 +74,17 @@ export type {
   UpdateBudgetInput,
   ListBudgetsOptions,
 } from './services/budgets.js';
+||||||| parent of 3d22937f (feat(finance-db): scaffold transaction_corrections slice (Track N3 phase 1 PR 1))
+=======
+export * as transactionCorrectionsService from './services/transaction-corrections.js';
+
+export {
+  type TransactionCorrectionRow,
+  type TransactionCorrectionMatchType,
+  type TransactionCorrectionTransactionType,
+  type CreateTransactionCorrectionInput,
+  type UpdateTransactionCorrectionInput,
+  type TransactionCorrectionListResult,
+  type TransactionCorrectionListQuery,
+} from './services/transaction-corrections.js';
+>>>>>>> 3d22937f (feat(finance-db): scaffold transaction_corrections slice (Track N3 phase 1 PR 1))

--- a/packages/finance-db/src/index.ts
+++ b/packages/finance-db/src/index.ts
@@ -63,7 +63,7 @@ export type {
   ImportTransactionRow,
   CreateImportEntityResult,
 } from './services/imports.js';
-<<<<<<< HEAD
+
 export * as budgetsService from './services/budgets.js';
 
 export type {
@@ -74,8 +74,7 @@ export type {
   UpdateBudgetInput,
   ListBudgetsOptions,
 } from './services/budgets.js';
-||||||| parent of 3d22937f (feat(finance-db): scaffold transaction_corrections slice (Track N3 phase 1 PR 1))
-=======
+
 export * as transactionCorrectionsService from './services/transaction-corrections.js';
 
 export {
@@ -87,4 +86,3 @@ export {
   type TransactionCorrectionListResult,
   type TransactionCorrectionListQuery,
 } from './services/transaction-corrections.js';
->>>>>>> 3d22937f (feat(finance-db): scaffold transaction_corrections slice (Track N3 phase 1 PR 1))

--- a/packages/finance-db/src/services/transaction-corrections-matching.ts
+++ b/packages/finance-db/src/services/transaction-corrections-matching.ts
@@ -1,0 +1,135 @@
+/**
+ * Read-only matchers against `transaction_corrections`.
+ *
+ * Split out from `transaction-corrections.ts` so neither file exceeds the
+ * 200-line cap. CRUD lives there; pattern matching lives here. Both
+ * surface through the `transactionCorrectionsService` namespace on the
+ * package barrel and the in-tree consumer treats them as one slice.
+ */
+import { and, asc, desc, eq, gte, sql } from 'drizzle-orm';
+
+import { transactionCorrections } from '../schema.js';
+import {
+  normalizeDescription,
+  type TransactionCorrectionRow,
+} from './transaction-corrections-types.js';
+
+import type { FinanceDb } from './internal.js';
+
+function ruleMatchesNormalizedDescription(
+  rule: TransactionCorrectionRow,
+  normalized: string
+): boolean {
+  const pattern = rule.descriptionPattern;
+  switch (rule.matchType) {
+    case 'exact':
+      return pattern.toUpperCase() === normalized;
+    case 'contains':
+      return pattern.length > 0 && normalized.includes(pattern.toUpperCase());
+    case 'regex':
+      if (pattern.length === 0) return false;
+      try {
+        return new RegExp(pattern, 'i').test(normalized);
+      } catch {
+        return false;
+      }
+    default:
+      return false;
+  }
+}
+
+/**
+ * Return every active correction whose pattern matches `description`, in
+ * priority order (priority ASC, id ASC as tie-breaker).
+ *
+ * Filters out rules below `minConfidence` and inactive rules before the
+ * in-memory pattern test, mirroring the in-tree
+ * `findAllMatchingCorrectionFromDB` semantics.
+ */
+export function findAllMatchingTransactionCorrectionsFromDb(
+  db: FinanceDb,
+  description: string,
+  minConfidence: number = 0.7
+): TransactionCorrectionRow[] {
+  const normalized = normalizeDescription(description);
+
+  const candidates = db
+    .select()
+    .from(transactionCorrections)
+    .where(
+      and(
+        eq(transactionCorrections.isActive, true),
+        gte(transactionCorrections.confidence, minConfidence)
+      )
+    )
+    .orderBy(asc(transactionCorrections.priority), asc(transactionCorrections.id))
+    .all();
+
+  return candidates.filter((rule) => ruleMatchesNormalizedDescription(rule, normalized));
+}
+
+/**
+ * Return every active correction whose pattern matches `description`, grouped
+ * by `matchType` in `[exact, contains, regex]` order, with each group sorted
+ * by `confidence DESC, timesApplied DESC`.
+ *
+ * Used by callers that need to surface all matches (not just the winning
+ * rule) to the user — typically the rule-management UI.
+ *
+ * Regex rules with invalid patterns are silently dropped so a single
+ * malformed entry can't poison the result.
+ */
+export function findAllMatchingTransactionCorrections(
+  db: FinanceDb,
+  description: string
+): TransactionCorrectionRow[] {
+  const normalized = normalizeDescription(description);
+
+  const exactMatches = db
+    .select()
+    .from(transactionCorrections)
+    .where(
+      and(
+        eq(transactionCorrections.isActive, true),
+        eq(transactionCorrections.matchType, 'exact'),
+        eq(transactionCorrections.descriptionPattern, normalized)
+      )
+    )
+    .orderBy(desc(transactionCorrections.confidence), desc(transactionCorrections.timesApplied))
+    .all();
+
+  const containsMatches = db
+    .select()
+    .from(transactionCorrections)
+    .where(
+      and(
+        eq(transactionCorrections.isActive, true),
+        eq(transactionCorrections.matchType, 'contains'),
+        sql`${normalized} LIKE '%' || ${transactionCorrections.descriptionPattern} || '%'`
+      )
+    )
+    .orderBy(desc(transactionCorrections.confidence), desc(transactionCorrections.timesApplied))
+    .all();
+
+  const regexCandidates = db
+    .select()
+    .from(transactionCorrections)
+    .where(
+      and(eq(transactionCorrections.isActive, true), eq(transactionCorrections.matchType, 'regex'))
+    )
+    .orderBy(desc(transactionCorrections.confidence), desc(transactionCorrections.timesApplied))
+    .all();
+
+  const regexMatches: TransactionCorrectionRow[] = [];
+  for (const row of regexCandidates) {
+    try {
+      if (new RegExp(row.descriptionPattern).test(normalized)) {
+        regexMatches.push(row);
+      }
+    } catch {
+      // skip invalid regex pattern — see fn doc-comment
+    }
+  }
+
+  return [...exactMatches, ...containsMatches, ...regexMatches];
+}

--- a/packages/finance-db/src/services/transaction-corrections-types.ts
+++ b/packages/finance-db/src/services/transaction-corrections-types.ts
@@ -1,0 +1,75 @@
+/**
+ * Public types for the transaction-corrections slice.
+ *
+ * Split from `transaction-corrections.ts` so neither file exceeds the
+ * 200-line cap. CRUD handlers live in `transaction-corrections.ts`,
+ * matchers in `transaction-corrections-matching.ts`, both consume the
+ * types declared here.
+ */
+import type { transactionCorrections } from '../schema.js';
+
+/** Raw drizzle row shape — matches the persisted `transaction_corrections` record. */
+export type TransactionCorrectionRow = typeof transactionCorrections.$inferSelect;
+
+/** Discriminant for how `descriptionPattern` is interpreted against an incoming description. */
+export type TransactionCorrectionMatchType = 'exact' | 'contains' | 'regex';
+
+/** Optional `transaction_type` tag stamped onto the matched transaction. */
+export type TransactionCorrectionTransactionType = 'purchase' | 'transfer' | 'income';
+
+/**
+ * Mutable subset accepted on create / upsert.
+ *
+ * `tags` is the structured form callers pass in; the service layer is
+ * responsible for serialising it into the on-disk JSON string the schema
+ * stores.
+ */
+export interface CreateTransactionCorrectionInput {
+  descriptionPattern: string;
+  matchType: TransactionCorrectionMatchType;
+  entityId?: string | null;
+  entityName?: string | null;
+  location?: string | null;
+  tags?: string[];
+  transactionType?: TransactionCorrectionTransactionType | null;
+  priority?: number;
+}
+
+/** PATCH-semantic update input — every field is optional. */
+export interface UpdateTransactionCorrectionInput {
+  descriptionPattern?: string;
+  matchType?: TransactionCorrectionMatchType;
+  entityId?: string | null;
+  entityName?: string | null;
+  location?: string | null;
+  tags?: string[];
+  transactionType?: TransactionCorrectionTransactionType | null;
+  isActive?: boolean;
+  confidence?: number;
+  priority?: number;
+}
+
+/** Result of a paginated list call. */
+export interface TransactionCorrectionListResult {
+  rows: TransactionCorrectionRow[];
+  total: number;
+}
+
+/** Filters + pagination accepted by `listTransactionCorrections`. */
+export interface TransactionCorrectionListQuery {
+  minConfidence?: number;
+  matchType?: TransactionCorrectionMatchType;
+  limit: number;
+  offset: number;
+}
+
+/**
+ * Canonical pattern normalisation used by the matcher and on insert/update.
+ *
+ * Uppercases, strips digits, collapses whitespace, and trims. Kept identical
+ * to the in-tree implementation so a cutover (PR 3) is a routing flip — not
+ * a behavioural change.
+ */
+export function normalizeDescription(description: string): string {
+  return description.toUpperCase().replaceAll(/\d+/g, '').replaceAll(/\s+/g, ' ').trim();
+}

--- a/packages/finance-db/src/services/transaction-corrections.ts
+++ b/packages/finance-db/src/services/transaction-corrections.ts
@@ -1,0 +1,261 @@
+/**
+ * Transaction-corrections CRUD for the finance domain.
+ *
+ * The `transaction_corrections` table stores learned patterns derived from
+ * user-supplied corrections of imported transactions. Matching is a
+ * priority-ordered scan over active rules — see PRD-024 and PRD-032 for
+ * the runtime semantics this layer preserves.
+ *
+ * The in-tree service at
+ * `apps/pops-api/src/modules/core/corrections/handlers/query-helpers.ts`
+ * (and its sibling `pattern-match.ts`) still uses `getDrizzle()`; this
+ * package version takes a `FinanceDb` handle as its first argument. PR 3 of
+ * phase 1 flips the in-tree call sites to call into here.
+ *
+ * Mirrors the wish-list pattern: db-arg services, plain functions, typed
+ * domain errors, no HTTP or tRPC concerns. Higher-level orchestrations
+ * (changesets, AI rewrites, preview helpers) stay in-tree — they layer on
+ * top of these primitives and migrate later in the slice cutover.
+ *
+ * The file is intentionally split into three siblings to stay under the
+ * 200-line cap: types + normalisation in `transaction-corrections-types.ts`,
+ * read-only matchers in `transaction-corrections-matching.ts`, write CRUD
+ * here. All three surface through the `transactionCorrectionsService`
+ * namespace on the package barrel.
+ */
+import { and, count, desc, eq, gte, sql } from 'drizzle-orm';
+
+import { TransactionCorrectionNotFoundError } from '../errors.js';
+import { transactionCorrections } from '../schema.js';
+import {
+  normalizeDescription,
+  type CreateTransactionCorrectionInput,
+  type TransactionCorrectionListQuery,
+  type TransactionCorrectionListResult,
+  type TransactionCorrectionRow,
+  type UpdateTransactionCorrectionInput,
+} from './transaction-corrections-types.js';
+
+import type { FinanceDb } from './internal.js';
+
+export * from './transaction-corrections-types.js';
+export {
+  findAllMatchingTransactionCorrections,
+  findAllMatchingTransactionCorrectionsFromDb,
+} from './transaction-corrections-matching.js';
+
+/**
+ * List corrections, ordered by `confidence DESC, timesApplied DESC`,
+ * with optional minimum confidence and match-type filters.
+ *
+ * Returns both the paginated rows and the unpaginated total so the router
+ * can render pagination controls without a second round trip.
+ */
+export function listTransactionCorrections(
+  db: FinanceDb,
+  query: TransactionCorrectionListQuery
+): TransactionCorrectionListResult {
+  const { minConfidence, matchType, limit, offset } = query;
+  const conditions = [];
+  if (minConfidence !== undefined) {
+    conditions.push(gte(transactionCorrections.confidence, minConfidence));
+  }
+  if (matchType) {
+    conditions.push(eq(transactionCorrections.matchType, matchType));
+  }
+  const where = conditions.length > 0 ? and(...conditions) : undefined;
+
+  const countRow = db.select({ total: count() }).from(transactionCorrections).where(where).all()[0];
+
+  const rows = db
+    .select()
+    .from(transactionCorrections)
+    .where(where)
+    .orderBy(desc(transactionCorrections.confidence), desc(transactionCorrections.timesApplied))
+    .limit(limit)
+    .offset(offset)
+    .all();
+
+  return { rows, total: countRow?.total ?? 0 };
+}
+
+/** Get a single correction by id. Throws `TransactionCorrectionNotFoundError` if missing. */
+export function getTransactionCorrection(db: FinanceDb, id: string): TransactionCorrectionRow {
+  const row = db
+    .select()
+    .from(transactionCorrections)
+    .where(eq(transactionCorrections.id, id))
+    .get();
+  if (!row) throw new TransactionCorrectionNotFoundError(id);
+  return row;
+}
+
+function reinforceExistingCorrection(
+  db: FinanceDb,
+  existing: TransactionCorrectionRow,
+  input: CreateTransactionCorrectionInput
+): TransactionCorrectionRow {
+  db.update(transactionCorrections)
+    .set({
+      confidence: Math.min(existing.confidence + 0.1, 1.0),
+      timesApplied: existing.timesApplied + 1,
+      lastUsedAt: new Date().toISOString(),
+      entityId: input.entityId ?? existing.entityId,
+      entityName: input.entityName ?? existing.entityName,
+      location: input.location ?? existing.location,
+      tags: JSON.stringify(input.tags ?? []),
+      transactionType: input.transactionType ?? existing.transactionType,
+      priority: input.priority ?? existing.priority,
+      isActive: true,
+    })
+    .where(eq(transactionCorrections.id, existing.id))
+    .run();
+  return getTransactionCorrection(db, existing.id);
+}
+
+function insertNewCorrection(
+  db: FinanceDb,
+  input: CreateTransactionCorrectionInput,
+  normalized: string
+): TransactionCorrectionRow {
+  const result = db
+    .insert(transactionCorrections)
+    .values({
+      descriptionPattern: normalized,
+      matchType: input.matchType,
+      entityId: input.entityId ?? null,
+      entityName: input.entityName ?? null,
+      location: input.location ?? null,
+      tags: JSON.stringify(input.tags ?? []),
+      transactionType: input.transactionType ?? null,
+      priority: input.priority ?? 0,
+      isActive: true,
+    })
+    .run();
+
+  const inserted = db
+    .select()
+    .from(transactionCorrections)
+    .where(sql`rowid = ${result.lastInsertRowid}`)
+    .get();
+
+  if (!inserted) throw new TransactionCorrectionNotFoundError(String(result.lastInsertRowid));
+  return inserted;
+}
+
+/**
+ * Upsert a correction keyed on `(normalized descriptionPattern, matchType)`.
+ *
+ * On hit, the row is "reinforced" — confidence is bumped by 0.1 (capped at 1.0),
+ * `timesApplied` is incremented, `lastUsedAt` is stamped, optional fields are
+ * overlaid with non-null values from `input`, and `isActive` is reset to true.
+ * On miss, a new row is inserted with confidence + timesApplied left at the
+ * schema defaults (0.5 and 0 respectively).
+ */
+export function createOrUpdateTransactionCorrection(
+  db: FinanceDb,
+  input: CreateTransactionCorrectionInput
+): TransactionCorrectionRow {
+  const normalized = normalizeDescription(input.descriptionPattern);
+
+  const existing = db
+    .select()
+    .from(transactionCorrections)
+    .where(
+      and(
+        eq(transactionCorrections.descriptionPattern, normalized),
+        eq(transactionCorrections.matchType, input.matchType)
+      )
+    )
+    .get();
+
+  if (existing) return reinforceExistingCorrection(db, existing, input);
+  return insertNewCorrection(db, input, normalized);
+}
+
+function buildCorrectionUpdates(
+  input: UpdateTransactionCorrectionInput
+): Partial<typeof transactionCorrections.$inferInsert> {
+  const updates: Partial<typeof transactionCorrections.$inferInsert> = {};
+  if (input.descriptionPattern !== undefined) {
+    updates.descriptionPattern = normalizeDescription(input.descriptionPattern);
+  }
+  if (input.matchType !== undefined) updates.matchType = input.matchType;
+  if (input.entityId !== undefined) updates.entityId = input.entityId;
+  if (input.entityName !== undefined) updates.entityName = input.entityName;
+  if (input.location !== undefined) updates.location = input.location;
+  if (input.tags !== undefined) updates.tags = JSON.stringify(input.tags);
+  if (input.transactionType !== undefined) updates.transactionType = input.transactionType;
+  if (input.isActive !== undefined) updates.isActive = input.isActive;
+  if (input.confidence !== undefined) updates.confidence = input.confidence;
+  if (input.priority !== undefined) updates.priority = input.priority;
+  return updates;
+}
+
+/**
+ * PATCH a correction. Throws `TransactionCorrectionNotFoundError` if missing.
+ * Empty input still re-reads the row but skips the UPDATE — mirrors the
+ * in-tree behaviour the routers already depend on.
+ */
+export function updateTransactionCorrection(
+  db: FinanceDb,
+  id: string,
+  input: UpdateTransactionCorrectionInput
+): TransactionCorrectionRow {
+  const existing = getTransactionCorrection(db, id);
+  const updates = buildCorrectionUpdates(input);
+
+  if (Object.keys(updates).length === 0) return existing;
+
+  db.update(transactionCorrections).set(updates).where(eq(transactionCorrections.id, id)).run();
+
+  return getTransactionCorrection(db, id);
+}
+
+/** Delete a correction. Throws `TransactionCorrectionNotFoundError` if it never existed. */
+export function deleteTransactionCorrection(db: FinanceDb, id: string): void {
+  const result = db.delete(transactionCorrections).where(eq(transactionCorrections.id, id)).run();
+  if (result.changes === 0) throw new TransactionCorrectionNotFoundError(id);
+}
+
+/**
+ * Bump `timesApplied` and stamp `lastUsedAt` without otherwise touching the row.
+ *
+ * Silently no-ops if `id` does not exist — the in-tree caller treats this as
+ * a best-effort telemetry update inside the import pipeline and doesn't want
+ * the surrounding transaction to fail on a stale id.
+ */
+export function incrementTransactionCorrectionUsage(db: FinanceDb, id: string): void {
+  db.update(transactionCorrections)
+    .set({
+      timesApplied: sql`${transactionCorrections.timesApplied} + 1`,
+      lastUsedAt: new Date().toISOString(),
+    })
+    .where(eq(transactionCorrections.id, id))
+    .run();
+}
+
+/**
+ * Nudge a correction's confidence by `delta`, clamped to `[0, 1]`.
+ *
+ * When the resulting confidence is below 0.3 the row is deleted — the import
+ * pipeline uses this to garbage-collect rules that the user has consistently
+ * rejected. Throws `TransactionCorrectionNotFoundError` if `id` is missing.
+ */
+export function adjustTransactionCorrectionConfidence(
+  db: FinanceDb,
+  id: string,
+  delta: number
+): void {
+  const existing = getTransactionCorrection(db, id);
+  const newConfidence = Math.max(0, Math.min(1, existing.confidence + delta));
+
+  db.update(transactionCorrections)
+    .set({ confidence: newConfidence })
+    .where(eq(transactionCorrections.id, id))
+    .run();
+
+  if (newConfidence < 0.3) {
+    deleteTransactionCorrection(db, id);
+  }
+}

--- a/packages/finance-db/src/services/transaction-corrections.ts
+++ b/packages/finance-db/src/services/transaction-corrections.ts
@@ -147,8 +147,15 @@ function insertNewCorrection(
  * Upsert a correction keyed on `(normalized descriptionPattern, matchType)`.
  *
  * On hit, the row is "reinforced" — confidence is bumped by 0.1 (capped at 1.0),
- * `timesApplied` is incremented, `lastUsedAt` is stamped, optional fields are
- * overlaid with non-null values from `input`, and `isActive` is reset to true.
+ * `timesApplied` is incremented, `lastUsedAt` is stamped, `isActive` is reset
+ * to true, the `entityId` / `entityName` / `location` / `transactionType` /
+ * `priority` fields are overlaid with the input only when the input value is
+ * non-null (a `null` keeps the existing value), and `tags` is always
+ * overwritten by `input.tags ?? []`. The last item is intentional and
+ * matches the in-tree behaviour the cutover (PR 3) preserves — omitting
+ * `tags` from a reinforcement clears them. Pass the existing tags through
+ * explicitly if you want to keep them.
+ *
  * On miss, a new row is inserted with confidence + timesApplied left at the
  * schema defaults (0.5 and 0 respectively).
  */


### PR DESCRIPTION
## Summary

Scaffolds the `transaction_corrections` slice inside `@pops/finance-db` — db-arg CRUD + the two read-only matchers — without yet flipping the in-tree consumer.

Phase 1 PR 1 of Track N3's 4-PR sequence:
- **PR 1 (this)**: scaffold + tests
- **PR 2**: package journal alignment (TBD — the table is already covered by `0000`/`0025`/`0026`/`0027` in the package journal per `open-finance-db.test.ts`; may not need a dedicated PR)
- **PR 3**: cutover — flip the in-tree consumer at `apps/pops-api/src/modules/core/corrections/handlers/{query-helpers,pattern-match}.ts` to route through `@pops/finance-db`
- **PR 4**: delete the in-tree implementation

Reference patterns: [#2766](https://github.com/knoxio/pops/pull/2766) (wish-list pilot) and [#2852](https://github.com/knoxio/pops/pull/2852) (tag_vocabulary).

Closes the scaffold step of #2839 — keep open until PR 4 lands.

## Scoping decision

Like `tag_vocabulary` (N5), the audit said `transaction_corrections` lives under `apps/pops-api/src/modules/finance/imports/lib/*`. The survey turned up a different story:

- The **canonical** in-tree service is at `apps/pops-api/src/modules/core/corrections/` — under `modules/core`, not `modules/finance`. The finance imports pipeline (`reclassify-existing.ts`, the imports tests) only **consumes** the service; it doesn't own the CRUD.
- The narrowest correct slice is therefore the schema + the CRUD/matching service surface that lives in `modules/core/corrections/handlers/{query-helpers,pattern-match}.ts`.

What this PR moves into `@pops/finance-db/services/transaction-corrections{,-types,-matching}.ts`:

- `listTransactionCorrections`
- `getTransactionCorrection`
- `createOrUpdateTransactionCorrection` (with the reinforcement / insert split factored as private helpers)
- `updateTransactionCorrection`
- `deleteTransactionCorrection`
- `incrementTransactionCorrectionUsage`
- `adjustTransactionCorrectionConfidence`
- `findAllMatchingTransactionCorrectionsFromDb`
- `findAllMatchingTransactionCorrections`
- `normalizeDescription` (kept identical so the cutover is a pure routing flip)

What this PR deliberately **leaves in-tree** for PR 3 / the cutover:

- `pure-service.ts` — already pure in-memory; no DB dependency, no need to live in `@pops/finance-db`
- `handlers/apply-corrections.ts`, `handlers/compute-changeset.ts`, `handlers/preview-matches.ts`, `handlers/ai-inference.ts`, `handlers/changeset-builders.ts` — higher-level orchestrations that layer on top of the primitives above. Their churn surface, dependence on the changeset / AI subsystems, and lack of a clean drizzle-only contract means they're a poor fit for the `FinanceDb`-arg pattern.

PR 3's cutover will also have to make the same modules-core-vs-modules-finance routing decision tag_vocabulary already flagged.

## Test plan

- [x] `pnpm --filter @pops/finance-db test` — **49** new tests covering normalisation, insert/upsert reinforcement paths, confidence clamping, soft-deleted reactivation, the `(pattern, matchType)` composite key, the empty-patch no-op, all not-found error paths, telemetry no-op semantics, the confidence-driven GC threshold (incl. the inclusive `0.3` boundary), priority-ordered matching, contains/regex semantics, invalid-regex robustness, and the matchType-grouped result ordering. 75 total in the package suite.
- [x] `pnpm typecheck` — clean across 45 packages
- [x] `pnpm --filter @pops/api test` — 4842 / 4842 passing; no in-tree consumer touched
- [x] `pnpm lint` — clean (the only lint errors observed were the file-size cap on the initial single-file scaffold, hence the 3-sibling split documented in the file header)
- [x] `pnpm build` — clean