### PR TITLE
ci(_pkg-check): build pillar-sdk after all *-contract packages

### DIFF
--- a/.github/workflows/_pkg-check.yml
+++ b/.github/workflows/_pkg-check.yml
@@ -55,7 +55,6 @@ jobs:
           pnpm --filter @pops/lists-db build
           pnpm --filter @pops/app-lists-db build
           pnpm --filter @pops/app-food-db build
-          pnpm --filter @pops/pillar-sdk build
           pnpm --filter @pops/finance-contract build
           pnpm --filter @pops/media-contract build
           pnpm --filter @pops/inventory-contract build
@@ -63,6 +62,7 @@ jobs:
           pnpm --filter @pops/core-contract build
           pnpm --filter @pops/lists-contract build
           pnpm --filter @pops/food-contract build
+          pnpm --filter @pops/pillar-sdk build
       - run: cd ${{ inputs.package-path }} && pnpm typecheck
         if: inputs.skip != 'true'
 
@@ -101,7 +101,6 @@ jobs:
           pnpm --filter @pops/lists-db build
           pnpm --filter @pops/app-lists-db build
           pnpm --filter @pops/app-food-db build
-          pnpm --filter @pops/pillar-sdk build
           pnpm --filter @pops/finance-contract build
           pnpm --filter @pops/media-contract build
           pnpm --filter @pops/inventory-contract build
@@ -109,6 +108,7 @@ jobs:
           pnpm --filter @pops/core-contract build
           pnpm --filter @pops/lists-contract build
           pnpm --filter @pops/food-contract build
+          pnpm --filter @pops/pillar-sdk build
       - name: Run tests (with coverage if configured)
         if: inputs.skip != 'true'
         run: |


### PR DESCRIPTION
## Problem

Same root cause as #2969: `pillar-sdk`'s `src/contracts/index.ts` (PRD-195) re-exports types from `@pops/finance-contract` subpaths. Building pillar-sdk first fails with `Cannot find module @pops/finance-contract/manifest`.

`#2969` fixed this in `contract-semver.yml`; `_pkg-check.yml` (used by every per-pillar quality workflow) still had the wrong order. Caught by #2974 (PRD-158 bootstrap rollout).

## Fix

Move `pillar-sdk build` after all `*-contract build` lines in both the typecheck and test jobs.

## Test plan

- [ ] CI on this PR runs cleanly.
- [ ] After merge, #2974 rebased + CI green.