### PR TITLE
feat(media-db): scaffold movies service + baseline migration (PRD-165 US-01)

### DIFF
--- a/apps/pops-api/src/db/backfill-media-from-shared.test.ts
+++ b/apps/pops-api/src/db/backfill-media-from-shared.test.ts
@@ -21,7 +21,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { openMediaDb } from '@pops/media-db';
 
 import { backfillMediaFromShared, closeMediaDb, setMediaDb } from '../db/media-db-handle.js';
-import { SHELF_IMPRESSIONS_TABLE_SQL, TV_SHOWS_TABLE_SQL } from './backfill-test-fixtures.js';
+import {
+  MOVIES_TABLE_SQL,
+  SHELF_IMPRESSIONS_TABLE_SQL,
+  TV_SHOWS_TABLE_SQL,
+} from './backfill-test-fixtures.js';
 
 let tmpDir: string;
 
@@ -277,6 +281,171 @@ describe('backfillMediaFromShared', () => {
 
       expect(() => backfillMediaFromShared()).not.toThrow();
       const count = media.raw.prepare('SELECT count(*) AS n FROM tv_shows').get() as { n: number };
+      expect(count.n).toBe(0);
+    });
+  });
+
+  describe('movies (PRD-165 PR 1)', () => {
+    function openSharedWithMovies(
+      rows: { tmdbId: number; title: string; releaseDate?: string | null }[]
+    ): string {
+      const path = join(tmpDir, 'pops.db');
+      const raw = new BetterSqlite3(path);
+      raw.exec(SHELF_IMPRESSIONS_TABLE_SQL);
+      raw.exec(MOVIES_TABLE_SQL);
+      const insert = raw.prepare(
+        'INSERT INTO movies (tmdb_id, title, release_date) VALUES (?, ?, ?)'
+      );
+      for (const row of rows) {
+        insert.run(row.tmdbId, row.title, row.releaseDate ?? null);
+      }
+      raw.close();
+      process.env['SQLITE_PATH'] = path;
+      return path;
+    }
+
+    it('copies fresh movie rows on first run and is a no-op on the second', () => {
+      openSharedWithMovies([
+        { tmdbId: 603, title: 'The Matrix', releaseDate: '1999-03-31' },
+        { tmdbId: 27205, title: 'Inception', releaseDate: '2010-07-16' },
+      ]);
+      const media = openMediaDb(join(tmpDir, 'media.db'));
+      setMediaDb(media);
+
+      backfillMediaFromShared();
+      const after = media.raw
+        .prepare('SELECT id, tmdb_id, title FROM movies ORDER BY id')
+        .all() as { id: number; tmdb_id: number; title: string }[];
+      expect(after.map((r) => r.title)).toEqual(['The Matrix', 'Inception']);
+
+      backfillMediaFromShared();
+      const second = media.raw.prepare('SELECT count(*) AS n FROM movies').get() as { n: number };
+      expect(second.n).toBe(2);
+    });
+
+    it('only inserts movies missing from the media copy', () => {
+      openSharedWithMovies([
+        { tmdbId: 603, title: 'The Matrix' },
+        { tmdbId: 27205, title: 'Inception' },
+      ]);
+      const media = openMediaDb(join(tmpDir, 'media.db'));
+      setMediaDb(media);
+      // Pre-seed id=1 in media with a different tmdb_id so the backfill skips it
+      // by id and the unique tmdb_id constraint doesn't conflict with id=2.
+      media.raw
+        .prepare('INSERT INTO movies (id, tmdb_id, title) VALUES (?, ?, ?)')
+        .run(1, 99999, 'Pre-existing');
+
+      backfillMediaFromShared();
+      const rows = media.raw.prepare('SELECT id, tmdb_id, title FROM movies ORDER BY id').all() as {
+        id: number;
+        tmdb_id: number;
+        title: string;
+      }[];
+      expect(rows).toEqual([
+        { id: 1, tmdb_id: 99999, title: 'Pre-existing' },
+        { id: 2, tmdb_id: 27205, title: 'Inception' },
+      ]);
+    });
+
+    it('carries every column across (full-shape roundtrip)', () => {
+      const path = join(tmpDir, 'pops.db');
+      const raw = new BetterSqlite3(path);
+      raw.exec(SHELF_IMPRESSIONS_TABLE_SQL);
+      raw.exec(MOVIES_TABLE_SQL);
+      raw
+        .prepare(
+          `INSERT INTO movies (
+            tmdb_id, imdb_id, title, original_title, overview, tagline,
+            release_date, runtime, status, original_language, budget, revenue,
+            poster_path, backdrop_path, logo_path, poster_override_path,
+            discover_rating_key, vote_average, vote_count, genres,
+            created_at, updated_at,
+            rotation_status, rotation_expires_at, rotation_marked_at
+          ) VALUES (
+            ?, ?, ?, ?, ?, ?,
+            ?, ?, ?, ?, ?, ?,
+            ?, ?, ?, ?,
+            ?, ?, ?, ?,
+            ?, ?,
+            ?, ?, ?
+          )`
+        )
+        .run(
+          603,
+          'tt0133093',
+          'The Matrix',
+          'The Matrix',
+          'A computer hacker learns from mysterious rebels…',
+          'Welcome to the Real World.',
+          '1999-03-31',
+          136,
+          'Released',
+          'en',
+          63_000_000,
+          463_517_383,
+          '/poster.jpg',
+          '/backdrop.jpg',
+          '/logo.png',
+          '/override.jpg',
+          'discover-key-matrix',
+          8.2,
+          25_678,
+          JSON.stringify(['Action', 'Science Fiction']),
+          '2026-06-01 00:00:00',
+          '2026-06-02 00:00:00',
+          'leaving',
+          '2026-07-01 00:00:00',
+          '2026-06-01 00:00:00'
+        );
+      raw.close();
+      process.env['SQLITE_PATH'] = path;
+
+      const media = openMediaDb(join(tmpDir, 'media.db'));
+      setMediaDb(media);
+      backfillMediaFromShared();
+
+      const row = media.raw.prepare('SELECT * FROM movies WHERE tmdb_id = ?').get(603) as Record<
+        string,
+        unknown
+      >;
+      expect(row).toMatchObject({
+        tmdb_id: 603,
+        imdb_id: 'tt0133093',
+        title: 'The Matrix',
+        original_title: 'The Matrix',
+        runtime: 136,
+        original_language: 'en',
+        budget: 63_000_000,
+        revenue: 463_517_383,
+        poster_path: '/poster.jpg',
+        backdrop_path: '/backdrop.jpg',
+        logo_path: '/logo.png',
+        poster_override_path: '/override.jpg',
+        discover_rating_key: 'discover-key-matrix',
+        vote_average: 8.2,
+        vote_count: 25_678,
+        rotation_status: 'leaving',
+        rotation_expires_at: '2026-07-01 00:00:00',
+        rotation_marked_at: '2026-06-01 00:00:00',
+      });
+      expect(JSON.parse(String(row['genres']))).toEqual(['Action', 'Science Fiction']);
+    });
+
+    it('tolerates a shared DB without the movies table', () => {
+      // Shared DB has shelf_impressions but no movies — backfill copies shelf
+      // rows and skips movies without throwing.
+      const path = join(tmpDir, 'pops.db');
+      const raw = new BetterSqlite3(path);
+      raw.exec(SHELF_IMPRESSIONS_TABLE_SQL);
+      raw.close();
+      process.env['SQLITE_PATH'] = path;
+
+      const media = openMediaDb(join(tmpDir, 'media.db'));
+      setMediaDb(media);
+
+      expect(() => backfillMediaFromShared()).not.toThrow();
+      const count = media.raw.prepare('SELECT count(*) AS n FROM movies').get() as { n: number };
       expect(count.n).toBe(0);
     });
   });

