### PR TITLE
feat(lists-db): scaffold @pops/lists-db + list_items slice (Track K phase 1 PR 1)

### DIFF
--- a/.github/workflows/_pkg-check.yml
+++ b/.github/workflows/_pkg-check.yml
@@ -52,6 +52,7 @@ jobs:
           pnpm --filter @pops/media-db build
           pnpm --filter @pops/cerebrum-db build
           pnpm --filter @pops/food-db build
+          pnpm --filter @pops/lists-db build
           pnpm --filter @pops/app-lists-db build
           pnpm --filter @pops/app-food-db build
       - run: cd ${{ inputs.package-path }} && pnpm typecheck
@@ -89,6 +90,7 @@ jobs:
           pnpm --filter @pops/media-db build
           pnpm --filter @pops/cerebrum-db build
           pnpm --filter @pops/food-db build
+          pnpm --filter @pops/lists-db build
           pnpm --filter @pops/app-lists-db build
           pnpm --filter @pops/app-food-db build
       - name: Run tests (with coverage if configured)

--- a/.github/workflows/api-quality.yml
+++ b/.github/workflows/api-quality.yml
@@ -12,6 +12,7 @@ on:
       - "packages/finance-db/**"
       - "packages/food-db/**"
       - "packages/inventory-db/**"
+      - "packages/lists-db/**"
       - "packages/types/**"
       - ".github/workflows/api-quality.yml"
 
@@ -35,6 +36,7 @@ jobs:
               - 'packages/finance-db/**'
               - 'packages/food-db/**'
               - 'packages/inventory-db/**'
+              - 'packages/lists-db/**'
               - 'packages/types/**'
               - '.github/workflows/api-quality.yml'
 
@@ -81,6 +83,7 @@ jobs:
           cd ../media-db && pnpm build
           cd ../cerebrum-db && pnpm build
           cd ../food-db && pnpm build
+          cd ../lists-db && pnpm build
           cd ../app-lists-db && pnpm build
           cd ../app-food-db && pnpm build
 

--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -10,6 +10,7 @@ on:
       - "packages/finance-db/**"
       - "packages/food-db/**"
       - "packages/inventory-db/**"
+      - "packages/lists-db/**"
       - "packages/types/**"
       - "packages/auth/**"
       - ".github/workflows/api-test.yml"
@@ -35,6 +36,7 @@ jobs:
               - 'packages/finance-db/**'
               - 'packages/food-db/**'
               - 'packages/inventory-db/**'
+              - 'packages/lists-db/**'
               - 'packages/types/**'
               - 'packages/auth/**'
               - '.github/workflows/api-test.yml'
@@ -82,6 +84,7 @@ jobs:
           cd ../media-db && pnpm build
           cd ../cerebrum-db && pnpm build
           cd ../food-db && pnpm build
+          cd ../lists-db && pnpm build
           cd ../app-lists-db && pnpm build
           cd ../app-food-db && pnpm build
 

--- a/.github/workflows/fe-quality.yml
+++ b/.github/workflows/fe-quality.yml
@@ -10,6 +10,7 @@ on:
       - "packages/db-types/**"
       - "packages/food-db/**"
       - "packages/inventory-db/**"
+      - "packages/lists-db/**"
       - "packages/ui/**"
       - "packages/api-client/**"
       - "packages/widgets/**"
@@ -38,6 +39,7 @@ jobs:
               - 'packages/db-types/**'
               - 'packages/food-db/**'
               - 'packages/inventory-db/**'
+              - 'packages/lists-db/**'
               - 'packages/ui/**'
               - 'packages/api-client/**'
               - 'packages/widgets/**'
@@ -85,6 +87,7 @@ jobs:
           cd ../media-db && pnpm build
           cd ../cerebrum-db && pnpm build
           cd ../food-db && pnpm build
+          cd ../lists-db && pnpm build
           cd ../app-lists-db && pnpm build
           cd ../app-food-db && pnpm build
 

--- a/.github/workflows/fe-test-e2e.yml
+++ b/.github/workflows/fe-test-e2e.yml
@@ -68,6 +68,7 @@ jobs:
           cd ../media-db && pnpm build
           cd ../cerebrum-db && pnpm build
           cd ../food-db && pnpm build
+          cd ../lists-db && pnpm build
           cd ../app-lists-db && pnpm build
           cd ../app-food-db && pnpm build
 

