### PR TITLE
feat(docs): pops-docs Stoplight Elements container (Theme 13 PRD-219)

### DIFF
--- a/apps/pops-docs/Dockerfile
+++ b/apps/pops-docs/Dockerfile
@@ -1,0 +1,25 @@
+FROM node:22-alpine AS builder
+WORKDIR /app
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json ./
+COPY apps/pops-docs/package.json ./apps/pops-docs/
+
+RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
+    corepack enable && pnpm install --frozen-lockfile --filter @pops/docs...
+
+COPY apps/pops-docs/ ./apps/pops-docs/
+COPY packages/ ./packages/
+
+WORKDIR /app/apps/pops-docs
+RUN pnpm build
+
+# ── Production image ──────────────────────────────────────────────
+FROM nginx:alpine
+COPY --from=builder /app/apps/pops-docs/dist /usr/share/nginx/html
+COPY apps/pops-docs/nginx/default.conf /etc/nginx/conf.d/default.conf
+
+EXPOSE 80
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+    CMD wget -q --spider http://127.0.0.1:80/healthz || exit 1
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/apps/pops-docs/nginx/default.conf
+++ b/apps/pops-docs/nginx/default.conf
@@ -1,0 +1,32 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript image/svg+xml;
+    gzip_min_length 256;
+
+    location = /healthz {
+        access_log off;
+        default_type application/json;
+        return 200 '{"ok":true}\n';
+    }
+
+    location = /catalog.json {
+        default_type application/json;
+        add_header Cache-Control "no-store";
+        try_files /catalog.json =404;
+    }
+
+    location /openapi/ {
+        default_type application/json;
+        add_header Cache-Control "public, max-age=300";
+        try_files $uri =404;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/apps/pops-docs/package.json
+++ b/apps/pops-docs/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@pops/docs",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Static container serving Stoplight Elements pointed at every contract's OpenAPI snapshot (Theme 13 PRD-219).",
+  "type": "module",
+  "scripts": {
+    "build": "tsx scripts/collect-specs.ts",
+    "dev": "tsx scripts/dev-serve.ts",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "devDependencies": {
+    "@types/node": "^25.9.3",
+    "tsx": "^4.22.4",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.8"
+  }
+}

--- a/apps/pops-docs/scripts/collect-specs.test.ts
+++ b/apps/pops-docs/scripts/collect-specs.test.ts
@@ -1,0 +1,53 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync, rmSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import type { Catalog } from '../src/catalog.ts';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const APP_ROOT = resolve(HERE, '..');
+const REPO_ROOT = resolve(APP_ROOT, '..', '..');
+const DIST_DIR = resolve(APP_ROOT, 'dist');
+
+describe('collect-specs', () => {
+  it('discovers the finance contract snapshot and emits a catalog entry', () => {
+    rmSync(DIST_DIR, { recursive: true, force: true });
+
+    const result = spawnSync('tsx', [resolve(HERE, 'collect-specs.ts')], {
+      cwd: APP_ROOT,
+      encoding: 'utf8',
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+
+    const catalog = JSON.parse(readFileSync(resolve(DIST_DIR, 'catalog.json'), 'utf8')) as Catalog;
+    expect(catalog.generatedAt).toBeTypeOf('string');
+    expect(catalog.contracts.length).toBeGreaterThanOrEqual(1);
+
+    const finance = catalog.contracts.find((entry) => entry.id === 'finance');
+    expect(finance, 'expected a finance contract entry in the catalog').toBeDefined();
+    expect(finance?.openapiPath).toBe('/openapi/finance.json');
+    expect(finance?.registryPillarId).toBe('finance');
+    expect(finance?.contractTag).toMatch(/^contract-finance@v/);
+
+    expect(existsSync(resolve(DIST_DIR, 'openapi', 'finance.json'))).toBe(true);
+    expect(existsSync(resolve(DIST_DIR, 'index.html'))).toBe(true);
+    expect(existsSync(resolve(DIST_DIR, 'styles.css'))).toBe(true);
+
+    const copiedSpec = JSON.parse(
+      readFileSync(resolve(DIST_DIR, 'openapi', 'finance.json'), 'utf8')
+    ) as {
+      info?: { title?: string };
+    };
+    const sourceSpec = JSON.parse(
+      readFileSync(
+        resolve(REPO_ROOT, 'packages/finance-contract/openapi/finance.openapi.json'),
+        'utf8'
+      )
+    ) as { info?: { title?: string } };
+    expect(copiedSpec.info?.title).toBe(sourceSpec.info?.title);
+  });
+});

--- a/apps/pops-docs/scripts/collect-specs.ts
+++ b/apps/pops-docs/scripts/collect-specs.ts
@@ -1,0 +1,139 @@
+/**
+ * Theme 13 PRD-219 — collect every contract package's OpenAPI snapshot
+ * into the pops-docs image build context.
+ *
+ * Walks `packages/*-contract/` from the monorepo root. For each contract:
+ *   - if `openapi/<pillar>.openapi.json` exists → emit a catalog entry,
+ *     copy the spec into `apps/pops-docs/dist/openapi/<pillar>.json`
+ *   - otherwise → log a warning and skip (the contract is in flight but
+ *     hasn't generated its snapshot yet; that is not an error)
+ *
+ * The output `catalog.json` is what `src/index.html` reads at runtime to
+ * populate Stoplight Elements' multi-spec navigation. There is no runtime
+ * registry dependency: the catalog snapshot reflects the contracts that
+ * existed at image build time, which is exactly the deploy semantics the
+ * PRD calls for (a container redeploy reflects the latest contracts).
+ *
+ * `generatedAt` records the current git commit sha when the build is
+ * inside a git checkout, otherwise the ISO timestamp — handy when the
+ * image is built from a release tarball where `.git` is absent.
+ */
+import { execSync } from 'node:child_process';
+import {
+  cpSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  buildCatalog,
+  type CollectedContract,
+  type ContractPackageJson,
+  type OpenApiSnapshot,
+} from '../src/catalog.ts';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const APP_ROOT = resolve(HERE, '..');
+const REPO_ROOT = resolve(APP_ROOT, '..', '..');
+const PACKAGES_DIR = resolve(REPO_ROOT, 'packages');
+const SRC_DIR = resolve(APP_ROOT, 'src');
+const OUT_DIR = resolve(APP_ROOT, 'dist');
+const OUT_OPENAPI_DIR = resolve(OUT_DIR, 'openapi');
+
+function readJson<T>(path: string): T {
+  return JSON.parse(readFileSync(path, 'utf8')) as T;
+}
+
+function resolveGitSha(): string {
+  try {
+    return execSync('git rev-parse HEAD', { cwd: REPO_ROOT, stdio: ['ignore', 'pipe', 'ignore'] })
+      .toString()
+      .trim();
+  } catch {
+    return new Date().toISOString();
+  }
+}
+
+/**
+ * Discover every `packages/*-contract` directory that ships an OpenAPI
+ * snapshot. Pure filesystem walk — no workspace manifest required.
+ */
+function discoverContracts(): CollectedContract[] {
+  const entries = readdirSync(PACKAGES_DIR, { withFileTypes: true });
+  const collected: CollectedContract[] = [];
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    if (!entry.name.endsWith('-contract')) continue;
+
+    const id = entry.name.replace(/-contract$/, '');
+    const pkgDir = resolve(PACKAGES_DIR, entry.name);
+    const pkgJsonPath = resolve(pkgDir, 'package.json');
+    const openapiPath = resolve(pkgDir, 'openapi', `${id}.openapi.json`);
+
+    let pkg: ContractPackageJson;
+    try {
+      pkg = readJson<ContractPackageJson>(pkgJsonPath);
+    } catch {
+      console.warn(`[pops-docs] skipping ${entry.name}: package.json unreadable`);
+      continue;
+    }
+
+    let snapshot: OpenApiSnapshot;
+    try {
+      statSync(openapiPath);
+      snapshot = readJson<OpenApiSnapshot>(openapiPath);
+    } catch {
+      console.warn(
+        `[pops-docs] skipping ${entry.name}: no openapi snapshot at openapi/${id}.openapi.json`
+      );
+      continue;
+    }
+
+    collected.push({
+      id,
+      packageName: pkg.name,
+      packageVersion: pkg.version,
+      sourcePath: openapiPath,
+      snapshot,
+    });
+  }
+
+  return collected.toSorted((a, b) => a.id.localeCompare(b.id));
+}
+
+function main(): void {
+  rmSync(OUT_DIR, { recursive: true, force: true });
+  mkdirSync(OUT_DIR, { recursive: true });
+  mkdirSync(OUT_OPENAPI_DIR, { recursive: true });
+
+  const contracts = discoverContracts();
+  if (contracts.length === 0) {
+    console.warn('[pops-docs] no contract OpenAPI snapshots discovered — catalog will be empty');
+  }
+
+  for (const contract of contracts) {
+    const dest = resolve(OUT_OPENAPI_DIR, `${contract.id}.json`);
+    cpSync(contract.sourcePath, dest);
+  }
+
+  const catalog = buildCatalog({ generatedAt: resolveGitSha(), contracts });
+  writeFileSync(resolve(OUT_DIR, 'catalog.json'), `${JSON.stringify(catalog, null, 2)}\n`);
+
+  for (const staticFile of ['index.html', 'styles.css'] as const) {
+    cpSync(resolve(SRC_DIR, staticFile), resolve(OUT_DIR, staticFile));
+  }
+
+  process.stdout.write(`[pops-docs] catalog ready — ${catalog.contracts.length} contract(s)\n`);
+  for (const entry of catalog.contracts) {
+    process.stdout.write(`  - ${entry.id}@${entry.version} → ${entry.openapiPath}\n`);
+  }
+}
+
+main();

--- a/apps/pops-docs/scripts/dev-serve.ts
+++ b/apps/pops-docs/scripts/dev-serve.ts
@@ -1,0 +1,110 @@
+/**
+ * Local dev server for pops-docs (Theme 13 PRD-219 US-05).
+ *
+ * Behaviour:
+ *   1. Runs `collect-specs.ts` once to populate `dist/`
+ *   2. Watches every discovered `packages/*-contract/openapi/` directory
+ *      and re-runs the collector when an OpenAPI snapshot changes (so
+ *      contract authors can preview docs without restarting the server)
+ *   3. Serves `dist/` over a tiny Node http server on `POPS_DOCS_PORT`
+ *      (default 4280) with the same URL layout that nginx serves in prod
+ *
+ * Intentionally has no third-party server dependency — Stoplight
+ * Elements is loaded from a CDN by `index.html`, and Node's built-in
+ * `http`/`fs.watch` are enough for a local preview.
+ */
+import { spawnSync } from 'node:child_process';
+import { createReadStream, readdirSync, statSync, watch } from 'node:fs';
+import { createServer } from 'node:http';
+import { dirname, extname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const APP_ROOT = resolve(HERE, '..');
+const REPO_ROOT = resolve(APP_ROOT, '..', '..');
+const PACKAGES_DIR = resolve(REPO_ROOT, 'packages');
+const DIST_DIR = resolve(APP_ROOT, 'dist');
+const COLLECT_SCRIPT = resolve(HERE, 'collect-specs.ts');
+
+const PORT = Number.parseInt(process.env.POPS_DOCS_PORT ?? '4280', 10);
+
+const MIME: Readonly<Record<string, string>> = {
+  '.html': 'text/html; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+};
+
+function runCollect(): void {
+  const result = spawnSync('tsx', [COLLECT_SCRIPT], { cwd: APP_ROOT, stdio: 'inherit' });
+  if (result.status !== 0) {
+    process.stderr.write('[pops-docs] collect-specs failed\n');
+  }
+}
+
+function watchOpenapiDirs(): void {
+  const dirs: string[] = [];
+  for (const entry of readdirSync(PACKAGES_DIR, { withFileTypes: true })) {
+    if (!entry.isDirectory() || !entry.name.endsWith('-contract')) continue;
+    const candidate = resolve(PACKAGES_DIR, entry.name, 'openapi');
+    try {
+      if (statSync(candidate).isDirectory()) dirs.push(candidate);
+    } catch {
+      continue;
+    }
+  }
+
+  let pending: NodeJS.Timeout | null = null;
+  const debouncedRecollect = (): void => {
+    if (pending) clearTimeout(pending);
+    pending = setTimeout(() => {
+      pending = null;
+      process.stdout.write('[pops-docs] contract change detected — recollecting\n');
+      runCollect();
+    }, 200);
+  };
+
+  for (const dir of dirs) {
+    watch(dir, { persistent: true }, debouncedRecollect);
+    process.stdout.write(`[pops-docs] watching ${dir}\n`);
+  }
+}
+
+function resolveServePath(urlPath: string): string {
+  if (urlPath === '/' || urlPath === '') return resolve(DIST_DIR, 'index.html');
+  const safe = urlPath.replace(/\?.*$/, '').replace(/\.\.+/g, '');
+  return resolve(DIST_DIR, `.${safe}`);
+}
+
+function startHttpServer(): void {
+  const server = createServer((req, res) => {
+    const url = req.url ?? '/';
+    if (url === '/healthz') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end('{"ok":true}\n');
+      return;
+    }
+
+    const filePath = resolveServePath(url);
+    try {
+      const stat = statSync(filePath);
+      if (!stat.isFile()) throw new Error('not a file');
+    } catch {
+      res.writeHead(404, { 'Content-Type': 'text/plain' });
+      res.end('not found');
+      return;
+    }
+
+    res.writeHead(200, { 'Content-Type': MIME[extname(filePath)] ?? 'application/octet-stream' });
+    createReadStream(filePath).pipe(res);
+  });
+
+  server.listen(PORT, () => {
+    process.stdout.write(`[pops-docs] dev server on http://localhost:${PORT}\n`);
+  });
+}
+
+runCollect();
+watchOpenapiDirs();
+startHttpServer();

--- a/apps/pops-docs/src/catalog.test.ts
+++ b/apps/pops-docs/src/catalog.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildCatalog, type CollectedContract } from './catalog.ts';
+
+function makeContract(overrides: Partial<CollectedContract> & { id: string }): CollectedContract {
+  return {
+    packageName: `@pops/${overrides.id}-contract`,
+    packageVersion: '0.1.0',
+    sourcePath: `/tmp/${overrides.id}.openapi.json`,
+    snapshot: {},
+    ...overrides,
+  };
+}
+
+describe('buildCatalog', () => {
+  it('preserves generatedAt unchanged', () => {
+    const catalog = buildCatalog({ generatedAt: 'abc123', contracts: [] });
+    expect(catalog.generatedAt).toBe('abc123');
+  });
+
+  it('produces an empty catalog when no contracts are collected', () => {
+    const catalog = buildCatalog({ generatedAt: 'sha', contracts: [] });
+    expect(catalog.contracts).toEqual([]);
+  });
+
+  it('maps a contract using OpenAPI info.title + info.version when present', () => {
+    const catalog = buildCatalog({
+      generatedAt: 'sha',
+      contracts: [
+        makeContract({
+          id: 'finance',
+          packageVersion: '0.1.0',
+          snapshot: { info: { title: 'Finance Pillar', version: '1.4.2' } },
+        }),
+      ],
+    });
+
+    expect(catalog.contracts).toHaveLength(1);
+    expect(catalog.contracts[0]).toEqual({
+      id: 'finance',
+      name: 'Finance Pillar',
+      version: '1.4.2',
+      openapiPath: '/openapi/finance.json',
+      registryPillarId: 'finance',
+      contractTag: 'contract-finance@v1.4.2',
+    });
+  });
+
+  it('falls back to capitalised id when info.title is missing', () => {
+    const catalog = buildCatalog({
+      generatedAt: 'sha',
+      contracts: [makeContract({ id: 'media', packageVersion: '0.3.0' })],
+    });
+
+    expect(catalog.contracts[0]?.name).toBe('Media');
+    expect(catalog.contracts[0]?.version).toBe('0.3.0');
+    expect(catalog.contracts[0]?.contractTag).toBe('contract-media@v0.3.0');
+  });
+
+  it('falls back to package.json version when info.version is blank', () => {
+    const catalog = buildCatalog({
+      generatedAt: 'sha',
+      contracts: [
+        makeContract({
+          id: 'lists',
+          packageVersion: '0.2.0',
+          snapshot: { info: { title: 'Lists', version: '   ' } },
+        }),
+      ],
+    });
+
+    expect(catalog.contracts[0]?.version).toBe('0.2.0');
+  });
+
+  it('emits one openapi path per contract id', () => {
+    const catalog = buildCatalog({
+      generatedAt: 'sha',
+      contracts: [
+        makeContract({ id: 'finance' }),
+        makeContract({ id: 'media' }),
+        makeContract({ id: 'inventory' }),
+      ],
+    });
+
+    expect(catalog.contracts.map((c) => c.openapiPath)).toEqual([
+      '/openapi/finance.json',
+      '/openapi/media.json',
+      '/openapi/inventory.json',
+    ]);
+  });
+});

--- a/apps/pops-docs/src/catalog.ts
+++ b/apps/pops-docs/src/catalog.ts
@@ -1,0 +1,89 @@
+/**
+ * Catalog builder for pops-docs (Theme 13 PRD-219).
+ *
+ * Separated from `scripts/collect-specs.ts` so the transformation from
+ * "list of contract package directories" → "Stoplight Elements catalog"
+ * is testable without the filesystem walk or git invocation.
+ */
+
+export interface ContractPackageJson {
+  readonly name: string;
+  readonly version: string;
+}
+
+export interface OpenApiInfo {
+  readonly title?: string;
+  readonly version?: string;
+  readonly description?: string;
+}
+
+export interface OpenApiSnapshot {
+  readonly info?: OpenApiInfo;
+}
+
+export interface CollectedContract {
+  readonly id: string;
+  readonly packageName: string;
+  readonly packageVersion: string;
+  readonly sourcePath: string;
+  readonly snapshot: OpenApiSnapshot;
+}
+
+export interface CatalogContract {
+  readonly id: string;
+  readonly name: string;
+  readonly version: string;
+  readonly openapiPath: string;
+  readonly registryPillarId: string;
+  readonly contractTag: string;
+}
+
+export interface Catalog {
+  readonly generatedAt: string;
+  readonly contracts: readonly CatalogContract[];
+}
+
+export interface BuildCatalogInput {
+  readonly generatedAt: string;
+  readonly contracts: readonly CollectedContract[];
+}
+
+/**
+ * `info.title` from the OpenAPI snapshot is human-friendly when present;
+ * otherwise fall back to the contract id capitalised so the sidebar in
+ * Stoplight Elements stays readable for in-flight contracts that have
+ * not customised their title yet.
+ */
+function displayName(contract: CollectedContract): string {
+  const fromSpec = contract.snapshot.info?.title?.trim();
+  if (fromSpec && fromSpec.length > 0) return fromSpec;
+  return contract.id.charAt(0).toUpperCase() + contract.id.slice(1);
+}
+
+/**
+ * Prefer the OpenAPI snapshot's `info.version` (the contract package's
+ * own `package.json` version is what feeds it via the generator) and
+ * fall back to the raw package.json version if a hand-rolled snapshot
+ * happens to omit it.
+ */
+function displayVersion(contract: CollectedContract): string {
+  const fromSpec = contract.snapshot.info?.version?.trim();
+  if (fromSpec && fromSpec.length > 0) return fromSpec;
+  return contract.packageVersion;
+}
+
+export function buildCatalog(input: BuildCatalogInput): Catalog {
+  const contracts = input.contracts.map<CatalogContract>((contract) => {
+    const version = displayVersion(contract);
+    return {
+      id: contract.id,
+      name: displayName(contract),
+      version,
+      openapiPath: `/openapi/${contract.id}.json`,
+      registryPillarId: contract.id,
+      contractTag: `contract-${contract.id}@v${version}`,
+    };
+  });
+
+  return { generatedAt: input.generatedAt, contracts };
+}

--- a/apps/pops-docs/src/index.html
+++ b/apps/pops-docs/src/index.html
@@ -1,0 +1,101 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>POPS — API docs</title>
+    <link rel="stylesheet" href="/styles.css" />
+    <link rel="stylesheet" href="https://unpkg.com/@stoplight/elements@9.0.6/styles.min.css" />
+    <script
+      src="https://unpkg.com/@stoplight/elements@9.0.6/web-components.min.js"
+      defer
+      crossorigin="anonymous"
+    ></script>
+  </head>
+  <body>
+    <header class="pops-docs-header">
+      <h1>POPS — API docs</h1>
+      <p>Live navigable view of every contract package's OpenAPI surface.</p>
+    </header>
+    <main id="pops-docs-root" class="pops-docs-root">
+      <p class="pops-docs-loading">Loading catalog…</p>
+    </main>
+    <script>
+      (async () => {
+        const root = document.getElementById('pops-docs-root');
+        try {
+          const catalogResponse = await fetch('/catalog.json', { cache: 'no-store' });
+          if (!catalogResponse.ok) {
+            throw new Error('catalog fetch failed: ' + catalogResponse.status);
+          }
+          const catalog = await catalogResponse.json();
+          const contracts = Array.isArray(catalog.contracts) ? catalog.contracts : [];
+
+          if (contracts.length === 0) {
+            root.innerHTML =
+              '<p class="pops-docs-empty">No contract OpenAPI snapshots in this build. Generate one via the contract package and rebuild this image.</p>';
+            return;
+          }
+
+          if (contracts.length === 1) {
+            const only = contracts[0];
+            const element = document.createElement('elements-api');
+            element.setAttribute('apiDescriptionUrl', only.openapiPath);
+            element.setAttribute('router', 'hash');
+            element.setAttribute('layout', 'sidebar');
+            element.setAttribute('hideInternal', 'true');
+            root.replaceChildren(element);
+            return;
+          }
+
+          const nav = document.createElement('nav');
+          nav.className = 'pops-docs-nav';
+          const list = document.createElement('ul');
+          for (const contract of contracts) {
+            const item = document.createElement('li');
+            const button = document.createElement('button');
+            button.type = 'button';
+            button.textContent = contract.name + ' v' + contract.version;
+            button.dataset.contractId = contract.id;
+            button.dataset.openapiPath = contract.openapiPath;
+            item.appendChild(button);
+            list.appendChild(item);
+          }
+          nav.appendChild(list);
+
+          const stage = document.createElement('section');
+          stage.className = 'pops-docs-stage';
+
+          root.replaceChildren(nav, stage);
+
+          const mount = (contract) => {
+            stage.innerHTML = '';
+            const element = document.createElement('elements-api');
+            element.setAttribute('apiDescriptionUrl', contract.openapiPath);
+            element.setAttribute('router', 'hash');
+            element.setAttribute('layout', 'sidebar');
+            element.setAttribute('hideInternal', 'true');
+            stage.appendChild(element);
+            for (const button of nav.querySelectorAll('button')) {
+              button.classList.toggle('is-active', button.dataset.contractId === contract.id);
+            }
+          };
+
+          nav.addEventListener('click', (event) => {
+            const target = event.target;
+            if (!(target instanceof HTMLButtonElement)) return;
+            const match = contracts.find((c) => c.id === target.dataset.contractId);
+            if (match) mount(match);
+          });
+
+          mount(contracts[0]);
+        } catch (error) {
+          root.innerHTML =
+            '<p class="pops-docs-error">Failed to load catalog: ' +
+            (error instanceof Error ? error.message : String(error)) +
+            '</p>';
+        }
+      })();
+    </script>
+  </body>
+</html>

--- a/apps/pops-docs/src/styles.css
+++ b/apps/pops-docs/src/styles.css
@@ -1,0 +1,109 @@
+:root {
+  color-scheme: dark;
+  --pops-docs-bg: #0b0d10;
+  --pops-docs-surface: #15181d;
+  --pops-docs-border: #232830;
+  --pops-docs-fg: #e7ebf0;
+  --pops-docs-muted: #8a93a0;
+  --pops-docs-accent: #7aa2ff;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  background: var(--pops-docs-bg);
+  color: var(--pops-docs-fg);
+  font-family:
+    'Plus Jakarta Sans',
+    system-ui,
+    -apple-system,
+    'Segoe UI',
+    sans-serif;
+  height: 100%;
+}
+
+.pops-docs-header {
+  padding: 16px 24px;
+  border-bottom: 1px solid var(--pops-docs-border);
+  background: var(--pops-docs-surface);
+}
+
+.pops-docs-header h1 {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.pops-docs-header p {
+  margin: 4px 0 0;
+  color: var(--pops-docs-muted);
+  font-size: 13px;
+}
+
+.pops-docs-root {
+  display: flex;
+  height: calc(100vh - 64px);
+  min-height: 480px;
+}
+
+.pops-docs-nav {
+  width: 240px;
+  border-right: 1px solid var(--pops-docs-border);
+  background: var(--pops-docs-surface);
+  overflow-y: auto;
+}
+
+.pops-docs-nav ul {
+  list-style: none;
+  margin: 0;
+  padding: 12px 0;
+}
+
+.pops-docs-nav button {
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: 0;
+  color: var(--pops-docs-fg);
+  font: inherit;
+  padding: 10px 20px;
+  cursor: pointer;
+  border-left: 2px solid transparent;
+}
+
+.pops-docs-nav button:hover {
+  background: rgba(122, 162, 255, 0.08);
+}
+
+.pops-docs-nav button.is-active {
+  border-left-color: var(--pops-docs-accent);
+  background: rgba(122, 162, 255, 0.12);
+  color: var(--pops-docs-accent);
+}
+
+.pops-docs-stage {
+  flex: 1;
+  overflow: hidden;
+}
+
+.pops-docs-stage elements-api {
+  display: block;
+  height: 100%;
+}
+
+.pops-docs-loading,
+.pops-docs-empty,
+.pops-docs-error {
+  margin: 24px;
+  color: var(--pops-docs-muted);
+}
+
+.pops-docs-error {
+  color: #ff7373;
+}

--- a/apps/pops-docs/tsconfig.json
+++ b/apps/pops-docs/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "lib": ["ES2023"],
+    "types": ["node"],
+    "noEmit": true,
+    "allowImportingTsExtensions": true
+  },
+  "include": ["scripts/**/*.ts", "src/**/*.ts"]
+}

--- a/apps/pops-docs/vitest.config.ts
+++ b/apps/pops-docs/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts', 'scripts/**/*.test.ts'],
+  },
+});

