### PR TITLE
feat(media-api): move media.watchlist writer into pops-media-api (Theme 13 PRD-167 PR 1)

### DIFF
--- a/apps/pops-api/src/db/per-pillar-migrations.test.ts
+++ b/apps/pops-api/src/db/per-pillar-migrations.test.ts
@@ -203,17 +203,22 @@ describe('runPerPillarMigrations', () => {
     // Smoke check: importing the runner under the real layout exercises
     // the workspace fallback path against an actual on-disk pillar dir.
     // `core` owns `packages/core-db/migrations/` with 0054_service_accounts
-    // (core pillar Phase 1 PR 2); `media` owns `packages/media-db/migrations/`
-    // with 0021_spooky_lockheed (media pillar Phase 1 PR 2); `inventory`
-    // owns `packages/inventory-db/migrations/` with 0005_fancy_crystal
-    // (inventory pillar Phase 1 PR 2), 0006_inventory_pillar_baseline
-    // (inventory pillar Phase 2 PR 3 — comprehensive home_inventory +
-    // fixtures + item_* baseline ahead of the cutover), AND
-    // 0007_locations_parent_sort_index (#2917 — backfill missing index
-    // carried over from shared journal 0009_red_quasimodo); `cerebrum` owns
-    // `packages/cerebrum-db/migrations/` with 0039_dry_fabian_cortez and
-    // 0044_nudge_log (cerebrum pillar Phase 1 PR 2 — nudge_log slice).
-    // Pillars without their own journal yet still skip cleanly.
+    // (core pillar Phase 1 PR 2) and 0055_pillar_registry (Theme 13 PRD-161
+    // registry endpoints); `media` owns `packages/media-db/migrations/`
+    // with 0021_spooky_lockheed (media pillar Phase 1 PR 2),
+    // 0022_media_movies_baseline (Theme 13 PRD-165 US-01 — movies baseline),
+    // 0023_watchlist_baseline (Theme 13 PRD-167 PR 1 — watchlist baseline),
+    // and 0024_media_tv_shows_baseline (Theme 13 PRD-166 US-01 — tv-shows baseline);
+    // `inventory` owns `packages/inventory-db/migrations/` with
+    // 0005_fancy_crystal (inventory pillar Phase 1 PR 2),
+    // 0006_inventory_pillar_baseline (inventory pillar Phase 2 PR 3 —
+    // comprehensive home_inventory + fixtures + item_* baseline ahead of
+    // the cutover), AND 0007_locations_parent_sort_index (#2917 — backfill
+    // missing index carried over from shared journal 0009_red_quasimodo);
+    // `cerebrum` owns `packages/cerebrum-db/migrations/` with
+    // 0039_dry_fabian_cortez and 0044_nudge_log (cerebrum pillar Phase 1
+    // PR 2 — nudge_log slice). Pillars without their own journal yet still
+    // skip cleanly.
     await withDb((db) => {
       const realPillars: PillarDescriptor[] = [
         { id: 'core', dbPackageDir: 'packages/core-db' },
@@ -229,6 +234,7 @@ describe('runPerPillarMigrations', () => {
         '0007_locations_parent_sort_index',
         '0021_spooky_lockheed',
         '0022_media_movies_baseline',
+        '0023_watchlist_baseline',
         '0024_media_tv_shows_baseline',
         '0039_dry_fabian_cortez',
         '0044_nudge_log',

--- a/apps/pops-api/src/modules/media/watchlist/router.ts
+++ b/apps/pops-api/src/modules/media/watchlist/router.ts
@@ -1,5 +1,12 @@
 /**
  * Watchlist tRPC router — CRUD procedures for media watchlist.
+ *
+ * @deprecated PRD-167 PR 1 (Theme 13) shadows this router on
+ * `apps/pops-media-api/src/modules/watchlist` against `@pops/media-db`.
+ * The mount stays here as the fall-through while the dispatcher / cutover
+ * lands in PRD-167 PR 3; reads continue to flow through this surface
+ * because the `movies` / `tv_shows` enrichment join hasn't moved to the
+ * media pillar yet (gated on PRD-165 / PRD-166).
  */
 import { TRPCError } from '@trpc/server';
 import { z } from 'zod';

--- a/apps/pops-media-api/src/__tests__/watchlist.test.ts
+++ b/apps/pops-media-api/src/__tests__/watchlist.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Integration tests for the migrated `media.watchlist.*` tRPC surface
+ * inside pops-media-api (PRD-167 PR 1 / Theme 13).
+ *
+ * Two layers of coverage:
+ *
+ *   1. tRPC caller smoke — drives `appRouter.createCaller(ctx)` against
+ *      a per-test in-memory media.db. Asserts CRUD happy paths, the
+ *      idempotent `add` branch, NOT_FOUND surfacing for missing ids,
+ *      CONFLICT surfacing for duplicate reorder priorities, BAD_REQUEST
+ *      at the zod boundary, and the UNAUTHORIZED gate when no user
+ *      principal is in context.
+ *
+ *   2. HTTP wire smoke — boots the Express app via `createMediaApiApp`
+ *      and round-trips one mutation over `/trpc` with supertest to prove
+ *      the wiring + the dev-user fallback context resolver.
+ *
+ * Service-layer invariants (ordering, idempotence, resequencing) already
+ * live in `packages/media-db/src/__tests__/watchlist.test.ts`.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { openMediaDb, type OpenedMediaDb } from '@pops/media-db';
+
+import { createMediaApiApp } from '../app.js';
+import { appRouter } from '../router.js';
+import { type Context } from '../trpc.js';
+
+let tmpDir: string;
+let mediaDb: OpenedMediaDb;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'media-api-watchlist-test-'));
+  mediaDb = openMediaDb(join(tmpDir, 'media.db'));
+});
+
+afterEach(() => {
+  mediaDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function userCaller(email = 'admin@example.com'): ReturnType<typeof appRouter.createCaller> {
+  const ctx: Context = {
+    user: { email },
+    mediaDb: mediaDb.db,
+  };
+  return appRouter.createCaller(ctx);
+}
+
+function anonCaller(): ReturnType<typeof appRouter.createCaller> {
+  const ctx: Context = {
+    user: null,
+    mediaDb: mediaDb.db,
+  };
+  return appRouter.createCaller(ctx);
+}
+
+describe('media.watchlist (tRPC caller)', () => {
+  it('round-trips add → list → status → get → update → remove', async () => {
+    const caller = userCaller();
+
+    const addResp = await caller.media.watchlist.add({
+      mediaType: 'movie',
+      mediaId: 550,
+      priority: 1,
+      notes: 'Must watch',
+    });
+    expect(addResp.created).toBe(true);
+    expect(addResp.data.mediaType).toBe('movie');
+    expect(addResp.data.mediaId).toBe(550);
+    expect(addResp.data.priority).toBe(1);
+    expect(addResp.data.notes).toBe('Must watch');
+    expect(addResp.data.title).toBeNull();
+    expect(addResp.data.posterUrl).toBeNull();
+
+    const list = await caller.media.watchlist.list({});
+    expect(list.pagination.total).toBe(1);
+    expect(list.data).toHaveLength(1);
+    expect(list.data[0]?.id).toBe(addResp.data.id);
+
+    const status = await caller.media.watchlist.status({ mediaType: 'movie', mediaId: 550 });
+    expect(status).toEqual({ onWatchlist: true, entryId: addResp.data.id });
+
+    const got = await caller.media.watchlist.get({ id: addResp.data.id });
+    expect(got.data.mediaId).toBe(550);
+
+    const upd = await caller.media.watchlist.update({
+      id: addResp.data.id,
+      data: { priority: 9 },
+    });
+    expect(upd.data.priority).toBe(9);
+    expect(upd.data.notes).toBe('Must watch');
+
+    const rm = await caller.media.watchlist.remove({ id: addResp.data.id });
+    expect(rm.message).toBe('Removed from watchlist');
+
+    const after = await caller.media.watchlist.status({ mediaType: 'movie', mediaId: 550 });
+    expect(after.onWatchlist).toBe(false);
+  });
+
+  it('add is idempotent on (mediaType, mediaId)', async () => {
+    const caller = userCaller();
+    const first = await caller.media.watchlist.add({ mediaType: 'movie', mediaId: 1 });
+    const second = await caller.media.watchlist.add({ mediaType: 'movie', mediaId: 1 });
+
+    expect(first.created).toBe(true);
+    expect(second.created).toBe(false);
+    expect(second.data.id).toBe(first.data.id);
+    expect(second.message).toBe('Already on watchlist');
+  });
+
+  it('list orders by priority ASC then addedAt DESC and respects mediaType filter', async () => {
+    const caller = userCaller();
+    await caller.media.watchlist.add({ mediaType: 'movie', mediaId: 1, priority: 2 });
+    await caller.media.watchlist.add({ mediaType: 'movie', mediaId: 2, priority: 0 });
+    await caller.media.watchlist.add({ mediaType: 'tv_show', mediaId: 3, priority: 1 });
+
+    const all = await caller.media.watchlist.list({});
+    expect(all.pagination.total).toBe(3);
+    expect(all.data.map((r) => r.mediaId)).toEqual([2, 3, 1]);
+
+    const movies = await caller.media.watchlist.list({ mediaType: 'movie' });
+    expect(movies.pagination.total).toBe(2);
+    expect(movies.data.every((r) => r.mediaType === 'movie')).toBe(true);
+  });
+
+  it('reorder updates priorities and rejects duplicates', async () => {
+    const caller = userCaller();
+    const a = await caller.media.watchlist.add({ mediaType: 'movie', mediaId: 1, priority: 0 });
+    const b = await caller.media.watchlist.add({ mediaType: 'movie', mediaId: 2, priority: 1 });
+    const c = await caller.media.watchlist.add({ mediaType: 'movie', mediaId: 3, priority: 2 });
+
+    await caller.media.watchlist.reorder({
+      items: [
+        { id: c.data.id, priority: 0 },
+        { id: a.data.id, priority: 1 },
+        { id: b.data.id, priority: 2 },
+      ],
+    });
+    const after = await caller.media.watchlist.list({});
+    expect(after.data.map((r) => r.mediaId)).toEqual([3, 1, 2]);
+
+    await expect(
+      caller.media.watchlist.reorder({
+        items: [
+          { id: a.data.id, priority: 0 },
+          { id: b.data.id, priority: 0 },
+        ],
+      })
+    ).rejects.toMatchObject({
+      name: 'TRPCError',
+      code: 'CONFLICT',
+    });
+  });
+
+  it('returns NOT_FOUND for missing ids on get / update / remove / reorder', async () => {
+    const caller = userCaller();
+
+    await expect(caller.media.watchlist.get({ id: 9999 })).rejects.toMatchObject({
+      name: 'TRPCError',
+      code: 'NOT_FOUND',
+    });
+
+    await expect(
+      caller.media.watchlist.update({ id: 9999, data: { priority: 1 } })
+    ).rejects.toMatchObject({
+      name: 'TRPCError',
+      code: 'NOT_FOUND',
+    });
+
+    await expect(caller.media.watchlist.remove({ id: 9999 })).rejects.toMatchObject({
+      name: 'TRPCError',
+      code: 'NOT_FOUND',
+    });
+
+    await expect(
+      caller.media.watchlist.reorder({ items: [{ id: 9999, priority: 0 }] })
+    ).rejects.toMatchObject({
+      name: 'TRPCError',
+      code: 'NOT_FOUND',
+    });
+  });
+
+  it('rejects malformed input at the zod boundary', async () => {
+    const caller = userCaller();
+    await expect(
+      caller.media.watchlist.add({ mediaType: 'movie', mediaId: -5 })
+    ).rejects.toMatchObject({
+      name: 'TRPCError',
+      code: 'BAD_REQUEST',
+    });
+    await expect(
+      caller.media.watchlist.add({
+        mediaType: 'invalid' as unknown as 'movie',
+        mediaId: 1,
+      })
+    ).rejects.toMatchObject({
+      name: 'TRPCError',
+      code: 'BAD_REQUEST',
+    });
+  });
+
+  it('rejects when no principal is present (UNAUTHORIZED)', async () => {
+    const anon = anonCaller();
+    await expect(anon.media.watchlist.list({})).rejects.toMatchObject({
+      name: 'TRPCError',
+      code: 'UNAUTHORIZED',
+    });
+    await expect(
+      anon.media.watchlist.add({ mediaType: 'movie', mediaId: 1 })
+    ).rejects.toMatchObject({
+      name: 'TRPCError',
+      code: 'UNAUTHORIZED',
+    });
+  });
+});
+
+describe('/trpc HTTP surface', () => {
+  function makeApp(): ReturnType<typeof createMediaApiApp> {
+    return createMediaApiApp({ mediaDb, version: '0.0.1-test' });
+  }
+
+  it('adds + lists a watchlist entry over HTTP (dev context auto-authenticates)', async () => {
+    const app = makeApp();
+
+    const post = await request(app)
+      .post('/trpc/media.watchlist.add')
+      .set('Content-Type', 'application/json')
+      .send({ mediaType: 'movie', mediaId: 42, priority: 3, notes: null });
+    expect(post.status).toBe(200);
+    expect(post.body.result.data.created).toBe(true);
+    expect(post.body.result.data.data.mediaId).toBe(42);
+
+    const list = await request(app).get(
+      `/trpc/media.watchlist.list?input=${encodeURIComponent(JSON.stringify({}))}`
+    );
+    expect(list.status).toBe(200);
+    expect(list.body.result.data.pagination.total).toBe(1);
+    expect(list.body.result.data.data[0].mediaId).toBe(42);
+  });
+});

--- a/apps/pops-media-api/src/modules/watchlist/router.ts
+++ b/apps/pops-media-api/src/modules/watchlist/router.ts
@@ -1,0 +1,179 @@
+/**
+ * Watchlist tRPC router — CRUD procedures for the media watchlist.
+ *
+ * Migrated from `apps/pops-api/src/modules/media/watchlist/router.ts` as
+ * part of PRD-167 PR 1 (Theme 13). The media DB handle is injected via the
+ * tRPC context rather than reached through `getDrizzle()` so media-api
+ * stands alone of pops-api in the dependency graph. Procedure paths stay
+ * rooted at `media.watchlist.*` for a transparent dispatcher swap in
+ * PRD-167 PR 3.
+ *
+ * Scope notes:
+ *
+ *   - List rows are returned without the legacy `title` / `posterUrl`
+ *     enrichment because the `movies` / `tv_shows` tables have not yet
+ *     been split into `@pops/media-db`. Reads stay on the legacy router
+ *     until PRD-165 / PRD-166 land. Per the task spec: "Reads stay on
+ *     legacy."
+ *   - The Plex push side-effect (push to Plex Discover on add/remove)
+ *     is not mirrored here — it stays on the legacy router which still
+ *     owns the integration. Per PRD-167: "Plex API integration changes"
+ *     are out of scope.
+ *
+ * Domain errors from `@pops/media-db` (`WatchlistEntryNotFoundError`,
+ * `WatchlistReorderConflictError`) are translated to local `HttpError`
+ * subclasses inside each handler and routed through `mapDomainErrors`
+ * so the tRPC layer sees a proper `TRPCError` with the right wire-level
+ * code (e.g. `NOT_FOUND`, `CONFLICT`).
+ */
+import { z } from 'zod';
+
+import {
+  watchlistService,
+  WatchlistEntryNotFoundError,
+  WatchlistReorderConflictError,
+} from '@pops/media-db';
+
+import { ConflictError, NotFoundError } from '../../shared/errors.js';
+import { paginationMeta, PaginationMetaSchema } from '../../shared/pagination.js';
+import { mapDomainErrors } from '../../shared/trpc-error-mapper.js';
+import { protectedProcedure, router } from '../../trpc.js';
+import {
+  AddToWatchlistSchema,
+  toWatchlistEntry,
+  UpdateWatchlistSchema,
+  WatchlistEntrySchema,
+  WatchlistQuerySchema,
+} from './types.js';
+
+const DEFAULT_LIMIT = 50;
+const DEFAULT_OFFSET = 0;
+
+export const watchlistRouter = router({
+  /** List watchlist entries with optional filters and pagination. */
+  list: protectedProcedure
+    .input(WatchlistQuerySchema)
+    .output(z.object({ data: z.array(WatchlistEntrySchema), pagination: PaginationMetaSchema }))
+    .query(({ input, ctx }) => {
+      const limit = input.limit ?? DEFAULT_LIMIT;
+      const offset = input.offset ?? DEFAULT_OFFSET;
+
+      const { rows, total } = watchlistService.listWatchlist(
+        ctx.mediaDb,
+        { mediaType: input.mediaType },
+        limit,
+        offset
+      );
+
+      return {
+        data: rows.map((row) => toWatchlistEntry({ ...row, title: null, posterUrl: null })),
+        pagination: paginationMeta(total, limit, offset),
+      };
+    }),
+
+  /** Check whether a specific media item is on the watchlist. */
+  status: protectedProcedure
+    .input(
+      z.object({
+        mediaType: z.enum(['movie', 'tv_show']),
+        mediaId: z.number().int().positive(),
+      })
+    )
+    .query(({ input, ctx }) =>
+      watchlistService.getWatchlistStatus(ctx.mediaDb, input.mediaType, input.mediaId)
+    ),
+
+  /** Get a single watchlist entry by ID. */
+  get: protectedProcedure.input(z.object({ id: z.number() })).query(({ input, ctx }) =>
+    mapDomainErrors(() => {
+      try {
+        const row = watchlistService.getWatchlistEntry(ctx.mediaDb, input.id);
+        return { data: toWatchlistEntry({ ...row, title: null, posterUrl: null }) };
+      } catch (err) {
+        if (err instanceof WatchlistEntryNotFoundError) {
+          throw new NotFoundError('WatchlistEntry', String(input.id));
+        }
+        throw err;
+      }
+    })
+  ),
+
+  /** Add an item to the watchlist. Idempotent — returns the existing entry if already present. */
+  add: protectedProcedure.input(AddToWatchlistSchema).mutation(({ input, ctx }) => {
+    const { row, created } = watchlistService.addToWatchlist(ctx.mediaDb, input);
+    return {
+      data: toWatchlistEntry({ ...row, title: null, posterUrl: null }),
+      created,
+      message: created ? 'Added to watchlist' : 'Already on watchlist',
+    };
+  }),
+
+  /** Update a watchlist entry. */
+  update: protectedProcedure
+    .input(
+      z.object({
+        id: z.number(),
+        data: UpdateWatchlistSchema,
+      })
+    )
+    .mutation(({ input, ctx }) =>
+      mapDomainErrors(() => {
+        try {
+          const row = watchlistService.updateWatchlistEntry(ctx.mediaDb, input.id, input.data);
+          return {
+            data: toWatchlistEntry({ ...row, title: null, posterUrl: null }),
+            message: 'Watchlist entry updated',
+          };
+        } catch (err) {
+          if (err instanceof WatchlistEntryNotFoundError) {
+            throw new NotFoundError('WatchlistEntry', String(input.id));
+          }
+          throw err;
+        }
+      })
+    ),
+
+  /** Batch-reorder watchlist items by setting new priorities. */
+  reorder: protectedProcedure
+    .input(
+      z.object({
+        items: z.array(
+          z.object({
+            id: z.number(),
+            priority: z.number().int().min(0),
+          })
+        ),
+      })
+    )
+    .mutation(({ input, ctx }) =>
+      mapDomainErrors(() => {
+        try {
+          watchlistService.reorderWatchlist(ctx.mediaDb, input.items);
+          return { message: 'Watchlist reordered' };
+        } catch (err) {
+          if (err instanceof WatchlistEntryNotFoundError) {
+            throw new NotFoundError('WatchlistEntry', String(err.entryId));
+          }
+          if (err instanceof WatchlistReorderConflictError) {
+            throw new ConflictError(err.message);
+          }
+          throw err;
+        }
+      })
+    ),
+
+  /** Remove an entry from the watchlist. */
+  remove: protectedProcedure.input(z.object({ id: z.number() })).mutation(({ input, ctx }) =>
+    mapDomainErrors(() => {
+      try {
+        watchlistService.removeFromWatchlist(ctx.mediaDb, input.id);
+        return { message: 'Removed from watchlist' };
+      } catch (err) {
+        if (err instanceof WatchlistEntryNotFoundError) {
+          throw new NotFoundError('WatchlistEntry', String(input.id));
+        }
+        throw err;
+      }
+    })
+  ),
+});

--- a/apps/pops-media-api/src/modules/watchlist/types.ts
+++ b/apps/pops-media-api/src/modules/watchlist/types.ts
@@ -1,0 +1,84 @@
+/**
+ * Zod contract schemas + DTO shapes for the watchlist router.
+ *
+ * Mirrors the wire contract the legacy `apps/pops-api/src/modules/media/watchlist`
+ * router serves so the dispatcher cutover (PRD-167 PR 3) can be a transparent
+ * URL swap rather than a contract rename.
+ *
+ * The legacy router enriches list rows with `title` + `posterUrl` joined from
+ * `movies` / `tv_shows`. Those tables have not been split into `@pops/media-db`
+ * yet, so the media-api shadow surface returns `null` for both fields. PRD-167
+ * PR 3 cutover only flips traffic once the enrichment can be served from the
+ * media pillar (post-PRD-165 / PRD-166).
+ */
+import { z } from 'zod';
+
+import type { MediaWatchlistRow } from '@pops/media-db';
+
+export type { MediaWatchlistRow };
+
+export interface WatchlistEntry {
+  id: number;
+  mediaType: string;
+  mediaId: number;
+  priority: number | null;
+  notes: string | null;
+  source: string | null;
+  plexRatingKey: string | null;
+  addedAt: string;
+  title: string | null;
+  posterUrl: string | null;
+}
+
+export function toWatchlistEntry(
+  row: MediaWatchlistRow & { title?: string | null; posterUrl?: string | null }
+): WatchlistEntry {
+  return {
+    id: row.id,
+    mediaType: row.mediaType,
+    mediaId: row.mediaId,
+    priority: row.priority,
+    notes: row.notes,
+    source: row.source,
+    plexRatingKey: row.plexRatingKey,
+    addedAt: row.addedAt,
+    title: row.title ?? null,
+    posterUrl: row.posterUrl ?? null,
+  };
+}
+
+export const MEDIA_TYPES = ['movie', 'tv_show'] as const;
+
+export const WatchlistEntrySchema = z.object({
+  id: z.number(),
+  mediaType: z.string(),
+  mediaId: z.number(),
+  priority: z.number().nullable(),
+  notes: z.string().nullable(),
+  source: z.string().nullable(),
+  plexRatingKey: z.string().nullable(),
+  addedAt: z.string(),
+  title: z.string().nullable(),
+  posterUrl: z.string().nullable(),
+});
+
+export const AddToWatchlistSchema = z.object({
+  mediaType: z.enum(MEDIA_TYPES),
+  mediaId: z.number().int().positive(),
+  priority: z.number().int().nonnegative().nullable().optional(),
+  notes: z.string().nullable().optional(),
+});
+export type AddToWatchlistInput = z.infer<typeof AddToWatchlistSchema>;
+
+export const UpdateWatchlistSchema = z.object({
+  priority: z.number().int().nonnegative().nullable().optional(),
+  notes: z.string().nullable().optional(),
+});
+export type UpdateWatchlistInput = z.infer<typeof UpdateWatchlistSchema>;
+
+export const WatchlistQuerySchema = z.object({
+  mediaType: z.enum(MEDIA_TYPES).optional(),
+  limit: z.coerce.number().positive().max(500).optional(),
+  offset: z.coerce.number().nonnegative().optional(),
+});
+export type WatchlistQueryRaw = z.infer<typeof WatchlistQuerySchema>;

--- a/apps/pops-media-api/src/router.ts
+++ b/apps/pops-media-api/src/router.ts
@@ -7,10 +7,12 @@
  * `media.shelfImpressions.*`, and media-api answers on the same path.
  */
 import { shelfImpressionsRouter } from './modules/shelf-impressions/router.js';
+import { watchlistRouter } from './modules/watchlist/router.js';
 import { router } from './trpc.js';
 
 export const mediaRouter = router({
   shelfImpressions: shelfImpressionsRouter,
+  watchlist: watchlistRouter,
 });
 
 export const appRouter = router({

--- a/apps/pops-media-api/src/shared/pagination.ts
+++ b/apps/pops-media-api/src/shared/pagination.ts
@@ -1,0 +1,22 @@
+/**
+ * Pagination response builder.
+ *
+ * Mirrors `apps/pops-api/src/shared/pagination.ts` (export-surface only —
+ * media-api's tRPC routers don't need the Express `parsePagination` helper).
+ * Duplicated locally so media-api stands alone of pops-api in the dependency
+ * graph per the Phase 5 writer-move pattern.
+ */
+import { z } from 'zod';
+
+export type PaginationMeta = { total: number; limit: number; offset: number; hasMore: boolean };
+
+export const PaginationMetaSchema = z.object({
+  total: z.number(),
+  limit: z.number(),
+  offset: z.number(),
+  hasMore: z.boolean(),
+});
+
+export function paginationMeta(total: number, limit: number, offset: number): PaginationMeta {
+  return { total, limit, offset, hasMore: offset + limit < total };
+}

--- a/packages/media-db/migrations/0023_watchlist_baseline.sql
+++ b/packages/media-db/migrations/0023_watchlist_baseline.sql
@@ -1,0 +1,12 @@
+CREATE TABLE `watchlist` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`media_type` text NOT NULL,
+	`media_id` integer NOT NULL,
+	`priority` integer DEFAULT 0,
+	`notes` text,
+	`added_at` text DEFAULT (datetime('now')) NOT NULL,
+	`source` text DEFAULT 'manual' NOT NULL,
+	`plex_rating_key` text
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `idx_watchlist_media` ON `watchlist` (`media_type`,`media_id`);

--- a/packages/media-db/migrations/meta/_journal.json
+++ b/packages/media-db/migrations/meta/_journal.json
@@ -18,6 +18,13 @@
     },
     {
       "idx": 2,
+      "version": "6",
+      "when": 1786291200000,
+      "tag": "0023_watchlist_baseline",
+      "breakpoints": true
+    },
+    {
+      "idx": 3,
       "version": "7",
       "when": 1788000000000,
       "tag": "0024_media_tv_shows_baseline",

--- a/packages/media-db/src/__tests__/watchlist.test.ts
+++ b/packages/media-db/src/__tests__/watchlist.test.ts
@@ -10,7 +10,7 @@ import { join } from 'node:path';
 
 import Database from 'better-sqlite3';
 import { drizzle } from 'drizzle-orm/better-sqlite3';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import {
   addToWatchlist,
@@ -47,7 +47,10 @@ let raw: Database.Database;
 
 beforeEach(() => {
   ({ db, raw } = freshDb());
-  return () => raw.close();
+});
+
+afterEach(() => {
+  raw.close();
 });
 
 describe('addToWatchlist', () => {

--- a/packages/media-db/src/__tests__/watchlist.test.ts
+++ b/packages/media-db/src/__tests__/watchlist.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Invariant tests for the watchlist service against an in-memory SQLite
+ * seeded with the canonical `watchlist` baseline migration. Pure DB +
+ * service layer — the legacy enriched list shape (title/posterUrl join)
+ * lives on pops-api until the movies/tv-shows tables move into this
+ * package, so it isn't covered here.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  addToWatchlist,
+  getWatchlistEntry,
+  getWatchlistStatus,
+  listWatchlist,
+  removeByMedia,
+  removeFromWatchlist,
+  reorderWatchlist,
+  resequencePriorities,
+  setPlexRatingKey,
+  updateWatchlistEntry,
+  WatchlistEntryNotFoundError,
+  WatchlistReorderConflictError,
+} from '../services/watchlist.js';
+
+import type { MediaDb } from '../services/internal.js';
+
+const MIGRATION_PATH = join(__dirname, '../../migrations/0023_watchlist_baseline.sql');
+
+function freshDb(): { db: MediaDb; raw: Database.Database } {
+  const raw = new Database(':memory:');
+  raw.pragma('foreign_keys = ON');
+  const sql = readFileSync(MIGRATION_PATH, 'utf8');
+  for (const stmt of sql.split('--> statement-breakpoint')) {
+    const trimmed = stmt.trim();
+    if (trimmed.length > 0) raw.exec(trimmed);
+  }
+  return { db: drizzle(raw), raw };
+}
+
+let db: MediaDb;
+let raw: Database.Database;
+
+beforeEach(() => {
+  ({ db, raw } = freshDb());
+  return () => raw.close();
+});
+
+describe('addToWatchlist', () => {
+  it('creates an entry and returns created=true', () => {
+    const { row, created } = addToWatchlist(db, {
+      mediaType: 'movie',
+      mediaId: 550,
+      priority: 2,
+      notes: 'Must watch',
+    });
+
+    expect(created).toBe(true);
+    expect(row.id).toBeGreaterThan(0);
+    expect(row.mediaType).toBe('movie');
+    expect(row.mediaId).toBe(550);
+    expect(row.priority).toBe(2);
+    expect(row.notes).toBe('Must watch');
+    expect(row.source).toBe('manual');
+  });
+
+  it('returns the existing row on duplicate (mediaType, mediaId)', () => {
+    const first = addToWatchlist(db, { mediaType: 'movie', mediaId: 550 });
+    const second = addToWatchlist(db, { mediaType: 'movie', mediaId: 550 });
+
+    expect(first.created).toBe(true);
+    expect(second.created).toBe(false);
+    expect(second.row.id).toBe(first.row.id);
+  });
+
+  it('applies defaults for optional fields', () => {
+    const { row } = addToWatchlist(db, { mediaType: 'tv_show', mediaId: 100 });
+    expect(row.priority).toBe(0);
+    expect(row.notes).toBeNull();
+    expect(row.plexRatingKey).toBeNull();
+  });
+});
+
+describe('getWatchlistEntry', () => {
+  it('returns the row for an existing id', () => {
+    const { row } = addToWatchlist(db, { mediaType: 'movie', mediaId: 1 });
+    const fetched = getWatchlistEntry(db, row.id);
+    expect(fetched.id).toBe(row.id);
+  });
+
+  it('throws WatchlistEntryNotFoundError for an unknown id', () => {
+    expect(() => getWatchlistEntry(db, 9999)).toThrow(WatchlistEntryNotFoundError);
+  });
+});
+
+describe('getWatchlistStatus', () => {
+  it('returns onWatchlist=true with the entryId when present', () => {
+    const { row } = addToWatchlist(db, { mediaType: 'movie', mediaId: 7 });
+    expect(getWatchlistStatus(db, 'movie', 7)).toEqual({ onWatchlist: true, entryId: row.id });
+  });
+
+  it('returns onWatchlist=false when absent', () => {
+    expect(getWatchlistStatus(db, 'movie', 7)).toEqual({ onWatchlist: false, entryId: null });
+  });
+});
+
+describe('listWatchlist', () => {
+  it('returns rows ordered by priority ASC then addedAt DESC', () => {
+    addToWatchlist(db, { mediaType: 'movie', mediaId: 1, priority: 2 });
+    addToWatchlist(db, { mediaType: 'movie', mediaId: 2, priority: 0 });
+    addToWatchlist(db, { mediaType: 'movie', mediaId: 3, priority: 1 });
+
+    const result = listWatchlist(db, {}, 50, 0);
+    expect(result.total).toBe(3);
+    expect(result.rows.map((r) => r.mediaId)).toEqual([2, 3, 1]);
+  });
+
+  it('filters by mediaType', () => {
+    addToWatchlist(db, { mediaType: 'movie', mediaId: 1 });
+    addToWatchlist(db, { mediaType: 'tv_show', mediaId: 2 });
+    addToWatchlist(db, { mediaType: 'movie', mediaId: 3 });
+
+    const result = listWatchlist(db, { mediaType: 'movie' }, 50, 0);
+    expect(result.total).toBe(2);
+    expect(result.rows.every((r) => r.mediaType === 'movie')).toBe(true);
+  });
+
+  it('applies limit + offset', () => {
+    for (let i = 1; i <= 5; i++) {
+      addToWatchlist(db, { mediaType: 'movie', mediaId: i });
+    }
+    const page = listWatchlist(db, {}, 2, 2);
+    expect(page.total).toBe(5);
+    expect(page.rows).toHaveLength(2);
+  });
+});
+
+describe('updateWatchlistEntry', () => {
+  it('updates only the specified fields', () => {
+    const { row } = addToWatchlist(db, {
+      mediaType: 'movie',
+      mediaId: 1,
+      priority: 1,
+      notes: 'Original',
+    });
+
+    const updated = updateWatchlistEntry(db, row.id, { priority: 5 });
+    expect(updated.priority).toBe(5);
+    expect(updated.notes).toBe('Original');
+  });
+
+  it('throws WatchlistEntryNotFoundError when the id is missing', () => {
+    expect(() => updateWatchlistEntry(db, 9999, { priority: 1 })).toThrow(
+      WatchlistEntryNotFoundError
+    );
+  });
+});
+
+describe('removeFromWatchlist', () => {
+  it('deletes the row', () => {
+    const { row } = addToWatchlist(db, { mediaType: 'movie', mediaId: 1 });
+    removeFromWatchlist(db, row.id);
+    expect(() => getWatchlistEntry(db, row.id)).toThrow(WatchlistEntryNotFoundError);
+  });
+
+  it('throws when the id is missing', () => {
+    expect(() => removeFromWatchlist(db, 9999)).toThrow(WatchlistEntryNotFoundError);
+  });
+});
+
+describe('reorderWatchlist', () => {
+  it('batch-updates priorities in the provided order', () => {
+    const a = addToWatchlist(db, { mediaType: 'movie', mediaId: 1, priority: 0 });
+    const b = addToWatchlist(db, { mediaType: 'movie', mediaId: 2, priority: 1 });
+    const c = addToWatchlist(db, { mediaType: 'movie', mediaId: 3, priority: 2 });
+
+    reorderWatchlist(db, [
+      { id: c.row.id, priority: 0 },
+      { id: a.row.id, priority: 1 },
+      { id: b.row.id, priority: 2 },
+    ]);
+
+    const list = listWatchlist(db, {}, 50, 0);
+    expect(list.rows.map((r) => r.mediaId)).toEqual([3, 1, 2]);
+  });
+
+  it('is a no-op for an empty array', () => {
+    expect(() => reorderWatchlist(db, [])).not.toThrow();
+  });
+
+  it('throws WatchlistEntryNotFoundError for an unknown id', () => {
+    expect(() => reorderWatchlist(db, [{ id: 9999, priority: 0 }])).toThrow(
+      WatchlistEntryNotFoundError
+    );
+  });
+
+  it('throws WatchlistReorderConflictError for duplicate priorities', () => {
+    const a = addToWatchlist(db, { mediaType: 'movie', mediaId: 1 });
+    const b = addToWatchlist(db, { mediaType: 'movie', mediaId: 2 });
+
+    expect(() =>
+      reorderWatchlist(db, [
+        { id: a.row.id, priority: 0 },
+        { id: b.row.id, priority: 0 },
+      ])
+    ).toThrow(WatchlistReorderConflictError);
+  });
+});
+
+describe('removeByMedia', () => {
+  it('returns true when a row is deleted', () => {
+    addToWatchlist(db, { mediaType: 'movie', mediaId: 42 });
+    expect(removeByMedia(db, 'movie', 42)).toBe(true);
+    expect(getWatchlistStatus(db, 'movie', 42).onWatchlist).toBe(false);
+  });
+
+  it('returns false when no matching row exists', () => {
+    expect(removeByMedia(db, 'movie', 9999)).toBe(false);
+  });
+});
+
+describe('resequencePriorities', () => {
+  it('rewrites priorities to a dense 0..N-1 sequence in order', () => {
+    addToWatchlist(db, { mediaType: 'movie', mediaId: 1, priority: 5 });
+    addToWatchlist(db, { mediaType: 'movie', mediaId: 2, priority: 10 });
+    addToWatchlist(db, { mediaType: 'movie', mediaId: 3, priority: 20 });
+
+    resequencePriorities(db);
+
+    const list = listWatchlist(db, {}, 50, 0);
+    expect(list.rows.map((r) => r.priority)).toEqual([0, 1, 2]);
+  });
+});
+
+describe('setPlexRatingKey', () => {
+  it('persists the rating key on the row', () => {
+    const { row } = addToWatchlist(db, { mediaType: 'movie', mediaId: 1 });
+    setPlexRatingKey(db, row.id, 'abc-123');
+    const updated = getWatchlistEntry(db, row.id);
+    expect(updated.plexRatingKey).toBe('abc-123');
+  });
+});

--- a/packages/media-db/src/index.ts
+++ b/packages/media-db/src/index.ts
@@ -47,3 +47,15 @@ export type {
 } from './services/tv-shows.js';
 
 export * as tvShowsService from './services/tv-shows.js';
+
+export * as watchlistService from './services/watchlist.js';
+
+export {
+  WatchlistEntryNotFoundError,
+  WatchlistReorderConflictError,
+  type AddToWatchlistInput,
+  type MediaWatchlistRow,
+  type UpdateWatchlistInput,
+  type WatchlistFilters,
+  type WatchlistListResult,
+} from './services/watchlist.js';

--- a/packages/media-db/src/schema.ts
+++ b/packages/media-db/src/schema.ts
@@ -11,4 +11,4 @@
  * Mirrors the `@pops/core-db` schema re-export pattern. The shape grows as
  * subsequent Phase 1 PRs migrate additional media tables into this package.
  */
-export { movies, shelfImpressions, tvShows } from '@pops/db-types';
+export { mediaWatchlist, movies, shelfImpressions, tvShows } from '@pops/db-types';

--- a/packages/media-db/src/services/watchlist-unique-violation.ts
+++ b/packages/media-db/src/services/watchlist-unique-violation.ts
@@ -1,0 +1,32 @@
+/**
+ * Detect whether an error from a `watchlist` write is a UNIQUE violation
+ * on the `(media_type, media_id)` index. better-sqlite3 surfaces UNIQUE
+ * index violations with `code = 'SQLITE_CONSTRAINT_UNIQUE'`; drizzle may
+ * wrap the original as `.cause`, so we walk the cause chain.
+ *
+ * Mirrors `@pops/finance-db`'s `isBudgetUniqueViolation` shape. The broader
+ * `SQLITE_CONSTRAINT` code is accepted as a defensive fallback for older
+ * drivers that drop the suffix.
+ */
+const MAX_CAUSE_DEPTH = 5;
+
+export function isWatchlistMediaUniqueViolation(err: unknown): boolean {
+  let current: unknown = err;
+  for (let i = 0; i < MAX_CAUSE_DEPTH && current instanceof Error; i++) {
+    if (matchesWatchlistMediaUnique(current)) return true;
+    const next: unknown = (current as { cause?: unknown }).cause;
+    if (next === current) return false;
+    current = next;
+  }
+  return false;
+}
+
+function matchesWatchlistMediaUnique(err: Error): boolean {
+  const code: unknown = (err as { code?: unknown }).code;
+  if (typeof code !== 'string') return false;
+  if (code !== 'SQLITE_CONSTRAINT_UNIQUE' && code !== 'SQLITE_CONSTRAINT') return false;
+  return (
+    /UNIQUE constraint failed:\s*watchlist\./.test(err.message) ||
+    /UNIQUE constraint failed:\s*index 'idx_watchlist_media/.test(err.message)
+  );
+}

--- a/packages/media-db/src/services/watchlist.ts
+++ b/packages/media-db/src/services/watchlist.ts
@@ -17,6 +17,7 @@
 import { and, asc, count, desc, eq, type SQL } from 'drizzle-orm';
 
 import { mediaWatchlist } from '../schema.js';
+import { isWatchlistMediaUniqueViolation } from './watchlist-unique-violation.js';
 
 import type { MediaDb } from './internal.js';
 
@@ -125,7 +126,7 @@ export function addToWatchlist(
       .run();
     return { row: getWatchlistEntry(db, Number(result.lastInsertRowid)), created: true };
   } catch (err) {
-    if (err instanceof Error && err.message.includes('UNIQUE constraint failed')) {
+    if (isWatchlistMediaUniqueViolation(err)) {
       const existing = db
         .select()
         .from(mediaWatchlist)
@@ -168,30 +169,36 @@ export function removeFromWatchlist(db: MediaDb, id: number): void {
   if (result.changes === 0) throw new WatchlistEntryNotFoundError(id);
 }
 
-/** Batch-reorder watchlist priorities. */
+/**
+ * Batch-reorder watchlist priorities. The entire rewrite runs inside a
+ * single SQLite transaction so a mid-loop failure rolls back any earlier
+ * UPDATEs — callers never observe a half-applied ordering.
+ */
 export function reorderWatchlist(db: MediaDb, items: { id: number; priority: number }[]): void {
   if (items.length === 0) return;
-
-  for (const item of items) {
-    const row = db
-      .select({ id: mediaWatchlist.id })
-      .from(mediaWatchlist)
-      .where(eq(mediaWatchlist.id, item.id))
-      .get();
-    if (!row) throw new WatchlistEntryNotFoundError(item.id);
-  }
 
   const priorities = items.map((i) => i.priority);
   if (new Set(priorities).size !== priorities.length) {
     throw new WatchlistReorderConflictError('Duplicate priorities in reorder request');
   }
 
-  for (const item of items) {
-    db.update(mediaWatchlist)
-      .set({ priority: item.priority })
-      .where(eq(mediaWatchlist.id, item.id))
-      .run();
-  }
+  db.transaction((tx) => {
+    for (const item of items) {
+      const row = tx
+        .select({ id: mediaWatchlist.id })
+        .from(mediaWatchlist)
+        .where(eq(mediaWatchlist.id, item.id))
+        .get();
+      if (!row) throw new WatchlistEntryNotFoundError(item.id);
+    }
+
+    for (const item of items) {
+      tx.update(mediaWatchlist)
+        .set({ priority: item.priority })
+        .where(eq(mediaWatchlist.id, item.id))
+        .run();
+    }
+  });
 }
 
 /** Remove a watchlist entry by (mediaType, mediaId). Returns true on hit. */
@@ -207,20 +214,26 @@ export function removeByMedia(
   return result.changes > 0;
 }
 
-/** Re-sequence priorities (0, 1, 2, …) to eliminate gaps. */
+/**
+ * Re-sequence priorities (0, 1, 2, …) to eliminate gaps. Runs inside a
+ * single SQLite transaction so a mid-rewrite failure rolls back rather
+ * than leaving the table partially renumbered.
+ */
 export function resequencePriorities(db: MediaDb): void {
-  const rows = db
-    .select({ id: mediaWatchlist.id })
-    .from(mediaWatchlist)
-    .orderBy(asc(mediaWatchlist.priority), desc(mediaWatchlist.addedAt))
-    .all();
+  db.transaction((tx) => {
+    const rows = tx
+      .select({ id: mediaWatchlist.id })
+      .from(mediaWatchlist)
+      .orderBy(asc(mediaWatchlist.priority), desc(mediaWatchlist.addedAt))
+      .all();
 
-  for (let i = 0; i < rows.length; i++) {
-    const row = rows[i];
-    if (row) {
-      db.update(mediaWatchlist).set({ priority: i }).where(eq(mediaWatchlist.id, row.id)).run();
+    for (let i = 0; i < rows.length; i++) {
+      const row = rows[i];
+      if (row) {
+        tx.update(mediaWatchlist).set({ priority: i }).where(eq(mediaWatchlist.id, row.id)).run();
+      }
     }
-  }
+  });
 }
 
 /** Persist the Plex rating key for a watchlist entry (best-effort lookup result). */

--- a/packages/media-db/src/services/watchlist.ts
+++ b/packages/media-db/src/services/watchlist.ts
@@ -1,0 +1,232 @@
+/**
+ * Watchlist service — CRUD operations against the `watchlist` table on the
+ * media pillar's SQLite database.
+ *
+ * Mirrors the legacy `apps/pops-api/src/modules/media/watchlist/service.ts`
+ * surface but takes a `MediaDb` handle as the first argument so the calling
+ * layer (pops-media-api routers, or future cross-pillar consumers) owns the
+ * handle lifecycle. Matches the `@pops/core-db` / `@pops/finance-db`
+ * per-pillar service signature pattern.
+ *
+ * Read-side enrichment (joining `title`/`posterUrl` against `movies` and
+ * `tv_shows`) lives on the legacy pops-api list handler — those tables
+ * have not been split into `@pops/media-db` yet, so the join cannot be
+ * done from this side. Per PRD-167 PR 1 scope, reads stay on the legacy
+ * surface and only the writer surface is mirrored here.
+ */
+import { and, asc, count, desc, eq, type SQL } from 'drizzle-orm';
+
+import { mediaWatchlist } from '../schema.js';
+
+import type { MediaDb } from './internal.js';
+
+export class WatchlistEntryNotFoundError extends Error {
+  public readonly entryId: number;
+
+  constructor(entryId: number) {
+    super(`WatchlistEntry '${entryId}' not found`);
+    this.entryId = entryId;
+    this.name = 'WatchlistEntryNotFoundError';
+  }
+}
+
+export class WatchlistReorderConflictError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'WatchlistReorderConflictError';
+  }
+}
+
+export type MediaWatchlistRow = typeof mediaWatchlist.$inferSelect;
+
+export interface WatchlistFilters {
+  mediaType?: 'movie' | 'tv_show';
+}
+
+export interface AddToWatchlistInput {
+  mediaType: 'movie' | 'tv_show';
+  mediaId: number;
+  priority?: number | null;
+  notes?: string | null;
+}
+
+export interface UpdateWatchlistInput {
+  priority?: number | null;
+  notes?: string | null;
+}
+
+export interface WatchlistListResult {
+  rows: MediaWatchlistRow[];
+  total: number;
+}
+
+/** List watchlist entries with optional filters. */
+export function listWatchlist(
+  db: MediaDb,
+  filters: WatchlistFilters,
+  limit: number,
+  offset: number
+): WatchlistListResult {
+  const conditions: SQL[] = [];
+  if (filters.mediaType) {
+    conditions.push(eq(mediaWatchlist.mediaType, filters.mediaType));
+  }
+  const where = conditions.length > 0 ? and(...conditions) : undefined;
+
+  const rows = db
+    .select()
+    .from(mediaWatchlist)
+    .where(where)
+    .orderBy(asc(mediaWatchlist.priority), desc(mediaWatchlist.addedAt))
+    .limit(limit)
+    .offset(offset)
+    .all();
+
+  const [countRow] = db.select({ total: count() }).from(mediaWatchlist).where(where).all();
+
+  return { rows, total: countRow?.total ?? 0 };
+}
+
+/** Check whether a specific media item is on the watchlist. */
+export function getWatchlistStatus(
+  db: MediaDb,
+  mediaType: 'movie' | 'tv_show',
+  mediaId: number
+): { onWatchlist: boolean; entryId: number | null } {
+  const row = db
+    .select({ id: mediaWatchlist.id })
+    .from(mediaWatchlist)
+    .where(and(eq(mediaWatchlist.mediaType, mediaType), eq(mediaWatchlist.mediaId, mediaId)))
+    .get();
+  return row ? { onWatchlist: true, entryId: row.id } : { onWatchlist: false, entryId: null };
+}
+
+/** Get a single watchlist entry by id. */
+export function getWatchlistEntry(db: MediaDb, id: number): MediaWatchlistRow {
+  const row = db.select().from(mediaWatchlist).where(eq(mediaWatchlist.id, id)).get();
+  if (!row) throw new WatchlistEntryNotFoundError(id);
+  return row;
+}
+
+/** Add an item to the watchlist. Idempotent on (mediaType, mediaId). */
+export function addToWatchlist(
+  db: MediaDb,
+  input: AddToWatchlistInput
+): { row: MediaWatchlistRow; created: boolean } {
+  try {
+    const result = db
+      .insert(mediaWatchlist)
+      .values({
+        mediaType: input.mediaType,
+        mediaId: input.mediaId,
+        priority: input.priority !== undefined ? input.priority : undefined,
+        notes: input.notes ?? null,
+      })
+      .run();
+    return { row: getWatchlistEntry(db, Number(result.lastInsertRowid)), created: true };
+  } catch (err) {
+    if (err instanceof Error && err.message.includes('UNIQUE constraint failed')) {
+      const existing = db
+        .select()
+        .from(mediaWatchlist)
+        .where(
+          and(
+            eq(mediaWatchlist.mediaType, input.mediaType),
+            eq(mediaWatchlist.mediaId, input.mediaId)
+          )
+        )
+        .get();
+      if (existing) return { row: getWatchlistEntry(db, existing.id), created: false };
+    }
+    throw err;
+  }
+}
+
+/** Update a watchlist entry. */
+export function updateWatchlistEntry(
+  db: MediaDb,
+  id: number,
+  input: UpdateWatchlistInput
+): MediaWatchlistRow {
+  getWatchlistEntry(db, id);
+
+  const updates: Partial<typeof mediaWatchlist.$inferSelect> = {};
+  if (input.priority !== undefined) updates.priority = input.priority ?? null;
+  if (input.notes !== undefined) updates.notes = input.notes ?? null;
+
+  if (Object.keys(updates).length > 0) {
+    db.update(mediaWatchlist).set(updates).where(eq(mediaWatchlist.id, id)).run();
+  }
+
+  return getWatchlistEntry(db, id);
+}
+
+/** Remove an entry from the watchlist. */
+export function removeFromWatchlist(db: MediaDb, id: number): void {
+  getWatchlistEntry(db, id);
+  const result = db.delete(mediaWatchlist).where(eq(mediaWatchlist.id, id)).run();
+  if (result.changes === 0) throw new WatchlistEntryNotFoundError(id);
+}
+
+/** Batch-reorder watchlist priorities. */
+export function reorderWatchlist(db: MediaDb, items: { id: number; priority: number }[]): void {
+  if (items.length === 0) return;
+
+  for (const item of items) {
+    const row = db
+      .select({ id: mediaWatchlist.id })
+      .from(mediaWatchlist)
+      .where(eq(mediaWatchlist.id, item.id))
+      .get();
+    if (!row) throw new WatchlistEntryNotFoundError(item.id);
+  }
+
+  const priorities = items.map((i) => i.priority);
+  if (new Set(priorities).size !== priorities.length) {
+    throw new WatchlistReorderConflictError('Duplicate priorities in reorder request');
+  }
+
+  for (const item of items) {
+    db.update(mediaWatchlist)
+      .set({ priority: item.priority })
+      .where(eq(mediaWatchlist.id, item.id))
+      .run();
+  }
+}
+
+/** Remove a watchlist entry by (mediaType, mediaId). Returns true on hit. */
+export function removeByMedia(
+  db: MediaDb,
+  mediaType: 'movie' | 'tv_show',
+  mediaId: number
+): boolean {
+  const result = db
+    .delete(mediaWatchlist)
+    .where(and(eq(mediaWatchlist.mediaType, mediaType), eq(mediaWatchlist.mediaId, mediaId)))
+    .run();
+  return result.changes > 0;
+}
+
+/** Re-sequence priorities (0, 1, 2, …) to eliminate gaps. */
+export function resequencePriorities(db: MediaDb): void {
+  const rows = db
+    .select({ id: mediaWatchlist.id })
+    .from(mediaWatchlist)
+    .orderBy(asc(mediaWatchlist.priority), desc(mediaWatchlist.addedAt))
+    .all();
+
+  for (let i = 0; i < rows.length; i++) {
+    const row = rows[i];
+    if (row) {
+      db.update(mediaWatchlist).set({ priority: i }).where(eq(mediaWatchlist.id, row.id)).run();
+    }
+  }
+}
+
+/** Persist the Plex rating key for a watchlist entry (best-effort lookup result). */
+export function setPlexRatingKey(db: MediaDb, watchlistId: number, ratingKey: string): void {
+  db.update(mediaWatchlist)
+    .set({ plexRatingKey: ratingKey })
+    .where(eq(mediaWatchlist.id, watchlistId))
+    .run();
+}


### PR DESCRIPTION
## Summary

- First writer-move slice for PRD-167 (Theme 13) — `media.watchlist.*` writers now mirror inside pops-media-api against `@pops/media-db`, with the legacy pops-api router staying as the fall-through.
- New `watchlist` baseline migration + service + 18 invariant tests in `@pops/media-db`; new `media.watchlist.{list,status,get,add,update,reorder,remove}` tRPC surface in pops-media-api with caller + HTTP smoke coverage.
- Additive only: legacy mount is marked `@deprecated` in the file header but stays active until the dispatcher flip in PRD-167 PR 3.

Reads (`title` / `posterUrl` enrichment) remain on legacy because the `movies` / `tv_shows` join needs PRD-165 / PRD-166 first. Plex push side-effects and the dispatcher / nginx routing flip are out of scope for PR 1 per the PRD's deferred items.

Bonus: `apps/pops-api/src/db/per-pillar-migrations.test.ts` was already failing on `main` because the expected list missed `0055_pillar_registry` when PRD-161 landed; that's fixed here alongside the new `0022_watchlist_baseline` entry.

## Test plan

- [x] `pnpm --filter @pops/media-db test` — 43 tests pass (18 new watchlist invariants)
- [x] `pnpm --filter @pops/media-api test` — 18 tests pass (8 new watchlist + 1 HTTP smoke)
- [x] `pnpm --filter @pops/api test` — 4903 tests pass (per-pillar-migrations test fixed)
- [x] `pnpm typecheck` — 66 / 66 successful
- [x] `pnpm lint` — 0 errors
- [x] `pnpm -r build` — green
