### PR TITLE
feat(pillars): wire bootstrapPillar in media/inventory/cerebrum/food/lists/core (Theme 13 PRD-158)

### DIFF
--- a/apps/pops-cerebrum-api/package.json
+++ b/apps/pops-cerebrum-api/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@pops/cerebrum-db": "workspace:*",
     "@pops/core-db": "workspace:*",
+    "@pops/pillar-sdk": "workspace:*",
     "@pops/types": "workspace:*",
     "@trpc/server": "^11.17.0",
     "drizzle-orm": "^0.45.2",

--- a/apps/pops-cerebrum-api/src/server.ts
+++ b/apps/pops-cerebrum-api/src/server.ts
@@ -12,13 +12,23 @@
  * on the core pillar. The core.db handle MUST be writable — auth
  * touches `service_accounts.last_used_at` per request and `openCoreDb`
  * applies migrations at boot.
+ *
+ * Theme 13 PRD-158 adds an opt-in registry handshake via
+ * `bootstrapPillar`. When `POPS_REGISTRY_ENABLED=true`, the process
+ * builds a hand-rolled cerebrum manifest (PRD-155 will generate this
+ * later) and registers with the central registry on boot. SIGTERM
+ * triggers `pillarHandle.stop()` so the heartbeat clears and the
+ * registry sees an explicit deregister.
  */
 import { openCerebrumDb } from '@pops/cerebrum-db';
 import { openCoreDb } from '@pops/core-db';
+import { bootstrapPillar, type PillarBootstrapHandle } from '@pops/pillar-sdk/bootstrap';
 
 import { createCerebrumApiApp } from './app.js';
 import { resolveCerebrumSqlitePath } from './cerebrum-sqlite-path.js';
 import { resolveCoreSqlitePath } from './core-sqlite-path.js';
