### PR TITLE
feat(api): flip lists module to lists.db + ATTACH backfill (pillar lists phase 2 PR 3)

### DIFF
--- a/apps/pops-api/src/db/backfill-lists-from-shared.test.ts
+++ b/apps/pops-api/src/db/backfill-lists-from-shared.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Boot-time backfill tests for `backfillListsFromShared` (phase 2 PR 3).
+ *
+ * Exercises the ATTACH-based copy from the shared `pops.db` to the
+ * pillar's `lists.db` against on-disk SQLite files (in-memory DBs
+ * can't be ATTACHed). Confirms:
+ *   - first run carries existing rows across,
+ *   - second run is a no-op (idempotent — the per-table WHERE filter dedupes),
+ *   - mixed state (some rows already in lists) only inserts the missing ones,
+ *   - children copy AFTER parents (FK order matters under `foreign_keys=ON`),
+ *   - missing source table is tolerated without throwing.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import BetterSqlite3 from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { openListsDb } from '@pops/lists-db';
+
+import { backfillListsFromShared } from './backfill-lists-from-shared.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'lists-backfill-'));
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+const LISTS_SQL = `
+CREATE TABLE lists (
+  id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  name text NOT NULL,
+  kind text NOT NULL,
+  owner_app text NOT NULL,
+  archived_at text,
+  created_at text DEFAULT (datetime('now')) NOT NULL,
+  CONSTRAINT "ck_lists_kind" CHECK("lists"."kind" IN ('shopping','packing','todo','generic'))
+);
+CREATE INDEX idx_lists_kind ON lists (kind);
+CREATE INDEX idx_lists_owner_app ON lists (owner_app);
+CREATE TABLE list_items (
+  id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  list_id integer NOT NULL,
+  position integer DEFAULT 0 NOT NULL,
+  label text NOT NULL,
+  qty real,
+  unit text,
+  ref_kind text DEFAULT 'free' NOT NULL,
+  ref_id integer,
+  checked integer DEFAULT 0 NOT NULL,
+  checked_at text,
+  due_at text,
+  notes text,
+  created_at text DEFAULT (datetime('now')) NOT NULL,
+  FOREIGN KEY (list_id) REFERENCES lists(id) ON UPDATE no action ON DELETE no action,
+  CONSTRAINT "ck_list_items_ref_kind" CHECK("list_items"."ref_kind" IN ('free','ingredient','variant','recipe','custom')),
+  CONSTRAINT "ck_list_items_checked" CHECK("list_items"."checked" IN (0,1))
+);
+CREATE INDEX idx_list_items_list ON list_items (list_id);
+CREATE INDEX idx_list_items_checked ON list_items (list_id, checked);
+CREATE INDEX idx_list_items_ref ON list_items (ref_kind, ref_id) WHERE ref_id IS NOT NULL;
+`;
+
+function openSharedWithSeed(seed: (raw: BetterSqlite3.Database) => void): string {
+  const path = join(tmpDir, 'pops.db');
+  const raw = new BetterSqlite3(path);
+  raw.exec(LISTS_SQL);
+  seed(raw);
+  raw.close();
+  return path;
+}
+
+function insertList(
+  raw: BetterSqlite3.Database,
+  id: number,
+  name: string,
+  kind: 'shopping' | 'packing' | 'todo' | 'generic' = 'shopping',
+  ownerApp = 'user'
+): void {
+  raw
+    .prepare(
+      "INSERT INTO lists (id, name, kind, owner_app, created_at) VALUES (?, ?, ?, ?, '2026-06-10T00:00:00Z')"
+    )
+    .run(id, name, kind, ownerApp);
+}
+
+function insertItem(
+  raw: BetterSqlite3.Database,
+  id: number,
+  listId: number,
+  label: string,
+  position = 0
+): void {
+  raw
+    .prepare(
+      "INSERT INTO list_items (id, list_id, position, label, ref_kind, checked, created_at) VALUES (?, ?, ?, ?, 'free', 0, '2026-06-10T00:00:00Z')"
+    )
+    .run(id, listId, position, label);
+}
+
+describe('backfillListsFromShared', () => {
+  it('copies lists rows from the shared DB on first run', () => {
+    const sharedPath = openSharedWithSeed((raw) => insertList(raw, 1, 'Groceries'));
+
+    const lists = openListsDb(join(tmpDir, 'lists.db'));
+    try {
+      backfillListsFromShared(lists, sharedPath);
+      const { n } = lists.raw.prepare('SELECT count(*) AS n FROM lists').get() as { n: number };
+      expect(n).toBe(1);
+    } finally {
+      lists.raw.close();
+    }
+  });
+
+  it('copies list_items rows in FK-safe order after their parent lists', () => {
+    const sharedPath = openSharedWithSeed((raw) => {
+      insertList(raw, 1, 'Groceries');
+      insertItem(raw, 10, 1, 'milk', 0);
+      insertItem(raw, 11, 1, 'bread', 1);
+    });
+
+    const lists = openListsDb(join(tmpDir, 'lists.db'));
+    try {
+      backfillListsFromShared(lists, sharedPath);
+      const items = lists.raw
+        .prepare('SELECT id, list_id, label, position FROM list_items ORDER BY id')
+        .all() as { id: number; list_id: number; label: string; position: number }[];
+      expect(items).toEqual([
+        { id: 10, list_id: 1, label: 'milk', position: 0 },
+        { id: 11, list_id: 1, label: 'bread', position: 1 },
+      ]);
+    } finally {
+      lists.raw.close();
+    }
+  });
+
+  it('is idempotent — a second run does not duplicate rows', () => {
+    const sharedPath = openSharedWithSeed((raw) => {
+      insertList(raw, 1, 'Groceries');
+      insertItem(raw, 10, 1, 'milk');
+    });
+
+    const lists = openListsDb(join(tmpDir, 'lists.db'));
+    try {
+      backfillListsFromShared(lists, sharedPath);
+      backfillListsFromShared(lists, sharedPath);
+      const { listsCount } = lists.raw
+        .prepare('SELECT count(*) AS listsCount FROM lists')
+        .get() as { listsCount: number };
+      const { itemsCount } = lists.raw
+        .prepare('SELECT count(*) AS itemsCount FROM list_items')
+        .get() as { itemsCount: number };
+      expect(listsCount).toBe(1);
+      expect(itemsCount).toBe(1);
+    } finally {
+      lists.raw.close();
+    }
+  });
+
+  it('only inserts rows missing from the lists copy (mixed state)', () => {
+    const sharedPath = openSharedWithSeed((raw) => {
+      insertList(raw, 1, 'Groceries');
+      insertList(raw, 2, 'Packing');
+      insertItem(raw, 10, 1, 'milk');
+      insertItem(raw, 11, 2, 'socks');
+    });
+
+    const lists = openListsDb(join(tmpDir, 'lists.db'));
+    try {
+      insertList(lists.raw, 1, 'Groceries');
+      insertItem(lists.raw, 10, 1, 'milk');
+      backfillListsFromShared(lists, sharedPath);
+      const listRows = lists.raw.prepare('SELECT id, name FROM lists ORDER BY id').all() as {
+        id: number;
+        name: string;
+      }[];
+      const itemRows = lists.raw.prepare('SELECT id, label FROM list_items ORDER BY id').all() as {
+        id: number;
+        label: string;
+      }[];
+      expect(listRows.map((r) => r.id)).toEqual([1, 2]);
+      expect(itemRows.map((r) => r.id)).toEqual([10, 11]);
+    } finally {
+      lists.raw.close();
+    }
+  });
+
+  it('tolerates a shared DB with no lists tables (post-PR-4 drop scenario)', () => {
+    const sharedPath = join(tmpDir, 'pops.db');
+    const raw = new BetterSqlite3(sharedPath);
+    raw.exec(`CREATE TABLE other_table (id integer PRIMARY KEY)`);
+    raw.close();
+
+    const lists = openListsDb(join(tmpDir, 'lists.db'));
+    try {
+      expect(() => backfillListsFromShared(lists, sharedPath)).not.toThrow();
+      const { n } = lists.raw.prepare('SELECT count(*) AS n FROM lists').get() as { n: number };
+      expect(n).toBe(0);
+    } finally {
+      lists.raw.close();
+    }
+  });
+});

