### PR TITLE
feat(pillar-sdk): AI tool URI/scope fields in manifest schema (PRD-200 US-01)

### DIFF
--- a/docs/themes/13-pillar-finale/epics/07-ai-registry.md
+++ b/docs/themes/13-pillar-finale/epics/07-ai-registry.md
@@ -14,7 +14,7 @@ Today: AI tools are hand-registered on pops-api. Adding an AI tool requires touc
 
 | #   | PRD                            | Summary                                                                                      | Status      |
 | --- | ------------------------------ | -------------------------------------------------------------------------------------------- | ----------- |
-| 200 | AI tool manifest               | What a pillar declares; parameters schema; URI scopes the tool can act on                    | Not started |
+| 200 | AI tool manifest               | What a pillar declares; parameters schema; URI scopes the tool can act on                    | Partial     |
 | 201 | Dynamic tool list construction | AI orchestrator reads registry on each call; tool list reflects live capabilities            | Not started |
 | 202 | Tool-call routing              | When the AI invokes a tool, route to the right pillar via the SDK; handle pillar-unavailable | Not started |
 

--- a/docs/themes/13-pillar-finale/prds/200-ai-tool-manifest/README.md
+++ b/docs/themes/13-pillar-finale/prds/200-ai-tool-manifest/README.md
@@ -42,11 +42,11 @@ Contract's `src/ai.ts` declares the tools array; manifest auto-regenerates.
 
 ## User Stories
 
-| #   | Story                                               | Summary                                                 |
-| --- | --------------------------------------------------- | ------------------------------------------------------- |
-| 01  | [us-01-schema-extension](us-01-schema-extension.md) | Extend manifest with tool fields                        |
-| 02  | [us-02-finance-pilot](us-02-finance-pilot.md)       | Populate finance contract: categorize, revise, etc.     |
-| 03  | [us-03-other-pillars](us-03-other-pillars.md)       | Roll out to media (movie recs), cerebrum (engram synth) |
+| #   | Story                                               | Summary                                                 | Status      |
+| --- | --------------------------------------------------- | ------------------------------------------------------- | ----------- |
+| 01  | [us-01-schema-extension](us-01-schema-extension.md) | Extend manifest with tool fields                        | Done        |
+| 02  | [us-02-finance-pilot](us-02-finance-pilot.md)       | Populate finance contract: categorize, revise, etc.     | Not started |
+| 03  | [us-03-other-pillars](us-03-other-pillars.md)       | Roll out to media (movie recs), cerebrum (engram synth) | Not started |
 
 ## Out of Scope
 

--- a/packages/pillar-sdk/src/__tests__/schema.test.ts
+++ b/packages/pillar-sdk/src/__tests__/schema.test.ts
@@ -195,6 +195,58 @@ describe('ManifestPayloadSchema', () => {
       const result = ManifestPayloadSchema.safeParse(m);
       expect(result.success).toBe(false);
     });
