### PR TITLE
feat(registry): reconciliation on restart + client reconnect (Theme 13 PRD-164)

### DIFF
--- a/apps/pops-core-api/src/__tests__/boot-reconciliation.test.ts
+++ b/apps/pops-core-api/src/__tests__/boot-reconciliation.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Boot-time registry reconciliation tests (Theme 13 PRD-164).
+ *
+ * Simulates the core-api restart scenario:
+ *   - Persisted rows survive across boots.
+ *   - `lastHeartbeatAt` reflects the pre-restart wall clock.
+ *   - On boot, rows stale beyond `UNAVAILABLE_AFTER_MS` flip to
+ *     `unknown`; fresher rows are left alone.
+ *
+ * Uses an in-memory core.db plus an explicit `now` so the test does not
+ * touch the singleton clock and can run in parallel with PRD-162 tests.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { openCoreDb, pillarRegistryService, type OpenedCoreDb } from '@pops/core-db';
+
+import { reconcileRegistryOnBoot } from '../modules/registry/boot.js';
+import { UNAVAILABLE_AFTER_MS } from '../modules/registry/status.js';
+
+interface SeedRow {
+  pillarId: string;
+  baseUrl: string;
+  ageMs: number;
+  status: 'healthy' | 'unavailable' | 'unknown';
+}
+
+let tmpDir: string;
+let coreDb: OpenedCoreDb;
+const bootNow = new Date('2026-06-12T12:00:00.000Z');
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'core-api-boot-test-'));
+  coreDb = openCoreDb(join(tmpDir, 'core.db'));
+});
+
+afterEach(() => {
+  coreDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function seedRegistration(row: SeedRow): void {
+  const lastHeartbeatAt = new Date(bootNow.getTime() - row.ageMs).toISOString();
+  pillarRegistryService.upsertPillarRegistration(coreDb.db, {
+    baseUrl: row.baseUrl,
+    manifest: {
+      pillar: row.pillarId,
+      contract: {
+        package: `@pops/${row.pillarId}-contract`,
+        version: '1.0.0',
+        tag: `contract-${row.pillarId}@v1.0.0`,
+      },
+    },
+    now: lastHeartbeatAt,
+  });
+  if (row.status !== 'healthy') {
+    pillarRegistryService.applyStatusUpdates(coreDb.db, [
+      {
+        pillarId: row.pillarId,
+        status: row.status,
+        statusUpdatedAt: lastHeartbeatAt,
+      },
+    ]);
+  }
+}
+
+describe('reconcileRegistryOnBoot (PRD-164)', () => {
+  it('marks pillars whose lastHeartbeatAt exceeds the threshold as unknown', () => {
+    seedRegistration({
+      pillarId: 'finance',
+      baseUrl: 'http://finance-api:3004',
+      ageMs: UNAVAILABLE_AFTER_MS + 60_000,
+      status: 'healthy',
+    });
+    seedRegistration({
+      pillarId: 'media',
+      baseUrl: 'http://media-api:3006',
+      ageMs: 5_000,
+      status: 'healthy',
+    });
+    seedRegistration({
+      pillarId: 'recipes',
+      baseUrl: 'http://recipes-api:3007',
+      ageMs: UNAVAILABLE_AFTER_MS * 3,
+      status: 'unavailable',
+    });
+
+    const transitions = reconcileRegistryOnBoot(coreDb.db, {
+      now: bootNow,
+      logger: () => {},
+    });
+
+    expect(transitions.map((t) => t.pillarId).toSorted()).toEqual(['finance', 'recipes']);
+    for (const t of transitions) {
+      expect(t.nextStatus).toBe('unknown');
+      expect(t.at).toBe(bootNow.toISOString());
+    }
+
+    const finance = pillarRegistryService.getPillarRegistration(coreDb.db, 'finance');
+    const media = pillarRegistryService.getPillarRegistration(coreDb.db, 'media');
+    const recipes = pillarRegistryService.getPillarRegistration(coreDb.db, 'recipes');
+
+    expect(finance?.status).toBe('unknown');
+    expect(finance?.statusUpdatedAt).toBe(bootNow.toISOString());
+    expect(media?.status).toBe('healthy');
+    expect(recipes?.status).toBe('unknown');
+  });
+
+  it('is idempotent: re-running on already-unknown rows is a no-op', () => {
+    seedRegistration({
+      pillarId: 'finance',
+      baseUrl: 'http://finance-api:3004',
+      ageMs: UNAVAILABLE_AFTER_MS * 2,
+      status: 'healthy',
+    });
+
+    const first = reconcileRegistryOnBoot(coreDb.db, { now: bootNow, logger: () => {} });
+    expect(first).toHaveLength(1);
+
+    const second = reconcileRegistryOnBoot(coreDb.db, { now: bootNow, logger: () => {} });
+    expect(second).toHaveLength(0);
+  });
+
+  it('leaves boundary rows (exactly the threshold) untouched — only strictly stale rows flip', () => {
+    seedRegistration({
+      pillarId: 'finance',
+      baseUrl: 'http://finance-api:3004',
+      ageMs: UNAVAILABLE_AFTER_MS,
+      status: 'healthy',
+    });
+
+    const transitions = reconcileRegistryOnBoot(coreDb.db, { now: bootNow, logger: () => {} });
+
+    expect(transitions).toEqual([]);
+    const persisted = pillarRegistryService.getPillarRegistration(coreDb.db, 'finance');
+    expect(persisted?.status).toBe('healthy');
+  });
+
+  it('preserves lastHeartbeatAt — only status + statusUpdatedAt change', () => {
+    seedRegistration({
+      pillarId: 'finance',
+      baseUrl: 'http://finance-api:3004',
+      ageMs: UNAVAILABLE_AFTER_MS * 10,
+      status: 'healthy',
+    });
+    const beforeHeartbeat = pillarRegistryService.getPillarRegistration(
+      coreDb.db,
+      'finance'
+    )?.lastHeartbeatAt;
+
+    reconcileRegistryOnBoot(coreDb.db, { now: bootNow, logger: () => {} });
+
+    const after = pillarRegistryService.getPillarRegistration(coreDb.db, 'finance');
+    expect(after?.lastHeartbeatAt).toBe(beforeHeartbeat);
+    expect(after?.status).toBe('unknown');
+  });
+
+  it('respects custom staleThresholdMs', () => {
+    seedRegistration({
+      pillarId: 'finance',
+      baseUrl: 'http://finance-api:3004',
+      ageMs: 15_000,
+      status: 'healthy',
+    });
+
+    const noTransitions = reconcileRegistryOnBoot(coreDb.db, {
+      now: bootNow,
+      staleThresholdMs: 60_000,
+      logger: () => {},
+    });
+    expect(noTransitions).toEqual([]);
+
+    const transitions = reconcileRegistryOnBoot(coreDb.db, {
+      now: bootNow,
+      staleThresholdMs: 10_000,
+      logger: () => {},
+    });
+    expect(transitions).toHaveLength(1);
+    expect(transitions[0]?.pillarId).toBe('finance');
+  });
+
+  it('forwards each transition through the onTransition callback', () => {
+    seedRegistration({
+      pillarId: 'finance',
+      baseUrl: 'http://finance-api:3004',
+      ageMs: UNAVAILABLE_AFTER_MS * 2,
+      status: 'healthy',
+    });
+
+    const seen: string[] = [];
+    reconcileRegistryOnBoot(coreDb.db, {
+      now: bootNow,
+      onTransition: (t) => seen.push(`${t.pillarId}:${t.previousStatus}->${t.nextStatus}`),
+      logger: () => {},
+    });
+
+    expect(seen).toEqual(['finance:healthy->unknown']);
+  });
+
+  it('handles an empty registry without throwing', () => {
+    const transitions = reconcileRegistryOnBoot(coreDb.db, { now: bootNow, logger: () => {} });
+    expect(transitions).toEqual([]);
+  });
+});

--- a/apps/pops-core-api/src/modules/registry/boot.ts
+++ b/apps/pops-core-api/src/modules/registry/boot.ts
@@ -1,0 +1,103 @@
+/**
+ * Boot-time registry reconciliation (Theme 13 PRD-164).
+ *
+ * When `pops-core-api` restarts, the persisted `pillar_registry` rows
+ * survive but their `lastHeartbeatAt` is stale relative to the new boot
+ * clock. The persisted `status` cache is equally stale — a row last
+ * written as `healthy` may correspond to a pillar that died during the
+ * outage.
+ *
+ * This module reconciles that gap before the HTTP server starts
+ * accepting traffic. For every existing row:
+ *
+ *   - If `now - lastHeartbeatAt > UNAVAILABLE_AFTER_MS`, the pillar
+ *     missed at least the standard threshold of heartbeats during the
+ *     outage. We set `status = 'unknown'` (NOT `unavailable` — we don't
+ *     *know* it's down, we just observed a missed heartbeat). The
+ *     PRD-162 heartbeat ticker takes over from here: a heartbeat from
+ *     the pillar will flip it back to `healthy`; continued silence
+ *     will eventually compute `unavailable` via the lazy-status path.
+ *
+ *   - If `now - lastHeartbeatAt <= UNAVAILABLE_AFTER_MS`, the row is
+ *     within the live threshold and is left as-is. The pillar's next
+ *     heartbeat (due within ~10s) refreshes the row normally.
+ *
+ * The function is idempotent: re-running it on the same data produces
+ * the same result. Tests simulate restart by calling it explicitly.
+ *
+ * Single-instance assumption per ADR-027. Multi-region / multi-instance
+ * reconciliation is a follow-up (see PRD-164 "Out of Scope").
+ */
+import {
+  pillarRegistryService,
+  type ApplyStatusUpdate,
+  type CoreDb,
+  type PillarRegistration,
+  type StatusTransition,
+} from '@pops/core-db';
+
+import { UNAVAILABLE_AFTER_MS, registryNow } from './status.js';
+
+export interface ReconcileOnBootOptions {
+  readonly now?: Date;
+  readonly staleThresholdMs?: number;
+  readonly onTransition?: (transition: StatusTransition) => void;
+  readonly logger?: (message: string) => void;
+}
+
+/**
+ * Run a single boot-time reconciliation pass.
+ *
+ * Returns the transitions that were persisted so the caller (and tests)
+ * can assert on the result without subscribing via `onTransition`.
+ */
+export function reconcileRegistryOnBoot(
+  db: CoreDb,
+  options?: ReconcileOnBootOptions
+): readonly StatusTransition[] {
+  const now = options?.now ?? registryNow();
+  const nowIso = now.toISOString();
+  const threshold = options?.staleThresholdMs ?? UNAVAILABLE_AFTER_MS;
+  const log = options?.logger ?? ((message: string): void => console.warn(message));
+
+  const rows = pillarRegistryService.listPillarRegistrations(db);
+  const { updates, transitions } = planBootTransitions(rows, now, nowIso, threshold);
+
+  pillarRegistryService.applyStatusUpdates(db, updates);
+
+  log(
+    `[core-api] boot reconciliation: ${rows.length} pillar(s) inspected, ` +
+      `${transitions.length} marked unknown (stale heartbeat > ${threshold}ms)`
+  );
+
+  if (options?.onTransition) {
+    for (const transition of transitions) {
+      options.onTransition(transition);
+    }
+  }
+
+  return transitions;
+}
+
+function planBootTransitions(
+  rows: readonly PillarRegistration[],
+  now: Date,
+  nowIso: string,
+  thresholdMs: number
+): { updates: ApplyStatusUpdate[]; transitions: StatusTransition[] } {
+  const updates: ApplyStatusUpdate[] = [];
+  const transitions: StatusTransition[] = [];
+  for (const row of rows) {
+    const ageMs = now.getTime() - Date.parse(row.lastHeartbeatAt);
+    if (ageMs <= thresholdMs) continue;
+    if (row.status === 'unknown') continue;
+    updates.push({ pillarId: row.pillarId, status: 'unknown', statusUpdatedAt: nowIso });
+    transitions.push({
+      pillarId: row.pillarId,
+      previousStatus: row.status,
+      nextStatus: 'unknown',
+      at: nowIso,
+    });
+  }
+  return { updates, transitions };
+}

--- a/apps/pops-core-api/src/server.ts
+++ b/apps/pops-core-api/src/server.ts
@@ -14,6 +14,7 @@ import { openCoreDb } from '@pops/core-db';
 
 import { createCoreApiApp } from './app.js';
 import { resolveCoreSqlitePath } from './core-sqlite-path.js';
+import { reconcileRegistryOnBoot } from './modules/registry/boot.js';
 import { startHeartbeatTicker } from './modules/registry/ticker.js';
 import { parseBareOrigin } from './pillars/env.js';
 
@@ -39,6 +40,9 @@ const selfBaseUrl = parseBareOrigin(
 );
 
 const coreDb = openCoreDb(resolveCoreSqlitePath());
+
+reconcileRegistryOnBoot(coreDb.db);
+
 const app = createCoreApiApp({ coreDb, version, selfBaseUrl });
 
 const server = app.listen(port, () => {

--- a/packages/pillar-sdk/src/discovery/__tests__/reconnect.test.ts
+++ b/packages/pillar-sdk/src/discovery/__tests__/reconnect.test.ts
@@ -1,0 +1,306 @@
+/**
+ * SSE reconnection helper tests (Theme 13 PRD-164).
+ *
+ * Drives `startReconnectingSubscription` with a fake clock + fake
+ * subscription handle so the schedule can be asserted deterministically:
+ *
+ *   - Each close triggers exactly one snapshot refetch.
+ *   - Reconnect attempts follow exponential backoff capped at 30s.
+ *   - A successful reconnect resets the attempt counter.
+ *   - `stop()` halts everything: no further reconnects, the handle is
+ *     closed if active.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  RECONNECT_INITIAL_DELAY_MS,
+  RECONNECT_MAX_DELAY_MS,
+  computeBackoffDelay,
+  startReconnectingSubscription,
+  type SubscriptionHandle,
+} from '../reconnect.js';
+
+interface FakeHandle extends SubscriptionHandle {
+  triggerClose: () => void;
+  closeCount: number;
+}
+
+function createFakeHandle(): FakeHandle {
+  let closeListener: ((reason?: unknown) => void) | null = null;
+  let closed = false;
+  const handle = {
+    closeCount: 0,
+    close: (): void => {
+      if (closed) return;
+      closed = true;
+      handle.closeCount += 1;
+      closeListener?.();
+    },
+    onClose: (listener: (reason?: unknown) => void): (() => void) => {
+      closeListener = listener;
+      return () => {
+        closeListener = null;
+      };
+    },
+    triggerClose: (): void => {
+      if (closed) return;
+      closed = true;
+      closeListener?.();
+    },
+  };
+  return handle;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('computeBackoffDelay', () => {
+  it('returns the initial delay for attempt 1', () => {
+    expect(computeBackoffDelay(1)).toBe(RECONNECT_INITIAL_DELAY_MS);
+  });
+
+  it('doubles by default for each subsequent attempt', () => {
+    expect(computeBackoffDelay(2)).toBe(RECONNECT_INITIAL_DELAY_MS * 2);
+    expect(computeBackoffDelay(3)).toBe(RECONNECT_INITIAL_DELAY_MS * 4);
+    expect(computeBackoffDelay(4)).toBe(RECONNECT_INITIAL_DELAY_MS * 8);
+  });
+
+  it('caps at RECONNECT_MAX_DELAY_MS (30s)', () => {
+    expect(computeBackoffDelay(20)).toBe(RECONNECT_MAX_DELAY_MS);
+    expect(computeBackoffDelay(50)).toBe(RECONNECT_MAX_DELAY_MS);
+  });
+
+  it('respects custom initial / max / factor', () => {
+    expect(
+      computeBackoffDelay(3, { initialDelayMs: 100, backoffFactor: 3, maxDelayMs: 100_000 })
+    ).toBe(900);
+    expect(
+      computeBackoffDelay(10, { initialDelayMs: 100, backoffFactor: 3, maxDelayMs: 5_000 })
+    ).toBe(5_000);
+  });
+});
+
+describe('startReconnectingSubscription', () => {
+  it('opens an initial connection without delay', async () => {
+    const handles: FakeHandle[] = [];
+    const connect = vi.fn(async () => {
+      const handle = createFakeHandle();
+      handles.push(handle);
+      return handle;
+    });
+    const fetchSnapshot = vi.fn();
+
+    const sub = startReconnectingSubscription({ connect, fetchSnapshot });
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(connect).toHaveBeenCalledTimes(1);
+    expect(fetchSnapshot).not.toHaveBeenCalled();
+    sub.stop();
+  });
+
+  it('refetches the snapshot once and reconnects after the underlying handle closes', async () => {
+    const handles: FakeHandle[] = [];
+    const connect = vi.fn(async () => {
+      const handle = createFakeHandle();
+      handles.push(handle);
+      return handle;
+    });
+    const fetchSnapshot = vi.fn().mockResolvedValue(undefined);
+
+    const sub = startReconnectingSubscription({ connect, fetchSnapshot });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(handles).toHaveLength(1);
+
+    handles[0]!.triggerClose();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(fetchSnapshot).toHaveBeenCalledTimes(1);
+    expect(connect).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(RECONNECT_INITIAL_DELAY_MS);
+    expect(connect).toHaveBeenCalledTimes(2);
+    sub.stop();
+  });
+
+  it('follows exponential backoff across consecutive failures', async () => {
+    let connectAttempts = 0;
+    const handles: FakeHandle[] = [];
+    const connect = vi.fn(async () => {
+      connectAttempts += 1;
+      if (connectAttempts <= 4) throw new Error(`connect fail ${connectAttempts}`);
+      const handle = createFakeHandle();
+      handles.push(handle);
+      return handle;
+    });
+    const fetchSnapshot = vi.fn().mockResolvedValue(undefined);
+    const onReconnectScheduled = vi.fn();
+    const onReconnectError = vi.fn();
+
+    const sub = startReconnectingSubscription({
+      connect,
+      fetchSnapshot,
+      onReconnectScheduled,
+      onReconnectError,
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(connect).toHaveBeenCalledTimes(1);
+    expect(onReconnectError).toHaveBeenCalledTimes(1);
+    expect(onReconnectScheduled).toHaveBeenLastCalledWith(1, RECONNECT_INITIAL_DELAY_MS);
+
+    await vi.advanceTimersByTimeAsync(RECONNECT_INITIAL_DELAY_MS);
+    expect(connect).toHaveBeenCalledTimes(2);
+    expect(onReconnectScheduled).toHaveBeenLastCalledWith(2, RECONNECT_INITIAL_DELAY_MS * 2);
+
+    await vi.advanceTimersByTimeAsync(RECONNECT_INITIAL_DELAY_MS * 2);
+    expect(connect).toHaveBeenCalledTimes(3);
+    expect(onReconnectScheduled).toHaveBeenLastCalledWith(3, RECONNECT_INITIAL_DELAY_MS * 4);
+
+    await vi.advanceTimersByTimeAsync(RECONNECT_INITIAL_DELAY_MS * 4);
+    expect(connect).toHaveBeenCalledTimes(4);
+    expect(onReconnectScheduled).toHaveBeenLastCalledWith(4, RECONNECT_INITIAL_DELAY_MS * 8);
+
+    await vi.advanceTimersByTimeAsync(RECONNECT_INITIAL_DELAY_MS * 8);
+    expect(connect).toHaveBeenCalledTimes(5);
+    expect(handles).toHaveLength(1);
+
+    sub.stop();
+  });
+
+  it('caps backoff at the configured maximum', async () => {
+    const scheduledDelays: number[] = [];
+    const connect = vi.fn(async () => {
+      throw new Error('always fail');
+    });
+    const sub = startReconnectingSubscription({
+      connect,
+      fetchSnapshot: vi.fn(),
+      initialDelayMs: 1_000,
+      maxDelayMs: 4_000,
+      backoffFactor: 2,
+      onReconnectScheduled: (_attempt, delay) => scheduledDelays.push(delay),
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    for (let i = 0; i < 8; i += 1) {
+      const delay = scheduledDelays[scheduledDelays.length - 1] ?? 1_000;
+      await vi.advanceTimersByTimeAsync(delay);
+    }
+
+    expect(scheduledDelays.slice(0, 4)).toEqual([1_000, 2_000, 4_000, 4_000]);
+    expect(scheduledDelays.every((d) => d <= 4_000)).toBe(true);
+    sub.stop();
+  });
+
+  it('resets the attempt counter after a successful reconnect', async () => {
+    let phase = 0;
+    const handles: FakeHandle[] = [];
+    const connect = vi.fn(async () => {
+      phase += 1;
+      if (phase === 2) throw new Error('transient');
+      const handle = createFakeHandle();
+      handles.push(handle);
+      return handle;
+    });
+    const onReconnectScheduled = vi.fn();
+    const sub = startReconnectingSubscription({
+      connect,
+      fetchSnapshot: vi.fn().mockResolvedValue(undefined),
+      onReconnectScheduled,
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(sub.currentAttempt()).toBe(0);
+
+    handles[0]!.triggerClose();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(onReconnectScheduled).toHaveBeenLastCalledWith(1, RECONNECT_INITIAL_DELAY_MS);
+
+    await vi.advanceTimersByTimeAsync(RECONNECT_INITIAL_DELAY_MS);
+    expect(onReconnectScheduled).toHaveBeenLastCalledWith(2, RECONNECT_INITIAL_DELAY_MS * 2);
+
+    await vi.advanceTimersByTimeAsync(RECONNECT_INITIAL_DELAY_MS * 2);
+    expect(sub.currentAttempt()).toBe(0);
+
+    handles[1]!.triggerClose();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(onReconnectScheduled).toHaveBeenLastCalledWith(1, RECONNECT_INITIAL_DELAY_MS);
+
+    sub.stop();
+  });
+
+  it('stop() halts the schedule and closes the active handle', async () => {
+    const handles: FakeHandle[] = [];
+    const connect = vi.fn(async () => {
+      const handle = createFakeHandle();
+      handles.push(handle);
+      return handle;
+    });
+
+    const sub = startReconnectingSubscription({ connect, fetchSnapshot: vi.fn() });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(handles).toHaveLength(1);
+
+    sub.stop();
+
+    handles[0]!.triggerClose();
+    await vi.advanceTimersByTimeAsync(RECONNECT_MAX_DELAY_MS * 2);
+
+    expect(connect).toHaveBeenCalledTimes(1);
+    expect(handles[0]!.closeCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it('stop() during a pending reconnect prevents the next connect', async () => {
+    const handles: FakeHandle[] = [];
+    let shouldFail = true;
+    const connect = vi.fn(async () => {
+      if (shouldFail) throw new Error('fail');
+      const handle = createFakeHandle();
+      handles.push(handle);
+      return handle;
+    });
+
+    const sub = startReconnectingSubscription({ connect, fetchSnapshot: vi.fn() });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(connect).toHaveBeenCalledTimes(1);
+
+    sub.stop();
+    shouldFail = false;
+    await vi.advanceTimersByTimeAsync(RECONNECT_MAX_DELAY_MS);
+    expect(connect).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports snapshot refetch errors via onReconnectError', async () => {
+    const handles: FakeHandle[] = [];
+    const connect = vi.fn(async () => {
+      const handle = createFakeHandle();
+      handles.push(handle);
+      return handle;
+    });
+    const fetchSnapshot = vi.fn().mockRejectedValue(new Error('snapshot 503'));
+    const onReconnectError = vi.fn();
+
+    const sub = startReconnectingSubscription({
+      connect,
+      fetchSnapshot,
+      onReconnectError,
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    handles[0]!.triggerClose();
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(fetchSnapshot).toHaveBeenCalledTimes(1);
+    expect(onReconnectError).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(RECONNECT_INITIAL_DELAY_MS);
+    expect(connect).toHaveBeenCalledTimes(2);
+    sub.stop();
+  });
+});

--- a/packages/pillar-sdk/src/discovery/index.ts
+++ b/packages/pillar-sdk/src/discovery/index.ts
@@ -9,3 +9,13 @@ export {
   MIN_CACHE_TTL_MS,
 } from './cache.js';
 export { RegistryUnreachableError, type PillarSnapshot, type RegistrySnapshot } from './types.js';
+export {
+  computeBackoffDelay,
+  startReconnectingSubscription,
+  RECONNECT_INITIAL_DELAY_MS,
+  RECONNECT_MAX_DELAY_MS,
+  RECONNECT_BACKOFF_FACTOR,
+  type ReconnectingSubscription,
+  type ReconnectingSubscriptionOptions,
+  type SubscriptionHandle,
+} from './reconnect.js';

--- a/packages/pillar-sdk/src/discovery/reconnect.ts
+++ b/packages/pillar-sdk/src/discovery/reconnect.ts
@@ -1,0 +1,167 @@
+/**
+ * SSE reconnection helper for the registry subscription transport
+ * (Theme 13 PRD-164).
+ *
+ * When `pops-core-api` restarts (or any transient network drop), the
+ * SSE stream from `GET /registry/subscribe` closes. PRD-163 stops at
+ * the server; the client side reconnection is PRD-164's job.
+ *
+ * Behaviour shipped here — deliberately minimal, not a state machine:
+ *   1. Open the SSE stream via the caller-supplied `connect` function.
+ *   2. On close, refetch the snapshot once (so the consumer's local
+ *      cache is correct even if events were missed during the gap).
+ *   3. Reconnect with exponential backoff capped at 30s.
+ *
+ * The helper does not own the SSE protocol — the caller hands in
+ * `connect` and `fetchSnapshot` so unit tests can drive both without
+ * a real network. The helper owns the schedule.
+ *
+ * Single-instance assumption per ADR-027. Multi-region clients are a
+ * follow-up — they would need a different transport (likely WebSocket
+ * with sticky routing) and live outside this helper.
+ */
+
+export const RECONNECT_INITIAL_DELAY_MS = 500;
+export const RECONNECT_MAX_DELAY_MS = 30_000;
+export const RECONNECT_BACKOFF_FACTOR = 2;
+
+export interface SubscriptionHandle {
+  readonly close: () => void;
+  readonly onClose: (listener: (reason?: unknown) => void) => () => void;
+}
+
+export type ReconnectTimerHandle = ReturnType<typeof setTimeout>;
+
+export interface ReconnectingSubscriptionOptions {
+  readonly connect: () => Promise<SubscriptionHandle> | SubscriptionHandle;
+  readonly fetchSnapshot: () => Promise<void> | void;
+  readonly initialDelayMs?: number;
+  readonly maxDelayMs?: number;
+  readonly backoffFactor?: number;
+  readonly setTimeoutImpl?: (handler: () => void, ms: number) => ReconnectTimerHandle;
+  readonly clearTimeoutImpl?: (handle: ReconnectTimerHandle) => void;
+  readonly onReconnectScheduled?: (attempt: number, delayMs: number) => void;
+  readonly onReconnectError?: (error: unknown) => void;
+}
+
+export interface ReconnectingSubscription {
+  readonly stop: () => void;
+  readonly currentAttempt: () => number;
+}
+
+/**
+ * Compute the exponential-backoff delay for a given attempt index
+ * (1-based). Capped at `maxDelayMs`.
+ *
+ *   attempt 1 → initialDelayMs
+ *   attempt 2 → initialDelayMs * factor
+ *   ...
+ *   attempt N → min(initialDelayMs * factor^(N-1), maxDelayMs)
+ */
+export function computeBackoffDelay(
+  attempt: number,
+  options?: {
+    initialDelayMs?: number;
+    maxDelayMs?: number;
+    backoffFactor?: number;
+  }
+): number {
+  const initial = options?.initialDelayMs ?? RECONNECT_INITIAL_DELAY_MS;
+  const max = options?.maxDelayMs ?? RECONNECT_MAX_DELAY_MS;
+  const factor = options?.backoffFactor ?? RECONNECT_BACKOFF_FACTOR;
+  if (attempt <= 1) return Math.min(initial, max);
+  const raw = initial * Math.pow(factor, attempt - 1);
+  return Math.min(raw, max);
+}
+
+/**
+ * Open a self-healing subscription. When the underlying handle closes,
+ * the helper refetches the snapshot once and re-invokes `connect` on a
+ * capped exponential backoff schedule. `stop()` halts the loop and
+ * closes the active handle, if any.
+ */
+class ReconnectingSubscriptionImpl {
+  private stopped = false;
+  private attempt = 0;
+  private activeHandle: SubscriptionHandle | null = null;
+  private pendingTimer: ReconnectTimerHandle | null = null;
+  private readonly setTimeoutFn: (handler: () => void, ms: number) => ReconnectTimerHandle;
+  private readonly clearTimeoutFn: (handle: ReconnectTimerHandle) => void;
+
+  constructor(private readonly options: ReconnectingSubscriptionOptions) {
+    this.setTimeoutFn =
+      options.setTimeoutImpl ?? ((handler, ms) => setTimeout(handler, ms) as ReconnectTimerHandle);
+    this.clearTimeoutFn = options.clearTimeoutImpl ?? ((handle) => clearTimeout(handle));
+  }
+
+  start(): void {
+    void this.runConnectCycle();
+  }
+
+  stop(): void {
+    if (this.stopped) return;
+    this.stopped = true;
+    if (this.pendingTimer !== null) {
+      this.clearTimeoutFn(this.pendingTimer);
+      this.pendingTimer = null;
+    }
+    this.activeHandle?.close();
+    this.activeHandle = null;
+  }
+
+  currentAttempt(): number {
+    return this.attempt;
+  }
+
+  private scheduleReconnect(): void {
+    if (this.stopped) return;
+    this.attempt += 1;
+    const delayMs = computeBackoffDelay(this.attempt, {
+      initialDelayMs: this.options.initialDelayMs,
+      maxDelayMs: this.options.maxDelayMs,
+      backoffFactor: this.options.backoffFactor,
+    });
+    this.options.onReconnectScheduled?.(this.attempt, delayMs);
+    this.pendingTimer = this.setTimeoutFn(() => {
+      this.pendingTimer = null;
+      void this.runConnectCycle();
+    }, delayMs);
+  }
+
+  private handleClose(): void {
+    this.activeHandle = null;
+    if (this.stopped) return;
+    Promise.resolve()
+      .then(() => this.options.fetchSnapshot())
+      .catch((error: unknown) => this.options.onReconnectError?.(error))
+      .finally(() => this.scheduleReconnect());
+  }
+
+  private async runConnectCycle(): Promise<void> {
+    if (this.stopped) return;
+    try {
+      const handle = await this.options.connect();
+      if (this.stopped) {
+        handle.close();
+        return;
+      }
+      this.activeHandle = handle;
+      this.attempt = 0;
+      handle.onClose(() => this.handleClose());
+    } catch (error) {
+      this.options.onReconnectError?.(error);
+      this.scheduleReconnect();
+    }
+  }
+}
+
+export function startReconnectingSubscription(
+  options: ReconnectingSubscriptionOptions
+): ReconnectingSubscription {
+  const sub = new ReconnectingSubscriptionImpl(options);
+  sub.start();
+  return {
+    stop: (): void => sub.stop(),
+    currentAttempt: (): number => sub.currentAttempt(),
+  };
+}


### PR DESCRIPTION
## Summary

Implements [PRD-164 reconciliation on restart](docs/themes/13-pillar-finale/prds/164-reconciliation-on-restart/README.md).

When core-api restarts, the registry SQLite table has stale `lastHeartbeatAt` values from before the outage. This PR adds boot-time reconciliation that flips stale entries to `unknown` so the PRD-162 ticker can take over; and adds a client-side reconnect helper that reopens the SSE stream with exponential backoff.

## What's included

- `apps/pops-core-api/src/modules/registry/boot.ts` — on boot, scan registrations and reset stale `lastHeartbeatAt` → `status: 'unknown'`. PRD-162 ticker handles the transition to `unavailable` from there.
- `apps/pops-core-api/src/server.ts` — calls the boot reconciliation before mounting the registry router.
- `packages/pillar-sdk/src/discovery/reconnect.ts` — SSE reconnect helper with exponential backoff capped at 30s. On reconnect, refetches the snapshot once to reconcile state.
- 2 test files, ~500 LoC of tests (boot reconciliation + reconnect backoff).

## Out of scope

- Pillar-side acknowledgement of registry restart — pillars don't observe the registry's lifecycle.
- Multi-instance reconciliation (single-instance assumption per ADR-027).
- Multi-region forward compatibility — follow-up.

## Test plan

- [x] Boot reconciliation tests with three pillars at varying staleness.
- [x] Client reconnect backoff schedule asserted.
- [ ] CI green on this PR.