### PR TITLE
feat(media): migrate watch-history writes to media.db (PRD-168 PR3)

### DIFF
--- a/apps/pops-api/src/modules/media/watch-history/handlers/batch-operations.ts
+++ b/apps/pops-api/src/modules/media/watch-history/handlers/batch-operations.ts
@@ -1,3 +1,14 @@
+/**
+ * `batchLogWatch` — mixed-table writer. PRD-168 PR3 left this on
+ * `getDrizzle()` for the same reason as `logWatch`: the transaction
+ * walks `seasons`/`episodes` to expand the input, dedups against
+ * existing `watchHistory` rows, inserts the new events, then on a
+ * fully-watched show deletes from `mediaWatchlist` and resequences
+ * priorities. Every read and write must hit the same store within one
+ * transaction; until `episodes`, `seasons`, and `mediaWatchlist` move
+ * into `@pops/media-db` this whole orchestrator stays pinned to
+ * `pops.db`.
+ */
 import { and, countDistinct, eq, inArray, isNotNull, lte } from 'drizzle-orm';
 
 import { episodes, mediaWatchlist, seasons, watchHistory } from '@pops/db-types';

--- a/apps/pops-api/src/modules/media/watch-history/handlers/log-watch-event.ts
+++ b/apps/pops-api/src/modules/media/watch-history/handlers/log-watch-event.ts
@@ -1,3 +1,19 @@
+/**
+ * `logWatch` — mixed-table writer. PRD-168 PR3 left this on `getDrizzle()`
+ * deliberately: the transaction inserts into `watchHistory`, then for an
+ * episode resolves `episodes` -> `seasons` -> `tv_show` to seed debrief
+ * state, deletes from `mediaWatchlist`, and resequences watchlist
+ * priorities. Splitting any of those reads/writes across a different
+ * SQLite file would break atomicity, so the whole transaction stays on
+ * `pops.db` until `episodes`, `seasons`, and `mediaWatchlist` move into
+ * `@pops/media-db` (and `debriefSessions` / `debriefStatus` move into
+ * the cerebrum pillar). At that point this orchestrator either fans out
+ * to per-pillar services or, more likely, becomes a router-layer call
+ * sequencing distinct transactions per store.
+ *
+ * `autoRemoveTvShowIfFullyWatched` is exported only for `batchLogWatch`
+ * and runs inside the same `getDrizzle()` transaction.
+ */
 import { and, countDistinct, eq, inArray } from 'drizzle-orm';
 
 import { episodes, mediaWatchlist, seasons, watchHistory } from '@pops/db-types';

