### PR TITLE
feat(food-db): scaffold @pops/food-db + prep_states slice (Track J phase 1 PR 1)

### DIFF
--- a/.github/workflows/_pkg-check.yml
+++ b/.github/workflows/_pkg-check.yml
@@ -51,6 +51,7 @@ jobs:
           pnpm --filter @pops/inventory-db build
           pnpm --filter @pops/media-db build
           pnpm --filter @pops/cerebrum-db build
+          pnpm --filter @pops/food-db build
           pnpm --filter @pops/app-lists-db build
           pnpm --filter @pops/app-food-db build
       - run: cd ${{ inputs.package-path }} && pnpm typecheck
@@ -87,6 +88,7 @@ jobs:
           pnpm --filter @pops/inventory-db build
           pnpm --filter @pops/media-db build
           pnpm --filter @pops/cerebrum-db build
+          pnpm --filter @pops/food-db build
           pnpm --filter @pops/app-lists-db build
           pnpm --filter @pops/app-food-db build
       - name: Run tests (with coverage if configured)

--- a/.github/workflows/api-quality.yml
+++ b/.github/workflows/api-quality.yml
@@ -10,6 +10,7 @@ on:
       - "packages/cerebrum-db/**"
       - "packages/db-types/**"
       - "packages/finance-db/**"
+      - "packages/food-db/**"
       - "packages/inventory-db/**"
       - "packages/types/**"
       - ".github/workflows/api-quality.yml"
@@ -32,6 +33,7 @@ jobs:
               - 'packages/cerebrum-db/**'
               - 'packages/db-types/**'
               - 'packages/finance-db/**'
+              - 'packages/food-db/**'
               - 'packages/inventory-db/**'
               - 'packages/types/**'
               - '.github/workflows/api-quality.yml'
@@ -78,6 +80,7 @@ jobs:
           cd ../inventory-db && pnpm build
           cd ../media-db && pnpm build
           cd ../cerebrum-db && pnpm build
+          cd ../food-db && pnpm build
           cd ../app-lists-db && pnpm build
           cd ../app-food-db && pnpm build
 

--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -8,6 +8,7 @@ on:
       - "packages/cerebrum-db/**"
       - "packages/db-types/**"
       - "packages/finance-db/**"
+      - "packages/food-db/**"
       - "packages/inventory-db/**"
       - "packages/types/**"
       - "packages/auth/**"
@@ -32,6 +33,7 @@ jobs:
               - 'packages/cerebrum-db/**'
               - 'packages/db-types/**'
               - 'packages/finance-db/**'
+              - 'packages/food-db/**'
               - 'packages/inventory-db/**'
               - 'packages/types/**'
               - 'packages/auth/**'
@@ -79,6 +81,7 @@ jobs:
           cd ../inventory-db && pnpm build
           cd ../media-db && pnpm build
           cd ../cerebrum-db && pnpm build
+          cd ../food-db && pnpm build
           cd ../app-lists-db && pnpm build
           cd ../app-food-db && pnpm build
 

--- a/.github/workflows/fe-quality.yml
+++ b/.github/workflows/fe-quality.yml
@@ -8,6 +8,7 @@ on:
       - "packages/app-*/**"
       - "packages/cerebrum-db/**"
       - "packages/db-types/**"
+      - "packages/food-db/**"
       - "packages/inventory-db/**"
       - "packages/ui/**"
       - "packages/api-client/**"
@@ -35,6 +36,7 @@ jobs:
               - 'packages/app-*/**'
               - 'packages/cerebrum-db/**'
               - 'packages/db-types/**'
+              - 'packages/food-db/**'
               - 'packages/inventory-db/**'
               - 'packages/ui/**'
               - 'packages/api-client/**'
@@ -82,6 +84,7 @@ jobs:
           cd ../inventory-db && pnpm build
           cd ../media-db && pnpm build
           cd ../cerebrum-db && pnpm build
+          cd ../food-db && pnpm build
           cd ../app-lists-db && pnpm build
           cd ../app-food-db && pnpm build
 

--- a/.github/workflows/fe-test-e2e.yml
+++ b/.github/workflows/fe-test-e2e.yml
@@ -67,6 +67,7 @@ jobs:
           cd ../inventory-db && pnpm build
           cd ../media-db && pnpm build
           cd ../cerebrum-db && pnpm build
+          cd ../food-db && pnpm build
           cd ../app-lists-db && pnpm build
           cd ../app-food-db && pnpm build
 

