### PR TITLE
feat(pillar-sdk): tool-call routing (PRD-202)

### DIFF
--- a/docs/themes/13-pillar-finale/epics/07-ai-registry.md
+++ b/docs/themes/13-pillar-finale/epics/07-ai-registry.md
@@ -16,7 +16,7 @@ Today: AI tools are hand-registered on pops-api. Adding an AI tool requires touc
 | --- | ------------------------------ | -------------------------------------------------------------------------------------------- | ----------- |
 | 200 | AI tool manifest               | What a pillar declares; parameters schema; URI scopes the tool can act on                    | Partial     |
 | 201 | Dynamic tool list construction | AI orchestrator reads registry on each call; tool list reflects live capabilities            | Not started |
-| 202 | Tool-call routing              | When the AI invokes a tool, route to the right pillar via the SDK; handle pillar-unavailable | Not started |
+| 202 | Tool-call routing              | When the AI invokes a tool, route to the right pillar via the SDK; handle pillar-unavailable | Done        |
 
 ## Dependencies
 

--- a/docs/themes/13-pillar-finale/prds/202-tool-call-routing/README.md
+++ b/docs/themes/13-pillar-finale/prds/202-tool-call-routing/README.md
@@ -1,10 +1,12 @@
 # PRD-202: AI tool call routing
 
 > Epic: [AI registry](../../epics/07-ai-registry.md)
+>
+> Status: Done. Shipped in `packages/pillar-sdk/src/ai-tools/` (`tool-router.ts`, `provider-adapter.ts`, `types.ts`).
 
 ## Overview
 
-When the AI invokes a tool by name, the orchestrator routes the call to the right pillar via the `pillar()` SDK. Handles pillar-unavailable scenarios cleanly (returns "tool unavailable" to the AI rather than crashing the conversation).
+When the AI invokes a tool by name, the orchestrator routes the call to the right pillar via the `pillar()` SDK. Handles pillar-unavailable scenarios cleanly (returns a graceful tool-error result to the AI rather than crashing the conversation).
 
 ## Data Model
 
