### PR TITLE
feat(pillar-sdk): React hooks for pillar() (Theme 13 PRD-193)

### DIFF
--- a/packages/pillar-sdk/package.json
+++ b/packages/pillar-sdk/package.json
@@ -38,6 +38,10 @@
       "types": "./dist/capabilities/index.d.ts",
       "default": "./dist/capabilities/index.js"
     },
+    "./react": {
+      "types": "./dist/react/index.d.ts",
+      "default": "./dist/react/index.js"
+    },
     "./package.json": "./package.json"
   },
   "scripts": {
@@ -51,9 +55,28 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@tanstack/react-query": "5.101.0",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "^25.9.3",
+    "@types/react": "^19.2.17",
     "@vitest/coverage-v8": "^4.1.8",
+    "jsdom": "^29.1.1",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
     "typescript": "^6.0.3",
     "vitest": "^4.1.8"
+  },
+  "peerDependencies": {
+    "@tanstack/react-query": "^5.101.0",
+    "react": "^19.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@tanstack/react-query": {
+      "optional": true
+    },
+    "react": {
+      "optional": true
+    }
   }
 }

--- a/packages/pillar-sdk/src/react/__tests__/hooks.test.tsx
+++ b/packages/pillar-sdk/src/react/__tests__/hooks.test.tsx
@@ -1,0 +1,216 @@
+// @vitest-environment jsdom
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  discoveredPillar,
+  fakeFetch,
+  FakeRegistryTransport,
+  jsonResponse,
+} from '../../client/__tests__/fixtures.js';
+import { __resetSharedPillarClient } from '../../client/factory.js';
+import { usePillarMutation, usePillarQuery } from '../hooks.js';
+import { PillarSdkProvider } from '../provider.js';
+
+import type { ReactNode } from 'react';
+
+import type { PillarClientOptions } from '../../client/factory.js';
+
+type FetchScript = (url: string, body: unknown) => Response | Promise<Response>;
+
+type Harness = {
+  wrapper: (props: { children: ReactNode }) => ReactNode;
+  queryClient: QueryClient;
+  calls: { url: string; body: unknown }[];
+};
+
+function buildHarness(transport: FakeRegistryTransport, script: FetchScript): Harness {
+  const calls: { url: string; body: unknown }[] = [];
+  const fetchImpl = fakeFetch(async (url, init) => {
+    let parsed: unknown = null;
+    if (init?.body && typeof init.body === 'string') {
+      try {
+        parsed = JSON.parse(init.body);
+      } catch {
+        parsed = init.body;
+      }
+    }
+    calls.push({ url, body: parsed });
+    return script(url, parsed);
+  });
+  const options: PillarClientOptions = { transport, fetchImpl };
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  const wrapper = ({ children }: { children: ReactNode }): ReactNode => (
+    <QueryClientProvider client={queryClient}>
+      <PillarSdkProvider options={options}>{children}</PillarSdkProvider>
+    </QueryClientProvider>
+  );
+  return { wrapper, queryClient, calls };
+}
+
+describe('usePillarQuery', () => {
+  beforeEach(() => __resetSharedPillarClient());
+  afterEach(() => __resetSharedPillarClient());
+
+  it('returns data from a successful pillar call (happy path)', async () => {
+    const transport = new FakeRegistryTransport({ pillars: [discoveredPillar()] });
+    const harness = buildHarness(transport, () =>
+      jsonResponse({ result: { data: [{ id: 'wish-1' }] } })
+    );
+    const { result } = renderHook(
+      () =>
+        usePillarQuery<readonly { id: string }[]>('finance', ['wishlist', 'list'], { limit: 10 }),
+      { wrapper: harness.wrapper }
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([{ id: 'wish-1' }]);
+    expect(result.current.isContractMismatch).toBe(false);
+    expect(result.current.isUnavailable).toBe(false);
+    expect(result.current.isDegraded).toBe(false);
+  });
+
+  it('maps `unavailable` failures onto isUnavailable', async () => {
+    const transport = new FakeRegistryTransport({ pillars: [] });
+    const harness = buildHarness(transport, () => jsonResponse({}));
+    const { result } = renderHook(() => usePillarQuery('finance', ['wishlist', 'list'], {}), {
+      wrapper: harness.wrapper,
+    });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.isUnavailable).toBe(true);
+    expect(result.current.isContractMismatch).toBe(false);
+    expect(result.current.isDegraded).toBe(false);
+  });
+
+  it('maps `contract-mismatch` failures onto isContractMismatch', async () => {
+    const transport = new FakeRegistryTransport({
+      pillars: [
+        discoveredPillar({
+          manifest: {
+            ...discoveredPillar().manifest,
+            contract: {
+              package: '@pops/finance-contract',
+              version: '2.0.0',
+              tag: 'contract-finance@v2.0.0',
+            },
+          },
+        }),
+      ],
+    });
+    const harness = buildHarness(transport, () => jsonResponse({}));
+    const wrapper = ({ children }: { children: ReactNode }): ReactNode => (
+      <QueryClientProvider client={harness.queryClient}>
+        <PillarSdkProvider
+          options={{
+            transport,
+            fetchImpl: fakeFetch(() => jsonResponse({})),
+            contractVersion: '1.4.2',
+          }}
+        >
+          {children}
+        </PillarSdkProvider>
+      </QueryClientProvider>
+    );
+    const { result } = renderHook(() => usePillarQuery('finance', ['wishlist', 'list'], {}), {
+      wrapper,
+    });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.isContractMismatch).toBe(true);
+    expect(result.current.isUnavailable).toBe(false);
+  });
+
+  it('maps `degraded` failures onto isDegraded', async () => {
+    const transport = new FakeRegistryTransport({
+      pillars: [discoveredPillar({ status: 'unknown' })],
+    });
+    const harness = buildHarness(transport, () => jsonResponse({}));
+    const { result } = renderHook(() => usePillarQuery('finance', ['wishlist', 'list'], {}), {
+      wrapper: harness.wrapper,
+    });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.isDegraded).toBe(true);
+    expect(result.current.isUnavailable).toBe(false);
+  });
+});
+
+describe('usePillarMutation', () => {
+  beforeEach(() => __resetSharedPillarClient());
+  afterEach(() => __resetSharedPillarClient());
+
+  it('runs the mutation and reports isPending + final data', async () => {
+    const transport = new FakeRegistryTransport({ pillars: [discoveredPillar()] });
+    const harness = buildHarness(transport, () =>
+      jsonResponse({ result: { data: { id: 'created' } } })
+    );
+    const { result } = renderHook(
+      () => usePillarMutation<{ name: string }, { id: string }>('finance', ['wishlist', 'create']),
+      { wrapper: harness.wrapper }
+    );
+    expect(result.current.isPending).toBe(false);
+    await act(async () => {
+      await result.current.mutateAsync({ name: 'new wish' });
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual({ id: 'created' });
+    expect(result.current.error).toBeNull();
+  });
+
+  it('invalidates the matching query prefix on success', async () => {
+    const transport = new FakeRegistryTransport({ pillars: [discoveredPillar()] });
+    const harness = buildHarness(transport, (url) => {
+      if (url.endsWith('finance.wishlist.list')) {
+        return jsonResponse({ result: { data: [{ id: 'a' }] } });
+      }
+      return jsonResponse({ result: { data: { id: 'created' } } });
+    });
+
+    const { result: queryResult } = renderHook(
+      () =>
+        usePillarQuery<readonly { id: string }[]>('finance', ['wishlist', 'list'], { limit: 10 }),
+      { wrapper: harness.wrapper }
+    );
+    await waitFor(() => expect(queryResult.current.isSuccess).toBe(true));
+
+    const listCallsBefore = harness.calls.filter((c) =>
+      c.url.endsWith('finance.wishlist.list')
+    ).length;
+    expect(listCallsBefore).toBe(1);
+
+    const { result: mutationResult } = renderHook(
+      () => usePillarMutation<{ name: string }, { id: string }>('finance', ['wishlist', 'create']),
+      { wrapper: harness.wrapper }
+    );
+    await act(async () => {
+      await mutationResult.current.mutateAsync({ name: 'new' });
+    });
+
+    await waitFor(() => {
+      const listCallsAfter = harness.calls.filter((c) =>
+        c.url.endsWith('finance.wishlist.list')
+      ).length;
+      expect(listCallsAfter).toBeGreaterThan(listCallsBefore);
+    });
+  });
+
+  it('maps mutation failures onto failure flags', async () => {
+    const transport = new FakeRegistryTransport({ pillars: [] });
+    const harness = buildHarness(transport, () => jsonResponse({}));
+    const { result } = renderHook(() => usePillarMutation('finance', ['wishlist', 'create']), {
+      wrapper: harness.wrapper,
+    });
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({});
+      } catch {
+        // expected — mutation throws PillarCallError
+      }
+    });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.isUnavailable).toBe(true);
+  });
+});

