### PR TITLE
ci(workflows): narrow path filters for per-change-shape CI (Theme 13 PRD-220)

### DIFF
--- a/.github/workflows/ai-quality.yml
+++ b/.github/workflows/ai-quality.yml
@@ -12,6 +12,9 @@ on:
       - ".github/workflows/ai-quality.yml"
       - ".github/workflows/_pkg-check.yml"
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
 
 jobs:
   changes:

--- a/.github/workflows/api-client-quality.yml
+++ b/.github/workflows/api-client-quality.yml
@@ -9,6 +9,9 @@ on:
       - ".github/workflows/api-client-quality.yml"
       - ".github/workflows/_pkg-check.yml"
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
 
 jobs:
   changes:

--- a/.github/workflows/api-quality.yml
+++ b/.github/workflows/api-quality.yml
@@ -2,6 +2,9 @@ name: API Quality
 
 on:
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
   push:
     branches:
       - main

--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -15,6 +15,9 @@ on:
       - "packages/auth/**"
       - ".github/workflows/api-test.yml"
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
 
 jobs:
   changes:

--- a/.github/workflows/cerebrum-api-quality.yml
+++ b/.github/workflows/cerebrum-api-quality.yml
@@ -10,6 +10,9 @@ on:
       - ".github/workflows/cerebrum-api-quality.yml"
       - ".github/workflows/_pkg-check.yml"
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
 
 jobs:
   changes:

--- a/.github/workflows/cerebrum-db-quality.yml
+++ b/.github/workflows/cerebrum-db-quality.yml
@@ -9,6 +9,9 @@ on:
       - ".github/workflows/cerebrum-db-quality.yml"
       - ".github/workflows/_pkg-check.yml"
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
 
 jobs:
   changes:

--- a/.github/workflows/core-api-quality.yml
+++ b/.github/workflows/core-api-quality.yml
@@ -10,6 +10,9 @@ on:
       - ".github/workflows/core-api-quality.yml"
       - ".github/workflows/_pkg-check.yml"
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
 
 jobs:
   changes:

--- a/.github/workflows/core-quality.yml
+++ b/.github/workflows/core-quality.yml
@@ -9,6 +9,9 @@ on:
       - ".github/workflows/core-quality.yml"
       - ".github/workflows/_pkg-check.yml"
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
 
 jobs:
   changes:

--- a/.github/workflows/db-types-quality.yml
+++ b/.github/workflows/db-types-quality.yml
@@ -8,6 +8,9 @@ on:
       - ".github/workflows/db-types-quality.yml"
       - ".github/workflows/_pkg-check.yml"
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
 
 jobs:
   changes:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -2,24 +2,31 @@ name: Docker Build
 
 on:
   pull_request:
+    paths:
+      - "infra/docker*/**"
+      - "infra/docker-compose*.yml"
+      - "**/Dockerfile"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "turbo.json"
+      - "tsconfig.base.json"
+      - ".github/workflows/docker-build.yml"
   push:
     branches: [main]
     paths:
-      - "apps/pops-api/**"
-      - "apps/pops-shell/**"
-      - "apps/pops-mcp/**"
-      - "apps/pops-core-api/**"
-      - "apps/pops-finance-api/**"
-      - "apps/pops-inventory-api/**"
-      - "apps/pops-media-api/**"
-      - "apps/pops-cerebrum-api/**"
-      - "apps/pops-food-api/**"
-      - "apps/pops-lists-api/**"
-      - "packages/**"
+      - "infra/docker*/**"
       - "infra/docker-compose*.yml"
+      - "**/Dockerfile"
       - "pnpm-lock.yaml"
       - "pnpm-workspace.yaml"
+      - "turbo.json"
+      - "tsconfig.base.json"
       - ".github/workflows/docker-build.yml"
+
+# Workflow-level filter keeps `Validate Docker builds` off docs/code-only
+# PRs entirely. Per-pillar code is validated by `pillar-images.yml` and
+# the `*-api-quality.yml` workflows — this job only re-validates the
+# Dockerfile + compose surfaces. (Theme 13 PRD-220.)
 
 jobs:
   changes:
@@ -36,19 +43,12 @@ jobs:
         with:
           filters: |
             docker:
-              - 'apps/pops-api/**'
-              - 'apps/pops-shell/**'
-              - 'apps/pops-mcp/**'
-              - 'apps/pops-core-api/**'
-              - 'apps/pops-finance-api/**'
-              - 'apps/pops-inventory-api/**'
-              - 'apps/pops-media-api/**'
-              - 'apps/pops-cerebrum-api/**'
-              - 'apps/pops-food-api/**'
-              - 'apps/pops-lists-api/**'
-              - 'packages/**'
+              - '**/Dockerfile'
+              - 'infra/docker*/**'
               - 'pnpm-lock.yaml'
               - 'pnpm-workspace.yaml'
+              - 'turbo.json'
+              - 'tsconfig.base.json'
               - '.github/workflows/docker-build.yml'
             compose:
               - 'infra/docker-compose*.yml'

--- a/.github/workflows/fe-quality.yml
+++ b/.github/workflows/fe-quality.yml
@@ -18,6 +18,9 @@ on:
       - "packages/types/**"
       - ".github/workflows/fe-quality.yml"
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
 
 jobs:
   changes:

--- a/.github/workflows/fe-test-e2e.yml
+++ b/.github/workflows/fe-test-e2e.yml
@@ -4,6 +4,19 @@ on:
   push:
     branches: [main, develop]
   pull_request:
+    paths:
+      - 'apps/pops-shell/**'
+      - 'apps/pops-api/**'
+      - 'packages/ui/**'
+      - 'packages/app-*/**'
+      - 'packages/api-client/**'
+      - 'packages/auth/**'
+      - 'packages/navigation/**'
+      - 'packages/widgets/**'
+      - 'packages/types/**'
+      - 'packages/db-types/**'
+      - 'packages/test-utils/**'
+      - '.github/workflows/fe-test-e2e.yml'
 
 jobs:
   changes:
@@ -21,7 +34,15 @@ jobs:
             e2e:
               - 'apps/pops-shell/**'
               - 'apps/pops-api/**'
-              - 'packages/**'
+              - 'packages/ui/**'
+              - 'packages/app-*/**'
+              - 'packages/api-client/**'
+              - 'packages/auth/**'
+              - 'packages/navigation/**'
+              - 'packages/widgets/**'
+              - 'packages/types/**'
+              - 'packages/db-types/**'
+              - 'packages/test-utils/**'
               - '.github/workflows/fe-test-e2e.yml'
 
   e2e-tests:

--- a/.github/workflows/fe-test-e2e.yml
+++ b/.github/workflows/fe-test-e2e.yml
@@ -16,6 +16,9 @@ on:
       - 'packages/types/**'
       - 'packages/db-types/**'
       - 'packages/test-utils/**'
+      - 'packages/module-registry/**'
+      - 'packages/food-contracts/**'
+      - 'packages/*-db/**'
       - '.github/workflows/fe-test-e2e.yml'
 
 jobs:
@@ -43,6 +46,9 @@ jobs:
               - 'packages/types/**'
               - 'packages/db-types/**'
               - 'packages/test-utils/**'
+              - 'packages/module-registry/**'
+              - 'packages/food-contracts/**'
+              - 'packages/*-db/**'
               - '.github/workflows/fe-test-e2e.yml'
 
   e2e-tests:

--- a/.github/workflows/finance-api-quality.yml
+++ b/.github/workflows/finance-api-quality.yml
@@ -5,11 +5,15 @@ on:
     branches: [main]
     paths:
       - "apps/pops-finance-api/**"
+      - "packages/finance-contract/**"
       - "packages/finance-db/**"
       - "packages/db-types/**"
       - ".github/workflows/finance-api-quality.yml"
       - ".github/workflows/_pkg-check.yml"
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
 
 jobs:
   changes:
@@ -26,6 +30,7 @@ jobs:
           filters: |
             relevant:
               - 'apps/pops-finance-api/**'
+              - 'packages/finance-contract/**'
               - 'packages/finance-db/**'
               - 'packages/db-types/**'
               - '.github/workflows/finance-api-quality.yml'

--- a/.github/workflows/finance-db-quality.yml
+++ b/.github/workflows/finance-db-quality.yml
@@ -4,11 +4,15 @@ on:
   push:
     branches: [main]
     paths:
+      - "packages/finance-contract/**"
       - "packages/finance-db/**"
       - "packages/db-types/**"
       - ".github/workflows/finance-db-quality.yml"
       - ".github/workflows/_pkg-check.yml"
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
 
 jobs:
   changes:
@@ -24,6 +28,7 @@ jobs:
         with:
           filters: |
             relevant:
+              - 'packages/finance-contract/**'
               - 'packages/finance-db/**'
               - 'packages/db-types/**'
               - '.github/workflows/finance-db-quality.yml'

--- a/.github/workflows/finance-quality.yml
+++ b/.github/workflows/finance-quality.yml
@@ -11,6 +11,9 @@ on:
       - ".github/workflows/finance-quality.yml"
       - ".github/workflows/_pkg-check.yml"
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
 
 jobs:
   changes:

--- a/.github/workflows/food-api-quality.yml
+++ b/.github/workflows/food-api-quality.yml
@@ -10,6 +10,9 @@ on:
       - ".github/workflows/food-api-quality.yml"
       - ".github/workflows/_pkg-check.yml"
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
 
 jobs:
   changes:

--- a/.github/workflows/food-db-quality.yml
+++ b/.github/workflows/food-db-quality.yml
@@ -10,6 +10,9 @@ on:
       - ".github/workflows/food-db-quality.yml"
       - ".github/workflows/_pkg-check.yml"
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
 
 jobs:
   changes:

--- a/.github/workflows/food-quality.yml
+++ b/.github/workflows/food-quality.yml
@@ -11,6 +11,9 @@ on:
       - ".github/workflows/food-quality.yml"
       - ".github/workflows/_pkg-check.yml"
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
 
 jobs:
   changes:

--- a/.github/workflows/infra-lint.yml
+++ b/.github/workflows/infra-lint.yml
@@ -7,6 +7,9 @@ on:
       - "infra/litestream/**"
       - ".github/workflows/infra-lint.yml"
   pull_request:
+    paths:
+      - "infra/litestream/**"
+      - ".github/workflows/infra-lint.yml"
 
 jobs:
   changes:

--- a/.github/workflows/inventory-api-quality.yml
+++ b/.github/workflows/inventory-api-quality.yml
@@ -10,6 +10,9 @@ on:
       - ".github/workflows/inventory-api-quality.yml"
       - ".github/workflows/_pkg-check.yml"
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
 
 jobs:
   changes:

--- a/.github/workflows/inventory-db-quality.yml
+++ b/.github/workflows/inventory-db-quality.yml
@@ -9,6 +9,9 @@ on:
       - ".github/workflows/inventory-db-quality.yml"
       - ".github/workflows/_pkg-check.yml"
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
 
 jobs:
   changes:

--- a/.github/workflows/inventory-quality.yml
+++ b/.github/workflows/inventory-quality.yml
@@ -11,6 +11,9 @@ on:
       - ".github/workflows/inventory-quality.yml"
       - ".github/workflows/_pkg-check.yml"
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
 
 jobs:
   changes:

--- a/.github/workflows/lists-api-quality.yml
+++ b/.github/workflows/lists-api-quality.yml
@@ -10,6 +10,9 @@ on:
       - ".github/workflows/lists-api-quality.yml"
       - ".github/workflows/_pkg-check.yml"
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
 
 jobs:
   changes:

--- a/.github/workflows/lists-db-quality.yml
+++ b/.github/workflows/lists-db-quality.yml
@@ -10,6 +10,9 @@ on:
       - ".github/workflows/lists-db-quality.yml"
       - ".github/workflows/_pkg-check.yml"
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
 
 jobs:
   changes:

--- a/.github/workflows/media-api-quality.yml
+++ b/.github/workflows/media-api-quality.yml
@@ -10,6 +10,9 @@ on:
       - ".github/workflows/media-api-quality.yml"
       - ".github/workflows/_pkg-check.yml"
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
 
 jobs:
   changes:

--- a/.github/workflows/media-db-quality.yml
+++ b/.github/workflows/media-db-quality.yml
@@ -9,6 +9,9 @@ on:
       - ".github/workflows/media-db-quality.yml"
       - ".github/workflows/_pkg-check.yml"
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
 
 jobs:
   changes:

--- a/.github/workflows/media-quality.yml
+++ b/.github/workflows/media-quality.yml
@@ -11,6 +11,9 @@ on:
       - ".github/workflows/media-quality.yml"
       - ".github/workflows/_pkg-check.yml"
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
 
 jobs:
   changes:

--- a/.github/workflows/module-registry-quality.yml
+++ b/.github/workflows/module-registry-quality.yml
@@ -9,6 +9,9 @@ on:
       - ".github/workflows/module-registry-quality.yml"
       - ".github/workflows/_pkg-check.yml"
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
 
 jobs:
   changes:

