### PR TITLE
feat(finance-db): flip transaction_corrections consumer to @pops/finance-db (Track N3 phase 1 PR 3)

### DIFF
--- a/apps/pops-api/src/modules/core/corrections/handlers/pattern-match.ts
+++ b/apps/pops-api/src/modules/core/corrections/handlers/pattern-match.ts
@@ -1,10 +1,16 @@
-import { and, asc, desc, eq, gte, sql } from 'drizzle-orm';
-
-import { transactionCorrections } from '@pops/db-types';
+/**
+ * Thin shims that forward the in-tree pattern-match read API to
+ * `@pops/finance-db`'s `transactionCorrectionsService`.
+ *
+ * Track N3 phase 1 PR 3 routing flip — see `query-helpers.ts` for the
+ * full rationale. The `getDrizzle()` handle still resolves to the shared
+ * `pops.db` so the in-tree imports pipeline (the other consumer) keeps
+ * seeing the same rows.
+ */
+import { transactionCorrectionsService } from '@pops/finance-db';
 
 import { getDrizzle } from '../../../../db.js';
-import { ruleMatchesDescription } from '../pure-service.js';
-import { classifyCorrectionMatch, normalizeDescription } from '../types.js';
+import { classifyCorrectionMatch } from '../types.js';
 
 import type { CorrectionMatchResult, CorrectionRow } from '../types.js';
 
