### PR TITLE
docs(theme-13): rewrite PRD-171 — no media.arr slice to cut over

### DIFF
--- a/docs/themes/13-pillar-finale/prds/171-media-arr-cutover/README.md
+++ b/docs/themes/13-pillar-finale/prds/171-media-arr-cutover/README.md
@@ -23,12 +23,14 @@ There is therefore **no slice to cut over** under this PRD. No package scaffold,
 
 ## API Surface
 
-| Procedure (namespace)             | File                                              | DB handle today                          |
-| --------------------------------- | ------------------------------------------------- | ---------------------------------------- |
-| `media.radarr.*` settings I/O     | `media/arr/service-settings.ts`                   | `getCoreDrizzle()` (correct — stays)     |
-| `media.radarr.*` HTTP ops         | `media/arr/radarr-client.ts`, `radarr-procedures` | none (outbound HTTP)                     |
-| `media.sonarr.*` HTTP ops         | `media/arr/sonarr-client.ts`, `sonarr-procedures` | none (outbound HTTP)                     |
-| `media.radarr.downloadAndProtect` | `media/arr/download-and-protect.ts`               | `getMediaDrizzle()` for the movies write |
+All procedures are wired under `media.arr.*` — the `arrRouter` flattens Radarr and Sonarr procedures into a single namespace (see `apps/pops-api/src/modules/media/index.ts`).
+
+| Procedure (namespace)          | File                                              | DB handle today                          |
+| ------------------------------ | ------------------------------------------------- | ---------------------------------------- |
+| `media.arr.*` settings I/O     | `media/arr/service-settings.ts`                   | `getCoreDrizzle()` (correct — stays)     |
+| `media.arr.*` Radarr HTTP ops  | `media/arr/radarr-client.ts`, `radarr-procedures` | none (outbound HTTP)                     |
+| `media.arr.*` Sonarr HTTP ops  | `media/arr/sonarr-client.ts`, `sonarr-procedures` | none (outbound HTTP)                     |
+| `media.arr.downloadAndProtect` | `media/arr/download-and-protect.ts`               | `getMediaDrizzle()` for the movies write |
 
 The HTTP clients (`radarr-client.ts`, `sonarr-client.ts`, `base-client.ts`) make outbound calls to Radarr/Sonarr — no DB at all.
 

--- a/docs/themes/13-pillar-finale/prds/171-media-arr-cutover/README.md
+++ b/docs/themes/13-pillar-finale/prds/171-media-arr-cutover/README.md
@@ -4,62 +4,62 @@
 
 ## Overview
 
-Move `media.arr.*` (Radarr/Sonarr integration) procedures + related tables into `media.db`. Follows the canonical N-track pattern from [PRD-165](../165-media-movies-cutover/README.md).
+`media/arr/` is the bridge between pops and the Radarr/Sonarr download stack: read URL + API key, talk to the `*arr` HTTP APIs, queue/search/calendar, mark a movie as "protected" so it survives rotation. It has **no tables of its own**.
 
-The \*arr surface is the bridge between pops and the Radarr/Sonarr download stack: register them with API keys, query their status, trigger searches, sync their library back into pops.
+Investigation against the live code shows the persistence touch points are already where they belong:
 
-## Data Model
+| Persistence touchpoint                                   | Lives on                                                    | Already cut over by |
+| -------------------------------------------------------- | ----------------------------------------------------------- | ------------------- |
+| Radarr URL + API key (`radarr_url`, `radarr_api_key`)    | `core.settings` (generic settings table on `core.db`)       | Stays on core       |
+| Sonarr URL + API key (`sonarr_url`, `sonarr_api_key`)    | `core.settings`                                             | Stays on core       |
+| Rotation defaults (`rotation_quality_profile_id`, …path) | `core.settings`                                             | Stays on core       |
+| "Protected" marker on a movie (`movies.rotation_status`) | `media.movies` column on `media.db` (via `getMediaDrizzle`) | PRD-165 PR 3        |
 
-Tables (move from shared to `packages/media-db`):
+The PRD's original data model (`arr_instances`, `arr_protected_items`) was speculative — those tables do not exist in the codebase. The `*arr` URL + API key are 4 rows in the generic `settings` table on `core.db`, and "protected" is a `rotation_status='protected'` column on the existing `media.movies` row.
 
