### PR TITLE
feat(cerebrum-db): scaffold engrams services + sqlite-vec wiring (PRD-179 US-01)

### DIFF
--- a/apps/pops-api/src/db/backfill-cerebrum-from-shared.test.ts
+++ b/apps/pops-api/src/db/backfill-cerebrum-from-shared.test.ts
@@ -48,10 +48,59 @@ CREATE TABLE nudge_log (
 );
 `;
 
+const ENGRAMS_SCHEMA_SQL = `
+CREATE TABLE engram_index (
+  id text PRIMARY KEY NOT NULL,
+  file_path text NOT NULL,
+  type text NOT NULL,
+  source text NOT NULL,
+  status text NOT NULL,
+  template text,
+  created_at text NOT NULL,
+  modified_at text NOT NULL,
+  title text NOT NULL,
+  content_hash text NOT NULL,
+  body_hash text,
+  word_count integer NOT NULL,
+  custom_fields text
+);
+CREATE TABLE engram_scopes (
+  engram_id text NOT NULL,
+  scope text NOT NULL,
+  FOREIGN KEY (engram_id) REFERENCES engram_index(id) ON UPDATE no action ON DELETE cascade
+);
+CREATE UNIQUE INDEX uq_engram_scopes_pair ON engram_scopes (engram_id, scope);
+CREATE TABLE engram_tags (
+  engram_id text NOT NULL,
+  tag text NOT NULL,
+  FOREIGN KEY (engram_id) REFERENCES engram_index(id) ON UPDATE no action ON DELETE cascade
+);
+CREATE UNIQUE INDEX uq_engram_tags_pair ON engram_tags (engram_id, tag);
+CREATE TABLE engram_links (
+  source_id text NOT NULL,
+  target_id text NOT NULL,
+  FOREIGN KEY (source_id) REFERENCES engram_index(id) ON UPDATE no action ON DELETE cascade
+);
+CREATE UNIQUE INDEX uq_engram_links_pair ON engram_links (source_id, target_id);
+`;
+
+function insertEngram(raw: BetterSqlite3.Database, id: string): void {
+  raw
+    .prepare(
+      `INSERT INTO engram_index
+        (id, file_path, type, source, status, created_at, modified_at, title, content_hash, word_count)
+       VALUES (?, ?, 'note', 'manual', 'active', '2026-05-10T10:00:00Z', '2026-05-10T10:00:00Z', 'T', 'h', 1)`
+    )
+    .run(id, `notes/${id}.md`);
+  raw.prepare(`INSERT INTO engram_scopes (engram_id, scope) VALUES (?, 'work')`).run(id);
+  raw.prepare(`INSERT INTO engram_tags (engram_id, tag) VALUES (?, 'food')`).run(id);
+}
+
 function openSharedWithSeed(seed: (raw: BetterSqlite3.Database) => void): string {
   const path = join(tmpDir, 'pops.db');
   const raw = new BetterSqlite3(path);
   raw.exec(NUDGE_LOG_SQL);
+  raw.exec(ENGRAMS_SCHEMA_SQL);
   seed(raw);
   raw.close();
   return path;
@@ -71,7 +120,7 @@ describe('backfillCerebrumFromShared', () => {
   it('copies nudge_log rows from the shared DB on first run', () => {
     const sharedPath = openSharedWithSeed((raw) => insertNudge(raw, 'nudge-1'));
 
-    const cerebrum = openCerebrumDb(join(tmpDir, 'cerebrum.db'));
+    const cerebrum = openCerebrumDb(join(tmpDir, 'cerebrum.db'), { loadVec: false });
     try {
       backfillCerebrumFromShared(cerebrum, sharedPath);
       const { n } = cerebrum.raw.prepare('SELECT count(*) AS n FROM nudge_log').get() as {
@@ -86,7 +135,7 @@ describe('backfillCerebrumFromShared', () => {
   it('is idempotent — a second run does not duplicate rows', () => {
     const sharedPath = openSharedWithSeed((raw) => insertNudge(raw, 'nudge-1'));
 
-    const cerebrum = openCerebrumDb(join(tmpDir, 'cerebrum.db'));
+    const cerebrum = openCerebrumDb(join(tmpDir, 'cerebrum.db'), { loadVec: false });
     try {
       backfillCerebrumFromShared(cerebrum, sharedPath);
       backfillCerebrumFromShared(cerebrum, sharedPath);
@@ -105,7 +154,7 @@ describe('backfillCerebrumFromShared', () => {
       insertNudge(raw, 'nudge-both');
     });
 
-    const cerebrum = openCerebrumDb(join(tmpDir, 'cerebrum.db'));
+    const cerebrum = openCerebrumDb(join(tmpDir, 'cerebrum.db'), { loadVec: false });
     try {
       // Pre-seed the cerebrum.db with one of the rows that also lives
       // in the shared DB; the backfill must skip it but pick up the other.
@@ -120,13 +169,55 @@ describe('backfillCerebrumFromShared', () => {
     }
   });
 
+  it('copies engram_index + scopes + tags from the shared DB on first run', () => {
+    const sharedPath = openSharedWithSeed((raw) => {
+      insertEngram(raw, 'eng_20260510_1000_a');
+      insertEngram(raw, 'eng_20260510_1000_b');
+    });
+
+    const cerebrum = openCerebrumDb(join(tmpDir, 'cerebrum.db'), { loadVec: false });
+    try {
+      backfillCerebrumFromShared(cerebrum, sharedPath);
+      const { engrams } = cerebrum.raw
+        .prepare('SELECT count(*) AS engrams FROM engram_index')
+        .get() as { engrams: number };
+      const { scopes } = cerebrum.raw
+        .prepare('SELECT count(*) AS scopes FROM engram_scopes')
+        .get() as { scopes: number };
+      const { tags } = cerebrum.raw.prepare('SELECT count(*) AS tags FROM engram_tags').get() as {
+        tags: number;
+      };
+      expect(engrams).toBe(2);
+      expect(scopes).toBe(2);
+      expect(tags).toBe(2);
+    } finally {
+      cerebrum.raw.close();
+    }
+  });
+
+  it('skips engrams already present in the cerebrum copy (idempotent)', () => {
+    const sharedPath = openSharedWithSeed((raw) => insertEngram(raw, 'eng_dup'));
+
+    const cerebrum = openCerebrumDb(join(tmpDir, 'cerebrum.db'), { loadVec: false });
+    try {
+      backfillCerebrumFromShared(cerebrum, sharedPath);
+      backfillCerebrumFromShared(cerebrum, sharedPath);
+      const { n } = cerebrum.raw.prepare('SELECT count(*) AS n FROM engram_index').get() as {
+        n: number;
+      };
+      expect(n).toBe(1);
+    } finally {
+      cerebrum.raw.close();
+    }
+  });
+
   it('tolerates a shared DB with no cerebrum tables (post-PR-4 drop scenario)', () => {
     const sharedPath = join(tmpDir, 'pops.db');
     const raw = new BetterSqlite3(sharedPath);
     raw.exec(`CREATE TABLE other_table (id integer PRIMARY KEY)`);
     raw.close();
 
-    const cerebrum = openCerebrumDb(join(tmpDir, 'cerebrum.db'));
+    const cerebrum = openCerebrumDb(join(tmpDir, 'cerebrum.db'), { loadVec: false });
     try {
       expect(() => backfillCerebrumFromShared(cerebrum, sharedPath)).not.toThrow();
       const { n } = cerebrum.raw.prepare('SELECT count(*) AS n FROM nudge_log').get() as {

--- a/apps/pops-api/src/db/backfill-cerebrum-from-shared.test.ts
+++ b/apps/pops-api/src/db/backfill-cerebrum-from-shared.test.ts
@@ -48,6 +48,35 @@ CREATE TABLE nudge_log (
 );
 `;
 
