### PR TITLE
feat(ci): contract semver CI + affected rebuild (Theme 13 PRD-154)

### DIFF
--- a/.github/workflows/contract-semver.yml
+++ b/.github/workflows/contract-semver.yml
@@ -1,0 +1,150 @@
+name: Contract Semver
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/*-contract/**"
+      - "scripts/contract/**"
+      - ".github/workflows/contract-semver.yml"
+  pull_request:
+    paths:
+      - "packages/*-contract/**"
+      - "scripts/contract/**"
+      - ".github/workflows/contract-semver.yml"
+
+concurrency:
+  group: contract-semver-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  semver-and-drift:
+    name: Semver + drift check
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Full history + all tags so `loadBaseline()` can resolve
+          # `contract-<pillar>@v*`. PRs need merge-base to be reachable
+          # for `turbo --filter='...[merge-base]'` later.
+          fetch-depth: 0
+          fetch-tags: true
+
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build shared prerequisites
+        run: |
+          pnpm --filter @pops/db-types build
+          pnpm --filter @pops/types build
+          pnpm --filter @pops/module-registry build
+          pnpm --filter @pops/food-contracts build
+          pnpm --filter @pops/core-db build
+          pnpm --filter @pops/finance-db build
+          pnpm --filter @pops/inventory-db build
+          pnpm --filter @pops/media-db build
+          pnpm --filter @pops/cerebrum-db build
+          pnpm --filter @pops/food-db build
+          pnpm --filter @pops/lists-db build
+          pnpm --filter @pops/app-lists-db build
+          pnpm --filter @pops/app-food-db build
+          pnpm --filter @pops/pillar-sdk build
+          pnpm --filter @pops/finance-contract build
+
+      - name: Regenerate snapshots (in-place)
+        run: pnpm --filter @pops/finance-contract extract:all
+
+      - name: Fail on uncommitted snapshot drift
+        run: |
+          if ! git diff --quiet -- 'packages/*-contract/etc/'; then
+            echo "::error::Contract snapshots in etc/ drifted from a fresh emission."
+            echo "Run \`pnpm -F @pops/finance-contract extract:all\` and commit the result."
+            git --no-pager diff -- 'packages/*-contract/etc/'
+            exit 1
+          fi
+
+      - name: Fail on OpenAPI drift
+        run: |
+          if ! git diff --quiet -- 'packages/*-contract/openapi/'; then
+            echo "::error::Committed OpenAPI snapshot drifted from a fresh emission."
+            echo "Run \`pnpm -F @pops/finance-contract build\` and commit openapi/finance.openapi.json."
+            git --no-pager diff -- 'packages/*-contract/openapi/'
+            exit 1
+          fi
+
+      - name: Diff vs baseline tag
+        run: pnpm tsx scripts/contract/diff-contract.ts --pillar finance
+
+  affected-rebuild:
+    name: Affected rebuild (turbo --filter='...[<merge-base>]')
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Compute merge-base
+        id: merge-base
+        run: |
+          # PR's base ref vs HEAD. The fetch-depth: 0 above guarantees
+          # both sides are present; merge-base anchors the diff to the
+          # branch's actual fork point, not main's tip.
+          BASE_REF="origin/${{ github.event.pull_request.base.ref }}"
+          MERGE_BASE="$(git merge-base "$BASE_REF" HEAD)"
+          echo "sha=$MERGE_BASE" >> "$GITHUB_OUTPUT"
+          echo "Merge base: $MERGE_BASE"
+
+      - name: Affected package typecheck + test via turbo
+        run: |
+          # `...[<merge-base>]` selects every workspace package that
+          # transitively depends on a package changed since merge-base.
+          # If no consumers, turbo simply runs zero tasks (pass-no-consumers).
+          pnpm turbo run typecheck test --filter="...[${{ steps.merge-base.outputs.sha }}]" --concurrency=4
+
+  tag-on-bump:
+    name: Tag contract bumps
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: true
+
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Plan + apply tags
+        run: pnpm tsx scripts/contract/tag-on-bump.ts --rev HEAD

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "tsx": "^4.22.4",
     "turbo": "^2.9.18",
     "typescript": "^6.0.3",
-    "vitest": "^4.1.8"
+    "vitest": "^4.1.8",
+    "zod": "^4.4.3"
   },
   "packageManager": "pnpm@10.32.1",
   "pnpm": {

--- a/packages/finance-contract/CHANGELOG.md
+++ b/packages/finance-contract/CHANGELOG.md
@@ -1,0 +1,17 @@
+# @pops/finance-contract changelog
+
+All notable changes to the finance pillar's public contract surface land here.
+
+Format: each entry lists the contract version, then the user-facing
+classification (`patch` / `minor` / `major`), then bullets. Major
+versions MUST include a non-empty `### Migration from X.Y to N.0`
+section per PRD-154.
+
+## 0.1.0 — minor
+
+Initial baseline.
+
+- Establish `WishListItem` entity and `WishListItemSchema` (`@pops/finance-contract` public surface).
+- Establish `FinanceError`, `FinanceDomainError`, `ContractStatus` envelopes.
+- First OpenAPI snapshot at `openapi/finance.openapi.json`.
+- First `.api.json` + `.zod.json` snapshots committed to `etc/` (PRD-154 baseline).

--- a/packages/finance-contract/etc/finance-contract.api.json
+++ b/packages/finance-contract/etc/finance-contract.api.json
@@ -1,0 +1,150 @@
+{
+  "contract": "@pops/finance-contract",
+  "version": "0.1.0",
+  "entries": [
+    {
+      "entry": ".",
+      "name": "ContractStatus",
+      "kind": "type",
+      "text": "export type ContractStatus = 'ok' | 'not-found' | 'unavailable' | 'degraded';"
+    },
+    {
+      "entry": ".",
+      "name": "ContractStatusSchema",
+      "kind": "variable",
+      "text": "export declare const ContractStatusSchema: z.ZodEnum<{\n    ok: \"ok\";\n    \"not-found\": \"not-found\";\n    unavailable: \"unavailable\";\n    degraded: \"degraded\";\n}>;"
+    },
+    {
+      "entry": ".",
+      "name": "FinanceContract",
+      "kind": "interface",
+      "text": "export interface FinanceContract {\n    readonly pillar: 'finance';\n    readonly version: string;\n    readonly entities: {\n        readonly wishListItem: WishListItem;\n    };\n    readonly errors: FinanceError;\n    readonly router: FinanceRouter;\n}"
+    },
+    {
+      "entry": ".",
+      "name": "FinanceDomainError",
+      "kind": "type",
+      "text": "export type FinanceDomainError = {\n    kind: 'budget-exceeded';\n    budgetId: string;\n    overspendCents: number;\n} | {\n    kind: 'invalid-currency';\n    code: string;\n};"
+    },
+    {
+      "entry": ".",
+      "name": "FinanceDomainErrorSchema",
+      "kind": "variable",
+      "text": "export declare const FinanceDomainErrorSchema: z.ZodDiscriminatedUnion<[\n    z.ZodObject<{\n        kind: z.ZodLiteral<\"budget-exceeded\">;\n        budgetId: z.ZodString;\n        overspendCents: z.ZodNumber;\n    }, z.core.$strip>,\n    z.ZodObject<{\n        kind: z.ZodLiteral<\"invalid-currency\">;\n        code: z.ZodString;\n    }, z.core.$strip>\n], \"kind\">;"
+    },
+    {
+      "entry": ".",
+      "name": "FinanceError",
+      "kind": "type",
+      "text": "export type FinanceError = {\n    kind: ContractStatus;\n} | FinanceDomainError;"
+    },
+    {
+      "entry": ".",
+      "name": "FinanceErrorSchema",
+      "kind": "variable",
+      "text": "export declare const FinanceErrorSchema: z.ZodUnion<readonly [\n    z.ZodObject<{\n        kind: z.ZodEnum<{\n            ok: \"ok\";\n            \"not-found\": \"not-found\";\n            unavailable: \"unavailable\";\n            degraded: \"degraded\";\n        }>;\n    }, z.core.$strict>,\n    z.ZodDiscriminatedUnion<[\n        z.ZodObject<{\n            kind: z.ZodLiteral<\"budget-exceeded\">;\n            budgetId: z.ZodString;\n            overspendCents: z.ZodNumber;\n        }, z.core.$strip>,\n        z.ZodObject<{\n            kind: z.ZodLiteral<\"invalid-currency\">;\n            code: z.ZodString;\n        }, z.core.$strip>\n    ], \"kind\">\n]>;"
+    },
+    {
+      "entry": ".",
+      "name": "FinanceRouter",
+      "kind": "type",
+      "text": "export type FinanceRouter = typeof financeRouter;"
+    },
+    {
+      "entry": ".",
+      "name": "WishListItem",
+      "kind": "interface",
+      "text": "export interface WishListItem {\n    id: string;\n    item: string;\n    targetAmount: number | null;\n    saved: number | null;\n    remainingAmount: number | null;\n    priority: WishListPriority | null;\n    url: string | null;\n    notes: string | null;\n    lastEditedTime: string;\n}"
+    },
+    {
+      "entry": ".",
+      "name": "WishListItemSchema",
+      "kind": "variable",
+      "text": "export declare const WishListItemSchema: z.ZodObject<{\n    id: z.ZodString;\n    item: z.ZodString;\n    targetAmount: z.ZodNullable<z.ZodNumber>;\n    saved: z.ZodNullable<z.ZodNumber>;\n    remainingAmount: z.ZodNullable<z.ZodNumber>;\n    priority: z.ZodNullable<z.ZodEnum<{\n        Needing: \"Needing\";\n        Soon: \"Soon\";\n        \"One Day\": \"One Day\";\n        Dreaming: \"Dreaming\";\n    }>>;\n    url: z.ZodNullable<z.ZodString>;\n    notes: z.ZodNullable<z.ZodString>;\n    lastEditedTime: z.ZodString;\n}, z.core.$strip>;"
+    },
+    {
+      "entry": ".",
+      "name": "WishListPriority",
+      "kind": "type",
+      "text": "export type WishListPriority = (typeof WISH_LIST_PRIORITIES)[number];"
+    },
+    {
+      "entry": ".",
+      "name": "WishListPrioritySchema",
+      "kind": "variable",
+      "text": "export declare const WishListPrioritySchema: z.ZodEnum<{\n    Needing: \"Needing\";\n    Soon: \"Soon\";\n    \"One Day\": \"One Day\";\n    Dreaming: \"Dreaming\";\n}>;"
+    },
+    {
+      "entry": "./errors",
+      "name": "ContractStatus",
+      "kind": "type",
+      "text": "export type ContractStatus = 'ok' | 'not-found' | 'unavailable' | 'degraded';"
+    },
+    {
+      "entry": "./errors",
+      "name": "ContractStatusSchema",
+      "kind": "variable",
+      "text": "export declare const ContractStatusSchema: z.ZodEnum<{\n    ok: \"ok\";\n    \"not-found\": \"not-found\";\n    unavailable: \"unavailable\";\n    degraded: \"degraded\";\n}>;"
+    },
+    {
+      "entry": "./errors",
+      "name": "FinanceDomainError",
+      "kind": "type",
+      "text": "export type FinanceDomainError = {\n    kind: 'budget-exceeded';\n    budgetId: string;\n    overspendCents: number;\n} | {\n    kind: 'invalid-currency';\n    code: string;\n};"
+    },
+    {
+      "entry": "./errors",
+      "name": "FinanceDomainErrorSchema",
+      "kind": "variable",
+      "text": "export declare const FinanceDomainErrorSchema: z.ZodDiscriminatedUnion<[\n    z.ZodObject<{\n        kind: z.ZodLiteral<\"budget-exceeded\">;\n        budgetId: z.ZodString;\n        overspendCents: z.ZodNumber;\n    }, z.core.$strip>,\n    z.ZodObject<{\n        kind: z.ZodLiteral<\"invalid-currency\">;\n        code: z.ZodString;\n    }, z.core.$strip>\n], \"kind\">;"
+    },
+    {
+      "entry": "./errors",
+      "name": "FinanceError",
+      "kind": "type",
+      "text": "export type FinanceError = {\n    kind: ContractStatus;\n} | FinanceDomainError;"
+    },
+    {
+      "entry": "./errors",
+      "name": "FinanceErrorSchema",
+      "kind": "variable",
+      "text": "export declare const FinanceErrorSchema: z.ZodUnion<readonly [\n    z.ZodObject<{\n        kind: z.ZodEnum<{\n            ok: \"ok\";\n            \"not-found\": \"not-found\";\n            unavailable: \"unavailable\";\n            degraded: \"degraded\";\n        }>;\n    }, z.core.$strict>,\n    z.ZodDiscriminatedUnion<[\n        z.ZodObject<{\n            kind: z.ZodLiteral<\"budget-exceeded\">;\n            budgetId: z.ZodString;\n            overspendCents: z.ZodNumber;\n        }, z.core.$strip>,\n        z.ZodObject<{\n            kind: z.ZodLiteral<\"invalid-currency\">;\n            code: z.ZodString;\n        }, z.core.$strip>\n    ], \"kind\">\n]>;"
+    },
+    {
+      "entry": "./manifest",
+      "name": "FinanceContract",
+      "kind": "interface",
+      "text": "export interface FinanceContract {\n    readonly pillar: 'finance';\n    readonly version: string;\n    readonly entities: {\n        readonly wishListItem: WishListItem;\n    };\n    readonly errors: FinanceError;\n    readonly router: FinanceRouter;\n}"
+    },
+    {
+      "entry": "./router",
+      "name": "FinanceRouter",
+      "kind": "type",
+      "text": "export type FinanceRouter = typeof financeRouter;"
+    },
+    {
+      "entry": "./schemas",
+      "name": "WishListItemSchema",
+      "kind": "variable",
+      "text": "export declare const WishListItemSchema: z.ZodObject<{\n    id: z.ZodString;\n    item: z.ZodString;\n    targetAmount: z.ZodNullable<z.ZodNumber>;\n    saved: z.ZodNullable<z.ZodNumber>;\n    remainingAmount: z.ZodNullable<z.ZodNumber>;\n    priority: z.ZodNullable<z.ZodEnum<{\n        Needing: \"Needing\";\n        Soon: \"Soon\";\n        \"One Day\": \"One Day\";\n        Dreaming: \"Dreaming\";\n    }>>;\n    url: z.ZodNullable<z.ZodString>;\n    notes: z.ZodNullable<z.ZodString>;\n    lastEditedTime: z.ZodString;\n}, z.core.$strip>;"
+    },
+    {
+      "entry": "./schemas",
+      "name": "WishListPrioritySchema",
+      "kind": "variable",
+      "text": "export declare const WishListPrioritySchema: z.ZodEnum<{\n    Needing: \"Needing\";\n    Soon: \"Soon\";\n    \"One Day\": \"One Day\";\n    Dreaming: \"Dreaming\";\n}>;"
+    },
+    {
+      "entry": "./types",
+      "name": "WishListItem",
+      "kind": "interface",
+      "text": "export interface WishListItem {\n    id: string;\n    item: string;\n    targetAmount: number | null;\n    saved: number | null;\n    remainingAmount: number | null;\n    priority: WishListPriority | null;\n    url: string | null;\n    notes: string | null;\n    lastEditedTime: string;\n}"
+    },
+    {
+      "entry": "./types",
+      "name": "WishListPriority",
+      "kind": "type",
+      "text": "export type WishListPriority = (typeof WISH_LIST_PRIORITIES)[number];"
+    }
+  ]
+}

--- a/packages/finance-contract/etc/finance-contract.zod.json
+++ b/packages/finance-contract/etc/finance-contract.zod.json
@@ -1,0 +1,108 @@
+{
+  "contract": "@pops/finance-contract",
+  "version": "0.1.0",
+  "entries": [
+    {
+      "name": "WishListItemSchema",
+      "schema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "item": {
+            "type": "string"
+          },
+          "targetAmount": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "saved": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "remainingAmount": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "priority": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": ["Needing", "Soon", "One Day", "Dreaming"]
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "url": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uri"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "lastEditedTime": {
+            "type": "string",
+            "format": "date-time",
+            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+          }
+        },
+        "required": [
+          "id",
+          "item",
+          "targetAmount",
+          "saved",
+          "remainingAmount",
+          "priority",
+          "url",
+          "notes",
+          "lastEditedTime"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "WishListPrioritySchema",
+      "schema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "string",
+        "enum": ["Needing", "Soon", "One Day", "Dreaming"]
+      }
+    }
+  ]
+}

--- a/packages/finance-contract/package.json
+++ b/packages/finance-contract/package.json
@@ -36,6 +36,10 @@
   "scripts": {
     "build": "tsc && tsx scripts/generate-openapi.ts",
     "generate:openapi": "tsx scripts/generate-openapi.ts",
+    "extract:ts": "tsc && tsx ../../scripts/contract/extract-cli.ts --pillar finance --kind ts",
+    "extract:zod": "tsc && tsx ../../scripts/contract/extract-cli.ts --pillar finance --kind zod",
+    "extract:all": "tsc && tsx ../../scripts/contract/extract-cli.ts --pillar finance --kind all",
+    "diff:contract": "tsx ../../scripts/contract/diff-contract.ts --pillar finance",
     "typecheck": "tsc --noEmit && tsc --noEmit -p scripts/tsconfig.json",
     "test": "vitest run",
     "test:watch": "vitest"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
       vitest:
         specifier: ^4.1.8
         version: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.3)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
 
   apps/pops-api:
     dependencies:

--- a/scripts/contract/__tests__/changelog.test.ts
+++ b/scripts/contract/__tests__/changelog.test.ts
@@ -1,0 +1,86 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { checkMigrationSection, hasMigrationSection } from '../changelog.js';
+
+describe('hasMigrationSection', () => {
+  it('detects a non-empty migration section', () => {
+    const changelog = `
+# Changelog
+
+## 2.0.0
+
+### Migration from 1.4 to 2.0
+- removed FooSchema; use BarSchema instead.
+
+## 1.4.0
+`;
+    expect(hasMigrationSection(changelog, '1.4.2', '2.0.0')).toBe(true);
+  });
+
+  it('rejects a missing header', () => {
+    expect(hasMigrationSection('# Changelog\n', '1.4.2', '2.0.0')).toBe(false);
+  });
+
+  it('rejects an empty section', () => {
+    const changelog = `### Migration from 1.4 to 2.0\n\n#### something else`;
+    expect(hasMigrationSection(changelog, '1.4.2', '2.0.0')).toBe(false);
+  });
+});
+
+describe('checkMigrationSection', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(resolve(tmpdir(), 'contract-changelog-test-'));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('passes when no major bump', () => {
+    const r = checkMigrationSection({
+      packageDir: dir,
+      baselineVersion: '1.4.2',
+      currentVersion: '1.5.0',
+    });
+    expect(r.ok).toBe(true);
+  });
+
+  it('fails when CHANGELOG.md missing on major bump', () => {
+    const r = checkMigrationSection({
+      packageDir: dir,
+      baselineVersion: '1.4.2',
+      currentVersion: '2.0.0',
+    });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toMatch(/CHANGELOG\.md missing/);
+  });
+
+  it('fails when CHANGELOG lacks the migration section', () => {
+    writeFileSync(resolve(dir, 'CHANGELOG.md'), '# Changelog\n## 2.0.0\nWhatever.\n');
+    const r = checkMigrationSection({
+      packageDir: dir,
+      baselineVersion: '1.4.2',
+      currentVersion: '2.0.0',
+    });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toMatch(/non-empty/);
+  });
+
+  it('passes with a populated migration section', () => {
+    writeFileSync(
+      resolve(dir, 'CHANGELOG.md'),
+      '# Changelog\n## 2.0.0\n### Migration from 1.4 to 2.0\n- removed Foo.\n'
+    );
+    const r = checkMigrationSection({
+      packageDir: dir,
+      baselineVersion: '1.4.2',
+      currentVersion: '2.0.0',
+    });
+    expect(r.ok).toBe(true);
+  });
+});

--- a/scripts/contract/__tests__/contract-list.test.ts
+++ b/scripts/contract/__tests__/contract-list.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { CONTRACTS, findContract, isEnrolled } from '../contract-list.js';
+
+describe('CONTRACTS registry', () => {
+  it('includes finance as the pilot', () => {
+    expect(CONTRACTS.find((c) => c.pillar === 'finance')).toBeDefined();
+  });
+
+  it('produces a tag prefix matching the PRD format', () => {
+    const finance = CONTRACTS.find((c) => c.pillar === 'finance');
+    expect(finance?.tagPrefix).toBe('contract-finance@v');
+  });
+
+  it('produces a package name and dir consistent with the workspace layout', () => {
+    for (const c of CONTRACTS) {
+      expect(c.packageName).toBe(`@pops/${c.pillar}-contract`);
+      expect(c.packageDir).toBe(`packages/${c.pillar}-contract`);
+    }
+  });
+
+  it('findContract returns the entry when enrolled', () => {
+    expect(findContract('finance')?.pillar).toBe('finance');
+  });
+
+  it('findContract returns undefined for a known pillar that is not enrolled', () => {
+    expect(findContract('media')).toBeUndefined();
+  });
+
+  it('isEnrolled is a type guard over PILLARS', () => {
+    expect(isEnrolled('finance')).toBe(true);
+    expect(isEnrolled('media')).toBe(false);
+    expect(isEnrolled('mystery')).toBe(false);
+  });
+});

--- a/scripts/contract/__tests__/diff-ts.test.ts
+++ b/scripts/contract/__tests__/diff-ts.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+
+import { diffTsSurface } from '../diff-ts.js';
+
+import type { TsSurface, TsSurfaceEntry } from '../types.js';
+
+function surface(entries: TsSurfaceEntry[]): TsSurface {
+  return { contract: '@pops/finance-contract', version: '0.1.0', entries };
+}
+
+const e = (entry: string, name: string, text: string, kind: TsSurfaceEntry['kind'] = 'type') => ({
+  entry,
+  name,
+  kind,
+  text,
+});
+
+describe('diffTsSurface', () => {
+  it('returns "none" for identical surfaces', () => {
+    const surf = surface([e('.', 'A', 'export type A = string;')]);
+    const result = diffTsSurface(surf, surf);
+    expect(result.kind).toBe('none');
+    expect(result.added).toEqual([]);
+    expect(result.removed).toEqual([]);
+    expect(result.changed).toEqual([]);
+  });
+
+  it('classifies pure additions as additive', () => {
+    const baseline = surface([e('.', 'A', 'export type A = string;')]);
+    const current = surface([
+      e('.', 'A', 'export type A = string;'),
+      e('.', 'B', 'export type B = number;'),
+    ]);
+    const result = diffTsSurface(baseline, current);
+    expect(result.kind).toBe('additive');
+    expect(result.added).toEqual(['.::B']);
+  });
+
+  it('classifies removals as breaking', () => {
+    const baseline = surface([
+      e('.', 'A', 'export type A = string;'),
+      e('.', 'B', 'export type B = number;'),
+    ]);
+    const current = surface([e('.', 'A', 'export type A = string;')]);
+    const result = diffTsSurface(baseline, current);
+    expect(result.kind).toBe('breaking');
+    expect(result.removed).toEqual(['.::B']);
+  });
+
+  it('classifies signature changes as breaking', () => {
+    const baseline = surface([e('.', 'A', 'export type A = string;')]);
+    const current = surface([e('.', 'A', 'export type A = number;')]);
+    const result = diffTsSurface(baseline, current);
+    expect(result.kind).toBe('breaking');
+    expect(result.changed).toHaveLength(1);
+    expect(result.changed[0]?.name).toBe('.::A');
+  });
+
+  it('classifies removal + addition as breaking (a rename)', () => {
+    const baseline = surface([e('.', 'A', 'export type A = string;')]);
+    const current = surface([e('.', 'B', 'export type B = string;')]);
+    const result = diffTsSurface(baseline, current);
+    expect(result.kind).toBe('breaking');
+    expect(result.added).toEqual(['.::B']);
+    expect(result.removed).toEqual(['.::A']);
+  });
+
+  it('treats same name in different entry points as distinct symbols', () => {
+    const baseline = surface([e('.', 'A', 'export type A = string;')]);
+    const current = surface([
+      e('.', 'A', 'export type A = string;'),
+      e('./schemas', 'A', 'export type A = string;'),
+    ]);
+    expect(diffTsSurface(baseline, current).added).toEqual(['./schemas::A']);
+  });
+
+  it('reports diff kind changes (interface → type) as breaking', () => {
+    const baseline = surface([e('.', 'A', 'export interface A { x: string; }', 'interface')]);
+    const current = surface([e('.', 'A', 'export interface A { x: string; }', 'type')]);
+    const result = diffTsSurface(baseline, current);
+    expect(result.kind).toBe('breaking');
+  });
+});

--- a/scripts/contract/__tests__/diff-zod.test.ts
+++ b/scripts/contract/__tests__/diff-zod.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from 'vitest';
+
+import { diffZodSurface } from '../diff-zod.js';
+
+import type { ZodSurface, ZodSurfaceEntry } from '../types.js';
+
+function surface(entries: ZodSurfaceEntry[]): ZodSurface {
+  return { contract: '@pops/finance-contract', version: '0.1.0', entries };
+}
+
+describe('diffZodSurface', () => {
+  it('returns "none" for identical surfaces', () => {
+    const s = surface([
+      {
+        name: 'A',
+        schema: { type: 'object', properties: { x: { type: 'string' } }, required: ['x'] },
+      },
+    ]);
+    expect(diffZodSurface(s, s).kind).toBe('none');
+  });
+
+  it('classifies added top-level schema as additive', () => {
+    const baseline = surface([{ name: 'A', schema: { type: 'string' } }]);
+    const current = surface([
+      { name: 'A', schema: { type: 'string' } },
+      { name: 'B', schema: { type: 'number' } },
+    ]);
+    const r = diffZodSurface(baseline, current);
+    expect(r.kind).toBe('additive');
+    expect(r.added).toEqual(['B']);
+  });
+
+  it('classifies removed top-level schema as breaking', () => {
+    const baseline = surface([
+      { name: 'A', schema: { type: 'string' } },
+      { name: 'B', schema: { type: 'string' } },
+    ]);
+    const current = surface([{ name: 'A', schema: { type: 'string' } }]);
+    expect(diffZodSurface(baseline, current).kind).toBe('breaking');
+  });
+
+  it('classifies a newly required property as breaking', () => {
+    const baseline = surface([
+      {
+        name: 'A',
+        schema: { type: 'object', properties: { x: { type: 'string' } }, required: ['x'] },
+      },
+    ]);
+    const current = surface([
+      {
+        name: 'A',
+        schema: {
+          type: 'object',
+          properties: { x: { type: 'string' }, y: { type: 'string' } },
+          required: ['x', 'y'],
+        },
+      },
+    ]);
+    const r = diffZodSurface(baseline, current);
+    expect(r.kind).toBe('breaking');
+    expect(r.changed[0]?.reason).toMatch(/required property added \(y\)/);
+  });
+
+  it('classifies a newly optional property as additive', () => {
+    const baseline = surface([
+      {
+        name: 'A',
+        schema: { type: 'object', properties: { x: { type: 'string' } }, required: ['x'] },
+      },
+    ]);
+    const current = surface([
+      {
+        name: 'A',
+        schema: {
+          type: 'object',
+          properties: { x: { type: 'string' }, y: { type: 'string' } },
+          required: ['x'],
+        },
+      },
+    ]);
+    const r = diffZodSurface(baseline, current);
+    expect(r.kind).toBe('additive');
+    expect(r.changed[0]?.reason).toMatch(/optional property added \(y\)/);
+  });
+
+  it('classifies a removed enum value as breaking', () => {
+    const baseline = surface([{ name: 'E', schema: { type: 'string', enum: ['a', 'b', 'c'] } }]);
+    const current = surface([{ name: 'E', schema: { type: 'string', enum: ['a', 'b'] } }]);
+    const r = diffZodSurface(baseline, current);
+    expect(r.kind).toBe('breaking');
+    expect(r.changed[0]?.reason).toMatch(/enum value removed/);
+  });
+
+  it('classifies an added enum value as additive', () => {
+    const baseline = surface([{ name: 'E', schema: { type: 'string', enum: ['a', 'b'] } }]);
+    const current = surface([{ name: 'E', schema: { type: 'string', enum: ['a', 'b', 'c'] } }]);
+    expect(diffZodSurface(baseline, current).kind).toBe('additive');
+  });
+
+  it('classifies a property type change as breaking', () => {
+    const baseline = surface([
+      {
+        name: 'A',
+        schema: { type: 'object', properties: { x: { type: 'string' } }, required: ['x'] },
+      },
+    ]);
+    const current = surface([
+      {
+        name: 'A',
+        schema: { type: 'object', properties: { x: { type: 'number' } }, required: ['x'] },
+      },
+    ]);
+    expect(diffZodSurface(baseline, current).kind).toBe('breaking');
+  });
+
+  it('classifies optional → required as breaking', () => {
+    const baseline = surface([
+      {
+        name: 'A',
+        schema: { type: 'object', properties: { x: { type: 'string' } }, required: [] },
+      },
+    ]);
+    const current = surface([
+      {
+        name: 'A',
+        schema: { type: 'object', properties: { x: { type: 'string' } }, required: ['x'] },
+      },
+    ]);
+    const r = diffZodSurface(baseline, current);
+    expect(r.kind).toBe('breaking');
+    expect(r.changed[0]?.reason).toMatch(/made required/);
+  });
+
+  it('classifies required → optional as additive', () => {
+    const baseline = surface([
+      {
+        name: 'A',
+        schema: { type: 'object', properties: { x: { type: 'string' } }, required: ['x'] },
+      },
+    ]);
+    const current = surface([
+      {
+        name: 'A',
+        schema: { type: 'object', properties: { x: { type: 'string' } }, required: [] },
+      },
+    ]);
+    expect(diffZodSurface(baseline, current).kind).toBe('additive');
+  });
+
+  it('classifies a narrowed minimum as breaking', () => {
+    const baseline = surface([{ name: 'N', schema: { type: 'number', minimum: 0 } }]);
+    const current = surface([{ name: 'N', schema: { type: 'number', minimum: 10 } }]);
+    expect(diffZodSurface(baseline, current).kind).toBe('breaking');
+  });
+
+  it('classifies a widened maximum as additive', () => {
+    const baseline = surface([{ name: 'N', schema: { type: 'number', maximum: 100 } }]);
+    const current = surface([{ name: 'N', schema: { type: 'number', maximum: 200 } }]);
+    expect(diffZodSurface(baseline, current).kind).toBe('additive');
+  });
+
+  it('classifies a tightened pattern as breaking', () => {
+    const baseline = surface([{ name: 'S', schema: { type: 'string', pattern: '^.+$' } }]);
+    const current = surface([{ name: 'S', schema: { type: 'string', pattern: '^[a-z]+$' } }]);
+    expect(diffZodSurface(baseline, current).kind).toBe('breaking');
+  });
+
+  it('classifies a removed union member as breaking', () => {
+    const baseline = surface([
+      { name: 'U', schema: { anyOf: [{ type: 'string' }, { type: 'number' }] } },
+    ]);
+    const current = surface([{ name: 'U', schema: { anyOf: [{ type: 'string' }] } }]);
+    expect(diffZodSurface(baseline, current).kind).toBe('breaking');
+  });
+
+  it('classifies a newly added union member as additive', () => {
+    const baseline = surface([{ name: 'U', schema: { anyOf: [{ type: 'string' }] } }]);
+    const current = surface([
+      { name: 'U', schema: { anyOf: [{ type: 'string' }, { type: 'number' }] } },
+    ]);
+    expect(diffZodSurface(baseline, current).kind).toBe('additive');
+  });
+
+  it('classifies a nested property removal as breaking', () => {
+    const baseline = surface([
+      {
+        name: 'A',
+        schema: {
+          type: 'object',
+          properties: {
+            inner: { type: 'object', properties: { x: { type: 'string' } }, required: ['x'] },
+          },
+          required: ['inner'],
+        },
+      },
+    ]);
+    const current = surface([
+      {
+        name: 'A',
+        schema: {
+          type: 'object',
+          properties: {
+            inner: { type: 'object', properties: {}, required: [] },
+          },
+          required: ['inner'],
+        },
+      },
+    ]);
+    expect(diffZodSurface(baseline, current).kind).toBe('breaking');
+  });
+});

--- a/scripts/contract/__tests__/extract-ts.test.ts
+++ b/scripts/contract/__tests__/extract-ts.test.ts
@@ -1,0 +1,96 @@
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { extractTsSurface } from '../extract-ts.js';
+
+import type { TsSurface } from '../types.js';
+
+let FIXTURE_DIR: string;
+
+function setupFixture(): void {
+  const dist = resolve(FIXTURE_DIR, 'dist');
+  mkdirSync(dist, { recursive: true });
+  writeFileSync(
+    resolve(FIXTURE_DIR, 'package.json'),
+    JSON.stringify(
+      {
+        name: '@fixtures/tiny-contract',
+        version: '1.0.0',
+        type: 'module',
+        exports: {
+          '.': { types: './dist/index.d.ts', default: './dist/index.js' },
+          './schemas': { types: './dist/schemas.d.ts', default: './dist/schemas.js' },
+        },
+      },
+      null,
+      2
+    ) + '\n'
+  );
+  writeFileSync(
+    resolve(dist, 'index.d.ts'),
+    `export interface Foo {\n    a: string;\n    b: number;\n}\nexport type Bar = 'x' | 'y';\nexport declare function hi(name: string): string;\n`
+  );
+  writeFileSync(
+    resolve(dist, 'schemas.d.ts'),
+    `export declare const FooSchema: { parse(input: unknown): unknown };\n`
+  );
+}
+
+beforeAll(() => {
+  FIXTURE_DIR = mkdtempSync(resolve(tmpdir(), 'extract-ts-fixture-'));
+});
+
+afterAll(() => {
+  rmSync(FIXTURE_DIR, { recursive: true, force: true });
+});
+
+describe('extractTsSurface', () => {
+  it('returns the public surface for each declared sub-path', () => {
+    setupFixture();
+    const surface: TsSurface = extractTsSurface(FIXTURE_DIR);
+    expect(surface.contract).toBe('@fixtures/tiny-contract');
+    expect(surface.version).toBe('1.0.0');
+    expect(surface.entries.map((e) => `${e.entry}::${e.name}`)).toEqual([
+      '.::Bar',
+      '.::Foo',
+      '.::hi',
+      './schemas::FooSchema',
+    ]);
+  });
+
+  it('preserves kind tags', () => {
+    setupFixture();
+    const surface = extractTsSurface(FIXTURE_DIR);
+    const find = (name: string) => surface.entries.find((e) => e.name === name);
+    expect(find('Foo')?.kind).toBe('interface');
+    expect(find('Bar')?.kind).toBe('type');
+    expect(find('hi')?.kind).toBe('function');
+    expect(find('FooSchema')?.kind).toBe('variable');
+  });
+
+  it('emits entries sorted by entry then name (stable)', () => {
+    setupFixture();
+    const surface = extractTsSurface(FIXTURE_DIR);
+    const entries = surface.entries;
+    for (let i = 1; i < entries.length; i++) {
+      const prev = entries[i - 1];
+      const cur = entries[i];
+      if (!prev || !cur) continue;
+      if (prev.entry === cur.entry) {
+        expect(prev.name <= cur.name).toBe(true);
+      } else {
+        expect(prev.entry < cur.entry).toBe(true);
+      }
+    }
+  });
+});
+
+describe('fixture sanity', () => {
+  it('writes into a known fixture directory', () => {
+    setupFixture();
+    expect(existsSync(resolve(FIXTURE_DIR, 'dist', 'index.d.ts'))).toBe(true);
+  });
+});

--- a/scripts/contract/__tests__/self-test.test.ts
+++ b/scripts/contract/__tests__/self-test.test.ts
@@ -1,0 +1,149 @@
+/**
+ * PRD-154 US-07: synthetic breaking-change self-test.
+ *
+ * Injects a fake breaking change into a fixture surface (modeled after
+ * the finance contract) and verifies that:
+ *
+ *   1. `diffTsSurface` classifies it as breaking.
+ *   2. `diffZodSurface` classifies it as breaking.
+ *   3. `computeVerdict` returns `fail-bump-required` when the version
+ *      is unchanged.
+ *   4. `computeVerdict` returns `fail-bump-too-small` if a minor bump
+ *      is declared for a breaking change.
+ *   5. `computeVerdict` returns `pass-bumped-correctly` when the author
+ *      bumps to the required major.
+ *
+ * Mirrors the self-test pattern from PRD-2917 — the test is the proof
+ * that the CI workflow actually catches breakages, not just that the
+ * sub-units agree in isolation.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { diffTsSurface } from '../diff-ts.js';
+import { diffZodSurface } from '../diff-zod.js';
+import { computeVerdict } from '../verdict.js';
+
+import type { TsSurface, ZodSurface } from '../types.js';
+
+const baselineTs: TsSurface = {
+  contract: '@pops/finance-contract',
+  version: '1.4.2',
+  entries: [
+    {
+      entry: '.',
+      name: 'WishListItem',
+      kind: 'interface',
+      text: 'export interface WishListItem {\n    id: string;\n    item: string;\n    targetAmount: number | null;\n}',
+    },
+    {
+      entry: './schemas',
+      name: 'WishListItemSchema',
+      kind: 'variable',
+      text: 'export declare const WishListItemSchema: z.ZodObject<{ id: z.ZodString; item: z.ZodString; targetAmount: z.ZodNullable<z.ZodNumber>; }>;',
+    },
+  ],
+};
+
+const baselineZod: ZodSurface = {
+  contract: '@pops/finance-contract',
+  version: '1.4.2',
+  entries: [
+    {
+      name: 'WishListItemSchema',
+      schema: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+          item: { type: 'string' },
+          targetAmount: { type: 'number' },
+        },
+        required: ['id', 'item', 'targetAmount'],
+      },
+    },
+  ],
+};
+
+function injectBreakingTs(): TsSurface {
+  return {
+    ...baselineTs,
+    entries: baselineTs.entries.map((e) =>
+      e.name === 'WishListItem'
+        ? {
+            ...e,
+            text: 'export interface WishListItem {\n    id: number;\n    item: string;\n}',
+          }
+        : e
+    ),
+  };
+}
+
+function injectBreakingZod(): ZodSurface {
+  return {
+    ...baselineZod,
+    entries: baselineZod.entries.map((e) =>
+      e.name === 'WishListItemSchema'
+        ? {
+            name: e.name,
+            schema: {
+              type: 'object',
+              properties: {
+                id: { type: 'number' },
+                item: { type: 'string' },
+              },
+              required: ['id', 'item'],
+            },
+          }
+        : e
+    ),
+  };
+}
+
+describe('PRD-154 self-test (synthetic breaking change)', () => {
+  it('TS diff classifies the synthetic break as breaking', () => {
+    const diff = diffTsSurface(baselineTs, injectBreakingTs());
+    expect(diff.kind).toBe('breaking');
+    expect(diff.changed.map((c) => c.name)).toContain('.::WishListItem');
+  });
+
+  it('Zod diff classifies the synthetic break as breaking', () => {
+    const diff = diffZodSurface(baselineZod, injectBreakingZod());
+    expect(diff.kind).toBe('breaking');
+  });
+
+  it('verdict is fail-bump-required when version unchanged', () => {
+    const tsDiff = diffTsSurface(baselineTs, injectBreakingTs());
+    const zodDiff = diffZodSurface(baselineZod, injectBreakingZod());
+    const v = computeVerdict({
+      baselineVersion: '1.4.2',
+      currentVersion: '1.4.2',
+      tsDiff,
+      zodDiff,
+    });
+    expect(v.verdict).toBe('fail-bump-required');
+    expect(v.requiredVersion).toBe('2.0.0');
+  });
+
+  it('verdict is fail-bump-too-small with a minor bump', () => {
+    const tsDiff = diffTsSurface(baselineTs, injectBreakingTs());
+    const zodDiff = diffZodSurface(baselineZod, injectBreakingZod());
+    const v = computeVerdict({
+      baselineVersion: '1.4.2',
+      currentVersion: '1.5.0',
+      tsDiff,
+      zodDiff,
+    });
+    expect(v.verdict).toBe('fail-bump-too-small');
+  });
+
+  it('verdict is pass-bumped-correctly with a major bump', () => {
+    const tsDiff = diffTsSurface(baselineTs, injectBreakingTs());
+    const zodDiff = diffZodSurface(baselineZod, injectBreakingZod());
+    const v = computeVerdict({
+      baselineVersion: '1.4.2',
+      currentVersion: '2.0.0',
+      tsDiff,
+      zodDiff,
+    });
+    expect(v.verdict).toBe('pass-bumped-correctly');
+  });
+});

--- a/scripts/contract/__tests__/semver.test.ts
+++ b/scripts/contract/__tests__/semver.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+
+import { bump, classifyBump, compareSemver, parseSemver, stringifySemver } from '../semver.js';
+
+describe('parseSemver', () => {
+  it('parses strict X.Y.Z triples', () => {
+    expect(parseSemver('1.2.3')).toEqual({ major: 1, minor: 2, patch: 3 });
+    expect(parseSemver('0.0.0')).toEqual({ major: 0, minor: 0, patch: 0 });
+  });
+
+  it('rejects pre-release suffixes', () => {
+    expect(() => parseSemver('1.0.0-alpha')).toThrow(/invalid semver/);
+  });
+
+  it('rejects missing components', () => {
+    expect(() => parseSemver('1.2')).toThrow(/invalid semver/);
+    expect(() => parseSemver('1')).toThrow(/invalid semver/);
+  });
+});
+
+describe('stringifySemver', () => {
+  it('round-trips parse → stringify', () => {
+    expect(stringifySemver(parseSemver('4.5.6'))).toBe('4.5.6');
+  });
+});
+
+describe('compareSemver', () => {
+  it('returns 0 for equal versions', () => {
+    expect(compareSemver(parseSemver('1.2.3'), parseSemver('1.2.3'))).toBe(0);
+  });
+
+  it('orders by major first', () => {
+    expect(compareSemver(parseSemver('1.99.99'), parseSemver('2.0.0'))).toBe(-1);
+    expect(compareSemver(parseSemver('2.0.0'), parseSemver('1.99.99'))).toBe(1);
+  });
+
+  it('orders by minor when major equal', () => {
+    expect(compareSemver(parseSemver('1.2.99'), parseSemver('1.3.0'))).toBe(-1);
+  });
+
+  it('orders by patch when major and minor equal', () => {
+    expect(compareSemver(parseSemver('1.2.3'), parseSemver('1.2.4'))).toBe(-1);
+  });
+});
+
+describe('bump', () => {
+  const baseline = parseSemver('1.4.2');
+
+  it('returns baseline for none', () => {
+    expect(bump(baseline, 'none')).toEqual(baseline);
+  });
+
+  it('bumps patch', () => {
+    expect(stringifySemver(bump(baseline, 'patch'))).toBe('1.4.3');
+  });
+
+  it('bumps minor and zeroes patch', () => {
+    expect(stringifySemver(bump(baseline, 'minor'))).toBe('1.5.0');
+  });
+
+  it('bumps major and zeroes minor + patch', () => {
+    expect(stringifySemver(bump(baseline, 'major'))).toBe('2.0.0');
+  });
+});
+
+describe('classifyBump', () => {
+  it('detects no bump', () => {
+    expect(classifyBump(parseSemver('1.2.3'), parseSemver('1.2.3'))).toBe('none');
+  });
+  it('detects patch bump', () => {
+    expect(classifyBump(parseSemver('1.2.3'), parseSemver('1.2.4'))).toBe('patch');
+  });
+  it('detects minor bump', () => {
+    expect(classifyBump(parseSemver('1.2.3'), parseSemver('1.3.0'))).toBe('minor');
+  });
+  it('detects major bump', () => {
+    expect(classifyBump(parseSemver('1.2.3'), parseSemver('2.0.0'))).toBe('major');
+  });
+  it('rejects regressions', () => {
+    expect(() => classifyBump(parseSemver('1.2.3'), parseSemver('1.2.2'))).toThrow(/regresses/);
+    expect(() => classifyBump(parseSemver('1.2.3'), parseSemver('1.1.9'))).toThrow(/regresses/);
+    expect(() => classifyBump(parseSemver('2.0.0'), parseSemver('1.9.9'))).toThrow(/downgrades/);
+  });
+});

--- a/scripts/contract/__tests__/verdict.test.ts
+++ b/scripts/contract/__tests__/verdict.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest';
+
+import { computeVerdict } from '../verdict.js';
+
+import type { SurfaceDiff } from '../types.js';
+
+const noneDiff: SurfaceDiff = { kind: 'none', added: [], removed: [], changed: [] };
+const additiveDiff: SurfaceDiff = { kind: 'additive', added: ['X'], removed: [], changed: [] };
+const breakingDiff: SurfaceDiff = { kind: 'breaking', added: [], removed: ['Y'], changed: [] };
+
+describe('computeVerdict — initial version (no baseline)', () => {
+  it('passes regardless of declared version', () => {
+    expect(
+      computeVerdict({
+        baselineVersion: null,
+        currentVersion: '0.1.0',
+        tsDiff: noneDiff,
+        zodDiff: noneDiff,
+      }).verdict
+    ).toBe('pass-initial-version');
+  });
+});
+
+describe('computeVerdict — no diff', () => {
+  it('passes when version unchanged', () => {
+    const v = computeVerdict({
+      baselineVersion: '1.4.2',
+      currentVersion: '1.4.2',
+      tsDiff: noneDiff,
+      zodDiff: noneDiff,
+    });
+    expect(v.verdict).toBe('pass-no-change');
+    expect(v.classification).toBe('none');
+  });
+
+  it('passes (advisory) when version bumped with no diff', () => {
+    const v = computeVerdict({
+      baselineVersion: '1.4.2',
+      currentVersion: '1.4.3',
+      tsDiff: noneDiff,
+      zodDiff: noneDiff,
+    });
+    expect(v.verdict).toBe('pass-no-change');
+    expect(v.reason).toMatch(/consider not bumping/);
+  });
+});
+
+describe('computeVerdict — additive diff', () => {
+  it('fails when version unchanged', () => {
+    const v = computeVerdict({
+      baselineVersion: '1.4.2',
+      currentVersion: '1.4.2',
+      tsDiff: additiveDiff,
+      zodDiff: noneDiff,
+    });
+    expect(v.verdict).toBe('fail-bump-required');
+    expect(v.requiredVersion).toBe('1.5.0');
+  });
+
+  it('passes when minor bump declared', () => {
+    const v = computeVerdict({
+      baselineVersion: '1.4.2',
+      currentVersion: '1.5.0',
+      tsDiff: additiveDiff,
+      zodDiff: noneDiff,
+    });
+    expect(v.verdict).toBe('pass-bumped-correctly');
+  });
+
+  it('fails when patch bump declared but minor required', () => {
+    const v = computeVerdict({
+      baselineVersion: '1.4.2',
+      currentVersion: '1.4.3',
+      tsDiff: additiveDiff,
+      zodDiff: noneDiff,
+    });
+    expect(v.verdict).toBe('fail-bump-too-small');
+  });
+
+  it('fails when major bump declared but minor would suffice', () => {
+    const v = computeVerdict({
+      baselineVersion: '1.4.2',
+      currentVersion: '2.0.0',
+      tsDiff: additiveDiff,
+      zodDiff: noneDiff,
+    });
+    expect(v.verdict).toBe('fail-bump-too-large');
+  });
+});
+
+describe('computeVerdict — breaking diff', () => {
+  it('fails when version unchanged', () => {
+    const v = computeVerdict({
+      baselineVersion: '1.4.2',
+      currentVersion: '1.4.2',
+      tsDiff: breakingDiff,
+      zodDiff: noneDiff,
+    });
+    expect(v.verdict).toBe('fail-bump-required');
+    expect(v.requiredVersion).toBe('2.0.0');
+  });
+
+  it('fails when minor bump declared but major required', () => {
+    const v = computeVerdict({
+      baselineVersion: '1.4.2',
+      currentVersion: '1.5.0',
+      tsDiff: breakingDiff,
+      zodDiff: noneDiff,
+    });
+    expect(v.verdict).toBe('fail-bump-too-small');
+  });
+
+  it('passes when major bump declared', () => {
+    const v = computeVerdict({
+      baselineVersion: '1.4.2',
+      currentVersion: '2.0.0',
+      tsDiff: breakingDiff,
+      zodDiff: noneDiff,
+    });
+    expect(v.verdict).toBe('pass-bumped-correctly');
+  });
+
+  it('still requires major when Zod is breaking but TS is none', () => {
+    const v = computeVerdict({
+      baselineVersion: '1.4.2',
+      currentVersion: '1.4.2',
+      tsDiff: noneDiff,
+      zodDiff: breakingDiff,
+    });
+    expect(v.verdict).toBe('fail-bump-required');
+    expect(v.requiredVersion).toBe('2.0.0');
+  });
+});

--- a/scripts/contract/baseline.ts
+++ b/scripts/contract/baseline.ts
@@ -1,0 +1,71 @@
+/**
+ * Baseline fetcher: given a contract entry, look up the latest
+ * `contract-<pillar>@v*` tag in the repo and read the `etc/*.api.json`
+ * and `etc/*.zod.json` snapshots from that revision.
+ *
+ * Returns `null` when no baseline tag exists (initial-version case).
+ */
+import { execFileSync } from 'node:child_process';
+
+import type { ContractEntry } from './contract-list.js';
+import type { TsSurface, ZodSurface } from './types.js';
+
+export interface BaselineSnapshots {
+  readonly tag: string;
+  readonly version: string;
+  readonly tsSurface: TsSurface;
+  readonly zodSurface: ZodSurface;
+}
+
+function git(args: readonly string[], opts: { cwd: string; allowFailure?: boolean }): string {
+  try {
+    return execFileSync('git', args, { cwd: opts.cwd, encoding: 'utf8' }).trim();
+  } catch (err) {
+    if (opts.allowFailure) return '';
+    throw err;
+  }
+}
+
+export function latestBaselineTag(contract: ContractEntry, repoRoot: string): string | null {
+  const pattern = `${contract.tagPrefix}*`;
+  const lsRemote = git(['tag', '--list', pattern, '--sort=-v:refname'], {
+    cwd: repoRoot,
+    allowFailure: true,
+  });
+  const lines = lsRemote.split('\n').filter(Boolean);
+  if (lines.length === 0) return null;
+  const first = lines[0];
+  return first ?? null;
+}
+
+export function readFileAtRev(repoRoot: string, rev: string, path: string): string | null {
+  try {
+    return execFileSync('git', ['show', `${rev}:${path}`], { cwd: repoRoot, encoding: 'utf8' });
+  } catch {
+    return null;
+  }
+}
+
+export function loadBaseline(contract: ContractEntry, repoRoot: string): BaselineSnapshots | null {
+  const tag = latestBaselineTag(contract, repoRoot);
+  if (!tag) return null;
+
+  const apiPath = `${contract.packageDir}/etc/${contract.pillar}-contract.api.json`;
+  const zodPath = `${contract.packageDir}/etc/${contract.pillar}-contract.zod.json`;
+
+  const apiRaw = readFileAtRev(repoRoot, tag, apiPath);
+  const zodRaw = readFileAtRev(repoRoot, tag, zodPath);
+
+  if (apiRaw === null || zodRaw === null) {
+    throw new Error(
+      `baseline tag ${tag} does not contain ${apiPath} or ${zodPath}. ` +
+        `Either delete the tag or run a one-off resync to backfill snapshots at that revision.`
+    );
+  }
+
+  const tsSurface = JSON.parse(apiRaw) as TsSurface;
+  const zodSurface = JSON.parse(zodRaw) as ZodSurface;
+  const version = tag.slice(contract.tagPrefix.length);
+
+  return { tag, version, tsSurface, zodSurface };
+}

