### PR TITLE
chore(migrations): retire media shared-journal entry 0021_spooky_lockheed (Track L3)

### DIFF
--- a/.github/workflows/media-db-quality.yml
+++ b/.github/workflows/media-db-quality.yml
@@ -6,7 +6,6 @@ on:
     paths:
       - "packages/media-db/**"
       - "packages/db-types/**"
-      - "apps/pops-api/src/db/drizzle-migrations/0021_spooky_lockheed.sql"
       - ".github/workflows/media-db-quality.yml"
       - ".github/workflows/_pkg-check.yml"
   pull_request:
@@ -27,33 +26,8 @@ jobs:
             relevant:
               - 'packages/media-db/**'
               - 'packages/db-types/**'
-              - 'apps/pops-api/src/db/drizzle-migrations/0021_spooky_lockheed.sql'
               - '.github/workflows/media-db-quality.yml'
               - '.github/workflows/_pkg-check.yml'
-
-  migration-drift-guard:
-    name: Migration drift (shared vs media-db)
-    needs: [changes]
-    if: always()
-    runs-on: ubuntu-latest
-    steps:
-      - name: "Skip — no relevant changes"
-        if: github.event_name == 'pull_request' && needs.changes.outputs.relevant != 'true'
-        run: echo "Skipping — no relevant changes"
-      - uses: actions/checkout@v6
-        if: github.event_name != 'pull_request' || needs.changes.outputs.relevant == 'true'
-      - name: Diff media-db copy against shared journal copy
-        if: github.event_name != 'pull_request' || needs.changes.outputs.relevant == 'true'
-        run: |
-          set -euo pipefail
-          shared='apps/pops-api/src/db/drizzle-migrations/0021_spooky_lockheed.sql'
-          pillar='packages/media-db/migrations/0021_spooky_lockheed.sql'
-          if ! diff -q "$shared" "$pillar"; then
-            echo "::error::Migration drift detected: $shared and $pillar must be byte-identical during the transitional release cycle (media pillar phase 1)."
-            diff "$shared" "$pillar" || true
-            exit 1
-          fi
-          echo "OK — both 0021_spooky_lockheed.sql copies are byte-identical."
 
   quality:
     needs: [changes]

--- a/apps/pops-api/src/db/drizzle-migrations/0021_spooky_lockheed.sql
+++ b/apps/pops-api/src/db/drizzle-migrations/0021_spooky_lockheed.sql
@@ -1,7 +1,0 @@
-CREATE TABLE `shelf_impressions` (
-	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
-	`shelf_id` text NOT NULL,
-	`shown_at` text DEFAULT (datetime('now')) NOT NULL
-);
---> statement-breakpoint
-CREATE INDEX `idx_shelf_impressions_shelf_id` ON `shelf_impressions` (`shelf_id`);

--- a/apps/pops-api/src/db/drizzle-migrations/meta/_journal.json
+++ b/apps/pops-api/src/db/drizzle-migrations/meta/_journal.json
@@ -150,13 +150,6 @@
       "breakpoints": true
     },
     {
-      "idx": 21,
-      "version": "6",
-      "when": 1775359502281,
-      "tag": "0021_spooky_lockheed",
-      "breakpoints": true
-    },
-    {
       "idx": 22,
       "version": "6",
       "when": 1744030000000,

--- a/apps/pops-api/src/db/migration-ownership.ts
+++ b/apps/pops-api/src/db/migration-ownership.ts
@@ -50,7 +50,6 @@ export const MIGRATION_OWNERS: Readonly<Record<string, string>> = {
   '0018_high_excalibur': 'media',
   '0019_little_diamondback': 'media',
   '0020_melodic_major_mapleleaf': 'media',
-  '0021_spooky_lockheed': 'media',
   '0022_elo_deltas': 'media',
   '0023_kind_james_howlett': 'media',
   '0024_dedupe_comparisons': 'media',

--- a/apps/pops-api/src/modules/media/migrations.ts
+++ b/apps/pops-api/src/modules/media/migrations.ts
@@ -39,8 +39,6 @@ export const mediaMigrationTags: readonly string[] = [
   '0019_little_diamondback',
   // debrief_status.
   '0020_melodic_major_mapleleaf',
-  // shelf_impressions.
-  '0021_spooky_lockheed',
   // comparisons elo deltas.
   '0022_elo_deltas',
   // comparisons source column.


### PR DESCRIPTION
## Summary

Track L3 from the pillar-migration roadmap. Retires the transitional
shared-journal copy of `0021_spooky_lockheed` (media shelf_impressions
DDL) now that the per-pillar runner has been carrying it via
`@pops/media-db` for a release cycle. User explicitly authorised
proceeding without the standard 7-day post-Phase-2 wait on the Track L
gate.

Tracking issue: #2829.

## Deletions (lockstep)

- `apps/pops-api/src/db/drizzle-migrations/0021_spooky_lockheed.sql`
- entry in `apps/pops-api/src/db/drizzle-migrations/meta/_journal.json`
- `MIGRATION_OWNERS` row in `apps/pops-api/src/db/migration-ownership.ts`
- tag in `mediaMigrationTags` (`apps/pops-api/src/modules/media/migrations.ts`)
  — drops it from the media module manifest by construction
- drift-guard job (`Migration drift (shared vs media-db)`) + the
  `0021_spooky_lockheed.sql` path triggers in
  `.github/workflows/media-db-quality.yml`. The `quality` job for the
  `@pops/media-db` package itself stays in place.

## Preserved

- `packages/media-db/migrations/0021_spooky_lockheed.sql` — canonical
  copy, untouched.
- `packages/media-db/migrations/meta/_journal.json` — package journal
  entry stays.
- `packages/media-db/src/__tests__/shelf-impressions.test.ts` — already
  resolves against the package SQL path.

## Test plan

- [x] `pnpm --filter @pops/api test` — 4842 / 4842 pass
- [x] Migration-ownership contract test (`migration-ownership.test.ts`)
      passes without test edits
- [x] `per-pillar-migrations.test.ts` still asserts
      `0021_spooky_lockheed` is applied by the per-pillar runner via
      `packages/media-db`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm build`
- [ ] CI green on this PR (media-db-quality without drift-guard, all
      package checks)
