### PR TITLE
test(per-pillar-migrations): expect 0026_media_dismissed_discover_baseline

### DIFF
--- a/apps/pops-api/src/db/per-pillar-migrations.test.ts
+++ b/apps/pops-api/src/db/per-pillar-migrations.test.ts
@@ -212,7 +212,8 @@ describe('runPerPillarMigrations', () => {
     // 0022_media_movies_baseline (Theme 13 PRD-165 US-01 — movies baseline),
     // 0023_watchlist_baseline (Theme 13 PRD-167 PR 1 — watchlist baseline),
     // 0024_media_tv_shows_baseline (Theme 13 PRD-166 US-01 — tv-shows baseline),
-    // and 0025_media_watch_history_baseline (Theme 13 PRD-168 PR 1 — watch-history baseline);
+    // 0025_media_watch_history_baseline (Theme 13 PRD-168 PR 1 — watch-history baseline),
+    // and 0026_media_dismissed_discover_baseline (Theme 13 PRD-170 — dismissed-discover baseline);
     // `inventory` owns `packages/inventory-db/migrations/` with
     // 0005_fancy_crystal (inventory pillar Phase 1 PR 2),
     // 0006_inventory_pillar_baseline (inventory pillar Phase 2 PR 3 —
@@ -245,6 +246,7 @@ describe('runPerPillarMigrations', () => {
         '0023_watchlist_baseline',
         '0024_media_tv_shows_baseline',
         '0025_media_watch_history_baseline',
+        '0026_media_dismissed_discover_baseline',
         '0039_dry_fabian_cortez',
         '0044_nudge_log',
         '0050_engrams_baseline',


### PR DESCRIPTION
## Summary

PR #3037 (PRD-170 scaffold) added migration slot `0026_media_dismissed_discover_baseline` to `packages/media-db/migrations/` but did not update the workspace-fallback test in `apps/pops-api/src/db/per-pillar-migrations.test.ts`. That test enumerates every expected applied migration tag against the real on-disk pillar layout, so the new file made it fail on `main`.

This patch adds `0026_media_dismissed_discover_baseline` to the sorted expected list and extends the inline pillar inventory comment so future PRs notice it.

## Test plan

- [x] `pnpm exec vitest run src/db/per-pillar-migrations.test.ts` in `apps/pops-api` — 7/7 pass locally.