### PR TITLE
fix(finance-db): flip applyChangeSet inner tx wrap to finance handle

### DIFF
--- a/apps/pops-api/src/modules/core/corrections/handlers/apply-corrections.ts
+++ b/apps/pops-api/src/modules/core/corrections/handlers/apply-corrections.ts
@@ -2,13 +2,13 @@ import { desc, eq } from 'drizzle-orm';
 
 import { transactionCorrections } from '@pops/db-types';
 
-import { getDrizzle } from '../../../../db.js';
+import { getFinanceDrizzle } from '../../../../db/finance-handle.js';
 import { NotFoundError } from '../../../../shared/errors.js';
 import { normalizeDescription } from '../types.js';
 
 import type { ChangeSet, ChangeSetOp, CorrectionRow } from '../types.js';
 
-type Tx = Parameters<Parameters<ReturnType<typeof getDrizzle>['transaction']>[0]>[0];
+type Tx = Parameters<Parameters<ReturnType<typeof getFinanceDrizzle>['transaction']>[0]>[0];
 
 function applyAddOp(tx: Tx, op: Extract<ChangeSetOp, { op: 'add' }>): void {
   tx.insert(transactionCorrections)
@@ -62,7 +62,7 @@ function applyMutatingOp(tx: Tx, op: Exclude<ChangeSetOp, { op: 'add' }>): void 
 }
 
 export function applyChangeSet(changeSet: ChangeSet): CorrectionRow[] {
-  const db = getDrizzle();
+  const db = getFinanceDrizzle();
 
   return db.transaction((tx) => {
     const order: Record<ChangeSetOp['op'], number> = { add: 1, edit: 2, disable: 3, remove: 4 };

--- a/apps/pops-api/src/modules/finance/imports/service.test.ts
+++ b/apps/pops-api/src/modules/finance/imports/service.test.ts
@@ -12,6 +12,7 @@ import { closeDb, setDb } from '../../../db.js';
 import { setFinanceDb } from '../../../db/finance-handle.js';
 import { createTestDb, seedEntity, seedTransaction } from '../../../shared/test-utils.js';
 import { clearCache } from '../../core/ai-usage/cache.js';
+import { normalizeDescription } from '../../core/corrections/types-base.js';
 import { getProgress, setProgress } from './progress-store.js';
 import {
   applyLearnedCorrection,
@@ -1271,58 +1272,68 @@ describe('commitImport — atomicity', () => {
   });
 
   it('rolls back applyChangeSet (correction add) when a later phase throws — proves shared finance.db tx', () => {
-    const tempEntityId = 'temp:entity:00000000-0000-0000-0000-0000000000bb';
-    const probePattern = 'CROSS_DB_TX_PROBE_PATTERN';
+    const financeRaw = createTestDb();
+    const prevFinance = setFinanceDb({ db: drizzle(financeRaw), raw: financeRaw });
 
-    const [correctionsBefore] = orm()
-      .select({ cnt: count() })
-      .from(transactionCorrections)
-      .where(eq(transactionCorrections.descriptionPattern, probePattern.toLowerCase()))
-      .all();
-    expect(correctionsBefore!.cnt).toBe(0);
+    try {
+      const probePattern = 'CROSS_DB_TX_PROBE_PATTERN';
+      const storedPattern = normalizeDescription(probePattern);
+      const financeOrm = drizzle(financeRaw);
 
-    expect(() =>
-      commitImport({
-        entities: [{ tempId: tempEntityId, name: 'CrossDbTxProbe', type: 'company' }],
-        changeSets: [
-          {
-            ops: [
-              {
-                op: 'add',
-                data: {
-                  descriptionPattern: probePattern,
-                  matchType: 'contains',
-                  entityId: tempEntityId,
-                  tags: [],
-                  confidence: 0.9,
-                  isActive: true,
+      const countCorrectionsIn = (handle: typeof financeOrm): number => {
+        const [row] = handle
+          .select({ cnt: count() })
+          .from(transactionCorrections)
+          .where(eq(transactionCorrections.descriptionPattern, storedPattern))
+          .all();
+        return row!.cnt;
+      };
+
+      expect(countCorrectionsIn(orm())).toBe(0);
+      expect(countCorrectionsIn(financeOrm)).toBe(0);
+
+      expect(() =>
+        commitImport({
+          entities: [],
+          changeSets: [
+            {
+              ops: [
+                {
+                  op: 'add',
+                  data: {
+                    descriptionPattern: probePattern,
+                    matchType: 'contains',
+                    entityId: null,
+                    tags: [],
+                    confidence: 0.9,
+                    isActive: true,
+                  },
                 },
-              },
-            ],
-          },
-        ],
-        tagRuleChangeSets: [
-          {
-            source: 'tag-edit-signal',
-            reason: 'force-failure-on-missing-tag-rule',
-            ops: [
-              {
-                op: 'edit',
-                id: 'tag-rule-that-does-not-exist',
-                data: { tags: ['boom'] },
-              },
-            ],
-          },
-        ],
-        transactions: [],
-      })
-    ).toThrow();
+              ],
+            },
+          ],
+          tagRuleChangeSets: [
+            {
+              source: 'tag-edit-signal',
+              reason: 'force-failure-on-missing-tag-rule',
+              ops: [
+                {
+                  op: 'edit',
+                  id: 'tag-rule-that-does-not-exist',
+                  data: { tags: ['boom'] },
+                },
+              ],
+            },
+          ],
+          transactions: [],
+        })
+      ).toThrow();
 
-    const [correctionsAfter] = orm()
-      .select({ cnt: count() })
-      .from(transactionCorrections)
-      .where(eq(transactionCorrections.descriptionPattern, probePattern.toLowerCase()))
-      .all();
-    expect(correctionsAfter!.cnt).toBe(0);
+      expect(countCorrectionsIn(orm())).toBe(0);
+      expect(countCorrectionsIn(financeOrm)).toBe(0);
+    } finally {
+      setFinanceDb(prevFinance);
+      financeRaw.close();
+    }
   });
 });

--- a/apps/pops-api/src/modules/finance/imports/service.test.ts
+++ b/apps/pops-api/src/modules/finance/imports/service.test.ts
@@ -1269,4 +1269,60 @@ describe('commitImport — atomicity', () => {
       .all();
     expect(afterTxns!.cnt).toBe(0);
   });
+
+  it('rolls back applyChangeSet (correction add) when a later phase throws — proves shared finance.db tx', () => {
+    const tempEntityId = 'temp:entity:00000000-0000-0000-0000-0000000000bb';
+    const probePattern = 'CROSS_DB_TX_PROBE_PATTERN';
+
+    const [correctionsBefore] = orm()
+      .select({ cnt: count() })
+      .from(transactionCorrections)
+      .where(eq(transactionCorrections.descriptionPattern, probePattern.toLowerCase()))
+      .all();
+    expect(correctionsBefore!.cnt).toBe(0);
+
+    expect(() =>
+      commitImport({
+        entities: [{ tempId: tempEntityId, name: 'CrossDbTxProbe', type: 'company' }],
+        changeSets: [
+          {
+            ops: [
+              {
+                op: 'add',
+                data: {
+                  descriptionPattern: probePattern,
+                  matchType: 'contains',
+                  entityId: tempEntityId,
+                  tags: [],
+                  confidence: 0.9,
+                  isActive: true,
+                },
+              },
+            ],
+          },
+        ],
+        tagRuleChangeSets: [
+          {
+            source: 'tag-edit-signal',
+            reason: 'force-failure-on-missing-tag-rule',
+            ops: [
+              {
+                op: 'edit',
+                id: 'tag-rule-that-does-not-exist',
+                data: { tags: ['boom'] },
+              },
+            ],
+          },
+        ],
+        transactions: [],
+      })
+    ).toThrow();
+
+    const [correctionsAfter] = orm()
+      .select({ cnt: count() })
+      .from(transactionCorrections)
+      .where(eq(transactionCorrections.descriptionPattern, probePattern.toLowerCase()))
+      .all();
+    expect(correctionsAfter!.cnt).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary

`applyChangeSet` (corrections) still opens its inner transaction via `getDrizzle()` (pops.db) while `commitImport` and the rest of the persistence pipeline runs on `getFinanceDrizzle()` (finance.db). After N3/N4 cutovers the `transaction_corrections` table lives in finance.db, so the inner tx targets the wrong file.

In tests both handles share the same raw connection, so nested savepoints work and atomicity holds. In prod they're different SQLite files — a failure in a later commitImport phase would leave correction writes committed on pops.db while everything else rolls back on finance.db, producing orphan rules.

`applyTagRuleChangeSet` already uses `getFinanceDrizzle()` (N4 phase 1 PR 3), so the fix is scoped to `applyChangeSet`.

## Changes

- `apps/pops-api/src/modules/core/corrections/handlers/apply-corrections.ts` — swap `getDrizzle()` → `getFinanceDrizzle()` for both the handle resolve and the `Tx` parameter type extraction.
- `apps/pops-api/src/modules/finance/imports/service.test.ts` — add an atomicity regression test that stages a correction add + a tag-rule edit on a non-existent rule, expects `commitImport` to throw, and asserts no correction rows persist for the probe pattern.

Closes #2921
References #2902 (Option A merge `947628ec`)

## Test plan

- [x] `pnpm -F @pops/api typecheck`
- [x] `pnpm lint`
- [x] `pnpm format:check`
- [x] `pnpm -F @pops/api test` — 4899/4899 pass
- [ ] CI green on PR
