### PR TITLE
feat(finance-api): move finance routers into pops-finance-api (Track M2 PR 1)

### DIFF
--- a/apps/pops-finance-api/Dockerfile
+++ b/apps/pops-finance-api/Dockerfile
@@ -7,6 +7,7 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json ./
 # Copy workspace package.json files (for dep resolution)
 COPY packages/db-types/package.json ./packages/db-types/
 COPY packages/types/package.json ./packages/types/
+COPY packages/core-db/package.json ./packages/core-db/
 COPY packages/finance-db/package.json ./packages/finance-db/
 COPY apps/pops-finance-api/package.json ./apps/pops-finance-api/
 
@@ -19,6 +20,9 @@ COPY packages/db-types/src ./packages/db-types/src
 COPY packages/db-types/tsconfig.json ./packages/db-types/
 COPY packages/types/src ./packages/types/src
 COPY packages/types/tsconfig.json packages/types/tsconfig.build.json ./packages/types/
+COPY packages/core-db/src ./packages/core-db/src
+COPY packages/core-db/tsconfig.json ./packages/core-db/
+COPY packages/core-db/migrations ./packages/core-db/migrations
 COPY packages/finance-db/src ./packages/finance-db/src
 COPY packages/finance-db/tsconfig.json ./packages/finance-db/
 COPY packages/finance-db/migrations ./packages/finance-db/migrations
@@ -31,6 +35,8 @@ COPY apps/pops-finance-api/src ./apps/pops-finance-api/src
 WORKDIR /app/packages/db-types
 RUN pnpm build
 WORKDIR /app/packages/types
+RUN pnpm build
+WORKDIR /app/packages/core-db
 RUN pnpm build
 WORKDIR /app/packages/finance-db
 RUN pnpm build

--- a/apps/pops-finance-api/package.json
+++ b/apps/pops-finance-api/package.json
@@ -12,13 +12,19 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@pops/core-db": "workspace:*",
+    "@pops/db-types": "workspace:*",
     "@pops/finance-db": "workspace:*",
     "@pops/types": "workspace:*",
+    "@trpc/server": "^11.17.0",
     "express": "^5.1.0",
-    "pino": "^10.3.1"
+    "jsonwebtoken": "^9.0.3",
+    "pino": "^10.3.1",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/express": "^5.0.4",
+    "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^25.9.3",
     "@types/supertest": "^6.0.3",
     "@vitest/coverage-v8": "^4.1.8",

