### PR TITLE
feat(food-db): add openFoodDb helper (Track J phase 2 PR 1)

### DIFF
--- a/packages/food-db/src/__tests__/open-food-db.test.ts
+++ b/packages/food-db/src/__tests__/open-food-db.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Smoke tests for the standalone `openFoodDb` helper.
+ *
+ * Exercises the migration apply path against a fresh tmp file, verifies
+ * the resulting schema, and confirms the helper is idempotent when
+ * re-run against the same DB.
+ *
+ * Uses real tmpdir-backed files (not `:memory:`) because the Phase 2
+ * follow-ups (PR 2's pops-api boot wire-up, PR 3's consumer cutover,
+ * and the eventual ATTACH-based backfill window) will exercise this
+ * helper against on-disk DBs and shared paths. Keep parity here so
+ * surprises surface in tests, not in production.
+ */
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { openFoodDb } from '../open-food-db.js';
+import { prepStates } from '../schema.js';
+import { listPrepStates } from '../services/prep-states.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'food-db-test-'));
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('openFoodDb', () => {
+  it('creates the parent directory and opens a fresh DB', () => {
+    const path = join(tmpDir, 'nested', 'sub', 'food.db');
+    expect(existsSync(path)).toBe(false);
+
+    const { raw } = openFoodDb(path);
+    try {
+      expect(existsSync(path)).toBe(true);
+      expect(raw.pragma('journal_mode', { simple: true })).toBe('wal');
+      expect(raw.pragma('foreign_keys', { simple: true })).toBe(1);
+      expect(raw.pragma('busy_timeout', { simple: true })).toBe(5000);
+    } finally {
+      raw.close();
+    }
+  });
+
+  it('applies the food slice migration', () => {
+    const path = join(tmpDir, 'food.db');
+    const { db, raw } = openFoodDb(path);
+    try {
+      expect(listPrepStates(db)).toEqual([]);
+      const inserted = db
+        .insert(prepStates)
+        .values({ name: 'Diced', slug: 'diced' })
+        .returning()
+        .get();
+      expect(inserted?.slug).toBe('diced');
+      expect(listPrepStates(db)).toHaveLength(1);
+    } finally {
+      raw.close();
+    }
+  });
+
+  it('is idempotent — re-opening the same DB does not re-apply migrations', () => {
+    const path = join(tmpDir, 'food.db');
+    const first = openFoodDb(path);
+    try {
+      first.db.insert(prepStates).values({ name: 'Whole', slug: 'whole' }).run();
+      expect(listPrepStates(first.db)).toHaveLength(1);
+    } finally {
+      first.raw.close();
+    }
+
+    const second = openFoodDb(path);
+    try {
+      const rows = listPrepStates(second.db);
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.slug).toBe('whole');
+    } finally {
+      second.raw.close();
+    }
+  });
+
+  it('throws when the path points at a directory that cannot be opened as a DB file', () => {
+    expect(() => openFoodDb(tmpDir)).toThrow();
+  });
+});

--- a/packages/food-db/src/index.ts
+++ b/packages/food-db/src/index.ts
@@ -19,4 +19,6 @@ export * from './schema.js';
 
 export type { FoodDb } from './services/internal.js';
 
+export { openFoodDb, type OpenedFoodDb } from './open-food-db.js';
+
 export * as prepStatesService from './services/prep-states.js';

