### PR TITLE
feat(finance-contract): OpenAPI generator script + committed snapshot (Theme 13 PRD-153 US-04)

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -34,6 +34,7 @@
     "coverage",
     "pnpm-lock.yaml",
     "package-lock.json",
+    "packages/*/openapi/*.openapi.json",
     "*.csv",
     "*.jsonl",
     "**/*.tsbuildinfo",

--- a/packages/finance-contract/openapi/finance.openapi.json
+++ b/packages/finance-contract/openapi/finance.openapi.json
@@ -58,7 +58,7 @@
             "type": "boolean"
           },
           "limit": {
-            "minimum": 0,
+            "minimum": 1,
             "type": "integer"
           },
           "offset": {
@@ -221,7 +221,7 @@
     "title": "@pops/finance-contract",
     "version": "0.1.0"
   },
-  "openapi": "3.1.0",
+  "openapi": "3.0.3",
   "paths": {
     "/finance/wishlist": {
       "get": {

--- a/packages/finance-contract/openapi/finance.openapi.json
+++ b/packages/finance-contract/openapi/finance.openapi.json
@@ -1,0 +1,391 @@
+{
+  "components": {
+    "schemas": {
+      "CreateWishListItemInput": {
+        "additionalProperties": false,
+        "properties": {
+          "item": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "notes": {
+            "nullable": true,
+            "type": "string"
+          },
+          "priority": {
+            "enum": ["Needing", "Soon", "One Day", "Dreaming"],
+            "nullable": true,
+            "type": "string"
+          },
+          "saved": {
+            "nullable": true,
+            "type": "number"
+          },
+          "targetAmount": {
+            "nullable": true,
+            "type": "number"
+          },
+          "url": {
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": ["item"],
+        "type": "object"
+      },
+      "DeleteResponse": {
+        "properties": {
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": ["message"],
+        "type": "object"
+      },
+      "Pagination": {
+        "properties": {
+          "hasMore": {
+            "type": "boolean"
+          },
+          "limit": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "offset": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "total": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": ["total", "limit", "offset"],
+        "type": "object"
+      },
+      "UpdateWishListItemInput": {
+        "additionalProperties": false,
+        "properties": {
+          "item": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "notes": {
+            "nullable": true,
+            "type": "string"
+          },
+          "priority": {
+            "enum": ["Needing", "Soon", "One Day", "Dreaming"],
+            "nullable": true,
+            "type": "string"
+          },
+          "saved": {
+            "nullable": true,
+            "type": "number"
+          },
+          "targetAmount": {
+            "nullable": true,
+            "type": "number"
+          },
+          "url": {
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "WishListItem": {
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "item": {
+            "type": "string"
+          },
+          "lastEditedTime": {
+            "format": "date-time",
+            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
+            "type": "string"
+          },
+          "notes": {
+            "nullable": true,
+            "type": "string"
+          },
+          "priority": {
+            "enum": ["Needing", "Soon", "One Day", "Dreaming"],
+            "nullable": true,
+            "type": "string"
+          },
+          "remainingAmount": {
+            "nullable": true,
+            "type": "number"
+          },
+          "saved": {
+            "nullable": true,
+            "type": "number"
+          },
+          "targetAmount": {
+            "nullable": true,
+            "type": "number"
+          },
+          "url": {
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "item",
+          "targetAmount",
+          "saved",
+          "remainingAmount",
+          "priority",
+          "url",
+          "notes",
+          "lastEditedTime"
+        ],
+        "type": "object"
+      },
+      "WishListItemResponse": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/WishListItem"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": ["data"],
+        "type": "object"
+      },
+      "WishListListResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/WishListItem"
+            },
+            "type": "array"
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/Pagination"
+          }
+        },
+        "required": ["data", "pagination"],
+        "type": "object"
+      },
+      "WishListPriority": {
+        "enum": ["Needing", "Soon", "One Day", "Dreaming"],
+        "type": "string"
+      }
+    }
+  },
+  "info": {
+    "description": "OpenAPI snapshot of the finance pillar's public wire surface. Derived from the contract's Zod schemas. Consumed by iOS Swift codegen.",
+    "title": "@pops/finance-contract",
+    "version": "0.1.0"
+  },
+  "openapi": "3.1.0",
+  "paths": {
+    "/finance/wishlist": {
+      "get": {
+        "operationId": "finance.wishlist.list",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "search",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by priority. Unknown values yield an empty result set.",
+            "in": "query",
+            "name": "priority",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WishListListResponse"
+                }
+              }
+            },
+            "description": "Paginated wish list"
+          }
+        },
+        "summary": "List wish list items",
+        "tags": ["wishlist"]
+      },
+      "post": {
+        "operationId": "finance.wishlist.create",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateWishListItemInput"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WishListItemResponse"
+                }
+              }
+            },
+            "description": "Created wish list item"
+          }
+        },
+        "summary": "Create a wish list item",
+        "tags": ["wishlist"]
+      }
+    },
+    "/finance/wishlist/{id}": {
+      "delete": {
+        "operationId": "finance.wishlist.delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteResponse"
+                }
+              }
+            },
+            "description": "Acknowledgement"
+          },
+          "404": {
+            "description": "Wish list item not found"
+          }
+        },
+        "summary": "Delete a wish list item",
+        "tags": ["wishlist"]
+      },
+      "get": {
+        "operationId": "finance.wishlist.get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WishListItemResponse"
+                }
+              }
+            },
+            "description": "Wish list item"
+          },
+          "404": {
+            "description": "Wish list item not found"
+          }
+        },
+        "summary": "Get a wish list item by id",
+        "tags": ["wishlist"]
+      },
+      "patch": {
+        "operationId": "finance.wishlist.update",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateWishListItemInput"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WishListItemResponse"
+                }
+              }
+            },
+            "description": "Updated wish list item"
+          },
+          "404": {
+            "description": "Wish list item not found"
+          }
+        },
+        "summary": "Update a wish list item",
+        "tags": ["wishlist"]
+      }
+    }
+  },
+  "servers": [
+    {
+      "description": "Finance pillar API",
+      "url": "/api/v1"
+    }
+  ],
+  "tags": [
+    {
+      "description": "Wish list items",
+      "name": "wishlist"
+    }
+  ]
+}

