### PR TITLE
feat(finance-api): URI resolver for pops:finance/transaction/<id> (Track O3, closes #2845)

### DIFF
--- a/apps/pops-finance-api/src/modules/transactions/uri-handler.test.ts
+++ b/apps/pops-finance-api/src/modules/transactions/uri-handler.test.ts
@@ -1,8 +1,8 @@
 /**
  * Unit tests for the transaction URI handler (Track O3, #2845).
  *
- * Drives `createTransactionUriHandler` against a per-test in-memory
- * finance.db so the resolution paths are exercised end-to-end against the
+ * Drives `createTransactionUriHandler` against a per-test file-backed
+ * finance.db (under a fresh tmpdir) so the resolution paths are exercised end-to-end against the
  * real `transactionsService.getTransaction` — `not-found` for an absent
  * row, `object` for an existing one, and `not-found` for an unrecognised
  * type (the descriptor only advertises `transaction`, but the dispatcher

--- a/apps/pops-finance-api/src/modules/transactions/uri-handler.test.ts
+++ b/apps/pops-finance-api/src/modules/transactions/uri-handler.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Unit tests for the transaction URI handler (Track O3, #2845).
+ *
+ * Drives `createTransactionUriHandler` against a per-test in-memory
+ * finance.db so the resolution paths are exercised end-to-end against the
+ * real `transactionsService.getTransaction` — `not-found` for an absent
+ * row, `object` for an existing one, and `not-found` for an unrecognised
+ * type (the descriptor only advertises `transaction`, but the dispatcher
+ * contract still asks us to handle a mismatched type gracefully).
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { openFinanceDb, transactionsService, type OpenedFinanceDb } from '@pops/finance-db';
+
+import { createTransactionUriHandler, TRANSACTION_URI_TYPES } from './uri-handler.js';
+
+let tmpDir: string;
+let financeDb: OpenedFinanceDb;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'transaction-uri-handler-test-'));
+  financeDb = openFinanceDb(join(tmpDir, 'finance.db'));
+});
+
+afterEach(() => {
+  financeDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('createTransactionUriHandler', () => {
+  it('declares the transaction type', () => {
+    const handler = createTransactionUriHandler(financeDb.db);
+    expect(handler.types).toEqual(TRANSACTION_URI_TYPES);
+    expect(handler.types).toEqual(['transaction']);
+  });
+
+  it('resolves an existing transaction to { kind: "object" } with the row', async () => {
+    const handler = createTransactionUriHandler(financeDb.db);
+    const row = transactionsService.createTransaction(financeDb.db, {
+      description: 'Groceries',
+      account: 'Up Savings',
+      amount: 50.0,
+      date: '2025-06-15',
+      type: 'Purchase',
+    });
+
+    const result = await handler.resolve('transaction', row.id);
+
+    expect(result.kind).toBe('object');
+    if (result.kind !== 'object') throw new Error('unreachable');
+    expect(result.data).toMatchObject({
+      id: row.id,
+      description: 'Groceries',
+      account: 'Up Savings',
+      amount: 50.0,
+      date: '2025-06-15',
+      type: 'Purchase',
+    });
+  });
+
+  it('returns { kind: "not-found" } for an unknown id (does not throw)', async () => {
+    const handler = createTransactionUriHandler(financeDb.db);
+    const result = await handler.resolve('transaction', 'no-such-transaction');
+    expect(result).toEqual({ kind: 'not-found' });
+  });
+
+  it('returns { kind: "not-found" } for a type the handler does not own', async () => {
+    const handler = createTransactionUriHandler(financeDb.db);
+    const result = await handler.resolve('budget', 'irrelevant');
+    expect(result).toEqual({ kind: 'not-found' });
+  });
+});

--- a/apps/pops-finance-api/src/modules/transactions/uri-handler.ts
+++ b/apps/pops-finance-api/src/modules/transactions/uri-handler.ts
@@ -1,0 +1,50 @@
+/**
+ * Transaction URI handler for the finance pillar container (Track O3, #2845).
+ *
+ * Resolves `pops:finance/transaction/<id>` to a `UriResolution` by calling
+ * into `transactionsService.getTransaction` on the injected `FinanceDb`.
+ * Mirrors the legacy `apps/pops-api/src/modules/finance/uri-handler.ts`
+ * shape but takes the DB handle as a constructor argument rather than
+ * reaching through the pops-api `getFinanceDrizzle()` global — finance-api
+ * stands alone of pops-api in the dep graph (same convention as the
+ * migrated routers from M2 PR 1 and the budget URI handler from O2).
+ *
+ * The descriptor follows the platform-wide `UriHandlerDescriptor` contract
+ * (PRD-101 US-08, ADR-012): resolution that fails because the row is missing
+ * returns `{ kind: 'not-found' }`; only hard failures bubble up.
+ */
+import { TransactionNotFoundError, transactionsService, type FinanceDb } from '@pops/finance-db';
+
+import type { UriHandlerDescriptor, UriResolution } from '@pops/types';
+
+export const TRANSACTION_URI_TYPES = ['transaction'] as const;
+
+async function tryGet<TData>(get: () => TData | Promise<TData>): Promise<UriResolution<TData>> {
+  try {
+    return { kind: 'object', data: await get() };
+  } catch (error) {
+    if (error instanceof TransactionNotFoundError) {
+      return { kind: 'not-found' };
+    }
+    throw error;
+  }
+}
+
+/**
+ * Factory for the transaction URI handler. The DB handle is injected so
+ * the container can wire it from the same `FinanceDb` it uses for the tRPC
+ * routers, and tests can supply an in-memory handle.
+ */
+export function createTransactionUriHandler(financeDb: FinanceDb): UriHandlerDescriptor {
+  return {
+    types: TRANSACTION_URI_TYPES,
+    resolve: async (type, id) => {
+      switch (type) {
+        case 'transaction':
+          return tryGet(() => transactionsService.getTransaction(financeDb, id));
+        default:
+          return { kind: 'not-found' };
+      }
+    },
+  };
+}

--- a/apps/pops-finance-api/src/modules/transactions/uri-handler.ts
+++ b/apps/pops-finance-api/src/modules/transactions/uri-handler.ts
@@ -7,7 +7,7 @@
  * shape but takes the DB handle as a constructor argument rather than
  * reaching through the pops-api `getFinanceDrizzle()` global — finance-api
  * stands alone of pops-api in the dep graph (same convention as the
- * migrated routers from M2 PR 1 and the budget URI handler from O2).
+ * migrated routers from M2 PR 1).
  *
  * The descriptor follows the platform-wide `UriHandlerDescriptor` contract
  * (PRD-101 US-08, ADR-012): resolution that fails because the row is missing


### PR DESCRIPTION
## Summary

- Adds `createTransactionUriHandler` factory in `apps/pops-finance-api/src/modules/transactions/uri-handler.ts`, mirroring the O2 budget pattern. Takes an injected `FinanceDb` handle and resolves `pops:finance/transaction/<id>` via `transactionsService.getTransaction`.
- Maps `TransactionNotFoundError` to `{ kind: 'not-found' }`; everything else bubbles per the `UriHandlerDescriptor` contract (PRD-101 US-08, ADR-012).
- Adds a per-test in-memory finance.db unit suite covering the happy path, missing-row, mismatched-type, and the declared types contract.

closes #2845

## Test plan

- [x] `pnpm -F @pops/finance-api run typecheck`
- [x] `pnpm -F @pops/finance-api run test` (19 passed)
- [x] `pnpm lint apps/pops-finance-api/src/modules/transactions/uri-handler.ts apps/pops-finance-api/src/modules/transactions/uri-handler.test.ts`
- [x] `pnpm format:check`