### PR TITLE
feat(pillar-sdk): server-side pillar() helper (Theme 13 PRD-192)

### DIFF
--- a/docs/themes/13-pillar-finale/epics/05-unified-consumption-sdk.md
+++ b/docs/themes/13-pillar-finale/epics/05-unified-consumption-sdk.md
@@ -23,7 +23,7 @@ React hooks layer on top: `usePillarQuery(...)`, `usePillarMutation(...)` for th
 | #   | PRD                      | Summary                                                                                 | Status      |
 | --- | ------------------------ | --------------------------------------------------------------------------------------- | ----------- |
 | 191 | Client surface           | The `pillar('id').router.proc(...)` proxy + failure-mode discriminants                  | Not started |
-| 192 | Server surface           | Same SDK for sibling pillars + worker calling each other                                | Not started |
+| 192 | Server surface           | Same SDK for sibling pillars + worker calling each other                                | Done        |
 | 193 | React hooks              | `usePillarQuery`, `usePillarMutation` with React Query integration                      | Not started |
 | 194 | Caching + invalidation   | Registry snapshot TTL, change-subscription invalidation, per-procedure response caching | Not started |
 | 195 | Type generation pipeline | Generate the consumer-side typings from each pillar's contract                          | Not started |

--- a/packages/pillar-sdk/package.json
+++ b/packages/pillar-sdk/package.json
@@ -22,6 +22,10 @@
       "types": "./dist/client/index.d.ts",
       "default": "./dist/client/index.js"
     },
+    "./server": {
+      "types": "./dist/server/index.d.ts",
+      "default": "./dist/server/index.js"
+    },
     "./discovery": {
       "types": "./dist/discovery/index.d.ts",
       "default": "./dist/discovery/index.js"

--- a/packages/pillar-sdk/src/server/__tests__/config.test.ts
+++ b/packages/pillar-sdk/src/server/__tests__/config.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  __resetServerSdkConfig,
+  configureServerSdk,
+  getServerSdkConfig,
+  resolveApiKey,
+  SERVER_SDK_API_KEY_ENV,
+} from '../config.js';
+
+describe('configureServerSdk', () => {
+  beforeEach(() => __resetServerSdkConfig());
+  afterEach(() => __resetServerSdkConfig());
+
+  it('starts with an empty config', () => {
+    expect(getServerSdkConfig()).toEqual({});
+  });
+
+  it('shallow-merges later calls into the existing config', () => {
+    configureServerSdk({ apiKey: 'first', callTimeoutMs: 1000 });
+    configureServerSdk({ callTimeoutMs: 2000 });
+    const config = getServerSdkConfig();
+    expect(config.apiKey).toBe('first');
+    expect(config.callTimeoutMs).toBe(2000);
+  });
+
+  it('replaces a field when the new value is explicit', () => {
+    configureServerSdk({ apiKey: 'first' });
+    configureServerSdk({ apiKey: 'second' });
+    expect(getServerSdkConfig().apiKey).toBe('second');
+  });
+});
+
+describe('resolveApiKey', () => {
+  beforeEach(() => __resetServerSdkConfig());
+  afterEach(() => __resetServerSdkConfig());
+
+  it('prefers an explicitly configured key over the env var', () => {
+    configureServerSdk({ apiKey: 'config-key' });
+    const env = { [SERVER_SDK_API_KEY_ENV]: 'env-key' } as NodeJS.ProcessEnv;
+    expect(resolveApiKey(env)).toBe('config-key');
+  });
+
+  it('falls back to the env var when no key is configured', () => {
+    const env = { [SERVER_SDK_API_KEY_ENV]: 'env-key' } as NodeJS.ProcessEnv;
+    expect(resolveApiKey(env)).toBe('env-key');
+  });
+
+  it('treats empty configured key as unset', () => {
+    configureServerSdk({ apiKey: '' });
+    const env = { [SERVER_SDK_API_KEY_ENV]: 'env-key' } as NodeJS.ProcessEnv;
+    expect(resolveApiKey(env)).toBe('env-key');
+  });
+
+  it('returns undefined when neither config nor env supplies a key', () => {
+    expect(resolveApiKey({} as NodeJS.ProcessEnv)).toBeUndefined();
+  });
+
+  it('treats empty env value as unset', () => {
+    const env = { [SERVER_SDK_API_KEY_ENV]: '' } as NodeJS.ProcessEnv;
+    expect(resolveApiKey(env)).toBeUndefined();
+  });
+});

