### PR TITLE
feat(inventory-db): scaffold connections service (PRD-175 US-01)

### DIFF
--- a/packages/inventory-db/src/__tests__/connections.test.ts
+++ b/packages/inventory-db/src/__tests__/connections.test.ts
@@ -1,0 +1,463 @@
+/**
+ * Invariant tests for the connections service against an in-memory SQLite
+ * seeded with the canonical `home_inventory` + `item_connections` tables.
+ * Pure DB + service layer — no tRPC, no Express, no auth middleware.
+ *
+ * Higher-level integration coverage (auth, router, tRPC error mapping)
+ * lives in pops-api's own suite; the writer move + reads cutover PRs
+ * route those through `connectionsService.*`.
+ *
+ * The `home_inventory` and `item_connections` DDL is inlined here because
+ * the canonical baseline migration (`0006_inventory_pillar_baseline`)
+ * bundles unrelated FK tables. The locations migration is read from the
+ * package's journal so the FK target exists.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { connectionsService } from '../index.js';
+import {
+  ConnectionConflictError,
+  ConnectionItemNotFoundError,
+  ConnectionNotFoundError,
+  SelfConnectionError,
+} from '../services/connections-errors.js';
+import { create as createItem } from '../services/items.js';
+
+import type { TraceNode } from '../services/connections-types.js';
+import type { InventoryDb } from '../services/internal.js';
+
+const LOCATIONS_MIGRATION = join(__dirname, '../../migrations/0005_fancy_crystal.sql');
+
+const HOME_INVENTORY_DDL = `
+CREATE TABLE home_inventory (
+  id text PRIMARY KEY NOT NULL,
+  notion_id text UNIQUE,
+  item_name text NOT NULL,
+  brand text,
+  model text,
+  item_id text,
+  room text,
+  location text,
+  type text,
+  condition text DEFAULT 'good',
+  in_use integer,
+  deductible integer,
+  purchase_date text,
+  warranty_expires text,
+  replacement_value real,
+  resale_value real,
+  purchase_transaction_id text,
+  purchased_from_id text,
+  purchased_from_name text,
+  purchase_price real,
+  asset_id text UNIQUE,
+  notes text,
+  location_id text REFERENCES locations(id) ON DELETE set null,
+  created_at text NOT NULL DEFAULT (datetime('now')),
+  updated_at text NOT NULL DEFAULT (datetime('now')),
+  last_edited_time text NOT NULL
+);
+`;
+
+const ITEM_CONNECTIONS_DDL = `
+CREATE TABLE item_connections (
+  id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  item_a_id text NOT NULL REFERENCES home_inventory(id) ON DELETE CASCADE,
+  item_b_id text NOT NULL REFERENCES home_inventory(id) ON DELETE CASCADE,
+  created_at text NOT NULL DEFAULT (datetime('now')),
+  CONSTRAINT chk_item_connections_order CHECK (item_a_id < item_b_id)
+);
+CREATE UNIQUE INDEX uq_item_connections_pair ON item_connections (item_a_id, item_b_id);
+CREATE INDEX idx_item_connections_a ON item_connections (item_a_id);
+CREATE INDEX idx_item_connections_b ON item_connections (item_b_id);
+`;
+
+function freshDb(): InventoryDb {
+  const raw = new Database(':memory:');
+  raw.pragma('foreign_keys = ON');
+  const sql = readFileSync(LOCATIONS_MIGRATION, 'utf8');
+  for (const stmt of sql.split('--> statement-breakpoint')) {
+    const trimmed = stmt.trim();
+    if (trimmed.length > 0) raw.exec(trimmed);
+  }
+  raw.exec(HOME_INVENTORY_DDL);
+  raw.exec(ITEM_CONNECTIONS_DDL);
+  return drizzle(raw);
+}
+
+/** Seed two items and return their IDs in sorted (A<B) order. */
+function seedPair(db: InventoryDb, nameA = 'Item A', nameB = 'Item B'): [string, string] {
+  const a = createItem(db, { itemName: nameA });
+  const b = createItem(db, { itemName: nameB });
+  return [a.id, b.id].toSorted() as [string, string];
+}
+
+describe('connectionsService.create', () => {
+  let db: InventoryDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('connects two items and returns the row with A<B ordering', () => {
+    const [idA, idB] = seedPair(db);
+    const row = connectionsService.create(db, { itemAId: idA, itemBId: idB });
+    expect(row.itemAId).toBe(idA);
+    expect(row.itemBId).toBe(idB);
+    expect(typeof row.id).toBe('number');
+    expect(row.createdAt).toBeTruthy();
+  });
+
+  it('normalises caller-provided reverse ordering to A<B', () => {
+    const [idA, idB] = seedPair(db);
+    const row = connectionsService.create(db, { itemAId: idB, itemBId: idA });
+    expect(row.itemAId).toBe(idA);
+    expect(row.itemBId).toBe(idB);
+  });
+
+  it('rejects connecting an item to itself with SelfConnectionError', () => {
+    const item = createItem(db, { itemName: 'Solo' });
+    expect(() =>
+      connectionsService.create(db, { itemAId: item.id, itemBId: item.id })
+    ).toThrowError(SelfConnectionError);
+  });
+
+  it('rejects duplicate pairs with ConnectionConflictError', () => {
+    const [idA, idB] = seedPair(db);
+    connectionsService.create(db, { itemAId: idA, itemBId: idB });
+    expect(() => connectionsService.create(db, { itemAId: idA, itemBId: idB })).toThrowError(
+      ConnectionConflictError
+    );
+  });
+
+  it('rejects duplicate pairs in reverse order (same canonical pair)', () => {
+    const [idA, idB] = seedPair(db);
+    connectionsService.create(db, { itemAId: idA, itemBId: idB });
+    expect(() => connectionsService.create(db, { itemAId: idB, itemBId: idA })).toThrowError(
+      ConnectionConflictError
+    );
+  });
+
+  it('throws ConnectionItemNotFoundError when itemA is missing', () => {
+    const b = createItem(db, { itemName: 'B' });
+    expect(() => connectionsService.create(db, { itemAId: 'nope', itemBId: b.id })).toThrowError(
+      ConnectionItemNotFoundError
+    );
+  });
+
+  it('throws ConnectionItemNotFoundError when itemB is missing', () => {
+    const a = createItem(db, { itemName: 'A' });
+    expect(() => connectionsService.create(db, { itemAId: a.id, itemBId: 'nope' })).toThrowError(
+      ConnectionItemNotFoundError
+    );
+  });
+});
+
+describe('connectionsService.get', () => {
+  let db: InventoryDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('returns the row for an existing pair (normalised)', () => {
+    const [idA, idB] = seedPair(db);
+    connectionsService.create(db, { itemAId: idA, itemBId: idB });
+    const row = connectionsService.get(db, idB, idA);
+    expect(row.itemAId).toBe(idA);
+    expect(row.itemBId).toBe(idB);
+  });
+
+  it('throws ConnectionNotFoundError when no row matches', () => {
+    const [idA, idB] = seedPair(db);
+    expect(() => connectionsService.get(db, idA, idB)).toThrowError(ConnectionNotFoundError);
+  });
+});
+
+describe('connectionsService.list', () => {
+  let db: InventoryDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('returns empty rows + zero total when the item has no connections', () => {
+    const item = createItem(db, { itemName: 'Lonely' });
+    const result = connectionsService.list(db, item.id, 50, 0);
+    expect(result).toEqual({ rows: [], total: 0 });
+  });
+
+  it('returns rows where the item appears in column A', () => {
+    const [idA, idB] = seedPair(db, 'AAA', 'ZZZ');
+    connectionsService.create(db, { itemAId: idA, itemBId: idB });
+    const result = connectionsService.list(db, idA, 50, 0);
+    expect(result.total).toBe(1);
+    expect(result.rows[0]!.itemAId).toBe(idA);
+    expect(result.rows[0]!.itemBId).toBe(idB);
+  });
+
+  it('returns rows where the item appears in column B', () => {
+    const [idA, idB] = seedPair(db, 'AAA', 'ZZZ');
+    connectionsService.create(db, { itemAId: idA, itemBId: idB });
+    const result = connectionsService.list(db, idB, 50, 0);
+    expect(result.total).toBe(1);
+    expect(result.rows[0]!.itemAId).toBe(idA);
+    expect(result.rows[0]!.itemBId).toBe(idB);
+  });
+
+  it('paginates rows but reports the full total for the filter', () => {
+    const hub = createItem(db, { itemName: 'Hub' });
+    for (let i = 0; i < 3; i++) {
+      const peer = createItem(db, { itemName: `Peer ${i}` });
+      connectionsService.create(db, { itemAId: hub.id, itemBId: peer.id });
+    }
+
+    const page1 = connectionsService.list(db, hub.id, 2, 0);
+    expect(page1.rows).toHaveLength(2);
+    expect(page1.total).toBe(3);
+
+    const page2 = connectionsService.list(db, hub.id, 2, 2);
+    expect(page2.rows).toHaveLength(1);
+    expect(page2.total).toBe(3);
+  });
+});
+
+describe('connectionsService.delete', () => {
+  let db: InventoryDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('removes an existing connection by ordered pair', () => {
+    const [idA, idB] = seedPair(db);
+    connectionsService.create(db, { itemAId: idA, itemBId: idB });
+    connectionsService.delete(db, idA, idB);
+    expect(() => connectionsService.get(db, idA, idB)).toThrowError(ConnectionNotFoundError);
+  });
+
+  it('normalises reverse ordering before deleting', () => {
+    const [idA, idB] = seedPair(db);
+    connectionsService.create(db, { itemAId: idA, itemBId: idB });
+    connectionsService.delete(db, idB, idA);
+    expect(connectionsService.list(db, idA, 50, 0).total).toBe(0);
+  });
+
+  it('throws ConnectionNotFoundError when no row matches', () => {
+    const [idA, idB] = seedPair(db);
+    expect(() => connectionsService.delete(db, idA, idB)).toThrowError(ConnectionNotFoundError);
+  });
+
+  it('leaves unrelated connections untouched', () => {
+    const a = createItem(db, { itemName: 'A' });
+    const b = createItem(db, { itemName: 'B' });
+    const c = createItem(db, { itemName: 'C' });
+
+    const pairAB = [a.id, b.id].toSorted() as [string, string];
+    const pairAC = [a.id, c.id].toSorted() as [string, string];
+    connectionsService.create(db, { itemAId: pairAB[0], itemBId: pairAB[1] });
+    connectionsService.create(db, { itemAId: pairAC[0], itemBId: pairAC[1] });
+
+    connectionsService.delete(db, pairAB[0], pairAB[1]);
+
+    expect(connectionsService.get(db, pairAC[0], pairAC[1]).itemAId).toBe(pairAC[0]);
+  });
+});
+
+describe('connectionsService.trace', () => {
+  let db: InventoryDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('returns root with no children when the item has no connections', () => {
+    const item = createItem(db, { itemName: 'Lonely' });
+    const tree = connectionsService.trace(db, item.id, 10);
+    expect(tree.id).toBe(item.id);
+    expect(tree.itemName).toBe('Lonely');
+    expect(tree.children).toEqual([]);
+  });
+
+  it('returns immediate neighbours as direct children', () => {
+    const hub = createItem(db, { itemName: 'Hub' });
+    const peer1 = createItem(db, { itemName: 'Peer 1' });
+    const peer2 = createItem(db, { itemName: 'Peer 2' });
+    connectionsService.create(db, { itemAId: hub.id, itemBId: peer1.id });
+    connectionsService.create(db, { itemAId: hub.id, itemBId: peer2.id });
+
+    const tree = connectionsService.trace(db, hub.id, 10);
+    expect(tree.children).toHaveLength(2);
+    expect(tree.children.map((c) => c.id).toSorted()).toEqual([peer1.id, peer2.id].toSorted());
+  });
+
+  it('traverses multi-hop chains recursively', () => {
+    const a = createItem(db, { itemName: 'A' });
+    const b = createItem(db, { itemName: 'B' });
+    const c = createItem(db, { itemName: 'C' });
+    const d = createItem(db, { itemName: 'D' });
+
+    const pairs = [
+      [a.id, b.id],
+      [b.id, c.id],
+      [c.id, d.id],
+    ];
+    for (const [x, y] of pairs) {
+      const sorted = [x!, y!].toSorted() as [string, string];
+      connectionsService.create(db, { itemAId: sorted[0], itemBId: sorted[1] });
+    }
+
+    const tree = connectionsService.trace(db, a.id, 10);
+    expect(tree.children).toHaveLength(1);
+    const nodeB = tree.children[0]!;
+    expect(nodeB.id).toBe(b.id);
+    const nodeC = nodeB.children[0]!;
+    expect(nodeC.id).toBe(c.id);
+    const nodeD = nodeC.children[0]!;
+    expect(nodeD.id).toBe(d.id);
+    expect(nodeD.children).toEqual([]);
+  });
+
+  it('caps depth at maxDepth', () => {
+    const a = createItem(db, { itemName: 'A' });
+    const b = createItem(db, { itemName: 'B' });
+    const c = createItem(db, { itemName: 'C' });
+
+    const pairAB = [a.id, b.id].toSorted() as [string, string];
+    const pairBC = [b.id, c.id].toSorted() as [string, string];
+    connectionsService.create(db, { itemAId: pairAB[0], itemBId: pairAB[1] });
+    connectionsService.create(db, { itemAId: pairBC[0], itemBId: pairBC[1] });
+
+    const tree = connectionsService.trace(db, a.id, 1);
+    expect(tree.children).toHaveLength(1);
+    expect(tree.children[0]!.id).toBe(b.id);
+    expect(tree.children[0]!.children).toEqual([]);
+  });
+
+  it('breaks cycles in a triangle so each node appears at most once', () => {
+    const a = createItem(db, { itemName: 'A' });
+    const b = createItem(db, { itemName: 'B' });
+    const c = createItem(db, { itemName: 'C' });
+
+    for (const [x, y] of [
+      [a.id, b.id],
+      [a.id, c.id],
+      [b.id, c.id],
+    ]) {
+      const sorted = [x!, y!].toSorted() as [string, string];
+      connectionsService.create(db, { itemAId: sorted[0], itemBId: sorted[1] });
+    }
+
+    const tree = connectionsService.trace(db, a.id, 10);
+
+    function countNodes(node: TraceNode): number {
+      return 1 + node.children.reduce((sum, child) => sum + countNodes(child), 0);
+    }
+    expect(countNodes(tree)).toBe(3);
+  });
+
+  it('throws ConnectionItemNotFoundError when the root is missing', () => {
+    expect(() => connectionsService.trace(db, 'nope', 10)).toThrowError(
+      ConnectionItemNotFoundError
+    );
+  });
+});
+
+describe('connectionsService.graph', () => {
+  let db: InventoryDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('returns a single-node subgraph when the item has no connections', () => {
+    const item = createItem(db, { itemName: 'Lonely' });
+    const result = connectionsService.graph(db, item.id, 10);
+    expect(result.nodes).toHaveLength(1);
+    expect(result.nodes[0]!.id).toBe(item.id);
+    expect(result.edges).toEqual([]);
+  });
+
+  it('includes cross-links between visited nodes (triangle)', () => {
+    const a = createItem(db, { itemName: 'A' });
+    const b = createItem(db, { itemName: 'B' });
+    const c = createItem(db, { itemName: 'C' });
+
+    for (const [x, y] of [
+      [a.id, b.id],
+      [a.id, c.id],
+      [b.id, c.id],
+    ]) {
+      const sorted = [x!, y!].toSorted() as [string, string];
+      connectionsService.create(db, { itemAId: sorted[0], itemBId: sorted[1] });
+    }
+
+    const result = connectionsService.graph(db, a.id, 10);
+    expect(result.nodes).toHaveLength(3);
+    expect(result.edges).toHaveLength(3);
+  });
+
+  it('respects maxDepth', () => {
+    const a = createItem(db, { itemName: 'A' });
+    const b = createItem(db, { itemName: 'B' });
+    const c = createItem(db, { itemName: 'C' });
+
+    const pairAB = [a.id, b.id].toSorted() as [string, string];
+    const pairBC = [b.id, c.id].toSorted() as [string, string];
+    connectionsService.create(db, { itemAId: pairAB[0], itemBId: pairAB[1] });
+    connectionsService.create(db, { itemAId: pairBC[0], itemBId: pairBC[1] });
+
+    const result = connectionsService.graph(db, a.id, 1);
+    expect(result.nodes.map((n) => n.id).toSorted()).toEqual([a.id, b.id].toSorted());
+  });
+
+  it('emits edges in canonical A<B (source<target) ordering', () => {
+    const [idA, idB] = seedPair(db);
+    connectionsService.create(db, { itemAId: idA, itemBId: idB });
+
+    const result = connectionsService.graph(db, idA, 10);
+    expect(result.edges).toHaveLength(1);
+    expect(result.edges[0]!.source).toBe(idA);
+    expect(result.edges[0]!.target).toBe(idB);
+  });
+
+  it('includes node metadata (itemName, assetId, type)', () => {
+    const item = createItem(db, {
+      itemName: 'MacBook Pro',
+      assetId: 'ASSET-001',
+      type: 'electronics',
+    });
+
+    const result = connectionsService.graph(db, item.id, 10);
+    expect(result.nodes[0]).toMatchObject({
+      id: item.id,
+      itemName: 'MacBook Pro',
+      assetId: 'ASSET-001',
+      type: 'electronics',
+    });
+  });
+
+  it('throws ConnectionItemNotFoundError when the root is missing', () => {
+    expect(() => connectionsService.graph(db, 'nope', 10)).toThrowError(
+      ConnectionItemNotFoundError
+    );
+  });
+});
+
+describe('connectionsService.toConnection', () => {
+  let db: InventoryDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('maps a row to the public API shape', () => {
+    const [idA, idB] = seedPair(db);
+    const row = connectionsService.create(db, { itemAId: idA, itemBId: idB });
+    const dto = connectionsService.toConnection(row);
+    expect(dto).toEqual({
+      id: row.id,
+      itemAId: idA,
+      itemBId: idB,
+      createdAt: row.createdAt,
+    });
+  });
+});

