### PR TITLE
ci(schema-coverage): repair self-test with synthetic mismatch injection

### DIFF
--- a/.github/workflows/pillar-schema-coverage.yml
+++ b/.github/workflows/pillar-schema-coverage.yml
@@ -49,7 +49,7 @@ jobs:
         run: node scripts/check-pillar-schema-coverage.mjs --pillar ${{ matrix.pillar }}
 
   selftest:
-    name: Self-test (allowlist-bypass catches latent finance break)
+    name: Self-test (script catches injected missing table)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -63,23 +63,16 @@ jobs:
         run: |
           pnpm --filter @pops/db-types build
           pnpm --filter @pops/finance-db build
-      - name: Assert --ignore-allowlist flags the known finance gap
+      - name: Self-test (script catches injected missing table)
         run: |
           set +e
           node scripts/check-pillar-schema-coverage.mjs \
-            --pillar finance --ignore-allowlist > out.txt 2>&1
-          actual_exit=$?
-          cat out.txt
+            --pillar finance --inject-fake-table finance:fake_self_test_table 2>&1 | tee out.log
+          actual_exit=${PIPESTATUS[0]}
           if [ "$actual_exit" -eq 0 ]; then
-            echo "::error::expected non-zero exit when --ignore-allowlist is set against current main; got 0"
+            echo "::error::Self-test failed: script exited 0 with an injected fake table"
             exit 1
           fi
-          if ! grep -q "Missing tables" out.txt; then
-            echo "::error::expected output to mention 'Missing tables'"
-            exit 1
-          fi
-          if ! grep -q "transactions" out.txt; then
-            echo "::error::expected output to mention the transactions table"
-            exit 1
-          fi
-          echo "selftest OK — guard catches the latent finance break."
+          grep -q "fake_self_test_table" out.log || { echo "::error::Self-test failed: script did not flag injected fake table"; exit 1; }
+          grep -q "Missing tables" out.log || { echo "::error::Self-test failed: script did not produce 'Missing tables' message"; exit 1; }
+          echo "Self-test passed: script correctly catches injected missing tables"

--- a/scripts/check-pillar-schema-coverage.mjs
+++ b/scripts/check-pillar-schema-coverage.mjs
@@ -23,6 +23,7 @@
  *   node scripts/check-pillar-schema-coverage.mjs --pillar finance
  *   node scripts/check-pillar-schema-coverage.mjs --all
  *   node scripts/check-pillar-schema-coverage.mjs --pillar finance --ignore-allowlist
+ *   node scripts/check-pillar-schema-coverage.mjs --pillar finance --inject-fake-table finance:fake_table
  *
  * Exit code 0 on full coverage (or allowlisted). Non-zero on any miss.
  * Non-zero on usage errors.
@@ -68,14 +69,7 @@ const ALLOWLISTED_MISSING_INDEXES = {};
  *
  * @type {Record<string, Set<string>>}
  */
