### PR TITLE
feat(food-db): flip prep_states consumer to @pops/food-db (Track J phase 1 PR 3)

### DIFF
--- a/apps/pops-api/package.json
+++ b/apps/pops-api/package.json
@@ -83,6 +83,7 @@
     "@pops/db-types": "workspace:*",
     "@pops/finance-db": "workspace:*",
     "@pops/food-contracts": "workspace:*",
+    "@pops/food-db": "workspace:*",
     "@pops/inventory-db": "workspace:*",
     "@pops/media-db": "workspace:*",
     "@pops/module-registry": "workspace:*",

--- a/apps/pops-api/src/modules/food/routers/prep-states.ts
+++ b/apps/pops-api/src/modules/food/routers/prep-states.ts
@@ -1,19 +1,35 @@
 import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 
-import { InvalidSlugError, prepStatesService, SlugAlreadyRegisteredError } from '@pops/app-food-db';
+import {
+  InvalidSlugError,
+  prepStatesService as legacyPrepStatesService,
+  SlugAlreadyRegisteredError,
+} from '@pops/app-food-db';
+import { prepStatesService } from '@pops/food-db';
 
 import { getDrizzle } from '../../../db.js';
 import { protectedProcedure, router } from '../../../trpc.js';
 
+/**
+ * `food.prepStates` tRPC router.
+ *
+ * Reads (`listPrepStates`) are sourced from the pillar package
+ * `@pops/food-db`. The `createPrepState` mutation and its slug-registry
+ * typed errors (`InvalidSlugError`, `SlugAlreadyRegisteredError`) still
+ * live in `@pops/app-food-db` because the slug-registry + transaction
+ * helpers haven't been extracted into the pillar package yet.
+ */
 export const prepStatesRouter = router({
-  list: protectedProcedure.query(() => ({ items: prepStatesService.listPrepStates(getDrizzle()) })),
+  list: protectedProcedure.query(() => ({
+    items: prepStatesService.listPrepStates(getDrizzle()),
+  })),
 
   create: protectedProcedure
     .input(z.object({ slug: z.string(), name: z.string().min(1) }))
     .mutation(({ input }) => {
       try {
-        return prepStatesService.createPrepState(getDrizzle(), input);
+        return legacyPrepStatesService.createPrepState(getDrizzle(), input);
       } catch (err) {
         if (err instanceof InvalidSlugError) {
           throw new TRPCError({ code: 'BAD_REQUEST', message: err.message, cause: err });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       '@pops/food-contracts':
         specifier: workspace:*
         version: link:../../packages/food-contracts
+      '@pops/food-db':
+        specifier: workspace:*
+        version: link:../../packages/food-db
       '@pops/inventory-db':
         specifier: workspace:*
         version: link:../../packages/inventory-db


### PR DESCRIPTION
## Summary

Flips the only consumer of `prep_states` reads (the `food.prepStates.list` tRPC procedure in pops-api) over to the new `@pops/food-db` pillar package scaffolded in #2866. The `create` mutation still imports `createPrepState` + the slug-registry typed errors from `@pops/app-food-db` because those helpers haven't been extracted yet — the next slice PR widens the food-db surface once the slug-registry + transaction helpers move.

Mirrors inventory phase 1 PR 3 (#2778) and finance phase 1 PR 3 (#2781): incremental cutover with the legacy shim still intact.

## Changes

- `apps/pops-api/src/modules/food/routers/prep-states.ts`: import `prepStatesService` (read namespace) from `@pops/food-db`; alias the legacy namespace as `legacyPrepStatesService` for `createPrepState`.
- `apps/pops-api/package.json`: add `@pops/food-db` workspace dependency.
- `pnpm-lock.yaml`: pin the new workspace link.

## What's still on `@pops/app-food-db`

- `createPrepState` (transactional, pulls slug-registry + transaction helpers)
- `InvalidSlugError`, `SlugAlreadyRegisteredError` (live with slug helpers)
- Test fixtures that seed via `prepStatesService.createPrepState` (`recipes-router.test.ts`, `plan-router.test.ts`, `search-for-consume.test.ts`, `data-routers.test.ts`)

The `@pops/app-food-db` re-export shim added in PR 1 keeps these resolving. PR 4 of phase 1 will delete the shim once the slug-registry + transaction helpers (and `createPrepState`) move into the pillar package.

## CI / Docker

PR 1 (#2866) already wired the Dockerfiles (`pops-api`, `pops-mcp`, `pops-shell`) and CI workflows (`_pkg-check.yml`, `api-quality.yml`, `api-test.yml`, `fe-quality.yml`, `fe-test-e2e.yml`) to build `@pops/food-db` before pops-api consumers. No infra changes are needed for the cutover.

## Test plan

- [x] `pnpm --filter @pops/food-db build` / `typecheck` / `test` (7/7)
- [x] `pnpm --filter @pops/api test` — 4857/4857 pass (full pops-api suite — covers `food.prepStates.{list, create}` end-to-end via the tRPC caller in `data-routers.test.ts`, plus every cook/plan/recipes/send-to-list test that seeds via `prepStatesService.createPrepState`)
- [x] `pnpm typecheck` (turbo, full workspace) — 47/47 clean
- [x] `pnpm lint` — clean (warnings only, no errors)
- [x] `pnpm format`  / `pnpm build` — clean