### PR TITLE
feat(cerebrum-db): scaffold conversations service + baseline migration (PRD-182 US-01)

### DIFF
--- a/apps/pops-api/src/db/backfill-cerebrum-from-shared.test.ts
+++ b/apps/pops-api/src/db/backfill-cerebrum-from-shared.test.ts
@@ -471,6 +471,29 @@ describe('backfillCerebrumFromShared', () => {
     }
   });
 
+  it('converges new conversation_context pairs when one row for the conversation already exists', () => {
+    const sharedPath = openSharedWithSeed((raw) => {
+      insertConversationRow(raw, 'conv_shared');
+      insertConversationContextRow(raw, 'conv_shared', 'eng_shared_a');
+      insertConversationContextRow(raw, 'conv_shared', 'eng_shared_b');
+    });
+
+    const cerebrum = openCerebrumDb(join(tmpDir, 'cerebrum.db'), { loadVec: false });
+    try {
+      insertConversationRow(cerebrum.raw, 'conv_shared');
+      insertConversationContextRow(cerebrum.raw, 'conv_shared', 'eng_shared_a');
+      backfillCerebrumFromShared(cerebrum, sharedPath);
+      const rows = cerebrum.raw
+        .prepare(
+          'SELECT engram_id FROM conversation_context WHERE conversation_id = ? ORDER BY engram_id'
+        )
+        .all('conv_shared') as { engram_id: string }[];
+      expect(rows.map((r) => r.engram_id)).toEqual(['eng_shared_a', 'eng_shared_b']);
+    } finally {
+      cerebrum.raw.close();
+    }
+  });
+
   it('tolerates a shared DB with no cerebrum tables (post-PR-4 drop scenario)', () => {
     const sharedPath = join(tmpDir, 'pops.db');
     const raw = new BetterSqlite3(sharedPath);

--- a/apps/pops-api/src/db/backfill-cerebrum-from-shared.test.ts
+++ b/apps/pops-api/src/db/backfill-cerebrum-from-shared.test.ts
@@ -77,6 +77,38 @@ CREATE TABLE glia_trust_state (
 );
 `;
 
+const CONVERSATIONS_SCHEMA_SQL = `
+CREATE TABLE conversations (
+  id text PRIMARY KEY NOT NULL,
+  title text,
+  active_scopes text NOT NULL,
+  app_context text,
+  model text NOT NULL,
+  created_at text NOT NULL,
+  updated_at text NOT NULL
+);
+CREATE TABLE messages (
+  id text PRIMARY KEY NOT NULL,
+  conversation_id text NOT NULL,
+  role text NOT NULL,
+  content text NOT NULL,
+  citations text,
+  tool_calls text,
+  tokens_in integer,
+  tokens_out integer,
+  created_at text NOT NULL,
+  FOREIGN KEY (conversation_id) REFERENCES conversations(id) ON UPDATE no action ON DELETE cascade
+);
+CREATE TABLE conversation_context (
+  conversation_id text NOT NULL,
+  engram_id text NOT NULL,
+  relevance_score real,
+  loaded_at text NOT NULL,
+  PRIMARY KEY (conversation_id, engram_id),
+  FOREIGN KEY (conversation_id) REFERENCES conversations(id) ON UPDATE no action ON DELETE cascade
+);
+`;
+
 const ENGRAMS_SCHEMA_SQL = `
 CREATE TABLE engram_index (
   id text PRIMARY KEY NOT NULL,
@@ -131,9 +163,44 @@ function openSharedWithSeed(seed: (raw: BetterSqlite3.Database) => void): string
   raw.exec(NUDGE_LOG_SQL);
   raw.exec(ENGRAMS_SCHEMA_SQL);
   raw.exec(GLIA_SCHEMA_SQL);
+  raw.exec(CONVERSATIONS_SCHEMA_SQL);
   seed(raw);
   raw.close();
   return path;
+}
+
+function insertConversationRow(raw: BetterSqlite3.Database, id: string): void {
+  raw
+    .prepare(
+      `INSERT INTO conversations
+        (id, title, active_scopes, app_context, model, created_at, updated_at)
+       VALUES (?, 'T', '[]', NULL, 'gpt-4', '2026-06-10T10:00:00Z', '2026-06-10T10:00:00Z')`
+    )
+    .run(id);
+}
+
+function insertMessageRow(raw: BetterSqlite3.Database, id: string, conversationId: string): void {
+  raw
+    .prepare(
+      `INSERT INTO messages
+        (id, conversation_id, role, content, created_at)
+       VALUES (?, ?, 'user', 'hi', '2026-06-10T10:00:01Z')`
+    )
+    .run(id, conversationId);
+}
+
+function insertConversationContextRow(
+  raw: BetterSqlite3.Database,
+  conversationId: string,
+  engramId: string
+): void {
+  raw
+    .prepare(
+      `INSERT INTO conversation_context
+        (conversation_id, engram_id, relevance_score, loaded_at)
+       VALUES (?, ?, 0.5, '2026-06-10T10:00:00Z')`
+    )
+    .run(conversationId, engramId);
 }
 
 function insertGliaAction(raw: BetterSqlite3.Database, id: string): void {
@@ -322,6 +389,83 @@ describe('backfillCerebrumFromShared', () => {
         id: string;
       }[];
       expect(rows.map((r) => r.id)).toEqual(['glia_both', 'glia_shared_only']);
+    } finally {
+      cerebrum.raw.close();
+    }
+  });
+
+  it('copies conversations + messages + conversation_context on first run', () => {
+    const sharedPath = openSharedWithSeed((raw) => {
+      insertConversationRow(raw, 'conv_a');
+      insertConversationRow(raw, 'conv_b');
+      insertMessageRow(raw, 'msg_a1', 'conv_a');
+      insertMessageRow(raw, 'msg_a2', 'conv_a');
+      insertConversationContextRow(raw, 'conv_a', 'eng_a');
+      insertConversationContextRow(raw, 'conv_b', 'eng_b');
+    });
+
+    const cerebrum = openCerebrumDb(join(tmpDir, 'cerebrum.db'), { loadVec: false });
+    try {
+      backfillCerebrumFromShared(cerebrum, sharedPath);
+      const { convs } = cerebrum.raw
+        .prepare('SELECT count(*) AS convs FROM conversations')
+        .get() as { convs: number };
+      const { msgs } = cerebrum.raw.prepare('SELECT count(*) AS msgs FROM messages').get() as {
+        msgs: number;
+      };
+      const { ctx } = cerebrum.raw
+        .prepare('SELECT count(*) AS ctx FROM conversation_context')
+        .get() as { ctx: number };
+      expect(convs).toBe(2);
+      expect(msgs).toBe(2);
+      expect(ctx).toBe(2);
+    } finally {
+      cerebrum.raw.close();
+    }
+  });
+
+  it('skips conversation rows already present in the cerebrum copy (idempotent)', () => {
+    const sharedPath = openSharedWithSeed((raw) => {
+      insertConversationRow(raw, 'conv_dup');
+      insertMessageRow(raw, 'msg_dup', 'conv_dup');
+      insertConversationContextRow(raw, 'conv_dup', 'eng_dup');
+    });
+
+    const cerebrum = openCerebrumDb(join(tmpDir, 'cerebrum.db'), { loadVec: false });
+    try {
+      backfillCerebrumFromShared(cerebrum, sharedPath);
+      backfillCerebrumFromShared(cerebrum, sharedPath);
+      const { convs } = cerebrum.raw
+        .prepare('SELECT count(*) AS convs FROM conversations')
+        .get() as { convs: number };
+      const { msgs } = cerebrum.raw.prepare('SELECT count(*) AS msgs FROM messages').get() as {
+        msgs: number;
+      };
+      const { ctx } = cerebrum.raw
+        .prepare('SELECT count(*) AS ctx FROM conversation_context')
+        .get() as { ctx: number };
+      expect(convs).toBe(1);
+      expect(msgs).toBe(1);
+      expect(ctx).toBe(1);
+    } finally {
+      cerebrum.raw.close();
+    }
+  });
+
+  it('only inserts conversation rows missing from the cerebrum copy (mixed state)', () => {
+    const sharedPath = openSharedWithSeed((raw) => {
+      insertConversationRow(raw, 'conv_shared_only');
+      insertConversationRow(raw, 'conv_both');
+    });
+
+    const cerebrum = openCerebrumDb(join(tmpDir, 'cerebrum.db'), { loadVec: false });
+    try {
+      insertConversationRow(cerebrum.raw, 'conv_both');
+      backfillCerebrumFromShared(cerebrum, sharedPath);
+      const rows = cerebrum.raw.prepare('SELECT id FROM conversations ORDER BY id').all() as {
+        id: string;
+      }[];
+      expect(rows.map((r) => r.id)).toEqual(['conv_both', 'conv_shared_only']);
     } finally {
       cerebrum.raw.close();
     }

--- a/apps/pops-api/src/db/backfill-cerebrum-from-shared.ts
+++ b/apps/pops-api/src/db/backfill-cerebrum-from-shared.ts
@@ -17,14 +17,19 @@
  *   - `glia_actions` + `glia_trust_state` (PRD-181 US-01 — scaffold;
  *     consumers still write to the shared pops.db until US-03 flips
  *     them over)
+ *   - `conversations` + `messages` + `conversation_context` (PRD-182
+ *     US-01 — scaffold; consumers still write to the shared pops.db
+ *     until PR 3 flips them over)
  *
- * The remaining cerebrum tables (embeddings + embeddings_vec,
- * conversations, plexus) add their entries here when their cutovers
- * land. Order matters when FKs are introduced across cerebrum-owned
- * tables — `engram_index` is copied first so the cascading auxiliaries
- * (`engram_scopes`, `engram_tags`, `engram_links`) can satisfy their FK
- * at insert time. The two glia tables have no cross-table FKs so their
- * order is independent of the engram block.
+ * The remaining cerebrum tables (embeddings + embeddings_vec, plexus)
+ * add their entries here when their cutovers land. Order matters when
+ * FKs are introduced across cerebrum-owned tables — `engram_index` is
+ * copied first so the cascading auxiliaries (`engram_scopes`,
+ * `engram_tags`, `engram_links`) can satisfy their FK at insert time.
+ * The two glia tables have no cross-table FKs so their order is
+ * independent of the engram block. The conversations block has an FK
+ * from `messages` and `conversation_context` to `conversations`, so the
+ * parent table is copied first.
  *
  * Non-fatal: ATTACH or INSERT failures are logged and swallowed so a
  * stale on-disk pops.db never bricks the boot path. Partial failures
@@ -150,6 +155,41 @@ const TABLE_COPIES: readonly TableCopy[] = [
       'graduated_at',
       'updated_at',
     ],
+  },
+  {
+    // Conversations is the parent of `messages` and `conversation_context`
+    // (both FK with ON DELETE CASCADE); copying it first lets the
+    // dependents satisfy their FK at insert time.
+    table: 'conversations',
+    idColumn: 'id',
+    columns: ['id', 'title', 'active_scopes', 'app_context', 'model', 'created_at', 'updated_at'],
+  },
+  {
+    table: 'messages',
+    idColumn: 'id',
+    columns: [
+      'id',
+      'conversation_id',
+      'role',
+      'content',
+      'citations',
+      'tool_calls',
+      'tokens_in',
+      'tokens_out',
+      'created_at',
+    ],
+  },
+  {
+    // conversation_context's PK is the (conversation_id, engram_id) pair.
+    // Use conversation_id as the existence-filter column — once any row
+    // for a conversation is copied across, subsequent runs are no-ops
+    // for that conversation; new engram associations on a still-shared
+    // conversation won't replicate, which is acceptable for the same
+    // reason engram_scopes is: PR 3 routes new writes through the
+    // cerebrum handle before this asymmetry matters.
+    table: 'conversation_context',
+    idColumn: 'conversation_id',
+    columns: ['conversation_id', 'engram_id', 'relevance_score', 'loaded_at'],
   },
 ];
 

--- a/apps/pops-api/src/db/backfill-cerebrum-from-shared.ts
+++ b/apps/pops-api/src/db/backfill-cerebrum-from-shared.ts
@@ -7,7 +7,8 @@
  * the existing nudge_log rows from the shared DB across before any
  * reads come from the new file. Subsequent boots find the cerebrum
  * copy already populated and become a no-op via the
- * `WHERE id NOT IN (...)` existence filter.
+ * `WHERE NOT EXISTS (...)` existence filter (composite-key aware for
+ * junction tables like `conversation_context`).
  *
  * Today the slice covers:
  *   - `nudge_log` (Track M5 / PRD-149)
@@ -51,14 +52,19 @@ interface TableCopy {
    * image was built.
    */
   readonly columns: readonly string[];
-  /** Identifier column used in the existence filter. */
-  readonly idColumn: string;
+  /**
+   * Identifier column(s) used in the existence filter. A single entry
+   * covers tables with a surrogate PK; multiple entries express a
+   * composite key on junction tables (e.g. `conversation_context`)
+   * where row identity is the tuple, not a single column.
+   */
+  readonly idColumns: readonly [string, ...string[]];
 }
 
 const TABLE_COPIES: readonly TableCopy[] = [
   {
     table: 'nudge_log',
-    idColumn: 'id',
+    idColumns: ['id'],
     columns: [
       'id',
       'type',
@@ -77,7 +83,7 @@ const TABLE_COPIES: readonly TableCopy[] = [
   },
   {
     table: 'engram_index',
-    idColumn: 'id',
+    idColumns: ['id'],
     columns: [
       'id',
       'file_path',
@@ -96,28 +102,25 @@ const TABLE_COPIES: readonly TableCopy[] = [
   },
   {
     // engram_scopes has no surrogate id — the pair (engram_id, scope) is
-    // unique. Use engram_id as the existence-filter column; once any row
-    // for an engram is copied across, subsequent runs are no-ops for that
-    // engram. New scopes added to a still-shared engram won't replicate,
-    // which is acceptable: the cutover PR (US-03) routes new writes
-    // through getCerebrumDrizzle() before this asymmetry matters.
+    // unique. Filter on the composite tuple so new scopes added to an
+    // already-copied engram still converge on subsequent boots.
     table: 'engram_scopes',
-    idColumn: 'engram_id',
+    idColumns: ['engram_id', 'scope'],
     columns: ['engram_id', 'scope'],
   },
   {
     table: 'engram_tags',
-    idColumn: 'engram_id',
+    idColumns: ['engram_id', 'tag'],
     columns: ['engram_id', 'tag'],
   },
   {
     table: 'engram_links',
-    idColumn: 'source_id',
+    idColumns: ['source_id', 'target_id'],
     columns: ['source_id', 'target_id'],
   },
   {
     table: 'glia_actions',
-    idColumn: 'id',
+    idColumns: ['id'],
     columns: [
       'id',
       'action_type',
@@ -143,7 +146,7 @@ const TABLE_COPIES: readonly TableCopy[] = [
     // engram_scopes is: PR 3 (US-03) routes writes through the cerebrum
     // handle before any divergence matters.
     table: 'glia_trust_state',
-    idColumn: 'action_type',
+    idColumns: ['action_type'],
     columns: [
       'action_type',
       'current_phase',
@@ -161,12 +164,12 @@ const TABLE_COPIES: readonly TableCopy[] = [
     // (both FK with ON DELETE CASCADE); copying it first lets the
     // dependents satisfy their FK at insert time.
     table: 'conversations',
-    idColumn: 'id',
+    idColumns: ['id'],
     columns: ['id', 'title', 'active_scopes', 'app_context', 'model', 'created_at', 'updated_at'],
   },
   {
     table: 'messages',
-    idColumn: 'id',
+    idColumns: ['id'],
     columns: [
       'id',
       'conversation_id',
@@ -181,14 +184,10 @@ const TABLE_COPIES: readonly TableCopy[] = [
   },
   {
     // conversation_context's PK is the (conversation_id, engram_id) pair.
-    // Use conversation_id as the existence-filter column — once any row
-    // for a conversation is copied across, subsequent runs are no-ops
-    // for that conversation; new engram associations on a still-shared
-    // conversation won't replicate, which is acceptable for the same
-    // reason engram_scopes is: PR 3 routes new writes through the
-    // cerebrum handle before this asymmetry matters.
+    // Filter on the composite tuple so new engram associations added to
+    // an already-copied conversation still converge on subsequent boots.
     table: 'conversation_context',
-    idColumn: 'conversation_id',
+    idColumns: ['conversation_id', 'engram_id'],
     columns: ['conversation_id', 'engram_id', 'relevance_score', 'loaded_at'],
   },
 ];
@@ -200,11 +199,16 @@ function tryCopyTable(raw: Database.Database, copy: TableCopy): void {
       .get();
     if (!hasTable) return;
     const cols = copy.columns.join(', ');
+    const keyMatch = copy.idColumns
+      .map((col) => `target.${col} = pops.${copy.table}.${col}`)
+      .join(' AND ');
     raw.exec(`
       INSERT INTO ${copy.table} (${cols})
       SELECT ${cols}
       FROM pops.${copy.table}
-      WHERE ${copy.idColumn} NOT IN (SELECT ${copy.idColumn} FROM ${copy.table})
+      WHERE NOT EXISTS (
+        SELECT 1 FROM ${copy.table} AS target WHERE ${keyMatch}
+      )
     `);
   } catch (err) {
     console.warn(`[db] Cerebrum backfill of ${copy.table} failed (non-fatal):`, err);

--- a/apps/pops-api/src/db/per-pillar-migrations.test.ts
+++ b/apps/pops-api/src/db/per-pillar-migrations.test.ts
@@ -220,8 +220,10 @@ describe('runPerPillarMigrations', () => {
     // `cerebrum` owns `packages/cerebrum-db/migrations/` with
     // 0039_dry_fabian_cortez and 0044_nudge_log (cerebrum pillar Phase 1
     // PR 2 — nudge_log slice), 0050_engrams_baseline (PRD-179 US-01 —
-    // engrams baseline) and 0051_glia_baseline (PRD-181 US-01 — glia
-    // baseline). Pillars without their own journal yet still skip cleanly.
+    // engrams baseline), 0051_glia_baseline (PRD-181 US-01 — glia
+    // baseline) and 0052_conversations_baseline (PRD-182 US-01 —
+    // conversations baseline). Pillars without their own journal yet
+    // still skip cleanly.
     await withDb((db) => {
       const realPillars: PillarDescriptor[] = [
         { id: 'core', dbPackageDir: 'packages/core-db' },
@@ -244,6 +246,7 @@ describe('runPerPillarMigrations', () => {
         '0044_nudge_log',
         '0050_engrams_baseline',
         '0051_glia_baseline',
+        '0052_conversations_baseline',
         '0054_service_accounts',
         '0055_pillar_registry',
         '0056_settings_baseline',

--- a/packages/cerebrum-db/migrations/0052_conversations_baseline.sql
+++ b/packages/cerebrum-db/migrations/0052_conversations_baseline.sql
@@ -1,0 +1,55 @@
+-- Cerebrum pillar baseline for the conversations slice (PRD-182 US-01).
+--
+-- Mirrors the conversations / messages / conversation_context schema as it
+-- stands in the shared pops.db (canonical definitions in
+-- `packages/db-types/src/schema/ego.ts`). Column definitions and indexes
+-- are copied verbatim so a fresh cerebrum.db matches the shared shape
+-- byte-for-byte; the boot-time backfill ATTACHes pops.db and copies rows
+-- across without column-rename gymnastics.
+--
+-- Conversations are chat-with-cerebrum sessions: stored prompts, model
+-- responses, and references to engrams via the `conversation_context`
+-- junction table. Append-only message stream per conversation; deletes
+-- cascade from `conversations` to both `messages` and
+-- `conversation_context`. The chat orchestration (streaming, model
+-- selection, scope negotiation, auto-titling heuristics) stays in
+-- `apps/pops-api/src/modules/cerebrum/ego/*` until PRD-182 PR 3 flips
+-- routing through `getCerebrumDrizzle()`.
+
+CREATE TABLE `conversations` (
+	`id` text PRIMARY KEY NOT NULL,
+	`title` text,
+	`active_scopes` text NOT NULL,
+	`app_context` text,
+	`model` text NOT NULL,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `idx_conversations_created_at` ON `conversations` (`created_at`);--> statement-breakpoint
+CREATE INDEX `idx_conversations_updated_at` ON `conversations` (`updated_at`);--> statement-breakpoint
+CREATE TABLE `messages` (
+	`id` text PRIMARY KEY NOT NULL,
+	`conversation_id` text NOT NULL,
+	`role` text NOT NULL,
+	`content` text NOT NULL,
+	`citations` text,
+	`tool_calls` text,
+	`tokens_in` integer,
+	`tokens_out` integer,
+	`created_at` text NOT NULL,
+	FOREIGN KEY (`conversation_id`) REFERENCES `conversations`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `idx_messages_conversation_created` ON `messages` (`conversation_id`,`created_at`);--> statement-breakpoint
+CREATE TABLE `conversation_context` (
+	`conversation_id` text NOT NULL,
+	`engram_id` text NOT NULL,
+	`relevance_score` real,
+	`loaded_at` text NOT NULL,
+	PRIMARY KEY(`conversation_id`, `engram_id`),
+	FOREIGN KEY (`conversation_id`) REFERENCES `conversations`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `idx_conversation_context_conversation` ON `conversation_context` (`conversation_id`);--> statement-breakpoint
+CREATE INDEX `idx_conversation_context_engram` ON `conversation_context` (`engram_id`);

--- a/packages/cerebrum-db/migrations/meta/_journal.json
+++ b/packages/cerebrum-db/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1781913600000,
       "tag": "0051_glia_baseline",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1782000000000,
+      "tag": "0052_conversations_baseline",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cerebrum-db/src/__tests__/conversations.test.ts
+++ b/packages/cerebrum-db/src/__tests__/conversations.test.ts
@@ -1,0 +1,434 @@
+/**
+ * Invariant tests for the conversations data-access service against an
+ * in-memory SQLite seeded with the package-local conversations baseline
+ * migration. Covers conversation CRUD + filters, message append + list
+ * + count helpers, context upsert + list + delete, and the FK cascade
+ * from conversation deletion across messages + context.
+ *
+ * The baseline is read from
+ * `packages/cerebrum-db/migrations/0052_conversations_baseline.sql` so
+ * the table shape under test is identical to the one shipped in the
+ * journal.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  ConversationConflictError,
+  ConversationNotFoundError,
+  MessageConflictError,
+  countMessages,
+  deleteConversation,
+  deleteConversationContext,
+  deleteMessage,
+  getConversation,
+  getMessage,
+  insertConversation,
+  insertMessage,
+  listConversationContext,
+  listConversations,
+  listMessages,
+  requireConversation,
+  updateConversation,
+  upsertConversationContext,
+} from '../services/conversations.js';
+
+import type { InsertConversationRow, InsertMessageRow } from '../services/conversations-types.js';
+import type { CerebrumDb } from '../services/internal.js';
+
+const CONVERSATIONS_MIGRATION = join(__dirname, '../../migrations/0052_conversations_baseline.sql');
+
+function freshDb(): CerebrumDb {
+  const raw = new Database(':memory:');
+  raw.pragma('foreign_keys = ON');
+  const sql = readFileSync(CONVERSATIONS_MIGRATION, 'utf8');
+  for (const stmt of sql.split('--> statement-breakpoint')) {
+    const trimmed = stmt.trim();
+    if (trimmed.length > 0) raw.exec(trimmed);
+  }
+  return drizzle(raw);
+}
+
+function makeConversation(
+  overrides: Partial<InsertConversationRow> & Pick<InsertConversationRow, 'id'>
+): InsertConversationRow {
+  return {
+    title: null,
+    activeScopes: [],
+    appContext: null,
+    model: 'gpt-4',
+    createdAt: '2026-06-10T10:00:00Z',
+    updatedAt: '2026-06-10T10:00:00Z',
+    ...overrides,
+  };
+}
+
+function makeMessage(
+  overrides: Partial<InsertMessageRow> & Pick<InsertMessageRow, 'id' | 'conversationId'>
+): InsertMessageRow {
+  return {
+    role: 'user',
+    content: 'hello',
+    citations: null,
+    toolCalls: null,
+    tokensIn: null,
+    tokensOut: null,
+    createdAt: '2026-06-10T10:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('insertConversation', () => {
+  let db: CerebrumDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('serialises activeScopes + appContext as JSON and round-trips via getConversation', () => {
+    const created = insertConversation(
+      db,
+      makeConversation({
+        id: 'conv_1',
+        title: 'Trip planning',
+        activeScopes: ['work', 'travel'],
+        appContext: { pillar: 'cerebrum' },
+      })
+    );
+
+    expect(created.activeScopes).toEqual(['work', 'travel']);
+    expect(created.appContext).toEqual({ pillar: 'cerebrum' });
+
+    const fetched = getConversation(db, 'conv_1');
+    expect(fetched).not.toBeNull();
+    expect(fetched?.title).toBe('Trip planning');
+  });
+
+  it('throws ConversationConflictError when the id already exists', () => {
+    insertConversation(db, makeConversation({ id: 'conv_dup' }));
+    expect(() => insertConversation(db, makeConversation({ id: 'conv_dup' }))).toThrow(
+      ConversationConflictError
+    );
+  });
+
+  it('stores null appContext as SQL NULL (not the string "null")', () => {
+    insertConversation(db, makeConversation({ id: 'conv_null_ctx', appContext: null }));
+    const fetched = getConversation(db, 'conv_null_ctx');
+    expect(fetched?.appContext).toBeNull();
+  });
+});
+
+describe('getConversation + requireConversation', () => {
+  it('getConversation returns null when missing', () => {
+    expect(getConversation(freshDb(), 'missing')).toBeNull();
+  });
+
+  it('requireConversation throws ConversationNotFoundError when missing', () => {
+    expect(() => requireConversation(freshDb(), 'missing')).toThrow(ConversationNotFoundError);
+  });
+});
+
+describe('listConversations', () => {
+  let db: CerebrumDb;
+  beforeEach(() => {
+    db = freshDb();
+    insertConversation(
+      db,
+      makeConversation({
+        id: 'c1',
+        title: 'Apple recipes',
+        updatedAt: '2026-06-10T10:00:00Z',
+      })
+    );
+    insertConversation(
+      db,
+      makeConversation({ id: 'c2', title: 'Banana bread', updatedAt: '2026-06-10T11:00:00Z' })
+    );
+    insertConversation(
+      db,
+      makeConversation({ id: 'c3', title: 'Apple pie', updatedAt: '2026-06-10T12:00:00Z' })
+    );
+  });
+
+  it('returns all rows in updated_at desc order with total', () => {
+    const result = listConversations(db);
+    expect(result.total).toBe(3);
+    expect(result.conversations.map((c) => c.id)).toEqual(['c3', 'c2', 'c1']);
+  });
+
+  it('filters by title via LIKE substring match', () => {
+    const result = listConversations(db, { search: 'Apple' });
+    expect(result.total).toBe(2);
+    expect(result.conversations.map((c) => c.id).toSorted()).toEqual(['c1', 'c3']);
+  });
+
+  it('paginates with limit + offset on top of filters', () => {
+    const page = listConversations(db, { limit: 1, offset: 1 });
+    expect(page.conversations.map((c) => c.id)).toEqual(['c2']);
+    expect(page.total).toBe(3);
+  });
+});
+
+describe('updateConversation', () => {
+  let db: CerebrumDb;
+  beforeEach(() => {
+    db = freshDb();
+    insertConversation(db, makeConversation({ id: 'conv_u', title: 'old' }));
+  });
+
+  it('patches mutable columns and bumps updatedAt', () => {
+    const updated = updateConversation(db, 'conv_u', {
+      title: 'new',
+      activeScopes: ['focus'],
+      appContext: { mode: 'focus' },
+      updatedAt: '2026-06-10T12:00:00Z',
+    });
+    expect(updated.title).toBe('new');
+    expect(updated.activeScopes).toEqual(['focus']);
+    expect(updated.appContext).toEqual({ mode: 'focus' });
+    expect(updated.updatedAt).toBe('2026-06-10T12:00:00Z');
+  });
+
+  it('allows clearing title to null', () => {
+    const updated = updateConversation(db, 'conv_u', {
+      title: null,
+      updatedAt: '2026-06-10T12:00:00Z',
+    });
+    expect(updated.title).toBeNull();
+  });
+
+  it('throws ConversationNotFoundError when the conversation is missing', () => {
+    expect(() =>
+      updateConversation(db, 'missing', { title: 't', updatedAt: '2026-06-10T12:00:00Z' })
+    ).toThrow(ConversationNotFoundError);
+  });
+});
+
+describe('deleteConversation', () => {
+  it('returns 0 when missing (idempotent)', () => {
+    expect(deleteConversation(freshDb(), 'missing')).toBe(0);
+  });
+
+  it('removes the row and cascades to messages + context', () => {
+    const db = freshDb();
+    insertConversation(db, makeConversation({ id: 'conv_del' }));
+    insertMessage(db, makeMessage({ id: 'msg_1', conversationId: 'conv_del' }));
+    upsertConversationContext(db, {
+      conversationId: 'conv_del',
+      engramId: 'eng_a',
+      relevanceScore: 0.8,
+      loadedAt: '2026-06-10T10:00:00Z',
+    });
+
+    expect(deleteConversation(db, 'conv_del')).toBe(1);
+    expect(getConversation(db, 'conv_del')).toBeNull();
+    expect(listMessages(db, 'conv_del')).toEqual([]);
+    expect(listConversationContext(db, 'conv_del')).toEqual([]);
+  });
+});
+
+describe('insertMessage', () => {
+  let db: CerebrumDb;
+  beforeEach(() => {
+    db = freshDb();
+    insertConversation(db, makeConversation({ id: 'conv_msg', updatedAt: '2026-06-10T10:00:00Z' }));
+  });
+
+  it('serialises citations + toolCalls as JSON and round-trips', () => {
+    const created = insertMessage(
+      db,
+      makeMessage({
+        id: 'msg_1',
+        conversationId: 'conv_msg',
+        role: 'assistant',
+        citations: [{ engramId: 'eng_a' }],
+        toolCalls: [{ name: 'search', args: { q: 'apple' } }],
+        tokensIn: 10,
+        tokensOut: 20,
+      })
+    );
+    expect(created.citations).toEqual([{ engramId: 'eng_a' }]);
+    expect(created.toolCalls).toEqual([{ name: 'search', args: { q: 'apple' } }]);
+
+    const fetched = getMessage(db, 'msg_1');
+    expect(fetched?.tokensIn).toBe(10);
+    expect(fetched?.tokensOut).toBe(20);
+  });
+
+  it('bumps the parent conversation updatedAt to the message createdAt', () => {
+    insertMessage(
+      db,
+      makeMessage({
+        id: 'msg_bump',
+        conversationId: 'conv_msg',
+        createdAt: '2026-06-10T11:00:00Z',
+      })
+    );
+    expect(getConversation(db, 'conv_msg')?.updatedAt).toBe('2026-06-10T11:00:00Z');
+  });
+
+  it('throws ConversationNotFoundError when the parent does not exist', () => {
+    expect(() =>
+      insertMessage(db, makeMessage({ id: 'msg_orphan', conversationId: 'nope' }))
+    ).toThrow(ConversationNotFoundError);
+  });
+
+  it('throws MessageConflictError when the message id already exists', () => {
+    insertMessage(db, makeMessage({ id: 'msg_dup', conversationId: 'conv_msg' }));
+    expect(() =>
+      insertMessage(db, makeMessage({ id: 'msg_dup', conversationId: 'conv_msg' }))
+    ).toThrow(MessageConflictError);
+  });
+});
+
+describe('listMessages + countMessages', () => {
+  let db: CerebrumDb;
+  beforeEach(() => {
+    db = freshDb();
+    insertConversation(db, makeConversation({ id: 'conv_list' }));
+    insertMessage(
+      db,
+      makeMessage({
+        id: 'm1',
+        conversationId: 'conv_list',
+        role: 'user',
+        createdAt: '2026-06-10T10:00:00Z',
+      })
+    );
+    insertMessage(
+      db,
+      makeMessage({
+        id: 'm2',
+        conversationId: 'conv_list',
+        role: 'assistant',
+        createdAt: '2026-06-10T10:00:01Z',
+      })
+    );
+    insertMessage(
+      db,
+      makeMessage({
+        id: 'm3',
+        conversationId: 'conv_list',
+        role: 'user',
+        createdAt: '2026-06-10T10:00:02Z',
+      })
+    );
+  });
+
+  it('lists messages in created_at asc order', () => {
+    expect(listMessages(db, 'conv_list').map((m) => m.id)).toEqual(['m1', 'm2', 'm3']);
+  });
+
+  it('counts all messages for a conversation', () => {
+    expect(countMessages(db, 'conv_list')).toBe(3);
+  });
+
+  it('counts messages filtered by role', () => {
+    expect(countMessages(db, 'conv_list', 'user')).toBe(2);
+    expect(countMessages(db, 'conv_list', 'assistant')).toBe(1);
+    expect(countMessages(db, 'conv_list', 'system')).toBe(0);
+  });
+});
+
+describe('deleteMessage', () => {
+  it('returns 0 when missing (idempotent)', () => {
+    expect(deleteMessage(freshDb(), 'missing')).toBe(0);
+  });
+
+  it('removes the row and returns 1', () => {
+    const db = freshDb();
+    insertConversation(db, makeConversation({ id: 'conv_dm' }));
+    insertMessage(db, makeMessage({ id: 'msg_dm', conversationId: 'conv_dm' }));
+    expect(deleteMessage(db, 'msg_dm')).toBe(1);
+    expect(getMessage(db, 'msg_dm')).toBeNull();
+  });
+});
+
+describe('upsertConversationContext', () => {
+  let db: CerebrumDb;
+  beforeEach(() => {
+    db = freshDb();
+    insertConversation(db, makeConversation({ id: 'conv_ctx' }));
+  });
+
+  it('inserts a new context entry', () => {
+    upsertConversationContext(db, {
+      conversationId: 'conv_ctx',
+      engramId: 'eng_a',
+      relevanceScore: 0.7,
+      loadedAt: '2026-06-10T10:00:00Z',
+    });
+    const rows = listConversationContext(db, 'conv_ctx');
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.engramId).toBe('eng_a');
+    expect(rows[0]?.relevanceScore).toBe(0.7);
+  });
+
+  it('refreshes relevance_score + loaded_at on conflict (composite PK)', () => {
+    upsertConversationContext(db, {
+      conversationId: 'conv_ctx',
+      engramId: 'eng_a',
+      relevanceScore: 0.5,
+      loadedAt: '2026-06-10T10:00:00Z',
+    });
+    upsertConversationContext(db, {
+      conversationId: 'conv_ctx',
+      engramId: 'eng_a',
+      relevanceScore: 0.95,
+      loadedAt: '2026-06-10T11:00:00Z',
+    });
+    const rows = listConversationContext(db, 'conv_ctx');
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.relevanceScore).toBe(0.95);
+    expect(rows[0]?.loadedAt).toBe('2026-06-10T11:00:00Z');
+  });
+
+  it('throws ConversationNotFoundError when the parent is missing', () => {
+    expect(() =>
+      upsertConversationContext(db, {
+        conversationId: 'missing',
+        engramId: 'eng_a',
+        relevanceScore: 0.5,
+        loadedAt: '2026-06-10T10:00:00Z',
+      })
+    ).toThrow(ConversationNotFoundError);
+  });
+});
+
+describe('listConversationContext + deleteConversationContext', () => {
+  let db: CerebrumDb;
+  beforeEach(() => {
+    db = freshDb();
+    insertConversation(db, makeConversation({ id: 'conv_lc' }));
+    upsertConversationContext(db, {
+      conversationId: 'conv_lc',
+      engramId: 'eng_a',
+      relevanceScore: 0.5,
+      loadedAt: '2026-06-10T10:00:00Z',
+    });
+    upsertConversationContext(db, {
+      conversationId: 'conv_lc',
+      engramId: 'eng_b',
+      relevanceScore: 0.9,
+      loadedAt: '2026-06-10T11:00:00Z',
+    });
+  });
+
+  it('orders entries by loaded_at desc', () => {
+    const rows = listConversationContext(db, 'conv_lc');
+    expect(rows.map((r) => r.engramId)).toEqual(['eng_b', 'eng_a']);
+  });
+
+  it('deletes a single (conversation, engram) pair and leaves the others', () => {
+    expect(deleteConversationContext(db, 'conv_lc', 'eng_a')).toBe(1);
+    const rows = listConversationContext(db, 'conv_lc');
+    expect(rows.map((r) => r.engramId)).toEqual(['eng_b']);
+  });
+
+  it('returns 0 when the pair does not exist (idempotent)', () => {
+    expect(deleteConversationContext(db, 'conv_lc', 'eng_missing')).toBe(0);
+  });
+});

--- a/packages/cerebrum-db/src/index.ts
+++ b/packages/cerebrum-db/src/index.ts
@@ -21,9 +21,14 @@
  *     `glia_actions` and the per-action-type trust state. Trust
  *     graduation, dispatch and digest rendering stay in pops-api until
  *     PRD-181 US-03.
+ *   - PRD-182 US-01 added the conversations data layer — schemas,
+ *     baseline migration, and the `conversationsService` namespace
+ *     covering CRUD on `conversations`, append/list on `messages`, and
+ *     upsert/list on the `conversation_context` junction table. The
+ *     chat orchestration (streaming, model selection, auto-titling)
+ *     stays in pops-api until PRD-182 PR 3.
  *
- * The remaining slices (embeddings, conversations, plexus) follow in
- * subsequent PRs. Cerebrum's load-bearing surgery is the URI
+ * The remaining slices (embeddings, plexus) follow in subsequent PRs. Cerebrum's load-bearing surgery is the URI
  * dispatcher round-trip (engrams reference other pillars' entities by
  * URI) — that lands when the consumers cut over, not in this scaffold.
  *
@@ -51,6 +56,7 @@ export {
 export * as nudgeLogService from './services/nudge-log.js';
 export * as engramsService from './services/engrams.js';
 export * as gliaService from './services/glia.js';
+export * as conversationsService from './services/conversations.js';
 
 export type {
   Nudge,
@@ -94,3 +100,24 @@ export {
   type UpdateTrustStatePatch,
   type UserDecision,
 } from './services/glia-types.js';
+
+export {
+  MESSAGE_ROLES,
+  type Conversation,
+  type ConversationContextEntry,
+  type ConversationListFilters,
+  type InsertConversationRow,
+  type InsertMessageRow,
+  type ListConversationsResult,
+  type Message,
+  type MessageRole,
+  type UpdateConversationPatch,
+  type UpsertContextRow,
+} from './services/conversations-types.js';
+
+export {
+  ConversationConflictError,
+  ConversationNotFoundError,
+  MessageConflictError,
+  MessageNotFoundError,
+} from './services/conversations-errors.js';

--- a/packages/cerebrum-db/src/schema.ts
+++ b/packages/cerebrum-db/src/schema.ts
@@ -15,10 +15,13 @@
  *     PRD-179 atomic memory units + their graph edges.
  *   - `gliaActions` / `gliaTrustState` — PRD-181 autonomous-action
  *     proposals + per-type trust graduation state (ADR-021 / PRD-086).
+ *   - `conversations` / `messages` / `conversationContext` — PRD-182
+ *     chat-with-cerebrum sessions, append-only message stream, and the
+ *     conversation → engram junction table.
  *
- * Downstream slices (embeddings, conversations, plexus_adapters,
- * plexus_filters) will add their tables here as their service code
- * lands.
+ * Downstream slices (embeddings, plexus_adapters, plexus_filters) will
+ * add their tables here as their service code lands.
  */
 export { engramIndex, engramLinks, engramScopes, engramTags, nudgeLog } from '@pops/db-types';
 export { gliaActions, gliaTrustState } from '@pops/db-types/schema';
+export { conversationContext, conversations, messages } from '@pops/db-types/schema';

--- a/packages/cerebrum-db/src/services/conversations-errors.ts
+++ b/packages/cerebrum-db/src/services/conversations-errors.ts
@@ -1,0 +1,47 @@
+/**
+ * Typed errors raised by the conversations data-access layer.
+ *
+ * Plain Error subclasses — the service layer doesn't know about HTTP.
+ * The pops-api router/middleware maps them to status codes when surfacing
+ * to clients. Mirrors `@pops/media-db`'s error pattern.
+ */
+
+export class ConversationNotFoundError extends Error {
+  override readonly name = 'ConversationNotFoundError' as const;
+  readonly id: string;
+
+  constructor(id: string) {
+    super(`Conversation '${id}' not found`);
+    this.id = id;
+  }
+}
+
+export class ConversationConflictError extends Error {
+  override readonly name = 'ConversationConflictError' as const;
+  readonly id: string;
+
+  constructor(id: string) {
+    super(`Conversation with id '${id}' already exists`);
+    this.id = id;
+  }
+}
+
+export class MessageNotFoundError extends Error {
+  override readonly name = 'MessageNotFoundError' as const;
+  readonly id: string;
+
+  constructor(id: string) {
+    super(`Message '${id}' not found`);
+    this.id = id;
+  }
+}
+
+export class MessageConflictError extends Error {
+  override readonly name = 'MessageConflictError' as const;
+  readonly id: string;
+
+  constructor(id: string) {
+    super(`Message with id '${id}' already exists`);
+    this.id = id;
+  }
+}

--- a/packages/cerebrum-db/src/services/conversations-helpers.ts
+++ b/packages/cerebrum-db/src/services/conversations-helpers.ts
@@ -1,0 +1,68 @@
+/**
+ * Conversation row serialisation helpers.
+ *
+ * Extracted so the SQL seam in `conversations.ts` stays focused on
+ * queries and so tests can exercise the JSON deserialisation logic in
+ * isolation. `active_scopes` is stored as a JSON-encoded `string[]`;
+ * `app_context`, `citations`, and `tool_calls` are stored as
+ * JSON-encoded opaque values (the chat orchestration layer owns the
+ * shape) and round-tripped as `unknown` here.
+ */
+import type { conversationContext, conversations, messages } from '../schema.js';
+import type {
+  Conversation,
+  ConversationContextEntry,
+  Message,
+  MessageRole,
+} from './conversations-types.js';
+
+/** Deserialise a row from `conversations` into a `Conversation`. */
+export function rowToConversation(row: typeof conversations.$inferSelect): Conversation {
+  return {
+    id: row.id,
+    title: row.title,
+    activeScopes: parseScopes(row.activeScopes),
+    appContext: parseJsonOrNull(row.appContext),
+    model: row.model,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+/** Deserialise a row from `messages` into a `Message`. */
+export function rowToMessage(row: typeof messages.$inferSelect): Message {
+  return {
+    id: row.id,
+    conversationId: row.conversationId,
+    role: row.role as MessageRole,
+    content: row.content,
+    citations: parseJsonOrNull(row.citations),
+    toolCalls: parseJsonOrNull(row.toolCalls),
+    tokensIn: row.tokensIn,
+    tokensOut: row.tokensOut,
+    createdAt: row.createdAt,
+  };
+}
+
+/** Deserialise a row from `conversation_context`. */
+export function rowToContextEntry(
+  row: typeof conversationContext.$inferSelect
+): ConversationContextEntry {
+  return {
+    conversationId: row.conversationId,
+    engramId: row.engramId,
+    relevanceScore: row.relevanceScore,
+    loadedAt: row.loadedAt,
+  };
+}
+
+function parseScopes(value: string): string[] {
+  const parsed = JSON.parse(value) as unknown;
+  if (!Array.isArray(parsed)) return [];
+  return parsed.filter((s): s is string => typeof s === 'string');
+}
+
+function parseJsonOrNull(value: string | null): unknown | null {
+  if (value == null) return null;
+  return JSON.parse(value) as unknown;
+}

--- a/packages/cerebrum-db/src/services/conversations-types.ts
+++ b/packages/cerebrum-db/src/services/conversations-types.ts
@@ -1,0 +1,97 @@
+/**
+ * Conversations public shapes returned from the data-access layer.
+ *
+ * Mirrors the conversation / message / context shapes the pops-api
+ * `ConversationPersistence` exposes today. Kept in the data package so
+ * `cerebrum-api` and any other consumer can build views without
+ * re-deriving them from drizzle row shapes.
+ */
+
+/** Message roles allowed in the chat stream. */
+export const MESSAGE_ROLES = ['user', 'assistant', 'system', 'tool'] as const;
+export type MessageRole = (typeof MESSAGE_ROLES)[number];
+
+/** A conversation row deserialised from `conversations`. */
+export interface Conversation {
+  id: string;
+  title: string | null;
+  activeScopes: string[];
+  appContext: unknown | null;
+  model: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** A message row deserialised from `messages`. */
+export interface Message {
+  id: string;
+  conversationId: string;
+  role: MessageRole;
+  content: string;
+  citations: unknown | null;
+  toolCalls: unknown | null;
+  tokensIn: number | null;
+  tokensOut: number | null;
+  createdAt: string;
+}
+
+/** A conversation context (engram association) row. */
+export interface ConversationContextEntry {
+  conversationId: string;
+  engramId: string;
+  relevanceScore: number | null;
+  loadedAt: string;
+}
+
+/** Insert payload for `insertConversation`. */
+export interface InsertConversationRow {
+  id: string;
+  title: string | null;
+  activeScopes: readonly string[];
+  appContext: unknown | null;
+  model: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** Patch payload for `updateConversation` — every column optional. */
+export interface UpdateConversationPatch {
+  title?: string | null;
+  activeScopes?: readonly string[];
+  appContext?: unknown | null;
+  updatedAt: string;
+}
+
+/** Insert payload for `insertMessage`. */
+export interface InsertMessageRow {
+  id: string;
+  conversationId: string;
+  role: MessageRole;
+  content: string;
+  citations: unknown | null;
+  toolCalls: unknown | null;
+  tokensIn: number | null;
+  tokensOut: number | null;
+  createdAt: string;
+}
+
+/** Upsert payload for `upsertConversationContext`. */
+export interface UpsertContextRow {
+  conversationId: string;
+  engramId: string;
+  relevanceScore: number | null;
+  loadedAt: string;
+}
+
+/** Filters for `listConversations`. */
+export interface ConversationListFilters {
+  search?: string;
+  limit?: number;
+  offset?: number;
+}
+
+/** Result envelope from `listConversations`. */
+export interface ListConversationsResult {
+  conversations: Conversation[];
+  total: number;
+}

--- a/packages/cerebrum-db/src/services/conversations.ts
+++ b/packages/cerebrum-db/src/services/conversations.ts
@@ -1,0 +1,298 @@
+/**
+ * Conversations data-access for the cerebrum pillar (PRD-182 US-01).
+ *
+ * Scope boundary: this file is the SQL seam for the conversations slice.
+ * It covers CRUD on `conversations`, append/read on `messages`, and
+ * upsert/list on `conversation_context` (the engram association junction
+ * table). All writes serialise JSON-encoded columns (`active_scopes`,
+ * `app_context`, `citations`, `tool_calls`) and apply the throw-if-not-
+ * found contract via the typed errors in `conversations-errors.ts`.
+ *
+ * Domain orchestration (chat streaming, model selection, scope
+ * negotiation, auto-titling, persistence-store wiring) stays in
+ * `apps/pops-api/src/modules/cerebrum/ego/*` until PRD-182 PR 3 flips
+ * routing through `getCerebrumDrizzle()`. That keeps this package pure
+ * data-access — no node:fs imports, no zod cross-validation, no LLM
+ * client wiring.
+ *
+ * The functions take a `CerebrumDb` handle as their first argument; the
+ * calling layer (pops-api today, `cerebrum-api` after the cutover)
+ * resolves the singleton or transaction handle. Mirrors the
+ * `nudge-log.ts` / `engrams.ts` / `glia.ts` db-arg pattern in this
+ * package.
+ */
+import { and, asc, count, desc, eq, like } from 'drizzle-orm';
+
+import { conversationContext, conversations, messages } from '../schema.js';
+import {
+  ConversationConflictError,
+  ConversationNotFoundError,
+  MessageConflictError,
+  MessageNotFoundError,
+} from './conversations-errors.js';
+import { rowToContextEntry, rowToConversation, rowToMessage } from './conversations-helpers.js';
+
+import type {
+  Conversation,
+  ConversationContextEntry,
+  ConversationListFilters,
+  InsertConversationRow,
+  InsertMessageRow,
+  ListConversationsResult,
+  Message,
+  UpdateConversationPatch,
+  UpsertContextRow,
+} from './conversations-types.js';
+import type { CerebrumDb } from './internal.js';
+
+export { rowToContextEntry, rowToConversation, rowToMessage };
+export {
+  ConversationConflictError,
+  ConversationNotFoundError,
+  MessageConflictError,
+  MessageNotFoundError,
+};
+
+/** Fetch a single conversation by id. Returns null when missing. */
+export function getConversation(db: CerebrumDb, id: string): Conversation | null {
+  const row = db.select().from(conversations).where(eq(conversations.id, id)).get();
+  return row ? rowToConversation(row) : null;
+}
+
+/**
+ * Strict variant of `getConversation` — throws `ConversationNotFoundError`
+ * when the row is missing. The caller picks the variant that matches the
+ * surrounding flow's error contract.
+ */
+export function requireConversation(db: CerebrumDb, id: string): Conversation {
+  const found = getConversation(db, id);
+  if (!found) throw new ConversationNotFoundError(id);
+  return found;
+}
+
+/**
+ * Paginated list of conversations. Orders by `updated_at desc` so the
+ * most recently touched session surfaces first. The optional `search`
+ * filters by title via LIKE; matches the inline persistence search
+ * behaviour today. Returns both the rows and the unpaginated `total`.
+ */
+export function listConversations(
+  db: CerebrumDb,
+  filters: ConversationListFilters = {}
+): ListConversationsResult {
+  const { search, limit = 50, offset = 0 } = filters;
+  const where = search ? like(conversations.title, `%${search}%`) : undefined;
+
+  const rows = db
+    .select()
+    .from(conversations)
+    .where(where)
+    .orderBy(desc(conversations.updatedAt))
+    .limit(limit)
+    .offset(offset)
+    .all();
+
+  const [totalRow] = db.select({ total: count() }).from(conversations).where(where).all();
+
+  return {
+    conversations: rows.map(rowToConversation),
+    total: totalRow?.total ?? 0,
+  };
+}
+
+/**
+ * Insert a fully-formed `conversations` row. The caller is expected to
+ * have generated the id and resolved timestamps; this function only
+ * serialises and writes. Throws `ConversationConflictError` if the id
+ * already exists so the caller can distinguish create-vs-update intent.
+ */
+export function insertConversation(db: CerebrumDb, row: InsertConversationRow): Conversation {
+  if (getConversation(db, row.id)) throw new ConversationConflictError(row.id);
+  const values = {
+    id: row.id,
+    title: row.title,
+    activeScopes: JSON.stringify([...row.activeScopes]),
+    appContext: row.appContext != null ? JSON.stringify(row.appContext) : null,
+    model: row.model,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+  db.insert(conversations).values(values).run();
+  return rowToConversation(values);
+}
+
+/**
+ * Apply a patch to a conversation row. The patch shape is intentionally
+ * narrow: only mutable columns can be set. Identity columns (`id`,
+ * `model`, `createdAt`) are immutable post-insert. Throws
+ * `ConversationNotFoundError` when the row does not exist; the caller is
+ * forced to supply `updatedAt` so the data layer never reaches for a
+ * clock.
+ */
+export function updateConversation(
+  db: CerebrumDb,
+  id: string,
+  patch: UpdateConversationPatch
+): Conversation {
+  if (!getConversation(db, id)) throw new ConversationNotFoundError(id);
+  const next: Record<string, unknown> = { updatedAt: patch.updatedAt };
+  if (patch.title !== undefined) next.title = patch.title;
+  if (patch.activeScopes !== undefined) next.activeScopes = JSON.stringify([...patch.activeScopes]);
+  if (patch.appContext !== undefined) {
+    next.appContext = patch.appContext != null ? JSON.stringify(patch.appContext) : null;
+  }
+  db.update(conversations).set(next).where(eq(conversations.id, id)).run();
+  return requireConversation(db, id);
+}
+
+/**
+ * Delete a conversation. The ON DELETE CASCADE on the FK columns of
+ * `messages` and `conversation_context` carries the dependent rows
+ * along, so callers don't need an explicit transaction. Returns the
+ * number of conversation rows deleted (0 if `id` was already gone —
+ * caller can treat this as idempotent).
+ */
+export function deleteConversation(db: CerebrumDb, id: string): number {
+  return db.delete(conversations).where(eq(conversations.id, id)).run().changes;
+}
+
+/** Fetch a single message by id. Returns null when missing. */
+export function getMessage(db: CerebrumDb, id: string): Message | null {
+  const row = db.select().from(messages).where(eq(messages.id, id)).get();
+  return row ? rowToMessage(row) : null;
+}
+
+/**
+ * List every message for a conversation, ordered by `created_at asc` so
+ * the chat surface can render the stream chronologically without an
+ * additional sort.
+ */
+export function listMessages(db: CerebrumDb, conversationId: string): Message[] {
+  const rows = db
+    .select()
+    .from(messages)
+    .where(eq(messages.conversationId, conversationId))
+    .orderBy(asc(messages.createdAt))
+    .all();
+  return rows.map(rowToMessage);
+}
+
+/**
+ * Insert a message and bump the parent conversation's `updated_at` so
+ * the conversation list re-sorts to surface the active session. Wrapped
+ * in a transaction so the two writes commit atomically. Throws
+ * `ConversationNotFoundError` if the parent conversation is missing and
+ * `MessageConflictError` if the supplied message id already exists.
+ */
+export function insertMessage(db: CerebrumDb, row: InsertMessageRow): Message {
+  if (!getConversation(db, row.conversationId)) {
+    throw new ConversationNotFoundError(row.conversationId);
+  }
+  if (getMessage(db, row.id)) throw new MessageConflictError(row.id);
+  const values = {
+    id: row.id,
+    conversationId: row.conversationId,
+    role: row.role,
+    content: row.content,
+    citations: row.citations != null ? JSON.stringify(row.citations) : null,
+    toolCalls: row.toolCalls != null ? JSON.stringify(row.toolCalls) : null,
+    tokensIn: row.tokensIn,
+    tokensOut: row.tokensOut,
+    createdAt: row.createdAt,
+  };
+  db.transaction((tx) => {
+    tx.insert(messages).values(values).run();
+    tx.update(conversations)
+      .set({ updatedAt: row.createdAt })
+      .where(eq(conversations.id, row.conversationId))
+      .run();
+  });
+  return rowToMessage(values);
+}
+
+/**
+ * Delete a message by id. Returns the number of rows actually deleted
+ * (0 if missing — caller can treat this as idempotent). Does not bump
+ * the conversation's `updated_at`: deletion is an administrative
+ * operation, not a chat-stream event.
+ */
+export function deleteMessage(db: CerebrumDb, id: string): number {
+  return db.delete(messages).where(eq(messages.id, id)).run().changes;
+}
+
+/**
+ * Count messages for a conversation, optionally filtered by role. Used
+ * by the auto-title heuristic in pops-api to detect the first user
+ * message; kept here so the data layer owns the COUNT and the
+ * orchestration code stays focused on the heuristic.
+ */
+export function countMessages(
+  db: CerebrumDb,
+  conversationId: string,
+  role?: Message['role']
+): number {
+  const where = role
+    ? and(eq(messages.conversationId, conversationId), eq(messages.role, role))
+    : eq(messages.conversationId, conversationId);
+  const row = db.select({ total: count() }).from(messages).where(where).get();
+  return row?.total ?? 0;
+}
+
+/**
+ * Insert or update a context entry linking a conversation to an engram.
+ * Conflict target is the composite primary key (conversation_id,
+ * engram_id); re-loading the same engram into the same conversation
+ * refreshes `relevance_score` and `loaded_at`. Throws
+ * `ConversationNotFoundError` if the parent conversation is missing.
+ */
+export function upsertConversationContext(db: CerebrumDb, row: UpsertContextRow): void {
+  if (!getConversation(db, row.conversationId)) {
+    throw new ConversationNotFoundError(row.conversationId);
+  }
+  db.insert(conversationContext)
+    .values(row)
+    .onConflictDoUpdate({
+      target: [conversationContext.conversationId, conversationContext.engramId],
+      set: { relevanceScore: row.relevanceScore, loadedAt: row.loadedAt },
+    })
+    .run();
+}
+
+/**
+ * List context entries for a conversation, ordered by `loaded_at desc`
+ * so the freshest engram association surfaces first. Mirrors the
+ * `getContextEntries` shape pops-api exposes today.
+ */
+export function listConversationContext(
+  db: CerebrumDb,
+  conversationId: string
+): ConversationContextEntry[] {
+  const rows = db
+    .select()
+    .from(conversationContext)
+    .where(eq(conversationContext.conversationId, conversationId))
+    .orderBy(desc(conversationContext.loadedAt))
+    .all();
+  return rows.map(rowToContextEntry);
+}
+
+/**
+ * Remove a single engram association from a conversation. Returns the
+ * number of rows actually deleted (0 if missing — caller can treat this
+ * as idempotent).
+ */
+export function deleteConversationContext(
+  db: CerebrumDb,
+  conversationId: string,
+  engramId: string
+): number {
+  return db
+    .delete(conversationContext)
+    .where(
+      and(
+        eq(conversationContext.conversationId, conversationId),
+        eq(conversationContext.engramId, engramId)
+      )
+    )
+    .run().changes;
+}


### PR DESCRIPTION
## Summary

PRD-182 PR 1 — carves out the conversations data layer in `@pops/cerebrum-db`. Mirrors the shape of PR #2994 (engrams) and PR #3000 (glia) for the conversations / messages / conversation_context slice.

- `migrations/0052_conversations_baseline.sql` mirrors the live `db-types/schema/ego.ts` shape byte-for-byte (3 tables, FK cascades, indexes).
- `services/conversations.ts` exposes CRUD on `conversations`, append/list on `messages`, upsert/list on `conversation_context`, plus `countMessages` + `requireConversation`. Pure data-access — no `node:fs`, no zod, no LLM client.
- `services/conversations-errors.ts` adds `ConversationNotFoundError`, `ConversationConflictError`, `MessageNotFoundError`, `MessageConflictError` — same `extends Error` pattern as `@pops/media-db`.
- `backfill-cerebrum-from-shared.ts` copies the three new tables out of the shared `pops.db` on boot. Parent table copied first so the dependents' FKs are satisfied at insert time.
- `per-pillar-migrations.test.ts` adds the new slot.

Consumers in `apps/pops-api/src/modules/cerebrum/ego/*` still write to the shared handle; PRD-182 PR 3 flips routing through `getCerebrumDrizzle()`.

Migration slot: claimed `0052` (engrams=0050, glia=0051; plexus baseline is still in flight and will land later).

Divergence from PRD text: the README describes an idealised future schema (`primary_intent`, `summary`, `conversation_engram_refs`, etc). The implementation mirrors the live shape that pops-api persists today (`active_scopes`, `app_context`, `model`, `conversation_context`), per the canonical pattern of mirroring whatever the shared `pops.db` actually has so the backfill copies row-for-row.

## Test plan

- [x] `pnpm -F @pops/cerebrum-db build` — green
- [x] `pnpm -F @pops/cerebrum-db test` — 96 cases, 5 files (17 new for conversations)
- [x] `pnpm -F @pops/cerebrum-db typecheck` — green
- [x] `pnpm -F @pops/api test src/db/per-pillar-migrations.test.ts src/db/backfill-cerebrum-from-shared.test.ts` — 19 cases (3 new for conversations)
- [x] `pnpm oxlint` + `pnpm oxfmt` — clean on touched paths
- [x] `pnpm -w typecheck` — 66/66 green