### PR TITLE
feat(core-db): scaffold settings service + baseline migration (PRD-183 US-01)

### DIFF
--- a/apps/pops-api/src/db/backfill-core-from-shared.test.ts
+++ b/apps/pops-api/src/db/backfill-core-from-shared.test.ts
@@ -19,7 +19,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { openCoreDb } from '@pops/core-db';
 
 import { backfillCoreFromShared, closeCoreDb, setCoreDb } from '../db.js';
-import { SERVICE_ACCOUNTS_TABLE_SQL } from './backfill-test-fixtures.js';
+import { SERVICE_ACCOUNTS_TABLE_SQL, SETTINGS_TABLE_SQL } from './backfill-test-fixtures.js';
 
 let tmpDir: string;
 
@@ -124,5 +124,104 @@ describe('backfillCoreFromShared', () => {
       n: number;
     };
     expect(count.n).toBe(0);
+  });
+
+  describe('settings (PRD-183 PR 1)', () => {
+    function openSharedWithSettings(rows: { key: string; value: string }[]): string {
+      const path = join(tmpDir, 'pops.db');
+      const raw = new BetterSqlite3(path);
+      raw.exec(SERVICE_ACCOUNTS_TABLE_SQL);
+      raw.exec(SETTINGS_TABLE_SQL);
+      const insert = raw.prepare('INSERT INTO settings (key, value) VALUES (?, ?)');
+      for (const row of rows) insert.run(row.key, row.value);
+      raw.close();
+      process.env['SQLITE_PATH'] = path;
+      return path;
+    }
+
+    it('copies fresh settings rows on first run and is a no-op on the second', () => {
+      openSharedWithSettings([
+        { key: 'ui.theme', value: 'dark' },
+        { key: 'ai.model', value: 'sonnet' },
+      ]);
+      const core = openCoreDb(join(tmpDir, 'core.db'));
+      setCoreDb(core);
+
+      backfillCoreFromShared();
+      const after = core.raw.prepare('SELECT key, value FROM settings ORDER BY key').all() as {
+        key: string;
+        value: string;
+      }[];
+      expect(after).toEqual([
+        { key: 'ai.model', value: 'sonnet' },
+        { key: 'ui.theme', value: 'dark' },
+      ]);
+
+      backfillCoreFromShared();
+      const second = core.raw.prepare('SELECT count(*) AS n FROM settings').get() as {
+        n: number;
+      };
+      expect(second.n).toBe(2);
+    });
+
+    it('only inserts settings rows missing from the core copy (preserves existing values)', () => {
+      openSharedWithSettings([
+        { key: 'ui.theme', value: 'dark' },
+        { key: 'ai.model', value: 'sonnet' },
+      ]);
+      const core = openCoreDb(join(tmpDir, 'core.db'));
+      setCoreDb(core);
+      core.raw
+        .prepare('INSERT INTO settings (key, value) VALUES (?, ?)')
+        .run('ui.theme', 'pre-existing-value');
+
+      backfillCoreFromShared();
+      const rows = core.raw.prepare('SELECT key, value FROM settings ORDER BY key').all() as {
+        key: string;
+        value: string;
+      }[];
+      expect(rows).toEqual([
+        { key: 'ai.model', value: 'sonnet' },
+        { key: 'ui.theme', value: 'pre-existing-value' },
+      ]);
+    });
+
+    it('tolerates a shared DB without the settings table', () => {
+      const path = join(tmpDir, 'pops.db');
+      const raw = new BetterSqlite3(path);
+      raw.exec(SERVICE_ACCOUNTS_TABLE_SQL);
+      raw.close();
+      process.env['SQLITE_PATH'] = path;
+
+      const core = openCoreDb(join(tmpDir, 'core.db'));
+      setCoreDb(core);
+
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      try {
+        expect(() => backfillCoreFromShared()).not.toThrow();
+        expect(warn).not.toHaveBeenCalled();
+      } finally {
+        warn.mockRestore();
+      }
+      const count = core.raw.prepare('SELECT count(*) AS n FROM settings').get() as {
+        n: number;
+      };
+      expect(count.n).toBe(0);
+    });
+
+    it('carries every column across (full-shape roundtrip)', () => {
+      openSharedWithSettings([
+        { key: 'ai.modelOverrides.query', value: 'haiku' },
+        { key: 'cerebrum.auditor.contradictionModel', value: 'opus' },
+      ]);
+      const core = openCoreDb(join(tmpDir, 'core.db'));
+      setCoreDb(core);
+
+      backfillCoreFromShared();
+      const row = core.raw
+        .prepare('SELECT key, value FROM settings WHERE key = ?')
+        .get('ai.modelOverrides.query') as { key: string; value: string };
+      expect(row).toEqual({ key: 'ai.modelOverrides.query', value: 'haiku' });
+    });
   });
 });

