### PR TITLE
feat(lists-db): flip list_items consumer to @pops/lists-db (Track K phase 1 PR 3)

### DIFF
--- a/apps/pops-api/package.json
+++ b/apps/pops-api/package.json
@@ -85,6 +85,7 @@
     "@pops/food-contracts": "workspace:*",
     "@pops/food-db": "workspace:*",
     "@pops/inventory-db": "workspace:*",
+    "@pops/lists-db": "workspace:*",
     "@pops/media-db": "workspace:*",
     "@pops/module-registry": "workspace:*",
     "@pops/types": "workspace:*",

--- a/apps/pops-api/src/modules/lists/routers/error-mapping.ts
+++ b/apps/pops-api/src/modules/lists/routers/error-mapping.ts
@@ -6,18 +6,36 @@
  *   - SQLite `UNIQUE` constraint → tRPC `CONFLICT`
  *   - SQLite `FOREIGN KEY` constraint → tRPC `CONFLICT`
  *   - anything else propagates as-is
+ *
+ * Track K phase 1 PR 3 cutover: `ListItemNotFoundError` is now imported
+ * from the canonical `@pops/lists-db`. Until PR 4 retires the legacy
+ * `@pops/app-lists-db` list-items services, the older package still throws
+ * its own (separate-identity) `ListItemNotFoundError` from `updateItem` —
+ * we alias it as `LegacyListItemNotFoundError` and include both classes in
+ * the `instanceof` guard so the mapping keeps working across the
+ * transition.
  */
 import { TRPCError } from '@trpc/server';
 
-import { ListItemNotFoundError, ListNotFoundError } from '@pops/app-lists-db';
+import {
+  ListItemNotFoundError as LegacyListItemNotFoundError,
+  ListNotFoundError,
+} from '@pops/app-lists-db';
+import { ListItemNotFoundError } from '@pops/lists-db';
 
 import {
   isForeignKeyConstraintError,
   isUniqueConstraintError,
 } from '../../../shared/sqlite-errors.js';
 
