### PR TITLE
feat(docs): catalog picks up all 7 pillar contracts (Theme 13 PRD-219 follow-up)

### DIFF
--- a/apps/pops-docs/scripts/collect-specs.test.ts
+++ b/apps/pops-docs/scripts/collect-specs.test.ts
@@ -38,14 +38,14 @@ describe('collect-specs', () => {
     expect(catalog.contracts).toHaveLength(EXPECTED_PILLARS.length);
 
     const ids = catalog.contracts.map((entry) => entry.id).toSorted();
-    expect(ids).toEqual([...EXPECTED_PILLARS]);
+    expect(ids).toEqual([...EXPECTED_PILLARS].toSorted());
 
     for (const pillar of EXPECTED_PILLARS) {
       const entry = catalog.contracts.find((c) => c.id === pillar);
-      expect(entry, `expected a ${pillar} contract entry in the catalog`).toBeDefined();
-      expect(entry?.openapiPath).toBe(`/openapi/${pillar}.json`);
-      expect(entry?.registryPillarId).toBe(pillar);
-      expect(entry?.contractTag).toMatch(new RegExp(`^contract-${pillar}@v`));
+      if (!entry) throw new Error(`expected a ${pillar} contract entry in the catalog`);
+      expect(entry.openapiPath).toBe(`/openapi/${pillar}.json`);
+      expect(entry.registryPillarId).toBe(pillar);
+      expect(entry.contractTag).toMatch(new RegExp(`^contract-${pillar}@v`));
 
       expect(existsSync(resolve(DIST_DIR, 'openapi', `${pillar}.json`))).toBe(true);
 

--- a/apps/pops-docs/scripts/collect-specs.test.ts
+++ b/apps/pops-docs/scripts/collect-specs.test.ts
@@ -12,8 +12,18 @@ const APP_ROOT = resolve(HERE, '..');
 const REPO_ROOT = resolve(APP_ROOT, '..', '..');
 const DIST_DIR = resolve(APP_ROOT, 'dist');
 
+const EXPECTED_PILLARS = [
+  'cerebrum',
+  'core',
+  'finance',
+  'food',
+  'inventory',
+  'lists',
+  'media',
+] as const;
+
 describe('collect-specs', () => {
-  it('discovers the finance contract snapshot and emits a catalog entry', () => {
+  it('discovers every pillar contract snapshot and emits a catalog entry per pillar', () => {
     rmSync(DIST_DIR, { recursive: true, force: true });
 
     const result = spawnSync('tsx', [resolve(HERE, 'collect-specs.ts')], {
@@ -25,29 +35,33 @@ describe('collect-specs', () => {
 
     const catalog = JSON.parse(readFileSync(resolve(DIST_DIR, 'catalog.json'), 'utf8')) as Catalog;
     expect(catalog.generatedAt).toBeTypeOf('string');
-    expect(catalog.contracts.length).toBeGreaterThanOrEqual(1);
+    expect(catalog.contracts).toHaveLength(EXPECTED_PILLARS.length);
 
-    const finance = catalog.contracts.find((entry) => entry.id === 'finance');
-    expect(finance, 'expected a finance contract entry in the catalog').toBeDefined();
-    expect(finance?.openapiPath).toBe('/openapi/finance.json');
-    expect(finance?.registryPillarId).toBe('finance');
-    expect(finance?.contractTag).toMatch(/^contract-finance@v/);
+    const ids = catalog.contracts.map((entry) => entry.id).toSorted();
+    expect(ids).toEqual([...EXPECTED_PILLARS]);
 
-    expect(existsSync(resolve(DIST_DIR, 'openapi', 'finance.json'))).toBe(true);
+    for (const pillar of EXPECTED_PILLARS) {
+      const entry = catalog.contracts.find((c) => c.id === pillar);
+      expect(entry, `expected a ${pillar} contract entry in the catalog`).toBeDefined();
+      expect(entry?.openapiPath).toBe(`/openapi/${pillar}.json`);
+      expect(entry?.registryPillarId).toBe(pillar);
+      expect(entry?.contractTag).toMatch(new RegExp(`^contract-${pillar}@v`));
+
+      expect(existsSync(resolve(DIST_DIR, 'openapi', `${pillar}.json`))).toBe(true);
+
+      const copiedSpec = JSON.parse(
+        readFileSync(resolve(DIST_DIR, 'openapi', `${pillar}.json`), 'utf8')
+      ) as { info?: { title?: string } };
+      const sourceSpec = JSON.parse(
+        readFileSync(
+          resolve(REPO_ROOT, `packages/${pillar}-contract/openapi/${pillar}.openapi.json`),
+          'utf8'
+        )
+      ) as { info?: { title?: string } };
+      expect(copiedSpec.info?.title).toBe(sourceSpec.info?.title);
+    }
+
     expect(existsSync(resolve(DIST_DIR, 'index.html'))).toBe(true);
     expect(existsSync(resolve(DIST_DIR, 'styles.css'))).toBe(true);
-
-    const copiedSpec = JSON.parse(
-      readFileSync(resolve(DIST_DIR, 'openapi', 'finance.json'), 'utf8')
-    ) as {
-      info?: { title?: string };
-    };
-    const sourceSpec = JSON.parse(
-      readFileSync(
-        resolve(REPO_ROOT, 'packages/finance-contract/openapi/finance.openapi.json'),
-        'utf8'
-      )
-    ) as { info?: { title?: string } };
-    expect(copiedSpec.info?.title).toBe(sourceSpec.info?.title);
   });
 });


### PR DESCRIPTION
## Summary

PRD-219 follow-up: the `pops-docs` catalog generator already walks every `packages/*-contract/openapi/*.json`, but the integration test only asserted the finance entry. Now that all 7 pillar contracts ship openapi snapshots on `main` (`cerebrum`, `core`, `finance`, `food`, `inventory`, `lists`, `media`), the test pins the expected catalog size to 7 and asserts the shape of each entry plus the copied spec under `dist/openapi/`.

- Verified `scripts/collect-specs.ts` discovers and emits all 7 pillars locally.
- Updated `scripts/collect-specs.test.ts` to enumerate the 7 expected pillars and assert per-entry id, openapi path, registry pillar id, contract tag, copied snapshot, and `info.title` parity with the source spec.
- `src/catalog.test.ts` had no hardcoded "1" expectation, so no change there — its synthetic-input unit tests stay shape-focused.
- Manually verified the Stoplight Elements bootstrap in `src/index.html` against the live dev server: catalog returns 7 entries, the multi-spec nav branch (`contracts.length > 1`) triggers, and each `/openapi/<pillar>.json` resolves to the contract's snapshot.

## Catalog entries the generator now emits

```
cerebrum@0.1.0  → /openapi/cerebrum.json
core@0.1.0      → /openapi/core.json
finance@0.1.0   → /openapi/finance.json
food@0.1.0      → /openapi/food.json
inventory@0.1.0 → /openapi/inventory.json
lists@0.1.0     → /openapi/lists.json
media@0.1.0     → /openapi/media.json
```

## Test plan

- [x] `pnpm test` (apps/pops-docs) — 2 files, 7 tests passing
- [x] `pnpm build` (apps/pops-docs) reports `catalog ready — 7 contract(s)` and copies 7 snapshots into `dist/openapi/`
- [x] `pnpm dev` (apps/pops-docs) serves `/catalog.json` with 7 entries and each `/openapi/<pillar>.json` returns the contract spec
- [x] `mise lint` — no new warnings, exit 0
- [x] `mise typecheck` — 66 tasks green

## Out of scope

- New container features (auth, search)
- Compose changes (already wired)
