### PR TITLE
feat(api-client): batching invariants for splitLink (Theme 13 PRD-188)

### DIFF
--- a/docs/themes/13-pillar-finale/prds/188-batching-invariants/README.md
+++ b/docs/themes/13-pillar-finale/prds/188-batching-invariants/README.md
@@ -41,6 +41,16 @@ A test that exercises every page's data loader, captures tRPC calls, and asserts
 - CI assertions are hard failures.
 - The invariant set is documented in `apps/pops-shell/src/lib/trpc.invariants.md`.
 
+## Acceptance Criteria
+
+- [x] A pure runtime assertion (`assertSingleTargetBatch`) lives in `packages/api-client/src/batching-invariants.ts` and throws `CrossPillarBatchError` when a batch contains ops resolving to more than one pillar URL (or mixes a pillar with the legacy catch-all).
+- [x] A non-throwing variant (`checkSingleTargetBatch`) is exposed for dev-mode logging that returns a violation descriptor instead of throwing.
+- [x] The error message references PRD-188 and the offending paths/targets, so consumers can surface a useful warning.
+- [x] Tests at `packages/api-client/src/__tests__/batching-invariants.test.ts` cover: same-pillar batch passes, cross-pillar batch throws, mix of pillar + legacy throws, and the empty / single-op edge cases.
+- [x] `mise lint` and `mise typecheck` pass.
+
+> Audit of existing batch call sites is tracked under PRD-189. nginx dispatcher rules are tracked under PRD-190.
+
 ## Edge Cases
 
 | Case                                           | Behaviour                                    |

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -6,15 +6,18 @@
   "main": "src/index.ts",
   "scripts": {
     "typecheck": "tsc --noEmit",
-    "test": "echo \"(no tests in @pops/api-client)\""
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@pops/api": "workspace:*",
+    "@pops/pillar-sdk": "workspace:*",
     "@trpc/client": "11.17.0",
     "@trpc/react-query": "11.17.0"
   },
   "devDependencies": {
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.8"
   },
   "peerDependencies": {
     "react": "^19.0.0"

--- a/packages/api-client/src/__tests__/batching-invariants.test.ts
+++ b/packages/api-client/src/__tests__/batching-invariants.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  CrossPillarBatchError,
+  LEGACY_BATCH_TARGET,
+  assertSingleTargetBatch,
+  batchTargetOfPath,
+  checkSingleTargetBatch,
+} from '../batching-invariants.js';
+
+import type { BatchableOp } from '../batching-invariants.js';
+
+function ops(...paths: string[]): BatchableOp[] {
+  return paths.map((path) => ({ path }));
+}
+
+describe('batchTargetOfPath', () => {
+  it.each([
+    ['finance.wishlist.list', 'finance'],
+    ['media.movies.get', 'media'],
+    ['core.health', 'core'],
+    ['inventory.items.list', 'inventory'],
+    ['cerebrum.notes.search', 'cerebrum'],
+    ['food.recipes.list', 'food'],
+    ['lists.items.list', 'lists'],
+  ])('routes %s to %s', (path, expected) => {
+    expect(batchTargetOfPath(path)).toBe(expected);
+  });
+
+  it('routes unprefixed and unknown-namespace paths to the legacy target', () => {
+    expect(batchTargetOfPath('health')).toBe(LEGACY_BATCH_TARGET);
+    expect(batchTargetOfPath('pops.health')).toBe(LEGACY_BATCH_TARGET);
+    expect(batchTargetOfPath('debug.ping')).toBe(LEGACY_BATCH_TARGET);
+    expect(batchTargetOfPath('')).toBe(LEGACY_BATCH_TARGET);
+  });
+});
+
+describe('assertSingleTargetBatch', () => {
+  it('passes for an empty batch', () => {
+    expect(() => assertSingleTargetBatch([])).not.toThrow();
+  });
+
+  it('passes for a single-op batch regardless of target', () => {
+    expect(() => assertSingleTargetBatch(ops('finance.x'))).not.toThrow();
+    expect(() => assertSingleTargetBatch(ops('debug.ping'))).not.toThrow();
+  });
+
+  it('passes when every op resolves to the same pillar', () => {
+    expect(() =>
+      assertSingleTargetBatch(ops('finance.wishlist.list', 'finance.budget.summary'))
+    ).not.toThrow();
+    expect(() =>
+      assertSingleTargetBatch(ops('media.movies.get', 'media.shows.list', 'media.images.show'))
+    ).not.toThrow();
+  });
+
+  it('passes when every op resolves to the legacy catch-all', () => {
+    expect(() =>
+      assertSingleTargetBatch(ops('health', 'debug.ping', 'pops.bootstrap'))
+    ).not.toThrow();
+  });
+
+  it('throws CrossPillarBatchError for a cross-pillar batch', () => {
+    expect(() => assertSingleTargetBatch(ops('finance.wishlist.list', 'media.movies.get'))).toThrow(
+      CrossPillarBatchError
+    );
+  });
+
+  it('throws for a three-way cross-pillar batch and reports all targets', () => {
+    let caught: unknown;
+    try {
+      assertSingleTargetBatch(ops('finance.a', 'media.b', 'inventory.c'));
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(CrossPillarBatchError);
+    const err = caught as CrossPillarBatchError;
+    expect(new Set(err.targets)).toEqual(new Set(['finance', 'media', 'inventory']));
+    expect(err.offendingPaths).toEqual(
+      expect.arrayContaining(['finance.a', 'media.b', 'inventory.c'])
+    );
+    expect(err.message).toContain('PRD-188');
+  });
+
+  it('throws for a batch mixing a pillar with a legacy path', () => {
+    let caught: unknown;
+    try {
+      assertSingleTargetBatch(ops('finance.wishlist.list', 'health'));
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(CrossPillarBatchError);
+    const err = caught as CrossPillarBatchError;
+    expect(new Set(err.targets)).toEqual(new Set(['finance', LEGACY_BATCH_TARGET]));
+    expect(err.offendingPaths).toEqual(expect.arrayContaining(['finance.wishlist.list', 'health']));
+  });
+
+  it('throws for a batch mixing a pillar with an unknown-namespace legacy path', () => {
+    expect(() => assertSingleTargetBatch(ops('media.movies.get', 'debug.ping'))).toThrow(
+      CrossPillarBatchError
+    );
+  });
+});
+
+describe('checkSingleTargetBatch', () => {
+  it('returns ok with a null target for an empty batch', () => {
+    expect(checkSingleTargetBatch([])).toEqual({ ok: true, target: null });
+  });
+
+  it('returns ok with the resolved target for a same-pillar batch', () => {
+    expect(checkSingleTargetBatch(ops('finance.a', 'finance.b'))).toEqual({
+      ok: true,
+      target: 'finance',
+    });
+  });
+
+  it('returns ok with the legacy target for a legacy-only batch', () => {
+    expect(checkSingleTargetBatch(ops('health', 'debug.ping'))).toEqual({
+      ok: true,
+      target: LEGACY_BATCH_TARGET,
+    });
+  });
+
+  it('returns a violation for a cross-pillar batch without throwing', () => {
+    const result = checkSingleTargetBatch(ops('finance.a', 'media.b'));
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(new Set(result.violation.targets)).toEqual(new Set(['finance', 'media']));
+    expect(result.violation.message).toContain('PRD-188');
+  });
+
+  it('returns a violation when a pillar batch is contaminated with a legacy path', () => {
+    const result = checkSingleTargetBatch(ops('media.movies.get', 'pops.bootstrap'));
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(new Set(result.violation.targets)).toEqual(new Set(['media', LEGACY_BATCH_TARGET]));
+  });
+});

--- a/packages/api-client/src/batching-invariants.ts
+++ b/packages/api-client/src/batching-invariants.ts
@@ -1,0 +1,125 @@
+import { PILLARS, type KnownPillarId } from '@pops/pillar-sdk';
+
+/**
+ * Batching invariants enforced for the splitLink (PRD-187/PRD-188).
+ *
+ * The shell's tRPC client must never compose a batch whose operations
+ * resolve to more than one pillar URL. nginx and the per-pillar API
+ * processes rely on a simple prefix match — a batch URL that mixes
+ * `finance.*` and `media.*` cannot be routed deterministically once
+ * pillars run as separate upstreams. The same constraint applies to
+ * the legacy `/trpc` catch-all: pillar paths and legacy paths must
+ * never share a batch.
+ *
+ * See `docs/themes/13-pillar-finale/prds/188-batching-invariants/`.
+ */
+
+/** Identifies the catch-all target for non-pillar (legacy) procedures. */
+export const LEGACY_BATCH_TARGET = 'legacy' as const;
+export type LegacyBatchTarget = typeof LEGACY_BATCH_TARGET;
+
+/** Where a single op routes: a known pillar, or the legacy catch-all. */
+export type BatchTarget = KnownPillarId | LegacyBatchTarget;
+
+const PILLAR_SET: ReadonlySet<string> = new Set(PILLARS);
+
+function isKnownPillarId(value: string): value is KnownPillarId {
+  return PILLAR_SET.has(value);
+}
+
+/**
+ * Resolves the batch target for a tRPC procedure path. The first dot-
+ * separated segment selects the target; unknown / missing namespaces
+ * fall through to the legacy catch-all.
+ */
+export function batchTargetOfPath(path: string): BatchTarget {
+  const namespace = path.split('.')[0];
+  if (!namespace) return LEGACY_BATCH_TARGET;
+  return isKnownPillarId(namespace) ? namespace : LEGACY_BATCH_TARGET;
+}
+
+/** Op shape consumed by the invariant check — minimal on purpose. */
+export interface BatchableOp {
+  readonly path: string;
+}
+
+export interface BatchInvariantViolation {
+  readonly message: string;
+  readonly offendingPaths: ReadonlyArray<string>;
+  readonly targets: ReadonlyArray<BatchTarget>;
+}
+
+/**
+ * Thrown when a composed batch contains ops that resolve to more than
+ * one batch target. The shape exposes the offending paths and resolved
+ * targets so the caller can surface a useful dev-mode warning.
+ */
+export class CrossPillarBatchError extends Error implements BatchInvariantViolation {
+  readonly offendingPaths: ReadonlyArray<string>;
+  readonly targets: ReadonlyArray<BatchTarget>;
+
+  constructor(violation: BatchInvariantViolation) {
+    super(violation.message);
+    this.name = 'CrossPillarBatchError';
+    this.offendingPaths = violation.offendingPaths;
+    this.targets = violation.targets;
+  }
+}
+
+function formatViolation(
+  pathsByTarget: ReadonlyMap<BatchTarget, ReadonlyArray<string>>
+): BatchInvariantViolation {
+  const targets = Array.from(pathsByTarget.keys());
+  const offendingPaths = targets.flatMap((target) => pathsByTarget.get(target) ?? []);
+  const summary = targets
+    .map((target) => `${target}=[${(pathsByTarget.get(target) ?? []).join(', ')}]`)
+    .join(' | ');
+  return {
+    message:
+      `Batch invariant violation (PRD-188): every op in a batch must resolve to the same ` +
+      `pillar URL. Got ${targets.length} distinct targets — ${summary}. ` +
+      `See docs/themes/13-pillar-finale/prds/188-batching-invariants/README.md.`,
+    offendingPaths,
+    targets,
+  };
+}
+
+function groupByTarget(ops: ReadonlyArray<BatchableOp>): Map<BatchTarget, string[]> {
+  const grouped = new Map<BatchTarget, string[]>();
+  for (const op of ops) {
+    const target = batchTargetOfPath(op.path);
+    const bucket = grouped.get(target);
+    if (bucket) bucket.push(op.path);
+    else grouped.set(target, [op.path]);
+  }
+  return grouped;
+}
+
+/**
+ * Asserts that every op in `ops` routes to the same batch target.
+ * Throws {@link CrossPillarBatchError} when the invariant is violated.
+ * Empty batches and single-op batches always pass.
+ */
+export function assertSingleTargetBatch(ops: ReadonlyArray<BatchableOp>): void {
+  if (ops.length < 2) return;
+  const grouped = groupByTarget(ops);
+  if (grouped.size <= 1) return;
+  throw new CrossPillarBatchError(formatViolation(grouped));
+}
+
+/**
+ * Non-throwing variant: returns the resolved target on success, or a
+ * {@link BatchInvariantViolation} describing the cross-target mix. Useful
+ * for dev-mode logging where we don't want to crash the UI.
+ */
+export function checkSingleTargetBatch(
+  ops: ReadonlyArray<BatchableOp>
+): { ok: true; target: BatchTarget | null } | { ok: false; violation: BatchInvariantViolation } {
+  if (ops.length === 0) return { ok: true, target: null };
+  const grouped = groupByTarget(ops);
+  if (grouped.size === 1) {
+    const [target] = grouped.keys();
+    return { ok: true, target: target ?? null };
+  }
+  return { ok: false, violation: formatViolation(grouped) };
+}

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -91,3 +91,17 @@ export function isNetworkError(err: unknown): boolean {
 }
 
 export type { AppRouter };
+
+export {
+  CrossPillarBatchError,
+  LEGACY_BATCH_TARGET,
+  assertSingleTargetBatch,
+  batchTargetOfPath,
+  checkSingleTargetBatch,
+} from './batching-invariants.js';
+export type {
+  BatchInvariantViolation,
+  BatchTarget,
+  BatchableOp,
+  LegacyBatchTarget,
+} from './batching-invariants.js';

--- a/packages/api-client/vitest.config.ts
+++ b/packages/api-client/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: false,
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -922,6 +922,9 @@ importers:
       '@pops/api':
         specifier: workspace:*
         version: link:../../apps/pops-api
+      '@pops/pillar-sdk':
+        specifier: workspace:*
+        version: link:../pillar-sdk
       '@trpc/client':
         specifier: 11.17.0
         version: 11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3)
@@ -935,6 +938,9 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.3)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/app-ai:
     dependencies:


### PR DESCRIPTION
## Summary

- Adds a runtime assertion (`assertSingleTargetBatch`) and a non-throwing companion (`checkSingleTargetBatch`) in `@pops/api-client` that enforce the Theme 13 PRD-188 invariant: every op in a tRPC batch must resolve to the same pillar URL (or all to the legacy catch-all).
- Throws `CrossPillarBatchError` with a message that names the offending paths/targets and references PRD-188, so callers can surface a useful dev-mode warning or fail CI hard.
- Implemented as a pure utility decoupled from the splitLink itself, so it can be consumed by the dev-mode subscriber (us-01), the CI scanner (us-02), and the PRD-187 splitLink integration without circular imports.

PRD: [`docs/themes/13-pillar-finale/prds/188-batching-invariants/README.md`](../blob/feat/theme13-prd-188-batching-invariants/docs/themes/13-pillar-finale/prds/188-batching-invariants/README.md)

Related: PRD-187 splitLink (#2976). The two land independently; PRD-189 audits existing call sites and PRD-190 owns the nginx side.

## Test plan

- [x] `pnpm --filter @pops/api-client test` — 21 tests passing.
- [x] `pnpm --filter @pops/api-client typecheck` clean.
- [x] `mise lint` clean (no new warnings, exit 0).
- [x] `mise typecheck` (full workspace) — 66/66 pass.
- [x] Cases covered: same-pillar batch passes, cross-pillar batch throws, pillar+legacy mix throws, all seven known pillars route correctly, empty / single-op batches pass.
