### PR TITLE
docs(theme-13): add CI lean-ness track to implementation plan

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -465,16 +465,17 @@ When working in this repository (any `pops*` workspace), agents should:
 
 - **Auto-commit logical chunks as you go.** Don't wait for explicit permission for each commit. A "logical chunk" is one coherent change: a feature increment, a bug fix, a refactor that compiles + passes tests. Don't bundle unrelated changes into one commit.
 - **Auto-open the PR when the work is ready for review.** Push the branch and run `gh pr create` without prompting first. PR title + body must follow the project conventions (see commit messages in git log for tone).
-- **Still ask before any destructive operation.** No force-push, no `git reset --hard` on shared branches, no pushes directly to `main`, no PR closes/merges, no branch deletes — these always require explicit user confirmation regardless of this override.
+- **Auto-merge a PR once BOTH of these are true:** (a) every required CI check is green (no skipped-required, no in-progress, no failure), AND (b) every Copilot review comment is either addressed in a follow-up commit on the same branch OR explicitly rebutted with a reply that explains why the comment is wrong. No human review wait — the project relies on CI + Copilot as the gates. Use `gh pr merge --squash --delete-branch` (squash to keep main history flat). Do NOT auto-merge when CI is partially green but some required checks are still pending — wait for them.
+- **Still ask before other destructive operations.** No force-push, no `git reset --hard` on shared branches, no pushes directly to `main`, no PR closes (non-merge), no branch deletes outside of `gh pr merge --delete-branch`, no `--no-verify` on hooks — these always require explicit user confirmation regardless of this override.
 - **Still respect signed-off / no-claude-references rules** from the global `~/.claude/CLAUDE.md`: no Claude as co-author, no Claude references in commit messages or PR bodies.
 - **Still verify CI passes locally before pushing** per the "CI should never fail" rule in `~/.claude/CLAUDE.md`.
 
 ### PR review cadence
 
-GitHub Copilot's automated PR review is **disabled** on this repo (it was hitting usage limits). The user is **not** reviewing PRs manually either. There is no review safety net — every PR you open ships as-is.
+CI + GitHub Copilot are the merge gates. The user does **not** review PRs manually — getting it right before pushing is non-negotiable.
 
-Implication for agents:
-
+- **CI is required and non-skippable.** Every required check must complete green before the merge. A skipped check that satisfies branch protection counts as green; a check stuck `in_progress` does not — wait it out.
+- **Copilot review comments are blocking.** When Copilot's automated review leaves comments on a PR, each comment must be either: (a) addressed in a fix commit on the same branch and the comment resolved, or (b) replied to with a rebuttal that explains why Copilot is wrong. Agents must check `gh pr view <n> --json reviews,reviewThreads` (or equivalent) before merging and act on any unresolved Copilot thread.
 - **Get the PR right before pushing.** Run typecheck, tests, lint, and the relevant Docker/compose validations locally. If it fails locally, it ships broken.
 - Do **not** suggest "request a re-review" or "ping a human" — neither will happen.
 

--- a/docs/themes/13-pillar-finale/IMPLEMENTATION-PLAN.md
+++ b/docs/themes/13-pillar-finale/IMPLEMENTATION-PLAN.md
@@ -55,6 +55,7 @@ Five waves. Each wave is a set of PRDs that can ship concurrently. Waves are gat
 | 155 manifest type generation (finance pilot) | 4 (parallel with 158) | `a:manifest-gen`      |
 | 191 client surface                           | 5                     | `a:client-sdk`        |
 | 192 server surface                           | 5 (parallel with 191) | `a:server-sdk`        |
+| 220 CI path-filter audit                     | 1 (parallel with 153) | `a:ci-lean-1`         |
 
 **Wave 1 exit criteria:**
 
@@ -63,6 +64,7 @@ Five waves. Each wave is a set of PRDs that can ship concurrently. Waves are gat
 - `pillar('finance').wishlist.list({})` works end-to-end from pops-shell (or a test harness)
 - Contract semver CI (PRD-154) catches at least one synthetic breaking change in tests
 - Import discipline lint (PRD-156) baseline is committed
+- Docs-only PR fires ≤ 4 required checks (PRD-220)
 
 **Wave 1 duration:** 6-8 weeks.
 
@@ -388,6 +390,89 @@ Status legend: ⏳ Not started · 🔄 In progress · ✅ Done · ⛔ Blocked
 | 219     | docs-swagger-container           | 2    | ⏳     | 153                    | dev ergonomics                 |
 | 184     | core-tag-rules-cleanup           | 3    | ⏳     | 206                    | core cleanup                   |
 | 185     | core-corrections-cleanup         | 3    | ⏳     | 206                    | core cleanup                   |
