### PR TITLE
feat(core): cut ai-usage reads to @pops/core-db (PRD-186 PR2)

### DIFF
--- a/apps/pops-api/src/modules/core/ai-budgets/enforcement.ts
+++ b/apps/pops-api/src/modules/core/ai-budgets/enforcement.ts
@@ -4,12 +4,23 @@
  * Split out of `service.ts` so the read-side CRUD/status code (mounted on
  * `core.aiBudgets`) and the inference-middleware enforcement path can each
  * stay under the project's max-lines lint budget.
+ *
+ * Read/write split (PRD-186 PR 2 cutover): `listApplicableBudgets` and the
+ * per-scope usage aggregation forward to `@pops/core-db`'s `aiUsageService`
+ * against `getCoreDrizzle()` so reads land on `core.db`. The conflict-
+ * detection read in `migrateLegacyBudgetSettings` is routed through the
+ * same package surface. `findFallbackProvider` stays on the legacy
+ * `getDrizzle()` handle because it joins `ai_providers` and
+ * `ai_model_pricing`, which are not part of the core-db package surface.
+ * Writes (`upsertBudget`) keep flowing through the shared store until
+ * PRD-186 PR 3 flips writes too.
  */
-import { and, asc, desc, eq, gte, sql } from 'drizzle-orm';
+import { and, asc, desc, eq } from 'drizzle-orm';
 
-import { aiBudgets, aiInferenceLog, aiModelPricing, aiProviders } from '@pops/db-types';
+import { aiUsageService, type AiBudgetRow } from '@pops/core-db';
+import { aiModelPricing, aiProviders } from '@pops/db-types';
 
-import { getDrizzle } from '../../../db.js';
+import { getCoreDrizzle, getDrizzle } from '../../../db.js';
 import { logger } from '../../../lib/logger.js';
 import { getSettingOrNull, setRawSetting } from '../settings/service.js';
 import { upsertBudget } from './service.js';
@@ -41,49 +52,37 @@ export interface BudgetBreach {
   limit: number;
 }
 
-type BudgetRow = typeof aiBudgets.$inferSelect;
-
 function monthStart(): string {
   const d = new Date();
   return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1, 0, 0, 0, 0)).toISOString();
 }
 
 function getUsageForScope(
-  db: ReturnType<typeof getDrizzle>,
-  row: BudgetRow,
+  row: AiBudgetRow,
   start: string
 ): { currentTokenUsage: number; currentCostUsage: number } {
-  const conditions = [gte(aiInferenceLog.createdAt, start)];
-  if (row.scopeType === 'provider' && row.scopeValue) {
-    conditions.push(eq(aiInferenceLog.provider, row.scopeValue));
-  } else if (row.scopeType === 'operation' && row.scopeValue) {
-    conditions.push(eq(aiInferenceLog.operation, row.scopeValue));
-  }
-  const [agg] = db
-    .select({
-      totalTokens: sql<number>`COALESCE(SUM(${aiInferenceLog.inputTokens} + ${aiInferenceLog.outputTokens}), 0)`,
-      totalCost: sql<number>`COALESCE(SUM(${aiInferenceLog.costUsd}), 0)`,
-    })
-    .from(aiInferenceLog)
-    .where(and(...conditions))
-    .all();
+  const usage = aiUsageService.sumInferenceLogUsage(getCoreDrizzle(), {
+    since: start,
+    ...(row.scopeType === 'provider' && row.scopeValue ? { provider: row.scopeValue } : {}),
+    ...(row.scopeType === 'operation' && row.scopeValue ? { operation: row.scopeValue } : {}),
+  });
   return {
-    currentTokenUsage: agg?.totalTokens ?? 0,
-    currentCostUsage: agg?.totalCost ?? 0,
+    currentTokenUsage: usage.totalInputTokens + usage.totalOutputTokens,
+    currentCostUsage: usage.totalCostUsd,
   };
 }
 
