### PR TITLE
docs(theme-13): rewrite PRD-174 — inventory.reports is runtime aggregation

### DIFF
--- a/docs/themes/13-pillar-finale/epics/03-remaining-data-migrations.md
+++ b/docs/themes/13-pillar-finale/epics/03-remaining-data-migrations.md
@@ -13,6 +13,7 @@ By the end of this epic, every table is owned by exactly one pillar's DB and the
 - **Media (8):** movies, tvShows, watchlist, watchHistory, library, discovery, arr, plex
   - `plex` ([PRD-172](../prds/172-media-plex-cutover/)) is documentation-only — no tables to move, slice has no N-track sequence.
 - **Inventory (6):** items, reports, connections, documents, paperless, warranties
+  - `reports` ([PRD-174](../prds/174-inventory-reports-cutover/)) is documentation-only — runtime aggregation over inventory tables owned by PRD-173 / PRD-176, no own schema, no N-track sequence.
 - **Cerebrum (4):** engrams, plexus, glia, conversations
 - **Core (4):** settings, tagRules (already shimmed), corrections (already shimmed), aiUsage
 

--- a/docs/themes/13-pillar-finale/prds/174-inventory-reports-cutover/README.md
+++ b/docs/themes/13-pillar-finale/prds/174-inventory-reports-cutover/README.md
@@ -6,7 +6,7 @@
 
 ## Overview
 
-`inventory.reports.*` is a read-only aggregation surface — dashboard summaries, warranty lists, value breakdowns, and the insurance report — computed at request time by joining `home_inventory`, `item_photos`, `item_documents`, and `locations`. There is no `insurance_reports` table, no report cache, no persisted report metadata. Reports are produced by SQL aggregations and returned to the caller; nothing is written.
+`inventory.reports.*` is a read-only aggregation surface — dashboard summaries, warranty lists, value breakdowns, and the insurance report — computed at request time over `home_inventory`, `item_photos`, `item_documents`, and `locations`. There is no `insurance_reports` table, no report cache, no persisted report metadata. Reports are produced by read-only DB queries (some using SQL aggregates, others by reading rows and grouping in-memory) and returned to the caller; nothing is written.
 
 Because the slice owns zero schema, the canonical 4-PR N-track sequence (package scaffold → journal split → handle flip → shim deletion) does not apply. The handle the router uses (`getInventoryDrizzle()`) already resolves to `inventory.db` once the source tables move there under their own PRDs.
 
@@ -16,13 +16,13 @@ This PRD is preserved as a documented no-op so the epic's slice list stays compl
 
 Surveyed `apps/pops-api/src/modules/inventory/reports/` (2026-06-13):
 
-| File                  | Role                                                                                                           |
-| --------------------- | -------------------------------------------------------------------------------------------------------------- |
-| `router.ts`           | tRPC router exposing `dashboard`, `warranties`, `insuranceReport`, `valueByLocation`, `valueByType`.           |
-| `service.ts`          | Aggregation queries (counts, sums, warranty windows, recent items, value-by-X breakdowns) via `drizzle-orm`.   |
-| `insurance-report.ts` | Cross-join report over `home_inventory` + `locations` + `item_photos` + `item_documents`, grouped by location. |
-| `types.ts`            | `DashboardSummary`, `RecentItem`, `ValueBreakdownEntry`. All response shapes; no row types.                    |
-| `index.ts`            | Re-export only.                                                                                                |
+| File                  | Role                                                                                                                                                                                                                        |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `router.ts`           | tRPC router exposing `dashboard`, `warranties`, `insuranceReport`, `valueByLocation`, `valueByType`.                                                                                                                        |
+| `service.ts`          | Aggregation queries (counts, sums, warranty windows, recent items, value-by-X breakdowns) via `drizzle-orm`.                                                                                                                |
+| `insurance-report.ts` | Report over `home_inventory` + `locations` + `item_photos` + `item_documents`. Reads each table with `select().all()`, then assembles lookup maps and groups items by location in memory (no SQL join, no SQL aggregation). |
+| `types.ts`            | `DashboardSummary`, `RecentItem`, `ValueBreakdownEntry`. All response shapes; no row types.                                                                                                                                 |
+| `index.ts`            | Re-export only.                                                                                                                                                                                                             |
 
 Grep results that confirm the no-DB picture:
 
@@ -33,13 +33,13 @@ Grep results that confirm the no-DB picture:
 
 The actual wire surface today is:
 