+const GLIA_SCHEMA_SQL = `
+CREATE TABLE glia_actions (
+  id text PRIMARY KEY NOT NULL,
+  action_type text NOT NULL,
+  affected_ids text NOT NULL,
+  rationale text NOT NULL,
+  payload text,
+  phase text NOT NULL,
+  status text NOT NULL,
+  user_decision text,
+  user_note text,
+  executed_at text,
+  decided_at text,
+  reverted_at text,
+  created_at text NOT NULL
+);
+CREATE TABLE glia_trust_state (
+  action_type text PRIMARY KEY NOT NULL,
+  current_phase text NOT NULL,
+  approved_count integer DEFAULT 0 NOT NULL,
+  rejected_count integer DEFAULT 0 NOT NULL,
+  reverted_count integer DEFAULT 0 NOT NULL,
+  autonomous_since text,
+  last_revert_at text,
+  graduated_at text,
+  updated_at text NOT NULL
+);
+`;
+
 const ENGRAMS_SCHEMA_SQL = `
 CREATE TABLE engram_index (
   id text PRIMARY KEY NOT NULL,
@@ -101,9 +130,30 @@ function openSharedWithSeed(seed: (raw: BetterSqlite3.Database) => void): string
   const raw = new BetterSqlite3(path);
   raw.exec(NUDGE_LOG_SQL);
   raw.exec(ENGRAMS_SCHEMA_SQL);
+  raw.exec(GLIA_SCHEMA_SQL);
   seed(raw);
   raw.close();
   return path;
+}
+
+function insertGliaAction(raw: BetterSqlite3.Database, id: string): void {
+  raw
+    .prepare(
+      `INSERT INTO glia_actions
+        (id, action_type, affected_ids, rationale, phase, status, created_at)
+       VALUES (?, 'prune', '["eng_a"]', 'r', 'propose', 'pending', '2026-06-10T10:00:00Z')`
+    )
+    .run(id);
+}
+
+function insertGliaTrustState(raw: BetterSqlite3.Database, actionType: string): void {
+  raw
+    .prepare(
+      `INSERT INTO glia_trust_state
+        (action_type, current_phase, approved_count, rejected_count, reverted_count, updated_at)
+       VALUES (?, 'propose', 0, 0, 0, '2026-06-10T10:00:00Z')`
+    )
+    .run(actionType);
 }
 
 function insertNudge(raw: BetterSqlite3.Database, id: string): void {
@@ -206,6 +256,72 @@ describe('backfillCerebrumFromShared', () => {
         n: number;
       };
       expect(n).toBe(1);
+    } finally {
+      cerebrum.raw.close();
+    }
+  });
+
+  it('copies glia_actions + glia_trust_state from the shared DB on first run', () => {
+    const sharedPath = openSharedWithSeed((raw) => {
+      insertGliaAction(raw, 'glia_a');
+      insertGliaAction(raw, 'glia_b');
+      insertGliaTrustState(raw, 'prune');
+      insertGliaTrustState(raw, 'consolidate');
+    });
+
+    const cerebrum = openCerebrumDb(join(tmpDir, 'cerebrum.db'), { loadVec: false });
+    try {
+      backfillCerebrumFromShared(cerebrum, sharedPath);
+      const { actions } = cerebrum.raw
+        .prepare('SELECT count(*) AS actions FROM glia_actions')
+        .get() as { actions: number };
+      const { trust } = cerebrum.raw
+        .prepare('SELECT count(*) AS trust FROM glia_trust_state')
+        .get() as { trust: number };
+      expect(actions).toBe(2);
+      expect(trust).toBe(2);
+    } finally {
+      cerebrum.raw.close();
+    }
+  });
+
+  it('skips glia rows already present in the cerebrum copy (idempotent)', () => {
+    const sharedPath = openSharedWithSeed((raw) => {
+      insertGliaAction(raw, 'glia_dup');
+      insertGliaTrustState(raw, 'prune');
+    });
+
+    const cerebrum = openCerebrumDb(join(tmpDir, 'cerebrum.db'), { loadVec: false });
+    try {
+      backfillCerebrumFromShared(cerebrum, sharedPath);
+      backfillCerebrumFromShared(cerebrum, sharedPath);
+      const { actions } = cerebrum.raw
+        .prepare('SELECT count(*) AS actions FROM glia_actions')
+        .get() as { actions: number };
+      const { trust } = cerebrum.raw
+        .prepare('SELECT count(*) AS trust FROM glia_trust_state')
+        .get() as { trust: number };
+      expect(actions).toBe(1);
+      expect(trust).toBe(1);
+    } finally {
+      cerebrum.raw.close();
+    }
+  });
+
+  it('only inserts glia rows missing from the cerebrum copy (mixed state)', () => {
+    const sharedPath = openSharedWithSeed((raw) => {
+      insertGliaAction(raw, 'glia_shared_only');
+      insertGliaAction(raw, 'glia_both');
+    });
+
+    const cerebrum = openCerebrumDb(join(tmpDir, 'cerebrum.db'), { loadVec: false });
+    try {
+      insertGliaAction(cerebrum.raw, 'glia_both');
+      backfillCerebrumFromShared(cerebrum, sharedPath);
+      const rows = cerebrum.raw.prepare('SELECT id FROM glia_actions ORDER BY id').all() as {
+        id: string;
+      }[];
+      expect(rows.map((r) => r.id)).toEqual(['glia_both', 'glia_shared_only']);
     } finally {
       cerebrum.raw.close();
     }

--- a/apps/pops-api/src/db/backfill-cerebrum-from-shared.ts
+++ b/apps/pops-api/src/db/backfill-cerebrum-from-shared.ts
@@ -14,13 +14,17 @@
  *   - `engram_index` + `engram_scopes` + `engram_tags` + `engram_links`
  *     (PRD-179 US-01 — scaffold; consumers still write to the shared
  *     pops.db until US-03 flips them over)
+ *   - `glia_actions` + `glia_trust_state` (PRD-181 US-01 — scaffold;
+ *     consumers still write to the shared pops.db until US-03 flips
+ *     them over)
  *
  * The remaining cerebrum tables (embeddings + embeddings_vec,
- * conversations, glia, plexus) add their entries here when their
- * cutovers land. Order matters when FKs are introduced across
- * cerebrum-owned tables — `engram_index` is copied first so the
- * cascading auxiliaries (`engram_scopes`, `engram_tags`, `engram_links`)
- * can satisfy their FK at insert time.
+ * conversations, plexus) add their entries here when their cutovers
+ * land. Order matters when FKs are introduced across cerebrum-owned
+ * tables — `engram_index` is copied first so the cascading auxiliaries
+ * (`engram_scopes`, `engram_tags`, `engram_links`) can satisfy their FK
+ * at insert time. The two glia tables have no cross-table FKs so their
+ * order is independent of the engram block.
  *
  * Non-fatal: ATTACH or INSERT failures are logged and swallowed so a
  * stale on-disk pops.db never bricks the boot path. Partial failures
@@ -105,6 +109,47 @@ const TABLE_COPIES: readonly TableCopy[] = [
     table: 'engram_links',
     idColumn: 'source_id',
     columns: ['source_id', 'target_id'],
+  },
+  {
+    table: 'glia_actions',
+    idColumn: 'id',
+    columns: [
+      'id',
+      'action_type',
+      'affected_ids',
+      'rationale',
+      'payload',
+      'phase',
+      'status',
+      'user_decision',
+      'user_note',
+      'executed_at',
+      'decided_at',
+      'reverted_at',
+      'created_at',
+    ],
+  },
+  {
+    // glia_trust_state's PK is `action_type` — the same column doubles
+    // as the existence-filter source. Once a row for an action type is
+    // copied across, the WHERE NOT IN clause makes subsequent runs a
+    // no-op for that type; new counter increments on the still-shared
+    // row won't replicate, which is acceptable for the same reason
+    // engram_scopes is: PR 3 (US-03) routes writes through the cerebrum
+    // handle before any divergence matters.
+    table: 'glia_trust_state',
+    idColumn: 'action_type',
+    columns: [
+      'action_type',
+      'current_phase',
+      'approved_count',
+      'rejected_count',
+      'reverted_count',
+      'autonomous_since',
+      'last_revert_at',
+      'graduated_at',
+      'updated_at',
+    ],
   },
 ];
 

--- a/apps/pops-api/src/db/backfill-cerebrum-from-shared.ts
+++ b/apps/pops-api/src/db/backfill-cerebrum-from-shared.ts
@@ -9,11 +9,18 @@
  * copy already populated and become a no-op via the
  * `WHERE id NOT IN (...)` existence filter.
  *
- * Today the slice only covers the `nudge_log` table; the engrams +
- * embeddings + conversations + glia + plexus slices add their entries
- * here when their cutovers land. Order matters when FKs are introduced
- * across cerebrum-owned tables — for the nudge_log-only slice the
- * order is trivial.
+ * Today the slice covers:
+ *   - `nudge_log` (Track M5 / PRD-149)
+ *   - `engram_index` + `engram_scopes` + `engram_tags` + `engram_links`
+ *     (PRD-179 US-01 — scaffold; consumers still write to the shared
+ *     pops.db until US-03 flips them over)
+ *
+ * The remaining cerebrum tables (embeddings + embeddings_vec,
+ * conversations, glia, plexus) add their entries here when their
+ * cutovers land. Order matters when FKs are introduced across
+ * cerebrum-owned tables — `engram_index` is copied first so the
+ * cascading auxiliaries (`engram_scopes`, `engram_tags`, `engram_links`)
+ * can satisfy their FK at insert time.
  *
  * Non-fatal: ATTACH or INSERT failures are logged and swallowed so a
  * stale on-disk pops.db never bricks the boot path. Partial failures
@@ -58,6 +65,46 @@ const TABLE_COPIES: readonly TableCopy[] = [
       'action_label',
       'action_params',
     ],
+  },
+  {
+    table: 'engram_index',
+    idColumn: 'id',
+    columns: [
+      'id',
+      'file_path',
+      'type',
+      'source',
+      'status',
+      'template',
+      'created_at',
+      'modified_at',
+      'title',
+      'content_hash',
+      'body_hash',
+      'word_count',
+      'custom_fields',
+    ],
+  },
+  {
+    // engram_scopes has no surrogate id — the pair (engram_id, scope) is
+    // unique. Use engram_id as the existence-filter column; once any row
+    // for an engram is copied across, subsequent runs are no-ops for that
+    // engram. New scopes added to a still-shared engram won't replicate,
+    // which is acceptable: the cutover PR (US-03) routes new writes
+    // through getCerebrumDrizzle() before this asymmetry matters.
+    table: 'engram_scopes',
+    idColumn: 'engram_id',
+    columns: ['engram_id', 'scope'],
+  },
+  {
+    table: 'engram_tags',
+    idColumn: 'engram_id',
+    columns: ['engram_id', 'tag'],
+  },
+  {
+    table: 'engram_links',
+    idColumn: 'source_id',
+    columns: ['source_id', 'target_id'],
   },
 ];
 

--- a/apps/pops-api/src/db/per-pillar-migrations.test.ts
+++ b/apps/pops-api/src/db/per-pillar-migrations.test.ts
@@ -219,9 +219,9 @@ describe('runPerPillarMigrations', () => {
     // missing index carried over from shared journal 0009_red_quasimodo);
     // `cerebrum` owns `packages/cerebrum-db/migrations/` with
     // 0039_dry_fabian_cortez and 0044_nudge_log (cerebrum pillar Phase 1
-    // PR 2 — nudge_log slice) and 0050_engrams_baseline (PRD-179 US-01 —
-    // engrams baseline). Pillars without their own journal yet still skip
-    // cleanly.
+    // PR 2 — nudge_log slice), 0050_engrams_baseline (PRD-179 US-01 —
+    // engrams baseline) and 0051_glia_baseline (PRD-181 US-01 — glia
+    // baseline). Pillars without their own journal yet still skip cleanly.
     await withDb((db) => {
       const realPillars: PillarDescriptor[] = [
         { id: 'core', dbPackageDir: 'packages/core-db' },
@@ -243,6 +243,7 @@ describe('runPerPillarMigrations', () => {
         '0039_dry_fabian_cortez',
         '0044_nudge_log',
         '0050_engrams_baseline',
+        '0051_glia_baseline',
         '0054_service_accounts',
         '0055_pillar_registry',
         '0056_settings_baseline',

--- a/apps/pops-api/src/db/per-pillar-migrations.test.ts
+++ b/apps/pops-api/src/db/per-pillar-migrations.test.ts
@@ -219,8 +219,9 @@ describe('runPerPillarMigrations', () => {
     // missing index carried over from shared journal 0009_red_quasimodo);
     // `cerebrum` owns `packages/cerebrum-db/migrations/` with
     // 0039_dry_fabian_cortez and 0044_nudge_log (cerebrum pillar Phase 1
-    // PR 2 — nudge_log slice). Pillars without their own journal yet still
-    // skip cleanly.
+    // PR 2 — nudge_log slice) and 0050_engrams_baseline (PRD-179 US-01 —
+    // engrams baseline). Pillars without their own journal yet still skip
+    // cleanly.
     await withDb((db) => {
       const realPillars: PillarDescriptor[] = [
         { id: 'core', dbPackageDir: 'packages/core-db' },
@@ -241,6 +242,7 @@ describe('runPerPillarMigrations', () => {
         '0025_media_watch_history_baseline',
         '0039_dry_fabian_cortez',
         '0044_nudge_log',
+        '0050_engrams_baseline',
         '0054_service_accounts',
         '0055_pillar_registry',
         '0056_settings_baseline',

--- a/apps/pops-api/src/shared/test-utils.ts
+++ b/apps/pops-api/src/shared/test-utils.ts
@@ -1502,7 +1502,9 @@ export function setupTestContext() {
     // Same for the cerebrum pillar handle (phase 2 PR 3): nudge_log
     // reads/writes now resolve getCerebrumDrizzle(), so the test
     // fixture has to surface that table on the cerebrum handle too.
-    setCerebrumDb({ db: drizzle(db), raw: db });
+    // vecAvailable: false — the in-memory test fixture doesn't load
+    // sqlite-vec; vector consumers that need it inject their own handle.
+    setCerebrumDb({ db: drizzle(db), raw: db, vecAvailable: false });
 
     // Same for the food pillar handle (phase 2 PR 2): the handle is
     // opened at boot but no router has cut over yet. The injection is

--- a/packages/cerebrum-db/migrations/0050_engrams_baseline.sql
+++ b/packages/cerebrum-db/migrations/0050_engrams_baseline.sql
@@ -1,0 +1,65 @@
+-- Cerebrum pillar baseline for the engrams slice (PRD-179 US-01).
+--
+-- Mirrors the engram_index / engram_scopes / engram_tags / engram_links
+-- schema as it stands in the shared pops.db after all body_hash patches
+-- (0031_romantic_hannibal_king + 0036_body_hash_engram_index). Column
+-- definitions and indexes are copied verbatim so a fresh cerebrum.db
+-- matches the shared shape byte-for-byte; the boot-time backfill ATTACHes
+-- pops.db and copies rows across without column-rename gymnastics.
+--
+-- The `embeddings_vec` virtual table is NOT created via this migration —
+-- it requires the sqlite-vec extension and is created imperatively by
+-- `ensureEmbeddingsVecTable` after the extension loads in
+-- `openCerebrumDb`. Drizzle's schema builder can't express virtual
+-- tables, and keeping the create-virtual-table call out of the migration
+-- journal lets the engrams baseline still succeed on builds where
+-- sqlite-vec isn't available (engram CRUD + scopes/tags/links work
+-- without it).
+
+CREATE TABLE `engram_index` (
+	`id` text PRIMARY KEY NOT NULL,
+	`file_path` text NOT NULL,
+	`type` text NOT NULL,
+	`source` text NOT NULL,
+	`status` text NOT NULL,
+	`template` text,
+	`created_at` text NOT NULL,
+	`modified_at` text NOT NULL,
+	`title` text NOT NULL,
+	`content_hash` text NOT NULL,
+	`body_hash` text,
+	`word_count` integer NOT NULL,
+	`custom_fields` text
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `engram_index_file_path_unique` ON `engram_index` (`file_path`);--> statement-breakpoint
+CREATE INDEX `idx_engram_index_type` ON `engram_index` (`type`);--> statement-breakpoint
+CREATE INDEX `idx_engram_index_source` ON `engram_index` (`source`);--> statement-breakpoint
+CREATE INDEX `idx_engram_index_status` ON `engram_index` (`status`);--> statement-breakpoint
+CREATE INDEX `idx_engram_index_created_at` ON `engram_index` (`created_at`);--> statement-breakpoint
+CREATE INDEX `idx_engram_index_content_hash` ON `engram_index` (`content_hash`);--> statement-breakpoint
+CREATE INDEX `idx_engram_index_body_hash` ON `engram_index` (`body_hash`);--> statement-breakpoint
+CREATE TABLE `engram_links` (
+	`source_id` text NOT NULL,
+	`target_id` text NOT NULL,
+	FOREIGN KEY (`source_id`) REFERENCES `engram_index`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `idx_engram_links_target` ON `engram_links` (`target_id`);--> statement-breakpoint
+CREATE UNIQUE INDEX `uq_engram_links_pair` ON `engram_links` (`source_id`,`target_id`);--> statement-breakpoint
+CREATE TABLE `engram_scopes` (
+	`engram_id` text NOT NULL,
+	`scope` text NOT NULL,
+	FOREIGN KEY (`engram_id`) REFERENCES `engram_index`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `idx_engram_scopes_scope` ON `engram_scopes` (`scope`);--> statement-breakpoint
+CREATE UNIQUE INDEX `uq_engram_scopes_pair` ON `engram_scopes` (`engram_id`,`scope`);--> statement-breakpoint
+CREATE TABLE `engram_tags` (
+	`engram_id` text NOT NULL,
+	`tag` text NOT NULL,
+	FOREIGN KEY (`engram_id`) REFERENCES `engram_index`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `idx_engram_tags_tag` ON `engram_tags` (`tag`);--> statement-breakpoint
+CREATE UNIQUE INDEX `uq_engram_tags_pair` ON `engram_tags` (`engram_id`,`tag`);

--- a/packages/cerebrum-db/migrations/0051_glia_baseline.sql
+++ b/packages/cerebrum-db/migrations/0051_glia_baseline.sql
@@ -1,0 +1,46 @@
+-- Cerebrum pillar baseline for the glia slice (PRD-181 US-01).
+--
+-- Mirrors the glia_actions / glia_trust_state schema as it stands in the
+-- shared pops.db after the safety migration 0047_glia_actions (issue #2330).
+-- Column definitions and indexes are copied verbatim so a fresh
+-- cerebrum.db matches the shared shape byte-for-byte; the boot-time
+-- backfill ATTACHes pops.db and copies rows across without column-rename
+-- gymnastics.
+--
+-- Glia tracks every autonomous-action proposal (prune, consolidate,
+-- link, audit) plus a per-action-type trust state that drives the
+-- three-phase graduation model (propose → act_report → silent) — see
+-- ADR-021 / PRD-086 for the full spec. Action execution and digest
+-- generation stay in pops-api; this slice is the persistence layer only.
+
+CREATE TABLE `glia_actions` (
+	`id` text PRIMARY KEY NOT NULL,
+	`action_type` text NOT NULL,
+	`affected_ids` text NOT NULL,
+	`rationale` text NOT NULL,
+	`payload` text,
+	`phase` text NOT NULL,
+	`status` text NOT NULL,
+	`user_decision` text,
+	`user_note` text,
+	`executed_at` text,
+	`decided_at` text,
+	`reverted_at` text,
+	`created_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `idx_glia_actions_action_type` ON `glia_actions` (`action_type`);--> statement-breakpoint
+CREATE INDEX `idx_glia_actions_status` ON `glia_actions` (`status`);--> statement-breakpoint
+CREATE INDEX `idx_glia_actions_phase` ON `glia_actions` (`phase`);--> statement-breakpoint
+CREATE INDEX `idx_glia_actions_created_at` ON `glia_actions` (`created_at`);--> statement-breakpoint
+CREATE TABLE `glia_trust_state` (
+	`action_type` text PRIMARY KEY NOT NULL,
+	`current_phase` text NOT NULL,
+	`approved_count` integer DEFAULT 0 NOT NULL,
+	`rejected_count` integer DEFAULT 0 NOT NULL,
+	`reverted_count` integer DEFAULT 0 NOT NULL,
+	`autonomous_since` text,
+	`last_revert_at` text,
+	`graduated_at` text,
+	`updated_at` text NOT NULL
+);

--- a/packages/cerebrum-db/migrations/meta/_journal.json
+++ b/packages/cerebrum-db/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1777633800000,
       "tag": "0044_nudge_log",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1781827200000,
+      "tag": "0050_engrams_baseline",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cerebrum-db/migrations/meta/_journal.json
+++ b/packages/cerebrum-db/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1781827200000,
       "tag": "0050_engrams_baseline",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1781913600000,