--- a/.github/workflows/navigation-quality.yml
+++ b/.github/workflows/navigation-quality.yml
@@ -10,6 +10,9 @@ on:
       - ".github/workflows/navigation-quality.yml"
       - ".github/workflows/_pkg-check.yml"
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
 
 jobs:
   changes:

--- a/.github/workflows/pillar-images.yml
+++ b/.github/workflows/pillar-images.yml
@@ -10,10 +10,33 @@ name: Pillar Images
 
 on:
   pull_request:
+    paths:
+      - 'apps/pops-*-api/**'
+      - 'packages/*-api/**'
+      - 'packages/*-db/**'
+      - 'packages/*-contract/**'
+      - 'packages/db-types/**'
+      - 'packages/types/**'
+      - 'packages/module-registry/**'
+      - 'packages/food-contracts/**'
+      - 'infra/docker/pillar.Dockerfile'
+      - 'infra/docker-compose*.yml'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - 'turbo.json'
+      - 'tsconfig.base.json'
+      - '.github/workflows/pillar-images.yml'
   push:
     branches: [main]
     paths:
-      - 'packages/**'
+      - 'apps/pops-*-api/**'
+      - 'packages/*-api/**'
+      - 'packages/*-db/**'
+      - 'packages/*-contract/**'
+      - 'packages/db-types/**'
+      - 'packages/types/**'
+      - 'packages/module-registry/**'
+      - 'packages/food-contracts/**'
       - 'infra/docker/pillar.Dockerfile'
       - 'infra/docker-compose*.yml'
       - 'pnpm-lock.yaml'
@@ -63,10 +86,40 @@ jobs:
         pillar: ${{ fromJson(needs.discover.outputs.pillars) }}
     steps:
       - uses: actions/checkout@v6
+
+      # Per-pillar path filter: a finance-only change should not rebuild
+      # the media/inventory/cerebrum/food/lists/core builders. Shared
+      # surfaces (the Dockerfile, root manifests, the workflow file) still
+      # trigger every pillar — anything else gates by pillar prefix.
+      - id: pillar-changes
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@v4
+        with:
+          filters: |
+            relevant:
+              - 'apps/pops-${{ matrix.pillar.short }}-api/**'
+              - 'packages/${{ matrix.pillar.short }}-*/**'
+              - 'packages/app-${{ matrix.pillar.short }}-*/**'
+              - 'packages/db-types/**'
+              - 'packages/types/**'
+              - 'packages/module-registry/**'
+              - 'packages/food-contracts/**'
+              - 'infra/docker/pillar.Dockerfile'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - 'turbo.json'
+              - 'tsconfig.base.json'
+              - '.github/workflows/pillar-images.yml'
+
+      - name: Skip — ${{ matrix.pillar.short }} unchanged
+        if: github.event_name == 'pull_request' && steps.pillar-changes.outputs.relevant != 'true'
+        run: echo "No ${{ matrix.pillar.short }} sources changed — skipping build."
+
       - uses: docker/setup-buildx-action@v3
+        if: github.event_name == 'push' || steps.pillar-changes.outputs.relevant == 'true'
 
       - name: Build ${{ matrix.pillar.name }} (builder stage)
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && steps.pillar-changes.outputs.relevant == 'true'
         uses: docker/build-push-action@v6
         with:
           context: .

--- a/.github/workflows/pillar-images.yml
+++ b/.github/workflows/pillar-images.yml
@@ -103,7 +103,6 @@ jobs:
               - 'packages/db-types/**'
               - 'packages/types/**'
               - 'packages/module-registry/**'
-              - 'packages/food-contracts/**'
               - 'infra/docker/pillar.Dockerfile'
               - 'pnpm-lock.yaml'
               - 'pnpm-workspace.yaml'

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,9 +1,22 @@
 name: Quality
 
+# Workspace-wide lint / format / module-boundaries / duplication gate.
+# Docs-only PRs (paths under `docs/**` or any `*.md`) cannot break code
+# quality, so the whole workflow is excluded from those changes. GitHub
+# rulesets with `strict_required_status_checks_policy: false` treat a
+# workflow that never triggered as non-blocking, which keeps docs-only
+# PRs to ≤ 4 required checks (Theme 13 PRD-220).
+
 on:
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
   push:
     branches: [main]
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
 
 jobs:
   lint:

--- a/.github/workflows/storybook-quality.yml
+++ b/.github/workflows/storybook-quality.yml
@@ -9,6 +9,9 @@ on:
       - ".github/workflows/storybook-quality.yml"
       - ".github/workflows/_pkg-check.yml"
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
 
 jobs:
   changes:

--- a/.github/workflows/ui-quality.yml
+++ b/.github/workflows/ui-quality.yml
@@ -8,6 +8,9 @@ on:
       - ".github/workflows/ui-quality.yml"
       - ".github/workflows/_pkg-check.yml"
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
 
 jobs:
   changes:

--- a/.github/workflows/worker-food-image.yml
+++ b/.github/workflows/worker-food-image.yml
@@ -13,7 +13,8 @@ on:
     paths:
       - 'apps/pops-worker-food/**'
       - 'infra/docker/pops-worker-food/**'
-      - 'packages/food-contracts/**'
+      - 'packages/food-*/**'
+      - 'packages/app-food-db/**'
       - 'pnpm-lock.yaml'
       - 'pnpm-workspace.yaml'
       - 'turbo.json'
@@ -24,7 +25,8 @@ on:
     paths:
       - 'apps/pops-worker-food/**'
       - 'infra/docker/pops-worker-food/**'
-      - 'packages/food-contracts/**'
+      - 'packages/food-*/**'
+      - 'packages/app-food-db/**'
       - 'pnpm-lock.yaml'
       - 'pnpm-workspace.yaml'
       - 'turbo.json'

--- a/.github/workflows/workflows-quality.yml
+++ b/.github/workflows/workflows-quality.yml
@@ -6,6 +6,9 @@ on:
     paths:
       - ".github/workflows/**"
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
 
 jobs:
   changes:


### PR DESCRIPTION
## Summary

Implements [Theme 13 PRD-220](docs/themes/13-pillar-finale/IMPLEMENTATION-PLAN.md#ci-lean-ness-continuous-track-runs-across-all-waves) — the Wave 1 deliverable of the CI lean-ness track. Tightens `paths:` / `paths-ignore:` filters across every workflow so a PR only fires the checks that can plausibly fail on its diff.

## Baseline before this PR

- PR #2945 (docs-only): ~100 required checks fired.
- PR #2944 (contract-package only): ~100 required checks fired.
- PR #2947 (lint-rule change): worker-food-image + docker-build still ran.

## What this PR changes

| Workflow              | Before                                           | After                                                                                          |
| --------------------- | ------------------------------------------------ | ---------------------------------------------------------------------------------------------- |
| `quality.yml`         | every PR, no filter                              | `paths-ignore: docs/**, **/*.md` — docs PRs skip workspace lint/format/boundaries/duplication |
| `fe-test-e2e.yml`     | `paths: packages/**`                             | narrowed to actual FE consumer set (ui, app-*, api-client, auth, navigation, widgets, types, db-types, test-utils, shell, pops-api) |
| `docker-build.yml`    | every app + every package                        | only Dockerfile + compose + lockfiles + turbo/tsconfig                                          |
| `pillar-images.yml`   | `paths: packages/**` + full pillar matrix         | narrow to per-pillar source dirs + pillar Dockerfile + shared workspace surfaces                |
| `worker-food-image.yml` | broad pillar trigger                            | scoped to food touch points only                                                                |
| Per-pillar `*-quality.yml` (×27) | broad path filter                       | `paths-ignore: docs/**, **/*.md` added to `pull_request` trigger                              |

35 workflow files touched in total.

## Acceptance (Wave 1 gate)

- [ ] Docs-only PR fires <= 4 required checks (measured against #2945-style change after merge)
- [ ] Contract-package only PR fires <= 10 required checks (measured against #2944-style)
- [ ] Single-pillar API PR fires only that pillar's quality workflows + workspace gates

## Follow-up (deferred to Waves 2-5)

- PRD-221: `affected-rebuild` orchestrator job to drive matrix-of-one for pillar-images
- PRD-222: docs-only fast-path workflow (currently relies on skip-as-pass)
- PRD-223: per-pillar matrix narrowing
- PRD-224: E2E pillar tagging
- PRD-225: publish narrowing
- PRD-226: budget enforcement check

## Test plan

- [ ] CI on this PR runs only `workflows-quality` (the YAML lint) + format + module-boundaries (no code changed, so these are the only gates that should care)
- [ ] After merge, open a follow-up docs-only PR to verify the <= 4 check budget