### PR TITLE
feat(finance-db): flip transaction_tag_rules consumer to @pops/finance-db (Track N4 phase 1 PR 3)

### DIFF
--- a/apps/pops-api/src/modules/core/tag-rules/router.ts
+++ b/apps/pops-api/src/modules/core/tag-rules/router.ts
@@ -1,8 +1,7 @@
-import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 
 import { logger } from '../../../lib/logger.js';
-import { NotFoundError } from '../../../shared/errors.js';
+import { mapDomainErrors } from '../../../shared/trpc-error-mapper.js';
 import { protectedProcedure, router } from '../../../trpc.js';
 import * as service from './service.js';
 import { TagRuleChangeSetSchema } from './types.js';
@@ -72,27 +71,21 @@ export const tagRulesRouter = router({
         acceptedNewTags: z.array(z.string()).optional().default([]),
       })
     )
-    .mutation(({ input }) => {
-      logger.info(
-        { opCount: input.changeSet.ops.length, acceptedNewTags: input.acceptedNewTags.length },
-        '[TagRules] Apply ChangeSet'
-      );
+    .mutation(({ input }) =>
+      mapDomainErrors(() => {
+        logger.info(
+          { opCount: input.changeSet.ops.length, acceptedNewTags: input.acceptedNewTags.length },
+          '[TagRules] Apply ChangeSet'
+        );
 
-      // Persist newly-accepted tags into vocabulary before applying rules.
-      for (const t of input.acceptedNewTags) {
-        if (t.trim()) service.upsertVocabularyTag(t.trim(), 'user');
-      }
+        for (const t of input.acceptedNewTags) {
+          if (t.trim()) service.upsertVocabularyTag(t.trim(), 'user');
+        }
 
-      try {
         const rules = service.applyTagRuleChangeSet(input.changeSet);
         return { rules };
-      } catch (err) {
-        if (err instanceof NotFoundError) {
-          throw new TRPCError({ code: 'NOT_FOUND', message: err.message });
-        }
-        throw err;
-      }
-    }),
+      })
+    ),
 
   rejectTagRuleChangeSet: protectedProcedure
     .input(

--- a/apps/pops-api/src/modules/core/tag-rules/service.ts
+++ b/apps/pops-api/src/modules/core/tag-rules/service.ts
@@ -1,12 +1,28 @@
-import { desc, eq } from 'drizzle-orm';
+/**
+ * Thin shims that forward `transaction_tag_rules` CRUD to
+ * `@pops/finance-db`'s `transactionTagRulesService`.
+ *
+ * Track N4 phase 1 PR 3 routing flip. The underlying SQLite file moves
+ * to the finance pillar's `finance.db` via `getFinanceDrizzle()` — the
+ * package's services already accept a `FinanceDb` handle (including a
+ * transaction) as their first arg, so the legacy in-tree transaction
+ * wrapping in `applyTagRuleChangeSet` keeps working unchanged.
+ *
+ * Domain errors thrown by the package (`TransactionTagRuleNotFoundError`)
+ * are translated to the in-tree `NotFoundError` so the existing router
+ * + consumers (the imports persistence pipeline at
+ * `apps/pops-api/src/modules/finance/imports/lib/transaction-persistence.ts`)
+ * keep seeing the same error type and the tRPC envelope keeps surfacing
+ * `404 NOT_FOUND`. PR 4 of the phase 1 sequence deletes this shim once
+ * nothing in-tree still imports from here.
+ */
+import { transactionTagRulesService, TransactionTagRuleNotFoundError } from '@pops/finance-db';
 
-import { transactionTagRules } from '@pops/db-types';
-
-import { getDrizzle } from '../../../db.js';
+import { getFinanceDrizzle } from '../../../db/finance-handle.js';
 import { NotFoundError } from '../../../shared/errors.js';
 import { previewTagRuleChangeSet, type PreviewInputTransaction } from './preview.js';
 
-import type { TransactionTagRuleRow } from '@pops/db-types';
+import type { FinanceDb, TransactionTagRuleRow } from '@pops/finance-db';
 
 import type { TagRuleChangeSet, TagRuleChangeSetOp, TagRuleChangeSetProposal } from './types.js';
 
@@ -16,73 +32,64 @@ export { listVocabulary, upsertVocabularyTag } from './vocabulary.js';
 export { previewTagRuleChangeSet };
 export type { PreviewInputTransaction };
 
-export function listTagRules(): TagRuleRow[] {
-  return getDrizzle()
-    .select()
-    .from(transactionTagRules)
-    .orderBy(desc(transactionTagRules.confidence), desc(transactionTagRules.timesApplied))
-    .all();
+function rethrowAsNotFound(err: unknown, id: string): never {
+  if (err instanceof TransactionTagRuleNotFoundError) {
+    throw new NotFoundError('transaction_tag_rules', id);
+  }
+  throw err;
 }
 
-type TagRulesTx = ReturnType<typeof getDrizzle>;
+export function listTagRules(): TagRuleRow[] {
+  return transactionTagRulesService.listTransactionTagRules(getFinanceDrizzle());
+}
 
-function addTagRule(
-  tx: TagRulesTx,
-  data: Extract<TagRuleChangeSetOp, { op: 'add' }>['data']
-): void {
-  tx.insert(transactionTagRules)
-    .values({
-      descriptionPattern: data.descriptionPattern,
-      matchType: data.matchType,
-      entityId: data.entityId ?? null,
-      tags: JSON.stringify(data.tags ?? []),
-      confidence: data.confidence ?? 0.95,
-      isActive: data.isActive ?? true,
-      priority: data.priority ?? 0,
-      timesApplied: 0,
-    })
-    .run();
+function addTagRule(tx: FinanceDb, data: Extract<TagRuleChangeSetOp, { op: 'add' }>['data']): void {
+  transactionTagRulesService.createTransactionTagRule(tx, {
+    descriptionPattern: data.descriptionPattern,
+    matchType: data.matchType,
+    entityId: data.entityId ?? null,
+    tags: data.tags ?? [],
+    confidence: data.confidence ?? 0.95,
+    isActive: data.isActive ?? true,
+    priority: data.priority ?? 0,
+  });
 }
 
 function editTagRule(
-  tx: TagRulesTx,
+  tx: FinanceDb,
   id: string,
   data: Extract<TagRuleChangeSetOp, { op: 'edit' }>['data']
 ): void {
-  const existing = tx
-    .select({ id: transactionTagRules.id })
-    .from(transactionTagRules)
-    .where(eq(transactionTagRules.id, id))
-    .get();
-  if (!existing) throw new NotFoundError('transaction_tag_rules', id);
-
-  tx.update(transactionTagRules)
-    .set({
-      entityId: data.entityId !== undefined ? data.entityId : undefined,
-      tags: data.tags ? JSON.stringify(data.tags) : undefined,
-      confidence: data.confidence ?? undefined,
-      isActive: data.isActive ?? undefined,
-      priority: data.priority ?? undefined,
-    })
-    .where(eq(transactionTagRules.id, id))
-    .run();
+  try {
+    transactionTagRulesService.updateTransactionTagRule(tx, id, {
+      entityId: data.entityId,
+      tags: data.tags,
+      confidence: data.confidence,
+      isActive: data.isActive,
+      priority: data.priority,
+    });
+  } catch (err) {
+    rethrowAsNotFound(err, id);
+  }
 }
 
-function disableTagRule(tx: TagRulesTx, id: string): void {
-  const res = tx
-    .update(transactionTagRules)
-    .set({ isActive: false })
-    .where(eq(transactionTagRules.id, id))
-    .run();
-  if (res.changes === 0) throw new NotFoundError('transaction_tag_rules', id);
+function disableTagRule(tx: FinanceDb, id: string): void {
+  try {
+    transactionTagRulesService.disableTransactionTagRule(tx, id);
+  } catch (err) {
+    rethrowAsNotFound(err, id);
+  }
 }
 
-function removeTagRule(tx: TagRulesTx, id: string): void {
-  const res = tx.delete(transactionTagRules).where(eq(transactionTagRules.id, id)).run();
-  if (res.changes === 0) throw new NotFoundError('transaction_tag_rules', id);
+function removeTagRule(tx: FinanceDb, id: string): void {
+  try {
+    transactionTagRulesService.deleteTransactionTagRule(tx, id);
+  } catch (err) {
+    rethrowAsNotFound(err, id);
+  }
 }
 
-function applyOp(tx: TagRulesTx, op: TagRuleChangeSetOp): void {
+function applyOp(tx: FinanceDb, op: TagRuleChangeSetOp): void {
   switch (op.op) {
     case 'add':
       addTagRule(tx, op.data);
@@ -99,14 +106,10 @@ function applyOp(tx: TagRulesTx, op: TagRuleChangeSetOp): void {
 }
 
 export function applyTagRuleChangeSet(changeSet: TagRuleChangeSet): TagRuleRow[] {
-  const db = getDrizzle();
+  const db = getFinanceDrizzle();
   return db.transaction((tx) => {
     for (const op of changeSet.ops) applyOp(tx, op);
-    return tx
-      .select()
-      .from(transactionTagRules)
-      .orderBy(desc(transactionTagRules.confidence), desc(transactionTagRules.timesApplied))
-      .all();
+    return transactionTagRulesService.listTransactionTagRules(tx);
   });
 }
 


### PR DESCRIPTION
## Summary

Flips the in-tree consumer of the `transaction_tag_rules` slice (`apps/pops-api/src/modules/core/tag-rules/`) over to `transactionTagRulesService` from `@pops/finance-db` scaffolded in #2856.

Mirrors the canonical PR 3 pattern from Track N1 (#2894), Track N2 (#2903), and Track N3 (#2899). The wish-list cutover (#2806) and budgets cutover (#2894) already established `getFinanceDrizzle()` as the handle of choice for finance-owned tables.

## Scoping decision — Option A

N4 PR 1 (#2856) deferred a choice between:

- **Option A**: keep the consumer under `modules/core/tag-rules/` and let it cross-pillar import `@pops/finance-db`.
- **Option B**: skip the cutover, pending reclassification of the slice from finance to core.

This PR picks **Option A**. Workspace deps make the cross-pillar import structurally clean — there is nothing awkward at the dependency level about `modules/core/tag-rules/` importing `@pops/finance-db` when the table itself is finance-owned (DDL in `packages/finance-db/migrations/0026_little_frank_castle.sql`). The same situation applies to N5 (`tag_vocabulary`), which already lives under `modules/core/tag-rules/vocabulary.ts` and reads through the package's barrel re-export. Re-homing the slice into a `modules/core`-owned `core-db` package can land later as a follow-up without blocking this cutover.

## Changes

- `apps/pops-api/src/modules/core/tag-rules/service.ts` — drops the in-tree drizzle calls. Every CRUD path (`addTagRule`, `editTagRule`, `disableTagRule`, `removeTagRule`) now forwards to `transactionTagRulesService.{create,update,disable,delete}TransactionTagRule` against `getFinanceDrizzle()`. `applyTagRuleChangeSet` keeps its `db.transaction(tx => …)` wrapper because the package services accept a `FinanceDb` handle (a transaction is a `FinanceDb`), so atomicity over multi-op change sets is preserved. `TransactionTagRuleNotFoundError` from the package is translated to the in-tree `NotFoundError` so the existing imports persistence consumer (`apps/pops-api/src/modules/finance/imports/lib/transaction-persistence.ts`) keeps seeing the same error type.
- `apps/pops-api/src/modules/core/tag-rules/router.ts` — drops the per-procedure `try { … } catch (NotFoundError) { throw new TRPCError(NOT_FOUND) }` ladder. `applyTagRuleChangeSet` is now wrapped in `mapDomainErrors(() => …)` so `NotFoundError` routes through the shared `trpc-error-mapper` and surfaces as `TRPCError { code: 'NOT_FOUND' }` automatically.

## Where the data actually lives

The `transaction_tag_rules` table now reads/writes through the finance pillar's `finance.db` via `getFinanceDrizzle()`. The legacy `getDrizzle()` path on the shared `pops.db` is no longer touched by this consumer. The imports persistence pipeline still imports `applyTagRuleChangeSet` / `upsertVocabularyTag` from the in-tree `service.ts`, so it rides the cutover transparently — no changes needed in `modules/finance/imports/lib/transaction-persistence.ts`.

In tests, `setupTestContext` in `shared/test-utils.ts` wires `setFinanceDb({ db, raw })` to the same in-memory fixture as `setDb(...)`, so `getDrizzle()` and `getFinanceDrizzle()` resolve to the same handle for the duration of a test — the existing `tag-rules.test.ts` suite stays green without changes.

## What stays for PR 4

The in-tree `apps/pops-api/src/modules/core/tag-rules/` directory stays in place — `service.ts`, `preview.ts`, `vocabulary.ts`, `types.ts`, `index.ts`, `tag-rules.test.ts`, `router.ts`. PR 4 of the phase 1 sequence deletes the in-tree CRUD shim once nothing in-tree imports the legacy `applyTagRuleChangeSet` / `listTagRules` paths (notably the imports persistence consumer will need to migrate first, likely under Track N6).

`preview.ts` and `vocabulary.ts` stay untouched — `preview.ts` is suggestion logic, no persistence; `vocabulary.ts` reads/writes `tag_vocabulary` and waits on Track N5 PR 3.

## Test plan

- [x] `pnpm --filter @pops/finance-db test` — 195/195 passing
- [x] `pnpm --filter @pops/api exec vitest run src/modules/core/tag-rules` — 12/12 passing
- [x] `pnpm --filter @pops/api exec vitest run src/modules/finance/imports src/modules/core src/shared/tag-suggester` — 1015/1015 passing (covers the imports persistence consumer of `applyTagRuleChangeSet` end-to-end)
- [x] `pnpm --filter @pops/api test` — 4875/4875 passing
- [x] `pnpm typecheck` — 51/51 clean
- [x] `pnpm lint` — clean (pre-existing warnings only, none from this diff)
- [x] `pnpm lint:boundaries` — 1989 modules / 5601 deps cruised, no violations
- [x] `pnpm build` — 25/25 green
- [x] `pnpm format` — clean

## References

- Phase 1 PR 1 (scaffold): #2856
- Track N1 phase 1 PR 3 (canonical pattern): #2894
- Track N2 phase 1 PR 3: #2903
- Track N3 phase 1 PR 3: #2899
