### PR TITLE
feat(finance-db): scaffold imports slice (Track N6 phase 1 PR 1)

### DIFF
--- a/packages/finance-db/src/__tests__/imports.test.ts
+++ b/packages/finance-db/src/__tests__/imports.test.ts
@@ -1,0 +1,434 @@
+/**
+ * Invariant tests for the imports persistence helpers against an
+ * in-memory SQLite seeded with the canonical `transactions` + `entities`
+ * DDL. Pure DB + service layer — no transformers, no AI categoriser, no
+ * tRPC, no Express.
+ *
+ * Higher-level orchestration coverage (transformer pipeline, AI matching,
+ * progress streaming, commit phase) stays in pops-api until later PRs of
+ * the N6 sequence — Phase 1 PR 1 is scaffold-only.
+ *
+ * The DDL is inlined rather than read from the shared baseline migration
+ * (`0000_naive_chameleon.sql`) because that migration creates the entire
+ * pre-modular schema (hundreds of tables) and applying it for every test
+ * here is wasted work. The byte-identical DDL is reproduced from
+ * `packages/db-types/src/schema/{transactions,entities}.ts`.
+ */
+import Database from 'better-sqlite3';
+import { eq } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { ImportTransactionPersistError } from '../errors.js';
+import { entities, transactions } from '../schema.js';
+import {
+  createImportEntity,
+  findExistingChecksums,
+  insertImportTransaction,
+  loadEntityMaps,
+} from '../services/imports.js';
+
+import type { FinanceDb } from '../services/internal.js';
+
+const SCHEMA_DDL = `
+CREATE TABLE entities (
+  id text PRIMARY KEY NOT NULL,
+  notion_id text,
+  name text NOT NULL,
+  type text DEFAULT 'company' NOT NULL,
+  abn text,
+  aliases text,
+  default_transaction_type text,
+  default_tags text,
+  notes text,
+  last_edited_time text NOT NULL
+);
+CREATE UNIQUE INDEX entities_notion_id_unique ON entities (notion_id);
+
+CREATE TABLE transactions (
+  id text PRIMARY KEY NOT NULL,
+  notion_id text,
+  description text NOT NULL,
+  account text NOT NULL,
+  amount real NOT NULL,
+  date text NOT NULL,
+  type text NOT NULL,
+  tags text DEFAULT '[]' NOT NULL,
+  entity_id text,
+  entity_name text,
+  location text,
+  country text,
+  related_transaction_id text,
+  notes text,
+  checksum text,
+  raw_row text,
+  last_edited_time text NOT NULL,
+  FOREIGN KEY (entity_id) REFERENCES entities(id) ON DELETE SET NULL
+);
+CREATE UNIQUE INDEX transactions_notion_id_unique ON transactions (notion_id);
+CREATE INDEX idx_transactions_date ON transactions (date);
+CREATE INDEX idx_transactions_account ON transactions (account);
+CREATE INDEX idx_transactions_entity ON transactions (entity_id);
+CREATE INDEX idx_transactions_last_edited ON transactions (last_edited_time);
+CREATE INDEX idx_transactions_notion_id ON transactions (notion_id);
+CREATE UNIQUE INDEX idx_transactions_checksum ON transactions (checksum);
+`;
+
+interface TestHarness {
+  db: FinanceDb;
+  raw: Database.Database;
+}
+
+function freshDb(): TestHarness {
+  const raw = new Database(':memory:');
+  raw.pragma('foreign_keys = ON');
+  raw.exec(SCHEMA_DDL);
+  return { db: drizzle(raw), raw };
+}
+
+function seedEntity(
+  db: FinanceDb,
+  input: { id?: string; name: string; aliases?: string | null }
+): string {
+  const id = input.id ?? crypto.randomUUID();
+  db.insert(entities)
+    .values({
+      id,
+      name: input.name,
+      aliases: input.aliases ?? null,
+      lastEditedTime: new Date().toISOString(),
+    })
+    .run();
+  return id;
+}
+
+function seedTransaction(
+  db: FinanceDb,
+  input: { description?: string; checksum?: string | null; date?: string; account?: string }
+): string {
+  const id = crypto.randomUUID();
+  db.insert(transactions)
+    .values({
+      id,
+      description: input.description ?? 'seed txn',
+      account: input.account ?? 'amex',
+      amount: -10,
+      date: input.date ?? '2026-01-01',
+      type: 'Expense',
+      tags: '[]',
+      entityId: null,
+      entityName: null,
+      location: null,
+      checksum: input.checksum ?? null,
+      rawRow: null,
+      lastEditedTime: new Date().toISOString(),
+    })
+    .run();
+  return id;
+}
+
+describe('findExistingChecksums', () => {
+  let harness: TestHarness;
+  beforeEach(() => {
+    harness = freshDb();
+  });
+
+  it('returns an empty set without querying when the input is empty', () => {
+    const result = findExistingChecksums(harness.db, []);
+    expect(result.size).toBe(0);
+  });
+
+  it('returns an empty set when no checksums are present', () => {
+    seedTransaction(harness.db, { checksum: 'a' });
+    const result = findExistingChecksums(harness.db, ['b', 'c']);
+    expect(result.size).toBe(0);
+  });
+
+  it('returns only the checksums that already exist', () => {
+    seedTransaction(harness.db, { checksum: 'aaa' });
+    seedTransaction(harness.db, { checksum: 'bbb' });
+    seedTransaction(harness.db, { checksum: 'ccc' });
+
+    const result = findExistingChecksums(harness.db, ['aaa', 'bbb', 'ddd']);
+
+    expect([...result].toSorted()).toEqual(['aaa', 'bbb']);
+  });
+
+  it('ignores transactions with a null checksum', () => {
+    seedTransaction(harness.db, { checksum: null });
+    seedTransaction(harness.db, { checksum: 'kept' });
+
+    const result = findExistingChecksums(harness.db, ['kept']);
+
+    expect([...result]).toEqual(['kept']);
+  });
+
+  it('deduplicates the result even if the same checksum is asked for twice', () => {
+    seedTransaction(harness.db, { checksum: 'shared' });
+    const result = findExistingChecksums(harness.db, ['shared', 'shared', 'other']);
+    expect(result.size).toBe(1);
+    expect(result.has('shared')).toBe(true);
+  });
+
+  it('handles input larger than the 500-row batch size', () => {
+    const present: string[] = [];
+    for (let i = 0; i < 25; i++) {
+      const checksum = `present-${i}`;
+      seedTransaction(harness.db, { checksum });
+      present.push(checksum);
+    }
+
+    const absent: string[] = [];
+    for (let i = 0; i < 1200; i++) absent.push(`absent-${i}`);
+
+    const result = findExistingChecksums(harness.db, [...absent, ...present]);
+
+    expect(result.size).toBe(present.length);
+    for (const c of present) expect(result.has(c)).toBe(true);
+  });
+});
+
+describe('loadEntityMaps', () => {
+  let harness: TestHarness;
+  beforeEach(() => {
+    harness = freshDb();
+  });
+
+  it('returns empty maps when no entities exist', () => {
+    const { entityLookup, aliasMap } = loadEntityMaps(harness.db);
+    expect(entityLookup.size).toBe(0);
+    expect(aliasMap.size).toBe(0);
+  });
+
+  it('keys the lookup by lowercased name but stores the original case', () => {
+    const id = seedEntity(harness.db, { name: 'Coles Express' });
+
+    const { entityLookup } = loadEntityMaps(harness.db);
+
+    expect(entityLookup.get('coles express')).toEqual({ id, name: 'Coles Express' });
+    expect(entityLookup.has('Coles Express')).toBe(false);
+  });
+
+  it('maps each lowercased alias to the entity name in original case', () => {
+    seedEntity(harness.db, { name: 'Woolworths', aliases: 'WW, Woolies, woolworths group' });
+
+    const { aliasMap } = loadEntityMaps(harness.db);
+
+    expect(aliasMap.get('ww')).toBe('Woolworths');
+    expect(aliasMap.get('woolies')).toBe('Woolworths');
+    expect(aliasMap.get('woolworths group')).toBe('Woolworths');
+  });
+
+  it('skips entities with a null aliases column', () => {
+    seedEntity(harness.db, { name: 'Solo', aliases: null });
+
+    const { entityLookup, aliasMap } = loadEntityMaps(harness.db);
+
+    expect(entityLookup.size).toBe(1);
+    expect(aliasMap.size).toBe(0);
+  });
+
+  it('drops whitespace-only alias entries', () => {
+    seedEntity(harness.db, { name: 'Aldi', aliases: 'ALDI, ,  ,aldi store' });
+
+    const { aliasMap } = loadEntityMaps(harness.db);
+
+    expect(aliasMap.size).toBe(2);
+    expect(aliasMap.get('aldi')).toBe('Aldi');
+    expect(aliasMap.get('aldi store')).toBe('Aldi');
+  });
+
+  it('honours collision semantics — later aliases overwrite earlier ones', () => {
+    seedEntity(harness.db, { name: 'Cafe One', aliases: 'shared' });
+    seedEntity(harness.db, { name: 'Cafe Two', aliases: 'shared' });
+
+    const { aliasMap } = loadEntityMaps(harness.db);
+
+    expect(aliasMap.get('shared')).toMatch(/Cafe (One|Two)/);
+  });
+});
+
+describe('createImportEntity', () => {
+  let harness: TestHarness;
+  beforeEach(() => {
+    harness = freshDb();
+  });
+
+  it('inserts an entity with a generated UUID and returns the id + original name', () => {
+    const result = createImportEntity(harness.db, 'New Vendor');
+
+    expect(result.entityName).toBe('New Vendor');
+    expect(result.entityId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+    );
+
+    const row = harness.db.select().from(entities).where(eq(entities.id, result.entityId)).get();
+    expect(row?.name).toBe('New Vendor');
+    expect(row?.type).toBe('company');
+    expect(row?.aliases).toBeNull();
+  });
+
+  it('stamps lastEditedTime with an ISO-8601 string', () => {
+    const result = createImportEntity(harness.db, 'Timestamped');
+    const row = harness.db
+      .select({ lastEditedTime: entities.lastEditedTime })
+      .from(entities)
+      .where(eq(entities.id, result.entityId))
+      .get();
+    expect(row?.lastEditedTime).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+  });
+
+  it('generates a distinct id per call even when names collide', () => {
+    const a = createImportEntity(harness.db, 'Same Name');
+    const b = createImportEntity(harness.db, 'Same Name');
+    expect(a.entityId).not.toBe(b.entityId);
+  });
+});
+
+describe('insertImportTransaction', () => {
+  let harness: TestHarness;
+  beforeEach(() => {
+    harness = freshDb();
+  });
+
+  it('persists the supplied fields and round-trips them on the returned row', () => {
+    const entityId = seedEntity(harness.db, { name: 'Acme' });
+
+    const row = insertImportTransaction(harness.db, {
+      description: 'Espresso',
+      account: 'amex',
+      amount: -4.5,
+      date: '2026-02-14',
+      type: 'Expense',
+      tags: ['Coffee', 'Outings'],
+      entityId,
+      entityName: 'Acme',
+      location: 'Sydney',
+      rawRow: 'csv,row,here',
+      checksum: 'chk-1',
+    });
+
+    expect(row.description).toBe('Espresso');
+    expect(row.account).toBe('amex');
+    expect(row.amount).toBe(-4.5);
+    expect(row.date).toBe('2026-02-14');
+    expect(row.type).toBe('Expense');
+    expect(row.tags).toBe('["Coffee","Outings"]');
+    expect(row.entityId).toBe(entityId);
+    expect(row.entityName).toBe('Acme');
+    expect(row.location).toBe('Sydney');
+    expect(row.rawRow).toBe('csv,row,here');
+    expect(row.checksum).toBe('chk-1');
+    expect(row.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+    expect(row.lastEditedTime).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('serialises tags as a JSON array (empty array when no tags supplied)', () => {
+    const row = insertImportTransaction(harness.db, {
+      description: 'No tags',
+      account: 'amex',
+      amount: -1,
+      date: '2026-02-15',
+      type: 'Expense',
+      tags: [],
+      entityId: null,
+      entityName: null,
+      location: null,
+    });
+    expect(row.tags).toBe('[]');
+  });
+
+  it('defaults optional rawRow and checksum to null when omitted', () => {
+    const row = insertImportTransaction(harness.db, {
+      description: 'Defaults',
+      account: 'amex',
+      amount: -2,
+      date: '2026-02-15',
+      type: 'Expense',
+      tags: [],
+      entityId: null,
+      entityName: null,
+      location: null,
+    });
+    expect(row.rawRow).toBeNull();
+    expect(row.checksum).toBeNull();
+  });
+
+  it('coerces an empty `type` string to the empty string (does not throw)', () => {
+    const row = insertImportTransaction(harness.db, {
+      description: 'Untyped',
+      account: 'amex',
+      amount: -3,
+      date: '2026-02-15',
+      type: '',
+      tags: [],
+      entityId: null,
+      entityName: null,
+      location: null,
+    });
+    expect(row.type).toBe('');
+  });
+
+  it('honours the transactions.checksum unique index', () => {
+    insertImportTransaction(harness.db, {
+      description: 'first',
+      account: 'amex',
+      amount: -1,
+      date: '2026-02-15',
+      type: 'Expense',
+      tags: [],
+      entityId: null,
+      entityName: null,
+      location: null,
+      checksum: 'dup',
+    });
+
+    expect(() =>
+      insertImportTransaction(harness.db, {
+        description: 'second',
+        account: 'amex',
+        amount: -1,
+        date: '2026-02-15',
+        type: 'Expense',
+        tags: [],
+        entityId: null,
+        entityName: null,
+        location: null,
+        checksum: 'dup',
+      })
+    ).toThrow(/UNIQUE constraint failed/);
+  });
+
+  it('rolls back when used inside a transaction that aborts', () => {
+    expect(() =>
+      harness.db.transaction(() => {
+        insertImportTransaction(harness.db, {
+          description: 'rolled back',
+          account: 'amex',
+          amount: -1,
+          date: '2026-02-15',
+          type: 'Expense',
+          tags: [],
+          entityId: null,
+          entityName: null,
+          location: null,
+          checksum: 'rb',
+        });
+        throw new Error('abort');
+      })
+    ).toThrow('abort');
+
+    const found = findExistingChecksums(harness.db, ['rb']);
+    expect(found.size).toBe(0);
+  });
+});
+
+describe('ImportTransactionPersistError', () => {
+  it('exposes the offending id on the thrown instance', () => {
+    const err = new ImportTransactionPersistError('abc');
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe('ImportTransactionPersistError');
+    expect(err.id).toBe('abc');
+    expect(err.message).toContain('abc');
+  });
+});

--- a/packages/finance-db/src/__tests__/imports.test.ts
+++ b/packages/finance-db/src/__tests__/imports.test.ts
@@ -238,13 +238,15 @@ describe('loadEntityMaps', () => {
     expect(aliasMap.get('aldi store')).toBe('Aldi');
   });
 
-  it('honours collision semantics — later aliases overwrite earlier ones', () => {
+  it('keeps a single winner when two entities share an alias (insertion order not guaranteed)', () => {
     seedEntity(harness.db, { name: 'Cafe One', aliases: 'shared' });
     seedEntity(harness.db, { name: 'Cafe Two', aliases: 'shared' });
 
     const { aliasMap } = loadEntityMaps(harness.db);
 
-    expect(aliasMap.get('shared')).toMatch(/Cafe (One|Two)/);
+    expect(aliasMap.size).toBe(1);
+    const winner = aliasMap.get('shared');
+    expect(winner === 'Cafe One' || winner === 'Cafe Two').toBe(true);
   });
 });
 

--- a/packages/finance-db/src/errors.ts
+++ b/packages/finance-db/src/errors.ts
@@ -45,3 +45,13 @@ export class TransactionAlreadyExistsError extends Error {
     this.id = id;
   }
 }
+
+export class ImportTransactionPersistError extends Error {
+  override readonly name = 'ImportTransactionPersistError' as const;
+  readonly id: string;
+
+  constructor(id: string) {
+    super(`Import transaction insert succeeded but row not found: ${id}`);
+    this.id = id;
+  }
+}

--- a/packages/finance-db/src/index.ts
+++ b/packages/finance-db/src/index.ts
@@ -53,3 +53,13 @@ export {
   type TransactionRow,
   type UpdateTransactionInput,
 } from './services/transactions.js';
+
+export * as importsService from './services/imports.js';
+
+export type {
+  EntityLookupEntry,
+  EntityMaps,
+  InsertImportTransactionInput,
+  ImportTransactionRow,
+  CreateImportEntityResult,
+} from './services/imports.js';

--- a/packages/finance-db/src/schema.ts
+++ b/packages/finance-db/src/schema.ts
@@ -10,4 +10,10 @@
  *
  * Mirrors the `@pops/core-db` schema re-export pattern.
  */
-export { tagVocabulary, transactions, transactionTagRules, wishList } from '@pops/db-types';
+export {
+  entities,
+  tagVocabulary,
+  transactions,
+  transactionTagRules,
+  wishList,
+} from '@pops/db-types';

--- a/packages/finance-db/src/services/imports.ts
+++ b/packages/finance-db/src/services/imports.ts
@@ -1,0 +1,194 @@
+/**
+ * Persistence helpers for the finance imports slice.
+ *
+ * The in-tree pipeline in `apps/pops-api/src/modules/finance/imports/` is
+ * a large orchestration surface — CSV/PDF transformers, AI categorisation,
+ * progress streaming, transfer classification, retroactive reclassification.
+ * Most of that is coordination logic, not data layer.
+ *
+ * This module scaffolds only the pure-persistence primitives the pipeline
+ * uses against `transactions` and `entities`:
+ *
+ *   - `findExistingChecksums` — checksum dedup probe (read-only)
+ *   - `loadEntityMaps`        — name + alias lookup loader (read-only)
+ *   - `createImportEntity`    — minimal entity insert (write)
+ *   - `insertImportTransaction` — low-level transactions insert (write)
+ *
+ * Crucially, the imports slice owns NO tables of its own — every write
+ * lands in sibling-slice tables (`transactions` → N2, `entities` → core).
+ * The migration journal split (PR 2) is therefore a no-op for this slice;
+ * PRs 2-4 of N6 only re-route consumers and delete the in-tree shim.
+ *
+ * Mirrors the wish-list / budgets / tag-vocabulary pattern: db-arg
+ * services, plain functions, typed domain errors, no HTTP concerns.
+ */
+import { eq, inArray, isNotNull } from 'drizzle-orm';
+
+import { ImportTransactionPersistError } from '../errors.js';
+import { entities, transactions } from '../schema.js';
+
+import type { FinanceDb } from './internal.js';
+
+/** Single entry in the entity name lookup map. */
+export interface EntityLookupEntry {
+  id: string;
+  /** Original-case entity name as stored in the database. */
+  name: string;
+}
+
+/** Two pre-built maps consumed by the import matching stages. */
+export interface EntityMaps {
+  /** Lowercase entity name → `{ id, name (original case) }`. */
+  entityLookup: Map<string, EntityLookupEntry>;
+  /** Lowercase alias → entity name (original case). */
+  aliasMap: Map<string, string>;
+}
+
+/** Mutable subset accepted on `insertImportTransaction`. */
+export interface InsertImportTransactionInput {
+  description: string;
+  account: string;
+  amount: number;
+  date: string;
+  type: string;
+  tags: string[];
+  entityId: string | null;
+  entityName: string | null;
+  location: string | null;
+  rawRow?: string;
+  checksum?: string;
+}
+
+/** Raw drizzle row shape returned by `insertImportTransaction`. */
+export type ImportTransactionRow = typeof transactions.$inferSelect;
+
+/** Result of a successful `createImportEntity`. */
+export interface CreateImportEntityResult {
+  entityId: string;
+  entityName: string;
+}
+
+const CHECKSUM_BATCH_SIZE = 500;
+
+/**
+ * Return the subset of `checksums` that already exist in the
+ * `transactions` table. Empty input returns an empty set without
+ * issuing a query.
+ *
+ * Batched at 500 per IN-list to stay under SQLite's `SQLITE_MAX_VARIABLE_NUMBER`
+ * limit (default 999).
+ */
+export function findExistingChecksums(db: FinanceDb, checksums: string[]): Set<string> {
+  if (checksums.length === 0) return new Set();
+
+  const existing = new Set<string>();
+  for (let i = 0; i < checksums.length; i += CHECKSUM_BATCH_SIZE) {
+    const batch = checksums.slice(i, i + CHECKSUM_BATCH_SIZE);
+    const rows = db
+      .select({ checksum: transactions.checksum })
+      .from(transactions)
+      .where(inArray(transactions.checksum, batch))
+      .all();
+    for (const row of rows) {
+      if (row.checksum) existing.add(row.checksum);
+    }
+  }
+
+  return existing;
+}
+
+/**
+ * Build the entity lookup + alias maps consumed by the import matching
+ * stages. Two-pass: one query for the full lookup, a second narrower query
+ * for the alias map.
+ *
+ * - Lookup keys are lowercased for O(1) case-insensitive lookups.
+ * - Values preserve the original-case name for display.
+ * - Aliases are parsed from comma-separated strings; whitespace-only
+ *   aliases are dropped.
+ */
+export function loadEntityMaps(db: FinanceDb): EntityMaps {
+  const entityLookup = new Map<string, EntityLookupEntry>();
+  const aliasMap = new Map<string, string>();
+
+  const allRows = db.select({ name: entities.name, id: entities.id }).from(entities).all();
+  for (const row of allRows) {
+    entityLookup.set(row.name.toLowerCase(), { id: row.id, name: row.name });
+  }
+
+  const aliasRows = db
+    .select({ name: entities.name, aliases: entities.aliases })
+    .from(entities)
+    .where(isNotNull(entities.aliases))
+    .all();
+  for (const row of aliasRows) {
+    if (!row.aliases) continue;
+    for (const raw of row.aliases.split(',')) {
+      const alias = raw.trim();
+      if (alias.length === 0) continue;
+      aliasMap.set(alias.toLowerCase(), row.name);
+    }
+  }
+
+  return { entityLookup, aliasMap };
+}
+
+/**
+ * Insert a minimal entity row (name only, defaults for type) and return
+ * the generated id alongside the original-case name. The richer entity
+ * CRUD surface (aliases, type overrides, ABN, notes) is owned by the
+ * core entities module — this is the narrow path import commits take when
+ * the user accepts a new entity during a session.
+ */
+export function createImportEntity(db: FinanceDb, name: string): CreateImportEntityResult {
+  const entityId = crypto.randomUUID();
+  db.insert(entities)
+    .values({ id: entityId, name, lastEditedTime: new Date().toISOString() })
+    .run();
+  return { entityId, entityName: name };
+}
+
+/**
+ * Insert a single transaction during the commit phase of an import.
+ *
+ * Mirrors the in-tree `insertTransaction` shape verbatim so the cutover
+ * (PR 3) is a pure routing flip. The full atomic commit pipeline
+ * (`commitImport`) remains in-tree for now because it depends on
+ * `applyChangeSet` (core/corrections), `applyTagRuleChangeSet`
+ * (core/tag-rules), and `reclassifyExistingTransactions` (transactions
+ * slice) — cross-slice orchestration the persistence layer should not
+ * own.
+ *
+ * Throws `ImportTransactionPersistError` if the row is not readable
+ * after the insert — a defensive check against silent SQLite write
+ * failures that the in-tree implementation surfaces as a bare `Error`.
+ */
+export function insertImportTransaction(
+  db: FinanceDb,
+  input: InsertImportTransactionInput
+): ImportTransactionRow {
+  const id = crypto.randomUUID();
+  const now = new Date().toISOString();
+
+  db.insert(transactions)
+    .values({
+      id,
+      description: input.description,
+      account: input.account,
+      amount: input.amount,
+      date: input.date,
+      type: input.type || '',
+      tags: JSON.stringify(input.tags),
+      entityId: input.entityId,
+      entityName: input.entityName,
+      location: input.location,
+      checksum: input.checksum ?? null,
+      rawRow: input.rawRow ?? null,
+      lastEditedTime: now,
+    })
+    .run();
+
+  const row = db.select().from(transactions).where(eq(transactions.id, id)).get();
+  if (!row) throw new ImportTransactionPersistError(id);
+  return row;
+}


### PR DESCRIPTION
## Summary

- Phase 1 PR 1 of the Track N6 (deferred-backlog `imports` slice) migration to `@pops/finance-db`. Tracked as #2842.
- Strictly additive: in-tree `apps/pops-api/src/modules/finance/imports/` is untouched; no consumer cutover.
- Adds the persistence primitives the import pipeline uses to read/write `transactions` and `entities`. All transformer + orchestration code stays in pops-api.

## Scoping decision — persistence vs orchestration

The imports slice has the largest UI surface of the finance domain but **owns no tables of its own**. Every write lands in sibling-slice tables (`transactions` → N2, `entities` → core). The slice's bulk is coordination logic — CSV/PDF transformers, AI categoriser, progress streaming, transfer classification, retroactive reclassification, commit-phase changeset application against core/corrections + core/tag-rules.

Phase 1 PR 1 ships **only** the pure-persistence helpers:

| Function | Reads/writes | Origin in-tree |
|---|---|---|
| `findExistingChecksums(db, checksums)` | read `transactions.checksum` (500-row batched) | `imports/lib/deduplication.ts` |
| `loadEntityMaps(db)` | read `entities.{id,name,aliases}` (two-pass) | `imports/lib/entity-lookup.ts:loadEntityMaps` |
| `createImportEntity(db, name)` | write `entities` (minimal row) | `imports/service.ts:createEntity` + `imports/lib/transaction-persistence.ts:createEntityInternal` |
| `insertImportTransaction(db, input)` | write `transactions`, read-back | `imports/lib/transaction-persistence.ts:insertTransaction` |

Adds `ImportTransactionPersistError` (typed domain error) to replace the in-tree bare `throw new Error(...)` on silent SQLite write failures.

**Deliberately left in `apps/pops-api/src/modules/finance/imports/`** (deferred to PR 3 cutover or out of scope entirely):

- `transformers/` (amex, anz, anz-pdf, ing) — pure-function CSV/PDF parsing, not DB
- `lib/transformers/` — N/A (no such dir; see `transformers/` above)
- `lib/ai-categorizer*` — LLM I/O
- `lib/entity-matcher.ts`, `lib/transfer-classifier.ts` — heuristic classifiers
- `lib/transaction-persistence.ts:commitImport` — depends on `applyChangeSet` (core/corrections), `applyTagRuleChangeSet` (core/tag-rules), `reclassifyExistingTransactions` (transactions slice). Cross-slice orchestration the persistence layer should not own. Cutover (PR 3) will decide whether `commitImport` itself moves or the in-tree shim keeps it.
- `lib/correction-application.ts` — calls into N3's `transaction_corrections` slice
- `progress-store.ts` — in-memory WS state, not data layer
- `router.ts`, `service.ts`, `process-service.ts`, `execute-service.ts` — orchestration entry points

## Test plan

- [x] `pnpm --filter @pops/finance-db test` — 4 files / 50 tests pass (new `imports.test.ts` adds 22 invariants)
- [x] `pnpm --filter @pops/api test` — 299 files / 4842 tests pass (in-tree imports module unchanged)
- [x] `pnpm typecheck` — 45 packages clean
- [x] `pnpm lint` — finance-db package clean (no new warnings)
- [x] `pnpm build` — 21 packages clean
- [x] `pnpm format` — oxfmt clean

Coverage of the new `imports.test.ts` includes:

- Empty input → empty Set without query
- Batch size > 500 (1,200 checksums + 25 hits) round-trips correctly
- Null-checksum rows ignored
- Dedup on repeated input
- Entity lookup: lowercase keying with original-case values
- Alias map: comma split, whitespace dropping, collision semantics
- `createImportEntity`: UUID format, ISO `lastEditedTime`, distinct ids per call
- `insertImportTransaction`: round-trip of every field, JSON tag serialisation, null defaults, empty-type coercion, checksum UNIQUE-index enforcement, rollback inside outer transaction
- `ImportTransactionPersistError`: name + id exposed

## Deferred to later PRs of the N6 sequence

| PR | Scope | Notes |
|---|---|---|
| Phase 1 PR 2 | Migration journal split | Likely no-op for N6 — slice owns no tables. Re-confirm before opening; may skip straight to PR 3. |
| Phase 1 PR 3 | Cutover | Route in-tree callers (`imports/lib/deduplication.ts`, `lib/entity-lookup.ts`, `lib/transaction-persistence.ts`, `service.ts:createEntity`) through `@pops/finance-db`. Decide whether `commitImport` moves into the package or stays in-tree given its cross-slice dependencies. |
| Phase 1 PR 4 | In-tree shim deletion | Delete the now-empty thin wrappers in `apps/pops-api/src/modules/finance/imports/lib/`. Transformer + orchestration code stays. |

## Pattern PRs

- #2766 — wish-list pilot (the original 4-PR template)
- #2852 — tag_vocabulary slice (recent reference)
- #2855 — budgets slice (concurrent sibling, same shape)
