### PR TITLE
docs(inventory-api): Phase 5 verification drill (Track M4 PR 4)

### DIFF
--- a/docs/runbooks/inventory-api-pillar-verification.md
+++ b/docs/runbooks/inventory-api-pillar-verification.md
@@ -129,8 +129,13 @@ docker compose -f infra/docker-compose.yml exec pops-api \
   node -e "fetch('http://inventory-api:3002/health').then(r=>r.json()).then(j=>console.log(JSON.stringify(j)))"
 # {"ok":true,"pillar":"inventory","version":"<git-sha>"}
 
-# Single-procedure URL through the dispatcher — should land on inventory-api:
-curl -sS -o /dev/null -w "%{http_code}\n" "http://localhost:80/trpc/inventory.locations.tree?batch=1&input=%7B%220%22%3A%7B%22json%22%3Anull%7D%7D"
+# Single-procedure URL through the dispatcher — should land on inventory-api.
+# pops-shell only exposes port 80 inside the frontend network, so run
+# the probe through `docker compose exec` against a sibling on that
+# network. httpBatchLink uses GET for queries, so the probe is a GET
+# with URL-encoded input.
+docker compose -f infra/docker-compose.yml exec pops-api \
+  node -e "fetch('http://pops-shell/trpc/inventory.locations.tree?batch=1&input=%7B%220%22%3A%7B%22json%22%3Anull%7D%7D').then(r=>r.status).then(console.log)"
 # 200 (or 401 without auth — the route resolves on inventory-api).
 ```
 
@@ -142,8 +147,8 @@ docker compose -f infra/docker-compose.yml stop inventory-api
 
 Expected behaviour:
 
-- **Single-procedure** `POST /trpc/inventory.locations.*` URLs return 502 from the dispatcher upstream. Re-run the curl probe in Step A — it should now fail with a 502.
-- **Batched** `POST /trpc/inventory.locations.tree,inventory.items.distinctTypes,...` URLs continue to succeed because they fall through to the legacy `locationsRouter` on pops-api, which keeps reading `inventory.db` via `getInventoryDrizzle()` against the shared volume. This is the load-bearing behaviour of the dispatcher's `[^,]+$` anchor — it is what keeps the shell hydrated during an inventory-api outage.
+- **Single-procedure** `GET /trpc/inventory.locations.*` URLs return 502 from the dispatcher upstream. Re-run the Step A probe — it should now fail with a 502. (`httpBatchLink` uses GET for queries; mutations are POST and follow the same routing.)
+- **Batched** `GET /trpc/inventory.locations.tree,inventory.items.distinctTypes,...` URLs continue to succeed because they fall through to the legacy `locationsRouter` on pops-api, which keeps reading `inventory.db` via `getInventoryDrizzle()` against the shared volume. This is the load-bearing behaviour of the dispatcher's `[^,]+$` anchor — it is what keeps the shell hydrated during an inventory-api outage.
 - The shell's `/pillars/health` aggregator (still on pops-api) flips inventory's status to `'unavailable'` after the per-probe timeout fires. `PillarGuard` reads `'unavailable'` and shows the unavailable placeholder on inventory routes; other pillars (food, finance, media, lists, cerebrum, core) keep working — degrade per-route, not whole-shell.
 - The shell's boot probe to `/pillars` still succeeds because the proxy hits core-api, not inventory-api.
 

--- a/docs/runbooks/inventory-api-pillar-verification.md
+++ b/docs/runbooks/inventory-api-pillar-verification.md
@@ -110,6 +110,59 @@ Option 1 is the planned path. Until then, `pops-api` keeps `locationsRouter` mou
 
 A single `httpBatchLink` plus a regex-dispatcher pattern can only retire a router slice when **every co-existing slice in the same `AppRouter` has also moved**. Plan migrations in whole-namespace units, not per-subrouter, or accept the legacy mount living on indefinitely.
 
+## Phase 5 verification drill
+
+After Track M4 lands the writer-move sequence (PR 1 #2891, PR 2 #2896, PR 3 #2900), `pops-inventory-api` is the tRPC handler for **single-procedure** `inventory.locations.*` URLs only. Batched URLs (the common case from `useItemsPageModel.ts`, `useItemFormPageModel.ts`, `useReportModel.ts`, `useLocationTreePageModel.ts`) still fall through to the legacy `locationsRouter` mount on `pops-api`. PR 3 was deferred to docs (#2900) for exactly this reason.
+
+This changes the outage drill in two material ways from the Phase 4 baseline:
+
+1. Stopping `inventory-api` now genuinely 502s any **single-procedure** `/trpc/inventory.locations.*` URL that lands on the dispatcher upstream. The shell rarely emits these in practice (sibling queries co-batch), so the visible impact is small — but admin / curl / MCP probes that hit a single-procedure URL will fail.
+2. Every **batched** `/trpc/inventory.locations.*,...` URL still resolves on `pops-api` against `inventory.db` via the shared volume mount. So the bulk of shell traffic keeps working even with inventory-api down — and the data layer is genuinely still up because `pops-api` opens its own handle on `inventory.db`. The drill is therefore **partial-cutover only**; full data-layer isolation requires Option 1 from the PR 3 deferral (migrate the rest of `inventoryRouter` subrouters, then route the whole `^/trpc/inventory\.` namespace and delete the legacy mount).
+
+### Step A — capture the new baseline
+
+```sh
+docker compose -f infra/docker-compose.yml ps
+# inventory-api running healthy.
+
+docker compose -f infra/docker-compose.yml exec pops-api \
+  node -e "fetch('http://inventory-api:3002/health').then(r=>r.json()).then(j=>console.log(JSON.stringify(j)))"
+# {"ok":true,"pillar":"inventory","version":"<git-sha>"}
+
+# Single-procedure URL through the dispatcher — should land on inventory-api:
+curl -sS -o /dev/null -w "%{http_code}\n" "http://localhost:80/trpc/inventory.locations.tree?batch=1&input=%7B%220%22%3A%7B%22json%22%3Anull%7D%7D"
+# 200 (or 401 without auth — the route resolves on inventory-api).
+```
+
+### Step B — stop inventory-api and confirm split degradation
+
+```sh
+docker compose -f infra/docker-compose.yml stop inventory-api
+```
+
+Expected behaviour:
+
+- **Single-procedure** `POST /trpc/inventory.locations.*` URLs return 502 from the dispatcher upstream. Re-run the curl probe in Step A — it should now fail with a 502.
+- **Batched** `POST /trpc/inventory.locations.tree,inventory.items.distinctTypes,...` URLs continue to succeed because they fall through to the legacy `locationsRouter` on pops-api, which keeps reading `inventory.db` via `getInventoryDrizzle()` against the shared volume. This is the load-bearing behaviour of the dispatcher's `[^,]+$` anchor — it is what keeps the shell hydrated during an inventory-api outage.
+- The shell's `/pillars/health` aggregator (still on pops-api) flips inventory's status to `'unavailable'` after the per-probe timeout fires. `PillarGuard` reads `'unavailable'` and shows the unavailable placeholder on inventory routes; other pillars (food, finance, media, lists, cerebrum, core) keep working — degrade per-route, not whole-shell.
+- The shell's boot probe to `/pillars` still succeeds because the proxy hits core-api, not inventory-api.
+
+### Step C — restart and confirm recovery
+
+```sh
+docker compose -f infra/docker-compose.yml start inventory-api
+```
+
+Within ~30s the healthcheck reports healthy. Re-run the Step A curl probe — single-procedure URLs route to inventory-api again. `PillarGuard` re-promotes inventory from `'unavailable'` back to `'healthy'` on the next status-context refresh; the inventory UI hydrates without a hard navigation.
+
+### Step D — lessons captured during PR 1/2/3
+
+- M4 is the canonical example of why PR 3 deletion is unsafe under a single shared `httpBatchLink`. The shell's inventory pages co-batch `locations.*` with sibling subrouter queries (`items.*`, `reports.*`, `connections.*`, `documents.*`, `documentFiles.*`, `paperless.*`, `fixtures.*`, `photos.*`) from the same render cycle, and the dispatcher's `[^,]+$` anchor refuses batched URLs by design. Deleting the legacy `locationsRouter` from pops-api would 404 every batched URL that includes a locations call.
+- The unblock path is Option 1 from the PR 3 deferral: migrate the rest of `inventoryRouter` into `pops-inventory-api`, then broaden the dispatcher to `^/trpc/inventory\.` and delete the legacy mount in one go. Option 2 (`splitLink` / per-router transports) is less invasive but still adds link-aware batching and a separate dispatcher prefix. Option 3 (force locations into a separate React tick) is rejected as brittle.
+- The dispatcher comment in `apps/pops-shell/nginx.conf` (lines 30-72) documents the trade-off in-place. Keep it in sync with any future cutover.
+- The data-layer caveat is the same as M3's: stopping inventory-api is not a true outage of `inventory.db` while pops-api still opens its own handle on the shared volume. This is the bridging cost of a partial cutover.
+- Record any unexpected behaviour in the **Lessons captured** section of `.claude/pillar-migration-roadmap.md` before flipping Track M to ✅.
+
 ## Reference
 
 - ADR-026: per-domain pillar architecture
@@ -119,3 +172,6 @@ A single `httpBatchLink` plus a regex-dispatcher pattern can only retire a route
 - `packages/api-client/src/index.ts` — shared `httpBatchLink` setup
 - `docs/runbooks/core-api-pillar-verification.md` — sibling runbook for the core pillar
 - `.claude/pillar-migration-roadmap.md` — Track G status + lessons captured (gitignored, local-only)
+- #2891 — M4 PR 1 (locations router moved into pops-inventory-api)
+- #2896 — M4 PR 2 (nginx dispatcher cutover, `[^,]+$`-anchored)
+- #2900 — M4 PR 3 (docs-only deferral)


### PR DESCRIPTION
## Summary

Track M4 phase 5 PR 4. Docs-only — adds a "Phase 5 verification drill" section to `docs/runbooks/inventory-api-pillar-verification.md` capturing the split-degradation behaviour now that `pops-inventory-api` handles single-procedure `inventory.locations.*` URLs while the legacy `locationsRouter` on pops-api still serves every batched URL. PR 3 (#2900) deferred the legacy delete to documentation for the batching reason.

## What the new section documents

- **Step A** — baseline probe targeting `inventory-api:3002` directly + a single-procedure URL through the dispatcher.
- **Step B** — `docker compose stop inventory-api` and the split degradation: single-procedure URLs 502, batched URLs (the common shell case) keep working through the pops-api fall-through. The `[^,]+$` anchor is what makes the drill non-catastrophic.
- **Step C** — recovery via `docker compose start inventory-api`.
- **Step D** — lessons captured during PR 1/2/3:
  - Why the legacy `locationsRouter` cannot be deleted while the shell co-batches `locations.*` with sibling subrouter queries (`items.*`, `reports.*`, `connections.*`, `documents.*`, `documentFiles.*`, `paperless.*`, `fixtures.*`, `photos.*`).
  - The three unblock paths (whole-namespace migration, `splitLink`, separate React ticks — only the first is acceptable).
  - The data-layer caveat shared with M3.

`PillarGuard` continues to flip inventory to `'unavailable'` on outage and show the placeholder on inventory routes only — other pillars hydrate normally.

## References

- M4 PR 1: #2891 (locations router moved into pops-inventory-api)
- M4 PR 2: #2896 (nginx dispatcher cutover, `[^,]+$`-anchored)
- M4 PR 3: #2900 (docs-only deferral)
- Roadmap row M4: #2835

## Test plan

- [x] `pnpm format:check` clean (oxfmt --check on the file).
- [ ] CI green on this PR.
- [ ] Runbook section renders correctly in GitHub preview.