--- a/scripts/contract/changelog.ts
+++ b/scripts/contract/changelog.ts
@@ -1,0 +1,68 @@
+/**
+ * CHANGELOG migration-section guard: when a contract bumps to a new
+ * major, its `CHANGELOG.md` must include a non-empty
+ * `### Migration from X.Y to N.0` section. PRD-154 enforces this in CI
+ * (US-06) to keep the audit log honest.
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { parseSemver } from './semver.js';
+
+export interface MigrationCheckInput {
+  readonly packageDir: string;
+  readonly baselineVersion: string;
+  readonly currentVersion: string;
+}
+
+export interface MigrationCheckResult {
+  readonly ok: boolean;
+  readonly reason: string;
+}
+
+function readChangelog(packageDir: string): string | null {
+  try {
+    return readFileSync(resolve(packageDir, 'CHANGELOG.md'), 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+export function hasMigrationSection(
+  changelog: string,
+  baselineVersion: string,
+  currentVersion: string
+): boolean {
+  const baseline = parseSemver(baselineVersion);
+  const current = parseSemver(currentVersion);
+  const header = `### Migration from ${baseline.major}.${baseline.minor} to ${current.major}.0`;
+  const idx = changelog.indexOf(header);
+  if (idx === -1) return false;
+  const after = changelog.slice(idx + header.length);
+  const nextHeader = after.search(/\n#{1,4} /);
+  const body = nextHeader === -1 ? after : after.slice(0, nextHeader);
+  return body.replace(/\s+/g, '').length > 0;
+}
+
+export function checkMigrationSection(input: MigrationCheckInput): MigrationCheckResult {
+  const baseline = parseSemver(input.baselineVersion);
+  const current = parseSemver(input.currentVersion);
+  if (current.major === baseline.major) {
+    return { ok: true, reason: 'no major bump; migration section not required.' };
+  }
+  const changelog = readChangelog(input.packageDir);
+  if (changelog === null) {
+    return {
+      ok: false,
+      reason: `major bump to ${input.currentVersion}: CHANGELOG.md missing in ${input.packageDir}.`,
+    };
+  }
+  if (!hasMigrationSection(changelog, input.baselineVersion, input.currentVersion)) {
+    const expected = `### Migration from ${baseline.major}.${baseline.minor} to ${current.major}.0`;
+    return {
+      ok: false,
+      reason: `major bump to ${input.currentVersion} requires a non-empty "${expected}" section in CHANGELOG.md.`,
+    };
+  }
+  return { ok: true, reason: 'migration section present and non-empty.' };
+}

--- a/scripts/contract/contract-list.ts
+++ b/scripts/contract/contract-list.ts
@@ -1,0 +1,45 @@
+/**
+ * Registry of contract packages enrolled in the semver CI flow.
+ *
+ * Adding a contract here opts it into:
+ *   - `.api.json` + `.zod.json` snapshot extraction (`extract:ts`,
+ *     `extract:zod`).
+ *   - `diff:contract` baseline-vs-current classification.
+ *   - The CI workflow at `.github/workflows/contract-semver.yml`.
+ *   - Tag-on-bump for pushes to `main`.
+ *
+ * PRD-154 ships `finance` only as the pilot. PRD-154 US-09 rolls the
+ * scaffolding out to the remaining pillars once their contract packages
+ * exist.
+ */
+import { PILLARS, type Pillar } from './pillar-list.js';
+
+export interface ContractEntry {
+  readonly pillar: Pillar;
+  readonly packageName: string;
+  readonly packageDir: string;
+  readonly tagPrefix: string;
+}
+
+const ENROLLED_PILLARS: readonly Pillar[] = ['finance'];
+
+function buildEntry(pillar: Pillar): ContractEntry {
+  return {
+    pillar,
+    packageName: `@pops/${pillar}-contract`,
+    packageDir: `packages/${pillar}-contract`,
+    tagPrefix: `contract-${pillar}@v`,
+  };
+}
+
+export const CONTRACTS: readonly ContractEntry[] = ENROLLED_PILLARS.map(buildEntry);
+
+export function isEnrolled(pillar: string): pillar is Pillar {
+  return (
+    (PILLARS as readonly string[]).includes(pillar) && ENROLLED_PILLARS.includes(pillar as Pillar)
+  );
+}
+
+export function findContract(pillar: string): ContractEntry | undefined {
+  return CONTRACTS.find((c) => c.pillar === pillar);
+}