--- a/packages/pillar-sdk/src/react/__tests__/provider.test.tsx
+++ b/packages/pillar-sdk/src/react/__tests__/provider.test.tsx
@@ -1,0 +1,33 @@
+// @vitest-environment jsdom
+import { QueryClient, useQueryClient } from '@tanstack/react-query';
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { PillarSdkProvider, usePillarSdkOptions } from '../provider.js';
+
+import type { ReactNode } from 'react';
+
+describe('PillarSdkProvider', () => {
+  it('exposes the configured options through usePillarSdkOptions', () => {
+    const options = { contractVersion: '1.2.3' };
+    const wrapper = ({ children }: { children: ReactNode }): ReactNode => (
+      <PillarSdkProvider options={options}>{children}</PillarSdkProvider>
+    );
+    const { result } = renderHook(() => usePillarSdkOptions(), { wrapper });
+    expect(result.current.contractVersion).toBe('1.2.3');
+  });
+
+  it('returns empty options when no provider is mounted', () => {
+    const { result } = renderHook(() => usePillarSdkOptions());
+    expect(result.current).toEqual({});
+  });
+
+  it('wires a QueryClientProvider when queryClient is passed', () => {
+    const queryClient = new QueryClient();
+    const wrapper = ({ children }: { children: ReactNode }): ReactNode => (
+      <PillarSdkProvider queryClient={queryClient}>{children}</PillarSdkProvider>
+    );
+    const { result } = renderHook(() => useQueryClient(), { wrapper });
+    expect(result.current).toBe(queryClient);
+  });
+});

