### PR TITLE
feat(inventory-db): scaffold documents service (PRD-176 US-01)

### DIFF
--- a/docs/themes/13-pillar-finale/prds/176-inventory-documents-cutover/README.md
+++ b/docs/themes/13-pillar-finale/prds/176-inventory-documents-cutover/README.md
@@ -12,16 +12,15 @@ Documents are the linkage layer between inventory items and external document st
 
 Tables (move from shared to `packages/inventory-db`):
 
-- `item_documents` — { id, item_id, document_source ('paperless' | 'local'), document_ref, label, attached_at } (already in `inventory.db` after M4)
+- `item_documents` — { id, item_id, paperless_document_id, document_type ('receipt' | 'warranty' | 'manual' | 'invoice' | 'other'), title, created_at } (already in `inventory.db` after M4). Unique on `(item_id, paperless_document_id)`.
 
 ## API Surface
 
-| Procedure                    | Kind     |
-| ---------------------------- | -------- |
-| `inventory.documents.byItem` | query    |
-| `inventory.documents.attach` | mutation |
-| `inventory.documents.detach` | mutation |
-| `inventory.documents.update` | mutation |
+| Procedure                         | Kind     |
+| --------------------------------- | -------- |
+| `inventory.documents.listForItem` | query    |
+| `inventory.documents.link`        | mutation |
+| `inventory.documents.unlink`      | mutation |
 
 Files today: `apps/pops-api/src/modules/inventory/documents/{router.ts, service.ts}`.
 
