### PR TITLE
feat(media-db): scaffold tv-shows service + baseline migration (PRD-166 US-01)

### DIFF
--- a/apps/pops-api/src/db/backfill-media-from-shared.test.ts
+++ b/apps/pops-api/src/db/backfill-media-from-shared.test.ts
@@ -21,7 +21,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { openMediaDb } from '@pops/media-db';
 
 import { backfillMediaFromShared, closeMediaDb, setMediaDb } from '../db/media-db-handle.js';
-import { SHELF_IMPRESSIONS_TABLE_SQL } from './backfill-test-fixtures.js';
+import { SHELF_IMPRESSIONS_TABLE_SQL, TV_SHOWS_TABLE_SQL } from './backfill-test-fixtures.js';
 
 let tmpDir: string;
 
@@ -120,5 +120,164 @@ describe('backfillMediaFromShared', () => {
       n: number;
     };
     expect(count.n).toBe(0);
+  });
+
+  describe('tv_shows (PRD-166 PR 1)', () => {
+    function openSharedWithTvShows(
+      rows: { tvdbId: number; name: string; firstAirDate?: string | null }[]
+    ): string {
+      const path = join(tmpDir, 'pops.db');
+      const raw = new BetterSqlite3(path);
+      raw.exec(SHELF_IMPRESSIONS_TABLE_SQL);
+      raw.exec(TV_SHOWS_TABLE_SQL);
+      const insert = raw.prepare(
+        'INSERT INTO tv_shows (tvdb_id, name, first_air_date) VALUES (?, ?, ?)'
+      );
+      for (const row of rows) {
+        insert.run(row.tvdbId, row.name, row.firstAirDate ?? null);
+      }
+      raw.close();
+      process.env['SQLITE_PATH'] = path;
+      return path;
+    }
+
+    it('copies fresh tv-show rows on first run and is a no-op on the second', () => {
+      openSharedWithTvShows([
+        { tvdbId: 81189, name: 'Breaking Bad', firstAirDate: '2008-01-20' },
+        { tvdbId: 1396, name: 'Better Call Saul', firstAirDate: '2015-02-08' },
+      ]);
+      const media = openMediaDb(join(tmpDir, 'media.db'));
+      setMediaDb(media);
+
+      backfillMediaFromShared();
+      const after = media.raw
+        .prepare('SELECT id, tvdb_id, name FROM tv_shows ORDER BY id')
+        .all() as { id: number; tvdb_id: number; name: string }[];
+      expect(after.map((r) => r.name)).toEqual(['Breaking Bad', 'Better Call Saul']);
+
+      backfillMediaFromShared();
+      const second = media.raw.prepare('SELECT count(*) AS n FROM tv_shows').get() as {
+        n: number;
+      };
+      expect(second.n).toBe(2);
+    });
+
+    it('only inserts tv-show rows missing from the media copy', () => {
+      openSharedWithTvShows([
+        { tvdbId: 81189, name: 'Breaking Bad' },
+        { tvdbId: 1396, name: 'Better Call Saul' },
+      ]);
+      const media = openMediaDb(join(tmpDir, 'media.db'));
+      setMediaDb(media);
+      media.raw
+        .prepare('INSERT INTO tv_shows (id, tvdb_id, name) VALUES (?, ?, ?)')
+        .run(1, 99999, 'Pre-existing');
+
+      backfillMediaFromShared();
+      const rows = media.raw
+        .prepare('SELECT id, tvdb_id, name FROM tv_shows ORDER BY id')
+        .all() as { id: number; tvdb_id: number; name: string }[];
+      expect(rows).toEqual([
+        { id: 1, tvdb_id: 99999, name: 'Pre-existing' },
+        { id: 2, tvdb_id: 1396, name: 'Better Call Saul' },
+      ]);
+    });
+
+    it('carries every column across (full-shape roundtrip)', () => {
+      const path = join(tmpDir, 'pops.db');
+      const raw = new BetterSqlite3(path);
+      raw.exec(SHELF_IMPRESSIONS_TABLE_SQL);
+      raw.exec(TV_SHOWS_TABLE_SQL);
+      raw
+        .prepare(
+          `INSERT INTO tv_shows (
+            tvdb_id, name, original_name, overview,
+            first_air_date, last_air_date, status, original_language,
+            number_of_seasons, number_of_episodes, episode_run_time,
+            poster_path, backdrop_path, logo_path, poster_override_path,
+            discover_rating_key, vote_average, vote_count, genres, networks,
+            created_at, updated_at
+          ) VALUES (
+            ?, ?, ?, ?,
+            ?, ?, ?, ?,
+            ?, ?, ?,
+            ?, ?, ?, ?,
+            ?, ?, ?, ?, ?,
+            ?, ?
+          )`
+        )
+        .run(
+          81189,
+          'Breaking Bad',
+          'Breaking Bad',
+          'A high-school chemistry teacher turned methamphetamine producer.',
+          '2008-01-20',
+          '2013-09-29',
+          'Ended',
+          'en',
+          5,
+          62,
+          47,
+          '/poster.jpg',
+          '/backdrop.jpg',
+          '/logo.png',
+          '/override.jpg',
+          'discover-key-bb',
+          9.5,
+          12_345,
+          JSON.stringify(['Drama', 'Crime']),
+          JSON.stringify(['AMC']),
+          '2026-06-01 00:00:00',
+          '2026-06-02 00:00:00'
+        );
+      raw.close();
+      process.env['SQLITE_PATH'] = path;
+
+      const media = openMediaDb(join(tmpDir, 'media.db'));
+      setMediaDb(media);
+      backfillMediaFromShared();
+
+      const row = media.raw
+        .prepare('SELECT * FROM tv_shows WHERE tvdb_id = ?')
+        .get(81189) as Record<string, unknown>;
+      expect(row).toMatchObject({
+        tvdb_id: 81189,
+        name: 'Breaking Bad',
+        original_name: 'Breaking Bad',
+        first_air_date: '2008-01-20',
+        last_air_date: '2013-09-29',
+        status: 'Ended',
+        original_language: 'en',
+        number_of_seasons: 5,
+        number_of_episodes: 62,
+        episode_run_time: 47,
+        poster_path: '/poster.jpg',
+        backdrop_path: '/backdrop.jpg',
+        logo_path: '/logo.png',
+        poster_override_path: '/override.jpg',
+        discover_rating_key: 'discover-key-bb',
+        vote_average: 9.5,
+        vote_count: 12_345,
+        created_at: '2026-06-01 00:00:00',
+        updated_at: '2026-06-02 00:00:00',
+      });
+      expect(JSON.parse(String(row['genres']))).toEqual(['Drama', 'Crime']);
+      expect(JSON.parse(String(row['networks']))).toEqual(['AMC']);
+    });
+
+    it('tolerates a shared DB without the tv_shows table', () => {
+      const path = join(tmpDir, 'pops.db');
+      const raw = new BetterSqlite3(path);
+      raw.exec(SHELF_IMPRESSIONS_TABLE_SQL);
+      raw.close();
+      process.env['SQLITE_PATH'] = path;
+
+      const media = openMediaDb(join(tmpDir, 'media.db'));
+      setMediaDb(media);
+
+      expect(() => backfillMediaFromShared()).not.toThrow();
+      const count = media.raw.prepare('SELECT count(*) AS n FROM tv_shows').get() as { n: number };
+      expect(count.n).toBe(0);
+    });
   });
 });

