### PR TITLE
docs(theme-13): PRD-227 SDK consumer migration audit

### DIFF
--- a/docs/themes/13-pillar-finale/IMPLEMENTATION-PLAN.md
+++ b/docs/themes/13-pillar-finale/IMPLEMENTATION-PLAN.md
@@ -133,24 +133,25 @@ Five waves. Each wave is a set of PRDs that can ship concurrently. Waves are gat
 
 **Goal:** repartition load-bearing cross-pillar code; FE registry-aware end-to-end.
 
-| PRD                                | Parallelism                     | Owner agent                     |
-| ---------------------------------- | ------------------------------- | ------------------------------- |
-| 196 search adapter manifest        | follows Wave 2 (registry alive) | `a:search-manifest`             |
-| 197 federated query orchestrator   | follows 196                     | `a:search-orchestrator`         |
-| 198 ranking strategy               | follows 197                     | `a:ranking`                     |
-| 199 partial failure semantics      | follows 197                     | `a:partial-failure`             |
-| 200 AI tool manifest               | follows Wave 2                  | `a:ai-manifest`                 |
-| 201 dynamic tool list              | follows 200                     | `a:dynamic-tools`               |
-| 202 tool call routing              | follows 201                     | `a:tool-routing`                |
-| 207 ADR-029 decision matrix        | follows Wave 3                  | `a:adr-029`                     |
-| 208 search orchestrator relocation | follows 207 + 197               | `a:search-api-container`        |
-| 209 AI orchestrator relocation     | follows 207 + 202               | `a:ai-api-container`            |
-| 210 worker partitioning audit      | follows 207 + Wave 3            | `a:worker-audit`                |
-| 211 URI dispatcher relocation      | follows 207                     | `a:uri-dispatcher`              |
-| 215 React SDK                      | follows Wave 2                  | `a:react-sdk`                   |
-| 216 PillarGuard rewrite            | follows 215                     | `a:pillar-guard`                |
-| 217 nginx config generator         | follows Wave 3                  | `a:nginx-gen`                   |
-| 218 module-registry deprecation    | follows 215                     | `a:module-registry-deprecation` |
+| PRD                                | Parallelism                      | Owner agent                     |
+| ---------------------------------- | -------------------------------- | ------------------------------- |
+| 196 search adapter manifest        | follows Wave 2 (registry alive)  | `a:search-manifest`             |
+| 197 federated query orchestrator   | follows 196                      | `a:search-orchestrator`         |
+| 198 ranking strategy               | follows 197                      | `a:ranking`                     |
+| 199 partial failure semantics      | follows 197                      | `a:partial-failure`             |
+| 200 AI tool manifest               | follows Wave 2                   | `a:ai-manifest`                 |
+| 201 dynamic tool list              | follows 200                      | `a:dynamic-tools`               |
+| 202 tool call routing              | follows 201                      | `a:tool-routing`                |
+| 207 ADR-029 decision matrix        | follows Wave 3                   | `a:adr-029`                     |
+| 208 search orchestrator relocation | follows 207 + 197                | `a:search-api-container`        |
+| 209 AI orchestrator relocation     | follows 207 + 202                | `a:ai-api-container`            |
+| 210 worker partitioning audit      | follows 207 + Wave 3             | `a:worker-audit`                |
+| 211 URI dispatcher relocation      | follows 207                      | `a:uri-dispatcher`              |
+| 215 React SDK                      | follows Wave 2                   | `a:react-sdk`                   |
+| 216 PillarGuard rewrite            | follows 215                      | `a:pillar-guard`                |
+| 217 nginx config generator         | follows Wave 3                   | `a:nginx-gen`                   |
+| 218 module-registry deprecation    | follows 215                      | `a:module-registry-deprecation` |
+| 227 SDK consumer migration audit   | follows Wave 2 (parallel w/ 215) | `a:sdk-consumer-audit`          |
 
 **Wave 4 exit criteria:**
 
@@ -397,6 +398,7 @@ Status legend: ⏳ Not started · 🔄 In progress · ✅ Done · ⛔ Blocked
 | 224     | ci-e2e-scoping                   | 3    | ⏳     | 221                    | CI leanness wave 3             |
 | 225     | ci-publish-narrowing             | 4    | ⏳     | 221                    | CI leanness wave 4             |
 | 226     | ci-budget-enforcement            | 5    | ⏳     | 220-225                | CI leanness wave 5             |
