### PR TITLE
feat(inventory-api): move locations router into pops-inventory-api (Track M4 PR 1)

### DIFF
--- a/apps/pops-inventory-api/Dockerfile
+++ b/apps/pops-inventory-api/Dockerfile
@@ -7,6 +7,7 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json ./
 # Copy workspace package.json files (for dep resolution)
 COPY packages/db-types/package.json ./packages/db-types/
 COPY packages/types/package.json ./packages/types/
+COPY packages/core-db/package.json ./packages/core-db/
 COPY packages/inventory-db/package.json ./packages/inventory-db/
 COPY apps/pops-inventory-api/package.json ./apps/pops-inventory-api/
 
@@ -19,6 +20,9 @@ COPY packages/db-types/src ./packages/db-types/src
 COPY packages/db-types/tsconfig.json ./packages/db-types/
 COPY packages/types/src ./packages/types/src
 COPY packages/types/tsconfig.json packages/types/tsconfig.build.json ./packages/types/
+COPY packages/core-db/src ./packages/core-db/src
+COPY packages/core-db/tsconfig.json ./packages/core-db/
+COPY packages/core-db/migrations ./packages/core-db/migrations
 COPY packages/inventory-db/src ./packages/inventory-db/src
 COPY packages/inventory-db/tsconfig.json ./packages/inventory-db/
 COPY packages/inventory-db/migrations ./packages/inventory-db/migrations
@@ -31,6 +35,8 @@ COPY apps/pops-inventory-api/src ./apps/pops-inventory-api/src
 WORKDIR /app/packages/db-types
 RUN pnpm build
 WORKDIR /app/packages/types
+RUN pnpm build
+WORKDIR /app/packages/core-db
 RUN pnpm build
 WORKDIR /app/packages/inventory-db
 RUN pnpm build

--- a/apps/pops-inventory-api/package.json
+++ b/apps/pops-inventory-api/package.json
@@ -12,12 +12,18 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@pops/core-db": "workspace:*",
+    "@pops/db-types": "workspace:*",
     "@pops/inventory-db": "workspace:*",
     "@pops/types": "workspace:*",
-    "express": "^5.1.0"
+    "@trpc/server": "^11.17.0",
+    "express": "^5.1.0",
+    "jsonwebtoken": "^9.0.3",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/express": "^5.0.4",
+    "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^25.9.1",
     "@types/supertest": "^6.0.3",
     "@vitest/coverage-v8": "^4.1.8",

