### PR TITLE
feat(cerebrum): cut plexus reads to @pops/cerebrum-db (PRD-180 PR2)

### DIFF
--- a/apps/pops-api/src/modules/cerebrum/__integration__/cerebrum-handle-coverage.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/__integration__/cerebrum-handle-coverage.test.ts
@@ -30,11 +30,8 @@ import { createCaller, createTestDb } from '../../../shared/test-utils.js';
  * via `getCerebrumDrizzle()`.
  */
 const CEREBRUM_IGNORE = new Set<string>([
-  // `plexus_adapters` lives on the shared schema (see src/db/schema.ts) but
-  // is NOT in createTestDb's synthetic fixture. Pillar handle not involved.
-  'cerebrum.plexus.adapters.list',
-  'cerebrum.plexus.adapters.get',
-  // `reflex_executions` — same shared-only situation.
+  // `reflex_executions` — shared-only table, not in createTestDb's
+  // synthetic fixture. Pillar handle not involved.
   'cerebrum.reflex.history',
   // `embeddings_vec` is a sqlite-vec virtual table that requires the
   // extension to be loaded — createTestDb doesn't bind sqlite-vec so the
@@ -66,6 +63,7 @@ const CEREBRUM_INPUTS: PillarSmokeInputs = {
   'cerebrum.glia.getQualityScore': { engramId: 'nonexistent-engram-id' },
   'cerebrum.nudges.get': { id: 'nonexistent-nudge-id' },
   'cerebrum.plexus.adapters.get': { adapterId: 'nonexistent-adapter' },
+  'cerebrum.plexus.filters.list': { adapterId: 'nonexistent-adapter' },
   'cerebrum.reflex.get': { name: 'nonexistent-reflex-name' },
   'ego.conversations.get': { id: 'nonexistent-conversation-id' },
 };

--- a/apps/pops-api/src/modules/cerebrum/plexus/router.ts
+++ b/apps/pops-api/src/modules/cerebrum/plexus/router.ts
@@ -3,41 +3,40 @@
  *
  * Exposes adapter management and ingestion filter CRUD. The router is a thin
  * adapter over the lifecycle manager and database — no business logic here.
+ *
+ * Read/write split during the PRD-180 cutover window (PR 2):
+ *  - Pure user-facing reads — `adapters.list`, `adapters.get`, `filters.list`
+ *    — resolve through `getCerebrumDrizzle()` and forward to the
+ *    `@pops/cerebrum-db` `plexusService.{listAdapters,getAdapter,listFilters}`
+ *    namespace. These are the seam called out by PRD-180 PR 2.
+ *  - Writes (`filters.set` — atomic delete-then-insert) plus their
+ *    accompanying parent-exists guard still go through the shared
+ *    `pops.db` write handle (`getDb()`); the lifecycle-manager mutations
+ *    (`register`, `unregister`, `healthCheck`, `sync`) also stay on
+ *    `getDb()` via `lifecycle-db.ts` for read-after-write consistency.
+ *    PRD-180 US-03 flips the writes too, at which point the router can
+ *    collapse onto a single `CerebrumDb` handle and `getDb()` drops out.
+ *
+ * Cross-store consistency between the legacy `pops.db` writes and the
+ * pillar's `cerebrum.db` reads relies on the boot-time backfill in
+ * `apps/pops-api/src/db/backfill-cerebrum-from-shared.ts` — same
+ * pattern as the engrams (PRD-179 PR 2) and conversations (PRD-182
+ * PR 2) cutovers.
  */
 import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 
+import { plexusService } from '@pops/cerebrum-db';
+
 import { getDb } from '../../../db.js';
+import { getCerebrumDrizzle } from '../../../db/cerebrum-handle.js';
 import { protectedProcedure, router } from '../../../trpc.js';
 
-import type { PlexusAdapter, PlexusAdapterRow, PlexusFilter, PlexusFilterRow } from './types.js';
+import type { PlexusFilter, PlexusFilterRow } from './types.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function rowToAdapter(row: PlexusAdapterRow): PlexusAdapter {
-  let config: Record<string, unknown> | null = null;
-  if (row.config) {
-    try {
-      config = JSON.parse(row.config) as Record<string, unknown>;
-    } catch {
-      config = null;
-    }
-  }
-  return {
-    id: row.id,
-    name: row.name,
-    status: row.status,
-    config,
-    lastHealth: row.last_health,
-    lastError: row.last_error,
-    ingestedCount: row.ingested_count,
-    emittedCount: row.emitted_count,
-    createdAt: row.created_at,
-    updatedAt: row.updated_at,
-  };
-}
 
 function rowToFilter(row: PlexusFilterRow): PlexusFilter {
   return {
@@ -73,25 +72,27 @@ const setFiltersSchema = z.object({
 // ---------------------------------------------------------------------------
 
 const adaptersRouter = router({
-  /** List all registered adapters. */
+  /**
+   * List all registered adapters.
+   *
+   * Pure read — routed through the cerebrum pillar handle. See the
+   * top-of-file JSDoc for the read/write split contract.
+   */
   list: protectedProcedure.query(() => {
-    const db = getDb();
-    const rows = db
-      .prepare('SELECT * FROM plexus_adapters ORDER BY name')
-      .all() as PlexusAdapterRow[];
-    return { adapters: rows.map(rowToAdapter) };
+    return { adapters: plexusService.listAdapters(getCerebrumDrizzle()) };
   }),
 
-  /** Get a single adapter by ID. */
+  /**
+   * Get a single adapter by ID.
+   *
+   * Pure read — routed through the cerebrum pillar handle.
+   */
   get: protectedProcedure.input(adapterIdSchema).query(({ input }) => {
-    const db = getDb();
-    const row = db.prepare('SELECT * FROM plexus_adapters WHERE id = ?').get(input.adapterId) as
-      | PlexusAdapterRow
-      | undefined;
-    if (!row) {
+    const adapter = plexusService.getAdapter(getCerebrumDrizzle(), input.adapterId);
+    if (!adapter) {
       throw new TRPCError({ code: 'NOT_FOUND', message: `Adapter '${input.adapterId}' not found` });
     }
-    return { adapter: rowToAdapter(row) };
+    return { adapter };
   }),
 
   /** Run a health check on a specific adapter. */
@@ -121,16 +122,26 @@ const adaptersRouter = router({
 });
 
 const filtersRouter = router({
-  /** List filters for an adapter. */
+  /**
+   * List filters for an adapter.
+   *
+   * Pure read — routed through the cerebrum pillar handle.
+   */
   list: protectedProcedure.input(adapterIdSchema).query(({ input }) => {
-    const db = getDb();
-    const rows = db
-      .prepare('SELECT * FROM plexus_filters WHERE adapter_id = ? ORDER BY id')
-      .all(input.adapterId) as PlexusFilterRow[];
-    return { filters: rows.map(rowToFilter) };
+    return { filters: plexusService.listFilters(getCerebrumDrizzle(), input.adapterId) };
   }),
 
-  /** Replace all filters for an adapter (atomic). */
+  /**
+   * Replace all filters for an adapter (atomic).
+   *
+   * Write path — stays on the shared `pops.db` handle (`getDb()`). The
+   * parent-exists check shares the same handle so the guard sees the
+   * latest write state. Returning the freshly-written filter list off
+   * the same handle keeps the response consistent with the caller's
+   * own write; routing the post-write read through the pillar handle
+   * would surface a backfill-lag hole inside the same RPC. PRD-180
+   * US-03 collapses both onto the pillar handle.
+   */
   set: protectedProcedure.input(setFiltersSchema).mutation(({ input }) => {
     const db = getDb();
 

--- a/apps/pops-api/src/modules/cerebrum/plexus/router.ts
+++ b/apps/pops-api/src/modules/cerebrum/plexus/router.ts
@@ -4,24 +4,27 @@
  * Exposes adapter management and ingestion filter CRUD. The router is a thin
  * adapter over the lifecycle manager and database — no business logic here.
  *
- * Read/write split during the PRD-180 cutover window (PR 2):
+ * Read/write split during the cerebrum.plexus cutover window:
  *  - Pure user-facing reads — `adapters.list`, `adapters.get`, `filters.list`
  *    — resolve through `getCerebrumDrizzle()` and forward to the
  *    `@pops/cerebrum-db` `plexusService.{listAdapters,getAdapter,listFilters}`
- *    namespace. These are the seam called out by PRD-180 PR 2.
+ *    namespace. This is the read seam of the cutover.
  *  - Writes (`filters.set` — atomic delete-then-insert) plus their
  *    accompanying parent-exists guard still go through the shared
  *    `pops.db` write handle (`getDb()`); the lifecycle-manager mutations
  *    (`register`, `unregister`, `healthCheck`, `sync`) also stay on
  *    `getDb()` via `lifecycle-db.ts` for read-after-write consistency.
- *    PRD-180 US-03 flips the writes too, at which point the router can
- *    collapse onto a single `CerebrumDb` handle and `getDb()` drops out.
+ *    A follow-up cutover flips the writes too, at which point the
+ *    router can collapse onto a single `CerebrumDb` handle and
+ *    `getDb()` drops out. See PRD-180 for the broader pillar sequence;
+ *    exact phase/PR numbering is owned by that doc and may drift from
+ *    this comment.
  *
  * Cross-store consistency between the legacy `pops.db` writes and the
  * pillar's `cerebrum.db` reads relies on the boot-time backfill in
  * `apps/pops-api/src/db/backfill-cerebrum-from-shared.ts` — same
- * pattern as the engrams (PRD-179 PR 2) and conversations (PRD-182
- * PR 2) cutovers.
+ * pattern as the other cerebrum pillar cutovers (engrams,
+ * conversations).
  */
 import { TRPCError } from '@trpc/server';
 import { z } from 'zod';


### PR DESCRIPTION
## Summary

PR 2 of [PRD-180](../blob/main/docs/themes/13-pillar-finale/prds/180-cerebrum-plexus-cutover/README.md)'s cutover sequence — the plexus read seam. PR 1 (#3004) scaffolded `plexusService` in `@pops/cerebrum-db`; this PR flips the pure user-facing reads on the plexus router through the cerebrum pillar handle. Mirrors PR #3011 (engrams) and PR #3015 (conversations).

- `apps/pops-api/src/modules/cerebrum/plexus/router.ts`:
  - `adapters.list` / `adapters.get` / `filters.list` now resolve through `getCerebrumDrizzle()` and forward to `plexusService.{listAdapters, getAdapter, listFilters}`.
  - `filters.set` (atomic delete-then-insert mutation) keeps its parent-exists guard and its post-write filter-list read on the shared write handle (`getDb()`) so the response is consistent with the caller's own write inside the same RPC.
  - Top-of-file JSDoc documents the read/write split per the PR #3008 / #3011 precedent.
- The lifecycle-manager mutations (`register`, `unregister`, `healthCheck`, `sync`) and their write-adjacent reads in `lifecycle-db.ts` stay on the shared write handle until PRD-180 US-03.
- `apps/pops-api/src/modules/cerebrum/__integration__/cerebrum-handle-coverage.test.ts`: drops `cerebrum.plexus.adapters.list` / `cerebrum.plexus.adapters.get` from `CEREBRUM_IGNORE` — they now reach the per-pillar `cerebrum.db` successfully — and adds `cerebrum.plexus.filters.list` to `CEREBRUM_INPUTS` so the same coverage extends to filters.

Cross-store consistency between `pops.db` writes and `cerebrum.db` reads relies on the boot-time backfill already configured for `plexus_adapters` + `plexus_filters` in `apps/pops-api/src/db/backfill-cerebrum-from-shared.ts`.

## Out of scope (deliberate, per PRD)

- All write paths on the plexus router and `lifecycle-db.ts` — flipped in PRD-180 US-03 once the encrypted-config envelope, the TOML loader, and the per-adapter HTTP clients move to `cerebrum-api`.
- The TOML config loader (`registry.ts`), the per-adapter HTTP clients, and the lifecycle orchestrator stay in pops-api per the PRD.

## Test plan

- [x] `pnpm -F @pops/api test src/modules/cerebrum/plexus` — 54/54 pass
- [x] `pnpm -F @pops/api test src/modules/cerebrum/__integration__` — 3/3 pass (smoke harness covers `cerebrum.plexus.adapters.list`, `cerebrum.plexus.adapters.get`, `cerebrum.plexus.filters.list` via the pillar handle)
- [x] `pnpm -F @pops/api test src/modules/cerebrum` — 1128/1128 pass
- [x] `pnpm -F @pops/api test` — 4940/4941 pass (the one pre-existing failure is `glia/__tests__/toml-config.test.ts`, untouched on `origin/main`)
- [x] `pnpm -w typecheck` — 66/66 packages green
- [x] `pnpm oxlint` — 0 errors
- [x] `pnpm oxfmt --check` — clean on changed files

## PRD

`docs/themes/13-pillar-finale/prds/180-cerebrum-plexus-cutover/README.md`