--- a/packages/pillar-sdk/src/server/__tests__/factory.test.ts
+++ b/packages/pillar-sdk/src/server/__tests__/factory.test.ts
@@ -140,6 +140,10 @@ describe('server pillar() — outbound auth header', () => {
     const finance = pillar('finance', { transport, fetchImpl });
     await finance.wishlist.list({});
     expect(calls.at(-1)?.headers['x-api-key']).toBe('env-a');
+
+    process.env[SERVER_SDK_API_KEY_ENV] = 'env-b';
+    await finance.wishlist.list({});
+    expect(calls.at(-1)?.headers['x-api-key']).toBe('env-b');
   });
 });
 

--- a/packages/pillar-sdk/src/server/__tests__/factory.test.ts
+++ b/packages/pillar-sdk/src/server/__tests__/factory.test.ts
@@ -1,0 +1,265 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  discoveredPillar,
+  fakeFetch,
+  FakeRegistryTransport,
+  jsonResponse,
+} from '../../client/__tests__/fixtures.js';
+import { __resetSharedPillarClient, isOk } from '../../client/index.js';
+import {
+  __resetServerPillarCache,
+  __resetServerSdkConfig,
+  configureServerSdk,
+  pillar,
+  PillarServerSdkError,
+  SERVER_SDK_API_KEY_ENV,
+} from '../index.js';
+
+type FetchCall = { url: string; headers: Record<string, string>; body: unknown };
+
+function recordingFetch(responder: (url: string) => Response | Promise<Response>): {
+  fetchImpl: typeof fetch;
+  calls: FetchCall[];
+} {
+  const calls: FetchCall[] = [];
+  const fetchImpl = fakeFetch(async (url, init) => {
+    const rawBody = typeof init?.body === 'string' ? init.body : '';
+    let parsed: unknown = null;
+    try {
+      parsed = rawBody ? JSON.parse(rawBody) : null;
+    } catch {
+      parsed = rawBody;
+    }
+    calls.push({
+      url,
+      headers: (init?.headers ?? {}) as Record<string, string>,
+      body: parsed,
+    });
+    return responder(url);
+  });
+  return { fetchImpl, calls };
+}
+
+type WishlistRouter = {
+  wishlist: {
+    list: (input: { limit: number }) => Promise<readonly { id: string }[]>;
+  };
+};
+
+const ORIGINAL_API_KEY = process.env[SERVER_SDK_API_KEY_ENV];
+
+function clearApiKeyEnv(): void {
+  delete process.env[SERVER_SDK_API_KEY_ENV];
+}
+
+function resetAll(): void {
+  __resetServerSdkConfig();
+  __resetServerPillarCache();
+  __resetSharedPillarClient();
+}
+
+describe('server pillar() — auth bootstrapping', () => {
+  beforeEach(() => {
+    resetAll();
+    clearApiKeyEnv();
+  });
+
+  afterEach(() => {
+    resetAll();
+    if (ORIGINAL_API_KEY === undefined) clearApiKeyEnv();
+    else process.env[SERVER_SDK_API_KEY_ENV] = ORIGINAL_API_KEY;
+  });
+
+  it('throws PillarServerSdkError when neither config nor env supplies a key', () => {
+    expect(() => pillar('finance')).toThrowError(PillarServerSdkError);
+  });
+
+  it('mentions both knobs in the error so the caller can self-diagnose', () => {
+    try {
+      pillar('finance');
+    } catch (err) {
+      expect(err).toBeInstanceOf(PillarServerSdkError);
+      if (err instanceof PillarServerSdkError) {
+        expect(err.message).toContain(SERVER_SDK_API_KEY_ENV);
+        expect(err.message).toContain('configureServerSdk');
+      }
+    }
+  });
+
+  it('accepts the env var alone', () => {
+    process.env[SERVER_SDK_API_KEY_ENV] = 'env-key';
+    const transport = new FakeRegistryTransport({ pillars: [discoveredPillar()] });
+    expect(() => pillar('finance', { transport })).not.toThrow();
+  });
+
+  it('accepts a configured key alone', () => {
+    configureServerSdk({ apiKey: 'config-key' });
+    const transport = new FakeRegistryTransport({ pillars: [discoveredPillar()] });
+    expect(() => pillar('finance', { transport })).not.toThrow();
+  });
+});
+
+describe('server pillar() — outbound auth header', () => {
+  beforeEach(() => {
+    resetAll();
+    clearApiKeyEnv();
+    configureServerSdk({ apiKey: 'svc-key-123' });
+  });
+
+  afterEach(() => {
+    resetAll();
+    if (ORIGINAL_API_KEY === undefined) clearApiKeyEnv();
+    else process.env[SERVER_SDK_API_KEY_ENV] = ORIGINAL_API_KEY;
+  });
+
+  it("sends the service-account key as 'X-API-Key' on every call", async () => {
+    const transport = new FakeRegistryTransport({ pillars: [discoveredPillar()] });
+    const { fetchImpl, calls } = recordingFetch(() =>
+      jsonResponse({ result: { data: [{ id: 'wish-1' }] } })
+    );
+    const finance = pillar<WishlistRouter>('finance', { transport, fetchImpl });
+    const result = await finance.wishlist.list({ limit: 1 });
+    expect(isOk(result)).toBe(true);
+    expect(calls[0]?.headers['x-api-key']).toBe('svc-key-123');
+  });
+
+  it('does not pass through nginx — uses the registry-published baseUrl directly', async () => {
+    const transport = new FakeRegistryTransport({ pillars: [discoveredPillar()] });
+    const { fetchImpl, calls } = recordingFetch(() => jsonResponse({ result: { data: null } }));
+    const finance = pillar<WishlistRouter>('finance', { transport, fetchImpl });
+    await finance.wishlist.list({ limit: 1 });
+    expect(calls[0]?.url).toBe('http://finance-api:3004/trpc/finance.wishlist.list');
+  });
+
+  it('reads the env-supplied key at call time so a later env update is picked up', async () => {
+    __resetServerSdkConfig();
+    process.env[SERVER_SDK_API_KEY_ENV] = 'env-a';
+    const transport = new FakeRegistryTransport({ pillars: [discoveredPillar()] });
+    const { fetchImpl, calls } = recordingFetch(() => jsonResponse({ result: { data: null } }));
+    const finance = pillar('finance', { transport, fetchImpl });
+    await finance.wishlist.list({});
+    expect(calls.at(-1)?.headers['x-api-key']).toBe('env-a');
+  });
+});
+
+describe('server pillar() — handle reuse + discovery cache', () => {
+  beforeEach(() => {
+    resetAll();
+    clearApiKeyEnv();
+    configureServerSdk({ apiKey: 'svc-key' });
+  });
+
+  afterEach(() => {
+    resetAll();
+    if (ORIGINAL_API_KEY === undefined) clearApiKeyEnv();
+    else process.env[SERVER_SDK_API_KEY_ENV] = ORIGINAL_API_KEY;
+  });
+
+  it('memoises the per-pillar handle so the discovery cache survives across pillar() calls', async () => {
+    const transport = new FakeRegistryTransport({ pillars: [discoveredPillar()] });
+    const { fetchImpl } = recordingFetch(() => jsonResponse({ result: { data: null } }));
+    const a = pillar('finance', { transport, fetchImpl, cacheTtlMs: 60_000 });
+    const b = pillar('finance', { transport, fetchImpl, cacheTtlMs: 60_000 });
+    expect(a).toBe(b);
+    await a.wishlist.list({});
+    await b.wishlist.list({});
+    expect(transport.callCount).toBe(1);
+  });
+
+  it('rebuilds the handle when the configured api key changes', async () => {
+    const transport = new FakeRegistryTransport({ pillars: [discoveredPillar()] });
+    const { fetchImpl } = recordingFetch(() => jsonResponse({ result: { data: null } }));
+    const a = pillar('finance', { transport, fetchImpl });
+    configureServerSdk({ apiKey: 'rotated-key' });
+    const b = pillar('finance', { transport, fetchImpl });
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('server pillar() — internal base URL overrides', () => {
+  beforeEach(() => {
+    resetAll();
+    clearApiKeyEnv();
+    configureServerSdk({ apiKey: 'svc-key' });
+  });
+
+  afterEach(() => {
+    resetAll();
+    if (ORIGINAL_API_KEY === undefined) clearApiKeyEnv();
+    else process.env[SERVER_SDK_API_KEY_ENV] = ORIGINAL_API_KEY;
+  });
+
+  it('routes calls to the override URL for matching pillars', async () => {
+    configureServerSdk({ internalBaseUrls: { finance: 'http://localhost:3104' } });
+    const transport = new FakeRegistryTransport({ pillars: [discoveredPillar()] });
+    const { fetchImpl, calls } = recordingFetch(() => jsonResponse({ result: { data: null } }));
+    const finance = pillar('finance', { transport, fetchImpl });
+    await finance.wishlist.list({});
+    expect(calls[0]?.url).toBe('http://localhost:3104/trpc/finance.wishlist.list');
+  });
+
+  it('leaves the URL untouched for pillars that are not in the override map', async () => {
+    configureServerSdk({ internalBaseUrls: { media: 'http://localhost:3105' } });
+    const transport = new FakeRegistryTransport({ pillars: [discoveredPillar()] });
+    const { fetchImpl, calls } = recordingFetch(() => jsonResponse({ result: { data: null } }));
+    const finance = pillar('finance', { transport, fetchImpl });
+    await finance.wishlist.list({});
+    expect(calls[0]?.url).toBe('http://finance-api:3004/trpc/finance.wishlist.list');
+  });
+});
+
+describe('server pillar() — error-mapping parity with client', () => {
+  beforeEach(() => {
+    resetAll();
+    clearApiKeyEnv();
+    configureServerSdk({ apiKey: 'svc-key' });
+  });
+
+  afterEach(() => {
+    resetAll();
+    if (ORIGINAL_API_KEY === undefined) clearApiKeyEnv();
+    else process.env[SERVER_SDK_API_KEY_ENV] = ORIGINAL_API_KEY;
+  });
+
+  it("returns 'unavailable' when the pillar is missing from the registry", async () => {
+    const transport = new FakeRegistryTransport({ pillars: [] });
+    const { fetchImpl } = recordingFetch(() => jsonResponse({}));
+    const finance = pillar('finance', { transport, fetchImpl });
+    const result = await finance.wishlist.list({});
+    expect(result.kind).toBe('unavailable');
+  });
+
+  it("returns 'contract-mismatch' on a 404 from the pillar", async () => {
+    const transport = new FakeRegistryTransport({ pillars: [discoveredPillar()] });
+    const { fetchImpl } = recordingFetch(() => new Response('not found', { status: 404 }));
+    const finance = pillar('finance', { transport, fetchImpl });
+    const result = await finance.wishlist.list({});
+    expect(result.kind).toBe('contract-mismatch');
+  });
+
+  it('flags a contract major skew when contractVersion is pinned', async () => {
+    const transport = new FakeRegistryTransport({
+      pillars: [
+        discoveredPillar({
+          manifest: {
+            ...discoveredPillar().manifest,
+            contract: {
+              package: '@pops/finance-contract',
+              version: '2.0.0',
+              tag: 'contract-finance@v2.0.0',
+            },
+          },
+        }),
+      ],
+    });
+    const { fetchImpl } = recordingFetch(() => jsonResponse({}));
+    const finance = pillar('finance', {
+      transport,
+      fetchImpl,
+      contractVersion: '1.4.0',
+    });
+    const result = await finance.wishlist.list({});
+    expect(result.kind).toBe('contract-mismatch');
+  });
+});

--- a/packages/pillar-sdk/src/server/__tests__/transport.test.ts
+++ b/packages/pillar-sdk/src/server/__tests__/transport.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import { discoveredPillar, FakeRegistryTransport } from '../../client/__tests__/fixtures.js';
+import { InternalBaseUrlTransport } from '../transport.js';
+
+describe('InternalBaseUrlTransport', () => {
+  it('passes the snapshot through untouched when the override map is empty', async () => {
+    const inner = new FakeRegistryTransport({ pillars: [discoveredPillar()] });
+    const transport = new InternalBaseUrlTransport(inner, {});
+    const snapshot = await transport.fetchSnapshot();
+    expect(snapshot[0]?.baseUrl).toBe('http://finance-api:3004');
+  });
+
+  it('rewrites the baseUrl for matching pillars', async () => {
+    const inner = new FakeRegistryTransport({
+      pillars: [
+        discoveredPillar({ pillarId: 'finance', baseUrl: 'http://finance-api:3004' }),
+        discoveredPillar({ pillarId: 'media', baseUrl: 'http://media-api:3005' }),
+      ],
+    });
+    const transport = new InternalBaseUrlTransport(inner, {
+      finance: 'http://localhost:3104',
+    });
+    const snapshot = await transport.fetchSnapshot();
+    expect(snapshot.find((p) => p.pillarId === 'finance')?.baseUrl).toBe('http://localhost:3104');
+    expect(snapshot.find((p) => p.pillarId === 'media')?.baseUrl).toBe('http://media-api:3005');
+  });
+
+  it('does not mutate the inner entries', async () => {
+    const original = discoveredPillar({ pillarId: 'finance', baseUrl: 'http://x' });
+    const inner = new FakeRegistryTransport({ pillars: [original] });
+    const transport = new InternalBaseUrlTransport(inner, { finance: 'http://y' });
+    await transport.fetchSnapshot();
+    expect(original.baseUrl).toBe('http://x');
+  });
+});

--- a/packages/pillar-sdk/src/server/config.ts
+++ b/packages/pillar-sdk/src/server/config.ts
@@ -1,0 +1,94 @@
+import type { HttpDiscoveryTransportOptions } from '../client/index.js';
+
+/**
+ * Caller-provided overrides for the process-wide server SDK.
+ *
+ * Every field is optional. `configureServerSdk` is intended to be called
+ * once at process boot (e.g. in `bootstrapPillar`'s server wiring, or in
+ * the top of a worker entry-point), but it is safe to call multiple times
+ * — later calls shallow-merge into the existing config.
+ */
+export type ServerSdkConfig = {
+  /**
+   * Service-account API key sent as `X-API-Key` on every outbound call.
+   * When omitted, the SDK falls back to `process.env.POPS_INTERNAL_API_KEY`
+   * at call time. Explicit > env.
+   */
+  apiKey?: string;
+
+  /**
+   * Custom fetch implementation. Server callers typically wire this to a
+   * keepalive-enabled fetch (e.g. `undici`'s pool-backed fetch) to get
+   * connection reuse without paying TCP handshake costs per call.
+   */
+  fetchImpl?: typeof fetch;
+
+  /**
+   * Default per-call timeout for outbound pillar-to-pillar requests.
+   * Defaults to 30s in the underlying client.
+   */
+  callTimeoutMs?: number;
+
+  /**
+   * Default registry discovery TTL.
+   */
+  cacheTtlMs?: number;
+
+  /**
+   * Registry transport overrides. The same shape accepted by the client
+   * `HttpDiscoveryTransport` — internal Docker hostnames for the registry,
+   * a custom timeout, extra headers, etc.
+   */
+  registry?: HttpDiscoveryTransportOptions;
+
+  /**
+   * Optional per-pillar base-URL overrides. Useful for local development
+   * where a sibling pillar is reachable on `localhost` rather than the
+   * registry-published Docker hostname. The override is matched by
+   * `pillarId`; if absent, the discovery baseUrl is used as-is.
+   */
+  internalBaseUrls?: Record<string, string>;
+};
+
+const SERVER_API_KEY_ENV = 'POPS_INTERNAL_API_KEY';
+
+let currentConfig: ServerSdkConfig = {};
+
+/**
+ * Set or update the process-wide server SDK configuration. Repeated calls
+ * shallow-merge — pass `{ apiKey: undefined }` to clear a single field if
+ * needed.
+ */
+export function configureServerSdk(config: ServerSdkConfig): void {
+  currentConfig = { ...currentConfig, ...config };
+}
+
+/**
+ * Read the active server SDK config. Exposed for the factory and tests;
+ * not part of the public surface.
+ */
+export function getServerSdkConfig(): Readonly<ServerSdkConfig> {
+  return currentConfig;
+}
+
+/**
+ * Reset config back to empty. Used by tests; not exported from the
+ * package entry-point.
+ */
+export function __resetServerSdkConfig(): void {
+  currentConfig = {};
+}
+
+/**
+ * Resolve the service-account API key. Caller-supplied config wins over
+ * the env var; an empty string is treated as unset.
+ */
+export function resolveApiKey(env: NodeJS.ProcessEnv = process.env): string | undefined {
+  const fromConfig = currentConfig.apiKey;
+  if (fromConfig !== undefined && fromConfig.length > 0) return fromConfig;
+  const fromEnv = env[SERVER_API_KEY_ENV];
+  if (typeof fromEnv === 'string' && fromEnv.length > 0) return fromEnv;
+  return undefined;
+}
+
+export const SERVER_SDK_API_KEY_ENV = SERVER_API_KEY_ENV;

--- a/packages/pillar-sdk/src/server/config.ts
+++ b/packages/pillar-sdk/src/server/config.ts
@@ -64,16 +64,17 @@ export function configureServerSdk(config: ServerSdkConfig): void {
 }
 
 /**
- * Read the active server SDK config. Exposed for the factory and tests;
- * not part of the public surface.
+ * Read the active server SDK config. Exported via the package's
+ * `./server` subpath for tests and advanced introspection.
  */
 export function getServerSdkConfig(): Readonly<ServerSdkConfig> {
   return currentConfig;
 }
 
 /**
- * Reset config back to empty. Used by tests; not exported from the
- * package entry-point.
+ * Reset config back to empty. Exported via the package's `./server`
+ * subpath for tests; production callers should treat the config as
+ * write-once at boot.
  */
 export function __resetServerSdkConfig(): void {
   currentConfig = {};

--- a/packages/pillar-sdk/src/server/errors.ts
+++ b/packages/pillar-sdk/src/server/errors.ts
@@ -1,0 +1,16 @@
+/**
+ * Thrown the first time `pillar()` (server) is invoked without a
+ * service-account API key available — either via {@link configureServerSdk}
+ * or the `POPS_INTERNAL_API_KEY` env var.
+ *
+ * Server-side calls go pillar-to-pillar without traversing nginx, so the
+ * absence of an internal key is treated as a configuration bug rather than
+ * a transient runtime failure.
+ */
+export class PillarServerSdkError extends Error {
+  override readonly name = 'PillarServerSdkError';
+
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+  }
+}

--- a/packages/pillar-sdk/src/server/factory.ts
+++ b/packages/pillar-sdk/src/server/factory.ts
@@ -1,0 +1,163 @@
+import {
+  HttpDiscoveryTransport,
+  pillar as clientPillar,
+  type DiscoveryTransport,
+  type PillarClientOptions,
+  type PillarHandle,
+} from '../client/index.js';
+import { getServerSdkConfig, resolveApiKey, SERVER_SDK_API_KEY_ENV } from './config.js';
+import { PillarServerSdkError } from './errors.js';
+import { InternalBaseUrlTransport } from './transport.js';
+
+/**
+ * Per-call options for the server `pillar()`. Mirrors the client options
+ * but with server-specific knobs only:
+ *
+ * - `contractVersion`: opt-in major-version pinning, identical semantics
+ *   to the client.
+ * - `transport`, `fetchImpl`, `cacheTtlMs`: escape hatches for tests.
+ *   Production callers should configure these via {@link configureServerSdk}
+ *   and let the per-call handle reuse them.
+ */
+export type ServerPillarOptions = {
+  contractVersion?: string;
+  transport?: DiscoveryTransport;
+  fetchImpl?: typeof fetch;
+  cacheTtlMs?: number;
+};
+
+type CacheKey = string;
+
+type CachedHandle = {
+  handle: PillarHandle<unknown>;
+  configSnapshot: object;
+};
+
+const handleCache = new Map<CacheKey, CachedHandle>();
+
+/**
+ * Server-side `pillar()`. Same proxy shape as the client surface, but:
+ *
+ *  - Authenticates with the `POPS_INTERNAL_API_KEY` env var (or a key set
+ *    via {@link configureServerSdk}) as `X-API-Key`.
+ *  - Reuses a per-pillar handle (and therefore its discovery cache) across
+ *    calls within the same process, so a worker hitting `pillar('finance')`
+ *    in a tight loop does one registry fetch per TTL window.
+ *  - Optionally rewrites discovered base URLs via the configured
+ *    `internalBaseUrls` map.
+ *
+ * Throws {@link PillarServerSdkError} on first call if no service-account
+ * key is available — server-to-server traffic must be authenticated.
+ *
+ * @example
+ * configureServerSdk({ apiKey: process.env.POPS_INTERNAL_API_KEY });
+ * const finance = pillar<FinanceRouter>('finance');
+ * const movies = await finance.wishlist.list({ limit: 10 });
+ */
+export function pillar<TRouter>(
+  pillarId: string,
+  options: ServerPillarOptions = {}
+): PillarHandle<TRouter> {
+  const apiKey = resolveApiKey();
+  if (apiKey === undefined) {
+    throw new PillarServerSdkError(
+      `service-account auth required for server-side SDK: set ${SERVER_SDK_API_KEY_ENV} or call configureServerSdk({ apiKey }).`
+    );
+  }
+
+  const config = getServerSdkConfig();
+  const cacheKey = buildCacheKey(pillarId, options);
+  const configSnapshot = snapshotConfig(config, options);
+  const existing = handleCache.get(cacheKey);
+  if (existing !== undefined && shallowEqual(existing.configSnapshot, configSnapshot)) {
+    return existing.handle as PillarHandle<TRouter>;
+  }
+
+  const clientOptions = buildClientOptions(apiKey, config, options);
+  const handle = clientPillar<TRouter>(pillarId, clientOptions);
+  handleCache.set(cacheKey, {
+    handle: handle as PillarHandle<unknown>,
+    configSnapshot,
+  });
+  return handle;
+}
+
+function buildClientOptions(
+  apiKey: string,
+  config: ReturnType<typeof getServerSdkConfig>,
+  options: ServerPillarOptions
+): PillarClientOptions {
+  const transport = resolveTransport(config, options);
+  const clientOptions: PillarClientOptions = {
+    transport,
+    authHeaders: () => ({ 'x-api-key': apiKey }),
+  };
+  const fetchImpl = options.fetchImpl ?? config.fetchImpl;
+  if (fetchImpl !== undefined) clientOptions.fetchImpl = fetchImpl;
+  if (options.cacheTtlMs !== undefined) clientOptions.cacheTtlMs = options.cacheTtlMs;
+  else if (config.cacheTtlMs !== undefined) clientOptions.cacheTtlMs = config.cacheTtlMs;
+  if (config.callTimeoutMs !== undefined) clientOptions.callTimeoutMs = config.callTimeoutMs;
+  if (options.contractVersion !== undefined)
+    clientOptions.contractVersion = options.contractVersion;
+  return clientOptions;
+}
+
+function resolveTransport(
+  config: ReturnType<typeof getServerSdkConfig>,
+  options: ServerPillarOptions
+): DiscoveryTransport {
+  if (options.transport !== undefined) {
+    return wrapWithOverrides(options.transport, config.internalBaseUrls);
+  }
+  const base = new HttpDiscoveryTransport(config.registry ?? {});
+  return wrapWithOverrides(base, config.internalBaseUrls);
+}
+
+function wrapWithOverrides(
+  inner: DiscoveryTransport,
+  overrides: Record<string, string> | undefined
+): DiscoveryTransport {
+  if (overrides === undefined || Object.keys(overrides).length === 0) return inner;
+  return new InternalBaseUrlTransport(inner, overrides);
+}
+
+function buildCacheKey(pillarId: string, options: ServerPillarOptions): CacheKey {
+  return `${pillarId}::${options.contractVersion ?? ''}::${options.transport ? 'custom-transport' : 'default-transport'}::${options.fetchImpl ? 'custom-fetch' : 'default-fetch'}::${options.cacheTtlMs ?? ''}`;
+}
+
+function snapshotConfig(
+  config: ReturnType<typeof getServerSdkConfig>,
+  options: ServerPillarOptions
+): object {
+  return {
+    apiKey: config.apiKey ?? null,
+    fetchImpl: config.fetchImpl ?? null,
+    callTimeoutMs: config.callTimeoutMs ?? null,
+    cacheTtlMs: options.cacheTtlMs ?? config.cacheTtlMs ?? null,
+    registry: config.registry ?? null,
+    internalBaseUrls: config.internalBaseUrls ?? null,
+    transport: options.transport ?? null,
+    fetchOverride: options.fetchImpl ?? null,
+    contractVersion: options.contractVersion ?? null,
+  };
+}
+
+function shallowEqual(a: object, b: object): boolean {
+  const ak = Object.keys(a as Record<string, unknown>);
+  const bk = Object.keys(b as Record<string, unknown>);
+  if (ak.length !== bk.length) return false;
+  const ar = a as Record<string, unknown>;
+  const br = b as Record<string, unknown>;
+  for (const k of ak) {
+    if (ar[k] !== br[k]) return false;
+  }
+  return true;
+}
+
+/**
+ * Drop every memoised pillar handle. Used by tests; production callers
+ * should rely on TTL-based discovery refresh instead.
+ */
+export function __resetServerPillarCache(): void {
+  handleCache.clear();
+}

--- a/packages/pillar-sdk/src/server/factory.ts
+++ b/packages/pillar-sdk/src/server/factory.ts
@@ -58,8 +58,7 @@ export function pillar<TRouter>(
   pillarId: string,
   options: ServerPillarOptions = {}
 ): PillarHandle<TRouter> {
-  const apiKey = resolveApiKey();
-  if (apiKey === undefined) {
+  if (resolveApiKey() === undefined) {
     throw new PillarServerSdkError(
       `service-account auth required for server-side SDK: set ${SERVER_SDK_API_KEY_ENV} or call configureServerSdk({ apiKey }).`
     );
@@ -73,7 +72,7 @@ export function pillar<TRouter>(
     return existing.handle as PillarHandle<TRouter>;
   }
 
-  const clientOptions = buildClientOptions(apiKey, config, options);
+  const clientOptions = buildClientOptions(config, options);
   const handle = clientPillar<TRouter>(pillarId, clientOptions);
   handleCache.set(cacheKey, {
     handle: handle as PillarHandle<unknown>,
@@ -83,14 +82,21 @@ export function pillar<TRouter>(
 }
 
 function buildClientOptions(
-  apiKey: string,
   config: ReturnType<typeof getServerSdkConfig>,
   options: ServerPillarOptions
 ): PillarClientOptions {
   const transport = resolveTransport(config, options);
   const clientOptions: PillarClientOptions = {
     transport,
-    authHeaders: () => ({ 'x-api-key': apiKey }),
+    authHeaders: () => {
+      const current = resolveApiKey();
+      if (current === undefined) {
+        throw new PillarServerSdkError(
+          `service-account auth required for server-side SDK call: set ${SERVER_SDK_API_KEY_ENV} or call configureServerSdk({ apiKey }).`
+        );
+      }
+      return { 'x-api-key': current };
+    },
   };
   const fetchImpl = options.fetchImpl ?? config.fetchImpl;
   if (fetchImpl !== undefined) clientOptions.fetchImpl = fetchImpl;

--- a/packages/pillar-sdk/src/server/index.ts
+++ b/packages/pillar-sdk/src/server/index.ts
@@ -1,0 +1,24 @@
+export { pillar, __resetServerPillarCache } from './factory.js';
+export type { ServerPillarOptions } from './factory.js';
+export {
+  configureServerSdk,
+  getServerSdkConfig,
+  resolveApiKey,
+  SERVER_SDK_API_KEY_ENV,
+  __resetServerSdkConfig,
+} from './config.js';
+export type { ServerSdkConfig } from './config.js';
+export { PillarServerSdkError } from './errors.js';
+export { InternalBaseUrlTransport } from './transport.js';
+
+export type {
+  PillarHandle,
+  CallableProcedure,
+  PillarClientOptions,
+  DiscoveredPillar,
+  DiscoveryTransport,
+  CallFailure,
+  CallResult,
+  CallSuccess,
+} from '../client/index.js';
+export { PillarCallError, PillarSdkError, isOk } from '../client/index.js';

--- a/packages/pillar-sdk/src/server/transport.ts
+++ b/packages/pillar-sdk/src/server/transport.ts
@@ -1,0 +1,29 @@
+import type { DiscoveredPillar, DiscoveryTransport } from '../client/index.js';
+
+/**
+ * Wraps an existing discovery transport and rewrites the `baseUrl` of
+ * each discovered pillar against the supplied overrides map. Used by the
+ * server SDK to redirect in-cluster calls at internal Docker hostnames
+ * (or `localhost` in dev) without round-tripping through nginx.
+ *
+ * The override map is matched by `pillarId`. Pillars not in the map are
+ * passed through untouched, so partial maps are fine — e.g. override
+ * `finance` for a local debugging session while every other pillar still
+ * goes to its registry-advertised hostname.
+ */
+export class InternalBaseUrlTransport implements DiscoveryTransport {
+  constructor(
+    private readonly inner: DiscoveryTransport,
+    private readonly overrides: Readonly<Record<string, string>>
+  ) {}
+
+  async fetchSnapshot(): Promise<readonly DiscoveredPillar[]> {
+    const snapshot = await this.inner.fetchSnapshot();
+    if (Object.keys(this.overrides).length === 0) return snapshot;
+    return snapshot.map((entry) => {
+      const override = this.overrides[entry.pillarId];
+      if (override === undefined) return entry;
+      return { ...entry, baseUrl: override };
+    });
+  }
+}


### PR DESCRIPTION
## Summary

- New `@pops/pillar-sdk/server` subpath: same `pillar('id').router.proc(...)` proxy shape as the client surface, but tuned for sibling-pillar / worker callers.
- Service-account auth: `X-API-Key` injected on every outbound call, resolved from `configureServerSdk({ apiKey })` or `POPS_INTERNAL_API_KEY`. First call throws `PillarServerSdkError` with a self-diagnosing message when neither is set.
- Per-pillar handle memoisation so the underlying discovery cache survives across `pillar()` calls within a process; rebuilt when the resolved config changes (e.g. key rotation).
- Optional `internalBaseUrls` map rewrites registry-published base URLs at the transport boundary via `InternalBaseUrlTransport` — useful for localhost dev or routing around the published Docker hostname.
- 202/202 package tests pass (29 new for the server surface across `config`, `transport`, and `factory`).

## Layering

- Reuses `client/factory.ts` end-to-end — same proxy, same `CallResult` discriminants, same contract-version skew detection. The server module only owns auth resolution, transport composition, and handle-level memoisation.
- `discovery/` (PRD-159) remains the registry-snapshot reader; the server transport sits *between* `discovery` and `client` by wrapping a configured `DiscoveryTransport`.
- `bootstrap/` (PRD-158) is the producer side (a pillar registering itself); `server/` is the consumer side (a pillar talking to a sibling). They share no state but the registry is the rendezvous point.

## Test plan

- [x] `pnpm --filter @pops/pillar-sdk test`
- [x] `pnpm --filter @pops/pillar-sdk typecheck`
- [x] `pnpm typecheck` (all 55 workspace packages)
- [x] `pnpm lint`