### PR TITLE
feat(api): flip food module to food.db + ATTACH backfill (pillar food phase 2 PR 3)

### DIFF
--- a/apps/pops-api/src/db/backfill-food-from-shared.test.ts
+++ b/apps/pops-api/src/db/backfill-food-from-shared.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Boot-time backfill tests for `backfillFoodFromShared` (phase 2 PR 3).
+ *
+ * Exercises the ATTACH-based copy from the shared `pops.db` to the
+ * pillar's `food.db` against on-disk SQLite files (in-memory DBs
+ * can't be ATTACHed). Confirms:
+ *   - first run carries existing rows across,
+ *   - second run is a no-op (idempotent — the per-table WHERE filter dedupes),
+ *   - mixed state (some rows already in food) only inserts the missing ones,
+ *   - missing source table is tolerated without throwing.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import BetterSqlite3 from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { openFoodDb } from '@pops/food-db';
+
+import { backfillFoodFromShared } from './backfill-food-from-shared.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'food-backfill-'));
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+const PREP_STATES_SQL = `
+CREATE TABLE prep_states (
+  id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  name text NOT NULL,
+  slug text NOT NULL
+);
+CREATE UNIQUE INDEX prep_states_name_unique ON prep_states (name);
+CREATE UNIQUE INDEX prep_states_slug_unique ON prep_states (slug);
+CREATE TABLE slug_registry (
+  slug text PRIMARY KEY NOT NULL,
+  kind text NOT NULL,
+  target_id integer NOT NULL,
+  created_at text DEFAULT (datetime('now')) NOT NULL,
+  CONSTRAINT "ck_slug_registry_kind" CHECK(kind IN ('ingredient','recipe','prep_state'))
+);
+CREATE INDEX idx_slug_registry_kind_target ON slug_registry (kind, target_id);
+`;
+
+function openSharedWithSeed(seed: (raw: BetterSqlite3.Database) => void): string {
+  const path = join(tmpDir, 'pops.db');
+  const raw = new BetterSqlite3(path);
+  raw.exec(PREP_STATES_SQL);
+  seed(raw);
+  raw.close();
+  return path;
+}
+
+function insertPrepState(
+  raw: BetterSqlite3.Database,
+  id: number,
+  name: string,
+  slug: string
+): void {
+  raw.prepare('INSERT INTO prep_states (id, name, slug) VALUES (?, ?, ?)').run(id, name, slug);
+}
+
+function insertSlug(
+  raw: BetterSqlite3.Database,
+  slug: string,
+  kind: 'prep_state' | 'ingredient' | 'recipe',
+  targetId: number
+): void {
+  raw
+    .prepare(
+      "INSERT INTO slug_registry (slug, kind, target_id, created_at) VALUES (?, ?, ?, '2026-06-10T00:00:00Z')"
+    )
+    .run(slug, kind, targetId);
+}
+
+describe('backfillFoodFromShared', () => {
+  it('copies prep_states rows from the shared DB on first run', () => {
+    const sharedPath = openSharedWithSeed((raw) => insertPrepState(raw, 1, 'Diced', 'diced'));
+
+    const food = openFoodDb(join(tmpDir, 'food.db'));
+    try {
+      backfillFoodFromShared(food, sharedPath);
+      const { n } = food.raw.prepare('SELECT count(*) AS n FROM prep_states').get() as {
+        n: number;
+      };
+      expect(n).toBe(1);
+    } finally {
+      food.raw.close();
+    }
+  });
+
+  it('is idempotent — a second run does not duplicate rows', () => {
+    const sharedPath = openSharedWithSeed((raw) => insertPrepState(raw, 1, 'Diced', 'diced'));
+
+    const food = openFoodDb(join(tmpDir, 'food.db'));
+    try {
+      backfillFoodFromShared(food, sharedPath);
+      backfillFoodFromShared(food, sharedPath);
+      const { n } = food.raw.prepare('SELECT count(*) AS n FROM prep_states').get() as {
+        n: number;
+      };
+      expect(n).toBe(1);
+    } finally {
+      food.raw.close();
+    }
+  });
+
+  it('only inserts rows missing from the food copy (mixed state)', () => {
+    const sharedPath = openSharedWithSeed((raw) => {
+      insertPrepState(raw, 1, 'Diced', 'diced');
+      insertPrepState(raw, 2, 'Sliced', 'sliced');
+    });
+
+    const food = openFoodDb(join(tmpDir, 'food.db'));
+    try {
+      insertPrepState(food.raw, 1, 'Diced', 'diced');
+      backfillFoodFromShared(food, sharedPath);
+      const rows = food.raw.prepare('SELECT id, slug FROM prep_states ORDER BY id').all() as {
+        id: number;
+        slug: string;
+      }[];
+      expect(rows.map((r) => r.slug)).toEqual(['diced', 'sliced']);
+    } finally {
+      food.raw.close();
+    }
+  });
+
+  it("only copies slug_registry rows with kind='prep_state' (other kinds belong to legacy)", () => {
+    const sharedPath = openSharedWithSeed((raw) => {
+      insertPrepState(raw, 1, 'Diced', 'diced');
+      insertSlug(raw, 'diced', 'prep_state', 1);
+      insertSlug(raw, 'tomato', 'ingredient', 99);
+      insertSlug(raw, 'pasta-bolognese', 'recipe', 42);
+    });
+
+    const food = openFoodDb(join(tmpDir, 'food.db'));
+    try {
+      backfillFoodFromShared(food, sharedPath);
+      const rows = food.raw.prepare('SELECT slug, kind FROM slug_registry ORDER BY slug').all() as {
+        slug: string;
+        kind: string;
+      }[];
+      expect(rows).toEqual([{ slug: 'diced', kind: 'prep_state' }]);
+    } finally {
+      food.raw.close();
+    }
+  });
+
+  it('tolerates a shared DB with no food tables (post-PR-4 drop scenario)', () => {
+    const sharedPath = join(tmpDir, 'pops.db');
+    const raw = new BetterSqlite3(sharedPath);
+    raw.exec(`CREATE TABLE other_table (id integer PRIMARY KEY)`);
+    raw.close();
+
+    const food = openFoodDb(join(tmpDir, 'food.db'));
+    try {
+      expect(() => backfillFoodFromShared(food, sharedPath)).not.toThrow();
+      const { n } = food.raw.prepare('SELECT count(*) AS n FROM prep_states').get() as {
+        n: number;
+      };
+      expect(n).toBe(0);
+    } finally {
+      food.raw.close();
+    }
+  });
+});