@@ -12,22 +18,11 @@ export function findAllMatchingCorrectionFromDB(
   description: string,
   minConfidence: number = 0.7
 ): CorrectionRow[] {
-  const db = getDrizzle();
-  const normalized = normalizeDescription(description);
-
-  const candidates = db
-    .select()
-    .from(transactionCorrections)
-    .where(
-      and(
-        eq(transactionCorrections.isActive, true),
-        gte(transactionCorrections.confidence, minConfidence)
-      )
-    )
-    .orderBy(asc(transactionCorrections.priority), asc(transactionCorrections.id))
-    .all();
-
-  return candidates.filter((rule) => ruleMatchesDescription(rule, normalized));
+  return transactionCorrectionsService.findAllMatchingTransactionCorrectionsFromDb(
+    getDrizzle(),
+    description,
+    minConfidence
+  );
 }
 
 export function findMatchingCorrection(
@@ -41,54 +36,8 @@ export function findMatchingCorrection(
 }
 
 export function findAllMatchingCorrections(description: string): CorrectionRow[] {
-  const db = getDrizzle();
-  const normalized = normalizeDescription(description);
-
-  const exactMatches = db
-    .select()
-    .from(transactionCorrections)
-    .where(
-      and(
-        eq(transactionCorrections.isActive, true),
-        eq(transactionCorrections.matchType, 'exact'),
-        eq(transactionCorrections.descriptionPattern, normalized)
-      )
-    )
-    .orderBy(desc(transactionCorrections.confidence), desc(transactionCorrections.timesApplied))
-    .all();
-
-  const containsMatches = db
-    .select()
-    .from(transactionCorrections)
-    .where(
-      and(
-        eq(transactionCorrections.isActive, true),
-        eq(transactionCorrections.matchType, 'contains'),
-        sql`${normalized} LIKE '%' || ${transactionCorrections.descriptionPattern} || '%'`
-      )
-    )
-    .orderBy(desc(transactionCorrections.confidence), desc(transactionCorrections.timesApplied))
-    .all();
-
-  const regexCandidates = db
-    .select()
-    .from(transactionCorrections)
-    .where(
-      and(eq(transactionCorrections.isActive, true), eq(transactionCorrections.matchType, 'regex'))
-    )
-    .orderBy(desc(transactionCorrections.confidence), desc(transactionCorrections.timesApplied))
-    .all();
-
-  const regexMatches: CorrectionRow[] = [];
-  for (const row of regexCandidates) {
-    try {
-      if (new RegExp(row.descriptionPattern).test(normalized)) {
-        regexMatches.push(row);
-      }
-    } catch {
-      // ignore invalid regex
-    }
-  }
-
-  return [...exactMatches, ...containsMatches, ...regexMatches];
+  return transactionCorrectionsService.findAllMatchingTransactionCorrections(
+    getDrizzle(),
+    description
+  );
 }

--- a/apps/pops-api/src/modules/core/corrections/handlers/query-helpers.ts
+++ b/apps/pops-api/src/modules/core/corrections/handlers/query-helpers.ts
@@ -1,12 +1,38 @@
-import { and, count, desc, eq, gte, sql } from 'drizzle-orm';
-
-import { transactionCorrections } from '@pops/db-types';
+/**
+ * Thin shims that forward CRUD operations on `transaction_corrections` to
+ * `@pops/finance-db`'s `transactionCorrectionsService`.
+ *
+ * Track N3 phase 1 PR 3 routing flip: the underlying drizzle handle (and
+ * the on-disk SQLite file) is unchanged — `getDrizzle()` still resolves to
+ * the shared `pops.db` so the in-tree imports pipeline (the other consumer
+ * of this table) keeps reading and writing the same rows. Only the code
+ * path moves from the in-tree implementation to the package one. PR 4 of
+ * phase 1 will delete this shim once the imports pipeline (N6) is also on
+ * the package and the handle can shift to `getFinanceDrizzle()`.
+ *
+ * Domain errors thrown by the package (`TransactionCorrectionNotFoundError`)
+ * are translated to `NotFoundError` so the existing router layer (and the
+ * tRPC error envelope it depends on) keeps returning `404 NOT_FOUND` with
+ * the same `common.notFound` i18n key.
+ */
+import {
+  transactionCorrectionsService,
+  TransactionCorrectionNotFoundError,
+  type CreateTransactionCorrectionInput,
+  type UpdateTransactionCorrectionInput,
+} from '@pops/finance-db';
 
 import { getDrizzle } from '../../../../db.js';
 import { NotFoundError } from '../../../../shared/errors.js';
-import { normalizeDescription } from '../types.js';
 
 import type { CorrectionRow, CreateCorrectionInput, UpdateCorrectionInput } from '../types.js';
+
+function rethrowAsNotFound(err: unknown, id: string): never {
+  if (err instanceof TransactionCorrectionNotFoundError) {
+    throw new NotFoundError('Correction', id);
+  }
+  throw err;
+}
 
 export function listCorrections(
   minConfidence?: number,
@@ -14,209 +40,79 @@ export function listCorrections(
   offset: number = 0,
   matchType?: 'exact' | 'contains' | 'regex'
 ): { rows: CorrectionRow[]; total: number } {
-  const db = getDrizzle();
-
-  const conditions = [];
-  if (minConfidence !== undefined) {
-    conditions.push(gte(transactionCorrections.confidence, minConfidence));
-  }
-  if (matchType) {
-    conditions.push(eq(transactionCorrections.matchType, matchType));
-  }
-  const condition = conditions.length > 0 ? and(...conditions) : undefined;
-
-  const [countResult] = db
-    .select({ count: count() })
-    .from(transactionCorrections)
-    .where(condition)
-    .all();
-
-  const rows = db
-    .select()
-    .from(transactionCorrections)
-    .where(condition)
-    .orderBy(desc(transactionCorrections.confidence), desc(transactionCorrections.timesApplied))
-    .limit(limit)
-    .offset(offset)
-    .all();
-
-  return { rows, total: countResult?.count ?? 0 };
+  return transactionCorrectionsService.listTransactionCorrections(getDrizzle(), {
+    minConfidence,
+    matchType,
+    limit,
+    offset,
+  });
 }
 
 export function getCorrection(id: string): CorrectionRow {
-  const db = getDrizzle();
-  const [row] = db
-    .select()
-    .from(transactionCorrections)
-    .where(eq(transactionCorrections.id, id))
-    .all();
-
-  if (!row) {
-    throw new NotFoundError('Correction', id);
+  try {
+    return transactionCorrectionsService.getTransactionCorrection(getDrizzle(), id);
+  } catch (err) {
+    rethrowAsNotFound(err, id);
   }
-
-  return row;
-}
-
-function updateExistingCorrection(
-  existing: CorrectionRow,
-  input: CreateCorrectionInput
-): CorrectionRow {
-  const db = getDrizzle();
-  db.update(transactionCorrections)
-    .set({
-      confidence: Math.min(existing.confidence + 0.1, 1.0),
-      timesApplied: existing.timesApplied + 1,
-      lastUsedAt: new Date().toISOString(),
-      entityId: input.entityId ?? existing.entityId,
-      entityName: input.entityName ?? existing.entityName,
-      location: input.location ?? existing.location,
-      tags: JSON.stringify(input.tags ?? []),
-      transactionType: input.transactionType ?? existing.transactionType,
-      priority: input.priority ?? existing.priority,
-      isActive: true,
-    })
-    .where(eq(transactionCorrections.id, existing.id))
-    .run();
-  return getCorrection(existing.id);
-}
-
-function insertNewCorrection(input: CreateCorrectionInput, normalized: string): CorrectionRow {
-  const db = getDrizzle();
-  const result = db
-    .insert(transactionCorrections)
-    .values({
-      descriptionPattern: normalized,
-      matchType: input.matchType,
-      entityId: input.entityId ?? null,
-      entityName: input.entityName ?? null,
-      location: input.location ?? null,
-      tags: JSON.stringify(input.tags ?? []),
-      transactionType: input.transactionType ?? null,
-      priority: input.priority ?? 0,
-      isActive: true,
-    })
-    .run();
-
-  const [inserted] = db
-    .select()
-    .from(transactionCorrections)
-    .where(sql`rowid = ${result.lastInsertRowid}`)
-    .all();
-
-  if (!inserted) throw new NotFoundError('Correction', String(result.lastInsertRowid));
-  return inserted;
 }
 
 export function createOrUpdateCorrection(input: CreateCorrectionInput): CorrectionRow {
-  const db = getDrizzle();
-  const normalized = normalizeDescription(input.descriptionPattern);
-
-  const [existing] = db
-    .select()
-    .from(transactionCorrections)
-    .where(
-      and(
-        eq(transactionCorrections.descriptionPattern, normalized),
-        eq(transactionCorrections.matchType, input.matchType)
-      )
-    )
-    .all();
-
-  if (existing) return updateExistingCorrection(existing, input);
-  return insertNewCorrection(input, normalized);
+  const packageInput: CreateTransactionCorrectionInput = {
+    descriptionPattern: input.descriptionPattern,
+    matchType: input.matchType,
+    entityId: input.entityId,
+    entityName: input.entityName,
+    location: input.location,
+    tags: input.tags,
+    transactionType: input.transactionType,
+    priority: input.priority,
+  };
+  return transactionCorrectionsService.createOrUpdateTransactionCorrection(
+    getDrizzle(),
+    packageInput
+  );
 }
 
 export function updateCorrection(id: string, input: UpdateCorrectionInput): CorrectionRow {
-  const db = getDrizzle();
-  const existing = getCorrection(id);
-
-  const updates: Partial<typeof transactionCorrections.$inferInsert> = {};
-  let hasUpdates = false;
-
-  if (input.descriptionPattern !== undefined) {
-    // Normalise on edit so the stored pattern stays consistent with how
-    // createOrUpdateCorrection persists newly created rules.
-    updates.descriptionPattern = normalizeDescription(input.descriptionPattern);
-    hasUpdates = true;
+  const packageInput: UpdateTransactionCorrectionInput = {
+    descriptionPattern: input.descriptionPattern,
+    matchType: input.matchType,
+    entityId: input.entityId,
+    entityName: input.entityName,
+    location: input.location,
+    tags: input.tags,
+    transactionType: input.transactionType,
+    isActive: input.isActive,
+    confidence: input.confidence,
+    priority: input.priority,
+  };
+  try {
+    return transactionCorrectionsService.updateTransactionCorrection(
+      getDrizzle(),
+      id,
+      packageInput
+    );
+  } catch (err) {
+    rethrowAsNotFound(err, id);
   }
-  if (input.matchType !== undefined) {
-    updates.matchType = input.matchType;
-    hasUpdates = true;
-  }
-  if (input.entityId !== undefined) {
-    updates.entityId = input.entityId;
-    hasUpdates = true;
-  }
-  if (input.entityName !== undefined) {
-    updates.entityName = input.entityName;
-    hasUpdates = true;
-  }
-  if (input.location !== undefined) {
-    updates.location = input.location;
-    hasUpdates = true;
-  }
-  if (input.tags !== undefined) {
-    updates.tags = JSON.stringify(input.tags);
-    hasUpdates = true;
-  }
-  if (input.transactionType !== undefined) {
-    updates.transactionType = input.transactionType;
-    hasUpdates = true;
-  }
-  if (input.isActive !== undefined) {
-    updates.isActive = input.isActive;
-    hasUpdates = true;
-  }
-  if (input.confidence !== undefined) {
-    updates.confidence = input.confidence;
-    hasUpdates = true;
-  }
-  if (input.priority !== undefined) {
-    updates.priority = input.priority;
-    hasUpdates = true;
-  }
-
-  if (!hasUpdates) {
-    return existing;
-  }
-
-  db.update(transactionCorrections).set(updates).where(eq(transactionCorrections.id, id)).run();
-
-  return getCorrection(id);
 }
 
 export function deleteCorrection(id: string): void {
-  const db = getDrizzle();
-  const result = db.delete(transactionCorrections).where(eq(transactionCorrections.id, id)).run();
-
-  if (result.changes === 0) {
-    throw new NotFoundError('Correction', id);
+  try {
+    transactionCorrectionsService.deleteTransactionCorrection(getDrizzle(), id);
+  } catch (err) {
+    rethrowAsNotFound(err, id);
   }
 }
 
 export function incrementCorrectionUsage(id: string): void {
-  const db = getDrizzle();
-  db.update(transactionCorrections)
-    .set({
-      timesApplied: sql`${transactionCorrections.timesApplied} + 1`,
-      lastUsedAt: new Date().toISOString(),
-    })
-    .where(eq(transactionCorrections.id, id))
-    .run();
+  transactionCorrectionsService.incrementTransactionCorrectionUsage(getDrizzle(), id);
 }
 
 export function adjustConfidence(id: string, delta: number): void {
-  const db = getDrizzle();
-  const existing = getCorrection(id);
-  const newConfidence = Math.max(0, Math.min(1, existing.confidence + delta));
-
-  db.update(transactionCorrections)
-    .set({ confidence: newConfidence })
-    .where(eq(transactionCorrections.id, id))
-    .run();
-
-  if (newConfidence < 0.3) {
-    deleteCorrection(id);
+  try {
+    transactionCorrectionsService.adjustTransactionCorrectionConfidence(getDrizzle(), id, delta);
+  } catch (err) {
+    rethrowAsNotFound(err, id);
   }
 }

--- a/apps/pops-api/src/modules/core/corrections/router-crud.ts
+++ b/apps/pops-api/src/modules/core/corrections/router-crud.ts
@@ -1,8 +1,7 @@
-import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 
-import { NotFoundError } from '../../../shared/errors.js';
 import { paginationMeta } from '../../../shared/pagination.js';
+import { mapDomainErrors } from '../../../shared/trpc-error-mapper.js';
 import { protectedProcedure, router } from '../../../trpc.js';
 import { previewMatches } from './handlers/preview-matches.js';
 import { analyzeCorrection, generateRules } from './lib/rule-generator.js';
@@ -62,8 +61,8 @@ export const crudRouter = router({
         offset: z.coerce.number().nonnegative().optional(),
       })
     )
-    .query(({ input }) => {
-      try {
+    .query(({ input }) =>
+      mapDomainErrors(() => {
         const dbRules = service.listCorrections(undefined, PREVIEW_RULES_FETCH_LIMIT, 0).rows;
         const merged =
           input.pendingChangeSets && input.pendingChangeSets.length > 0
@@ -80,25 +79,15 @@ export const crudRouter = router({
           data: sliced.map(toCorrection),
           pagination: paginationMeta(merged.length, limit ?? merged.length, offset),
         };
-      } catch (err) {
-        if (err instanceof NotFoundError) {
-          throw new TRPCError({ code: 'NOT_FOUND', message: err.message });
-        }
-        throw err;
-      }
-    }),
+      })
+    ),
 
-  get: protectedProcedure.input(z.object({ id: z.string() })).query(({ input }) => {
-    try {
+  get: protectedProcedure.input(z.object({ id: z.string() })).query(({ input }) =>
+    mapDomainErrors(() => {
       const row = service.getCorrection(input.id);
       return { data: toCorrection(row) };
-    } catch (err) {
-      if (err instanceof NotFoundError) {
-        throw new TRPCError({ code: 'NOT_FOUND', message: err.message });
-      }
-      throw err;
-    }
-  }),
+    })
+  ),
 
   findMatch: protectedProcedure.input(FindCorrectionSchema).query(({ input }) => {
     const result = service.findMatchingCorrection(input.description, input.minConfidence);
@@ -113,43 +102,28 @@ export const crudRouter = router({
 
   update: protectedProcedure
     .input(z.object({ id: z.string(), data: UpdateCorrectionSchema }))
-    .mutation(({ input }) => {
-      try {
+    .mutation(({ input }) =>
+      mapDomainErrors(() => {
         const row = service.updateCorrection(input.id, input.data);
         return { data: toCorrection(row), message: 'Correction updated' };
-      } catch (err) {
-        if (err instanceof NotFoundError) {
-          throw new TRPCError({ code: 'NOT_FOUND', message: err.message });
-        }
-        throw err;
-      }
-    }),
+      })
+    ),
 
-  delete: protectedProcedure.input(z.object({ id: z.string() })).mutation(({ input }) => {
-    try {
+  delete: protectedProcedure.input(z.object({ id: z.string() })).mutation(({ input }) =>
+    mapDomainErrors(() => {
       service.deleteCorrection(input.id);
       return { message: 'Correction deleted' };
-    } catch (err) {
-      if (err instanceof NotFoundError) {
-        throw new TRPCError({ code: 'NOT_FOUND', message: err.message });
-      }
-      throw err;
-    }
-  }),
+    })
+  ),
 
   adjustConfidence: protectedProcedure
     .input(z.object({ id: z.string(), delta: z.number().min(-1).max(1) }))
-    .mutation(({ input }) => {
-      try {
+    .mutation(({ input }) =>
+      mapDomainErrors(() => {
         service.adjustConfidence(input.id, input.delta);
         return { message: 'Confidence adjusted' };
-      } catch (err) {
-        if (err instanceof NotFoundError) {
-          throw new TRPCError({ code: 'NOT_FOUND', message: err.message });
-        }
-        throw err;
-      }
-    }),
+      })
+    ),
 
   analyzeCorrection: protectedProcedure
     .input(


### PR DESCRIPTION
## Summary

Flips the user-facing CRUD + matcher surface for `transaction_corrections` (the `core.corrections.*` tRPC procedures backed by `apps/pops-api/src/modules/core/corrections/handlers/{query-helpers,pattern-match}.ts`) over to the `@pops/finance-db` package scaffolded in #2857. The two handler files become thin shims that delegate to `transactionCorrectionsService` — every other in-tree caller compiles unchanged because the public function signatures are preserved.

PR 1 (#2857) shipped the scaffold + tests. PR 2 of the original 4-PR sequence is skipped — the journal split for the slice is already covered by Track E's pilot (0025/0026/0027/0052). PR 4 will retire the shim once the imports pipeline (Track N6) is also on the package.

Reference pattern: Track J3 (#2868), Track K3 (#2879), and the finance pillar wish-list cutover (#2781).

## Scope — what flipped vs. what stays

### Flipped to `@pops/finance-db`

- `apps/pops-api/src/modules/core/corrections/handlers/query-helpers.ts` — every CRUD function (`listCorrections`, `getCorrection`, `createOrUpdateCorrection`, `updateCorrection`, `deleteCorrection`, `incrementCorrectionUsage`, `adjustConfidence`) now forwards to `transactionCorrectionsService.*`. `TransactionCorrectionNotFoundError` from the package is translated to the in-tree `NotFoundError` so the tRPC envelope keeps surfacing `404 NOT_FOUND` with the `common.notFound` i18n key.
- `apps/pops-api/src/modules/core/corrections/handlers/pattern-match.ts` — `findAllMatchingCorrectionFromDB`, `findMatchingCorrection`, `findAllMatchingCorrections` all delegate to `transactionCorrectionsService.findAllMatchingTransactionCorrections{FromDb,}`.
- `apps/pops-api/src/modules/core/corrections/router-crud.ts` — routes `NotFoundError` through `mapDomainErrors`, replacing the per-procedure try/catch ladder that hand-mapped to `TRPCError`. Covers `get`, `update`, `delete`, `adjustConfidence`, `listMerged`.

### Intentionally not flipped (per #2857's scoping note)

- `apps/pops-api/src/modules/finance/imports/lib/correction-application.ts`, `correction-helpers.ts`, `apply-learned-correction.ts` — the imports-pipeline consumer of the matchers. These call into the in-tree `query-helpers` / `pattern-match` exports, so they ride the cutover transparently via the shim. They will be migrated to the package as part of Track N6's imports cutover.
- `apps/pops-api/src/modules/core/corrections/handlers/{apply-corrections,compute-changeset,changeset-impact,ai-revise,ai-inference,preview-matches}.ts` — higher-level changeset / AI orchestrations that the scaffold scoping decision deferred. They still hit `transaction_corrections` via raw drizzle and `getDrizzle()`.
- `router-changeset.ts` — its error paths come from the deferred in-tree handlers above, and each route has logger side-effects on the error path that `mapDomainErrors` would strip. Left as-is.

### Why the drizzle handle stays on `getDrizzle()` (not `getFinanceDrizzle()`)

The on-disk `transaction_corrections` rows live in the shared `pops.db` today. The finance pillar SQLite has the schema but no backfill yet, and the in-tree imports pipeline still writes via `getDrizzle()`. Routing the user-facing surface through `getFinanceDrizzle()` would silently split reads from writes. PR 4 (the imports cutover) will land the backfill + handle swap together.

## Test plan

- [x] `pnpm --filter @pops/finance-db test` — 195 / 195 pass
- [x] `pnpm --filter @pops/api exec vitest run src/modules/core/corrections` — 99 / 99 pass (covers `core.corrections.{list, listMerged, get, findMatch, createOrUpdate, update, delete, adjustConfidence}` end-to-end via the tRPC caller, including the `listMerged` NOT_FOUND path that depends on `mapDomainErrors` catching the `NotFoundError` thrown by the in-tree changeset apply step)
- [x] `pnpm --filter @pops/api exec vitest run src/modules/finance/imports` — 456 / 456 pass (covers the imports pipeline's reads of the shimmed `findAllMatchingCorrectionFromDB` / `listCorrections`)
- [x] `pnpm --filter @pops/api test` — 4875 / 4875 pass (full pops-api suite)
- [x] `pnpm typecheck` — 51 / 51 clean
- [x] `pnpm lint` — clean (pre-existing warnings only, no errors; exit 0)
- [x] `pnpm lint:boundaries` — no dependency violations (1989 modules, 5600 deps cruised)
- [x] `pnpm build` — 25 / 25 green

## References

- Phase 1 PR 1 (scaffold): #2857
- Track J3 (most recent cutover pattern): #2868
- Track K3: #2879
- Finance pillar wish-list cutover (the `getDrizzle` → `getFinanceDrizzle` precedent for PR 4): #2781