### PR TITLE
feat(lists-api): scaffold pops-lists-api container (pillar lists phase 3 PR 1)

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -14,6 +14,7 @@ on:
       - "apps/pops-media-api/**"
       - "apps/pops-cerebrum-api/**"
       - "apps/pops-food-api/**"
+      - "apps/pops-lists-api/**"
       - "packages/**"
       - "infra/docker-compose*.yml"
       - "pnpm-lock.yaml"
@@ -44,6 +45,7 @@ jobs:
               - 'apps/pops-media-api/**'
               - 'apps/pops-cerebrum-api/**'
               - 'apps/pops-food-api/**'
+              - 'apps/pops-lists-api/**'
               - 'packages/**'
               - 'pnpm-lock.yaml'
               - 'pnpm-workspace.yaml'
@@ -100,6 +102,10 @@ jobs:
       - name: Build pops-food-api (builder stage)
         if: github.event_name == 'push' || needs.changes.outputs.relevant == 'true'
         run: docker build --target builder -f apps/pops-food-api/Dockerfile .
+
+      - name: Build pops-lists-api (builder stage)
+        if: github.event_name == 'push' || needs.changes.outputs.relevant == 'true'
+        run: docker build --target builder -f apps/pops-lists-api/Dockerfile .
 
   compose-validate:
     name: Validate docker-compose

--- a/.github/workflows/lists-api-quality.yml
+++ b/.github/workflows/lists-api-quality.yml
@@ -1,0 +1,41 @@
+name: Lists API Quality
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "apps/pops-lists-api/**"
+      - "packages/lists-db/**"
+      - "packages/db-types/**"
+      - ".github/workflows/lists-api-quality.yml"
+      - ".github/workflows/_pkg-check.yml"
+  pull_request:
+
+jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - 'apps/pops-lists-api/**'
+              - 'packages/lists-db/**'
+              - 'packages/db-types/**'
+              - '.github/workflows/lists-api-quality.yml'
+              - '.github/workflows/_pkg-check.yml'
+
+  quality:
+    needs: [changes]
+    if: always()
+    uses: ./.github/workflows/_pkg-check.yml
+    with:
+      package-path: apps/pops-lists-api
+      needs-db-build: true
+      skip: ${{ github.event_name == 'pull_request' && needs.changes.outputs.relevant != 'true' }}

--- a/apps/pops-lists-api/Dockerfile
+++ b/apps/pops-lists-api/Dockerfile
@@ -1,0 +1,64 @@
+FROM node:22-slim AS builder
+WORKDIR /app
+
+# Copy workspace root files
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json ./
+
+# Copy workspace package.json files (for dep resolution)
+COPY packages/db-types/package.json ./packages/db-types/
+COPY packages/types/package.json ./packages/types/
+COPY packages/lists-db/package.json ./packages/lists-db/
+COPY apps/pops-lists-api/package.json ./apps/pops-lists-api/
+
+# Install pnpm and all workspace dependencies
+RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
+    corepack enable && pnpm install --frozen-lockfile
+
+# Copy shared package sources
+COPY packages/db-types/src ./packages/db-types/src
+COPY packages/db-types/tsconfig.json ./packages/db-types/
+COPY packages/types/src ./packages/types/src
+COPY packages/types/tsconfig.json packages/types/tsconfig.build.json ./packages/types/
+COPY packages/lists-db/src ./packages/lists-db/src
+COPY packages/lists-db/tsconfig.json ./packages/lists-db/
+COPY packages/lists-db/migrations ./packages/lists-db/migrations
+
+# Copy lists-api source
+COPY apps/pops-lists-api/tsconfig.json ./apps/pops-lists-api/
+COPY apps/pops-lists-api/src ./apps/pops-lists-api/src
+
+# Build shared packages first
+WORKDIR /app/packages/db-types
+RUN pnpm build
+WORKDIR /app/packages/types
+RUN pnpm build
+WORKDIR /app/packages/lists-db
+RUN pnpm build
+
+# Build lists-api
+WORKDIR /app/apps/pops-lists-api
+RUN pnpm build
+
+# Create standalone deployment (production deps only, no symlinks)
+RUN pnpm --filter @pops/lists-api deploy --prod --legacy /app/deploy
+
+FROM node:22-slim
+WORKDIR /app
+RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder --chown=node:node /app/deploy ./
+COPY --from=builder --chown=node:node /app/apps/pops-lists-api/dist ./dist
+
+# Bundled migrations so openListsDb's import.meta.url-relative
+# `migrations/` lookup finds the journal at runtime under the deployed
+# node_modules layout. The opener computes the path from its own module
+# URL (`<pkg>/dist/open-lists-db.js` → `<pkg>/migrations/`), so the
+# folder has to land next to the built dist inside @pops/lists-db.
+COPY --from=builder --chown=node:node /app/packages/lists-db/migrations ./node_modules/@pops/lists-db/migrations
+
+ARG BUILD_VERSION=dev
+ENV BUILD_VERSION=$BUILD_VERSION
+
+EXPOSE 3006
+USER node
+CMD ["node", "dist/server.js"]

