### PR TITLE
feat(infra): wire food-api into docker-compose + publish image (pillar food phase 3 PR 2)

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -206,6 +206,32 @@ jobs:
           build-args: |
             BUILD_VERSION=${{ github.sha }}
 
+      - name: Generate metadata for pops-food-api
+        id: meta-food-api
+        uses: docker/metadata-action@v6
+        with:
+          images: ghcr.io/knoxio/pops-food-api
+          tags: |
+            type=raw,value=main,enable={{is_default_branch}}
+            type=sha,prefix=sha-,format=short
+            type=semver,pattern={{version}}
+            type=semver,pattern=v{{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=semver,pattern=v{{major}}
+
+      - name: Build and push pops-food-api
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: apps/pops-food-api/Dockerfile
+          push: true
+          tags: ${{ steps.meta-food-api.outputs.tags }}
+          labels: ${{ steps.meta-food-api.outputs.labels }}
+          build-args: |
+            BUILD_VERSION=${{ github.sha }}
+
       - name: Generate metadata for pops-cerebrum-api
         id: meta-cerebrum-api
         uses: docker/metadata-action@v6

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -48,7 +48,7 @@ services:
       # `/pillars` snapshot that the shell's nginx proxy fans out to,
       # so it MUST default to the full sibling list rather than empty.
       # Sibling pillars get appended (id:baseUrl,...) as they extract.
-      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,cerebrum:http://cerebrum-api:3007}
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,cerebrum:http://cerebrum-api:3007}
     expose:
       - '3001'
     healthcheck:
@@ -88,7 +88,7 @@ services:
       INVENTORY_SELF_BASE_URL: http://inventory-api:3002
       # Cross-pillar registry. Includes core-api by default so /pillars
       # surfaces both host pillars on the synthetic-entry list.
-      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,cerebrum:http://cerebrum-api:3007}
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,cerebrum:http://cerebrum-api:3007}
     expose:
       - '3002'
     depends_on:
@@ -130,7 +130,7 @@ services:
       FINANCE_SELF_BASE_URL: http://finance-api:3004
       # Cross-pillar registry — included for parity with siblings even
       # though finance-api today only exposes /health.
-      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,cerebrum:http://cerebrum-api:3007}
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,cerebrum:http://cerebrum-api:3007}
     expose:
       - '3004'
     depends_on:
@@ -172,7 +172,7 @@ services:
       MEDIA_SELF_BASE_URL: http://media-api:3003
       # Cross-pillar registry. Includes core-api + inventory-api by default
       # so /pillars surfaces every host pillar on the synthetic-entry list.
-      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,cerebrum:http://cerebrum-api:3007}
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,cerebrum:http://cerebrum-api:3007}
     expose:
       - '3003'
     depends_on:
@@ -185,6 +185,48 @@ services:
           'node',
           '-e',
           "fetch('http://localhost:3003/health').then(r=>{if(!r.ok)process.exit(1)})",
+        ]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+  # Food pillar API (ADR-026, Phase 3 PR 2 of the food track). Hosts
+  # food.db reads/writes today exposes only /health + /pillars;
+  # subsequent slices (recipes, ingredients, ingest, meal planning,
+  # review queue, URI dispatcher) move their tRPC routers behind it.
+  food-api:
+    build:
+      context: ..
+      dockerfile: apps/pops-food-api/Dockerfile
+      args:
+        BUILD_VERSION: ${BUILD_VERSION:-dev}
+    container_name: pops-food-api
+    restart: unless-stopped
+    networks:
+      - frontend
+      - backend
+    volumes:
+      - sqlite-data:/data/sqlite
+    environment:
+      NODE_ENV: production
+      PORT: '3005'
+      FOOD_SQLITE_PATH: /data/sqlite/food.db
+      FOOD_SELF_BASE_URL: http://food-api:3005
+      # Cross-pillar registry — included for parity with siblings even
+      # though food-api today only exposes /health.
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,cerebrum:http://cerebrum-api:3007}
+    expose:
+      - '3005'
+    depends_on:
+      core-api:
+        condition: service_healthy
+    healthcheck:
+      test:
+        [
+          'CMD',
+          'node',
+          '-e',
+          "fetch('http://localhost:3005/health').then(r=>{if(!r.ok)process.exit(1)})",
         ]
       interval: 30s
       timeout: 5s
@@ -214,7 +256,7 @@ services:
       CEREBRUM_SELF_BASE_URL: http://cerebrum-api:3007
       # Cross-pillar registry — included for parity with siblings even
       # though cerebrum-api today only exposes /health.
-      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,cerebrum:http://cerebrum-api:3007}
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,cerebrum:http://cerebrum-api:3007}
     expose:
       - '3007'
     depends_on:
@@ -263,7 +305,7 @@ services:
       # its compose hostname so pops-api's URI dispatcher can route
       # outbound `pops:core/...` traffic to the new container. Deployers
       # override POPS_PILLARS to extend with sibling pillars.
-      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,cerebrum:http://cerebrum-api:3007}
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,cerebrum:http://cerebrum-api:3007}
       # Paperless-ngx integration (optional — leave unset to disable)
       PAPERLESS_BASE_URL: ${PAPERLESS_BASE_URL:-}
       PAPERLESS_API_TOKEN: ${PAPERLESS_API_TOKEN:-}
@@ -279,6 +321,8 @@ services:
       media-api:
         condition: service_healthy
       finance-api:
+        condition: service_healthy
+      food-api:
         condition: service_healthy
       cerebrum-api:
         condition: service_healthy
@@ -320,7 +364,7 @@ services:
       SQLITE_PATH: /data/sqlite/pops.db
       REDIS_HOST: pops-redis
       REDIS_PORT: '6379'
-      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,cerebrum:http://cerebrum-api:3007}
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,cerebrum:http://cerebrum-api:3007}
     depends_on:
       pops-redis:
         condition: service_healthy
@@ -331,6 +375,8 @@ services:
       media-api:
         condition: service_healthy
       finance-api:
+        condition: service_healthy
+      food-api:
         condition: service_healthy
       cerebrum-api:
         condition: service_healthy

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       # Cross-pillar registry — core-api hosts the authoritative
       # `/pillars` snapshot that the shell's nginx proxy fans out to,
       # so it MUST default to the full sibling list rather than empty.
-      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,cerebrum:http://cerebrum-api:3007}
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,cerebrum:http://cerebrum-api:3007}
     expose:
       - '3001'
     healthcheck:
@@ -81,7 +81,7 @@ services:
       PORT: '3002'
       INVENTORY_SQLITE_PATH: /data/sqlite/inventory.db
       INVENTORY_SELF_BASE_URL: http://inventory-api:3002
-      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,cerebrum:http://cerebrum-api:3007}
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,cerebrum:http://cerebrum-api:3007}
     expose:
       - '3002'
     depends_on:
@@ -119,7 +119,7 @@ services:
       PORT: '3004'
       FINANCE_SQLITE_PATH: /data/sqlite/finance.db
       FINANCE_SELF_BASE_URL: http://finance-api:3004
-      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,cerebrum:http://cerebrum-api:3007}
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,cerebrum:http://cerebrum-api:3007}
     expose:
       - '3004'
     depends_on:
@@ -157,7 +157,7 @@ services:
       PORT: '3003'
       MEDIA_SQLITE_PATH: /data/sqlite/media.db
       MEDIA_SELF_BASE_URL: http://media-api:3003
-      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,cerebrum:http://cerebrum-api:3007}
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,cerebrum:http://cerebrum-api:3007}
     expose:
       - '3003'
     depends_on:
@@ -170,6 +170,44 @@ services:
           'node',
           '-e',
           "fetch('http://localhost:3003/health').then(r=>{if(!r.ok)process.exit(1)})",
+        ]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+  # Food pillar API (ADR-026, Phase 3 PR 2 of the food track). Hosts
+  # food.db reads/writes today exposes only /health + /pillars;
+  # subsequent slices (recipes, ingredients, ingest, meal planning,
+  # review queue, URI dispatcher) move their tRPC routers behind it.
+  food-api:
+    image: ghcr.io/knoxio/pops-food-api:${POPS_IMAGE_TAG:-main}
+    container_name: pops-food-api
+    restart: unless-stopped
+    labels:
+      com.centurylinklabs.watchtower.enable: 'true'
+    networks:
+      - frontend
+      - backend
+    volumes:
+      - sqlite-data:/data/sqlite
+    environment:
+      NODE_ENV: production
+      PORT: '3005'
+      FOOD_SQLITE_PATH: /data/sqlite/food.db
+      FOOD_SELF_BASE_URL: http://food-api:3005
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,cerebrum:http://cerebrum-api:3007}
+    expose:
+      - '3005'
+    depends_on:
+      core-api:
+        condition: service_healthy
+    healthcheck:
+      test:
+        [
+          'CMD',
+          'node',
+          '-e',
+          "fetch('http://localhost:3005/health').then(r=>{if(!r.ok)process.exit(1)})",
         ]
       interval: 30s
       timeout: 5s