@@ -31,13 +30,14 @@ Follows [PRD-165's 4-PR sequence](../165-media-movies-cutover/README.md#business
 
 - The paperless-ngx client (PRD-177) is a separate concern; this PRD only moves the linkage table.
 - Cutover gated on PRD-173 (items).
+- Duplicate `(item_id, paperless_document_id)` pairs are rejected as a typed conflict (no in-place update).
 
 ## Edge Cases
 
-| Case                                                               | Behaviour                                                              |
-| ------------------------------------------------------------------ | ---------------------------------------------------------------------- |
-| Document references a paperless document_ref that no longer exists | Existing behaviour preserved; query returns the row, consumer handles. |
-| Attach without paperless reachable                                 | Pure DB write; doesn't probe paperless.                                |
+| Case                                                              | Behaviour                                                              |
+| ----------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| Document references a paperless document_id that no longer exists | Existing behaviour preserved; query returns the row, consumer handles. |
+| Link without paperless reachable                                  | Pure DB write; doesn't probe paperless.                                |
 
 ## User Stories
 

--- a/packages/inventory-db/src/__tests__/documents.test.ts
+++ b/packages/inventory-db/src/__tests__/documents.test.ts
@@ -1,0 +1,337 @@
+/**
+ * Invariant tests for the documents service against an in-memory SQLite
+ * seeded with the canonical `home_inventory` + `item_documents` tables.
+ * Pure DB + service layer — no tRPC, no Express, no auth middleware.
+ *
+ * Higher-level integration coverage (auth, router, tRPC error mapping)
+ * lives in pops-api's own suite; the writer move + reads cutover PRs
+ * route those through `documentsService.*`.
+ *
+ * The `home_inventory` and `item_documents` DDL is inlined here because
+ * the canonical baseline migration (`0006_inventory_pillar_baseline`)
+ * bundles unrelated FK tables. The locations migration is read from the
+ * package's journal so the FK target exists.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import BetterSqlite3 from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { documentsService } from '../index.js';
+import {
+  DocumentConflictError,
+  DocumentItemNotFoundError,
+  DocumentNotFoundError,
+} from '../services/documents-errors.js';
+import { create as createItem } from '../services/items.js';
+
+import type { Database } from 'better-sqlite3';
+
+import type { InventoryDb } from '../services/internal.js';
+
+const LOCATIONS_MIGRATION = join(__dirname, '../../migrations/0005_fancy_crystal.sql');
+
+const HOME_INVENTORY_DDL = `
+CREATE TABLE home_inventory (
+  id text PRIMARY KEY NOT NULL,
+  notion_id text UNIQUE,
+  item_name text NOT NULL,
+  brand text,
+  model text,
+  item_id text,
+  room text,
+  location text,
+  type text,
+  condition text DEFAULT 'good',
+  in_use integer,
+  deductible integer,
+  purchase_date text,
+  warranty_expires text,
+  replacement_value real,
+  resale_value real,
+  purchase_transaction_id text,
+  purchased_from_id text,
+  purchased_from_name text,
+  purchase_price real,
+  asset_id text UNIQUE,
+  notes text,
+  location_id text REFERENCES locations(id) ON DELETE set null,
+  created_at text NOT NULL DEFAULT (datetime('now')),
+  updated_at text NOT NULL DEFAULT (datetime('now')),
+  last_edited_time text NOT NULL
+);
+`;
+
+const ITEM_DOCUMENTS_DDL = `
+CREATE TABLE item_documents (
+  id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  item_id text NOT NULL REFERENCES home_inventory(id) ON DELETE CASCADE,
+  paperless_document_id integer NOT NULL,
+  document_type text NOT NULL,
+  title text,
+  created_at text NOT NULL DEFAULT (datetime('now'))
+);
+CREATE UNIQUE INDEX uq_item_documents_pair ON item_documents (item_id, paperless_document_id);
+CREATE INDEX idx_item_documents_item ON item_documents (item_id);
+CREATE INDEX idx_item_documents_doc ON item_documents (paperless_document_id);
+`;
+
+interface FreshDb {
+  db: InventoryDb;
+  raw: Database;
+}
+
+function freshDb(): FreshDb {
+  const raw = new BetterSqlite3(':memory:');
+  raw.pragma('foreign_keys = ON');
+  const sql = readFileSync(LOCATIONS_MIGRATION, 'utf8');
+  for (const stmt of sql.split('--> statement-breakpoint')) {
+    const trimmed = stmt.trim();
+    if (trimmed.length > 0) raw.exec(trimmed);
+  }
+  raw.exec(HOME_INVENTORY_DDL);
+  raw.exec(ITEM_DOCUMENTS_DDL);
+  return { db: drizzle(raw), raw };
+}
+
+function seedItem(db: InventoryDb, name = 'Test Item'): string {
+  return createItem(db, { itemName: name }).id;
+}
+
+describe('documentsService.link', () => {
+  let db: InventoryDb;
+  beforeEach(() => {
+    ({ db } = freshDb());
+  });
+
+  it('links a document to an item and returns the row', () => {
+    const itemId = seedItem(db);
+    const row = documentsService.link(db, {
+      itemId,
+      paperlessDocumentId: 42,
+      documentType: 'receipt',
+      title: 'Purchase Receipt',
+    });
+    expect(row.itemId).toBe(itemId);
+    expect(row.paperlessDocumentId).toBe(42);
+    expect(row.documentType).toBe('receipt');
+    expect(row.title).toBe('Purchase Receipt');
+    expect(typeof row.id).toBe('number');
+    expect(row.createdAt).toBeTruthy();
+  });
+
+  it('links without title and stores null', () => {
+    const itemId = seedItem(db);
+    const row = documentsService.link(db, {
+      itemId,
+      paperlessDocumentId: 7,
+      documentType: 'warranty',
+    });
+    expect(row.title).toBeNull();
+  });
+
+  it('coerces undefined title to null', () => {
+    const itemId = seedItem(db);
+    const row = documentsService.link(db, {
+      itemId,
+      paperlessDocumentId: 8,
+      documentType: 'manual',
+      title: undefined,
+    });
+    expect(row.title).toBeNull();
+  });
+
+  it('rejects duplicate (item, paperless) pairs with DocumentConflictError', () => {
+    const itemId = seedItem(db);
+    documentsService.link(db, { itemId, paperlessDocumentId: 42, documentType: 'receipt' });
+    expect(() =>
+      documentsService.link(db, { itemId, paperlessDocumentId: 42, documentType: 'receipt' })
+    ).toThrowError(DocumentConflictError);
+  });
+
+  it('allows the same paperless document linked to different items', () => {
+    const itemA = seedItem(db, 'A');
+    const itemB = seedItem(db, 'B');
+    documentsService.link(db, { itemId: itemA, paperlessDocumentId: 42, documentType: 'receipt' });
+    const second = documentsService.link(db, {
+      itemId: itemB,
+      paperlessDocumentId: 42,
+      documentType: 'receipt',
+    });
+    expect(second.itemId).toBe(itemB);
+    expect(second.paperlessDocumentId).toBe(42);
+  });
+
+  it('allows different documents linked to the same item', () => {
+    const itemId = seedItem(db);
+    documentsService.link(db, { itemId, paperlessDocumentId: 1, documentType: 'receipt' });
+    const second = documentsService.link(db, {
+      itemId,
+      paperlessDocumentId: 2,
+      documentType: 'warranty',
+    });
+    expect(second.paperlessDocumentId).toBe(2);
+  });
+
+  it('throws DocumentItemNotFoundError when the item is missing', () => {
+    expect(() =>
+      documentsService.link(db, {
+        itemId: 'nope',
+        paperlessDocumentId: 1,
+        documentType: 'receipt',
+      })
+    ).toThrowError(DocumentItemNotFoundError);
+  });
+
+  it('does not insert a row when the item is missing', () => {
+    expect(() =>
+      documentsService.link(db, {
+        itemId: 'nope',
+        paperlessDocumentId: 1,
+        documentType: 'receipt',
+      })
+    ).toThrow();
+    const itemId = seedItem(db);
+    const result = documentsService.listForItem(db, itemId, 50, 0);
+    expect(result.total).toBe(0);
+  });
+});
+
+describe('documentsService.unlink', () => {
+  let db: InventoryDb;
+  beforeEach(() => {
+    ({ db } = freshDb());
+  });
+
+  it('removes an existing link', () => {
+    const itemId = seedItem(db);
+    const row = documentsService.link(db, {
+      itemId,
+      paperlessDocumentId: 42,
+      documentType: 'receipt',
+    });
+    documentsService.unlink(db, row.id);
+    const result = documentsService.listForItem(db, itemId, 50, 0);
+    expect(result.total).toBe(0);
+  });
+
+  it('throws DocumentNotFoundError for an unknown id', () => {
+    expect(() => documentsService.unlink(db, 999)).toThrowError(DocumentNotFoundError);
+  });
+
+  it('does not affect other links', () => {
+    const itemId = seedItem(db);
+    const a = documentsService.link(db, {
+      itemId,
+      paperlessDocumentId: 1,
+      documentType: 'receipt',
+    });
+    documentsService.link(db, { itemId, paperlessDocumentId: 2, documentType: 'warranty' });
+    documentsService.unlink(db, a.id);
+    const result = documentsService.listForItem(db, itemId, 50, 0);
+    expect(result.total).toBe(1);
+    expect(result.rows[0]!.paperlessDocumentId).toBe(2);
+  });
+});
+
+describe('documentsService.listForItem', () => {
+  let db: InventoryDb;
+  let raw: Database;
+  beforeEach(() => {
+    ({ db, raw } = freshDb());
+  });
+
+  it('returns empty rows + zero total when the item has no documents', () => {
+    const itemId = seedItem(db);
+    const result = documentsService.listForItem(db, itemId, 50, 0);
+    expect(result).toEqual({ rows: [], total: 0 });
+  });
+
+  it('returns only documents linked to the requested item', () => {
+    const itemA = seedItem(db, 'A');
+    const itemB = seedItem(db, 'B');
+    documentsService.link(db, { itemId: itemA, paperlessDocumentId: 10, documentType: 'receipt' });
+    documentsService.link(db, { itemId: itemB, paperlessDocumentId: 20, documentType: 'manual' });
+
+    const result = documentsService.listForItem(db, itemA, 50, 0);
+    expect(result.total).toBe(1);
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0]!.paperlessDocumentId).toBe(10);
+  });
+
+  it('orders by id ascending (insertion order) for stable pagination', () => {
+    const itemId = seedItem(db);
+    for (let i = 1; i <= 5; i++) {
+      documentsService.link(db, {
+        itemId,
+        paperlessDocumentId: i,
+        documentType: 'receipt',
+      });
+    }
+    const result = documentsService.listForItem(db, itemId, 50, 0);
+    expect(result.rows.map((r) => r.paperlessDocumentId)).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('respects limit and offset and reports the unpaginated total', () => {
+    const itemId = seedItem(db);
+    for (let i = 1; i <= 5; i++) {
+      documentsService.link(db, {
+        itemId,
+        paperlessDocumentId: i,
+        documentType: 'receipt',
+      });
+    }
+    const page1 = documentsService.listForItem(db, itemId, 2, 0);
+    expect(page1.total).toBe(5);
+    expect(page1.rows.map((r) => r.paperlessDocumentId)).toEqual([1, 2]);
+
+    const page2 = documentsService.listForItem(db, itemId, 2, 2);
+    expect(page2.total).toBe(5);
+    expect(page2.rows.map((r) => r.paperlessDocumentId)).toEqual([3, 4]);
+
+    const page3 = documentsService.listForItem(db, itemId, 2, 4);
+    expect(page3.total).toBe(5);
+    expect(page3.rows.map((r) => r.paperlessDocumentId)).toEqual([5]);
+  });
+
+  it('cascades deletes when the parent item is removed', () => {
+    const itemId = seedItem(db);
+    documentsService.link(db, { itemId, paperlessDocumentId: 1, documentType: 'receipt' });
+    documentsService.link(db, { itemId, paperlessDocumentId: 2, documentType: 'warranty' });
+
+    raw.prepare('DELETE FROM home_inventory WHERE id = ?').run(itemId);
+
+    const remaining = raw
+      .prepare('SELECT COUNT(*) as c FROM item_documents WHERE item_id = ?')
+      .get(itemId) as { c: number };
+    expect(remaining.c).toBe(0);
+  });
+});
+
+describe('toItemDocument', () => {
+  it('round-trips all DB row fields to the public shape', () => {
+    const row = {
+      id: 7,
+      itemId: 'item-1',
+      paperlessDocumentId: 42,
+      documentType: 'receipt',
+      title: 'Receipt',
+      createdAt: '2026-01-01T00:00:00Z',
+    };
+    expect(documentsService.toItemDocument(row)).toEqual(row);
+  });
+
+  it('preserves null title', () => {
+    const row = {
+      id: 8,
+      itemId: 'item-2',
+      paperlessDocumentId: 1,
+      documentType: 'manual',
+      title: null,
+      createdAt: '2026-01-01T00:00:00Z',
+    };
+    expect(documentsService.toItemDocument(row).title).toBeNull();
+  });
+});

--- a/packages/inventory-db/src/index.ts
+++ b/packages/inventory-db/src/index.ts
@@ -83,6 +83,7 @@ export { DOCUMENT_TYPES, toItemDocument } from './services/documents.js';
 
 export {
   DocumentConflictError,
+  DocumentCreateFailedError,
   DocumentItemNotFoundError,
   DocumentNotFoundError,
 } from './services/documents-errors.js';

--- a/packages/inventory-db/src/index.ts
+++ b/packages/inventory-db/src/index.ts
@@ -9,7 +9,8 @@
  * Per the CI-never-breaks pattern the migration is incremental — this PR
  * scaffolds the package and moves only the `locations` slice. The other
  * slices (items, connections, documents, photos, fixtures, document-files,
- * paperless) follow in subsequent PRs.
+ * paperless) follow in subsequent PRs. `items`, `connections`, and
+ * `documents` are now scaffolded; the live writers still own production.
  */
 export * from './errors.js';
 export * from './schema.js';
@@ -21,6 +22,7 @@ export { openInventoryDb, type OpenedInventoryDb } from './open-inventory-db.js'
 export * as locationsService from './services/locations.js';
 export * as itemsService from './services/items.js';
 export * as connectionsService from './services/connections.js';
+export * as documentsService from './services/documents.js';
 
 // Public types re-exported at the package root so consumers can name
 // them without reaching into the namespaces.
@@ -68,3 +70,19 @@ export {
   ConnectionNotFoundError,
   SelfConnectionError,
 } from './services/connections-errors.js';
+
+export type {
+  DocumentListResult,
+  DocumentType,
+  ItemDocument,
+  ItemDocumentRow,
+  LinkDocumentInput,
+} from './services/documents.js';
+
+export { DOCUMENT_TYPES, toItemDocument } from './services/documents.js';
+
+export {
+  DocumentConflictError,
+  DocumentItemNotFoundError,
+  DocumentNotFoundError,
+} from './services/documents-errors.js';

--- a/packages/inventory-db/src/schema.ts
+++ b/packages/inventory-db/src/schema.ts
@@ -14,4 +14,4 @@
  * `getLocationItems` / `getDeleteStats`, and downstream slice PRs (items,
  * connections, documents, photos, fixtures) will need it too.
  */
-export { homeInventory, itemConnections, locations } from '@pops/db-types';
+export { homeInventory, itemConnections, itemDocuments, locations } from '@pops/db-types';

--- a/packages/inventory-db/src/services/documents-errors.ts
+++ b/packages/inventory-db/src/services/documents-errors.ts
@@ -38,3 +38,17 @@ export class DocumentItemNotFoundError extends Error {
     this.id = id;
   }
 }
