### PR TITLE
feat(lists-db): add openListsDb helper (Track K phase 2 PR 1)

### DIFF
--- a/packages/lists-db/src/__tests__/open-lists-db.test.ts
+++ b/packages/lists-db/src/__tests__/open-lists-db.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Smoke tests for the standalone `openListsDb` helper.
+ *
+ * Exercises the migration apply path against a fresh tmp file, verifies
+ * the resulting schema, and confirms the helper is idempotent when
+ * re-run against the same DB.
+ *
+ * Uses real tmpdir-backed files (not `:memory:`) because the Phase 2
+ * follow-ups (PR 2's pops-api boot wire-up, PR 3's consumer cutover,
+ * and the eventual ATTACH-based backfill window) will exercise this
+ * helper against on-disk DBs and shared paths. Keep parity here so
+ * surprises surface in tests, not in production.
+ */
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { openListsDb } from '../open-lists-db.js';
+import { listItems, lists } from '../schema.js';
+import { listItemsForList } from '../services/list-items.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'lists-db-test-'));
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('openListsDb', () => {
+  it('creates the parent directory and opens a fresh DB with the expected pragmas', () => {
+    const path = join(tmpDir, 'nested', 'sub', 'lists.db');
+    expect(existsSync(path)).toBe(false);
+
+    const { raw } = openListsDb(path);
+    try {
+      expect(existsSync(path)).toBe(true);
+      expect(raw.pragma('journal_mode', { simple: true })).toBe('wal');
+      expect(raw.pragma('foreign_keys', { simple: true })).toBe(1);
+      expect(raw.pragma('busy_timeout', { simple: true })).toBe(5000);
+    } finally {
+      raw.close();
+    }
+  });
+
+  it('applies the lists slice migration — `lists` + `list_items` tables exist and accept writes', () => {
+    const path = join(tmpDir, 'lists.db');
+    const { db, raw } = openListsDb(path);
+    try {
+      const tables = raw
+        .prepare(`SELECT name FROM sqlite_master WHERE type='table' ORDER BY name`)
+        .all() as { name: string }[];
+      const names = tables.map((t) => t.name);
+      expect(names).toEqual(expect.arrayContaining(['lists', 'list_items']));
+
+      const list = db
+        .insert(lists)
+        .values({ name: 'Test list', kind: 'shopping', ownerApp: 'tests' })
+        .returning()
+        .get();
+      expect(list?.id).toBeTypeOf('number');
+      const listId = list?.id;
+      if (listId === undefined) throw new Error('insert into lists did not return a row');
+
+      const inserted = db
+        .insert(listItems)
+        .values({ listId, label: 'Milk', refKind: 'free' })
+        .returning()
+        .get();
+      expect(inserted?.label).toBe('Milk');
+      expect(listItemsForList(db, listId)).toHaveLength(1);
+    } finally {
+      raw.close();
+    }
+  });
+
+  it('is idempotent — re-opening the same DB does not re-apply migrations and rows persist', () => {
+    const path = join(tmpDir, 'lists.db');
+    const first = openListsDb(path);
+    let listId: number;
+    try {
+      const row = first.db
+        .insert(lists)
+        .values({ name: 'Persisted', kind: 'todo', ownerApp: 'tests' })
+        .returning()
+        .get();
+      if (row === undefined) throw new Error('seed insert returned no row');
+      listId = row.id;
+      first.db.insert(listItems).values({ listId, label: 'Eggs', refKind: 'free' }).run();
+      expect(listItemsForList(first.db, listId)).toHaveLength(1);
+    } finally {
+      first.raw.close();
+    }
+
+    const second = openListsDb(path);
+    try {
+      const rows = listItemsForList(second.db, listId);
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.label).toBe('Eggs');
+    } finally {
+      second.raw.close();
+    }
+  });
+
+  it('throws when the path points at a directory that cannot be opened as a DB file', () => {
+    expect(() => openListsDb(tmpDir)).toThrow();
+  });
+});

--- a/packages/lists-db/src/index.ts
+++ b/packages/lists-db/src/index.ts
@@ -27,3 +27,5 @@ export * from './schema.js';
 export type { ListsDb } from './services/internal.js';
 
 export * as listItemsService from './services/list-items.js';
+
+export { openListsDb, type OpenedListsDb } from './open-lists-db.js';

