### PR TITLE
fix(finance-contract): stub FinanceRouter to break pillar-sdk build-graph cycle

### DIFF
--- a/packages/finance-contract/etc/finance-contract.api.json
+++ b/packages/finance-contract/etc/finance-contract.api.json
@@ -4,6 +4,30 @@
   "entries": [
     {
       "entry": ".",
+      "name": "Budget",
+      "kind": "interface",
+      "text": "export interface Budget {\n    id: string;\n    name: string;\n    cap: number;\n    period: BudgetPeriod;\n    categoryId: string | null;\n    lastEditedTime: string;\n}"
+    },
+    {
+      "entry": ".",
+      "name": "BudgetPeriod",
+      "kind": "type",
+      "text": "export type BudgetPeriod = (typeof BUDGET_PERIODS)[number];"
+    },
+    {
+      "entry": ".",
+      "name": "BudgetPeriodSchema",
+      "kind": "variable",
+      "text": "export declare const BudgetPeriodSchema: z.ZodEnum<{\n    monthly: \"monthly\";\n    yearly: \"yearly\";\n}>;"
+    },
+    {
+      "entry": ".",
+      "name": "BudgetSchema",
+      "kind": "variable",
+      "text": "export declare const BudgetSchema: z.ZodObject<{\n    id: z.ZodString;\n    name: z.ZodString;\n    cap: z.ZodNumber;\n    period: z.ZodEnum<{\n        monthly: \"monthly\";\n        yearly: \"yearly\";\n    }>;\n    categoryId: z.ZodNullable<z.ZodString>;\n    lastEditedTime: z.ZodString;\n}, z.core.$strip>;"
+    },
+    {
+      "entry": ".",
       "name": "ContractStatus",
       "kind": "type",
       "text": "export type ContractStatus = 'ok' | 'not-found' | 'unavailable' | 'degraded';"
@@ -16,9 +40,21 @@
     },
     {
       "entry": ".",
+      "name": "Entity",
+      "kind": "interface",
+      "text": "export interface Entity {\n    id: string;\n    name: string;\n    aliases: readonly string[];\n    lastEditedTime: string;\n}"
+    },
+    {
+      "entry": ".",
+      "name": "EntitySchema",
+      "kind": "variable",
+      "text": "export declare const EntitySchema: z.ZodObject<{\n    id: z.ZodString;\n    name: z.ZodString;\n    aliases: z.ZodReadonly<z.ZodArray<z.ZodString>>;\n    lastEditedTime: z.ZodString;\n}, z.core.$strip>;"
+    },
+    {
+      "entry": ".",
       "name": "FinanceContract",
       "kind": "interface",
-      "text": "export interface FinanceContract {\n    readonly pillar: 'finance';\n    readonly version: string;\n    readonly entities: {\n        readonly wishListItem: WishListItem;\n    };\n    readonly errors: FinanceError;\n    readonly router: FinanceRouter;\n}"
+      "text": "export interface FinanceContract {\n    readonly pillar: 'finance';\n    readonly version: string;\n    readonly entities: {\n        readonly budget: Budget;\n        readonly entity: Entity;\n        readonly transaction: Transaction;\n        readonly wishListItem: WishListItem;\n    };\n    readonly errors: FinanceError;\n    readonly router: FinanceRouter;\n}"
     },
     {
       "entry": ".",
@@ -48,7 +84,19 @@
       "entry": ".",
       "name": "FinanceRouter",
       "kind": "type",
-      "text": "export type FinanceRouter = typeof financeRouter;"
+      "text": "export type FinanceRouter = AnyTRPCRouter;"
+    },
+    {
+      "entry": ".",
+      "name": "Transaction",
+      "kind": "interface",
+      "text": "export interface Transaction {\n    id: string;\n    description: string;\n    amount: number;\n    date: string;\n    entityId: string | null;\n    tagIds: readonly string[];\n    lastEditedTime: string;\n}"
+    },
+    {
+      "entry": ".",
+      "name": "TransactionSchema",
+      "kind": "variable",
+      "text": "export declare const TransactionSchema: z.ZodObject<{\n    id: z.ZodString;\n    description: z.ZodString;\n    amount: z.ZodNumber;\n    date: z.ZodString;\n    entityId: z.ZodNullable<z.ZodString>;\n    tagIds: z.ZodReadonly<z.ZodArray<z.ZodString>>;\n    lastEditedTime: z.ZodString;\n}, z.core.$strip>;"
     },
     {
       "entry": ".",
@@ -114,13 +162,37 @@
       "entry": "./manifest",
       "name": "FinanceContract",
       "kind": "interface",
-      "text": "export interface FinanceContract {\n    readonly pillar: 'finance';\n    readonly version: string;\n    readonly entities: {\n        readonly wishListItem: WishListItem;\n    };\n    readonly errors: FinanceError;\n    readonly router: FinanceRouter;\n}"
+      "text": "export interface FinanceContract {\n    readonly pillar: 'finance';\n    readonly version: string;\n    readonly entities: {\n        readonly budget: Budget;\n        readonly entity: Entity;\n        readonly transaction: Transaction;\n        readonly wishListItem: WishListItem;\n    };\n    readonly errors: FinanceError;\n    readonly router: FinanceRouter;\n}"
     },
     {
       "entry": "./router",
       "name": "FinanceRouter",
       "kind": "type",
-      "text": "export type FinanceRouter = typeof financeRouter;"
+      "text": "export type FinanceRouter = AnyTRPCRouter;"
+    },
+    {
+      "entry": "./schemas",
+      "name": "BudgetPeriodSchema",
+      "kind": "variable",
+      "text": "export declare const BudgetPeriodSchema: z.ZodEnum<{\n    monthly: \"monthly\";\n    yearly: \"yearly\";\n}>;"
+    },
+    {
+      "entry": "./schemas",
+      "name": "BudgetSchema",
+      "kind": "variable",
+      "text": "export declare const BudgetSchema: z.ZodObject<{\n    id: z.ZodString;\n    name: z.ZodString;\n    cap: z.ZodNumber;\n    period: z.ZodEnum<{\n        monthly: \"monthly\";\n        yearly: \"yearly\";\n    }>;\n    categoryId: z.ZodNullable<z.ZodString>;\n    lastEditedTime: z.ZodString;\n}, z.core.$strip>;"
+    },
+    {
+      "entry": "./schemas",
+      "name": "EntitySchema",
+      "kind": "variable",
+      "text": "export declare const EntitySchema: z.ZodObject<{\n    id: z.ZodString;\n    name: z.ZodString;\n    aliases: z.ZodReadonly<z.ZodArray<z.ZodString>>;\n    lastEditedTime: z.ZodString;\n}, z.core.$strip>;"
+    },
+    {
+      "entry": "./schemas",
+      "name": "TransactionSchema",
+      "kind": "variable",
+      "text": "export declare const TransactionSchema: z.ZodObject<{\n    id: z.ZodString;\n    description: z.ZodString;\n    amount: z.ZodNumber;\n    date: z.ZodString;\n    entityId: z.ZodNullable<z.ZodString>;\n    tagIds: z.ZodReadonly<z.ZodArray<z.ZodString>>;\n    lastEditedTime: z.ZodString;\n}, z.core.$strip>;"
     },
     {
       "entry": "./schemas",
@@ -133,6 +205,30 @@
       "name": "WishListPrioritySchema",
       "kind": "variable",
       "text": "export declare const WishListPrioritySchema: z.ZodEnum<{\n    Needing: \"Needing\";\n    Soon: \"Soon\";\n    \"One Day\": \"One Day\";\n    Dreaming: \"Dreaming\";\n}>;"
+    },
+    {
+      "entry": "./types",
+      "name": "Budget",
+      "kind": "interface",
+      "text": "export interface Budget {\n    id: string;\n    name: string;\n    cap: number;\n    period: BudgetPeriod;\n    categoryId: string | null;\n    lastEditedTime: string;\n}"
+    },
+    {
+      "entry": "./types",
+      "name": "BudgetPeriod",
+      "kind": "type",
+      "text": "export type BudgetPeriod = (typeof BUDGET_PERIODS)[number];"
+    },
+    {
+      "entry": "./types",
+      "name": "Entity",
+      "kind": "interface",
+      "text": "export interface Entity {\n    id: string;\n    name: string;\n    aliases: readonly string[];\n    lastEditedTime: string;\n}"
+    },
+    {
+      "entry": "./types",
+      "name": "Transaction",
+      "kind": "interface",
+      "text": "export interface Transaction {\n    id: string;\n    description: string;\n    amount: number;\n    date: string;\n    entityId: string | null;\n    tagIds: readonly string[];\n    lastEditedTime: string;\n}"
     },
     {
       "entry": "./types",

--- a/packages/finance-contract/etc/finance-contract.zod.json
+++ b/packages/finance-contract/etc/finance-contract.zod.json
@@ -3,6 +3,130 @@
   "version": "0.1.0",
   "entries": [
     {
+      "name": "BudgetPeriodSchema",
+      "schema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "string",
+        "enum": ["monthly", "yearly"]
+      }
+    },
+    {
+      "name": "BudgetSchema",
+      "schema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "cap": {
+            "type": "number",
+            "minimum": 0
+          },
+          "period": {
+            "type": "string",
+            "enum": ["monthly", "yearly"]
+          },
+          "categoryId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "lastEditedTime": {
+            "type": "string",
+            "format": "date-time",
+            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+          }
+        },
+        "required": ["id", "name", "cap", "period", "categoryId", "lastEditedTime"],
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "EntitySchema",
+      "schema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "aliases": {
+            "readOnly": true,
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "lastEditedTime": {
+            "type": "string",
+            "format": "date-time",
+            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+          }
+        },
+        "required": ["id", "name", "aliases", "lastEditedTime"],
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "TransactionSchema",
+      "schema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "amount": {
+            "type": "number"
+          },
+          "date": {
+            "type": "string",
+            "format": "date",
+            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))$"
+          },
+          "entityId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "tagIds": {
+            "readOnly": true,
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "lastEditedTime": {
+            "type": "string",
+            "format": "date-time",
+            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+          }
+        },
+        "required": ["id", "description", "amount", "date", "entityId", "tagIds", "lastEditedTime"],
+        "additionalProperties": false
+      }
+    },
+    {
       "name": "WishListItemSchema",
       "schema": {
         "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/packages/finance-contract/package.json
+++ b/packages/finance-contract/package.json
@@ -48,10 +48,10 @@
   },
   "dependencies": {
     "@pops/types": "workspace:*",
+    "@trpc/server": "^11.17.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@pops/finance-api": "workspace:*",
     "tsx": "^4.22.4",
     "typescript": "^6.0.3",
     "vitest": "^4.1.8"

--- a/packages/finance-contract/src/router.ts
+++ b/packages/finance-contract/src/router.ts
@@ -1,19 +1,18 @@
-/**
- * The finance pillar's tRPC router *type*. Type-only re-export from
- * `apps/pops-finance-api` — no runtime tRPC code crosses the contract
- * boundary. Consumers use this to type the `pillar('finance').foo.bar(…)`
- * SDK calls (Epic 05 / PRD-191).
- *
- * Current shape: `typeof financeRouter`. Until PRD-153 us-04 + PRD-155 land
- * the build-time declaration bundler, this re-export means the contract's
- * emitted `.d.ts` still references `@pops/finance-api` (which transitively
- * references `@pops/finance-db`). The lint rule in PRD-156 stays focused
- * on *value* imports; type-only references through the contract are
- * tolerated as the migration intermediate. A committed OpenAPI snapshot
- * at `openapi/finance.openapi.json` is the planned long-term wire-typed
- * alternative consumers can use instead (PRD-153 US-04 — not yet
- * shipped).
- */
-import type { financeRouter } from '@pops/finance-api/router';
+import type { AnyTRPCRouter } from '@trpc/server';
 
-export type FinanceRouter = typeof financeRouter;
+/**
+ * Opaque tRPC router type for the finance pillar. Until PRD-155 ships the
+ * declaration bundler, `FinanceRouter` is the generic `AnyTRPCRouter` —
+ * consumers using `pillar<FinanceRouter>('finance')` get the router shape
+ * but lose per-procedure typing. The committed OpenAPI snapshot at
+ * `openapi/finance.openapi.json` is the wire-typed alternative.
+ *
+ * This shape was previously `typeof financeRouter` (re-exporting from
+ * `@pops/finance-api`), but that import-type closed a build-graph cycle
+ * (pillar-sdk → finance-contract → finance-api → pillar-sdk) that broke
+ * turbo's `^build` chain and forced every CI workflow to manually
+ * pre-build packages in order. PRD-155's declaration bundler will
+ * restore the concrete per-procedure types without re-introducing the
+ * cycle.
+ */
+export type FinanceRouter = AnyTRPCRouter;

--- a/packages/finance-contract/src/router.ts
+++ b/packages/finance-contract/src/router.ts
@@ -3,9 +3,10 @@ import type { AnyTRPCRouter } from '@trpc/server';
 /**
  * Opaque tRPC router type for the finance pillar. Until PRD-155 ships the
  * declaration bundler, `FinanceRouter` is the generic `AnyTRPCRouter` —
- * consumers using `pillar<FinanceRouter>('finance')` get the router shape
- * but lose per-procedure typing. The committed OpenAPI snapshot at
- * `openapi/finance.openapi.json` is the wire-typed alternative.
+ * consumers using `pillar<FinanceRouter>('finance')` get a fully opaque
+ * `PillarHandle` with no route or procedure keys preserved. The committed
+ * OpenAPI snapshot at `openapi/finance.openapi.json` is the wire-typed
+ * alternative until PRD-155 lands.
  *
  * This shape was previously `typeof financeRouter` (re-exporting from
  * `@pops/finance-api`), but that import-type closed a build-graph cycle

--- a/packages/pillar-sdk/package.json
+++ b/packages/pillar-sdk/package.json
@@ -59,6 +59,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@pops/finance-contract": "workspace:*",
     "@tanstack/react-query": "5.101.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1813,13 +1813,13 @@ importers:
       '@pops/types':
         specifier: workspace:*
         version: link:../types
+      '@trpc/server':
+        specifier: ^11.17.0
+        version: 11.17.0(typescript@6.0.3)
       zod:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
-      '@pops/finance-api':
-        specifier: workspace:*
-        version: link:../../apps/pops-finance-api
       tsx:
         specifier: ^4.22.4
         version: 4.22.4
@@ -2183,13 +2183,13 @@ importers:
 
   packages/pillar-sdk:
     dependencies:
-      '@pops/finance-contract':
-        specifier: workspace:*
-        version: link:../finance-contract
       zod:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@pops/finance-contract':
+        specifier: workspace:*
+        version: link:../finance-contract
       '@tanstack/react-query':
         specifier: 5.101.0
         version: 5.101.0(react@19.2.7)


### PR DESCRIPTION
## Summary

- Breaks the `pillar-sdk → finance-contract → finance-api → pillar-sdk` workspace cycle that has been closed since `@pops/finance-contract` shipped. Even though the offending edge was a single `import type { financeRouter } from '@pops/finance-api/router'`, it was enough to make turbo's `^build` graph cyclic, so every CI workflow that touches pillar-sdk (`Affected rebuild`, `Backend Tests`, `quality`, `_pkg-check`) had to hand-roll a 13-package pre-build chain before turbo could schedule anything.
- Replaces `export type FinanceRouter = typeof financeRouter` with an opaque `FinanceRouter = AnyTRPCRouter` from `@trpc/server`. Consumers using `pillar<FinanceRouter>('finance')` keep the router shape but lose per-procedure typing until PRD-155 ships the declaration bundler. The committed wire-typed alternative at `packages/finance-contract/openapi/finance.openapi.json` is unchanged.
- Fixes the graph so turbo can rebuild finance-contract before pillar-sdk on its own: `@pops/finance-contract` is now a direct devDependency of pillar-sdk (the optional peer entry stays for runtime opt-in semantics), and `@pops/finance-api` is dropped from finance-contract's devDependencies (the import-type was its only reason to be there).

## Why

This cycle is the root cause of the recurring "we just added another contract package and CI is exploding again" patches — every new contract triggers another round of "remember to add it to every workflow's pre-build chain." Examples currently in flight on other branches:

- `fix/contract-semver-pre-build-chain`
- `fix/api-workflows-pre-build-finance-contract`
- `fix/pkg-check-pillar-sdk-before-other-contracts`
- `fix/semver-build-order-pillar-sdk`
- `fix/contract-semver-build-order`

Breaking the cycle once lets turbo's `^build` schedule do its job, reclaims 1–4 minutes per CI run on the affected workflows, and stops the workflow patches from piling up. The pre-build chains in `.github/workflows/*.yml` are intentionally left in place in this PR for safety — a follow-up will reclaim that time once the cycle break is verified stable on main.

## Verification

Locally on `fix/break-pillar-sdk-cycle`:

- `pnpm -F @pops/finance-contract build` — green.
- `pnpm -F @pops/finance-contract test` — 3 files / 39 tests pass.
- `pnpm -F @pops/pillar-sdk build` — green.
- `pnpm -F @pops/pillar-sdk test` — 22 files / 274 tests pass.
- `pnpm exec turbo run build --filter='@pops/pillar-sdk^...' --dry-run=json` — lists `@pops/finance-contract` + `@pops/types` in the rebuild scope, no cycle warning.
- `pnpm -w typecheck` — 66/66 tasks green.
- `mise lint` — exit 0 (warnings only, pre-existing).

## Snapshot churn

`packages/finance-contract/etc/finance-contract.api.json` and `.zod.json` regenerate as part of this change. Two kinds of diff appear:

- `FinanceRouter`: text flips from `typeof financeRouter` to `AnyTRPCRouter` — expected.
- Budget/Entity/Transaction entries appear for the first time — stale from #2981 (the snapshots weren't regenerated in that PR). Picked up as a drive-by; they match the current contract surface.

## Test plan

- [ ] Wait for `Affected rebuild` to pass without the pre-build chain having to do extra work.
- [ ] Confirm `Backend Tests`, `quality`, `_pkg-check` are all green.
- [ ] Sanity-check a pillar consumer still compiles against `FinanceRouter` (lossy types are the intended cost until PRD-155).