--- a/apps/pops-finance-api/src/__tests__/finance-routers.test.ts
+++ b/apps/pops-finance-api/src/__tests__/finance-routers.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Integration tests for the migrated finance tRPC surface inside
+ * pops-finance-api (Phase 5 PR 1 / Track M2).
+ *
+ * Two layers of coverage:
+ *
+ *   1. tRPC caller smoke — drives `appRouter.createCaller(ctx)` against
+ *      a per-test in-memory finance.db. Asserts the same shape contract
+ *      the legacy pops-api routers enforced (wishlist + budgets + the
+ *      CRUD slice of transactions, with NOT_FOUND on unknown ids,
+ *      CONFLICT on the budget unique-key violation, UNAUTHORIZED when
+ *      no principal is present, FORBIDDEN when a service-account caller
+ *      lacks scope coverage).
+ *
+ *   2. HTTP wire smoke — boots the Express app via `createFinanceApiApp`
+ *      and round-trips a list query and a create mutation over `/trpc`
+ *      with supertest. Proves `createExpressMiddleware` is wired up and
+ *      the context factory reaches the finance DB.
+ *
+ * Service-layer invariants (validation, FK behaviour, withSpend math)
+ * already live in `packages/finance-db/src/__tests__/` — duplicating
+ * them here would just test drizzle.
+ *
+ * Out of scope: transactions' `suggestTags` / `listDescriptionsForPreview`
+ * / `availableTags` and the entire `imports` subrouter — see the scope
+ * docstring on `src/router.ts` and `src/modules/transactions/router.ts`.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { TRPCError } from '@trpc/server';
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { openFinanceDb, type OpenedFinanceDb } from '@pops/finance-db';
+
+import { createFinanceApiApp } from '../app.js';
+import { appRouter } from '../router.js';
+import { type Context } from '../trpc.js';
+
+let tmpDir: string;
+let financeDb: OpenedFinanceDb;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'finance-api-routers-test-'));
+  financeDb = openFinanceDb(join(tmpDir, 'finance.db'));
+});
+
+afterEach(() => {
+  financeDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function userCaller(email = 'admin@example.com'): ReturnType<typeof appRouter.createCaller> {
+  const ctx: Context = {
+    user: { email },
+    serviceAccount: null,
+    financeDb: financeDb.db,
+  };
+  return appRouter.createCaller(ctx);
+}
+
+function serviceAccountCaller(scopes: string[]): ReturnType<typeof appRouter.createCaller> {
+  const ctx: Context = {
+    user: null,
+    serviceAccount: { id: 'sa_test', name: 'test-sa', scopes },
+    financeDb: financeDb.db,
+  };
+  return appRouter.createCaller(ctx);
+}
+
+function anonCaller(): ReturnType<typeof appRouter.createCaller> {
+  const ctx: Context = {
+    user: null,
+    serviceAccount: null,
+    financeDb: financeDb.db,
+  };
+  return appRouter.createCaller(ctx);
+}
+
+describe('finance.wishlist (tRPC caller)', () => {
+  it('round-trips create -> list -> get -> update -> delete', async () => {
+    const admin = userCaller();
+    const created = await admin.finance.wishlist.create({
+      item: 'New camera',
+      targetAmount: 1500,
+      saved: 200,
+      priority: 'Soon',
+    });
+    expect(created.data.item).toBe('New camera');
+    expect(created.data.remainingAmount).toBe(1300);
+
+    const list = await admin.finance.wishlist.list({});
+    expect(list.data).toHaveLength(1);
+    expect(list.pagination.total).toBe(1);
+
+    const fetched = await admin.finance.wishlist.get({ id: created.data.id });
+    expect(fetched.data.item).toBe('New camera');
+
+    const updated = await admin.finance.wishlist.update({
+      id: created.data.id,
+      data: { saved: 400 },
+    });
+    expect(updated.data.remainingAmount).toBe(1100);
+
+    const deleted = await admin.finance.wishlist.delete({ id: created.data.id });
+    expect(deleted).toEqual({ message: 'Wish list item deleted' });
+  });
+
+  it('returns empty data + total=0 for an unknown priority filter (preserves wire semantics)', async () => {
+    const admin = userCaller();
+    await admin.finance.wishlist.create({ item: 'A', priority: 'Soon' });
+    const res = await admin.finance.wishlist.list({ priority: 'NotAPriority' });
+    expect(res.data).toEqual([]);
+    expect(res.pagination.total).toBe(0);
+  });
+
+  it('maps a missing-id get to NOT_FOUND', async () => {
+    const admin = userCaller();
+    await expect(admin.finance.wishlist.get({ id: 'missing' })).rejects.toMatchObject({
+      name: 'TRPCError',
+      code: 'NOT_FOUND',
+    });
+  });
+});
+
+describe('finance.budgets (tRPC caller)', () => {
+  it('round-trips create -> list -> get -> update -> delete', async () => {
+    const admin = userCaller();
+    const created = await admin.finance.budgets.create({
+      category: 'Groceries',
+      period: 'Monthly',
+      amount: 800,
+      active: true,
+    });
+    expect(created.data.category).toBe('Groceries');
+    expect(created.data.active).toBe(true);
+    expect(created.data.spent).toBe(0);
+
+    const list = await admin.finance.budgets.list({});
+    expect(list.data).toHaveLength(1);
+
+    const fetched = await admin.finance.budgets.get({ id: created.data.id });
+    expect(fetched.data.category).toBe('Groceries');
+
+    const updated = await admin.finance.budgets.update({
+      id: created.data.id,
+      data: { amount: 1000 },
+    });
+    expect(updated.data.amount).toBe(1000);
+
+    const deleted = await admin.finance.budgets.delete({ id: created.data.id });
+    expect(deleted).toEqual({ message: 'Budget deleted' });
+  });
+
+  it('maps a missing-id get to NOT_FOUND', async () => {
+    const admin = userCaller();
+    await expect(admin.finance.budgets.get({ id: 'missing' })).rejects.toMatchObject({
+      name: 'TRPCError',
+      code: 'NOT_FOUND',
+    });
+  });
+});
+
+describe('finance.transactions (tRPC caller)', () => {
+  it('round-trips create -> list -> get -> update -> delete -> restore', async () => {
+    const admin = userCaller();
+    const created = await admin.finance.transactions.create({
+      description: 'Coffee',
+      account: 'ANZ',
+      amount: -5.5,
+      date: '2026-06-12',
+      type: 'expense',
+      tags: ['food', 'coffee'],
+    });
+    expect(created.data.description).toBe('Coffee');
+    expect(created.data.tags).toEqual(['food', 'coffee']);
+
+    const list = await admin.finance.transactions.list({});
+    expect(list.data).toHaveLength(1);
+
+    const fetched = await admin.finance.transactions.get({ id: created.data.id });
+    expect(fetched.data.description).toBe('Coffee');
+
+    const updated = await admin.finance.transactions.update({
+      id: created.data.id,
+      data: { description: 'Latte' },
+    });
+    expect(updated.data.description).toBe('Latte');
+
+    const deleted = await admin.finance.transactions.delete({ id: created.data.id });
+    expect(deleted.message).toBe('Transaction deleted');
+    expect(deleted.snapshot.id).toBe(created.data.id);
+
+    const restored = await admin.finance.transactions.restore(deleted.snapshot);
+    expect(restored.data.id).toBe(created.data.id);
+    expect(restored.data.description).toBe('Latte');
+  });
+
+  it('maps a missing-id get to NOT_FOUND', async () => {
+    const admin = userCaller();
+    await expect(admin.finance.transactions.get({ id: 'missing' })).rejects.toMatchObject({
+      name: 'TRPCError',
+      code: 'NOT_FOUND',
+    });
+  });
+});
+
+describe('finance.* (auth surface)', () => {
+  it('rejects an anonymous caller as UNAUTHORIZED', async () => {
+    const anon = anonCaller();
+    await expect(anon.finance.wishlist.list({})).rejects.toMatchObject({
+      name: 'TRPCError',
+      code: 'UNAUTHORIZED',
+    });
+  });
+
+  it('accepts a service-account caller that holds the matching scope', async () => {
+    const sa = serviceAccountCaller(['finance.wishlist']);
+    const created = await sa.finance.wishlist.create({ item: 'Drone' });
+    expect(created.data.item).toBe('Drone');
+  });
+
+  it('rejects a service-account caller without scope coverage as FORBIDDEN', async () => {
+    const sa = serviceAccountCaller(['food.recipes']);
+    await expect(sa.finance.budgets.list({})).rejects.toMatchObject({
+      name: 'TRPCError',
+      code: 'FORBIDDEN',
+    });
+  });
+
+  it('rejects malformed input at the zod boundary', async () => {
+    const admin = userCaller();
+    await expect(admin.finance.wishlist.create({ item: '' })).rejects.toBeInstanceOf(TRPCError);
+  });
+});
+
+describe('/trpc HTTP surface', () => {
+  function makeApp(): ReturnType<typeof createFinanceApiApp> {
+    return createFinanceApiApp({ financeDb, version: '0.0.1-test' });
+  }
+
+  it('answers finance.wishlist.list over HTTP (dev context auto-authenticates)', async () => {
+    const app = makeApp();
+    const res = await request(app).get(
+      '/trpc/finance.wishlist.list?input=' + encodeURIComponent(JSON.stringify({}))
+    );
+    expect(res.status).toBe(200);
+    expect(res.body.result.data.data).toEqual([]);
+    expect(res.body.result.data.pagination.total).toBe(0);
+  });
+
+  it('round-trips a budgets.create mutation over HTTP', async () => {
+    const app = makeApp();
+    const created = await request(app)
+      .post('/trpc/finance.budgets.create')
+      .send({ category: 'Fuel', period: 'Monthly', amount: 150 });
+    expect(created.status).toBe(200);
+    expect(created.body.result.data.data.category).toBe('Fuel');
+
+    const list = await admin().finance.budgets.list({});
+    expect(list.data).toHaveLength(1);
+    expect(list.data[0]?.category).toBe('Fuel');
+  });
+});
+
+function admin(): ReturnType<typeof appRouter.createCaller> {
+  return userCaller();
+}

--- a/apps/pops-finance-api/src/app.ts
+++ b/apps/pops-finance-api/src/app.ts
@@ -1,18 +1,20 @@
 /**
  * Express app factory for the finance pillar container.
  *
- * Phase 3 PR 1 of the finance pillar migration boots the minimal
- * surface (`/health`) so the new container can be wired into
- * docker-compose and Watchtower without depending on the (still-
- * unfinished) tRPC migration. Subsequent PRs mount additional routes.
+ * Phase 3 PR 1 of the finance pillar migration scaffolded the minimal
+ * `/health` surface. Phase 5 PR 1 (Track M2) wires the tRPC handler at
+ * `/trpc` with the migrated finance subrouters (wishlist + budgets +
+ * the CRUD slice of transactions) backed by `@pops/finance-db` directly.
+ *
  * Kept as a factory so the test suite can spin up an in-process
  * `supertest` instance without binding a real port.
- *
- * Mirrors `apps/pops-media-api/src/app.ts`.
  */
+import { createExpressMiddleware } from '@trpc/server/adapters/express';
 import express, { type Express, type Request, type Response } from 'express';
 
 import { type FinanceApiDeps, makeRequestHandler } from './handlers.js';
+import { appRouter } from './router.js';
+import { createFinanceTrpcContextFactory } from './trpc.js';
 
 export function createFinanceApiApp(deps: FinanceApiDeps): Express {
   const app = express();
@@ -25,6 +27,17 @@ export function createFinanceApiApp(deps: FinanceApiDeps): Express {
   app.get('/health', (_req: Request, res: Response) => {
     res.json(handlers.health());
   });
+
+  app.use(
+    '/trpc',
+    createExpressMiddleware({
+      router: appRouter,
+      createContext: createFinanceTrpcContextFactory({
+        financeDb: deps.financeDb.db,
+        coreDb: deps.coreDb?.db,
+      }),
+    })
+  );
 
   return app;
 }

--- a/apps/pops-finance-api/src/core-sqlite-path.ts
+++ b/apps/pops-finance-api/src/core-sqlite-path.ts
@@ -1,0 +1,28 @@
+import { dirname, join } from 'node:path';
+
+/**
+ * Standalone resolver for the shared `core.db` path inside the
+ * finance-api container.
+ *
+ * Intentionally NOT imported from `apps/pops-api/src/db/core-sqlite-path.ts`
+ * (or from `apps/pops-core-api/src/core-sqlite-path.ts`) — finance-api
+ * is supposed to be runnable without either of those packages in its
+ * dependency graph. The precedence chain mirrors the other resolvers
+ * verbatim so every process agrees on the location of `core.db` given
+ * the same env: a deployer who only sets `SQLITE_PATH` (legacy
+ * contract) still ends up with `core.db` next to `pops.db`.
+ *
+ * Resolution order:
+ *   1. `CORE_SQLITE_PATH` (absolute or relative).
+ *   2. `<dirname(SQLITE_PATH)>/core.db` if the shared path is set.
+ *   3. `./data/core.db` (matches the shared default's `./data/pops.db`).
+ */
+export const DEFAULT_CORE_SQLITE_PATH = './data/core.db';
+
+export function resolveCoreSqlitePath(): string {
+  const envPath = process.env['CORE_SQLITE_PATH'];
+  if (envPath) return envPath;
+  const sharedPath = process.env['SQLITE_PATH'];
+  if (sharedPath) return join(dirname(sharedPath), 'core.db');
+  return DEFAULT_CORE_SQLITE_PATH;
+}

--- a/apps/pops-finance-api/src/handlers.ts
+++ b/apps/pops-finance-api/src/handlers.ts
@@ -2,18 +2,28 @@
  * Request handlers for the finance pillar container.
  *
  * Logic lives here (not inline in `app.ts`) so tests can call into the
- * shape directly without booting Express. Subsequent PRs add tRPC +
- * domain-specific handlers alongside the existing health probe.
- *
- * Mirrors `apps/pops-media-api/src/handlers.ts` minus any pillar-specific
- * surface.
+ * shape directly without booting Express. Phase 5 PR 1 (Track M2) adds
+ * the optional `coreDb` dep so the tRPC context factory can authenticate
+ * `X-API-Key` callers against the shared `core.db` service-accounts
+ * table.
  */
 
+import type { OpenedCoreDb } from '@pops/core-db';
 import type { OpenedFinanceDb } from '@pops/finance-db';
 
 export interface FinanceApiDeps {
   /** Open handle to the finance pillar's SQLite. */
   financeDb: OpenedFinanceDb;
+  /**
+   * Optional handle to the shared `core.db`. When present, finance-api's
+   * tRPC context factory uses it to authenticate `X-API-Key` callers
+   * against the service-accounts table so machine principals reach
+   * finance endpoints with the same semantics they get from the legacy
+   * pops-api router. When absent, only Cloudflare Access (or the
+   * dev/tunnel fallbacks) is honoured — used by tests that don't
+   * exercise SA auth.
+   */
+  coreDb?: OpenedCoreDb;
   /** Semver of the build, surfaced on the health response. */
   version: string;
 }

--- a/apps/pops-finance-api/src/middleware/cloudflare-jwt.ts
+++ b/apps/pops-finance-api/src/middleware/cloudflare-jwt.ts
@@ -1,0 +1,89 @@
+/**
+ * Cloudflare Access JWT validation.
+ *
+ * Mirrors `apps/pops-api/src/middleware/cloudflare-jwt.ts` (and the
+ * local copies in `apps/pops-core-api/src/middleware/cloudflare-jwt.ts`
+ * + `apps/pops-inventory-api/src/middleware/cloudflare-jwt.ts`) because
+ * finance-api stands alone in the dependency graph — see the standalone
+ * comment on `finance-sqlite-path.ts`. A future refactor can lift this
+ * into a shared `@pops/auth` package; for now duplication is the right
+ * call to keep the writer-move PR additive and easy to revert.
+ */
+import jwt from 'jsonwebtoken';
+
+import type { JwtPayload } from 'jsonwebtoken';
+
+export interface CloudflareJWTPayload extends JwtPayload {
+  email: string;
+  aud: string[];
+  iss: string;
+}
+
+interface KeyCache {
+  keys: Record<string, string>;
+  expiresAt: number;
+}
+
+let keyCache: KeyCache | null = null;
+
+async function getCloudflarePublicKeys(): Promise<Record<string, string>> {
+  const now = Date.now();
+  if (keyCache && keyCache.expiresAt > now) {
+    return keyCache.keys;
+  }
+
+  const teamName = process.env['CLOUDFLARE_ACCESS_TEAM_NAME'];
+  if (!teamName) {
+    throw new Error('CLOUDFLARE_ACCESS_TEAM_NAME not configured');
+  }
+
+  const certsUrl = `https://${teamName}.cloudflareaccess.com/cdn-cgi/access/certs`;
+  const response = await fetch(certsUrl);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch Cloudflare certs: ${response.statusText}`);
+  }
+
+  const data = (await response.json()) as {
+    public_certs: Array<{ kid: string; cert: string }>;
+  };
+
+  const keys: Record<string, string> = {};
+  for (const cert of data.public_certs) {
+    keys[cert.kid] = cert.cert;
+  }
+
+  keyCache = {
+    keys,
+    expiresAt: now + 15 * 60 * 1000,
+  };
+  return keys;
+}
+
+export async function verifyCloudflareJWT(token: string): Promise<CloudflareJWTPayload> {
+  const decoded = jwt.decode(token, { complete: true });
+  if (!decoded || typeof decoded === 'string') {
+    throw new Error('Invalid JWT: Unable to decode header');
+  }
+  const kid = decoded.header.kid;
+  if (!kid) {
+    throw new Error('Invalid JWT: Missing kid in header');
+  }
+  const publicKeys = await getCloudflarePublicKeys();
+  const publicKey = publicKeys[kid];
+  if (!publicKey) {
+    throw new Error(`Invalid JWT: Public key not found for kid ${kid}`);
+  }
+
+  const payload = jwt.verify(token, publicKey, {
+    algorithms: ['RS256'],
+  }) as CloudflareJWTPayload;
+
+  const expectedAud = process.env['CLOUDFLARE_ACCESS_AUD'];
+  if (expectedAud && !payload.aud.includes(expectedAud)) {
+    throw new Error('Invalid JWT: Audience mismatch');
+  }
+  if (!payload.email) {
+    throw new Error('Invalid JWT: Missing email claim');
+  }
+  return payload;
+}

--- a/apps/pops-finance-api/src/modules/budgets/router.ts
+++ b/apps/pops-finance-api/src/modules/budgets/router.ts
@@ -1,0 +1,143 @@
+/**
+ * Budget tRPC router — CRUD procedures for budgets.
+ *
+ * Migrated from `apps/pops-api/src/modules/finance/budgets/router.ts`
+ * as part of Phase 5 PR 1 (Track M2). The finance DB handle is injected
+ * via the tRPC context rather than reached through `getFinanceDrizzle()`
+ * so finance-api stands alone of pops-api in the dep graph. Procedure
+ * paths stay rooted at `finance.budgets.*` for a transparent dispatcher
+ * swap in Phase 5 PR 2.
+ *
+ * Domain errors from `@pops/finance-db` (`BudgetNotFoundError`,
+ * `BudgetConflictError`) are translated to local `HttpError` subclasses
+ * inside each handler and then routed through `mapDomainErrors` so the
+ * tRPC layer sees a proper `TRPCError` with the right wire-level `code`
+ * (`NOT_FOUND` / `CONFLICT`).
+ *
+ * Note: the legacy router carried `meta({ openapi: ... })` on `list` and
+ * `get` so they appeared in the pops-api OpenAPI schema. The dispatcher
+ * (PR 2) keeps publishing OpenAPI from pops-api so the meta stays there
+ * during the dual-mount window; it is intentionally NOT replicated here.
+ */
+import { z } from 'zod';
+
+import { BudgetConflictError, BudgetNotFoundError, budgetsService } from '@pops/finance-db';
+
+import { ConflictError, NotFoundError } from '../../shared/errors.js';
+import { paginationMeta, PaginationMetaSchema } from '../../shared/pagination.js';
+import { mapDomainErrors } from '../../shared/trpc-error-mapper.js';
+import { protectedProcedure, router } from '../../trpc.js';
+import {
+  BudgetQuerySchema,
+  BudgetSchema,
+  CreateBudgetSchema,
+  toBudget,
+  UpdateBudgetSchema,
+} from './types.js';
+
+/** Default pagination values. */
+const DEFAULT_LIMIT = 50;
+const DEFAULT_OFFSET = 0;
+
+function translateBudgetError(err: unknown, id?: string): never {
+  if (err instanceof BudgetNotFoundError) {
+    throw new NotFoundError('Budget', id ?? err.id);
+  }
+  if (err instanceof BudgetConflictError) {
+    throw new ConflictError(err.message);
+  }
+  throw err;
+}
+
+export const budgetsRouter = router({
+  /** List budgets with optional search/period/active filters and pagination. */
+  list: protectedProcedure
+    .input(BudgetQuerySchema)
+    .output(z.object({ data: z.array(BudgetSchema), pagination: PaginationMetaSchema }))
+    .query(({ input, ctx }) => {
+      const limit = input.limit ?? DEFAULT_LIMIT;
+      const offset = input.offset ?? DEFAULT_OFFSET;
+
+      let activeFilter: boolean | undefined;
+      if (input.active === 'true') activeFilter = true;
+      else if (input.active === 'false') activeFilter = false;
+      else activeFilter = undefined;
+
+      const { rows, total } = budgetsService.listBudgets(ctx.financeDb, {
+        search: input.search,
+        period: input.period,
+        active: activeFilter,
+        limit,
+        offset,
+      });
+
+      return {
+        data: rows.map(toBudget),
+        pagination: paginationMeta(total, limit, offset),
+      };
+    }),
+
+  /** Get a single budget by ID. */
+  get: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .output(z.object({ data: BudgetSchema }))
+    .query(({ input, ctx }) =>
+      mapDomainErrors(() => {
+        try {
+          const row = budgetsService.getBudget(ctx.financeDb, input.id);
+          return { data: toBudget(budgetsService.withSpend(ctx.financeDb, row)) };
+        } catch (err) {
+          translateBudgetError(err, input.id);
+        }
+      })
+    ),
+
+  /** Create a new budget. */
+  create: protectedProcedure.input(CreateBudgetSchema).mutation(({ input, ctx }) =>
+    mapDomainErrors(() => {
+      try {
+        const row = budgetsService.createBudget(ctx.financeDb, input);
+        return {
+          data: toBudget(budgetsService.withSpend(ctx.financeDb, row)),
+          message: 'Budget created',
+        };
+      } catch (err) {
+        translateBudgetError(err);
+      }
+    })
+  ),
+
+  /** Update an existing budget. */
+  update: protectedProcedure
+    .input(
+      z.object({
+        id: z.string(),
+        data: UpdateBudgetSchema,
+      })
+    )
+    .mutation(({ input, ctx }) =>
+      mapDomainErrors(() => {
+        try {
+          const row = budgetsService.updateBudget(ctx.financeDb, input.id, input.data);
+          return {
+            data: toBudget(budgetsService.withSpend(ctx.financeDb, row)),
+            message: 'Budget updated',
+          };
+        } catch (err) {
+          translateBudgetError(err, input.id);
+        }
+      })
+    ),
+
+  /** Delete a budget. */
+  delete: protectedProcedure.input(z.object({ id: z.string() })).mutation(({ input, ctx }) =>
+    mapDomainErrors(() => {
+      try {
+        budgetsService.deleteBudget(ctx.financeDb, input.id);
+        return { message: 'Budget deleted' };
+      } catch (err) {
+        translateBudgetError(err, input.id);
+      }
+    })
+  ),
+});

--- a/apps/pops-finance-api/src/modules/budgets/types.ts
+++ b/apps/pops-finance-api/src/modules/budgets/types.ts
@@ -1,0 +1,84 @@
+import { z } from 'zod';
+
+import type { BudgetRow } from '@pops/db-types';
+import type { BudgetWithSpend } from '@pops/finance-db';
+
+export type { BudgetRow };
+
+/** API response shape (camelCase). */
+export interface Budget {
+  id: string;
+  category: string;
+  period: string | null;
+  amount: number | null;
+  active: boolean;
+  notes: string | null;
+  lastEditedTime: string;
+  /** Aggregated outflow over the budget's period (always >= 0). */
+  spent: number;
+  /** `amount - spent`, or `null` when the budget has no target amount. */
+  remaining: number | null;
+}
+
+/**
+ * Map a SQLite row (enriched with spend aggregates) to the API response shape.
+ * Converts active from INTEGER (0/1) to boolean.
+ */
+export function toBudget(row: BudgetWithSpend): Budget {
+  return {
+    id: row.id,
+    category: row.category,
+    period: row.period,
+    amount: row.amount,
+    active: row.active === 1,
+    notes: row.notes,
+    lastEditedTime: row.lastEditedTime,
+    spent: row.spent,
+    remaining: row.remaining,
+  };
+}
+
+/** Zod schema for the budget response shape. */
+export const BudgetSchema = z.object({
+  id: z.string(),
+  category: z.string(),
+  period: z.string().nullable(),
+  amount: z.number().nullable(),
+  active: z.boolean(),
+  notes: z.string().nullable(),
+  lastEditedTime: z.string(),
+  spent: z.number(),
+  remaining: z.number().nullable(),
+});
+
+const BudgetPeriodSchema = z.enum(['Monthly', 'Yearly']).nullable().optional();
+
+/** Zod schema for creating a budget. */
+export const CreateBudgetSchema = z.object({
+  category: z.string().min(1, 'Category is required'),
+  period: BudgetPeriodSchema,
+  amount: z.number().nullable().optional(),
+  active: z.boolean().optional().default(false),
+  notes: z.string().nullable().optional(),
+});
+export type CreateBudgetInput = z.infer<typeof CreateBudgetSchema>;
+
+/** Zod schema for updating a budget (all fields optional). */
+export const UpdateBudgetSchema = z.object({
+  category: z.string().min(1, 'Category cannot be empty').optional(),
+  period: BudgetPeriodSchema,
+  amount: z.number().nullable().optional(),
+  active: z.boolean().optional(),
+  notes: z.string().nullable().optional(),
+});
+export type UpdateBudgetInput = z.infer<typeof UpdateBudgetSchema>;
+
+/** Zod schema for budget list query params. */
+export const BudgetQuerySchema = z.object({
+  search: z.string().optional(),
+  period: z.string().optional(),
+  active: z.enum(['true', 'false']).optional(),
+  limit: z.coerce.number().positive().optional(),
+  offset: z.coerce.number().nonnegative().optional(),
+});
+export type BudgetQuery = z.infer<typeof BudgetQuerySchema>;

--- a/apps/pops-finance-api/src/modules/transactions/router.ts
+++ b/apps/pops-finance-api/src/modules/transactions/router.ts
@@ -1,0 +1,169 @@
+/**
+ * Transaction tRPC router — CRUD via `@pops/finance-db`'s `transactionsService`.
+ *
+ * Migrated from `apps/pops-api/src/modules/finance/transactions/router.ts`
+ * as part of Phase 5 PR 1 (Track M2). The finance DB handle is injected
+ * via the tRPC context rather than reached through `getFinanceDrizzle()`
+ * so finance-api stands alone of pops-api in the dep graph. Procedure
+ * paths stay rooted at `finance.transactions.*` for a transparent
+ * dispatcher swap in Phase 5 PR 2.
+ *
+ * **Scope: 6 of 9 procedures.** The CRUD slice (list/get/create/update/
+ * delete/restore) is in scope. The following stay on the legacy pops-api
+ * router as fall-through because their implementations reach into
+ * cross-pillar surfaces still living in pops-api:
+ *
+ *   - `suggestTags`               — uses `shared/tag-suggester.ts`, which
+ *     pulls in `core/corrections/{service,types-base}` and the entities
+ *     table via the legacy unified-db drizzle handle.
+ *   - `listDescriptionsForPreview` — issues raw drizzle reads against the
+ *     `transactions` table via `getDrizzle()` (legacy pops.db); the
+ *     equivalent helper isn't exposed by `@pops/finance-db` yet.
+ *   - `availableTags`              — issues raw better-sqlite3 reads via
+ *     `getDb()` (legacy pops.db); same shape as above.
+ *
+ * These three follow the M4 / M5 precedent of leaving entangled
+ * procedures on the legacy side until the cross-pillar surfaces they
+ * depend on move out of pops-api. The legacy router keeps serving them
+ * unchanged; the dispatcher swap in PR 2 will only route the in-scope
+ * procedure paths to finance-api.
+ *
+ * Domain errors from `@pops/finance-db` (`TransactionNotFoundError`,
+ * `TransactionAlreadyExistsError`) are translated to local `HttpError`
+ * subclasses inside each handler and then routed through
+ * `mapDomainErrors` so the tRPC layer sees a proper `TRPCError` with
+ * the right wire-level `code` (`NOT_FOUND` / `CONFLICT`).
+ */
+import { z } from 'zod';
+
+import {
+  TransactionAlreadyExistsError,
+  TransactionNotFoundError,
+  transactionsService,
+} from '@pops/finance-db';
+
+import { ConflictError, NotFoundError } from '../../shared/errors.js';
+import { paginationMeta, PaginationMetaSchema } from '../../shared/pagination.js';
+import { mapDomainErrors } from '../../shared/trpc-error-mapper.js';
+import { protectedProcedure, router } from '../../trpc.js';
+import {
+  CreateTransactionSchema,
+  toTransaction,
+  type TransactionFilters,
+  TransactionQuerySchema,
+  TransactionSchema,
+  TransactionSnapshotSchema,
+  UpdateTransactionSchema,
+} from './types.js';
+
+/** Default pagination values. */
+const DEFAULT_LIMIT = 50;
+const DEFAULT_OFFSET = 0;
+
+function runTransaction<T>(id: string | undefined, fn: () => T): T {
+  return mapDomainErrors(() => {
+    try {
+      return fn();
+    } catch (err) {
+      if (err instanceof TransactionNotFoundError) {
+        throw new NotFoundError('Transaction', id ?? err.id);
+      }
+      if (err instanceof TransactionAlreadyExistsError) {
+        throw new ConflictError(err.message);
+      }
+      throw err;
+    }
+  });
+}
+
+export const transactionsRouter = router({
+  /** List transactions with optional filters and pagination. */
+  list: protectedProcedure
+    .input(TransactionQuerySchema)
+    .output(z.object({ data: z.array(TransactionSchema), pagination: PaginationMetaSchema }))
+    .query(({ input, ctx }) => {
+      const limit = input.limit ?? DEFAULT_LIMIT;
+      const offset = input.offset ?? DEFAULT_OFFSET;
+
+      const filters: TransactionFilters = {
+        search: input.search,
+        account: input.account,
+        startDate: input.startDate,
+        endDate: input.endDate,
+        tag: input.tag,
+        entityId: input.entityId,
+        type: input.type,
+      };
+
+      const { rows, total } = transactionsService.listTransactions(
+        ctx.financeDb,
+        filters,
+        limit,
+        offset
+      );
+
+      return {
+        data: rows.map(toTransaction),
+        pagination: paginationMeta(total, limit, offset),
+      };
+    }),
+
+  /** Get a single transaction by ID. */
+  get: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .output(z.object({ data: TransactionSchema }))
+    .query(({ input, ctx }) =>
+      runTransaction(input.id, () => {
+        const row = transactionsService.getTransaction(ctx.financeDb, input.id);
+        return { data: toTransaction(row) };
+      })
+    ),
+
+  /** Create a new transaction. */
+  create: protectedProcedure.input(CreateTransactionSchema).mutation(({ input, ctx }) =>
+    runTransaction(undefined, () => {
+      const row = transactionsService.createTransaction(ctx.financeDb, input);
+      return { data: toTransaction(row), message: 'Transaction created' };
+    })
+  ),
+
+  /** Update an existing transaction. */
+  update: protectedProcedure
+    .input(z.object({ id: z.string(), data: UpdateTransactionSchema }))
+    .mutation(({ input, ctx }) =>
+      runTransaction(input.id, () => {
+        const row = transactionsService.updateTransaction(ctx.financeDb, input.id, input.data);
+        return { data: toTransaction(row), message: 'Transaction updated' };
+      })
+    ),
+
+  /**
+   * Delete a transaction. Returns the deleted row as a `snapshot` so the
+   * client can offer Undo via `restore`. The snapshot carries the full row
+   * including original id, checksum, raw_row, and notion_id — fields that
+   * the list shape strips and that an Undo flow needs to preserve.
+   */
+  delete: protectedProcedure.input(z.object({ id: z.string() })).mutation(({ input, ctx }) =>
+    runTransaction(input.id, () => {
+      const snapshot = transactionsService.deleteTransaction(ctx.financeDb, input.id);
+      return { message: 'Transaction deleted', snapshot };
+    })
+  ),
+
+  /**
+   * Restore a previously-deleted transaction from a snapshot returned by
+   * `delete`. Re-inserts preserving id and dedup metadata so a re-import of
+   * the same source row is still detected as a duplicate.
+   *
+   * Note: SQLite's `ON DELETE SET NULL` already cleared `inventory.purchase_transaction_id`
+   * pointers when the original delete ran. Restore re-creates the
+   * transaction id but does not auto-reattach those FKs — that requires
+   * a separate manual step.
+   */
+  restore: protectedProcedure.input(TransactionSnapshotSchema).mutation(({ input, ctx }) =>
+    runTransaction(input.id, () => {
+      const row = transactionsService.restoreTransaction(ctx.financeDb, input);
+      return { data: toTransaction(row), message: 'Transaction restored' };
+    })
+  ),
+});

--- a/apps/pops-finance-api/src/modules/transactions/types.ts
+++ b/apps/pops-finance-api/src/modules/transactions/types.ts
@@ -1,0 +1,165 @@
+import { z } from 'zod';
+
+import type { TransactionRow } from '@pops/db-types';
+
+export type { TransactionRow };
+
+/** API response shape (camelCase). */
+export interface Transaction {
+  id: string;
+  description: string;
+  account: string;
+  amount: number;
+  date: string;
+  type: string;
+  tags: string[];
+  entityId: string | null;
+  entityName: string | null;
+  location: string | null;
+  country: string | null;
+  relatedTransactionId: string | null;
+  notes: string | null;
+  lastEditedTime: string;
+}
+
+/** Map a SQLite row to the API response shape. */
+export function toTransaction(row: TransactionRow): Transaction {
+  return {
+    id: row.id,
+    description: row.description,
+    account: row.account,
+    amount: row.amount,
+    date: row.date,
+    type: row.type,
+    tags: parseTagsJson(row.tags),
+    entityId: row.entityId,
+    entityName: row.entityName,
+    location: row.location,
+    country: row.country,
+    relatedTransactionId: row.relatedTransactionId,
+    notes: row.notes,
+    lastEditedTime: row.lastEditedTime,
+  };
+}
+
+function parseTagsJson(raw: string | null): string[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (Array.isArray(parsed)) {
+      return parsed.filter((item): item is string => typeof item === 'string');
+    }
+    return [];
+  } catch {
+    return [];
+  }
+}
+
+/** Zod schema for the transaction response shape. */
+export const TransactionSchema = z.object({
+  id: z.string(),
+  description: z.string(),
+  account: z.string(),
+  amount: z.number(),
+  date: z.string(),
+  type: z.string(),
+  tags: z.array(z.string()),
+  entityId: z.string().nullable(),
+  entityName: z.string().nullable(),
+  location: z.string().nullable(),
+  country: z.string().nullable(),
+  relatedTransactionId: z.string().nullable(),
+  notes: z.string().nullable(),
+  lastEditedTime: z.string(),
+});
+
+/** Zod schema for creating a transaction. */
+export const CreateTransactionSchema = z.object({
+  description: z.string().min(1, 'Description is required'),
+  account: z.string().min(1, 'Account is required'),
+  amount: z.number(),
+  date: z.string().min(1, 'Date is required'),
+  type: z.string().min(1, 'Type is required'),
+  tags: z.array(z.string()).optional().default([]),
+  entityId: z.string().nullable().optional(),
+  entityName: z.string().nullable().optional(),
+  location: z.string().nullable().optional(),
+  country: z.string().nullable().optional(),
+  relatedTransactionId: z.string().nullable().optional(),
+  notes: z.string().nullable().optional(),
+  /** Import-only: raw CSV row for audit trail. */
+  rawRow: z.string().optional(),
+  /** Import-only: checksum for deduplication. */
+  checksum: z.string().optional(),
+});
+export type CreateTransactionInput = z.infer<typeof CreateTransactionSchema>;
+
+/** Zod schema for updating a transaction (all fields optional). */
+export const UpdateTransactionSchema = z.object({
+  description: z.string().min(1, 'Description cannot be empty').optional(),
+  account: z.string().min(1, 'Account cannot be empty').optional(),
+  amount: z.number().optional(),
+  date: z.string().min(1, 'Date cannot be empty').optional(),
+  type: z.string().optional(),
+  tags: z.array(z.string()).optional(),
+  entityId: z.string().nullable().optional(),
+  entityName: z.string().nullable().optional(),
+  location: z.string().nullable().optional(),
+  country: z.string().nullable().optional(),
+  relatedTransactionId: z.string().nullable().optional(),
+  notes: z.string().nullable().optional(),
+});
+export type UpdateTransactionInput = z.infer<typeof UpdateTransactionSchema>;
+
+/**
+ * Zod schema for the snapshot returned by `delete` and accepted by `restore`.
+ *
+ * Mirrors the SQLite row exactly — including the original `id`, `checksum`,
+ * `rawRow`, and `notionId` — so an Undo flow restores dedup metadata and any
+ * link pointing at the original id keeps resolving.
+ */
+export const TransactionSnapshotSchema = z.object({
+  id: z.string(),
+  notionId: z.string().nullable(),
+  description: z.string(),
+  account: z.string(),
+  amount: z.number(),
+  date: z.string(),
+  type: z.string(),
+  tags: z.string(),
+  entityId: z.string().nullable(),
+  entityName: z.string().nullable(),
+  location: z.string().nullable(),
+  country: z.string().nullable(),
+  relatedTransactionId: z.string().nullable(),
+  notes: z.string().nullable(),
+  checksum: z.string().nullable(),
+  rawRow: z.string().nullable(),
+  lastEditedTime: z.string(),
+});
+export type TransactionSnapshot = z.infer<typeof TransactionSnapshotSchema>;
+
+/** Zod schema for transaction list query params. */
+export const TransactionQuerySchema = z.object({
+  search: z.string().optional(),
+  account: z.string().optional(),
+  startDate: z.string().optional(),
+  endDate: z.string().optional(),
+  tag: z.string().optional(),
+  entityId: z.string().optional(),
+  type: z.string().optional(),
+  limit: z.coerce.number().positive().optional(),
+  offset: z.coerce.number().nonnegative().optional(),
+});
+export type TransactionQueryRaw = z.infer<typeof TransactionQuerySchema>;
+
+/** Parsed filter params passed to the service layer. */
+export interface TransactionFilters {
+  search?: string;
+  account?: string;
+  startDate?: string;
+  endDate?: string;
+  tag?: string;
+  entityId?: string;
+  type?: string;
+}

--- a/apps/pops-finance-api/src/modules/wishlist/router.ts
+++ b/apps/pops-finance-api/src/modules/wishlist/router.ts
@@ -1,0 +1,149 @@
+/**
+ * Wish list tRPC router — CRUD procedures for wish list items.
+ *
+ * Migrated from `apps/pops-api/src/modules/finance/wishlist/router.ts`
+ * as part of Phase 5 PR 1 (Track M2). The finance DB handle is injected
+ * via the tRPC context rather than reached through `getFinanceDrizzle()`
+ * so finance-api stands alone of pops-api in the dep graph. Procedure
+ * paths stay rooted at `finance.wishlist.*` for a transparent
+ * dispatcher swap in Phase 5 PR 2.
+ *
+ * Domain errors from `@pops/finance-db` (`WishListItemNotFoundError`)
+ * are translated to local `HttpError` subclasses inside each handler
+ * and then routed through `mapDomainErrors` so the tRPC layer sees a
+ * proper `TRPCError` with the right wire-level `code` (e.g.
+ * `NOT_FOUND`).
+ */
+import { z } from 'zod';
+
+import {
+  wishListService,
+  WishListItemNotFoundError,
+  WISH_LIST_PRIORITIES,
+  type WishListPriority,
+} from '@pops/finance-db';
+
+import { NotFoundError } from '../../shared/errors.js';
+import { paginationMeta } from '../../shared/pagination.js';
+import { mapDomainErrors } from '../../shared/trpc-error-mapper.js';
+import { protectedProcedure, router } from '../../trpc.js';
+import {
+  CreateWishListItemSchema,
+  toWishListItem,
+  UpdateWishListItemSchema,
+  WishListQuerySchema,
+} from './types.js';
+
+/** Default pagination values. */
+const DEFAULT_LIMIT = 50;
+const DEFAULT_OFFSET = 0;
+
+const PRIORITY_LOOKUP: ReadonlySet<string> = new Set(WISH_LIST_PRIORITIES);
+
+/**
+ * Preserve the pre-pillar wire semantic: the original SQL filter applied
+ * `eq(priority, '<any-string>')` for any non-empty value, so an unknown
+ * priority matched zero rows. The package's typed query drops invalid
+ * values entirely, which would return ALL rows — a silent behaviour
+ * change. The router short-circuits unknown values instead.
+ */
+function asKnownPriority(value: string | undefined): {
+  valid: boolean;
+  typed: WishListPriority | undefined;
+} {
+  if (value === undefined || value === '') return { valid: true, typed: undefined };
+  if (!PRIORITY_LOOKUP.has(value)) return { valid: false, typed: undefined };
+  return { valid: true, typed: value as WishListPriority };
+}
+
+export const wishlistRouter = router({
+  /** List wish list items with optional search/priority filters and pagination. */
+  list: protectedProcedure.input(WishListQuerySchema).query(({ input, ctx }) => {
+    const limit = input.limit ?? DEFAULT_LIMIT;
+    const offset = input.offset ?? DEFAULT_OFFSET;
+
+    const { valid, typed } = asKnownPriority(input.priority);
+    if (!valid) {
+      return {
+        data: [],
+        pagination: paginationMeta(0, limit, offset),
+      };
+    }
+
+    const { rows, total } = wishListService.listWishListItems(ctx.financeDb, {
+      search: input.search,
+      priority: typed,
+      limit,
+      offset,
+    });
+
+    return {
+      data: rows.map(toWishListItem),
+      pagination: paginationMeta(total, limit, offset),
+    };
+  }),
+
+  /** Get a single wish list item by ID. */
+  get: protectedProcedure.input(z.object({ id: z.string() })).query(({ input, ctx }) =>
+    mapDomainErrors(() => {
+      try {
+        const row = wishListService.getWishListItem(ctx.financeDb, input.id);
+        return { data: toWishListItem(row) };
+      } catch (err) {
+        if (err instanceof WishListItemNotFoundError) {
+          throw new NotFoundError('Wish list item', input.id);
+        }
+        throw err;
+      }
+    })
+  ),
+
+  /** Create a new wish list item. */
+  create: protectedProcedure.input(CreateWishListItemSchema).mutation(({ input, ctx }) => {
+    const row = wishListService.createWishListItem(ctx.financeDb, input);
+    return {
+      data: toWishListItem(row),
+      message: 'Wish list item created',
+    };
+  }),
+
+  /** Update an existing wish list item. */
+  update: protectedProcedure
+    .input(
+      z.object({
+        id: z.string(),
+        data: UpdateWishListItemSchema,
+      })
+    )
+    .mutation(({ input, ctx }) =>
+      mapDomainErrors(() => {
+        try {
+          const row = wishListService.updateWishListItem(ctx.financeDb, input.id, input.data);
+          return {
+            data: toWishListItem(row),
+            message: 'Wish list item updated',
+          };
+        } catch (err) {
+          if (err instanceof WishListItemNotFoundError) {
+            throw new NotFoundError('Wish list item', input.id);
+          }
+          throw err;
+        }
+      })
+    ),
+
+  /** Delete a wish list item. */
+  delete: protectedProcedure.input(z.object({ id: z.string() })).mutation(({ input, ctx }) =>
+    mapDomainErrors(() => {
+      try {
+        wishListService.deleteWishListItem(ctx.financeDb, input.id);
+        return { message: 'Wish list item deleted' };
+      } catch (err) {
+        if (err instanceof WishListItemNotFoundError) {
+          throw new NotFoundError('Wish list item', input.id);
+        }
+        throw err;
+      }
+    })
+  ),
+});

--- a/apps/pops-finance-api/src/modules/wishlist/types.ts
+++ b/apps/pops-finance-api/src/modules/wishlist/types.ts
@@ -1,0 +1,70 @@
+import { z } from 'zod';
+
+import { WISH_LIST_PRIORITIES, type WishListPriority, type WishListRow } from '@pops/db-types';
+
+export { WISH_LIST_PRIORITIES, type WishListPriority, type WishListRow };
+
+/** API response shape (camelCase). */
+export interface WishListItem {
+  id: string;
+  item: string;
+  targetAmount: number | null;
+  saved: number | null;
+  remainingAmount: number | null;
+  priority: string | null;
+  url: string | null;
+  notes: string | null;
+  lastEditedTime: string;
+}
+
+/**
+ * Map a SQLite row to the API response shape.
+ * Computes remainingAmount as targetAmount - saved, or null if either is null.
+ */
+export function toWishListItem(row: WishListRow): WishListItem {
+  const remainingAmount =
+    row.targetAmount !== null && row.saved !== null ? row.targetAmount - row.saved : null;
+
+  return {
+    id: row.id,
+    item: row.item,
+    targetAmount: row.targetAmount,
+    saved: row.saved,
+    remainingAmount,
+    priority: row.priority,
+    url: row.url,
+    notes: row.notes,
+    lastEditedTime: row.lastEditedTime,
+  };
+}
+
+/** Zod schema for creating a wish list item. */
+export const CreateWishListItemSchema = z.object({
+  item: z.string().min(1, 'Item is required'),
+  targetAmount: z.number().nullable().optional(),
+  saved: z.number().nullable().optional(),
+  priority: z.enum(WISH_LIST_PRIORITIES).nullable().optional(),
+  url: z.string().url('Invalid URL').nullable().optional(),
+  notes: z.string().nullable().optional(),
+});
+export type CreateWishListItemInput = z.infer<typeof CreateWishListItemSchema>;
+
+/** Zod schema for updating a wish list item (all fields optional). */
+export const UpdateWishListItemSchema = z.object({
+  item: z.string().min(1, 'Item cannot be empty').optional(),
+  targetAmount: z.number().nullable().optional(),
+  saved: z.number().nullable().optional(),
+  priority: z.enum(WISH_LIST_PRIORITIES).nullable().optional(),
+  url: z.string().url('Invalid URL').nullable().optional(),
+  notes: z.string().nullable().optional(),
+});
+export type UpdateWishListItemInput = z.infer<typeof UpdateWishListItemSchema>;
+
+/** Zod schema for wish list query params. */
+export const WishListQuerySchema = z.object({
+  search: z.string().optional(),
+  priority: z.string().optional(),
+  limit: z.coerce.number().positive().optional(),
+  offset: z.coerce.number().nonnegative().optional(),
+});
+export type WishListQuery = z.infer<typeof WishListQuerySchema>;

--- a/apps/pops-finance-api/src/router.ts
+++ b/apps/pops-finance-api/src/router.ts
@@ -1,0 +1,36 @@
+/**
+ * Root tRPC router for the finance pillar container.
+ *
+ * The procedure paths are intentionally rooted at `finance.*` so the
+ * Phase 5 PR 2 dispatcher cutover can be a transparent URL swap rather
+ * than a procedure-path rename: existing pops-api clients call
+ * `finance.wishlist.list` / `finance.budgets.create` /
+ * `finance.transactions.update`, and finance-api answers on the same
+ * paths.
+ *
+ * Scope note: this PR ships the wishlist + budgets subrouters in full,
+ * plus the CRUD slice of transactions (list/get/create/update/delete/
+ * restore). Transactions' `suggestTags` / `listDescriptionsForPreview`
+ * / `availableTags` and the entire `imports` subrouter stay on the
+ * legacy pops-api router as fall-through because they reach into
+ * cross-pillar surfaces (`core/corrections`, `core/tag-rules`,
+ * `core/ai-usage`, `core/settings`, `shared/tag-suggester`, and the
+ * legacy unified `pops.db` drizzle handle) that haven't moved yet —
+ * see the procedure-by-procedure breakdown in `modules/transactions/router.ts`.
+ */
+import { budgetsRouter } from './modules/budgets/router.js';
+import { transactionsRouter } from './modules/transactions/router.js';
+import { wishlistRouter } from './modules/wishlist/router.js';
+import { router } from './trpc.js';
+
+export const financeRouter = router({
+  wishlist: wishlistRouter,
+  budgets: budgetsRouter,
+  transactions: transactionsRouter,
+});
+
+export const appRouter = router({
+  finance: financeRouter,
+});
+
+export type AppRouter = typeof appRouter;

--- a/apps/pops-finance-api/src/server.ts
+++ b/apps/pops-finance-api/src/server.ts
@@ -2,9 +2,11 @@
  * Entry point for the finance pillar HTTP server.
  *
  * Phase 3 PR 1 scaffolded the minimal `/health` surface. Phase 5 PR 1
- * (Track M2) opens both `finance.db` (for writes) and a read-only
- * handle to the shared `core.db` (for service-account auth) and wires
- * them into the Express app factory.
+ * (Track M2) opens both `finance.db` (for writes) and a handle to the
+ * shared `core.db` (for service-account auth) and wires them into the
+ * Express app factory. `openCoreDb` runs migrations on open so the
+ * core handle is read/write at the SQLite level even though finance-api
+ * only issues reads against it.
  *
  * The process opens its OWN `finance.db` connection via `openFinanceDb`
  * rather than reaching back into pops-api's singleton — that's the

--- a/apps/pops-finance-api/src/server.ts
+++ b/apps/pops-finance-api/src/server.ts
@@ -1,18 +1,21 @@
 /**
  * Entry point for the finance pillar HTTP server.
  *
- * Phase 3 PR 1 of the finance pillar migration boots the process with
- * the minimal `/health` surface so the new container can be wired into
- * docker-compose + Watchtower without depending on the (still-
- * unfinished) tRPC + URI-dispatcher migration.
+ * Phase 3 PR 1 scaffolded the minimal `/health` surface. Phase 5 PR 1
+ * (Track M2) opens both `finance.db` (for writes) and a read-only
+ * handle to the shared `core.db` (for service-account auth) and wires
+ * them into the Express app factory.
  *
  * The process opens its OWN `finance.db` connection via `openFinanceDb`
  * rather than reaching back into pops-api's singleton — that's the
- * whole point of phase 3. Mirrors `apps/pops-media-api/src/server.ts`.
+ * whole point of phase 3. Mirrors `apps/pops-media-api/src/server.ts`
+ * and `apps/pops-inventory-api/src/server.ts`.
  */
+import { openCoreDb } from '@pops/core-db';
 import { openFinanceDb } from '@pops/finance-db';
 
 import { createFinanceApiApp } from './app.js';
+import { resolveCoreSqlitePath } from './core-sqlite-path.js';
 import { resolveFinanceSqlitePath } from './finance-sqlite-path.js';
 
 function resolvePort(): number {
@@ -31,7 +34,8 @@ const port = resolvePort();
 const version = process.env['BUILD_VERSION'] ?? 'dev';
 
 const financeDb = openFinanceDb(resolveFinanceSqlitePath());
-const app = createFinanceApiApp({ financeDb, version });
+const coreDb = openCoreDb(resolveCoreSqlitePath());
+const app = createFinanceApiApp({ financeDb, coreDb, version });
 
 const server = app.listen(port, () => {
   console.warn(`[finance-api] Listening on port ${port}`);
@@ -44,6 +48,7 @@ function shutdown(signal: NodeJS.Signals): void {
   console.warn(`[finance-api] Shutting down (${signal})`);
   server.close(() => {
     financeDb.raw.close();
+    coreDb.raw.close();
   });
 }
 

--- a/apps/pops-finance-api/src/shared/errors.ts
+++ b/apps/pops-finance-api/src/shared/errors.ts
@@ -1,0 +1,47 @@
+/**
+ * HTTP-shaped domain errors used by finance-api router handlers.
+ *
+ * Intentionally NOT imported from `apps/pops-api/src/shared/errors.ts` —
+ * the per-pillar container is supposed to stand alone of pops-api in the
+ * dependency graph (Phase 5 writer-move pattern). Each error carries an
+ * optional `messageKey` so the frontend can look up the translated string
+ * while the EN-AU fallback lives in `message`; the finance-api tRPC
+ * initialiser plumbs it through the wire error shape so clients continue
+ * receiving `data.messageKey` after the Phase 5 PR 2 cutover.
+ */
+export class HttpError extends Error {
+  /** i18n key the frontend uses to resolve a localised message. */
+  public readonly messageKey?: string;
+
+  constructor(
+    public readonly statusCode: number,
+    message: string,
+    public readonly details?: unknown,
+    messageKey?: string
+  ) {
+    super(message);
+    this.name = 'HttpError';
+    this.messageKey = messageKey;
+  }
+}
+
+export class NotFoundError extends HttpError {
+  constructor(resource: string, id: string) {
+    super(404, `${resource} '${id}' not found`, undefined, 'common.notFound');
+    this.name = 'NotFoundError';
+  }
+}
+
+export class ValidationError extends HttpError {
+  constructor(details: unknown) {
+    super(400, 'Validation failed', details, 'common.validationFailed');
+    this.name = 'ValidationError';
+  }
+}
+
+export class ConflictError extends HttpError {
+  constructor(message: string) {
+    super(409, message, undefined, 'common.conflict');
+    this.name = 'ConflictError';
+  }
+}

--- a/apps/pops-finance-api/src/shared/pagination.ts
+++ b/apps/pops-finance-api/src/shared/pagination.ts
@@ -1,0 +1,25 @@
+/**
+ * Pagination response builder.
+ *
+ * Mirrors `apps/pops-api/src/shared/pagination.ts` (export-surface only —
+ * finance-api's tRPC routers don't need the Express `parsePagination`
+ * helper). Duplicated locally so finance-api stands alone of pops-api in
+ * the dependency graph per the Phase 5 writer-move pattern.
+ */
+import { z } from 'zod';
+
+/** Shape of pagination metadata returned by list endpoints. */
+export type PaginationMeta = { total: number; limit: number; offset: number; hasMore: boolean };
+
+/** Zod schema for the pagination metadata response shape. */
+export const PaginationMetaSchema = z.object({
+  total: z.number(),
+  limit: z.number(),
+  offset: z.number(),
+  hasMore: z.boolean(),
+});
+
+/** Build the pagination metadata for a response. */
+export function paginationMeta(total: number, limit: number, offset: number): PaginationMeta {
+  return { total, limit, offset, hasMore: offset + limit < total };
+}

--- a/apps/pops-finance-api/src/shared/trpc-error-mapper.ts
+++ b/apps/pops-finance-api/src/shared/trpc-error-mapper.ts
@@ -1,0 +1,46 @@
+import { TRPCError } from '@trpc/server';
+
+import { HttpError } from './errors.js';
+
+type TRPCCode = ConstructorParameters<typeof TRPCError>[0]['code'];
+
+const HTTP_STATUS_TO_TRPC_CODE: Readonly<Record<number, TRPCCode>> = {
+  400: 'BAD_REQUEST',
+  401: 'UNAUTHORIZED',
+  402: 'PAYMENT_REQUIRED',
+  403: 'FORBIDDEN',
+  404: 'NOT_FOUND',
+  409: 'CONFLICT',
+  412: 'PRECONDITION_FAILED',
+  422: 'UNPROCESSABLE_CONTENT',
+  429: 'TOO_MANY_REQUESTS',
+  500: 'INTERNAL_SERVER_ERROR',
+};
+
+function toTRPCError(err: HttpError): TRPCError {
+  const code = HTTP_STATUS_TO_TRPC_CODE[err.statusCode] ?? 'INTERNAL_SERVER_ERROR';
+  return new TRPCError({ code, message: err.message, cause: err });
+}
+
+/**
+ * Runs `fn` and re-throws any HttpError subclass as the corresponding
+ * TRPCError. Non-HttpError throws bubble unchanged so the global tRPC
+ * error handler can see them as 500s.
+ */
+export function mapDomainErrors<T>(fn: () => T): T {
+  try {
+    return fn();
+  } catch (err) {
+    if (err instanceof HttpError) throw toTRPCError(err);
+    throw err;
+  }
+}
+
+export async function mapDomainErrorsAsync<T>(fn: () => Promise<T>): Promise<T> {
+  try {
+    return await fn();
+  } catch (err) {
+    if (err instanceof HttpError) throw toTRPCError(err);
+    throw err;
+  }
+}

--- a/apps/pops-finance-api/src/trpc.ts
+++ b/apps/pops-finance-api/src/trpc.ts
@@ -1,0 +1,185 @@
+/**
+ * tRPC initialisation for the finance pillar container.
+ *
+ * Mirrors the auth surface of `apps/pops-api/src/trpc.ts` (and the local
+ * copies in `apps/pops-core-api/src/trpc.ts` + `apps/pops-inventory-api/src/trpc.ts`)
+ * but trims what finance-api doesn't need yet:
+ *   - no module gate (per-pillar containers serve a single pillar by
+ *     definition; the install-set check lives at the dispatcher layer
+ *     above this process);
+ *   - no `internalProcedure` (no sibling-process callers for finance
+ *     yet);
+ *   - no OpenAPI meta (the dispatcher/gateway owns OpenAPI; finance-api
+ *     handlers are tRPC-only for now).
+ *
+ * The finance DB handle is injected at context-creation time via the
+ * factory in `createFinanceTrpcContextFactory` so tests can swap in
+ * an in-memory handle without touching env vars or the production
+ * resolver. The optional `coreDb` handle is what powers service-account
+ * authentication and scope checks; production wires it from the shared
+ * `core.db` volume so `protectedProcedure` keeps accepting machine
+ * principals byte-identically to the legacy pops-api router. Tests that
+ * don't exercise service-account auth can omit it — `protectedProcedure`
+ * will fall back to UNAUTHORIZED for any caller without a user.
+ */
+import { initTRPC, TRPCError } from '@trpc/server';
+
+import {
+  type AuthenticatedServiceAccount,
+  type CoreDb,
+  serviceAccountKeys,
+  serviceAccountsService,
+} from '@pops/core-db';
+import { type FinanceDb } from '@pops/finance-db';
+
+import { verifyCloudflareJWT } from './middleware/cloudflare-jwt.js';
+
+import type { CreateExpressContextOptions } from '@trpc/server/adapters/express';
+
+export interface User {
+  email: string;
+}
+
+export interface Context {
+  user: User | null;
+  serviceAccount: AuthenticatedServiceAccount | null;
+  financeDb: FinanceDb;
+}
+
+function readApiKeyHeader(req: CreateExpressContextOptions['req']): string | null {
+  const raw = req.headers['x-api-key'];
+  if (Array.isArray(raw)) return raw[0] ?? null;
+  if (typeof raw === 'string' && raw.length > 0) return raw;
+  return null;
+}
+
+async function tryServiceAccountAuth(
+  coreDb: CoreDb | null,
+  req: CreateExpressContextOptions['req']
+): Promise<AuthenticatedServiceAccount | null> {
+  if (!coreDb) return null;
+  const header = readApiKeyHeader(req);
+  if (!header) return null;
+  const parsed = serviceAccountKeys.parseApiKey(header);
+  if (!parsed) return null;
+  return serviceAccountsService.authenticateServiceAccount(coreDb, parsed.prefix, parsed.secret);
+}
+
+export interface FinanceTrpcContextFactoryDeps {
+  financeDb: FinanceDb;
+  /**
+   * Optional core DB handle used to authenticate `X-API-Key` callers.
+   * When omitted, service-account auth is disabled and only Cloudflare
+   * Access (or the dev/tunnel fallbacks) is honoured. Production wires
+   * this from the shared `core.db` volume; tests typically leave it
+   * undefined unless they specifically exercise SA paths.
+   */
+  coreDb?: CoreDb;
+}
+
+/**
+ * Build a tRPC context factory bound to specific DB handles.
+ */
+export function createFinanceTrpcContextFactory(
+  deps: FinanceTrpcContextFactoryDeps
+): (opts: CreateExpressContextOptions) => Promise<Context> {
+  const coreDb = deps.coreDb ?? null;
+  return async ({ req }: CreateExpressContextOptions): Promise<Context> => {
+    const serviceAccount = await tryServiceAccountAuth(coreDb, req);
+    if (serviceAccount) {
+      return { user: null, serviceAccount, financeDb: deps.financeDb };
+    }
+
+    if (process.env['NODE_ENV'] !== 'production') {
+      return {
+        user: { email: 'dev@example.com' },
+        serviceAccount: null,
+        financeDb: deps.financeDb,
+      };
+    }
+
+    if (!process.env['CLOUDFLARE_ACCESS_TEAM_NAME']) {
+      return {
+        user: { email: 'tunnel-authenticated@pops.local' },
+        serviceAccount: null,
+        financeDb: deps.financeDb,
+      };
+    }
+
+    const token = req.headers['cf-access-jwt-assertion'];
+    if (typeof token === 'string') {
+      try {
+        const payload = await verifyCloudflareJWT(token);
+        return {
+          user: { email: payload.email },
+          serviceAccount: null,
+          financeDb: deps.financeDb,
+        };
+      } catch (error) {
+        console.error('[finance-api] JWT verification failed:', error);
+        return { user: null, serviceAccount: null, financeDb: deps.financeDb };
+      }
+    }
+
+    return { user: null, serviceAccount: null, financeDb: deps.financeDb };
+  };
+}
+
+const t = initTRPC.context<Context>().create({
+  errorFormatter({ shape, error }) {
+    return {
+      ...shape,
+      data: {
+        ...shape.data,
+        /** i18n key for frontend translation lookup — mirrors pops-api's wire shape. */
+        messageKey:
+          error.cause instanceof Error && 'messageKey' in error.cause
+            ? (error.cause as { messageKey?: string }).messageKey
+            : undefined,
+      },
+    };
+  },
+});
+
+export const router = t.router;
+
+export const publicProcedure = t.procedure;
+
+/**
+ * Protected procedure that requires either a Cloudflare Access user OR
+ * an authenticated service account whose granted scopes cover the
+ * procedure path. Mirrors the semantics of `protectedProcedure` in
+ * `apps/pops-api/src/trpc.ts` so the writer-move is wire-compatible.
+ */
+export const protectedProcedure = t.procedure.use(({ ctx, path, next }) => {
+  if (ctx.user) {
+    return next({
+      ctx: {
+        user: ctx.user,
+        serviceAccount: ctx.serviceAccount,
+        financeDb: ctx.financeDb,
+      },
+    });
+  }
+
+  if (ctx.serviceAccount) {
+    if (!serviceAccountsService.hasScopeFor(ctx.serviceAccount.scopes, path)) {
+      throw new TRPCError({
+        code: 'FORBIDDEN',
+        message: `Service account '${ctx.serviceAccount.name}' is not authorised for '${path}'`,
+      });
+    }
+    return next({
+      ctx: {
+        user: ctx.user,
+        serviceAccount: ctx.serviceAccount,
+        financeDb: ctx.financeDb,
+      },
+    });
+  }
+
+  throw new TRPCError({
+    code: 'UNAUTHORIZED',
+    message: 'Missing or invalid credentials (expected Cloudflare Access JWT or X-API-Key)',
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -346,22 +346,40 @@ importers:
 
   apps/pops-finance-api:
     dependencies:
+      '@pops/core-db':
+        specifier: workspace:*
+        version: link:../../packages/core-db
+      '@pops/db-types':
+        specifier: workspace:*
+        version: link:../../packages/db-types
       '@pops/finance-db':
         specifier: workspace:*
         version: link:../../packages/finance-db
       '@pops/types':
         specifier: workspace:*
         version: link:../../packages/types
+      '@trpc/server':
+        specifier: ^11.17.0
+        version: 11.17.0(typescript@6.0.3)
       express:
         specifier: ^5.1.0
         version: 5.2.1
+      jsonwebtoken:
+        specifier: ^9.0.3
+        version: 9.0.3
       pino:
         specifier: ^10.3.1
         version: 10.3.1
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@types/express':
         specifier: ^5.0.4
         version: 5.0.6
+      '@types/jsonwebtoken':
+        specifier: ^9.0.10
+        version: 9.0.10
       '@types/node':
         specifier: ^25.9.3
         version: 25.9.3


### PR DESCRIPTION
## Summary

First writer-move across the **finance pillar** (Track M2 / Phase 5 PR 1 of the core-pillar migration). Adds a tRPC handler at `/trpc` inside `pops-finance-api` that exposes `finance.wishlist.*`, `finance.budgets.*`, and the CRUD slice of `finance.transactions.*` backed directly by `@pops/finance-db` on its own `finance.db` handle.

- **Additive only.** The legacy `pops-api` routers stay in place and continue to serve all real traffic until the dispatcher / nginx cutover in **PR 2** of this M2 sequence.
- Mirrors the canonical pattern from M1 (#2889), M4 (#2891), and M5 (#2892).
- Tracks roadmap row M2 + issue #2833.

## Scope kept narrow on purpose

Following the M4 (locations minus `getItems`) and M5 (nudges only) precedent of moving the clean slice and deferring entangled procedures.

### In scope (procedure paths rooted at `finance.*`)

- `finance.wishlist.{list, get, create, update, delete}`               — all 5 procedures
- `finance.budgets.{list, get, create, update, delete}`                — all 5 procedures
- `finance.transactions.{list, get, create, update, delete, restore}`  — CRUD slice (6 of 9)

### Intentionally deferred (legacy fall-through continues to serve)

- `finance.transactions.suggestTags` — uses `shared/tag-suggester`, which pulls in `core/corrections` + `core/tag-rules` + the `entities` table via the legacy unified-db drizzle handle.
- `finance.transactions.listDescriptionsForPreview` / `availableTags` — raw drizzle/better-sqlite3 reads against `getDrizzle()` / `getDb()` (legacy `pops.db`); no equivalent helper exposed by `@pops/finance-db` yet.
- `finance.imports.*` — deep cross-pillar deps into `core/corrections`, `core/tag-rules`, `core/ai-usage`, `core/settings`, `shared/tag-suggester`, and a ~10KLOC `lib/` tree under `apps/pops-api/src/modules/finance/imports/`.

These follow the M4 (`getItems`) / M5 (`scan`/`act`/`configure`) precedent of leaving entangled procedures on the legacy side until the cross-pillar surfaces they depend on move out of pops-api. The dispatcher swap in PR 2 will only route the in-scope procedure paths to finance-api.

## What landed in pops-finance-api

- `src/trpc.ts` — context factory that takes the finance DB handle as an argument (hermetic test injection); optional core DB handle drives service-account authentication; `protectedProcedure` enforces user OR scope-matched service-account principal byte-identically to the legacy router.
- `src/router.ts` — `appRouter` with `finance.{wishlist, budgets, transactions}` mounted under the same procedure paths the legacy router uses.
- `src/modules/{wishlist,budgets,transactions}/{router,types}.ts` — ported routers + types; service-layer calls take `ctx.financeDb` instead of calling `getFinanceDrizzle()` directly.
- `src/middleware/cloudflare-jwt.ts` + `src/shared/{errors,pagination,trpc-error-mapper}.ts` + `src/core-sqlite-path.ts` — local copies of the pops-api / inventory-api / core-api pieces. The container stands alone of pops-api in the dep graph (same standalone-comment convention as `finance-sqlite-path.ts`); a future refactor can lift the duplicates into a shared `@pops/auth` + `@pops/api-common` package.
- `/trpc` mounted via `createExpressMiddleware` alongside the existing `/health` route.
- New runtime deps: `@trpc/server`, `zod`, `jsonwebtoken`, `@pops/core-db`, `@pops/db-types` (versions pinned to the same ranges inventory-api uses).
- `Dockerfile` updated to bundle `packages/core-db` so the standalone deployment can authenticate service-account callers via the shared `core.db` volume.

## What's deferred to PR 2 / 3 / 4

- **PR 2 (cutover):** flip the URI dispatcher + nginx routing rules so external `finance.wishlist.*` / `finance.budgets.*` / `finance.transactions.{list,get,create,update,delete,restore}` traffic terminates at `pops-finance-api` instead of `pops-api`.
- **PR 3 (cleanup):** delete the in-scope mounts from the legacy `apps/pops-api/src/modules/finance/{wishlist,budgets,transactions}/router.ts` (keeping the deferred procedures + the entire `imports` subrouter intact so legacy fall-through still answers them).
- **PR 4 (verification):** drill (stop finance-api -> confirm shell behaviour), runbook update, and flip Track M2 row to Done in `.claude/pillar-migration-roadmap.md`.

## Test plan

- [x] `pnpm --filter @pops/finance-api typecheck` — clean
- [x] `pnpm --filter @pops/finance-api test` — 15/15 pass (2 files: health, finance-routers)
- [x] `pnpm typecheck` (turbo, all projects) — 51/51 successful
- [x] `pnpm lint` — exit 0 (warnings only, none from this PR)
- [x] `pnpm format:check` — clean
- [x] `pnpm --filter @pops/api test` — 4898/4898 pass (legacy routers untouched)
- [ ] Phase 5 PR 2 will exercise this via the dispatcher cutover; this PR is shadow-only

## Coverage in `src/__tests__/finance-routers.test.ts`

- **Happy-path tRPC caller** per slice — `wishlist`: create -> list -> get -> update -> delete (including `remainingAmount` computation); `budgets`: create -> list -> get -> update -> delete (including `spent: 0` on empty DB); `transactions`: create -> list -> get -> update -> delete -> restore round-trip preserving id + dedup metadata.
- **Wire-semantic preservation** — unknown wishlist priority short-circuits to empty data + total=0 (matches the legacy router's quirk where invalid enum values previously matched zero rows via raw SQL).
- **Auth + error mapping** — anonymous -> `UNAUTHORIZED`; in-scope SA caller succeeds; out-of-scope SA -> `FORBIDDEN`; unknown ids on `get` -> `NOT_FOUND`; malformed zod input rejected.
- **HTTP wire smoke via supertest** — `GET /trpc/finance.wishlist.list` returns the empty shape; `POST /trpc/finance.budgets.create` round-trips and the row is readable via the service layer.

## References

- Roadmap row: Track M2 in `.claude/pillar-migration-roadmap.md` — claimed as In progress with this branch name.
- Pattern: M1 (#2889), M4 (#2891), M5 (#2892).
- Tracking issue: #2833.
- Related cross-pillar URI handlers (O1-O3) gated on this row: #2843 / #2844 / #2845.