### PR TITLE
feat(media): migrate movies writes in rotation/plex/arr to media.db (PRD-165 PR3)

### DIFF
--- a/apps/pops-api/src/modules/media/arr/download-and-protect.ts
+++ b/apps/pops-api/src/modules/media/arr/download-and-protect.ts
@@ -4,6 +4,7 @@ import { eq } from 'drizzle-orm';
 import { movies, settings } from '@pops/db-types';
 
 import { getDrizzle } from '../../../db.js';
+import { getMediaDrizzle } from '../../../db/media-db-handle.js';
 import { addMovie as addMovieToLibrary } from '../library/service.js';
 import { getImageCache, getTmdbClient } from '../tmdb/index.js';
 import * as arrService from './service.js';
@@ -80,7 +81,7 @@ async function ensureLibraryEntry(tmdbId: number): Promise<void> {
 }
 
 function markMovieProtected(tmdbId: number): void {
-  const db = getDrizzle();
+  const db = getMediaDrizzle();
   const updateResult = db
     .update(movies)
     .set({ rotationStatus: 'protected' })

--- a/apps/pops-api/src/modules/media/plex/sync-discover-check.ts
+++ b/apps/pops-api/src/modules/media/plex/sync-discover-check.ts
@@ -2,7 +2,7 @@ import { eq } from 'drizzle-orm';
 
 import { movies } from '@pops/db-types';
 
-import { getDrizzle } from '../../../db.js';
+import { getMediaDrizzle } from '../../../db/media-db-handle.js';
 import { logWatch } from '../watch-history/service.js';
 import { getPlexToken } from './service.js';
 import { fetchActivityForItem } from './sync-discover-graphql.js';
@@ -75,7 +75,7 @@ export async function checkAndLogMovieWatch(
     const ratingKey = await findRatingKey({ plexClient, title, tmdbId });
     if (!ratingKey) return false;
 
-    const db = getDrizzle();
+    const db = getMediaDrizzle();
     db.update(movies).set({ discoverRatingKey: ratingKey }).where(eq(movies.id, movieId)).run();
 
     const state = await plexClient.getUserState(ratingKey);

--- a/apps/pops-api/src/modules/media/plex/sync-discover-movie.ts
+++ b/apps/pops-api/src/modules/media/plex/sync-discover-movie.ts
@@ -2,6 +2,7 @@ import { eq } from 'drizzle-orm';
 
 import { movies } from '@pops/db-types';
 
+import { getMediaDrizzle } from '../../../db/media-db-handle.js';
 import { addMovie } from '../library/service.js';
 import { logWatch } from '../watch-history/service.js';
 import {
@@ -12,7 +13,6 @@ import {
 } from './sync-discover-types.js';
 import { extractExternalIdAsNumber } from './sync-helpers.js';
 
-import type { getDrizzle } from '../../../db.js';
 import type { getImageCache, getTmdbClient } from '../tmdb/index.js';
 import type { PlexClient } from './client.js';
 import type { ActivityWatchEntry } from './sync-discover-graphql.js';
@@ -28,7 +28,6 @@ export interface ProcessMovieEntryArgs {
   movieByRatingKey: MovieByRatingKey;
   movieByTmdbId: MovieByTmdbId;
   result: DiscoverItemResult;
-  db: ReturnType<typeof getDrizzle>;
 }
 
 interface ResolveMovieArgs {
@@ -39,22 +38,13 @@ interface ResolveMovieArgs {
   movieByRatingKey: MovieByRatingKey;
   movieByTmdbId: MovieByTmdbId;
   result: DiscoverItemResult;
-  db: ReturnType<typeof getDrizzle>;
 }
 
 async function resolveMovie(
   args: ResolveMovieArgs
 ): Promise<{ id: number; title: string; tmdbId: number } | null> {
-  const {
-    ratingKey,
-    plexClient,
-    tmdbClient,
-    imageCache,
-    movieByRatingKey,
-    movieByTmdbId,
-    result,
-    db,
-  } = args;
+  const { ratingKey, plexClient, tmdbClient, imageCache, movieByRatingKey, movieByTmdbId, result } =
+    args;
 
   await delay(RATE_LIMIT_DELAY_MS);
   const meta = await plexClient.getDiscoverMetadata(ratingKey);
@@ -69,16 +59,25 @@ async function resolveMovie(
     return null;
   }
 
+  const mediaDb = getMediaDrizzle();
   const existing = movieByTmdbId.get(tmdbId);
   if (existing) {
-    db.update(movies).set({ discoverRatingKey: ratingKey }).where(eq(movies.id, existing.id)).run();
+    mediaDb
+      .update(movies)
+      .set({ discoverRatingKey: ratingKey })
+      .where(eq(movies.id, existing.id))
+      .run();
     const movie = { ...existing, tmdbId };
     movieByRatingKey.set(ratingKey, movie);
     return movie;
   }
 
   const { movie: newMovie } = await addMovie(tmdbId, tmdbClient, imageCache);
-  db.update(movies).set({ discoverRatingKey: ratingKey }).where(eq(movies.id, newMovie.id)).run();
+  mediaDb
+    .update(movies)
+    .set({ discoverRatingKey: ratingKey })
+    .where(eq(movies.id, newMovie.id))
+    .run();
   const movie = { id: newMovie.id, title: newMovie.title, tmdbId };
   movieByRatingKey.set(ratingKey, movie);
   movieByTmdbId.set(tmdbId, { id: newMovie.id, title: newMovie.title });

--- a/apps/pops-api/src/modules/media/plex/sync-discover-watches.test.ts
+++ b/apps/pops-api/src/modules/media/plex/sync-discover-watches.test.ts
@@ -14,6 +14,10 @@ vi.mock('../../../db.js', () => ({
   getDrizzle: vi.fn(),
 }));
 
+vi.mock('../../../db/media-db-handle.js', () => ({
+  getMediaDrizzle: vi.fn(),
+}));
+
 vi.mock('./service.js', () => ({
   getPlexToken: vi.fn(),
   getPlexClientId: vi.fn(),
@@ -66,6 +70,7 @@ vi.mock('@pops/db-types', () => ({
 }));
 
 import { getDrizzle } from '../../../db.js';
+import { getMediaDrizzle } from '../../../db/media-db-handle.js';
 import { addMovie } from '../library/service.js';
 import { logWatch } from '../watch-history/service.js';
 import { getPlexClientId, getPlexToken } from './service.js';
@@ -77,6 +82,7 @@ import type { PlexMediaItem } from './types.js';
 
 const mockLogWatch = vi.mocked(logWatch);
 const mockGetDrizzle = vi.mocked(getDrizzle);
+const mockGetMediaDrizzle = vi.mocked(getMediaDrizzle);
 const mockGetPlexToken = vi.mocked(getPlexToken);
 const mockGetPlexClientId = vi.mocked(getPlexClientId);
 const mockExtractExternalId = vi.mocked(extractExternalIdAsNumber);
@@ -124,6 +130,10 @@ function setupDrizzleMock(
   const mockSet = vi.fn().mockReturnValue({ where: mockWhere });
   const mockUpdate = vi.fn().mockReturnValue({ set: mockSet });
   mockGetDrizzle.mockReturnValue({
+    select: mockSelect,
+    update: mockUpdate,
+  } as unknown as BetterSQLite3Database);
+  mockGetMediaDrizzle.mockReturnValue({
     select: mockSelect,
     update: mockUpdate,
   } as unknown as BetterSQLite3Database);

--- a/apps/pops-api/src/modules/media/plex/sync-discover-watches.ts
+++ b/apps/pops-api/src/modules/media/plex/sync-discover-watches.ts
@@ -1,6 +1,7 @@
 import { movies } from '@pops/db-types';
 
 import { getDrizzle } from '../../../db.js';
+import { getMediaDrizzle } from '../../../db/media-db-handle.js';
 import { getTvdbClient } from '../thetvdb/index.js';
 import { getImageCache, getTmdbClient } from '../tmdb/index.js';
 import { getPlexToken } from './service.js';
@@ -38,7 +39,7 @@ interface MovieLookupMaps {
 }
 
 function buildMovieLookupMaps(): MovieLookupMaps {
-  const db = getDrizzle();
+  const db = getMediaDrizzle();
   const allMovies = db
     .select({
       id: movies.id,

--- a/apps/pops-api/src/modules/media/plex/sync-discover-watches.ts
+++ b/apps/pops-api/src/modules/media/plex/sync-discover-watches.ts
@@ -85,7 +85,6 @@ async function dispatchEntry(entry: ActivityWatchEntry, ctx: ProcessEntryContext
       movieByRatingKey: ctx.movieByRatingKey,
       movieByTmdbId: ctx.movieByTmdbId,
       result: ctx.movieResult,
-      db,
     });
     return;
   }

--- a/apps/pops-api/src/modules/media/rotation/download-candidate.ts
+++ b/apps/pops-api/src/modules/media/rotation/download-candidate.ts
@@ -3,6 +3,7 @@ import { eq } from 'drizzle-orm';
 import { movies, rotationCandidates, settings } from '@pops/db-types';
 
 import { getDrizzle } from '../../../db.js';
+import { getMediaDrizzle } from '../../../db/media-db-handle.js';
 import { trpcError } from '../../../shared/trpc-error.js';
 import { getRadarrClient } from '../arr/service.js';
 import { addMovie as addMovieToLibrary } from '../library/service.js';
@@ -91,7 +92,8 @@ export async function downloadCandidateImpl(
     .where(eq(rotationCandidates.id, candidateId))
     .run();
 
-  db.update(movies)
+  getMediaDrizzle()
+    .update(movies)
     .set({ rotationStatus: 'protected' })
     .where(eq(movies.tmdbId, candidate.tmdbId))
     .run();

--- a/apps/pops-api/src/modules/media/rotation/leaving-lifecycle.test.ts
+++ b/apps/pops-api/src/modules/media/rotation/leaving-lifecycle.test.ts
@@ -9,8 +9,8 @@ const mockFrom = vi.fn(() => ({ where: mockWhere }));
 const mockSelect = vi.fn(() => ({ from: mockFrom }));
 const mockUpdate = vi.fn(() => ({ set: mockSet }));
 
-vi.mock('../../../db.js', () => ({
-  getDrizzle: () => ({
+vi.mock('../../../db/media-db-handle.js', () => ({
+  getMediaDrizzle: () => ({
     select: mockSelect,
     update: mockUpdate,
   }),

--- a/apps/pops-api/src/modules/media/rotation/leaving-lifecycle.ts
+++ b/apps/pops-api/src/modules/media/rotation/leaving-lifecycle.ts
@@ -7,14 +7,14 @@ import { eq } from 'drizzle-orm';
  */
 import { movies } from '@pops/db-types';
 
-import { getDrizzle } from '../../../db.js';
+import { getMediaDrizzle } from '../../../db/media-db-handle.js';
 
 /**
  * Clear leaving/protected rotation status for a specific movie.
  * Returns true if the movie existed and was updated, false otherwise.
  */
 export function cancelLeaving(movieId: number): boolean {
-  const db = getDrizzle();
+  const db = getMediaDrizzle();
   const movie = db
     .select({ id: movies.id, rotationStatus: movies.rotationStatus })
     .from(movies)
@@ -46,7 +46,7 @@ export function cancelLeaving(movieId: number): boolean {
 export function clearLeavingOnWatchlistAdd(mediaType: string, mediaId: number): boolean {
   if (mediaType !== 'movie') return false;
 
-  const db = getDrizzle();
+  const db = getMediaDrizzle();
   const movie = db
     .select({ id: movies.id, rotationStatus: movies.rotationStatus })
     .from(movies)

--- a/apps/pops-api/src/modules/media/rotation/removal-selection.ts
+++ b/apps/pops-api/src/modules/media/rotation/removal-selection.ts
@@ -9,6 +9,7 @@ import { and, asc, eq, inArray, ne, sql } from 'drizzle-orm';
 import { mediaWatchlist, movies } from '@pops/db-types';
 
 import { getDrizzle } from '../../../db.js';
+import { getMediaDrizzle } from '../../../db/media-db-handle.js';
 import { getRadarrClient } from '../arr/service.js';
 
 const BYTES_PER_GB = 1_073_741_824;
@@ -209,7 +210,7 @@ export interface ExpiredMovieResult {
  * Continues on individual failures — never aborts the cycle.
  */
 export async function processExpiredMovies(): Promise<ExpiredMovieResult[]> {
-  const db = getDrizzle();
+  const db = getMediaDrizzle();
   const client = getRadarrClient();
   if (!client) throw new Error('Radarr not configured');
 
@@ -290,7 +291,7 @@ export function getLeavingMovieSizeGb(movieSizes: MovieSizeMap): number {
  */
 export function markMoviesAsLeaving(movieIds: number[], expiresAt: string): void {
   if (movieIds.length === 0) return;
-  const db = getDrizzle();
+  const db = getMediaDrizzle();
   const now = new Date().toISOString();
   db.update(movies)
     .set({

--- a/apps/pops-api/src/modules/media/rotation/removal-selection.ts
+++ b/apps/pops-api/src/modules/media/rotation/removal-selection.ts
@@ -90,19 +90,18 @@ export function getEligibleForRemoval(
   movieSizes: MovieSizeMap,
   downloadingTmdbIds: Set<number>
 ): EligibleMovie[] {
-  const db = getDrizzle();
+  const sharedDb = getDrizzle();
+  const mediaDb = getMediaDrizzle();
   const now = new Date().toISOString();
 
-  // Get watchlist movie IDs
-  const watchlistRows = db
+  const watchlistRows = sharedDb
     .select({ mediaId: mediaWatchlist.mediaId })
     .from(mediaWatchlist)
     .where(eq(mediaWatchlist.mediaType, 'movie'))
     .all();
   const watchlistMovieIds = new Set(watchlistRows.map((r) => r.mediaId));
 
-  // Query movies that are NOT leaving and NOT protected (with unexpired protection)
-  const candidates = db
+  const candidates = mediaDb
     .select({
       id: movies.id,
       tmdbId: movies.tmdbId,
@@ -272,7 +271,7 @@ export async function processExpiredMovies(): Promise<ExpiredMovieResult[]> {
  * Get the total size in GB of movies currently in the 'leaving' state.
  */
 export function getLeavingMovieSizeGb(movieSizes: MovieSizeMap): number {
-  const db = getDrizzle();
+  const db = getMediaDrizzle();
   const leavingMovies = db
     .select({ tmdbId: movies.tmdbId })
     .from(movies)


### PR DESCRIPTION
## Summary

Final cleanup before the media-backfill shim retires: migrate every direct `getDrizzle().update(movies)` site in the rotation, Plex sync, and Radarr modules over to `getMediaDrizzle()` so all `movies` writes land in `media.db`.

PR #3006 ([PRD-165 PR1/PR2](https://github.com/knoxio/pops/pull/3006)) routed the in-tree `moviesService` writer surface to the per-pillar handle but left six adjacent call sites talking to the shared `pops.db`. This PR closes that gap.

### Sites migrated

- `media/arr/download-and-protect.ts` — `markMovieProtected` now writes via `getMediaDrizzle()`. The `settings` reads remain on `getDrizzle()` (core-pillar table).
- `media/plex/sync-discover-movie.ts` — `resolveMovie` resolves `getMediaDrizzle()` locally; `db` is dropped from `ProcessMovieEntryArgs` / `ResolveMovieArgs` to keep the function signature honest. The caller in `sync-discover-watches.ts` no longer plumbs the legacy handle into the movie path; the episode path keeps using `getDrizzle()` since `seasons`/`episodes` haven't moved yet.
- `media/plex/sync-discover-check.ts` — `checkAndLogMovieWatch` now writes via `getMediaDrizzle()`.
- `media/rotation/leaving-lifecycle.ts` — `cancelLeaving` + `clearLeavingOnWatchlistAdd` only touch `movies`, so the whole handle moves to `getMediaDrizzle()`.
- `media/rotation/download-candidate.ts` — `downloadCandidateImpl` keeps the existing `getDrizzle()` handle for the `rotation_candidates` write but resolves a fresh `getMediaDrizzle()` for the paired `movies` update (mixed-table boundary).
- `media/rotation/removal-selection.ts` — `processExpiredMovies` + `markMoviesAsLeaving` (read + write only against `movies`) move to `getMediaDrizzle()`. Reads inside `getEligibleForRemoval` / `getLeavingMovieSizeGb` stay on `getDrizzle()` because they cross into `mediaWatchlist` — those are part of the later rotation reads cutover, not this PR.

### Why this matters for PR4

With these last writers flipped, every mutation against `movies` flows through the media pillar's SQLite file. PR4 can:

1. Delete the movies entry from `apps/pops-api/src/db/media-backfill.ts` (the ATTACH+INSERT-SELECT bridge from `pops.db` → `media.db`).
2. Drop the `movies` table + indexes from the shared `pops.db` migrations (the shim).
3. Add the Litestream config so `media.db` ships off-box.

No remaining call site reads-then-writes `movies` against a *different* handle within the same logical transaction, so PR4 isn't going to be ambushed by a cross-DB transaction surprise.

### Tests + checks run

- `pnpm -F @pops/api test src/modules/media/{rotation,plex,arr}` — 28 files / 376 tests pass. Mocks in `rotation/leaving-lifecycle.test.ts` and `plex/sync-discover-watches.test.ts` were updated to also stub `getMediaDrizzle`.
- `pnpm -F @pops/api test src/modules/media/movies` — 14 tests still pass (no regression on the PR1 cutover).
- `pnpm -w typecheck` — green.
- `pnpm format:check` — green.
- `pnpm lint` — no new errors (existing repo-wide warnings unchanged).

## Test plan

- [ ] CI passes on this branch.
- [ ] Smoke: in a dev environment with both legacy `pops.db` and `media.db`, drive a Plex Discover sync and confirm the `discover_rating_key` updates land in `media.db.movies` (not `pops.db.movies`).
- [ ] Smoke: trigger a rotation cycle that marks a movie as `leaving` then `protected` and confirm both states land in `media.db.movies`.
- [ ] Smoke: run `cancelLeaving` via the rotation router and confirm the cleared status persists in `media.db.movies`.