--- a/apps/pops-api/src/db/backfill-lists-from-shared.ts
+++ b/apps/pops-api/src/db/backfill-lists-from-shared.ts
@@ -1,0 +1,113 @@
+/**
+ * Boot-time backfill from the legacy shared `pops.db` into the lists
+ * pillar's `lists.db`.
+ *
+ * Phase 2 PR 3 of the lists pillar flips every lists module read +
+ * write (`lists.list.*` and `lists.items.*`) to the lists handle. The
+ * first deploy after PR 3 needs to carry the existing `lists` and
+ * `list_items` rows from the shared DB across before any reads come
+ * from the new file. Subsequent boots find the lists copy already
+ * populated and become a no-op via the `WHERE id NOT IN (...)`
+ * existence filter on every table.
+ *
+ * Order matters for FK enforcement (with `foreign_keys = ON`): the
+ * `list_items.list_id` FK requires the parent `lists` row to exist
+ * before children copy across. Parent first, then children.
+ *
+ * Each table is wrapped in `tryCopyTable` so a missing source table
+ * (post-PR-4 drop scenario, or a stale on-disk pops.db) doesn't bring
+ * the whole backfill down. Failures are logged + swallowed; the
+ * remaining tables still attempt.
+ *
+ * Non-fatal: ATTACH or INSERT failures are logged and swallowed so a
+ * stale on-disk pops.db never bricks the boot path. Partial failures
+ * leave the lists copy partially populated; the next deploy retries
+ * and the idempotent filter picks up only the still-missing rows.
+ *
+ * Mirrors `backfill-food-from-shared.ts` / `backfill-inventory-from-
+ * shared.ts` / `backfill-finance-from-shared.ts` / `backfill-media-
+ * from-shared.ts` / `backfill-cerebrum-from-shared.ts`.
+ */
+import type Database from 'better-sqlite3';
+
+import type { OpenedListsDb } from '@pops/lists-db';
+
+interface TableCopy {
+  readonly table: string;
+  /**
+   * Explicit column list keeps the backfill robust against a stale
+   * on-disk pops.db that already widened or narrowed since the boot
+   * image was built.
+   */
+  readonly columns: readonly string[];
+  /** Identifier column used in the existence filter. */
+  readonly idColumn: string;
+}
+
+const TABLE_COPIES: readonly TableCopy[] = [
+  {
+    table: 'lists',
+    idColumn: 'id',
+    columns: ['id', 'name', 'kind', 'owner_app', 'archived_at', 'created_at'],
+  },
+  {
+    table: 'list_items',
+    idColumn: 'id',
+    columns: [
+      'id',
+      'list_id',
+      'position',
+      'label',
+      'qty',
+      'unit',
+      'ref_kind',
+      'ref_id',
+      'checked',
+      'checked_at',
+      'due_at',
+      'notes',
+      'created_at',
+    ],
+  },
+];
+
+function tryCopyTable(raw: Database.Database, copy: TableCopy): void {
+  try {
+    const hasTable = raw
+      .prepare(`SELECT 1 FROM pops.sqlite_master WHERE type='table' AND name='${copy.table}'`)
+      .get();
+    if (!hasTable) return;
+    const cols = copy.columns.join(', ');
+    raw.exec(`
+      INSERT INTO ${copy.table} (${cols})
+      SELECT ${cols}
+      FROM pops.${copy.table}
+      WHERE ${copy.idColumn} NOT IN (SELECT ${copy.idColumn} FROM ${copy.table})
+    `);
+  } catch (err) {
+    console.warn(`[db] Lists backfill of ${copy.table} failed (non-fatal):`, err);
+  }
+}
+
+/**
+ * Copy `lists` + `list_items` rows from `pops.db` into `lists.db`, in
+ * FK-safe order (parent before children), idempotent against re-runs.
+ *
+ * Caller is responsible for supplying the lists handle (so this
+ * module stays decoupled from the lazy singleton in
+ * `db/lists-handle.ts`). Production wiring passes the result of
+ * `getListsDrizzle()` after the eager-open block; tests pass an
+ * in-memory handle with a tmpdir copy of the shared DB pre-populated.
+ */
+export function backfillListsFromShared(lists: OpenedListsDb, sharedPath: string): void {
+  try {
+    lists.raw.prepare('ATTACH DATABASE ? AS pops').run(sharedPath);
+    try {
+      for (const copy of TABLE_COPIES) tryCopyTable(lists.raw, copy);
+    } finally {
+      lists.raw.exec('DETACH DATABASE pops');
+    }
+  } catch (err) {
+    console.warn('[db] Lists backfill ATTACH failed (non-fatal):', err);
+  }
+}

