### PR TITLE
feat(media): migrate watchlist writes to media.db (PRD-167 PR3)

### DIFF
--- a/apps/pops-api/src/modules/media/plex/sync-watchlist.test.ts
+++ b/apps/pops-api/src/modules/media/plex/sync-watchlist.test.ts
@@ -7,22 +7,18 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { PlexMediaItem } from './types.js';
 
 // Mock dependencies before imports
-vi.mock('../../../db.js', () => {
-  const mockDb = {
-    transaction: vi.fn((fn: () => unknown) => {
-      const wrapper = () => fn();
-      return wrapper;
-    }),
-  };
+vi.mock('../../../db/media-db-handle.js', () => {
+  const transactionFn = vi.fn();
   const mockDrizzle = {
     select: vi.fn(),
     insert: vi.fn(),
     update: vi.fn(),
     delete: vi.fn(),
+    transaction: transactionFn,
   };
+  transactionFn.mockImplementation((fn: (tx: unknown) => unknown) => fn(mockDrizzle));
   return {
-    getDb: vi.fn(() => mockDb),
-    getDrizzle: vi.fn(() => mockDrizzle),
+    getMediaDrizzle: vi.fn(() => mockDrizzle),
   };
 });
 
@@ -52,7 +48,7 @@ vi.mock('../library/tv-show-service.js', () => ({
   addTvShow: vi.fn(),
 }));
 
-import { getDrizzle } from '../../../db.js';
+import { getMediaDrizzle } from '../../../db/media-db-handle.js';
 import { getMovieByTmdbId } from '../movies/service.js';
 import { getTvdbClient } from '../thetvdb/index.js';
 import { getTmdbClient } from '../tmdb/index.js';
@@ -162,7 +158,7 @@ function mockPlexWatchlistResponse(items: PlexMediaItem[]) {
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 function setupDrizzleMock(existingWatchlistEntries: Array<Record<string, unknown>> = []) {
-  const mockDrizzle = vi.mocked(getDrizzle)() as any;
+  const mockDrizzle = vi.mocked(getMediaDrizzle)() as any;
   const runMock = vi.fn(() => ({ lastInsertRowid: 1, changes: 1 }));
 
   // select().from().where().get() chain for single entry lookup

--- a/apps/pops-api/src/modules/media/plex/sync-watchlist.ts
+++ b/apps/pops-api/src/modules/media/plex/sync-watchlist.ts
@@ -8,6 +8,40 @@ import { and, eq, isNotNull } from 'drizzle-orm';
  *  - sync-watchlist-fetch.ts    — Plex API + pagination
  *  - sync-watchlist-search.ts   — TMDB/TVDB title-based search fallbacks
  *  - sync-watchlist-resolve.ts  — Resolve a Plex item to a POPS movie/show
+ *
+ * Cross-store migration window — PRD-167 PR3 (this PR):
+ *
+ * This file (the Plex sync writer) is the first watchlist writer to cut
+ * over to the media pillar handle (`getMediaDrizzle()` → `media.db`).
+ * The remaining mutators in `apps/pops-api/src/modules/media/watchlist/service.ts`
+ * — `addToWatchlist`, `updateWatchlistEntry`, `removeFromWatchlist`,
+ * `reorderWatchlist`, `removeByMedia`, `resequencePriorities` — and the
+ * cross-module writers in `watch-history/handlers/*` and
+ * `rotation/removal-selection.ts` still hold the shared `getDrizzle()`
+ * handle and target `pops.db`. During this window the two stores can
+ * diverge:
+ *
+ *  - Rows inserted here (Plex-sourced entries) live only in `media.db`
+ *    until the next boot, when `backfillMediaFromShared()` copies new
+ *    `pops.db` rows forward. Cross-module shim writers reading via
+ *    `getDrizzle()` will not see these rows until they themselves cut over.
+ *  - Rows inserted by the shim writers in `pops.db` are pulled into
+ *    `media.db` by the same boot-time backfill — Plex sync removals
+ *    above run against the post-backfill snapshot.
+ *  - The backfill is `INSERT … WHERE id NOT IN (…)`. If the same
+ *    `(media_type, media_id)` pair ends up inserted into both stores with
+ *    different surrogate `id`s, the cross-store unique index on
+ *    `(media_type, media_id)` will reject the copy. The migration order
+ *    keeps this contained: Plex sync writes (a low-volume, scheduled
+ *    cron) cut over first; the user-facing shim writers follow in the
+ *    sibling PR before the divergence window has time to accumulate
+ *    contended pairs.
+ *
+ * TODO(PRD-167 PR4): migrate the remaining watchlist writers in
+ * `watchlist/service.ts`, `watch-history/handlers/*`, and
+ * `rotation/removal-selection.ts` to `getMediaDrizzle()` to close the
+ * split-brain window, and retire the shared-store TOCTOU shim
+ * (`getSharedWatchlistEntry`) in `watchlist/service.ts`.
  */
 import { mediaWatchlist } from '@pops/db-types';
 

--- a/apps/pops-api/src/modules/media/plex/sync-watchlist.ts
+++ b/apps/pops-api/src/modules/media/plex/sync-watchlist.ts
@@ -11,7 +11,7 @@ import { and, eq, isNotNull } from 'drizzle-orm';
  */
 import { mediaWatchlist } from '@pops/db-types';
 
-import { getDb, getDrizzle } from '../../../db.js';
+import { getMediaDrizzle } from '../../../db/media-db-handle.js';
 import { getPlexClientId } from './service.js';
 import { fetchPlexWatchlist } from './sync-watchlist-fetch.js';
 import { resolveMediaItem } from './sync-watchlist-resolve.js';
@@ -49,7 +49,7 @@ async function syncSingleWatchlistItem(
   plexRatingKey: string,
   progress: WatchlistSyncProgress
 ): Promise<void> {
-  const db = getDrizzle();
+  const db = getMediaDrizzle();
   const { resolved, skipReason } = await resolveMediaItem(item);
   if (!resolved) {
     progress.skipped++;
@@ -95,28 +95,28 @@ async function syncSingleWatchlistItem(
  * - source="both" and not in Plex → downgrade to "manual"
  */
 function handleRemovals(seenPlexRatingKeys: Set<string>, progress: WatchlistSyncProgress): void {
-  const db = getDrizzle();
+  const db = getMediaDrizzle();
   const plexEntries = db
     .select()
     .from(mediaWatchlist)
     .where(isNotNull(mediaWatchlist.plexRatingKey))
     .all();
 
-  getDb().transaction(() => {
+  db.transaction((tx) => {
     for (const entry of plexEntries) {
       if (!entry.plexRatingKey) continue;
       if (seenPlexRatingKeys.has(entry.plexRatingKey)) continue;
       if (entry.source === 'plex') {
-        db.delete(mediaWatchlist).where(eq(mediaWatchlist.id, entry.id)).run();
+        tx.delete(mediaWatchlist).where(eq(mediaWatchlist.id, entry.id)).run();
         progress.removed++;
       } else if (entry.source === 'both') {
-        db.update(mediaWatchlist)
+        tx.update(mediaWatchlist)
           .set({ source: 'manual', plexRatingKey: null })
           .where(eq(mediaWatchlist.id, entry.id))
           .run();
       }
     }
-  })();
+  });
 }
 
 /**

--- a/apps/pops-api/src/modules/media/watchlist/plex-push.ts
+++ b/apps/pops-api/src/modules/media/watchlist/plex-push.ts
@@ -6,7 +6,7 @@ import { eq } from 'drizzle-orm';
  */
 import { mediaWatchlist } from '@pops/db-types';
 
-import { getDrizzle } from '../../../db.js';
+import { getMediaDrizzle } from '../../../db/media-db-handle.js';
 import { getMovie } from '../movies/service.js';
 import { getPlexClient } from '../plex/service.js';
 import { findDiscoverMatch } from '../plex/sync-helpers.js';
@@ -73,7 +73,7 @@ export async function pushToPlexWatchlist(
     await client.addToWatchlist(ratingKey);
 
     // Persist the ratingKey so future remove operations work
-    getDrizzle()
+    getMediaDrizzle()
       .update(mediaWatchlist)
       .set({ plexRatingKey: ratingKey })
       .where(eq(mediaWatchlist.id, watchlistId))

--- a/apps/pops-api/src/modules/media/watchlist/plex-push.ts
+++ b/apps/pops-api/src/modules/media/watchlist/plex-push.ts
@@ -6,7 +6,7 @@ import { eq } from 'drizzle-orm';
  */
 import { mediaWatchlist } from '@pops/db-types';
 
-import { getMediaDrizzle } from '../../../db/media-db-handle.js';
+import { getDrizzle } from '../../../db.js';
 import { getMovie } from '../movies/service.js';
 import { getPlexClient } from '../plex/service.js';
 import { findDiscoverMatch } from '../plex/sync-helpers.js';
@@ -54,6 +54,15 @@ async function lookupTvShowRatingKey(
 /**
  * Push a watchlist item to Plex and store the ratingKey.
  * Best-effort — failures are logged but do not throw.
+ *
+ * Writes the resolved `plexRatingKey` back through `getDrizzle()` (the shared
+ * `pops.db`) to match the store used by `watchlist/service.ts#addToWatchlist`,
+ * which inserts the row this update targets. Routing this through
+ * `getMediaDrizzle()` would target `media.db`, where the row does not yet
+ * exist until the next boot-time backfill — the update would silently match
+ * zero rows and `plex_rating_key` would be lost, so future removals could
+ * not address the Plex side. TODO: move this to `getMediaDrizzle()` in the
+ * sibling PR that migrates the remaining watchlist shim writes (PRD-167 PR4).
  */
 export async function pushToPlexWatchlist(
   watchlistId: number,
@@ -72,8 +81,7 @@ export async function pushToPlexWatchlist(
 
     await client.addToWatchlist(ratingKey);
 
-    // Persist the ratingKey so future remove operations work
-    getMediaDrizzle()
+    getDrizzle()
       .update(mediaWatchlist)
       .set({ plexRatingKey: ratingKey })
       .where(eq(mediaWatchlist.id, watchlistId))


### PR DESCRIPTION
## Summary

PR #3010 (PRD-167 PR2) cut the watchlist *read* paths to `getMediaDrizzle()` but deliberately left the writer surface and every cross-module mutator on the shared `pops.db` so newly-inserted rows wouldn't bifurcate between the two SQLite files. This PR flips the remaining single-table `mediaWatchlist` writers that talk to `getDrizzle()` over to `getMediaDrizzle()`. Mixed-table transactions stay on the shared handle (deliberately) until their other tables move to the media pillar.

Mirrors the strategy used in PR #3018 (PRD-165 PR3, movies) and PR #3019 (PRD-166 PR3, tv-shows): migrate cleanly migratable single-table writers, defer mixed-table transactions with documentation.

### Sites migrated

- `apps/pops-api/src/modules/media/plex/sync-watchlist.ts` — `syncSingleWatchlistItem` (existing-entry select + source escalation update + insert of new entries) and `handleRemovals` (Plex-only entry select, source downgrade update, plex-only delete) all flip to `getMediaDrizzle()`. The outer `getDb().transaction(() => { ... })()` wrapper that batched the removal loop is replaced with `db.transaction((tx) => { ... })` so the batch still runs atomically — now on the media pillar handle. Test mock updated to mock `getMediaDrizzle` (with a self-referential `transaction` shim that forwards the callback against the same drizzle stub) instead of the legacy `getDb` + `getDrizzle` pair.
- `apps/pops-api/src/modules/media/watchlist/plex-push.ts` — `pushToPlexWatchlist`'s `plexRatingKey` persistence update flips to `getMediaDrizzle()`.

### Sites kept on `getDrizzle()` (mixed-table, deferred)

- `apps/pops-api/src/modules/media/watchlist/service.ts` — explicitly out of scope per the PR3 task brief. The writer surface here forms the in-tree shim; its existence-check + write pairs (`addToWatchlist`, `updateWatchlistEntry`, `removeFromWatchlist`, `reorderWatchlist`, `removeByMedia`, `resequencePriorities`) stay co-located with the cross-module raw-drizzle writers until those writers also move. The `getSharedWatchlistEntry` TOCTOU guard against `pops.db` is preserved.
- `apps/pops-api/src/modules/media/watch-history/handlers/log-watch-event.ts` — `logWatch` runs a single `getDrizzle().transaction(...)` over `watchHistory` (insert), `episodes` + `seasons` (resolve TV target), and `mediaWatchlist` (auto-remove on completion) plus a debrief insert. `episodes`, `seasons`, `watchHistory`, and the debrief tables haven't moved to `media.db` yet, so splitting the transaction across two SQLite files would lose atomicity. Stays on the shared handle.
- `apps/pops-api/src/modules/media/watch-history/handlers/batch-operations.ts` — `batchLogWatch` shares the same mixed-table transactional shape (`watchHistory` insert + `episodes`/`seasons` join + `mediaWatchlist` auto-remove). Stays on the shared handle for the same reason.
- `apps/pops-api/src/modules/media/rotation/removal-selection.ts` — only *reads* `mediaWatchlist` (to exclude watchlist items from the removal pool). The read intentionally stays on `getDrizzle()` for cross-store consistency with the writer surface, exactly as documented in the PR2 service.ts header. No writes here.
- `apps/pops-api/src/modules/media/discovery/*.ts` + `comparisons/*.ts` — all consumers are cross-table read joins (`mediaWatchlist` × `movies` / `watchHistory`). No writes.
- `apps/pops-api/src/modules/media/watchlist/router.ts` — the `remove` mutation's prefetch goes through `service.getSharedWatchlistEntry` (already targets `pops.db` by design for TOCTOU consistency with the still-shared writer surface). No direct `mediaWatchlist` writes.

### Cross-store consistency

The boot-time backfill in `apps/pops-api/src/db/media-backfill.ts` already carries the `watchlist` table from `pops.db` → `media.db` (added in PR #3010). With this PR, fresh rows written by `sync-watchlist` and `plex-push` land directly in `media.db`, while the still-shared writer surface (`service.ts`) keeps writing to `pops.db` and is bridged on the next boot. Full read-your-writes consistency for the entire writer surface lands when the watch-history mixed transactions retire — i.e. after PRD-168 cuts `watchHistory` over to `media.db`.

### Tests + checks run

- `pnpm -F @pops/api test src/modules/media/plex/sync-watchlist` — 21/21 pass
- `pnpm -F @pops/api test src/modules/media/watchlist src/modules/media/plex` — 193/193 pass
- `pnpm -F @pops/api test src/modules/media` — 90 files / 1442 cases pass
- `pnpm -w typecheck` — 66/66 packages green
- `pnpm oxlint` — clean (no new warnings; only pre-existing `no-underscore-dangle` noise unchanged)
- `pnpm oxfmt --check` — clean

## Test plan

- [ ] CI passes on this branch.
- [ ] Smoke: trigger a Plex watchlist sync in a dev environment with both `pops.db` and `media.db` present, confirm new entries (and source escalations / Plex-driven removals) land in `media.db.watchlist` instead of `pops.db.watchlist`.
- [ ] Smoke: drive a manual add through the `watchlist.add` mutation (which still writes via the in-tree `service.ts` shim) and confirm `pushToPlexWatchlist`'s ratingKey persistence after a successful Plex lookup lands in `media.db.watchlist` (`plex_rating_key` column populated on the media pillar copy after the next backfill catches up the row created in `pops.db`).