### PR TITLE
feat(finance-api): URI resolver for pops:finance/budget/<id> (Track O2, closes #2844)

### DIFF
--- a/apps/pops-finance-api/src/modules/budgets/uri-handler.test.ts
+++ b/apps/pops-finance-api/src/modules/budgets/uri-handler.test.ts
@@ -1,12 +1,13 @@
 /**
  * Unit tests for the budget URI handler (Track O2, #2844).
  *
- * Drives `createBudgetUriHandler` against a per-test in-memory finance.db so
- * the resolution paths are exercised end-to-end against the real
- * `budgetsService.getBudget` — `not-found` for an absent row, `object` for an
- * existing one, and `not-found` for an unrecognised type (the descriptor only
- * advertises `budget`, but the dispatcher contract still asks us to handle a
- * mismatched type gracefully).
+ * Drives `createBudgetUriHandler` against a per-test file-backed finance.db
+ * (created in a fresh `mkdtempSync` directory and closed + removed in
+ * `afterEach`) so the resolution paths are exercised end-to-end against the
+ * real `budgetsService.getBudget` — `not-found` for an absent row, `object`
+ * for an existing one, and `not-found` for an unrecognised type (the
+ * descriptor only advertises `budget`, but the dispatcher contract still
+ * asks us to handle a mismatched type gracefully).
  */
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';

--- a/apps/pops-finance-api/src/modules/budgets/uri-handler.test.ts
+++ b/apps/pops-finance-api/src/modules/budgets/uri-handler.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Unit tests for the budget URI handler (Track O2, #2844).
+ *
+ * Drives `createBudgetUriHandler` against a per-test in-memory finance.db so
+ * the resolution paths are exercised end-to-end against the real
+ * `budgetsService.getBudget` — `not-found` for an absent row, `object` for an
+ * existing one, and `not-found` for an unrecognised type (the descriptor only
+ * advertises `budget`, but the dispatcher contract still asks us to handle a
+ * mismatched type gracefully).
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { budgetsService, openFinanceDb, type OpenedFinanceDb } from '@pops/finance-db';
+
+import { BUDGET_URI_TYPES, createBudgetUriHandler } from './uri-handler.js';
+
+let tmpDir: string;
+let financeDb: OpenedFinanceDb;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'budget-uri-handler-test-'));
+  financeDb = openFinanceDb(join(tmpDir, 'finance.db'));
+});
+
+afterEach(() => {
+  financeDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('createBudgetUriHandler', () => {
+  it('declares the budget type', () => {
+    const handler = createBudgetUriHandler(financeDb.db);
+    expect(handler.types).toEqual(BUDGET_URI_TYPES);
+    expect(handler.types).toEqual(['budget']);
+  });
+
+  it('resolves an existing budget to { kind: "object" } with the row', async () => {
+    const handler = createBudgetUriHandler(financeDb.db);
+    const row = budgetsService.createBudget(financeDb.db, {
+      category: 'Groceries',
+      period: 'Monthly',
+      amount: 800,
+      active: true,
+    });
+
+    const result = await handler.resolve('budget', row.id);
+
+    expect(result.kind).toBe('object');
+    if (result.kind !== 'object') throw new Error('unreachable');
+    expect(result.data).toMatchObject({
+      id: row.id,
+      category: 'Groceries',
+      period: 'Monthly',
+    });
+  });
+
+  it('returns { kind: "not-found" } for an unknown id (does not throw)', async () => {
+    const handler = createBudgetUriHandler(financeDb.db);
+    const result = await handler.resolve('budget', 'no-such-budget');
+    expect(result).toEqual({ kind: 'not-found' });
+  });
+
+  it('returns { kind: "not-found" } for a type the handler does not own', async () => {
+    const handler = createBudgetUriHandler(financeDb.db);
+    const result = await handler.resolve('transaction', 'irrelevant');
+    expect(result).toEqual({ kind: 'not-found' });
+  });
+});

--- a/apps/pops-finance-api/src/modules/budgets/uri-handler.ts
+++ b/apps/pops-finance-api/src/modules/budgets/uri-handler.ts
@@ -1,0 +1,49 @@
+/**
+ * Budget URI handler for the finance pillar container (Track O2, #2844).
+ *
+ * Resolves `pops:finance/budget/<id>` to a `UriResolution` by calling into
+ * `budgetsService.getBudget` on the injected `FinanceDb`. Mirrors the legacy
+ * `apps/pops-api/src/modules/finance/uri-handler.ts` shape but takes the DB
+ * handle as a constructor argument rather than reaching through the pops-api
+ * `getFinanceDrizzle()` global — finance-api stands alone of pops-api in the
+ * dep graph (same convention as the migrated routers from M2 PR 1).
+ *
+ * The descriptor follows the platform-wide `UriHandlerDescriptor` contract
+ * (PRD-101 US-08, ADR-012): resolution that fails because the row is missing
+ * returns `{ kind: 'not-found' }`; only hard failures bubble up.
+ */
+import { BudgetNotFoundError, budgetsService, type FinanceDb } from '@pops/finance-db';
+
+import type { UriHandlerDescriptor, UriResolution } from '@pops/types';
+
+export const BUDGET_URI_TYPES = ['budget'] as const;
+
+async function tryGet<TData>(get: () => TData | Promise<TData>): Promise<UriResolution<TData>> {
+  try {
+    return { kind: 'object', data: await get() };
+  } catch (error) {
+    if (error instanceof BudgetNotFoundError) {
+      return { kind: 'not-found' };
+    }
+    throw error;
+  }
+}
+
+/**
+ * Factory for the budget URI handler. The DB handle is injected so the
+ * container can wire it from the same `FinanceDb` it uses for the tRPC
+ * routers, and tests can supply an in-memory handle.
+ */
+export function createBudgetUriHandler(financeDb: FinanceDb): UriHandlerDescriptor {
+  return {
+    types: BUDGET_URI_TYPES,
+    resolve: async (type, id) => {
+      switch (type) {
+        case 'budget':
+          return tryGet(() => budgetsService.getBudget(financeDb, id));
+        default:
+          return { kind: 'not-found' };
+      }
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Adds a budget URI handler under `pops-finance-api` that resolves `pops:finance/budget/<id>` to a `UriResolution` via `budgetsService.getBudget` on an injected `FinanceDb` handle.

Mirrors the legacy `apps/pops-api/src/modules/finance/uri-handler.ts` shape but takes the DB handle as a constructor argument (`createBudgetUriHandler(db)`) rather than reaching through pops-api's `getFinanceDrizzle()` global — finance-api stands alone of pops-api in the dep graph, same convention as the routers migrated in M2 PR 1 (#2933).

This is the Track O2 deliverable per the pillar-migration roadmap (cross-pillar URI handlers). It lives alongside the just-moved `finance.budgets.*` routes so the budget surface in the standalone container is feature-complete on its own. The pops-api `financeUriHandler` is untouched — it continues to serve `pops:finance/budget/...` resolution for the duration of the dispatcher dual-mount window.

## Files

- `apps/pops-finance-api/src/modules/budgets/uri-handler.ts` — `createBudgetUriHandler` factory exporting a `UriHandlerDescriptor` over `['budget']`. `tryGet` translates `BudgetNotFoundError` to `{ kind: 'not-found' }` per the descriptor contract.
- `apps/pops-finance-api/src/modules/budgets/uri-handler.test.ts` — 4 unit tests against a per-test in-memory `finance.db` (`openFinanceDb` in a `mkdtempSync` dir):
  - declares the `budget` type
  - resolves an existing budget to `{ kind: 'object', data: row }`
  - returns `{ kind: 'not-found' }` for an unknown id (does not throw)
  - returns `{ kind: 'not-found' }` for a type the handler does not own

## Test plan

- [x] `pnpm --filter @pops/finance-api typecheck` — clean
- [x] `pnpm --filter @pops/finance-api test` — 19/19 pass (3 files: existing 2 + new uri-handler)
- [x] `pnpm --filter @pops/api typecheck` — clean
- [x] `pnpm --filter @pops/api test` — 4898/4898 pass (legacy `financeUriHandler` untouched)
- [x] `pnpm format:check` — clean
- [x] `pnpm lint` — 0 errors (warnings only, none from this PR)

## References

- Issue: #2844 (Track O2)
- Pattern reference: existing `apps/pops-api/src/modules/finance/uri-handler.ts` (`financeUriHandler`)
- Upstream: M2 PR 1 #2933 (moved `finance.budgets.*` routers into pops-finance-api)
- Specs: PRD-101 US-08, ADR-012 (URI namespace + dispatcher contract)