### PR TITLE
feat(pillar-sdk): discovery client (Theme 13 PRD-159)

### DIFF
--- a/docs/themes/13-pillar-finale/epics/01-pillar-sdk.md
+++ b/docs/themes/13-pillar-finale/epics/01-pillar-sdk.md
@@ -19,7 +19,7 @@ Goal: a pillar's `server.ts` becomes ~20 lines of `bootstrapPillar(manifest, app
 | --- | ------------------------------- | ------------------------------------------------------------------------------------------------- | ----------- |
 | 157 | Manifest schema + Zod validator | Define the manifest shape, validate at boot, surface errors clearly                               | Not started |
 | 158 | `bootstrapPillar()` boot helper | One-call pillar bootstrap with DB open, migrations, route mount, registry registration, heartbeat | Not started |
-| 159 | Discovery client                | Server-side `lookupPillar()`, `pillarRegistry()` with caching + invalidation                      | Not started |
+| 159 | Discovery client                | Server-side `lookupPillar()`, `pillarRegistry()` with caching + invalidation                      | Done        |
 | 160 | Capability projection types     | Type-level transforms from manifest → "what callers can invoke"                                   | Not started |
 
 PRDs run mostly in parallel after 157 (manifest schema is the contract everything depends on).

--- a/packages/pillar-sdk/package.json
+++ b/packages/pillar-sdk/package.json
@@ -22,6 +22,14 @@
       "types": "./dist/client/index.d.ts",
       "default": "./dist/client/index.js"
     },