-const ALLOWLISTED_MISSING_TABLES = {
-  // #2915 (feat(finance-db): extend pillar baseline …) adds the
-  // `transactions` table to the package journal. Until #2915 lands the
-  // runtime break documented in #2912 is still latent on main. This
-  // guard exists precisely to prevent the next instance — close out by
-  // removing this entry once #2915 merges.
-  finance: new Set(['transactions']),
-};
+const ALLOWLISTED_MISSING_TABLES = {};
 
 /**
  * Walk every file under `dir` recursively and return absolute paths
@@ -456,17 +450,29 @@ function diff(raw, usedSymbols, symbolToTable) {
  *
  * @param {typeof PILLARS[number]} pillar
  * @param {Map<string, { tableName: string; indexNames: string[] }>} symbolToTable
- * @param {{ ignoreAllowlist?: boolean }} [options]
+ * @param {{ ignoreAllowlist?: boolean; injectFakeTables?: string[] }} [options]
  * @returns {Promise<boolean>}
  */
 async function checkPillar(pillar, symbolToTable, options = {}) {
   const ignoreAllowlist = options.ignoreAllowlist === true;
+  const injectFakeTables = options.injectFakeTables ?? [];
   const pkgRoot = join(repoRoot, 'packages', pillar.pkg);
   if (!existsSync(pkgRoot)) {
     console.error(`[${pillar.name}] package not found at ${pkgRoot}`);
     return false;
   }
   const used = collectUsedTableSymbols(pkgRoot, symbolToTable);
+
+  for (const fakeTable of injectFakeTables) {
+    const fakeSymbol = `__injected_${fakeTable}`;
+    symbolToTable.set(fakeSymbol, {
+      tableName: fakeTable,
+      indexNames: [],
+      sourceFile: '<injected>',
+    });
+    used.add(fakeSymbol);
+    console.log(`[${pillar.name}] injected fake expected table: ${fakeTable}`);
+  }
 
   console.log(`[${pillar.name}] inspecting ${used.size} table symbol(s)`);
   if (used.size === 0) {
@@ -541,39 +547,59 @@ async function checkPillar(pillar, symbolToTable, options = {}) {
 
 /**
  * @param {string[]} argv
- * @returns {{ pillars: typeof PILLARS[number][]; help: boolean; ignoreAllowlist: boolean }}
+ * @returns {{ pillars: typeof PILLARS[number][]; help: boolean; ignoreAllowlist: boolean; injections: Map<string, string[]> }}
  */
 function parseArgs(argv) {
   let pillar = '';
   let all = false;
   let help = false;
   let ignoreAllowlist = false;
+  /**
+   * Synthetic injections used by the self-test job. The CI workflow asks
+   * the script to expect a table that the pillar's migrations do NOT
+   * create — proving the guard still catches missing tables without
+   * relying on a real prod-state mismatch. Format: `<pillar>:<table>`.
+   *
+   * @type {Map<string, string[]>}
+   */
+  const injections = new Map();
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
     if (arg === '--pillar') pillar = argv[++i] ?? '';
     else if (arg === '--all') all = true;
     else if (arg === '--help' || arg === '-h') help = true;
     else if (arg === '--ignore-allowlist') ignoreAllowlist = true;
-    else {
+    else if (arg === '--inject-fake-table') {
+      const spec = argv[++i] ?? '';
+      const [injPillar, injTable] = spec.split(':');
+      if (!injPillar || !injTable) {
+        console.error(`--inject-fake-table requires <pillar>:<table>, got: ${spec}`);
+        help = true;
+        continue;
+      }
+      const list = injections.get(injPillar) ?? [];
+      list.push(injTable);
+      injections.set(injPillar, list);
+    } else {
       console.error(`unknown arg: ${arg}`);
       help = true;
     }
   }
-  if (help) return { pillars: [], help: true, ignoreAllowlist };
-  if (all) return { pillars: [...PILLARS], help: false, ignoreAllowlist };
-  if (!pillar) return { pillars: [...PILLARS], help: false, ignoreAllowlist };
+  if (help) return { pillars: [], help: true, ignoreAllowlist, injections };
+  if (all) return { pillars: [...PILLARS], help: false, ignoreAllowlist, injections };
+  if (!pillar) return { pillars: [...PILLARS], help: false, ignoreAllowlist, injections };
   const match = PILLARS.find((p) => p.name === pillar);
   if (!match) {
     console.error(`unknown pillar: ${pillar}. Known: ${PILLARS.map((p) => p.name).join(', ')}`);
-    return { pillars: [], help: true, ignoreAllowlist };
+    return { pillars: [], help: true, ignoreAllowlist, injections };
   }
-  return { pillars: [match], help: false, ignoreAllowlist };
+  return { pillars: [match], help: false, ignoreAllowlist, injections };
 }
 
 function usage() {
   console.log(
     [
-      'Usage: node scripts/check-pillar-schema-coverage.mjs [--pillar <name>] [--all] [--ignore-allowlist]',
+      'Usage: node scripts/check-pillar-schema-coverage.mjs [--pillar <name>] [--all] [--ignore-allowlist] [--inject-fake-table <pillar>:<table>]',
       '',
       'Pillars: ' + PILLARS.map((p) => p.name).join(', '),
       '',
@@ -582,12 +608,17 @@ function usage() {
       '--ignore-allowlist disables the in-script grandfather list so the',
       'true diff (including known pre-existing drift) is reported. Use to',
       'verify a follow-up fix actually closes out an allowlisted entry.',
+      '',
+      '--inject-fake-table <pillar>:<table> tells the script to expect',
+      'a table that does NOT exist in the pillar migrations. Used by the',
+      'CI self-test to prove the guard still flags missing tables without',
+      'depending on a real prod-state mismatch. Repeatable.',
     ].join('\n')
   );
 }
 
 async function main() {
-  const { pillars, help, ignoreAllowlist } = parseArgs(process.argv.slice(2));
+  const { pillars, help, ignoreAllowlist, injections } = parseArgs(process.argv.slice(2));
   if (help) {
     usage();
     process.exit(2);
@@ -598,7 +629,10 @@ async function main() {
 
   let allOk = true;
   for (const pillar of pillars) {
-    const ok = await checkPillar(pillar, symbolToTable, { ignoreAllowlist });
+    const ok = await checkPillar(pillar, symbolToTable, {
+      ignoreAllowlist,
+      injectFakeTables: injections.get(pillar.name) ?? [],
+    });
     if (!ok) allOk = false;
   }
   process.exit(allOk ? 0 : 1);


### PR DESCRIPTION
## Summary

The Q1 schema-coverage self-test job in `.github/workflows/pillar-schema-coverage.yml` was wired to assert that running the script with `--ignore-allowlist --pillar finance` would still report the `transactions` table as missing. That assumption held only while the latent finance baseline gap was open.

After #2915 landed migration `0054_finance_pillar_baseline_extension.sql`, the pillar journal now creates `transactions` (and the rest of its cohort). Running the script with `--ignore-allowlist` correctly reports zero missing tables and exits 0 — but the self-test expects non-zero plus the literal `transactions` in the diff, so it fails on every PR (highlighted by #2923).

This PR decouples the self-test from real prod state and replaces it with a synthetic injection.

### Changes

- `scripts/check-pillar-schema-coverage.mjs`
  - New CLI flag `--inject-fake-table <pillar>:<table>`. Augments the script's expected-tables set with the supplied name without touching any allowlist. The pillar's migrations cannot create it, so the script reports it as missing and exits non-zero. Documented inline as a CI self-test mechanism.
  - Drop the now-stale `ALLOWLISTED_MISSING_TABLES.finance = { 'transactions' }` entry — #2915 closed that latent break and the allowlist comment explicitly said to remove the entry once that PR merged.
- `.github/workflows/pillar-schema-coverage.yml`
  - Self-test job now invokes the script with `--inject-fake-table finance:fake_self_test_table` and asserts the output contains both `Missing tables` and `fake_self_test_table`. Exit-code check uses `PIPESTATUS[0]` so `tee` does not mask the script's exit code.

### Why this design (Option A in the brief)

- **Decoupled from prod state**: the self-test no longer needs an open latent break to exercise the guard.
- **Stable**: every future allowlist close-out (like #2915 or #2923) won't break this job.
- **Honest**: a fake expected name is treated identically to a real missing table — the script's own diff path is exercised end-to-end.

### Local verification

```
node scripts/check-pillar-schema-coverage.mjs --pillar finance --inject-fake-table finance:fake_self_test_table
# Exits 1, reports 'Missing tables (1): - fake_self_test_table'

node scripts/check-pillar-schema-coverage.mjs --all
# Exits 0, all pillars OK
```

## Test plan

- [x] `pnpm format:check` — clean
- [x] `pnpm lint` — clean (exit 0)
- [x] `pnpm typecheck` — clean (exit 0)
- [x] Script with injection exits 1 and emits `Missing tables` + the fake name
- [x] Script with `--all` exits 0
- [ ] CI `Pillar Schema Coverage` workflow passes on this PR
- [ ] CI `selftest` job passes deterministically