### PR TITLE
feat(infra): food pillar Litestream config + AGENTS.md note (pillar food phase 2 PR 4)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -266,7 +266,7 @@ When a movie is added to the POPS library, automatically checks Plex Discover cl
 - **Chat:** Moltbot (Telegram)
 - **Backup:** Backblaze B2 via rclone (encrypted)
 - **Litestream exclusions:** `MEDIA_IMAGES_DIR` and `FOOD_INGEST_DIR` are regeneratable media trees and must be excluded from Litestream replication in the homelab-infra repo's Litestream config. The SQLite rows that reference these paths stay backed up; only the bytes are skipped.
-- **Per-pillar SQLite (ADR-026):** each pillar's database streams independently. The core pillar's reference config lives at `infra/litestream/core.yml`, the finance pillar's at `infra/litestream/finance.yml`, the inventory pillar's at `infra/litestream/inventory.yml`, the media pillar's at `infra/litestream/media.yml`, and the cerebrum pillar's at `infra/litestream/cerebrum.yml`; the deployer mirrors them into the homelab-infra Litestream config alongside the existing `pops.db` stream. As subsequent pillars extract their own SQLite files, each adds a sibling YAML next to `core.yml`.
+- **Per-pillar SQLite (ADR-026):** each pillar's database streams independently. The core pillar's reference config lives at `infra/litestream/core.yml`, the finance pillar's at `infra/litestream/finance.yml`, the inventory pillar's at `infra/litestream/inventory.yml`, the media pillar's at `infra/litestream/media.yml`, the cerebrum pillar's at `infra/litestream/cerebrum.yml`, and the food pillar's at `infra/litestream/food.yml`; the deployer mirrors them into the homelab-infra Litestream config alongside the existing `pops.db` stream. As subsequent pillars extract their own SQLite files, each adds a sibling YAML next to `core.yml`.
 
 ## Import Pipeline
 

--- a/infra/litestream/food.yml
+++ b/infra/litestream/food.yml
@@ -1,0 +1,30 @@
+## Litestream replication config — food pillar SQLite.
+##
+## Phase 2 PR 4 of the food pillar migration (ADR-026). Mirrors
+## the per-pillar pattern so each pillar's database streams
+## independently of the shared pops.db.
+##
+## Production deployment lives in the homelab-infra repo (see AGENTS.md
+## for the deployment model); this file is the canonical reference the
+## deployer copies into its own Litestream config. The replica target
+## (S3 bucket name, region, credentials) is provided by the deployer's
+## environment — leave it as a `${FOOD_LITESTREAM_REPLICA_URL}`
+## style placeholder here.
+##
+## Restore drill (single line — safe to copy/paste during an incident):
+##   litestream restore -o /data/sqlite/food.db "${FOOD_LITESTREAM_REPLICA_URL}"
+## Stop the food-api container first so it isn't writing
+## concurrently; the drill is exercised in Phase 4 verification.
+
+dbs:
+  - path: /data/sqlite/food.db
+    replicas:
+      - url: ${FOOD_LITESTREAM_REPLICA_URL}
+        # Per-pillar config so a single-pillar restore doesn't pull in
+        # the whole pops.db blob. Sync interval matches the shared
+        # singleton's existing replica config (1s by default — see
+        # homelab-infra).
+        sync-interval: 1s
+        retention: 24h
+        snapshot-interval: 1h
+        validation-interval: 12h


### PR DESCRIPTION
## Summary

Final PR of food Phase 2. Adds the per-pillar Litestream reference config so the deployer can mirror it into the homelab-infra repo's Litestream YAML alongside the existing `pops.db` / `core.db` / `finance.db` / `inventory.db` / `media.db` / `cerebrum.db` streams.

Mirrors the same per-pillar shape used for inventory ([#2796](https://github.com/knoxio/pops/pull/2796)) / finance ([#2811](https://github.com/knoxio/pops/pull/2811)) / media ([#2800](https://github.com/knoxio/pops/pull/2800)) / cerebrum ([#2820](https://github.com/knoxio/pops/pull/2820)):

- `/data/sqlite/food.db` path inside the production container.
- `sync-interval: 1s`, `retention: 24h`, `snapshot-interval: 1h`, `validation-interval: 12h` — matches the shared singleton's existing replica config.
- Replica URL kept as a `${FOOD_LITESTREAM_REPLICA_URL}` placeholder so the bucket / region / credentials are sourced from the deployer's environment, not committed here.

AGENTS.md's per-pillar SQLite paragraph gains the food entry alongside core / finance / inventory / media / cerebrum.

This completes Phase 2 of the food pillar migration (ADR-026). Source files (`FOOD_INGEST_DIR`) remain excluded from Litestream per the existing exclusion note — only the SQLite rows referencing them stream.

## Test plan

- [x] `diff infra/litestream/cerebrum.yml infra/litestream/food.yml` — only the pillar id + replica env var name differ, as intended.
- [x] `npx yaml-lint infra/litestream/food.yml` — clean.
- [x] `pnpm typecheck` — 47/47 packages green (no source change here, just docs + infra config).
- [x] `pnpm lint` — clean (only pre-existing warnings unrelated to this change).
- [x] `pnpm format:check` — clean.
