### PR TITLE
feat(core-api): move service-accounts router into pops-core-api (Track M1 PR 1)

### DIFF
--- a/apps/pops-core-api/package.json
+++ b/apps/pops-core-api/package.json
@@ -14,11 +14,15 @@
   "dependencies": {
     "@pops/core-db": "workspace:*",
     "@pops/types": "workspace:*",
+    "@trpc/server": "^11.17.0",
     "express": "^5.1.0",
-    "pino": "^10.3.1"
+    "jsonwebtoken": "^9.0.3",
+    "pino": "^10.3.1",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/express": "^5.0.4",
+    "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^25.9.1",
     "@types/supertest": "^6.0.3",
     "@vitest/coverage-v8": "^4.1.8",

--- a/apps/pops-core-api/src/__tests__/service-accounts.test.ts
+++ b/apps/pops-core-api/src/__tests__/service-accounts.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Integration tests for the migrated `core.serviceAccounts.*` tRPC
+ * surface inside pops-core-api (Phase 5 PR 1 / Track M1).
+ *
+ * Two layers of coverage:
+ *
+ *   1. tRPC caller smoke — drives `appRouter.createCaller(ctx)` against
+ *      a per-test in-memory core.db. Asserts the same shape contract the
+ *      legacy pops-api router enforced (mint → list → revoke flow, then
+ *      duplicate-name → BAD_REQUEST, unknown revoke → NOT_FOUND, double
+ *      revoke → CONFLICT, scope enforcement for service-account callers).
+ *
+ *   2. HTTP wire smoke — boots the Express app via `createCoreApiApp`
+ *      and round-trips one mutation over `/trpc` with supertest. Proves
+ *      `createExpressMiddleware` is wired up, the context factory reads
+ *      `X-API-Key` headers, and the user-only gate kicks in.
+ *
+ * Service-layer invariants (CRUD, FIFO, key hashing) already live in
+ * `packages/core-db/src/__tests__/` — duplicating them here would just
+ * test drizzle.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { TRPCError } from '@trpc/server';
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { openCoreDb, type OpenedCoreDb } from '@pops/core-db';
+
+import { createCoreApiApp } from '../app.js';
+import { appRouter } from '../router.js';
+import { type Context } from '../trpc.js';
+
+let tmpDir: string;
+let coreDb: OpenedCoreDb;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'core-api-sa-test-'));
+  coreDb = openCoreDb(join(tmpDir, 'core.db'));
+});
+
+afterEach(() => {
+  coreDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function userCaller(email = 'admin@example.com'): ReturnType<typeof appRouter.createCaller> {
+  const ctx: Context = {
+    user: { email },
+    serviceAccount: null,
+    coreDb: coreDb.db,
+  };
+  return appRouter.createCaller(ctx);
+}
+
+function serviceAccountCaller(scopes: string[]): ReturnType<typeof appRouter.createCaller> {
+  const ctx: Context = {
+    user: null,
+    serviceAccount: { id: 'sa_test', name: 'test-sa', scopes },
+    coreDb: coreDb.db,
+  };
+  return appRouter.createCaller(ctx);
+}
+
+function anonCaller(): ReturnType<typeof appRouter.createCaller> {
+  const ctx: Context = {
+    user: null,
+    serviceAccount: null,
+    coreDb: coreDb.db,
+  };
+  return appRouter.createCaller(ctx);
+}
+
+describe('core.serviceAccounts admin (tRPC caller)', () => {
+  it('lets a human admin mint, list, then revoke a service account', async () => {
+    const admin = userCaller();
+    const created = await admin.core.serviceAccounts.create({
+      name: 'moltbot',
+      scopes: ['cerebrum.ingest', 'cerebrum.query'],
+    });
+    expect(created.plaintextKey).toMatch(/^pops_sa_/);
+    expect(created.createdBy).toBe('admin@example.com');
+
+    const list = await admin.core.serviceAccounts.list();
+    expect(list).toHaveLength(1);
+    expect(list[0]?.name).toBe('moltbot');
+
+    const ack = await admin.core.serviceAccounts.revoke({ id: created.id });
+    expect(ack).toEqual({ ok: true });
+
+    const after = await admin.core.serviceAccounts.list();
+    const [revoked] = after;
+    if (!revoked) throw new Error('expected the revoked row to be returned');
+    expect(revoked.revokedAt).not.toBeNull();
+  });
+
+  it('rejects service-account callers from the admin endpoints', async () => {
+    const sa = serviceAccountCaller(['core.serviceAccounts']);
+    await expect(
+      sa.core.serviceAccounts.create({ name: 'self-mint', scopes: ['core.shell'] })
+    ).rejects.toThrow(TRPCError);
+    await expect(sa.core.serviceAccounts.list()).rejects.toThrow(TRPCError);
+    await expect(sa.core.serviceAccounts.revoke({ id: 'sa_x' })).rejects.toThrow(TRPCError);
+  });
+
+  it('rejects when no principal is present', async () => {
+    const anon = anonCaller();
+    await expect(anon.core.serviceAccounts.list()).rejects.toMatchObject({
+      name: 'TRPCError',
+      code: 'UNAUTHORIZED',
+    });
+  });
+
+  it('rejects duplicate names with a BAD_REQUEST tRPC error', async () => {
+    const admin = userCaller();
+    await admin.core.serviceAccounts.create({ name: 'dup', scopes: ['core.shell'] });
+    await expect(
+      admin.core.serviceAccounts.create({ name: 'dup', scopes: ['core.shell'] })
+    ).rejects.toMatchObject({
+      name: 'TRPCError',
+      code: 'BAD_REQUEST',
+      cause: expect.objectContaining({ name: 'ValidationError' }),
+    });
+  });
+
+  it('rejects unknown revoke targets with a NOT_FOUND tRPC error', async () => {
+    const admin = userCaller();
+    await expect(
+      admin.core.serviceAccounts.revoke({ id: 'sa_does-not-exist' })
+    ).rejects.toMatchObject({
+      name: 'TRPCError',
+      code: 'NOT_FOUND',
+      cause: expect.objectContaining({ name: 'NotFoundError' }),
+    });
+  });
+
+  it('rejects a second revoke with a CONFLICT tRPC error', async () => {
+    const admin = userCaller();
+    const created = await admin.core.serviceAccounts.create({
+      name: 'double-revoke',
+      scopes: ['cerebrum.query'],
+    });
+    await admin.core.serviceAccounts.revoke({ id: created.id });
+    await expect(admin.core.serviceAccounts.revoke({ id: created.id })).rejects.toMatchObject({
+      name: 'TRPCError',
+      code: 'CONFLICT',
+      cause: expect.objectContaining({ statusCode: 409 }),
+    });
+  });
+
+  it('rejects malformed input at the zod boundary', async () => {
+    const admin = userCaller();
+    await expect(
+      admin.core.serviceAccounts.create({ name: 'X', scopes: ['core.shell'] })
+    ).rejects.toMatchObject({
+      name: 'TRPCError',
+      code: 'BAD_REQUEST',
+    });
+    await expect(
+      admin.core.serviceAccounts.create({ name: 'has spaces', scopes: ['core.shell'] })
+    ).rejects.toMatchObject({
+      name: 'TRPCError',
+      code: 'BAD_REQUEST',
+    });
+    await expect(
+      admin.core.serviceAccounts.create({ name: 'no-scopes', scopes: [] })
+    ).rejects.toMatchObject({
+      name: 'TRPCError',
+      code: 'BAD_REQUEST',
+    });
+  });
+});
+
+describe('/trpc HTTP surface', () => {
+  function makeApp(): ReturnType<typeof createCoreApiApp> {
+    return createCoreApiApp({
+      coreDb,
+      version: '0.0.1-test',
+      selfBaseUrl: 'http://localhost:3001',
+    });
+  }
+
+  it('answers core.serviceAccounts.list over HTTP (dev context auto-authenticates)', async () => {
+    const app = makeApp();
+    const res = await request(app).get('/trpc/core.serviceAccounts.list');
+    expect(res.status).toBe(200);
+    expect(res.body.result.data).toEqual([]);
+  });
+
+  it('rejects an unknown but well-shaped X-API-Key by user-only-gating the list endpoint', async () => {
+    const app = makeApp();
+    // A header that passes parseApiKey but does not match any DB row leaves
+    // ctx.serviceAccount === null. In production that would land in the
+    // anonymous branch and bounce as UNAUTHORIZED; in this test context
+    // NODE_ENV !== 'production' so the dev-user fallback authenticates
+    // the caller as a human — which is the only path that admin endpoints
+    // accept anyway. The negative we actually want to lock in here is
+    // "well-shaped key for an unknown prefix never crashes the request
+    // pipeline" — i.e. a clean 200, not a 500.
+    const res = await request(app)
+      .get('/trpc/core.serviceAccounts.list')
+      .set('X-API-Key', 'pops_sa_abcdefgh.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+    expect(res.status).toBe(200);
+    expect(res.body.result.data).toEqual([]);
+  });
+
+  it('rejects a real, in-scope X-API-Key from the userOnly admin endpoint with FORBIDDEN-equivalent UNAUTHORIZED', async () => {
+    const app = makeApp();
+    const admin = userCaller();
+    const created = await admin.core.serviceAccounts.create({
+      name: 'http-roundtrip',
+      scopes: ['core.serviceAccounts'],
+    });
+
+    // Valid service-account principal → ctx.serviceAccount is set, ctx.user
+    // stays null → userOnlyProcedure refuses (the admin surface must never
+    // be reachable from a machine principal, even one that has the
+    // matching scope granted).
+    const res = await request(app)
+      .get('/trpc/core.serviceAccounts.list')
+      .set('X-API-Key', created.plaintextKey);
+    expect(res.status).toBe(401);
+    expect(res.body.error.data.code).toBe('UNAUTHORIZED');
+  });
+});

--- a/apps/pops-core-api/src/__tests__/service-accounts.test.ts
+++ b/apps/pops-core-api/src/__tests__/service-accounts.test.ts
@@ -189,7 +189,7 @@ describe('/trpc HTTP surface', () => {
     expect(res.body.result.data).toEqual([]);
   });
 
-  it('rejects an unknown but well-shaped X-API-Key by user-only-gating the list endpoint', async () => {
+  it('does not crash when handed a well-shaped X-API-Key that matches no DB row', async () => {
     const app = makeApp();
     // A header that passes parseApiKey but does not match any DB row leaves
     // ctx.serviceAccount === null. In production that would land in the
@@ -206,7 +206,7 @@ describe('/trpc HTTP surface', () => {
     expect(res.body.result.data).toEqual([]);
   });
 
-  it('rejects a real, in-scope X-API-Key from the userOnly admin endpoint with FORBIDDEN-equivalent UNAUTHORIZED', async () => {
+  it('rejects service-account principals from userOnly admin endpoints with UNAUTHORIZED', async () => {
     const app = makeApp();
     const admin = userCaller();
     const created = await admin.core.serviceAccounts.create({

--- a/apps/pops-core-api/src/app.ts
+++ b/apps/pops-core-api/src/app.ts
@@ -1,22 +1,27 @@
 /**
  * Express app factory for the core pillar container.
  *
- * Phase 3 PR 2 of the core pillar migration adds the pillar registry
+ * Phase 3 PR 2 of the core pillar migration added the pillar registry
  * snapshot endpoint (`GET /pillars`) alongside the existing `/health`
- * probe. The dispatcher (`POST /uri/resolve`) + tRPC routers land in
- * subsequent PRs. Kept as a factory so the test suite can spin up an
- * in-process `supertest` instance without binding a real port.
+ * probe. Phase 5 PR 1 (Track M1) wires the tRPC handler at `/trpc` with
+ * the migrated `core.serviceAccounts.*` admin procedures backed by
+ * `@pops/core-db` directly.
+ *
+ * The dispatcher (`POST /uri/resolve`) lands in a subsequent PR. Kept as
+ * a factory so the test suite can spin up an in-process `supertest`
+ * instance without binding a real port.
  */
+import { createExpressMiddleware } from '@trpc/server/adapters/express';
 import express, { type Express, type Request, type Response } from 'express';
 
 import { type CoreApiDeps, makeRequestHandler } from './handlers.js';
+import { appRouter } from './router.js';
+import { createCoreTrpcContextFactory } from './trpc.js';
 
 export function createCoreApiApp(deps: CoreApiDeps): Express {
   const app = express();
   app.disable('x-powered-by');
 
-  // Build the handler shape once at factory time so static deps don't
-  // get re-allocated on every request.
   const handlers = makeRequestHandler(deps);
 
   app.get('/health', (_req: Request, res: Response) => {
@@ -26,6 +31,14 @@ export function createCoreApiApp(deps: CoreApiDeps): Express {
   app.get('/pillars', (_req: Request, res: Response) => {
     res.json(handlers.pillars());
   });
+
+  app.use(
+    '/trpc',
+    createExpressMiddleware({
+      router: appRouter,
+      createContext: createCoreTrpcContextFactory(deps.coreDb.db),
+    })
+  );
 
   return app;
 }

--- a/apps/pops-core-api/src/middleware/cloudflare-jwt.ts
+++ b/apps/pops-core-api/src/middleware/cloudflare-jwt.ts
@@ -1,0 +1,87 @@
+/**
+ * Cloudflare Access JWT validation.
+ *
+ * Mirrors `apps/pops-api/src/middleware/cloudflare-jwt.ts` because core-api
+ * is supposed to stand alone in the dependency graph — see the standalone
+ * comment in `core-sqlite-path.ts`. A future refactor can lift this into
+ * a shared `@pops/auth` package; for now duplication is the right call
+ * to keep the writer-move PR additive and easy to revert.
+ */
+import jwt from 'jsonwebtoken';
+
+import type { JwtPayload } from 'jsonwebtoken';
+
+export interface CloudflareJWTPayload extends JwtPayload {
+  email: string;
+  aud: string[];
+  iss: string;
+}
+
+interface KeyCache {
+  keys: Record<string, string>;
+  expiresAt: number;
+}
+
+let keyCache: KeyCache | null = null;
+
+async function getCloudflarePublicKeys(): Promise<Record<string, string>> {
+  const now = Date.now();
+  if (keyCache && keyCache.expiresAt > now) {
+    return keyCache.keys;
+  }
+
+  const teamName = process.env['CLOUDFLARE_ACCESS_TEAM_NAME'];
+  if (!teamName) {
+    throw new Error('CLOUDFLARE_ACCESS_TEAM_NAME not configured');
+  }
+
+  const certsUrl = `https://${teamName}.cloudflareaccess.com/cdn-cgi/access/certs`;
+  const response = await fetch(certsUrl);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch Cloudflare certs: ${response.statusText}`);
+  }
+
+  const data = (await response.json()) as {
+    public_certs: Array<{ kid: string; cert: string }>;
+  };
+
+  const keys: Record<string, string> = {};
+  for (const cert of data.public_certs) {
+    keys[cert.kid] = cert.cert;
+  }
+
+  keyCache = {
+    keys,
+    expiresAt: now + 15 * 60 * 1000,
+  };
+  return keys;
+}
+
+export async function verifyCloudflareJWT(token: string): Promise<CloudflareJWTPayload> {
+  const decoded = jwt.decode(token, { complete: true });
+  if (!decoded || typeof decoded === 'string') {
+    throw new Error('Invalid JWT: Unable to decode header');
+  }
+  const kid = decoded.header.kid;
+  if (!kid) {
+    throw new Error('Invalid JWT: Missing kid in header');
+  }
+  const publicKeys = await getCloudflarePublicKeys();
+  const publicKey = publicKeys[kid];
+  if (!publicKey) {
+    throw new Error(`Invalid JWT: Public key not found for kid ${kid}`);
+  }
+
+  const payload = jwt.verify(token, publicKey, {
+    algorithms: ['RS256'],
+  }) as CloudflareJWTPayload;
+
+  const expectedAud = process.env['CLOUDFLARE_ACCESS_AUD'];
+  if (expectedAud && !payload.aud.includes(expectedAud)) {
+    throw new Error('Invalid JWT: Audience mismatch');
+  }
+  if (!payload.email) {
+    throw new Error('Invalid JWT: Missing email claim');
+  }
+  return payload;
+}

--- a/apps/pops-core-api/src/modules/service-accounts/router.ts
+++ b/apps/pops-core-api/src/modules/service-accounts/router.ts
@@ -1,0 +1,81 @@
+/**
+ * Service-accounts admin router — the first writer slice cut over from
+ * pops-api into pops-core-api as part of Phase 5 PR 1 (Track M1).
+ *
+ * Procedure surface is identical to
+ * `apps/pops-api/src/modules/core/service-accounts/router.ts`:
+ *   - `core.serviceAccounts.list`     userOnly  query
+ *   - `core.serviceAccounts.create`   userOnly  mutation
+ *   - `core.serviceAccounts.revoke`   userOnly  mutation
+ *
+ * Domain errors from `@pops/core-db` are translated to local `HttpError`
+ * subclasses and then routed through `mapDomainErrors*` so the tRPC layer
+ * sees a proper `TRPCError` with the right wire-level code.
+ *
+ * Until Phase 5 PR 2 flips the dispatcher / nginx routing rules, the
+ * legacy pops-api router keeps serving real traffic — this one is a
+ * shadow ready to take over.
+ */
+import { z } from 'zod';
+
+import {
+  ServiceAccountAlreadyRevokedError,
+  ServiceAccountNameAlreadyExistsError,
+  ServiceAccountNotFoundError,
+  serviceAccountsService,
+} from '@pops/core-db';
+
+import { ConflictError, NotFoundError, ValidationError } from '../../shared/errors.js';
+import { mapDomainErrors, mapDomainErrorsAsync } from '../../shared/trpc-error-mapper.js';
+import { router, userOnlyProcedure } from '../../trpc.js';
+import {
+  CreateServiceAccountInputSchema,
+  CreatedServiceAccountSchema,
+  ServiceAccountSchema,
+} from './types.js';
+
+export const serviceAccountsRouter = router({
+  list: userOnlyProcedure.output(z.array(ServiceAccountSchema)).query(({ ctx }) => {
+    return serviceAccountsService.listServiceAccounts(ctx.coreDb);
+  }),
+
+  create: userOnlyProcedure
+    .input(CreateServiceAccountInputSchema)
+    .output(CreatedServiceAccountSchema)
+    .mutation(({ input, ctx }) =>
+      mapDomainErrorsAsync(async () => {
+        try {
+          return await serviceAccountsService.createServiceAccount(
+            ctx.coreDb,
+            input,
+            ctx.user.email
+          );
+        } catch (err) {
+          if (err instanceof ServiceAccountNameAlreadyExistsError) {
+            throw new ValidationError({ message: err.message });
+          }
+          throw err;
+        }
+      })
+    ),
+
+  revoke: userOnlyProcedure
+    .input(z.object({ id: z.string().min(1) }))
+    .output(z.object({ ok: z.literal(true) }))
+    .mutation(({ input, ctx }) =>
+      mapDomainErrors(() => {
+        try {
+          serviceAccountsService.revokeServiceAccount(ctx.coreDb, input.id);
+        } catch (err) {
+          if (err instanceof ServiceAccountNotFoundError) {
+            throw new NotFoundError('ServiceAccount', input.id);
+          }
+          if (err instanceof ServiceAccountAlreadyRevokedError) {
+            throw new ConflictError(err.message);
+          }
+          throw err;
+        }
+        return { ok: true as const };
+      })
+    ),
+});

--- a/apps/pops-core-api/src/modules/service-accounts/types.ts
+++ b/apps/pops-core-api/src/modules/service-accounts/types.ts
@@ -1,0 +1,38 @@
+/**
+ * Zod contract schemas for the service-accounts admin router. The shapes
+ * are byte-identical to `apps/pops-api/src/modules/core/service-accounts/types.ts`
+ * — the duplication is intentional during the additive Phase 5 PR 1
+ * window so the legacy pops-api router can keep serving traffic while
+ * core-api stands up its own copy.
+ */
+import { z } from 'zod';
+
+export const ServiceAccountSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  keyPrefix: z.string(),
+  scopes: z.array(z.string()),
+  createdAt: z.string(),
+  lastUsedAt: z.string().nullable(),
+  revokedAt: z.string().nullable(),
+  createdBy: z.string().nullable(),
+});
+
+export type ServiceAccount = z.infer<typeof ServiceAccountSchema>;
+
+export const CreateServiceAccountInputSchema = z.object({
+  name: z
+    .string()
+    .min(3)
+    .max(64)
+    .regex(/^[a-z][a-z0-9_-]*$/, 'lowercase letters, digits, underscore or hyphen'),
+  scopes: z.array(z.string().min(1)).min(1),
+});
+
+export type CreateServiceAccountInput = z.infer<typeof CreateServiceAccountInputSchema>;
+
+export const CreatedServiceAccountSchema = ServiceAccountSchema.extend({
+  plaintextKey: z.string(),
+});
+
+export type CreatedServiceAccount = z.infer<typeof CreatedServiceAccountSchema>;

--- a/apps/pops-core-api/src/router.ts
+++ b/apps/pops-core-api/src/router.ts
@@ -1,0 +1,20 @@
+/**
+ * Root tRPC router for the core pillar container.
+ *
+ * The procedure paths are intentionally rooted at `core.*` so that the
+ * Phase 5 PR 2 dispatcher cutover can be a transparent URL swap rather
+ * than a procedure-path rename: existing pops-api clients call
+ * `core.serviceAccounts.create`, and core-api answers on the same path.
+ */
+import { serviceAccountsRouter } from './modules/service-accounts/router.js';
+import { router } from './trpc.js';
+
+export const coreRouter = router({
+  serviceAccounts: serviceAccountsRouter,
+});
+
+export const appRouter = router({
+  core: coreRouter,
+});
+
+export type AppRouter = typeof appRouter;

--- a/apps/pops-core-api/src/shared/errors.ts
+++ b/apps/pops-core-api/src/shared/errors.ts
@@ -1,0 +1,40 @@
+/**
+ * HTTP-shaped domain errors used by core-api router handlers.
+ *
+ * Intentionally NOT imported from `apps/pops-api/src/shared/errors.ts` —
+ * the per-pillar container is supposed to stand alone of pops-api in the
+ * dependency graph (Phase 5 writer-move pattern). The subset reproduced
+ * here is whatever the migrated routers need; future PRs can grow the
+ * set as more slices move across.
+ */
+export class HttpError extends Error {
+  constructor(
+    public readonly statusCode: number,
+    message: string,
+    public readonly details?: unknown
+  ) {
+    super(message);
+    this.name = 'HttpError';
+  }
+}
+
+export class NotFoundError extends HttpError {
+  constructor(resource: string, id: string) {
+    super(404, `${resource} '${id}' not found`);
+    this.name = 'NotFoundError';
+  }
+}
+
+export class ValidationError extends HttpError {
+  constructor(details: unknown) {
+    super(400, 'Validation failed', details);
+    this.name = 'ValidationError';
+  }
+}
+
+export class ConflictError extends HttpError {
+  constructor(message: string) {
+    super(409, message);
+    this.name = 'ConflictError';
+  }
+}

--- a/apps/pops-core-api/src/shared/trpc-error-mapper.ts
+++ b/apps/pops-core-api/src/shared/trpc-error-mapper.ts
@@ -1,0 +1,46 @@
+import { TRPCError } from '@trpc/server';
+
+import { HttpError } from './errors.js';
+
+type TRPCCode = ConstructorParameters<typeof TRPCError>[0]['code'];
+
+const HTTP_STATUS_TO_TRPC_CODE: Readonly<Record<number, TRPCCode>> = {
+  400: 'BAD_REQUEST',
+  401: 'UNAUTHORIZED',
+  402: 'PAYMENT_REQUIRED',
+  403: 'FORBIDDEN',
+  404: 'NOT_FOUND',
+  409: 'CONFLICT',
+  412: 'PRECONDITION_FAILED',
+  422: 'UNPROCESSABLE_CONTENT',
+  429: 'TOO_MANY_REQUESTS',
+  500: 'INTERNAL_SERVER_ERROR',
+};
+
+function toTRPCError(err: HttpError): TRPCError {
+  const code = HTTP_STATUS_TO_TRPC_CODE[err.statusCode] ?? 'INTERNAL_SERVER_ERROR';
+  return new TRPCError({ code, message: err.message, cause: err });
+}
+
+/**
+ * Runs `fn` and re-throws any HttpError subclass as the corresponding
+ * TRPCError. Non-HttpError throws bubble unchanged so the global tRPC
+ * error handler can see them as 500s.
+ */
+export function mapDomainErrors<T>(fn: () => T): T {
+  try {
+    return fn();
+  } catch (err) {
+    if (err instanceof HttpError) throw toTRPCError(err);
+    throw err;
+  }
+}
+
+export async function mapDomainErrorsAsync<T>(fn: () => Promise<T>): Promise<T> {
+  try {
+    return await fn();
+  } catch (err) {
+    if (err instanceof HttpError) throw toTRPCError(err);
+    throw err;
+  }
+}

--- a/apps/pops-core-api/src/trpc.ts
+++ b/apps/pops-core-api/src/trpc.ts
@@ -1,0 +1,167 @@
+/**
+ * tRPC initialisation for the core pillar container.
+ *
+ * Mirrors the auth surface of `apps/pops-api/src/trpc.ts` but trims off
+ * what core-api doesn't need yet:
+ *   - no module gate (per-pillar containers serve a single pillar by
+ *     definition; the install-set check lives at the dispatcher layer
+ *     above this process);
+ *   - no `internalProcedure` (no sibling-process callers yet);
+ *   - no OpenAPI meta (the dispatcher/gateway owns OpenAPI; core-api
+ *     handlers are tRPC-only for now).
+ *
+ * The core DB handle is injected at context-creation time via the
+ * factory in `createCoreTrpcContextFactory` so tests can swap in an
+ * in-memory handle without touching env vars or the production resolver.
+ */
+import { initTRPC, TRPCError } from '@trpc/server';
+
+import {
+  type AuthenticatedServiceAccount,
+  type CoreDb,
+  serviceAccountKeys,
+  serviceAccountsService,
+} from '@pops/core-db';
+
+import { verifyCloudflareJWT } from './middleware/cloudflare-jwt.js';
+
+import type { CreateExpressContextOptions } from '@trpc/server/adapters/express';
+
+export interface User {
+  email: string;
+}
+
+export interface Context {
+  user: User | null;
+  serviceAccount: AuthenticatedServiceAccount | null;
+  coreDb: CoreDb;
+}
+
+function readApiKeyHeader(req: CreateExpressContextOptions['req']): string | null {
+  const raw = req.headers['x-api-key'];
+  if (Array.isArray(raw)) return raw[0] ?? null;
+  if (typeof raw === 'string' && raw.length > 0) return raw;
+  return null;
+}
+
+async function tryServiceAccountAuth(
+  coreDb: CoreDb,
+  req: CreateExpressContextOptions['req']
+): Promise<AuthenticatedServiceAccount | null> {
+  const header = readApiKeyHeader(req);
+  if (!header) return null;
+  const parsed = serviceAccountKeys.parseApiKey(header);
+  if (!parsed) return null;
+  return serviceAccountsService.authenticateServiceAccount(coreDb, parsed.prefix, parsed.secret);
+}
+
+/**
+ * Build a tRPC context factory bound to a specific core DB handle.
+ *
+ * Production wires this at boot from `openCoreDb(resolveCoreSqlitePath())`;
+ * tests pass in an in-memory handle so each suite is hermetic.
+ */
+export function createCoreTrpcContextFactory(
+  coreDb: CoreDb
+): (opts: CreateExpressContextOptions) => Promise<Context> {
+  return async ({ req }: CreateExpressContextOptions): Promise<Context> => {
+    const serviceAccount = await tryServiceAccountAuth(coreDb, req);
+    if (serviceAccount) {
+      return { user: null, serviceAccount, coreDb };
+    }
+
+    if (process.env['NODE_ENV'] !== 'production') {
+      return {
+        user: { email: 'dev@example.com' },
+        serviceAccount: null,
+        coreDb,
+      };
+    }
+
+    if (!process.env['CLOUDFLARE_ACCESS_TEAM_NAME']) {
+      return {
+        user: { email: 'tunnel-authenticated@pops.local' },
+        serviceAccount: null,
+        coreDb,
+      };
+    }
+
+    const token = req.headers['cf-access-jwt-assertion'];
+    if (typeof token === 'string') {
+      try {
+        const payload = await verifyCloudflareJWT(token);
+        return {
+          user: { email: payload.email },
+          serviceAccount: null,
+          coreDb,
+        };
+      } catch (error) {
+        console.error('[core-api] JWT verification failed:', error);
+        return { user: null, serviceAccount: null, coreDb };
+      }
+    }
+
+    return { user: null, serviceAccount: null, coreDb };
+  };
+}
+
+const t = initTRPC.context<Context>().create();
+
+export const router = t.router;
+
+export const publicProcedure = t.procedure;
+
+export const protectedProcedure = t.procedure.use(({ ctx, path, next }) => {
+  if (ctx.user) {
+    return next({
+      ctx: {
+        user: ctx.user,
+        serviceAccount: ctx.serviceAccount,
+        coreDb: ctx.coreDb,
+      },
+    });
+  }
+
+  if (ctx.serviceAccount) {
+    if (!serviceAccountsService.hasScopeFor(ctx.serviceAccount.scopes, path)) {
+      throw new TRPCError({
+        code: 'FORBIDDEN',
+        message: `Service account '${ctx.serviceAccount.name}' is not authorised for '${path}'`,
+      });
+    }
+    return next({
+      ctx: {
+        user: ctx.user,
+        serviceAccount: ctx.serviceAccount,
+        coreDb: ctx.coreDb,
+      },
+    });
+  }
+
+  throw new TRPCError({
+    code: 'UNAUTHORIZED',
+    message: 'Missing or invalid credentials (expected Cloudflare Access JWT or X-API-Key)',
+  });
+});
+
+/**
+ * Procedure that requires a human (browser session) caller. Service-account
+ * principals are rejected unconditionally — used by the service-account
+ * admin endpoints so a machine principal can't mint or revoke other
+ * machine principals.
+ */
+export const userOnlyProcedure = t.procedure.use(({ ctx, next }) => {
+  if (!ctx.user) {
+    throw new TRPCError({
+      code: 'UNAUTHORIZED',
+      message: 'This endpoint requires a Cloudflare Access user session.',
+    });
+  }
+  return next({
+    ctx: {
+      user: ctx.user,
+      serviceAccount: ctx.serviceAccount,
+      coreDb: ctx.coreDb,
+    },
+  });
+});

--- a/docs/runbooks/core-api-pillar-verification.md
+++ b/docs/runbooks/core-api-pillar-verification.md
@@ -7,7 +7,7 @@ Verification drill for the **core pillar** container after the ADR-026 Phase 3 m
 After core pillar Phase 3:
 
 - `apps/pops-core-api/` ships as `ghcr.io/knoxio/pops-core-api`, listens on port 3001 inside the container network.
-- Endpoints exposed: `GET /health`, `GET /pillars`.
+- Endpoints exposed: `GET /health`, `GET /pillars`, and the tRPC surface at `/trpc` (currently hosting `core.serviceAccounts.{list, create, revoke}`; more procedures move under Track M1 PR 2/3/4). The tRPC surface honours the same `X-API-Key` / Cloudflare-JWT auth contract as `pops-api`.
 - `/pillars/health` aggregator stays on pops-api until the URI dispatcher migrates (PR follow-up).
 - `pops-api`, `pops-worker`, and `pops-shell` (via nginx proxy) all read pillar registry data from core-api.
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -282,16 +282,28 @@ importers:
       '@pops/types':
         specifier: workspace:*
         version: link:../../packages/types
+      '@trpc/server':
+        specifier: ^11.17.0
+        version: 11.17.0(typescript@6.0.3)
       express:
         specifier: ^5.1.0
         version: 5.2.1
+      jsonwebtoken:
+        specifier: ^9.0.3
+        version: 9.0.3
       pino:
         specifier: ^10.3.1
         version: 10.3.1
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@types/express':
         specifier: ^5.0.4
         version: 5.0.6
+      '@types/jsonwebtoken':
+        specifier: ^9.0.10
+        version: 9.0.10
       '@types/node':
         specifier: ^25.9.1
         version: 25.9.1


### PR DESCRIPTION
## Summary

First writer-move across the five pillars (Track M1, Phase 5 of the core-pillar migration, kickoff of the M-track sequence). Adds a tRPC handler at `/trpc` inside `pops-core-api` that exposes `core.serviceAccounts.{list,create,revoke}` backed directly by `@pops/core-db` — no `getDrizzle()`, the open `core.db` handle is passed in via context.

- Additive only. The legacy `pops-api` router stays in place and continues to serve all real traffic until the dispatcher / nginx cutover in **PR 2** of this M1 sequence.
- Follows the CI-never-breaks 4-PR pattern (additive → cutover → cleanup → verification) used for Phases 1-4.
- Tracks issue #2832.

## What landed in pops-core-api

- `src/trpc.ts` — context factory that takes the core DB handle as an argument (hermetic test injection), `userOnlyProcedure` that rejects machine principals from minting or revoking other machine principals.
- `src/modules/service-accounts/{router,types}.ts` — the migrated admin surface. Procedure paths are deliberately rooted at `core.*` so the dispatcher cutover in PR 2 is a transparent URL swap, not a procedure rename.
- `src/shared/{errors,trpc-error-mapper}.ts` + `src/middleware/cloudflare-jwt.ts` — local copies of the pops-api pieces. The container is supposed to stand alone of pops-api in the dep graph (same standalone-comment convention as `core-sqlite-path.ts`); a future refactor can lift the duplicates into a shared `@pops/auth` package.
- `/trpc` mounted via `createExpressMiddleware` alongside the existing `/health` and `/pillars` routes.
- New runtime deps: `@trpc/server`, `zod`, `jsonwebtoken` (versions pinned to the same ranges pops-api uses).

## What's deferred to PR 2 / 3 / 4

- **PR 2 (cutover):** flip the URI dispatcher + nginx routing rules so external `core.serviceAccounts.*` traffic terminates at `pops-core-api` instead of `pops-api`.
- **PR 3 (cleanup):** delete the legacy `apps/pops-api/src/modules/core/service-accounts/router.ts` and its tRPC mount.
- **PR 4 (verification):** drill (stop core-api → confirm shell behaviour), runbook, and flip Track M1 row to ✅ Done in the pillar roadmap.

## Test plan

- [x] `pnpm --filter @pops/core-api typecheck` — green
- [x] `pnpm --filter @pops/core-api test` — 22 tests pass (10 new in `__tests__/service-accounts.test.ts`)
- [x] `pnpm --filter @pops/api test` — 4875 tests pass (no regression in the legacy router)
- [x] `pnpm typecheck` — green across all 51 workspace projects
- [x] `pnpm lint` — exit 0 (warnings only, no new ones from this PR)
- [x] `pnpm build` — green across all 25 workspace builds
- [x] `pnpm format` — clean
- [ ] CI green on this PR
- [ ] Copilot review pass
- [ ] (Out of scope until PR 2) Smoke `core.serviceAccounts.*` against the new container in a preview environment