+      "tag": "0051_glia_baseline",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cerebrum-db/package.json
+++ b/packages/cerebrum-db/package.json
@@ -22,7 +22,8 @@
   "dependencies": {
     "@pops/db-types": "workspace:*",
     "better-sqlite3": "^12.10.0",
-    "drizzle-orm": "^0.45.2"
+    "drizzle-orm": "^0.45.2",
+    "sqlite-vec": "^0.1.7"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.12",

--- a/packages/cerebrum-db/src/__tests__/engrams.test.ts
+++ b/packages/cerebrum-db/src/__tests__/engrams.test.ts
@@ -1,0 +1,365 @@
+/**
+ * Invariant tests for the engrams data-access service against an
+ * in-memory SQLite seeded with the package-local engrams baseline
+ * migration. Covers CRUD on `engram_index` + auxiliaries, list filters,
+ * cascade behaviour, link insert/delete, and the detector-scan helper
+ * `loadActiveEngrams`.
+ *
+ * The engrams baseline is read from
+ * `packages/cerebrum-db/migrations/0050_engrams_baseline.sql`. The
+ * `embeddings_vec` virtual table is NOT seeded here — vector search is
+ * out of scope for the data-access slice (it's wired up in the
+ * `openCerebrumDb` happy path tested separately).
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { engramIndex, engramLinks, engramScopes, engramTags } from '../schema.js';
+import {
+  deleteEngramIndex,
+  deleteEngramLinkPair,
+  existsEngram,
+  findIndexRow,
+  getEngram,
+  hydrateEngrams,
+  insertEngramLink,
+  listEngrams,
+  loadActiveEngrams,
+  upsertEngramIndex,
+} from '../services/engrams.js';
+
+import type { UpsertEngramArgs } from '../services/engrams-types.js';
+import type { CerebrumDb } from '../services/internal.js';
+
+const ENGRAMS_MIGRATION = join(__dirname, '../../migrations/0050_engrams_baseline.sql');
+
+function freshDb(): CerebrumDb {
+  const raw = new Database(':memory:');
+  raw.pragma('foreign_keys = ON');
+  const sql = readFileSync(ENGRAMS_MIGRATION, 'utf8');
+  for (const stmt of sql.split('--> statement-breakpoint')) {
+    const trimmed = stmt.trim();
+    if (trimmed.length > 0) raw.exec(trimmed);
+  }
+  return drizzle(raw);
+}
+
+function makeArgs(
+  overrides: Partial<UpsertEngramArgs> & Pick<UpsertEngramArgs, 'id'>
+): UpsertEngramArgs {
+  return {
+    filePath: `notes/${overrides.id}.md`,
+    type: 'note',
+    source: 'manual',
+    status: 'active',
+    template: null,
+    createdAt: '2026-05-10T10:00:00Z',
+    modifiedAt: '2026-05-10T10:00:00Z',
+    title: 'T',
+    contentHash: 'h',
+    bodyHash: 'bh',
+    wordCount: 3,
+    customFields: {},
+    scopes: ['work'],
+    tags: [],
+    links: [],
+    ...overrides,
+  };
+}
+
+describe('upsertEngramIndex', () => {
+  let db: CerebrumDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('inserts a row with its scopes/tags/links and round-trips through hydrate', () => {
+    upsertEngramIndex(
+      db,
+      makeArgs({
+        id: 'eng_20260510_1000_a',
+        scopes: ['work', 'personal'],
+        tags: ['idea', 'sprint'],
+        links: ['eng_other'],
+      })
+    );
+
+    const engram = getEngram(db, 'eng_20260510_1000_a');
+    expect(engram).not.toBeNull();
+    expect(engram?.scopes.toSorted()).toEqual(['personal', 'work']);
+    expect(engram?.tags.toSorted()).toEqual(['idea', 'sprint']);
+    expect(engram?.links).toEqual(['eng_other']);
+  });
+
+  it('deduplicates scopes/tags/links before insert', () => {
+    upsertEngramIndex(
+      db,
+      makeArgs({
+        id: 'eng_dup',
+        scopes: ['work', 'work', 'personal'],
+        tags: ['x', 'x'],
+        links: ['eng_o', 'eng_o'],
+      })
+    );
+
+    const engram = getEngram(db, 'eng_dup');
+    expect(engram?.scopes.toSorted()).toEqual(['personal', 'work']);
+    expect(engram?.tags).toEqual(['x']);
+    expect(engram?.links).toEqual(['eng_o']);
+  });
+
+  it('replaces auxiliaries on re-upsert (idempotent index rebuild)', () => {
+    upsertEngramIndex(
+      db,
+      makeArgs({ id: 'eng_replace', scopes: ['old'], tags: ['tag-old'], links: [] })
+    );
+    upsertEngramIndex(
+      db,
+      makeArgs({ id: 'eng_replace', scopes: ['new'], tags: ['tag-new'], links: ['eng_target'] })
+    );
+
+    const engram = getEngram(db, 'eng_replace');
+    expect(engram?.scopes).toEqual(['new']);
+    expect(engram?.tags).toEqual(['tag-new']);
+    expect(engram?.links).toEqual(['eng_target']);
+    expect(db.select().from(engramScopes).all()).toHaveLength(1);
+    expect(db.select().from(engramTags).all()).toHaveLength(1);
+    expect(db.select().from(engramLinks).all()).toHaveLength(1);
+  });
+
+  it('stores customFields as JSON when non-empty and null when empty', () => {
+    upsertEngramIndex(db, makeArgs({ id: 'eng_cf', customFields: { foo: 1 } }));
+    upsertEngramIndex(db, makeArgs({ id: 'eng_empty', customFields: {} }));
+
+    const rows = db.select().from(engramIndex).all();
+    const withFields = rows.find((r) => r.id === 'eng_cf');
+    const empty = rows.find((r) => r.id === 'eng_empty');
+    expect(withFields?.customFields).toBe(JSON.stringify({ foo: 1 }));
+    expect(empty?.customFields).toBeNull();
+  });
+});
+
+describe('findIndexRow / existsEngram', () => {
+  let db: CerebrumDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('returns null / false when the engram is absent', () => {
+    expect(findIndexRow(db, 'missing')).toBeNull();
+    expect(existsEngram(db, 'missing')).toBe(false);
+  });
+
+  it('returns the row / true when present', () => {
+    upsertEngramIndex(db, makeArgs({ id: 'eng_present' }));
+    expect(findIndexRow(db, 'eng_present')?.id).toBe('eng_present');
+    expect(existsEngram(db, 'eng_present')).toBe(true);
+  });
+});
+
+describe('deleteEngramIndex', () => {
+  let db: CerebrumDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('returns 0 when the engram does not exist (idempotent)', () => {
+    expect(deleteEngramIndex(db, 'missing')).toBe(0);
+  });
+
+  it('cascades to scopes/tags/outbound-links and sweeps inbound link rows', () => {
+    upsertEngramIndex(db, makeArgs({ id: 'eng_a', scopes: ['s'], tags: ['t'], links: ['eng_b'] }));
+    upsertEngramIndex(db, makeArgs({ id: 'eng_b', scopes: ['s'], tags: ['t'], links: ['eng_a'] }));
+
+    expect(deleteEngramIndex(db, 'eng_a')).toBe(1);
+    expect(
+      db
+        .select()
+        .from(engramScopes)
+        .all()
+        .some((r) => r.engramId === 'eng_a')
+    ).toBe(false);
+    expect(
+      db
+        .select()
+        .from(engramTags)
+        .all()
+        .some((r) => r.engramId === 'eng_a')
+    ).toBe(false);
+    expect(
+      db
+        .select()
+        .from(engramLinks)
+        .all()
+        .some((r) => r.targetId === 'eng_a')
+    ).toBe(false);
+    expect(existsEngram(db, 'eng_b')).toBe(true);
+  });
+});
+
+describe('listEngrams', () => {
+  let db: CerebrumDb;
+  beforeEach(() => {
+    db = freshDb();
+    upsertEngramIndex(
+      db,
+      makeArgs({
+        id: 'eng_1',
+        type: 'note',
+        title: 'apple pie',
+        status: 'active',
+        scopes: ['work'],
+        tags: ['food'],
+        createdAt: '2026-05-10T10:00:00Z',
+        modifiedAt: '2026-05-10T10:00:00Z',
+      })
+    );
+    upsertEngramIndex(
+      db,
+      makeArgs({
+        id: 'eng_2',
+        type: 'note',
+        title: 'banana split',
+        status: 'archived',
+        scopes: ['personal'],
+        tags: ['food', 'idea'],
+        createdAt: '2026-05-11T10:00:00Z',
+        modifiedAt: '2026-05-12T10:00:00Z',
+      })
+    );
+    upsertEngramIndex(
+      db,
+      makeArgs({
+        id: 'eng_3',
+        type: 'task',
+        title: 'cherry rant',
+        status: 'active',
+        scopes: ['work', 'personal'],
+        tags: ['idea'],
+        createdAt: '2026-05-12T10:00:00Z',
+        modifiedAt: '2026-05-11T10:00:00Z',
+      })
+    );
+  });
+
+  it('returns all rows with total when no filter is supplied', () => {
+    const result = listEngrams(db);
+    expect(result.total).toBe(3);
+    expect(result.engrams).toHaveLength(3);
+  });
+
+  it('filters by type', () => {
+    expect(listEngrams(db, { type: 'task' }).engrams.map((e) => e.id)).toEqual(['eng_3']);
+  });
+
+  it('filters by status', () => {
+    expect(listEngrams(db, { status: 'archived' }).engrams.map((e) => e.id)).toEqual(['eng_2']);
+  });
+
+  it('filters by scope (intersection)', () => {
+    const result = listEngrams(db, { scopes: ['personal'] });
+    expect(result.engrams.map((e) => e.id).toSorted()).toEqual(['eng_2', 'eng_3']);
+  });
+
+  it('filters by tag (intersection)', () => {
+    const result = listEngrams(db, { tags: ['idea'] });
+    expect(result.engrams.map((e) => e.id).toSorted()).toEqual(['eng_2', 'eng_3']);
+  });
+
+  it('substring-matches title via search', () => {
+    expect(listEngrams(db, { search: 'pie' }).engrams.map((e) => e.id)).toEqual(['eng_1']);
+  });
+
+  it('filters by ids and respects ids.length when limit is unspecified', () => {
+    const result = listEngrams(db, { ids: ['eng_1', 'eng_3'] });
+    expect(result.engrams.map((e) => e.id).toSorted()).toEqual(['eng_1', 'eng_3']);
+    expect(result.total).toBe(2);
+  });
+
+  it('orders by modified_at desc by default', () => {
+    expect(listEngrams(db).engrams.map((e) => e.id)).toEqual(['eng_2', 'eng_3', 'eng_1']);
+  });
+
+  it('honours an explicit sort.field and direction', () => {
+    expect(
+      listEngrams(db, { sort: { field: 'title', direction: 'asc' } }).engrams.map((e) => e.id)
+    ).toEqual(['eng_1', 'eng_2', 'eng_3']);
+  });
+
+  it('paginates with limit + offset on top of filters', () => {
+    const page = listEngrams(db, {
+      sort: { field: 'created_at', direction: 'asc' },
+      limit: 1,
+      offset: 1,
+    });
+    expect(page.engrams.map((e) => e.id)).toEqual(['eng_2']);
+    expect(page.total).toBe(3);
+  });
+});
+
+describe('hydrateEngrams', () => {
+  it('returns an empty array when given no rows', () => {
+    const db = freshDb();
+    expect(hydrateEngrams(db, [])).toEqual([]);
+  });
+});
+
+describe('insertEngramLink / deleteEngramLinkPair', () => {
+  let db: CerebrumDb;
+  beforeEach(() => {
+    db = freshDb();
+    upsertEngramIndex(db, makeArgs({ id: 'eng_a' }));
+    upsertEngramIndex(db, makeArgs({ id: 'eng_b' }));
+  });
+
+  it('is idempotent under repeated insertion', () => {
+    insertEngramLink(db, 'eng_a', 'eng_b');
+    insertEngramLink(db, 'eng_a', 'eng_b');
+    expect(db.select().from(engramLinks).all()).toHaveLength(1);
+  });
+
+  it('deletes both directions of a pair', () => {
+    insertEngramLink(db, 'eng_a', 'eng_b');
+    insertEngramLink(db, 'eng_b', 'eng_a');
+    expect(db.select().from(engramLinks).all()).toHaveLength(2);
+    deleteEngramLinkPair(db, 'eng_a', 'eng_b');
+    expect(db.select().from(engramLinks).all()).toHaveLength(0);
+  });
+});
+
+describe('loadActiveEngrams', () => {
+  let db: CerebrumDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('returns an empty array when nothing is seeded', () => {
+    expect(loadActiveEngrams(db)).toEqual([]);
+  });
+
+  it('excludes archived and consolidated rows but keeps active and stale', () => {
+    upsertEngramIndex(db, makeArgs({ id: 'eng_active', status: 'active' }));
+    upsertEngramIndex(db, makeArgs({ id: 'eng_stale', status: 'stale' }));
+    upsertEngramIndex(db, makeArgs({ id: 'eng_archived', status: 'archived' }));
+    upsertEngramIndex(db, makeArgs({ id: 'eng_consolidated', status: 'consolidated' }));
+
+    const ids = loadActiveEngrams(db)
+      .map((e) => e.id)
+      .toSorted();
+    expect(ids).toEqual(['eng_active', 'eng_stale']);
+  });
+
+  it('hydrates scopes and tags for each active row', () => {
+    upsertEngramIndex(
+      db,
+      makeArgs({ id: 'eng_a', scopes: ['s1', 's2'], tags: ['t1'], status: 'active' })
+    );
+    const [active] = loadActiveEngrams(db);
+    expect(active?.scopes.toSorted()).toEqual(['s1', 's2']);
+    expect(active?.tags).toEqual(['t1']);
+  });
+});

--- a/packages/cerebrum-db/src/__tests__/glia.test.ts
+++ b/packages/cerebrum-db/src/__tests__/glia.test.ts
@@ -1,0 +1,433 @@
+/**
+ * Invariant tests for the glia data-access service against an in-memory
+ * SQLite seeded with the package-local glia baseline migration. Covers
+ * action CRUD + filters, autonomous-window helpers, revert-window counts,
+ * and trust-state seed/read/update including the counter-increment
+ * shortcut.
+ *
+ * The baseline is read from
+ * `packages/cerebrum-db/migrations/0051_glia_baseline.sql` so the table
+ * shape under test is identical to the one shipped in the journal.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import Database from 'better-sqlite3';
+import { eq } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { gliaActions } from '../schema.js';
+import {
+  countAutonomousExecutionsSince,
+  countAutonomousRevertsSince,
+  countRevertsInWindow,
+  deleteAction,
+  getAction,
+  getTrustState,
+  incrementTrustStateCounter,
+  insertAction,
+  listActions,
+  listAutonomousActionsInWindow,
+  listTrustStates,
+  seedTrustState,
+  updateAction,
+  updateTrustState,
+} from '../services/glia.js';
+
+import type { InsertActionRow } from '../services/glia-types.js';
+import type { CerebrumDb } from '../services/internal.js';
+
+const GLIA_MIGRATION = join(__dirname, '../../migrations/0051_glia_baseline.sql');
+
+function freshDb(): CerebrumDb {
+  const raw = new Database(':memory:');
+  raw.pragma('foreign_keys = ON');
+  const sql = readFileSync(GLIA_MIGRATION, 'utf8');
+  for (const stmt of sql.split('--> statement-breakpoint')) {
+    const trimmed = stmt.trim();
+    if (trimmed.length > 0) raw.exec(trimmed);
+  }
+  return drizzle(raw);
+}
+
+function makeAction(
+  overrides: Partial<InsertActionRow> & Pick<InsertActionRow, 'id'>
+): InsertActionRow {
+  return {
+    actionType: 'prune',
+    affectedIds: ['eng_a'],
+    rationale: 'because reasons',
+    payload: null,
+    phase: 'propose',
+    status: 'pending',
+    executedAt: null,
+    createdAt: '2026-06-10T10:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('insertAction', () => {
+  let db: CerebrumDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('serialises affectedIds and payload as JSON and round-trips via getAction', () => {
+    const created = insertAction(
+      db,
+      makeAction({
+        id: 'glia_prune_001',
+        affectedIds: ['eng_a', 'eng_b'],
+        payload: { mergePlan: 'a+b' },
+      })
+    );
+
+    expect(created.affectedIds).toEqual(['eng_a', 'eng_b']);
+    expect(created.payload).toEqual({ mergePlan: 'a+b' });
+
+    const fetched = getAction(db, 'glia_prune_001');
+    expect(fetched).not.toBeNull();
+    expect(fetched?.payload).toEqual({ mergePlan: 'a+b' });
+  });
+
+  it('stores null payload as SQL NULL (not the string "null")', () => {
+    insertAction(db, makeAction({ id: 'glia_null_payload', payload: null }));
+    const row = db.select().from(gliaActions).where(eq(gliaActions.id, 'glia_null_payload')).get();
+    expect(row?.payload).toBeNull();
+  });
+
+  it('preserves autonomous execution status + executedAt as supplied', () => {
+    const created = insertAction(
+      db,
+      makeAction({
+        id: 'glia_auto',
+        phase: 'act_report',
+        status: 'executed',
+        executedAt: '2026-06-10T10:05:00Z',
+      })
+    );
+    expect(created.status).toBe('executed');
+    expect(created.executedAt).toBe('2026-06-10T10:05:00Z');
+  });
+});
+
+describe('getAction', () => {
+  it('returns null when the row is missing', () => {
+    expect(getAction(freshDb(), 'missing')).toBeNull();
+  });
+});
+
+describe('listActions', () => {
+  let db: CerebrumDb;
+  beforeEach(() => {
+    db = freshDb();
+    insertAction(
+      db,
+      makeAction({
+        id: 'a1',
+        actionType: 'prune',
+        status: 'pending',
+        createdAt: '2026-06-10T10:00:00Z',
+      })
+    );
+    insertAction(
+      db,
+      makeAction({
+        id: 'a2',
+        actionType: 'consolidate',
+        status: 'approved',
+        createdAt: '2026-06-10T11:00:00Z',
+      })
+    );
+    insertAction(
+      db,
+      makeAction({
+        id: 'a3',
+        actionType: 'prune',
+        status: 'executed',
+        createdAt: '2026-06-11T10:00:00Z',
+      })
+    );
+  });
+
+  it('returns all rows in created_at desc order with total', () => {
+    const result = listActions(db);
+    expect(result.total).toBe(3);
+    expect(result.actions.map((a) => a.id)).toEqual(['a3', 'a2', 'a1']);
+  });
+
+  it('filters by actionType', () => {
+    const result = listActions(db, { actionType: 'prune' });
+    expect(result.total).toBe(2);
+    expect(result.actions.map((a) => a.id).toSorted()).toEqual(['a1', 'a3']);
+  });
+
+  it('filters by status', () => {
+    const result = listActions(db, { status: 'approved' });
+    expect(result.actions.map((a) => a.id)).toEqual(['a2']);
+  });
+
+  it('filters by inclusive dateFrom / dateTo', () => {
+    const result = listActions(db, {
+      dateFrom: '2026-06-10T11:00:00Z',
+      dateTo: '2026-06-10T23:59:59Z',
+    });
+    expect(result.actions.map((a) => a.id)).toEqual(['a2']);
+  });
+
+  it('paginates with limit + offset on top of filters', () => {
+    const page = listActions(db, { limit: 1, offset: 1 });
+    expect(page.actions.map((a) => a.id)).toEqual(['a2']);
+    expect(page.total).toBe(3);
+  });
+});
+
+describe('updateAction', () => {
+  let db: CerebrumDb;
+  beforeEach(() => {
+    db = freshDb();
+    insertAction(db, makeAction({ id: 'a1' }));
+  });
+
+  it('patches lifecycle columns and returns the updated row', () => {
+    const updated = updateAction(db, 'a1', {
+      status: 'approved',
+      userDecision: 'approve',
+      userNote: 'looks good',
+      decidedAt: '2026-06-10T12:00:00Z',
+    });
+    expect(updated?.status).toBe('approved');
+    expect(updated?.userDecision).toBe('approve');
+    expect(updated?.userNote).toBe('looks good');
+    expect(updated?.decidedAt).toBe('2026-06-10T12:00:00Z');
+  });
+
+  it('returns the current row when the patch is empty (no-op)', () => {
+    const result = updateAction(db, 'a1', {});
+    expect(result?.status).toBe('pending');
+  });
+
+  it('returns null when the action does not exist', () => {
+    expect(updateAction(db, 'missing', { status: 'approved' })).toBeNull();
+  });
+});
+
+describe('deleteAction', () => {
+  it('returns 0 when the action is missing (idempotent)', () => {
+    expect(deleteAction(freshDb(), 'missing')).toBe(0);
+  });
+
+  it('removes the row and returns 1', () => {
+    const db = freshDb();
+    insertAction(db, makeAction({ id: 'a1' }));
+    expect(deleteAction(db, 'a1')).toBe(1);
+    expect(getAction(db, 'a1')).toBeNull();
+  });
+});
+
+describe('listAutonomousActionsInWindow', () => {
+  let db: CerebrumDb;
+  beforeEach(() => {
+    db = freshDb();
+    // Autonomous (decided_at null, executed) inside the window.
+    insertAction(
+      db,
+      makeAction({
+        id: 'auto1',
+        status: 'executed',
+        executedAt: '2026-06-10T10:00:00Z',
+        createdAt: '2026-06-10T10:00:00Z',
+      })
+    );
+    insertAction(
+      db,
+      makeAction({
+        id: 'auto2',
+        status: 'executed',
+        executedAt: '2026-06-10T11:00:00Z',
+        createdAt: '2026-06-10T11:00:00Z',
+      })
+    );
+    // Manually decided — should be excluded.
+    insertAction(
+      db,
+      makeAction({ id: 'manual', status: 'executed', executedAt: '2026-06-10T12:00:00Z' })
+    );
+    updateAction(db, 'manual', { userDecision: 'approve', decidedAt: '2026-06-10T11:30:00Z' });
+    // Outside the window on the upper boundary — endDate is exclusive.
+    insertAction(
+      db,
+      makeAction({ id: 'boundary', status: 'executed', executedAt: '2026-06-11T00:00:00Z' })
+    );
+  });
+
+  it('returns only autonomous executions within [start, end), ordered by executedAt asc', () => {
+    const rows = listAutonomousActionsInWindow(db, '2026-06-10T00:00:00Z', '2026-06-11T00:00:00Z');
+    expect(rows.map((r) => r.id)).toEqual(['auto1', 'auto2']);
+  });
+});
+
+describe('countAutonomousExecutionsSince / countAutonomousRevertsSince', () => {
+  let db: CerebrumDb;
+  beforeEach(() => {
+    db = freshDb();
+    insertAction(
+      db,
+      makeAction({
+        id: 'exec1',
+        actionType: 'prune',
+        status: 'executed',
+        executedAt: '2026-06-10T10:00:00Z',
+      })
+    );
+    insertAction(
+      db,
+      makeAction({
+        id: 'exec2',
+        actionType: 'prune',
+        status: 'executed',
+        executedAt: '2026-06-10T11:00:00Z',
+      })
+    );
+    insertAction(
+      db,
+      makeAction({
+        id: 'reverted1',
+        actionType: 'prune',
+        status: 'reverted',
+        executedAt: '2026-06-10T09:00:00Z',
+      })
+    );
+    updateAction(db, 'reverted1', { revertedAt: '2026-06-10T12:00:00Z' });
+  });
+
+  it('counts only executed autonomous rows for the type since the cutoff', () => {
+    expect(countAutonomousExecutionsSince(db, 'prune', '2026-06-10T00:00:00Z')).toBe(2);
+    expect(countAutonomousExecutionsSince(db, 'consolidate', '2026-06-10T00:00:00Z')).toBe(0);
+  });
+
+  it('excludes rows with null revertedAt from the revert count', () => {
+    insertAction(
+      db,
+      makeAction({
+        id: 'broken',
+        actionType: 'prune',
+        status: 'reverted',
+        executedAt: '2026-06-10T09:30:00Z',
+      })
+    );
+    expect(countAutonomousRevertsSince(db, 'prune', '2026-06-10T00:00:00Z')).toBe(1);
+  });
+});
+
+describe('countRevertsInWindow', () => {
+  it('counts reverts of the given type after windowStart', () => {
+    const db = freshDb();
+    insertAction(db, makeAction({ id: 'r1', actionType: 'prune', status: 'reverted' }));
+    updateAction(db, 'r1', { revertedAt: '2026-06-10T10:00:00Z' });
+    insertAction(db, makeAction({ id: 'r2', actionType: 'prune', status: 'reverted' }));
+    updateAction(db, 'r2', { revertedAt: '2026-06-09T10:00:00Z' });
+    insertAction(db, makeAction({ id: 'r3', actionType: 'consolidate', status: 'reverted' }));
+    updateAction(db, 'r3', { revertedAt: '2026-06-10T11:00:00Z' });
+
+    expect(countRevertsInWindow(db, 'prune', '2026-06-10T00:00:00Z')).toBe(1);
+    expect(countRevertsInWindow(db, 'consolidate', '2026-06-10T00:00:00Z')).toBe(1);
+  });
+});
+
+describe('seedTrustState + getTrustState + listTrustStates', () => {
+  let db: CerebrumDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('inserts a new row idempotently and reads it back', () => {
+    seedTrustState(db, {
+      actionType: 'prune',
+      currentPhase: 'propose',
+      approvedCount: 0,
+      rejectedCount: 0,
+      revertedCount: 0,
+      updatedAt: '2026-06-10T10:00:00Z',
+    });
+    seedTrustState(db, {
+      actionType: 'prune',
+      currentPhase: 'silent',
+      approvedCount: 99,
+      rejectedCount: 99,
+      revertedCount: 99,
+      updatedAt: '2026-06-10T11:00:00Z',
+    });
+
+    const state = getTrustState(db, 'prune');
+    expect(state?.currentPhase).toBe('propose');
+    expect(state?.approvedCount).toBe(0);
+  });
+
+  it('listTrustStates returns every seeded type', () => {
+    seedTrustState(db, {
+      actionType: 'prune',
+      currentPhase: 'propose',
+      approvedCount: 0,
+      rejectedCount: 0,
+      revertedCount: 0,
+      updatedAt: '2026-06-10T10:00:00Z',
+    });
+    seedTrustState(db, {
+      actionType: 'consolidate',
+      currentPhase: 'propose',
+      approvedCount: 0,
+      rejectedCount: 0,
+      revertedCount: 0,
+      updatedAt: '2026-06-10T10:00:00Z',
+    });
+    expect(
+      listTrustStates(db)
+        .map((s) => s.actionType)
+        .toSorted()
+    ).toEqual(['consolidate', 'prune']);
+  });
+});
+
+describe('updateTrustState + incrementTrustStateCounter', () => {
+  let db: CerebrumDb;
+  beforeEach(() => {
+    db = freshDb();
+    seedTrustState(db, {
+      actionType: 'prune',
+      currentPhase: 'propose',
+      approvedCount: 0,
+      rejectedCount: 0,
+      revertedCount: 0,
+      updatedAt: '2026-06-10T10:00:00Z',
+    });
+  });
+
+  it('patches a single field and returns the updated row', () => {
+    const updated = updateTrustState(db, 'prune', {
+      currentPhase: 'act_report',
+      autonomousSince: '2026-06-10T11:00:00Z',
+      updatedAt: '2026-06-10T11:00:00Z',
+    });
+    expect(updated?.currentPhase).toBe('act_report');
+    expect(updated?.autonomousSince).toBe('2026-06-10T11:00:00Z');
+  });
+
+  it('returns null when the action type was never seeded', () => {
+    expect(
+      updateTrustState(db, 'link', { currentPhase: 'silent', updatedAt: '2026-06-10T10:00:00Z' })
+    ).toBeNull();
+  });
+
+  it('incrementTrustStateCounter atomically bumps the named counter', () => {
+    incrementTrustStateCounter(db, 'prune', 'approvedCount', '2026-06-10T11:00:00Z');
+    incrementTrustStateCounter(db, 'prune', 'approvedCount', '2026-06-10T11:01:00Z');
+    incrementTrustStateCounter(db, 'prune', 'revertedCount', '2026-06-10T11:02:00Z');
+
+    const state = getTrustState(db, 'prune');
+    expect(state?.approvedCount).toBe(2);
+    expect(state?.revertedCount).toBe(1);
+    expect(state?.updatedAt).toBe('2026-06-10T11:02:00Z');
+  });
+});

--- a/packages/cerebrum-db/src/__tests__/open-cerebrum-db.test.ts
+++ b/packages/cerebrum-db/src/__tests__/open-cerebrum-db.test.ts
@@ -3,7 +3,8 @@
  *
  * Exercises the migration apply path against a fresh tmp file, verifies
  * the resulting schema, and confirms the helper is idempotent when
- * re-run against the same DB.
+ * re-run against the same DB. Covers both the nudge_log slice (Track M5)
+ * and the engrams baseline (PRD-179 US-01).
  */
 import { existsSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -12,7 +13,8 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { openCerebrumDb } from '../open-cerebrum-db.js';
-import { nudgeLog } from '../schema.js';
+import { engramIndex, nudgeLog } from '../schema.js';
+import { upsertEngramIndex } from '../services/engrams.js';
 import { persistCandidates } from '../services/nudge-log.js';
 
 let tmpDir: string;
@@ -30,7 +32,7 @@ describe('openCerebrumDb', () => {
     const path = join(tmpDir, 'nested', 'sub', 'cerebrum.db');
     expect(existsSync(path)).toBe(false);
 
-    const { raw } = openCerebrumDb(path);
+    const { raw } = openCerebrumDb(path, { loadVec: false });
     try {
       expect(existsSync(path)).toBe(true);
       expect(raw.pragma('journal_mode', { simple: true })).toBe('wal');
@@ -43,7 +45,7 @@ describe('openCerebrumDb', () => {
 
   it('applies the nudge_log migration and accepts writes via the service', () => {
     const path = join(tmpDir, 'cerebrum.db');
-    const { db, raw } = openCerebrumDb(path);
+    const { db, raw } = openCerebrumDb(path, { loadVec: false });
     try {
       expect(db.select().from(nudgeLog).all()).toHaveLength(0);
       const created = persistCandidates(
@@ -68,9 +70,52 @@ describe('openCerebrumDb', () => {
     }
   });
 
+  it('applies the engrams baseline and accepts writes via the service', () => {
+    const path = join(tmpDir, 'cerebrum.db');
+    const { db, raw } = openCerebrumDb(path, { loadVec: false });
+    try {
+      expect(db.select().from(engramIndex).all()).toHaveLength(0);
+      upsertEngramIndex(db, {
+        id: 'eng_20260510_1000_test',
+        filePath: 'notes/eng_20260510_1000_test.md',
+        type: 'note',
+        source: 'manual',
+        status: 'active',
+        template: null,
+        createdAt: '2026-05-10T10:00:00Z',
+        modifiedAt: '2026-05-10T10:00:00Z',
+        title: 'T',
+        contentHash: 'h',
+        bodyHash: 'bh',
+        wordCount: 1,
+        customFields: {},
+        scopes: ['work'],
+        tags: [],
+        links: [],
+      });
+      expect(db.select().from(engramIndex).all()).toHaveLength(1);
+    } finally {
+      raw.close();
+    }
+  });
+
+  it('skips sqlite-vec when loadVec is false and reports vecAvailable=false', () => {
+    const path = join(tmpDir, 'cerebrum.db');
+    const opened = openCerebrumDb(path, { loadVec: false });
+    try {
+      expect(opened.vecAvailable).toBe(false);
+      const row = opened.raw
+        .prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='embeddings_vec'`)
+        .get();
+      expect(row).toBeUndefined();
+    } finally {
+      opened.raw.close();
+    }
+  });
+
   it('is idempotent — re-opening the same DB does not re-apply migrations', () => {
     const path = join(tmpDir, 'cerebrum.db');
-    const first = openCerebrumDb(path);
+    const first = openCerebrumDb(path, { loadVec: false });
     try {
       persistCandidates(
         first.db,
@@ -92,7 +137,7 @@ describe('openCerebrumDb', () => {
       first.raw.close();
     }
 
-    const second = openCerebrumDb(path);
+    const second = openCerebrumDb(path, { loadVec: false });
     try {
       expect(second.db.select().from(nudgeLog).all()).toHaveLength(1);
     } finally {

--- a/packages/cerebrum-db/src/index.ts
+++ b/packages/cerebrum-db/src/index.ts
@@ -16,9 +16,14 @@
  *     namespace. Pops-api still owns engram routing and consumes the
  *     legacy shared handle via `getDrizzle()`; PRD-179 US-03 flips it
  *     over to `getCerebrumDrizzle()`.
+ *   - PRD-181 US-01 added the glia data layer — schemas, baseline
+ *     migration, and the `gliaService` namespace covering CRUD on
+ *     `glia_actions` and the per-action-type trust state. Trust
+ *     graduation, dispatch and digest rendering stay in pops-api until
+ *     PRD-181 US-03.
  *
- * The remaining slices (embeddings, conversations, glia, plexus) follow
- * in subsequent PRs. Cerebrum's load-bearing surgery is the URI
+ * The remaining slices (embeddings, conversations, plexus) follow in
+ * subsequent PRs. Cerebrum's load-bearing surgery is the URI
  * dispatcher round-trip (engrams reference other pillars' entities by
  * URI) — that lands when the consumers cut over, not in this scaffold.
  *
@@ -45,6 +50,7 @@ export {
 
 export * as nudgeLogService from './services/nudge-log.js';
 export * as engramsService from './services/engrams.js';
+export * as gliaService from './services/glia.js';
 
 export type {
   Nudge,
@@ -69,3 +75,22 @@ export type {
   ListEngramsResult,
   UpsertEngramArgs,
 } from './services/engrams-types.js';
+
+export {
+  ACTION_STATUSES,
+  ACTION_TYPES,
+  TRUST_PHASES,
+  USER_DECISIONS,
+  type ActionListFilters,
+  type ActionStatus,
+  type ActionType,
+  type GliaAction,
+  type GliaTrustState,
+  type InsertActionRow,
+  type ListActionsResult,
+  type SeedTrustStateRow,
+  type TrustPhase,
+  type UpdateActionPatch,
+  type UpdateTrustStatePatch,
+  type UserDecision,
+} from './services/glia-types.js';

--- a/packages/cerebrum-db/src/index.ts
+++ b/packages/cerebrum-db/src/index.ts
@@ -2,17 +2,25 @@
  * Backend-safe barrel for the cerebrum domain's persistence layer.
  *
  * Hosts cerebrum pillar tables: engram_index + engram_scopes + engram_tags
- * (knowledge graph), embeddings + embeddings_vec (dense vector store),
- * conversations + messages + conversation_context (ego), nudge_log
- * (reflex audit), glia_actions + glia_trust_state (glia worker audit),
- * plexus_adapters + plexus_filters (external adapter registry).
+ * + engram_links (knowledge graph), embeddings + embeddings_vec (dense
+ * vector store), conversations + messages + conversation_context (ego),
+ * nudge_log (reflex audit), glia_actions + glia_trust_state (glia worker
+ * audit), plexus_adapters + plexus_filters (external adapter registry).
  *
- * Per the CI-never-breaks pattern the migration is incremental — this PR
- * scaffolds the package and moves only the `nudge_log` slice (PRD-084
- * reflex audit). The other slices (engrams, embeddings, conversations,
- * glia, plexus) follow in subsequent PRs. Cerebrum's load-bearing
- * surgery is the URI dispatcher round-trip (engrams reference other
- * pillars' entities by URI) — that lands when the engrams slice moves.
+ * Per the CI-never-breaks pattern the migration is incremental:
+ *   - Track M5 (PRD-149) moved the `nudge_log` slice (PRD-084 reflex
+ *     audit) into this package and routed pops-api through the
+ *     `nudgeLogService` exports.
+ *   - PRD-179 US-01 added the engrams data layer — schemas, baseline
+ *     migration, sqlite-vec wiring, and the `engramsService`
+ *     namespace. Pops-api still owns engram routing and consumes the
+ *     legacy shared handle via `getDrizzle()`; PRD-179 US-03 flips it
+ *     over to `getCerebrumDrizzle()`.
+ *
+ * The remaining slices (embeddings, conversations, glia, plexus) follow
+ * in subsequent PRs. Cerebrum's load-bearing surgery is the URI
+ * dispatcher round-trip (engrams reference other pillars' entities by
+ * URI) — that lands when the consumers cut over, not in this scaffold.
  *
  * Subsequent PRs flesh out three sibling packages — `cerebrum-contract`,
  * `cerebrum-api`, `cerebrum-ui` — which are deferred until their first
@@ -22,12 +30,22 @@ export * from './schema.js';
 
 export type { CerebrumDb } from './services/internal.js';
 
-export { openCerebrumDb, type OpenedCerebrumDb } from './open-cerebrum-db.js';
+export {
+  openCerebrumDb,
+  type OpenCerebrumDbOptions,
+  type OpenedCerebrumDb,
+} from './open-cerebrum-db.js';
+
+export {
+  ensureEmbeddingsVecTable,
+  isVecAvailable,
+  tryLoadVecExtension,
+  type VecLoaderLogger,
+} from './vec-loader.js';
 
 export * as nudgeLogService from './services/nudge-log.js';
+export * as engramsService from './services/engrams.js';
 
-// Public types re-exported at the package root so consumers can name
-// them without reaching into the namespaces.
 export type {
   Nudge,
   NudgeAction,
@@ -40,3 +58,14 @@ export type {
 } from './services/nudge-log-types.js';
 
 export { generateNudgeId, rowToNudge, type NudgeLogRow } from './services/nudge-log-helpers.js';
+
+export type {
+  Engram,
+  EngramSource,
+  EngramStatus,
+  EngramSummary,
+  IndexRow as EngramIndexRow,
+  ListEngramsOptions,
+  ListEngramsResult,
+  UpsertEngramArgs,
+} from './services/engrams-types.js';

--- a/packages/cerebrum-db/src/open-cerebrum-db.ts
+++ b/packages/cerebrum-db/src/open-cerebrum-db.ts
@@ -1,17 +1,27 @@
 /**
  * Standalone opener for the cerebrum pillar's SQLite database.
  *
- * Phase 2 PR 1 of the cerebrum pillar migration scaffolds the
- * per-pillar connection so subsequent PRs can flip readers/writers
- * over without touching pops-api's existing singleton. The opener is
- * intentionally minimal — it relies on drizzle-orm's built-in
- * `migrate` helper to apply the in-package migrations journal at
- * `packages/cerebrum-db/migrations/meta/_journal.json`.
+ * Phase 2 PR 1 of the cerebrum pillar migration scaffolded the
+ * per-pillar connection so subsequent PRs can flip readers/writers over
+ * without touching pops-api's existing singleton. PRD-179 US-01 layered
+ * the engrams slice on top — adding sqlite-vec extension loading before
+ * the migration apply so the `embeddings_vec` virtual table (cerebrum's
+ * only vector consumer) can be created on first open.
+ *
+ * The opener is intentionally minimal — it relies on drizzle-orm's
+ * built-in `migrate` helper to apply the in-package migrations journal
+ * at `packages/cerebrum-db/migrations/meta/_journal.json`. Today that
+ * covers the nudge_log tables (0039, 0044) and the engrams baseline
+ * (0050). The `embeddings_vec` virtual table is created imperatively
+ * after `tryLoadVecExtension` succeeds — kept out of the drizzle
+ * migration journal because virtual tables aren't representable in the
+ * schema builder and because we tolerate a missing extension on the
+ * non-vector cerebrum consumers (engram CRUD, nudges).
  *
  * No production consumer wires this up yet. Subsequent PRs add the
- * `CEREBRUM_SQLITE_PATH` env-var read in pops-api, the boot-time
- * call, and the ATTACH-based backfill of nudge_log rows from the
- * shared pops.db.
+ * `CEREBRUM_SQLITE_PATH` env-var read in pops-api, the boot-time call,
+ * and the ATTACH-based backfill of cerebrum-owned rows from the shared
+ * pops.db.
  */
 import { mkdirSync } from 'node:fs';
 import { dirname, join } from 'node:path';
@@ -20,6 +30,12 @@ import { fileURLToPath } from 'node:url';
 import Database from 'better-sqlite3';
 import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+
+import {
+  ensureEmbeddingsVecTable,
+  tryLoadVecExtension,
+  type VecLoaderLogger,
+} from './vec-loader.js';
 
 import type { CerebrumDb } from './services/internal.js';
 
@@ -35,16 +51,32 @@ function migrationsDir(): string {
   return join(here, '..', 'migrations');
 }
 
+export interface OpenCerebrumDbOptions {
+  /**
+   * Whether to attempt loading the sqlite-vec extension. Defaults to
+   * `true` so production wiring picks up vector support automatically;
+   * tests for non-vector cerebrum consumers can pass `false` to keep the
+   * boot fast and avoid sqlite-vec install requirements in CI sandboxes.
+   */
+  loadVec?: boolean;
+  /** Optional logger forwarded to the vec loader. */
+  logger?: VecLoaderLogger;
+}
+
 /**
  * Result of {@link openCerebrumDb}. The raw handle is exposed for callers
  * that need lifecycle control (close on shutdown, prepared statements,
- * pragmas the drizzle wrapper hides).
+ * pragmas the drizzle wrapper hides). `vecAvailable` records whether
+ * sqlite-vec actually loaded on this connection so callers can branch
+ * on it without re-probing.
  */
 export interface OpenedCerebrumDb {
-  /** Drizzle handle — pass into any `nudgeLogService.*` call. */
+  /** Drizzle handle — pass into any `*Service.*` call. */
   db: CerebrumDb;
   /** Raw better-sqlite3 handle. Call `.close()` on shutdown. */
   raw: Database.Database;
+  /** True iff sqlite-vec was loaded successfully on this connection. */
+  vecAvailable: boolean;
 }
 
 /**
@@ -57,24 +89,33 @@ export interface OpenedCerebrumDb {
  *   - `journal_mode=WAL`, `foreign_keys=ON`, and `busy_timeout=5000`
  *     are enabled to match the shared singleton in
  *     `apps/pops-api/src/db.ts`.
- *   - Every migration in
+ *   - When `options.loadVec !== false`, `tryLoadVecExtension(raw)` runs
+ *     before the migration apply so the `embeddings_vec` virtual table
+ *     can be created afterwards via `ensureEmbeddingsVecTable`. Failures
+ *     are non-fatal — `vecAvailable` is reported on the result.
+ *   - Every migration listed in
  *     `packages/cerebrum-db/migrations/meta/_journal.json` is applied
  *     via drizzle's built-in migrator (idempotent — re-running against
  *     the same DB short-circuits on the `__drizzle_migrations` hash
- *     check). Today that's `0039_dry_fabian_cortez` (creates
- *     `nudge_log`) and `0044_nudge_log` (the idempotent safety
- *     re-creation).
+ *     check).
  *
  * If the migration apply throws (corrupt DB, malformed migration,
  * missing folder), the raw handle is closed before the error is
  * re-thrown so the caller can't leak a locked file descriptor.
  */
-export function openCerebrumDb(path: string): OpenedCerebrumDb {
+export function openCerebrumDb(
+  path: string,
+  options: OpenCerebrumDbOptions = {}
+): OpenedCerebrumDb {
   mkdirSync(dirname(path), { recursive: true });
   const raw = new Database(path);
   raw.pragma('journal_mode = WAL');
   raw.pragma('foreign_keys = ON');
   raw.pragma('busy_timeout = 5000');
+
+  const shouldLoadVec = options.loadVec !== false;
+  const vecAvailable = shouldLoadVec ? tryLoadVecExtension(raw, options.logger) : false;
+
   const db = drizzle(raw) as CerebrumDb;
   try {
     migrate(db, { migrationsFolder: migrationsDir() });
@@ -82,5 +123,8 @@ export function openCerebrumDb(path: string): OpenedCerebrumDb {
     raw.close();
     throw err;
   }
-  return { db, raw };
+
+  if (vecAvailable) ensureEmbeddingsVecTable(raw);
+
+  return { db, raw, vecAvailable };
 }

--- a/packages/cerebrum-db/src/open-cerebrum-db.ts
+++ b/packages/cerebrum-db/src/open-cerebrum-db.ts
@@ -114,7 +114,7 @@ export function openCerebrumDb(
   raw.pragma('busy_timeout = 5000');
 
   const shouldLoadVec = options.loadVec !== false;
-  const vecAvailable = shouldLoadVec ? tryLoadVecExtension(raw, options.logger) : false;
+  const vecLoaded = shouldLoadVec ? tryLoadVecExtension(raw, options.logger) : false;
 
   const db = drizzle(raw) as CerebrumDb;
   try {
@@ -124,7 +124,35 @@ export function openCerebrumDb(
     throw err;
   }
 
-  if (vecAvailable) ensureEmbeddingsVecTable(raw);
+  const vecAvailable = vecLoaded && ensureAndProbeEmbeddingsVec(raw, options.logger);
 
   return { db, raw, vecAvailable };
+}
+
+/**
+ * Create the `embeddings_vec` virtual table and probe it with a no-op
+ * query to confirm the vec0 module is actually usable on this
+ * connection. Returns `true` only when both the create and the probe
+ * succeed — covers the case where the extension loads but the virtual
+ * table can't be queried (module init error, name collision against a
+ * non-vec0 table, etc.).
+ */
+function ensureAndProbeEmbeddingsVec(
+  raw: Database.Database,
+  logger: VecLoaderLogger | undefined
+): boolean {
+  if (!ensureEmbeddingsVecTable(raw)) {
+    logger?.warn?.({}, '[cerebrum-db] embeddings_vec ensure failed — vector features disabled');
+    return false;
+  }
+  try {
+    raw.prepare('SELECT 1 FROM embeddings_vec LIMIT 0').all();
+    return true;
+  } catch (err) {
+    logger?.warn?.(
+      { err: (err as Error).message },
+      '[cerebrum-db] embeddings_vec probe failed — vector features disabled'
+    );
+    return false;
+  }
 }

--- a/packages/cerebrum-db/src/schema.ts
+++ b/packages/cerebrum-db/src/schema.ts
@@ -9,9 +9,13 @@
  * cerebrum pillar's read surface stays self-describing. Mirrors the
  * `@pops/core-db` / `@pops/inventory-db` schema re-export pattern.
  *
- * This first slice exposes only `nudgeLog` (PRD-084 reflex/nudge audit
- * trail). Downstream slices (engrams, embeddings, conversations,
- * glia_actions, plexus_adapters, plexus_filters) will add their tables
- * here as their service code lands.
+ * Currently exposes:
+ *   - `nudgeLog` — PRD-084 reflex/nudge audit trail.
+ *   - `engramIndex` / `engramScopes` / `engramTags` / `engramLinks` —
+ *     PRD-179 atomic memory units + their graph edges.
+ *
+ * Downstream slices (embeddings, conversations, glia_actions,
+ * plexus_adapters, plexus_filters) will add their tables here as their
+ * service code lands.
  */
-export { nudgeLog } from '@pops/db-types';
+export { engramIndex, engramLinks, engramScopes, engramTags, nudgeLog } from '@pops/db-types';

--- a/packages/cerebrum-db/src/schema.ts
+++ b/packages/cerebrum-db/src/schema.ts
@@ -13,9 +13,12 @@
  *   - `nudgeLog` — PRD-084 reflex/nudge audit trail.
  *   - `engramIndex` / `engramScopes` / `engramTags` / `engramLinks` —
  *     PRD-179 atomic memory units + their graph edges.
+ *   - `gliaActions` / `gliaTrustState` — PRD-181 autonomous-action
+ *     proposals + per-type trust graduation state (ADR-021 / PRD-086).
  *
- * Downstream slices (embeddings, conversations, glia_actions,
- * plexus_adapters, plexus_filters) will add their tables here as their
- * service code lands.
+ * Downstream slices (embeddings, conversations, plexus_adapters,
+ * plexus_filters) will add their tables here as their service code
+ * lands.
  */
 export { engramIndex, engramLinks, engramScopes, engramTags, nudgeLog } from '@pops/db-types';
+export { gliaActions, gliaTrustState } from '@pops/db-types/schema';

--- a/packages/cerebrum-db/src/services/engrams-helpers.ts
+++ b/packages/cerebrum-db/src/services/engrams-helpers.ts
@@ -1,0 +1,83 @@
+/**
+ * Pure helpers shared by the engrams data-access layer.
+ *
+ * Anything that touches the filesystem, parses Markdown, or evaluates
+ * scope rules stays in `apps/pops-api/src/modules/cerebrum/engrams/*`
+ * — this file is the SQL-projection seam only.
+ */
+import type { engramIndex } from '../schema.js';
+import type { Engram, EngramSource, EngramStatus, IndexRow } from './engrams-types.js';
+
+export function dedupe<T>(values: readonly T[]): T[] {
+  const seen = new Set<T>();
+  const out: T[] = [];
+  for (const v of values) {
+    if (seen.has(v)) continue;
+    seen.add(v);
+    out.push(v);
+  }
+  return out;
+}
+
+export function parseCustomFields(json: string | null): Record<string, unknown> {
+  if (!json) return {};
+  try {
+    return JSON.parse(json) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
+export function indexRowFromDrizzle(row: typeof engramIndex.$inferSelect): IndexRow {
+  return {
+    id: row.id,
+    filePath: row.filePath,
+    type: row.type,
+    source: row.source,
+    status: row.status,
+    template: row.template,
+    createdAt: row.createdAt,
+    modifiedAt: row.modifiedAt,
+    title: row.title,
+    contentHash: row.contentHash,
+    bodyHash: row.bodyHash ?? null,
+    wordCount: row.wordCount,
+    customFields: row.customFields,
+  };
+}
+
+/** Group `{ engramId, value }` rows into a map keyed by engramId. */
+export function bucket(rows: { engramId: string; value: string }[]): Map<string, string[]> {
+  const out = new Map<string, string[]>();
+  for (const row of rows) {
+    const existing = out.get(row.engramId);
+    if (existing) existing.push(row.value);
+    else out.set(row.engramId, [row.value]);
+  }
+  return out;
+}
+
+export function projectEngram(
+  row: IndexRow,
+  scopes: string[],
+  tags: string[],
+  links: string[]
+): Engram {
+  return {
+    id: row.id,
+    type: row.type,
+    scopes,
+    tags,
+    links,
+    created: row.createdAt,
+    modified: row.modifiedAt,
+    source: row.source as EngramSource,
+    status: row.status as EngramStatus,
+    template: row.template,
+    title: row.title,
+    filePath: row.filePath,
+    contentHash: row.contentHash,
+    wordCount: row.wordCount,
+    customFields: parseCustomFields(row.customFields),
+  };
+}

--- a/packages/cerebrum-db/src/services/engrams-list.ts
+++ b/packages/cerebrum-db/src/services/engrams-list.ts
@@ -1,0 +1,123 @@
+/**
+ * List + hydrate primitives for the engrams data-access layer.
+ *
+ * Split out from `engrams.ts` so each file stays under the 200-line
+ * project ceiling. Functional contract is identical to the listEngrams +
+ * hydrateEngrams pair pops-api exposes today.
+ */
+import { and, count, eq, inArray, like, sql } from 'drizzle-orm';
+
+import { engramIndex, engramLinks, engramScopes, engramTags } from '../schema.js';
+import { bucket, indexRowFromDrizzle, projectEngram } from './engrams-helpers.js';
+
+import type { Engram, IndexRow, ListEngramsOptions, ListEngramsResult } from './engrams-types.js';
+import type { CerebrumDb } from './internal.js';
+
+function buildConditions(
+  db: CerebrumDb,
+  opts: ListEngramsOptions
+): ReturnType<typeof and> | undefined {
+  const conditions = [];
+  if (opts.type) conditions.push(eq(engramIndex.type, opts.type));
+  if (opts.status) conditions.push(eq(engramIndex.status, opts.status));
+  if (opts.search) conditions.push(like(engramIndex.title, `%${opts.search}%`));
+  if (opts.scopes && opts.scopes.length > 0) {
+    conditions.push(
+      inArray(
+        engramIndex.id,
+        db
+          .select({ engramId: engramScopes.engramId })
+          .from(engramScopes)
+          .where(inArray(engramScopes.scope, opts.scopes))
+      )
+    );
+  }
+  if (opts.tags && opts.tags.length > 0) {
+    conditions.push(
+      inArray(
+        engramIndex.id,
+        db
+          .select({ engramId: engramTags.engramId })
+          .from(engramTags)
+          .where(inArray(engramTags.tag, opts.tags))
+      )
+    );
+  }
+  if (opts.ids && opts.ids.length > 0) {
+    conditions.push(inArray(engramIndex.id, opts.ids));
+  }
+  return conditions.length === 0 ? undefined : and(...conditions);
+}
+
+function resolveOrderColumn(
+  field: NonNullable<ListEngramsOptions['sort']>['field']
+): typeof engramIndex.title | typeof engramIndex.createdAt | typeof engramIndex.modifiedAt {
+  if (field === 'title') return engramIndex.title;
+  if (field === 'created_at') return engramIndex.createdAt;
+  return engramIndex.modifiedAt;
+}
+
+function resolveLimit(opts: ListEngramsOptions): number {
+  if (opts.ids && opts.limit === undefined) return opts.ids.length;
+  return opts.limit ?? 50;
+}
+
+export function listEngrams(db: CerebrumDb, opts: ListEngramsOptions = {}): ListEngramsResult {
+  const where = buildConditions(db, opts);
+  const sortField = opts.sort?.field ?? 'modified_at';
+  const sortDir = opts.sort?.direction ?? 'desc';
+  const orderColumn = resolveOrderColumn(sortField);
+  const limit = resolveLimit(opts);
+  const offset = opts.offset ?? 0;
+
+  const rowsQuery = db.select().from(engramIndex).$dynamic();
+  const rows = (where ? rowsQuery.where(where) : rowsQuery)
+    .orderBy(sortDir === 'asc' ? orderColumn : sql`${orderColumn} desc`)
+    .limit(limit)
+    .offset(offset)
+    .all();
+
+  const totalQuery = db.select({ total: count() }).from(engramIndex).$dynamic();
+  const [totalRow] = (where ? totalQuery.where(where) : totalQuery).all();
+
+  return {
+    engrams: hydrateEngrams(db, rows.map(indexRowFromDrizzle)),
+    total: totalRow?.total ?? 0,
+  };
+}
+
+export function hydrateEngrams(db: CerebrumDb, rows: IndexRow[]): Engram[] {
+  if (rows.length === 0) return [];
+  const ids = rows.map((r) => r.id);
+
+  const scopesByEngram = bucket(
+    db
+      .select({ engramId: engramScopes.engramId, value: engramScopes.scope })
+      .from(engramScopes)
+      .where(inArray(engramScopes.engramId, ids))
+      .all()
+  );
+  const tagsByEngram = bucket(
+    db
+      .select({ engramId: engramTags.engramId, value: engramTags.tag })
+      .from(engramTags)
+      .where(inArray(engramTags.engramId, ids))
+      .all()
+  );
+  const linksByEngram = bucket(
+    db
+      .select({ engramId: engramLinks.sourceId, value: engramLinks.targetId })
+      .from(engramLinks)
+      .where(inArray(engramLinks.sourceId, ids))
+      .all()
+  );
+
+  return rows.map((row) =>
+    projectEngram(
+      row,
+      scopesByEngram.get(row.id) ?? [],
+      tagsByEngram.get(row.id) ?? [],
+      linksByEngram.get(row.id) ?? []
+    )
+  );
+}

--- a/packages/cerebrum-db/src/services/engrams-types.ts
+++ b/packages/cerebrum-db/src/services/engrams-types.ts
@@ -1,0 +1,117 @@
+/**
+ * Engram public shapes returned from the data-access layer.
+ *
+ * Source of truth for an engram's full document form remains the
+ * Markdown file on disk; this package owns only the index projection.
+ * Keeping these types in the data package lets `cerebrum-api` (and any
+ * other consumer) build views without re-deriving them from drizzle row
+ * shapes.
+ */
+
+/** Frontmatter source — accepts the fixed channels plus `plexus:{name}`. */
+export type EngramSource = 'manual' | 'agent' | 'moltbot' | 'cli' | `plexus:${string}`;
+
+/** Lifecycle status from frontmatter. */
+export type EngramStatus = 'active' | 'archived' | 'consolidated' | 'stale';
+
+/**
+ * An engram summary — all the index columns plus the materialised
+ * scopes/tags/links. Equivalent to one `engram_index` row joined with its
+ * many-to-many auxiliaries.
+ */
+export interface Engram {
+  id: string;
+  type: string;
+  scopes: string[];
+  tags: string[];
+  links: string[];
+  created: string;
+  modified: string;
+  source: EngramSource;
+  status: EngramStatus;
+  template: string | null;
+  title: string;
+  filePath: string;
+  contentHash: string;
+  wordCount: number;
+  customFields: Record<string, unknown>;
+}
+
+/**
+ * The minimal subset of `engram_index` that detector-style scans need.
+ * Returned by `loadActiveEngrams` — non-archived, non-consolidated rows
+ * with their scopes and tags hydrated. Body is intentionally omitted; if
+ * a consumer needs the body it should read the file via `filePath` from
+ * a full `Engram` instead.
+ */
+export interface EngramSummary {
+  id: string;
+  type: string;
+  title: string;
+  status: string;
+  scopes: string[];
+  tags: string[];
+  createdAt: string;
+  modifiedAt: string;
+}
+
+export interface IndexRow {
+  id: string;
+  filePath: string;
+  type: string;
+  source: string;
+  status: string;
+  template: string | null;
+  createdAt: string;
+  modifiedAt: string;
+  title: string;
+  contentHash: string;
+  bodyHash: string | null;
+  wordCount: number;
+  customFields: string | null;
+}
+
+export interface ListEngramsOptions {
+  type?: string;
+  scopes?: string[];
+  tags?: string[];
+  ids?: string[];
+  status?: EngramStatus;
+  search?: string;
+  limit?: number;
+  offset?: number;
+  sort?: {
+    field: 'created_at' | 'modified_at' | 'title';
+    direction: 'asc' | 'desc';
+  };
+}
+
+export interface ListEngramsResult {
+  engrams: Engram[];
+  total: number;
+}
+
+/**
+ * Inputs for `upsertEngramIndex` — the index row plus the scopes/tags/
+ * links arrays the indexer derived from frontmatter. The caller is
+ * expected to have already serialised any customFields they want stored
+ * on the row.
+ */
+export interface UpsertEngramArgs {
+  id: string;
+  filePath: string;
+  type: string;
+  source: EngramSource;
+  status: EngramStatus;
+  template: string | null;
+  createdAt: string;
+  modifiedAt: string;
+  title: string;
+  contentHash: string;
+  bodyHash: string | null;
+  wordCount: number;
+  customFields: Record<string, unknown>;
+  scopes: readonly string[];
+  tags: readonly string[];
+  links: readonly string[];
+}

--- a/packages/cerebrum-db/src/services/engrams.ts
+++ b/packages/cerebrum-db/src/services/engrams.ts
@@ -1,0 +1,189 @@
+/**
+ * Engram data-access for the cerebrum pillar (PRD-179 US-01).
+ *
+ * Scope boundary: this file is the SQL seam for the engrams slice. It
+ * covers find / upsert / delete on `engram_index` and its three
+ * many-to-many auxiliaries (`engram_scopes`, `engram_tags`,
+ * `engram_links`), plus link insert/delete edges and the cross-table
+ * detector helper `loadActiveEngrams`. The list/hydrate pair lives in
+ * `engrams-list.ts` (kept separate to stay under the per-file line
+ * ceiling). Anything that touches the filesystem (parsing Markdown,
+ * writing files atomically, renaming on type change), the template
+ * registry, or the scope-rule engine stays in
+ * `apps/pops-api/src/modules/cerebrum/engrams/*` until PRD-179 US-03
+ * flips routing through `getCerebrumDrizzle()`. That keeps this package
+ * pure data-access — no node:fs imports, no zod cross-validation, no
+ * domain orchestration.
+ *
+ * The functions take a `CerebrumDb` handle as their first argument; the
+ * calling layer (pops-api today, `cerebrum-api` after the cutover)
+ * resolves the singleton or transaction handle. Mirrors the `nudge-log.ts`
+ * db-arg pattern in this package.
+ */
+import { eq, inArray, sql } from 'drizzle-orm';
+
+import { engramIndex, engramLinks, engramScopes, engramTags } from '../schema.js';
+import { bucket, dedupe, indexRowFromDrizzle, parseCustomFields } from './engrams-helpers.js';
+import { hydrateEngrams, listEngrams } from './engrams-list.js';
+
+import type { Engram, EngramSummary, IndexRow, UpsertEngramArgs } from './engrams-types.js';
+import type { CerebrumDb } from './internal.js';
+
+export { hydrateEngrams, listEngrams };
+export { parseCustomFields };
+
+export function findIndexRow(db: CerebrumDb, id: string): IndexRow | null {
+  const [row] = db.select().from(engramIndex).where(eq(engramIndex.id, id)).all();
+  return row ? indexRowFromDrizzle(row) : null;
+}
+
+export function existsEngram(db: CerebrumDb, id: string): boolean {
+  return findIndexRow(db, id) !== null;
+}
+
+/**
+ * Replace the `engram_index` row and re-seed its scopes/tags/links from
+ * the supplied arrays. Runs in a single transaction so a concurrent reader
+ * never observes a half-replaced row + stale auxiliaries.
+ *
+ * The cascade on `engram_index.id` handles the auxiliary deletes; we then
+ * re-insert the deduplicated new sets. Caller is expected to have already
+ * normalised `customFields` to the JSON-storable shape.
+ */
+export function upsertEngramIndex(db: CerebrumDb, args: UpsertEngramArgs): void {
+  const customFieldsBlob =
+    Object.keys(args.customFields).length > 0 ? JSON.stringify(args.customFields) : null;
+
+  db.transaction((tx) => {
+    tx.delete(engramIndex).where(eq(engramIndex.id, args.id)).run();
+    tx.insert(engramIndex)
+      .values({
+        id: args.id,
+        filePath: args.filePath,
+        type: args.type,
+        source: args.source,
+        status: args.status,
+        template: args.template,
+        createdAt: args.createdAt,
+        modifiedAt: args.modifiedAt,
+        title: args.title,
+        contentHash: args.contentHash,
+        bodyHash: args.bodyHash,
+        wordCount: args.wordCount,
+        customFields: customFieldsBlob,
+      })
+      .run();
+
+    const scopes = dedupe(args.scopes);
+    if (scopes.length > 0) {
+      tx.insert(engramScopes)
+        .values(scopes.map((scope) => ({ engramId: args.id, scope })))
+        .run();
+    }
+    const tags = dedupe(args.tags);
+    if (tags.length > 0) {
+      tx.insert(engramTags)
+        .values(tags.map((tag) => ({ engramId: args.id, tag })))
+        .run();
+    }
+    const links = dedupe(args.links);
+    if (links.length > 0) {
+      tx.insert(engramLinks)
+        .values(links.map((targetId) => ({ sourceId: args.id, targetId })))
+        .run();
+    }
+  });
+}
+
+/**
+ * Hard-delete an `engram_index` row. The FK cascades wipe scopes, tags,
+ * and outbound links. Inbound `engram_links` rows (other engrams that
+ * reference this id as their target) are NOT cascaded — those carry no
+ * FK by design (frontmatter may reference a target that has not been
+ * indexed yet), so we sweep them explicitly here.
+ *
+ * Returns the number of `engram_index` rows actually deleted (0 if `id`
+ * was already gone — caller can treat this as an idempotent op).
+ */
+export function deleteEngramIndex(db: CerebrumDb, id: string): number {
+  return db.transaction((tx) => {
+    const result = tx.delete(engramIndex).where(eq(engramIndex.id, id)).run();
+    tx.delete(engramLinks).where(eq(engramLinks.targetId, id)).run();
+    return result.changes;
+  });
+}
+
+/**
+ * Look up an engram by id and hydrate it. Returns null if the row is gone
+ * — leaving the not-found policy (throw vs return) to the caller so this
+ * package stays decoupled from pops-api's error types.
+ */
+export function getEngram(db: CerebrumDb, id: string): Engram | null {
+  const row = findIndexRow(db, id);
+  if (!row) return null;
+  const [hydrated] = hydrateEngrams(db, [row]);
+  return hydrated ?? null;
+}
+
+/**
+ * Insert a single (sourceId, targetId) edge. Idempotent via
+ * `onConflictDoNothing` against the `uq_engram_links_pair` unique index.
+ * Reverse-edge bookkeeping (insert (targetId, sourceId) too) and any
+ * frontmatter file mutation are the caller's responsibility — they live
+ * in pops-api until US-03.
+ */
+export function insertEngramLink(db: CerebrumDb, sourceId: string, targetId: string): void {
+  db.insert(engramLinks).values({ sourceId, targetId }).onConflictDoNothing().run();
+}
+
+/** Delete every (a, b) and (b, a) pair between the two engrams. */
+export function deleteEngramLinkPair(db: CerebrumDb, a: string, b: string): void {
+  db.delete(engramLinks)
+    .where(
+      sql`(${engramLinks.sourceId} = ${a} AND ${engramLinks.targetId} = ${b}) OR (${engramLinks.sourceId} = ${b} AND ${engramLinks.targetId} = ${a})`
+    )
+    .run();
+}
+
+/**
+ * Active engrams snapshot for detector-style scans (PRD-084 nudges, glia
+ * workers, etc.). Filters out archived/consolidated rows server-side and
+ * hydrates scopes + tags in two range queries — same shape pops-api's
+ * `loadActiveEngrams` returns today, ported here so consumers can resolve
+ * it against `getCerebrumDrizzle()` without a cross-package read helper.
+ */
+export function loadActiveEngrams(db: CerebrumDb): EngramSummary[] {
+  const rows = db
+    .select()
+    .from(engramIndex)
+    .where(sql`${engramIndex.status} NOT IN ('archived', 'consolidated')`)
+    .all();
+  if (rows.length === 0) return [];
+
+  const ids = rows.map((r) => r.id);
+  const scopeMap = bucket(
+    db
+      .select({ engramId: engramScopes.engramId, value: engramScopes.scope })
+      .from(engramScopes)
+      .where(inArray(engramScopes.engramId, ids))
+      .all()
+  );
+  const tagMap = bucket(
+    db
+      .select({ engramId: engramTags.engramId, value: engramTags.tag })
+      .from(engramTags)
+      .where(inArray(engramTags.engramId, ids))
+      .all()
+  );
+
+  return rows.map((r) => ({
+    id: r.id,
+    type: r.type,
+    title: r.title,
+    status: r.status,
+    scopes: scopeMap.get(r.id) ?? [],
+    tags: tagMap.get(r.id) ?? [],
+    createdAt: r.createdAt,
+    modifiedAt: r.modifiedAt,
+  }));
+}

--- a/packages/cerebrum-db/src/services/glia-helpers.ts
+++ b/packages/cerebrum-db/src/services/glia-helpers.ts
@@ -1,0 +1,49 @@
+/**
+ * Glia row serialisation helpers.
+ *
+ * Extracted so the SQL seam in `glia.ts` stays focused on queries and so
+ * tests can exercise the deserialisation logic in isolation.
+ */
+import type { gliaActions, gliaTrustState } from '../schema.js';
+import type {
+  ActionStatus,
+  ActionType,
+  GliaAction,
+  GliaTrustState,
+  TrustPhase,
+  UserDecision,
+} from './glia-types.js';
+
+/** Deserialise a row from `glia_actions` into a `GliaAction`. */
+export function rowToGliaAction(row: typeof gliaActions.$inferSelect): GliaAction {
+  return {
+    id: row.id,
+    actionType: row.actionType as ActionType,
+    affectedIds: JSON.parse(row.affectedIds) as string[],
+    rationale: row.rationale,
+    payload: row.payload != null ? (JSON.parse(row.payload) as unknown) : null,
+    phase: row.phase as TrustPhase,
+    status: row.status as ActionStatus,
+    userDecision: row.userDecision as UserDecision | null,
+    userNote: row.userNote,
+    executedAt: row.executedAt,
+    decidedAt: row.decidedAt,
+    revertedAt: row.revertedAt,
+    createdAt: row.createdAt,
+  };
+}
+
+/** Deserialise a row from `glia_trust_state` into a `GliaTrustState`. */
+export function rowToGliaTrustState(row: typeof gliaTrustState.$inferSelect): GliaTrustState {
+  return {
+    actionType: row.actionType as ActionType,
+    currentPhase: row.currentPhase as TrustPhase,
+    approvedCount: row.approvedCount,
+    rejectedCount: row.rejectedCount,
+    revertedCount: row.revertedCount,
+    autonomousSince: row.autonomousSince,
+    lastRevertAt: row.lastRevertAt,
+    graduatedAt: row.graduatedAt,
+    updatedAt: row.updatedAt,
+  };
+}

--- a/packages/cerebrum-db/src/services/glia-types.ts
+++ b/packages/cerebrum-db/src/services/glia-types.ts
@@ -1,0 +1,121 @@
+/**
+ * Glia public shapes returned from the data-access layer.
+ *
+ * Mirrors the action / trust-state shapes the pops-api `GliaActionService`
+ * exposes today. Kept in the data package so `cerebrum-api` and any other
+ * consumer can build views without re-deriving them from drizzle row
+ * shapes.
+ */
+
+/** The four Glia action types (ADR-021). */
+export const ACTION_TYPES = ['prune', 'consolidate', 'link', 'audit'] as const;
+export type ActionType = (typeof ACTION_TYPES)[number];
+
+/** Trust phases in graduation order (ADR-021). */
+export const TRUST_PHASES = ['propose', 'act_report', 'silent'] as const;
+export type TrustPhase = (typeof TRUST_PHASES)[number];
+
+/** Action lifecycle statuses. */
+export const ACTION_STATUSES = ['pending', 'approved', 'rejected', 'executed', 'reverted'] as const;
+export type ActionStatus = (typeof ACTION_STATUSES)[number];
+
+/** User decisions on a pending proposal. */
+export const USER_DECISIONS = ['approve', 'reject', 'modify'] as const;
+export type UserDecision = (typeof USER_DECISIONS)[number];
+
+/** A Glia action record — one row from `glia_actions` deserialised. */
+export interface GliaAction {
+  id: string;
+  actionType: ActionType;
+  affectedIds: string[];
+  rationale: string;
+  payload: unknown | null;
+  phase: TrustPhase;
+  status: ActionStatus;
+  userDecision: UserDecision | null;
+  userNote: string | null;
+  executedAt: string | null;
+  decidedAt: string | null;
+  revertedAt: string | null;
+  createdAt: string;
+}
+
+/** Trust state for a single action type — one row from `glia_trust_state`. */
+export interface GliaTrustState {
+  actionType: ActionType;
+  currentPhase: TrustPhase;
+  approvedCount: number;
+  rejectedCount: number;
+  revertedCount: number;
+  autonomousSince: string | null;
+  lastRevertAt: string | null;
+  graduatedAt: string | null;
+  updatedAt: string;
+}
+
+/** Filters for `listActions`. */
+export interface ActionListFilters {
+  actionType?: ActionType;
+  status?: ActionStatus;
+  dateFrom?: string;
+  dateTo?: string;
+  limit?: number;
+  offset?: number;
+}
+
+/** Result envelope from `listActions` — kept symmetrical with `nudge-log`. */
+export interface ListActionsResult {
+  actions: GliaAction[];
+  total: number;
+}
+
+/**
+ * Insert payload for `insertAction` — the data-access layer's contract for
+ * creating a new glia_actions row. The caller (pops-api today, cerebrum-api
+ * after the cutover) is responsible for ID generation, phase resolution,
+ * autonomous-vs-pending status branching, and any trust-state updates. This
+ * keeps the service decoupled from the trust machine.
+ */
+export interface InsertActionRow {
+  id: string;
+  actionType: ActionType;
+  affectedIds: readonly string[];
+  rationale: string;
+  payload: unknown | null;
+  phase: TrustPhase;
+  status: ActionStatus;
+  executedAt: string | null;
+  createdAt: string;
+}
+
+/** Patch payload for `updateAction` — only the lifecycle-mutable columns. */
+export interface UpdateActionPatch {
+  status?: ActionStatus;
+  userDecision?: UserDecision | null;
+  userNote?: string | null;
+  executedAt?: string | null;
+  decidedAt?: string | null;
+  revertedAt?: string | null;
+}
+
+/** Seed payload for `seedTrustState` — used to bootstrap a missing row. */
+export interface SeedTrustStateRow {
+  actionType: ActionType;
+  currentPhase: TrustPhase;
+  approvedCount: number;
+  rejectedCount: number;
+  revertedCount: number;
+  updatedAt: string;
+}
+
+/** Patch payload for `updateTrustState` — every field optional. */
+export interface UpdateTrustStatePatch {
+  currentPhase?: TrustPhase;
+  approvedCount?: number;
+  rejectedCount?: number;
+  revertedCount?: number;
+  autonomousSince?: string | null;
+  lastRevertAt?: string | null;
+  graduatedAt?: string | null;
+  updatedAt: string;
+}

--- a/packages/cerebrum-db/src/services/glia.ts
+++ b/packages/cerebrum-db/src/services/glia.ts
@@ -1,0 +1,300 @@
+/**
+ * Glia data-access for the cerebrum pillar (PRD-181 US-01).
+ *
+ * Scope boundary: this file is the SQL seam for the glia slice. It covers
+ * CRUD on `glia_actions` plus seed / read / update on `glia_trust_state`
+ * and a handful of window/count helpers the digest + trust machine in
+ * pops-api depend on. The trust-graduation orchestration (phase
+ * transitions, demotion windows, threshold reads from
+ * `engrams/.config/glia.toml` + settings DB), the in-process dispatch
+ * (`GliaActionService.executeAction` callbacks, cross-pillar SDK writes),
+ * the scheduled digest renderer and channel filesystem layout stay in
+ * `apps/pops-api/src/modules/cerebrum/glia/*` until PRD-181 US-03 flips
+ * routing through `getCerebrumDrizzle()`. That keeps this package pure
+ * data-access — no node:fs imports, no zod, no domain orchestration.
+ *
+ * The functions take a `CerebrumDb` handle as their first argument; the
+ * calling layer (pops-api today, `cerebrum-api` after the cutover)
+ * resolves the singleton or transaction handle. Mirrors the
+ * `nudge-log.ts` / `engrams.ts` db-arg pattern in this package.
+ */
+import { and, asc, count, desc, eq, gte, isNotNull, isNull, lt, lte, sql } from 'drizzle-orm';
+
+import { gliaActions, gliaTrustState } from '../schema.js';
+import { rowToGliaAction, rowToGliaTrustState } from './glia-helpers.js';
+
+import type {
+  ActionListFilters,
+  ActionType,
+  GliaAction,
+  GliaTrustState,
+  InsertActionRow,
+  ListActionsResult,
+  SeedTrustStateRow,
+  UpdateActionPatch,
+  UpdateTrustStatePatch,
+} from './glia-types.js';
+import type { CerebrumDb } from './internal.js';
+
+export { rowToGliaAction, rowToGliaTrustState };
+
+/** Fetch a single action by id. Returns null when missing. */
+export function getAction(db: CerebrumDb, id: string): GliaAction | null {
+  const row = db.select().from(gliaActions).where(eq(gliaActions.id, id)).get();
+  return row ? rowToGliaAction(row) : null;
+}
+
+/**
+ * Paginated list of actions matching the supplied filters. Orders by
+ * `created_at desc` so the most recent proposals surface first. Returns
+ * both the rows and the unpaginated `total` so the caller can drive a
+ * paging UI without a second round-trip.
+ */
+export function listActions(db: CerebrumDb, filters: ActionListFilters = {}): ListActionsResult {
+  const conditions = [];
+  if (filters.actionType) conditions.push(eq(gliaActions.actionType, filters.actionType));
+  if (filters.status) conditions.push(eq(gliaActions.status, filters.status));
+  if (filters.dateFrom) conditions.push(gte(gliaActions.createdAt, filters.dateFrom));
+  if (filters.dateTo) conditions.push(lte(gliaActions.createdAt, filters.dateTo));
+
+  const where = conditions.length > 0 ? and(...conditions) : undefined;
+  const limit = filters.limit ?? 50;
+  const offset = filters.offset ?? 0;
+
+  const rows = db
+    .select()
+    .from(gliaActions)
+    .where(where)
+    .orderBy(desc(gliaActions.createdAt))
+    .limit(limit)
+    .offset(offset)
+    .all();
+
+  const [totalRow] = db.select({ total: count() }).from(gliaActions).where(where).all();
+
+  return {
+    actions: rows.map(rowToGliaAction),
+    total: totalRow?.total ?? 0,
+  };
+}
+
+/**
+ * Insert a fully-formed `glia_actions` row. The caller is expected to have
+ * generated the id and resolved phase/status/executedAt according to the
+ * trust machine's rules; this function only serialises and writes.
+ */
+export function insertAction(db: CerebrumDb, row: InsertActionRow): GliaAction {
+  const values = {
+    id: row.id,
+    actionType: row.actionType,
+    affectedIds: JSON.stringify([...row.affectedIds]),
+    rationale: row.rationale,
+    payload: row.payload != null ? JSON.stringify(row.payload) : null,
+    phase: row.phase,
+    status: row.status,
+    userDecision: null,
+    userNote: null,
+    executedAt: row.executedAt,
+    decidedAt: null,
+    revertedAt: null,
+    createdAt: row.createdAt,
+  };
+  db.insert(gliaActions).values(values).run();
+  return rowToGliaAction(values);
+}
+
+/**
+ * Apply a lifecycle patch to an action. Returns the resulting row or null
+ * if the action no longer exists. The patch shape is intentionally narrow:
+ * only columns that mutate over an action's lifecycle (status + the four
+ * timestamp/decision columns) can be set. Identity columns and the
+ * payload are immutable post-insert.
+ */
+export function updateAction(
+  db: CerebrumDb,
+  id: string,
+  patch: UpdateActionPatch
+): GliaAction | null {
+  if (Object.keys(patch).length === 0) return getAction(db, id);
+  db.update(gliaActions).set(patch).where(eq(gliaActions.id, id)).run();
+  return getAction(db, id);
+}
+
+/**
+ * Hard-delete an action row. Returns the number of rows actually deleted
+ * (0 if `id` was already gone — caller can treat this as idempotent).
+ * Trust-state counters are intentionally NOT decremented; counters track
+ * lifetime decisions, not active rows, and reverts are modelled via
+ * status transitions rather than deletions.
+ */
+export function deleteAction(db: CerebrumDb, id: string): number {
+  return db.delete(gliaActions).where(eq(gliaActions.id, id)).run().changes;
+}
+
+/**
+ * Autonomous actions executed in `[startDate, endDate)`. Filters out rows
+ * with a user decision so only worker-executed actions surface in the
+ * digest. Window is matched against `executed_at` because `created_at`
+ * could be earlier than execution for delayed worker runs; the end bound
+ * is exclusive so a row pinned on the boundary can't appear in two
+ * consecutive digests.
+ */
+export function listAutonomousActionsInWindow(
+  db: CerebrumDb,
+  startDate: string,
+  endDate: string
+): GliaAction[] {
+  const rows = db
+    .select()
+    .from(gliaActions)
+    .where(
+      and(
+        eq(gliaActions.status, 'executed'),
+        isNull(gliaActions.decidedAt),
+        gte(gliaActions.executedAt, startDate),
+        lt(gliaActions.executedAt, endDate)
+      )
+    )
+    .orderBy(asc(gliaActions.executedAt))
+    .all();
+  return rows.map(rowToGliaAction);
+}
+
+/**
+ * Count autonomous actions still in `executed` status for an action type
+ * since `sinceIso`. Excludes reverted rows so the digest can compute the
+ * rejection rate as `reverted / (executed + reverted)` without
+ * double-counting actions that have already been rolled back.
+ */
+export function countAutonomousExecutionsSince(
+  db: CerebrumDb,
+  actionType: ActionType,
+  sinceIso: string
+): number {
+  const row = db
+    .select({ total: count() })
+    .from(gliaActions)
+    .where(
+      and(
+        eq(gliaActions.actionType, actionType),
+        eq(gliaActions.status, 'executed'),
+        isNull(gliaActions.decidedAt),
+        gte(gliaActions.executedAt, sinceIso)
+      )
+    )
+    .get();
+  return row?.total ?? 0;
+}
+
+/**
+ * Count autonomous reverts for an action type since `sinceIso`. The
+ * `isNotNull(revertedAt)` guard makes intent explicit: a row with
+ * `status='reverted'` but null `reverted_at` is excluded by design rather
+ * than by SQL accident.
+ */
+export function countAutonomousRevertsSince(
+  db: CerebrumDb,
+  actionType: ActionType,
+  sinceIso: string
+): number {
+  const row = db
+    .select({ total: count() })
+    .from(gliaActions)
+    .where(
+      and(
+        eq(gliaActions.actionType, actionType),
+        eq(gliaActions.status, 'reverted'),
+        isNull(gliaActions.decidedAt),
+        isNotNull(gliaActions.revertedAt),
+        gte(gliaActions.revertedAt, sinceIso)
+      )
+    )
+    .get();
+  return row?.total ?? 0;
+}
+
+/**
+ * Count reverts within a rolling window for an action type. Used by the
+ * trust machine's demotion check (2+ reverts in 7 days → demote).
+ */
+export function countRevertsInWindow(
+  db: CerebrumDb,
+  actionType: ActionType,
+  windowStart: string
+): number {
+  const row = db
+    .select({ total: count() })
+    .from(gliaActions)
+    .where(
+      and(
+        eq(gliaActions.actionType, actionType),
+        eq(gliaActions.status, 'reverted'),
+        gte(gliaActions.revertedAt, windowStart)
+      )
+    )
+    .get();
+  return row?.total ?? 0;
+}
+
+/**
+ * Fetch trust state for a single action type. Returns null when the row
+ * has not been seeded yet — the caller (pops-api today) decides whether
+ * to surface that as an error or to seed lazily.
+ */
+export function getTrustState(db: CerebrumDb, actionType: ActionType): GliaTrustState | null {
+  const row = db
+    .select()
+    .from(gliaTrustState)
+    .where(eq(gliaTrustState.actionType, actionType))
+    .get();
+  return row ? rowToGliaTrustState(row) : null;
+}
+
+/** List every seeded trust-state row. */
+export function listTrustStates(db: CerebrumDb): GliaTrustState[] {
+  return db.select().from(gliaTrustState).all().map(rowToGliaTrustState);
+}
+
+/**
+ * Seed a trust-state row idempotently. Re-seeding an existing row is a
+ * no-op (via `onConflictDoNothing`) so callers can call this on every
+ * boot without clobbering counters that have already drifted from zero.
+ */
+export function seedTrustState(db: CerebrumDb, row: SeedTrustStateRow): void {
+  db.insert(gliaTrustState).values(row).onConflictDoNothing().run();
+}
+
+/**
+ * Apply a patch to a trust-state row. Returns the resulting row or null if
+ * the action type has not been seeded. `updatedAt` is required on the
+ * patch so the caller is forced to think about which clock to use; the
+ * service intentionally does not call `new Date()` itself.
+ */
+export function updateTrustState(
+  db: CerebrumDb,
+  actionType: ActionType,
+  patch: UpdateTrustStatePatch
+): GliaTrustState | null {
+  db.update(gliaTrustState).set(patch).where(eq(gliaTrustState.actionType, actionType)).run();
+  return getTrustState(db, actionType);
+}
+
+/**
+ * Increment one of the trust-state counters atomically and bump
+ * `updatedAt`. Used by the decide/revert paths in pops-api where the
+ * counter delta and the corresponding action update need to land in the
+ * same logical write. The caller wraps both writes in a single
+ * transaction.
+ */
+export function incrementTrustStateCounter(
+  db: CerebrumDb,
+  actionType: ActionType,
+  counter: 'approvedCount' | 'rejectedCount' | 'revertedCount',
+  updatedAt: string
+): void {
+  const column = gliaTrustState[counter];
+  db.update(gliaTrustState)
+    .set({ [counter]: sql`${column} + 1`, updatedAt })
+    .where(eq(gliaTrustState.actionType, actionType))
+    .run();
+}

--- a/packages/cerebrum-db/src/vec-loader.ts
+++ b/packages/cerebrum-db/src/vec-loader.ts
@@ -1,0 +1,81 @@
+/**
+ * sqlite-vec extension loader for the cerebrum pillar database.
+ *
+ * Mirrors the pops-api singleton loader (`apps/pops-api/src/db/vec-loader.ts`)
+ * but keeps its own module-level `vecAvailable` flag so the cerebrum
+ * handle can be loaded independently of the legacy shared handle. The
+ * extension binary itself is loaded once per process by `sqlite-vec`;
+ * calling `load` on multiple connections is safe.
+ *
+ * Why this lives in `@pops/cerebrum-db`: the `embeddings_vec` virtual
+ * table is cerebrum-owned, and once PRD-179 US-03 routes search through
+ * `getCerebrumDrizzle()` the only consumer of `vec_*` SQL is in this
+ * pillar. Keeping the loader colocated with `openCerebrumDb` removes the
+ * cross-package import that the M5 nudge slice avoided by not needing
+ * the extension.
+ */
+import * as sqliteVec from 'sqlite-vec';
+
+import type BetterSqlite3 from 'better-sqlite3';
+
+let vecAvailable = false;
+
+export function isVecAvailable(): boolean {
+  return vecAvailable;
+}
+
+export interface VecLoaderLogger {
+  info?: (payload: unknown, msg: string) => void;
+  warn?: (payload: unknown, msg: string) => void;
+}
+
+/**
+ * Try to load the sqlite-vec extension into `raw`. Returns `true` on
+ * success, `false` if the extension can't be loaded (binary missing,
+ * platform unsupported, etc.). Failures are non-fatal — callers that
+ * need vector search should branch on the return value or surface a
+ * domain-level error; non-vector consumers (engram CRUD, scopes, tags,
+ * links) all work without it.
+ *
+ * Does not throw. Logs at most one warning per process via the optional
+ * logger argument.
+ */
+export function tryLoadVecExtension(
+  raw: BetterSqlite3.Database,
+  logger?: VecLoaderLogger
+): boolean {
+  try {
+    sqliteVec.load(raw);
+    if (!vecAvailable) {
+      const version = raw.prepare('SELECT vec_version()').pluck().get() as string;
+      logger?.info?.({ version }, '[cerebrum-db] sqlite-vec loaded');
+      vecAvailable = true;
+    }
+    return true;
+  } catch (err) {
+    if (!vecAvailable) {
+      logger?.warn?.(
+        { err: (err as Error).message },
+        '[cerebrum-db] sqlite-vec failed to load — vector features disabled'
+      );
+    }
+    return false;
+  }
+}
+
+/**
+ * Idempotent creation of the `embeddings_vec` virtual table. Skipped
+ * with a swallowed error when sqlite-vec hasn't been loaded — that path
+ * is the right one for unit tests and any cerebrum-owned consumer that
+ * doesn't need vector search. The dimension is fixed at 1536
+ * (text-embedding-3-small) to match the shared baseline; changing it
+ * requires a full re-embed.
+ */
+export function ensureEmbeddingsVecTable(raw: BetterSqlite3.Database): boolean {
+  try {
+    raw.exec(`CREATE VIRTUAL TABLE IF NOT EXISTS embeddings_vec USING vec0(vector float[1536])`);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1728,6 +1728,9 @@ importers:
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.10.0)
+      sqlite-vec:
+        specifier: ^0.1.7
+        version: 0.1.9
     devDependencies:
       '@types/better-sqlite3':
         specifier: ^7.6.12


### PR DESCRIPTION
## Summary

PR 1 of [PRD-179: cerebrum.engrams cutover](docs/themes/13-pillar-finale/prds/179-cerebrum-engrams-cutover/README.md). Stands up the engrams data layer on `@pops/cerebrum-db` — schemas, baseline migration, sqlite-vec wiring, backfill, services. Purely additive — pops-api still writes and reads through `getDrizzle()`, no router or consumer changes. US-03 flips routing through `getCerebrumDrizzle()`.

## What changed

### `@pops/cerebrum-db`
- **Schema** — re-exports `engramIndex` / `engramScopes` / `engramTags` / `engramLinks` alongside the existing `nudgeLog` (canonical defs stay in `@pops/db-types`).
- **Baseline migration** — `migrations/0050_engrams_baseline.sql` copies the shared `engram_index` + scopes + tags + links definitions column-for-column (post body_hash patches) so a fresh `cerebrum.db` matches the shared shape byte-for-byte.
- **sqlite-vec wiring** — new `vec-loader.ts` mirrors pops-api's loader pattern. `openCerebrumDb` now loads sqlite-vec before applying migrations and creates the `embeddings_vec` virtual table imperatively after the extension loads (kept out of the drizzle journal because virtual tables aren't representable in the schema builder). New `OpenCerebrumDbOptions.loadVec` lets tests opt out; result reports `vecAvailable`.
- **`engramsService`** — data-access only: `findIndexRow`, `existsEngram`, `getEngram`, `listEngrams`, `hydrateEngrams`, `upsertEngramIndex`, `deleteEngramIndex`, `insertEngramLink`, `deleteEngramLinkPair`, `loadActiveEngrams`. Filesystem + template + scope-rule integrations stay in pops-api until US-03.
- **Barrel** — adds `engramsService` namespace, vec loader helpers, and `Engram` / `EngramSource` / `EngramStatus` / `EngramSummary` / `EngramIndexRow` / `ListEngramsOptions` / `ListEngramsResult` / `UpsertEngramArgs` type exports.

### `apps/pops-api`
- `backfill-cerebrum-from-shared.ts` adds `engram_index` + `engram_scopes` + `engram_tags` + `engram_links` to `TABLE_COPIES`. Order matters: `engram_index` is copied first so the FK-cascaded auxiliaries can satisfy their constraints at insert time.
- `test-utils.ts` `setCerebrumDb` fixture passes `vecAvailable: false` to satisfy the widened `OpenedCerebrumDb`.
- `per-pillar-migrations.test.ts` expected migration list includes `0050_engrams_baseline` (and the already-existing `0055_pillar_registry` the test was stale on).

## Test plan

- [x] `pnpm -F @pops/cerebrum-db build && test && typecheck` — 45 tests green (3 test files: nudge-log, open-cerebrum-db, engrams)
- [x] `pnpm -F @pops/api test` — full pops-api suite 4905/4905 pass including backfill + per-pillar-migrations
- [x] `pnpm -F @pops/cerebrum-api test` — 23/23 pass (validates the widened `OpenedCerebrumDb` works with existing consumers)
- [x] `pnpm -w typecheck` — 66/66 tasks green
- [x] `pnpm oxlint` + `pnpm oxfmt` on changed files — clean