### PR TITLE
feat(media-db): scaffold watch-history service + baseline migration (PRD-168 US-01)

### DIFF
--- a/apps/pops-api/src/db/backfill-media-from-shared.test.ts
+++ b/apps/pops-api/src/db/backfill-media-from-shared.test.ts
@@ -25,6 +25,7 @@ import {
   MOVIES_TABLE_SQL,
   SHELF_IMPRESSIONS_TABLE_SQL,
   TV_SHOWS_TABLE_SQL,
+  WATCH_HISTORY_TABLE_SQL,
 } from './backfill-test-fixtures.js';
 
 let tmpDir: string;
@@ -446,6 +447,130 @@ describe('backfillMediaFromShared', () => {
 
       expect(() => backfillMediaFromShared()).not.toThrow();
       const count = media.raw.prepare('SELECT count(*) AS n FROM movies').get() as { n: number };
+      expect(count.n).toBe(0);
+    });
+  });
+
+  describe('watch_history (PRD-168 PR 1)', () => {
+    interface WatchHistorySeed {
+      mediaType: 'movie' | 'episode';
+      mediaId: number;
+      watchedAt: string;
+      completed?: number;
+      blacklisted?: number;
+    }
+
+    function openSharedWithWatchHistory(rows: WatchHistorySeed[]): string {
+      const path = join(tmpDir, 'pops.db');
+      const raw = new BetterSqlite3(path);
+      raw.exec(SHELF_IMPRESSIONS_TABLE_SQL);
+      raw.exec(WATCH_HISTORY_TABLE_SQL);
+      const insert = raw.prepare(
+        'INSERT INTO watch_history (media_type, media_id, watched_at, completed, blacklisted) VALUES (?, ?, ?, ?, ?)'
+      );
+      for (const row of rows) {
+        insert.run(
+          row.mediaType,
+          row.mediaId,
+          row.watchedAt,
+          row.completed ?? 1,
+          row.blacklisted ?? 0
+        );
+      }
+      raw.close();
+      process.env['SQLITE_PATH'] = path;
+      return path;
+    }
+
+    it('copies fresh watch_history rows on first run and is a no-op on the second', () => {
+      openSharedWithWatchHistory([
+        { mediaType: 'movie', mediaId: 603, watchedAt: '2026-06-01 12:00:00' },
+        { mediaType: 'episode', mediaId: 42, watchedAt: '2026-06-02 18:00:00' },
+      ]);
+      const media = openMediaDb(join(tmpDir, 'media.db'));
+      setMediaDb(media);
+
+      backfillMediaFromShared();
+      const after = media.raw
+        .prepare('SELECT id, media_type, media_id FROM watch_history ORDER BY id')
+        .all() as { id: number; media_type: string; media_id: number }[];
+      expect(after.map((r) => r.media_id)).toEqual([603, 42]);
+
+      backfillMediaFromShared();
+      const second = media.raw.prepare('SELECT count(*) AS n FROM watch_history').get() as {
+        n: number;
+      };
+      expect(second.n).toBe(2);
+    });
+
+    it('only inserts watch_history rows missing from the media copy', () => {
+      openSharedWithWatchHistory([
+        { mediaType: 'movie', mediaId: 603, watchedAt: '2026-06-01 12:00:00' },
+        { mediaType: 'episode', mediaId: 42, watchedAt: '2026-06-02 18:00:00' },
+      ]);
+      const media = openMediaDb(join(tmpDir, 'media.db'));
+      setMediaDb(media);
+      // Pre-seed id=1 with a different (media_type, media_id, watched_at)
+      // tuple so the backfill skips it by id and the unique index doesn't
+      // conflict with the id=2 carry-over.
+      media.raw
+        .prepare(
+          'INSERT INTO watch_history (id, media_type, media_id, watched_at) VALUES (?, ?, ?, ?)'
+        )
+        .run(1, 'movie', 99_999, '2026-05-01 00:00:00');
+
+      backfillMediaFromShared();
+      const rows = media.raw
+        .prepare('SELECT id, media_type, media_id FROM watch_history ORDER BY id')
+        .all() as { id: number; media_type: string; media_id: number }[];
+      expect(rows).toEqual([
+        { id: 1, media_type: 'movie', media_id: 99_999 },
+        { id: 2, media_type: 'episode', media_id: 42 },
+      ]);
+    });
+
+    it('carries every column across (full-shape roundtrip)', () => {
+      openSharedWithWatchHistory([
+        {
+          mediaType: 'episode',
+          mediaId: 12_345,
+          watchedAt: '2026-06-03 21:30:00',
+          completed: 0,
+          blacklisted: 1,
+        },
+      ]);
+      const media = openMediaDb(join(tmpDir, 'media.db'));
+      setMediaDb(media);
+      backfillMediaFromShared();
+
+      const row = media.raw
+        .prepare('SELECT * FROM watch_history WHERE media_id = ?')
+        .get(12_345) as Record<string, unknown>;
+      expect(row).toMatchObject({
+        media_type: 'episode',
+        media_id: 12_345,
+        watched_at: '2026-06-03 21:30:00',
+        completed: 0,
+        blacklisted: 1,
+      });
+    });
+
+    it('tolerates a shared DB without the watch_history table', () => {
+      // Shared DB has shelf_impressions but no watch_history — backfill
+      // copies shelf rows and skips watch_history without throwing.
+      const path = join(tmpDir, 'pops.db');
+      const raw = new BetterSqlite3(path);
+      raw.exec(SHELF_IMPRESSIONS_TABLE_SQL);
+      raw.close();
+      process.env['SQLITE_PATH'] = path;
+
+      const media = openMediaDb(join(tmpDir, 'media.db'));
+      setMediaDb(media);
+
+      expect(() => backfillMediaFromShared()).not.toThrow();
+      const count = media.raw.prepare('SELECT count(*) AS n FROM watch_history').get() as {
+        n: number;
+      };
       expect(count.n).toBe(0);
     });
   });

--- a/apps/pops-api/src/db/backfill-test-fixtures-core.ts
+++ b/apps/pops-api/src/db/backfill-test-fixtures-core.ts
@@ -1,0 +1,22 @@
+/**
+ * SQL fixtures for the core-pillar backfill suite. Split out of
+ * `backfill-test-fixtures.ts` to keep each file under the 200-line cap.
+ * See that module's header for why these DDLs live alongside the tests.
+ */
+export const SERVICE_ACCOUNTS_TABLE_SQL = `
+CREATE TABLE service_accounts (
+  id text PRIMARY KEY NOT NULL,
+  name text NOT NULL,
+  key_prefix text NOT NULL,
+  key_hash text NOT NULL,
+  scopes text DEFAULT '[]' NOT NULL,
+  created_at text DEFAULT (datetime('now')) NOT NULL,
+  last_used_at text,
+  revoked_at text,
+  created_by text
+);
+CREATE UNIQUE INDEX service_accounts_name_unique ON service_accounts (name);
+CREATE UNIQUE INDEX service_accounts_key_prefix_unique ON service_accounts (key_prefix);
+CREATE INDEX idx_service_accounts_key_prefix ON service_accounts (key_prefix);
+CREATE INDEX idx_service_accounts_revoked_at ON service_accounts (revoked_at);
+`;