--- a/apps/pops-api/src/db/backfill-test-fixtures-core.ts
+++ b/apps/pops-api/src/db/backfill-test-fixtures-core.ts
@@ -20,3 +20,10 @@ CREATE UNIQUE INDEX service_accounts_key_prefix_unique ON service_accounts (key_
 CREATE INDEX idx_service_accounts_key_prefix ON service_accounts (key_prefix);
 CREATE INDEX idx_service_accounts_revoked_at ON service_accounts (revoked_at);
 `;
+
+export const SETTINGS_TABLE_SQL = `
+CREATE TABLE settings (
+  key text PRIMARY KEY NOT NULL,
+  value text NOT NULL
+);
+`;

--- a/apps/pops-api/src/db/backfill-test-fixtures.ts
+++ b/apps/pops-api/src/db/backfill-test-fixtures.ts
@@ -12,10 +12,7 @@
  * `-media.ts`, `-finance.ts`) so each file stays under the 200-line
  * lint cap. This barrel keeps the existing import surface stable.
  */
-export {
-  SERVICE_ACCOUNTS_TABLE_SQL,
-  SETTINGS_TABLE_SQL,
-} from './backfill-test-fixtures-core.js';
+export { SERVICE_ACCOUNTS_TABLE_SQL, SETTINGS_TABLE_SQL } from './backfill-test-fixtures-core.js';
 export {
   MOVIES_TABLE_SQL,
   SHELF_IMPRESSIONS_TABLE_SQL,

--- a/apps/pops-api/src/db/backfill-test-fixtures.ts
+++ b/apps/pops-api/src/db/backfill-test-fixtures.ts
@@ -12,7 +12,10 @@
  * `-media.ts`, `-finance.ts`) so each file stays under the 200-line
  * lint cap. This barrel keeps the existing import surface stable.
  */
-export { SERVICE_ACCOUNTS_TABLE_SQL } from './backfill-test-fixtures-core.js';
+export {
+  SERVICE_ACCOUNTS_TABLE_SQL,
+  SETTINGS_TABLE_SQL,
+} from './backfill-test-fixtures-core.js';
 export {
   MOVIES_TABLE_SQL,
   SHELF_IMPRESSIONS_TABLE_SQL,

--- a/apps/pops-api/src/db/core-backfill.ts
+++ b/apps/pops-api/src/db/core-backfill.ts
@@ -1,25 +1,82 @@
 import { resolveSqlitePath } from './sqlite-path.js';
 
 /**
- * One-shot core-pillar backfill — copies service-account rows from the
- * shared `pops.db` into `core.db` via ATTACH.
+ * Boot-time backfill from the legacy shared `pops.db` into the core
+ * pillar's `core.db`.
  *
- * Lifted out of `db.ts` so that file stays under the eslint(max-lines) cap
- * once the core + inventory + media pillar handles + the closes all
- * landed there. The behaviour is unchanged.
+ * Each slice cutover (Phase 2 PR 3 service-accounts, PRD-183 settings, …)
+ * flips its handle to `getCoreDrizzle()`. The first deploy after each
+ * cutover needs to carry the existing rows from the shared DB across
+ * before any reads come from the new file. Subsequent boots find the
+ * core copy already populated and become a no-op via the
+ * `WHERE <id> NOT IN (...)` existence filter on every table.
  *
- * Boot-time contract: Phase 2 PR 2 opened the core DB but did not yet
- * consume it. PR 3 (this entry point) flipped service-accounts traffic
- * to the core handle, so the first deploy after PR 3 carried the existing
- * rows across before any reads came from the new file. Subsequent boots
- * find the core copy already populated and become a no-op via the
- * `WHERE id NOT IN (...)` existence filter.
+ * No FK relationships exist between the listed core tables, so order
+ * is independent — but each entry is wrapped in `tryCopyTable` so a
+ * missing source table (post-PR-4 drop scenario, or a stale on-disk
+ * pops.db) doesn't bring the whole backfill down. Failures are logged
+ * + swallowed; the remaining tables still attempt.
  *
  * Non-fatal: ATTACH or INSERT failures are logged and swallowed so a
- * stale on-disk pops.db never bricks the boot path. Failures here leave
- * the core copy empty for that boot; the next deploy retries.
+ * stale on-disk pops.db never bricks the boot path. Failures here
+ * leave the core copy partially populated for that boot; the next
+ * deploy retries and the idempotent filter picks up only the
+ * still-missing rows.
+ *
+ * Mirrors `./backfill-finance-from-shared.ts` and `./media-backfill.ts`.
  */
 import type Database from 'better-sqlite3';
+
+interface TableCopy {
+  readonly table: string;
+  /** Explicit column list keeps the backfill robust against a stale
+   * on-disk pops.db that already widened or narrowed since the boot
+   * image was built. */
+  readonly columns: readonly string[];
+  /** Identifier column used in the existence filter. */
+  readonly idColumn: string;
+}
+
+const TABLE_COPIES: readonly TableCopy[] = [
+  {
+    table: 'service_accounts',
+    idColumn: 'id',
+    columns: [
+      'id',
+      'name',
+      'key_prefix',
+      'key_hash',
+      'scopes',
+      'created_at',
+      'last_used_at',
+      'revoked_at',
+      'created_by',
+    ],
+  },
+  {
+    table: 'settings',
+    idColumn: 'key',
+    columns: ['key', 'value'],
+  },
+];
+
+function tryCopyTable(raw: Database.Database, copy: TableCopy): void {
+  try {
+    const hasTable = raw
+      .prepare(`SELECT 1 FROM pops.sqlite_master WHERE type='table' AND name='${copy.table}'`)
+      .get();
+    if (!hasTable) return;
+    const cols = copy.columns.join(', ');
+    raw.exec(`
+      INSERT INTO ${copy.table} (${cols})
+      SELECT ${cols}
+      FROM pops.${copy.table}
+      WHERE ${copy.idColumn} NOT IN (SELECT ${copy.idColumn} FROM ${copy.table})
+    `);
+  } catch (err) {
+    console.warn(`[db] Core backfill of ${copy.table} failed (non-fatal):`, err);
+  }
+}
 
 /**
  * Run the idempotent backfill against the open core SQLite handle. The
@@ -33,30 +90,11 @@ export function backfillCoreFromShared(coreRaw: Database.Database | null): void 
   try {
     coreRaw.prepare('ATTACH DATABASE ? AS pops').run(sharedPath);
     try {
-      const hasTable = coreRaw
-        .prepare("SELECT 1 FROM pops.sqlite_master WHERE type='table' AND name='service_accounts'")
-        .get();
-      if (hasTable) {
-        // Enumerate columns explicitly so a future migration that
-        // widens the core table won't break the backfill against a
-        // stale on-disk pops.db that still has the older shape. Order
-        // matches the 0054_service_accounts.sql DDL byte-for-byte.
-        coreRaw.exec(`
-          INSERT INTO service_accounts (
-            id, name, key_prefix, key_hash, scopes,
-            created_at, last_used_at, revoked_at, created_by
-          )
-          SELECT
-            id, name, key_prefix, key_hash, scopes,
-            created_at, last_used_at, revoked_at, created_by
-          FROM pops.service_accounts
-          WHERE id NOT IN (SELECT id FROM service_accounts)
-        `);
-      }
+      for (const copy of TABLE_COPIES) tryCopyTable(coreRaw, copy);
     } finally {
       coreRaw.exec('DETACH DATABASE pops');
     }
   } catch (err) {
-    console.warn('[db] Core service-accounts backfill failed (non-fatal):', err);
+    console.warn('[db] Core backfill ATTACH failed (non-fatal):', err);
   }
 }

--- a/apps/pops-api/src/db/per-pillar-migrations.test.ts
+++ b/apps/pops-api/src/db/per-pillar-migrations.test.ts
@@ -203,8 +203,9 @@ describe('runPerPillarMigrations', () => {
     // Smoke check: importing the runner under the real layout exercises
     // the workspace fallback path against an actual on-disk pillar dir.
     // `core` owns `packages/core-db/migrations/` with 0054_service_accounts
-    // (core pillar Phase 1 PR 2) and 0055_pillar_registry (Theme 13 PRD-161
-    // registry endpoints); `media` owns `packages/media-db/migrations/`
+    // (core pillar Phase 1 PR 2), 0055_pillar_registry (Theme 13 PRD-161
+    // registry endpoints), and 0056_settings_baseline (PRD-183 US-01 —
+    // settings baseline); `media` owns `packages/media-db/migrations/`
     // with 0021_spooky_lockheed (media pillar Phase 1 PR 2),
     // 0022_media_movies_baseline (Theme 13 PRD-165 US-01 — movies baseline),
     // 0023_watchlist_baseline (Theme 13 PRD-167 PR 1 — watchlist baseline),
@@ -242,6 +243,7 @@ describe('runPerPillarMigrations', () => {
         '0044_nudge_log',
         '0054_service_accounts',
         '0055_pillar_registry',
+        '0056_settings_baseline',
       ]);
       expect([...result.pillarsApplied].toSorted()).toEqual([
         'cerebrum',

--- a/docs/themes/13-pillar-finale/prds/183-core-settings-cutover/README.md
+++ b/docs/themes/13-pillar-finale/prds/183-core-settings-cutover/README.md
@@ -10,10 +10,19 @@ Settings are key-value app configuration: theme, language, default behaviours, f
 
 ## Data Model
 
-Tables (move from shared to `packages/core-db`):
+Tables (move from shared to `packages/core-db`). Schema mirrors the existing
+shared definitions verbatim — the cutover preserves them as-is and does not
+re-shape them. Any future widening (typed value columns, `updated_at`, etc.)
+ships under its own PRD.
 
-- `settings` — { key, value_text, value_json, value_type, updated_at } (global app settings)
-- `user_settings` — { user_id, key, value, updated_at } (per-user; single-user today but kept for future)
+- `settings` — `{ key TEXT PK, value TEXT NOT NULL }` (global app settings).
+  Callers JSON-encode structured values into `value`.
+- `user_settings` — `{ user_email TEXT, key TEXT, value TEXT NOT NULL,
+PRIMARY KEY (user_email, key) }` with `idx_user_settings_user` on
+  `user_email` (per-user; single-user today but kept for future).
+  Scoped to PR 1's follow-up — the US-01 baseline only ships the `settings`
+  table; `user_settings` lands alongside the journal split (PR 2) so the
+  shared journal can drop both at once.
 
 ## API Surface
 

--- a/packages/core-db/migrations/0056_settings_baseline.sql
+++ b/packages/core-db/migrations/0056_settings_baseline.sql
@@ -1,0 +1,4 @@
+CREATE TABLE `settings` (
+	`key` text PRIMARY KEY NOT NULL,
+	`value` text NOT NULL
+);

--- a/packages/core-db/migrations/meta/_journal.json
+++ b/packages/core-db/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1781568000000,
       "tag": "0055_pillar_registry",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1781827200000,
+      "tag": "0056_settings_baseline",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core-db/src/__tests__/settings.test.ts
+++ b/packages/core-db/src/__tests__/settings.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Invariant tests for the settings service against an in-memory SQLite
+ * seeded with the canonical `0056_settings_baseline.sql` migration. Pure
+ * DB + service layer — no tRPC, no Express, no feature-toggle wiring.
+ *
+ * Higher-level router-level coverage continues to live in pops-api's own
+ * suite (`apps/pops-api/src/modules/core/settings/settings.test.ts`) and
+ * exercises the same persisted shape via the in-tree shim until PRD-183
+ * PR 3 flips it onto this service.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { SettingNotFoundError } from '../errors.js';
+import {
+  deleteSetting,
+  getBulkSettings,
+  getSetting,
+  getSettingOrNull,
+  getSettingValue,
+  listSettings,
+  setBulkSettings,
+  setRawSetting,
+  setSetting,
+} from '../services/settings.js';
+
+import type { CoreDb } from '../services/internal.js';
+
+const MIGRATION_PATH = join(__dirname, '../../migrations/0056_settings_baseline.sql');
+
+function freshDb(): CoreDb {
+  const raw = new Database(':memory:');
+  raw.pragma('foreign_keys = ON');
+  const sql = readFileSync(MIGRATION_PATH, 'utf8');
+  for (const stmt of sql.split('--> statement-breakpoint')) {
+    const trimmed = stmt.trim();
+    if (trimmed.length > 0) raw.exec(trimmed);
+  }
+  return drizzle(raw);
+}
+
+describe('setSetting / setRawSetting', () => {
+  let db: CoreDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('inserts a new key and returns the persisted row', () => {
+    const row = setSetting(db, { key: 'ui.theme', value: 'dark' });
+    expect(row).toEqual({ key: 'ui.theme', value: 'dark' });
+  });
+
+  it('updates an existing key on the second call (UPSERT)', () => {
+    setSetting(db, { key: 'ui.theme', value: 'dark' });
+    const row = setSetting(db, { key: 'ui.theme', value: 'light' });
+    expect(row.value).toBe('light');
+    const all = listSettings(db, undefined, 10, 0);
+    expect(all.total).toBe(1);
+  });
+
+  it('setRawSetting accepts an arbitrary key namespace', () => {
+    const row = setRawSetting(db, 'feature.flag.beta', 'true');
+    expect(row).toEqual({ key: 'feature.flag.beta', value: 'true' });
+  });
+});
+
+describe('getSetting / getSettingOrNull', () => {
+  let db: CoreDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('getSetting returns the persisted row', () => {
+    setSetting(db, { key: 'k', value: 'v' });
+    expect(getSetting(db, 'k')).toEqual({ key: 'k', value: 'v' });
+  });
+
+  it('getSetting throws SettingNotFoundError on miss', () => {
+    expect(() => getSetting(db, 'missing')).toThrow(SettingNotFoundError);
+  });
+
+  it('getSettingOrNull returns null on miss without throwing', () => {
+    expect(getSettingOrNull(db, 'missing')).toBeNull();
+  });
+
+  it('getSettingOrNull returns the row when present', () => {
+    setSetting(db, { key: 'k', value: 'v' });
+    expect(getSettingOrNull(db, 'k')).toEqual({ key: 'k', value: 'v' });
+  });
+});
+
+describe('listSettings', () => {
+  let db: CoreDb;
+  beforeEach(() => {
+    db = freshDb();
+    setSetting(db, { key: 'ai.model', value: 'sonnet' });
+    setSetting(db, { key: 'ai.modelOverrides.query', value: 'haiku' });
+    setSetting(db, { key: 'ui.theme', value: 'dark' });
+  });
+
+  it('returns rows ordered by key with the total count', () => {
+    const result = listSettings(db, undefined, 10, 0);
+    expect(result.total).toBe(3);
+    expect(result.rows.map((r) => r.key)).toEqual([
+      'ai.model',
+      'ai.modelOverrides.query',
+      'ui.theme',
+    ]);
+  });
+
+  it('respects limit + offset for pagination', () => {
+    const result = listSettings(db, undefined, 1, 1);
+    expect(result.total).toBe(3);
+    expect(result.rows.map((r) => r.key)).toEqual(['ai.modelOverrides.query']);
+  });
+
+  it('filters by key LIKE when `search` is set', () => {
+    const result = listSettings(db, 'ai.', 10, 0);
+    expect(result.total).toBe(2);
+    expect(result.rows.map((r) => r.key)).toEqual(['ai.model', 'ai.modelOverrides.query']);
+  });
+
+  it('returns zero rows when the search matches nothing', () => {
+    const result = listSettings(db, 'nope', 10, 0);
+    expect(result.total).toBe(0);
+    expect(result.rows).toEqual([]);
+  });
+});
+
+describe('getBulkSettings', () => {
+  let db: CoreDb;
+  beforeEach(() => {
+    db = freshDb();
+    setSetting(db, { key: 'a', value: '1' });
+    setSetting(db, { key: 'b', value: '2' });
+  });
+
+  it('returns the requested key→value map', () => {
+    expect(getBulkSettings(db, ['a', 'b'])).toEqual({ a: '1', b: '2' });
+  });
+
+  it('omits missing keys from the result', () => {
+    expect(getBulkSettings(db, ['a', 'missing'])).toEqual({ a: '1' });
+  });
+
+  it('short-circuits to {} when given an empty input', () => {
+    expect(getBulkSettings(db, [])).toEqual({});
+  });
+
+  it('de-dupes the input before the IN clause', () => {
+    expect(getBulkSettings(db, ['a', 'a', 'a'])).toEqual({ a: '1' });
+  });
+});
+
+describe('setBulkSettings', () => {
+  let db: CoreDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('inserts every entry in a single transaction', () => {
+    const written = setBulkSettings(db, [
+      { key: 'a', value: '1' },
+      { key: 'b', value: '2' },
+    ]);
+    expect(written).toEqual({ a: '1', b: '2' });
+    expect(listSettings(db, undefined, 10, 0).total).toBe(2);
+  });
+
+  it('upserts existing keys without inserting duplicates', () => {
+    setSetting(db, { key: 'a', value: 'old' });
+    const written = setBulkSettings(db, [{ key: 'a', value: 'new' }]);
+    expect(written).toEqual({ a: 'new' });
+    const result = listSettings(db, undefined, 10, 0);
+    expect(result.total).toBe(1);
+    expect(result.rows[0]).toEqual({ key: 'a', value: 'new' });
+  });
+
+  it('is a no-op for an empty input', () => {
+    expect(setBulkSettings(db, [])).toEqual({});
+    expect(listSettings(db, undefined, 10, 0).total).toBe(0);
+  });
+});
+
+describe('getSettingValue', () => {
+  let db: CoreDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('returns the persisted string when present', () => {
+    setSetting(db, { key: 'ui.theme', value: 'dark' });
+    expect(getSettingValue(db, 'ui.theme', 'light')).toBe('dark');
+  });
+
+  it('returns the fallback when the key is missing', () => {
+    expect(getSettingValue(db, 'ui.theme', 'light')).toBe('light');
+  });
+
+  it('coerces to number when the fallback is numeric', () => {
+    setSetting(db, { key: 'limit', value: '42' });
+    expect(getSettingValue(db, 'limit', 10)).toBe(42);
+  });
+
+  it('returns the fallback when the persisted value is not a number', () => {
+    setSetting(db, { key: 'limit', value: 'oops' });
+    expect(getSettingValue(db, 'limit', 10)).toBe(10);
+  });
+});
+
+describe('deleteSetting', () => {
+  let db: CoreDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('removes the row and a subsequent get throws SettingNotFoundError', () => {
+    setSetting(db, { key: 'k', value: 'v' });
+    deleteSetting(db, 'k');
+    expect(() => getSetting(db, 'k')).toThrow(SettingNotFoundError);
+  });
+
+  it('throws SettingNotFoundError when the key is missing', () => {
+    expect(() => deleteSetting(db, 'missing')).toThrow(SettingNotFoundError);
+  });
+});

--- a/packages/core-db/src/errors.ts
+++ b/packages/core-db/src/errors.ts
@@ -36,3 +36,13 @@ export class ServiceAccountAlreadyRevokedError extends Error {
     this.id = id;
   }
 }
+
+export class SettingNotFoundError extends Error {
+  override readonly name = 'SettingNotFoundError' as const;
+  readonly key: string;
+
+  constructor(key: string) {
+    super(`Setting '${key}' not found`);
+    this.key = key;
+  }
+}

--- a/packages/core-db/src/index.ts
+++ b/packages/core-db/src/index.ts
@@ -20,6 +20,7 @@ export { openCoreDb, type OpenedCoreDb } from './open-core-db.js';
 export * as serviceAccountsService from './services/service-accounts.js';
 export * as serviceAccountKeys from './services/service-account-keys.js';
 export * as pillarRegistryService from './services/pillar-registry.js';
+export * as settingsService from './services/settings.js';
 
 export type {
   ApplyStatusUpdate,
@@ -41,3 +42,10 @@ export type {
 } from './services/service-accounts.js';
 
 export type { IssuedKey } from './services/service-account-keys.js';
+
+export type {
+  Setting,
+  SetSettingInput,
+  SettingListResult,
+  SettingRow,
+} from './services/settings.js';

--- a/packages/core-db/src/schema.ts
+++ b/packages/core-db/src/schema.ts
@@ -10,4 +10,4 @@
  *
  * Mirrors the `@pops/app-food-db` schema re-export pattern.
  */
-export { pillarRegistry, serviceAccounts } from '@pops/db-types';
+export { pillarRegistry, serviceAccounts, settings } from '@pops/db-types';

--- a/packages/core-db/src/services/settings.ts
+++ b/packages/core-db/src/services/settings.ts
@@ -1,0 +1,177 @@
+/**
+ * Settings CRUD against the core pillar's SQLite via drizzle.
+ *
+ * Services take a `CoreDb` handle as their first argument; the calling
+ * layer (pops-api modules) is responsible for resolving the singleton
+ * or transaction handle to pass in. Mirrors `@pops/finance-db`'s
+ * service signature pattern.
+ *
+ * The in-tree service in `apps/pops-api/src/modules/core/settings/`
+ * still routes through the shared `getDrizzle()` handle for now —
+ * PRD-183 PR 3 flips that to `getCoreDrizzle()` and routes through
+ * this module.
+ */
+import { count, eq, inArray, like } from 'drizzle-orm';
+
+import { SettingNotFoundError } from '../errors.js';
+import { settings } from '../schema.js';
+
+import type { CoreDb } from './internal.js';
+
+/** Raw drizzle row shape — the persisted settings record. */
+export type SettingRow = typeof settings.$inferSelect;
+
+/** Public alias for the persisted setting row. */
+export type Setting = SettingRow;
+
+/** Count + rows for a paginated list. */
+export interface SettingListResult {
+  rows: SettingRow[];
+  total: number;
+}
+
+/** Input for setting a value (upsert). */
+export interface SetSettingInput {
+  key: string;
+  value: string;
+}
+
+/**
+ * Read a single setting. Throws `SettingNotFoundError` if the key is
+ * absent. Prefer {@link getSettingOrNull} for caller-controlled
+ * fallback semantics.
+ */
+export function getSetting(db: CoreDb, key: string): SettingRow {
+  const row = db.select().from(settings).where(eq(settings.key, key)).get();
+  if (!row) throw new SettingNotFoundError(key);
+  return row;
+}
+
+/** Read a single setting; returns `null` if the key is absent. */
+export function getSettingOrNull(db: CoreDb, key: string): SettingRow | null {
+  return db.select().from(settings).where(eq(settings.key, key)).get() ?? null;
+}
+
+/**
+ * Read multiple settings by key. Missing keys are omitted from the
+ * result. Duplicate input keys are de-duped before the IN clause.
+ */
+export function getBulkSettings(db: CoreDb, keys: readonly string[]): Record<string, string> {
+  if (keys.length === 0) return {};
+  const uniqueKeys = [...new Set(keys)];
+  const rows = db.select().from(settings).where(inArray(settings.key, uniqueKeys)).all();
+  const out: Record<string, string> = {};
+  for (const row of rows) out[row.key] = row.value;
+  return out;
+}
+
+/**
+ * List settings ordered by key with an optional substring filter on
+ * the key. Returns the paginated rows + the total count under the
+ * same filter (so callers can render pagination controls without a
+ * second round-trip).
+ */
+export function listSettings(
+  db: CoreDb,
+  search: string | undefined,
+  limit: number,
+  offset: number
+): SettingListResult {
+  const condition = search ? like(settings.key, `%${search}%`) : undefined;
+
+  const countRow = db.select({ total: count() }).from(settings).where(condition).get();
+  const rows = db
+    .select()
+    .from(settings)
+    .where(condition)
+    .orderBy(settings.key)
+    .limit(limit)
+    .offset(offset)
+    .all();
+
+  return { rows, total: countRow?.total ?? 0 };
+}
+
+/**
+ * Upsert a setting. Returns the persisted row. Equivalent to
+ * {@link setRawSetting} — the typed signature is for callers that
+ * already have a {@link SetSettingInput} from a validated payload.
+ */
+export function setSetting(db: CoreDb, input: SetSettingInput): SettingRow {
+  return setRawSetting(db, input.key, input.value);
+}
+
+/**
+ * Untyped upsert into the settings table — used by callers that own
+ * their own key namespace (e.g. the feature-toggle framework, which
+ * manages keys via the features registry rather than `SETTINGS_KEYS`).
+ * Prefer {@link setSetting} when the key is part of the typed key set.
+ */
+export function setRawSetting(db: CoreDb, key: string, value: string): SettingRow {
+  db.insert(settings)
+    .values({ key, value })
+    .onConflictDoUpdate({
+      target: settings.key,
+      set: { value },
+    })
+    .run();
+
+  const row = db.select().from(settings).where(eq(settings.key, key)).get();
+  if (!row) throw new SettingNotFoundError(key);
+  return row;
+}
+
+/**
+ * Write multiple settings inside a single SQLite transaction — either
+ * every row lands or none of them do. Returns a mirror of the written
+ * entries (key → value) without re-reading the table.
+ */
+export function setBulkSettings(
+  db: CoreDb,
+  entries: readonly SetSettingInput[]
+): Record<string, string> {
+  if (entries.length === 0) return {};
+  db.transaction((tx) => {
+    for (const { key, value } of entries) {
+      tx.insert(settings)
+        .values({ key, value })
+        .onConflictDoUpdate({ target: settings.key, set: { value } })
+        .run();
+    }
+  });
+  const out: Record<string, string> = {};
+  for (const { key, value } of entries) out[key] = value;
+  return out;
+}
+
+/**
+ * Read a setting's value, returning `fallback` if the key does not
+ * exist. The default is coerced to match the `fallback` primitive
+ * type so a string-valued column can serve a numeric caller without
+ * the caller having to parse. NaN coercion falls back to the default
+ * rather than silently propagating.
+ */
+export function getSettingValue<T extends string | number>(
+  db: CoreDb,
+  key: string,
+  fallback: T
+): T {
+  const row = db.select().from(settings).where(eq(settings.key, key)).get();
+  if (!row) return fallback;
+  if (typeof fallback === 'number') {
+    const parsed = Number(row.value);
+    return (Number.isNaN(parsed) ? fallback : parsed) as T;
+  }
+  return row.value as T;
+}
+
+/**
+ * Delete a setting by key. Throws `SettingNotFoundError` if no row
+ * matched (`changes === 0`) — mirrors the in-tree pops-api service
+ * so PRD-183 PR 3 can swap the handle without altering the error
+ * contract observable from callers.
+ */
+export function deleteSetting(db: CoreDb, key: string): void {
+  const result = db.delete(settings).where(eq(settings.key, key)).run();
+  if (result.changes === 0) throw new SettingNotFoundError(key);
+}


### PR DESCRIPTION
PRD-183 US-01 — settings table on core-db. Mirrors the PRD-165 US-01 movies scaffold pattern (#2987, merged).

## What's in

- `packages/core-db/src/schema.ts` — re-export `settings` from db-types
- `packages/core-db/migrations/0056_settings_baseline.sql` — synthetic baseline (next slot after 0055_pillar_registry)
- `packages/core-db/src/services/settings.ts` — `settingsService.{get, list, set, delete}` data-access layer
- `packages/core-db/src/errors.ts` — Not-Found / Conflict classes
- `packages/core-db/src/__tests__/settings.test.ts` — unit tests
- `apps/pops-api/src/db/core-backfill.ts` — adds settings to TABLE_COPIES
- `apps/pops-api/src/db/per-pillar-migrations.test.ts` — adds 0056 to expected list

## Tests

70 tests pass on @pops/core-db. Backfill + per-pillar-migrations tests verified.

## Scope

Purely additive — pops-api keeps using getDrizzle() until PR 2/3 of PRD-183.

Refs docs/themes/13-pillar-finale/prds/183-core-settings-cutover/README.md