### PR TITLE
feat(api): open the food pillar SQLite at boot (pillar food phase 2 PR 2)

### DIFF
--- a/apps/pops-api/.env.example
+++ b/apps/pops-api/.env.example
@@ -46,6 +46,11 @@ MEDIA_SQLITE_PATH=./data/media.db
 # cerebrum needs its own mount point / Litestream stream in production.
 CEREBRUM_SQLITE_PATH=./data/cerebrum.db
 
+# Food pillar database (ADR-026). Defaults to <dirname(SQLITE_PATH)>/food.db,
+# falling back to ./data/food.db if SQLITE_PATH is unset. Set explicitly when
+# food needs its own mount point / Litestream stream in production.
+FOOD_SQLITE_PATH=./data/food.db
+
 # Media Images
 # Directory for locally cached posters and backdrops
 MEDIA_IMAGES_DIR=./data/media/images

--- a/apps/pops-api/src/db.ts
+++ b/apps/pops-api/src/db.ts
@@ -11,6 +11,7 @@ import { closeCerebrumDb } from './db/cerebrum-handle.js';
 import { backfillCoreFromShared as backfillCoreImpl } from './db/core-backfill.js';
 import { resolveCoreSqlitePath } from './db/core-sqlite-path.js';
 import { closeFinanceDb } from './db/finance-handle.js';
+import { closeFoodDb } from './db/food-handle.js';
 import { closeInventoryDb } from './db/inventory-handle.js';
 import { KNOWN_PILLARS } from './db/known-pillars.js';
 import { closeMediaDb } from './db/media-db-handle.js';
@@ -241,6 +242,7 @@ export function closeDb(): void {
   closeInventoryDb();
   closeMediaDb();
   closeCerebrumDb();
+  closeFoodDb();
 }
 
 /**

--- a/apps/pops-api/src/db/food-handle.ts
+++ b/apps/pops-api/src/db/food-handle.ts
@@ -1,0 +1,87 @@
+/**
+ * Lazily-initialised handle to the food pillar's SQLite file.
+ *
+ * Phase 2 PR 2 of the food pillar migration: opens the connection
+ * (and applies the in-package migrations journal) at boot but does NOT
+ * yet route any production traffic through it. PR 3 of phase 2 flips
+ * the prep_states slice (and subsequent slices) over with a single
+ * edit to `getDrizzle()` → `getFoodDrizzle()` plus an ATTACH-based
+ * backfill of any existing rows from the shared pops.db; PR 4 drops
+ * the food-owned tags from the shared journal + adds the Litestream
+ * config.
+ *
+ * Lives in its own module so `db.ts` stays under the lint cap as more
+ * pillars come online. Mirrors `core-handle.ts` / `inventory-handle.ts` /
+ * `finance-handle.ts` / `media-db-handle.ts` / `cerebrum-handle.ts`.
+ */
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+
+import { openFoodDb, type FoodDb, type OpenedFoodDb } from '@pops/food-db';
+
+import { getDb, isNamedEnvContext } from '../db.js';
+import { resolveFoodSqlitePath } from './food-sqlite-path.js';
+
+let foodDb: OpenedFoodDb | null = null;
+
+/**
+ * Resolve (and lazily open) the food pillar's drizzle handle.
+ *
+ * **Env-aware**: inside a `withEnvDb()` scope (PRD-101 named environments —
+ * each E2E test fixture creates a per-test pops.db with its own seeded
+ * food tables) the env DB takes precedence. The env DB already contains
+ * every food-owned table because `seedDatabase()` writes them there, so
+ * a single fixture stays self-contained without a background backfill
+ * into the global `food.db`. Outside an env scope (real production
+ * boot, dev), the pillar's `food.db` is resolved + lazily opened so
+ * the in-package migrations apply.
+ *
+ * The handle is opened on first call so per-pillar migrations land
+ * before any request hits the API. Phase 2 PR 3 routes the prep_states
+ * slice's reads/writes through this getter.
+ */
+export function getFoodDrizzle(): FoodDb {
+  if (isNamedEnvContext()) return drizzle(getDb()) as FoodDb;
+  if (!foodDb) {
+    foodDb = openFoodDb(resolveFoodSqlitePath());
+  }
+  return foodDb.db;
+}
+
+/**
+ * Resolve the food pillar's raw better-sqlite3 handle. Same lazy
+ * open + env-aware behaviour as `getFoodDrizzle()` — exposed for
+ * the same lower-level needs (`.transaction()`, `.prepare()`,
+ * `.pragma()`) that the drizzle wrapper hides. Prefer
+ * `getFoodDrizzle()` for everything that doesn't need it.
+ */
+export function getFoodRawDb(): OpenedFoodDb['raw'] {
+  if (isNamedEnvContext()) return getDb();
+  if (!foodDb) {
+    foodDb = openFoodDb(resolveFoodSqlitePath());
+  }
+  return foodDb.raw;
+}
+
+/**
+ * Close the food pillar's connection if it was opened. Idempotent
+ * — safe to call from `closeDb()` on shutdown even when the food
+ * handle was never resolved.
+ */
+export function closeFoodDb(): void {
+  if (foodDb) {
+    foodDb.raw.close();
+    foodDb = null;
+  }
+}
+
+/**
+ * Test-only: swap the food pillar handle. `setupTestContext` in
+ * `shared/test-utils.ts` calls this hook so test suites can inject an
+ * in-memory DB and avoid writing to the dev `data/food.db` file.
+ * Returns the previous handle (or null).
+ */
+export function setFoodDb(next: OpenedFoodDb | null): OpenedFoodDb | null {
+  const prev = foodDb;
+  foodDb = next;
+  return prev;
+}

