### PR TITLE
feat(finance-db): flip budgets consumer to @pops/finance-db (Track N1 phase 1 PR 3)

### DIFF
--- a/apps/pops-api/src/modules/finance/budgets/router.ts
+++ b/apps/pops-api/src/modules/finance/budgets/router.ts
@@ -1,13 +1,27 @@
 /**
  * Budget tRPC router — CRUD procedures for budgets.
+ *
+ * Calls into `@pops/finance-db`'s `budgetsService` directly (the in-tree
+ * shim stays in place until PR 4 of the Track N1 phase 1 sequence deletes
+ * it).
+ *
+ * Domain errors from the package (`BudgetNotFoundError`,
+ * `BudgetConflictError`) are translated to `HttpError` subclasses inside
+ * each handler and then routed through `mapDomainErrors` so the tRPC
+ * layer sees a proper `TRPCError` with the right wire-level `code`
+ * (`NOT_FOUND` / `CONFLICT`). Throwing `HttpError` directly out of a
+ * tRPC handler surfaces as `INTERNAL_SERVER_ERROR` at the OpenAPI
+ * boundary, which we don't want.
  */
-import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 
+import { BudgetConflictError, BudgetNotFoundError, budgetsService } from '@pops/finance-db';
+
+import { getFinanceDrizzle } from '../../../db/finance-handle.js';
 import { ConflictError, NotFoundError } from '../../../shared/errors.js';
 import { paginationMeta, PaginationMetaSchema } from '../../../shared/pagination.js';
+import { mapDomainErrors } from '../../../shared/trpc-error-mapper.js';
 import { protectedProcedure, router } from '../../../trpc.js';
