### PR TITLE
feat(core): migrate ai-usage writes to core.db (PRD-186 PR3)

### DIFF
--- a/.dependency-cruiser-known-violations.json
+++ b/.dependency-cruiser-known-violations.json
@@ -331,6 +331,17 @@
   },
   {
     "type": "dependency",
+    "from": "apps/pops-api/src/lib/inference-middleware.ts",
+    "to": "packages/core-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/core-db",
+    "dependencyTypes": ["undetermined", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-core"
+    }
+  },
+  {
+    "type": "dependency",
     "from": "apps/pops-api/src/modules/core/ai-budgets/enforcement.ts",
     "to": "packages/core-db/dist/index.d.ts",
     "unresolvedTo": "@pops/core-db",
@@ -346,6 +357,39 @@
     "to": "packages/core-db/dist/index.d.ts",
     "unresolvedTo": "@pops/core-db",
     "dependencyTypes": ["undetermined", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-core"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/core/ai-observability/retention-db.ts",
+    "to": "packages/core-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/core-db",
+    "dependencyTypes": ["undetermined", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-core"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/core/ai-observability/retention.test.ts",
+    "to": "packages/core-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/core-db",
+    "dependencyTypes": ["undetermined", "type-only", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-core"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/core/ai-observability/retention.ts",
+    "to": "packages/core-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/core-db",
+    "dependencyTypes": ["undetermined", "type-only", "import"],
     "rule": {
       "severity": "error",
       "name": "no-cross-pillar-runtime-import-core"

--- a/apps/pops-api/src/db.ts
+++ b/apps/pops-api/src/db.ts
@@ -262,6 +262,19 @@ export function getCoreDrizzle(): CoreDb {
 }
 
 /**
+ * Resolve the core pillar's raw better-sqlite3 handle. Same lazy open
+ * behaviour as `getCoreDrizzle()` — exposed for the lower-level needs
+ * (`.transaction()`, `.prepare()`, `.pragma()`) that the drizzle wrapper
+ * hides. Prefer `getCoreDrizzle()` for everything that doesn't need it.
+ */
+export function getCoreRawDb(): BetterSqlite3.Database {
+  if (!coreDb) {
+    coreDb = openCoreDb(resolveCoreSqlitePath());
+  }
+  return coreDb.raw;
+}
+
+/**
  * Close the core pillar's connection if it was opened. Idempotent —
  * safe to call from {@link closeDb} on shutdown even when the core
  * handle was never resolved.

--- a/apps/pops-api/src/lib/inference-middleware.ts
+++ b/apps/pops-api/src/lib/inference-middleware.ts
@@ -1,6 +1,22 @@
-import { aiInferenceLog } from '@pops/db-types';
+/**
+ * Inference middleware — wraps every AI provider call with the persisted
+ * `ai_inference_log` audit row, pricing/cost lookup, latency capture, error
+ * classification, and pre-call budget enforcement.
+ *
+ * Every log write goes through `@pops/core-db`'s `aiUsageService.createInferenceLog`
+ * resolved against the core pillar handle (`getCoreDrizzle()`), so each
+ * audit row lands in `core.db` instead of the shared `pops.db`. Budget
+ * enforcement reads land on the same store, so usage aggregation (cost,
+ * tokens) now sees freshly inserted rows immediately — the read/write
+ * staleness window that existed between PRD-186 PR 2 and PR 3 is gone.
+ *
+ * Errors during the log insert are swallowed and logged — the AI call's
+ * result still propagates so a transient DB failure doesn't turn a
+ * successful provider call into a hard error for the caller.
+ */
+import { aiUsageService } from '@pops/core-db';
 
-import { getDrizzle } from '../db.js';
+import { getCoreDrizzle } from '../db.js';
 import { enforceBudgets } from './inference-budget-enforcement.js';
 import { lookupPricing } from './inference-pricing.js';
 import { extractTokens } from './inference-tokens.js';
@@ -16,14 +32,7 @@ export type { TrackInferenceParams } from './inference-middleware-types.js';
 
 function insertLog(values: InferenceLogInsert): void {
   try {
-    getDrizzle()
-      .insert(aiInferenceLog)
-      .values({
-        ...values,
-        metadata: null,
-        createdAt: new Date().toISOString(),
-      })
-      .run();
+    aiUsageService.createInferenceLog(getCoreDrizzle(), values);
   } catch (err) {
     logger.warn({ err }, '[inference] Failed to log inference row');
   }

--- a/apps/pops-api/src/modules/core/ai-budgets/enforcement.ts
+++ b/apps/pops-api/src/modules/core/ai-budgets/enforcement.ts
@@ -5,15 +5,13 @@
  * `core.aiBudgets`) and the inference-middleware enforcement path can each
  * stay under the project's max-lines lint budget.
  *
- * Read/write split (PRD-186 PR 2 cutover): `listApplicableBudgets` and the
- * per-scope usage aggregation forward to `@pops/core-db`'s `aiUsageService`
- * against `getCoreDrizzle()` so reads land on `core.db`. The conflict-
- * detection read in `migrateLegacyBudgetSettings` is routed through the
- * same package surface. `findFallbackProvider` stays on the legacy
+ * Routing: `listApplicableBudgets`, the per-scope usage aggregation, and the
+ * conflict-detection read in `migrateLegacyBudgetSettings` all forward into
+ * `@pops/core-db`'s `aiUsageService` against `getCoreDrizzle()`, so reads
+ * land on `core.db`. `findFallbackProvider` stays on the shared
  * `getDrizzle()` handle because it joins `ai_providers` and
- * `ai_model_pricing`, which are not part of the core-db package surface.
- * Writes (`upsertBudget`) keep flowing through the shared store until
- * PRD-186 PR 3 flips writes too.
+ * `ai_model_pricing`, which are not part of the core-db package surface
+ * yet — a future PR can lift those tables too.
  */
 import { and, asc, desc, eq } from 'drizzle-orm';
 
@@ -58,17 +56,11 @@ function monthStart(): string {
 }
 
 /**
- * Aggregate monthly token + cost usage for a single budget scope.
- *
- * Staleness window: reads from `core.db` via `aiUsageService`, but
- * inference logs are still inserted into the shared `pops.db` by
- * `apps/pops-api/src/lib/inference-middleware.ts`. The `core.db` copy is
- * only refreshed by the boot-time backfill, so any inference recorded
- * since process start is invisible here. Net effect: enforcement can
- * under-count usage and over-allow calls (fail to warn/block/fallback)
- * during normal uptime. Accepted risk during the read/write split window.
- * TODO(PRD-186 PR 3): drop this note once the inference writer flips to
- * `core.db` (or a dual-write path lands).
+ * Aggregate monthly token + cost usage for a single budget scope. Reads
+ * from `core.db` via `aiUsageService.sumInferenceLogUsage`; since the
+ * inference middleware writes to the same store, the aggregate reflects
+ * every recorded call immediately — there is no read/write staleness
+ * window.
  */
 function getUsageForScope(
   row: AiBudgetRow,

--- a/apps/pops-api/src/modules/core/ai-budgets/service.ts
+++ b/apps/pops-api/src/modules/core/ai-budgets/service.ts
@@ -1,17 +1,17 @@
 /**
  * AI budgets module — CRUD + budget status for `core.aiBudgets.*`.
  *
- * Read/write split (PRD-186 PR 2 cutover): the pure read surface forwards
- * into `@pops/core-db`'s `aiUsageService` against `getCoreDrizzle()`, so
- * `listBudgets` and `getBudgetStatus` resolve against `core.db`.
- * Mutations (`upsertBudget`) still land via the shared `getDrizzle()`
- * handle — the legacy `pops.db -> core.db` boot-time backfill bridges the
- * gap until PRD-186 PR 3 flips the writer too. This matches the
- * watch-history cutover precedent (PR #3008).
+ * Every read and write goes through `@pops/core-db`'s `aiUsageService`
+ * resolved against `getCoreDrizzle()`, so `listBudgets`, `getBudgetStatus`,
+ * and `upsertBudget` all land on `core.db`. Per-budget usage aggregation
+ * (`sumInferenceLogUsage`) reads from the same store the inference middleware
+ * writes to, so there is no read/write staleness window — usage reflects
+ * every recorded call immediately. The boot-time `pops.db -> core.db`
+ * backfill carries any legacy rows forward; PR 4 drops the shim entirely.
  */
-import { aiBudgets, aiUsageService } from '@pops/core-db';
+import { aiUsageService, type AiBudgetRow } from '@pops/core-db';
 
-import { getCoreDrizzle, getDrizzle } from '../../../db.js';
+import { getCoreDrizzle } from '../../../db.js';
 
 export interface Budget {
   id: string;
@@ -70,59 +70,26 @@ export function listBudgets(): Budget[] {
 }
 
 /**
- * WRITE — upsert lands on the shared `pops.db` via `getDrizzle()`. The
- * boot-time `pops.db -> core.db` backfill propagates the new row to the
- * read store on the next boot. PRD-186 PR 3 flips this to `core.db`.
- *
- * The read-after-write hop deliberately uses the SAME `getDrizzle()` handle
- * the insert went to. Routing the readback through `getCoreDrizzle()` would
- * miss the freshly-inserted row until the next boot-time backfill, breaking
- * both the mutation response and `migrateLegacyBudgetSettings()` at startup.
+ * WRITE — upsert lands on `core.db` via `aiUsageService.upsertBudget`.
+ * Returns the persisted row including the canonicalised `scopeValue`
+ * (`null` for global scope regardless of the supplied value).
  */
 export function upsertBudget(input: UpsertBudgetInput): Budget {
-  const now = new Date().toISOString();
-  const db = getDrizzle();
-  db.insert(aiBudgets)
-    .values({
-      id: input.id,
-      scopeType: input.scopeType,
-      scopeValue: input.scopeValue ?? null,
-      monthlyTokenLimit: input.monthlyTokenLimit ?? null,
-      monthlyCostLimit: input.monthlyCostLimit ?? null,
-      action: input.action ?? 'warn',
-      createdAt: now,
-      updatedAt: now,
-    })
-    .onConflictDoUpdate({
-      target: aiBudgets.id,
-      set: {
-        scopeType: input.scopeType,
-        scopeValue: input.scopeValue ?? null,
-        monthlyTokenLimit: input.monthlyTokenLimit ?? null,
-        monthlyCostLimit: input.monthlyCostLimit ?? null,
-        action: input.action ?? 'warn',
-        updatedAt: now,
-      },
-    })
-    .run();
-  const row = aiUsageService.getBudgetOrNull(db, input.id);
-  if (!row) throw new Error(`Budget not found: ${input.id}`);
-  return row;
+  return aiUsageService.upsertBudget(getCoreDrizzle(), {
+    id: input.id,
+    scopeType: input.scopeType,
+    scopeValue: input.scopeValue ?? null,
+    monthlyTokenLimit: input.monthlyTokenLimit ?? null,
+    monthlyCostLimit: input.monthlyCostLimit ?? null,
+    action: input.action,
+  });
 }
 
 /**
  * READ — budgets come from `aiUsageService.listBudgets`; per-budget usage
- * comes from `aiUsageService.sumInferenceLogUsage` against `core.db` so
- * both the budget row and its rolled-up monthly usage stay on the same
- * read handle.
- *
- * Staleness window: until PRD-186 PR 3 cuts the inference-log writer over
- * to `core.db`, inference rows are still inserted into the shared `pops.db`
- * by `apps/pops-api/src/lib/inference-middleware.ts`. The `core.db` copy is
- * only refreshed by the boot-time backfill, so the reported monthly usage,
- * percentage, and projected exhaustion date can under-count any inference
- * recorded since process start. Accepted lag during the split window.
- * TODO(PRD-186 PR 3): drop this staleness note once writes flip to core.db.
+ * comes from `aiUsageService.sumInferenceLogUsage` against `core.db`. The
+ * inference middleware writes to the same store, so usage reflects every
+ * recorded call immediately — no read/write staleness window.
  */
 export function getBudgetStatus(): BudgetStatus[] {
   const start = monthStart();
@@ -132,10 +99,8 @@ export function getBudgetStatus(): BudgetStatus[] {
   return budgets.map((budget) => buildBudgetStatus(budget, start, monthStartDate));
 }
 
-type BudgetRow = typeof aiBudgets.$inferSelect;
-
 function getBudgetUsage(
-  budget: BudgetRow,
+  budget: AiBudgetRow,
   start: string
 ): { currentTokenUsage: number; currentCostUsage: number } {
   const usage = aiUsageService.sumInferenceLogUsage(getCoreDrizzle(), {
@@ -154,7 +119,7 @@ function getBudgetUsage(
 }
 
 function computeBudgetStatusFields(
-  budget: BudgetRow,
+  budget: AiBudgetRow,
   usage: { currentTokenUsage: number; currentCostUsage: number },
   monthStartDate: Date
 ): { percentageUsed: number | null; projectedExhaustionDate: string | null } {
@@ -181,7 +146,7 @@ function computeBudgetStatusFields(
   return { percentageUsed: null, projectedExhaustionDate: null };
 }
 
-function buildBudgetStatus(budget: BudgetRow, start: string, monthStartDate: Date): BudgetStatus {
+function buildBudgetStatus(budget: AiBudgetRow, start: string, monthStartDate: Date): BudgetStatus {
   const usage = getBudgetUsage(budget, start);
   const fields = computeBudgetStatusFields(budget, usage, monthStartDate);
   return { ...budget, ...usage, ...fields };

--- a/apps/pops-api/src/modules/core/ai-observability/retention-db.ts
+++ b/apps/pops-api/src/modules/core/ai-observability/retention-db.ts
@@ -1,115 +1,27 @@
-import type BetterSqlite3 from 'better-sqlite3';
-
 /**
- * SQL helpers for the AI inference log retention job (PRD-092 US-08).
- * Split from `retention.ts` to keep both files under the file-size lint cap.
+ * Thin adapter between the retention orchestrator's `DailyAggregate` /
+ * `RetentionInputRow` shapes and `@pops/core-db`'s `aiUsageService`.
+ *
+ * Every helper resolves the core pillar handle the caller supplies and
+ * delegates the actual SQL into the package. This keeps the rollup
+ * routing entirely on `core.db` (PRD-186 PR 3).
  */
+import { aiUsageService, type CoreDb } from '@pops/core-db';
+
 import type { DailyAggregate, RetentionInputRow } from './retention-types.js';
 
-interface RawInferenceRow {
-  id: number;
-  created_at: string;
-  provider: string;
-  model: string;
-  operation: string;
-  domain: string | null;
-  input_tokens: number;
-  output_tokens: number;
-  cost_usd: number;
-  latency_ms: number;
-  status: string;
-  cached: number;
-}
-
 export function fetchAgedBatch(
-  db: BetterSqlite3.Database,
+  db: CoreDb,
   cutoffIso: string,
   batchSize: number
 ): Array<{ id: number; row: RetentionInputRow }> {
-  const raw = db
-    .prepare(
-      `SELECT id, created_at, provider, model, operation, domain,
-              input_tokens, output_tokens, cost_usd, latency_ms, status, cached
-       FROM ai_inference_log
-       WHERE created_at < ?
-       ORDER BY id
-       LIMIT ?`
-    )
-    .all(cutoffIso, batchSize) as RawInferenceRow[];
-
-  return raw.map((r) => ({
-    id: r.id,
-    row: {
-      createdAt: r.created_at,
-      provider: r.provider,
-      model: r.model,
-      operation: r.operation,
-      domain: r.domain,
-      inputTokens: r.input_tokens,
-      outputTokens: r.output_tokens,
-      costUsd: r.cost_usd,
-      latencyMs: r.latency_ms,
-      status: r.status,
-      cached: r.cached,
-    },
-  }));
+  return aiUsageService.fetchAgedInferenceLogs(db, cutoffIso, batchSize);
 }
 
-/**
- * Upsert an aggregate row, merging with any existing row with the same
- * natural key. SQLite's `ON CONFLICT` clause keys off the unique index
- * `idx_ai_inference_daily_key`. Existing `avg_latency_ms` is folded into
- * the new value using a weighted mean against `total_calls` — close enough
- * for trend lines (the daily table is for trends, not exact replays).
- */
-export function upsertAggregate(db: BetterSqlite3.Database, agg: DailyAggregate): void {
-  db.prepare(
-    `INSERT INTO ai_inference_daily (
-        date, provider, model, operation, domain,
-        total_calls, total_input_tokens, total_output_tokens, total_cost_usd,
-        avg_latency_ms, error_count, timeout_count, cache_hit_count, budget_blocked_count
-     ) VALUES (
-        @date, @provider, @model, @operation, @domain,
-        @total_calls, @total_input_tokens, @total_output_tokens, @total_cost_usd,
-        @avg_latency_ms, @error_count, @timeout_count, @cache_hit_count, @budget_blocked_count
-     )
-     ON CONFLICT(date, provider, model, operation, domain) DO UPDATE SET
-        total_calls = total_calls + excluded.total_calls,
-        total_input_tokens = total_input_tokens + excluded.total_input_tokens,
-        total_output_tokens = total_output_tokens + excluded.total_output_tokens,
-        total_cost_usd = total_cost_usd + excluded.total_cost_usd,
-        avg_latency_ms = CASE
-          WHEN (total_calls + excluded.total_calls) = 0 THEN 0
-          ELSE CAST(
-            (avg_latency_ms * total_calls + excluded.avg_latency_ms * excluded.total_calls)
-            / (total_calls + excluded.total_calls)
-            AS INTEGER
-          )
-        END,
-        error_count = error_count + excluded.error_count,
-        timeout_count = timeout_count + excluded.timeout_count,
-        cache_hit_count = cache_hit_count + excluded.cache_hit_count,
-        budget_blocked_count = budget_blocked_count + excluded.budget_blocked_count`
-  ).run({
-    date: agg.date,
-    provider: agg.provider,
-    model: agg.model,
-    operation: agg.operation,
-    domain: agg.domain,
-    total_calls: agg.totalCalls,
-    total_input_tokens: agg.totalInputTokens,
-    total_output_tokens: agg.totalOutputTokens,
-    total_cost_usd: agg.totalCostUsd,
-    avg_latency_ms: agg.avgLatencyMs,
-    error_count: agg.errorCount,
-    timeout_count: agg.timeoutCount,
-    cache_hit_count: agg.cacheHitCount,
-    budget_blocked_count: agg.budgetBlockedCount,
-  });
+export function upsertAggregate(db: CoreDb, agg: DailyAggregate): void {
+  aiUsageService.recordInferenceDaily(db, agg);
 }
 
-export function deleteRowsByIds(db: BetterSqlite3.Database, ids: number[]): void {
-  if (ids.length === 0) return;
-  const placeholders = ids.map(() => '?').join(',');
-  db.prepare(`DELETE FROM ai_inference_log WHERE id IN (${placeholders})`).run(...ids);
+export function deleteRowsByIds(db: CoreDb, ids: number[]): void {
+  aiUsageService.deleteInferenceLogsByIds(db, ids);
 }

--- a/apps/pops-api/src/modules/core/ai-observability/retention.test.ts
+++ b/apps/pops-api/src/modules/core/ai-observability/retention.test.ts
@@ -5,7 +5,10 @@
  * input rows, once end-to-end against an in-memory SQLite DB to validate
  * the upsert + delete cycle and idempotency.
  */
+import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { type CoreDb } from '@pops/core-db';
 
 import { seedAiUsage, setupTestContext } from '../../../shared/test-utils.js';
 import {
@@ -19,9 +22,11 @@ import type { Database } from 'better-sqlite3';
 
 const ctx = setupTestContext();
 let db: Database;
+let coreDb: CoreDb;
 
 beforeEach(() => {
   ({ db } = ctx.setup());
+  coreDb = drizzle(db);
 });
 
 afterEach(() => {
@@ -155,7 +160,7 @@ describe('runRetention end-to-end', () => {
     const result = runRetention({
       retentionDays: 90,
       now: new Date('2026-05-11T12:00:00Z'),
-      db,
+      db: coreDb,
     });
 
     expect(result.rowsAggregated).toBe(50);
@@ -185,7 +190,7 @@ describe('runRetention end-to-end', () => {
     const second = runRetention({
       retentionDays: 90,
       now: new Date('2026-05-11T12:00:00Z'),
-      db,
+      db: coreDb,
     });
     expect(second.rowsAggregated).toBe(0);
     expect(second.bucketsWritten).toBe(0);
@@ -200,7 +205,7 @@ describe('runRetention end-to-end', () => {
     const result = runRetention({
       retentionDays: 90,
       now: new Date('2026-05-11T12:00:00Z'),
-      db,
+      db: coreDb,
     });
 
     expect(result.rowsAggregated).toBe(1);
@@ -228,7 +233,7 @@ describe('runRetention end-to-end', () => {
     runRetention({
       retentionDays: 90,
       now: new Date('2026-05-11T12:00:00Z'),
-      db,
+      db: coreDb,
     });
 
     // Second batch: 3 more rows on the SAME day, same tuple, with different
@@ -248,7 +253,7 @@ describe('runRetention end-to-end', () => {
     runRetention({
       retentionDays: 90,
       now: new Date('2026-05-11T12:00:00Z'),
-      db,
+      db: coreDb,
     });
 
     const rows = db.prepare('SELECT * FROM ai_inference_daily').all() as {
@@ -278,7 +283,7 @@ describe('runRetention end-to-end', () => {
       retentionDays: 90,
       batchSize: 10,
       now: new Date('2026-05-11T12:00:00Z'),
-      db,
+      db: coreDb,
     });
 
     expect(result.rowsAggregated).toBe(25);

--- a/apps/pops-api/src/modules/core/ai-observability/retention.ts
+++ b/apps/pops-api/src/modules/core/ai-observability/retention.ts
@@ -5,19 +5,21 @@
  *  - `aggregateRowsToDaily` is a pure function over input rows used by the
  *    unit tests.
  *  - `runRetention` performs the full cycle (read → aggregate → upsert →
- *    delete) against `getDb()`.
+ *    delete) against `getCoreDrizzle()` — every `ai_inference_log` read,
+ *    `ai_inference_daily` upsert, and `ai_inference_log` delete lands on
+ *    `core.db`.
  *
  * The job is idempotent: a re-run with no aged-out rows returns zero
  * deletions, and re-running over the same horizon adds to existing daily
  * rows via the unique-key-aware upsert (it does not double-count because
  * the source rows have already been deleted by the previous run).
  */
-import { getDb } from '../../../db.js';
+import { type CoreDb } from '@pops/core-db';
+
+import { getCoreDrizzle } from '../../../db.js';
 import { logger } from '../../../lib/logger.js';
 import { getSettingValue } from '../settings/service.js';
 import { deleteRowsByIds, fetchAgedBatch, upsertAggregate } from './retention-db.js';
-
-import type BetterSqlite3 from 'better-sqlite3';
 
 import type { DailyAggregate, RetentionInputRow, RetentionResult } from './retention-types.js';
 
@@ -142,19 +144,21 @@ export interface RunRetentionOptions {
   batchSize?: number;
   /** Override "now" — used by tests to pin the cutoff. */
   now?: Date;
-  /** Database handle. Defaults to `getDb()`. */
-  db?: BetterSqlite3.Database;
+  /** Core pillar drizzle handle. Defaults to `getCoreDrizzle()`. */
+  db?: CoreDb;
 }
 
 /**
  * Roll up and prune `ai_inference_log` rows older than the retention horizon.
  *
- * Each batch runs in its own transaction: aggregation upsert + delete are
- * atomic per-batch. If a batch fails partway, only that batch rolls back;
- * the next invocation re-processes it.
+ * Each batch runs in its own drizzle transaction: aggregation upsert + delete
+ * are atomic per-batch. If a batch fails partway, only that batch rolls back;
+ * the next invocation re-processes it. The transaction handle is passed
+ * through to the package helpers so writes target the same `core.db`
+ * connection that opened the batch.
  */
 export function runRetention(opts: RunRetentionOptions = {}): RetentionResult {
-  const db = opts.db ?? getDb();
+  const db = opts.db ?? getCoreDrizzle();
   const retentionDays = opts.retentionDays ?? getRetentionDays();
   const batchSize = opts.batchSize ?? RETENTION_BATCH_SIZE;
   const cutoff = computeCutoff(retentionDays, opts.now);
@@ -172,11 +176,10 @@ export function runRetention(opts: RunRetentionOptions = {}): RetentionResult {
     const aggregates = aggregateRowsToDaily(batch.map((b) => b.row));
     const ids = batch.map((b) => b.id);
 
-    const tx = db.transaction(() => {
-      for (const agg of aggregates) upsertAggregate(db, agg);
-      deleteRowsByIds(db, ids);
+    db.transaction((tx) => {
+      for (const agg of aggregates) upsertAggregate(tx, agg);
+      deleteRowsByIds(tx, ids);
     });
-    tx();
 
     rowsAggregated += batch.length;
     bucketsWritten += aggregates.length;

--- a/packages/core-db/src/__tests__/ai-usage.test.ts
+++ b/packages/core-db/src/__tests__/ai-usage.test.ts
@@ -17,17 +17,21 @@ import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import { AiBudgetNotFoundError } from '../errors.js';
-import { aiInferenceDaily } from '../schema.js';
+import { aiInferenceDaily, aiInferenceLog } from '../schema.js';
 import {
   createInferenceLog,
   deleteBudget,
+  deleteInferenceLogsByIds,
+  fetchAgedInferenceLogs,
   getBudget,
   getBudgetOrNull,
   listBudgets,
   listInferenceDaily,
   listInferenceLogs,
+  recordInferenceDaily,
   sumInferenceLogUsage,
   upsertBudget,
+  type InferenceDailyAggregate,
 } from '../services/ai-usage.js';
 
 import type { CoreDb } from '../services/internal.js';
@@ -253,6 +257,132 @@ describe('listInferenceDaily', () => {
   it('honours start/end date window', () => {
     const rows = listInferenceDaily(db, { startDate: '2026-06-01', endDate: '2026-06-04' });
     expect(rows.map((r) => r.date)).toEqual(['2026-06-01']);
+  });
+});
+
+describe('fetchAgedInferenceLogs', () => {
+  let db: CoreDb;
+  beforeEach(() => {
+    db = freshDb();
+    createInferenceLog(db, logBase({ createdAt: '2026-01-01T00:00:00.000Z' }));
+    createInferenceLog(db, logBase({ createdAt: '2026-02-01T00:00:00.000Z' }));
+    createInferenceLog(db, logBase({ createdAt: '2026-06-01T00:00:00.000Z' }));
+  });
+
+  it('returns rows older than or equal to the cutoff', () => {
+    const batch = fetchAgedInferenceLogs(db, '2026-02-01T00:00:00.000Z', 10);
+    expect(batch.map((b) => b.row.createdAt).toSorted()).toEqual([
+      '2026-01-01T00:00:00.000Z',
+      '2026-02-01T00:00:00.000Z',
+    ]);
+  });
+
+  it('honours batchSize as a hard ceiling', () => {
+    const batch = fetchAgedInferenceLogs(db, '2026-12-31T00:00:00.000Z', 2);
+    expect(batch).toHaveLength(2);
+  });
+
+  it('returns rows ordered by id ascending so consecutive batches make progress', () => {
+    const batch = fetchAgedInferenceLogs(db, '2026-12-31T00:00:00.000Z', 10);
+    const ids = batch.map((b) => b.id);
+    expect(ids).toEqual([...ids].toSorted((a, b) => a - b));
+  });
+});
+
+describe('recordInferenceDaily', () => {
+  let db: CoreDb;
+  const baseAgg: InferenceDailyAggregate = {
+    date: '2026-05-01',
+    provider: 'claude',
+    model: 'sonnet',
+    operation: 'classify',
+    domain: 'finance',
+    totalCalls: 10,
+    totalInputTokens: 1000,
+    totalOutputTokens: 500,
+    totalCostUsd: 0.01,
+    avgLatencyMs: 100,
+    errorCount: 1,
+    timeoutCount: 0,
+    cacheHitCount: 2,
+    budgetBlockedCount: 0,
+  };
+
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('inserts a fresh aggregate row', () => {
+    recordInferenceDaily(db, baseAgg);
+    const rows = listInferenceDaily(db, {});
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.totalCalls).toBe(10);
+    expect(rows[0]?.avgLatencyMs).toBe(100);
+  });
+
+  it('folds new counters into an existing bucket on the same natural key', () => {
+    recordInferenceDaily(db, baseAgg);
+    recordInferenceDaily(db, {
+      ...baseAgg,
+      totalCalls: 5,
+      totalInputTokens: 500,
+      totalCostUsd: 0.005,
+      avgLatencyMs: 200,
+      errorCount: 2,
+      cacheHitCount: 1,
+    });
+
+    const rows = listInferenceDaily(db, {});
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.totalCalls).toBe(15);
+    expect(rows[0]?.totalInputTokens).toBe(1500);
+    expect(rows[0]?.totalCostUsd).toBeCloseTo(0.015, 6);
+    expect(rows[0]?.errorCount).toBe(3);
+    expect(rows[0]?.cacheHitCount).toBe(3);
+  });
+
+  it('computes weighted-mean avgLatencyMs across folds', () => {
+    recordInferenceDaily(db, { ...baseAgg, totalCalls: 5, avgLatencyMs: 100 });
+    recordInferenceDaily(db, { ...baseAgg, totalCalls: 3, avgLatencyMs: 200 });
+
+    const rows = listInferenceDaily(db, {});
+    // ((5*100) + (3*200)) / 8 = 137.5 → CAST AS INTEGER → 137
+    expect(rows[0]?.avgLatencyMs).toBe(137);
+  });
+
+  it('treats different domains as distinct buckets', () => {
+    recordInferenceDaily(db, { ...baseAgg, domain: 'finance' });
+    recordInferenceDaily(db, { ...baseAgg, domain: 'media' });
+    recordInferenceDaily(db, { ...baseAgg, domain: null });
+
+    const rows = listInferenceDaily(db, {});
+    expect(rows).toHaveLength(3);
+  });
+});
+
+describe('deleteInferenceLogsByIds', () => {
+  let db: CoreDb;
+  let ids: number[];
+  beforeEach(() => {
+    db = freshDb();
+    const a = createInferenceLog(db, logBase({ createdAt: '2026-01-01T00:00:00.000Z' }));
+    const b = createInferenceLog(db, logBase({ createdAt: '2026-02-01T00:00:00.000Z' }));
+    const c = createInferenceLog(db, logBase({ createdAt: '2026-03-01T00:00:00.000Z' }));
+    ids = [a.id, b.id, c.id];
+  });
+
+  it('removes only the rows whose ids are supplied', () => {
+    const [first, , third] = ids;
+    deleteInferenceLogsByIds(db, [first as number, third as number]);
+
+    const remaining = db.select({ id: aiInferenceLog.id }).from(aiInferenceLog).all();
+    expect(remaining.map((r) => r.id)).toEqual([ids[1]]);
+  });
+
+  it('is a no-op for an empty id list', () => {
+    deleteInferenceLogsByIds(db, []);
+    const remaining = db.select({ id: aiInferenceLog.id }).from(aiInferenceLog).all();
+    expect(remaining).toHaveLength(3);
   });
 });
 

--- a/packages/core-db/src/__tests__/ai-usage.test.ts
+++ b/packages/core-db/src/__tests__/ai-usage.test.ts
@@ -358,6 +358,16 @@ describe('recordInferenceDaily', () => {
     const rows = listInferenceDaily(db, {});
     expect(rows).toHaveLength(3);
   });
+
+  it('folds null-domain aggregates into a single bucket via the empty-string sentinel', () => {
+    recordInferenceDaily(db, { ...baseAgg, domain: null, totalCalls: 4 });
+    recordInferenceDaily(db, { ...baseAgg, domain: null, totalCalls: 6 });
+
+    const rows = listInferenceDaily(db, {});
+    const nullDomainRows = rows.filter((r) => r.domain === '' || r.domain === null);
+    expect(nullDomainRows).toHaveLength(1);
+    expect(nullDomainRows[0]?.totalCalls).toBe(10);
+  });
 });
 
 describe('deleteInferenceLogsByIds', () => {

--- a/packages/core-db/src/index.ts
+++ b/packages/core-db/src/index.ts
@@ -61,6 +61,8 @@ export type {
   AiInferenceLogInsert,
   AiInferenceLogRow,
   CreateInferenceLogInput,
+  InferenceDailyAggregate,
+  InferenceLogRetentionRow,
   ListInferenceLogsFilter,
   UpsertBudgetInput,
 } from './services/ai-usage.js';

--- a/packages/core-db/src/services/ai-usage-budgets.ts
+++ b/packages/core-db/src/services/ai-usage-budgets.ts
@@ -1,0 +1,93 @@
+/**
+ * Budget CRUD helpers for `core.aiBudgets.*`.
+ *
+ * Split out of `ai-usage.ts` so each half stays under the file-size lint
+ * cap. The barrel `ai-usage.ts` re-exports everything so consumers see a
+ * single `aiUsageService` namespace.
+ */
+import { eq } from 'drizzle-orm';
+
+import { AiBudgetNotFoundError } from '../errors.js';
+import { aiBudgets } from '../schema.js';
+
+import type { CoreDb } from './internal.js';
+
+export type AiBudgetRow = typeof aiBudgets.$inferSelect;
+export type AiBudgetInsert = typeof aiBudgets.$inferInsert;
+export type AiBudget = AiBudgetRow;
+
+/** Input for {@link upsertBudget}. `scopeValue` is required for non-global
+ * scopes. `action` defaults to `warn` to match the shared journal. */
+export interface UpsertBudgetInput {
+  id: string;
+  scopeType: 'global' | 'provider' | 'operation';
+  scopeValue?: string | null;
+  monthlyTokenLimit?: number | null;
+  monthlyCostLimit?: number | null;
+  action?: 'block' | 'warn' | 'fallback';
+}
+
+/** Read all configured budgets in insertion order. */
+export function listBudgets(db: CoreDb): AiBudgetRow[] {
+  return db.select().from(aiBudgets).all();
+}
+
+/** Read a single budget by id; returns `null` when absent. */
+export function getBudgetOrNull(db: CoreDb, id: string): AiBudgetRow | null {
+  return db.select().from(aiBudgets).where(eq(aiBudgets.id, id)).get() ?? null;
+}
+
+/** Read a single budget by id; throws {@link AiBudgetNotFoundError} when
+ * absent. Prefer {@link getBudgetOrNull} when the caller wants to
+ * fall back. */
+export function getBudget(db: CoreDb, id: string): AiBudgetRow {
+  const row = getBudgetOrNull(db, id);
+  if (!row) throw new AiBudgetNotFoundError(id);
+  return row;
+}
+
+/**
+ * Upsert a budget. Returns the persisted row. The `scopeValue` column is
+ * normalised to `null` for the `global` scope so the unique scope key is
+ * always `(scope_type, scope_value)`-shaped from the reader's POV.
+ */
+export function upsertBudget(db: CoreDb, input: UpsertBudgetInput): AiBudgetRow {
+  const now = new Date().toISOString();
+  const scopeValue = input.scopeType === 'global' ? null : (input.scopeValue ?? null);
+  const monthlyTokenLimit = input.monthlyTokenLimit ?? null;
+  const monthlyCostLimit = input.monthlyCostLimit ?? null;
+  const action = input.action ?? 'warn';
+
+  db.insert(aiBudgets)
+    .values({
+      id: input.id,
+      scopeType: input.scopeType,
+      scopeValue,
+      monthlyTokenLimit,
+      monthlyCostLimit,
+      action,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .onConflictDoUpdate({
+      target: aiBudgets.id,
+      set: {
+        scopeType: input.scopeType,
+        scopeValue,
+        monthlyTokenLimit,
+        monthlyCostLimit,
+        action,
+        updatedAt: now,
+      },
+    })
+    .run();
+
+  return getBudget(db, input.id);
+}
+
+/** Delete a budget by id. Throws {@link AiBudgetNotFoundError} when no
+ * row matched (`changes === 0`). */
+export function deleteBudget(db: CoreDb, id: string): void {
+  const result = db.delete(aiBudgets).where(eq(aiBudgets.id, id)).run();
+  if (result.changes === 0) throw new AiBudgetNotFoundError(id);
+}

--- a/packages/core-db/src/services/ai-usage-retention.ts
+++ b/packages/core-db/src/services/ai-usage-retention.ts
@@ -1,0 +1,177 @@
+/**
+ * Retention/rollup helpers for the AI inference log slice.
+ *
+ * Split out of `ai-usage.ts` so each half stays under the file-size lint
+ * cap. The barrel re-exports everything so consumers see a single
+ * `aiUsageService` namespace.
+ *
+ * Covers:
+ *   - `fetchAgedInferenceLogs` — projection over the columns the retention
+ *     aggregator consumes, ordered by id so consecutive batches make
+ *     forward progress.
+ *   - `recordInferenceDaily` — natural-key upsert into `ai_inference_daily`
+ *     that folds counters into any existing row and merges latency via a
+ *     weighted mean.
+ *   - `deleteInferenceLogsByIds` — bulk delete on the source table after
+ *     the aggregates have been folded in.
+ */
+import { inArray, lte, sql } from 'drizzle-orm';
+
+import { aiInferenceDaily, aiInferenceLog } from '../schema.js';
+
+import type { CoreDb } from './internal.js';
+
+/**
+ * Subset of `ai_inference_log` columns the retention aggregator consumes.
+ * Exposed so callers can build batches in their own pipeline before
+ * handing them off to {@link recordInferenceDaily}.
+ */
+export interface InferenceLogRetentionRow {
+  createdAt: string;
+  provider: string;
+  model: string;
+  operation: string;
+  domain: string | null;
+  inputTokens: number;
+  outputTokens: number;
+  costUsd: number;
+  latencyMs: number;
+  status: string;
+  cached: number;
+}
+
+/**
+ * Daily aggregate row written by the retention rollup. Keys + counters
+ * for one `(date, provider, model, operation, domain)` bucket.
+ */
+export interface InferenceDailyAggregate {
+  date: string;
+  provider: string;
+  model: string;
+  operation: string;
+  domain: string | null;
+  totalCalls: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalCostUsd: number;
+  avgLatencyMs: number;
+  errorCount: number;
+  timeoutCount: number;
+  cacheHitCount: number;
+  budgetBlockedCount: number;
+}
+
+/**
+ * Fetch the next batch of `ai_inference_log` rows older than `cutoffIso`
+ * for retention rollup. Returns each row's `id` alongside the projected
+ * columns the aggregator consumes. Ordered by `id` so consecutive batches
+ * progress monotonically through the table.
+ */
+export function fetchAgedInferenceLogs(
+  db: CoreDb,
+  cutoffIso: string,
+  batchSize: number
+): Array<{ id: number; row: InferenceLogRetentionRow }> {
+  const rows = db
+    .select({
+      id: aiInferenceLog.id,
+      createdAt: aiInferenceLog.createdAt,
+      provider: aiInferenceLog.provider,
+      model: aiInferenceLog.model,
+      operation: aiInferenceLog.operation,
+      domain: aiInferenceLog.domain,
+      inputTokens: aiInferenceLog.inputTokens,
+      outputTokens: aiInferenceLog.outputTokens,
+      costUsd: aiInferenceLog.costUsd,
+      latencyMs: aiInferenceLog.latencyMs,
+      status: aiInferenceLog.status,
+      cached: aiInferenceLog.cached,
+    })
+    .from(aiInferenceLog)
+    .where(lte(aiInferenceLog.createdAt, cutoffIso))
+    .orderBy(aiInferenceLog.id)
+    .limit(batchSize)
+    .all();
+
+  return rows.map((r) => ({
+    id: r.id,
+    row: {
+      createdAt: r.createdAt,
+      provider: r.provider,
+      model: r.model,
+      operation: r.operation,
+      domain: r.domain,
+      inputTokens: r.inputTokens,
+      outputTokens: r.outputTokens,
+      costUsd: r.costUsd,
+      latencyMs: r.latencyMs,
+      status: r.status,
+      cached: r.cached,
+    },
+  }));
+}
+
+/**
+ * Upsert one daily aggregate row, folding the new counters into any
+ * existing row keyed by `(date, provider, model, operation, domain)` via
+ * `idx_ai_inference_daily_key`. Existing `avg_latency_ms` is merged using
+ * a weighted mean against `total_calls`. Used by the retention rollup;
+ * idempotent against re-running over the same source rows because the
+ * caller deletes the source on success.
+ */
+export function recordInferenceDaily(db: CoreDb, agg: InferenceDailyAggregate): void {
+  db.insert(aiInferenceDaily)
+    .values({
+      date: agg.date,
+      provider: agg.provider,
+      model: agg.model,
+      operation: agg.operation,
+      domain: agg.domain,
+      totalCalls: agg.totalCalls,
+      totalInputTokens: agg.totalInputTokens,
+      totalOutputTokens: agg.totalOutputTokens,
+      totalCostUsd: agg.totalCostUsd,
+      avgLatencyMs: agg.avgLatencyMs,
+      errorCount: agg.errorCount,
+      timeoutCount: agg.timeoutCount,
+      cacheHitCount: agg.cacheHitCount,
+      budgetBlockedCount: agg.budgetBlockedCount,
+    })
+    .onConflictDoUpdate({
+      target: [
+        aiInferenceDaily.date,
+        aiInferenceDaily.provider,
+        aiInferenceDaily.model,
+        aiInferenceDaily.operation,
+        aiInferenceDaily.domain,
+      ],
+      set: {
+        totalCalls: sql`${aiInferenceDaily.totalCalls} + excluded.total_calls`,
+        totalInputTokens: sql`${aiInferenceDaily.totalInputTokens} + excluded.total_input_tokens`,
+        totalOutputTokens: sql`${aiInferenceDaily.totalOutputTokens} + excluded.total_output_tokens`,
+        totalCostUsd: sql`${aiInferenceDaily.totalCostUsd} + excluded.total_cost_usd`,
+        avgLatencyMs: sql`CASE
+          WHEN (${aiInferenceDaily.totalCalls} + excluded.total_calls) = 0 THEN 0
+          ELSE CAST(
+            (${aiInferenceDaily.avgLatencyMs} * ${aiInferenceDaily.totalCalls} + excluded.avg_latency_ms * excluded.total_calls)
+            / (${aiInferenceDaily.totalCalls} + excluded.total_calls)
+            AS INTEGER
+          )
+        END`,
+        errorCount: sql`${aiInferenceDaily.errorCount} + excluded.error_count`,
+        timeoutCount: sql`${aiInferenceDaily.timeoutCount} + excluded.timeout_count`,
+        cacheHitCount: sql`${aiInferenceDaily.cacheHitCount} + excluded.cache_hit_count`,
+        budgetBlockedCount: sql`${aiInferenceDaily.budgetBlockedCount} + excluded.budget_blocked_count`,
+      },
+    })
+    .run();
+}
+
+/**
+ * Delete `ai_inference_log` rows by id list. No-op when `ids` is empty.
+ * Used by the retention rollup after the aggregates have been folded in.
+ */
+export function deleteInferenceLogsByIds(db: CoreDb, ids: number[]): void {
+  if (ids.length === 0) return;
+  db.delete(aiInferenceLog).where(inArray(aiInferenceLog.id, ids)).run();
+}

--- a/packages/core-db/src/services/ai-usage-retention.ts
+++ b/packages/core-db/src/services/ai-usage-retention.ts
@@ -126,7 +126,7 @@ export function recordInferenceDaily(db: CoreDb, agg: InferenceDailyAggregate): 
       provider: agg.provider,
       model: agg.model,
       operation: agg.operation,
-      domain: agg.domain,
+      domain: agg.domain ?? '',
       totalCalls: agg.totalCalls,
       totalInputTokens: agg.totalInputTokens,
       totalOutputTokens: agg.totalOutputTokens,

--- a/packages/core-db/src/services/ai-usage.ts
+++ b/packages/core-db/src/services/ai-usage.ts
@@ -19,10 +19,15 @@
  * transaction handle to pass in. Mirrors `@pops/finance-db`'s service
  * signature pattern.
  *
- * Post-PRD-186 PR 3: every read AND write site in `apps/pops-api` routes
- * through this module against `getCoreDrizzle()`. The boot-time
- * `pops.db -> core.db` backfill bridges any pre-cutover rows; PR 4 drops
- * the legacy `ai_*` tables from the shared journal.
+ * Post-PRD-186 PR 3: the hot inference-log write path and the retention
+ * rollup in `apps/pops-api` route through this module against
+ * `getCoreDrizzle()`. A handful of dashboard read paths
+ * (`ai-observability/history.ts`, `group-stats.ts`, `summary.ts`,
+ * `service.ts`, plus `findFallbackProvider`) still query
+ * `ai_inference_log` / `ai_inference_daily` directly via `getDrizzle()`
+ * and migrate in a follow-up PR. The boot-time `pops.db -> core.db`
+ * backfill bridges any pre-cutover rows; PR 4 drops the legacy `ai_*`
+ * tables from the shared journal once the read sites move over.
  */
 import { and, desc, eq, gte, lte, sql, type SQL } from 'drizzle-orm';
 

--- a/packages/core-db/src/services/ai-usage.ts
+++ b/packages/core-db/src/services/ai-usage.ts
@@ -4,44 +4,60 @@
  * Carries the three hot tables behind `core.aiUsage.*`:
  *   - `ai_inference_log` — append-only per-call record written by the
  *     inference middleware on every provider invocation. The dashboard
- *     reads it for stats + history. PRD-186 lists the surface as
- *     `core.aiUsage.log.{create,list}`.
+ *     reads it for stats + history.
  *   - `ai_inference_daily` — aggregate roll-up written by the retention
  *     job (PRD-092 US-08) once raw rows pass the 90-day horizon. The
  *     dashboard reads it for the continuous timeline across the retention
- *     boundary.
+ *     boundary. Helpers live in `./ai-usage-retention.ts`.
  *   - `ai_budgets` — small CRUD surface that gates AI calls. Budgets are
- *     scoped global / per-provider / per-operation; `checkAvailable`
- *     (PRD-186) consults them on the hot path before the middleware fires.
+ *     scoped global / per-provider / per-operation; consulted on the hot
+ *     path before the middleware fires. CRUD lives in
+ *     `./ai-usage-budgets.ts`.
  *
  * Services take a `CoreDb` handle as their first argument; the calling
  * layer (pops-api modules) is responsible for resolving the singleton or
  * transaction handle to pass in. Mirrors `@pops/finance-db`'s service
  * signature pattern.
  *
- * The in-tree services in `apps/pops-api/src/modules/core/ai-usage/` and
- * `apps/pops-api/src/modules/core/ai-budgets/` still route through the
- * shared `getDrizzle()` handle for now — PRD-186 PR 3 flips that to
- * `getCoreDrizzle()` and routes through this module.
+ * Post-PRD-186 PR 3: every read AND write site in `apps/pops-api` routes
+ * through this module against `getCoreDrizzle()`. The boot-time
+ * `pops.db -> core.db` backfill bridges any pre-cutover rows; PR 4 drops
+ * the legacy `ai_*` tables from the shared journal.
  */
 import { and, desc, eq, gte, lte, sql, type SQL } from 'drizzle-orm';
 
-import { AiBudgetNotFoundError } from '../errors.js';
-import { aiBudgets, aiInferenceDaily, aiInferenceLog } from '../schema.js';
+import { aiInferenceDaily, aiInferenceLog } from '../schema.js';
 
 import type { CoreDb } from './internal.js';
+
+export {
+  deleteBudget,
+  getBudget,
+  getBudgetOrNull,
+  listBudgets,
+  upsertBudget,
+  type AiBudget,
+  type AiBudgetInsert,
+  type AiBudgetRow,
+  type UpsertBudgetInput,
+} from './ai-usage-budgets.js';
+
+export {
+  deleteInferenceLogsByIds,
+  fetchAgedInferenceLogs,
+  recordInferenceDaily,
+  type InferenceDailyAggregate,
+  type InferenceLogRetentionRow,
+} from './ai-usage-retention.js';
 
 /** Raw drizzle row shapes — persisted records. */
 export type AiInferenceLogRow = typeof aiInferenceLog.$inferSelect;
 export type AiInferenceLogInsert = typeof aiInferenceLog.$inferInsert;
 export type AiInferenceDailyRow = typeof aiInferenceDaily.$inferSelect;
-export type AiBudgetRow = typeof aiBudgets.$inferSelect;
-export type AiBudgetInsert = typeof aiBudgets.$inferInsert;
 
 /** Public aliases for the persisted records. */
 export type AiInferenceLog = AiInferenceLogRow;
 export type AiInferenceDaily = AiInferenceDailyRow;
-export type AiBudget = AiBudgetRow;
 
 /** Input for an `ai_inference_log` insert. `created_at` is auto-filled
  * to the current UTC ISO timestamp when the caller omits it so the log
@@ -73,17 +89,6 @@ export interface ListInferenceLogsFilter {
   domain?: string;
   status?: string;
   contextId?: string;
-}
-
-/** Input for {@link upsertBudget}. `scopeValue` is required for non-global
- * scopes. `action` defaults to `warn` to match the shared journal. */
-export interface UpsertBudgetInput {
-  id: string;
-  scopeType: 'global' | 'provider' | 'operation';
-  scopeValue?: string | null;
-  monthlyTokenLimit?: number | null;
-  monthlyCostLimit?: number | null;
-  action?: 'block' | 'warn' | 'fallback';
 }
 
 function buildInferenceLogInsert(input: CreateInferenceLogInput): AiInferenceLogInsert {
@@ -212,71 +217,4 @@ export function listInferenceDaily(
     .where(condition)
     .orderBy(desc(aiInferenceDaily.date), desc(aiInferenceDaily.id))
     .all();
-}
-
-/** Read all configured budgets in insertion order. */
-export function listBudgets(db: CoreDb): AiBudgetRow[] {
-  return db.select().from(aiBudgets).all();
-}
-
-/** Read a single budget by id; returns `null` when absent. */
-export function getBudgetOrNull(db: CoreDb, id: string): AiBudgetRow | null {
-  return db.select().from(aiBudgets).where(eq(aiBudgets.id, id)).get() ?? null;
-}
-
-/** Read a single budget by id; throws {@link AiBudgetNotFoundError} when
- * absent. Prefer {@link getBudgetOrNull} when the caller wants to
- * fall back. */
-export function getBudget(db: CoreDb, id: string): AiBudgetRow {
-  const row = getBudgetOrNull(db, id);
-  if (!row) throw new AiBudgetNotFoundError(id);
-  return row;
-}
-
-/**
- * Upsert a budget. Returns the persisted row. The `scopeValue` column is
- * normalised to `null` for the `global` scope so the unique scope key is
- * always `(scope_type, scope_value)`-shaped from the reader's POV.
- */
-export function upsertBudget(db: CoreDb, input: UpsertBudgetInput): AiBudgetRow {
-  const now = new Date().toISOString();
-  const scopeValue = input.scopeType === 'global' ? null : (input.scopeValue ?? null);
-  const monthlyTokenLimit = input.monthlyTokenLimit ?? null;
-  const monthlyCostLimit = input.monthlyCostLimit ?? null;
-  const action = input.action ?? 'warn';
-
-  db.insert(aiBudgets)
-    .values({
-      id: input.id,
-      scopeType: input.scopeType,
-      scopeValue,
-      monthlyTokenLimit,
-      monthlyCostLimit,
-      action,
-      createdAt: now,
-      updatedAt: now,
-    })
-    .onConflictDoUpdate({
-      target: aiBudgets.id,
-      set: {
-        scopeType: input.scopeType,
-        scopeValue,
-        monthlyTokenLimit,
-        monthlyCostLimit,
-        action,
-        updatedAt: now,
-      },
-    })
-    .run();
-
-  return getBudget(db, input.id);
-}
-
-/** Delete a budget by id. Throws {@link AiBudgetNotFoundError} when no
- * row matched (`changes === 0`) — mirrors the in-tree pops-api service
- * so PRD-186 PR 3 can swap the handle without altering the error
- * contract observable from callers. */
-export function deleteBudget(db: CoreDb, id: string): void {
-  const result = db.delete(aiBudgets).where(eq(aiBudgets.id, id)).run();
-  if (result.changes === 0) throw new AiBudgetNotFoundError(id);
 }


### PR DESCRIPTION
## Summary
- Flips `ai_inference_log`, `ai_inference_daily`, and `ai_budgets` writes from the shared `pops.db` to the core pillar handle (`core.db`).
- `inference-middleware.ts` (the hot-path audit writer on every AI call), `ai-budgets/service.ts` (`upsertBudget`), and the nightly retention rollup (`ai-observability/retention.ts` + `retention-db.ts`) all delegate to `aiUsageService` against `getCoreDrizzle()`.
- Closes the read/write staleness window introduced in PRD-186 PR 2: budget enforcement reads now see freshly written inference rows immediately.

## What moved
- `@pops/core-db` `aiUsageService` gains `fetchAgedInferenceLogs`, `recordInferenceDaily`, `deleteInferenceLogsByIds`. Service file split into `ai-usage.ts` / `ai-usage-budgets.ts` / `ai-usage-retention.ts` to stay under the workspace's max-lines lint cap.
- `apps/pops-api/src/db.ts` adds a `getCoreRawDb()` helper for parity with the cerebrum pillar's pattern.
- Retention now uses drizzle's `tx`-bound `db.transaction(tx => …)` variant so the per-batch atomicity guarantee is preserved on the pillar handle.
- `.dependency-cruiser-known-violations.json` regenerated to record the four new `@pops/core-db` cross-pillar imports.

## Cross-store consistency
`backfillCoreFromShared()` already carries `ai_inference_log`, `ai_inference_daily`, and `ai_budgets` from `pops.db` into `core.db` at boot — the first deploy after this cut closes the initial divergence; subsequent boots are no-ops via the idempotent per-table existence filter. PR 4 drops the backfill bridge and the shared-journal `ai_*` tags.

## Test plan
- [x] `pnpm -F @pops/core-db test` — 102 tests pass (9 new tests cover the retention helpers).
- [x] Targeted `pnpm -F @pops/api test` over `inference-middleware`, `ai-budgets`, `ai-observability/retention`, `ai-usage` — 52/52 pass.
- [x] `pnpm -F @pops/api test` full suite — 4940/4941 pass. The single failure (`glia/toml-config.test.ts` default-threshold drift) reproduces on `origin/main` and is documented in the prior PR 3 cutover notes (PRD-179/180/181).
- [x] `pnpm -w typecheck` — 66/66 packages green.
- [x] `pnpm oxlint` — 0 errors (pre-existing warnings unchanged).
- [x] `pnpm format:check` — clean.
- [x] `pnpm lint:boundaries` — clean against the regenerated baseline.