+
+import type { ManifestPayload } from '@pops/pillar-sdk/manifest-schema';
 
 function resolvePort(): number {
   const raw = process.env['PORT'];
@@ -30,12 +40,39 @@ function resolvePort(): number {
   return parsed;
 }
 
+function buildCerebrumManifest(version: string): ManifestPayload {
+  return {
+    pillar: 'cerebrum',
+    version,
+    contract: {
+      package: '@pops/cerebrum-contract',
+      version,
+      tag: `contract-cerebrum@v${version}`,
+    },
+    routes: {
+      queries: ['cerebrum.nudges.list', 'cerebrum.nudges.get', 'cerebrum.nudges.contradictions'],
+      mutations: ['cerebrum.nudges.dismiss'],
+      subscriptions: [],
+    },
+    search: { adapters: [] },
+    ai: { tools: [] },
+    uri: { types: [] },
+    settings: { keys: [] },
+    healthcheck: { path: '/health' },
+  };
+}
+
 const port = resolvePort();
 const version = process.env['BUILD_VERSION'] ?? 'dev';
 
 const cerebrumDb = openCerebrumDb(resolveCerebrumSqlitePath());
 const coreDb = openCoreDb(resolveCoreSqlitePath());
 const app = createCerebrumApiApp({ cerebrumDb, coreDb, version });
+
+let pillarHandle: PillarBootstrapHandle | undefined;
+if (process.env['POPS_REGISTRY_ENABLED'] === 'true') {
+  pillarHandle = await bootstrapPillar({ manifest: buildCerebrumManifest(version) });
+}
 
 const server = app.listen(port, () => {
   console.warn(`[cerebrum-api] Listening on port ${port}`);
@@ -46,9 +83,11 @@ function shutdown(signal: NodeJS.Signals): void {
   if (shuttingDown) return;
   shuttingDown = true;
   console.warn(`[cerebrum-api] Shutting down (${signal})`);
-  server.close(() => {
-    cerebrumDb.raw.close();
-    coreDb.raw.close();
+  void (pillarHandle?.stop() ?? Promise.resolve()).finally(() => {
+    server.close(() => {
+      cerebrumDb.raw.close();
+      coreDb.raw.close();
+    });
   });
 }
 

--- a/apps/pops-core-api/src/server.ts
+++ b/apps/pops-core-api/src/server.ts
@@ -9,14 +9,25 @@
  * The process opens its OWN core.db connection via `openCoreDb` rather
  * than reaching back into pops-api's singleton — that's the whole point
  * of phase 3.
+ *
+ * Theme 13 PRD-158 adds an opt-in registry handshake via
+ * `bootstrapPillar`. When `POPS_REGISTRY_ENABLED=true`, the process
+ * builds a hand-rolled core manifest (PRD-155 will generate this
+ * later) and registers with its OWN registry on boot — same loop the
+ * other pillars use, just pointed at localhost. SIGTERM triggers
+ * `pillarHandle.stop()` so the heartbeat clears and the registry sees
+ * an explicit deregister before the HTTP server shuts down.
  */
 import { openCoreDb } from '@pops/core-db';
+import { bootstrapPillar, type PillarBootstrapHandle } from '@pops/pillar-sdk/bootstrap';
 
 import { createCoreApiApp } from './app.js';
 import { resolveCoreSqlitePath } from './core-sqlite-path.js';
 import { reconcileRegistryOnBoot } from './modules/registry/boot.js';
 import { startHeartbeatTicker } from './modules/registry/ticker.js';
 import { parseBareOrigin } from './pillars/env.js';
+
+import type { ManifestPayload } from '@pops/pillar-sdk/manifest-schema';
 
 function resolvePort(): number {
   const raw = process.env['PORT'];
@@ -26,6 +37,34 @@ function resolvePort(): number {
     throw new Error(`[core-api] PORT must be a positive integer in 1-65535; got '${raw}'`);
   }
   return parsed;
+}
+
+function buildCoreManifest(version: string): ManifestPayload {
+  return {
+    pillar: 'core',
+    version,
+    contract: {
+      package: '@pops/core-contract',
+      version,
+      tag: `contract-core@v${version}`,
+    },
+    routes: {
+      queries: ['core.registry.list', 'core.registry.get', 'core.serviceAccounts.list'],
+      mutations: [
+        'core.registry.register',
+        'core.registry.deregister',
+        'core.registry.heartbeat',
+        'core.serviceAccounts.create',
+        'core.serviceAccounts.revoke',
+      ],
+      subscriptions: [],
+    },
+    search: { adapters: [] },
+    ai: { tools: [] },
+    uri: { types: [] },
+    settings: { keys: [] },
+    healthcheck: { path: '/health' },
+  };
 }
 
 const port = resolvePort();
@@ -51,14 +90,26 @@ const server = app.listen(port, () => {
 
 const stopHeartbeatTicker = startHeartbeatTicker(coreDb.db);
 
+// The bootstrap handshake registers core with its own registry once the
+// HTTP server is accepting traffic. Done after `app.listen` because the
+// SDK transport posts to `${registryUrl}/registry/...` and the registry
+// lives in this very process — registering before listen would race the
+// HTTP server up.
+let pillarHandle: PillarBootstrapHandle | undefined;
+if (process.env['POPS_REGISTRY_ENABLED'] === 'true') {
+  pillarHandle = await bootstrapPillar({ manifest: buildCoreManifest(version) });
+}
+
 let shuttingDown = false;
 function shutdown(signal: NodeJS.Signals): void {
   if (shuttingDown) return;
   shuttingDown = true;
   console.warn(`[core-api] Shutting down (${signal})`);
   stopHeartbeatTicker();
-  server.close(() => {
-    coreDb.raw.close();
+  void (pillarHandle?.stop() ?? Promise.resolve()).finally(() => {
+    server.close(() => {
+      coreDb.raw.close();
+    });
   });
 }
 

--- a/apps/pops-food-api/package.json
+++ b/apps/pops-food-api/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@pops/food-db": "workspace:*",
+    "@pops/pillar-sdk": "workspace:*",
     "@pops/types": "workspace:*",
     "express": "^5.1.0"
   },

--- a/apps/pops-food-api/src/server.ts
+++ b/apps/pops-food-api/src/server.ts
@@ -9,12 +9,26 @@
  * The process opens its OWN `food.db` connection via `openFoodDb`
  * rather than reaching back into pops-api's singleton — that's the
  * whole point of phase 3.
+ *
+ * Theme 13 PRD-158 adds an opt-in registry handshake via
+ * `bootstrapPillar`. When `POPS_REGISTRY_ENABLED=true`, the process
+ * builds a hand-rolled food manifest (PRD-155 will generate this
+ * later) and registers with the central registry on boot. SIGTERM
+ * triggers `pillarHandle.stop()` so the heartbeat clears and the
+ * registry sees an explicit deregister.
+ *
+ * The runtime tRPC surface is still pending, so `routes.queries`
+ * and `routes.mutations` are empty for now — bootstrap registers
+ * the pillar's identity, health probe, and contract pin.
  */
 import { openFoodDb } from '@pops/food-db';
+import { bootstrapPillar, type PillarBootstrapHandle } from '@pops/pillar-sdk/bootstrap';
 
 import { createFoodApiApp } from './app.js';
 import { resolveFoodSqlitePath } from './food-sqlite-path.js';
 import { parseBareOrigin } from './pillars/env.js';
+
+import type { ManifestPayload } from '@pops/pillar-sdk/manifest-schema';
 
 function resolvePort(): number {
   // 3001 is core-api, 3002 is inventory-api, 3003 is media-api,
@@ -26,6 +40,24 @@ function resolvePort(): number {
     throw new Error(`[food-api] PORT must be a positive integer in 1-65535; got '${raw}'`);
   }
   return parsed;
+}
+
+function buildFoodManifest(version: string): ManifestPayload {
+  return {
+    pillar: 'food',
+    version,
+    contract: {
+      package: '@pops/food-contracts',
+      version,
+      tag: `contract-food@v${version}`,
+    },
+    routes: { queries: [], mutations: [], subscriptions: [] },
+    search: { adapters: [] },
+    ai: { tools: [] },
+    uri: { types: [] },
+    settings: { keys: [] },
+    healthcheck: { path: '/health' },
+  };
 }
 
 const port = resolvePort();
@@ -55,6 +87,11 @@ const selfBaseUrl = resolveSelfBaseUrl();
 const foodDb = openFoodDb(resolveFoodSqlitePath());
 const app = createFoodApiApp({ foodDb, version, selfBaseUrl });
 
+let pillarHandle: PillarBootstrapHandle | undefined;
+if (process.env['POPS_REGISTRY_ENABLED'] === 'true') {
+  pillarHandle = await bootstrapPillar({ manifest: buildFoodManifest(version) });
+}
+
 const server = app.listen(port, () => {
   console.warn(`[food-api] Listening on port ${port}`);
 });
@@ -64,8 +101,10 @@ function shutdown(signal: NodeJS.Signals): void {
   if (shuttingDown) return;
   shuttingDown = true;
   console.warn(`[food-api] Shutting down (${signal})`);
-  server.close(() => {
-    foodDb.raw.close();
+  void (pillarHandle?.stop() ?? Promise.resolve()).finally(() => {
+    server.close(() => {
+      foodDb.raw.close();
+    });
   });
 }
 

--- a/apps/pops-inventory-api/package.json
+++ b/apps/pops-inventory-api/package.json
@@ -20,6 +20,7 @@
     "@pops/core-db": "workspace:*",
     "@pops/db-types": "workspace:*",
     "@pops/inventory-db": "workspace:*",
+    "@pops/pillar-sdk": "workspace:*",
     "@pops/types": "workspace:*",
     "@trpc/server": "^11.17.0",
     "express": "^5.1.0",

--- a/apps/pops-inventory-api/src/server.ts
+++ b/apps/pops-inventory-api/src/server.ts
@@ -9,14 +9,24 @@
  * The process opens its OWN `inventory.db` connection via
  * `openInventoryDb` rather than reaching back into pops-api's
  * singleton — that's the whole point of phase 3.
+ *
+ * Theme 13 PRD-158 adds an opt-in registry handshake via
+ * `bootstrapPillar`. When `POPS_REGISTRY_ENABLED=true`, the process
+ * builds a hand-rolled inventory manifest (PRD-155 will generate this
+ * later) and registers with the central registry on boot. SIGTERM
+ * triggers `pillarHandle.stop()` so the heartbeat clears and the
+ * registry sees an explicit deregister.
  */
 import { openCoreDb } from '@pops/core-db';
 import { openInventoryDb } from '@pops/inventory-db';
+import { bootstrapPillar, type PillarBootstrapHandle } from '@pops/pillar-sdk/bootstrap';
 
 import { createInventoryApiApp } from './app.js';
 import { resolveCoreSqlitePath } from './core-sqlite-path.js';
 import { resolveInventorySqlitePath } from './inventory-sqlite-path.js';
 import { parseBareOrigin } from './pillars/env.js';
+
+import type { ManifestPayload } from '@pops/pillar-sdk/manifest-schema';
 
 function resolvePort(): number {
   const raw = process.env['PORT'];
@@ -26,6 +36,39 @@ function resolvePort(): number {
     throw new Error(`[inventory-api] PORT must be a positive integer in 1-65535; got '${raw}'`);
   }
   return parsed;
+}
+
+function buildInventoryManifest(version: string): ManifestPayload {
+  return {
+    pillar: 'inventory',
+    version,
+    contract: {
+      package: '@pops/inventory-contract',
+      version,
+      tag: `contract-inventory@v${version}`,
+    },
+    routes: {
+      queries: [
+        'inventory.locations.tree',
+        'inventory.locations.list',
+        'inventory.locations.get',
+        'inventory.locations.getPath',
+        'inventory.locations.children',
+        'inventory.locations.deleteStats',
+      ],
+      mutations: [
+        'inventory.locations.create',
+        'inventory.locations.update',
+        'inventory.locations.delete',
+      ],
+      subscriptions: [],
+    },
+    search: { adapters: [] },
+    ai: { tools: [] },
+    uri: { types: [] },
+    settings: { keys: [] },
+    healthcheck: { path: '/health' },
+  };
 }
 
 const port = resolvePort();
@@ -56,6 +99,11 @@ const inventoryDb = openInventoryDb(resolveInventorySqlitePath());
 const coreDb = openCoreDb(resolveCoreSqlitePath());
 const app = createInventoryApiApp({ inventoryDb, coreDb, version, selfBaseUrl });
 
+let pillarHandle: PillarBootstrapHandle | undefined;
+if (process.env['POPS_REGISTRY_ENABLED'] === 'true') {
+  pillarHandle = await bootstrapPillar({ manifest: buildInventoryManifest(version) });
+}
+
 const server = app.listen(port, () => {
   console.warn(`[inventory-api] Listening on port ${port}`);
 });
@@ -65,9 +113,11 @@ function shutdown(signal: NodeJS.Signals): void {
   if (shuttingDown) return;
   shuttingDown = true;
   console.warn(`[inventory-api] Shutting down (${signal})`);
-  server.close(() => {
-    inventoryDb.raw.close();
-    coreDb.raw.close();
+  void (pillarHandle?.stop() ?? Promise.resolve()).finally(() => {
+    server.close(() => {
+      inventoryDb.raw.close();
+      coreDb.raw.close();
+    });
   });
 }
 

--- a/apps/pops-lists-api/package.json
+++ b/apps/pops-lists-api/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@pops/lists-db": "workspace:*",
+    "@pops/pillar-sdk": "workspace:*",
     "@pops/types": "workspace:*",
     "express": "^5.1.0"
   },

--- a/apps/pops-lists-api/src/server.ts
+++ b/apps/pops-lists-api/src/server.ts
@@ -9,12 +9,26 @@
  * The process opens its OWN `lists.db` connection via `openListsDb`
  * rather than reaching back into pops-api's singleton — that's the
  * whole point of phase 3.
+ *
+ * Theme 13 PRD-158 adds an opt-in registry handshake via
+ * `bootstrapPillar`. When `POPS_REGISTRY_ENABLED=true`, the process
+ * builds a hand-rolled lists manifest (PRD-155 will generate this
+ * later) and registers with the central registry on boot. SIGTERM
+ * triggers `pillarHandle.stop()` so the heartbeat clears and the
+ * registry sees an explicit deregister.
+ *
+ * The runtime tRPC surface is still pending, so `routes.queries`
+ * and `routes.mutations` are empty for now — bootstrap registers
+ * the pillar's identity, health probe, and contract pin.
  */
 import { openListsDb } from '@pops/lists-db';
+import { bootstrapPillar, type PillarBootstrapHandle } from '@pops/pillar-sdk/bootstrap';
 
 import { createListsApiApp } from './app.js';
 import { resolveListsSqlitePath } from './lists-sqlite-path.js';
 import { parseBareOrigin } from './pillars/env.js';
+
+import type { ManifestPayload } from '@pops/pillar-sdk/manifest-schema';
 
 function resolvePort(): number {
   // 3001 is core-api, 3002 is inventory-api, 3003 is media-api,
@@ -27,6 +41,24 @@ function resolvePort(): number {
     throw new Error(`[lists-api] PORT must be a positive integer in 1-65535; got '${raw}'`);
   }
   return parsed;
+}
+
+function buildListsManifest(version: string): ManifestPayload {
+  return {
+    pillar: 'lists',
+    version,
+    contract: {
+      package: '@pops/lists-contract',
+      version,
+      tag: `contract-lists@v${version}`,
+    },
+    routes: { queries: [], mutations: [], subscriptions: [] },
+    search: { adapters: [] },
+    ai: { tools: [] },
+    uri: { types: [] },
+    settings: { keys: [] },
+    healthcheck: { path: '/health' },
+  };
 }
 
 const port = resolvePort();
@@ -56,6 +88,11 @@ const selfBaseUrl = resolveSelfBaseUrl();
 const listsDb = openListsDb(resolveListsSqlitePath());
 const app = createListsApiApp({ listsDb, version, selfBaseUrl });
 
+let pillarHandle: PillarBootstrapHandle | undefined;
+if (process.env['POPS_REGISTRY_ENABLED'] === 'true') {
+  pillarHandle = await bootstrapPillar({ manifest: buildListsManifest(version) });
+}
+
 const server = app.listen(port, () => {
   console.warn(`[lists-api] Listening on port ${port}`);
 });
@@ -65,8 +102,10 @@ function shutdown(signal: NodeJS.Signals): void {
   if (shuttingDown) return;
   shuttingDown = true;
   console.warn(`[lists-api] Shutting down (${signal})`);
-  server.close(() => {
-    listsDb.raw.close();
+  void (pillarHandle?.stop() ?? Promise.resolve()).finally(() => {
+    server.close(() => {
+      listsDb.raw.close();
+    });
   });
 }
 

--- a/apps/pops-media-api/package.json
+++ b/apps/pops-media-api/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@pops/media-db": "workspace:*",
+    "@pops/pillar-sdk": "workspace:*",
     "@pops/types": "workspace:*",
     "@trpc/server": "^11.17.0",
     "express": "^5.1.0",

--- a/apps/pops-media-api/src/server.ts
+++ b/apps/pops-media-api/src/server.ts
@@ -9,11 +9,21 @@
  * The process opens its OWN `media.db` connection via `openMediaDb`
  * rather than reaching back into pops-api's singleton — that's the whole
  * point of phase 3. Mirrors `apps/pops-core-api/src/server.ts`.
+ *
+ * Theme 13 PRD-158 adds an opt-in registry handshake via
+ * `bootstrapPillar`. When `POPS_REGISTRY_ENABLED=true`, the process
+ * builds a hand-rolled media manifest (PRD-155 will generate this
+ * later) and registers with the central registry on boot. SIGTERM
+ * triggers `pillarHandle.stop()` so the heartbeat clears and the
+ * registry sees an explicit deregister.
  */
 import { openMediaDb, shelfImpressionsService } from '@pops/media-db';
+import { bootstrapPillar, type PillarBootstrapHandle } from '@pops/pillar-sdk/bootstrap';
 
 import { createMediaApiApp } from './app.js';
 import { resolveMediaSqlitePath } from './media-sqlite-path.js';
+
+import type { ManifestPayload } from '@pops/pillar-sdk/manifest-schema';
 
 function resolvePort(): number {
   // 3001 is core-api, 3002 is inventory-api, 3003 is media-api.
@@ -26,6 +36,31 @@ function resolvePort(): number {
   return parsed;
 }
 
+function buildMediaManifest(version: string): ManifestPayload {
+  return {
+    pillar: 'media',
+    version,
+    contract: {
+      package: '@pops/media-contract',
+      version,
+      tag: `contract-media@v${version}`,
+    },
+    routes: {
+      queries: [
+        'media.shelfImpressions.getRecentImpressions',
+        'media.shelfImpressions.getShelfFreshness',
+      ],
+      mutations: ['media.shelfImpressions.recordImpressions', 'media.shelfImpressions.cleanup'],
+      subscriptions: [],
+    },
+    search: { adapters: [] },
+    ai: { tools: [] },
+    uri: { types: [] },
+    settings: { keys: [] },
+    healthcheck: { path: '/health' },
+  };
+}
+
 const port = resolvePort();
 const version = process.env['BUILD_VERSION'] ?? 'dev';
 
@@ -36,6 +71,11 @@ const mediaDb = openMediaDb(resolveMediaSqlitePath());
 shelfImpressionsService.initImpressionsService(mediaDb.db);
 const app = createMediaApiApp({ mediaDb, version });
 
+let pillarHandle: PillarBootstrapHandle | undefined;
+if (process.env['POPS_REGISTRY_ENABLED'] === 'true') {
+  pillarHandle = await bootstrapPillar({ manifest: buildMediaManifest(version) });
+}
+
 const server = app.listen(port, () => {
   console.warn(`[media-api] Listening on port ${port}`);
 });
@@ -45,8 +85,10 @@ function shutdown(signal: NodeJS.Signals): void {
   if (shuttingDown) return;
   shuttingDown = true;
   console.warn(`[media-api] Shutting down (${signal})`);
-  server.close(() => {
-    mediaDb.raw.close();
+  void (pillarHandle?.stop() ?? Promise.resolve()).finally(() => {
+    server.close(() => {
+      mediaDb.raw.close();
+    });
   });
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -235,6 +235,9 @@ importers:
       '@pops/core-db':
         specifier: workspace:*
         version: link:../../packages/core-db
+      '@pops/pillar-sdk':
+        specifier: workspace:*
+        version: link:../../packages/pillar-sdk
       '@pops/types':
         specifier: workspace:*
         version: link:../../packages/types
@@ -443,6 +446,9 @@ importers:
       '@pops/food-db':
         specifier: workspace:*
         version: link:../../packages/food-db
+      '@pops/pillar-sdk':
+        specifier: workspace:*
+        version: link:../../packages/pillar-sdk
       '@pops/types':
         specifier: workspace:*
         version: link:../../packages/types
@@ -486,6 +492,9 @@ importers:
       '@pops/inventory-db':
         specifier: workspace:*
         version: link:../../packages/inventory-db
+      '@pops/pillar-sdk':
+        specifier: workspace:*
+        version: link:../../packages/pillar-sdk
       '@pops/types':
         specifier: workspace:*
         version: link:../../packages/types
@@ -535,6 +544,9 @@ importers:
       '@pops/lists-db':
         specifier: workspace:*
         version: link:../../packages/lists-db
+      '@pops/pillar-sdk':
+        specifier: workspace:*
+        version: link:../../packages/pillar-sdk
       '@pops/types':
         specifier: workspace:*
         version: link:../../packages/types
@@ -606,6 +618,9 @@ importers:
       '@pops/media-db':
         specifier: workspace:*
         version: link:../../packages/media-db
+      '@pops/pillar-sdk':
+        specifier: workspace:*
+        version: link:../../packages/pillar-sdk
       '@pops/types':
         specifier: workspace:*
         version: link:../../packages/types


### PR DESCRIPTION
## Summary

Theme 13 PRD-158 rollout. Finance already calls `bootstrapPillar()` on main; this PR mirrors that wiring across the other 6 pillar APIs so every pillar registers with the core registry on boot when `POPS_REGISTRY_ENABLED=true`.

Each pillar's `server.ts` now:
- Imports `bootstrapPillar` + `ManifestPayload` from `@pops/pillar-sdk`
- Defines a `build{Pillar}Manifest(version)` helper with the standard fields (pillar, version, contract block, routes, search, ai, uri, settings, healthcheck)
- Gates the bootstrap call behind `process.env['POPS_REGISTRY_ENABLED'] === 'true'`
- Wires SIGTERM/SIGINT → `pillarHandle?.stop()` → `server.close()` so heartbeats clear cleanly on shutdown

The manifest payload is hand-built per pillar — deriving it from the contract package is PRD-155 follow-up.

## Pillars wired

- `pops-media-api` (port 3003) — `media.shelfImpressions.*` queries + mutations
- `pops-inventory-api` (port 3002) — `inventory.locations.*` queries + mutations
- `pops-cerebrum-api` (port 3007) — `cerebrum.nudges.*` queries + mutation
- `pops-food-api` (port 3005) — no runtime tRPC surface yet, empty routes (bootstrap still wires identity + health + contract pin)
- `pops-lists-api` (port 3006) — same as food, empty routes
- `pops-core-api` (port 3001) — `core.registry.*` + `core.serviceAccounts.*`; bootstrap runs **after** `app.listen` since core is the registry itself and would race the HTTP server up otherwise; pre-existing `reconcileRegistryOnBoot` + `startHeartbeatTicker` remain untouched

No pillars skipped — all 6 followed the finance shape.

## Test plan
- [x] `pnpm typecheck` (65/65)
- [x] `pnpm lint` (no new errors; only pre-existing warnings)
- [x] `pnpm --filter @pops/{media,inventory,cerebrum,food,lists,core}-api test` (147 tests passed)
- [ ] Manual smoke: boot each pillar with `POPS_REGISTRY_ENABLED=true` and confirm `core.registry.list` shows the entry