--- a/.github/workflows/food-db-quality.yml
+++ b/.github/workflows/food-db-quality.yml
@@ -1,0 +1,67 @@
+name: Food DB Quality
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/food-db/**"
+      - "packages/db-types/**"
+      - "apps/pops-api/src/db/drizzle-migrations/0058_high_sentinel.sql"
+      - ".github/workflows/food-db-quality.yml"
+      - ".github/workflows/_pkg-check.yml"
+  pull_request:
+
+jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - 'packages/food-db/**'
+              - 'packages/db-types/**'
+              - 'apps/pops-api/src/db/drizzle-migrations/0058_high_sentinel.sql'
+              - '.github/workflows/food-db-quality.yml'
+              - '.github/workflows/_pkg-check.yml'
+
+  migration-drift-guard:
+    name: Migration drift (shared vs food-db)
+    needs: [changes]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Skip — no relevant changes"
+        if: github.event_name == 'pull_request' && needs.changes.outputs.relevant != 'true'
+        run: echo "Skipping — no relevant changes"
+      - uses: actions/checkout@v6
+        if: github.event_name != 'pull_request' || needs.changes.outputs.relevant == 'true'
+      - name: Diff food-db copies against shared journal copies
+        if: github.event_name != 'pull_request' || needs.changes.outputs.relevant == 'true'
+        run: |
+          set -euo pipefail
+          for tag in 0058_high_sentinel; do
+            shared="apps/pops-api/src/db/drizzle-migrations/${tag}.sql"
+            pillar="packages/food-db/migrations/${tag}.sql"
+            if ! diff -q "$shared" "$pillar"; then
+              echo "::error::Migration drift detected: $shared and $pillar must be byte-identical during the transitional release cycle (food pillar phase 1)."
+              diff "$shared" "$pillar" || true
+              exit 1
+            fi
+            echo "OK — both ${tag}.sql copies are byte-identical."
+          done
+
+  quality:
+    needs: [changes]
+    if: always()
+    uses: ./.github/workflows/_pkg-check.yml
+    with:
+      package-path: packages/food-db
+      needs-db-build: true
+      skip: ${{ github.event_name == 'pull_request' && needs.changes.outputs.relevant != 'true' }}

--- a/apps/pops-api/Dockerfile
+++ b/apps/pops-api/Dockerfile
@@ -17,6 +17,7 @@ COPY packages/media-db/package.json ./packages/media-db/
 COPY packages/food-contracts/package.json ./packages/food-contracts/
 COPY packages/inventory-db/package.json ./packages/inventory-db/
 COPY packages/cerebrum-db/package.json ./packages/cerebrum-db/
+COPY packages/food-db/package.json ./packages/food-db/
 COPY apps/pops-api/package.json ./apps/pops-api/
 
 # Install pnpm and dependencies (cached across builds)
@@ -51,6 +52,9 @@ COPY packages/inventory-db/migrations ./packages/inventory-db/migrations
 COPY packages/cerebrum-db/src ./packages/cerebrum-db/src
 COPY packages/cerebrum-db/tsconfig.json ./packages/cerebrum-db/
 COPY packages/cerebrum-db/migrations ./packages/cerebrum-db/migrations
+COPY packages/food-db/src ./packages/food-db/src
+COPY packages/food-db/tsconfig.json ./packages/food-db/
+COPY packages/food-db/migrations ./packages/food-db/migrations
 COPY apps/pops-api/tsconfig.json ./apps/pops-api/
 COPY apps/pops-api/src ./apps/pops-api/src
 
@@ -72,6 +76,8 @@ RUN pnpm build
 WORKDIR /app/packages/media-db
 RUN pnpm build
 WORKDIR /app/packages/cerebrum-db
+RUN pnpm build
+WORKDIR /app/packages/food-db
 RUN pnpm build
 WORKDIR /app/packages/app-lists-db
 RUN pnpm build
@@ -125,6 +131,9 @@ COPY --from=builder /app/packages/media-db/migrations ./node_modules/@pops/media
 COPY --from=builder /app/packages/cerebrum-db/dist ./node_modules/@pops/cerebrum-db/dist
 COPY --from=builder /app/packages/cerebrum-db/package.json ./node_modules/@pops/cerebrum-db/
 COPY --from=builder /app/packages/cerebrum-db/migrations ./node_modules/@pops/cerebrum-db/migrations
+COPY --from=builder /app/packages/food-db/dist ./node_modules/@pops/food-db/dist
+COPY --from=builder /app/packages/food-db/package.json ./node_modules/@pops/food-db/
+COPY --from=builder /app/packages/food-db/migrations ./node_modules/@pops/food-db/migrations
 
 # Copy types source into node_modules (source-only package, no build step)
 COPY --from=builder /app/packages/types/src ./node_modules/@pops/types/src

--- a/apps/pops-mcp/Dockerfile
+++ b/apps/pops-mcp/Dockerfile
@@ -17,6 +17,7 @@ COPY packages/media-db/package.json ./packages/media-db/
 COPY packages/food-contracts/package.json ./packages/food-contracts/
 COPY packages/inventory-db/package.json ./packages/inventory-db/
 COPY packages/cerebrum-db/package.json ./packages/cerebrum-db/
+COPY packages/food-db/package.json ./packages/food-db/
 COPY apps/pops-api/package.json ./apps/pops-api/
 COPY apps/pops-mcp/package.json ./apps/pops-mcp/
 
@@ -52,6 +53,9 @@ COPY packages/inventory-db/migrations ./packages/inventory-db/migrations
 COPY packages/cerebrum-db/src ./packages/cerebrum-db/src
 COPY packages/cerebrum-db/tsconfig.json ./packages/cerebrum-db/
 COPY packages/cerebrum-db/migrations ./packages/cerebrum-db/migrations
+COPY packages/food-db/src ./packages/food-db/src
+COPY packages/food-db/tsconfig.json ./packages/food-db/
+COPY packages/food-db/migrations ./packages/food-db/migrations
 
 # Copy pops-api source (needed only for AppRouter type resolution at compile time)
 COPY apps/pops-api/tsconfig.json ./apps/pops-api/
@@ -80,6 +84,8 @@ RUN pnpm build
 WORKDIR /app/packages/media-db
 RUN pnpm build
 WORKDIR /app/packages/cerebrum-db
+RUN pnpm build
+WORKDIR /app/packages/food-db
 RUN pnpm build
 WORKDIR /app/packages/app-lists-db
 RUN pnpm build

--- a/apps/pops-shell/Dockerfile
+++ b/apps/pops-shell/Dockerfile
@@ -20,6 +20,7 @@ COPY packages/finance-db/package.json ./packages/finance-db/
 COPY packages/inventory-db/package.json ./packages/inventory-db/
 COPY packages/media-db/package.json ./packages/media-db/
 COPY packages/cerebrum-db/package.json ./packages/cerebrum-db/
+COPY packages/food-db/package.json ./packages/food-db/
 COPY packages/app-media/package.json ./packages/app-media/
 COPY packages/app-inventory/package.json ./packages/app-inventory/
 COPY packages/app-ai/package.json ./packages/app-ai/
@@ -49,6 +50,7 @@ COPY packages/finance-db/ ./packages/finance-db/
 COPY packages/inventory-db/ ./packages/inventory-db/
 COPY packages/media-db/ ./packages/media-db/
 COPY packages/cerebrum-db/ ./packages/cerebrum-db/
+COPY packages/food-db/ ./packages/food-db/
 COPY packages/food-contracts/ ./packages/food-contracts/
 WORKDIR /app/packages/db-types
 RUN pnpm build
@@ -67,6 +69,8 @@ RUN pnpm build
 WORKDIR /app/packages/media-db
 RUN pnpm build
 WORKDIR /app/packages/cerebrum-db
+RUN pnpm build
+WORKDIR /app/packages/food-db
 RUN pnpm build
 WORKDIR /app/packages/app-lists-db
 RUN pnpm build

--- a/packages/app-food-db/src/index.ts
+++ b/packages/app-food-db/src/index.ts
@@ -14,6 +14,12 @@ export * from './errors.js';
 export * from './schema.js';
 export * from './slug.js';
 
+// Re-export from `@pops/food-db` for the slices that have moved to the
+// pillar package as part of Track J phase 1. Existing imports from
+// `@pops/app-food-db` keep resolving — the shim narrows over time as more
+// slices migrate, and disappears entirely in Track J phase 1 PR 4.
+export { PrepStateNotFoundError } from '@pops/food-db';
+
 // Drizzle handle type — re-exported so consumers don't have to reach
 // into the internal services module.
 export { MAX_INGREDIENT_DEPTH, type FoodDb } from './services/internal.js';

--- a/packages/food-db/migrations/0058_high_sentinel.sql
+++ b/packages/food-db/migrations/0058_high_sentinel.sql
@@ -1,0 +1,68 @@
+CREATE TABLE `ingredient_aliases` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`ingredient_id` integer,
+	`variant_id` integer,
+	`alias` text NOT NULL,
+	`source` text NOT NULL,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL,
+	FOREIGN KEY (`ingredient_id`) REFERENCES `ingredients`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`variant_id`) REFERENCES `ingredient_variants`(`id`) ON UPDATE no action ON DELETE no action,
+	CONSTRAINT "ck_aliases_xor_target" CHECK(("ingredient_aliases"."ingredient_id" IS NOT NULL) <> ("ingredient_aliases"."variant_id" IS NOT NULL)),
+	CONSTRAINT "ck_aliases_source" CHECK("ingredient_aliases"."source" IN ('user','llm','ingest'))
+);
+--> statement-breakpoint
+CREATE INDEX `idx_aliases_alias` ON `ingredient_aliases` (`alias` COLLATE NOCASE);--> statement-breakpoint
+-- Partial uniques split the PRD's `UNIQUE (alias, ingredient_id, variant_id)` into two
+-- index expressions, because SQLite treats NULL as distinct in compound UNIQUE
+-- constraints. With the XOR CHECK above, exactly one of these applies per row.
+CREATE UNIQUE INDEX `uq_aliases_alias_ingredient` ON `ingredient_aliases` (`alias`,`ingredient_id`) WHERE `variant_id` IS NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX `uq_aliases_alias_variant` ON `ingredient_aliases` (`alias`,`variant_id`) WHERE `ingredient_id` IS NULL;--> statement-breakpoint
+CREATE TABLE `ingredient_variants` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`ingredient_id` integer NOT NULL,
+	`name` text NOT NULL,
+	`slug` text NOT NULL,
+	`default_unit` text NOT NULL,
+	`package_size_g` real,
+	`notes` text,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL,
+	FOREIGN KEY (`ingredient_id`) REFERENCES `ingredients`(`id`) ON UPDATE no action ON DELETE no action,
+	CONSTRAINT "ck_variants_default_unit" CHECK("ingredient_variants"."default_unit" IN ('g','ml','count'))
+);
+--> statement-breakpoint
+CREATE INDEX `idx_variants_ingredient` ON `ingredient_variants` (`ingredient_id`);--> statement-breakpoint
+CREATE INDEX `idx_variants_name` ON `ingredient_variants` (`name` COLLATE NOCASE);--> statement-breakpoint
+CREATE UNIQUE INDEX `uq_variants_ingredient_slug` ON `ingredient_variants` (`ingredient_id`,`slug`);--> statement-breakpoint
+CREATE TABLE `ingredients` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`parent_id` integer,
+	`name` text NOT NULL,
+	`slug` text NOT NULL,
+	`default_unit` text NOT NULL,
+	`density_g_per_ml` real,
+	`notes` text,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL,
+	FOREIGN KEY (`parent_id`) REFERENCES `ingredients`(`id`) ON UPDATE no action ON DELETE no action,
+	CONSTRAINT "ck_ingredients_default_unit" CHECK("ingredients"."default_unit" IN ('g','ml','count'))
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `ingredients_slug_unique` ON `ingredients` (`slug`);--> statement-breakpoint
+CREATE INDEX `idx_ingredients_parent` ON `ingredients` (`parent_id`);--> statement-breakpoint
+CREATE INDEX `idx_ingredients_name` ON `ingredients` (`name` COLLATE NOCASE);--> statement-breakpoint
+CREATE TABLE `prep_states` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`name` text NOT NULL,
+	`slug` text NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `prep_states_name_unique` ON `prep_states` (`name`);--> statement-breakpoint
+CREATE UNIQUE INDEX `prep_states_slug_unique` ON `prep_states` (`slug`);--> statement-breakpoint
+CREATE TABLE `slug_registry` (
+	`slug` text PRIMARY KEY NOT NULL,
+	`kind` text NOT NULL,
+	`target_id` integer NOT NULL,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL,
+	CONSTRAINT "ck_slug_registry_kind" CHECK("slug_registry"."kind" IN ('ingredient','recipe','prep_state'))
+);
+--> statement-breakpoint
+CREATE INDEX `idx_slug_registry_kind_target` ON `slug_registry` (`kind`,`target_id`);

--- a/packages/food-db/migrations/meta/_journal.json
+++ b/packages/food-db/migrations/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "6",
+      "when": 1780921852351,
+      "tag": "0058_high_sentinel",
+      "breakpoints": true
+    }
+  ]
+}

--- a/packages/food-db/package.json
+++ b/packages/food-db/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@pops/app-food-db",
+  "name": "@pops/food-db",
   "version": "0.1.0",
   "private": true,
   "type": "module",
@@ -10,10 +10,7 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
-    "./seed": {
-      "types": "./dist/seed/index.d.ts",
-      "default": "./dist/seed/index.js"
-    }
+    "./package.json": "./package.json"
   },
   "scripts": {
     "build": "tsc",
@@ -23,16 +20,13 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@pops/app-lists-db": "workspace:*",
     "@pops/db-types": "workspace:*",
-    "@pops/food-contracts": "workspace:*",
-    "@pops/food-db": "workspace:*",
+    "better-sqlite3": "^12.10.0",
     "drizzle-orm": "^0.45.2"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.12",
     "@vitest/coverage-v8": "^4.1.8",
-    "better-sqlite3": "^12.10.0",
     "typescript": "^6.0.3",
     "vitest": "^4.1.8"
   }

--- a/packages/food-db/src/__tests__/prep-states.test.ts
+++ b/packages/food-db/src/__tests__/prep-states.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Invariant tests for the prep-states service against an in-memory SQLite
+ * seeded with the canonical `prep_states` migration. Pure DB + service
+ * layer — no tRPC, no Express, no auth middleware.
+ *
+ * Higher-level tRPC coverage lives in pops-api's own integration suite
+ * until the cutover PR routes it through this package.
+ *
+ * The `prep_states` CREATE TABLE is read from the package-local migration
+ * copy at `packages/food-db/migrations/0058_high_sentinel.sql`. A drift
+ * guard in `food-db-quality.yml` keeps that file byte-identical to the
+ * shared journal copy at
+ * `apps/pops-api/src/db/drizzle-migrations/0058_high_sentinel.sql` until
+ * the eventual journal-split + deletion PR retires the shared one.
+ *
+ * The 0058 SQL also creates ingredients/variants/aliases/slug_registry —
+ * the test re-uses the full file because the additional tables are
+ * harmless to a prep_states unit suite and applying the same SQL the
+ * shared journal applies is the strongest possible match.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import Database from 'better-sqlite3';
+import { eq } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { PrepStateNotFoundError } from '../errors.js';
+import { prepStates } from '../schema.js';
+import { getPrepState, listPrepStates } from '../services/prep-states.js';
+
+import type { FoodDb } from '../services/internal.js';
+
+const FOOD_MIGRATION = join(__dirname, '../../migrations/0058_high_sentinel.sql');
+
+function freshDb(): FoodDb {
+  const raw = new Database(':memory:');
+  raw.pragma('foreign_keys = ON');
+  const sql = readFileSync(FOOD_MIGRATION, 'utf8');
+  for (const stmt of sql.split('--> statement-breakpoint')) {
+    const trimmed = stmt.trim();
+    if (trimmed.length > 0) raw.exec(trimmed);
+  }
+  return drizzle(raw);
+}
+
+interface Seed {
+  name: string;
+  slug: string;
+}
+
+function seed(db: FoodDb, rows: Seed[]): number[] {
+  const ids: number[] = [];
+  for (const row of rows) {
+    const inserted = db
+      .insert(prepStates)
+      .values({ name: row.name, slug: row.slug })
+      .returning()
+      .get();
+    if (inserted === undefined) throw new Error('insert returned no row');
+    ids.push(inserted.id);
+  }
+  return ids;
+}
+
+describe('listPrepStates', () => {
+  let db: FoodDb;
+
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('returns the empty array against a fresh schema', () => {
+    expect(listPrepStates(db)).toEqual([]);
+  });
+
+  it('returns rows in id-ascending order regardless of insert sequence', () => {
+    seed(db, [
+      { name: 'Diced', slug: 'diced' },
+      { name: 'Whole', slug: 'whole' },
+      { name: 'Sliced', slug: 'sliced' },
+    ]);
+
+    const rows = listPrepStates(db);
+
+    expect(rows.map((r) => r.slug)).toEqual(['diced', 'whole', 'sliced']);
+    expect(rows.map((r) => r.id)).toEqual([...rows.map((r) => r.id)].toSorted((a, b) => a - b));
+  });
+
+  it('surfaces every row — no implicit pagination', () => {
+    const seeds = Array.from({ length: 25 }, (_, i) => ({
+      name: `State ${i}`,
+      slug: `state-${i}`,
+    }));
+    seed(db, seeds);
+
+    expect(listPrepStates(db)).toHaveLength(25);
+  });
+});
+
+describe('getPrepState', () => {
+  let db: FoodDb;
+  let dicedId: number;
+  let wholeId: number;
+
+  beforeEach(() => {
+    db = freshDb();
+    const ids = seed(db, [
+      { name: 'Diced', slug: 'diced' },
+      { name: 'Whole', slug: 'whole' },
+    ]);
+    const first = ids[0];
+    const second = ids[1];
+    if (first === undefined || second === undefined) {
+      throw new Error('seed did not return the expected number of ids');
+    }
+    dicedId = first;
+    wholeId = second;
+  });
+
+  it('returns the row matching the id', () => {
+    const row = getPrepState(db, dicedId);
+
+    expect(row.slug).toBe('diced');
+    expect(row.name).toBe('Diced');
+  });
+
+  it('throws PrepStateNotFoundError when no row matches', () => {
+    expect(() => getPrepState(db, 999_999)).toThrow(PrepStateNotFoundError);
+  });
+
+  it('the thrown error carries the queried id', () => {
+    try {
+      getPrepState(db, 42);
+      throw new Error('expected getPrepState to throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(PrepStateNotFoundError);
+      if (err instanceof PrepStateNotFoundError) {
+        expect(err.id).toBe(42);
+        expect(err.name).toBe('PrepStateNotFoundError');
+      }
+    }
+  });
+
+  it('does not match a deleted row', () => {
+    db.delete(prepStates).where(eq(prepStates.id, wholeId)).run();
+
+    expect(() => getPrepState(db, wholeId)).toThrow(PrepStateNotFoundError);
+  });
+});

--- a/packages/food-db/src/errors.ts
+++ b/packages/food-db/src/errors.ts
@@ -1,0 +1,18 @@
+/**
+ * Typed errors raised by the food domain service layer.
+ *
+ * Plain Error subclasses — the service layer doesn't know about HTTP.
+ * Pops-api routers map them to the appropriate tRPC codes when surfacing
+ * to clients. Mirrors `@pops/inventory-db` / `@pops/finance-db` /
+ * `@pops/media-db` / `@pops/cerebrum-db` error patterns.
+ */
+
+export class PrepStateNotFoundError extends Error {
+  override readonly name = 'PrepStateNotFoundError' as const;
+  readonly id: number;
+
+  constructor(id: number) {
+    super(`Prep state '${id}' not found`);
+    this.id = id;
+  }
+}

