### PR TITLE
feat(finance-contract): scaffold @pops/finance-contract package (Theme 13 PRD-153)

### DIFF
--- a/apps/pops-finance-api/package.json
+++ b/apps/pops-finance-api/package.json
@@ -5,8 +5,7 @@
   "type": "module",
   "exports": {
     "./router": {
-      "types": "./src/router.ts",
-      "default": "./src/router.ts"
+      "types": "./src/router.ts"
     }
   },
   "scripts": {

--- a/apps/pops-finance-api/package.json
+++ b/apps/pops-finance-api/package.json
@@ -3,6 +3,12 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
+  "exports": {
+    "./router": {
+      "types": "./src/router.ts",
+      "default": "./src/router.ts"
+    }
+  },
   "scripts": {
     "build": "tsc",
     "dev": "tsx watch --clear-screen=false src/server.ts",

--- a/docs/themes/13-pillar-finale/epics/00-contract-packages.md
+++ b/docs/themes/13-pillar-finale/epics/00-contract-packages.md
@@ -10,14 +10,15 @@ This is the foundation for cross-pillar type safety after the registry-based dis
 
 ## PRDs
 
-| #   | PRD                        | Summary                                                                                                                   | Status      |
-| --- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| 153 | Contract package scaffold  | Per-pillar `@pops/contract-<pillar>` package shape, content boundaries, build pipeline                                    | Not started |
-| 154 | Semver enforcement CI      | A new CI job that diffs contract-package public surface area and fails the build on breaking changes without a major bump | Not started |
-| 155 | Manifest type generation   | Generate the union `<Pillar>Contract` interface from the per-feature exports so consumers have one entry point            | Not started |
-| 156 | Consumer import discipline | Lint rule: "non-owning code may not import from `@pops/<pillar>-db`"; consumers go through `@pops/contract-<pillar>`      | Not started |
+| #   | PRD                        | Summary                                                                                                                                                                                           | Status      |
+| --- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| 153 | Contract package scaffold  | Per-pillar `@pops/<pillar>-contract` package shape, content boundaries, build pipeline                                                                                                            | Partial     |
+| 154 | Semver enforcement CI      | CI job that diffs contract-package public surface (TS + Zod) against last git tag and blocks PRs on mismatched bumps. Includes affected-package rebuild via turbo `--filter='...[<merge-base>]'`. | Not started |
+| 155 | Manifest type generation   | Generate the union `<Pillar>Contract` interface from the per-feature exports so consumers have one entry point                                                                                    | Not started |
+| 156 | Consumer import discipline | Lint rule: "non-owning code may not import from `@pops/<pillar>-db`"; consumers go through `@pops/<pillar>-contract`                                                                              | Not started |
+| 219 | pops-docs container        | Tiny static container serving Stoplight Elements pointed at every contract's OpenAPI spec; browseable at `/docs/`                                                                                 | Not started |
 
-PRDs 153-156 can run in parallel. 153 unblocks the rest by providing the package shape.
+PRDs 153, 154, 155, 156 can run in parallel after 153 establishes the shape. PRD-219 is independent of the rest (only depends on PRD-153 emitting OpenAPI specs); good "filler" PRD when waiting on something else.
 
 ## Dependencies
 

--- a/packages/finance-contract/README.md
+++ b/packages/finance-contract/README.md
@@ -1,7 +1,8 @@
 # @pops/finance-contract
 
 Public contract for the **finance** pillar — types, Zod schemas, tRPC router
-type, error discriminants, and OpenAPI snapshot.
+type, and error discriminants. An OpenAPI snapshot is planned (see PRD-153
+US-04) but not yet shipped.
 
 Workspace-only. Never published to npm.
 
@@ -16,6 +17,12 @@ src/
 ├── errors.ts       discriminated error envelope { kind: 'ok' | 'not-found' | … }
 ├── manifest.ts     <FinanceContract> structural snapshot for the registry
 └── __tests__/      round-trip Zod ↔ TS tests
+```
+
+Planned in subsequent PRs (PRD-153 US-04 + the scaffold script PRD-153 US-06,
+and the OpenAPI drift-check half of PRD-154):
+
+```
 openapi/
 └── finance.openapi.json   generated; committed for iOS Swift codegen
 scripts/
@@ -26,14 +33,16 @@ scripts/
 
 - **Zero runtime deps on `@pops/finance-db`.** `finance-db` is a
   devDependency only — used at build time to extract the router type and
-  emit OpenAPI. Consumers depend on this package; the lint rule in PRD-156
-  enforces that.
+  (once shipped) emit OpenAPI. Consumers depend on this package; the lint
+  rule in PRD-156 enforces that.
 - **Types and schemas agree.** `z.infer<typeof XSchema>` must structurally
   equal `X` from `./types`. The round-trip test in `__tests__/schemas.test.ts`
   is the gate.
-- **OpenAPI regenerates on every build.** A drift-check job (PRD-154) runs
-  the generator and fails if the committed `openapi/finance.openapi.json`
-  diverges from a fresh emission.
+- **OpenAPI regenerates on every build (planned).** PRD-153 US-04 ships
+  `scripts/generate-openapi.ts` and the committed `openapi/finance.openapi.json`
+  snapshot. PRD-154 adds the drift-check job that fails the build if the
+  committed file diverges from a fresh emission. Until those PRDs land,
+  `pnpm build` only runs `tsc`.
 
 See [PRD-153](../../docs/themes/13-pillar-finale/prds/153-contract-package-scaffold/README.md)
 for the full design.

--- a/packages/finance-contract/README.md
+++ b/packages/finance-contract/README.md
@@ -1,0 +1,39 @@
+# @pops/finance-contract
+
+Public contract for the **finance** pillar — types, Zod schemas, tRPC router
+type, error discriminants, and OpenAPI snapshot.
+
+Workspace-only. Never published to npm.
+
+## Shape
+
+```
+src/
+├── index.ts        barrel
+├── types/          plain TypeScript entity types (Wishlist, Transaction, …)
+├── schemas/        Zod runtime validators matching ./types 1:1
+├── router.ts       tRPC router *type* extracted from pops-finance-api (no runtime)
+├── errors.ts       discriminated error envelope { kind: 'ok' | 'not-found' | … }
+├── manifest.ts     <FinanceContract> structural snapshot for the registry
+└── __tests__/      round-trip Zod ↔ TS tests
+openapi/
+└── finance.openapi.json   generated; committed for iOS Swift codegen
+scripts/
+└── generate-openapi.ts    runs at build time; emits the JSON above
+```
+
+## Rules
+
+- **Zero runtime deps on `@pops/finance-db`.** `finance-db` is a
+  devDependency only — used at build time to extract the router type and
+  emit OpenAPI. Consumers depend on this package; the lint rule in PRD-156
+  enforces that.
+- **Types and schemas agree.** `z.infer<typeof XSchema>` must structurally
+  equal `X` from `./types`. The round-trip test in `__tests__/schemas.test.ts`
+  is the gate.
+- **OpenAPI regenerates on every build.** A drift-check job (PRD-154) runs
+  the generator and fails if the committed `openapi/finance.openapi.json`
+  diverges from a fresh emission.
+
+See [PRD-153](../../docs/themes/13-pillar-finale/prds/153-contract-package-scaffold/README.md)
+for the full design.

--- a/packages/finance-contract/package.json
+++ b/packages/finance-contract/package.json
@@ -30,7 +30,6 @@
       "types": "./dist/manifest.d.ts",
       "default": "./dist/manifest.js"
     },
-    "./openapi": "./openapi/finance.openapi.json",
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/packages/finance-contract/package.json
+++ b/packages/finance-contract/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@pops/finance-contract",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./types": {
+      "types": "./dist/types/index.d.ts",
+      "default": "./dist/types/index.js"
+    },
+    "./schemas": {
+      "types": "./dist/schemas/index.d.ts",
+      "default": "./dist/schemas/index.js"
+    },
+    "./router": {
+      "types": "./dist/router.d.ts",
+      "default": "./dist/router.js"
+    },
+    "./errors": {
+      "types": "./dist/errors.d.ts",
+      "default": "./dist/errors.js"
+    },
+    "./manifest": {
+      "types": "./dist/manifest.d.ts",
+      "default": "./dist/manifest.js"
+    },
+    "./openapi": "./openapi/finance.openapi.json",
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@pops/types": "workspace:*",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@pops/finance-api": "workspace:*",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.8"
+  }
+}

