### PR TITLE
feat(pillar-sdk): manifest schema + validator (Theme 13 PRD-157)

### DIFF
--- a/packages/pillar-sdk/package.json
+++ b/packages/pillar-sdk/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@pops/pillar-sdk",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./manifest-schema": {
+      "types": "./dist/manifest-schema/index.d.ts",
+      "default": "./dist/manifest-schema/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@vitest/coverage-v8": "^4.1.8",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.8"
+  }
+}

--- a/packages/pillar-sdk/src/__tests__/fixtures.ts
+++ b/packages/pillar-sdk/src/__tests__/fixtures.ts
@@ -1,0 +1,39 @@
+import type { ManifestPayload } from '../manifest-schema/schema.js';
+
+export function validManifest(): ManifestPayload {
+  return {
+    pillar: 'finance',
+    version: '1.2.3',
+    contract: {
+      package: '@pops/finance-contract',
+      version: '1.2.3',
+      tag: 'contract-finance@v1.2.3',
+    },
+    routes: {
+      queries: ['finance.transactions.list', 'finance.budgets.get'],
+      mutations: ['finance.transactions.create'],
+      subscriptions: [],
+    },
+    search: {
+      adapters: ['transactionsAdapter', 'budgetsAdapter'],
+    },
+    ai: {
+      tools: [
+        {
+          name: 'createTransaction',
+          description: 'Create a new transaction in the finance ledger.',
+          parameters: { type: 'object' },
+        },
+      ],
+    },
+    uri: {
+      types: ['finance/transaction', 'finance/budget'],
+    },
+    settings: {
+      keys: ['finance.defaultCurrency', 'finance.locale'],
+    },
+    healthcheck: {
+      path: '/healthz',
+    },
+  };
+}