--- a/.github/workflows/lists-db-quality.yml
+++ b/.github/workflows/lists-db-quality.yml
@@ -1,0 +1,67 @@
+name: Lists DB Quality
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/lists-db/**"
+      - "packages/db-types/**"
+      - "apps/pops-api/src/db/drizzle-migrations/0062_chemical_donald_blake.sql"
+      - ".github/workflows/lists-db-quality.yml"
+      - ".github/workflows/_pkg-check.yml"
+  pull_request:
+
+jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - 'packages/lists-db/**'
+              - 'packages/db-types/**'
+              - 'apps/pops-api/src/db/drizzle-migrations/0062_chemical_donald_blake.sql'
+              - '.github/workflows/lists-db-quality.yml'
+              - '.github/workflows/_pkg-check.yml'
+
+  migration-drift-guard:
+    name: Migration drift (shared vs lists-db)
+    needs: [changes]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Skip — no relevant changes"
+        if: github.event_name == 'pull_request' && needs.changes.outputs.relevant != 'true'
+        run: echo "Skipping — no relevant changes"
+      - uses: actions/checkout@v6
+        if: github.event_name != 'pull_request' || needs.changes.outputs.relevant == 'true'
+      - name: Diff lists-db copies against shared journal copies
+        if: github.event_name != 'pull_request' || needs.changes.outputs.relevant == 'true'
+        run: |
+          set -euo pipefail
+          for tag in 0062_chemical_donald_blake; do
+            shared="apps/pops-api/src/db/drizzle-migrations/${tag}.sql"
+            pillar="packages/lists-db/migrations/${tag}.sql"
+            if ! diff -q "$shared" "$pillar"; then
+              echo "::error::Migration drift detected: $shared and $pillar must be byte-identical during the transitional release cycle (lists pillar phase 1)."
+              diff "$shared" "$pillar" || true
+              exit 1
+            fi
+            echo "OK — both ${tag}.sql copies are byte-identical."
+          done
+
+  quality:
+    needs: [changes]
+    if: always()
+    uses: ./.github/workflows/_pkg-check.yml
+    with:
+      package-path: packages/lists-db
+      needs-db-build: true
+      skip: ${{ github.event_name == 'pull_request' && needs.changes.outputs.relevant != 'true' }}

--- a/apps/pops-api/Dockerfile
+++ b/apps/pops-api/Dockerfile
@@ -18,6 +18,7 @@ COPY packages/food-contracts/package.json ./packages/food-contracts/
 COPY packages/inventory-db/package.json ./packages/inventory-db/
 COPY packages/cerebrum-db/package.json ./packages/cerebrum-db/
 COPY packages/food-db/package.json ./packages/food-db/
+COPY packages/lists-db/package.json ./packages/lists-db/
 COPY apps/pops-api/package.json ./apps/pops-api/
 
 # Install pnpm and dependencies (cached across builds)
@@ -55,6 +56,9 @@ COPY packages/cerebrum-db/migrations ./packages/cerebrum-db/migrations
 COPY packages/food-db/src ./packages/food-db/src
 COPY packages/food-db/tsconfig.json ./packages/food-db/
 COPY packages/food-db/migrations ./packages/food-db/migrations
+COPY packages/lists-db/src ./packages/lists-db/src
+COPY packages/lists-db/tsconfig.json ./packages/lists-db/
+COPY packages/lists-db/migrations ./packages/lists-db/migrations
 COPY apps/pops-api/tsconfig.json ./apps/pops-api/
 COPY apps/pops-api/src ./apps/pops-api/src
 
@@ -78,6 +82,8 @@ RUN pnpm build
 WORKDIR /app/packages/cerebrum-db
 RUN pnpm build
 WORKDIR /app/packages/food-db
+RUN pnpm build
+WORKDIR /app/packages/lists-db
 RUN pnpm build
 WORKDIR /app/packages/app-lists-db
 RUN pnpm build
@@ -134,6 +140,9 @@ COPY --from=builder /app/packages/cerebrum-db/migrations ./node_modules/@pops/ce
 COPY --from=builder /app/packages/food-db/dist ./node_modules/@pops/food-db/dist
 COPY --from=builder /app/packages/food-db/package.json ./node_modules/@pops/food-db/
 COPY --from=builder /app/packages/food-db/migrations ./node_modules/@pops/food-db/migrations
+COPY --from=builder /app/packages/lists-db/dist ./node_modules/@pops/lists-db/dist
+COPY --from=builder /app/packages/lists-db/package.json ./node_modules/@pops/lists-db/
+COPY --from=builder /app/packages/lists-db/migrations ./node_modules/@pops/lists-db/migrations
 
 # Copy types source into node_modules (source-only package, no build step)
 COPY --from=builder /app/packages/types/src ./node_modules/@pops/types/src

--- a/apps/pops-mcp/Dockerfile
+++ b/apps/pops-mcp/Dockerfile
@@ -18,6 +18,7 @@ COPY packages/food-contracts/package.json ./packages/food-contracts/
 COPY packages/inventory-db/package.json ./packages/inventory-db/
 COPY packages/cerebrum-db/package.json ./packages/cerebrum-db/
 COPY packages/food-db/package.json ./packages/food-db/
+COPY packages/lists-db/package.json ./packages/lists-db/
 COPY apps/pops-api/package.json ./apps/pops-api/
 COPY apps/pops-mcp/package.json ./apps/pops-mcp/
 
@@ -56,6 +57,9 @@ COPY packages/cerebrum-db/migrations ./packages/cerebrum-db/migrations
 COPY packages/food-db/src ./packages/food-db/src
 COPY packages/food-db/tsconfig.json ./packages/food-db/
 COPY packages/food-db/migrations ./packages/food-db/migrations
+COPY packages/lists-db/src ./packages/lists-db/src
+COPY packages/lists-db/tsconfig.json ./packages/lists-db/
+COPY packages/lists-db/migrations ./packages/lists-db/migrations
 
 # Copy pops-api source (needed only for AppRouter type resolution at compile time)
 COPY apps/pops-api/tsconfig.json ./apps/pops-api/
@@ -86,6 +90,8 @@ RUN pnpm build
 WORKDIR /app/packages/cerebrum-db
 RUN pnpm build
 WORKDIR /app/packages/food-db
+RUN pnpm build
+WORKDIR /app/packages/lists-db
 RUN pnpm build
 WORKDIR /app/packages/app-lists-db
 RUN pnpm build

--- a/apps/pops-shell/Dockerfile
+++ b/apps/pops-shell/Dockerfile
@@ -21,6 +21,7 @@ COPY packages/inventory-db/package.json ./packages/inventory-db/
 COPY packages/media-db/package.json ./packages/media-db/
 COPY packages/cerebrum-db/package.json ./packages/cerebrum-db/
 COPY packages/food-db/package.json ./packages/food-db/
+COPY packages/lists-db/package.json ./packages/lists-db/
 COPY packages/app-media/package.json ./packages/app-media/
 COPY packages/app-inventory/package.json ./packages/app-inventory/
 COPY packages/app-ai/package.json ./packages/app-ai/
@@ -51,6 +52,7 @@ COPY packages/inventory-db/ ./packages/inventory-db/
 COPY packages/media-db/ ./packages/media-db/
 COPY packages/cerebrum-db/ ./packages/cerebrum-db/
 COPY packages/food-db/ ./packages/food-db/
+COPY packages/lists-db/ ./packages/lists-db/
 COPY packages/food-contracts/ ./packages/food-contracts/
 WORKDIR /app/packages/db-types
 RUN pnpm build
@@ -71,6 +73,8 @@ RUN pnpm build
 WORKDIR /app/packages/cerebrum-db
 RUN pnpm build
 WORKDIR /app/packages/food-db
+RUN pnpm build
+WORKDIR /app/packages/lists-db
 RUN pnpm build
 WORKDIR /app/packages/app-lists-db
 RUN pnpm build

--- a/packages/lists-db/migrations/0062_chemical_donald_blake.sql
+++ b/packages/lists-db/migrations/0062_chemical_donald_blake.sql
@@ -1,0 +1,37 @@
+CREATE TABLE `list_items` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`list_id` integer NOT NULL,
+	`position` integer DEFAULT 0 NOT NULL,
+	`label` text NOT NULL,
+	`qty` real,
+	`unit` text,
+	`ref_kind` text DEFAULT 'free' NOT NULL,
+	`ref_id` integer,
+	`checked` integer DEFAULT 0 NOT NULL,
+	`checked_at` text,
+	`due_at` text,
+	`notes` text,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL,
+	FOREIGN KEY (`list_id`) REFERENCES `lists`(`id`) ON UPDATE no action ON DELETE no action,
+	CONSTRAINT "ck_list_items_ref_kind" CHECK("list_items"."ref_kind" IN ('free','ingredient','variant','recipe','custom')),
+	CONSTRAINT "ck_list_items_checked" CHECK("list_items"."checked" IN (0,1))
+);
+--> statement-breakpoint
+CREATE INDEX `idx_list_items_list` ON `list_items` (`list_id`);--> statement-breakpoint
+CREATE INDEX `idx_list_items_checked` ON `list_items` (`list_id`,`checked`);--> statement-breakpoint
+-- Partial index — only non-null ref_ids participate in the polymorphic lookup.
+-- Drizzle-kit's schema DSL can't express the WHERE clause; the hand-edit
+-- realises PRD-112's "WHERE ref_id IS NOT NULL" requirement verbatim.
+CREATE INDEX `idx_list_items_ref` ON `list_items` (`ref_kind`,`ref_id`) WHERE `ref_id` IS NOT NULL;--> statement-breakpoint
+CREATE TABLE `lists` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`name` text NOT NULL,
+	`kind` text NOT NULL,
+	`owner_app` text NOT NULL,
+	`archived_at` text,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL,
+	CONSTRAINT "ck_lists_kind" CHECK("lists"."kind" IN ('shopping','packing','todo','generic'))
+);
+--> statement-breakpoint
+CREATE INDEX `idx_lists_kind` ON `lists` (`kind`);--> statement-breakpoint
+CREATE INDEX `idx_lists_owner_app` ON `lists` (`owner_app`);

--- a/packages/lists-db/migrations/meta/_journal.json
+++ b/packages/lists-db/migrations/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "6",
+      "when": 1780990201767,
+      "tag": "0062_chemical_donald_blake",
+      "breakpoints": true
+    }
+  ]
+}

--- a/packages/lists-db/package.json
+++ b/packages/lists-db/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@pops/lists-db",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@pops/db-types": "workspace:*",
+    "better-sqlite3": "^12.10.0",
+    "drizzle-orm": "^0.45.2"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.12",
+    "@vitest/coverage-v8": "^4.1.8",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.8"
+  }
+}

--- a/packages/lists-db/src/__tests__/list-items.test.ts
+++ b/packages/lists-db/src/__tests__/list-items.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Lists-db Phase 1 PR 1 invariant tests — exercise the package-local
+ * migration journal + the list-items read / check slice against an in-memory
+ * SQLite. No Redis, no API process, no external services.
+ *
+ * The tests apply the package-local migration copy (not the shared journal)
+ * so the suite stays self-describing — if the drift-guard CI flags the two
+ * copies as divergent, this test pivots from "schema is canonical" to
+ * "schema matches what the package shipped".
+ */
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { ListItemNotFoundError } from '../errors.js';
+import { listItemsService, type ListsDb } from '../index.js';
+import { lists } from '../schema.js';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const MIGRATION_SQL = readFileSync(
+  join(HERE, '..', '..', 'migrations', '0062_chemical_donald_blake.sql'),
+  'utf8'
+);
+
+function freshDb(): { db: ListsDb; raw: Database.Database } {
+  const raw = new Database(':memory:');
+  raw.pragma('foreign_keys = ON');
+  const stmts = MIGRATION_SQL.split('--> statement-breakpoint');
+  for (const stmt of stmts) {
+    const trimmed = stmt.trim();
+    if (trimmed.length > 0) raw.exec(trimmed);
+  }
+  return { db: drizzle(raw), raw };
+}
+
+function seedList(db: ListsDb): number {
+  const rows = db
+    .insert(lists)
+    .values({ name: 'Test list', kind: 'shopping', ownerApp: 'tests' })
+    .returning()
+    .all();
+  const first = rows[0];
+  if (first === undefined) {
+    throw new Error('seedList: insert did not return a row');
+  }
+  return first.id;
+}
+
+describe('@pops/lists-db — package-local migration applies cleanly', () => {
+  it('creates the `lists` and `list_items` tables', () => {
+    const { raw } = freshDb();
+    const tables = raw
+      .prepare(`SELECT name FROM sqlite_master WHERE type='table' ORDER BY name`)
+      .all() as { name: string }[];
+    const names = tables.map((t) => t.name);
+    expect(names).toEqual(expect.arrayContaining(['lists', 'list_items']));
+  });
+
+  it('creates the partial index `idx_list_items_ref` with WHERE ref_id IS NOT NULL', () => {
+    const { raw } = freshDb();
+    const partial = raw
+      .prepare(`SELECT sql FROM sqlite_master WHERE name='idx_list_items_ref'`)
+      .get() as { sql: string } | undefined;
+    expect(partial?.sql).toMatch(/WHERE.*ref_id.*IS NOT NULL/i);
+  });
+});
+
+describe('@pops/lists-db — listItemsService surface', () => {
+  let db: ListsDb;
+  let raw: Database.Database;
+  let listId: number;
+
+  beforeEach(() => {
+    ({ db, raw } = freshDb());
+    listId = seedList(db);
+  });
+
+  function insertItem(label: string, position: number): number {
+    const info = raw
+      .prepare(
+        `INSERT INTO list_items (list_id, position, label, ref_kind, checked) VALUES (?, ?, ?, 'free', 0)`
+      )
+      .run(listId, position, label);
+    return Number(info.lastInsertRowid);
+  }
+
+  describe('listItemsForList', () => {
+    it('returns rows ordered by position then id', () => {
+      insertItem('second', 1);
+      insertItem('first', 0);
+      insertItem('third', 2);
+      const rows = listItemsService.listItemsForList(db, listId);
+      expect(rows.map((r) => r.label)).toEqual(['first', 'second', 'third']);
+    });
+
+    it('returns an empty array when the list has no items', () => {
+      const rows = listItemsService.listItemsForList(db, listId);
+      expect(rows).toEqual([]);
+    });
+
+    it('is scoped to the target list', () => {
+      const other = seedList(db);
+      insertItem('a', 0);
+      raw
+        .prepare(
+          `INSERT INTO list_items (list_id, position, label, ref_kind, checked) VALUES (?, 0, 'b', 'free', 0)`
+        )
+        .run(other);
+      const rows = listItemsService.listItemsForList(db, listId);
+      expect(rows.map((r) => r.label)).toEqual(['a']);
+    });
+
+    it('falls back to id ordering when two rows share a position', () => {
+      const firstId = insertItem('a', 0);
+      const secondId = insertItem('b', 0);
+      const rows = listItemsService.listItemsForList(db, listId);
+      expect(rows.map((r) => r.id)).toEqual([firstId, secondId]);
+    });
+  });
+
+  describe('getListItem', () => {
+    it('returns the matching row', () => {
+      const id = insertItem('milk', 0);
+      const row = listItemsService.getListItem(db, id);
+      expect(row.id).toBe(id);
+      expect(row.label).toBe('milk');
+      expect(row.checked).toBe(0);
+      expect(row.checkedAt).toBeNull();
+    });
+
+    it('throws ListItemNotFoundError on an unknown id', () => {
+      expect(() => listItemsService.getListItem(db, 9999)).toThrow(ListItemNotFoundError);
+      try {
+        listItemsService.getListItem(db, 9999);
+      } catch (err) {
+        if (err instanceof ListItemNotFoundError) {
+          expect(err.itemId).toBe(9999);
+          expect(err.name).toBe('ListItemNotFoundError');
+        } else {
+          throw err;
+        }
+      }
+    });
+  });
+
+  describe('checkListItem', () => {
+    it('flips checked to 1 and stamps checked_at', () => {
+      const id = insertItem('milk', 0);
+      const row = listItemsService.checkListItem(db, id);
+      expect(row.checked).toBe(1);
+      expect(row.checkedAt).not.toBeNull();
+      expect(Date.parse(row.checkedAt ?? '')).not.toBeNaN();
+    });
+
+    it('refreshes checked_at when re-checking an already-checked row', async () => {
+      const id = insertItem('milk', 0);
+      const first = listItemsService.checkListItem(db, id);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      const second = listItemsService.checkListItem(db, id);
+      expect(second.checked).toBe(1);
+      expect(second.checkedAt).not.toBe(first.checkedAt);
+    });
+
+    it('throws ListItemNotFoundError on an unknown id', () => {
+      expect(() => listItemsService.checkListItem(db, 9999)).toThrow(ListItemNotFoundError);
+    });
+  });
+
+  describe('uncheckListItem', () => {
+    it('clears checked + checked_at on a previously-checked row', () => {
+      const id = insertItem('milk', 0);
+      listItemsService.checkListItem(db, id);
+      const row = listItemsService.uncheckListItem(db, id);
+      expect(row.checked).toBe(0);
+      expect(row.checkedAt).toBeNull();
+    });
+
+    it('is idempotent on an already-unchecked row', () => {
+      const id = insertItem('milk', 0);
+      const row = listItemsService.uncheckListItem(db, id);
+      expect(row.checked).toBe(0);
+      expect(row.checkedAt).toBeNull();
+    });
+
+    it('throws ListItemNotFoundError on an unknown id', () => {
+      expect(() => listItemsService.uncheckListItem(db, 9999)).toThrow(ListItemNotFoundError);
+    });
+  });
+
+  describe('uncheckAllListItems', () => {
+    it('flips every checked row in the target list + returns the count', () => {
+      const a = insertItem('a', 0);
+      const b = insertItem('b', 1);
+      const c = insertItem('c', 2);
+      listItemsService.checkListItem(db, a);
+      listItemsService.checkListItem(db, b);
+      const count = listItemsService.uncheckAllListItems(db, listId);
+      expect(count).toBe(2);
+      const rows = listItemsService.listItemsForList(db, listId);
+      expect(rows.every((r) => r.checked === 0)).toBe(true);
+      expect(rows.every((r) => r.checkedAt === null)).toBe(true);
+      const cRow = rows.find((r) => r.id === c);
+      expect(cRow?.checked).toBe(0);
+    });
+
+    it('returns 0 when nothing is checked', () => {
+      insertItem('a', 0);
+      insertItem('b', 1);
+      expect(listItemsService.uncheckAllListItems(db, listId)).toBe(0);
+    });
+
+    it('is scoped to the target list', () => {
+      const other = seedList(db);
+      const aId = insertItem('a', 0);
+      const otherInsert = raw
+        .prepare(
+          `INSERT INTO list_items (list_id, position, label, ref_kind, checked) VALUES (?, 0, 'b', 'free', 0)`
+        )
+        .run(other);
+      const otherItemId = Number(otherInsert.lastInsertRowid);
+      listItemsService.checkListItem(db, aId);
+      listItemsService.checkListItem(db, otherItemId);
+      expect(listItemsService.uncheckAllListItems(db, listId)).toBe(1);
+      const refreshed = listItemsService.getListItem(db, otherItemId);
+      expect(refreshed.checked).toBe(1);
+    });
+  });
+});