--- a/apps/pops-api/src/db/lists-handle.ts
+++ b/apps/pops-api/src/db/lists-handle.ts
@@ -20,6 +20,7 @@ import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { openListsDb, type ListsDb, type OpenedListsDb } from '@pops/lists-db';
 
 import { getDb, isNamedEnvContext } from '../db.js';
+import { backfillListsFromShared } from './backfill-lists-from-shared.js';
 import { resolveListsSqlitePath } from './lists-sqlite-path.js';
 
 let listsDb: OpenedListsDb | null = null;
@@ -85,4 +86,16 @@ export function setListsDb(next: OpenedListsDb | null): OpenedListsDb | null {
   const prev = listsDb;
   listsDb = next;
   return prev;
+}
+
+/**
+ * Run the one-shot ATTACH backfill from the legacy shared pops.db into
+ * the lists pillar's lists.db. No-op if the lists handle isn't open
+ * (e.g. boot still resolving). Idempotent against repeated boots via
+ * per-table `WHERE id NOT IN (...)` filters. See
+ * `backfill-lists-from-shared.ts` for the table-by-table behaviour.
+ */
+export function backfillListsFromSharedDb(sharedPath: string): void {
+  if (!listsDb) return;
+  backfillListsFromShared(listsDb, sharedPath);
 }