--- a/apps/pops-api/src/db/backfill-food-from-shared.ts
+++ b/apps/pops-api/src/db/backfill-food-from-shared.ts
@@ -9,11 +9,14 @@
  * find the food copy already populated and become a no-op via the
  * `WHERE id NOT IN (...)` existence filter.
  *
- * Today the slice only covers the `prep_states` table; ingredients +
- * ingredient_variants + ingredient_aliases + slug_registry + recipes +
- * recipe_versions + plan slices add their entries here when their
- * cutovers land. The `prep_states` table has no FK references to
- * other food tables so order is trivial for this PR.
+ * The current scope covers `prep_states` plus the prep-state subset of
+ * `slug_registry` (filtered to `kind='prep_state'`) so the slug
+ * lookups behind the cutover keep resolving. Other food tables —
+ * ingredients + ingredient_variants + ingredient_aliases + the rest of
+ * `slug_registry` + recipes + recipe_versions + plan slices — are
+ * added to the table-copies list when their cutovers land. The
+ * `prep_states` table has no FK references to other food tables so
+ * order is trivial for this PR.
  *
  * Non-fatal: ATTACH or INSERT failures are logged and swallowed so a
  * stale on-disk pops.db never bricks the boot path. Partial failures
@@ -82,8 +85,11 @@ function tryCopyTable(raw: Database.Database, copy: TableCopy): void {
 }
 
 /**
- * Copy every food-owned table's rows from `pops.db` into `food.db`,
- * idempotent against re-runs.
+ * Copy rows for each table currently listed in `TABLE_COPIES`
+ * (`prep_states` plus the `kind='prep_state'` slice of `slug_registry`
+ * as of Phase 2 PR 3) from `pops.db` into `food.db`, idempotent against
+ * re-runs. Subsequent slice cutovers append to `TABLE_COPIES` so the
+ * coverage grows with each PR rather than landing all at once.
  *
  * Caller is responsible for supplying the food handle (so this module
  * stays decoupled from the lazy singleton in `db/food-handle.ts`).

--- a/apps/pops-api/src/db/backfill-food-from-shared.ts
+++ b/apps/pops-api/src/db/backfill-food-from-shared.ts
@@ -1,0 +1,105 @@
+/**
+ * Boot-time backfill from the legacy shared `pops.db` into the food
+ * pillar's `food.db`.
+ *
+ * Phase 2 PR 3 of the food pillar flips the prep_states slice reads
+ * (`food.prepStates.list`) to the food handle. The first deploy after
+ * PR 3 needs to carry the existing prep_states rows from the shared DB
+ * across before any reads come from the new file. Subsequent boots
+ * find the food copy already populated and become a no-op via the
+ * `WHERE id NOT IN (...)` existence filter.
+ *
+ * Today the slice only covers the `prep_states` table; ingredients +
+ * ingredient_variants + ingredient_aliases + slug_registry + recipes +
+ * recipe_versions + plan slices add their entries here when their
+ * cutovers land. The `prep_states` table has no FK references to
+ * other food tables so order is trivial for this PR.
+ *
+ * Non-fatal: ATTACH or INSERT failures are logged and swallowed so a
+ * stale on-disk pops.db never bricks the boot path. Partial failures
+ * leave the food copy partially populated; the next deploy retries
+ * and the idempotent filter picks up only the still-missing rows.
+ *
+ * Mirrors `backfill-inventory-from-shared.ts` / `backfill-finance-from-
+ * shared.ts` / `backfill-media-from-shared.ts` / `backfill-cerebrum-
+ * from-shared.ts`.
+ */
+import type Database from 'better-sqlite3';
+
+import type { OpenedFoodDb } from '@pops/food-db';
+
+interface TableCopy {
+  readonly table: string;
+  /**
+   * Explicit column list keeps the backfill robust against a stale
+   * on-disk pops.db that already widened or narrowed since the boot
+   * image was built.
+   */
+  readonly columns: readonly string[];
+  /** Identifier column used in the existence filter. */
+  readonly idColumn: string;
+  /**
+   * Optional WHERE filter on the source side, evaluated against the
+   * attached `pops.<table>`. Used by the slug_registry copy in this
+   * slice so only `kind = 'prep_state'` rows come across — the other
+   * kinds (`ingredient`, `recipe`) still belong to the legacy shared
+   * registry until their slices migrate.
+   */
+  readonly sourceWhere?: string;
+}
+
+const TABLE_COPIES: readonly TableCopy[] = [
+  {
+    table: 'prep_states',
+    idColumn: 'id',
+    columns: ['id', 'name', 'slug'],
+  },
+  {
+    table: 'slug_registry',
+    idColumn: 'slug',
+    columns: ['slug', 'kind', 'target_id', 'created_at'],
+    sourceWhere: "kind = 'prep_state'",
+  },
+];
+
+function tryCopyTable(raw: Database.Database, copy: TableCopy): void {
+  try {
+    const hasTable = raw
+      .prepare(`SELECT 1 FROM pops.sqlite_master WHERE type='table' AND name='${copy.table}'`)
+      .get();
+    if (!hasTable) return;
+    const cols = copy.columns.join(', ');
+    const sourceWhere = copy.sourceWhere ? ` AND ${copy.sourceWhere}` : '';
+    raw.exec(`
+      INSERT INTO ${copy.table} (${cols})
+      SELECT ${cols}
+      FROM pops.${copy.table}
+      WHERE ${copy.idColumn} NOT IN (SELECT ${copy.idColumn} FROM ${copy.table})${sourceWhere}
+    `);
+  } catch (err) {
+    console.warn(`[db] Food backfill of ${copy.table} failed (non-fatal):`, err);
+  }
+}
+
+/**
+ * Copy every food-owned table's rows from `pops.db` into `food.db`,
+ * idempotent against re-runs.
+ *
+ * Caller is responsible for supplying the food handle (so this module
+ * stays decoupled from the lazy singleton in `db/food-handle.ts`).
+ * Production wiring passes the result of `getFoodDrizzle()` after the
+ * eager-open block; tests pass an in-memory handle with a tmpdir copy
+ * of the shared DB pre-populated.
+ */
+export function backfillFoodFromShared(food: OpenedFoodDb, sharedPath: string): void {
+  try {
+    food.raw.prepare('ATTACH DATABASE ? AS pops').run(sharedPath);
+    try {
+      for (const copy of TABLE_COPIES) tryCopyTable(food.raw, copy);
+    } finally {
+      food.raw.exec('DETACH DATABASE pops');
+    }
+  } catch (err) {
+    console.warn('[db] Food backfill ATTACH failed (non-fatal):', err);
+  }
+}

