### PR TITLE
feat(lists-db): delete list_items shim from @pops/app-lists-db (Track K phase 1 PR 4)

### DIFF
--- a/packages/app-food-db/package.json
+++ b/packages/app-food-db/package.json
@@ -27,6 +27,7 @@
     "@pops/db-types": "workspace:*",
     "@pops/food-contracts": "workspace:*",
     "@pops/food-db": "workspace:*",
+    "@pops/lists-db": "workspace:*",
     "drizzle-orm": "^0.45.2"
   },
   "devDependencies": {

--- a/packages/app-food-db/src/seed/step-lists.ts
+++ b/packages/app-food-db/src/seed/step-lists.ts
@@ -3,10 +3,15 @@
  *
  * Uses app-lists services so ref_kind / ref_id normalisation flows through
  * the canonical code path. Items checked at fixture-time get an immediate
- * `checkItem` call so `checked_at` is populated, matching prod behaviour.
+ * `checkListItem` call so `checked_at` is populated, matching prod behaviour.
+ *
+ * Track K phase 1 PR 4: the `check` mutation resolves through the canonical
+ * `@pops/lists-db` package (renamed from `checkItem` to `checkListItem`).
+ * The un-migrated `addItem` + `createList` stay on `@pops/app-lists-db`
+ * until subsequent slice PRs migrate them.
  */
-import { type AddItemInput, addItem, checkItem } from '@pops/app-lists-db';
-import { createList, type ListsDb } from '@pops/app-lists-db';
+import { type AddItemInput, addItem, createList, type ListsDb } from '@pops/app-lists-db';
+import { listItemsService } from '@pops/lists-db';
 
 import { LIST_FIXTURES, type ListItemFixture } from './data-lists.js';
 
@@ -69,7 +74,7 @@ export function seedLists(
     for (const item of fixture.items) {
       const inserted = addItem(db, toAddItemInput(item, list.id, foodCtx));
       if (item.checked === true) {
-        checkItem(db, inserted.id);
+        listItemsService.checkListItem(db, inserted.id);
       }
       itemCount += 1;
     }

--- a/packages/app-lists-db/src/index.ts
+++ b/packages/app-lists-db/src/index.ts
@@ -28,14 +28,16 @@ export * as listItemsService from './services/list-items.js';
 export type { CreateListInput, ListListsFilter, UpdateListInput } from './services/lists.js';
 export type { AddItemInput, UpdateItemInput } from './services/list-items.js';
 
-// Backwards-compatible flat re-exports of every service free function.
-// New code should prefer the namespace forms above (`listsService.createList`)
-// — these keep the `/db` subpath shim a one-line passthrough.
+// Backwards-compatible flat re-exports of the service free functions that
+// HAVE NOT yet migrated to the canonical pillar packages. New code should
+// prefer the namespace forms above (`listsService.createList`) — these flat
+// re-exports keep the `/db` subpath shim a one-line passthrough during the
+// migration window.
 //
 // Track K phase 1 PR 4: the `list_items` read + check-state surface
-// (`listItemsForList`, `checkItem`, `uncheckItem`, `uncheckAllItems`)
-// no longer ships through this barrel — every consumer flipped to
-// `@pops/lists-db`'s `listItemsService.{listItemsForList, checkListItem,
+// (`listItemsForList`, `checkItem`, `uncheckItem`, `uncheckAllItems`) used
+// to be flat-exported here but has been retired — every consumer flipped
+// to `@pops/lists-db`'s `listItemsService.{listItemsForList, checkListItem,
 // uncheckListItem, uncheckAllListItems}` in PR 3 (#2879). The
 // implementations still live in `./services/list-items.js` because the
 // remaining un-migrated mutations (`addItem`, `bulkAdd`, `updateItem`,

--- a/packages/app-lists-db/src/index.ts
+++ b/packages/app-lists-db/src/index.ts
@@ -31,6 +31,17 @@ export type { AddItemInput, UpdateItemInput } from './services/list-items.js';
 // Backwards-compatible flat re-exports of every service free function.
 // New code should prefer the namespace forms above (`listsService.createList`)
 // — these keep the `/db` subpath shim a one-line passthrough.
+//
+// Track K phase 1 PR 4: the `list_items` read + check-state surface
+// (`listItemsForList`, `checkItem`, `uncheckItem`, `uncheckAllItems`)
+// no longer ships through this barrel — every consumer flipped to
+// `@pops/lists-db`'s `listItemsService.{listItemsForList, checkListItem,
+// uncheckListItem, uncheckAllListItems}` in PR 3 (#2879). The
+// implementations still live in `./services/list-items.js` because the
+// remaining un-migrated mutations (`addItem`, `bulkAdd`, `updateItem`,
+// `removeItem`, `reorderItems`, `removeCheckedItems`) share helper state
+// with them and the package's own unit suite still exercises them — they
+// get retired once subsequent slice PRs migrate the remaining mutations.
 export {
   archiveList,
   createList,
@@ -43,12 +54,8 @@ export {
 export {
   addItem,
   bulkAdd,
-  checkItem,
-  listItemsForList,
   removeCheckedItems,
   removeItem,
   reorderItems,
-  uncheckAllItems,
-  uncheckItem,
   updateItem,
 } from './services/list-items.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1199,6 +1199,9 @@ importers:
       '@pops/food-db':
         specifier: workspace:*
         version: link:../food-db
+      '@pops/lists-db':
+        specifier: workspace:*
+        version: link:../lists-db
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.10.0)


### PR DESCRIPTION
## Summary

Track K phase 1 PR 4 — deletes the now-dead `list_items` read + check-state flat re-exports from `@pops/app-lists-db`'s barrel. With PR 3 (#2879) flipping `apps/pops-api/src/modules/lists/` over to `listItemsService` from the canonical `@pops/lists-db`, the flat exports of `listItemsForList` / `checkItem` / `uncheckItem` / `uncheckAllItems` from the older package are external dead code.

Mirrors food Phase 1 PR 4 (#2870) and inventory Phase 1 PR 4 (#2782): drop the migrated slice's externally-exposed entries once the consumer cutover lands.

## What changed

- `packages/app-lists-db/src/index.ts` — removed the flat re-exports of `checkItem`, `listItemsForList`, `uncheckAllItems`, `uncheckItem` from the `./services/list-items.js` re-export block. Added a header comment block documenting the PR 4 retirement window and naming the un-migrated mutations that intentionally stay.
- `packages/app-food-db/src/seed/step-lists.ts` — the lone non-test straggler. The seed's `checkItem(db, inserted.id)` call now resolves through `listItemsService.checkListItem` from `@pops/lists-db`. Header docstring updated to name the renamed mutation + the partial-scope migration.
- `packages/app-food-db/package.json` — adds `@pops/lists-db` as a workspace dependency so the seed import resolves through the canonical package.
- `pnpm-lock.yaml` — regenerated for the new dependency edge.

## What deliberately stays

- `addItem`, `bulkAdd`, `updateItem`, `removeItem`, `reorderItems`, `removeCheckedItems` services in `@pops/app-lists-db` — these are the un-migrated mutations the rest of pops-api (lists routers + food shopping/send-to-list) still consume. They move in subsequent slice PRs.
- `ListItemNotFoundError` class in `@pops/app-lists-db/errors.ts` — `updateItem` still throws it, and the `LegacyListItemNotFoundError` alias in `error-mapping.ts` (added in #2879) is load-bearing for the dual-identity `instanceof` guard until the remaining mutations migrate.
- The `listItemsService` namespace export from `@pops/app-lists-db` — kept for parity with the food PR 4 pattern (`prepStatesService` namespace stayed even though it contained dead `listPrepStates`/`getPrepState`). The migrated functions are dead code inside `./services/list-items.js` but the file is still load-bearing for the un-migrated mutations that share helper state (`normalise`, `nextPosition`, `expectRow`).
- The `@pops/lists-db` workspace dep added to `@pops/app-food-db` — future slices will route through it as more services migrate.

## Consumer audit

```
$ grep -rn "from '@pops/app-lists-db'" --include="*.ts" | grep -v node_modules | grep -v "app-lists-db/src"
apps/pops-api/src/modules/lists/routers/items.ts: { addItem, bulkAdd, type ListsDb, removeCheckedItems, removeItem, reorderItems, updateItem }
apps/pops-api/src/modules/lists/routers/error-mapping.ts: { ListItemNotFoundError as LegacyListItemNotFoundError, ListNotFoundError }
apps/pops-api/src/modules/lists/routers/list.ts: { ... un-migrated lists CRUD ... }
apps/pops-api/src/modules/lists/services/aggregate.ts: { type ListKind, type ListsDb }
apps/pops-api/src/modules/food/shopping/generate.ts: { bulkAdd, createList }
apps/pops-api/src/modules/food/recipes/send-to-list/*.ts: { addItem, createList, listItems, lists }
packages/app-food-db/src/seed/step-lists.ts: { type AddItemInput, addItem, createList, type ListsDb }
packages/app-food-db/src/seed/{index,types}.ts: type-only { ListsDb }
packages/app-lists/src/db/index.ts: wildcard shim
packages/app-lists/src/pages/detail/types.ts: type-only { ListItemRefKind, ListItemRow, ListKind, ListRow }
```

Every remaining consumer touches only un-migrated services or type-only imports. No external consumer of the deleted flat exports remains.

## Local CI gauntlet

- `pnpm typecheck` — 50/50 tasks green.
- `pnpm lint` — clean (pre-existing warnings only, 0 errors).
- `pnpm --filter @pops/api test` — 4866/4866 passed.
- `pnpm --filter @pops/lists-db test` — 17/17 passed.
- `pnpm --filter @pops/app-lists-db test` — 41/41 passed.
- `pnpm build` — 24/24 tasks green.
- `pnpm format` — clean.

## Test plan

- [ ] `_pkg-check.yml`, `api-quality.yml`, `api-test.yml`, `fe-quality.yml`, `fe-test-e2e.yml` all green.
- [ ] `lists-db-quality.yml` drift-guard still green (no migration touched).
- [ ] Docker builds for pops-api / pops-shell / pops-mcp succeed.
