### PR TITLE
feat(inventory-api): make pops-inventory-api the canonical inventory.* handler (Track M4 PR 2)

### DIFF
--- a/apps/pops-shell/nginx.conf
+++ b/apps/pops-shell/nginx.conf
@@ -4,15 +4,15 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
-    # Resolver for variable-form `proxy_pass`. Only the upstream that
-    # uses this (the `core-api` proxy in the `/pillars` location) is
-    # deferred to request-time DNS — every literal `proxy_pass <name>;`
-    # below still resolves at config-load time, so removing pops-api or
-    # any other literal upstream from a host would still kill the nginx
-    # boot. Today the only optional upstream is `core-api`; if more
-    # pillar APIs become optional in the future they need the same
-    # variable-form treatment to inherit this behaviour.
-    resolver 127.0.0.11 valid=30s ipv6=off;
+    # Resolver for variable-form `proxy_pass`. Upstreams held in an
+    # nginx variable defer DNS resolution to request time (vs. config-
+    # load time for literal `proxy_pass <name>`), letting nginx boot
+    # even when an optional pillar container is missing. Today both the
+    # `/pillars` proxy and the `/trpc/inventory.locations.*` dispatcher
+    # (Track M4 PR 2) use the variable form; every literal `proxy_pass`
+    # below still hard-fails the boot if its host is unreachable, so
+    # new optional upstreams must adopt the variable form to inherit
+    # the boot-resilience.
     resolver 127.0.0.11 valid=30s ipv6=off;
 
     # Gzip compression