--- a/packages/food-db/src/index.ts
+++ b/packages/food-db/src/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Backend-safe barrel for the food domain's persistence layer.
+ *
+ * Hosts food pillar tables (Phase 1 PR 1 surfaces `prep_states`; the
+ * remaining slices — ingredients, variants, recipes, recipe_versions,
+ * recipe_runs, batches, ingest_sources, plan_slots, plan_entries,
+ * substitutions, unit_conversions, ingredient_tags, slug_registry, and
+ * the DSL pipeline — follow in subsequent slice PRs). Extracted from
+ * `@pops/app-food-db` per ADR-026 and the per-pillar plan documented in
+ * `.claude/pillar-migration-roadmap.md`.
+ *
+ * Per the CI-never-breaks pattern the migration is incremental — this
+ * PR scaffolds the package and surfaces only the `prep_states` slice.
+ * `@pops/app-food-db` continues to expose every other food table and
+ * service unchanged; this barrel is purely additive.
+ */
+export * from './errors.js';
+export * from './schema.js';
+
+export type { FoodDb } from './services/internal.js';
+
+export * as prepStatesService from './services/prep-states.js';

--- a/packages/food-db/src/schema.ts
+++ b/packages/food-db/src/schema.ts
@@ -1,0 +1,17 @@
+/**
+ * Local re-export of food-domain tables surfaced by `@pops/food-db`.
+ *
+ * Canonical definitions live in `@pops/db-types/src/schema/*.ts` so the
+ * drizzle-kit config (which globs `packages/db-types/src/schema/*`) picks
+ * them up and the rest of the platform sees a single schema barrel.
+ *
+ * Services in this package import from here for ergonomics and so the
+ * food pillar's read surface stays self-describing. Mirrors the
+ * `@pops/core-db` / `@pops/inventory-db` / `@pops/media-db` / `@pops/finance-db`
+ * schema re-export pattern.
+ *
+ * Phase 1 PR 1 ships only the `prepStates` row — additional tables get
+ * surfaced here as subsequent slices land.
+ */
+export { prepStates } from '@pops/db-types';
+export type { PrepStateInsert, PrepStateRow } from '@pops/db-types';