--- a/apps/pops-lists-api/package.json
+++ b/apps/pops-lists-api/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@pops/lists-api",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsx watch --clear-screen=false src/server.ts",
+    "start": "node dist/server.js",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@pops/lists-db": "workspace:*",
+    "@pops/types": "workspace:*",
+    "express": "^5.1.0"
+  },
+  "devDependencies": {
+    "@types/express": "^5.0.4",
+    "@types/node": "^25.9.1",
+    "@types/supertest": "^6.0.3",
+    "@vitest/coverage-v8": "^4.1.8",
+    "supertest": "^7.1.4",
+    "tsx": "^4.22.4",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.8"
+  }
+}

--- a/apps/pops-lists-api/src/__tests__/health.test.ts
+++ b/apps/pops-lists-api/src/__tests__/health.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Smoke tests for the lists-api Express app + health probe.
+ *
+ * Boots the app against a per-test temp-dir lists.db (mkdtemp +
+ * cleanup in afterEach) and confirms the `/health` route returns the
+ * agreed `{ ok, pillar, version }` shape.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { openListsDb, type OpenedListsDb } from '@pops/lists-db';
+
+import { createListsApiApp } from '../app.js';
+
+let tmpDir: string;
+let listsDb: OpenedListsDb;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'lists-api-test-'));
+  listsDb = openListsDb(join(tmpDir, 'lists.db'));
+});
+
+afterEach(() => {
+  listsDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('GET /health', () => {
+  it('returns ok + pillar + version', async () => {
+    const app = createListsApiApp({
+      listsDb,
+      version: '0.0.1-test',
+      selfBaseUrl: 'http://localhost:3006',
+    });
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, pillar: 'lists', version: '0.0.1-test' });
+  });
+
+  it('fails closed when the lists handle is closed', async () => {
+    const app = createListsApiApp({
+      listsDb,
+      version: '0.0.1-test',
+      selfBaseUrl: 'http://localhost:3006',
+    });
+    listsDb.raw.close();
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(500);
+  });
+});

--- a/apps/pops-lists-api/src/__tests__/lists-sqlite-path.test.ts
+++ b/apps/pops-lists-api/src/__tests__/lists-sqlite-path.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Resolver tests — guards the precedence chain so future pillar work
+ * doesn't accidentally drift lists-api away from pops-api's resolver.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { DEFAULT_LISTS_SQLITE_PATH, resolveListsSqlitePath } from '../lists-sqlite-path.js';
+
+const originalListsPath = process.env['LISTS_SQLITE_PATH'];
+const originalSharedPath = process.env['SQLITE_PATH'];
+
+beforeEach(() => {
+  delete process.env['LISTS_SQLITE_PATH'];
+  delete process.env['SQLITE_PATH'];
+});
+
+afterEach(() => {
+  if (originalListsPath === undefined) delete process.env['LISTS_SQLITE_PATH'];
+  else process.env['LISTS_SQLITE_PATH'] = originalListsPath;
+  if (originalSharedPath === undefined) delete process.env['SQLITE_PATH'];
+  else process.env['SQLITE_PATH'] = originalSharedPath;
+});
+
+describe('resolveListsSqlitePath', () => {
+  it('returns LISTS_SQLITE_PATH verbatim when set', () => {
+    process.env['LISTS_SQLITE_PATH'] = '/abs/path/lists.db';
+    expect(resolveListsSqlitePath()).toBe('/abs/path/lists.db');
+  });
+
+  it('derives the path from the shared SQLITE_PATH when LISTS_SQLITE_PATH is unset', () => {
+    process.env['SQLITE_PATH'] = '/opt/pops/data/pops.db';
+    expect(resolveListsSqlitePath()).toBe('/opt/pops/data/lists.db');
+  });
+
+  it('falls back to ./data/lists.db when neither env is set', () => {
+    expect(resolveListsSqlitePath()).toBe(DEFAULT_LISTS_SQLITE_PATH);
+  });
+});