+
+export class DocumentCreateFailedError extends Error {
+  override readonly name = 'DocumentCreateFailedError' as const;
+  readonly itemId: string;
+  readonly paperlessDocumentId: number;
+
+  constructor(itemId: string, paperlessDocumentId: number) {
+    super(
+      `Failed to create item document link for item '${itemId}' and paperless document '${paperlessDocumentId}'`
+    );
+    this.itemId = itemId;
+    this.paperlessDocumentId = paperlessDocumentId;
+  }
+}

--- a/packages/inventory-db/src/services/documents-errors.ts
+++ b/packages/inventory-db/src/services/documents-errors.ts
@@ -1,0 +1,40 @@
+/**
+ * Typed errors raised by the item documents service layer.
+ *
+ * Plain Error subclasses — the service layer is HTTP-agnostic. Router
+ * layers (pops-api, pops-inventory-api) map these to the appropriate
+ * tRPC / HTTP codes. Mirrors the items / locations / connections error
+ * pattern.
+ */
+
+export class DocumentNotFoundError extends Error {
+  override readonly name = 'DocumentNotFoundError' as const;
+  readonly id: number;
+
+  constructor(id: number) {
+    super(`Item document link '${id}' not found`);
+    this.id = id;
+  }
+}
+
+export class DocumentConflictError extends Error {
+  override readonly name = 'DocumentConflictError' as const;
+  readonly itemId: string;
+  readonly paperlessDocumentId: number;
+
+  constructor(itemId: string, paperlessDocumentId: number) {
+    super(`Document '${paperlessDocumentId}' is already linked to item '${itemId}'`);
+    this.itemId = itemId;
+    this.paperlessDocumentId = paperlessDocumentId;
+  }
+}
+
+export class DocumentItemNotFoundError extends Error {
+  override readonly name = 'DocumentItemNotFoundError' as const;
+  readonly id: string;
+
+  constructor(id: string) {
+    super(`Inventory item '${id}' not found`);
+    this.id = id;
+  }
+}

