### PR TITLE
feat(pillar-sdk): dynamic AI tool list builder (PRD-201)

### DIFF
--- a/docs/themes/13-pillar-finale/prds/201-dynamic-tool-list/README.md
+++ b/docs/themes/13-pillar-finale/prds/201-dynamic-tool-list/README.md
@@ -42,11 +42,19 @@ type Tool = {
 
 ## User Stories
 
-| #   | Story                                       | Summary                                             |
-| --- | ------------------------------------------- | --------------------------------------------------- |
-| 01  | [us-01-list-builder](us-01-list-builder.md) | Read registry; filter active pillars; flatten tools |
-| 02  | [us-02-cache-layer](us-02-cache-layer.md)   | 30s TTL cache                                       |
-| 03  | [us-03-tests](us-03-tests.md)               | Test: simulated registry → tool list shape          |
+| #   | Story                                       | Summary                                             | Status |
+| --- | ------------------------------------------- | --------------------------------------------------- | ------ |
+| 01  | [us-01-list-builder](us-01-list-builder.md) | Read registry; filter active pillars; flatten tools | Done   |
+| 02  | [us-02-cache-layer](us-02-cache-layer.md)   | 30s TTL cache                                       | Done   |
+| 03  | [us-03-tests](us-03-tests.md)               | Test: simulated registry → tool list shape          | Done   |
+
+## Implementation Notes
+
+- Lives in `@pops/pillar-sdk/ai-tools` (`packages/pillar-sdk/src/ai-tools`).
+- `buildToolList()` pulls a snapshot via `pillarRegistry()` (PRD-159) and projects each pillar's `manifest.ai.tools` slot (PRD-200) into a flat list.
+- Memoised by `(snapshot.fetchedAt, opts)` with a 30s wall-clock floor; `invalidateToolListCache()` is the explicit reset hook.
+- Filters by the discovery `status` field (`'healthy' | 'unavailable' | 'unknown'`). Pillars without `status` fall back to the `registered` flag (PRD-162 reconciliation window).
+- **Known gap:** pillars only populate `manifest.ai.tools` once they ship PRD-200-compliant descriptors. Until then `buildToolList()` returns an empty list — the AI runs with whatever in-process tools the orchestrator already carries, matching the "all pillars down" edge case.
 
 ## Out of Scope
 

--- a/packages/pillar-sdk/package.json
+++ b/packages/pillar-sdk/package.json
@@ -38,6 +38,10 @@
       "types": "./dist/capabilities/index.d.ts",
       "default": "./dist/capabilities/index.js"
     },
