### PR TITLE
feat(inventory-db): scaffold items service (PRD-173 US-01)

### DIFF
--- a/packages/inventory-db/src/__tests__/items.test.ts
+++ b/packages/inventory-db/src/__tests__/items.test.ts
@@ -1,0 +1,403 @@
+/**
+ * Invariant tests for the items service against an in-memory SQLite
+ * seeded with the canonical `home_inventory` table. Pure DB + service
+ * layer — no tRPC, no Express, no auth middleware.
+ *
+ * Higher-level integration coverage lives in pops-api and
+ * pops-inventory-api's own suites.
+ *
+ * The `home_inventory` schema is inlined here because its canonical
+ * migration (`0006_inventory_pillar_baseline`) bundles unrelated FK
+ * tables; the locations migration is read from the package's journal so
+ * the FK target exists for the location-filter tests.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { itemsService } from '../index.js';
+import { ItemNotFoundError } from '../services/items-errors.js';
+import { createLocation } from '../services/locations.js';
+
+import type { InventoryDb } from '../services/internal.js';
+
+const LOCATIONS_MIGRATION = join(__dirname, '../../migrations/0005_fancy_crystal.sql');
+
+const HOME_INVENTORY_DDL = `
+CREATE TABLE home_inventory (
+  id text PRIMARY KEY NOT NULL,
+  notion_id text UNIQUE,
+  item_name text NOT NULL,
+  brand text,
+  model text,
+  item_id text,
+  room text,
+  location text,
+  type text,
+  condition text DEFAULT 'good',
+  in_use integer,
+  deductible integer,
+  purchase_date text,
+  warranty_expires text,
+  replacement_value real,
+  resale_value real,
+  purchase_transaction_id text,
+  purchased_from_id text,
+  purchased_from_name text,
+  purchase_price real,
+  asset_id text UNIQUE,
+  notes text,
+  location_id text REFERENCES locations(id) ON DELETE set null,
+  created_at text NOT NULL DEFAULT (datetime('now')),
+  updated_at text NOT NULL DEFAULT (datetime('now')),
+  last_edited_time text NOT NULL
+);
+CREATE INDEX idx_inventory_location ON home_inventory (location_id);
+CREATE INDEX idx_inventory_name ON home_inventory (item_name);
+`;
+
+function freshDb(): InventoryDb {
+  const raw = new Database(':memory:');
+  raw.pragma('foreign_keys = ON');
+  const sql = readFileSync(LOCATIONS_MIGRATION, 'utf8');
+  for (const stmt of sql.split('--> statement-breakpoint')) {
+    const trimmed = stmt.trim();
+    if (trimmed.length > 0) raw.exec(trimmed);
+  }
+  raw.exec(HOME_INVENTORY_DDL);
+  return drizzle(raw);
+}
+
+const BASE_FILTERS = { limit: 50, offset: 0 } as const;
+
+describe('itemsService.list', () => {
+  let db: InventoryDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('returns an empty result when no items exist', () => {
+    const result = itemsService.list(db, { ...BASE_FILTERS });
+    expect(result).toEqual({
+      rows: [],
+      total: 0,
+      totalReplacementValue: 0,
+      totalResaleValue: 0,
+    });
+  });
+
+  it('orders results by item name ascending', () => {
+    itemsService.create(db, { itemName: 'Couch' });
+    itemsService.create(db, { itemName: 'Armchair' });
+    itemsService.create(db, { itemName: 'Bed' });
+
+    const result = itemsService.list(db, { ...BASE_FILTERS });
+    expect(result.rows.map((r) => r.itemName)).toEqual(['Armchair', 'Bed', 'Couch']);
+    expect(result.total).toBe(3);
+  });
+
+  it('paginates rows with limit + offset but reports the full total', () => {
+    for (let i = 0; i < 5; i++) itemsService.create(db, { itemName: `Item ${i}` });
+
+    const page1 = itemsService.list(db, { limit: 2, offset: 0 });
+    expect(page1.rows).toHaveLength(2);
+    expect(page1.total).toBe(5);
+
+    const page2 = itemsService.list(db, { limit: 2, offset: 2 });
+    expect(page2.rows).toHaveLength(2);
+    expect(page2.rows[0]!.itemName).not.toBe(page1.rows[0]!.itemName);
+  });
+
+  it('filters by partial item name (case-sensitive LIKE)', () => {
+    itemsService.create(db, { itemName: 'Coffee Table' });
+    itemsService.create(db, { itemName: 'Coffee Maker' });
+    itemsService.create(db, { itemName: 'Chair' });
+
+    const result = itemsService.list(db, { ...BASE_FILTERS, search: 'Coffee' });
+    expect(result.total).toBe(2);
+  });
+
+  it('filters by room', () => {
+    itemsService.create(db, { itemName: 'Fridge', room: 'Kitchen' });
+    itemsService.create(db, { itemName: 'TV', room: 'Living' });
+
+    const result = itemsService.list(db, { ...BASE_FILTERS, room: 'Kitchen' });
+    expect(result.total).toBe(1);
+    expect(result.rows[0]!.itemName).toBe('Fridge');
+  });
+
+  it('filters by type', () => {
+    itemsService.create(db, { itemName: 'Fridge', type: 'appliance' });
+    itemsService.create(db, { itemName: 'Couch', type: 'furniture' });
+
+    const result = itemsService.list(db, { ...BASE_FILTERS, type: 'appliance' });
+    expect(result.total).toBe(1);
+  });
+
+  it('filters by condition case-insensitively', () => {
+    itemsService.create(db, { itemName: 'A', condition: 'Good' });
+    itemsService.create(db, { itemName: 'B', condition: 'good' });
+    itemsService.create(db, { itemName: 'C', condition: 'Broken' });
+
+    const result = itemsService.list(db, { ...BASE_FILTERS, condition: 'GOOD' });
+    expect(result.total).toBe(2);
+  });
+
+  it('filters by inUse and deductible flags', () => {
+    itemsService.create(db, { itemName: 'A', inUse: true, deductible: true });
+    itemsService.create(db, { itemName: 'B', inUse: false, deductible: true });
+    itemsService.create(db, { itemName: 'C', inUse: true, deductible: false });
+
+    expect(itemsService.list(db, { ...BASE_FILTERS, inUse: true }).total).toBe(2);
+    expect(itemsService.list(db, { ...BASE_FILTERS, deductible: false }).total).toBe(1);
+    expect(itemsService.list(db, { ...BASE_FILTERS, inUse: true, deductible: true }).total).toBe(1);
+  });
+
+  it('filters by assetId exactly', () => {
+    itemsService.create(db, { itemName: 'A', assetId: 'AST-1' });
+    itemsService.create(db, { itemName: 'B', assetId: 'AST-2' });
+
+    const result = itemsService.list(db, { ...BASE_FILTERS, assetId: 'AST-1' });
+    expect(result.total).toBe(1);
+  });
+
+  it('filters by locationId (direct only)', () => {
+    const kitchen = createLocation(db, { name: 'Kitchen' });
+    const bedroom = createLocation(db, { name: 'Bedroom' });
+    itemsService.create(db, { itemName: 'Fridge', locationId: kitchen.id });
+    itemsService.create(db, { itemName: 'Bed', locationId: bedroom.id });
+
+    const result = itemsService.list(db, { ...BASE_FILTERS, locationId: kitchen.id });
+    expect(result.total).toBe(1);
+    expect(result.rows[0]!.itemName).toBe('Fridge');
+  });
+
+  it('filters by locationId including descendants', () => {
+    const home = createLocation(db, { name: 'Home' });
+    const kitchen = createLocation(db, { name: 'Kitchen', parentId: home.id });
+    itemsService.create(db, { itemName: 'Couch', locationId: home.id });
+    itemsService.create(db, { itemName: 'Fridge', locationId: kitchen.id });
+    itemsService.create(db, { itemName: 'Orphan', locationId: null });
+
+    const result = itemsService.list(db, {
+      ...BASE_FILTERS,
+      locationId: home.id,
+      includeChildren: true,
+    });
+    expect(result.total).toBe(2);
+  });
+
+  it('aggregates replacement and resale values across filtered rows', () => {
+    itemsService.create(db, { itemName: 'A', replacementValue: 100, resaleValue: 40 });
+    itemsService.create(db, { itemName: 'B', replacementValue: 200, resaleValue: 80 });
+    itemsService.create(db, { itemName: 'C' });
+
+    const result = itemsService.list(db, { ...BASE_FILTERS });
+    expect(result.totalReplacementValue).toBe(300);
+    expect(result.totalResaleValue).toBe(120);
+  });
+});
+
+describe('itemsService.get', () => {
+  let db: InventoryDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('returns the row when present', () => {
+    const created = itemsService.create(db, { itemName: 'Lamp' });
+    const row = itemsService.get(db, created.id);
+    expect(row.id).toBe(created.id);
+    expect(row.itemName).toBe('Lamp');
+  });
+
+  it('throws ItemNotFoundError when missing', () => {
+    expect(() => itemsService.get(db, 'nope')).toThrowError(ItemNotFoundError);
+  });
+});
+
+describe('itemsService.searchByAssetId', () => {
+  let db: InventoryDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('returns the row for an exact match', () => {
+    itemsService.create(db, { itemName: 'A', assetId: 'AST-1' });
+    const row = itemsService.searchByAssetId(db, 'AST-1');
+    expect(row).not.toBeNull();
+    expect(row!.itemName).toBe('A');
+  });
+
+  it('matches case-insensitively', () => {
+    itemsService.create(db, { itemName: 'A', assetId: 'AST-001' });
+    expect(itemsService.searchByAssetId(db, 'ast-001')).not.toBeNull();
+  });
+
+  it('returns null when no asset matches', () => {
+    expect(itemsService.searchByAssetId(db, 'missing')).toBeNull();
+  });
+});
+
+describe('itemsService.getByAssetId', () => {
+  let db: InventoryDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('throws ItemNotFoundError when no asset matches', () => {
+    expect(() => itemsService.getByAssetId(db, 'nope')).toThrowError(ItemNotFoundError);
+  });
+
+  it('returns the row when present (case-insensitive)', () => {
+    itemsService.create(db, { itemName: 'A', assetId: 'AST-1' });
+    expect(itemsService.getByAssetId(db, 'ast-1').itemName).toBe('A');
+  });
+});
+
+describe('itemsService.countByAssetPrefix', () => {
+  let db: InventoryDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('counts rows whose assetId starts with the prefix, case-insensitively', () => {
+    itemsService.create(db, { itemName: 'A', assetId: 'POPS-001' });
+    itemsService.create(db, { itemName: 'B', assetId: 'POPS-002' });
+    itemsService.create(db, { itemName: 'C', assetId: 'OTHER-1' });
+
+    expect(itemsService.countByAssetPrefix(db, 'POPS-')).toBe(2);
+    expect(itemsService.countByAssetPrefix(db, 'pops-')).toBe(2);
+    expect(itemsService.countByAssetPrefix(db, 'MISSING')).toBe(0);
+  });
+});
+
+describe('itemsService.distinctTypes', () => {
+  let db: InventoryDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('returns distinct non-null types sorted ascending', () => {
+    itemsService.create(db, { itemName: 'A', type: 'appliance' });
+    itemsService.create(db, { itemName: 'B', type: 'furniture' });
+    itemsService.create(db, { itemName: 'C', type: 'appliance' });
+    itemsService.create(db, { itemName: 'D', type: null });
+
+    expect(itemsService.distinctTypes(db)).toEqual(['appliance', 'furniture']);
+  });
+
+  it('returns empty array when nothing is typed', () => {
+    expect(itemsService.distinctTypes(db)).toEqual([]);
+  });
+});
+
+describe('itemsService.create', () => {
+  let db: InventoryDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('creates a minimal item with defaults and a stable id', () => {
+    const row = itemsService.create(db, { itemName: 'Lamp' });
+    expect(row.id).toMatch(/[0-9a-f-]{36}/i);
+    expect(row.itemName).toBe('Lamp');
+    expect(row.inUse).toBe(0);
+    expect(row.deductible).toBe(0);
+    expect(row.assetId).toBeNull();
+    expect(row.lastEditedTime).toBeTruthy();
+  });
+
+  it('persists nullable string fields', () => {
+    const row = itemsService.create(db, {
+      itemName: 'Fridge',
+      brand: 'Brand',
+      assetId: 'AST-1',
+      notes: 'cold',
+    });
+    expect(row.brand).toBe('Brand');
+    expect(row.assetId).toBe('AST-1');
+    expect(row.notes).toBe('cold');
+  });
+
+  it('persists numeric fields and boolean flags', () => {
+    const row = itemsService.create(db, {
+      itemName: 'Couch',
+      inUse: true,
+      deductible: true,
+      replacementValue: 500,
+      resaleValue: 100,
+      purchasePrice: 750,
+    });
+    expect(row.inUse).toBe(1);
+    expect(row.deductible).toBe(1);
+    expect(row.replacementValue).toBe(500);
+    expect(row.resaleValue).toBe(100);
+    expect(row.purchasePrice).toBe(750);
+  });
+});
+
+describe('itemsService.update', () => {
+  let db: InventoryDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('renames an item', () => {
+    const created = itemsService.create(db, { itemName: 'Befor' });
+    const updated = itemsService.update(db, created.id, { itemName: 'After' });
+    expect(updated.itemName).toBe('After');
+  });
+
+  it('clears a field when passed null', () => {
+    const created = itemsService.create(db, { itemName: 'A', brand: 'X' });
+    const updated = itemsService.update(db, created.id, { brand: null });
+    expect(updated.brand).toBeNull();
+  });
+
+  it('leaves unspecified fields unchanged', () => {
+    const created = itemsService.create(db, { itemName: 'A', brand: 'X', notes: 'keep' });
+    const updated = itemsService.update(db, created.id, { brand: 'Y' });
+    expect(updated.brand).toBe('Y');
+    expect(updated.notes).toBe('keep');
+  });
+
+  it('updates boolean flags', () => {
+    const created = itemsService.create(db, { itemName: 'A', inUse: false });
+    const updated = itemsService.update(db, created.id, { inUse: true });
+    expect(updated.inUse).toBe(1);
+  });
+
+  it('throws ItemNotFoundError for a missing id', () => {
+    expect(() => itemsService.update(db, 'nope', { itemName: 'X' })).toThrowError(
+      ItemNotFoundError
+    );
+  });
+
+  it('is a no-op when no fields are provided', () => {
+    const created = itemsService.create(db, { itemName: 'A' });
+    const originalLastEdited = created.lastEditedTime;
+    const updated = itemsService.update(db, created.id, {});
+    expect(updated.lastEditedTime).toBe(originalLastEdited);
+  });
+});
+
+describe('itemsService.delete', () => {
+  let db: InventoryDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('deletes an existing row', () => {
+    const created = itemsService.create(db, { itemName: 'Tmp' });
+    itemsService.delete(db, created.id);
+    expect(() => itemsService.get(db, created.id)).toThrowError(ItemNotFoundError);
+  });
+
+  it('throws ItemNotFoundError when missing', () => {
+    expect(() => itemsService.delete(db, 'nope')).toThrowError(ItemNotFoundError);
+  });
+});

--- a/packages/inventory-db/src/index.ts
+++ b/packages/inventory-db/src/index.ts
@@ -19,6 +19,7 @@ export type { InventoryDb } from './services/internal.js';
 export { openInventoryDb, type OpenedInventoryDb } from './open-inventory-db.js';
 
 export * as locationsService from './services/locations.js';
+export * as itemsService from './services/items.js';
 
 // Public types re-exported at the package root so consumers can name
 // them without reaching into the namespaces.
@@ -33,3 +34,16 @@ export type {
 } from './services/locations.js';
 
 export { toLocation } from './services/locations.js';
+
+export type {
+  CreateItemInput,
+  InventoryRow,
+  Item,
+  ItemFilters,
+  ItemListResult,
+  UpdateItemInput,
+} from './services/items.js';
+
+export { toItem } from './services/items.js';
+
+export { ItemConflictError, ItemNotFoundError } from './services/items-errors.js';

--- a/packages/inventory-db/src/services/items-create-builder.ts
+++ b/packages/inventory-db/src/services/items-create-builder.ts
@@ -1,0 +1,67 @@
+/**
+ * Insert-payload builder for the items service.
+ *
+ * Mirrors the live writer (`apps/pops-inventory-api/.../create-builder.ts`)
+ * so the consumer cutover stays mechanical.
+ */
+import type { homeInventory } from '../schema.js';
+import type { CreateItemInput } from './items-types.js';
+
+type InventoryInsert = typeof homeInventory.$inferInsert;
+
+const CREATE_NULLABLE_STRING_KEYS = [
+  'brand',
+  'model',
+  'itemId',
+  'room',
+  'location',
+  'type',
+  'condition',
+  'purchaseDate',
+  'warrantyExpires',
+  'purchaseTransactionId',
+  'purchasedFromId',
+  'purchasedFromName',
+  'assetId',
+  'notes',
+  'locationId',
+] as const satisfies ReadonlyArray<keyof CreateItemInput & keyof InventoryInsert>;
+
+const CREATE_NULLABLE_NUMBER_KEYS = [
+  'replacementValue',
+  'resaleValue',
+  'purchasePrice',
+] as const satisfies ReadonlyArray<keyof CreateItemInput & keyof InventoryInsert>;
+
+function nullableStringsFromInput(input: CreateItemInput): Partial<InventoryInsert> {
+  const out: Partial<InventoryInsert> = {};
+  for (const key of CREATE_NULLABLE_STRING_KEYS) {
+    out[key] = input[key] ?? null;
+  }
+  return out;
+}
+
+function nullableNumbersFromInput(input: CreateItemInput): Partial<InventoryInsert> {
+  const out: Partial<InventoryInsert> = {};
+  for (const key of CREATE_NULLABLE_NUMBER_KEYS) {
+    out[key] = input[key] ?? null;
+  }
+  return out;
+}
+
+/** Build the insert payload for a new inventory item. */
+export function buildCreateValues(
+  id: string,
+  now: string,
+  input: CreateItemInput
+): InventoryInsert {
+  return {
+    id,
+    itemName: input.itemName,
+    inUse: input.inUse ? 1 : 0,
+    deductible: input.deductible ? 1 : 0,
+    lastEditedTime: now,
+    ...nullableStringsFromInput(input),
+    ...nullableNumbersFromInput(input),
+  };
+}

