### PR TITLE
feat(cerebrum-db): scaffold glia service + baseline migration (PRD-181 US-01)

### DIFF
--- a/apps/pops-api/src/db/backfill-cerebrum-from-shared.test.ts
+++ b/apps/pops-api/src/db/backfill-cerebrum-from-shared.test.ts
@@ -48,6 +48,35 @@ CREATE TABLE nudge_log (
 );
 `;
 
+const GLIA_SCHEMA_SQL = `
+CREATE TABLE glia_actions (
+  id text PRIMARY KEY NOT NULL,
+  action_type text NOT NULL,
+  affected_ids text NOT NULL,
+  rationale text NOT NULL,
+  payload text,
+  phase text NOT NULL,
+  status text NOT NULL,
+  user_decision text,
+  user_note text,
+  executed_at text,
+  decided_at text,
+  reverted_at text,
+  created_at text NOT NULL
+);
+CREATE TABLE glia_trust_state (
+  action_type text PRIMARY KEY NOT NULL,
+  current_phase text NOT NULL,
+  approved_count integer DEFAULT 0 NOT NULL,
+  rejected_count integer DEFAULT 0 NOT NULL,
+  reverted_count integer DEFAULT 0 NOT NULL,
+  autonomous_since text,
+  last_revert_at text,
+  graduated_at text,
+  updated_at text NOT NULL
+);
+`;
+
 const ENGRAMS_SCHEMA_SQL = `
 CREATE TABLE engram_index (
   id text PRIMARY KEY NOT NULL,
@@ -101,9 +130,30 @@ function openSharedWithSeed(seed: (raw: BetterSqlite3.Database) => void): string
   const raw = new BetterSqlite3(path);
   raw.exec(NUDGE_LOG_SQL);
   raw.exec(ENGRAMS_SCHEMA_SQL);
+  raw.exec(GLIA_SCHEMA_SQL);
   seed(raw);
   raw.close();
   return path;
+}
+
+function insertGliaAction(raw: BetterSqlite3.Database, id: string): void {
+  raw
+    .prepare(
+      `INSERT INTO glia_actions
+        (id, action_type, affected_ids, rationale, phase, status, created_at)
+       VALUES (?, 'prune', '["eng_a"]', 'r', 'propose', 'pending', '2026-06-10T10:00:00Z')`
+    )
+    .run(id);
+}
+
+function insertGliaTrustState(raw: BetterSqlite3.Database, actionType: string): void {
+  raw
+    .prepare(
+      `INSERT INTO glia_trust_state
+        (action_type, current_phase, approved_count, rejected_count, reverted_count, updated_at)
+       VALUES (?, 'propose', 0, 0, 0, '2026-06-10T10:00:00Z')`
+    )
+    .run(actionType);
 }
 
 function insertNudge(raw: BetterSqlite3.Database, id: string): void {
@@ -206,6 +256,72 @@ describe('backfillCerebrumFromShared', () => {
         n: number;
       };
       expect(n).toBe(1);
+    } finally {
+      cerebrum.raw.close();
+    }
+  });
+
+  it('copies glia_actions + glia_trust_state from the shared DB on first run', () => {
+    const sharedPath = openSharedWithSeed((raw) => {
+      insertGliaAction(raw, 'glia_a');
+      insertGliaAction(raw, 'glia_b');
+      insertGliaTrustState(raw, 'prune');
+      insertGliaTrustState(raw, 'consolidate');
+    });
+
+    const cerebrum = openCerebrumDb(join(tmpDir, 'cerebrum.db'), { loadVec: false });
+    try {
+      backfillCerebrumFromShared(cerebrum, sharedPath);
+      const { actions } = cerebrum.raw
+        .prepare('SELECT count(*) AS actions FROM glia_actions')
+        .get() as { actions: number };
+      const { trust } = cerebrum.raw
+        .prepare('SELECT count(*) AS trust FROM glia_trust_state')
+        .get() as { trust: number };
+      expect(actions).toBe(2);
+      expect(trust).toBe(2);
+    } finally {
+      cerebrum.raw.close();
+    }
+  });
+
+  it('skips glia rows already present in the cerebrum copy (idempotent)', () => {
+    const sharedPath = openSharedWithSeed((raw) => {
+      insertGliaAction(raw, 'glia_dup');
+      insertGliaTrustState(raw, 'prune');
+    });
+
+    const cerebrum = openCerebrumDb(join(tmpDir, 'cerebrum.db'), { loadVec: false });
+    try {
+      backfillCerebrumFromShared(cerebrum, sharedPath);
+      backfillCerebrumFromShared(cerebrum, sharedPath);
+      const { actions } = cerebrum.raw
+        .prepare('SELECT count(*) AS actions FROM glia_actions')
+        .get() as { actions: number };
+      const { trust } = cerebrum.raw
+        .prepare('SELECT count(*) AS trust FROM glia_trust_state')
+        .get() as { trust: number };
+      expect(actions).toBe(1);
+      expect(trust).toBe(1);
+    } finally {
+      cerebrum.raw.close();
+    }
+  });
+
+  it('only inserts glia rows missing from the cerebrum copy (mixed state)', () => {
+    const sharedPath = openSharedWithSeed((raw) => {
+      insertGliaAction(raw, 'glia_shared_only');
+      insertGliaAction(raw, 'glia_both');
+    });
+
+    const cerebrum = openCerebrumDb(join(tmpDir, 'cerebrum.db'), { loadVec: false });
+    try {
+      insertGliaAction(cerebrum.raw, 'glia_both');
+      backfillCerebrumFromShared(cerebrum, sharedPath);
+      const rows = cerebrum.raw.prepare('SELECT id FROM glia_actions ORDER BY id').all() as {
+        id: string;
+      }[];
+      expect(rows.map((r) => r.id)).toEqual(['glia_both', 'glia_shared_only']);
     } finally {
       cerebrum.raw.close();
     }

--- a/apps/pops-api/src/db/backfill-cerebrum-from-shared.ts
+++ b/apps/pops-api/src/db/backfill-cerebrum-from-shared.ts
@@ -14,13 +14,17 @@
  *   - `engram_index` + `engram_scopes` + `engram_tags` + `engram_links`
  *     (PRD-179 US-01 — scaffold; consumers still write to the shared
  *     pops.db until US-03 flips them over)
+ *   - `glia_actions` + `glia_trust_state` (PRD-181 US-01 — scaffold;
+ *     consumers still write to the shared pops.db until US-03 flips
+ *     them over)
  *
  * The remaining cerebrum tables (embeddings + embeddings_vec,
- * conversations, glia, plexus) add their entries here when their
- * cutovers land. Order matters when FKs are introduced across
- * cerebrum-owned tables — `engram_index` is copied first so the
- * cascading auxiliaries (`engram_scopes`, `engram_tags`, `engram_links`)
- * can satisfy their FK at insert time.
+ * conversations, plexus) add their entries here when their cutovers
+ * land. Order matters when FKs are introduced across cerebrum-owned
+ * tables — `engram_index` is copied first so the cascading auxiliaries
+ * (`engram_scopes`, `engram_tags`, `engram_links`) can satisfy their FK
+ * at insert time. The two glia tables have no cross-table FKs so their
+ * order is independent of the engram block.
  *
  * Non-fatal: ATTACH or INSERT failures are logged and swallowed so a
  * stale on-disk pops.db never bricks the boot path. Partial failures
@@ -105,6 +109,47 @@ const TABLE_COPIES: readonly TableCopy[] = [
     table: 'engram_links',
     idColumn: 'source_id',
     columns: ['source_id', 'target_id'],
+  },
+  {
+    table: 'glia_actions',
+    idColumn: 'id',
+    columns: [
+      'id',
+      'action_type',
+      'affected_ids',
+      'rationale',
+      'payload',
+      'phase',
+      'status',
+      'user_decision',
+      'user_note',
+      'executed_at',
+      'decided_at',
+      'reverted_at',
+      'created_at',
+    ],
+  },
+  {
+    // glia_trust_state's PK is `action_type` — the same column doubles
+    // as the existence-filter source. Once a row for an action type is
+    // copied across, the WHERE NOT IN clause makes subsequent runs a
+    // no-op for that type; new counter increments on the still-shared
+    // row won't replicate, which is acceptable for the same reason
+    // engram_scopes is: PR 3 (US-03) routes writes through the cerebrum
+    // handle before any divergence matters.
+    table: 'glia_trust_state',
+    idColumn: 'action_type',
+    columns: [
+      'action_type',
+      'current_phase',
+      'approved_count',
+      'rejected_count',
+      'reverted_count',
+      'autonomous_since',
+      'last_revert_at',
+      'graduated_at',
+      'updated_at',
+    ],
   },
 ];
 

