### PR TITLE
feat(finance-db): flip tag_vocabulary consumer to @pops/finance-db (Track N5 phase 1 PR 3)

### DIFF
--- a/apps/pops-api/src/db/backfill-finance-from-shared.test.ts
+++ b/apps/pops-api/src/db/backfill-finance-from-shared.test.ts
@@ -470,10 +470,10 @@ describe('backfillFinanceFromShared', () => {
   it('copies tag_vocabulary rows from the shared DB on first run (Track N5 PR 3)', () => {
     const sharedPath = openSharedWithSeed((raw) => {
       raw.exec(
-        `INSERT INTO tag_vocabulary (tag, source, is_active) VALUES ('Groceries', 'seed', 1)`
+        `INSERT INTO tag_vocabulary (tag, source, is_active) VALUES ('backfill-test-tag-1', 'seed', 1)`
       );
       raw.exec(
-        `INSERT INTO tag_vocabulary (tag, source, is_active) VALUES ('Pet supplies', 'user', 1)`
+        `INSERT INTO tag_vocabulary (tag, source, is_active) VALUES ('backfill-test-tag-2', 'user', 1)`
       );
     });
 
@@ -486,8 +486,8 @@ describe('backfillFinanceFromShared', () => {
       // The package's own migration seeds many `seed` rows into finance.db;
       // assert presence of the carried rows rather than full equality.
       const byTag = new Map(rows.map((r) => [r.tag, r]));
-      expect(byTag.get('Groceries')).toMatchObject({ source: 'seed', is_active: 1 });
-      expect(byTag.get('Pet supplies')).toMatchObject({ source: 'user', is_active: 1 });
+      expect(byTag.get('backfill-test-tag-1')).toMatchObject({ source: 'seed', is_active: 1 });
+      expect(byTag.get('backfill-test-tag-2')).toMatchObject({ source: 'user', is_active: 1 });
     } finally {
       finance.raw.close();
     }

--- a/apps/pops-api/src/db/backfill-finance-from-shared.test.ts
+++ b/apps/pops-api/src/db/backfill-finance-from-shared.test.ts
@@ -466,4 +466,50 @@ describe('backfillFinanceFromShared', () => {
       }
     });
   });
+
+  it('copies tag_vocabulary rows from the shared DB on first run (Track N5 PR 3)', () => {
+    const sharedPath = openSharedWithSeed((raw) => {
+      raw.exec(
+        `INSERT INTO tag_vocabulary (tag, source, is_active) VALUES ('Groceries', 'seed', 1)`
+      );
+      raw.exec(
+        `INSERT INTO tag_vocabulary (tag, source, is_active) VALUES ('Pet supplies', 'user', 1)`
+      );
+    });
+
+    const finance = openFinanceDb(join(tmpDir, 'finance.db'));
+    try {
+      backfillFinanceFromShared(finance, sharedPath);
+      const rows = finance.raw
+        .prepare('SELECT tag, source, is_active FROM tag_vocabulary ORDER BY tag')
+        .all() as { tag: string; source: string; is_active: number }[];
+      // The package's own migration seeds many `seed` rows into finance.db;
+      // assert presence of the carried rows rather than full equality.
+      const byTag = new Map(rows.map((r) => [r.tag, r]));
+      expect(byTag.get('Groceries')).toMatchObject({ source: 'seed', is_active: 1 });
+      expect(byTag.get('Pet supplies')).toMatchObject({ source: 'user', is_active: 1 });
+    } finally {
+      finance.raw.close();
+    }
+  });
+
+  it('tag_vocabulary backfill is idempotent — second run does not duplicate', () => {
+    const sharedPath = openSharedWithSeed((raw) => {
+      raw.exec(
+        `INSERT INTO tag_vocabulary (tag, source, is_active) VALUES ('Pet supplies', 'user', 1)`
+      );
+    });
+
+    const finance = openFinanceDb(join(tmpDir, 'finance.db'));
+    try {
+      backfillFinanceFromShared(finance, sharedPath);
+      backfillFinanceFromShared(finance, sharedPath);
+      const count = finance.raw
+        .prepare(`SELECT count(*) AS n FROM tag_vocabulary WHERE tag = 'Pet supplies'`)
+        .get() as { n: number };
+      expect(count.n).toBe(1);
+    } finally {
+      finance.raw.close();
+    }
+  });
 });

--- a/apps/pops-api/src/db/backfill-test-fixtures.ts
+++ b/apps/pops-api/src/db/backfill-test-fixtures.ts
@@ -133,7 +133,7 @@ export const TAG_VOCABULARY_TABLE_SQL = `
 CREATE TABLE tag_vocabulary (
   tag text PRIMARY KEY NOT NULL,
   source text DEFAULT 'seed' NOT NULL,
-  is_active integer DEFAULT 1 NOT NULL,
+  is_active integer DEFAULT true NOT NULL,
   created_at text DEFAULT (datetime('now')) NOT NULL
 );
 `;