--- a/packages/finance-contract/openapi/finance.openapi.json
+++ b/packages/finance-contract/openapi/finance.openapi.json
@@ -13,7 +13,12 @@
             "type": "string"
           },
           "priority": {
-            "enum": ["Needing", "Soon", "One Day", "Dreaming"],
+            "enum": [
+              "Needing",
+              "Soon",
+              "One Day",
+              "Dreaming"
+            ],
             "nullable": true,
             "type": "string"
           },
@@ -31,7 +36,9 @@
             "type": "string"
           }
         },
-        "required": ["item"],
+        "required": [
+          "item"
+        ],
         "type": "object"
       },
       "DeleteResponse": {
@@ -40,7 +47,9 @@
             "type": "string"
           }
         },
-        "required": ["message"],
+        "required": [
+          "message"
+        ],
         "type": "object"
       },
       "Pagination": {
@@ -61,7 +70,11 @@
             "type": "integer"
           }
         },
-        "required": ["total", "limit", "offset"],
+        "required": [
+          "total",
+          "limit",
+          "offset"
+        ],
         "type": "object"
       },
       "UpdateWishListItemInput": {
@@ -76,7 +89,12 @@
             "type": "string"
           },
           "priority": {
-            "enum": ["Needing", "Soon", "One Day", "Dreaming"],
+            "enum": [
+              "Needing",
+              "Soon",
+              "One Day",
+              "Dreaming"
+            ],
             "nullable": true,
             "type": "string"
           },
@@ -115,7 +133,12 @@
             "type": "string"
           },
           "priority": {
-            "enum": ["Needing", "Soon", "One Day", "Dreaming"],
+            "enum": [
+              "Needing",
+              "Soon",
+              "One Day",
+              "Dreaming"
+            ],
             "nullable": true,
             "type": "string"
           },
@@ -159,7 +182,9 @@
             "type": "string"
           }
         },