--- a/packages/pillar-sdk/src/react/__tests__/query-key.test.ts
+++ b/packages/pillar-sdk/src/react/__tests__/query-key.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { pillarQueryKey } from '../query-key.js';
+
+describe('pillarQueryKey', () => {
+  it('places the pillarId and path segments before the serialised input', () => {
+    const key = pillarQueryKey('finance', ['wishlist', 'list'], { limit: 10 });
+    expect(key[0]).toBe('finance');
+    expect(key[1]).toBe('wishlist');
+    expect(key[2]).toBe('list');
+    expect(key[3]).toBe('{"limit":10}');
+  });
+
+  it('produces stable keys regardless of input key order', () => {
+    const a = pillarQueryKey('finance', ['wishlist', 'list'], { b: 2, a: 1 });
+    const b = pillarQueryKey('finance', ['wishlist', 'list'], { a: 1, b: 2 });
+    expect(a).toEqual(b);
+  });
+
+  it('recurses into nested objects', () => {
+    const a = pillarQueryKey('finance', ['x'], { filter: { b: 2, a: 1 } });
+    const b = pillarQueryKey('finance', ['x'], { filter: { a: 1, b: 2 } });
+    expect(a).toEqual(b);
+  });
+
+  it('serialises undefined input as null', () => {
+    const key = pillarQueryKey('finance', ['x'], undefined);
+    expect(key[key.length - 1]).toBe('null');
+  });
+
+  it('drops undefined values from objects', () => {
+    const key = pillarQueryKey('finance', ['x'], { a: 1, b: undefined });
+    expect(key[key.length - 1]).toBe('{"a":1}');
+  });
+
+  it('preserves array element order', () => {
+    const a = pillarQueryKey('finance', ['x'], { ids: ['b', 'a'] });
+    const b = pillarQueryKey('finance', ['x'], { ids: ['a', 'b'] });
+    expect(a).not.toEqual(b);
+  });
+});