--- a/packages/food-db/src/services/internal.ts
+++ b/packages/food-db/src/services/internal.ts
@@ -1,0 +1,16 @@
+/**
+ * Shared helpers for the food schema service layer.
+ *
+ * `FoodDb` is re-exported from the package barrel so callers can type
+ * the handle they pass in. Any additional helpers added here stay internal
+ * to `src/services/*.ts`.
+ *
+ * The type uses `Record<string, unknown>` (not `Record<string, never>`) so
+ * the same alias matches both the package's narrow handle and the pops-api
+ * default `getDrizzle()` return shape — see the cerebrum-db lesson in the
+ * pillar-migration roadmap.
+ */
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+
+/** A drizzle handle — either the top-level db or a transaction. */
+export type FoodDb = BetterSQLite3Database<Record<string, unknown>>;

--- a/packages/food-db/src/services/prep-states.ts
+++ b/packages/food-db/src/services/prep-states.ts
@@ -1,0 +1,37 @@
+/**
+ * Read services for the `prep_states` table.
+ *
+ * Phase 1 PR 1 ships only the list + get pair — the create/delete
+ * mutations stay in `@pops/app-food-db` for now because they pull in the
+ * slug registry + transaction helpers that haven't been extracted yet.
+ * The next slice PR widens this surface once those helpers move.
+ */
+import { eq } from 'drizzle-orm';
+
+import { PrepStateNotFoundError } from '../errors.js';
+import { prepStates, type PrepStateRow } from '../schema.js';
+
+import type { FoodDb } from './internal.js';
+
+/**
+ * Return every prep state row.
+ *
+ * Stable ordering is by `id` ascending so seeded fixtures appear in
+ * insertion order. Callers that need a different sort apply it after
+ * the read.
+ */
+export function listPrepStates(db: FoodDb): PrepStateRow[] {
+  return db.select().from(prepStates).orderBy(prepStates.id).all();
+}
+
+/**
+ * Return a single prep state row by primary key. Throws
+ * `PrepStateNotFoundError` when no row matches.
+ */
+export function getPrepState(db: FoodDb, id: number): PrepStateRow {
+  const row = db.select().from(prepStates).where(eq(prepStates.id, id)).get();
+  if (row === undefined) {
+    throw new PrepStateNotFoundError(id);
+  }
+  return row;
+}

