### PR TITLE
feat(media-api): make pops-media-api the canonical media.* handler (Track M3 PR 2)

### DIFF
--- a/apps/pops-shell/nginx.conf
+++ b/apps/pops-shell/nginx.conf
@@ -9,8 +9,9 @@ server {
     # load time for literal `proxy_pass <name>`), letting nginx boot
     # even when an optional pillar container is missing. Today the
     # `/pillars` proxy plus the `/trpc/inventory.locations.*` (Track M4
-    # PR 2) and `/trpc/cerebrum.nudges.{list,get,dismiss,contradictions}`
-    # (Track M5 PR 2) dispatchers use the variable form; every literal
+    # PR 2), `/trpc/media.shelfImpressions.*` (Track M3 PR 2), and
+    # `/trpc/cerebrum.nudges.{list,get,dismiss,contradictions}` (Track
+    # M5 PR 2) dispatchers use the variable form; every literal
     # `proxy_pass` below still hard-fails the boot if its host is
     # unreachable, so new optional upstreams must adopt the variable
     # form to inherit the boot-resilience.
@@ -78,23 +79,33 @@ server {
     # un-migrated `cerebrum.nudges.{scan,act,configure}` stay on pops-api
     # because they reach into EngramService + HybridSearchService, which
     # haven't moved to `@pops/cerebrum-db` yet — naming them explicitly
-    # in the regex (rather than `cerebrum\.nudges\.[^,]+$`) prevents
-    # `scan`/`act`/`configure` requests from being mis-routed to
-    # cerebrum-api where they'd 404 (Copilot R1 finding).
-    #
-    # Same `[^,]+$` anchor as the inventory dispatcher: batched URLs
-    # (mixed OR all-nudges) keep falling through to pops-api, which
-    # still mounts the whole cerebrumRouter.
-    #
-    # `$cerebrum_nudges_upstream` defers DNS to request time
-    # (variable-form `proxy_pass`) matching the #2886 pattern: boot
-    # doesn't fail if `cerebrum-api` is unavailable, the call 502s and
-    # per-route `PillarGuard` flips to the unavailable placeholder —
-    # documented soft-fallback in
-    # `docs/runbooks/cerebrum-api-pillar-verification.md`.
+    # in the regex prevents mis-routing.
     location ~ ^/trpc/cerebrum\.nudges\.(list|get|dismiss|contradictions)$ {
         set $cerebrum_nudges_upstream http://cerebrum-api:3007;
         proxy_pass $cerebrum_nudges_upstream;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 30s;
+        proxy_connect_timeout 5s;
+        proxy_send_timeout 30s;
+    }
+
+    # Media dispatcher cutover — Track M3 PR 2.
+    #
+    # `media.shelfImpressions.{recordImpressions,getRecentImpressions,getShelfFreshness,cleanup}`
+    # was migrated into pops-media-api (Track M3 PR 1, #2890). Route the
+    # tRPC URLs for those procedures to media-api so it becomes the
+    # canonical handler. The legacy mediaRouter on pops-api stays as a
+    # fall-through until Track M3 PR 3 deletes it.
+    #
+    # `media.shelfImpressions.*` has no frontend batched callers
+    # (server-to-server only), so a prefix match is safe.
+    location ~ ^/trpc/media\.shelfImpressions\. {
+        set $media_dispatcher_upstream http://media-api:3003;
+        proxy_pass $media_dispatcher_upstream;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
## Summary

- Adds a regex `location ~ ^/trpc/media\.shelfImpressions\.` in `apps/pops-shell/nginx.conf` so the four `media.shelfImpressions.*` tRPC procedures (`recordImpressions`, `getRecentImpressions`, `getShelfFreshness`, `cleanup`) route to `media-api:3003` instead of falling through to pops-api.
- Upstream held in `$media_dispatcher_upstream` so DNS resolution defers to request time — pops-shell still boots on hosts that haven't yet deployed `pops-media-api` (same boot-resilience pattern #2886 established for `/pillars`).
- Updates the resolver comment to cover the second variable-form upstream.

## Why nginx-level

Mirrors the canonical dispatcher pattern set by Track M1 PR 2 for `core.serviceAccounts.*` — same regex shape, same variable-form upstream, same comment style. Keeps the M-track cutovers uniform: one gateway hop, no extra tRPC middleware to plumb `messageKey` through, no second error envelope.

Batch-mixing risk is bounded: `media.shelfImpressions.*` has zero frontend callers today (server-to-server only, plus admin tooling that doesn't batch with non-media-api routers), so a mixed-router batch can't land on the wrong handler.

## What stays mounted

- pops-api's `mediaRouter` is untouched. It already does NOT expose `shelfImpressions` as tRPC procedures (the legacy in-process call from `media.discovery.assembleSession` to `shelfImpressionsService` uses the `media.db` handle directly), but PR 3 is what formally cleans up the now-unreachable surface — this PR keeps the fall-through as documented in the Track M3 plan.
- The in-process `assembleSession` call to `shelfImpressionsService` keeps reading/writing the same `media.db` handle — the cutover is purely about external tRPC traffic.

## Refs

- Track M3 PR 1 (#2890) — shipped the router as a shadow surface.
- #2886 — variable-form `proxy_pass` boot-resilience pattern.
- ADR-026 — pillar dispatcher architecture.

## Test plan

- [x] `nginx -t` against the rendered conf in `nginx:alpine` (DNS stubbed): syntax ok.
- [x] `pnpm typecheck` — 51/51 tasks green.
- [x] `pnpm lint` — clean (only pre-existing warnings).
- [x] `pnpm --filter @pops/api test` — 306 files, 4875 tests green; legacy media surface untouched.
- [x] `pnpm --filter @pops/media-api test` — 2 files, 10 tests green.
- [x] `pnpm --filter @pops/shell test` — 28 files, 342 tests green.
- [x] `pnpm build` — full workspace builds.
- [x] `pnpm format` — no diff.
- [ ] Smoke against a live stack post-merge: confirm `media-api` answers `POST /trpc/media.shelfImpressions.recordImpressions` and pops-api still answers every other `media.*` procedure.
