### PR TITLE
feat(finance-db): scaffold transactions slice (Track N2 phase 1 PR 1)

### DIFF
--- a/packages/finance-db/src/__tests__/transactions.test.ts
+++ b/packages/finance-db/src/__tests__/transactions.test.ts
@@ -1,0 +1,501 @@
+/**
+ * Invariant tests for the transactions service against an in-memory SQLite
+ * seeded with the canonical `transactions` DDL. Pure DB + service layer —
+ * no tRPC, no Express, no auth middleware.
+ *
+ * Higher-level router coverage lives in pops-api's own integration suite
+ * and exercises the same service via the pops-api wrapper.
+ *
+ * The DDL is inlined (rather than read from the shared baseline
+ * `0000_naive_chameleon.sql` or the package's own `0053_finance_pillar_baseline`)
+ * because those create the entire pre-modular schema and applying them for
+ * every test here is wasted work. Phase 1 PR 2 of N2 will move the canonical
+ * statement into the package's own migration journal alongside the other
+ * finance-owned tables — until then this inlined copy is the test fixture.
+ */
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { TransactionAlreadyExistsError, TransactionNotFoundError } from '../errors.js';
+import {
+  createTransaction,
+  deleteTransaction,
+  getTransaction,
+  listTransactions,
+  restoreTransaction,
+  updateTransaction,
+} from '../services/transactions.js';
+
+import type { FinanceDb } from '../services/internal.js';
+
+const TRANSACTIONS_DDL = `
+CREATE TABLE transactions (
+  id text PRIMARY KEY NOT NULL,
+  notion_id text,
+  description text NOT NULL,
+  account text NOT NULL,
+  amount real NOT NULL,
+  date text NOT NULL,
+  type text NOT NULL,
+  tags text NOT NULL DEFAULT '[]',
+  entity_id text,
+  entity_name text,
+  location text,
+  country text,
+  related_transaction_id text,
+  notes text,
+  checksum text,
+  raw_row text,
+  last_edited_time text NOT NULL
+);
+CREATE UNIQUE INDEX transactions_notion_id_unique ON transactions (notion_id);
+CREATE INDEX idx_transactions_date ON transactions (date);
+CREATE INDEX idx_transactions_account ON transactions (account);
+CREATE INDEX idx_transactions_entity ON transactions (entity_id);
+CREATE INDEX idx_transactions_last_edited ON transactions (last_edited_time);
+CREATE INDEX idx_transactions_notion_id ON transactions (notion_id);
+CREATE UNIQUE INDEX idx_transactions_checksum ON transactions (checksum);
+`;
+
+function freshDb(): FinanceDb {
+  const raw = new Database(':memory:');
+  raw.pragma('foreign_keys = ON');
+  raw.exec(TRANSACTIONS_DDL);
+  return drizzle(raw);
+}
+
+describe('createTransaction', () => {
+  let db: FinanceDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('inserts a row with the supplied fields and a generated UUID', () => {
+    const created = createTransaction(db, {
+      description: 'Groceries',
+      account: 'Up Savings',
+      amount: 50.0,
+      date: '2025-06-15',
+      type: 'Purchase',
+    });
+
+    expect(created.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+    expect(created.description).toBe('Groceries');
+    expect(created.account).toBe('Up Savings');
+    expect(created.amount).toBe(50.0);
+    expect(created.date).toBe('2025-06-15');
+    expect(created.type).toBe('Purchase');
+    expect(created.tags).toBe('[]');
+    expect(created.lastEditedTime).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('defaults type to empty string when omitted', () => {
+    const created = createTransaction(db, {
+      description: 'Test',
+      account: 'Up',
+      amount: 10,
+      date: '2025-06-15',
+    });
+    expect(created.type).toBe('');
+  });
+
+  it('serialises tags as a JSON string', () => {
+    const created = createTransaction(db, {
+      description: 'Test',
+      account: 'Up',
+      amount: 10,
+      date: '2025-06-15',
+      tags: ['Groceries', 'Online'],
+    });
+    expect(created.tags).toBe('["Groceries","Online"]');
+  });
+
+  it('defaults optional reference fields to null', () => {
+    const created = createTransaction(db, {
+      description: 'Test',
+      account: 'Up',
+      amount: 10,
+      date: '2025-06-15',
+    });
+    expect(created.entityId).toBeNull();
+    expect(created.entityName).toBeNull();
+    expect(created.location).toBeNull();
+    expect(created.country).toBeNull();
+    expect(created.relatedTransactionId).toBeNull();
+    expect(created.notes).toBeNull();
+    expect(created.checksum).toBeNull();
+    expect(created.rawRow).toBeNull();
+  });
+
+  it('persists every supplied optional field', () => {
+    const created = createTransaction(db, {
+      description: 'Woolworths Groceries',
+      account: 'Up Savings',
+      amount: 150.75,
+      date: '2025-06-15',
+      type: 'Purchase',
+      tags: ['Groceries'],
+      entityId: 'ent-123',
+      entityName: 'Woolworths',
+      location: 'Sydney CBD',
+      country: 'Australia',
+      relatedTransactionId: 'txn-456',
+      notes: 'Weekly shop',
+      checksum: 'abc123',
+      rawRow: '15/06/2025,Woolworths,150.75',
+    });
+
+    expect(created.entityId).toBe('ent-123');
+    expect(created.entityName).toBe('Woolworths');
+    expect(created.location).toBe('Sydney CBD');
+    expect(created.country).toBe('Australia');
+    expect(created.relatedTransactionId).toBe('txn-456');
+    expect(created.notes).toBe('Weekly shop');
+    expect(created.checksum).toBe('abc123');
+    expect(created.rawRow).toBe('15/06/2025,Woolworths,150.75');
+  });
+});
+
+describe('getTransaction', () => {
+  let db: FinanceDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('returns the persisted row by id', () => {
+    const created = createTransaction(db, {
+      description: 'X',
+      account: 'Up',
+      amount: 1,
+      date: '2025-06-15',
+    });
+    const fetched = getTransaction(db, created.id);
+    expect(fetched).toEqual(created);
+  });
+
+  it('throws TransactionNotFoundError for an unknown id', () => {
+    expect(() => getTransaction(db, 'missing')).toThrow(TransactionNotFoundError);
+  });
+
+  it('TransactionNotFoundError carries the offending id', () => {
+    try {
+      getTransaction(db, 'nope-123');
+      expect.fail('expected throw');
+    } catch (error) {
+      expect(error).toBeInstanceOf(TransactionNotFoundError);
+      expect((error as TransactionNotFoundError).id).toBe('nope-123');
+    }
+  });
+});
+
+describe('listTransactions', () => {
+  let db: FinanceDb;
+  beforeEach(() => {
+    db = freshDb();
+    createTransaction(db, {
+      description: 'Woolworths Groceries',
+      account: 'Up Savings',
+      amount: 50,
+      date: '2025-06-15',
+      type: 'Purchase',
+      tags: ['Groceries', 'Online'],
+      entityId: 'ent-123',
+    });
+    createTransaction(db, {
+      description: 'Coles Groceries',
+      account: 'ANZ Visa',
+      amount: 30,
+      date: '2025-06-14',
+      type: 'Purchase',
+      tags: ['Groceries'],
+      entityId: 'ent-456',
+    });
+    createTransaction(db, {
+      description: 'Fuel Station',
+      account: 'Up Savings',
+      amount: 60,
+      date: '2025-06-13',
+      type: 'Purchase',
+      tags: ['Transport'],
+    });
+    createTransaction(db, {
+      description: 'Salary',
+      account: 'Up Savings',
+      amount: 5000,
+      date: '2025-05-30',
+      type: 'Income',
+    });
+  });
+
+  it('returns all rows sorted by date DESC with a total count', () => {
+    const result = listTransactions(db, {}, 50, 0);
+    expect(result.total).toBe(4);
+    expect(result.rows.map((r) => r.description)).toEqual([
+      'Woolworths Groceries',
+      'Coles Groceries',
+      'Fuel Station',
+      'Salary',
+    ]);
+  });
+
+  it('filters by description LIKE (ASCII case-insensitive per SQLite default)', () => {
+    const result = listTransactions(db, { search: 'wool' }, 50, 0);
+    expect(result.total).toBe(1);
+    expect(result.rows[0]?.description).toBe('Woolworths Groceries');
+  });
+
+  it('filters by exact account', () => {
+    const result = listTransactions(db, { account: 'ANZ Visa' }, 50, 0);
+    expect(result.total).toBe(1);
+    expect(result.rows[0]?.description).toBe('Coles Groceries');
+  });
+
+  it('filters by startDate inclusive', () => {
+    const result = listTransactions(db, { startDate: '2025-06-14' }, 50, 0);
+    expect(result.total).toBe(2);
+    expect(result.rows.map((r) => r.description)).toEqual([
+      'Woolworths Groceries',
+      'Coles Groceries',
+    ]);
+  });
+
+  it('filters by endDate inclusive', () => {
+    const result = listTransactions(db, { endDate: '2025-06-13' }, 50, 0);
+    expect(result.total).toBe(2);
+    expect(result.rows.map((r) => r.description)).toEqual(['Fuel Station', 'Salary']);
+  });
+
+  it('filters by date range', () => {
+    const result = listTransactions(db, { startDate: '2025-06-13', endDate: '2025-06-14' }, 50, 0);
+    expect(result.total).toBe(2);
+    expect(result.rows.map((r) => r.description)).toEqual(['Coles Groceries', 'Fuel Station']);
+  });
+
+  it('filters by tag membership (json_each match)', () => {
+    const result = listTransactions(db, { tag: 'Groceries' }, 50, 0);
+    expect(result.total).toBe(2);
+    expect(result.rows.every((r) => r.tags.includes('Groceries'))).toBe(true);
+  });
+
+  it('does not match partial tag substrings', () => {
+    const result = listTransactions(db, { tag: 'Groc' }, 50, 0);
+    expect(result.total).toBe(0);
+  });
+
+  it('filters by entityId equality', () => {
+    const result = listTransactions(db, { entityId: 'ent-123' }, 50, 0);
+    expect(result.total).toBe(1);
+    expect(result.rows[0]?.description).toBe('Woolworths Groceries');
+  });
+
+  it('filters by type', () => {
+    const result = listTransactions(db, { type: 'Income' }, 50, 0);
+    expect(result.total).toBe(1);
+    expect(result.rows[0]?.description).toBe('Salary');
+  });
+
+  it('combines multiple filters as AND', () => {
+    const result = listTransactions(
+      db,
+      { account: 'Up Savings', type: 'Purchase', tag: 'Transport' },
+      50,
+      0
+    );
+    expect(result.total).toBe(1);
+    expect(result.rows[0]?.description).toBe('Fuel Station');
+  });
+
+  it('paginates via limit + offset and reports the unpaginated total', () => {
+    const page1 = listTransactions(db, {}, 2, 0);
+    const page2 = listTransactions(db, {}, 2, 2);
+    expect(page1.total).toBe(4);
+    expect(page1.rows).toHaveLength(2);
+    expect(page2.total).toBe(4);
+    expect(page2.rows).toHaveLength(2);
+    const page1Ids = page1.rows.map((r) => r.id);
+    const page2Ids = page2.rows.map((r) => r.id);
+    expect(page1Ids.some((id) => page2Ids.includes(id))).toBe(false);
+  });
+
+  it('returns an empty result with total=0 for an unmatched filter', () => {
+    const result = listTransactions(db, { account: 'nope' }, 50, 0);
+    expect(result.total).toBe(0);
+    expect(result.rows).toEqual([]);
+  });
+});
+
+describe('updateTransaction', () => {
+  let db: FinanceDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('patches only the supplied fields and bumps lastEditedTime', async () => {
+    const created = createTransaction(db, {
+      description: 'Original',
+      account: 'Up',
+      amount: 10,
+      date: '2025-06-15',
+    });
+    const original = created.lastEditedTime;
+    await new Promise((r) => setTimeout(r, 5));
+
+    const updated = updateTransaction(db, created.id, { description: 'Updated', amount: 25 });
+    expect(updated.id).toBe(created.id);
+    expect(updated.description).toBe('Updated');
+    expect(updated.amount).toBe(25);
+    expect(updated.account).toBe('Up');
+    expect(updated.date).toBe('2025-06-15');
+    expect(updated.lastEditedTime).not.toBe(original);
+  });
+
+  it('re-serialises tags from an array to a JSON string', () => {
+    const created = createTransaction(db, {
+      description: 'Test',
+      account: 'Up',
+      amount: 10,
+      date: '2025-06-15',
+      tags: ['Old'],
+    });
+    const updated = updateTransaction(db, created.id, { tags: ['Shopping', 'Online'] });
+    expect(updated.tags).toBe('["Shopping","Online"]');
+  });
+
+  it('clears a nullable field by setting to null', () => {
+    const created = createTransaction(db, {
+      description: 'Test',
+      account: 'Up',
+      amount: 10,
+      date: '2025-06-15',
+      notes: 'Some notes',
+      entityId: 'ent-1',
+      entityName: 'Foo',
+      location: 'Sydney',
+      country: 'AU',
+      relatedTransactionId: 'rel-1',
+    });
+    const updated = updateTransaction(db, created.id, {
+      notes: null,
+      entityId: null,
+      entityName: null,
+      location: null,
+      country: null,
+      relatedTransactionId: null,
+    });
+    expect(updated.notes).toBeNull();
+    expect(updated.entityId).toBeNull();
+    expect(updated.entityName).toBeNull();
+    expect(updated.location).toBeNull();
+    expect(updated.country).toBeNull();
+    expect(updated.relatedTransactionId).toBeNull();
+  });
+
+  it('is a no-op when the patch is empty (but still returns the row)', () => {
+    const created = createTransaction(db, {
+      description: 'Test',
+      account: 'Up',
+      amount: 10,
+      date: '2025-06-15',
+    });
+    const updated = updateTransaction(db, created.id, {});
+    expect(updated.lastEditedTime).toBe(created.lastEditedTime);
+    expect(updated.description).toBe('Test');
+  });
+
+  it('throws TransactionNotFoundError for an unknown id', () => {
+    expect(() => updateTransaction(db, 'missing', { description: 'x' })).toThrow(
+      TransactionNotFoundError
+    );
+  });
+});
+
+describe('deleteTransaction', () => {
+  let db: FinanceDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('removes the row and returns the snapshot', () => {
+    const created = createTransaction(db, {
+      description: 'To Delete',
+      account: 'Up',
+      amount: 10,
+      date: '2025-06-15',
+      tags: ['X'],
+      notes: 'Bye',
+    });
+    const snapshot = deleteTransaction(db, created.id);
+    expect(snapshot).toEqual(created);
+    expect(() => getTransaction(db, created.id)).toThrow(TransactionNotFoundError);
+  });
+
+  it('throws TransactionNotFoundError when the row is already gone', () => {
+    const created = createTransaction(db, {
+      description: 'X',
+      account: 'Up',
+      amount: 1,
+      date: '2025-06-15',
+    });
+    deleteTransaction(db, created.id);
+    expect(() => deleteTransaction(db, created.id)).toThrow(TransactionNotFoundError);
+  });
+
+  it('throws TransactionNotFoundError for an unknown id', () => {
+    expect(() => deleteTransaction(db, 'missing')).toThrow(TransactionNotFoundError);
+  });
+});
+
+describe('restoreTransaction', () => {
+  let db: FinanceDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('re-inserts a deleted row preserving id and dedup metadata', () => {
+    const created = createTransaction(db, {
+      description: 'Restored',
+      account: 'Up',
+      amount: 99,
+      date: '2025-06-15',
+      tags: ['Z'],
+      checksum: 'sum-1',
+      rawRow: 'raw-1',
+    });
+    const snapshot = deleteTransaction(db, created.id);
+
+    const restored = restoreTransaction(db, snapshot);
+    expect(restored.id).toBe(created.id);
+    expect(restored.checksum).toBe('sum-1');
+    expect(restored.rawRow).toBe('raw-1');
+    expect(restored.description).toBe('Restored');
+    expect(restored.tags).toBe(snapshot.tags);
+    expect(restored.lastEditedTime).toBe(snapshot.lastEditedTime);
+  });
+
+  it('throws TransactionAlreadyExistsError if a row with the same id exists', () => {
+    const created = createTransaction(db, {
+      description: 'X',
+      account: 'Up',
+      amount: 1,
+      date: '2025-06-15',
+    });
+    expect(() => restoreTransaction(db, created)).toThrow(TransactionAlreadyExistsError);
+  });
+
+  it('TransactionAlreadyExistsError carries the conflicting id', () => {
+    const created = createTransaction(db, {
+      description: 'X',
+      account: 'Up',
+      amount: 1,
+      date: '2025-06-15',
+    });
+    try {
+      restoreTransaction(db, created);
+      expect.fail('expected throw');
+    } catch (error) {
+      expect(error).toBeInstanceOf(TransactionAlreadyExistsError);
+      expect((error as TransactionAlreadyExistsError).id).toBe(created.id);
+    }
+  });
+});

--- a/packages/finance-db/src/errors.ts
+++ b/packages/finance-db/src/errors.ts
@@ -25,3 +25,23 @@ export class TransactionTagRuleNotFoundError extends Error {
     this.id = id;
   }
 }
+
+export class TransactionNotFoundError extends Error {
+  override readonly name = 'TransactionNotFoundError' as const;
+  readonly id: string;
+
+  constructor(id: string) {
+    super(`Transaction '${id}' not found`);
+    this.id = id;
+  }
+}
+
+export class TransactionAlreadyExistsError extends Error {
+  override readonly name = 'TransactionAlreadyExistsError' as const;
+  readonly id: string;
+
+  constructor(id: string) {
+    super(`Transaction '${id}' already exists`);
+    this.id = id;
+  }
+}

--- a/packages/finance-db/src/index.ts
+++ b/packages/finance-db/src/index.ts
@@ -43,3 +43,13 @@ export {
   type CreateTransactionTagRuleInput,
   type UpdateTransactionTagRuleInput,
 } from './services/transaction-tag-rules.js';
+
+export * as transactionsService from './services/transactions.js';
+
+export {
+  type CreateTransactionInput,
+  type TransactionFilters,
+  type TransactionListResult,
+  type TransactionRow,
+  type UpdateTransactionInput,
+} from './services/transactions.js';

--- a/packages/finance-db/src/schema.ts
+++ b/packages/finance-db/src/schema.ts
@@ -10,4 +10,4 @@
  *
  * Mirrors the `@pops/core-db` schema re-export pattern.
  */
-export { tagVocabulary, transactionTagRules, wishList } from '@pops/db-types';
+export { tagVocabulary, transactions, transactionTagRules, wishList } from '@pops/db-types';

--- a/packages/finance-db/src/services/transactions.ts
+++ b/packages/finance-db/src/services/transactions.ts
@@ -1,0 +1,264 @@
+/**
+ * Transactions CRUD against finance's SQLite via drizzle.
+ *
+ * Mirrors the wish-list pattern: db-arg services, typed domain errors,
+ * no HTTP / tRPC concerns. The in-tree service at
+ * `apps/pops-api/src/modules/finance/transactions/service.ts` still
+ * uses `getDrizzle()`; this package version takes a `FinanceDb` handle
+ * as its first argument. PR 3 of phase 1 flips the router to call into
+ * here.
+ *
+ * The `tags` column is stored as a JSON-encoded array of strings — the
+ * caller passes a `string[]` and persists `JSON.stringify(...)`. The
+ * parsing back into a `string[]` is the responsibility of the API
+ * presentation layer (it stays out of the persistence service so the
+ * raw row shape stays Drizzle-native).
+ *
+ * `restoreTransaction` exists for the Undo flow: delete returns the
+ * raw row snapshot, restore re-inserts it preserving the original `id`,
+ * `checksum`, `rawRow`, and `notionId` so dedup metadata is intact and
+ * any downstream link that still points at the original id resolves
+ * again.
+ */
+import { and, count, desc, eq, gte, like, lte, type SQL, sql } from 'drizzle-orm';
+
+import { TransactionAlreadyExistsError, TransactionNotFoundError } from '../errors.js';
+import { transactions } from '../schema.js';
+
+import type { FinanceDb } from './internal.js';
+
+/** Raw drizzle row shape — exposed so callers can reuse the inferred select type. */
+export type TransactionRow = typeof transactions.$inferSelect;
+
+/** Mutable subset accepted on create. `notionId` stays the import/sync layer's job. */
+export interface CreateTransactionInput {
+  description: string;
+  account: string;
+  amount: number;
+  date: string;
+  type?: string | undefined;
+  tags?: string[] | undefined;
+  entityId?: string | null | undefined;
+  entityName?: string | null | undefined;
+  location?: string | null | undefined;
+  country?: string | null | undefined;
+  relatedTransactionId?: string | null | undefined;
+  notes?: string | null | undefined;
+  /** Import-only: raw CSV row for audit trail. */
+  rawRow?: string | null | undefined;
+  /** Import-only: checksum for dedup. */
+  checksum?: string | null | undefined;
+}
+
+/** Same shape as create — all fields optional for PATCH semantics. */
+export interface UpdateTransactionInput {
+  description?: string;
+  account?: string;
+  amount?: number;
+  date?: string;
+  type?: string;
+  tags?: string[];
+  entityId?: string | null;
+  entityName?: string | null;
+  location?: string | null;
+  country?: string | null;
+  relatedTransactionId?: string | null;
+  notes?: string | null;
+}
+
+/** Filters accepted by `listTransactions`. */
+export interface TransactionFilters {
+  search?: string | undefined;
+  account?: string | undefined;
+  startDate?: string | undefined;
+  endDate?: string | undefined;
+  tag?: string | undefined;
+  entityId?: string | undefined;
+  type?: string | undefined;
+}
+
+/** Count + rows for a paginated list. */
+export interface TransactionListResult {
+  rows: TransactionRow[];
+  total: number;
+}
+
+function buildListConditions(filters: TransactionFilters): SQL[] {
+  const conditions: SQL[] = [];
+  if (filters.search) {
+    conditions.push(like(transactions.description, `%${filters.search}%`));
+  }
+  if (filters.account) {
+    conditions.push(eq(transactions.account, filters.account));
+  }
+  if (filters.startDate) {
+    conditions.push(gte(transactions.date, filters.startDate));
+  }
+  if (filters.endDate) {
+    conditions.push(lte(transactions.date, filters.endDate));
+  }
+  if (filters.tag) {
+    conditions.push(
+      sql`EXISTS (SELECT 1 FROM json_each(${transactions.tags}) WHERE json_each.value = ${filters.tag})`
+    );
+  }
+  if (filters.entityId) {
+    conditions.push(eq(transactions.entityId, filters.entityId));
+  }
+  if (filters.type) {
+    conditions.push(eq(transactions.type, filters.type));
+  }
+  return conditions;
+}
+
+/** List transactions with optional filters. Sorted by date DESC, newest first. */
+export function listTransactions(
+  db: FinanceDb,
+  filters: TransactionFilters,
+  limit: number,
+  offset: number
+): TransactionListResult {
+  const conditions = buildListConditions(filters);
+  const where = conditions.length > 0 ? and(...conditions) : undefined;
+
+  const rows = db
+    .select()
+    .from(transactions)
+    .where(where)
+    .orderBy(desc(transactions.date))
+    .limit(limit)
+    .offset(offset)
+    .all();
+  const countRow = db.select({ total: count() }).from(transactions).where(where).all()[0];
+
+  return { rows, total: countRow?.total ?? 0 };
+}
+
+/** Get a single transaction by id. Throws `TransactionNotFoundError` if missing. */
+export function getTransaction(db: FinanceDb, id: string): TransactionRow {
+  const row = db.select().from(transactions).where(eq(transactions.id, id)).get();
+  if (!row) throw new TransactionNotFoundError(id);
+  return row;
+}
+
+/**
+ * Create a new transaction. Generates a UUID, persists, and returns the row.
+ *
+ * `type` defaults to '' for parity with the in-tree service — the column is
+ * `NOT NULL` and historic rows have empty-string defaults rather than a real
+ * categorisation. `tags` defaults to `[]` serialised.
+ */
+export function createTransaction(db: FinanceDb, input: CreateTransactionInput): TransactionRow {
+  const id = crypto.randomUUID();
+  const now = new Date().toISOString();
+
+  db.insert(transactions)
+    .values({
+      id,
+      description: input.description,
+      account: input.account,
+      amount: input.amount,
+      date: input.date,
+      type: input.type ?? '',
+      tags: JSON.stringify(input.tags ?? []),
+      entityId: input.entityId ?? null,
+      entityName: input.entityName ?? null,
+      location: input.location ?? null,
+      country: input.country ?? null,
+      relatedTransactionId: input.relatedTransactionId ?? null,
+      notes: input.notes ?? null,
+      checksum: input.checksum ?? null,
+      rawRow: input.rawRow ?? null,
+      lastEditedTime: now,
+    })
+    .run();
+
+  return getTransaction(db, id);
+}
+
+type TransactionUpdate = Partial<typeof transactions.$inferInsert>;
+
+function applyCoreFields(input: UpdateTransactionInput, updates: TransactionUpdate): void {
+  if (input.description !== undefined) updates.description = input.description;
+  if (input.account !== undefined) updates.account = input.account;
+  if (input.amount !== undefined) updates.amount = input.amount;
+  if (input.date !== undefined) updates.date = input.date;
+  if (input.type !== undefined) updates.type = input.type;
+  if (input.tags !== undefined) updates.tags = JSON.stringify(input.tags);
+}
+
+function applyEntityFields(input: UpdateTransactionInput, updates: TransactionUpdate): void {
+  if (input.entityId !== undefined) updates.entityId = input.entityId ?? null;
+  if (input.entityName !== undefined) updates.entityName = input.entityName ?? null;
+}
+
+function applyLocationFields(input: UpdateTransactionInput, updates: TransactionUpdate): void {
+  if (input.location !== undefined) updates.location = input.location ?? null;
+  if (input.country !== undefined) updates.country = input.country ?? null;
+}
+
+function applyMetadataFields(input: UpdateTransactionInput, updates: TransactionUpdate): void {
+  if (input.relatedTransactionId !== undefined) {
+    updates.relatedTransactionId = input.relatedTransactionId ?? null;
+  }
+  if (input.notes !== undefined) updates.notes = input.notes ?? null;
+}
+
+function buildTransactionUpdates(input: UpdateTransactionInput): TransactionUpdate {
+  const updates: TransactionUpdate = {};
+  applyCoreFields(input, updates);
+  applyEntityFields(input, updates);
+  applyLocationFields(input, updates);
+  applyMetadataFields(input, updates);
+  return updates;
+}
+
+/**
+ * Patch a transaction. Throws `TransactionNotFoundError` if missing.
+ * No-op writes (empty `input`) still re-read the row but skip the UPDATE.
+ */
+export function updateTransaction(
+  db: FinanceDb,
+  id: string,
+  input: UpdateTransactionInput
+): TransactionRow {
+  getTransaction(db, id);
+
+  const updates = buildTransactionUpdates(input);
+  if (Object.keys(updates).length > 0) {
+    updates.lastEditedTime = new Date().toISOString();
+    db.update(transactions).set(updates).where(eq(transactions.id, id)).run();
+  }
+
+  return getTransaction(db, id);
+}
+
+/**
+ * Delete a transaction by id. Throws `TransactionNotFoundError` if missing.
+ *
+ * Returns the deleted row snapshot so a caller can hand it to
+ * `restoreTransaction` for an Undo flow.
+ */
+export function deleteTransaction(db: FinanceDb, id: string): TransactionRow {
+  const snapshot = getTransaction(db, id);
+
+  const result = db.delete(transactions).where(eq(transactions.id, id)).run();
+  if (result.changes === 0) throw new TransactionNotFoundError(id);
+  return snapshot;
+}
+
+/**
+ * Restore a previously-deleted transaction from a server-issued snapshot.
+ *
+ * Re-inserts preserving the original id, checksum, raw_row, and notion_id
+ * so dedup metadata is intact. Throws `TransactionAlreadyExistsError` if a
+ * row with the same id is already present (caller should handle that case).
+ */
+export function restoreTransaction(db: FinanceDb, snapshot: TransactionRow): TransactionRow {
+  const existing = db.select().from(transactions).where(eq(transactions.id, snapshot.id)).get();
+  if (existing) {
+    throw new TransactionAlreadyExistsError(snapshot.id);
+  }
+  db.insert(transactions).values(snapshot).run();
+  return getTransaction(db, snapshot.id);
+}


### PR DESCRIPTION
## Summary

- First PR of the 4-PR sequence to migrate the finance `transactions` slice from `apps/pops-api/src/modules/finance/transactions/` into `@pops/finance-db` (Track N2 of the deferred-backlog tracker in `.claude/pillar-migration-roadmap.md`, tracking issue #2838).
- Mirrors the wish-list pilot (#2766), tag_vocabulary (#2852), and transaction_tag_rules (#2856) patterns — strictly additive, no behaviour change, in-tree callers untouched.
- Adds `transactionsService` (`listTransactions`, `getTransaction`, `createTransaction`, `updateTransaction`, `deleteTransaction`, `restoreTransaction`) as db-arg functions on `FinanceDb`, plus the `TransactionRow`, `CreateTransactionInput`, `UpdateTransactionInput`, `TransactionFilters`, `TransactionListResult` types and the `transactions` schema re-export.

## Scope

This is **PR 1 of 4** for the N2 slice, per the [CI-never-breaks 4×4 pattern](../../../.claude/pillar-migration-roadmap.md#ci-never-breaks-pattern).

Deferred to subsequent N2 PRs:
- **PR 2** — Migration journal split + drift-guard CI for the `transactions` portion of `0000_naive_chameleon`. The CREATE TABLE / indices are already in `apps/pops-api/src/db/drizzle-migrations/0000_naive_chameleon.sql`; the package journal needs to claim them via a finance-pillar baseline entry similar to `0053_finance_pillar_baseline.sql` (which currently covers `entities` / `transaction_corrections` / `budgets` / `wish_list` but not yet `transactions`).
- **PR 3** — Router cutover. Flip `apps/pops-api/src/modules/finance/transactions/router.ts` to delegate into `@pops/finance-db`'s `transactionsService`. Wire `mapDomainErrors` to surface `TransactionNotFoundError` / `TransactionAlreadyExistsError` as `NOT_FOUND` / `CONFLICT`. **Gated on N3 (transaction_corrections)** — PR 3 must land after N3's cutover so the sibling-FK threading is clean.
- **PR 4** — Delete the in-tree `service.ts` / `types.ts` once the router cutover is done; keep `router.ts` until the writer-move (Track M2).

## Files

- `packages/finance-db/src/services/transactions.ts` (281 lines) — db-arg `listTransactions` / `getTransaction` / `createTransaction` / `updateTransaction` / `deleteTransaction` / `restoreTransaction`, type exports. List helper split into a `buildListConditions` pure builder; update helper split into `applyCoreFields` / `applyEntityFields` / `applyLocationFields` / `applyMetadataFields` for readability.
- `packages/finance-db/src/schema.ts` — add `transactions` to the re-export alongside `tagVocabulary`, `transactionTagRules`, `wishList`.
- `packages/finance-db/src/errors.ts` — add `TransactionNotFoundError` and `TransactionAlreadyExistsError` alongside `WishListItemNotFoundError` / `TransactionTagRuleNotFoundError`.
- `packages/finance-db/src/index.ts` — barrel exports `transactionsService` namespace + 5 type re-exports.
- `packages/finance-db/src/__tests__/transactions.test.ts` — 32 in-memory unit tests against the inlined canonical `transactions` DDL (mirrors the wish-list / tag-vocabulary test layout). Coverage:
  - `createTransaction` × 5 — UUID + `lastEditedTime` shape, `type` defaulting to `''`, tags JSON-serialised, optional fields default null, every optional field persists.
  - `getTransaction` × 3 — round-trip, `TransactionNotFoundError`, error carries id.
  - `listTransactions` × 12 — DESC ordering + total count, search LIKE, account / startDate / endDate / range filters, tag membership via `json_each` (and the partial-substring negative case), entityId / type filters, multi-filter AND, pagination, empty result shape.
  - `updateTransaction` × 5 — partial patch + `lastEditedTime` bump, tags re-serialisation, null-clearing for every nullable field, no-op empty patch, NotFound.
  - `deleteTransaction` × 3 — snapshot return + row removal, idempotence (second delete throws), NotFound.
  - `restoreTransaction` × 3 — round-trip preserving id / checksum / rawRow / lastEditedTime, `TransactionAlreadyExistsError` on duplicate, error carries id.

## Coordination

- N1 (budgets) PR #2855 was open during this work but had not landed at rebase time. Schema.ts inherits `transactionTagRules` from N4 (PR #2856) cleanly; when N1 lands, the conflict resolution will be a one-token diff in `schema.ts` and `index.ts` — same pattern as this PR resolved against N4.
- N3 (transaction_corrections) is in flight — PR 3 of this sequence is gated on it.

## Notes

- The in-tree `apps/pops-api/src/modules/finance/transactions/service.ts` is left untouched, so all existing callers keep working through `getDrizzle()`. Router cutover comes in PR 3 (gated on N3).
- `restoreTransaction` is preserved because the in-tree service uses it for the Undo flow; the typed error path replaces the original `new Error(...)` string match.
- No `JSON.parse` happens in the persistence layer — `tags` round-trips as a serialised string. The pops-api presentation layer continues to do the `string[]` parse on read (per the existing `toTransaction` in `apps/pops-api/src/modules/finance/transactions/types.ts`).
- No typed-error wiring needed beyond the two new errors — `restoreTransaction`'s original string-match error (`Transaction '<id>' already exists`) is now a typed `TransactionAlreadyExistsError`, which is strictly safer for callers.

## Test plan

- [x] `pnpm --filter @pops/finance-db typecheck`
- [x] `pnpm --filter @pops/finance-db test` (82 / 82 passing — 32 new transactions + 50 prior across wishlist / tag-vocabulary / transaction-tag-rules / open-finance-db)
- [x] `pnpm --filter @pops/finance-db build`
- [x] `pnpm typecheck` (full repo — 45 / 45 tasks)
- [x] `pnpm --filter @pops/api test` (4842 / 4842 passing)
- [x] `pnpm build` (21 / 21 tasks)
- [x] `pnpm lint` clean (warnings only, all preexisting)