### PR TITLE
feat(media): cut watchlist router to @pops/media-db (PRD-167 PR2)

### DIFF
--- a/apps/pops-api/src/db/backfill-media-from-shared.test.ts
+++ b/apps/pops-api/src/db/backfill-media-from-shared.test.ts
@@ -26,6 +26,7 @@ import {
   SHELF_IMPRESSIONS_TABLE_SQL,
   TV_SHOWS_TABLE_SQL,
   WATCH_HISTORY_TABLE_SQL,
+  WATCHLIST_TABLE_SQL,
 } from './backfill-test-fixtures.js';
 
 let tmpDir: string;
@@ -569,6 +570,132 @@ describe('backfillMediaFromShared', () => {
 
       expect(() => backfillMediaFromShared()).not.toThrow();
       const count = media.raw.prepare('SELECT count(*) AS n FROM watch_history').get() as {
+        n: number;
+      };
+      expect(count.n).toBe(0);
+    });
+  });
+
+  describe('watchlist (PRD-167 PR 2)', () => {
+    interface WatchlistSeed {
+      mediaType: 'movie' | 'tv_show';
+      mediaId: number;
+      priority?: number | null;
+      notes?: string | null;
+      source?: string;
+      plexRatingKey?: string | null;
+    }
+
+    function openSharedWithWatchlist(rows: WatchlistSeed[]): string {
+      const path = join(tmpDir, 'pops.db');
+      const raw = new BetterSqlite3(path);
+      raw.exec(SHELF_IMPRESSIONS_TABLE_SQL);
+      raw.exec(WATCHLIST_TABLE_SQL);
+      const insert = raw.prepare(
+        'INSERT INTO watchlist (media_type, media_id, priority, notes, source, plex_rating_key) VALUES (?, ?, ?, ?, ?, ?)'
+      );
+      for (const row of rows) {
+        insert.run(
+          row.mediaType,
+          row.mediaId,
+          row.priority ?? null,
+          row.notes ?? null,
+          row.source ?? 'manual',
+          row.plexRatingKey ?? null
+        );
+      }
+      raw.close();
+      process.env['SQLITE_PATH'] = path;
+      return path;
+    }
+
+    it('copies fresh watchlist rows on first run and is a no-op on the second', () => {
+      openSharedWithWatchlist([
+        { mediaType: 'movie', mediaId: 603, priority: 0 },
+        { mediaType: 'tv_show', mediaId: 42, priority: 1 },
+      ]);
+      const media = openMediaDb(join(tmpDir, 'media.db'));
+      setMediaDb(media);
+
+      backfillMediaFromShared();
+      const after = media.raw
+        .prepare('SELECT id, media_type, media_id FROM watchlist ORDER BY id')
+        .all() as { id: number; media_type: string; media_id: number }[];
+      expect(after.map((r) => r.media_id)).toEqual([603, 42]);
+
+      backfillMediaFromShared();
+      const second = media.raw.prepare('SELECT count(*) AS n FROM watchlist').get() as {
+        n: number;
+      };
+      expect(second.n).toBe(2);
+    });
+
+    it('only inserts watchlist rows missing from the media copy', () => {
+      openSharedWithWatchlist([
+        { mediaType: 'movie', mediaId: 603 },
+        { mediaType: 'tv_show', mediaId: 42 },
+      ]);
+      const media = openMediaDb(join(tmpDir, 'media.db'));
+      setMediaDb(media);
+      // Pre-seed id=1 with a different (media_type, media_id) tuple so the
+      // backfill skips it by id and the unique index doesn't conflict with
+      // the id=2 carry-over.
+      media.raw
+        .prepare('INSERT INTO watchlist (id, media_type, media_id) VALUES (?, ?, ?)')
+        .run(1, 'movie', 99_999);
+
+      backfillMediaFromShared();
+      const rows = media.raw
+        .prepare('SELECT id, media_type, media_id FROM watchlist ORDER BY id')
+        .all() as { id: number; media_type: string; media_id: number }[];
+      expect(rows).toEqual([
+        { id: 1, media_type: 'movie', media_id: 99_999 },
+        { id: 2, media_type: 'tv_show', media_id: 42 },
+      ]);
+    });
+
+    it('carries every column across (full-shape roundtrip)', () => {
+      openSharedWithWatchlist([
+        {
+          mediaType: 'tv_show',
+          mediaId: 12_345,
+          priority: 3,
+          notes: 'Pinned for the weekend',
+          source: 'plex',
+          plexRatingKey: 'discover-key-1',
+        },
+      ]);
+      const media = openMediaDb(join(tmpDir, 'media.db'));
+      setMediaDb(media);
+      backfillMediaFromShared();
+
+      const row = media.raw
+        .prepare('SELECT * FROM watchlist WHERE media_id = ?')
+        .get(12_345) as Record<string, unknown>;
+      expect(row).toMatchObject({
+        media_type: 'tv_show',
+        media_id: 12_345,
+        priority: 3,
+        notes: 'Pinned for the weekend',
+        source: 'plex',
+        plex_rating_key: 'discover-key-1',
+      });
+    });
+
+    it('tolerates a shared DB without the watchlist table', () => {
+      // Shared DB has shelf_impressions but no watchlist — backfill copies
+      // shelf rows and skips watchlist without throwing.
+      const path = join(tmpDir, 'pops.db');
+      const raw = new BetterSqlite3(path);
+      raw.exec(SHELF_IMPRESSIONS_TABLE_SQL);
+      raw.close();
+      process.env['SQLITE_PATH'] = path;
+
+      const media = openMediaDb(join(tmpDir, 'media.db'));
+      setMediaDb(media);
+
+      expect(() => backfillMediaFromShared()).not.toThrow();
+      const count = media.raw.prepare('SELECT count(*) AS n FROM watchlist').get() as {
         n: number;
       };
       expect(count.n).toBe(0);

--- a/apps/pops-api/src/db/backfill-test-fixtures-media.ts
+++ b/apps/pops-api/src/db/backfill-test-fixtures-media.ts
@@ -91,3 +91,17 @@ CREATE INDEX idx_watch_history_media ON watch_history (media_type, media_id);
 CREATE INDEX idx_watch_history_watched_at ON watch_history (watched_at);
 CREATE UNIQUE INDEX idx_watch_history_unique ON watch_history (media_type, media_id, watched_at);
 `;
+
+export const WATCHLIST_TABLE_SQL = `
+CREATE TABLE watchlist (
+  id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  media_type text NOT NULL,
+  media_id integer NOT NULL,
+  priority integer DEFAULT 0,
+  notes text,
+  added_at text DEFAULT (datetime('now')) NOT NULL,
+  source text DEFAULT 'manual' NOT NULL,
+  plex_rating_key text
+);
+CREATE UNIQUE INDEX idx_watchlist_media ON watchlist (media_type, media_id);
+`;

--- a/apps/pops-api/src/db/backfill-test-fixtures.ts
+++ b/apps/pops-api/src/db/backfill-test-fixtures.ts
@@ -24,6 +24,7 @@ export {
   SHELF_IMPRESSIONS_TABLE_SQL,
   TV_SHOWS_TABLE_SQL,
   WATCH_HISTORY_TABLE_SQL,
+  WATCHLIST_TABLE_SQL,
 } from './backfill-test-fixtures-media.js';
 export {
   BUDGETS_TABLE_SQL,

--- a/apps/pops-api/src/db/media-backfill.ts
+++ b/apps/pops-api/src/db/media-backfill.ts
@@ -110,6 +110,20 @@ const TABLE_COPIES: readonly TableCopy[] = [
     idColumn: 'id',
     columns: ['id', 'media_type', 'media_id', 'watched_at', 'completed', 'blacklisted'],
   },
+  {
+    table: 'watchlist',
+    idColumn: 'id',
+    columns: [
+      'id',
+      'media_type',
+      'media_id',
+      'priority',
+      'notes',
+      'added_at',
+      'source',
+      'plex_rating_key',
+    ],
+  },
 ];
 
 function tryCopyTable(raw: Database.Database, copy: TableCopy): void {

--- a/apps/pops-api/src/db/media-backfill.ts
+++ b/apps/pops-api/src/db/media-backfill.ts
@@ -18,6 +18,27 @@ import { resolveSqlitePath } from './sqlite-path.js';
  * pops.db) doesn't bring the whole backfill down. Failures are logged
  * + swallowed; the remaining tables still attempt.
  *
+ * Insert-only semantics — staleness model: `tryCopyTable` runs
+ * `INSERT ... WHERE id NOT IN (SELECT id FROM target)`, so the boot
+ * copy is strictly additive. For slices whose writes still target
+ * `pops.db` during the read/write split (`watchlist` is the live
+ * example as of PRD-167 PR 2), an UPDATE or DELETE applied to
+ * `pops.db.<table>` between boots is not reflected in
+ * `media.db.<table>`: an updated row keeps its stale fields in the
+ * media copy, and a deleted row keeps existing there until a manual
+ * intervention or the writer cutover lands. Reads off the media handle
+ * therefore lag writes by up to one boot cycle for the in-flight
+ * `priority` / `notes` / `plex_rating_key` columns and may
+ * temporarily surface entries that have already been deleted on the
+ * shared store. The watchlist router's removal flow guards against
+ * the deletion-resurrection foot-gun by routing the pre-delete
+ * existence check through `getSharedWatchlistEntry` (writes go to the
+ * same store as the check). Full read-your-writes consistency lands
+ * with PRD-167's writer cutover, at which point this `watchlist`
+ * entry collapses into a pure post-cutover seed and the staleness
+ * window disappears. Mirrors the precedent set by PRD-168 PR 2 for
+ * `watch_history` and PRD-165 PR 3 for `movies`.
+ *
  * Non-fatal: ATTACH or INSERT failures are logged and swallowed so a
  * stale on-disk pops.db never bricks the boot path. Failures here
  * leave the media copy partially populated for that boot; the next

--- a/apps/pops-api/src/modules/media/watchlist/router.ts
+++ b/apps/pops-api/src/modules/media/watchlist/router.ts
@@ -4,9 +4,12 @@
  * @deprecated PRD-167 PR 1 (Theme 13) shadows this router on
  * `apps/pops-media-api/src/modules/watchlist` against `@pops/media-db`.
  * The mount stays here as the fall-through while the dispatcher / cutover
- * lands in PRD-167 PR 3; reads continue to flow through this surface
- * because the `movies` / `tv_shows` enrichment join hasn't moved to the
- * media pillar yet (gated on PRD-165 / PRD-166).
+ * lands in PRD-167 PR 3.
+ *
+ * PRD-167 PR 2 (this PR) cuts the read paths in `./service.ts` over to
+ * `@pops/media-db`'s `watchlistService` via `getMediaDrizzle()`. Writes
+ * still target `pops.db`; see `./service.ts` for the documented split
+ * and the cross-store consistency contract.
  */
 import { TRPCError } from '@trpc/server';
 import { z } from 'zod';

--- a/apps/pops-api/src/modules/media/watchlist/router.ts
+++ b/apps/pops-api/src/modules/media/watchlist/router.ts
@@ -185,11 +185,10 @@ export const watchlistRouter = router({
 
   /** Remove an entry from the watchlist. Pushes removal to Plex if connected (best-effort). */
   remove: protectedProcedure.input(z.object({ id: z.number() })).mutation(async ({ input }) => {
-    // Fetch entry before removing to get plexRatingKey
     let plexRatingKey: string | null;
     try {
-      const entry = service.getWatchlistEntry(input.id);
-      plexRatingKey = (entry as Record<string, unknown>).plexRatingKey as string | null;
+      const entry = service.getSharedWatchlistEntry(input.id);
+      plexRatingKey = entry.plexRatingKey;
     } catch (err) {
       if (err instanceof NotFoundError) {
         throw new TRPCError({ code: 'NOT_FOUND', message: err.message });

--- a/apps/pops-api/src/modules/media/watchlist/service.ts
+++ b/apps/pops-api/src/modules/media/watchlist/service.ts
@@ -93,12 +93,21 @@ function translate<T>(fn: () => T): T {
   }
 }
 
-/** Read an entry off the shared `pops.db` — used by write paths to avoid a cross-store TOCTOU. */
+/**
+ * Read an entry off the shared `pops.db` — used by write paths to avoid a
+ * cross-store TOCTOU. Exported as `getSharedWatchlistEntry` for callers
+ * (e.g. the router's removal prefetch) that need a write-store-consistent
+ * existence check during the cutover window: a row newly added since the
+ * last boot lives only in `pops.db` and would 404 against the now-media-pillar
+ * `getWatchlistEntry`. Drop this once writes also move to `media.db`.
+ */
 function readSharedEntry(id: number): MediaWatchlistRow {
   const row = getDrizzle().select().from(mediaWatchlist).where(eq(mediaWatchlist.id, id)).get();
   if (!row) throw new NotFoundError('WatchlistEntry', String(id));
   return row;
 }
+
+export { readSharedEntry as getSharedWatchlistEntry };
 
 function enrichRow(row: MediaWatchlistRow): EnrichedWatchlistRow {
   const rawDb = getDb();

--- a/apps/pops-api/src/modules/media/watchlist/service.ts
+++ b/apps/pops-api/src/modules/media/watchlist/service.ts
@@ -1,11 +1,63 @@
-import { and, asc, count, desc, eq, type SQL } from 'drizzle-orm';
-
 /**
- * Watchlist service — CRUD operations against SQLite via Drizzle ORM.
+ * Watchlist read/write surface — PRD-167 PR 2 cutover.
+ *
+ * Read/write split during the migration window (mirrors the watch-history
+ * PR #3008 / movies PR #3006 pattern):
+ *
+ *  - `listWatchlist`, `getWatchlistEntry` and `getWatchlistStatus` are
+ *    routed through `getMediaDrizzle()` (the media pillar's per-pillar
+ *    `media.db.watchlist`) by forwarding to `@pops/media-db`'s
+ *    `watchlistService`. The list-row enrichment (`title` / `posterUrl`
+ *    join against `movies` / `tv_shows`) still runs through the raw
+ *    `getDb()` handle against the shared `pops.db` because the legacy
+ *    `movies` / `tv_shows` reads in this app continue to do so until
+ *    PRD-165 PR 4 / PRD-166 PR 4 retire the shared copies — both stores
+ *    stay in sync via the boot-time backfill so the join sees the same
+ *    rows either way.
+ *
+ *  - Every write path — `addToWatchlist`, `updateWatchlistEntry`,
+ *    `removeFromWatchlist`, `reorderWatchlist`, `removeByMedia`,
+ *    `resequencePriorities` — still goes through `getDrizzle()` (the
+ *    shared `pops.db`). Cross-module writers in this app
+ *    (`watch-history/handlers/log-watch-event.ts`,
+ *    `watch-history/handlers/batch-operations.ts`,
+ *    `plex/sync-watchlist.ts`, `rotation/removal-selection.ts`, the
+ *    discovery and comparisons readers) hold raw drizzle handles on
+ *    `mediaWatchlist` and target `pops.db`; keeping writes on the same
+ *    store avoids bifurcating new rows between the two SQLite files
+ *    until the full slice can be moved.
+ *
+ * Cross-store consistency relies on `backfillMediaFromShared()` in
+ * `apps/pops-api/src/db/media-backfill.ts`, which now copies the
+ * `watchlist` table from `pops.db` -> `media.db` on boot (this PR
+ * extends the `TABLE_COPIES` list). The copy is idempotent (`WHERE id
+ * NOT IN (...)`). Between boots, newly-written rows live only in
+ * `pops.db` and won't appear in `listWatchlist` / `getWatchlistEntry`
+ * results until the next deploy reruns the backfill — the same
+ * trade-off taken by the movies (PRD-165) and watch-history (PRD-168)
+ * cutovers. Full read-your-writes consistency lands when the writers
+ * also cut over.
+ *
+ * TOCTOU note: write paths that need an existence check (update /
+ * remove / reorder) read it from `pops.db` directly via
+ * `readSharedEntry` rather than going through the now-media-pillar
+ * `getWatchlistEntry`. This keeps the check and the subsequent UPDATE /
+ * DELETE on the same store so a row present on one side but not the
+ * other can't produce inconsistent "not found vs. silent no-op"
+ * behaviour. Mirrors the watch-history `deleteWatchHistoryEntry` fix
+ * shipped in PR #3008.
  */
+import { and, asc, desc, eq } from 'drizzle-orm';
+
 import { mediaWatchlist } from '@pops/db-types';
+import {
+  watchlistService,
+  WatchlistEntryNotFoundError,
+  WatchlistReorderConflictError,
+} from '@pops/media-db';
 
 import { getDb, getDrizzle } from '../../../db.js';
+import { getMediaDrizzle } from '../../../db/media-db-handle.js';
 import { ConflictError, NotFoundError } from '../../../shared/errors.js';
 
 import type {
@@ -22,90 +74,94 @@ export interface WatchlistListResult {
   total: number;
 }
 
-/** List watchlist entries with optional filters. */
+function narrowMediaType(value: string | undefined): 'movie' | 'tv_show' | undefined {
+  if (value === 'movie' || value === 'tv_show') return value;
+  return undefined;
+}
+
+function translate<T>(fn: () => T): T {
+  try {
+    return fn();
+  } catch (err) {
+    if (err instanceof WatchlistEntryNotFoundError) {
+      throw new NotFoundError('WatchlistEntry', String(err.entryId));
+    }
+    if (err instanceof WatchlistReorderConflictError) {
+      throw new ConflictError(err.message);
+    }
+    throw err;
+  }
+}
+
+/** Read an entry off the shared `pops.db` — used by write paths to avoid a cross-store TOCTOU. */
+function readSharedEntry(id: number): MediaWatchlistRow {
+  const row = getDrizzle().select().from(mediaWatchlist).where(eq(mediaWatchlist.id, id)).get();
+  if (!row) throw new NotFoundError('WatchlistEntry', String(id));
+  return row;
+}
+
+function enrichRow(row: MediaWatchlistRow): EnrichedWatchlistRow {
+  const rawDb = getDb();
+  let title: string | null = null;
+  let posterUrl: string | null = null;
+
+  if (row.mediaType === 'movie') {
+    const movie = rawDb
+      .prepare('SELECT title, tmdb_id, poster_path FROM movies WHERE id = ?')
+      .get(row.mediaId) as
+      | { title: string; tmdb_id: number; poster_path: string | null }
+      | undefined;
+    if (movie) {
+      title = movie.title;
+      posterUrl = movie.poster_path ? `/media/images/movie/${movie.tmdb_id}/poster.jpg` : null;
+    }
+  } else if (row.mediaType === 'tv_show') {
+    const show = rawDb
+      .prepare('SELECT name, tvdb_id, poster_path FROM tv_shows WHERE id = ?')
+      .get(row.mediaId) as
+      | { name: string; tvdb_id: number; poster_path: string | null }
+      | undefined;
+    if (show) {
+      title = show.name;
+      posterUrl = show.poster_path ? `/media/images/tv/${show.tvdb_id}/poster.jpg` : null;
+    }
+  }
+
+  return { ...row, title, posterUrl };
+}
+
+/** List watchlist entries with optional filters. Reads from the media pillar handle. */
 export function listWatchlist(
   filters: WatchlistFilters,
   limit: number,
   offset: number
 ): WatchlistListResult {
-  const db = getDrizzle();
-  const conditions: SQL[] = [];
-
-  if (filters.mediaType) {
-    conditions.push(eq(mediaWatchlist.mediaType, filters.mediaType as 'movie' | 'tv_show'));
-  }
-
-  const where = conditions.length > 0 ? and(...conditions) : undefined;
-
-  const rawRows = db
-    .select()
-    .from(mediaWatchlist)
-    .where(where)
-    .orderBy(asc(mediaWatchlist.priority), desc(mediaWatchlist.addedAt))
-    .limit(limit)
-    .offset(offset)
-    .all();
-
-  // Enrich with title and poster from movies/tv_shows tables
-  const rawDb = getDb();
-  const rows = rawRows.map((row) => {
-    let title: string | null = null;
-    let posterUrl: string | null = null;
-
-    if (row.mediaType === 'movie') {
-      const movie = rawDb
-        .prepare('SELECT title, tmdb_id, poster_path FROM movies WHERE id = ?')
-        .get(row.mediaId) as
-        | { title: string; tmdb_id: number; poster_path: string | null }
-        | undefined;
-      if (movie) {
-        title = movie.title;
-        posterUrl = movie.poster_path ? `/media/images/movie/${movie.tmdb_id}/poster.jpg` : null;
-      }
-    } else if (row.mediaType === 'tv_show') {
-      const show = rawDb
-        .prepare('SELECT name, tvdb_id, poster_path FROM tv_shows WHERE id = ?')
-        .get(row.mediaId) as
-        | { name: string; tvdb_id: number; poster_path: string | null }
-        | undefined;
-      if (show) {
-        title = show.name;
-        posterUrl = show.poster_path ? `/media/images/tv/${show.tvdb_id}/poster.jpg` : null;
-      }
-    }
-
-    return { ...row, title, posterUrl };
-  });
-
-  const [countRow] = db.select({ total: count() }).from(mediaWatchlist).where(where).all();
-
-  return { rows, total: countRow?.total ?? 0 };
+  const { rows, total } = watchlistService.listWatchlist(
+    getMediaDrizzle(),
+    { mediaType: narrowMediaType(filters.mediaType) },
+    limit,
+    offset
+  );
+  return { rows: rows.map(enrichRow), total };
 }
 
-/** Check whether a specific media item is on the watchlist. Returns entry ID if present. */
+/** Check whether a specific media item is on the watchlist. Reads from the media pillar handle. */
 export function getWatchlistStatus(
   mediaType: 'movie' | 'tv_show',
   mediaId: number
 ): { onWatchlist: boolean; entryId: number | null } {
-  const db = getDrizzle();
-  const row = db
-    .select({ id: mediaWatchlist.id })
-    .from(mediaWatchlist)
-    .where(and(eq(mediaWatchlist.mediaType, mediaType), eq(mediaWatchlist.mediaId, mediaId)))
-    .get();
-  return row ? { onWatchlist: true, entryId: row.id } : { onWatchlist: false, entryId: null };
+  return watchlistService.getWatchlistStatus(getMediaDrizzle(), mediaType, mediaId);
 }
 
-/** Get a single watchlist entry by id. Throws NotFoundError if missing. */
+/** Get a single watchlist entry by id. Reads from the media pillar handle. */
 export function getWatchlistEntry(id: number): MediaWatchlistRow {
-  const db = getDrizzle();
-  const row = db.select().from(mediaWatchlist).where(eq(mediaWatchlist.id, id)).get();
-
-  if (!row) throw new NotFoundError('WatchlistEntry', String(id));
-  return row;
+  return translate(() => watchlistService.getWatchlistEntry(getMediaDrizzle(), id));
 }
 
-/** Add an item to the watchlist. Idempotent — returns the existing entry if already present. */
+/**
+ * Add an item to the watchlist. Idempotent — returns the existing entry if
+ * already present. Writes go to `pops.db` (see file header for the split).
+ */
 export function addToWatchlist(input: AddToWatchlistInput): {
   row: MediaWatchlistRow;
   created: boolean;
@@ -123,7 +179,7 @@ export function addToWatchlist(input: AddToWatchlistInput): {
       })
       .run();
 
-    return { row: getWatchlistEntry(Number(result.lastInsertRowid)), created: true };
+    return { row: readSharedEntry(Number(result.lastInsertRowid)), created: true };
   } catch (err) {
     if (err instanceof Error && err.message.includes('UNIQUE constraint failed')) {
       const existing = db
@@ -136,7 +192,7 @@ export function addToWatchlist(input: AddToWatchlistInput): {
           )
         )
         .get();
-      if (existing) return { row: getWatchlistEntry(existing.id), created: false };
+      if (existing) return { row: readSharedEntry(existing.id), created: false };
     }
     throw err;
   }
@@ -144,10 +200,9 @@ export function addToWatchlist(input: AddToWatchlistInput): {
 
 /** Update a watchlist entry. Returns the updated row. */
 export function updateWatchlistEntry(id: number, input: UpdateWatchlistInput): MediaWatchlistRow {
-  getWatchlistEntry(id);
+  readSharedEntry(id);
 
   const updates: Partial<typeof mediaWatchlist.$inferSelect> = {};
-
   if (input.priority !== undefined) updates.priority = input.priority ?? null;
   if (input.notes !== undefined) updates.notes = input.notes ?? null;
 
@@ -155,12 +210,12 @@ export function updateWatchlistEntry(id: number, input: UpdateWatchlistInput): M
     getDrizzle().update(mediaWatchlist).set(updates).where(eq(mediaWatchlist.id, id)).run();
   }
 
-  return getWatchlistEntry(id);
+  return readSharedEntry(id);
 }
 
 /** Remove an entry from the watchlist. Throws NotFoundError if missing. */
 export function removeFromWatchlist(id: number): void {
-  getWatchlistEntry(id);
+  readSharedEntry(id);
 
   const result = getDrizzle().delete(mediaWatchlist).where(eq(mediaWatchlist.id, id)).run();
   if (result.changes === 0) throw new NotFoundError('WatchlistEntry', String(id));
@@ -172,19 +227,16 @@ export function reorderWatchlist(items: { id: number; priority: number }[]): voi
 
   const db = getDrizzle();
 
-  // Validate all IDs exist
   for (const item of items) {
     const row = db.select().from(mediaWatchlist).where(eq(mediaWatchlist.id, item.id)).get();
     if (!row) throw new NotFoundError('WatchlistEntry', String(item.id));
   }
 
-  // Check for duplicate priorities
   const priorities = items.map((i) => i.priority);
   if (new Set(priorities).size !== priorities.length) {
     throw new ConflictError('Duplicate priorities in reorder request');
   }
 
-  // Update all priorities in a transaction
   getDb().transaction(() => {
     for (const item of items) {
       db.update(mediaWatchlist)
@@ -209,7 +261,10 @@ export function removeByMedia(mediaType: 'movie' | 'tv_show', mediaId: number): 
 
 /**
  * Re-sequence all watchlist priorities to eliminate gaps (0, 1, 2, ...).
- * Accepts an optional drizzle-compatible instance to run inside an existing transaction.
+ * Accepts an optional drizzle-compatible instance to run inside an existing
+ * transaction. Writes go to the shared `pops.db`; callers in this app
+ * (e.g. `watch-history/handlers/log-watch-event.ts`) hold the matching
+ * handle.
  */
 export function resequencePriorities(drizzleInstance?: ReturnType<typeof getDrizzle>): void {
   const db = drizzleInstance ?? getDrizzle();


### PR DESCRIPTION
## Summary

- Flip the leaf read paths in `apps/pops-api/src/modules/media/watchlist/service.ts` (`list`, `getById`, `status`) to forward to `@pops/media-db`'s `watchlistService` via `getMediaDrizzle()`. Writes (`add`, `update`, `remove`, `reorder`, `removeByMedia`, `resequencePriorities`) stay on the shared `pops.db` so they keep co-located with the cross-module raw-drizzle writers in `watch-history/handlers`, `plex/sync-watchlist`, `rotation/removal-selection`, etc. Mirrors PR #3008 (watch-history) / PR #3006 (movies) exactly.
- Extend `apps/pops-api/src/db/media-backfill.ts` `TABLE_COPIES` with `watchlist` (all 8 columns) so the boot-time backfill carries newly-written shared rows across to `media.db`. Add `WATCHLIST_TABLE_SQL` fixture + a `watchlist (PRD-167 PR 2)` describe block to the media backfill suite (fresh copy, idempotent rerun, mixed pre-seeded state, full-shape roundtrip, missing-table tolerance — one-for-one with the `watch_history` block).
- Read/write split, the boot-time backfill bridge, and the TOCTOU fix (writers do their existence check against `pops.db` via `readSharedEntry`, not the now-media-pillar `getWatchlistEntry`) are documented in the new `service.ts` header.
- Out of scope (deliberate): the raw-drizzle cross-module writers, the legacy router mount (stays for batched URLs until the dispatcher flip in PR 3), and Plex integration changes.

## Test plan

- [x] `pnpm -F @pops/api test src/modules/media/watchlist` — 18/18 pass
- [x] `pnpm -F @pops/api test src/db/backfill-media-from-shared` — 20/20 pass
- [x] `pnpm -F @pops/api test src/modules/media` — 90 files / 1442 cases pass
- [x] `pnpm -F @pops/api test src/db` — 21 files / 190 cases pass
- [x] `pnpm -F @pops/api test src/modules/media/__integration__` — 3 cases pass
- [x] `pnpm -F @pops/api typecheck`
- [x] `pnpm -w typecheck` — 66/66 packages green
- [x] `pnpm oxlint` — 0 errors
- [x] `pnpm oxfmt --check` — clean

PRD: `docs/themes/13-pillar-finale/prds/167-media-watchlist-cutover/README.md`
