### PR TITLE
ci: revert workflow-level paths on required-check workflows (Theme 13 PRD-220 follow-up)

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,16 +1,12 @@
 name: Docker Build
 
 on:
+  # Pull requests: NO workflow-level paths filter.
+  # `Validate Docker builds` is a required branch-protection check, so the
+  # workflow must always trigger on every PR; the job-level
+  # `dorny/paths-filter` below skips the heavy docker-buildx work and the
+  # required check still posts green via the skip-as-pass pattern.
   pull_request:
-    paths:
-      - "infra/docker*/**"
-      - "infra/docker-compose*.yml"
-      - "**/Dockerfile"
-      - "pnpm-lock.yaml"
-      - "pnpm-workspace.yaml"
-      - "turbo.json"
-      - "tsconfig.base.json"
-      - ".github/workflows/docker-build.yml"
   push:
     branches: [main]
     paths:
@@ -22,11 +18,6 @@ on:
       - "turbo.json"
       - "tsconfig.base.json"
       - ".github/workflows/docker-build.yml"
-
-# Workflow-level filter keeps `Validate Docker builds` off docs/code-only
-# PRs entirely. Per-pillar code is validated by `pillar-images.yml` and
-# the `*-api-quality.yml` workflows — this job only re-validates the
-# Dockerfile + compose surfaces. (Theme 13 PRD-220.)
 
 jobs:
   changes:

--- a/.github/workflows/fe-test-e2e.yml
+++ b/.github/workflows/fe-test-e2e.yml
@@ -3,7 +3,6 @@ name: E2E Tests
 on:
   push:
     branches: [main, develop]
-  pull_request:
     paths:
       - 'apps/pops-shell/**'
       - 'apps/pops-api/**'
@@ -20,6 +19,12 @@ on:
       - 'packages/food-contracts/**'
       - 'packages/*-db/**'
       - '.github/workflows/fe-test-e2e.yml'
+  # Pull requests: NO workflow-level paths filter.
+  # `Playwright E2E Tests` is a required branch-protection check, so the
+  # workflow must always trigger on every PR; the job-level
+  # `dorny/paths-filter` below skips the heavy work and the required
+  # check still goes green via the skip-as-pass pattern.
+  pull_request:
 
 jobs:
   changes:


### PR DESCRIPTION
## Problem

PRD-220 (CI lean-ness) added workflow-level `paths:` filters to:

- `fe-test-e2e.yml` — posts the required check `Playwright E2E Tests`
- `docker-build.yml` — posts the required check `Validate Docker builds`

Both checks are required in main's branch ruleset. When a PR's diff doesn't match the workflow's paths filter, the workflow never triggers, so the required check never posts. Branch protection then blocks merge with `the base branch policy prohibits the merge`.

PR #2950 (PRD-153 US-04 OpenAPI generator) hit this — only `packages/finance-contract/**` was touched, fe-test-e2e + docker-build didn't fire, merge blocked despite every other check green.

## Fix

Drop the `paths:` filter from the `pull_request:` trigger on both workflows. The existing job-level `dorny/paths-filter` already skips the heavy work (Playwright build / Docker buildx) and the required check posts `SUCCESS` via the skip-as-pass pattern — same cost saving, no blocked merges.

`push:` triggers on main keep the paths filter; main-publish doesn't need branch protection's required-check appearance trick.

This aligns with the principle clarification I made in #2945's docs:

> Add `paths:` (or `paths-ignore:`) to the `pull_request:` AND `push: branches: [main]` triggers — both apply on PRs and on `main`. If the workflow is a **required** branch-protection check, also add a `dorny/paths-filter` *job-level* gate so the workflow still runs (to mark the required check green) but skips the heavy steps when the trigger filter alone would have skipped it.

The principle said "keep job-level filter". The implementation went further and dropped the workflow-level filter entirely on required workflows. This PR aligns the implementation with the principle.

## Test plan

- [ ] CI on this PR fires both `Playwright E2E Tests` and `Validate Docker builds` as required-check posts (they should skip-as-pass since the only diff is workflow yaml).
- [ ] After merge, #2950 (rebased) and any future contract-only / package-only PR can merge without admin override.