### PR TITLE
fix(shell): drop URI part from /pillars proxy_pass to satisfy nginx regex-location rule

### DIFF
--- a/apps/pops-shell/nginx.conf
+++ b/apps/pops-shell/nginx.conf
@@ -52,13 +52,15 @@ server {
     # for now because the aggregator probe still depends on its internal
     # service registry; that endpoint moves to core-api when the
     # dispatcher migrates.
-    # Regex match so /pillars and /pillars/ both proxy to core-api
-    # (and similarly for /pillars/health). Exact-match locations would
-    # let a trailing-slash request fall through to the SPA
-    # `try_files ... /index.html`, reintroducing the silent-collapse
-    # behaviour this PR is trying to eliminate.
+    #
+    # Regex match so /pillars and /pillars/ both reach the upstream (and
+    # similarly for /pillars/health). nginx forbids a URI part on
+    # `proxy_pass` inside a regex location, so the upstream is the bare
+    # host:port and the original `$request_uri` flows through unchanged.
+    # Both upstreams are Express with default `strict routing: off` so
+    # the trailing-slash and bare variants hit the same handler.
     location ~ ^/pillars/?$ {
-        proxy_pass http://core-api:3001/pillars;
+        proxy_pass http://core-api:3001;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -70,7 +72,7 @@ server {
     }
 
     location ~ ^/pillars/health/?$ {
-        proxy_pass http://pops-api:3000/pillars/health;
+        proxy_pass http://pops-api:3000;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
## Summary

`pops-shell` has been in a CrashLoopBackoff on every host running the `main` image since #2762 (commit [4677e2ab](https://github.com/knoxio/pops/commit/4677e2ab)). Spotted on `capivara`:

```
NAMES      STATUS
pops-shell Restarting (1) 37 seconds ago   ghcr.io/knoxio/pops-shell:main
```

The container exits because nginx refuses to load the shipped config:

```
[emerg] "proxy_pass" cannot have URI part in location given by regular expression,
or inside named location, or inside "if" statement, or inside "limit_except" block
in /etc/nginx/conf.d/default.conf:61
```

Two regex `location` blocks added by #2762 carry URI parts on `proxy_pass`, which nginx forbids inside regex locations:

```nginx
location ~ ^/pillars/?$        { proxy_pass http://core-api:3001/pillars; ... }
location ~ ^/pillars/health/?$ { proxy_pass http://pops-api:3000/pillars/health; ... }
```

## Fix

Drop the URI part from both upstreams. nginx then forwards the original `$request_uri` unchanged, so `/pillars` and `/pillars/` still reach core-api at the same path. Both upstreams are Express with the default `strict routing: off`, so the trailing-slash and bare variants hit the same handler — the original "handle both slash variants" intent of the regex is preserved.

## Test plan

- [x] `docker run --rm -v $(pwd)/apps/pops-shell/nginx.conf:/etc/nginx/conf.d/default.conf:ro nginx:alpine nginx -t` — original `proxy_pass URI in regex location` emerg is gone (the remaining emerg is the expected DNS-unresolved upstream when not in the compose network).
- [x] `pnpm typecheck` — clean.
- [ ] Post-merge: pull `main` on `capivara`, `docker compose up -d pops-shell`, confirm container goes `Up (healthy)` and `curl http://shell/pillars` returns the core-api registry snapshot.