--- a/apps/pops-api/src/db/backfill-test-fixtures-finance.ts
+++ b/apps/pops-api/src/db/backfill-test-fixtures-finance.ts
@@ -1,0 +1,122 @@
+/**
+ * SQL fixtures for the finance-pillar backfill suite. Split out of
+ * `backfill-test-fixtures.ts` to keep each file under the 200-line cap.
+ * See that module's header for why these DDLs live alongside the tests.
+ */
+export const WISH_LIST_TABLE_SQL = `
+CREATE TABLE wish_list (
+  id text PRIMARY KEY NOT NULL,
+  notion_id text,
+  item text NOT NULL,
+  target_amount real,
+  saved real,
+  priority text,
+  url text,
+  notes text,
+  last_edited_time text NOT NULL
+);
+CREATE UNIQUE INDEX wish_list_notion_id_unique ON wish_list (notion_id);
+`;
+
+export const ENTITIES_TABLE_SQL = `
+CREATE TABLE entities (
+  id text PRIMARY KEY NOT NULL,
+  notion_id text,
+  name text NOT NULL,
+  type text DEFAULT 'company' NOT NULL,
+  abn text,
+  aliases text,
+  default_transaction_type text,
+  default_tags text,
+  notes text,
+  last_edited_time text NOT NULL
+);
+CREATE UNIQUE INDEX entities_notion_id_unique ON entities (notion_id);
+`;
+
+export const TRANSACTIONS_TABLE_SQL = `
+CREATE TABLE transactions (
+  id text PRIMARY KEY NOT NULL,
+  notion_id text,
+  description text NOT NULL,
+  account text NOT NULL,
+  amount real NOT NULL,
+  date text NOT NULL,
+  type text NOT NULL,
+  tags text DEFAULT '[]' NOT NULL,
+  entity_id text,
+  entity_name text,
+  location text,
+  country text,
+  related_transaction_id text,
+  notes text,
+  checksum text,
+  raw_row text,
+  last_edited_time text NOT NULL,
+  FOREIGN KEY (entity_id) REFERENCES entities(id) ON UPDATE no action ON DELETE set null
+);
+CREATE UNIQUE INDEX transactions_notion_id_unique ON transactions (notion_id);
+CREATE INDEX idx_transactions_date ON transactions (date);
+CREATE UNIQUE INDEX idx_transactions_checksum ON transactions (checksum);
+`;
+
+export const TRANSACTION_CORRECTIONS_TABLE_SQL = `
+CREATE TABLE transaction_corrections (
+  id text PRIMARY KEY NOT NULL,
+  description_pattern text NOT NULL,
+  match_type text DEFAULT 'exact' NOT NULL,
+  entity_id text,
+  entity_name text,
+  location text,
+  tags text DEFAULT '[]' NOT NULL,
+  transaction_type text,
+  is_active integer DEFAULT 1 NOT NULL,
+  confidence real DEFAULT 0.5 NOT NULL,
+  priority integer DEFAULT 0 NOT NULL,
+  times_applied integer DEFAULT 0 NOT NULL,
+  created_at text DEFAULT (datetime('now')) NOT NULL,
+  last_used_at text,
+  FOREIGN KEY (entity_id) REFERENCES entities(id) ON UPDATE no action ON DELETE set null
+);
+`;
+
+export const TRANSACTION_TAG_RULES_TABLE_SQL = `
+CREATE TABLE transaction_tag_rules (
+  id text PRIMARY KEY NOT NULL,
+  description_pattern text NOT NULL,
+  match_type text DEFAULT 'exact' NOT NULL,
+  entity_id text,
+  tags text DEFAULT '[]' NOT NULL,
+  is_active integer DEFAULT 1 NOT NULL,
+  confidence real DEFAULT 0.5 NOT NULL,
+  priority integer DEFAULT 0 NOT NULL,
+  times_applied integer DEFAULT 0 NOT NULL,
+  created_at text DEFAULT (datetime('now')) NOT NULL,
+  last_used_at text,
+  FOREIGN KEY (entity_id) REFERENCES entities(id) ON UPDATE no action ON DELETE set null
+);
+`;
+
+export const TAG_VOCABULARY_TABLE_SQL = `
+CREATE TABLE tag_vocabulary (
+  tag text PRIMARY KEY NOT NULL,
+  source text DEFAULT 'seed' NOT NULL,
+  is_active integer DEFAULT true NOT NULL,
+  created_at text DEFAULT (datetime('now')) NOT NULL
+);
+`;
+
+export const BUDGETS_TABLE_SQL = `
+CREATE TABLE budgets (
+  id text PRIMARY KEY NOT NULL,
+  notion_id text,
+  category text NOT NULL,
+  period text,
+  amount real,
+  active integer DEFAULT 0 NOT NULL,
+  notes text,
+  last_edited_time text NOT NULL
+);
+CREATE UNIQUE INDEX budgets_notion_id_unique ON budgets (notion_id);
+CREATE UNIQUE INDEX idx_budgets_category_period ON budgets (category, COALESCE(period, char(0)));
+`;

--- a/apps/pops-api/src/db/backfill-test-fixtures-media.ts
+++ b/apps/pops-api/src/db/backfill-test-fixtures-media.ts
@@ -1,0 +1,93 @@
+/**
+ * SQL fixtures for the media-pillar backfill suite. Split out of
+ * `backfill-test-fixtures.ts` to keep each file under the 200-line cap.
+ * See that module's header for why these DDLs live alongside the tests.
+ */
+export const SHELF_IMPRESSIONS_TABLE_SQL = `
+CREATE TABLE shelf_impressions (
+  id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  shelf_id text NOT NULL,
+  shown_at text DEFAULT (datetime('now')) NOT NULL
+);
+CREATE INDEX idx_shelf_impressions_shelf_id ON shelf_impressions (shelf_id);
+`;
+
+export const MOVIES_TABLE_SQL = `
+CREATE TABLE movies (
+  id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  tmdb_id integer NOT NULL,
+  imdb_id text,
+  title text NOT NULL,
+  original_title text,
+  overview text,
+  tagline text,
+  release_date text,
+  runtime integer,
+  status text,
+  original_language text,
+  budget integer,
+  revenue integer,
+  poster_path text,
+  backdrop_path text,
+  logo_path text,
+  poster_override_path text,
+  discover_rating_key text,
+  vote_average real,
+  vote_count integer,
+  genres text,
+  created_at text DEFAULT (datetime('now')) NOT NULL,
+  updated_at text DEFAULT (datetime('now')) NOT NULL,
+  rotation_status text,
+  rotation_expires_at text,
+  rotation_marked_at text
+);
+CREATE INDEX idx_movies_rotation_status ON movies (rotation_status);
+CREATE UNIQUE INDEX idx_movies_tmdb_id ON movies (tmdb_id);
+CREATE INDEX idx_movies_title ON movies (title);
+CREATE INDEX idx_movies_release_date ON movies (release_date);
+`;
+
+export const TV_SHOWS_TABLE_SQL = `
+CREATE TABLE tv_shows (
+  id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  tvdb_id integer NOT NULL,
+  name text NOT NULL,
+  original_name text,
+  overview text,
+  first_air_date text,
+  last_air_date text,
+  status text,
+  original_language text,
+  number_of_seasons integer,
+  number_of_episodes integer,
+  episode_run_time integer,
+  poster_path text,
+  backdrop_path text,
+  logo_path text,
+  poster_override_path text,
+  discover_rating_key text,
+  vote_average real,
+  vote_count integer,
+  genres text,
+  networks text,
+  created_at text DEFAULT (datetime('now')) NOT NULL,
+  updated_at text DEFAULT (datetime('now')) NOT NULL
+);
+CREATE UNIQUE INDEX idx_tv_shows_tvdb_id ON tv_shows (tvdb_id);
+CREATE INDEX idx_tv_shows_name ON tv_shows (name);
+CREATE INDEX idx_tv_shows_first_air_date ON tv_shows (first_air_date);
+`;
+
+export const WATCH_HISTORY_TABLE_SQL = `
+CREATE TABLE watch_history (
+  id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  media_type text NOT NULL,
+  media_id integer NOT NULL,
+  watched_at text DEFAULT (datetime('now')) NOT NULL,
+  completed integer DEFAULT 1 NOT NULL,
+  blacklisted integer DEFAULT 0 NOT NULL
+);
+CREATE INDEX idx_watch_history_media ON watch_history (media_type, media_id);
+CREATE INDEX idx_watch_history_watched_at ON watch_history (watched_at);
+CREATE UNIQUE INDEX idx_watch_history_unique ON watch_history (media_type, media_id, watched_at);
+`;