+| 227     | sdk-consumer-migration-audit     | 4    | ⏳     | 193, 215               | FE + Node `pillar()` rollout   |
 
 ---
 

--- a/docs/themes/13-pillar-finale/epics/10-fe-sdk-dispatcher-generator.md
+++ b/docs/themes/13-pillar-finale/epics/10-fe-sdk-dispatcher-generator.md
@@ -18,6 +18,7 @@ Make the front-end registry-aware end-to-end. Three pieces:
 | 216 | `PillarGuard` rewrite               | Reads live registry; subscribes to changes; per-route unavailable placeholders               | Not started |
 | 217 | nginx config generator              | Generated `default.conf` from registry snapshot; init container OR sidecar strategy          | Not started |
 | 218 | `@pops/module-registry` deprecation | The build-time registry becomes a thin wrapper around the runtime one (offline-dev fallback) | Not started |
+| 227 | SDK consumer migration audit        | Punch list of every `trpc.*` consumer with its `pillar()` migration target + preconditions   | Not started |
 
 ## Dependencies
 

--- a/docs/themes/13-pillar-finale/prds/227-sdk-consumer-migration-audit/README.md
+++ b/docs/themes/13-pillar-finale/prds/227-sdk-consumer-migration-audit/README.md
@@ -53,7 +53,7 @@ Each `app-*` package migrates as a single PR per pillar once its writer move PR 
 
 | Tool file                        | Calls                                        | Target                                                   | Blocker                                                        |
 | -------------------------------- | -------------------------------------------- | -------------------------------------------------------- | -------------------------------------------------------------- |
-| `tools/inventory-locations.ts`   | 7× `inventory.locations.*`                   | `pillar('inventory').locations.*`                        | none — manifest covers full surface                            |
+| `tools/inventory-locations.ts`   | 5× `inventory.locations.*`                   | `pillar('inventory').locations.*`                        | `core.registry.snapshot` precondition (PRD-161 alignment)      |
 | `tools/inventory-items.ts`       | `inventory.items.*` read                     | `pillar('inventory').items.*`                            | inventory-api items module migration                           |
 | `tools/inventory-items-write.ts` | `inventory.items.{create,update,…}`          | `pillar('inventory').items.*`                            | inventory-api items module migration                           |
 | `tools/inventory-fixtures*.ts`   | `inventory.fixtures.*`                       | `pillar('inventory').fixtures.*`                         | inventory-api fixtures module migration                        |