--- a/apps/pops-shell/nginx.conf
+++ b/apps/pops-shell/nginx.conf
@@ -290,6 +290,30 @@ server {
         proxy_send_timeout 10s;
     }
 
+    # API docs browser — Theme 13 PRD-219.
+    #
+    # `pops-docs` is a tiny static nginx image serving Stoplight Elements
+    # pointed at every contract package's OpenAPI snapshot. Variable-form
+    # `proxy_pass` so pops-shell still boots if pops-docs is absent
+    # (consistent with the rest of this file); requests to `/docs/` 502
+    # in that case instead of failing the shell container.
+    #
+    # The trailing slash on `proxy_pass` strips the `/docs/` prefix
+    # before forwarding so pops-docs's own nginx serves `/`, `/catalog.json`,
+    # `/openapi/<pillar>.json`, and `/healthz` at their natural paths.
+    location /docs/ {
+        set $pops_docs_upstream http://pops-docs:80;
+        proxy_pass $pops_docs_upstream/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_connect_timeout 5s;
+        proxy_read_timeout 10s;
+        proxy_send_timeout 10s;
+    }
+
     # SPA fallback — serve index.html for all routes
     location / {
         try_files $uri $uri/ /index.html;

--- a/docs/themes/13-pillar-finale/epics/00-contract-packages.md
+++ b/docs/themes/13-pillar-finale/epics/00-contract-packages.md
@@ -16,7 +16,7 @@ This is the foundation for cross-pillar type safety after the registry-based dis
 | 154 | Semver enforcement CI      | CI job that diffs contract-package public surface (TS + Zod) against last git tag and blocks PRs on mismatched bumps. Includes affected-package rebuild via turbo `--filter='...[<merge-base>]'`. | Not started |
 | 155 | Manifest type generation   | Generate the union `<Pillar>Contract` interface from the per-feature exports so consumers have one entry point                                                                                    | Not started |
 | 156 | Consumer import discipline | Lint rule: "non-owning code may not import from `@pops/<pillar>-db`"; consumers go through `@pops/<pillar>-contract`                                                                              | Not started |
-| 219 | pops-docs container        | Tiny static container serving Stoplight Elements pointed at every contract's OpenAPI spec; browseable at `/docs/`                                                                                 | Not started |
+| 219 | pops-docs container        | Tiny static container serving Stoplight Elements pointed at every contract's OpenAPI spec; browseable at `/docs/`                                                                                 | Done        |
 
 PRDs 153, 154, 155, 156 can run in parallel after 153 establishes the shape. PRD-219 is independent of the rest (only depends on PRD-153 emitting OpenAPI specs); good "filler" PRD when waiting on something else.
 

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -446,6 +446,26 @@ services:
       timeout: 5s
       retries: 3
 
+  # API docs browser — Stoplight Elements pointed at every contract
+  # package's OpenAPI snapshot (Theme 13 PRD-219).
+  pops-docs:
+    build:
+      context: ..
+      dockerfile: apps/pops-docs/Dockerfile
+      args:
+        BUILD_VERSION: ${BUILD_VERSION:-dev}
+    container_name: pops-docs
+    restart: unless-stopped
+    networks:
+      - frontend
+    expose:
+      - '80'
+    healthcheck:
+      test: ['CMD', 'wget', '-q', '--spider', 'http://127.0.0.1:80/healthz']
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
   metabase:
     image: metabase/metabase:v0.52.5
     container_name: pops-metabase

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -476,6 +476,28 @@ services:
       timeout: 5s
       retries: 3
 
+  # API docs browser — Stoplight Elements pointed at every contract
+  # package's OpenAPI snapshot (Theme 13 PRD-219). Purely static; the
+  # `/docs/` location block in pops-shell's nginx.conf reverse-proxies
+  # browser traffic here. The catalog of contracts is a build-time
+  # snapshot baked into the image — redeploys reflect the contracts
+  # that existed at image build time.
+  pops-docs:
+    image: ghcr.io/knoxio/pops-docs:${POPS_IMAGE_TAG:-main}
+    container_name: pops-docs
+    restart: unless-stopped
+    labels:
+      com.centurylinklabs.watchtower.enable: 'true'
+    networks:
+      - frontend
+    expose:
+      - '80'
+    healthcheck:
+      test: ['CMD', 'wget', '-q', '--spider', 'http://127.0.0.1:80/healthz']
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
   metabase:
     image: metabase/metabase:v0.52.5
     container_name: pops-metabase

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -359,6 +359,21 @@ importers:
         specifier: ^4.1.8
         version: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.3)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
 