--- a/apps/pops-api/src/db/backfill-test-fixtures.ts
+++ b/apps/pops-api/src/db/backfill-test-fixtures.ts
@@ -101,6 +101,20 @@ CREATE INDEX idx_tv_shows_name ON tv_shows (name);
 CREATE INDEX idx_tv_shows_first_air_date ON tv_shows (first_air_date);
 `;
 
+export const WATCH_HISTORY_TABLE_SQL = `
+CREATE TABLE watch_history (
+  id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  media_type text NOT NULL,
+  media_id integer NOT NULL,
+  watched_at text DEFAULT (datetime('now')) NOT NULL,
+  completed integer DEFAULT 1 NOT NULL,
+  blacklisted integer DEFAULT 0 NOT NULL
+);
+CREATE INDEX idx_watch_history_media ON watch_history (media_type, media_id);
+CREATE INDEX idx_watch_history_watched_at ON watch_history (watched_at);
+CREATE UNIQUE INDEX idx_watch_history_unique ON watch_history (media_type, media_id, watched_at);
+`;
+
 export const WISH_LIST_TABLE_SQL = `
 CREATE TABLE wish_list (
   id text PRIMARY KEY NOT NULL,

--- a/apps/pops-api/src/db/backfill-test-fixtures.ts
+++ b/apps/pops-api/src/db/backfill-test-fixtures.ts
@@ -7,228 +7,24 @@
  * byte-identical migration that lands in both
  * `apps/pops-api/src/db/drizzle-migrations/` and
  * `packages/<id>-db/migrations/`.
+ *
+ * Split across per-pillar siblings (`backfill-test-fixtures-core.ts`,
+ * `-media.ts`, `-finance.ts`) so each file stays under the 200-line
+ * lint cap. This barrel keeps the existing import surface stable.
  */
-export const SERVICE_ACCOUNTS_TABLE_SQL = `
-CREATE TABLE service_accounts (
-  id text PRIMARY KEY NOT NULL,
-  name text NOT NULL,
-  key_prefix text NOT NULL,
-  key_hash text NOT NULL,
-  scopes text DEFAULT '[]' NOT NULL,
-  created_at text DEFAULT (datetime('now')) NOT NULL,
-  last_used_at text,
-  revoked_at text,
-  created_by text
-);
-CREATE UNIQUE INDEX service_accounts_name_unique ON service_accounts (name);
-CREATE UNIQUE INDEX service_accounts_key_prefix_unique ON service_accounts (key_prefix);
-CREATE INDEX idx_service_accounts_key_prefix ON service_accounts (key_prefix);
-CREATE INDEX idx_service_accounts_revoked_at ON service_accounts (revoked_at);
-`;
-
-export const SHELF_IMPRESSIONS_TABLE_SQL = `
-CREATE TABLE shelf_impressions (
-  id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
-  shelf_id text NOT NULL,
-  shown_at text DEFAULT (datetime('now')) NOT NULL
-);
-CREATE INDEX idx_shelf_impressions_shelf_id ON shelf_impressions (shelf_id);
-`;
-
-export const MOVIES_TABLE_SQL = `
-CREATE TABLE movies (
-  id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
-  tmdb_id integer NOT NULL,
-  imdb_id text,
-  title text NOT NULL,
-  original_title text,
-  overview text,
-  tagline text,
-  release_date text,
-  runtime integer,
-  status text,
-  original_language text,
-  budget integer,
-  revenue integer,
-  poster_path text,
-  backdrop_path text,
-  logo_path text,
-  poster_override_path text,
-  discover_rating_key text,
-  vote_average real,
-  vote_count integer,
-  genres text,
-  created_at text DEFAULT (datetime('now')) NOT NULL,
-  updated_at text DEFAULT (datetime('now')) NOT NULL,
-  rotation_status text,
-  rotation_expires_at text,
-  rotation_marked_at text
-);
-CREATE INDEX idx_movies_rotation_status ON movies (rotation_status);
-CREATE UNIQUE INDEX idx_movies_tmdb_id ON movies (tmdb_id);
-CREATE INDEX idx_movies_title ON movies (title);
-CREATE INDEX idx_movies_release_date ON movies (release_date);
-`;
-
-export const TV_SHOWS_TABLE_SQL = `
-CREATE TABLE tv_shows (
-  id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
-  tvdb_id integer NOT NULL,
-  name text NOT NULL,
-  original_name text,
-  overview text,
-  first_air_date text,
-  last_air_date text,
-  status text,
-  original_language text,
-  number_of_seasons integer,
-  number_of_episodes integer,
-  episode_run_time integer,
-  poster_path text,
-  backdrop_path text,
-  logo_path text,
-  poster_override_path text,
-  discover_rating_key text,
-  vote_average real,
-  vote_count integer,
-  genres text,
-  networks text,
-  created_at text DEFAULT (datetime('now')) NOT NULL,
-  updated_at text DEFAULT (datetime('now')) NOT NULL
-);
-CREATE UNIQUE INDEX idx_tv_shows_tvdb_id ON tv_shows (tvdb_id);
-CREATE INDEX idx_tv_shows_name ON tv_shows (name);
-CREATE INDEX idx_tv_shows_first_air_date ON tv_shows (first_air_date);
-`;
-
-export const WATCH_HISTORY_TABLE_SQL = `
-CREATE TABLE watch_history (
-  id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
-  media_type text NOT NULL,
-  media_id integer NOT NULL,
-  watched_at text DEFAULT (datetime('now')) NOT NULL,
-  completed integer DEFAULT 1 NOT NULL,
-  blacklisted integer DEFAULT 0 NOT NULL
-);
-CREATE INDEX idx_watch_history_media ON watch_history (media_type, media_id);
-CREATE INDEX idx_watch_history_watched_at ON watch_history (watched_at);
-CREATE UNIQUE INDEX idx_watch_history_unique ON watch_history (media_type, media_id, watched_at);
-`;
-
-export const WISH_LIST_TABLE_SQL = `
-CREATE TABLE wish_list (
-  id text PRIMARY KEY NOT NULL,
-  notion_id text,
-  item text NOT NULL,
-  target_amount real,
-  saved real,
-  priority text,
-  url text,
-  notes text,
-  last_edited_time text NOT NULL
-);
-CREATE UNIQUE INDEX wish_list_notion_id_unique ON wish_list (notion_id);
-`;
-
-export const ENTITIES_TABLE_SQL = `
-CREATE TABLE entities (
-  id text PRIMARY KEY NOT NULL,
-  notion_id text,
-  name text NOT NULL,
-  type text DEFAULT 'company' NOT NULL,
-  abn text,
-  aliases text,
-  default_transaction_type text,
-  default_tags text,
-  notes text,
-  last_edited_time text NOT NULL
-);
-CREATE UNIQUE INDEX entities_notion_id_unique ON entities (notion_id);
-`;
-
-export const TRANSACTIONS_TABLE_SQL = `
-CREATE TABLE transactions (
-  id text PRIMARY KEY NOT NULL,
-  notion_id text,
-  description text NOT NULL,
-  account text NOT NULL,
-  amount real NOT NULL,
-  date text NOT NULL,
-  type text NOT NULL,
-  tags text DEFAULT '[]' NOT NULL,
-  entity_id text,
-  entity_name text,
-  location text,
-  country text,
-  related_transaction_id text,
-  notes text,
-  checksum text,
-  raw_row text,
-  last_edited_time text NOT NULL,
-  FOREIGN KEY (entity_id) REFERENCES entities(id) ON UPDATE no action ON DELETE set null
-);
-CREATE UNIQUE INDEX transactions_notion_id_unique ON transactions (notion_id);
-CREATE INDEX idx_transactions_date ON transactions (date);
-CREATE UNIQUE INDEX idx_transactions_checksum ON transactions (checksum);
-`;
-
-export const TRANSACTION_CORRECTIONS_TABLE_SQL = `
-CREATE TABLE transaction_corrections (
-  id text PRIMARY KEY NOT NULL,
-  description_pattern text NOT NULL,
-  match_type text DEFAULT 'exact' NOT NULL,
-  entity_id text,
-  entity_name text,
-  location text,
-  tags text DEFAULT '[]' NOT NULL,
-  transaction_type text,
-  is_active integer DEFAULT 1 NOT NULL,
-  confidence real DEFAULT 0.5 NOT NULL,
-  priority integer DEFAULT 0 NOT NULL,
-  times_applied integer DEFAULT 0 NOT NULL,
-  created_at text DEFAULT (datetime('now')) NOT NULL,
-  last_used_at text,
-  FOREIGN KEY (entity_id) REFERENCES entities(id) ON UPDATE no action ON DELETE set null
-);
-`;
-
-export const TRANSACTION_TAG_RULES_TABLE_SQL = `
-CREATE TABLE transaction_tag_rules (
-  id text PRIMARY KEY NOT NULL,
-  description_pattern text NOT NULL,
-  match_type text DEFAULT 'exact' NOT NULL,
-  entity_id text,
-  tags text DEFAULT '[]' NOT NULL,
-  is_active integer DEFAULT 1 NOT NULL,
-  confidence real DEFAULT 0.5 NOT NULL,
-  priority integer DEFAULT 0 NOT NULL,
-  times_applied integer DEFAULT 0 NOT NULL,
-  created_at text DEFAULT (datetime('now')) NOT NULL,
-  last_used_at text,
-  FOREIGN KEY (entity_id) REFERENCES entities(id) ON UPDATE no action ON DELETE set null
-);
-`;
-
-export const TAG_VOCABULARY_TABLE_SQL = `
-CREATE TABLE tag_vocabulary (
-  tag text PRIMARY KEY NOT NULL,
-  source text DEFAULT 'seed' NOT NULL,
-  is_active integer DEFAULT true NOT NULL,
-  created_at text DEFAULT (datetime('now')) NOT NULL
-);
-`;
-
-export const BUDGETS_TABLE_SQL = `
-CREATE TABLE budgets (
-  id text PRIMARY KEY NOT NULL,
-  notion_id text,
-  category text NOT NULL,
-  period text,
-  amount real,
-  active integer DEFAULT 0 NOT NULL,
-  notes text,
-  last_edited_time text NOT NULL
-);
-CREATE UNIQUE INDEX budgets_notion_id_unique ON budgets (notion_id);
-CREATE UNIQUE INDEX idx_budgets_category_period ON budgets (category, COALESCE(period, char(0)));
-`;
+export { SERVICE_ACCOUNTS_TABLE_SQL } from './backfill-test-fixtures-core.js';
+export {
+  MOVIES_TABLE_SQL,
+  SHELF_IMPRESSIONS_TABLE_SQL,
+  TV_SHOWS_TABLE_SQL,
+  WATCH_HISTORY_TABLE_SQL,
+} from './backfill-test-fixtures-media.js';
+export {
+  BUDGETS_TABLE_SQL,
+  ENTITIES_TABLE_SQL,
+  TAG_VOCABULARY_TABLE_SQL,
+  TRANSACTION_CORRECTIONS_TABLE_SQL,
+  TRANSACTION_TAG_RULES_TABLE_SQL,
+  TRANSACTIONS_TABLE_SQL,
+  WISH_LIST_TABLE_SQL,
+} from './backfill-test-fixtures-finance.js';

--- a/apps/pops-api/src/db/media-backfill.ts
+++ b/apps/pops-api/src/db/media-backfill.ts
@@ -5,11 +5,12 @@ import { resolveSqlitePath } from './sqlite-path.js';
  * pillar's `media.db`.
  *
  * Each slice cutover (Phase 2 PR 3 shelf-impressions, PRD-165 movies,
- * PRD-166 tv-shows, …) flips its handle to `getMediaDrizzle()`. The
- * first deploy after each cutover needs to carry the existing rows from
- * the shared DB across before any reads come from the new file.
- * Subsequent boots find the media copy already populated and become a
- * no-op via the `WHERE id NOT IN (...)` existence filter on every table.
+ * PRD-166 tv-shows, PRD-168 watch history, …) flips its handle to
+ * `getMediaDrizzle()`. The first deploy after each cutover needs to
+ * carry the existing rows from the shared DB across before any reads
+ * come from the new file. Subsequent boots find the media copy already
+ * populated and become a no-op via the `WHERE id NOT IN (...)`
+ * existence filter on every table.
  *
  * No FK relationships exist between the listed media tables, so order
  * is independent — but each entry is wrapped in `tryCopyTable` so a
