### PR TITLE
feat(pillar-sdk): cross-pillar ranking merge (PRD-198)

### DIFF
--- a/docs/themes/13-pillar-finale/epics/06-search-registry.md
+++ b/docs/themes/13-pillar-finale/epics/06-search-registry.md
@@ -16,7 +16,7 @@ Open design question: cross-pillar relevance scoring. Each pillar returns its ow
 | --- | ---------------------------- | ------------------------------------------------------------------------ | ----------- |
 | 196 | Search adapter manifest      | What a pillar declares in its manifest; types + Zod schema               | Not started |
 | 197 | Federated query orchestrator | Fan-out, timeout, partial-failure handling                               | Not started |
-| 198 | Ranking strategy             | Per-pillar weights, merge algorithm, fallback when one pillar times out  | Not started |
+| 198 | Ranking strategy             | Per-pillar weights, merge algorithm, fallback when one pillar times out  | Done        |
 | 199 | Partial-failure semantics    | Surface to caller: "got 4/5 pillar responses; results may be incomplete" | Not started |
 
 ## Dependencies

--- a/docs/themes/13-pillar-finale/prds/198-ranking-strategy/README.md
+++ b/docs/themes/13-pillar-finale/prds/198-ranking-strategy/README.md
@@ -14,16 +14,50 @@ Settings table extension:
 
 ## API Surface
 
+Exported from `@pops/pillar-sdk/ranking`:
+
 ```ts
-function mergeResults(perPillarResults: Map<string, ScoredResult[]>): ScoredResult[];
+export const DEFAULT_PILLAR_WEIGHT = 1.0;
+export const SETTINGS_KEY_PREFIX = 'search.pillarWeights.';
+
+export function pillarWeightSettingKey(pillarId: string): string;
+
+export type PillarWeights = ReadonlyMap<string, number>;
+
+export interface ScoredResult {
+  readonly score: number;
+  readonly entityName: string;
+  readonly data: unknown;
+}
+
+export interface MergedResult extends ScoredResult {
+  readonly pillarId: string;
+  readonly adjustedScore: number;
+}
+
+export interface MergeOptions {
+  readonly limit?: number;
+  readonly weights?: PillarWeights;
+  readonly onWarn?: (message: string) => void;
+}
+
+export function mergeResults(
+  perPillarResults: ReadonlyMap<string, readonly ScoredResult[]>,
+  options?: MergeOptions
+): MergedResult[];
 ```
 
 Algorithm:
 
-1. Normalise each pillar's scores to [0, 1] (divide by max).
-2. Multiply by `pillarWeight[pillar]`.
-3. Sort descending by adjusted score.
-4. Return top-N.
+1. Normalise each pillar's scores to `[0, 1]` (divide by that pillar's max; non-finite scores treated as 0).
+2. Multiply by `weights.get(pillarId) ?? DEFAULT_PILLAR_WEIGHT`.
+3. Sort descending by adjusted score, breaking ties by pillar insertion order (adapter priority, PRD-196).
+4. If every adjusted score is 0, fall back to a locale-independent code-point comparison on `entityName`.
+5. Apply `limit` (clamped to non-negative integer) if provided.
+
+`pillarWeightSettingKey(pillarId)` composes the canonical `core.db.settings` key (`search.pillarWeights.<pillarId>`) so the orchestrator and admin tooling cannot drift.
+
+`mergeResults` is a pure function — no I/O, no settings reads, no default logger. The orchestrator (PRD-197) sources weights from `core.db.settings` and supplies `onWarn` if it wants misconfig warnings surfaced.
 
 ## Business Rules
 
@@ -34,19 +68,24 @@ Algorithm:
 
 ## Edge Cases
 
-| Case                         | Behaviour                                         |
-| ---------------------------- | ------------------------------------------------- |
-| One pillar returns 0 results | Empty contribution; doesn't affect merge.         |
-| All results have score 0     | Sorted alphabetically by entity name as fallback. |
-| Negative weight              | Treated as 0; logged as misconfig.                |
+| Case                              | Behaviour                                                                       |
+| --------------------------------- | ------------------------------------------------------------------------------- |
+| One pillar returns 0 results      | Empty contribution; doesn't affect merge.                                       |
+| All results have score 0          | Sorted by locale-independent code-point comparison on `entityName` as fallback. |
+| Negative weight                   | Treated as 0; warning emitted via `onWarn`.                                     |
+| Non-finite weight (`NaN`, `±Inf`) | Treated as `DEFAULT_PILLAR_WEIGHT`; warning emitted via `onWarn`.               |
+| Non-finite adapter score          | Treated as 0 during normalisation; never produces `NaN` adjusted scores.        |
+| Negative or non-finite `limit`    | Treated as 0 (no `slice(0, -1)` surprise); fractional limits are floored.       |
 
 ## User Stories
 