--- a/packages/food-db/tsconfig.json
+++ b/packages/food-db/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "lib": ["ES2023"],
+    "types": [],
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/__tests__/**", "**/*.test.ts"]
+}

--- a/packages/food-db/vitest.config.ts
+++ b/packages/food-db/vitest.config.ts
@@ -1,0 +1,15 @@
+/// <reference types="vitest/config" />
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json-summary', 'html'],
+      reportsDirectory: 'coverage',
+      include: ['src/**/*.ts'],
+      exclude: ['**/node_modules/**', '**/dist/**', '**/*.test.ts'],
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1153,6 +1153,9 @@ importers:
       '@pops/food-contracts':
         specifier: workspace:*
         version: link:../food-contracts
+      '@pops/food-db':
+        specifier: workspace:*
+        version: link:../food-db
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.10.0)
@@ -1570,6 +1573,31 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+
+  packages/food-db:
+    dependencies:
+      '@pops/db-types':
+        specifier: workspace:*
+        version: link:../db-types
+      better-sqlite3:
+        specifier: ^12.10.0
+        version: 12.10.0
+      drizzle-orm:
+        specifier: ^0.45.2
+        version: 0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.10.0)
+    devDependencies:
+      '@types/better-sqlite3':
+        specifier: ^7.6.12
+        version: 7.6.13
+      '@vitest/coverage-v8':
+        specifier: ^4.1.8
+        version: 4.1.8(vitest@4.1.8)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@25.9.1)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/inventory-db:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,6 +17,7 @@ packages:
   - 'packages/inventory-db'
   - 'packages/media-db'
   - 'packages/cerebrum-db'