--- a/docs/themes/13-pillar-finale/prds/227-sdk-consumer-migration-audit/README.md
+++ b/docs/themes/13-pillar-finale/prds/227-sdk-consumer-migration-audit/README.md
@@ -1,0 +1,130 @@
+# PRD-227: SDK consumer migration audit
+
+> Epic: [FE pillar SDK + dispatcher generator](../../epics/10-fe-sdk-dispatcher-generator.md)
+
+## Overview
+
+Catalogue every call site that currently issues HTTP / tRPC against a per-pillar router and assign each one a migration target on the unified `@pops/pillar-sdk` consumption surface (PRD-191 client, PRD-192 server, PRD-193 React hooks). Records preconditions so the consumer migrations can be parallelised against the right wave gate.
+
+## Data Model
+
+No persistent data. The deliverable is the punch list below plus the per-PR migration tickets it spawns.
+
+## API Surface
+
+| SDK surface         | Source                              | Used by                              |
+| ------------------- | ----------------------------------- | ------------------------------------ |
+| `pillar()`          | `@pops/pillar-sdk/client` (PRD-191) | Node consumers (workers, MCP, CLI)   |
+| `pillar()` + auth   | `@pops/pillar-sdk/server` (PRD-192) | Sibling-pillar containers, search/AI |
+| `usePillarQuery`    | `@pops/pillar-sdk/react` (PRD-193)  | `pops-shell`, `packages/app-*`       |
+| `usePillarMutation` | `@pops/pillar-sdk/react` (PRD-193)  | `pops-shell`, `packages/app-*`       |
+| `PillarSdkProvider` | `@pops/pillar-sdk/react` (PRD-215)  | `pops-shell` root                    |
+
+## Consumer punch list
+
+### Frontend — `apps/pops-shell/src/`
+
+| Call site                                          | Current                                  | Target                                                      | Blocker                                  |
+| -------------------------------------------------- | ---------------------------------------- | ----------------------------------------------------------- | ---------------------------------------- |
+| `app/IndexRedirect.tsx`                            | `trpc.core.shell.manifest.useQuery`      | `usePillarQuery('core', ['shell','manifest'], undefined)`   | core writer move complete                |
+| `app/capture/CaptureHotkeyHost.tsx`                | `trpc.core.settings.get.useQuery`        | `usePillarQuery('core', ['settings','get'], { key })`       | core writer move                         |
+| `app/layout/top-bar/NudgeIndicator.tsx`            | `trpc.cerebrum.nudges.list.useQuery`     | `usePillarQuery('cerebrum', ['nudges','list'], …)`          | none — `cerebrum-api` already owns route |
+| `app/pages/features-page/use-feature-mutations.ts` | 3× `trpc.core.features.*.useMutation`    | `usePillarMutation('core', ['features',…])`                 | core writer move                         |
+| `app/pages/features-page/FeaturesPage.tsx`         | 2× `trpc.core.features.*.useQuery`       | `usePillarQuery('core', …)`                                 | core writer move                         |
+| `components/settings/SectionRenderer.tsx`          | `trpc.core.settings.getBulk` + `setBulk` | `usePillarQuery` + `usePillarMutation` on `core`            | core writer move                         |
+| `lib/use-feature-enabled.ts`                       | `trpc.core.features.isEnabled.useQuery`  | `usePillarQuery('core', ['features','isEnabled'], { key })` | core writer move                         |
+
+### Frontend — `packages/app-*`
+
+Total surface (raw `trpc.<pillar>.*` references): **453**.
+
+| Package         | Call sites | Pillars touched    | Blockers                                   |
+| --------------- | ---------: | ------------------ | ------------------------------------------ |
+| `app-finance`   |       ~110 | `finance` (mostly) | finance writer move complete — migrate now |
+| `app-media`     |       ~140 | `media`            | media writer cutover — Wave 3              |
+| `app-food`      |        ~80 | `food`             | food writer cutover — Wave 3               |
+| `app-inventory` |        ~50 | `inventory`        | inventory writer cutover — Wave 3          |
+| `app-cerebrum`  |        ~50 | `cerebrum`         | cerebrum writer cutover — Wave 3           |
+| `app-lists`     |        ~25 | `lists`            | lists writer cutover — Wave 3              |
+
+Each `app-*` package migrates as a single PR per pillar once its writer move PR lands.
+
+### Node — `apps/pops-mcp/src/`
+
+| Tool file                        | Calls                                        | Target                                                   | Blocker                                                        |
+| -------------------------------- | -------------------------------------------- | -------------------------------------------------------- | -------------------------------------------------------------- |
+| `tools/inventory-locations.ts`   | 7× `inventory.locations.*`                   | `pillar('inventory').locations.*`                        | none — manifest covers full surface                            |
+| `tools/inventory-items.ts`       | `inventory.items.*` read                     | `pillar('inventory').items.*`                            | inventory-api items module migration                           |
+| `tools/inventory-items-write.ts` | `inventory.items.{create,update,…}`          | `pillar('inventory').items.*`                            | inventory-api items module migration                           |
+| `tools/inventory-fixtures*.ts`   | `inventory.fixtures.*`                       | `pillar('inventory').fixtures.*`                         | inventory-api fixtures module migration                        |
+| `tools/inventory-connections.ts` | `inventory.connections.*`                    | `pillar('inventory').connections.*`                      | inventory-api connections migration                            |
+| `tools/cerebrum.ts`              | `cerebrum.engrams.*`, `…retrieval.*`         | `pillar('cerebrum').engrams.*`, `retrieval.*`            | engrams + retrieval not in cerebrum-api yet                    |
+| `tools/finance.ts`               | `finance.*` reads                            | `pillar('finance').…`                                    | finance writer move complete — migrate now                     |
+| `tools/media.ts`                 | `media.*`                                    | `pillar('media').…`                                      | media writer cutover                                           |
+| `client.ts` (shared)             | `createTRPCClient<AppRouter>` w/ `x-api-key` | replace with `pillar()` factory wired with `authHeaders` | requires `core.registry.snapshot` to exist (PRD-161 alignment) |
+
+### Node — `apps/pops-worker-food/src/`
+
+| Call site       | Calls                        | Target                                 | Blocker                                |
+| --------------- | ---------------------------- | -------------------------------------- | -------------------------------------- |
+| `api-client.ts` | `food.ingest.workerComplete` | `pillar('food').ingest.workerComplete` | `food.ingest.*` still in pops-api mono |
+
+### Node — `apps/pops-api/src/cli/`
+
+| Call site        | Calls                                 | Target                            | Blocker                              |
+| ---------------- | ------------------------------------- | --------------------------------- | ------------------------------------ |
+| `cli/ego.ts`     | `core.embeddings.query` (and similar) | `pillar('core').embeddings.query` | core writer move + registry endpoint |
+| `cli/capture.ts` | `core.entities.*`, `core.uri.handle`  | `pillar('core').…`                | core writer move + registry endpoint |
+
+### Node — sibling-pillar fan-out (server SDK)
+
+Today: zero sibling-pillar fan-out goes through `pillar()`. Each pillar API still reaches sibling data via shared SQLite handles or via pops-api round-trips.
+
+| Surface                                              | Target                                               | Blocker                                              |
+| ---------------------------------------------------- | ---------------------------------------------------- | ---------------------------------------------------- |
+| `pops-search-api` federated query (Epic 06, PRD-197) | `pillar('media').search`, `pillar('food').search`, … | PRDs 196–199 — server-SDK call shape is the contract |
+| `pops-ai-api` tool routing (Epic 07, PRD-202)        | `pillar('<id>').<tool>`                              | PRDs 200–202 — same                                  |
+
+## Preconditions
+
+- **`core.registry.snapshot`** must exist in `pops-core-api`. The SDK's `HttpDiscoveryTransport` calls `core.registry.snapshot`; today `pops-core-api` exposes `core.registry.list` instead. Either align the SDK to `list` or expose `snapshot` — pick one before any consumer adopts `pillar()`.
+- **Browser-reachable `baseUrl`s.** Registry entries currently advertise container-network origins (e.g. `http://cerebrum-api:3007`). The browser cannot reach those. The SDK on the FE needs either a transport that rewrites `baseUrl` to the `/trpc-<id>` nginx prefix, or the registry must publish browser-side URLs alongside the container ones.
+- **URL shape parity with nginx dispatcher.** The SDK builds `${baseUrl}/trpc/${pillarId}.${path}`. The dispatcher rewrites `/trpc-<id>/(.*)$ → /trpc/$1`. With `baseUrl = '/trpc-<id>'` the result is `/trpc-<id>/trpc/<path>` which double-prefixes. The SDK should either drop the `/trpc/` segment when `baseUrl` already names a tRPC mount, or the FE-side `baseUrl` must be `''` (pointing at the legacy pops-api mono) until per-pillar dispatcher rules align.
+
+## Migration order
+
+1. Land `core.registry.snapshot` (or align SDK to `list`).
+2. Land `PillarSdkProvider` in `pops-shell` root with a transport that knows about browser-reachable URLs.
+3. Migrate one read-only FE component as the canary (recommended: `NudgeIndicator` because cerebrum-api owns the route and the call has no side effects).
+4. Wave 4 in parallel — one PR per `app-*` package against its pillar.
+5. Node side: migrate `pops-mcp` (one tool file per PR), `pops-worker-food`, and `apps/pops-api/cli/` once their target routes leave the mono.
+6. Retire the `@pops/api-client` `splitLink` once every FE call site uses hooks (PRD-218 territory).
+
+## Business Rules
+
+- One PR per consumer file. No PR mixes shell wiring with consumer migration.
+- Canary FE migration ships behind no flag — the call replaces the existing `trpc.*` invocation atomically.
+- Tests that mock the old tRPC client are updated alongside the migration; no dual-client mocks.
+
+## Edge Cases
+
+| Case                                                | Behaviour                                                                                                                                                                                   |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Pillar manifest does not advertise the called route | SDK returns `{ kind: 'contract-mismatch' }`; the React hook surfaces `isContractMismatch`. The component must render a fallback or the call needs to wait for the pillar to ship the route. |
+| Registry snapshot is stale                          | Discovery cache TTL (default 60s) hides churn; the subscription bridge invalidates on `pillar.registered` / `pillar.deregistered` events.                                                   |
+| Auth header missing                                 | `pops-mcp` and `pops-worker-food` must thread `authHeaders` through the SDK options. Failure surfaces as `kind: 'unavailable'`.                                                             |
+
+## User Stories
+
+| #   | Story                                       | Summary                                                                     | Parallelisable           |
+| --- | ------------------------------------------- | --------------------------------------------------------------------------- | ------------------------ |
+| 01  | [us-01-shell-wiring](us-01-shell-wiring.md) | Add `PillarSdkProvider` to `pops-shell` with a browser-reachable transport. | Blocked by preconditions |
+| 02  | [us-02-fe-canary](us-02-fe-canary.md)       | Migrate `NudgeIndicator.tsx` to `usePillarQuery` as the FE canary.          | Blocked by us-01         |
+| 03  | [us-03-mcp-canary](us-03-mcp-canary.md)     | Migrate one `pops-mcp` tool file (`inventory-locations.ts`) to `pillar()`.  | Blocked by preconditions |
+
+## Out of Scope
+
+- Renaming `core.corrections.*` / `core.tagRules.*` to `finance.*` (PRDs 203–205 own that).
+- nginx dispatcher generation (PRD-217).
+- `PillarGuard` rewrite (PRD-216).
+- New pillar routes — this PRD only repoints existing calls.