-| #   | Story                                             | Summary                                      | Status |
-| --- | ------------------------------------------------- | -------------------------------------------- | ------ |
-| 01  | [us-01-merge-impl](us-01-merge-impl.md)           | The weighted-sum merge function              | Done   |
-| 02  | [us-02-settings-tuning](us-02-settings-tuning.md) | Settings key for per-pillar weights          | Done   |
-| 03  | [us-03-tests](us-03-tests.md)                     | Merge tests with various score distributions | Done   |
+| #   | Story                                        | Summary                                                                                  | Status |
+| --- | -------------------------------------------- | ---------------------------------------------------------------------------------------- | ------ |
+| 01  | Merge implementation                         | Weighted-sum merge function with per-pillar normalisation                                | Done   |
+| 02  | Settings key for per-pillar weights          | `pillarWeightSettingKey` helper + `SETTINGS_KEY_PREFIX` constant for `core.db.settings`  | Done   |
+| 03  | Merge tests with various score distributions | Vitest suite covering normalisation, weights, ties, all-zero fallback, limits, misconfig | Done   |
+
+Each story above is implemented and covered by the test suite in `packages/pillar-sdk/src/ranking/__tests__/merge.test.ts`. The PRD is scoped tightly enough that splitting each story into its own doc would be ceremony with no audit value — the acceptance criteria are encoded as tests, not prose.
 
 Shipped in `@pops/pillar-sdk/ranking` (`mergeResults`, `pillarWeightSettingKey`). Consumed by the federated orchestrator (PRD-197) once it lands.
 

--- a/docs/themes/13-pillar-finale/prds/198-ranking-strategy/README.md
+++ b/docs/themes/13-pillar-finale/prds/198-ranking-strategy/README.md
@@ -42,11 +42,13 @@ Algorithm:
 
 ## User Stories
 
-| #   | Story                                             | Summary                                      |
-| --- | ------------------------------------------------- | -------------------------------------------- |
-| 01  | [us-01-merge-impl](us-01-merge-impl.md)           | The weighted-sum merge function              |
-| 02  | [us-02-settings-tuning](us-02-settings-tuning.md) | Settings key for per-pillar weights          |
-| 03  | [us-03-tests](us-03-tests.md)                     | Merge tests with various score distributions |
+| #   | Story                                             | Summary                                      | Status |
+| --- | ------------------------------------------------- | -------------------------------------------- | ------ |
+| 01  | [us-01-merge-impl](us-01-merge-impl.md)           | The weighted-sum merge function              | Done   |
+| 02  | [us-02-settings-tuning](us-02-settings-tuning.md) | Settings key for per-pillar weights          | Done   |
+| 03  | [us-03-tests](us-03-tests.md)                     | Merge tests with various score distributions | Done   |
+
+Shipped in `@pops/pillar-sdk/ranking` (`mergeResults`, `pillarWeightSettingKey`). Consumed by the federated orchestrator (PRD-197) once it lands.
 
 ## Out of Scope
 

--- a/packages/pillar-sdk/package.json
+++ b/packages/pillar-sdk/package.json
@@ -46,6 +46,10 @@
       "types": "./dist/contracts/index.d.ts",
       "default": "./dist/contracts/index.js"
     },
+    "./ranking": {
+      "types": "./dist/ranking/index.d.ts",
+      "default": "./dist/ranking/index.js"
+    },
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/packages/pillar-sdk/src/index.ts
+++ b/packages/pillar-sdk/src/index.ts
@@ -2,6 +2,7 @@ export * from './manifest-schema/index.js';
 export * from './bootstrap/index.js';
 export * from './discovery/index.js';
 export * from './capabilities/index.js';
+export * from './ranking/index.js';
 // NOTE: contracts/ is intentionally NOT re-exported from the root barrel.
 // Re-exporting it would put @pops/finance-contract on the root index.d.ts
 // import graph, forcing every TS consumer (including non-React / non-Node

--- a/packages/pillar-sdk/src/ranking/__tests__/merge.test.ts
+++ b/packages/pillar-sdk/src/ranking/__tests__/merge.test.ts
@@ -178,6 +178,96 @@ describe('mergeResults', () => {
       expect(m.adjustedScore).toBe(1);
     }
   });