--- a/packages/pillar-sdk/src/__tests__/schema.test.ts
+++ b/packages/pillar-sdk/src/__tests__/schema.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, it } from 'vitest';
+
+import { ManifestPayloadSchema } from '../manifest-schema/schema.js';
+import { validManifest } from './fixtures.js';
+
+describe('ManifestPayloadSchema', () => {
+  it('accepts a valid manifest', () => {
+    const result = ManifestPayloadSchema.safeParse(validManifest());
+    expect(result.success).toBe(true);
+  });
+
+  it('defaults routes.subscriptions to an empty array when omitted', () => {
+    const manifest = validManifest();
+    const { subscriptions: _ignored, ...routes } = manifest.routes;
+    const input = { ...manifest, routes };
+    const result = ManifestPayloadSchema.safeParse(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.routes.subscriptions).toEqual([]);
+    }
+  });
+
+  describe('pillar id', () => {
+    it.each([
+      ['Finance', 'uppercase rejected'],
+      ['finance_a', 'underscore rejected'],
+      ['1finance', 'leading digit rejected'],
+      ['-finance', 'leading hyphen rejected'],
+      ['', 'empty rejected'],
+    ])('rejects %s (%s)', (pillar) => {
+      const result = ManifestPayloadSchema.safeParse({ ...validManifest(), pillar });
+      expect(result.success).toBe(false);
+    });
+
+    it.each(['finance', 'app-finance', 'a', 'media-lib'])('accepts %s', (pillar) => {
+      const m = validManifest();
+      m.pillar = pillar;
+      m.contract.package = `@pops/${pillar}-contract`;
+      m.contract.tag = `contract-${pillar}@v${m.contract.version}`;
+      const result = ManifestPayloadSchema.safeParse(m);
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('semver', () => {
+    it.each(['1', '1.2', '1.2.3.4', 'v1.2.3', '1.2.3-FOO', ''])('rejects %s', (version) => {
+      const result = ManifestPayloadSchema.safeParse({ ...validManifest(), version });
+      expect(result.success).toBe(false);
+    });
+
+    it.each(['1.2.3', '0.0.1', '1.2.3-beta.1', '10.20.30-rc.0'])('accepts %s', (version) => {
+      const m = validManifest();
+      m.version = version;
+      const result = ManifestPayloadSchema.safeParse(m);
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('procedure path', () => {
+    it.each([
+      'finance.transactions',
+      'finance',
+      'Finance.transactions.list',
+      'finance.Transactions.list',
+      'finance..list',
+      'finance.transactions.',
+      '.transactions.list',
+      'finance.transactions.list.extra',
+    ])('rejects %s', (path) => {
+      const m = validManifest();
+      m.routes.queries = [path];
+      const result = ManifestPayloadSchema.safeParse(m);
+      expect(result.success).toBe(false);
+    });
+
+    it.each(['finance.transactions.list', 'a.bC.dE2', 'finance.txns2.listAll'])(
+      'accepts %s',
+      (path) => {
+        const m = validManifest();
+        m.routes.queries = [path];
+        const result = ManifestPayloadSchema.safeParse(m);
+        expect(result.success).toBe(true);
+      }
+    );
+  });
+
+  describe('contract package regex', () => {
+    it.each([
+      '@pops/finance',
+      '@pops/finance-contract-v2',
+      '@other/finance-contract',
+      'pops/finance-contract',
+      '@pops/Finance-contract',
+    ])('rejects %s', (pkg) => {
+      const m = validManifest();
+      m.contract.package = pkg;
+      const result = ManifestPayloadSchema.safeParse(m);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('contract tag regex', () => {
+    it.each([
+      'contract-finance',
+      'contract-finance@1.2.3',
+      'contract-finance@v1.2',
+      'finance-contract@v1.2.3',
+      'contract-Finance@v1.2.3',
+    ])('rejects %s', (tag) => {
+      const m = validManifest();
+      m.contract.tag = tag;
+      const result = ManifestPayloadSchema.safeParse(m);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('uri types regex', () => {
+    it.each(['finance', 'finance/', '/transaction', 'Finance/transaction', 'finance/Transaction'])(
+      'rejects %s',
+      (uri) => {
+        const m = validManifest();
+        m.uri.types = [uri];
+        const result = ManifestPayloadSchema.safeParse(m);
+        expect(result.success).toBe(false);
+      }
+    );
+  });
+
+  describe('settings keys regex', () => {
+    it.each(['Foo', '.foo', 'foo.', '1foo', 'foo..bar'])('rejects %s', (key) => {
+      const m = validManifest();
+      m.settings.keys = [key];
+      const result = ManifestPayloadSchema.safeParse(m);
+      expect(result.success).toBe(false);
+    });
+
+    it.each(['finance', 'finance.defaultCurrency', 'finance.a.b.c'])('accepts %s', (key) => {
+      const m = validManifest();
+      m.settings.keys = [key];
+      const result = ManifestPayloadSchema.safeParse(m);
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('search adapters regex', () => {
+    it.each(['Foo', 'foo-bar', '1foo', ''])('rejects %s', (adapter) => {
+      const m = validManifest();
+      m.search.adapters = [adapter];
+      const result = ManifestPayloadSchema.safeParse(m);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('healthcheck path', () => {
+    it.each(['healthz', 'http://example.com/healthz', ''])('rejects %s', (path) => {
+      const m = validManifest();
+      m.healthcheck.path = path;
+      const result = ManifestPayloadSchema.safeParse(m);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('ai tools', () => {
+    it('rejects description shorter than 10 chars', () => {
+      const m = validManifest();
+      m.ai.tools[0]!.description = 'tooshort';
+      const result = ManifestPayloadSchema.safeParse(m);
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects description longer than 500 chars', () => {
+      const m = validManifest();
+      m.ai.tools[0]!.description = 'a'.repeat(501);
+      const result = ManifestPayloadSchema.safeParse(m);
+      expect(result.success).toBe(false);
+    });
+
+    it('accepts description exactly 10 chars', () => {
+      const m = validManifest();
+      m.ai.tools[0]!.description = 'a'.repeat(10);
+      const result = ManifestPayloadSchema.safeParse(m);
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts description exactly 500 chars', () => {
+      const m = validManifest();
+      m.ai.tools[0]!.description = 'a'.repeat(500);
+      const result = ManifestPayloadSchema.safeParse(m);
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects non-camelCase tool name', () => {
+      const m = validManifest();
+      m.ai.tools[0]!.name = 'create_transaction';
+      const result = ManifestPayloadSchema.safeParse(m);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('strict mode', () => {
+    it('rejects an unknown top-level field', () => {
+      const input = { ...validManifest(), extraField: 'nope' };
+      const result = ManifestPayloadSchema.safeParse(input);
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects an unknown nested field on routes', () => {
+      const m = validManifest();
+      const input = { ...m, routes: { ...m.routes, unknownThing: [] } };
+      const result = ManifestPayloadSchema.safeParse(input);
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects an unknown nested field on contract', () => {
+      const m = validManifest();
+      const input = { ...m, contract: { ...m.contract, sneaky: true } };
+      const result = ManifestPayloadSchema.safeParse(input);
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects an unknown nested field on healthcheck', () => {
+      const m = validManifest();
+      const input = { ...m, healthcheck: { ...m.healthcheck, port: 8080 } };
+      const result = ManifestPayloadSchema.safeParse(input);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('empty arrays', () => {
+    it('accepts empty search adapters', () => {
+      const m = validManifest();
+      m.search.adapters = [];
+      const result = ManifestPayloadSchema.safeParse(m);
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts empty ai tools', () => {
+      const m = validManifest();
+      m.ai.tools = [];
+      const result = ManifestPayloadSchema.safeParse(m);
+      expect(result.success).toBe(true);
+    });
+  });
+});

--- a/packages/pillar-sdk/src/__tests__/validate.test.ts
+++ b/packages/pillar-sdk/src/__tests__/validate.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  checkContractPackageMatchesPillar,
+  checkContractTagMatchesVersion,
+  pathToDotted,
+  validateManifestPayload,
+} from '../manifest-schema/validate.js';
+import { validManifest } from './fixtures.js';
+
+describe('validateManifestPayload', () => {
+  it('returns ok with payload on valid input', () => {
+    const result = validateManifestPayload(validManifest());
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.payload.pillar).toBe('finance');
+    }
+  });
+
+  it('rejects null with a top-level invalid_type issue', () => {
+    const result = validateManifestPayload(null);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.issues).toHaveLength(1);
+      expect(result.issues[0]!.field).toBe('');
+      expect(result.issues[0]!.got).toBe(null);
+    }
+  });
+
+  it.each([42, 'a string', true, []])('rejects non-object input %s', (input) => {
+    const result = validateManifestPayload(input);
+    expect(result.ok).toBe(false);
+  });
+
+  it('reports invalid_format issues with field, reason, got', () => {
+    const m = validManifest();
+    m.routes.queries = ['finance.transactions.list', 'finance.transactions', 'finance.foo.bar'];
+    const result = validateManifestPayload(m);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      const bad = result.issues.find((i) => i.field === 'routes.queries[1]');
+      expect(bad).toBeDefined();
+      expect(bad?.got).toBe('finance.transactions');
+      expect(bad?.reason).toContain('<pillar>.<router>.<procedure>');
+      expect(bad?.schemaPath).toEqual(['routes', 'queries', 1]);
+    }
+  });
+
+  it('reports description min length with field, reason, got', () => {
+    const m = validManifest();
+    m.ai.tools[0]!.description = 'short';
+    const result = validateManifestPayload(m);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      const issue = result.issues.find((i) => i.field === 'ai.tools[0].description');
+      expect(issue).toBeDefined();
+      expect(issue?.got).toBe('short');
+    }
+  });
+
+  describe('strict mode → unknown field issues', () => {
+    it('emits an issue per unknown top-level key', () => {
+      const result = validateManifestPayload({ ...validManifest(), foo: 1, bar: 2 });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        const fields = result.issues.map((i) => i.field).toSorted();
+        expect(fields).toEqual(['bar', 'foo']);
+        for (const issue of result.issues) {
+          expect(issue.reason).toBe('unknown field');
+        }
+        const foo = result.issues.find((i) => i.field === 'foo');
+        expect(foo?.got).toBe(1);
+        expect(foo?.schemaPath).toEqual(['foo']);
+      }
+    });
+
+    it('emits a nested field name on unknown nested key', () => {
+      const m = validManifest();
+      const input = { ...m, routes: { ...m.routes, unknownThing: 'x' } };
+      const result = validateManifestPayload(input);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        const issue = result.issues.find((i) => i.field === 'routes.unknownThing');
+        expect(issue).toBeDefined();
+        expect(issue?.reason).toBe('unknown field');
+        expect(issue?.got).toBe('x');
+        expect(issue?.schemaPath).toEqual(['routes', 'unknownThing']);
+      }
+    });
+  });
+
+  describe('cross-field rules', () => {
+    it('reports mismatched contract.package', () => {
+      const m = validManifest();
+      m.contract.package = '@pops/media-contract';
+      const result = validateManifestPayload(m);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.issues).toHaveLength(1);
+        const issue = result.issues[0]!;
+        expect(issue.field).toBe('contract.package');
+        expect(issue.reason).toContain('expected @pops/finance-contract');
+        expect(issue.reason).toContain('got @pops/media-contract');
+        expect(issue.got).toBe('@pops/media-contract');
+      }
+    });
+
+    it('reports mismatched contract.tag', () => {
+      const m = validManifest();
+      m.contract.tag = 'contract-finance@v9.9.9';
+      const result = validateManifestPayload(m);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.issues).toHaveLength(1);
+        const issue = result.issues[0]!;
+        expect(issue.field).toBe('contract.tag');
+        expect(issue.reason).toContain('expected contract-finance@v1.2.3');
+      }
+    });
+
+    it('collects both cross-field violations in one pass (no short-circuit)', () => {
+      const m = validManifest();
+      m.contract.package = '@pops/media-contract';
+      m.contract.tag = 'contract-finance@v9.9.9';
+      const result = validateManifestPayload(m);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.issues).toHaveLength(2);
+        const fields = result.issues.map((i) => i.field).toSorted();
+        expect(fields).toEqual(['contract.package', 'contract.tag']);
+      }
+    });
+
+    it('does not run cross-field rules when Zod parse already failed', () => {
+      const m = validManifest();
+      m.contract.package = 'totally-bogus';
+      m.contract.tag = 'totally-bogus-too';
+      const result = validateManifestPayload(m);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        for (const issue of result.issues) {
+          expect(issue.reason).not.toContain('expected @pops/');
+          expect(issue.reason).not.toContain('expected contract-');
+        }
+      }
+    });
+  });
+
+  describe('multi-issue collection', () => {
+    it('does not short-circuit on the first Zod error', () => {
+      const m = validManifest();
+      m.routes.queries = ['bogus', 'also.bogus'];
+      m.routes.mutations = ['nope'];
+      const result = validateManifestPayload(m);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.issues.length).toBeGreaterThanOrEqual(3);
+      }
+    });
+  });
+});
+
+describe('pathToDotted', () => {
+  it('returns empty string for empty path', () => {
+    expect(pathToDotted([])).toBe('');
+  });
+
+  it('joins string segments with dots', () => {
+    expect(pathToDotted(['routes', 'queries'])).toBe('routes.queries');
+  });
+
+  it('renders numeric segments as [N] without a leading dot', () => {
+    expect(pathToDotted(['routes', 'queries', 3])).toBe('routes.queries[3]');
+  });
+
+  it('handles consecutive array indices', () => {
+    expect(pathToDotted(['matrix', 0, 1])).toBe('matrix[0][1]');
+  });
+
+  it('handles a leading numeric segment', () => {
+    expect(pathToDotted([0, 'name'])).toBe('[0].name');
+  });
+});
+
+describe('cross-field checkers (pure)', () => {
+  it('checkContractPackageMatchesPillar returns [] on match', () => {
+    expect(checkContractPackageMatchesPillar(validManifest())).toEqual([]);
+  });
+
+  it('checkContractTagMatchesVersion returns [] on match', () => {
+    expect(checkContractTagMatchesVersion(validManifest())).toEqual([]);
+  });
+
+  it('checkContractPackageMatchesPillar emits one ValidationIssue on mismatch', () => {
+    const m = validManifest();
+    m.contract.package = '@pops/media-contract';
+    const issues = checkContractPackageMatchesPillar(m);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]!.field).toBe('contract.package');
+    expect(issues[0]!.schemaPath).toEqual(['contract', 'package']);
+  });
+
+  it('checkContractTagMatchesVersion emits one ValidationIssue on mismatch', () => {
+    const m = validManifest();
+    m.contract.tag = 'contract-finance@v0.0.1';
+    const issues = checkContractTagMatchesVersion(m);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]!.field).toBe('contract.tag');
+    expect(issues[0]!.schemaPath).toEqual(['contract', 'tag']);
+  });
+});

--- a/packages/pillar-sdk/src/index.ts
+++ b/packages/pillar-sdk/src/index.ts
@@ -1,0 +1,1 @@
+export * from './manifest-schema/index.js';

--- a/packages/pillar-sdk/src/manifest-schema/index.ts
+++ b/packages/pillar-sdk/src/manifest-schema/index.ts
@@ -1,0 +1,9 @@
+export { ManifestPayloadSchema, type ManifestPayload } from './schema.js';
+export {
+  validateManifestPayload,
+  checkContractPackageMatchesPillar,
+  checkContractTagMatchesVersion,
+  pathToDotted,
+  type ValidationResult,
+  type ValidationIssue,
+} from './validate.js';

--- a/packages/pillar-sdk/src/manifest-schema/schema.ts
+++ b/packages/pillar-sdk/src/manifest-schema/schema.ts
@@ -1,0 +1,100 @@
+import { z } from 'zod';
+
+const PILLAR_ID = z.string().regex(/^[a-z][a-z0-9-]*$/, 'pillar id must be lowercase kebab-case');
+
+const SEMVER = z.string().regex(/^\d+\.\d+\.\d+(-[a-z0-9.]+)?$/, 'must be semver');
+
+const PROCEDURE_PATH = z
+  .string()
+  .regex(
+    /^[a-z][a-z0-9]*\.[a-z][a-zA-Z0-9]*\.[a-z][a-zA-Z0-9]*$/,
+    'must match <pillar>.<router>.<procedure>'
+  );
+
+const CAMEL_IDENTIFIER = z.string().regex(/^[a-z][a-zA-Z0-9]*$/, 'must be camelCase identifier');
+
+const URI_TYPE = z
+  .string()
+  .regex(/^[a-z][a-z0-9-]*\/[a-z][a-z0-9-]*$/, 'must be <pillar>/<entity>');
+
+const SETTINGS_KEY = z
+  .string()
+  .regex(/^[a-z][a-zA-Z0-9]*(\.[a-zA-Z0-9]+)*$/, 'must be dotted.lower.camel');
+
+const CONTRACT_PACKAGE = z
+  .string()
+  .regex(/^@pops\/[a-z-]+-contract$/, 'must be @pops/<pillar>-contract');
+
+const CONTRACT_TAG = z
+  .string()
+  .regex(/^contract-[a-z-]+@v\d+\.\d+\.\d+(-[a-z0-9.]+)?$/, 'must be contract-<pillar>@v<semver>');
+
+const AI_TOOL = z
+  .object({
+    name: CAMEL_IDENTIFIER,
+    description: z.string().min(10).max(500),
+    parameters: z.record(z.string(), z.unknown()),
+  })
+  .strict();
+
+const CONTRACT = z
+  .object({
+    package: CONTRACT_PACKAGE,
+    version: SEMVER,
+    tag: CONTRACT_TAG,
+  })
+  .strict();
+
+const ROUTES = z
+  .object({
+    queries: z.array(PROCEDURE_PATH),
+    mutations: z.array(PROCEDURE_PATH),
+    subscriptions: z.array(PROCEDURE_PATH).default([]),
+  })
+  .strict();
+
+const SEARCH = z
+  .object({
+    adapters: z.array(CAMEL_IDENTIFIER),
+  })
+  .strict();
+
+const AI = z
+  .object({
+    tools: z.array(AI_TOOL),
+  })
+  .strict();
+
+const URI = z
+  .object({
+    types: z.array(URI_TYPE),
+  })
+  .strict();
+
+const SETTINGS = z
+  .object({
+    keys: z.array(SETTINGS_KEY),
+  })
+  .strict();
+
+const HEALTHCHECK = z
+  .object({
+    path: z.string().regex(/^\//, 'must start with /'),
+  })
+  .strict();
+
+export const ManifestPayloadSchema = z
+  .object({
+    pillar: PILLAR_ID,
+    version: SEMVER,
+    contract: CONTRACT,
+    routes: ROUTES,
+    search: SEARCH,
+    ai: AI,
+    uri: URI,
+    settings: SETTINGS,
+    healthcheck: HEALTHCHECK,
+  })
+  .strict();
+
+export type ManifestPayload = z.infer<typeof ManifestPayloadSchema>;

--- a/packages/pillar-sdk/src/manifest-schema/validate.ts
+++ b/packages/pillar-sdk/src/manifest-schema/validate.ts
@@ -1,6 +1,8 @@
 import { ManifestPayloadSchema, type ManifestPayload } from './schema.js';
 
-import type { $ZodIssue } from 'zod/v4/core';
+import type { ZodError } from 'zod';
+
+type ZodIssue = ZodError['issues'][number];
 
 export type ValidationIssue = {
   field: string;
@@ -33,7 +35,7 @@ export function validateManifestPayload(input: unknown): ValidationResult {
   return { ok: true, payload: parsed.data };
 }
 
-function mapZodIssue(issue: $ZodIssue, input: unknown): ValidationIssue[] {
+function mapZodIssue(issue: ZodIssue, input: unknown): ValidationIssue[] {
   if (issue.code === 'unrecognized_keys') {
     return issue.keys.map((key) => {
       const childPath: (string | number)[] = [...toStringNumberPath(issue.path), key];

--- a/packages/pillar-sdk/src/manifest-schema/validate.ts
+++ b/packages/pillar-sdk/src/manifest-schema/validate.ts
@@ -1,0 +1,119 @@
+import { ManifestPayloadSchema, type ManifestPayload } from './schema.js';
+
+import type { $ZodIssue } from 'zod/v4/core';
+
+export type ValidationIssue = {
+  field: string;
+  reason: string;
+  got: unknown;
+  schemaPath: readonly (string | number)[];
+};
+
+export type ValidationResult =
+  | { ok: true; payload: ManifestPayload }
+  | { ok: false; issues: ValidationIssue[] };
+
+export function validateManifestPayload(input: unknown): ValidationResult {
+  const parsed = ManifestPayloadSchema.safeParse(input);
+
+  if (!parsed.success) {
+    const issues = parsed.error.issues.flatMap((issue) => mapZodIssue(issue, input));
+    return { ok: false, issues };
+  }
+
+  const crossFieldIssues = [
+    ...checkContractPackageMatchesPillar(parsed.data),
+    ...checkContractTagMatchesVersion(parsed.data),
+  ];
+
+  if (crossFieldIssues.length > 0) {
+    return { ok: false, issues: crossFieldIssues };
+  }
+
+  return { ok: true, payload: parsed.data };
+}
+
+function mapZodIssue(issue: $ZodIssue, input: unknown): ValidationIssue[] {
+  if (issue.code === 'unrecognized_keys') {
+    return issue.keys.map((key) => {
+      const childPath: (string | number)[] = [...toStringNumberPath(issue.path), key];
+      return {
+        field: pathToDotted(childPath),
+        reason: 'unknown field',
+        got: walkPath(input, childPath),
+        schemaPath: childPath,
+      };
+    });
+  }
+
+  const path = toStringNumberPath(issue.path);
+  return [
+    {
+      field: pathToDotted(path),
+      reason: issue.message,
+      got: walkPath(input, path),
+      schemaPath: path,
+    },
+  ];
+}
+
+function toStringNumberPath(path: ReadonlyArray<PropertyKey>): (string | number)[] {
+  return path.map((segment) => {
+    if (typeof segment === 'number') return segment;
+    if (typeof segment === 'string') return segment;
+    return segment.toString();
+  });
+}
+
+export function pathToDotted(path: ReadonlyArray<string | number>): string {
+  let out = '';
+  for (const segment of path) {
+    if (typeof segment === 'number') {
+      out += `[${segment}]`;
+      continue;
+    }
+    out = out.length === 0 ? segment : `${out}.${segment}`;
+  }
+  return out;
+}
+
+function walkPath(input: unknown, path: ReadonlyArray<string | number>): unknown {
+  let current: unknown = input;
+  for (const segment of path) {
+    if (current === null || current === undefined) return undefined;
+    if (typeof segment === 'number') {
+      if (!Array.isArray(current)) return undefined;
+      current = current[segment];
+      continue;
+    }
+    if (typeof current !== 'object') return undefined;
+    current = (current as Record<string, unknown>)[segment];
+  }
+  return current;
+}
+
+export function checkContractPackageMatchesPillar(payload: ManifestPayload): ValidationIssue[] {
+  const expected = `@pops/${payload.pillar}-contract`;
+  if (payload.contract.package === expected) return [];
+  return [
+    {
+      field: 'contract.package',
+      reason: `must match pillar id: expected ${expected}, got ${payload.contract.package}`,
+      got: payload.contract.package,
+      schemaPath: ['contract', 'package'],
+    },
+  ];
+}
+
+export function checkContractTagMatchesVersion(payload: ManifestPayload): ValidationIssue[] {
+  const expected = `contract-${payload.pillar}@v${payload.contract.version}`;
+  if (payload.contract.tag === expected) return [];
+  return [
+    {
+      field: 'contract.tag',
+      reason: `must match contract version: expected ${expected}, got ${payload.contract.tag}`,
+      got: payload.contract.tag,
+      schemaPath: ['contract', 'tag'],
+    },
+  ];
+}

--- a/packages/pillar-sdk/tsconfig.json
+++ b/packages/pillar-sdk/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "lib": ["ES2022"],
+    "types": [],
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/__tests__/**", "**/*.test.ts"]
+}

--- a/packages/pillar-sdk/vitest.config.ts
+++ b/packages/pillar-sdk/vitest.config.ts
@@ -1,0 +1,15 @@
+/// <reference types="vitest/config" />
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json-summary', 'html'],
+      reportsDirectory: 'coverage',
+      include: ['src/**/*.ts'],
+      exclude: ['**/node_modules/**', '**/dist/**', '**/*.test.ts'],
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1973,6 +1973,22 @@ importers:
         specifier: ^4.1.8
         version: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.3)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
 
+  packages/pillar-sdk:
+    dependencies:
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@vitest/coverage-v8':
+        specifier: ^4.1.8
+        version: 4.1.8(vitest@4.1.8)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.3)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
+
   packages/types:
     devDependencies:
       '@vitest/coverage-v8':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,4 +23,5 @@ packages:
   - 'packages/types'
   - 'packages/module-registry'
   - 'packages/navigation'
+  - 'packages/pillar-sdk'
   - 'packages/ui'


### PR DESCRIPTION
## Summary

Lands `@pops/pillar-sdk` (private workspace package) carrying the canonical manifest schema and validator described in Theme 13 PRD-157.

- `ManifestPayloadSchema` — `.strict()` Zod schema for the pillar manifest wire format, with the per-field regexes from the PRD (pillar id, semver, procedure path, contract package, contract tag, uri type, settings key, search adapter, ai tool name, healthcheck path).
- `validateManifestPayload(input)` — pure validator returning a `{ ok: true, payload } | { ok: false, issues }` discriminated union. Zod `path` arrays map to dotted-string `field` names (e.g. `routes.queries[3]`); `got` is captured by walking the original input; `.strict()` unknown-key issues are expanded to one issue per key.
- Two named cross-field invariants (`checkContractPackageMatchesPillar`, `checkContractTagMatchesVersion`) run after Zod parse succeeds. All cross-field issues are collected and returned together — no short-circuit on first failure.

## Scope

Implements US-01, US-02, US-03, US-04, US-05 from [PRD-157](../docs/themes/13-pillar-finale/prds/157-manifest-schema-validator/README.md).

Deferred to follow-up PRs:
- US-06 — `pnpm validate:manifest <pillar>` CLI tool.
- US-07 — pillar SDK boot integration (depends on PRD-158).
- US-08 — registry endpoint integration (depends on PRD-161).
- US-09 — schema evolution docs.

The package is not yet wired into any other workspace; integration lands in those follow-up PRDs.

## Test plan

- [x] `pnpm test` from `packages/pillar-sdk` — 97 tests, all green
- [x] `mise typecheck` — all 52 workspace tasks pass
- [x] `mise lint` — no new warnings in `packages/pillar-sdk`
- [x] Negative tests for every regex (pillar id, semver, procedure path, contract package, contract tag, uri type, settings key, search adapter, ai tool name, healthcheck path)
- [x] `.strict()` rejection at top level and inside every nested object (`routes`, `contract`, `healthcheck`)
- [x] Dotted-path conversion including numeric array indices (`routes.queries[3]`, `matrix[0][1]`, `[0].name`)
- [x] `got` value capture verified for nested array-element errors
- [x] Cross-field rules: mismatched package, mismatched tag, both at once (no short-circuit), and not run when Zod parse already failed
- [x] Multi-issue collection (no early exit)