--- a/apps/pops-lists-api/src/__tests__/pillars.test.ts
+++ b/apps/pops-lists-api/src/__tests__/pillars.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Smoke tests for the `GET /pillars` registry endpoint.
+ *
+ * Covers the synthetic-`lists`-entry contract, deduplication when the
+ * env already lists `lists`, and a malformed POPS_PILLARS returning 500
+ * (since the parser is strict by design).
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { openListsDb, type OpenedListsDb } from '@pops/lists-db';
+
+import { createListsApiApp } from '../app.js';
+import { __resetPillarRegistryCache } from '../pillars/registry.js';
+
+let tmpDir: string;
+let listsDb: OpenedListsDb;
+const originalPillars = process.env['POPS_PILLARS'];
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'lists-api-pillars-test-'));
+  listsDb = openListsDb(join(tmpDir, 'lists.db'));
+  delete process.env['POPS_PILLARS'];
+  __resetPillarRegistryCache();
+});
+
+afterEach(() => {
+  listsDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+  if (originalPillars === undefined) delete process.env['POPS_PILLARS'];
+  else process.env['POPS_PILLARS'] = originalPillars;
+  __resetPillarRegistryCache();
+});
+
+function makeApp(): ReturnType<typeof createListsApiApp> {
+  return createListsApiApp({
+    listsDb,
+    version: '0.0.1-test',
+    selfBaseUrl: 'http://lists-api:3006',
+  });
+}
+
+describe('GET /pillars', () => {
+  it('returns the synthetic lists entry when POPS_PILLARS is unset', async () => {
+    const res = await request(makeApp()).get('/pillars');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      pillars: [{ id: 'lists', baseUrl: 'http://lists-api:3006' }],
+    });
+  });
+
+  it('merges the synthetic lists entry ahead of POPS_PILLARS-parsed siblings', async () => {
+    process.env['POPS_PILLARS'] =
+      'inventory:http://inventory-api:3002,finance:http://finance-api:3004';
+    const res = await request(makeApp()).get('/pillars');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      pillars: [
+        { id: 'lists', baseUrl: 'http://lists-api:3006' },
+        { id: 'inventory', baseUrl: 'http://inventory-api:3002' },
+        { id: 'finance', baseUrl: 'http://finance-api:3004' },
+      ],
+    });
+  });
+
+  it('overrides a POPS_PILLARS `lists` entry with the live selfBaseUrl', async () => {
+    process.env['POPS_PILLARS'] = 'lists:http://stale-lists:9000,finance:http://finance-api:3004';
+    const res = await request(makeApp()).get('/pillars');
+    expect(res.body).toEqual({
+      pillars: [
+        { id: 'lists', baseUrl: 'http://lists-api:3006' },
+        { id: 'finance', baseUrl: 'http://finance-api:3004' },
+      ],
+    });
+  });
+
+  it('returns 500 on a malformed POPS_PILLARS', async () => {
+    process.env['POPS_PILLARS'] = 'no-colon-here';
+    const res = await request(makeApp()).get('/pillars');
+    expect(res.status).toBe(500);
+  });
+
+  it('rejects a POPS_PILLARS entry with a path/query/fragment', async () => {
+    process.env['POPS_PILLARS'] = 'inventory:http://inventory-api:3002/api';
+    const res = await request(makeApp()).get('/pillars');
+    expect(res.status).toBe(500);
+  });
+
+  it('strips a trailing slash from a clean origin', async () => {
+    process.env['POPS_PILLARS'] = 'inventory:http://inventory-api:3002/';
+    const res = await request(makeApp()).get('/pillars');
+    expect(res.status).toBe(200);
+    expect(res.body.pillars).toContainEqual({
+      id: 'inventory',
+      baseUrl: 'http://inventory-api:3002',
+    });
+  });
+});