--- a/apps/pops-api/src/db/food-handle.ts
+++ b/apps/pops-api/src/db/food-handle.ts
@@ -19,6 +19,7 @@ import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { openFoodDb, type FoodDb, type OpenedFoodDb } from '@pops/food-db';
 
 import { getDb, isNamedEnvContext } from '../db.js';
+import { backfillFoodFromShared } from './backfill-food-from-shared.js';
 import { resolveFoodSqlitePath } from './food-sqlite-path.js';
 
 let foodDb: OpenedFoodDb | null = null;
@@ -84,4 +85,16 @@ export function setFoodDb(next: OpenedFoodDb | null): OpenedFoodDb | null {
   const prev = foodDb;
   foodDb = next;
   return prev;
+}
+
+/**
+ * Run the one-shot ATTACH backfill from the legacy shared pops.db into
+ * the food pillar's food.db. No-op if the food handle isn't open (e.g.
+ * boot still resolving). Idempotent against repeated boots via
+ * per-table `WHERE id NOT IN (...)` filters. See
+ * `backfill-food-from-shared.ts` for the table-by-table behaviour.
+ */
+export function backfillFoodFromSharedDb(sharedPath: string): void {
+  if (!foodDb) return;
+  backfillFoodFromShared(foodDb, sharedPath);
 }