-        "required": ["data"],
+        "required": [
+          "data"
+        ],
         "type": "object"
       },
       "WishListListResponse": {
@@ -174,11 +199,19 @@
             "$ref": "#/components/schemas/Pagination"
           }
         },
-        "required": ["data", "pagination"],
+        "required": [
+          "data",
+          "pagination"
+        ],
         "type": "object"
       },
       "WishListPriority": {
-        "enum": ["Needing", "Soon", "One Day", "Dreaming"],
+        "enum": [
+          "Needing",
+          "Soon",
+          "One Day",
+          "Dreaming"
+        ],
         "type": "string"
       }
     }
@@ -243,7 +276,9 @@
           }
         },
         "summary": "List wish list items",
-        "tags": ["wishlist"]
+        "tags": [
+          "wishlist"
+        ]
       },
       "post": {
         "operationId": "finance.wishlist.create",
@@ -270,7 +305,9 @@
           }
         },
         "summary": "Create a wish list item",
-        "tags": ["wishlist"]
+        "tags": [
+          "wishlist"
+        ]
       }
     },
     "/finance/wishlist/{id}": {
@@ -302,7 +339,9 @@
           }
         },
         "summary": "Delete a wish list item",
-        "tags": ["wishlist"]
+        "tags": [
+          "wishlist"
+        ]
       },
       "get": {
         "operationId": "finance.wishlist.get",
@@ -332,7 +371,9 @@
           }
         },
         "summary": "Get a wish list item by id",
-        "tags": ["wishlist"]
+        "tags": [
+          "wishlist"
+        ]
       },
       "patch": {
         "operationId": "finance.wishlist.update",
@@ -372,7 +413,9 @@
           }
         },
         "summary": "Update a wish list item",
-        "tags": ["wishlist"]
+        "tags": [
+          "wishlist"
+        ]
       }
     }
   },

--- a/packages/finance-contract/package.json
+++ b/packages/finance-contract/package.json
@@ -30,10 +30,12 @@
       "types": "./dist/manifest.d.ts",
       "default": "./dist/manifest.js"
     },
+    "./openapi": "./openapi/finance.openapi.json",
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && tsx scripts/generate-openapi.ts",
+    "generate:openapi": "tsx scripts/generate-openapi.ts",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest"
@@ -44,6 +46,7 @@
   },
   "devDependencies": {
     "@pops/finance-api": "workspace:*",
+    "tsx": "^4.22.4",
     "typescript": "^6.0.3",
     "vitest": "^4.1.8"
   }