@@ -195,7 +233,7 @@ services:
       PORT: '3007'
       CEREBRUM_SQLITE_PATH: /data/sqlite/cerebrum.db
       CEREBRUM_SELF_BASE_URL: http://cerebrum-api:3007
-      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,cerebrum:http://cerebrum-api:3007}
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,cerebrum:http://cerebrum-api:3007}
     expose:
       - '3007'
     depends_on:
@@ -248,7 +286,7 @@ services:
       POPS_OVERLAYS: ${POPS_OVERLAYS:-}
       # Cross-pillar registry (ADR-026 Phase 3 PR 3). pops-api routes
       # outbound `pops:core/...` traffic to the core-api container.
-      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,cerebrum:http://cerebrum-api:3007}
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,cerebrum:http://cerebrum-api:3007}
     expose:
       - '3000'
     depends_on:
@@ -261,6 +299,8 @@ services:
       media-api:
         condition: service_healthy
       finance-api:
+        condition: service_healthy
+      food-api:
         condition: service_healthy
       cerebrum-api:
         condition: service_healthy
@@ -303,7 +343,7 @@ services:
       # PRD-100 — same module set as the api so worker jobs scope correctly.
       POPS_APPS: ${POPS_APPS:-}
       POPS_OVERLAYS: ${POPS_OVERLAYS:-}