--- a/scripts/contract/diff-contract.ts
+++ b/scripts/contract/diff-contract.ts
@@ -1,0 +1,249 @@
+/**
+ * `diff-contract.ts` — the CI entry point.
+ *
+ * Usage:
+ *   tsx scripts/contract/diff-contract.ts --pillar finance
+ *   tsx scripts/contract/diff-contract.ts --pillar finance --json
+ *   tsx scripts/contract/diff-contract.ts --all
+ *
+ * For each enrolled contract this script:
+ *   1. Resolves the latest `contract-<pillar>@v*` git tag.
+ *   2. Reads the committed `etc/*.api.json` + `etc/*.zod.json` at that
+ *      revision and at the current working tree.
+ *   3. Builds the current package if needed so `dist/` is populated,
+ *      then re-extracts the surfaces from the current tree and checks
+ *      for drift against the committed snapshots (drift = "snapshots
+ *      stale", a fail).
+ *   4. Diffs baseline vs current snapshots, classifies, and emits a
+ *      verdict.
+ *   5. If the verdict requires a major bump, also runs the CHANGELOG
+ *      migration-section guard.
+ *
+ * Exit code 0 if all enrolled contracts pass; non-zero otherwise. The
+ * JSON report is written to stdout when `--json` is passed.
+ */
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { loadBaseline } from './baseline.js';
+import { checkMigrationSection } from './changelog.js';
+import { CONTRACTS, findContract, type ContractEntry } from './contract-list.js';
+import { diffTsSurface } from './diff-ts.js';
+import { diffZodSurface } from './diff-zod.js';
+import { extractTsSurface, serialiseTsSurface } from './extract-ts.js';
+import { extractZodSurface, serialiseZodSurface } from './extract-zod.js';
+import { computeVerdict } from './verdict.js';
+
+import type { DiffReport, Verdict } from './types.js';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(HERE, '..', '..');
+
+interface CliOptions {
+  readonly pillars: readonly string[];
+  readonly json: boolean;
+  readonly writeSnapshots: boolean;
+  readonly skipDriftCheck: boolean;
+}
+
+function parseArgs(argv: readonly string[]): CliOptions {
+  let json = false;
+  let writeSnapshots = false;
+  let skipDriftCheck = false;
+  const pillars: string[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--json') json = true;
+    else if (arg === '--write-snapshots') writeSnapshots = true;
+    else if (arg === '--skip-drift-check') skipDriftCheck = true;
+    else if (arg === '--all') {
+      for (const c of CONTRACTS) pillars.push(c.pillar);
+    } else if (arg === '--pillar') {
+      const next = argv[i + 1];
+      if (!next) throw new Error('--pillar requires a value');
+      pillars.push(next);
+      i += 1;
+    } else {
+      throw new Error(`unknown argument: ${arg}`);
+    }
+  }
+  if (pillars.length === 0) {
+    for (const c of CONTRACTS) pillars.push(c.pillar);
+  }
+  return { pillars, json, writeSnapshots, skipDriftCheck };
+}
+
+function resolveVerdict(
+  base: Verdict,
+  drift: { reason: string } | undefined,
+  migration: { reason: string } | undefined
+): Verdict {
+  if (drift) return 'fail-snapshot-stale';
+  if (migration) return 'fail-migration-section-missing';
+  return base;
+}
+
+function safeRead(path: string): string {
+  try {
+    return readFileSync(path, 'utf8');
+  } catch {
+    return '';
+  }
+}
+
+function writeIfChanged(path: string, content: string): boolean {
+  mkdirSync(dirname(path), { recursive: true });
+  if (existsSync(path)) {
+    const existing = safeRead(path);
+    if (existing === content) return false;
+  }
+  writeFileSync(path, content, 'utf8');
+  return true;
+}
+
+interface RunResult {
+  readonly report: DiffReport;
+  readonly migrationFail?: { reason: string };
+  readonly snapshotDrift?: { reason: string };
+}
+
+async function runOne(contract: ContractEntry, options: CliOptions): Promise<RunResult> {
+  const packageDir = resolve(REPO_ROOT, contract.packageDir);
+  const apiPath = resolve(packageDir, 'etc', `${contract.pillar}-contract.api.json`);
+  const zodPath = resolve(packageDir, 'etc', `${contract.pillar}-contract.zod.json`);
+
+  const freshTs = extractTsSurface(packageDir);
+  const freshZod = await extractZodSurface(packageDir);
+
+  const freshTsSerialised = serialiseTsSurface(freshTs);
+  const freshZodSerialised = serialiseZodSurface(freshZod);
+
+  if (options.writeSnapshots) {
+    writeIfChanged(apiPath, freshTsSerialised);
+    writeIfChanged(zodPath, freshZodSerialised);
+  }
+
+  let snapshotDrift: RunResult['snapshotDrift'];
+  if (!options.skipDriftCheck) {
+    const committedTs = existsSync(apiPath) ? safeRead(apiPath) : '';
+    const committedZod = existsSync(zodPath) ? safeRead(zodPath) : '';
+    if (committedTs !== freshTsSerialised || committedZod !== freshZodSerialised) {
+      snapshotDrift = {
+        reason:
+          `${contract.packageName} snapshots are stale. ` +
+          `Run \`pnpm -F ${contract.packageName} extract:ts extract:zod\` and commit etc/.`,
+      };
+    }
+  }
+
+  const baseline = loadBaseline(contract, REPO_ROOT);
+
+  const tsDiff = baseline
+    ? diffTsSurface(baseline.tsSurface, freshTs)
+    : { kind: 'none' as const, added: [], removed: [], changed: [] };
+  const zodDiff = baseline
+    ? diffZodSurface(baseline.zodSurface, freshZod)
+    : { kind: 'none' as const, added: [], removed: [], changed: [] };
+
+  const verdict = computeVerdict({
+    baselineVersion: baseline?.version ?? null,
+    currentVersion: freshTs.version,
+    tsDiff,
+    zodDiff,
+  });
+
+  let migrationFail: RunResult['migrationFail'];
+  if (verdict.classification === 'major' && baseline) {
+    const check = checkMigrationSection({
+      packageDir,
+      baselineVersion: baseline.version,
+      currentVersion: freshTs.version,
+    });
+    if (!check.ok) migrationFail = { reason: check.reason };
+  }
+
+  const report: DiffReport = {
+    contract: contract.packageName,
+    baselineTag: baseline?.tag ?? null,
+    baselineVersion: baseline?.version ?? null,
+    currentVersion: freshTs.version,
+    tsDiff,
+    zodDiff,
+    classification: verdict.classification,
+    requiredVersion: verdict.requiredVersion,
+    verdict: resolveVerdict(verdict.verdict, snapshotDrift, migrationFail),
+    reason: snapshotDrift?.reason ?? migrationFail?.reason ?? verdict.reason,
+  };
+
+  return { report, migrationFail, snapshotDrift };
+}
+
+function isFailureVerdict(verdict: DiffReport['verdict']): boolean {
+  return verdict.startsWith('fail-');
+}
+
+async function main(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2));
+
+  const results: RunResult[] = [];
+  for (const pillar of options.pillars) {
+    const contract = findContract(pillar);
+    if (!contract) {
+      process.stderr.write(
+        `[contract-semver] no enrolled contract for pillar "${pillar}"; skipping\n`
+      );
+      continue;
+    }
+    results.push(await runOne(contract, options));
+  }
+
+  if (options.json) {
+    process.stdout.write(
+      `${JSON.stringify(
+        results.map((r) => r.report),
+        null,
+        2
+      )}\n`
+    );
+  } else {
+    for (const { report } of results) {
+      process.stdout.write(formatReport(report));
+    }
+  }
+
+  const anyFail = results.some(({ report }) => isFailureVerdict(report.verdict));
+  process.exit(anyFail ? 1 : 0);
+}
+
+function formatReport(report: DiffReport): string {
+  const lines: string[] = [];
+  lines.push(`\n=== ${report.contract} ===`);
+  lines.push(`  baseline: ${report.baselineTag ?? '(none — initial version)'}`);
+  lines.push(`  current:  v${report.currentVersion}`);
+  lines.push(
+    `  ts:       ${report.tsDiff.kind} (+${report.tsDiff.added.length} -${report.tsDiff.removed.length} ~${report.tsDiff.changed.length})`
+  );
+  lines.push(
+    `  zod:      ${report.zodDiff.kind} (+${report.zodDiff.added.length} -${report.zodDiff.removed.length} ~${report.zodDiff.changed.length})`
+  );
+  lines.push(`  verdict:  ${report.verdict}`);
+  lines.push(`  reason:   ${report.reason}`);
+  if (report.tsDiff.removed.length > 0) {
+    lines.push(`  ts.removed: ${report.tsDiff.removed.join(', ')}`);
+  }
+  if (report.tsDiff.changed.length > 0) {
+    lines.push(`  ts.changed: ${report.tsDiff.changed.map((c) => c.name).join(', ')}`);
+  }
+  if (report.zodDiff.changed.length > 0) {
+    for (const c of report.zodDiff.changed) {
+      lines.push(`  zod.${c.breaking ? 'breaking' : 'additive'} ${c.name}: ${c.reason}`);
+    }
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+main().catch((err: unknown) => {
+  process.stderr.write(`${err instanceof Error ? (err.stack ?? err.message) : String(err)}\n`);
+  process.exit(1);
+});

--- a/scripts/contract/diff-ts.ts
+++ b/scripts/contract/diff-ts.ts
@@ -1,0 +1,73 @@
+/**
+ * TypeScript surface diff classifier.
+ *
+ * Rules (matches PRD-154 business rules):
+ *   - additive: entries appear in current that did not exist in baseline.
+ *     No removed or changed signatures.
+ *   - breaking: any entry removed; any entry's signature text changed
+ *     (we treat *all* signature edits as breaking by default — narrowing
+ *     a return type, widening a parameter, renaming a member, all
+ *     surface as a text diff. Authors who know a change is non-breaking
+ *     still need to declare it as such by bumping minor and letting CI
+ *     re-classify; that path is rare).
+ *
+ * Signature text is the TypeScript printer's normalised form, so
+ * formatting churn alone never trips the classifier.
+ */
+import type { ChangedEntry, SurfaceDiff, TsSurface, TsSurfaceEntry } from './types.js';
+
+function keyOf(entry: TsSurfaceEntry): string {
+  return `${entry.entry}::${entry.name}`;
+}
+
+function indexBy(surface: TsSurface): Map<string, TsSurfaceEntry> {
+  const out = new Map<string, TsSurfaceEntry>();
+  for (const e of surface.entries) out.set(keyOf(e), e);
+  return out;
+}
+
+export function diffTsSurface(baseline: TsSurface, current: TsSurface): SurfaceDiff {
+  const baselineIdx = indexBy(baseline);
+  const currentIdx = indexBy(current);
+
+  const added: string[] = [];
+  const removed: string[] = [];
+  const changed: ChangedEntry[] = [];
+
+  for (const [key, entry] of currentIdx) {
+    if (!baselineIdx.has(key)) {
+      added.push(key);
+      continue;
+    }
+    const before = baselineIdx.get(key);
+    if (!before) continue;
+    if (before.text !== entry.text || before.kind !== entry.kind) {
+      changed.push({
+        name: key,
+        breaking: true,
+        reason: `signature changed (${before.kind} → ${entry.kind})`,
+      });
+    }
+  }
+
+  for (const [key] of baselineIdx) {
+    if (!currentIdx.has(key)) removed.push(key);
+  }
+
+  added.sort();
+  removed.sort();
+  changed.sort((a, b) => {
+    if (a.name < b.name) return -1;
+    if (a.name > b.name) return 1;
+    return 0;
+  });
+
+  let kind: SurfaceDiff['kind'] = 'none';
+  if (removed.length > 0 || changed.length > 0) {
+    kind = 'breaking';
+  } else if (added.length > 0) {
+    kind = 'additive';
+  }
+
+  return { kind, added, removed, changed };
+}

--- a/scripts/contract/diff-zod.ts
+++ b/scripts/contract/diff-zod.ts
@@ -1,0 +1,290 @@
+/**
+ * Zod-surface diff classifier.
+ *
+ * Inputs are the JSON Schema documents emitted by `extract-zod.ts`.
+ * Classification rules (PRD-154 business rules):
+ *
+ *   Breaking (any of):
+ *     - a top-level schema is removed.
+ *     - a required object property is added.
+ *     - an optional object property is made required.
+ *     - an object property is removed.
+ *     - a property's `type` changes.
+ *     - an enum value is removed.
+ *     - a union member is removed.
+ *     - a numeric range narrows (minimum raised or maximum lowered).
+ *     - a string pattern tightens (gain a pattern, or a different pattern).
+ *
+ *   Additive (any of, none of the above):
+ *     - a top-level schema added.
+ *     - a new optional object property.
+ *     - a new enum value.
+ *     - a new union member.
+ *     - a widened numeric range.
+ *
+ * Anything we cannot classify confidently as additive is treated as
+ * breaking — safer to over-report than to ship a silent break. The
+ * adversarial bias is explicit in the test suite.
+ */
+import type { ChangedEntry, SurfaceDiff, ZodSurface, ZodSurfaceEntry } from './types.js';
+
+type JsonValue = string | number | boolean | null | JsonObject | JsonValue[];
+type JsonObject = { [key: string]: JsonValue };
+
+interface NodeDiff {
+  readonly breaking: readonly string[];
+  readonly additive: readonly string[];
+}
+
+interface DiffAcc {
+  readonly breaking: string[];
+  readonly additive: string[];
+}
+
+function isObj(value: unknown): value is JsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function asObj(value: unknown): JsonObject | null {
+  return isObj(value) ? value : null;
+}
+
+function asArray(value: unknown): readonly JsonValue[] | null {
+  return Array.isArray(value) ? value : null;
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === 'string' ? value : null;
+}
+
+function asNumber(value: unknown): number | null {
+  return typeof value === 'number' ? value : null;
+}
+
+function indexBy(surface: ZodSurface): Map<string, ZodSurfaceEntry> {
+  const out = new Map<string, ZodSurfaceEntry>();
+  for (const e of surface.entries) out.set(e.name, e);
+  return out;
+}
+
+function pushAll(target: string[], path: string, items: readonly string[]): void {
+  for (const item of items) target.push(`${path}: ${item}`);
+}
+
+function diffNode(baseline: JsonObject, current: JsonObject, path: string): NodeDiff {
+  const acc: DiffAcc = { breaking: [], additive: [] };
+
+  const baselineType = asString(baseline['type']);
+  const currentType = asString(current['type']);
+  if (baselineType !== null && currentType !== null && baselineType !== currentType) {
+    acc.breaking.push(`type changed (${baselineType} → ${currentType})`);
+    return acc;
+  }
+
+  diffEnum(baseline, current, acc);
+  diffObjectShape(baseline, current, path, acc);
+  diffArray(baseline, current, path, acc);
+  diffUnion(baseline, current, path, acc);
+  diffNumericRange(baseline, current, acc);
+  diffStringConstraints(baseline, current, acc);
+
+  return acc;
+}
+
+function diffEnum(baseline: JsonObject, current: JsonObject, acc: DiffAcc): void {
+  const baselineEnum = asArray(baseline['enum']);
+  const currentEnum = asArray(current['enum']);
+  if (!baselineEnum || !currentEnum) return;
+  const baseSet = new Set(baselineEnum.map((v) => JSON.stringify(v)));
+  const curSet = new Set(currentEnum.map((v) => JSON.stringify(v)));
+  for (const v of baseSet) {
+    if (!curSet.has(v)) acc.breaking.push(`enum value removed (${v})`);
+  }
+  for (const v of curSet) {
+    if (!baseSet.has(v)) acc.additive.push(`enum value added (${v})`);
+  }
+}
+
+function diffObjectShape(
+  baseline: JsonObject,
+  current: JsonObject,
+  path: string,
+  acc: DiffAcc
+): void {
+  const { breaking, additive } = acc;
+  const baselineProps = asObj(baseline['properties']);
+  const currentProps = asObj(current['properties']);
+  if (!baselineProps && !currentProps) return;
+
+  const baseRequired = new Set((asArray(baseline['required']) ?? []).map(String));
+  const curRequired = new Set((asArray(current['required']) ?? []).map(String));
+
+  const baseProps = baselineProps ?? {};
+  const curProps = currentProps ?? {};
+
+  for (const name of Object.keys(baseProps)) {
+    if (!(name in curProps)) {
+      breaking.push(`property removed (${name})`);
+      continue;
+    }
+    if (baseRequired.has(name) && !curRequired.has(name)) {
+      additive.push(`property made optional (${name})`);
+    }
+    if (!baseRequired.has(name) && curRequired.has(name)) {
+      breaking.push(`property made required (${name})`);
+    }
+    const childBase = asObj(baseProps[name]);
+    const childCur = asObj(curProps[name]);
+    if (childBase && childCur) {
+      const child = diffNode(childBase, childCur, `${path}.${name}`);
+      pushAll(breaking, `${path}.${name}`, child.breaking);
+      pushAll(additive, `${path}.${name}`, child.additive);
+    }
+  }
+
+  for (const name of Object.keys(curProps)) {
+    if (name in baseProps) continue;
+    if (curRequired.has(name)) {
+      breaking.push(`required property added (${name})`);
+    } else {
+      additive.push(`optional property added (${name})`);
+    }
+  }
+}
+
+function diffArray(baseline: JsonObject, current: JsonObject, path: string, acc: DiffAcc): void {
+  const baseItems = asObj(baseline['items']);
+  const curItems = asObj(current['items']);
+  if (!baseItems || !curItems) return;
+  const child = diffNode(baseItems, curItems, `${path}[]`);
+  pushAll(acc.breaking, `${path}[]`, child.breaking);
+  pushAll(acc.additive, `${path}[]`, child.additive);
+}
+
+function diffUnion(baseline: JsonObject, current: JsonObject, path: string, acc: DiffAcc): void {
+  const { breaking, additive } = acc;
+  for (const key of ['anyOf', 'oneOf', 'allOf'] as const) {
+    const baseUnion = asArray(baseline[key]);
+    const curUnion = asArray(current[key]);
+    if (!baseUnion || !curUnion) continue;
+    const baseFingerprints = baseUnion.map((m) => JSON.stringify(m));
+    const curFingerprints = curUnion.map((m) => JSON.stringify(m));
+    const baseSet = new Set(baseFingerprints);
+    const curSet = new Set(curFingerprints);
+    for (const fp of baseFingerprints) {
+      if (!curSet.has(fp)) breaking.push(`${key} member removed (${path})`);
+    }
+    for (const fp of curFingerprints) {
+      if (!baseSet.has(fp)) additive.push(`${key} member added (${path})`);
+    }
+  }
+}
+
+function diffNumericRange(baseline: JsonObject, current: JsonObject, acc: DiffAcc): void {
+  const { breaking, additive } = acc;
+  const baseMin = asNumber(baseline['minimum']);
+  const curMin = asNumber(current['minimum']);
+  if (baseMin === null && curMin !== null) breaking.push(`minimum added (${curMin})`);
+  if (baseMin !== null && curMin === null) additive.push('minimum removed');
+  if (baseMin !== null && curMin !== null) {
+    if (curMin > baseMin) breaking.push(`minimum raised (${baseMin} → ${curMin})`);
+    if (curMin < baseMin) additive.push(`minimum lowered (${baseMin} → ${curMin})`);
+  }
+
+  const baseMax = asNumber(baseline['maximum']);
+  const curMax = asNumber(current['maximum']);
+  if (baseMax === null && curMax !== null) breaking.push(`maximum added (${curMax})`);
+  if (baseMax !== null && curMax === null) additive.push('maximum removed');
+  if (baseMax !== null && curMax !== null) {
+    if (curMax < baseMax) breaking.push(`maximum lowered (${baseMax} → ${curMax})`);
+    if (curMax > baseMax) additive.push(`maximum raised (${baseMax} → ${curMax})`);
+  }
+}
+
+function diffStringConstraints(baseline: JsonObject, current: JsonObject, acc: DiffAcc): void {
+  const { breaking, additive } = acc;
+  const basePattern = asString(baseline['pattern']);
+  const curPattern = asString(current['pattern']);
+  if (basePattern === null && curPattern !== null) breaking.push(`pattern added (${curPattern})`);
+  if (basePattern !== null && curPattern === null) additive.push('pattern removed');
+  if (basePattern !== null && curPattern !== null && basePattern !== curPattern) {
+    breaking.push(`pattern changed (${basePattern} → ${curPattern})`);
+  }
+
+  const baseFormat = asString(baseline['format']);
+  const curFormat = asString(current['format']);
+  if (baseFormat !== null && curFormat !== null && baseFormat !== curFormat) {
+    breaking.push(`format changed (${baseFormat} → ${curFormat})`);
+  }
+  if (baseFormat === null && curFormat !== null) breaking.push(`format added (${curFormat})`);
+  if (baseFormat !== null && curFormat === null) additive.push('format removed');
+
+  const baseMinLen = asNumber(baseline['minLength']);
+  const curMinLen = asNumber(current['minLength']);
+  if (baseMinLen === null && curMinLen !== null) breaking.push(`minLength added (${curMinLen})`);
+  if (baseMinLen !== null && curMinLen !== null && curMinLen > baseMinLen) {
+    breaking.push(`minLength raised (${baseMinLen} → ${curMinLen})`);
+  }
+  const baseMaxLen = asNumber(baseline['maxLength']);
+  const curMaxLen = asNumber(current['maxLength']);
+  if (baseMaxLen === null && curMaxLen !== null) breaking.push(`maxLength added (${curMaxLen})`);
+  if (baseMaxLen !== null && curMaxLen !== null && curMaxLen < baseMaxLen) {
+    breaking.push(`maxLength lowered (${baseMaxLen} → ${curMaxLen})`);
+  }
+}
+
+export function diffZodSurface(baseline: ZodSurface, current: ZodSurface): SurfaceDiff {
+  const baselineIdx = indexBy(baseline);
+  const currentIdx = indexBy(current);
+
+  const added: string[] = [];
+  const removed: string[] = [];
+  const changed: ChangedEntry[] = [];
+
+  for (const [name, entry] of currentIdx) {
+    if (!baselineIdx.has(name)) {
+      added.push(name);
+      continue;
+    }
+    const before = baselineIdx.get(name);
+    if (!before) continue;
+    const baseObj = asObj(before.schema);
+    const curObj = asObj(entry.schema);
+    if (!baseObj || !curObj) continue;
+    const node = diffNode(baseObj, curObj, name);
+    if (node.breaking.length > 0) {
+      changed.push({
+        name,
+        breaking: true,
+        reason: node.breaking.join('; '),
+      });
+    } else if (node.additive.length > 0) {
+      changed.push({
+        name,
+        breaking: false,
+        reason: node.additive.join('; '),
+      });
+    }
+  }
+
+  for (const [name] of baselineIdx) {
+    if (!currentIdx.has(name)) removed.push(name);
+  }
+
+  added.sort();
+  removed.sort();
+  changed.sort((a, b) => {
+    if (a.name < b.name) return -1;
+    if (a.name > b.name) return 1;
+    return 0;
+  });
+
+  let kind: SurfaceDiff['kind'] = 'none';
+  if (removed.length > 0 || changed.some((c) => c.breaking)) {
+    kind = 'breaking';
+  } else if (added.length > 0 || changed.length > 0) {
+    kind = 'additive';
+  }
+
+  return { kind, added, removed, changed };
+}

--- a/scripts/contract/extract-cli.ts
+++ b/scripts/contract/extract-cli.ts
@@ -1,0 +1,87 @@
+/**
+ * `extract-cli.ts` — regenerates committed `.api.json` and `.zod.json`
+ * snapshots for a single contract. Intended to be wired into each
+ * contract package's `extract:ts` / `extract:zod` / `extract:all` npm
+ * scripts so authors can rerun a single command after editing a
+ * schema.
+ *
+ * The CI workflow does NOT run this — it runs `diff-contract.ts` which
+ * compares fresh extraction against committed snapshots and fails on
+ * drift. CI never mutates the repo.
+ */
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { findContract } from './contract-list.js';
+import { extractTsSurface, serialiseTsSurface } from './extract-ts.js';
+import { extractZodSurface, serialiseZodSurface } from './extract-zod.js';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(HERE, '..', '..');
+
+type Kind = 'ts' | 'zod' | 'all';
+
+interface CliOptions {
+  readonly pillar: string;
+  readonly kind: Kind;
+}
+
+function parseArgs(argv: readonly string[]): CliOptions {
+  let pillar: string | null = null;
+  let kind: Kind = 'all';
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--pillar') {
+      const next = argv[i + 1];
+      if (!next) throw new Error('--pillar requires a value');
+      pillar = next;
+      i += 1;
+    } else if (arg === '--kind') {
+      const next = argv[i + 1];
+      if (!next) throw new Error('--kind requires a value');
+      if (next !== 'ts' && next !== 'zod' && next !== 'all') {
+        throw new Error(`--kind must be ts|zod|all, got "${next}"`);
+      }
+      kind = next;
+      i += 1;
+    } else {
+      throw new Error(`unknown argument: ${arg}`);
+    }
+  }
+  if (!pillar) throw new Error('--pillar is required');
+  return { pillar, kind };
+}
+
+function writeFile(path: string, content: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content, 'utf8');
+}
+
+async function main(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2));
+  const contract = findContract(options.pillar);
+  if (!contract) {
+    throw new Error(`no enrolled contract for pillar "${options.pillar}"`);
+  }
+  const packageDir = resolve(REPO_ROOT, contract.packageDir);
+  const etcDir = resolve(packageDir, 'etc');
+
+  if (options.kind === 'ts' || options.kind === 'all') {
+    const tsSurface = extractTsSurface(packageDir);
+    const out = resolve(etcDir, `${contract.pillar}-contract.api.json`);
+    writeFile(out, serialiseTsSurface(tsSurface));
+    process.stdout.write(`[extract-cli] wrote ${out}\n`);
+  }
+  if (options.kind === 'zod' || options.kind === 'all') {
+    const zodSurface = await extractZodSurface(packageDir);
+    const out = resolve(etcDir, `${contract.pillar}-contract.zod.json`);
+    writeFile(out, serialiseZodSurface(zodSurface));
+    process.stdout.write(`[extract-cli] wrote ${out}\n`);
+  }
+}
+
+main().catch((err: unknown) => {
+  process.stderr.write(`${err instanceof Error ? (err.stack ?? err.message) : String(err)}\n`);
+  process.exit(1);
+});