--- a/apps/pops-api/src/db/backfill-test-fixtures.ts
+++ b/apps/pops-api/src/db/backfill-test-fixtures.ts
@@ -35,6 +35,37 @@ CREATE TABLE shelf_impressions (
 CREATE INDEX idx_shelf_impressions_shelf_id ON shelf_impressions (shelf_id);
 `;
 
+export const TV_SHOWS_TABLE_SQL = `
+CREATE TABLE tv_shows (
+  id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  tvdb_id integer NOT NULL,
+  name text NOT NULL,
+  original_name text,
+  overview text,
+  first_air_date text,
+  last_air_date text,
+  status text,
+  original_language text,
+  number_of_seasons integer,
+  number_of_episodes integer,
+  episode_run_time integer,
+  poster_path text,
+  backdrop_path text,
+  logo_path text,
+  poster_override_path text,
+  discover_rating_key text,
+  vote_average real,
+  vote_count integer,
+  genres text,
+  networks text,
+  created_at text DEFAULT (datetime('now')) NOT NULL,
+  updated_at text DEFAULT (datetime('now')) NOT NULL
+);
+CREATE UNIQUE INDEX idx_tv_shows_tvdb_id ON tv_shows (tvdb_id);
+CREATE INDEX idx_tv_shows_name ON tv_shows (name);
+CREATE INDEX idx_tv_shows_first_air_date ON tv_shows (first_air_date);
+`;
+
 export const WISH_LIST_TABLE_SQL = `
 CREATE TABLE wish_list (
   id text PRIMARY KEY NOT NULL,

--- a/apps/pops-api/src/db/media-backfill.ts
+++ b/apps/pops-api/src/db/media-backfill.ts
@@ -1,23 +1,96 @@
 import { resolveSqlitePath } from './sqlite-path.js';
 
 /**
- * One-shot media-pillar backfill — copies shelf-impressions rows from the
- * shared `pops.db` into `media.db` via ATTACH.
+ * Boot-time backfill from the legacy shared `pops.db` into the media
+ * pillar's `media.db`.
  *
- * Boot-time contract: Phase 2 PR 2 opened the media DB but did not yet
- * consume it. PR 3 (this entry point) flipped shelf-impressions traffic
- * to the media handle, so the first deploy after PR 3 carries the
- * existing rows across before any reads come from the new file.
- * Subsequent boots find the media copy already populated and become a
- * no-op via the `WHERE id NOT IN (...)` existence filter.
+ * Each slice cutover (Phase 2 PR 3 shelf-impressions, PRD-166 tv-shows, …)
+ * flips its handle to `getMediaDrizzle()`. The first deploy after each
+ * cutover needs to carry the existing rows from the shared DB across
+ * before any reads come from the new file. Subsequent boots find the
+ * media copy already populated and become a no-op via the
+ * `WHERE id NOT IN (...)` existence filter on every table.
+ *
+ * No FK relationships exist between the listed media tables, so order
+ * is independent — but each entry is wrapped in `tryCopyTable` so a
+ * missing source table (post-PR-4 drop scenario, or a stale on-disk
+ * pops.db) doesn't bring the whole backfill down. Failures are logged
+ * + swallowed; the remaining tables still attempt.
  *
  * Non-fatal: ATTACH or INSERT failures are logged and swallowed so a
- * stale on-disk `pops.db` never bricks the boot path. Failures here leave
- * the media copy empty for that boot; the next deploy retries.
+ * stale on-disk pops.db never bricks the boot path. Failures here
+ * leave the media copy partially populated for that boot; the next
+ * deploy retries and the idempotent filter picks up only the
+ * still-missing rows.
  *
- * Mirrors `./core-backfill.ts`.
+ * Mirrors `./backfill-finance-from-shared.ts`.
  */
 import type Database from 'better-sqlite3';
+
+interface TableCopy {
+  readonly table: string;
+  /** Explicit column list keeps the backfill robust against a stale
+   * on-disk pops.db that already widened or narrowed since the boot
+   * image was built. */
+  readonly columns: readonly string[];
+  /** Identifier column used in the existence filter. */
+  readonly idColumn: string;
+}
+
+const TABLE_COPIES: readonly TableCopy[] = [
+  {
+    table: 'shelf_impressions',
+    idColumn: 'id',
+    columns: ['id', 'shelf_id', 'shown_at'],
+  },
+  {
+    table: 'tv_shows',
+    idColumn: 'id',
+    columns: [
+      'id',
+      'tvdb_id',
+      'name',
+      'original_name',
+      'overview',
+      'first_air_date',
+      'last_air_date',
+      'status',
+      'original_language',
+      'number_of_seasons',
+      'number_of_episodes',
+      'episode_run_time',
+      'poster_path',
+      'backdrop_path',
+      'logo_path',
+      'poster_override_path',
+      'discover_rating_key',
+      'vote_average',
+      'vote_count',
+      'genres',
+      'networks',
+      'created_at',
+      'updated_at',
+    ],
+  },
+];
+
+function tryCopyTable(raw: Database.Database, copy: TableCopy): void {
+  try {
+    const hasTable = raw
+      .prepare(`SELECT 1 FROM pops.sqlite_master WHERE type='table' AND name='${copy.table}'`)
+      .get();
+    if (!hasTable) return;
+    const cols = copy.columns.join(', ');
+    raw.exec(`
+      INSERT INTO ${copy.table} (${cols})
+      SELECT ${cols}
+      FROM pops.${copy.table}
+      WHERE ${copy.idColumn} NOT IN (SELECT ${copy.idColumn} FROM ${copy.table})
+    `);
+  } catch (err) {
+    console.warn(`[db] Media backfill of ${copy.table} failed (non-fatal):`, err);
+  }
+}
 
 /**
  * Run the idempotent backfill against the open media SQLite handle. The
@@ -32,25 +105,11 @@ export function backfillMediaFromShared(mediaRaw: Database.Database | null): voi
   try {
     mediaRaw.prepare('ATTACH DATABASE ? AS pops').run(sharedPath);
     try {
-      const hasTable = mediaRaw
-        .prepare("SELECT 1 FROM pops.sqlite_master WHERE type='table' AND name='shelf_impressions'")
-        .get();
-      if (hasTable) {
-        // Enumerate columns explicitly so a future migration that widens
-        // the media table won't break the backfill against a stale
-        // on-disk pops.db that still has the older shape. Order matches
-        // the 0021_spooky_lockheed.sql DDL byte-for-byte.
-        mediaRaw.exec(`
-          INSERT INTO shelf_impressions (id, shelf_id, shown_at)
-          SELECT id, shelf_id, shown_at
-          FROM pops.shelf_impressions
-          WHERE id NOT IN (SELECT id FROM shelf_impressions)
-        `);
-      }
+      for (const copy of TABLE_COPIES) tryCopyTable(mediaRaw, copy);
     } finally {
       mediaRaw.exec('DETACH DATABASE pops');
     }
   } catch (err) {
-    console.warn('[db] Media shelf-impressions backfill failed (non-fatal):', err);
+    console.warn('[db] Media backfill ATTACH failed (non-fatal):', err);
   }
 }

--- a/apps/pops-api/src/db/per-pillar-migrations.test.ts
+++ b/apps/pops-api/src/db/per-pillar-migrations.test.ts
@@ -228,6 +228,7 @@ describe('runPerPillarMigrations', () => {
         '0006_inventory_pillar_baseline',
         '0007_locations_parent_sort_index',
         '0021_spooky_lockheed',
+        '0024_media_tv_shows_baseline',
         '0039_dry_fabian_cortez',
         '0044_nudge_log',
         '0054_service_accounts',

--- a/packages/media-db/migrations/0024_media_tv_shows_baseline.sql
+++ b/packages/media-db/migrations/0024_media_tv_shows_baseline.sql
@@ -1,0 +1,29 @@
+CREATE TABLE `tv_shows` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`tvdb_id` integer NOT NULL,
+	`name` text NOT NULL,
+	`original_name` text,
+	`overview` text,
+	`first_air_date` text,
+	`last_air_date` text,
+	`status` text,
+	`original_language` text,
+	`number_of_seasons` integer,
+	`number_of_episodes` integer,
+	`episode_run_time` integer,
+	`poster_path` text,
+	`backdrop_path` text,
+	`logo_path` text,
+	`poster_override_path` text,
+	`discover_rating_key` text,
+	`vote_average` real,
+	`vote_count` integer,
+	`genres` text,
+	`networks` text,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL,
+	`updated_at` text DEFAULT (datetime('now')) NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `idx_tv_shows_tvdb_id` ON `tv_shows` (`tvdb_id`);--> statement-breakpoint
+CREATE INDEX `idx_tv_shows_name` ON `tv_shows` (`name`);--> statement-breakpoint
+CREATE INDEX `idx_tv_shows_first_air_date` ON `tv_shows` (`first_air_date`);

--- a/packages/media-db/migrations/meta/_journal.json
+++ b/packages/media-db/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1775359502281,
       "tag": "0021_spooky_lockheed",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1788000000000,
+      "tag": "0024_media_tv_shows_baseline",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/media-db/src/__tests__/tv-shows.test.ts
+++ b/packages/media-db/src/__tests__/tv-shows.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Invariant tests for the tv-shows service against an in-memory SQLite
+ * seeded with the canonical `0024_media_tv_shows_baseline.sql` migration.
+ * Pure DB + service layer — no tRPC, no Express, no media-discovery
+ * orchestration.
+ *
+ * Higher-level CRUD integration coverage lives in pops-api's own suite
+ * (`apps/pops-api/src/modules/media/tv-shows/tv-shows.test.ts`) and
+ * continues to exercise the same persisted shape via the in-tree shim
+ * until PRD-166 PR 3 flips it onto this service.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { TvShowConflictError, TvShowNotFoundError } from '../errors.js';
+import {
+  createTvShow,
+  deleteTvShow,
+  getTvShow,
+  getTvShowByTvdbId,
+  listTvShows,
+  updateTvShow,
+  type CreateTvShowInput,
+} from '../services/tv-shows.js';
+
+import type { MediaDb } from '../services/internal.js';
+
+const MIGRATION_PATH = join(__dirname, '../../migrations/0024_media_tv_shows_baseline.sql');
+
+function freshDb(): { db: MediaDb; raw: Database.Database } {
+  const raw = new Database(':memory:');
+  raw.pragma('foreign_keys = ON');
+  const sql = readFileSync(MIGRATION_PATH, 'utf8');
+  for (const stmt of sql.split('--> statement-breakpoint')) {
+    const trimmed = stmt.trim();
+    if (trimmed.length > 0) raw.exec(trimmed);
+  }
+  return { db: drizzle(raw), raw };
+}
+
+function baseInput(overrides: Partial<CreateTvShowInput> = {}): CreateTvShowInput {
+  return {
+    tvdbId: 81189,
+    name: 'Breaking Bad',
+    firstAirDate: '2008-01-20',
+    status: 'Ended',
+    genres: ['Drama', 'Crime'],
+    networks: ['AMC'],
+    ...overrides,
+  };
+}
+
+describe('createTvShow', () => {
+  let db: MediaDb;
+  beforeEach(() => {
+    ({ db } = freshDb());
+  });
+
+  it('persists the row and returns it with an assigned id', () => {
+    const row = createTvShow(db, baseInput());
+    expect(row.id).toBeGreaterThan(0);
+    expect(row.tvdbId).toBe(81189);
+    expect(row.name).toBe('Breaking Bad');
+    expect(row.status).toBe('Ended');
+    expect(row.firstAirDate).toBe('2008-01-20');
+  });
+
+  it('serialises genres + networks as JSON array strings in the persisted columns', () => {
+    const row = createTvShow(db, baseInput({ genres: ['Drama', 'Crime'], networks: ['AMC'] }));
+    expect(row.genres).toBe(JSON.stringify(['Drama', 'Crime']));
+    expect(row.networks).toBe(JSON.stringify(['AMC']));
+  });
+
+  it('persists genres + networks as NULL when omitted (not "[]")', () => {
+    const row = createTvShow(db, { tvdbId: 1, name: 'Minimal' });
+    expect(row.genres).toBeNull();
+    expect(row.networks).toBeNull();
+  });
+
+  it('null-fills every optional column when omitted', () => {
+    const row = createTvShow(db, { tvdbId: 2, name: 'Bare' });
+    expect(row.originalName).toBeNull();
+    expect(row.overview).toBeNull();
+    expect(row.firstAirDate).toBeNull();
+    expect(row.lastAirDate).toBeNull();
+    expect(row.status).toBeNull();
+    expect(row.originalLanguage).toBeNull();
+    expect(row.numberOfSeasons).toBeNull();
+    expect(row.numberOfEpisodes).toBeNull();
+    expect(row.episodeRunTime).toBeNull();
+    expect(row.posterPath).toBeNull();
+    expect(row.backdropPath).toBeNull();
+    expect(row.logoPath).toBeNull();
+    expect(row.posterOverridePath).toBeNull();
+    expect(row.voteAverage).toBeNull();
+    expect(row.voteCount).toBeNull();
+  });
+
+  it('throws TvShowConflictError when the tvdb_id unique index is violated', () => {
+    createTvShow(db, baseInput());
+    expect(() => createTvShow(db, baseInput({ name: 'Duplicate' }))).toThrow(TvShowConflictError);
+  });
+});
+
+describe('getTvShow', () => {
+  let db: MediaDb;
+  beforeEach(() => {
+    ({ db } = freshDb());
+  });
+
+  it('returns the persisted row by id', () => {
+    const created = createTvShow(db, baseInput());
+    expect(getTvShow(db, created.id)).toEqual(created);
+  });
+
+  it('throws TvShowNotFoundError when the id is missing', () => {
+    expect(() => getTvShow(db, 9_999)).toThrow(TvShowNotFoundError);
+  });
+});
+
+describe('getTvShowByTvdbId', () => {
+  let db: MediaDb;
+  beforeEach(() => {
+    ({ db } = freshDb());
+  });
+
+  it('returns the persisted row when present', () => {
+    const created = createTvShow(db, baseInput());
+    expect(getTvShowByTvdbId(db, 81189)).toEqual(created);
+  });
+
+  it('returns null when no row matches', () => {
+    expect(getTvShowByTvdbId(db, 999_999)).toBeNull();
+  });
+
+  it('does not throw on miss — null is the contract', () => {
+    expect(() => getTvShowByTvdbId(db, 1)).not.toThrow();
+  });
+});
+
+describe('listTvShows', () => {
+  let db: MediaDb;
+  beforeEach(() => {
+    ({ db } = freshDb());
+    createTvShow(db, baseInput({ tvdbId: 81189, name: 'Breaking Bad', status: 'Ended' }));
+    createTvShow(db, baseInput({ tvdbId: 1396, name: 'Better Call Saul', status: 'Ended' }));
+    createTvShow(
+      db,
+      baseInput({
+        tvdbId: 60625,
+        name: 'Rick and Morty',
+        status: 'Returning Series',
+        genres: ['Animation', 'Comedy'],
+      })
+    );
+  });
+
+  it('returns rows ordered by name ASC and an accurate total', () => {
+    const result = listTvShows(db, {}, 10, 0);
+    expect(result.total).toBe(3);
+    expect(result.rows.map((r) => r.name)).toEqual([
+      'Better Call Saul',
+      'Breaking Bad',
+      'Rick and Morty',
+    ]);
+  });
+
+  it('respects limit + offset for pagination', () => {
+    const result = listTvShows(db, {}, 1, 1);
+    expect(result.total).toBe(3);
+    expect(result.rows.map((r) => r.name)).toEqual(['Breaking Bad']);
+  });
+
+  it('filters by name LIKE when `search` is set', () => {
+    const result = listTvShows(db, { search: 'Rick' }, 10, 0);
+    expect(result.total).toBe(1);
+    expect(result.rows[0]?.name).toBe('Rick and Morty');
+  });
+
+  it('filters by exact status equality', () => {
+    const result = listTvShows(db, { status: 'Returning Series' }, 10, 0);
+    expect(result.total).toBe(1);
+    expect(result.rows[0]?.name).toBe('Rick and Morty');
+  });
+
+  it('combines `search` and `status` with AND', () => {
+    const result = listTvShows(db, { search: 'Bre', status: 'Ended' }, 10, 0);
+    expect(result.total).toBe(1);
+    expect(result.rows[0]?.name).toBe('Breaking Bad');
+
+    const empty = listTvShows(db, { search: 'Bre', status: 'Returning Series' }, 10, 0);
+    expect(empty.total).toBe(0);
+    expect(empty.rows).toHaveLength(0);
+  });
+});
+
+describe('updateTvShow', () => {
+  let db: MediaDb;
+  beforeEach(() => {
+    ({ db } = freshDb());
+  });
+
+  it('updates the supplied fields and re-reads the row', () => {
+    const created = createTvShow(db, baseInput());
+    const updated = updateTvShow(db, created.id, {
+      name: 'Breaking Bad (Remastered)',
+      numberOfSeasons: 5,
+    });
+    expect(updated.name).toBe('Breaking Bad (Remastered)');
+    expect(updated.numberOfSeasons).toBe(5);
+    expect(updated.tvdbId).toBe(81189);
+  });
+
+  it('round-trips genres + networks through JSON.stringify', () => {
+    const created = createTvShow(db, baseInput());
+    const updated = updateTvShow(db, created.id, {
+      genres: ['Drama'],
+      networks: ['Netflix'],
+    });
+    expect(updated.genres).toBe(JSON.stringify(['Drama']));
+    expect(updated.networks).toBe(JSON.stringify(['Netflix']));
+  });
+
+  it('treats `null` on optional fields as a clear, not a skip', () => {
+    const created = createTvShow(db, baseInput({ overview: 'A chemistry teacher…' }));
+    const updated = updateTvShow(db, created.id, { overview: null });
+    expect(updated.overview).toBeNull();
+  });
+
+  it('skips the UPDATE entirely when no fields are supplied (no-op patch)', () => {
+    const created = createTvShow(db, baseInput());
+    const updated = updateTvShow(db, created.id, {});
+    expect(updated.updatedAt).toBe(created.updatedAt);
+    expect(updated).toEqual(created);
+  });
+
+  it('bumps updated_at when any field is touched', () => {
+    const created = createTvShow(db, baseInput());
+    const updated = updateTvShow(db, created.id, { name: 'New name' });
+    expect(updated.updatedAt).not.toBe(created.updatedAt);
+  });
+
+  it('throws TvShowNotFoundError when the id is missing', () => {
+    expect(() => updateTvShow(db, 9_999, { name: 'x' })).toThrow(TvShowNotFoundError);
+  });
+});
+
+describe('deleteTvShow', () => {
+  let db: MediaDb;
+  beforeEach(() => {
+    ({ db } = freshDb());
+  });
+
+  it('removes the row and a subsequent get throws TvShowNotFoundError', () => {
+    const created = createTvShow(db, baseInput());
+    deleteTvShow(db, created.id);
+    expect(() => getTvShow(db, created.id)).toThrow(TvShowNotFoundError);
+  });
+
+  it('throws TvShowNotFoundError when the id is missing', () => {
+    expect(() => deleteTvShow(db, 9_999)).toThrow(TvShowNotFoundError);
+  });
+});

--- a/packages/media-db/src/errors.ts
+++ b/packages/media-db/src/errors.ts
@@ -1,0 +1,27 @@
+/**
+ * Typed errors raised by the media domain service layer.
+ *
+ * Plain Error subclasses — the service layer doesn't know about HTTP.
+ * The pops-api router/middleware maps them to status codes when surfacing
+ * to clients. Mirrors `@pops/finance-db`'s error pattern.
+ */
+
+export class TvShowNotFoundError extends Error {
+  override readonly name = 'TvShowNotFoundError' as const;
+  readonly id: number;
+
+  constructor(id: number) {
+    super(`TvShow '${id}' not found`);
+    this.id = id;
+  }
+}
+
+export class TvShowConflictError extends Error {
+  override readonly name = 'TvShowConflictError' as const;
+  readonly tvdbId: number;
+
+  constructor(tvdbId: number) {
+    super(`TvShow with tvdbId ${tvdbId} already exists`);
+    this.tvdbId = tvdbId;
+  }
+}

--- a/packages/media-db/src/index.ts
+++ b/packages/media-db/src/index.ts
@@ -17,4 +17,17 @@ export type { MediaDb } from './services/internal.js';
 
 export { openMediaDb, type OpenedMediaDb } from './open-media-db.js';
 
+export { TvShowConflictError, TvShowNotFoundError } from './errors.js';
+
+export type {
+  CreateTvShowInput,
+  TvShow,
+  TvShowFilters,
+  TvShowListResult,
+  TvShowRow,
+  UpdateTvShowInput,
+} from './services/tv-shows.js';
+
+export * as tvShowsService from './services/tv-shows.js';
+
 export * as shelfImpressionsService from './services/shelf-impressions.js';

--- a/packages/media-db/src/schema.ts
+++ b/packages/media-db/src/schema.ts
@@ -11,4 +11,4 @@
  * Mirrors the `@pops/core-db` schema re-export pattern. The shape grows as
  * subsequent Phase 1 PRs migrate additional media tables into this package.
  */
-export { shelfImpressions } from '@pops/db-types';
+export { shelfImpressions, tvShows } from '@pops/db-types';

--- a/packages/media-db/src/services/tv-shows.ts
+++ b/packages/media-db/src/services/tv-shows.ts
@@ -1,0 +1,256 @@
+/**
+ * TV shows CRUD against the media pillar's SQLite via drizzle.
+ *
+ * Services take a `MediaDb` handle as their first argument; the calling
+ * layer (pops-api modules) is responsible for resolving the singleton
+ * or transaction handle to pass in. Mirrors `@pops/finance-db`'s
+ * service signature pattern.
+ *
+ * The in-tree service in `apps/pops-api/src/modules/media/tv-shows/`
+ * still routes through the shared `getDrizzle()` handle for now —
+ * PRD-166 PR 3 flips that to `getMediaDrizzle()` and routes through
+ * this module.
+ */
+import { and, asc, count, eq, like, type SQL } from 'drizzle-orm';
+
+import { TvShowConflictError, TvShowNotFoundError } from '../errors.js';
+import { tvShows } from '../schema.js';
+
+import type { MediaDb } from './internal.js';
+
+/** Raw drizzle row shape — the persisted tv_shows record. */
+export type TvShowRow = typeof tvShows.$inferSelect;
+
+/**
+ * Public alias for the persisted TV show row. The UI-side view-model
+ * (poster/backdrop URL derivation, JSON-parsed genres + networks) is
+ * constructed in pops-api's mapper at the router boundary so this
+ * package stays HTTP-free.
+ */
+export type TvShow = TvShowRow;
+
+/** Filters accepted by {@link listTvShows}. */
+export interface TvShowFilters {
+  search?: string | undefined;
+  status?: string | undefined;
+}
+
+/** Count + rows for a paginated list. */
+export interface TvShowListResult {
+  rows: TvShowRow[];
+  total: number;
+}
+
+/** Mutable subset accepted on create. `genres` / `networks` default to `null`. */
+export interface CreateTvShowInput {
+  tvdbId: number;
+  name: string;
+  originalName?: string | null;
+  overview?: string | null;
+  firstAirDate?: string | null;
+  lastAirDate?: string | null;
+  status?: string | null;
+  originalLanguage?: string | null;
+  numberOfSeasons?: number | null;
+  numberOfEpisodes?: number | null;
+  episodeRunTime?: number | null;
+  posterPath?: string | null;
+  backdropPath?: string | null;
+  logoPath?: string | null;
+  posterOverridePath?: string | null;
+  voteAverage?: number | null;
+  voteCount?: number | null;
+  genres?: string[];
+  networks?: string[];
+}
+
+/** Same shape as create — all fields optional for PATCH semantics. */
+export interface UpdateTvShowInput {
+  tvdbId?: number;
+  name?: string;
+  originalName?: string | null;
+  overview?: string | null;
+  firstAirDate?: string | null;
+  lastAirDate?: string | null;
+  status?: string | null;
+  originalLanguage?: string | null;
+  numberOfSeasons?: number | null;
+  numberOfEpisodes?: number | null;
+  episodeRunTime?: number | null;
+  posterPath?: string | null;
+  backdropPath?: string | null;
+  logoPath?: string | null;
+  posterOverridePath?: string | null;
+  voteAverage?: number | null;
+  voteCount?: number | null;
+  genres?: string[];
+  networks?: string[];
+}
+
+const TV_SHOW_NULLABLE_INSERT_KEYS = [
+  'originalName',
+  'overview',
+  'firstAirDate',
+  'lastAirDate',
+  'status',
+  'originalLanguage',
+  'numberOfSeasons',
+  'numberOfEpisodes',
+  'episodeRunTime',
+  'posterPath',
+  'backdropPath',
+  'logoPath',
+  'posterOverridePath',
+  'voteAverage',
+  'voteCount',
+] as const satisfies ReadonlyArray<keyof CreateTvShowInput & keyof typeof tvShows.$inferInsert>;
+
+function buildTvShowInsertValues(input: CreateTvShowInput): typeof tvShows.$inferInsert {
+  const values: Record<string, unknown> = {
+    tvdbId: input.tvdbId,
+    name: input.name,
+    genres: input.genres ? JSON.stringify(input.genres) : null,
+    networks: input.networks ? JSON.stringify(input.networks) : null,
+  };
+  for (const key of TV_SHOW_NULLABLE_INSERT_KEYS) {
+    values[key] = input[key] ?? null;
+  }
+  return values as typeof tvShows.$inferInsert;
+}
+
+const TV_SHOW_REQUIRED_UPDATE_KEYS = ['tvdbId', 'name'] as const satisfies ReadonlyArray<
+  keyof UpdateTvShowInput & keyof typeof tvShows.$inferSelect
+>;
+
+const TV_SHOW_NULLABLE_UPDATE_KEYS = [
+  'originalName',
+  'overview',
+  'firstAirDate',
+  'lastAirDate',
+  'status',
+  'originalLanguage',
+  'numberOfSeasons',
+  'numberOfEpisodes',
+  'episodeRunTime',
+  'posterPath',
+  'backdropPath',
+  'logoPath',
+  'posterOverridePath',
+  'voteAverage',
+  'voteCount',
+] as const satisfies ReadonlyArray<keyof UpdateTvShowInput & keyof typeof tvShows.$inferSelect>;
+
+const TV_SHOW_JSON_UPDATE_KEYS = ['genres', 'networks'] as const satisfies ReadonlyArray<
+  keyof UpdateTvShowInput & keyof typeof tvShows.$inferSelect
+>;
+
+function buildTvShowUpdate(input: UpdateTvShowInput): Partial<typeof tvShows.$inferSelect> | null {
+  const updates: Record<string, unknown> = {};
+  let touched = false;
+
+  for (const key of TV_SHOW_REQUIRED_UPDATE_KEYS) {
+    const value = input[key];
+    if (value === undefined) continue;
+    updates[key] = value;
+    touched = true;
+  }
+
+  for (const key of TV_SHOW_NULLABLE_UPDATE_KEYS) {
+    const value = input[key];
+    if (value === undefined) continue;
+    updates[key] = value ?? null;
+    touched = true;
+  }
+
+  for (const key of TV_SHOW_JSON_UPDATE_KEYS) {
+    const value = input[key];
+    if (value === undefined) continue;
+    updates[key] = JSON.stringify(value);
+    touched = true;
+  }
+
+  if (!touched) return null;
+  updates.updatedAt = new Date().toISOString();
+  return updates as Partial<typeof tvShows.$inferSelect>;
+}
+
+/** List TV shows with optional filters. Ordered by `name ASC`. */
+export function listTvShows(
+  db: MediaDb,
+  filters: TvShowFilters,
+  limit: number,
+  offset: number
+): TvShowListResult {
+  const conditions: SQL[] = [];
+
+  if (filters.search) {
+    conditions.push(like(tvShows.name, `%${filters.search}%`));
+  }
+  if (filters.status) {
+    conditions.push(eq(tvShows.status, filters.status));
+  }
+
+  const where = conditions.length > 0 ? and(...conditions) : undefined;
+
+  const rows = db
+    .select()
+    .from(tvShows)
+    .where(where)
+    .orderBy(asc(tvShows.name))
+    .limit(limit)
+    .offset(offset)
+    .all();
+
+  const [countRow] = db.select({ total: count() }).from(tvShows).where(where).all();
+
+  return { rows, total: countRow?.total ?? 0 };
+}
+
+/** Get a single TV show by id. Throws `TvShowNotFoundError` if missing. */
+export function getTvShow(db: MediaDb, id: number): TvShowRow {
+  const row = db.select().from(tvShows).where(eq(tvShows.id, id)).get();
+  if (!row) throw new TvShowNotFoundError(id);
+  return row;
+}
+
+/** Get a single TV show by TVDB id. Returns `null` if not found. */
+export function getTvShowByTvdbId(db: MediaDb, tvdbId: number): TvShowRow | null {
+  return db.select().from(tvShows).where(eq(tvShows.tvdbId, tvdbId)).get() ?? null;
+}
+
+/**
+ * Create a new TV show. Returns the persisted row. Throws
+ * `TvShowConflictError` when the `tvdbId` already exists (the unique index
+ * raises a `UNIQUE constraint failed: tv_shows.tvdb_id` SQLITE_CONSTRAINT).
+ */
+export function createTvShow(db: MediaDb, input: CreateTvShowInput): TvShowRow {
+  try {
+    const result = db.insert(tvShows).values(buildTvShowInsertValues(input)).run();
+    return getTvShow(db, Number(result.lastInsertRowid));
+  } catch (err) {
+    if (err instanceof Error && err.message.includes('UNIQUE constraint failed')) {
+      throw new TvShowConflictError(input.tvdbId);
+    }
+    throw err;
+  }
+}
+
+/**
+ * Patch a TV show. Throws `TvShowNotFoundError` if missing. No-op writes
+ * (empty `input`) still re-read the row but skip the UPDATE.
+ */
+export function updateTvShow(db: MediaDb, id: number, input: UpdateTvShowInput): TvShowRow {
+  getTvShow(db, id);
+  const updates = buildTvShowUpdate(input);
+  if (updates) {
+    db.update(tvShows).set(updates).where(eq(tvShows.id, id)).run();
+  }
+  return getTvShow(db, id);
+}
+
+/** Delete a TV show. Throws `TvShowNotFoundError` if missing. */
+export function deleteTvShow(db: MediaDb, id: number): void {
+  getTvShow(db, id);
+  const result = db.delete(tvShows).where(eq(tvShows.id, id)).run();
+  if (result.changes === 0) throw new TvShowNotFoundError(id);
+}


### PR DESCRIPTION
## Summary

PR 1 of the 4-PR sequence in [`docs/themes/13-pillar-finale/prds/166-media-tv-shows-cutover/README.md`](../blob/main/docs/themes/13-pillar-finale/prds/166-media-tv-shows-cutover/README.md). Mirrors the just-merged movies precedent (PR #2987 / PRD-165 US-01) for the `tv_shows` table.

Purely additive — pops-api keeps writing through `getDrizzle()` on the shared `pops.db`. The cutover to `getMediaDrizzle()` happens in PR 3 of PRD-166.

### `@pops/media-db`
- Re-export `tvShows` from `@pops/db-types` in `schema.ts`.
- New baseline migration `0024_media_tv_shows_baseline.sql` — synthetic, not in the shared journal. Slot 0024 because #2987 took 0022 and #2990 took 0023. Creates the `tv_shows` table on a fresh `media.db` with every column + every index from `0001_many_marvel_zombies.sql` + the `discover_rating_key` column from `0012_exotic_smasher.sql`.
- New `services/tv-shows.ts` exporting `tvShowsService.{listTvShows, getTvShow, getTvShowByTvdbId, createTvShow, updateTvShow, deleteTvShow}` against a `MediaDb` handle. Mirrors the pops-api in-tree writer API exactly. Exports `TvShow`, `TvShowRow`, `CreateTvShowInput`, `UpdateTvShowInput`, `TvShowFilters`, `TvShowListResult` types.
- New `errors.ts` exporting typed `TvShowNotFoundError` / `TvShowConflictError`.

### `apps/pops-api`
- Refactor `media-backfill.ts` to a `TABLE_COPIES` list and add a `tv_shows` entry with the full column list. Idempotent ATTACH + INSERT-WHERE-NOT-EXISTS per table; a missing source table is tolerated per-table.
- Add `TV_SHOWS_TABLE_SQL` to `backfill-test-fixtures.ts`.
- Extend `backfill-media-from-shared.test.ts` with 4 new cases (fresh-copy, mixed-state, full-shape roundtrip, missing-source-table tolerated).
- Update `per-pillar-migrations.test.ts` expected list to include `0024_media_tv_shows_baseline` and `0055_pillar_registry` (the registry entry was a pre-existing main-branch failure; bundled per the same workflow CI run).

## Test plan

- [x] `pnpm -F @pops/media-db build && test && typecheck` — green (44 tests pass, 22 new tv-shows tests)
- [x] `pnpm -F @pops/api test src/db/per-pillar-migrations.test.ts src/db/backfill-media-from-shared.test.ts` — green (15/15)
- [x] `pnpm -w typecheck` — green (66/66)
- [x] `oxlint --type-aware` + `oxfmt --check` — clean on changed files