+
+  it('falls back to default weight when a configured weight is NaN', () => {
+    const onWarn = vi.fn();
+    const merged = mergeResults(
+      new Map([
+        ['finance', [r(10, 'tx-1')]],
+        ['media', [r(10, 'movie-1')]],
+      ]),
+      {
+        weights: new Map([
+          ['finance', Number.NaN],
+          ['media', 2],
+        ]),
+        onWarn,
+      }
+    );
+
+    expect(onWarn).toHaveBeenCalledOnce();
+    expect(onWarn.mock.calls[0]?.[0]).toContain('finance');
+    expect(onWarn.mock.calls[0]?.[0]).toContain('NaN');
+    const finance = merged.find((m) => m.pillarId === 'finance');
+    expect(finance?.adjustedScore).toBe(DEFAULT_PILLAR_WEIGHT);
+  });
+
+  it('falls back to default weight when a configured weight is Infinity', () => {
+    const onWarn = vi.fn();
+    const merged = mergeResults(new Map([['finance', [r(10, 'tx-1')]]]), {
+      weights: new Map([['finance', Number.POSITIVE_INFINITY]]),
+      onWarn,
+    });
+
+    expect(onWarn).toHaveBeenCalledOnce();
+    const finance = merged.find((m) => m.pillarId === 'finance');
+    expect(finance?.adjustedScore).toBe(DEFAULT_PILLAR_WEIGHT);
+    expect(Number.isFinite(finance?.adjustedScore)).toBe(true);
+  });
+
+  it('treats non-finite adapter scores as 0 instead of producing NaN', () => {
+    const merged = mergeResults(new Map([['finance', [r(Number.NaN, 'tx-nan'), r(10, 'tx-ok')]]]));
+
+    expect(merged.every((m) => Number.isFinite(m.adjustedScore))).toBe(true);
+    expect(merged[0]?.entityName).toBe('tx-ok');
+    expect(merged[0]?.adjustedScore).toBe(1);
+    const nanRow = merged.find((m) => m.entityName === 'tx-nan');
+    expect(nanRow?.adjustedScore).toBe(0);
+  });
+
+  it('returns an empty list when limit is negative (no `slice(0, -1)` surprise)', () => {
+    const merged = mergeResults(new Map([['finance', [r(10, 'a'), r(8, 'b')]]]), {
+      limit: -1,
+    });
+
+    expect(merged).toEqual([]);
+  });
+
+  it('returns an empty list when limit is non-finite', () => {
+    const merged = mergeResults(new Map([['finance', [r(10, 'a'), r(8, 'b')]]]), {
+      limit: Number.NaN,
+    });
+
+    expect(merged).toEqual([]);
+  });
+
+  it('floors fractional limits', () => {
+    const merged = mergeResults(new Map([['finance', [r(10, 'a'), r(8, 'b'), r(6, 'c')]]]), {
+      limit: 2.9,
+    });
+
+    expect(merged.map((m) => m.entityName)).toEqual(['a', 'b']);
+  });
+
+  it('does not invoke a default warning sink (mergeResults stays pure)', () => {
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      mergeResults(new Map([['finance', [r(10, 'tx-1')]]]), {
+        weights: new Map([['finance', -5]]),
+      });
+      expect(consoleWarn).not.toHaveBeenCalled();
+    } finally {
+      consoleWarn.mockRestore();
+    }
+  });
+
+  it('all-zero fallback ordering is deterministic regardless of host locale', () => {
+    const merged = mergeResults(
+      new Map([['finance', [r(0, 'Z'), r(0, 'a'), r(0, 'A'), r(0, 'b')]]])
+    );
+
+    expect(merged.map((m) => m.entityName)).toEqual(['A', 'Z', 'a', 'b']);
+  });
 });
 
 describe('pillarWeightSettingKey', () => {

--- a/packages/pillar-sdk/src/ranking/__tests__/merge.test.ts
+++ b/packages/pillar-sdk/src/ranking/__tests__/merge.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  DEFAULT_PILLAR_WEIGHT,
+  SETTINGS_KEY_PREFIX,
+  mergeResults,
+  pillarWeightSettingKey,
+} from '../merge.js';
+
+import type { ScoredResult } from '../types.js';
+
+function r(score: number, entityName: string, data: unknown = null): ScoredResult {
+  return { score, entityName, data };
+}
+
+describe('mergeResults', () => {
+  it('returns an empty list when every pillar is empty', () => {
+    const merged = mergeResults(
+      new Map([
+        ['finance', []],
+        ['media', []],
+      ])
+    );
+    expect(merged).toEqual([]);
+  });
+
+  it('normalises per pillar so a 100-result pillar cannot dominate a 1-result pillar', () => {
+    const finance: ScoredResult[] = Array.from({ length: 100 }, (_, i) => r(100 - i, `tx-${i}`));
+    const media: ScoredResult[] = [r(0.5, 'movie-A')];
+
+    const merged = mergeResults(
+      new Map([
+        ['finance', finance],
+        ['media', media],
+      ])
+    );
+
+    expect(merged[0]?.pillarId).toBe('finance');
+    expect(merged[0]?.adjustedScore).toBe(1);
+    expect(merged[1]?.pillarId).toBe('media');
+    expect(merged[1]?.adjustedScore).toBe(1);
+    expect(merged).toHaveLength(101);
+  });
+
+  it('applies per-pillar weights', () => {
+    const merged = mergeResults(
+      new Map([
+        ['finance', [r(10, 'tx-1')]],
+        ['media', [r(10, 'movie-1')]],
+      ]),
+      {
+        weights: new Map([
+          ['finance', 2],
+          ['media', 0.5],
+        ]),
+      }
+    );
+
+    expect(merged[0]?.pillarId).toBe('finance');
+    expect(merged[0]?.adjustedScore).toBe(2);
+    expect(merged[1]?.pillarId).toBe('media');
+    expect(merged[1]?.adjustedScore).toBe(0.5);
+  });
+
+  it('defaults missing weights to 1.0', () => {
+    const merged = mergeResults(
+      new Map([
+        ['finance', [r(5, 'tx-1')]],
+        ['media', [r(5, 'movie-1')]],
+      ]),
+      { weights: new Map([['finance', 3]]) }
+    );
+
+    const media = merged.find((m) => m.pillarId === 'media');
+    expect(media?.adjustedScore).toBe(DEFAULT_PILLAR_WEIGHT);
+  });
+
+  it('clamps negative weights to 0 and logs a warning', () => {
+    const onWarn = vi.fn();
+    const merged = mergeResults(
+      new Map([
+        ['finance', [r(10, 'tx-1')]],
+        ['media', [r(10, 'movie-1')]],
+      ]),
+      {
+        weights: new Map([
+          ['finance', -2],
+          ['media', 1],
+        ]),
+        onWarn,
+      }
+    );
+
+    expect(onWarn).toHaveBeenCalledOnce();
+    expect(onWarn.mock.calls[0]?.[0]).toContain('finance');
+    expect(onWarn.mock.calls[0]?.[0]).toContain('-2');
+    expect(merged[0]?.pillarId).toBe('media');
+    const finance = merged.find((m) => m.pillarId === 'finance');
+    expect(finance?.adjustedScore).toBe(0);
+  });
+
+  it('breaks ties on equal adjusted scores by insertion order (adapter priority)', () => {
+    const merged = mergeResults(
+      new Map([
+        ['finance', [r(1, 'tx-1')]],
+        ['media', [r(1, 'movie-1')]],
+        ['inventory', [r(1, 'item-1')]],
+      ])
+    );
+
+    expect(merged.map((m) => m.pillarId)).toEqual(['finance', 'media', 'inventory']);
+  });
+
+  it('falls back to alphabetical entityName when every result is score 0', () => {
+    const merged = mergeResults(
+      new Map([
+        ['finance', [r(0, 'zebra'), r(0, 'apple')]],
+        ['media', [r(0, 'mango')]],
+      ])
+    );
+
+    expect(merged.map((m) => m.entityName)).toEqual(['apple', 'mango', 'zebra']);
+  });
+
+  it('all-zero fallback breaks alphabetical ties by pillar order', () => {
+    const merged = mergeResults(
+      new Map([
+        ['finance', [r(0, 'duplicate')]],
+        ['media', [r(0, 'duplicate')]],
+      ])
+    );
+
+    expect(merged.map((m) => m.pillarId)).toEqual(['finance', 'media']);
+  });
+
+  it('handles an empty pillar without affecting the rest of the merge', () => {
+    const merged = mergeResults(
+      new Map([
+        ['finance', []],
+        ['media', [r(2, 'movie-1')]],
+      ])
+    );
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0]?.pillarId).toBe('media');
+  });
+
+  it('honours the limit option', () => {
+    const merged = mergeResults(
+      new Map([['finance', [r(10, 'a'), r(8, 'b'), r(6, 'c'), r(4, 'd')]]]),
+      { limit: 2 }
+    );
+
+    expect(merged).toHaveLength(2);
+    expect(merged.map((m) => m.entityName)).toEqual(['a', 'b']);
+  });
+
+  it('preserves the raw score on the merged result while exposing the adjusted score separately', () => {
+    const merged = mergeResults(new Map([['finance', [r(42, 'tx-1')]]]), {
+      weights: new Map([['finance', 0.5]]),
+    });
+
+    expect(merged[0]?.score).toBe(42);
+    expect(merged[0]?.adjustedScore).toBe(0.5);
+  });
+
+  it('forwards opaque payload data untouched', () => {
+    const payload = { id: 'tx-1', amount: 99 };
+    const merged = mergeResults(new Map([['finance', [r(5, 'tx-1', payload)]]]));
+
+    expect(merged[0]?.data).toBe(payload);
+  });
+
+  it('handles a pillar where every score is the same non-zero value (normalises all to 1)', () => {
+    const merged = mergeResults(new Map([['finance', [r(7, 'a'), r(7, 'b'), r(7, 'c')]]]));
+
+    for (const m of merged) {
+      expect(m.adjustedScore).toBe(1);
+    }
+  });
+});
+
+describe('pillarWeightSettingKey', () => {
+  it('composes the canonical settings key', () => {
+    expect(pillarWeightSettingKey('finance')).toBe(`${SETTINGS_KEY_PREFIX}finance`);
+    expect(pillarWeightSettingKey('finance')).toBe('search.pillarWeights.finance');
+  });
+});