--- a/docs/themes/13-pillar-finale/prds/227-sdk-consumer-migration-audit/us-01-shell-wiring.md
+++ b/docs/themes/13-pillar-finale/prds/227-sdk-consumer-migration-audit/us-01-shell-wiring.md
@@ -1,0 +1,20 @@
+# US-01: Wire `PillarSdkProvider` into `pops-shell`
+
+> PRD: [SDK consumer migration audit](README.md)
+
+## Description
+
+As a shell developer, I want a `PillarSdkProvider` mounted at the root of `pops-shell` so that any component can pull data through `usePillarQuery` / `usePillarMutation` without each call site reconstructing transport, auth headers, or registry config.
+
+## Acceptance Criteria
+
+- [ ] `apps/pops-shell/src/app/App.tsx` mounts `<PillarSdkProvider>` inside the existing `<QueryClientProvider>` and outside `<PillarStatusProvider>`.
+- [ ] The provider is configured with a `DiscoveryTransport` that consults a browser-reachable URL (`/pillars/snapshot` or equivalent) and yields entries whose `baseUrl` resolves through nginx to the matching pillar API.
+- [ ] `authHeaders` forwards the session cookie / `X-API-Key` for parity with the existing `@pops/api-client` chain.
+- [ ] Subscription bridge is enabled (`subscribe: true`) so registry events invalidate React Query caches under the matching pillar prefix.
+- [ ] A vitest in `apps/pops-shell/src/app/__tests__/` confirms that a child component calling `usePillarQuery` receives the seeded transport's data (no real HTTP).
+- [ ] `pnpm --filter @pops/shell typecheck` + `pnpm --filter @pops/shell test` pass.
+
+## Notes
+
+The transport wrapper lives in `apps/pops-shell/src/lib/pillar-sdk-transport.ts` so it's reusable for tests. It depends on `core.registry.snapshot` (or `core.registry.list` if the SDK is realigned). The wrapper must map registry `baseUrl` container-network origins to the `/trpc-<id>` browser path. Do **not** import from `@pops/pillar-sdk/server` — the shell is a browser bundle.

