### PR TITLE
feat(pillar-sdk): search adapter manifest US-01 (PRD-196)

### DIFF
--- a/apps/pops-core-api/src/__tests__/heartbeat.test.ts
+++ b/apps/pops-core-api/src/__tests__/heartbeat.test.ts
@@ -70,11 +70,25 @@ function financeManifest(): ManifestPayload {
       tag: 'contract-finance@v1.2.3',
     },
     routes: {
-      queries: ['finance.transactions.list'],
+      queries: ['finance.transactions.list', 'finance.transactions.search'],
       mutations: ['finance.transactions.create'],
       subscriptions: [],
     },
-    search: { adapters: ['transactionsAdapter'] },
+    search: {
+      adapters: [
+        {
+          name: 'transactionsAdapter',
+          entityType: 'transaction',
+          queryShape: {
+            supportsText: true,
+            supportsTags: false,
+            supportsDateRange: false,
+            supportsScope: [],
+          },
+          procedurePath: 'finance.transactions.search',
+        },
+      ],
+    },
     ai: { tools: [] },
     uri: { types: ['finance/transaction'] },
     settings: { keys: [] },
@@ -91,8 +105,26 @@ function mediaManifest(): ManifestPayload {
       version: '0.5.0',
       tag: 'contract-media@v0.5.0',
     },
-    routes: { queries: ['media.library.list'], mutations: [], subscriptions: [] },
-    search: { adapters: ['libraryAdapter'] },
+    routes: {
+      queries: ['media.library.list', 'media.library.search'],
+      mutations: [],
+      subscriptions: [],
+    },
+    search: {
+      adapters: [
+        {
+          name: 'libraryAdapter',
+          entityType: 'movie',
+          queryShape: {
+            supportsText: true,
+            supportsTags: false,
+            supportsDateRange: false,
+            supportsScope: [],
+          },
+          procedurePath: 'media.library.search',
+        },
+      ],
+    },
     ai: { tools: [] },
     uri: { types: ['media/movie'] },
     settings: { keys: [] },

--- a/apps/pops-core-api/src/__tests__/registry.test.ts
+++ b/apps/pops-core-api/src/__tests__/registry.test.ts
@@ -56,11 +56,25 @@ function financeManifest(overrides?: Partial<ManifestPayload>): ManifestPayload 
       tag: 'contract-finance@v1.2.3',
     },
     routes: {
-      queries: ['finance.transactions.list'],
+      queries: ['finance.transactions.list', 'finance.transactions.search'],
       mutations: ['finance.transactions.create'],
       subscriptions: [],
     },