--- a/packages/pillar-sdk/src/ranking/index.ts
+++ b/packages/pillar-sdk/src/ranking/index.ts
@@ -1,0 +1,14 @@
+/**
+ * `@pops/pillar-sdk/ranking` — cross-pillar ranking strategy (PRD-198).
+ *
+ * Used by the federated search orchestrator (PRD-197) to merge `ScoredResult`
+ * lists from each pillar adapter (PRD-196) into a single ranked response.
+ */
+
+export type { ScoredResult, MergedResult, PillarWeights, MergeOptions } from './types.js';
+export {
+  mergeResults,
+  pillarWeightSettingKey,
+  DEFAULT_PILLAR_WEIGHT,
+  SETTINGS_KEY_PREFIX,
+} from './merge.js';

--- a/packages/pillar-sdk/src/ranking/merge.ts
+++ b/packages/pillar-sdk/src/ranking/merge.ts
@@ -8,11 +8,14 @@
  *  3. Sort descending by adjusted score.
  *  4. Break ties by the pillar's position in the input map (PRD-196 adapter
  *     priority is encoded by insertion order).
- *  5. If every adjusted score is 0, fall back to alphabetical order by
- *     `entityName` (PRD-198 "all results have score 0" edge case).
+ *  5. If every adjusted score is 0, fall back to a locale-independent
+ *     code-point comparison on `entityName` (PRD-198 "all results have
+ *     score 0" edge case). Determinism matters: relying on the runtime
+ *     locale would produce different orderings across environments.
  *
  * Pure function — no I/O, no settings reads. Callers (orchestrator in
- * PRD-197) are responsible for sourcing weights from `core.db.settings`.
+ * PRD-197) are responsible for sourcing weights from `core.db.settings`,
+ * and for passing an `onWarn` sink if they want misconfig warnings surfaced.
  */
 
 import type { MergedResult, MergeOptions, PillarWeights, ScoredResult } from './types.js';
