### PR TITLE
feat(core-api): make pops-core-api the canonical core.serviceAccounts.* handler (Track M1 PR 2)

### DIFF
--- a/apps/pops-shell/nginx.conf
+++ b/apps/pops-shell/nginx.conf
@@ -8,8 +8,9 @@ server {
     # nginx variable defer DNS resolution to request time (vs. config-
     # load time for literal `proxy_pass <name>`), letting nginx boot
     # even when an optional pillar container is missing. Today the
-    # `/pillars` proxy plus the `/trpc/inventory.locations.*` (Track M4
-    # PR 2), `/trpc/media.shelfImpressions.*` (Track M3 PR 2), and
+    # `/pillars` proxy plus the `/trpc/core.serviceAccounts.*` (Track M1
+    # PR 2), `/trpc/inventory.locations.*` (Track M4 PR 2),
+    # `/trpc/media.shelfImpressions.*` (Track M3 PR 2), and
     # `/trpc/cerebrum.nudges.{list,get,dismiss,contradictions}` (Track
     # M5 PR 2) dispatchers use the variable form; every literal
     # `proxy_pass` below still hard-fails the boot if its host is
@@ -77,9 +78,7 @@ server {
     # ONLY the four migrated `cerebrum.nudges.{list,get,dismiss,contradictions}`
     # procedures route to pops-cerebrum-api (Track M5 PR 1, #2892). The
     # un-migrated `cerebrum.nudges.{scan,act,configure}` stay on pops-api
-    # because they reach into EngramService + HybridSearchService, which
-    # haven't moved to `@pops/cerebrum-db` yet — naming them explicitly
-    # in the regex prevents mis-routing.
+    # because they reach into EngramService + HybridSearchService.
     location ~ ^/trpc/cerebrum\.nudges\.(list|get|dismiss|contradictions)$ {
         set $cerebrum_nudges_upstream http://cerebrum-api:3007;
         proxy_pass $cerebrum_nudges_upstream;
@@ -106,6 +105,24 @@ server {
     location ~ ^/trpc/media\.shelfImpressions\. {
         set $media_dispatcher_upstream http://media-api:3003;
         proxy_pass $media_dispatcher_upstream;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 30s;
+        proxy_connect_timeout 5s;
+        proxy_send_timeout 30s;
+    }
+
+    # Core dispatcher cutover — Track M1 PR 2.
+    #
+    # `core.serviceAccounts.*` was migrated into pops-core-api (Track M1
+    # PR 1, #2889). Admin-only (CLI/MCP), no batched callers — prefix
+    # match safe.
+    location ~ ^/trpc/core\.serviceAccounts\. {
+        set $core_dispatcher_upstream http://core-api:3001;
+        proxy_pass $core_dispatcher_upstream;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
## Summary

Flips the canonical handler for `core.serviceAccounts.{list,create,revoke}` from `pops-api` to `pops-core-api`. The migrated router landed in #2889; this PR is the URL-level cutover — no application code changes, just an nginx routing rule.

A new regex `location` in `apps/pops-shell/nginx.conf` matches `^/trpc/core\.serviceAccounts\.` and proxies to `http://core-api:3001` before the generic `/trpc` prefix that routes everything else to `pops-api`. The legacy `core.serviceAccounts` router on `pops-api` stays mounted as a fall-through until Track M1 PR 3 deletes it — only this proxy rule decides which one answers.

### Boot resilience

The new upstream uses the same variable-form `proxy_pass` pattern as the `/pillars` proxy (#2886), so DNS resolves at request time rather than nginx config-load time. If a host doesn't have `core-api` deployed yet, the shell still boots and these specific procedures return 502 — the correct failure mode, not a wedged shell. I also collapsed a duplicated `resolver` directive that was left behind and rewrote the neighbouring comment block to reflect that two locations (not one) now use the variable form.

### Why a path-based split is safe

`core.serviceAccounts.*` is admin-only — invoked by CLI/MCP tooling, never from the shell UI. So the tRPC `httpBatchLink` comma-tail batch case (`/trpc/foo.bar,core.serviceAccounts.list`) can't arise in practice; anchored-prefix routing is fine.

### `/pillars` is untouched

The existing `/pillars` registry proxy and `/pillars/health` aggregator probe stay exactly as they were. The new `/trpc/core.…` rule sits independently of them.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm --filter @pops/api test` (306 files, 4875 tests)
- [x] `pnpm --filter @pops/core-api test` (4 files, 22 tests)
- [x] `pnpm --filter @pops/shell test` (28 files, 342 tests)
- [x] `pnpm build`
- [x] `nginx -t` against the edited config inside the `nginx:alpine` image (with `--add-host` stubs for `pops-api`/`core-api`) — syntax OK
- [ ] Post-merge: hit `POST /trpc/core.serviceAccounts.list` from a service-account-authenticated CLI and confirm it lands on `pops-core-api` (X-Real-IP/audit log inspection)
- [ ] Post-merge: stop the `core-api` container and confirm pops-shell still boots and `/trpc/media.shelves.list` (or any non-core procedure) still works — only `/trpc/core.serviceAccounts.*` should 502

Refs #2889, #2886.
