### PR TITLE
fix(ci): pre-build finance-contract before pillar-sdk in api-test and api-quality

### DIFF
--- a/.github/workflows/api-quality.yml
+++ b/.github/workflows/api-quality.yml
@@ -89,6 +89,7 @@ jobs:
           cd ../lists-db && pnpm build
           cd ../app-lists-db && pnpm build
           cd ../app-food-db && pnpm build
+          cd ../finance-contract && pnpm build
           cd ../pillar-sdk && pnpm build
 
       - name: Type check

--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -90,6 +90,7 @@ jobs:
           cd ../lists-db && pnpm build
           cd ../app-lists-db && pnpm build
           cd ../app-food-db && pnpm build
+          cd ../finance-contract && pnpm build
           cd ../pillar-sdk && pnpm build
 
       - name: Typecheck

--- a/apps/pops-api/src/db/per-pillar-migrations.test.ts
+++ b/apps/pops-api/src/db/per-pillar-migrations.test.ts
@@ -231,6 +231,7 @@ describe('runPerPillarMigrations', () => {
         '0039_dry_fabian_cortez',
         '0044_nudge_log',
         '0054_service_accounts',
+        '0055_pillar_registry',
       ]);
       expect([...result.pillarsApplied].toSorted()).toEqual([
         'cerebrum',


### PR DESCRIPTION
## Summary

- `pillar-sdk/src/contracts/index.ts` imports from `@pops/finance-contract/{manifest,types,errors}`, but `api-test.yml` and `api-quality.yml` build the db chain straight into `pillar-sdk` without first building `finance-contract`.
- `pillar-sdk`'s `tsc` then fails with `TS2307: Cannot find module '@pops/finance-contract/manifest'`.
- Inserts `cd ../finance-contract && pnpm build` between `app-food-db` and `pillar-sdk` in both workflows.

Same precedent as #2988, which closed the identical gap in `contract-semver.yml`.

Failing run on PR #2987: https://github.com/knoxio/pops/actions/runs/27412978872

## Test plan

- [ ] `api-test` workflow `Build shared packages` step succeeds (no TS2307 from pillar-sdk).
- [ ] `api-quality` workflow `Build shared packages` step succeeds.
- [ ] Downstream `Typecheck` / `Type check` step runs.