--- a/apps/pops-api/src/index.ts
+++ b/apps/pops-api/src/index.ts
@@ -11,7 +11,7 @@ import { backfillCerebrumFromSharedDb, getCerebrumDrizzle } from './db/cerebrum-
 import { backfillFinanceFromSharedDb, getFinanceDrizzle } from './db/finance-handle.js';
 import { backfillFoodFromSharedDb, getFoodDrizzle } from './db/food-handle.js';
 import { backfillInventoryFromSharedDb, getInventoryDrizzle } from './db/inventory-handle.js';
-import { getListsDrizzle } from './db/lists-handle.js';
+import { backfillListsFromSharedDb, getListsDrizzle } from './db/lists-handle.js';
 import { backfillMediaFromShared, getMediaDrizzle } from './db/media-db-handle.js';
 import { resolveSqlitePath } from './db/sqlite-path.js';
 import { closeQueues } from './jobs/queues.js';
@@ -126,17 +126,15 @@ try {
   throw err;
 }
 
-// Eagerly open the lists pillar's SQLite + apply its journal at boot so
-// the in-package migrations land before any request hits the API. Phase
-// 2 PR 2 only opens the handle — no production traffic is routed
-// through it yet; the list_items slice still reads/writes against the
-// shared pops.db. Phase 2 PR 3 flips the list_items slice over with an
-// ATTACH-based backfill from pops.db (matching the inventory / finance
-// / media / core / cerebrum / food PR-3 pattern); PR 4 adds the
-// Litestream config. Opening early surfaces migration failures during
-// boot rather than on first lists-route request.
+// Eagerly open the lists pillar's SQLite + apply its journal at boot.
+// Every lists module read + write now resolves against this handle
+// (phase 2 PR 3); the one-shot `backfillListsFromSharedDb` carries any
+// `lists` + `list_items` rows that still live in the legacy pops.db
+// across. The backfill is idempotent (per-table `WHERE id NOT IN (...)`
+// filters) and non-fatal (partial failure logs + continues).
 try {
   getListsDrizzle();
+  backfillListsFromSharedDb(resolveSqlitePath());
 } catch (err) {
   console.error('[db] Failed to bootstrap the lists pillar SQLite:', err);
   throw err;

--- a/apps/pops-api/src/modules/lists/__tests__/lists-router.test.ts
+++ b/apps/pops-api/src/modules/lists/__tests__/lists-router.test.ts
@@ -66,7 +66,6 @@ describe('PRD-140 lists router', () => {
   afterEach(() => {
     setListsDb(null);
     closeDb();
-    raw.close();
   });
 
   describe('list.create', () => {

--- a/apps/pops-api/src/modules/lists/__tests__/lists-router.test.ts
+++ b/apps/pops-api/src/modules/lists/__tests__/lists-router.test.ts
@@ -24,9 +24,11 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import BetterSqlite3, { type Database } from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { closeDb, setDb } from '../../../db.js';
+import { setListsDb } from '../../../db/lists-handle.js';
 import { createCaller } from '../../../shared/test-utils.js';
 
 const MIGRATION_FILES = ['0062_chemical_donald_blake.sql'];
@@ -53,9 +55,16 @@ describe('PRD-140 lists router', () => {
   beforeEach(() => {
     raw = createListsTestDb();
     setDb(raw);
+    // Track K phase 2 PR 3 cutover: every lists router call site now
+    // resolves through `getListsDrizzle()` instead of `getDrizzle()`,
+    // so the test fixture has to inject the same in-memory DB into the
+    // lists handle. Without this the singleton would lazy-open
+    // `data/lists.db` mid-suite.
+    setListsDb({ db: drizzle(raw), raw });
   });
 
   afterEach(() => {
+    setListsDb(null);
     closeDb();
     raw.close();
   });

--- a/apps/pops-api/src/modules/lists/routers/items.ts
+++ b/apps/pops-api/src/modules/lists/routers/items.ts
@@ -14,6 +14,16 @@
  * `updateItem`, `removeItem`, `reorderItems`, `removeCheckedItems`) stay on
  * `@pops/app-lists-db` until a follow-up slice migrates the position-
  * allocation + ref-kind helpers across.
+ *
+ * Track K phase 2 PR 3 cutover: the DB handle every call site receives
+ * now comes from `getListsDrizzle()` (the lists pillar's `lists.db`)
+ * instead of the shared `getDrizzle()` core handle. The boot-time
+ * `backfillListsFromSharedDb` carries the existing `lists` + `list_items`
+ * rows across so the cutover is transparent on first deploy. The mix of
+ * `@pops/lists-db` (reads + check-state) and `@pops/app-lists-db`
+ * (writes still pending slice migration) both accept the same
+ * structural `ListsDb` drizzle type, so the single handle change covers
+ * both packages.
  */
 import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
@@ -29,7 +39,7 @@ import {
 } from '@pops/app-lists-db';
 import { listItemsService } from '@pops/lists-db';
 
-import { getDrizzle } from '../../../db.js';
+import { getListsDrizzle } from '../../../db/lists-handle.js';
 import { protectedProcedure, router } from '../../../trpc.js';
 import { runOrMap } from './error-mapping.js';
 
@@ -84,22 +94,22 @@ function currentItemIds(db: ListsDb, listId: number): readonly number[] {
 
 export const itemsRouter = router({
   add: protectedProcedure.input(AddInputSchema).mutation(({ input }) => {
-    const row = runOrMap(() => addItem(getDrizzle(), input));
+    const row = runOrMap(() => addItem(getListsDrizzle(), input));
     return { id: row.id, position: row.position };
   }),
 
   bulkAdd: protectedProcedure.input(BulkAddInputSchema).mutation(({ input }) => {
-    const rows = runOrMap(() => bulkAdd(getDrizzle(), input.listId, input.items));
+    const rows = runOrMap(() => bulkAdd(getListsDrizzle(), input.listId, input.items));
     return { addedIds: rows.map((r) => r.id) };
   }),
 
   update: protectedProcedure.input(UpdateInputSchema).mutation(({ input }) => {
-    runOrMap(() => updateItem(getDrizzle(), input.id, input));
+    runOrMap(() => updateItem(getListsDrizzle(), input.id, input));
     return { ok: true as const };
   }),
 
   check: protectedProcedure.input(IdInputSchema).mutation(({ input }) => {
-    const row = runOrMap(() => listItemsService.checkListItem(getDrizzle(), input.id));
+    const row = runOrMap(() => listItemsService.checkListItem(getListsDrizzle(), input.id));
     if (row.checkedAt === null) {
       // PRD-112 enforces `checked_at` is set when `checked=1` — this branch
       // is defensive against a future schema change.
@@ -112,13 +122,13 @@ export const itemsRouter = router({
   }),
 
   uncheck: protectedProcedure.input(IdInputSchema).mutation(({ input }) => {
-    runOrMap(() => listItemsService.uncheckListItem(getDrizzle(), input.id));
+    runOrMap(() => listItemsService.uncheckListItem(getListsDrizzle(), input.id));
     return { ok: true as const };
   }),
 
   remove: protectedProcedure.input(IdInputSchema).mutation(({ input }) => {
     // PRD-112's removeItem is idempotent (no NotFound). Always returns ok.
-    runOrMap(() => removeItem(getDrizzle(), input.id));
+    runOrMap(() => removeItem(getListsDrizzle(), input.id));
     return { ok: true as const };
   }),
 
@@ -132,7 +142,7 @@ export const itemsRouter = router({
    * are tighter versions of the same defence.
    */
   reorder: protectedProcedure.input(ReorderInputSchema).mutation(({ input }) => {
-    const db = getDrizzle();
+    const db = getListsDrizzle();
     const current = currentItemIds(db, input.listId);
     if (current.length !== input.orderedIds.length) {
       return { ok: false as const, reason: 'BadIds' as const };
@@ -155,7 +165,9 @@ export const itemsRouter = router({
    * without a follow-up read.
    */
   uncheckAll: protectedProcedure.input(ListIdInputSchema).mutation(({ input }) => {
-    const count = runOrMap(() => listItemsService.uncheckAllListItems(getDrizzle(), input.listId));
+    const count = runOrMap(() =>
+      listItemsService.uncheckAllListItems(getListsDrizzle(), input.listId)
+    );
     return { ok: true as const, count };
   }),
 
@@ -164,7 +176,7 @@ export const itemsRouter = router({
    * the row count removed; unchecked items are untouched.
    */
   removeChecked: protectedProcedure.input(ListIdInputSchema).mutation(({ input }) => {
-    const removedCount = runOrMap(() => removeCheckedItems(getDrizzle(), input.listId));
+    const removedCount = runOrMap(() => removeCheckedItems(getListsDrizzle(), input.listId));
     return { ok: true as const, removedCount };
   }),
 });

--- a/apps/pops-api/src/modules/lists/routers/list.ts
+++ b/apps/pops-api/src/modules/lists/routers/list.ts
@@ -11,6 +11,12 @@
  * header surface (createList / getList / updateList / etc.) and the
  * `ListNotFoundError` typed error stay on `@pops/app-lists-db` until the
  * next slice migrates the `lists` CRUD services across.
+ *
+ * Track K phase 2 PR 3 cutover: the DB handle now comes from
+ * `getListsDrizzle()` (the lists pillar's `lists.db`) instead of the
+ * shared `getDrizzle()` core handle. The boot-time
+ * `backfillListsFromSharedDb` carries the existing `lists` + `list_items`
+ * rows across so the cutover is transparent on first deploy.
  */
 import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
@@ -26,7 +32,7 @@ import {
 } from '@pops/app-lists-db';
 import { listItemsService } from '@pops/lists-db';
 
-import { getDrizzle } from '../../../db.js';
+import { getListsDrizzle } from '../../../db/lists-handle.js';
 import { protectedProcedure, router } from '../../../trpc.js';
 import { selectListAggregate } from '../services/aggregate.js';
 import { runOrMap } from './error-mapping.js';
@@ -65,7 +71,7 @@ const IdInputSchema = z.object({ id: z.number().int().positive() });
 export const listRouter = router({
   /** Aggregate list query for the /lists index page. */
   list: protectedProcedure.input(ListInputSchema).query(({ input }) => {
-    const items = selectListAggregate(getDrizzle(), input ?? {});
+    const items = selectListAggregate(getListsDrizzle(), input ?? {});
     return { items };
   }),
 
@@ -77,7 +83,7 @@ export const listRouter = router({
    * a generic error toast instead.
    */
   get: protectedProcedure.input(GetInputSchema).query(({ input }) => {
-    const db = getDrizzle();
+    const db = getListsDrizzle();
     const list = getList(db, input.id);
     if (list === null) return null;
     const items = listItemsService.listItemsForList(db, input.id);
@@ -86,7 +92,7 @@ export const listRouter = router({
 
   create: protectedProcedure.input(CreateInputSchema).mutation(({ input }) => {
     const row = runOrMap(() =>
-      createList(getDrizzle(), {
+      createList(getListsDrizzle(), {
         name: input.name,
         kind: input.kind,
         ownerApp: input.ownerApp ?? 'user',
@@ -102,7 +108,7 @@ export const listRouter = router({
    */
   update: protectedProcedure.input(UpdateInputSchema).mutation(({ input }) => {
     try {
-      updateList(getDrizzle(), input.id, { name: input.name, kind: input.kind });
+      updateList(getListsDrizzle(), input.id, { name: input.name, kind: input.kind });
       return { ok: true as const };
     } catch (err) {
       if (err instanceof ListNotFoundError) {
@@ -113,17 +119,17 @@ export const listRouter = router({
   }),
 
   archive: protectedProcedure.input(IdInputSchema).mutation(({ input }) => {
-    runOrMap(() => archiveList(getDrizzle(), input.id));
+    runOrMap(() => archiveList(getListsDrizzle(), input.id));
     return { ok: true as const };
   }),
 
   unarchive: protectedProcedure.input(IdInputSchema).mutation(({ input }) => {
-    runOrMap(() => unarchiveList(getDrizzle(), input.id));
+    runOrMap(() => unarchiveList(getListsDrizzle(), input.id));
     return { ok: true as const };
   }),
 
   delete: protectedProcedure.input(IdInputSchema).mutation(({ input }) => {
-    const db = getDrizzle();
+    const db = getListsDrizzle();
     // PRD-140 line 213: cascade items via PRD-112's `deleteList` (one
     // transaction). The service is intentionally idempotent on unknown id,
     // but we throw NOT_FOUND if the row was never there so the UI can show

--- a/apps/pops-api/src/shared/test-utils.ts
+++ b/apps/pops-api/src/shared/test-utils.ts
@@ -1512,12 +1512,16 @@ export function setupTestContext() {
     // `data/food.db` mid-suite.
     setFoodDb({ db: drizzle(db), raw: db });
 
-    // Same for the lists pillar handle (phase 2 PR 2): the handle is
-    // opened at boot but no router has cut over yet. The injection is
-    // forward-looking — once PR 3 routes list_items (and subsequent
-    // slices) through getListsDrizzle() the fixture will already be
-    // pointed at the in-memory DB and won't try to open
-    // `data/lists.db` mid-suite.
+    // Same for the lists pillar handle (phase 2 PR 3): every lists
+    // module read + write now resolves getListsDrizzle(), so the test
+    // fixture has to surface its tables (lists, list_items) on the
+    // lists handle too. The shared in-memory DB created by
+    // createTestDb() doesn't seed lists tables on its own — suites
+    // that exercise the lists routers (e.g.
+    // `modules/lists/__tests__/lists-router.test.ts`) apply the
+    // package-local 0062 migration and call `setListsDb(...)`
+    // explicitly with their own raw handle. The injection here keeps
+    // unrelated suites from lazy-opening `data/lists.db` mid-test.
     setListsDb({ db: drizzle(db), raw: db });
 
     return { db, caller: createCaller(true) };


### PR DESCRIPTION
## Summary

Track K phase 2 PR 3 — cuts the lists module over to the pillar's `lists.db` handle and lands the one-shot ATTACH-based backfill that carries existing `lists` + `list_items` rows across from the legacy shared `pops.db`.

Mirrors the canonical pattern from food (#2872), inventory (#2794), finance (#2806), media, cerebrum, and core Phase 2 PR 3s.

### Cutover

- `lists/routers/list.ts` + `lists/routers/items.ts` swap `getDrizzle()` (the shared core handle) for `getListsDrizzle()` (the lists pillar handle from #2880). Single change covers both `@pops/lists-db` (reads + check-state) and `@pops/app-lists-db` (write surface still pending slice migration) — both packages accept the same structural `ListsDb` drizzle type.

### Backfill module

- New `apps/pops-api/src/db/backfill-lists-from-shared.ts`: ATTACH-based copy keyed on `WHERE id NOT IN (...)` per table so repeated boots become no-ops. Parent (`lists`) first, then children (`list_items`) — FK order matters under `foreign_keys=ON`.
- Each `tryCopyTable` is wrapped in its own try/catch so a missing source table (post-PR-4 drop) or stale on-disk pops.db never bricks the boot path; failures log + swallow, the rest still attempts.
- `backfillListsFromSharedDb(sharedPath)` wrapper in `lists-handle.ts` is wired from `src/index.ts` right after `getListsDrizzle()` boots.
- 5 unit tests against a tmpdir on-disk pair (first-run copy, FK-order children, idempotent re-run, mixed-state partial copy, missing source table tolerance).

### Env-aware resolver verified

`getListsDrizzle()` already checks `isNamedEnvContext()` first (landed in #2880) so PRD-101 named-environments fixtures keep routing reads + writes to the env-scoped DB instead of the global `lists.db`. The food/inventory/finance Phase 2 PR 3 lesson (f) is honoured.

### Baseline migration

Not needed: `0062_chemical_donald_blake.sql` from Phase 1 PR 1 (#2877) already CREATEs the full `lists` + `list_items` baseline in the package journal.

### Test fixtures

- `shared/test-utils.ts` lists-handle injection comment updated from "forward-looking" to load-bearing; the in-memory DB now backs every lists call site.
- `modules/lists/__tests__/lists-router.test.ts` adds an explicit `setListsDb({ db: drizzle(raw), raw })` alongside its existing `setDb(raw)` so the freshly-migrated in-memory DB backs the lists handle instead of the singleton lazy-opening `data/lists.db` mid-suite.

### Out of scope

- Litestream (Phase 2 PR 4).
- pops-lists-api container (Phase 3).

### Refs

- Phase 2 PR 1 (openListsDb helper): #2878
- Phase 2 PR 2 (boot wiring): #2880
- food canonical PR 3: #2872
- inventory PR 3: #2794
- finance PR 3: #2806
- media PR 3: #2791
- cerebrum PR 3: #2817
- core PR 3: #2751

## Test plan

- [x] `pnpm typecheck` (turbo) green
- [x] `pnpm lint` green (warnings only — all pre-existing)
- [x] `pnpm --filter @pops/api test` — 306 files / 4875 tests pass
- [x] `pnpm --filter @pops/lists-db test` — 2 files / 21 tests pass
- [x] `pnpm build` (turbo, 24/24 tasks) green
- [x] `pnpm format` clean
- [ ] Copilot R1 reviewed + threads resolved
- [ ] CI green on the PR before merge
