### PR TITLE
feat(cerebrum): cut glia reads to @pops/cerebrum-db (PRD-181 PR2)

### DIFF
--- a/apps/pops-api/src/modules/cerebrum/glia/action-service.ts
+++ b/apps/pops-api/src/modules/cerebrum/glia/action-service.ts
@@ -5,24 +5,42 @@
  * (wrapped in transactions with the corresponding glia_actions update).
  *
  * PRD-086 US-02: Approval Tracking.
+ *
+ * Read/write split during the migration window (PRD-181 PR 2):
+ *  - Pure user-facing reads — `getAction`, `listActions`, `getTrustState`,
+ *    `listTrustStates`, `listAutonomousActionsInWindow`,
+ *    `countAutonomousExecutionsSince`, `countAutonomousRevertsSince`,
+ *    `countRevertsInWindow` — are routed through `readDb` (a
+ *    `CerebrumDb` handle, wired to `getCerebrumDrizzle()` in
+ *    `instance.ts`) and forwarded to the `@pops/cerebrum-db`
+ *    `gliaService` namespace.
+ *  - Every write path — `seedTrustStates`, `createAction`,
+ *    `decideAction`, `executeAction`, `revertAction`,
+ *    `updateTrustState` — and any read-after-write hop (the private
+ *    `requireAction` helper used to rehydrate the row we just wrote)
+ *    still goes through `db` (the shared `pops.db` handle).
+ *    Read-after-write consistency lives on that same store. PRD-181
+ *    US-03 flips the writes too, at which point `db` collapses into
+ *    `readDb`.
+ *
+ * Cross-store consistency relies on `backfillCerebrumFromShared()` in
+ * `apps/pops-api/src/db/backfill-cerebrum-from-shared.ts`: a one-way,
+ * boot-time copy from `pops.db` -> `cerebrum.db` that idempotently
+ * fills missing rows on `glia_actions` + `glia_trust_state`. Between
+ * boots, newly-written actions live only in `pops.db` and won't appear
+ * in the public read methods served from `readDb` until the next deploy
+ * reruns the backfill. Read-after-write is preserved within the same
+ * process because `requireAction` reads from the write store. This is
+ * the same trade-off taken by the engrams (PRD-179 PR 2) and
+ * conversations (PRD-182 PR 2) cutovers.
  */
 import { eq, sql } from 'drizzle-orm';
 
+import { gliaService, type CerebrumDb } from '@pops/cerebrum-db';
 import { gliaActions, gliaTrustState } from '@pops/db-types/schema';
 
 import { ConflictError, NotFoundError, ValidationError } from '../../../shared/errors.js';
-import {
-  countAutonomousExecutionsSince,
-  countAutonomousRevertsSince,
-  countRevertsInWindow,
-  generateActionId,
-  getActionById,
-  getTrustStateByType,
-  listAllTrustStates,
-  listAutonomousActionsInWindow,
-  queryActions,
-  toGliaAction,
-} from './helpers.js';
+import { generateActionId, getActionById, getTrustStateByType, toGliaAction } from './helpers.js';
 import { ACTION_TYPES } from './types.js';
 
 import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