--- a/packages/finance-contract/src/__tests__/schemas.test.ts
+++ b/packages/finance-contract/src/__tests__/schemas.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+
+import { WishListItemSchema } from '../schemas/wish-list-item.js';
+
+import type { z } from 'zod';
+
+import type { WishListItem } from '../types/wish-list-item.js';
+
+describe('@pops/finance-contract round-trip', () => {
+  it('WishListItem ↔ WishListItemSchema agree structurally', () => {
+    expectTypeOf<z.infer<typeof WishListItemSchema>>().toEqualTypeOf<WishListItem>();
+  });
+
+  it('WishListItemSchema accepts a well-formed payload', () => {
+    const payload: WishListItem = {
+      id: 'wl_1',
+      item: 'Espresso machine',
+      targetAmount: 80000,
+      saved: 12000,
+      remainingAmount: 68000,
+      priority: 'high',
+      url: null,
+      notes: null,
+      lastEditedTime: '2026-06-12T00:00:00.000Z',
+    };
+
+    expect(WishListItemSchema.parse(payload)).toEqual(payload);
+  });
+
+  it('WishListItemSchema rejects an unknown priority', () => {
+    const bad = {
+      id: 'wl_1',
+      item: 'x',
+      targetAmount: null,
+      saved: null,
+      remainingAmount: null,
+      priority: 'urgent',
+      url: null,
+      notes: null,
+      lastEditedTime: '2026-06-12T00:00:00.000Z',
+    };
+
+    expect(() => WishListItemSchema.parse(bad)).toThrow();
+  });
+});

