### PR TITLE
feat(cerebrum): cut engrams reads to @pops/cerebrum-db (PRD-179 PR2)

### DIFF
--- a/apps/pops-api/src/modules/cerebrum/engrams/router.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/router.test.ts
@@ -2,9 +2,11 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { closeDb, setDb } from '../../../db.js';
+import { setCerebrumDb } from '../../../db/cerebrum-handle.js';
 import { appRouter } from '../../../router.js';
 import { createTestDb } from '../../../shared/test-utils.js';
 import { resetCerebrumCache } from '../instance.js';
@@ -27,6 +29,7 @@ describe('cerebrum tRPC router', () => {
   beforeEach(() => {
     db = createTestDb();
     setDb(db);
+    setCerebrumDb({ db: drizzle(db), raw: db, vecAvailable: false });
     root = mkdtempSync(join(tmpdir(), 'cerebrum-router-'));
     previousRoot = process.env['ENGRAM_ROOT'];
     process.env['ENGRAM_ROOT'] = root;
@@ -34,6 +37,7 @@ describe('cerebrum tRPC router', () => {
   });
 
   afterEach(() => {
+    setCerebrumDb(null);
     closeDb();
     rmSync(root, { recursive: true, force: true });
     if (previousRoot === undefined) delete process.env['ENGRAM_ROOT'];

--- a/apps/pops-api/src/modules/cerebrum/engrams/scopes-router.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/scopes-router.test.ts
@@ -6,6 +6,7 @@ import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { closeDb, setDb } from '../../../db.js';
+import { setCerebrumDb } from '../../../db/cerebrum-handle.js';
 import { appRouter } from '../../../router.js';
 import { createTestDb } from '../../../shared/test-utils.js';
 import { resetCerebrumCache } from '../instance.js';
@@ -157,6 +158,7 @@ describe('cerebrum.scopes tRPC procedures', () => {
   beforeEach(() => {
     rawDb = createTestDb();
     setDb(rawDb);
+    setCerebrumDb({ db: drizzle(rawDb), raw: rawDb, vecAvailable: false });
     root = mkdtempSync(join(tmpdir(), 'scopes-trpc-'));
     previousRoot = process.env['ENGRAM_ROOT'];
     process.env['ENGRAM_ROOT'] = root;
@@ -164,6 +166,7 @@ describe('cerebrum.scopes tRPC procedures', () => {
   });
 
   afterEach(() => {
+    setCerebrumDb(null);
     closeDb();
     rmSync(root, { recursive: true, force: true });
     if (previousRoot === undefined) delete process.env['ENGRAM_ROOT'];

--- a/apps/pops-api/src/modules/cerebrum/engrams/service.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/service.ts
@@ -5,12 +5,16 @@
  * All write operations use atomic file writes before index updates.
  *
  * Read/write split during the migration window (PRD-179 PR 2):
- *  - Pure user-facing reads — `list`, `read`, `exists` — are routed
- *    through `readDb` (a `CerebrumDb` handle, wired to
- *    `getCerebrumDrizzle()` in `instance.ts`) and forwarded to the
- *    `@pops/cerebrum-db` `engramsService.{listEngrams,findIndexRow,
- *    existsEngram}` namespace. These are the seam called out by
- *    PRD-179 PR 2.
+ *  - Pure user-facing reads — `list`, `read` — are routed through
+ *    `readDb` (a `CerebrumDb` handle, wired to `getCerebrumDrizzle()`
+ *    in `instance.ts`) and forwarded to the `@pops/cerebrum-db`
+ *    `engramsService.{listEngrams,findIndexRow}` namespace. These are
+ *    the seam called out by PRD-179 PR 2.
+ *  - `exists` checks `readDb` first then falls back to `db` (the write
+ *    store). Glia revert calls `exists` to gate `restore`/`unlink`
+ *    writes, so a row newly created since boot — present only in
+ *    `pops.db` — must still report `true`. Drop the fallback once
+ *    PRD-179 US-03 collapses writes onto `cerebrum.db`.
  *  - Every write path — `create`, `update`, `archive`, `restore`,
  *    `changeType`, `link`, `unlink`, `hardDelete`, `reindex` — and any
  *    read-after-write hop (the private `loadEngram` helper used to
@@ -60,7 +64,7 @@ import {
 } from './handlers/list-engrams.js';
 import { reindexEngrams } from './handlers/rebuild-index.js';
 import { restoreEngram, type RestoreResult } from './handlers/restore-engram.js';
-import { getIndexRow, upsertIndex } from './handlers/upsert-index.js';
+import { findIndexRow, getIndexRow, upsertIndex } from './handlers/upsert-index.js';
 import { canTransitionStatus, type EngramFrontmatter, type EngramStatus } from './schema.js';
 import { buildEngram, type Engram } from './types.js';
 
@@ -221,9 +225,22 @@ export class EngramService {
     return deleteEngram({ root: this.root, db: this.db, now: this.now }, id);
   }
 
-  /** True iff `id` is present in the engram index. */
+  /**
+   * True iff `id` is present in the engram index.
+   *
+   * Consults the cerebrum read store first; falls back to the shared write
+   * store (`pops.db`) when missing. Write-context callers (glia revert in
+   * particular — see `../glia/revert-operations.ts`) check existence before
+   * issuing `restore` / `unlink` mutations on the write store. A row newly
+   * created since boot lives only in `pops.db` until the next backfill, so
+   * a `readDb`-only check would produce false negatives and silently skip
+   * the restore. The fallback keeps the TOCTOU window closed during the
+   * cutover; once PRD-179 US-03 collapses writes onto `cerebrum.db`, the
+   * second hop becomes redundant and can be dropped.
+   */
   exists(id: string): boolean {
-    return engramsService.existsEngram(this.readDb, id);
+    if (engramsService.existsEngram(this.readDb, id)) return true;
+    return findIndexRow(this.db, id) !== null;
   }
 
   /**

--- a/apps/pops-api/src/modules/cerebrum/engrams/service.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/service.ts
@@ -1,9 +1,44 @@
 /**
- * Engram CRUD service — thin orchestrator.
- * All write operations use atomic file writes before index updates.
+ * Engram CRUD service — read/write split during the PRD-179 cutover.
+ *
  * The filesystem is source of truth; the index is a regenerable cache.
+ * All write operations use atomic file writes before index updates.
+ *
+ * Read/write split during the migration window (PRD-179 PR 2):
+ *  - Pure user-facing reads — `list`, `read`, `exists` — are routed
+ *    through `readDb` (a `CerebrumDb` handle, wired to
+ *    `getCerebrumDrizzle()` in `instance.ts`) and forwarded to the
+ *    `@pops/cerebrum-db` `engramsService.{listEngrams,findIndexRow,
+ *    existsEngram}` namespace. These are the seam called out by
+ *    PRD-179 PR 2.
+ *  - Every write path — `create`, `update`, `archive`, `restore`,
+ *    `changeType`, `link`, `unlink`, `hardDelete`, `reindex` — and any
+ *    read-after-write hop (the private `loadEngram` helper used to
+ *    rehydrate the row we just wrote) still goes through `db` (the
+ *    shared `pops.db` handle). Read-after-write consistency lives on
+ *    that same store. PRD-179 US-03 flips the writes too, at which
+ *    point `db` collapses into `readDb`.
+ *
+ * Cross-store consistency relies on `backfillCerebrumFromShared()` in
+ * `apps/pops-api/src/db/backfill-cerebrum-from-shared.ts`: a one-way,
+ * boot-time copy from `pops.db` -> `cerebrum.db` that idempotently
+ * fills missing rows on `engram_index` + its three many-to-many
+ * auxiliaries. Between boots, newly-written engrams live only in
+ * `pops.db` and won't appear in `list`/`read`/`exists` results from
+ * `readDb` until the next deploy reruns the backfill. Read-after-write
+ * is preserved within the same process because `loadEngram` reads from
+ * the write store. This is the same trade-off taken by the watch-history
+ * (PRD-168 PR 2) and movies (PRD-165 PR 3) cutovers.
+ *
+ * Filesystem markdown writes, the template registry, and the scope-rule
+ * engine stay in pops-api — `@pops/cerebrum-db` is pure data-access.
+ * `EngramServiceOptions.readDb` is optional so the existing in-memory
+ * test rigs (which inject a single SQLite handle for both stores) keep
+ * working without churn; when omitted it falls back to `db`.
  */
 import { readFileSync } from 'node:fs';
+
+import { engramsService, type CerebrumDb } from '@pops/cerebrum-db';
 
 import { NotFoundError, ValidationError } from '../../../shared/errors.js';
 import { parseEngramFile, serializeEngram } from './file.js';
@@ -20,13 +55,12 @@ import {
 import { linkEngrams, unlinkEngrams } from './handlers/link-helpers.js';
 import {
   hydrateEngrams,
-  listEngrams,
   type ListEngramsOptions,
   type ListEngramsResult,
 } from './handlers/list-engrams.js';
 import { reindexEngrams } from './handlers/rebuild-index.js';
 import { restoreEngram, type RestoreResult } from './handlers/restore-engram.js';
-import { findIndexRow, getIndexRow, upsertIndex } from './handlers/upsert-index.js';
+import { getIndexRow, upsertIndex } from './handlers/upsert-index.js';
 import { canTransitionStatus, type EngramFrontmatter, type EngramStatus } from './schema.js';
 import { buildEngram, type Engram } from './types.js';
 
@@ -56,7 +90,20 @@ export interface UpdateEngramInput {
 
 export interface EngramServiceOptions {
   root: string;
+  /**
+   * Write handle — the shared `pops.db` drizzle wrapper. All write paths
+   * and read-after-write hops route through this handle until PRD-179
+   * US-03 flips the writes too.
+   */
   db: BetterSQLite3Database;
+  /**
+   * Read handle — the cerebrum pillar's `cerebrum.db` drizzle wrapper.
+   * Pure user-facing reads (`list`, `read`, `exists`) forward through
+   * `@pops/cerebrum-db`'s `engramsService` against this handle. Defaults
+   * to `db` so test rigs that inject a single in-memory SQLite keep
+   * working without churn.
+   */
+  readDb?: CerebrumDb;
   templates: TemplateRegistry;
   scopeRuleEngine?: ScopeRuleEngine;
   now?: () => Date;
@@ -65,6 +112,7 @@ export interface EngramServiceOptions {
 export class EngramService {
   private readonly root: string;
   private readonly db: BetterSQLite3Database;
+  private readonly readDb: CerebrumDb;
   private readonly templates: TemplateRegistry;
   private readonly scopeRuleEngine: ScopeRuleEngine | undefined;
   private readonly now: () => Date;
@@ -72,6 +120,7 @@ export class EngramService {
   constructor(options: EngramServiceOptions) {
     this.root = options.root;
     this.db = options.db;
+    this.readDb = options.readDb ?? options.db;
     this.templates = options.templates;
     this.scopeRuleEngine = options.scopeRuleEngine;
     this.now = options.now ?? (() => new Date());
@@ -92,16 +141,17 @@ export class EngramService {
   }
 
   read(id: string): { engram: Engram; body: string } {
-    const row = getIndexRow(this.db, id);
-    const content = readFileSync(absolutePath(this.root, row.file_path), 'utf8');
+    const row = engramsService.findIndexRow(this.readDb, id);
+    if (!row) throw new NotFoundError('Engram', id);
+    const content = readFileSync(absolutePath(this.root, row.filePath), 'utf8');
     const { frontmatter, body } = parseEngramFile(content);
     return {
       engram: buildEngram(frontmatter, {
-        filePath: row.file_path,
+        filePath: row.filePath,
         title: row.title,
-        contentHash: row.content_hash,
-        wordCount: row.word_count,
-        customFields: parseCustomFields(row.custom_fields),
+        contentHash: row.contentHash,
+        wordCount: row.wordCount,
+        customFields: engramsService.parseCustomFields(row.customFields),
       }),
       body,
     };
@@ -173,7 +223,7 @@ export class EngramService {
 
   /** True iff `id` is present in the engram index. */
   exists(id: string): boolean {
-    return findIndexRow(this.db, id) !== null;
+    return engramsService.existsEngram(this.readDb, id);
   }
 
   /**
@@ -196,7 +246,7 @@ export class EngramService {
   }
 
   list(opts: ListEngramsOptions = {}): ListEngramsResult {
-    return listEngrams(this.db, opts);
+    return engramsService.listEngrams(this.readDb, opts);
   }
 
   reindex(): { indexed: number } {

--- a/apps/pops-api/src/modules/cerebrum/instance.ts
+++ b/apps/pops-api/src/modules/cerebrum/instance.ts
@@ -9,6 +9,7 @@
 import { join } from 'node:path';
 
 import { getDrizzle } from '../../db.js';
+import { getCerebrumDrizzle } from '../../db/cerebrum-handle.js';
 import { ScopeRuleEngine } from './engrams/scope-rules.js';
 import { EngramService } from './engrams/service.js';
 import { TemplateRegistry } from './templates/registry.js';
@@ -53,11 +54,21 @@ export function getScopeRuleEngine(): ScopeRuleEngine {
   return cachedScopeRuleEngine;
 }
 
-/** Build an EngramService bound to the current request's drizzle context. */
+/**
+ * Build an EngramService bound to the current request's drizzle context.
+ *
+ * `db` is the shared `pops.db` handle (writes + read-after-write);
+ * `readDb` is the cerebrum pillar's `cerebrum.db` handle (pure reads).
+ * PRD-179 PR 2 — the read seam routes through `@pops/cerebrum-db`'s
+ * `engramsService` against `readDb`; writes still land on `pops.db`
+ * until PRD-179 US-03 flips them too. See `EngramService` top-of-file
+ * JSDoc for the cross-store consistency contract.
+ */
 export function getEngramService(): EngramService {
   return new EngramService({
     root: getEngramRoot(),
     db: getDrizzle(),
+    readDb: getCerebrumDrizzle(),
     templates: getTemplateRegistry(),
     scopeRuleEngine: getScopeRuleEngine(),
   });

--- a/apps/pops-api/src/modules/cerebrum/instance.ts
+++ b/apps/pops-api/src/modules/cerebrum/instance.ts
@@ -63,6 +63,25 @@ export function getScopeRuleEngine(): ScopeRuleEngine {
  * `engramsService` against `readDb`; writes still land on `pops.db`
  * until PRD-179 US-03 flips them too. See `EngramService` top-of-file
  * JSDoc for the cross-store consistency contract.
+ *
+ * Blast radius: this is the single production factory, so every
+ * consumer — user-facing routers (engrams, ingest, scopes), AI tools,
+ * curation jobs, glia revert, nudges, ego context helpers — picks up
+ * the `cerebrum.db`-backed read seam. That is the intended cutover
+ * shape: keeping a parallel `pops.db` read path defeats the migration
+ * and re-introduces the divergence the cutover is closing.
+ *
+ * Write-adjacent safety: read-after-write goes through the private
+ * `loadEngram` (write store) so created/updated rows surface
+ * immediately. The one cross-store existence check that gates writes
+ * — `EngramService.exists`, used by glia revert — falls back to the
+ * write store when the read store misses, so newly-written rows can
+ * still be restored/unlinked before the next backfill. See the
+ * `exists()` JSDoc for the contract.
+ *
+ * Tests inject a single in-memory SQLite via `new EngramService({ db,
+ * ... })`; `readDb` defaults to `db` at the constructor so existing
+ * harnesses keep working without churn.
  */
 export function getEngramService(): EngramService {
   return new EngramService({


### PR DESCRIPTION
## Summary

Second PR of [PRD-179](../blob/main/docs/themes/13-pillar-finale/prds/179-cerebrum-engrams-cutover/README.md)'s 4-PR sequence — the reads cutover. PR 1 (#2994) scaffolded the cerebrum-db engrams service + sqlite-vec wiring; this PR flips the pure user-facing reads on `EngramService` over to forward through `@pops/cerebrum-db`'s `engramsService` namespace, resolved against the cerebrum pillar's `getCerebrumDrizzle()` handle.

- `apps/pops-api/src/modules/cerebrum/engrams/service.ts` gains a `readDb: CerebrumDb` field alongside the existing `db: BetterSQLite3Database` write handle. `list`, `read`, and `exists` now call `engramsService.{listEngrams, findIndexRow, existsEngram}` against `readDb`. Writes (`create`, `update`, `archive`, `restore`, `changeType`, `link`, `unlink`, `hardDelete`, `reindex`) and the private `loadEngram` read-after-write hop stay on the shared `pops.db` handle until PRD-179 US-03 flips them too.
- `apps/pops-api/src/modules/cerebrum/instance.ts` wires `readDb` to `getCerebrumDrizzle()`. In production reads land on `cerebrum.db` while writes stay on `pops.db`; cross-store consistency is maintained by the boot-time backfill already configured for `engram_index` + its three many-to-many auxiliaries in `backfill-cerebrum-from-shared.ts`.
- `EngramServiceOptions.readDb` is optional and falls back to `db`. Every existing test rig that injects a single in-memory SQLite (e.g. `service.test.ts`, `scope-filter.test.ts`, `tags-router.test.ts`, glia `revert-operations.test.ts`) keeps working untouched.
- The two tRPC suites that touch the production seam (`router.test.ts`, the `cerebrum.scopes tRPC procedures` block in `scopes-router.test.ts`) now also call `setCerebrumDb({ db: drizzle(db), raw: db, vecAvailable: false })` so `getCerebrumDrizzle()` resolves to the test fixture instead of trying to open the dev `data/cerebrum.db` file mid-suite.

The read/write split is documented in `service.ts` top-of-file JSDoc — mirroring the watch-history pattern from #3008. Heavy orchestration (filesystem markdown writes, template registry, scope-rule engine) stays in pops-api per the PRD.

## Out of scope (deliberate, per PRD)

- The `loadActiveEngrams` helper in `apps/pops-api/src/modules/cerebrum/nudges/nudge-persistence.ts`. It's a write-adjacent detector seam consumed by `NudgeService` and the cerebrum-db package already exports an equivalent `engramsService.loadActiveEngrams`; that swap rides with the writer cutover (US-03) to keep the nudge persistence transaction on one handle.
- Direct `engramIndex` / `engramScopes` / `engramTags` / `engramLinks` drizzle reads in `cerebrum/ingest/pipeline-helpers.ts` and `cerebrum/thalamus/*`. Those are inside write paths (idempotency dedup, junction sync, file scan reconciliation) — PRD-179 US-03 / Epic 09 finish them.
- The legacy mount on pops-api stays as a fall-through. The backfill (already configured in `TABLE_COPIES` for the engrams tables) keeps `pops.db` -> `cerebrum.db` in sync on boot until the writes also move.

## Test plan

- [x] `pnpm -F @pops/api test src/modules/cerebrum/engrams` — 170/170 pass
- [x] `pnpm -F @pops/api test src/modules/cerebrum` — 1127/1128 (the single failure is the pre-existing `glia/__tests__/toml-config.test.ts` case on origin/main, untouched by this PR)
- [x] `pnpm -F @pops/api test` — 4936/4937 (same single pre-existing failure)
- [x] `pnpm -w typecheck` — 66/66 packages green
- [x] `pnpm oxlint` — 0 errors
- [x] `pnpm oxfmt` — clean

## PRD

`docs/themes/13-pillar-finale/prds/179-cerebrum-engrams-cutover/README.md` (the "PR 2 — reads cutover" slice).