--- a/packages/inventory-db/src/services/documents-types.ts
+++ b/packages/inventory-db/src/services/documents-types.ts
@@ -18,7 +18,7 @@ export type DocumentType = (typeof DOCUMENT_TYPES)[number];
 export interface LinkDocumentInput {
   itemId: string;
   paperlessDocumentId: number;
-  documentType: string;
+  documentType: DocumentType;
   title?: string | null;
 }
 

--- a/packages/inventory-db/src/services/documents-types.ts
+++ b/packages/inventory-db/src/services/documents-types.ts
@@ -1,0 +1,51 @@
+/**
+ * Input and result types for the item documents service, plus the
+ * `toItemDocument` row→API mapper.
+ *
+ * Validation (zod) lives with the router layers — this package stays
+ * HTTP-agnostic and only exposes the service surface, row types, and
+ * the canonical row→public-shape mapper needed to call it.
+ */
+import type { ItemDocumentRow } from '@pops/db-types';
+
+export type { ItemDocumentRow };
+
+/** Document types accepted by the link mutation. */
+export const DOCUMENT_TYPES = ['receipt', 'warranty', 'manual', 'invoice', 'other'] as const;
+export type DocumentType = (typeof DOCUMENT_TYPES)[number];
+
+/** Input for linking a Paperless-ngx document to an inventory item. */
+export interface LinkDocumentInput {
+  itemId: string;
+  paperlessDocumentId: number;
+  documentType: string;
+  title?: string | null;
+}
+
+/** Paginated list result for item documents. */
+export interface DocumentListResult {
+  rows: ItemDocumentRow[];
+  total: number;
+}
+
+/** Public API shape for an item document link. */
+export interface ItemDocument {
+  id: number;
+  itemId: string;
+  paperlessDocumentId: number;
+  documentType: string;
+  title: string | null;
+  createdAt: string;
+}
+
+/** Map a SQLite row to the public API shape. */
+export function toItemDocument(row: ItemDocumentRow): ItemDocument {
+  return {
+    id: row.id,
+    itemId: row.itemId,
+    paperlessDocumentId: row.paperlessDocumentId,
+    documentType: row.documentType,
+    title: row.title,
+    createdAt: row.createdAt,
+  };
+}

