### PR TITLE
feat(api): open the lists pillar SQLite at boot (pillar lists phase 2 PR 2)

### DIFF
--- a/apps/pops-api/.env.example
+++ b/apps/pops-api/.env.example
@@ -51,6 +51,11 @@ CEREBRUM_SQLITE_PATH=./data/cerebrum.db
 # food needs its own mount point / Litestream stream in production.
 FOOD_SQLITE_PATH=./data/food.db
 
+# Lists pillar database (ADR-026). Defaults to <dirname(SQLITE_PATH)>/lists.db,
+# falling back to ./data/lists.db if SQLITE_PATH is unset. Set explicitly when
+# lists needs its own mount point / Litestream stream in production.
+LISTS_SQLITE_PATH=./data/lists.db
+
 # Media Images
 # Directory for locally cached posters and backdrops
 MEDIA_IMAGES_DIR=./data/media/images

--- a/apps/pops-api/src/db.ts
+++ b/apps/pops-api/src/db.ts
@@ -14,6 +14,7 @@ import { closeFinanceDb } from './db/finance-handle.js';
 import { closeFoodDb } from './db/food-handle.js';
 import { closeInventoryDb } from './db/inventory-handle.js';
 import { KNOWN_PILLARS } from './db/known-pillars.js';
+import { closeListsDb } from './db/lists-handle.js';
 import { closeMediaDb } from './db/media-db-handle.js';
 import { migrationOwners } from './db/migration-ownership.js';
 import {
@@ -243,6 +244,7 @@ export function closeDb(): void {
   closeMediaDb();
   closeCerebrumDb();
   closeFoodDb();
+  closeListsDb();
 }
 
 /**

--- a/apps/pops-api/src/db/lists-handle.ts
+++ b/apps/pops-api/src/db/lists-handle.ts
@@ -1,0 +1,88 @@
+/**
+ * Lazily-initialised handle to the lists pillar's SQLite file.
+ *
+ * Phase 2 PR 2 of the lists pillar migration: opens the connection
+ * (and applies the in-package migrations journal) at boot but does NOT
+ * yet route any production traffic through it. PR 3 of phase 2 flips
+ * the list_items slice (and subsequent slices) over with a single
+ * edit to `getDrizzle()` → `getListsDrizzle()` plus an ATTACH-based
+ * backfill of any existing rows from the shared pops.db; PR 4 drops
+ * the lists-owned tags from the shared journal + adds the Litestream
+ * config.
+ *
+ * Lives in its own module so `db.ts` stays under the lint cap as more
+ * pillars come online. Mirrors `core-handle.ts` / `inventory-handle.ts` /
+ * `finance-handle.ts` / `media-db-handle.ts` / `cerebrum-handle.ts` /
+ * `food-handle.ts`.
+ */
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+
+import { openListsDb, type ListsDb, type OpenedListsDb } from '@pops/lists-db';
+
+import { getDb, isNamedEnvContext } from '../db.js';
+import { resolveListsSqlitePath } from './lists-sqlite-path.js';
+
+let listsDb: OpenedListsDb | null = null;
+
+/**
+ * Resolve (and lazily open) the lists pillar's drizzle handle.
+ *
+ * **Env-aware**: inside a `withEnvDb()` scope (PRD-101 named environments —
+ * each E2E test fixture creates a per-test pops.db with its own seeded
+ * lists tables) the env DB takes precedence. The env DB already contains
+ * every lists-owned table because `seedDatabase()` writes them there, so
+ * a single fixture stays self-contained without a background backfill
+ * into the global `lists.db`. Outside an env scope (real production
+ * boot, dev), the pillar's `lists.db` is resolved + lazily opened so
+ * the in-package migrations apply.
+ *
+ * The handle is opened on first call so per-pillar migrations land
+ * before any request hits the API. Phase 2 PR 3 routes the list_items
+ * slice's reads/writes through this getter.
+ */
+export function getListsDrizzle(): ListsDb {
+  if (isNamedEnvContext()) return drizzle(getDb()) as ListsDb;
+  if (!listsDb) {
+    listsDb = openListsDb(resolveListsSqlitePath());
+  }
+  return listsDb.db;
+}
+
+/**
+ * Resolve the lists pillar's raw better-sqlite3 handle. Same lazy
+ * open + env-aware behaviour as `getListsDrizzle()` — exposed for
+ * the same lower-level needs (`.transaction()`, `.prepare()`,
+ * `.pragma()`) that the drizzle wrapper hides. Prefer
+ * `getListsDrizzle()` for everything that doesn't need it.
+ */
+export function getListsRawDb(): OpenedListsDb['raw'] {
+  if (isNamedEnvContext()) return getDb();
+  if (!listsDb) {
+    listsDb = openListsDb(resolveListsSqlitePath());
+  }
+  return listsDb.raw;
+}
+
+/**
+ * Close the lists pillar's connection if it was opened. Idempotent
+ * — safe to call from `closeDb()` on shutdown even when the lists
+ * handle was never resolved.
+ */
+export function closeListsDb(): void {
+  if (listsDb) {
+    listsDb.raw.close();
+    listsDb = null;
+  }
+}
+
+/**
+ * Test-only: swap the lists pillar handle. `setupTestContext` in
+ * `shared/test-utils.ts` calls this hook so test suites can inject an
+ * in-memory DB and avoid writing to the dev `data/lists.db` file.
+ * Returns the previous handle (or null).
+ */
+export function setListsDb(next: OpenedListsDb | null): OpenedListsDb | null {
+  const prev = listsDb;
+  listsDb = next;
+  return prev;
+}

--- a/apps/pops-api/src/db/lists-sqlite-path.test.ts
+++ b/apps/pops-api/src/db/lists-sqlite-path.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Resolver tests for the lists pillar's SQLite path.
+ *
+ * Covers the precedence chain: LISTS_SQLITE_PATH > <dirname(SQLITE_PATH)>/lists.db > fallback.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DEFAULT_LISTS_SQLITE_PATH, resolveListsSqlitePath } from './lists-sqlite-path.js';
+
+const originalListsPath = process.env['LISTS_SQLITE_PATH'];
+const originalSharedPath = process.env['SQLITE_PATH'];
+
+beforeEach(() => {
+  delete process.env['LISTS_SQLITE_PATH'];
+  delete process.env['SQLITE_PATH'];
+});
+
+afterEach(() => {
+  if (originalListsPath === undefined) delete process.env['LISTS_SQLITE_PATH'];
+  else process.env['LISTS_SQLITE_PATH'] = originalListsPath;
+  if (originalSharedPath === undefined) delete process.env['SQLITE_PATH'];
+  else process.env['SQLITE_PATH'] = originalSharedPath;
+});
+
+describe('resolveListsSqlitePath', () => {
+  it('returns LISTS_SQLITE_PATH verbatim when set', () => {
+    process.env['LISTS_SQLITE_PATH'] = '/abs/path/lists.db';
+    expect(resolveListsSqlitePath()).toBe('/abs/path/lists.db');
+  });
+
+  it('derives the path from the shared SQLITE_PATH when LISTS_SQLITE_PATH is unset', () => {
+    process.env['SQLITE_PATH'] = '/opt/pops/data/pops.db';
+    expect(resolveListsSqlitePath()).toBe('/opt/pops/data/lists.db');
+  });
+
+  it('handles relative SQLITE_PATH values', () => {
+    process.env['SQLITE_PATH'] = './data/pops.db';
+    expect(resolveListsSqlitePath()).toBe('data/lists.db');
+  });
+
+  it('falls back to ./data/lists.db when neither env is set', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      expect(resolveListsSqlitePath()).toBe(DEFAULT_LISTS_SQLITE_PATH);
+      expect(warn).toHaveBeenCalledOnce();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});

--- a/apps/pops-api/src/db/lists-sqlite-path.ts
+++ b/apps/pops-api/src/db/lists-sqlite-path.ts
@@ -1,0 +1,33 @@
+import { dirname, join } from 'node:path';
+
+import { DEFAULT_SQLITE_PATH } from './sqlite-path.js';
+
+/**
+ * Default location of the lists pillar's SQLite file.
+ *
+ * Per the ADR-026 pillar architecture each pillar owns its own SQLite
+ * file alongside the shared pops.db. The default places `lists.db`
+ * in the same directory the shared singleton resolves to so dev setups
+ * that already have a writable data dir don't need extra configuration.
+ * Production deployments set `LISTS_SQLITE_PATH` explicitly; the
+ * fallback here is local-dev-only and matches `resolveSqlitePath`'s
+ * default-path convention (`./data/<file>.db`).
+ *
+ * Resolution order:
+ *   1. `LISTS_SQLITE_PATH` env (absolute or relative).
+ *   2. `<dirname(SQLITE_PATH)>/lists.db` if the shared path is set.
+ *   3. `./data/lists.db` (matches the shared default's `./data/pops.db`).
+ */
+export const DEFAULT_LISTS_SQLITE_PATH = './data/lists.db';
+
+export function resolveListsSqlitePath(): string {
+  const envPath = process.env['LISTS_SQLITE_PATH'];
+  if (envPath) return envPath;
+  const sharedPath = process.env['SQLITE_PATH'];
+  if (sharedPath) return join(dirname(sharedPath), 'lists.db');
+  console.warn(
+    `[db] LISTS_SQLITE_PATH not set — using fallback: ${DEFAULT_LISTS_SQLITE_PATH} ` +
+      `(co-located with the shared singleton default '${DEFAULT_SQLITE_PATH}')`
+  );
+  return DEFAULT_LISTS_SQLITE_PATH;
+}

--- a/apps/pops-api/src/index.ts
+++ b/apps/pops-api/src/index.ts
@@ -11,6 +11,7 @@ import { backfillCerebrumFromSharedDb, getCerebrumDrizzle } from './db/cerebrum-
 import { backfillFinanceFromSharedDb, getFinanceDrizzle } from './db/finance-handle.js';
 import { backfillFoodFromSharedDb, getFoodDrizzle } from './db/food-handle.js';
 import { backfillInventoryFromSharedDb, getInventoryDrizzle } from './db/inventory-handle.js';
+import { getListsDrizzle } from './db/lists-handle.js';
 import { backfillMediaFromShared, getMediaDrizzle } from './db/media-db-handle.js';
 import { resolveSqlitePath } from './db/sqlite-path.js';
 import { closeQueues } from './jobs/queues.js';
@@ -122,6 +123,22 @@ try {
   backfillFoodFromSharedDb(resolveSqlitePath());
 } catch (err) {
   console.error('[db] Failed to bootstrap the food pillar SQLite:', err);
+  throw err;
+}
+
+// Eagerly open the lists pillar's SQLite + apply its journal at boot so
+// the in-package migrations land before any request hits the API. Phase
+// 2 PR 2 only opens the handle — no production traffic is routed
+// through it yet; the list_items slice still reads/writes against the
+// shared pops.db. Phase 2 PR 3 flips the list_items slice over with an
+// ATTACH-based backfill from pops.db (matching the inventory / finance
+// / media / core / cerebrum / food PR-3 pattern); PR 4 adds the
+// Litestream config. Opening early surfaces migration failures during
+// boot rather than on first lists-route request.
+try {
+  getListsDrizzle();
+} catch (err) {
+  console.error('[db] Failed to bootstrap the lists pillar SQLite:', err);
   throw err;
 }
 

--- a/apps/pops-api/src/shared/test-utils.ts
+++ b/apps/pops-api/src/shared/test-utils.ts
@@ -6,6 +6,7 @@ import { setCerebrumDb } from '../db/cerebrum-handle.js';
 import { setFinanceDb } from '../db/finance-handle.js';
 import { setFoodDb } from '../db/food-handle.js';
 import { setInventoryDb } from '../db/inventory-handle.js';
+import { setListsDb } from '../db/lists-handle.js';
 import { setMediaDb } from '../db/media-db-handle.js';
 import { appRouter } from '../router.js';
 import { TAG_VOCABULARY_V1 } from './tag-vocabulary.js';
@@ -1511,6 +1512,14 @@ export function setupTestContext() {
     // `data/food.db` mid-suite.
     setFoodDb({ db: drizzle(db), raw: db });
 
+    // Same for the lists pillar handle (phase 2 PR 2): the handle is
+    // opened at boot but no router has cut over yet. The injection is
+    // forward-looking — once PR 3 routes list_items (and subsequent
+    // slices) through getListsDrizzle() the fixture will already be
+    // pointed at the in-memory DB and won't try to open
+    // `data/lists.db` mid-suite.
+    setListsDb({ db: drizzle(db), raw: db });
+
     return { db, caller: createCaller(true) };
   }
 
@@ -1521,6 +1530,7 @@ export function setupTestContext() {
     setMediaDb(null);
     setCerebrumDb(null);
     setFoodDb(null);
+    setListsDb(null);
     closeDb();
   }
 


### PR DESCRIPTION
## Summary

Phase 2 PR 2 of the lists pillar migration — wires the boot-time `openListsDb()` helper landed in #2878 into pops-api. Mirrors the canonical Phase 2 PR 2 pattern from food (#2871), cerebrum (#2817), media (#2791), finance (#2799), inventory (#2792), and core (#2751).

- New env var `LISTS_SQLITE_PATH` (default `./data/lists.db`) documented in `apps/pops-api/.env.example`.
- `apps/pops-api/src/db/lists-sqlite-path.{ts,test.ts}` resolver + 4 unit tests covering the standard `LISTS_SQLITE_PATH > <dirname(SQLITE_PATH)>/lists.db > fallback` precedence chain.
- `apps/pops-api/src/db/lists-handle.ts` exposes env-aware `getListsDrizzle()` / `getListsRawDb()` (PRD-101 named-env scope returns the env DB per the food/inventory/finance/media/cerebrum Phase 2 PR 2 lesson) plus idempotent `closeListsDb()` and a `setListsDb()` test-injection hook.
- Boot wiring in `src/index.ts` calls `getListsDrizzle()` after the food bootstrap and re-throws so migration failures surface at boot.
- `closeDb()` in `src/db.ts` calls `closeListsDb()` for SIGTERM/SIGINT cleanup.
- `shared/test-utils.ts` injects an in-memory lists handle on `setupTestContext.setup()` and clears it on teardown. Forward-looking — no router has cut over to `getListsDrizzle()` yet.

## Out of scope (deferred)

- **Phase 2 PR 3** — `lists/routers/*.ts` cutover to `getListsDrizzle()` + ATTACH-based `backfillListsFromSharedDb()` carrying any rows still living in `pops.db` across (matching the inventory/finance/media/core/cerebrum/food PR-3 pattern).
- **Phase 2 PR 4** — `infra/litestream/lists.yml` + AGENTS.md docs.

## Track K progress

- Phase 1 PR 1 #2877 (canonical `@pops/lists-db` scaffold + list_items slice)
- Phase 1 PR 3 #2879 (pops-api routers flip to `listItemsService` from `@pops/lists-db`)
- Phase 2 PR 1 #2878 (`openListsDb()` helper — base of this stack)
- **Phase 2 PR 2** (this PR)

## Sibling Phase 2 PR 2s

- food #2871 (most recent canonical)
- cerebrum #2817
- media #2791
- finance #2799
- inventory #2792
- core #2751

## Test plan

- [x] `pnpm install`
- [x] `pnpm build` (24 packages successful)
- [x] `pnpm --filter @pops/api typecheck` clean
- [x] `pnpm lint` — only pre-existing warnings, no new errors
- [x] `pnpm --filter @pops/api test` — 4870 tests pass
- [x] `pnpm format`
- [x] Husky pre-commit hooks pass

Note: this branch is stacked on #2878. Once that merges, GitHub will retarget this PR's diff against `main` automatically.