--- a/apps/pops-lists-api/src/app.ts
+++ b/apps/pops-lists-api/src/app.ts
@@ -1,0 +1,31 @@
+/**
+ * Express app factory for the lists pillar container.
+ *
+ * Phase 3 PR 1 of the lists pillar migration scaffolds the minimal
+ * `/health` + `/pillars` surface so the new container can be wired
+ * into docker-compose and Watchtower without depending on the
+ * (still-unfinished) tRPC + URI-dispatcher migration. Subsequent PRs
+ * mount the URI dispatcher and pillar tRPC routers. Kept as a factory
+ * so the test suite can spin up an in-process `supertest` instance
+ * without binding a real port.
+ */
+import express, { type Express, type Request, type Response } from 'express';
+
+import { type ListsApiDeps, makeRequestHandler } from './handlers.js';
+
+export function createListsApiApp(deps: ListsApiDeps): Express {
+  const app = express();
+  app.disable('x-powered-by');
+
+  const handlers = makeRequestHandler(deps);
+
+  app.get('/health', (_req: Request, res: Response) => {
+    res.json(handlers.health());
+  });
+
+  app.get('/pillars', (_req: Request, res: Response) => {
+    res.json(handlers.pillars());
+  });
+
+  return app;
+}

--- a/apps/pops-lists-api/src/handlers.ts
+++ b/apps/pops-lists-api/src/handlers.ts
@@ -1,0 +1,53 @@
+/**
+ * Request handlers for the lists pillar container.
+ *
+ * Logic lives here (not inline in `app.ts`) so tests can call into the
+ * shape directly without booting Express. Phase 3 PR 1 ships the
+ * `/health` + `/pillars` probes; subsequent PRs add the URI dispatcher
+ * (`POST /uri/resolve`) and tRPC routers.
+ */
+import { getPillarRegistry } from './pillars/registry.js';
+
+import type { OpenedListsDb } from '@pops/lists-db';
+import type { PillarRegistryEntry } from '@pops/types';
+
+export interface ListsApiDeps {
+  /** Open handle to the lists pillar's SQLite. */
+  listsDb: OpenedListsDb;
+  /** Semver of the build, surfaced on the health response. */
+  version: string;
+  /**
+   * HTTP origin lists-api is reachable at. Surfaced as the synthetic
+   * `lists` entry in `GET /pillars` so consumers don't have to
+   * special-case the host pillar.
+   */
+  selfBaseUrl: string;
+}
+
+export interface HealthResponse {
+  ok: true;
+  pillar: 'lists';
+  version: string;
+}
+
+export interface PillarsResponse {
+  pillars: readonly PillarRegistryEntry[];
+}
+
+export function makeRequestHandler(deps: ListsApiDeps): {
+  health(): HealthResponse;
+  pillars(): PillarsResponse;
+} {
+  return {
+    health(): HealthResponse {
+      // Touch the DB so a closed handle surfaces as a thrown error
+      // (caught by the Express error pipeline -> 500) rather than a
+      // bogus 200 OK that hides a broken connection.
+      deps.listsDb.raw.prepare('SELECT 1').get();
+      return { ok: true, pillar: 'lists', version: deps.version };
+    },
+    pillars(): PillarsResponse {
+      return { pillars: getPillarRegistry({ selfBaseUrl: deps.selfBaseUrl }) };
+    },
+  };
+}

