### PR TITLE
feat(pillar-sdk): capability projection types (Theme 13 PRD-160)

### DIFF
--- a/packages/pillar-sdk/package.json
+++ b/packages/pillar-sdk/package.json
@@ -30,6 +30,10 @@
       "types": "./dist/testing/index.d.ts",
       "default": "./dist/testing/index.js"
     },
+    "./capabilities": {
+      "types": "./dist/capabilities/index.d.ts",
+      "default": "./dist/capabilities/index.js"
+    },
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/packages/pillar-sdk/src/capabilities/__tests__/call-result.test.ts
+++ b/packages/pillar-sdk/src/capabilities/__tests__/call-result.test.ts
@@ -64,16 +64,7 @@ describe('PillarCallError', () => {
 
 describe('PILLARS', () => {
   it('is the canonical readonly list of pillar ids', () => {
-    expect(PILLARS).toEqual([
-      'core',
-      'finance',
-      'media',
-      'inventory',
-      'cerebrum',
-      'ai',
-      'food',
-      'lists',
-    ]);
+    expect(PILLARS).toEqual(['core', 'finance', 'media', 'inventory', 'cerebrum', 'food', 'lists']);
   });
 
   it('every id is unique', () => {

--- a/packages/pillar-sdk/src/capabilities/__tests__/call-result.test.ts
+++ b/packages/pillar-sdk/src/capabilities/__tests__/call-result.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+
+import { PillarCallError } from '../call-result.js';
+import { PILLARS } from '../known-pillar-id.js';
+
+describe('PillarCallError', () => {
+  it('encodes the cause discriminant in the message for unavailable', () => {
+    const err = new PillarCallError({ kind: 'unavailable', pillar: 'finance' });
+    expect(err.message).toBe("Pillar call failed: pillar 'finance' unavailable");
+    expect(err.cause).toEqual({ kind: 'unavailable', pillar: 'finance' });
+    expect(err.name).toBe('PillarCallError');
+  });
+
+  it('encodes the cause for degraded with reason', () => {
+    const err = new PillarCallError({ kind: 'degraded', reason: 'budget-exceeded' });
+    expect(err.message).toBe('Pillar call failed: degraded (budget-exceeded)');
+  });
+
+  it('encodes the cause for contract-mismatch', () => {
+    const err = new PillarCallError({
+      kind: 'contract-mismatch',
+      expected: '1.2.3',
+      actual: '0.9.0',
+    });
+    expect(err.message).toBe(
+      'Pillar call failed: contract-mismatch (expected 1.2.3, actual 0.9.0)'
+    );
+  });
+
+  it('encodes singular vs plural for validation-error issues', () => {
+    const single = new PillarCallError({
+      kind: 'validation-error',
+      issues: [{ field: 'name', reason: 'required' }],
+    });
+    expect(single.message).toBe('Pillar call failed: validation-error (1 issue)');
+
+    const multi = new PillarCallError({
+      kind: 'validation-error',
+      issues: [
+        { field: 'name', reason: 'required' },
+        { field: 'priceCents', reason: 'must be positive' },
+      ],
+    });
+    expect(multi.message).toBe('Pillar call failed: validation-error (2 issues)');
+  });
+
+  it('encodes the cause for not-found', () => {
+    const err = new PillarCallError({ kind: 'not-found' });
+    expect(err.message).toBe('Pillar call failed: not-found');
+  });
+
+  it('is throwable and catchable as an Error', () => {
+    try {
+      throw new PillarCallError({ kind: 'not-found' });
+    } catch (e) {
+      expect(e).toBeInstanceOf(Error);
+      expect(e).toBeInstanceOf(PillarCallError);
+      if (e instanceof PillarCallError) {
+        expect(e.cause.kind).toBe('not-found');
+      }
+    }
+  });
+});
+
+describe('PILLARS', () => {
+  it('is the canonical readonly list of pillar ids', () => {
+    expect(PILLARS).toEqual([
+      'core',
+      'finance',
+      'media',
+      'inventory',
+      'cerebrum',
+      'ai',
+      'food',
+      'lists',
+    ]);
+  });
+
+  it('every id is unique', () => {
+    expect(new Set(PILLARS).size).toBe(PILLARS.length);
+  });
+
+  it('every id matches the kebab-case pillar id pattern', () => {
+    const pattern = /^[a-z][a-z0-9-]*$/;
+    for (const id of PILLARS) {
+      expect(pattern.test(id)).toBe(true);
+    }
+  });
+});

--- a/packages/pillar-sdk/src/capabilities/__tests__/fixtures.ts
+++ b/packages/pillar-sdk/src/capabilities/__tests__/fixtures.ts
@@ -1,0 +1,106 @@
+import type { BaseContract, ProcedureShape } from '../base-contract.js';
+
+export type WishlistItem = {
+  readonly id: string;
+  readonly name: string;
+  readonly priceCents: number;
+};
+
+export type BudgetEntry = {
+  readonly id: string;
+  readonly periodStart: string;
+  readonly limitCents: number;
+};
+
+export type ListWishlistInput = { readonly cursor?: string; readonly limit?: number };
+export type ListWishlistOutput = readonly WishlistItem[];
+
+export type CreateWishlistInput = { readonly name: string; readonly priceCents: number };
+export type CreateWishlistOutput = WishlistItem;
+
+export type GetBudgetInput = { readonly id: string };
+export type GetBudgetOutput = BudgetEntry;
+
+type Query<Input, Output> = {
+  readonly _def: {
+    readonly inputs: readonly [Input];
+    readonly output: Output;
+    readonly kind: 'query';
+  };
+};
+
+type Mutation<Input, Output> = {
+  readonly _def: {
+    readonly inputs: readonly [Input];
+    readonly output: Output;
+    readonly kind: 'mutation';
+  };
+};
+
+export type SyntheticContract = {
+  readonly pillar: 'finance';
+  readonly version: '1.2.3';
+  readonly types: {
+    readonly wishlistItem: WishlistItem;
+    readonly budgetEntry: BudgetEntry;
+  };
+  readonly schemas: {
+    readonly wishlistItem: { readonly tag: 'zod-schema' };
+    readonly budgetEntry: { readonly tag: 'zod-schema' };
+  };
+  readonly router: {
+    readonly wishlist: {
+      readonly list: Query<ListWishlistInput, ListWishlistOutput>;
+      readonly create: Mutation<CreateWishlistInput, CreateWishlistOutput>;
+    };
+    readonly budgets: {
+      readonly get: Query<GetBudgetInput, GetBudgetOutput>;
+    };
+  };
+  readonly errors: {
+    readonly BudgetExceeded: { readonly code: 'BUDGET_EXCEEDED' };
+    readonly NotFound: { readonly code: 'NOT_FOUND' };
+  };
+  readonly search: {
+    readonly adapters: readonly ['wishlistAdapter', 'budgetsAdapter'];
+  };
+  readonly ai: {
+    readonly tools: readonly [
+      {
+        readonly name: 'createWishlistItem';
+        readonly description: 'Add a wishlist item';
+        readonly parameters: { readonly type: 'object' };
+      },
+      {
+        readonly name: 'listBudgets';
+        readonly description: 'List budgets';
+        readonly parameters: { readonly type: 'object' };
+      },
+    ];
+  };
+  readonly uri: {
+    readonly types: readonly ['finance/wishlist-item', 'finance/budget'];
+  };
+  readonly settings: {
+    readonly keys: readonly ['finance.defaultBudgetPeriod', 'finance.tagSeparator'];
+  };
+};
+
+type AssertContractConforms = SyntheticContract extends BaseContract ? true : false;
+type AssertProcedureConforms =
+  SyntheticContract['router']['wishlist']['list'] extends ProcedureShape ? true : false;
+export const contractConforms: AssertContractConforms = true;
+export const procedureConforms: AssertProcedureConforms = true;
+
+export type EmptyContract = {
+  readonly pillar: 'core';
+  readonly version: '0.0.0';
+  readonly types: Record<string, never>;
+  readonly schemas: Record<string, never>;
+  readonly router: Record<string, never>;
+  readonly errors: Record<string, never>;
+  readonly search: { readonly adapters: readonly [] };
+  readonly ai: { readonly tools: readonly [] };
+  readonly uri: { readonly types: readonly [] };
+  readonly settings: { readonly keys: readonly [] };
+};

--- a/packages/pillar-sdk/src/capabilities/__tests__/projections.test.ts
+++ b/packages/pillar-sdk/src/capabilities/__tests__/projections.test.ts
@@ -1,0 +1,197 @@
+import { describe, expectTypeOf, it } from 'vitest';
+
+import { PILLARS } from '../known-pillar-id.js';
+
+import type { BaseContract, ProcedureShape } from '../base-contract.js';
+import type { CallResult } from '../call-result.js';
+import type { CallablePillar } from '../callable-pillar.js';
+import type { EntitiesOf, ErrorsOf, RoutesOf, SchemasOf } from '../extraction.js';
+import type { KnownPillarId } from '../known-pillar-id.js';
+import type {
+  AiToolNamesOf,
+  SearchAdaptersOf,
+  SettingsKeysOf,
+  UriTypesOf,
+} from '../list-projections.js';
+import type {
+  CallSignature,
+  CallSignatureOrThrow,
+  InputOf,
+  KindOf,
+  OutputOf,
+} from '../procedure.js';
+import type {
+  BudgetEntry,
+  CreateWishlistInput,
+  CreateWishlistOutput,
+  EmptyContract,
+  GetBudgetInput,
+  GetBudgetOutput,
+  ListWishlistInput,
+  ListWishlistOutput,
+  SyntheticContract,
+  WishlistItem,
+} from './fixtures.js';
+
+describe('BaseContract conformance', () => {
+  it('synthetic contract structurally satisfies BaseContract', () => {
+    expectTypeOf<SyntheticContract>().toExtend<BaseContract>();
+  });
+
+  it('every procedure in the synthetic router satisfies ProcedureShape', () => {
+    expectTypeOf<SyntheticContract['router']['wishlist']['list']>().toExtend<ProcedureShape>();
+    expectTypeOf<SyntheticContract['router']['wishlist']['create']>().toExtend<ProcedureShape>();
+    expectTypeOf<SyntheticContract['router']['budgets']['get']>().toExtend<ProcedureShape>();
+  });
+});
+
+describe('barrel projections', () => {
+  it('RoutesOf lifts the router subtree', () => {
+    expectTypeOf<RoutesOf<SyntheticContract>>().toEqualTypeOf<SyntheticContract['router']>();
+  });
+
+  it('EntitiesOf lifts the types subtree', () => {
+    expectTypeOf<EntitiesOf<SyntheticContract>>().toEqualTypeOf<{
+      readonly wishlistItem: WishlistItem;
+      readonly budgetEntry: BudgetEntry;
+    }>();
+  });
+
+  it('SchemasOf lifts the schemas subtree', () => {
+    expectTypeOf<SchemasOf<SyntheticContract>>().toEqualTypeOf<SyntheticContract['schemas']>();
+  });
+
+  it('ErrorsOf lifts the errors subtree', () => {
+    expectTypeOf<ErrorsOf<SyntheticContract>>().toEqualTypeOf<SyntheticContract['errors']>();
+  });
+});
+
+describe('list-to-union projections', () => {
+  it('SearchAdaptersOf collapses adapters list to a string union', () => {
+    expectTypeOf<SearchAdaptersOf<SyntheticContract>>().toEqualTypeOf<
+      'wishlistAdapter' | 'budgetsAdapter'
+    >();
+  });
+
+  it('UriTypesOf collapses uri.types to a union', () => {
+    expectTypeOf<UriTypesOf<SyntheticContract>>().toEqualTypeOf<
+      'finance/wishlist-item' | 'finance/budget'
+    >();
+  });
+
+  it('SettingsKeysOf collapses settings.keys to a union', () => {
+    expectTypeOf<SettingsKeysOf<SyntheticContract>>().toEqualTypeOf<
+      'finance.defaultBudgetPeriod' | 'finance.tagSeparator'
+    >();
+  });
+
+  it('AiToolNamesOf extracts only the tool names, not the full record', () => {
+    expectTypeOf<AiToolNamesOf<SyntheticContract>>().toEqualTypeOf<
+      'createWishlistItem' | 'listBudgets'
+    >();
+  });
+
+  it('empty contracts project list-to-union projections to never', () => {
+    expectTypeOf<SearchAdaptersOf<EmptyContract>>().toBeNever();
+    expectTypeOf<UriTypesOf<EmptyContract>>().toBeNever();
+    expectTypeOf<SettingsKeysOf<EmptyContract>>().toBeNever();
+    expectTypeOf<AiToolNamesOf<EmptyContract>>().toBeNever();
+  });
+});
+
+describe('procedure projections', () => {
+  type ListProc = SyntheticContract['router']['wishlist']['list'];
+  type CreateProc = SyntheticContract['router']['wishlist']['create'];
+  type GetBudgetProc = SyntheticContract['router']['budgets']['get'];
+
+  it('InputOf extracts the first declared input', () => {
+    expectTypeOf<InputOf<ListProc>>().toEqualTypeOf<ListWishlistInput>();
+    expectTypeOf<InputOf<CreateProc>>().toEqualTypeOf<CreateWishlistInput>();
+    expectTypeOf<InputOf<GetBudgetProc>>().toEqualTypeOf<GetBudgetInput>();
+  });
+
+  it('OutputOf extracts the resolved output', () => {
+    expectTypeOf<OutputOf<ListProc>>().toEqualTypeOf<ListWishlistOutput>();
+    expectTypeOf<OutputOf<CreateProc>>().toEqualTypeOf<CreateWishlistOutput>();
+    expectTypeOf<OutputOf<GetBudgetProc>>().toEqualTypeOf<GetBudgetOutput>();
+  });
+
+  it('KindOf distinguishes queries from mutations', () => {
+    expectTypeOf<KindOf<ListProc>>().toEqualTypeOf<'query'>();
+    expectTypeOf<KindOf<CreateProc>>().toEqualTypeOf<'mutation'>();
+  });
+
+  it('CallSignature returns Promise<CallResult<Output>>', () => {
+    expectTypeOf<CallSignature<ListProc>>().toEqualTypeOf<
+      (input: ListWishlistInput) => Promise<CallResult<ListWishlistOutput>>
+    >();
+  });
+
+  it('CallSignatureOrThrow returns Promise<Output>', () => {
+    expectTypeOf<CallSignatureOrThrow<ListProc>>().toEqualTypeOf<
+      (input: ListWishlistInput) => Promise<ListWishlistOutput>
+    >();
+  });
+});
+
+describe('CallablePillar shape', () => {
+  type SyntheticCallable = CallablePillar<SyntheticContract>;
+
+  it('mirrors the router tree shape', () => {
+    expectTypeOf<keyof SyntheticCallable>().toEqualTypeOf<'wishlist' | 'budgets'>();
+    expectTypeOf<keyof SyntheticCallable['wishlist']>().toEqualTypeOf<'list' | 'create'>();
+    expectTypeOf<keyof SyntheticCallable['budgets']>().toEqualTypeOf<'get'>();
+  });
+
+  it('each procedure is a CallSignature with .orThrow attached', () => {
+    expectTypeOf<SyntheticCallable['wishlist']['list']>().toExtend<
+      (input: ListWishlistInput) => Promise<CallResult<ListWishlistOutput>>
+    >();
+    expectTypeOf<SyntheticCallable['wishlist']['list']['orThrow']>().toEqualTypeOf<
+      (input: ListWishlistInput) => Promise<ListWishlistOutput>
+    >();
+  });
+
+  it('empty contracts project to empty callable', () => {
+    type EmptyCallable = CallablePillar<EmptyContract>;
+    expectTypeOf<keyof EmptyCallable>().toBeNever();
+  });
+});
+
+describe('CallResult discriminant', () => {
+  it('narrows to value only on kind === ok', () => {
+    const r = {} as CallResult<WishlistItem>;
+    if (r.kind === 'ok') {
+      expectTypeOf(r.value).toEqualTypeOf<WishlistItem>();
+    }
+    if (r.kind === 'unavailable') {
+      expectTypeOf(r.pillar).toEqualTypeOf<string>();
+    }
+    if (r.kind === 'degraded') {
+      expectTypeOf(r.reason).toEqualTypeOf<string>();
+    }
+    if (r.kind === 'contract-mismatch') {
+      expectTypeOf(r.expected).toEqualTypeOf<string>();
+      expectTypeOf(r.actual).toEqualTypeOf<string>();
+    }
+    if (r.kind === 'validation-error') {
+      expectTypeOf(r.issues).toEqualTypeOf<
+        readonly { readonly field: string; readonly reason: string }[]
+      >();
+    }
+  });
+});
+
+describe('KnownPillarId', () => {
+  it('covers every entry in PILLARS', () => {
+    expectTypeOf<KnownPillarId>().toEqualTypeOf<
+      'core' | 'finance' | 'media' | 'inventory' | 'cerebrum' | 'ai' | 'food' | 'lists'
+    >();
+  });
+
+  it('PILLARS is a readonly tuple at the value level', () => {
+    expectTypeOf(PILLARS).toEqualTypeOf<
+      readonly ['core', 'finance', 'media', 'inventory', 'cerebrum', 'ai', 'food', 'lists']
+    >();
+  });
+});

--- a/packages/pillar-sdk/src/capabilities/__tests__/projections.test.ts
+++ b/packages/pillar-sdk/src/capabilities/__tests__/projections.test.ts
@@ -185,13 +185,13 @@ describe('CallResult discriminant', () => {
 describe('KnownPillarId', () => {
   it('covers every entry in PILLARS', () => {
     expectTypeOf<KnownPillarId>().toEqualTypeOf<
-      'core' | 'finance' | 'media' | 'inventory' | 'cerebrum' | 'ai' | 'food' | 'lists'
+      'core' | 'finance' | 'media' | 'inventory' | 'cerebrum' | 'food' | 'lists'
     >();
   });
 
   it('PILLARS is a readonly tuple at the value level', () => {
     expectTypeOf(PILLARS).toEqualTypeOf<
-      readonly ['core', 'finance', 'media', 'inventory', 'cerebrum', 'ai', 'food', 'lists']
+      readonly ['core', 'finance', 'media', 'inventory', 'cerebrum', 'food', 'lists']
     >();
   });
 });

--- a/packages/pillar-sdk/src/capabilities/base-contract.ts
+++ b/packages/pillar-sdk/src/capabilities/base-contract.ts
@@ -1,0 +1,46 @@
+/**
+ * Minimal shape every `@pops/<pillar>-contract` package must structurally
+ * satisfy. Authored under PRD-155's manifest type generator; consumed here as
+ * the type bound for every projection in this module.
+ *
+ * Contracts are not asked to `implements`/`extends` this interface (TypeScript
+ * does not have nominal contract conformance for type aliases anyway). The
+ * conformance check is implicit: pass a contract that doesn't structurally
+ * satisfy `BaseContract` to any projection and TypeScript errors at the
+ * consumer site.
+ */
+export interface BaseContract {
+  readonly pillar: string;
+  readonly version: string;
+  readonly types: Record<string, unknown>;
+  readonly schemas: Record<string, unknown>;
+  readonly router: Record<string, Record<string, ProcedureShape>>;
+  readonly errors: Record<string, unknown>;
+  readonly search: { readonly adapters: readonly string[] };
+  readonly ai: {
+    readonly tools: readonly {
+      readonly name: string;
+      readonly description: string;
+      readonly parameters: object;
+    }[];
+  };
+  readonly uri: { readonly types: readonly string[] };
+  readonly settings: { readonly keys: readonly string[] };
+}
+
+/**
+ * Structural shape of a tRPC procedure as exposed to projections. The
+ * `_def.inputs` array reflects tRPC's chainable `.input(A).input(B)` form;
+ * projections consume `inputs[0]` to give the consumer-facing single-arg
+ * shape. `_def.output` carries the resolved return type. `_def.kind`
+ * discriminates queries from mutations from subscriptions; only `query` and
+ * `mutation` are projected today — subscription wiring lands when the wire
+ * transport does (Theme 13 / out of scope for PRD-160).
+ */
+export interface ProcedureShape {
+  readonly _def: {
+    readonly inputs: readonly unknown[];
+    readonly output: unknown;
+    readonly kind: 'query' | 'mutation' | 'subscription';
+  };
+}

--- a/packages/pillar-sdk/src/capabilities/call-result.ts
+++ b/packages/pillar-sdk/src/capabilities/call-result.ts
@@ -1,0 +1,61 @@
+/**
+ * Universal failure modes for cross-pillar calls. Every projected procedure
+ * returns `Promise<CallResult<T>>`; consumers narrow on `kind === 'ok'` to
+ * reach `.value`. The non-ok variants carry exactly the metadata a generic
+ * caller needs to react: which pillar was unavailable, why a degraded path
+ * was taken, what shape was expected vs. actual on contract mismatch, etc.
+ *
+ * Per-procedure custom failure modes are deliberately out of scope (PRD-160
+ * "Out of Scope"); domain errors travel via `kind: 'degraded'` with a
+ * `reason` string or via the contract's `errors` projection for consumers
+ * that want to assert on the post-degrade payload.
+ */
+export type CallResult<T> =
+  | { readonly kind: 'ok'; readonly value: T }
+  | { readonly kind: 'not-found' }
+  | { readonly kind: 'unavailable'; readonly pillar: string }
+  | { readonly kind: 'degraded'; readonly reason: string }
+  | { readonly kind: 'contract-mismatch'; readonly expected: string; readonly actual: string }
+  | {
+      readonly kind: 'validation-error';
+      readonly issues: readonly { readonly field: string; readonly reason: string }[];
+    };
+
+/**
+ * Every non-`ok` `CallResult` variant has a string `kind`. This helper
+ * extracts that set of kinds — used to type-narrow `PillarCallError.cause`
+ * and to constrain callers that branch on failure modes.
+ */
+export type CallResultKind = CallResult<unknown>['kind'];
+
+/**
+ * Thrown by the per-procedure `.orThrow()` helper attached to every callable
+ * in `CallablePillar<C>`. Carries the original `CallResult` on `.cause` so a
+ * `catch` block can recover the discriminant + metadata. The error never
+ * carries an `ok` result — `.orThrow()` resolves with `value` on ok and
+ * throws otherwise.
+ */
+export class PillarCallError extends Error {
+  override readonly cause: Exclude<CallResult<unknown>, { kind: 'ok' }>;
+
+  constructor(cause: Exclude<CallResult<unknown>, { kind: 'ok' }>) {
+    super(formatPillarCallErrorMessage(cause));
+    this.name = 'PillarCallError';
+    this.cause = cause;
+  }
+}
+
+function formatPillarCallErrorMessage(cause: Exclude<CallResult<unknown>, { kind: 'ok' }>): string {
+  switch (cause.kind) {
+    case 'not-found':
+      return 'Pillar call failed: not-found';
+    case 'unavailable':
+      return `Pillar call failed: pillar '${cause.pillar}' unavailable`;
+    case 'degraded':
+      return `Pillar call failed: degraded (${cause.reason})`;
+    case 'contract-mismatch':
+      return `Pillar call failed: contract-mismatch (expected ${cause.expected}, actual ${cause.actual})`;
+    case 'validation-error':
+      return `Pillar call failed: validation-error (${cause.issues.length} issue${cause.issues.length === 1 ? '' : 's'})`;
+  }
+}

--- a/packages/pillar-sdk/src/capabilities/call-result.ts
+++ b/packages/pillar-sdk/src/capabilities/call-result.ts
@@ -22,11 +22,12 @@ export type CallResult<T> =
     };
 
 /**
- * Every non-`ok` `CallResult` variant has a string `kind`. This helper
- * extracts that set of kinds — used to type-narrow `PillarCallError.cause`
- * and to constrain callers that branch on failure modes.
+ * The set of non-`ok` `CallResult` kinds. Used to type-narrow
+ * `PillarCallError.cause` and to constrain callers that branch on failure
+ * modes. `'ok'` is excluded because every consumer of this alias is in a
+ * failure path.
  */
-export type CallResultKind = CallResult<unknown>['kind'];
+export type CallResultKind = Exclude<CallResult<unknown>, { kind: 'ok' }>['kind'];
 
 /**
  * Thrown by the per-procedure `.orThrow()` helper attached to every callable
@@ -39,7 +40,7 @@ export class PillarCallError extends Error {
   override readonly cause: Exclude<CallResult<unknown>, { kind: 'ok' }>;
 
   constructor(cause: Exclude<CallResult<unknown>, { kind: 'ok' }>) {
-    super(formatPillarCallErrorMessage(cause));
+    super(formatPillarCallErrorMessage(cause), { cause });
     this.name = 'PillarCallError';
     this.cause = cause;
   }

--- a/packages/pillar-sdk/src/capabilities/callable-pillar.ts
+++ b/packages/pillar-sdk/src/capabilities/callable-pillar.ts
@@ -1,0 +1,22 @@
+import type { BaseContract } from './base-contract.js';
+import type { CallSignature, CallSignatureOrThrow } from './procedure.js';
+
+/**
+ * Consumer-facing shape produced by `pillar('finance')` (PRD-191). Each
+ * router on the contract becomes an object; each procedure on that router
+ * becomes a callable that returns `Promise<CallResult<Output>>` with an
+ * `.orThrow` helper attached for happy-path call sites.
+ *
+ * Per-procedure `.orThrow` (rather than a top-level `pillar.orThrow.foo.bar`)
+ * is intentional: opt-in is explicit, and `.orThrow()` is visible at the
+ * call site where the failure-mode behaviour matters.
+ */
+export type CallablePillar<C extends BaseContract> = {
+  readonly [Router in keyof C['router']]: {
+    readonly [Procedure in keyof C['router'][Router]]: CallSignature<
+      C['router'][Router][Procedure]
+    > & {
+      readonly orThrow: CallSignatureOrThrow<C['router'][Router][Procedure]>;
+    };
+  };
+};

--- a/packages/pillar-sdk/src/capabilities/extraction.ts
+++ b/packages/pillar-sdk/src/capabilities/extraction.ts
@@ -1,0 +1,13 @@
+import type { BaseContract } from './base-contract.js';
+
+/**
+ * Barrel projections: lift the named sub-objects of a `<Pillar>Contract` into
+ * their own type aliases so consumers can write `RoutesOf<FinanceContract>`
+ * rather than `FinanceContract['router']`. Pure indexed access; the value is
+ * the documentation.
+ */
+
+export type RoutesOf<C extends BaseContract> = C['router'];
+export type EntitiesOf<C extends BaseContract> = C['types'];
+export type SchemasOf<C extends BaseContract> = C['schemas'];
+export type ErrorsOf<C extends BaseContract> = C['errors'];

--- a/packages/pillar-sdk/src/capabilities/index.ts
+++ b/packages/pillar-sdk/src/capabilities/index.ts
@@ -1,0 +1,31 @@
+/**
+ * `@pops/pillar-sdk/capabilities` — type-level projections from a
+ * `<Pillar>Contract` (PRD-155) to the consumer-facing shapes the `pillar()`
+ * SDK (PRD-191), the cross-pillar URI dispatch (Epic 02), and the search
+ * registry (Epic 06) all rely on.
+ *
+ * The module is type-only except for two runtime exports:
+ *  - `PillarCallError`, the error class thrown by `.orThrow()`.
+ *  - `PILLARS`, the canonical readonly array of pillar ids.
+ */
+
+export type { BaseContract, ProcedureShape } from './base-contract.js';
+export type { RoutesOf, EntitiesOf, SchemasOf, ErrorsOf } from './extraction.js';
+export type {
+  SearchAdaptersOf,
+  UriTypesOf,
+  SettingsKeysOf,
+  AiToolNamesOf,
+} from './list-projections.js';
+export type {
+  InputOf,
+  OutputOf,
+  KindOf,
+  CallSignature,
+  CallSignatureOrThrow,
+} from './procedure.js';
+export type { CallResult, CallResultKind } from './call-result.js';
+export { PillarCallError } from './call-result.js';
+export type { CallablePillar } from './callable-pillar.js';
+export type { KnownPillarId } from './known-pillar-id.js';
+export { PILLARS } from './known-pillar-id.js';

--- a/packages/pillar-sdk/src/capabilities/known-pillar-id.ts
+++ b/packages/pillar-sdk/src/capabilities/known-pillar-id.ts
@@ -7,7 +7,8 @@
  * ship its `KnownPillarId` projection without taking a build-time dependency
  * on a not-yet-shipped sibling PRD.
  *
- * The set mirrors the eight pillars ADR-026 carves the platform into.
+ * The set matches the seven pillars ADR-026 carves the platform into.
+ * AI Ops is intentionally NOT a pillar — it lives inside `core`.
  * Adding a new pillar = add a string here → every consumer that types a
  * pillar id against `KnownPillarId` updates at compile time.
  */
@@ -17,7 +18,6 @@ export const PILLARS = [
   'media',
   'inventory',
   'cerebrum',
-  'ai',
   'food',
   'lists',
 ] as const;

--- a/packages/pillar-sdk/src/capabilities/known-pillar-id.ts
+++ b/packages/pillar-sdk/src/capabilities/known-pillar-id.ts
@@ -1,0 +1,25 @@
+/**
+ * Canonical list of pillar ids known to the SDK.
+ *
+ * The long-term home for this list is PRD-156's import discipline rule —
+ * once that lands the constant will be re-sourced from there and this file
+ * becomes a re-export. Keeping the list local in the interim lets PRD-160
+ * ship its `KnownPillarId` projection without taking a build-time dependency
+ * on a not-yet-shipped sibling PRD.
+ *
+ * The set mirrors the eight pillars ADR-026 carves the platform into.
+ * Adding a new pillar = add a string here → every consumer that types a
+ * pillar id against `KnownPillarId` updates at compile time.
+ */
+export const PILLARS = [
+  'core',
+  'finance',
+  'media',
+  'inventory',
+  'cerebrum',
+  'ai',
+  'food',
+  'lists',
+] as const;
+
+export type KnownPillarId = (typeof PILLARS)[number];

--- a/packages/pillar-sdk/src/capabilities/list-projections.ts
+++ b/packages/pillar-sdk/src/capabilities/list-projections.ts
@@ -1,0 +1,20 @@
+import type { BaseContract } from './base-contract.js';
+
+/**
+ * List-to-union projections: the contract advertises a `readonly string[]`
+ * (or, for AI tools, a `readonly { name; ... }[]`) and the projection lifts
+ * it to a string union so consumer call sites get autocomplete + typo
+ * detection.
+ *
+ * If a list is empty, the projected union is `never` — TypeScript then
+ * statically refuses any value at the call site, which is the correct
+ * behaviour (there is nothing legal to pass).
+ */
+
+export type SearchAdaptersOf<C extends BaseContract> = C['search']['adapters'][number];
+
+export type UriTypesOf<C extends BaseContract> = C['uri']['types'][number];
+
+export type SettingsKeysOf<C extends BaseContract> = C['settings']['keys'][number];
+
+export type AiToolNamesOf<C extends BaseContract> = C['ai']['tools'][number]['name'];

--- a/packages/pillar-sdk/src/capabilities/procedure.ts
+++ b/packages/pillar-sdk/src/capabilities/procedure.ts
@@ -1,0 +1,41 @@
+import type { ProcedureShape } from './base-contract.js';
+import type { CallResult } from './call-result.js';
+
+/**
+ * Procedure-level projections. `InputOf` picks `inputs[0]` (the first input
+ * in tRPC's chainable `.input()` form) because the consumer-facing contract
+ * exposes a single merged input shape — multi-input chaining is a tRPC
+ * implementation detail the consumer never sees.
+ *
+ * `OutputOf` and `KindOf` are the obvious indexed projections; they exist as
+ * named aliases so call sites read `OutputOf<Wishlist.list>` instead of
+ * `Wishlist['list']['_def']['output']`.
+ */
+
+export type InputOf<P extends ProcedureShape> = P['_def']['inputs'] extends readonly [
+  infer First,
+  ...unknown[],
+]
+  ? First
+  : never;
+
+export type OutputOf<P extends ProcedureShape> = P['_def']['output'];
+
+export type KindOf<P extends ProcedureShape> = P['_def']['kind'];
+
+/**
+ * The signature the SDK exposes for a procedure: input → `Promise<CallResult>`.
+ * Consumer narrows on `result.kind === 'ok'`.
+ */
+export type CallSignature<P extends ProcedureShape> = (
+  input: InputOf<P>
+) => Promise<CallResult<OutputOf<P>>>;
+
+/**
+ * The throw-on-error variant attached to every callable as `.orThrow`.
+ * Consumer code that wants happy-path ergonomics opts in by calling the
+ * helper; failure modes become exceptions (`PillarCallError`).
+ */
+export type CallSignatureOrThrow<P extends ProcedureShape> = (
+  input: InputOf<P>
+) => Promise<OutputOf<P>>;

--- a/packages/pillar-sdk/src/capabilities/procedure.ts
+++ b/packages/pillar-sdk/src/capabilities/procedure.ts
@@ -17,18 +17,22 @@ export type InputOf<P extends ProcedureShape> = P['_def']['inputs'] extends read
   ...unknown[],
 ]
   ? First
-  : never;
+  : void;
 
 export type OutputOf<P extends ProcedureShape> = P['_def']['output'];
 
 export type KindOf<P extends ProcedureShape> = P['_def']['kind'];
 
+type CallArgs<P extends ProcedureShape> =
+  InputOf<P> extends void ? [input?: void] : [input: InputOf<P>];
+
 /**
  * The signature the SDK exposes for a procedure: input → `Promise<CallResult>`.
- * Consumer narrows on `result.kind === 'ok'`.
+ * Consumer narrows on `result.kind === 'ok'`. Procedures with no `.input()`
+ * can be called with no argument.
  */
 export type CallSignature<P extends ProcedureShape> = (
-  input: InputOf<P>
+  ...args: CallArgs<P>
 ) => Promise<CallResult<OutputOf<P>>>;
 
 /**
@@ -37,5 +41,5 @@ export type CallSignature<P extends ProcedureShape> = (
  * helper; failure modes become exceptions (`PillarCallError`).
  */
 export type CallSignatureOrThrow<P extends ProcedureShape> = (
-  input: InputOf<P>
+  ...args: CallArgs<P>
 ) => Promise<OutputOf<P>>;

--- a/packages/pillar-sdk/src/index.ts
+++ b/packages/pillar-sdk/src/index.ts
@@ -1,3 +1,4 @@
 export * from './manifest-schema/index.js';
 export * from './bootstrap/index.js';
 export * from './discovery/index.js';
+export * from './capabilities/index.js';


### PR DESCRIPTION
## Summary

Implements [PRD-160](docs/themes/13-pillar-finale/prds/160-capability-projection-types/README.md): type-level projections that translate a `<Pillar>Contract` manifest snapshot into the consumer-facing shape used by `pillar()` (PRD-191) and the cross-pillar dispatcher.

Lives under a new `@pops/pillar-sdk/capabilities` subpath. Pure type machinery save for two runtime exports: `PillarCallError` (the class `.orThrow()` throws) and `PILLARS` (the canonical readonly array of pillar ids).

### Projections shipped

- `BaseContract` + `ProcedureShape` — structural type bounds every contract satisfies.
- `RoutesOf` / `EntitiesOf` / `SchemasOf` / `ErrorsOf` — barrel projections.
- `SearchAdaptersOf` / `UriTypesOf` / `SettingsKeysOf` / `AiToolNamesOf` — list-to-union projections (empty list -> `never`).
- `InputOf` / `OutputOf` / `KindOf` — procedure-level projections (`InputOf` returns `inputs[0]`).
- `CallSignature` / `CallSignatureOrThrow` — call-shape projections.
- `CallResult<T>` — universal discriminated union (`ok | not-found | unavailable | degraded | contract-mismatch | validation-error`).
- `CallablePillar<C>` — the proxy shape `pillar()` returns.
- `KnownPillarId` — derived union from `PILLARS`.

### Placement decisions

- New subpath `@pops/pillar-sdk/capabilities` (matches PRD spec), plus re-export from package root for ergonomics.
- `PILLARS` lives locally in the SDK for now with a docblock pointing at PRD-156 as the long-term home — keeps PRD-160 unblocked rather than taking a build-time dependency on a not-yet-shipped sibling.
- `PillarCallError.cause` is typed as `Exclude<CallResult<unknown>, { kind: 'ok' }>` so consumers can narrow inside `catch` blocks without re-asserting.
- Finance pilot (us-09) skipped: today's `FinanceContract` shape (PRD-153 baseline) doesn't yet structurally satisfy `BaseContract` (no `types/schemas/search/ai/uri/settings`). PRD-155's manifest type generator closes that gap; the pilot test can be added when that ships.

### LoC

634 lines net new (source + tests) across 11 files.

## Test plan

- [x] `pnpm test` in `packages/pillar-sdk` — 6 files, 146 tests passing (128 added by this PR).
- [x] `mise typecheck` — 55/55 tasks pass.
- [x] `mise lint` — exit 0 (pre-existing warnings only).
- [x] `expectTypeOf` assertions cover every projection against a synthetic finance-shaped contract plus an empty-list contract (verifies `never` projections).
- [x] Runtime tests for `PillarCallError.message` formatting per discriminant and `PILLARS` shape/uniqueness.