### PR TITLE
feat(inventory): migrate connections writes to @pops/inventory-db (PRD-175 PR3)

### DIFF
--- a/apps/pops-api/src/modules/inventory/connections/service.ts
+++ b/apps/pops-api/src/modules/inventory/connections/service.ts
@@ -1,28 +1,34 @@
 /**
- * Inventory connections read/write surface — PRD-175 PR 2 cutover.
+ * Inventory connections read/write surface — PRD-175 PR 3 cutover.
  *
- * Read/write split during the migration window (mirrors PRD-173 PR 2 +
- * PRD-179 PR 2):
- *  - `listConnectionsForItem`, `traceConnections`, and `getConnectionGraph`
- *    are routed through `connectionsService` from `@pops/inventory-db`
- *    against the inventory pillar handle (`getInventoryDrizzle()`). Reads
- *    now resolve from the canonical package implementation.
- *  - Writes (`connectItems`, `disconnectItems`) keep their inline drizzle
- *    statements against the same handle to preserve the existing
- *    read-after-write guarantee on the inventory pillar's SQLite file.
- *    Both calls validate via in-line reads against the same handle, so
- *    the writes stay inline until PRD-175 PR 3 collapses them onto
- *    `connectionsService.{create, delete}`.
+ * All five operations (`listConnectionsForItem`, `traceConnections`,
+ * `getConnectionGraph`, `connectItems`, `disconnectItems`) now delegate to
+ * `connectionsService` from `@pops/inventory-db`, resolved against the
+ * inventory pillar handle (`getInventoryDrizzle()`). The legacy inline
+ * drizzle writes have been removed — `connectionsService.create` /
+ * `connectionsService.delete` own the wire surface end-to-end (mirrors
+ * PRD-179 PR 3 + PRD-165 PR 3).
+ *
+ * Typed errors from the package layer are translated back to the in-tree
+ * `NotFoundError` / `ConflictError` instances so the router's `instanceof`
+ * checks keep working (mirrors the items #3014 / engrams #3021 pattern):
+ *  - `ConnectionItemNotFoundError`  -> `NotFoundError('Inventory item', id)`
+ *  - `ConnectionNotFoundError`      -> `NotFoundError('Item connection', 'A-B')`
+ *  - `ConnectionConflictError`      -> `ConflictError(<existing-pair message>)`
+ *  - `SelfConnectionError`          -> `ConflictError('Cannot connect an item to itself')`
  *
  * The legacy router stays mounted in pops-api as a fall-through while the
  * dispatcher cutover routes `inventory.connections.*` traffic to
  * pops-inventory-api. Consumers (router.ts here) keep the same wire
  * surface — no caller churn.
  */
-import { and, eq } from 'drizzle-orm';
-
-import { homeInventory, itemConnections } from '@pops/db-types';
-import { ConnectionItemNotFoundError, connectionsService } from '@pops/inventory-db';
+import {
+  ConnectionConflictError,
+  ConnectionItemNotFoundError,
+  ConnectionNotFoundError,
+  connectionsService,
+  SelfConnectionError,
+} from '@pops/inventory-db';
 
 import { getInventoryDrizzle } from '../../../db/inventory-handle.js';
 import { ConflictError, NotFoundError } from '../../../shared/errors.js';