--- a/apps/pops-inventory-api/src/__tests__/locations.test.ts
+++ b/apps/pops-inventory-api/src/__tests__/locations.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Integration tests for the migrated `inventory.locations.*` tRPC
+ * surface inside pops-inventory-api (Phase 5 PR 1 / Track M4).
+ *
+ * Two layers of coverage:
+ *
+ *   1. tRPC caller smoke — drives `appRouter.createCaller(ctx)` against
+ *      a per-test in-memory inventory.db. Asserts the same shape contract
+ *      the legacy pops-api router enforced (list/get/tree/create/update/
+ *      delete happy paths, NOT_FOUND on unknown ids, CONFLICT on cycles
+ *      and self-parent, UNAUTHORIZED when no principal is present).
+ *
+ *   2. HTTP wire smoke — boots the Express app via `createInventoryApiApp`
+ *      and round-trips one query over `/trpc` with supertest. Proves
+ *      `createExpressMiddleware` is wired up and the context factory
+ *      reaches the inventory DB.
+ *
+ * Service-layer invariants (cycle detection, tree assembly, cascade
+ * delete) already live in `packages/inventory-db/src/__tests__/` —
+ * duplicating them here would just test drizzle.
+ *
+ * Out of scope for this PR: the legacy router's `getItems` procedure,
+ * which depends on `toInventoryItem` from the items module — that slice
+ * is still in pops-api and will migrate in a follow-up PR. The legacy
+ * pops-api router keeps serving `inventory.locations.getItems` (and
+ * every other `inventory.*` route) as fall-through until Phase 5 PR 2
+ * flips the dispatcher.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { TRPCError } from '@trpc/server';
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { locationsService, openInventoryDb, type OpenedInventoryDb } from '@pops/inventory-db';
+
+import { createInventoryApiApp } from '../app.js';
+import { appRouter } from '../router.js';
+import { type Context } from '../trpc.js';
+
+let tmpDir: string;
+let inventoryDb: OpenedInventoryDb;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'inventory-api-loc-test-'));
+  inventoryDb = openInventoryDb(join(tmpDir, 'inventory.db'));
+});
+
+afterEach(() => {
+  inventoryDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function userCaller(email = 'admin@example.com'): ReturnType<typeof appRouter.createCaller> {
+  const ctx: Context = {
+    user: { email },
+    serviceAccount: null,
+    inventoryDb: inventoryDb.db,
+  };
+  return appRouter.createCaller(ctx);
+}
+
+function serviceAccountCaller(scopes: string[]): ReturnType<typeof appRouter.createCaller> {
+  const ctx: Context = {
+    user: null,
+    serviceAccount: { id: 'sa_test', name: 'test-sa', scopes },
+    inventoryDb: inventoryDb.db,
+  };
+  return appRouter.createCaller(ctx);
+}
+
+function anonCaller(): ReturnType<typeof appRouter.createCaller> {
+  const ctx: Context = {
+    user: null,
+    serviceAccount: null,
+    inventoryDb: inventoryDb.db,
+  };
+  return appRouter.createCaller(ctx);
+}
+
+describe('inventory.locations (tRPC caller — happy paths)', () => {
+  it('lets a human admin create, list, get, then delete a location', async () => {
+    const admin = userCaller();
+    const created = await admin.inventory.locations.create({ name: 'Home' });
+    expect(created.data.name).toBe('Home');
+    expect(created.data.parentId).toBeNull();
+
+    const list = await admin.inventory.locations.list();
+    expect(list.total).toBe(1);
+    expect(list.data[0]?.name).toBe('Home');
+
+    const fetched = await admin.inventory.locations.get({ id: created.data.id });
+    expect(fetched.data.name).toBe('Home');
+
+    const ack = await admin.inventory.locations.delete({ id: created.data.id });
+    expect(ack).toEqual({ message: 'Location deleted' });
+
+    const after = await admin.inventory.locations.list();
+    expect(after.total).toBe(0);
+  });
+
+  it('builds a nested tree across parent-child rows', async () => {
+    const admin = userCaller();
+    const home = await admin.inventory.locations.create({ name: 'Home' });
+    const kitchen = await admin.inventory.locations.create({
+      name: 'Kitchen',
+      parentId: home.data.id,
+    });
+    await admin.inventory.locations.create({ name: 'Pantry', parentId: kitchen.data.id });
+
+    const tree = await admin.inventory.locations.tree();
+    expect(tree.data).toHaveLength(1);
+    expect(tree.data[0]?.name).toBe('Home');
+    expect(tree.data[0]?.children).toHaveLength(1);
+    expect(tree.data[0]?.children[0]?.name).toBe('Kitchen');
+    expect(tree.data[0]?.children[0]?.children[0]?.name).toBe('Pantry');
+  });
+
+  it('returns a root-first breadcrumb path', async () => {
+    const admin = userCaller();
+    const home = await admin.inventory.locations.create({ name: 'Home' });
+    const kitchen = await admin.inventory.locations.create({
+      name: 'Kitchen',
+      parentId: home.data.id,
+    });
+    const pantry = await admin.inventory.locations.create({
+      name: 'Pantry',
+      parentId: kitchen.data.id,
+    });
+
+    const path = await admin.inventory.locations.getPath({ id: pantry.data.id });
+    expect(path.data.map((row) => row.name)).toEqual(['Home', 'Kitchen', 'Pantry']);
+  });
+
+  it('lists direct children only', async () => {
+    const admin = userCaller();
+    const home = await admin.inventory.locations.create({ name: 'Home' });
+    await admin.inventory.locations.create({ name: 'Kitchen', parentId: home.data.id });
+    await admin.inventory.locations.create({ name: 'Bedroom', parentId: home.data.id });
+    await admin.inventory.locations.create({ name: 'Car' });
+
+    const children = await admin.inventory.locations.children({ parentId: home.data.id });
+    expect(children.data).toHaveLength(2);
+    expect(children.data.map((row) => row.name).toSorted()).toEqual(['Bedroom', 'Kitchen']);
+  });
+
+  it('updates a location name', async () => {
+    const admin = userCaller();
+    const created = await admin.inventory.locations.create({ name: 'Old Name' });
+    const updated = await admin.inventory.locations.update({
+      id: created.data.id,
+      data: { name: 'New Name' },
+    });
+    expect(updated.data.name).toBe('New Name');
+  });
+
+  it('requires confirmation before deleting a populated location', async () => {
+    const admin = userCaller();
+    const home = await admin.inventory.locations.create({ name: 'Home' });
+    await admin.inventory.locations.create({ name: 'Kitchen', parentId: home.data.id });
+
+    const res = await admin.inventory.locations.delete({ id: home.data.id });
+    expect(res).toMatchObject({ requiresConfirmation: true });
+
+    const forced = await admin.inventory.locations.delete({ id: home.data.id, force: true });
+    expect(forced).toEqual({ message: 'Location deleted' });
+  });
+});
+
+describe('inventory.locations (auth + error mapping)', () => {
+  it('rejects callers with no principal as UNAUTHORIZED', async () => {
+    const anon = anonCaller();
+    await expect(anon.inventory.locations.list()).rejects.toMatchObject({
+      name: 'TRPCError',
+      code: 'UNAUTHORIZED',
+    });
+  });
+
+  it('accepts a service-account caller that holds the matching scope', async () => {
+    const sa = serviceAccountCaller(['inventory.locations']);
+    const created = await sa.inventory.locations.create({ name: 'WarehouseBot' });
+    expect(created.data.name).toBe('WarehouseBot');
+  });
+
+  it('rejects a service-account caller without scope coverage as FORBIDDEN', async () => {
+    const sa = serviceAccountCaller(['food.recipes']);
+    await expect(sa.inventory.locations.list()).rejects.toMatchObject({
+      name: 'TRPCError',
+      code: 'FORBIDDEN',
+    });
+  });
+
+  it('maps LocationNotFoundError to NOT_FOUND', async () => {
+    const admin = userCaller();
+    await expect(admin.inventory.locations.get({ id: 'nope' })).rejects.toMatchObject({
+      name: 'TRPCError',
+      code: 'NOT_FOUND',
+    });
+  });
+
+  it('maps ParentLocationNotFoundError to NOT_FOUND on create', async () => {
+    const admin = userCaller();
+    await expect(
+      admin.inventory.locations.create({ name: 'Orphan', parentId: 'missing' })
+    ).rejects.toMatchObject({
+      name: 'TRPCError',
+      code: 'NOT_FOUND',
+    });
+  });
+
+  it('maps LocationSelfParentError to CONFLICT on update', async () => {
+    const admin = userCaller();
+    const created = await admin.inventory.locations.create({ name: 'Self' });
+    await expect(
+      admin.inventory.locations.update({
+        id: created.data.id,
+        data: { parentId: created.data.id },
+      })
+    ).rejects.toMatchObject({
+      name: 'TRPCError',
+      code: 'CONFLICT',
+    });
+  });
+
+  it('maps LocationCycleError to CONFLICT on update', async () => {
+    const admin = userCaller();
+    const home = await admin.inventory.locations.create({ name: 'Home' });
+    const kitchen = await admin.inventory.locations.create({
+      name: 'Kitchen',
+      parentId: home.data.id,
+    });
+    await expect(
+      admin.inventory.locations.update({
+        id: home.data.id,
+        data: { parentId: kitchen.data.id },
+      })
+    ).rejects.toMatchObject({
+      name: 'TRPCError',
+      code: 'CONFLICT',
+    });
+  });
+
+  it('rejects malformed input at the zod boundary', async () => {
+    const admin = userCaller();
+    await expect(admin.inventory.locations.create({ name: '' })).rejects.toBeInstanceOf(TRPCError);
+  });
+});
+
+describe('/trpc HTTP surface', () => {
+  function makeApp(): ReturnType<typeof createInventoryApiApp> {
+    return createInventoryApiApp({
+      inventoryDb,
+      version: '0.0.1-test',
+      selfBaseUrl: 'http://localhost:3002',
+    });
+  }
+
+  it('answers inventory.locations.list over HTTP (dev context auto-authenticates)', async () => {
+    const app = makeApp();
+    const res = await request(app).get('/trpc/inventory.locations.list');
+    expect(res.status).toBe(200);
+    expect(res.body.result.data).toEqual({ data: [], total: 0 });
+  });
+
+  it('round-trips a create mutation and reads it back', async () => {
+    const app = makeApp();
+    const created = await request(app)
+      .post('/trpc/inventory.locations.create')
+      .send({ name: 'Garage' });
+    expect(created.status).toBe(200);
+    expect(created.body.result.data.data.name).toBe('Garage');
+
+    // Service-layer write should be visible without rebooting the app.
+    const rows = locationsService.listLocations(inventoryDb.db);
+    expect(rows.total).toBe(1);
+    expect(rows.rows[0]?.name).toBe('Garage');
+  });
+});

--- a/apps/pops-inventory-api/src/app.ts
+++ b/apps/pops-inventory-api/src/app.ts
@@ -1,22 +1,26 @@
 /**
  * Express app factory for the inventory pillar container.
  *
- * Phase 3 PR 1 of the inventory pillar migration scaffolds the minimal
- * `/health` + `/pillars` surface. Subsequent PRs add the URI dispatcher
- * (`POST /uri/resolve`) and tRPC routers. Kept as a factory so the test
- * suite can spin up an in-process `supertest` instance without binding
- * a real port.
+ * Phase 3 PR 1 of the inventory pillar migration scaffolded the minimal
+ * `/health` + `/pillars` surface. Phase 5 PR 1 (Track M4) wires the
+ * tRPC handler at `/trpc` with the migrated `inventory.locations.*`
+ * procedures backed by `@pops/inventory-db` directly.
+ *
+ * The dispatcher (`POST /uri/resolve`) lands in a subsequent PR. Kept as
+ * a factory so the test suite can spin up an in-process `supertest`
+ * instance without binding a real port.
  */
+import { createExpressMiddleware } from '@trpc/server/adapters/express';
 import express, { type Express, type Request, type Response } from 'express';
 
 import { type InventoryApiDeps, makeRequestHandler } from './handlers.js';
+import { appRouter } from './router.js';
+import { createInventoryTrpcContextFactory } from './trpc.js';
 
 export function createInventoryApiApp(deps: InventoryApiDeps): Express {
   const app = express();
   app.disable('x-powered-by');
 
-  // Build the handler shape once at factory time so static deps don't
-  // get re-allocated on every request.
   const handlers = makeRequestHandler(deps);
 
   app.get('/health', (_req: Request, res: Response) => {
@@ -26,6 +30,17 @@ export function createInventoryApiApp(deps: InventoryApiDeps): Express {
   app.get('/pillars', (_req: Request, res: Response) => {
     res.json(handlers.pillars());
   });
+
+  app.use(
+    '/trpc',
+    createExpressMiddleware({
+      router: appRouter,
+      createContext: createInventoryTrpcContextFactory({
+        inventoryDb: deps.inventoryDb.db,
+        coreDb: deps.coreDb?.db,
+      }),
+    })
+  );
 
   return app;
 }

--- a/apps/pops-inventory-api/src/core-sqlite-path.ts
+++ b/apps/pops-inventory-api/src/core-sqlite-path.ts
@@ -1,0 +1,28 @@
+import { dirname, join } from 'node:path';
+
+/**
+ * Standalone resolver for the shared `core.db` path inside the
+ * inventory-api container.
+ *
+ * Intentionally NOT imported from `apps/pops-api/src/db/core-sqlite-path.ts`
+ * (or from `apps/pops-core-api/src/core-sqlite-path.ts`) — inventory-api
+ * is supposed to be runnable without either of those packages in its
+ * dependency graph. The precedence chain mirrors the other resolvers
+ * verbatim so every process agrees on the location of `core.db` given
+ * the same env: a deployer who only sets `SQLITE_PATH` (legacy
+ * contract) still ends up with `core.db` next to `pops.db`.
+ *
+ * Resolution order:
+ *   1. `CORE_SQLITE_PATH` (absolute or relative).
+ *   2. `<dirname(SQLITE_PATH)>/core.db` if the shared path is set.
+ *   3. `./data/core.db` (matches the shared default's `./data/pops.db`).
+ */
+export const DEFAULT_CORE_SQLITE_PATH = './data/core.db';
+
+export function resolveCoreSqlitePath(): string {
+  const envPath = process.env['CORE_SQLITE_PATH'];
+  if (envPath) return envPath;
+  const sharedPath = process.env['SQLITE_PATH'];
+  if (sharedPath) return join(dirname(sharedPath), 'core.db');
+  return DEFAULT_CORE_SQLITE_PATH;
+}

--- a/apps/pops-inventory-api/src/handlers.ts
+++ b/apps/pops-inventory-api/src/handlers.ts
@@ -7,12 +7,23 @@
  */
 import { getPillarRegistry } from './pillars/registry.js';
 
+import type { OpenedCoreDb } from '@pops/core-db';
 import type { OpenedInventoryDb } from '@pops/inventory-db';
 import type { PillarRegistryEntry } from '@pops/types';
 
 export interface InventoryApiDeps {
   /** Open handle to the inventory pillar's SQLite. */
   inventoryDb: OpenedInventoryDb;
+  /**
+   * Optional handle to the shared `core.db`. When present, inventory-api's
+   * tRPC context factory uses it to authenticate `X-API-Key` callers
+   * against the service-accounts table so machine principals reach
+   * inventory endpoints with the same semantics they get from the
+   * legacy pops-api router. When absent, only Cloudflare Access (or the
+   * dev/tunnel fallbacks) is honoured — used by tests that don't
+   * exercise SA auth.
+   */
+  coreDb?: OpenedCoreDb;
   /** Semver of the build, surfaced on the health response. */
   version: string;
   /**

--- a/apps/pops-inventory-api/src/middleware/cloudflare-jwt.ts
+++ b/apps/pops-inventory-api/src/middleware/cloudflare-jwt.ts
@@ -1,0 +1,89 @@
+/**
+ * Cloudflare Access JWT validation.
+ *
+ * Mirrors `apps/pops-api/src/middleware/cloudflare-jwt.ts` (and the
+ * local copy in `apps/pops-core-api/src/middleware/cloudflare-jwt.ts`)
+ * because inventory-api stands alone in the dependency graph — see the
+ * standalone comment on `inventory-sqlite-path.ts`. A future refactor
+ * can lift this into a shared `@pops/auth` package; for now duplication
+ * is the right call to keep the writer-move PR additive and easy to
+ * revert.
+ */
+import jwt from 'jsonwebtoken';
+
+import type { JwtPayload } from 'jsonwebtoken';
+
+export interface CloudflareJWTPayload extends JwtPayload {
+  email: string;
+  aud: string[];
+  iss: string;
+}
+
+interface KeyCache {
+  keys: Record<string, string>;
+  expiresAt: number;
+}
+
+let keyCache: KeyCache | null = null;
+
+async function getCloudflarePublicKeys(): Promise<Record<string, string>> {
+  const now = Date.now();
+  if (keyCache && keyCache.expiresAt > now) {
+    return keyCache.keys;
+  }
+
+  const teamName = process.env['CLOUDFLARE_ACCESS_TEAM_NAME'];
+  if (!teamName) {
+    throw new Error('CLOUDFLARE_ACCESS_TEAM_NAME not configured');
+  }
+
+  const certsUrl = `https://${teamName}.cloudflareaccess.com/cdn-cgi/access/certs`;
+  const response = await fetch(certsUrl);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch Cloudflare certs: ${response.statusText}`);
+  }
+
+  const data = (await response.json()) as {
+    public_certs: Array<{ kid: string; cert: string }>;
+  };
+
+  const keys: Record<string, string> = {};
+  for (const cert of data.public_certs) {
+    keys[cert.kid] = cert.cert;
+  }
+
+  keyCache = {
+    keys,
+    expiresAt: now + 15 * 60 * 1000,
+  };
+  return keys;
+}
+
+export async function verifyCloudflareJWT(token: string): Promise<CloudflareJWTPayload> {
+  const decoded = jwt.decode(token, { complete: true });
+  if (!decoded || typeof decoded === 'string') {
+    throw new Error('Invalid JWT: Unable to decode header');
+  }
+  const kid = decoded.header.kid;
+  if (!kid) {
+    throw new Error('Invalid JWT: Missing kid in header');
+  }
+  const publicKeys = await getCloudflarePublicKeys();
+  const publicKey = publicKeys[kid];
+  if (!publicKey) {
+    throw new Error(`Invalid JWT: Public key not found for kid ${kid}`);
+  }
+
+  const payload = jwt.verify(token, publicKey, {
+    algorithms: ['RS256'],
+  }) as CloudflareJWTPayload;
+
+  const expectedAud = process.env['CLOUDFLARE_ACCESS_AUD'];
+  if (expectedAud && !payload.aud.includes(expectedAud)) {
+    throw new Error('Invalid JWT: Audience mismatch');
+  }
+  if (!payload.email) {
+    throw new Error('Invalid JWT: Missing email claim');
+  }
+  return payload;
+}

--- a/apps/pops-inventory-api/src/modules/locations/router.ts
+++ b/apps/pops-inventory-api/src/modules/locations/router.ts
@@ -1,0 +1,156 @@
+/**
+ * Locations tRPC router — the first writer slice cut over from pops-api
+ * into pops-inventory-api as part of Phase 5 PR 1 (Track M4).
+ *
+ * Procedure surface mirrors `apps/pops-api/src/modules/inventory/locations/router.ts`
+ * with one deliberate exclusion: `getItems` is not migrated in this PR
+ * because the inventory items projection (`toInventoryItem`) still lives
+ * in `apps/pops-api/src/modules/inventory/items/types.ts` and inventory-api
+ * is supposed to stand alone in the dep graph. The legacy pops-api
+ * router keeps serving `inventory.locations.getItems` (and every other
+ * `inventory.*` route) as fall-through until Phase 5 PR 2 flips the
+ * dispatcher; this PR is purely additive.
+ *
+ * Domain errors from `@pops/inventory-db` are translated to local
+ * `HttpError` subclasses and then routed through `mapDomainErrors` so
+ * the tRPC layer sees a proper `TRPCError` with the right wire-level
+ * code (`NOT_FOUND` / `CONFLICT`).
+ */
+import { z } from 'zod';
+
+import {
+  LocationCycleError,
+  LocationNotFoundError,
+  LocationSelfParentError,
+  ParentLocationNotFoundError,
+  locationsService,
+} from '@pops/inventory-db';
+
+import { ConflictError, NotFoundError } from '../../shared/errors.js';
+import { mapDomainErrors } from '../../shared/trpc-error-mapper.js';
+import { protectedProcedure, router } from '../../trpc.js';
+import { CreateLocationSchema, LocationSchema, toLocation, UpdateLocationSchema } from './types.js';
+
+function translateLocationError(err: unknown): never {
+  if (err instanceof LocationNotFoundError) {
+    throw new NotFoundError('Location', err.id);
+  }
+  if (err instanceof ParentLocationNotFoundError) {
+    throw new NotFoundError('Parent location', err.id);
+  }
+  if (err instanceof LocationCycleError) {
+    throw new ConflictError('Moving this location would create a circular reference');
+  }
+  if (err instanceof LocationSelfParentError) {
+    throw new ConflictError('A location cannot be its own parent');
+  }
+  throw err;
+}
+
+export const locationsRouter = router({
+  tree: protectedProcedure.query(({ ctx }) => {
+    return { data: locationsService.getLocationTree(ctx.inventoryDb) };
+  }),
+
+  list: protectedProcedure
+    .output(z.object({ data: z.array(LocationSchema), total: z.number() }))
+    .query(({ ctx }) => {
+      const { rows, total } = locationsService.listLocations(ctx.inventoryDb);
+      return {
+        data: rows.map(toLocation),
+        total,
+      };
+    }),
+
+  get: protectedProcedure.input(z.object({ id: z.string() })).query(({ input, ctx }) =>
+    mapDomainErrors(() => {
+      try {
+        const row = locationsService.getLocation(ctx.inventoryDb, input.id);
+        return { data: toLocation(row) };
+      } catch (err) {
+        translateLocationError(err);
+      }
+    })
+  ),
+
+  getPath: protectedProcedure.input(z.object({ id: z.string() })).query(({ input, ctx }) =>
+    mapDomainErrors(() => {
+      try {
+        const rows = locationsService.getLocationPath(ctx.inventoryDb, input.id);
+        return { data: rows.map(toLocation) };
+      } catch (err) {
+        translateLocationError(err);
+      }
+    })
+  ),
+
+  children: protectedProcedure.input(z.object({ parentId: z.string() })).query(({ input, ctx }) => {
+    const rows = locationsService.getChildren(ctx.inventoryDb, input.parentId);
+    return { data: rows.map(toLocation) };
+  }),
+
+  create: protectedProcedure.input(CreateLocationSchema).mutation(({ input, ctx }) =>
+    mapDomainErrors(() => {
+      try {
+        const row = locationsService.createLocation(ctx.inventoryDb, input);
+        return {
+          data: toLocation(row),
+          message: 'Location created',
+        };
+      } catch (err) {
+        translateLocationError(err);
+      }
+    })
+  ),
+
+  update: protectedProcedure
+    .input(
+      z.object({
+        id: z.string(),
+        data: UpdateLocationSchema,
+      })
+    )
+    .mutation(({ input, ctx }) =>
+      mapDomainErrors(() => {
+        try {
+          const row = locationsService.updateLocation(ctx.inventoryDb, input.id, input.data);
+          return {
+            data: toLocation(row),
+            message: 'Location updated',
+          };
+        } catch (err) {
+          translateLocationError(err);
+        }
+      })
+    ),
+
+  deleteStats: protectedProcedure.input(z.object({ id: z.string() })).query(({ input, ctx }) =>
+    mapDomainErrors(() => {
+      try {
+        const stats = locationsService.getDeleteStats(ctx.inventoryDb, input.id);
+        return { data: stats };
+      } catch (err) {
+        translateLocationError(err);
+      }
+    })
+  ),
+
+  delete: protectedProcedure
+    .input(z.object({ id: z.string(), force: z.boolean().optional().default(false) }))
+    .mutation(({ input, ctx }) =>
+      mapDomainErrors(() => {
+        try {
+          if (!input.force) {
+            const stats = locationsService.getDeleteStats(ctx.inventoryDb, input.id);
+            if (stats.childCount > 0 || stats.itemCount > 0) {
+              return { requiresConfirmation: true, stats };
+            }
+          }
+          locationsService.deleteLocation(ctx.inventoryDb, input.id);
+          return { message: 'Location deleted' };
+        } catch (err) {
+          translateLocationError(err);
+        }
+      })
+    ),
+});

--- a/apps/pops-inventory-api/src/modules/locations/types.ts
+++ b/apps/pops-inventory-api/src/modules/locations/types.ts
@@ -1,0 +1,48 @@
+/**
+ * Zod contract schemas for the inventory.locations router. The shapes are
+ * byte-identical to `apps/pops-api/src/modules/inventory/locations/types.ts`
+ * — the duplication is intentional during the additive Phase 5 PR 1
+ * window so the legacy pops-api router can keep serving traffic while
+ * inventory-api stands up its own copy.
+ */
+import { z } from 'zod';
+
+import type { LocationRow } from '@pops/db-types';
+
+/** API response shape for a location. */
+export interface Location {
+  id: string;
+  name: string;
+  parentId: string | null;
+  sortOrder: number;
+}
+
+export function toLocation(row: LocationRow): Location {
+  return {
+    id: row.id,
+    name: row.name,
+    parentId: row.parentId,
+    sortOrder: row.sortOrder,
+  };
+}
+
+export const LocationSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  parentId: z.string().nullable(),
+  sortOrder: z.number(),
+});
+
+export const CreateLocationSchema = z.object({
+  name: z.string().min(1, 'Name is required'),
+  parentId: z.string().nullable().optional(),
+  sortOrder: z.number().int().nonnegative().optional().default(0),
+});
+export type CreateLocationInput = z.infer<typeof CreateLocationSchema>;
+
+export const UpdateLocationSchema = z.object({
+  name: z.string().min(1, 'Name cannot be empty').optional(),
+  parentId: z.string().nullable().optional(),
+  sortOrder: z.number().int().nonnegative().optional(),
+});
+export type UpdateLocationInput = z.infer<typeof UpdateLocationSchema>;

--- a/apps/pops-inventory-api/src/router.ts
+++ b/apps/pops-inventory-api/src/router.ts
@@ -1,0 +1,21 @@
+/**
+ * Root tRPC router for the inventory pillar container.
+ *
+ * The procedure paths are intentionally rooted at `inventory.*` so the
+ * Phase 5 PR 2 dispatcher cutover can be a transparent URL swap rather
+ * than a procedure-path rename: existing pops-api clients call
+ * `inventory.locations.list`, and inventory-api answers on the same
+ * path.
+ */
+import { locationsRouter } from './modules/locations/router.js';
+import { router } from './trpc.js';
+
+export const inventoryRouter = router({
+  locations: locationsRouter,
+});
+
+export const appRouter = router({
+  inventory: inventoryRouter,
+});
+
+export type AppRouter = typeof appRouter;

--- a/apps/pops-inventory-api/src/server.ts
+++ b/apps/pops-inventory-api/src/server.ts
@@ -10,9 +10,11 @@
  * `openInventoryDb` rather than reaching back into pops-api's
  * singleton — that's the whole point of phase 3.
  */
+import { openCoreDb } from '@pops/core-db';
 import { openInventoryDb } from '@pops/inventory-db';
 
 import { createInventoryApiApp } from './app.js';
+import { resolveCoreSqlitePath } from './core-sqlite-path.js';
 import { resolveInventorySqlitePath } from './inventory-sqlite-path.js';
 import { parseBareOrigin } from './pillars/env.js';
 
@@ -51,7 +53,8 @@ function resolveSelfBaseUrl(): string {
 const selfBaseUrl = resolveSelfBaseUrl();
 
 const inventoryDb = openInventoryDb(resolveInventorySqlitePath());
-const app = createInventoryApiApp({ inventoryDb, version, selfBaseUrl });
+const coreDb = openCoreDb(resolveCoreSqlitePath());
+const app = createInventoryApiApp({ inventoryDb, coreDb, version, selfBaseUrl });
 
 const server = app.listen(port, () => {
   console.warn(`[inventory-api] Listening on port ${port}`);
@@ -64,6 +67,7 @@ function shutdown(signal: NodeJS.Signals): void {
   console.warn(`[inventory-api] Shutting down (${signal})`);
   server.close(() => {
     inventoryDb.raw.close();
+    coreDb.raw.close();
   });
 }
 

--- a/apps/pops-inventory-api/src/shared/errors.ts
+++ b/apps/pops-inventory-api/src/shared/errors.ts
@@ -3,37 +3,45 @@
  *
  * Intentionally NOT imported from `apps/pops-api/src/shared/errors.ts` —
  * the per-pillar container is supposed to stand alone of pops-api in the
- * dependency graph (Phase 5 writer-move pattern, mirrors
- * `apps/pops-core-api/src/shared/errors.ts`).
+ * dependency graph (Phase 5 writer-move pattern). Each error carries an
+ * optional `messageKey` so the frontend can look up the translated string
+ * while the EN-AU fallback lives in `message`; the inventory-api tRPC
+ * initialiser plumbs it through the wire error shape so clients continue
+ * receiving `data.messageKey` after the Phase 5 PR 2 cutover.
  */
 export class HttpError extends Error {
+  /** i18n key the frontend uses to resolve a localised message. */
+  public readonly messageKey?: string;
+
   constructor(
     public readonly statusCode: number,
     message: string,
-    public readonly details?: unknown
+    public readonly details?: unknown,
+    messageKey?: string
   ) {
     super(message);
     this.name = 'HttpError';
+    this.messageKey = messageKey;
   }
 }
 
 export class NotFoundError extends HttpError {
   constructor(resource: string, id: string) {
-    super(404, `${resource} '${id}' not found`);
+    super(404, `${resource} '${id}' not found`, undefined, 'common.notFound');
     this.name = 'NotFoundError';
   }
 }
 
 export class ValidationError extends HttpError {
   constructor(details: unknown) {
-    super(400, 'Validation failed', details);
+    super(400, 'Validation failed', details, 'common.validationFailed');
     this.name = 'ValidationError';
   }
 }
 
 export class ConflictError extends HttpError {
   constructor(message: string) {
-    super(409, message);
+    super(409, message, undefined, 'common.conflict');
     this.name = 'ConflictError';
   }
 }

--- a/apps/pops-inventory-api/src/shared/errors.ts
+++ b/apps/pops-inventory-api/src/shared/errors.ts
@@ -1,0 +1,39 @@
+/**
+ * HTTP-shaped domain errors used by inventory-api router handlers.
+ *
+ * Intentionally NOT imported from `apps/pops-api/src/shared/errors.ts` —
+ * the per-pillar container is supposed to stand alone of pops-api in the
+ * dependency graph (Phase 5 writer-move pattern, mirrors
+ * `apps/pops-core-api/src/shared/errors.ts`).
+ */
+export class HttpError extends Error {
+  constructor(
+    public readonly statusCode: number,
+    message: string,
+    public readonly details?: unknown
+  ) {
+    super(message);
+    this.name = 'HttpError';
+  }
+}
+
+export class NotFoundError extends HttpError {
+  constructor(resource: string, id: string) {
+    super(404, `${resource} '${id}' not found`);
+    this.name = 'NotFoundError';
+  }
+}
+
+export class ValidationError extends HttpError {
+  constructor(details: unknown) {
+    super(400, 'Validation failed', details);
+    this.name = 'ValidationError';
+  }
+}
+
+export class ConflictError extends HttpError {
+  constructor(message: string) {
+    super(409, message);
+    this.name = 'ConflictError';
+  }
+}

--- a/apps/pops-inventory-api/src/shared/trpc-error-mapper.ts
+++ b/apps/pops-inventory-api/src/shared/trpc-error-mapper.ts
@@ -1,0 +1,46 @@
+import { TRPCError } from '@trpc/server';
+
+import { HttpError } from './errors.js';
+
+type TRPCCode = ConstructorParameters<typeof TRPCError>[0]['code'];
+
+const HTTP_STATUS_TO_TRPC_CODE: Readonly<Record<number, TRPCCode>> = {
+  400: 'BAD_REQUEST',
+  401: 'UNAUTHORIZED',
+  402: 'PAYMENT_REQUIRED',
+  403: 'FORBIDDEN',
+  404: 'NOT_FOUND',
+  409: 'CONFLICT',
+  412: 'PRECONDITION_FAILED',
+  422: 'UNPROCESSABLE_CONTENT',
+  429: 'TOO_MANY_REQUESTS',
+  500: 'INTERNAL_SERVER_ERROR',
+};
+
+function toTRPCError(err: HttpError): TRPCError {
+  const code = HTTP_STATUS_TO_TRPC_CODE[err.statusCode] ?? 'INTERNAL_SERVER_ERROR';
+  return new TRPCError({ code, message: err.message, cause: err });
+}
+
+/**
+ * Runs `fn` and re-throws any HttpError subclass as the corresponding
+ * TRPCError. Non-HttpError throws bubble unchanged so the global tRPC
+ * error handler can see them as 500s.
+ */
+export function mapDomainErrors<T>(fn: () => T): T {
+  try {
+    return fn();
+  } catch (err) {
+    if (err instanceof HttpError) throw toTRPCError(err);
+    throw err;
+  }
+}
+
+export async function mapDomainErrorsAsync<T>(fn: () => Promise<T>): Promise<T> {
+  try {
+    return await fn();
+  } catch (err) {
+    if (err instanceof HttpError) throw toTRPCError(err);
+    throw err;
+  }
+}

--- a/apps/pops-inventory-api/src/trpc.ts
+++ b/apps/pops-inventory-api/src/trpc.ts
@@ -1,0 +1,171 @@
+/**
+ * tRPC initialisation for the inventory pillar container.
+ *
+ * Mirrors the auth surface of `apps/pops-api/src/trpc.ts` (and the local
+ * copy in `apps/pops-core-api/src/trpc.ts`) but trims what inventory-api
+ * doesn't need yet:
+ *   - no module gate (per-pillar containers serve a single pillar by
+ *     definition; the install-set check lives at the dispatcher layer
+ *     above this process);
+ *   - no `internalProcedure` (no sibling-process callers for inventory
+ *     yet);
+ *   - no OpenAPI meta (the dispatcher/gateway owns OpenAPI; inventory-api
+ *     handlers are tRPC-only for now).
+ *
+ * The inventory DB handle is injected at context-creation time via the
+ * factory in `createInventoryTrpcContextFactory` so tests can swap in
+ * an in-memory handle without touching env vars or the production
+ * resolver. The optional `coreDb` handle is what powers service-account
+ * authentication and scope checks; production wires it from the shared
+ * `core.db` volume so `protectedProcedure` keeps accepting machine
+ * principals byte-identically to the legacy pops-api router. Tests that
+ * don't exercise service-account auth can omit it — `protectedProcedure`
+ * will fall back to UNAUTHORIZED for any caller without a user.
+ */
+import { initTRPC, TRPCError } from '@trpc/server';
+
+import {
+  type AuthenticatedServiceAccount,
+  type CoreDb,
+  serviceAccountKeys,
+  serviceAccountsService,
+} from '@pops/core-db';
+import { type InventoryDb } from '@pops/inventory-db';
+
+import { verifyCloudflareJWT } from './middleware/cloudflare-jwt.js';
+
+import type { CreateExpressContextOptions } from '@trpc/server/adapters/express';
+
+export interface User {
+  email: string;
+}
+
+export interface Context {
+  user: User | null;
+  serviceAccount: AuthenticatedServiceAccount | null;
+  inventoryDb: InventoryDb;
+}
+
+function readApiKeyHeader(req: CreateExpressContextOptions['req']): string | null {
+  const raw = req.headers['x-api-key'];
+  if (Array.isArray(raw)) return raw[0] ?? null;
+  if (typeof raw === 'string' && raw.length > 0) return raw;
+  return null;
+}
+
+async function tryServiceAccountAuth(
+  coreDb: CoreDb | null,
+  req: CreateExpressContextOptions['req']
+): Promise<AuthenticatedServiceAccount | null> {
+  if (!coreDb) return null;
+  const header = readApiKeyHeader(req);
+  if (!header) return null;
+  const parsed = serviceAccountKeys.parseApiKey(header);
+  if (!parsed) return null;
+  return serviceAccountsService.authenticateServiceAccount(coreDb, parsed.prefix, parsed.secret);
+}
+
+export interface InventoryTrpcContextFactoryDeps {
+  inventoryDb: InventoryDb;
+  /**
+   * Optional core DB handle used to authenticate `X-API-Key` callers.
+   * When omitted, service-account auth is disabled and only Cloudflare
+   * Access (or the dev/tunnel fallbacks) is honoured. Production wires
+   * this from the shared `core.db` volume; tests typically leave it
+   * undefined unless they specifically exercise SA paths.
+   */
+  coreDb?: CoreDb;
+}
+
+/**
+ * Build a tRPC context factory bound to specific DB handles.
+ */
+export function createInventoryTrpcContextFactory(
+  deps: InventoryTrpcContextFactoryDeps
+): (opts: CreateExpressContextOptions) => Promise<Context> {
+  const coreDb = deps.coreDb ?? null;
+  return async ({ req }: CreateExpressContextOptions): Promise<Context> => {
+    const serviceAccount = await tryServiceAccountAuth(coreDb, req);
+    if (serviceAccount) {
+      return { user: null, serviceAccount, inventoryDb: deps.inventoryDb };
+    }
+
+    if (process.env['NODE_ENV'] !== 'production') {
+      return {
+        user: { email: 'dev@example.com' },
+        serviceAccount: null,
+        inventoryDb: deps.inventoryDb,
+      };
+    }
+
+    if (!process.env['CLOUDFLARE_ACCESS_TEAM_NAME']) {
+      return {
+        user: { email: 'tunnel-authenticated@pops.local' },
+        serviceAccount: null,
+        inventoryDb: deps.inventoryDb,
+      };
+    }
+
+    const token = req.headers['cf-access-jwt-assertion'];
+    if (typeof token === 'string') {
+      try {
+        const payload = await verifyCloudflareJWT(token);
+        return {
+          user: { email: payload.email },
+          serviceAccount: null,
+          inventoryDb: deps.inventoryDb,
+        };
+      } catch (error) {
+        console.error('[inventory-api] JWT verification failed:', error);
+        return { user: null, serviceAccount: null, inventoryDb: deps.inventoryDb };
+      }
+    }
+
+    return { user: null, serviceAccount: null, inventoryDb: deps.inventoryDb };
+  };
+}
+
+const t = initTRPC.context<Context>().create();
+
+export const router = t.router;
+
+export const publicProcedure = t.procedure;
+
+/**
+ * Protected procedure that requires either a Cloudflare Access user OR
+ * an authenticated service account whose granted scopes cover the
+ * procedure path. Mirrors the semantics of `protectedProcedure` in
+ * `apps/pops-api/src/trpc.ts` so the writer-move is wire-compatible.
+ */
+export const protectedProcedure = t.procedure.use(({ ctx, path, next }) => {
+  if (ctx.user) {
+    return next({
+      ctx: {
+        user: ctx.user,
+        serviceAccount: ctx.serviceAccount,
+        inventoryDb: ctx.inventoryDb,
+      },
+    });
+  }
+
+  if (ctx.serviceAccount) {
+    if (!serviceAccountsService.hasScopeFor(ctx.serviceAccount.scopes, path)) {
+      throw new TRPCError({
+        code: 'FORBIDDEN',
+        message: `Service account '${ctx.serviceAccount.name}' is not authorised for '${path}'`,
+      });
+    }
+    return next({
+      ctx: {
+        user: ctx.user,
+        serviceAccount: ctx.serviceAccount,
+        inventoryDb: ctx.inventoryDb,
+      },
+    });
+  }
+
+  throw new TRPCError({
+    code: 'UNAUTHORIZED',
+    message: 'Missing or invalid credentials (expected Cloudflare Access JWT or X-API-Key)',
+  });
+});

--- a/apps/pops-inventory-api/src/trpc.ts
+++ b/apps/pops-inventory-api/src/trpc.ts
@@ -125,7 +125,21 @@ export function createInventoryTrpcContextFactory(
   };
 }
 
-const t = initTRPC.context<Context>().create();
+const t = initTRPC.context<Context>().create({
+  errorFormatter({ shape, error }) {
+    return {
+      ...shape,
+      data: {
+        ...shape.data,
+        /** i18n key for frontend translation lookup — mirrors pops-api's wire shape. */
+        messageKey:
+          error.cause instanceof Error && 'messageKey' in error.cause
+            ? (error.cause as { messageKey?: string }).messageKey
+            : undefined,
+      },
+    };
+  },
+});
 
 export const router = t.router;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -423,19 +423,37 @@ importers:
 
   apps/pops-inventory-api:
     dependencies:
+      '@pops/core-db':
+        specifier: workspace:*
+        version: link:../../packages/core-db
+      '@pops/db-types':
+        specifier: workspace:*
+        version: link:../../packages/db-types
       '@pops/inventory-db':
         specifier: workspace:*
         version: link:../../packages/inventory-db
       '@pops/types':
         specifier: workspace:*
         version: link:../../packages/types
+      '@trpc/server':
+        specifier: ^11.17.0
+        version: 11.17.0(typescript@6.0.3)
       express:
         specifier: ^5.1.0
         version: 5.2.1
+      jsonwebtoken:
+        specifier: ^9.0.3
+        version: 9.0.3
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@types/express':
         specifier: ^5.0.4
         version: 5.0.6
+      '@types/jsonwebtoken':
+        specifier: ^9.0.10
+        version: 9.0.10
       '@types/node':
         specifier: ^25.9.1
         version: 25.9.1


### PR DESCRIPTION
## Summary

- **Phase 5 PR 1 / Track M4 (inventory pillar writer-move kickoff).** Moves the `inventory.locations.*` tRPC surface from `apps/pops-api/src/modules/inventory/locations/` into `apps/pops-inventory-api/src/modules/locations/`, backed by `@pops/inventory-db` directly through the already-open `inventory.db` handle.
- Mirrors the canonical pattern from M1 #2889: local copy of `trpc.ts` + `middleware/cloudflare-jwt.ts` + `shared/{errors,trpc-error-mapper}.ts` so `pops-inventory-api` stands alone in the dep graph. `protectedProcedure` keeps the legacy semantics (Cloudflare Access user OR scope-checked service-account principal).
- **Additive only — the legacy router in `pops-api` stays in place.** Until Phase 5 PR 2 flips the dispatcher / nginx routing rules, every `inventory.*` request still lands in the legacy router; the new container is a shadow ready to take over.

## Scope notes

- `getItems` is intentionally **not** migrated. It depends on the items projection (`toInventoryItem`) which still lives in `apps/pops-api/src/modules/inventory/items/types.ts`, and pulling that across would force the items slice to move at the same time. The legacy router keeps serving `inventory.locations.getItems` (and every other `inventory.*` route) as fall-through; a follow-up PR moves it once the items slice itself is in `@pops/inventory-db`.
- `pops-inventory-api` now opens both `inventory.db` (for writes) and the shared `core.db` (read-only, for service-account auth). Retiring the shared volume is the explicit goal of Phase 5 PR 3, not this one.
- Procedure paths are rooted at `inventory.*` so the Phase 5 PR 2 dispatcher swap is a transparent URL flip, not a path rename.

## Test plan

- [x] `pnpm --filter @pops/inventory-api typecheck` — clean
- [x] `pnpm --filter @pops/inventory-api test` — 27/27 pass (4 files: health, pillars, sqlite-path, locations)
- [x] `pnpm --filter @pops/inventory-api build` — clean
- [x] `pnpm typecheck` (turbo, all projects) — 51/51 successful
- [x] `pnpm lint` — no new errors; one pre-existing warning in `pillars/registry.ts` left untouched
- [x] `pnpm format`
- [x] `pnpm --filter @pops/api test` — 4874 pass, 1 pre-existing flaky cerebrum/thalamus/watcher test (passes in isolation)
- [ ] Phase 5 PR 2 will exercise this via the dispatcher cutover; this PR is shadow-only

## Coverage in `src/__tests__/locations.test.ts`

- Happy-path tRPC caller: create → list → get → delete, nested tree assembly, breadcrumb path, direct children only, name update, populated-location delete requires `force`.
- Auth + error mapping: anonymous → UNAUTHORIZED, in-scope SA caller succeeds, out-of-scope SA → FORBIDDEN, unknown id → NOT_FOUND, missing parent → NOT_FOUND, self-parent → CONFLICT, cycle → CONFLICT, malformed zod input rejected.
- HTTP wire smoke via supertest: `GET /trpc/inventory.locations.list` returns the empty shape; `POST /trpc/inventory.locations.create` round-trips and the row is readable via the service layer.

## References

- Roadmap row: Track M4 in `pillar-migration-roadmap.md` — claimed as `In progress` with this branch name.
- Pattern: M1 (#2889) — service-accounts router move into `pops-core-api`.
- Tracking issue: #2835.
