### PR TITLE
feat(finance-db): extend pillar baseline with transactions, transaction_tag_rules, tag_vocabulary (Track N migrations gap)

### DIFF
--- a/packages/finance-db/migrations/0054_finance_pillar_baseline_extension.sql
+++ b/packages/finance-db/migrations/0054_finance_pillar_baseline_extension.sql
@@ -1,0 +1,96 @@
+-- Finance pillar baseline extension — adds the four finance-owned tables
+-- absent from `0053_finance_pillar_baseline.sql`.
+--
+-- Track N4 (#2908) flipped `transaction_tag_rules` consumers to
+-- `getFinanceDrizzle()`, but the underlying table only existed in the
+-- shared pre-modular baseline (`0000_naive_chameleon.sql`) — a fresh
+-- per-pillar `finance.db` populated solely by 0053 has no
+-- `transactions`, `transaction_tag_rules`, or `tag_vocabulary` tables.
+-- (`transaction_tag_rules` + `tag_vocabulary` were already created by
+-- 0026 against the shared journal, but the older 0026 statements were
+-- written without IF NOT EXISTS — replaying them in the package journal
+-- against a DB where 0026 has already run would explode. They are
+-- guarded here in case an older boot path created them before 0054
+-- runs.)
+--
+-- Statements mirror
+-- `apps/pops-api/src/db/drizzle-migrations/0000_naive_chameleon.sql` for
+-- `transactions` and the drizzle schemas in `packages/db-types/src/schema/`
+-- for the others. The FK on `transaction_tag_rules.entity_id` matches
+-- migration 0026.
+--
+-- IF NOT EXISTS is used throughout because this migration runs against
+-- production `finance.db` files that may already contain some of these
+-- tables (created by the legacy boot path that pointed
+-- `getFinanceDrizzle()` at the shared pops.db, or by an earlier
+-- back-fill). Once drizzle records 0054 in `__drizzle_migrations` the
+-- file is replay-skipped on every subsequent boot.
+
+CREATE TABLE IF NOT EXISTS `transactions` (
+	`id` text PRIMARY KEY NOT NULL,
+	`notion_id` text,
+	`description` text NOT NULL,
+	`account` text NOT NULL,
+	`amount` real NOT NULL,
+	`date` text NOT NULL,
+	`type` text NOT NULL,
+	`tags` text DEFAULT '[]' NOT NULL,
+	`entity_id` text,
+	`entity_name` text,
+	`location` text,
+	`country` text,
+	`related_transaction_id` text,
+	`notes` text,
+	`checksum` text,
+	`raw_row` text,
+	`last_edited_time` text NOT NULL,
+	FOREIGN KEY (`entity_id`) REFERENCES `entities`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `transactions_notion_id_unique` ON `transactions` (`notion_id`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_transactions_date` ON `transactions` (`date`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_transactions_account` ON `transactions` (`account`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_transactions_entity` ON `transactions` (`entity_id`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_transactions_last_edited` ON `transactions` (`last_edited_time`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_transactions_notion_id` ON `transactions` (`notion_id`);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `idx_transactions_checksum` ON `transactions` (`checksum`);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `transaction_tag_rules` (
+	`id` text PRIMARY KEY NOT NULL,
+	`description_pattern` text NOT NULL,
+	`match_type` text DEFAULT 'exact' NOT NULL,
+	`entity_id` text,
+	`tags` text DEFAULT '[]' NOT NULL,
+	`is_active` integer DEFAULT true NOT NULL,
+	`confidence` real DEFAULT 0.5 NOT NULL,
+	`priority` integer DEFAULT 0 NOT NULL,
+	`times_applied` integer DEFAULT 0 NOT NULL,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL,
+	`last_used_at` text,
+	FOREIGN KEY (`entity_id`) REFERENCES `entities`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_tag_rules_pattern` ON `transaction_tag_rules` (`description_pattern`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_tag_rules_entity_id` ON `transaction_tag_rules` (`entity_id`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_tag_rules_priority` ON `transaction_tag_rules` (`priority`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_tag_rules_confidence` ON `transaction_tag_rules` (`confidence`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_tag_rules_times_applied` ON `transaction_tag_rules` (`times_applied`);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `tag_vocabulary` (
+	`tag` text PRIMARY KEY NOT NULL,
+	`source` text DEFAULT 'seed' NOT NULL,
+	`is_active` integer DEFAULT true NOT NULL,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_tag_vocabulary_active` ON `tag_vocabulary` (`is_active`);

--- a/packages/finance-db/migrations/0054_finance_pillar_baseline_extension.sql
+++ b/packages/finance-db/migrations/0054_finance_pillar_baseline_extension.sql
@@ -1,4 +1,4 @@
--- Finance pillar baseline extension — adds the four finance-owned tables
+-- Finance pillar baseline extension — adds the three finance-owned tables
 -- absent from `0053_finance_pillar_baseline.sql`.
 --
 -- Track N4 (#2908) flipped `transaction_tag_rules` consumers to

--- a/packages/finance-db/migrations/meta/_journal.json
+++ b/packages/finance-db/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1778429000000,
       "tag": "0052_budgets_active_default_zero",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1778500000001,
+      "tag": "0054_finance_pillar_baseline_extension",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/finance-db/src/__tests__/baseline-extension.test.ts
+++ b/packages/finance-db/src/__tests__/baseline-extension.test.ts
@@ -140,7 +140,15 @@ describe('0054_finance_pillar_baseline_extension', () => {
              (id, description, account, amount, date, type, last_edited_time)
            VALUES (?, ?, ?, ?, ?, ?, ?)`
         )
-        .run('txn-1', 'Test charge', 'Up Savings', 12.5, '2026-06-01', 'Purchase', '2026-06-01T00:00:00Z');
+        .run(
+          'txn-1',
+          'Test charge',
+          'Up Savings',
+          12.5,
+          '2026-06-01',
+          'Purchase',
+          '2026-06-01T00:00:00Z'
+        );
 
       raw
         .prepare(
@@ -207,7 +215,15 @@ describe('0054_finance_pillar_baseline_extension', () => {
              (id, description, account, amount, date, type, last_edited_time)
            VALUES (?, ?, ?, ?, ?, ?, ?)`
         )
-        .run('seed-1', 'Seed row', 'Up Savings', 1, '2026-06-01', 'Purchase', '2026-06-01T00:00:00Z');
+        .run(
+          'seed-1',
+          'Seed row',
+          'Up Savings',
+          1,
+          '2026-06-01',
+          'Purchase',
+          '2026-06-01T00:00:00Z'
+        );
     } finally {
       first.raw.close();
     }
@@ -215,9 +231,9 @@ describe('0054_finance_pillar_baseline_extension', () => {
     expect(() => {
       const second = openFinanceDb(path);
       try {
-        const txn = second.raw
-          .prepare('SELECT id FROM transactions WHERE id = ?')
-          .get('seed-1') as { id: string } | undefined;
+        const txn = second.raw.prepare('SELECT id FROM transactions WHERE id = ?').get('seed-1') as
+          | { id: string }
+          | undefined;
         expect(txn?.id).toBe('seed-1');
       } finally {
         second.raw.close();
@@ -236,7 +252,15 @@ describe('0054_finance_pillar_baseline_extension', () => {
              (id, description, account, amount, date, type, last_edited_time)
            VALUES (?, ?, ?, ?, ?, ?, ?)`
         )
-        .run('legacy-1', 'Legacy charge', 'Up Savings', 1, '2026-06-01', 'Purchase', '2026-06-01T00:00:00Z');
+        .run(
+          'legacy-1',
+          'Legacy charge',
+          'Up Savings',
+          1,
+          '2026-06-01',
+          'Purchase',
+          '2026-06-01T00:00:00Z'
+        );
     } finally {
       first.raw.close();
     }
@@ -248,7 +272,7 @@ describe('0054_finance_pillar_baseline_extension', () => {
     ).n;
     const deleteInfo = raw
       .prepare(
-        "DELETE FROM __drizzle_migrations WHERE created_at = (SELECT MAX(created_at) FROM __drizzle_migrations)"
+        'DELETE FROM __drizzle_migrations WHERE created_at = (SELECT MAX(created_at) FROM __drizzle_migrations)'
       )
       .run();
     expect(deleteInfo.changes).toBeGreaterThan(0);

--- a/packages/finance-db/src/__tests__/baseline-extension.test.ts
+++ b/packages/finance-db/src/__tests__/baseline-extension.test.ts
@@ -1,0 +1,277 @@
+/**
+ * Coverage for `0054_finance_pillar_baseline_extension.sql` — the
+ * follow-up migration that creates the three finance tables absent from
+ * the 0053 baseline (`transactions`, `transaction_tag_rules`,
+ * `tag_vocabulary`).
+ *
+ * Track N4 (#2908) flipped `transaction_tag_rules` consumers to
+ * `getFinanceDrizzle()` but the table was only created by the legacy
+ * shared `0000_naive_chameleon.sql` / `0026_little_frank_castle.sql`
+ * statements — on a fresh per-pillar `finance.db` populated solely by
+ * 0053 the table did not exist.
+ *
+ * The migration uses CREATE TABLE / CREATE INDEX IF NOT EXISTS so
+ * replaying it against a production `finance.db` populated by the
+ * legacy boot path (where `transaction_tag_rules` already exists from
+ * the shared journal) is a no-op rather than an error.
+ */
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import Database from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { openFinanceDb } from '../open-finance-db.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'finance-db-extension-test-'));
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+interface TableInfoRow {
+  name: string;
+}
+
+interface ForeignKeyRow {
+  table: string;
+  from: string;
+  to: string;
+  on_delete: string;
+}
+
+interface IndexInfoRow {
+  name: string;
+}
+
+function listTables(raw: Database.Database): string[] {
+  return (
+    raw
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+      .all() as TableInfoRow[]
+  ).map((row) => row.name);
+}
+
+function listIndexes(raw: Database.Database, table: string): string[] {
+  return (raw.prepare(`PRAGMA index_list(${table})`).all() as IndexInfoRow[]).map(
+    (row) => row.name
+  );
+}
+
+describe('0054_finance_pillar_baseline_extension', () => {
+  it('creates transactions, transaction_tag_rules, and tag_vocabulary on a fresh finance.db', () => {
+    const path = join(tmpDir, 'finance.db');
+    const { raw } = openFinanceDb(path);
+    try {
+      expect(existsSync(path)).toBe(true);
+      const tables = listTables(raw);
+      expect(tables).toContain('transactions');
+      expect(tables).toContain('transaction_tag_rules');
+      expect(tables).toContain('tag_vocabulary');
+    } finally {
+      raw.close();
+    }
+  });
+
+  it('preserves the transaction_tag_rules.entity_id → entities.id FK with ON DELETE SET NULL', () => {
+    const path = join(tmpDir, 'finance.db');
+    const { raw } = openFinanceDb(path);
+    try {
+      const fks = raw
+        .prepare('PRAGMA foreign_key_list(transaction_tag_rules)')
+        .all() as ForeignKeyRow[];
+      const entityFk = fks.find((fk) => fk.from === 'entity_id');
+      expect(entityFk).toBeDefined();
+      expect(entityFk?.table).toBe('entities');
+      expect(entityFk?.to).toBe('id');
+      expect(entityFk?.on_delete).toBe('SET NULL');
+    } finally {
+      raw.close();
+    }
+  });
+
+  it('creates every named index from the migration', () => {
+    const path = join(tmpDir, 'finance.db');
+    const { raw } = openFinanceDb(path);
+    try {
+      const transactionsIndexes = listIndexes(raw, 'transactions');
+      expect(transactionsIndexes).toEqual(
+        expect.arrayContaining([
+          'idx_transactions_date',
+          'idx_transactions_account',
+          'idx_transactions_entity',
+          'idx_transactions_last_edited',
+          'idx_transactions_notion_id',
+          'idx_transactions_checksum',
+          'transactions_notion_id_unique',
+        ])
+      );
+
+      const tagRulesIndexes = listIndexes(raw, 'transaction_tag_rules');
+      expect(tagRulesIndexes).toEqual(
+        expect.arrayContaining([
+          'idx_tag_rules_pattern',
+          'idx_tag_rules_entity_id',
+          'idx_tag_rules_priority',
+          'idx_tag_rules_confidence',
+          'idx_tag_rules_times_applied',
+        ])
+      );
+
+      const tagVocabIndexes = listIndexes(raw, 'tag_vocabulary');
+      expect(tagVocabIndexes).toEqual(expect.arrayContaining(['idx_tag_vocabulary_active']));
+    } finally {
+      raw.close();
+    }
+  });
+
+  it('supports round-trip insert + read against each new table', () => {
+    const path = join(tmpDir, 'finance.db');
+    const { raw } = openFinanceDb(path);
+    try {
+      raw
+        .prepare(
+          `INSERT INTO transactions
+             (id, description, account, amount, date, type, last_edited_time)
+           VALUES (?, ?, ?, ?, ?, ?, ?)`
+        )
+        .run('txn-1', 'Test charge', 'Up Savings', 12.5, '2026-06-01', 'Purchase', '2026-06-01T00:00:00Z');
+
+      raw
+        .prepare(
+          `INSERT INTO transaction_tag_rules
+             (id, description_pattern, match_type, tags, is_active, confidence, priority, times_applied, created_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))`
+        )
+        .run('rule-1', 'WOOLWORTHS%', 'contains', '["Groceries"]', 1, 0.75, 10, 0);
+
+      raw
+        .prepare(
+          `INSERT INTO tag_vocabulary
+             (tag, source, is_active, created_at)
+           VALUES (?, ?, ?, datetime('now'))`
+        )
+        .run('Custom Tag', 'user', 1);
+
+      const txn = raw
+        .prepare('SELECT id, description, account, amount FROM transactions WHERE id = ?')
+        .get('txn-1') as { id: string; description: string; account: string; amount: number };
+      expect(txn).toEqual({
+        id: 'txn-1',
+        description: 'Test charge',
+        account: 'Up Savings',
+        amount: 12.5,
+      });
+
+      const rule = raw
+        .prepare(
+          'SELECT id, description_pattern, match_type, tags, confidence FROM transaction_tag_rules WHERE id = ?'
+        )
+        .get('rule-1') as {
+        id: string;
+        description_pattern: string;
+        match_type: string;
+        tags: string;
+        confidence: number;
+      };
+      expect(rule).toEqual({
+        id: 'rule-1',
+        description_pattern: 'WOOLWORTHS%',
+        match_type: 'contains',
+        tags: '["Groceries"]',
+        confidence: 0.75,
+      });
+
+      const tag = raw
+        .prepare('SELECT tag, source, is_active FROM tag_vocabulary WHERE tag = ?')
+        .get('Custom Tag') as { tag: string; source: string; is_active: number };
+      expect(tag).toEqual({ tag: 'Custom Tag', source: 'user', is_active: 1 });
+    } finally {
+      raw.close();
+    }
+  });
+
+  it('is idempotent — re-running migrations against an already-populated finance.db is a no-op', () => {
+    const path = join(tmpDir, 'finance.db');
+
+    const first = openFinanceDb(path);
+    try {
+      first.raw
+        .prepare(
+          `INSERT INTO transactions
+             (id, description, account, amount, date, type, last_edited_time)
+           VALUES (?, ?, ?, ?, ?, ?, ?)`
+        )
+        .run('seed-1', 'Seed row', 'Up Savings', 1, '2026-06-01', 'Purchase', '2026-06-01T00:00:00Z');
+    } finally {
+      first.raw.close();
+    }
+
+    expect(() => {
+      const second = openFinanceDb(path);
+      try {
+        const txn = second.raw
+          .prepare('SELECT id FROM transactions WHERE id = ?')
+          .get('seed-1') as { id: string } | undefined;
+        expect(txn?.id).toBe('seed-1');
+      } finally {
+        second.raw.close();
+      }
+    }).not.toThrow();
+  });
+
+  it('applies cleanly when the target tables already exist (production-upgrade scenario)', () => {
+    const path = join(tmpDir, 'finance-prefilled.db');
+
+    const first = openFinanceDb(path);
+    try {
+      first.raw
+        .prepare(
+          `INSERT INTO transactions
+             (id, description, account, amount, date, type, last_edited_time)
+           VALUES (?, ?, ?, ?, ?, ?, ?)`
+        )
+        .run('legacy-1', 'Legacy charge', 'Up Savings', 1, '2026-06-01', 'Purchase', '2026-06-01T00:00:00Z');
+    } finally {
+      first.raw.close();
+    }
+
+    const raw = new Database(path);
+    raw.pragma('journal_mode = WAL');
+    const beforeRows = (
+      raw.prepare('SELECT COUNT(*) AS n FROM __drizzle_migrations').get() as { n: number }
+    ).n;
+    const deleteInfo = raw
+      .prepare(
+        "DELETE FROM __drizzle_migrations WHERE created_at = (SELECT MAX(created_at) FROM __drizzle_migrations)"
+      )
+      .run();
+    expect(deleteInfo.changes).toBeGreaterThan(0);
+    const afterRows = (
+      raw.prepare('SELECT COUNT(*) AS n FROM __drizzle_migrations').get() as { n: number }
+    ).n;
+    raw.close();
+    expect(afterRows).toBeLessThan(beforeRows);
+
+    expect(() => {
+      const reopened = openFinanceDb(path);
+      try {
+        const txn = reopened.raw
+          .prepare('SELECT id FROM transactions WHERE id = ?')
+          .get('legacy-1') as { id: string } | undefined;
+        expect(txn?.id).toBe('legacy-1');
+        const tables = listTables(reopened.raw);
+        expect(tables).toContain('transactions');
+        expect(tables).toContain('transaction_tag_rules');
+        expect(tables).toContain('tag_vocabulary');
+      } finally {
+        reopened.raw.close();
+      }
+    }).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
Add `0054_finance_pillar_baseline_extension.sql` to `packages/finance-db/migrations/` creating the three finance-owned tables missing from the 0053 baseline: `transactions`, `transaction_tag_rules`, `tag_vocabulary`. Uses CREATE TABLE / INDEX IF NOT EXISTS for idempotency against existing finance.db files.

## Why this is urgent
- #2908 (N4 transaction_tag_rules cutover) is on `main`; on next prod boot, all `transaction_tag_rules.*` calls throw `no such table` against `getFinanceDrizzle()`.
- #2903 (N2 transactions), #2906 (N5 tag_vocabulary), #2902 (N6 imports) are blocked on this PR.

## Test plan
- [x] `pnpm -F @pops/finance-db run test` — new table-existence + FK + idempotency suites green (201 tests pass)
- [x] `pnpm -F @pops/api run test` — full suite green (4875 tests pass)
- [x] Drift-guard CI: no sibling under `apps/pops-api/src/db/drizzle-migrations/` — finance entries were retired from the shared journal under Track L2 (#2861), so the package journal is the sole source of truth.
- [x] Boot a `finance.db` against the package locally and verify the new tables exist (covered by `baseline-extension.test.ts`).
