### PR TITLE
feat(finance-db): flip transactions consumer to @pops/finance-db (Track N2 phase 1 PR 3)

### DIFF
--- a/apps/pops-api/src/modules/finance/transactions/router.ts
+++ b/apps/pops-api/src/modules/finance/transactions/router.ts
@@ -1,17 +1,20 @@
-import { TRPCError } from '@trpc/server';
+/** Transaction tRPC router — CRUD via `@pops/finance-db`'s `transactionsService`. */
 import { z } from 'zod';
 
-/**
- * Transaction tRPC router — CRUD procedures for transactions.
- */
 import { transactions as transactionsTable } from '@pops/db-types';
+import {
+  TransactionAlreadyExistsError,
+  TransactionNotFoundError,
+  transactionsService,
+} from '@pops/finance-db';
 
 import { getDb, getDrizzle } from '../../../db.js';
-import { NotFoundError } from '../../../shared/errors.js';
+import { getFinanceDrizzle } from '../../../db/finance-handle.js';
+import { ConflictError, NotFoundError } from '../../../shared/errors.js';
 import { paginationMeta, PaginationMetaSchema } from '../../../shared/pagination.js';
 import { suggestTags } from '../../../shared/tag-suggester.js';
+import { mapDomainErrors } from '../../../shared/trpc-error-mapper.js';
 import { protectedProcedure, router } from '../../../trpc.js';