--- a/packages/finance-contract/src/__tests__/schemas.test.ts
+++ b/packages/finance-contract/src/__tests__/schemas.test.ts
@@ -1,14 +1,20 @@
 import { describe, expect, expectTypeOf, it } from 'vitest';
 
+import { FinanceErrorSchema } from '../errors.js';
 import { WishListItemSchema } from '../schemas/wish-list-item.js';
 
 import type { z } from 'zod';
 
+import type { FinanceError } from '../errors.js';
 import type { WishListItem } from '../types/wish-list-item.js';
 
 describe('@pops/finance-contract round-trip', () => {
   it('WishListItem ↔ WishListItemSchema agree structurally', () => {
     expectTypeOf<z.infer<typeof WishListItemSchema>>().toEqualTypeOf<WishListItem>();
+  });
+
+  it('FinanceError ↔ FinanceErrorSchema agree structurally', () => {
+    expectTypeOf<z.infer<typeof FinanceErrorSchema>>().toEqualTypeOf<FinanceError>();
   });
 
   it('WishListItemSchema accepts a well-formed payload', () => {
@@ -18,8 +24,8 @@ describe('@pops/finance-contract round-trip', () => {
       targetAmount: 80000,
       saved: 12000,
       remainingAmount: 68000,
-      priority: 'high',
-      url: null,
+      priority: 'Soon',
+      url: 'https://example.com/espresso',
       notes: null,
       lastEditedTime: '2026-06-12T00:00:00.000Z',
     };
@@ -34,12 +40,57 @@ describe('@pops/finance-contract round-trip', () => {
       targetAmount: null,
       saved: null,
       remainingAmount: null,
-      priority: 'urgent',
+      priority: 'high',
       url: null,
       notes: null,
       lastEditedTime: '2026-06-12T00:00:00.000Z',
     };
 
     expect(() => WishListItemSchema.parse(bad)).toThrow();
+  });
+
+  it('WishListItemSchema rejects a malformed URL', () => {
+    const bad: WishListItem = {
+      id: 'wl_1',
+      item: 'x',
+      targetAmount: null,
+      saved: null,
+      remainingAmount: null,
+      priority: null,
+      url: 'not-a-url',
+      notes: null,
+      lastEditedTime: '2026-06-12T00:00:00.000Z',
+    };
+
+    expect(() => WishListItemSchema.parse(bad)).toThrow();
+  });
+
+  it('WishListItemSchema rejects a non-ISO-8601 lastEditedTime', () => {
+    const bad: WishListItem = {
+      id: 'wl_1',
+      item: 'x',
+      targetAmount: null,
+      saved: null,
+      remainingAmount: null,
+      priority: null,
+      url: null,
+      notes: null,
+      lastEditedTime: '12 June 2026',
+    };
+
+    expect(() => WishListItemSchema.parse(bad)).toThrow();
+  });
+
+  it('FinanceErrorSchema accepts ContractStatus envelope', () => {
+    expect(FinanceErrorSchema.parse({ kind: 'unavailable' })).toEqual({ kind: 'unavailable' });
+  });
+
+  it('FinanceErrorSchema accepts a budget-exceeded domain error', () => {
+    const err: FinanceError = { kind: 'budget-exceeded', budgetId: 'b_1', overspendCents: 4200 };
+    expect(FinanceErrorSchema.parse(err)).toEqual(err);
+  });
+
+  it('FinanceErrorSchema rejects an unknown kind', () => {
+    expect(() => FinanceErrorSchema.parse({ kind: 'mystery' })).toThrow();
   });
 });

--- a/packages/finance-contract/src/errors.ts
+++ b/packages/finance-contract/src/errors.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod';
+
+/**
+ * Shared error envelope every contract surfaces. Cross-pillar callers
+ * branch on `kind` to render UX (placeholder for `unavailable`, retry for
+ * `degraded`, etc.) without needing pillar-specific knowledge.
+ *
+ * Per-pillar domain errors extend this union — see `FinanceDomainError`.
+ */
+export type ContractStatus = 'ok' | 'not-found' | 'unavailable' | 'degraded';
+
+export const ContractStatusSchema = z.enum(['ok', 'not-found', 'unavailable', 'degraded']);
+
+/**
+ * Finance-specific domain errors. Add new discriminants here as the pillar
+ * grows; consumers narrow on `kind`.
+ */
+export type FinanceDomainError =
+  | { kind: 'budget-exceeded'; budgetId: string; overspendCents: number }
+  | { kind: 'invalid-currency'; code: string };
+
+export const FinanceDomainErrorSchema = z.discriminatedUnion('kind', [
+  z.object({
+    kind: z.literal('budget-exceeded'),
+    budgetId: z.string(),
+    overspendCents: z.number().int(),
+  }),
+  z.object({
+    kind: z.literal('invalid-currency'),
+    code: z.string(),
+  }),
+]);
+
+export type FinanceError = { kind: ContractStatus } | FinanceDomainError;

--- a/packages/finance-contract/src/errors.ts
+++ b/packages/finance-contract/src/errors.ts
@@ -32,3 +32,8 @@ export const FinanceDomainErrorSchema = z.discriminatedUnion('kind', [
 ]);
 
 export type FinanceError = { kind: ContractStatus } | FinanceDomainError;
+
+export const FinanceErrorSchema = z.union([
+  z.object({ kind: ContractStatusSchema }).strict(),
+  FinanceDomainErrorSchema,
+]);

--- a/packages/finance-contract/src/index.ts
+++ b/packages/finance-contract/src/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Barrel for `@pops/finance-contract`. Sub-paths
+ * (`/types`, `/schemas`, `/router`, `/errors`, `/manifest`) are the
+ * preferred imports for consumers — the barrel exists for ergonomics and
+ * for the registry/SDK code paths that pull everything.
+ */
+export * from './types/index.js';
+export * from './schemas/index.js';
+export * from './errors.js';
+export type { FinanceRouter } from './router.js';
+export type { FinanceContract } from './manifest.js';

--- a/packages/finance-contract/src/manifest.ts
+++ b/packages/finance-contract/src/manifest.ts
@@ -1,0 +1,21 @@
+import type { FinanceError } from './errors.js';
+import type { FinanceRouter } from './router.js';
+import type { WishListItem } from './types/wish-list-item.js';
+
+/**
+ * Structural snapshot of the finance pillar's public surface. The registry
+ * (Epic 02 / PRD-161) serves this shape; the iOS Swift codegen reads it via
+ * the OpenAPI sibling; PRD-154's semver CI diffs it.
+ *
+ * Hand-maintained for now; PRD-155 replaces this with a generator that
+ * derives the structure from the per-entity exports.
+ */
+export interface FinanceContract {
+  readonly pillar: 'finance';
+  readonly version: string;
+  readonly entities: {
+    readonly wishListItem: WishListItem;
+  };
+  readonly errors: FinanceError;
+  readonly router: FinanceRouter;
+}

--- a/packages/finance-contract/src/manifest.ts
+++ b/packages/finance-contract/src/manifest.ts
@@ -4,10 +4,11 @@ import type { WishListItem } from './types/wish-list-item.js';
 
 /**
  * Structural snapshot of the finance pillar's public surface. The registry
- * (Epic 02 / PRD-161) serves this shape; the iOS Swift codegen reads it via
- * the OpenAPI sibling; PRD-154's semver CI diffs it.
+ * (Epic 02 / PRD-161) will serve this shape; the iOS Swift codegen will read
+ * it via the OpenAPI sibling (planned in PRD-153 US-04 — not yet shipped);
+ * PRD-154's semver CI will diff it.
  *
- * Hand-maintained for now; PRD-155 replaces this with a generator that
+ * Hand-maintained for now; PRD-155 will replace this with a generator that
  * derives the structure from the per-entity exports.
  */
 export interface FinanceContract {

--- a/packages/finance-contract/src/router.ts
+++ b/packages/finance-contract/src/router.ts
@@ -9,9 +9,10 @@
  * emitted `.d.ts` still references `@pops/finance-api` (which transitively
  * references `@pops/finance-db`). The lint rule in PRD-156 stays focused
  * on *value* imports; type-only references through the contract are
- * tolerated as the migration intermediate. The OpenAPI snapshot
- * (`openapi/finance.openapi.json`) is the long-term wire-typed alternative
- * consumers can use instead.
+ * tolerated as the migration intermediate. A committed OpenAPI snapshot
+ * at `openapi/finance.openapi.json` is the planned long-term wire-typed
+ * alternative consumers can use instead (PRD-153 US-04 — not yet
+ * shipped).
  */
 import type { financeRouter } from '@pops/finance-api/router';
 

--- a/packages/finance-contract/src/router.ts
+++ b/packages/finance-contract/src/router.ts
@@ -1,0 +1,18 @@
+/**
+ * The finance pillar's tRPC router *type*. Type-only re-export from
+ * `apps/pops-finance-api` — no runtime tRPC code crosses the contract
+ * boundary. Consumers use this to type the `pillar('finance').foo.bar(…)`
+ * SDK calls (Epic 05 / PRD-191).
+ *
+ * Current shape: `typeof financeRouter`. Until PRD-153 us-04 + PRD-155 land
+ * the build-time declaration bundler, this re-export means the contract's
+ * emitted `.d.ts` still references `@pops/finance-api` (which transitively
+ * references `@pops/finance-db`). The lint rule in PRD-156 stays focused
+ * on *value* imports; type-only references through the contract are
+ * tolerated as the migration intermediate. The OpenAPI snapshot
+ * (`openapi/finance.openapi.json`) is the long-term wire-typed alternative
+ * consumers can use instead.
+ */
+import type { financeRouter } from '@pops/finance-api/router';
+
+export type FinanceRouter = typeof financeRouter;

--- a/packages/finance-contract/src/schemas/index.ts
+++ b/packages/finance-contract/src/schemas/index.ts
@@ -1,0 +1,1 @@
+export { WishListItemSchema, WishListPrioritySchema } from './wish-list-item.js';

--- a/packages/finance-contract/src/schemas/wish-list-item.ts
+++ b/packages/finance-contract/src/schemas/wish-list-item.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod';
+
+import { WISH_LIST_PRIORITIES } from '../types/wish-list-item.js';
+
+export const WishListPrioritySchema = z.enum(WISH_LIST_PRIORITIES);
+
+export const WishListItemSchema = z.object({
+  id: z.string(),
+  item: z.string(),
+  targetAmount: z.number().nullable(),
+  saved: z.number().nullable(),
+  remainingAmount: z.number().nullable(),
+  priority: WishListPrioritySchema.nullable(),
+  url: z.string().nullable(),
+  notes: z.string().nullable(),
+  lastEditedTime: z.string(),
+});

--- a/packages/finance-contract/src/schemas/wish-list-item.ts
+++ b/packages/finance-contract/src/schemas/wish-list-item.ts
@@ -11,7 +11,7 @@ export const WishListItemSchema = z.object({
   saved: z.number().nullable(),
   remainingAmount: z.number().nullable(),
   priority: WishListPrioritySchema.nullable(),
-  url: z.string().nullable(),
+  url: z.string().url().nullable(),
   notes: z.string().nullable(),
-  lastEditedTime: z.string(),
+  lastEditedTime: z.string().datetime(),
 });

--- a/packages/finance-contract/src/types/index.ts
+++ b/packages/finance-contract/src/types/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Public entity types for the finance pillar. Hand-maintained — adding
+ * a new entity means adding both a file under `types/` and a matching
+ * schema under `schemas/`. The round-trip test enforces that they agree.
+ */
+export type { WishListItem, WishListPriority } from './wish-list-item.js';

--- a/packages/finance-contract/src/types/wish-list-item.ts
+++ b/packages/finance-contract/src/types/wish-list-item.ts
@@ -1,0 +1,22 @@
+export const WISH_LIST_PRIORITIES = ['low', 'medium', 'high'] as const;
+
+export type WishListPriority = (typeof WISH_LIST_PRIORITIES)[number];
+
+/**
+ * A single row on a user's wishlist. The shape mirrors the API response
+ * (camelCase) — DB-internal shape lives in `@pops/finance-db` and is not
+ * surfaced through the contract.
+ */
+export interface WishListItem {
+  id: string;
+  item: string;
+  targetAmount: number | null;
+  saved: number | null;
+  /** `targetAmount - saved`, or `null` when either operand is null. */
+  remainingAmount: number | null;
+  priority: WishListPriority | null;
+  url: string | null;
+  notes: string | null;
+  /** ISO-8601 timestamp. */
+  lastEditedTime: string;
+}

--- a/packages/finance-contract/src/types/wish-list-item.ts
+++ b/packages/finance-contract/src/types/wish-list-item.ts
@@ -1,4 +1,4 @@
-export const WISH_LIST_PRIORITIES = ['low', 'medium', 'high'] as const;
+export const WISH_LIST_PRIORITIES = ['Needing', 'Soon', 'One Day', 'Dreaming'] as const;
 
 export type WishListPriority = (typeof WISH_LIST_PRIORITIES)[number];
 
@@ -15,8 +15,9 @@ export interface WishListItem {
   /** `targetAmount - saved`, or `null` when either operand is null. */
   remainingAmount: number | null;
   priority: WishListPriority | null;
+  /** Absolute URL. Validated by `WishListItemSchema` via `.url()`. */
   url: string | null;
   notes: string | null;
-  /** ISO-8601 timestamp. */
+  /** ISO-8601 timestamp. Validated by `WishListItemSchema` via `.datetime()`. */
   lastEditedTime: string;
 }

--- a/packages/finance-contract/tsconfig.json
+++ b/packages/finance-contract/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "lib": ["ES2022"],
+    "types": [],
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/__tests__/**", "**/*.test.ts", "scripts/**"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1704,6 +1704,25 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
 
+  packages/finance-contract:
+    dependencies:
+      '@pops/types':
+        specifier: workspace:*
+        version: link:../types
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@pops/finance-api':
+        specifier: workspace:*
+        version: link:../../apps/pops-finance-api
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.3)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
+
   packages/finance-db:
     dependencies:
       '@pops/db-types':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,6 +12,7 @@ packages:
   - 'packages/overlay-ego'
   - 'packages/api-client'
   - 'packages/core-db'
+  - 'packages/finance-contract'
   - 'packages/finance-db'
   - 'packages/db-types'
   - 'packages/inventory-db'


### PR DESCRIPTION
## Summary

Establishes the shape for per-pillar contract packages — TypeScript types + Zod schemas + tRPC router type re-export + error envelope + manifest snapshot. Workspace-only; no npm publish. Finance is the pilot pillar.

Covers initial scope of [PRD-153](docs/themes/13-pillar-finale/prds/153-contract-package-scaffold/README.md) — US-01 (package skeleton), US-02 (types/schemas/errors with round-trip test), US-03 (router type re-export).

## Changes

- `packages/finance-contract/` skeleton with `src/{types,schemas}/index.ts` barrels, `errors.ts`, `manifest.ts`, `router.ts`
- `WishListItem` as the first migrated entity — type + Zod schema + round-trip test asserting `z.infer<typeof X>` matches the TS type
- `apps/pops-finance-api` exposes `./router` export for type-only router extraction
- pnpm workspace includes `packages/finance-contract`
- Epic 00 PRD-153 status: Not started → Partial

## Remaining PRD-153 work (subsequent PRs)

- US-04 OpenAPI generator (`scripts/generate-openapi.ts`)
- US-05 manifest snapshot auto-generation (PRD-155 covers this)
- US-06 scaffold script (`pnpm gen:contract <pillar>`)
- US-07 finance entity content migration (transactions, budgets, entities)
- US-08 consumer migration pilot (one consumer flips to `@pops/finance-contract`)

## Test plan

- [x] `pnpm test` in `packages/finance-contract` — 3 tests pass (round-trip type equality, well-formed payload accept, malformed payload reject)
- [x] `mise typecheck` — 53/53 workspace packages green
- [x] `mise lint` — exit 0 (warnings only, no errors)
- [ ] CI green on this PR