### PR TITLE
ci(_pkg-check): build pillar-sdk between finance-contract and other contracts

### DIFF
--- a/.github/workflows/_pkg-check.yml
+++ b/.github/workflows/_pkg-check.yml
@@ -56,13 +56,13 @@ jobs:
           pnpm --filter @pops/app-lists-db build
           pnpm --filter @pops/app-food-db build
           pnpm --filter @pops/finance-contract build
+          pnpm --filter @pops/pillar-sdk build
           pnpm --filter @pops/media-contract build
           pnpm --filter @pops/inventory-contract build
           pnpm --filter @pops/cerebrum-contract build
           pnpm --filter @pops/core-contract build
           pnpm --filter @pops/lists-contract build
           pnpm --filter @pops/food-contract build
-          pnpm --filter @pops/pillar-sdk build
       - run: cd ${{ inputs.package-path }} && pnpm typecheck
         if: inputs.skip != 'true'
 
@@ -102,13 +102,13 @@ jobs:
           pnpm --filter @pops/app-lists-db build
           pnpm --filter @pops/app-food-db build
           pnpm --filter @pops/finance-contract build
+          pnpm --filter @pops/pillar-sdk build
           pnpm --filter @pops/media-contract build
           pnpm --filter @pops/inventory-contract build
           pnpm --filter @pops/cerebrum-contract build
           pnpm --filter @pops/core-contract build
           pnpm --filter @pops/lists-contract build
           pnpm --filter @pops/food-contract build
-          pnpm --filter @pops/pillar-sdk build
       - name: Run tests (with coverage if configured)
         if: inputs.skip != 'true'
         run: |


### PR DESCRIPTION
## Problem

Circular build chain at the type-resolution level:

- `pillar-sdk` re-exports types from `@pops/finance-contract` (PRD-195) → pillar-sdk needs finance-contract built first.
- `core-contract` type-imports `@pops/core-api/router` (typeof). pops-core-api's `modules/registry/router.ts` imports `@pops/pillar-sdk` → tsc walking core-contract → core-api → pillar-sdk needs pillar-sdk's dist.

#2975 fixed half the loop (pillar-sdk after finance-contract). This patch fixes the other half: pillar-sdk must build BEFORE the other contracts (media/inventory/cerebrum/core/lists/food), because they all transitively need pillar-sdk's dist when tsc walks their `*-api/router` type imports.

Discovered when #2976 (PRD-187 splitLink) failed with `Cannot find module @pops/pillar-sdk` originating in `apps/pops-core-api/src/modules/registry/router.ts` line 28 — tsc was walking from api-client → pillar-sdk → finance-contract → finance-api → core-api → pillar-sdk and finding the second pillar-sdk reference before its dist was built.

## Fix

Reorder shared-build to: finance-contract → pillar-sdk → media-contract → inventory-contract → cerebrum-contract → core-contract → lists-contract → food-contract.

## Test plan

- [ ] CI on this PR runs cleanly.
- [ ] After merge, #2976 + #2977 + #2978 rebased + CI green.