### PR TITLE
feat(cerebrum): migrate conversations writes to cerebrum.db (PRD-182 PR3)

### DIFF
--- a/apps/pops-api/src/modules/cerebrum/ego/__tests__/chat-helpers.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/ego/__tests__/chat-helpers.test.ts
@@ -39,7 +39,10 @@ describe('chat-helpers persistence ordering', () => {
 
   beforeEach(() => {
     db = createTestDb();
-    persistence = new ConversationPersistence({ db: drizzle(db), now: makeClock() });
+    persistence = new ConversationPersistence({
+      db: drizzle<Record<string, unknown>>(db),
+      now: makeClock(),
+    });
   });
 
   afterEach(() => {

--- a/apps/pops-api/src/modules/cerebrum/ego/__tests__/ego-chat.integration.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/ego/__tests__/ego-chat.integration.test.ts
@@ -228,7 +228,7 @@ describe('Ego chat pipeline (integration)', () => {
     setTestDrizzle(drizzleDb);
 
     persistence = new ConversationPersistence({
-      db: drizzleDb,
+      db: drizzle<Record<string, unknown>>(rawDb),
       now: makeClock(),
     });
 

--- a/apps/pops-api/src/modules/cerebrum/ego/__tests__/persistence.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/ego/__tests__/persistence.test.ts
@@ -23,7 +23,7 @@ describe('ConversationPersistence', () => {
   beforeEach(() => {
     db = createTestDb();
     svc = new ConversationPersistence({
-      db: drizzle(db),
+      db: drizzle<Record<string, unknown>>(db),
       now: makeClock(),
     });
   });

--- a/apps/pops-api/src/modules/cerebrum/ego/chat-helpers.ts
+++ b/apps/pops-api/src/modules/cerebrum/ego/chat-helpers.ts
@@ -5,7 +5,6 @@
  * Extracted to avoid duplicating persistence, conversation resolution,
  * and app context comparison logic across the two code paths.
  */
-import { getDrizzle } from '../../../db.js';
 import { getCerebrumDrizzle } from '../../../db/cerebrum-handle.js';
 import { getSettingValue } from '../../core/settings/service.js';
 import { ConversationEngine } from './engine.js';
@@ -16,17 +15,14 @@ import { autoTitle } from './types.js';
 import type { AppContext, ChatResult, Conversation, Message, ScopeNegotiation } from './types.js';
 
 /**
- * Lazily instantiated persistence service.
- *
- * `db` is the shared `pops.db` write handle; `readDb` is the cerebrum
- * pillar's `cerebrum.db` read handle (PRD-182 PR 2 read seam — pure
- * reads forward to `@pops/cerebrum-db`'s `conversationsService`).
- * Writes plus read-after-write hops stay on `pops.db` until PRD-182
- * PR 3 flips them too. See `ConversationPersistence` top-of-file JSDoc
- * for the cross-store consistency contract.
+ * Lazily instantiated persistence service. Every conversation read,
+ * write, and read-after-write hop routes through the cerebrum pillar
+ * handle (`cerebrum.db`) after PRD-182 PR 3 collapses the read/write
+ * split. See `ConversationPersistence` top-of-file JSDoc for the
+ * cross-store consistency contract.
  */
 export function getPersistence(): ConversationPersistence {
-  return new ConversationPersistence({ db: getDrizzle(), readDb: getCerebrumDrizzle() });
+  return new ConversationPersistence({ db: getCerebrumDrizzle() });
 }
 
 export function getStore(): PersistenceStoreAdapter {

--- a/apps/pops-api/src/modules/cerebrum/ego/persistence.ts
+++ b/apps/pops-api/src/modules/cerebrum/ego/persistence.ts
@@ -1,60 +1,42 @@
 /**
- * Ego conversation persistence service — read/write split during the
- * PRD-182 cutover.
+ * Ego conversation persistence service — fully routed through the
+ * cerebrum pillar handle (`cerebrum.db`) after PRD-182 PR 3 collapses
+ * the read/write split.
  *
  * Thin CRUD layer over the `conversations`, `messages`, and
- * `conversation_context` tables. The class accepts two drizzle handles:
+ * `conversation_context` tables. PRD-182 PR 2 cut pure reads through
+ * `@pops/cerebrum-db`'s `conversationsService` namespace while writes
+ * still landed on the shared `pops.db`. This cutover (PR 3) closes the
+ * split so every path — `createConversation`, `appendMessage` (plus
+ * the auto-title heuristic's read-after-write hop), `upsertContext`,
+ * `deleteConversation`, `updateTitle`, `updateScopes`,
+ * `updateAppContext`, plus the read methods — routes through a single
+ * `CerebrumDb` handle wired to `getCerebrumDrizzle()` in
+ * `chat-helpers.ts` / `router-context.ts`.
  *
- *  - `db` (BetterSQLite3Database) — the shared `pops.db` write handle.
- *    Every write path lands here: `createConversation`,
- *    `appendMessage` (plus the auto-title heuristic's read-after-write
- *    hop), `upsertContext`, `deleteConversation`, `updateTitle`,
- *    `updateScopes`, `updateAppContext`.
- *  - `readDb` (CerebrumDb) — the cerebrum pillar's `cerebrum.db` read
- *    handle. PRD-182 PR 2 routes pure user-facing reads through
- *    `@pops/cerebrum-db`'s `conversationsService` namespace against this
- *    handle: `listConversations`, `getConversation`,
- *    `getContextEntries`. `readDb` is optional and falls back to `db`
- *    so the existing in-memory test rigs (which inject a single SQLite
- *    handle for both stores) keep working without churn.
+ * The boot-time backfill (`backfillCerebrumFromShared()` in
+ * `apps/pops-api/src/db/backfill-cerebrum-from-shared.ts`) carries any
+ * residual rows on the legacy shared `pops.db` forward on the first
+ * deploy after the cut. Subsequent boots are no-ops via the per-table
+ * existence filter; a follow-up PR retires the backfill and drops the
+ * shared-journal shim.
  *
- * Cross-store consistency relies on `backfillCerebrumFromShared()` in
- * `apps/pops-api/src/db/backfill-cerebrum-from-shared.ts`: a one-way,
- * boot-time copy from `pops.db` -> `cerebrum.db` that idempotently
- * fills missing rows on `conversations` + `messages` +
- * `conversation_context`. Between boots, newly-written rows live only
- * in `pops.db` until the next backfill, but read-after-write within the
- * same process is preserved because `maybeAutoTitle` (the only
- * post-write read) routes through `db`. Mirrors the read/write split
- * landed in PRD-179 PR 2 (engrams) and PRD-168 PR 2 (watch-history).
- *
- * PRD-182 PR 3 flips the writes too, at which point `db` collapses
- * into `readDb`. Heavy chat orchestration (LLM streaming, scope
- * negotiation, auto-title heuristic, persistence-store adapter) stays
- * in pops-api — `@pops/cerebrum-db` is pure data-access.
+ * Heavy chat orchestration (LLM streaming, scope negotiation,
+ * auto-title heuristic, persistence-store adapter) stays in pops-api
+ * — `@pops/cerebrum-db` is pure data-access.
  */
-import { and, eq, sql } from 'drizzle-orm';
-
 import { conversationsService, type CerebrumDb } from '@pops/cerebrum-db';
-import { conversations, conversationContext, messages } from '@pops/db-types/schema';
 
 import { mapPackageConversation, mapPackageMessage } from './persistence-mappers.js';
 import {
   autoTitle,
   generateConversationId,
   generateMessageId,
-  toConversation,
-  toMessage,
-} from './types.js';
-
-import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
-
-import type {
-  AppendMessageInput,
-  Conversation,
-  CreateConversationInput,
-  ListConversationsInput,
-  Message,
+  type AppendMessageInput,
+  type Conversation,
+  type CreateConversationInput,
+  type ListConversationsInput,
+  type Message,
 } from './types.js';
 
 export type {
@@ -66,68 +48,54 @@ export type {
 } from './types.js';
 export { autoTitle } from './types.js';
 
-type ConversationRow = typeof conversations.$inferSelect;
-type MessageRow = typeof messages.$inferSelect;
-
 export interface ConversationPersistenceOptions {
   /**
-   * Write handle — the shared `pops.db` drizzle wrapper. All write
-   * paths and read-after-write hops (the auto-title heuristic in
-   * particular) route through this handle until PRD-182 PR 3 flips the
-   * writes too.
+   * Cerebrum pillar drizzle handle (`getCerebrumDrizzle()` in
+   * production). After PRD-182 PR 3 every conversation read and write
+   * — including the auto-title read-after-write hop inside
+   * `appendMessage` — flows through this single handle. Test rigs that
+   * inject an in-memory SQLite pass it here as the only DB argument.
    */
-  db: BetterSQLite3Database;
-  /**
-   * Read handle — the cerebrum pillar's `cerebrum.db` drizzle wrapper.
-   * Pure user-facing reads (`listConversations`, `getConversation`,
-   * `getContextEntries`) forward through `@pops/cerebrum-db`'s
-   * `conversationsService` against this handle. Defaults to `db` so
-   * test rigs that inject a single in-memory SQLite keep working
-   * without churn.
-   */
-  readDb?: CerebrumDb;
+  db: CerebrumDb;
   now?: () => Date;
 }
 
 export class ConversationPersistence {
-  private readonly db: BetterSQLite3Database;
-  private readonly readDb: CerebrumDb;
+  private readonly db: CerebrumDb;
   private readonly now: () => Date;
 
   constructor(options: ConversationPersistenceOptions) {
     this.db = options.db;
-    this.readDb = options.readDb ?? options.db;
     this.now = options.now ?? (() => new Date());
   }
 
-  /** Create a new conversation. Writes to the shared `pops.db`. */
+  /** Create a new conversation. Writes to `cerebrum.db`. */
   createConversation(input: CreateConversationInput): Conversation {
     const now = this.now();
     const id = generateConversationId(now);
     const iso = now.toISOString();
-    const row: ConversationRow = {
+    const row = conversationsService.insertConversation(this.db, {
       id,
       title: input.title ?? null,
-      activeScopes: JSON.stringify(input.scopes ?? []),
-      appContext: input.appContext !== undefined ? JSON.stringify(input.appContext) : null,
+      activeScopes: input.scopes ?? [],
+      appContext: input.appContext ?? null,
       model: input.model,
       createdAt: iso,
       updatedAt: iso,
-    };
-    this.db.insert(conversations).values(row).run();
-    return toConversation(row);
+    });
+    return mapPackageConversation(row);
   }
 
   /**
    * List conversations with optional pagination and title search.
-   * Pure read — routed through `@pops/cerebrum-db`'s
-   * `conversationsService.listConversations` against `readDb`.
+   * Routed through `@pops/cerebrum-db`'s
+   * `conversationsService.listConversations`.
    */
   listConversations(input: ListConversationsInput = {}): {
     conversations: Conversation[];
     total: number;
   } {
-    const result = conversationsService.listConversations(this.readDb, {
+    const result = conversationsService.listConversations(this.db, {
       search: input.search,
       limit: input.limit ?? 50,
       offset: input.offset ?? 0,
@@ -139,150 +107,133 @@ export class ConversationPersistence {
   }
 
   /**
-   * Get a conversation with all its messages. Pure read — routed
-   * through `@pops/cerebrum-db`'s
-   * `conversationsService.{getConversation,listMessages}` against
-   * `readDb`. Returns `null` when the conversation is missing.
+   * Get a conversation with all its messages. Routed through
+   * `@pops/cerebrum-db`'s `conversationsService.{getConversation,
+   * listMessages}`. Returns `null` when the conversation is missing.
    */
   getConversation(id: string): { conversation: Conversation; messages: Message[] } | null {
-    const conv = conversationsService.getConversation(this.readDb, id);
+    const conv = conversationsService.getConversation(this.db, id);
     if (!conv) return null;
-    const msgs = conversationsService.listMessages(this.readDb, id);
+    const msgs = conversationsService.listMessages(this.db, id);
     return {
       conversation: mapPackageConversation(conv),
       messages: msgs.map(mapPackageMessage),
     };
   }
 
-  /** Delete a conversation and cascade to messages + context. Writes to `pops.db`. */
+  /**
+   * Delete a conversation. The ON DELETE CASCADE on `messages` and
+   * `conversation_context` carries the dependent rows along, so the
+   * package's `deleteConversation` doesn't need an explicit transaction.
+   */
   deleteConversation(id: string): void {
-    this.db.transaction((tx) => {
-      tx.delete(conversationContext).where(eq(conversationContext.conversationId, id)).run();
-      tx.delete(messages).where(eq(messages.conversationId, id)).run();
-      tx.delete(conversations).where(eq(conversations.id, id)).run();
-    });
+    conversationsService.deleteConversation(this.db, id);
   }
 
   /**
-   * Append a message to a conversation. Updates conversation.updatedAt.
-   * Auto-generates a title from the first user message when none is
-   * set. Writes (and the auto-title read-after-write hop) land on
-   * `pops.db`.
+   * Append a message to a conversation. The package's `insertMessage`
+   * already bumps `conversations.updated_at` atomically inside a
+   * transaction. Auto-generates a title from the first user message
+   * when none is set; the read-after-write hop stays on the same
+   * `cerebrum.db` handle.
    */
   appendMessage(conversationId: string, input: AppendMessageInput): Message {
     const now = this.now();
     const id = generateMessageId(now);
     const iso = now.toISOString();
-    const row: MessageRow = {
+    const row = conversationsService.insertMessage(this.db, {
       id,
       conversationId,
-      role: input.role,
+      role: this.coerceRole(input.role),
       content: input.content,
-      citations: input.citations ? JSON.stringify(input.citations) : null,
-      toolCalls: input.toolCalls ? JSON.stringify(input.toolCalls) : null,
+      citations: input.citations ?? null,
+      toolCalls: input.toolCalls ?? null,
       tokensIn: input.tokensIn ?? null,
       tokensOut: input.tokensOut ?? null,
       createdAt: iso,
-    };
-    this.db.insert(messages).values(row).run();
-    this.db
-      .update(conversations)
-      .set({ updatedAt: iso })
-      .where(eq(conversations.id, conversationId))
-      .run();
-    this.maybeAutoTitle(conversationId, input);
-    return toMessage(row);
+    });
+    this.maybeAutoTitle(conversationId, input, iso);
+    return mapPackageMessage(row);
   }
 
   /**
-   * Insert or update a context entry linking a conversation to an engram.
-   * Writes to `pops.db`.
+   * Insert or update a context entry linking a conversation to an
+   * engram. Writes to `cerebrum.db`.
    */
   upsertContext(conversationId: string, engramId: string, relevanceScore?: number): void {
     const iso = this.now().toISOString();
-    this.db
-      .insert(conversationContext)
-      .values({ conversationId, engramId, relevanceScore: relevanceScore ?? null, loadedAt: iso })
-      .onConflictDoUpdate({
-        target: [conversationContext.conversationId, conversationContext.engramId],
-        set: { relevanceScore: relevanceScore ?? null, loadedAt: iso },
-      })
-      .run();
+    conversationsService.upsertConversationContext(this.db, {
+      conversationId,
+      engramId,
+      relevanceScore: relevanceScore ?? null,
+      loadedAt: iso,
+    });
   }
 
-  /** Update the conversation title. Writes to `pops.db`. */
+  /** Update the conversation title. Writes to `cerebrum.db`. */
   updateTitle(conversationId: string, title: string): void {
-    this.db
-      .update(conversations)
-      .set({ title, updatedAt: this.now().toISOString() })
-      .where(eq(conversations.id, conversationId))
-      .run();
+    conversationsService.updateConversation(this.db, conversationId, {
+      title,
+      updatedAt: this.now().toISOString(),
+    });
   }
 
-  /** Replace the conversation's active scopes. Writes to `pops.db`. */
+  /** Replace the conversation's active scopes. Writes to `cerebrum.db`. */
   updateScopes(conversationId: string, scopes: string[]): void {
-    this.db
-      .update(conversations)
-      .set({ activeScopes: JSON.stringify(scopes), updatedAt: this.now().toISOString() })
-      .where(eq(conversations.id, conversationId))
-      .run();
+    conversationsService.updateConversation(this.db, conversationId, {
+      activeScopes: scopes,
+      updatedAt: this.now().toISOString(),
+    });
   }
 
-  /** Update the conversation's app context (US-03). Writes to `pops.db`. */
+  /** Update the conversation's app context (US-03). Writes to `cerebrum.db`. */
   updateAppContext(conversationId: string, appContext: unknown): void {
-    this.db
-      .update(conversations)
-      .set({
-        appContext: appContext != null ? JSON.stringify(appContext) : null,
-        updatedAt: this.now().toISOString(),
-      })
-      .where(eq(conversations.id, conversationId))
-      .run();
+    conversationsService.updateConversation(this.db, conversationId, {
+      appContext: appContext ?? null,
+      updatedAt: this.now().toISOString(),
+    });
   }
 
   /**
    * Get all context entries (engram associations) for a conversation
-   * (US-03). Pure read — routed through `@pops/cerebrum-db`'s
-   * `conversationsService.listConversationContext` against `readDb`.
+   * (US-03). Routed through `@pops/cerebrum-db`'s
+   * `conversationsService.listConversationContext`.
    */
   getContextEntries(
     conversationId: string
   ): Array<{ engramId: string; relevanceScore: number | null; loadedAt: string }> {
-    return conversationsService
-      .listConversationContext(this.readDb, conversationId)
-      .map((entry) => ({
-        engramId: entry.engramId,
-        relevanceScore: entry.relevanceScore,
-        loadedAt: entry.loadedAt,
-      }));
+    return conversationsService.listConversationContext(this.db, conversationId).map((entry) => ({
+      engramId: entry.engramId,
+      relevanceScore: entry.relevanceScore,
+      loadedAt: entry.loadedAt,
+    }));
   }
 
   /**
-   * Auto-generate title from first user message when no title is set.
-   * Stays on the write handle (`db`) because it is a read-after-write
-   * hop inside the `appendMessage` flow: the row we just inserted lives
-   * only on `pops.db` until the next backfill, so consulting `readDb`
-   * would silently miss it and skip the title.
+   * Auto-generate title from the first user message when no title is
+   * set. The read-after-write hop reuses the single `cerebrum.db`
+   * handle, so it sees the row we just inserted.
    */
-  private maybeAutoTitle(conversationId: string, input: AppendMessageInput): void {
+  private maybeAutoTitle(
+    conversationId: string,
+    input: AppendMessageInput,
+    timestamp: string
+  ): void {
     if (input.role !== 'user') return;
-    const conv = this.db
-      .select({ title: conversations.title })
-      .from(conversations)
-      .where(eq(conversations.id, conversationId))
-      .get();
+    const conv = conversationsService.getConversation(this.db, conversationId);
     if (!conv || conv.title) return;
-    const msgCount = this.db
-      .select({ count: sql<number>`count(*)` })
-      .from(messages)
-      .where(and(eq(messages.conversationId, conversationId), eq(messages.role, 'user')))
-      .get();
-    if (msgCount && msgCount.count === 1) {
-      this.db
-        .update(conversations)
-        .set({ title: autoTitle(input.content) })
-        .where(eq(conversations.id, conversationId))
-        .run();
+    const userCount = conversationsService.countMessages(this.db, conversationId, 'user');
+    if (userCount !== 1) return;
+    conversationsService.updateConversation(this.db, conversationId, {
+      title: autoTitle(input.content),
+      updatedAt: timestamp,
+    });
+  }
+
+  private coerceRole(role: string): 'user' | 'assistant' | 'system' | 'tool' {
+    if (role === 'user' || role === 'assistant' || role === 'system' || role === 'tool') {
+      return role;
     }
+    throw new Error(`Invalid message role: ${role}`);
   }
 }

--- a/apps/pops-api/src/modules/cerebrum/ego/persistence.ts
+++ b/apps/pops-api/src/modules/cerebrum/ego/persistence.ts
@@ -25,7 +25,12 @@
  * auto-title heuristic, persistence-store adapter) stays in pops-api
  * — `@pops/cerebrum-db` is pure data-access.
  */
-import { conversationsService, type CerebrumDb } from '@pops/cerebrum-db';
+import {
+  conversationsService,
+  MESSAGE_ROLES,
+  type CerebrumDb,
+  type MessageRole,
+} from '@pops/cerebrum-db';
 
 import { mapPackageConversation, mapPackageMessage } from './persistence-mappers.js';
 import {
@@ -230,9 +235,9 @@ export class ConversationPersistence {
     });
   }
 
-  private coerceRole(role: string): 'user' | 'assistant' | 'system' | 'tool' {
-    if (role === 'user' || role === 'assistant' || role === 'system' || role === 'tool') {
-      return role;
+  private coerceRole(role: string): MessageRole {
+    for (const allowed of MESSAGE_ROLES) {
+      if (allowed === role) return allowed;
     }
     throw new Error(`Invalid message role: ${role}`);
   }

--- a/apps/pops-api/src/modules/cerebrum/ego/router-context.ts
+++ b/apps/pops-api/src/modules/cerebrum/ego/router-context.ts
@@ -4,7 +4,6 @@
 import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 
-import { getDrizzle } from '../../../db.js';
 import { getCerebrumDrizzle } from '../../../db/cerebrum-handle.js';
 import { protectedProcedure, router } from '../../../trpc.js';
 import { ConversationPersistence } from './persistence.js';
@@ -12,15 +11,13 @@ import { ConversationPersistence } from './persistence.js';
 import type { AppContext } from './types.js';
 
 /**
- * `db` is the shared `pops.db` write handle; `readDb` is the cerebrum
- * pillar's `cerebrum.db` read handle. Pure reads (`setScopes`'
- * pre-check, `getActive`'s lookup, the context-entry list) forward
- * through `@pops/cerebrum-db`'s `conversationsService` against
- * `readDb`. Writes (`updateScopes`) keep landing on `pops.db` until
- * PRD-182 PR 3 collapses them onto the pillar handle.
+ * Every conversation read and write — including `setScopes`'
+ * pre-check, `getActive`'s lookup, the context-entry list, and the
+ * `updateScopes` write — routes through the cerebrum pillar handle
+ * (`cerebrum.db`) after PRD-182 PR 3.
  */
 function getPersistence(): ConversationPersistence {
-  return new ConversationPersistence({ db: getDrizzle(), readDb: getCerebrumDrizzle() });
+  return new ConversationPersistence({ db: getCerebrumDrizzle() });
 }
 
 const setScopesSchema = z.object({


### PR DESCRIPTION
## Summary
PRD-182 PR 2 cut conversation reads to `getCerebrumDrizzle()` while writes still landed on the shared `pops.db`. This PR closes the split so every conversations path — `createConversation`, `appendMessage` (plus the auto-title heuristic's read-after-write hop), `upsertContext`, `deleteConversation`, `updateTitle`, `updateScopes`, `updateAppContext` — routes through the cerebrum pillar handle (`cerebrum.db`). Mirrors the engrams (PRD-179 PR 3), glia (PRD-181 PR 3), and plexus (PRD-180 PR 3) cutovers that shipped earlier today.

## Sites migrated
- `ConversationPersistence` (`ego/persistence.ts`) — collapsed `db` + `readDb` into a single `CerebrumDb` handle. Every write now flows through `@pops/cerebrum-db`'s `conversationsService` (`insertConversation`, `insertMessage`, `upsertConversationContext`, `updateConversation`, `deleteConversation`). `insertMessage` bumps the parent's `updated_at` atomically inside the package-owned transaction, so the explicit drizzle.transaction wrap is gone. The auto-title heuristic still runs as a read-after-write hop but reuses the single `cerebrum.db` handle, so it sees the row it just wrote without depending on the shared store.
- `ego/chat-helpers.ts` — `getPersistence()` wires `getCerebrumDrizzle()` as the only handle; the `getDrizzle()` import is gone.
- `ego/router-context.ts` — same single-handle wiring for `setScopes` / `getActive`.

## Sites kept on `getDrizzle()` (documented, deferred)
- `ego/engine.ts` (`HybridSearchService`) — semantic + structured retrieval joins cross-pillar source tables for citation enrichment. Inherited from the engrams PR 3 cutover notes; the cross-source metadata resolver is split into its own PR.

## Test rigs
`__tests__/persistence.test.ts`, `__tests__/chat-helpers.test.ts`, and `__tests__/ego-chat.integration.test.ts` now pass `drizzle<Record<string, unknown>>(rawDb)` so the in-memory SQLite test handle satisfies the `CerebrumDb` shape without any `as` cast.

## Cross-store consistency
`backfillCerebrumFromShared()` already carries `conversations` + `messages` + `conversation_context` from `pops.db` into `cerebrum.db` at boot. First deploy after this cut closes the initial divergence; subsequent boots are no-ops via the idempotent per-table existence filter. A follow-up PR drops the backfill bridge and the shared-journal shim.

## Test plan
- [x] `pnpm -F @pops/api test src/modules/cerebrum/ego` — 137 tests pass
- [x] `pnpm -F @pops/api test src/modules/cerebrum` — 1128 tests pass
- [x] `pnpm -w typecheck` — clean
- [x] `pnpm format:check` — clean
- [x] `pnpm lint` — no new errors (pre-existing warnings unchanged)