### PR TITLE
feat(inventory): migrate documents writes to inventory.db (PRD-176 PR3)

### DIFF
--- a/apps/pops-api/src/modules/inventory/documents/service.ts
+++ b/apps/pops-api/src/modules/inventory/documents/service.ts
@@ -1,37 +1,62 @@
 /**
- * Inventory documents read/write surface — PRD-176 PR 2 cutover.
+ * Inventory documents read/write surface — PRD-176 PR 3 cutover.
  *
- * Read/write split during the migration window (mirrors PRD-175 PR 2 +
- * PRD-173 PR 2 + PRD-179 PR 2):
- *  - `listDocumentsForItem` is routed through `documentsService` from
- *    `@pops/inventory-db` against the inventory pillar handle
- *    (`getInventoryDrizzle()`). Reads now resolve from the canonical
- *    package implementation.
- *  - Writes (`linkDocument`, `unlinkDocument`) keep their inline drizzle
- *    statements against the same handle to preserve the existing
- *    read-after-write guarantee on the inventory pillar's SQLite file.
- *    Both calls validate via in-line reads against the same handle, so
- *    the writes stay inline until PRD-176 PR 3 collapses them onto
- *    `documentsService.{link, unlink}`.
+ * All paths (`linkDocument`, `unlinkDocument`, `listDocumentsForItem`)
+ * now forward into `documentsService` from `@pops/inventory-db` against
+ * the inventory pillar handle (`getInventoryDrizzle()`). PR 2 (#3033)
+ * cut the reads; this PR closes the split so reads and writes resolve
+ * against the same canonical package implementation on the inventory
+ * pillar's SQLite file.
  *
- * The legacy router stays mounted in pops-api as a fall-through while the
- * dispatcher cutover routes `inventory.documents.*` traffic to
+ * Typed errors raised by the package (`DocumentItemNotFoundError`,
+ * `DocumentConflictError`, `DocumentNotFoundError`,
+ * `DocumentCreateFailedError`) are translated back to the in-tree
+ * `NotFoundError` / `ConflictError` so the router's `instanceof`
+ * checks keep working (mirrors PRD-173 PR 2 / PRD-175 PR 2 pattern).
+ *
+ * The legacy router stays mounted in pops-api as a fall-through while
+ * the dispatcher cutover routes `inventory.documents.*` traffic to
  * pops-inventory-api. Consumers (router.ts here) keep the same wire
  * surface — no caller churn.
  */
-import { and, eq } from 'drizzle-orm';
-
-import { homeInventory, itemDocuments } from '@pops/db-types';
-import { documentsService } from '@pops/inventory-db';
+import {
+  DocumentConflictError,
+  DocumentCreateFailedError,
+  DocumentItemNotFoundError,
+  DocumentNotFoundError,
+  documentsService,
+} from '@pops/inventory-db';
 
 import { getInventoryDrizzle } from '../../../db/inventory-handle.js';
 import { ConflictError, NotFoundError } from '../../../shared/errors.js';
 