--- a/packages/inventory-db/src/services/items-errors.ts
+++ b/packages/inventory-db/src/services/items-errors.ts
@@ -1,0 +1,29 @@
+/**
+ * Typed errors raised by the items service layer.
+ *
+ * Plain Error subclasses — the service layer is HTTP-agnostic. Router
+ * layers (pops-api, pops-inventory-api) map these to the appropriate
+ * tRPC / HTTP codes. Mirrors the `locations` error pattern.
+ */
+
+export class ItemNotFoundError extends Error {
+  override readonly name = 'ItemNotFoundError' as const;
+  readonly id: string;
+
+  constructor(id: string) {
+    super(`Inventory item '${id}' not found`);
+    this.id = id;
+  }
+}
+
+export class ItemConflictError extends Error {
+  override readonly name = 'ItemConflictError' as const;
+  readonly field: string;
+  readonly value: string;
+
+  constructor(field: string, value: string) {
+    super(`Inventory item with ${field} '${value}' already exists`);
+    this.field = field;
+    this.value = value;
+  }
+}

--- a/packages/inventory-db/src/services/items-types.ts
+++ b/packages/inventory-db/src/services/items-types.ts
@@ -1,0 +1,139 @@
+/**
+ * Input and result types for the items service.
+ *
+ * Validation (zod) and the API response mapper live with the router
+ * layers — this package stays HTTP-agnostic and only exposes the
+ * service surface and row types needed to call it.
+ */
+import type { InventoryRow } from '@pops/db-types';
+
+export type { InventoryRow };
+
+/** Input for creating a new inventory item. */
+export interface CreateItemInput {
+  itemName: string;
+  brand?: string | null;
+  model?: string | null;
+  itemId?: string | null;
+  room?: string | null;
+  location?: string | null;
+  type?: string | null;
+  condition?: string | null;
+  inUse?: boolean;
+  deductible?: boolean;
+  purchaseDate?: string | null;
+  warrantyExpires?: string | null;
+  replacementValue?: number | null;
+  resaleValue?: number | null;
+  purchasePrice?: number | null;
+  purchaseTransactionId?: string | null;
+  purchasedFromId?: string | null;
+  purchasedFromName?: string | null;
+  assetId?: string | null;
+  notes?: string | null;
+  locationId?: string | null;
+}
+
+/** Input for updating an existing inventory item — all fields optional. */
+export interface UpdateItemInput {
+  itemName?: string;
+  brand?: string | null;
+  model?: string | null;
+  itemId?: string | null;
+  room?: string | null;
+  location?: string | null;
+  type?: string | null;
+  condition?: string | null;
+  inUse?: boolean;
+  deductible?: boolean;
+  purchaseDate?: string | null;
+  warrantyExpires?: string | null;
+  replacementValue?: number | null;
+  resaleValue?: number | null;
+  purchasePrice?: number | null;
+  purchaseTransactionId?: string | null;
+  purchasedFromId?: string | null;
+  purchasedFromName?: string | null;
+  assetId?: string | null;
+  notes?: string | null;
+  locationId?: string | null;
+}
+
+/** Filters for listing inventory items. */
+export interface ItemFilters {
+  search?: string;
+  room?: string;
+  type?: string;
+  condition?: string;
+  inUse?: boolean;
+  deductible?: boolean;
+  limit: number;
+  offset: number;
+  locationId?: string;
+  assetId?: string;
+  includeChildren?: boolean;
+}
+
+/** Paginated list result with value aggregates. */
+export interface ItemListResult {
+  rows: InventoryRow[];
+  total: number;
+  totalReplacementValue: number;
+  totalResaleValue: number;
+}
+
+/** Public API shape for an inventory item (camelCase, booleans normalised). */
+export interface Item {
+  id: string;
+  itemName: string;
+  brand: string | null;
+  model: string | null;
+  itemId: string | null;
+  room: string | null;
+  location: string | null;
+  type: string | null;
+  condition: string | null;
+  inUse: boolean;
+  deductible: boolean;
+  purchaseDate: string | null;
+  warrantyExpires: string | null;
+  replacementValue: number | null;
+  resaleValue: number | null;
+  purchasePrice: number | null;
+  purchaseTransactionId: string | null;
+  purchasedFromId: string | null;
+  purchasedFromName: string | null;
+  assetId: string | null;
+  notes: string | null;
+  locationId: string | null;
+  lastEditedTime: string;
+}
+
+/** Map a SQLite row to the public API shape. */
+export function toItem(row: InventoryRow): Item {
+  return {
+    id: row.id,
+    itemName: row.itemName,
+    brand: row.brand,
+    model: row.model,
+    itemId: row.itemId,
+    room: row.room,
+    location: row.location,
+    type: row.type,
+    condition: row.condition,
+    inUse: row.inUse === 1,
+    deductible: row.deductible === 1,
+    purchaseDate: row.purchaseDate,
+    warrantyExpires: row.warrantyExpires,
+    replacementValue: row.replacementValue,
+    resaleValue: row.resaleValue,
+    purchasePrice: row.purchasePrice,
+    purchaseTransactionId: row.purchaseTransactionId,
+    purchasedFromId: row.purchasedFromId,
+    purchasedFromName: row.purchasedFromName,
+    assetId: row.assetId,
+    notes: row.notes,
+    locationId: row.locationId,
+    lastEditedTime: row.lastEditedTime,
+  };
+}