--- a/scripts/contract/extract-ts.ts
+++ b/scripts/contract/extract-ts.ts
@@ -1,0 +1,223 @@
+/**
+ * TypeScript public-surface extractor for contract packages.
+ *
+ * Why custom and not api-extractor: api-extractor expects a single rollup
+ * entry point and a global `.api.md` snapshot. Our contract packages
+ * export multiple sub-paths (`/types`, `/schemas`, `/router`, `/errors`,
+ * `/manifest`) each with their own `.d.ts`, and the router type is
+ * deliberately a type-only re-export of `@pops/finance-api/router` — a
+ * graph api-extractor does not love. A direct AST pass over the emitted
+ * `.d.ts` files for each declared export gives us the exact granularity
+ * we want (per-entry-point symbol list with normalised signature text)
+ * with no extra runtime dep.
+ *
+ * The surface JSON has a stable, sorted shape so `git diff` only shows
+ * meaningful changes — entries are sorted by `entry` then `name`, and
+ * the signature text is whatever the TypeScript printer emits for the
+ * declaration node (post-normalisation of whitespace).
+ */
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+
+import ts from 'typescript';
+
+import type { TsSurface, TsSurfaceEntry } from './types.js';
+
+interface PackageManifest {
+  readonly name: string;
+  readonly version: string;
+  readonly exports?: Record<string, ExportConditions | string>;
+  readonly types?: string;
+  readonly main?: string;
+}
+
+type ExportConditions = {
+  readonly types?: string;
+  readonly default?: string;
+};
+
+const PRINTER = ts.createPrinter({
+  removeComments: true,
+  newLine: ts.NewLineKind.LineFeed,
+  omitTrailingSemicolon: false,
+});
+
+function readPackageJson(packageDir: string): PackageManifest {
+  const raw = readFileSync(resolve(packageDir, 'package.json'), 'utf8');
+  return JSON.parse(raw) as PackageManifest;
+}
+
+function collectEntryPoints(pkg: PackageManifest): { name: string; typesPath: string }[] {
+  const out: { name: string; typesPath: string }[] = [];
+  if (pkg.exports) {
+    for (const [name, value] of Object.entries(pkg.exports)) {
+      if (typeof value === 'string') continue;
+      const types = value.types;
+      if (!types) continue;
+      if (!types.endsWith('.d.ts')) continue;
+      out.push({ name, typesPath: types });
+    }
+  } else if (pkg.types) {
+    out.push({ name: '.', typesPath: pkg.types });
+  }
+  return out;
+}
+
+function normaliseWhitespace(text: string): string {
+  return text
+    .replace(/\r\n/g, '\n')
+    .replace(/[ \t]+\n/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+function entryKind(node: ts.Node): TsSurfaceEntry['kind'] {
+  if (ts.isInterfaceDeclaration(node)) return 'interface';
+  if (ts.isTypeAliasDeclaration(node)) return 'type';
+  if (ts.isFunctionDeclaration(node)) return 'function';
+  if (ts.isClassDeclaration(node)) return 'class';
+  if (ts.isEnumDeclaration(node)) return 'enum';
+  if (ts.isVariableStatement(node)) return 'variable';
+  if (ts.isModuleDeclaration(node)) return 'namespace';
+  return 'reexport';
+}
+
+function entryName(node: ts.Node): string | null {
+  if (
+    ts.isInterfaceDeclaration(node) ||
+    ts.isTypeAliasDeclaration(node) ||
+    ts.isFunctionDeclaration(node) ||
+    ts.isClassDeclaration(node) ||
+    ts.isEnumDeclaration(node) ||
+    ts.isModuleDeclaration(node)
+  ) {
+    return node.name?.getText() ?? null;
+  }
+  if (ts.isVariableStatement(node)) {
+    const first = node.declarationList.declarations[0];
+    return first?.name.getText() ?? null;
+  }
+  return null;
+}
+
+function hasExportModifier(node: ts.Node): boolean {
+  if (!ts.canHaveModifiers(node)) return false;
+  const modifiers = ts.getModifiers(node);
+  return modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword) ?? false;
+}
+
+function collectFromSourceFile(
+  sourceFile: ts.SourceFile,
+  entry: string,
+  resolveImport: (specifier: string, fromFile: string) => string | null,
+  visited: Set<string>
+): TsSurfaceEntry[] {
+  if (visited.has(sourceFile.fileName)) return [];
+  visited.add(sourceFile.fileName);
+
+  const out: TsSurfaceEntry[] = [];
+
+  for (const node of sourceFile.statements) {
+    if (ts.isExportDeclaration(node)) {
+      const specifier = node.moduleSpecifier;
+      if (specifier && ts.isStringLiteral(specifier)) {
+        const target = resolveImport(specifier.text, sourceFile.fileName);
+        if (target) {
+          const child = ts.createSourceFile(
+            target,
+            readFileSync(target, 'utf8'),
+            ts.ScriptTarget.Latest,
+            true,
+            ts.ScriptKind.TS
+          );
+          if (node.exportClause && ts.isNamedExports(node.exportClause)) {
+            const childEntries = collectFromSourceFile(child, entry, resolveImport, visited);
+            const wanted = new Set(
+              node.exportClause.elements.map((el) => (el.propertyName ?? el.name).getText())
+            );
+            for (const e of childEntries) {
+              if (wanted.has(e.name)) out.push({ ...e, entry });
+            }
+          } else {
+            out.push(...collectFromSourceFile(child, entry, resolveImport, visited));
+          }
+          continue;
+        }
+      }
+      if (node.exportClause && ts.isNamedExports(node.exportClause)) {
+        for (const el of node.exportClause.elements) {
+          const exportedName = el.name.getText();
+          const text = normaliseWhitespace(
+            PRINTER.printNode(ts.EmitHint.Unspecified, el, sourceFile)
+          );
+          out.push({ entry, name: exportedName, kind: 'reexport', text });
+        }
+      }
+      continue;
+    }
+
+    if (!hasExportModifier(node)) continue;
+    const name = entryName(node);
+    if (!name) continue;
+    const text = normaliseWhitespace(PRINTER.printNode(ts.EmitHint.Unspecified, node, sourceFile));
+    out.push({ entry, name, kind: entryKind(node), text });
+  }
+
+  return out;
+}
+
+export function extractTsSurface(packageDir: string): TsSurface {
+  const pkg = readPackageJson(packageDir);
+  const entryPoints = collectEntryPoints(pkg);
+
+  const resolveImport = (specifier: string, fromFile: string): string | null => {
+    if (!specifier.startsWith('.')) return null;
+    const baseDir = dirname(fromFile);
+    const noExt = specifier.replace(/\.js$/, '');
+    const candidates = [`${noExt}.d.ts`, `${noExt}/index.d.ts`];
+    for (const c of candidates) {
+      const abs = resolve(baseDir, c);
+      try {
+        readFileSync(abs);
+        return abs;
+      } catch {
+        continue;
+      }
+    }
+    return null;
+  };
+
+  const entries: TsSurfaceEntry[] = [];
+  for (const { name, typesPath } of entryPoints) {
+    const absPath = resolve(packageDir, typesPath);
+    const source = readFileSync(absPath, 'utf8');
+    const sf = ts.createSourceFile(absPath, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+    entries.push(...collectFromSourceFile(sf, name, resolveImport, new Set()));
+  }
+
+  const seen = new Set<string>();
+  const deduped: TsSurfaceEntry[] = [];
+  for (const e of entries) {
+    const key = `${e.entry}::${e.name}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    deduped.push(e);
+  }
+
+  deduped.sort((a, b) => {
+    if (a.entry !== b.entry) return a.entry < b.entry ? -1 : 1;
+    if (a.name < b.name) return -1;
+    if (a.name > b.name) return 1;
+    return 0;
+  });
+
+  return {
+    contract: pkg.name,
+    version: pkg.version,
+    entries: deduped,
+  };
+}
+
+export function serialiseTsSurface(surface: TsSurface): string {
+  return `${JSON.stringify(surface, null, 2)}\n`;
+}

--- a/scripts/contract/extract-zod.ts
+++ b/scripts/contract/extract-zod.ts
@@ -1,0 +1,86 @@
+/**
+ * Zod-schema surface extractor for contract packages.
+ *
+ * Strategy: dynamically `import()` the package's built `schemas` entry
+ * point, enumerate exports whose value is a Zod schema (duck-typed via
+ * the `_def` shape), and emit a normalised JSON document via
+ * `z.toJSONSchema(...)`. The resulting JSON is stable, structural and
+ * doesn't drift on insignificant ordering or library-internal field
+ * additions, which matches our diff requirement.
+ *
+ * Why `z.toJSONSchema` instead of raw `_def`: raw `_def` contains
+ * function references and ordering noise; toJSONSchema is the
+ * library-blessed serialiser. Breaking-change classification on the
+ * emitted JSON Schema is straightforward:
+ *
+ *   - additive: a new optional property; a new enum value; a widened
+ *     numeric range; a new top-level schema.
+ *   - breaking: a new required property; a removed enum value; a
+ *     narrowed numeric range; a removed property; a tightened pattern.
+ *
+ * The diff classifier lives in `diff-zod.ts`.
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { z } from 'zod';
+
+import type { ZodSurface, ZodSurfaceEntry } from './types.js';
+
+interface PackageManifest {
+  readonly name: string;
+  readonly version: string;
+  readonly exports?: Record<string, { default?: string } | string>;
+}
+
+function readPackageJson(packageDir: string): PackageManifest {
+  const raw = readFileSync(resolve(packageDir, 'package.json'), 'utf8');
+  return JSON.parse(raw) as PackageManifest;
+}
+
+function resolveSchemasEntry(packageDir: string, pkg: PackageManifest): string {
+  const fromExports = pkg.exports?.['./schemas'];
+  if (fromExports && typeof fromExports !== 'string' && fromExports.default) {
+    return resolve(packageDir, fromExports.default);
+  }
+  return resolve(packageDir, 'dist/schemas/index.js');
+}
+
+function isZodSchema(value: unknown): value is z.ZodType {
+  if (typeof value !== 'object' || value === null) return false;
+  const candidate = value as { _def?: unknown };
+  if (typeof candidate._def !== 'object' || candidate._def === null) return false;
+  const def = candidate._def as { type?: unknown };
+  return typeof def.type === 'string';
+}
+
+export async function extractZodSurface(packageDir: string): Promise<ZodSurface> {
+  const pkg = readPackageJson(packageDir);
+  const schemasEntry = resolveSchemasEntry(packageDir, pkg);
+
+  const mod = (await import(pathToFileURL(schemasEntry).href)) as Record<string, unknown>;
+
+  const entries: ZodSurfaceEntry[] = [];
+  for (const [name, value] of Object.entries(mod)) {
+    if (!isZodSchema(value)) continue;
+    const jsonSchema = z.toJSONSchema(value, { unrepresentable: 'any' });
+    entries.push({ name, schema: jsonSchema });
+  }
+
+  entries.sort((a, b) => {
+    if (a.name < b.name) return -1;
+    if (a.name > b.name) return 1;
+    return 0;
+  });
+
+  return {
+    contract: pkg.name,
+    version: pkg.version,
+    entries,
+  };
+}
+
+export function serialiseZodSurface(surface: ZodSurface): string {
+  return `${JSON.stringify(surface, null, 2)}\n`;
+}

--- a/scripts/contract/semver.ts
+++ b/scripts/contract/semver.ts
@@ -1,0 +1,69 @@
+/**
+ * Tiny semver helpers — we only need parsing, comparison and bumping by
+ * level. Avoid pulling in `semver` (extra runtime dep, mostly geared at
+ * range parsing we do not use). All inputs are strict `X.Y.Z` triples;
+ * pre-release suffixes are rejected — contract packages never ship
+ * pre-releases (see ADR-030).
+ */
+import type { Classification, SemverParts } from './types.js';
+
+const STRICT = /^(\d+)\.(\d+)\.(\d+)$/;
+
+export function parseSemver(version: string): SemverParts {
+  const match = STRICT.exec(version);
+  if (!match) {
+    throw new Error(`invalid semver "${version}" — expected strict X.Y.Z`);
+  }
+  const [, major, minor, patch] = match;
+  return {
+    major: Number(major),
+    minor: Number(minor),
+    patch: Number(patch),
+  };
+}
+
+export function stringifySemver(parts: SemverParts): string {
+  return `${parts.major}.${parts.minor}.${parts.patch}`;
+}
+
+export function compareSemver(a: SemverParts, b: SemverParts): -1 | 0 | 1 {
+  if (a.major !== b.major) return a.major < b.major ? -1 : 1;
+  if (a.minor !== b.minor) return a.minor < b.minor ? -1 : 1;
+  if (a.patch !== b.patch) return a.patch < b.patch ? -1 : 1;
+  return 0;
+}
+
+export function bump(baseline: SemverParts, classification: Classification): SemverParts {
+  switch (classification) {
+    case 'none':
+      return baseline;
+    case 'patch':
+      return { major: baseline.major, minor: baseline.minor, patch: baseline.patch + 1 };
+    case 'minor':
+      return { major: baseline.major, minor: baseline.minor + 1, patch: 0 };
+    case 'major':
+      return { major: baseline.major + 1, minor: 0, patch: 0 };
+  }
+}
+
+export function classifyBump(baseline: SemverParts, current: SemverParts): Classification {
+  if (current.major > baseline.major) return 'major';
+  if (current.major < baseline.major) {
+    throw new Error(
+      `current version ${stringifySemver(current)} is below baseline ${stringifySemver(baseline)}; downgrades are not allowed`
+    );
+  }
+  if (current.minor > baseline.minor) return 'minor';
+  if (current.minor < baseline.minor) {
+    throw new Error(
+      `current version ${stringifySemver(current)} regresses the minor component below baseline ${stringifySemver(baseline)}`
+    );
+  }
+  if (current.patch > baseline.patch) return 'patch';
+  if (current.patch < baseline.patch) {
+    throw new Error(
+      `current version ${stringifySemver(current)} regresses the patch component below baseline ${stringifySemver(baseline)}`
+    );
+  }
+  return 'none';
+}

--- a/scripts/contract/tag-on-bump.ts
+++ b/scripts/contract/tag-on-bump.ts
@@ -1,0 +1,150 @@
+/**
+ * `tag-on-bump.ts` — runs on push to `main`.
+ *
+ * For every enrolled contract, inspect whether the latest commit on
+ * `main` changed `packages/<pillar>-contract/package.json`'s `version`
+ * field. If yes and the corresponding `contract-<pillar>@v<version>`
+ * tag does not yet exist, create it (annotated) and push it.
+ *
+ * Idempotent: rerunning on the same revision is a no-op. Tag operations
+ * are idempotent; a race with a concurrent push results in a non-fatal
+ * "already exists" warning.
+ *
+ * Usage:
+ *   tsx scripts/contract/tag-on-bump.ts            # tag any bumps
+ *   tsx scripts/contract/tag-on-bump.ts --dry-run  # report intent only
+ *   tsx scripts/contract/tag-on-bump.ts --rev HEAD # explicit rev
+ */
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { CONTRACTS, type ContractEntry } from './contract-list.js';
+
+const HERE = resolve(fileURLToPath(import.meta.url), '..');
+const REPO_ROOT = resolve(HERE, '..', '..');
+
+interface CliOptions {
+  readonly dryRun: boolean;
+  readonly rev: string;
+  readonly push: boolean;
+}
+
+function parseArgs(argv: readonly string[]): CliOptions {
+  let dryRun = false;
+  let rev = 'HEAD';
+  let push = true;
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--dry-run') dryRun = true;
+    else if (arg === '--no-push') push = false;
+    else if (arg === '--rev') {
+      const next = argv[i + 1];
+      if (!next) throw new Error('--rev requires a value');
+      rev = next;
+      i += 1;
+    } else {
+      throw new Error(`unknown argument: ${arg}`);
+    }
+  }
+  return { dryRun, rev, push };
+}
+
+function git(args: readonly string[], opts: { allowFailure?: boolean } = {}): string {
+  try {
+    return execFileSync('git', args, { cwd: REPO_ROOT, encoding: 'utf8' }).trim();
+  } catch (err) {
+    if (opts.allowFailure) return '';
+    throw err;
+  }
+}
+
+function readVersionAt(contract: ContractEntry, rev: string): string | null {
+  const path = `${contract.packageDir}/package.json`;
+  const raw = git(['show', `${rev}:${path}`], { allowFailure: true });
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as { version?: string };
+    return parsed.version ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function readCurrentVersion(contract: ContractEntry): string {
+  const path = resolve(REPO_ROOT, contract.packageDir, 'package.json');
+  const parsed = JSON.parse(readFileSync(path, 'utf8')) as { version?: string };
+  if (!parsed.version) {
+    throw new Error(`${contract.packageName} has no version field in package.json`);
+  }
+  return parsed.version;
+}
+
+function tagExists(tag: string): boolean {
+  const local = git(['tag', '--list', tag], { allowFailure: true });
+  if (local) return true;
+  const remote = git(['ls-remote', '--tags', 'origin', tag], { allowFailure: true });
+  return remote.length > 0;
+}
+
+interface TagAction {
+  readonly contract: ContractEntry;
+  readonly tag: string;
+  readonly previousVersion: string | null;
+  readonly currentVersion: string;
+  readonly action: 'created' | 'skipped-exists' | 'skipped-no-bump' | 'dry-run';
+}
+
+export function planTagActions(rev: string): TagAction[] {
+  const out: TagAction[] = [];
+  for (const contract of CONTRACTS) {
+    const currentVersion = readCurrentVersion(contract);
+    const parentRev = `${rev}^`;
+    const previousVersion = readVersionAt(contract, parentRev);
+    const tag = `${contract.tagPrefix}${currentVersion}`;
+
+    if (previousVersion === currentVersion) {
+      out.push({ contract, tag, previousVersion, currentVersion, action: 'skipped-no-bump' });
+      continue;
+    }
+    if (tagExists(tag)) {
+      out.push({ contract, tag, previousVersion, currentVersion, action: 'skipped-exists' });
+      continue;
+    }
+    out.push({ contract, tag, previousVersion, currentVersion, action: 'created' });
+  }
+  return out;
+}
+
+function applyAction(action: TagAction, options: CliOptions): TagAction {
+  if (action.action !== 'created') return action;
+  if (options.dryRun) {
+    return { ...action, action: 'dry-run' };
+  }
+  const message = `${action.contract.packageName} v${action.currentVersion}`;
+  git(['tag', '-a', action.tag, '-m', message, options.rev]);
+  if (options.push) {
+    git(['push', 'origin', action.tag]);
+  }
+  return action;
+}
+
+async function main(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2));
+  const plan = planTagActions(options.rev);
+
+  for (const action of plan) {
+    const applied = applyAction(action, options);
+    process.stdout.write(
+      `[tag-on-bump] ${applied.contract.packageName}: ${applied.action} ` +
+        `(prev=${applied.previousVersion ?? 'n/a'} → cur=${applied.currentVersion}) ` +
+        `tag=${applied.tag}\n`
+    );
+  }
+}
+
+main().catch((err: unknown) => {
+  process.stderr.write(`${err instanceof Error ? (err.stack ?? err.message) : String(err)}\n`);
+  process.exit(1);
+});

--- a/scripts/contract/tsconfig.json
+++ b/scripts/contract/tsconfig.json
@@ -6,5 +6,5 @@
     "noEmit": true,
     "types": ["node", "vitest/globals"]
   },
-  "include": ["*.ts"]
+  "include": ["*.ts", "__tests__/**/*.ts"]
 }

--- a/scripts/contract/types.ts
+++ b/scripts/contract/types.ts
@@ -1,0 +1,87 @@
+/**
+ * Shared types for the contract semver pipeline (PRD-154).
+ *
+ * Snapshots are committed JSON files in `etc/<pillar>-contract.api.json`
+ * and `etc/<pillar>-contract.zod.json`. Diffs are computed against the
+ * baseline tag's snapshots and classified into the verdicts below.
+ */
+export type DiffKind = 'none' | 'additive' | 'breaking';
+
+export type Classification = 'none' | 'patch' | 'minor' | 'major';
+
+export type Verdict =
+  | 'pass-no-change'
+  | 'pass-additive-noop'
+  | 'pass-bumped-correctly'
+  | 'pass-initial-version'
+  | 'pass-no-consumers'
+  | 'fail-bump-required'
+  | 'fail-bump-too-small'
+  | 'fail-bump-too-large'
+  | 'fail-migration-section-missing'
+  | 'fail-snapshot-stale'
+  | 'fail-baseline-missing-on-tag';
+
+export interface TsSurfaceEntry {
+  readonly entry: string;
+  readonly name: string;
+  readonly kind:
+    | 'interface'
+    | 'type'
+    | 'function'
+    | 'class'
+    | 'enum'
+    | 'variable'
+    | 'namespace'
+    | 'reexport';
+  readonly text: string;
+}
+
+export interface TsSurface {
+  readonly contract: string;
+  readonly version: string;
+  readonly entries: readonly TsSurfaceEntry[];
+}
+
+export interface ZodSurfaceEntry {
+  readonly name: string;
+  readonly schema: unknown;
+}
+
+export interface ZodSurface {
+  readonly contract: string;
+  readonly version: string;
+  readonly entries: readonly ZodSurfaceEntry[];
+}
+
+export interface SurfaceDiff {
+  readonly kind: DiffKind;
+  readonly added: readonly string[];
+  readonly removed: readonly string[];
+  readonly changed: readonly ChangedEntry[];
+}
+
+export interface ChangedEntry {
+  readonly name: string;
+  readonly breaking: boolean;
+  readonly reason: string;
+}
+
+export interface SemverParts {
+  readonly major: number;
+  readonly minor: number;
+  readonly patch: number;
+}
+
+export interface DiffReport {
+  readonly contract: string;
+  readonly baselineTag: string | null;
+  readonly baselineVersion: string | null;
+  readonly currentVersion: string;
+  readonly tsDiff: SurfaceDiff;
+  readonly zodDiff: SurfaceDiff;
+  readonly classification: Classification;
+  readonly requiredVersion: string;
+  readonly verdict: Verdict;
+  readonly reason: string;
+}

--- a/scripts/contract/verdict.ts
+++ b/scripts/contract/verdict.ts
@@ -1,0 +1,119 @@
+/**
+ * Verdict computation: given two diffs and the baseline / current
+ * versions, produce a `Verdict` and a human-readable reason. Pure
+ * function of its inputs — the orchestrator (`diff-contract.ts`)
+ * gathers the snapshots and calls in here.
+ */
+import { bump, classifyBump, compareSemver, parseSemver, stringifySemver } from './semver.js';
+
+import type { Classification, SurfaceDiff, Verdict } from './types.js';
+
+export interface VerdictInputs {
+  readonly baselineVersion: string | null;
+  readonly currentVersion: string;
+  readonly tsDiff: SurfaceDiff;
+  readonly zodDiff: SurfaceDiff;
+}
+
+export interface VerdictOutput {
+  readonly classification: Classification;
+  readonly requiredVersion: string;
+  readonly verdict: Verdict;
+  readonly reason: string;
+}
+
+function combineClassification(ts: SurfaceDiff, zod: SurfaceDiff): Classification {
+  if (ts.kind === 'breaking' || zod.kind === 'breaking') return 'major';
+  if (ts.kind === 'additive' || zod.kind === 'additive') return 'minor';
+  return 'none';
+}
+
+export function classifyDiffs(ts: SurfaceDiff, zod: SurfaceDiff): Classification {
+  return combineClassification(ts, zod);
+}
+
+export function computeVerdict(input: VerdictInputs): VerdictOutput {
+  const classification = combineClassification(input.tsDiff, input.zodDiff);
+
+  if (input.baselineVersion === null) {
+    return {
+      classification,
+      requiredVersion: input.currentVersion,
+      verdict: 'pass-initial-version',
+      reason: 'no baseline tag found — this PR establishes the initial baseline.',
+    };
+  }
+
+  const baseline = parseSemver(input.baselineVersion);
+  const current = parseSemver(input.currentVersion);
+  const required = bump(baseline, classification);
+  const requiredString = stringifySemver(required);
+
+  const bumpLevel = classifyBump(baseline, current);
+
+  if (classification === 'none') {
+    if (compareSemver(current, baseline) === 0) {
+      return {
+        classification,
+        requiredVersion: requiredString,
+        verdict: 'pass-no-change',
+        reason: 'no surface diff detected; version unchanged.',
+      };
+    }
+    return {
+      classification,
+      requiredVersion: requiredString,
+      verdict: 'pass-no-change',
+      reason: `no surface diff detected but version bumped to ${input.currentVersion}; consider not bumping.`,
+    };
+  }
+
+  if (compareSemver(current, baseline) === 0) {
+    return {
+      classification,
+      requiredVersion: requiredString,
+      verdict: 'fail-bump-required',
+      reason: `${classification} changes detected but version was not bumped (still ${input.currentVersion}). bump to ${requiredString}.`,
+    };
+  }
+
+  const requiredLevel = classificationRank(classification);
+  const declaredLevel = classificationRank(bumpLevel);
+
+  if (declaredLevel < requiredLevel) {
+    return {
+      classification,
+      requiredVersion: requiredString,
+      verdict: 'fail-bump-too-small',
+      reason: `detected ${classification} change but version was bumped only ${bumpLevel}; bump to ${requiredString}.`,
+    };
+  }
+  if (declaredLevel > requiredLevel) {
+    return {
+      classification,
+      requiredVersion: requiredString,
+      verdict: 'fail-bump-too-large',
+      reason: `${bumpLevel} bump declared but only ${classification} would suffice; consider ${requiredString} instead of ${input.currentVersion}.`,
+    };
+  }
+
+  return {
+    classification,
+    requiredVersion: requiredString,
+    verdict: 'pass-bumped-correctly',
+    reason: `version bump to ${input.currentVersion} matches the detected ${classification} change.`,
+  };
+}
+
+function classificationRank(c: Classification): number {
+  switch (c) {
+    case 'none':
+      return 0;
+    case 'patch':
+      return 1;
+    case 'minor':
+      return 2;
+    case 'major':
+      return 3;
+  }
+}


### PR DESCRIPTION
## Summary

Implements the contract semver enforcement CI from Theme 13 PRD-154. `@pops/finance-contract` is the pilot per US-08; the other pillars roll out under US-09 once their contract packages exist.

The pipeline:

- **TS surface diff**: custom extractor over the contract's emitted `.d.ts` files (TypeScript Compiler API). Rationale for not using `@microsoft/api-extractor` is in the `extract-ts.ts` header: the contract ships multiple sub-path exports (`./types`, `./schemas`, `./router`, `./errors`, `./manifest`) and api-extractor wants a single rolled-up `.api.md`. The custom extractor gives per-entry-point granularity with no extra runtime dep.
- **Zod surface diff**: serialises each Zod schema via `z.toJSONSchema(...)` and walks the JSON Schema for breaking-vs-additive classification (required property added, enum value removed, narrowed range, tightened pattern, removed union member, type change, nested property removal).
- **Verdict**: 11 verdicts mapping (tsDiff, zodDiff, baseline version, current version) → pass / fail with the exact required version printed. `package.json` version is the only source of truth.
- **Drift check**: regenerates `etc/*.api.json` + `etc/*.zod.json` and the OpenAPI snapshot in CI; fails on any diff vs what's committed.
- **Affected rebuild**: `pnpm turbo run typecheck test --filter='...[<merge-base>]'` on every contract PR. Consumer failures block the contract PR.
- **Tag-on-bump**: push-to-main job creates `contract-<pillar>@v<version>` annotated tags when the version field changes. Idempotent.

Per AGENTS.md / global rules: no `as any`, no suppressions, comprehensive tests (73 across 8 files), `mise lint` + `mise typecheck` pass.

## What a synthetic breaking-change test looks like

`scripts/contract/__tests__/self-test.test.ts` (PRD-154 US-07). It builds a baseline `TsSurface` + `ZodSurface` modeled on the finance contract, injects a breaking change (rename `id: string` to `id: number` and drop `targetAmount`), and asserts:

1. `diffTsSurface` returns `kind: 'breaking'` with the changed entry surfaced.
2. `diffZodSurface` returns `kind: 'breaking'`.
3. `computeVerdict({ baseline: '1.4.2', current: '1.4.2', ... })` → `fail-bump-required` with `requiredVersion: '2.0.0'`.
4. `computeVerdict({ ..., current: '1.5.0', ... })` → `fail-bump-too-small`.
5. `computeVerdict({ ..., current: '2.0.0', ... })` → `pass-bumped-correctly`.

It's the proof that the workflow catches breakages end-to-end, not just that the sub-units agree in isolation.

## First baseline

`packages/finance-contract/etc/finance-contract.{api,zod}.json` are the initial 0.1.0 baseline. No `contract-finance@v0.1.0` tag yet — the tag is created on merge-to-main by the `tag-on-bump` job, exercising the `pass-initial-version` path.

## Test plan

- [ ] CI: semver-and-drift job passes (no baseline tag yet → `pass-initial-version`).
- [ ] CI: affected-rebuild job passes (only the contract changed; consumers are limited).
- [ ] CI: vitest run for `scripts/contract/__tests__/` shows 73 tests passing.
- [ ] On merge: `tag-on-bump` job creates `contract-finance@v0.1.0`.
- [ ] Follow-up: simulate a breaking change in a separate PR and confirm CI blocks without a major bump.