--- a/packages/lists-db/src/errors.ts
+++ b/packages/lists-db/src/errors.ts
@@ -1,0 +1,22 @@
+/**
+ * Typed errors raised by the lists domain service layer.
+ *
+ * Plain Error subclasses — the service layer doesn't know about HTTP.
+ * Pops-api routers map them to the appropriate tRPC codes when surfacing
+ * to clients. Mirrors `@pops/inventory-db` / `@pops/finance-db` /
+ * `@pops/media-db` / `@pops/cerebrum-db` / `@pops/food-db` error patterns.
+ *
+ * Phase 1 PR 1 ships only the list-items errors. The `ListNotFoundError`
+ * surfaced by the broader `lists` slice stays in `@pops/app-lists-db`
+ * until the next slice migrates.
+ */
+
+export class ListItemNotFoundError extends Error {
+  override readonly name = 'ListItemNotFoundError' as const;
+  readonly itemId: number;
+
+  constructor(itemId: number) {
+    super(`List item #${itemId} not found`);
+    this.itemId = itemId;
+  }
+}

--- a/packages/lists-db/src/index.ts
+++ b/packages/lists-db/src/index.ts
@@ -1,0 +1,29 @@
+/**
+ * Backend-safe barrel for the lists domain's persistence layer.
+ *
+ * Hosts lists pillar tables (Phase 1 PR 1 surfaces the `list_items` read /
+ * check slice; the remaining slices — full `lists` CRUD, item create /
+ * update / bulk-add / reorder / remove, the PRD-141 shopping specialisation
+ * — follow in subsequent slice PRs). The package is the canonical
+ * `@pops/lists-db` and mirrors the per-pillar shape adopted across
+ * `@pops/core-db`, `@pops/finance-db`, `@pops/inventory-db`,
+ * `@pops/media-db`, `@pops/cerebrum-db`, and `@pops/food-db`.
+ *
+ * Per ADR-026 and `.claude/pillar-migration-roadmap.md`, the lists pillar
+ * pre-existed as `@pops/app-lists-db` (extracted in PRD-140 part API
+ * #2725). This new package is the canonical name going forward; the older
+ * `@pops/app-lists-db` is left in place during the Phase 1 transition
+ * and gets converted to a re-export shim in PR 4 once every consumer has
+ * been flipped.
+ *
+ * Per the CI-never-breaks pattern the migration is incremental — this PR
+ * scaffolds the package and surfaces only the `list_items` read / check
+ * slice. `@pops/app-lists-db` continues to expose every list + list-item
+ * service unchanged; this barrel is purely additive.
+ */
+export * from './errors.js';
+export * from './schema.js';
+
+export type { ListsDb } from './services/internal.js';
+
+export * as listItemsService from './services/list-items.js';