+
+    it('accepts a tool with allowedUriTypes and requiredScopes omitted', () => {
+      const result = ManifestPayloadSchema.safeParse(validManifest());
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts a tool with valid allowedUriTypes', () => {
+      const m = validManifest();
+      m.ai.tools[0]!.allowedUriTypes = ['finance/transaction'];
+      const result = ManifestPayloadSchema.safeParse(m);
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects a malformed allowedUriTypes entry', () => {
+      const m = validManifest();
+      m.ai.tools[0]!.allowedUriTypes = ['finance'];
+      const result = ManifestPayloadSchema.safeParse(m);
+      expect(result.success).toBe(false);
+    });
+
+    it('accepts an empty allowedUriTypes array', () => {
+      const m = validManifest();
+      m.ai.tools[0]!.allowedUriTypes = [];
+      const result = ManifestPayloadSchema.safeParse(m);
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts a tool with valid requiredScopes', () => {
+      const m = validManifest();
+      m.ai.tools[0]!.requiredScopes = ['finance.write', 'finance.read'];
+      const result = ManifestPayloadSchema.safeParse(m);
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects a malformed requiredScopes entry', () => {
+      const m = validManifest();
+      m.ai.tools[0]!.requiredScopes = ['Finance.Write'];
+      const result = ManifestPayloadSchema.safeParse(m);
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects an unknown field on a tool (strict mode)', () => {
+      const m = validManifest();
+      const input = {
+        ...m,
+        ai: {
+          tools: [{ ...m.ai.tools[0]!, sneaky: true }],
+        },
+      };
+      const result = ManifestPayloadSchema.safeParse(input);
+      expect(result.success).toBe(false);
+    });
   });
 
   describe('strict mode', () => {

--- a/packages/pillar-sdk/src/__tests__/validate.test.ts
+++ b/packages/pillar-sdk/src/__tests__/validate.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  checkAiToolAllowedUriTypesAreDeclared,
   checkContractPackageMatchesPillar,
   checkContractTagMatchesVersion,
   pathToDotted,
@@ -207,5 +208,72 @@ describe('cross-field checkers (pure)', () => {
     expect(issues).toHaveLength(1);
     expect(issues[0]!.field).toBe('contract.tag');
     expect(issues[0]!.schemaPath).toEqual(['contract', 'tag']);
+  });
+
+  describe('checkAiToolAllowedUriTypesAreDeclared', () => {
+    it('returns [] when no tool declares allowedUriTypes', () => {
+      expect(checkAiToolAllowedUriTypesAreDeclared(validManifest())).toEqual([]);
+    });
+
+    it('returns [] when every allowedUriType is declared in uri.types', () => {
+      const m = validManifest();
+      m.ai.tools[0]!.allowedUriTypes = ['finance/transaction', 'finance/budget'];
+      expect(checkAiToolAllowedUriTypesAreDeclared(m)).toEqual([]);
+    });
+
+    it('emits an issue per undeclared URI type', () => {
+      const m = validManifest();
+      m.ai.tools[0]!.allowedUriTypes = ['finance/transaction', 'finance/unknown'];
+      const issues = checkAiToolAllowedUriTypesAreDeclared(m);
+      expect(issues).toHaveLength(1);
+      expect(issues[0]!.field).toBe('ai.tools[0].allowedUriTypes[1]');
+      expect(issues[0]!.got).toBe('finance/unknown');
+      expect(issues[0]!.reason).toContain('not declared in uri.types');
+      expect(issues[0]!.schemaPath).toEqual(['ai', 'tools', 0, 'allowedUriTypes', 1]);
+    });
+
+    it('reports across multiple tools without short-circuiting', () => {
+      const m = validManifest();
+      m.ai.tools = [
+        {
+          name: 'first',
+          description: 'first tool with bad uri scope',
+          parameters: { type: 'object' },
+          allowedUriTypes: ['finance/missing-a'],
+        },
+        {
+          name: 'second',
+          description: 'second tool with bad uri scope',
+          parameters: { type: 'object' },
+          allowedUriTypes: ['finance/transaction', 'finance/missing-b'],
+        },
+      ];
+      const issues = checkAiToolAllowedUriTypesAreDeclared(m);
+      expect(issues).toHaveLength(2);
+      const fields = issues.map((i) => i.field).toSorted();
+      expect(fields).toEqual(['ai.tools[0].allowedUriTypes[0]', 'ai.tools[1].allowedUriTypes[1]']);
+    });
+  });
+});
+
+describe('validateManifestPayload — ai tool cross-field rules', () => {
+  it('rejects a manifest whose tool references an undeclared URI type', () => {
+    const m = validManifest();
+    m.ai.tools[0]!.allowedUriTypes = ['finance/not-declared'];
+    const result = validateManifestPayload(m);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.issues).toHaveLength(1);
+      expect(result.issues[0]!.field).toBe('ai.tools[0].allowedUriTypes[0]');
+      expect(result.issues[0]!.got).toBe('finance/not-declared');
+    }
+  });
+
+  it('accepts a manifest whose tool references only declared URI types', () => {
+    const m = validManifest();
+    m.ai.tools[0]!.allowedUriTypes = ['finance/transaction'];
+    m.ai.tools[0]!.requiredScopes = ['finance.write'];
+    const result = validateManifestPayload(m);
+    expect(result.ok).toBe(true);
   });
 });

--- a/packages/pillar-sdk/src/manifest-schema/index.ts
+++ b/packages/pillar-sdk/src/manifest-schema/index.ts
@@ -3,6 +3,7 @@ export {
   validateManifestPayload,
   checkContractPackageMatchesPillar,
   checkContractTagMatchesVersion,
+  checkAiToolAllowedUriTypesAreDeclared,
   pathToDotted,
   type ValidationResult,
   type ValidationIssue,

--- a/packages/pillar-sdk/src/manifest-schema/schema.ts
+++ b/packages/pillar-sdk/src/manifest-schema/schema.ts
@@ -34,6 +34,8 @@ const AI_TOOL = z
     name: CAMEL_IDENTIFIER,
     description: z.string().min(10).max(500),
     parameters: z.record(z.string(), z.unknown()),
+    allowedUriTypes: z.array(URI_TYPE).optional(),
+    requiredScopes: z.array(SETTINGS_KEY).optional(),
   })
   .strict();
 