--- a/apps/pops-lists-api/src/lists-sqlite-path.ts
+++ b/apps/pops-lists-api/src/lists-sqlite-path.ts
@@ -1,0 +1,29 @@
+import { dirname, join } from 'node:path';
+
+/**
+ * Standalone resolver for the lists pillar's SQLite path inside the
+ * lists-api container.
+ *
+ * Intentionally NOT imported from `apps/pops-api/src/db/lists-sqlite-path.ts`
+ * — lists-api is supposed to be runnable without pops-api in the
+ * dependency graph. The precedence chain matches pops-api's resolver
+ * so the two processes agree on the location of `lists.db` given the
+ * same env: a deployer who only sets `SQLITE_PATH` (legacy contract)
+ * still ends up with `lists.db` next to `pops.db`.
+ *
+ * Resolution order:
+ *   1. `LISTS_SQLITE_PATH` (absolute or relative).
+ *   2. `<dirname(SQLITE_PATH)>/lists.db` if the shared path is set.
+ *   3. `./data/lists.db` (matches the shared default's `./data/pops.db`).
+ *
+ * Mirrors core-api / inventory-api / media-api / finance-api / cerebrum-api / food-api resolvers.
+ */
+export const DEFAULT_LISTS_SQLITE_PATH = './data/lists.db';
+
+export function resolveListsSqlitePath(): string {
+  const envPath = process.env['LISTS_SQLITE_PATH'];
+  if (envPath) return envPath;
+  const sharedPath = process.env['SQLITE_PATH'];
+  if (sharedPath) return join(dirname(sharedPath), 'lists.db');
+  return DEFAULT_LISTS_SQLITE_PATH;
+}

--- a/apps/pops-lists-api/src/pillars/env.ts
+++ b/apps/pops-lists-api/src/pillars/env.ts
@@ -1,0 +1,116 @@
+/**
+ * `POPS_PILLARS` environment variable parser inside the lists-api process.
+ *
+ * Functionally identical to `apps/pops-food-api/src/pillars/env.ts`
+ * (and the original in `apps/pops-api/src/modules/core/pillars/env.ts`)
+ * — kept as a local copy so lists-api can boot without a runtime
+ * dependency on pops-api. The implementations should be promoted into
+ * a shared `packages/core-contract` (or `@pops/types`) package once the
+ * pillar split stabilises; until then contract guard tests in pops-api
+ * keep this behaviour pinned.
+ *
+ * Format: `id:baseUrl[,id:baseUrl,...]`
+ *   - `id` lowercase kebab-case pillar slug (`food`, `finance`, …)
+ *   - `baseUrl` fully-qualified http(s) origin (trailing slashes stripped)
+ *   - whitespace around `:` and `,` tolerated
+ *
+ * Strict: malformed input throws rather than silently dropping entries.
+ */
+
+import type { PillarRegistryEntry } from '@pops/types';
+
+const PILLAR_ID_RE = /^[a-z0-9-]+$/;
+
+export interface ParsePillarsEnvOptions {
+  /**
+   * When true (default), empty / undefined input returns an empty registry.
+   * When false, empty input throws — useful for deploys that require
+   * the variable to be set explicitly.
+   */
+  readonly allowEmpty?: boolean;
+}
+
+export class PillarsEnvParseError extends Error {
+  override readonly name = 'PillarsEnvParseError' as const;
+
+  constructor(message: string) {
+    super(`POPS_PILLARS: ${message}`);
+  }
+}
+
+export function parsePillarsEnv(
+  raw: string | undefined,
+  options: ParsePillarsEnvOptions = {}
+): readonly PillarRegistryEntry[] {
+  const { allowEmpty = true } = options;
+  const trimmed = (raw ?? '').trim();
+
+  if (trimmed.length === 0) {
+    if (allowEmpty) return [];
+    throw new PillarsEnvParseError('value is empty');
+  }
+
+  const entries: PillarRegistryEntry[] = [];
+  const seenIds = new Set<string>();
+
+  for (const rawPair of trimmed.split(',')) {
+    const entry = parsePillarEntry(rawPair, seenIds);
+    seenIds.add(entry.id);
+    entries.push(entry);
+  }
+
+  return entries;
+}
+
+function parsePillarEntry(rawPair: string, seenIds: ReadonlySet<string>): PillarRegistryEntry {
+  const pair = rawPair.trim();
+  if (pair.length === 0) {
+    throw new PillarsEnvParseError('empty entry between commas — remove the stray comma or value');
+  }
+  const colon = pair.indexOf(':');
+  if (colon === -1) {
+    throw new PillarsEnvParseError(`entry "${pair}" is missing a colon — expected id:baseUrl`);
+  }
+  const id = pair.slice(0, colon).trim();
+  const baseUrlRaw = pair.slice(colon + 1).trim();
+  if (id.length === 0) {
+    throw new PillarsEnvParseError(`entry "${pair}" is missing the id half`);
+  }
+  if (!PILLAR_ID_RE.test(id)) {
+    throw new PillarsEnvParseError(`id "${id}" is not lowercase kebab-case ([a-z0-9-]+)`);
+  }
+  if (seenIds.has(id)) {
+    throw new PillarsEnvParseError(`duplicate pillar id "${id}"`);
+  }
+  if (baseUrlRaw.length === 0) {
+    throw new PillarsEnvParseError(`entry "${pair}" is missing the baseUrl half`);
+  }
+  return { id, baseUrl: parseBareOrigin(`pillar '${id}'`, baseUrlRaw) };
+}
+
+/**
+ * Parse `raw` as a bare http(s) origin. Throws if it carries a path,
+ * query, or fragment so consumers can append URL paths cleanly without
+ * silently routing through a prefix. Reused by `selfBaseUrl` validation
+ * and the per-entry parser above so both surfaces enforce the same
+ * `PillarRegistryEntry.baseUrl` contract.
+ */
+export function parseBareOrigin(label: string, raw: string): string {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new PillarsEnvParseError(`${label} baseUrl "${raw}" is not a valid URL`);
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new PillarsEnvParseError(
+      `${label} baseUrl "${raw}" must use http or https; got ${url.protocol}`
+    );
+  }
+  if ((url.pathname !== '/' && url.pathname !== '') || url.search !== '' || url.hash !== '') {
+    throw new PillarsEnvParseError(
+      `${label} baseUrl "${raw}" must be a bare origin (no path, query, or fragment)`
+    );
+  }
+  return url.origin;
+}