--- a/packages/lists-db/src/schema.ts
+++ b/packages/lists-db/src/schema.ts
@@ -11,9 +11,12 @@
  * / `@pops/food-db` schema re-export pattern.
  *
  * Phase 1 PR 1 ships only the `listItems` slice — the `lists` table itself
- * is referenced for the FK + cascading delete tests, but the public list
- * surface (createList / listLists / archiveList / etc.) stays in
- * `@pops/app-lists-db` until the next slice PR moves it across.
+ * is referenced because the in-memory test suite needs to seed parent rows
+ * before inserting children (the `list_items.list_id` FK is plain ON DELETE
+ * NO ACTION, so there is no cascade — `deleteList` walks the children
+ * explicitly in `@pops/app-lists-db`). The public list surface
+ * (createList / listLists / archiveList / etc.) stays in `@pops/app-lists-db`
+ * until the next slice PR moves it across.
  */
 export { listItems, lists } from '@pops/db-types';
 export type {

--- a/packages/lists-db/src/schema.ts
+++ b/packages/lists-db/src/schema.ts
@@ -1,0 +1,26 @@
+/**
+ * Local re-export of lists-domain tables surfaced by `@pops/lists-db`.
+ *
+ * Canonical definitions live in `@pops/db-types/src/schema/lists.ts` so the
+ * drizzle-kit config (which globs `packages/db-types/src/schema/*`) picks
+ * them up and the rest of the platform sees a single schema barrel.
+ *
+ * Services in this package import from here for ergonomics and so the
+ * lists pillar's read surface stays self-describing. Mirrors the
+ * `@pops/core-db` / `@pops/inventory-db` / `@pops/media-db` / `@pops/finance-db`
+ * / `@pops/food-db` schema re-export pattern.
+ *
+ * Phase 1 PR 1 ships only the `listItems` slice — the `lists` table itself
+ * is referenced for the FK + cascading delete tests, but the public list
+ * surface (createList / listLists / archiveList / etc.) stays in
+ * `@pops/app-lists-db` until the next slice PR moves it across.
+ */
+export { listItems, lists } from '@pops/db-types';
+export type {
+  ListInsert,
+  ListItemInsert,
+  ListItemRefKind,
+  ListItemRow,
+  ListKind,
+  ListRow,
+} from '@pops/db-types';

--- a/packages/lists-db/src/services/internal.ts
+++ b/packages/lists-db/src/services/internal.ts
@@ -1,0 +1,35 @@
+/**
+ * Shared helpers for the lists schema service layer.
+ *
+ * `ListsDb` is re-exported from the package barrel so callers can type
+ * the handle they pass in. Any additional helpers added here stay internal
+ * to `src/services/*.ts`.
+ *
+ * The type uses `Record<string, unknown>` (not `Record<string, never>`) so
+ * the same alias matches both the package's narrow handle and the pops-api
+ * default `getDrizzle()` return shape — see the cerebrum-db lesson in the
+ * pillar-migration roadmap.
+ */
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+
+/** A drizzle handle — either the top-level db or a transaction. */
+export type ListsDb = BetterSQLite3Database<Record<string, unknown>>;
+
+/**
+ * Extract the row from an `.insert(...).returning().all()` or equivalent
+ * mutation that's guaranteed to produce at least one result. Throws with a
+ * pointed message if it didn't — that indicates a logic error in the caller
+ * (e.g. updating a row id that doesn't exist) rather than a normal flow.
+ */
+export function expectRow<T>(rows: readonly T[], label: string): T {
+  const row = rows[0];
+  if (row === undefined) {
+    throw new Error(`${label}: expected a row but got none`);
+  }
+  return row;
+}
+
+/** Current ISO timestamp (UTC) — service-layer wall-clock. */
+export function nowIso(): string {
+  return new Date().toISOString();
+}

--- a/packages/lists-db/src/services/list-items.ts
+++ b/packages/lists-db/src/services/list-items.ts
@@ -1,0 +1,105 @@
+/**
+ * Read services for the `list_items` table.
+ *
+ * Phase 1 PR 1 ships only the list + get + check trio — the create / update /
+ * remove / bulk-add / reorder surface stays in `@pops/app-lists-db` for now
+ * because it pulls in the position-allocation transaction helpers and the
+ * ref-kind normalisation logic that haven't been audited for the new
+ * package boundary yet. The next slice PR widens this surface once the
+ * helpers move across.
+ *
+ * `ref_id` is polymorphic — no FK enforcement at the schema level. Callers
+ * that need cross-table validation do it in the router (mirrors how the
+ * existing `@pops/app-lists-db` callers work).
+ */
+import { and, asc, eq } from 'drizzle-orm';
+
+import { ListItemNotFoundError } from '../errors.js';
+import { listItems, type ListItemRow } from '../schema.js';
+import { expectRow, type ListsDb, nowIso } from './internal.js';
+
+/**
+ * Return every list-item row for a given list, ordered by `position` then
+ * `id` so display is stable across reorder edge cases (two rows sharing a
+ * position fall back to insertion order).
+ */
+export function listItemsForList(db: ListsDb, listId: number): readonly ListItemRow[] {
+  return db
+    .select()
+    .from(listItems)
+    .where(eq(listItems.listId, listId))
+    .orderBy(asc(listItems.position), asc(listItems.id))
+    .all();
+}
+
+/**
+ * Return a single list-item row by primary key. Throws
+ * `ListItemNotFoundError` when no row matches — callers in the router layer
+ * map the typed error onto the appropriate tRPC code.
+ */
+export function getListItem(db: ListsDb, itemId: number): ListItemRow {
+  const row = db.select().from(listItems).where(eq(listItems.id, itemId)).get();
+  if (row === undefined) {
+    throw new ListItemNotFoundError(itemId);
+  }
+  return row;
+}
+
+/**
+ * Flip a single list-item to `checked=1` and stamp `checked_at`. Re-checking
+ * an already-checked row refreshes the timestamp (idempotent at the row
+ * level, not at the timestamp level — matches PRD-141 semantics).
+ *
+ * Throws `ListItemNotFoundError` when the id is unknown.
+ */
+export function checkListItem(db: ListsDb, itemId: number): ListItemRow {
+  const rows = db
+    .update(listItems)
+    .set({ checked: 1, checkedAt: nowIso() })
+    .where(eq(listItems.id, itemId))
+    .returning()
+    .all();
+  if (rows.length === 0) {
+    throw new ListItemNotFoundError(itemId);
+  }
+  return expectRow(rows, `checkListItem(${itemId})`);
+}
+
+/**
+ * Clear `checked` + `checked_at` on a single list-item. Idempotent — un-
+ * checking an already-unchecked row is a no-op write (drizzle still emits
+ * the UPDATE but the resulting row is identical).
+ *
+ * Throws `ListItemNotFoundError` when the id is unknown.
+ */
+export function uncheckListItem(db: ListsDb, itemId: number): ListItemRow {
+  const rows = db
+    .update(listItems)
+    .set({ checked: 0, checkedAt: null })
+    .where(eq(listItems.id, itemId))
+    .returning()
+    .all();
+  if (rows.length === 0) {
+    throw new ListItemNotFoundError(itemId);
+  }
+  return expectRow(rows, `uncheckListItem(${itemId})`);
+}
+
+/**
+ * Bulk-uncheck every currently-checked item in a list (PRD-141 amendment).
+ *
+ * Single UPDATE inside a transaction. Returns the row count affected so the
+ * UI can show "Unchecked N items" without a follow-up read. No-op (returns
+ * 0) when nothing was checked.
+ */
+export function uncheckAllListItems(db: ListsDb, listId: number): number {
+  return db.transaction((tx) => {
+    const rows = tx
+      .update(listItems)
+      .set({ checked: 0, checkedAt: null })
+      .where(and(eq(listItems.listId, listId), eq(listItems.checked, 1)))
+      .returning({ id: listItems.id })
+      .all();
+    return rows.length;
+  });
+}

--- a/packages/lists-db/src/services/list-items.ts
+++ b/packages/lists-db/src/services/list-items.ts
@@ -1,12 +1,13 @@
 /**
- * Read services for the `list_items` table.
+ * Read + check-state services for the `list_items` table.
  *
- * Phase 1 PR 1 ships only the list + get + check trio — the create / update /
- * remove / bulk-add / reorder surface stays in `@pops/app-lists-db` for now
- * because it pulls in the position-allocation transaction helpers and the
- * ref-kind normalisation logic that haven't been audited for the new
- * package boundary yet. The next slice PR widens this surface once the
- * helpers move across.
+ * Phase 1 PR 1 ships two reads (list / get) and three check-state mutations
+ * (check / uncheck / bulk-uncheck). The create / update / remove / bulk-add
+ * / reorder surface stays in `@pops/app-lists-db` for now because it pulls
+ * in the position-allocation transaction helpers and the ref-kind
+ * normalisation logic that haven't been audited for the new package
+ * boundary yet. The next slice PR widens this surface once the helpers
+ * move across.
  *
  * `ref_id` is polymorphic — no FK enforcement at the schema level. Callers
  * that need cross-table validation do it in the router (mirrors how the

--- a/packages/lists-db/tsconfig.json
+++ b/packages/lists-db/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "lib": ["ES2023"],
+    "types": [],
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/__tests__/**", "**/*.test.ts"]
+}