--- a/apps/pops-api/src/modules/core/tag-rules/vocabulary.ts
+++ b/apps/pops-api/src/modules/core/tag-rules/vocabulary.ts
@@ -1,26 +1,44 @@
-import { eq } from 'drizzle-orm';
+/**
+ * Thin shim that forwards the in-tree `tag_vocabulary` read/write API to
+ * `@pops/finance-db`'s `tagVocabularyService`.
+ *
+ * Track N5 phase 1 PR 3 routing flip — the public signatures
+ * (`listVocabulary` / `upsertVocabularyTag(tag, source)`) are preserved so
+ * the in-tree callers — `tagRulesRouter.listVocabulary`,
+ * `tagRulesRouter.applyTagRuleChangeSet`, and the imports pipeline's
+ * `applyTagRuleChangeSetsPhase` (under `modules/finance/imports/`) — keep
+ * compiling untouched.
+ *
+ * **Scoping note (Option A: cross-pillar workspace import).** This file
+ * lives under `modules/core/` because tag rules + the vocabulary they
+ * govern were originally classified as a `core` concern. The data and
+ * the package owner are firmly in the finance pillar, so the cutover
+ * imports `@pops/finance-db` directly rather than waiting for PRD-level
+ * reclassification of the slice (Option B). This mirrors the way Track N3
+ * (#2899) handled the same `core/`-housed-but-finance-owned situation
+ * for `transaction_corrections`. PR 4 of the sequence deletes this shim
+ * once nothing in pops-api references it.
+ *
+ * **Handle: `getFinanceDrizzle()`.** Per the canonical PR 3 pattern
+ * (#2781, #2894) reads + writes now go through the finance pillar's
+ * lazily-opened `finance.db`. In named-env / test context
+ * `getFinanceDrizzle()` short-circuits to the env DB so existing fixtures
+ * keep seeing the same rows; in production the next deploy's boot-time
+ * backfill carries the existing rows across (see
+ * `db/backfill-finance-from-shared.ts`).
+ *
+ * No `mapDomainErrors` plumbing: the package exports no typed errors
+ * for this slice — `listVocabularyTags` returns `[]` when empty and
+ * `upsertVocabularyTag` is idempotent.
+ */
+import { tagVocabularyService } from '@pops/finance-db';
 
-import { tagVocabulary } from '@pops/db-types';
-
-import { getDrizzle } from '../../../db.js';
+import { getFinanceDrizzle } from '../../../db/finance-handle.js';
 
 export function listVocabulary(): string[] {
-  const db = getDrizzle();
-  return db
-    .select({ tag: tagVocabulary.tag })
-    .from(tagVocabulary)
-    .where(eq(tagVocabulary.isActive, true))
-    .all()
-    .map((r) => r.tag);
+  return tagVocabularyService.listVocabularyTags(getFinanceDrizzle());
 }
 
 export function upsertVocabularyTag(tag: string, source: 'seed' | 'user'): void {
-  const db = getDrizzle();
-  db.insert(tagVocabulary)
-    .values({ tag, source, isActive: true })
-    .onConflictDoUpdate({
-      target: tagVocabulary.tag,
-      set: { isActive: true },
-    })
-    .run();
+  tagVocabularyService.upsertVocabularyTag(getFinanceDrizzle(), tag, source);
 }

--- a/apps/pops-api/src/modules/core/tag-rules/vocabulary.ts
+++ b/apps/pops-api/src/modules/core/tag-rules/vocabulary.ts
@@ -31,7 +31,7 @@
  * for this slice — `listVocabularyTags` returns `[]` when empty and
  * `upsertVocabularyTag` is idempotent.
  */
-import { tagVocabularyService } from '@pops/finance-db';
+import { tagVocabularyService, type TagVocabularySource } from '@pops/finance-db';
 
 import { getFinanceDrizzle } from '../../../db/finance-handle.js';
 
@@ -39,6 +39,6 @@ export function listVocabulary(): string[] {
   return tagVocabularyService.listVocabularyTags(getFinanceDrizzle());
 }
 