@@ -42,57 +48,25 @@ function translate<T>(fn: () => T): T {
     if (err instanceof ConnectionItemNotFoundError) {
       throw new NotFoundError('Inventory item', err.id);
     }
+    if (err instanceof ConnectionNotFoundError) {
+      throw new NotFoundError('Item connection', `${err.itemAId}-${err.itemBId}`);
+    }
+    if (err instanceof ConnectionConflictError || err instanceof SelfConnectionError) {
+      throw new ConflictError(err.message);
+    }
     throw err;
   }
 }
 
 /**
  * Connect two inventory items. Enforces itemAId < itemBId ordering.
- * Validates both items exist. Throws ConflictError on duplicate.
+ * Validates both items exist. Throws ConflictError on duplicate or
+ * self-connection.
  */
 export function connectItems(inputA: string, inputB: string): ItemConnectionRow {
-  const db = getInventoryDrizzle();
-
-  if (inputA === inputB) {
-    throw new ConflictError('Cannot connect an item to itself');
-  }
-
-  const [itemAId, itemBId] = inputA < inputB ? [inputA, inputB] : [inputB, inputA];
-
-  const [itemA] = db
-    .select({ id: homeInventory.id })
-    .from(homeInventory)
-    .where(eq(homeInventory.id, itemAId))
-    .all();
-  if (!itemA) throw new NotFoundError('Inventory item', itemAId);
-
-  const [itemB] = db
-    .select({ id: homeInventory.id })
-    .from(homeInventory)
-    .where(eq(homeInventory.id, itemBId))
-    .all();
-  if (!itemB) throw new NotFoundError('Inventory item', itemBId);
-
-  const [existing] = db
-    .select({ id: itemConnections.id })
-    .from(itemConnections)
-    .where(and(eq(itemConnections.itemAId, itemAId), eq(itemConnections.itemBId, itemBId)))
-    .all();
-
-  if (existing) {
-    throw new ConflictError(`Connection between '${itemAId}' and '${itemBId}' already exists`);
-  }
-
-  db.insert(itemConnections).values({ itemAId, itemBId }).run();
-
-  const [created] = db
-    .select()
-    .from(itemConnections)
-    .where(and(eq(itemConnections.itemAId, itemAId), eq(itemConnections.itemBId, itemBId)))
-    .all();
-
-  if (!created) throw new NotFoundError('Item connection', `${itemAId}-${itemBId}`);
-  return created;
+  return translate(() =>
+    connectionsService.create(getInventoryDrizzle(), { itemAId: inputA, itemBId: inputB })
+  );
 }
 
 /**
@@ -100,21 +74,7 @@ export function connectItems(inputA: string, inputB: string): ItemConnectionRow 
  * Throws NotFoundError if no connection exists between the two items.
  */
 export function disconnectItems(inputA: string, inputB: string): void {
-  const db = getInventoryDrizzle();
-
-  const [itemAId, itemBId] = inputA < inputB ? [inputA, inputB] : [inputB, inputA];
-
-  const [row] = db
-    .select({ id: itemConnections.id })
-    .from(itemConnections)
-    .where(and(eq(itemConnections.itemAId, itemAId), eq(itemConnections.itemBId, itemBId)))
-    .all();
-
-  if (!row) {
-    throw new NotFoundError('Item connection', `${itemAId}-${itemBId}`);
-  }
-
-  db.delete(itemConnections).where(eq(itemConnections.id, row.id)).run();
+  translate(() => connectionsService.delete(getInventoryDrizzle(), inputA, inputB));
 }
 
 /** List all connections for a given item (checking both A and B columns). */


### PR DESCRIPTION
## Summary

Final PR of PRD-175's sequence (scaffold #3028, reads cutover #3030). Flips the inline `connectItems` / `disconnectItems` writes in `apps/pops-api/src/modules/inventory/connections/service.ts` over to `connectionsService.{create, delete}` from `@pops/inventory-db`, resolved against the inventory pillar handle (`getInventoryDrizzle()`). The package owns the wire surface end-to-end now.

Mirrors the PRD-165 PR3 (#3018) / PRD-179 PR3 (#3021) write-cutover pattern.

### What moved

- `connectItems` -> `connectionsService.create(getInventoryDrizzle(), { itemAId, itemBId })`. The inline item-exists guards, A<B normalisation, duplicate-pair check, and read-back-on-insert are gone — `connectionsService.create` enforces all of those (and the `homeInventory` lookup runs against the same inventory handle, so behaviour is identical).
- `disconnectItems` -> `connectionsService.delete(getInventoryDrizzle(), inputA, inputB)`. Same normalisation + not-found semantics inside the package.

### Error translation

Typed errors from the package layer are translated back to the in-tree `NotFoundError` / `ConflictError` so the router's `instanceof` checks in `connections/router.ts` keep working without churn:

- `ConnectionItemNotFoundError` -> `NotFoundError('Inventory item', id)`
- `ConnectionNotFoundError` -> `NotFoundError('Item connection', 'A-B')`
- `ConnectionConflictError` -> `ConflictError(<existing-pair message>)`
- `SelfConnectionError` -> `ConflictError('Cannot connect an item to itself')`

`ConflictError` is preferred over `BAD_REQUEST` for `SelfConnectionError` to preserve the existing router behaviour, which mapped `inputA === inputB` to a `CONFLICT` tRPC code (see `connections.test.ts` line 95-107).

### Why this is safe

- `connectionsService.create` reads + writes against the *same* `InventoryDb` handle this caller passes in, so the existing read-after-write guarantee on the inventory pillar's SQLite file is preserved (no cross-DB transaction surprise).
- `router.ts` is unchanged — same wire surface, same imports from `./service.js`.
- The package's `create` / `delete` semantics were already exercised by `packages/inventory-db/src/__tests__/connections.test.ts` (37 tests there) — this PR just removes the duplicate behaviour from pops-api.

## Test plan

- [x] `pnpm -F @pops/api test src/modules/inventory/connections` — 33/33 pass
- [x] `pnpm -F @pops/api test src/modules/inventory` — 313/313 pass
- [x] `pnpm -F @pops/inventory-db test` — 117/117 pass
- [x] `pnpm -w typecheck` — 66/66 green
- [x] `pnpm oxlint` — 0 errors
- [x] `pnpm oxfmt --check` — clean