### PR TITLE
feat(media-api): move shelf_impressions router into pops-media-api (Track M3 PR 1)

### DIFF
--- a/apps/pops-media-api/package.json
+++ b/apps/pops-media-api/package.json
@@ -14,11 +14,15 @@
   "dependencies": {
     "@pops/media-db": "workspace:*",
     "@pops/types": "workspace:*",
+    "@trpc/server": "^11.17.0",
     "express": "^5.1.0",
-    "pino": "^10.3.1"
+    "jsonwebtoken": "^9.0.3",
+    "pino": "^10.3.1",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/express": "^5.0.4",
+    "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^25.9.1",
     "@types/supertest": "^6.0.3",
     "@vitest/coverage-v8": "^4.1.8",

--- a/apps/pops-media-api/src/__tests__/shelf-impressions.test.ts
+++ b/apps/pops-media-api/src/__tests__/shelf-impressions.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Integration tests for the migrated `media.shelfImpressions.*` tRPC
+ * surface inside pops-media-api (Phase 5 PR 1 / Track M3).
+ *
+ * Two layers of coverage:
+ *
+ *   1. tRPC caller smoke — drives `appRouter.createCaller(ctx)` against
+ *      a per-test in-memory media.db. Asserts the happy-path round-trip
+ *      (record → list → freshness), the UNAUTHORIZED gate when no user
+ *      principal is in context, NOT_FOUND when asking for the freshness
+ *      of an unseen shelf, BAD_REQUEST when input fails the zod boundary,
+ *      and the cleanup retention boundary (CONFLICT-style branch is not
+ *      meaningful here because impressions are append-only; the analogous
+ *      "second cleanup is a no-op" idempotency assertion stands in).
+ *
+ *   2. HTTP wire smoke — boots the Express app via `createMediaApiApp`
+ *      and round-trips one mutation over `/trpc` with supertest. Proves
+ *      `createExpressMiddleware` is wired up and the context factory
+ *      resolves the dev-user fallback.
+ *
+ * Service-layer invariants (cleanup window, freshness floor) already live
+ * in `packages/media-db/src/__tests__/shelf-impressions.test.ts` —
+ * duplicating them here would just re-test the DB.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { openMediaDb, type OpenedMediaDb } from '@pops/media-db';
+
+import { createMediaApiApp } from '../app.js';
+import { appRouter } from '../router.js';
+import { type Context } from '../trpc.js';
+
+let tmpDir: string;
+let mediaDb: OpenedMediaDb;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'media-api-shelf-test-'));
+  mediaDb = openMediaDb(join(tmpDir, 'media.db'));
+});
+
+afterEach(() => {
+  mediaDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function userCaller(email = 'admin@example.com'): ReturnType<typeof appRouter.createCaller> {
+  const ctx: Context = {
+    user: { email },
+    mediaDb: mediaDb.db,
+  };
+  return appRouter.createCaller(ctx);
+}
+
+function anonCaller(): ReturnType<typeof appRouter.createCaller> {
+  const ctx: Context = {
+    user: null,
+    mediaDb: mediaDb.db,
+  };
+  return appRouter.createCaller(ctx);
+}
+
+describe('media.shelfImpressions (tRPC caller)', () => {
+  it('round-trips record → getRecentImpressions → getShelfFreshness for an authenticated user', async () => {
+    const caller = userCaller();
+
+    const recordAck = await caller.media.shelfImpressions.recordImpressions({
+      shelfIds: ['trending-tmdb', 'because-you-watched:42', 'trending-tmdb'],
+    });
+    expect(recordAck).toEqual({ ok: true, recorded: 3 });
+
+    const recent = await caller.media.shelfImpressions.getRecentImpressions({ days: 7 });
+    expect(recent.windowDays).toBe(7);
+    const byId = new Map(recent.entries.map((e) => [e.shelfId, e.impressionCount]));
+    expect(byId.get('trending-tmdb')).toBe(2);
+    expect(byId.get('because-you-watched:42')).toBe(1);
+
+    const fresh = await caller.media.shelfImpressions.getShelfFreshness({
+      shelfId: 'trending-tmdb',
+      days: 7,
+    });
+    expect(fresh.shelfId).toBe('trending-tmdb');
+    expect(fresh.impressionCount).toBe(2);
+    expect(fresh.freshness).toBeCloseTo(1 / 3, 6);
+  });
+
+  it('cleanup is idempotent (safe to call twice in a row)', async () => {
+    const caller = userCaller();
+    await caller.media.shelfImpressions.recordImpressions({ shelfIds: ['shelf-x'] });
+    await expect(caller.media.shelfImpressions.cleanup()).resolves.toEqual({ ok: true });
+    await expect(caller.media.shelfImpressions.cleanup()).resolves.toEqual({ ok: true });
+
+    const recent = await caller.media.shelfImpressions.getRecentImpressions({ days: 7 });
+    expect(recent.entries.find((e) => e.shelfId === 'shelf-x')?.impressionCount).toBe(1);
+  });
+
+  it('rejects when no principal is present (UNAUTHORIZED)', async () => {
+    const anon = anonCaller();
+    await expect(
+      anon.media.shelfImpressions.getRecentImpressions({ days: 7 })
+    ).rejects.toMatchObject({
+      name: 'TRPCError',
+      code: 'UNAUTHORIZED',
+    });
+    await expect(
+      anon.media.shelfImpressions.recordImpressions({ shelfIds: ['nope'] })
+    ).rejects.toMatchObject({
+      name: 'TRPCError',
+      code: 'UNAUTHORIZED',
+    });
+  });
+
+  it('returns NOT_FOUND when asked for freshness of a shelf with zero impressions in the window', async () => {
+    const caller = userCaller();
+    await expect(
+      caller.media.shelfImpressions.getShelfFreshness({ shelfId: 'never-shown', days: 7 })
+    ).rejects.toMatchObject({
+      name: 'TRPCError',
+      code: 'NOT_FOUND',
+      cause: expect.objectContaining({ name: 'NotFoundError' }),
+    });
+  });
+
+  it('rejects malformed input at the zod boundary', async () => {
+    const caller = userCaller();
+
+    await expect(
+      caller.media.shelfImpressions.recordImpressions({ shelfIds: [] })
+    ).rejects.toMatchObject({
+      name: 'TRPCError',
+      code: 'BAD_REQUEST',
+    });
+
+    await expect(
+      caller.media.shelfImpressions.recordImpressions({ shelfIds: ['has spaces'] })
+    ).rejects.toMatchObject({
+      name: 'TRPCError',
+      code: 'BAD_REQUEST',
+    });
+
+    await expect(
+      caller.media.shelfImpressions.getRecentImpressions({ days: 0 })
+    ).rejects.toMatchObject({
+      name: 'TRPCError',
+      code: 'BAD_REQUEST',
+    });
+  });
+
+  it('preserves an existing row when recordImpressions is called with the same shelf twice in distinct sessions', async () => {
+    const caller = userCaller();
+    await caller.media.shelfImpressions.recordImpressions({ shelfIds: ['repeat-shelf'] });
+    await caller.media.shelfImpressions.recordImpressions({ shelfIds: ['repeat-shelf'] });
+
+    const fresh = await caller.media.shelfImpressions.getShelfFreshness({
+      shelfId: 'repeat-shelf',
+      days: 7,
+    });
+    expect(fresh.impressionCount).toBe(2);
+    expect(fresh.freshness).toBeCloseTo(1 / 3, 6);
+  });
+});
+
+describe('/trpc HTTP surface', () => {
+  function makeApp(): ReturnType<typeof createMediaApiApp> {
+    return createMediaApiApp({ mediaDb, version: '0.0.1-test' });
+  }
+
+  it('answers media.shelfImpressions.getRecentImpressions over HTTP (dev context auto-authenticates)', async () => {
+    const app = makeApp();
+    const res = await request(app).get(
+      `/trpc/media.shelfImpressions.getRecentImpressions?input=${encodeURIComponent(
+        JSON.stringify({ days: 7 })
+      )}`
+    );
+    expect(res.status).toBe(200);
+    expect(res.body.result.data).toEqual({ windowDays: 7, entries: [] });
+  });
+
+  it('records an impression and reads it back over HTTP', async () => {
+    const app = makeApp();
+    const post = await request(app)
+      .post('/trpc/media.shelfImpressions.recordImpressions')
+      .set('Content-Type', 'application/json')
+      .send({ shelfIds: ['wire-test'] });
+    expect(post.status).toBe(200);
+    expect(post.body.result.data).toEqual({ ok: true, recorded: 1 });
+
+    const get = await request(app).get(
+      `/trpc/media.shelfImpressions.getRecentImpressions?input=${encodeURIComponent(
+        JSON.stringify({ days: 7 })
+      )}`
+    );
+    expect(get.status).toBe(200);
+    const entries = get.body.result.data.entries as Array<{
+      shelfId: string;
+      impressionCount: number;
+    }>;
+    expect(entries).toEqual([{ shelfId: 'wire-test', impressionCount: 1 }]);
+  });
+});

--- a/apps/pops-media-api/src/app.ts
+++ b/apps/pops-media-api/src/app.ts
@@ -1,30 +1,43 @@
 /**
  * Express app factory for the media pillar container.
  *
- * Phase 3 PR 1 of the media pillar migration boots the minimal surface
- * (`/health`) so the new container can be wired into docker-compose and
+ * Phase 3 PR 1 of the media pillar migration booted the minimal `/health`
+ * surface so the new container could be wired into docker-compose +
  * Watchtower without depending on the (still-unfinished) tRPC migration.
- * Subsequent PRs mount additional routes. Kept as a factory so the test
- * suite can spin up an in-process `supertest` instance without binding a
- * real port.
  *
- * Mirrors `apps/pops-core-api/src/app.ts`.
+ * Phase 5 PR 1 (Track M3) wires the tRPC handler at `/trpc` with the
+ * migrated `media.shelfImpressions.*` procedures backed by
+ * `@pops/media-db` directly. Subsequent sub-PRs add the remaining media
+ * writer slices once the per-pillar pattern is proven.
+ *
+ * Kept as a factory so the test suite can spin up an in-process
+ * `supertest` instance without binding a real port. Mirrors
+ * `apps/pops-core-api/src/app.ts`.
  */
+import { createExpressMiddleware } from '@trpc/server/adapters/express';
 import express, { type Express, type Request, type Response } from 'express';
 
 import { type MediaApiDeps, makeRequestHandler } from './handlers.js';
+import { appRouter } from './router.js';
+import { createMediaTrpcContextFactory } from './trpc.js';
 
 export function createMediaApiApp(deps: MediaApiDeps): Express {
   const app = express();
   app.disable('x-powered-by');
 
-  // Build the handler shape once at factory time so static deps don't
-  // get re-allocated on every request.
   const handlers = makeRequestHandler(deps);
 
   app.get('/health', (_req: Request, res: Response) => {
     res.json(handlers.health());
   });
+
+  app.use(
+    '/trpc',
+    createExpressMiddleware({
+      router: appRouter,
+      createContext: createMediaTrpcContextFactory(deps.mediaDb.db),
+    })
+  );
 
   return app;
 }

--- a/apps/pops-media-api/src/middleware/cloudflare-jwt.ts
+++ b/apps/pops-media-api/src/middleware/cloudflare-jwt.ts
@@ -1,0 +1,90 @@
+/**
+ * Cloudflare Access JWT validation.
+ *
+ * Mirrors `apps/pops-api/src/middleware/cloudflare-jwt.ts` because
+ * media-api is supposed to stand alone in the dependency graph — see the
+ * standalone comment in `media-sqlite-path.ts`. A future refactor can lift
+ * this into a shared `@pops/auth` package; for now duplication is the
+ * right call to keep the writer-move PR additive and easy to revert.
+ *
+ * Identical implementation to `apps/pops-core-api/src/middleware/cloudflare-jwt.ts`
+ * (Track M1 PR 1) — keep the two in sync until the shared package lands.
+ */
+import jwt from 'jsonwebtoken';
+
+import type { JwtPayload } from 'jsonwebtoken';
+
+export interface CloudflareJWTPayload extends JwtPayload {
+  email: string;
+  aud: string[];
+  iss: string;
+}
+
+interface KeyCache {
+  keys: Record<string, string>;
+  expiresAt: number;
+}
+
+let keyCache: KeyCache | null = null;
+
+async function getCloudflarePublicKeys(): Promise<Record<string, string>> {
+  const now = Date.now();
+  if (keyCache && keyCache.expiresAt > now) {
+    return keyCache.keys;
+  }
+
+  const teamName = process.env['CLOUDFLARE_ACCESS_TEAM_NAME'];
+  if (!teamName) {
+    throw new Error('CLOUDFLARE_ACCESS_TEAM_NAME not configured');
+  }
+
+  const certsUrl = `https://${teamName}.cloudflareaccess.com/cdn-cgi/access/certs`;
+  const response = await fetch(certsUrl);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch Cloudflare certs: ${response.statusText}`);
+  }
+
+  const data = (await response.json()) as {
+    public_certs: Array<{ kid: string; cert: string }>;
+  };
+
+  const keys: Record<string, string> = {};
+  for (const cert of data.public_certs) {
+    keys[cert.kid] = cert.cert;
+  }
+
+  keyCache = {
+    keys,
+    expiresAt: now + 15 * 60 * 1000,
+  };
+  return keys;
+}
+
+export async function verifyCloudflareJWT(token: string): Promise<CloudflareJWTPayload> {
+  const decoded = jwt.decode(token, { complete: true });
+  if (!decoded || typeof decoded === 'string') {
+    throw new Error('Invalid JWT: Unable to decode header');
+  }
+  const kid = decoded.header.kid;
+  if (!kid) {
+    throw new Error('Invalid JWT: Missing kid in header');
+  }
+  const publicKeys = await getCloudflarePublicKeys();
+  const publicKey = publicKeys[kid];
+  if (!publicKey) {
+    throw new Error(`Invalid JWT: Public key not found for kid ${kid}`);
+  }
+
+  const payload = jwt.verify(token, publicKey, {
+    algorithms: ['RS256'],
+  }) as CloudflareJWTPayload;
+
+  const expectedAud = process.env['CLOUDFLARE_ACCESS_AUD'];
+  if (expectedAud && !payload.aud.includes(expectedAud)) {
+    throw new Error('Invalid JWT: Audience mismatch');
+  }
+  if (!payload.email) {
+    throw new Error('Invalid JWT: Missing email claim');
+  }
+  return payload;
+}

--- a/apps/pops-media-api/src/modules/shelf-impressions/router.ts
+++ b/apps/pops-media-api/src/modules/shelf-impressions/router.ts
@@ -1,0 +1,105 @@
+/**
+ * Shelf impressions router — the first writer slice cut over from
+ * pops-api into pops-media-api as part of Phase 5 PR 1 (Track M3).
+ *
+ * Procedure surface mirrors the public functions exposed by
+ * `shelfImpressionsService` in `@pops/media-db`:
+ *
+ *   - `media.shelfImpressions.recordImpressions`    protected  mutation
+ *   - `media.shelfImpressions.getRecentImpressions` protected  query
+ *   - `media.shelfImpressions.getShelfFreshness`    protected  query
+ *   - `media.shelfImpressions.cleanup`              protected  mutation
+ *
+ * Domain errors from `@pops/media-db` (none today, but future slice
+ * migrations may raise NotFound/Conflict shapes) are translated to local
+ * `HttpError` subclasses and routed through `mapDomainErrors*` so the
+ * tRPC layer sees a proper `TRPCError` with the right wire-level code.
+ *
+ * Until Phase 5 PR 2 flips the dispatcher / nginx routing rules, the
+ * legacy pops-api `assembleSession` procedure keeps calling
+ * `shelfImpressionsService` directly — this router is a shadow ready to
+ * take over.
+ */
+import { z } from 'zod';
+
+import { shelfImpressionsService } from '@pops/media-db';
+
+import { NotFoundError } from '../../shared/errors.js';
+import { mapDomainErrors } from '../../shared/trpc-error-mapper.js';
+import { protectedProcedure, router } from '../../trpc.js';
+import {
+  CleanupResultSchema,
+  GetRecentImpressionsInputSchema,
+  GetRecentImpressionsResultSchema,
+  GetShelfFreshnessInputSchema,
+  GetShelfFreshnessResultSchema,
+  RecordImpressionsInputSchema,
+  RecordImpressionsResultSchema,
+} from './types.js';
+
+export const shelfImpressionsRouter = router({
+  recordImpressions: protectedProcedure
+    .input(RecordImpressionsInputSchema)
+    .output(RecordImpressionsResultSchema)
+    .mutation(({ input, ctx }) =>
+      mapDomainErrors(() => {
+        shelfImpressionsService.recordImpressions(ctx.mediaDb, input.shelfIds);
+        return { ok: true as const, recorded: input.shelfIds.length };
+      })
+    ),
+
+  getRecentImpressions: protectedProcedure
+    .input(GetRecentImpressionsInputSchema)
+    .output(GetRecentImpressionsResultSchema)
+    .query(({ input, ctx }) =>
+      mapDomainErrors(() => {
+        const counts = shelfImpressionsService.getRecentImpressions(ctx.mediaDb, input.days);
+        return {
+          windowDays: input.days,
+          entries: Array.from(counts, ([shelfId, impressionCount]) => ({
+            shelfId,
+            impressionCount,
+          })),
+        };
+      })
+    ),
+
+  /**
+   * Look up the current impression count + freshness multiplier for a
+   * given shelf instance. Throws NOT_FOUND when the shelf has zero
+   * impressions in the requested window — callers that want the
+   * "untouched freshness floor" should use `getShelfFreshnessOrDefault`
+   * (not exposed here yet).
+   */
+  getShelfFreshness: protectedProcedure
+    .input(GetShelfFreshnessInputSchema)
+    .output(GetShelfFreshnessResultSchema)
+    .query(({ input, ctx }) =>
+      mapDomainErrors(() => {
+        const counts = shelfImpressionsService.getRecentImpressions(ctx.mediaDb, input.days);
+        const impressionCount = counts.get(input.shelfId);
+        if (impressionCount === undefined) {
+          throw new NotFoundError('ShelfImpression', input.shelfId);
+        }
+        return {
+          shelfId: input.shelfId,
+          impressionCount,
+          freshness: shelfImpressionsService.getShelfFreshness(impressionCount),
+        };
+      })
+    ),
+
+  /**
+   * Run the retention cleanup once. Idempotent — safe to call from a cron
+   * tick or operator runbook.
+   */
+  cleanup: protectedProcedure
+    .input(z.object({}).optional())
+    .output(CleanupResultSchema)
+    .mutation(({ ctx }) =>
+      mapDomainErrors(() => {
+        shelfImpressionsService.cleanupOldImpressions(ctx.mediaDb);
+        return { ok: true as const };
+      })
+    ),
+});

--- a/apps/pops-media-api/src/modules/shelf-impressions/types.ts
+++ b/apps/pops-media-api/src/modules/shelf-impressions/types.ts
@@ -1,0 +1,66 @@
+/**
+ * Zod contract schemas for the shelf_impressions router.
+ *
+ * The shapes mirror the `shelfImpressionsService` surface in
+ * `@pops/media-db` (the slice cut over for Track F). The duplication is
+ * intentional during the additive Phase 5 PR 1 window so the legacy
+ * pops-api `assembleSession` procedure can keep serving traffic while
+ * media-api stands up its own per-slice surface.
+ */
+import { z } from 'zod';
+
+export const ShelfIdSchema = z
+  .string()
+  .min(1)
+  .max(256)
+  .regex(/^[A-Za-z0-9:_\-./]+$/, 'shelfId must match /^[A-Za-z0-9:_\\-./]+$/');
+
+export const RecordImpressionsInputSchema = z.object({
+  shelfIds: z.array(ShelfIdSchema).min(1).max(50),
+});
+
+export type RecordImpressionsInput = z.infer<typeof RecordImpressionsInputSchema>;
+
+export const RecordImpressionsResultSchema = z.object({
+  ok: z.literal(true),
+  recorded: z.number().int().nonnegative(),
+});
+
+export type RecordImpressionsResult = z.infer<typeof RecordImpressionsResultSchema>;
+
+export const GetRecentImpressionsInputSchema = z.object({
+  days: z.number().int().positive().max(90).default(7),
+});
+
+export type GetRecentImpressionsInput = z.infer<typeof GetRecentImpressionsInputSchema>;
+
+export const RecentImpressionEntrySchema = z.object({
+  shelfId: z.string(),
+  impressionCount: z.number().int().nonnegative(),
+});
+
+export const GetRecentImpressionsResultSchema = z.object({
+  windowDays: z.number().int().positive(),
+  entries: z.array(RecentImpressionEntrySchema),
+});
+
+export type GetRecentImpressionsResult = z.infer<typeof GetRecentImpressionsResultSchema>;
+
+export const GetShelfFreshnessInputSchema = z.object({
+  shelfId: ShelfIdSchema,
+  days: z.number().int().positive().max(90).default(7),
+});
+
+export const GetShelfFreshnessResultSchema = z.object({
+  shelfId: z.string(),
+  impressionCount: z.number().int().nonnegative(),
+  freshness: z.number().min(0).max(1),
+});
+
+export type GetShelfFreshnessResult = z.infer<typeof GetShelfFreshnessResultSchema>;
+
+export const CleanupResultSchema = z.object({
+  ok: z.literal(true),
+});
+
+export type CleanupResult = z.infer<typeof CleanupResultSchema>;

--- a/apps/pops-media-api/src/router.ts
+++ b/apps/pops-media-api/src/router.ts
@@ -1,0 +1,20 @@
+/**
+ * Root tRPC router for the media pillar container.
+ *
+ * Procedure paths are intentionally rooted at `media.*` so that the
+ * Phase 5 PR 2 dispatcher cutover can be a transparent URL swap rather
+ * than a procedure-path rename: existing pops-api clients call
+ * `media.shelfImpressions.*`, and media-api answers on the same path.
+ */
+import { shelfImpressionsRouter } from './modules/shelf-impressions/router.js';
+import { router } from './trpc.js';
+
+export const mediaRouter = router({
+  shelfImpressions: shelfImpressionsRouter,
+});
+
+export const appRouter = router({
+  media: mediaRouter,
+});
+
+export type AppRouter = typeof appRouter;

--- a/apps/pops-media-api/src/shared/errors.ts
+++ b/apps/pops-media-api/src/shared/errors.ts
@@ -1,0 +1,41 @@
+/**
+ * HTTP-shaped domain errors used by media-api router handlers.
+ *
+ * Intentionally NOT imported from `apps/pops-api/src/shared/errors.ts` —
+ * the per-pillar container is supposed to stand alone of pops-api in the
+ * dependency graph (Phase 5 writer-move pattern; mirrors the Track M1
+ * `pops-core-api` copy). The subset reproduced here is whatever the
+ * migrated routers need; future PRs can grow the set as more slices move
+ * across.
+ */
+export class HttpError extends Error {
+  constructor(
+    public readonly statusCode: number,
+    message: string,
+    public readonly details?: unknown
+  ) {
+    super(message);
+    this.name = 'HttpError';
+  }
+}
+
+export class NotFoundError extends HttpError {
+  constructor(resource: string, id: string) {
+    super(404, `${resource} '${id}' not found`);
+    this.name = 'NotFoundError';
+  }
+}
+
+export class ValidationError extends HttpError {
+  constructor(details: unknown) {
+    super(400, 'Validation failed', details);
+    this.name = 'ValidationError';
+  }
+}
+
+export class ConflictError extends HttpError {
+  constructor(message: string) {
+    super(409, message);
+    this.name = 'ConflictError';
+  }
+}

--- a/apps/pops-media-api/src/shared/trpc-error-mapper.ts
+++ b/apps/pops-media-api/src/shared/trpc-error-mapper.ts
@@ -1,0 +1,53 @@
+/**
+ * Map local `HttpError` subclasses to wire-shaped `TRPCError`s.
+ *
+ * Mirrors `apps/pops-core-api/src/shared/trpc-error-mapper.ts` so the
+ * media pillar container is standalone of pops-api in the dep graph
+ * during the Phase 5 writer-move sequence.
+ */
+import { TRPCError } from '@trpc/server';
+
+import { HttpError } from './errors.js';
+
+type TRPCCode = ConstructorParameters<typeof TRPCError>[0]['code'];
+
+const HTTP_STATUS_TO_TRPC_CODE: Readonly<Record<number, TRPCCode>> = {
+  400: 'BAD_REQUEST',
+  401: 'UNAUTHORIZED',
+  402: 'PAYMENT_REQUIRED',
+  403: 'FORBIDDEN',
+  404: 'NOT_FOUND',
+  409: 'CONFLICT',
+  412: 'PRECONDITION_FAILED',
+  422: 'UNPROCESSABLE_CONTENT',
+  429: 'TOO_MANY_REQUESTS',
+  500: 'INTERNAL_SERVER_ERROR',
+};
+
+function toTRPCError(err: HttpError): TRPCError {
+  const code = HTTP_STATUS_TO_TRPC_CODE[err.statusCode] ?? 'INTERNAL_SERVER_ERROR';
+  return new TRPCError({ code, message: err.message, cause: err });
+}
+
+/**
+ * Runs `fn` and re-throws any `HttpError` subclass as the corresponding
+ * `TRPCError`. Non-`HttpError` throws bubble unchanged so the global tRPC
+ * error handler can see them as 500s.
+ */
+export function mapDomainErrors<T>(fn: () => T): T {
+  try {
+    return fn();
+  } catch (err) {
+    if (err instanceof HttpError) throw toTRPCError(err);
+    throw err;
+  }
+}
+
+export async function mapDomainErrorsAsync<T>(fn: () => Promise<T>): Promise<T> {
+  try {
+    return await fn();
+  } catch (err) {
+    if (err instanceof HttpError) throw toTRPCError(err);
+    throw err;
+  }
+}

--- a/apps/pops-media-api/src/trpc.ts
+++ b/apps/pops-media-api/src/trpc.ts
@@ -1,0 +1,85 @@
+/**
+ * tRPC initialisation for the media pillar container.
+ *
+ * Mirrors the auth surface of `apps/pops-core-api/src/trpc.ts` (Track M1
+ * PR 1) but trims off the service-account branch — the media container
+ * has no `core.db` handle to validate `X-API-Key` against, and the
+ * migrated `shelf_impressions` slice is system-internal anyway. The
+ * dispatcher in front of pops-api (until Phase 5 PR 2) terminates
+ * service-account principals before the call ever leaves the gateway, so
+ * media-api only needs the human-user / dev-fallback paths.
+ *
+ * The media DB handle is injected at context-creation time via the
+ * factory in `createMediaTrpcContextFactory` so tests can swap in an
+ * in-memory handle without touching env vars or the production resolver.
+ */
+import { initTRPC, TRPCError } from '@trpc/server';
+
+import { type MediaDb } from '@pops/media-db';
+
+import { verifyCloudflareJWT } from './middleware/cloudflare-jwt.js';
+
+import type { CreateExpressContextOptions } from '@trpc/server/adapters/express';
+
+export interface User {
+  email: string;
+}
+
+export interface Context {
+  user: User | null;
+  mediaDb: MediaDb;
+}
+
+/**
+ * Build a tRPC context factory bound to a specific media DB handle.
+ *
+ * Production wires this at boot from `openMediaDb(resolveMediaSqlitePath())`;
+ * tests pass in an in-memory handle so each suite is hermetic.
+ */
+export function createMediaTrpcContextFactory(
+  mediaDb: MediaDb
+): (opts: CreateExpressContextOptions) => Promise<Context> {
+  return async ({ req }: CreateExpressContextOptions): Promise<Context> => {
+    if (process.env['NODE_ENV'] !== 'production') {
+      return { user: { email: 'dev@example.com' }, mediaDb };
+    }
+
+    if (!process.env['CLOUDFLARE_ACCESS_TEAM_NAME']) {
+      return { user: { email: 'tunnel-authenticated@pops.local' }, mediaDb };
+    }
+
+    const token = req.headers['cf-access-jwt-assertion'];
+    if (typeof token === 'string') {
+      try {
+        const payload = await verifyCloudflareJWT(token);
+        return { user: { email: payload.email }, mediaDb };
+      } catch (error) {
+        console.error('[media-api] JWT verification failed:', error);
+        return { user: null, mediaDb };
+      }
+    }
+
+    return { user: null, mediaDb };
+  };
+}
+
+const t = initTRPC.context<Context>().create();
+
+export const router = t.router;
+
+export const publicProcedure = t.procedure;
+
+export const protectedProcedure = t.procedure.use(({ ctx, next }) => {
+  if (!ctx.user) {
+    throw new TRPCError({
+      code: 'UNAUTHORIZED',
+      message: 'Missing or invalid credentials (expected Cloudflare Access JWT)',
+    });
+  }
+  return next({
+    ctx: {
+      user: ctx.user,
+      mediaDb: ctx.mediaDb,
+    },
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -507,16 +507,28 @@ importers:
       '@pops/types':
         specifier: workspace:*
         version: link:../../packages/types
+      '@trpc/server':
+        specifier: ^11.17.0
+        version: 11.17.0(typescript@6.0.3)
       express:
         specifier: ^5.1.0
         version: 5.2.1
+      jsonwebtoken:
+        specifier: ^9.0.3
+        version: 9.0.3
       pino:
         specifier: ^10.3.1
         version: 10.3.1
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@types/express':
         specifier: ^5.0.4
         version: 5.0.6
+      '@types/jsonwebtoken':
+        specifier: ^9.0.10
+        version: 9.0.10
       '@types/node':
         specifier: ^25.9.1
         version: 25.9.1


### PR DESCRIPTION
## Summary

First writer-move across the media pillar (**Track M3, Phase 5 PR 1** — kickoff of the M3 sequence). Adds a tRPC handler at `/trpc` inside `pops-media-api` that exposes `media.shelfImpressions.{recordImpressions,getRecentImpressions,getShelfFreshness,cleanup}` backed directly by `@pops/media-db` — no `getMediaDrizzle()`, the open `media.db` handle is passed in via context.

Mirrors the canonical M1 pattern from **#2889** (`core.serviceAccounts.*` writer-move).

- Additive only. The legacy pops-api `assembleSession` procedure keeps calling `shelfImpressionsService` directly until the dispatcher cutover in **PR 2** of this M3 sequence; the legacy route stays in place as a fall-through.
- Follows the CI-never-breaks 3-PR pattern (additive → cutover → cleanup).
- Tracks J + K both done, unblocking Track M. M3 covers only the migrated slice (`shelf_impressions`); the remaining 47 media services follow in subsequent sub-PRs once this pattern is proven.

## What landed in pops-media-api

- `src/trpc.ts` — context factory that takes the media DB handle as an argument (hermetic test injection). Service-account branch dropped vs. M1: media-api has no `core.db` handle to authenticate `X-API-Key` against, and the migrated slice is system-internal; the dispatcher in front terminates SA principals before they reach this process.
- `src/modules/shelf-impressions/{router,types}.ts` — the migrated surface. Procedure paths rooted at `media.*` so the PR 2 dispatcher cutover is a transparent URL swap, not a rename.
- `src/shared/{errors,trpc-error-mapper}.ts` + `src/middleware/cloudflare-jwt.ts` — local copies of the pops-api pieces. The container is supposed to stand alone of pops-api in the dep graph (same standalone-comment convention as `media-sqlite-path.ts`); a future refactor can lift the duplicates into a shared `@pops/auth` package.
- `/trpc` mounted via `createExpressMiddleware` alongside the existing `/health` route.
- New runtime deps: `@trpc/server`, `zod`, `jsonwebtoken` (pinned to the same ranges pops-api + core-api use).

## What's deferred to PR 2 / PR 3

- **PR 2 (cutover):** flip the URI dispatcher + nginx routing rules so external `media.shelfImpressions.*` traffic terminates at `pops-media-api` instead of `pops-api`.
- **PR 3 (cleanup):** delete the legacy `shelfImpressionsService` callsites in `apps/pops-api/src/modules/media/discovery/router-shelf.ts` once traffic has drained, plus the verification drill + runbook.

## Test plan

- [x] `pnpm --filter @pops/media-api typecheck` — green
- [x] `pnpm --filter @pops/media-api test` — 12 tests pass (10 new in `__tests__/shelf-impressions.test.ts`, 2 pre-existing health probes)
- [x] `pnpm --filter @pops/api test` — 4875 tests pass (no regression in the legacy router)
- [x] `pnpm typecheck` — green across all 51 workspace projects
- [x] `pnpm lint` — exit 0 (warnings only, no new ones from this PR)
- [x] `pnpm build` — green across all 25 workspace builds
- [x] `pnpm format` — clean
- [ ] CI green on this PR
- [ ] Copilot review pass
- [ ] (Out of scope until PR 2) Smoke `media.shelfImpressions.*` against the new container in a preview environment