--- a/apps/pops-lists-api/src/pillars/registry.ts
+++ b/apps/pops-lists-api/src/pillars/registry.ts
@@ -27,7 +27,7 @@ export interface PillarRegistryOptions {
 
 export function getPillarRegistry(options: PillarRegistryOptions): readonly PillarRegistryEntry[] {
   cached ??= parsePillarsEnv(process.env['POPS_PILLARS']);
-  const normalisedSelf = parseBareOrigin("lists's selfBaseUrl", options.selfBaseUrl);
+  const normalisedSelf = parseBareOrigin('lists-api selfBaseUrl', options.selfBaseUrl);
   const withoutSelf = cached.filter((p) => p.id !== 'lists');
   return [{ id: 'lists', baseUrl: normalisedSelf }, ...withoutSelf];
 }

--- a/apps/pops-lists-api/src/pillars/registry.ts
+++ b/apps/pops-lists-api/src/pillars/registry.ts
@@ -1,0 +1,38 @@
+/**
+ * Pillar registry view served by lists-api.
+ *
+ * Wraps the local copy of `parsePillarsEnv` with a process-level cache
+ * (same pattern pops-api / inventory-api / food-api use). Adds the
+ * synthetic `lists` entry so the shell sees the host pillar in the
+ * `/pillars` listing without having to special-case the call site.
+ */
+import { parseBareOrigin, parsePillarsEnv } from './env.js';
+
+import type { PillarRegistryEntry } from '@pops/types';
+
+let cached: readonly PillarRegistryEntry[] | undefined;
+
+export interface PillarRegistryOptions {
+  /**
+   * HTTP origin lists-api is reachable at. Required — `server.ts`
+   * derives it from `LISTS_SELF_BASE_URL` (or falls back to
+   * `http://localhost:PORT`) before passing it in. The registry
+   * returns this as the synthetic `lists` entry's `baseUrl` after
+   * normalising it through `parseBareOrigin` so callers can always
+   * append `/uri/resolve` etc. without a double-slash or stale path
+   * prefix.
+   */
+  readonly selfBaseUrl: string;
+}
+
+export function getPillarRegistry(options: PillarRegistryOptions): readonly PillarRegistryEntry[] {
+  cached ??= parsePillarsEnv(process.env['POPS_PILLARS']);
+  const normalisedSelf = parseBareOrigin("lists's selfBaseUrl", options.selfBaseUrl);
+  const withoutSelf = cached.filter((p) => p.id !== 'lists');
+  return [{ id: 'lists', baseUrl: normalisedSelf }, ...withoutSelf];
+}
+
+/** Test-only: forget the cached registry so a new `POPS_PILLARS` is re-read. */
+export function __resetPillarRegistryCache(): void {
+  cached = undefined;
+}

--- a/apps/pops-lists-api/src/server.ts
+++ b/apps/pops-lists-api/src/server.ts
@@ -1,0 +1,74 @@
+/**
+ * Entry point for the lists pillar HTTP server.
+ *
+ * Phase 3 PR 1 of the lists pillar migration boots the process with
+ * the minimal `/health` + `/pillars` surface so the new container can
+ * be wired into docker-compose + Watchtower without depending on the
+ * (still-unfinished) tRPC + URI-dispatcher migration.
+ *
+ * The process opens its OWN `lists.db` connection via `openListsDb`
+ * rather than reaching back into pops-api's singleton — that's the
+ * whole point of phase 3.
+ */
+import { openListsDb } from '@pops/lists-db';
+
+import { createListsApiApp } from './app.js';
+import { resolveListsSqlitePath } from './lists-sqlite-path.js';
+import { parseBareOrigin } from './pillars/env.js';
+
+function resolvePort(): number {
+  // 3001 is core-api, 3002 is inventory-api, 3003 is media-api,
+  // 3004 is finance-api, 3005 is food-api, 3006 is lists-api,
+  // 3007 is cerebrum-api.
+  const raw = process.env['PORT'];
+  if (raw === undefined || raw === '') return 3006;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed <= 0 || parsed > 65535) {
+    throw new Error(`[lists-api] PORT must be a positive integer in 1-65535; got '${raw}'`);
+  }
+  return parsed;
+}
+
+const port = resolvePort();
+const version = process.env['BUILD_VERSION'] ?? 'dev';
+// Normalise LISTS_SELF_BASE_URL (or the localhost fallback) through
+// the shared bare-origin parser so a misconfigured env crashes boot
+// loudly instead of publishing an invalid PillarRegistryEntry.baseUrl
+// that breaks downstream consumers appending `/uri/resolve`, `/health`,
+// etc. parseBareOrigin throws a PillarsEnvParseError prefixed with
+// `POPS_PILLARS:` — fine when the parser is consulted from
+// parsePillarsEnv, but misleading when the failing env is actually
+// LISTS_SELF_BASE_URL. Wrap + rethrow with a lists-api-scoped message
+// so operators look at the right env var.
+function resolveSelfBaseUrl(): string {
+  const raw = process.env['LISTS_SELF_BASE_URL'] ?? `http://localhost:${port}`;
+  try {
+    return parseBareOrigin('LISTS_SELF_BASE_URL', raw);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`[lists-api] LISTS_SELF_BASE_URL ${raw} is invalid — ${message}`, {
+      cause: err,
+    });
+  }
+}
+const selfBaseUrl = resolveSelfBaseUrl();
+
+const listsDb = openListsDb(resolveListsSqlitePath());
+const app = createListsApiApp({ listsDb, version, selfBaseUrl });
+
+const server = app.listen(port, () => {
+  console.warn(`[lists-api] Listening on port ${port}`);
+});
+
+let shuttingDown = false;
+function shutdown(signal: NodeJS.Signals): void {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  console.warn(`[lists-api] Shutting down (${signal})`);
+  server.close(() => {
+    listsDb.raw.close();
+  });
+}
+
+process.on('SIGTERM', shutdown);
+process.on('SIGINT', shutdown);

