### PR TITLE
feat(cerebrum): cut conversations reads to @pops/cerebrum-db (PRD-182 PR2)

### DIFF
--- a/apps/pops-api/src/modules/cerebrum/ego/chat-helpers.ts
+++ b/apps/pops-api/src/modules/cerebrum/ego/chat-helpers.ts
@@ -6,6 +6,7 @@
  * and app context comparison logic across the two code paths.
  */
 import { getDrizzle } from '../../../db.js';
+import { getCerebrumDrizzle } from '../../../db/cerebrum-handle.js';
 import { getSettingValue } from '../../core/settings/service.js';
 import { ConversationEngine } from './engine.js';
 import { PersistenceStoreAdapter } from './persistence-store.js';
@@ -14,9 +15,18 @@ import { autoTitle } from './types.js';
 
 import type { AppContext, ChatResult, Conversation, Message, ScopeNegotiation } from './types.js';
 
-/** Lazily instantiated persistence service (uses the global Drizzle instance). */
+/**
+ * Lazily instantiated persistence service.
+ *
+ * `db` is the shared `pops.db` write handle; `readDb` is the cerebrum
+ * pillar's `cerebrum.db` read handle (PRD-182 PR 2 read seam — pure
+ * reads forward to `@pops/cerebrum-db`'s `conversationsService`).
+ * Writes plus read-after-write hops stay on `pops.db` until PRD-182
+ * PR 3 flips them too. See `ConversationPersistence` top-of-file JSDoc
+ * for the cross-store consistency contract.
+ */
 export function getPersistence(): ConversationPersistence {
-  return new ConversationPersistence({ db: getDrizzle() });
+  return new ConversationPersistence({ db: getDrizzle(), readDb: getCerebrumDrizzle() });
 }
 
 export function getStore(): PersistenceStoreAdapter {

--- a/apps/pops-api/src/modules/cerebrum/ego/persistence-mappers.ts
+++ b/apps/pops-api/src/modules/cerebrum/ego/persistence-mappers.ts
@@ -1,0 +1,83 @@
+/**
+ * Adapters mapping `@pops/cerebrum-db`'s `conversationsService` row
+ * shapes onto the in-tree ego domain types.
+ *
+ * The package's types are structurally compatible today; this layer
+ * exists as a single seam to absorb future divergence (when PR 3 of
+ * the PRD-182 cutover collapses the in-tree types directly onto the
+ * package). Keeping the mappers out of `persistence.ts` is also a
+ * line-count discipline: the read/write split docstring + the dual
+ * handle wiring push the class itself past the file cap, so the
+ * shape-coercion lives here.
+ *
+ * `citations` / `toolCalls` are stored on the wire as opaque JSON
+ * (the chat orchestration layer owns the payload). The package
+ * surfaces them as `unknown`; the in-tree contract tightens them to
+ * `string[] | null` / `unknown[] | null`. The narrowing uses
+ * `Array.isArray` + `typeof` guards so a future non-array payload
+ * surfaces as `null` instead of leaking a wrong type to the chat
+ * pipeline.
+ */
+import type { Conversation, Message } from './types.js';
+
+/** Subset of the package's `Conversation` shape this adapter needs. */
+export interface PackageConversation {
+  id: string;
+  title: string | null;
+  activeScopes: string[];
+  appContext: unknown | null;
+  model: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** Subset of the package's `Message` shape this adapter needs. */
+export interface PackageMessage {
+  id: string;
+  conversationId: string;
+  role: string;
+  content: string;
+  citations: unknown | null;
+  toolCalls: unknown | null;
+  tokensIn: number | null;
+  tokensOut: number | null;
+  createdAt: string;
+}
+
+/** Map the package's `Conversation` onto the in-tree `Conversation`. */
+export function mapPackageConversation(row: PackageConversation): Conversation {
+  return {
+    id: row.id,
+    title: row.title,
+    activeScopes: row.activeScopes,
+    appContext: row.appContext,
+    model: row.model,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+/** Map the package's `Message` onto the in-tree `Message`. */
+export function mapPackageMessage(row: PackageMessage): Message {
+  return {
+    id: row.id,
+    conversationId: row.conversationId,
+    role: row.role,
+    content: row.content,
+    citations: toStringArrayOrNull(row.citations),
+    toolCalls: toUnknownArrayOrNull(row.toolCalls),
+    tokensIn: row.tokensIn,
+    tokensOut: row.tokensOut,
+    createdAt: row.createdAt,
+  };
+}
+
+function toStringArrayOrNull(value: unknown): string[] | null {
+  if (!Array.isArray(value)) return null;
+  return value.filter((item): item is string => typeof item === 'string');
+}
+
+function toUnknownArrayOrNull(value: unknown): unknown[] | null {
+  if (!Array.isArray(value)) return null;
+  return value;
+}

--- a/apps/pops-api/src/modules/cerebrum/ego/persistence.ts
+++ b/apps/pops-api/src/modules/cerebrum/ego/persistence.ts
@@ -1,13 +1,44 @@
 /**
- * Ego conversation persistence service.
+ * Ego conversation persistence service — read/write split during the
+ * PRD-182 cutover.
  *
- * Thin CRUD layer over the conversations, messages, and conversation_context
- * tables. All writes go through Drizzle ORM.
+ * Thin CRUD layer over the `conversations`, `messages`, and
+ * `conversation_context` tables. The class accepts two drizzle handles:
+ *
+ *  - `db` (BetterSQLite3Database) — the shared `pops.db` write handle.
+ *    Every write path lands here: `createConversation`,
+ *    `appendMessage` (plus the auto-title heuristic's read-after-write
+ *    hop), `upsertContext`, `deleteConversation`, `updateTitle`,
+ *    `updateScopes`, `updateAppContext`.
+ *  - `readDb` (CerebrumDb) — the cerebrum pillar's `cerebrum.db` read
+ *    handle. PRD-182 PR 2 routes pure user-facing reads through
+ *    `@pops/cerebrum-db`'s `conversationsService` namespace against this
+ *    handle: `listConversations`, `getConversation`,
+ *    `getContextEntries`. `readDb` is optional and falls back to `db`
+ *    so the existing in-memory test rigs (which inject a single SQLite
+ *    handle for both stores) keep working without churn.
+ *
+ * Cross-store consistency relies on `backfillCerebrumFromShared()` in
+ * `apps/pops-api/src/db/backfill-cerebrum-from-shared.ts`: a one-way,
+ * boot-time copy from `pops.db` -> `cerebrum.db` that idempotently
+ * fills missing rows on `conversations` + `messages` +
+ * `conversation_context`. Between boots, newly-written rows live only
+ * in `pops.db` until the next backfill, but read-after-write within the
+ * same process is preserved because `maybeAutoTitle` (the only
+ * post-write read) routes through `db`. Mirrors the read/write split
+ * landed in PRD-179 PR 2 (engrams) and PRD-168 PR 2 (watch-history).
+ *
+ * PRD-182 PR 3 flips the writes too, at which point `db` collapses
+ * into `readDb`. Heavy chat orchestration (LLM streaming, scope
+ * negotiation, auto-title heuristic, persistence-store adapter) stays
+ * in pops-api — `@pops/cerebrum-db` is pure data-access.
  */
-import { and, desc, eq, like, sql } from 'drizzle-orm';
+import { and, eq, sql } from 'drizzle-orm';
 
+import { conversationsService, type CerebrumDb } from '@pops/cerebrum-db';
 import { conversations, conversationContext, messages } from '@pops/db-types/schema';
 
+import { mapPackageConversation, mapPackageMessage } from './persistence-mappers.js';
 import {
   autoTitle,
   generateConversationId,
@@ -39,20 +70,37 @@ type ConversationRow = typeof conversations.$inferSelect;
 type MessageRow = typeof messages.$inferSelect;
 
 export interface ConversationPersistenceOptions {
+  /**
+   * Write handle — the shared `pops.db` drizzle wrapper. All write
+   * paths and read-after-write hops (the auto-title heuristic in
+   * particular) route through this handle until PRD-182 PR 3 flips the
+   * writes too.
+   */
   db: BetterSQLite3Database;
+  /**
+   * Read handle — the cerebrum pillar's `cerebrum.db` drizzle wrapper.
+   * Pure user-facing reads (`listConversations`, `getConversation`,
+   * `getContextEntries`) forward through `@pops/cerebrum-db`'s
+   * `conversationsService` against this handle. Defaults to `db` so
+   * test rigs that inject a single in-memory SQLite keep working
+   * without churn.
+   */
+  readDb?: CerebrumDb;
   now?: () => Date;
 }
 
 export class ConversationPersistence {
   private readonly db: BetterSQLite3Database;
+  private readonly readDb: CerebrumDb;
   private readonly now: () => Date;
 
   constructor(options: ConversationPersistenceOptions) {
     this.db = options.db;
+    this.readDb = options.readDb ?? options.db;
     this.now = options.now ?? (() => new Date());
   }
 
-  /** Create a new conversation. */
+  /** Create a new conversation. Writes to the shared `pops.db`. */
   createConversation(input: CreateConversationInput): Conversation {
     const now = this.now();
     const id = generateConversationId(now);
@@ -70,43 +118,43 @@ export class ConversationPersistence {
     return toConversation(row);
   }
 
-  /** List conversations with optional pagination and title search. */
+  /**
+   * List conversations with optional pagination and title search.
+   * Pure read — routed through `@pops/cerebrum-db`'s
+   * `conversationsService.listConversations` against `readDb`.
+   */
   listConversations(input: ListConversationsInput = {}): {
     conversations: Conversation[];
     total: number;
   } {
-    const { limit = 50, offset = 0, search } = input;
-    const where = search ? like(conversations.title, `%${search}%`) : undefined;
-    const totalResult = this.db
-      .select({ count: sql<number>`count(*)` })
-      .from(conversations)
-      .where(where)
-      .get();
-    const rows = this.db
-      .select()
-      .from(conversations)
-      .where(where)
-      .orderBy(desc(conversations.updatedAt))
-      .limit(limit)
-      .offset(offset)
-      .all();
-    return { conversations: rows.map(toConversation), total: totalResult?.count ?? 0 };
+    const result = conversationsService.listConversations(this.readDb, {
+      search: input.search,
+      limit: input.limit ?? 50,
+      offset: input.offset ?? 0,
+    });
+    return {
+      conversations: result.conversations.map(mapPackageConversation),
+      total: result.total,
+    };
   }
 
-  /** Get a conversation with all its messages. */
+  /**
+   * Get a conversation with all its messages. Pure read — routed
+   * through `@pops/cerebrum-db`'s
+   * `conversationsService.{getConversation,listMessages}` against
+   * `readDb`. Returns `null` when the conversation is missing.
+   */
   getConversation(id: string): { conversation: Conversation; messages: Message[] } | null {
-    const row = this.db.select().from(conversations).where(eq(conversations.id, id)).get();
-    if (!row) return null;
-    const msgRows = this.db
-      .select()
-      .from(messages)
-      .where(eq(messages.conversationId, id))
-      .orderBy(messages.createdAt)
-      .all();
-    return { conversation: toConversation(row), messages: msgRows.map(toMessage) };
+    const conv = conversationsService.getConversation(this.readDb, id);
+    if (!conv) return null;
+    const msgs = conversationsService.listMessages(this.readDb, id);
+    return {
+      conversation: mapPackageConversation(conv),
+      messages: msgs.map(mapPackageMessage),
+    };
   }
 
-  /** Delete a conversation and cascade to messages + context. */
+  /** Delete a conversation and cascade to messages + context. Writes to `pops.db`. */
   deleteConversation(id: string): void {
     this.db.transaction((tx) => {
       tx.delete(conversationContext).where(eq(conversationContext.conversationId, id)).run();
@@ -117,7 +165,9 @@ export class ConversationPersistence {
 
   /**
    * Append a message to a conversation. Updates conversation.updatedAt.
-   * Auto-generates a title from the first user message when none is set.
+   * Auto-generates a title from the first user message when none is
+   * set. Writes (and the auto-title read-after-write hop) land on
+   * `pops.db`.
    */
   appendMessage(conversationId: string, input: AppendMessageInput): Message {
     const now = this.now();
@@ -144,7 +194,10 @@ export class ConversationPersistence {
     return toMessage(row);
   }
 
-  /** Insert or update a context entry linking a conversation to an engram. */
+  /**
+   * Insert or update a context entry linking a conversation to an engram.
+   * Writes to `pops.db`.
+   */
   upsertContext(conversationId: string, engramId: string, relevanceScore?: number): void {
     const iso = this.now().toISOString();
     this.db
@@ -157,7 +210,7 @@ export class ConversationPersistence {
       .run();
   }
 
-  /** Update the conversation title. */
+  /** Update the conversation title. Writes to `pops.db`. */
   updateTitle(conversationId: string, title: string): void {
     this.db
       .update(conversations)
@@ -166,7 +219,7 @@ export class ConversationPersistence {
       .run();
   }
 
-  /** Replace the conversation's active scopes. */
+  /** Replace the conversation's active scopes. Writes to `pops.db`. */
   updateScopes(conversationId: string, scopes: string[]): void {
     this.db
       .update(conversations)
@@ -175,7 +228,7 @@ export class ConversationPersistence {
       .run();
   }
 
-  /** Update the conversation's app context (US-03). */
+  /** Update the conversation's app context (US-03). Writes to `pops.db`. */
   updateAppContext(conversationId: string, appContext: unknown): void {
     this.db
       .update(conversations)
@@ -187,23 +240,30 @@ export class ConversationPersistence {
       .run();
   }
 
-  /** Get all context entries (engram associations) for a conversation (US-03). */
+  /**
+   * Get all context entries (engram associations) for a conversation
+   * (US-03). Pure read — routed through `@pops/cerebrum-db`'s
+   * `conversationsService.listConversationContext` against `readDb`.
+   */
   getContextEntries(
     conversationId: string
   ): Array<{ engramId: string; relevanceScore: number | null; loadedAt: string }> {
-    return this.db
-      .select({
-        engramId: conversationContext.engramId,
-        relevanceScore: conversationContext.relevanceScore,
-        loadedAt: conversationContext.loadedAt,
-      })
-      .from(conversationContext)
-      .where(eq(conversationContext.conversationId, conversationId))
-      .orderBy(desc(conversationContext.loadedAt))
-      .all();
+    return conversationsService
+      .listConversationContext(this.readDb, conversationId)
+      .map((entry) => ({
+        engramId: entry.engramId,
+        relevanceScore: entry.relevanceScore,
+        loadedAt: entry.loadedAt,
+      }));
   }
 
-  /** Auto-generate title from first user message when no title is set. */
+  /**
+   * Auto-generate title from first user message when no title is set.
+   * Stays on the write handle (`db`) because it is a read-after-write
+   * hop inside the `appendMessage` flow: the row we just inserted lives
+   * only on `pops.db` until the next backfill, so consulting `readDb`
+   * would silently miss it and skip the title.
+   */
   private maybeAutoTitle(conversationId: string, input: AppendMessageInput): void {
     if (input.role !== 'user') return;
     const conv = this.db

--- a/apps/pops-api/src/modules/cerebrum/ego/router-context.ts
+++ b/apps/pops-api/src/modules/cerebrum/ego/router-context.ts
@@ -5,13 +5,22 @@ import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 
 import { getDrizzle } from '../../../db.js';
+import { getCerebrumDrizzle } from '../../../db/cerebrum-handle.js';
 import { protectedProcedure, router } from '../../../trpc.js';
 import { ConversationPersistence } from './persistence.js';
 
 import type { AppContext } from './types.js';
 
+/**
+ * `db` is the shared `pops.db` write handle; `readDb` is the cerebrum
+ * pillar's `cerebrum.db` read handle. Pure reads (`setScopes`'
+ * pre-check, `getActive`'s lookup, the context-entry list) forward
+ * through `@pops/cerebrum-db`'s `conversationsService` against
+ * `readDb`. Writes (`updateScopes`) keep landing on `pops.db` until
+ * PRD-182 PR 3 collapses them onto the pillar handle.
+ */
 function getPersistence(): ConversationPersistence {
-  return new ConversationPersistence({ db: getDrizzle() });
+  return new ConversationPersistence({ db: getDrizzle(), readDb: getCerebrumDrizzle() });
 }
 
 const setScopesSchema = z.object({


### PR DESCRIPTION
## Summary

PR 2 of [PRD-182](../blob/main/docs/themes/13-pillar-finale/prds/182-cerebrum-conversations-cutover/README.md)'s cutover sequence — the conversations read seam. PR 1 (#3003) scaffolded `conversationsService` in `@pops/cerebrum-db`; this PR flips the pure user-facing reads on `ConversationPersistence` through the cerebrum pillar handle.

- `persistence.ts` adds an optional `readDb` (`CerebrumDb`) handle alongside the existing `db` (`BetterSQLite3Database`) write handle. `listConversations`, `getConversation`, and `getContextEntries` now call `conversationsService.{listConversations,getConversation,listMessages,listConversationContext}` against `readDb`. Writes (`createConversation`, `deleteConversation`, `appendMessage`, `upsertContext`, `updateTitle`, `updateScopes`, `updateAppContext`) plus the private `maybeAutoTitle` read-after-write hop keep going through the shared `pops.db` handle until PRD-182 PR 3.
- `chat-helpers.ts` + `router-context.ts` wire `readDb` to `getCerebrumDrizzle()`. Outside tests reads land on `cerebrum.db`, writes stay on `pops.db`; cross-store consistency is maintained by the boot-time backfill already configured for `conversations` + `messages` + `conversation_context` in `backfill-cerebrum-from-shared.ts`.
- `ConversationPersistenceOptions.readDb` is optional and defaults to `db`. Existing in-memory test rigs (persistence.test.ts, chat-helpers.test.ts, ego-chat.integration.test.ts) inject a single drizzle handle and keep working untouched. The cerebrum smoke harness already installs the pillar handle via `setCerebrumDb(...)` so `ego.conversations.get` reaches the per-pillar `conversations` table without further test changes.
- New `persistence-mappers.ts` absorbs the shape coercion between the package's row shapes and the in-tree domain types. The package surfaces `citations`/`toolCalls` as opaque `unknown`; the in-tree contract tightens them to `string[] | null` / `unknown[] | null`. Narrowing uses `Array.isArray` + `typeof` guards so a non-array payload surfaces as `null` instead of leaking a wrong type. Extracted from `persistence.ts` to stay under the file-line cap.

Mirrors the PRD-179 PR 2 (#3011) and PRD-168 PR 2 (#3008) read/write split: pure reads forward to the package; writes plus read-after-write keep the existing guarantee on the shared store. Heavy chat orchestration (LLM streaming, scope negotiation, persistence-store adapter, auto-title heuristic) stays in pops-api per the PRD.

## Out of scope (deliberate, per PRD)

- All write paths on `ConversationPersistence` — flipped in PRD-182 PR 3.
- The legacy mount on pops-api stays as the only consumer surface; `cerebrum-api` lands when the writes do.

## Test plan

- [x] `pnpm -F @pops/api test src/modules/cerebrum/ego` — 137/137 pass
- [x] `pnpm -F @pops/api test src/modules/cerebrum/__integration__` — 3/3 pass (smoke harness covers `ego.conversations.get` via the pillar handle)
- [x] `pnpm -F @pops/api test src/modules/cerebrum` — 1128/1128 pass
- [x] `pnpm -F @pops/api test` — 4940/4941 pass (the one pre-existing failure is `toml-config.test.ts`, untouched on `origin/main`)
- [x] `pnpm -w typecheck` — 66/66 packages green
- [x] `pnpm oxlint` — 0 errors
- [x] `pnpm oxfmt` — clean

## PRD

`docs/themes/13-pillar-finale/prds/182-cerebrum-conversations-cutover/README.md`
