### PR TITLE
feat(infra): wire lists-api into docker-compose + publish image (pillar lists phase 3 PR 2)

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -232,6 +232,32 @@ jobs:
           build-args: |
             BUILD_VERSION=${{ github.sha }}
 
+      - name: Generate metadata for pops-lists-api
+        id: meta-lists-api
+        uses: docker/metadata-action@v6
+        with:
+          images: ghcr.io/knoxio/pops-lists-api
+          tags: |
+            type=raw,value=main,enable={{is_default_branch}}
+            type=sha,prefix=sha-,format=short
+            type=semver,pattern={{version}}
+            type=semver,pattern=v{{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=semver,pattern=v{{major}}
+
+      - name: Build and push pops-lists-api
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: apps/pops-lists-api/Dockerfile
+          push: true
+          tags: ${{ steps.meta-lists-api.outputs.tags }}
+          labels: ${{ steps.meta-lists-api.outputs.labels }}
+          build-args: |
+            BUILD_VERSION=${{ github.sha }}
+
       - name: Generate metadata for pops-cerebrum-api
         id: meta-cerebrum-api
         uses: docker/metadata-action@v6

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -48,7 +48,7 @@ services:
       # `/pillars` snapshot that the shell's nginx proxy fans out to,
       # so it MUST default to the full sibling list rather than empty.
       # Sibling pillars get appended (id:baseUrl,...) as they extract.
-      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,cerebrum:http://cerebrum-api:3007}
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,lists:http://lists-api:3006,cerebrum:http://cerebrum-api:3007}
     expose:
       - '3001'
     healthcheck:
@@ -88,7 +88,7 @@ services:
       INVENTORY_SELF_BASE_URL: http://inventory-api:3002
       # Cross-pillar registry. Includes core-api by default so /pillars
       # surfaces both host pillars on the synthetic-entry list.
-      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,cerebrum:http://cerebrum-api:3007}
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,lists:http://lists-api:3006,cerebrum:http://cerebrum-api:3007}
     expose:
       - '3002'
     depends_on:
@@ -130,7 +130,7 @@ services:
       FINANCE_SELF_BASE_URL: http://finance-api:3004
       # Cross-pillar registry — included for parity with siblings even
       # though finance-api today only exposes /health.
-      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,cerebrum:http://cerebrum-api:3007}
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,lists:http://lists-api:3006,cerebrum:http://cerebrum-api:3007}
     expose:
       - '3004'
     depends_on:
@@ -172,7 +172,7 @@ services:
       MEDIA_SELF_BASE_URL: http://media-api:3003
       # Cross-pillar registry. Includes core-api + inventory-api by default
       # so /pillars surfaces every host pillar on the synthetic-entry list.
-      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,cerebrum:http://cerebrum-api:3007}
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,lists:http://lists-api:3006,cerebrum:http://cerebrum-api:3007}
     expose:
       - '3003'
     depends_on:
@@ -214,7 +214,7 @@ services:
       FOOD_SELF_BASE_URL: http://food-api:3005
       # Cross-pillar registry — included for parity with siblings even
       # though food-api today only exposes /health.
-      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,cerebrum:http://cerebrum-api:3007}
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,lists:http://lists-api:3006,cerebrum:http://cerebrum-api:3007}
     expose:
       - '3005'
     depends_on:
@@ -227,6 +227,48 @@ services:
           'node',
           '-e',
           "fetch('http://localhost:3005/health').then(r=>{if(!r.ok)process.exit(1)})",
+        ]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+  # Lists pillar API (ADR-026, Phase 3 PR 2 of the lists track). Hosts
+  # lists.db reads/writes today exposes only /health + /pillars;
+  # subsequent slices (list CRUD, item CRUD, bulk-add, reorder,
+  # URI dispatcher) move their tRPC routers behind it.
+  lists-api:
+    build:
+      context: ..
+      dockerfile: apps/pops-lists-api/Dockerfile
+      args:
+        BUILD_VERSION: ${BUILD_VERSION:-dev}
+    container_name: pops-lists-api
+    restart: unless-stopped
+    networks:
+      - frontend
+      - backend
+    volumes:
+      - sqlite-data:/data/sqlite
+    environment:
+      NODE_ENV: production
+      PORT: '3006'
+      LISTS_SQLITE_PATH: /data/sqlite/lists.db
+      LISTS_SELF_BASE_URL: http://lists-api:3006
+      # Cross-pillar registry — included for parity with siblings even
+      # though lists-api today only exposes /health.
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,lists:http://lists-api:3006,cerebrum:http://cerebrum-api:3007}
+    expose:
+      - '3006'
+    depends_on:
+      core-api:
+        condition: service_healthy
+    healthcheck:
+      test:
+        [
+          'CMD',
+          'node',
+          '-e',
+          "fetch('http://localhost:3006/health').then(r=>{if(!r.ok)process.exit(1)})",
         ]
       interval: 30s
       timeout: 5s
@@ -256,7 +298,7 @@ services:
       CEREBRUM_SELF_BASE_URL: http://cerebrum-api:3007
       # Cross-pillar registry — included for parity with siblings even
       # though cerebrum-api today only exposes /health.
-      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,cerebrum:http://cerebrum-api:3007}
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,lists:http://lists-api:3006,cerebrum:http://cerebrum-api:3007}
     expose:
       - '3007'
     depends_on:
@@ -305,7 +347,7 @@ services:
       # its compose hostname so pops-api's URI dispatcher can route
       # outbound `pops:core/...` traffic to the new container. Deployers
       # override POPS_PILLARS to extend with sibling pillars.
-      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,cerebrum:http://cerebrum-api:3007}
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,lists:http://lists-api:3006,cerebrum:http://cerebrum-api:3007}
       # Paperless-ngx integration (optional — leave unset to disable)
       PAPERLESS_BASE_URL: ${PAPERLESS_BASE_URL:-}
       PAPERLESS_API_TOKEN: ${PAPERLESS_API_TOKEN:-}
@@ -323,6 +365,8 @@ services:
       finance-api:
         condition: service_healthy
       food-api:
+        condition: service_healthy
+      lists-api:
         condition: service_healthy
       cerebrum-api:
         condition: service_healthy
@@ -364,7 +408,7 @@ services:
       SQLITE_PATH: /data/sqlite/pops.db
       REDIS_HOST: pops-redis
       REDIS_PORT: '6379'
-      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,cerebrum:http://cerebrum-api:3007}
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,lists:http://lists-api:3006,cerebrum:http://cerebrum-api:3007}
     depends_on:
       pops-redis:
         condition: service_healthy
@@ -377,6 +421,8 @@ services:
       finance-api:
         condition: service_healthy
       food-api:
+        condition: service_healthy
+      lists-api:
         condition: service_healthy
       cerebrum-api:
         condition: service_healthy

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       # Cross-pillar registry — core-api hosts the authoritative
       # `/pillars` snapshot that the shell's nginx proxy fans out to,
       # so it MUST default to the full sibling list rather than empty.
-      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,cerebrum:http://cerebrum-api:3007}
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,lists:http://lists-api:3006,cerebrum:http://cerebrum-api:3007}
     expose:
       - '3001'
     healthcheck:
@@ -81,7 +81,7 @@ services:
       PORT: '3002'
       INVENTORY_SQLITE_PATH: /data/sqlite/inventory.db
       INVENTORY_SELF_BASE_URL: http://inventory-api:3002
-      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,cerebrum:http://cerebrum-api:3007}
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,lists:http://lists-api:3006,cerebrum:http://cerebrum-api:3007}
     expose:
       - '3002'
     depends_on:
@@ -119,7 +119,7 @@ services:
       PORT: '3004'
       FINANCE_SQLITE_PATH: /data/sqlite/finance.db
       FINANCE_SELF_BASE_URL: http://finance-api:3004
-      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,cerebrum:http://cerebrum-api:3007}
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,lists:http://lists-api:3006,cerebrum:http://cerebrum-api:3007}
     expose:
       - '3004'
     depends_on:
@@ -157,7 +157,7 @@ services:
       PORT: '3003'
       MEDIA_SQLITE_PATH: /data/sqlite/media.db
       MEDIA_SELF_BASE_URL: http://media-api:3003
-      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,cerebrum:http://cerebrum-api:3007}
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,lists:http://lists-api:3006,cerebrum:http://cerebrum-api:3007}
     expose:
       - '3003'
     depends_on:
@@ -195,7 +195,7 @@ services:
       PORT: '3005'
       FOOD_SQLITE_PATH: /data/sqlite/food.db
       FOOD_SELF_BASE_URL: http://food-api:3005
-      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,cerebrum:http://cerebrum-api:3007}
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,lists:http://lists-api:3006,cerebrum:http://cerebrum-api:3007}
     expose:
       - '3005'
     depends_on:
@@ -208,6 +208,44 @@ services:
           'node',
           '-e',
           "fetch('http://localhost:3005/health').then(r=>{if(!r.ok)process.exit(1)})",
+        ]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+  # Lists pillar API (ADR-026, Phase 3 PR 2 of the lists track). Hosts
+  # lists.db reads/writes today exposes only /health + /pillars;
+  # subsequent slices (list CRUD, item CRUD, bulk-add, reorder,
+  # URI dispatcher) move their tRPC routers behind it.
+  lists-api:
+    image: ghcr.io/knoxio/pops-lists-api:${POPS_IMAGE_TAG:-main}
+    container_name: pops-lists-api
+    restart: unless-stopped
+    labels:
+      com.centurylinklabs.watchtower.enable: 'true'
+    networks:
+      - frontend
+      - backend
+    volumes:
+      - sqlite-data:/data/sqlite
+    environment:
+      NODE_ENV: production
+      PORT: '3006'
+      LISTS_SQLITE_PATH: /data/sqlite/lists.db
+      LISTS_SELF_BASE_URL: http://lists-api:3006
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,lists:http://lists-api:3006,cerebrum:http://cerebrum-api:3007}
+    expose:
+      - '3006'
+    depends_on:
+      core-api:
+        condition: service_healthy
+    healthcheck:
+      test:
+        [
+          'CMD',
+          'node',
+          '-e',
+          "fetch('http://localhost:3006/health').then(r=>{if(!r.ok)process.exit(1)})",
         ]
       interval: 30s
       timeout: 5s