--- a/apps/pops-lists-api/tsconfig.json
+++ b/apps/pops-lists-api/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "sourceMap": true,
+    "types": ["node"]
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/__tests__/**"]
+}

--- a/apps/pops-lists-api/vitest.config.ts
+++ b/apps/pops-lists-api/vitest.config.ts
@@ -1,0 +1,15 @@
+/// <reference types="vitest/config" />
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json-summary', 'html'],
+      reportsDirectory: 'coverage',
+      include: ['src/**/*.ts'],
+      exclude: ['**/node_modules/**', '**/dist/**', '**/*.test.ts'],
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -428,6 +428,43 @@ importers:
         specifier: ^4.1.8
         version: 4.1.8(@types/node@25.9.1)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
 
+  apps/pops-lists-api:
+    dependencies:
+      '@pops/lists-db':
+        specifier: workspace:*
+        version: link:../../packages/lists-db
+      '@pops/types':
+        specifier: workspace:*
+        version: link:../../packages/types
+      express:
+        specifier: ^5.1.0
+        version: 5.2.1
+    devDependencies:
+      '@types/express':
+        specifier: ^5.0.4
+        version: 5.0.6
+      '@types/node':
+        specifier: ^25.9.1
+        version: 25.9.1
+      '@types/supertest':
+        specifier: ^6.0.3
+        version: 6.0.3
+      '@vitest/coverage-v8':
+        specifier: ^4.1.8
+        version: 4.1.8(vitest@4.1.8)
+      supertest:
+        specifier: ^7.1.4
+        version: 7.2.2
+      tsx:
+        specifier: ^4.22.4
+        version: 4.22.4
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@25.9.1)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
+
   apps/pops-mcp:
     dependencies:
       '@modelcontextprotocol/sdk':


