### PR TITLE
chore(husky): move typecheck from pre-commit to pre-push

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,1 @@
 npx lint-staged
-pnpm typecheck

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,3 +1,5 @@
+pnpm typecheck
+
 branch=$(git branch --show-current)
 
 [ "$branch" = "main" ] && exit 0
@@ -7,5 +9,3 @@ if ! git merge-tree --write-tree origin/main HEAD > /dev/null 2>&1; then
   echo "pre-push: branch '$branch' conflicts with origin/main — rebase before pushing."
   exit 1
 fi
-
-pnpm typecheck

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -7,3 +7,5 @@ if ! git merge-tree --write-tree origin/main HEAD > /dev/null 2>&1; then
   echo "pre-push: branch '$branch' conflicts with origin/main — rebase before pushing."
   exit 1
 fi
+
+pnpm typecheck


### PR DESCRIPTION
Pre-commit was running `pnpm typecheck` across 51 packages — 12+ minute wall per commit, killing agent throughput.

Typecheck still runs before code reaches remote (now in pre-push). Pre-commit keeps lint-staged for fast checks on staged files only.

Trade-off: typecheck failures now caught at push-time instead of commit-time. Acceptable because:
- pre-push still blocks bad code from reaching the remote
- 12-min pre-commit was causing agents to time out + skip husky entirely (worse outcome)