### PR TITLE
feat(finance-api): URI resolver for pops:finance/wish-list/<id> (Track O1, closes #2843)

### DIFF
--- a/apps/pops-api/src/modules/finance/uri-handler.test.ts
+++ b/apps/pops-api/src/modules/finance/uri-handler.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { seedWishListItem, setupTestContext } from '../../shared/test-utils.js';
+import { financeUriHandler, FINANCE_URI_TYPES } from './uri-handler.js';
+
+import type { Database } from 'better-sqlite3';
+
+const ctx = setupTestContext();
+let db: Database;
+
+beforeEach(() => {
+  ({ db } = ctx.setup());
+});
+
+afterEach(() => {
+  ctx.teardown();
+});
+
+describe('financeUriHandler', () => {
+  it('declares wish-list among the owned types', () => {
+    expect(FINANCE_URI_TYPES).toContain('wish-list');
+  });
+
+  it('returns unknown types as not-found rather than throwing', async () => {
+    const result = await financeUriHandler.resolve('not-a-real-type', 'anything');
+    expect(result).toEqual({ kind: 'not-found' });
+  });
+
+  describe('wish-list', () => {
+    it('resolves an existing wish list item to its row', async () => {
+      const id = seedWishListItem(db, {
+        item: 'MacBook Pro',
+        target_amount: 3999,
+        saved: 1500,
+        priority: 'Needing',
+      });
+
+      const result = await financeUriHandler.resolve('wish-list', id);
+
+      expect(result.kind).toBe('object');
+      if (result.kind !== 'object') return;
+      expect(result.data).toMatchObject({
+        id,
+        item: 'MacBook Pro',
+        targetAmount: 3999,
+        saved: 1500,
+        priority: 'Needing',
+      });
+    });
+
+    it('returns not-found for a missing wish list id', async () => {
+      const result = await financeUriHandler.resolve('wish-list', 'does-not-exist');
+      expect(result).toEqual({ kind: 'not-found' });
+    });
+  });
+});

--- a/apps/pops-api/src/modules/finance/uri-handler.ts
+++ b/apps/pops-api/src/modules/finance/uri-handler.ts
@@ -3,6 +3,8 @@ import {
   budgetsService,
   TransactionNotFoundError,
   transactionsService,
+  WishListItemNotFoundError,
+  wishListService,
 } from '@pops/finance-db';
 
 import { getFinanceDrizzle } from '../../db/finance-handle.js';
@@ -10,11 +12,11 @@ import { NotFoundError } from '../../shared/errors.js';
 /**
  * Finance URI handler (PRD-101 US-08, ADR-012).
  *
- * Owns the `pops:finance/{type}/{id}` namespace for the three object types
- * that are referenced cross-module: transactions, budgets, and entities
- * (entities live under finance because every existing reference site —
- * search adapter, tag-rule changeset, AI tool — already addresses them via
- * `pops:finance/entity/...`).
+ * Owns the `pops:finance/{type}/{id}` namespace for the object types that
+ * are referenced cross-module: transactions, budgets, entities, and wish
+ * list items (entities live under finance because every existing reference
+ * site — search adapter, tag-rule changeset, AI tool — already addresses
+ * them via `pops:finance/entity/...`).
  *
  * The handler returns `not-found` on missing rows rather than throwing the
  * service-layer `NotFoundError` — the central dispatcher (US-08) translates
@@ -24,7 +26,7 @@ import { getEntity } from '../core/entities/service.js';
 
 import type { UriHandlerDescriptor, UriResolution } from '@pops/types';
 
-export const FINANCE_URI_TYPES = ['transaction', 'entity', 'budget'] as const;
+export const FINANCE_URI_TYPES = ['transaction', 'entity', 'budget', 'wish-list'] as const;
 
 /** Run a service-layer get and translate `NotFoundError` to `not-found`. */
 async function tryGet<TData>(get: () => TData | Promise<TData>): Promise<UriResolution<TData>> {
@@ -34,7 +36,8 @@ async function tryGet<TData>(get: () => TData | Promise<TData>): Promise<UriReso
     if (
       error instanceof NotFoundError ||
       error instanceof BudgetNotFoundError ||
-      error instanceof TransactionNotFoundError
+      error instanceof TransactionNotFoundError ||
+      error instanceof WishListItemNotFoundError
     ) {
       return { kind: 'not-found' };
     }
@@ -52,6 +55,8 @@ export const financeUriHandler: UriHandlerDescriptor = {
         return tryGet(() => getEntity(id));
       case 'budget':
         return tryGet(() => budgetsService.getBudget(getFinanceDrizzle(), id));
+      case 'wish-list':
+        return tryGet(() => wishListService.getWishListItem(getFinanceDrizzle(), id));
       default:
         return { kind: 'not-found' };
     }


### PR DESCRIPTION
## Summary

- Adds `wish-list` to the finance URI handler so `pops:finance/wish-list/<id>` resolves to the wish list row via `wishListService.getWishListItem`.
- Maps `WishListItemNotFoundError` to `{ kind: 'not-found' }` alongside the existing transaction/budget/entity error translation.
- Unit-tested in `apps/pops-api/src/modules/finance/uri-handler.test.ts` (existing-id, missing-id, unknown-type).

Closes #2843.

## Test plan

- [x] `pnpm -F @pops/api run typecheck`
- [x] `pnpm -F @pops/finance-api run typecheck`
- [x] `pnpm -F @pops/api run test` — 4902/4902 pass
- [x] `pnpm lint` — clean (only pre-existing warnings)
- [x] `pnpm format:check` — clean
- [x] `pnpm -F @pops/api run build` and `openapi:validate`