-    search: { adapters: ['transactionsAdapter'] },
+    search: {
+      adapters: [
+        {
+          name: 'transactionsAdapter',
+          entityType: 'transaction',
+          queryShape: {
+            supportsText: true,
+            supportsTags: false,
+            supportsDateRange: false,
+            supportsScope: [],
+          },
+          procedurePath: 'finance.transactions.search',
+        },
+      ],
+    },
     ai: {
       tools: [
         {
@@ -87,11 +101,25 @@ function mediaManifest(): ManifestPayload {
       tag: 'contract-media@v0.5.0',
     },
     routes: {
-      queries: ['media.library.list'],
+      queries: ['media.library.list', 'media.library.search'],
       mutations: [],
       subscriptions: [],
     },
-    search: { adapters: ['libraryAdapter'] },
+    search: {
+      adapters: [
+        {
+          name: 'libraryAdapter',
+          entityType: 'movie',
+          queryShape: {
+            supportsText: true,
+            supportsTags: false,
+            supportsDateRange: false,
+            supportsScope: [],
+          },
+          procedurePath: 'media.library.search',
+        },
+      ],
+    },
     ai: { tools: [] },
     uri: { types: ['media/movie'] },
     settings: { keys: [] },

--- a/apps/pops-core-api/src/__tests__/subscribe.test.ts
+++ b/apps/pops-core-api/src/__tests__/subscribe.test.ts
@@ -73,11 +73,25 @@ function financeManifest(): ManifestPayload {
       tag: 'contract-finance@v1.2.3',
     },
     routes: {
-      queries: ['finance.transactions.list'],
+      queries: ['finance.transactions.list', 'finance.transactions.search'],
       mutations: ['finance.transactions.create'],
       subscriptions: [],
     },
-    search: { adapters: ['transactionsAdapter'] },
+    search: {
+      adapters: [
+        {
+          name: 'transactionsAdapter',
+          entityType: 'transaction',
+          queryShape: {
+            supportsText: true,
+            supportsTags: false,
+            supportsDateRange: false,
+            supportsScope: [],
+          },
+          procedurePath: 'finance.transactions.search',
+        },
+      ],
+    },
     ai: {
       tools: [
         {

--- a/docs/themes/13-pillar-finale/prds/196-search-adapter-manifest/README.md
+++ b/docs/themes/13-pillar-finale/prds/196-search-adapter-manifest/README.md
@@ -14,7 +14,7 @@ Extends the manifest schema (PRD-157) with richer search adapter shape:
 search: {
   adapters: readonly {
     name: string;                  // 'transactions' | 'movies' | ...
-    entityType: string;            // 'transaction', 'movie', ...
+    entityType: string;            // lowercase kebab-case, e.g. 'transaction', 'tv-show'
     queryShape: {
       supportsText: boolean;       // free-text query
       supportsTags: boolean;

--- a/packages/pillar-sdk/src/__tests__/fixtures.ts
+++ b/packages/pillar-sdk/src/__tests__/fixtures.ts
@@ -1,5 +1,33 @@
 import type { ManifestPayload } from '../manifest-schema/schema.js';
 
+function validAdapters(): ManifestPayload['search']['adapters'] {
+  return [
+    {
+      name: 'transactionsAdapter',
+      entityType: 'transaction',
+      queryShape: {
+        supportsText: true,
+        supportsTags: true,
+        supportsDateRange: true,
+        supportsScope: ['accountId'],
+      },
+      procedurePath: 'finance.transactions.search',
+    },
+    {
+      name: 'budgetsAdapter',
+      entityType: 'budget',
+      queryShape: {
+        supportsText: true,
+        supportsTags: false,
+        supportsDateRange: false,
+        supportsScope: [],
+      },
+      procedurePath: 'finance.budgets.search',
+      rankFieldName: 'updatedAt',
+    },
+  ];
+}
+
 export function validManifest(): ManifestPayload {
   return {
     pillar: 'finance',
@@ -10,13 +38,16 @@ export function validManifest(): ManifestPayload {
       tag: 'contract-finance@v1.2.3',
     },
     routes: {
-      queries: ['finance.transactions.list', 'finance.budgets.get'],
+      queries: [
+        'finance.transactions.list',
+        'finance.transactions.search',
+        'finance.budgets.get',
+        'finance.budgets.search',
+      ],
       mutations: ['finance.transactions.create'],
       subscriptions: [],
     },
-    search: {
-      adapters: ['transactionsAdapter', 'budgetsAdapter'],
-    },
+    search: { adapters: validAdapters() },
     ai: {
       tools: [
         {
@@ -26,14 +57,8 @@ export function validManifest(): ManifestPayload {
         },
       ],
     },
-    uri: {
-      types: ['finance/transaction', 'finance/budget'],
-    },
-    settings: {
-      keys: ['finance.defaultCurrency', 'finance.locale'],
-    },
-    healthcheck: {
-      path: '/healthz',
-    },
+    uri: { types: ['finance/transaction', 'finance/budget'] },
+    settings: { keys: ['finance.defaultCurrency', 'finance.locale'] },
+    healthcheck: { path: '/healthz' },
   };
 }

--- a/packages/pillar-sdk/src/__tests__/schema.test.ts
+++ b/packages/pillar-sdk/src/__tests__/schema.test.ts
@@ -142,11 +142,101 @@ describe('ManifestPayloadSchema', () => {
     });
   });
 
-  describe('search adapters regex', () => {
-    it.each(['Foo', 'foo-bar', '1foo', ''])('rejects %s', (adapter) => {
+  describe('search adapters', () => {
+    it.each(['Foo', 'foo-bar', '1foo', ''])('rejects non-camelCase name %s', (name) => {
       const m = validManifest();
-      m.search.adapters = [adapter];
+      m.search.adapters[0]!.name = name;
       const result = ManifestPayloadSchema.safeParse(m);
+      expect(result.success).toBe(false);
+    });
+
+    it.each(['Transaction', 'transaction-type', '1type', ''])(
+      'rejects non-camelCase entityType %s',
+      (entityType) => {
+        const m = validManifest();
+        m.search.adapters[0]!.entityType = entityType;
+        const result = ManifestPayloadSchema.safeParse(m);
+        expect(result.success).toBe(false);
+      }
+    );
+
+    it.each([
+      'finance.transactions',
+      'finance',
+      'Finance.transactions.search',
+      'finance.transactions.search.extra',
+    ])('rejects malformed procedurePath %s', (procedurePath) => {
+      const m = validManifest();
+      m.search.adapters[0]!.procedurePath = procedurePath;
+      const result = ManifestPayloadSchema.safeParse(m);
+      expect(result.success).toBe(false);
+    });
+
+    it('accepts adapter with rankFieldName omitted', () => {
+      const result = ManifestPayloadSchema.safeParse(validManifest());
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts adapter with rankFieldName set', () => {
+      const m = validManifest();
+      m.search.adapters[0]!.rankFieldName = 'createdAt';
+      const result = ManifestPayloadSchema.safeParse(m);
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects non-camelCase rankFieldName', () => {
+      const m = validManifest();
+      m.search.adapters[0]!.rankFieldName = 'created_at';
+      const result = ManifestPayloadSchema.safeParse(m);
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects non-camelCase queryShape.supportsScope entry', () => {
+      const m = validManifest();
+      m.search.adapters[0]!.queryShape.supportsScope = ['Account-Id'];
+      const result = ManifestPayloadSchema.safeParse(m);
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects unknown adapter field (strict mode)', () => {
+      const m = validManifest();
+      const input = {
+        ...m,
+        search: {
+          adapters: [{ ...m.search.adapters[0]!, sneaky: true }, m.search.adapters[1]!],
+        },
+      };
+      const result = ManifestPayloadSchema.safeParse(input);
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects unknown queryShape field (strict mode)', () => {
+      const m = validManifest();
+      const input = {
+        ...m,
+        search: {
+          adapters: [
+            {
+              ...m.search.adapters[0]!,
+              queryShape: { ...m.search.adapters[0]!.queryShape, sneaky: true },
+            },
+            m.search.adapters[1]!,
+          ],
+        },
+      };
+      const result = ManifestPayloadSchema.safeParse(input);
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects missing queryShape fields', () => {
+      const m = validManifest();
+      const input = {
+        ...m,
+        search: {
+          adapters: [{ ...m.search.adapters[0]!, queryShape: { supportsText: true } }],
+        },
+      };
+      const result = ManifestPayloadSchema.safeParse(input);
       expect(result.success).toBe(false);
     });
   });

--- a/packages/pillar-sdk/src/__tests__/schema.test.ts
+++ b/packages/pillar-sdk/src/__tests__/schema.test.ts
@@ -150,13 +150,23 @@ describe('ManifestPayloadSchema', () => {
       expect(result.success).toBe(false);
     });
 
-    it.each(['Transaction', 'transaction-type', '1type', ''])(
-      'rejects non-camelCase entityType %s',
+    it.each(['Transaction', '1type', '', 'transaction_type', '-leading', 'trailing-'])(
+      'rejects non-kebab-case entityType %s',
       (entityType) => {
         const m = validManifest();
         m.search.adapters[0]!.entityType = entityType;
         const result = ManifestPayloadSchema.safeParse(m);
         expect(result.success).toBe(false);
+      }
+    );
+
+    it.each(['transaction', 'transaction-type', 'tv-show', 'a', 'paperless-document-2'])(
+      'accepts kebab-case entityType %s',
+      (entityType) => {
+        const m = validManifest();
+        m.search.adapters[0]!.entityType = entityType;
+        const result = ManifestPayloadSchema.safeParse(m);
+        expect(result.success).toBe(true);
       }
     );
 

--- a/packages/pillar-sdk/src/__tests__/validate.test.ts
+++ b/packages/pillar-sdk/src/__tests__/validate.test.ts
@@ -4,6 +4,7 @@ import {
   checkAiToolAllowedUriTypesAreDeclared,
   checkContractPackageMatchesPillar,
   checkContractTagMatchesVersion,
+  checkSearchAdapterProceduresAreDeclared,
   pathToDotted,
   validateManifestPayload,
 } from '../manifest-schema/validate.js';
@@ -253,6 +254,56 @@ describe('cross-field checkers (pure)', () => {
       const fields = issues.map((i) => i.field).toSorted();
       expect(fields).toEqual(['ai.tools[0].allowedUriTypes[0]', 'ai.tools[1].allowedUriTypes[1]']);
     });
+  });
+});
+
+describe('checkSearchAdapterProceduresAreDeclared', () => {
+  it('returns [] when every adapter procedurePath is declared', () => {
+    expect(checkSearchAdapterProceduresAreDeclared(validManifest())).toEqual([]);
+  });
+
+  it('emits an issue when an adapter references an undeclared procedure', () => {
+    const m = validManifest();
+    m.search.adapters[0]!.procedurePath = 'finance.transactions.missing';
+    const issues = checkSearchAdapterProceduresAreDeclared(m);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]!.field).toBe('search.adapters[0].procedurePath');
+    expect(issues[0]!.got).toBe('finance.transactions.missing');
+    expect(issues[0]!.reason).toContain('not declared in routes.queries or routes.mutations');
+    expect(issues[0]!.schemaPath).toEqual(['search', 'adapters', 0, 'procedurePath']);
+  });
+
+  it('accepts a procedurePath declared in routes.mutations', () => {
+    const m = validManifest();
+    m.search.adapters[0]!.procedurePath = 'finance.transactions.create';
+    expect(checkSearchAdapterProceduresAreDeclared(m)).toEqual([]);
+  });
+
+  it('reports across multiple adapters without short-circuiting', () => {
+    const m = validManifest();
+    m.search.adapters[0]!.procedurePath = 'finance.transactions.missingA';
+    m.search.adapters[1]!.procedurePath = 'finance.budgets.missingB';
+    const issues = checkSearchAdapterProceduresAreDeclared(m);
+    expect(issues).toHaveLength(2);
+    const fields = issues.map((i) => i.field).toSorted();
+    expect(fields).toEqual([
+      'search.adapters[0].procedurePath',
+      'search.adapters[1].procedurePath',
+    ]);
+  });
+});
+
+describe('validateManifestPayload — search adapter cross-field rules', () => {
+  it('rejects a manifest whose adapter references an undeclared procedure', () => {
+    const m = validManifest();
+    m.search.adapters[0]!.procedurePath = 'finance.transactions.notDeclared';
+    const result = validateManifestPayload(m);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.issues).toHaveLength(1);
+      expect(result.issues[0]!.field).toBe('search.adapters[0].procedurePath');
+      expect(result.issues[0]!.got).toBe('finance.transactions.notDeclared');
+    }
   });
 });
 

--- a/packages/pillar-sdk/src/manifest-schema/index.ts
+++ b/packages/pillar-sdk/src/manifest-schema/index.ts
@@ -4,6 +4,7 @@ export {
   checkContractPackageMatchesPillar,
   checkContractTagMatchesVersion,
   checkAiToolAllowedUriTypesAreDeclared,
+  checkSearchAdapterProceduresAreDeclared,
   pathToDotted,
   type ValidationResult,
   type ValidationIssue,

--- a/packages/pillar-sdk/src/manifest-schema/schema.ts
+++ b/packages/pillar-sdk/src/manifest-schema/schema.ts
@@ -55,9 +55,28 @@ const ROUTES = z
   })
   .strict();
 
+const QUERY_SHAPE = z
+  .object({
+    supportsText: z.boolean(),
+    supportsTags: z.boolean(),
+    supportsDateRange: z.boolean(),
+    supportsScope: z.array(CAMEL_IDENTIFIER),
+  })
+  .strict();
+
+const SEARCH_ADAPTER = z
+  .object({
+    name: CAMEL_IDENTIFIER,
+    entityType: CAMEL_IDENTIFIER,
+    queryShape: QUERY_SHAPE,
+    procedurePath: PROCEDURE_PATH,
+    rankFieldName: CAMEL_IDENTIFIER.optional(),
+  })
+  .strict();
+
 const SEARCH = z
   .object({
-    adapters: z.array(CAMEL_IDENTIFIER),
+    adapters: z.array(SEARCH_ADAPTER),
   })
   .strict();
 

--- a/packages/pillar-sdk/src/manifest-schema/schema.ts
+++ b/packages/pillar-sdk/src/manifest-schema/schema.ts
@@ -13,6 +13,10 @@ const PROCEDURE_PATH = z
 
 const CAMEL_IDENTIFIER = z.string().regex(/^[a-z][a-zA-Z0-9]*$/, 'must be camelCase identifier');
 
+const KEBAB_IDENTIFIER = z
+  .string()
+  .regex(/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/, 'must be lowercase kebab-case identifier');
+
 const URI_TYPE = z
   .string()
   .regex(/^[a-z][a-z0-9-]*\/[a-z][a-z0-9-]*$/, 'must be <pillar>/<entity>');
@@ -67,7 +71,7 @@ const QUERY_SHAPE = z
 const SEARCH_ADAPTER = z
   .object({
     name: CAMEL_IDENTIFIER,
-    entityType: CAMEL_IDENTIFIER,
+    entityType: KEBAB_IDENTIFIER,
     queryShape: QUERY_SHAPE,
     procedurePath: PROCEDURE_PATH,
     rankFieldName: CAMEL_IDENTIFIER.optional(),

--- a/packages/pillar-sdk/src/manifest-schema/validate.ts
+++ b/packages/pillar-sdk/src/manifest-schema/validate.ts
@@ -27,6 +27,7 @@ export function validateManifestPayload(input: unknown): ValidationResult {
     ...checkContractPackageMatchesPillar(parsed.data),
     ...checkContractTagMatchesVersion(parsed.data),
     ...checkAiToolAllowedUriTypesAreDeclared(parsed.data),
+    ...checkSearchAdapterProceduresAreDeclared(parsed.data),
   ];
 
   if (crossFieldIssues.length > 0) {
@@ -119,6 +120,30 @@ export function checkContractTagMatchesVersion(payload: ManifestPayload): Valida
       schemaPath: ['contract', 'tag'],
     },
   ];
+}
+
+/**
+ * Each search adapter's `procedurePath` must reference a procedure the
+ * pillar actually exposes (a `routes.queries` or `routes.mutations` entry).
+ * PRD-196 business rule: an adapter cannot fan out to a procedure the
+ * pillar doesn't serve.
+ */
+export function checkSearchAdapterProceduresAreDeclared(
+  payload: ManifestPayload
+): ValidationIssue[] {
+  const declared = new Set<string>([...payload.routes.queries, ...payload.routes.mutations]);
+  const issues: ValidationIssue[] = [];
+  payload.search.adapters.forEach((adapter, adapterIndex) => {
+    if (declared.has(adapter.procedurePath)) return;
+    const path: (string | number)[] = ['search', 'adapters', adapterIndex, 'procedurePath'];
+    issues.push({
+      field: pathToDotted(path),
+      reason: `procedurePath '${adapter.procedurePath}' is not declared in routes.queries or routes.mutations`,
+      got: adapter.procedurePath,
+      schemaPath: path,
+    });
+  });
+  return issues;
 }
 
 /**


### PR DESCRIPTION
Adds structured `SearchAdapter[]` to manifest schema replacing opaque `search.adapters: string[]`. Includes cross-field validator ensuring `procedurePath` references declared routes. Test coverage: 329 pillar-sdk tests pass + all api fixture tests updated.

Refs docs/themes/13-pillar-finale/prds/196-search-adapter-manifest/README.md