### PR DESCRIPTION
## Summary

Scaffolds **`apps/pops-lists-api`** as the lists pillar's standalone HTTP container — first of Phase 3's 2 PRs for Track K. Mirrors the canonical `pops-food-api` shape (#2874) so all six pillar containers share one playbook.

- Express factory exposing `/health` → `{ ok: true, pillar: 'lists', version }` and `/pillars` → passive `POPS_PILLARS` snapshot with synthetic `lists` entry merged ahead of env-parsed siblings.
- Process opens its own `lists.db` via `openListsDb()` from `@pops/lists-db` — no runtime dep on pops-api.
- Local copies of `parsePillarsEnv` + `parseBareOrigin` keep boot independent of pops-api (same pattern food / inventory / finance / media / cerebrum use; promotion into a shared package is tracked as a future follow-up).
- `lists-sqlite-path.ts` resolver mirrors pops-api's precedence chain: `LISTS_SQLITE_PATH` → `<dirname(SQLITE_PATH)>/lists.db` → `./data/lists.db`.
- 11 unit tests across health (happy + closed-handle 500), `/pillars` (synthetic merge, dedupe, malformed-env 500, path/query rejection, trailing-slash strip), and the sqlite-path resolver precedence chain.
- Multi-stage `Dockerfile` with non-root `USER node` + `--chown=node:node`, port **3006** (3001=core, 3002=inventory, 3003=media, 3004=finance, 3005=food, 3006=lists, 3007=cerebrum). Runtime stage copies `packages/lists-db/migrations` into `node_modules/@pops/lists-db/migrations` so the in-package migrator finds the journal under the deployed layout.
- New `lists-api-quality.yml` CI workflow (paths-filter parity); `docker-build.yml` extended to build the new image's builder stage.

## Sibling Phase 3 PR 1s

- inventory — #2798 (port 3002)
- media — #2803 (port 3003)
- finance — #2816 (port 3004)
- cerebrum — #2821 (port 3007)
- food — #2874 (port 3005, most recent canonical)

## Deferred

- **Phase 3 PR 2** — docker-compose dev + prod wiring (`depends_on: lists-api (service_healthy)` from pops-api + pops-worker, `POPS_PILLARS` default extended to include `lists:http://lists-api:3006`, `publish-images.yml` entry for the new image).
- **Phase 4** — `docs/runbooks/lists-api-pillar-verification.md` covering the stop/restart drill, per-route soft-fallback behaviour, the shared-volume caveat (writers still live in pops-api until Phase 5), and the next-deploy backfill retry path.

## Test plan

- [ ] `pnpm typecheck` clean
- [ ] `pnpm --filter @pops/lists-api test` — 11 passing (3 files: health, pillars, lists-sqlite-path)
- [ ] `pnpm build` succeeds
- [ ] `docker build --target builder -f apps/pops-lists-api/Dockerfile .` exercised in CI (`Build pops-lists-api (builder stage)` step)
- [ ] `Lists API Quality` workflow green on the PR