-export function upsertVocabularyTag(tag: string, source: 'seed' | 'user'): void {
+export function upsertVocabularyTag(tag: string, source: TagVocabularySource): void {
   tagVocabularyService.upsertVocabularyTag(getFinanceDrizzle(), tag, source);
 }


### PR DESCRIPTION
## Summary

Flips the in-tree consumer of the `tag_vocabulary` slice over to `tagVocabularyService` from `@pops/finance-db` scaffolded in #2852. The shim at `apps/pops-api/src/modules/core/tag-rules/vocabulary.ts` now delegates to the package; both callers (the `core.tagRules.*` tRPC router and the imports pipeline's `applyTagRuleChangeSetsPhase`) keep compiling against the same public surface.

Mirrors Track N1 (#2894), Track N3 (#2899), and the wish-list pilot pattern. PR 2 of the original 4-PR sequence is skipped — the migration journal copy at `packages/finance-db/migrations/0026_little_frank_castle.sql` is already byte-identical from the wish-list pilot, as noted in #2852.

## Scoping decision — Option A (cross-pillar workspace import)

The in-tree shim lives under `modules/core/tag-rules/` because tag rules + their vocabulary were originally classified as `core`. The data and the package owner are firmly in the finance pillar, so PR 3 imports `@pops/finance-db` from the `core/`-housed file directly (Option A) rather than waiting for a PRD-level reclassification of the slice (Option B). This matches Track N3's handling of the same situation for `transaction_corrections` (#2899) — the location of the file is a legacy classification artefact, not a domain boundary.

PR 4 of the sequence will delete the shim once nothing in pops-api references it.

## Changes

- `apps/pops-api/src/modules/core/tag-rules/vocabulary.ts` — replace the in-tree drizzle calls with thin forwards to `tagVocabularyService.{listVocabularyTags, upsertVocabularyTag}`. Switch the handle from `getDrizzle()` to `getFinanceDrizzle()` so reads + writes now flow through the finance pillar's `finance.db`. In named-env / test scope `getFinanceDrizzle()` short-circuits to the env DB, so existing fixtures keep seeing the same rows untouched.
- `apps/pops-api/src/db/backfill-finance-from-shared.ts` — extend `TABLE_COPIES` with `tag_vocabulary` (`tag` PK, `source`, `is_active`, `created_at`). The first deploy after this PR carries the existing rows from the shared `pops.db` into the pillar's `finance.db`; subsequent boots are a no-op via the per-table `WHERE tag NOT IN (...)` filter.
- `apps/pops-api/src/db/backfill-test-fixtures.ts` — add `TAG_VOCABULARY_TABLE_SQL` DDL (matches the migration in `packages/finance-db/migrations/0026_little_frank_castle.sql`).
- `apps/pops-api/src/db/backfill-finance-from-shared.test.ts` — extend the suite with two new cases: first-run copy carries a seeded + user-source row across, and a second invocation is idempotent.

No `mapDomainErrors` plumbing: per the PR 1 scoping note, `tagVocabularyService` exports no typed errors — `listVocabularyTags` returns `[]` on empty and `upsertVocabularyTag` is idempotent.

## What stays for PR 4

- `apps/pops-api/src/modules/core/tag-rules/vocabulary.ts` (this shim) — deleted once the in-tree barrel re-export in `service.ts` is dropped and the two call sites import `tagVocabularyService` directly.
- The seed loop in `apps/pops-api/src/db/schema.ts` and the test reset in `apps/pops-api/src/db/data-reset.ts` that re-seed `tag_vocabulary` from `TAG_VOCABULARY_V1` against `getDrizzle()`. These run during boot/test-reset before the finance handle resolves and don't go through the shim — PR 4 either retires the legacy seed entirely (once the finance package owns first-boot population) or routes it through `getFinanceDrizzle()` alongside the shim deletion.

## CI / Docker

PR 1 (#2852) confirmed `packages/finance-db/**` is wired into `_pkg-check.yml`, `api-quality.yml`, `api-test.yml`, `fe-quality.yml`, `fe-test-e2e.yml`, and all three Dockerfiles (`pops-api`, `pops-shell`, `pops-mcp`) plus `pops-finance-api` already COPY + BUILD `@pops/finance-db`. No infra changes needed.

## Test plan

- [x] `pnpm typecheck` — 51 / 51 clean
- [x] `pnpm lint` — clean (pre-existing warnings only, no errors)
- [x] `pnpm lint:boundaries` — no dependency violations (1989 modules, 5601 deps cruised)
- [x] `pnpm --filter @pops/finance-db test` — 195 / 195 pass
- [x] `pnpm --filter @pops/api test` — 4877 / 4877 pass (full pops-api suite — exercises `core.tagRules.{listVocabulary, applyTagRuleChangeSet}` end-to-end + the imports pipeline's `upsertVocabularyTag` call site + the new `backfill-finance-from-shared` cases)
- [x] `pnpm build` — 25 / 25 green
- [x] `pnpm format` — clean

## References

- Phase 1 PR 1 (scaffold + scoping note): #2852
- Track N1 phase 1 PR 3 (canonical pattern): #2894
- Track N2 phase 1 PR 3: #2903
- Track N3 phase 1 PR 3 (canonical `core/`-housed-but-finance-owned precedent): #2899