--- a/packages/pillar-sdk/src/react/hooks.ts
+++ b/packages/pillar-sdk/src/react/hooks.ts
@@ -1,0 +1,167 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
+
+import { PillarCallError } from '../client/errors.js';
+import { pillar } from '../client/factory.js';
+import { usePillarSdkOptions } from './provider.js';
+import { pillarQueryKey } from './query-key.js';
+
+import type {
+  UseMutationOptions,
+  UseMutationResult,
+  UseQueryOptions,
+  UseQueryResult,
+} from '@tanstack/react-query';
+
+import type { CallFailure, CallResult } from '../client/errors.js';
+
+type ProcedurePath = readonly [string, ...string[]];
+
+type FailureFlags = {
+  isContractMismatch: boolean;
+  isUnavailable: boolean;
+  isDegraded: boolean;
+};
+
+const NO_FAILURE: FailureFlags = {
+  isContractMismatch: false,
+  isUnavailable: false,
+  isDegraded: false,
+};
+
+function failureFlagsFrom(failure: CallFailure): FailureFlags {
+  return {
+    isContractMismatch: failure.kind === 'contract-mismatch',
+    isUnavailable: failure.kind === 'unavailable',
+    isDegraded: failure.kind === 'degraded',
+  };
+}
+
+function callProcedure<TOutput>(
+  pillarId: string,
+  path: ProcedurePath,
+  input: unknown,
+  options: ReturnType<typeof usePillarSdkOptions>
+): Promise<CallResult<TOutput>> {
+  const handle = pillar<unknown>(pillarId, options);
+  let node: unknown = handle;
+  for (let i = 0; i < path.length - 1; i += 1) {
+    const segment = path[i] as string;
+    node = (node as Record<string, unknown>)[segment];
+  }
+  const leaf = (node as Record<string, unknown>)[path[path.length - 1] as string];
+  if (typeof leaf !== 'function') {
+    throw new PillarCallError(pillarId, {
+      kind: 'contract-mismatch',
+      pillar: pillarId,
+      actual: path.join('.'),
+    });
+  }
+  return (leaf as (i: unknown) => Promise<CallResult<TOutput>>)(input);
+}
+
+export type UsePillarQueryOptions<TOutput> = Omit<
+  UseQueryOptions<TOutput, PillarCallError, TOutput, readonly unknown[]>,
+  'queryKey' | 'queryFn'
+>;
+
+export type UsePillarQueryResult<TOutput> = UseQueryResult<TOutput, PillarCallError> & FailureFlags;
+
+/**
+ * React Query hook that wraps a `pillar(pillarId).path(input)` call.
+ *
+ * The underlying call uses `.orThrow()` semantics so React Query owns
+ * retry / error surfaces. Failure discriminants from `CallResult` are
+ * also mapped onto convenience flags (`isContractMismatch`,
+ * `isUnavailable`, `isDegraded`) so call sites can branch without
+ * unpacking the `PillarCallError`.
+ *
+ * Cache key is `pillarQueryKey(pillarId, path, input)`.
+ */
+export function usePillarQuery<TOutput>(
+  pillarId: string,
+  path: ProcedurePath,
+  input: unknown,
+  options: UsePillarQueryOptions<TOutput> = {}
+): UsePillarQueryResult<TOutput> {
+  const sdkOptions = usePillarSdkOptions();
+  const queryKey = pillarQueryKey(pillarId, path, input);
+
+  const query = useQuery<TOutput, PillarCallError, TOutput, readonly unknown[]>({
+    queryKey,
+    queryFn: async () => {
+      const result = await callProcedure<TOutput>(pillarId, path, input, sdkOptions);
+      if (result.kind === 'ok') return result.value;
+      throw new PillarCallError(pillarId, result);
+    },
+    ...options,
+  });
+
+  const flags =
+    query.error instanceof PillarCallError ? failureFlagsFrom(query.error.result) : NO_FAILURE;
+
+  return { ...query, ...flags } as UsePillarQueryResult<TOutput>;
+}
+
+export type UsePillarMutationOptions<TInput, TOutput> = Omit<
+  UseMutationOptions<TOutput, PillarCallError, TInput>,
+  'mutationFn'
+>;
+
+export type UsePillarMutationResult<TInput, TOutput> = UseMutationResult<
+  TOutput,
+  PillarCallError,
+  TInput
+> &
+  FailureFlags;
+
+/**
+ * React Query hook that wraps a `pillar(pillarId).path(input)` mutation.
+ *
+ * On success, the mutation invalidates every query under the same router
+ * prefix (`[pillarId, ...path.slice(0, -1)]`) — e.g. `wishlist.create`
+ * invalidates `wishlist.list`, `wishlist.get`, etc. Top-level procedures
+ * (single-segment paths) invalidate the entire `[pillarId]` prefix.
+ *
+ * Pass `options.onSuccess` to layer additional behaviour; the built-in
+ * invalidation runs first. The hook does not maintain its own cache —
+ * only the mutation lifecycle (pending / error) plus the failure-flag
+ * mapping.
+ */
+export function usePillarMutation<TInput = unknown, TOutput = unknown>(
+  pillarId: string,
+  path: ProcedurePath,
+  options: UsePillarMutationOptions<TInput, TOutput> = {}
+): UsePillarMutationResult<TInput, TOutput> {
+  const sdkOptions = usePillarSdkOptions();
+  const queryClient = useQueryClient();
+  const { onSuccess, ...rest } = options;
+
+  const handleSuccess = useCallback<
+    NonNullable<UseMutationOptions<TOutput, PillarCallError, TInput>['onSuccess']>
+  >(
+    (data, variables, onMutateResult, context) => {
+      const routerPrefix = path.length > 1 ? [pillarId, ...path.slice(0, -1)] : [pillarId];
+      void queryClient.invalidateQueries({ queryKey: routerPrefix });
+      return onSuccess?.(data, variables, onMutateResult, context);
+    },
+    [queryClient, pillarId, path, onSuccess]
+  );
+
+  const mutation = useMutation<TOutput, PillarCallError, TInput>({
+    mutationFn: async (input: TInput) => {
+      const result = await callProcedure<TOutput>(pillarId, path, input, sdkOptions);
+      if (result.kind === 'ok') return result.value;
+      throw new PillarCallError(pillarId, result);
+    },
+    onSuccess: handleSuccess,
+    ...rest,
+  });
+
+  const flags =
+    mutation.error instanceof PillarCallError
+      ? failureFlagsFrom(mutation.error.result)
+      : NO_FAILURE;
+
+  return { ...mutation, ...flags } as UsePillarMutationResult<TInput, TOutput>;
+}