--- a/packages/inventory-db/src/services/documents.ts
+++ b/packages/inventory-db/src/services/documents.ts
@@ -22,6 +22,7 @@ import { and, asc, count, eq } from 'drizzle-orm';
 import { homeInventory, itemDocuments } from '../schema.js';
 import {
   DocumentConflictError,
+  DocumentCreateFailedError,
   DocumentItemNotFoundError,
   DocumentNotFoundError,
 } from './documents-errors.js';
@@ -41,6 +42,7 @@ export {
 
 export {
   DocumentConflictError,
+  DocumentCreateFailedError,
   DocumentItemNotFoundError,
   DocumentNotFoundError,
 } from './documents-errors.js';
@@ -93,7 +95,7 @@ export function link(db: InventoryDb, input: LinkDocumentInput): ItemDocumentRow
     .run();
 
   const created = findByPair(db, input.itemId, input.paperlessDocumentId);
-  if (!created) throw new DocumentNotFoundError(0);
+  if (!created) throw new DocumentCreateFailedError(input.itemId, input.paperlessDocumentId);
   return created;
 }
 

--- a/packages/inventory-db/src/services/documents.ts
+++ b/packages/inventory-db/src/services/documents.ts
@@ -1,0 +1,140 @@
+/**
+ * Item documents service — link/unlink Paperless-ngx documents to
+ * inventory items, list documents for an item.
+ *
+ * Each function takes an `InventoryDb` handle as its first argument; the
+ * calling layer (pops-api modules, pops-inventory-api routers) resolves
+ * the singleton or transaction handle to pass in. Mirrors the items /
+ * locations / connections writer pattern (db-arg, typed errors).
+ *
+ * The live writer in `apps/pops-api/src/modules/inventory/documents/service.ts`
+ * is the source of truth for the wire surface — this scaffold mirrors
+ * its semantics so the PR2 reads-cutover can swap consumers over to
+ * `documentsService.*` without a behavioural change.
+ *
+ * Pair uniqueness is enforced at the schema level via the
+ * `uq_item_documents_pair` unique index on (item_id, paperless_document_id);
+ * the service performs an explicit existence check first so callers get a
+ * typed `DocumentConflictError` instead of a raw SQLITE_CONSTRAINT.
+ */
+import { and, asc, count, eq } from 'drizzle-orm';
+
+import { homeInventory, itemDocuments } from '../schema.js';
+import {
+  DocumentConflictError,
+  DocumentItemNotFoundError,
+  DocumentNotFoundError,
+} from './documents-errors.js';
+
+import type { DocumentListResult, ItemDocumentRow, LinkDocumentInput } from './documents-types.js';
+import type { InventoryDb } from './internal.js';
+
+export {
+  DOCUMENT_TYPES,
+  type DocumentListResult,
+  type DocumentType,
+  type ItemDocument,
+  type ItemDocumentRow,
+  type LinkDocumentInput,
+  toItemDocument,
+} from './documents-types.js';
+
+export {
+  DocumentConflictError,
+  DocumentItemNotFoundError,
+  DocumentNotFoundError,
+} from './documents-errors.js';
+
+function assertItemExists(db: InventoryDb, id: string): void {
+  const [row] = db
+    .select({ id: homeInventory.id })
+    .from(homeInventory)
+    .where(eq(homeInventory.id, id))
+    .all();
+  if (!row) throw new DocumentItemNotFoundError(id);
+}
+
+function findByPair(
+  db: InventoryDb,
+  itemId: string,
+  paperlessDocumentId: number
+): ItemDocumentRow | undefined {
+  const [row] = db
+    .select()
+    .from(itemDocuments)
+    .where(
+      and(
+        eq(itemDocuments.itemId, itemId),
+        eq(itemDocuments.paperlessDocumentId, paperlessDocumentId)
+      )
+    )
+    .all();
+  return row;
+}
+
+/**
+ * Link a Paperless-ngx document to an inventory item. Validates the item
+ * exists and the (item, document) pair is not already linked.
+ */
+export function link(db: InventoryDb, input: LinkDocumentInput): ItemDocumentRow {
+  assertItemExists(db, input.itemId);
+
+  if (findByPair(db, input.itemId, input.paperlessDocumentId)) {
+    throw new DocumentConflictError(input.itemId, input.paperlessDocumentId);
+  }
+
+  db.insert(itemDocuments)
+    .values({
+      itemId: input.itemId,
+      paperlessDocumentId: input.paperlessDocumentId,
+      documentType: input.documentType,
+      title: input.title ?? null,
+    })
+    .run();
+
+  const created = findByPair(db, input.itemId, input.paperlessDocumentId);
+  if (!created) throw new DocumentNotFoundError(0);
+  return created;
+}
+
+/**
+ * Unlink a document from an item by link ID. Throws
+ * `DocumentNotFoundError` if no row matches.
+ */
+export function unlink(db: InventoryDb, id: number): void {
+  const [row] = db
+    .select({ id: itemDocuments.id })
+    .from(itemDocuments)
+    .where(eq(itemDocuments.id, id))
+    .all();
+
+  if (!row) throw new DocumentNotFoundError(id);
+
+  db.delete(itemDocuments).where(eq(itemDocuments.id, id)).run();
+}
+
+/**
+ * List all documents linked to a given item. Paginated; returns the
+ * matching slice plus the full count for the filter.
+ */
+export function listForItem(
+  db: InventoryDb,
+  itemId: string,
+  limit: number,
+  offset: number
+): DocumentListResult {
+  const condition = eq(itemDocuments.itemId, itemId);
+
+  const rows = db
+    .select()
+    .from(itemDocuments)
+    .where(condition)
+    .orderBy(asc(itemDocuments.id))
+    .limit(limit)
+    .offset(offset)
+    .all();
+
+  const [countResult] = db.select({ total: count() }).from(itemDocuments).where(condition).all();
+
+  return { rows, total: countResult?.total ?? 0 };
+}