-import type { ItemDocumentRow } from './types.js';
+import type { DocumentType, ItemDocumentRow } from './types.js';
 
 export interface DocumentListResult {
   rows: ItemDocumentRow[];
   total: number;
+}
+
+function translate<T>(fn: () => T): T {
+  try {
+    return fn();
+  } catch (err) {
+    if (err instanceof DocumentItemNotFoundError) {
+      throw new NotFoundError('Inventory item', err.id);
+    }
+    if (err instanceof DocumentNotFoundError) {
+      throw new NotFoundError('Item document link', String(err.id));
+    }
+    if (err instanceof DocumentConflictError) {
+      throw new ConflictError(
+        `Document '${err.paperlessDocumentId}' is already linked to item '${err.itemId}'`
+      );
+    }
+    if (err instanceof DocumentCreateFailedError) {
+      throw new NotFoundError('Item document link', `${err.itemId}-${err.paperlessDocumentId}`);
+    }
+    throw err;
+  }
 }
 
 /**
@@ -41,70 +66,24 @@ export interface DocumentListResult {
 export function linkDocument(
   itemId: string,
   paperlessDocumentId: number,
-  documentType: string,
+  documentType: DocumentType,
   title?: string
 ): ItemDocumentRow {
-  const db = getInventoryDrizzle();
-
-  const [item] = db
-    .select({ id: homeInventory.id })
-    .from(homeInventory)
-    .where(eq(homeInventory.id, itemId))
-    .all();
-
-  if (!item) throw new NotFoundError('Inventory item', itemId);
-
-  const [existing] = db
-    .select({ id: itemDocuments.id })
-    .from(itemDocuments)
-    .where(
-      and(
-        eq(itemDocuments.itemId, itemId),
-        eq(itemDocuments.paperlessDocumentId, paperlessDocumentId)
-      )
-    )
-    .all();
-
-  if (existing) {
-    throw new ConflictError(
-      `Document '${paperlessDocumentId}' is already linked to item '${itemId}'`
-    );
-  }
-
-  db.insert(itemDocuments)
-    .values({ itemId, paperlessDocumentId, documentType, title: title ?? null })
-    .run();
-
-  const [created] = db
-    .select()
-    .from(itemDocuments)
-    .where(
-      and(
-        eq(itemDocuments.itemId, itemId),
-        eq(itemDocuments.paperlessDocumentId, paperlessDocumentId)
-      )
-    )
-    .all();
-
-  if (!created) throw new NotFoundError('Item document link', `${itemId}-${paperlessDocumentId}`);
-  return created;
+  return translate(() =>
+    documentsService.link(getInventoryDrizzle(), {
+      itemId,
+      paperlessDocumentId,
+      documentType,
+      title: title ?? null,
+    })
+  );
 }
 
 /**
  * Unlink a document from an item by link ID.
  */
 export function unlinkDocument(id: number): void {
-  const db = getInventoryDrizzle();
-
-  const [row] = db
-    .select({ id: itemDocuments.id })
-    .from(itemDocuments)
-    .where(eq(itemDocuments.id, id))
-    .all();
-
-  if (!row) throw new NotFoundError('Item document link', String(id));
-
-  db.delete(itemDocuments).where(eq(itemDocuments.id, id)).run();
+  translate(() => documentsService.unlink(getInventoryDrizzle(), id));
 }
 
 /**

--- a/apps/pops-api/src/modules/inventory/documents/service.ts
+++ b/apps/pops-api/src/modules/inventory/documents/service.ts
@@ -48,9 +48,7 @@ function translate<T>(fn: () => T): T {
       throw new NotFoundError('Item document link', String(err.id));
     }
     if (err instanceof DocumentConflictError) {
-      throw new ConflictError(
-        `Document '${err.paperlessDocumentId}' is already linked to item '${err.itemId}'`
-      );
+      throw new ConflictError(err.message);
     }
     if (err instanceof DocumentCreateFailedError) {
       throw new NotFoundError('Item document link', `${err.itemId}-${err.paperlessDocumentId}`);


### PR DESCRIPTION
## Summary

PR 3 of PRD-176's sequence. PR #3033 cut `listDocumentsForItem` to `documentsService.listForItem` against `getInventoryDrizzle()`; `linkDocument` and `unlinkDocument` kept their inline drizzle statements on the same handle. This PR collapses the writes onto `documentsService.{link, unlink}` so reads and writes resolve through the canonical package implementation on the inventory pillar's SQLite file.

- `linkDocument` forwards into `documentsService.link(getInventoryDrizzle(), { itemId, paperlessDocumentId, documentType, title })`.
- `unlinkDocument` forwards into `documentsService.unlink(getInventoryDrizzle(), id)`.
- Typed errors raised by the package (`DocumentItemNotFoundError`, `DocumentConflictError`, `DocumentNotFoundError`, `DocumentCreateFailedError`) are translated back to the in-tree `NotFoundError` / `ConflictError` so the router's `instanceof` checks keep working. Mirrors the PRD-173 PR 2 / PRD-175 PR 2 translation pattern.
- `linkDocument`'s `documentType` parameter is tightened from `string` to the in-tree `DocumentType` enum so the package call site doesn't need an unsafe cast — the router already passes the zod-validated enum.
- Wrapper header rewritten to describe the post-cutover routing instead of the PR 2 read/write split.

No consumer changes — `router.ts` keeps importing the same function names from `./service.js`.

## Test plan

- [x] `pnpm -F @pops/api test src/modules/inventory/documents` — 15/15 pass
- [x] `pnpm -F @pops/api test src/modules/inventory` — 313/313 pass
- [x] `pnpm -F @pops/inventory-db test` — 117/117 pass
- [x] `pnpm -w typecheck` — 66/66 packages green
- [x] `pnpm format:check apps/pops-api/src/modules/inventory/documents` — clean
- [x] `pnpm oxlint apps/pops-api/src/modules/inventory/documents` — clean
- [ ] CI green