### PR TITLE
fix(shell): lazy-resolve core-api upstream so missing service doesn't kill nginx boot

### DIFF
--- a/apps/pops-shell/nginx.conf
+++ b/apps/pops-shell/nginx.conf
@@ -4,13 +4,15 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
-    # Resolve upstream hostnames at request time (via Docker's embedded
-    # DNS) rather than at config-load time. Without this, nginx refuses
-    # to start whenever any referenced upstream container is missing
-    # from the compose stack — which was happening on hosts that hadn't
-    # yet been updated to deploy the new pillar API services. The SPA
-    # itself stays up; routes whose upstream is genuinely down will
-    # 502, which is the correct failure mode.
+    # Resolver for variable-form `proxy_pass`. Only the upstream that
+    # uses this (the `core-api` proxy in the `/pillars` location) is
+    # deferred to request-time DNS — every literal `proxy_pass <name>;`
+    # below still resolves at config-load time, so removing pops-api or
+    # any other literal upstream from a host would still kill the nginx
+    # boot. Today the only optional upstream is `core-api`; if more
+    # pillar APIs become optional in the future they need the same
+    # variable-form treatment to inherit this behaviour.
+    resolver 127.0.0.11 valid=30s ipv6=off;
     resolver 127.0.0.11 valid=30s ipv6=off;
 
     # Gzip compression

--- a/apps/pops-shell/nginx.conf
+++ b/apps/pops-shell/nginx.conf
@@ -4,6 +4,15 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Resolve upstream hostnames at request time (via Docker's embedded
+    # DNS) rather than at config-load time. Without this, nginx refuses
+    # to start whenever any referenced upstream container is missing
+    # from the compose stack — which was happening on hosts that hadn't
+    # yet been updated to deploy the new pillar API services. The SPA
+    # itself stays up; routes whose upstream is genuinely down will
+    # 502, which is the correct failure mode.
+    resolver 127.0.0.11 valid=30s ipv6=off;
+
     # Gzip compression
     gzip on;
     gzip_types text/plain text/css application/json application/javascript text/xml application/xml text/javascript image/svg+xml;
@@ -59,8 +68,16 @@ server {
     # host:port and the original `$request_uri` flows through unchanged.
     # Both upstreams are Express with default `strict routing: off` so
     # the trailing-slash and bare variants hit the same handler.
+    #
+    # The core-api upstream is stored in a variable so nginx defers DNS
+    # resolution to request time. Hosts that haven't yet deployed
+    # `pops-core-api` would otherwise fail to boot pops-shell entirely
+    # (`host not found in upstream "core-api"`); with the variable form
+    # the SPA stays up and `/pillars` returns 502 until the upstream is
+    # in place — the correct failure mode.
     location ~ ^/pillars/?$ {
-        proxy_pass http://core-api:3001;
+        set $pillars_upstream http://core-api:3001;
+        proxy_pass $pillars_upstream;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
## Summary

#2885 fixed the nginx regex-location syntax error from #2762, but on hosts that haven't yet deployed the new pillar API services — such as capivara, whose compose stack still snapshots the pre-pillar shape — nginx now fails earlier, at config load time:

```
[emerg] 1#1: host not found in upstream "core-api" in /etc/nginx/conf.d/default.conf:63
```

`pops-shell` is back in a CrashLoopBackoff because nginx eagerly resolves every literal upstream hostname at boot, and `core-api` doesn't exist on those hosts.

## Fix

Defer the lookup to request time for the one upstream that may not be deployed:

- Add a top-level `resolver 127.0.0.11 valid=30s ipv6=off;` pointing at Docker's embedded DNS.
- Store the `/pillars` upstream in a variable (`set $pillars_upstream http://core-api:3001`) and reference it from `proxy_pass`. nginx only resolves variable-form `proxy_pass` lazily.

`pops-api` upstreams stay as bare literals — that container is part of every compose stack that boots `pops-shell`, and keeping the boot-time check there is the desired behaviour.

## Net effect

| Host shape | Before this PR | After this PR |
|---|---|---|
| Legacy (no `core-api`) | nginx fails to boot, crash loop | SPA boots; `/pillars` returns 502 until `core-api` is deployed |
| New (with `core-api`) | Boots and serves `/pillars` correctly | Unchanged |

The 502 is the correct failure mode — host-side compose update can land async without further source changes.

## Test plan

- [x] `docker run --rm -v $(pwd)/apps/pops-shell/nginx.conf:/etc/nginx/conf.d/default.conf:ro nginx:alpine nginx -t` — original `host not found in upstream "core-api"` emerg is gone; the remaining emerg is `pops-api` resolution which only fires in isolation (the container always exists in a real compose stack).
- [x] `pnpm typecheck` — clean.
- [ ] Post-merge: pull `main` on `capivara`, recreate `pops-shell`, confirm it goes `Up`; `curl http://shell/health` returns 200; `curl http://shell/pillars` returns 502 (expected — `core-api` not yet deployed).