--- a/apps/pops-api/src/db/per-pillar-migrations.test.ts
+++ b/apps/pops-api/src/db/per-pillar-migrations.test.ts
@@ -212,8 +212,9 @@ describe('runPerPillarMigrations', () => {
     // 0007_locations_parent_sort_index (#2917 — backfill missing index
     // carried over from shared journal 0009_red_quasimodo); `cerebrum` owns
     // `packages/cerebrum-db/migrations/` with 0039_dry_fabian_cortez +
-    // 0044_nudge_log (cerebrum pillar Phase 1 PR 2 — nudge_log slice) and
-    // 0050_engrams_baseline (PRD-179 US-01 — engrams baseline).
+    // 0044_nudge_log (cerebrum pillar Phase 1 PR 2 — nudge_log slice),
+    // 0050_engrams_baseline (PRD-179 US-01 — engrams baseline) and
+    // 0051_glia_baseline (PRD-181 US-01 — glia baseline).
     // Pillars without their own journal yet still skip cleanly.
     await withDb((db) => {
       const realPillars: PillarDescriptor[] = [
@@ -234,6 +235,7 @@ describe('runPerPillarMigrations', () => {
         '0039_dry_fabian_cortez',
         '0044_nudge_log',
         '0050_engrams_baseline',
+        '0051_glia_baseline',
         '0054_service_accounts',
         '0055_pillar_registry',
       ]);

--- a/packages/cerebrum-db/migrations/0051_glia_baseline.sql
+++ b/packages/cerebrum-db/migrations/0051_glia_baseline.sql
@@ -1,0 +1,46 @@
+-- Cerebrum pillar baseline for the glia slice (PRD-181 US-01).
+--
+-- Mirrors the glia_actions / glia_trust_state schema as it stands in the
+-- shared pops.db after the safety migration 0047_glia_actions (issue #2330).
+-- Column definitions and indexes are copied verbatim so a fresh
+-- cerebrum.db matches the shared shape byte-for-byte; the boot-time
+-- backfill ATTACHes pops.db and copies rows across without column-rename
+-- gymnastics.
+--
+-- Glia tracks every autonomous-action proposal (prune, consolidate,
+-- link, audit) plus a per-action-type trust state that drives the
+-- three-phase graduation model (propose → act_report → silent) — see
+-- ADR-021 / PRD-086 for the full spec. Action execution and digest
+-- generation stay in pops-api; this slice is the persistence layer only.
+
+CREATE TABLE `glia_actions` (
+	`id` text PRIMARY KEY NOT NULL,
+	`action_type` text NOT NULL,
+	`affected_ids` text NOT NULL,
+	`rationale` text NOT NULL,
+	`payload` text,
+	`phase` text NOT NULL,
+	`status` text NOT NULL,
+	`user_decision` text,
+	`user_note` text,
+	`executed_at` text,
+	`decided_at` text,
+	`reverted_at` text,
+	`created_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `idx_glia_actions_action_type` ON `glia_actions` (`action_type`);--> statement-breakpoint
+CREATE INDEX `idx_glia_actions_status` ON `glia_actions` (`status`);--> statement-breakpoint
+CREATE INDEX `idx_glia_actions_phase` ON `glia_actions` (`phase`);--> statement-breakpoint
+CREATE INDEX `idx_glia_actions_created_at` ON `glia_actions` (`created_at`);--> statement-breakpoint
+CREATE TABLE `glia_trust_state` (
+	`action_type` text PRIMARY KEY NOT NULL,
+	`current_phase` text NOT NULL,
+	`approved_count` integer DEFAULT 0 NOT NULL,
+	`rejected_count` integer DEFAULT 0 NOT NULL,
+	`reverted_count` integer DEFAULT 0 NOT NULL,
+	`autonomous_since` text,
+	`last_revert_at` text,
+	`graduated_at` text,
+	`updated_at` text NOT NULL
+);

--- a/packages/cerebrum-db/migrations/meta/_journal.json
+++ b/packages/cerebrum-db/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1781827200000,
       "tag": "0050_engrams_baseline",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1781913600000,
+      "tag": "0051_glia_baseline",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cerebrum-db/src/__tests__/glia.test.ts
+++ b/packages/cerebrum-db/src/__tests__/glia.test.ts
@@ -1,0 +1,433 @@
+/**
+ * Invariant tests for the glia data-access service against an in-memory
+ * SQLite seeded with the package-local glia baseline migration. Covers
+ * action CRUD + filters, autonomous-window helpers, revert-window counts,
+ * and trust-state seed/read/update including the counter-increment
+ * shortcut.
+ *
+ * The baseline is read from
+ * `packages/cerebrum-db/migrations/0051_glia_baseline.sql` so the table
+ * shape under test is identical to the one shipped in the journal.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import Database from 'better-sqlite3';
+import { eq } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { gliaActions } from '../schema.js';
+import {
+  countAutonomousExecutionsSince,
+  countAutonomousRevertsSince,
+  countRevertsInWindow,
+  deleteAction,
+  getAction,
+  getTrustState,
+  incrementTrustStateCounter,
+  insertAction,
+  listActions,
+  listAutonomousActionsInWindow,
+  listTrustStates,
+  seedTrustState,
+  updateAction,
+  updateTrustState,
+} from '../services/glia.js';
+
+import type { InsertActionRow } from '../services/glia-types.js';
+import type { CerebrumDb } from '../services/internal.js';
+
+const GLIA_MIGRATION = join(__dirname, '../../migrations/0051_glia_baseline.sql');
+
+function freshDb(): CerebrumDb {
+  const raw = new Database(':memory:');
+  raw.pragma('foreign_keys = ON');
+  const sql = readFileSync(GLIA_MIGRATION, 'utf8');
+  for (const stmt of sql.split('--> statement-breakpoint')) {
+    const trimmed = stmt.trim();
+    if (trimmed.length > 0) raw.exec(trimmed);
+  }
+  return drizzle(raw);
+}
+
+function makeAction(
+  overrides: Partial<InsertActionRow> & Pick<InsertActionRow, 'id'>
+): InsertActionRow {
+  return {
+    actionType: 'prune',
+    affectedIds: ['eng_a'],
+    rationale: 'because reasons',
+    payload: null,
+    phase: 'propose',
+    status: 'pending',
+    executedAt: null,
+    createdAt: '2026-06-10T10:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('insertAction', () => {
+  let db: CerebrumDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('serialises affectedIds and payload as JSON and round-trips via getAction', () => {
+    const created = insertAction(
+      db,
+      makeAction({
+        id: 'glia_prune_001',
+        affectedIds: ['eng_a', 'eng_b'],
+        payload: { mergePlan: 'a+b' },
+      })
+    );
+
+    expect(created.affectedIds).toEqual(['eng_a', 'eng_b']);
+    expect(created.payload).toEqual({ mergePlan: 'a+b' });
+
+    const fetched = getAction(db, 'glia_prune_001');
+    expect(fetched).not.toBeNull();
+    expect(fetched?.payload).toEqual({ mergePlan: 'a+b' });
+  });
+
+  it('stores null payload as SQL NULL (not the string "null")', () => {
+    insertAction(db, makeAction({ id: 'glia_null_payload', payload: null }));
+    const row = db.select().from(gliaActions).where(eq(gliaActions.id, 'glia_null_payload')).get();
+    expect(row?.payload).toBeNull();
+  });
+
+  it('preserves autonomous execution status + executedAt as supplied', () => {
+    const created = insertAction(
+      db,
+      makeAction({
+        id: 'glia_auto',
+        phase: 'act_report',
+        status: 'executed',
+        executedAt: '2026-06-10T10:05:00Z',
+      })
+    );
+    expect(created.status).toBe('executed');
+    expect(created.executedAt).toBe('2026-06-10T10:05:00Z');
+  });
+});
+
+describe('getAction', () => {
+  it('returns null when the row is missing', () => {
+    expect(getAction(freshDb(), 'missing')).toBeNull();
+  });
+});
+
+describe('listActions', () => {
+  let db: CerebrumDb;
+  beforeEach(() => {
+    db = freshDb();
+    insertAction(
+      db,
+      makeAction({
+        id: 'a1',
+        actionType: 'prune',
+        status: 'pending',
+        createdAt: '2026-06-10T10:00:00Z',
+      })
+    );
+    insertAction(
+      db,
+      makeAction({
+        id: 'a2',
+        actionType: 'consolidate',
+        status: 'approved',
+        createdAt: '2026-06-10T11:00:00Z',
+      })
+    );
+    insertAction(
+      db,
+      makeAction({
+        id: 'a3',
+        actionType: 'prune',
+        status: 'executed',
+        createdAt: '2026-06-11T10:00:00Z',
+      })
+    );
+  });
+
+  it('returns all rows in created_at desc order with total', () => {
+    const result = listActions(db);
+    expect(result.total).toBe(3);
+    expect(result.actions.map((a) => a.id)).toEqual(['a3', 'a2', 'a1']);
+  });
+
+  it('filters by actionType', () => {
+    const result = listActions(db, { actionType: 'prune' });
+    expect(result.total).toBe(2);
+    expect(result.actions.map((a) => a.id).toSorted()).toEqual(['a1', 'a3']);
+  });
+
+  it('filters by status', () => {
+    const result = listActions(db, { status: 'approved' });
+    expect(result.actions.map((a) => a.id)).toEqual(['a2']);
+  });
+
+  it('filters by inclusive dateFrom / dateTo', () => {
+    const result = listActions(db, {
+      dateFrom: '2026-06-10T11:00:00Z',
+      dateTo: '2026-06-10T23:59:59Z',
+    });
+    expect(result.actions.map((a) => a.id)).toEqual(['a2']);
+  });
+
+  it('paginates with limit + offset on top of filters', () => {
+    const page = listActions(db, { limit: 1, offset: 1 });
+    expect(page.actions.map((a) => a.id)).toEqual(['a2']);
+    expect(page.total).toBe(3);
+  });
+});
+
+describe('updateAction', () => {
+  let db: CerebrumDb;
+  beforeEach(() => {
+    db = freshDb();
+    insertAction(db, makeAction({ id: 'a1' }));
+  });
+
+  it('patches lifecycle columns and returns the updated row', () => {
+    const updated = updateAction(db, 'a1', {
+      status: 'approved',
+      userDecision: 'approve',
+      userNote: 'looks good',
+      decidedAt: '2026-06-10T12:00:00Z',
+    });
+    expect(updated?.status).toBe('approved');
+    expect(updated?.userDecision).toBe('approve');
+    expect(updated?.userNote).toBe('looks good');
+    expect(updated?.decidedAt).toBe('2026-06-10T12:00:00Z');
+  });
+
+  it('returns the current row when the patch is empty (no-op)', () => {
+    const result = updateAction(db, 'a1', {});
+    expect(result?.status).toBe('pending');
+  });
+
+  it('returns null when the action does not exist', () => {
+    expect(updateAction(db, 'missing', { status: 'approved' })).toBeNull();
+  });
+});
+
+describe('deleteAction', () => {
+  it('returns 0 when the action is missing (idempotent)', () => {
+    expect(deleteAction(freshDb(), 'missing')).toBe(0);
+  });
+
+  it('removes the row and returns 1', () => {
+    const db = freshDb();
+    insertAction(db, makeAction({ id: 'a1' }));
+    expect(deleteAction(db, 'a1')).toBe(1);
+    expect(getAction(db, 'a1')).toBeNull();
+  });
+});
+
+describe('listAutonomousActionsInWindow', () => {
+  let db: CerebrumDb;
+  beforeEach(() => {
+    db = freshDb();
+    // Autonomous (decided_at null, executed) inside the window.
+    insertAction(
+      db,
+      makeAction({
+        id: 'auto1',
+        status: 'executed',
+        executedAt: '2026-06-10T10:00:00Z',
+        createdAt: '2026-06-10T10:00:00Z',
+      })
+    );
+    insertAction(
+      db,
+      makeAction({
+        id: 'auto2',
+        status: 'executed',
+        executedAt: '2026-06-10T11:00:00Z',
+        createdAt: '2026-06-10T11:00:00Z',
+      })
+    );
+    // Manually decided — should be excluded.
+    insertAction(
+      db,
+      makeAction({ id: 'manual', status: 'executed', executedAt: '2026-06-10T12:00:00Z' })
+    );
+    updateAction(db, 'manual', { userDecision: 'approve', decidedAt: '2026-06-10T11:30:00Z' });
+    // Outside the window on the upper boundary — endDate is exclusive.
+    insertAction(
+      db,
+      makeAction({ id: 'boundary', status: 'executed', executedAt: '2026-06-11T00:00:00Z' })
+    );
+  });
+
+  it('returns only autonomous executions within [start, end), ordered by executedAt asc', () => {
+    const rows = listAutonomousActionsInWindow(db, '2026-06-10T00:00:00Z', '2026-06-11T00:00:00Z');
+    expect(rows.map((r) => r.id)).toEqual(['auto1', 'auto2']);
+  });
+});
+
+describe('countAutonomousExecutionsSince / countAutonomousRevertsSince', () => {
+  let db: CerebrumDb;
+  beforeEach(() => {
+    db = freshDb();
+    insertAction(
+      db,
+      makeAction({
+        id: 'exec1',
+        actionType: 'prune',
+        status: 'executed',
+        executedAt: '2026-06-10T10:00:00Z',
+      })
+    );
+    insertAction(
+      db,
+      makeAction({
+        id: 'exec2',
+        actionType: 'prune',
+        status: 'executed',
+        executedAt: '2026-06-10T11:00:00Z',
+      })
+    );
+    insertAction(
+      db,
+      makeAction({
+        id: 'reverted1',
+        actionType: 'prune',
+        status: 'reverted',
+        executedAt: '2026-06-10T09:00:00Z',
+      })
+    );
+    updateAction(db, 'reverted1', { revertedAt: '2026-06-10T12:00:00Z' });
+  });
+
+  it('counts only executed autonomous rows for the type since the cutoff', () => {
+    expect(countAutonomousExecutionsSince(db, 'prune', '2026-06-10T00:00:00Z')).toBe(2);
+    expect(countAutonomousExecutionsSince(db, 'consolidate', '2026-06-10T00:00:00Z')).toBe(0);
+  });
+
+  it('excludes rows with null revertedAt from the revert count', () => {
+    insertAction(
+      db,
+      makeAction({
+        id: 'broken',
+        actionType: 'prune',
+        status: 'reverted',
+        executedAt: '2026-06-10T09:30:00Z',
+      })
+    );
+    expect(countAutonomousRevertsSince(db, 'prune', '2026-06-10T00:00:00Z')).toBe(1);
+  });
+});
+
+describe('countRevertsInWindow', () => {
+  it('counts reverts of the given type after windowStart', () => {
+    const db = freshDb();
+    insertAction(db, makeAction({ id: 'r1', actionType: 'prune', status: 'reverted' }));
+    updateAction(db, 'r1', { revertedAt: '2026-06-10T10:00:00Z' });
+    insertAction(db, makeAction({ id: 'r2', actionType: 'prune', status: 'reverted' }));
+    updateAction(db, 'r2', { revertedAt: '2026-06-09T10:00:00Z' });
+    insertAction(db, makeAction({ id: 'r3', actionType: 'consolidate', status: 'reverted' }));
+    updateAction(db, 'r3', { revertedAt: '2026-06-10T11:00:00Z' });
+
+    expect(countRevertsInWindow(db, 'prune', '2026-06-10T00:00:00Z')).toBe(1);
+    expect(countRevertsInWindow(db, 'consolidate', '2026-06-10T00:00:00Z')).toBe(1);
+  });
+});
+
+describe('seedTrustState + getTrustState + listTrustStates', () => {
+  let db: CerebrumDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('inserts a new row idempotently and reads it back', () => {
+    seedTrustState(db, {
+      actionType: 'prune',
+      currentPhase: 'propose',
+      approvedCount: 0,
+      rejectedCount: 0,
+      revertedCount: 0,
+      updatedAt: '2026-06-10T10:00:00Z',
+    });
+    seedTrustState(db, {
+      actionType: 'prune',
+      currentPhase: 'silent',
+      approvedCount: 99,
+      rejectedCount: 99,
+      revertedCount: 99,
+      updatedAt: '2026-06-10T11:00:00Z',
+    });
+
+    const state = getTrustState(db, 'prune');
+    expect(state?.currentPhase).toBe('propose');
+    expect(state?.approvedCount).toBe(0);
+  });
+
+  it('listTrustStates returns every seeded type', () => {
+    seedTrustState(db, {
+      actionType: 'prune',
+      currentPhase: 'propose',
+      approvedCount: 0,
+      rejectedCount: 0,
+      revertedCount: 0,
+      updatedAt: '2026-06-10T10:00:00Z',
+    });
+    seedTrustState(db, {
+      actionType: 'consolidate',
+      currentPhase: 'propose',
+      approvedCount: 0,
+      rejectedCount: 0,
+      revertedCount: 0,
+      updatedAt: '2026-06-10T10:00:00Z',
+    });
+    expect(
+      listTrustStates(db)
+        .map((s) => s.actionType)
+        .toSorted()
+    ).toEqual(['consolidate', 'prune']);
+  });
+});
+
+describe('updateTrustState + incrementTrustStateCounter', () => {
+  let db: CerebrumDb;
+  beforeEach(() => {
+    db = freshDb();
+    seedTrustState(db, {
+      actionType: 'prune',
+      currentPhase: 'propose',
+      approvedCount: 0,
+      rejectedCount: 0,
+      revertedCount: 0,
+      updatedAt: '2026-06-10T10:00:00Z',
+    });
+  });
+
+  it('patches a single field and returns the updated row', () => {
+    const updated = updateTrustState(db, 'prune', {
+      currentPhase: 'act_report',
+      autonomousSince: '2026-06-10T11:00:00Z',
+      updatedAt: '2026-06-10T11:00:00Z',
+    });
+    expect(updated?.currentPhase).toBe('act_report');
+    expect(updated?.autonomousSince).toBe('2026-06-10T11:00:00Z');
+  });
+
+  it('returns null when the action type was never seeded', () => {
+    expect(
+      updateTrustState(db, 'link', { currentPhase: 'silent', updatedAt: '2026-06-10T10:00:00Z' })
+    ).toBeNull();
+  });
+
+  it('incrementTrustStateCounter atomically bumps the named counter', () => {
+    incrementTrustStateCounter(db, 'prune', 'approvedCount', '2026-06-10T11:00:00Z');
+    incrementTrustStateCounter(db, 'prune', 'approvedCount', '2026-06-10T11:01:00Z');
+    incrementTrustStateCounter(db, 'prune', 'revertedCount', '2026-06-10T11:02:00Z');
+
+    const state = getTrustState(db, 'prune');
+    expect(state?.approvedCount).toBe(2);
+    expect(state?.revertedCount).toBe(1);
+    expect(state?.updatedAt).toBe('2026-06-10T11:02:00Z');
+  });
+});

--- a/packages/cerebrum-db/src/index.ts
+++ b/packages/cerebrum-db/src/index.ts
@@ -16,9 +16,14 @@
  *     namespace. Pops-api still owns engram routing and consumes the
  *     legacy shared handle via `getDrizzle()`; PRD-179 US-03 flips it
  *     over to `getCerebrumDrizzle()`.
+ *   - PRD-181 US-01 added the glia data layer — schemas, baseline
+ *     migration, and the `gliaService` namespace covering CRUD on
+ *     `glia_actions` and the per-action-type trust state. Trust
+ *     graduation, dispatch and digest rendering stay in pops-api until
+ *     PRD-181 US-03.
  *
- * The remaining slices (embeddings, conversations, glia, plexus) follow
- * in subsequent PRs. Cerebrum's load-bearing surgery is the URI
+ * The remaining slices (embeddings, conversations, plexus) follow in
+ * subsequent PRs. Cerebrum's load-bearing surgery is the URI
  * dispatcher round-trip (engrams reference other pillars' entities by
  * URI) — that lands when the consumers cut over, not in this scaffold.
  *
@@ -45,6 +50,7 @@ export {
 
 export * as nudgeLogService from './services/nudge-log.js';
 export * as engramsService from './services/engrams.js';
+export * as gliaService from './services/glia.js';
 
 export type {
   Nudge,
@@ -69,3 +75,22 @@ export type {
   ListEngramsResult,
   UpsertEngramArgs,
 } from './services/engrams-types.js';
+
+export {
+  ACTION_STATUSES,
+  ACTION_TYPES,
+  TRUST_PHASES,
+  USER_DECISIONS,
+  type ActionListFilters,
+  type ActionStatus,
+  type ActionType,
+  type GliaAction,
+  type GliaTrustState,
+  type InsertActionRow,
+  type ListActionsResult,
+  type SeedTrustStateRow,
+  type TrustPhase,
+  type UpdateActionPatch,
+  type UpdateTrustStatePatch,
+  type UserDecision,
+} from './services/glia-types.js';

--- a/packages/cerebrum-db/src/schema.ts
+++ b/packages/cerebrum-db/src/schema.ts
@@ -13,9 +13,12 @@
  *   - `nudgeLog` — PRD-084 reflex/nudge audit trail.
  *   - `engramIndex` / `engramScopes` / `engramTags` / `engramLinks` —
  *     PRD-179 atomic memory units + their graph edges.
+ *   - `gliaActions` / `gliaTrustState` — PRD-181 autonomous-action
+ *     proposals + per-type trust graduation state (ADR-021 / PRD-086).
  *
- * Downstream slices (embeddings, conversations, glia_actions,
- * plexus_adapters, plexus_filters) will add their tables here as their
- * service code lands.
+ * Downstream slices (embeddings, conversations, plexus_adapters,
+ * plexus_filters) will add their tables here as their service code
+ * lands.
  */
 export { engramIndex, engramLinks, engramScopes, engramTags, nudgeLog } from '@pops/db-types';
+export { gliaActions, gliaTrustState } from '@pops/db-types/schema';

--- a/packages/cerebrum-db/src/services/glia-helpers.ts
+++ b/packages/cerebrum-db/src/services/glia-helpers.ts
@@ -1,0 +1,49 @@
+/**
+ * Glia row serialisation helpers.
+ *
+ * Extracted so the SQL seam in `glia.ts` stays focused on queries and so
+ * tests can exercise the deserialisation logic in isolation.
+ */
+import type { gliaActions, gliaTrustState } from '../schema.js';
+import type {
+  ActionStatus,
+  ActionType,
+  GliaAction,
+  GliaTrustState,
+  TrustPhase,
+  UserDecision,
+} from './glia-types.js';
+
+/** Deserialise a row from `glia_actions` into a `GliaAction`. */
+export function rowToGliaAction(row: typeof gliaActions.$inferSelect): GliaAction {
+  return {
+    id: row.id,
+    actionType: row.actionType as ActionType,
+    affectedIds: JSON.parse(row.affectedIds) as string[],
+    rationale: row.rationale,
+    payload: row.payload != null ? (JSON.parse(row.payload) as unknown) : null,
+    phase: row.phase as TrustPhase,
+    status: row.status as ActionStatus,
+    userDecision: row.userDecision as UserDecision | null,
+    userNote: row.userNote,
+    executedAt: row.executedAt,
+    decidedAt: row.decidedAt,
+    revertedAt: row.revertedAt,
+    createdAt: row.createdAt,
+  };
+}
+
+/** Deserialise a row from `glia_trust_state` into a `GliaTrustState`. */
+export function rowToGliaTrustState(row: typeof gliaTrustState.$inferSelect): GliaTrustState {
+  return {
+    actionType: row.actionType as ActionType,
+    currentPhase: row.currentPhase as TrustPhase,
+    approvedCount: row.approvedCount,
+    rejectedCount: row.rejectedCount,
+    revertedCount: row.revertedCount,
+    autonomousSince: row.autonomousSince,
+    lastRevertAt: row.lastRevertAt,
+    graduatedAt: row.graduatedAt,
+    updatedAt: row.updatedAt,
+  };
+}

--- a/packages/cerebrum-db/src/services/glia-types.ts
+++ b/packages/cerebrum-db/src/services/glia-types.ts
@@ -1,0 +1,121 @@
+/**
+ * Glia public shapes returned from the data-access layer.
+ *
+ * Mirrors the action / trust-state shapes the pops-api `GliaActionService`
+ * exposes today. Kept in the data package so `cerebrum-api` and any other
+ * consumer can build views without re-deriving them from drizzle row
+ * shapes.
+ */
+
+/** The four Glia action types (ADR-021). */
+export const ACTION_TYPES = ['prune', 'consolidate', 'link', 'audit'] as const;
+export type ActionType = (typeof ACTION_TYPES)[number];
+
+/** Trust phases in graduation order (ADR-021). */
+export const TRUST_PHASES = ['propose', 'act_report', 'silent'] as const;
+export type TrustPhase = (typeof TRUST_PHASES)[number];
+
+/** Action lifecycle statuses. */
+export const ACTION_STATUSES = ['pending', 'approved', 'rejected', 'executed', 'reverted'] as const;
+export type ActionStatus = (typeof ACTION_STATUSES)[number];
+
+/** User decisions on a pending proposal. */
+export const USER_DECISIONS = ['approve', 'reject', 'modify'] as const;
+export type UserDecision = (typeof USER_DECISIONS)[number];
+
+/** A Glia action record — one row from `glia_actions` deserialised. */
+export interface GliaAction {
+  id: string;
+  actionType: ActionType;
+  affectedIds: string[];
+  rationale: string;
+  payload: unknown | null;
+  phase: TrustPhase;
+  status: ActionStatus;
+  userDecision: UserDecision | null;
+  userNote: string | null;
+  executedAt: string | null;
+  decidedAt: string | null;
+  revertedAt: string | null;
+  createdAt: string;
+}
+
+/** Trust state for a single action type — one row from `glia_trust_state`. */
+export interface GliaTrustState {
+  actionType: ActionType;
+  currentPhase: TrustPhase;
+  approvedCount: number;
+  rejectedCount: number;
+  revertedCount: number;
+  autonomousSince: string | null;
+  lastRevertAt: string | null;
+  graduatedAt: string | null;
+  updatedAt: string;
+}
+
+/** Filters for `listActions`. */
+export interface ActionListFilters {
+  actionType?: ActionType;
+  status?: ActionStatus;
+  dateFrom?: string;
+  dateTo?: string;
+  limit?: number;
+  offset?: number;
+}
+
+/** Result envelope from `listActions` — kept symmetrical with `nudge-log`. */
+export interface ListActionsResult {
+  actions: GliaAction[];
+  total: number;
+}
+
+/**
+ * Insert payload for `insertAction` — the data-access layer's contract for
+ * creating a new glia_actions row. The caller (pops-api today, cerebrum-api
+ * after the cutover) is responsible for ID generation, phase resolution,
+ * autonomous-vs-pending status branching, and any trust-state updates. This
+ * keeps the service decoupled from the trust machine.
+ */
+export interface InsertActionRow {
+  id: string;
+  actionType: ActionType;
+  affectedIds: readonly string[];
+  rationale: string;
+  payload: unknown | null;
+  phase: TrustPhase;
+  status: ActionStatus;
+  executedAt: string | null;
+  createdAt: string;
+}
+
+/** Patch payload for `updateAction` — only the lifecycle-mutable columns. */
+export interface UpdateActionPatch {
+  status?: ActionStatus;
+  userDecision?: UserDecision | null;
+  userNote?: string | null;
+  executedAt?: string | null;
+  decidedAt?: string | null;
+  revertedAt?: string | null;
+}
+
+/** Seed payload for `seedTrustState` — used to bootstrap a missing row. */
+export interface SeedTrustStateRow {
+  actionType: ActionType;
+  currentPhase: TrustPhase;
+  approvedCount: number;
+  rejectedCount: number;
+  revertedCount: number;
+  updatedAt: string;
+}
+
+/** Patch payload for `updateTrustState` — every field optional. */
+export interface UpdateTrustStatePatch {
+  currentPhase?: TrustPhase;
+  approvedCount?: number;
+  rejectedCount?: number;
+  revertedCount?: number;
+  autonomousSince?: string | null;
+  lastRevertAt?: string | null;
+  graduatedAt?: string | null;
+  updatedAt: string;
+}

--- a/packages/cerebrum-db/src/services/glia.ts
+++ b/packages/cerebrum-db/src/services/glia.ts
@@ -1,0 +1,300 @@
+/**
+ * Glia data-access for the cerebrum pillar (PRD-181 US-01).
+ *
+ * Scope boundary: this file is the SQL seam for the glia slice. It covers
+ * CRUD on `glia_actions` plus seed / read / update on `glia_trust_state`
+ * and a handful of window/count helpers the digest + trust machine in
+ * pops-api depend on. The trust-graduation orchestration (phase
+ * transitions, demotion windows, threshold reads from
+ * `engrams/.config/glia.toml` + settings DB), the in-process dispatch
+ * (`GliaActionService.executeAction` callbacks, cross-pillar SDK writes),
+ * the scheduled digest renderer and channel filesystem layout stay in
+ * `apps/pops-api/src/modules/cerebrum/glia/*` until PRD-181 US-03 flips
+ * routing through `getCerebrumDrizzle()`. That keeps this package pure
+ * data-access — no node:fs imports, no zod, no domain orchestration.
+ *
+ * The functions take a `CerebrumDb` handle as their first argument; the
+ * calling layer (pops-api today, `cerebrum-api` after the cutover)
+ * resolves the singleton or transaction handle. Mirrors the
+ * `nudge-log.ts` / `engrams.ts` db-arg pattern in this package.
+ */
+import { and, asc, count, desc, eq, gte, isNotNull, isNull, lt, lte, sql } from 'drizzle-orm';
+
+import { gliaActions, gliaTrustState } from '../schema.js';
+import { rowToGliaAction, rowToGliaTrustState } from './glia-helpers.js';
+
+import type {
+  ActionListFilters,
+  ActionType,
+  GliaAction,
+  GliaTrustState,
+  InsertActionRow,
+  ListActionsResult,
+  SeedTrustStateRow,
+  UpdateActionPatch,
+  UpdateTrustStatePatch,
+} from './glia-types.js';
+import type { CerebrumDb } from './internal.js';
+
+export { rowToGliaAction, rowToGliaTrustState };
+
+/** Fetch a single action by id. Returns null when missing. */
+export function getAction(db: CerebrumDb, id: string): GliaAction | null {
+  const row = db.select().from(gliaActions).where(eq(gliaActions.id, id)).get();
+  return row ? rowToGliaAction(row) : null;
+}
+
+/**
+ * Paginated list of actions matching the supplied filters. Orders by
+ * `created_at desc` so the most recent proposals surface first. Returns
+ * both the rows and the unpaginated `total` so the caller can drive a
+ * paging UI without a second round-trip.
+ */
+export function listActions(db: CerebrumDb, filters: ActionListFilters = {}): ListActionsResult {
+  const conditions = [];
+  if (filters.actionType) conditions.push(eq(gliaActions.actionType, filters.actionType));
+  if (filters.status) conditions.push(eq(gliaActions.status, filters.status));
+  if (filters.dateFrom) conditions.push(gte(gliaActions.createdAt, filters.dateFrom));
+  if (filters.dateTo) conditions.push(lte(gliaActions.createdAt, filters.dateTo));
+
+  const where = conditions.length > 0 ? and(...conditions) : undefined;
+  const limit = filters.limit ?? 50;
+  const offset = filters.offset ?? 0;
+
+  const rows = db
+    .select()
+    .from(gliaActions)
+    .where(where)
+    .orderBy(desc(gliaActions.createdAt))
+    .limit(limit)
+    .offset(offset)
+    .all();
+
+  const [totalRow] = db.select({ total: count() }).from(gliaActions).where(where).all();
+
+  return {
+    actions: rows.map(rowToGliaAction),
+    total: totalRow?.total ?? 0,
+  };
+}
+
+/**
+ * Insert a fully-formed `glia_actions` row. The caller is expected to have
+ * generated the id and resolved phase/status/executedAt according to the
+ * trust machine's rules; this function only serialises and writes.
+ */
+export function insertAction(db: CerebrumDb, row: InsertActionRow): GliaAction {
+  const values = {
+    id: row.id,
+    actionType: row.actionType,
+    affectedIds: JSON.stringify([...row.affectedIds]),
+    rationale: row.rationale,
+    payload: row.payload != null ? JSON.stringify(row.payload) : null,
+    phase: row.phase,
+    status: row.status,
+    userDecision: null,
+    userNote: null,
+    executedAt: row.executedAt,
+    decidedAt: null,
+    revertedAt: null,
+    createdAt: row.createdAt,
+  };
+  db.insert(gliaActions).values(values).run();
+  return rowToGliaAction(values);
+}
+
+/**
+ * Apply a lifecycle patch to an action. Returns the resulting row or null
+ * if the action no longer exists. The patch shape is intentionally narrow:
+ * only columns that mutate over an action's lifecycle (status + the four
+ * timestamp/decision columns) can be set. Identity columns and the
+ * payload are immutable post-insert.
+ */
+export function updateAction(
+  db: CerebrumDb,
+  id: string,
+  patch: UpdateActionPatch
+): GliaAction | null {
+  if (Object.keys(patch).length === 0) return getAction(db, id);
+  db.update(gliaActions).set(patch).where(eq(gliaActions.id, id)).run();
+  return getAction(db, id);
+}
+
+/**
+ * Hard-delete an action row. Returns the number of rows actually deleted
+ * (0 if `id` was already gone — caller can treat this as idempotent).
+ * Trust-state counters are intentionally NOT decremented; counters track
+ * lifetime decisions, not active rows, and reverts are modelled via
+ * status transitions rather than deletions.
+ */
+export function deleteAction(db: CerebrumDb, id: string): number {
+  return db.delete(gliaActions).where(eq(gliaActions.id, id)).run().changes;
+}
+
+/**
+ * Autonomous actions executed in `[startDate, endDate)`. Filters out rows
+ * with a user decision so only worker-executed actions surface in the
+ * digest. Window is matched against `executed_at` because `created_at`
+ * could be earlier than execution for delayed worker runs; the end bound
+ * is exclusive so a row pinned on the boundary can't appear in two
+ * consecutive digests.
+ */
+export function listAutonomousActionsInWindow(
+  db: CerebrumDb,
+  startDate: string,
+  endDate: string
+): GliaAction[] {
+  const rows = db
+    .select()
+    .from(gliaActions)
+    .where(
+      and(
+        eq(gliaActions.status, 'executed'),
+        isNull(gliaActions.decidedAt),
+        gte(gliaActions.executedAt, startDate),
+        lt(gliaActions.executedAt, endDate)
+      )
+    )
+    .orderBy(asc(gliaActions.executedAt))
+    .all();
+  return rows.map(rowToGliaAction);
+}
+
+/**
+ * Count autonomous actions still in `executed` status for an action type
+ * since `sinceIso`. Excludes reverted rows so the digest can compute the
+ * rejection rate as `reverted / (executed + reverted)` without
+ * double-counting actions that have already been rolled back.
+ */
+export function countAutonomousExecutionsSince(
+  db: CerebrumDb,
+  actionType: ActionType,
+  sinceIso: string
+): number {
+  const row = db
+    .select({ total: count() })
+    .from(gliaActions)
+    .where(
+      and(
+        eq(gliaActions.actionType, actionType),
+        eq(gliaActions.status, 'executed'),
+        isNull(gliaActions.decidedAt),
+        gte(gliaActions.executedAt, sinceIso)
+      )
+    )
+    .get();
+  return row?.total ?? 0;
+}
+
+/**
+ * Count autonomous reverts for an action type since `sinceIso`. The
+ * `isNotNull(revertedAt)` guard makes intent explicit: a row with
+ * `status='reverted'` but null `reverted_at` is excluded by design rather
+ * than by SQL accident.
+ */
+export function countAutonomousRevertsSince(
+  db: CerebrumDb,
+  actionType: ActionType,
+  sinceIso: string
+): number {
+  const row = db
+    .select({ total: count() })
+    .from(gliaActions)
+    .where(
+      and(
+        eq(gliaActions.actionType, actionType),
+        eq(gliaActions.status, 'reverted'),
+        isNull(gliaActions.decidedAt),
+        isNotNull(gliaActions.revertedAt),
+        gte(gliaActions.revertedAt, sinceIso)
+      )
+    )
+    .get();
+  return row?.total ?? 0;
+}
+
+/**
+ * Count reverts within a rolling window for an action type. Used by the
+ * trust machine's demotion check (2+ reverts in 7 days → demote).
+ */
+export function countRevertsInWindow(
+  db: CerebrumDb,
+  actionType: ActionType,
+  windowStart: string
+): number {
+  const row = db
+    .select({ total: count() })
+    .from(gliaActions)
+    .where(
+      and(
+        eq(gliaActions.actionType, actionType),
+        eq(gliaActions.status, 'reverted'),
+        gte(gliaActions.revertedAt, windowStart)
+      )
+    )
+    .get();
+  return row?.total ?? 0;
+}
+
+/**
+ * Fetch trust state for a single action type. Returns null when the row
+ * has not been seeded yet — the caller (pops-api today) decides whether
+ * to surface that as an error or to seed lazily.
+ */
+export function getTrustState(db: CerebrumDb, actionType: ActionType): GliaTrustState | null {
+  const row = db
+    .select()
+    .from(gliaTrustState)
+    .where(eq(gliaTrustState.actionType, actionType))
+    .get();
+  return row ? rowToGliaTrustState(row) : null;
+}
+
+/** List every seeded trust-state row. */
+export function listTrustStates(db: CerebrumDb): GliaTrustState[] {
+  return db.select().from(gliaTrustState).all().map(rowToGliaTrustState);
+}
+
+/**
+ * Seed a trust-state row idempotently. Re-seeding an existing row is a
+ * no-op (via `onConflictDoNothing`) so callers can call this on every
+ * boot without clobbering counters that have already drifted from zero.
+ */
+export function seedTrustState(db: CerebrumDb, row: SeedTrustStateRow): void {
+  db.insert(gliaTrustState).values(row).onConflictDoNothing().run();
+}
+
+/**
+ * Apply a patch to a trust-state row. Returns the resulting row or null if
+ * the action type has not been seeded. `updatedAt` is required on the
+ * patch so the caller is forced to think about which clock to use; the
+ * service intentionally does not call `new Date()` itself.
+ */
+export function updateTrustState(
+  db: CerebrumDb,
+  actionType: ActionType,
+  patch: UpdateTrustStatePatch
+): GliaTrustState | null {
+  db.update(gliaTrustState).set(patch).where(eq(gliaTrustState.actionType, actionType)).run();
+  return getTrustState(db, actionType);
+}
+
+/**
+ * Increment one of the trust-state counters atomically and bump
+ * `updatedAt`. Used by the decide/revert paths in pops-api where the
+ * counter delta and the corresponding action update need to land in the
+ * same logical write. The caller wraps both writes in a single
+ * transaction.
+ */
+export function incrementTrustStateCounter(
+  db: CerebrumDb,
+  actionType: ActionType,
+  counter: 'approvedCount' | 'rejectedCount' | 'revertedCount',
+  updatedAt: string
+): void {
+  const column = gliaTrustState[counter];
+  db.update(gliaTrustState)
+    .set({ [counter]: sql`${column} + 1`, updatedAt })
+    .where(eq(gliaTrustState.actionType, actionType))
+    .run();
+}


### PR DESCRIPTION
## Summary

PR 1 of [PRD-181: cerebrum.glia cutover](docs/themes/13-pillar-finale/prds/181-cerebrum-glia-cutover/README.md). Stands up the glia data layer on `@pops/cerebrum-db` — schema re-exports, baseline migration, service, backfill. Purely additive — pops-api still writes and reads through `getDrizzle()`, no router or consumer changes. US-03 flips routing through `getCerebrumDrizzle()`.

> Mirrors PR #2994 (PRD-179 US-01 engrams scaffold). This branch is stacked on top of `feat/theme13-prd-179-us-01-cerebrum-db-engrams-scaffold` so the journal slot `0051` is sequenced after `0050`; rebase onto main once #2994 merges.

> PRD-181's README mentions `glia_digests` / `glia_digest_channels`, but the live schema only persists `glia_actions` + `glia_trust_state` — digests are rendered on demand from those tables plus `nudge_log`. This PR scopes to the actually-persisted shape; the PRD doc itself should be reconciled separately.

## What changed

### `@pops/cerebrum-db`

- **Schema** — re-exports `gliaActions` + `gliaTrustState` from `@pops/db-types/schema` alongside the existing engrams + nudge_log re-exports (canonical defs stay in `@pops/db-types`).
- **Baseline migration** — `migrations/0051_glia_baseline.sql` copies the shared `glia_actions` / `glia_trust_state` definitions verbatim (post the `0047_glia_actions` safety migration) so a fresh `cerebrum.db` matches the shared shape byte-for-byte.
- **`gliaService`** — data-access only: `getAction`, `listActions` (filtered + paginated), `insertAction`, `updateAction` (narrow lifecycle patch), `deleteAction`, `listAutonomousActionsInWindow`, `countAutonomousExecutionsSince`, `countAutonomousRevertsSince`, `countRevertsInWindow`, `getTrustState`, `listTrustStates`, `seedTrustState` (idempotent), `updateTrustState`, and an atomic `incrementTrustStateCounter`. Trust graduation, dispatch and digest rendering stay in pops-api until US-03 per the service's top-level scope-boundary JSDoc.
- **Barrel** — adds `gliaService` namespace plus `ACTION_TYPES` / `ACTION_STATUSES` / `TRUST_PHASES` / `USER_DECISIONS` enums and `ActionType` / `ActionStatus` / `TrustPhase` / `UserDecision` / `GliaAction` / `GliaTrustState` / `ActionListFilters` / `ListActionsResult` / `InsertActionRow` / `UpdateActionPatch` / `SeedTrustStateRow` / `UpdateTrustStatePatch` types.

### `apps/pops-api`

- `backfill-cerebrum-from-shared.ts` adds `glia_actions` + `glia_trust_state` to `TABLE_COPIES`. The two tables have no cross-table FKs so their order is independent of the engram block; `glia_trust_state` uses its `action_type` PK as the existence-filter column (same idempotency pattern as `engram_scopes`).
- `per-pillar-migrations.test.ts` expected migration list now includes `0051_glia_baseline` alongside `0050_engrams_baseline` and `0055_pillar_registry`.

## Test plan

- [x] `pnpm -F @pops/cerebrum-db build && test && typecheck` — 68 tests green (4 test files: nudge-log, open-cerebrum-db, engrams, glia)
- [x] `pnpm -F @pops/api test` — full pops-api suite 4908/4908 pass including backfill + per-pillar-migrations
- [x] `pnpm -w typecheck` — 66/66 tasks green
- [x] `pnpm oxlint` + `pnpm oxfmt` on changed files — clean