+    "./discovery": {
+      "types": "./dist/discovery/index.d.ts",
+      "default": "./dist/discovery/index.js"
+    },
+    "./testing/discovery": {
+      "types": "./dist/testing/index.d.ts",
+      "default": "./dist/testing/index.js"
+    },
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/packages/pillar-sdk/src/discovery/__tests__/cache.test.ts
+++ b/packages/pillar-sdk/src/discovery/__tests__/cache.test.ts
@@ -1,0 +1,245 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { lookupPillar, pillarRegistry } from '../api.js';
+import {
+  configureCache,
+  disposeDiscoveryClient,
+  invalidateRegistryCache,
+  type RegistryFetcher,
+} from '../cache.js';
+import { RegistryUnreachableError } from '../types.js';
+import { fetchResult, pillar } from './fixtures.js';
+
+type ScheduledEntry = { cb: () => void; runAt: number; cancelled: boolean };
+
+type FakeClock = {
+  now: () => number;
+  advance(ms: number): void;
+  scheduled: ScheduledEntry[];
+  set(cb: () => void, ms: number): ScheduledEntry;
+  clear(handle: unknown): void;
+};
+
+function fakeClock(start = 1_700_000_000_000): FakeClock {
+  let current = start;
+  const scheduled: FakeClock['scheduled'] = [];
+
+  function set(cb: () => void, ms: number): ScheduledEntry {
+    const entry: ScheduledEntry = { cb, runAt: current + ms, cancelled: false };
+    scheduled.push(entry);
+    return entry;
+  }
+
+  function clear(handle: unknown): void {
+    if (handle === null || handle === undefined) return;
+    if (typeof handle === 'object' && 'cancelled' in handle) {
+      (handle as ScheduledEntry).cancelled = true;
+    }
+  }
+
+  function advance(ms: number): void {
+    const target = current + ms;
+    let progressed = true;
+    while (progressed) {
+      progressed = false;
+      for (const entry of scheduled) {
+        if (entry.cancelled) continue;
+        if (entry.runAt > target) continue;
+        entry.cancelled = true;
+        current = entry.runAt;
+        entry.cb();
+        progressed = true;
+      }
+    }
+    current = target;
+  }
+
+  return {
+    now: () => current,
+    advance,
+    scheduled,
+    set,
+    clear,
+  };
+}
+
+describe('discovery cache singleton', () => {
+  let clock: FakeClock;
+  let warnings: Array<{ message: string; context: Record<string, unknown> }>;
+
+  beforeEach(() => {
+    clock = fakeClock();
+    warnings = [];
+    configureCache({
+      registryUrl: 'http://core-api:3001',
+      ttlMs: 30_000,
+      now: clock.now,
+      setTimeoutImpl: clock.set,
+      clearTimeoutImpl: clock.clear,
+      onWarn: (message, context) => warnings.push({ message, context }),
+    });
+  });
+
+  afterEach(() => {
+    disposeDiscoveryClient();
+  });
+
+  function withFetcher(fetcher: RegistryFetcher): void {
+    configureCache({
+      registryUrl: 'http://core-api:3001',
+      ttlMs: 30_000,
+      now: clock.now,
+      setTimeoutImpl: clock.set,
+      clearTimeoutImpl: clock.clear,
+      onWarn: (message, context) => warnings.push({ message, context }),
+      fetcher,
+    });
+  }
+
+  it('throws RegistryUnreachableError when the first fetch fails with an empty cache', async () => {
+    const fetcher = vi.fn().mockRejectedValue(new Error('econnrefused'));
+    withFetcher(fetcher);
+
+    await expect(lookupPillar('finance')).rejects.toBeInstanceOf(RegistryUnreachableError);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns undefined when the pillar is missing from a fresh snapshot', async () => {
+    withFetcher(async () => fetchResult(pillar('finance', 'http://finance-api:3004')));
+    const result = await lookupPillar('media');
+    expect(result).toBeUndefined();
+  });
+
+  it('serves a cached snapshot on the second call within TTL', async () => {
+    const fetcher = vi
+      .fn()
+      .mockResolvedValue(fetchResult(pillar('finance', 'http://finance-api:3004')));
+    withFetcher(fetcher);
+
+    const first = await pillarRegistry();
+    expect(first.source).toBe('fresh');
+
+    clock.advance(1_000);
+
+    const second = await pillarRegistry();
+    expect(second.source).toBe('cached');
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it('refreshes the cache when TTL has expired (background refresh transparently updates baseUrl)', async () => {
+    let callCount = 0;
+    withFetcher(async () => {
+      callCount += 1;
+      return fetchResult(pillar('finance', `http://finance-api:300${callCount}`));
+    });
+
+    const first = await pillarRegistry();
+    expect(first.pillars[0]!.baseUrl).toBe('http://finance-api:3001');
+    expect(first.source).toBe('fresh');
+
+    clock.advance(40_000);
+
+    const second = await pillarRegistry();
+    expect(second.pillars[0]!.baseUrl).toBe('http://finance-api:3002');
+    expect(callCount).toBe(2);
+  });
+
+  it('dedupes concurrent fetches: two awaits share one HTTP call', async () => {
+    let resolve!: (value: ReturnType<typeof fetchResult>) => void;
+    const fetcher = vi.fn().mockImplementation(
+      () =>
+        new Promise((res) => {
+          resolve = res;
+        })
+    );
+    withFetcher(fetcher);
+
+    const a = lookupPillar('finance');
+    const b = lookupPillar('media');
+    expect(fetcher).toHaveBeenCalledTimes(1);
+
+    resolve(
+      fetchResult(pillar('finance', 'http://finance-api:3004'), pillar('media', 'http://media:3'))
+    );
+
+    const [aResult, bResult] = await Promise.all([a, b]);
+    expect(aResult?.pillarId).toBe('finance');
+    expect(bResult?.pillarId).toBe('media');
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it('serves stale-fallback when a background refresh fails after a successful fetch', async () => {
+    let calls = 0;
+    withFetcher(async () => {
+      calls += 1;
+      if (calls === 1) {
+        return fetchResult(pillar('finance', 'http://finance-api:3004'));
+      }
+      throw new Error('connection reset');
+    });
+
+    const first = await pillarRegistry();
+    expect(first.source).toBe('fresh');
+
+    clock.advance(40_000);
+
+    const second = await pillarRegistry();
+    expect(second.source).toBe('stale-fallback');
+    expect(second.pillars[0]!.pillarId).toBe('finance');
+    expect(warnings.some((w) => w.message.includes('stale cache'))).toBe(true);
+    expect(warnings[0]!.context['consecutiveFailures']).toBeGreaterThanOrEqual(1);
+  });
+
+  it('background timer fires automatically before TTL expiry', async () => {
+    let calls = 0;
+    withFetcher(async () => {
+      calls += 1;
+      return fetchResult(pillar('finance', `http://finance-api:300${calls}`));
+    });
+
+    await pillarRegistry();
+    expect(calls).toBe(1);
+
+    clock.advance(29_500);
+    await pillarRegistry();
+    expect(calls).toBe(2);
+
+    clock.advance(1_000);
+
+    const next = await pillarRegistry();
+    expect(next.source).toBe('cached');
+    expect(next.pillars[0]!.baseUrl).toBe('http://finance-api:3002');
+  });
+
+  it('invalidateRegistryCache() forces a refetch on the next call', async () => {
+    const fetcher = vi
+      .fn()
+      .mockResolvedValue(fetchResult(pillar('finance', 'http://finance-api:3004')));
+    withFetcher(fetcher);
+
+    await pillarRegistry();
+    expect(fetcher).toHaveBeenCalledTimes(1);
+
+    invalidateRegistryCache();
+
+    const result = await pillarRegistry();
+    expect(result.source).toBe('fresh');
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it('disposeDiscoveryClient() cancels the background timer', async () => {
+    let calls = 0;
+    withFetcher(async () => {
+      calls += 1;
+      return fetchResult(pillar('finance', 'http://finance-api:3004'));
+    });
+
+    await pillarRegistry();
+    expect(calls).toBe(1);
+
+    disposeDiscoveryClient();
+
+    clock.advance(60_000);
+    expect(calls).toBe(1);
+  });
+});

--- a/packages/pillar-sdk/src/discovery/__tests__/fetcher.test.ts
+++ b/packages/pillar-sdk/src/discovery/__tests__/fetcher.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { fetchRegistrySnapshot } from '../fetcher.js';
+import { jsonResponse, pillar, wirePayload } from './fixtures.js';
+
+describe('fetchRegistrySnapshot', () => {
+  it('parses a healthy tRPC envelope into PillarSnapshots', async () => {
+    const fin = pillar('finance', 'http://finance-api:3004');
+    const media = pillar('media', 'http://media-api:3005');
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(wirePayload(fin, media)));
+
+    const result = await fetchRegistrySnapshot({
+      registryUrl: 'http://core-api:3001',
+      fetchImpl,
+    });
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'http://core-api:3001/trpc/core.registry.snapshot',
+      expect.objectContaining({ method: 'GET' })
+    );
+    expect(result.pillars).toHaveLength(2);
+    expect(result.pillars[0]!.pillarId).toBe('finance');
+    expect(result.pillars[0]!.lastSeenAt).toBeInstanceOf(Date);
+    expect(result.pillars[1]!.pillarId).toBe('media');
+  });
+
+  it('also accepts an un-enveloped payload (raw shape)', async () => {
+    const fin = pillar('finance', 'http://finance-api:3004');
+    const raw = {
+      pillars: [
+        {
+          pillarId: fin.pillarId,
+          baseUrl: fin.baseUrl,
+          manifest: fin.manifest,
+          lastSeenAt: fin.lastSeenAt.toISOString(),
+          status: 'healthy',
+        },
+      ],
+    };
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(raw));
+
+    const result = await fetchRegistrySnapshot({
+      registryUrl: 'http://core-api:3001',
+      fetchImpl,
+    });
+
+    expect(result.pillars).toHaveLength(1);
+  });
+
+  it('strips a trailing slash from the registry URL', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(wirePayload()));
+    await fetchRegistrySnapshot({
+      registryUrl: 'http://core-api:3001/',
+      fetchImpl,
+    });
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'http://core-api:3001/trpc/core.registry.snapshot',
+      expect.anything()
+    );
+  });
+
+  it('throws on non-2xx', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(new Response('boom', { status: 503, statusText: 'Service Unavailable' }));
+    await expect(
+      fetchRegistrySnapshot({ registryUrl: 'http://core-api:3001', fetchImpl })
+    ).rejects.toThrow(/HTTP 503/);
+  });
+
+  it('throws on malformed JSON', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response('not-json', {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+    await expect(
+      fetchRegistrySnapshot({ registryUrl: 'http://core-api:3001', fetchImpl })
+    ).rejects.toThrow(/malformed JSON/);
+  });
+
+  it('throws on schema-invalid response (missing pillarId)', async () => {
+    const bad = {
+      result: {
+        data: {
+          pillars: [
+            {
+              baseUrl: 'http://x:1',
+              manifest: pillar('finance', 'http://x:1').manifest,
+              lastSeenAt: new Date().toISOString(),
+            },
+          ],
+        },
+      },
+    };
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(bad));
+    await expect(
+      fetchRegistrySnapshot({ registryUrl: 'http://core-api:3001', fetchImpl })
+    ).rejects.toBeTruthy();
+  });
+
+  it('aborts the request when the timeout fires', async () => {
+    const fetchImpl = vi.fn().mockImplementation(
+      (_url: string, init: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init.signal?.addEventListener('abort', () => {
+            const reason = init.signal?.reason;
+            reject(reason instanceof Error ? reason : new Error('aborted'));
+          });
+        })
+    );
+
+    await expect(
+      fetchRegistrySnapshot({
+        registryUrl: 'http://core-api:3001',
+        fetchImpl,
+        timeoutMs: 5,
+      })
+    ).rejects.toThrow(/timeout/);
+  });
+
+  it('marks registered=false when status is "unknown" and the field is absent', async () => {
+    const fin = pillar('finance', 'http://finance-api:3004');
+    const raw = {
+      pillars: [
+        {
+          pillarId: fin.pillarId,
+          baseUrl: fin.baseUrl,
+          manifest: fin.manifest,
+          lastSeenAt: fin.lastSeenAt.toISOString(),
+          status: 'unknown',
+        },
+      ],
+    };
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(raw));
+    const result = await fetchRegistrySnapshot({
+      registryUrl: 'http://core-api:3001',
+      fetchImpl,
+    });
+    expect(result.pillars[0]!.registered).toBe(false);
+  });
+});