--- a/packages/pillar-sdk/src/react/index.ts
+++ b/packages/pillar-sdk/src/react/index.ts
@@ -1,0 +1,10 @@
+export { PillarSdkProvider, usePillarSdkOptions } from './provider.js';
+export type { PillarSdkProviderProps } from './provider.js';
+export { usePillarQuery, usePillarMutation } from './hooks.js';
+export type {
+  UsePillarQueryOptions,
+  UsePillarQueryResult,
+  UsePillarMutationOptions,
+  UsePillarMutationResult,
+} from './hooks.js';
+export { pillarQueryKey } from './query-key.js';

--- a/packages/pillar-sdk/src/react/provider.tsx
+++ b/packages/pillar-sdk/src/react/provider.tsx
@@ -1,0 +1,57 @@
+import { QueryClientProvider } from '@tanstack/react-query';
+import { createContext, useContext, useMemo } from 'react';
+
+import type { QueryClient } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+
+import type { PillarClientOptions } from '../client/factory.js';
+
+const PillarSdkContext = createContext<PillarClientOptions | null>(null);
+
+export type PillarSdkProviderProps = {
+  /** Forwarded to every `pillar()` call made by the hooks. */
+  options?: PillarClientOptions;
+  /**
+   * Optional `QueryClient`. When provided the provider also wires a
+   * `QueryClientProvider`. When omitted, the host shell is expected to
+   * have its own `QueryClientProvider` further up the tree — the hooks
+   * read from whichever is closest.
+   */
+  queryClient?: QueryClient;
+  children: ReactNode;
+};
+
+/**
+ * Wires the `pillar()` SDK options (transport, registry config, auth
+ * headers, contract version) into React context so `usePillarQuery` /
+ * `usePillarMutation` pick them up.
+ *
+ * Layering: the provider is intentionally lightweight. If you pass a
+ * `queryClient`, it nests a `QueryClientProvider` for convenience;
+ * otherwise it composes cleanly under an existing one (the common case
+ * inside `pops-shell`, which already owns its `QueryClientProvider`).
+ */
+export function PillarSdkProvider({
+  options,
+  queryClient,
+  children,
+}: PillarSdkProviderProps): ReactNode {
+  const memoised = useMemo<PillarClientOptions>(() => options ?? {}, [options]);
+  const inner = <PillarSdkContext.Provider value={memoised}>{children}</PillarSdkContext.Provider>;
+  if (queryClient) {
+    return <QueryClientProvider client={queryClient}>{inner}</QueryClientProvider>;
+  }
+  return inner;
+}
+
+/**
+ * Reads the closest `PillarSdkProvider` options. Returns an empty options
+ * object when no provider is present — the hooks still work in that case,
+ * they just fall back to `pillar()`'s built-in defaults (shared discovery
+ * cache, default fetch, no auth headers).
+ */
+export function usePillarSdkOptions(): PillarClientOptions {
+  return useContext(PillarSdkContext) ?? EMPTY_OPTIONS;
+}
+
+const EMPTY_OPTIONS: PillarClientOptions = {};