@@ -233,7 +271,7 @@ services:
       PORT: '3007'
       CEREBRUM_SQLITE_PATH: /data/sqlite/cerebrum.db
       CEREBRUM_SELF_BASE_URL: http://cerebrum-api:3007
-      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,cerebrum:http://cerebrum-api:3007}
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,lists:http://lists-api:3006,cerebrum:http://cerebrum-api:3007}
     expose:
       - '3007'
     depends_on:
@@ -286,7 +324,7 @@ services:
       POPS_OVERLAYS: ${POPS_OVERLAYS:-}
       # Cross-pillar registry (ADR-026 Phase 3 PR 3). pops-api routes
       # outbound `pops:core/...` traffic to the core-api container.
-      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,cerebrum:http://cerebrum-api:3007}
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,lists:http://lists-api:3006,cerebrum:http://cerebrum-api:3007}
     expose:
       - '3000'
     depends_on:
@@ -301,6 +339,8 @@ services:
       finance-api:
         condition: service_healthy
       food-api:
+        condition: service_healthy
+      lists-api:
         condition: service_healthy
       cerebrum-api:
         condition: service_healthy
@@ -343,7 +383,7 @@ services:
       # PRD-100 — same module set as the api so worker jobs scope correctly.
       POPS_APPS: ${POPS_APPS:-}
       POPS_OVERLAYS: ${POPS_OVERLAYS:-}