--- a/apps/pops-api/src/db/backfill-test-fixtures.ts
+++ b/apps/pops-api/src/db/backfill-test-fixtures.ts
@@ -35,6 +35,41 @@ CREATE TABLE shelf_impressions (
 CREATE INDEX idx_shelf_impressions_shelf_id ON shelf_impressions (shelf_id);
 `;
 
+export const MOVIES_TABLE_SQL = `
+CREATE TABLE movies (
+  id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  tmdb_id integer NOT NULL,
+  imdb_id text,
+  title text NOT NULL,
+  original_title text,
+  overview text,
+  tagline text,
+  release_date text,
+  runtime integer,
+  status text,
+  original_language text,
+  budget integer,
+  revenue integer,
+  poster_path text,
+  backdrop_path text,
+  logo_path text,
+  poster_override_path text,
+  discover_rating_key text,
+  vote_average real,
+  vote_count integer,
+  genres text,
+  created_at text DEFAULT (datetime('now')) NOT NULL,
+  updated_at text DEFAULT (datetime('now')) NOT NULL,
+  rotation_status text,
+  rotation_expires_at text,
+  rotation_marked_at text
+);
+CREATE INDEX idx_movies_rotation_status ON movies (rotation_status);
+CREATE UNIQUE INDEX idx_movies_tmdb_id ON movies (tmdb_id);
+CREATE INDEX idx_movies_title ON movies (title);
+CREATE INDEX idx_movies_release_date ON movies (release_date);
+`;
+
 export const TV_SHOWS_TABLE_SQL = `
 CREATE TABLE tv_shows (
   id integer PRIMARY KEY AUTOINCREMENT NOT NULL,

--- a/apps/pops-api/src/db/media-backfill.ts
+++ b/apps/pops-api/src/db/media-backfill.ts
@@ -4,12 +4,12 @@ import { resolveSqlitePath } from './sqlite-path.js';
  * Boot-time backfill from the legacy shared `pops.db` into the media
  * pillar's `media.db`.
  *
- * Each slice cutover (Phase 2 PR 3 shelf-impressions, PRD-166 tv-shows, …)
- * flips its handle to `getMediaDrizzle()`. The first deploy after each
- * cutover needs to carry the existing rows from the shared DB across
- * before any reads come from the new file. Subsequent boots find the
- * media copy already populated and become a no-op via the
- * `WHERE id NOT IN (...)` existence filter on every table.
+ * Each slice cutover (Phase 2 PR 3 shelf-impressions, PRD-165 movies,
+ * PRD-166 tv-shows, …) flips its handle to `getMediaDrizzle()`. The
+ * first deploy after each cutover needs to carry the existing rows from
+ * the shared DB across before any reads come from the new file.
+ * Subsequent boots find the media copy already populated and become a
+ * no-op via the `WHERE id NOT IN (...)` existence filter on every table.
  *
  * No FK relationships exist between the listed media tables, so order
  * is independent — but each entry is wrapped in `tryCopyTable` so a
@@ -42,6 +42,38 @@ const TABLE_COPIES: readonly TableCopy[] = [
     table: 'shelf_impressions',
     idColumn: 'id',
     columns: ['id', 'shelf_id', 'shown_at'],
+  },
+  {
+    table: 'movies',
+    idColumn: 'id',
+    columns: [
+      'id',
+      'tmdb_id',
+      'imdb_id',
+      'title',
+      'original_title',
+      'overview',
+      'tagline',
+      'release_date',
+      'runtime',
+      'status',
+      'original_language',
+      'budget',
+      'revenue',
+      'poster_path',
+      'backdrop_path',
+      'logo_path',
+      'poster_override_path',
+      'discover_rating_key',
+      'vote_average',
+      'vote_count',
+      'genres',
+      'created_at',
+      'updated_at',
+      'rotation_status',
+      'rotation_expires_at',
+      'rotation_marked_at',
+    ],
   },
   {
     table: 'tv_shows',

--- a/apps/pops-api/src/db/per-pillar-migrations.test.ts
+++ b/apps/pops-api/src/db/per-pillar-migrations.test.ts
@@ -228,6 +228,7 @@ describe('runPerPillarMigrations', () => {
         '0006_inventory_pillar_baseline',
         '0007_locations_parent_sort_index',
         '0021_spooky_lockheed',
+        '0022_media_movies_baseline',
         '0024_media_tv_shows_baseline',
         '0039_dry_fabian_cortez',
         '0044_nudge_log',

--- a/packages/media-db/migrations/0022_media_movies_baseline.sql
+++ b/packages/media-db/migrations/0022_media_movies_baseline.sql
@@ -1,0 +1,33 @@
+CREATE TABLE `movies` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`tmdb_id` integer NOT NULL,
+	`imdb_id` text,
+	`title` text NOT NULL,
+	`original_title` text,
+	`overview` text,
+	`tagline` text,
+	`release_date` text,
+	`runtime` integer,
+	`status` text,
+	`original_language` text,
+	`budget` integer,
+	`revenue` integer,
+	`poster_path` text,
+	`backdrop_path` text,
+	`logo_path` text,
+	`poster_override_path` text,
+	`discover_rating_key` text,
+	`vote_average` real,
+	`vote_count` integer,
+	`genres` text,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL,
+	`updated_at` text DEFAULT (datetime('now')) NOT NULL,
+	`rotation_status` text,
+	`rotation_expires_at` text,
+	`rotation_marked_at` text
+);
+--> statement-breakpoint
+CREATE INDEX `idx_movies_rotation_status` ON `movies` (`rotation_status`);--> statement-breakpoint
+CREATE UNIQUE INDEX `idx_movies_tmdb_id` ON `movies` (`tmdb_id`);--> statement-breakpoint
+CREATE INDEX `idx_movies_title` ON `movies` (`title`);--> statement-breakpoint
+CREATE INDEX `idx_movies_release_date` ON `movies` (`release_date`);

--- a/packages/media-db/migrations/meta/_journal.json
+++ b/packages/media-db/migrations/meta/_journal.json
@@ -12,6 +12,13 @@
     {
       "idx": 1,
       "version": "7",
+      "when": 1780000000000,
+      "tag": "0022_media_movies_baseline",
+      "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
       "when": 1788000000000,
       "tag": "0024_media_tv_shows_baseline",
       "breakpoints": true

--- a/packages/media-db/src/__tests__/movies.test.ts
+++ b/packages/media-db/src/__tests__/movies.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Invariant tests for the movies service against an in-memory SQLite
+ * seeded with the canonical `0022_media_movies_baseline.sql` migration.
+ * Pure DB + service layer — no tRPC, no Express, no media-discovery
+ * orchestration.
+ *
+ * Higher-level CRUD integration coverage lives in pops-api's own suite
+ * (`apps/pops-api/src/modules/media/movies/service.test.ts`) and continues
+ * to exercise the same persisted shape via the in-tree shim until PRD-165
+ * PR 3 flips it onto this service.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { MovieConflictError, MovieNotFoundError } from '../errors.js';
+import {
+  createMovie,
+  deleteMovie,
+  getMovie,
+  getMovieByTmdbId,
+  listMovies,
+  updateMovie,
+  type CreateMovieInput,
+} from '../services/movies.js';
+
+import type { MediaDb } from '../services/internal.js';
+
+const MIGRATION_PATH = join(__dirname, '../../migrations/0022_media_movies_baseline.sql');
+
+function freshDb(): { db: MediaDb; raw: Database.Database } {
+  const raw = new Database(':memory:');
+  raw.pragma('foreign_keys = ON');
+  const sql = readFileSync(MIGRATION_PATH, 'utf8');
+  for (const stmt of sql.split('--> statement-breakpoint')) {
+    const trimmed = stmt.trim();
+    if (trimmed.length > 0) raw.exec(trimmed);
+  }
+  return { db: drizzle(raw), raw };
+}
+
+function baseInput(overrides: Partial<CreateMovieInput> = {}): CreateMovieInput {
+  return {
+    tmdbId: 603,
+    title: 'The Matrix',
+    releaseDate: '1999-03-31',
+    runtime: 136,
+    genres: ['Action', 'Science Fiction'],
+    ...overrides,
+  };
+}
+
+describe('createMovie', () => {
+  let db: MediaDb;
+  beforeEach(() => {
+    ({ db } = freshDb());
+  });
+
+  it('persists the row and returns it with an assigned id', () => {
+    const row = createMovie(db, baseInput());
+    expect(row.id).toBeGreaterThan(0);
+    expect(row.tmdbId).toBe(603);
+    expect(row.title).toBe('The Matrix');
+    expect(row.runtime).toBe(136);
+    expect(row.releaseDate).toBe('1999-03-31');
+  });
+
+  it('serialises genres as a JSON array string in the persisted column', () => {
+    const row = createMovie(db, baseInput({ genres: ['Action', 'Science Fiction'] }));
+    expect(row.genres).toBe(JSON.stringify(['Action', 'Science Fiction']));
+  });
+
+  it('defaults genres to an empty JSON array when omitted', () => {
+    const row = createMovie(db, baseInput({ genres: undefined }));
+    expect(row.genres).toBe('[]');
+  });
+
+  it('null-fills every optional column when omitted', () => {
+    const row = createMovie(db, { tmdbId: 1, title: 'Minimal' });
+    expect(row.imdbId).toBeNull();
+    expect(row.overview).toBeNull();
+    expect(row.tagline).toBeNull();
+    expect(row.releaseDate).toBeNull();
+    expect(row.runtime).toBeNull();
+    expect(row.voteAverage).toBeNull();
+    expect(row.voteCount).toBeNull();
+    expect(row.posterPath).toBeNull();
+    expect(row.backdropPath).toBeNull();
+    expect(row.logoPath).toBeNull();
+    expect(row.posterOverridePath).toBeNull();
+  });
+
+  it('throws MovieConflictError when the tmdb_id unique index is violated', () => {
+    createMovie(db, baseInput());
+    expect(() => createMovie(db, baseInput({ title: 'Duplicate' }))).toThrow(MovieConflictError);
+  });
+});
+
+describe('getMovie', () => {
+  let db: MediaDb;
+  beforeEach(() => {
+    ({ db } = freshDb());
+  });
+
+  it('returns the persisted row by id', () => {
+    const created = createMovie(db, baseInput());
+    expect(getMovie(db, created.id)).toEqual(created);
+  });
+
+  it('throws MovieNotFoundError when the id is missing', () => {
+    expect(() => getMovie(db, 9_999)).toThrow(MovieNotFoundError);
+  });
+});
+
+describe('getMovieByTmdbId', () => {
+  let db: MediaDb;
+  beforeEach(() => {
+    ({ db } = freshDb());
+  });
+
+  it('returns the persisted row when present', () => {
+    const created = createMovie(db, baseInput());
+    expect(getMovieByTmdbId(db, 603)).toEqual(created);
+  });
+
+  it('returns null when no row matches', () => {
+    expect(getMovieByTmdbId(db, 999_999)).toBeNull();
+  });
+
+  it('does not throw on miss — null is the contract', () => {
+    expect(() => getMovieByTmdbId(db, 1)).not.toThrow();
+  });
+});
+
+describe('listMovies', () => {
+  let db: MediaDb;
+  beforeEach(() => {
+    ({ db } = freshDb());
+    createMovie(db, baseInput({ tmdbId: 603, title: 'The Matrix', releaseDate: '1999-03-31' }));
+    createMovie(db, baseInput({ tmdbId: 27205, title: 'Inception', releaseDate: '2010-07-16' }));
+    createMovie(
+      db,
+      baseInput({
+        tmdbId: 157336,
+        title: 'Interstellar',
+        releaseDate: '2014-11-05',
+        genres: ['Adventure', 'Drama'],
+      })
+    );
+  });
+
+  it('returns rows ordered by release_date DESC and an accurate total', () => {
+    const result = listMovies(db, {}, 10, 0);
+    expect(result.total).toBe(3);
+    expect(result.rows.map((r) => r.title)).toEqual(['Interstellar', 'Inception', 'The Matrix']);
+  });
+
+  it('respects limit + offset for pagination', () => {
+    const result = listMovies(db, {}, 1, 1);
+    expect(result.total).toBe(3);
+    expect(result.rows.map((r) => r.title)).toEqual(['Inception']);
+  });
+
+  it('filters by title LIKE when `search` is set', () => {
+    const result = listMovies(db, { search: 'Inter' }, 10, 0);
+    expect(result.total).toBe(1);
+    expect(result.rows[0]?.title).toBe('Interstellar');
+  });
+
+  it('filters by genre via json_each on the genres column', () => {
+    const result = listMovies(db, { genre: 'Drama' }, 10, 0);
+    expect(result.total).toBe(1);
+    expect(result.rows[0]?.title).toBe('Interstellar');
+  });
+
+  it('combines `search` and `genre` with AND', () => {
+    const result = listMovies(db, { search: 'Inter', genre: 'Adventure' }, 10, 0);
+    expect(result.total).toBe(1);
+    expect(result.rows[0]?.title).toBe('Interstellar');
+
+    const empty = listMovies(db, { search: 'Inter', genre: 'Action' }, 10, 0);
+    expect(empty.total).toBe(0);
+    expect(empty.rows).toHaveLength(0);
+  });
+});
+
+describe('updateMovie', () => {
+  let db: MediaDb;
+  beforeEach(() => {
+    ({ db } = freshDb());
+  });
+
+  it('updates the supplied fields and re-reads the row', () => {
+    const created = createMovie(db, baseInput());
+    const updated = updateMovie(db, created.id, { title: 'The Matrix (Reloaded)', runtime: 138 });
+    expect(updated.title).toBe('The Matrix (Reloaded)');
+    expect(updated.runtime).toBe(138);
+    expect(updated.tmdbId).toBe(603);
+  });
+
+  it('round-trips genres through JSON.stringify', () => {
+    const created = createMovie(db, baseInput());
+    const updated = updateMovie(db, created.id, { genres: ['Action'] });
+    expect(updated.genres).toBe(JSON.stringify(['Action']));
+  });
+
+  it('treats `null` on optional fields as a clear, not a skip', () => {
+    const created = createMovie(db, baseInput({ tagline: 'Hello world' }));
+    const updated = updateMovie(db, created.id, { tagline: null });
+    expect(updated.tagline).toBeNull();
+  });
+
+  it('skips the UPDATE entirely when no fields are supplied (no-op patch)', () => {
+    const created = createMovie(db, baseInput());
+    const updated = updateMovie(db, created.id, {});
+    expect(updated.updatedAt).toBe(created.updatedAt);
+    expect(updated).toEqual(created);
+  });
+
+  it('bumps updated_at when any field is touched', () => {
+    const created = createMovie(db, baseInput());
+    const updated = updateMovie(db, created.id, { title: 'New title' });
+    expect(updated.updatedAt).not.toBe(created.updatedAt);
+  });
+
+  it('throws MovieNotFoundError when the id is missing', () => {
+    expect(() => updateMovie(db, 9_999, { title: 'x' })).toThrow(MovieNotFoundError);
+  });
+});
+
+describe('deleteMovie', () => {
+  let db: MediaDb;
+  beforeEach(() => {
+    ({ db } = freshDb());
+  });
+
+  it('removes the row and a subsequent get throws MovieNotFoundError', () => {
+    const created = createMovie(db, baseInput());
+    deleteMovie(db, created.id);
+    expect(() => getMovie(db, created.id)).toThrow(MovieNotFoundError);
+  });
+
+  it('throws MovieNotFoundError when the id is missing', () => {
+    expect(() => deleteMovie(db, 9_999)).toThrow(MovieNotFoundError);
+  });
+});

--- a/packages/media-db/src/errors.ts
+++ b/packages/media-db/src/errors.ts
@@ -6,6 +6,26 @@
  * to clients. Mirrors `@pops/finance-db`'s error pattern.
  */
 
+export class MovieNotFoundError extends Error {
+  override readonly name = 'MovieNotFoundError' as const;
+  readonly id: number;
+
+  constructor(id: number) {
+    super(`Movie '${id}' not found`);
+    this.id = id;
+  }
+}
+
+export class MovieConflictError extends Error {
+  override readonly name = 'MovieConflictError' as const;
+  readonly tmdbId: number;
+
+  constructor(tmdbId: number) {
+    super(`Movie with tmdbId ${tmdbId} already exists`);
+    this.tmdbId = tmdbId;
+  }
+}
+
 export class TvShowNotFoundError extends Error {
   override readonly name = 'TvShowNotFoundError' as const;
   readonly id: number;

--- a/packages/media-db/src/index.ts
+++ b/packages/media-db/src/index.ts
@@ -17,7 +17,25 @@ export type { MediaDb } from './services/internal.js';
 
 export { openMediaDb, type OpenedMediaDb } from './open-media-db.js';
 
-export { TvShowConflictError, TvShowNotFoundError } from './errors.js';
+export {
+  MovieConflictError,
+  MovieNotFoundError,
+  TvShowConflictError,
+  TvShowNotFoundError,
+} from './errors.js';
+
+export type {
+  CreateMovieInput,
+  Movie,
+  MovieFilters,
+  MovieListResult,
+  MovieRow,
+  UpdateMovieInput,
+} from './services/movies.js';
+
+export * as moviesService from './services/movies.js';
+
+export * as shelfImpressionsService from './services/shelf-impressions.js';
 
 export type {
   CreateTvShowInput,
@@ -29,5 +47,3 @@ export type {
 } from './services/tv-shows.js';
 
 export * as tvShowsService from './services/tv-shows.js';
-
-export * as shelfImpressionsService from './services/shelf-impressions.js';

--- a/packages/media-db/src/schema.ts
+++ b/packages/media-db/src/schema.ts
@@ -11,4 +11,4 @@
  * Mirrors the `@pops/core-db` schema re-export pattern. The shape grows as
  * subsequent Phase 1 PRs migrate additional media tables into this package.
  */
-export { shelfImpressions, tvShows } from '@pops/db-types';
+export { movies, shelfImpressions, tvShows } from '@pops/db-types';

--- a/packages/media-db/src/services/movies-unique-violation.ts
+++ b/packages/media-db/src/services/movies-unique-violation.ts
@@ -1,0 +1,30 @@
+/**
+ * Detect whether an error from a `movies` write is a UNIQUE-on-`tmdb_id`
+ * violation. better-sqlite3 surfaces UNIQUE index violations with
+ * `code = 'SQLITE_CONSTRAINT_UNIQUE'` and a message that names the table
+ * and column. Drizzle may wrap the original as `.cause`, so we walk the
+ * cause chain.
+ *
+ * Mirrors `@pops/finance-db`'s `isBudgetUniqueViolation` shape. The broader
+ * `SQLITE_CONSTRAINT` code is accepted as a defensive fallback for older
+ * drivers that drop the suffix.
+ */
+const MAX_CAUSE_DEPTH = 5;
+
+export function isMoviesTmdbIdUniqueViolation(err: unknown): boolean {
+  let current: unknown = err;
+  for (let i = 0; i < MAX_CAUSE_DEPTH && current instanceof Error; i++) {
+    if (matchesMoviesTmdbIdUnique(current)) return true;
+    const next: unknown = (current as { cause?: unknown }).cause;
+    if (next === current) return false;
+    current = next;
+  }
+  return false;
+}
+
+function matchesMoviesTmdbIdUnique(err: Error): boolean {
+  const code: unknown = (err as { code?: unknown }).code;
+  if (typeof code !== 'string') return false;
+  if (code !== 'SQLITE_CONSTRAINT_UNIQUE' && code !== 'SQLITE_CONSTRAINT') return false;
+  return /UNIQUE constraint failed:\s*movies\.tmdb_id/.test(err.message);
+}

--- a/packages/media-db/src/services/movies.ts
+++ b/packages/media-db/src/services/movies.ts
@@ -1,0 +1,253 @@
+/**
+ * Movies CRUD against the media pillar's SQLite via drizzle.
+ *
+ * Services take a `MediaDb` handle as their first argument; the calling
+ * layer (pops-api modules) is responsible for resolving the singleton
+ * or transaction handle to pass in. Mirrors `@pops/finance-db`'s
+ * service signature pattern.
+ *
+ * The in-tree service in `apps/pops-api/src/modules/media/movies/`
+ * still routes through the shared `getDrizzle()` handle for now —
+ * PRD-165 PR 3 flips that to `getMediaDrizzle()` and routes through
+ * this module.
+ */
+import { and, count, desc, eq, like, type SQL, sql } from 'drizzle-orm';
+
+import { MovieConflictError, MovieNotFoundError } from '../errors.js';
+import { movies } from '../schema.js';
+
+import type { MediaDb } from './internal.js';
+
+/** Raw drizzle row shape — the persisted movies record. */
+export type MovieRow = typeof movies.$inferSelect;
+
+/**
+ * Public alias for the persisted movie row. The UI-side view-model
+ * (poster/backdrop URL derivation, JSON-parsed genres) is constructed in
+ * pops-api's `toMovie` helper at the router boundary so this package
+ * stays HTTP-free.
+ */
+export type Movie = MovieRow;
+
+/** Filters accepted by {@link listMovies}. */
+export interface MovieFilters {
+  search?: string | undefined;
+  genre?: string | undefined;
+}
+
+/** Count + rows for a paginated list. */
+export interface MovieListResult {
+  rows: MovieRow[];
+  total: number;
+}
+
+/** Mutable subset accepted on create. `genres` defaults to `[]`. */
+export interface CreateMovieInput {
+  tmdbId: number;
+  imdbId?: string | null;
+  title: string;
+  originalTitle?: string | null;
+  overview?: string | null;
+  tagline?: string | null;
+  releaseDate?: string | null;
+  runtime?: number | null;
+  status?: string | null;
+  originalLanguage?: string | null;
+  budget?: number | null;
+  revenue?: number | null;
+  posterPath?: string | null;
+  backdropPath?: string | null;
+  logoPath?: string | null;
+  posterOverridePath?: string | null;
+  voteAverage?: number | null;
+  voteCount?: number | null;
+  genres?: string[];
+}
+
+/** Same shape as create — all fields optional for PATCH semantics. */
+export interface UpdateMovieInput {
+  tmdbId?: number;
+  imdbId?: string | null;
+  title?: string;
+  originalTitle?: string | null;
+  overview?: string | null;
+  tagline?: string | null;
+  releaseDate?: string | null;
+  runtime?: number | null;
+  status?: string | null;
+  originalLanguage?: string | null;
+  budget?: number | null;
+  revenue?: number | null;
+  posterPath?: string | null;
+  backdropPath?: string | null;
+  logoPath?: string | null;
+  posterOverridePath?: string | null;
+  voteAverage?: number | null;
+  voteCount?: number | null;
+  genres?: string[];
+}
+
+const MOVIE_NULLABLE_INSERT_KEYS = [
+  'imdbId',
+  'originalTitle',
+  'overview',
+  'tagline',
+  'releaseDate',
+  'runtime',
+  'status',
+  'originalLanguage',
+  'budget',
+  'revenue',
+  'posterPath',
+  'backdropPath',
+  'logoPath',
+  'posterOverridePath',
+  'voteAverage',
+  'voteCount',
+] as const satisfies ReadonlyArray<keyof CreateMovieInput & keyof typeof movies.$inferInsert>;
+
+function buildMovieInsertValues(input: CreateMovieInput): typeof movies.$inferInsert {
+  const values: Record<string, unknown> = {
+    tmdbId: input.tmdbId,
+    title: input.title,
+    genres: JSON.stringify(input.genres ?? []),
+  };
+  for (const key of MOVIE_NULLABLE_INSERT_KEYS) {
+    values[key] = input[key] ?? null;
+  }
+  return values as typeof movies.$inferInsert;
+}
+
+const MOVIE_REQUIRED_UPDATE_KEYS = ['tmdbId', 'title'] as const satisfies ReadonlyArray<
+  keyof UpdateMovieInput & keyof typeof movies.$inferSelect
+>;
+
+const MOVIE_NULLABLE_UPDATE_KEYS = [
+  'imdbId',
+  'originalTitle',
+  'overview',
+  'tagline',
+  'releaseDate',
+  'runtime',
+  'status',
+  'originalLanguage',
+  'budget',
+  'revenue',
+  'posterPath',
+  'backdropPath',
+  'logoPath',
+  'posterOverridePath',
+  'voteAverage',
+  'voteCount',
+] as const satisfies ReadonlyArray<keyof UpdateMovieInput & keyof typeof movies.$inferSelect>;
+
+function buildMovieUpdate(input: UpdateMovieInput): Partial<typeof movies.$inferSelect> | null {
+  const updates: Record<string, unknown> = {};
+  let touched = false;
+
+  for (const key of MOVIE_REQUIRED_UPDATE_KEYS) {
+    const value = input[key];
+    if (value === undefined) continue;
+    updates[key] = value;
+    touched = true;
+  }
+
+  for (const key of MOVIE_NULLABLE_UPDATE_KEYS) {
+    const value = input[key];
+    if (value === undefined) continue;
+    updates[key] = value ?? null;
+    touched = true;
+  }
+
+  if (input.genres !== undefined) {
+    updates.genres = JSON.stringify(input.genres);
+    touched = true;
+  }
+
+  if (!touched) return null;
+  updates.updatedAt = new Date().toISOString();
+  return updates as Partial<typeof movies.$inferSelect>;
+}
+
+/** List movies with optional filters. Ordered by `release_date DESC`. */
+export function listMovies(
+  db: MediaDb,
+  filters: MovieFilters,
+  limit: number,
+  offset: number
+): MovieListResult {
+  const conditions: SQL[] = [];
+
+  if (filters.search) {
+    conditions.push(like(movies.title, `%${filters.search}%`));
+  }
+  if (filters.genre) {
+    conditions.push(
+      sql`EXISTS (SELECT 1 FROM json_each(${movies.genres}) WHERE json_each.value = ${filters.genre})`
+    );
+  }
+
+  const where = conditions.length > 0 ? and(...conditions) : undefined;
+
+  const rows = db
+    .select()
+    .from(movies)
+    .where(where)
+    .orderBy(desc(movies.releaseDate))
+    .limit(limit)
+    .offset(offset)
+    .all();
+
+  const [countRow] = db.select({ total: count() }).from(movies).where(where).all();
+
+  return { rows, total: countRow?.total ?? 0 };
+}
+
+/** Get a single movie by id. Throws `MovieNotFoundError` if missing. */
+export function getMovie(db: MediaDb, id: number): MovieRow {
+  const row = db.select().from(movies).where(eq(movies.id, id)).get();
+  if (!row) throw new MovieNotFoundError(id);
+  return row;
+}
+
+/** Get a single movie by TMDB id. Returns `null` if not found. */
+export function getMovieByTmdbId(db: MediaDb, tmdbId: number): MovieRow | null {
+  return db.select().from(movies).where(eq(movies.tmdbId, tmdbId)).get() ?? null;
+}
+
+/**
+ * Create a new movie. Returns the persisted row. Throws
+ * `MovieConflictError` when the `tmdbId` already exists (the unique index
+ * raises a `UNIQUE constraint failed: movies.tmdb_id` SQLITE_CONSTRAINT).
+ */
+export function createMovie(db: MediaDb, input: CreateMovieInput): MovieRow {
+  try {
+    const result = db.insert(movies).values(buildMovieInsertValues(input)).run();
+    return getMovie(db, Number(result.lastInsertRowid));
+  } catch (err) {
+    if (err instanceof Error && err.message.includes('UNIQUE constraint failed')) {
+      throw new MovieConflictError(input.tmdbId);
+    }
+    throw err;
+  }
+}
+
+/**
+ * Patch a movie. Throws `MovieNotFoundError` if missing. No-op writes
+ * (empty `input`) still re-read the row but skip the UPDATE.
+ */
+export function updateMovie(db: MediaDb, id: number, input: UpdateMovieInput): MovieRow {
+  getMovie(db, id);
+  const updates = buildMovieUpdate(input);
+  if (updates) {
+    db.update(movies).set(updates).where(eq(movies.id, id)).run();
+  }
+  return getMovie(db, id);
+}
+
+/** Delete a movie. Throws `MovieNotFoundError` if missing. */
+export function deleteMovie(db: MediaDb, id: number): void {
+  getMovie(db, id);
+  const result = db.delete(movies).where(eq(movies.id, id)).run();
+  if (result.changes === 0) throw new MovieNotFoundError(id);
+}

--- a/packages/media-db/src/services/movies.ts
+++ b/packages/media-db/src/services/movies.ts
@@ -15,6 +15,7 @@ import { and, count, desc, eq, like, type SQL, sql } from 'drizzle-orm';
 
 import { MovieConflictError, MovieNotFoundError } from '../errors.js';
 import { movies } from '../schema.js';
+import { isMoviesTmdbIdUniqueViolation } from './movies-unique-violation.js';
 
 import type { MediaDb } from './internal.js';
 
@@ -198,7 +199,7 @@ export function listMovies(
     .offset(offset)
     .all();
 
-  const [countRow] = db.select({ total: count() }).from(movies).where(where).all();
+  const countRow = db.select({ total: count() }).from(movies).where(where).get();
 
   return { rows, total: countRow?.total ?? 0 };
 }
@@ -218,14 +219,15 @@ export function getMovieByTmdbId(db: MediaDb, tmdbId: number): MovieRow | null {
 /**
  * Create a new movie. Returns the persisted row. Throws
  * `MovieConflictError` when the `tmdbId` already exists (the unique index
- * raises a `UNIQUE constraint failed: movies.tmdb_id` SQLITE_CONSTRAINT).
+ * raises `SQLITE_CONSTRAINT_UNIQUE` on `movies.tmdb_id`). Any other
+ * constraint violation propagates untouched so the caller can map it.
  */
 export function createMovie(db: MediaDb, input: CreateMovieInput): MovieRow {
   try {
     const result = db.insert(movies).values(buildMovieInsertValues(input)).run();
     return getMovie(db, Number(result.lastInsertRowid));
   } catch (err) {
-    if (err instanceof Error && err.message.includes('UNIQUE constraint failed')) {
+    if (isMoviesTmdbIdUniqueViolation(err)) {
       throw new MovieConflictError(input.tmdbId);
     }
     throw err;


### PR DESCRIPTION
## Summary

PR 1 of the 4-PR sequence in [`docs/themes/13-pillar-finale/prds/165-media-movies-cutover/README.md`](../blob/main/docs/themes/13-pillar-finale/prds/165-media-movies-cutover/README.md). Stands up the `movies` slice on `@pops/media-db` and extends the boot-time media-pillar backfill — **purely additive**. pops-api keeps reading and writing through `getDrizzle()` on the shared `pops.db`; the cutover to `getMediaDrizzle()` lands in PR 3.

- `@pops/media-db`: re-export `movies` from the schema barrel, new `0022_media_movies_baseline.sql` (synthetic — every column + every index from the shared journal's `0001` + `0012` + `0028` slices), new `services/movies.ts` exporting `moviesService.{list, get, getByTmdbId, create, update, delete}` against a `MediaDb` handle, typed `MovieNotFoundError` / `MovieConflictError`. API mirrors the pops-api in-tree service exactly so PR 3 is a swap of `getDrizzle()` for `getMediaDrizzle()` at the call site.
- `apps/pops-api`: refactor `media-backfill.ts` to the `TABLE_COPIES` pattern used by the finance backfill, add a `movies` entry with the full column list, extend the test fixtures + test suite with movie row fresh-copy, mixed-state, full-shape roundtrip, and missing-source-table cases.

No consumer code changes — the in-tree shim in `apps/pops-api/src/modules/media/movies/*` is untouched and the schema-coverage CI guard already includes `media`.

## Test plan

- [x] `pnpm -F @pops/media-db build && test && typecheck` — green (44 tests, 22 new movies cases)
- [x] `pnpm -F @pops/api typecheck` — green
- [x] `pnpm -w turbo typecheck` — green (66 / 66)
- [x] `apps/pops-api` media-backfill suite — green (8 / 8)
- [x] `apps/pops-api` movies router suite — green (14 / 14, unchanged behaviour)
- [x] `node scripts/check-pillar-schema-coverage.mjs --pillar media` — OK (movies + shelf_impressions)
- [x] `oxlint --type-aware` + `oxfmt --check` — clean on changed files
- [ ] CI green on `Pillar Schema Coverage` (matrix: media) and `Media DB Quality`
