### PR TITLE
feat(registry): SSE subscription endpoint (Theme 13 PRD-163)

### DIFF
--- a/apps/pops-core-api/src/__tests__/subscribe.test.ts
+++ b/apps/pops-core-api/src/__tests__/subscribe.test.ts
@@ -1,0 +1,288 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+/**
+ * SSE smoke tests for `GET /registry/subscribe` (Theme 13 PRD-163).
+ *
+ * Drives a real Express listener via Node's `http` client so we can
+ * assert on the event-stream framing, including:
+ *   - initial `pillar.snapshot` event on connect;
+ *   - per-mutation `pillar.registered` / `pillar.deregistered` frames;
+ *   - per-client cleanup on disconnect (listener count returns to the
+ *     pre-connect baseline);
+ *   - mid-stream client kill leaves no leaked listeners.
+ */
+import { createServer, get as httpGet, type Server } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { openCoreDb, type OpenedCoreDb } from '@pops/core-db';
+
+import { createCoreApiApp } from '../app.js';
+import { registryEventBus, registryEventListenerCount } from '../modules/registry/event-bus.js';
+import { appRouter } from '../router.js';
+import { type Context } from '../trpc.js';
+
+import type { AddressInfo } from 'node:net';
+
+import type { ManifestPayload } from '@pops/pillar-sdk';
+
+let tmpDir: string;
+let coreDb: OpenedCoreDb;
+let server: Server;
+let baseUrl: string;
+
+beforeEach(async () => {
+  registryEventBus.removeAllListeners();
+  tmpDir = mkdtempSync(join(tmpdir(), 'core-api-subscribe-test-'));
+  coreDb = openCoreDb(join(tmpDir, 'core.db'));
+  const app = createCoreApiApp({
+    coreDb,
+    version: '0.0.1-test',
+    selfBaseUrl: 'http://core-api:3001',
+  });
+  server = createServer(app);
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const addr = server.address() as AddressInfo;
+  baseUrl = `http://127.0.0.1:${addr.port}`;
+});
+
+afterEach(async () => {
+  server.closeAllConnections?.();
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  coreDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function caller(): ReturnType<typeof appRouter.createCaller> {
+  const ctx: Context = {
+    user: { email: 'dev@example.com' },
+    serviceAccount: null,
+    coreDb: coreDb.db,
+  };
+  return appRouter.createCaller(ctx);
+}
+
+function financeManifest(): ManifestPayload {
+  return {
+    pillar: 'finance',
+    version: '1.2.3',
+    contract: {
+      package: '@pops/finance-contract',
+      version: '1.2.3',
+      tag: 'contract-finance@v1.2.3',
+    },
+    routes: {
+      queries: ['finance.transactions.list'],
+      mutations: ['finance.transactions.create'],
+      subscriptions: [],
+    },
+    search: { adapters: ['transactionsAdapter'] },
+    ai: {
+      tools: [
+        {
+          name: 'createTransaction',
+          description: 'Create a transaction in the finance ledger.',
+          parameters: { type: 'object' },
+        },
+      ],
+    },
+    uri: { types: ['finance/transaction'] },
+    settings: { keys: ['finance.defaultCurrency'] },
+    healthcheck: { path: '/healthz' },
+  };
+}
+
+interface SseEvent {
+  event: string;
+  data: unknown;
+}
+
+interface SseClient {
+  events: SseEvent[];
+  waitFor: (predicate: (evt: SseEvent) => boolean, timeoutMs?: number) => Promise<SseEvent>;
+  close: () => Promise<void>;
+  destroyed: Promise<void>;
+}
+
+function openSseClient(url: string): Promise<SseClient> {
+  return new Promise((resolve, reject) => {
+    const events: SseEvent[] = [];
+    const waiters: Array<{ predicate: (e: SseEvent) => boolean; resolve: (e: SseEvent) => void }> =
+      [];
+    let buffer = '';
+
+    const pushEvent = (evt: SseEvent): void => {
+      events.push(evt);
+      for (let i = waiters.length - 1; i >= 0; i--) {
+        const waiter = waiters[i];
+        if (!waiter) continue;
+        if (waiter.predicate(evt)) {
+          waiters.splice(i, 1);
+          waiter.resolve(evt);
+        }
+      }
+    };
+
+    const flushBuffer = (): void => {
+      let idx = buffer.indexOf('\n\n');
+      while (idx !== -1) {
+        const frame = buffer.slice(0, idx);
+        buffer = buffer.slice(idx + 2);
+        let eventName = 'message';
+        const dataLines: string[] = [];
+        for (const line of frame.split('\n')) {
+          if (line.startsWith('event: ')) eventName = line.slice(7);
+          else if (line.startsWith('data: ')) dataLines.push(line.slice(6));
+        }
+        if (dataLines.length > 0) {
+          const raw = dataLines.join('\n');
+          let parsed: unknown = raw;
+          try {
+            parsed = JSON.parse(raw);
+          } catch {
+            parsed = raw;
+          }
+          pushEvent({ event: eventName, data: parsed });
+        }
+        idx = buffer.indexOf('\n\n');
+      }
+    };
+
+    const req = httpGet(url, (res) => {
+      if (res.statusCode !== 200) {
+        reject(new Error(`SSE connect failed: status ${res.statusCode ?? 'unknown'}`));
+        res.resume();
+        return;
+      }
+      res.setEncoding('utf8');
+      res.on('data', (chunk: string) => {
+        buffer += chunk;
+        flushBuffer();
+      });
+
+      const destroyed = new Promise<void>((resolveDestroyed) => {
+        const finish = (): void => resolveDestroyed();
+        res.once('close', finish);
+        res.once('end', finish);
+      });
+
+      const close = (): Promise<void> => {
+        req.destroy();
+        return destroyed;
+      };
+
+      const waitFor = (
+        predicate: (evt: SseEvent) => boolean,
+        timeoutMs = 2000
+      ): Promise<SseEvent> =>
+        new Promise<SseEvent>((resolveWait, rejectWait) => {
+          const existing = events.find(predicate);
+          if (existing) {
+            resolveWait(existing);
+            return;
+          }
+          const timer = setTimeout(() => {
+            const idx = waiters.findIndex((w) => w.resolve === wrapped);
+            if (idx >= 0) waiters.splice(idx, 1);
+            rejectWait(new Error(`Timed out waiting for SSE event after ${timeoutMs}ms`));
+          }, timeoutMs);
+          const wrapped = (evt: SseEvent): void => {
+            clearTimeout(timer);
+            resolveWait(evt);
+          };
+          waiters.push({ predicate, resolve: wrapped });
+        });
+
+      resolve({ events, waitFor, close, destroyed });
+    });
+
+    req.on('error', reject);
+  });
+}
+
+async function waitForListenerCount(expected: number, timeoutMs = 2000): Promise<number> {
+  const start = Date.now();
+  while (registryEventListenerCount() !== expected && Date.now() - start < timeoutMs) {
+    await new Promise((r) => setTimeout(r, 10));
+  }
+  return registryEventListenerCount();
+}
+
+describe('GET /registry/subscribe', () => {
+  it('emits a pillar.snapshot on connect with the current registry state', async () => {
+    await caller().core.registry.register({
+      baseUrl: 'http://finance-api:3004',
+      manifest: financeManifest(),
+    });
+
+    const client = await openSseClient(`${baseUrl}/registry/subscribe`);
+    const snapshot = await client.waitFor((evt) => evt.event === 'pillar.snapshot');
+    expect(Array.isArray(snapshot.data)).toBe(true);
+    const entries = snapshot.data as Array<{ pillarId: string; baseUrl: string }>;
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.pillarId).toBe('finance');
+    expect(entries[0]?.baseUrl).toBe('http://finance-api:3004');
+
+    await client.close();
+  });
+
+  it('emits a pillar.registered event when a pillar registers mid-stream', async () => {
+    const client = await openSseClient(`${baseUrl}/registry/subscribe`);
+    await client.waitFor((evt) => evt.event === 'pillar.snapshot');
+
+    await caller().core.registry.register({
+      baseUrl: 'http://finance-api:3004',
+      manifest: financeManifest(),
+    });
+
+    const registered = await client.waitFor((evt) => evt.event === 'pillar.registered');
+    const payload = registered.data as {
+      event: string;
+      pillarId: string;
+      entry: { pillarId: string; baseUrl: string } | null;
+    };
+    expect(payload.event).toBe('registered');
+    expect(payload.pillarId).toBe('finance');
+    expect(payload.entry?.pillarId).toBe('finance');
+    expect(payload.entry?.baseUrl).toBe('http://finance-api:3004');
+
+    await client.close();
+  });
+
+  it('removes the bus listener on client disconnect (no leaks)', async () => {
+    const baseline = await waitForListenerCount(0);
+    expect(baseline).toBe(0);
+
+    const client = await openSseClient(`${baseUrl}/registry/subscribe`);
+    await client.waitFor((evt) => evt.event === 'pillar.snapshot');
+    expect(await waitForListenerCount(1)).toBe(1);
+
+    await client.close();
+
+    expect(await waitForListenerCount(0)).toBe(0);
+  });
+
+  it('cleans up listeners even when a client is killed mid-stream', async () => {
+    const baseline = await waitForListenerCount(0);
+    expect(baseline).toBe(0);
+
+    const a = await openSseClient(`${baseUrl}/registry/subscribe`);
+    const b = await openSseClient(`${baseUrl}/registry/subscribe`);
+    await a.waitFor((evt) => evt.event === 'pillar.snapshot');
+    await b.waitFor((evt) => evt.event === 'pillar.snapshot');
+    expect(await waitForListenerCount(2)).toBe(2);
+
+    await a.close();
+    expect(await waitForListenerCount(1)).toBe(1);
+
+    await caller().core.registry.register({
+      baseUrl: 'http://finance-api:3004',
+      manifest: financeManifest(),
+    });
+    await b.waitFor((evt) => evt.event === 'pillar.registered');
+
+    await b.close();
+    expect(await waitForListenerCount(0)).toBe(0);
+  });
+});

--- a/apps/pops-core-api/src/app.ts
+++ b/apps/pops-core-api/src/app.ts
@@ -15,6 +15,7 @@ import { createExpressMiddleware } from '@trpc/server/adapters/express';
 import express, { type Express, type Request, type Response } from 'express';
 
 import { type CoreApiDeps, makeRequestHandler } from './handlers.js';
+import { createRegistrySubscribeHandler } from './modules/registry/subscribe.js';
 import { appRouter } from './router.js';
 import { createCoreTrpcContextFactory } from './trpc.js';
 
@@ -31,6 +32,8 @@ export function createCoreApiApp(deps: CoreApiDeps): Express {
   app.get('/pillars', (_req: Request, res: Response) => {
     res.json(handlers.pillars());
   });
+
+  app.get('/registry/subscribe', createRegistrySubscribeHandler(deps.coreDb.db));
 
   app.use(
     '/trpc',

--- a/apps/pops-core-api/src/modules/registry/event-bus.ts
+++ b/apps/pops-core-api/src/modules/registry/event-bus.ts
@@ -1,0 +1,54 @@
+/**
+ * In-process registry event bus (Theme 13 PRD-163).
+ *
+ * Singleton `EventEmitter` that the registry router publishes to on
+ * register / deregister / heartbeat status transitions, and that the
+ * `GET /registry/subscribe` SSE handler subscribes to.
+ *
+ * Per the PRD: no sequence numbers, no cross-process distribution, no
+ * server-side filtering. Multi-process scaling is explicitly out of
+ * scope; the bus is a singleton per core-api process.
+ */
+import { EventEmitter } from 'node:events';
+
+import type { RegistryEntry } from './types.js';
+
+export type RegistryEventName = 'registered' | 'deregistered' | 'health-changed';
+
+export interface RegistryEventPayload {
+  event: RegistryEventName;
+  pillarId: string;
+  entry: RegistryEntry | null;
+  emittedAt: string;
+}
+
+const EVENT_KEY = 'registry:event' as const;
+
+/**
+ * Process-local registry event bus. Exported so tests can probe
+ * `listenerCount` to assert per-client cleanup; production callers
+ * should go through `emitRegistryEvent` / `subscribeToRegistryEvents`.
+ */
+export const registryEventBus: EventEmitter = new EventEmitter();
+registryEventBus.setMaxListeners(0);
+
+export function emitRegistryEvent(payload: Omit<RegistryEventPayload, 'emittedAt'>): void {
+  const enriched: RegistryEventPayload = {
+    ...payload,
+    emittedAt: new Date().toISOString(),
+  };
+  registryEventBus.emit(EVENT_KEY, enriched);
+}
+
+export function subscribeToRegistryEvents(
+  listener: (payload: RegistryEventPayload) => void
+): () => void {
+  registryEventBus.on(EVENT_KEY, listener);
+  return () => {
+    registryEventBus.off(EVENT_KEY, listener);
+  };
+}
+
+export function registryEventListenerCount(): number {
+  return registryEventBus.listenerCount(EVENT_KEY);
+}

--- a/apps/pops-core-api/src/modules/registry/router.ts
+++ b/apps/pops-core-api/src/modules/registry/router.ts
@@ -28,6 +28,7 @@ import { pillarRegistryService } from '@pops/core-db';
 import { validateManifestPayload } from '@pops/pillar-sdk';
 
 import { publicProcedure, router } from '../../trpc.js';
+import { emitRegistryEvent } from './event-bus.js';
 import { computeStatus, registryNow } from './status.js';
 import {
   DeregisterInputSchema,
@@ -81,6 +82,8 @@ export const registryRouter = router({
         manifest: result.payload,
         now: registryNow().toISOString(),
       });
+      const entry = toRegistryEntry(persisted, registryNow());
+      emitRegistryEvent({ event: 'registered', pillarId: entry.pillarId, entry });
       return {
         ok: true as const,
         pillarId: persisted.pillarId,
@@ -93,6 +96,9 @@ export const registryRouter = router({
     .output(DeregisterOutputSchema)
     .mutation(({ input, ctx }) => {
       const removed = pillarRegistryService.deletePillarRegistration(ctx.coreDb, input.pillar);
+      if (removed) {
+        emitRegistryEvent({ event: 'deregistered', pillarId: input.pillar, entry: null });
+      }
       return { ok: true as const, removed };
     }),
 
@@ -105,6 +111,10 @@ export const registryRouter = router({
       });
       if (!result.recorded || !result.registration) {
         return { ok: false as const, reason: 'not-registered' as const };
+      }
+      if (result.statusChanged) {
+        const entry = toRegistryEntry(result.registration, registryNow());
+        emitRegistryEvent({ event: 'health-changed', pillarId: entry.pillarId, entry });
       }
       return {
         ok: true as const,

--- a/apps/pops-core-api/src/modules/registry/subscribe.ts
+++ b/apps/pops-core-api/src/modules/registry/subscribe.ts
@@ -1,0 +1,98 @@
+/**
+ * SSE handler for `GET /registry/subscribe` (Theme 13 PRD-163).
+ *
+ * Plain Express route — NOT a tRPC subscription. tRPC subscriptions
+ * require a WebSocket transport; SSE is plain HTTP. The handler sits
+ * alongside the tRPC mount in `app.ts`.
+ *
+ * Lifecycle:
+ *   1. On connect, write a `snapshot` event containing the current
+ *      `RegistryEntry[]` (one read against `pillar_registry`).
+ *   2. Subscribe to the in-process event bus and forward every
+ *      register / deregister / health-changed payload as a discrete
+ *      `event: pillar.<name>` SSE frame.
+ *   3. On `req.on('close')`, unsubscribe from the bus so a flaky
+ *      client cannot leak listeners.
+ *
+ * Auth: registry mutations are nginx-gated; `/registry/subscribe` is
+ * read-only and public for now (PRD-163 "Out of Scope: Authentication
+ * on the SSE endpoint"). Reconnect behaviour + client-side backoff
+ * are PRD-164's responsibility — this PR only ships the server.
+ *
+ * Follow-ups (intentionally not in this PR):
+ *   - 30s keep-alive comments (covered when PRD-164 needs them).
+ *   - Per-client write-queue bounds + backpressure handling.
+ */
+import { pillarRegistryService, type CoreDb } from '@pops/core-db';
+
+import { subscribeToRegistryEvents, type RegistryEventPayload } from './event-bus.js';
+import { computeStatus, registryNow } from './status.js';
+import { RegistryEntrySchema, type RegistryEntry } from './types.js';
+
+import type { Request, Response } from 'express';
+
+import type { PillarRegistration } from '@pops/core-db';
+
+function toRegistryEntry(reg: PillarRegistration, now: Date): RegistryEntry {
+  const manifest = RegistryEntrySchema.shape.manifest.parse(reg.manifest);
+  const status =
+    reg.status === 'unknown' ? 'unknown' : computeStatus(new Date(reg.lastHeartbeatAt), now);
+  return {
+    pillarId: reg.pillarId,
+    baseUrl: reg.baseUrl,
+    manifest,
+    contract: {
+      package: reg.contractPackage,
+      version: reg.contractVersion,
+      tag: reg.contractTag,
+    },
+    registeredAt: reg.registeredAt,
+    lastHeartbeatAt: reg.lastHeartbeatAt,
+    status,
+    statusUpdatedAt: reg.statusUpdatedAt,
+  };
+}
+
+function writeFrame(res: Response, eventName: string, data: unknown): boolean {
+  if (res.writableEnded || res.closed) return false;
+  try {
+    res.write(`event: ${eventName}\n`);
+    res.write(`data: ${JSON.stringify(data)}\n\n`);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function createRegistrySubscribeHandler(
+  coreDb: CoreDb
+): (req: Request, res: Response) => void {
+  return (req: Request, res: Response): void => {
+    res.statusCode = 200;
+    res.setHeader('Content-Type', 'text/event-stream');
+    res.setHeader('Cache-Control', 'no-cache, no-transform');
+    res.setHeader('Connection', 'keep-alive');
+    res.setHeader('X-Accel-Buffering', 'no');
+    res.flushHeaders?.();
+
+    const now = registryNow();
+    const snapshot = pillarRegistryService
+      .listPillarRegistrations(coreDb)
+      .map((row) => toRegistryEntry(row, now));
+    writeFrame(res, 'pillar.snapshot', snapshot);
+
+    const unsubscribe = subscribeToRegistryEvents((payload: RegistryEventPayload) => {
+      writeFrame(res, `pillar.${payload.event}`, payload);
+    });
+
+    let cleanedUp = false;
+    const cleanup = (): void => {
+      if (cleanedUp) return;
+      cleanedUp = true;
+      unsubscribe();
+    };
+
+    req.once('close', cleanup);
+    res.once('close', cleanup);
+  };
+}


### PR DESCRIPTION
## Summary

- Ships `GET /registry/subscribe` on `pops-core-api` as plain Express SSE (not a tRPC subscription — tRPC subscriptions need WebSocket, this is read-only HTTP). First frame is `pillar.snapshot` with the current `RegistryEntry[]`; subsequent frames are `pillar.registered` / `pillar.deregistered` / `pillar.health-changed` as the registry mutates.
- Adds an in-process `EventEmitter` bus (`modules/registry/event-bus.ts`); the registry router's `register`, `deregister`, and `heartbeat` procedures emit through it. Per-client cleanup is wired to `req.on('close')` + `res.on('close')` so a flaky client cannot leak listeners.
- Endpoint is intentionally public read; mutating procedures stay nginx-gated. Auth on the SSE channel, 30s keep-alive comments, and per-client backpressure are explicit follow-ups (PRD-164 owns the client side).

## Test plan

- [x] `pnpm --filter @pops/core-api test` (58 tests, 4 new in `subscribe.test.ts`):
  - snapshot-on-connect carries existing registrations
  - mid-stream `register` fans out as `pillar.registered`
  - per-client listener removed on disconnect (count returns to baseline)
  - one client killed mid-stream leaves the other client's listener intact, both clean up on close
- [x] `mise typecheck` clean
- [x] `mise lint` clean (no new warnings)

Spec: `docs/themes/13-pillar-finale/prds/163-subscription-model/README.md`.