--- a/apps/pops-api/src/modules/media/watch-history/handlers/query-helpers.ts
+++ b/apps/pops-api/src/modules/media/watch-history/handlers/query-helpers.ts
@@ -1,5 +1,5 @@
 /**
- * Watch-history read/write surface — PRD-168 PR2 cutover.
+ * Watch-history read/write surface — PRD-168 PR2 + PR3 cutover.
  *
  * Read/write split during the migration window:
  *  - `listWatchHistory` and `getWatchHistoryEntry` are routed through
@@ -8,10 +8,17 @@
  *  - Every write path — `logWatch` in `./log-watch-event.ts`,
  *    `deleteWatchHistoryEntry` below, `batchLogWatch`, the cascade
  *    deletes for `debrief_sessions` / `debrief_results` — still goes
- *    through `getDrizzle()` (the shared `pops.db`). Debrief tables and
- *    the `watch_history.id` FK they hang off are still pinned to the
- *    legacy mount, so writes must stay there until the full slice
- *    moves to `@pops/media-db`.
+ *    through `getDrizzle()` (the shared `pops.db`). PR3 audit confirmed
+ *    every writer in the pops-api watch-history surface is a mixed-table
+ *    transaction spanning `watch_history` plus at least one of
+ *    `episodes`, `seasons`, `mediaWatchlist`, `debrief_sessions`, or
+ *    `debrief_results`. None of those tables live in `@pops/media-db`
+ *    yet, so flipping `watch_history` alone would split a single
+ *    transaction across two SQLite files. PR3 therefore defers the
+ *    writes cutover until the dependent slices ship their own
+ *    `getMediaDrizzle()` / `getCerebrumDrizzle()` handles. See the
+ *    per-handler headers in `./log-watch-event.ts` and
+ *    `./batch-operations.ts` for the table-by-table breakdown.
  *
  * Cross-store consistency relies on `backfillMediaFromShared()` in
  * `apps/pops-api/src/db/media-backfill.ts`: a one-way, boot-time copy

--- a/docs/themes/13-pillar-finale/prds/168-media-watch-history-cutover/README.md
+++ b/docs/themes/13-pillar-finale/prds/168-media-watch-history-cutover/README.md
@@ -46,12 +46,12 @@ Follows [PRD-165's 4-PR sequence](../165-media-movies-cutover/README.md#business
 
 ## User Stories
 
-| #   | Story                                                       | Summary                                    |
-| --- | ----------------------------------------------------------- | ------------------------------------------ |
-| 01  | [us-01-pr1-package-scaffold](us-01-pr1-package-scaffold.md) | PR 1 — Schema + service + batched backfill |
-| 02  | [us-02-pr2-journal-split](us-02-pr2-journal-split.md)       | PR 2 — Drop from shared journal            |
-| 03  | [us-03-pr3-cutover](us-03-pr3-cutover.md)                   | PR 3 — Flip router to `getMediaDrizzle()`  |
-| 04  | [us-04-pr4-shim-deletion](us-04-pr4-shim-deletion.md)       | PR 4 — Delete or defer shim                |
+| #   | Story                                                       | Summary                                                                                      |
+| --- | ----------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| 01  | [us-01-pr1-package-scaffold](us-01-pr1-package-scaffold.md) | PR 1 — Schema + service + batched backfill                                                   |
+| 02  | [us-02-pr2-journal-split](us-02-pr2-journal-split.md)       | PR 2 — Drop from shared journal                                                              |
+| 03  | [us-03-pr3-cutover](us-03-pr3-cutover.md)                   | PR 3 — Flip leaf reads to `getMediaDrizzle()`; writes deferred (every writer is mixed-table) |
+| 04  | [us-04-pr4-shim-deletion](us-04-pr4-shim-deletion.md)       | PR 4 — Delete or defer shim                                                                  |
 
 ## Out of Scope
 


### PR DESCRIPTION
## Summary

PRD-168 PR 3 — writes cutover for `media.watchHistory`. PR #2999 scaffolded the package; PR #3008 cut the leaf reads (`list`, `getById`) to `getMediaDrizzle()` and explicitly left every writer on the shared `pops.db` because each one is a mixed-table transaction.

PR3 audit confirms the deferral: every writer in `apps/pops-api/src/modules/media/watch-history/handlers/*` is a single transaction spanning `watch_history` plus at least one of `episodes`, `seasons`, `mediaWatchlist`, `debrief_sessions`, or `debrief_results`. None of those tables live in `@pops/media-db` yet, so flipping `watch_history` writes alone would split a single SQLite transaction across two files.

Unlike PR #3018 / PR #3019 (which had leaf non-transactional writers to peel off), the watch-history surface only exposes mixed-table orchestrators (`log`, `batchLog`, `delete`) at the router layer. There is no `add` or `update` call site outside the transactions. The PR3 step that normally flips the simple writers is therefore purely documentation here.

## Sites kept on `getDrizzle()` (mixed-table, documented)

- `handlers/log-watch-event.ts` — `logWatch` inserts into `watchHistory`, resolves `episodes` -> `seasons` -> `tv_show` for the debrief side effects (`createDebriefSession`, `queueDebriefStatus`, `resetStaleness`), deletes from `mediaWatchlist` on a completed movie/show, and resequences priorities. All inside one transaction.
- `handlers/batch-operations.ts` — `batchLogWatch` expands the season or show via `seasons`/`episodes`, dedups against `watchHistory`, inserts new events, deletes from `mediaWatchlist` on a fully-watched show, and resequences. Same single-transaction shape as `logWatch`.
- `handlers/query-helpers.ts` — `deleteWatchHistoryEntry` cascades `debriefResults` -> `debriefSessions` -> `watchHistory` in one transaction; debrief tables are in the cerebrum pillar's roadmap, not media's.

## Docs updated

- `handlers/query-helpers.ts` header expanded to cover PR3's audit conclusion and point readers at the per-handler headers below for the table-by-table breakdown.
- `handlers/log-watch-event.ts` and `handlers/batch-operations.ts` gain file-level docstrings explaining why each writer stays on `getDrizzle()` and what would need to move for it to flip.
- PRD-168 README user-stories table updated so PR3's summary reflects the actual scope — reads cut in PR2, writes deferred to the slices that own the joined tables.

## Why this is still a useful PR

- Locks in the audit conclusion so the next agent picking up the dependent slices (`episodes` / `seasons` / `mediaWatchlist` into `@pops/media-db`; `debrief_*` into the cerebrum pillar) sees the writer-side dependency wall before changing anything.
- Keeps the PRD-168 PR sequence numbered consistently with sibling cutovers (PR1/PR2/PR3/PR4 across PRD-165, PRD-166, PRD-167, PRD-186, ...) so the roadmap tracker stays clean.

## Test plan

- [x] `pnpm -F @pops/api test src/modules/media/watch-history` — 66/66 pass
- [x] `pnpm -w typecheck` — green
- [x] `pnpm oxlint apps/pops-api/src/modules/media/watch-history` — clean
- [x] `pnpm oxfmt --check` on touched files — clean
- [ ] CI passes on this branch

## Follow-up

When the dependent slices land, follow-up PRs can flip these orchestrators by either fanning out to per-pillar services or restructuring the router layer to sequence distinct transactions per store.
