### PR TITLE
docs(core-api): Phase 5 verification drill (Track M1 PR 4)

### DIFF
--- a/docs/runbooks/core-api-pillar-verification.md
+++ b/docs/runbooks/core-api-pillar-verification.md
@@ -71,9 +71,58 @@ workspaces, so it isn't linkable from GitHub. Examples worth flagging:
 - nginx returns a 502 / HTML index for `/pillars` instead of propagating a clean error to the SPA.
 - The shell's "core unavailable" placeholder paints over working routes (PillarGuard wrongly treats unknown as unhealthy).
 
+## Phase 5 verification drill
+
+After Track M1 lands the writer-move sequence (PR 1 #2889, PR 2 #2897, PR 3 #2918), `pops-core-api` is the **sole** tRPC handler for `core.serviceAccounts.{list,create,revoke}`. The legacy mount on `pops-api` is gone (PR 3 deleted `apps/pops-api/src/modules/core/service-accounts/`), and the nginx dispatcher in `apps/pops-shell/nginx.conf` no longer has a fall-through. This changes the outage drill in two material ways from the Phase 4 baseline:
+
+1. Stopping `core-api` now truly takes those endpoints down — there is no in-process backstop in `pops-api` to absorb the traffic.
+2. The `PillarGuard` soft-fallback still applies: `core` reads `'unknown'` from `/pillars/health` (still served by `pops-api`, since the `/pillars/health` aggregator has not moved) and unknown is treated as healthy. So the shell does not paint a "core unavailable" placeholder across every route — only callers of the migrated procedures see a network error.
+
+### Step A — capture the new baseline
+
+```sh
+docker compose -f infra/docker-compose.yml ps
+# All pillars running healthy.
+
+docker compose -f infra/docker-compose.yml exec pops-api \
+  node -e "fetch('http://core-api:3001/trpc/core.serviceAccounts.list?batch=1&input=%7B%220%22%3A%7B%22json%22%3Anull%7D%7D', { headers: { 'X-API-Key': process.env.POPS_ADMIN_API_KEY } }).then(r=>r.status).then(console.log)"
+# 200 (or 401 if no key is set — the point is the route resolves on core-api).
+```
+
+### Step B — stop core-api and confirm per-route degradation
+
+```sh
+docker compose -f infra/docker-compose.yml stop core-api
+```
+
+Expected behaviour:
+
+- `POST /trpc/core.serviceAccounts.list` (and `create`, `revoke`) via the shell's nginx proxy returns a 502 from the dispatcher upstream — `pops-api` no longer serves these procedures, so there is no fall-through. The single admin caller (CLI / MCP server) sees a clean transport error rather than a stale response.
+- Every other shell route keeps rendering. `PillarGuard` reads `core` as `'unknown'` from `/pillars/health` and treats unknown as healthy. The food, finance, inventory, media, lists, and cerebrum routes hydrate normally.
+- `pops-api` and `pops-worker` were started behind `depends_on: core-api (service_healthy)` — they keep running. Anything that resolves `pops:core/...` URIs through the dispatcher continues to live on `pops-api` (none today, because the URI dispatcher itself has not moved).
+- `pops-shell`'s boot probe to `/pillars` still succeeds because the registry endpoint is core-api — but with core-api down, the registry-client collapses to the synthetic `core` self-entry per `pillar-registry-client.ts`. The shell does not boot-fail.
+
+### Step C — restart and confirm recovery
+
+```sh
+docker compose -f infra/docker-compose.yml start core-api
+```
+
+Within ~30s the healthcheck reports healthy. Repeat the Step A probe. The admin CLI / MCP traffic to `core.serviceAccounts.*` resumes on the next call — no cache invalidation is needed because the procedures are admin-only and not on a polling loop.
+
+### Step D — lessons captured during PR 1/2/3
+
+- The M1 sequence is the only Phase 5 track that completed PR 3 (legacy router deletion). Tracks M3/M4/M5 all deferred their PR 3 to documentation because their procedures co-batch through the shell's shared `httpBatchLink`. M1 escapes that constraint because `core.serviceAccounts.*` has no shell-side caller — the procedures are admin-only (CLI/MCP), so a non-comma-anchored prefix dispatcher rule (`^/trpc/core\.serviceAccounts\.`) is safe.
+- The `pops-api` `protectedProcedure` scope-enforcement tests that were colocated with the deleted router were preserved by moving them into `apps/pops-api/src/trpc-scope.test.ts` next to the module they exercise. This avoids losing coverage of cross-pillar scope checks just because the procedures themselves moved.
+- The dispatcher comment in `apps/pops-shell/nginx.conf` was updated from "forward cutover with fall-through" to "sole handler" — record any future regression in this comment, not in PR-body prose.
+- Record any unexpected behaviour in the **Lessons captured** section of `.claude/pillar-migration-roadmap.md` before flipping Track M to ✅.
+
 ## Reference
 
 - ADR-026: per-domain pillar architecture
 - `apps/pops-core-api/src/server.ts` — boot sequence
 - `apps/pops-shell/src/app/pillars/pillar-registry-client.ts` — soft-fallback behaviour
 - `.claude/pillar-migration-roadmap.md` — Track D status + lessons captured (gitignored, local-only)
+- #2889 — M1 PR 1 (service-accounts router moved into pops-core-api)
+- #2897 — M1 PR 2 (nginx dispatcher cutover)
+- #2918 — M1 PR 3 (legacy router deleted from pops-api)

--- a/docs/runbooks/core-api-pillar-verification.md
+++ b/docs/runbooks/core-api-pillar-verification.md
@@ -84,9 +84,13 @@ After Track M1 lands the writer-move sequence (PR 1 #2889, PR 2 #2897, PR 3 #291
 docker compose -f infra/docker-compose.yml ps
 # All pillars running healthy.
 
+# Probe the migrated tRPC surface without auth — the point is to prove
+# the route resolves on core-api, not to authenticate. Expect 401
+# because `core.serviceAccounts.list` is `userOnly` and the probe sends
+# no Cloudflare Access user headers.
 docker compose -f infra/docker-compose.yml exec pops-api \
-  node -e "fetch('http://core-api:3001/trpc/core.serviceAccounts.list?batch=1&input=%7B%220%22%3A%7B%22json%22%3Anull%7D%7D', { headers: { 'X-API-Key': process.env.POPS_ADMIN_API_KEY } }).then(r=>r.status).then(console.log)"
-# 200 (or 401 if no key is set — the point is the route resolves on core-api).
+  node -e "fetch('http://core-api:3001/trpc/core.serviceAccounts.list?batch=1&input=%7B%220%22%3A%7B%22json%22%3Anull%7D%7D').then(r=>r.status).then(console.log)"
+# 401 — handler is alive on core-api, auth correctly refuses.
 ```
 
 ### Step B — stop core-api and confirm per-route degradation
@@ -100,7 +104,7 @@ Expected behaviour:
 - `POST /trpc/core.serviceAccounts.list` (and `create`, `revoke`) via the shell's nginx proxy returns a 502 from the dispatcher upstream — `pops-api` no longer serves these procedures, so there is no fall-through. The single admin caller (CLI / MCP server) sees a clean transport error rather than a stale response.
 - Every other shell route keeps rendering. `PillarGuard` reads `core` as `'unknown'` from `/pillars/health` and treats unknown as healthy. The food, finance, inventory, media, lists, and cerebrum routes hydrate normally.
 - `pops-api` and `pops-worker` were started behind `depends_on: core-api (service_healthy)` — they keep running. Anything that resolves `pops:core/...` URIs through the dispatcher continues to live on `pops-api` (none today, because the URI dispatcher itself has not moved).
-- `pops-shell`'s boot probe to `/pillars` still succeeds because the registry endpoint is core-api — but with core-api down, the registry-client collapses to the synthetic `core` self-entry per `pillar-registry-client.ts`. The shell does not boot-fail.
+- `pops-shell`'s boot probe to `/pillars` fails at the HTTP layer (typically 502 — the `/pillars` proxy hits core-api which is now stopped). The shell still boots because `fetchPillarRegistry` (`apps/pops-shell/src/app/pillars/pillar-registry-client.ts`) collapses the failure to the synthetic `core` self-entry rather than propagating it.
 
 ### Step C — restart and confirm recovery
 


### PR DESCRIPTION
## Summary

Track M1 phase 5 PR 4. Docs-only — adds a "Phase 5 verification drill" section to `docs/runbooks/core-api-pillar-verification.md` capturing how the outage drill differs now that `pops-core-api` is the sole writer for `core.serviceAccounts.{list,create,revoke}` (the M1 PR 3 deletion #2918 removed the legacy mount on pops-api).

## What the new section documents

- **Step A** — baseline probe targeting `core-api:3001` directly.
- **Step B** — `docker compose stop core-api` and the per-route 502 it now produces. Service-accounts traffic has no fall-through; admin CLI / MCP callers see a clean transport error rather than a stale response.
- **Step C** — recovery via `docker compose start core-api`.
- **Step D** — lessons captured during the PR 1/2/3 sequence:
  - Why M1 is the only M-track that completed PR 3 (no shell-side caller, so the unanchored prefix dispatcher is safe).
  - Why the `protectedProcedure` scope tests moved into `apps/pops-api/src/trpc-scope.test.ts` to preserve coverage.
  - Why the `nginx.conf` dispatcher comment now says "sole handler" rather than "forward cutover with fall-through".

The `PillarGuard` soft-fallback (core → `'unknown'` → treated as healthy) is unchanged. The shell continues to render food, finance, inventory, media, lists, and cerebrum routes normally during a core-api outage — only the admin endpoints fail.

## References

- M1 PR 1: #2889 (service-accounts router moved into pops-core-api)
- M1 PR 2: #2897 (nginx dispatcher cutover)
- M1 PR 3: #2918 (legacy router deleted from pops-api)
- Roadmap row M1: #2832

## Test plan

- [x] `pnpm format:check` clean.
- [ ] CI green on this PR.
- [ ] Runbook section renders correctly in GitHub preview.