@@ -24,6 +24,50 @@ server {
     location /assets/ {
         expires 1y;
         add_header Cache-Control "public, immutable";
+    }
+
+    # Inventory dispatcher cutover — Track M4 PR 2.
+    #
+    # `inventory.locations.*` was migrated into pops-inventory-api
+    # (Track M4 PR 1, #2891). Route the tRPC URLs for those procedures
+    # to inventory-api so it becomes the canonical handler. The legacy
+    # `inventoryRouter` (locations slice included) stays mounted on
+    # pops-api as the fall-through until Track M4 PR 3 deletes it.
+    #
+    # Why exclude commas from the match — the shell's `httpBatchLink`
+    # packs N procedures into one URL of the form `/trpc/a,b,…`. Only
+    # `inventory.locations.*` is migrated today; sibling submodules
+    # (`inventory.items.*`, `inventory.reports.*`, `inventory.
+    # connections.*`, `inventory.documents.*`, `inventory.paperless.*`,
+    # `inventory.warranties.*`, …) still live on pops-api. A prefix
+    # match `^/trpc/inventory\.locations\.` would happily grab a batch
+    # whose FIRST member is a locations call but whose remaining
+    # members hit other inventory subrouters — inventory-api would
+    # 404 every non-locations procedure. Anchoring with `[^,]+$`
+    # forces a single-procedure URL: pure single-call requests land
+    # on the new container; every batched request (mixed OR locations-
+    # only) keeps falling through to pops-api, which still serves the
+    # whole `inventoryRouter`. Tradeoff accepted — partial-but-
+    # monotonic cutover that's trivial to revert if the new container
+    # misbehaves.
+    #
+    # `$inventory_locations_upstream` defers DNS resolution to request
+    # time (variable-form `proxy_pass`), matching the pattern landed
+    # in #2886: boot doesn't fail if `inventory-api` is unavailable,
+    # the call 502s and per-route `PillarGuard` flips to the
+    # unavailable placeholder — the documented soft-fallback in
+    # `docs/runbooks/inventory-api-pillar-verification.md`.
+    location ~ ^/trpc/inventory\.locations\.[^,]+$ {
+        set $inventory_locations_upstream http://inventory-api:3002;
+        proxy_pass $inventory_locations_upstream;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 30s;
+        proxy_connect_timeout 5s;
+        proxy_send_timeout 30s;
     }
 
     # Proxy tRPC API requests to pops-api


### PR DESCRIPTION
## Summary

- Track M4 PR 2 of the inventory pillar migration: cuts the shell's nginx gateway over to route `/trpc/inventory.locations.*` single-procedure tRPC calls to `pops-inventory-api:3002` (the container that received the migrated router in PR 1, #2891). pops-inventory-api becomes the canonical handler for those URLs; pops-api's in-process `inventoryRouter` stays mounted as the fall-through so PR 3 can do the legacy delete.
- No backend code changes. Single-file diff to `apps/pops-shell/nginx.conf`.

## Dispatcher strategy

**nginx-level routing, smallest diff and trivial to revert.** The alternative was a tRPC-layer proxy in pops-api that forwards `inventory.locations.*` procedures to the new container — it would have meant a new outbound HTTP client, response-shape plumbing, and a new failure mode (proxy fails, fall-through reaches in-process router). nginx wins on simplicity for this slice: one `location ~` block, no new dependencies, and a 1-line revert.

The match is anchored as `^/trpc/inventory\.locations\.[^,]+$`. The `[^,]+` exclusion is the load-bearing piece:

- The shell's tRPC client uses `httpBatchLink` (see `packages/api-client/src/index.ts`) which packs N procedures into a single URL of the form `/trpc/a,b,c?batch=1`.
- Only `inventory.locations.*` is migrated today. Sibling submodules (`inventory.items.*`, `inventory.reports.*`, `inventory.connections.*`, `inventory.documents.*`, `inventory.paperless.*`, `inventory.warranties.*`) still live on pops-api.
- A naive prefix match `^/trpc/inventory\.locations\.` would happily grab a batched URL whose first member is a locations call but whose remaining members hit other inventory subrouters. inventory-api would 404 every non-locations procedure in the batch.
- Anchoring on a comma-free single-procedure URL keeps every batched call (mixed OR pure-locations) on pops-api's intact `inventoryRouter`. Single-call requests land on the new container. The cutover is partial-but-monotonic — PR 3 widens the match (or deletes the legacy router) once items/reports/connections/etc. migrate behind subsequent PRs.

`$inventory_locations_upstream` is held in an nginx variable so DNS resolution defers to request time — same pattern landed in #2886 for the `/pillars` proxy. Boot doesn't fail when `inventory-api` is missing from a host; calls 502 and per-route `PillarGuard` flips to the documented soft-fallback (`docs/runbooks/inventory-api-pillar-verification.md`).

## What stays the same

- pops-api's `inventoryRouter` remains mounted at `inventory.*` on `appRouter` (`apps/pops-api/src/router.ts`). Every existing pops-api integration test against `food.locations.*` and the broader `inventory.*` surface continues to pass against the in-process implementation.
- The migrated procedures' wire shape is byte-identical (PR 1's Copilot R1 fix already plumbed `messageKey` through the tRPC `errorFormatter` in inventory-api), so the shell's i18n keeps working when calls land on either upstream.
- The `inventory-api` Dockerfile/compose entry and `expose: 3002` already landed in PR 1; this PR is gateway-only.

## Test plan

- [x] `pnpm typecheck` — 51 tasks pass
- [x] `pnpm lint` — exits 0 (warnings only, pre-existing)
- [x] `pnpm --filter @pops/api test` — 4875 tests pass (in-process `inventoryRouter` still serves its full surface)
- [x] `pnpm --filter @pops/inventory-api test` — 27 tests pass (PR 1 router + handlers unchanged)
- [x] `pnpm --filter @pops/shell test` — 342 tests pass
- [x] `pnpm build` — 25 tasks pass
- [x] `pnpm format` — clean
- [x] nginx config syntactically valid (`docker run nginx:alpine nginx -t` parses past the new `location` block; only "host not found" errors remain, which are expected when running outside the compose network)

Refs #2891 (Track M4 PR 1).
