### PR TITLE
feat(pillar-sdk): bootstrapPillar helper + finance-api wiring (Theme 13 PRD-158)

### DIFF
--- a/.github/workflows/_pkg-check.yml
+++ b/.github/workflows/_pkg-check.yml
@@ -55,6 +55,8 @@ jobs:
           pnpm --filter @pops/lists-db build
           pnpm --filter @pops/app-lists-db build
           pnpm --filter @pops/app-food-db build
+          pnpm --filter @pops/pillar-sdk build
+          pnpm --filter @pops/finance-contract build
       - run: cd ${{ inputs.package-path }} && pnpm typecheck
         if: inputs.skip != 'true'
 
@@ -93,6 +95,8 @@ jobs:
           pnpm --filter @pops/lists-db build
           pnpm --filter @pops/app-lists-db build
           pnpm --filter @pops/app-food-db build
+          pnpm --filter @pops/pillar-sdk build
+          pnpm --filter @pops/finance-contract build
       - name: Run tests (with coverage if configured)
         if: inputs.skip != 'true'
         run: |

--- a/apps/pops-finance-api/Dockerfile
+++ b/apps/pops-finance-api/Dockerfile
@@ -9,6 +9,7 @@ COPY packages/db-types/package.json ./packages/db-types/
 COPY packages/types/package.json ./packages/types/
 COPY packages/core-db/package.json ./packages/core-db/
 COPY packages/finance-db/package.json ./packages/finance-db/
+COPY packages/pillar-sdk/package.json ./packages/pillar-sdk/
 COPY apps/pops-finance-api/package.json ./apps/pops-finance-api/
 
 # Install pnpm and all workspace dependencies
@@ -26,6 +27,8 @@ COPY packages/core-db/migrations ./packages/core-db/migrations
 COPY packages/finance-db/src ./packages/finance-db/src
 COPY packages/finance-db/tsconfig.json ./packages/finance-db/
 COPY packages/finance-db/migrations ./packages/finance-db/migrations
+COPY packages/pillar-sdk/src ./packages/pillar-sdk/src
+COPY packages/pillar-sdk/tsconfig.json ./packages/pillar-sdk/
 
 # Copy finance-api source
 COPY apps/pops-finance-api/tsconfig.json ./apps/pops-finance-api/
@@ -39,6 +42,8 @@ RUN pnpm build
 WORKDIR /app/packages/core-db
 RUN pnpm build
 WORKDIR /app/packages/finance-db
+RUN pnpm build
+WORKDIR /app/packages/pillar-sdk
 RUN pnpm build
 
 # Build finance-api

--- a/apps/pops-finance-api/package.json
+++ b/apps/pops-finance-api/package.json
@@ -20,6 +20,7 @@
     "@pops/core-db": "workspace:*",
     "@pops/db-types": "workspace:*",
     "@pops/finance-db": "workspace:*",
+    "@pops/pillar-sdk": "workspace:*",
     "@pops/types": "workspace:*",
     "@trpc/server": "^11.17.0",
     "express": "^5.1.0",

--- a/apps/pops-finance-api/src/server.ts
+++ b/apps/pops-finance-api/src/server.ts
@@ -1,3 +1,5 @@
+import { openCoreDb } from '@pops/core-db';
+import { openFinanceDb } from '@pops/finance-db';
 /**
  * Entry point for the finance pillar HTTP server.
  *
@@ -12,13 +14,21 @@
  * rather than reaching back into pops-api's singleton — that's the
  * whole point of phase 3. Mirrors `apps/pops-media-api/src/server.ts`
  * and `apps/pops-inventory-api/src/server.ts`.
+ *
+ * Theme 13 PRD-158 adds an opt-in registry handshake via
+ * `bootstrapPillar`. When `POPS_REGISTRY_ENABLED=true`, the process
+ * builds a hand-rolled finance manifest (PRD-155 will generate this
+ * later) and registers with the central registry on boot. SIGTERM
+ * triggers `runtime.stop()` so the heartbeat clears and the registry
+ * sees an explicit deregister.
  */
-import { openCoreDb } from '@pops/core-db';
-import { openFinanceDb } from '@pops/finance-db';
+import { bootstrapPillar, type PillarBootstrapHandle } from '@pops/pillar-sdk/bootstrap';
 
 import { createFinanceApiApp } from './app.js';
 import { resolveCoreSqlitePath } from './core-sqlite-path.js';
 import { resolveFinanceSqlitePath } from './finance-sqlite-path.js';
