### PR TITLE
feat(cerebrum): migrate engrams writes to cerebrum.db (PRD-179 PR3)

### DIFF
--- a/apps/pops-api/src/jobs/handlers/curation.test.ts
+++ b/apps/pops-api/src/jobs/handlers/curation.test.ts
@@ -60,6 +60,10 @@ vi.mock('../../db.js', () => ({
   getDrizzle: () => ({}),
 }));
 
+vi.mock('../../db/cerebrum-handle.js', () => ({
+  getCerebrumDrizzle: () => ({}),
+}));
+
 const { process: processJob } = await import('./curation.js');
 
 function makeJob(data: Record<string, unknown>): Job {

--- a/apps/pops-api/src/jobs/handlers/curation.ts
+++ b/apps/pops-api/src/jobs/handlers/curation.ts
@@ -11,7 +11,7 @@
  */
 import pino from 'pino';
 
-import { getDrizzle } from '../../db.js';
+import { getCerebrumDrizzle } from '../../db/cerebrum-handle.js';
 import { createScopeReconciliationService } from '../../modules/cerebrum/engrams/scope-reconciliation.js';
 import { listScopes } from '../../modules/cerebrum/engrams/scopes-router.js';
 import { CortexClassifier } from '../../modules/cerebrum/ingest/classifier.js';
@@ -156,7 +156,7 @@ async function resolveScopes(
     const reconciler = createScopeReconciliationService();
     const { suggestions } = reconciler.reconcile({
       suggestedScopes: engram.scopes,
-      knownScopes: listScopes(getDrizzle()),
+      knownScopes: listScopes(getCerebrumDrizzle()),
       dismissedSegmentSetKeys: dismissedKeys,
     });
     return { scopes: engram.scopes, reconciled: true, suggestions };

--- a/apps/pops-api/src/modules/cerebrum/engrams/handlers/archive-engram.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/handlers/archive-engram.ts
@@ -1,15 +1,15 @@
 import { existsSync, mkdirSync, readFileSync, unlinkSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 
+import { type CerebrumDb } from '@pops/cerebrum-db';
+
 import { parseEngramFile, serializeEngram } from '../file.js';
 import { ARCHIVE_DIR, absolutePath, parseCustomFields, writeFileAtomic } from './fs-helpers.js';
 import { getIndexRow, upsertIndex } from './upsert-index.js';
 
-import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
-
 export type ArchiveDeps = {
   root: string;
-  db: BetterSQLite3Database;
+  db: CerebrumDb;
   now: () => Date;
 };
 

--- a/apps/pops-api/src/modules/cerebrum/engrams/handlers/change-type.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/handlers/change-type.test.ts
@@ -42,7 +42,7 @@ describe('EngramService.changeType (PRD-081 US-03 AC #6)', () => {
     seedDefaultTemplates(templatesDir);
     service = new EngramService({
       root,
-      db: drizzle(db),
+      db: drizzle<Record<string, unknown>>(db),
       templates: new TemplateRegistry(templatesDir),
       now: makeClock(),
     });

--- a/apps/pops-api/src/modules/cerebrum/engrams/handlers/change-type.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/handlers/change-type.ts
@@ -14,16 +14,16 @@
  */
 import { existsSync, readFileSync, unlinkSync } from 'node:fs';
 
+import { type CerebrumDb } from '@pops/cerebrum-db';
+
 import { ValidationError } from '../../../../shared/errors.js';
 import { parseEngramFile, serializeEngram } from '../file.js';
 import { absolutePath, assertSafeType, parseCustomFields, writeFileAtomic } from './fs-helpers.js';
 import { getIndexRow, upsertIndex } from './upsert-index.js';
 
-import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
-
 export type ChangeTypeDeps = {
   root: string;
-  db: BetterSQLite3Database;
+  db: CerebrumDb;
   now: () => Date;
 };
 

--- a/apps/pops-api/src/modules/cerebrum/engrams/handlers/create-engram.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/handlers/create-engram.ts
@@ -1,3 +1,5 @@
+import { type CerebrumDb } from '@pops/cerebrum-db';
+
 import { ValidationError } from '../../../../shared/errors.js';
 import { applyTemplate } from '../../templates/apply.js';
 import { serializeEngram } from '../file.js';
@@ -5,15 +7,13 @@ import { generateEngramId } from '../id.js';
 import { absolutePath, assertSafeType, dedupe, isIdTaken, writeFileAtomic } from './fs-helpers.js';
 import { upsertIndex } from './upsert-index.js';
 
-import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
-
 import type { TemplateRegistry } from '../../templates/registry.js';
 import type { EngramFrontmatter, EngramSource } from '../schema.js';
 import type { ScopeRuleEngine } from '../scope-rules.js';
 
 export type CreateDeps = {
   root: string;
-  db: BetterSQLite3Database;
+  db: CerebrumDb;
   templates: TemplateRegistry;
   scopeRuleEngine?: ScopeRuleEngine;
   now: () => Date;

--- a/apps/pops-api/src/modules/cerebrum/engrams/handlers/delete-engram.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/handlers/delete-engram.ts
@@ -11,17 +11,16 @@ import { existsSync, readFileSync, unlinkSync } from 'node:fs';
 
 import { eq } from 'drizzle-orm';
 
+import { type CerebrumDb } from '@pops/cerebrum-db';
 import { engramIndex, engramLinks } from '@pops/db-types';
 
 import { parseEngramFile, serializeEngram } from '../file.js';
 import { absolutePath, parseCustomFields, writeFileAtomic } from './fs-helpers.js';
 import { findIndexRow, upsertIndex } from './upsert-index.js';
 
-import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
-
 export type DeleteDeps = {
   root: string;
-  db: BetterSQLite3Database;
+  db: CerebrumDb;
   now: () => Date;
 };
 
@@ -81,7 +80,7 @@ export function deleteEngram(deps: DeleteDeps, id: string): DeleteResult {
  * actually reference the target.
  */
 function stripFrontmatterLink(
-  deps: { root: string; db: BetterSQLite3Database; now: () => Date },
+  deps: { root: string; db: CerebrumDb; now: () => Date },
   sourceId: string,
   targetId: string
 ): boolean {

--- a/apps/pops-api/src/modules/cerebrum/engrams/handlers/fs-helpers.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/handlers/fs-helpers.ts
@@ -11,11 +11,10 @@ import { dirname, join, relative, sep } from 'node:path';
 
 import { eq } from 'drizzle-orm';
 
+import { type CerebrumDb } from '@pops/cerebrum-db';
 import { engramIndex } from '@pops/db-types';
 
 import { ValidationError } from '../../../../shared/errors.js';
-
-import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 
 import type { EngramFrontmatter } from '../schema.js';
 
@@ -168,12 +167,7 @@ export function indexRowFromDrizzle(row: typeof engramIndex.$inferSelect): Index
   };
 }
 
-export function isIdTaken(
-  db: BetterSQLite3Database,
-  root: string,
-  candidate: string,
-  type: string
-): boolean {
+export function isIdTaken(db: CerebrumDb, root: string, candidate: string, type: string): boolean {
   const [row] = db
     .select({ id: engramIndex.id })
     .from(engramIndex)

--- a/apps/pops-api/src/modules/cerebrum/engrams/handlers/link-helpers.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/handlers/link-helpers.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs';
 
 import { sql } from 'drizzle-orm';
 
+import { type CerebrumDb } from '@pops/cerebrum-db';
 import { engramLinks } from '@pops/db-types';
 
 import { ValidationError } from '../../../../shared/errors.js';
@@ -9,13 +10,11 @@ import { parseEngramFile, serializeEngram } from '../file.js';
 import { absolutePath, parseCustomFields, writeFileAtomic } from './fs-helpers.js';
 import { findIndexRow, getIndexRow, upsertIndex } from './upsert-index.js';
 
-import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
-
 import type { EngramFrontmatter } from '../schema.js';
 
 export type LinkDeps = {
   root: string;
-  db: BetterSQLite3Database;
+  db: CerebrumDb;
   now: () => Date;
 };
 

--- a/apps/pops-api/src/modules/cerebrum/engrams/handlers/list-engrams.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/handlers/list-engrams.ts
@@ -1,10 +1,9 @@
 import { and, count, eq, inArray, like, sql } from 'drizzle-orm';
 
+import { type CerebrumDb } from '@pops/cerebrum-db';
 import { engramIndex, engramLinks, engramScopes, engramTags } from '@pops/db-types';
 
 import { bucket, indexRowFromDrizzle, parseCustomFields, type IndexRow } from './fs-helpers.js';
-
-import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 
 import type { EngramSource, EngramStatus } from '../schema.js';
 import type { Engram } from '../types.js';
@@ -30,7 +29,7 @@ export interface ListEngramsResult {
 }
 
 function buildConditions(
-  db: BetterSQLite3Database,
+  db: CerebrumDb,
   opts: ListEngramsOptions
 ): ReturnType<typeof and> | undefined {
   const conditions = [];
@@ -81,7 +80,7 @@ interface QueryParams {
   offset: number;
 }
 
-function fetchRows(db: BetterSQLite3Database, p: QueryParams): { rows: unknown[]; total: number } {
+function fetchRows(db: CerebrumDb, p: QueryParams): { rows: unknown[]; total: number } {
   const rowsQuery = db.select().from(engramIndex).$dynamic();
   const rows = (p.where ? rowsQuery.where(p.where) : rowsQuery)
     .orderBy(p.sortDir === 'asc' ? p.orderColumn : sql`${p.orderColumn} desc`)
@@ -100,10 +99,7 @@ function resolveLimit(opts: ListEngramsOptions): number {
   return opts.limit ?? 50;
 }
 
-export function listEngrams(
-  db: BetterSQLite3Database,
-  opts: ListEngramsOptions = {}
-): ListEngramsResult {
+export function listEngrams(db: CerebrumDb, opts: ListEngramsOptions = {}): ListEngramsResult {
   const where = buildConditions(db, opts);
   const sortField = opts.sort?.field ?? 'modified_at';
   const sortDir = opts.sort?.direction ?? 'desc';
@@ -125,7 +121,7 @@ export function listEngrams(
   };
 }
 
-export function hydrateEngrams(db: BetterSQLite3Database, rows: IndexRow[]): Engram[] {
+export function hydrateEngrams(db: CerebrumDb, rows: IndexRow[]): Engram[] {
   if (rows.length === 0) return [];
   const ids = rows.map((r) => r.id);
 

--- a/apps/pops-api/src/modules/cerebrum/engrams/handlers/rebuild-index.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/handlers/rebuild-index.ts
@@ -1,11 +1,10 @@
 import { readFileSync } from 'node:fs';
 
+import { type CerebrumDb } from '@pops/cerebrum-db';
 import { engramIndex, engramLinks, engramScopes, engramTags } from '@pops/db-types';
 
 import { countWords, deriveTitle, parseEngramFile } from '../file.js';
 import { absolutePath, dedupe, listEngramFiles, sha256, splitCustomFields } from './fs-helpers.js';
-
-import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 
 interface IndexEntry {
   row: typeof engramIndex.$inferInsert;
@@ -49,7 +48,7 @@ function buildEntryFromFile(root: string, relPath: string): IndexEntry | null {
   };
 }
 
-function persistEntries(db: BetterSQLite3Database, entries: IndexEntry[]): void {
+function persistEntries(db: CerebrumDb, entries: IndexEntry[]): void {
   db.transaction((tx) => {
     tx.delete(engramLinks).run();
     tx.delete(engramTags).run();
@@ -77,7 +76,7 @@ function persistEntries(db: BetterSQLite3Database, entries: IndexEntry[]): void 
   });
 }
 
-export function reindexEngrams(db: BetterSQLite3Database, root: string): { indexed: number } {
+export function reindexEngrams(db: CerebrumDb, root: string): { indexed: number } {
   const files = listEngramFiles(root);
   const entries: IndexEntry[] = [];
 

--- a/apps/pops-api/src/modules/cerebrum/engrams/handlers/restore-engram.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/handlers/restore-engram.test.ts
@@ -33,7 +33,7 @@ describe('restoreEngram idempotency', () => {
     seedDefaultTemplates(templatesDir);
     service = new EngramService({
       root,
-      db: drizzle(db),
+      db: drizzle<Record<string, unknown>>(db),
       templates: new TemplateRegistry(templatesDir),
       now: makeClock(),
     });
@@ -60,6 +60,6 @@ describe('restoreEngram idempotency', () => {
 
     expect(result.moved).toBe(false);
     expect(result.filePath).toBe(archivedRel);
-    expect(getIndexRow(drizzle(db), engram.id).status).toBe('archived');
+    expect(getIndexRow(drizzle<Record<string, unknown>>(db), engram.id).status).toBe('archived');
   });
 });

--- a/apps/pops-api/src/modules/cerebrum/engrams/handlers/restore-engram.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/handlers/restore-engram.ts
@@ -7,15 +7,15 @@
  */
 import { existsSync, readFileSync, unlinkSync } from 'node:fs';
 
+import { type CerebrumDb } from '@pops/cerebrum-db';
+
 import { parseEngramFile, serializeEngram } from '../file.js';
 import { ARCHIVE_DIR, absolutePath, parseCustomFields, writeFileAtomic } from './fs-helpers.js';
 import { getIndexRow, upsertIndex } from './upsert-index.js';
 
-import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
-
 export type RestoreDeps = {
   root: string;
-  db: BetterSQLite3Database;
+  db: CerebrumDb;
   now: () => Date;
 };
 

--- a/apps/pops-api/src/modules/cerebrum/engrams/handlers/upsert-index.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/handlers/upsert-index.ts
@@ -1,28 +1,27 @@
 import { eq } from 'drizzle-orm';
 
+import { type CerebrumDb } from '@pops/cerebrum-db';
 import { engramIndex, engramLinks, engramScopes, engramTags } from '@pops/db-types';
 
 import { NotFoundError } from '../../../../shared/errors.js';
 import { countWords, deriveTitle, serializeEngram } from '../file.js';
 import { dedupe, indexRowFromDrizzle, sha256, type IndexRow } from './fs-helpers.js';
 
-import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
-
 import type { EngramFrontmatter } from '../schema.js';
 
-export function getIndexRow(db: BetterSQLite3Database, id: string): IndexRow {
+export function getIndexRow(db: CerebrumDb, id: string): IndexRow {
   const row = findIndexRow(db, id);
   if (!row) throw new NotFoundError('Engram', id);
   return row;
 }
 
-export function findIndexRow(db: BetterSQLite3Database, id: string): IndexRow | null {
+export function findIndexRow(db: CerebrumDb, id: string): IndexRow | null {
   const [row] = db.select().from(engramIndex).where(eq(engramIndex.id, id)).all();
   return row ? indexRowFromDrizzle(row) : null;
 }
 
 export function upsertIndex(
-  db: BetterSQLite3Database,
+  db: CerebrumDb,
   args: {
     id: string;
     filePath: string;

--- a/apps/pops-api/src/modules/cerebrum/engrams/reclassify.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/reclassify.ts
@@ -4,12 +4,11 @@ import { dirname, join } from 'node:path';
 
 import { eq, inArray, like, or, sql } from 'drizzle-orm';
 
+import { type CerebrumDb } from '@pops/cerebrum-db';
 import { engramIndex, engramScopes } from '@pops/db-types';
 
 import { ValidationError } from '../../../shared/errors.js';
 import { parseEngramFile, serializeEngram } from './file.js';
-
-import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 
 interface ReclassifyTarget {
   engramId: string;
@@ -32,7 +31,7 @@ export interface ReclassifyResult {
 }
 
 function findReclassifyTargets(
-  db: BetterSQLite3Database,
+  db: CerebrumDb,
   fromScope: string,
   toScope: string
 ): ReclassifyTarget[] {
@@ -76,7 +75,7 @@ function groupByEngram(targets: ReclassifyTarget[]): Map<string, EngramReclassEn
 }
 
 function buildWorkItems(
-  db: BetterSQLite3Database,
+  db: CerebrumDb,
   root: string,
   affectedIds: string[],
   byEngram: Map<string, EngramReclassEntry>
@@ -141,7 +140,7 @@ function writeAllAtomic(work: WorkItem[]): WorkItem[] {
   return written;
 }
 
-function applyDbChanges(db: BetterSQLite3Database, work: WorkItem[]): void {
+function applyDbChanges(db: CerebrumDb, work: WorkItem[]): void {
   db.transaction((tx) => {
     for (const item of work) {
       for (const oldScope of item.oldScopeSet) {
@@ -170,7 +169,7 @@ export interface ReclassifyParams {
 }
 
 export function reclassifyScopes(
-  db: BetterSQLite3Database,
+  db: CerebrumDb,
   root: string,
   params: ReclassifyParams
 ): ReclassifyResult {

--- a/apps/pops-api/src/modules/cerebrum/engrams/scope-filter.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/scope-filter.test.ts
@@ -5,6 +5,8 @@ import { join } from 'node:path';
 import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { describe, expect, it, afterEach, beforeEach } from 'vitest';
 
+import { type CerebrumDb } from '@pops/cerebrum-db';
+
 import { createTestDb } from '../../../shared/test-utils.js';
 import { TemplateRegistry } from '../templates/registry.js';
 import { seedDefaultTemplates } from '../templates/seed.js';
@@ -12,7 +14,6 @@ import { filterByScopes, inferScopesFromContext } from './scope-filter.js';
 import { EngramService } from './service.js';
 
 import type { Database } from 'better-sqlite3';
-import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 
 /** A fixed clock that advances one minute per call. */
 function makeClock(start = new Date('2026-04-18T09:00:00Z')): () => Date {
@@ -26,13 +27,13 @@ function makeClock(start = new Date('2026-04-18T09:00:00Z')): () => Date {
 
 describe('filterByScopes', () => {
   let rawDb: Database;
-  let db: BetterSQLite3Database;
+  let db: CerebrumDb;
   let service: EngramService;
   let root: string;
 
   beforeEach(() => {
     rawDb = createTestDb();
-    db = drizzle(rawDb);
+    db = drizzle<Record<string, unknown>>(rawDb);
     root = mkdtempSync(join(tmpdir(), 'scope-filter-'));
     const templatesDir = join(root, '.templates');
     seedDefaultTemplates(templatesDir);

--- a/apps/pops-api/src/modules/cerebrum/engrams/scope-filter.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/scope-filter.ts
@@ -12,14 +12,14 @@ import { like, or, sql } from 'drizzle-orm';
 
 import { engramScopes } from '@pops/db-types';
 
-import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import type { CerebrumDb } from '@pops/cerebrum-db';
 
 export interface FilterByScopesOptions {
   /** Scope prefixes to match. Empty array = no scope filter (all engrams). */
   scopes: string[];
   /** When true, secret-scoped engrams are included. Default: false. */
   includeSecret?: boolean;
-  db: BetterSQLite3Database;
+  db: CerebrumDb;
 }
 
 export interface FilterByScopesResult {
@@ -57,7 +57,7 @@ export function filterByScopes(opts: FilterByScopesOptions): FilterByScopesResul
 }
 
 /** Fetch all engram IDs that have at least one secret scope. */
-function getSecretEngramIds(db: BetterSQLite3Database): Set<string> {
+function getSecretEngramIds(db: CerebrumDb): Set<string> {
   // Any scope containing a segment exactly named 'secret' is treated as secret,
   // regardless of position. Three LIKE patterns cover middle, start, and end.
   const rows = db
@@ -75,7 +75,7 @@ function getSecretEngramIds(db: BetterSQLite3Database): Set<string> {
 }
 
 /** Fetch all engram IDs from the scopes table (distinct). */
-function getAllEngramIds(db: BetterSQLite3Database): string[] {
+function getAllEngramIds(db: CerebrumDb): string[] {
   const rows = db.selectDistinct({ engramId: engramScopes.engramId }).from(engramScopes).all();
   return rows.map((r) => r.engramId);
 }
@@ -84,7 +84,7 @@ function getAllEngramIds(db: BetterSQLite3Database): string[] {
  * Return engram IDs where at least one stored scope matches any of the
  * requested prefix patterns. Uses SQL LIKE for prefix queries.
  */
-function getScopeMatchingIds(db: BetterSQLite3Database, scopes: string[]): string[] {
+function getScopeMatchingIds(db: CerebrumDb, scopes: string[]): string[] {
   // Build a LIKE condition per prefix. A stored scope matches prefix `p` when:
   //   scope = p           (exact match)
   //   scope LIKE 'p.%'   (child scope)

--- a/apps/pops-api/src/modules/cerebrum/engrams/scopes-router.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/scopes-router.test.ts
@@ -5,6 +5,8 @@ import { join } from 'node:path';
 import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
+import { type CerebrumDb } from '@pops/cerebrum-db';
+
 import { closeDb, setDb } from '../../../db.js';
 import { setCerebrumDb } from '../../../db/cerebrum-handle.js';
 import { appRouter } from '../../../router.js';
@@ -16,7 +18,6 @@ import { listScopes } from './scopes-router.js';
 import { EngramService } from './service.js';
 
 import type { Database } from 'better-sqlite3';
-import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 
 /** A fixed clock that advances one minute per call. */
 function makeClock(start = new Date('2026-04-18T09:00:00Z')): () => Date {
@@ -28,7 +29,7 @@ function makeClock(start = new Date('2026-04-18T09:00:00Z')): () => Date {
   };
 }
 
-function makeService(db: BetterSQLite3Database, root: string): EngramService {
+function makeService(db: CerebrumDb, root: string): EngramService {
   const templatesDir = join(root, '.templates');
   seedDefaultTemplates(templatesDir);
   return new EngramService({
@@ -45,13 +46,13 @@ function makeService(db: BetterSQLite3Database, root: string): EngramService {
 
 describe('listScopes', () => {
   let rawDb: Database;
-  let db: BetterSQLite3Database;
+  let db: CerebrumDb;
   let service: EngramService;
   let root: string;
 
   beforeEach(() => {
     rawDb = createTestDb();
-    db = drizzle(rawDb);
+    db = drizzle<Record<string, unknown>>(rawDb);
     root = mkdtempSync(join(tmpdir(), 'scopes-router-'));
     service = makeService(db, root);
   });
@@ -104,12 +105,12 @@ describe('listScopes', () => {
 
 describe('EngramService.create scope inference', () => {
   let rawDb: Database;
-  let db: BetterSQLite3Database;
+  let db: CerebrumDb;
   let root: string;
 
   beforeEach(() => {
     rawDb = createTestDb();
-    db = drizzle(rawDb);
+    db = drizzle<Record<string, unknown>>(rawDb);
     root = mkdtempSync(join(tmpdir(), 'scope-infer-'));
     mkdirSync(join(root, '.config'), { recursive: true });
     mkdirSync(join(root, '.templates'), { recursive: true });
@@ -158,7 +159,7 @@ describe('cerebrum.scopes tRPC procedures', () => {
   beforeEach(() => {
     rawDb = createTestDb();
     setDb(rawDb);
-    setCerebrumDb({ db: drizzle(rawDb), raw: rawDb, vecAvailable: false });
+    setCerebrumDb({ db: drizzle<Record<string, unknown>>(rawDb), raw: rawDb, vecAvailable: false });
     root = mkdtempSync(join(tmpdir(), 'scopes-trpc-'));
     previousRoot = process.env['ENGRAM_ROOT'];
     process.env['ENGRAM_ROOT'] = root;

--- a/apps/pops-api/src/modules/cerebrum/engrams/scopes-router.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/scopes-router.ts
@@ -11,7 +11,7 @@ import { z } from 'zod';
 
 import { engramScopes } from '@pops/db-types';
 
-import { getDrizzle } from '../../../db.js';
+import { getCerebrumDrizzle } from '../../../db/cerebrum-handle.js';
 import { HttpError, NotFoundError, ValidationError } from '../../../shared/errors.js';
 import { protectedProcedure, router } from '../../../trpc.js';
 import { getEngramRoot, getEngramService } from '../instance.js';
@@ -20,7 +20,7 @@ import { filterByScopes } from './scope-filter.js';
 import { createScopeReconciliationService } from './scope-reconciliation.js';
 import { normaliseScope, scopeStringSchema, validateScope } from './scope-schema.js';
 
-import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import type { CerebrumDb } from '@pops/cerebrum-db';
 
 const engramIdSchema = z.string().regex(/^eng_\d{8}_\d{4}_[a-z0-9-]+$/);
 const scopeInputSchema = scopeStringSchema;
@@ -61,7 +61,7 @@ export interface ScopeInfo {
  * List all distinct scopes with engram counts. If `prefix` is provided,
  * only scopes that are equal to or children of the prefix are returned.
  */
-export function listScopes(db: BetterSQLite3Database, prefix?: string): ScopeInfo[] {
+export function listScopes(db: CerebrumDb, prefix?: string): ScopeInfo[] {
   const norm = prefix !== undefined && prefix.trim() !== '' ? normaliseScope(prefix) : undefined;
   const q = db.select({ scope: engramScopes.scope, total: count() }).from(engramScopes).$dynamic();
   const rows = (
@@ -159,7 +159,7 @@ export const scopesRouter = router({
    */
   reclassify: protectedProcedure.input(reclassifyInput).mutation(({ input }) => {
     try {
-      return reclassifyScopes(getDrizzle(), getEngramRoot(), input);
+      return reclassifyScopes(getCerebrumDrizzle(), getEngramRoot(), input);
     } catch (err) {
       toTrpcError(err);
     }
@@ -171,7 +171,7 @@ export const scopesRouter = router({
   list: protectedProcedure
     .input(z.object({ prefix: scopePrefixSchema.optional() }).optional())
     .query(({ input }) => {
-      return { scopes: listScopes(getDrizzle(), input?.prefix) };
+      return { scopes: listScopes(getCerebrumDrizzle(), input?.prefix) };
     }),
 
   /**
@@ -190,7 +190,7 @@ export const scopesRouter = router({
   reconcile: protectedProcedure
     .input(z.object({ suggestedScopes: scopesArraySchema }))
     .query(({ input }) => {
-      const knownScopes = listScopes(getDrizzle());
+      const knownScopes = listScopes(getCerebrumDrizzle());
       const svc = createScopeReconciliationService();
       return svc.reconcile({ suggestedScopes: input.suggestedScopes, knownScopes });
     }),
@@ -203,7 +203,7 @@ export const scopesRouter = router({
       const { engramIds } = filterByScopes({
         scopes: input.scopes,
         includeSecret: input.includeSecret,
-        db: getDrizzle(),
+        db: getCerebrumDrizzle(),
       });
       if (engramIds.length === 0) return { engrams: [] };
       const { engrams } = getEngramService().list({ ids: engramIds });

--- a/apps/pops-api/src/modules/cerebrum/engrams/service.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/service.test.ts
@@ -36,7 +36,7 @@ describe('EngramService', () => {
     seedDefaultTemplates(templatesDir);
     service = new EngramService({
       root,
-      db: drizzle(db),
+      db: drizzle<Record<string, unknown>>(db),
       templates: new TemplateRegistry(templatesDir),
       now: makeClock(),
     });

--- a/apps/pops-api/src/modules/cerebrum/engrams/service.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/service.ts
@@ -1,44 +1,24 @@
 /**
- * Engram CRUD service — read/write split during the PRD-179 cutover.
+ * Engram CRUD service — fully routed through the cerebrum pillar handle
+ * (`cerebrum.db`) after PRD-179 PR 3 collapses the read/write split.
  *
  * The filesystem is source of truth; the index is a regenerable cache.
  * All write operations use atomic file writes before index updates.
  *
- * Read/write split during the migration window (PRD-179 PR 2):
- *  - Pure user-facing reads — `list`, `read` — are routed through
- *    `readDb` (a `CerebrumDb` handle, wired to `getCerebrumDrizzle()`
- *    in `instance.ts`) and forwarded to the `@pops/cerebrum-db`
- *    `engramsService.{listEngrams,findIndexRow}` namespace. These are
- *    the seam called out by PRD-179 PR 2.
- *  - `exists` checks `readDb` first then falls back to `db` (the write
- *    store). Glia revert calls `exists` to gate `restore`/`unlink`
- *    writes, so a row newly created since boot — present only in
- *    `pops.db` — must still report `true`. Drop the fallback once
- *    PRD-179 US-03 collapses writes onto `cerebrum.db`.
- *  - Every write path — `create`, `update`, `archive`, `restore`,
- *    `changeType`, `link`, `unlink`, `hardDelete`, `reindex` — and any
- *    read-after-write hop (the private `loadEngram` helper used to
- *    rehydrate the row we just wrote) still goes through `db` (the
- *    shared `pops.db` handle). Read-after-write consistency lives on
- *    that same store. PRD-179 US-03 flips the writes too, at which
- *    point `db` collapses into `readDb`.
- *
- * Cross-store consistency relies on `backfillCerebrumFromShared()` in
- * `apps/pops-api/src/db/backfill-cerebrum-from-shared.ts`: a one-way,
- * boot-time copy from `pops.db` -> `cerebrum.db` that idempotently
- * fills missing rows on `engram_index` + its three many-to-many
- * auxiliaries. Between boots, newly-written engrams live only in
- * `pops.db` and won't appear in `list`/`read`/`exists` results from
- * `readDb` until the next deploy reruns the backfill. Read-after-write
- * is preserved within the same process because `loadEngram` reads from
- * the write store. This is the same trade-off taken by the watch-history
- * (PRD-168 PR 2) and movies (PRD-165 PR 3) cutovers.
+ * PRD-179 PR 3 (this PR) collapses the split established by PR 2: every
+ * path — `list`, `read`, `exists`, `create`, `update`, `archive`,
+ * `restore`, `changeType`, `link`, `unlink`, `hardDelete`, `reindex` —
+ * now routes through a single `CerebrumDb` handle wired to
+ * `getCerebrumDrizzle()` in `instance.ts`. The boot-time backfill
+ * (`backfillCerebrumFromShared()` in
+ * `apps/pops-api/src/db/backfill-cerebrum-from-shared.ts`) carries any
+ * residual rows on the legacy shared `pops.db` forward on the first
+ * deploy after the cut. Subsequent boots are no-ops via the per-table
+ * existence filter; PR 4 retires the backfill and drops the shared
+ * journal entries.
  *
  * Filesystem markdown writes, the template registry, and the scope-rule
  * engine stay in pops-api — `@pops/cerebrum-db` is pure data-access.
- * `EngramServiceOptions.readDb` is optional so the existing in-memory
- * test rigs (which inject a single SQLite handle for both stores) keep
- * working without churn; when omitted it falls back to `db`.
  */
 import { readFileSync } from 'node:fs';
 
@@ -64,11 +44,9 @@ import {
 } from './handlers/list-engrams.js';
 import { reindexEngrams } from './handlers/rebuild-index.js';
 import { restoreEngram, type RestoreResult } from './handlers/restore-engram.js';
-import { findIndexRow, getIndexRow, upsertIndex } from './handlers/upsert-index.js';
+import { getIndexRow, upsertIndex } from './handlers/upsert-index.js';
 import { canTransitionStatus, type EngramFrontmatter, type EngramStatus } from './schema.js';
 import { buildEngram, type Engram } from './types.js';
-
-import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 
 import type { TemplateRegistry } from '../templates/registry.js';
 import type { ScopeRuleEngine } from './scope-rules.js';
@@ -95,19 +73,13 @@ export interface UpdateEngramInput {
 export interface EngramServiceOptions {
   root: string;
   /**
-   * Write handle — the shared `pops.db` drizzle wrapper. All write paths
-   * and read-after-write hops route through this handle until PRD-179
-   * US-03 flips the writes too.
+   * Cerebrum pillar drizzle handle (`getCerebrumDrizzle()` in production).
+   * After PRD-179 PR 3 every engram read and write — including the
+   * read-after-write hop inside `loadEngram` — flows through this single
+   * handle. Test rigs that inject an in-memory SQLite still pass it here
+   * as the only DB argument.
    */
-  db: BetterSQLite3Database;
-  /**
-   * Read handle — the cerebrum pillar's `cerebrum.db` drizzle wrapper.
-   * Pure user-facing reads (`list`, `read`, `exists`) forward through
-   * `@pops/cerebrum-db`'s `engramsService` against this handle. Defaults
-   * to `db` so test rigs that inject a single in-memory SQLite keep
-   * working without churn.
-   */
-  readDb?: CerebrumDb;
+  db: CerebrumDb;
   templates: TemplateRegistry;
   scopeRuleEngine?: ScopeRuleEngine;
   now?: () => Date;
@@ -115,8 +87,7 @@ export interface EngramServiceOptions {
 
 export class EngramService {
   private readonly root: string;
-  private readonly db: BetterSQLite3Database;
-  private readonly readDb: CerebrumDb;
+  private readonly db: CerebrumDb;
   private readonly templates: TemplateRegistry;
   private readonly scopeRuleEngine: ScopeRuleEngine | undefined;
   private readonly now: () => Date;
@@ -124,7 +95,6 @@ export class EngramService {
   constructor(options: EngramServiceOptions) {
     this.root = options.root;
     this.db = options.db;
-    this.readDb = options.readDb ?? options.db;
     this.templates = options.templates;
     this.scopeRuleEngine = options.scopeRuleEngine;
     this.now = options.now ?? (() => new Date());
@@ -145,7 +115,7 @@ export class EngramService {
   }
 
   read(id: string): { engram: Engram; body: string } {
-    const row = engramsService.findIndexRow(this.readDb, id);
+    const row = engramsService.findIndexRow(this.db, id);
     if (!row) throw new NotFoundError('Engram', id);
     const content = readFileSync(absolutePath(this.root, row.filePath), 'utf8');
     const { frontmatter, body } = parseEngramFile(content);
@@ -228,19 +198,13 @@ export class EngramService {
   /**
    * True iff `id` is present in the engram index.
    *
-   * Consults the cerebrum read store first; falls back to the shared write
-   * store (`pops.db`) when missing. Write-context callers (glia revert in
-   * particular — see `../glia/revert-operations.ts`) check existence before
-   * issuing `restore` / `unlink` mutations on the write store. A row newly
-   * created since boot lives only in `pops.db` until the next backfill, so
-   * a `readDb`-only check would produce false negatives and silently skip
-   * the restore. The fallback keeps the TOCTOU window closed during the
-   * cutover; once PRD-179 US-03 collapses writes onto `cerebrum.db`, the
-   * second hop becomes redundant and can be dropped.
+   * Routes through `@pops/cerebrum-db`'s `engramsService.existsEngram`
+   * against the cerebrum handle. Used by glia revert (see
+   * `../glia/revert-operations.ts`) to gate `restore` / `unlink`
+   * mutations.
    */
   exists(id: string): boolean {
-    if (engramsService.existsEngram(this.readDb, id)) return true;
-    return findIndexRow(this.db, id) !== null;
+    return engramsService.existsEngram(this.db, id);
   }
 
   /**
@@ -263,7 +227,7 @@ export class EngramService {
   }
 
   list(opts: ListEngramsOptions = {}): ListEngramsResult {
-    return engramsService.listEngrams(this.readDb, opts);
+    return engramsService.listEngrams(this.db, opts);
   }
 
   reindex(): { indexed: number } {

--- a/apps/pops-api/src/modules/cerebrum/engrams/tags-router.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/tags-router.test.ts
@@ -8,6 +8,8 @@ import { join } from 'node:path';
 import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
+import { type CerebrumDb } from '@pops/cerebrum-db';
+
 import { createTestDb } from '../../../shared/test-utils.js';
 import { TemplateRegistry } from '../templates/registry.js';
 import { seedDefaultTemplates } from '../templates/seed.js';
@@ -15,9 +17,8 @@ import { EngramService } from './service.js';
 import { listTags } from './tags-router.js';
 
 import type { Database } from 'better-sqlite3';
-import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 
-function makeService(db: BetterSQLite3Database, root: string): EngramService {
+function makeService(db: CerebrumDb, root: string): EngramService {
   const templatesDir = join(root, '.templates');
   seedDefaultTemplates(templatesDir);
   return new EngramService({
@@ -29,13 +30,13 @@ function makeService(db: BetterSQLite3Database, root: string): EngramService {
 
 describe('listTags', () => {
   let rawDb: Database;
-  let db: BetterSQLite3Database;
+  let db: CerebrumDb;
   let service: EngramService;
   let root: string;
 
   beforeEach(() => {
     rawDb = createTestDb();
-    db = drizzle(rawDb);
+    db = drizzle<Record<string, unknown>>(rawDb);
     root = mkdtempSync(join(tmpdir(), 'tags-router-'));
     service = makeService(db, root);
   });

--- a/apps/pops-api/src/modules/cerebrum/engrams/tags-router.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/tags-router.ts
@@ -10,10 +10,10 @@ import { z } from 'zod';
 
 import { engramTags } from '@pops/db-types';
 
-import { getDrizzle } from '../../../db.js';
+import { getCerebrumDrizzle } from '../../../db/cerebrum-handle.js';
 import { protectedProcedure, router } from '../../../trpc.js';
 
-import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import type { CerebrumDb } from '@pops/cerebrum-db';
 
 export interface TagInfo {
   tag: string;
@@ -36,7 +36,7 @@ const tagPrefixSchema = z
  * Results are ordered by count desc then tag asc so the most-used tags
  * surface first in typeahead suggestions.
  */
-export function listTags(db: BetterSQLite3Database, prefix?: string, limit = 100): TagInfo[] {
+export function listTags(db: CerebrumDb, prefix?: string, limit = 100): TagInfo[] {
   const norm = prefix !== undefined && prefix.trim() !== '' ? prefix.trim().toLowerCase() : '';
   const baseQuery = db.select({ tag: engramTags.tag, total: count() }).from(engramTags).$dynamic();
   const filtered = norm ? baseQuery.where(like(engramTags.tag, `${norm}%`)) : baseQuery;
@@ -65,6 +65,6 @@ export const tagsRouter = router({
         .optional()
     )
     .query(({ input }) => {
-      return { tags: listTags(getDrizzle(), input?.prefix, input?.limit) };
+      return { tags: listTags(getCerebrumDrizzle(), input?.prefix, input?.limit) };
     }),
 });

--- a/apps/pops-api/src/modules/cerebrum/glia/__tests__/revert-operations.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/glia/__tests__/revert-operations.test.ts
@@ -57,7 +57,7 @@ describe('executeRevert (filesystem)', () => {
     seedDefaultTemplates(templatesDir);
     service = new EngramService({
       root,
-      db: drizzle(db),
+      db: drizzle<Record<string, unknown>>(db),
       templates: new TemplateRegistry(templatesDir),
       now: makeClock(),
     });

--- a/apps/pops-api/src/modules/cerebrum/ingest/pipeline-helpers.ts
+++ b/apps/pops-api/src/modules/cerebrum/ingest/pipeline-helpers.ts
@@ -8,7 +8,7 @@ import { and, eq } from 'drizzle-orm';
 
 import { engramIndex } from '@pops/db-types';
 
-import { getDrizzle } from '../../../db.js';
+import { getCerebrumDrizzle } from '../../../db/cerebrum-handle.js';
 
 export function hashContent(body: string): string {
   return createHash('sha256').update(body, 'utf8').digest('hex');
@@ -16,7 +16,7 @@ export function hashContent(body: string): string {
 
 export function findDuplicate(bodyHash: string): string | null {
   try {
-    const db = getDrizzle();
+    const db = getCerebrumDrizzle();
     const row = db
       .select({ id: engramIndex.id })
       .from(engramIndex)

--- a/apps/pops-api/src/modules/cerebrum/instance.ts
+++ b/apps/pops-api/src/modules/cerebrum/instance.ts
@@ -8,7 +8,6 @@
  */
 import { join } from 'node:path';
 
-import { getDrizzle } from '../../db.js';
 import { getCerebrumDrizzle } from '../../db/cerebrum-handle.js';
 import { ScopeRuleEngine } from './engrams/scope-rules.js';
 import { EngramService } from './engrams/service.js';
@@ -55,39 +54,29 @@ export function getScopeRuleEngine(): ScopeRuleEngine {
 }
 
 /**
- * Build an EngramService bound to the current request's drizzle context.
+ * Build an EngramService bound to the current request's cerebrum
+ * drizzle context.
  *
- * `db` is the shared `pops.db` handle (writes + read-after-write);
- * `readDb` is the cerebrum pillar's `cerebrum.db` handle (pure reads).
- * PRD-179 PR 2 — the read seam routes through `@pops/cerebrum-db`'s
- * `engramsService` against `readDb`; writes still land on `pops.db`
- * until PRD-179 US-03 flips them too. See `EngramService` top-of-file
- * JSDoc for the cross-store consistency contract.
+ * After PRD-179 PR 3 every engram path — reads (`list`, `read`,
+ * `exists`) and writes (`create`, `update`, `archive`, `restore`,
+ * `changeType`, `link`, `unlink`, `hardDelete`, `reindex`) — flows
+ * through `getCerebrumDrizzle()` (`cerebrum.db`). The boot-time
+ * backfill (`backfillCerebrumFromShared`) carries any residual rows on
+ * the legacy shared `pops.db` forward on the first deploy after the
+ * cut.
  *
  * Blast radius: this is the single production factory, so every
  * consumer — user-facing routers (engrams, ingest, scopes), AI tools,
  * curation jobs, glia revert, nudges, ego context helpers — picks up
- * the `cerebrum.db`-backed read seam. That is the intended cutover
- * shape: keeping a parallel `pops.db` read path defeats the migration
- * and re-introduces the divergence the cutover is closing.
+ * the cerebrum handle uniformly.
  *
- * Write-adjacent safety: read-after-write goes through the private
- * `loadEngram` (write store) so created/updated rows surface
- * immediately. The one cross-store existence check that gates writes
- * — `EngramService.exists`, used by glia revert — falls back to the
- * write store when the read store misses, so newly-written rows can
- * still be restored/unlinked before the next backfill. See the
- * `exists()` JSDoc for the contract.
- *
- * Tests inject a single in-memory SQLite via `new EngramService({ db,
- * ... })`; `readDb` defaults to `db` at the constructor so existing
- * harnesses keep working without churn.
+ * Tests inject a single in-memory SQLite as `db` and the same handle
+ * satisfies the cerebrum-pillar contract.
  */
 export function getEngramService(): EngramService {
   return new EngramService({
     root: getEngramRoot(),
-    db: getDrizzle(),
-    readDb: getCerebrumDrizzle(),
+    db: getCerebrumDrizzle(),
     templates: getTemplateRegistry(),
     scopeRuleEngine: getScopeRuleEngine(),
   });

--- a/apps/pops-api/src/modules/cerebrum/nudges/detectors/citation-flush.ts
+++ b/apps/pops-api/src/modules/cerebrum/nudges/detectors/citation-flush.ts
@@ -6,18 +6,17 @@
  */
 import { eq } from 'drizzle-orm';
 
+import { type CerebrumDb } from '@pops/cerebrum-db';
 import { engramIndex } from '@pops/db-types';
 
 import { getAllCitationCounts, resetCitationCounts } from './citation-tracker.js';
-
-import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 
 /**
  * Flush citation counts to the database, updating the modifiedAt
  * timestamp to reflect recent usage. This reduces staleness scores
  * for frequently-cited engrams.
  */
-export function flushCitationsToDb(db: BetterSQLite3Database): number {
+export function flushCitationsToDb(db: CerebrumDb): number {
   let flushed = 0;
   const now = new Date().toISOString();
   const counts = getAllCitationCounts();

--- a/apps/pops-api/src/modules/cerebrum/nudges/router.ts
+++ b/apps/pops-api/src/modules/cerebrum/nudges/router.ts
@@ -32,13 +32,20 @@ let activeThresholds: NudgeThresholds = getDefaultNudgeThresholds();
 
 /** Build a NudgeService for the current request context. */
 function getService(): NudgeService {
-  // Post-cutover (Phase 2 PR 3): nudge_log lives on the cerebrum pillar
-  // handle; engrams reads still come from the shared pops.db until the
-  // engrams slice migrates. `searchService` reads against the shared DB
-  // (same engrams source) so it stays on `getDrizzle()`.
+  // Post PRD-179 PR 3: engrams CRUD writes flow through the cerebrum
+  // handle (`cerebrum.db`). `loadActiveEngrams` here also resolves
+  // against the cerebrum handle so detector input lines up with fresh
+  // writes. `HybridSearchService` still consumes `getDrizzle()` (the
+  // shared `pops.db`) because its underlying `semantic-search-metadata`
+  // path joins cross-pillar tables (movies/tvShows/transactions/
+  // homeInventory) that have not migrated yet — narrowing that handle
+  // would break the cross-source result enrichment. The shared-store
+  // engram tables are kept current by `backfillCerebrumFromShared` so
+  // this read is acceptable until the cross-pillar metadata resolver
+  // is split.
   const db = getCerebrumDrizzle();
-  const engramsDb = getDrizzle();
-  const searchService = new HybridSearchService(engramsDb);
+  const engramsDb = getCerebrumDrizzle();
+  const searchService = new HybridSearchService(getDrizzle());
   const engramService = getEngramService();
   const patternDetector = new PatternDetector({
     thresholds: activeThresholds,

--- a/apps/pops-api/src/modules/cerebrum/nudges/router.ts
+++ b/apps/pops-api/src/modules/cerebrum/nudges/router.ts
@@ -37,12 +37,16 @@ function getService(): NudgeService {
   // against the cerebrum handle so detector input lines up with fresh
   // writes. `HybridSearchService` still consumes `getDrizzle()` (the
   // shared `pops.db`) because its underlying `semantic-search-metadata`
-  // path joins cross-pillar tables (movies/tvShows/transactions/
-  // homeInventory) that have not migrated yet — narrowing that handle
-  // would break the cross-source result enrichment. The shared-store
-  // engram tables are kept current by `backfillCerebrumFromShared` so
-  // this read is acceptable until the cross-pillar metadata resolver
-  // is split.
+  // path joins `engram_index` with cross-pillar tables
+  // (movies/tvShows/transactions/homeInventory) that have not migrated
+  // yet — narrowing that handle to the cerebrum file would break the
+  // cross-source enrichment joins. Note `backfillCerebrumFromShared` is
+  // one-directional (pops → cerebrum) and does *not* mirror post-PR-3
+  // engram writes back into `pops.db`, so this hybrid search can return
+  // stale results for engrams created or modified after PR 3. The
+  // window closes in PRD-179 PR 4, which restructures retrieval (see
+  // JSDoc on HybridSearchService / SemanticSearchService /
+  // StructuredQueryService for the full plan).
   const db = getCerebrumDrizzle();
   const engramsDb = getCerebrumDrizzle();
   const searchService = new HybridSearchService(getDrizzle());

--- a/apps/pops-api/src/modules/cerebrum/retrieval/hybrid-search.ts
+++ b/apps/pops-api/src/modules/cerebrum/retrieval/hybrid-search.ts
@@ -9,6 +9,44 @@ import { StructuredQueryService } from './structured-query.js';
  * and routes the unified `search` procedure.
  *
  * RRF formula: score = sum(1 / (k + rank_i)) where k = 60.
+ *
+ * ## Cross-store read pattern (PRD-179 PR 3)
+ *
+ * After PRD-179 PR 3 the engram CRUD path writes the `engram_index` /
+ * `engram_scopes` / `engram_tags` / `engram_links` rows exclusively to
+ * the cerebrum pillar handle (`cerebrum.db`). This service, however, is
+ * still wired to the shared `pops.db` handle (`getDrizzle()`) at every
+ * call site because both legs of the hybrid pipeline join engram
+ * metadata with cross-pillar domain tables that have **not** migrated
+ * to the cerebrum file yet:
+ *
+ *   - `StructuredQueryService` reads `engram_index` + junctions.
+ *   - `SemanticSearchService` calls `resolveEngramMetadata` in
+ *     `semantic-search-metadata.ts`, which joins `engram_index` against
+ *     `transactions`, `movies`, `tv_shows`, and `home_inventory` on
+ *     the shared handle.
+ *
+ * Switching the constructor to `getCerebrumDrizzle()` would make the
+ * engram-side reads consistent with the writes but would break the
+ * cross-pillar enrichment joins immediately. The trade-off chosen for
+ * PR 3 is to keep the shared handle and lean on
+ * `backfillCerebrumFromShared` to seed `cerebrum.db.engram_index` from
+ * `pops.db` on boot. The backfill is one-directional (pops → cerebrum),
+ * so any engram created or mutated *after* PR 3 lands only in
+ * `cerebrum.db` and is **invisible** to this service until either:
+ *
+ *   1. A boot redeploy re-runs the backfill (which does not back-copy
+ *      cerebrum → pops, so this does not actually heal the gap), or
+ *   2. PRD-179 PR 4 retires the backfill and restructures retrieval
+ *      to either (a) route engram metadata through
+ *      `getCerebrumDrizzle()` and resolve cross-pillar enrichment via
+ *      per-pillar SDK lookups instead of SQL joins, or (b) reintroduce
+ *      a cerebrum → pops mirror for the engram tables.
+ *
+ * TODO(PRD-179 PR 4): split engram metadata reads off the shared handle.
+ * The current shape is a known stale-read window between PR 3 (writes
+ * flipped) and PR 4 (retrieval flipped). Tracked under the PRD-179
+ * cutover plan.
  */
 import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 

--- a/apps/pops-api/src/modules/cerebrum/retrieval/semantic-search-metadata.ts
+++ b/apps/pops-api/src/modules/cerebrum/retrieval/semantic-search-metadata.ts
@@ -1,3 +1,24 @@
+/**
+ * Engram metadata + cross-pillar enrichment resolver for
+ * SemanticSearchService.
+ *
+ * ## Cross-store read pattern (PRD-179 PR 3)
+ *
+ * The `db` handle passed in is the shared `pops.db` (`getDrizzle()`)
+ * because `fetchDomainRow` and `resolveMetadata` join `engram_index`
+ * against `transactions`, `movies`, `tv_shows`, and `home_inventory`,
+ * all of which still live in the shared file. After PRD-179 PR 3,
+ * engram writes land in `cerebrum.db`; the boot-time backfill is
+ * pops → cerebrum only, so any engram created or modified after the
+ * PR 3 cutover is invisible to this resolver until PRD-179 PR 4
+ * restructures retrieval (either: read engram metadata from
+ * `getCerebrumDrizzle()` and pull domain rows via per-pillar SDK
+ * lookups, or add a reverse cerebrum → pops mirror).
+ *
+ * TODO(PRD-179 PR 4): replace cross-pillar SQL joins with SDK-driven
+ * per-pillar lookups so this resolver can read engrams from the
+ * cerebrum handle without losing enrichment.
+ */
 import { eq } from 'drizzle-orm';
 
 import {

--- a/apps/pops-api/src/modules/cerebrum/retrieval/semantic-search.ts
+++ b/apps/pops-api/src/modules/cerebrum/retrieval/semantic-search.ts
@@ -1,6 +1,28 @@
 /**
  * SemanticSearchService — wraps core semanticSearch with Thalamus metadata
  * resolution, scope/type/status filtering, and RetrievalResult shaping.
+ *
+ * ## Cross-store read pattern (PRD-179 PR 3)
+ *
+ * The `db` handle injected into this service is the shared
+ * `pops.db` (`getDrizzle()`) at every production call site, even though
+ * PRD-179 PR 3 has already moved engram writes to `cerebrum.db`. The
+ * reason is `resolveMetadata` (see `semantic-search-metadata.ts`),
+ * which joins `engram_index` against cross-pillar tables —
+ * `transactions`, `movies`, `tv_shows`, `home_inventory` — that still
+ * live in the shared file. Narrowing this handle to
+ * `getCerebrumDrizzle()` would make engram reads consistent with the
+ * new writes but break the cross-pillar enrichment.
+ *
+ * The boot-time `backfillCerebrumFromShared` is one-directional
+ * (pops → cerebrum), so post-PR-3 engram writes are **not** mirrored
+ * back to `pops.db`. Until PRD-179 PR 4 restructures retrieval to
+ * either (a) read engram metadata via `getCerebrumDrizzle()` and
+ * resolve domain enrichment via per-pillar SDK calls, or (b) add a
+ * reverse mirror, this service can return stale data for engrams
+ * created or modified after PR 3 lands.
+ *
+ * TODO(PRD-179 PR 4): split engram metadata reads off the shared handle.
  */
 import { createHash } from 'node:crypto';
 

--- a/apps/pops-api/src/modules/cerebrum/retrieval/structured-query.ts
+++ b/apps/pops-api/src/modules/cerebrum/retrieval/structured-query.ts
@@ -1,6 +1,30 @@
 /**
  * StructuredQueryService — filters engram_index and junction tables using
  * parameterised SQL. Returns RetrievalResult[] with matchType: 'structured'.
+ *
+ * ## Cross-store read pattern (PRD-179 PR 3)
+ *
+ * The `db` handle injected here is the shared `pops.db` (`getDrizzle()`)
+ * at every production call site, even though PRD-179 PR 3 has already
+ * routed engram writes (`engram_index`, `engram_scopes`, `engram_tags`,
+ * `engram_links`) to `cerebrum.db`. The reason this service stays on
+ * the shared handle is the downstream `HybridSearchService` pairing
+ * with `SemanticSearchService`, whose metadata resolver joins
+ * `engram_index` with cross-pillar tables (`transactions`, `movies`,
+ * `tv_shows`, `home_inventory`) that have not migrated to `cerebrum.db`.
+ * Splitting just this service onto `getCerebrumDrizzle()` would create
+ * a structured vs. semantic store mismatch and complicate RRF merging.
+ *
+ * `backfillCerebrumFromShared` runs one-directionally on boot
+ * (pops → cerebrum), so post-PR-3 writes that land only in `cerebrum.db`
+ * are **not** mirrored back to `pops.db`. This service therefore can
+ * miss engrams created or modified after the PR 3 cutover. The known
+ * window closes with PRD-179 PR 4, which restructures retrieval to
+ * either route engram metadata through `getCerebrumDrizzle()` and
+ * resolve domain enrichment via per-pillar SDK calls, or add a
+ * cerebrum → pops mirror for the engram tables.
+ *
+ * TODO(PRD-179 PR 4): split engram metadata reads off the shared handle.
  */
 import { and, desc, eq, inArray } from 'drizzle-orm';
 

--- a/apps/pops-api/src/modules/cerebrum/thalamus/instance.ts
+++ b/apps/pops-api/src/modules/cerebrum/thalamus/instance.ts
@@ -12,7 +12,7 @@ import { eq } from 'drizzle-orm';
 
 import { engramIndex } from '@pops/db-types';
 
-import { getDrizzle } from '../../../db.js';
+import { getCerebrumDrizzle } from '../../../db/cerebrum-handle.js';
 import { DEFAULT_JOB_OPTIONS, getDefaultQueue } from '../../../jobs/queues.js';
 import { getSettingValue } from '../../core/settings/service.js';
 import { getEngramRoot } from '../instance.js';
@@ -49,7 +49,7 @@ export async function startThalamus(): Promise<void> {
     return;
   }
 
-  const db = getDrizzle();
+  const db = getCerebrumDrizzle();
 
   // Build the set of paths currently in the index so the watcher can
   // reconcile files that were modified while the server was down.

--- a/apps/pops-api/src/modules/cerebrum/thalamus/router.ts
+++ b/apps/pops-api/src/modules/cerebrum/thalamus/router.ts
@@ -5,6 +5,7 @@
 import { z } from 'zod';
 
 import { getDrizzle } from '../../../db.js';
+import { getCerebrumDrizzle } from '../../../db/cerebrum-handle.js';
 import { EMBEDDINGS_QUEUE, getEmbeddingsQueue } from '../../../jobs/queues.js';
 import { protectedProcedure, router } from '../../../trpc.js';
 import { getEngramRoot } from '../instance.js';
@@ -55,7 +56,7 @@ export const indexRouter = router({
         // If forced, enqueue embeddings for all engrams in the index.
         const { FrontmatterSyncService } = await import('./sync.js');
         const { EmbeddingTrigger } = await import('./embedding-trigger.js');
-        const db = getDrizzle();
+        const db = getCerebrumDrizzle();
         const root = getEngramRoot();
         const syncService = new FrontmatterSyncService(root, db);
         const trigger = new EmbeddingTrigger();
@@ -100,7 +101,7 @@ export const indexRouter = router({
       const { engramIndex } = await import('@pops/db-types');
 
       const root = getEngramRoot();
-      const db = getDrizzle();
+      const db = getCerebrumDrizzle();
 
       if (!existsSync(root)) {
         return { missing: [], orphaned: [], dryRun: input.dryRun ?? false };

--- a/apps/pops-api/src/modules/cerebrum/thalamus/sync-junctions.ts
+++ b/apps/pops-api/src/modules/cerebrum/thalamus/sync-junctions.ts
@@ -1,10 +1,9 @@
 import { and, eq, inArray } from 'drizzle-orm';
 
+import { type CerebrumDb } from '@pops/cerebrum-db';
 import { engramLinks, engramScopes, engramTags } from '@pops/db-types';
 
-import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
-
-type Tx = Parameters<Parameters<BetterSQLite3Database['transaction']>[0]>[0];
+type Tx = Parameters<Parameters<CerebrumDb['transaction']>[0]>[0];
 
 export function syncEngramScopes(tx: Tx, engramId: string, newScopes: string[]): void {
   const currentScopes = tx

--- a/apps/pops-api/src/modules/cerebrum/thalamus/sync.ts
+++ b/apps/pops-api/src/modules/cerebrum/thalamus/sync.ts
@@ -8,12 +8,11 @@ import { join } from 'node:path';
 
 import { eq } from 'drizzle-orm';
 
+import { type CerebrumDb } from '@pops/cerebrum-db';
 import { engramIndex } from '@pops/db-types';
 
 import { countWords, deriveTitle, parseEngramFile } from '../engrams/file.js';
 import { syncEngramLinks, syncEngramScopes, syncEngramTags } from './sync-junctions.js';
-
-import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 
 import type { WatchEvent } from './watcher.js';
 
@@ -82,7 +81,7 @@ interface IndexValues {
 }
 
 function upsertIndexRow(
-  tx: Parameters<Parameters<BetterSQLite3Database['transaction']>[0]>[0],
+  tx: Parameters<Parameters<CerebrumDb['transaction']>[0]>[0],
   values: IndexValues
 ): void {
   tx.insert(engramIndex)
@@ -108,7 +107,7 @@ function upsertIndexRow(
 export class FrontmatterSyncService {
   constructor(
     private readonly root: string,
-    private readonly db: BetterSQLite3Database
+    private readonly db: CerebrumDb
   ) {}
 
   /**


### PR DESCRIPTION
## Summary

PRD-179 PR 2 (#3011) cut engram **reads** to `getCerebrumDrizzle()` while writes still landed on the shared `pops.db`. This PR closes the split so every engram path — `list`, `read`, `exists`, `create`, `update`, `archive`, `restore`, `changeType`, `link`, `unlink`, `hardDelete`, `reindex` — plus the thalamus watcher/reconcile path and scope reclassification route through the cerebrum pillar handle (`cerebrum.db`).

## Sites migrated

- **`EngramService` (`engrams/service.ts`)** — collapsed `db` + `readDb` into a single `CerebrumDb` handle. `exists` no longer falls back to the shared store now that writes target the same DB. `instance.ts` wires `getCerebrumDrizzle()` as the single handle.
- **Engram write handlers (`handlers/*.ts`)** — `upsert-index`, `archive-engram`, `restore-engram`, `change-type`, `create-engram`, `delete-engram`, `link-helpers`, `rebuild-index`, `fs-helpers`, `list-engrams` — parameter types flipped from `BetterSQLite3Database` to `CerebrumDb`.
- **`engrams/reclassify.ts`** (bulk scope rename) and its caller in `scopes-router.ts`.
- **`engrams/scopes-router.ts`** — `reclassify` (write), `list` / `reconcile` / `filter` (reads paired with the cutover writes).
- **`engrams/tags-router.ts`** — `list` reads from the cerebrum handle.
- **`engrams/scope-filter.ts`** — widened to `CerebrumDb`.
- **`thalamus/sync.ts` (`FrontmatterSyncService`) + `sync-junctions.ts`** — filesystem-watcher index updates now target `cerebrum.db`.
- **`thalamus/instance.ts`** — boot-time reconciliation reads against the cerebrum handle.
- **`thalamus/router.ts`** — `reindex (force)` + `reconcile` mutations flow through `getCerebrumDrizzle()`.
- **`ingest/pipeline-helpers.ts`** — `findDuplicate` body-hash check moved to `cerebrum.db` so dedup sees freshly-written rows.
- **`nudges/router.ts`** — `engramsDb` for `loadActiveEngrams` resolved via `getCerebrumDrizzle()`.
- **`nudges/detectors/citation-flush.ts`** — type signature widened to `CerebrumDb` for the dead-code engram_index update.
- **`jobs/handlers/curation.ts`** — `listScopes(getCerebrumDrizzle())`.

## Sites kept on `getDrizzle()` (documented, deferred)

- **`retrieval/{semantic-search,structured-query,hybrid-search}.ts` + `semantic-search-metadata.ts`** — semantic search joins cross-pillar source tables (`movies`, `tvShows`, `transactions`, `homeInventory`) for cross-source result enrichment. Those tables live in their own pillar DBs / the shared `pops.db`, so narrowing the handle here would break the join. Documented inline in `nudges/router.ts`; the cross-source metadata resolver will be split in a separate PR.

## Test rig changes

- `service.test.ts`, `scopes-router.test.ts`, `scope-filter.test.ts`, `tags-router.test.ts`, `handlers/restore-engram.test.ts`, `handlers/change-type.test.ts`, `glia/__tests__/revert-operations.test.ts` now pass `drizzle<Record<string, unknown>>(rawDb)` so the in-memory SQLite test handle satisfies the `CerebrumDb` shape without any `as` cast.
- `jobs/handlers/curation.test.ts` extended with a mock for `../../db/cerebrum-handle.js` so `processClassifyEngram` can resolve the new handle in isolation.

## Cross-store consistency

`backfillCerebrumFromShared()` already carries `engram_index`, `engram_scopes`, `engram_tags`, `engram_links` from `pops.db` into `cerebrum.db` at boot — the first deploy after this cut closes the initial divergence; subsequent boots are no-ops via the idempotent per-table existence filter. PR 4 drops the backfill bridge and the shared-journal shim.

## Tests + checks run

- `pnpm -F @pops/api test src/modules/cerebrum` — **1128 tests pass**.
- `pnpm -F @pops/api test src/modules/cerebrum/engrams` — **170 tests pass**.
- `pnpm -F @pops/api test src/jobs/handlers/curation.test.ts` — **16 tests pass**.
- `pnpm -F @pops/cerebrum-db test` — **119 tests pass**.
- `pnpm -w typecheck` — clean.
- `pnpm format:check` — clean (post `pnpm format`).
- `pnpm lint` — no new errors (pre-existing warnings unchanged).
- `pnpm -F @pops/api test` full suite — only pre-existing failures (`glia/toml-config.test.ts` default-threshold drift, `thalamus/watcher.test.ts` filesystem-timing flake that passes in isolation).

## Test plan

- [ ] CI passes on this branch.
- [ ] Smoke: in a dev environment with both `pops.db` and `cerebrum.db`, create + archive + restore + link + unlink + hardDelete engrams via the tRPC surface and confirm every row lands in `cerebrum.db.engram_index`/`engram_scopes`/`engram_tags`/`engram_links` (not `pops.db`).
- [ ] Smoke: drive the curation worker through `classifyEngram` and confirm `scope_reconciliation` sees the cerebrum scopes.
- [ ] Smoke: trigger `cerebrum.index.reindex({ force: true })` and confirm the `FrontmatterSyncService` writes land in `cerebrum.db`.
- [ ] Smoke: trigger glia consolidate + revert; confirm both the merged engram delete and the source-engram restore mutations land in `cerebrum.db`.
