### PR TITLE
feat(inventory): cut documents reads to @pops/inventory-db (PRD-176 PR2)

### DIFF
--- a/apps/pops-api/src/modules/inventory/documents/documents.test.ts
+++ b/apps/pops-api/src/modules/inventory/documents/documents.test.ts
@@ -222,6 +222,7 @@ describe('inventory.documents.listForItem', () => {
     });
 
     expect(page1.data).toHaveLength(2);
+    expect(page1.data.map((r) => r.paperlessDocumentId)).toEqual([1, 2]);
     expect(page1.pagination.total).toBe(3);
     expect(page1.pagination.hasMore).toBe(true);
 
@@ -232,6 +233,7 @@ describe('inventory.documents.listForItem', () => {
     });
 
     expect(page2.data).toHaveLength(1);
+    expect(page2.data.map((r) => r.paperlessDocumentId)).toEqual([3]);
     expect(page2.pagination.hasMore).toBe(false);
   });
 });

--- a/apps/pops-api/src/modules/inventory/documents/service.ts
+++ b/apps/pops-api/src/modules/inventory/documents/service.ts
@@ -1,9 +1,28 @@
-import { and, count, eq } from 'drizzle-orm';
-
 /**
- * Item documents service — link/unlink Paperless-ngx documents to inventory items.
+ * Inventory documents read/write surface — PRD-176 PR 2 cutover.
+ *
+ * Read/write split during the migration window (mirrors PRD-175 PR 2 +
+ * PRD-173 PR 2 + PRD-179 PR 2):
+ *  - `listDocumentsForItem` is routed through `documentsService` from
+ *    `@pops/inventory-db` against the inventory pillar handle
+ *    (`getInventoryDrizzle()`). Reads now resolve from the canonical
+ *    package implementation.
+ *  - Writes (`linkDocument`, `unlinkDocument`) keep their inline drizzle
+ *    statements against the same handle to preserve the existing
+ *    read-after-write guarantee on the inventory pillar's SQLite file.
+ *    Both calls validate via in-line reads against the same handle, so
+ *    the writes stay inline until PRD-176 PR 3 collapses them onto
+ *    `documentsService.{link, unlink}`.
+ *
+ * The legacy router stays mounted in pops-api as a fall-through while the
+ * dispatcher cutover routes `inventory.documents.*` traffic to
+ * pops-inventory-api. Consumers (router.ts here) keep the same wire
+ * surface — no caller churn.
  */
+import { and, eq } from 'drizzle-orm';
+
 import { homeInventory, itemDocuments } from '@pops/db-types';
+import { documentsService } from '@pops/inventory-db';
 
 import { getInventoryDrizzle } from '../../../db/inventory-handle.js';
 import { ConflictError, NotFoundError } from '../../../shared/errors.js';
@@ -27,7 +46,6 @@ export function linkDocument(
 ): ItemDocumentRow {
   const db = getInventoryDrizzle();
 
-  // Validate item exists
   const [item] = db
     .select({ id: homeInventory.id })
     .from(homeInventory)
@@ -36,7 +54,6 @@ export function linkDocument(
 
   if (!item) throw new NotFoundError('Inventory item', itemId);
 
-  // Check for existing link
   const [existing] = db
     .select({ id: itemDocuments.id })
     .from(itemDocuments)
@@ -58,7 +75,6 @@ export function linkDocument(
     .values({ itemId, paperlessDocumentId, documentType, title: title ?? null })
     .run();
 
-  // Fetch the created row
   const [created] = db
     .select()
     .from(itemDocuments)
@@ -99,13 +115,5 @@ export function listDocumentsForItem(
   limit: number,
   offset: number
 ): DocumentListResult {
-  const db = getInventoryDrizzle();
-
-  const condition = eq(itemDocuments.itemId, itemId);
-
-  const rows = db.select().from(itemDocuments).where(condition).limit(limit).offset(offset).all();
-
-  const [countResult] = db.select({ total: count() }).from(itemDocuments).where(condition).all();
-
-  return { rows, total: countResult?.total ?? 0 };
+  return documentsService.listForItem(getInventoryDrizzle(), itemId, limit, offset);
 }

--- a/packages/inventory-db/src/services/documents.ts
+++ b/packages/inventory-db/src/services/documents.ts
@@ -118,6 +118,12 @@ export function unlink(db: InventoryDb, id: number): void {
 /**
  * List all documents linked to a given item. Paginated; returns the
  * matching slice plus the full count for the filter.
+ *
+ * Rows are ordered by `item_documents.id` ascending. The id column is the
+ * autoincrement PK, so this is insertion order — the contract callers
+ * implicitly relied on under the legacy inline implementation, now made
+ * explicit so pagination slices are deterministic across SQLite planner
+ * versions and storage layouts.
  */
 export function listForItem(
   db: InventoryDb,


### PR DESCRIPTION
## Summary

- Route `listDocumentsForItem` through `documentsService.listForItem` from `@pops/inventory-db` against the inventory pillar handle (`getInventoryDrizzle()`).
- Keep writes (`linkDocument`, `unlinkDocument`) inline against the same handle so read-after-write semantics stay intact on the pillar's SQLite file.
- Update the service header JSDoc to document the cross-store read/write split, matching the PRD-175 PR 2 (connections) and PRD-173 PR 2 / PRD-179 PR 2 pattern.

## Why

PRD-176 PR 2 — incremental documents-store cutover. Reads consolidate onto the canonical package implementation now that `documentsService` is on `main` (PR #3031). Writes flip in PR 3.

## Test plan

- [x] `pnpm -F @pops/api test src/modules/inventory/documents` — 15/15 pass
- [x] `pnpm -F @pops/api typecheck`
- [x] `pnpm lint`
- [x] `pnpm format:check apps/pops-api/src/modules/inventory/documents`
- [ ] CI green