+
+import type { ManifestPayload } from '@pops/pillar-sdk/manifest-schema';
 
 function resolvePort(): number {
   // 3001 is core-api, 3002 is inventory-api, 3003 is media-api,
@@ -32,12 +42,57 @@ function resolvePort(): number {
   return parsed;
 }
 
+function buildFinanceManifest(version: string): ManifestPayload {
+  return {
+    pillar: 'finance',
+    version,
+    contract: {
+      package: '@pops/finance-contract',
+      version,
+      tag: `contract-finance@v${version}`,
+    },
+    routes: {
+      queries: [
+        'finance.wishlist.list',
+        'finance.wishlist.get',
+        'finance.budgets.list',
+        'finance.budgets.get',
+        'finance.transactions.list',
+        'finance.transactions.get',
+      ],
+      mutations: [
+        'finance.wishlist.create',
+        'finance.wishlist.update',
+        'finance.wishlist.delete',
+        'finance.budgets.create',
+        'finance.budgets.update',
+        'finance.budgets.delete',
+        'finance.transactions.create',
+        'finance.transactions.update',
+        'finance.transactions.delete',
+        'finance.transactions.restore',
+      ],
+      subscriptions: [],
+    },
+    search: { adapters: [] },
+    ai: { tools: [] },
+    uri: { types: ['finance/transaction', 'finance/wishlist-item', 'finance/budget'] },
+    settings: { keys: [] },
+    healthcheck: { path: '/health' },
+  };
+}
+
 const port = resolvePort();
-const version = process.env['BUILD_VERSION'] ?? 'dev';
+const version = process.env['BUILD_VERSION'] ?? '0.1.0';
 
 const financeDb = openFinanceDb(resolveFinanceSqlitePath());
 const coreDb = openCoreDb(resolveCoreSqlitePath());
 const app = createFinanceApiApp({ financeDb, coreDb, version });
+
+let pillarHandle: PillarBootstrapHandle | undefined;
+if (process.env['POPS_REGISTRY_ENABLED'] === 'true') {
+  pillarHandle = await bootstrapPillar({ manifest: buildFinanceManifest(version) });
+}
 
 const server = app.listen(port, () => {
   console.warn(`[finance-api] Listening on port ${port}`);
@@ -48,9 +103,11 @@ function shutdown(signal: NodeJS.Signals): void {
   if (shuttingDown) return;
   shuttingDown = true;
   console.warn(`[finance-api] Shutting down (${signal})`);
-  server.close(() => {
-    financeDb.raw.close();
-    coreDb.raw.close();
+  void (pillarHandle?.stop() ?? Promise.resolve()).finally(() => {
+    server.close(() => {
+      financeDb.raw.close();
+      coreDb.raw.close();
+    });
   });
 }
 

--- a/packages/pillar-sdk/package.json
+++ b/packages/pillar-sdk/package.json
@@ -14,6 +14,10 @@
       "types": "./dist/manifest-schema/index.d.ts",
       "default": "./dist/manifest-schema/index.js"
     },
+    "./bootstrap": {
+      "types": "./dist/bootstrap/index.d.ts",
+      "default": "./dist/bootstrap/index.js"
+    },
     "./package.json": "./package.json"
   },
   "scripts": {
@@ -27,6 +31,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@types/node": "^25.9.3",
     "@vitest/coverage-v8": "^4.1.8",
     "typescript": "^6.0.3",
     "vitest": "^4.1.8"

--- a/packages/pillar-sdk/src/bootstrap/__tests__/bootstrap.test.ts
+++ b/packages/pillar-sdk/src/bootstrap/__tests__/bootstrap.test.ts
@@ -1,0 +1,393 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { validManifest } from '../../__tests__/fixtures.js';
+import { bootstrapPillar } from '../bootstrap.js';
+import {
+  PillarManifestInvalidError,
+  PillarRegistrationFailedError,
+  PillarRegistrationRejectedError,
+} from '../errors.js';
+import {
+  RegistryNetworkError,
+  RegistryTransportError,
+  type RegistryTransport,
+} from '../transport.js';
+
+interface RecordedTransport extends RegistryTransport {
+  registerCalls: number;
+  heartbeatCalls: number;
+  unregisterCalls: number;
+  heartbeats: string[];
+}
+
+interface MakeTransportOptions {
+  registerImpl?: () => Promise<{ pillarId: string }>;
+  heartbeatImpl?: () => Promise<{ pillarId: string; acknowledgedAt: string }>;
+  unregisterImpl?: () => Promise<void>;
+}
+
+function makeTransport(options: MakeTransportOptions = {}): RecordedTransport {
+  const state: RecordedTransport = {
+    registerCalls: 0,
+    heartbeatCalls: 0,
+    unregisterCalls: 0,
+    heartbeats: [],
+    async register(payload) {
+      state.registerCalls += 1;
+      if (options.registerImpl) return options.registerImpl();
+      return { pillarId: payload.pillar };
+    },
+    async heartbeat(pillarId) {
+      state.heartbeatCalls += 1;
+      state.heartbeats.push(pillarId);
+      if (options.heartbeatImpl) return options.heartbeatImpl();
+      return { pillarId, acknowledgedAt: new Date().toISOString() };
+    },
+    async unregister() {
+      state.unregisterCalls += 1;
+      if (options.unregisterImpl) await options.unregisterImpl();
+    },
+  };
+  return state;
+}
+
+function silentLogger() {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+}
+
+describe('bootstrapPillar', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('validates, registers, and returns a handle on the happy path', async () => {
+    const transport = makeTransport();
+    const handle = await bootstrapPillar({
+      manifest: validManifest(),
+      transport,
+      logger: silentLogger(),
+      heartbeatMs: 1_000,
+    });
+
+    expect(transport.registerCalls).toBe(1);
+    expect(handle.pillarId).toBe('finance');
+
+    await handle.stop();
+    expect(transport.unregisterCalls).toBe(1);
+  });
+
+  it('throws PillarManifestInvalidError when manifest is malformed', async () => {
+    const bad = validManifest();
+    bad.pillar = 'INVALID_UPPERCASE';
+
+    const transport = makeTransport();
+    await expect(
+      bootstrapPillar({
+        manifest: bad,
+        transport,
+        logger: silentLogger(),
+      })
+    ).rejects.toBeInstanceOf(PillarManifestInvalidError);
+
+    expect(transport.registerCalls).toBe(0);
+  });
+
+  it('exposes per-field issues on PillarManifestInvalidError', async () => {
+    const bad = validManifest();
+    bad.routes.queries = ['not.a.valid'];
+    bad.routes.queries.push('also.invalid');
+
+    try {
+      await bootstrapPillar({
+        manifest: bad,
+        transport: makeTransport(),
+        logger: silentLogger(),
+      });
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(PillarManifestInvalidError);
+      if (err instanceof PillarManifestInvalidError) {
+        expect(err.issues.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('throws PillarRegistrationRejectedError when registry returns a 4xx', async () => {
+    const transport = makeTransport({
+      registerImpl: async () => {
+        throw new RegistryTransportError('400 Bad Request', {
+          status: 400,
+          issues: [
+            {
+              field: 'routes.queries',
+              reason: 'duplicate procedure',
+              got: 'finance.foo.bar',
+              schemaPath: ['routes', 'queries'],
+            },
+          ],
+          retriable: false,
+        });
+      },
+    });
+
+    await expect(
+      bootstrapPillar({
+        manifest: validManifest(),
+        transport,
+        logger: silentLogger(),
+      })
+    ).rejects.toBeInstanceOf(PillarRegistrationRejectedError);
+
+    expect(transport.registerCalls).toBe(1);
+  });
+
+  it('retries on network failure with exponential backoff and eventually fails', async () => {
+    const transport = makeTransport({
+      registerImpl: async () => {
+        throw new RegistryNetworkError('connect ECONNREFUSED', new Error('boom'));
+      },
+    });
+
+    const promise = bootstrapPillar({
+      manifest: validManifest(),
+      transport,
+      logger: silentLogger(),
+      maxRegisterAttempts: 3,
+      registerInitialBackoffMs: 10,
+      registerMaxBackoffMs: 40,
+    });
+    const settled = promise.then(
+      () => ({ ok: true as const }),
+      (err: unknown) => ({ ok: false as const, err })
+    );
+
+    await vi.advanceTimersByTimeAsync(10);
+    await vi.advanceTimersByTimeAsync(20);
+    const result = await settled;
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.err).toBeInstanceOf(PillarRegistrationFailedError);
+    }
+    expect(transport.registerCalls).toBe(3);
+  });
+
+  it('retries on network failure and succeeds when a later attempt is ok', async () => {
+    let attempt = 0;
+    const transport = makeTransport({
+      registerImpl: async () => {
+        attempt += 1;
+        if (attempt < 3) {
+          throw new RegistryNetworkError('flaky', new Error('boom'));
+        }
+        return { pillarId: 'finance' };
+      },
+    });
+
+    const promise = bootstrapPillar({
+      manifest: validManifest(),
+      transport,
+      logger: silentLogger(),
+      heartbeatMs: 1_000_000,
+      maxRegisterAttempts: 5,
+      registerInitialBackoffMs: 10,
+      registerMaxBackoffMs: 40,
+    });
+
+    await vi.advanceTimersByTimeAsync(10);
+    await vi.advanceTimersByTimeAsync(20);
+    const handle = await promise;
+    expect(transport.registerCalls).toBe(3);
+    await handle.stop();
+  });
+
+  it('retries on 5xx and treats it as transient', async () => {
+    let attempt = 0;
+    const transport = makeTransport({
+      registerImpl: async () => {
+        attempt += 1;
+        if (attempt === 1) {
+          throw new RegistryTransportError('503 Service Unavailable', {
+            status: 503,
+            retriable: true,
+          });
+        }
+        return { pillarId: 'finance' };
+      },
+    });
+
+    const promise = bootstrapPillar({
+      manifest: validManifest(),
+      transport,
+      logger: silentLogger(),
+      heartbeatMs: 1_000_000,
+      maxRegisterAttempts: 3,
+      registerInitialBackoffMs: 5,
+      registerMaxBackoffMs: 10,
+    });
+
+    await vi.advanceTimersByTimeAsync(5);
+    const handle = await promise;
+    expect(transport.registerCalls).toBe(2);
+    await handle.stop();
+  });
+
+  it('fires heartbeat at the configured interval', async () => {
+    const transport = makeTransport();
+    const handle = await bootstrapPillar({
+      manifest: validManifest(),
+      transport,
+      logger: silentLogger(),
+      heartbeatMs: 1_000,
+    });
+
+    expect(transport.heartbeatCalls).toBe(0);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(transport.heartbeatCalls).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(transport.heartbeatCalls).toBe(3);
+    expect(transport.heartbeats.every((id) => id === 'finance')).toBe(true);
+
+    await handle.stop();
+  });
+
+  it('stop() clears the heartbeat interval and calls unregister', async () => {
+    const transport = makeTransport();
+    const handle = await bootstrapPillar({
+      manifest: validManifest(),
+      transport,
+      logger: silentLogger(),
+      heartbeatMs: 500,
+    });
+
+    await vi.advanceTimersByTimeAsync(500);
+    expect(transport.heartbeatCalls).toBe(1);
+
+    await handle.stop();
+    expect(transport.unregisterCalls).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(transport.heartbeatCalls).toBe(1);
+  });
+
+  it('stop() is idempotent and only unregisters once', async () => {
+    const transport = makeTransport();
+    const handle = await bootstrapPillar({
+      manifest: validManifest(),
+      transport,
+      logger: silentLogger(),
+      heartbeatMs: 1_000,
+    });
+
+    await handle.stop();
+    await handle.stop();
+    expect(transport.unregisterCalls).toBe(1);
+  });
+
+  it('heartbeat failures do not crash the loop', async () => {
+    let heartbeatAttempt = 0;
+    const logger = silentLogger();
+    const transport = makeTransport({
+      heartbeatImpl: async () => {
+        heartbeatAttempt += 1;
+        if (heartbeatAttempt === 1) {
+          throw new RegistryNetworkError('timeout', new Error('boom'));
+        }
+        return { pillarId: 'finance', acknowledgedAt: '2026-01-01T00:00:00Z' };
+      },
+    });
+
+    const handle = await bootstrapPillar({
+      manifest: validManifest(),
+      transport,
+      logger,
+      heartbeatMs: 100,
+    });
+
+    await vi.advanceTimersByTimeAsync(100);
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(100);
+    expect(transport.heartbeatCalls).toBe(2);
+    expect(logger.warn).toHaveBeenCalled();
+
+    await handle.stop();
+  });
+
+  it('mounts a /health route on the provided app', async () => {
+    type HealthHandler = (
+      req: unknown,
+      res: {
+        json: (body: unknown) => unknown;
+        status: (code: number) => {
+          json: (body: unknown) => unknown;
+          status: (code: number) => unknown;
+        };
+      }
+    ) => void;
+    const routes: Record<string, HealthHandler> = {};
+    const app = {
+      get(path: string, handler: HealthHandler): unknown {
+        routes[path] = handler;
+        return undefined;
+      },
+    };
+
+    const transport = makeTransport();
+    const handle = await bootstrapPillar({
+      manifest: validManifest(),
+      app,
+      transport,
+      logger: silentLogger(),
+      heartbeatMs: 10_000,
+    });
+
+    const handler = routes['/healthz'];
+    expect(handler).toBeDefined();
+
+    const body: { json: unknown }[] = [];
+    const res = {
+      json(b: unknown): unknown {
+        body.push({ json: b });
+        return undefined;
+      },
+      status(): { json: (b: unknown) => unknown; status: (c: number) => unknown } {
+        return res;
+      },
+    };
+    handler?.({}, res);
+
+    expect(body[0]?.json).toMatchObject({
+      ok: true,
+      pillar: 'finance',
+      version: '1.2.3',
+    });
+
+    await handle.stop();
+  });
+
+  it('best-effort unregister: stop() resolves even if unregister throws', async () => {
+    const transport = makeTransport({
+      unregisterImpl: async () => {
+        throw new Error('registry down');
+      },
+    });
+
+    const handle = await bootstrapPillar({
+      manifest: validManifest(),
+      transport,
+      logger: silentLogger(),
+      heartbeatMs: 1_000,
+    });
+
+    await expect(handle.stop()).resolves.toBeUndefined();
+  });
+});

--- a/packages/pillar-sdk/src/bootstrap/__tests__/transport.test.ts
+++ b/packages/pillar-sdk/src/bootstrap/__tests__/transport.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { validManifest } from '../../__tests__/fixtures.js';
+import {
+  createHttpRegistryTransport,
+  RegistryNetworkError,
+  RegistryTransportError,
+} from '../transport.js';
+
+function mockFetch(
+  responses: Array<{ status: number; body?: unknown; throwOnce?: boolean }>
+): typeof fetch {
+  let i = 0;
+  const fn: typeof fetch = async (_input, _init) => {
+    const r = responses[i];
+    i += 1;
+    if (!r) throw new Error('no more mock responses');
+    if (r.throwOnce) throw new Error('network down');
+    const body = r.body === undefined ? '' : JSON.stringify(r.body);
+    return new Response(body, {
+      status: r.status,
+      headers: { 'content-type': 'application/json' },
+    });
+  };
+  return vi.fn(fn);
+}
+
+describe('createHttpRegistryTransport', () => {
+  it('POSTs the manifest to /registry/register', async () => {
+    const fetchImpl = mockFetch([{ status: 200, body: { pillarId: 'finance' } }]);
+    const transport = createHttpRegistryTransport({
+      baseUrl: 'http://registry.test',
+      fetchImpl,
+    });
+
+    const result = await transport.register(validManifest());
+    expect(result.pillarId).toBe('finance');
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    const [url, init] = (fetchImpl as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    expect(url).toBe('http://registry.test/registry/register');
+    expect((init as RequestInit).method).toBe('POST');
+  });
+
+  it('throws RegistryNetworkError when fetch rejects', async () => {
+    const fetchImpl = mockFetch([{ status: 0, throwOnce: true }]);
+    const transport = createHttpRegistryTransport({
+      baseUrl: 'http://registry.test',
+      fetchImpl,
+    });
+
+    await expect(transport.register(validManifest())).rejects.toBeInstanceOf(RegistryNetworkError);
+  });
+
+  it('throws non-retriable RegistryTransportError on 400 with parsed issues', async () => {
+    const fetchImpl = mockFetch([
+      {
+        status: 400,
+        body: {
+          issues: [{ field: 'routes.queries', reason: 'dup' }],
+        },
+      },
+    ]);
+    const transport = createHttpRegistryTransport({
+      baseUrl: 'http://registry.test',
+      fetchImpl,
+    });
+
+    try {
+      await transport.register(validManifest());
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(RegistryTransportError);
+      if (err instanceof RegistryTransportError) {
+        expect(err.status).toBe(400);
+        expect(err.retriable).toBe(false);
+        expect(err.issues).toHaveLength(1);
+      }
+    }
+  });
+
+  it('throws retriable RegistryTransportError on 503', async () => {
+    const fetchImpl = mockFetch([{ status: 503, body: { error: 'down' } }]);
+    const transport = createHttpRegistryTransport({
+      baseUrl: 'http://registry.test',
+      fetchImpl,
+    });
+
+    try {
+      await transport.heartbeat('finance');
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(RegistryTransportError);
+      if (err instanceof RegistryTransportError) {
+        expect(err.retriable).toBe(true);
+      }
+    }
+  });
+
+  it('unregister returns void on 200 with empty body', async () => {
+    const fetchImpl = mockFetch([{ status: 200, body: {} }]);
+    const transport = createHttpRegistryTransport({
+      baseUrl: 'http://registry.test/',
+      fetchImpl,
+    });
+
+    await expect(transport.unregister('finance')).resolves.toBeUndefined();
+  });
+});

--- a/packages/pillar-sdk/src/bootstrap/bootstrap.ts
+++ b/packages/pillar-sdk/src/bootstrap/bootstrap.ts
@@ -1,0 +1,126 @@
+import { type ManifestPayload } from '../manifest-schema/schema.js';
+import { validateManifestPayload } from '../manifest-schema/validate.js';
+import { errSummary, PillarManifestInvalidError } from './errors.js';
+import { mountHealthRoute, type HealthApp } from './health-route.js';
+import { consoleLogger, type BootstrapLogger } from './logger.js';
+import { registerWithRetry } from './register.js';
+import { createHttpRegistryTransport, type RegistryTransport } from './transport.js';
+
+export interface BootstrapPillarOptions {
+  manifest: ManifestPayload;
+  app?: HealthApp;
+  transport?: RegistryTransport;
+  heartbeatMs?: number;
+  maxRegisterAttempts?: number;
+  registerInitialBackoffMs?: number;
+  registerMaxBackoffMs?: number;
+  logger?: BootstrapLogger;
+  registryUrl?: string;
+  setIntervalImpl?: typeof setInterval;
+  clearIntervalImpl?: typeof clearInterval;
+  setTimeoutImpl?: typeof setTimeout;
+}
+
+export interface PillarBootstrapHandle {
+  pillarId: string;
+  stop(): Promise<void>;
+}
+
+const DEFAULT_HEARTBEAT_MS = 10_000;
+const DEFAULT_MAX_REGISTER_ATTEMPTS = 5;
+const DEFAULT_REGISTER_INITIAL_BACKOFF_MS = 1_000;
+const DEFAULT_REGISTER_MAX_BACKOFF_MS = 30_000;
+const DEFAULT_REGISTRY_URL_ENV = 'POPS_REGISTRY_URL';
+const DEFAULT_REGISTRY_URL_FALLBACK = 'http://core-api:3001';
+
+export async function bootstrapPillar(
+  options: BootstrapPillarOptions
+): Promise<PillarBootstrapHandle> {
+  const logger = options.logger ?? consoleLogger();
+
+  const validation = validateManifestPayload(options.manifest);
+  if (!validation.ok) {
+    throw new PillarManifestInvalidError(validation.issues);
+  }
+  const manifest = validation.payload;
+
+  const transport = options.transport ?? defaultTransport(options.registryUrl);
+  const setIntervalImpl = options.setIntervalImpl ?? setInterval;
+  const clearIntervalImpl = options.clearIntervalImpl ?? clearInterval;
+  const setTimeoutImpl = options.setTimeoutImpl ?? setTimeout;
+  const heartbeatMs = options.heartbeatMs ?? DEFAULT_HEARTBEAT_MS;
+
+  mountHealthRoute(options.app, manifest, logger);
+
+  await registerWithRetry({
+    transport,
+    manifest,
+    logger,
+    maxAttempts: options.maxRegisterAttempts ?? DEFAULT_MAX_REGISTER_ATTEMPTS,
+    initialBackoffMs: options.registerInitialBackoffMs ?? DEFAULT_REGISTER_INITIAL_BACKOFF_MS,
+    maxBackoffMs: options.registerMaxBackoffMs ?? DEFAULT_REGISTER_MAX_BACKOFF_MS,
+    setTimeoutImpl,
+  });
+
+  return startRuntime({
+    manifest,
+    transport,
+    logger,
+    heartbeatMs,
+    setIntervalImpl,
+    clearIntervalImpl,
+  });
+}
+
+interface StartRuntimeArgs {
+  manifest: ManifestPayload;
+  transport: RegistryTransport;
+  logger: BootstrapLogger;
+  heartbeatMs: number;
+  setIntervalImpl: typeof setInterval;
+  clearIntervalImpl: typeof clearInterval;
+}
+
+function startRuntime(args: StartRuntimeArgs): PillarBootstrapHandle {
+  let stopped = false;
+  const interval = args.setIntervalImpl(() => {
+    if (stopped) return;
+    args.transport.heartbeat(args.manifest.pillar).catch((err: unknown) => {
+      args.logger.warn('[pillar-sdk] heartbeat failed', {
+        pillar: args.manifest.pillar,
+        err: errSummary(err),
+      });
+    });
+  }, args.heartbeatMs);
+
+  if (typeof (interval as { unref?: () => void }).unref === 'function') {
+    (interval as { unref: () => void }).unref();
+  }
+
+  args.logger.info('[pillar-sdk] pillar bootstrapped', {
+    pillar: args.manifest.pillar,
+    heartbeatMs: args.heartbeatMs,
+  });
+
+  return {
+    pillarId: args.manifest.pillar,
+    async stop() {
+      if (stopped) return;
+      stopped = true;
+      args.clearIntervalImpl(interval);
+      try {
+        await args.transport.unregister(args.manifest.pillar);
+      } catch (err) {
+        args.logger.warn('[pillar-sdk] unregister failed (best-effort)', {
+          pillar: args.manifest.pillar,
+          err: errSummary(err),
+        });
+      }
+    },
+  };
+}
+
+function defaultTransport(explicitUrl: string | undefined): RegistryTransport {
+  const url = explicitUrl ?? process.env[DEFAULT_REGISTRY_URL_ENV] ?? DEFAULT_REGISTRY_URL_FALLBACK;
+  return createHttpRegistryTransport({ baseUrl: url });
+}

--- a/packages/pillar-sdk/src/bootstrap/bootstrap.ts
+++ b/packages/pillar-sdk/src/bootstrap/bootstrap.ts
@@ -52,7 +52,7 @@ export async function bootstrapPillar(
 
   mountHealthRoute(options.app, manifest, logger);
 
-  await registerWithRetry({
+  const registration = await registerWithRetry({
     transport,
     manifest,
     logger,
@@ -63,7 +63,7 @@ export async function bootstrapPillar(
   });
 
   return startRuntime({
-    manifest,
+    pillarId: registration.pillarId,
     transport,
     logger,
     heartbeatMs,
@@ -73,7 +73,7 @@ export async function bootstrapPillar(
 }
 
 interface StartRuntimeArgs {
-  manifest: ManifestPayload;
+  pillarId: string;
   transport: RegistryTransport;
   logger: BootstrapLogger;
   heartbeatMs: number;
@@ -85,9 +85,9 @@ function startRuntime(args: StartRuntimeArgs): PillarBootstrapHandle {
   let stopped = false;
   const interval = args.setIntervalImpl(() => {
     if (stopped) return;
-    args.transport.heartbeat(args.manifest.pillar).catch((err: unknown) => {
+    args.transport.heartbeat(args.pillarId).catch((err: unknown) => {
       args.logger.warn('[pillar-sdk] heartbeat failed', {
-        pillar: args.manifest.pillar,
+        pillar: args.pillarId,
         err: errSummary(err),
       });
     });
@@ -98,21 +98,21 @@ function startRuntime(args: StartRuntimeArgs): PillarBootstrapHandle {
   }
 
   args.logger.info('[pillar-sdk] pillar bootstrapped', {
-    pillar: args.manifest.pillar,
+    pillar: args.pillarId,
     heartbeatMs: args.heartbeatMs,
   });
 
   return {
-    pillarId: args.manifest.pillar,
+    pillarId: args.pillarId,
     async stop() {
       if (stopped) return;
       stopped = true;
       args.clearIntervalImpl(interval);
       try {
-        await args.transport.unregister(args.manifest.pillar);
+        await args.transport.unregister(args.pillarId);
       } catch (err) {
         args.logger.warn('[pillar-sdk] unregister failed (best-effort)', {
-          pillar: args.manifest.pillar,
+          pillar: args.pillarId,
           err: errSummary(err),
         });
       }

--- a/packages/pillar-sdk/src/bootstrap/errors.ts
+++ b/packages/pillar-sdk/src/bootstrap/errors.ts
@@ -1,0 +1,54 @@
+import { RegistryNetworkError, RegistryTransportError } from './transport.js';
+
+import type { ValidationIssue } from '../manifest-schema/validate.js';
+
+function describeIssues(issues: ValidationIssue[]): string {
+  return issues.map((i) => `${i.field || '<root>'}: ${i.reason}`).join('; ');
+}
+
+export class PillarManifestInvalidError extends Error {
+  readonly issues: ValidationIssue[];
+
+  constructor(issues: ValidationIssue[]) {
+    super(`Manifest invalid: ${describeIssues(issues)}`);
+    this.name = 'PillarManifestInvalidError';
+    this.issues = issues;
+  }
+}
+
+export class PillarRegistrationRejectedError extends Error {
+  readonly issues: ValidationIssue[];
+  readonly status: number;
+
+  constructor(status: number, issues: ValidationIssue[]) {
+    const detail = issues.length > 0 ? describeIssues(issues) : 'no issues reported';
+    super(`Registry rejected manifest (${status}): ${detail}`);
+    this.name = 'PillarRegistrationRejectedError';
+    this.issues = issues;
+    this.status = status;
+  }
+}
+
+export class PillarRegistrationFailedError extends Error {
+  readonly attempts: number;
+  readonly lastCause: unknown;
+
+  constructor(attempts: number, lastCause: unknown) {
+    const causeMessage = lastCause instanceof Error ? lastCause.message : String(lastCause);
+    super(`Registration failed after ${attempts} attempt(s): ${causeMessage}`);
+    this.name = 'PillarRegistrationFailedError';
+    this.attempts = attempts;
+    this.lastCause = lastCause;
+  }
+}
+
+export function errSummary(err: unknown): string {
+  if (err instanceof RegistryTransportError) {
+    return `${err.name}(status=${err.status}): ${err.message}`;
+  }
+  if (err instanceof RegistryNetworkError) {
+    return `${err.name}: ${err.message}`;
+  }
+  if (err instanceof Error) return `${err.name}: ${err.message}`;
+  return String(err);
+}

--- a/packages/pillar-sdk/src/bootstrap/health-route.ts
+++ b/packages/pillar-sdk/src/bootstrap/health-route.ts
@@ -1,0 +1,39 @@
+import { errSummary } from './errors.js';
+
+import type { ManifestPayload } from '../manifest-schema/schema.js';
+import type { BootstrapLogger } from './logger.js';
+
+export interface HealthResponseLike {
+  json(body: unknown): unknown;
+  status(code: number): HealthResponseLike;
+}
+
+export interface HealthApp {
+  get(path: string, handler: (req: unknown, res: HealthResponseLike) => void): unknown;
+}
+
+export function mountHealthRoute(
+  app: HealthApp | undefined,
+  manifest: ManifestPayload,
+  logger: BootstrapLogger
+): void {
+  if (!app) return;
+  try {
+    app.get(manifest.healthcheck.path, (_req, res) => {
+      res.json({
+        ok: true,
+        pillar: manifest.pillar,
+        version: manifest.version,
+        contract: {
+          package: manifest.contract.package,
+          version: manifest.contract.version,
+        },
+      });
+    });
+  } catch (err) {
+    logger.warn('[pillar-sdk] could not mount health route', {
+      path: manifest.healthcheck.path,
+      err: errSummary(err),
+    });
+  }
+}

--- a/packages/pillar-sdk/src/bootstrap/index.ts
+++ b/packages/pillar-sdk/src/bootstrap/index.ts
@@ -1,0 +1,21 @@
+export {
+  bootstrapPillar,
+  type BootstrapPillarOptions,
+  type PillarBootstrapHandle,
+} from './bootstrap.js';
+export {
+  PillarManifestInvalidError,
+  PillarRegistrationFailedError,
+  PillarRegistrationRejectedError,
+} from './errors.js';
+export { type BootstrapLogger } from './logger.js';
+export { type HealthApp, type HealthResponseLike } from './health-route.js';
+export {
+  createHttpRegistryTransport,
+  RegistryNetworkError,
+  RegistryTransportError,
+  type HeartbeatResult,
+  type HttpRegistryTransportOptions,
+  type RegistrationResult,
+  type RegistryTransport,
+} from './transport.js';

--- a/packages/pillar-sdk/src/bootstrap/logger.ts
+++ b/packages/pillar-sdk/src/bootstrap/logger.ts
@@ -1,0 +1,29 @@
+export interface BootstrapLogger {
+  info(msg: string, meta?: Record<string, unknown>): void;
+  warn(msg: string, meta?: Record<string, unknown>): void;
+  error(msg: string, meta?: Record<string, unknown>): void;
+}
+
+function writeWarn(msg: string, meta?: Record<string, unknown>): void {
+  if (meta !== undefined) {
+    console.warn(msg, meta);
+    return;
+  }
+  console.warn(msg);
+}
+
+function writeError(msg: string, meta?: Record<string, unknown>): void {
+  if (meta !== undefined) {
+    console.error(msg, meta);
+    return;
+  }
+  console.error(msg);
+}
+
+export function consoleLogger(): BootstrapLogger {
+  return {
+    info: writeWarn,
+    warn: writeWarn,
+    error: writeError,
+  };
+}

--- a/packages/pillar-sdk/src/bootstrap/register.ts
+++ b/packages/pillar-sdk/src/bootstrap/register.ts
@@ -1,0 +1,66 @@
+import {
+  errSummary,
+  PillarRegistrationFailedError,
+  PillarRegistrationRejectedError,
+} from './errors.js';
+import { RegistryTransportError, type RegistryTransport } from './transport.js';
+
+import type { ManifestPayload } from '../manifest-schema/schema.js';
+import type { BootstrapLogger } from './logger.js';
+
+export interface RegisterWithRetryArgs {
+  transport: RegistryTransport;
+  manifest: ManifestPayload;
+  logger: BootstrapLogger;
+  maxAttempts: number;
+  initialBackoffMs: number;
+  maxBackoffMs: number;
+  setTimeoutImpl: typeof setTimeout;
+}
+
+export async function registerWithRetry(args: RegisterWithRetryArgs): Promise<void> {
+  let attempt = 0;
+  let lastErr: unknown;
+
+  while (attempt < args.maxAttempts) {
+    attempt += 1;
+    try {
+      await args.transport.register(args.manifest);
+      args.logger.info('[pillar-sdk] registered with registry', {
+        pillar: args.manifest.pillar,
+        attempt,
+      });
+      return;
+    } catch (err) {
+      lastErr = err;
+      if (err instanceof RegistryTransportError && !err.retriable) {
+        throw new PillarRegistrationRejectedError(err.status, err.issues ?? []);
+      }
+      if (attempt >= args.maxAttempts) break;
+      await waitForRetry(args, attempt, err);
+    }
+  }
+
+  throw new PillarRegistrationFailedError(attempt, lastErr);
+}
+
+async function waitForRetry(
+  args: RegisterWithRetryArgs,
+  attempt: number,
+  err: unknown
+): Promise<void> {
+  const backoff = Math.min(args.initialBackoffMs * 2 ** (attempt - 1), args.maxBackoffMs);
+  args.logger.warn('[pillar-sdk] registration attempt failed, retrying', {
+    pillar: args.manifest.pillar,
+    attempt,
+    nextDelayMs: backoff,
+    err: errSummary(err),
+  });
+  await sleep(backoff, args.setTimeoutImpl);
+}
+
+function sleep(ms: number, setTimeoutImpl: typeof setTimeout): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeoutImpl(resolve, ms);
+  });
+}

--- a/packages/pillar-sdk/src/bootstrap/register.ts
+++ b/packages/pillar-sdk/src/bootstrap/register.ts
@@ -3,7 +3,11 @@ import {
   PillarRegistrationFailedError,
   PillarRegistrationRejectedError,
 } from './errors.js';
-import { RegistryTransportError, type RegistryTransport } from './transport.js';
+import {
+  RegistryTransportError,
+  type RegistrationResult,
+  type RegistryTransport,
+} from './transport.js';
 
 import type { ManifestPayload } from '../manifest-schema/schema.js';
 import type { BootstrapLogger } from './logger.js';
@@ -18,19 +22,19 @@ export interface RegisterWithRetryArgs {
   setTimeoutImpl: typeof setTimeout;
 }
 
-export async function registerWithRetry(args: RegisterWithRetryArgs): Promise<void> {
+export async function registerWithRetry(args: RegisterWithRetryArgs): Promise<RegistrationResult> {
   let attempt = 0;
   let lastErr: unknown;
 
   while (attempt < args.maxAttempts) {
     attempt += 1;
     try {
-      await args.transport.register(args.manifest);
+      const result = await args.transport.register(args.manifest);
       args.logger.info('[pillar-sdk] registered with registry', {
-        pillar: args.manifest.pillar,
+        pillar: result.pillarId,
         attempt,
       });
-      return;
+      return result;
     } catch (err) {
       lastErr = err;
       if (err instanceof RegistryTransportError && !err.retriable) {

--- a/packages/pillar-sdk/src/bootstrap/transport.ts
+++ b/packages/pillar-sdk/src/bootstrap/transport.ts
@@ -19,7 +19,14 @@ export interface RegistryTransport {
 export interface HttpRegistryTransportOptions {
   baseUrl: string;
   fetchImpl?: typeof fetch;
+  /**
+   * Per-request timeout in milliseconds. Prevents a hung TCP connection
+   * from blocking pillar boot or shutdown indefinitely. Defaults to 10s.
+   */
+  timeoutMs?: number;
 }
+
+const DEFAULT_TIMEOUT_MS = 10_000;
 
 export class RegistryTransportError extends Error {
   readonly status: number;
@@ -53,17 +60,23 @@ export function createHttpRegistryTransport(
 ): RegistryTransport {
   const baseUrl = options.baseUrl.replace(/\/+$/, '');
   const fetchImpl = options.fetchImpl ?? fetch;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 
   async function post<T>(path: string, body: unknown): Promise<T> {
     let response: Response;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
     try {
       response = await fetchImpl(`${baseUrl}${path}`, {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify(body),
+        signal: controller.signal,
       });
     } catch (err) {
       throw new RegistryNetworkError(`POST ${path} failed`, err);
+    } finally {
+      clearTimeout(timer);
     }
 
     if (response.ok) {

--- a/packages/pillar-sdk/src/bootstrap/transport.ts
+++ b/packages/pillar-sdk/src/bootstrap/transport.ts
@@ -1,0 +1,115 @@
+import type { ManifestPayload } from '../manifest-schema/schema.js';
+import type { ValidationIssue } from '../manifest-schema/validate.js';
+
+export interface RegistrationResult {
+  pillarId: string;
+}
+
+export interface HeartbeatResult {
+  pillarId: string;
+  acknowledgedAt: string;
+}
+
+export interface RegistryTransport {
+  register(payload: ManifestPayload): Promise<RegistrationResult>;
+  heartbeat(pillarId: string): Promise<HeartbeatResult>;
+  unregister(pillarId: string): Promise<void>;
+}
+
+export interface HttpRegistryTransportOptions {
+  baseUrl: string;
+  fetchImpl?: typeof fetch;
+}
+
+export class RegistryTransportError extends Error {
+  readonly status: number;
+  readonly issues: ValidationIssue[] | undefined;
+  readonly retriable: boolean;
+
+  constructor(
+    message: string,
+    options: { status: number; issues?: ValidationIssue[]; retriable: boolean }
+  ) {
+    super(message);
+    this.name = 'RegistryTransportError';
+    this.status = options.status;
+    this.issues = options.issues;
+    this.retriable = options.retriable;
+  }
+}
+
+export class RegistryNetworkError extends Error {
+  readonly cause: unknown;
+
+  constructor(message: string, cause: unknown) {
+    super(message);
+    this.name = 'RegistryNetworkError';
+    this.cause = cause;
+  }
+}
+
+export function createHttpRegistryTransport(
+  options: HttpRegistryTransportOptions
+): RegistryTransport {
+  const baseUrl = options.baseUrl.replace(/\/+$/, '');
+  const fetchImpl = options.fetchImpl ?? fetch;
+
+  async function post<T>(path: string, body: unknown): Promise<T> {
+    let response: Response;
+    try {
+      response = await fetchImpl(`${baseUrl}${path}`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+    } catch (err) {
+      throw new RegistryNetworkError(`POST ${path} failed`, err);
+    }
+
+    if (response.ok) {
+      if (response.status === 204) {
+        return undefined as T;
+      }
+      return (await response.json()) as T;
+    }
+
+    const text = await response.text().catch(() => '');
+    const issues = extractIssues(text);
+    throw new RegistryTransportError(`POST ${path} → ${response.status} ${response.statusText}`, {
+      status: response.status,
+      issues,
+      retriable: response.status >= 500,
+    });
+  }
+
+  return {
+    async register(payload) {
+      return post<RegistrationResult>('/registry/register', payload);
+    },
+    async heartbeat(pillarId) {
+      return post<HeartbeatResult>('/registry/heartbeat', { pillarId });
+    },
+    async unregister(pillarId) {
+      await post<void>('/registry/unregister', { pillarId });
+    },
+  };
+}
+
+function extractIssues(text: string): ValidationIssue[] | undefined {
+  if (text.length === 0) return undefined;
+  try {
+    const parsed: unknown = JSON.parse(text);
+    if (parsed === null || typeof parsed !== 'object') return undefined;
+    const maybeIssues = (parsed as { issues?: unknown }).issues;
+    if (!Array.isArray(maybeIssues)) return undefined;
+    return maybeIssues.filter(isValidationIssue);
+  } catch {
+    return undefined;
+  }
+}
+
+function isValidationIssue(value: unknown): value is ValidationIssue {
+  if (value === null || typeof value !== 'object') return false;
+  const v = value as Record<string, unknown>;
+  return typeof v['field'] === 'string' && typeof v['reason'] === 'string';
+}

--- a/packages/pillar-sdk/src/index.ts
+++ b/packages/pillar-sdk/src/index.ts
@@ -1,1 +1,2 @@
 export * from './manifest-schema/index.js';
+export * from './bootstrap/index.js';

--- a/packages/pillar-sdk/tsconfig.json
+++ b/packages/pillar-sdk/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "Node16",
     "moduleResolution": "Node16",
     "lib": ["ES2022"],
-    "types": [],
+    "types": ["node"],
     "declaration": true,
     "declarationMap": true,
     "outDir": "dist",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -355,6 +355,9 @@ importers:
       '@pops/finance-db':
         specifier: workspace:*
         version: link:../../packages/finance-db
+      '@pops/pillar-sdk':
+        specifier: workspace:*
+        version: link:../../packages/pillar-sdk
       '@pops/types':
         specifier: workspace:*
         version: link:../../packages/types
@@ -1998,6 +2001,9 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@types/node':
+        specifier: ^25.9.3
+        version: 25.9.3
       '@vitest/coverage-v8':
         specifier: ^4.1.8
         version: 4.1.8(vitest@4.1.8)


### PR DESCRIPTION
## Scope (Theme 13 PRD-158)

First production wiring of the pillar→registry handshake. Lands the load-bearing helper every pillar's `server.ts` will call on boot, and proves the loop against finance.

### What's in

- **`@pops/pillar-sdk/bootstrap`** subpath. `bootstrapPillar({ manifest, app?, transport?, heartbeatMs?, logger?, ... })`:
  - Validates the manifest with `validateManifestPayload` (throws `PillarManifestInvalidError` with per-field issues on bad input).
  - POSTs to the registry via an injectable `RegistryTransport` (default: HTTP fetch against `POPS_REGISTRY_URL`, falling back to `http://core-api:3001`).
  - Retries network/5xx failures with exponential backoff (1s → 2s → 4s …, capped at 30s, max 5 attempts by default). 4xx responses are surfaced immediately as `PillarRegistrationRejectedError` with the registry's issues array.
  - Starts a heartbeat interval (default 10s); failures are logged via the injected logger and do not crash the loop.
  - Returns `{ pillarId, stop() }`. `stop()` clears the interval and best-effort POSTs an unregister.
  - When an Express-like `app` is provided, mounts the manifest's `healthcheck.path` returning `{ ok, pillar, version, contract }`.
- **`apps/pops-finance-api/src/server.ts`** wires it in behind `POPS_REGISTRY_ENABLED=true`. Existing deployments without the env flag are unaffected. Hand-rolled finance manifest lives in the same file for now — PRD-155 will generate it.
- 18 new vitest tests (13 bootstrap + 5 transport): happy path, malformed manifest, 4xx rejection, network retry success + exhaustion, 5xx retry, heartbeat interval cadence, idempotent `stop()`, heartbeat failures don't crash, best-effort unregister, health route mounting.

### What's deferred

- Registry endpoint impl (PRD-161 — parallel agent). Helper is written against `ManifestPayload` and an abstract transport; no dependency on the wire surface landing first.
- SSE subscription wiring (PRD-163).
- Reconciliation on registry restart (PRD-164).
- Per-pillar manifest generator (PRD-155). Finance manifest is hand-built in `server.ts`.
- Full state machine + drain semantics from the PRD (DB_OPEN → REGISTERING → DRAINING phases). This PR ships the register/heartbeat/unregister loop; drain logic stays in the existing `server.ts` shutdown handler.
- `createTestRegistryClient` / `injectRegistryClient` test harness from PRD's us-07 — superseded by the simpler injectable `transport` option used in tests.

### Decisions made

- **Transport interface**: minimal three-method surface (`register`, `heartbeat`, `unregister`) so PRD-161 can iterate on the wire shape without breaking this PR. The default HTTP impl POSTs JSON to `/registry/{register,heartbeat,unregister}` — those paths can shift when PRD-161 lands; the helper is decoupled from them via the transport seam.
- **Heartbeat default**: 10s (matches the PRD).
- **Retry policy**: capped at 5 attempts × exponential backoff (1s→30s) on transient failures, immediate fail on 4xx. PRD calls for retry-forever; the bounded default is safer for the proof-of-concept and is overridable. Re-evaluate before the full Phase 5 rollout.
- **`app` is generic**, not coupled to Express. Only requires `app.get(path, handler)` — keeps the pillar-sdk free of an Express dependency.
- **Env flag**: `POPS_REGISTRY_ENABLED=true` gates the bootstrap call in finance-api so existing deployments without a registry running don't break on boot.

### Test plan

- [x] `pnpm test` in `packages/pillar-sdk` — 115 passing (97 existing + 18 new).
- [x] `pnpm test` in `apps/pops-finance-api` — 23 passing.
- [x] `mise typecheck` — green.
- [x] `mise lint` — no errors (warnings are pre-existing).
- [x] `mise build` — green.
- [ ] Smoke test finance-api boot with `POPS_REGISTRY_ENABLED=true` once PRD-161 endpoints are live.