--- a/packages/pillar-sdk/src/discovery/__tests__/fixtures.ts
+++ b/packages/pillar-sdk/src/discovery/__tests__/fixtures.ts
@@ -1,0 +1,65 @@
+import { validManifest } from '../../__tests__/fixtures.js';
+
+import type { RegistryFetchResult } from '../fetcher.js';
+import type { PillarSnapshot } from '../types.js';
+
+export function pillar(id: string, baseUrl: string, lastSeenAt = new Date()): PillarSnapshot {
+  const base = validManifest();
+  const manifest = {
+    ...base,
+    pillar: id,
+    contract: {
+      ...base.contract,
+      package: `@pops/${id}-contract`,
+      tag: `contract-${id}@v${base.contract.version}`,
+    },
+    routes: {
+      queries: [`${id}.routerA.list`],
+      mutations: [`${id}.routerA.create`],
+      subscriptions: [],
+    },
+    uri: { types: [`${id}/entity`] },
+    settings: { keys: [`${id}.defaultThing`] },
+  };
+  return {
+    pillarId: id,
+    baseUrl,
+    manifest,
+    registered: true,
+    lastSeenAt,
+  };
+}
+
+export function fetchResult(...pillars: PillarSnapshot[]): RegistryFetchResult {
+  return { pillars, fetchedAt: new Date() };
+}
+
+/**
+ * Build the registry-side wire payload as PRD-161 emits it from
+ * `core.registry.snapshot`. Tests that exercise the HTTP fetcher use
+ * this to round-trip the schema.
+ */
+export function wirePayload(...pillars: PillarSnapshot[]): unknown {
+  return {
+    result: {
+      data: {
+        pillars: pillars.map((p) => ({
+          pillarId: p.pillarId,
+          baseUrl: p.baseUrl,
+          manifest: p.manifest,
+          lastSeenAt: p.lastSeenAt.toISOString(),
+          registered: p.registered,
+          status: 'healthy' as const,
+        })),
+        fetchedAt: new Date().toISOString(),
+      },
+    },
+  };
+}
+
+export function jsonResponse(body: unknown, init: { status?: number } = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: init.status ?? 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}

--- a/packages/pillar-sdk/src/discovery/api.ts
+++ b/packages/pillar-sdk/src/discovery/api.ts
@@ -1,0 +1,25 @@
+import { getRegistrySnapshot } from './cache.js';
+
+import type { PillarSnapshot, RegistrySnapshot } from './types.js';
+
+/**
+ * Returns the manifest snapshot for one pillar, or `undefined` if it's
+ * not registered. First call may await a network fetch; subsequent
+ * calls within the TTL window are served from the in-process cache.
+ *
+ * Throws {@link RegistryUnreachableError} only when the cache is empty
+ * AND the registry can't be reached. If the cache holds anything (even
+ * stale), that is returned in preference to throwing.
+ */
+export async function lookupPillar(pillarId: string): Promise<PillarSnapshot | undefined> {
+  const snapshot = await getRegistrySnapshot();
+  return snapshot.pillars.find((p) => p.pillarId === pillarId);
+}
+
+/**
+ * Returns the full registry snapshot. Same caching + fallback semantics
+ * as {@link lookupPillar}.
+ */
+export async function pillarRegistry(): Promise<RegistrySnapshot> {
+  return getRegistrySnapshot();
+}

