### PR TITLE
feat(cerebrum-api): move nudge_log router into pops-cerebrum-api (Track M5 PR 1)

### DIFF
--- a/apps/pops-cerebrum-api/Dockerfile
+++ b/apps/pops-cerebrum-api/Dockerfile
@@ -7,6 +7,7 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json ./
 # Copy workspace package.json files (for dep resolution)
 COPY packages/db-types/package.json ./packages/db-types/
 COPY packages/types/package.json ./packages/types/
+COPY packages/core-db/package.json ./packages/core-db/
 COPY packages/cerebrum-db/package.json ./packages/cerebrum-db/
 COPY apps/pops-cerebrum-api/package.json ./apps/pops-cerebrum-api/
 
@@ -19,6 +20,9 @@ COPY packages/db-types/src ./packages/db-types/src
 COPY packages/db-types/tsconfig.json ./packages/db-types/
 COPY packages/types/src ./packages/types/src
 COPY packages/types/tsconfig.json packages/types/tsconfig.build.json ./packages/types/
+COPY packages/core-db/src ./packages/core-db/src
+COPY packages/core-db/tsconfig.json ./packages/core-db/
+COPY packages/core-db/migrations ./packages/core-db/migrations
 COPY packages/cerebrum-db/src ./packages/cerebrum-db/src
 COPY packages/cerebrum-db/tsconfig.json ./packages/cerebrum-db/
 COPY packages/cerebrum-db/migrations ./packages/cerebrum-db/migrations
@@ -31,6 +35,8 @@ COPY apps/pops-cerebrum-api/src ./apps/pops-cerebrum-api/src
 WORKDIR /app/packages/db-types
 RUN pnpm build
 WORKDIR /app/packages/types
+RUN pnpm build
+WORKDIR /app/packages/core-db
 RUN pnpm build
 WORKDIR /app/packages/cerebrum-db
 RUN pnpm build