-| Procedure                           | Kind  | Computes                                                                                                                                            |
-| ----------------------------------- | ----- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `inventory.reports.dashboard`       | query | Item count, total replacement value, total resale value, count of warranties expiring in the next 90 days, 5 most-recently-edited items.            |
-| `inventory.reports.warranties`      | query | Every item with a non-null `warrantyExpires`, sorted by expiry; left-joined with `item_documents` to surface a warranty document id.                |
-| `inventory.reports.insuranceReport` | query | Items grouped by location (optionally restricted to a location subtree), each with primary photo path, replacement value, and receipt document ids. |
-| `inventory.reports.valueByLocation` | query | `SUM(replacementValue)` grouped by `locations.name` (with an `Unassigned` bucket).                                                                  |
-| `inventory.reports.valueByType`     | query | `SUM(replacementValue)` grouped by `homeInventory.type` (with an `Uncategorized` bucket).                                                           |
+| Procedure                           | Kind  | Computes                                                                                                                                                                                                                           |
+| ----------------------------------- | ----- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `inventory.reports.dashboard`       | query | Item count, total replacement value, total resale value, count of warranties expiring in the next 90 days, 5 most-recently-edited items.                                                                                           |
+| `inventory.reports.warranties`      | query | Every item with a non-null `warrantyExpires`, sorted by expiry; left-joined with `item_documents` to surface the warranty's Paperless document id (`itemDocuments.paperlessDocumentId`, not a local `item_documents.id`).          |
+| `inventory.reports.insuranceReport` | query | Items grouped by location (optionally restricted to a location subtree), each with primary photo path, replacement value, and receipt Paperless document ids (`itemDocuments.paperlessDocumentId`, not local `item_documents.id`). |
+| `inventory.reports.valueByLocation` | query | `SUM(replacementValue)` grouped by `locations.name` (with an `Unassigned` bucket).                                                                                                                                                 |
+| `inventory.reports.valueByType`     | query | `SUM(replacementValue)` grouped by `homeInventory.type` (with an `Uncategorized` bucket).                                                                                                                                          |
 
 The earlier draft of this PRD described an `insurance_reports` table with `{ id, title, generated_at, criteria_json, file_path }` and procedures `list` / `generate` / `get` / `delete`. None of those exist. The live shape is "aggregate-on-read"; reports are never persisted, never cached, and never have a file path.
 

--- a/docs/themes/13-pillar-finale/prds/174-inventory-reports-cutover/README.md
+++ b/docs/themes/13-pillar-finale/prds/174-inventory-reports-cutover/README.md
@@ -1,56 +1,78 @@
 # PRD-174: inventory.reports cutover
 
 > Epic: [Remaining data migrations](../../epics/03-remaining-data-migrations.md)