+  - 'packages/food-db'
   - 'packages/food-contracts'
   - 'packages/types'
   - 'packages/module-registry'


### PR DESCRIPTION
## Summary

Track J phase 1 PR 1 — kick off the food pillar migration per ADR-026 and the CI-never-breaks pattern in `.claude/pillar-migration-roadmap.md`. Mirrors the inventory (#2768), media (#2767), finance (#2766), and cerebrum (#2797) canonical 4-package per-pillar pattern. The `-db` package ships first; `-contract` / `-api` / `-ui` follow in subsequent Phase 1 sub-PRs as their slices migrate.

### Gate-opener

PRD-149 (`#2865`, `46a2899c`) landed on `main`, closing the "no other open food-touching PRD" clause from the [Held: food](.claude/pillar-migration-roadmap.md#held-food) gate. ≥50% of γ rows are ✅. Track J is unblocked.

### What landed

- `@pops/food-db` package — backend-safe barrel for the food pillar's persistence layer.
- **Slice:** `prep_states` (PRD-106 leaf table — 0 FK references to other food tables, ~10 seed rows, smallest viable canary).
  - Schema re-export from `@pops/db-types` (`prepStates` + `PrepStateRow` / `PrepStateInsert`).
  - `PrepStateNotFoundError` typed error.
  - `listPrepStates(db)` + `getPrepState(db, id)` db-arg services.
  - 7 in-memory unit tests against the package-local migration copy.
- **Package-local migration journal** at `packages/food-db/migrations/` with `0058_high_sentinel.sql` byte-identical to the shared journal copy. Mirrors the cerebrum-db PR 1 pre-copy lesson: pre-copying the SQL in PR 1 keeps the test self-describing and PR 2 only adds the drift-guard CI + journal split work on top.
- **Drift-guard CI workflow** at `.github/workflows/food-db-quality.yml` enforcing byte-identity between the shared journal copy and the pillar copy across the transitional release cycle. Matches the inventory / media / finance / cerebrum drift-guard shape verbatim.
- **CI parity:**
  - `_pkg-check.yml`: added `pnpm --filter @pops/food-db build` to the shared build step.
  - `api-quality.yml`, `api-test.yml`: added `packages/food-db/**` to both `push.paths` and the `paths-filter` filter + `cd ../food-db && pnpm build` to the shared build step.
  - `fe-quality.yml`: same paths/filter/build additions.
  - `fe-test-e2e.yml`: build-step addition (its filter already covers `packages/**`).
- **Dockerfile parity:** `apps/pops-api/Dockerfile`, `apps/pops-shell/Dockerfile`, `apps/pops-mcp/Dockerfile` all copy `food-db` package.json + src + tsconfig + migrations, build the package after `core-db` / `finance-db` / `inventory-db` / `media-db` / `cerebrum-db`, and (pops-api runtime) install the built `dist/` + `package.json` + `migrations/` into `node_modules/@pops/food-db/` so `require.resolve('@pops/food-db/package.json')` works for the per-pillar migration runner under pnpm's hoisted layout (see the [core PR 1 lesson](.claude/pillar-migration-roadmap.md)).
- **`@pops/app-food-db` shim:** re-exports `PrepStateNotFoundError` from `@pops/food-db` so future consumers can pull it through the new package; the existing `prepStatesService` (with `create`/`delete`) stays on `app-food-db` until PR 3 cuts the router over. Existing imports keep resolving unchanged.

### Reference patterns

- Inventory PR 1: [#2768](https://github.com/knoxio/pops/pull/2768) (canonical pattern).
- Media PR 1: [#2767](https://github.com/knoxio/pops/pull/2767) (second proof).
- Finance PR 1: [#2766](https://github.com/knoxio/pops/pull/2766) (γ pilot).
- Cerebrum PR 1: [#2797](https://github.com/knoxio/pops/pull/2797) (URI-pillar canary + pre-copy migration lesson applied here).

### Scope discipline

- `@pops/app-food` + `@pops/app-food-db` stay in place as re-export shims for now — they are deleted in PR 4. The shim only re-exports `PrepStateNotFoundError` because that's all this slice introduces; the rest of `app-food-db`'s surface is unchanged.
- The other 3 pillar packages (`@pops/food-contract`, `@pops/food-api`, `@pops/food-ui`) are **deferred** to subsequent Phase 1 sub-PRs. The canonical inventory/finance/media/cerebrum pattern ships `-db` first and treats the contract/api/ui packages as separate migrations on their own slim slices — see roadmap line 128. Trying to scaffold all four in one PR would balloon this to >>4000 LOC of additive boilerplate and create endless rebase conflicts with the other in-flight pillar work on `main`.
- `apps/pops-api/src/modules/food/` is **not** cut over — that's PR 3.
- `@pops/app-food-db` deletion is **not** in scope — that's PR 4.

### Deferred follow-ups

- **PR 2:** journal split + drift-guard polish (the journal split for `0058_high_sentinel` is conceptually subtle because that tag bundles `ingredients` / `ingredient_variants` / `ingredient_aliases` / `prep_states` / `slug_registry` — only `prep_states` is moving in this slice; the journal-split PR documents the splitting strategy and lands the drizzle-emit verification).
- **PR 3:** pops-api `food/routers/prep-states.ts` cutover to `import { prepStatesService } from '@pops/food-db'`.
- **PR 4:** retire `prep-states` from `app-food-db`'s `prepStatesService` namespace + the shim re-export.
- **Phase 1 sub-PRs (J1.A/B/C):** scaffold `@pops/food-contract` (zod from drizzle-zod via `.pick()` / `.extend()`), `@pops/food-api` (tRPC routers + jobs + manifest), `@pops/food-ui` (React + pages + i18n). Each on its own slim slice following the same 4×4 sequence.
- **Future slices:** ingredients, variants, recipes, recipe_versions, recipe_runs, batches, ingest_sources, plan_slots, plan_entries, substitutions, unit_conversions, ingredient_tags, slug_registry, DSL pipeline. Each gets its own slice PR sequence under the same `@pops/food-db`.

### Local CI gauntlet (all green before push)

- `pnpm install` — 34 workspace projects.
- `pnpm --filter @pops/food-db test` — 7/7 passed.
- `pnpm typecheck` — 47 tasks, all green.
- `pnpm --filter @pops/api test` — 4857/4857 passed.
- `pnpm --filter @pops/shell test` — 342/342 passed.
- `pnpm lint` — 0 errors.
- `pnpm build` — 22 packages, all green.
- `pnpm format` — clean.

## Test plan

- [ ] Drift-guard job passes (shared 0058 vs pillar 0058 byte-identical).
- [ ] `_pkg-check.yml` runs the new package's typecheck + test.
- [ ] api-quality, api-test, fe-quality, fe-test-e2e all green.
- [ ] Validate Docker builds green for pops-api + pops-shell + pops-mcp images.
- [ ] No regression in existing food pops-api routers — `app-food-db`'s surface is unchanged.