@@ -103,6 +104,11 @@ const TABLE_COPIES: readonly TableCopy[] = [
       'created_at',
       'updated_at',
     ],
+  },
+  {
+    table: 'watch_history',
+    idColumn: 'id',
+    columns: ['id', 'media_type', 'media_id', 'watched_at', 'completed', 'blacklisted'],
   },
 ];
 

--- a/apps/pops-api/src/db/per-pillar-migrations.test.ts
+++ b/apps/pops-api/src/db/per-pillar-migrations.test.ts
@@ -208,7 +208,8 @@ describe('runPerPillarMigrations', () => {
     // with 0021_spooky_lockheed (media pillar Phase 1 PR 2),
     // 0022_media_movies_baseline (Theme 13 PRD-165 US-01 — movies baseline),
     // 0023_watchlist_baseline (Theme 13 PRD-167 PR 1 — watchlist baseline),
-    // and 0024_media_tv_shows_baseline (Theme 13 PRD-166 US-01 — tv-shows baseline);
+    // 0024_media_tv_shows_baseline (Theme 13 PRD-166 US-01 — tv-shows baseline),
+    // and 0025_media_watch_history_baseline (Theme 13 PRD-168 PR 1 — watch-history baseline);
     // `inventory` owns `packages/inventory-db/migrations/` with
     // 0005_fancy_crystal (inventory pillar Phase 1 PR 2),
     // 0006_inventory_pillar_baseline (inventory pillar Phase 2 PR 3 —
@@ -236,6 +237,7 @@ describe('runPerPillarMigrations', () => {
         '0022_media_movies_baseline',
         '0023_watchlist_baseline',
         '0024_media_tv_shows_baseline',
+        '0025_media_watch_history_baseline',
         '0039_dry_fabian_cortez',
         '0044_nudge_log',
         '0054_service_accounts',

--- a/packages/media-db/migrations/0025_media_watch_history_baseline.sql
+++ b/packages/media-db/migrations/0025_media_watch_history_baseline.sql
@@ -1,0 +1,12 @@
+CREATE TABLE `watch_history` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`media_type` text NOT NULL,
+	`media_id` integer NOT NULL,
+	`watched_at` text DEFAULT (datetime('now')) NOT NULL,
+	`completed` integer DEFAULT 1 NOT NULL,
+	`blacklisted` integer DEFAULT 0 NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `idx_watch_history_media` ON `watch_history` (`media_type`,`media_id`);--> statement-breakpoint
+CREATE INDEX `idx_watch_history_watched_at` ON `watch_history` (`watched_at`);--> statement-breakpoint
+CREATE UNIQUE INDEX `idx_watch_history_unique` ON `watch_history` (`media_type`,`media_id`,`watched_at`);

--- a/packages/media-db/migrations/meta/_journal.json
+++ b/packages/media-db/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1788000000000,
       "tag": "0024_media_tv_shows_baseline",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1790000000000,
+      "tag": "0025_media_watch_history_baseline",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/media-db/src/__tests__/watch-history.test.ts
+++ b/packages/media-db/src/__tests__/watch-history.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Invariant tests for the watch-history service against an in-memory
+ * SQLite seeded with the canonical `0025_media_watch_history_baseline.sql`
+ * migration. Pure DB + service layer — no tRPC, no Express, no
+ * cross-table orchestration (debrief sessions, watchlist auto-removal,
+ * comparison staleness reset, …) which stays at the router layer until
+ * the dependent tables are themselves resident here.
+ *
+ * Higher-level CRUD integration coverage lives in pops-api's own suite
+ * (`apps/pops-api/src/modules/media/watch-history/**`) and continues to
+ * exercise the same persisted shape via the in-tree handlers until
+ * PRD-168 PR 3 flips them onto this service.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { WatchHistoryConflictError, WatchHistoryNotFoundError } from '../errors.js';
+import {
+  add,
+  byDateRange,
+  byItem,
+  delete as deleteEntry,
+  getById,
+  list,
+  update,
+  type AddWatchHistoryInput,
+} from '../services/watch-history.js';
+
+import type { MediaDb } from '../services/internal.js';
+
+const MIGRATION_PATH = join(__dirname, '../../migrations/0025_media_watch_history_baseline.sql');
+
+function freshDb(): { db: MediaDb; raw: Database.Database } {
+  const raw = new Database(':memory:');
+  raw.pragma('foreign_keys = ON');
+  const sql = readFileSync(MIGRATION_PATH, 'utf8');
+  for (const stmt of sql.split('--> statement-breakpoint')) {
+    const trimmed = stmt.trim();
+    if (trimmed.length > 0) raw.exec(trimmed);
+  }
+  return { db: drizzle(raw), raw };
+}
+
+function baseInput(overrides: Partial<AddWatchHistoryInput> = {}): AddWatchHistoryInput {
+  return {
+    mediaType: 'movie',
+    mediaId: 603,
+    watchedAt: '2026-06-01 12:00:00',
+    ...overrides,
+  };
+}
+
+describe('add', () => {
+  let db: MediaDb;
+  beforeEach(() => {
+    ({ db } = freshDb());
+  });
+
+  it('persists the row and returns it with an assigned id', () => {
+    const row = add(db, baseInput());
+    expect(row.id).toBeGreaterThan(0);
+    expect(row.mediaType).toBe('movie');
+    expect(row.mediaId).toBe(603);
+    expect(row.watchedAt).toBe('2026-06-01 12:00:00');
+  });
+
+  it('defaults completed to 1 when omitted', () => {
+    const row = add(db, baseInput());
+    expect(row.completed).toBe(1);
+  });
+
+  it('defaults blacklisted to 0 when omitted', () => {
+    const row = add(db, baseInput());
+    expect(row.blacklisted).toBe(0);
+  });
+
+  it('respects an explicit completed = 0 (partial watch)', () => {
+    const row = add(db, baseInput({ completed: 0 }));
+    expect(row.completed).toBe(0);
+  });
+
+  it('respects an explicit blacklisted = 1 (do-not-recommend marker)', () => {
+    const row = add(db, baseInput({ blacklisted: 1 }));
+    expect(row.blacklisted).toBe(1);
+  });
+
+  it('throws WatchHistoryConflictError on duplicate (mediaType, mediaId, watchedAt)', () => {
+    add(db, baseInput());
+    expect(() => add(db, baseInput())).toThrow(WatchHistoryConflictError);
+  });
+
+  it('allows multiple rows for the same item at different watched_at values', () => {
+    const a = add(db, baseInput({ watchedAt: '2026-06-01 12:00:00' }));
+    const b = add(db, baseInput({ watchedAt: '2026-06-02 12:00:00' }));
+    expect(a.id).not.toBe(b.id);
+  });
+});
+
+describe('getById', () => {
+  let db: MediaDb;
+  beforeEach(() => {
+    ({ db } = freshDb());
+  });
+
+  it('returns the persisted row by id', () => {
+    const created = add(db, baseInput());
+    expect(getById(db, created.id)).toEqual(created);
+  });
+
+  it('throws WatchHistoryNotFoundError when the id is missing', () => {
+    expect(() => getById(db, 9_999)).toThrow(WatchHistoryNotFoundError);
+  });
+});
+
+describe('list', () => {
+  let db: MediaDb;
+
+  beforeEach(() => {
+    ({ db } = freshDb());
+    add(db, { mediaType: 'movie', mediaId: 603, watchedAt: '2026-06-01 12:00:00' });
+    add(db, { mediaType: 'movie', mediaId: 27205, watchedAt: '2026-06-02 12:00:00' });
+    add(db, { mediaType: 'episode', mediaId: 42, watchedAt: '2026-06-03 12:00:00' });
+    add(db, {
+      mediaType: 'episode',
+      mediaId: 43,
+      watchedAt: '2026-06-04 12:00:00',
+      completed: 0,
+    });
+  });
+
+  it('returns all rows ordered by watched_at DESC with an accurate total', () => {
+    const result = list(db, {}, 10, 0);
+    expect(result.total).toBe(4);
+    expect(result.rows.map((r) => r.mediaId)).toEqual([43, 42, 27205, 603]);
+  });
+
+  it('respects limit + offset for pagination', () => {
+    const result = list(db, {}, 2, 1);
+    expect(result.total).toBe(4);
+    expect(result.rows.map((r) => r.mediaId)).toEqual([42, 27205]);
+  });
+
+  it('filters by mediaType', () => {
+    const result = list(db, { mediaType: 'movie' }, 10, 0);
+    expect(result.total).toBe(2);
+    expect(result.rows.every((r) => r.mediaType === 'movie')).toBe(true);
+  });
+
+  it('filters by mediaId', () => {
+    const result = list(db, { mediaId: 603 }, 10, 0);
+    expect(result.total).toBe(1);
+    expect(result.rows[0]?.mediaId).toBe(603);
+  });
+
+  it('filters by completed', () => {
+    const result = list(db, { completed: 0 }, 10, 0);
+    expect(result.total).toBe(1);
+    expect(result.rows[0]?.mediaId).toBe(43);
+  });
+
+  it('combines filters with AND', () => {
+    const result = list(db, { mediaType: 'episode', completed: 1 }, 10, 0);
+    expect(result.total).toBe(1);
+    expect(result.rows[0]?.mediaId).toBe(42);
+  });
+});
+
+describe('byItem', () => {
+  let db: MediaDb;
+  beforeEach(() => {
+    ({ db } = freshDb());
+  });
+
+  it('returns every watch entry for a single item, most recent first', () => {
+    add(db, { mediaType: 'movie', mediaId: 603, watchedAt: '2026-06-01 12:00:00' });
+    add(db, { mediaType: 'movie', mediaId: 603, watchedAt: '2026-06-03 12:00:00' });
+    add(db, { mediaType: 'movie', mediaId: 603, watchedAt: '2026-06-02 12:00:00' });
+    add(db, { mediaType: 'movie', mediaId: 27205, watchedAt: '2026-06-02 12:00:00' });
+
+    const rows = byItem(db, 'movie', 603);
+    expect(rows).toHaveLength(3);
+    expect(rows.map((r) => r.watchedAt)).toEqual([
+      '2026-06-03 12:00:00',
+      '2026-06-02 12:00:00',
+      '2026-06-01 12:00:00',
+    ]);
+  });
+
+  it('returns an empty array for an item with no history', () => {
+    expect(byItem(db, 'movie', 999)).toEqual([]);
+  });
+
+  it('does not bleed across mediaType when ids collide', () => {
+    add(db, { mediaType: 'movie', mediaId: 1, watchedAt: '2026-06-01 12:00:00' });
+    add(db, { mediaType: 'episode', mediaId: 1, watchedAt: '2026-06-02 12:00:00' });
+
+    expect(byItem(db, 'movie', 1)).toHaveLength(1);
+    expect(byItem(db, 'episode', 1)).toHaveLength(1);
+  });
+});
+
+describe('byDateRange', () => {
+  let db: MediaDb;
+
+  beforeEach(() => {
+    ({ db } = freshDb());
+    add(db, { mediaType: 'movie', mediaId: 1, watchedAt: '2026-06-01 12:00:00' });
+    add(db, { mediaType: 'movie', mediaId: 2, watchedAt: '2026-06-05 12:00:00' });
+    add(db, { mediaType: 'movie', mediaId: 3, watchedAt: '2026-06-10 12:00:00' });
+    add(db, { mediaType: 'episode', mediaId: 1, watchedAt: '2026-06-05 18:00:00' });
+  });
+
+  it('returns rows in the inclusive date range', () => {
+    const rows = byDateRange(db, '2026-06-04 00:00:00', '2026-06-07 00:00:00');
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => r.watchedAt)).toEqual(['2026-06-05 18:00:00', '2026-06-05 12:00:00']);
+  });
+
+  it('treats startDate and endDate as inclusive bounds', () => {
+    const rows = byDateRange(db, '2026-06-01 12:00:00', '2026-06-10 12:00:00');
+    expect(rows).toHaveLength(4);
+  });
+
+  it('excludes rows strictly outside the range', () => {
+    const rows = byDateRange(db, '2026-06-11 00:00:00', '2026-06-30 23:59:59');
+    expect(rows).toEqual([]);
+  });
+
+  it('narrows by mediaType when supplied', () => {
+    const rows = byDateRange(db, '2026-06-01 00:00:00', '2026-06-30 23:59:59', 'episode');
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.mediaType).toBe('episode');
+  });
+});
+
+describe('update', () => {
+  let db: MediaDb;
+  beforeEach(() => {
+    ({ db } = freshDb());
+  });
+
+  it('updates the supplied fields and re-reads the row', () => {
+    const created = add(db, baseInput());
+    const updated = update(db, created.id, { completed: 0 });
+    expect(updated.completed).toBe(0);
+    expect(updated.mediaId).toBe(603);
+  });
+
+  it('skips the UPDATE entirely when no fields are supplied (no-op patch)', () => {
+    const created = add(db, baseInput());
+    const updated = update(db, created.id, {});
+    expect(updated).toEqual(created);
+  });
+
+  it('throws WatchHistoryNotFoundError when the id is missing', () => {
+    expect(() => update(db, 9_999, { completed: 0 })).toThrow(WatchHistoryNotFoundError);
+  });
+
+  it('throws WatchHistoryConflictError when a patch collides with another row', () => {
+    const a = add(db, { mediaType: 'movie', mediaId: 1, watchedAt: '2026-06-01 12:00:00' });
+    add(db, { mediaType: 'movie', mediaId: 1, watchedAt: '2026-06-02 12:00:00' });
+    expect(() => update(db, a.id, { watchedAt: '2026-06-02 12:00:00' })).toThrow(
+      WatchHistoryConflictError
+    );
+  });
+});
+
+describe('delete', () => {
+  let db: MediaDb;
+  beforeEach(() => {
+    ({ db } = freshDb());
+  });
+
+  it('removes the row and a subsequent getById throws WatchHistoryNotFoundError', () => {
+    const created = add(db, baseInput());
+    deleteEntry(db, created.id);
+    expect(() => getById(db, created.id)).toThrow(WatchHistoryNotFoundError);
+  });
+
+  it('throws WatchHistoryNotFoundError when the id is missing', () => {
+    expect(() => deleteEntry(db, 9_999)).toThrow(WatchHistoryNotFoundError);
+  });
+});

--- a/packages/media-db/src/errors.ts
+++ b/packages/media-db/src/errors.ts
@@ -45,3 +45,27 @@ export class TvShowConflictError extends Error {
     this.tvdbId = tvdbId;
   }
 }