@@ -37,10 +55,25 @@ import type {
 } from './types.js';
 
 export class GliaActionService {
-  constructor(
-    private readonly db: BetterSQLite3Database,
-    private readonly now: () => Date = () => new Date()
-  ) {}
+  private readonly db: BetterSQLite3Database;
+  private readonly readDb: CerebrumDb;
+  private readonly now: () => Date;
+
+  /**
+   * @param db Write handle — shared `pops.db` drizzle wrapper. Every
+   *   write path and read-after-write hop routes through this handle
+   *   until PRD-181 US-03 flips the writes too.
+   * @param now Optional clock injection.
+   * @param readDb Optional cerebrum pillar `cerebrum.db` drizzle wrapper.
+   *   Pure user-facing reads forward through `@pops/cerebrum-db`'s
+   *   `gliaService` against this handle. Defaults to `db` so test rigs
+   *   that inject a single in-memory SQLite keep working without churn.
+   */
+  constructor(db: BetterSQLite3Database, now: () => Date = () => new Date(), readDb?: CerebrumDb) {
+    this.db = db;
+    this.now = now;
+    this.readDb = readDb ?? db;
+  }
 
   /** Seed initial trust states for all four action types. Idempotent. */
   seedTrustStates(): void {
@@ -71,7 +104,7 @@ export class GliaActionService {
     }
 
     const timestamp = this.now().toISOString();
-    const trustState = this.getTrustState(input.actionType);
+    const trustState = getTrustStateByType(this.db, input.actionType);
     if (!trustState) {
       throw new ValidationError(`Trust state not initialized for: ${input.actionType}`);
     }
@@ -180,34 +213,34 @@ export class GliaActionService {
   }
 
   getAction(id: string): GliaAction | null {
-    return getActionById(this.db, id);
+    return gliaService.getAction(this.readDb, id);
   }
   listActions(filters: ActionListFilters = {}): { actions: GliaAction[]; total: number } {
-    return queryActions(this.db, filters);
+    return gliaService.listActions(this.readDb, filters);
   }
   getTrustState(actionType: ActionType): GliaTrustState | null {
-    return getTrustStateByType(this.db, actionType);
+    return gliaService.getTrustState(this.readDb, actionType);
   }
   listTrustStates(): GliaTrustState[] {
-    return listAllTrustStates(this.db);
+    return gliaService.listTrustStates(this.readDb);
   }
   countRevertsInWindow(actionType: ActionType, windowStart: string): number {
-    return countRevertsInWindow(this.db, actionType, windowStart);
+    return gliaService.countRevertsInWindow(this.readDb, actionType, windowStart);
   }
 
   /** Autonomous actions executed in a window (used by the digest). */
   listAutonomousActionsInWindow(startDate: string, endDate: string): GliaAction[] {
-    return listAutonomousActionsInWindow(this.db, startDate, endDate);
+    return gliaService.listAutonomousActionsInWindow(this.readDb, startDate, endDate);
   }
 
   /** Count autonomous executions for a type since a given timestamp. */
   countAutonomousExecutionsSince(actionType: ActionType, sinceIso: string): number {
-    return countAutonomousExecutionsSince(this.db, actionType, sinceIso);
+    return gliaService.countAutonomousExecutionsSince(this.readDb, actionType, sinceIso);
   }
 
   /** Count autonomous reverts for a type since a given timestamp. */
   countAutonomousRevertsSince(actionType: ActionType, sinceIso: string): number {
-    return countAutonomousRevertsSince(this.db, actionType, sinceIso);
+    return gliaService.countAutonomousRevertsSince(this.readDb, actionType, sinceIso);
   }
 
   /** Update trust state directly (used by the trust machine). */
@@ -222,8 +255,14 @@ export class GliaActionService {
       .run();
   }
 
+  /**
+   * Read-after-write hop. Goes through the write store (`db`) so callers
+   * that just wrote a row see it back immediately — `readDb` may not yet
+   * reflect the change until the next boot's backfill (see top-of-file
+   * JSDoc).
+   */
   private requireAction(id: string): GliaAction {
-    const action = this.getAction(id);
+    const action = getActionById(this.db, id);
     if (!action) throw new NotFoundError('GliaAction', id);
     return action;
   }

--- a/apps/pops-api/src/modules/cerebrum/glia/action-service.ts
+++ b/apps/pops-api/src/modules/cerebrum/glia/action-service.ts
@@ -6,7 +6,7 @@
  *
  * PRD-086 US-02: Approval Tracking.
  *
- * Read/write split during the migration window (PRD-181 PR 2):
+ * Read/write split during the cerebrum-pillar cutover window:
  *  - Pure user-facing reads — `getAction`, `listActions`, `getTrustState`,
  *    `listTrustStates`, `listAutonomousActionsInWindow`,
  *    `countAutonomousExecutionsSince`, `countAutonomousRevertsSince`,
@@ -19,9 +19,11 @@
  *    `updateTrustState` — and any read-after-write hop (the private
  *    `requireAction` helper used to rehydrate the row we just wrote)
  *    still goes through `db` (the shared `pops.db` handle).
- *    Read-after-write consistency lives on that same store. PRD-181
- *    US-03 flips the writes too, at which point `db` collapses into
- *    `readDb`.
+ *    Read-after-write consistency lives on that same store. A
+ *    follow-up cutover flips the writes too, at which point `db`
+ *    collapses into `readDb`. See PRD-181 for the broader pillar
+ *    sequence; exact phase numbering is owned by that doc and may
+ *    drift from this comment.
  *
  * Cross-store consistency relies on `backfillCerebrumFromShared()` in
  * `apps/pops-api/src/db/backfill-cerebrum-from-shared.ts`: a one-way,
@@ -30,9 +32,9 @@
  * boots, newly-written actions live only in `pops.db` and won't appear
  * in the public read methods served from `readDb` until the next deploy
  * reruns the backfill. Read-after-write is preserved within the same
- * process because `requireAction` reads from the write store. This is
- * the same trade-off taken by the engrams (PRD-179 PR 2) and
- * conversations (PRD-182 PR 2) cutovers.
+ * process because `requireAction` reads from the write store. Same
+ * trade-off taken by the other cerebrum pillar cutovers (engrams,
+ * conversations).
  */
 import { eq, sql } from 'drizzle-orm';
 

--- a/apps/pops-api/src/modules/cerebrum/glia/instance.ts
+++ b/apps/pops-api/src/modules/cerebrum/glia/instance.ts
@@ -4,8 +4,15 @@
  * Builds GliaActionService and GliaTrustMachine bound to the current
  * request's Drizzle context. Resolved per-call so env-scoped DB context
  * (AsyncLocalStorage) is honoured like every other module.
+ *
+ * PRD-181 PR 2 — the read seam routes through `@pops/cerebrum-db`'s
+ * `gliaService` against `readDb` (the cerebrum pillar handle); writes
+ * still land on `pops.db` via `db` until PRD-181 US-03 flips them too.
+ * See `GliaActionService` top-of-file JSDoc for the cross-store
+ * consistency contract.
  */
 import { getDrizzle } from '../../../db.js';
+import { getCerebrumDrizzle } from '../../../db/cerebrum-handle.js';
 import { GliaActionService } from './action-service.js';
 import { defaultDigestChannels } from './digest-channels.js';
 import { GliaDigestService } from './digest-service.js';
@@ -19,7 +26,7 @@ interface GliaServices {
 
 /** Build Glia services bound to the current request's drizzle context. */
 export function getGliaServices(): GliaServices {
-  const actionService = new GliaActionService(getDrizzle());
+  const actionService = new GliaActionService(getDrizzle(), () => new Date(), getCerebrumDrizzle());
   const trustMachine = new GliaTrustMachine(actionService);
   const digestService = new GliaDigestService(actionService, {
     channels: defaultDigestChannels,


### PR DESCRIPTION
## Summary

PR 2 of PRD-181's 4-PR sequence (the scaffold landed in #3000). Flips the pure user-facing reads on `GliaActionService` through the cerebrum pillar handle and forwards them to `@pops/cerebrum-db`'s `gliaService` namespace. Mirrors PR #3011 (engrams reads cutover).

- `action-service.ts` adds a `readDb` (`CerebrumDb`) handle alongside the existing `db` (`BetterSQLite3Database`) write handle. The pure user-facing reads — `getAction`, `listActions`, `getTrustState`, `listTrustStates`, `countRevertsInWindow`, `listAutonomousActionsInWindow`, `countAutonomousExecutionsSince`, `countAutonomousRevertsSince` — now forward through `gliaService.*` against `readDb`. Writes (`seedTrustStates`, `createAction`, `decideAction`, `executeAction`, `revertAction`, `updateTrustState`) plus the private `requireAction` read-after-write hop and the `createAction` trust-state preflight all keep going through the shared `pops.db` handle until PRD-181 US-03 flips them too.

- `instance.ts` wires `readDb` to `getCerebrumDrizzle()`. Outside tests this means reads land on `cerebrum.db` while writes stay on `pops.db`; cross-store consistency is maintained by the boot-time backfill already configured for `glia_actions` + `glia_trust_state` in `backfill-cerebrum-from-shared.ts`.

- The constructor gains an optional third positional `readDb` argument that falls back to `db`. Existing rigs that inject a single in-memory SQLite (`action-service.test.ts`, `trust-machine.test.ts`, `digest-service.test.ts`, `revert-operations.test.ts`, `autonomous-digest.test.ts`, `digest-reports.test.ts`) keep working untouched. The cerebrum pillar handle smoke harness already exercises `cerebrum.glia.actions.get`, `actions.history`, and `trustState.get` against a fresh per-pillar `cerebrum.db` and continues to pass.

Read/write split rationale is documented in `action-service.ts` top-of-file JSDoc, mirroring PR #3011's engrams pattern: pure reads forward to the package; writes plus read-after-write keep the existing TOCTOU guarantee on the shared store. Trust graduation orchestration, dispatch, and the scheduled digest renderer stay in pops-api per the PRD.

## Test plan

- [x] `pnpm -F @pops/api test src/modules/cerebrum/glia src/modules/cerebrum/__integration__` — 107/108 (the one failure is `toml-config.test.ts`, pre-existing on `origin/main`)
- [x] `pnpm -F @pops/api test` — 4940/4941 (same pre-existing toml-config failure)
- [x] `pnpm -w typecheck` — 66/66
- [x] `pnpm oxlint` — 0 errors
- [x] `pnpm oxfmt` — clean