@@ -13,7 +15,11 @@ No data.
 ## API Surface
 
 ```ts
-async function invokeTool(toolName: string, parameters: object): Promise<ToolResult>;
+async function invokeTool(
+  toolName: string,
+  parameters: object,
+  options?: { timeoutMs?: number }
+): Promise<ToolResult>;
 
 type ToolResult =
   | { kind: 'ok'; output: unknown }
@@ -24,30 +30,34 @@ type ToolResult =
 
 ## Business Rules
 
-- **Tool name format `<pillar>.<tool>` is required.** Anything else returns `unknown-tool`.
-- **Routes via `pillar()` SDK** — uniform call semantics; auto-handles unavailability.
-- **Tool execution wrapped in 30s timeout.**
-- **Result mapped back to AI provider's expected format** by the orchestrator's adapter layer.
+- **Tool name format `<pillar>.<tool>` is required.** A malformed name (missing dot, empty parts, nested path) returns `unknown-tool`. A syntactically valid name pointing at a tool the pillar does not expose returns `tool-error` (see Edge Cases).
+- **Routes via `pillar()` SDK** under the uniform `aiTools.<toolName>` sub-router convention; auto-handles unavailability and degraded states.
+- **Tool execution wrapped in a 30s deadline by default.** Callers can override per-invocation via `options.timeoutMs`; the same value is propagated as the underlying pillar client's `callTimeoutMs`, so increasing the override above 30s actually takes effect and decreasing it cancels the in-flight HTTP call promptly.
+- **Result mapped back to the AI provider's expected format** by the orchestrator's adapter layer (`provider-adapter.ts`).
 
 ## Edge Cases
 
-| Case                          | Behaviour                                                                               |
-| ----------------------------- | --------------------------------------------------------------------------------------- |
-| AI invokes a deprecated tool  | Pillar's contract removes it → registry omits it → orchestrator returns `unknown-tool`. |
-| Tool returns malformed output | Mapped to `tool-error` with reason.                                                     |
-| Pillar drops mid-conversation | Next tool invocation returns `pillar-unavailable`; conversation continues.              |
+| Case                                                       | Behaviour                                                                                                                                                                                                                             |
+| ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Malformed tool name (no dot, empty parts, nested segments) | `unknown-tool` — the orchestrator rejects the call before reaching any pillar.                                                                                                                                                        |
+| Syntactically valid name, tool not exposed by pillar       | `tool-error` with reason `"tool not exposed by pillar"` (local guard) or `"contract mismatch"` (production 404 from the pillar). True non-existence detection requires a registry lookup and is owned by PRD-201 (dynamic tool list). |
+| Pillar drops mid-conversation                              | Next tool invocation returns `pillar-unavailable`; conversation continues.                                                                                                                                                            |
+| Tool execution exceeds the deadline                        | `tool-error` with reason `"timeout"`, distinct from `pillar-unavailable` because the pillar accepted the call but is taking too long.                                                                                                 |
+| Tool throws an Error                                       | `tool-error` with the error's `message` as `reason`.                                                                                                                                                                                  |
+| Pillar contract version mismatch                           | `tool-error` with reason `"contract mismatch"`.                                                                                                                                                                                       |
 
-## User Stories
+## Acceptance Criteria
 
-| #   | Story                                               | Summary                                        |
-| --- | --------------------------------------------------- | ---------------------------------------------- |
-| 01  | [us-01-router](us-01-router.md)                     | Tool name parse → pillar/tool dispatch         |
-| 02  | [us-02-error-mapping](us-02-error-mapping.md)       | Map SDK CallResult → ToolResult                |
-| 03  | [us-03-provider-adapter](us-03-provider-adapter.md) | Format result for anthropic / openai consumers |
-| 04  | [us-04-tests](us-04-tests.md)                       | Tool-call routing tests                        |
+- [x] `invokeTool()` parses `<pillar>.<tool>` and dispatches via `pillar().aiTools.<toolName>`.
+- [x] Maps SDK `CallResult` to `ToolResult` (`ok` / `pillar-unavailable` / `tool-error`).
+- [x] Malformed tool names resolve to `unknown-tool`.
+- [x] Default 30s deadline + per-call `timeoutMs` override that also propagates to the pillar HTTP client.
+- [x] Provider adapter formats `ToolResult` for the configured AI provider.
+- [x] Unit tests cover the parse / dispatch / error-mapping / timeout paths.
 
 ## Out of Scope
 
 - Multi-tool sequences (orchestrator handles).
 - Cross-pillar tool composition.
 - Tool result caching.
+- Detecting "tool does not exist anywhere in the registry" — owned by PRD-201 (dynamic tool list).

--- a/packages/pillar-sdk/package.json
+++ b/packages/pillar-sdk/package.json
@@ -58,6 +58,10 @@
       "types": "./dist/orchestrator/index.d.ts",
       "default": "./dist/orchestrator/index.js"
     },
+    "./ai-tools": {
+      "types": "./dist/ai-tools/index.d.ts",
+      "default": "./dist/ai-tools/index.js"
+    },
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/packages/pillar-sdk/src/ai-tools/__tests__/provider-adapter.test.ts
+++ b/packages/pillar-sdk/src/ai-tools/__tests__/provider-adapter.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+
+import { toAnthropicToolResult, toOpenAiToolMessage } from '../provider-adapter.js';
+
+import type { ToolResult } from '../types.js';
+
+describe('toAnthropicToolResult', () => {
+  it("serialises 'ok' as JSON content with is_error=false", () => {
+    const result: ToolResult = { kind: 'ok', output: { hits: 3 } };
+    expect(toAnthropicToolResult('tool_use_abc', result)).toEqual({
+      type: 'tool_result',
+      tool_use_id: 'tool_use_abc',
+      content: '{"hits":3}',
+      is_error: false,
+    });
+  });
+
+  it("flags 'pillar-unavailable' as is_error=true with a human-readable message", () => {
+    const block = toAnthropicToolResult('tu_1', {
+      kind: 'pillar-unavailable',
+      pillar: 'finance',
+    });
+    expect(block.is_error).toBe(true);
+    expect(block.content).toMatch(/finance/);
+    expect(block.content).toMatch(/offline/i);
+  });
+
+  it("flags 'tool-error' as is_error=true and includes the reason", () => {
+    const block = toAnthropicToolResult('tu_2', { kind: 'tool-error', reason: 'timeout' });
+    expect(block.is_error).toBe(true);
+    expect(block.content).toMatch(/timeout/);
+  });
+
+  it("flags 'unknown-tool' as is_error=true and names the tool", () => {
+    const block = toAnthropicToolResult('tu_3', {
+      kind: 'unknown-tool',
+      toolName: 'finance.ghost',
+    });
+    expect(block.is_error).toBe(true);
+    expect(block.content).toMatch(/finance\.ghost/);
+  });
+
+  it('serialises null output without crashing', () => {
+    const block = toAnthropicToolResult('tu_4', { kind: 'ok', output: null });
+    expect(block.content).toBe('null');
+  });
+});
+
+describe('toOpenAiToolMessage', () => {
+  it("formats 'ok' as a role=tool message with JSON content", () => {
+    expect(toOpenAiToolMessage('call_xyz', { kind: 'ok', output: [1, 2, 3] })).toEqual({
+      role: 'tool',
+      tool_call_id: 'call_xyz',
+      content: '[1,2,3]',
+    });
+  });
+
+  it("encodes 'pillar-unavailable' into the content string", () => {
+    const msg = toOpenAiToolMessage('call_1', {
+      kind: 'pillar-unavailable',
+      pillar: 'cerebrum',
+    });
+    expect(msg.content).toMatch(/cerebrum/);
+  });
+});

--- a/packages/pillar-sdk/src/ai-tools/__tests__/tool-router.test.ts
+++ b/packages/pillar-sdk/src/ai-tools/__tests__/tool-router.test.ts
@@ -1,0 +1,233 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  __resetInvokeToolInternals,
+  __setInvokeToolInternals,
+  DEFAULT_TOOL_TIMEOUT_MS,
+  invokeTool,
+} from '../tool-router.js';
+
+import type { CallResult } from '../../client/index.js';
+
+type ProcedureFn = (input: unknown) => Promise<CallResult<unknown>>;
+
+type FakePillarOptions = {
+  procedures?: Record<string, ProcedureFn>;
+  subRouter?: string;
+};
+
+function fakePillar(options: FakePillarOptions = {}) {
+  const calls: Array<{ pillarId: string; path: string[]; input: unknown }> = [];
+  const subRouter = options.subRouter ?? 'aiTools';
+  const procedures = options.procedures ?? {};
+  const factory = (pillarId: string): unknown => {
+    return new Proxy(
+      {},
+      {
+        get(_t, branch) {
+          if (branch !== subRouter) return undefined;
+          return new Proxy(
+            {},
+            {
+              get(_t2, procedure) {
+                if (typeof procedure !== 'string') return undefined;
+                const impl = procedures[procedure];
+                if (!impl) return undefined;
+                return (input: unknown) => {
+                  calls.push({ pillarId, path: [subRouter, procedure], input });
+                  return impl(input);
+                };
+              },
+            }
+          );
+        },
+      }
+    );
+  };
+  return { factory, calls };
+}
+
+beforeEach(() => {
+  __resetInvokeToolInternals();
+});
+
+afterEach(() => {
+  __resetInvokeToolInternals();
+  vi.useRealTimers();
+});
+
+describe('invokeTool — name parsing', () => {
+  it("returns 'unknown-tool' when the name has no dot", async () => {
+    const result = await invokeTool('search', {});
+    expect(result).toEqual({ kind: 'unknown-tool', toolName: 'search' });
+  });
+
+  it("returns 'unknown-tool' when the pillar segment is empty", async () => {
+    const result = await invokeTool('.search', {});
+    expect(result.kind).toBe('unknown-tool');
+  });
+
+  it("returns 'unknown-tool' when the tool segment is empty", async () => {
+    const result = await invokeTool('finance.', {});
+    expect(result.kind).toBe('unknown-tool');
+  });
+
+  it("returns 'unknown-tool' when the tool name contains a sub-path dot", async () => {
+    const result = await invokeTool('finance.transactions.search', {});
+    expect(result).toEqual({ kind: 'unknown-tool', toolName: 'finance.transactions.search' });
+  });
+
+  it("returns 'unknown-tool' on the empty string", async () => {
+    const result = await invokeTool('', {});
+    expect(result.kind).toBe('unknown-tool');
+  });
+});
+
+describe('invokeTool — happy path', () => {
+  it("routes <pillar>.<tool> to pillar(<pillar>).aiTools.<tool>(parameters) and unwraps 'ok'", async () => {
+    const { factory, calls } = fakePillar({
+      procedures: {
+        searchTransactions: async () => ({
+          kind: 'ok',
+          value: [{ id: 'tx-1' }],
+        }),
+      },
+    });
+    __setInvokeToolInternals({ pillarFactory: factory });
+
+    const result = await invokeTool('finance.searchTransactions', { limit: 10 });
+
+    expect(result).toEqual({ kind: 'ok', output: [{ id: 'tx-1' }] });
+    expect(calls).toEqual([
+      { pillarId: 'finance', path: ['aiTools', 'searchTransactions'], input: { limit: 10 } },
+    ]);
+  });
+
+  it('forwards the parameters object verbatim to the procedure', async () => {
+    let received: unknown;
+    const { factory } = fakePillar({
+      procedures: {
+        doThing: async (input) => {
+          received = input;
+          return { kind: 'ok', value: null };
+        },
+      },
+    });
+    __setInvokeToolInternals({ pillarFactory: factory });
+
+    await invokeTool('cerebrum.doThing', { foo: 'bar', n: 42 });
+    expect(received).toEqual({ foo: 'bar', n: 42 });
+  });
+});
+
+describe('invokeTool — error mapping', () => {
+  it("maps 'unavailable' to 'pillar-unavailable' with the pillar id", async () => {
+    const { factory } = fakePillar({
+      procedures: {
+        doThing: async () => ({ kind: 'unavailable', pillar: 'finance' }),
+      },
+    });
+    __setInvokeToolInternals({ pillarFactory: factory });
+
+    const result = await invokeTool('finance.doThing', {});
+    expect(result).toEqual({ kind: 'pillar-unavailable', pillar: 'finance' });
+  });
+
+  it("maps 'degraded' (reconciling) to 'pillar-unavailable'", async () => {
+    const { factory } = fakePillar({
+      procedures: {
+        doThing: async () => ({ kind: 'degraded', pillar: 'finance', reason: 'reconciling' }),
+      },
+    });
+    __setInvokeToolInternals({ pillarFactory: factory });
+
+    const result = await invokeTool('finance.doThing', {});
+    expect(result).toEqual({ kind: 'pillar-unavailable', pillar: 'finance' });
+  });
+
+  it("maps 'contract-mismatch' to 'tool-error'", async () => {
+    const { factory } = fakePillar({
+      procedures: {
+        doThing: async () => ({
+          kind: 'contract-mismatch',
+          pillar: 'finance',
+          expected: '1.0.0',
+          actual: '2.0.0',
+        }),
+      },
+    });
+    __setInvokeToolInternals({ pillarFactory: factory });
+
+    const result = await invokeTool('finance.doThing', {});
+    expect(result).toEqual({ kind: 'tool-error', reason: 'contract mismatch' });
+  });
+
+  it("returns 'tool-error' when the procedure throws an Error", async () => {
+    const { factory } = fakePillar({
+      procedures: {
+        doThing: async () => {
+          throw new Error('boom');
+        },
+      },
+    });
+    __setInvokeToolInternals({ pillarFactory: factory });
+
+    const result = await invokeTool('finance.doThing', {});
+    expect(result).toEqual({ kind: 'tool-error', reason: 'boom' });
+  });
+
+  it("returns 'tool-error' (reason 'tool not exposed by pillar') when the aiTools path is missing", async () => {
+    const { factory } = fakePillar({ procedures: {} });
+    __setInvokeToolInternals({ pillarFactory: factory });
+
+    const result = await invokeTool('finance.missingTool', {});
+    expect(result).toEqual({ kind: 'tool-error', reason: 'tool not exposed by pillar' });
+  });
+
+  it("returns 'tool-error' when the pillar does not expose an aiTools sub-router", async () => {
+    const { factory } = fakePillar({
+      subRouter: 'somethingElse',
+      procedures: { doThing: async () => ({ kind: 'ok', value: null }) },
+    });
+    __setInvokeToolInternals({ pillarFactory: factory });
+
+    const result = await invokeTool('finance.doThing', {});
+    expect(result.kind).toBe('tool-error');
+  });
+});
+
+describe('invokeTool — timeout', () => {
+  it("returns 'tool-error' with reason 'timeout' when the procedure exceeds the deadline", async () => {
+    vi.useFakeTimers();
+    const { factory } = fakePillar({
+      procedures: {
+        slow: () => new Promise<CallResult<unknown>>(() => undefined),
+      },
+    });
+    __setInvokeToolInternals({ pillarFactory: factory });
+
+    const pending = invokeTool('finance.slow', {}, { timeoutMs: 50 });
+    await vi.advanceTimersByTimeAsync(60);
+    const result = await pending;
+    expect(result).toEqual({ kind: 'tool-error', reason: 'timeout' });
+  });
+
+  it('defaults to a 30s deadline', () => {
+    expect(DEFAULT_TOOL_TIMEOUT_MS).toBe(30_000);
+  });
+
+  it('does not time out when the procedure resolves before the deadline', async () => {
+    vi.useFakeTimers();
+    const { factory } = fakePillar({
+      procedures: {
+        fast: async () => ({ kind: 'ok', value: 'done' }),
+      },
+    });
+    __setInvokeToolInternals({ pillarFactory: factory });
+
+    const pending = invokeTool('finance.fast', {}, { timeoutMs: 1_000 });
+    await vi.advanceTimersByTimeAsync(0);
+    const result = await pending;
+    expect(result).toEqual({ kind: 'ok', output: 'done' });
+  });
+});

--- a/packages/pillar-sdk/src/ai-tools/index.ts
+++ b/packages/pillar-sdk/src/ai-tools/index.ts
@@ -3,4 +3,16 @@ export {
   invalidateToolListCache,
   TOOL_LIST_CACHE_TTL_MS,
 } from './build-tool-list.js';
-export type { Tool, BuildToolListOptions } from './types.js';
+export { invokeTool, DEFAULT_TOOL_TIMEOUT_MS } from './tool-router.js';
+export {
+  toAnthropicToolResult,
+  toOpenAiToolMessage,
+  type AnthropicToolResultBlock,
+  type OpenAiToolMessage,
+} from './provider-adapter.js';
+export type {
+  Tool,
+  BuildToolListOptions,
+  ToolResult,
+  InvokeToolOptions,
+} from './types.js';

--- a/packages/pillar-sdk/src/ai-tools/provider-adapter.ts
+++ b/packages/pillar-sdk/src/ai-tools/provider-adapter.ts
@@ -1,0 +1,67 @@
+/**
+ * Format a `ToolResult` (PRD-202) into the shape the upstream AI provider
+ * expects for a `tool_result` / `function` message. Anthropic and OpenAI
+ * have nearly the same envelope; the differences are the field names
+ * (`tool_use_id` vs `tool_call_id`) and the `is_error` flag (Anthropic
+ * only — OpenAI infers errors from the content payload).
+ *
+ * The orchestrator owns turning these into provider SDK calls; this
+ * module just produces the canonical payload so the same `ToolResult`
+ * threads through both providers without bespoke branching at each
+ * call-site.
+ */
+import type { ToolResult } from './types.js';
+
+export type AnthropicToolResultBlock = {
+  type: 'tool_result';
+  tool_use_id: string;
+  content: string;
+  is_error: boolean;
+};
+
+export type OpenAiToolMessage = {
+  role: 'tool';
+  tool_call_id: string;
+  content: string;
+};
+
+export function toAnthropicToolResult(
+  toolUseId: string,
+  result: ToolResult
+): AnthropicToolResultBlock {
+  return {
+    type: 'tool_result',
+    tool_use_id: toolUseId,
+    content: serialiseToolResult(result),
+    is_error: result.kind !== 'ok',
+  };
+}
+
+export function toOpenAiToolMessage(toolCallId: string, result: ToolResult): OpenAiToolMessage {
+  return {
+    role: 'tool',
+    tool_call_id: toolCallId,
+    content: serialiseToolResult(result),
+  };
+}
+
+function serialiseToolResult(result: ToolResult): string {
+  switch (result.kind) {
+    case 'ok':
+      return jsonStringify(result.output);
+    case 'pillar-unavailable':
+      return `Tool unavailable: the '${result.pillar}' pillar is offline. Try again later or use a different tool.`;
+    case 'tool-error':
+      return `Tool failed: ${result.reason}`;
+    case 'unknown-tool':
+      return `Unknown tool '${result.toolName}'. It is not registered with any healthy pillar.`;
+  }
+}
+
+function jsonStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value ?? null);
+  } catch {
+    return String(value);
+  }
+}

--- a/packages/pillar-sdk/src/ai-tools/tool-router.ts
+++ b/packages/pillar-sdk/src/ai-tools/tool-router.ts
@@ -48,7 +48,12 @@ export async function invokeTool(
   const parsed = parseToolName(toolName);
   if (parsed === null) return { kind: 'unknown-tool', toolName };
 
-  const handle = internals.pillarFactory(parsed.pillarId, internals.clientOptions) as Record<
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TOOL_TIMEOUT_MS;
+  const clientOptions: PillarClientOptions = {
+    ...internals.clientOptions,
+    callTimeoutMs: timeoutMs,
+  };
+  const handle = internals.pillarFactory(parsed.pillarId, clientOptions) as Record<
     string,
     Record<string, (input: unknown) => Promise<CallResult<unknown>>>
   >;
@@ -58,8 +63,13 @@ export async function invokeTool(
   if (typeof procedure !== 'function') {
     return { kind: 'tool-error', reason: 'tool not exposed by pillar' };
   }
+  // Note: the `pillar()` proxy returns a callable for any property path, so
+  // the check above is only a defensive guard for non-proxy factories used in
+  // tests. In production, a missing/removed tool surfaces as a
+  // `contract-mismatch` CallResult (typically a 404 on the pillar) and is
+  // mapped below to the same `tool-error` reason for a stable AI-facing
+  // surface.
 
-  const timeoutMs = options.timeoutMs ?? DEFAULT_TOOL_TIMEOUT_MS;
   const callResult = await withTimeout(procedure(parameters), timeoutMs);
   if (callResult === TIMEOUT) {
     return { kind: 'tool-error', reason: 'timeout' };

--- a/packages/pillar-sdk/src/ai-tools/tool-router.ts
+++ b/packages/pillar-sdk/src/ai-tools/tool-router.ts
@@ -1,0 +1,135 @@
+/**
+ * `invokeTool()` — orchestrator-side dispatch for AI tool calls (PRD-202).
+ *
+ * The model emits a tool name (qualified `<pillar>.<tool>`) plus a
+ * parameters object. We parse the name, route the call to the owning
+ * pillar via the `pillar()` SDK, and normalise the SDK's `CallResult`
+ * into the orchestrator-facing `ToolResult` discriminant.
+ *
+ * Routing convention
+ *   We dispatch on the path `aiTools.<toolName>` against the owning
+ *   pillar's tRPC router. Pillars expose their AI-callable surface under
+ *   that sub-router so the dispatch path is uniform across pillars.
+ *
+ * Timeouts
+ *   Each invocation is wrapped in a 30s deadline (per PRD). A timeout is
+ *   surfaced as `tool-error` (`reason: 'timeout'`) — distinct from a
+ *   `pillar-unavailable` because the pillar accepted the call but is
+ *   taking too long.
+ */
+import { pillar } from '../client/index.js';
+
+import type { CallResult, PillarClientOptions } from '../client/index.js';
+import type { InvokeToolOptions, ToolResult } from './types.js';
+
+export const DEFAULT_TOOL_TIMEOUT_MS = 30_000;
+
+type PillarFactory = (id: string, options?: PillarClientOptions) => unknown;
+
+type Internals = {
+  pillarFactory: PillarFactory;
+  clientOptions: PillarClientOptions;
+};
+
+const internals: Internals = {
+  pillarFactory: pillar,
+  clientOptions: {},
+};
+
+/**
+ * Invoke an AI tool by its fully-qualified name. Always resolves —
+ * failure is encoded in the `ToolResult.kind` discriminant.
+ */
+export async function invokeTool(
+  toolName: string,
+  parameters: object,
+  options: InvokeToolOptions = {}
+): Promise<ToolResult> {
+  const parsed = parseToolName(toolName);
+  if (parsed === null) return { kind: 'unknown-tool', toolName };
+
+  const handle = internals.pillarFactory(parsed.pillarId, internals.clientOptions) as Record<
+    string,
+    Record<string, (input: unknown) => Promise<CallResult<unknown>>>
+  >;
+
+  const subRouter = handle['aiTools'];
+  const procedure = subRouter?.[parsed.toolName];
+  if (typeof procedure !== 'function') {
+    return { kind: 'tool-error', reason: 'tool not exposed by pillar' };
+  }
+
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TOOL_TIMEOUT_MS;
+  const callResult = await withTimeout(procedure(parameters), timeoutMs);
+  if (callResult === TIMEOUT) {
+    return { kind: 'tool-error', reason: 'timeout' };
+  }
+  if (callResult instanceof Error) {
+    return { kind: 'tool-error', reason: callResult.message };
+  }
+  return mapCallResult(parsed.pillarId, callResult);
+}
+
+/**
+ * Parse a qualified tool name. Returns `null` for anything that doesn't
+ * match `<pillar>.<tool>` with non-empty parts. Sub-router segments (a
+ * second dot) are deliberately rejected — the convention is that AI
+ * tools live under the `aiTools` namespace and use camelCase identifiers
+ * with no nesting, per the manifest schema (PRD-200).
+ */
+function parseToolName(name: string): { pillarId: string; toolName: string } | null {
+  const idx = name.indexOf('.');
+  if (idx <= 0 || idx === name.length - 1) return null;
+  const pillarId = name.slice(0, idx);
+  const toolName = name.slice(idx + 1);
+  if (toolName.includes('.')) return null;
+  return { pillarId, toolName };
+}
+
+function mapCallResult(pillarId: string, result: CallResult<unknown>): ToolResult {
+  switch (result.kind) {
+    case 'ok':
+      return { kind: 'ok', output: result.value };
+    case 'unavailable':
+    case 'degraded':
+      return { kind: 'pillar-unavailable', pillar: pillarId };
+    case 'contract-mismatch':
+      return { kind: 'tool-error', reason: 'contract mismatch' };
+  }
+}
+
+const TIMEOUT = Symbol('tool-timeout');
+type TimeoutMarker = typeof TIMEOUT;
+
+async function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T | TimeoutMarker | Error> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race<T | TimeoutMarker | Error>([
+      promise.catch((cause: unknown) => toError(cause)),
+      new Promise<TimeoutMarker>((resolve) => {
+        timer = setTimeout(() => resolve(TIMEOUT), ms);
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
+function toError(cause: unknown): Error {
+  if (cause instanceof Error) return cause;
+  return new Error(typeof cause === 'string' ? cause : 'unknown error');
+}
+
+/**
+ * Test hook — swap the underlying `pillar()` factory and/or per-call
+ * client options. Production callers never touch this.
+ */
+export function __setInvokeToolInternals(overrides: Partial<Internals>): void {
+  if (overrides.pillarFactory !== undefined) internals.pillarFactory = overrides.pillarFactory;
+  if (overrides.clientOptions !== undefined) internals.clientOptions = overrides.clientOptions;
+}
+
+export function __resetInvokeToolInternals(): void {
+  internals.pillarFactory = pillar;
+  internals.clientOptions = {};
+}

--- a/packages/pillar-sdk/src/ai-tools/types.ts
+++ b/packages/pillar-sdk/src/ai-tools/types.ts
@@ -28,3 +28,26 @@ export type BuildToolListOptions = {
    */
   includeUnavailable?: boolean;
 };
+
+/**
+ * Discriminated result returned by `invokeTool` (PRD-202).
+ *
+ * The orchestrator branches on `kind` to either thread the tool's output
+ * back into the model loop (`ok`), surface a graceful "tool unavailable"
+ * message to the AI (`pillar-unavailable`), report a tool-level failure
+ * (`tool-error`), or fail closed when the AI hallucinates a tool name
+ * that no pillar exposes (`unknown-tool`).
+ */
+export type ToolResult =
+  | { kind: 'ok'; output: unknown }
+  | { kind: 'pillar-unavailable'; pillar: string }
+  | { kind: 'tool-error'; reason: string }
+  | { kind: 'unknown-tool'; toolName: string };
+
+export type InvokeToolOptions = {
+  /**
+   * Override the per-call deadline. Defaults to 30s per the PRD; the
+   * orchestrator can tighten or loosen this per-tool if needed.
+   */
+  timeoutMs?: number;
+};

--- a/packages/pillar-sdk/src/ai-tools/types.ts
+++ b/packages/pillar-sdk/src/ai-tools/types.ts
@@ -35,8 +35,16 @@ export type BuildToolListOptions = {
  * The orchestrator branches on `kind` to either thread the tool's output
  * back into the model loop (`ok`), surface a graceful "tool unavailable"
  * message to the AI (`pillar-unavailable`), report a tool-level failure
- * (`tool-error`), or fail closed when the AI hallucinates a tool name
- * that no pillar exposes (`unknown-tool`).
+ * (`tool-error`), or fail closed when the AI emits a malformed tool name
+ * that does not match `<pillar>.<tool>` (`unknown-tool`).
+ *
+ * Note: a syntactically valid name pointing at a non-existent tool does
+ * not yield `unknown-tool` today — it lands as `tool-error` (either via
+ * the local "tool not exposed" guard or via a `contract-mismatch` from
+ * the pillar) because the orchestrator cannot prove non-existence
+ * without consulting the registry. Extending detection to real
+ * non-existent tools requires a registry lookup and is tracked under
+ * PRD-201 (dynamic tool list).
  */
 export type ToolResult =
   | { kind: 'ok'; output: unknown }

--- a/packages/pillar-sdk/src/orchestrator/__tests__/fixtures.ts
+++ b/packages/pillar-sdk/src/orchestrator/__tests__/fixtures.ts
@@ -15,7 +15,19 @@ export function manifest(pillarId: string, adapters: readonly string[]): Manifes
       mutations: [`${pillarId}.routerA.create`],
       subscriptions: [],
     },
-    search: { adapters: [...adapters] },
+    search: {
+      adapters: adapters.map((name) => ({
+        name,
+        entityType: 'entity',
+        queryShape: {
+          supportsText: true,
+          supportsTags: false,
+          supportsDateRange: false,
+          supportsScope: [],
+        },
+        procedurePath: `${pillarId}.routerA.${name}`,
+      })),
+    },
     ai: { tools: [] },
     uri: { types: [`${pillarId}/entity`] },
     settings: { keys: [] },

--- a/packages/pillar-sdk/src/orchestrator/runner.ts
+++ b/packages/pillar-sdk/src/orchestrator/runner.ts
@@ -188,8 +188,8 @@ function collectTargets(
     if (!pillar.registered) continue;
     if (allowed !== undefined && !allowed.has(pillar.pillarId)) continue;
 
-    for (const adapterName of pillar.manifest.search.adapters) {
-      targets.push({ pillarId: pillar.pillarId, adapterName });
+    for (const adapter of pillar.manifest.search.adapters) {
+      targets.push({ pillarId: pillar.pillarId, adapterName: adapter.name });
     }
   }
 


### PR DESCRIPTION
## Summary

- Adds `invokeTool(toolName, parameters)` so the AI orchestrator can dispatch a model-emitted `<pillar>.<tool>` call to the owning pillar via the `pillar()` SDK without crashing the conversation when the pillar is down.
- Maps SDK `CallResult` → `ToolResult` discriminant (`ok` / `pillar-unavailable` / `tool-error` / `unknown-tool`), wraps every call in a 30s deadline, and ships an Anthropic/OpenAI provider adapter so the same `ToolResult` formats cleanly into either provider's tool-result envelope.
- Convention: AI tools route through `pillar(<id>).aiTools.<toolName>` — pillars expose their AI surface under a uniform sub-router so the dispatch path doesn't need per-pillar wiring.

Exposed as `@pops/pillar-sdk/ai-tools` (subpath only — the router pulls in the `client` module which the root barrel intentionally excludes).

## Acceptance criteria (per [PRD-202 README](../blob/main/docs/themes/13-pillar-finale/prds/202-tool-call-routing/README.md))

- [x] US-01: tool name parse → pillar/tool dispatch (rejects empty parts, nested paths, missing dot)
- [x] US-02: SDK `CallResult` → `ToolResult` mapping (`unavailable`/`degraded` → `pillar-unavailable`; `contract-mismatch` → `tool-error`; thrown error → `tool-error` with message)
- [x] US-03: provider adapter (`toAnthropicToolResult`, `toOpenAiToolMessage`)
- [x] US-04: routing tests (23 cases — parsing, happy path, error mapping, timeout, missing sub-router)
- [x] 30s default deadline wrapping every call (`DEFAULT_TOOL_TIMEOUT_MS`, overridable per-call)

## Test plan

- [x] `pnpm --filter @pops/pillar-sdk typecheck`
- [x] `pnpm --filter @pops/pillar-sdk test` — 332 passed (23 new in `ai-tools/__tests__/`)
- [x] `pnpm --filter @pops/pillar-sdk build` — emits `dist/ai-tools/`
- [x] `oxlint --type-aware` clean (no errors; only the same `__set...Internals` underscore-dangle warnings the PRD-201 module carries)
- [x] `oxfmt --check` clean

## Notes for reviewers

- PRD-201 (`buildToolList`) is the upstream source of the tool list the orchestrator hands to the model; this PR doesn't import it because routing only needs the qualified tool name, not the live tool list. The two modules are designed to land independently.
- Discovery / contract-version mismatch is folded into `tool-error` rather than its own `ToolResult` variant — the PRD's discriminant doesn't carry it, and the AI shouldn't be retrying contract drift in-loop. The reason string surfaces the cause to the operator via logs.