+    "./ai-tools": {
+      "types": "./dist/ai-tools/index.d.ts",
+      "default": "./dist/ai-tools/index.js"
+    },
     "./react": {
       "types": "./dist/react/index.d.ts",
       "default": "./dist/react/index.js"

--- a/packages/pillar-sdk/src/ai-tools/__tests__/build-tool-list.test.ts
+++ b/packages/pillar-sdk/src/ai-tools/__tests__/build-tool-list.test.ts
@@ -115,6 +115,21 @@ describe('buildToolList', () => {
     expect(await buildToolList({ includeUnavailable: true })).toHaveLength(1);
   });
 
+  it('treats registered=false as unavailable even when status is "healthy"', async () => {
+    const reconciling: PillarSnapshot = {
+      ...withTools(pillar('media', 'http://media:3005'), [makeTool('searchMovies', 'find')]),
+      status: 'healthy',
+      registered: false,
+    };
+    currentSnapshot = snapshot([reconciling]);
+
+    expect(await buildToolList()).toEqual([]);
+
+    const diagnostic = await buildToolList({ includeUnavailable: true });
+    expect(diagnostic).toHaveLength(1);
+    expect(diagnostic[0]).toMatchObject({ pillar: 'media', pillarStatus: 'unavailable' });
+  });
+
   it('falls back to the registered flag when status is missing', async () => {
     const legacyHealthy: PillarSnapshot = {
       ...withTools(pillar('finance', 'http://finance:3004'), [makeTool('createTransaction', 'go')]),

--- a/packages/pillar-sdk/src/ai-tools/__tests__/build-tool-list.test.ts
+++ b/packages/pillar-sdk/src/ai-tools/__tests__/build-tool-list.test.ts
@@ -1,0 +1,246 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { pillar } from '../../discovery/__tests__/fixtures.js';
+import {
+  __resetBuildToolListInternals,
+  __setBuildToolListInternals,
+  buildToolList,
+  invalidateToolListCache,
+  TOOL_LIST_CACHE_TTL_MS,
+} from '../build-tool-list.js';
+
+import type { PillarSnapshot, PillarStatus, RegistrySnapshot } from '../../discovery/index.js';
+import type { ManifestPayload } from '../../manifest-schema/index.js';
+
+type ToolDescriptor = ManifestPayload['ai']['tools'][number];
+
+function withTools(p: PillarSnapshot, tools: readonly ToolDescriptor[]): PillarSnapshot {
+  return { ...p, manifest: { ...p.manifest, ai: { tools: [...tools] } } };
+}
+
+function withStatus(p: PillarSnapshot, status: PillarStatus): PillarSnapshot {
+  return { ...p, status, registered: status === 'healthy' };
+}
+
+function snapshot(pillars: readonly PillarSnapshot[], fetchedAt = new Date(1)): RegistrySnapshot {
+  return {
+    pillars: [...pillars],
+    fetchedAt,
+    ttlMs: 30_000,
+    source: 'fresh',
+  };
+}
+
+function makeTool(name: string, description: string): ToolDescriptor {
+  return {
+    name,
+    description: description.padEnd(15, '.'),
+    parameters: { type: 'object' },
+  };
+}
+
+describe('buildToolList', () => {
+  let currentNow = 1_700_000_000_000;
+  let currentSnapshot: RegistrySnapshot;
+  let fetchCalls = 0;
+
+  beforeEach(() => {
+    currentNow = 1_700_000_000_000;
+    fetchCalls = 0;
+    currentSnapshot = snapshot([]);
+    __setBuildToolListInternals({
+      now: () => currentNow,
+      fetchSnapshot: async () => {
+        fetchCalls += 1;
+        return currentSnapshot;
+      },
+    });
+  });
+
+  afterEach(() => {
+    __resetBuildToolListInternals();
+  });
+
+  it('flattens ai.tools across registered healthy pillars', async () => {
+    const finance = withStatus(
+      withTools(pillar('finance', 'http://finance:3004'), [
+        makeTool('createTransaction', 'create a transaction'),
+        makeTool('listBudgets', 'list active budgets'),
+      ]),
+      'healthy'
+    );
+    const media = withStatus(
+      withTools(pillar('media', 'http://media:3005'), [makeTool('searchMovies', 'find a movie')]),
+      'healthy'
+    );
+    currentSnapshot = snapshot([finance, media]);
+
+    const tools = await buildToolList();
+    expect(tools).toHaveLength(3);
+    expect(tools.map((t) => t.name)).toEqual(['createTransaction', 'listBudgets', 'searchMovies']);
+    expect(tools[0]).toMatchObject({ pillar: 'finance', pillarStatus: 'healthy' });
+    expect(tools[2]).toMatchObject({ pillar: 'media', pillarStatus: 'healthy' });
+  });
+
+  it('excludes unavailable pillars by default and includes them with includeUnavailable', async () => {
+    const healthy = withStatus(
+      withTools(pillar('finance', 'http://finance:3004'), [
+        makeTool('createTransaction', 'create'),
+      ]),
+      'healthy'
+    );
+    const down = withStatus(
+      withTools(pillar('media', 'http://media:3005'), [makeTool('searchMovies', 'find a movie')]),
+      'unavailable'
+    );
+    currentSnapshot = snapshot([healthy, down]);
+
+    const defaultList = await buildToolList();
+    expect(defaultList.map((t) => t.pillar)).toEqual(['finance']);
+
+    const diagnostic = await buildToolList({ includeUnavailable: true });
+    expect(diagnostic).toHaveLength(2);
+    const mediaEntry = diagnostic.find((t) => t.pillar === 'media');
+    expect(mediaEntry?.pillarStatus).toBe('unavailable');
+  });
+
+  it('treats unknown-status pillars as unhealthy by default', async () => {
+    const cold = withStatus(
+      withTools(pillar('food', 'http://food:3006'), [makeTool('addRecipe', 'save a recipe')]),
+      'unknown'
+    );
+    currentSnapshot = snapshot([cold]);
+
+    expect(await buildToolList()).toHaveLength(0);
+    expect(await buildToolList({ includeUnavailable: true })).toHaveLength(1);
+  });
+
+  it('falls back to the registered flag when status is missing', async () => {
+    const legacyHealthy: PillarSnapshot = {
+      ...withTools(pillar('finance', 'http://finance:3004'), [makeTool('createTransaction', 'go')]),
+      registered: true,
+    };
+    delete legacyHealthy.status;
+    const legacyDown: PillarSnapshot = {
+      ...withTools(pillar('media', 'http://media:3005'), [makeTool('searchMovies', 'go')]),
+      registered: false,
+    };
+    delete legacyDown.status;
+    currentSnapshot = snapshot([legacyHealthy, legacyDown]);
+
+    const tools = await buildToolList();
+    expect(tools.map((t) => t.pillar)).toEqual(['finance']);
+  });
+
+  it('restricts to the requested pillars when opts.pillars is set', async () => {
+    const finance = withStatus(
+      withTools(pillar('finance', 'http://finance:3004'), [makeTool('createTransaction', 'a')]),
+      'healthy'
+    );
+    const media = withStatus(
+      withTools(pillar('media', 'http://media:3005'), [makeTool('searchMovies', 'a')]),
+      'healthy'
+    );
+    currentSnapshot = snapshot([finance, media]);
+
+    const tools = await buildToolList({ pillars: ['media'] });
+    expect(tools.map((t) => t.pillar)).toEqual(['media']);
+  });
+
+  it('silently excludes pillars that declare no tools', async () => {
+    const empty = withStatus(withTools(pillar('inventory', 'http://inv:3007'), []), 'healthy');
+    const full = withStatus(
+      withTools(pillar('finance', 'http://finance:3004'), [makeTool('createTransaction', 'a')]),
+      'healthy'
+    );
+    currentSnapshot = snapshot([empty, full]);
+
+    const tools = await buildToolList();
+    expect(tools.map((t) => t.pillar)).toEqual(['finance']);
+  });
+
+  it('returns an empty list when every pillar is down', async () => {
+    const a = withStatus(
+      withTools(pillar('finance', 'http://finance:3004'), [makeTool('createTransaction', 'a')]),
+      'unavailable'
+    );
+    currentSnapshot = snapshot([a]);
+    expect(await buildToolList()).toEqual([]);
+  });
+
+  it('memoises identical requests inside the TTL window', async () => {
+    const fin = withStatus(
+      withTools(pillar('finance', 'http://finance:3004'), [makeTool('createTransaction', 'a')]),
+      'healthy'
+    );
+    currentSnapshot = snapshot([fin]);
+
+    await buildToolList();
+    await buildToolList();
+    expect(fetchCalls).toBe(2);
+
+    // The cache short-circuits the projection but still consults discovery
+    // for the snapshot — verifying memoisation by checking we returned the
+    // same reference.
+    const a = await buildToolList();
+    const b = await buildToolList();
+    expect(a).toBe(b);
+  });
+
+  it('invalidates the memo when the snapshot fetchedAt advances', async () => {
+    const fin = withStatus(
+      withTools(pillar('finance', 'http://finance:3004'), [makeTool('createTransaction', 'a')]),
+      'healthy'
+    );
+    currentSnapshot = snapshot([fin], new Date(1));
+    const first = await buildToolList();
+
+    currentSnapshot = snapshot([fin], new Date(2));
+    const second = await buildToolList();
+
+    expect(first).not.toBe(second);
+    expect(second.map((t) => t.name)).toEqual(['createTransaction']);
+  });
+
+  it('invalidates the memo after the 30s TTL elapses even if discovery is sticky', async () => {
+    const fin = withStatus(
+      withTools(pillar('finance', 'http://finance:3004'), [makeTool('createTransaction', 'a')]),
+      'healthy'
+    );
+    currentSnapshot = snapshot([fin], new Date(42));
+
+    const first = await buildToolList();
+    currentNow += TOOL_LIST_CACHE_TTL_MS + 1;
+    const second = await buildToolList();
+    expect(first).not.toBe(second);
+  });
+
+  it('keys the cache by request options', async () => {
+    const fin = withStatus(
+      withTools(pillar('finance', 'http://finance:3004'), [makeTool('createTransaction', 'a')]),
+      'healthy'
+    );
+    const down = withStatus(
+      withTools(pillar('media', 'http://media:3005'), [makeTool('searchMovies', 'a')]),
+      'unavailable'
+    );
+    currentSnapshot = snapshot([fin, down]);
+
+    const withoutDiag = await buildToolList();
+    const withDiag = await buildToolList({ includeUnavailable: true });
+    expect(withoutDiag.map((t) => t.pillar)).toEqual(['finance']);
+    expect(withDiag.map((t) => t.pillar).toSorted()).toEqual(['finance', 'media']);
+  });
+
+  it('invalidateToolListCache forces a rebuild', async () => {
+    const fin = withStatus(
+      withTools(pillar('finance', 'http://finance:3004'), [makeTool('createTransaction', 'a')]),
+      'healthy'
+    );
+    currentSnapshot = snapshot([fin]);
+    const first = await buildToolList();
+    invalidateToolListCache();
+    const second = await buildToolList();
+    expect(first).not.toBe(second);
+  });
+});

--- a/packages/pillar-sdk/src/ai-tools/build-tool-list.ts
+++ b/packages/pillar-sdk/src/ai-tools/build-tool-list.ts
@@ -116,13 +116,25 @@ function projectTools(
 }
 
 /**
+ * Resolve the effective availability of a pillar for tool-list
+ * purposes.
+ *
+ * `registered=false` is authoritative — call-time `guardAvailability`
+ * in the client factory treats an unregistered pillar as unavailable
+ * regardless of `status`, so the tool list must not advertise tools
+ * the orchestrator will then refuse to route. This matters during
+ * PRD-162 reconciliation windows where a snapshot can carry
+ * `status: 'healthy'` from the last heartbeat while the registry has
+ * already flipped `registered` to false.
+ *
  * Snapshots from PRD-161 carry an explicit `status`; older ones don't.
- * When status is missing, fall back to the discovery `registered` flag
- * (false === pillar removed itself from the registry).
+ * When `status` is missing we fall back to the same `registered`
+ * signal.
  */
 function resolveStatus(pillar: PillarSnapshot): PillarStatus {
+  if (!pillar.registered) return 'unavailable';
   if (pillar.status !== undefined) return pillar.status;
-  return pillar.registered ? 'healthy' : 'unavailable';
+  return 'healthy';
 }
 
 function makeCacheKey(fetchedAt: Date, opts: BuildToolListOptions): CacheKey {

--- a/packages/pillar-sdk/src/ai-tools/build-tool-list.ts
+++ b/packages/pillar-sdk/src/ai-tools/build-tool-list.ts
@@ -1,0 +1,138 @@
+/**
+ * `buildToolList()` — the dynamic AI tool list (PRD-201).
+ *
+ * The AI orchestrator calls this once per request. It pulls the current
+ * registry snapshot from the discovery cache (PRD-159), projects each
+ * registered pillar's `ai.tools` manifest slot (PRD-200) into a flat
+ * list, and filters out pillars that aren't currently healthy.
+ *
+ * Caching
+ *   We additionally memoise the projected list keyed by the snapshot's
+ *   `fetchedAt` timestamp, with a 30s wall-clock floor matching the
+ *   discovery TTL. This keeps high-frequency AI request bursts from
+ *   re-walking the manifests every time while still tracking the
+ *   underlying discovery TTL — if discovery serves a fresh snapshot, the
+ *   memoised entry is invalidated automatically.
+ *
+ * Known limitation
+ *   Pillars in the wild only populate `manifest.ai.tools` once they ship
+ *   PRD-200-compliant tool descriptors. Until then the function returns
+ *   an empty list — which is the correct degraded behaviour (the AI runs
+ *   with whatever in-process tools the orchestrator carries).
+ */
+import { pillarRegistry } from '../discovery/index.js';
+
+import type { PillarSnapshot, PillarStatus, RegistrySnapshot } from '../discovery/index.js';
+import type { BuildToolListOptions, Tool } from './types.js';
+
+export const TOOL_LIST_CACHE_TTL_MS = 30_000;
+
+type CacheKey = string;
+
+type CacheEntry = {
+  tools: readonly Tool[];
+  expiresAt: number;
+};
+
+type Clock = () => number;
+
+type FetchSnapshot = () => Promise<RegistrySnapshot>;
+
+type Internals = {
+  cache: Map<CacheKey, CacheEntry>;
+  now: Clock;
+  fetchSnapshot: FetchSnapshot;
+};
+
+const internals: Internals = {
+  cache: new Map(),
+  now: () => Date.now(),
+  fetchSnapshot: pillarRegistry,
+};
+
+export async function buildToolList(opts: BuildToolListOptions = {}): Promise<readonly Tool[]> {
+  const snapshot = await internals.fetchSnapshot();
+  const key = makeCacheKey(snapshot.fetchedAt, opts);
+  const now = internals.now();
+
+  const cached = internals.cache.get(key);
+  if (cached !== undefined && cached.expiresAt > now) return cached.tools;
+
+  const tools = projectTools(snapshot.pillars, opts);
+  internals.cache.set(key, { tools, expiresAt: now + TOOL_LIST_CACHE_TTL_MS });
+  pruneExpired(now);
+  return tools;
+}
+
+/**
+ * Drop every memoised tool list. Tests and the discovery-invalidation
+ * hook (PRD-159) call this to force a rebuild on next request.
+ */
+export function invalidateToolListCache(): void {
+  internals.cache.clear();
+}
+
+/**
+ * Test hook — swap the snapshot source and clock. The public surface
+ * sticks to `buildToolList`; this is intentionally not re-exported from
+ * the package root.
+ */
+export function __setBuildToolListInternals(overrides: Partial<Internals>): void {
+  if (overrides.now !== undefined) internals.now = overrides.now;
+  if (overrides.fetchSnapshot !== undefined) internals.fetchSnapshot = overrides.fetchSnapshot;
+  internals.cache.clear();
+}
+
+export function __resetBuildToolListInternals(): void {
+  internals.cache.clear();
+  internals.now = () => Date.now();
+  internals.fetchSnapshot = pillarRegistry;
+}
+
+function projectTools(
+  pillars: readonly PillarSnapshot[],
+  opts: BuildToolListOptions
+): readonly Tool[] {
+  const allowList = opts.pillars !== undefined ? new Set(opts.pillars) : null;
+  const includeUnavailable = opts.includeUnavailable === true;
+  const out: Tool[] = [];
+
+  for (const pillar of pillars) {
+    if (allowList !== null && !allowList.has(pillar.pillarId)) continue;
+    const status = resolveStatus(pillar);
+    if (!includeUnavailable && status !== 'healthy') continue;
+
+    for (const tool of pillar.manifest.ai.tools) {
+      out.push({
+        name: tool.name,
+        description: tool.description,
+        parameters: tool.parameters,
+        pillar: pillar.pillarId,
+        pillarStatus: status,
+      });
+    }
+  }
+  return out;
+}
+
+/**
+ * Snapshots from PRD-161 carry an explicit `status`; older ones don't.
+ * When status is missing, fall back to the discovery `registered` flag
+ * (false === pillar removed itself from the registry).
+ */
+function resolveStatus(pillar: PillarSnapshot): PillarStatus {
+  if (pillar.status !== undefined) return pillar.status;
+  return pillar.registered ? 'healthy' : 'unavailable';
+}
+
+function makeCacheKey(fetchedAt: Date, opts: BuildToolListOptions): CacheKey {
+  const pillars = opts.pillars !== undefined ? [...opts.pillars].toSorted().join(',') : '*';
+  const include = opts.includeUnavailable === true ? '1' : '0';
+  return `${fetchedAt.getTime()}|${pillars}|${include}`;
+}
+
+function pruneExpired(now: number): void {
+  for (const [key, entry] of internals.cache) {
+    if (entry.expiresAt <= now) internals.cache.delete(key);
+  }
+}

--- a/packages/pillar-sdk/src/ai-tools/index.ts
+++ b/packages/pillar-sdk/src/ai-tools/index.ts
@@ -1,0 +1,6 @@
+export {
+  buildToolList,
+  invalidateToolListCache,
+  TOOL_LIST_CACHE_TTL_MS,
+} from './build-tool-list.js';
+export type { Tool, BuildToolListOptions } from './types.js';

--- a/packages/pillar-sdk/src/ai-tools/types.ts
+++ b/packages/pillar-sdk/src/ai-tools/types.ts
@@ -1,0 +1,30 @@
+import type { PillarStatus } from '../discovery/index.js';
+
+/**
+ * One AI-callable tool projected from a pillar manifest's `ai.tools` slot
+ * (see PRD-200). Carries enough context for the orchestrator to route the
+ * invocation back to the owning pillar (`pillar`) and to surface its
+ * liveness (`pillarStatus`).
+ */
+export type Tool = {
+  name: string;
+  description: string;
+  parameters: Record<string, unknown>;
+  pillar: string;
+  pillarStatus: PillarStatus;
+};
+
+export type BuildToolListOptions = {
+  /**
+   * Restrict the result to tools owned by these pillar ids. Unknown ids are
+   * silently skipped (the orchestrator sees an empty list, not an error).
+   * Omit to include every registered pillar.
+   */
+  pillars?: readonly string[];
+  /**
+   * Include tools from pillars whose registry-side status is `unavailable`
+   * or `unknown`. Off by default so the AI never sees a tool it can't call.
+   * Mostly useful for diagnostics and tests.
+   */
+  includeUnavailable?: boolean;
+};

--- a/packages/pillar-sdk/src/discovery/fetcher.ts
+++ b/packages/pillar-sdk/src/discovery/fetcher.ts
@@ -91,6 +91,7 @@ function toPillarSnapshot(entry: PillarRegistryEntryPayload): PillarSnapshot {
     manifest: entry.manifest,
     registered,
     lastSeenAt,
+    ...(entry.status !== undefined ? { status: entry.status } : {}),
   };
 }
 

--- a/packages/pillar-sdk/src/discovery/index.ts
+++ b/packages/pillar-sdk/src/discovery/index.ts
@@ -8,7 +8,12 @@ export {
   DEFAULT_CACHE_TTL_MS,
   MIN_CACHE_TTL_MS,
 } from './cache.js';
-export { RegistryUnreachableError, type PillarSnapshot, type RegistrySnapshot } from './types.js';
+export {
+  RegistryUnreachableError,
+  type PillarSnapshot,
+  type PillarStatus,
+  type RegistrySnapshot,
+} from './types.js';
 export {
   computeBackoffDelay,
   startReconnectingSubscription,

--- a/packages/pillar-sdk/src/discovery/types.ts
+++ b/packages/pillar-sdk/src/discovery/types.ts
@@ -7,12 +7,27 @@ import type { ManifestPayload } from '../manifest-schema/index.js';
  * `registered` flag (false during PRD-162 reconciliation windows) and
  * normalises `lastSeenAt` from ISO string to Date.
  */
+export type PillarStatus = 'healthy' | 'unavailable' | 'unknown';
+
 export type PillarSnapshot = {
   pillarId: string;
   baseUrl: string;
   manifest: ManifestPayload;
   registered: boolean;
   lastSeenAt: Date;
+  /**
+   * Liveness flag emitted by the core registry (PRD-161).
+   *
+   * - `'healthy'`: registry got a successful healthcheck within its window.
+   * - `'unavailable'`: registry observed at least one failed healthcheck and
+   *   has not recovered. Consumers building tool lists or routing AI calls
+   *   should treat these pillars as down.
+   * - `'unknown'`: the registry has not yet probed this pillar (cold-start
+   *   window). Conservative consumers treat this as down too.
+   *
+   * Optional because legacy snapshots / tests may omit it.
+   */
+  status?: PillarStatus;
 };
 
 /**

--- a/packages/pillar-sdk/src/index.ts
+++ b/packages/pillar-sdk/src/index.ts
@@ -4,6 +4,7 @@ export * from './discovery/index.js';
 export * from './capabilities/index.js';
 export * from './ranking/index.js';
 export * from './orchestrator/index.js';
+export * from './ai-tools/index.js';
 // NOTE: contracts/ is intentionally NOT re-exported from the root barrel.
 // Re-exporting it would put @pops/finance-contract on the root index.d.ts
 // import graph, forcing every TS consumer (including non-React / non-Node


### PR DESCRIPTION
## Summary

PRD-201 — Dynamic AI tool list. Adds `@pops/pillar-sdk/ai-tools` exporting
`buildToolList()`, the per-request dynamic AI tool list. It pulls the discovery
snapshot (PRD-159), projects each pillar's `manifest.ai.tools` slot (PRD-200)
into a flat list, and filters by registry-reported pillar health.

- `buildToolList(opts?)` returns `Tool[]` with `{ name, description, parameters, pillar, pillarStatus }`.
- 30s wall-clock memoisation keyed by `(snapshot.fetchedAt, opts)` — fresh discovery snapshots invalidate the memo automatically. Explicit reset via `invalidateToolListCache()`.
- Filters: default surfaces only `'healthy'` pillars; `includeUnavailable: true` for diagnostics; `pillars: [...]` to restrict to specific ids.
- Discovery wiring: `PillarSnapshot` gains an optional `status: 'healthy' | 'unavailable' | 'unknown'` field (already validated by the snapshot schema; was being dropped in the fetcher). `PillarStatus` re-exported from `@pops/pillar-sdk/discovery`.
- Backward-compatible fallback: when `status` is absent, treat `registered=true` as healthy, `registered=false` as unavailable. Keeps PRD-162 reconciliation semantics intact.

## Known limitation

Pillars only populate `manifest.ai.tools` once they ship PRD-200 descriptors.
Until then `buildToolList()` returns an empty list — the AI runs with whatever
in-process tools the orchestrator already carries. This matches the PRD's
"all pillars down -> empty tool list" edge case.

## Test plan

- [x] 12 new cases in `src/ai-tools/__tests__/build-tool-list.test.ts` covering: flattening, filter-by-health (`healthy` / `unavailable` / `unknown`), legacy `registered`-flag fallback, `pillars` restriction, empty-tools pillars, all-down empty list, per-snapshot memo, snapshot-advance invalidation, 30s TTL invalidation, opts-keyed cache, explicit `invalidateToolListCache()`.
- [x] Full pillar-sdk suite: 321/321 pass.
- [x] `pnpm typecheck` across all 66 packages: green.
- [x] `pnpm lint`: no new errors.
- [x] `oxfmt --check`: clean.