--- a/packages/pillar-sdk/src/discovery/cache-internals.ts
+++ b/packages/pillar-sdk/src/discovery/cache-internals.ts
@@ -1,0 +1,133 @@
+import { fetchRegistrySnapshot, type RegistryFetchResult } from './fetcher.js';
+
+import type { RegistrySnapshot } from './types.js';
+
+export const DEFAULT_REGISTRY_URL = 'http://core-api:3001';
+export const DEFAULT_CACHE_TTL_MS = 30_000;
+export const MIN_CACHE_TTL_MS = 5_000;
+export const REFRESH_LEAD_MS = 1_000;
+
+/**
+ * Adapter the cache uses to talk to the registry. Production wires the
+ * real {@link fetchRegistrySnapshot}; tests inject a fake to avoid IO.
+ */
+export type RegistryFetcher = (registryUrl: string) => Promise<RegistryFetchResult>;
+
+export type WarnFn = (message: string, context: Record<string, unknown>) => void;
+
+/**
+ * Opaque handle for the cache's background timer. The real impl uses
+ * `setTimeout`/`clearTimeout`; tests inject a fake clock that returns
+ * anything matching this shape.
+ */
+export type TimerHandle = unknown;
+
+export type SetTimerFn = (cb: () => void, ms: number) => TimerHandle;
+export type ClearTimerFn = (handle: TimerHandle) => void;
+
+export type CacheConfig = {
+  registryUrl?: string;
+  ttlMs?: number;
+  fetcher?: RegistryFetcher;
+  now?: () => number;
+  setTimeoutImpl?: SetTimerFn;
+  clearTimeoutImpl?: ClearTimerFn;
+  onWarn?: WarnFn;
+};
+
+export type ResolvedConfig = {
+  registryUrl: string;
+  ttlMs: number;
+  fetcher: RegistryFetcher;
+  now: () => number;
+  setTimeoutImpl: SetTimerFn;
+  clearTimeoutImpl: ClearTimerFn;
+  onWarn: WarnFn;
+};
+
+export type CachedSnapshot = {
+  pillars: RegistrySnapshot['pillars'];
+  fetchedAt: Date;
+  isStale: boolean;
+};
+
+export type CacheState = {
+  config: ResolvedConfig;
+  snapshot: CachedSnapshot | null;
+  inFlight: Promise<CachedSnapshot> | null;
+  backgroundTimer: TimerHandle | null;
+  consecutiveFailures: number;
+  queuedFailures: { count: number; error: Error } | null;
+  seeded: boolean;
+};
+
+export function defaultFetcher(registryUrl: string): Promise<RegistryFetchResult> {
+  return fetchRegistrySnapshot({ registryUrl });
+}
+
+export class NodeTimerHandle {
+  constructor(readonly handle: ReturnType<typeof setTimeout>) {}
+}
+
+export function defaultSetTimer(cb: () => void, ms: number): TimerHandle {
+  return new NodeTimerHandle(setTimeout(cb, ms));
+}
+
+export function defaultClearTimer(handle: TimerHandle): void {
+  if (handle instanceof NodeTimerHandle) clearTimeout(handle.handle);
+}
+
+export function defaultWarn(message: string, context: Record<string, unknown>): void {
+  globalThis.console.warn(`[pillar-sdk:discovery] ${message}`, context);
+}
+
+export function clampTtl(ttlMs: number, onWarn: WarnFn): number {
+  if (ttlMs < MIN_CACHE_TTL_MS) {
+    onWarn('ttlMs below minimum; clamped', { requested: ttlMs, applied: MIN_CACHE_TTL_MS });
+    return MIN_CACHE_TTL_MS;
+  }
+  return ttlMs;
+}
+
+export function unrefTimer(timer: TimerHandle): void {
+  if (timer instanceof NodeTimerHandle) timer.handle.unref?.();
+}
+
+export function describeError(err: unknown): string {
+  if (err instanceof Error) return `${err.name}: ${err.message}`;
+  return String(err);
+}
+
+export function toRegistrySnapshot(
+  cached: CachedSnapshot,
+  source: RegistrySnapshot['source'],
+  ttlMs: number
+): RegistrySnapshot {
+  return {
+    pillars: cached.pillars,
+    fetchedAt: cached.fetchedAt,
+    ttlMs,
+    source,
+  };
+}
+
+export function createInitialState(overrides: CacheConfig): CacheState {
+  const onWarn: WarnFn = overrides.onWarn ?? defaultWarn;
+  return {
+    config: {
+      registryUrl: overrides.registryUrl ?? DEFAULT_REGISTRY_URL,
+      ttlMs: clampTtl(overrides.ttlMs ?? DEFAULT_CACHE_TTL_MS, onWarn),
+      fetcher: overrides.fetcher ?? defaultFetcher,
+      now: overrides.now ?? Date.now,
+      setTimeoutImpl: overrides.setTimeoutImpl ?? defaultSetTimer,
+      clearTimeoutImpl: overrides.clearTimeoutImpl ?? defaultClearTimer,
+      onWarn,
+    },
+    snapshot: null,
+    inFlight: null,
+    backgroundTimer: null,
+    consecutiveFailures: 0,
+    queuedFailures: null,
+    seeded: false,
+  };
+}