@@ -43,6 +46,12 @@ function resolveWeight(
   onWarn: (message: string) => void
 ): number {
   const raw = weights?.get(pillarId) ?? DEFAULT_PILLAR_WEIGHT;
+  if (!Number.isFinite(raw)) {
+    onWarn(
+      `[ranking] Non-finite weight ${String(raw)} for pillar "${pillarId}" treated as default ${DEFAULT_PILLAR_WEIGHT} (misconfig).`
+    );
+    return DEFAULT_PILLAR_WEIGHT;
+  }
   if (raw < 0) {
     onWarn(`[ranking] Negative weight ${raw} for pillar "${pillarId}" treated as 0 (misconfig).`);
     return 0;
@@ -61,7 +70,7 @@ export function mergeResults(
   perPillarResults: ReadonlyMap<string, readonly ScoredResult[]>,
   options: MergeOptions = {}
 ): MergedResult[] {
-  const { limit, weights, onWarn = console.warn } = options;
+  const { limit, weights, onWarn = noopWarn } = options;
 
   const annotated: AnnotatedResult[] = [];
   let pillarIndex = 0;
@@ -72,12 +81,13 @@ export function mergeResults(
 
     const weight = resolveWeight(pillarId, weights, onWarn);
     const maxScore = results.reduce(
-      (acc, r) => (r.score > acc ? r.score : acc),
+      (acc, r) => (Number.isFinite(r.score) && r.score > acc ? r.score : acc),
       Number.NEGATIVE_INFINITY
     );
 
     for (const result of results) {
-      const normalised = maxScore > 0 ? result.score / maxScore : 0;
+      const safeScore = Number.isFinite(result.score) ? result.score : 0;
+      const normalised = maxScore > 0 ? safeScore / maxScore : 0;
       annotated.push({
         pillarId,
         pillarIndex: currentIndex,
@@ -91,7 +101,7 @@ export function mergeResults(
 
   annotated.sort((a, b) => {
     if (allZero) {
-      const nameCompare = a.original.entityName.localeCompare(b.original.entityName);
+      const nameCompare = compareCodepoints(a.original.entityName, b.original.entityName);
       if (nameCompare !== 0) return nameCompare;
       return a.pillarIndex - b.pillarIndex;
     }
@@ -102,7 +112,8 @@ export function mergeResults(
     return a.pillarIndex - b.pillarIndex;
   });
 
-  const sliced = limit !== undefined ? annotated.slice(0, limit) : annotated;
+  const effectiveLimit = clampLimit(limit);
+  const sliced = effectiveLimit !== undefined ? annotated.slice(0, effectiveLimit) : annotated;
 
   return sliced.map((a) => ({
     pillarId: a.pillarId,
@@ -111,4 +122,21 @@ export function mergeResults(
     data: a.original.data,
     adjustedScore: a.adjustedScore,
   }));
+}
+
+function noopWarn(_message: string): void {
+  /* default sink — see `MergeOptions.onWarn` JSDoc. */
+}
+
+function compareCodepoints(a: string, b: string): number {
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+}
+
+function clampLimit(limit: number | undefined): number | undefined {
+  if (limit === undefined) return undefined;
+  if (!Number.isFinite(limit)) return 0;
+  if (limit < 0) return 0;
+  return Math.floor(limit);
 }

--- a/packages/pillar-sdk/src/ranking/merge.ts
+++ b/packages/pillar-sdk/src/ranking/merge.ts
@@ -1,0 +1,114 @@
+/**
+ * Cross-pillar ranking merge (PRD-198).
+ *
+ * Given per-pillar `ScoredResult[]` lists, produces a single ranked list:
+ *
+ *  1. Normalise each pillar's scores to `[0, 1]` (divide by that pillar's max).
+ *  2. Multiply by `weights.get(pillarId) ?? DEFAULT_PILLAR_WEIGHT`.
+ *  3. Sort descending by adjusted score.
+ *  4. Break ties by the pillar's position in the input map (PRD-196 adapter
+ *     priority is encoded by insertion order).
+ *  5. If every adjusted score is 0, fall back to alphabetical order by
+ *     `entityName` (PRD-198 "all results have score 0" edge case).
+ *
+ * Pure function — no I/O, no settings reads. Callers (orchestrator in
+ * PRD-197) are responsible for sourcing weights from `core.db.settings`.
+ */
+
+import type { MergedResult, MergeOptions, PillarWeights, ScoredResult } from './types.js';
+
+export const DEFAULT_PILLAR_WEIGHT = 1.0;
+
+/** Settings key prefix; consumers compose `${SETTINGS_KEY_PREFIX}${pillarId}`. */
+export const SETTINGS_KEY_PREFIX = 'search.pillarWeights.';
+
+/**
+ * Compose the `core.db.settings` key that carries the weight for a given
+ * pillar. Centralised so the orchestrator and admin tooling cannot drift.
+ */
+export function pillarWeightSettingKey(pillarId: string): string {
+  return `${SETTINGS_KEY_PREFIX}${pillarId}`;
+}
+
+interface AnnotatedResult {
+  readonly pillarId: string;
+  readonly pillarIndex: number;
+  readonly original: ScoredResult;
+  readonly adjustedScore: number;
+}
+
+function resolveWeight(
+  pillarId: string,
+  weights: PillarWeights | undefined,
+  onWarn: (message: string) => void
+): number {
+  const raw = weights?.get(pillarId) ?? DEFAULT_PILLAR_WEIGHT;
+  if (raw < 0) {
+    onWarn(`[ranking] Negative weight ${raw} for pillar "${pillarId}" treated as 0 (misconfig).`);
+    return 0;
+  }
+  return raw;
+}
+
+/**
+ * Merge per-pillar scored results into a single ranked list.
+ *
+ * The input is a `Map` (not a plain object) because insertion order doubles
+ * as the adapter-priority tiebreaker (PRD-196). Callers building the map from
+ * an object should preserve registry order.
+ */
+export function mergeResults(
+  perPillarResults: ReadonlyMap<string, readonly ScoredResult[]>,
+  options: MergeOptions = {}
+): MergedResult[] {
+  const { limit, weights, onWarn = console.warn } = options;
+
+  const annotated: AnnotatedResult[] = [];
+  let pillarIndex = 0;
+
+  for (const [pillarId, results] of perPillarResults) {
+    const currentIndex = pillarIndex++;
+    if (results.length === 0) continue;
+
+    const weight = resolveWeight(pillarId, weights, onWarn);
+    const maxScore = results.reduce(
+      (acc, r) => (r.score > acc ? r.score : acc),
+      Number.NEGATIVE_INFINITY
+    );
+
+    for (const result of results) {
+      const normalised = maxScore > 0 ? result.score / maxScore : 0;
+      annotated.push({
+        pillarId,
+        pillarIndex: currentIndex,
+        original: result,
+        adjustedScore: normalised * weight,
+      });
+    }
+  }
+
+  const allZero = annotated.every((a) => a.adjustedScore === 0);
+
+  annotated.sort((a, b) => {
+    if (allZero) {
+      const nameCompare = a.original.entityName.localeCompare(b.original.entityName);
+      if (nameCompare !== 0) return nameCompare;
+      return a.pillarIndex - b.pillarIndex;
+    }
+
+    if (a.adjustedScore !== b.adjustedScore) {
+      return b.adjustedScore - a.adjustedScore;
+    }
+    return a.pillarIndex - b.pillarIndex;
+  });
+
+  const sliced = limit !== undefined ? annotated.slice(0, limit) : annotated;
+
+  return sliced.map((a) => ({
+    pillarId: a.pillarId,
+    score: a.original.score,
+    entityName: a.original.entityName,
+    data: a.original.data,
+    adjustedScore: a.adjustedScore,
+  }));
+}

--- a/packages/pillar-sdk/src/ranking/types.ts
+++ b/packages/pillar-sdk/src/ranking/types.ts
@@ -1,0 +1,75 @@
+/**
+ * Shared types for the cross-pillar ranking strategy (PRD-198).
+ *
+ * The federated search orchestrator (PRD-197) fans a query out to every
+ * registered pillar adapter (PRD-196), collects per-pillar `ScoredResult[]`
+ * lists, then hands them to `mergeResults` for cross-pillar ranking.
+ */
+
+/**
+ * A single search hit returned by a pillar adapter. The shape is intentionally
+ * minimal — the orchestrator does not need to understand pillar-specific
+ * payloads to rank them, only the score and a stable name for fallback
+ * ordering.
+ */
+export interface ScoredResult {
+  /**
+   * Raw relevance score returned by the owning pillar's adapter. Scale is
+   * pillar-defined; the merge step normalises per-pillar so adapters are free
+   * to use whatever range they like.
+   */
+  readonly score: number;
+  /**
+   * Stable entity name used as the alphabetical tie-breaker when every result
+   * in the merge set has score 0.
+   */
+  readonly entityName: string;
+  /**
+   * Arbitrary payload forwarded to the caller untouched. Type is unknown
+   * because each pillar returns a different shape; the orchestrator (PRD-197)
+   * is responsible for typing the consumer-facing union.
+   */
+  readonly data: unknown;
+}
+
+/**
+ * The merged result carries the pillar id alongside the original payload so
+ * the caller can section results, attribute hits, and recover the adapter
+ * that produced each row.
+ */
+export interface MergedResult extends ScoredResult {
+  /** Pillar id the result came from — matches a key of the input map. */
+  readonly pillarId: string;
+  /**
+   * Adjusted score after per-pillar normalisation + weight application. Kept
+   * for transparency (debugging / UI tooltips). Always in `[0, 1 * weight]`.
+   */
+  readonly adjustedScore: number;
+}
+
+/**
+ * Per-pillar weights, typically sourced from `core.db.settings` under
+ * `search.pillarWeights.<pillarId>`. A pillar not present in the map gets the
+ * default weight (1.0). Negative weights are treated as 0 and a warning is
+ * logged (see `mergeResults`).
+ */
+export type PillarWeights = ReadonlyMap<string, number>;
+
+export interface MergeOptions {
+  /**
+   * Optional cap on the number of results returned. When omitted, all merged
+   * results are returned in ranked order.
+   */
+  readonly limit?: number;
+  /**
+   * Per-pillar weight overrides. Missing entries default to
+   * `DEFAULT_PILLAR_WEIGHT` (1.0).
+   */
+  readonly weights?: PillarWeights;
+  /**
+   * Sink for misconfiguration warnings (e.g. negative weights). Defaults to
+   * `console.warn`; tests inject a spy to assert the message without polluting
+   * stdout.
+   */
+  readonly onWarn?: (message: string) => void;
+}

--- a/packages/pillar-sdk/src/ranking/types.ts
+++ b/packages/pillar-sdk/src/ranking/types.ts
@@ -50,15 +50,18 @@ export interface MergedResult extends ScoredResult {
 /**
  * Per-pillar weights, typically sourced from `core.db.settings` under
  * `search.pillarWeights.<pillarId>`. A pillar not present in the map gets the
- * default weight (1.0). Negative weights are treated as 0 and a warning is
- * logged (see `mergeResults`).
+ * default weight (1.0). Negative weights are treated as 0; non-finite weights
+ * (`NaN`, `±Infinity`) fall back to the default weight. Both cases emit a
+ * warning through `MergeOptions.onWarn` (see `mergeResults`).
  */
 export type PillarWeights = ReadonlyMap<string, number>;
 
 export interface MergeOptions {
   /**
    * Optional cap on the number of results returned. When omitted, all merged
-   * results are returned in ranked order.
+   * results are returned in ranked order. Negative or non-finite limits are
+   * treated as 0 (no `slice(0, -1)` "all but the last" surprise); fractional
+   * limits are floored.
    */
   readonly limit?: number;
   /**
@@ -67,9 +70,10 @@ export interface MergeOptions {
    */
   readonly weights?: PillarWeights;
   /**
-   * Sink for misconfiguration warnings (e.g. negative weights). Defaults to
-   * `console.warn`; tests inject a spy to assert the message without polluting
-   * stdout.
+   * Sink for misconfiguration warnings (e.g. negative or non-finite weights).
+   * Defaults to a no-op so `mergeResults` stays a pure function with no I/O —
+   * callers that care about warnings (the orchestrator in PRD-197, tests) must
+   * inject their own logger / spy.
    */
   readonly onWarn?: (message: string) => void;
 }


### PR DESCRIPTION
## Summary

Implements [PRD-198: Ranking strategy](docs/themes/13-pillar-finale/prds/198-ranking-strategy/README.md) — the cross-pillar merge algorithm for federated search.

Adds `@pops/pillar-sdk/ranking`:

- `mergeResults(perPillarResults, options?)` — pure weighted-sum merger
  - Per-pillar normalisation to `[0, 1]` (divide by max) so a chatty pillar cannot dominate a sparse one
  - Multiply by per-pillar weight (default `1.0`); negative weights clamp to `0` with a warning
  - Tie-break by adapter priority (insertion order of the input map — matches PRD-196's adapter priority)
  - All-zero-score fallback: alphabetical by `entityName`
- `pillarWeightSettingKey(pillarId)` returning `search.pillarWeights.<pillar>` — single source of truth for the settings key used by the orchestrator and admin tooling
- Pure: no I/O, no settings reads. The federated orchestrator (PRD-197) will source weights from `core.db.settings` and pass them in

## Scope

PRD-198 was small and self-contained — a pure function + tests + a settings key constant. PRD-197 (federated orchestrator) and PRD-196 (search adapter manifest) are still pending and consume this independently.

## Test plan

- [x] `pnpm --filter @pops/pillar-sdk test` — 14 new tests for the merge algorithm (normalisation, weights, tiebreakers, all-zero fallback, empty pillars, limit, payload pass-through, negative-weight warning), 301 total in the package, all green
- [x] `pnpm --filter @pops/pillar-sdk typecheck` — clean
- [x] `pnpm --filter @pops/pillar-sdk build` — clean
- [x] Repo-wide `turbo` pre-push hook — 66/66 tasks green