--- a/packages/lists-db/vitest.config.ts
+++ b/packages/lists-db/vitest.config.ts
@@ -1,0 +1,15 @@
+/// <reference types="vitest/config" />
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json-summary', 'html'],
+      reportsDirectory: 'coverage',
+      include: ['src/**/*.ts'],
+      exclude: ['**/node_modules/**', '**/dist/**', '**/*.test.ts'],
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1664,6 +1664,31 @@ importers:
         specifier: ^4.1.8
         version: 4.1.8(@types/node@25.9.1)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
 
+  packages/lists-db:
+    dependencies:
+      '@pops/db-types':
+        specifier: workspace:*
+        version: link:../db-types
+      better-sqlite3:
+        specifier: ^12.10.0
+        version: 12.10.0
+      drizzle-orm:
+        specifier: ^0.45.2
+        version: 0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.10.0)
+    devDependencies:
+      '@types/better-sqlite3':
+        specifier: ^7.6.12
+        version: 7.6.13
+      '@vitest/coverage-v8':
+        specifier: ^4.1.8
+        version: 4.1.8(vitest@4.1.8)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@25.9.1)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
+
   packages/media-db:
     dependencies:
       '@pops/db-types':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,6 +19,7 @@ packages:
   - 'packages/cerebrum-db'
   - 'packages/food-db'
   - 'packages/food-contracts'
