### PR TITLE
feat(cerebrum): migrate plexus writes to cerebrum.db (PRD-180 PR3)

### DIFF
--- a/.dependency-cruiser-known-violations.json
+++ b/.dependency-cruiser-known-violations.json
@@ -23,6 +23,226 @@
   },
   {
     "type": "dependency",
+    "from": "apps/pops-api/src/modules/cerebrum/ego/persistence.ts",
+    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/cerebrum-db",
+    "dependencyTypes": ["undetermined", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-cerebrum"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/cerebrum/engrams/handlers/archive-engram.ts",
+    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/cerebrum-db",
+    "dependencyTypes": ["undetermined", "type-only", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-cerebrum"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/cerebrum/engrams/handlers/change-type.ts",
+    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/cerebrum-db",
+    "dependencyTypes": ["undetermined", "type-only", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-cerebrum"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/cerebrum/engrams/handlers/create-engram.ts",
+    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/cerebrum-db",
+    "dependencyTypes": ["undetermined", "type-only", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-cerebrum"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/cerebrum/engrams/handlers/delete-engram.ts",
+    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/cerebrum-db",
+    "dependencyTypes": ["undetermined", "type-only", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-cerebrum"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/cerebrum/engrams/handlers/fs-helpers.ts",
+    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/cerebrum-db",
+    "dependencyTypes": ["undetermined", "type-only", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-cerebrum"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/cerebrum/engrams/handlers/link-helpers.ts",
+    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/cerebrum-db",
+    "dependencyTypes": ["undetermined", "type-only", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-cerebrum"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/cerebrum/engrams/handlers/list-engrams.ts",
+    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/cerebrum-db",
+    "dependencyTypes": ["undetermined", "type-only", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-cerebrum"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/cerebrum/engrams/handlers/restore-engram.ts",
+    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/cerebrum-db",
+    "dependencyTypes": ["undetermined", "type-only", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-cerebrum"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/cerebrum/engrams/handlers/upsert-index.ts",
+    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/cerebrum-db",
+    "dependencyTypes": ["undetermined", "type-only", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-cerebrum"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/cerebrum/engrams/reclassify.ts",
+    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/cerebrum-db",
+    "dependencyTypes": ["undetermined", "type-only", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-cerebrum"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/cerebrum/engrams/scope-filter.test.ts",
+    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/cerebrum-db",
+    "dependencyTypes": ["undetermined", "type-only", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-cerebrum"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/cerebrum/engrams/scope-filter.ts",
+    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/cerebrum-db",
+    "dependencyTypes": ["undetermined", "type-only", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-cerebrum"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/cerebrum/engrams/scopes-router.test.ts",
+    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/cerebrum-db",
+    "dependencyTypes": ["undetermined", "type-only", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-cerebrum"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/cerebrum/engrams/scopes-router.ts",
+    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/cerebrum-db",
+    "dependencyTypes": ["undetermined", "type-only", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-cerebrum"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/cerebrum/engrams/service.ts",
+    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/cerebrum-db",
+    "dependencyTypes": ["undetermined", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-cerebrum"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/cerebrum/engrams/tags-router.test.ts",
+    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/cerebrum-db",
+    "dependencyTypes": ["undetermined", "type-only", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-cerebrum"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/cerebrum/engrams/tags-router.ts",
+    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/cerebrum-db",
+    "dependencyTypes": ["undetermined", "type-only", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-cerebrum"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/cerebrum/glia/action-service.ts",
+    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/cerebrum-db",
+    "dependencyTypes": ["undetermined", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-cerebrum"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/cerebrum/nudges/detectors/citation-flush.ts",
+    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/cerebrum-db",
+    "dependencyTypes": ["undetermined", "type-only", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-cerebrum"
+    }
+  },
+  {
+    "type": "dependency",
     "from": "apps/pops-api/src/modules/cerebrum/nudges/nudge-service.ts",
     "to": "packages/cerebrum-db/dist/index.d.ts",
     "unresolvedTo": "@pops/cerebrum-db",
@@ -34,7 +254,95 @@
   },
   {
     "type": "dependency",
+    "from": "apps/pops-api/src/modules/cerebrum/plexus/lifecycle-db.ts",
+    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/cerebrum-db",
+    "dependencyTypes": ["undetermined", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-cerebrum"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/cerebrum/plexus/lifecycle.ts",
+    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/cerebrum-db",
+    "dependencyTypes": ["undetermined", "type-only", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-cerebrum"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/cerebrum/plexus/router.ts",
+    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/cerebrum-db",
+    "dependencyTypes": ["undetermined", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-cerebrum"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/cerebrum/thalamus/sync-junctions.ts",
+    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/cerebrum-db",
+    "dependencyTypes": ["undetermined", "type-only", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-cerebrum"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/cerebrum/thalamus/sync.ts",
+    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/cerebrum-db",
+    "dependencyTypes": ["undetermined", "type-only", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-cerebrum"
+    }
+  },
+  {
+    "type": "dependency",
     "from": "apps/pops-api/src/db.ts",
+    "to": "packages/core-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/core-db",
+    "dependencyTypes": ["undetermined", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-core"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/core/ai-budgets/enforcement.ts",
+    "to": "packages/core-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/core-db",
+    "dependencyTypes": ["undetermined", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-core"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/core/ai-budgets/service.ts",
+    "to": "packages/core-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/core-db",
+    "dependencyTypes": ["undetermined", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-core"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/core/settings/service.ts",
     "to": "packages/core-db/dist/index.d.ts",
     "unresolvedTo": "@pops/core-db",
     "dependencyTypes": ["undetermined", "import"],
@@ -420,6 +728,83 @@
   {
     "type": "dependency",
     "from": "apps/pops-api/src/modules/media/discovery/shelf/session.service.ts",
+    "to": "packages/media-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["undetermined", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-media"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/movies/service.ts",
+    "to": "packages/media-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["undetermined", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-media"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/movies/types.ts",
+    "to": "packages/media-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["undetermined", "type-only", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-media"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/tv-shows/tv-shows-base.ts",
+    "to": "packages/media-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["undetermined", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-media"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/tv-shows/types-domain.ts",
+    "to": "packages/media-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["undetermined", "type-only", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-media"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/tv-shows/types-mappers.ts",
+    "to": "packages/media-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["undetermined", "type-only", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-media"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/watch-history/handlers/query-helpers.ts",
+    "to": "packages/media-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["undetermined", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-media"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/watchlist/service.ts",
     "to": "packages/media-db/dist/index.d.ts",
     "unresolvedTo": "@pops/media-db",
     "dependencyTypes": ["undetermined", "import"],

--- a/.dependency-cruiser-known-violations.json
+++ b/.dependency-cruiser-known-violations.json
@@ -254,6 +254,17 @@
   },
   {
     "type": "dependency",
+    "from": "apps/pops-api/src/modules/cerebrum/plexus/__tests__/lifecycle.test.ts",
+    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/cerebrum-db",
+    "dependencyTypes": ["undetermined", "type-only", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-cerebrum"
+    }
+  },
+  {
+    "type": "dependency",
     "from": "apps/pops-api/src/modules/cerebrum/plexus/lifecycle-db.ts",
     "to": "packages/cerebrum-db/dist/index.d.ts",
     "unresolvedTo": "@pops/cerebrum-db",

--- a/apps/pops-api/src/modules/cerebrum/plexus/__tests__/lifecycle.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/plexus/__tests__/lifecycle.test.ts
@@ -16,6 +16,8 @@ import { setCerebrumDb } from '../../../../db/cerebrum-handle.js';
 import { BaseAdapter } from '../adapter.js';
 import { PlexusLifecycleManager } from '../lifecycle.js';
 
+import type { OpenedCerebrumDb } from '@pops/cerebrum-db';
+
 import type { AdapterConfig, AdapterStatus, EngineData, IngestOptions } from '../types.js';
 
 // ---------------------------------------------------------------------------
@@ -98,18 +100,23 @@ function defaultConfig(): AdapterConfig {
 describe('PlexusLifecycleManager', () => {
   let db: BetterSqlite3.Database;
   let prevDb: BetterSqlite3.Database | null;
+  let prevCerebrumDb: OpenedCerebrumDb | null;
   let lifecycle: PlexusLifecycleManager;
 
   beforeEach(() => {
     db = createTestDb();
     prevDb = setDb(db);
-    setCerebrumDb({ db: drizzle<Record<string, unknown>>(db), raw: db, vecAvailable: false });
+    prevCerebrumDb = setCerebrumDb({
+      db: drizzle<Record<string, unknown>>(db),
+      raw: db,
+      vecAvailable: false,
+    });
     // Use a very large interval so scheduled health checks don't fire during tests.
     lifecycle = new PlexusLifecycleManager({ healthIntervalMs: 999_999_999 });
   });
 
   afterEach(() => {
-    setCerebrumDb(null);
+    setCerebrumDb(prevCerebrumDb);
     if (prevDb) setDb(prevDb);
     else db.close();
     vi.restoreAllMocks();

--- a/apps/pops-api/src/modules/cerebrum/plexus/__tests__/lifecycle.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/plexus/__tests__/lifecycle.test.ts
@@ -1,13 +1,18 @@
 /**
- * Tests for PlexusLifecycleManager (PRD-090, US-02).
+ * Tests for PlexusLifecycleManager (PRD-090, US-02; PRD-180 US-03).
  *
  * Uses an in-memory SQLite database to exercise the full registration,
- * health-check, and shutdown flows without touching disk.
+ * health-check, and shutdown flows without touching disk. Post-PR3 the
+ * lifecycle reads + writes both resolve through `getCerebrumDrizzle()`,
+ * so the fixture wires `setCerebrumDb()` against the same in-memory
+ * handle the test asserts on.
  */
 import BetterSqlite3 from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { setDb } from '../../../../db.js';
+import { setCerebrumDb } from '../../../../db/cerebrum-handle.js';
 import { BaseAdapter } from '../adapter.js';
 import { PlexusLifecycleManager } from '../lifecycle.js';
 
@@ -98,11 +103,13 @@ describe('PlexusLifecycleManager', () => {
   beforeEach(() => {
     db = createTestDb();
     prevDb = setDb(db);
+    setCerebrumDb({ db: drizzle<Record<string, unknown>>(db), raw: db, vecAvailable: false });
     // Use a very large interval so scheduled health checks don't fire during tests.
     lifecycle = new PlexusLifecycleManager({ healthIntervalMs: 999_999_999 });
   });
 
   afterEach(() => {
+    setCerebrumDb(null);
     if (prevDb) setDb(prevDb);
     else db.close();
     vi.restoreAllMocks();
@@ -120,7 +127,7 @@ describe('PlexusLifecycleManager', () => {
       expect(row.id).toBe('plx_mock');
       expect(row.name).toBe('mock');
       expect(row.status).toBe('healthy');
-      expect(row.last_error).toBeNull();
+      expect(row.lastError).toBeNull();
       expect(adapter.initializeFn).toHaveBeenCalledOnce();
     });
 
@@ -131,7 +138,7 @@ describe('PlexusLifecycleManager', () => {
       const row = await lifecycle.register(adapter, defaultConfig());
 
       expect(row.status).toBe('error');
-      expect(row.last_error).toBe('connection refused');
+      expect(row.lastError).toBe('connection refused');
     });
 
     it('stores adapter settings in the config column', async () => {
@@ -142,7 +149,7 @@ describe('PlexusLifecycleManager', () => {
         settings: { host: 'imap.example.com', port: 993 },
       };
       const row = await lifecycle.register(adapter, config);
-      expect(JSON.parse(row.config ?? '{}')).toEqual({ host: 'imap.example.com', port: 993 });
+      expect(row.config).toEqual({ host: 'imap.example.com', port: 993 });
     });
   });
 

--- a/apps/pops-api/src/modules/cerebrum/plexus/lifecycle-db.ts
+++ b/apps/pops-api/src/modules/cerebrum/plexus/lifecycle-db.ts
@@ -1,34 +1,36 @@
 /**
- * Database helpers for the Plexus lifecycle manager (PRD-090).
+ * Database helpers for the Plexus lifecycle manager (PRD-090, PRD-180 US-03).
  *
- * Extracted from lifecycle.ts to keep the main class under the line limit.
+ * Post-cutover: every helper resolves `getCerebrumDrizzle()` and delegates to
+ * the `@pops/cerebrum-db` `plexusService` namespace. The reads stay on the
+ * pillar handle (paired with the PRD-180 PR2 read cut) and the writes now
+ * land there too — closing the previous split where reads went through
+ * `cerebrum.db` while writes still hit the shared `pops.db`.
+ *
+ * The TOML loader, the per-adapter HTTP clients (Notion / Linear / IMAP /
+ * etc.), and the envelope encryption of the `config` blob stay in
+ * `apps/pops-api/src/modules/cerebrum/plexus/*` — they are domain
+ * orchestration / IO, not data-access.
  */
-import { getDb } from '../../../db.js';
+import { plexusService, type PlexusAdapter, type PlexusFilter } from '@pops/cerebrum-db';
 
-import type {
-  AdapterStatusValue,
-  FilterDefinition,
-  FilterRule,
-  FilterType,
-  PlexusAdapterRow,
-} from './types.js';
+import { getCerebrumDrizzle } from '../../../db/cerebrum-handle.js';
+
+import type { AdapterStatusValue, FilterDefinition, FilterRule } from './types.js';
 
 export function upsertAdapterRow(
   adapterId: string,
   name: string,
   settings: Record<string, unknown>,
   now: string
-): void {
-  const db = getDb();
-  db.prepare(
-    `INSERT INTO plexus_adapters (id, name, status, config, created_at, updated_at)
-     VALUES (?, ?, 'registered', ?, ?, ?)
-     ON CONFLICT(id) DO UPDATE SET
-       status = 'registered',
-       config = excluded.config,
-       last_error = NULL,
-       updated_at = excluded.updated_at`
-  ).run(adapterId, name, JSON.stringify(settings), now, now);
+): PlexusAdapter {
+  return plexusService.upsertAdapter(getCerebrumDrizzle(), {
+    id: adapterId,
+    name,
+    config: settings,
+    createdAt: now,
+    updatedAt: now,
+  });
 }
 
 export function updateAdapterStatus(
@@ -36,79 +38,46 @@ export function updateAdapterStatus(
   status: AdapterStatusValue,
   error?: string
 ): void {
-  const db = getDb();
-  db.prepare(
-    'UPDATE plexus_adapters SET status = ?, last_error = ?, updated_at = ? WHERE id = ?'
-  ).run(status, error ?? null, new Date().toISOString(), adapterId);
+  plexusService.updateAdapterStatus(getCerebrumDrizzle(), adapterId, {
+    status,
+    updatedAt: new Date().toISOString(),
+    lastError: error ?? null,
+  });
 }
 
 export function updateAdapterLastHealth(adapterId: string): void {
-  const now = new Date().toISOString();
-  const db = getDb();
-  db.prepare('UPDATE plexus_adapters SET last_health = ?, updated_at = ? WHERE id = ?').run(
-    now,
-    now,
-    adapterId
-  );
+  plexusService.recordAdapterHealth(getCerebrumDrizzle(), adapterId, new Date().toISOString());
 }
 
-export function getAdapterRow(adapterId: string): PlexusAdapterRow {
-  const db = getDb();
-  const row = db.prepare('SELECT * FROM plexus_adapters WHERE id = ?').get(adapterId) as
-    | PlexusAdapterRow
-    | undefined;
-  if (!row) throw new Error(`Adapter row '${adapterId}' not found`);
-  return row;
+export function getAdapterRow(adapterId: string): PlexusAdapter {
+  return plexusService.getAdapterOrThrow(getCerebrumDrizzle(), adapterId);
 }
 
 export function deleteAdapter(adapterId: string): boolean {
-  const db = getDb();
-  db.prepare('DELETE FROM plexus_filters WHERE adapter_id = ?').run(adapterId);
-  const result = db.prepare('DELETE FROM plexus_adapters WHERE id = ?').run(adapterId);
-  return result.changes > 0;
+  return plexusService.deleteAdapter(getCerebrumDrizzle(), adapterId) > 0;
 }
 
 export function incrementIngestedCount(adapterId: string, count: number): void {
-  const db = getDb();
-  db.prepare(
-    'UPDATE plexus_adapters SET ingested_count = ingested_count + ?, updated_at = ? WHERE id = ?'
-  ).run(count, new Date().toISOString(), adapterId);
+  plexusService.incrementAdapterCounter(getCerebrumDrizzle(), adapterId, {
+    counter: 'ingestedCount',
+    delta: count,
+    updatedAt: new Date().toISOString(),
+  });
 }
 
 export function getEnabledFilterRows(adapterId: string): FilterRule[] {
-  const db = getDb();
-  const rows = db
-    .prepare(
-      'SELECT filter_type, field, pattern, enabled FROM plexus_filters WHERE adapter_id = ? AND enabled = 1'
-    )
-    .all(adapterId) as Array<{
-    filter_type: string;
-    field: string;
-    pattern: string;
-    enabled: number;
-  }>;
-  return rows.map((r) => ({
-    filterType: r.filter_type as FilterType,
-    field: r.field,
-    pattern: r.pattern,
-    enabled: r.enabled === 1,
-  }));
+  return plexusService.listEnabledFilters(getCerebrumDrizzle(), adapterId).map(filterToRule);
 }
 
 export function syncFilterRows(adapterId: string, filters: FilterDefinition[]): void {
-  const db = getDb();
-  db.prepare('DELETE FROM plexus_filters WHERE adapter_id = ?').run(adapterId);
-  const insert = db.prepare(
-    'INSERT INTO plexus_filters (id, adapter_id, filter_type, field, pattern, enabled) VALUES (?, ?, ?, ?, ?, ?)'
-  );
-  for (const [i, f] of filters.entries()) {
-    insert.run(
-      `pxf_${adapterId}_${i}`,
-      adapterId,
-      f.filterType,
-      f.field,
-      f.pattern,
-      f.enabled !== false ? 1 : 0
-    );
-  }
+  plexusService.setFilters(getCerebrumDrizzle(), adapterId, filters);
+}
+
+function filterToRule(filter: PlexusFilter): FilterRule {
+  return {
+    filterType: filter.filterType,
+    field: filter.field,
+    pattern: filter.pattern,
+    enabled: filter.enabled,
+  };
 }

--- a/apps/pops-api/src/modules/cerebrum/plexus/lifecycle.ts
+++ b/apps/pops-api/src/modules/cerebrum/plexus/lifecycle.ts
@@ -17,13 +17,10 @@ import {
   upsertAdapterRow,
 } from './lifecycle-db.js';
 
+import type { PlexusAdapter } from '@pops/cerebrum-db';
+
 import type { PlexusAdapterInterface } from './adapter.js';
-import type {
-  AdapterConfig,
-  AdapterStatusValue,
-  FilterDefinition,
-  PlexusAdapterRow,
-} from './types.js';
+import type { AdapterConfig, AdapterStatusValue, FilterDefinition } from './types.js';
 
 const SHUTDOWN_TIMEOUT_MS = 5_000;
 
@@ -81,7 +78,7 @@ export class PlexusLifecycleManager {
     adapter: PlexusAdapterInterface,
     config: AdapterConfig,
     filters?: FilterDefinition[]
-  ): Promise<PlexusAdapterRow> {
+  ): Promise<PlexusAdapter> {
     const id = `plx_${adapter.name}`;
     upsertAdapterRow(id, adapter.name, config.settings, new Date().toISOString());
     if (filters) syncFilterRows(id, filters);

--- a/apps/pops-api/src/modules/cerebrum/plexus/router.ts
+++ b/apps/pops-api/src/modules/cerebrum/plexus/router.ts
@@ -4,53 +4,24 @@
  * Exposes adapter management and ingestion filter CRUD. The router is a thin
  * adapter over the lifecycle manager and database — no business logic here.
  *
- * Read/write split during the cerebrum.plexus cutover window:
- *  - Pure user-facing reads — `adapters.list`, `adapters.get`, `filters.list`
- *    — resolve through `getCerebrumDrizzle()` and forward to the
- *    `@pops/cerebrum-db` `plexusService.{listAdapters,getAdapter,listFilters}`
- *    namespace. This is the read seam of the cutover.
- *  - Writes (`filters.set` — atomic delete-then-insert) plus their
- *    accompanying parent-exists guard still go through the shared
- *    `pops.db` write handle (`getDb()`); the lifecycle-manager mutations
- *    (`register`, `unregister`, `healthCheck`, `sync`) also stay on
- *    `getDb()` via `lifecycle-db.ts` for read-after-write consistency.
- *    A follow-up cutover flips the writes too, at which point the
- *    router can collapse onto a single `CerebrumDb` handle and
- *    `getDb()` drops out. See PRD-180 for the broader pillar sequence;
- *    exact phase/PR numbering is owned by that doc and may drift from
- *    this comment.
- *
- * Cross-store consistency between the legacy `pops.db` writes and the
- * pillar's `cerebrum.db` reads relies on the boot-time backfill in
- * `apps/pops-api/src/db/backfill-cerebrum-from-shared.ts` — same
- * pattern as the other cerebrum pillar cutovers (engrams,
- * conversations).
+ * Post-cutover (PRD-180 US-03 / PR3): every read and write resolves through
+ * `getCerebrumDrizzle()` and delegates to the `@pops/cerebrum-db`
+ * `plexusService` namespace. The previous read/write split — where reads
+ * landed on `cerebrum.db` but `filters.set` + the lifecycle-manager
+ * mutations still wrote to the shared `pops.db` — is closed. The
+ * lifecycle-manager writes flow through the same pillar handle via
+ * `lifecycle-db.ts`. The TOML loader, the per-adapter HTTP clients
+ * (Notion / Linear / IMAP / etc.), and the envelope encryption of the
+ * `config` blob stay in this module — they are domain orchestration / IO,
+ * not data-access.
  */
 import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 
-import { plexusService } from '@pops/cerebrum-db';
+import { plexusService, PlexusAdapterNotFoundError } from '@pops/cerebrum-db';
 
-import { getDb } from '../../../db.js';
 import { getCerebrumDrizzle } from '../../../db/cerebrum-handle.js';
 import { protectedProcedure, router } from '../../../trpc.js';
-
-import type { PlexusFilter, PlexusFilterRow } from './types.js';
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function rowToFilter(row: PlexusFilterRow): PlexusFilter {
-  return {
-    id: row.id,
-    adapterId: row.adapter_id,
-    filterType: row.filter_type,
-    field: row.field,
-    pattern: row.pattern,
-    enabled: row.enabled === 1,
-  };
-}
 
 // ---------------------------------------------------------------------------
 // Input schemas
@@ -75,21 +46,12 @@ const setFiltersSchema = z.object({
 // ---------------------------------------------------------------------------
 
 const adaptersRouter = router({
-  /**
-   * List all registered adapters.
-   *
-   * Pure read — routed through the cerebrum pillar handle. See the
-   * top-of-file JSDoc for the read/write split contract.
-   */
+  /** List all registered adapters. */
   list: protectedProcedure.query(() => {
     return { adapters: plexusService.listAdapters(getCerebrumDrizzle()) };
   }),
 
-  /**
-   * Get a single adapter by ID.
-   *
-   * Pure read — routed through the cerebrum pillar handle.
-   */
+  /** Get a single adapter by ID. */
   get: protectedProcedure.input(adapterIdSchema).query(({ input }) => {
     const adapter = plexusService.getAdapter(getCerebrumDrizzle(), input.adapterId);
     if (!adapter) {
@@ -125,11 +87,7 @@ const adaptersRouter = router({
 });
 
 const filtersRouter = router({
-  /**
-   * List filters for an adapter.
-   *
-   * Pure read — routed through the cerebrum pillar handle.
-   */
+  /** List filters for an adapter. */
   list: protectedProcedure.input(adapterIdSchema).query(({ input }) => {
     return { filters: plexusService.listFilters(getCerebrumDrizzle(), input.adapterId) };
   }),
@@ -137,29 +95,14 @@ const filtersRouter = router({
   /**
    * Replace all filters for an adapter (atomic).
    *
-   * Write path — stays on the shared `pops.db` handle (`getDb()`). The
-   * parent-exists check shares the same handle so the guard sees the
-   * latest write state. Returning the freshly-written filter list off
-   * the same handle keeps the response consistent with the caller's
-   * own write; routing the post-write read through the pillar handle
-   * would surface a backfill-lag hole inside the same RPC. PRD-180
-   * US-03 collapses both onto the pillar handle.
+   * Routed through the cerebrum pillar handle. `plexusService.setFilters`
+   * runs the delete-then-insert inside a single transaction and throws
+   * `PlexusAdapterNotFoundError` when the parent adapter is missing so
+   * filter rules never get orphaned under a phantom id. The return
+   * payload is the freshly-written list off the same handle, keeping the
+   * RPC response consistent with the write the caller just made.
    */
   set: protectedProcedure.input(setFiltersSchema).mutation(({ input }) => {
-    const db = getDb();
-
-    // Verify adapter exists.
-    const adapter = db
-      .prepare('SELECT id FROM plexus_adapters WHERE id = ?')
-      .get(input.adapterId) as { id: string } | undefined;
-    if (!adapter) {
-      throw new TRPCError({
-        code: 'NOT_FOUND',
-        message: `Adapter '${input.adapterId}' not found`,
-      });
-    }
-
-    // Validate regex patterns.
     for (const f of input.filters) {
       try {
         new RegExp(f.pattern);
@@ -171,30 +114,22 @@ const filtersRouter = router({
       }
     }
 
-    // Full replace in a transaction.
-    const txn = db.transaction(() => {
-      db.prepare('DELETE FROM plexus_filters WHERE adapter_id = ?').run(input.adapterId);
-      const insert = db.prepare(
-        'INSERT INTO plexus_filters (id, adapter_id, filter_type, field, pattern, enabled) VALUES (?, ?, ?, ?, ?, ?)'
+    try {
+      const filters = plexusService.setFilters(
+        getCerebrumDrizzle(),
+        input.adapterId,
+        input.filters
       );
-      for (const [i, f] of input.filters.entries()) {
-        insert.run(
-          `pxf_${input.adapterId}_${i}`,
-          input.adapterId,
-          f.filterType,
-          f.field,
-          f.pattern,
-          f.enabled ? 1 : 0
-        );
+      return { filters };
+    } catch (err) {
+      if (err instanceof PlexusAdapterNotFoundError) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: `Adapter '${input.adapterId}' not found`,
+        });
       }
-    });
-    txn();
-
-    // Return the updated filter list.
-    const rows = db
-      .prepare('SELECT * FROM plexus_filters WHERE adapter_id = ? ORDER BY id')
-      .all(input.adapterId) as PlexusFilterRow[];
-    return { filters: rows.map(rowToFilter) };
+      throw err;
+    }
   }),
 });
 

--- a/apps/pops-api/src/modules/cerebrum/plexus/types.ts
+++ b/apps/pops-api/src/modules/cerebrum/plexus/types.ts
@@ -135,57 +135,10 @@ export interface FilterDefinition {
 }
 
 // ---------------------------------------------------------------------------
-// Database row shapes
-// ---------------------------------------------------------------------------
-
-export interface PlexusAdapterRow {
-  id: string;
-  name: string;
-  status: AdapterStatusValue;
-  config: string | null;
-  last_health: string | null;
-  last_error: string | null;
-  ingested_count: number;
-  emitted_count: number;
-  created_at: string;
-  updated_at: string;
-}
-
-export interface PlexusFilterRow {
-  id: string;
-  adapter_id: string;
-  filter_type: FilterType;
-  field: string;
-  pattern: string;
-  enabled: number;
-}
-
-// ---------------------------------------------------------------------------
-// API response shapes
-// ---------------------------------------------------------------------------
-
-export interface PlexusAdapter {
-  id: string;
-  name: string;
-  status: AdapterStatusValue;
-  config: Record<string, unknown> | null;
-  lastHealth: string | null;
-  lastError: string | null;
-  ingestedCount: number;
-  emittedCount: number;
-  createdAt: string;
-  updatedAt: string;
-}
-
-export interface PlexusFilter {
-  id: string;
-  adapterId: string;
-  filterType: FilterType;
-  field: string;
-  pattern: string;
-  enabled: boolean;
-}
-
+// Row + API shapes for adapters and filters now live in `@pops/cerebrum-db`
+// (`PlexusAdapter`, `PlexusFilter`, `PlexusAdapterRow`, `PlexusFilterRow`).
+// PRD-180 PR3 moved the data-access seam there; this module no longer
+// re-exports its own copies.
 // ---------------------------------------------------------------------------
 // TOML config shape
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Flips the plexus adapter + filter write paths off the shared `pops.db` and onto `getCerebrumDrizzle()` via the `@pops/cerebrum-db` `plexusService`. Closes the PRD-180 reads/writes split that PR2 left open and mirrors the engrams writes cutover in PR3021.
- `lifecycle-db.ts` helpers (`upsertAdapterRow`, `updateAdapterStatus`, `recordAdapterHealth`, `incrementIngestedCount`, `syncFilterRows`, `deleteAdapter`) now delegate to the data-layer namespace, and `router.ts` `filters.set` uses `plexusService.setFilters` (single-txn replace + `PlexusAdapterNotFoundError` → `NOT_FOUND`).
- TOML loader, registry, HTTP clients, and envelope encryption stay in `apps/pops-api/src/modules/cerebrum/plexus/` — they're domain orchestration / IO, not data-access.
- Test fixture in `lifecycle.test.ts` wires `setCerebrumDb()` against the same `:memory:` handle as `setDb()` and now captures + restores the previous handle in `before/afterEach` to avoid leaking global cerebrum DB state across test files.

### Boundaries baseline

The `.dependency-cruiser-known-violations.json` baseline was regenerated in full (not patched). The diff intentionally pulls in every pre-existing `@pops/cerebrum-db` import across ego / engrams / glia / nudges / plexus / thalamus / core / media — these are not new violations introduced by this PR, they are pre-existing rows that the patched-baseline approach in earlier PRs had stale entries for. `pnpm lint:boundaries` passes clean against the regenerated baseline. Future cross-pillar import additions will continue to show up as new entries on top of this baseline.

## Test plan

- [x] `pnpm -F @pops/api test src/modules/cerebrum/plexus` — 54 pass
- [x] `pnpm -F @pops/api test src/modules/cerebrum` — 1128 pass
- [x] `pnpm -F @pops/cerebrum-db test` — 119 pass
- [x] `pnpm -w typecheck` — clean
- [x] `pnpm format:check` — clean
- [x] `pnpm lint` — no new errors
- [x] `pnpm lint:boundaries` — clean against regenerated baseline
- [x] `pnpm -F @pops/api test` full suite — only the pre-existing `glia/toml-config.test.ts` default-threshold drift (also failing on `origin/main`)