+  apps/pops-docs:
+    devDependencies:
+      '@types/node':
+        specifier: ^25.9.3
+        version: 25.9.3
+      tsx:
+        specifier: ^4.22.4
+        version: 4.22.4
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.3)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
+
   apps/pops-finance-api:
     dependencies:
       '@pops/core-db':


### PR DESCRIPTION
## Summary

Theme 13 PRD-219 — a tiny static nginx container (`pops-docs`) that serves Stoplight Elements pointed at every `packages/<pillar>-contract/openapi/<pillar>.openapi.json` in the monorepo. Browseable at `/docs/` via the existing pops-shell reverse proxy. Today the catalog lists the finance contract (PRD-153 US-04); future contracts appear automatically with zero catalog maintenance.

- `apps/pops-docs/` — new workspace package: `src/index.html` + `styles.css` (Stoplight Elements bootstrap, CDN-pinned), `scripts/collect-specs.ts` (build-time discovery + catalog emit), `scripts/dev-serve.ts` (`pnpm dev` with hot-reload on contract changes), `nginx/default.conf`, `Dockerfile` (nginx-alpine).
- `infra/docker-compose{,.dev}.yml` — `pops-docs` service on the `frontend` network with `/healthz` healthcheck and Watchtower label.
- `apps/pops-shell/nginx.conf` — new `/docs/` location block that variable-form-proxies to `pops-docs:80`, matching the boot-resilience pattern used elsewhere in the file.
- `docs/themes/13-pillar-finale/epics/00-contract-packages.md` — PRD-219 status → Done.

The catalog snapshot is baked into the image at build time, so a redeploy reflects the contracts that existed at image build time (acceptable: contracts only change in PRs, which already trigger a rebuild via Watchtower).

## Test plan

- [x] `mise typecheck` (56 successful)
- [x] `mise lint` — no new errors (only pre-existing warnings remain)
- [x] `pnpm format:check`
- [x] `apps/pops-docs` unit tests — `buildCatalog` shape, fallbacks for missing `info.title`/`info.version`, multi-contract path emission
- [x] `apps/pops-docs` integration test — runs the real `collect-specs.ts` against `packages/`, asserts `dist/openapi/finance.json` is emitted and the catalog has a matching entry
- [x] `docker compose -f infra/docker-compose.yml config` — valid
- [x] `docker compose -f infra/docker-compose.dev.yml config` — valid