+  - 'packages/lists-db'
   - 'packages/types'
   - 'packages/module-registry'
   - 'packages/navigation'


### PR DESCRIPTION
## Summary

Track K phase 1 PR 1 — kick off the lists pillar migration per ADR-026 and the CI-never-breaks pattern in `.claude/pillar-migration-roadmap.md`. Mirrors the food (#2866), inventory (#2768), and finance (#2766) canonical 4-package per-pillar pattern. The `-db` package ships first; `-contract` / `-api` / `-ui` follow in subsequent Phase 1 sub-PRs as their slices migrate.

### Gate-opener

Track J (food) ✅ Done at #2876. Track K's `food (Track J) ✅` gate is satisfied; PRD-139 already on `main` (squashed as `3999d519`).

### Scoping decision — Option A (canonical rename)

Unlike every other pillar, lists already had a `-db` package: `@pops/app-lists-db` was extracted in PRD-140 part API (#2725). Two valid Phase 1 PR 1 shapes:

- **Option A (picked)** — scaffold a NEW canonical `@pops/lists-db` package mirroring the food / inventory / finance / media / cerebrum / core naming convention. Existing `@pops/app-lists-db` stays in place during the transition; PR 3 cuts pops-api consumers over (24 import sites) and PR 4 converts `app-lists-db` into a re-export shim (or deletes it once every consumer is on the new package). This is the additive scaffold pattern every other pillar followed; the renaming work lives in the cutover / deletion PRs where the larger blast radius belongs.
- **Option B (rejected)** — accept `@pops/app-lists-db` as the canonical package, skip the rename. Pragmatic but breaks the per-pillar naming convention every other pillar uses (`@pops/<pillar>-db`, no `app-` prefix). The `app-` prefix in the existing name reflects the PRD-140 extraction context, not the per-pillar pattern; keeping it would be a permanent compatibility scar across the rest of the roadmap.

The Option A risk weigh — 24 consumer imports of `@pops/app-lists-db` — does not land in this PR. Phase 1 PR 1 stays a purely additive scaffold; the cutover sits in PR 3 where the blast radius is intentional. Picking Option A in PR 1 makes the rename incremental and reviewable instead of trying to slip a 24-file rename into the scaffold PR.

### What landed

- `@pops/lists-db` package — backend-safe barrel for the lists pillar's persistence layer.
- **Slice:** `list_items` read + check surface (PRD-112 + PRD-141 — smallest viable canary that exercises both reads and the shopping-specialisation mutations).
  - Schema re-export from `@pops/db-types` (`lists`, `listItems` + `ListRow` / `ListInsert` / `ListItemRow` / `ListItemInsert` / `ListKind` / `ListItemRefKind`).
  - `ListItemNotFoundError` typed error.
  - `listItemsForList(db, listId)` + `getListItem(db, itemId)` reads.
  - `checkListItem(db, itemId)` + `uncheckListItem(db, itemId)` + `uncheckAllListItems(db, listId)` mutations.
  - 17 in-memory unit tests against the package-local migration copy.
- **Package-local migration journal** at `packages/lists-db/migrations/` with `0062_chemical_donald_blake.sql` byte-identical to the shared journal copy. Mirrors the cerebrum-db / food-db PR 1 pre-copy lesson — the package is self-describing from day 1 and the drift-guard CI enforces lockstep across the transitional release cycle.
- **Drift-guard CI workflow** at `.github/workflows/lists-db-quality.yml` enforcing byte-identity between the shared journal copy and the pillar copy. Matches the food / inventory / media / finance / cerebrum drift-guard shape verbatim.
- **CI parity:**
  - `_pkg-check.yml`: added `pnpm --filter @pops/lists-db build` to the shared build step.
  - `api-quality.yml`, `api-test.yml`: added `packages/lists-db/**` to both `push.paths` and the `paths-filter` filter + `cd ../lists-db && pnpm build` to the shared build step.
  - `fe-quality.yml`: same paths/filter/build additions.
  - `fe-test-e2e.yml`: build-step addition (its filter already covers `packages/**`).
- **Dockerfile parity:** `apps/pops-api/Dockerfile`, `apps/pops-shell/Dockerfile`, `apps/pops-mcp/Dockerfile` all copy `lists-db` package.json + src + tsconfig + migrations, build the package after `food-db`, and (pops-api runtime) install the built `dist/` + `package.json` + `migrations/` into `node_modules/@pops/lists-db/` so `require.resolve('@pops/lists-db/package.json')` works for the per-pillar migration runner under pnpm's hoisted layout.

### Reference patterns

- Food PR 1: [#2866](https://github.com/knoxio/pops/pull/2866) (most recent canonical Phase 1 PR 1).
- Inventory PR 1: [#2768](https://github.com/knoxio/pops/pull/2768) (canonical pattern).
- Finance PR 1: [#2766](https://github.com/knoxio/pops/pull/2766).

### Scope discipline

- `@pops/app-lists-db` is **unchanged** in this PR — every existing consumer keeps resolving through the old package. PR 3 cuts over; PR 4 converts to a re-export shim (or deletes).
- `apps/pops-api/src/modules/lists/` is **not** cut over — that's PR 3.
- The other 3 pillar packages (`@pops/lists-contract`, `@pops/lists-api`, `@pops/lists-ui`) are **deferred** to subsequent Phase 1 sub-PRs.
- Public zod schemas are **deferred** — they belong in `@pops/lists-contract`, which doesn't exist yet (Phase 5 work).

### Deferred follow-ups

- **PR 2** — migration journal split + drift-guard polish.
- **PR 3** — pops-api `lists/routers/*.ts` cutover to `import { listItemsService } from '@pops/lists-db'`. 24 consumer files identified across `apps/pops-api/`, `packages/app-food-db/seed/`, and `packages/app-lists/`.
- **PR 4** — convert `@pops/app-lists-db` to a re-export shim (or delete) once every consumer is on `@pops/lists-db`.
- **Phase 1 sub-PRs** — scaffold `@pops/lists-contract`, `@pops/lists-api`, `@pops/lists-ui`. Each on its own slim slice.
- **Future slices** for `@pops/lists-db`: full `lists` CRUD, item create / update / bulk-add / reorder / remove.
- **Phase 2 / 3 / 4** — `openListsDb()` helper, boot-time open + `LISTS_SQLITE_PATH` env + ATTACH backfill, `apps/pops-lists-api` container, Litestream config, verification runbook.

### Local CI gauntlet (all green before push)

- `pnpm install` — 35 workspace projects.
- `pnpm --filter @pops/lists-db test` — 17/17 passed.
- `pnpm typecheck` — 49 tasks, all green.
- `pnpm --filter @pops/api test` — 4866/4866 passed.
- `pnpm --filter @pops/shell test` — 342/342 passed.
- `pnpm lint` — exit 0 (pre-existing warnings only).
- `pnpm build` — 24 tasks, all green.
- `pnpm format` — clean.

## Test plan

- [ ] Drift-guard job passes (shared 0062 vs pillar 0062 byte-identical).
- [ ] `_pkg-check.yml` runs the new package's typecheck + test.
- [ ] api-quality, api-test, fe-quality, fe-test-e2e all green.
- [ ] Validate Docker builds green for pops-api + pops-shell + pops-mcp images.
- [ ] No regression in existing lists pops-api routers — `app-lists-db`'s surface is unchanged.