--- a/apps/pops-api/src/db/food-sqlite-path.test.ts
+++ b/apps/pops-api/src/db/food-sqlite-path.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Resolver tests for the food pillar's SQLite path.
+ *
+ * Covers the precedence chain: FOOD_SQLITE_PATH > <dirname(SQLITE_PATH)>/food.db > fallback.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DEFAULT_FOOD_SQLITE_PATH, resolveFoodSqlitePath } from './food-sqlite-path.js';
+
+const originalFoodPath = process.env['FOOD_SQLITE_PATH'];
+const originalSharedPath = process.env['SQLITE_PATH'];
+
+beforeEach(() => {
+  delete process.env['FOOD_SQLITE_PATH'];
+  delete process.env['SQLITE_PATH'];
+});
+
+afterEach(() => {
+  if (originalFoodPath === undefined) delete process.env['FOOD_SQLITE_PATH'];
+  else process.env['FOOD_SQLITE_PATH'] = originalFoodPath;
+  if (originalSharedPath === undefined) delete process.env['SQLITE_PATH'];
+  else process.env['SQLITE_PATH'] = originalSharedPath;
+});
+
+describe('resolveFoodSqlitePath', () => {
+  it('returns FOOD_SQLITE_PATH verbatim when set', () => {
+    process.env['FOOD_SQLITE_PATH'] = '/abs/path/food.db';
+    expect(resolveFoodSqlitePath()).toBe('/abs/path/food.db');
+  });
+
+  it('derives the path from the shared SQLITE_PATH when FOOD_SQLITE_PATH is unset', () => {
+    process.env['SQLITE_PATH'] = '/opt/pops/data/pops.db';
+    expect(resolveFoodSqlitePath()).toBe('/opt/pops/data/food.db');
+  });
+
+  it('handles relative SQLITE_PATH values', () => {
+    process.env['SQLITE_PATH'] = './data/pops.db';
+    expect(resolveFoodSqlitePath()).toBe('data/food.db');
+  });
+
+  it('falls back to ./data/food.db when neither env is set', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      expect(resolveFoodSqlitePath()).toBe(DEFAULT_FOOD_SQLITE_PATH);
+      expect(warn).toHaveBeenCalledOnce();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});

--- a/apps/pops-api/src/db/food-sqlite-path.ts
+++ b/apps/pops-api/src/db/food-sqlite-path.ts
@@ -1,0 +1,33 @@
+import { dirname, join } from 'node:path';
+
+import { DEFAULT_SQLITE_PATH } from './sqlite-path.js';
+
+/**
+ * Default location of the food pillar's SQLite file.
+ *
+ * Per the ADR-026 pillar architecture each pillar owns its own SQLite
+ * file alongside the shared pops.db. The default places `food.db`
+ * in the same directory the shared singleton resolves to so dev setups
+ * that already have a writable data dir don't need extra configuration.
+ * Production deployments set `FOOD_SQLITE_PATH` explicitly; the
+ * fallback here is local-dev-only and matches `resolveSqlitePath`'s
+ * default-path convention (`./data/<file>.db`).
+ *
+ * Resolution order:
+ *   1. `FOOD_SQLITE_PATH` env (absolute or relative).
+ *   2. `<dirname(SQLITE_PATH)>/food.db` if the shared path is set.
+ *   3. `./data/food.db` (matches the shared default's `./data/pops.db`).
+ */
+export const DEFAULT_FOOD_SQLITE_PATH = './data/food.db';
+
+export function resolveFoodSqlitePath(): string {
+  const envPath = process.env['FOOD_SQLITE_PATH'];
+  if (envPath) return envPath;
+  const sharedPath = process.env['SQLITE_PATH'];
+  if (sharedPath) return join(dirname(sharedPath), 'food.db');
+  console.warn(
+    `[db] FOOD_SQLITE_PATH not set — using fallback: ${DEFAULT_FOOD_SQLITE_PATH} ` +
+      `(co-located with the shared singleton default '${DEFAULT_SQLITE_PATH}')`
+  );
+  return DEFAULT_FOOD_SQLITE_PATH;
+}

--- a/apps/pops-api/src/index.ts
+++ b/apps/pops-api/src/index.ts
@@ -9,6 +9,7 @@ import { createApp } from './app.js';
 import { backfillCoreFromShared, closeDb, getCoreDrizzle } from './db.js';
 import { backfillCerebrumFromSharedDb, getCerebrumDrizzle } from './db/cerebrum-handle.js';
 import { backfillFinanceFromSharedDb, getFinanceDrizzle } from './db/finance-handle.js';
+import { getFoodDrizzle } from './db/food-handle.js';
 import { backfillInventoryFromSharedDb, getInventoryDrizzle } from './db/inventory-handle.js';
 import { backfillMediaFromShared, getMediaDrizzle } from './db/media-db-handle.js';
 import { resolveSqlitePath } from './db/sqlite-path.js';
@@ -107,6 +108,22 @@ try {
   backfillCerebrumFromSharedDb(resolveSqlitePath());
 } catch (err) {
   console.error('[db] Failed to bootstrap the cerebrum pillar SQLite:', err);
+  throw err;
+}
+
+// Eagerly open the food pillar's SQLite + apply its journal at boot so
+// the in-package migrations land before any request hits the API. Phase
+// 2 PR 2 only opens the handle — no production traffic is routed
+// through it yet; the prep_states slice still reads/writes against the
+// shared pops.db. Phase 2 PR 3 flips the prep_states slice over with an
+// ATTACH-based backfill from pops.db (matching the inventory / finance
+// / media / core / cerebrum PR-3 pattern); PR 4 adds the Litestream
+// config. Opening early surfaces migration failures during boot rather
+// than on first food-route request.
+try {
+  getFoodDrizzle();
+} catch (err) {
+  console.error('[db] Failed to bootstrap the food pillar SQLite:', err);
   throw err;
 }
 

--- a/apps/pops-api/src/shared/test-utils.ts
+++ b/apps/pops-api/src/shared/test-utils.ts
@@ -4,6 +4,7 @@ import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { closeDb, setCoreDb, setDb } from '../db.js';
 import { setCerebrumDb } from '../db/cerebrum-handle.js';
 import { setFinanceDb } from '../db/finance-handle.js';
+import { setFoodDb } from '../db/food-handle.js';
 import { setInventoryDb } from '../db/inventory-handle.js';
 import { setMediaDb } from '../db/media-db-handle.js';
 import { appRouter } from '../router.js';
@@ -1502,6 +1503,14 @@ export function setupTestContext() {
     // fixture has to surface that table on the cerebrum handle too.
     setCerebrumDb({ db: drizzle(db), raw: db });
 
+    // Same for the food pillar handle (phase 2 PR 2): the handle is
+    // opened at boot but no router has cut over yet. The injection is
+    // forward-looking — once PR 3 routes prep_states (and subsequent
+    // slices) through getFoodDrizzle() the fixture will already be
+    // pointed at the in-memory DB and won't try to open
+    // `data/food.db` mid-suite.
+    setFoodDb({ db: drizzle(db), raw: db });
+
     return { db, caller: createCaller(true) };
   }
 
@@ -1511,6 +1520,7 @@ export function setupTestContext() {
     setInventoryDb(null);
     setMediaDb(null);
     setCerebrumDb(null);
+    setFoodDb(null);
     closeDb();
   }
 


### PR DESCRIPTION
## Summary

Phase 2 PR 2 of the food pillar migration (Track J). Wires the `openFoodDb()` helper landed in PR 1 (#2867 / `644fb3e0`) into the pops-api boot path, alongside the other pillar opens. Mirrors the sibling Phase 2 PR 2s:

- inventory (#2792)
- finance (#2799)
- media (#2791)
- cerebrum (#2817)

## What lands

- `FOOD_SQLITE_PATH` env var (default `./data/food.db`) documented in `apps/pops-api/.env.example`.
- `apps/pops-api/src/db/food-sqlite-path.ts` resolver + 4 unit tests covering the `FOOD_SQLITE_PATH > <dirname(SQLITE_PATH)>/food.db > fallback` precedence chain.
- `apps/pops-api/src/db/food-handle.ts` holding the module-scoped `OpenedFoodDb` singleton with:
  - env-aware `getFoodDrizzle()` / `getFoodRawDb()` — returns the env DB inside a `withEnvDb()` scope to keep PRD-101 named-environment fixtures self-contained (lesson (f) from inventory Phase 2 PR 2);
  - `closeFoodDb()` for shutdown (idempotent);
  - `setFoodDb()` test-only hook for in-memory injection.
- Boot wiring in `src/index.ts` calls `getFoodDrizzle()` after the cerebrum bootstrap so the in-package migrations apply during startup. Errors are logged and re-thrown so a corrupt DB surfaces at boot rather than on first request.
- `closeDb()` calls `closeFoodDb()` so SIGTERM/SIGINT releases the handle cleanly.
- `shared/test-utils.ts` injects an in-memory food handle on `setupTestContext.setup()` and clears it on teardown — forward-looking per inventory Phase 2 PR 2 lesson (d) so no router cutover in PR 3 introduces a fixture that tries to open `data/food.db` mid-suite.

## Deferred

- Cutover of `food.prepStates.list` (and other food module routers) to `getFoodDrizzle()` — Phase 2 PR 3, with the ATTACH-based backfill from `pops.db` (mirroring the inventory/finance/media/cerebrum PR-3 pattern).
- `infra/litestream/food.yml` + AGENTS.md docs — Phase 2 PR 4.

## Test plan

- [x] `pnpm typecheck` (workspace) green
- [x] `pnpm lint` (workspace) green — no new errors, only pre-existing warnings
- [x] `pnpm --filter @pops/api test` — 303 files / 4861 tests pass
- [x] `pnpm build` — all 22 build tasks succeed
- [x] `pnpm format` clean
- [ ] Local boot drill (deferred to deployer — homelab not available in this worktree)