-import * as service from './service.js';
 import {
   CreateTransactionSchema,
   toTransaction,
@@ -28,6 +31,22 @@ const PREVIEW_DESCRIPTIONS_LIMIT = 2000;
 /** Default pagination values. */
 const DEFAULT_LIMIT = 50;
 const DEFAULT_OFFSET = 0;
+
+function runTransaction<T>(id: string | undefined, fn: () => T): T {
+  return mapDomainErrors(() => {
+    try {
+      return fn();
+    } catch (err) {
+      if (err instanceof TransactionNotFoundError) {
+        throw new NotFoundError('Transaction', id ?? err.id);
+      }
+      if (err instanceof TransactionAlreadyExistsError) {
+        throw new ConflictError(err.message);
+      }
+      throw err;
+    }
+  });
+}
 
 export const transactionsRouter = router({
   /** List transactions with optional filters and pagination. */
@@ -56,7 +75,12 @@ export const transactionsRouter = router({
         type: input.type,
       };
 
-      const { rows, total } = service.listTransactions(filters, limit, offset);
+      const { rows, total } = transactionsService.listTransactions(
+        getFinanceDrizzle(),
+        filters,
+        limit,
+        offset
+      );
 
       return {
         data: rows.map(toTransaction),
@@ -76,49 +100,34 @@ export const transactionsRouter = router({
     })
     .input(z.object({ id: z.string() }))
     .output(z.object({ data: TransactionSchema }))
-    .query(({ input }) => {
-      try {
-        const row = service.getTransaction(input.id);
+    .query(({ input }) =>
+      runTransaction(input.id, () => {
+        const row = transactionsService.getTransaction(getFinanceDrizzle(), input.id);
         return { data: toTransaction(row) };
-      } catch (err) {
-        if (err instanceof NotFoundError) {
-          throw new TRPCError({ code: 'NOT_FOUND', message: err.message });
-        }
-        throw err;
-      }
-    }),
+      })
+    ),
 
   /** Create a new transaction. */
-  create: protectedProcedure.input(CreateTransactionSchema).mutation(({ input }) => {
-    const row = service.createTransaction(input);
-    return {
-      data: toTransaction(row),
-      message: 'Transaction created',
-    };
-  }),
+  create: protectedProcedure.input(CreateTransactionSchema).mutation(({ input }) =>
+    runTransaction(undefined, () => {
+      const row = transactionsService.createTransaction(getFinanceDrizzle(), input);
+      return { data: toTransaction(row), message: 'Transaction created' };
+    })
+  ),
 
   /** Update an existing transaction. */
   update: protectedProcedure
-    .input(
-      z.object({
-        id: z.string(),
-        data: UpdateTransactionSchema,
+    .input(z.object({ id: z.string(), data: UpdateTransactionSchema }))
+    .mutation(({ input }) =>
+      runTransaction(input.id, () => {
+        const row = transactionsService.updateTransaction(
+          getFinanceDrizzle(),
+          input.id,
+          input.data
+        );
+        return { data: toTransaction(row), message: 'Transaction updated' };
       })
-    )
-    .mutation(({ input }) => {
-      try {
-        const row = service.updateTransaction(input.id, input.data);
-        return {
-          data: toTransaction(row),
-          message: 'Transaction updated',
-        };
-      } catch (err) {
-        if (err instanceof NotFoundError) {
-          throw new TRPCError({ code: 'NOT_FOUND', message: err.message });
-        }
-        throw err;
-      }
-    }),
+    ),
 
   /**
    * Delete a transaction. Returns the deleted row as a `snapshot` so the
@@ -126,17 +135,12 @@ export const transactionsRouter = router({
    * including original id, checksum, raw_row, and notion_id — fields that
    * the list shape strips and that an Undo flow needs to preserve.
    */
-  delete: protectedProcedure.input(z.object({ id: z.string() })).mutation(({ input }) => {
-    try {
-      const snapshot = service.deleteTransaction(input.id);
+  delete: protectedProcedure.input(z.object({ id: z.string() })).mutation(({ input }) =>
+    runTransaction(input.id, () => {
+      const snapshot = transactionsService.deleteTransaction(getFinanceDrizzle(), input.id);
       return { message: 'Transaction deleted', snapshot };
-    } catch (err) {
-      if (err instanceof NotFoundError) {
-        throw new TRPCError({ code: 'NOT_FOUND', message: err.message });
-      }
-      throw err;
-    }
-  }),
+    })
+  ),
 
   /**
    * Restore a previously-deleted transaction from a snapshot returned by
@@ -148,15 +152,12 @@ export const transactionsRouter = router({
    * transaction id but does not auto-reattach those FKs — that requires
    * a separate manual step.
    */
-  restore: protectedProcedure.input(TransactionSnapshotSchema).mutation(({ input }) => {
-    try {
-      const row = service.restoreTransaction(input);
+  restore: protectedProcedure.input(TransactionSnapshotSchema).mutation(({ input }) =>
+    runTransaction(input.id, () => {
+      const row = transactionsService.restoreTransaction(getFinanceDrizzle(), input);
       return { data: toTransaction(row), message: 'Transaction restored' };
-    } catch (err) {
-      const message = err instanceof Error ? err.message : 'Restore failed';
-      throw new TRPCError({ code: 'CONFLICT', message });
-    }
-  }),
+    })
+  ),
 
   /**
    * Suggest tags for a transaction using entity defaults + correction rules.

--- a/apps/pops-api/src/modules/finance/uri-handler.ts
+++ b/apps/pops-api/src/modules/finance/uri-handler.ts
@@ -1,4 +1,9 @@
-import { BudgetNotFoundError, budgetsService } from '@pops/finance-db';
+import {
+  BudgetNotFoundError,
+  budgetsService,
+  TransactionNotFoundError,
+  transactionsService,
+} from '@pops/finance-db';
 
 import { getFinanceDrizzle } from '../../db/finance-handle.js';
 import { NotFoundError } from '../../shared/errors.js';
@@ -16,7 +21,6 @@ import { NotFoundError } from '../../shared/errors.js';
  * its result into a `UriResolverResult` for the caller.
  */
 import { getEntity } from '../core/entities/service.js';
-import { getTransaction } from './transactions/service.js';
 
 import type { UriHandlerDescriptor, UriResolution } from '@pops/types';
 
@@ -27,7 +31,11 @@ async function tryGet<TData>(get: () => TData | Promise<TData>): Promise<UriReso
   try {
     return { kind: 'object', data: await get() };
   } catch (error) {
-    if (error instanceof NotFoundError || error instanceof BudgetNotFoundError) {
+    if (
+      error instanceof NotFoundError ||
+      error instanceof BudgetNotFoundError ||
+      error instanceof TransactionNotFoundError
+    ) {
       return { kind: 'not-found' };
     }
     throw error;
@@ -39,7 +47,7 @@ export const financeUriHandler: UriHandlerDescriptor = {
   resolve: async (type, id) => {
     switch (type) {
       case 'transaction':
-        return tryGet(() => getTransaction(id));
+        return tryGet(() => transactionsService.getTransaction(getFinanceDrizzle(), id));
       case 'entity':
         return tryGet(() => getEntity(id));
       case 'budget':


### PR DESCRIPTION
## Summary

Flips the in-tree consumers of the `transactions` slice (the `finance.transactions.*` tRPC router and the finance URI handler's `transaction` branch) over to `transactionsService` from `@pops/finance-db` scaffolded in #2863.

Mirrors Track J phase 1 PR 3 (#2868), Track K phase 1 PR 3 (#2879), Track N1 phase 1 PR 3 (#2894), and Track N3 phase 1 PR 3 (#2899) — the canonical PR 3 cutover pattern.

## PR 2 was a no-op

Track N2 originally planned PR 2 to split the migration journal for the transactions-relevant migrations into a transactions-owned copy under `packages/finance-db/migrations/`. The Track E wish-list pilot already split the finance journal when it landed, and the transactions-relevant statements share the same baseline file (`packages/finance-db/migrations/0053_finance_pillar_baseline.sql`). The per-package copy is already byte-identical, the drift-guard CI from the wish-list pilot is enforcing both copies, and #2863 explicitly noted the baseline copy already exists. **PR 2 is skipped — jumping straight to PR 3 (cutover).**

## Changes

- `apps/pops-api/src/modules/finance/transactions/router.ts`: import `transactionsService`, `TransactionNotFoundError`, `TransactionAlreadyExistsError` from `@pops/finance-db`. Pass `getFinanceDrizzle()` as the first arg on every service call (the transactions table lives on the finance pillar handle per Track E phase 2 PR 3 — using `getDrizzle()` would target the wrong DB). Route every handler through a small `runTransaction(id, fn)` helper that wraps `mapDomainErrors` and translates the package's typed errors to `NotFoundError` / `ConflictError` so the existing tRPC mapping (`NOT_FOUND` / `CONFLICT`) keeps holding.
- `apps/pops-api/src/modules/finance/uri-handler.ts`: import `transactionsService.getTransaction` from `@pops/finance-db`. Match `TransactionNotFoundError` alongside the legacy `NotFoundError` (and the existing `BudgetNotFoundError` branch) in the `tryGet` helper so the `pops:finance/transaction/{id}` resolution still surfaces `{ kind: 'not-found' }` on missing rows.

## What stays for PR 4

The in-tree `apps/pops-api/src/modules/finance/transactions/` directory stays in place — `service.ts`, `types.ts`, `search-adapter.ts`, `search-adapter.test.ts`, `transactions.test.ts`, `index.ts`. PR 4 of the phase 1 sequence deletes the in-tree service + barrel re-export once nothing inside pops-api references them.

The search adapter (`search-adapter.ts`) does not use the service — it queries drizzle directly — so it stays untouched in this PR. If the package grows a search surface later, that can be a follow-up.

The `transactions.test.ts` suite still imports from the in-tree `./service.js` for unit-level coverage of the legacy code path. Those tests stay green because the in-tree service is still present; PR 4 either moves the assertions to the `@pops/finance-db` package's own unit tests (where they already exist) or rewrites them against `transactionsService`.

## CI / Docker

PR 1 (#2863) confirmed CI parity was already in place from the wish-list pilot — `packages/finance-db/**` is wired into `_pkg-check.yml`, `api-quality.yml`, `api-test.yml`, `fe-quality.yml`, `fe-test-e2e.yml`, and all three Dockerfiles (`pops-api`, `pops-shell`, `pops-mcp`) plus `pops-finance-api` already COPY + BUILD `@pops/finance-db` ahead of the consumers. No infra changes needed for the cutover.

## Test plan

- [x] `pnpm typecheck` — 51/51 clean
- [x] `pnpm lint` — clean (pre-existing warnings only, no errors)
- [x] `pnpm --filter @pops/finance-db test` — 195/195 passing
- [x] `pnpm --filter @pops/api test` — 4875/4875 passing (full pops-api suite — exercises `finance.transactions.{list, get, create, update, delete, restore}` end-to-end via the tRPC caller + the finance URI handler's transaction branch)
- [x] `pnpm build` — 25/25 green
- [x] `pnpm format:check` — clean

## References

- Phase 1 PR 1 (scaffold): #2863
- Track J phase 1 PR 3 (canonical pattern): #2868
- Track K phase 1 PR 3 (canonical pattern): #2879
- Track N1 phase 1 PR 3 (canonical pattern, same pillar): #2894
- Track N3 phase 1 PR 3 (canonical pattern, same pillar): #2899