-import * as service from './service.js';
 import {
   BudgetQuerySchema,
   BudgetSchema,
@@ -19,6 +33,16 @@ import {
 /** Default pagination values. */
 const DEFAULT_LIMIT = 50;
 const DEFAULT_OFFSET = 0;
+
+function translateBudgetError(err: unknown, id?: string): never {
+  if (err instanceof BudgetNotFoundError) {
+    throw new NotFoundError('Budget', id ?? err.id);
+  }
+  if (err instanceof BudgetConflictError) {
+    throw new ConflictError(err.message);
+  }
+  throw err;
+}
 
 export const budgetsRouter = router({
   /** List budgets with optional search/period/active filters and pagination. */
@@ -42,7 +66,7 @@ export const budgetsRouter = router({
       else if (input.active === 'false') activeFilter = false;
       else activeFilter = undefined;
 
-      const { rows, total } = service.listBudgets({
+      const { rows, total } = budgetsService.listBudgets(getFinanceDrizzle(), {
         search: input.search,
         period: input.period,
         active: activeFilter,
@@ -68,33 +92,33 @@ export const budgetsRouter = router({
     })
     .input(z.object({ id: z.string() }))
     .output(z.object({ data: BudgetSchema }))
-    .query(({ input }) => {
-      try {
-        const row = service.getBudget(input.id);
-        return { data: toBudget(service.withSpend(row)) };
-      } catch (err) {
-        if (err instanceof NotFoundError) {
-          throw new TRPCError({ code: 'NOT_FOUND', message: err.message });
+    .query(({ input }) =>
+      mapDomainErrors(() => {
+        try {
+          const db = getFinanceDrizzle();
+          const row = budgetsService.getBudget(db, input.id);
+          return { data: toBudget(budgetsService.withSpend(db, row)) };
+        } catch (err) {
+          translateBudgetError(err, input.id);
         }
-        throw err;
-      }
-    }),
+      })
+    ),
 
   /** Create a new budget. */
-  create: protectedProcedure.input(CreateBudgetSchema).mutation(({ input }) => {
-    try {
-      const row = service.createBudget(input);
-      return {
-        data: toBudget(service.withSpend(row)),
-        message: 'Budget created',
-      };
-    } catch (err) {
-      if (err instanceof ConflictError) {
-        throw new TRPCError({ code: 'CONFLICT', message: err.message });
+  create: protectedProcedure.input(CreateBudgetSchema).mutation(({ input }) =>
+    mapDomainErrors(() => {
+      try {
+        const db = getFinanceDrizzle();
+        const row = budgetsService.createBudget(db, input);
+        return {
+          data: toBudget(budgetsService.withSpend(db, row)),
+          message: 'Budget created',
+        };
+      } catch (err) {
+        translateBudgetError(err);
       }
-      throw err;
-    }
-  }),
+    })
+  ),
 
   /** Update an existing budget. */
   update: protectedProcedure
@@ -104,31 +128,30 @@ export const budgetsRouter = router({
         data: UpdateBudgetSchema,
       })
     )
-    .mutation(({ input }) => {
-      try {
-        const row = service.updateBudget(input.id, input.data);
-        return {
-          data: toBudget(service.withSpend(row)),
-          message: 'Budget updated',
-        };
-      } catch (err) {
-        if (err instanceof NotFoundError) {
-          throw new TRPCError({ code: 'NOT_FOUND', message: err.message });
+    .mutation(({ input }) =>
+      mapDomainErrors(() => {
+        try {
+          const db = getFinanceDrizzle();
+          const row = budgetsService.updateBudget(db, input.id, input.data);
+          return {
+            data: toBudget(budgetsService.withSpend(db, row)),
+            message: 'Budget updated',
+          };
+        } catch (err) {
+          translateBudgetError(err, input.id);
         }
-        throw err;
-      }
-    }),
+      })
+    ),
 
   /** Delete a budget. */
-  delete: protectedProcedure.input(z.object({ id: z.string() })).mutation(({ input }) => {
-    try {
-      service.deleteBudget(input.id);
-      return { message: 'Budget deleted' };
-    } catch (err) {
-      if (err instanceof NotFoundError) {
-        throw new TRPCError({ code: 'NOT_FOUND', message: err.message });
+  delete: protectedProcedure.input(z.object({ id: z.string() })).mutation(({ input }) =>
+    mapDomainErrors(() => {
+      try {
+        budgetsService.deleteBudget(getFinanceDrizzle(), input.id);
+        return { message: 'Budget deleted' };
+      } catch (err) {
+        translateBudgetError(err, input.id);
       }
-      throw err;
-    }
-  }),
+    })
+  ),
 });

--- a/apps/pops-api/src/modules/finance/uri-handler.ts
+++ b/apps/pops-api/src/modules/finance/uri-handler.ts
@@ -1,3 +1,6 @@
+import { BudgetNotFoundError, budgetsService } from '@pops/finance-db';
+
+import { getFinanceDrizzle } from '../../db/finance-handle.js';
 import { NotFoundError } from '../../shared/errors.js';
 /**
  * Finance URI handler (PRD-101 US-08, ADR-012).
@@ -13,7 +16,6 @@ import { NotFoundError } from '../../shared/errors.js';
  * its result into a `UriResolverResult` for the caller.
  */
 import { getEntity } from '../core/entities/service.js';
-import { getBudget } from './budgets/service.js';
 import { getTransaction } from './transactions/service.js';
 
 import type { UriHandlerDescriptor, UriResolution } from '@pops/types';
@@ -25,7 +27,7 @@ async function tryGet<TData>(get: () => TData | Promise<TData>): Promise<UriReso
   try {
     return { kind: 'object', data: await get() };
   } catch (error) {
-    if (error instanceof NotFoundError) {
+    if (error instanceof NotFoundError || error instanceof BudgetNotFoundError) {
       return { kind: 'not-found' };
     }
     throw error;
@@ -41,7 +43,7 @@ export const financeUriHandler: UriHandlerDescriptor = {
       case 'entity':
         return tryGet(() => getEntity(id));
       case 'budget':
-        return tryGet(() => getBudget(id));
+        return tryGet(() => budgetsService.getBudget(getFinanceDrizzle(), id));
       default:
         return { kind: 'not-found' };
     }


### PR DESCRIPTION
## Summary

Flips the in-tree consumers of the `budgets` slice (the `finance.budgets.*` tRPC router and the finance URI handler) over to `budgetsService` from `@pops/finance-db` scaffolded in #2855.

Mirrors Track J phase 1 PR 3 (#2868) and Track K phase 1 PR 3 (#2879) — the canonical PR 3 cutover pattern. The wish-list cutover already established the same pattern inside this pillar.

## PR 2 was a no-op

Track N1 originally planned PR 2 to split the migration journal for `0000_naive_chameleon` + `0052_budgets_active_default_zero` into a budgets-owned copy under `packages/finance-db/migrations/`. The Track E wish-list pilot already split the finance journal for `0025` / `0026` / `0027` / `0052` when it landed, and the budgets-relevant statements share the same baseline file (`packages/finance-db/migrations/0053_finance_pillar_baseline.sql`). The per-package copy is already byte-identical, the drift-guard CI from the wish-list pilot is enforcing both copies, and #2855 explicitly noted the baseline copy already exists. **PR 2 is skipped — jumping straight to PR 3 (cutover).**

## Changes

- `apps/pops-api/src/modules/finance/budgets/router.ts`: import `budgetsService`, `BudgetNotFoundError`, `BudgetConflictError` from `@pops/finance-db`. Pass `getFinanceDrizzle()` as the first arg on every service call. Wrap every handler in `mapDomainErrors(() => { ... })` and translate the package's typed errors to `NotFoundError` / `ConflictError` via a small `translateBudgetError` helper so the existing tRPC mapping (`NOT_FOUND` / `CONFLICT`) keeps holding.
- `apps/pops-api/src/modules/finance/uri-handler.ts`: import `budgetsService.getBudget` from `@pops/finance-db`. Match `BudgetNotFoundError` alongside the legacy `NotFoundError` in the `tryGet` helper so the `pops:finance/budget/{id}` resolution still surfaces `{ kind: 'not-found' }` on missing rows.

## What stays for PR 4

The in-tree `apps/pops-api/src/modules/finance/budgets/` directory stays in place — `service.ts`, `period-window.ts`, `types.ts`, `search-adapter.ts`, `budgets.test.ts`, `index.ts`. PR 4 of the phase 1 sequence deletes the in-tree services + barrel re-export once nothing inside pops-api references them.

The search adapter (`search-adapter.ts`) does not use the service — it queries drizzle directly via `getDrizzle()` — so it stays untouched in this PR. If the package grows a search surface later, that can be a follow-up.

The `budgets.test.ts` suite still imports `listBudgets` from the in-tree `./service.js` for the deterministic-`now`-override tests. Those tests stay green because the in-tree service is still present; PR 4 either moves the assertion to the `@pops/finance-db` package's own unit tests (where they already exist) or rewrites them against `budgetsService`.

## CI / Docker

PR 1 (#2855) confirmed CI parity was already in place from the wish-list pilot — `packages/finance-db/**` is wired into `_pkg-check.yml`, `api-quality.yml`, `api-test.yml`, `fe-quality.yml`, `fe-test-e2e.yml`, and all three Dockerfiles (`pops-api`, `pops-shell`, `pops-mcp`) plus `pops-finance-api` already COPY + BUILD `@pops/finance-db` ahead of the consumers. No infra changes needed for the cutover.

## Test plan

- [x] `pnpm typecheck` — 51/51 clean
- [x] `pnpm lint` — clean (pre-existing warnings only, no errors)
- [x] `pnpm --filter @pops/finance-db test` — 195/195 passing
- [x] `pnpm --filter @pops/api test` — 4875/4875 passing (full pops-api suite — exercises `finance.budgets.{list, get, create, update, delete}` end-to-end via the tRPC caller + the finance URI handler's budget branch)
- [x] `pnpm build` — 25/25 green
- [x] `pnpm format` — clean

## References

- Phase 1 PR 1 (scaffold): #2855
- Track J phase 1 PR 3 (canonical pattern): #2868
- Track K phase 1 PR 3 (canonical pattern): #2879
