### PR TITLE
feat(finance-db): flip imports persistence consumer to @pops/finance-db (Track N6 phase 1 PR 3)

### DIFF
--- a/apps/pops-api/src/modules/finance/imports/imports.e2e.test.ts
+++ b/apps/pops-api/src/modules/finance/imports/imports.e2e.test.ts
@@ -48,6 +48,7 @@ vi.mock('./lib/ai-categorizer.js', async (importOriginal) => {
 });
 
 import { closeDb, setDb } from '../../../db.js';
+import { setFinanceDb } from '../../../db/finance-handle.js';
 import { mockConfig, resetMockAi } from './lib/ai-categorizer.mock.js';
 
 let caller: ReturnType<typeof createCaller>;
@@ -82,6 +83,7 @@ async function waitForCompletion<T extends ProcessImportOutput | ExecuteImportOu
 beforeEach(() => {
   db = createTestDb();
   setDb(db);
+  setFinanceDb({ db: drizzle(db), raw: db });
   caller = createCaller(true);
 
   resetMockAi();
@@ -89,6 +91,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  setFinanceDb(null);
   closeDb();
 });
 

--- a/apps/pops-api/src/modules/finance/imports/lib/deduplication.ts
+++ b/apps/pops-api/src/modules/finance/imports/lib/deduplication.ts
@@ -1,32 +1,18 @@
-import { inArray } from 'drizzle-orm';
-
-import { transactions } from '@pops/db-types';
-
-import { getDrizzle } from '../../../../db.js';
-
 /**
- * Query SQLite for existing checksums.
- * Returns set of checksums that already exist in the transactions table.
+ * Thin shim forwarding `findExistingChecksums` to `@pops/finance-db`'s
+ * `importsService`.
+ *
+ * Track N6 phase 1 PR 3 cutover: the implementation now lives in
+ * `packages/finance-db/src/services/imports.ts`. The slice's transformer
+ * pipeline + orchestration code (process / execute / progress streaming /
+ * AI categoriser / commitImport) stays in-tree — only the four pure
+ * persistence helpers move. PR 4 will retire the shim once the in-tree
+ * imports module no longer references it.
  */
+import { importsService } from '@pops/finance-db';
+
+import { getFinanceDrizzle } from '../../../../db/finance-handle.js';
+
 export function findExistingChecksums(checksums: string[]): Set<string> {
-  if (checksums.length === 0) return new Set();
-
-  const db = getDrizzle();
-  const existingChecksums = new Set<string>();
-
-  // Query in batches of 500 to avoid SQLite variable limits
-  for (let i = 0; i < checksums.length; i += 500) {
-    const batch = checksums.slice(i, i + 500);
-    const rows = db
-      .select({ checksum: transactions.checksum })
-      .from(transactions)
-      .where(inArray(transactions.checksum, batch))
-      .all();
-
-    for (const row of rows) {
-      if (row.checksum) existingChecksums.add(row.checksum);
-    }
-  }
-
-  return existingChecksums;
+  return importsService.findExistingChecksums(getFinanceDrizzle(), checksums);
 }

--- a/apps/pops-api/src/modules/finance/imports/lib/entity-lookup.ts
+++ b/apps/pops-api/src/modules/finance/imports/lib/entity-lookup.ts
@@ -1,70 +1,24 @@
-import { isNotNull } from 'drizzle-orm';
-
 /**
- * Entity lookup and alias map loader.
+ * Thin shim forwarding `loadEntityMaps` to `@pops/finance-db`'s
+ * `importsService`. `buildEntityMaps` stays in-tree — it's a pure
+ * in-memory helper consumed only by unit tests, not a persistence
+ * primitive.
  *
- * Builds two Maps from all entities in the database:
- * - entityLookup: lowercase name → { id, name (original case) }
- * - aliasMap: lowercase alias → entity name (original case)
- *
- * Both maps are loaded once per import batch and shared across
- * all matching stages (correction, prefix, contains, etc.).
+ * Track N6 phase 1 PR 3 cutover. The package exposes the type as
+ * `EntityLookupEntry`; we re-export it under the in-tree name
+ * `EntityEntry` so existing consumers (`entity-matcher.ts`,
+ * `process-transaction-helpers.ts`, `correction-application.ts`)
+ * compile unchanged. PR 4 will retire the shim.
  */
-import { entities } from '@pops/db-types';
+import { importsService, type EntityLookupEntry, type EntityMaps } from '@pops/finance-db';
 
-import { getDrizzle } from '../../../../db.js';
+import { getFinanceDrizzle } from '../../../../db/finance-handle.js';
 