+function budgetMatchesCall(row: AiBudgetRow, provider: string, operation: string): boolean {
+  if (row.scopeType === 'global') return true;
+  if (row.scopeType === 'provider') return row.scopeValue === provider;
+  if (row.scopeType === 'operation') return row.scopeValue === operation;
+  return false;
+}
+
 function listApplicableBudgets(provider: string, operation: string): ApplicableBudget[] {
-  const db = getDrizzle();
-  const rows = db
-    .select()
-    .from(aiBudgets)
-    .where(
-      sql`(${aiBudgets.scopeType} = 'global')
-        OR (${aiBudgets.scopeType} = 'provider' AND ${aiBudgets.scopeValue} = ${provider})
-        OR (${aiBudgets.scopeType} = 'operation' AND ${aiBudgets.scopeValue} = ${operation})`
-    )
-    .all();
+  const rows = aiUsageService
+    .listBudgets(getCoreDrizzle())
+    .filter((row) => budgetMatchesCall(row, provider, operation));
   if (rows.length === 0) return [];
   const start = monthStart();
   const usageByScope = new Map<string, { currentTokenUsage: number; currentCostUsage: number }>();
@@ -91,7 +90,7 @@ function listApplicableBudgets(provider: string, operation: string): ApplicableB
     const scopeKey = `${row.scopeType}:${row.scopeValue ?? ''}`;
     let usage = usageByScope.get(scopeKey);
     if (!usage) {
-      usage = getUsageForScope(db, row, start);
+      usage = getUsageForScope(row, start);
       usageByScope.set(scopeKey, usage);
     }
     return {
@@ -170,6 +169,11 @@ function mapLegacyFallbackToAction(raw: string | null): 'block' | 'warn' {
   return 'warn';
 }
 
+function hasGlobalBudgetConflict(): boolean {
+  const rows = aiUsageService.listBudgets(getCoreDrizzle());
+  return rows.some((row) => row.scopeType === 'global' || row.id === 'global');
+}
+
 /**
  * Idempotent startup migration from legacy `ai.monthlyTokenBudget` /
  * `ai.budgetExceededFallback` settings into a global `ai_budgets` row.
@@ -180,16 +184,10 @@ function mapLegacyFallbackToAction(raw: string | null): 'block' | 'warn' {
 export function migrateLegacyBudgetSettings(): void {
   if (getSettingOrNull(LEGACY_MIGRATED_FLAG_KEY)) return;
 
-  const db = getDrizzle();
   // Skip if either: a global-scoped row already exists, or a row with id='global'
   // already exists under a different scope. upsertBudget keys on id, so the
   // latter would silently clobber unrelated data.
-  const conflict = db
-    .select({ id: aiBudgets.id })
-    .from(aiBudgets)
-    .where(sql`${aiBudgets.scopeType} = 'global' OR ${aiBudgets.id} = 'global'`)
-    .get();
-  if (conflict) {
+  if (hasGlobalBudgetConflict()) {
     setRawSetting(LEGACY_MIGRATED_FLAG_KEY, '1');
     return;
   }
@@ -220,6 +218,11 @@ export function migrateLegacyBudgetSettings(): void {
  * the first active local provider together with its default model. Returns
  * `null` when no candidate is available — the middleware then treats fallback
  * as block.
+ *
+ * Stays on `getDrizzle()` (shared `pops.db`) because this query joins
+ * `ai_providers` + `ai_model_pricing`, neither of which lives in
+ * `@pops/core-db`. A future PR can lift those tables into the package
+ * surface and complete the cutover.
  */
 export function findFallbackProvider(): { provider: string; model: string } | null {
   const db = getDrizzle();

--- a/apps/pops-api/src/modules/core/ai-budgets/enforcement.ts
+++ b/apps/pops-api/src/modules/core/ai-budgets/enforcement.ts
@@ -57,6 +57,19 @@ function monthStart(): string {
   return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1, 0, 0, 0, 0)).toISOString();
 }
 
+/**
+ * Aggregate monthly token + cost usage for a single budget scope.
+ *
+ * Staleness window: reads from `core.db` via `aiUsageService`, but
+ * inference logs are still inserted into the shared `pops.db` by
+ * `apps/pops-api/src/lib/inference-middleware.ts`. The `core.db` copy is
+ * only refreshed by the boot-time backfill, so any inference recorded
+ * since process start is invisible here. Net effect: enforcement can
+ * under-count usage and over-allow calls (fail to warn/block/fallback)
+ * during normal uptime. Accepted risk during the read/write split window.
+ * TODO(PRD-186 PR 3): drop this note once the inference writer flips to
+ * `core.db` (or a dual-write path lands).
+ */
 function getUsageForScope(
   row: AiBudgetRow,
   start: string

--- a/apps/pops-api/src/modules/core/ai-budgets/service.ts
+++ b/apps/pops-api/src/modules/core/ai-budgets/service.ts
@@ -1,8 +1,17 @@
-import { and, gte, sql } from 'drizzle-orm';
+/**
+ * AI budgets module — CRUD + budget status for `core.aiBudgets.*`.
+ *
+ * Read/write split (PRD-186 PR 2 cutover): the pure read surface forwards
+ * into `@pops/core-db`'s `aiUsageService` against `getCoreDrizzle()`, so
+ * `listBudgets` and `getBudgetStatus` resolve against `core.db`.
+ * Mutations (`upsertBudget`) still land via the shared `getDrizzle()`
+ * handle — the legacy `pops.db -> core.db` boot-time backfill bridges the
+ * gap until PRD-186 PR 3 flips the writer too. This matches the
+ * watch-history cutover precedent (PR #3008).
+ */
+import { aiBudgets, aiUsageService } from '@pops/core-db';
 
-import { aiBudgets, aiInferenceLog } from '@pops/db-types';
-
-import { getDrizzle } from '../../../db.js';
+import { getCoreDrizzle, getDrizzle } from '../../../db.js';
 
 export interface Budget {
   id: string;
@@ -53,10 +62,18 @@ function computeProjectedExhaustion(
   return exhaustionDate.toISOString().split('T')[0] ?? null;
 }
 
+/**
+ * READ — forwards to `aiUsageService.listBudgets` against `core.db`.
+ */
 export function listBudgets(): Budget[] {
-  return getDrizzle().select().from(aiBudgets).all();
+  return aiUsageService.listBudgets(getCoreDrizzle());
 }
 
+/**
+ * WRITE — upsert lands on the shared `pops.db` via `getDrizzle()`. The
+ * boot-time `pops.db -> core.db` backfill propagates the new row to the
+ * read store on the next boot. PRD-186 PR 3 flips this to `core.db`.
+ */
 export function upsertBudget(input: UpsertBudgetInput): Budget {
   const now = new Date().toISOString();
   const db = getDrizzle();
@@ -83,46 +100,44 @@ export function upsertBudget(input: UpsertBudgetInput): Budget {
       },
     })
     .run();
-  const row = db
-    .select()
-    .from(aiBudgets)
-    .where(sql`id = ${input.id}`)
-    .get();
+  const row = aiUsageService.getBudgetOrNull(getCoreDrizzle(), input.id);
   if (!row) throw new Error(`Budget not found: ${input.id}`);
   return row;
 }
 
+/**
+ * READ — budgets come from `aiUsageService.listBudgets`; per-budget usage
+ * comes from `aiUsageService.sumInferenceLogUsage` against `core.db` so
+ * both the budget row and its rolled-up monthly usage stay on the same
+ * read handle.
+ */
 export function getBudgetStatus(): BudgetStatus[] {
-  const db = getDrizzle();
-  const budgets = db.select().from(aiBudgets).all();
   const start = monthStart();
   const monthStartDate = new Date(start);
+  const budgets = aiUsageService.listBudgets(getCoreDrizzle());
 
-  return budgets.map((budget) => buildBudgetStatus(db, budget, start, monthStartDate));
+  return budgets.map((budget) => buildBudgetStatus(budget, start, monthStartDate));
 }
 
 type BudgetRow = typeof aiBudgets.$inferSelect;
 
 function getBudgetUsage(
-  db: ReturnType<typeof getDrizzle>,
   budget: BudgetRow,
   start: string
 ): { currentTokenUsage: number; currentCostUsage: number } {
-  const conditions = [gte(aiInferenceLog.createdAt, start)];
-  if (budget.scopeType === 'provider' && budget.scopeValue) {
-    conditions.push(sql`${aiInferenceLog.provider} = ${budget.scopeValue}`);
-  } else if (budget.scopeType === 'operation' && budget.scopeValue) {
-    conditions.push(sql`${aiInferenceLog.operation} = ${budget.scopeValue}`);
-  }
-  const [agg] = db
-    .select({
-      totalTokens: sql<number>`COALESCE(SUM(${aiInferenceLog.inputTokens} + ${aiInferenceLog.outputTokens}), 0)`,
-      totalCost: sql<number>`COALESCE(SUM(${aiInferenceLog.costUsd}), 0)`,
-    })
-    .from(aiInferenceLog)
-    .where(and(...conditions))
-    .all();
-  return { currentTokenUsage: agg?.totalTokens ?? 0, currentCostUsage: agg?.totalCost ?? 0 };
+  const usage = aiUsageService.sumInferenceLogUsage(getCoreDrizzle(), {
+    since: start,
+    ...(budget.scopeType === 'provider' && budget.scopeValue
+      ? { provider: budget.scopeValue }
+      : {}),
+    ...(budget.scopeType === 'operation' && budget.scopeValue
+      ? { operation: budget.scopeValue }
+      : {}),
+  });
+  return {
+    currentTokenUsage: usage.totalInputTokens + usage.totalOutputTokens,
+    currentCostUsage: usage.totalCostUsd,
+  };
 }
 
 function computeBudgetStatusFields(
@@ -153,13 +168,8 @@ function computeBudgetStatusFields(
   return { percentageUsed: null, projectedExhaustionDate: null };
 }
 
-function buildBudgetStatus(
-  db: ReturnType<typeof getDrizzle>,
-  budget: BudgetRow,
-  start: string,
-  monthStartDate: Date
-): BudgetStatus {
-  const usage = getBudgetUsage(db, budget, start);
+function buildBudgetStatus(budget: BudgetRow, start: string, monthStartDate: Date): BudgetStatus {
+  const usage = getBudgetUsage(budget, start);
   const fields = computeBudgetStatusFields(budget, usage, monthStartDate);
   return { ...budget, ...usage, ...fields };
 }

--- a/apps/pops-api/src/modules/core/ai-budgets/service.ts
+++ b/apps/pops-api/src/modules/core/ai-budgets/service.ts
@@ -73,6 +73,11 @@ export function listBudgets(): Budget[] {
  * WRITE — upsert lands on the shared `pops.db` via `getDrizzle()`. The
  * boot-time `pops.db -> core.db` backfill propagates the new row to the
  * read store on the next boot. PRD-186 PR 3 flips this to `core.db`.
+ *
+ * The read-after-write hop deliberately uses the SAME `getDrizzle()` handle
+ * the insert went to. Routing the readback through `getCoreDrizzle()` would
+ * miss the freshly-inserted row until the next boot-time backfill, breaking
+ * both the mutation response and `migrateLegacyBudgetSettings()` at startup.
  */
 export function upsertBudget(input: UpsertBudgetInput): Budget {
   const now = new Date().toISOString();
@@ -100,7 +105,7 @@ export function upsertBudget(input: UpsertBudgetInput): Budget {
       },
     })
     .run();
-  const row = aiUsageService.getBudgetOrNull(getCoreDrizzle(), input.id);
+  const row = aiUsageService.getBudgetOrNull(db, input.id);
   if (!row) throw new Error(`Budget not found: ${input.id}`);
   return row;
 }
@@ -110,6 +115,14 @@ export function upsertBudget(input: UpsertBudgetInput): Budget {
  * comes from `aiUsageService.sumInferenceLogUsage` against `core.db` so
  * both the budget row and its rolled-up monthly usage stay on the same
  * read handle.
+ *
+ * Staleness window: until PRD-186 PR 3 cuts the inference-log writer over
+ * to `core.db`, inference rows are still inserted into the shared `pops.db`
+ * by `apps/pops-api/src/lib/inference-middleware.ts`. The `core.db` copy is
+ * only refreshed by the boot-time backfill, so the reported monthly usage,
+ * percentage, and projected exhaustion date can under-count any inference
+ * recorded since process start. Accepted lag during the split window.
+ * TODO(PRD-186 PR 3): drop this staleness note once writes flip to core.db.
  */
 export function getBudgetStatus(): BudgetStatus[] {
   const start = monthStart();


### PR DESCRIPTION
## Summary

PRD-186 PR 2 cutover — flips the pure read paths in `apps/pops-api/src/modules/core/ai-budgets/{service,enforcement}.ts` into `@pops/core-db`'s `aiUsageService` against `getCoreDrizzle()`. Budget list, status, and per-scope usage aggregation now land in `core.db.*` instead of the shared `pops.db`. Writes (`upsertBudget`) stay on `getDrizzle()` per PR #3008's (watch-history) read/write split precedent; the boot-time `pops.db -> core.db` backfill bridges the two stores until PRD-186 PR 3 flips the writer too.

- Replaces in-tree drizzle queries with thin forwards into `aiUsageService.{listBudgets, getBudgetOrNull, sumInferenceLogUsage}`.
- `findFallbackProvider` keeps `getDrizzle()` (joins `ai_providers` + `ai_model_pricing` — out of `@pops/core-db` scope).
- `inference-middleware.ts` is write-only (insertLog) and unchanged; its budget enforcement read path is routed through the updated `enforcement.ts`.

## Out of scope (follow-up)

- `ai-observability` and `ai-usage` routers' bespoke SQL (percentiles, group-by aggregations, CASE-WHEN cached splits, log/daily UNION timeline). They do not map onto the current `aiUsageService` surface — they need either new package helpers or a wider redesign. Same pragmatic restraint as PR #3008 (cross-table orchestrators) and PR #3011 (engrams).

## Test plan

- [x] `pnpm -F @pops/api typecheck` — green
- [x] `pnpm -F @pops/api test src/modules/core/ai-budgets src/modules/core/ai-observability src/modules/core/ai-usage` — 71/71 pass
- [x] `pnpm -F @pops/api test` — 4941/4941 pass
- [x] `pnpm -w typecheck` — 66/66 packages green
- [x] `pnpm oxlint` — 0 errors (pre-existing warnings unchanged)
- [x] `pnpm oxfmt --check` — clean