--- a/apps/pops-cerebrum-api/package.json
+++ b/apps/pops-cerebrum-api/package.json
@@ -13,12 +13,18 @@
   },
   "dependencies": {
     "@pops/cerebrum-db": "workspace:*",
+    "@pops/core-db": "workspace:*",
     "@pops/types": "workspace:*",
+    "@trpc/server": "^11.17.0",
+    "drizzle-orm": "^0.45.2",
     "express": "^5.1.0",
-    "pino": "^10.3.1"
+    "jsonwebtoken": "^9.0.3",
+    "pino": "^10.3.1",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/express": "^5.0.4",
+    "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^25.9.1",
     "@types/supertest": "^6.0.3",
     "@vitest/coverage-v8": "^4.1.8",

--- a/apps/pops-cerebrum-api/src/__tests__/health.test.ts
+++ b/apps/pops-cerebrum-api/src/__tests__/health.test.ts
@@ -13,32 +13,36 @@ import request from 'supertest';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { openCerebrumDb, type OpenedCerebrumDb } from '@pops/cerebrum-db';
+import { openCoreDb, type OpenedCoreDb } from '@pops/core-db';
 
 import { createCerebrumApiApp } from '../app.js';
 
 let tmpDir: string;
 let cerebrumDb: OpenedCerebrumDb;
+let coreDb: OpenedCoreDb;
 
 beforeEach(() => {
   tmpDir = mkdtempSync(join(tmpdir(), 'cerebrum-api-test-'));
   cerebrumDb = openCerebrumDb(join(tmpDir, 'cerebrum.db'));
+  coreDb = openCoreDb(join(tmpDir, 'core.db'));
 });
 
 afterEach(() => {
   cerebrumDb.raw.close();
+  coreDb.raw.close();
   rmSync(tmpDir, { recursive: true, force: true });
 });
 
 describe('GET /health', () => {
   it('returns ok + pillar + version', async () => {
-    const app = createCerebrumApiApp({ cerebrumDb, version: '0.0.1-test' });
+    const app = createCerebrumApiApp({ cerebrumDb, coreDb, version: '0.0.1-test' });
     const res = await request(app).get('/health');
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ ok: true, pillar: 'cerebrum', version: '0.0.1-test' });
   });
 
   it('fails closed when the cerebrum handle is closed', async () => {
-    const app = createCerebrumApiApp({ cerebrumDb, version: '0.0.1-test' });
+    const app = createCerebrumApiApp({ cerebrumDb, coreDb, version: '0.0.1-test' });
     cerebrumDb.raw.close();
     const res = await request(app).get('/health');
     expect(res.status).toBe(500);

--- a/apps/pops-cerebrum-api/src/__tests__/nudges.test.ts
+++ b/apps/pops-cerebrum-api/src/__tests__/nudges.test.ts
@@ -1,0 +1,316 @@
+/**
+ * Integration tests for the migrated `cerebrum.nudges.*` read/dismiss
+ * tRPC surface inside pops-cerebrum-api (Phase 5 PR 1 / Track M5).
+ *
+ * Two layers of coverage:
+ *
+ *   1. tRPC caller smoke — drives `appRouter.createCaller(ctx)` against
+ *      a per-test in-memory cerebrum.db. Locks in the shape contract the
+ *      legacy pops-api router enforced (list / get / dismiss /
+ *      contradictions) and the new wire-shape error split for dismiss
+ *      (NOT_FOUND vs CONFLICT) — the legacy router collapsed both into
+ *      BAD_REQUEST.
+ *
+ *   2. HTTP wire smoke — boots the Express app via `createCerebrumApiApp`
+ *      and round-trips one query over `/trpc` with supertest. Proves
+ *      `createExpressMiddleware` is wired up and the dev-context
+ *      fallback authenticates the caller as a human.
+ *
+ * Persistence-layer invariants (cooldown dedup, pending-cap, contradiction
+ * filtering at the SQL layer) already live in
+ * `packages/cerebrum-db/src/__tests__/nudge-log.test.ts` — duplicating
+ * them here would just test drizzle.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { TRPCError } from '@trpc/server';
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  type CerebrumDb,
+  nudgeLog,
+  openCerebrumDb,
+  type OpenedCerebrumDb,
+} from '@pops/cerebrum-db';
+import { openCoreDb, type OpenedCoreDb } from '@pops/core-db';
+
+import { createCerebrumApiApp } from '../app.js';
+import { appRouter } from '../router.js';
+import { type Context } from '../trpc.js';
+
+let tmpDir: string;
+let cerebrumDb: OpenedCerebrumDb;
+let coreDb: OpenedCoreDb;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'cerebrum-api-nudges-test-'));
+  cerebrumDb = openCerebrumDb(join(tmpDir, 'cerebrum.db'));
+  coreDb = openCoreDb(join(tmpDir, 'core.db'));
+});
+
+afterEach(() => {
+  cerebrumDb.raw.close();
+  coreDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+interface SeedRow {
+  id: string;
+  type?: 'pattern' | 'staleness' | 'consolidation' | 'insight';
+  status?: 'pending' | 'dismissed' | 'acted' | 'expired';
+  priority?: 'low' | 'medium' | 'high';
+  createdAt: string;
+  actionParams?: Record<string, unknown> | null;
+}
+
+function seed(db: CerebrumDb, rows: SeedRow[]): void {
+  for (const r of rows) {
+    db.insert(nudgeLog)
+      .values({
+        id: r.id,
+        type: r.type ?? 'pattern',
+        title: `Title for ${r.id}`,
+        body: `Body for ${r.id}`,
+        engramIds: JSON.stringify(['eA', 'eB']),
+        priority: r.priority ?? 'medium',
+        status: r.status ?? 'pending',
+        createdAt: r.createdAt,
+        actionType: r.actionParams === null ? null : 'link',
+        actionLabel: r.actionParams === null ? null : 'Open',
+        actionParams:
+          r.actionParams === null || r.actionParams === undefined
+            ? null
+            : JSON.stringify(r.actionParams),
+      })
+      .run();
+  }
+}
+
+function userCaller(email = 'user@example.com'): ReturnType<typeof appRouter.createCaller> {
+  const ctx: Context = {
+    user: { email },
+    serviceAccount: null,
+    coreDb: coreDb.db,
+    cerebrumDb: cerebrumDb.db,
+  };
+  return appRouter.createCaller(ctx);
+}
+
+function anonCaller(): ReturnType<typeof appRouter.createCaller> {
+  const ctx: Context = {
+    user: null,
+    serviceAccount: null,
+    coreDb: coreDb.db,
+    cerebrumDb: cerebrumDb.db,
+  };
+  return appRouter.createCaller(ctx);
+}
+
+describe('cerebrum.nudges.list (tRPC caller)', () => {
+  it('returns an empty page when no nudges are present', async () => {
+    const result = await userCaller().cerebrum.nudges.list();
+    expect(result).toEqual({ nudges: [], total: 0 });
+  });
+
+  it('returns rows in createdAt-desc order with a total count', async () => {
+    seed(cerebrumDb.db, [
+      { id: 'n_1', createdAt: '2026-06-09T10:00:00.000Z' },
+      { id: 'n_2', createdAt: '2026-06-10T10:00:00.000Z' },
+      { id: 'n_3', createdAt: '2026-06-11T10:00:00.000Z' },
+    ]);
+    const result = await userCaller().cerebrum.nudges.list();
+    expect(result.total).toBe(3);
+    expect(result.nudges.map((n) => n.id)).toEqual(['n_3', 'n_2', 'n_1']);
+  });
+
+  it('honours the status filter', async () => {
+    seed(cerebrumDb.db, [
+      { id: 'p1', status: 'pending', createdAt: '2026-06-10T10:00:00.000Z' },
+      { id: 'd1', status: 'dismissed', createdAt: '2026-06-10T11:00:00.000Z' },
+      { id: 'p2', status: 'pending', createdAt: '2026-06-10T12:00:00.000Z' },
+    ]);
+    const result = await userCaller().cerebrum.nudges.list({ status: 'pending' });
+    expect(result.total).toBe(2);
+    expect(result.nudges.map((n) => n.id).toSorted()).toEqual(['p1', 'p2']);
+  });
+
+  it('rejects an anonymous caller (UNAUTHORIZED)', async () => {
+    await expect(anonCaller().cerebrum.nudges.list()).rejects.toMatchObject({
+      name: 'TRPCError',
+      code: 'UNAUTHORIZED',
+    });
+  });
+});
+
+describe('cerebrum.nudges.get (tRPC caller)', () => {
+  it('returns a known nudge wrapped in `{ nudge }`', async () => {
+    seed(cerebrumDb.db, [{ id: 'n_known', createdAt: '2026-06-11T10:00:00.000Z' }]);
+    const result = await userCaller().cerebrum.nudges.get({ id: 'n_known' });
+    expect(result.nudge.id).toBe('n_known');
+    expect(result.nudge.title).toBe('Title for n_known');
+  });
+
+  it('throws NOT_FOUND for an unknown nudge id', async () => {
+    await expect(
+      userCaller().cerebrum.nudges.get({ id: 'n_does_not_exist' })
+    ).rejects.toMatchObject({
+      name: 'TRPCError',
+      code: 'NOT_FOUND',
+      cause: expect.objectContaining({ name: 'NotFoundError' }),
+    });
+  });
+
+  it('rejects an anonymous caller (UNAUTHORIZED)', async () => {
+    await expect(anonCaller().cerebrum.nudges.get({ id: 'whatever' })).rejects.toMatchObject({
+      name: 'TRPCError',
+      code: 'UNAUTHORIZED',
+    });
+  });
+});
+
+describe('cerebrum.nudges.dismiss (tRPC caller)', () => {
+  it('dismisses a pending nudge', async () => {
+    seed(cerebrumDb.db, [{ id: 'd_ok', status: 'pending', createdAt: '2026-06-11T10:00:00.000Z' }]);
+    const result = await userCaller().cerebrum.nudges.dismiss({ id: 'd_ok' });
+    expect(result).toEqual({ success: true });
+    const after = await userCaller().cerebrum.nudges.get({ id: 'd_ok' });
+    expect(after.nudge.status).toBe('dismissed');
+  });
+
+  it('throws NOT_FOUND for an unknown nudge id', async () => {
+    await expect(userCaller().cerebrum.nudges.dismiss({ id: 'd_missing' })).rejects.toMatchObject({
+      name: 'TRPCError',
+      code: 'NOT_FOUND',
+    });
+  });
+
+  it('throws CONFLICT when the nudge is already dismissed', async () => {
+    seed(cerebrumDb.db, [
+      { id: 'd_done', status: 'dismissed', createdAt: '2026-06-11T10:00:00.000Z' },
+    ]);
+    await expect(userCaller().cerebrum.nudges.dismiss({ id: 'd_done' })).rejects.toMatchObject({
+      name: 'TRPCError',
+      code: 'CONFLICT',
+    });
+  });
+
+  it('throws CONFLICT when the nudge has already been acted on', async () => {
+    seed(cerebrumDb.db, [
+      { id: 'd_acted', status: 'acted', createdAt: '2026-06-11T10:00:00.000Z' },
+    ]);
+    await expect(userCaller().cerebrum.nudges.dismiss({ id: 'd_acted' })).rejects.toMatchObject({
+      name: 'TRPCError',
+      code: 'CONFLICT',
+    });
+  });
+
+  it('rejects an anonymous caller (UNAUTHORIZED)', async () => {
+    seed(cerebrumDb.db, [{ id: 'd_x', status: 'pending', createdAt: '2026-06-11T10:00:00.000Z' }]);
+    await expect(anonCaller().cerebrum.nudges.dismiss({ id: 'd_x' })).rejects.toMatchObject({
+      name: 'TRPCError',
+      code: 'UNAUTHORIZED',
+    });
+  });
+
+  it('rejects malformed input at the zod boundary (BAD_REQUEST)', async () => {
+    await expect(userCaller().cerebrum.nudges.dismiss({ id: '' })).rejects.toBeInstanceOf(
+      TRPCError
+    );
+  });
+});
+
+describe('cerebrum.nudges.contradictions (tRPC caller)', () => {
+  it('returns an empty page when no contradictions exist', async () => {
+    const result = await userCaller().cerebrum.nudges.contradictions();
+    expect(result).toEqual({ contradictions: [], total: 0 });
+  });
+
+  it('returns shaped rows for contradiction-pattern nudges only', async () => {
+    seed(cerebrumDb.db, [
+      {
+        id: 'c_1',
+        type: 'pattern',
+        createdAt: '2026-06-11T10:00:00.000Z',
+        actionParams: {
+          contradiction: {
+            engramA: 'engA1',
+            engramB: 'engB1',
+            excerptA: 'first claim',
+            excerptB: 'opposite claim',
+            conflict: 'they disagree on X',
+          },
+        },
+      },
+      {
+        id: 'c_recurring',
+        type: 'pattern',
+        createdAt: '2026-06-11T11:00:00.000Z',
+        actionParams: { recurring: true },
+      },
+      {
+        id: 'c_other_type',
+        type: 'staleness',
+        createdAt: '2026-06-11T12:00:00.000Z',
+        actionParams: {
+          contradiction: {
+            engramA: 'x',
+            engramB: 'y',
+            excerptA: 'a',
+            excerptB: 'b',
+            conflict: 'c',
+          },
+        },
+      },
+    ]);
+    const result = await userCaller().cerebrum.nudges.contradictions();
+    expect(result.total).toBe(1);
+    expect(result.contradictions).toHaveLength(1);
+    const [row] = result.contradictions;
+    expect(row).toMatchObject({
+      id: 'c_1',
+      engramA: 'engA1',
+      engramB: 'engB1',
+      conflict: 'they disagree on X',
+    });
+  });
+
+  it('rejects an anonymous caller (UNAUTHORIZED)', async () => {
+    await expect(anonCaller().cerebrum.nudges.contradictions()).rejects.toMatchObject({
+      name: 'TRPCError',
+      code: 'UNAUTHORIZED',
+    });
+  });
+});
+
+describe('/trpc HTTP surface', () => {
+  function makeApp(): ReturnType<typeof createCerebrumApiApp> {
+    return createCerebrumApiApp({ cerebrumDb, coreDb, version: '0.0.1-test' });
+  }
+
+  it('answers cerebrum.nudges.list over HTTP (dev context auto-authenticates)', async () => {
+    seed(cerebrumDb.db, [
+      { id: 'http_1', createdAt: '2026-06-11T10:00:00.000Z' },
+      { id: 'http_2', createdAt: '2026-06-11T11:00:00.000Z' },
+    ]);
+    const app = makeApp();
+    const res = await request(app).get('/trpc/cerebrum.nudges.list');
+    expect(res.status).toBe(200);
+    expect(res.body.result.data.total).toBe(2);
+    expect(res.body.result.data.nudges.map((n: { id: string }) => n.id)).toEqual([
+      'http_2',
+      'http_1',
+    ]);
+  });
+
+  it('returns a tRPC NOT_FOUND envelope for an unknown nudge over HTTP', async () => {
+    const app = makeApp();
+    const res = await request(app)
+      .get('/trpc/cerebrum.nudges.get')
+      .query({ input: JSON.stringify({ id: 'unknown' }) });
+    expect(res.status).toBe(404);
+    expect(res.body.error.data.code).toBe('NOT_FOUND');
+  });
+});

--- a/apps/pops-cerebrum-api/src/app.ts
+++ b/apps/pops-cerebrum-api/src/app.ts
@@ -1,28 +1,45 @@
 /**
  * Express app factory for the cerebrum pillar container.
  *
- * Phase 3 PR 1 of the cerebrum pillar migration ships the minimal
- * `/health` surface so the new container can be wired into
+ * Phase 3 PR 1 of the cerebrum pillar migration shipped the minimal
+ * `/health` surface so the new container could be wired into
  * docker-compose + Watchtower without depending on the (still-unfinished)
- * tRPC + URI-dispatcher migration. Kept as a factory so the test suite
- * can spin up an in-process `supertest` instance without binding a real
- * port.
+ * tRPC + URI-dispatcher migration. Phase 5 PR 1 (Track M5) wires the
+ * tRPC handler at `/trpc` with the migrated
+ * `cerebrum.nudges.{list,get,dismiss,contradictions}` procedures backed
+ * by `@pops/cerebrum-db` directly.
+ *
+ * The `/uri/resolve` dispatcher handler lands in a subsequent PR. Kept
+ * as a factory so the test suite can spin up an in-process `supertest`
+ * instance without binding a real port.
  */
+import { createExpressMiddleware } from '@trpc/server/adapters/express';
 import express, { type Express, type Request, type Response } from 'express';
 
 import { type CerebrumApiDeps, makeRequestHandler } from './handlers.js';
+import { appRouter } from './router.js';
+import { createCerebrumTrpcContextFactory } from './trpc.js';
 
 export function createCerebrumApiApp(deps: CerebrumApiDeps): Express {
   const app = express();
   app.disable('x-powered-by');
 
-  // Build the handler shape once at factory time so static deps don't
-  // get re-allocated on every request.
   const handlers = makeRequestHandler(deps);
 
   app.get('/health', (_req: Request, res: Response) => {
     res.json(handlers.health());
   });
+
+  app.use(
+    '/trpc',
+    createExpressMiddleware({
+      router: appRouter,
+      createContext: createCerebrumTrpcContextFactory({
+        coreDb: deps.coreDb.db,
+        cerebrumDb: deps.cerebrumDb.db,
+      }),
+    })
+  );
 
   return app;
 }

--- a/apps/pops-cerebrum-api/src/core-sqlite-path.ts
+++ b/apps/pops-cerebrum-api/src/core-sqlite-path.ts
@@ -6,8 +6,10 @@ import { dirname, join } from 'node:path';
  *
  * cerebrum-api needs its OWN open handle to `core.db` because the
  * `service_accounts` table that backs `X-API-Key` authentication lives
- * on the core pillar. The handle is read-only in practice (auth queries
- * are SELECTs); the write surface stays in pops-api / pops-core-api.
+ * on the core pillar. The handle MUST be writable: auth touches
+ * `service_accounts.last_used_at` on every request, and `openCoreDb`
+ * applies the package-local migration journal at boot. Deployers
+ * mounting `core.db` read-only will break both auth and boot.
  *
  * Intentionally NOT imported from `apps/pops-api/src/db/core-sqlite-path.ts`
  * — the per-pillar container is supposed to stand alone of pops-api in

--- a/apps/pops-cerebrum-api/src/core-sqlite-path.ts
+++ b/apps/pops-cerebrum-api/src/core-sqlite-path.ts
@@ -1,0 +1,30 @@
+import { dirname, join } from 'node:path';
+
+/**
+ * Standalone resolver for the core pillar's SQLite path as seen from
+ * inside the cerebrum-api container.
+ *
+ * cerebrum-api needs its OWN open handle to `core.db` because the
+ * `service_accounts` table that backs `X-API-Key` authentication lives
+ * on the core pillar. The handle is read-only in practice (auth queries
+ * are SELECTs); the write surface stays in pops-api / pops-core-api.
+ *
+ * Intentionally NOT imported from `apps/pops-api/src/db/core-sqlite-path.ts`
+ * — the per-pillar container is supposed to stand alone of pops-api in
+ * the dependency graph. The precedence chain matches pops-api so both
+ * processes agree on the location given the same env.
+ *
+ * Resolution order:
+ *   1. `CORE_SQLITE_PATH` env (absolute or relative).
+ *   2. `<dirname(SQLITE_PATH)>/core.db` if the shared path is set.
+ *   3. `./data/core.db` (matches the shared default's `./data/pops.db`).
+ */
+export const DEFAULT_CEREBRUM_API_CORE_SQLITE_PATH = './data/core.db';
+
+export function resolveCoreSqlitePath(): string {
+  const envPath = process.env['CORE_SQLITE_PATH'];
+  if (envPath) return envPath;
+  const sharedPath = process.env['SQLITE_PATH'];
+  if (sharedPath) return join(dirname(sharedPath), 'core.db');
+  return DEFAULT_CEREBRUM_API_CORE_SQLITE_PATH;
+}

--- a/apps/pops-cerebrum-api/src/handlers.ts
+++ b/apps/pops-cerebrum-api/src/handlers.ts
@@ -16,8 +16,10 @@ export interface CerebrumApiDeps {
   /**
    * Open handle to the core pillar's SQLite. Required for the
    * service-account authentication path (the canonical
-   * `service_accounts` table lives on the core pillar). Reads-only in
-   * practice — the write surface stays in pops-api / pops-core-api.
+   * `service_accounts` table lives on the core pillar). MUST be
+   * writable — auth touches `service_accounts.last_used_at` per
+   * request and `openCoreDb` applies migrations at boot. Mounting
+   * `core.db` read-only will break both auth and boot.
    */
   coreDb: OpenedCoreDb;
   /** Semver of the build, surfaced on the health response. */

--- a/apps/pops-cerebrum-api/src/handlers.ts
+++ b/apps/pops-cerebrum-api/src/handlers.ts
@@ -2,15 +2,24 @@
  * Request handlers for the cerebrum pillar container.
  *
  * Logic lives here (not inline in `app.ts`) so tests can call into the
- * shape directly without booting Express. Phase 3 PR 1 ships only the
- * `/health` probe — the tRPC routers + `/uri/resolve` handler land in
- * subsequent slice-migration PRs.
+ * shape directly without booting Express. Phase 3 PR 1 shipped the
+ * `/health` probe; Phase 5 PR 1 (Track M5) adds the tRPC handler at
+ * `/trpc` for the nudge_log read/dismiss surface. The `/uri/resolve`
+ * handler lands in a subsequent slice-migration PR.
  */
 import type { OpenedCerebrumDb } from '@pops/cerebrum-db';
+import type { OpenedCoreDb } from '@pops/core-db';
 
 export interface CerebrumApiDeps {
   /** Open handle to the cerebrum pillar's SQLite. */
   cerebrumDb: OpenedCerebrumDb;
+  /**
+   * Open handle to the core pillar's SQLite. Required for the
+   * service-account authentication path (the canonical
+   * `service_accounts` table lives on the core pillar). Reads-only in
+   * practice — the write surface stays in pops-api / pops-core-api.
+   */
+  coreDb: OpenedCoreDb;
   /** Semver of the build, surfaced on the health response. */
   version: string;
 }

--- a/apps/pops-cerebrum-api/src/middleware/cloudflare-jwt.ts
+++ b/apps/pops-cerebrum-api/src/middleware/cloudflare-jwt.ts
@@ -1,0 +1,88 @@
+/**
+ * Cloudflare Access JWT validation.
+ *
+ * Mirrors `apps/pops-api/src/middleware/cloudflare-jwt.ts` because
+ * cerebrum-api is supposed to stand alone in the dependency graph — see
+ * the standalone comment on the analogous core-api file. A future
+ * refactor can lift this into a shared `@pops/auth` package; for now
+ * duplication is the right call to keep the writer-move PR additive and
+ * easy to revert.
+ */
+import jwt from 'jsonwebtoken';
+
+import type { JwtPayload } from 'jsonwebtoken';
+
+export interface CloudflareJWTPayload extends JwtPayload {
+  email: string;
+  aud: string[];
+  iss: string;
+}
+
+interface KeyCache {
+  keys: Record<string, string>;
+  expiresAt: number;
+}
+
+let keyCache: KeyCache | null = null;
+
+async function getCloudflarePublicKeys(): Promise<Record<string, string>> {
+  const now = Date.now();
+  if (keyCache && keyCache.expiresAt > now) {
+    return keyCache.keys;
+  }
+
+  const teamName = process.env['CLOUDFLARE_ACCESS_TEAM_NAME'];
+  if (!teamName) {
+    throw new Error('CLOUDFLARE_ACCESS_TEAM_NAME not configured');
+  }
+
+  const certsUrl = `https://${teamName}.cloudflareaccess.com/cdn-cgi/access/certs`;
+  const response = await fetch(certsUrl);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch Cloudflare certs: ${response.statusText}`);
+  }
+
+  const data = (await response.json()) as {
+    public_certs: Array<{ kid: string; cert: string }>;
+  };
+
+  const keys: Record<string, string> = {};
+  for (const cert of data.public_certs) {
+    keys[cert.kid] = cert.cert;
+  }
+
+  keyCache = {
+    keys,
+    expiresAt: now + 15 * 60 * 1000,
+  };
+  return keys;
+}
+
+export async function verifyCloudflareJWT(token: string): Promise<CloudflareJWTPayload> {
+  const decoded = jwt.decode(token, { complete: true });
+  if (!decoded || typeof decoded === 'string') {
+    throw new Error('Invalid JWT: Unable to decode header');
+  }
+  const kid = decoded.header.kid;
+  if (!kid) {
+    throw new Error('Invalid JWT: Missing kid in header');
+  }
+  const publicKeys = await getCloudflarePublicKeys();
+  const publicKey = publicKeys[kid];
+  if (!publicKey) {
+    throw new Error(`Invalid JWT: Public key not found for kid ${kid}`);
+  }
+
+  const payload = jwt.verify(token, publicKey, {
+    algorithms: ['RS256'],
+  }) as CloudflareJWTPayload;
+
+  const expectedAud = process.env['CLOUDFLARE_ACCESS_AUD'];
+  if (expectedAud && !payload.aud.includes(expectedAud)) {
+    throw new Error('Invalid JWT: Audience mismatch');
+  }
+  if (!payload.email) {
+    throw new Error('Invalid JWT: Missing email claim');
+  }
+  return payload;
+}

--- a/apps/pops-cerebrum-api/src/modules/nudges/router.ts
+++ b/apps/pops-cerebrum-api/src/modules/nudges/router.ts
@@ -1,0 +1,157 @@
+/**
+ * nudge_log read/dismiss router — first writer slice cut over from
+ * pops-api into pops-cerebrum-api as part of Phase 5 PR 1 (Track M5).
+ *
+ * Procedure paths intentionally match
+ * `apps/pops-api/src/modules/cerebrum/nudges/router.ts` so the Phase 5
+ * PR 2 dispatcher cutover can be a transparent URL swap rather than a
+ * procedure-path rename:
+ *
+ *   - `cerebrum.nudges.list`            protected query
+ *   - `cerebrum.nudges.get`             protected query
+ *   - `cerebrum.nudges.dismiss`         protected mutation
+ *   - `cerebrum.nudges.contradictions`  protected query
+ *
+ * The cross-pillar procedures (`scan`, `act`, `configure`) stay in the
+ * legacy pops-api router for now — they reach into the engrams + retrieval
+ * subsystems that have not yet migrated to `@pops/cerebrum-db`. They
+ * follow once those slices move.
+ *
+ * Until the dispatcher swap, the legacy pops-api router keeps serving
+ * real traffic — this one is a shadow ready to take over.
+ */
+import { z } from 'zod';
+
+import { ConflictError, NotFoundError } from '../../shared/errors.js';
+import { mapDomainErrors } from '../../shared/trpc-error-mapper.js';
+import { protectedProcedure, router } from '../../trpc.js';
+import { createNudgeReadService } from './service.js';
+
+const nudgeTypeSchema = z.enum(['consolidation', 'staleness', 'pattern', 'insight']);
+const nudgeStatusSchema = z.enum(['pending', 'dismissed', 'acted', 'expired']);
+const nudgePrioritySchema = z.enum(['low', 'medium', 'high']);
+
+/**
+ * Type guard that extracts contradiction evidence from a nudge action.
+ *
+ * Contradiction evidence is stored on `Nudge.action.params.contradiction`
+ * when the underlying pattern is a contradiction. Other pattern nudges
+ * (recurring/emerging) carry no contradiction field, so this returns null.
+ */
+function extractContradiction(params: Record<string, unknown> | undefined): {
+  engramA: string;
+  engramB: string;
+  excerptA: string;
+  excerptB: string;
+  conflict: string;
+} | null {
+  if (!params) return null;
+  const raw = params['contradiction'];
+  if (!raw || typeof raw !== 'object') return null;
+  const evidence = raw as Record<string, unknown>;
+  const fields = ['engramA', 'engramB', 'excerptA', 'excerptB', 'conflict'] as const;
+  for (const field of fields) {
+    if (typeof evidence[field] !== 'string' || (evidence[field] as string).length === 0) {
+      return null;
+    }
+  }
+  return {
+    engramA: evidence['engramA'] as string,
+    engramB: evidence['engramB'] as string,
+    excerptA: evidence['excerptA'] as string,
+    excerptB: evidence['excerptB'] as string,
+    conflict: evidence['conflict'] as string,
+  };
+}
+
+export const nudgesRouter = router({
+  list: protectedProcedure
+    .input(
+      z
+        .object({
+          type: nudgeTypeSchema.optional(),
+          status: nudgeStatusSchema.optional(),
+          priority: nudgePrioritySchema.optional(),
+          limit: z.number().int().positive().max(100).optional(),
+          offset: z.number().int().nonnegative().optional(),
+        })
+        .optional()
+    )
+    .query(({ input, ctx }) => {
+      return createNudgeReadService(ctx.cerebrumDb).list(input ?? {});
+    }),
+
+  get: protectedProcedure.input(z.object({ id: z.string().min(1) })).query(({ input, ctx }) =>
+    mapDomainErrors(() => {
+      const nudge = createNudgeReadService(ctx.cerebrumDb).get(input.id);
+      if (!nudge) throw new NotFoundError('Nudge', input.id);
+      return { nudge };
+    })
+  ),
+
+  /**
+   * Dismiss a pending nudge.
+   *
+   * The legacy pops-api router collapsed missing-vs-already-dismissed
+   * into a single `BAD_REQUEST`. The shadow surface tightens that into:
+   *   - missing nudge       → NOT_FOUND
+   *   - non-pending nudge   → CONFLICT (already dismissed/acted/expired)
+   *
+   * Both branches surface as a single transition-failed signal at the
+   * UI layer; the wire-shape split exists so cerebrum-api consumers can
+   * tell a stale UI cache apart from a no-op double-click.
+   */
+  dismiss: protectedProcedure
+    .input(z.object({ id: z.string().min(1) }))
+    .mutation(({ input, ctx }) =>
+      mapDomainErrors(() => {
+        const svc = createNudgeReadService(ctx.cerebrumDb);
+        const existing = svc.get(input.id);
+        if (!existing) throw new NotFoundError('Nudge', input.id);
+        if (existing.status !== 'pending') {
+          throw new ConflictError(
+            `Nudge '${input.id}' is not pending (status=${existing.status}).`
+          );
+        }
+        const result = svc.dismiss(input.id);
+        if (!result.success) {
+          throw new ConflictError(`Nudge '${input.id}' could not be dismissed.`);
+        }
+        return result;
+      })
+    ),
+
+  contradictions: protectedProcedure
+    .input(
+      z
+        .object({
+          status: nudgeStatusSchema.nullable().optional(),
+          limit: z.number().int().positive().max(100).optional(),
+          offset: z.number().int().nonnegative().optional(),
+        })
+        .optional()
+    )
+    .query(({ input, ctx }) => {
+      const status = input?.status === undefined ? 'pending' : input.status;
+      const result = createNudgeReadService(ctx.cerebrumDb).listContradictions({
+        status,
+        limit: input?.limit ?? 50,
+        offset: input?.offset ?? 0,
+      });
+      const contradictions = result.nudges
+        .map((nudge) => {
+          const evidence = extractContradiction(nudge.action?.params);
+          if (!evidence) return null;
+          return {
+            id: nudge.id,
+            createdAt: nudge.createdAt,
+            status: nudge.status,
+            priority: nudge.priority,
+            title: nudge.title,
+            ...evidence,
+          };
+        })
+        .filter((row): row is NonNullable<typeof row> => row !== null);
+      return { contradictions, total: result.total };
+    }),
+});

--- a/apps/pops-cerebrum-api/src/modules/nudges/service.ts
+++ b/apps/pops-cerebrum-api/src/modules/nudges/service.ts
@@ -1,0 +1,93 @@
+/**
+ * Thin nudge_log read/dismiss service for the cerebrum-api container.
+ *
+ * Phase 5 PR 1 (Track M5) moves the read-only + dismiss surface of the
+ * nudges router into cerebrum-api — the procedures that touch ONLY the
+ * `nudge_log` table and therefore depend on nothing outside
+ * `@pops/cerebrum-db`.
+ *
+ * The cross-pillar procedures (`scan`, `act`, `configure`) stay in
+ * pops-api for now because they pull in detectors, the HybridSearchService,
+ * the EngramService and a module-level thresholds object that hasn't
+ * migrated yet. They follow once the engrams + retrieval slices move.
+ */
+import { and, count, eq, sql } from 'drizzle-orm';
+
+import {
+  type CerebrumDb,
+  type Nudge,
+  nudgeLog,
+  nudgeLogService,
+  rowToNudge,
+} from '@pops/cerebrum-db';
+
+import type { NudgePriority, NudgeStatus, NudgeType } from '@pops/cerebrum-db';
+
+export interface ListNudgesOptions {
+  type?: NudgeType;
+  status?: NudgeStatus;
+  priority?: NudgePriority;
+  limit?: number;
+  offset?: number;
+}
+
+export interface ListContradictionsOptions {
+  status?: NudgeStatus | null;
+  limit?: number;
+  offset?: number;
+}
+
+export interface NudgeReadService {
+  list(opts: ListNudgesOptions): { nudges: Nudge[]; total: number };
+  get(id: string): Nudge | null;
+  dismiss(id: string): { success: boolean };
+  listContradictions(opts: ListContradictionsOptions): { nudges: Nudge[]; total: number };
+}
+
+export function createNudgeReadService(db: CerebrumDb): NudgeReadService {
+  return {
+    list(opts: ListNudgesOptions): { nudges: Nudge[]; total: number } {
+      const conditions = [];
+      if (opts.type) conditions.push(eq(nudgeLog.type, opts.type));
+      if (opts.status) conditions.push(eq(nudgeLog.status, opts.status));
+      if (opts.priority) conditions.push(eq(nudgeLog.priority, opts.priority));
+
+      const where = conditions.length > 0 ? and(...conditions) : undefined;
+      const limit = opts.limit ?? 50;
+      const offset = opts.offset ?? 0;
+
+      const baseQuery = db.select().from(nudgeLog);
+      const rows = (where ? baseQuery.where(where) : baseQuery)
+        .orderBy(sql`${nudgeLog.createdAt} desc`)
+        .limit(limit)
+        .offset(offset)
+        .all();
+
+      const countQuery = db.select({ total: count() }).from(nudgeLog);
+      const [totalRow] = (where ? countQuery.where(where) : countQuery).all();
+
+      return {
+        nudges: rows.map((r) => rowToNudge(r)),
+        total: totalRow?.total ?? 0,
+      };
+    },
+
+    get(id: string): Nudge | null {
+      const [row] = db.select().from(nudgeLog).where(eq(nudgeLog.id, id)).all();
+      return row ? rowToNudge(row) : null;
+    },
+
+    dismiss(id: string): { success: boolean } {
+      const result = db
+        .update(nudgeLog)
+        .set({ status: 'dismissed' })
+        .where(and(eq(nudgeLog.id, id), eq(nudgeLog.status, 'pending')))
+        .run();
+      return { success: result.changes > 0 };
+    },
+
+    listContradictions(opts: ListContradictionsOptions): { nudges: Nudge[]; total: number } {
+      return nudgeLogService.listContradictions(db, opts);
+    },
+  };
+}

--- a/apps/pops-cerebrum-api/src/router.ts
+++ b/apps/pops-cerebrum-api/src/router.ts
@@ -1,0 +1,20 @@
+/**
+ * Root tRPC router for the cerebrum pillar container.
+ *
+ * Procedure paths are rooted at `cerebrum.*` so that the Phase 5 PR 2
+ * dispatcher cutover is a transparent URL swap: existing pops-api
+ * clients call `cerebrum.nudges.list`, and cerebrum-api answers on the
+ * same path.
+ */
+import { nudgesRouter } from './modules/nudges/router.js';
+import { router } from './trpc.js';
+
+export const cerebrumRouter = router({
+  nudges: nudgesRouter,
+});
+
+export const appRouter = router({
+  cerebrum: cerebrumRouter,
+});
+
+export type AppRouter = typeof appRouter;

--- a/apps/pops-cerebrum-api/src/server.ts
+++ b/apps/pops-cerebrum-api/src/server.ts
@@ -9,7 +9,9 @@
  * than reaching back into pops-api's singletons — that's the whole
  * point of phase 3. core.db is required because the canonical
  * `service_accounts` table that backs `X-API-Key` authentication lives
- * on the core pillar; the handle is read-only in practice.
+ * on the core pillar. The core.db handle MUST be writable — auth
+ * touches `service_accounts.last_used_at` per request and `openCoreDb`
+ * applies migrations at boot.
  */
 import { openCerebrumDb } from '@pops/cerebrum-db';
 import { openCoreDb } from '@pops/core-db';

--- a/apps/pops-cerebrum-api/src/server.ts
+++ b/apps/pops-cerebrum-api/src/server.ts
@@ -2,18 +2,21 @@
  * Entry point for the cerebrum pillar HTTP server.
  *
  * Phase 3 PR 1 of the cerebrum pillar migration boots the process with
- * the minimal `/health` surface so the new container can be wired into
- * docker-compose + Watchtower without depending on the (still-unfinished)
- * tRPC + URI-dispatcher migration.
+ * the minimal `/health` surface; Phase 5 PR 1 (Track M5) adds the tRPC
+ * handler at `/trpc` for the nudge_log read/dismiss surface.
  *
- * The process opens its OWN cerebrum.db connection via `openCerebrumDb`
- * rather than reaching back into pops-api's singleton — that's the
- * whole point of phase 3.
+ * The process opens its OWN cerebrum.db AND core.db connections rather
+ * than reaching back into pops-api's singletons — that's the whole
+ * point of phase 3. core.db is required because the canonical
+ * `service_accounts` table that backs `X-API-Key` authentication lives
+ * on the core pillar; the handle is read-only in practice.
  */
 import { openCerebrumDb } from '@pops/cerebrum-db';
+import { openCoreDb } from '@pops/core-db';
 
 import { createCerebrumApiApp } from './app.js';
 import { resolveCerebrumSqlitePath } from './cerebrum-sqlite-path.js';
+import { resolveCoreSqlitePath } from './core-sqlite-path.js';
 
 function resolvePort(): number {
   const raw = process.env['PORT'];
@@ -29,7 +32,8 @@ const port = resolvePort();
 const version = process.env['BUILD_VERSION'] ?? 'dev';
 
 const cerebrumDb = openCerebrumDb(resolveCerebrumSqlitePath());
-const app = createCerebrumApiApp({ cerebrumDb, version });
+const coreDb = openCoreDb(resolveCoreSqlitePath());
+const app = createCerebrumApiApp({ cerebrumDb, coreDb, version });
 
 const server = app.listen(port, () => {
   console.warn(`[cerebrum-api] Listening on port ${port}`);
@@ -42,6 +46,7 @@ function shutdown(signal: NodeJS.Signals): void {
   console.warn(`[cerebrum-api] Shutting down (${signal})`);
   server.close(() => {
     cerebrumDb.raw.close();
+    coreDb.raw.close();
   });
 }
 

--- a/apps/pops-cerebrum-api/src/shared/errors.ts
+++ b/apps/pops-cerebrum-api/src/shared/errors.ts
@@ -1,0 +1,40 @@
+/**
+ * HTTP-shaped domain errors used by cerebrum-api router handlers.
+ *
+ * Intentionally NOT imported from `apps/pops-api/src/shared/errors.ts` —
+ * the per-pillar container is supposed to stand alone of pops-api in the
+ * dependency graph (Phase 5 writer-move pattern). The subset reproduced
+ * here is whatever the migrated routers need; future PRs can grow the
+ * set as more slices move across.
+ */
+export class HttpError extends Error {
+  constructor(
+    public readonly statusCode: number,
+    message: string,
+    public readonly details?: unknown
+  ) {
+    super(message);
+    this.name = 'HttpError';
+  }
+}
+
+export class NotFoundError extends HttpError {
+  constructor(resource: string, id: string) {
+    super(404, `${resource} '${id}' not found`);
+    this.name = 'NotFoundError';
+  }
+}
+
+export class ValidationError extends HttpError {
+  constructor(details: unknown) {
+    super(400, 'Validation failed', details);
+    this.name = 'ValidationError';
+  }
+}
+
+export class ConflictError extends HttpError {
+  constructor(message: string) {
+    super(409, message);
+    this.name = 'ConflictError';
+  }
+}

--- a/apps/pops-cerebrum-api/src/shared/trpc-error-mapper.ts
+++ b/apps/pops-cerebrum-api/src/shared/trpc-error-mapper.ts
@@ -1,0 +1,46 @@
+import { TRPCError } from '@trpc/server';
+
+import { HttpError } from './errors.js';
+
+type TRPCCode = ConstructorParameters<typeof TRPCError>[0]['code'];
+
+const HTTP_STATUS_TO_TRPC_CODE: Readonly<Record<number, TRPCCode>> = {
+  400: 'BAD_REQUEST',
+  401: 'UNAUTHORIZED',
+  402: 'PAYMENT_REQUIRED',
+  403: 'FORBIDDEN',
+  404: 'NOT_FOUND',
+  409: 'CONFLICT',
+  412: 'PRECONDITION_FAILED',
+  422: 'UNPROCESSABLE_CONTENT',
+  429: 'TOO_MANY_REQUESTS',
+  500: 'INTERNAL_SERVER_ERROR',
+};
+
+function toTRPCError(err: HttpError): TRPCError {
+  const code = HTTP_STATUS_TO_TRPC_CODE[err.statusCode] ?? 'INTERNAL_SERVER_ERROR';
+  return new TRPCError({ code, message: err.message, cause: err });
+}
+
+/**
+ * Runs `fn` and re-throws any HttpError subclass as the corresponding
+ * TRPCError. Non-HttpError throws bubble unchanged so the global tRPC
+ * error handler can see them as 500s.
+ */
+export function mapDomainErrors<T>(fn: () => T): T {
+  try {
+    return fn();
+  } catch (err) {
+    if (err instanceof HttpError) throw toTRPCError(err);
+    throw err;
+  }
+}
+
+export async function mapDomainErrorsAsync<T>(fn: () => Promise<T>): Promise<T> {
+  try {
+    return await fn();
+  } catch (err) {
+    if (err instanceof HttpError) throw toTRPCError(err);
+    throw err;
+  }
+}

--- a/apps/pops-cerebrum-api/src/trpc.ts
+++ b/apps/pops-cerebrum-api/src/trpc.ts
@@ -1,0 +1,162 @@
+/**
+ * tRPC initialisation for the cerebrum pillar container.
+ *
+ * Mirrors the auth surface of `apps/pops-api/src/trpc.ts` but trims off
+ * what cerebrum-api doesn't need yet:
+ *   - no module gate (per-pillar containers serve a single pillar by
+ *     definition; the install-set check lives at the dispatcher layer
+ *     above this process);
+ *   - no `internalProcedure` (no sibling-process callers yet);
+ *   - no OpenAPI meta (the dispatcher/gateway owns OpenAPI; cerebrum-api
+ *     handlers are tRPC-only for now).
+ *
+ * Service-account authentication still reads from `core.db` because the
+ * canonical `service_accounts` table lives on the core pillar. The
+ * cerebrum-owned handle is exposed on `ctx.cerebrumDb` for the nudge_log
+ * router; both handles are injected at context-creation time via the
+ * factory in `createCerebrumTrpcContextFactory` so tests can swap in
+ * in-memory handles without touching env vars or the production resolver.
+ */
+import { initTRPC, TRPCError } from '@trpc/server';
+
+import {
+  type AuthenticatedServiceAccount,
+  type CoreDb,
+  serviceAccountKeys,
+  serviceAccountsService,
+} from '@pops/core-db';
+
+import { verifyCloudflareJWT } from './middleware/cloudflare-jwt.js';
+
+import type { CreateExpressContextOptions } from '@trpc/server/adapters/express';
+
+import type { CerebrumDb } from '@pops/cerebrum-db';
+
+export interface User {
+  email: string;
+}
+
+export interface Context {
+  user: User | null;
+  serviceAccount: AuthenticatedServiceAccount | null;
+  coreDb: CoreDb;
+  cerebrumDb: CerebrumDb;
+}
+
+function readApiKeyHeader(req: CreateExpressContextOptions['req']): string | null {
+  const raw = req.headers['x-api-key'];
+  if (Array.isArray(raw)) return raw[0] ?? null;
+  if (typeof raw === 'string' && raw.length > 0) return raw;
+  return null;
+}
+
+async function tryServiceAccountAuth(
+  coreDb: CoreDb,
+  req: CreateExpressContextOptions['req']
+): Promise<AuthenticatedServiceAccount | null> {
+  const header = readApiKeyHeader(req);
+  if (!header) return null;
+  const parsed = serviceAccountKeys.parseApiKey(header);
+  if (!parsed) return null;
+  return serviceAccountsService.authenticateServiceAccount(coreDb, parsed.prefix, parsed.secret);
+}
+
+export interface CerebrumTrpcDeps {
+  coreDb: CoreDb;
+  cerebrumDb: CerebrumDb;
+}
+
+/**
+ * Build a tRPC context factory bound to a specific pair of DB handles.
+ *
+ * Production wires this at boot from `openCerebrumDb(...)` + `openCoreDb(...)`;
+ * tests pass in-memory handles so each suite is hermetic.
+ */
+export function createCerebrumTrpcContextFactory(
+  deps: CerebrumTrpcDeps
+): (opts: CreateExpressContextOptions) => Promise<Context> {
+  const { coreDb, cerebrumDb } = deps;
+  return async ({ req }: CreateExpressContextOptions): Promise<Context> => {
+    const serviceAccount = await tryServiceAccountAuth(coreDb, req);
+    if (serviceAccount) {
+      return { user: null, serviceAccount, coreDb, cerebrumDb };
+    }
+
+    if (process.env['NODE_ENV'] !== 'production') {
+      return {
+        user: { email: 'dev@example.com' },
+        serviceAccount: null,
+        coreDb,
+        cerebrumDb,
+      };
+    }
+
+    if (!process.env['CLOUDFLARE_ACCESS_TEAM_NAME']) {
+      return {
+        user: { email: 'tunnel-authenticated@pops.local' },
+        serviceAccount: null,
+        coreDb,
+        cerebrumDb,
+      };
+    }
+
+    const token = req.headers['cf-access-jwt-assertion'];
+    if (typeof token === 'string') {
+      try {
+        const payload = await verifyCloudflareJWT(token);
+        return {
+          user: { email: payload.email },
+          serviceAccount: null,
+          coreDb,
+          cerebrumDb,
+        };
+      } catch (error) {
+        console.error('[cerebrum-api] JWT verification failed:', error);
+        return { user: null, serviceAccount: null, coreDb, cerebrumDb };
+      }
+    }
+
+    return { user: null, serviceAccount: null, coreDb, cerebrumDb };
+  };
+}
+
+const t = initTRPC.context<Context>().create();
+
+export const router = t.router;
+
+export const publicProcedure = t.procedure;
+
+export const protectedProcedure = t.procedure.use(({ ctx, path, next }) => {
+  if (ctx.user) {
+    return next({
+      ctx: {
+        user: ctx.user,
+        serviceAccount: ctx.serviceAccount,
+        coreDb: ctx.coreDb,
+        cerebrumDb: ctx.cerebrumDb,
+      },
+    });
+  }
+
+  if (ctx.serviceAccount) {
+    if (!serviceAccountsService.hasScopeFor(ctx.serviceAccount.scopes, path)) {
+      throw new TRPCError({
+        code: 'FORBIDDEN',
+        message: `Service account '${ctx.serviceAccount.name}' is not authorised for '${path}'`,
+      });
+    }
+    return next({
+      ctx: {
+        user: ctx.user,
+        serviceAccount: ctx.serviceAccount,
+        coreDb: ctx.coreDb,
+        cerebrumDb: ctx.cerebrumDb,
+      },
+    });
+  }
+
+  throw new TRPCError({
+    code: 'UNAUTHORIZED',
+    message: 'Missing or invalid credentials (expected Cloudflare Access JWT or X-API-Key)',
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -217,19 +217,37 @@ importers:
       '@pops/cerebrum-db':
         specifier: workspace:*
         version: link:../../packages/cerebrum-db
+      '@pops/core-db':
+        specifier: workspace:*
+        version: link:../../packages/core-db
       '@pops/types':
         specifier: workspace:*
         version: link:../../packages/types
+      '@trpc/server':
+        specifier: ^11.17.0
+        version: 11.17.0(typescript@6.0.3)
+      drizzle-orm:
+        specifier: ^0.45.2
+        version: 0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.10.0)
       express:
         specifier: ^5.1.0
         version: 5.2.1
+      jsonwebtoken:
+        specifier: ^9.0.3
+        version: 9.0.3
       pino:
         specifier: ^10.3.1
         version: 10.3.1
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@types/express':
         specifier: ^5.0.4
         version: 5.0.6
+      '@types/jsonwebtoken':
+        specifier: ^9.0.10
+        version: 9.0.10
       '@types/node':
         specifier: ^25.9.1
         version: 25.9.1


### PR DESCRIPTION
## Summary

Phase 5 PR 1 of the **cerebrum pillar writer-move** — Track M5 row in `.claude/pillar-migration-roadmap.md` (issue #2836). M5 was gated on Track J (food) + Track K (lists), both now ✅ Done; gate opens with this PR.

Cuts the read/dismiss surface of `cerebrum.nudges.*` over from `apps/pops-api/src/modules/cerebrum/nudges/` into the `pops-cerebrum-api` container, backed directly by `@pops/cerebrum-db` on its own `cerebrum.db` handle:

- `cerebrum.nudges.list`            — protected query
- `cerebrum.nudges.get`             — protected query
- `cerebrum.nudges.dismiss`         — protected mutation
- `cerebrum.nudges.contradictions`  — protected query

Reference pattern: **#2889** (Track M1 / `pops-core-api` service-accounts writer-move). This PR mirrors that structure verbatim:

- local `trpc.ts` initialiser + `protectedProcedure` with `core.db`-backed service-account auth (the canonical `service_accounts` table lives on the core pillar — cerebrum-api opens its own read-only handle to `core.db` for `X-API-Key` validation).
- local `middleware/cloudflare-jwt.ts` (no shared `@pops/auth` package yet — duplication is deliberate per the M1 writer-move pattern so cerebrum-api stands alone in the dep graph).
- local `shared/errors.ts` + `shared/trpc-error-mapper.ts` translating `HttpError` subclasses → `TRPCError`.
- local `core-sqlite-path.ts` mirroring the same resolution order as pops-api / core-api so all three processes agree on the location of `core.db` given the same env.

### Scope kept narrow on purpose

The cross-pillar procedures (`scan`, `act`, `configure`) stay in the legacy pops-api router for now — they pull in `HybridSearchService`, `EngramService`, and the detector stack, none of which are in `@pops/cerebrum-db` yet. They follow once the engrams + retrieval slices migrate.

**The URI-dispatcher round-trip work** (engrams referencing other pillars' entities via URI — the "load-bearing" cerebrum surgery flagged in the M5 row) is a separate Phase 5 sub-track and is **NOT** in scope here. This PR is strictly the `nudge_log` slice — the only cerebrum slice already cut over to `@pops/cerebrum-db`.

### Legacy fall-through

The legacy `apps/pops-api/src/modules/cerebrum/nudges/router.ts` is **untouched** and continues to serve real traffic. This PR is the additive shadow. The dispatcher swap that flips routing onto the new container lands in **Phase 5 PR 2**; legacy fall-through stays until **Phase 5 PR 3**.

### One deliberate contract tightening

The new `dismiss` procedure splits the "not pending" failure mode into:

- missing nudge → `NOT_FOUND`
- already dismissed / acted / expired → `CONFLICT`

The legacy router collapsed both into `BAD_REQUEST`. The wire-shape split exists so cerebrum-api consumers can tell a stale UI cache apart from a no-op double-click. Documented inline at the procedure docstring.

## Test plan

- [x] `pnpm typecheck` — all 51 tasks green
- [x] `pnpm lint` — clean (warnings only, none in cerebrum-api)
- [x] `pnpm --filter @pops/cerebrum-api test` — 3 files / 23 tests pass
- [x] `pnpm --filter @pops/api test` — 306 files / 4875 tests pass (legacy router untouched)
- [x] `pnpm build` — clean
- [x] `pnpm format` — clean
- [x] Integration tests cover happy-path on all four procedures + UNAUTHORIZED on anonymous callers + NOT_FOUND on `get` for missing + NOT_FOUND on `dismiss` for missing + CONFLICT on `dismiss` for already-dismissed AND already-acted + HTTP wire surface via `supertest` (`/trpc/cerebrum.nudges.list` and `/trpc/cerebrum.nudges.get`)