+>
+> **Status: Done (no work required).** The slice owns no tables of its own — it is a runtime aggregation router over inventory tables owned by neighbouring PRDs. See [Investigation](#investigation) below.
 
 ## Overview
 
-Move `inventory.reports.*` (insurance reports + related views) into `inventory.db`. Follows the canonical N-track pattern from [PRD-165](../165-media-movies-cutover/README.md).
+`inventory.reports.*` is a read-only aggregation surface — dashboard summaries, warranty lists, value breakdowns, and the insurance report — computed at request time by joining `home_inventory`, `item_photos`, `item_documents`, and `locations`. There is no `insurance_reports` table, no report cache, no persisted report metadata. Reports are produced by SQL aggregations and returned to the caller; nothing is written.
 
-Reports are generated aggregations of the inventory: total value, per-room summaries, insurance schedules. Today they're computed views over `home_inventory` + `locations` + `item_photos`; after PRD-173 lands, all source data is in `inventory.db` and the report generators just need their handle flipped.
+Because the slice owns zero schema, the canonical 4-PR N-track sequence (package scaffold → journal split → handle flip → shim deletion) does not apply. The handle the router uses (`getInventoryDrizzle()`) already resolves to `inventory.db` once the source tables move there under their own PRDs.
 
-## Data Model
+This PRD is preserved as a documented no-op so the epic's slice list stays complete and so a future agent doesn't reopen the question.
 
-Tables (move from shared to `packages/inventory-db`):
+## Investigation
 
-- `insurance_reports` — generated report metadata; { id, title, generated_at, criteria_json, file_path }
-- Plus uses joins over `home_inventory`, `locations`, `item_photos`, `item_documents` (all already in `inventory.db` after PRD-173).
+Surveyed `apps/pops-api/src/modules/inventory/reports/` (2026-06-13):
 
-## API Surface
+| File                  | Role                                                                                                           |
+| --------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `router.ts`           | tRPC router exposing `dashboard`, `warranties`, `insuranceReport`, `valueByLocation`, `valueByType`.           |
+| `service.ts`          | Aggregation queries (counts, sums, warranty windows, recent items, value-by-X breakdowns) via `drizzle-orm`.   |
+| `insurance-report.ts` | Cross-join report over `home_inventory` + `locations` + `item_photos` + `item_documents`, grouped by location. |
+| `types.ts`            | `DashboardSummary`, `RecentItem`, `ValueBreakdownEntry`. All response shapes; no row types.                    |
+| `index.ts`            | Re-export only.                                                                                                |
 
-| Procedure                    | Kind     |
-| ---------------------------- | -------- |
-| `inventory.reports.list`     | query    |
-| `inventory.reports.generate` | mutation |
-| `inventory.reports.get`      | query    |
-| `inventory.reports.delete`   | mutation |
+Grep results that confirm the no-DB picture:
 
-Files today: `apps/pops-api/src/modules/inventory/reports/{router.ts, service.ts, insurance-report.ts}`.
+- `insurance_reports` — does not exist anywhere in the repo (no schema, no migration, no Drizzle type, no SQL).
+- `insuranceReports` — does not exist anywhere in the repo as a Drizzle table.
+- All four tables the router joins (`homeInventory`, `itemPhotos`, `itemDocuments`, `locations`) come from `@pops/db-types`; their cutover is owned by **PRD-173 (`inventory.items`)** and **PRD-176 (`inventory.documents`)**.
+- The handle is `getInventoryDrizzle()` (already pillar-scoped). Once PRD-173 and PRD-176 land, that handle resolves to `inventory.db` for every join — no router change needed here.
 
-## Business Rules
+The actual wire surface today is:
 
-Follows [PRD-165's 4-PR sequence](../165-media-movies-cutover/README.md#business-rules--the-n-track-4-pr-sequence). Slice specifics:
+| Procedure                           | Kind  | Computes                                                                                                                                            |
+| ----------------------------------- | ----- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `inventory.reports.dashboard`       | query | Item count, total replacement value, total resale value, count of warranties expiring in the next 90 days, 5 most-recently-edited items.            |
+| `inventory.reports.warranties`      | query | Every item with a non-null `warrantyExpires`, sorted by expiry; left-joined with `item_documents` to surface a warranty document id.                |
+| `inventory.reports.insuranceReport` | query | Items grouped by location (optionally restricted to a location subtree), each with primary photo path, replacement value, and receipt document ids. |
+| `inventory.reports.valueByLocation` | query | `SUM(replacementValue)` grouped by `locations.name` (with an `Unassigned` bucket).                                                                  |
+| `inventory.reports.valueByType`     | query | `SUM(replacementValue)` grouped by `homeInventory.type` (with an `Uncategorized` bucket).                                                           |
 
-- Report generation is read-heavy; the cutover only affects which handle joins are computed against.
-- Generated PDF/CSV files are stored on disk; file paths are absolute and survive the cutover.
+The earlier draft of this PRD described an `insurance_reports` table with `{ id, title, generated_at, criteria_json, file_path }` and procedures `list` / `generate` / `get` / `delete`. None of those exist. The live shape is "aggregate-on-read"; reports are never persisted, never cached, and never have a file path.
 
-## Edge Cases
+### PRD discrepancy
 
-| Case                                                                | Behaviour                                                   |
-| ------------------------------------------------------------------- | ----------------------------------------------------------- |
-| Report generation references items that haven't been backfilled yet | PRD-173 (items) must land first; gates this PRD's PR 3.     |
-| Generated file path is stale (file deleted out-of-band)             | Existing behaviour preserved; report row returns null file. |
+The original PRD-174 data model and API table were copy-paste from the canonical PRD-165 template without a fact check against `apps/pops-api/src/modules/inventory/reports/`. Two corrections:
 
-## User Stories
+1. **No `insurance_reports` table.** The router computes the report on every call. There is no `criteria_json`, no `file_path`, no `generated_at`.
+2. **No `list` / `generate` / `get` / `delete` procedures.** The router exposes five read-only queries (see table above).
 
-| #   | Story                                                       | Summary                                           |
-| --- | ----------------------------------------------------------- | ------------------------------------------------- |
-| 01  | [us-01-pr1-package-scaffold](us-01-pr1-package-scaffold.md) | PR 1 — Schema + service into `@pops/inventory-db` |
-| 02  | [us-02-pr2-journal-split](us-02-pr2-journal-split.md)       | PR 2 — Drop from shared journal                   |
-| 03  | [us-03-pr3-cutover](us-03-pr3-cutover.md)                   | PR 3 — Flip router to `getInventoryDrizzle()`     |
-| 04  | [us-04-pr4-shim-deletion](us-04-pr4-shim-deletion.md)       | PR 4 — Delete or defer shim                       |
+Either the original PRD captured a speculative future-state design, or it was templated from PRD-165 (`media.movies`) without inspection. Either way, the live shape is "runtime aggregation over inventory tables".
+
+## Decision
+
+**No PRs to ship.** The slice is complete-by-construction:
+
+- No own schema → nothing to move to `inventory.db`.
+- No shared-journal entries to drop (PR2-equivalent is a no-op).
+- No router handle to flip — `getInventoryDrizzle()` is already the pillar-scoped handle, and its target follows the source tables under PRD-173 / PRD-176.
+- No shim to delete (PR4-equivalent is a no-op).
+
+When PRD-173 (items) and PRD-176 (documents) land, every join in this router automatically resolves against `inventory.db` with zero change to `reports/`. That is the entire "cutover" for this slice.
+
+If a future feature persists generated reports (e.g. signed PDF snapshots, saved insurance schedules with criteria captured at generation time), that work goes in a **new** PRD scoped to those tables — not in PRD-174.
+
+## Dependencies
+
+- **Reads from (no writes):** `home_inventory`, `item_photos`, `item_documents`, `locations` — all owned by PRD-173 (items + photos) and PRD-176 (documents).
+- **Coupled to:** PRD-173 and PRD-176 landing first so the joined tables actually live on `inventory.db`. No code change required in `reports/` after they land.
 
 ## Out of Scope
 
-- Report templates / formatting changes.
-- New report types beyond insurance.
-- Cloud export of generated reports.
+- New report types (saved insurance schedules, depreciation reports, time-series value tracking) — would need their own PRD with their own tables.
+- Report caching or pre-computation — current aggregations are cheap; no performance need identified.
+- PDF / CSV export of reports — not part of the current router; would need a new PRD.
+- Changes to the underlying inventory tables — owned by PRD-173 / PRD-176.


### PR DESCRIPTION
## Summary

PRD-174 (`inventory.reports` cutover) — investigation outcome. Mirrors the doc-rewrite pattern from #3032 (PRD-171), #3034 (PRD-172), #3035 (PRD-177).

The PRD's original data model (`insurance_reports` table with `{ id, title, generated_at, criteria_json, file_path }`) was speculative. Reading `apps/pops-api/src/modules/inventory/reports/` shows it doesn't exist.

### Findings

- `insurance_reports` — no schema, no migration, no Drizzle type, no SQL reference anywhere in the repo.
- The router exposes five **read-only queries**, not the `list` / `generate` / `get` / `delete` shape the original PRD described:
  - `dashboard` — item count, replacement/resale value totals, warranty alerts, recently-added items.
  - `warranties` — items with `warrantyExpires`, sorted by expiry.
  - `insuranceReport` — items grouped by location with photo paths and totals (computed on every call).
  - `valueByLocation` — `SUM(replacementValue)` grouped by `locations.name`.
  - `valueByType` — `SUM(replacementValue)` grouped by `homeInventory.type`.
- The slice's source tables (`home_inventory`, `item_photos`, `item_documents`, `locations`) are owned by **PRD-173 (items)** and **PRD-176 (documents)**.
- The handle is `getInventoryDrizzle()` — already pillar-scoped. Once PRD-173 and PRD-176 land, every join automatically resolves against `inventory.db` with zero change to `reports/`.

Net: **no slice to cut over** under this PRD. No package scaffold, no shared-journal split, no handle flip, no shim to delete.

This PR rewrites the PRD to reflect that, and adds the same Epic-03 marker pattern PRD-172 uses so the slice list signals the no-op status at a glance.

Code in `apps/pops-api/src/modules/inventory/reports/` is unchanged.

## Test plan

- [x] Docs-only change; no code or migrations touched.
- [x] Pre-push turbo pipeline — 66/66 tasks pass.
- [x] `oxfmt --write` ran via lint-staged hook on commit.
