### PR TITLE
feat(inventory-db): backfill missing idx_locations_parent_sort from shared journal

### DIFF
--- a/apps/pops-api/src/db/per-pillar-migrations.test.ts
+++ b/apps/pops-api/src/db/per-pillar-migrations.test.ts
@@ -206,9 +206,11 @@ describe('runPerPillarMigrations', () => {
     // (core pillar Phase 1 PR 2); `media` owns `packages/media-db/migrations/`
     // with 0021_spooky_lockheed (media pillar Phase 1 PR 2); `inventory`
     // owns `packages/inventory-db/migrations/` with 0005_fancy_crystal
-    // (inventory pillar Phase 1 PR 2) AND 0006_inventory_pillar_baseline
+    // (inventory pillar Phase 1 PR 2), 0006_inventory_pillar_baseline
     // (inventory pillar Phase 2 PR 3 — comprehensive home_inventory +
-    // fixtures + item_* baseline ahead of the cutover); `cerebrum` owns
+    // fixtures + item_* baseline ahead of the cutover), AND
+    // 0007_locations_parent_sort_index (#2917 — backfill missing index
+    // carried over from shared journal 0009_red_quasimodo); `cerebrum` owns
     // `packages/cerebrum-db/migrations/` with 0039_dry_fabian_cortez and
     // 0044_nudge_log (cerebrum pillar Phase 1 PR 2 — nudge_log slice).
     // Pillars without their own journal yet still skip cleanly.
@@ -224,6 +226,7 @@ describe('runPerPillarMigrations', () => {
       expect([...result.applied].toSorted()).toEqual([
         '0005_fancy_crystal',
         '0006_inventory_pillar_baseline',
+        '0007_locations_parent_sort_index',
         '0021_spooky_lockheed',
         '0039_dry_fabian_cortez',
         '0044_nudge_log',

--- a/packages/inventory-db/migrations/0007_locations_parent_sort_index.sql
+++ b/packages/inventory-db/migrations/0007_locations_parent_sort_index.sql
@@ -1,0 +1,5 @@
+-- Inventory pillar — backfill missing index from shared journal 0009_red_quasimodo.
+-- The shared journal added this composite index on locations(parent_id, sort_order)
+-- to accelerate the tree-listing query; the inventory baseline (0006) missed it.
+-- Surfaced by the Q1 schema-coverage CI (#2917).
+CREATE INDEX IF NOT EXISTS `idx_locations_parent_sort` ON `locations` (`parent_id`,`sort_order`);

--- a/packages/inventory-db/migrations/meta/_journal.json
+++ b/packages/inventory-db/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1781650200000,
       "tag": "0006_inventory_pillar_baseline",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1781650200001,
+      "tag": "0007_locations_parent_sort_index",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/check-pillar-schema-coverage.mjs
+++ b/scripts/check-pillar-schema-coverage.mjs
@@ -58,9 +58,7 @@ const PILLARS = /** @type {const} */ ([
  *
  * @type {Record<string, Set<string>>}
  */
-const ALLOWLISTED_MISSING_INDEXES = {
-  inventory: new Set(['locations:idx_locations_parent_sort']),
-};
+const ALLOWLISTED_MISSING_INDEXES = {};
 
 /**
  * Pre-existing missing tables — only as a transitional grandfather while


### PR DESCRIPTION
## Summary

- Adds inventory migration `0007_locations_parent_sort_index` to backfill the composite `idx_locations_parent_sort` index on `locations(parent_id, sort_order)`. The index was introduced by the shared journal's `0009_red_quasimodo` migration but was never carried over when the inventory pillar baseline (`0006_inventory_pillar_baseline`) was authored.
- Uses `CREATE INDEX IF NOT EXISTS` so the migration is idempotent against any existing on-disk `inventory.db` that already received the index from the shared journal in production.
- Closes out the allowlist entry for `locations:idx_locations_parent_sort` in `scripts/check-pillar-schema-coverage.mjs` (and updates the `per-pillar-migrations` "real repo root" test to expect the new tag).

## Why

The Q1 schema-coverage CI (#2917) was added precisely to catch this kind of drift between the drizzle schema in `@pops/db-types` and the per-pillar migration journals. The inventory entry has been allowlisted as the known-good baseline; this PR is the follow-up that closes it out and re-arms the guard for future drift.

## Test plan

- [x] `pnpm -F @pops/inventory-db run typecheck`
- [x] `pnpm -F @pops/inventory-db run test` (36 tests pass)
- [x] `pnpm -F @pops/api run typecheck`
- [x] `pnpm -F @pops/api run test` (4876 tests pass)
- [x] `node scripts/check-pillar-schema-coverage.mjs --pillar inventory` exits 0 with no allowlist
- [x] `node scripts/check-pillar-schema-coverage.mjs --all` exits 0 across every pillar
- [x] `pnpm format:check`
- [x] `pnpm typecheck` (full monorepo, 51 successful tasks)