--- a/packages/inventory-db/src/services/items-update-builder.ts
+++ b/packages/inventory-db/src/services/items-update-builder.ts
@@ -1,0 +1,95 @@
+/**
+ * Update-payload builder for the items service.
+ *
+ * Mirrors the live writer (`apps/pops-inventory-api/.../update-builder.ts`).
+ *
+ * - `undefined` means "leave unchanged" (the key is not written)
+ * - `null` means "clear the field" (the key is written as null)
+ */
+import type { homeInventory } from '../schema.js';
+import type { UpdateItemInput } from './items-types.js';
+
+type InventoryUpdate = Partial<typeof homeInventory.$inferInsert>;
+
+const NULLABLE_STRING_KEYS = [
+  'brand',
+  'model',
+  'itemId',
+  'room',
+  'location',
+  'type',
+  'condition',
+  'purchaseDate',
+  'warrantyExpires',
+  'purchaseTransactionId',
+  'purchasedFromId',
+  'purchasedFromName',
+  'assetId',
+  'notes',
+  'locationId',
+] as const satisfies ReadonlyArray<keyof UpdateItemInput & keyof InventoryUpdate>;
+
+const NULLABLE_NUMBER_KEYS = [
+  'replacementValue',
+  'resaleValue',
+  'purchasePrice',
+] as const satisfies ReadonlyArray<keyof UpdateItemInput & keyof InventoryUpdate>;
+
+function assignItemName(updates: InventoryUpdate, input: UpdateItemInput): boolean {
+  if (input.itemName === undefined) return false;
+  updates.itemName = input.itemName;
+  return true;
+}
+
+function assignNullableStringKeys(updates: InventoryUpdate, input: UpdateItemInput): boolean {
+  let touched = false;
+  for (const key of NULLABLE_STRING_KEYS) {
+    const value = input[key];
+    if (value === undefined) continue;
+    updates[key] = value ?? null;
+    touched = true;
+  }
+  return touched;
+}
+
+function assignNullableNumberKeys(updates: InventoryUpdate, input: UpdateItemInput): boolean {
+  let touched = false;
+  for (const key of NULLABLE_NUMBER_KEYS) {
+    const value = input[key];
+    if (value === undefined) continue;
+    updates[key] = value ?? null;
+    touched = true;
+  }
+  return touched;
+}
+
+function assignBooleanFlags(updates: InventoryUpdate, input: UpdateItemInput): boolean {
+  let touched = false;
+  if (input.inUse !== undefined) {
+    updates.inUse = input.inUse ? 1 : 0;
+    touched = true;
+  }
+  if (input.deductible !== undefined) {
+    updates.deductible = input.deductible ? 1 : 0;
+    touched = true;
+  }
+  return touched;
+}
+
+/**
+ * Build the partial update payload for an inventory item.
+ * Returns `null` when the caller supplied no fields — callers skip the DB write.
+ */
+export function buildUpdateValues(input: UpdateItemInput): InventoryUpdate | null {
+  const updates: InventoryUpdate = {};
+  let touched = false;
+
+  if (assignItemName(updates, input)) touched = true;
+  if (assignNullableStringKeys(updates, input)) touched = true;
+  if (assignNullableNumberKeys(updates, input)) touched = true;
+  if (assignBooleanFlags(updates, input)) touched = true;
+
+  if (!touched) return null;
+  updates.lastEditedTime = new Date().toISOString();
+  return updates;
+}

