### PR TITLE
feat(pillar-sdk/react): subscription bridge for cache invalidation (Theme 13 PRD-194)

### DIFF
--- a/packages/pillar-sdk/src/react/__tests__/subscription-bridge.test.tsx
+++ b/packages/pillar-sdk/src/react/__tests__/subscription-bridge.test.tsx
@@ -125,11 +125,13 @@ describe('applySubscriptionEvent (pure rules)', () => {
     });
   });
 
-  it('pillar.snapshot invalidates every cache entry whose first segment matches a pillar in the snapshot', async () => {
+  it('pillar.snapshot invalidates every cache entry whose first segment looks like a pillarId (defends against deregistered-during-gap)', async () => {
     const client = new QueryClient();
     seedQuery(client, ['finance', 'wishlist', 'list', '{}'], [{ id: 'wish-1' }]);
     seedQuery(client, ['media', 'movies', 'list', '{}'], []);
-    seedQuery(client, ['health', 'metrics', 'get', '{}'], { hr: 60 });
+    // A first-segment key that does NOT match the pillarId pattern
+    // (uppercase) — should be left alone.
+    seedQuery(client, ['SystemMetrics', 'hr', '{}'], { hr: 60 });
 
     applySubscriptionEvent(client, {
       event: 'pillar.snapshot',
@@ -139,18 +141,37 @@ describe('applySubscriptionEvent (pure rules)', () => {
     await waitFor(() => {
       expect(client.getQueryState(['finance', 'wishlist', 'list', '{}'])?.isInvalidated).toBe(true);
       expect(client.getQueryState(['media', 'movies', 'list', '{}'])?.isInvalidated).toBe(true);
-      expect(client.getQueryState(['health', 'metrics', 'get', '{}'])?.isInvalidated).toBe(false);
+      expect(client.getQueryState(['SystemMetrics', 'hr', '{}'])?.isInvalidated).toBe(false);
     });
   });
 
-  it('ignores malformed payloads (missing pillarId / non-array snapshot)', async () => {
+  it('snapshot invalidates pillars NOT in the snapshot (deregistered-during-gap defense)', async () => {
     const client = new QueryClient();
+    // finance was previously cached but has been deregistered during the
+    // SSE gap; the reconnect snapshot only contains media.
     seedQuery(client, ['finance', 'wishlist', 'list', '{}'], [{ id: 'wish-1' }]);
+    seedQuery(client, ['media', 'movies', 'list', '{}'], []);
 
+    applySubscriptionEvent(client, {
+      event: 'pillar.snapshot',
+      data: [entry('media')],
+    });
+
+    await waitFor(() => {
+      // finance is invalidated even though it's absent from the snapshot.
+      expect(client.getQueryState(['finance', 'wishlist', 'list', '{}'])?.isInvalidated).toBe(true);
+      expect(client.getQueryState(['media', 'movies', 'list', '{}'])?.isInvalidated).toBe(true);
+    });
+  });
+
+  it('ignores malformed single-event payloads', async () => {
+    const client = new QueryClient();
+    seedQuery(client, ['SystemMetrics', 'hr', '{}'], { hr: 60 });
+
+    // Non-pillar key + malformed register payload = nothing invalidated.
     applySubscriptionEvent(client, { event: 'pillar.registered', data: { entry: {} } });
-    applySubscriptionEvent(client, { event: 'pillar.snapshot', data: 'oops' });
 
-    expect(client.getQueryState(['finance', 'wishlist', 'list', '{}'])?.isInvalidated).toBe(false);
+    expect(client.getQueryState(['SystemMetrics', 'hr', '{}'])?.isInvalidated).toBe(false);
   });
 });
 

--- a/packages/pillar-sdk/src/react/__tests__/subscription-bridge.test.tsx
+++ b/packages/pillar-sdk/src/react/__tests__/subscription-bridge.test.tsx
@@ -1,0 +1,287 @@
+// @vitest-environment jsdom
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { PillarSdkProvider } from '../provider.js';
+import {
+  applySubscriptionEvent,
+  usePillarSubscriptionBridge,
+  type SubscriptionConnect,
+  type SubscriptionEvent,
+  type SubscriptionSource,
+} from '../subscription-bridge.js';
+
+import type { ReactNode } from 'react';
+
+interface FakeSource extends SubscriptionSource {
+  emit: (event: SubscriptionEvent) => void;
+  triggerClose: () => void;
+  readonly closed: boolean;
+  eventListenerCount: () => number;
+}
+
+function createFakeSource(): FakeSource {
+  const eventListeners = new Set<(event: SubscriptionEvent) => void>();
+  const closeListeners = new Set<(reason?: unknown) => void>();
+  let closed = false;
+  const fake: FakeSource = {
+    close: () => {
+      closed = true;
+    },
+    onClose: (listener) => {
+      closeListeners.add(listener);
+      return () => {
+        closeListeners.delete(listener);
+      };
+    },
+    onEvent: (listener) => {
+      eventListeners.add(listener);
+      return () => {
+        eventListeners.delete(listener);
+      };
+    },
+    emit: (event) => {
+      for (const listener of eventListeners) listener(event);
+    },
+    triggerClose: () => {
+      for (const listener of closeListeners) listener();
+    },
+    eventListenerCount: () => eventListeners.size,
+    get closed() {
+      return closed;
+    },
+  };
+  return fake;
+}
+
+function entry(pillarId: string): Record<string, unknown> {
+  return { pillarId, baseUrl: `http://${pillarId}` };
+}
+
+function payload(pillarId: string): Record<string, unknown> {
+  return {
+    event: 'whatever',
+    pillarId,
+    entry: entry(pillarId),
+    emittedAt: '2026-06-12T00:00:00.000Z',
+  };
+}
+
+function buildWrapper(): {
+  wrapper: (props: { children: ReactNode }) => ReactNode;
+  queryClient: QueryClient;
+} {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: ReactNode }): ReactNode => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { wrapper, queryClient };
+}
+
+function seedQuery(client: QueryClient, queryKey: readonly unknown[], data: unknown): void {
+  client.setQueryData(queryKey, data);
+}
+
+describe('applySubscriptionEvent (pure rules)', () => {
+  it('pillar.registered invalidates every entry under the [pillarId] prefix', async () => {
+    const client = new QueryClient();
+    seedQuery(client, ['finance', 'wishlist', 'list', '{}'], [{ id: 'wish-1' }]);
+    seedQuery(client, ['finance', 'budget', 'get', '{}'], { id: 'b' });
+    seedQuery(client, ['media', 'movies', 'list', '{}'], []);
+
+    applySubscriptionEvent(client, { event: 'pillar.registered', data: payload('finance') });
+
+    await waitFor(() => {
+      expect(client.getQueryState(['finance', 'wishlist', 'list', '{}'])?.isInvalidated).toBe(true);
+      expect(client.getQueryState(['finance', 'budget', 'get', '{}'])?.isInvalidated).toBe(true);
+      expect(client.getQueryState(['media', 'movies', 'list', '{}'])?.isInvalidated).toBe(false);
+    });
+  });
+
+  it('pillar.deregistered invalidates the [pillarId] prefix', async () => {
+    const client = new QueryClient();
+    seedQuery(client, ['finance', 'wishlist', 'list', '{}'], [{ id: 'wish-1' }]);
+    seedQuery(client, ['media', 'movies', 'list', '{}'], []);
+
+    applySubscriptionEvent(client, { event: 'pillar.deregistered', data: payload('finance') });
+
+    await waitFor(() => {
+      expect(client.getQueryState(['finance', 'wishlist', 'list', '{}'])?.isInvalidated).toBe(true);
+      expect(client.getQueryState(['media', 'movies', 'list', '{}'])?.isInvalidated).toBe(false);
+    });
+  });
+
+  it('pillar.health-changed invalidates the [pillarId] prefix', async () => {
+    const client = new QueryClient();
+    seedQuery(client, ['finance', 'budget', 'get', '{}'], { id: 'b' });
+
+    applySubscriptionEvent(client, { event: 'pillar.health-changed', data: payload('finance') });
+
+    await waitFor(() => {
+      expect(client.getQueryState(['finance', 'budget', 'get', '{}'])?.isInvalidated).toBe(true);
+    });
+  });
+
+  it('pillar.snapshot invalidates every cache entry whose first segment matches a pillar in the snapshot', async () => {
+    const client = new QueryClient();
+    seedQuery(client, ['finance', 'wishlist', 'list', '{}'], [{ id: 'wish-1' }]);
+    seedQuery(client, ['media', 'movies', 'list', '{}'], []);
+    seedQuery(client, ['health', 'metrics', 'get', '{}'], { hr: 60 });
+
+    applySubscriptionEvent(client, {
+      event: 'pillar.snapshot',
+      data: [entry('finance'), entry('media')],
+    });
+
+    await waitFor(() => {
+      expect(client.getQueryState(['finance', 'wishlist', 'list', '{}'])?.isInvalidated).toBe(true);
+      expect(client.getQueryState(['media', 'movies', 'list', '{}'])?.isInvalidated).toBe(true);
+      expect(client.getQueryState(['health', 'metrics', 'get', '{}'])?.isInvalidated).toBe(false);
+    });
+  });
+
+  it('ignores malformed payloads (missing pillarId / non-array snapshot)', async () => {
+    const client = new QueryClient();
+    seedQuery(client, ['finance', 'wishlist', 'list', '{}'], [{ id: 'wish-1' }]);
+
+    applySubscriptionEvent(client, { event: 'pillar.registered', data: { entry: {} } });
+    applySubscriptionEvent(client, { event: 'pillar.snapshot', data: 'oops' });
+
+    expect(client.getQueryState(['finance', 'wishlist', 'list', '{}'])?.isInvalidated).toBe(false);
+  });
+});
+
+describe('usePillarSubscriptionBridge', () => {
+  it('invalidates the affected query keys when a register event arrives', async () => {
+    const source = createFakeSource();
+    const connect: SubscriptionConnect = () => source;
+    const { wrapper, queryClient } = buildWrapper();
+
+    seedQuery(queryClient, ['finance', 'wishlist', 'list', '{}'], [{ id: 'wish-1' }]);
+    seedQuery(queryClient, ['media', 'movies', 'list', '{}'], []);
+
+    renderHook(() => usePillarSubscriptionBridge({ connect }), { wrapper });
+
+    await waitFor(() => expect(source.eventListenerCount()).toBeGreaterThan(0));
+
+    act(() => {
+      source.emit({ event: 'pillar.registered', data: payload('finance') });
+    });
+
+    await waitFor(() => {
+      expect(queryClient.getQueryState(['finance', 'wishlist', 'list', '{}'])?.isInvalidated).toBe(
+        true
+      );
+      expect(queryClient.getQueryState(['media', 'movies', 'list', '{}'])?.isInvalidated).toBe(
+        false
+      );
+    });
+  });
+
+  it('invalidates on a deregister event', async () => {
+    const source = createFakeSource();
+    const connect: SubscriptionConnect = () => source;
+    const { wrapper, queryClient } = buildWrapper();
+
+    seedQuery(queryClient, ['finance', 'budget', 'get', '{}'], { id: 'b' });
+
+    renderHook(() => usePillarSubscriptionBridge({ connect }), { wrapper });
+    await waitFor(() => expect(source.eventListenerCount()).toBeGreaterThan(0));
+
+    act(() => {
+      source.emit({ event: 'pillar.deregistered', data: payload('finance') });
+    });
+
+    await waitFor(() => {
+      expect(queryClient.getQueryState(['finance', 'budget', 'get', '{}'])?.isInvalidated).toBe(
+        true
+      );
+    });
+  });
+
+  it('stops dispatching invalidations after the hook unmounts (disconnect)', async () => {
+    const source = createFakeSource();
+    const connect: SubscriptionConnect = () => source;
+    const { wrapper, queryClient } = buildWrapper();
+
+    seedQuery(queryClient, ['finance', 'wishlist', 'list', '{}'], [{ id: 'wish-1' }]);
+
+    const { unmount } = renderHook(() => usePillarSubscriptionBridge({ connect }), { wrapper });
+    await waitFor(() => expect(source.eventListenerCount()).toBeGreaterThan(0));
+
+    unmount();
+    expect(source.closed).toBe(true);
+
+    const spy = vi.spyOn(queryClient, 'invalidateQueries');
+    act(() => {
+      source.emit({ event: 'pillar.registered', data: payload('finance') });
+    });
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('does not subscribe when enabled=false', async () => {
+    const source = createFakeSource();
+    let connectCalls = 0;
+    const connect: SubscriptionConnect = () => {
+      connectCalls += 1;
+      return source;
+    };
+    const { wrapper } = buildWrapper();
+
+    renderHook(() => usePillarSubscriptionBridge({ connect, enabled: false }), { wrapper });
+    await Promise.resolve();
+    expect(connectCalls).toBe(0);
+    expect(source.eventListenerCount()).toBe(0);
+  });
+
+  it('PillarSdkProvider subscribe prop mounts the bridge', async () => {
+    const source = createFakeSource();
+    const connect: SubscriptionConnect = () => source;
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    seedQuery(queryClient, ['finance', 'wishlist', 'list', '{}'], [{ id: 'wish-1' }]);
+
+    const wrapper = ({ children }: { children: ReactNode }): ReactNode => (
+      <PillarSdkProvider queryClient={queryClient} subscribe subscriptionOptions={{ connect }}>
+        {children}
+      </PillarSdkProvider>
+    );
+
+    renderHook(() => null, { wrapper });
+    await waitFor(() => expect(source.eventListenerCount()).toBeGreaterThan(0));
+
+    act(() => {
+      source.emit({ event: 'pillar.registered', data: payload('finance') });
+    });
+
+    await waitFor(() => {
+      expect(queryClient.getQueryState(['finance', 'wishlist', 'list', '{}'])?.isInvalidated).toBe(
+        true
+      );
+    });
+  });
+
+  it('PillarSdkProvider does not mount the bridge by default', async () => {
+    const source = createFakeSource();
+    let connectCalls = 0;
+    const connect: SubscriptionConnect = () => {
+      connectCalls += 1;
+      return source;
+    };
+    const queryClient = new QueryClient();
+
+    const wrapper = ({ children }: { children: ReactNode }): ReactNode => (
+      <PillarSdkProvider queryClient={queryClient} subscriptionOptions={{ connect }}>
+        {children}
+      </PillarSdkProvider>
+    );
+
+    renderHook(() => null, { wrapper });
+    await Promise.resolve();
+    expect(connectCalls).toBe(0);
+  });
+});

--- a/packages/pillar-sdk/src/react/index.ts
+++ b/packages/pillar-sdk/src/react/index.ts
@@ -8,3 +8,11 @@ export type {
   UsePillarMutationResult,
 } from './hooks.js';
 export { pillarQueryKey } from './query-key.js';
+export { usePillarSubscriptionBridge, applySubscriptionEvent } from './subscription-bridge.js';
+export type {
+  SubscriptionConnect,
+  SubscriptionEvent,
+  SubscriptionEventName,
+  SubscriptionSource,
+  UsePillarSubscriptionBridgeOptions,
+} from './subscription-bridge.js';

--- a/packages/pillar-sdk/src/react/provider.tsx
+++ b/packages/pillar-sdk/src/react/provider.tsx
@@ -1,6 +1,11 @@
 import { QueryClientProvider } from '@tanstack/react-query';
 import { createContext, useContext, useMemo } from 'react';
 
+import {
+  usePillarSubscriptionBridge,
+  type UsePillarSubscriptionBridgeOptions,
+} from './subscription-bridge.js';
+
 import type { QueryClient } from '@tanstack/react-query';
 import type { ReactNode } from 'react';
 
@@ -18,6 +23,17 @@ export type PillarSdkProviderProps = {
    * read from whichever is closest.
    */
   queryClient?: QueryClient;
+  /**
+   * When true, mounts {@link usePillarSubscriptionBridge} so registry
+   * SSE events invalidate matching React Query caches. Off by default
+   * — tests stay deterministic and CLI consumers don't open sockets.
+   */
+  subscribe?: boolean;
+  /**
+   * Forwarded to `usePillarSubscriptionBridge` when `subscribe` is set.
+   * Ignored otherwise.
+   */
+  subscriptionOptions?: UsePillarSubscriptionBridgeOptions;
   children: ReactNode;
 };
 
@@ -34,14 +50,30 @@ export type PillarSdkProviderProps = {
 export function PillarSdkProvider({
   options,
   queryClient,
+  subscribe = false,
+  subscriptionOptions,
   children,
 }: PillarSdkProviderProps): ReactNode {
   const memoised = useMemo<PillarClientOptions>(() => options ?? {}, [options]);
-  const inner = <PillarSdkContext.Provider value={memoised}>{children}</PillarSdkContext.Provider>;
+  const inner = (
+    <PillarSdkContext.Provider value={memoised}>
+      {subscribe ? <SubscriptionBridgeMount options={subscriptionOptions} /> : null}
+      {children}
+    </PillarSdkContext.Provider>
+  );
   if (queryClient) {
     return <QueryClientProvider client={queryClient}>{inner}</QueryClientProvider>;
   }
   return inner;
+}
+
+function SubscriptionBridgeMount({
+  options,
+}: {
+  options?: UsePillarSubscriptionBridgeOptions;
+}): null {
+  usePillarSubscriptionBridge(options);
+  return null;
 }
 
 /**

--- a/packages/pillar-sdk/src/react/subscription-bridge.ts
+++ b/packages/pillar-sdk/src/react/subscription-bridge.ts
@@ -20,6 +20,7 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { useEffect } from 'react';
 
+import { DEFAULT_REGISTRY_URL } from '../discovery/cache-internals.js';
 import { startReconnectingSubscription, type SubscriptionHandle } from '../discovery/reconnect.js';
 
 import type { QueryClient } from '@tanstack/react-query';
@@ -51,7 +52,6 @@ export interface SubscriptionSource extends SubscriptionHandle {
 
 export type SubscriptionConnect = () => Promise<SubscriptionSource> | SubscriptionSource;
 
-const DEFAULT_REGISTRY_URL = 'http://core-api:3001';
 const SUBSCRIBE_PATH = '/registry/subscribe';
 
 const TRACKED_EVENTS: readonly SubscriptionEventName[] = [
@@ -71,7 +71,7 @@ export interface UsePillarSubscriptionBridgeOptions {
   readonly registryUrl?: string;
   /** Disable the bridge without unmounting the component. */
   readonly enabled?: boolean;
-  /** Bubble up reconnect / parse failures. Optional — defaults to console.warn. */
+  /** Bubble up reconnect / connection failures. Optional — defaults to console.warn. Malformed event payloads are swallowed (dropped) without firing this callback. */
   readonly onError?: (error: unknown) => void;
 }
 
@@ -146,12 +146,21 @@ export function applySubscriptionEvent(client: QueryClient, event: SubscriptionE
       return;
     }
     case 'pillar.snapshot': {
-      const pillarIds = extractSnapshotPillarIds(event.data);
-      if (pillarIds.size === 0) return;
+      // On reconnect we don't know which pillars were deregistered
+      // during the gap, so we invalidate EVERY pillar-prefixed cache
+      // entry, not just the ones still present in the snapshot. The
+      // snapshot pillars then refetch from a fresh source-of-truth,
+      // and any pillar that's gone returns `unavailable` (PRD-191).
+      // Targeting only snapshot members would leave stale data behind
+      // for pillars deregistered mid-gap.
+      const snapshotIds = extractSnapshotPillarIds(event.data);
       void client.invalidateQueries({
         predicate: (query) => {
           const first = query.queryKey[0];
-          return typeof first === 'string' && pillarIds.has(first);
+          if (typeof first !== 'string') return false;
+          // Invalidate everything whose first key segment looks like a
+          // pillarId — present-in-snapshot or otherwise.
+          return snapshotIds.has(first) || isLikelyPillarId(first);
         },
       });
       return;
@@ -176,6 +185,19 @@ function extractSnapshotPillarIds(data: unknown): ReadonlySet<string> {
     if (hasStringPillarId(entry)) ids.add(entry.pillarId);
   }
   return ids;
+}
+
+/**
+ * Heuristic: a query-key first segment looks like a pillar id if it
+ * matches the lowercase-kebab-case constraint from PRD-157's
+ * `ManifestPayloadSchema`. False positives are harmless (the
+ * invalidation just refetches) but false negatives would leave stale
+ * data after a deregistration during a gap, which is what we're
+ * defending against.
+ */
+const LIKELY_PILLAR_ID = /^[a-z][a-z0-9-]*$/;
+function isLikelyPillarId(value: string): boolean {
+  return LIKELY_PILLAR_ID.test(value);
 }
 
 function reportError(error: unknown, onError?: (error: unknown) => void): void {
@@ -220,19 +242,29 @@ function openEventSourceSubscription(registryUrl: string): SubscriptionSource {
     domListeners.push({ name, handler });
   }
 
+  let closed = false;
+  const closeSource = (): void => {
+    if (closed) return;
+    closed = true;
+    for (const { name, handler } of domListeners) {
+      source.removeEventListener(name, handler);
+    }
+    source.removeEventListener('error', onSourceError);
+    source.close();
+  };
+
   const onSourceError = (): void => {
+    // Stop EventSource's built-in retry by closing the underlying
+    // connection — startReconnectingSubscription owns the reconnect
+    // schedule and would otherwise race with EventSource opening a
+    // second connection on top of the first.
+    closeSource();
     for (const listener of closeListeners) listener();
   };
   source.addEventListener('error', onSourceError);
 
   return {
-    close: (): void => {
-      for (const { name, handler } of domListeners) {
-        source.removeEventListener(name, handler);
-      }
-      source.removeEventListener('error', onSourceError);
-      source.close();
-    },
+    close: closeSource,
     onClose: (listener) => {
       closeListeners.add(listener);
       return () => closeListeners.delete(listener);

--- a/packages/pillar-sdk/src/react/subscription-bridge.ts
+++ b/packages/pillar-sdk/src/react/subscription-bridge.ts
@@ -1,0 +1,245 @@
+/**
+ * SSE → React Query cache invalidation bridge (Theme 13 PRD-194).
+ *
+ * Reuses PRD-163's `GET /registry/subscribe` event stream and PRD-164's
+ * `startReconnectingSubscription` to keep the React Query cache fresh
+ * when registry state changes server-side.
+ *
+ * Invalidation rules:
+ *
+ *   pillar.registered    → invalidate ['<pillarId>'] prefix
+ *   pillar.deregistered  → invalidate ['<pillarId>'] prefix
+ *   pillar.health-changed→ invalidate ['<pillarId>'] prefix
+ *   pillar.snapshot      → invalidate every cache entry whose first key
+ *                          segment is a `pillarId` present in the snapshot
+ *
+ * The bridge is opt-in. `PillarSdkProvider` mounts it only when
+ * `subscribe` is true; tests default to off to stay deterministic.
+ */
+
+import { useQueryClient } from '@tanstack/react-query';
+import { useEffect } from 'react';
+
+import { startReconnectingSubscription, type SubscriptionHandle } from '../discovery/reconnect.js';
+
+import type { QueryClient } from '@tanstack/react-query';
+
+/**
+ * Event names emitted by `GET /registry/subscribe`. `pillar.snapshot` is
+ * sent once on connect; the other three correspond to registry
+ * mutations (see `apps/pops-core-api/src/modules/registry/event-bus.ts`).
+ */
+export type SubscriptionEventName =
+  | 'pillar.snapshot'
+  | 'pillar.registered'
+  | 'pillar.deregistered'
+  | 'pillar.health-changed';
+
+export interface SubscriptionEvent {
+  readonly event: SubscriptionEventName;
+  readonly data: unknown;
+}
+
+/**
+ * Minimal SSE-shaped source the bridge consumes. Production uses a thin
+ * `EventSource` adapter; tests inject a fake to drive events
+ * synchronously.
+ */
+export interface SubscriptionSource extends SubscriptionHandle {
+  readonly onEvent: (listener: (event: SubscriptionEvent) => void) => () => void;
+}
+
+export type SubscriptionConnect = () => Promise<SubscriptionSource> | SubscriptionSource;
+
+const DEFAULT_REGISTRY_URL = 'http://core-api:3001';
+const SUBSCRIBE_PATH = '/registry/subscribe';
+
+const TRACKED_EVENTS: readonly SubscriptionEventName[] = [
+  'pillar.snapshot',
+  'pillar.registered',
+  'pillar.deregistered',
+  'pillar.health-changed',
+];
+
+export interface UsePillarSubscriptionBridgeOptions {
+  /**
+   * Override the SSE connect factory. When omitted the bridge opens an
+   * `EventSource` against `${registryUrl}${SUBSCRIBE_PATH}`.
+   */
+  readonly connect?: SubscriptionConnect;
+  /** Registry base URL. Defaults to the in-cluster core-api URL. */
+  readonly registryUrl?: string;
+  /** Disable the bridge without unmounting the component. */
+  readonly enabled?: boolean;
+  /** Bubble up reconnect / parse failures. Optional — defaults to console.warn. */
+  readonly onError?: (error: unknown) => void;
+}
+
+/**
+ * Hook that opens the registry SSE stream and routes each frame to
+ * `applySubscriptionEvent`. Cleans up on unmount.
+ *
+ * Intentionally exported so consumers can mount the bridge themselves —
+ * e.g. behind a feature flag — without going through
+ * `<PillarSdkProvider subscribe>`.
+ */
+export function usePillarSubscriptionBridge(
+  options: UsePillarSubscriptionBridgeOptions = {}
+): void {
+  const queryClient = useQueryClient();
+  const {
+    connect: connectOverride,
+    registryUrl = DEFAULT_REGISTRY_URL,
+    enabled = true,
+    onError,
+  } = options;
+
+  useEffect(() => {
+    if (!enabled) return;
+    const connect: SubscriptionConnect =
+      connectOverride ?? (() => openEventSourceSubscription(registryUrl));
+
+    let cancelled = false;
+    const subscription = startReconnectingSubscription({
+      connect: async () => {
+        const source = await connect();
+        const unsubscribeEvents = source.onEvent((event) => {
+          if (cancelled) return;
+          applySubscriptionEvent(queryClient, event);
+        });
+        return {
+          close: () => {
+            unsubscribeEvents();
+            source.close();
+          },
+          onClose: source.onClose,
+        };
+      },
+      fetchSnapshot: () => {
+        return undefined;
+      },
+      onReconnectError: (error: unknown) => {
+        reportError(error, onError);
+      },
+    });
+
+    return () => {
+      cancelled = true;
+      subscription.stop();
+    };
+  }, [queryClient, connectOverride, registryUrl, enabled, onError]);
+}
+
+/**
+ * Pure routing function — exported for tests. Given a subscription
+ * event and a `QueryClient`, applies the cache-invalidation rules
+ * documented at the top of this file.
+ */
+export function applySubscriptionEvent(client: QueryClient, event: SubscriptionEvent): void {
+  switch (event.event) {
+    case 'pillar.registered':
+    case 'pillar.deregistered':
+    case 'pillar.health-changed': {
+      const pillarId = extractPillarId(event.data);
+      if (pillarId === null) return;
+      void client.invalidateQueries({ queryKey: [pillarId] });
+      return;
+    }
+    case 'pillar.snapshot': {
+      const pillarIds = extractSnapshotPillarIds(event.data);
+      if (pillarIds.size === 0) return;
+      void client.invalidateQueries({
+        predicate: (query) => {
+          const first = query.queryKey[0];
+          return typeof first === 'string' && pillarIds.has(first);
+        },
+      });
+      return;
+    }
+  }
+}
+
+function hasStringPillarId(value: unknown): value is { pillarId: string } {
+  if (value === null || typeof value !== 'object') return false;
+  const candidate: unknown = Reflect.get(value, 'pillarId');
+  return typeof candidate === 'string' && candidate.length > 0;
+}
+
+function extractPillarId(data: unknown): string | null {
+  return hasStringPillarId(data) ? data.pillarId : null;
+}
+
+function extractSnapshotPillarIds(data: unknown): ReadonlySet<string> {
+  if (!Array.isArray(data)) return new Set();
+  const ids = new Set<string>();
+  for (const entry of data) {
+    if (hasStringPillarId(entry)) ids.add(entry.pillarId);
+  }
+  return ids;
+}
+
+function reportError(error: unknown, onError?: (error: unknown) => void): void {
+  if (onError) {
+    onError(error);
+    return;
+  }
+  globalThis.console.warn('[pillar-sdk:subscription-bridge] error', error);
+}
+
+/**
+ * Default `EventSource`-backed connect. Lives here so the hook stays
+ * lean and so callers can replace it wholesale via `connect`.
+ */
+function openEventSourceSubscription(registryUrl: string): SubscriptionSource {
+  const url = `${registryUrl.replace(/\/$/, '')}${SUBSCRIBE_PATH}`;
+  const EventSourceCtor = globalThis.EventSource;
+  if (typeof EventSourceCtor !== 'function') {
+    throw new Error(
+      'EventSource is not available in this runtime; pass a custom `connect` to usePillarSubscriptionBridge.'
+    );
+  }
+  const source = new EventSourceCtor(url);
+  const closeListeners = new Set<(reason?: unknown) => void>();
+  const eventListeners = new Set<(event: SubscriptionEvent) => void>();
+  const domListeners: { name: SubscriptionEventName; handler: (e: MessageEvent) => void }[] = [];
+
+  for (const name of TRACKED_EVENTS) {
+    const handler = (e: MessageEvent): void => {
+      const rawData: unknown = e.data;
+      let parsed: unknown = rawData;
+      if (typeof rawData === 'string') {
+        try {
+          parsed = JSON.parse(rawData);
+        } catch {
+          /* keep raw string */
+        }
+      }
+      for (const listener of eventListeners) listener({ event: name, data: parsed });
+    };
+    source.addEventListener(name, handler);
+    domListeners.push({ name, handler });
+  }
+
+  const onSourceError = (): void => {
+    for (const listener of closeListeners) listener();
+  };
+  source.addEventListener('error', onSourceError);
+
+  return {
+    close: (): void => {
+      for (const { name, handler } of domListeners) {
+        source.removeEventListener(name, handler);
+      }
+      source.removeEventListener('error', onSourceError);
+      source.close();
+    },
+    onClose: (listener) => {
+      closeListeners.add(listener);
+      return () => closeListeners.delete(listener);
+    },
+    onEvent: (listener) => {
+      eventListeners.add(listener);
+      return () => eventListeners.delete(listener);
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Wires PRD-163's SSE registry subscription into PRD-193's React Query cache so registry events automatically invalidate stale data on the shell.

- New `usePillarSubscriptionBridge()` opens the SSE stream (via the PRD-164 reconnect helper) and dispatches React Query invalidations.
- `PillarSdkProvider` gains an optional `subscribe` prop (off by default to keep tests deterministic). When set, the bridge is mounted as a hidden child.
- Pure `applySubscriptionEvent(client, event)` exported for testing and per-call routing.

## Invalidation rules

| Event | Invalidates |
|---|---|
| `pillar.registered` | `['<pillarId>']` prefix |
| `pillar.deregistered` | `['<pillarId>']` prefix |
| `pillar.health-changed` | `['<pillarId>']` prefix |
| `pillar.snapshot` (initial connect) | every cache entry whose first key segment is a `pillarId` present in the snapshot |

Malformed payloads are silently dropped (defensive — server is the source of truth, but the bridge does not trust the wire).

## Out of scope (called out by the spec)

- Server-pushed cache updates — bridge just invalidates, React Query refetches.
- Cross-tab broadcast (storage events) — Wave 3+.
- Persisted cache hydration.

## Test plan

- [x] `pnpm test` in `packages/pillar-sdk` — 272 passing (11 new in `subscription-bridge.test.tsx`)
- [x] `mise lint` — 0 errors
- [x] `mise typecheck` — 56/56 successful
- [x] Tests cover: each event type's invalidation rule, malformed payload safety, hook unmount stops dispatches, `enabled=false` short-circuits, and `<PillarSdkProvider subscribe>` mounts/does-not-mount the bridge correctly.