--- a/packages/food-db/src/open-food-db.ts
+++ b/packages/food-db/src/open-food-db.ts
@@ -1,0 +1,86 @@
+/**
+ * Standalone opener for the food pillar's SQLite database.
+ *
+ * Phase 2 PR 1 of the food pillar migration scaffolds the per-pillar
+ * connection so subsequent PRs can flip readers/writers over without
+ * touching pops-api's existing singleton. The opener is intentionally
+ * minimal — it relies on drizzle-orm's built-in `migrate` helper to
+ * apply the in-package migrations journal at
+ * `packages/food-db/migrations/meta/_journal.json`.
+ *
+ * No production consumer wires this up yet. Subsequent PRs add the
+ * `FOOD_SQLITE_PATH` env-var read in pops-api (PR 2), the boot-time
+ * call + consumer cutover (PR 3), and the Litestream replication config
+ * (PR 4).
+ */
+import { mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+
+import type { FoodDb } from './services/internal.js';
+
+/**
+ * Path to the migrations folder inside this package. Resolved relative
+ * to this module's location (`src/open-food-db.ts` in dev,
+ * `dist/open-food-db.js` after build) so it works both when consumed
+ * via the workspace symlink and when bundled into a Docker image's
+ * `node_modules/@pops/food-db/`.
+ */
+function migrationsDir(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  return join(here, '..', 'migrations');
+}
+
+/**
+ * Result of {@link openFoodDb}. The raw handle is exposed for callers
+ * that need lifecycle control (close on shutdown, prepared statements,
+ * pragmas the drizzle wrapper hides).
+ */
+export interface OpenedFoodDb {
+  /** Drizzle handle — pass into any `prepStatesService.*` call. */
+  db: FoodDb;
+  /** Raw better-sqlite3 handle. Call `.close()` on shutdown. */
+  raw: Database.Database;
+}
+
+/**
+ * Open the food pillar's SQLite database at `path`, configure it,
+ * apply the in-package migrations journal, and return both the
+ * drizzle wrapper and the raw handle.
+ *
+ * Side effects:
+ *   - The parent directory of `path` is created if missing (recursive).
+ *   - `journal_mode=WAL`, `foreign_keys=ON`, and `busy_timeout=5000`
+ *     are enabled to match the shared singleton in
+ *     `apps/pops-api/src/db.ts`.
+ *   - Every migration in
+ *     `packages/food-db/migrations/meta/_journal.json` is applied via
+ *     drizzle's built-in migrator (idempotent — re-running against the
+ *     same DB short-circuits on the `__drizzle_migrations` hash check).
+ *     Today that's `0058_high_sentinel`, which creates the food slice's
+ *     foundational tables (ingredients, ingredient_variants,
+ *     ingredient_aliases, prep_states, slug_registry).
+ *
+ * If the migration apply throws (corrupt DB, malformed migration,
+ * missing folder), the raw handle is closed before the error is
+ * re-thrown so the caller can't leak a locked file descriptor.
+ */
+export function openFoodDb(path: string): OpenedFoodDb {
+  mkdirSync(dirname(path), { recursive: true });
+  const raw = new Database(path);
+  raw.pragma('journal_mode = WAL');
+  raw.pragma('foreign_keys = ON');
+  raw.pragma('busy_timeout = 5000');
+  const db = drizzle(raw) as FoodDb;
+  try {
+    migrate(db, { migrationsFolder: migrationsDir() });
+  } catch (err) {
+    raw.close();
+    throw err;
+  }
+  return { db, raw };
+}

--- a/packages/food-db/src/open-food-db.ts
+++ b/packages/food-db/src/open-food-db.ts
@@ -61,9 +61,6 @@ export interface OpenedFoodDb {
  *     `packages/food-db/migrations/meta/_journal.json` is applied via
  *     drizzle's built-in migrator (idempotent — re-running against the
  *     same DB short-circuits on the `__drizzle_migrations` hash check).
- *     Today that's `0058_high_sentinel`, which creates the food slice's
- *     foundational tables (ingredients, ingredient_variants,
- *     ingredient_aliases, prep_states, slug_registry).
  *
  * If the migration apply throws (corrupt DB, malformed migration,
  * missing folder), the raw handle is closed before the error is


### PR DESCRIPTION
## Summary

Track J Phase 2 PR 1: scaffolds the standalone `openFoodDb()` helper in `@pops/food-db`, mirroring the four sibling helpers that landed for the other migrated pillars.

- `openFoodDb(path)` opens a `better-sqlite3` connection, applies the same `journal_mode=WAL` / `foreign_keys=ON` / `busy_timeout=5000` pragmas as `apps/pops-api/src/db.ts`, and runs the in-package drizzle migration journal at `packages/food-db/migrations/meta/_journal.json` via `migrate()`.
- `OpenedFoodDb` exposes both the drizzle handle (`db: FoodDb`) and the raw `better-sqlite3` handle for lifecycle control.
- Migration apply errors close the raw handle before re-throwing so callers can't leak a locked fd.
- New tmpdir-backed vitest suite at `packages/food-db/src/__tests__/open-food-db.test.ts` covers fresh-open + pragma assertions, a `prep_states` insert/read round-trip against the applied schema, idempotent re-open against the same on-disk DB, and invalid-path failure. Real files (not `:memory:`) because the Phase 2 follow-ups exercise cross-DB ATTACH backfill that needs real paths.
- Helper + type added to the package barrel at `packages/food-db/src/index.ts`.

## Sibling helpers

Same shape as:

- inventory Phase 2 PR 1 → #2788 (`openInventoryDb`)
- finance Phase 2 PR 1 → #2793 (`openFinanceDb`)
- media Phase 2 PR 1 → #2785 (`openMediaDb`)
- cerebrum Phase 2 PR 1 → #2815 (`openCerebrumDb`)

## Deferred

- **Phase 2 PR 2** — pops-api boot-time open + `FOOD_SQLITE_PATH` env-var read + `closeFoodDb()` shutdown wiring.
- **Phase 2 PR 3** — consumer cutover: `apps/pops-api/src/modules/food/...` reads/writes routed through the `food.db` handle; ATTACH-based backfill of `prep_states` rows from the shared `pops.db`.
- **Phase 2 PR 4** — Litestream replication config for `food.db` + AGENTS.md update.
- **Phase 3 PRs (×4)** — `pops-food-api` container, `/health` endpoint, docker-compose + `POPS_PILLARS` + publish-images, verification runbook.

No production consumer is wired up by this PR.

## Test plan

- [x] `pnpm --filter @pops/food-db test` (4 new `openFoodDb` cases + the existing 7 `prep-states` cases, 11 total green)
- [x] `pnpm typecheck` (47 tasks green)
- [x] `pnpm lint` (exit 0, no new warnings in changed files)
- [x] `pnpm build` (22 tasks green)
- [ ] Copilot R1 review pass