### PR DESCRIPTION
## Summary

Scaffold the `documentsService` namespace in `@pops/inventory-db`, mirroring the connections scaffold from PR #3028. This is PRD-176 US-01 (PR1 of the canonical 4-PR N-track sequence). The live writer in `apps/pops-api/src/modules/inventory/documents/` is untouched; this PR just provides the namespace consumers will flip to in PR2.

- `services/documents.ts` — `link`, `unlink`, `listForItem` (db-arg). Explicit `(item, paperless_document_id)` pair existence check ahead of the unique index so callers get a typed `DocumentConflictError` rather than a raw `SQLITE_CONSTRAINT`.
- `services/documents-errors.ts` — `DocumentNotFoundError`, `DocumentConflictError`, `DocumentItemNotFoundError`.
- `services/documents-types.ts` — `ItemDocumentRow`, `ItemDocument`, `LinkDocumentInput`, `DocumentListResult`, `DOCUMENT_TYPES`, `toItemDocument`.
- `schema.ts` — re-export `itemDocuments` from `@pops/db-types`.
- `__tests__/documents.test.ts` — 19 invariant tests covering link validation, the unique pair contract (same item / cross-item / cross-document), `listForItem` ordering + pagination, unlink isolation, `ON DELETE CASCADE`, and the public mapper.

No new baseline migration — `item_documents` is already in `0006_inventory_pillar_baseline.sql`.

## PRD discrepancy

The PRD-176 README lists `attach / detach / update / byItem` procedures and columns `document_source / document_ref / label / attached_at`. The actual live module exposes `link / unlink / listForItem` against `(item_id, paperless_document_id, document_type, title, created_at)`. This scaffold mirrors the **live** wire surface so PR2 can flip consumers without a behavioural change. The PRD wording should be rewritten before PR2 lands.

## Test plan

- [x] `pnpm --filter @pops/inventory-db test` — 117 passing (19 new)
- [x] `pnpm --filter @pops/inventory-db typecheck`
- [x] `pnpm --filter @pops/inventory-db build`
- [x] `pnpm turbo typecheck --filter=...@pops/inventory-db` — 35 dependent tasks pass
- [x] `pnpm lint packages/inventory-db/src`
- [x] `pnpm format:check packages/inventory-db/src`