-- `arr_instances` — { id, type ('radarr' | 'sonarr'), base_url, api_key (encrypted), enabled }
-- `arr_protected_items` — { id, item_type, item_id, protection_reason, set_at } (downloads pops doesn't want \*arr to delete)
+The only file in `media/arr/` that hits a DB handle is `service-settings.ts` (reads/writes the 4 settings keys via `getCoreDrizzle()`) and `download-and-protect.ts` (reads rotation defaults via `getCoreDrizzle()`, then writes `movies.rotation_status` via `getMediaDrizzle()`). Both handle choices are correct: the settings live on core (per the encryption / key-management boundary stated in the original PRD), and the movies write is already on the media pillar.
 
-API keys stay encrypted via the existing `core.serviceAccounts` envelope key pattern (the encryption side stays on core; only the encrypted blob moves to `media.db`).
+There is therefore **no slice to cut over** under this PRD. No package scaffold, no shared-journal split, no handle flip, no shim to delete.
 
 ## API Surface
 
-| Procedure                    | Kind                        |
-| ---------------------------- | --------------------------- |
-| `media.arr.instances.list`   | query                       |
-| `media.arr.instances.create` | mutation                    |
-| `media.arr.instances.update` | mutation                    |
-| `media.arr.instances.delete` | mutation                    |
-| `media.arr.radarr.search`    | mutation (calls Radarr API) |
-| `media.arr.radarr.queue`     | query (calls Radarr API)    |
-| `media.arr.sonarr.*`         | similar shape for Sonarr    |
-| `media.arr.protected.list`   | query                       |
-| `media.arr.protected.add`    | mutation                    |
-| `media.arr.protected.remove` | mutation                    |
+| Procedure (namespace)             | File                                              | DB handle today                          |
+| --------------------------------- | ------------------------------------------------- | ---------------------------------------- |
+| `media.radarr.*` settings I/O     | `media/arr/service-settings.ts`                   | `getCoreDrizzle()` (correct — stays)     |
+| `media.radarr.*` HTTP ops         | `media/arr/radarr-client.ts`, `radarr-procedures` | none (outbound HTTP)                     |
+| `media.sonarr.*` HTTP ops         | `media/arr/sonarr-client.ts`, `sonarr-procedures` | none (outbound HTTP)                     |
+| `media.radarr.downloadAndProtect` | `media/arr/download-and-protect.ts`               | `getMediaDrizzle()` for the movies write |
 
-Files today: `apps/pops-api/src/modules/media/arr/{radarr-router.ts, radarr-client.ts, radarr-procedures.ts, base-client.ts, download-and-protect.ts}`.
+The HTTP clients (`radarr-client.ts`, `sonarr-client.ts`, `base-client.ts`) make outbound calls to Radarr/Sonarr — no DB at all.
 
 ## Business Rules
 
-Follows [PRD-165's 4-PR sequence](../165-media-movies-cutover/README.md#business-rules--the-n-track-4-pr-sequence). Slice specifics:
-
-- \*arr HTTP clients (radarr-client.ts) make outbound calls to Radarr/Sonarr; they don't touch the DB directly. Only the persistence layer (instances list, protected items) moves.
-- API keys are encrypted at the cell level today; encryption stays on core's key-management surface. The encrypted blob is opaque to media-api; it forwards the encrypted form to the existing decrypt service.
+- The `*arr` URL + API key live on `core.settings`. They stay there: this is the same boundary the original PRD called out for encryption / key-management. No move.
+- "Protected" is not a separate table; it is `movies.rotation_status = 'protected'`. The `movies` table already lives on `media.db` (PRD-165). The write in `download-and-protect.ts` is already on `getMediaDrizzle()`.
+- Rotation defaults (`rotation_quality_profile_id`, `rotation_root_folder_path`) are also `core.settings` rows. They stay on core for the same reason as the API keys.
 
 ## Edge Cases
 
-| Case                                                   | Behaviour                                                                                                                                                                                                                        |
-| ------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Decryption requires reaching back to core to unwrap    | Encrypt/decrypt is centralised on `core.serviceAccounts`'s key-management; media-api calls into core via SDK (Epic 05). For now: in-process via the workspace `@pops/core-db` package; switches to SDK call after Epic 05 lands. |
-| \*arr instance becomes unreachable                     | Outbound HTTP fails; preserved error semantics.                                                                                                                                                                                  |
-| Backfill encounters an arr_instance with a missing key | Logged warning; instance row is copied but flagged disabled.                                                                                                                                                                     |
+| Case                                                     | Behaviour                                                                                                    |
+| -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `*arr` instance unreachable                              | Outbound HTTP fails inside the client; existing error semantics preserved. Not a DB concern.                 |
+| Settings row missing for `radarr_url` / `radarr_api_key` | `getRadarrClient()` returns `null`; procedures surface `PRECONDITION_FAILED`. Existing behaviour; no change. |
+| Marking a movie as protected when no library row exists  | `markMovieProtected` throws `NOT_FOUND` (no `movies` row to update). Existing behaviour; no change.          |
 
 ## User Stories
 
-| #   | Story                                                       | Summary                                                                    |
-| --- | ----------------------------------------------------------- | -------------------------------------------------------------------------- |
-| 01  | [us-01-pr1-package-scaffold](us-01-pr1-package-scaffold.md) | PR 1 — Schemas + services into `@pops/media-db`                            |
-| 02  | [us-02-pr2-journal-split](us-02-pr2-journal-split.md)       | PR 2 — Drop from shared journal                                            |
-| 03  | [us-03-pr3-cutover](us-03-pr3-cutover.md)                   | PR 3 — Flip router to `getMediaDrizzle()`; keep encryption surface on core |
-| 04  | [us-04-pr4-shim-deletion](us-04-pr4-shim-deletion.md)       | PR 4 — Delete or defer shim                                                |
+This PRD has no shippable code work. The investigation outcome is the deliverable; no user stories are tracked.
+
+| #   | Story                       | Outcome                                                                                                    |
+| --- | --------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| 01  | PR 1 — Package scaffold     | N/A — no tables in this slice; nothing to scaffold into `@pops/media-db`.                                  |
+| 02  | PR 2 — Shared journal split | N/A — no `arr_*` tables are owned by shared `pops.db`.                                                     |
+| 03  | PR 3 — Cutover              | N/A — settings handle (`core.db`) is intentionally on core; movies handle (`media.db`) is already correct. |
+| 04  | PR 4 — Shim deletion        | N/A — no shim exists.                                                                                      |
 
 ## Out of Scope
 
-- API key encryption mechanics (stays on core).
-- \*arr-side scheduling / job queuing changes; only persistence moves.
-- New \*arr integrations (e.g. Lidarr, Readarr).
+- API key encryption mechanics (stays on core; envelope key pattern unchanged).
+- `*arr`-side scheduling / job queuing changes.
+- New `*arr` integrations (Lidarr, Readarr, etc.).
+- The eventual SDK-based cross-pillar settings read (Epic 05); `getCoreDrizzle()` is the correct in-process handle until then.


### PR DESCRIPTION
## Summary

PRD-171 (`media.arr` cutover) — investigation outcome. Mirrors the doc rewrite PR-3027 did for PRD-169.

The PRD's original data model (`arr_instances`, `arr_protected_items` tables) was speculative. Reading `apps/pops-api/src/modules/media/arr/` shows neither table exists:

- Radarr/Sonarr URL + API key live as 4 rows in the generic `core.settings` table on `core.db` (keys: `radarr_url`, `radarr_api_key`, `sonarr_url`, `sonarr_api_key`). The encryption / key-management boundary the PRD itself called out keeps them on core — no move.
- "Protected" is `movies.rotation_status = 'protected'` on the existing `media.movies` row, not a separate table. The `movies` table already lives on `media.db` via PRD-165 PR 3, and `download-and-protect.ts` already writes to it through `getMediaDrizzle()`.
- Rotation defaults (`rotation_quality_profile_id`, `rotation_root_folder_path`) are also `core.settings` rows; same story — stays on core.

Net: **no slice to cut over** under this PRD. No package scaffold, no shared-journal split, no handle flip, no shim to delete. This PR rewrites the PRD doc to reflect that so a future agent doesn't waste a cycle building tables that aren't there.

Code in `apps/pops-api/src/modules/media/arr/` is unchanged.

## Test plan

- [x] `pnpm install` — lockfile up to date
- [x] Pre-commit (`oxfmt --write`) — clean
- [x] Pre-push turbo pipeline — 66/66 tasks green (50 cached, 16 fresh)
- [x] No code changes; no tests to add