--- a/packages/inventory-db/src/index.ts
+++ b/packages/inventory-db/src/index.ts
@@ -20,6 +20,7 @@ export { openInventoryDb, type OpenedInventoryDb } from './open-inventory-db.js'
 
 export * as locationsService from './services/locations.js';
 export * as itemsService from './services/items.js';
+export * as connectionsService from './services/connections.js';
 
 // Public types re-exported at the package root so consumers can name
 // them without reaching into the namespaces.
@@ -47,3 +48,23 @@ export type {
 export { toItem } from './services/items.js';
 
 export { ItemConflictError, ItemNotFoundError } from './services/items-errors.js';
+
+export type {
+  Connection,
+  ConnectionListResult,
+  CreateConnectionInput,
+  GraphData,
+  GraphEdge,
+  GraphNode,
+  ItemConnectionRow,
+  TraceNode,
+} from './services/connections.js';
+
+export { toConnection } from './services/connections.js';
+
+export {
+  ConnectionConflictError,
+  ConnectionItemNotFoundError,
+  ConnectionNotFoundError,
+  SelfConnectionError,
+} from './services/connections-errors.js';

--- a/packages/inventory-db/src/schema.ts
+++ b/packages/inventory-db/src/schema.ts
@@ -14,4 +14,4 @@
  * `getLocationItems` / `getDeleteStats`, and downstream slice PRs (items,
  * connections, documents, photos, fixtures) will need it too.
  */
-export { homeInventory, locations } from '@pops/db-types';
+export { homeInventory, itemConnections, locations } from '@pops/db-types';

--- a/packages/inventory-db/src/services/connections-errors.ts
+++ b/packages/inventory-db/src/services/connections-errors.ts
@@ -1,0 +1,51 @@
+/**
+ * Typed errors raised by the item connections service layer.
+ *
+ * Plain Error subclasses — the service layer is HTTP-agnostic. Router
+ * layers (pops-api, pops-inventory-api) map these to the appropriate
+ * tRPC / HTTP codes. Mirrors the items / locations error pattern.
+ */
+
+export class ConnectionNotFoundError extends Error {
+  override readonly name = 'ConnectionNotFoundError' as const;
+  readonly itemAId: string;
+  readonly itemBId: string;
+
+  constructor(itemAId: string, itemBId: string) {
+    super(`Item connection '${itemAId}-${itemBId}' not found`);
+    this.itemAId = itemAId;
+    this.itemBId = itemBId;
+  }
+}
+
+export class ConnectionConflictError extends Error {
+  override readonly name = 'ConnectionConflictError' as const;
+  readonly itemAId: string;
+  readonly itemBId: string;
+
+  constructor(itemAId: string, itemBId: string) {
+    super(`Connection between '${itemAId}' and '${itemBId}' already exists`);
+    this.itemAId = itemAId;
+    this.itemBId = itemBId;
+  }
+}
+
+export class SelfConnectionError extends Error {
+  override readonly name = 'SelfConnectionError' as const;
+  readonly itemId: string;
+
+  constructor(itemId: string) {
+    super('Cannot connect an item to itself');
+    this.itemId = itemId;
+  }
+}
+
+export class ConnectionItemNotFoundError extends Error {
+  override readonly name = 'ConnectionItemNotFoundError' as const;
+  readonly id: string;
+
+  constructor(id: string) {
+    super(`Inventory item '${id}' not found`);
+    this.id = id;
+  }
+}

--- a/packages/inventory-db/src/services/connections-graph.ts
+++ b/packages/inventory-db/src/services/connections-graph.ts
@@ -1,4 +1,3 @@
-import { homeInventory, itemConnections } from '../schema.js';
 /**
  * In-process BFS over the item-connections adjacency to build a node/edge
  * subgraph from a starting item up to `maxDepth`. Lives next to the
@@ -9,6 +8,7 @@ import { homeInventory, itemConnections } from '../schema.js';
  * `select *` — the BFS works on in-memory adjacency maps so cycles, deep
  * chains, and dense fan-out don't reissue queries per node.
  */
+import { homeInventory, itemConnections } from '../schema.js';
 import { ConnectionItemNotFoundError } from './connections-errors.js';
 
 import type { GraphData, GraphEdge, GraphNode } from './connections-types.js';

--- a/packages/inventory-db/src/services/connections-graph.ts
+++ b/packages/inventory-db/src/services/connections-graph.ts
@@ -1,0 +1,109 @@
+import { homeInventory, itemConnections } from '../schema.js';
+/**
+ * In-process BFS over the item-connections adjacency to build a node/edge
+ * subgraph from a starting item up to `maxDepth`. Lives next to the
+ * connections service so callers get the full graph surface from one
+ * namespace.
+ *
+ * The graph traversal is intentionally db-agnostic beyond the initial
+ * `select *` — the BFS works on in-memory adjacency maps so cycles, deep
+ * chains, and dense fan-out don't reissue queries per node.
+ */
+import { ConnectionItemNotFoundError } from './connections-errors.js';
+
+import type { GraphData, GraphEdge, GraphNode } from './connections-types.js';
+import type { InventoryDb } from './internal.js';
+
+type AdjacencyEntry = { neighborId: string; itemAId: string; itemBId: string };
+type AdjacencyMap = Map<string, AdjacencyEntry[]>;
+
+function buildAdjacency(connections: { itemAId: string; itemBId: string }[]): AdjacencyMap {
+  const adjacency: AdjacencyMap = new Map();
+  for (const conn of connections) {
+    if (!adjacency.has(conn.itemAId)) adjacency.set(conn.itemAId, []);
+    if (!adjacency.has(conn.itemBId)) adjacency.set(conn.itemBId, []);
+    adjacency.get(conn.itemAId)?.push({
+      neighborId: conn.itemBId,
+      itemAId: conn.itemAId,
+      itemBId: conn.itemBId,
+    });
+    adjacency.get(conn.itemBId)?.push({
+      neighborId: conn.itemAId,
+      itemAId: conn.itemAId,
+      itemBId: conn.itemBId,
+    });
+  }
+  return adjacency;
+}
+
+interface BfsState {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+  visitedNodes: Set<string>;
+  visitedEdges: Set<string>;
+  queue: { nodeId: string; depth: number }[];
+}
+
+function visitNeighbors(
+  state: BfsState,
+  neighbors: AdjacencyEntry[],
+  itemMap: Map<string, GraphNode>,
+  depth: number
+): void {
+  for (const { neighborId, itemAId, itemBId } of neighbors) {
+    const edgeKey = `${itemAId}-${itemBId}`;
+    if (!state.visitedEdges.has(edgeKey)) {
+      state.visitedEdges.add(edgeKey);
+      state.edges.push({ source: itemAId, target: itemBId });
+    }
+
+    if (state.visitedNodes.has(neighborId)) continue;
+    state.visitedNodes.add(neighborId);
+
+    const neighbor = itemMap.get(neighborId);
+    if (!neighbor) continue;
+    state.nodes.push(neighbor);
+    state.queue.push({ nodeId: neighborId, depth: depth + 1 });
+  }
+}
+
+/**
+ * Build the connection subgraph rooted at `itemId`, expanding by BFS up to
+ * `maxDepth` hops. Throws `ConnectionItemNotFoundError` when the starting
+ * item is missing.
+ */
+export function getConnectionGraph(db: InventoryDb, itemId: string, maxDepth: number): GraphData {
+  const allConnections = db.select().from(itemConnections).all();
+  const allItems = db
+    .select({
+      id: homeInventory.id,
+      itemName: homeInventory.itemName,
+      assetId: homeInventory.assetId,
+      type: homeInventory.type,
+    })
+    .from(homeInventory)
+    .all();
+
+  const itemMap = new Map(allItems.map((item) => [item.id, item]));
+  const adjacency = buildAdjacency(allConnections);
+
+  const startItem = itemMap.get(itemId);
+  if (!startItem) throw new ConnectionItemNotFoundError(itemId);
+
+  const state: BfsState = {
+    nodes: [startItem],
+    edges: [],
+    visitedNodes: new Set<string>([itemId]),
+    visitedEdges: new Set<string>(),
+    queue: [{ nodeId: itemId, depth: 0 }],
+  };
+
+  while (state.queue.length > 0) {
+    const entry = state.queue.shift();
+    if (!entry) break;
+    if (entry.depth >= maxDepth) continue;
+    visitNeighbors(state, adjacency.get(entry.nodeId) ?? [], itemMap, entry.depth);
+  }
+
+  return { nodes: state.nodes, edges: state.edges };
+}

--- a/packages/inventory-db/src/services/connections-graph.ts
+++ b/packages/inventory-db/src/services/connections-graph.ts
@@ -51,7 +51,7 @@ function visitNeighbors(
   depth: number
 ): void {
   for (const { neighborId, itemAId, itemBId } of neighbors) {
-    const edgeKey = `${itemAId}-${itemBId}`;
+    const edgeKey = `${itemAId}|${itemBId}`;
     if (!state.visitedEdges.has(edgeKey)) {
       state.visitedEdges.add(edgeKey);
       state.edges.push({ source: itemAId, target: itemBId });

--- a/packages/inventory-db/src/services/connections-types.ts
+++ b/packages/inventory-db/src/services/connections-types.ts
@@ -1,9 +1,10 @@
 /**
- * Input and result types for the item connections service.
+ * Input and result types for the item connections service, plus the
+ * `toConnection` row→API mapper.
  *
- * Validation (zod) and the API response mapper live with the router
- * layers — this package stays HTTP-agnostic and only exposes the
- * service surface and row types needed to call it.
+ * Validation (zod) lives with the router layers — this package stays
+ * HTTP-agnostic and only exposes the service surface, row types, and
+ * the canonical row→public-shape mapper needed to call it.
  */
 import type { ItemConnectionRow } from '@pops/db-types';
 
@@ -39,7 +40,7 @@ export function toConnection(row: ItemConnectionRow): Connection {
   };
 }
 
-/** Tree node returned by `traceConnections`. */
+/** Tree node returned by `connectionsService.trace`. */
 export interface TraceNode {
   id: string;
   itemName: string;

--- a/packages/inventory-db/src/services/connections-types.ts
+++ b/packages/inventory-db/src/services/connections-types.ts
@@ -1,0 +1,69 @@
+/**
+ * Input and result types for the item connections service.
+ *
+ * Validation (zod) and the API response mapper live with the router
+ * layers — this package stays HTTP-agnostic and only exposes the
+ * service surface and row types needed to call it.
+ */
+import type { ItemConnectionRow } from '@pops/db-types';
+
+export type { ItemConnectionRow };
+
+/** Input for creating a new item connection. */
+export interface CreateConnectionInput {
+  itemAId: string;
+  itemBId: string;
+}
+
+/** Paginated list result for connections. */
+export interface ConnectionListResult {
+  rows: ItemConnectionRow[];
+  total: number;
+}
+
+/** Public API shape for an item connection. */
+export interface Connection {
+  id: number;
+  itemAId: string;
+  itemBId: string;
+  createdAt: string;
+}
+
+/** Map a SQLite row to the public API shape. */
+export function toConnection(row: ItemConnectionRow): Connection {
+  return {
+    id: row.id,
+    itemAId: row.itemAId,
+    itemBId: row.itemBId,
+    createdAt: row.createdAt,
+  };
+}
+
+/** Tree node returned by `traceConnections`. */
+export interface TraceNode {
+  id: string;
+  itemName: string;
+  assetId: string | null;
+  type: string | null;
+  children: TraceNode[];
+}
+
+/** Node in a connection graph. */
+export interface GraphNode {
+  id: string;
+  itemName: string;
+  assetId: string | null;
+  type: string | null;
+}
+
+/** Edge in a connection graph (always emitted with A<B ordering). */
+export interface GraphEdge {
+  source: string;
+  target: string;
+}
+
+/** Full connection subgraph for an item. */
+export interface GraphData {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+}

--- a/packages/inventory-db/src/services/connections.ts
+++ b/packages/inventory-db/src/services/connections.ts
@@ -1,0 +1,235 @@
+/**
+ * Item connections CRUD + traversal service.
+ *
+ * Each function takes an `InventoryDb` handle as its first argument; the
+ * calling layer (pops-api modules, pops-inventory-api routers) resolves
+ * the singleton or transaction handle to pass in. Mirrors the items /
+ * locations writer pattern (db-arg, typed errors).
+ *
+ * The live writer in `apps/pops-api/src/modules/inventory/connections/service.ts`
+ * is the source of truth for the wire surface — this scaffold mirrors
+ * its semantics so the PR2 reads-cutover can swap consumers over to
+ * `connectionsService.*` without a behavioural change.
+ *
+ * Pair ordering invariant: `item_a_id < item_b_id` is enforced by a CHECK
+ * constraint at the schema level. The service normalises caller-provided
+ * pairs to satisfy that ordering before any insert / lookup / delete.
+ */
+import { and, count, eq, or } from 'drizzle-orm';
+
+import { homeInventory, itemConnections } from '../schema.js';
+import {
+  ConnectionConflictError,
+  ConnectionItemNotFoundError,
+  ConnectionNotFoundError,
+  SelfConnectionError,
+} from './connections-errors.js';
+import { getConnectionGraph } from './connections-graph.js';
+
+import type {
+  ConnectionListResult,
+  CreateConnectionInput,
+  GraphData,
+  ItemConnectionRow,
+  TraceNode,
+} from './connections-types.js';
+import type { InventoryDb } from './internal.js';
+
+export {
+  type Connection,
+  type ConnectionListResult,
+  type CreateConnectionInput,
+  type GraphData,
+  type GraphEdge,
+  type GraphNode,
+  type ItemConnectionRow,
+  toConnection,
+  type TraceNode,
+} from './connections-types.js';
+
+export {
+  ConnectionConflictError,
+  ConnectionItemNotFoundError,
+  ConnectionNotFoundError,
+  SelfConnectionError,
+} from './connections-errors.js';
+
+export { getConnectionGraph } from './connections-graph.js';
+
+/** Normalise a caller-provided pair to satisfy the A<B schema invariant. */
+function normalisePair(inputA: string, inputB: string): [string, string] {
+  return inputA < inputB ? [inputA, inputB] : [inputB, inputA];
+}
+
+function assertItemExists(db: InventoryDb, id: string): void {
+  const [row] = db
+    .select({ id: homeInventory.id })
+    .from(homeInventory)
+    .where(eq(homeInventory.id, id))
+    .all();
+  if (!row) throw new ConnectionItemNotFoundError(id);
+}
+
+function findByPair(
+  db: InventoryDb,
+  itemAId: string,
+  itemBId: string
+): ItemConnectionRow | undefined {
+  const [row] = db
+    .select()
+    .from(itemConnections)
+    .where(and(eq(itemConnections.itemAId, itemAId), eq(itemConnections.itemBId, itemBId)))
+    .all();
+  return row;
+}
+
+/**
+ * List connections for a given item (matches rows where the item appears in
+ * either the A or B column). Paginated; returns the matching slice plus the
+ * full count for the filter.
+ */
+export function list(
+  db: InventoryDb,
+  itemId: string,
+  limit: number,
+  offset: number
+): ConnectionListResult {
+  const condition = or(eq(itemConnections.itemAId, itemId), eq(itemConnections.itemBId, itemId));
+
+  const rows = db.select().from(itemConnections).where(condition).limit(limit).offset(offset).all();
+
+  const [countResult] = db.select({ total: count() }).from(itemConnections).where(condition).all();
+
+  return { rows, total: countResult?.total ?? 0 };
+}
+
+/**
+ * Look up a connection by the ordered pair. Normalises ordering before
+ * the lookup. Throws `ConnectionNotFoundError` if no row matches.
+ */
+export function get(db: InventoryDb, inputA: string, inputB: string): ItemConnectionRow {
+  const [itemAId, itemBId] = normalisePair(inputA, inputB);
+  const row = findByPair(db, itemAId, itemBId);
+  if (!row) throw new ConnectionNotFoundError(itemAId, itemBId);
+  return row;
+}
+
+/**
+ * Connect two inventory items. Validates both endpoints exist, rejects
+ * self-connections, and rejects duplicate pairs (after A<B normalisation).
+ */
+export function create(db: InventoryDb, input: CreateConnectionInput): ItemConnectionRow {
+  if (input.itemAId === input.itemBId) {
+    throw new SelfConnectionError(input.itemAId);
+  }
+
+  const [itemAId, itemBId] = normalisePair(input.itemAId, input.itemBId);
+
+  assertItemExists(db, itemAId);
+  assertItemExists(db, itemBId);
+
+  if (findByPair(db, itemAId, itemBId)) {
+    throw new ConnectionConflictError(itemAId, itemBId);
+  }
+
+  db.insert(itemConnections).values({ itemAId, itemBId }).run();
+
+  const created = findByPair(db, itemAId, itemBId);
+  if (!created) throw new ConnectionNotFoundError(itemAId, itemBId);
+  return created;
+}
+
+/**
+ * Disconnect two items. Normalises the pair before lookup. Throws
+ * `ConnectionNotFoundError` if no connection exists.
+ */
+function deleteConnection(db: InventoryDb, inputA: string, inputB: string): void {
+  const [itemAId, itemBId] = normalisePair(inputA, inputB);
+  const row = findByPair(db, itemAId, itemBId);
+  if (!row) throw new ConnectionNotFoundError(itemAId, itemBId);
+
+  db.delete(itemConnections).where(eq(itemConnections.id, row.id)).run();
+}
+
+export { deleteConnection as delete };
+
+/**
+ * Walk the connection chain from `itemId` as a tree, capped at `maxDepth`
+ * hops. Uses BFS with a visited set to break cycles. Throws
+ * `ConnectionItemNotFoundError` if the root item is missing.
+ */
+export function trace(db: InventoryDb, itemId: string, maxDepth: number): TraceNode {
+  const [startItem] = db
+    .select({
+      id: homeInventory.id,
+      itemName: homeInventory.itemName,
+      assetId: homeInventory.assetId,
+      type: homeInventory.type,
+    })
+    .from(homeInventory)
+    .where(eq(homeInventory.id, itemId))
+    .all();
+
+  if (!startItem) throw new ConnectionItemNotFoundError(itemId);
+
+  const root: TraceNode = {
+    id: startItem.id,
+    itemName: startItem.itemName,
+    assetId: startItem.assetId,
+    type: startItem.type,
+    children: [],
+  };
+
+  const visited = new Set<string>([itemId]);
+  const queue: { node: TraceNode; depth: number }[] = [{ node: root, depth: 0 }];
+
+  while (queue.length > 0) {
+    const entry = queue.shift();
+    if (!entry) break;
+    const { node, depth } = entry;
+    if (depth >= maxDepth) continue;
+
+    const connections = db
+      .select()
+      .from(itemConnections)
+      .where(or(eq(itemConnections.itemAId, node.id), eq(itemConnections.itemBId, node.id)))
+      .all();
+
+    for (const conn of connections) {
+      const neighborId = conn.itemAId === node.id ? conn.itemBId : conn.itemAId;
+      if (visited.has(neighborId)) continue;
+      visited.add(neighborId);
+
+      const [neighbor] = db
+        .select({
+          id: homeInventory.id,
+          itemName: homeInventory.itemName,
+          assetId: homeInventory.assetId,
+          type: homeInventory.type,
+        })
+        .from(homeInventory)
+        .where(eq(homeInventory.id, neighborId))
+        .all();
+
+      if (!neighbor) continue;
+
+      const childNode: TraceNode = {
+        id: neighbor.id,
+        itemName: neighbor.itemName,
+        assetId: neighbor.assetId,
+        type: neighbor.type,
+        children: [],
+      };
+
+      node.children.push(childNode);
+      queue.push({ node: childNode, depth: depth + 1 });
+    }
+  }
+
+  return root;
+}
+
+/** Build the nodes-and-edges subgraph rooted at `itemId`. */
+export function graph(db: InventoryDb, itemId: string, maxDepth: number): GraphData {
+  return getConnectionGraph(db, itemId, maxDepth);
+}

--- a/packages/inventory-db/src/services/connections.ts
+++ b/packages/inventory-db/src/services/connections.ts
@@ -15,7 +15,7 @@
  * constraint at the schema level. The service normalises caller-provided
  * pairs to satisfy that ordering before any insert / lookup / delete.
  */
-import { and, count, eq, or } from 'drizzle-orm';
+import { and, asc, count, eq, or } from 'drizzle-orm';
 
 import { homeInventory, itemConnections } from '../schema.js';
 import {
@@ -96,7 +96,14 @@ export function list(
 ): ConnectionListResult {
   const condition = or(eq(itemConnections.itemAId, itemId), eq(itemConnections.itemBId, itemId));
 
-  const rows = db.select().from(itemConnections).where(condition).limit(limit).offset(offset).all();
+  const rows = db
+    .select()
+    .from(itemConnections)
+    .where(condition)
+    .orderBy(asc(itemConnections.id))
+    .limit(limit)
+    .offset(offset)
+    .all();
 
   const [countResult] = db.select({ total: count() }).from(itemConnections).where(condition).all();
 


### PR DESCRIPTION
## Summary

PRD-175 US-01 — scaffolds the inventory connections slice inside `@pops/inventory-db`, mirroring the items service scaffold from #3012. The live writer in `apps/pops-api/src/modules/inventory/connections/` is unchanged; this PR only adds the new namespace so subsequent PRs (PR2 reads cutover, PR3 writer move, PR4 shim deletion) have somewhere to flip consumers to.

- **Schema re-export**: `itemConnections` added to `packages/inventory-db/src/schema.ts`.
- **Service surface**: `connectionsService.{list, get, create, delete, trace, graph}` exposed via `services/connections.ts` with the db-arg pattern (each fn takes an `InventoryDb` first arg, mirroring locations / items). Pair ordering (`itemAId < itemBId`) is normalised in the service before insert / lookup / delete, matching the schema's CHECK invariant.
- **Graph helper**: `services/connections-graph.ts` is a db-arg port of the live BFS used by the existing graph procedure (adjacency built in-memory; constant queries per call).
- **Errors**: `ConnectionNotFoundError`, `ConnectionConflictError`, `SelfConnectionError`, `ConnectionItemNotFoundError` exported as plain `Error` subclasses (no HTTP coupling; routers map to tRPC codes).
- **Barrel**: `index.ts` exports `connectionsService` namespace + public types (`Connection`, `GraphData`, `TraceNode`, etc.).
- **Tests**: `__tests__/connections.test.ts` — 35 invariant tests covering A<B ordering, self-connection rejection, dup-pair conflict, pagination, BFS cycle-breaking, `maxDepth` caps, and the `toConnection` mapper. Uses inlined `home_inventory` + `item_connections` DDL plus the package's `0005_fancy_crystal.sql` migration for the locations FK target.

No new baseline migration — `item_connections` already lives in `0006_inventory_pillar_baseline.sql` from the M4 inventory pillar baseline.

## Test plan

- [x] `pnpm --filter @pops/inventory-db typecheck`
- [x] `pnpm --filter @pops/inventory-db test` — 99 tests pass (35 new connections tests + 64 existing)
- [x] `pnpm --filter @pops/inventory-db build`
- [x] `pnpm turbo run build --filter=@pops/api` — downstream still builds clean
- [x] `pnpm --filter @pops/inventory-db exec oxlint src/` — clean
- [x] Pre-push typecheck across all 66 turbo tasks — green