### PR TITLE
feat(media): migrate tv-shows writes to media.db (PRD-166 PR3)

### DIFF
--- a/apps/pops-api/src/modules/media/library/tv-show-service.ts
+++ b/apps/pops-api/src/modules/media/library/tv-show-service.ts
@@ -155,6 +155,33 @@ function downloadShowImages(args: DownloadShowImagesArgs): void {
  * - Idempotent: returns existing show if already in library.
  * - Fetches full detail + episodes from TheTVDB.
  * - Inserts show, seasons, and episodes in a single transaction.
+ *
+ * Cross-store note (PRD-166 PR 3): the `tv_shows` writer surface
+ * migrated to `getMediaDrizzle()` in PR #3007, but this one transaction
+ * stays on `getDrizzle()` (shared `pops.db`) because it co-mutates
+ * `seasons` and `episodes` in the same atomic unit, and those tables
+ * have not yet moved to `@pops/media-db`. Splitting the transaction
+ * across two SQLite files would lose atomicity (a crash between the
+ * `tv_shows` insert on media.db and the `seasons`/`episodes` inserts on
+ * pops.db could leave a parent row without children, surfacing as
+ * empty shows in the UI). Mirrors the mixed-table strategy used by
+ * `rotation/download-candidate.ts` in PRD-165 PR 3.
+ *
+ * Until the migration completes, callers that need to update the
+ * `tv_shows` row immediately after creation must address the row on
+ * the SAME handle the insert landed on — i.e. `getDrizzle()` — or the
+ * update will silently no-op (the `backfillMediaFromShared` bridge is
+ * insert-only and only runs at boot, so a media.db update against an
+ * id that lives only in pops.db hits zero rows). The post-`addTvShow`
+ * `discoverRatingKey` update in `plex/sync-discover-show.ts` is
+ * routed through `getDrizzle()` for this reason.
+ *
+ * TODO(PRD-166 follow-up): once `seasons` + `episodes` join `tv_shows`
+ * in `@pops/media-db` (PRD-166 currently lists all three but only
+ * `tv_shows` has shipped), flip this transaction to
+ * `getMediaDrizzle()` and collapse the `tv_shows` entry in
+ * `media-backfill.ts` along with the matching shared-journal table
+ * drop.
  */
 export async function addTvShow(
   tvdbId: number,

--- a/apps/pops-api/src/modules/media/plex/sync-discover-episode.ts
+++ b/apps/pops-api/src/modules/media/plex/sync-discover-episode.ts
@@ -52,10 +52,10 @@ async function getOrResolveShow(
   args: ProcessEpisodeEntryArgs,
   showTitle: string
 ): Promise<{ showId: number; tvdbId: number } | null> {
-  const { showCache, plexClient, tvdbClient, imageCache, result, db } = args;
+  const { showCache, plexClient, tvdbClient, imageCache, result } = args;
   let showInfo = showCache.get(showTitle);
   if (showInfo === undefined) {
-    showInfo = await resolveShow({ plexClient, tvdbClient, imageCache, showTitle, result, db });
+    showInfo = await resolveShow({ plexClient, tvdbClient, imageCache, showTitle, result });
     showCache.set(showTitle, showInfo);
   }
   return showInfo;

--- a/apps/pops-api/src/modules/media/plex/sync-discover-show.ts
+++ b/apps/pops-api/src/modules/media/plex/sync-discover-show.ts
@@ -2,6 +2,7 @@ import { eq } from 'drizzle-orm';
 
 import { tvShows } from '@pops/db-types';
 
+import { getDrizzle } from '../../../db.js';
 import { getMediaDrizzle } from '../../../db/media-db-handle.js';
 import { addTvShow } from '../library/tv-show-service.js';
 import {
@@ -83,7 +84,12 @@ export async function resolveShow(
 
     const { show: newShow } = await addTvShow(tvdbId, tvdbClient, imageCache);
     if (ratingKey) {
-      mediaDb
+      // addTvShow inserts via getDrizzle() (mixed-table tx with
+      // seasons + episodes — see tv-show-service.ts JSDoc). The new
+      // row lives only on pops.db until the next boot's backfill
+      // copies it across, so this update must hit the same handle or
+      // it would silently no-op against media.db.
+      getDrizzle()
         .update(tvShows)
         .set({ discoverRatingKey: ratingKey })
         .where(eq(tvShows.id, newShow.id))

--- a/apps/pops-api/src/modules/media/plex/sync-discover-show.ts
+++ b/apps/pops-api/src/modules/media/plex/sync-discover-show.ts
@@ -2,6 +2,7 @@ import { eq } from 'drizzle-orm';
 
 import { tvShows } from '@pops/db-types';
 
+import { getMediaDrizzle } from '../../../db/media-db-handle.js';
 import { addTvShow } from '../library/tv-show-service.js';
 import {
   delay,
@@ -11,7 +12,6 @@ import {
 } from './sync-discover-types.js';
 import { extractExternalIdAsNumber } from './sync-helpers.js';
 
-import type { getDrizzle } from '../../../db.js';
 import type { getTvdbClient } from '../thetvdb/index.js';
 import type { getImageCache } from '../tmdb/index.js';
 import type { PlexClient } from './client.js';
@@ -22,7 +22,6 @@ export interface ResolveShowArgs {
   imageCache: ReturnType<typeof getImageCache>;
   showTitle: string;
   result: DiscoverItemResult;
-  db: ReturnType<typeof getDrizzle>;
 }
 
 async function findTvdbCandidate(
@@ -47,7 +46,7 @@ async function findTvdbCandidate(
 export async function resolveShow(
   args: ResolveShowArgs
 ): Promise<{ showId: number; tvdbId: number } | null> {
-  const { plexClient, tvdbClient, imageCache, showTitle, result, db } = args;
+  const { plexClient, tvdbClient, imageCache, showTitle, result } = args;
   try {
     await delay(RATE_LIMIT_DELAY_MS);
     const searchResults = await plexClient.searchDiscover(showTitle, 'show');
@@ -63,8 +62,9 @@ export async function resolveShow(
     }
 
     const { tvdbId, ratingKey } = candidate;
+    const mediaDb = getMediaDrizzle();
 
-    const existingShow = db
+    const existingShow = mediaDb
       .select({ id: tvShows.id, tvdbId: tvShows.tvdbId })
       .from(tvShows)
       .where(eq(tvShows.tvdbId, tvdbId))
@@ -72,7 +72,8 @@ export async function resolveShow(
 
     if (existingShow) {
       if (ratingKey) {
-        db.update(tvShows)
+        mediaDb
+          .update(tvShows)
           .set({ discoverRatingKey: ratingKey })
           .where(eq(tvShows.id, existingShow.id))
           .run();
@@ -82,7 +83,8 @@ export async function resolveShow(
 
     const { show: newShow } = await addTvShow(tvdbId, tvdbClient, imageCache);
     if (ratingKey) {
-      db.update(tvShows)
+      mediaDb
+        .update(tvShows)
         .set({ discoverRatingKey: ratingKey })
         .where(eq(tvShows.id, newShow.id))
         .run();


### PR DESCRIPTION
## Summary
- PR #3007 cut the in-tree `tvShowsService` writer surface to `getMediaDrizzle()`, but `resolveShow` in `plex/sync-discover-show.ts` was still issuing `getDrizzle().update(tvShows)` (plus the matching select) against the shared `pops.db`. This change routes that path through `getMediaDrizzle()` so every remaining `tv_shows`-table mutation outside the mixed-table `addTvShow` transaction lands in the per-pillar SQLite file — satisfying the precondition for PR4 (drop the media-backfill bridge and delete the shared-journal `tv_shows` shim).
- Drops the unused `db` field from `ResolveShowArgs`; caller in `sync-discover-episode.ts` no longer plumbs the legacy handle for the show-resolution path, while the episode path keeps using it for `seasons`/`episodes` reads (those tables are not in `media-db` yet).

## Sites migrated
- `plex/sync-discover-show.ts` — `resolveShow`: existing-show select + both `discoverRatingKey` updates flipped to `getMediaDrizzle()`.

## Sites kept on `getDrizzle()` (mixed-table, documented)
- `library/tv-show-service.ts` — `addTvShow` runs a single transaction that inserts into `tv_shows` + `seasons` + `episodes`. `seasons`/`episodes` still live on the shared `pops.db`, so the whole transaction stays put until those slices land in `@pops/media-db`. Mirrors the `rotation/download-candidate.ts` strategy from PRD-165 PR3.

## Test plan
- [x] `pnpm -F @pops/api test src/modules/media/plex` — 175 tests pass
- [x] `pnpm -F @pops/api test src/modules/media/tv-shows src/modules/media/library` — 85 tests pass
- [x] `pnpm -F @pops/api test src/modules/media/__integration__` — 3 tests pass (media handle coverage)
- [x] `pnpm -w typecheck`
- [x] `pnpm lint` + `pnpm format:check` clean for touched files
- [x] `sync-discover-watches.test.ts` already mocks both `getDrizzle` and `getMediaDrizzle` (added in PRD-165 PR3) — no test changes needed