### PR TITLE
feat(food-db): delete prep_states shim from @pops/app-food-db (Track J phase 1 PR 4)

### DIFF
--- a/packages/app-food-db/src/index.ts
+++ b/packages/app-food-db/src/index.ts
@@ -14,12 +14,6 @@ export * from './errors.js';
 export * from './schema.js';
 export * from './slug.js';
 
-// Re-export from `@pops/food-db` for the slices that have moved to the
-// pillar package as part of Track J phase 1. Existing imports from
-// `@pops/app-food-db` keep resolving — the shim narrows over time as more
-// slices migrate, and disappears entirely in Track J phase 1 PR 4.
-export { PrepStateNotFoundError } from '@pops/food-db';
-
 // Drizzle handle type — re-exported so consumers don't have to reach
 // into the internal services module.
 export { MAX_INGREDIENT_DEPTH, type FoodDb } from './services/internal.js';


### PR DESCRIPTION
## Summary

Track J phase 1 PR 4 — deletes the `prep_states` re-export shim that PR 1 (#2866) added to `@pops/app-food-db`. With PR 3 (#2868) flipping `food.prepStates.list` and its typed-error handling over to `@pops/food-db`, the shim line is now dead code.

Mirrors inventory phase 1 PR 4 (#2782) and finance phase 1 PR 4 (#2783): drop the migrated slice's shim entries once the consumer cutover lands.

## What changed

- `packages/app-food-db/src/index.ts` — removed the `export { PrepStateNotFoundError } from '@pops/food-db'` line and the accompanying multi-line shim comment block that PR 1 had added at the top of the barrel.

## What deliberately stays

- The `prepStatesService` namespace export from `@pops/app-food-db` — `createPrepState` still lives there (it pulls `assertSlugAvailable` / `recordSlug` / `assertValidSlug` from the slug-registry + transaction helpers that haven't migrated to the pillar package yet), and the `food.prepStates.create` mutation in `apps/pops-api/src/modules/food/routers/prep-states.ts` still imports it as `legacyPrepStatesService.createPrepState`.
- `InvalidSlugError` and `SlugAlreadyRegisteredError` exports from `@pops/app-food-db` — same reason; the create mutation still maps them to `BAD_REQUEST` / `CONFLICT`. They move when the slug-registry slice migrates.
- The `@pops/food-db` workspace dependency in `packages/app-food-db/package.json` — kept on purpose; future slices will re-export through `@pops/app-food-db` as they migrate, mirroring the pattern this PR is retiring for prep_states.

## Consumer audit

```
$ grep -rn "@pops/app-food-db" --include="*.ts" | grep -iE "prepState|prep-state"
apps/pops-api/src/modules/food/routers/prep-states.ts:8:} from '@pops/app-food-db';
```

The remaining consumer is the `create` mutation (legacy alias for `createPrepState` + slug-registry typed errors) — out of scope for this PR.

```
$ grep -rn "PrepStateNotFoundError" --include="*.ts"
# only @pops/food-db sources + its own unit suite
```

No consumer imports `PrepStateNotFoundError` from `@pops/app-food-db` — the shim's only purpose was the migration window between PR 1 and PR 3.

## Local CI gauntlet

- `pnpm typecheck` — 47/47 tasks green.
- `pnpm lint` — clean (warnings only, 0 errors).
- `pnpm --filter @pops/api test` — 4857/4857 passed.
- `pnpm --filter @pops/food-db test` — 7/7 passed.
- `pnpm --filter @pops/app-food-db test` — 458/458 passed.
- `pnpm build` — 22/22 tasks green.
- `pnpm format` — clean.

## Test plan

- [ ] `_pkg-check.yml`, `api-quality.yml`, `api-test.yml`, `fe-quality.yml`, `fe-test-e2e.yml` all green.
- [ ] `food-db-quality.yml` drift-guard still green (no migration touched).
- [ ] Docker builds for pops-api / pops-shell / pops-mcp succeed.