--- a/docs/themes/13-pillar-finale/prds/227-sdk-consumer-migration-audit/us-01-shell-wiring.md
+++ b/docs/themes/13-pillar-finale/prds/227-sdk-consumer-migration-audit/us-01-shell-wiring.md
@@ -10,7 +10,7 @@ As a shell developer, I want a `PillarSdkProvider` mounted at the root of `pops-
 
 - [ ] `apps/pops-shell/src/app/App.tsx` mounts `<PillarSdkProvider>` inside the existing `<QueryClientProvider>` and outside `<PillarStatusProvider>`.
 - [ ] The provider is configured with a `DiscoveryTransport` that consults a browser-reachable URL (`/pillars/snapshot` or equivalent) and yields entries whose `baseUrl` resolves through nginx to the matching pillar API.
-- [ ] `authHeaders` forwards the session cookie / `X-API-Key` for parity with the existing `@pops/api-client` chain.
+- [ ] SDK requests stay same-origin (routed through nginx) so the browser sends the session cookie automatically; `authHeaders` is reserved for `X-API-Key` (and similar non-cookie credentials) for parity with the existing `@pops/api-client` chain.
 - [ ] Subscription bridge is enabled (`subscribe: true`) so registry events invalidate React Query caches under the matching pillar prefix.
 - [ ] A vitest in `apps/pops-shell/src/app/__tests__/` confirms that a child component calling `usePillarQuery` receives the seeded transport's data (no real HTTP).
 - [ ] `pnpm --filter @pops/shell typecheck` + `pnpm --filter @pops/shell test` pass.

--- a/docs/themes/13-pillar-finale/prds/227-sdk-consumer-migration-audit/us-02-fe-canary.md
+++ b/docs/themes/13-pillar-finale/prds/227-sdk-consumer-migration-audit/us-02-fe-canary.md
@@ -1,0 +1,20 @@
+# US-02: FE canary — migrate `NudgeIndicator` to `usePillarQuery`
+
+> PRD: [SDK consumer migration audit](README.md)
+
+## Description
+
+As a shell developer, I want one production component to consume the cerebrum nudges endpoint through `usePillarQuery` so the migration pattern is exercised end-to-end before fanning out to the rest of `app-*`.
+
+## Acceptance Criteria
+
+- [ ] `apps/pops-shell/src/app/layout/top-bar/NudgeIndicator.tsx` replaces the `trpc.cerebrum.nudges.list.useQuery(...)` call with `usePillarQuery('cerebrum', ['nudges', 'list'], { status: 'pending', limit: 1 }, { … })`.
+- [ ] The retry / staleTime / refetchInterval options carry over verbatim.
+- [ ] Existing `nudgeRefetchInterval` helper continues to receive the React Query `query` argument shape unchanged.
+- [ ] When the cerebrum pillar is `unavailable` or returns `contract-mismatch`, the indicator hides instead of crashing — covered by a new vitest.
+- [ ] The component test in `apps/pops-shell/src/app/layout/top-bar/__tests__/NudgeIndicator.test.tsx` exercises both the success path (1 pending nudge → badge renders) and the failure path (SDK returns `unavailable` → no badge).
+- [ ] `pnpm --filter @pops/shell typecheck` + `pnpm --filter @pops/shell test` pass.
+
+## Notes
+
+Choice of canary: `cerebrum.nudges.list` is the only FE call whose target pillar (`cerebrum-api`) already advertises the route in its registry manifest. The other shell calls hit `core.*` which still lives in pops-api.

--- a/docs/themes/13-pillar-finale/prds/227-sdk-consumer-migration-audit/us-03-mcp-canary.md
+++ b/docs/themes/13-pillar-finale/prds/227-sdk-consumer-migration-audit/us-03-mcp-canary.md
@@ -8,7 +8,7 @@ As an MCP maintainer, I want the locations tool file to call `pillar('inventory'
 
 ## Acceptance Criteria
 
-- [ ] `apps/pops-mcp/src/tools/inventory-locations.ts` stops importing `getClient` for every handler and instead calls `pillar('inventory', { authHeaders: () => ({ 'x-api-key': POPS_API_KEY }) }).locations.<proc>.orThrow(input)`.
+- [ ] `apps/pops-mcp/src/tools/inventory-locations.ts` stops calling `getClient()` inside every handler and instead calls `pillar('inventory', { authHeaders: () => ({ 'x-api-key': POPS_API_KEY }) }).locations.<proc>.orThrow(input)`.
 - [ ] The factory configuration (registry URL, auth headers) is centralised in a new `apps/pops-mcp/src/pillar-client.ts` so the other tool files can adopt it incrementally.
 - [ ] `apps/pops-mcp/src/tools/inventory-locations.test.ts` is rewritten to mock `pillar()` instead of `getClient` (a `@pops/pillar-sdk/testing/discovery` fake transport is acceptable).
 - [ ] Failure shapes (`unavailable`, `contract-mismatch`) surface as MCP `toolError` results with a descriptive message — verified by tests.
@@ -17,4 +17,4 @@ As an MCP maintainer, I want the locations tool file to call `pillar('inventory'
 
 ## Notes
 
-Blocker: this work cannot start until `core.registry.snapshot` resolves on `pops-core-api` (see PRD-227 preconditions). The `inventory.locations.*` manifest entries on `pops-inventory-api` already cover every procedure this file calls (tree, list, get, create, update, delete), so once the registry is healthy this tool file is a one-PR cut.
+Blocker: this work cannot start until `core.registry.snapshot` resolves on `pops-core-api` (see PRD-227 preconditions). The `inventory.locations.*` manifest entries on `pops-inventory-api` already cover every procedure this file calls (tree, list, create, update, delete), so once the registry is healthy this tool file is a one-PR cut.

--- a/docs/themes/13-pillar-finale/prds/227-sdk-consumer-migration-audit/us-03-mcp-canary.md
+++ b/docs/themes/13-pillar-finale/prds/227-sdk-consumer-migration-audit/us-03-mcp-canary.md
@@ -1,0 +1,20 @@
+# US-03: MCP canary — migrate `inventory-locations.ts` to `pillar()`
+
+> PRD: [SDK consumer migration audit](README.md)
+
+## Description
+
+As an MCP maintainer, I want the locations tool file to call `pillar('inventory').locations.*` instead of the merged `pops-api` tRPC client so the SDK pattern is proven on the Node side before fanning out across the remaining MCP / CLI tool files.
+
+## Acceptance Criteria
+
+- [ ] `apps/pops-mcp/src/tools/inventory-locations.ts` stops importing `getClient` for every handler and instead calls `pillar('inventory', { authHeaders: () => ({ 'x-api-key': POPS_API_KEY }) }).locations.<proc>.orThrow(input)`.
+- [ ] The factory configuration (registry URL, auth headers) is centralised in a new `apps/pops-mcp/src/pillar-client.ts` so the other tool files can adopt it incrementally.
+- [ ] `apps/pops-mcp/src/tools/inventory-locations.test.ts` is rewritten to mock `pillar()` instead of `getClient` (a `@pops/pillar-sdk/testing/discovery` fake transport is acceptable).
+- [ ] Failure shapes (`unavailable`, `contract-mismatch`) surface as MCP `toolError` results with a descriptive message — verified by tests.
+- [ ] `POPS_REGISTRY_URL` env var is documented in `apps/pops-mcp/README.md` (default `http://core-api:3001`).
+- [ ] `pnpm --filter @pops/mcp typecheck` + `pnpm --filter @pops/mcp test` pass.
+
+## Notes
+
+Blocker: this work cannot start until `core.registry.snapshot` resolves on `pops-core-api` (see PRD-227 preconditions). The `inventory.locations.*` manifest entries on `pops-inventory-api` already cover every procedure this file calls (tree, list, get, create, update, delete), so once the registry is healthy this tool file is a one-PR cut.


### PR DESCRIPTION
## Summary

- Scaffolds PRD-227 cataloguing every `trpc.*` / direct-fetch consumer with its `@pops/pillar-sdk` (PRD-191/192/193) migration target, blockers, and order
- Three canary user stories: shell wiring (US-01), FE `NudgeIndicator` swap (US-02), MCP `inventory-locations.ts` swap (US-03)
- Hooks the PRD into Epic 10 and the implementation plan as Wave 4, depending on PRDs 193 + 215

## Highlights from the audit

- **FE shell**: 7 call sites (mostly `core.*`) — all but `NudgeIndicator` blocked on the core writer move
- **app-* packages**: 453 raw `trpc.<pillar>.*` references across 6 packages — each migrates as one PR per pillar after its writer cutover
- **Node**: `pops-mcp` (12 tool files), `pops-worker-food`, `pops-api/cli/*`. Blocked on `core.registry.snapshot` (today core-api exposes `core.registry.list`).
- **Sibling-pillar fan-out**: zero today; comes online with PRDs 197 (search) and 202 (AI tool routing).

## Preconditions called out

1. `core.registry.snapshot` endpoint exists (SDK currently calls a name pops-core-api does not expose).
2. Registry advertises browser-reachable `baseUrl`s (today they are container-network origins).
3. SDK URL shape parity with the nginx `/trpc-<id>/` rewrite (the SDK appends `/trpc/` twice with the obvious wrapper).

## Test plan

- [ ] Verify the PRD-227 directory passes the docs format check (`pnpm format:check docs/themes/13-pillar-finale/prds/227-sdk-consumer-migration-audit`)
- [ ] Confirm the PRD links resolve in the rendered Epic 10 table