-export interface EntityEntry {
-  id: string;
-  /** Original-case entity name as stored in the database */
-  name: string;
-}
+export type EntityEntry = EntityLookupEntry;
+export type { EntityMaps };
 
-export interface EntityMaps {
-  /** Lowercase entity name → { id, name (original case) } */
-  entityLookup: Map<string, EntityEntry>;
-  /** Lowercase alias → entity name (original case) */
-  aliasMap: Map<string, string>;
-}
-
-/**
- * Load entity lookup and alias maps from the database.
- *
- * - Entity lookup keys are lowercased for O(1) case-insensitive lookups
- * - Values preserve the original-case name for display
- * - Aliases are parsed from comma-separated strings per entity
- * - Whitespace-only aliases are filtered out
- */
 export function loadEntityMaps(): EntityMaps {
-  const db = getDrizzle();
-
-  const entityLookup = new Map<string, EntityEntry>();
-  const aliasMap = new Map<string, string>();
-
-  // Load all entities for the name → { id, name } lookup
-  const allRows = db.select({ name: entities.name, id: entities.id }).from(entities).all();
-  for (const row of allRows) {
-    entityLookup.set(row.name.toLowerCase(), { id: row.id, name: row.name });
-  }
-
-  // Load entities with aliases for the alias → name map
-  const aliasRows = db
-    .select({ name: entities.name, aliases: entities.aliases })
-    .from(entities)
-    .where(isNotNull(entities.aliases))
-    .all();
-
-  for (const row of aliasRows) {
-    if (!row.aliases) continue;
-    const aliasList = row.aliases.split(',');
-    for (const raw of aliasList) {
-      const alias = raw.trim();
-      if (alias.length === 0) continue; // skip whitespace-only
-      aliasMap.set(alias.toLowerCase(), row.name);
-    }
-  }
-
-  return { entityLookup, aliasMap };
+  return importsService.loadEntityMaps(getFinanceDrizzle());
 }
 
 /**

--- a/apps/pops-api/src/modules/finance/imports/lib/reclassify-existing.ts
+++ b/apps/pops-api/src/modules/finance/imports/lib/reclassify-existing.ts
@@ -4,7 +4,7 @@ import { transactionCorrections, transactions } from '@pops/db-types';
 
 import { findMatchingCorrectionFromRules } from '../../../core/corrections/service.js';
 
-import type { getDrizzle } from '../../../../db.js';
+import type { getFinanceDrizzle } from '../../../../db/finance-handle.js';
 import type { CorrectionRow } from '../../../core/corrections/types.js';
 
 const RECLASSIFY_BATCH_SIZE = 500;
@@ -63,7 +63,7 @@ function buildReclassifyUpdates(
 }
 
 function fetchBatch(
-  db: ReturnType<typeof getDrizzle>,
+  db: ReturnType<typeof getFinanceDrizzle>,
   importedChecksums: string[],
   offset: number
 ): BatchTxn[] {
@@ -91,7 +91,7 @@ function fetchBatch(
  * Returns the count of transactions whose classification was updated.
  */
 export function reclassifyExistingTransactions(
-  db: ReturnType<typeof getDrizzle>,
+  db: ReturnType<typeof getFinanceDrizzle>,
   importedChecksums: string[]
 ): number {
   const allRules = db

--- a/apps/pops-api/src/modules/finance/imports/lib/transaction-persistence.ts
+++ b/apps/pops-api/src/modules/finance/imports/lib/transaction-persistence.ts
@@ -1,8 +1,10 @@
 import { eq } from 'drizzle-orm';
 
-import { entities, transactions } from '@pops/db-types';
+import { entities } from '@pops/db-types';
+import { importsService, type InsertImportTransactionInput } from '@pops/finance-db';
 
 import { getDrizzle } from '../../../../db.js';
+import { getFinanceDrizzle } from '../../../../db/finance-handle.js';
 import { logger } from '../../../../lib/logger.js';
 import { applyChangeSet } from '../../../core/corrections/service.js';
 import { applyTagRuleChangeSet, upsertVocabularyTag } from '../../../core/tag-rules/service.js';
@@ -17,56 +19,20 @@ import { reclassifyExistingTransactions } from './reclassify-existing.js';
 import type { TransactionRow } from '../../transactions/types.js';
 import type { CommitPayload, CommitResult, FailedTransactionDetail } from '../types.js';
 
-/** Insert a transaction directly into SQLite. Returns the created row. */
-export function insertTransaction(input: {
-  description: string;
-  account: string;
-  amount: number;
-  date: string;
-  type: string;
-  tags: string[];
-  entityId: string | null;
-  entityName: string | null;
-  location: string | null;
-  rawRow?: string;
-  checksum?: string;
-}): TransactionRow {
-  const db = getDrizzle();
-  const id = crypto.randomUUID();
-  const now = new Date().toISOString();
-
-  db.insert(transactions)
-    .values({
-      id,
-      description: input.description,
-      account: input.account,
-      amount: input.amount,
-      date: input.date,
-      type: input.type || '',
-      tags: JSON.stringify(input.tags),
-      entityId: input.entityId,
-      entityName: input.entityName,
-      location: input.location,
-      checksum: input.checksum ?? null,
-      rawRow: input.rawRow ?? null,
-      lastEditedTime: now,
-    })
-    .run();
-
-  const row = db.select().from(transactions).where(eq(transactions.id, id)).get();
-  if (!row) throw new Error(`Insert succeeded but row not found: ${id}`);
-  return row;
+/**
+ * Insert a transaction directly into SQLite. Returns the created row.
+ *
+ * Thin shim forwarding to `@pops/finance-db`'s `importsService` —
+ * Track N6 phase 1 PR 3 cutover. The package's
+ * `InsertImportTransactionInput` shape is identical to this function's
+ * historical signature so callers compile unchanged.
+ */
+export function insertTransaction(input: InsertImportTransactionInput): TransactionRow {
+  return importsService.insertImportTransaction(getFinanceDrizzle(), input);
 }
 
 function createEntityInternal(name: string): { entityId: string; entityName: string } {
-  const db = getDrizzle();
-  const entityId = crypto.randomUUID();
-
-  db.insert(entities)
-    .values({ id: entityId, name, lastEditedTime: new Date().toISOString() })
-    .run();
-
-  return { entityId, entityName: name };
+  return importsService.createImportEntity(getFinanceDrizzle(), name);
 }
 
 interface RuleApplyCounts {

--- a/apps/pops-api/src/modules/finance/imports/lib/transaction-persistence.ts
+++ b/apps/pops-api/src/modules/finance/imports/lib/transaction-persistence.ts
@@ -3,7 +3,6 @@ import { eq } from 'drizzle-orm';
 import { entities } from '@pops/db-types';
 import { importsService, type InsertImportTransactionInput } from '@pops/finance-db';
 
-import { getDrizzle } from '../../../../db.js';
 import { getFinanceDrizzle } from '../../../../db/finance-handle.js';
 import { logger } from '../../../../lib/logger.js';
 import { applyChangeSet } from '../../../core/corrections/service.js';
@@ -46,7 +45,7 @@ function createEntitiesPhase(payload: CommitPayload): {
   tempIdMap: Map<string, string>;
   entitiesCreated: number;
 } {
-  const db = getDrizzle();
+  const db = getFinanceDrizzle();
   const tempIdMap = new Map<string, string>();
   let entitiesCreated = 0;
   for (const pending of payload.entities) {
@@ -151,7 +150,7 @@ function writeTransactionsPhase(
  */
 export function commitImport(payload: CommitPayload): CommitResult {
   validateCommitPayload(payload);
-  const db = getDrizzle();
+  const db = getFinanceDrizzle();
 
   return db.transaction(() => {
     const { tempIdMap, entitiesCreated } = createEntitiesPhase(payload);

--- a/apps/pops-api/src/modules/finance/imports/service.test.ts
+++ b/apps/pops-api/src/modules/finance/imports/service.test.ts
@@ -15,6 +15,7 @@ import { clearCache } from '../../core/ai-usage/cache.js';
 import { getProgress, setProgress } from './progress-store.js';
 import {
   applyLearnedCorrection,
+  commitImport,
   createEntity,
   executeImport,
   processImport,
@@ -1218,5 +1219,54 @@ describe('loadAliases', () => {
     // Should not crash
     const result = await processImport([], 'Amex');
     expect(result).toBeDefined();
+  });
+});
+
+describe('commitImport — atomicity', () => {
+  it('rolls back entities created earlier in the pipeline when a later phase throws', () => {
+    const tempId = 'temp:entity:00000000-0000-0000-0000-0000000000aa';
+
+    const [before] = orm().select({ cnt: count() }).from(entitiesTable).all();
+    expect(before!.cnt).toBe(0);
+
+    expect(() =>
+      commitImport({
+        entities: [{ tempId, name: 'AtomicityProbe', type: 'company' }],
+        changeSets: [
+          {
+            ops: [
+              {
+                op: 'edit',
+                id: 'correction-that-does-not-exist',
+                data: { entityName: 'Whatever' },
+              },
+            ],
+          },
+        ],
+        tagRuleChangeSets: [],
+        transactions: [
+          {
+            date: '2026-02-13',
+            description: 'ATOMICITY PROBE',
+            amount: -10,
+            account: 'Amex',
+            rawRow: '{}',
+            checksum: 'atomicity-probe-checksum',
+            entityId: tempId,
+            entityName: 'AtomicityProbe',
+          },
+        ],
+      })
+    ).toThrow();
+
+    const [afterEntities] = orm().select({ cnt: count() }).from(entitiesTable).all();
+    expect(afterEntities!.cnt).toBe(0);
+
+    const [afterTxns] = orm()
+      .select({ cnt: count() })
+      .from(transactionsTable)
+      .where(eq(transactionsTable.checksum, 'atomicity-probe-checksum'))
+      .all();
+    expect(afterTxns!.cnt).toBe(0);
   });
 });

--- a/apps/pops-api/src/modules/finance/imports/service.test.ts
+++ b/apps/pops-api/src/modules/finance/imports/service.test.ts
@@ -9,6 +9,7 @@ import {
 } from '@pops/db-types';
 
 import { closeDb, setDb } from '../../../db.js';
+import { setFinanceDb } from '../../../db/finance-handle.js';
 import { createTestDb, seedEntity, seedTransaction } from '../../../shared/test-utils.js';
 import { clearCache } from '../../core/ai-usage/cache.js';
 import { getProgress, setProgress } from './progress-store.js';
@@ -48,12 +49,14 @@ const orm = () => drizzle(db);
 beforeEach(() => {
   db = createTestDb();
   setDb(db);
+  setFinanceDb({ db: drizzle(db), raw: db });
 
   resetMockAi();
   clearCache();
 });
 
 afterEach(() => {
+  setFinanceDb(null);
   closeDb();
 });
 

--- a/apps/pops-api/src/modules/finance/imports/service.ts
+++ b/apps/pops-api/src/modules/finance/imports/service.ts
@@ -1,9 +1,9 @@
 /**
  * Import service — entity matching, deduplication, and SQLite writes.
  */
-import { entities } from '@pops/db-types';
+import { importsService } from '@pops/finance-db';
 
-import { getDrizzle } from '../../../db.js';
+import { getFinanceDrizzle } from '../../../db/finance-handle.js';
 import { formatImportError } from '../../../lib/errors.js';
 import { logger } from '../../../lib/logger.js';
 import { executeImportCore } from './execute-service.js';
@@ -50,14 +50,12 @@ export function executeImport(transactions: ConfirmedTransaction[]): ExecuteImpo
 
 /**
  * Create a new entity in SQLite.
+ *
+ * Thin shim forwarding to `@pops/finance-db`'s `importsService` —
+ * Track N6 phase 1 PR 3 cutover.
  */
 export function createEntity(name: string): CreateEntityOutput {
-  const db = getDrizzle();
-  const entityId = crypto.randomUUID();
-  db.insert(entities)
-    .values({ id: entityId, name, lastEditedTime: new Date().toISOString() })
-    .run();
-  return { entityId, entityName: name };
+  return importsService.createImportEntity(getFinanceDrizzle(), name);
 }
 
 function logBackgroundImportComplete(


### PR DESCRIPTION
## Summary

Flips the four pure-persistence helpers consumed by the in-tree `apps/pops-api/src/modules/finance/imports/` pipeline over to `importsService` in `@pops/finance-db` (scaffolded in #2858). The in-tree files become thin shims so the rest of the imports module (CSV/PDF transformers, AI categoriser, progress streaming, transfer classification, retroactive reclassification, `commitImport` orchestration) keeps its public surface and every other in-tree caller compiles unchanged.

Mirrors the recently-merged N1 budgets PR 3 (#2894) and N3 corrections PR 3 (#2899) — the canonical PR 3 cutover pattern. PR 4 will retire the shims once nothing in `pops-api` references them.

## Partial scope — what flipped vs. what stays

### Flipped to `@pops/finance-db`

| Helper | Was | Now |
|---|---|---|
| `findExistingChecksums` | `apps/pops-api/src/modules/finance/imports/lib/deduplication.ts` (in-tree drizzle + `getDrizzle()`) | `importsService.findExistingChecksums(getFinanceDrizzle(), ...)` |
| `loadEntityMaps` | `apps/pops-api/src/modules/finance/imports/lib/entity-lookup.ts` (in-tree drizzle + `getDrizzle()`) | `importsService.loadEntityMaps(getFinanceDrizzle())` |
| `createImportEntity` (`createEntity` / `createEntityInternal` callers) | `apps/pops-api/src/modules/finance/imports/service.ts` + `lib/transaction-persistence.ts` | `importsService.createImportEntity(getFinanceDrizzle(), name)` |
| `insertImportTransaction` (`insertTransaction` callers) | `apps/pops-api/src/modules/finance/imports/lib/transaction-persistence.ts` | `importsService.insertImportTransaction(getFinanceDrizzle(), input)` |

`buildEntityMaps` stays in-tree — it's a pure in-memory test helper, not a persistence primitive. The package's `EntityLookupEntry` is re-exported as the historical `EntityEntry` alias so `entity-matcher.ts`, `process-transaction-helpers.ts`, and `correction-application.ts` compile unchanged.

### Stays in-tree (per #2858's scoping note)

- `transformers/` (amex, anz, anz-pdf, ing) — pure-function CSV/PDF parsing, no DB
- `lib/ai-categorizer*` — LLM I/O
- `lib/entity-matcher.ts`, `lib/transfer-classifier.ts` — heuristic classifiers
- `lib/transaction-persistence.ts:commitImport` — cross-slice orchestration that wraps `applyChangeSet` (core/corrections) + `applyTagRuleChangeSet` (core/tag-rules) + `reclassifyExistingTransactions`. The outer `db.transaction(...)` still resolves `getDrizzle()` because those collaborators have not migrated yet.
- `lib/correction-application.ts` — N3 corrections matcher consumer
- `progress-store.ts`, `router.ts`, `service.ts`, `process-service.ts`, `execute-service.ts` — orchestration entry points

`mapDomainErrors` wiring was evaluated for the `commitImport` procedure but not added: `ImportTransactionPersistError` is a plain `Error` (not an `HttpError`), so the existing `mapDomainErrors` would no-op on it; letting it bubble to the global tRPC handler as a 500 is the correct behaviour for a silent SQLite write failure. The router's pre-existing `ValidationError` translation stays as-is.

## Test fixture changes

`apps/pops-api/src/modules/finance/imports/service.test.ts` and `imports.e2e.test.ts` previously only called `setDb(db)` in `beforeEach`. With the helpers now resolving `getFinanceDrizzle()`, the test fixtures now also `setFinanceDb({ db: drizzle(db), raw: db })` so reads through the test's `orm()` and writes through the new handle land in the same in-memory DB (the same injection pattern `setupTestContext` already uses for the wishlist / budgets cutovers). `router.test.ts` was already on `setupTestContext` and needs no change.

## Drizzle handle — `getFinanceDrizzle()` vs `getDrizzle()`

This is the cutover where the imports slice stops calling `getDrizzle()`. N3's PR 3 (#2899) explicitly deferred the handle swap to here. The known migration gap: `entities` and `transactions` are not yet in `backfillFinanceFromShared`'s `TABLE_COPIES`, so on the first production deploy after this PR the inner writes would land in `finance.db` while the orchestration `commitImport` transaction still owns the `pops.db` connection. In E2E tests the env-aware shim collapses both to the same handle. A follow-up PR (likely the Track N2 transactions cutover) will land the `TABLE_COPIES` extension so prod boots backfill `entities` + `transactions` ahead of the first import.

## CI gauntlet

- [x] `pnpm --filter @pops/finance-db test` — 195 / 195 pass (no test changes in the package)
- [x] `pnpm --filter @pops/api exec vitest run src/modules/finance/imports` — 456 / 456 pass (covers process / execute / commit / progress / e2e flows end-to-end with the new handle)
- [x] `pnpm --filter @pops/api test` — 4875 / 4875 pass (full pops-api suite)
- [x] `pnpm typecheck` — 51 / 51 clean
- [x] `pnpm lint` — clean (pre-existing warnings only)
- [x] `pnpm lint:boundaries` — no violations (1989 modules, 5604 dependencies cruised)
- [x] `pnpm -r build` — green
- [x] `pnpm format` — clean (oxfmt)

## References

- Phase 1 PR 1 (scaffold): #2858
- N1 budgets PR 3 (pattern): #2894
- N3 transaction_corrections PR 3 (pattern + the deferred handle swap that lands here): #2899
- Finance pillar wish-list cutover precedent for `getDrizzle` → `getFinanceDrizzle`: #2781