### PR TITLE
fix(ci): pre-build contract chain before turbo affected-rebuild

### DIFF
--- a/.github/workflows/contract-semver.yml
+++ b/.github/workflows/contract-semver.yml
@@ -119,11 +119,38 @@ jobs:
           echo "sha=$MERGE_BASE" >> "$GITHUB_OUTPUT"
           echo "Merge base: $MERGE_BASE"
 
+      - name: Build shared packages
+        run: |
+          pnpm --filter @pops/db-types build
+          pnpm --filter @pops/types build
+          pnpm --filter @pops/module-registry build
+          pnpm --filter @pops/food-contracts build
+          pnpm --filter @pops/core-db build
+          pnpm --filter @pops/finance-db build
+          pnpm --filter @pops/inventory-db build
+          pnpm --filter @pops/media-db build
+          pnpm --filter @pops/cerebrum-db build
+          pnpm --filter @pops/food-db build
+          pnpm --filter @pops/lists-db build
+          pnpm --filter @pops/app-lists-db build
+          pnpm --filter @pops/app-food-db build
+          pnpm --filter @pops/finance-contract build
+          pnpm --filter @pops/pillar-sdk build
+          pnpm --filter @pops/media-contract build
+          pnpm --filter @pops/inventory-contract build
+          pnpm --filter @pops/cerebrum-contract build
+          pnpm --filter @pops/core-contract build
+          pnpm --filter @pops/lists-contract build
+          pnpm --filter @pops/food-contract build
+
       - name: Affected package typecheck + test via turbo
         run: |
           # `...[<merge-base>]` selects every workspace package that
           # transitively depends on a package changed since merge-base.
           # If no consumers, turbo simply runs zero tasks (pass-no-consumers).
+          # The pre-build step above closes the pillar-sdk → finance-contract
+          # gap that turbo's `^build` graph cannot see (optional peer-dep,
+          # not a workspace dep — and closing it as a devDep creates a cycle).
           pnpm turbo run typecheck test --filter="...[${{ steps.merge-base.outputs.sha }}]" --concurrency=4
 
   tag-on-bump:


### PR DESCRIPTION
## Summary

- The `affected-rebuild` job in `.github/workflows/contract-semver.yml` runs `pnpm turbo run typecheck test --filter='...[<merge-base>]'`. Turbo's `^build` graph does not follow `pillar-sdk -> finance-contract` (optional peer-dep, not a workspace dep), and closing that edge as a devDep creates a cycle (`pillar-sdk -> finance-contract -> finance-api -> pillar-sdk`) that turbo refuses to plan.
- When a non-finance contract changes (e.g. inventory-contract), turbo schedules `pillar-sdk` build but skips `finance-contract`, and `pillar-sdk/src/contracts/index.ts` then fails with `TS2307: Cannot find module '@pops/finance-contract/manifest'`.
- Fix: pre-build the contract chain explicitly before invoking turbo, mirroring the same precedent already used in `.github/workflows/_pkg-check.yml` (lines 45-65 / 91-109). Same ordered list of `pnpm --filter ... build` calls.

## Context

- Failing run: https://github.com/knoxio/pops/actions/runs/27411991056
- PR that surfaced it: #2985
- Not pursued: adding `finance-contract` as a devDep on `pillar-sdk` — confirmed cycle blocker.
- Not touched: `pillar-sdk/src/contracts/index.ts` (intentional type-only re-export, documented at `packages/finance-contract/src/router.ts:1-19`) and `turbo.json`.

## Test plan

- [ ] CI: `Contract Semver / Affected rebuild` succeeds on this PR.
- [ ] Confirm step ordering: `Compute merge-base` -> `Build shared packages` -> `Affected package typecheck + test via turbo`.
- [ ] Re-run #2985 (or rebase it onto this) and confirm `pillar-sdk` typecheck no longer fails on `@pops/finance-contract/manifest` resolution.