--- a/packages/pillar-sdk/src/discovery/cache.ts
+++ b/packages/pillar-sdk/src/discovery/cache.ts
@@ -1,0 +1,200 @@
+import {
+  clampTtl,
+  createInitialState,
+  describeError,
+  MIN_CACHE_TTL_MS,
+  REFRESH_LEAD_MS,
+  toRegistrySnapshot,
+  unrefTimer,
+  type CacheConfig,
+  type CacheState,
+  type CachedSnapshot,
+} from './cache-internals.js';
+import { RegistryUnreachableError, type RegistrySnapshot } from './types.js';
+
+import type { RegistryFetchResult } from './fetcher.js';
+
+export {
+  DEFAULT_REGISTRY_URL,
+  DEFAULT_CACHE_TTL_MS,
+  MIN_CACHE_TTL_MS,
+  type CacheConfig,
+  type RegistryFetcher,
+  type WarnFn,
+  type TimerHandle,
+  type SetTimerFn,
+  type ClearTimerFn,
+} from './cache-internals.js';
+
+let state: CacheState = createInitialState({});
+
+export function configureCache(overrides: CacheConfig): void {
+  cancelBackgroundTimer();
+  state = createInitialState({
+    registryUrl: overrides.registryUrl ?? state.config.registryUrl,
+    ttlMs: overrides.ttlMs ?? state.config.ttlMs,
+    fetcher: overrides.fetcher ?? state.config.fetcher,
+    now: overrides.now ?? state.config.now,
+    setTimeoutImpl: overrides.setTimeoutImpl ?? state.config.setTimeoutImpl,
+    clearTimeoutImpl: overrides.clearTimeoutImpl ?? state.config.clearTimeoutImpl,
+    onWarn: overrides.onWarn ?? state.config.onWarn,
+  });
+}
+
+export function setRegistryUrl(url: string): void {
+  state.config.registryUrl = url;
+  invalidateRegistryCache();
+}
+
+export function setCacheTtlMs(ttlMs: number): void {
+  state.config.ttlMs = clampTtl(ttlMs, state.config.onWarn);
+  invalidateRegistryCache();
+}
+
+export function invalidateRegistryCache(): void {
+  cancelBackgroundTimer();
+  state.snapshot = null;
+  state.seeded = false;
+}
+
+export function disposeDiscoveryClient(): void {
+  cancelBackgroundTimer();
+  state.snapshot = null;
+  state.inFlight = null;
+  state.consecutiveFailures = 0;
+  state.queuedFailures = null;
+  state.seeded = false;
+}
+
+export function seedSnapshot(snapshot: RegistrySnapshot): void {
+  cancelBackgroundTimer();
+  state.snapshot = {
+    pillars: snapshot.pillars,
+    fetchedAt: snapshot.fetchedAt,
+    isStale: snapshot.source === 'stale-fallback',
+  };
+  state.inFlight = null;
+  state.consecutiveFailures = 0;
+  state.seeded = true;
+}
+
+export function queueFailures(count: number, error: Error): void {
+  state.queuedFailures = { count, error };
+}
+
+export function getCurrentTtlMs(): number {
+  return state.config.ttlMs;
+}
+
+export async function getRegistrySnapshot(): Promise<RegistrySnapshot> {
+  const cached = state.snapshot;
+  const now = state.config.now();
+
+  if (cached !== null) {
+    if (state.seeded) return toRegistrySnapshot(cached, 'cached', state.config.ttlMs);
+    const age = now - cached.fetchedAt.getTime();
+    if (!cached.isStale && age < state.config.ttlMs) {
+      return toRegistrySnapshot(cached, 'cached', state.config.ttlMs);
+    }
+    if (cached.isStale) {
+      return toRegistrySnapshot(cached, 'stale-fallback', state.config.ttlMs);
+    }
+  }
+
+  const refreshed = await ensureInFlight();
+  const source: RegistrySnapshot['source'] = refreshed.isStale ? 'stale-fallback' : 'fresh';
+  return toRegistrySnapshot(refreshed, source, state.config.ttlMs);
+}
+
+function ensureInFlight(): Promise<CachedSnapshot> {
+  if (state.inFlight !== null) return state.inFlight;
+  const promise = doFetch();
+  state.inFlight = promise;
+  void promise.then(clearInFlight(promise), clearInFlight(promise));
+  return promise;
+}
+
+function clearInFlight(promise: Promise<CachedSnapshot>): () => void {
+  return () => {
+    if (state.inFlight === promise) state.inFlight = null;
+  };
+}
+
+async function doFetch(): Promise<CachedSnapshot> {
+  const cachedBefore = state.snapshot;
+  let lastError: unknown;
+
+  try {
+    const result = await invokeFetcher();
+    return commitFreshSnapshot(result);
+  } catch (err) {
+    lastError = err;
+    state.consecutiveFailures += 1;
+  }
+
+  if (cachedBefore !== null) return promoteToStale(cachedBefore, lastError);
+
+  throw new RegistryUnreachableError(
+    `discovery: registry at ${state.config.registryUrl} unreachable and no cache available`,
+    { attempts: 1, cause: lastError }
+  );
+}
+
+function commitFreshSnapshot(result: RegistryFetchResult): CachedSnapshot {
+  const next: CachedSnapshot = {
+    pillars: result.pillars,
+    fetchedAt: new Date(state.config.now()),
+    isStale: false,
+  };
+  state.snapshot = next;
+  state.consecutiveFailures = 0;
+  armBackgroundRefresh();
+  return next;
+}
+
+function promoteToStale(previous: CachedSnapshot, error: unknown): CachedSnapshot {
+  const stale: CachedSnapshot = { ...previous, isStale: true };
+  state.snapshot = stale;
+  state.config.onWarn('registry refresh failed; serving stale cache', {
+    consecutiveFailures: state.consecutiveFailures,
+    error: describeError(error),
+  });
+  armBackgroundRefresh();
+  return stale;
+}
+
+async function invokeFetcher(): Promise<RegistryFetchResult> {
+  const queued = state.queuedFailures;
+  if (queued !== null && queued.count > 0) {
+    queued.count -= 1;
+    if (queued.count <= 0) state.queuedFailures = null;
+    throw queued.error;
+  }
+  return state.config.fetcher(state.config.registryUrl);
+}
+
+function armBackgroundRefresh(): void {
+  cancelBackgroundTimer();
+  if (state.seeded) return;
+  const delay = Math.max(state.config.ttlMs - REFRESH_LEAD_MS, MIN_CACHE_TTL_MS - REFRESH_LEAD_MS);
+  state.backgroundTimer = state.config.setTimeoutImpl(() => {
+    state.backgroundTimer = null;
+    void runBackgroundRefresh();
+  }, delay);
+  unrefTimer(state.backgroundTimer);
+}
+
+async function runBackgroundRefresh(): Promise<void> {
+  try {
+    await ensureInFlight();
+  } catch {
+    // doFetch already promoted the cache to stale-fallback and logged.
+  }
+}
+
+function cancelBackgroundTimer(): void {
+  if (state.backgroundTimer !== null) {
+    state.config.clearTimeoutImpl(state.backgroundTimer);
+    state.backgroundTimer = null;
+  }
+}

