### PR TITLE
docs(runbook): lists-api pillar verification drill + Track K Done flip (pillar lists phase 4)

### DIFF
--- a/docs/runbooks/lists-api-pillar-verification.md
+++ b/docs/runbooks/lists-api-pillar-verification.md
@@ -1,0 +1,134 @@
+# Lists API Pillar Verification Runbook
+
+Verification drill for the **lists pillar** container after the ADR-026 Phase 3 migration. Run this before flipping Track K of the migration roadmap to ✅ Done.
+
+## What lists-api owns today
+
+After lists pillar Phase 3:
+
+- `apps/pops-lists-api/` ships as `ghcr.io/knoxio/pops-lists-api`, listens on port 3006 inside the container network (3001=core, 3002=inventory, 3003=media, 3004=finance, 3005=food, 3006=lists, 3007=cerebrum).
+- Endpoints exposed: `GET /health` (touches the DB so a closed handle fails closed with a 500) and `GET /pillars` (passive snapshot of `POPS_PILLARS` with the synthetic `lists` entry merged in / overriding any stale row in the env).
+- `lists.db` (separate SQLite file from `pops.db`, `core.db`, `inventory.db`, `media.db`, `finance.db`, `food.db`, and `cerebrum.db`) holds the `lists` and `list_items` tables today. Phase 2 PR 3 cut pops-api over to `getListsDrizzle()` for every lists module read/write (`lists.list.*` + `lists.items.*`).
+- The shell talks to lists **indirectly** via pops-api's tRPC routers (which now route through `lists.db`). The shell never opens a direct browser-to-lists-api connection; cross-pillar HTTP fan-out runs on the `/pillars/health` aggregator already proxied to pops-api.
+- `pops-api`, `pops-worker`, and `pops-shell` (via nginx → core-api) all read pillar registry data that includes the lists entry, because `POPS_PILLARS` in docker-compose lists `lists:http://lists-api:3006`.
+
+## Drill: simulate a lists-api outage
+
+The Phase 4 verification per the roadmap: stop the lists container and confirm the rest of the stack behaves as documented.
+
+### Step 1 — capture the healthy baseline
+
+`lists-api` is exposed inside the compose network (`expose: 3006`), not
+bound to a host port. Run the probes from inside the network — either
+via `docker compose exec` on a sibling service or with an ad-hoc curl
+container:
+
+```sh
+docker compose -f infra/docker-compose.yml ps
+# cerebrum-api, core-api, finance-api, food-api, inventory-api,
+# lists-api, media-api, pops-api, pops-shell, pops-worker should all be
+# "running (healthy)".
+
+# Probe from inside the compose network.
+docker compose -f infra/docker-compose.yml exec pops-api \
+  node -e "fetch('http://lists-api:3006/health').then(r=>r.json()).then(j=>console.log(JSON.stringify(j)))"
+# {"ok":true,"pillar":"lists","version":"<git-sha>"}
+
+docker compose -f infra/docker-compose.yml exec pops-api \
+  node -e "fetch('http://lists-api:3006/pillars').then(r=>r.json()).then(j=>console.log(JSON.stringify(j)))"
+# {"pillars":[{"id":"lists","baseUrl":"http://lists-api:3006"}, ...]}
+
+# The shell's /pillars proxy is wired to core-api, which surfaces lists
+# in its registry response too via POPS_PILLARS:
+curl -sS http://localhost:80/pillars
+# {"pillars":[{"id":"core","baseUrl":"http://core-api:3001"},
+#   ...,
+#   {"id":"lists","baseUrl":"http://lists-api:3006"},
+#   ...]}
+```
+
+### Step 2 — stop lists-api and observe
+
+```sh
+docker compose -f infra/docker-compose.yml stop lists-api
+```
+
+Expected behaviour:
+
+- `pops-api` was started behind `depends_on: lists-api (service_healthy)` — it keeps running, but **every lists tRPC call now flows through `getListsDrizzle()` in pops-api**, which opens / reuses a connection to `lists.db` on a shared volume. The lists-api container being stopped does NOT close the volume mount or the SQLite file, so `lists.list.*` and `lists.items.*` reads/writes continue to land on `lists.db` directly via pops-api's handle. The stop drill is therefore a soft test of compose ordering, not a real outage of the data layer. **To truly simulate an outage**, also unmount or move `lists.db` aside. Phase 5 (cross-pillar URI dispatch + true container isolation) will move the writers into lists-api so stopping its container fully simulates an outage.
+- `pops-shell` boot probe to `/pillars` still succeeds (because the proxy hits core-api, not lists-api). The lists entry stays in the registry; the `/pillars/health` aggregator (still on pops-api) flips lists's status from `'healthy'` to `'unavailable'` after the per-probe timeout fires. `PillarGuard` reads `'unavailable'` and shows the unavailable placeholder on lists routes; other routes (core, finance, inventory, media, food, cerebrum) keep working.
+- The soft fallback is intentional — losing the lists pillar should NOT take down the whole shell. The shell shows degraded UI on lists routes and full UI everywhere else.
+
+### Step 3 — restart lists-api and confirm recovery
+
+```sh
+docker compose -f infra/docker-compose.yml start lists-api
+```
+
+Within ~30s the healthcheck reports healthy. Re-running the probes in Step 1 returns the same shapes. `PillarGuard` re-promotes lists from `'unavailable'` back to `'healthy'` on the next status-context refresh; the lists UI hydrates without a hard navigation.
+
+### Step 4 — verify the boot-time backfill is idempotent
+
+`backfillListsFromShared()` (in `apps/pops-api/src/db/backfill-lists-from-shared.ts`) carries `lists` + `list_items` rows from the legacy `pops.db` into `lists.db` at boot, in FK-safe order (parent `lists` first, children `list_items` second — `list_items.list_id` has `foreign_keys = ON` and the child INSERT requires the parent row to exist). Each table copy uses an explicit `WHERE id NOT IN (...)` filter and is wrapped in `tryCopyTable` so a missing source table on a stale on-disk `pops.db` (post-PR-4 drop scenario, or a partial post-cutover cleanup) is non-fatal — the failure is logged and swallowed, the next deploy retries, and the idempotent filter picks up only the still-missing rows.
+
+The drill:
+
+```sh
+# Restart pops-api a second time after step 3.
+docker compose -f infra/docker-compose.yml restart pops-api
+
+# Inspect the row counts in both DBs. The backfill is idempotent via
+# the per-table `WHERE id NOT IN (...)` filter — re-running must not
+# duplicate rows.
+docker compose -f infra/docker-compose.yml exec pops-api \
+  node -e "
+const Database = require('better-sqlite3');
+const a = new Database('/data/sqlite/lists.db', { readonly: true });
+const b = new Database('/data/sqlite/pops.db', { readonly: true });
+const listsLists = a.prepare('SELECT count(*) AS n FROM lists').get().n;
+const listsItems = a.prepare('SELECT count(*) AS n FROM list_items').get().n;
+const sharedLists = b.prepare(
+  \"SELECT count(*) AS n FROM sqlite_master WHERE type='table' AND name='lists'\"
+).get().n
+  ? b.prepare('SELECT count(*) AS n FROM lists').get().n
+  : null;
+const sharedItems = b.prepare(
+  \"SELECT count(*) AS n FROM sqlite_master WHERE type='table' AND name='list_items'\"
+).get().n
+  ? b.prepare('SELECT count(*) AS n FROM list_items').get().n
+  : null;
+console.log({ listsLists, listsItems, sharedLists, sharedItems });
+"
+# Expected: listsLists >= sharedLists AND listsItems >= sharedItems
+# (every row that lives in the shared copy must also live in lists.db;
+# the lists copy may have more rows after the cutover since new writes
+# go there exclusively).
+```
+
+If the backfill encounters a stale on-disk `pops.db` that's already had its `lists` or `list_items` table dropped or renamed (e.g. after a partial post-cutover cleanup, or after the Track L shared-journal cleanup window runs), `tryCopyTable` logs `[db] Lists backfill of <table> failed (non-fatal): <err>` and continues with the remaining table. The next deploy retries the same copy with no duplication risk — the `WHERE id NOT IN (...)` filter is the single source of idempotency. A whole-ATTACH failure (e.g. missing `pops.db` file on disk) is also non-fatal: it logs `[db] Lists backfill ATTACH failed (non-fatal):` and the boot path proceeds.
+
+### Step 5 — write up surprises
+
+Record any unexpected behaviour in the **Lessons captured** section of `.claude/pillar-migration-roadmap.md` before flipping Track K to ✅ Done. That file is gitignored — it only exists in local clones / sibling workspaces, so it isn't linkable from GitHub. Examples worth flagging:
+
+- pops-api hard-crashes when lists-api is down (it shouldn't — should degrade per-route).
+- The shell's "lists unavailable" placeholder paints over working non-lists routes (PillarGuard scoping is too broad).
+- `lists.db` writes succeed against a stopped lists-api container (proves the shared-volume caveat noted in Step 2 — Phase 5 follow-up: convert lists-api to the sole writer once tRPC routers move into it).
+- The boot-time backfill duplicates rows (the `WHERE id NOT IN (...)` filter is supposed to dedupe — a failure here is a real bug).
+- `list_items` backfill runs **before** `lists` and trips the FK (the `TABLE_COPIES` order in `backfill-lists-from-shared.ts` is supposed to enforce parent-first — a failure here means the array got reordered).
+- `lists.list.*` reads return empty on a fresh boot when the shared `pops.db` still has rows (proves the backfill silently skipped — check `pops-api` logs for `[db] Lists backfill of lists failed (non-fatal):` lines and fix the root cause before the next deploy's retry).
+
+## Reference
+
+- ADR-026: per-domain pillar architecture
+- `apps/pops-lists-api/src/server.ts` — boot sequence
+- `apps/pops-api/src/db/lists-handle.ts` — lazy open + env-aware handle
+- `apps/pops-api/src/db/backfill-lists-from-shared.ts` — table-by-table backfill
+- `apps/pops-shell/src/app/pillars/pillar-registry-client.ts` — soft-fallback behaviour (shared with core)
+- `docs/runbooks/core-api-pillar-verification.md` — sibling runbook for the core pillar
+- `docs/runbooks/inventory-api-pillar-verification.md` — sibling runbook for the inventory pillar
+- `docs/runbooks/media-api-pillar-verification.md` — sibling runbook for the media pillar
+- `docs/runbooks/finance-api-pillar-verification.md` — sibling runbook for the finance pillar
+- `docs/runbooks/food-api-pillar-verification.md` — sibling runbook for the food pillar
+- `docs/runbooks/cerebrum-api-pillar-verification.md` — sibling runbook for the cerebrum pillar
+- `.claude/pillar-migration-roadmap.md` — Track K status + lessons captured (gitignored, local-only)


### PR DESCRIPTION
## Summary

Phase 4 verification runbook for the **lists pillar** — closes out Track K and the entire Phase γ primary tracker. Mirrors the canonical `pops-food-api` shape ([#2876](https://github.com/knoxio/pops/pull/2876)).

`docs/runbooks/lists-api-pillar-verification.md` documents:

- Stop/restart drill against `pops-lists-api` (port 3006, exposed inside the compose network).
- Expected per-route soft-fallback behaviour — `PillarGuard` scopes `'unavailable'` to lists routes only; core / finance / inventory / media / food / cerebrum keep working.
- Shared-volume caveat — pops-api still writes to `lists.db` directly via `getListsDrizzle()` until the Phase 5 writer-move, so the stop drill is a soft test of compose ordering rather than a true data-layer outage.
- Next-deploy retry path for the boot-time backfill: `backfillListsFromShared()` is idempotent via `WHERE id NOT IN (...)` on every table, FK-safe parent-first order (`lists` before `list_items`), and `tryCopyTable` swallows missing-source-table errors so a stale on-disk `pops.db` never bricks boot.

## Prior Track K PRs

- **Phase 1** — [#2877](https://github.com/knoxio/pops/pull/2877) `e4a13aab` (scaffold), [#2879](https://github.com/knoxio/pops/pull/2879) `fad4f238` (consumer flip), [#2881](https://github.com/knoxio/pops/pull/2881) `2d115e28` (shim deletion).
- **Phase 2** — [#2878](https://github.com/knoxio/pops/pull/2878) `71c245e6` (`openListsDb` helper), [#2880](https://github.com/knoxio/pops/pull/2880) `86ad2b96` (boot-time open + `LISTS_SQLITE_PATH`), [#2883](https://github.com/knoxio/pops/pull/2883) `d8e85e42` (module cutover + ATTACH backfill), [#2882](https://github.com/knoxio/pops/pull/2882) `03f90549` (Litestream + AGENTS.md).
- **Phase 3** — [#2884](https://github.com/knoxio/pops/pull/2884) (`pops-lists-api` scaffold), Phase 3 PR 2 sibling on `feat/lists-api-compose-phase-3-pr-2` (compose wiring + `publish-images.yml`).
- **Phase 4** — this PR.

## Phase γ closure

Track K is the final pillar in the primary tracker. With this PR merged, **all six pillar tracks (core, inventory, media, finance, cerebrum, food, lists) are ✅ Done through Phase 4**. Track M (Phase 5 cross-pillar URI dispatch + writer-moves into each pillar's own container) is now unblocked across every pillar.

Roadmap row K flipped from `🔄` to `✅ Done` in `.claude/pillar-migration-roadmap.md` (gitignored, local-only) with the full Phase 1/2/3/4 PR ledger appended.

## Merge prerequisite

This PR is authored against `origin/main`. Final merge requires Phase 3 PR 2 (lists-api compose wiring) on main first so the runbook's `docker compose` references resolve. The runbook content itself describes the post-PR-2 state; merging it before the compose wiring lands would document a non-existent service.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (warnings only, all pre-existing)
- [x] `pnpm build` clean
- [ ] Sibling runbook cross-references render correctly on GitHub
- [ ] Verify Phase 3 PR 2 is on main before final merge
