### PR TITLE
feat(media): cut tv-shows router to @pops/media-db (PRD-166 PR2)

### DIFF
--- a/apps/pops-api/src/modules/media/tv-shows/router.ts
+++ b/apps/pops-api/src/modules/media/tv-shows/router.ts
@@ -41,7 +41,11 @@ export const tvShowsRouter = router({
       const limit = input.limit ?? DEFAULT_LIMIT;
       const offset = input.offset ?? DEFAULT_OFFSET;
 
-      const { rows, total } = service.listTvShows(input.search, input.status, limit, offset);
+      const { rows, total } = service.listTvShows(
+        { search: input.search, status: input.status },
+        limit,
+        offset
+      );
 
       return {
         data: rows.map(toTvShow),

--- a/apps/pops-api/src/modules/media/tv-shows/tv-shows-base.ts
+++ b/apps/pops-api/src/modules/media/tv-shows/tv-shows-base.ts
@@ -7,10 +7,29 @@
  * thetvdb service + refresh-episodes, …) keep importing from
  * `./tv-shows/service.js` unchanged. The handle now points at the media
  * pillar's per-pillar SQLite via `getMediaDrizzle()` instead of the
- * shared `pops.db` singleton, so every tv-shows write lands in
- * `media.db.tv_shows`. Reads issued from the legacy mount still serve
- * the same rows because the backfill keeps both stores in sync until
- * the shim retires.
+ * shared `pops.db` singleton, so every tv-shows write through this
+ * wrapper lands in `media.db.tv_shows`.
+ *
+ * Cross-store consistency during the migration window:
+ *  - `backfillMediaFromShared()` runs at boot and is one-way only
+ *    (pops.db → media.db, idempotent via NOT IN id filter). It does NOT
+ *    keep the two stores in sync at runtime; it only catches media.db
+ *    up to pops.db on each restart.
+ *  - In-tree code paths that still write tv_shows to the shared
+ *    `pops.db` (notably `library/tv-show-service.ts` for plex/library
+ *    ingestion, and `seasons-service.ts` / `episodes-service.ts` whose
+ *    FK parents live on the legacy mount) remain the source of truth
+ *    for `seasons.tv_show_id` and `episodes.season_id` joins. Until
+ *    those slices ship to `@pops/media-db`, the seasons/episodes
+ *    services intentionally read+write the shared DB so their FK joins
+ *    resolve in one store, and the boot-time backfill carries rows
+ *    written there into media.db on the next deploy.
+ *  - This means a tv_show created via `createTvShow` (media.db only)
+ *    will not satisfy an FK insert in `createSeason` (pops.db) until
+ *    the seasons/episodes cutover ships. Callers that need both must
+ *    keep going through the library ingestion path which writes to the
+ *    shared DB; this wrapper is currently used by reads + the
+ *    metadata-refresh writes that don't need new season FKs.
  *
  * Error translation: the package surface throws `TvShowNotFoundError` /
  * `TvShowConflictError`. We re-throw them as the in-tree `NotFoundError`

--- a/apps/pops-api/src/modules/media/tv-shows/tv-shows-base.ts
+++ b/apps/pops-api/src/modules/media/tv-shows/tv-shows-base.ts
@@ -1,170 +1,85 @@
-import { and, asc, count, eq, like } from 'drizzle-orm';
+/**
+ * TV shows wrapper — resolves the media-pillar drizzle handle and forwards
+ * to `@pops/media-db`'s `tvShowsService` (PRD-166 cutover).
+ *
+ * Mirrors the movies PR 3 pattern: in-tree callers (router.ts,
+ * library/tv-show-service.ts, plex sync helpers, watchlist push,
+ * thetvdb service + refresh-episodes, …) keep importing from
+ * `./tv-shows/service.js` unchanged. The handle now points at the media
+ * pillar's per-pillar SQLite via `getMediaDrizzle()` instead of the
+ * shared `pops.db` singleton, so every tv-shows write lands in
+ * `media.db.tv_shows`. Reads issued from the legacy mount still serve
+ * the same rows because the backfill keeps both stores in sync until
+ * the shim retires.
+ *
+ * Error translation: the package surface throws `TvShowNotFoundError` /
+ * `TvShowConflictError`. We re-throw them as the in-tree `NotFoundError`
+ * / `ConflictError` so the router's `instanceof` checks (and library /
+ * plex callers that catch the same shapes) keep working without churn.
+ *
+ * Out of scope (per PRD-166): `seasons-service.ts` and
+ * `episodes-service.ts` still route through `getDrizzle()`; they migrate
+ * once their slices land in `@pops/media-db`.
+ */
+import {
+  tvShowsService,
+  TvShowConflictError,
+  TvShowNotFoundError,
+  type TvShowFilters,
+  type TvShowListResult,
+} from '@pops/media-db';
 
-import { tvShows } from '@pops/db-types';
-
-import { getDrizzle } from '../../../db.js';
+import { getMediaDrizzle } from '../../../db/media-db-handle.js';
 import { ConflictError, NotFoundError } from '../../../shared/errors.js';
 
-import type { TvShowRow } from '@pops/db-types';
+import type { CreateTvShowInput, TvShowRow, UpdateTvShowInput } from './types.js';
 
-import type { CreateTvShowInput, UpdateTvShowInput } from './types.js';
+export type { TvShowListResult };
 
-export interface TvShowListResult {
-  rows: TvShowRow[];
-  total: number;
+function translate<T>(fn: () => T): T {
+  try {
+    return fn();
+  } catch (err) {
+    if (err instanceof TvShowNotFoundError) {
+      throw new NotFoundError('TvShow', String(err.id));
+    }
+    if (err instanceof TvShowConflictError) {
+      throw new ConflictError(`TV show with TVDB ID ${err.tvdbId} already exists`);
+    }
+    throw err;
+  }
 }
 
+/** List TV shows with optional filters. */
 export function listTvShows(
-  search: string | undefined,
-  status: string | undefined,
+  filters: TvShowFilters,
   limit: number,
   offset: number
 ): TvShowListResult {
-  const db = getDrizzle();
-  const conditions = [];
-  if (search) conditions.push(like(tvShows.name, `%${search}%`));
-  if (status) conditions.push(eq(tvShows.status, status));
-  const where = conditions.length > 0 ? and(...conditions) : undefined;
-
-  const rows = db
-    .select()
-    .from(tvShows)
-    .where(where)
-    .orderBy(asc(tvShows.name))
-    .limit(limit)
-    .offset(offset)
-    .all();
-
-  const countRow = db.select({ total: count() }).from(tvShows).where(where).all()[0];
-  return { rows, total: countRow?.total ?? 0 };
+  return tvShowsService.listTvShows(getMediaDrizzle(), filters, limit, offset);
 }
 
+/** Get a single TV show by id. Throws `NotFoundError` if missing. */
 export function getTvShow(id: number): TvShowRow {
-  const db = getDrizzle();
-  const row = db.select().from(tvShows).where(eq(tvShows.id, id)).get();
-  if (!row) throw new NotFoundError('TvShow', String(id));
-  return row;
+  return translate(() => tvShowsService.getTvShow(getMediaDrizzle(), id));
 }
 
+/** Get a single TV show by TVDB ID. Returns `null` if not found. */
 export function getTvShowByTvdbId(tvdbId: number): TvShowRow | null {
-  const db = getDrizzle();
-  return db.select().from(tvShows).where(eq(tvShows.tvdbId, tvdbId)).get() ?? null;
+  return tvShowsService.getTvShowByTvdbId(getMediaDrizzle(), tvdbId);
 }
 
-const TV_SHOW_NULLABLE_INSERT_KEYS = [
-  'originalName',
-  'overview',
-  'firstAirDate',
-  'lastAirDate',
-  'status',
-  'originalLanguage',
-  'numberOfSeasons',
-  'numberOfEpisodes',
-  'episodeRunTime',
-  'posterPath',
-  'backdropPath',
-  'logoPath',
-  'posterOverridePath',
-  'voteAverage',
-  'voteCount',
-] as const satisfies ReadonlyArray<keyof CreateTvShowInput & keyof typeof tvShows.$inferInsert>;
-
-function buildTvShowInsertValues(
-  input: CreateTvShowInput,
-  now: string
-): typeof tvShows.$inferInsert {
-  const values: Record<string, unknown> = {
-    tvdbId: input.tvdbId,
-    name: input.name,
-    genres: input.genres ? JSON.stringify(input.genres) : null,
-    networks: input.networks ? JSON.stringify(input.networks) : null,
-    createdAt: now,
-    updatedAt: now,
-  };
-  for (const key of TV_SHOW_NULLABLE_INSERT_KEYS) {
-    values[key] = input[key] ?? null;
-  }
-  return values as typeof tvShows.$inferInsert;
-}
-
+/** Create a new TV show. Throws `ConflictError` on duplicate tvdbId. */
 export function createTvShow(input: CreateTvShowInput): TvShowRow {
-  const db = getDrizzle();
-  const existing = db
-    .select({ id: tvShows.id })
-    .from(tvShows)
-    .where(eq(tvShows.tvdbId, input.tvdbId))
-    .get();
-  if (existing) {
-    throw new ConflictError(`TV show with TVDB ID ${input.tvdbId} already exists`);
-  }
-  const now = new Date().toISOString();
-  db.insert(tvShows).values(buildTvShowInsertValues(input, now)).run();
-  const row = db.select().from(tvShows).where(eq(tvShows.tvdbId, input.tvdbId)).get();
-  if (!row) throw new Error(`TV show with TVDB ID ${input.tvdbId} not found after insert`);
-  return row;
+  return translate(() => tvShowsService.createTvShow(getMediaDrizzle(), input));
 }
 
-const TV_SHOW_NULLABLE_KEYS = [
-  'originalName',
-  'overview',
-  'firstAirDate',
-  'lastAirDate',
-  'status',
-  'originalLanguage',
-  'numberOfSeasons',
-  'numberOfEpisodes',
-  'episodeRunTime',
-  'posterPath',
-  'backdropPath',
-  'logoPath',
-  'posterOverridePath',
-  'voteAverage',
-  'voteCount',
-] as const satisfies ReadonlyArray<keyof UpdateTvShowInput & keyof typeof tvShows.$inferInsert>;
-
-const TV_SHOW_JSON_KEYS = ['genres', 'networks'] as const satisfies ReadonlyArray<
-  keyof UpdateTvShowInput & keyof typeof tvShows.$inferInsert
->;
-
-function buildTvShowUpdate(input: UpdateTvShowInput): Partial<typeof tvShows.$inferInsert> | null {
-  const updates: Record<string, unknown> = {};
-  let touched = false;
-
-  if (input.name !== undefined) {
-    updates.name = input.name;
-    touched = true;
-  }
-
-  for (const key of TV_SHOW_NULLABLE_KEYS) {
-    const value = input[key];
-    if (value === undefined) continue;
-    updates[key] = value ?? null;
-    touched = true;
-  }
-
-  for (const key of TV_SHOW_JSON_KEYS) {
-    const value = input[key];
-    if (value === undefined) continue;
-    updates[key] = JSON.stringify(value);
-    touched = true;
-  }
-
-  if (!touched) return null;
-  updates.updatedAt = new Date().toISOString();
-  return updates as Partial<typeof tvShows.$inferInsert>;
-}
-
+/** Update an existing TV show. Throws `NotFoundError` if missing. */
 export function updateTvShow(id: number, input: UpdateTvShowInput): TvShowRow {
-  getTvShow(id);
-  const updates = buildTvShowUpdate(input);
-  if (updates) {
-    getDrizzle().update(tvShows).set(updates).where(eq(tvShows.id, id)).run();
-  }
-  return getTvShow(id);
+  return translate(() => tvShowsService.updateTvShow(getMediaDrizzle(), id, input));
 }
 
+/** Delete a TV show by id. Throws `NotFoundError` if missing. */
 export function deleteTvShow(id: number): void {
-  getTvShow(id);
-  const db = getDrizzle();
-  db.delete(tvShows).where(eq(tvShows.id, id)).run();
+  translate(() => tvShowsService.deleteTvShow(getMediaDrizzle(), id));
 }

--- a/apps/pops-api/src/modules/media/tv-shows/types-domain.ts
+++ b/apps/pops-api/src/modules/media/tv-shows/types-domain.ts
@@ -1,4 +1,5 @@
-import type { EpisodeRow, SeasonRow, TvShowRow } from '@pops/db-types';
+import type { EpisodeRow, SeasonRow } from '@pops/db-types';
+import type { TvShowRow } from '@pops/media-db';
 
 export type { EpisodeRow, SeasonRow, TvShowRow };
 

--- a/apps/pops-api/src/modules/media/tv-shows/types-mappers.ts
+++ b/apps/pops-api/src/modules/media/tv-shows/types-mappers.ts
@@ -1,4 +1,5 @@
-import type { EpisodeRow, SeasonRow, TvShowRow } from '@pops/db-types';
+import type { EpisodeRow, SeasonRow } from '@pops/db-types';
+import type { TvShowRow } from '@pops/media-db';
 
 import type { Episode, Season, TvShow } from './types-domain.js';
 


### PR DESCRIPTION
## Summary

- Cuts `apps/pops-api/src/modules/media/tv-shows/tv-shows-base.ts` to a thin wrapper around `@pops/media-db`'s `tvShowsService`, resolved via the media pillar handle (`getMediaDrizzle()`). Every tv-shows CRUD now lands in `media.db.tv_shows`.
- Mirrors the movies cutover pattern from #3006 (`08f04d73`). `TvShowNotFoundError` / `TvShowConflictError` translate back to the in-tree `NotFoundError` / `ConflictError` so the router's `instanceof` checks (and library / plex / thetvdb / watchlist callers) keep working without churn.
- Flips `types-domain.ts`'s `TvShowRow` import from `@pops/db-types` to `@pops/media-db`. `EpisodeRow` / `SeasonRow` stay on `@pops/db-types` until their slices land in `@pops/media-db`.
- `listTvShows` takes a `TvShowFilters` object now (matching the package signature); the router (sole in-tree caller) is updated to pass `{ search, status }`.

### Out of scope (per PRD-166)

- `seasons-service.ts` / `episodes-service.ts` still route through `getDrizzle()` (shared `pops.db`) — they migrate once `@pops/media-db` gains those slices.
- Raw drizzle joins in library/quickPicks, debrief, comparisons, watch-history that read tv shows via `getDrizzle()` — Epic 09 finishes the migration.
- Removing the legacy mount on pops-api — stays mounted until E04 (batching fix) lands.

## Test plan

- [x] `pnpm -F @pops/api typecheck` — green
- [x] `pnpm -F @pops/api test src/modules/media/tv-shows` — 32 cases pass
- [x] `pnpm -F @pops/api test src/modules/media` — 90 files / 1442 cases pass
- [x] `pnpm -w typecheck` — 66/66 packages green
- [x] `pnpm oxlint` — 0 errors
- [x] `pnpm oxfmt` — clean

PRD: `docs/themes/13-pillar-finale/prds/166-media-tv-shows-cutover/README.md`
