### PR TITLE
docs(inventory-api): defer Track M4 PR 3 legacy router delete

### DIFF
--- a/apps/pops-shell/nginx.conf
+++ b/apps/pops-shell/nginx.conf
@@ -33,7 +33,14 @@ server {
     # (Track M4 PR 1, #2891). Route the tRPC URLs for those procedures
     # to inventory-api so it becomes the canonical handler. The legacy
     # `inventoryRouter` (locations slice included) stays mounted on
-    # pops-api as the fall-through until Track M4 PR 3 deletes it.
+    # pops-api as the fall-through. Track M4 PR 3 was deferred — the
+    # shared `httpBatchLink` in `packages/api-client` packs locations
+    # calls with siblings (items/reports/…) into batched URLs that
+    # this rule deliberately ignores, so the legacy mount has to stay
+    # until the rest of the `inventoryRouter` subrouters also migrate
+    # into inventory-api. See
+    # `docs/runbooks/inventory-api-pillar-verification.md` → "Track M4
+    # dispatcher cutover — PR 3 deferred" for the full rationale.
     #
     # Why exclude commas from the match — the shell's `httpBatchLink`
     # packs N procedures into one URL of the form `/trpc/a,b,…`. Only

--- a/docs/runbooks/inventory-api-pillar-verification.md
+++ b/docs/runbooks/inventory-api-pillar-verification.md
@@ -74,10 +74,48 @@ flagging:
 - The shell's "inventory unavailable" placeholder paints over working non-inventory routes (PillarGuard scoping is too broad).
 - `inventory.db` writes succeed against a stopped inventory-api container (proves the shared-volume caveat noted in Step 2 — phase 4 follow-up: convert inventory-api to the sole writer once tRPC routers move into it).
 
+## Track M4 dispatcher cutover — PR 3 deferred
+
+Track M4 ships in three PRs:
+
+| PR    | Status       | Scope                                                                                                                                                             |
+| ----- | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| #2891 | Merged       | Stand up `locationsRouter` inside `pops-inventory-api`.                                                                                                           |
+| #2896 | Merged       | nginx dispatches single-procedure `/trpc/inventory.locations.*` URLs to `inventory-api`. Legacy router on pops-api stays mounted as the batched-URL fall-through. |
+| PR 3  | **Deferred** | Delete the legacy `locations` router from `pops-api`.                                                                                                             |
+
+### Why PR 3 is deferred
+
+The shared `packages/api-client` configures `httpBatchLink`:
+
+```ts
+httpBatchLink({ url: '/trpc', maxURLLength: 2083, ... })
+```
+
+Every `useQuery`/`useMutation` that fires in the same React tick is packed into a single `/trpc/a,b,…` request. The shell's inventory pages call `locations.*` from the same render cycle as `items.*`, `reports.*`, etc. — e.g. `packages/app-inventory/src/pages/items-page/useItemsPageModel.ts` issues `trpc.inventory.items.distinctTypes.useQuery()` and `trpc.inventory.locations.tree.useQuery()` from the same hook.
+
+The Track M4 PR 2 nginx rule anchors with `[^,]+$` so only **single-procedure** URLs reach `inventory-api`. Every batched URL — including ones whose members are all `inventory.locations.*` calls that happen to share a tick — falls through to `pops-api`. Deleting the `locations` router from `pops-api` would therefore 404 those batched calls.
+
+### What would unblock PR 3
+
+Pick one of:
+
+1. **Migrate the rest of the `inventoryRouter` subrouters** (`items`, `reports`, `connections`, `documents`, `documentFiles`, `paperless`, `fixtures`, `photos`) into `pops-inventory-api` and route the whole `/trpc/inventory.*` namespace there, batched or not. PR 3 then becomes the final cleanup once the legacy mount has no remaining consumers.
+2. **Split inventory off its own `httpBatchLink` instance** with a dedicated URL prefix (e.g. `/trpc-inventory`) so the dispatcher can match the prefix unconditionally and pops-api never sees an inventory call. This is invasive — `createTRPCReact<AppRouter>()` is a single client today.
+3. **Force `locations.*` calls into their own React tick** (e.g. wrap in a separate `useQuery` with a microtask delay) so they never batch with siblings. Brittle; rejected.
+
+Option 1 is the planned path. Until then, `pops-api` keeps `locationsRouter` mounted and serves it from `inventory.db` (Phase 2 cutover) — the data layer is already unified, only the HTTP boundary remains split. Both code paths read/write the same SQLite file, so there is no drift risk.
+
+### Lesson captured
+
+A single `httpBatchLink` plus a regex-dispatcher pattern can only retire a router slice when **every co-existing slice in the same `AppRouter` has also moved**. Plan migrations in whole-namespace units, not per-subrouter, or accept the legacy mount living on indefinitely.
+
 ## Reference
 
 - ADR-026: per-domain pillar architecture
 - `apps/pops-inventory-api/src/server.ts` — boot sequence
 - `apps/pops-shell/src/app/pillars/pillar-registry-client.ts` — soft-fallback behaviour (shared with core)
+- `apps/pops-shell/nginx.conf` — Track M4 PR 2 dispatcher rule and trade-off comment
+- `packages/api-client/src/index.ts` — shared `httpBatchLink` setup
 - `docs/runbooks/core-api-pillar-verification.md` — sibling runbook for the core pillar
 - `.claude/pillar-migration-roadmap.md` — Track G status + lessons captured (gitignored, local-only)

--- a/docs/runbooks/inventory-api-pillar-verification.md
+++ b/docs/runbooks/inventory-api-pillar-verification.md
@@ -101,7 +101,7 @@ The Track M4 PR 2 nginx rule anchors with `[^,]+$` so only **single-procedure** 
 Pick one of:
 
 1. **Migrate the rest of the `inventoryRouter` subrouters** (`items`, `reports`, `connections`, `documents`, `documentFiles`, `paperless`, `fixtures`, `photos`) into `pops-inventory-api` and route the whole `/trpc/inventory.*` namespace there, batched or not. PR 3 then becomes the final cleanup once the legacy mount has no remaining consumers.
-2. **Split inventory off its own `httpBatchLink` instance** with a dedicated URL prefix (e.g. `/trpc-inventory`) so the dispatcher can match the prefix unconditionally and pops-api never sees an inventory call. This is invasive — `createTRPCReact<AppRouter>()` is a single client today.
+2. **Route inventory operations through a separate link inside the existing `createTRPCReact<AppRouter>()` client** — e.g. use `splitLink` to send `inventory.*` paths down a dedicated `httpBatchLink` with its own URL prefix (`/trpc-inventory`) while everything else keeps using the current `httpBatchLink('/trpc')`. The shared client + router types stay; only the link wiring is added. Less invasive than a parallel client but still needs link-aware batching and a separate dispatcher prefix.
 3. **Force `locations.*` calls into their own React tick** (e.g. wrap in a separate `useQuery` with a microtask delay) so they never batch with siblings. Brittle; rejected.
 
 Option 1 is the planned path. Until then, `pops-api` keeps `locationsRouter` mounted and serves it from `inventory.db` (Phase 2 cutover) — the data layer is already unified, only the HTTP boundary remains split. Both code paths read/write the same SQLite file, so there is no drift risk.


### PR DESCRIPTION
## Summary

Track M4 PR 3 was scoped to delete the legacy `inventory.locations.*` router from `pops-api` now that the M4 PR 2 dispatcher (#2896) routes single-procedure URLs to `pops-inventory-api` (#2891). Per the audit below, **PR 3 is deferred**, and this PR ships the documentation + nginx-comment update that captures the trade-off and the unblocker.

## Audit

Surveyed consumers of `trpc.inventory.locations.*`:

- `apps/pops-shell/src/` — zero direct callers (only i18n labels).
- `packages/app-inventory/src/pages/**` — five hooks issue `locations.{tree,getPath,create,update,delete}` calls **alongside sibling subrouter calls** from the same render cycle, e.g. `useItemsPageModel.ts` fires `inventory.items.distinctTypes.useQuery()` and `inventory.locations.tree.useQuery()` from the same hook.
- `apps/pops-mcp/src/tools/inventory-locations.ts` — uses a server-side tRPC client, not `httpBatchLink`, so not affected.

The shared tRPC client in `packages/api-client/src/index.ts` wires `httpBatchLink({ url: '/trpc', maxURLLength: 2083, ... })`, so all in-tick calls get packed into one URL of the form `/trpc/a,b,...`.

## Trade-off

The M4 PR 2 nginx rule is `^/trpc/inventory\.locations\.[^,]+$`. The `[^,]+$` anchor — added deliberately to prevent batched URLs with mixed subrouters from being mis-routed to `inventory-api` — means **every batched URL falls through to `pops-api`**, including all-locations batches that share a tick with sibling inventory calls. So:

- The legacy `inventory.locations.*` router on `pops-api` **must** stay mounted until either:
  1. The remaining `inventoryRouter` subrouters (`items`, `reports`, `connections`, `documents`, `documentFiles`, `paperless`, `fixtures`, `photos`) also move to `pops-inventory-api`, at which point a prefix rule on `^/trpc/inventory\.` routes the whole namespace and PR 3 becomes a trivial cleanup; or
  2. The shell adopts a dedicated `httpBatchLink` instance per pillar so locations calls never share a URL with other inventory procedures.

Deleting `apps/pops-api/src/modules/inventory/locations/` today would 404 every batched URL that includes a locations call — `useItemsPageModel`, `useItemFormPageModel`, `useReportModel`, and `useLocationTreePageModel` all rely on this.

## What this PR ships

- `docs/runbooks/inventory-api-pillar-verification.md` — new section "Track M4 dispatcher cutover — PR 3 deferred" covering the audit, the trade-off, the unblocker options, and the lesson.
- `apps/pops-shell/nginx.conf` — updated the M4 PR 2 dispatcher comment so it stops promising "until Track M4 PR 3 deletes it" and points to the runbook section instead.

## References

- M4 PR 1: #2891 (inventory-api router stand-up)
- M4 PR 2: #2896 (nginx dispatcher cutover)
- Trade-off comment landed in `nginx.conf` with #2896 — see lines 30-72.
- Shared batch link: `packages/api-client/src/index.ts`

## Lesson captured

A single `httpBatchLink` + regex-dispatcher pattern can only retire a router slice when every sibling slice in the same `AppRouter` has also moved. Plan pillar migrations in whole-namespace units, not per-subrouter, or accept the legacy mount living on indefinitely.

## Test plan

- [ ] `pnpm lint` exits 0 (warnings only, no new ones).
- [ ] `pnpm format:check` clean.
- [ ] Comment in `nginx.conf` reads cleanly and matches the runbook section it references.
- [ ] Runbook section renders correctly in GitHub preview.