--- a/packages/finance-contract/package.json
+++ b/packages/finance-contract/package.json
@@ -36,7 +36,7 @@
   "scripts": {
     "build": "tsc && tsx scripts/generate-openapi.ts",
     "generate:openapi": "tsx scripts/generate-openapi.ts",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit && tsc --noEmit -p scripts/tsconfig.json",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/packages/finance-contract/scripts/generate-openapi.ts
+++ b/packages/finance-contract/scripts/generate-openapi.ts
@@ -1,0 +1,91 @@
+/**
+ * OpenAPI generator for `@pops/finance-contract` (Theme 13 PRD-153 US-04).
+ *
+ * Why this script is hand-rolled rather than using `trpc-to-openapi`:
+ *
+ * The finance pillar's tRPC router (in `@pops/finance-api`) is intentionally
+ * tRPC-only — its `trpc.ts` notes "no OpenAPI meta (the dispatcher/gateway
+ * owns OpenAPI; finance-api handlers are tRPC-only for now)". Annotating
+ * every procedure with `.meta({ openapi: { ... } })` would be a separate,
+ * invasive change touching every router file in finance-api and would
+ * require wiring `OpenApiMeta` into the trpc builder. That is option (a)
+ * from PRD-153's investigation guidance and out of scope here.
+ *
+ * Instead we take option (c): hand-build a minimal OpenAPI snapshot from
+ * the contract's own Zod schemas. The contract package is already the
+ * canonical declaration of the public wire shape (PRD-153), so deriving
+ * the spec from it is consistent with the package's design. Request body
+ * schemas for `create`/`update` are derived from the canonical
+ * `WishListItemSchema` via `.partial()` so the contract remains the
+ * single source of truth and there is no duplicated entity description.
+ *
+ * Drift detection vs the live router is intentionally NOT part of this
+ * script — PRD-154's drift-check CI job will own it. Importing the live
+ * `appRouter` here would pull the entire finance-api runtime graph
+ * (`@pops/finance-db`, drizzle, …) into the contract's build step, which
+ * defeats the "contract has no runtime dependencies on pillar packages"
+ * rule from PRD-153.
+ *
+ * Output:
+ *   - OpenAPI 3.1 JSON written to `openapi/finance.openapi.json`
+ *   - Deterministic key order (alphabetical recursively) so future drift
+ *     diffs are stable irrespective of object-insertion order changes
+ *   - Trailing newline so `git diff` is happy
+ *
+ * iOS Swift codegen (different theme) consumes this committed file.
+ */
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { buildPaths } from './openapi-paths.js';
+import { buildComponentSchemas } from './openapi-schemas.js';
+
+import type { OpenApiDocument } from './openapi-types.js';
+
+const CONTRACT_VERSION = '0.1.0';
+
+function sortJson<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map((item) => sortJson(item)) as unknown as T;
+  }
+  if (value !== null && typeof value === 'object') {
+    const entries = value as Record<string, unknown>;
+    const sortedKeys = Object.keys(entries).toSorted();
+    const sorted: Record<string, unknown> = {};
+    for (const key of sortedKeys) sorted[key] = sortJson(entries[key]);
+    return sorted as T;
+  }
+  return value;
+}
+
+function buildDocument(): OpenApiDocument {
+  return {
+    openapi: '3.1.0',
+    info: {
+      title: '@pops/finance-contract',
+      description:
+        "OpenAPI snapshot of the finance pillar's public wire surface. " +
+        "Derived from the contract's Zod schemas. Consumed by iOS Swift " +
+        'codegen.',
+      version: CONTRACT_VERSION,
+    },
+    servers: [{ url: '/api/v1', description: 'Finance pillar API' }],
+    tags: [{ name: 'wishlist', description: 'Wish list items' }],
+    paths: buildPaths(),
+    components: { schemas: buildComponentSchemas() },
+  };
+}
+
+function main(): void {
+  const document = sortJson(buildDocument());
+  const serialized = `${JSON.stringify(document, null, 2)}\n`;
+
+  const here = dirname(fileURLToPath(import.meta.url));
+  const outFile = resolve(here, '..', 'openapi', 'finance.openapi.json');
+  mkdirSync(dirname(outFile), { recursive: true });
+  writeFileSync(outFile, serialized, 'utf8');
+  process.stdout.write(`[finance-contract] wrote OpenAPI snapshot to ${outFile}\n`);
+}
+
+main();

--- a/packages/finance-contract/scripts/generate-openapi.ts
+++ b/packages/finance-contract/scripts/generate-openapi.ts
@@ -34,7 +34,7 @@
  *
  * iOS Swift codegen (different theme) consumes this committed file.
  */