--- a/packages/pillar-sdk/src/discovery/fetcher.ts
+++ b/packages/pillar-sdk/src/discovery/fetcher.ts
@@ -1,0 +1,101 @@
+import {
+  parseRegistrySnapshotResponse,
+  type PillarRegistryEntryPayload,
+} from './snapshot-schema.js';
+
+import type { PillarSnapshot } from './types.js';
+
+export type FetcherOptions = {
+  registryUrl: string;
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+  now?: () => number;
+};
+
+export type RegistryFetchResult = {
+  pillars: PillarSnapshot[];
+  fetchedAt: Date;
+};
+
+export const DEFAULT_FETCH_TIMEOUT_MS = 5_000;
+
+/**
+ * One-shot fetch of `core.registry.snapshot` (PRD-161).
+ *
+ * - 5s timeout via `AbortController` (configurable, but 5s is the default
+ *   the PRD-159 contract calls out).
+ * - Aborts surface as plain `Error` instances; the cache layer converts
+ *   them to {@link RegistryUnreachableError} when appropriate.
+ * - Zod-validates the response (per PRD-159 §Edge Cases:
+ *   malformed JSON / schema failure → treated as a fetch failure).
+ */
+export async function fetchRegistrySnapshot(options: FetcherOptions): Promise<RegistryFetchResult> {
+  const fetchImpl = options.fetchImpl ?? globalThis.fetch;
+  if (typeof fetchImpl !== 'function') {
+    throw new Error('discovery fetcher: no fetch implementation available');
+  }
+  const timeoutMs = options.timeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS;
+  const now = options.now ?? Date.now;
+
+  const url = buildSnapshotUrl(options.registryUrl);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(new Error('discovery fetch timeout')), timeoutMs);
+
+  let response: Response;
+  try {
+    response = await fetchImpl(url, {
+      method: 'GET',
+      headers: { accept: 'application/json' },
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+
+  if (!response.ok) {
+    throw new Error(`discovery fetch: HTTP ${response.status} ${response.statusText}`);
+  }
+
+  const body = await readJson(response);
+  const payload = parseRegistrySnapshotResponse(body);
+
+  return {
+    pillars: payload.pillars.map(toPillarSnapshot),
+    fetchedAt: new Date(now()),
+  };
+}
+
+function buildSnapshotUrl(registryUrl: string): string {
+  return `${registryUrl.replace(/\/$/, '')}/trpc/core.registry.snapshot`;
+}
+
+async function readJson(response: Response): Promise<unknown> {
+  const text = await response.text();
+  try {
+    return JSON.parse(text);
+  } catch (cause) {
+    const preview = text.length > 200 ? `${text.slice(0, 200)}...` : text;
+    throw new Error(`discovery fetch: malformed JSON body: ${preview}`, { cause });
+  }
+}
+
+function toPillarSnapshot(entry: PillarRegistryEntryPayload): PillarSnapshot {
+  const lastSeenAt = new Date(entry.lastSeenAt);
+  if (Number.isNaN(lastSeenAt.getTime())) {
+    throw new Error(`discovery fetch: invalid lastSeenAt for pillar ${entry.pillarId}`);
+  }
+  const registered = resolveRegistered(entry);
+  return {
+    pillarId: entry.pillarId,
+    baseUrl: entry.baseUrl,
+    manifest: entry.manifest,
+    registered,
+    lastSeenAt,
+  };
+}
+
+function resolveRegistered(entry: PillarRegistryEntryPayload): boolean {
+  if (typeof entry.registered === 'boolean') return entry.registered;
+  if (entry.status === 'unknown') return false;
+  return true;
+}

--- a/packages/pillar-sdk/src/discovery/index.ts
+++ b/packages/pillar-sdk/src/discovery/index.ts
@@ -1,0 +1,11 @@
+export { lookupPillar, pillarRegistry } from './api.js';
+export {
+  setRegistryUrl,
+  setCacheTtlMs,
+  invalidateRegistryCache,
+  disposeDiscoveryClient,
+  DEFAULT_REGISTRY_URL,
+  DEFAULT_CACHE_TTL_MS,
+  MIN_CACHE_TTL_MS,
+} from './cache.js';
+export { RegistryUnreachableError, type PillarSnapshot, type RegistrySnapshot } from './types.js';

--- a/packages/pillar-sdk/src/discovery/snapshot-schema.ts
+++ b/packages/pillar-sdk/src/discovery/snapshot-schema.ts
@@ -1,0 +1,47 @@
+import { z } from 'zod';
+
+import { ManifestPayloadSchema } from '../manifest-schema/index.js';
+
+const PillarRegistryEntrySchema = z
+  .object({
+    pillarId: z.string().min(1),
+    baseUrl: z.string().min(1),
+    manifest: ManifestPayloadSchema,
+    lastSeenAt: z.string().min(1),
+    registered: z.boolean().optional(),
+    status: z.enum(['healthy', 'unavailable', 'unknown']).optional(),
+  })
+  .loose();
+
+const RegistrySnapshotPayloadSchema = z
+  .object({
+    pillars: z.array(PillarRegistryEntrySchema),
+    fetchedAt: z.string().optional(),
+  })
+  .loose();
+
+/**
+ * Validates the JSON body returned by `core.registry.snapshot` (PRD-161).
+ *
+ * Accepts both the bare payload shape and the tRPC-wrapped
+ * `{ result: { data: ... } }` envelope so the fetcher can talk to either
+ * a tRPC HTTP endpoint directly or a thin reverse-proxy that unwraps for us.
+ */
+export function parseRegistrySnapshotResponse(body: unknown): RegistrySnapshotPayload {
+  const candidate = unwrapTrpcEnvelope(body);
+  return RegistrySnapshotPayloadSchema.parse(candidate);
+}
+
+export type RegistrySnapshotPayload = z.infer<typeof RegistrySnapshotPayloadSchema>;
+export type PillarRegistryEntryPayload = z.infer<typeof PillarRegistryEntrySchema>;
+
+function unwrapTrpcEnvelope(body: unknown): unknown {
+  if (!isRecord(body)) return body;
+  const result = body['result'];
+  if (isRecord(result) && 'data' in result) return result['data'];
+  return body;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/packages/pillar-sdk/src/discovery/types.ts
+++ b/packages/pillar-sdk/src/discovery/types.ts
@@ -1,0 +1,50 @@
+import type { ManifestPayload } from '../manifest-schema/index.js';
+
+/**
+ * One pillar's runtime registration as observed by the discovery client.
+ *
+ * Mirrors {@link RegistrySnapshot} entries but adds the discovery-side
+ * `registered` flag (false during PRD-162 reconciliation windows) and
+ * normalises `lastSeenAt` from ISO string to Date.
+ */
+export type PillarSnapshot = {
+  pillarId: string;
+  baseUrl: string;
+  manifest: ManifestPayload;
+  registered: boolean;
+  lastSeenAt: Date;
+};
+
+/**
+ * The full registry view returned by {@link pillarRegistry}.
+ *
+ * `source` flags where the data came from:
+ *  - `'fresh'`: just fetched from the registry on this call.
+ *  - `'cached'`: in-TTL cache hit; no network was performed.
+ *  - `'stale-fallback'`: cache is past its TTL and the most recent refresh
+ *    failed, so we are serving the last-known-good snapshot. Consumers
+ *    that gate writes should respect this signal.
+ */
+export type RegistrySnapshot = {
+  pillars: PillarSnapshot[];
+  fetchedAt: Date;
+  ttlMs: number;
+  source: 'fresh' | 'cached' | 'stale-fallback';
+};
+
+/**
+ * Thrown by {@link lookupPillar}/{@link pillarRegistry} only when the
+ * cache is empty AND the registry can't be reached. If anything is
+ * cached (even stale), that is returned in preference to throwing.
+ */
+export class RegistryUnreachableError extends Error {
+  override readonly name = 'RegistryUnreachableError';
+  readonly attempts: number;
+  override readonly cause?: unknown;
+
+  constructor(message: string, options: { attempts: number; cause?: unknown }) {
+    super(message);
+    this.attempts = options.attempts;
+    if (options.cause !== undefined) this.cause = options.cause;
+  }
+}

--- a/packages/pillar-sdk/src/index.ts
+++ b/packages/pillar-sdk/src/index.ts
@@ -1,2 +1,3 @@
 export * from './manifest-schema/index.js';
 export * from './bootstrap/index.js';
+export * from './discovery/index.js';

--- a/packages/pillar-sdk/src/testing/__tests__/discovery.test.ts
+++ b/packages/pillar-sdk/src/testing/__tests__/discovery.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { pillar } from '../../discovery/__tests__/fixtures.js';
+import { lookupPillar, pillarRegistry } from '../../discovery/api.js';
+import { disposeDiscoveryClient } from '../../discovery/cache.js';
+import { RegistryUnreachableError, type RegistrySnapshot } from '../../discovery/types.js';
+import {
+  configureDiscoveryForTest,
+  failNextRegistryFetches,
+  seedRegistryCache,
+} from '../discovery.js';
+
+function emptySnapshot(source: RegistrySnapshot['source'] = 'fresh'): RegistrySnapshot {
+  return { pillars: [], fetchedAt: new Date(), ttlMs: 30_000, source };
+}
+
+describe('@pops/pillar-sdk/testing/discovery', () => {
+  beforeEach(() => {
+    configureDiscoveryForTest({
+      registryUrl: 'http://core-api:3001',
+      ttlMs: 30_000,
+      fetcher: async () => {
+        throw new Error('test must not hit the network');
+      },
+      onWarn: () => {},
+    });
+  });
+
+  afterEach(() => {
+    disposeDiscoveryClient();
+  });
+
+  it('seedRegistryCache injects a snapshot that subsequent lookups read from', async () => {
+    seedRegistryCache({
+      pillars: [pillar('finance', 'http://finance-api:3004')],
+      fetchedAt: new Date(),
+      ttlMs: 30_000,
+      source: 'fresh',
+    });
+
+    const result = await lookupPillar('finance');
+    expect(result?.baseUrl).toBe('http://finance-api:3004');
+
+    const all = await pillarRegistry();
+    expect(all.pillars).toHaveLength(1);
+    expect(all.source).toBe('cached');
+  });
+
+  it('a seeded snapshot suspends background refresh (no fetcher hit even after a long delay)', async () => {
+    let fetcherCalls = 0;
+    configureDiscoveryForTest({
+      registryUrl: 'http://core-api:3001',
+      ttlMs: 30_000,
+      fetcher: async () => {
+        fetcherCalls += 1;
+        throw new Error('should not be called when seeded');
+      },
+      onWarn: () => {},
+    });
+
+    seedRegistryCache({
+      pillars: [pillar('finance', 'http://finance-api:3004')],
+      fetchedAt: new Date(),
+      ttlMs: 30_000,
+      source: 'fresh',
+    });
+
+    await pillarRegistry();
+    await pillarRegistry();
+    await pillarRegistry();
+
+    expect(fetcherCalls).toBe(0);
+  });
+
+  it('failNextRegistryFetches causes the next call to surface RegistryUnreachableError when no cache', async () => {
+    failNextRegistryFetches(1, new Error('injected failure'));
+    await expect(lookupPillar('finance')).rejects.toBeInstanceOf(RegistryUnreachableError);
+  });
+
+  it('failNextRegistryFetches exhausts after N calls then falls through to the real fetcher', async () => {
+    let calls = 0;
+    configureDiscoveryForTest({
+      registryUrl: 'http://core-api:3001',
+      ttlMs: 30_000,
+      fetcher: async () => {
+        calls += 1;
+        return {
+          pillars: [pillar('finance', `http://finance:300${calls}`)],
+          fetchedAt: new Date(),
+        };
+      },
+      onWarn: () => {},
+    });
+
+    failNextRegistryFetches(2, new Error('still failing'));
+
+    await expect(pillarRegistry()).rejects.toBeInstanceOf(RegistryUnreachableError);
+    await expect(pillarRegistry()).rejects.toBeInstanceOf(RegistryUnreachableError);
+
+    const ok = await pillarRegistry();
+    expect(ok.pillars[0]!.baseUrl).toBe('http://finance:3001');
+  });
+
+  it('emptySnapshot through the test harness is a valid serializable shape', () => {
+    expect(emptySnapshot()).toMatchObject({ pillars: [], source: 'fresh' });
+  });
+});

--- a/packages/pillar-sdk/src/testing/discovery.ts
+++ b/packages/pillar-sdk/src/testing/discovery.ts
@@ -1,0 +1,37 @@
+import {
+  configureCache,
+  queueFailures,
+  seedSnapshot,
+  type CacheConfig,
+} from '../discovery/cache.js';
+
+import type { RegistrySnapshot } from '../discovery/types.js';
+
+/**
+ * Seeds the discovery cache with a hand-crafted snapshot. The
+ * background refresh timer is suspended; the cache returns the injected
+ * snapshot for every lookup until {@link invalidateRegistryCache} is
+ * called or {@link disposeDiscoveryClient} is invoked.
+ */
+export function seedRegistryCache(snapshot: RegistrySnapshot): void {
+  seedSnapshot(snapshot);
+}
+
+/**
+ * Makes the next `count` registry fetches throw `error`. Useful for
+ * exercising the stale-fallback + `RegistryUnreachableError` paths.
+ * Subsequent fetches (after the count is exhausted) fall through to
+ * the configured fetcher.
+ */
+export function failNextRegistryFetches(count: number, error: Error): void {
+  queueFailures(count, error);
+}
+
+/**
+ * Replaces the cache configuration wholesale. Test-only; production
+ * code should use the individual `set*` setters from the discovery
+ * subpath.
+ */
+export function configureDiscoveryForTest(overrides: CacheConfig): void {
+  configureCache(overrides);
+}

--- a/packages/pillar-sdk/src/testing/index.ts
+++ b/packages/pillar-sdk/src/testing/index.ts
@@ -1,0 +1,5 @@
+export {
+  seedRegistryCache,
+  failNextRegistryFetches,
+  configureDiscoveryForTest,
+} from './discovery.js';


### PR DESCRIPTION
## Summary

Server-side discovery for Theme 13 PRD-159. Any process in the docker network — sibling pillars, `pops-api`, `pops-worker`, the `pillar()` client factory (PRD-191) — can call `lookupPillar('finance')` and get a cached, deduped, fall-back-friendly view of the runtime registry without owning the cache lifecycle itself.

Two subpath exports:

- `@pops/pillar-sdk/discovery` — `lookupPillar`, `pillarRegistry`, `setRegistryUrl`, `setCacheTtlMs`, `invalidateRegistryCache`, `disposeDiscoveryClient`, `RegistryUnreachableError`.
- `@pops/pillar-sdk/testing/discovery` — `seedRegistryCache`, `failNextRegistryFetches`, `configureDiscoveryForTest`.

## Cache semantics (PRD §Business Rules)

- **One cache per process.** Module-level singleton; no per-call instances.
- **TTL default 30s.** `setCacheTtlMs` clamps below 5_000 and warns.
- **First lookup blocks until success or failure.** No optimistic empty cache.
- **Concurrent first-time lookups share one in-flight Promise.** No thundering herd.
- **Background refresh fires 1s before TTL expiry.** Keeps the cache warm without consumer awareness.
- **Refresh failures don't replace the cache.** Snapshot transitions to `[STALE_FALLBACK]`; consumers keep reading the last-known-good data with `source: 'stale-fallback'`; `consecutiveFailures` increments and emits a `console.warn`.
- **`lookupPillar` returns `undefined` when a pillar isn't registered.** Errors are reserved for "registry unreachable AND cache empty."
- **Fetch timeout 5s** via `AbortController`. Times out → counts as a fetch failure (same fallback path).
- **`disposeDiscoveryClient()` clears the background timer.** Required at process shutdown.

## Layering vs PR #2952 (PRD-191 `pillar()` client factory)

PR #2952's `DiscoveryCache` + `HttpDiscoveryTransport` (`packages/pillar-sdk/src/client/`) are scoped to the `pillar()` factory's needs — a memoizing wrapper with TTL + in-flight dedup and no background refresh, stale-fallback, or `RegistryUnreachableError` semantics.

PRD-159 specifies a meaningfully larger surface (background refresh, stale-fallback flag, error class, test harness, setter API) that the `pillar()` factory does **not** need. This PR ships PRD-159 as a sibling subpath (`./discovery`) with the full spec. PR #2952 is left untouched on purpose:

- They have no runtime overlap (`client/` does not import from `discovery/` today).
- A follow-up can collapse PR #2952's `HttpDiscoveryTransport` onto `pillarRegistry()` once both PRs land, removing the duplication. That's a 1-PR refactor with a clear seam; it doesn't gate either PR.
- Conversely, building PRD-159 by extracting from `client/` would force this PR to wait on #2952 merging — and would not match the PRD-159 contract (different shape, no background timer, no stale-fallback). Net-net: ship PRD-159 as-spec, dedupe later.

## Decisions

- **No `as any`, no `as unknown as`, no eslint-disable, no ts-ignore.** Timer handles use a typed `NodeTimerHandle` wrapper to keep production paths free of casts.
- **Both bare and tRPC-enveloped responses accepted.** The Zod schema unwraps `{ result: { data: ... } }` if present, otherwise reads the bare `{ pillars, fetchedAt }` shape. Lets the fetcher work whether it talks to core-api directly or through a thin reverse-proxy.
- **`registered` defaults to true on snapshot entries.** A registry entry with `status: 'unknown'` (PRD-164 reconciliation window) is normalized to `registered: false`; everything else is `registered: true` unless the registry explicitly sets the flag. Lines up with PRD-159's "`registered` is false during reconciliation windows" rule.
- **`source: 'fresh'` means "this call awaited a network fetch."** A call that joined a background refresh's in-flight Promise still reports `'fresh'` (or `'stale-fallback'` if the refresh failed). A call that read straight from a satisfied cache reports `'cached'`.
- **Cache `fetchedAt` is stamped by the cache's `now()`, not the fetcher's.** Lets the fake clock in tests drive TTL math without colliding with `Date.now`.
- **Background timer is `.unref()`'d.** Discovery doesn't keep the event loop alive past the last connection close.

## Deferred

- Wiring `disposeDiscoveryClient()` into `bootstrapPillar`'s shutdown path (PRD-159 US-09). Trivial follow-up; not blocked.
- SSE-based push invalidation (PRD §Out of Scope; revisit if 30s staleness causes real operational pain).
- `lookupPillarOrThrow()` (PRD §Out of Scope).
- Replacing PR #2952's `HttpDiscoveryTransport` with a call into `pillarRegistry()` — see "Layering" above.

## Test plan

- [x] `pnpm --filter @pops/pillar-sdk typecheck` — clean.
- [x] `pnpm --filter @pops/pillar-sdk test` — 7 files / 137 tests pass (18 new tests across cache, fetcher, and test-harness).
- [x] `pnpm typecheck` — full repo green (turbo cache 53/54 hit).
- [x] `pnpm lint` — pillar-sdk contributes 0 errors / 0 new warnings.
- [x] `pnpm lint:boundaries` — clean.
- [x] `pnpm format:check` — clean.
- [x] Covered branches: happy path, registry-down-from-cold, cache hit within TTL, TTL expiry triggers refresh, in-flight dedup of concurrent lookups, stale-fallback after background failure, malformed JSON / schema-invalid response treated as fetch failure, 5s `AbortController` timeout, `setRegistryUrl` and `setCacheTtlMs` invalidate the cache, `disposeDiscoveryClient` cancels the background timer, `seedRegistryCache` suspends background refresh, `failNextRegistryFetches` injects N failures then falls through.
