### PR TITLE
feat(pillar-sdk): pillar() client factory + discovery cache (Theme 13 PRD-191)

### DIFF
--- a/packages/pillar-sdk/package.json
+++ b/packages/pillar-sdk/package.json
@@ -18,6 +18,10 @@
       "types": "./dist/bootstrap/index.d.ts",
       "default": "./dist/bootstrap/index.js"
     },
+    "./client": {
+      "types": "./dist/client/index.d.ts",
+      "default": "./dist/client/index.js"
+    },
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/packages/pillar-sdk/src/client/__tests__/cache.test.ts
+++ b/packages/pillar-sdk/src/client/__tests__/cache.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { DiscoveryCache } from '../cache.js';
+import { discoveredPillar, FakeRegistryTransport } from './fixtures.js';
+
+describe('DiscoveryCache', () => {
+  let transport: FakeRegistryTransport;
+
+  beforeEach(() => {
+    transport = new FakeRegistryTransport({
+      pillars: [discoveredPillar({ pillarId: 'finance' })],
+    });
+  });
+
+  it('returns the pillar on first lookup and counts a miss', async () => {
+    const cache = new DiscoveryCache({ transport, ttlMs: 60_000 });
+    const result = await cache.lookup('finance');
+    expect(result?.pillarId).toBe('finance');
+    expect(transport.callCount).toBe(1);
+    expect(cache.missCount).toBe(1);
+    expect(cache.hitCount).toBe(0);
+  });
+
+  it('serves from cache while still within TTL', async () => {
+    const clock = { time: 0 };
+    const cache = new DiscoveryCache({
+      transport,
+      ttlMs: 60_000,
+      now: () => clock.time,
+    });
+    await cache.lookup('finance');
+    clock.time = 30_000;
+    await cache.lookup('finance');
+    await cache.lookup('finance');
+    expect(transport.callCount).toBe(1);
+    expect(cache.hitCount).toBe(2);
+  });
+
+  it('refetches once TTL elapses', async () => {
+    const clock = { time: 0 };
+    const cache = new DiscoveryCache({
+      transport,
+      ttlMs: 1_000,
+      now: () => clock.time,
+    });
+    await cache.lookup('finance');
+    clock.time = 1_500;
+    await cache.lookup('finance');
+    expect(transport.callCount).toBe(2);
+    expect(cache.refreshCount).toBe(2);
+  });
+
+  it('returns undefined when the pillar is not in the snapshot', async () => {
+    const cache = new DiscoveryCache({ transport, ttlMs: 60_000 });
+    const result = await cache.lookup('media');
+    expect(result).toBeUndefined();
+  });
+
+  it('dedupes concurrent fetches into one transport call', async () => {
+    transport = new FakeRegistryTransport({
+      pillars: [discoveredPillar()],
+      delayMs: 25,
+    });
+    const cache = new DiscoveryCache({ transport, ttlMs: 60_000 });
+    const [a, b, c] = await Promise.all([
+      cache.lookup('finance'),
+      cache.lookup('finance'),
+      cache.lookup('finance'),
+    ]);
+    expect(a?.pillarId).toBe('finance');
+    expect(b?.pillarId).toBe('finance');
+    expect(c?.pillarId).toBe('finance');
+    expect(transport.callCount).toBe(1);
+  });
+
+  it('invalidate() forces a refetch on the next lookup', async () => {
+    const cache = new DiscoveryCache({ transport, ttlMs: 60_000 });
+    await cache.lookup('finance');
+    cache.invalidate();
+    await cache.lookup('finance');
+    expect(transport.callCount).toBe(2);
+  });
+
+  it('a failed fetch propagates and does not poison the cache', async () => {
+    transport = new FakeRegistryTransport({
+      failNext: 1,
+      failError: new Error('boom'),
+    });
+    const cache = new DiscoveryCache({ transport, ttlMs: 60_000 });
+    await expect(cache.lookup('finance')).rejects.toThrow('boom');
+    transport.setPillars([discoveredPillar()]);
+    const result = await cache.lookup('finance');
+    expect(result?.pillarId).toBe('finance');
+    expect(transport.callCount).toBe(2);
+  });
+});

--- a/packages/pillar-sdk/src/client/__tests__/discovery.test.ts
+++ b/packages/pillar-sdk/src/client/__tests__/discovery.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+
+import { HttpDiscoveryTransport } from '../discovery.js';
+import { PillarSdkError } from '../errors.js';
+import { discoveredPillar, fakeFetch, jsonResponse } from './fixtures.js';
+
+describe('HttpDiscoveryTransport', () => {
+  it('GETs the registry snapshot URL and parses the tRPC envelope', async () => {
+    let calledUrl = '';
+    const fetchImpl = fakeFetch((url) => {
+      calledUrl = url;
+      return jsonResponse({
+        result: {
+          data: {
+            pillars: [discoveredPillar()],
+            fetchedAt: '2026-06-12T00:00:00.000Z',
+          },
+        },
+      });
+    });
+
+    const transport = new HttpDiscoveryTransport({
+      registryUrl: 'http://core-api:3001',
+      fetchImpl,
+    });
+
+    const snapshot = await transport.fetchSnapshot();
+    expect(calledUrl).toBe('http://core-api:3001/trpc/core.registry.snapshot');
+    expect(snapshot).toHaveLength(1);
+    expect(snapshot[0]?.pillarId).toBe('finance');
+  });
+
+  it('accepts a flat (non-tRPC-wrapped) snapshot body', async () => {
+    const fetchImpl = fakeFetch(() =>
+      jsonResponse({ pillars: [discoveredPillar({ pillarId: 'media' })] })
+    );
+    const transport = new HttpDiscoveryTransport({ fetchImpl });
+    const snapshot = await transport.fetchSnapshot();
+    expect(snapshot[0]?.pillarId).toBe('media');
+  });
+
+  it('strips a trailing slash from the registry URL', async () => {
+    let calledUrl = '';
+    const fetchImpl = fakeFetch((url) => {
+      calledUrl = url;
+      return jsonResponse({ pillars: [] });
+    });
+    const transport = new HttpDiscoveryTransport({
+      registryUrl: 'http://core-api:3001/',
+      fetchImpl,
+    });
+    await transport.fetchSnapshot();
+    expect(calledUrl).toBe('http://core-api:3001/trpc/core.registry.snapshot');
+  });
+
+  it('throws PillarSdkError on a non-2xx HTTP response', async () => {
+    const fetchImpl = fakeFetch(
+      () => new Response('nope', { status: 500, statusText: 'Server Error' })
+    );
+    const transport = new HttpDiscoveryTransport({ fetchImpl });
+    await expect(transport.fetchSnapshot()).rejects.toBeInstanceOf(PillarSdkError);
+  });
+
+  it('throws PillarSdkError on invalid JSON', async () => {
+    const fetchImpl = fakeFetch(
+      () =>
+        new Response('not json', { status: 200, headers: { 'content-type': 'application/json' } })
+    );
+    const transport = new HttpDiscoveryTransport({ fetchImpl });
+    await expect(transport.fetchSnapshot()).rejects.toBeInstanceOf(PillarSdkError);
+  });
+
+  it('throws PillarSdkError when the response shape is wrong', async () => {
+    const fetchImpl = fakeFetch(() => jsonResponse({ pillars: 'wat' }));
+    const transport = new HttpDiscoveryTransport({ fetchImpl });
+    await expect(transport.fetchSnapshot()).rejects.toBeInstanceOf(PillarSdkError);
+  });
+
+  it('throws PillarSdkError when an entry has an unknown status', async () => {
+    const fetchImpl = fakeFetch(() =>
+      jsonResponse({
+        pillars: [{ ...discoveredPillar(), status: 'exploded' }],
+      })
+    );
+    const transport = new HttpDiscoveryTransport({ fetchImpl });
+    await expect(transport.fetchSnapshot()).rejects.toBeInstanceOf(PillarSdkError);
+  });
+
+  it('translates fetch rejections into PillarSdkError', async () => {
+    const fetchImpl = fakeFetch(() => {
+      throw new Error('network down');
+    });
+    const transport = new HttpDiscoveryTransport({ fetchImpl });
+    await expect(transport.fetchSnapshot()).rejects.toBeInstanceOf(PillarSdkError);
+  });
+
+  it('attaches custom auth headers', async () => {
+    let seen: Record<string, string> = {};
+    const fetchImpl = fakeFetch((_url, init) => {
+      seen = (init?.headers ?? {}) as Record<string, string>;
+      return jsonResponse({ pillars: [] });
+    });
+    const transport = new HttpDiscoveryTransport({
+      fetchImpl,
+      headers: { authorization: 'Bearer service-token' },
+    });
+    await transport.fetchSnapshot();
+    expect(seen['authorization']).toBe('Bearer service-token');
+  });
+});

