### PR TITLE
feat(registry): heartbeat + lapsed-status reconciliation (Theme 13 PRD-162)

### DIFF
--- a/apps/pops-core-api/src/__tests__/heartbeat.test.ts
+++ b/apps/pops-core-api/src/__tests__/heartbeat.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Heartbeat lifecycle tests for `core.registry.*` (Theme 13 PRD-162).
+ *
+ * Covers the registry side of the heartbeat contract: the `heartbeat`
+ * mutation, the background reconciliation ticker, the lazy-compute
+ * status path on `list`/`get`, and the recovery cycle.
+ *
+ * Drives `appRouter.createCaller(ctx)` against a per-test in-memory
+ * core.db plus an injected clock so missed heartbeats can be simulated
+ * without sleeping in real time.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { openCoreDb, pillarRegistryService, type OpenedCoreDb } from '@pops/core-db';
+
+import {
+  HEARTBEAT_INTERVAL_MS,
+  HEALTHY_STALENESS_REFRESH_MS,
+  UNAVAILABLE_AFTER_MS,
+  injectRegistryClock,
+  resetRegistryClock,
+} from '../modules/registry/status.js';
+import { runHeartbeatTick } from '../modules/registry/ticker.js';
+import { appRouter } from '../router.js';
+import { type Context } from '../trpc.js';
+
+import type { ManifestPayload } from '@pops/pillar-sdk';
+
+let tmpDir: string;
+let coreDb: OpenedCoreDb;
+let clock: { now: Date };
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'core-api-heartbeat-test-'));
+  coreDb = openCoreDb(join(tmpDir, 'core.db'));
+  clock = { now: new Date('2026-06-12T12:00:00.000Z') };
+  injectRegistryClock(() => clock.now);
+});
+
+afterEach(() => {
+  resetRegistryClock();
+  coreDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function caller(): ReturnType<typeof appRouter.createCaller> {
+  const ctx: Context = {
+    user: { email: 'dev@example.com' },
+    serviceAccount: null,
+    coreDb: coreDb.db,
+  };
+  return appRouter.createCaller(ctx);
+}
+
+function advance(ms: number): void {
+  clock.now = new Date(clock.now.getTime() + ms);
+}
+
+function financeManifest(): ManifestPayload {
+  return {
+    pillar: 'finance',
+    version: '1.2.3',
+    contract: {
+      package: '@pops/finance-contract',
+      version: '1.2.3',
+      tag: 'contract-finance@v1.2.3',
+    },
+    routes: {
+      queries: ['finance.transactions.list'],
+      mutations: ['finance.transactions.create'],
+      subscriptions: [],
+    },
+    search: { adapters: ['transactionsAdapter'] },
+    ai: { tools: [] },
+    uri: { types: ['finance/transaction'] },
+    settings: { keys: [] },
+    healthcheck: { path: '/healthz' },
+  };
+}
+
+function mediaManifest(): ManifestPayload {
+  return {
+    pillar: 'media',
+    version: '0.5.0',
+    contract: {
+      package: '@pops/media-contract',
+      version: '0.5.0',
+      tag: 'contract-media@v0.5.0',
+    },
+    routes: { queries: ['media.library.list'], mutations: [], subscriptions: [] },
+    search: { adapters: ['libraryAdapter'] },
+    ai: { tools: [] },
+    uri: { types: ['media/movie'] },
+    settings: { keys: [] },
+    healthcheck: { path: '/healthz' },
+  };
+}
+
+async function registerFinance(): Promise<string> {
+  const result = await caller().core.registry.register({
+    baseUrl: 'http://finance-api:3004',
+    manifest: financeManifest(),
+  });
+  if (!result.ok) throw new Error('register fixture failed');
+  return result.pillarId;
+}
+
+describe('core.registry.heartbeat (PRD-162)', () => {
+  it('returns ok=false reason=not-registered for an unknown pillar', async () => {
+    const res = await caller().core.registry.heartbeat({ pillar: 'finance' });
+    expect(res).toEqual({ ok: false, reason: 'not-registered' });
+  });
+
+  it('updates lastHeartbeatAt to NOW() and reports statusChanged=false when already healthy', async () => {
+    await registerFinance();
+    const registeredAt = (await caller().core.registry.get({ pillar: 'finance' }))!.lastHeartbeatAt;
+
+    advance(HEARTBEAT_INTERVAL_MS);
+    const beforeHeartbeat = clock.now.toISOString();
+
+    pillarRegistryService.recordHeartbeat(coreDb.db, 'finance', { now: beforeHeartbeat });
+
+    const res = await caller().core.registry.heartbeat({ pillar: 'finance' });
+    if (!res.ok) throw new Error('expected ok=true');
+    expect(res.pillarId).toBe('finance');
+    expect(res.status).toBe('healthy');
+    expect(res.statusChanged).toBe(false);
+    expect(new Date(res.lastHeartbeatAt).getTime()).toBeGreaterThanOrEqual(
+      new Date(registeredAt).getTime()
+    );
+  });
+
+  it('flips status back to healthy and reports statusChanged=true after an unavailable transition', async () => {
+    await registerFinance();
+
+    advance(UNAVAILABLE_AFTER_MS + 1_000);
+    runHeartbeatTick(coreDb.db);
+
+    const persisted = pillarRegistryService.getPillarRegistration(coreDb.db, 'finance');
+    expect(persisted?.status).toBe('unavailable');
+
+    advance(1_000);
+    const res = await caller().core.registry.heartbeat({ pillar: 'finance' });
+    if (!res.ok) throw new Error('expected ok=true');
+    expect(res.status).toBe('healthy');
+    expect(res.statusChanged).toBe(true);
+
+    const back = await caller().core.registry.get({ pillar: 'finance' });
+    expect(back?.status).toBe('healthy');
+  });
+
+  it('is idempotent under concurrent heartbeats — last write wins', async () => {
+    await registerFinance();
+    const c = caller();
+
+    const t1 = c.core.registry.heartbeat({ pillar: 'finance' });
+    const t2 = c.core.registry.heartbeat({ pillar: 'finance' });
+    const t3 = c.core.registry.heartbeat({ pillar: 'finance' });
+    const results = await Promise.all([t1, t2, t3]);
+
+    for (const r of results) {
+      if (!r.ok) throw new Error('expected ok=true');
+      expect(r.status).toBe('healthy');
+    }
+
+    const entry = await c.core.registry.get({ pillar: 'finance' });
+    expect(entry?.status).toBe('healthy');
+  });
+});
+
+describe('lazy snapshot compute on list / get (PRD-162 us-03)', () => {
+  it('reports unavailable on list() once age exceeds UNAVAILABLE_AFTER_MS, even before the ticker runs', async () => {
+    await registerFinance();
+    advance(UNAVAILABLE_AFTER_MS + 1);
+
+    const res = await caller().core.registry.list();
+    expect(res.pillars).toHaveLength(1);
+    expect(res.pillars[0]?.status).toBe('unavailable');
+
+    const persisted = pillarRegistryService.getPillarRegistration(coreDb.db, 'finance');
+    expect(persisted?.status).toBe('healthy');
+  });
+
+  it('boundary: exactly UNAVAILABLE_AFTER_MS old is unavailable (boundary owned by unavailable)', async () => {
+    await registerFinance();
+    advance(UNAVAILABLE_AFTER_MS);
+
+    const entry = await caller().core.registry.get({ pillar: 'finance' });
+    expect(entry?.status).toBe('unavailable');
+  });
+
+  it('clock skew (lastHeartbeatAt in the future) is treated as healthy', async () => {
+    await registerFinance();
+    clock.now = new Date(clock.now.getTime() - 60_000);
+
+    const entry = await caller().core.registry.get({ pillar: 'finance' });
+    expect(entry?.status).toBe('healthy');
+  });
+});
+
+describe('background reconciliation ticker (PRD-162 us-02)', () => {
+  it('emits a healthy → unavailable transition once the heartbeat age exceeds the threshold', async () => {
+    await registerFinance();
+    advance(UNAVAILABLE_AFTER_MS + 1);
+
+    const transitions: Array<{ pillarId: string; previousStatus: string; nextStatus: string }> = [];
+    const result = runHeartbeatTick(coreDb.db, {
+      onTransition: (t) => {
+        transitions.push(t);
+      },
+    });
+
+    expect(result).toHaveLength(1);
+    expect(transitions).toEqual([
+      expect.objectContaining({
+        pillarId: 'finance',
+        previousStatus: 'healthy',
+        nextStatus: 'unavailable',
+      }),
+    ]);
+
+    const persisted = pillarRegistryService.getPillarRegistration(coreDb.db, 'finance');
+    expect(persisted?.status).toBe('unavailable');
+    expect(persisted?.statusUpdatedAt).toBe(clock.now.toISOString());
+  });
+
+  it('does not emit a transition when no status changes', async () => {
+    await registerFinance();
+    advance(HEARTBEAT_INTERVAL_MS);
+
+    const transitions: unknown[] = [];
+    const result = runHeartbeatTick(coreDb.db, {
+      onTransition: (t) => transitions.push(t),
+    });
+
+    expect(result).toEqual([]);
+    expect(transitions).toEqual([]);
+  });
+
+  it('drives an unavailable → healthy transition after a heartbeat arrives', async () => {
+    await registerFinance();
+    advance(UNAVAILABLE_AFTER_MS + 1_000);
+    runHeartbeatTick(coreDb.db);
+
+    expect(pillarRegistryService.getPillarRegistration(coreDb.db, 'finance')?.status).toBe(
+      'unavailable'
+    );
+
+    advance(1_000);
+    const beat = await caller().core.registry.heartbeat({ pillar: 'finance' });
+    if (!beat.ok) throw new Error('expected ok=true');
+
+    advance(HEARTBEAT_INTERVAL_MS);
+    const transitions: Array<{ pillarId: string; nextStatus: string }> = [];
+    runHeartbeatTick(coreDb.db, {
+      onTransition: (t) => transitions.push({ pillarId: t.pillarId, nextStatus: t.nextStatus }),
+    });
+
+    expect(transitions).toEqual([]);
+    expect(pillarRegistryService.getPillarRegistration(coreDb.db, 'finance')?.status).toBe(
+      'healthy'
+    );
+  });
+
+  it('refreshes status_updated_at on healthy pillars once HEALTHY_STALENESS_REFRESH_MS has elapsed', async () => {
+    await registerFinance();
+    const before = pillarRegistryService.getPillarRegistration(coreDb.db, 'finance')!;
+
+    advance(HEALTHY_STALENESS_REFRESH_MS + 5_000);
+    pillarRegistryService.recordHeartbeat(coreDb.db, 'finance', { now: clock.now.toISOString() });
+
+    runHeartbeatTick(coreDb.db);
+
+    const after = pillarRegistryService.getPillarRegistration(coreDb.db, 'finance')!;
+    expect(after.status).toBe('healthy');
+    expect(after.statusUpdatedAt).not.toBe(before.statusUpdatedAt);
+    expect(after.statusUpdatedAt).toBe(clock.now.toISOString());
+  });
+
+  it('handles many pillars: one tick emits a transition per missed pillar', async () => {
+    await caller().core.registry.register({
+      baseUrl: 'http://finance-api:3004',
+      manifest: financeManifest(),
+    });
+    await caller().core.registry.register({
+      baseUrl: 'http://media-api:3006',
+      manifest: mediaManifest(),
+    });
+
+    advance(UNAVAILABLE_AFTER_MS + 1);
+
+    const transitions = runHeartbeatTick(coreDb.db);
+    expect(transitions.map((t) => t.pillarId).toSorted()).toEqual(['finance', 'media']);
+    for (const t of transitions) {
+      expect(t.previousStatus).toBe('healthy');
+      expect(t.nextStatus).toBe('unavailable');
+    }
+  });
+});

--- a/apps/pops-core-api/src/__tests__/registry-status.test.ts
+++ b/apps/pops-core-api/src/__tests__/registry-status.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Pure unit tests for `computeStatus` and clock injection (PRD-162 us-01, us-06).
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  HEARTBEAT_INTERVAL_MS,
+  MISS_THRESHOLD,
+  UNAVAILABLE_AFTER_MS,
+  computeStatus,
+  injectRegistryClock,
+  registryNow,
+  resetRegistryClock,
+} from '../modules/registry/status.js';
+
+describe('computeStatus', () => {
+  const base = new Date('2026-06-12T12:00:00.000Z');
+
+  it('treats a heartbeat at exactly NOW as healthy', () => {
+    expect(computeStatus(base, base)).toBe('healthy');
+  });
+
+  it('treats an age just under the threshold as healthy', () => {
+    const now = new Date(base.getTime() + UNAVAILABLE_AFTER_MS - 1);
+    expect(computeStatus(base, now)).toBe('healthy');
+  });
+
+  it('treats an age exactly at the threshold as unavailable (boundary owned by unavailable)', () => {
+    const now = new Date(base.getTime() + UNAVAILABLE_AFTER_MS);
+    expect(computeStatus(base, now)).toBe('unavailable');
+  });
+
+  it('treats negative ages (clock skew) as healthy', () => {
+    const now = new Date(base.getTime() - 60_000);
+    expect(computeStatus(base, now)).toBe('healthy');
+  });
+
+  it('exports the canonical 10s × 3 = 30s constants', () => {
+    expect(HEARTBEAT_INTERVAL_MS).toBe(10_000);
+    expect(MISS_THRESHOLD).toBe(3);
+    expect(UNAVAILABLE_AFTER_MS).toBe(30_000);
+  });
+});
+
+describe('registry clock injection', () => {
+  afterEach(() => {
+    resetRegistryClock();
+  });
+
+  it('uses the injected clock for registryNow()', () => {
+    const frozen = new Date('2030-01-01T00:00:00.000Z');
+    injectRegistryClock(() => frozen);
+    expect(registryNow().toISOString()).toBe(frozen.toISOString());
+  });
+
+  it('resets to real time when passed null', () => {
+    injectRegistryClock(() => new Date('2030-01-01T00:00:00.000Z'));
+    injectRegistryClock(null);
+    const drift = Math.abs(registryNow().getTime() - Date.now());
+    expect(drift).toBeLessThan(1_000);
+  });
+});

--- a/apps/pops-core-api/src/modules/registry/router.ts
+++ b/apps/pops-core-api/src/modules/registry/router.ts
@@ -1,10 +1,11 @@
 /**
- * `core.registry.*` tRPC router (Theme 13 PRD-161).
+ * `core.registry.*` tRPC router (Theme 13 PRD-161 + PRD-162).
  *
  * Wire surface for pillar registration + discovery on `pops-core-api`:
  *
  *   - `core.registry.register`   mutation  (internal-only, blocked at nginx)
  *   - `core.registry.deregister` mutation  (internal-only, blocked at nginx)
+ *   - `core.registry.heartbeat`  mutation  (internal-only, blocked at nginx)
  *   - `core.registry.list`       query     (public — used by the shell + SDK)
  *   - `core.registry.get`        query     (public — single lookup)
  *
@@ -14,20 +15,26 @@
  * discriminated result rather than throwing; the SDK boot path crashes
  * loudly with the per-field report (PRD-158).
  *
+ * Status reporting on `list`/`get` is computed live from
+ * `lastHeartbeatAt` via `computeStatus` (PRD-162) so consumers see the
+ * freshest possible state even if the background ticker is delayed.
+ *
  * Authentication: mutating procedures use `publicProcedure` because the
  * trust boundary is the nginx dispatcher (which 403s these paths from
  * external traffic). Inside the docker network, pillars POST directly.
- * Heartbeat (PRD-162) and subscription transport (PRD-163) are out of
- * scope for this PR.
+ * The subscription transport (PRD-163) is still out of scope here.
  */
 import { pillarRegistryService } from '@pops/core-db';
 import { validateManifestPayload } from '@pops/pillar-sdk';
 
 import { publicProcedure, router } from '../../trpc.js';
+import { computeStatus, registryNow } from './status.js';
 import {
   DeregisterInputSchema,
   DeregisterOutputSchema,
   GetInputSchema,
+  HeartbeatInputSchema,
+  HeartbeatOutputSchema,
   ListOutputSchema,
   RegisterInputSchema,
   RegisterOutputSchema,
@@ -35,9 +42,14 @@ import {
   type RegistryEntry,
 } from './types.js';
 
-import type { PillarRegistration } from '@pops/core-db';
+import type { PillarRegistration, PillarStatus } from '@pops/core-db';
 
-function toRegistryEntry(reg: PillarRegistration): RegistryEntry {
+function liveStatus(reg: PillarRegistration, now: Date): PillarStatus {
+  if (reg.status === 'unknown') return 'unknown';
+  return computeStatus(new Date(reg.lastHeartbeatAt), now);
+}
+
+function toRegistryEntry(reg: PillarRegistration, now: Date): RegistryEntry {
   const manifest = RegistryEntrySchema.shape.manifest.parse(reg.manifest);
   return {
     pillarId: reg.pillarId,
@@ -50,7 +62,7 @@ function toRegistryEntry(reg: PillarRegistration): RegistryEntry {
     },
     registeredAt: reg.registeredAt,
     lastHeartbeatAt: reg.lastHeartbeatAt,
-    status: reg.status,
+    status: liveStatus(reg, now),
     statusUpdatedAt: reg.statusUpdatedAt,
   };
 }
@@ -67,6 +79,7 @@ export const registryRouter = router({
       const persisted = pillarRegistryService.upsertPillarRegistration(ctx.coreDb, {
         baseUrl: input.baseUrl,
         manifest: result.payload,
+        now: registryNow().toISOString(),
       });
       return {
         ok: true as const,
@@ -83,11 +96,31 @@ export const registryRouter = router({
       return { ok: true as const, removed };
     }),
 
+  heartbeat: publicProcedure
+    .input(HeartbeatInputSchema)
+    .output(HeartbeatOutputSchema)
+    .mutation(({ input, ctx }) => {
+      const result = pillarRegistryService.recordHeartbeat(ctx.coreDb, input.pillar, {
+        now: registryNow().toISOString(),
+      });
+      if (!result.recorded || !result.registration) {
+        return { ok: false as const, reason: 'not-registered' as const };
+      }
+      return {
+        ok: true as const,
+        pillarId: result.registration.pillarId,
+        lastHeartbeatAt: result.registration.lastHeartbeatAt,
+        status: result.registration.status,
+        statusChanged: result.statusChanged,
+      };
+    }),
+
   list: publicProcedure.output(ListOutputSchema).query(({ ctx }) => {
+    const now = registryNow();
     const rows = pillarRegistryService.listPillarRegistrations(ctx.coreDb);
     return {
-      pillars: rows.map(toRegistryEntry),
-      fetchedAt: new Date().toISOString(),
+      pillars: rows.map((row) => toRegistryEntry(row, now)),
+      fetchedAt: now.toISOString(),
     };
   }),
 
@@ -96,6 +129,6 @@ export const registryRouter = router({
     .output(RegistryEntrySchema.nullable())
     .query(({ input, ctx }) => {
       const row = pillarRegistryService.getPillarRegistration(ctx.coreDb, input.pillar);
-      return row ? toRegistryEntry(row) : null;
+      return row ? toRegistryEntry(row, registryNow()) : null;
     }),
 });

--- a/apps/pops-core-api/src/modules/registry/status.ts
+++ b/apps/pops-core-api/src/modules/registry/status.ts
@@ -1,0 +1,51 @@
+/**
+ * Heartbeat-driven status computation for the pillar registry
+ * (Theme 13 PRD-162).
+ *
+ * The registry persists `lastHeartbeatAt` per pillar; the status column
+ * is a denormalised cache. Live status is recomputed from
+ * `lastHeartbeatAt` on every read (via `computeStatus`) so consumers
+ * always see fresh state — the persisted column drives only the
+ * background ticker's transition emission.
+ *
+ * Rules (per PRD spec):
+ *   - 3 missed heartbeats at the 10s SDK cadence ⇒ `unavailable`.
+ *   - Boundary (NOW − last == 30000ms) is owned by `unavailable`.
+ *   - Negative ages (pillar clock ahead of core-api) are treated as
+ *     `healthy` — defensive, but the docker network keeps clocks tight.
+ */
+
+export const HEARTBEAT_INTERVAL_MS = 10_000;
+export const MISS_THRESHOLD = 3;
+export const UNAVAILABLE_AFTER_MS = HEARTBEAT_INTERVAL_MS * MISS_THRESHOLD;
+
+export const HEALTHY_STALENESS_REFRESH_MS = 60_000;
+
+export type LivePillarStatus = 'healthy' | 'unavailable';
+
+export function computeStatus(lastHeartbeatAt: Date, now: Date): LivePillarStatus {
+  const ageMs = now.getTime() - lastHeartbeatAt.getTime();
+  return ageMs < UNAVAILABLE_AFTER_MS ? 'healthy' : 'unavailable';
+}
+
+/**
+ * Test seam: `injectRegistryClock(() => fixedDate)` overrides the
+ * default `() => new Date()` reference used by the ticker and router.
+ * Tests advance simulated time without waiting on real intervals.
+ *
+ * Pass `null` (or call `resetRegistryClock`) to restore the default.
+ */
+type Clock = () => Date;
+let currentClock: Clock = () => new Date();
+
+export function injectRegistryClock(clock: Clock | null): void {
+  currentClock = clock ?? (() => new Date());
+}
+
+export function resetRegistryClock(): void {
+  currentClock = () => new Date();
+}
+
+export function registryNow(): Date {
+  return currentClock();
+}

--- a/apps/pops-core-api/src/modules/registry/ticker.ts
+++ b/apps/pops-core-api/src/modules/registry/ticker.ts
@@ -1,0 +1,129 @@
+/**
+ * Background status-reconciliation ticker for the pillar registry
+ * (Theme 13 PRD-162).
+ *
+ * Runs every `HEARTBEAT_INTERVAL_MS` (10s by default) inside core-api.
+ * On each pass:
+ *   1. Read every row in `pillar_registry`.
+ *   2. For each row, compute live status from `lastHeartbeatAt`.
+ *   3. Apply transitions (status differs from persisted) inside a
+ *      single SQLite transaction. Each transition stamps
+ *      `statusUpdatedAt = now`.
+ *   4. Healthy-staleness refresh: persisted `healthy` rows whose
+ *      `statusUpdatedAt` is older than `HEALTHY_STALENESS_REFRESH_MS`
+ *      get their `statusUpdatedAt` bumped to `now` so the timestamp
+ *      reflects "still alive as of this moment" (used by PRD-164's
+ *      restart reconciliation).
+ *
+ * Errors are logged and the next tick runs normally — no backoff. The
+ * lazy compute path inside the router is the authoritative status for
+ * snapshot reads, so a delayed tick only delays event emission.
+ *
+ * Subscription events (PRD-163) are not yet wired up. Transitions are
+ * delivered through the optional `onTransition` callback so the
+ * subscription layer can plug in without touching this file.
+ */
+import {
+  pillarRegistryService,
+  type ApplyStatusUpdate,
+  type CoreDb,
+  type PillarRegistration,
+  type StatusTransition,
+} from '@pops/core-db';
+
+import {
+  HEALTHY_STALENESS_REFRESH_MS,
+  HEARTBEAT_INTERVAL_MS,
+  computeStatus,
+  registryNow,
+} from './status.js';
+
+export interface HeartbeatTickerOptions {
+  readonly intervalMs?: number;
+  readonly onTransition?: (transition: StatusTransition) => void;
+  readonly onError?: (error: unknown) => void;
+}
+
+export type StopTicker = () => void;
+
+/**
+ * Run a single reconciliation pass synchronously. Exported for tests
+ * so they can drive the ticker deterministically without setInterval.
+ *
+ * Returns the transitions that were persisted (so tests can assert on
+ * counts without subscribing to `onTransition`).
+ */
+export function runHeartbeatTick(
+  db: CoreDb,
+  options?: { now?: Date; onTransition?: (transition: StatusTransition) => void }
+): readonly StatusTransition[] {
+  const now = options?.now ?? registryNow();
+  const nowIso = now.toISOString();
+  const rows = pillarRegistryService.listPillarRegistrations(db);
+
+  const updates: ApplyStatusUpdate[] = [];
+  const transitions: StatusTransition[] = [];
+
+  for (const row of rows) {
+    const computed = computeStatus(parseHeartbeat(row), now);
+    if (computed !== row.status) {
+      updates.push({
+        pillarId: row.pillarId,
+        status: computed,
+        statusUpdatedAt: nowIso,
+      });
+      transitions.push({
+        pillarId: row.pillarId,
+        previousStatus: row.status,
+        nextStatus: computed,
+        at: nowIso,
+      });
+      continue;
+    }
+    if (
+      row.status === 'healthy' &&
+      now.getTime() - Date.parse(row.statusUpdatedAt) > HEALTHY_STALENESS_REFRESH_MS
+    ) {
+      updates.push({
+        pillarId: row.pillarId,
+        status: row.status,
+        statusUpdatedAt: nowIso,
+      });
+    }
+  }
+
+  pillarRegistryService.applyStatusUpdates(db, updates);
+
+  if (options?.onTransition) {
+    for (const transition of transitions) {
+      options.onTransition(transition);
+    }
+  }
+  return transitions;
+}
+
+function parseHeartbeat(row: PillarRegistration): Date {
+  return new Date(row.lastHeartbeatAt);
+}
+
+/**
+ * Start the periodic ticker. Returns a stop function suitable for
+ * SIGTERM wiring. The first tick runs after `intervalMs`; tests that
+ * want a synchronous pass call `runHeartbeatTick` directly.
+ */
+export function startHeartbeatTicker(db: CoreDb, options?: HeartbeatTickerOptions): StopTicker {
+  const intervalMs = options?.intervalMs ?? HEARTBEAT_INTERVAL_MS;
+  const handle = setInterval(() => {
+    try {
+      runHeartbeatTick(db, { onTransition: options?.onTransition });
+    } catch (error) {
+      if (options?.onError) {
+        options.onError(error);
+      } else {
+        console.error('[core-api] heartbeat ticker error', error);
+      }
+    }
+  }, intervalMs);
+  if (typeof handle.unref === 'function') handle.unref();
+  return () => clearInterval(handle);
+}

--- a/apps/pops-core-api/src/modules/registry/types.ts
+++ b/apps/pops-core-api/src/modules/registry/types.ts
@@ -75,3 +75,29 @@ export const ListOutputSchema = z.object({
   pillars: z.array(RegistryEntrySchema),
   fetchedAt: z.string(),
 });
+
+/**
+ * Heartbeat wire shapes (Theme 13 PRD-162).
+ *
+ * Pillars POST `core.registry.heartbeat({ pillar })` every
+ * `HEARTBEAT_INTERVAL_MS` (≈10s). The output is a discriminated union:
+ *   - `ok: true`  — the heartbeat was recorded; status now `healthy`.
+ *   - `ok: false` — the pillar is not registered; SDK should re-register.
+ */
+export const HeartbeatInputSchema = z.object({
+  pillar: z.string().min(1),
+});
+
+export const HeartbeatOutputSchema = z.discriminatedUnion('ok', [
+  z.object({
+    ok: z.literal(true),
+    pillarId: z.string(),
+    lastHeartbeatAt: z.string(),
+    status: PillarStatusSchema,
+    statusChanged: z.boolean(),
+  }),
+  z.object({
+    ok: z.literal(false),
+    reason: z.literal('not-registered'),
+  }),
+]);

--- a/apps/pops-core-api/src/server.ts
+++ b/apps/pops-core-api/src/server.ts
@@ -14,6 +14,7 @@ import { openCoreDb } from '@pops/core-db';
 
 import { createCoreApiApp } from './app.js';
 import { resolveCoreSqlitePath } from './core-sqlite-path.js';
+import { startHeartbeatTicker } from './modules/registry/ticker.js';
 import { parseBareOrigin } from './pillars/env.js';
 
 function resolvePort(): number {
@@ -44,11 +45,14 @@ const server = app.listen(port, () => {
   console.warn(`[core-api] Listening on port ${port}`);
 });
 
+const stopHeartbeatTicker = startHeartbeatTicker(coreDb.db);
+
 let shuttingDown = false;
 function shutdown(signal: NodeJS.Signals): void {
   if (shuttingDown) return;
   shuttingDown = true;
   console.warn(`[core-api] Shutting down (${signal})`);
+  stopHeartbeatTicker();
   server.close(() => {
     coreDb.raw.close();
   });

--- a/packages/core-db/src/__tests__/pillar-registry.test.ts
+++ b/packages/core-db/src/__tests__/pillar-registry.test.ts
@@ -11,9 +11,11 @@ import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import {
+  applyStatusUpdates,
   deletePillarRegistration,
   getPillarRegistration,
   listPillarRegistrations,
+  recordHeartbeat,
   upsertPillarRegistration,
   type PersistableManifest,
 } from '../services/pillar-registry.js';
@@ -193,5 +195,102 @@ describe('deletePillarRegistration', () => {
       now: second,
     });
     expect(reg.registeredAt).toBe(second);
+  });
+});
+
+describe('recordHeartbeat', () => {
+  let db: CoreDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('returns recorded=false for an unknown pillar (does NOT auto-create rows)', () => {
+    const result = recordHeartbeat(db, 'finance', { now: '2026-06-12T12:00:00.000Z' });
+    expect(result.recorded).toBe(false);
+    expect(result.registration).toBeNull();
+    expect(getPillarRegistration(db, 'finance')).toBeNull();
+  });
+
+  it('refreshes lastHeartbeatAt and leaves status_updated_at alone when already healthy', () => {
+    const registeredAt = '2026-06-12T12:00:00.000Z';
+    upsertPillarRegistration(db, {
+      baseUrl: 'http://finance-api:3004',
+      manifest: financeManifest(),
+      now: registeredAt,
+    });
+    const beat = '2026-06-12T12:00:10.000Z';
+    const result = recordHeartbeat(db, 'finance', { now: beat });
+    expect(result.recorded).toBe(true);
+    expect(result.previousStatus).toBe('healthy');
+    expect(result.statusChanged).toBe(false);
+    expect(result.registration?.lastHeartbeatAt).toBe(beat);
+    expect(result.registration?.statusUpdatedAt).toBe(registeredAt);
+  });
+
+  it('flips status back to healthy when previously unavailable, stamping status_updated_at', () => {
+    const registeredAt = '2026-06-12T12:00:00.000Z';
+    upsertPillarRegistration(db, {
+      baseUrl: 'http://finance-api:3004',
+      manifest: financeManifest(),
+      now: registeredAt,
+    });
+    applyStatusUpdates(db, [
+      { pillarId: 'finance', status: 'unavailable', statusUpdatedAt: '2026-06-12T12:00:30.000Z' },
+    ]);
+    expect(getPillarRegistration(db, 'finance')?.status).toBe('unavailable');
+
+    const beat = '2026-06-12T12:00:35.000Z';
+    const result = recordHeartbeat(db, 'finance', { now: beat });
+    expect(result.statusChanged).toBe(true);
+    expect(result.previousStatus).toBe('unavailable');
+    expect(result.registration?.status).toBe('healthy');
+    expect(result.registration?.statusUpdatedAt).toBe(beat);
+    expect(result.registration?.lastHeartbeatAt).toBe(beat);
+  });
+});
+
+describe('applyStatusUpdates', () => {
+  let db: CoreDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('is a no-op when given an empty list', () => {
+    expect(() => applyStatusUpdates(db, [])).not.toThrow();
+  });
+
+  it('writes one status row per update inside a single transaction', () => {
+    upsertPillarRegistration(db, {
+      baseUrl: 'http://finance-api:3004',
+      manifest: financeManifest(),
+      now: '2026-06-12T12:00:00.000Z',
+    });
+    upsertPillarRegistration(db, {
+      baseUrl: 'http://media-api:3006',
+      manifest: mediaManifest(),
+      now: '2026-06-12T12:00:00.000Z',
+    });
+    const now = '2026-06-12T12:00:30.000Z';
+    applyStatusUpdates(db, [
+      { pillarId: 'finance', status: 'unavailable', statusUpdatedAt: now },
+      { pillarId: 'media', status: 'unavailable', statusUpdatedAt: now },
+    ]);
+    expect(getPillarRegistration(db, 'finance')?.status).toBe('unavailable');
+    expect(getPillarRegistration(db, 'media')?.status).toBe('unavailable');
+  });
+
+  it('silently skips updates that target an unknown pillar', () => {
+    upsertPillarRegistration(db, {
+      baseUrl: 'http://finance-api:3004',
+      manifest: financeManifest(),
+      now: '2026-06-12T12:00:00.000Z',
+    });
+    expect(() =>
+      applyStatusUpdates(db, [
+        { pillarId: 'ghost', status: 'unavailable', statusUpdatedAt: '2026-06-12T12:00:30.000Z' },
+      ])
+    ).not.toThrow();
+    expect(getPillarRegistration(db, 'ghost')).toBeNull();
+    expect(getPillarRegistration(db, 'finance')?.status).toBe('healthy');
   });
 });

--- a/packages/core-db/src/index.ts
+++ b/packages/core-db/src/index.ts
@@ -22,9 +22,12 @@ export * as serviceAccountKeys from './services/service-account-keys.js';
 export * as pillarRegistryService from './services/pillar-registry.js';
 
 export type {
+  ApplyStatusUpdate,
+  HeartbeatResult,
   PersistableManifest,
   PillarRegistration,
   PillarStatus,
+  StatusTransition,
   UpsertPillarRegistrationInput,
 } from './services/pillar-registry.js';
 

--- a/packages/core-db/src/services/pillar-registry.ts
+++ b/packages/core-db/src/services/pillar-registry.ts
@@ -168,3 +168,88 @@ export function deletePillarRegistration(db: CoreDb, pillarId: string): boolean 
   const result = db.delete(pillarRegistry).where(eq(pillarRegistry.pillarId, pillarId)).run();
   return result.changes > 0;
 }
+
+export interface HeartbeatResult {
+  readonly recorded: boolean;
+  readonly registration: PillarRegistration | null;
+  readonly previousStatus: PillarStatus | null;
+  readonly statusChanged: boolean;
+}
+
+/**
+ * Idempotent heartbeat ingest (Theme 13 PRD-162).
+ *
+ * Updates `lastHeartbeatAt = now` and resets `status = 'healthy'` for
+ * the addressed pillar. Returns `recorded: false` if the pillar is not
+ * registered (cold registry, restart, deregistered). The router treats
+ * that as a soft signal — pillars retry on the next tick.
+ *
+ * `statusChanged` is true when this heartbeat flipped the persisted
+ * status (e.g. `unavailable → healthy`). `statusUpdatedAt` is rewritten
+ * only on a transition; a healthy-to-healthy heartbeat leaves it as is.
+ * The background ticker handles the healthy-staleness refresh.
+ */
+export function recordHeartbeat(
+  db: CoreDb,
+  pillarId: string,
+  options?: { now?: string }
+): HeartbeatResult {
+  const existing = getPillarRegistration(db, pillarId);
+  if (!existing) {
+    return { recorded: false, registration: null, previousStatus: null, statusChanged: false };
+  }
+  const now = options?.now ?? new Date().toISOString();
+  const previousStatus = existing.status;
+  const statusChanged = previousStatus !== 'healthy';
+
+  db.update(pillarRegistry)
+    .set({
+      lastHeartbeatAt: now,
+      status: 'healthy',
+      ...(statusChanged ? { statusUpdatedAt: now } : {}),
+    })
+    .where(eq(pillarRegistry.pillarId, pillarId))
+    .run();
+
+  const updated = getPillarRegistration(db, pillarId);
+  return {
+    recorded: true,
+    registration: updated,
+    previousStatus,
+    statusChanged,
+  };
+}
+
+export interface StatusTransition {
+  readonly pillarId: string;
+  readonly previousStatus: PillarStatus;
+  readonly nextStatus: PillarStatus;
+  readonly at: string;
+}
+
+export interface ApplyStatusUpdate {
+  readonly pillarId: string;
+  readonly status: PillarStatus;
+  readonly statusUpdatedAt: string;
+}
+
+/**
+ * Persist a batch of status updates emitted by the background ticker
+ * (Theme 13 PRD-162). One UPDATE per row, all inside a single SQLite
+ * transaction so a tick is atomic relative to concurrent heartbeats /
+ * registrations.
+ */
+export function applyStatusUpdates(db: CoreDb, updates: readonly ApplyStatusUpdate[]): void {
+  if (updates.length === 0) return;
+  db.transaction((tx) => {
+    for (const update of updates) {
+      tx.update(pillarRegistry)
+        .set({
+          status: update.status,
+          statusUpdatedAt: update.statusUpdatedAt,
+        })
+        .where(eq(pillarRegistry.pillarId, update.pillarId))
+        .run();
+    }
+  });
+}

--- a/packages/core-db/src/services/pillar-registry.ts
+++ b/packages/core-db/src/services/pillar-registry.ts
@@ -11,9 +11,12 @@
  * else (manifest blob, contract metadata, heartbeat, status) is
  * overwritten on every register.
  *
- * Heartbeat lifecycle and missed-heartbeat status transitions are out
- * of scope (PRD-162); this service only ships the persistence + read
- * path.
+ * `recordHeartbeat` updates `lastHeartbeatAt` and resets `status` →
+ * `healthy`; `applyStatusUpdates` lets the registry's reconciliation
+ * tick (PRD-162) batch transition pillars to `unavailable` once their
+ * heartbeat has lapsed past threshold. The "should this pillar still
+ * be healthy?" decision lives in the router (`computeStatus`), not in
+ * this service — keeping the persistence layer agnostic.
  */
 import { eq, sql } from 'drizzle-orm';
 


### PR DESCRIPTION
## Summary

Theme 13 PRD-162 — registry-side heartbeat lifecycle. Builds on top of PRD-161 (#2951, this branch is stacked on `feat/theme13-prd-161-registry-endpoints` until that lands).

- Adds `core.registry.heartbeat({ pillar })` mutation. Returns a discriminated `{ ok: true, pillarId, lastHeartbeatAt, status, statusChanged }` on success; `{ ok: false, reason: 'not-registered' }` when the pillar is unknown so the SDK can re-register.
- New service helpers in `@pops/core-db/pillarRegistryService`: `recordHeartbeat` (idempotent UPDATE of `last_heartbeat_at`, flips status back to `healthy`, only stamps `status_updated_at` on transition) and `applyStatusUpdates` (single-tx batch writer used by the ticker).
- `apps/pops-core-api/src/modules/registry/status.ts` — pure `computeStatus(lastHeartbeatAt, now)` + the 10s × 3 = 30s constants + a clock-injection seam for tests.
- `apps/pops-core-api/src/modules/registry/ticker.ts` — hybrid reconciliation: `list`/`get` recompute status live (source of truth for snapshot reads), and a 10s background ticker walks the registry, persists transitions, optionally emits `StatusTransition` events through an `onTransition` callback (PRD-163 plug point), and refreshes `status_updated_at` on healthy rows once it goes stale past 60s.
- Wired into `server.ts` boot/SIGTERM. The interval is `unref`'d so it does not pin the event loop in tests/dev.

## Reconciliation approach: hybrid (lazy compute + background ticker)

Per PRD spec. The router's `list`/`get` compute status live from `last_heartbeat_at` on every read, so consumers always see the freshest possible state even if the ticker is delayed. The ticker persists transitions so the future subscription transport (PRD-163) can emit them, and so reconciliation on restart (PRD-164) has a `status_updated_at` baseline that's no older than ~60s on healthy rows.

Why not on-read only: subscription events (PRD-163) need a single canonical emission point — the ticker — and PRD-164's restart reconciliation needs `status_updated_at` to actually move. Why not background only: the ticker can lag under GC/load; consumers must never see stale status for longer than a single SQLite read.

## Test plan

54 tests pass in `apps/pops-core-api`, 19 (incl. new ones) in `packages/core-db`.

- [x] `pnpm --filter @pops/core-api test`
- [x] `pnpm --filter @pops/core-db test:coverage` (93.7% lines)
- [x] `pnpm typecheck` (whole repo, 55 packages green)
- [x] `pnpm lint` — no new errors; one warning I introduced (sort vs toSorted) fixed before commit
- [x] `pnpm lint:boundaries` — no violations

Notable cases covered: heartbeat updates timestamp; healthy→unavailable via missed-tick reconciliation; unavailable→healthy via heartbeat (with `statusChanged=true`); concurrent heartbeats are idempotent; lazy snapshot returns `unavailable` even when persisted status is still `healthy`; threshold boundary owned by `unavailable`; clock-skew negative ages are healthy; many-pillars transition burst in a single tick; healthy-staleness 60s refresh.