### PR TITLE
ci(contract-semver): finance-contract → pillar-sdk → other contracts

### DIFF
--- a/.github/workflows/contract-semver.yml
+++ b/.github/workflows/contract-semver.yml
@@ -56,11 +56,13 @@ jobs:
           pnpm --filter @pops/app-lists-db build
           pnpm --filter @pops/app-food-db build
           pnpm --filter @pops/finance-contract build
+          pnpm --filter @pops/pillar-sdk build
+          pnpm --filter @pops/media-contract build
+          pnpm --filter @pops/inventory-contract build
           pnpm --filter @pops/cerebrum-contract build
           pnpm --filter @pops/core-contract build
           pnpm --filter @pops/lists-contract build
           pnpm --filter @pops/food-contract build
-          pnpm --filter @pops/pillar-sdk build
 
       - name: Regenerate snapshots (in-place)
         run: pnpm --filter @pops/finance-contract extract:all


### PR DESCRIPTION
## Problem

`contract-semver.yml` still had pillar-sdk at the BOTTOM of the shared-build list and was missing media + inventory contracts entirely. Same root cause as #2979 (which fixed `_pkg-check.yml`) — the build chain at the type-resolution level is:

- finance-contract has no SDK dep, builds clean first.
- pillar-sdk re-exports finance-contract types (PRD-195) → needs finance-contract built.
- Other contracts type-import their pillar's runtime router (`@pops/<pillar>-api/router`); those routers all transitively pull `@pops/pillar-sdk`, so the SDK's dist must already exist.

Discovered when #2981 (PRD-153 US-07 finance entities) tripped the `Semver + drift check` job.

## Fix

Same as #2979 but for contract-semver. Reorder to: finance-contract → pillar-sdk → media → inventory → cerebrum → core → lists → food.

## Test plan

- [ ] CI on this PR is clean.
- [ ] After merge, #2981 rebased + CI green.