--- a/packages/inventory-db/src/services/items.ts
+++ b/packages/inventory-db/src/services/items.ts
@@ -1,0 +1,193 @@
+/**
+ * Inventory items CRUD service.
+ *
+ * Each function takes an `InventoryDb` handle as its first argument; the
+ * calling layer (pops-api modules, pops-inventory-api routers) resolves
+ * the singleton or transaction handle to pass in. Mirrors the locations
+ * writer pattern (db-arg, scoped builders, typed errors).
+ *
+ * The live writer in `apps/pops-inventory-api/src/modules/items/service.ts`
+ * is the source of truth for the wire surface — this scaffold mirrors its
+ * signatures so the PR2 reads-cutover can swap consumers over to
+ * `itemsService.*` without a behavioural change.
+ */
+import { randomUUID } from 'node:crypto';
+
+import { and, count, eq, inArray, isNotNull, like, sql, sum, type SQL } from 'drizzle-orm';
+
+import { homeInventory } from '../schema.js';
+import { buildCreateValues } from './items-create-builder.js';
+import { ItemNotFoundError } from './items-errors.js';
+import { buildUpdateValues } from './items-update-builder.js';
+import { getDescendantLocationIds } from './locations-queries.js';
+
+import type { InventoryDb } from './internal.js';
+import type {
+  CreateItemInput,
+  InventoryRow,
+  ItemFilters,
+  ItemListResult,
+  UpdateItemInput,
+} from './items-types.js';
+
+export {
+  type CreateItemInput,
+  type InventoryRow,
+  type Item,
+  type ItemFilters,
+  type ItemListResult,
+  toItem,
+  type UpdateItemInput,
+} from './items-types.js';
+
+export { ItemConflictError, ItemNotFoundError } from './items-errors.js';
+
+function buildLocationCondition(
+  db: InventoryDb,
+  locationId: string,
+  includeChildren: boolean | undefined
+): SQL {
+  if (!includeChildren) return eq(homeInventory.locationId, locationId);
+  const descendants = getDescendantLocationIds(db, locationId);
+  return inArray(homeInventory.locationId, [locationId, ...descendants]);
+}
+
+function buildItemConditions(db: InventoryDb, opts: ItemFilters): SQL[] {
+  const conditions: SQL[] = [];
+  if (opts.search) conditions.push(like(homeInventory.itemName, `%${opts.search}%`));
+  if (opts.room) conditions.push(eq(homeInventory.room, opts.room));
+  if (opts.type) conditions.push(eq(homeInventory.type, opts.type));
+  if (opts.condition) {
+    conditions.push(sql`lower(${homeInventory.condition}) = lower(${opts.condition})`);
+  }
+  if (opts.inUse !== undefined) conditions.push(eq(homeInventory.inUse, opts.inUse ? 1 : 0));
+  if (opts.deductible !== undefined) {
+    conditions.push(eq(homeInventory.deductible, opts.deductible ? 1 : 0));
+  }
+  if (opts.locationId) {
+    conditions.push(buildLocationCondition(db, opts.locationId, opts.includeChildren));
+  }
+  if (opts.assetId) conditions.push(eq(homeInventory.assetId, opts.assetId));
+  return conditions;
+}
+
+function combineConditions(conditions: SQL[]): SQL | undefined {
+  if (conditions.length === 0) return undefined;
+  if (conditions.length === 1) return conditions[0];
+  return and(...conditions);
+}
+
+/** List inventory items with optional filters. */
+export function list(db: InventoryDb, opts: ItemFilters): ItemListResult {
+  let query = db.select().from(homeInventory).$dynamic();
+  let countQuery = db.select({ total: count() }).from(homeInventory).$dynamic();
+  let sumQuery = db
+    .select({
+      replacementSum: sum(homeInventory.replacementValue),
+      resaleSum: sum(homeInventory.resaleValue),
+    })
+    .from(homeInventory)
+    .$dynamic();
+
+  const where = combineConditions(buildItemConditions(db, opts));
+  if (where) {
+    query = query.where(where);
+    countQuery = countQuery.where(where);
+    sumQuery = sumQuery.where(where);
+  }
+
+  const rows = query.orderBy(homeInventory.itemName).limit(opts.limit).offset(opts.offset).all();
+  const [countResult] = countQuery.all();
+  const [sumResult] = sumQuery.all();
+
+  return {
+    rows,
+    total: countResult?.total ?? 0,
+    totalReplacementValue: Number(sumResult?.replacementSum) || 0,
+    totalResaleValue: Number(sumResult?.resaleSum) || 0,
+  };
+}
+
+/** Get a single inventory item by id. Throws `ItemNotFoundError` if missing. */
+export function get(db: InventoryDb, id: string): InventoryRow {
+  const [row] = db.select().from(homeInventory).where(eq(homeInventory.id, id)).all();
+  if (!row) throw new ItemNotFoundError(id);
+  return row;
+}
+
+/**
+ * Search for an inventory item by exact asset ID (case-insensitive).
+ * Returns the row or `null` if not found.
+ */
+export function searchByAssetId(db: InventoryDb, assetId: string): InventoryRow | null {
+  const [row] = db
+    .select()
+    .from(homeInventory)
+    .where(sql`LOWER(${homeInventory.assetId}) = LOWER(${assetId})`)
+    .all();
+  return row ?? null;
+}
+
+/**
+ * Like `searchByAssetId` but throws `ItemNotFoundError` if no row matches.
+ * Use when the caller already knows the asset ID is supposed to exist.
+ */
+export function getByAssetId(db: InventoryDb, assetId: string): InventoryRow {
+  const row = searchByAssetId(db, assetId);
+  if (!row) throw new ItemNotFoundError(assetId);
+  return row;
+}
+
+/** Count inventory items whose assetId starts with the given prefix (case-insensitive). */
+export function countByAssetPrefix(db: InventoryDb, prefix: string): number {
+  const [result] = db
+    .select({ count: sql<number>`COUNT(*)` })
+    .from(homeInventory)
+    .where(sql`LOWER(${homeInventory.assetId}) LIKE LOWER(${prefix + '%'})`)
+    .all();
+  return result?.count ?? 0;
+}
+
+/** Return distinct item types that exist in the database, sorted ascending. */
+export function distinctTypes(db: InventoryDb): string[] {
+  const rows = db
+    .selectDistinct({ type: homeInventory.type })
+    .from(homeInventory)
+    .where(isNotNull(homeInventory.type))
+    .orderBy(homeInventory.type)
+    .all();
+  return rows.map((r) => r.type).filter((t): t is string => t !== null);
+}
+
+/** Create a new inventory item. Returns the created row. */
+export function create(db: InventoryDb, input: CreateItemInput): InventoryRow {
+  const id = randomUUID();
+  const now = new Date().toISOString();
+
+  db.insert(homeInventory)
+    .values(buildCreateValues(id, now, input))
+    .run();
+
+  return get(db, id);
+}
+
+/** Update an existing inventory item. Returns the updated row. */
+export function update(db: InventoryDb, id: string, input: UpdateItemInput): InventoryRow {
+  get(db, id);
+
+  const updates = buildUpdateValues(input);
+  if (updates) {
+    db.update(homeInventory).set(updates).where(eq(homeInventory.id, id)).run();
+  }
+
+  return get(db, id);
+}
+
+/** Delete an inventory item by ID. Throws `ItemNotFoundError` if missing. */
+function deleteItem(db: InventoryDb, id: string): void {
+  get(db, id);
+  const result = db.delete(homeInventory).where(eq(homeInventory.id, id)).run();
+  if (result.changes === 0) throw new ItemNotFoundError(id);
+}
+
+export { deleteItem as delete };