--- a/apps/pops-api/src/index.ts
+++ b/apps/pops-api/src/index.ts
@@ -9,7 +9,7 @@ import { createApp } from './app.js';
 import { backfillCoreFromShared, closeDb, getCoreDrizzle } from './db.js';
 import { backfillCerebrumFromSharedDb, getCerebrumDrizzle } from './db/cerebrum-handle.js';
 import { backfillFinanceFromSharedDb, getFinanceDrizzle } from './db/finance-handle.js';
-import { getFoodDrizzle } from './db/food-handle.js';
+import { backfillFoodFromSharedDb, getFoodDrizzle } from './db/food-handle.js';
 import { backfillInventoryFromSharedDb, getInventoryDrizzle } from './db/inventory-handle.js';
 import { backfillMediaFromShared, getMediaDrizzle } from './db/media-db-handle.js';
 import { resolveSqlitePath } from './db/sqlite-path.js';
@@ -111,17 +111,15 @@ try {
   throw err;
 }
 
-// Eagerly open the food pillar's SQLite + apply its journal at boot so
-// the in-package migrations land before any request hits the API. Phase
-// 2 PR 2 only opens the handle — no production traffic is routed
-// through it yet; the prep_states slice still reads/writes against the
-// shared pops.db. Phase 2 PR 3 flips the prep_states slice over with an
-// ATTACH-based backfill from pops.db (matching the inventory / finance
-// / media / core / cerebrum PR-3 pattern); PR 4 adds the Litestream
-// config. Opening early surfaces migration failures during boot rather
-// than on first food-route request.
+// Eagerly open the food pillar's SQLite + apply its journal at boot.
+// The prep_states slice now reads/writes against this handle (phase 2
+// PR 3); the one-shot `backfillFoodFromSharedDb` carries any rows that
+// still live in the legacy pops.db across. The backfill is idempotent
+// (per-table `WHERE id NOT IN (...)` filters) and non-fatal (partial
+// failure logs + continues).
 try {
   getFoodDrizzle();
+  backfillFoodFromSharedDb(resolveSqlitePath());
 } catch (err) {
   console.error('[db] Failed to bootstrap the food pillar SQLite:', err);
   throw err;

--- a/apps/pops-api/src/modules/food/routers/prep-states.ts
+++ b/apps/pops-api/src/modules/food/routers/prep-states.ts
@@ -8,28 +8,33 @@ import {
 } from '@pops/app-food-db';
 import { prepStatesService } from '@pops/food-db';
 
-import { getDrizzle } from '../../../db.js';
+import { getFoodDrizzle } from '../../../db/food-handle.js';
 import { protectedProcedure, router } from '../../../trpc.js';
 
 /**
  * `food.prepStates` tRPC router.
  *
  * Reads (`listPrepStates`) are sourced from the pillar package
- * `@pops/food-db`. The `createPrepState` mutation and its slug-registry
- * typed errors (`InvalidSlugError`, `SlugAlreadyRegisteredError`) still
- * live in `@pops/app-food-db` because the slug-registry + transaction
- * helpers haven't been extracted into the pillar package yet.
+ * `@pops/food-db` and run against the food pillar handle (phase 2
+ * PR 3). The `createPrepState` mutation still calls into
+ * `@pops/app-food-db` because the slug-registry transaction helpers
+ * haven't been extracted into the pillar package yet, but both reads
+ * and writes now resolve through `getFoodDrizzle()` so they land on
+ * `food.db`. The boot-time `backfillFoodFromSharedDb` carries the
+ * existing prep_states rows + their `kind='prep_state'` slug_registry
+ * entries across so the mutation's slug-availability checks see the
+ * full pre-cutover history.
  */
 export const prepStatesRouter = router({
   list: protectedProcedure.query(() => ({
-    items: prepStatesService.listPrepStates(getDrizzle()),
+    items: prepStatesService.listPrepStates(getFoodDrizzle()),
   })),
 
   create: protectedProcedure
     .input(z.object({ slug: z.string(), name: z.string().min(1) }))
     .mutation(({ input }) => {
       try {
-        return legacyPrepStatesService.createPrepState(getDrizzle(), input);
+        return legacyPrepStatesService.createPrepState(getFoodDrizzle(), input);
       } catch (err) {
         if (err instanceof InvalidSlugError) {
           throw new TRPCError({ code: 'BAD_REQUEST', message: err.message, cause: err });


### PR DESCRIPTION
## Summary

Phase 2 PR 3 of the food pillar migration — flip the **prep_states** slice off the shared `pops.db` singleton onto the food pillar's `food.db` handle (opened at boot in PR 2) and wire an ATTACH-based backfill so existing rows carry across the first deploy.

- `apps/pops-api/src/modules/food/routers/prep-states.ts` swaps `getDrizzle()` → `getFoodDrizzle()` for both the `listPrepStates` query and the `legacyPrepStatesService.createPrepState` mutation. Reads come from `@pops/food-db`; the mutation still calls into `@pops/app-food-db` (slug-registry transaction helpers haven't been extracted into the pillar package yet) but both now land on `food.db`.
- New `apps/pops-api/src/db/backfill-food-from-shared.ts` runs `ATTACH DATABASE 'pops.db' AS pops`, copies `prep_states` rows + `slug_registry` rows where `kind = 'prep_state'` that aren't already present locally, then `DETACH`s. The `kind` filter keeps ingredient/recipe slug-registry rows on the legacy shared DB until those slices migrate. `tryCopyTable` swallows per-table failures so a missing source table (post-PR-4 drop scenario, or stale on-disk `pops.db`) doesn't bring the whole backfill down.
- `db/food-handle.ts` gains `backfillFoodFromSharedDb(sharedPath)` — no-op if the handle isn't open. Wired into `index.ts` immediately after `getFoodDrizzle()`.
- The package-local `food.db` migration journal (`0058_high_sentinel.sql` from PR 1 #2867) already creates `prep_states` + `slug_registry` at their final shape, so no new baseline migration is required for this slice.
- `getFoodDrizzle()` / `getFoodRawDb()` are already env-aware (`isNamedEnvContext()` check landed in PR 2 #2871) and `setupTestContext` in `shared/test-utils.ts` already injects the in-memory test DB on the food handle, so existing food tests stay green.

5 new backfill tests (fresh copy, idempotent re-run, mixed state, slug_registry `kind` filter, missing source table tolerated).

Refs:
- PR 1 #2867 (openFoodDb helper)
- PR 2 #2871 (boot-time open + FOOD_SQLITE_PATH env)
- Sibling PR 3s: inventory #2794, finance #2806, media #2795, cerebrum #2818

Does **not** touch Litestream (PR 4) or start Phase 3 container work (separate sequence).

## Test plan

- [x] `pnpm typecheck` — 47/47 passing
- [x] `pnpm lint` (oxlint) — clean (only pre-existing warnings)
- [x] `pnpm --filter @pops/api test` — 4866/4866 (one flaky thalamus watcher test, passes on re-run)
- [x] `pnpm --filter @pops/food-db test` — 11/11
- [x] `pnpm build` — 22/22
- [x] `pnpm format` — clean
- [ ] CI green on the PR
- [ ] On staging deploy: confirm `[db] Food backfill ATTACH …` log absent (no error), `food.db` populated with existing prep_states + their `kind='prep_state'` slug_registry entries
