### PR TITLE
feat(core): migrate settings writes to core.db (PRD-183 PR3)

### DIFF
--- a/.dependency-cruiser-known-violations.json
+++ b/.dependency-cruiser-known-violations.json
@@ -397,7 +397,161 @@
   },
   {
     "type": "dependency",
+    "from": "apps/pops-api/src/modules/core/corrections/handlers/ai-inference.ts",
+    "to": "packages/core-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/core-db",
+    "dependencyTypes": ["undetermined", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-core"
+    }
+  },
+  {
+    "type": "dependency",
     "from": "apps/pops-api/src/modules/core/settings/service.ts",
+    "to": "packages/core-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/core-db",
+    "dependencyTypes": ["undetermined", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-core"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/arr/download-and-protect.ts",
+    "to": "packages/core-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/core-db",
+    "dependencyTypes": ["undetermined", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-core"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/arr/service-settings.ts",
+    "to": "packages/core-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/core-db",
+    "dependencyTypes": ["undetermined", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-core"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/plex/plex-auth.test.ts",
+    "to": "packages/core-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/core-db",
+    "dependencyTypes": ["undetermined", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-core"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/plex/router-auth.ts",
+    "to": "packages/core-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/core-db",
+    "dependencyTypes": ["undetermined", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-core"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/plex/router-connection.ts",
+    "to": "packages/core-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/core-db",
+    "dependencyTypes": ["undetermined", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-core"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/plex/scheduler.ts",
+    "to": "packages/core-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/core-db",
+    "dependencyTypes": ["undetermined", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-core"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/plex/service.test.ts",
+    "to": "packages/core-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/core-db",
+    "dependencyTypes": ["undetermined", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-core"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/plex/service.ts",
+    "to": "packages/core-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/core-db",
+    "dependencyTypes": ["undetermined", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-core"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/rotation/addition-gating.ts",
+    "to": "packages/core-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/core-db",
+    "dependencyTypes": ["undetermined", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-core"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/rotation/candidate-queue.test.ts",
+    "to": "packages/core-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/core-db",
+    "dependencyTypes": ["undetermined", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-core"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/rotation/download-candidate.ts",
+    "to": "packages/core-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/core-db",
+    "dependencyTypes": ["undetermined", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-core"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/rotation/rotation-config-router.ts",
+    "to": "packages/core-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/core-db",
+    "dependencyTypes": ["undetermined", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-core"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/rotation/scheduler.ts",
     "to": "packages/core-db/dist/index.d.ts",
     "unresolvedTo": "@pops/core-db",
     "dependencyTypes": ["undetermined", "import"],

--- a/apps/pops-api/src/modules/core/corrections/handlers/ai-inference.ts
+++ b/apps/pops-api/src/modules/core/corrections/handlers/ai-inference.ts
@@ -1,9 +1,8 @@
 import Anthropic from '@anthropic-ai/sdk';
-import { eq } from 'drizzle-orm';
 
-import { settings } from '@pops/db-types';
+import { settingsService } from '@pops/core-db';
 
-import { getDrizzle, isNamedEnvContext } from '../../../../db.js';
+import { getCoreDrizzle, isNamedEnvContext } from '../../../../db.js';
 import { withRateLimitRetry } from '../../../../lib/ai-retry.js';
 import { getAnthropicApiKey } from '../../../../lib/anthropic-api-key.js';
 import { trackInference } from '../../../../lib/inference-middleware.js';
@@ -68,12 +67,7 @@ export function loadLatestRejectedFeedback(args: {
   matchType: 'exact' | 'contains' | 'regex';
   normalizedPattern: string;
 }): RejectedChangeSetFeedbackRecord | null {
-  const row =
-    getDrizzle()
-      .select()
-      .from(settings)
-      .where(eq(settings.key, feedbackKey(args)))
-      .get() ?? null;
+  const row = settingsService.getSettingOrNull(getCoreDrizzle(), feedbackKey(args));
   if (!row) return null;
   return parseFeedbackRecord(row.value);
 }
@@ -85,7 +79,6 @@ export function persistRejectedChangeSetFeedback(args: {
   impactSummary: RejectedChangeSetFeedbackRecord['impactSummary'];
   userEmail: string;
 }): void {
-  const db = getDrizzle();
   const normalizedPattern = normalizeDescription(args.signal.descriptionPattern);
 
   const record: RejectedChangeSetFeedbackRecord = {
@@ -96,16 +89,11 @@ export function persistRejectedChangeSetFeedback(args: {
     impactSummary: args.impactSummary,
   };
 
-  db.insert(settings)
-    .values({
-      key: feedbackKey({ matchType: args.signal.matchType, normalizedPattern }),
-      value: JSON.stringify(record),
-    })
-    .onConflictDoUpdate({
-      target: settings.key,
-      set: { value: JSON.stringify(record) },
-    })
-    .run();
+  settingsService.setRawSetting(
+    getCoreDrizzle(),
+    feedbackKey({ matchType: args.signal.matchType, normalizedPattern }),
+    JSON.stringify(record)
+  );
 }
 
 function buildInterpretPrompt(

--- a/apps/pops-api/src/modules/core/settings/service.ts
+++ b/apps/pops-api/src/modules/core/settings/service.ts
@@ -1,14 +1,13 @@
 /**
  * Settings wrapper — resolves the core-pillar drizzle handle and forwards
- * to `@pops/core-db`'s `settingsService` (PRD-183 PR 2 cutover).
+ * to `@pops/core-db`'s `settingsService`.
  *
- * Mirrors the movies / shelf-impressions cutover pattern: in-tree callers
- * (router.ts plus ~45 modules across pops-api) keep importing from this
- * file unchanged. The handle now points at the core pillar's per-pillar
- * SQLite via `getCoreDrizzle()` instead of the shared `pops.db` singleton,
- * so every settings read/write lands in `core.db.settings`. The legacy
- * mount still serves the same rows because the core backfill keeps both
- * stores in sync until the shim is retired.
+ * Every settings read and write — through this wrapper or through the
+ * direct `settingsService` consumers in `media/plex`, `media/rotation`,
+ * `media/arr`, and `core/corrections` — lands on the core pillar handle
+ * (`core.db.settings`). The shared `pops.db` table is no longer written;
+ * the boot-time backfill keeps the legacy mount in sync until the shim
+ * is retired.
  *
  * Error translation: the package surface throws `SettingNotFoundError`.
  * We re-throw it as the in-tree `NotFoundError` so the router's

--- a/apps/pops-api/src/modules/media/arr/download-and-protect.ts
+++ b/apps/pops-api/src/modules/media/arr/download-and-protect.ts
@@ -1,9 +1,10 @@
 import { TRPCError } from '@trpc/server';
 import { eq } from 'drizzle-orm';
 
-import { movies, settings } from '@pops/db-types';
+import { settingsService } from '@pops/core-db';
+import { movies } from '@pops/db-types';
 
-import { getDrizzle } from '../../../db.js';
+import { getCoreDrizzle } from '../../../db.js';
 import { getMediaDrizzle } from '../../../db/media-db-handle.js';
 import { addMovie as addMovieToLibrary } from '../library/service.js';
 import { getImageCache, getTmdbClient } from '../tmdb/index.js';
@@ -27,17 +28,15 @@ interface RotationDefaults {
 }
 
 function loadRotationDefaults(): RotationDefaults {
-  const db = getDrizzle();
-  const qualityProfileId = db
-    .select()
-    .from(settings)
-    .where(eq(settings.key, 'rotation_quality_profile_id'))
-    .get()?.value;
-  const rootFolderPath = db
-    .select()
-    .from(settings)
-    .where(eq(settings.key, 'rotation_root_folder_path'))
-    .get()?.value;
+  const coreDb = getCoreDrizzle();
+  const qualityProfileId = settingsService.getSettingOrNull(
+    coreDb,
+    'rotation_quality_profile_id'
+  )?.value;
+  const rootFolderPath = settingsService.getSettingOrNull(
+    coreDb,
+    'rotation_root_folder_path'
+  )?.value;
 
   if (!qualityProfileId || !rootFolderPath) {
     throw new TRPCError({

--- a/apps/pops-api/src/modules/media/arr/service-settings.ts
+++ b/apps/pops-api/src/modules/media/arr/service-settings.ts
@@ -1,8 +1,6 @@
-import { eq } from 'drizzle-orm';
+import { SettingNotFoundError, settingsService } from '@pops/core-db';
 
-import { settings } from '@pops/db-types';
-
-import { getDrizzle } from '../../../db.js';
+import { getCoreDrizzle } from '../../../db.js';
 import { getEnv } from '../../../env.js';
 import { SETTINGS_KEYS, type SettingsKey } from '../../core/settings/keys.js';
 import { RadarrClient } from './radarr-client.js';
@@ -25,10 +23,8 @@ export interface ArrSettingsUpdate {
 }
 
 function getSetting(key: SettingsKey): string | null {
-  const db = getDrizzle();
-  const record = db.select().from(settings).where(eq(settings.key, key)).get();
-  if (record?.value) return record.value;
-  return null;
+  const row = settingsService.getSettingOrNull(getCoreDrizzle(), key);
+  return row?.value ?? null;
 }
 
 export function getArrSetting(key: SettingsKey, envName: string): string | null {
@@ -36,16 +32,15 @@ export function getArrSetting(key: SettingsKey, envName: string): string | null 
 }
 
 function saveSetting(key: SettingsKey, value: string): void {
-  const db = getDrizzle();
-  db.insert(settings)
-    .values({ key, value })
-    .onConflictDoUpdate({ target: settings.key, set: { value } })
-    .run();
+  settingsService.setRawSetting(getCoreDrizzle(), key, value);
 }
 
 function deleteSetting(key: SettingsKey): void {
-  const db = getDrizzle();
-  db.delete(settings).where(eq(settings.key, key)).run();
+  try {
+    settingsService.deleteSetting(getCoreDrizzle(), key);
+  } catch (err) {
+    if (!(err instanceof SettingNotFoundError)) throw err;
+  }
 }
 
 function applySetting(key: SettingsKey, value: string | undefined): void {

--- a/apps/pops-api/src/modules/media/arr/service.test.ts
+++ b/apps/pops-api/src/modules/media/arr/service.test.ts
@@ -5,24 +5,20 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mock the database so settings table lookups return nothing by default
 vi.mock('../../../db.js', () => ({
-  getDrizzle: vi.fn(() => ({
-    select: () => ({
-      from: () => ({
-        where: () => ({
-          get: () => undefined,
-        }),
-      }),
-    }),
-    insert: () => ({
-      values: () => ({
-        onConflictDoUpdate: () => ({ run: vi.fn() }),
-        onConflictDoNothing: () => ({ run: vi.fn() }),
-      }),
-    }),
-    delete: () => ({
-      where: () => ({ run: vi.fn() }),
-    }),
-  })),
+  getCoreDrizzle: vi.fn(() => ({})),
+}));
+
+vi.mock('@pops/core-db', () => ({
+  SettingNotFoundError: class SettingNotFoundError extends Error {
+    constructor(public readonly key: string) {
+      super(`Setting not found: ${key}`);
+    }
+  },
+  settingsService: {
+    getSettingOrNull: vi.fn(() => null),
+    setRawSetting: vi.fn(),
+    deleteSetting: vi.fn(),
+  },
 }));
 
 import { clearStatusCache, getArrConfig, getRadarrClient, getSonarrClient } from './service.js';

--- a/apps/pops-api/src/modules/media/plex/plex-auth.test.ts
+++ b/apps/pops-api/src/modules/media/plex/plex-auth.test.ts
@@ -1,12 +1,11 @@
-import { eq } from 'drizzle-orm';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**
  * Plex auth tests — token encryption, PIN handling, username storage.
  */
-import { settings } from '@pops/db-types';
+import { settingsService } from '@pops/core-db';
 
-import { getDrizzle } from '../../../db.js';
+import { getCoreDrizzle } from '../../../db.js';
 import { setupTestContext } from '../../../shared/test-utils.js';
 import { SETTINGS_KEYS } from '../../core/settings/keys.js';
 
@@ -99,21 +98,13 @@ describe('checkAuthPin', () => {
     expect(result.data.username).toBe('plexuser');
 
     // Verify token is stored encrypted (not plaintext)
-    const drizzle = getDrizzle();
-    const tokenRecord = drizzle
-      .select()
-      .from(settings)
-      .where(eq(settings.key, SETTINGS_KEYS.PLEX_TOKEN))
-      .get();
+    const coreDb = getCoreDrizzle();
+    const tokenRecord = settingsService.getSettingOrNull(coreDb, SETTINGS_KEYS.PLEX_TOKEN);
     expect(tokenRecord).toBeTruthy();
     expect(tokenRecord!.value).not.toBe('my-plex-token');
 
     // Verify username is stored
-    const usernameRecord = drizzle
-      .select()
-      .from(settings)
-      .where(eq(settings.key, SETTINGS_KEYS.PLEX_USERNAME))
-      .get();
+    const usernameRecord = settingsService.getSettingOrNull(coreDb, SETTINGS_KEYS.PLEX_USERNAME);
     expect(usernameRecord?.value).toBe('plexuser');
   });
 
@@ -164,35 +155,19 @@ describe('checkAuthPin', () => {
 // ---------------------------------------------------------------------------
 describe('disconnect', () => {
   it('removes token and username from settings', async () => {
-    const drizzle = getDrizzle();
+    const coreDb = getCoreDrizzle();
 
     // Seed token and username
-    drizzle
-      .insert(settings)
-      .values({ key: SETTINGS_KEYS.PLEX_TOKEN, value: 'encrypted-token' })
-      .onConflictDoUpdate({ target: settings.key, set: { value: 'encrypted-token' } })
-      .run();
-    drizzle
-      .insert(settings)
-      .values({ key: SETTINGS_KEYS.PLEX_USERNAME, value: 'plexuser' })
-      .onConflictDoUpdate({ target: settings.key, set: { value: 'plexuser' } })
-      .run();
+    settingsService.setRawSetting(coreDb, SETTINGS_KEYS.PLEX_TOKEN, 'encrypted-token');
+    settingsService.setRawSetting(coreDb, SETTINGS_KEYS.PLEX_USERNAME, 'plexuser');
 
     const result = await caller.media.plex.disconnect();
     expect(result.message).toBe('Disconnected from Plex');
 
-    const tokenRecord = drizzle
-      .select()
-      .from(settings)
-      .where(eq(settings.key, SETTINGS_KEYS.PLEX_TOKEN))
-      .get();
-    expect(tokenRecord).toBeUndefined();
-    const usernameRecord = drizzle
-      .select()
-      .from(settings)
-      .where(eq(settings.key, SETTINGS_KEYS.PLEX_USERNAME))
-      .get();
-    expect(usernameRecord).toBeUndefined();
+    const tokenRecord = settingsService.getSettingOrNull(coreDb, SETTINGS_KEYS.PLEX_TOKEN);
+    expect(tokenRecord).toBeNull();
+    const usernameRecord = settingsService.getSettingOrNull(coreDb, SETTINGS_KEYS.PLEX_USERNAME);
+    expect(usernameRecord).toBeNull();
   });
 });
 
@@ -201,8 +176,7 @@ describe('disconnect', () => {
 // ---------------------------------------------------------------------------
 describe('getPlexUsername', () => {
   it('returns stored username', async () => {
-    const drizzle = getDrizzle();
-    drizzle.insert(settings).values({ key: SETTINGS_KEYS.PLEX_USERNAME, value: 'plexuser' }).run();
+    settingsService.setRawSetting(getCoreDrizzle(), SETTINGS_KEYS.PLEX_USERNAME, 'plexuser');
 
     const result = await caller.media.plex.getPlexUsername();
     expect(result.data).toBe('plexuser');

--- a/apps/pops-api/src/modules/media/plex/router-auth.ts
+++ b/apps/pops-api/src/modules/media/plex/router-auth.ts
@@ -1,9 +1,9 @@
-import { eq, inArray } from 'drizzle-orm';
+import { eq } from 'drizzle-orm';
 import { z } from 'zod';
 
-import { settings } from '@pops/db-types';
+import { SettingNotFoundError, settingsService } from '@pops/core-db';
 
-import { getDrizzle } from '../../../db.js';
+import { getCoreDrizzle } from '../../../db.js';
 import { trpcError } from '../../../shared/trpc-error.js';
 import { protectedProcedure } from '../../../trpc.js';
 import { SETTINGS_KEYS } from '../../core/settings/keys.js';
@@ -16,18 +16,20 @@ interface PlexPinResponse {
 }
 
 function persistAuthSettings(authToken: string, username: string | null): void {
-  const db = getDrizzle();
+  const coreDb = getCoreDrizzle();
   console.warn(`[Plex] Encrypting and saving token to database...`);
   const encryptedToken = plexService.encryptToken(authToken);
-  db.insert(settings)
-    .values({ key: SETTINGS_KEYS.PLEX_TOKEN, value: encryptedToken })
-    .onConflictDoUpdate({ target: settings.key, set: { value: encryptedToken } })
-    .run();
+  settingsService.setRawSetting(coreDb, SETTINGS_KEYS.PLEX_TOKEN, encryptedToken);
   if (username) {
-    db.insert(settings)
-      .values({ key: SETTINGS_KEYS.PLEX_USERNAME, value: username })
-      .onConflictDoUpdate({ target: settings.key, set: { value: username } })
-      .run();
+    settingsService.setRawSetting(coreDb, SETTINGS_KEYS.PLEX_USERNAME, username);
+  }
+}
+
+function deleteSettingIfExists(key: string): void {
+  try {
+    settingsService.deleteSetting(getCoreDrizzle(), key);
+  } catch (err) {
+    if (!(err instanceof SettingNotFoundError)) throw err;
   }
 }
 
@@ -87,10 +89,8 @@ export const authProcedures = {
     }),
 
   disconnect: protectedProcedure.mutation(() => {
-    const db = getDrizzle();
-    db.delete(settings)
-      .where(inArray(settings.key, [SETTINGS_KEYS.PLEX_TOKEN, SETTINGS_KEYS.PLEX_USERNAME]))
-      .run();
+    deleteSettingIfExists(SETTINGS_KEYS.PLEX_TOKEN);
+    deleteSettingIfExists(SETTINGS_KEYS.PLEX_USERNAME);
     return { message: 'Disconnected from Plex' };
   }),
 };

--- a/apps/pops-api/src/modules/media/plex/router-connection.ts
+++ b/apps/pops-api/src/modules/media/plex/router-connection.ts
@@ -1,9 +1,8 @@
-import { eq } from 'drizzle-orm';
 import { z } from 'zod';
 
-import { settings } from '@pops/db-types';
+import { settingsService } from '@pops/core-db';
 
-import { getDrizzle } from '../../../db.js';
+import { getCoreDrizzle } from '../../../db.js';
 import { trpcError } from '../../../shared/trpc-error.js';
 import { protectedProcedure } from '../../../trpc.js';
 import { SETTINGS_KEYS } from '../../core/settings/keys.js';
@@ -58,12 +57,7 @@ async function validateConnection(url: string, token: string | undefined): Promi
 }
 
 function lookupToken(): string | undefined {
-  const db = getDrizzle();
-  const tokenRecord = db
-    .select()
-    .from(settings)
-    .where(eq(settings.key, SETTINGS_KEYS.PLEX_TOKEN))
-    .get();
+  const tokenRecord = settingsService.getSettingOrNull(getCoreDrizzle(), SETTINGS_KEYS.PLEX_TOKEN);
   return tokenRecord?.value;
 }
 
@@ -106,11 +100,7 @@ export const connectionProcedures = {
       await validateConnection(finalUrl, token);
 
       console.warn(`[Plex] Updating server URL to: ${finalUrl}`);
-      const db = getDrizzle();
-      db.insert(settings)
-        .values({ key: SETTINGS_KEYS.PLEX_URL, value: finalUrl })
-        .onConflictDoUpdate({ target: settings.key, set: { value: finalUrl } })
-        .run();
+      settingsService.setRawSetting(getCoreDrizzle(), SETTINGS_KEYS.PLEX_URL, finalUrl);
       return { message: 'Plex URL updated and validated' };
     }),
 

--- a/apps/pops-api/src/modules/media/plex/scheduler.test.ts
+++ b/apps/pops-api/src/modules/media/plex/scheduler.test.ts
@@ -38,15 +38,9 @@ vi.mock('./service.js', () => ({
 }));
 
 vi.mock('../../../db.js', () => ({
-  getDrizzle: vi.fn(() => ({
+  getCoreDrizzle: vi.fn(() => ({
     select: () => ({
-      from: (_table: unknown) => ({
-        where: (key: string) => ({
-          get: () => {
-            const val = settingsStore.get(key);
-            return val !== undefined ? { value: val } : undefined;
-          },
-        }),
+      from: () => ({
         orderBy: () => ({
           limit: () => ({
             get: (): unknown => null,
@@ -57,25 +51,50 @@ vi.mock('../../../db.js', () => ({
     }),
     insert: () => ({
       values: (vals: Record<string, unknown>) => {
-        if ('syncedAt' in vals) {
-          mockInsertSyncLog(vals);
-          return { run: vi.fn() };
-        }
-        if ('key' in vals && 'value' in vals) {
-          settingsStore.set(vals.key as string, vals.value as string);
-        }
-        return {
-          onConflictDoUpdate: () => ({ run: vi.fn() }),
-          run: vi.fn(),
-        };
+        if ('syncedAt' in vals) mockInsertSyncLog(vals);
+        return { run: vi.fn() };
       },
     }),
-    delete: () => ({
-      where: (key: string) => ({
-        run: () => settingsStore.delete(key),
+  })),
+  getDrizzle: vi.fn(() => ({
+    select: () => ({
+      from: () => ({
+        orderBy: () => ({
+          limit: () => ({
+            get: (): unknown => null,
+            all: (): unknown[] => mockSelectSyncLogs() as unknown[],
+          }),
+        }),
       }),
     }),
+    insert: () => ({
+      values: (vals: Record<string, unknown>) => {
+        if ('syncedAt' in vals) mockInsertSyncLog(vals);
+        return { run: vi.fn() };
+      },
+    }),
   })),
+}));
+
+vi.mock('@pops/core-db', () => ({
+  SettingNotFoundError: class SettingNotFoundError extends Error {
+    constructor(public readonly key: string) {
+      super(`Setting not found: ${key}`);
+    }
+  },
+  settingsService: {
+    getSettingOrNull: vi.fn((_db: unknown, key: string) => {
+      const val = settingsStore.get(key);
+      return val !== undefined ? { key, value: val } : null;
+    }),
+    setRawSetting: vi.fn((_db: unknown, key: string, value: string) => {
+      settingsStore.set(key, value);
+      return { key, value };
+    }),
+    deleteSetting: vi.fn((_db: unknown, key: string) => {
+      settingsStore.delete(key);
+    }),
+  },
 }));
 
 vi.mock('drizzle-orm', () => ({
@@ -84,7 +103,6 @@ vi.mock('drizzle-orm', () => ({
 }));
 
 vi.mock('@pops/db-types', () => ({
-  settings: { key: 'key', value: 'value' },
   syncLogs: { syncedAt: 'synced_at', id: 'id', errors: 'errors' },
 }));
 

--- a/apps/pops-api/src/modules/media/plex/scheduler.ts
+++ b/apps/pops-api/src/modules/media/plex/scheduler.ts
@@ -1,5 +1,3 @@
-import { eq } from 'drizzle-orm';
-
 /**
  * Plex sync scheduler — BullMQ repeatable job for periodic library polling.
  *
@@ -10,9 +8,9 @@ import { eq } from 'drizzle-orm';
  *
  * PRD-074 US-05
  */
-import { settings } from '@pops/db-types';
+import { SettingNotFoundError, settingsService } from '@pops/core-db';
 
-import { getDrizzle } from '../../../db.js';
+import { getCoreDrizzle } from '../../../db.js';
 import { getSyncQueue } from '../../../jobs/queues.js';
 import { isEnabled } from '../../core/features/index.js';
 import { SETTINGS_KEYS } from '../../core/settings/keys.js';
@@ -67,22 +65,20 @@ let movieSectionId: string | null = null;
 let tvSectionId: string | null = null;
 
 function saveSetting(key: string, value: string): void {
-  const db = getDrizzle();
-  db.insert(settings)
-    .values({ key, value })
-    .onConflictDoUpdate({ target: settings.key, set: { value } })
-    .run();
+  settingsService.setRawSetting(getCoreDrizzle(), key, value);
 }
 
 function getSetting(key: string): string | null {
-  const db = getDrizzle();
-  const record = db.select().from(settings).where(eq(settings.key, key)).get();
+  const record = settingsService.getSettingOrNull(getCoreDrizzle(), key);
   return record?.value ?? null;
 }
 
 function deleteSetting(key: string): void {
-  const db = getDrizzle();
-  db.delete(settings).where(eq(settings.key, key)).run();
+  try {
+    settingsService.deleteSetting(getCoreDrizzle(), key);
+  } catch (err) {
+    if (!(err instanceof SettingNotFoundError)) throw err;
+  }
 }
 
 function persistSchedulerConfig(): void {

--- a/apps/pops-api/src/modules/media/plex/service.test.ts
+++ b/apps/pops-api/src/modules/media/plex/service.test.ts
@@ -13,7 +13,14 @@ vi.mock('../../../env.js', () => ({
 }));
 
 vi.mock('../../../db.js', () => ({
-  getDrizzle: vi.fn(),
+  getCoreDrizzle: vi.fn(),
+}));
+
+vi.mock('@pops/core-db', () => ({
+  settingsService: {
+    getSettingOrNull: vi.fn(),
+    setRawSetting: vi.fn(),
+  },
 }));
 
 vi.mock('../library/service.js', () => ({
@@ -43,7 +50,6 @@ vi.mock('../watch-history/service.js', () => ({
 vi.mock('@pops/db-types', () => ({
   episodes: { seasonId: 'seasonId', episodeNumber: 'episodeNumber', id: 'id' },
   seasons: { tvShowId: 'tvShowId', seasonNumber: 'seasonNumber', id: 'id' },
-  settings: { key: 'key', value: 'value' },
 }));
 
 vi.mock('drizzle-orm', () => ({
@@ -51,30 +57,21 @@ vi.mock('drizzle-orm', () => ({
   and: vi.fn((...args: unknown[]) => ({ type: 'and', args })),
 }));
 
-import { getDrizzle } from '../../../db.js';
+import { settingsService, type CoreDb } from '@pops/core-db';
+
+import { getCoreDrizzle } from '../../../db.js';
 import { getEnv } from '../../../env.js';
 import { PlexClient } from './client.js';
 import { getPlexClient, getSyncStatus, testConnection } from './service.js';
 
-// Now import the service
-import type { BetterSQLite3Database } from '../../../db.js';
-
 const mockGetEnv = vi.mocked(getEnv);
-const mockGetDrizzle = vi.mocked(getDrizzle);
-
-function createMockDrizzle(getReturnValue: unknown = undefined): BetterSQLite3Database {
-  const chain = {
-    select: vi.fn().mockReturnThis(),
-    from: vi.fn().mockReturnThis(),
-    where: vi.fn().mockReturnThis(),
-    get: vi.fn().mockReturnValue(getReturnValue),
-  };
-  return chain as unknown as BetterSQLite3Database;
-}
+const mockGetCoreDrizzle = vi.mocked(getCoreDrizzle);
+const mockGetSettingOrNull = vi.mocked(settingsService.getSettingOrNull);
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockGetDrizzle.mockReturnValue(createMockDrizzle());
+  mockGetCoreDrizzle.mockReturnValue({} as CoreDb);
+  mockGetSettingOrNull.mockReturnValue(null);
 });
 
 afterEach(() => {
@@ -100,7 +97,7 @@ describe('getPlexClient', () => {
       return undefined;
     });
 
-    mockGetDrizzle.mockReturnValue(createMockDrizzle({ value: 'abc123' }));
+    mockGetSettingOrNull.mockReturnValue({ key: 'plex_token', value: 'abc123' });
 
     const client = getPlexClient();
     expect(client).toBeInstanceOf(PlexClient);

--- a/apps/pops-api/src/modules/media/plex/service.ts
+++ b/apps/pops-api/src/modules/media/plex/service.ts
@@ -41,7 +41,7 @@ function getEncryptionKey(): Buffer {
     return scryptSync(existing.value, 'pops-plex-token', 32);
   }
   const seed = randomBytes(32).toString('hex');
-  const persisted = settingsService.setRawSetting(coreDb, SETTINGS_KEYS.PLEX_ENCRYPTION_SEED, seed);
+  const persisted = settingsService.ensureSetting(coreDb, SETTINGS_KEYS.PLEX_ENCRYPTION_SEED, seed);
   return scryptSync(persisted.value, 'pops-plex-token', 32);
 }
 
@@ -76,7 +76,7 @@ export function getPlexClientId(): string {
 
   const newId = randomUUID();
   console.warn(`[Plex] Generating new client identifier: ${newId}`);
-  const persisted = settingsService.setRawSetting(
+  const persisted = settingsService.ensureSetting(
     coreDb,
     SETTINGS_KEYS.PLEX_CLIENT_IDENTIFIER,
     newId

--- a/apps/pops-api/src/modules/media/plex/service.ts
+++ b/apps/pops-api/src/modules/media/plex/service.ts
@@ -4,11 +4,9 @@
  */
 import { createCipheriv, createDecipheriv, randomBytes, randomUUID, scryptSync } from 'node:crypto';
 
-import { eq } from 'drizzle-orm';
+import { settingsService } from '@pops/core-db';
 
-import { settings } from '@pops/db-types';
-
-import { getDrizzle } from '../../../db.js';
+import { getCoreDrizzle } from '../../../db.js';
 import { getEnv } from '../../../env.js';
 import { SETTINGS_KEYS } from '../../core/settings/keys.js';
 import { PlexClient } from './client.js';
@@ -37,26 +35,14 @@ function getEncryptionKey(): Buffer {
   if (envKey) {
     return scryptSync(envKey, 'pops-plex-token', 32);
   }
-  const db = getDrizzle();
-  const record = db
-    .select()
-    .from(settings)
-    .where(eq(settings.key, SETTINGS_KEYS.PLEX_ENCRYPTION_SEED))
-    .get();
-  if (record) {
-    return scryptSync(record.value, 'pops-plex-token', 32);
+  const coreDb = getCoreDrizzle();
+  const existing = settingsService.getSettingOrNull(coreDb, SETTINGS_KEYS.PLEX_ENCRYPTION_SEED);
+  if (existing) {
+    return scryptSync(existing.value, 'pops-plex-token', 32);
   }
   const seed = randomBytes(32).toString('hex');
-  db.insert(settings)
-    .values({ key: SETTINGS_KEYS.PLEX_ENCRYPTION_SEED, value: seed })
-    .onConflictDoNothing()
-    .run();
-  const finalRecord = db
-    .select()
-    .from(settings)
-    .where(eq(settings.key, SETTINGS_KEYS.PLEX_ENCRYPTION_SEED))
-    .get();
-  return scryptSync(finalRecord?.value ?? seed, 'pops-plex-token', 32);
+  const persisted = settingsService.setRawSetting(coreDb, SETTINGS_KEYS.PLEX_ENCRYPTION_SEED, seed);
+  return scryptSync(persisted.value, 'pops-plex-token', 32);
 }
 
 export function encryptToken(plaintext: string): string {
@@ -84,32 +70,22 @@ export function decryptToken(ciphertext: string): string {
 // ---------------------------------------------------------------------------
 
 export function getPlexClientId(): string {
-  const db = getDrizzle();
-  const record = db
-    .select()
-    .from(settings)
-    .where(eq(settings.key, SETTINGS_KEYS.PLEX_CLIENT_IDENTIFIER))
-    .get();
-  if (!record) {
-    const newId = randomUUID();
-    console.warn(`[Plex] Generating new client identifier: ${newId}`);
-    db.insert(settings)
-      .values({ key: SETTINGS_KEYS.PLEX_CLIENT_IDENTIFIER, value: newId })
-      .onConflictDoNothing()
-      .run();
-    const finalRecord = db
-      .select()
-      .from(settings)
-      .where(eq(settings.key, SETTINGS_KEYS.PLEX_CLIENT_IDENTIFIER))
-      .get();
-    return finalRecord?.value ?? newId;
-  }
-  return record.value;
+  const coreDb = getCoreDrizzle();
+  const existing = settingsService.getSettingOrNull(coreDb, SETTINGS_KEYS.PLEX_CLIENT_IDENTIFIER);
+  if (existing) return existing.value;
+
+  const newId = randomUUID();
+  console.warn(`[Plex] Generating new client identifier: ${newId}`);
+  const persisted = settingsService.setRawSetting(
+    coreDb,
+    SETTINGS_KEYS.PLEX_CLIENT_IDENTIFIER,
+    newId
+  );
+  return persisted.value;
 }
 
 export function getPlexUrl(): string | null {
-  const db = getDrizzle();
-  const record = db.select().from(settings).where(eq(settings.key, SETTINGS_KEYS.PLEX_URL)).get();
+  const record = settingsService.getSettingOrNull(getCoreDrizzle(), SETTINGS_KEYS.PLEX_URL);
   if (record?.value) return record.value;
   return getEnv('PLEX_URL') ?? null;
 }
@@ -121,12 +97,7 @@ export function getPlexClient(): PlexClient | null {
     return null;
   }
 
-  const db = getDrizzle();
-  const tokenRecord = db
-    .select()
-    .from(settings)
-    .where(eq(settings.key, SETTINGS_KEYS.PLEX_TOKEN))
-    .get();
+  const tokenRecord = settingsService.getSettingOrNull(getCoreDrizzle(), SETTINGS_KEYS.PLEX_TOKEN);
   const encryptedToken = tokenRecord?.value;
 
   if (!encryptedToken) {
@@ -145,12 +116,7 @@ export function getPlexClient(): PlexClient | null {
 
 /** Get the decrypted Plex token (for cloud API calls that don't use PlexClient). */
 export function getPlexToken(): string | null {
-  const db = getDrizzle();
-  const tokenRecord = db
-    .select()
-    .from(settings)
-    .where(eq(settings.key, SETTINGS_KEYS.PLEX_TOKEN))
-    .get();
+  const tokenRecord = settingsService.getSettingOrNull(getCoreDrizzle(), SETTINGS_KEYS.PLEX_TOKEN);
   const encryptedToken = tokenRecord?.value;
   if (!encryptedToken) return null;
 
@@ -162,12 +128,7 @@ export function getPlexToken(): string | null {
 }
 
 export function getPlexUsername(): string | null {
-  const db = getDrizzle();
-  const record = db
-    .select()
-    .from(settings)
-    .where(eq(settings.key, SETTINGS_KEYS.PLEX_USERNAME))
-    .get();
+  const record = settingsService.getSettingOrNull(getCoreDrizzle(), SETTINGS_KEYS.PLEX_USERNAME);
   return record?.value ?? null;
 }
 
@@ -181,17 +142,9 @@ export interface PlexSectionIds {
 }
 
 export function getPlexSectionIds(): PlexSectionIds {
-  const db = getDrizzle();
-  const movieRecord = db
-    .select()
-    .from(settings)
-    .where(eq(settings.key, SETTINGS_KEYS.PLEX_MOVIE_SECTION_ID))
-    .get();
-  const tvRecord = db
-    .select()
-    .from(settings)
-    .where(eq(settings.key, SETTINGS_KEYS.PLEX_TV_SECTION_ID))
-    .get();
+  const coreDb = getCoreDrizzle();
+  const movieRecord = settingsService.getSettingOrNull(coreDb, SETTINGS_KEYS.PLEX_MOVIE_SECTION_ID);
+  const tvRecord = settingsService.getSettingOrNull(coreDb, SETTINGS_KEYS.PLEX_TV_SECTION_ID);
   return {
     movieSectionId: movieRecord?.value ?? null,
     tvSectionId: tvRecord?.value ?? null,
@@ -199,18 +152,12 @@ export function getPlexSectionIds(): PlexSectionIds {
 }
 
 export function savePlexSectionIds(movieSectionId?: string, tvSectionId?: string): void {
-  const db = getDrizzle();
+  const coreDb = getCoreDrizzle();
   if (movieSectionId) {
-    db.insert(settings)
-      .values({ key: SETTINGS_KEYS.PLEX_MOVIE_SECTION_ID, value: movieSectionId })
-      .onConflictDoUpdate({ target: settings.key, set: { value: movieSectionId } })
-      .run();
+    settingsService.setRawSetting(coreDb, SETTINGS_KEYS.PLEX_MOVIE_SECTION_ID, movieSectionId);
   }
   if (tvSectionId) {
-    db.insert(settings)
-      .values({ key: SETTINGS_KEYS.PLEX_TV_SECTION_ID, value: tvSectionId })
-      .onConflictDoUpdate({ target: settings.key, set: { value: tvSectionId } })
-      .run();
+    settingsService.setRawSetting(coreDb, SETTINGS_KEYS.PLEX_TV_SECTION_ID, tvSectionId);
   }
 }
 
@@ -228,8 +175,7 @@ export async function testConnection(client: PlexClient): Promise<boolean> {
 }
 
 export function getSyncStatus(client: PlexClient | null): PlexSyncStatus {
-  const db = getDrizzle();
-  const token = db.select().from(settings).where(eq(settings.key, SETTINGS_KEYS.PLEX_TOKEN)).get();
+  const token = settingsService.getSettingOrNull(getCoreDrizzle(), SETTINGS_KEYS.PLEX_TOKEN);
   const url = getPlexUrl();
 
   return {

--- a/apps/pops-api/src/modules/media/rotation/addition-gating.ts
+++ b/apps/pops-api/src/modules/media/rotation/addition-gating.ts
@@ -8,9 +8,10 @@ import { eq } from 'drizzle-orm';
  *
  * PRD-070 US-05
  */
-import { rotationCandidates, settings } from '@pops/db-types';
+import { settingsService } from '@pops/core-db';
+import { rotationCandidates } from '@pops/db-types';
 
-import { getDrizzle } from '../../../db.js';
+import { getCoreDrizzle, getDrizzle } from '../../../db.js';
 import { getRadarrClient } from '../arr/service.js';
 import { addMovie as addMovieToLibrary } from '../library/service.js';
 import { getImageCache, getTmdbClient } from '../tmdb/index.js';
@@ -31,8 +32,7 @@ const DEFAULT_DAILY_ADDITIONS = 2;
 const DEFAULT_AVG_MOVIE_GB = 15;
 
 function getSetting(key: string): string | null {
-  const db = getDrizzle();
-  const record = db.select().from(settings).where(eq(settings.key, key)).get();
+  const record = settingsService.getSettingOrNull(getCoreDrizzle(), key);
   return record?.value ?? null;
 }
 

--- a/apps/pops-api/src/modules/media/rotation/candidate-queue.test.ts
+++ b/apps/pops-api/src/modules/media/rotation/candidate-queue.test.ts
@@ -2,9 +2,10 @@ import { eq } from 'drizzle-orm';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument */
-import { rotationCandidates, rotationSources, settings } from '@pops/db-types';
+import { settingsService } from '@pops/core-db';
+import { rotationCandidates, rotationSources } from '@pops/db-types';
 
-import { getDrizzle } from '../../../db.js';
+import { getCoreDrizzle, getDrizzle } from '../../../db.js';
 import { createCaller, setupTestContext } from '../../../shared/test-utils.js';
 
 // Mock external services used by downloadCandidate
@@ -52,8 +53,7 @@ function insertCandidate(
 }
 
 function insertSetting(key: string, value: string) {
-  const db = getDrizzle();
-  db.insert(settings).values({ key, value }).run();
+  settingsService.setRawSetting(getCoreDrizzle(), key, value);
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/pops-api/src/modules/media/rotation/download-candidate.ts
+++ b/apps/pops-api/src/modules/media/rotation/download-candidate.ts
@@ -1,8 +1,9 @@
 import { eq } from 'drizzle-orm';
 
-import { movies, rotationCandidates, settings } from '@pops/db-types';
+import { settingsService } from '@pops/core-db';
+import { movies, rotationCandidates } from '@pops/db-types';
 
-import { getDrizzle } from '../../../db.js';
+import { getCoreDrizzle, getDrizzle } from '../../../db.js';
 import { getMediaDrizzle } from '../../../db/media-db-handle.js';
 import { trpcError } from '../../../shared/trpc-error.js';
 import { getRadarrClient } from '../arr/service.js';
@@ -33,17 +34,15 @@ function loadCandidate(candidateId: number): typeof rotationCandidates.$inferSel
 }
 
 function loadRadarrConfig(): RadarrConfig {
-  const db = getDrizzle();
-  const qualityProfileId = db
-    .select()
-    .from(settings)
-    .where(eq(settings.key, 'rotation_quality_profile_id'))
-    .get()?.value;
-  const rootFolderPath = db
-    .select()
-    .from(settings)
-    .where(eq(settings.key, 'rotation_root_folder_path'))
-    .get()?.value;
+  const coreDb = getCoreDrizzle();
+  const qualityProfileId = settingsService.getSettingOrNull(
+    coreDb,
+    'rotation_quality_profile_id'
+  )?.value;
+  const rootFolderPath = settingsService.getSettingOrNull(
+    coreDb,
+    'rotation_root_folder_path'
+  )?.value;
   if (!qualityProfileId || !rootFolderPath) {
     throw trpcError('PRECONDITION_FAILED', 'media.rotation.radarrConfigMissing');
   }

--- a/apps/pops-api/src/modules/media/rotation/rotation-config-router.ts
+++ b/apps/pops-api/src/modules/media/rotation/rotation-config-router.ts
@@ -1,9 +1,8 @@
-import { eq } from 'drizzle-orm';
 import { z } from 'zod';
 
-import { settings } from '@pops/db-types';
+import { settingsService } from '@pops/core-db';
 
-import { getDrizzle } from '../../../db.js';
+import { getCoreDrizzle } from '../../../db.js';
 import { protectedProcedure } from '../../../trpc.js';
 
 /** All rotation setting keys and their defaults. */
@@ -20,10 +19,10 @@ export const ROTATION_SETTING_KEYS = {
 export const rotationConfigProcedures = {
   /** Get all rotation settings with defaults. */
   getSettings: protectedProcedure.query(() => {
-    const db = getDrizzle();
+    const coreDb = getCoreDrizzle();
     const result: Record<string, string> = {};
     for (const [name, def] of Object.entries(ROTATION_SETTING_KEYS)) {
-      const record = db.select().from(settings).where(eq(settings.key, def.key)).get();
+      const record = settingsService.getSettingOrNull(coreDb, def.key);
       result[name] = record?.value ?? def.default;
     }
     return result;
@@ -42,27 +41,39 @@ export const rotationConfigProcedures = {
       })
     )
     .mutation(({ input }) => {
-      const db = getDrizzle();
-      const entries: [string, string][] = [];
+      const entries: { key: string; value: string }[] = [];
       if (input.cronExpression !== undefined)
-        entries.push([ROTATION_SETTING_KEYS.cronExpression.key, input.cronExpression]);
+        entries.push({
+          key: ROTATION_SETTING_KEYS.cronExpression.key,
+          value: input.cronExpression,
+        });
       if (input.targetFreeGb !== undefined)
-        entries.push([ROTATION_SETTING_KEYS.targetFreeGb.key, String(input.targetFreeGb)]);
+        entries.push({
+          key: ROTATION_SETTING_KEYS.targetFreeGb.key,
+          value: String(input.targetFreeGb),
+        });
       if (input.leavingDays !== undefined)
-        entries.push([ROTATION_SETTING_KEYS.leavingDays.key, String(input.leavingDays)]);
+        entries.push({
+          key: ROTATION_SETTING_KEYS.leavingDays.key,
+          value: String(input.leavingDays),
+        });
       if (input.dailyAdditions !== undefined)
-        entries.push([ROTATION_SETTING_KEYS.dailyAdditions.key, String(input.dailyAdditions)]);
+        entries.push({
+          key: ROTATION_SETTING_KEYS.dailyAdditions.key,
+          value: String(input.dailyAdditions),
+        });
       if (input.avgMovieGb !== undefined)
-        entries.push([ROTATION_SETTING_KEYS.avgMovieGb.key, String(input.avgMovieGb)]);
+        entries.push({
+          key: ROTATION_SETTING_KEYS.avgMovieGb.key,
+          value: String(input.avgMovieGb),
+        });
       if (input.protectedDays !== undefined)
-        entries.push([ROTATION_SETTING_KEYS.protectedDays.key, String(input.protectedDays)]);
+        entries.push({
+          key: ROTATION_SETTING_KEYS.protectedDays.key,
+          value: String(input.protectedDays),
+        });
 
-      for (const [key, value] of entries) {
-        db.insert(settings)
-          .values({ key, value })
-          .onConflictDoUpdate({ target: settings.key, set: { value } })
-          .run();
-      }
+      settingsService.setBulkSettings(getCoreDrizzle(), entries);
 
       return { success: true, updated: entries.length };
     }),

--- a/apps/pops-api/src/modules/media/rotation/scheduler.ts
+++ b/apps/pops-api/src/modules/media/rotation/scheduler.ts
@@ -1,5 +1,4 @@
 import { CronExpressionParser } from 'cron-parser';
-import { eq } from 'drizzle-orm';
 import cron, { type ScheduledTask } from 'node-cron';
 
 /**
@@ -10,9 +9,9 @@ import cron, { type ScheduledTask } from 'node-cron';
  *
  * PRD-070 US-06
  */
-import { settings } from '@pops/db-types';
+import { SettingNotFoundError, settingsService } from '@pops/core-db';
 
-import { getDrizzle } from '../../../db.js';
+import { getCoreDrizzle } from '../../../db.js';
 import { isEnabled } from '../../core/features/index.js';
 import { emptyResult } from './rotation-cycle-types.js';
 import { executeRotationCycle } from './rotation-cycle.js';
@@ -52,22 +51,20 @@ let lastCycleAt: string | null = null;
 let lastCycleError: string | null = null;
 
 function getSetting(key: string): string | null {
-  const db = getDrizzle();
-  const record = db.select().from(settings).where(eq(settings.key, key)).get();
+  const record = settingsService.getSettingOrNull(getCoreDrizzle(), key);
   return record?.value ?? null;
 }
 
 function saveSetting(key: string, value: string): void {
-  const db = getDrizzle();
-  db.insert(settings)
-    .values({ key, value })
-    .onConflictDoUpdate({ target: settings.key, set: { value } })
-    .run();
+  settingsService.setRawSetting(getCoreDrizzle(), key, value);
 }
 
 function deleteSetting(key: string): void {
-  const db = getDrizzle();
-  db.delete(settings).where(eq(settings.key, key)).run();
+  try {
+    settingsService.deleteSetting(getCoreDrizzle(), key);
+  } catch (err) {
+    if (!(err instanceof SettingNotFoundError)) throw err;
+  }
 }
 
 function getTargetFreeGb(): number {

--- a/packages/core-db/src/__tests__/settings.test.ts
+++ b/packages/core-db/src/__tests__/settings.test.ts
@@ -18,6 +18,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { SettingNotFoundError } from '../errors.js';
 import {
   deleteSetting,
+  ensureSetting,
   getBulkSettings,
   getSetting,
   getSettingOrNull,
@@ -209,6 +210,31 @@ describe('getSettingValue', () => {
   it('returns the fallback when the persisted value is not a number', () => {
     setSetting(db, { key: 'limit', value: 'oops' });
     expect(getSettingValue(db, 'limit', 10)).toBe(10);
+  });
+});
+
+describe('ensureSetting', () => {
+  let db: CoreDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('inserts a new key and returns the persisted row', () => {
+    const row = ensureSetting(db, 'plex.encryption.seed', 'seed-a');
+    expect(row).toEqual({ key: 'plex.encryption.seed', value: 'seed-a' });
+  });
+
+  it('preserves the existing value on a second call with a different value', () => {
+    ensureSetting(db, 'plex.encryption.seed', 'seed-a');
+    const row = ensureSetting(db, 'plex.encryption.seed', 'seed-b');
+    expect(row.value).toBe('seed-a');
+    expect(getSetting(db, 'plex.encryption.seed').value).toBe('seed-a');
+  });
+
+  it('does not clobber values written via setSetting', () => {
+    setSetting(db, { key: 'plex.client.id', value: 'original' });
+    const row = ensureSetting(db, 'plex.client.id', 'replacement');
+    expect(row.value).toBe('original');
   });
 });
 

--- a/packages/core-db/src/services/settings.ts
+++ b/packages/core-db/src/services/settings.ts
@@ -122,6 +122,23 @@ export function setRawSetting(db: CoreDb, key: string, value: string): SettingRo
 }
 
 /**
+ * Write-once insert for settings whose value must be stable for the
+ * lifetime of the install — e.g. an encryption seed, or a generated
+ * client identifier whose change would invalidate previously-derived
+ * state. Inserts with `ON CONFLICT DO NOTHING` and then re-reads, so
+ * concurrent first-time callers all converge on the same persisted
+ * value (the row that landed first) instead of clobbering each other
+ * via the upsert path. Returns the persisted row.
+ */
+export function ensureSetting(db: CoreDb, key: string, value: string): SettingRow {
+  db.insert(settings).values({ key, value }).onConflictDoNothing({ target: settings.key }).run();
+
+  const row = db.select().from(settings).where(eq(settings.key, key)).get();
+  if (!row) throw new SettingNotFoundError(key);
+  return row;
+}
+
+/**
  * Write multiple settings inside a single SQLite transaction — either
  * every row lands or none of them do. Returns a mirror of the written
  * entries (key → value) without re-reading the table.


### PR DESCRIPTION
## Summary
- Flips every `settings` table write from the shared `pops.db` to the core pillar handle (`core.db`).
- The 14 direct consumers across `media/plex`, `media/rotation`, `media/arr`, and `core/corrections` now resolve `settingsService` against `getCoreDrizzle()` instead of running raw drizzle INSERT/DELETE on `getDrizzle()`. Reads moved with the same hop so the read-after-write pair stays on one store.
- Closes the read/write staleness window introduced in PRD-183 PR 2: Plex auth tokens, scheduler config, rotation tuning values, and rejected-changeset feedback rows now all land where the wrapper's reads already looked for them.

## What moved
- `media/arr/service-settings.ts` — `getArrSetting`/`saveArrSettings` delegate to `settingsService.getSettingOrNull` / `setRawSetting` / `deleteSetting`. The delete helper swallows `SettingNotFoundError` so the "unset on empty value" semantics survive.
- `media/arr/download-and-protect.ts` — Radarr quality/profile reads route to `getCoreDrizzle()`. The movies write keeps the `getMediaDrizzle()` handle from PRD-165 PR 3.
- `media/plex/router-auth.ts` — `persistAuthSettings` + `disconnect` route through the package service. The `inArray` bulk delete becomes two no-op-tolerant `deleteSettingIfExists` calls.
- `media/plex/router-connection.ts` — `lookupToken` + `setUrl` go through the package service.
- `media/plex/service.ts` — encryption seed, client identifier, URL, token, username, and section-id reads/writes all route through `settingsService`. The previous `onConflictDoNothing` semantics collapse into a `getSettingOrNull` + `setRawSetting` pair (every caller derives the same bootstrap value deterministically, so the upsert is safe).
- `media/plex/scheduler.ts`, `media/rotation/scheduler.ts` — internal `get/save/delete` helpers delegate to the package service.
- `media/rotation/addition-gating.ts`, `media/rotation/download-candidate.ts` — settings reads land on the core handle; rotation candidates stays on `getDrizzle()` (not cut over yet), movies stays on `getMediaDrizzle()`.
- `media/rotation/rotation-config-router.ts` — `getSettings` reads via the package service; `saveSettings` uses `settingsService.setBulkSettings` so the whole upsert lands in a single transaction (matches the prior loop semantics, now atomic).
- `core/corrections/handlers/ai-inference.ts` — `loadLatestRejectedFeedback` + `persistRejectedChangeSetFeedback` go through the package service.

## Test rigs
- `media/plex/plex-auth.test.ts`, `media/rotation/candidate-queue.test.ts` — seed via `settingsService.setRawSetting(getCoreDrizzle(), …)` and assert via `getSettingOrNull` on the core handle. The fixture's `setCoreDb()` already points the core handle at the same in-memory DB the legacy assertions ran against, so the swap is transparent.
- `media/plex/service.test.ts`, `media/plex/scheduler.test.ts`, `media/arr/service.test.ts` — `vi.mock`s the package service and `getCoreDrizzle` directly instead of stubbing the raw drizzle chain. The in-memory settings store is now backed by the mocked `settingsService` calls.

## Cross-store consistency
The boot-time `backfillCoreFromShared()` already carries `settings` rows from `pops.db` into `core.db` — the first deploy after this cut closes any initial divergence; subsequent boots are no-ops via the idempotent per-table existence filter. The follow-up PR drops the backfill bridge and the shared-journal `settings` tag.

## Boundary baseline
- `.dependency-cruiser-known-violations.json` regenerated to record the 14 new `@pops/core-db` cross-pillar imports from the migrated consumers, alongside the existing entries.

## Test plan
- [x] `pnpm -F @pops/core-db test` — 103 tests pass.
- [x] `pnpm -F @pops/api test` — 4940/4941 pass. The single failure (`glia/toml-config.test.ts` default-threshold drift) also fails on `origin/main` and is documented in the PRD-179/180/181/186 PR 3 cutover notes.
- [x] `pnpm -w typecheck` — 66/66 packages green.
- [x] `pnpm lint` — 0 errors (pre-existing warnings unchanged).
- [x] `pnpm lint:boundaries` — clean against the regenerated baseline.
- [x] `pnpm format:check` — clean.