--- a/packages/pillar-sdk/src/react/query-key.ts
+++ b/packages/pillar-sdk/src/react/query-key.ts
@@ -1,0 +1,41 @@
+/**
+ * Stable React Query cache key for a `pillar()` invocation.
+ *
+ * Shape: `[pillarId, ...path, stableInputKey]`.
+ *
+ * `stableInputKey` is the JSON serialisation of `input` with object keys
+ * sorted recursively so two structurally-equal inputs produce the same
+ * cache key regardless of key insertion order. `undefined` inputs collapse
+ * to `null`.
+ *
+ * Pure function from inputs to key — no internal state.
+ */
+export function pillarQueryKey(
+  pillarId: string,
+  path: readonly string[],
+  input: unknown
+): readonly [string, ...string[], string] {
+  return [pillarId, ...path, stableJson(input)] as const;
+}
+
+function stableJson(value: unknown): string {
+  return JSON.stringify(sortDeep(value) ?? null);
+}
+
+function sortDeep(value: unknown): unknown {
+  if (value === null || value === undefined) return value;
+  if (Array.isArray(value)) return value.map(sortDeep);
+  if (typeof value !== 'object') return value;
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, v]) => v !== undefined)
+    .toSorted(([a], [b]) => compareStrings(a, b));
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of entries) out[k] = sortDeep(v);
+  return out;
+}
+
+function compareStrings(a: string, b: string): number {
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+}

--- a/packages/pillar-sdk/tsconfig.json
+++ b/packages/pillar-sdk/tsconfig.json
@@ -3,13 +3,14 @@
   "compilerOptions": {
     "module": "Node16",
     "moduleResolution": "Node16",
-    "lib": ["ES2022", "DOM"],
+    "lib": ["ES2023", "DOM"],
     "types": ["node"],
+    "jsx": "react-jsx",
     "declaration": true,
     "declarationMap": true,
     "outDir": "dist",
     "rootDir": "src"
   },
   "include": ["src/**/*"],