+
+export class WatchHistoryNotFoundError extends Error {
+  override readonly name = 'WatchHistoryNotFoundError' as const;
+  readonly id: number;
+
+  constructor(id: number) {
+    super(`Watch history entry '${id}' not found`);
+    this.id = id;
+  }
+}
+
+export class WatchHistoryConflictError extends Error {
+  override readonly name = 'WatchHistoryConflictError' as const;
+  readonly mediaType: 'movie' | 'episode';
+  readonly mediaId: number;
+  readonly watchedAt: string;
+
+  constructor(mediaType: 'movie' | 'episode', mediaId: number, watchedAt: string) {
+    super(`Watch history entry for ${mediaType} ${mediaId} at ${watchedAt} already exists`);
+    this.mediaType = mediaType;
+    this.mediaId = mediaId;
+    this.watchedAt = watchedAt;
+  }
+}

--- a/packages/media-db/src/index.ts
+++ b/packages/media-db/src/index.ts
@@ -22,6 +22,8 @@ export {
   MovieNotFoundError,
   TvShowConflictError,
   TvShowNotFoundError,
+  WatchHistoryConflictError,
+  WatchHistoryNotFoundError,
 } from './errors.js';
 
 export type {
@@ -47,6 +49,18 @@ export type {
 } from './services/tv-shows.js';
 
 export * as tvShowsService from './services/tv-shows.js';
+
+export type {
+  AddWatchHistoryInput,
+  UpdateWatchHistoryInput,
+  WatchHistoryEntry,
+  WatchHistoryFilters,
+  WatchHistoryListResult,
+  WatchHistoryMediaType,
+  WatchHistoryRow,
+} from './services/watch-history.js';
+
+export * as watchHistoryService from './services/watch-history.js';
 
 export * as watchlistService from './services/watchlist.js';
 

--- a/packages/media-db/src/schema.ts
+++ b/packages/media-db/src/schema.ts
@@ -11,4 +11,4 @@
  * Mirrors the `@pops/core-db` schema re-export pattern. The shape grows as
  * subsequent Phase 1 PRs migrate additional media tables into this package.
  */
-export { mediaWatchlist, movies, shelfImpressions, tvShows } from '@pops/db-types';
+export { mediaWatchlist, movies, shelfImpressions, tvShows, watchHistory } from '@pops/db-types';

--- a/packages/media-db/src/services/watch-history.ts
+++ b/packages/media-db/src/services/watch-history.ts
@@ -1,0 +1,257 @@
+/**
+ * Watch history CRUD against the media pillar's SQLite via drizzle.
+ *
+ * Services take a `MediaDb` handle as their first argument; the calling
+ * layer (pops-api modules) is responsible for resolving the singleton
+ * or transaction handle to pass in. Mirrors `@pops/media-db`'s movies
+ * service signature.
+ *
+ * Procedure surface tracks the PRD-168 contract:
+ * `media.watchHistory.{list, byItem, byDateRange, add, update, delete}`.
+ * The in-tree service in `apps/pops-api/src/modules/media/watch-history/`
+ * still routes through the shared `getDrizzle()` handle for now —
+ * PRD-168 PR 3 flips that to `getMediaDrizzle()` and routes through
+ * this module.
+ *
+ * Cross-table orchestration that today lives in the in-tree handlers
+ * (auto-removing watchlist rows on a movie completion, queueing a debrief
+ * session, resetting comparison staleness, …) stays at the router/module
+ * layer until the dependent tables are themselves resident in the media
+ * pillar's SQLite. This package owns persistence; orchestration is a
+ * caller concern.
+ */
+import { and, count, desc, eq, gte, lte, type SQL } from 'drizzle-orm';
+
+import { WatchHistoryConflictError, WatchHistoryNotFoundError } from '../errors.js';
+import { watchHistory } from '../schema.js';
+
+import type { MediaDb } from './internal.js';
+
+/** Raw drizzle row shape — the persisted watch_history record. */
+export type WatchHistoryRow = typeof watchHistory.$inferSelect;
+
+/** Public alias for the persisted watch history entry. */
+export type WatchHistoryEntry = WatchHistoryRow;
+
+/** Media types that can appear in watch_history. */
+export type WatchHistoryMediaType = 'movie' | 'episode';
+
+/** Filters accepted by {@link list}. */
+export interface WatchHistoryFilters {
+  mediaType?: WatchHistoryMediaType | undefined;
+  mediaId?: number | undefined;
+  completed?: number | undefined;
+}
+
+/** Count + rows for a paginated list. */
+export interface WatchHistoryListResult {
+  rows: WatchHistoryRow[];
+  total: number;
+}
+
+/** Mutable subset accepted on add. */
+export interface AddWatchHistoryInput {
+  mediaType: WatchHistoryMediaType;
+  mediaId: number;
+  watchedAt?: string | undefined;
+  completed?: number | undefined;
+  blacklisted?: number | undefined;
+}
+
+/** PATCH-shape — every field optional. */
+export interface UpdateWatchHistoryInput {
+  mediaType?: WatchHistoryMediaType;
+  mediaId?: number;
+  watchedAt?: string;
+  completed?: number;
+  blacklisted?: number;
+}
+
+function buildListWhere(filters: WatchHistoryFilters): SQL | undefined {
+  const conditions: SQL[] = [];
+  if (filters.mediaType !== undefined) {
+    conditions.push(eq(watchHistory.mediaType, filters.mediaType));
+  }
+  if (filters.mediaId !== undefined) {
+    conditions.push(eq(watchHistory.mediaId, filters.mediaId));
+  }
+  if (filters.completed !== undefined) {
+    conditions.push(eq(watchHistory.completed, filters.completed));
+  }
+  return conditions.length > 0 ? and(...conditions) : undefined;
+}
+
+/** List watch history entries with optional filters. Ordered by `watched_at DESC`. */
+export function list(
+  db: MediaDb,
+  filters: WatchHistoryFilters,
+  limit: number,
+  offset: number
+): WatchHistoryListResult {
+  const where = buildListWhere(filters);
+
+  const rows = db
+    .select()
+    .from(watchHistory)
+    .where(where)
+    .orderBy(desc(watchHistory.watchedAt))
+    .limit(limit)
+    .offset(offset)
+    .all();
+
+  const [countRow] = db.select({ total: count() }).from(watchHistory).where(where).all();
+
+  return { rows, total: countRow?.total ?? 0 };
+}
+
+/**
+ * All watch history for a single media item. Ordered by `watched_at DESC`
+ * — the most-recent watch first.
+ */
+export function byItem(
+  db: MediaDb,
+  mediaType: WatchHistoryMediaType,
+  mediaId: number
+): WatchHistoryRow[] {
+  return db
+    .select()
+    .from(watchHistory)
+    .where(and(eq(watchHistory.mediaType, mediaType), eq(watchHistory.mediaId, mediaId)))
+    .orderBy(desc(watchHistory.watchedAt))
+    .all();
+}
+
+/**
+ * All watch history rows in `[startDate, endDate]` (inclusive on both
+ * ends — the heaviest production query). Optional `mediaType` filter
+ * narrows the time-range scan. Ordered by `watched_at DESC`.
+ */
+export function byDateRange(
+  db: MediaDb,
+  startDate: string,
+  endDate: string,
+  mediaType?: WatchHistoryMediaType
+): WatchHistoryRow[] {
+  const conditions: SQL[] = [
+    gte(watchHistory.watchedAt, startDate),
+    lte(watchHistory.watchedAt, endDate),
+  ];
+  if (mediaType !== undefined) {
+    conditions.push(eq(watchHistory.mediaType, mediaType));
+  }
+  return db
+    .select()
+    .from(watchHistory)
+    .where(and(...conditions))
+    .orderBy(desc(watchHistory.watchedAt))
+    .all();
+}
+
+/**
+ * Insert a new watch history row. Returns the persisted row.
+ *
+ * Throws `WatchHistoryConflictError` if the `(media_type, media_id, watched_at)`
+ * unique index rejects the insert. Callers that need idempotent semantics
+ * (e.g. plex sync) should catch and skip — or use `INSERT OR IGNORE`
+ * directly via the raw handle while we keep the public service strict.
+ */
+export function add(db: MediaDb, input: AddWatchHistoryInput): WatchHistoryRow {
+  const values: typeof watchHistory.$inferInsert = {
+    mediaType: input.mediaType,
+    mediaId: input.mediaId,
+    ...(input.watchedAt !== undefined ? { watchedAt: input.watchedAt } : {}),
+    ...(input.completed !== undefined ? { completed: input.completed } : {}),
+    ...(input.blacklisted !== undefined ? { blacklisted: input.blacklisted } : {}),
+  };
+  try {
+    const result = db.insert(watchHistory).values(values).run();
+    const row = db
+      .select()
+      .from(watchHistory)
+      .where(eq(watchHistory.id, Number(result.lastInsertRowid)))
+      .get();
+    if (!row) throw new WatchHistoryNotFoundError(Number(result.lastInsertRowid));
+    return row;
+  } catch (err) {
+    if (err instanceof Error && err.message.includes('UNIQUE constraint failed')) {
+      const watchedAt = input.watchedAt ?? '';
+      throw new WatchHistoryConflictError(input.mediaType, input.mediaId, watchedAt);
+    }
+    throw err;
+  }
+}
+
+function buildUpdatePatch(
+  input: UpdateWatchHistoryInput
+): Partial<typeof watchHistory.$inferSelect> | null {
+  const updates: Record<string, unknown> = {};
+  let touched = false;
+
+  if (input.mediaType !== undefined) {
+    updates.mediaType = input.mediaType;
+    touched = true;
+  }
+  if (input.mediaId !== undefined) {
+    updates.mediaId = input.mediaId;
+    touched = true;
+  }
+  if (input.watchedAt !== undefined) {
+    updates.watchedAt = input.watchedAt;
+    touched = true;
+  }
+  if (input.completed !== undefined) {
+    updates.completed = input.completed;
+    touched = true;
+  }
+  if (input.blacklisted !== undefined) {
+    updates.blacklisted = input.blacklisted;
+    touched = true;
+  }
+
+  if (!touched) return null;
+  return updates as Partial<typeof watchHistory.$inferSelect>;
+}
+
+/**
+ * Get a single watch history entry by id. Throws
+ * `WatchHistoryNotFoundError` if missing.
+ */
+export function getById(db: MediaDb, id: number): WatchHistoryRow {
+  const row = db.select().from(watchHistory).where(eq(watchHistory.id, id)).get();
+  if (!row) throw new WatchHistoryNotFoundError(id);
+  return row;
+}
+
+/**
+ * Patch a watch history entry. Throws `WatchHistoryNotFoundError` if missing.
+ * No-op writes (empty `input`) still re-read the row but skip the UPDATE.
+ */
+export function update(db: MediaDb, id: number, input: UpdateWatchHistoryInput): WatchHistoryRow {
+  getById(db, id);
+  const patch = buildUpdatePatch(input);
+  if (patch) {
+    try {
+      db.update(watchHistory).set(patch).where(eq(watchHistory.id, id)).run();
+    } catch (err) {
+      if (err instanceof Error && err.message.includes('UNIQUE constraint failed')) {
+        const current = getById(db, id);
+        throw new WatchHistoryConflictError(
+          (input.mediaType ?? current.mediaType) as WatchHistoryMediaType,
+          input.mediaId ?? current.mediaId,
+          input.watchedAt ?? current.watchedAt
+        );
+      }
+      throw err;
+    }
+  }
+  return getById(db, id);
+}
+
+/** Delete a watch history entry. Throws `WatchHistoryNotFoundError` if missing. */
+function deleteById(db: MediaDb, id: number): void {
+  getById(db, id);
+  const result = db.delete(watchHistory).where(eq(watchHistory.id, id)).run();
+  if (result.changes === 0) throw new WatchHistoryNotFoundError(id);
+}
+
+export { deleteById as delete };

--- a/packages/media-db/src/services/watch-history.ts
+++ b/packages/media-db/src/services/watch-history.ts
@@ -6,12 +6,21 @@
  * or transaction handle to pass in. Mirrors `@pops/media-db`'s movies
  * service signature.
  *
- * Procedure surface tracks the PRD-168 contract:
- * `media.watchHistory.{list, byItem, byDateRange, add, update, delete}`.
+ * Procedure surface tracks the PRD-168 contract plus a `getById` helper
+ * for the router layer:
+ * `media.watchHistory.{list, byItem, byDateRange, add, getById, update, delete}`.
  * The in-tree service in `apps/pops-api/src/modules/media/watch-history/`
  * still routes through the shared `getDrizzle()` handle for now —
  * PRD-168 PR 3 flips that to `getMediaDrizzle()` and routes through
  * this module.
+ *
+ * `watchedAt` is stored as SQLite `datetime('now')` text — second-precision
+ * `YYYY-MM-DD HH:MM:SS` UTC. When the caller omits it on insert we resolve
+ * the value in JS up front (same format) so it can be reused for the row,
+ * the conflict error, and any caller-side log. The unique index covers
+ * `(media_type, media_id, watched_at)`, so two omitted inserts for the
+ * same item inside the same second deliberately raise
+ * `WatchHistoryConflictError` with the resolved timestamp.
  *
  * Cross-table orchestration that today lives in the in-tree handlers
  * (auto-removing watchlist rows on a movie completion, queueing a debrief
@@ -155,11 +164,22 @@ export function byDateRange(
  * (e.g. plex sync) should catch and skip — or use `INSERT OR IGNORE`
  * directly via the raw handle while we keep the public service strict.
  */
+/**
+ * Format a JS Date as the second-precision UTC string SQLite returns from
+ * `datetime('now')` — `YYYY-MM-DD HH:MM:SS`. Used to materialise
+ * `watchedAt` up front when the caller omits it on insert, so the value
+ * survives into the conflict error.
+ */
+function nowSqliteDatetime(): string {
+  return new Date().toISOString().replace('T', ' ').slice(0, 19);
+}
+
 export function add(db: MediaDb, input: AddWatchHistoryInput): WatchHistoryRow {
+  const watchedAt = input.watchedAt ?? nowSqliteDatetime();
   const values: typeof watchHistory.$inferInsert = {
     mediaType: input.mediaType,
     mediaId: input.mediaId,
-    ...(input.watchedAt !== undefined ? { watchedAt: input.watchedAt } : {}),
+    watchedAt,
     ...(input.completed !== undefined ? { completed: input.completed } : {}),
     ...(input.blacklisted !== undefined ? { blacklisted: input.blacklisted } : {}),
   };
@@ -174,17 +194,16 @@ export function add(db: MediaDb, input: AddWatchHistoryInput): WatchHistoryRow {
     return row;
   } catch (err) {
     if (err instanceof Error && err.message.includes('UNIQUE constraint failed')) {
-      const watchedAt = input.watchedAt ?? '';
       throw new WatchHistoryConflictError(input.mediaType, input.mediaId, watchedAt);
     }
     throw err;
   }
 }
 
-function buildUpdatePatch(
-  input: UpdateWatchHistoryInput
-): Partial<typeof watchHistory.$inferSelect> | null {
-  const updates: Record<string, unknown> = {};
+type WatchHistoryUpdate = Partial<typeof watchHistory.$inferInsert>;
+
+function buildUpdatePatch(input: UpdateWatchHistoryInput): WatchHistoryUpdate | null {
+  const updates: WatchHistoryUpdate = {};
   let touched = false;
 
   if (input.mediaType !== undefined) {
@@ -209,7 +228,7 @@ function buildUpdatePatch(
   }
 
   if (!touched) return null;
-  return updates as Partial<typeof watchHistory.$inferSelect>;
+  return updates;
 }
 
 /**
@@ -236,7 +255,7 @@ export function update(db: MediaDb, id: number, input: UpdateWatchHistoryInput):
       if (err instanceof Error && err.message.includes('UNIQUE constraint failed')) {
         const current = getById(db, id);
         throw new WatchHistoryConflictError(
-          (input.mediaType ?? current.mediaType) as WatchHistoryMediaType,
+          input.mediaType ?? current.mediaType,
           input.mediaId ?? current.mediaId,
           input.watchedAt ?? current.watchedAt
         );


### PR DESCRIPTION
## Summary

PR 1 of the 4-PR [PRD-168](docs/themes/13-pillar-finale/prds/168-media-watch-history-cutover/README.md) `watch_history` cutover. Mirrors the PRD-165 PR 1 (movies) scaffold pattern — adds the `watch_history` table to `@pops/media-db` so the later cutover PR can flip the handle without churn.

## Changes

- **Schema + migration** — `0022_media_watch_history_baseline.sql` (table + 3 indexes: `idx_watch_history_media`, `idx_watch_history_watched_at`, `idx_watch_history_unique`), byte-identical to the shared journal shape produced by `0004/0009/0014`. `watchHistory` re-exported from `packages/media-db/src/schema.ts`.
- **Service** — `watchHistoryService.{list, byItem, byDateRange, add, update, delete, getById}` exposes the PRD-168 procedure surface against `MediaDb`. Pure watch_history persistence — cross-table orchestration (debrief sessions, watchlist auto-removal, comparison staleness reset, `listRecent` enrichment) stays at the router layer until those tables themselves move into media-db.
- **Errors** — `WatchHistoryNotFoundError`, `WatchHistoryConflictError` in `packages/media-db/src/errors.ts`.
- **Backfill** — `apps/pops-api/src/db/media-backfill.ts` rewritten to iterate a `TABLE_COPIES` array (matching the pattern PRD-165 PR 1 introduced). New `watch_history` entry is guarded by `tryCopyTable` so a stale on-disk `pops.db` without the table can't bring shelf_impressions down with it.
- **Tests** — 23 unit tests for the service (`add`, `getById`, `list`, `byItem`, `byDateRange` with inclusive bounds + mediaType narrowing, `update`, `delete`) + 4 backfill integration tests.
- **`per-pillar-migrations.test.ts`** — smoke list updated to include `0022_media_watch_history_baseline` and `0055_pillar_registry` (which was previously missing from the expected list despite already landing on `origin/main` via `core-db`'s journal).

## Test plan

- [x] `pnpm -F @pops/media-db build && pnpm -F @pops/media-db test && pnpm -F @pops/media-db typecheck` — green (3 files, 49 tests)
- [x] `pnpm -F @pops/api test src/db/per-pillar-migrations.test.ts src/db/backfill-media-from-shared.test.ts` — green (2 files, 15 tests)
- [x] `pnpm oxlint` — no new warnings/errors
- [x] `pnpm oxfmt`
- [x] `pnpm -w typecheck` — 66/66 tasks green

## Out of scope

- Touching `apps/pops-api/src/modules/media/watch-history/*` (that's PRD-168 PR 3 — the cutover that flips `getDrizzle()` to `getMediaDrizzle()`).
- Dropping `watch_history` from the shared journal (that's PRD-168 PR 2).