-      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,cerebrum:http://cerebrum-api:3007}
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,cerebrum:http://cerebrum-api:3007}
     depends_on:
       pops-redis:
         condition: service_healthy
@@ -314,6 +354,8 @@ services:
       media-api:
         condition: service_healthy
       finance-api:
+        condition: service_healthy
+      food-api:
         condition: service_healthy
       cerebrum-api:
         condition: service_healthy


### PR DESCRIPTION
## Summary

Phase 3 PR 2 of the food pillar migration. Wires the `pops-food-api` container scaffold from #2874 into the runtime + GHCR publish pipeline. This is the final Phase 3 PR for the food pillar — the next step (Phase 4) is the verification runbook.

- **`infra/docker-compose.yml`** — new `food-api` service (image `ghcr.io/knoxio/pops-food-api:${POPS_IMAGE_TAG:-main}`), mounted `sqlite-data` volume at `/data/sqlite`, `FOOD_SQLITE_PATH=/data/sqlite/food.db`, `FOOD_SELF_BASE_URL=http://food-api:3005`, port `3005`, Watchtower label enabled, `depends_on: core-api (service_healthy)`, node-`fetch` `/health` probe matching every other pillar. Added `food-api` to the `depends_on` of `pops-api` + `pops-worker`.
- **`infra/docker-compose.dev.yml`** — same shape with a local `build:` context so dev parity holds (per finance Phase 3 PR 2 lesson b that each compose file gets its own block).
- **`POPS_PILLARS` default** — extended in every block (core-api, inventory-api, finance-api, media-api, **food-api**, cerebrum-api, pops-api, pops-worker) to include `food:http://food-api:3005`, per finance Phase 3 PR 1 lesson `d` about keeping the default-list in sync across consumers.
- **`.github/workflows/publish-images.yml`** — new `metadata-action` + `build-push-action` step for `pops-food-api`, slotted before the cerebrum block.
- **`.github/workflows/docker-build.yml`** — already covers `apps/pops-food-api/**` and runs the builder-stage build (shipped with #2874 via follow-up `e7051fef`); no edit needed here.

## References

- Builds on #2874 (food-api scaffold + Dockerfile, port 3005)
- Sibling Phase 3 PR 2 patterns:
  - inventory — #2802
  - finance — #2819
  - media — #2807
  - cerebrum — #2823

## Deferred

- Phase 4 — `docs/runbooks/food-api-pillar-verification.md` end-to-end verification runbook (separate PR).
- Track J roadmap row flip.

## Test plan

- [x] `docker compose -f infra/docker-compose.yml config --quiet`
- [x] `docker compose -f infra/docker-compose.dev.yml config --quiet`
- [x] `npx yaml-lint infra/docker-compose*.yml .github/workflows/publish-images.yml .github/workflows/docker-build.yml`
- [x] `pnpm typecheck` (48/48)
- [x] `pnpm lint` (warnings only, no new errors)
- [x] `pnpm build` (23/23)
- [ ] `docker-build` workflow green (compose-validate + builder smoke)
- [ ] `publish-images` workflow green on merge to main (pushes `ghcr.io/knoxio/pops-food-api:main`)