--- a/packages/pillar-sdk/src/client/__tests__/errors.test.ts
+++ b/packages/pillar-sdk/src/client/__tests__/errors.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import { isOk, PillarCallError, PillarSdkError, type CallResult } from '../errors.js';
+
+describe('CallResult', () => {
+  it('isOk narrows the success branch', () => {
+    const ok: CallResult<number> = { kind: 'ok', value: 42 };
+    if (isOk(ok)) {
+      const n: number = ok.value;
+      expect(n).toBe(42);
+    }
+  });
+
+  it('isOk returns false for failure branches', () => {
+    const unavailable: CallResult<number> = { kind: 'unavailable', pillar: 'finance' };
+    const degraded: CallResult<number> = {
+      kind: 'degraded',
+      pillar: 'finance',
+      reason: 'reconciling',
+    };
+    const mismatch: CallResult<number> = {
+      kind: 'contract-mismatch',
+      pillar: 'finance',
+    };
+    expect(isOk(unavailable)).toBe(false);
+    expect(isOk(degraded)).toBe(false);
+    expect(isOk(mismatch)).toBe(false);
+  });
+});
+
+describe('PillarCallError', () => {
+  it('carries the pillar id and the failure result', () => {
+    const err = new PillarCallError('finance', { kind: 'unavailable', pillar: 'finance' });
+    expect(err.name).toBe('PillarCallError');
+    expect(err.pillarId).toBe('finance');
+    expect(err.result.kind).toBe('unavailable');
+    expect(err.message).toContain('finance');
+    expect(err.message).toContain('unavailable');
+  });
+});
+
+describe('PillarSdkError', () => {
+  it('wraps a cause for transport-level failures', () => {
+    const root = new Error('connection refused');
+    const err = new PillarSdkError('registry fetch failed', { cause: root });
+    expect(err.name).toBe('PillarSdkError');
+    expect(err.cause).toBe(root);
+  });
+});