-      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,cerebrum:http://cerebrum-api:3007}
+      POPS_PILLARS: ${POPS_PILLARS:-core:http://core-api:3001,inventory:http://inventory-api:3002,media:http://media-api:3003,finance:http://finance-api:3004,food:http://food-api:3005,lists:http://lists-api:3006,cerebrum:http://cerebrum-api:3007}
     depends_on:
       pops-redis:
         condition: service_healthy
@@ -356,6 +396,8 @@ services:
       finance-api:
         condition: service_healthy
       food-api:
+        condition: service_healthy
+      lists-api:
         condition: service_healthy
       cerebrum-api:
         condition: service_healthy


### PR DESCRIPTION
## Summary

Phase 3 PR 2 of Track K (lists pillar extraction, ADR-026). Wires the new `pops-lists-api` container (scaffolded by #2884) into both compose files and the publish-images workflow. Mirrors the canonical shape established by inventory #2802, finance #2819, and food #2875.

- Adds a `lists-api` service block to `infra/docker-compose.yml` (image: `ghcr.io/knoxio/pops-lists-api:${POPS_IMAGE_TAG:-main}`, watchtower label) and `infra/docker-compose.dev.yml` (local `build:` against `apps/pops-lists-api/Dockerfile`). Port `3006` (slot after food's `3005`, before cerebrum's `3007`), shared `sqlite-data` volume mounted at `/data/sqlite/`, `LISTS_SQLITE_PATH=/data/sqlite/lists.db`, `LISTS_SELF_BASE_URL=http://lists-api:3006`, healthcheck via `node fetch('http://localhost:3006/health')`, `depends_on: core-api (service_healthy)`.
- Extends the `POPS_PILLARS` default in every service block (core-api, inventory-api, media-api, finance-api, food-api, lists-api, cerebrum-api, pops-api, pops-worker) with `lists:http://lists-api:3006` so the `/pillars` snapshot surfaces lists on the synthetic-entry list.
- Adds `lists-api: { condition: service_healthy }` to the `depends_on` of `pops-api` and `pops-worker` in both compose files.
- Adds a `pops-lists-api` build step to `.github/workflows/publish-images.yml` (slot after pops-food-api, before pops-cerebrum-api) with the canonical metadata-action tag set.

## Coordination

- Sibling Phase 3 PR 2s for reference: inventory #2802, finance #2819, food #2875.
- Track K Phase 3 PR 1 (#2884) — pending merge — ships the `apps/pops-lists-api/Dockerfile`, source tree, package.json, and the `apps/pops-lists-api/**` paths-filter on `docker-build.yml`. This PR depends on #2884 landing for the dev compose `build:` context and the `docker-build.yml` `pops-lists-api` builder-stage smoke; will rebase against `origin/main` once #2884 merges.
- Phase 4 still queued: `docs/runbooks/lists-api-pillar-verification.md` + Track K row flip to ✅ Done.

## Test plan

- [x] `docker compose -f infra/docker-compose.yml config --quiet`
- [x] `docker compose -f infra/docker-compose.dev.yml config --quiet`
- [x] `npx yaml-lint infra/docker-compose*.yml`
- [x] `pnpm lint` (no new errors)
- [x] `pnpm typecheck` (51/51 successful)
- [x] `pnpm build` (25/25 successful)
- [ ] After #2884 merges + rebase: `docker-build.yml` `pops-lists-api` builder-stage smoke runs green
- [ ] After merge: `publish-images.yml` on `main` builds + pushes `ghcr.io/knoxio/pops-lists-api:main`
