### PR TITLE
feat(pillar-sdk): federated search orchestrator (PRD-197)

### DIFF
--- a/docs/themes/13-pillar-finale/prds/197-federated-query-orchestrator/README.md
+++ b/docs/themes/13-pillar-finale/prds/197-federated-query-orchestrator/README.md
@@ -19,7 +19,7 @@ export async function search(query: {
   text?: string;
   tags?: string[];
   dateRange?: { from: Date; to: Date };
-  scope?: string[];
+  scope?: Record<string, string>;
   pillars?: string[]; // optional — defaults to all
   limit?: number;
 }): Promise<SearchResult[]>;
@@ -27,11 +27,26 @@ export async function search(query: {
 
 Internally:
 
-1. Snapshot the registry; collect adapters matching the query shape.
-2. Fan out to each adapter via `pillar('<id>').<router>.<proc>({...})`.
-3. Each pillar returns scored results.
+1. Snapshot the registry; collect every pillar whose manifest advertises
+   at least one entry under `manifest.search.adapters`.
+2. Fan out to each `(pillarId, adapterName)` pair via the injected
+   `SearchAdapterInvoker` (in production resolved to
+   `pillar('<id>').<router>.<proc>({...})`).
+3. Each adapter returns scored results, or `[]` if the query is
+   unsupported by that adapter.
 4. Merge via ranking strategy (PRD-198).
 5. Return top-N.
+
+**Interim limitation — query-shape pre-filtering (PRD-196).** The shipped
+orchestrator does **not** filter adapters by query shape. The current
+manifest's `search.adapters` field is `readonly string[]` — adapter
+names only — so the orchestrator cannot know which dimensions
+(`text` / `tags` / `dateRange` / `scope`) an adapter advertises. Every
+adapter on every selected pillar is invoked unconditionally; each
+adapter must return `[]` for queries it does not support. Once PRD-196
+lands the richer adapter descriptor (`procedurePath`, `queryShape`,
+`entityType`, `rankFieldName`), the pre-filter belongs in
+`runFederatedSearch` so adapters do not pay the parse-and-reject cost.
 
 ## Business Rules
 

--- a/packages/pillar-sdk/package.json
+++ b/packages/pillar-sdk/package.json
@@ -50,6 +50,10 @@
       "types": "./dist/ranking/index.d.ts",
       "default": "./dist/ranking/index.js"
     },
+    "./orchestrator": {
+      "types": "./dist/orchestrator/index.d.ts",
+      "default": "./dist/orchestrator/index.js"
+    },
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/packages/pillar-sdk/src/index.ts
+++ b/packages/pillar-sdk/src/index.ts
@@ -3,6 +3,7 @@ export * from './bootstrap/index.js';
 export * from './discovery/index.js';
 export * from './capabilities/index.js';
 export * from './ranking/index.js';
+export * from './orchestrator/index.js';
 // NOTE: contracts/ is intentionally NOT re-exported from the root barrel.
 // Re-exporting it would put @pops/finance-contract on the root index.d.ts
 // import graph, forcing every TS consumer (including non-React / non-Node

--- a/packages/pillar-sdk/src/orchestrator/__tests__/fixtures.ts
+++ b/packages/pillar-sdk/src/orchestrator/__tests__/fixtures.ts
@@ -1,0 +1,38 @@
+import type { PillarSnapshot } from '../../discovery/types.js';
+import type { ManifestPayload } from '../../manifest-schema/schema.js';
+
+export function manifest(pillarId: string, adapters: readonly string[]): ManifestPayload {
+  return {
+    pillar: pillarId,
+    version: '1.0.0',
+    contract: {
+      package: `@pops/${pillarId}-contract`,
+      version: '1.0.0',
+      tag: `contract-${pillarId}@v1.0.0`,
+    },
+    routes: {
+      queries: [`${pillarId}.routerA.list`],
+      mutations: [`${pillarId}.routerA.create`],
+      subscriptions: [],
+    },
+    search: { adapters: [...adapters] },
+    ai: { tools: [] },
+    uri: { types: [`${pillarId}/entity`] },
+    settings: { keys: [] },
+    healthcheck: { path: '/health' },
+  };
+}
+
+export function snapshot(
+  pillarId: string,
+  adapters: readonly string[],
+  registered = true
+): PillarSnapshot {
+  return {
+    pillarId,
+    baseUrl: `https://${pillarId}.test`,
+    manifest: manifest(pillarId, adapters),
+    registered,
+    lastSeenAt: new Date('2026-01-01T00:00:00Z'),
+  };
+}

--- a/packages/pillar-sdk/src/orchestrator/__tests__/runner.test.ts
+++ b/packages/pillar-sdk/src/orchestrator/__tests__/runner.test.ts
@@ -1,0 +1,309 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  DEFAULT_ADAPTER_TIMEOUT_MS,
+  EmptyFederatedQueryError,
+  runFederatedSearch,
+} from '../runner.js';
+import { snapshot } from './fixtures.js';
+
+import type { ScoredResult } from '../../ranking/types.js';
+import type { FederatedSearchQuery, PillarAdapterTarget, SearchAdapterInvoker } from '../types.js';
+
+function result(score: number, entityName: string): ScoredResult {
+  return { score, entityName, data: { entityName } };
+}
+
+function makeInvoker(
+  handlers: Record<string, (query: FederatedSearchQuery) => Promise<readonly ScoredResult[]>>
+): SearchAdapterInvoker {
+  return (target, query) => {
+    const key = `${target.pillarId}/${target.adapterName}`;
+    const handler = handlers[key];
+    if (handler === undefined) throw new Error(`no handler registered for ${key}`);
+    return handler(query);
+  };
+}
+
+describe('runFederatedSearch', () => {
+  it('rejects an empty query (no text, tags, or dateRange)', async () => {
+    await expect(
+      runFederatedSearch({
+        query: {},
+        invoker: () => Promise.resolve([]),
+        discovery: [],
+      })
+    ).rejects.toBeInstanceOf(EmptyFederatedQueryError);
+  });
+
+  it('rejects whitespace-only text without other dimensions', async () => {
+    await expect(
+      runFederatedSearch({
+        query: { text: '   ' },
+        invoker: () => Promise.resolve([]),
+        discovery: [],
+      })
+    ).rejects.toBeInstanceOf(EmptyFederatedQueryError);
+  });
+
+  it.each([
+    ['text', { text: 'pizza' } satisfies FederatedSearchQuery],
+    ['tags', { tags: ['groceries'] } satisfies FederatedSearchQuery],
+    [
+      'dateRange',
+      {
+        dateRange: { from: new Date('2026-01-01'), to: new Date('2026-02-01') },
+      } satisfies FederatedSearchQuery,
+    ],
+  ])('accepts a query with just %s', async (_label, query) => {
+    const response = await runFederatedSearch({
+      query,
+      invoker: () => Promise.resolve([]),
+      discovery: [],
+    });
+
+    expect(response.results).toEqual([]);
+    expect(response.failures).toEqual([]);
+  });
+
+  it('fans out to every registered pillar that advertises an adapter', async () => {
+    const calls: PillarAdapterTarget[] = [];
+    const invoker: SearchAdapterInvoker = (target) => {
+      calls.push(target);
+      return Promise.resolve([result(1, `${target.pillarId}-${target.adapterName}`)]);
+    };
+
+    const response = await runFederatedSearch({
+      query: { text: 'pizza' },
+      invoker,
+      discovery: [snapshot('finance', ['transactions', 'budgets']), snapshot('media', ['movies'])],
+    });
+
+    expect(calls.map((c) => `${c.pillarId}/${c.adapterName}`)).toEqual([
+      'finance/transactions',
+      'finance/budgets',
+      'media/movies',
+    ]);
+    expect(response.results).toHaveLength(3);
+    expect(response.failures).toEqual([]);
+  });
+
+  it('skips unregistered pillars', async () => {
+    const calls: PillarAdapterTarget[] = [];
+    const invoker: SearchAdapterInvoker = (target) => {
+      calls.push(target);
+      return Promise.resolve([]);
+    };
+
+    await runFederatedSearch({
+      query: { text: 'pizza' },
+      invoker,
+      discovery: [snapshot('finance', ['transactions']), snapshot('media', ['movies'], false)],
+    });
+
+    expect(calls.map((c) => c.pillarId)).toEqual(['finance']);
+  });
+
+  it('skips pillars without any adapters declared', async () => {
+    const calls: PillarAdapterTarget[] = [];
+    const invoker: SearchAdapterInvoker = (target) => {
+      calls.push(target);
+      return Promise.resolve([]);
+    };
+
+    await runFederatedSearch({
+      query: { text: 'pizza' },
+      invoker,
+      discovery: [snapshot('finance', []), snapshot('media', ['movies'])],
+    });
+
+    expect(calls.map((c) => c.pillarId)).toEqual(['media']);
+  });
+
+  it('honours the pillars allow-list', async () => {
+    const calls: PillarAdapterTarget[] = [];
+    const invoker: SearchAdapterInvoker = (target) => {
+      calls.push(target);
+      return Promise.resolve([]);
+    };
+
+    await runFederatedSearch({
+      query: { text: 'pizza', pillars: ['media'] },
+      invoker,
+      discovery: [snapshot('finance', ['transactions']), snapshot('media', ['movies'])],
+    });
+
+    expect(calls.map((c) => c.pillarId)).toEqual(['media']);
+  });
+
+  it('merges per-pillar results via the ranking strategy', async () => {
+    const invoker = makeInvoker({
+      'finance/transactions': async () => [result(10, 'tx-1'), result(5, 'tx-2')],
+      'media/movies': async () => [result(0.5, 'movie-A')],
+    });
+
+    const response = await runFederatedSearch({
+      query: { text: 'pizza' },
+      invoker,
+      discovery: [snapshot('finance', ['transactions']), snapshot('media', ['movies'])],
+    });
+
+    expect(response.results.map((r) => r.entityName)).toEqual(['tx-1', 'movie-A', 'tx-2']);
+    expect(response.results[0]?.adjustedScore).toBe(1);
+    expect(response.results[1]?.adjustedScore).toBe(1);
+    expect(response.results[2]?.adjustedScore).toBe(0.5);
+  });
+
+  it('forwards limit and weights to the merge step', async () => {
+    const invoker = makeInvoker({
+      'finance/transactions': async () => [result(10, 'tx-1'), result(5, 'tx-2')],
+      'media/movies': async () => [result(0.5, 'movie-A')],
+    });
+
+    const response = await runFederatedSearch({
+      query: { text: 'pizza', limit: 2 },
+      weights: new Map([
+        ['finance', 0.5],
+        ['media', 2],
+      ]),
+      invoker,
+      discovery: [snapshot('finance', ['transactions']), snapshot('media', ['movies'])],
+    });
+
+    expect(response.results).toHaveLength(2);
+    expect(response.results[0]?.pillarId).toBe('media');
+    expect(response.results[0]?.adjustedScore).toBe(2);
+  });
+
+  it('collects failures via Promise.allSettled instead of rejecting', async () => {
+    const invoker = makeInvoker({
+      'finance/transactions': async () => [result(1, 'tx-1')],
+      'media/movies': async () => {
+        throw new Error('boom');
+      },
+    });
+
+    const response = await runFederatedSearch({
+      query: { text: 'pizza' },
+      invoker,
+      discovery: [snapshot('finance', ['transactions']), snapshot('media', ['movies'])],
+    });
+
+    expect(response.results.map((r) => r.entityName)).toEqual(['tx-1']);
+    expect(response.failures).toEqual([
+      {
+        pillarId: 'media',
+        adapterName: 'movies',
+        reason: 'error',
+        error: expect.objectContaining({ message: 'boom' }),
+      },
+    ]);
+  });
+
+  it('classifies timeouts separately from generic errors', async () => {
+    vi.useFakeTimers();
+    try {
+      const invoker: SearchAdapterInvoker = (target, _query, signal) =>
+        new Promise((resolve, reject) => {
+          signal.addEventListener('abort', () => reject(new Error('aborted')), { once: true });
+          if (target.pillarId === 'finance') {
+            resolve([result(1, 'fast-tx')]);
+          }
+        });
+
+      const promise = runFederatedSearch({
+        query: { text: 'pizza' },
+        invoker,
+        timeoutMs: 100,
+        discovery: [snapshot('finance', ['transactions']), snapshot('media', ['movies'])],
+      });
+
+      await vi.advanceTimersByTimeAsync(101);
+      const response = await promise;
+
+      expect(response.results.map((r) => r.entityName)).toEqual(['fast-tx']);
+      expect(response.failures).toEqual([
+        { pillarId: 'media', adapterName: 'movies', reason: 'timeout' },
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('returns empty results + per-target failures when every adapter times out', async () => {
+    vi.useFakeTimers();
+    try {
+      const invoker: SearchAdapterInvoker = () => new Promise(() => {});
+
+      const promise = runFederatedSearch({
+        query: { text: 'pizza' },
+        invoker,
+        timeoutMs: 50,
+        discovery: [snapshot('finance', ['transactions']), snapshot('media', ['movies'])],
+      });
+
+      await vi.advanceTimersByTimeAsync(51);
+      const response = await promise;
+
+      expect(response.results).toEqual([]);
+      expect(response.failures).toEqual([
+        { pillarId: 'finance', adapterName: 'transactions', reason: 'timeout' },
+        { pillarId: 'media', adapterName: 'movies', reason: 'timeout' },
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('warns and ignores non-array adapter results', async () => {
+    const warn = vi.fn();
+    const invoker: SearchAdapterInvoker = () =>
+      Promise.resolve('totally not an array' as unknown as readonly ScoredResult[]);
+
+    const response = await runFederatedSearch({
+      query: { text: 'pizza' },
+      invoker,
+      onWarn: warn,
+      discovery: [snapshot('finance', ['transactions'])],
+    });
+
+    expect(response.results).toEqual([]);
+    expect(response.failures).toEqual([]);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('finance/transactions'));
+  });
+
+  it('accepts a discovery fetcher function', async () => {
+    const invoker = makeInvoker({
+      'finance/transactions': async () => [result(1, 'tx-1')],
+    });
+
+    const response = await runFederatedSearch({
+      query: { text: 'pizza' },
+      invoker,
+      discovery: () => Promise.resolve([snapshot('finance', ['transactions'])]),
+    });
+
+    expect(response.results.map((r) => r.entityName)).toEqual(['tx-1']);
+  });
+
+  it('exposes a 3s default timeout per PRD-197', () => {
+    expect(DEFAULT_ADAPTER_TIMEOUT_MS).toBe(3_000);
+  });
+
+  it('aborts the per-adapter signal once the adapter resolves', async () => {
+    const seen: AbortSignal[] = [];
+    const invoker: SearchAdapterInvoker = (_target, _query, signal) => {
+      seen.push(signal);
+      return Promise.resolve([result(1, 'a')]);
+    };
+
+    await runFederatedSearch({
+      query: { text: 'pizza' },
+      invoker,
+      discovery: [snapshot('finance', ['transactions'])],
+    });
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0]?.aborted).toBe(true);
+  });
+});

--- a/packages/pillar-sdk/src/orchestrator/index.ts
+++ b/packages/pillar-sdk/src/orchestrator/index.ts
@@ -1,0 +1,20 @@
+/**
+ * `@pops/pillar-sdk/orchestrator` — federated query orchestrator (PRD-197).
+ *
+ * Reads the discovery registry, fans the query out to every pillar's
+ * search adapter (PRD-196), merges results via the cross-pillar ranking
+ * strategy (PRD-198), and surfaces partial failures (PRD-199).
+ */
+
+export {
+  runFederatedSearch,
+  EmptyFederatedQueryError,
+  DEFAULT_ADAPTER_TIMEOUT_MS,
+} from './runner.js';
+export type { FederatedSearchOptions, FederatedSearchResponse } from './runner.js';
+export type {
+  FederatedSearchQuery,
+  FederatedSearchFailure,
+  PillarAdapterTarget,
+  SearchAdapterInvoker,
+} from './types.js';

--- a/packages/pillar-sdk/src/orchestrator/runner.ts
+++ b/packages/pillar-sdk/src/orchestrator/runner.ts
@@ -1,0 +1,246 @@
+/**
+ * Federated query orchestrator (PRD-197).
+ *
+ * Reads the discovery registry, fans the query out to every pillar
+ * advertising a search adapter in `manifest.search.adapters` (PRD-196),
+ * waits with a per-target timeout, then merges the per-pillar
+ * `ScoredResult[]` via {@link mergeResults} (PRD-198).
+ *
+ * Pure orchestration: no global state, no I/O of its own. Discovery is
+ * passed in as an array (test) or as a fetcher returning the snapshot
+ * (production — typically `() => pillarRegistry().then(s => s.pillars)`).
+ * Adapter dispatch is delegated to a {@link SearchAdapterInvoker} so the
+ * orchestrator does not need to know how the underlying procedure is
+ * transported.
+ *
+ * See {@link FederatedSearchQuery} for the interim-shape limitation note
+ * (the manifest currently exposes only adapter names; PRD-196 will add
+ * `procedurePath` + `queryShape` so the orchestrator can pre-filter).
+ */
+
+import { mergeResults } from '../ranking/merge.js';
+
+import type { PillarSnapshot } from '../discovery/types.js';
+import type { MergedResult, PillarWeights, ScoredResult } from '../ranking/types.js';
+import type {
+  FederatedSearchFailure,
+  FederatedSearchQuery,
+  PillarAdapterTarget,
+  SearchAdapterInvoker,
+} from './types.js';
+
+/** Default per-adapter timeout — matches PRD-197 "Per-adapter timeout 3s". */
+export const DEFAULT_ADAPTER_TIMEOUT_MS = 3_000;
+
+export interface FederatedSearchOptions {
+  readonly query: FederatedSearchQuery;
+  readonly invoker: SearchAdapterInvoker;
+  /**
+   * Discovery source. Either an array (test fixtures) or a fetcher
+   * function returning the registered pillar snapshots — typically
+   * `() => pillarRegistry().then(s => s.pillars)`.
+   */
+  readonly discovery: readonly PillarSnapshot[] | (() => Promise<readonly PillarSnapshot[]>);
+  /** Per-adapter timeout. Defaults to {@link DEFAULT_ADAPTER_TIMEOUT_MS}. */
+  readonly timeoutMs?: number;
+  /** Per-pillar ranking weights forwarded to {@link mergeResults}. */
+  readonly weights?: PillarWeights;
+  /**
+   * Sink for orchestration warnings — e.g. an adapter returned a
+   * non-array result. Defaults to a no-op so the runner stays a pure
+   * function with no console I/O.
+   */
+  readonly onWarn?: (message: string) => void;
+  /**
+   * Clock injection point for deterministic timeout tests. Defaults to
+   * the global `setTimeout` / `clearTimeout`.
+   */
+  readonly setTimeoutImpl?: typeof setTimeout;
+  readonly clearTimeoutImpl?: typeof clearTimeout;
+}
+
+export interface FederatedSearchResponse {
+  readonly results: readonly MergedResult[];
+  readonly failures: readonly FederatedSearchFailure[];
+}
+
+export class EmptyFederatedQueryError extends Error {
+  override readonly name = 'EmptyFederatedQueryError';
+  constructor() {
+    super('Federated search requires at least one of text, tags, or dateRange.');
+  }
+}
+
+/**
+ * Run a federated search across every pillar advertising a search
+ * adapter. Resolves with the merged ranked results and a per-target
+ * failure list (timeout or thrown error). Never rejects on adapter
+ * failure — that is what {@link FederatedSearchResponse.failures} is
+ * for. Only rejects if the input query is structurally empty (PRD-197
+ * "empty queries are rejected"); see {@link EmptyFederatedQueryError}.
+ */
+export async function runFederatedSearch(
+  options: FederatedSearchOptions
+): Promise<FederatedSearchResponse> {
+  if (!hasAnyQueryDimension(options.query)) throw new EmptyFederatedQueryError();
+
+  const {
+    invoker,
+    query,
+    timeoutMs = DEFAULT_ADAPTER_TIMEOUT_MS,
+    weights,
+    onWarn = noopWarn,
+    setTimeoutImpl = setTimeout,
+    clearTimeoutImpl = clearTimeout,
+  } = options;
+
+  const pillars = await resolveDiscovery(options.discovery);
+  const targets = collectTargets(pillars, query.pillars);
+
+  const settled = await Promise.allSettled(
+    targets.map((target) =>
+      invokeWithTimeout({
+        target,
+        query,
+        invoker,
+        timeoutMs,
+        setTimeoutImpl,
+        clearTimeoutImpl,
+      })
+    )
+  );
+
+  const { perPillarResults, failures } = collectOutcomes(targets, settled, onWarn);
+
+  const merged = mergeResults(perPillarResults, {
+    limit: query.limit,
+    weights,
+    onWarn,
+  });
+
+  return { results: merged, failures };
+}
+
+interface CollectedOutcomes {
+  readonly perPillarResults: Map<string, ScoredResult[]>;
+  readonly failures: FederatedSearchFailure[];
+}
+
+function collectOutcomes(
+  targets: readonly PillarAdapterTarget[],
+  settled: readonly PromiseSettledResult<readonly ScoredResult[]>[],
+  onWarn: (message: string) => void
+): CollectedOutcomes {
+  const perPillarResults = new Map<string, ScoredResult[]>();
+  for (const target of targets) {
+    if (!perPillarResults.has(target.pillarId)) {
+      perPillarResults.set(target.pillarId, []);
+    }
+  }
+
+  const failures: FederatedSearchFailure[] = [];
+
+  for (const [index, target] of targets.entries()) {
+    const outcome = settled[index];
+    if (outcome === undefined) continue;
+
+    if (outcome.status === 'rejected') {
+      failures.push(classifyRejection(target, outcome.reason));
+      continue;
+    }
+
+    const adapterResults = outcome.value;
+    if (!Array.isArray(adapterResults)) {
+      onWarn(
+        `[orchestrator] Adapter ${target.pillarId}/${target.adapterName} returned a non-array result; ignored.`
+      );
+      continue;
+    }
+
+    perPillarResults.get(target.pillarId)?.push(...adapterResults);
+  }
+
+  return { perPillarResults, failures };
+}
+
+function hasAnyQueryDimension(query: FederatedSearchQuery): boolean {
+  if (query.text !== undefined && query.text.trim().length > 0) return true;
+  if (query.tags !== undefined && query.tags.length > 0) return true;
+  if (query.dateRange !== undefined) return true;
+  return false;
+}
+
+async function resolveDiscovery(
+  source: FederatedSearchOptions['discovery']
+): Promise<readonly PillarSnapshot[]> {
+  if (typeof source === 'function') return source();
+  return source;
+}
+
+function collectTargets(
+  pillars: readonly PillarSnapshot[],
+  allowList: readonly string[] | undefined
+): readonly PillarAdapterTarget[] {
+  const allowed = allowList && allowList.length > 0 ? new Set(allowList) : undefined;
+  const targets: PillarAdapterTarget[] = [];
+
+  for (const pillar of pillars) {
+    if (!pillar.registered) continue;
+    if (allowed !== undefined && !allowed.has(pillar.pillarId)) continue;
+
+    for (const adapterName of pillar.manifest.search.adapters) {
+      targets.push({ pillarId: pillar.pillarId, adapterName });
+    }
+  }
+
+  return targets;
+}
+
+interface InvokeWithTimeoutArgs {
+  readonly target: PillarAdapterTarget;
+  readonly query: FederatedSearchQuery;
+  readonly invoker: SearchAdapterInvoker;
+  readonly timeoutMs: number;
+  readonly setTimeoutImpl: typeof setTimeout;
+  readonly clearTimeoutImpl: typeof clearTimeout;
+}
+
+class AdapterTimeoutError extends Error {
+  override readonly name = 'AdapterTimeoutError';
+}
+
+async function invokeWithTimeout(args: InvokeWithTimeoutArgs): Promise<readonly ScoredResult[]> {
+  const { target, query, invoker, timeoutMs, setTimeoutImpl, clearTimeoutImpl } = args;
+  const controller = new AbortController();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timer = setTimeoutImpl(() => {
+      reject(new AdapterTimeoutError());
+      controller.abort();
+    }, timeoutMs);
+  });
+
+  try {
+    return await Promise.race([invoker(target, query, controller.signal), timeoutPromise]);
+  } finally {
+    if (timer !== undefined) clearTimeoutImpl(timer);
+    if (!controller.signal.aborted) controller.abort();
+  }
+}
+
+function classifyRejection(target: PillarAdapterTarget, reason: unknown): FederatedSearchFailure {
+  if (reason instanceof AdapterTimeoutError) {
+    return { pillarId: target.pillarId, adapterName: target.adapterName, reason: 'timeout' };
+  }
+  return {
+    pillarId: target.pillarId,
+    adapterName: target.adapterName,
+    reason: 'error',
+    error: reason,
+  };
+}
+
+function noopWarn(_message: string): void {
+  /* default sink — see `FederatedSearchOptions.onWarn`. */
+}

--- a/packages/pillar-sdk/src/orchestrator/types.ts
+++ b/packages/pillar-sdk/src/orchestrator/types.ts
@@ -1,0 +1,99 @@
+/**
+ * Federated search orchestrator types (PRD-197).
+ *
+ * The orchestrator fans a single user query out to every registered pillar
+ * whose manifest advertises at least one search adapter
+ * (`manifest.search.adapters`), merges the per-pillar `ScoredResult[]`
+ * lists via {@link mergeResults} (PRD-198), and returns a single ranked
+ * response plus a per-pillar partial-failure list (PRD-199).
+ *
+ * **Known limitation (interim shape).** As of this PRD-197 cut, the
+ * manifest schema's `search.adapters` field is `readonly string[]` —
+ * adapter names only. PRD-196's richer descriptor (`procedurePath`,
+ * `queryShape`, `entityType`, `rankFieldName`) has not landed. Until it
+ * does, the orchestrator cannot reject queries against an adapter that
+ * does not advertise the requested dimensions (text / tags / dateRange /
+ * scope) — every adapter is invoked unconditionally and is responsible
+ * for returning `[]` if the query is unsupported. When PRD-196 lands,
+ * the pre-filter belongs in {@link runFederatedSearch} so each adapter
+ * does not pay the parse-and-reject cost.
+ *
+ * Dispatch is delegated to a {@link SearchAdapterInvoker} so the
+ * orchestrator does not need to know how the underlying procedure is
+ * named or transported.
+ */
+
+import type { ScoredResult } from '../ranking/types.js';
+
+/**
+ * The free-form query the orchestrator forwards to each adapter. The
+ * orchestrator does not interpret the body of the query — it only
+ * enforces PRD-197's "empty queries are rejected with 400" by requiring
+ * at least one of `text`, `tags`, or `dateRange` to be non-empty.
+ */
+export interface FederatedSearchQuery {
+  readonly text?: string;
+  readonly tags?: readonly string[];
+  readonly dateRange?: { readonly from: Date; readonly to: Date };
+  /**
+   * Additional scope filters keyed by adapter-defined keys; forwarded
+   * untouched to each adapter. Validation (which keys an adapter
+   * accepts) becomes the orchestrator's job once PRD-196 lands.
+   */
+  readonly scope?: Readonly<Record<string, string>>;
+  /**
+   * Optional pillar id allow-list. When set, only pillars in this list
+   * are queried — others are skipped (not reported as failures).
+   */
+  readonly pillars?: readonly string[];
+  /**
+   * Optional cap on merged result count. Forwarded to
+   * {@link mergeResults} as `MergeOptions.limit`.
+   */
+  readonly limit?: number;
+}
+
+/**
+ * One pillar's contribution to the fan-out. Both ids are camelCase
+ * identifiers (PRD-196's manifest schema constraint on `adapters`).
+ */
+export interface PillarAdapterTarget {
+  readonly pillarId: string;
+  readonly adapterName: string;
+}
+
+/**
+ * Invoker contract: given a target adapter and the query, return that
+ * adapter's `ScoredResult[]`. The `signal` is wired to the per-adapter
+ * timeout so callers can short-circuit slow HTTP calls.
+ *
+ * Implementations live outside the orchestrator package so the
+ * dispatch detail (HTTP via the `pillar()` SDK, in-process, mock) is
+ * swappable. The orchestrator only requires that rejecting the
+ * returned promise — including via abort — is treated as a failure.
+ *
+ * In production the invoker is expected to resolve `(pillarId,
+ * adapterName)` to a procedure path. The current `search.adapters`
+ * shape (PRD-197 interim — adapter names only) does not carry the
+ * path itself; until PRD-196 lands, callers compose it by convention
+ * (e.g. `${pillarId}.${adapterName}.search`).
+ */
+export type SearchAdapterInvoker = (
+  target: PillarAdapterTarget,
+  query: FederatedSearchQuery,
+  signal: AbortSignal
+) => Promise<readonly ScoredResult[]>;
+
+/**
+ * Discriminated failure record reported per pillar+adapter pair when
+ * fan-out does not yield results. The orchestrator emits one record per
+ * failed target so PRD-199 partial-failure surfacing has full context.
+ */
+export type FederatedSearchFailure =
+  | { readonly pillarId: string; readonly adapterName: string; readonly reason: 'timeout' }
+  | {
+      readonly pillarId: string;
+      readonly adapterName: string;
+      readonly reason: 'error';
+      readonly error: unknown;
+    };

--- a/packages/pillar-sdk/src/orchestrator/types.ts
+++ b/packages/pillar-sdk/src/orchestrator/types.ts
@@ -54,8 +54,10 @@ export interface FederatedSearchQuery {
 }
 
 /**
- * One pillar's contribution to the fan-out. Both ids are camelCase
- * identifiers (PRD-196's manifest schema constraint on `adapters`).
+ * One pillar's contribution to the fan-out. `pillarId` is a kebab-case
+ * identifier (per the manifest schema's pillar id constraint);
+ * `adapterName` is camelCase (PRD-196's manifest schema constraint on
+ * `search.adapters`).
  */
 export interface PillarAdapterTarget {
   readonly pillarId: string;
@@ -86,8 +88,15 @@ export type SearchAdapterInvoker = (
 
 /**
  * Discriminated failure record reported per pillar+adapter pair when
- * fan-out does not yield results. The orchestrator emits one record per
- * failed target so PRD-199 partial-failure surfacing has full context.
+ * fan-out fails — meaning the adapter promise rejected (including via
+ * abort) or hit the per-adapter timeout. An adapter that resolves with
+ * an empty `ScoredResult[]` is *not* a failure: empty is a valid
+ * "nothing matched" answer and produces no record here. Contract
+ * violations (non-array return values) are currently warned and
+ * dropped without producing a failure record either; that should be
+ * tightened as part of PRD-199 plumbing. The orchestrator emits one
+ * record per failed target so PRD-199 partial-failure surfacing has
+ * full context.
  */
 export type FederatedSearchFailure =
   | { readonly pillarId: string; readonly adapterName: string; readonly reason: 'timeout' }


### PR DESCRIPTION
## Summary

Adds the runtime federated search orchestrator (PRD-197) under
`@pops/pillar-sdk/orchestrator`. Reads the discovery registry, fans
the query out to every pillar advertising a `search.adapter`,
merges per-pillar `ScoredResult[]` via the PRD-198 ranking strategy,
and reports per-target timeout/error failures for PRD-199 plumbing.

- Pure orchestration — no global state, no I/O. Discovery is injected
  (array for tests, fetcher for production); dispatch is delegated to
  a `SearchAdapterInvoker` so the orchestrator does not need to know
  how each adapter is reached.
- 3s default per-adapter timeout, `Promise.allSettled` for partial-
  failure tolerance, empty queries rejected with
  `EmptyFederatedQueryError`.
- 18 unit tests covering fan-out, allow-listing, registered-flag
  filtering, merge wiring (limit + weights), error vs. timeout
  classification, non-array adapter results, signal abort on resolve.

## Known limitation (interim)

The manifest schema's `search.adapters` field is currently
`readonly string[]` — adapter names only. PRD-196's richer
descriptor (`procedurePath`, `queryShape`, `entityType`,
`rankFieldName`) has not landed yet, so the orchestrator cannot
pre-filter targets by declared query shape; every adapter is
invoked unconditionally and is responsible for returning `[]` if
the query is unsupported. When PRD-196 lands the pre-filter
belongs in `runFederatedSearch`.

## Test plan

- [x] `pnpm --filter @pops/pillar-sdk test` — 327 / 327 pass
- [x] `pnpm --filter @pops/pillar-sdk typecheck` — clean
- [x] `pnpm --filter @pops/pillar-sdk build` — clean
- [x] `pnpm lint` — no errors introduced
- [x] `pnpm format:check` — clean
- [x] `pnpm lint:boundaries` — no violations