--- a/packages/pillar-sdk/src/client/__tests__/factory.test.ts
+++ b/packages/pillar-sdk/src/client/__tests__/factory.test.ts
@@ -64,8 +64,8 @@ describe('pillar() factory — happy path', () => {
       expect(result.value).toEqual([{ id: 'wish-1' }]);
     }
     expect(calls).toHaveLength(1);
-    expect(calls[0]?.url).toBe('http://finance-api:3004/trpc/wishlist.list');
-    expect(calls[0]?.body).toEqual({ input: { limit: 10 } });
+    expect(calls[0]?.url).toBe('http://finance-api:3004/trpc/finance.wishlist.list');
+    expect(calls[0]?.body).toEqual({ limit: 10 });
   });
 
   it('serialises a missing input argument as { input: null }', async () => {
@@ -74,7 +74,7 @@ describe('pillar() factory — happy path', () => {
     );
     const finance = pillar('finance', { transport, fetchImpl });
     await finance.wishlist.list();
-    expect(calls[0]?.body).toEqual({ input: null });
+    expect(calls[0]?.body).toBeNull();
   });
 
   it('orThrow() unwraps the value on success', async () => {
@@ -156,7 +156,7 @@ describe('pillar() factory — failure modes', () => {
     const result = await finance.wishlist.list({});
     expect(result.kind).toBe('contract-mismatch');
     if (result.kind === 'contract-mismatch') {
-      expect(result.expected).toBe('wishlist.list');
+      expect(result.expected).toBe('finance.wishlist.list');
     }
   });
 
@@ -177,7 +177,7 @@ describe('pillar() factory — failure modes', () => {
       pillars: [discoveredPillar()],
     });
     const fetchImpl = fakeFetch((url) => {
-      if (url.endsWith('/trpc/wishlist.list')) {
+      if (url.endsWith('/trpc/finance.wishlist.list')) {
         return new Response('boom', { status: 502 });
       }
       return jsonResponse({});
@@ -302,7 +302,7 @@ describe('pillar() factory — routing edge cases', () => {
     const { fetchImpl, calls } = recordingFetch(() => jsonResponse({ result: { data: 'ok' } }));
     const finance = pillar('finance', { transport, fetchImpl });
     await finance.transactions.imports.create({ id: '1' });
-    expect(calls[0]?.url).toBe('http://finance-api:3004/trpc/transactions.imports.create');
+    expect(calls[0]?.url).toBe('http://finance-api:3004/trpc/finance.transactions.imports.create');
   });
 
   it("returns 'contract-mismatch' when the consumer calls a top-level leaf with only one path segment", async () => {
@@ -320,6 +320,6 @@ describe('pillar() factory — routing edge cases', () => {
     const { fetchImpl, calls } = recordingFetch(() => jsonResponse({ result: { data: null } }));
     const finance = pillar('finance', { transport, fetchImpl });
     await finance.wishlist.list({});
-    expect(calls[0]?.url).toBe('http://finance-api:3004/trpc/wishlist.list');
+    expect(calls[0]?.url).toBe('http://finance-api:3004/trpc/finance.wishlist.list');
   });
 });

--- a/packages/pillar-sdk/src/client/__tests__/factory.test.ts
+++ b/packages/pillar-sdk/src/client/__tests__/factory.test.ts
@@ -1,0 +1,325 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { PillarCallError, isOk } from '../errors.js';
+import { __resetSharedPillarClient, pillar } from '../factory.js';
+import {
+  discoveredPillar,
+  fakeFetch,
+  FakeRegistryTransport,
+  jsonResponse,
+  type FakeFetchHandler,
+} from './fixtures.js';
+
+import type { DiscoveredPillar } from '../discovery.js';
+
+type WishlistRouter = {
+  wishlist: {
+    list: (input: { limit: number }) => Promise<readonly { id: string }[]>;
+  };
+};
+
+type FetchCall = { url: string; body: unknown };
+
+function recordingFetch(responder: (url: string, body: unknown) => Response | Promise<Response>): {
+  fetchImpl: typeof fetch;
+  calls: FetchCall[];
+} {
+  const calls: FetchCall[] = [];
+  const handler: FakeFetchHandler = async (url, init) => {
+    let parsed: unknown = null;
+    if (init?.body) {
+      const raw = typeof init.body === 'string' ? init.body : '';
+      try {
+        parsed = raw ? JSON.parse(raw) : null;
+      } catch {
+        parsed = raw;
+      }
+    }
+    calls.push({ url, body: parsed });
+    return responder(url, parsed);
+  };
+  return { fetchImpl: fakeFetch(handler), calls };
+}
+
+describe('pillar() factory — happy path', () => {
+  let transport: FakeRegistryTransport;
+
+  beforeEach(() => {
+    __resetSharedPillarClient();
+    transport = new FakeRegistryTransport({ pillars: [discoveredPillar()] });
+  });
+
+  afterEach(() => {
+    __resetSharedPillarClient();
+  });
+
+  it('routes calls to <baseUrl>/trpc/<router>.<procedure> and returns the data', async () => {
+    const { fetchImpl, calls } = recordingFetch(() =>
+      jsonResponse({ result: { data: [{ id: 'wish-1' }] } })
+    );
+    const finance = pillar<WishlistRouter>('finance', { transport, fetchImpl });
+    const result = await finance.wishlist.list({ limit: 10 });
+    expect(isOk(result)).toBe(true);
+    if (result.kind === 'ok') {
+      expect(result.value).toEqual([{ id: 'wish-1' }]);
+    }
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.url).toBe('http://finance-api:3004/trpc/wishlist.list');
+    expect(calls[0]?.body).toEqual({ input: { limit: 10 } });
+  });
+
+  it('serialises a missing input argument as { input: null }', async () => {
+    const { fetchImpl, calls } = recordingFetch(() =>
+      jsonResponse({ result: { data: { count: 0 } } })
+    );
+    const finance = pillar('finance', { transport, fetchImpl });
+    await finance.wishlist.list();
+    expect(calls[0]?.body).toEqual({ input: null });
+  });
+
+  it('orThrow() unwraps the value on success', async () => {
+    const { fetchImpl } = recordingFetch(() =>
+      jsonResponse({ result: { data: [{ id: 'a' }, { id: 'b' }] } })
+    );
+    const finance = pillar<WishlistRouter>('finance', { transport, fetchImpl });
+    const value = await finance.wishlist.list.orThrow({ limit: 5 });
+    expect(value).toEqual([{ id: 'a' }, { id: 'b' }]);
+  });
+
+  it('supports auth header injection per-call', async () => {
+    let seen: Record<string, string> = {};
+    const fetchImpl = fakeFetch((_url, init) => {
+      seen = (init?.headers ?? {}) as Record<string, string>;
+      return jsonResponse({ result: { data: null } });
+    });
+    const finance = pillar('finance', {
+      transport,
+      fetchImpl,
+      authHeaders: () => ({ authorization: 'Bearer svc-key' }),
+    });
+    await finance.wishlist.list({});
+    expect(seen['authorization']).toBe('Bearer svc-key');
+  });
+});
+
+describe('pillar() factory — failure modes', () => {
+  beforeEach(() => __resetSharedPillarClient());
+  afterEach(() => __resetSharedPillarClient());
+
+  it("returns 'unavailable' when the pillar is not in the registry", async () => {
+    const transport = new FakeRegistryTransport({ pillars: [] });
+    const { fetchImpl } = recordingFetch(() => jsonResponse({}));
+    const finance = pillar('finance', { transport, fetchImpl });
+    const result = await finance.wishlist.list({});
+    expect(result.kind).toBe('unavailable');
+    if (result.kind === 'unavailable') expect(result.pillar).toBe('finance');
+  });
+
+  it("returns 'unavailable' when the pillar status is 'unavailable'", async () => {
+    const transport = new FakeRegistryTransport({
+      pillars: [discoveredPillar({ status: 'unavailable' })],
+    });
+    const { fetchImpl } = recordingFetch(() => jsonResponse({}));
+    const finance = pillar('finance', { transport, fetchImpl });
+    const result = await finance.wishlist.list({});
+    expect(result.kind).toBe('unavailable');
+  });
+
+  it("returns 'degraded' (reconciling) when the pillar status is 'unknown'", async () => {
+    const transport = new FakeRegistryTransport({
+      pillars: [discoveredPillar({ status: 'unknown' })],
+    });
+    const { fetchImpl } = recordingFetch(() => jsonResponse({}));
+    const finance = pillar('finance', { transport, fetchImpl });
+    const result = await finance.wishlist.list({});
+    expect(result.kind).toBe('degraded');
+    if (result.kind === 'degraded') expect(result.reason).toBe('reconciling');
+  });
+
+  it("returns 'unavailable' when the registry itself is unreachable", async () => {
+    const transport = new FakeRegistryTransport({
+      failNext: 99,
+      failError: new (await import('../errors.js')).PillarSdkError('registry down'),
+    });
+    const { fetchImpl } = recordingFetch(() => jsonResponse({}));
+    const finance = pillar('finance', { transport, fetchImpl });
+    const result = await finance.wishlist.list({});
+    expect(result.kind).toBe('unavailable');
+  });
+
+  it("returns 'contract-mismatch' when the pillar replies 404", async () => {
+    const transport = new FakeRegistryTransport({
+      pillars: [discoveredPillar()],
+    });
+    const fetchImpl = fakeFetch(() => new Response('not found', { status: 404 }));
+    const finance = pillar('finance', { transport, fetchImpl });
+    const result = await finance.wishlist.list({});
+    expect(result.kind).toBe('contract-mismatch');
+    if (result.kind === 'contract-mismatch') {
+      expect(result.expected).toBe('wishlist.list');
+    }
+  });
+
+  it("returns 'unavailable' when the pillar HTTP call rejects", async () => {
+    const transport = new FakeRegistryTransport({
+      pillars: [discoveredPillar()],
+    });
+    const fetchImpl = fakeFetch(() => {
+      throw new Error('connection refused');
+    });
+    const finance = pillar('finance', { transport, fetchImpl });
+    const result = await finance.wishlist.list({});
+    expect(result.kind).toBe('unavailable');
+  });
+
+  it("returns 'unavailable' on 5xx and on non-JSON success bodies", async () => {
+    const transport = new FakeRegistryTransport({
+      pillars: [discoveredPillar()],
+    });
+    const fetchImpl = fakeFetch((url) => {
+      if (url.endsWith('/trpc/wishlist.list')) {
+        return new Response('boom', { status: 502 });
+      }
+      return jsonResponse({});
+    });
+    const finance = pillar('finance', { transport, fetchImpl });
+    const result = await finance.wishlist.list({});
+    expect(result.kind).toBe('unavailable');
+  });
+
+  it('detects a contract major-version skew before calling the pillar', async () => {
+    const pillarRecord: DiscoveredPillar = discoveredPillar({
+      manifest: {
+        ...discoveredPillar().manifest,
+        contract: {
+          package: '@pops/finance-contract',
+          version: '2.0.0',
+          tag: 'contract-finance@v2.0.0',
+        },
+      },
+    });
+    const transport = new FakeRegistryTransport({ pillars: [pillarRecord] });
+    let httpCalls = 0;
+    const fetchImpl = fakeFetch(() => {
+      httpCalls += 1;
+      return jsonResponse({});
+    });
+    const finance = pillar('finance', {
+      transport,
+      fetchImpl,
+      contractVersion: '1.4.2',
+    });
+    const result = await finance.wishlist.list({});
+    expect(result.kind).toBe('contract-mismatch');
+    expect(httpCalls).toBe(0);
+    if (result.kind === 'contract-mismatch') {
+      expect(result.expected).toBe('1.4.2');
+      expect(result.actual).toBe('2.0.0');
+    }
+  });
+
+  it('does not flag a same-major / different-minor skew as a mismatch', async () => {
+    const transport = new FakeRegistryTransport({ pillars: [discoveredPillar()] });
+    const { fetchImpl } = recordingFetch(() => jsonResponse({ result: { data: { ok: true } } }));
+    const finance = pillar('finance', {
+      transport,
+      fetchImpl,
+      contractVersion: '1.0.0',
+    });
+    const result = await finance.wishlist.list({});
+    expect(result.kind).toBe('ok');
+  });
+});
+
+describe('pillar() factory — orThrow()', () => {
+  beforeEach(() => __resetSharedPillarClient());
+  afterEach(() => __resetSharedPillarClient());
+
+  it('throws a PillarCallError carrying the failure result', async () => {
+    const transport = new FakeRegistryTransport({ pillars: [] });
+    const { fetchImpl } = recordingFetch(() => jsonResponse({}));
+    const finance = pillar('finance', { transport, fetchImpl });
+    let captured: unknown;
+    try {
+      await finance.wishlist.list.orThrow({});
+    } catch (err) {
+      captured = err;
+    }
+    expect(captured).toBeInstanceOf(PillarCallError);
+    if (captured instanceof PillarCallError) {
+      expect(captured.pillarId).toBe('finance');
+      expect(captured.result.kind).toBe('unavailable');
+    }
+  });
+});
+
+describe('pillar() factory — discovery cache behaviour', () => {
+  beforeEach(() => __resetSharedPillarClient());
+  afterEach(() => __resetSharedPillarClient());
+
+  it('memoises discovery across repeated calls within the TTL', async () => {
+    const transport = new FakeRegistryTransport({ pillars: [discoveredPillar()] });
+    const { fetchImpl } = recordingFetch(() => jsonResponse({ result: { data: null } }));
+    const finance = pillar('finance', { transport, fetchImpl, cacheTtlMs: 60_000 });
+    await finance.wishlist.list({});
+    await finance.wishlist.list({});
+    await finance.wishlist.list({});
+    expect(transport.callCount).toBe(1);
+  });
+
+  it('shares the in-flight discovery promise across concurrent calls', async () => {
+    const transport = new FakeRegistryTransport({
+      pillars: [discoveredPillar()],
+      delayMs: 30,
+    });
+    const { fetchImpl } = recordingFetch(() => jsonResponse({ result: { data: null } }));
+    const finance = pillar('finance', { transport, fetchImpl });
+    await Promise.all([
+      finance.wishlist.list({}),
+      finance.wishlist.list({}),
+      finance.wishlist.list({}),
+    ]);
+    expect(transport.callCount).toBe(1);
+  });
+
+  it('refreshes after TTL expiry', async () => {
+    const transport = new FakeRegistryTransport({ pillars: [discoveredPillar()] });
+    const { fetchImpl } = recordingFetch(() => jsonResponse({ result: { data: null } }));
+    const finance = pillar('finance', { transport, fetchImpl, cacheTtlMs: 5 });
+    await finance.wishlist.list({});
+    await new Promise((r) => setTimeout(r, 10));
+    await finance.wishlist.list({});
+    expect(transport.callCount).toBe(2);
+  });
+});
+
+describe('pillar() factory — routing edge cases', () => {
+  beforeEach(() => __resetSharedPillarClient());
+  afterEach(() => __resetSharedPillarClient());
+
+  it('builds nested router.subRouter.procedure paths', async () => {
+    const transport = new FakeRegistryTransport({ pillars: [discoveredPillar()] });
+    const { fetchImpl, calls } = recordingFetch(() => jsonResponse({ result: { data: 'ok' } }));
+    const finance = pillar('finance', { transport, fetchImpl });
+    await finance.transactions.imports.create({ id: '1' });
+    expect(calls[0]?.url).toBe('http://finance-api:3004/trpc/transactions.imports.create');
+  });
+
+  it("returns 'contract-mismatch' when the consumer calls a top-level leaf with only one path segment", async () => {
+    const transport = new FakeRegistryTransport({ pillars: [discoveredPillar()] });
+    const { fetchImpl } = recordingFetch(() => jsonResponse({}));
+    const finance = pillar('finance', { transport, fetchImpl });
+    const result = await finance.wishlist();
+    expect(result.kind).toBe('contract-mismatch');
+  });
+
+  it('strips a trailing slash from the discovered baseUrl', async () => {
+    const transport = new FakeRegistryTransport({
+      pillars: [discoveredPillar({ baseUrl: 'http://finance-api:3004/' })],
+    });
+    const { fetchImpl, calls } = recordingFetch(() => jsonResponse({ result: { data: null } }));
+    const finance = pillar('finance', { transport, fetchImpl });
+    await finance.wishlist.list({});
+    expect(calls[0]?.url).toBe('http://finance-api:3004/trpc/wishlist.list');
+  });
+});

--- a/packages/pillar-sdk/src/client/__tests__/fixtures.ts
+++ b/packages/pillar-sdk/src/client/__tests__/fixtures.ts
@@ -1,0 +1,77 @@
+import { validManifest } from '../../__tests__/fixtures.js';
+
+import type { DiscoveredPillar, DiscoveryTransport } from '../discovery.js';
+
+export function discoveredPillar(overrides: Partial<DiscoveredPillar> = {}): DiscoveredPillar {
+  return {
+    pillarId: 'finance',
+    baseUrl: 'http://finance-api:3004',
+    status: 'healthy',
+    manifest: validManifest(),
+    lastSeenAt: '2026-06-12T00:00:00.000Z',
+    registered: true,
+    ...overrides,
+  };
+}
+
+export type FakeRegistryOptions = {
+  pillars?: DiscoveredPillar[];
+  delayMs?: number;
+  failNext?: number;
+  failError?: Error;
+};
+
+export class FakeRegistryTransport implements DiscoveryTransport {
+  callCount = 0;
+  private pillars: DiscoveredPillar[];
+  private delayMs: number;
+  private failNext: number;
+  private failError: Error;
+
+  constructor(options: FakeRegistryOptions = {}) {
+    this.pillars = options.pillars ?? [discoveredPillar()];
+    this.delayMs = options.delayMs ?? 0;
+    this.failNext = options.failNext ?? 0;
+    this.failError = options.failError ?? new Error('registry unreachable');
+  }
+
+  setPillars(pillars: DiscoveredPillar[]): void {
+    this.pillars = pillars;
+  }
+
+  async fetchSnapshot(): Promise<readonly DiscoveredPillar[]> {
+    this.callCount += 1;
+    if (this.delayMs > 0) await new Promise((r) => setTimeout(r, this.delayMs));
+    if (this.failNext > 0) {
+      this.failNext -= 1;
+      throw this.failError;
+    }
+    return this.pillars;
+  }
+}
+
+export type FakeFetchInit = Parameters<typeof fetch>[1];
+
+export type FakeFetchHandler = (
+  url: string,
+  init: FakeFetchInit | undefined
+) => Promise<Response> | Response;
+
+export function fakeFetch(handler: FakeFetchHandler): typeof fetch {
+  const wrapped: typeof fetch = async (input, init) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    return handler(url, init);
+  };
+  return wrapped;
+}
+
+export function jsonResponse(
+  body: unknown,
+  init: { status?: number; statusText?: string; headers?: Record<string, string> } = {}
+): Response {
+  return new Response(JSON.stringify(body), {
+    status: init.status ?? 200,
+    statusText: init.statusText,
+    headers: { 'content-type': 'application/json', ...init.headers },
+  });
+}

--- a/packages/pillar-sdk/src/client/cache.ts
+++ b/packages/pillar-sdk/src/client/cache.ts
@@ -1,0 +1,70 @@
+import type { DiscoveredPillar, DiscoveryTransport } from './discovery.js';
+
+type CacheEntry = {
+  pillars: ReadonlyMap<string, DiscoveredPillar>;
+  fetchedAt: number;
+};
+
+/**
+ * TTL'd memoizing wrapper around a `DiscoveryTransport`. One in-flight
+ * fetch is shared across all concurrent callers; a second concurrent
+ * `lookup()` joins the same promise rather than firing a parallel HTTP
+ * request. Expired entries refetch lazily on the next call.
+ *
+ * Not exported from the package — `pillar()` owns the lifecycle.
+ */
+export class DiscoveryCache {
+  private readonly transport: DiscoveryTransport;
+  private readonly ttlMs: number;
+  private readonly now: () => number;
+
+  private entry: CacheEntry | null = null;
+  private inFlight: Promise<CacheEntry> | null = null;
+
+  hitCount = 0;
+  missCount = 0;
+  refreshCount = 0;
+
+  constructor(options: { transport: DiscoveryTransport; ttlMs: number; now?: () => number }) {
+    this.transport = options.transport;
+    this.ttlMs = options.ttlMs;
+    this.now = options.now ?? Date.now;
+  }
+
+  async lookup(pillarId: string): Promise<DiscoveredPillar | undefined> {
+    const snapshot = await this.snapshot();
+    return snapshot.pillars.get(pillarId);
+  }
+
+  async snapshot(): Promise<CacheEntry> {
+    const current = this.entry;
+    if (current !== null && this.now() - current.fetchedAt < this.ttlMs) {
+      this.hitCount += 1;
+      return current;
+    }
+
+    if (this.inFlight !== null) return this.inFlight;
+
+    this.missCount += 1;
+    const refresh = (async () => {
+      try {
+        const pillars = await this.transport.fetchSnapshot();
+        const next: CacheEntry = {
+          pillars: new Map(pillars.map((p) => [p.pillarId, p])),
+          fetchedAt: this.now(),
+        };
+        this.entry = next;
+        this.refreshCount += 1;
+        return next;
+      } finally {
+        this.inFlight = null;
+      }
+    })();
+    this.inFlight = refresh;
+    return refresh;
+  }
+
+  invalidate(): void {
+    this.entry = null;
+  }
+}

--- a/packages/pillar-sdk/src/client/cache.ts
+++ b/packages/pillar-sdk/src/client/cache.ts
@@ -11,7 +11,8 @@ type CacheEntry = {
  * `lookup()` joins the same promise rather than firing a parallel HTTP
  * request. Expired entries refetch lazily on the next call.
  *
- * Not exported from the package — `pillar()` owns the lifecycle.
+ * Re-exported under `@pops/pillar-sdk/client` for tests and advanced
+ * usage, but `pillar()` is the normal lifecycle owner.
  */
 export class DiscoveryCache {
   private readonly transport: DiscoveryTransport;

--- a/packages/pillar-sdk/src/client/discovery.ts
+++ b/packages/pillar-sdk/src/client/discovery.ts
@@ -1,0 +1,164 @@
+import { PillarSdkError } from './errors.js';
+
+import type { ManifestPayload } from '../manifest-schema/index.js';
+
+/**
+ * The shape returned by `core.registry.snapshot` (PRD-161 / PRD-159).
+ * One entry per registered pillar.
+ */
+export type DiscoveredPillar = {
+  pillarId: string;
+  baseUrl: string;
+  status: 'healthy' | 'unavailable' | 'unknown';
+  manifest: ManifestPayload;
+  lastSeenAt: string;
+  registered: boolean;
+};
+
+/**
+ * The transport the client uses to fetch the registry snapshot. The
+ * default HTTP impl talks to `core.registry.snapshot`; tests inject a
+ * fake. Decoupling the transport keeps the client unit-testable without
+ * a live registry and lets future deployments swap to an SSE / file /
+ * in-process variant without touching `pillar()`.
+ */
+export interface DiscoveryTransport {
+  fetchSnapshot(): Promise<readonly DiscoveredPillar[]>;
+}
+
+export type HttpDiscoveryTransportOptions = {
+  registryUrl?: string;
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+  headers?: Record<string, string>;
+};
+
+const DEFAULT_REGISTRY_URL = 'http://core-api:3001';
+
+const DEFAULT_FETCH_TIMEOUT_MS = 5_000;
+
+/**
+ * Default HTTP transport. Calls `core.registry.snapshot` over the tRPC
+ * GET wire format and reshapes the response into `DiscoveredPillar[]`.
+ *
+ * tRPC's HTTP GET shape:
+ *   GET /trpc/core.registry.snapshot
+ *   → { result: { data: { pillars: [...], fetchedAt: ... } } }
+ */
+export class HttpDiscoveryTransport implements DiscoveryTransport {
+  private readonly registryUrl: string;
+  private readonly fetchImpl: typeof fetch;
+  private readonly timeoutMs: number;
+  private readonly headers: Record<string, string>;
+
+  constructor(options: HttpDiscoveryTransportOptions = {}) {
+    this.registryUrl = options.registryUrl ?? DEFAULT_REGISTRY_URL;
+    this.fetchImpl = options.fetchImpl ?? fetch;
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS;
+    this.headers = options.headers ?? {};
+  }
+
+  async fetchSnapshot(): Promise<readonly DiscoveredPillar[]> {
+    const url = `${this.registryUrl.replace(/\/$/, '')}/trpc/core.registry.snapshot`;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    let response: Response;
+    try {
+      response = await this.fetchImpl(url, {
+        method: 'GET',
+        headers: { accept: 'application/json', ...this.headers },
+        signal: controller.signal,
+      });
+    } catch (cause) {
+      throw new PillarSdkError(`registry fetch failed: ${describeError(cause)}`, { cause });
+    } finally {
+      clearTimeout(timer);
+    }
+
+    if (!response.ok) {
+      throw new PillarSdkError(`registry returned HTTP ${response.status} ${response.statusText}`);
+    }
+
+    let body: unknown;
+    try {
+      body = await response.json();
+    } catch (cause) {
+      throw new PillarSdkError('registry returned non-JSON body', { cause });
+    }
+
+    return parseRegistryResponse(body);
+  }
+}
+
+function parseRegistryResponse(body: unknown): readonly DiscoveredPillar[] {
+  const data = extractTrpcData(body);
+  if (!isRecord(data)) {
+    throw new PillarSdkError('registry snapshot missing data payload');
+  }
+  const pillars = data['pillars'];
+  if (!Array.isArray(pillars)) {
+    throw new PillarSdkError('registry snapshot pillars field is not an array');
+  }
+  return pillars.map(parseRegistryEntry);
+}
+
+function parseRegistryEntry(entry: unknown, index: number): DiscoveredPillar {
+  if (!isRecord(entry)) {
+    throw new PillarSdkError(`registry snapshot entry ${index} is not an object`);
+  }
+  return {
+    pillarId: requireString(entry, 'pillarId', index),
+    baseUrl: requireString(entry, 'baseUrl', index),
+    status: requireStatus(entry['status'], index),
+    manifest: requireManifest(entry['manifest'], index),
+    lastSeenAt: requireString(entry, 'lastSeenAt', index),
+    registered: requireRegistered(entry['registered'], index),
+  };
+}
+
+function requireString(entry: Record<string, unknown>, key: string, index: number): string {
+  const value = entry[key];
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new PillarSdkError(`registry snapshot entry ${index} missing ${key}`);
+  }
+  return value;
+}
+
+function requireStatus(value: unknown, index: number): 'healthy' | 'unavailable' | 'unknown' {
+  if (value === 'healthy' || value === 'unavailable' || value === 'unknown') {
+    return value;
+  }
+  throw new PillarSdkError(`registry snapshot entry ${index} has unknown status: ${String(value)}`);
+}
+
+function requireManifest(value: unknown, index: number): ManifestPayload {
+  if (!isRecord(value)) {
+    throw new PillarSdkError(`registry snapshot entry ${index} missing manifest`);
+  }
+  return value as ManifestPayload;
+}
+
+function requireRegistered(value: unknown, index: number): boolean {
+  if (value === undefined) return true;
+  if (typeof value !== 'boolean') {
+    throw new PillarSdkError(`registry snapshot entry ${index} registered is not boolean`);
+  }
+  return value;
+}
+
+function extractTrpcData(body: unknown): unknown {
+  if (!isRecord(body)) return body;
+  const result = body['result'];
+  if (isRecord(result) && 'data' in result) return result['data'];
+  return body;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function describeError(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/packages/pillar-sdk/src/client/errors.ts
+++ b/packages/pillar-sdk/src/client/errors.ts
@@ -1,0 +1,47 @@
+/**
+ * Thrown by `.orThrow()` when the underlying call did not resolve to
+ * `{ kind: 'ok' }`. Carries the failure result for inspection.
+ */
+export class PillarCallError extends Error {
+  override readonly name = 'PillarCallError';
+  readonly pillarId: string;
+  readonly result: CallFailure;
+
+  constructor(pillarId: string, result: CallFailure) {
+    super(`pillar('${pillarId}') call failed: ${result.kind}`);
+    this.pillarId = pillarId;
+    this.result = result;
+  }
+}
+
+/**
+ * Thrown for a hard runtime error caller code couldn't reasonably handle —
+ * e.g. the SDK tried to read the discovery transport and it returned a
+ * non-conforming shape. This is *not* used for `unavailable` / `degraded`
+ * / `contract-mismatch`; those are returned as `CallResult` discriminants
+ * so the caller can branch on them.
+ */
+export class PillarSdkError extends Error {
+  override readonly name = 'PillarSdkError';
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+  }
+}
+
+export type CallSuccess<T> = { kind: 'ok'; value: T };
+
+export type CallFailure =
+  | { kind: 'unavailable'; pillar: string }
+  | { kind: 'degraded'; pillar: string; reason: 'reconciling' }
+  | {
+      kind: 'contract-mismatch';
+      pillar: string;
+      expected?: string;
+      actual?: string;
+    };
+
+export type CallResult<T> = CallSuccess<T> | CallFailure;
+
+export function isOk<T>(result: CallResult<T>): result is CallSuccess<T> {
+  return result.kind === 'ok';
+}

--- a/packages/pillar-sdk/src/client/factory.ts
+++ b/packages/pillar-sdk/src/client/factory.ts
@@ -35,7 +35,8 @@ function isCustomConfig(options: PillarClientOptions): boolean {
   return (
     options.transport !== undefined ||
     options.cacheTtlMs !== undefined ||
-    options.registry !== undefined
+    options.registry !== undefined ||
+    options.fetchImpl !== undefined
   );
 }
 

--- a/packages/pillar-sdk/src/client/factory.ts
+++ b/packages/pillar-sdk/src/client/factory.ts
@@ -1,0 +1,153 @@
+import { DiscoveryCache } from './cache.js';
+import {
+  HttpDiscoveryTransport,
+  type DiscoveryTransport,
+  type HttpDiscoveryTransportOptions,
+} from './discovery.js';
+import { PillarSdkError, type CallFailure, type CallResult } from './errors.js';
+import { performHttpCall } from './http-call.js';
+import { buildPillarProxy, type PillarHandle } from './proxy.js';
+
+import type { DiscoveredPillar } from './discovery.js';
+
+export type { PillarHandle } from './proxy.js';
+
+const DEFAULT_CACHE_TTL_MS = 60_000;
+
+export type PillarClientOptions = {
+  transport?: DiscoveryTransport;
+  cacheTtlMs?: number;
+  callTimeoutMs?: number;
+  fetchImpl?: typeof fetch;
+  authHeaders?: () => Record<string, string> | Promise<Record<string, string>>;
+  contractVersion?: string;
+  registry?: HttpDiscoveryTransportOptions;
+};
+
+type CachedClient = {
+  cache: DiscoveryCache;
+  fetchImpl: typeof fetch;
+};
+
+let sharedClient: CachedClient | null = null;
+
+function isCustomConfig(options: PillarClientOptions): boolean {
+  return (
+    options.transport !== undefined ||
+    options.cacheTtlMs !== undefined ||
+    options.registry !== undefined
+  );
+}
+
+function getSharedClient(options: PillarClientOptions): CachedClient {
+  if (isCustomConfig(options)) {
+    const transport = options.transport ?? new HttpDiscoveryTransport(options.registry ?? {});
+    return {
+      cache: new DiscoveryCache({
+        transport,
+        ttlMs: options.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS,
+      }),
+      fetchImpl: options.fetchImpl ?? fetch,
+    };
+  }
+  if (sharedClient !== null) return sharedClient;
+  const transport = new HttpDiscoveryTransport();
+  sharedClient = {
+    cache: new DiscoveryCache({ transport, ttlMs: DEFAULT_CACHE_TTL_MS }),
+    fetchImpl: fetch,
+  };
+  return sharedClient;
+}
+
+export function __resetSharedPillarClient(): void {
+  sharedClient = null;
+}
+
+export function pillar<TRouter>(
+  pillarId: string,
+  options: PillarClientOptions = {}
+): PillarHandle<TRouter> {
+  const client = getSharedClient(options);
+  const ctx: InvokeContext = { pillarId, client, options };
+  const proxy = buildPillarProxy(pillarId, (path, input) => invoke(ctx, path, input));
+  return proxy as PillarHandle<TRouter>;
+}
+
+type InvokeContext = {
+  pillarId: string;
+  client: CachedClient;
+  options: PillarClientOptions;
+};
+
+async function invoke(
+  ctx: InvokeContext,
+  path: readonly string[],
+  input: unknown
+): Promise<CallResult<unknown>> {
+  if (path.length < 2) {
+    return {
+      kind: 'contract-mismatch',
+      pillar: ctx.pillarId,
+      actual: path.join('.'),
+    };
+  }
+
+  const discovered = await safeLookup(ctx.client, ctx.pillarId);
+  const guard = guardAvailability(ctx.pillarId, discovered, ctx.options.contractVersion);
+  if (guard) return guard;
+
+  return performHttpCall({
+    pillarId: ctx.pillarId,
+    discovered: discovered as DiscoveredPillar,
+    path,
+    input,
+    fetchImpl: ctx.client.fetchImpl,
+    authHeaders: ctx.options.authHeaders,
+    callTimeoutMs: ctx.options.callTimeoutMs,
+  });
+}
+
+async function safeLookup(
+  client: CachedClient,
+  pillarId: string
+): Promise<DiscoveredPillar | undefined> {
+  try {
+    return await client.cache.lookup(pillarId);
+  } catch (cause) {
+    if (cause instanceof PillarSdkError) return undefined;
+    throw cause;
+  }
+}
+
+function guardAvailability(
+  pillarId: string,
+  discovered: DiscoveredPillar | undefined,
+  expectedVersion: string | undefined
+): CallFailure | null {
+  if (!discovered || !discovered.registered) {
+    return { kind: 'unavailable', pillar: pillarId };
+  }
+  if (discovered.status === 'unavailable') {
+    return { kind: 'unavailable', pillar: pillarId };
+  }
+  if (discovered.status === 'unknown') {
+    return { kind: 'degraded', pillar: pillarId, reason: 'reconciling' };
+  }
+  return detectContractMismatch(pillarId, discovered, expectedVersion);
+}
+
+function detectContractMismatch(
+  pillarId: string,
+  discovered: DiscoveredPillar,
+  expected: string | undefined
+): CallFailure | null {
+  if (!expected) return null;
+  const actual = discovered.manifest.contract.version;
+  if (majorOf(expected) === majorOf(actual)) return null;
+  return { kind: 'contract-mismatch', pillar: pillarId, expected, actual };
+}
+
+function majorOf(version: string): string {
+  const idx = version.indexOf('.');
+  return idx === -1 ? version : version.slice(0, idx);
+}

--- a/packages/pillar-sdk/src/client/http-call.ts
+++ b/packages/pillar-sdk/src/client/http-call.ts
@@ -1,0 +1,92 @@
+import type { DiscoveredPillar } from './discovery.js';
+import type { CallFailure, CallResult } from './errors.js';
+
+const DEFAULT_CALL_TIMEOUT_MS = 30_000;
+
+export type HttpCallContext = {
+  pillarId: string;
+  discovered: DiscoveredPillar;
+  path: readonly string[];
+  input: unknown;
+  fetchImpl: typeof fetch;
+  authHeaders?: () => Record<string, string> | Promise<Record<string, string>>;
+  callTimeoutMs?: number;
+};
+
+export async function performHttpCall(ctx: HttpCallContext): Promise<CallResult<unknown>> {
+  const url = buildUrl(ctx.discovered.baseUrl, ctx.path);
+  const headers = await buildHeaders(ctx.authHeaders);
+  const body = JSON.stringify({ input: ctx.input ?? null });
+
+  const controller = new AbortController();
+  const timeoutMs = ctx.callTimeoutMs ?? DEFAULT_CALL_TIMEOUT_MS;
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  let response: Response;
+  try {
+    response = await ctx.fetchImpl(url, {
+      method: 'POST',
+      headers,
+      body,
+      signal: controller.signal,
+    });
+  } catch {
+    return { kind: 'unavailable', pillar: ctx.pillarId };
+  } finally {
+    clearTimeout(timer);
+  }
+
+  return mapResponse(ctx.pillarId, ctx.path, response);
+}
+
+function buildUrl(baseUrl: string, path: readonly string[]): string {
+  return `${baseUrl.replace(/\/$/, '')}/trpc/${path.join('.')}`;
+}
+
+async function buildHeaders(
+  authHeaders?: () => Record<string, string> | Promise<Record<string, string>>
+): Promise<Record<string, string>> {
+  const headers: Record<string, string> = {
+    'content-type': 'application/json',
+    accept: 'application/json',
+  };
+  if (!authHeaders) return headers;
+  const extra = await authHeaders();
+  for (const [k, v] of Object.entries(extra)) headers[k] = v;
+  return headers;
+}
+
+async function mapResponse(
+  pillarId: string,
+  path: readonly string[],
+  response: Response
+): Promise<CallResult<unknown>> {
+  if (response.status === 404) {
+    const mismatch: CallFailure = {
+      kind: 'contract-mismatch',
+      pillar: pillarId,
+      expected: path.join('.'),
+    };
+    return mismatch;
+  }
+  if (!response.ok) {
+    return { kind: 'unavailable', pillar: pillarId };
+  }
+  let parsed: unknown;
+  try {
+    parsed = await response.json();
+  } catch {
+    return { kind: 'unavailable', pillar: pillarId };
+  }
+  return { kind: 'ok', value: extractTrpcResult(parsed) };
+}
+
+function extractTrpcResult(body: unknown): unknown {
+  if (typeof body !== 'object' || body === null || Array.isArray(body)) return body;
+  const record = body as Record<string, unknown>;
+  const result = record['result'];
+  if (typeof result === 'object' && result !== null && !Array.isArray(result) && 'data' in result) {
+    return (result as Record<string, unknown>)['data'];
+  }
+  return body;
+}

--- a/packages/pillar-sdk/src/client/http-call.ts
+++ b/packages/pillar-sdk/src/client/http-call.ts
@@ -14,9 +14,10 @@ export type HttpCallContext = {
 };
 
 export async function performHttpCall(ctx: HttpCallContext): Promise<CallResult<unknown>> {
-  const url = buildUrl(ctx.discovered.baseUrl, ctx.path);
+  const namespacedPath = [ctx.pillarId, ...ctx.path];
+  const url = buildUrl(ctx.discovered.baseUrl, namespacedPath);
   const headers = await buildHeaders(ctx.authHeaders);
-  const body = JSON.stringify({ input: ctx.input ?? null });
+  const body = JSON.stringify(ctx.input ?? null);
 
   const controller = new AbortController();
   const timeoutMs = ctx.callTimeoutMs ?? DEFAULT_CALL_TIMEOUT_MS;
@@ -36,7 +37,7 @@ export async function performHttpCall(ctx: HttpCallContext): Promise<CallResult<
     clearTimeout(timer);
   }
 
-  return mapResponse(ctx.pillarId, ctx.path, response);
+  return mapResponse(ctx.pillarId, namespacedPath, response);
 }
 
 function buildUrl(baseUrl: string, path: readonly string[]): string {

--- a/packages/pillar-sdk/src/client/index.ts
+++ b/packages/pillar-sdk/src/client/index.ts
@@ -1,0 +1,18 @@
+export { pillar, __resetSharedPillarClient } from './factory.js';
+export type { PillarClientOptions } from './factory.js';
+export type { PillarHandle, CallableProcedure } from './proxy.js';
+export { DiscoveryCache } from './cache.js';
+export {
+  HttpDiscoveryTransport,
+  type DiscoveredPillar,
+  type DiscoveryTransport,
+  type HttpDiscoveryTransportOptions,
+} from './discovery.js';
+export {
+  PillarCallError,
+  PillarSdkError,
+  isOk,
+  type CallFailure,
+  type CallResult,
+  type CallSuccess,
+} from './errors.js';

--- a/packages/pillar-sdk/src/client/proxy.ts
+++ b/packages/pillar-sdk/src/client/proxy.ts
@@ -1,0 +1,61 @@
+import { PillarCallError, type CallResult } from './errors.js';
+
+export type CallableProcedure<Args extends readonly unknown[], Output> = {
+  (...args: Args): Promise<CallResult<Output>>;
+  orThrow: (...args: Args) => Promise<Output>;
+};
+
+type ProcedureNode<T> = T extends (...args: infer Args) => infer Ret
+  ? CallableProcedure<Args, Awaited<Ret>>
+  : T extends Record<string, unknown>
+    ? { [K in keyof T]: ProcedureNode<T[K]> }
+    : CallableProcedure<readonly unknown[], unknown>;
+
+export type PillarHandle<TRouter> =
+  TRouter extends Record<string, unknown>
+    ? { [K in keyof TRouter]: ProcedureNode<TRouter[K]> }
+    : Record<string, ProcedureNode<unknown>>;
+
+export type InvokeFn = (path: readonly string[], input: unknown) => Promise<CallResult<unknown>>;
+
+export function buildPillarProxy(pillarId: string, invoke: InvokeFn): unknown {
+  return buildBranch(pillarId, [], invoke);
+}
+
+function buildBranch(pillarId: string, path: readonly string[], invoke: InvokeFn): unknown {
+  const target: Record<string, unknown> = {};
+  return new Proxy(target, {
+    get(_t, prop) {
+      if (typeof prop !== 'string' || prop === 'then') return undefined;
+      return buildCallable(pillarId, [...path, prop], invoke);
+    },
+  });
+}
+
+function buildCallable(pillarId: string, path: readonly string[], invoke: InvokeFn): unknown {
+  const fn = (input?: unknown): Promise<CallResult<unknown>> => invoke(path, input);
+
+  const handler: ProxyHandler<typeof fn> = {
+    get(_t, prop) {
+      if (prop === 'orThrow') return makeOrThrow(pillarId, fn);
+      if (typeof prop !== 'string' || prop === 'then') return undefined;
+      return buildCallable(pillarId, [...path, prop], invoke);
+    },
+    apply(_t, _thisArg, args: unknown[]) {
+      return fn(args[0]);
+    },
+  };
+
+  return new Proxy(fn, handler);
+}
+
+function makeOrThrow(
+  pillarId: string,
+  fn: (input?: unknown) => Promise<CallResult<unknown>>
+): (input?: unknown) => Promise<unknown> {
+  return async (input?: unknown): Promise<unknown> => {
+    const result = await fn(input);
+    if (result.kind === 'ok') return result.value;
+    throw new PillarCallError(pillarId, result);
+  };
+}

--- a/packages/pillar-sdk/tsconfig.json
+++ b/packages/pillar-sdk/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "module": "Node16",
     "moduleResolution": "Node16",
-    "lib": ["ES2022"],
+    "lib": ["ES2022", "DOM"],
     "types": ["node"],
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
## Summary

Ships the consumer-facing `pillar()` factory from Theme 13 PRD-191 — the API every cross-pillar caller will use (`pillar('finance').wishlist.list({})`). Proxy-backed runtime that walks `<router>.<procedure>` access, looks up the pillar via an injectable discovery transport, and POSTs to `<baseUrl>/trpc/<procedure>` using the tRPC wire format. Lives at `@pops/pillar-sdk/client`.

```ts
const finance = pillar<FinanceRouter>('finance');
const result = await finance.wishlist.list({});
if (result.kind === 'ok') console.log(result.value);
// or: const items = await finance.wishlist.list.orThrow({});
```

## Scope (in this PR)

- Discriminated-union `CallResult<T>`: `ok`, `unavailable`, `degraded` (`reason: 'reconciling'`), `contract-mismatch`.
- `pillar(pillarId, options?)` factory + `PillarHandle<TRouter>` recursive mapped type.
- `.orThrow()` companion on every callable leaf, throwing `PillarCallError` on non-`ok`.
- `DiscoveryTransport` interface + default `HttpDiscoveryTransport` against `core.registry.snapshot` (tRPC GET wire format per PRD-161).
- `DiscoveryCache` — TTL (default 60s), in-flight dedup so concurrent first-time lookups share one fetch.
- Failure mapping:
  - registry returns the pillar absent / `status: 'unavailable'` → `kind: 'unavailable'`.
  - registry returns `status: 'unknown'` → `kind: 'degraded'` (reconciling — PRD-164).
  - pillar replies 404 to a procedure POST → `kind: 'contract-mismatch'`.
  - consumer pins `contractVersion` and registry advertises a different major → `kind: 'contract-mismatch'` (no HTTP call made — ADR-031 §4 runtime safety net).
  - transport / 4xx / 5xx / non-JSON body → `kind: 'unavailable'`.
- Configurable: discovery TTL, per-call timeout (default 30s, matches tRPC), registry URL, fetch impl, auth headers, custom `DiscoveryTransport`.

## Layering

`packages/pillar-sdk/src/client/` (new subpath export `./client`):

| File             | LoC | Role                                                                        |
| ---------------- | --- | --------------------------------------------------------------------------- |
| `errors.ts`      |  47 | `CallResult` union, `PillarCallError`, `PillarSdkError`, `isOk` narrower    |
| `discovery.ts`   | 177 | `DiscoveryTransport` interface + `HttpDiscoveryTransport` default impl      |
| `cache.ts`       |  74 | `DiscoveryCache` — TTL math + in-flight Promise dedup                       |
| `http-call.ts`   |  99 | `performHttpCall` — builds + sends the tRPC POST, maps response → `CallResult` |
| `proxy.ts`       |  71 | `buildPillarProxy` — router → procedure → callable proxy + `.orThrow()`     |
| `factory.ts`     | 153 | `pillar()` entry point; assembles cache + transport + proxy; status guard   |
| `index.ts`       |  18 | Public re-exports for the `./client` subpath                                |
| `__tests__/*`    | 671 | Six test files covering every branch                                        |

Same-package home (not a sibling package) — the SDK is the natural place for both server-side `bootstrapPillar()` and client-side `pillar()` consumption, split by subpath. No circular issues since the contract package (`@pops/finance-contract`) and the SDK have no runtime dependency on each other (only the consumer combines them).

## Decisions

- **Cache TTL default: 60s.** Configurable per call site. PRD-159 uses 30s for the lower-level `lookupPillar()`; this client wraps that semantic at the consumer boundary and the spec gave 60s as the target.
- **Error envelope: discriminated union of `{ kind: 'ok' | 'unavailable' | 'degraded' | 'contract-mismatch' }`.** Failures are returned, not thrown — `.orThrow()` is the opt-in throw path per PRD-191 §Business Rules.
- **Contract version skew check is *consumer-pinned*, not auto-discovered.** The factory takes an optional `contractVersion: string` and major-version-compares against the registered manifest's `contract.version`. Without it, no skew check (consumer trusts the registry).
- **Discovery cache uses snapshot-level memoization, not per-pillar.** One registry round-trip serves every `pillar(*)` call in the TTL window, mirroring the PRD-159 design.
- **Injectable `DiscoveryTransport` interface, not a direct dep on the registry tRPC types.** Default impl hits the documented HTTP shape; unit tests use a fake. Decouples this PR from PR #2949 / PR #2951 landing.
- **`PillarHandle<TRouter>` is a recursive mapped type, not a tRPC-router inferred type.** Until PRD-195 (type generation pipeline) lands, consumers can either parameterise with `FinanceRouter` (which works for the call shape via structural matching) or roll their own minimal interface.

## Deferred

- React hooks → PRD-193.
- Pillar-side server surface → PRD-192.
- Cache invalidation on subscription events → PRD-194.
- React SDK consumer wiring + `pops-shell` integration → PRD-215.
- Strongly-typed `KnownPillarId` + `ContractFor<P>` registry-aware mapping → PRD-195.
- Snapshot freshness signalling (`source: 'stale-fallback'`) for write-call gating → covered by the underlying `pillarRegistry()` (PRD-159), exposed here only via the cache TTL.

## Test plan

- [x] `pnpm --filter @pops/pillar-sdk typecheck` — clean.
- [x] `pnpm --filter @pops/pillar-sdk test` — 6 files, 137 tests pass.
- [x] `pnpm typecheck` — full repo green.
- [x] `pnpm lint` — pillar-sdk contributes 0 errors, 0 new warnings; pre-existing baseline preserved.
- [x] Discovery-layer behaviour exercised via fake transport (no live registry needed).
- [x] HTTP-call layer exercised via fake `fetch` impl (no live pillar needed).