--- a/packages/lists-db/src/open-lists-db.ts
+++ b/packages/lists-db/src/open-lists-db.ts
@@ -1,0 +1,85 @@
+/**
+ * Standalone opener for the lists pillar's SQLite database.
+ *
+ * Phase 2 PR 1 of the lists pillar migration scaffolds the per-pillar
+ * connection so subsequent PRs can flip readers/writers over without
+ * touching pops-api's existing singleton. The opener is intentionally
+ * minimal — it relies on drizzle-orm's built-in `migrate` helper to
+ * apply the in-package migrations journal at
+ * `packages/lists-db/migrations/meta/_journal.json`.
+ *
+ * No production consumer wires this up yet. Subsequent PRs add the
+ * `LISTS_SQLITE_PATH` env-var read in pops-api (PR 2), the boot-time
+ * call + consumer cutover (PR 3), and the Litestream replication config
+ * (PR 4).
+ */
+import { mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+
+import type { ListsDb } from './services/internal.js';
+
+/**
+ * Path to the migrations folder inside this package. Resolved relative
+ * to this module's location (`src/open-lists-db.ts` in dev,
+ * `dist/open-lists-db.js` after build) so it works both when consumed
+ * via the workspace symlink and when bundled into a Docker image's
+ * `node_modules/@pops/lists-db/`.
+ */
+function migrationsDir(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  return join(here, '..', 'migrations');
+}
+
+/**
+ * Result of {@link openListsDb}. The raw handle is exposed for callers
+ * that need lifecycle control (close on shutdown, prepared statements,
+ * pragmas the drizzle wrapper hides).
+ */
+export interface OpenedListsDb {
+  /** Drizzle handle — pass into any `listItemsService.*` call. */
+  db: ListsDb;
+  /** Raw better-sqlite3 handle. Call `.close()` on shutdown. */
+  raw: Database.Database;
+}
+
+/**
+ * Open the lists pillar's SQLite database at `path`, configure it,
+ * apply the in-package migrations journal, and return both the
+ * drizzle wrapper and the raw handle.
+ *
+ * Side effects:
+ *   - The parent directory of `path` is created if missing (recursive).
+ *   - `journal_mode=WAL`, `foreign_keys=ON`, and `busy_timeout=5000`
+ *     are enabled to match the shared singleton in
+ *     `apps/pops-api/src/db.ts`.
+ *   - Every migration in
+ *     `packages/lists-db/migrations/meta/_journal.json` is applied via
+ *     drizzle's built-in migrator (idempotent — re-running against the
+ *     same DB short-circuits on the `__drizzle_migrations` hash check).
+ *     Today that's `0062_chemical_donald_blake` (creates `lists` and
+ *     `list_items`).
+ *
+ * If the migration apply throws (corrupt DB, malformed migration,
+ * missing folder), the raw handle is closed before the error is
+ * re-thrown so the caller can't leak a locked file descriptor.
+ */
+export function openListsDb(path: string): OpenedListsDb {
+  mkdirSync(dirname(path), { recursive: true });
+  const raw = new Database(path);
+  raw.pragma('journal_mode = WAL');
+  raw.pragma('foreign_keys = ON');
+  raw.pragma('busy_timeout = 5000');
+  const db = drizzle(raw) as ListsDb;
+  try {
+    migrate(db, { migrationsFolder: migrationsDir() });
+  } catch (err) {
+    raw.close();
+    throw err;
+  }
+  return { db, raw };
+}

--- a/packages/lists-db/src/open-lists-db.ts
+++ b/packages/lists-db/src/open-lists-db.ts
@@ -61,8 +61,6 @@ export interface OpenedListsDb {
  *     `packages/lists-db/migrations/meta/_journal.json` is applied via
  *     drizzle's built-in migrator (idempotent — re-running against the
  *     same DB short-circuits on the `__drizzle_migrations` hash check).
- *     Today that's `0062_chemical_donald_blake` (creates `lists` and
- *     `list_items`).
  *
  * If the migration apply throws (corrupt DB, malformed migration,
  * missing folder), the raw handle is closed before the error is


### PR DESCRIPTION
## Summary

Track K Phase 2 PR 1: scaffolds the standalone `openListsDb()` helper in `@pops/lists-db`, mirroring the five sibling helpers that landed for the other migrated pillars.

- `openListsDb(path)` opens a `better-sqlite3` connection, applies the same `journal_mode=WAL` / `foreign_keys=ON` / `busy_timeout=5000` pragmas as `apps/pops-api/src/db.ts`, and runs the in-package drizzle migration journal at `packages/lists-db/migrations/meta/_journal.json` via `migrate()`.
- `OpenedListsDb` exposes both the drizzle handle (`db: ListsDb`) and the raw `better-sqlite3` handle for lifecycle control.
- Migration apply errors close the raw handle before re-throwing so callers can't leak a locked fd.
- Migrations folder path resolved via `fileURLToPath(import.meta.url)` so the helper works under `src/` in dev and `dist/` after build.
- New tmpdir-backed vitest suite at `packages/lists-db/src/__tests__/open-lists-db.test.ts` covers fresh-open + pragma assertions, schema (`lists` + `list_items`) + insert/read round-trip via `listItemsService.listItemsForList`, idempotent re-open against the same on-disk DB, and invalid-path failure. Real files (not `:memory:`) because the Phase 2 follow-ups exercise cross-DB ATTACH backfill that needs real paths.
- Helper + type added to the package barrel at `packages/lists-db/src/index.ts`.

## Sibling helpers

Same shape as:

- food Phase 2 PR 1 → #2867 (`openFoodDb`) — most recent canonical
- inventory Phase 2 PR 1 → #2788 (`openInventoryDb`)
- finance Phase 2 PR 1 → #2793 (`openFinanceDb`)
- media Phase 2 PR 1 → #2785 (`openMediaDb`)
- cerebrum Phase 2 PR 1 → #2815 (`openCerebrumDb`)

## Deferred

- **Phase 2 PR 2** — pops-api boot-time open + `LISTS_SQLITE_PATH` env-var read + `closeListsDb()` shutdown wiring.
- **Phase 2 PR 3** — consumer cutover: lists module reads/writes routed through the `lists.db` handle; ATTACH-based backfill of `lists` / `list_items` rows from the shared `pops.db`.
- **Phase 2 PR 4** — Litestream replication config for `lists.db` + AGENTS.md update.

No production consumer is wired up by this PR.

## Test plan

- [x] `pnpm --filter @pops/lists-db test` (4 new `openListsDb` cases + the existing 17 list-items cases, 21 total green)
- [x] `pnpm typecheck` (49 tasks green)
- [x] `pnpm lint` (exit 0, no new warnings in changed files)
- [x] `pnpm build` (24 tasks green)
- [ ] Copilot R1 review pass