-function isTypedNotFound(err: unknown): err is ListNotFoundError | ListItemNotFoundError {
-  return err instanceof ListNotFoundError || err instanceof ListItemNotFoundError;
+function isTypedNotFound(
+  err: unknown
+): err is ListNotFoundError | ListItemNotFoundError | LegacyListItemNotFoundError {
+  return (
+    err instanceof ListNotFoundError ||
+    err instanceof ListItemNotFoundError ||
+    err instanceof LegacyListItemNotFoundError
+  );
 }
 
 export function mapServiceError(err: unknown): never {

--- a/apps/pops-api/src/modules/lists/routers/items.ts
+++ b/apps/pops-api/src/modules/lists/routers/items.ts
@@ -1,11 +1,19 @@
 /**
  * `lists.items.*` — item-level CRUD procedures (PRD-140).
  *
- * Thin transactional wrappers around the PRD-112 service layer in
- * `@pops/app-lists-db`. The router contributes:
+ * Thin transactional wrappers around the PRD-112 service layer. The router
+ * contributes:
  *   - `reorder` count-mismatch defence (rejects stale-state writes).
  *   - `check` returning a deterministic `checkedAt` ISO timestamp so the
  *     UI's optimistic update can rehydrate without a refetch.
+ *
+ * Track K phase 1 PR 3 cutover: the `list_items` read + check-state surface
+ * (`listItemsForList`, `checkListItem`, `uncheckListItem`,
+ * `uncheckAllListItems`) now resolves through the canonical
+ * `@pops/lists-db` package. The remaining mutations (`addItem`, `bulkAdd`,
+ * `updateItem`, `removeItem`, `reorderItems`, `removeCheckedItems`) stay on
+ * `@pops/app-lists-db` until a follow-up slice migrates the position-
+ * allocation + ref-kind helpers across.
  */
 import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
@@ -13,16 +21,13 @@ import { z } from 'zod';
 import {
   addItem,
   bulkAdd,
-  checkItem,
   type ListsDb,
-  listItemsForList,
   removeCheckedItems,
   removeItem,
   reorderItems,
-  uncheckAllItems,
-  uncheckItem,
   updateItem,
 } from '@pops/app-lists-db';
+import { listItemsService } from '@pops/lists-db';
 
 import { getDrizzle } from '../../../db.js';
 import { protectedProcedure, router } from '../../../trpc.js';
@@ -74,7 +79,7 @@ const ReorderInputSchema = z.object({
 const ListIdInputSchema = z.object({ listId: z.number().int().positive() });
 
 function currentItemIds(db: ListsDb, listId: number): readonly number[] {
-  return listItemsForList(db, listId).map((r) => r.id);
+  return listItemsService.listItemsForList(db, listId).map((r) => r.id);
 }
 
 export const itemsRouter = router({
@@ -94,7 +99,7 @@ export const itemsRouter = router({
   }),
 
   check: protectedProcedure.input(IdInputSchema).mutation(({ input }) => {
-    const row = runOrMap(() => checkItem(getDrizzle(), input.id));
+    const row = runOrMap(() => listItemsService.checkListItem(getDrizzle(), input.id));
     if (row.checkedAt === null) {
       // PRD-112 enforces `checked_at` is set when `checked=1` — this branch
       // is defensive against a future schema change.
@@ -107,7 +112,7 @@ export const itemsRouter = router({
   }),
 
   uncheck: protectedProcedure.input(IdInputSchema).mutation(({ input }) => {
-    runOrMap(() => uncheckItem(getDrizzle(), input.id));
+    runOrMap(() => listItemsService.uncheckListItem(getDrizzle(), input.id));
     return { ok: true as const };
   }),
 
@@ -150,7 +155,7 @@ export const itemsRouter = router({
    * without a follow-up read.
    */
   uncheckAll: protectedProcedure.input(ListIdInputSchema).mutation(({ input }) => {
-    const count = runOrMap(() => uncheckAllItems(getDrizzle(), input.listId));
+    const count = runOrMap(() => listItemsService.uncheckAllListItems(getDrizzle(), input.listId));
     return { ok: true as const, count };
   }),
 

--- a/apps/pops-api/src/modules/lists/routers/list.ts
+++ b/apps/pops-api/src/modules/lists/routers/list.ts
@@ -5,6 +5,12 @@
  * `lists` to `list_items` so the page gets `itemCount` / `uncheckedCount` /
  * `lastUpdatedAt` in one round-trip. Every other procedure is a thin
  * transactional pass-through to PRD-112 services in `@pops/app-lists-db`.
+ *
+ * Track K phase 1 PR 3 cutover: the `listItemsForList` read used by `get`
+ * now resolves through the canonical `@pops/lists-db` package. The `lists`-
+ * header surface (createList / getList / updateList / etc.) and the
+ * `ListNotFoundError` typed error stay on `@pops/app-lists-db` until the
+ * next slice migrates the `lists` CRUD services across.
  */
 import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
@@ -14,11 +20,11 @@ import {
   createList,
   deleteList,
   getList,
-  listItemsForList,
   ListNotFoundError,
   unarchiveList,
   updateList,
 } from '@pops/app-lists-db';
+import { listItemsService } from '@pops/lists-db';
 
 import { getDrizzle } from '../../../db.js';
 import { protectedProcedure, router } from '../../../trpc.js';
@@ -74,7 +80,7 @@ export const listRouter = router({
     const db = getDrizzle();
     const list = getList(db, input.id);
     if (list === null) return null;
-    const items = listItemsForList(db, input.id);
+    const items = listItemsService.listItemsForList(db, input.id);
     return { list, items };
   }),
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
       '@pops/inventory-db':
         specifier: workspace:*
         version: link:../../packages/inventory-db
+      '@pops/lists-db':
+        specifier: workspace:*
+        version: link:../../packages/lists-db
       '@pops/media-db':
         specifier: workspace:*
         version: link:../../packages/media-db


### PR DESCRIPTION
## Summary

Flips the in-tree consumer of the `list_items` read + check-state surface (the `lists.list.*` + `lists.items.*` tRPC routers in pops-api) over to the canonical `@pops/lists-db` package scaffolded in #2877. The remaining mutations on the items surface — `addItem`, `bulkAdd`, `updateItem`, `removeItem`, `reorderItems`, `removeCheckedItems` — still import from `@pops/app-lists-db` because the position-allocation + ref-kind helpers haven't been extracted to the new package yet. The `lists`-header CRUD surface and `ListNotFoundError` similarly stay on `@pops/app-lists-db` until the next slice migrates.

Mirrors food phase 1 PR 3 (#2868) and inventory phase 1 PR 3 (#2778): incremental cutover with the legacy package still intact, scoped to the slice the new pillar package actually surfaces.

## Changes

- `apps/pops-api/src/modules/lists/routers/items.ts`: split the import so `listItemsForList` + `checkListItem` + `uncheckListItem` + `uncheckAllListItems` resolve through `listItemsService` from `@pops/lists-db`; rename the call sites (the new package's mutations use `checkListItem` / `uncheckListItem` / `uncheckAllListItems`, not the old `checkItem` / `uncheckItem` / `uncheckAllItems`).
- `apps/pops-api/src/modules/lists/routers/list.ts`: flip the `listItemsForList` import used by the `get` aggregate to `@pops/lists-db`'s `listItemsService` namespace.
- `apps/pops-api/src/modules/lists/routers/error-mapping.ts`: import `ListItemNotFoundError` from `@pops/lists-db`; alias the legacy class from `@pops/app-lists-db` as `LegacyListItemNotFoundError` and include both in the `isTypedNotFound` instanceof guard so the mapping keeps working while `updateItem` still throws the older error identity across the PR 4 transition window.
- `apps/pops-api/package.json` + `pnpm-lock.yaml`: add the `@pops/lists-db` workspace dependency.

## What's still on `@pops/app-lists-db`

- Header CRUD: `archiveList`, `createList`, `deleteList`, `getList`, `unarchiveList`, `updateList`, `ListNotFoundError`.
- Item mutations: `addItem`, `bulkAdd`, `updateItem`, `removeItem`, `reorderItems`, `removeCheckedItems`.
- `ListsDb` + `ListKind` type imports used by `items.ts` + `services/aggregate.ts`.
- `packages/app-food-db/seed/` + `packages/app-lists/` consumers (frontend + seed paths are migrated by separate PRs).

PR 4 of phase 1 will convert `@pops/app-lists-db` into a re-export shim (or delete it) once every consumer is on `@pops/lists-db`. The `@pops/app-lists-db` surface stays unchanged in this PR.

## CI / Docker

PR 1 (#2877) already wired the Dockerfiles (`pops-api`, `pops-mcp`, `pops-shell`) and CI workflows (`_pkg-check.yml`, `api-quality.yml`, `api-test.yml`, `fe-quality.yml`, `fe-test-e2e.yml`) to build `@pops/lists-db` before pops-api consumers. No infra changes are needed for the cutover.

## Test plan

- [x] `pnpm --filter @pops/lists-db build` / `test` (17/17)
- [x] `pnpm --filter @pops/api test` — 4866/4866 pass (full pops-api suite — covers `lists.list.{list,get,update,delete}` + `lists.items.{check,uncheck,uncheckAll,reorder,add,bulkAdd,update,remove,removeChecked}` end-to-end via the tRPC caller in the lists router tests)
- [x] `pnpm typecheck` (turbo, full workspace) — 50/50 clean
- [x] `pnpm lint` — clean (pre-existing warnings only, no errors)
- [x] `pnpm build` — 24/24 green
- [x] `pnpm format` — clean

## References

- Phase 1 PR 1 (scaffold): #2877
- Food phase 1 PR 3 (most recent pattern): #2868
- Inventory phase 1 PR 3: #2778