+| 220     | ci-path-filter-audit             | 1    | ⏳     | independent            | CI lean-ness wave 1            |
+| 221     | ci-affected-rebuild              | 2    | ⏳     | 220                    | CI lean-ness wave 2            |
+| 222     | ci-docs-fast-path                | 2    | ⏳     | 220                    | CI lean-ness wave 2            |
+| 223     | ci-pillar-isolation              | 3    | ⏳     | 221                    | CI lean-ness wave 3            |
+| 224     | ci-e2e-scoping                   | 3    | ⏳     | 221                    | CI lean-ness wave 3            |
+| 225     | ci-publish-narrowing             | 4    | ⏳     | 221                    | CI lean-ness wave 4            |
+| 226     | ci-budget-enforcement            | 5    | ⏳     | 220-225                | CI lean-ness wave 5            |
+
+---
+
+## CI lean-ness (continuous track, runs across all waves)
+
+The pillar split is not just a runtime decoupling — it's also the opportunity to collapse the **PR turnaround time** by making CI fire only the jobs that can plausibly fail given the diff. A finance contract bump shouldn't run media's Playwright suite or rebuild the food worker image. Hold this discipline from PR-1.
+
+This track runs in parallel with the 5 waves, with a deliverable per wave so leanness compounds.
+
+### North-star budget
+
+Steady-state targets — measured as the wall-clock time from `git push` to all required checks green on a typical PR.
+
+| Change shape                                              | Target   | Today   | Notes                                                                                     |
+| --------------------------------------------------------- | -------- | ------- | ----------------------------------------------------------------------------------------- |
+| Docs-only PR (`docs/**`, `*.md`)                          | ≤ 30s    | ~3 min  | Only docs lint + format. Everything else skipped.                                         |
+| Contract package change (`packages/<pillar>-contract/**`) | ≤ 1 min  | ~5 min  | Contract typecheck + tests + semver CI (PRD-154). No app rebuilds, no E2E.                |
+| Single-pillar API/DB change                               | ≤ 3 min  | ~6 min  | That pillar's `*-api-quality` + `*-db-quality` + workspace lint/format/module boundaries. |
+| Single FE-package change                                  | ≤ 5 min  | ~10 min | That FE quality workflow + Playwright suite scoped to that app.                           |
+| Cross-pillar refactor (worker, search, AI)                | ≤ 8 min  | ~12 min | Affected pillars + workspace gates. Still narrower than today's "everything".             |
+| `main` push (publish path)                                | ≤ 10 min | ~15 min | Required for fast watchtower-friendly rollout.                                            |
+
+The "today" column is a rough field measurement on PR #2944 (a contract-only change that nonetheless triggered E2E + Docker Build + worker-food image). Re-measure at every wave gate.
+
+### Inventory of current bloat
+
+What fires when it shouldn't, as of PR #2944:
+
+| Workflow                   | Trigger today                                                                   | Problem                                                                                     | Fix                                                                                         |
+| -------------------------- | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `quality.yml`              | every PR, no `paths`                                                            | Full workspace `pnpm lint` + format + module boundaries + duplication on docs-only PRs      | Add `paths` for code paths; keep lint cheap by routing to per-pkg lint via turbo `--filter` |
+| `fe-test-e2e.yml`          | `paths: packages/**`                                                            | Fires on every contract / DB / unrelated package change                                     | Narrow to `apps/pops-shell/**`, `apps/pops-api/**`, `packages/ui/**`, `packages/app-*/**`   |
+| `pillar-images.yml`        | `paths: packages/**` + matrix over ALL pillars                                  | A finance-only change rebuilds the media/cerebrum/inventory/food/lists/core pillar builders | Per-pillar trigger: `packages/<pillar>-*/**` → matrix-of-one (or skip with `if`)            |
+| `worker-food-image.yml`    | runs on PR; no observed `paths` skip in `Detect changes`                        | Builds the food worker image for unrelated PRs                                              | Path-filter to food touch points only                                                       |
+| `docker-build.yml`         | runs `Validate Docker builds` on any PR                                         | Validates compose for unrelated PRs                                                         | Path-filter to `Dockerfile`, `infra/docker*`, `pnpm-lock.yaml`                              |
+| Per-pillar Quality (×7)    | each fires `Detect changes` then `quality / Typecheck`/`Test` even when skipped | The `Detect changes` step costs ~5s × 14 jobs = ~70s of wasted minutes per PR               | Skip the entire job at the workflow `if:` level when filter is false                        |
+| API Tests (`api-test.yml`) | runs `Frozen Migrations Check` + Backend Tests                                  | Fires on contract-only PRs that can't break backend migrations                              | Path-filter same as `api-quality`                                                           |
+
+### Per-wave deliverables
+
+| Wave | Lean-ness deliverable                                                                                                                                                                                                                                                                                 | Owner agent    |
+| ---- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
+| 1    | **PRD-220** `ci-path-filter-audit`: extend `paths:` to every workflow (close the per-pillar filters; carve out `quality.yml`; skip whole jobs on miss)                                                                                                                                                | `a:ci-lean-1`  |
+| 2    | **PRD-221** `ci-affected-rebuild`: wire turbo `--filter='...[origin/main]'` into a single `affected-rebuild` job that decides which pillar workflows can be skipped _globally_. Replaces N per-pillar `Detect changes` jobs with one. Feeds matrix outputs to pillar-images / fe-test-e2e / api-test. | `a:ci-lean-2`  |
+| 2    | **PRD-222** `ci-docs-fast-path`: docs-only PRs (path matches `docs/**`, `*.md`, `README.md`) hit a `docs-only` workflow that runs markdown lint + link check and short-circuits everything else with a "no-op success" check that satisfies branch protection.                                        | `a:ci-lean-2b` |
+| 3    | **PRD-223** `ci-pillar-isolation`: per-pillar matrix in `pillar-images.yml` becomes `matrix: include: [{ pillar: changed }]` — driven by the affected-rebuild output, not by full enumeration.                                                                                                        | `a:ci-lean-3`  |
+| 3    | **PRD-224** `ci-e2e-scoping`: Playwright suites are tagged by pillar (`@finance`, `@media`, etc.); the E2E job runs only the tagged subset for the affected pillars. Hard requirement: a finance-only PR runs 0 media E2E tests.                                                                      | `a:ci-lean-3b` |
+| 4    | **PRD-225** `ci-publish-narrowing`: `publish-images.yml` only publishes images whose contents actually changed since the previous main commit (turbo affected-hash check). Watchtower stops thrashing on rebuilds-of-nothing.                                                                         | `a:ci-lean-4`  |
+| 5    | **PRD-226** `ci-budget-enforcement`: a CI check that fails the PR if any required check exceeds its budget (per the table above) by >50%. Forces drift detection on the leanness gains.                                                                                                               | `a:ci-lean-5`  |
+
+PRD numbers continue the global counter from PRD-219; record in the [full checklist](#full-prd-checklist) as they're added.
+
+### Per-wave gate additions
+
+These are added to the existing wave gates — they don't replace anything, they extend.
+
+- **Gate 1 → 2:** A docs-only PR shows ≤ 4 required checks (down from ~20+).
+- **Gate 2 → 3:** A single-pillar API PR shows ≤ 6 required checks; affected-rebuild orchestrator job is live on `main`.
+- **Gate 3 → 4:** Cross-pillar refactor PR triggers exactly the affected pillars' workflows — measured via the `affected` matrix output recorded in the PR description.
+- **Gate 4 → 5:** Watchtower rollout time on a single-pillar publish is ≤ 5 min (down from ~10 min today).
+- **Gate 5:** Budget enforcement check (PRD-226) is green on the final theme-13 retrospective PR.
+
+### Principles for every PRD this theme
+
+1. **Path-filter every new workflow.** If you add a CI job, it must have a `paths:` filter at the workflow `on:` level AND a `dorny/paths-filter` at the job level. Both, because the workflow-level keeps the workflow off the queue entirely on `main`, and the job-level handles PRs.
+2. **Skip at the job, not the step.** The current `_pkg-check.yml` skips individual steps with `if:` — that still spins up the runner. Skip the whole job with `if: needs.changes.outputs.relevant == 'true'` and let the dependent check pass automatically.
+3. **Don't add a new "check all pillars" matrix.** Use the affected-rebuild output once PRD-221 lands; until then, route per-pillar logic through the per-pillar workflow files.
+4. **Measure before merging.** When you open a PR, glance at the required checks list. If your "small fix" fires >10 checks, the path filter for one of them is wrong — open a follow-up PR-220-series ticket.
+5. **No "just to be safe" reruns.** A flaky test means the test is wrong, not that we should rerun on every PR. PRD-226's budget enforcement will fail PRs that rerun gratuitously.
+
+### Anti-patterns to reject in review
+
+- A new workflow file without `paths:` filter.
+- A new step in `quality.yml` that runs `pnpm <something>` across the workspace.
+- A new "for parity, also run on this branch" trigger added to fix a missed regression — that regression is a test gap, not a CI scope gap.
+- Adding `pull_request:` with no filter and explaining "it's a quick job" in the PR description.
 
 ---
 
@@ -456,3 +541,4 @@ After Theme 13, the next theme is whatever you decide. Mobile (per the existing 
 - **Each wave has hard quality gates; don't paper over failed gates.**
 - **The critical path is PRD-153 → 157 → 161 → 158 → 191 — that's the load-bearing five.**
 - **Theme 12's CI patterns + the new contract semver CI together catch ~95% of regressions before merge.**
+- **CI lean-ness is a parallel track, not a Wave 5 afterthought.** Every wave ships a PRD that narrows CI scope; by Wave 3 a single-pillar PR fires ≤ 6 checks (down from ~20+).

--- a/docs/themes/13-pillar-finale/IMPLEMENTATION-PLAN.md
+++ b/docs/themes/13-pillar-finale/IMPLEMENTATION-PLAN.md
@@ -390,17 +390,17 @@ Status legend: ⏳ Not started · 🔄 In progress · ✅ Done · ⛔ Blocked
 | 219     | docs-swagger-container           | 2    | ⏳     | 153                    | dev ergonomics                 |
 | 184     | core-tag-rules-cleanup           | 3    | ⏳     | 206                    | core cleanup                   |
 | 185     | core-corrections-cleanup         | 3    | ⏳     | 206                    | core cleanup                   |
-| 220     | ci-path-filter-audit             | 1    | ⏳     | independent            | CI lean-ness wave 1            |
-| 221     | ci-affected-rebuild              | 2    | ⏳     | 220                    | CI lean-ness wave 2            |
-| 222     | ci-docs-fast-path                | 2    | ⏳     | 220                    | CI lean-ness wave 2            |
-| 223     | ci-pillar-isolation              | 3    | ⏳     | 221                    | CI lean-ness wave 3            |
-| 224     | ci-e2e-scoping                   | 3    | ⏳     | 221                    | CI lean-ness wave 3            |
-| 225     | ci-publish-narrowing             | 4    | ⏳     | 221                    | CI lean-ness wave 4            |
-| 226     | ci-budget-enforcement            | 5    | ⏳     | 220-225                | CI lean-ness wave 5            |
+| 220     | ci-path-filter-audit             | 1    | ⏳     | independent            | CI leanness wave 1             |
+| 221     | ci-affected-rebuild              | 2    | ⏳     | 220                    | CI leanness wave 2             |
+| 222     | ci-docs-fast-path                | 2    | ⏳     | 220                    | CI leanness wave 2             |
+| 223     | ci-pillar-isolation              | 3    | ⏳     | 221                    | CI leanness wave 3             |
+| 224     | ci-e2e-scoping                   | 3    | ⏳     | 221                    | CI leanness wave 3             |
+| 225     | ci-publish-narrowing             | 4    | ⏳     | 221                    | CI leanness wave 4             |
+| 226     | ci-budget-enforcement            | 5    | ⏳     | 220-225                | CI leanness wave 5             |
 
 ---
 
-## CI lean-ness (continuous track, runs across all waves)
+## CI leanness (continuous track, runs across all waves)
 
 The pillar split is not just a runtime decoupling — it's also the opportunity to collapse the **PR turnaround time** by making CI fire only the jobs that can plausibly fail given the diff. A finance contract bump shouldn't run media's Playwright suite or rebuild the food worker image. Hold this discipline from PR-1.
 
@@ -437,7 +437,7 @@ What fires when it shouldn't, as of PR #2944:
 
 ### Per-wave deliverables
 
-| Wave | Lean-ness deliverable                                                                                                                                                                                                                                                                                 | Owner agent    |
+| Wave | Leanness deliverable                                                                                                                                                                                                                                                                                  | Owner agent    |
 | ---- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
 | 1    | **PRD-220** `ci-path-filter-audit`: extend `paths:` to every workflow (close the per-pillar filters; carve out `quality.yml`; skip whole jobs on miss)                                                                                                                                                | `a:ci-lean-1`  |
 | 2    | **PRD-221** `ci-affected-rebuild`: wire turbo `--filter='...[origin/main]'` into a single `affected-rebuild` job that decides which pillar workflows can be skipped _globally_. Replaces N per-pillar `Detect changes` jobs with one. Feeds matrix outputs to pillar-images / fe-test-e2e / api-test. | `a:ci-lean-2`  |
@@ -461,7 +461,7 @@ These are added to the existing wave gates — they don't replace anything, they
 
 ### Principles for every PRD this theme
 
-1. **Path-filter every new workflow.** If you add a CI job, it must have a `paths:` filter at the workflow `on:` level AND a `dorny/paths-filter` at the job level. Both, because the workflow-level keeps the workflow off the queue entirely on `main`, and the job-level handles PRs.
+1. **Path-filter every new workflow at the trigger level.** Add `paths:` (or `paths-ignore:`) to the `pull_request:` AND `push: branches: [main]` triggers — both apply on PRs and on `main`. If the workflow is a **required** branch-protection check, also add a `dorny/paths-filter` _job-level_ gate so the workflow still runs (to mark the required check green) but skips the heavy steps when the trigger filter alone would have skipped it. Required-check workflows must always satisfy branch protection; not-required ones can skip outright via the trigger-level filter and don't need the job-level gate.
 2. **Skip at the job, not the step.** The current `_pkg-check.yml` skips individual steps with `if:` — that still spins up the runner. Skip the whole job with `if: needs.changes.outputs.relevant == 'true'` and let the dependent check pass automatically.
 3. **Don't add a new "check all pillars" matrix.** Use the affected-rebuild output once PRD-221 lands; until then, route per-pillar logic through the per-pillar workflow files.
 4. **Measure before merging.** When you open a PR, glance at the required checks list. If your "small fix" fires >10 checks, the path filter for one of them is wrong — open a follow-up PR-220-series ticket.
@@ -541,4 +541,4 @@ After Theme 13, the next theme is whatever you decide. Mobile (per the existing 
 - **Each wave has hard quality gates; don't paper over failed gates.**
 - **The critical path is PRD-153 → 157 → 161 → 158 → 191 — that's the load-bearing five.**
 - **Theme 12's CI patterns + the new contract semver CI together catch ~95% of regressions before merge.**
-- **CI lean-ness is a parallel track, not a Wave 5 afterthought.** Every wave ships a PRD that narrows CI scope; by Wave 3 a single-pillar PR fires ≤ 6 checks (down from ~20+).
+- **CI leanness is a parallel track, not a Wave 5 afterthought.** Every wave ships a PRD that narrows CI scope; by Wave 3 a single-pillar PR fires ≤ 6 checks (down from ~20+).


### PR DESCRIPTION
## Summary

Adds a continuous **CI lean-ness** track to the Theme 13 implementation plan. Goal: a finance-only PR should not run media's Playwright suite or rebuild the food worker image. PR #2944 was the wake-up call — a contract-only change triggered Docker build validation and Playwright E2E.

## What's added to the plan

- **North-star budget table.** Per-change-shape target PR turnaround (docs-only ≤ 30s; contract change ≤ 1 min; single-pillar API ≤ 3 min; cross-pillar refactor ≤ 8 min; main publish ≤ 10 min) with current measurements alongside.
- **Inventory of current bloat.** 7 specific workflows that fire when they shouldn't, with the fix for each (path-filter `fe-test-e2e.yml`, gate `quality.yml`, narrow `pillar-images` to one-pillar matrix, etc.).
- **7 new PRDs (220–226)**, one per wave so leanness compounds:
  - 220 `ci-path-filter-audit` (Wave 1)
  - 221 `ci-affected-rebuild` + 222 `ci-docs-fast-path` (Wave 2)
  - 223 `ci-pillar-isolation` + 224 `ci-e2e-scoping` (Wave 3)
  - 225 `ci-publish-narrowing` (Wave 4)
  - 226 `ci-budget-enforcement` (Wave 5)
- **Gate additions per wave** — every existing wave gate now includes a CI scope check (e.g. Gate 1→2: docs-only PR has ≤ 4 required checks).
- **Anti-patterns to reject in review.** No new workflow without `paths:`. No new `pnpm <workspace-wide>` step in `quality.yml`. No `pull_request:` trigger without a filter.
- **TL;DR updated** so the principle is visible from the top of the doc.

## Why this is on its own PR

Exercises the principle: the change is docs-only, so it should fire only docs lint + format. If you see Playwright, Docker Build, or pillar-images firing on this PR, that's the bloat PRD-220 needs to fix in Wave 1.

## Test plan

- [ ] CI on this PR runs ≤ 4 required checks (today: expected to run ~20+ — that's the baseline measurement for PRD-220)
- [ ] No code changes, no test additions