### PR DESCRIPTION
## Summary

- Scaffold `itemsService` in `@pops/inventory-db` mirroring the locations precedent — PR #2993 shipped the writer surface on `pops-inventory-api` with inline drizzle queries instead of placing it in the package, so this fills the gap and unblocks the PR2 reads-cutover.
- Surface: `itemsService.{list, get, getByAssetId, searchByAssetId, countByAssetPrefix, distinctTypes, create, update, delete}`, typed `ItemNotFoundError` / `ItemConflictError`, namespace + root-level type re-exports from the package barrel.
- Purely additive — no consumer changes; the legacy `pops-api` reads still resolve against `getInventoryDrizzle()` and the live writer at `apps/pops-inventory-api/src/modules/items/service.ts` is untouched. PR2 (reads cutover) flips consumers to `itemsService.*`.

## Test plan

- [x] `pnpm -F @pops/inventory-db typecheck`
- [x] `pnpm -F @pops/inventory-db test` — 69 tests passing (45 existing + 24 new)
- [x] `pnpm -F @pops/inventory-db build`
- [x] `pnpm -F @pops/api typecheck` — no consumer broke
- [x] `pnpm -w typecheck` — 66 tasks successful
- [x] `pnpm oxlint` + `pnpm oxfmt` clean on changed files
- [ ] Reviewer: confirm signature parity against `apps/pops-inventory-api/src/modules/items/service.ts` for the PR2 cutover

## Files

- `packages/inventory-db/src/services/items.ts` — CRUD + reads
- `packages/inventory-db/src/services/items-create-builder.ts` — insert payload
- `packages/inventory-db/src/services/items-update-builder.ts` — partial-update payload
- `packages/inventory-db/src/services/items-types.ts` — `Item`, `CreateItemInput`, `UpdateItemInput`, `ItemFilters`, `ItemListResult`, `toItem`
- `packages/inventory-db/src/services/items-errors.ts` — typed errors
- `packages/inventory-db/src/__tests__/items.test.ts` — 24 invariant tests against in-memory SQLite
- `packages/inventory-db/src/index.ts` — namespace + type re-exports