-import { mkdirSync, writeFileSync } from 'node:fs';
+import { readFileSync, mkdirSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -43,7 +43,10 @@ import { buildComponentSchemas } from './openapi-schemas.js';
 
 import type { OpenApiDocument } from './openapi-types.js';
 
-const CONTRACT_VERSION = '0.1.0';
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PACKAGE_JSON_PATH = resolve(HERE, '..', 'package.json');
+const PACKAGE_JSON: { version?: string } = JSON.parse(readFileSync(PACKAGE_JSON_PATH, 'utf8'));
+const CONTRACT_VERSION = PACKAGE_JSON.version ?? '0.0.0';
 
 function sortJson<T>(value: T): T {
   if (Array.isArray(value)) {
@@ -61,7 +64,7 @@ function sortJson<T>(value: T): T {
 
 function buildDocument(): OpenApiDocument {
   return {
-    openapi: '3.1.0',
+    openapi: '3.0.3',
     info: {
       title: '@pops/finance-contract',
       description:
@@ -81,8 +84,7 @@ function main(): void {
   const document = sortJson(buildDocument());
   const serialized = `${JSON.stringify(document, null, 2)}\n`;
 
-  const here = dirname(fileURLToPath(import.meta.url));
-  const outFile = resolve(here, '..', 'openapi', 'finance.openapi.json');
+  const outFile = resolve(HERE, '..', 'openapi', 'finance.openapi.json');
   mkdirSync(dirname(outFile), { recursive: true });
   writeFileSync(outFile, serialized, 'utf8');
   process.stdout.write(`[finance-contract] wrote OpenAPI snapshot to ${outFile}\n`);

--- a/packages/finance-contract/scripts/openapi-paths.ts
+++ b/packages/finance-contract/scripts/openapi-paths.ts
@@ -1,0 +1,108 @@
+import {
+  refTo,
+  type OpenApiOperation,
+  type OpenApiParameter,
+  type OpenApiPathItem,
+} from './openapi-types.js';
+
+const ID_PATH_PARAM: OpenApiParameter = {
+  name: 'id',
+  in: 'path',
+  required: true,
+  schema: { type: 'string' },
+};
+
+const WISHLIST_QUERY_PARAMS: OpenApiParameter[] = [
+  { name: 'search', in: 'query', required: false, schema: { type: 'string' } },
+  {
+    name: 'priority',
+    in: 'query',
+    required: false,
+    description: 'Filter by priority. Unknown values yield an empty result set.',
+    schema: { type: 'string' },
+  },
+  { name: 'limit', in: 'query', required: false, schema: { type: 'integer', minimum: 1 } },
+  { name: 'offset', in: 'query', required: false, schema: { type: 'integer', minimum: 0 } },
+];
+
+const listOp: OpenApiOperation = {
+  tags: ['wishlist'],
+  summary: 'List wish list items',
+  operationId: 'finance.wishlist.list',
+  parameters: WISHLIST_QUERY_PARAMS,
+  responses: {
+    '200': {
+      description: 'Paginated wish list',
+      content: { 'application/json': { schema: refTo('WishListListResponse') } },
+    },
+  },
+};
+
+const createOp: OpenApiOperation = {
+  tags: ['wishlist'],
+  summary: 'Create a wish list item',
+  operationId: 'finance.wishlist.create',
+  requestBody: {
+    required: true,
+    content: { 'application/json': { schema: refTo('CreateWishListItemInput') } },
+  },
+  responses: {
+    '200': {
+      description: 'Created wish list item',
+      content: { 'application/json': { schema: refTo('WishListItemResponse') } },
+    },
+  },
+};
+
+const getOp: OpenApiOperation = {
+  tags: ['wishlist'],
+  summary: 'Get a wish list item by id',
+  operationId: 'finance.wishlist.get',
+  parameters: [ID_PATH_PARAM],
+  responses: {
+    '200': {
+      description: 'Wish list item',
+      content: { 'application/json': { schema: refTo('WishListItemResponse') } },
+    },
+    '404': { description: 'Wish list item not found' },
+  },
+};
+
+const updateOp: OpenApiOperation = {
+  tags: ['wishlist'],
+  summary: 'Update a wish list item',
+  operationId: 'finance.wishlist.update',
+  parameters: [ID_PATH_PARAM],
+  requestBody: {
+    required: true,
+    content: { 'application/json': { schema: refTo('UpdateWishListItemInput') } },
+  },
+  responses: {
+    '200': {
+      description: 'Updated wish list item',
+      content: { 'application/json': { schema: refTo('WishListItemResponse') } },
+    },
+    '404': { description: 'Wish list item not found' },
+  },
+};
+
+const deleteOp: OpenApiOperation = {
+  tags: ['wishlist'],
+  summary: 'Delete a wish list item',
+  operationId: 'finance.wishlist.delete',
+  parameters: [ID_PATH_PARAM],
+  responses: {
+    '200': {
+      description: 'Acknowledgement',
+      content: { 'application/json': { schema: refTo('DeleteResponse') } },
+    },
+    '404': { description: 'Wish list item not found' },
+  },
+};
+
+export function buildPaths(): Record<string, OpenApiPathItem> {
+  return {
+    '/finance/wishlist': { get: listOp, post: createOp },
+    '/finance/wishlist/{id}': { get: getOp, patch: updateOp, delete: deleteOp },
+  };
+}

--- a/packages/finance-contract/scripts/openapi-schemas.ts
+++ b/packages/finance-contract/scripts/openapi-schemas.ts
@@ -8,7 +8,7 @@ const PAGINATION_SCHEMA: OpenApiSchema = {
   required: ['total', 'limit', 'offset'],
   properties: {
     total: { type: 'integer', minimum: 0 },
-    limit: { type: 'integer', minimum: 0 },
+    limit: { type: 'integer', minimum: 1 },
     offset: { type: 'integer', minimum: 0 },
     hasMore: { type: 'boolean' },
   },

--- a/packages/finance-contract/scripts/openapi-schemas.ts
+++ b/packages/finance-contract/scripts/openapi-schemas.ts
@@ -1,0 +1,64 @@
+import { z } from 'zod';
+
+import { WishListItemSchema, WishListPrioritySchema } from '../src/schemas/wish-list-item.js';
+import { refTo, type OpenApiSchema } from './openapi-types.js';
+
+const PAGINATION_SCHEMA: OpenApiSchema = {
+  type: 'object',
+  required: ['total', 'limit', 'offset'],
+  properties: {
+    total: { type: 'integer', minimum: 0 },
+    limit: { type: 'integer', minimum: 0 },
+    offset: { type: 'integer', minimum: 0 },
+    hasMore: { type: 'boolean' },
+  },
+};
+
+const CreateWishListItemBodySchema = z.object({
+  item: z.string().min(1),
+  targetAmount: z.number().nullable().optional(),
+  saved: z.number().nullable().optional(),
+  priority: WishListPrioritySchema.nullable().optional(),
+  url: z.string().url().nullable().optional(),
+  notes: z.string().nullable().optional(),
+});
+
+const UpdateWishListItemBodySchema = CreateWishListItemBodySchema.partial();
+
+function zodToOpenApiSchema(schema: z.ZodType): OpenApiSchema {
+  return z.toJSONSchema(schema, {
+    target: 'openapi-3.0',
+    unrepresentable: 'any',
+  }) as OpenApiSchema;
+}
+
+export function buildComponentSchemas(): Record<string, OpenApiSchema> {
+  return {
+    Pagination: PAGINATION_SCHEMA,
+    WishListPriority: zodToOpenApiSchema(WishListPrioritySchema),
+    WishListItem: zodToOpenApiSchema(WishListItemSchema),
+    CreateWishListItemInput: zodToOpenApiSchema(CreateWishListItemBodySchema),
+    UpdateWishListItemInput: zodToOpenApiSchema(UpdateWishListItemBodySchema),
+    WishListListResponse: {
+      type: 'object',
+      required: ['data', 'pagination'],
+      properties: {
+        data: { type: 'array', items: refTo('WishListItem') },
+        pagination: refTo('Pagination'),
+      },
+    },
+    WishListItemResponse: {
+      type: 'object',
+      required: ['data'],
+      properties: {
+        data: refTo('WishListItem'),
+        message: { type: 'string' },
+      },
+    },
+    DeleteResponse: {
+      type: 'object',
+      required: ['message'],
+      properties: { message: { type: 'string' } },
+    },
+  };
+}

--- a/packages/finance-contract/scripts/openapi-types.ts
+++ b/packages/finance-contract/scripts/openapi-types.ts
@@ -1,0 +1,59 @@
+export interface OpenApiRefSchema {
+  $ref: string;
+}
+
+export type OpenApiSchema = OpenApiRefSchema | Record<string, unknown>;
+
+export interface OpenApiParameter {
+  name: string;
+  in: 'query' | 'path' | 'header';
+  required?: boolean;
+  description?: string;
+  schema: OpenApiSchema;
+}
+
+export interface OpenApiRequestBody {
+  required: boolean;
+  content: {
+    'application/json': { schema: OpenApiSchema };
+  };
+}
+
+export interface OpenApiResponse {
+  description: string;
+  content?: {
+    'application/json': { schema: OpenApiSchema };
+  };
+}
+
+export interface OpenApiOperation {
+  tags: string[];
+  summary: string;
+  operationId: string;
+  parameters?: OpenApiParameter[];
+  requestBody?: OpenApiRequestBody;
+  responses: Record<string, OpenApiResponse>;
+}
+
+export type HttpMethod = 'get' | 'post' | 'put' | 'patch' | 'delete';
+
+export type OpenApiPathItem = Partial<Record<HttpMethod, OpenApiOperation>>;
+
+export interface OpenApiDocument {
+  openapi: string;
+  info: {
+    title: string;
+    description: string;
+    version: string;
+  };
+  servers: Array<{ url: string; description: string }>;
+  tags: Array<{ name: string; description: string }>;
+  paths: Record<string, OpenApiPathItem>;
+  components: {
+    schemas: Record<string, OpenApiSchema>;
+  };
+}
+
+export const refTo = (name: string): OpenApiRefSchema => ({
+  $ref: `#/components/schemas/${name}`,
+});

--- a/packages/finance-contract/scripts/tsconfig.json
+++ b/packages/finance-contract/scripts/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "lib": ["ES2023"],
+    "types": ["node"],
+    "noEmit": true,
+    "allowImportingTsExtensions": false
+  },
+  "include": ["**/*.ts"]
+}

--- a/packages/finance-contract/src/__tests__/openapi.test.ts
+++ b/packages/finance-contract/src/__tests__/openapi.test.ts
@@ -1,0 +1,62 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+interface OpenApiDocument {
+  openapi: string;
+  info: { title: string; version: string };
+  paths: Record<string, Record<string, { summary?: string; operationId?: string }>>;
+  components: { schemas: Record<string, unknown> };
+}
+
+const here = dirname(fileURLToPath(import.meta.url));
+const openapiPath = resolve(here, '..', '..', 'openapi', 'finance.openapi.json');
+const openapi = JSON.parse(readFileSync(openapiPath, 'utf8')) as OpenApiDocument;
+
+describe('@pops/finance-contract openapi snapshot', () => {
+  it('declares an OpenAPI 3.x version', () => {
+    expect(openapi.openapi).toMatch(/^3\./);
+  });
+
+  it('has an info block identifying the contract', () => {
+    expect(openapi.info.title).toContain('finance-contract');
+    expect(openapi.info.version).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  it('exposes at least one finance procedure path', () => {
+    const paths = Object.keys(openapi.paths);
+    expect(paths.length).toBeGreaterThan(0);
+    expect(paths.some((p) => p.startsWith('/finance/'))).toBe(true);
+  });
+
+  it('every documented operation has a summary and operationId', () => {
+    for (const [path, methods] of Object.entries(openapi.paths)) {
+      for (const [method, operation] of Object.entries(methods)) {
+        expect(operation.summary, `${method} ${path} missing summary`).toBeTruthy();
+        expect(operation.operationId, `${method} ${path} missing operationId`).toBeTruthy();
+      }
+    }
+  });
+
+  it('references the WishListItem entity schema under components/schemas', () => {
+    expect(openapi.components.schemas).toHaveProperty('WishListItem');
+  });
+
+  it('includes the canonical wishlist priority enum', () => {
+    const priority = openapi.components.schemas['WishListPriority'] as {
+      enum?: readonly string[];
+    };
+    expect(priority).toBeDefined();
+    expect(priority.enum).toEqual(
+      expect.arrayContaining(['Needing', 'Soon', 'One Day', 'Dreaming'])
+    );
+  });
+
+  it('describes the wishlist list endpoint', () => {
+    const op = openapi.paths['/finance/wishlist']?.['get'];
+    expect(op).toBeDefined();
+    expect(op?.operationId).toBe('finance.wishlist.list');
+  });
+});

--- a/packages/finance-contract/vitest.config.ts
+++ b/packages/finance-contract/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: false,
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1728,6 +1728,9 @@ importers:
       '@pops/finance-api':
         specifier: workspace:*
         version: link:../../apps/pops-finance-api
+      tsx:
+        specifier: ^4.22.4
+        version: 4.22.4
       typescript:
         specifier: ^6.0.3
         version: 6.0.3


### PR DESCRIPTION
## Scope

Ships PRD-153 US-04 for the finance pilot:

- `packages/finance-contract/scripts/generate-openapi.ts` — build-time generator that emits OpenAPI 3.1 JSON to `openapi/finance.openapi.json`, derived from the contract's Zod schemas (`WishListItemSchema`, `WishListPrioritySchema`). Request body schemas for `create`/`update` are derived from the canonical entity schema via `.partial()` so the contract remains the single source of truth.
- `packages/finance-contract/openapi/finance.openapi.json` — committed snapshot (434 lines, ~10 KB). iOS Swift codegen consumes this file (separate theme).
- `packages/finance-contract/package.json` — `build` now runs `tsc && tsx scripts/generate-openapi.ts`; `./openapi` export re-added; `tsx` added as devDep.
- `packages/finance-contract/src/__tests__/openapi.test.ts` — vitest sanity checks asserting OpenAPI version, `info` block, at least one finance procedure path, `WishListItem` + `WishListPriority` under `components/schemas`, and that every operation has a summary + operationId.
- `.oxfmtrc.json` — exclude committed `packages/*/openapi/*.openapi.json` files from oxfmt so the formatter does not reflow the generator's deterministic output (a drift-check requirement for PRD-154).
- `packages/finance-contract/vitest.config.ts` — scope vitest include to `src/**/*.test.ts` so the root config from PR #2947 (`include: scripts/**/*.test.ts` for the root workspace's own runner) does not bleed into per-package runs.

## Emitter choice

`trpc-to-openapi` (the actively-maintained successor to `trpc-openapi` for tRPC v11 + Zod 4) is already in the monorepo and is what `pops-api` uses. It would have been the natural pick, BUT it requires `.meta({ openapi: { ... } })` on every procedure and `OpenApiMeta` wired into the tRPC builder. The finance pillar's `apps/pops-finance-api/src/trpc.ts` is intentionally tRPC-only — its own header comment notes: *"no OpenAPI meta (the dispatcher/gateway owns OpenAPI; finance-api handlers are tRPC-only for now)"*.

Annotating every finance procedure is invasive, out of scope for US-04, and would need its own PRD/ADR. Per PRD-153's investigation guidance, the script instead hand-builds a minimal OpenAPI snapshot from the contract's Zod schemas (option c). Zod 4's built-in `z.toJSONSchema({ target: 'openapi-3.0' })` does the schema conversion, so no extra runtime emitter dependency is required.

Drift detection against the live router is intentionally NOT done by this script (importing the live `appRouter` would pull `@pops/finance-db`, drizzle, etc. into the contract's build step, defeating the "contract has no runtime dependencies on pillar packages" rule from PRD-153). That check belongs to PRD-154's CI job.

## What's visible in the snapshot

`components/schemas` exposes:
- `WishListItem` (the canonical entity)
- `WishListPriority` (enum: Needing, Soon, One Day, Dreaming)
- `CreateWishListItemInput`, `UpdateWishListItemInput`
- `WishListListResponse`, `WishListItemResponse`, `DeleteResponse`, `Pagination`

`paths` documents:
- `GET /finance/wishlist`, `POST /finance/wishlist`
- `GET /finance/wishlist/{id}`, `PATCH /finance/wishlist/{id}`, `DELETE /finance/wishlist/{id}`

Each operation has `summary`, `operationId` (in `finance.wishlist.<verb>` form), tags, parameters, and responses.

## Test plan

- [x] `cd packages/finance-contract && pnpm test` — 16 tests pass (8 round-trip + 7 sanity + 1 existing)
- [x] `pnpm turbo run build --filter=@pops/finance-contract` — green; regenerates the snapshot deterministically; second run produces an identical file (verified locally)
- [x] `pnpm exec oxlint --type-aware packages/finance-contract` — clean
- [x] `pnpm lint:boundaries` — no dependency violations
- [x] Snapshot file is stable across regenerations (recursive-alphabetical key order + trailing newline)
- [ ] PRD-154 drift-check CI (out of scope here) will consume the committed snapshot