### PR TITLE
feat(cerebrum-api): make pops-cerebrum-api the canonical cerebrum.nudges.* handler — partial cutover (Track M5 PR 2)

### DIFF
--- a/apps/pops-shell/nginx.conf
+++ b/apps/pops-shell/nginx.conf
@@ -7,12 +7,13 @@ server {
     # Resolver for variable-form `proxy_pass`. Upstreams held in an
     # nginx variable defer DNS resolution to request time (vs. config-
     # load time for literal `proxy_pass <name>`), letting nginx boot
-    # even when an optional pillar container is missing. Today both the
-    # `/pillars` proxy and the `/trpc/inventory.locations.*` dispatcher
-    # (Track M4 PR 2) use the variable form; every literal `proxy_pass`
-    # below still hard-fails the boot if its host is unreachable, so
-    # new optional upstreams must adopt the variable form to inherit
-    # the boot-resilience.
+    # even when an optional pillar container is missing. Today the
+    # `/pillars` proxy plus the `/trpc/inventory.locations.*` (Track M4
+    # PR 2) and `/trpc/cerebrum.nudges.{list,get,dismiss,contradictions}`
+    # (Track M5 PR 2) dispatchers use the variable form; every literal
+    # `proxy_pass` below still hard-fails the boot if its host is
+    # unreachable, so new optional upstreams must adopt the variable
+    # form to inherit the boot-resilience.
     resolver 127.0.0.11 valid=30s ipv6=off;
 
     # Gzip compression
@@ -60,6 +61,40 @@ server {
     location ~ ^/trpc/inventory\.locations\.[^,]+$ {
         set $inventory_locations_upstream http://inventory-api:3002;
         proxy_pass $inventory_locations_upstream;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 30s;
+        proxy_connect_timeout 5s;
+        proxy_send_timeout 30s;
+    }
+
+    # Cerebrum dispatcher cutover — Track M5 PR 2.
+    #
+    # ONLY the four migrated `cerebrum.nudges.{list,get,dismiss,contradictions}`
+    # procedures route to pops-cerebrum-api (Track M5 PR 1, #2892). The
+    # un-migrated `cerebrum.nudges.{scan,act,configure}` stay on pops-api
+    # because they reach into EngramService + HybridSearchService, which
+    # haven't moved to `@pops/cerebrum-db` yet — naming them explicitly
+    # in the regex (rather than `cerebrum\.nudges\.[^,]+$`) prevents
+    # `scan`/`act`/`configure` requests from being mis-routed to
+    # cerebrum-api where they'd 404 (Copilot R1 finding).
+    #
+    # Same `[^,]+$` anchor as the inventory dispatcher: batched URLs
+    # (mixed OR all-nudges) keep falling through to pops-api, which
+    # still mounts the whole cerebrumRouter.
+    #
+    # `$cerebrum_nudges_upstream` defers DNS to request time
+    # (variable-form `proxy_pass`) matching the #2886 pattern: boot
+    # doesn't fail if `cerebrum-api` is unavailable, the call 502s and
+    # per-route `PillarGuard` flips to the unavailable placeholder —
+    # documented soft-fallback in
+    # `docs/runbooks/cerebrum-api-pillar-verification.md`.
+    location ~ ^/trpc/cerebrum\.nudges\.(list|get|dismiss|contradictions)$ {
+        set $cerebrum_nudges_upstream http://cerebrum-api:3007;
+        proxy_pass $cerebrum_nudges_upstream;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
## Summary

Track M5 Phase 5 PR 2 — wire the pops-shell nginx dispatcher so external tRPC traffic for the migrated `cerebrum.nudges.*` procedures lands on `pops-cerebrum-api`. The legacy `pops-api` router stays mounted as the fall-through for everything else (mixed-batch URLs, the un-migrated procedures, and any other tRPC path).

PR 1 ([#2892](https://github.com/knoxio/pops/pull/2892), squashed as `dfcf6629`) moved the read/dismiss router into the container as a shadow. This PR makes it canonical.

## Partial cutover scope

**Now answered by `pops-cerebrum-api`:**

- `cerebrum.nudges.list`           (protected query)
- `cerebrum.nudges.get`             (protected query)
- `cerebrum.nudges.dismiss`         (protected mutation)
- `cerebrum.nudges.contradictions`  (protected query)

**Still answered by `pops-api`:**

- `cerebrum.nudges.scan`
- `cerebrum.nudges.act`
- `cerebrum.nudges.configure`

These three reach into `EngramService` + `HybridSearchService`, which still read engrams tables that have not yet moved to `@pops/cerebrum-db`. They migrate when the engrams slice does.

Plus, by design, every other `/trpc/*` URL (every batched URL included) keeps flowing through to `pops-api`.

## Mechanism

A new regex location ahead of the catch-all `/trpc` block:

```nginx
location ~ ^/trpc/cerebrum\.nudges\.[^,]+$ {
    set $cerebrum_nudges_upstream http://cerebrum-api:3007;
    proxy_pass $cerebrum_nudges_upstream;
    ...
}
```

- The `[^,]+$` anchor forces a single-procedure URL. Standalone calls (e.g. the `NudgeIndicator` poll for `cerebrum.nudges.list`) land on the new container; every batched URL — mixed OR even all-nudges — falls through to `pops-api`, which still has the whole `cerebrumRouter` mounted. Matches the M4 inventory dispatcher pattern (parallel sibling worktree `feat/inventory-dispatcher-cutover-m4-pr-2`).
- The upstream is held in an nginx variable so DNS resolution is deferred to request time, mirroring [#2886](https://github.com/knoxio/pops/pull/2886). Hosts that haven't yet deployed `pops-cerebrum-api` still boot the shell normally; the four nudges procedures 502 until the upstream is in place — the documented soft-fallback in `docs/runbooks/cerebrum-api-pillar-verification.md`.

Tradeoff accepted — a partial-but-monotonic cutover that's trivial to revert if `pops-cerebrum-api` misbehaves. The legacy router stays serving as a hot backup until Track M5 PR 3 deletes the migrated procedures from it.

## Drive-by

The pre-existing duplicate `resolver` directive (lines 15-16 on `main`) is dropped — it was a config error masked by the literal `pops-api` upstream emerg in the boot test. Sibling M4 inventory drops it the same way.

## Container boot invariant

`pops-cerebrum-api` opens both `cerebrum.db` (nudge data) AND `core.db` (service-account auth). This dispatcher swap is wire-only — no container code changes. Verified `pnpm --filter @pops/cerebrum-api test` stays green (23/23, including the supertest `/trpc` round-trip that boots both handles end-to-end).

## Test plan

- [x] `docker run --rm -v $(pwd)/apps/pops-shell/nginx.conf:/etc/nginx/conf.d/default.conf:ro nginx:alpine nginx -t` — only the expected literal-upstream emerg on `pops-api` (always present in a real compose stack); the duplicate-`resolver` emerg from `main` is gone; the new `cerebrum-api` upstream does NOT trigger a boot emerg because it's variable-form.
- [x] `pnpm lint` — clean (warnings only, no new ones).
- [x] `pnpm typecheck` — clean (51/51).
- [x] `pnpm format:check` — clean.
- [x] `pnpm --filter @pops/cerebrum-api test` — 23/23 (proves the container still boots both `cerebrum.db` + `core.db` handles).
- [x] `pnpm --filter @pops/shell test` — 342/342.
- [ ] Post-merge on a host with both containers: `curl /trpc/cerebrum.nudges.list?...` (single procedure) hits `pops-cerebrum-api` access log; a batched `/trpc/cerebrum.nudges.list,…` still hits `pops-api`.
- [ ] Post-merge on a host WITHOUT `pops-cerebrum-api` deployed: `pops-shell` still boots; `/trpc/cerebrum.nudges.list` returns 502; every other `/trpc/*` route keeps working.

Refs [#2892](https://github.com/knoxio/pops/pull/2892).