-  "exclude": ["**/__tests__/**", "**/*.test.ts"]
+  "exclude": ["**/__tests__/**", "**/*.test.ts", "**/*.test.tsx"]
 }

--- a/packages/pillar-sdk/vitest.config.ts
+++ b/packages/pillar-sdk/vitest.config.ts
@@ -8,8 +8,8 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'json-summary', 'html'],
       reportsDirectory: 'coverage',
-      include: ['src/**/*.ts'],
-      exclude: ['**/node_modules/**', '**/dist/**', '**/*.test.ts'],
+      include: ['src/**/*.{ts,tsx}'],
+      exclude: ['**/node_modules/**', '**/dist/**', '**/*.test.{ts,tsx}'],
     },
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2037,12 +2037,33 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@tanstack/react-query':
+        specifier: 5.101.0
+        version: 5.101.0(react@19.2.7)
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@types/node':
         specifier: ^25.9.3
         version: 25.9.3
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
       '@vitest/coverage-v8':
         specifier: ^4.1.8
         version: 4.1.8(vitest@4.1.8)
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1(@noble/hashes@1.8.0)
+      react:
+        specifier: ^19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3


### PR DESCRIPTION
## Summary

Adds a new `@pops/pillar-sdk/react` subpath that ships React Query-shaped hooks wrapping the existing `pillar()` factory:

- `usePillarQuery(pillarId, path, input, options?)` — wraps `pillar(pillarId).path(input)` and maps `CallResult` discriminants to React-friendly flags (`isContractMismatch`, `isUnavailable`, `isDegraded`).
- `usePillarMutation(pillarId, path, options?)` — same RPC under the hood, no auto-caching. On success invalidates queries under the router prefix so siblings on the same router refetch.
- `PillarSdkProvider` — lightweight context for `PillarClientOptions` (transport, registry, auth headers, contract version); optionally wires a `QueryClientProvider`, otherwise composes under the host shell's existing one.
- `pillarQueryKey(pillarId, path, input)` — pure cache-key function with deterministic JSON serialisation (recursive key sort, undefined-stripped).

Spec: `docs/themes/13-pillar-finale/prds/193-react-hooks/README.md`.

## Decisions

- React Query: `@tanstack/react-query@5.101.0` (matches the version pinned across `pops-shell` and every `app-*` package). Declared as an optional peer dep so non-React consumers of `@pops/pillar-sdk` aren't forced into it.
- Provider layering: `PillarSdkProvider` is intentionally minimal. It owns SDK options context only; the `QueryClient` prop is opt-in. The expected pattern in `pops-shell` is to keep the existing `<QueryClientProvider>` at the root and slot `<PillarSdkProvider options={...}>` below it.
- Cache invalidation: a mutation on `<pillar>.<router>.<procedure>` invalidates the entire `<pillar>.<router>` prefix — sibling-query staleness is the common case (`create` invalidates `list`, `get`, etc.). Top-level procedures invalidate the whole pillar.
- The pillar-sdk `tsconfig.lib` was bumped from ES2022 to ES2023 to use `Array#toSorted` for the cache-key sort (no mutation of intermediate arrays).

## Out of scope

- Subscription-driven cache invalidation (PRD-194).
- Suspense / SSR streaming.

## Test plan

- [x] `pnpm typecheck` (full repo) passes.
- [x] `pnpm lint` exit 0 (no new errors, only pre-existing warnings).
- [x] `packages/pillar-sdk` test suite: 249 passed (including 16 new tests across 3 new files — `query-key.test.ts` (6), `provider.test.tsx` (3), `hooks.test.tsx` (7) covering happy path, contract-mismatch / unavailable / degraded mapping, mutation lifecycle, and cache invalidation on mutate).