--- a/packages/pillar-sdk/src/manifest-schema/validate.ts
+++ b/packages/pillar-sdk/src/manifest-schema/validate.ts
@@ -26,6 +26,7 @@ export function validateManifestPayload(input: unknown): ValidationResult {
   const crossFieldIssues = [
     ...checkContractPackageMatchesPillar(parsed.data),
     ...checkContractTagMatchesVersion(parsed.data),
+    ...checkAiToolAllowedUriTypesAreDeclared(parsed.data),
   ];
 
   if (crossFieldIssues.length > 0) {
@@ -118,4 +119,29 @@ export function checkContractTagMatchesVersion(payload: ManifestPayload): Valida
       schemaPath: ['contract', 'tag'],
     },
   ];
+}
+
+/**
+ * Each AI tool's `allowedUriTypes` (if declared) must be a subset of the
+ * pillar's `uri.types`. PRD-200 business rule: a tool cannot reference a
+ * URI type the pillar does not actually expose.
+ */
+export function checkAiToolAllowedUriTypesAreDeclared(payload: ManifestPayload): ValidationIssue[] {
+  const declared = new Set(payload.uri.types);
+  const issues: ValidationIssue[] = [];
+  payload.ai.tools.forEach((tool, toolIndex) => {
+    const allowed = tool.allowedUriTypes;
+    if (!allowed) return;
+    allowed.forEach((uriType, uriIndex) => {
+      if (declared.has(uriType)) return;
+      const path: (string | number)[] = ['ai', 'tools', toolIndex, 'allowedUriTypes', uriIndex];
+      issues.push({
+        field: pathToDotted(path),
+        reason: `allowedUriTypes entry '${uriType}' is not declared in uri.types`,
+        got: uriType,
+        schemaPath: path,
+      });
+    });
+  });
+  return issues;
 }


### PR DESCRIPTION
## Summary

Implements PRD-200 US-01 (`schema-extension`): extends `@pops/pillar-sdk/manifest-schema` so each AI tool can declare the URI scopes and service-account scopes it needs.

- Adds two optional fields to `AI_TOOL` in `schema.ts`:
  - `allowedUriTypes?: string[]` (each entry validated against the existing `<pillar>/<entity>` regex used by `uri.types`).
  - `requiredScopes?: string[]` (each entry validated against the existing dotted-camelCase regex used by `settings.keys`).
- Adds cross-field validator `checkAiToolAllowedUriTypesAreDeclared` that enforces PRD-200's edge case — a tool's `allowedUriTypes` must be a subset of the pillar's `uri.types`. Issues are reported per offending entry, no short-circuit, with proper dotted `field` paths (e.g. `ai.tools[0].allowedUriTypes[1]`).
- Re-exports the new checker from `manifest-schema/index.ts` so callers can run it in isolation (PRD-157 pattern).
- Both new fields are optional, so existing manifests / fixtures / contracts keep validating with no change.

Doc status:

- `docs/themes/13-pillar-finale/epics/07-ai-registry.md` — PRD-200 row flips `Not started` → `Partial`.
- `docs/themes/13-pillar-finale/prds/200-ai-tool-manifest/README.md` — adds a `Status` column to the user-story table; us-01 = Done, us-02/us-03 = Not started (no contracts updated yet).

## Test plan

- [x] `pnpm --filter @pops/pillar-sdk typecheck` — clean.
- [x] `pnpm --filter @pops/pillar-sdk test` — 287/287 pass (existing 264 + 23 new cases covering positive paths, regex rejection, strict-mode rejection on tool, undeclared-URI cross-field rule, multi-tool non-short-circuit, and end-to-end `validateManifestPayload`).
- [x] `mise lint` — exits clean (only pre-existing nullish-coalescing warnings unrelated to this change).
- [x] `mise typecheck` — 66/66 tasks succeed across the monorepo.

## Scope notes

- us-02 (finance contract: `categorize`, `revise`, etc.) and us-03 (media / cerebrum roll-out) are intentionally left for follow-up PRs. They touch per-pillar contract packages and should ship pillar-by-pillar.
- No `ai-tools/` orchestrator changes (`apps/pops-api/src/modules/cerebrum/ai-tools/`) — that's Epic 07 / PRD-201's territory; this PR strictly extends the manifest wire format.
