### PR TITLE
feat(api-client): splitLink routes per-pillar calls (Theme 13 PRD-187)

### DIFF
--- a/apps/pops-shell/vite.config.ts
+++ b/apps/pops-shell/vite.config.ts
@@ -69,6 +69,17 @@ export default defineConfig({
         changeOrigin: true,
         // Don't rewrite — tRPC expects /trpc prefix
       },
+      // PRD-187 splitLink routes per-pillar batches through dedicated URL
+      // prefixes. While the legacy monolith still serves every router on
+      // /trpc, the dev proxy rewrites `/trpc-<pillar>` back to `/trpc` so
+      // existing endpoints keep answering. Once per-pillar APIs run as
+      // separate processes the rewrite goes away and each prefix targets
+      // its own upstream.
+      '^/trpc-(core|finance|media|inventory|cerebrum|food|lists)': {
+        target: 'http://localhost:3000',
+        changeOrigin: true,
+        rewrite: (urlPath: string) => urlPath.replace(/^\/trpc-[^/]+/, '/trpc'),
+      },
       '/media/images': {
         target: 'http://localhost:3000',
         changeOrigin: true,

--- a/apps/pops-shell/vite.config.ts
+++ b/apps/pops-shell/vite.config.ts
@@ -64,14 +64,13 @@ export default defineConfig({
       host: 'localhost',
     },
     proxy: {
-      '/trpc': {
-        target: 'http://localhost:3000',
-        changeOrigin: true,
-        // Don't rewrite — tRPC expects /trpc prefix
-      },
       // PRD-187 splitLink routes per-pillar batches through dedicated URL
-      // prefixes. While the legacy monolith still serves every router on
-      // /trpc, the dev proxy rewrites `/trpc-<pillar>` back to `/trpc` so
+      // prefixes. The per-pillar rule MUST come before the bare `/trpc`
+      // rule because Vite's `proxy` is a regex-first / prefix-match
+      // dispatcher and `/trpc` is a prefix of `/trpc-<pillar>`; if the
+      // bare rule is listed first it wins and the rewrite never fires.
+      // While the legacy monolith still serves every router on /trpc,
+      // the dev proxy rewrites `/trpc-<pillar>` back to `/trpc` so
       // existing endpoints keep answering. Once per-pillar APIs run as
       // separate processes the rewrite goes away and each prefix targets
       // its own upstream.
@@ -79,6 +78,11 @@ export default defineConfig({
         target: 'http://localhost:3000',
         changeOrigin: true,
         rewrite: (urlPath: string) => urlPath.replace(/^\/trpc-[^/]+/, '/trpc'),
+      },
+      '/trpc': {
+        target: 'http://localhost:3000',
+        changeOrigin: true,
+        // Don't rewrite — tRPC expects /trpc prefix
       },
       '/media/images': {
         target: 'http://localhost:3000',

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -16,6 +16,7 @@
     "@trpc/react-query": "11.17.0"
   },
   "devDependencies": {
+    "@trpc/server": "11.17.0",
     "typescript": "^6.0.3",
     "vitest": "^4.1.8"
   },

--- a/packages/api-client/src/__tests__/split-link.test.ts
+++ b/packages/api-client/src/__tests__/split-link.test.ts
@@ -1,0 +1,182 @@
+import { observable } from '@trpc/server/observable';
+import { describe, expect, it } from 'vitest';
+
+import {
+  LEGACY_TRPC_URL,
+  PILLAR_TRPC_URLS,
+  createPillarSplitLink,
+  pillarOfPath,
+} from '../split-link.js';
+
+import type { Operation, OperationLink, TRPCClientRuntime, TRPCLink } from '@trpc/client';
+
+import type { AppRouter } from '@pops/api';
+
+interface DispatchRecord {
+  readonly url: string;
+  readonly path: string;
+}
+
+interface RecordingHarness {
+  readonly link: TRPCLink<AppRouter>;
+  readonly records: DispatchRecord[];
+}
+
+function buildRecordingHarness(): RecordingHarness {
+  const records: DispatchRecord[] = [];
+  const link = createPillarSplitLink({
+    linkFor:
+      (url) =>
+      () =>
+      ({ op }) =>
+        observable((observer) => {
+          records.push({ url, path: op.path });
+          observer.next({ result: { type: 'data', data: { ok: true } } });
+          observer.complete();
+        }),
+  });
+  return { link, records };
+}
+
+const identity = <T>(v: T): T => v;
+const RUNTIME: TRPCClientRuntime = {
+  transformer: {
+    input: { serialize: identity, deserialize: identity },
+    output: { serialize: identity, deserialize: identity },
+  },
+};
+
+function makeOp(path: string, id: number): Operation {
+  return {
+    id,
+    type: 'query',
+    input: undefined,
+    path,
+    context: {},
+    signal: null,
+  };
+}
+
+function dispatch(link: TRPCLink<AppRouter>, op: Operation): void {
+  const handler: OperationLink<AppRouter> = link(RUNTIME);
+  const result$ = handler({
+    op,
+    next: () => {
+      throw new Error('terminal link should not call next');
+    },
+  });
+  const sub = result$.subscribe({});
+  sub.unsubscribe();
+}
+
+describe('pillarOfPath', () => {
+  it('returns the namespace when it is a known pillar', () => {
+    expect(pillarOfPath('finance.wishlist.list')).toBe('finance');
+    expect(pillarOfPath('media.movies.get')).toBe('media');
+    expect(pillarOfPath('core.health')).toBe('core');
+  });
+
+  it('returns null for unprefixed paths', () => {
+    expect(pillarOfPath('health')).toBeNull();
+  });
+
+  it('returns null for paths prefixed with a non-pillar namespace', () => {
+    expect(pillarOfPath('pops.health')).toBeNull();
+    expect(pillarOfPath('debug.ping')).toBeNull();
+  });
+
+  it('returns null for empty input', () => {
+    expect(pillarOfPath('')).toBeNull();
+  });
+});
+
+describe('createPillarSplitLink', () => {
+  it('routes finance.* operations to the finance URL', () => {
+    const { link, records } = buildRecordingHarness();
+
+    dispatch(link, makeOp('finance.wishlist.list', 1));
+
+    expect(records).toEqual([{ url: PILLAR_TRPC_URLS.finance, path: 'finance.wishlist.list' }]);
+  });
+
+  it('routes media.* operations to the media URL', () => {
+    const { link, records } = buildRecordingHarness();
+
+    dispatch(link, makeOp('media.movies.get', 7));
+
+    expect(records).toEqual([{ url: PILLAR_TRPC_URLS.media, path: 'media.movies.get' }]);
+  });
+
+  it('routes a mix of core and finance ops to two distinct URLs', () => {
+    const { link, records } = buildRecordingHarness();
+
+    dispatch(link, makeOp('core.foo', 1));
+    dispatch(link, makeOp('finance.bar', 2));
+
+    expect(records).toEqual([
+      { url: PILLAR_TRPC_URLS.core, path: 'core.foo' },
+      { url: PILLAR_TRPC_URLS.finance, path: 'finance.bar' },
+    ]);
+    const urls = new Set(records.map((r) => r.url));
+    expect(urls.size).toBe(2);
+  });
+
+  it('routes unprefixed paths to the legacy URL', () => {
+    const { link, records } = buildRecordingHarness();
+
+    dispatch(link, makeOp('health', 1));
+
+    expect(records).toEqual([{ url: LEGACY_TRPC_URL, path: 'health' }]);
+  });
+
+  it('routes paths with an unknown namespace to the legacy URL', () => {
+    const { link, records } = buildRecordingHarness();
+
+    dispatch(link, makeOp('pops.health', 1));
+    dispatch(link, makeOp('debug.ping', 2));
+
+    expect(records).toEqual([
+      { url: LEGACY_TRPC_URL, path: 'pops.health' },
+      { url: LEGACY_TRPC_URL, path: 'debug.ping' },
+    ]);
+  });
+
+  it('routes every known pillar to its dedicated URL', () => {
+    const { link, records } = buildRecordingHarness();
+    const cases = Object.entries(PILLAR_TRPC_URLS) as [keyof typeof PILLAR_TRPC_URLS, string][];
+
+    cases.forEach(([pillar], index) => {
+      dispatch(link, makeOp(`${pillar}.thing`, index + 1));
+    });
+
+    expect(records).toEqual(cases.map(([pillar, url]) => ({ url, path: `${pillar}.thing` })));
+  });
+
+  it('honours overridden pillar and legacy URLs', () => {
+    const records: DispatchRecord[] = [];
+    const link = createPillarSplitLink({
+      pillarUrls: {
+        ...PILLAR_TRPC_URLS,
+        finance: 'http://finance-api:3004/trpc',
+      },
+      legacyUrl: 'http://legacy:3000/trpc',
+      linkFor:
+        (url) =>
+        () =>
+        ({ op }) =>
+          observable((observer) => {
+            records.push({ url, path: op.path });
+            observer.next({ result: { type: 'data', data: { ok: true } } });
+            observer.complete();
+          }),
+    });
+
+    dispatch(link, makeOp('finance.x', 1));
+    dispatch(link, makeOp('unknown.y', 2));
+
+    expect(records).toEqual([
+      { url: 'http://finance-api:3004/trpc', path: 'finance.x' },
+      { url: 'http://legacy:3000/trpc', path: 'unknown.y' },
+    ]);
+  });
+});

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -1,5 +1,6 @@
-import { httpBatchLink } from '@trpc/client';
 import { createTRPCReact } from '@trpc/react-query';
+
+import { createPillarSplitLink } from './split-link.js';
 
 /**
  * Shared tRPC client for all app packages.
@@ -42,15 +43,17 @@ function fetchWithTimeout(input: RequestInfo | URL, init?: RequestInit): Promise
 }
 
 /**
- * tRPC client instance with httpBatchLink.
- * Batches multiple requests into a single HTTP call for better performance.
- * The shell passes this to <trpc.Provider>.
+ * tRPC client instance with a per-pillar splitLink (PRD-187).
+ *
+ * Each pillar's procedures route to their own batched URL
+ * (`/trpc-<pillar>`); non-pillar procedures keep flowing to the legacy
+ * `/trpc` endpoint. No batch URL ever spans more than one pillar, so the
+ * legacy nginx procedure-path regex rules can be retired once PRD-190
+ * lands.
  */
 export const trpcClient = trpc.createClient({
   links: [
-    httpBatchLink({
-      url: '/trpc', // Proxied by Vite to localhost:3000 in dev
-      maxURLLength: 2083,
+    createPillarSplitLink({
       fetch: fetchWithTimeout,
     }),
   ],
@@ -105,3 +108,10 @@ export type {
   BatchableOp,
   LegacyBatchTarget,
 } from './batching-invariants.js';
+export {
+  createPillarSplitLink,
+  pillarOfPath,
+  PILLAR_TRPC_URLS,
+  LEGACY_TRPC_URL,
+} from './split-link.js';
+export type { CreateSplitLinkOptions, TerminalLinkFactory } from './split-link.js';

--- a/packages/api-client/src/split-link.ts
+++ b/packages/api-client/src/split-link.ts
@@ -1,6 +1,6 @@
 import { httpBatchLink, splitLink } from '@trpc/client';
 
-import { PILLARS, type KnownPillarId } from '@pops/pillar-sdk';
+import { PILLARS, type KnownPillarId } from '@pops/pillar-sdk/capabilities';
 
 import type { Operation, TRPCLink } from '@trpc/client';
 

--- a/packages/api-client/src/split-link.ts
+++ b/packages/api-client/src/split-link.ts
@@ -1,0 +1,114 @@
+import { httpBatchLink, splitLink } from '@trpc/client';
+
+import { PILLARS, type KnownPillarId } from '@pops/pillar-sdk';
+
+import type { Operation, TRPCLink } from '@trpc/client';
+
+import type { AppRouter } from '@pops/api';
+
+/**
+ * tRPC URL prefix per pillar. Each pillar's API serves at its own URL so
+ * nginx can do a simple prefix match (no regex on procedure paths) and so
+ * the client batcher never assembles a batch URL targeting more than one
+ * pillar at a time.
+ *
+ * The shell consumes these as Vite proxy paths in dev; nginx maps the same
+ * prefixes to per-pillar upstreams in production. A future PRD (217) will
+ * generate this map from the pillar registry.
+ */
+export const PILLAR_TRPC_URLS: Readonly<Record<KnownPillarId, string>> = {
+  core: '/trpc-core',
+  finance: '/trpc-finance',
+  media: '/trpc-media',
+  inventory: '/trpc-inventory',
+  cerebrum: '/trpc-cerebrum',
+  food: '/trpc-food',
+  lists: '/trpc-lists',
+};
+
+/** Legacy pops-api URL — catches every procedure that isn't pillar-prefixed. */
+export const LEGACY_TRPC_URL = '/trpc';
+
+const PILLAR_SET: ReadonlySet<string> = new Set(PILLARS);
+
+function isKnownPillarId(value: string): value is KnownPillarId {
+  return PILLAR_SET.has(value);
+}
+
+/**
+ * Returns the pillar id encoded in the first segment of a tRPC procedure
+ * path, or `null` if the first segment is not a known pillar.
+ *
+ * @example
+ *   pillarOfPath('finance.wishlist.list') // 'finance'
+ *   pillarOfPath('health')                // null
+ *   pillarOfPath('pops.health')           // null
+ */
+export function pillarOfPath(path: string): KnownPillarId | null {
+  const namespace = path.split('.')[0];
+  if (!namespace) return null;
+  return isKnownPillarId(namespace) ? namespace : null;
+}
+
+/**
+ * Factory for the per-URL terminating link. Defaults to {@link httpBatchLink}
+ * with the project's standard `maxURLLength`. Tests inject a recording link
+ * factory to assert routing decisions without performing real fetches.
+ */
+export type TerminalLinkFactory = (url: string) => TRPCLink<AppRouter>;
+
+export interface CreateSplitLinkOptions {
+  /** Map of pillar id → URL. Defaults to {@link PILLAR_TRPC_URLS}. */
+  readonly pillarUrls?: Readonly<Record<KnownPillarId, string>>;
+  /** Catch-all URL for non-pillar procedures. Defaults to {@link LEGACY_TRPC_URL}. */
+  readonly legacyUrl?: string;
+  /**
+   * Override the terminal link constructor. Default builds an
+   * `httpBatchLink` with `maxURLLength: 2083` and the supplied `fetch`.
+   */
+  readonly linkFor?: TerminalLinkFactory;
+  /** Custom `fetch` used by the default terminal link factory. */
+  readonly fetch?: typeof fetch;
+  /** Max batch URL length used by the default terminal link factory. */
+  readonly maxURLLength?: number;
+}
+
+const DEFAULT_MAX_URL_LENGTH = 2083;
+
+function defaultLinkFor(
+  fetchImpl: typeof fetch | undefined,
+  maxURLLength: number
+): TerminalLinkFactory {
+  return (url) =>
+    httpBatchLink<AppRouter>({
+      url,
+      maxURLLength,
+      ...(fetchImpl ? { fetch: fetchImpl } : {}),
+    });
+}
+
+/**
+ * Builds a tRPC link that dispatches each operation to the per-pillar batch
+ * link matching its namespace, falling back to the legacy URL for anything
+ * else. tRPC's `splitLink` is binary, so the chain is nested once per pillar.
+ *
+ * Per-pillar links share no batch buffer: a request graph that mixes
+ * `core.foo` and `finance.bar` always produces two separate HTTP calls.
+ */
+export function createPillarSplitLink(opts: CreateSplitLinkOptions = {}): TRPCLink<AppRouter> {
+  const pillarUrls = opts.pillarUrls ?? PILLAR_TRPC_URLS;
+  const legacyUrl = opts.legacyUrl ?? LEGACY_TRPC_URL;
+  const linkFor =
+    opts.linkFor ?? defaultLinkFor(opts.fetch, opts.maxURLLength ?? DEFAULT_MAX_URL_LENGTH);
+
+  const legacyLink = linkFor(legacyUrl);
+
+  return PILLARS.reduce<TRPCLink<AppRouter>>((falseBranch, pillar) => {
+    const pillarLink = linkFor(pillarUrls[pillar]);
+    return splitLink<AppRouter>({
+      condition: (op: Operation) => pillarOfPath(op.path) === pillar,
+      true: pillarLink,
+      false: falseBranch,
+    });
+  }, legacyLink);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -935,6 +935,9 @@ importers:
         specifier: ^19.0.0
         version: 19.2.7
     devDependencies:
+      '@trpc/server':
+        specifier: 11.17.0
+        version: 11.17.0(typescript@6.0.3)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3


### PR DESCRIPTION
## Summary

- Replaces the shell's single `httpBatchLink` with a per-pillar `splitLink` chain so each pillar's procedure calls flow through their own batched URL prefix (`/trpc-<pillar>`); the legacy `/trpc` link keeps catching everything else (`health`, `pops.*`, debug).
- Adds `packages/api-client/src/split-link.ts` with `PILLAR_TRPC_URLS`, `pillarOfPath`, and `createPillarSplitLink({ pillarUrls, legacyUrl, linkFor, fetch, maxURLLength })`. The `linkFor` hook is what makes routing testable without real fetches.
- Wires the new link into `trpcClient` (preserving the existing `fetchWithTimeout`) and adds Vite dev-proxy rules that rewrite `/trpc-<pillar>` back to `/trpc` so the existing monolith keeps answering until per-pillar APIs split out.

## Scope notes

- Hand-written pillar URL map per the PRD; registry-driven map is PRD-217.
- nginx dispatcher simplification stays for PRD-190; the rewrite proxy in `vite.config.ts` is the dev-only equivalent until then.
- Cross-pillar batched-write semantics (PRD-188) untouched.

## Test plan

- [x] `pnpm --filter @pops/api-client test` — 11 tests pass (`pillarOfPath` x4, `createPillarSplitLink` x7 covering finance, media, mixed core+finance into two distinct URLs, unprefixed → legacy, unknown namespace → legacy, every known pillar → its URL, URL overrides).
- [x] `pnpm --filter @pops/api-client typecheck`.
- [x] `mise lint` (no new errors, warning counts unchanged).
- [x] `mise typecheck` across the workspace (66/66 successful).
- [x] `pnpm --filter @pops/shell test` (342 tests) and `pnpm --filter @pops/mcp test` (163 tests) — both green after the link swap.