### PR TITLE
feat(pillar-sdk): partial-failure summary on federated search (PRD-199)

### DIFF
--- a/docs/themes/13-pillar-finale/epics/06-search-registry.md
+++ b/docs/themes/13-pillar-finale/epics/06-search-registry.md
@@ -12,12 +12,12 @@ Open design question: cross-pillar relevance scoring. Each pillar returns its ow
 
 ## PRDs
 
-| #   | PRD                          | Summary                                                                  | Status      |
-| --- | ---------------------------- | ------------------------------------------------------------------------ | ----------- |
-| 196 | Search adapter manifest      | What a pillar declares in its manifest; types + Zod schema               | Not started |
-| 197 | Federated query orchestrator | Fan-out, timeout, partial-failure handling                               | Not started |
-| 198 | Ranking strategy             | Per-pillar weights, merge algorithm, fallback when one pillar times out  | Done        |
-| 199 | Partial-failure semantics    | Surface to caller: "got 4/5 pillar responses; results may be incomplete" | Not started |
+| #   | PRD                          | Summary                                                                  | Status                                                                                          |
+| --- | ---------------------------- | ------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------- |
+| 196 | Search adapter manifest      | What a pillar declares in its manifest; types + Zod schema               | Not started                                                                                     |
+| 197 | Federated query orchestrator | Fan-out, timeout, partial-failure handling                               | Not started                                                                                     |
+| 198 | Ranking strategy             | Per-pillar weights, merge algorithm, fallback when one pillar times out  | Done                                                                                            |
+| 199 | Partial-failure semantics    | Surface to caller: "got 4/5 pillar responses; results may be incomplete" | Partial — orchestrator response carries `partial` block; shell UI indicator (US-03) not started |
 
 ## Dependencies
 

--- a/docs/themes/13-pillar-finale/prds/189-batch-call-site-audit/README.md
+++ b/docs/themes/13-pillar-finale/prds/189-batch-call-site-audit/README.md
@@ -42,12 +42,12 @@ Audit produces a report at `docs/themes/13-pillar-finale/prds/189-batch-call-sit
 
 ## User Stories
 
-| #   | Story                                                                                                       | Status      |
-| --- | ----------------------------------------------------------------------------------------------------------- | ----------- |
-| 01  | Scan every shell + app-package source file for `trpc.<pillar>.*` calls; emit per-file report                | Done        |
+| #   | Story                                                                                                        | Status      |
+| --- | ------------------------------------------------------------------------------------------------------------ | ----------- |
+| 01  | Scan every shell + app-package source file for `trpc.<pillar>.*` calls; emit per-file report                 | Done        |
 | 02  | For each cross-pillar site, classify: single-pillar / cross-pillar-documented / cross-pillar-refactor-needed | Done        |
-| 03  | Refactor the 3-5 highest-volume cross-pillar pages (likely Dashboard, Cerebrum context view, etc.)          | Not started |
-| 04  | Final report committed alongside this PRD ([`inventory.md`](./inventory.md))                                | Done        |
+| 03  | Refactor the 3-5 highest-volume cross-pillar pages (likely Dashboard, Cerebrum context view, etc.)           | Not started |
+| 04  | Final report committed alongside this PRD ([`inventory.md`](./inventory.md))                                 | Done        |
 
 ## Out of Scope
 

--- a/docs/themes/13-pillar-finale/prds/199-partial-failure-semantics/README.md
+++ b/docs/themes/13-pillar-finale/prds/199-partial-failure-semantics/README.md
@@ -39,11 +39,11 @@ type SearchResponse = {
 
 ## User Stories
 
-| #   | Story                                                                       | Summary                                |
-| --- | --------------------------------------------------------------------------- | -------------------------------------- |
-| 01  | [us-01-response-shape](us-01-response-shape.md)                             | Add partial block to search response   |
-| 02  | [us-02-orchestrator-tracks-failures](us-02-orchestrator-tracks-failures.md) | Orchestrator collects failure info     |
-| 03  | [us-03-shell-ui-indicator](us-03-shell-ui-indicator.md)                     | Shell shows "X of Y sources" indicator |
+| #   | Story                                                                       | Summary                                | Status      |
+| --- | --------------------------------------------------------------------------- | -------------------------------------- | ----------- |
+| 01  | [us-01-response-shape](us-01-response-shape.md)                             | Add partial block to search response   | Done        |
+| 02  | [us-02-orchestrator-tracks-failures](us-02-orchestrator-tracks-failures.md) | Orchestrator collects failure info     | Done        |
+| 03  | [us-03-shell-ui-indicator](us-03-shell-ui-indicator.md)                     | Shell shows "X of Y sources" indicator | Not started |
 
 ## Out of Scope
 

--- a/packages/pillar-sdk/package.json
+++ b/packages/pillar-sdk/package.json
@@ -58,10 +58,6 @@
       "types": "./dist/orchestrator/index.d.ts",
       "default": "./dist/orchestrator/index.js"
     },
-    "./ai-tools": {
-      "types": "./dist/ai-tools/index.d.ts",
-      "default": "./dist/ai-tools/index.js"
-    },
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/packages/pillar-sdk/src/ai-tools/index.ts
+++ b/packages/pillar-sdk/src/ai-tools/index.ts
@@ -10,9 +10,4 @@ export {
   type AnthropicToolResultBlock,
   type OpenAiToolMessage,
 } from './provider-adapter.js';
-export type {
-  Tool,
-  BuildToolListOptions,
-  ToolResult,
-  InvokeToolOptions,
-} from './types.js';
+export type { Tool, BuildToolListOptions, ToolResult, InvokeToolOptions } from './types.js';

--- a/packages/pillar-sdk/src/orchestrator/__tests__/partial.test.ts
+++ b/packages/pillar-sdk/src/orchestrator/__tests__/partial.test.ts
@@ -1,0 +1,250 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { summarisePartialFailures } from '../partial.js';
+import { runFederatedSearch } from '../runner.js';
+import { snapshot } from './fixtures.js';
+
+import type { ScoredResult } from '../../ranking/types.js';
+import type {
+  FederatedSearchFailure,
+  PillarAdapterTarget,
+  SearchAdapterInvoker,
+} from '../types.js';
+
+function result(score: number, entityName: string): ScoredResult {
+  return { score, entityName, data: { entityName } };
+}
+
+const target = (pillarId: string, adapterName: string): PillarAdapterTarget => ({
+  pillarId,
+  adapterName,
+});
+
+describe('summarisePartialFailures', () => {
+  it('returns empty failure arrays when no failures were recorded', () => {
+    const summary = summarisePartialFailures(
+      [target('finance', 'transactions'), target('media', 'movies')],
+      []
+    );
+
+    expect(summary).toEqual({
+      requestedPillars: ['finance', 'media'],
+      respondedPillars: ['finance', 'media'],
+      failedPillars: [],
+      timeoutPillars: [],
+    });
+  });
+
+  it('dedupes pillars across multiple adapters when building requestedPillars', () => {
+    const summary = summarisePartialFailures(
+      [target('finance', 'transactions'), target('finance', 'budgets'), target('media', 'movies')],
+      []
+    );
+
+    expect(summary.requestedPillars).toEqual(['finance', 'media']);
+    expect(summary.respondedPillars).toEqual(['finance', 'media']);
+  });
+
+  it('preserves the fan-out order in requestedPillars', () => {
+    const summary = summarisePartialFailures(
+      [target('media', 'movies'), target('finance', 'transactions')],
+      []
+    );
+
+    expect(summary.requestedPillars).toEqual(['media', 'finance']);
+  });
+
+  it('reports a pillar as failed when one of its adapters threw', () => {
+    const failures: FederatedSearchFailure[] = [
+      { pillarId: 'media', adapterName: 'movies', reason: 'error', error: new Error('boom') },
+    ];
+
+    const summary = summarisePartialFailures(
+      [target('finance', 'transactions'), target('media', 'movies')],
+      failures
+    );
+
+    expect(summary.failedPillars).toEqual([{ pillar: 'media', reason: 'boom' }]);
+    expect(summary.respondedPillars).toEqual(['finance']);
+    expect(summary.timeoutPillars).toEqual([]);
+  });
+
+  it('reports a pillar as timed-out when one of its adapters hit the per-adapter timeout', () => {
+    const failures: FederatedSearchFailure[] = [
+      { pillarId: 'media', adapterName: 'movies', reason: 'timeout' },
+    ];
+
+    const summary = summarisePartialFailures(
+      [target('finance', 'transactions'), target('media', 'movies')],
+      failures
+    );
+
+    expect(summary.timeoutPillars).toEqual(['media']);
+    expect(summary.failedPillars).toEqual([]);
+    expect(summary.respondedPillars).toEqual(['finance']);
+  });
+
+  it('prefers the timeout classification when a pillar has both timeout and error adapters', () => {
+    const failures: FederatedSearchFailure[] = [
+      {
+        pillarId: 'media',
+        adapterName: 'movies',
+        reason: 'error',
+        error: new Error('first adapter boom'),
+      },
+      { pillarId: 'media', adapterName: 'shows', reason: 'timeout' },
+    ];
+
+    const summary = summarisePartialFailures(
+      [target('media', 'movies'), target('media', 'shows')],
+      failures
+    );
+
+    expect(summary.timeoutPillars).toEqual(['media']);
+    expect(summary.failedPillars).toEqual([]);
+    expect(summary.respondedPillars).toEqual([]);
+  });
+
+  it('keeps the first error reason seen for a pillar when multiple adapters fail', () => {
+    const failures: FederatedSearchFailure[] = [
+      { pillarId: 'media', adapterName: 'movies', reason: 'error', error: new Error('first') },
+      { pillarId: 'media', adapterName: 'shows', reason: 'error', error: new Error('second') },
+    ];
+
+    const summary = summarisePartialFailures(
+      [target('media', 'movies'), target('media', 'shows')],
+      failures
+    );
+
+    expect(summary.failedPillars).toEqual([{ pillar: 'media', reason: 'first' }]);
+  });
+
+  it('falls back to a generic reason string when the error is not an Error instance', () => {
+    const failures: FederatedSearchFailure[] = [
+      { pillarId: 'media', adapterName: 'movies', reason: 'error', error: 42 },
+    ];
+
+    const summary = summarisePartialFailures([target('media', 'movies')], failures);
+
+    expect(summary.failedPillars).toEqual([{ pillar: 'media', reason: 'unknown error' }]);
+  });
+
+  it('passes through a string error payload as the failure reason', () => {
+    const failures: FederatedSearchFailure[] = [
+      { pillarId: 'media', adapterName: 'movies', reason: 'error', error: 'network down' },
+    ];
+
+    const summary = summarisePartialFailures([target('media', 'movies')], failures);
+
+    expect(summary.failedPillars).toEqual([{ pillar: 'media', reason: 'network down' }]);
+  });
+
+  it('falls back to the error name when the message is empty', () => {
+    class WeirdError extends Error {
+      override readonly name = 'WeirdError';
+    }
+
+    const failures: FederatedSearchFailure[] = [
+      { pillarId: 'media', adapterName: 'movies', reason: 'error', error: new WeirdError('') },
+    ];
+
+    const summary = summarisePartialFailures([target('media', 'movies')], failures);
+
+    expect(summary.failedPillars).toEqual([{ pillar: 'media', reason: 'WeirdError' }]);
+  });
+});
+
+describe('runFederatedSearch — partial summary integration', () => {
+  it('includes an empty partial block when every pillar responded', async () => {
+    const invoker: SearchAdapterInvoker = (callTarget) =>
+      Promise.resolve([result(1, `${callTarget.pillarId}-${callTarget.adapterName}`)]);
+
+    const response = await runFederatedSearch({
+      query: { text: 'pizza' },
+      invoker,
+      discovery: [snapshot('finance', ['transactions']), snapshot('media', ['movies'])],
+    });
+
+    expect(response.partial).toEqual({
+      requestedPillars: ['finance', 'media'],
+      respondedPillars: ['finance', 'media'],
+      failedPillars: [],
+      timeoutPillars: [],
+    });
+  });
+
+  it('demotes a pillar from respondedPillars when its adapter throws', async () => {
+    const invoker: SearchAdapterInvoker = (callTarget) => {
+      if (callTarget.pillarId === 'media') throw new Error('boom');
+      return Promise.resolve([result(1, 'tx-1')]);
+    };
+
+    const response = await runFederatedSearch({
+      query: { text: 'pizza' },
+      invoker,
+      discovery: [snapshot('finance', ['transactions']), snapshot('media', ['movies'])],
+    });
+
+    expect(response.partial.respondedPillars).toEqual(['finance']);
+    expect(response.partial.failedPillars).toEqual([{ pillar: 'media', reason: 'boom' }]);
+    expect(response.partial.timeoutPillars).toEqual([]);
+  });
+
+  it('reports timeoutPillars when an adapter aborts via the per-adapter timeout', async () => {
+    vi.useFakeTimers();
+    try {
+      const invoker: SearchAdapterInvoker = (callTarget, _query, signal) =>
+        new Promise((resolve, reject) => {
+          signal.addEventListener('abort', () => reject(new Error('aborted')), { once: true });
+          if (callTarget.pillarId === 'finance') resolve([result(1, 'fast-tx')]);
+        });
+
+      const promise = runFederatedSearch({
+        query: { text: 'pizza' },
+        invoker,
+        timeoutMs: 100,
+        discovery: [snapshot('finance', ['transactions']), snapshot('media', ['movies'])],
+      });
+
+      await vi.advanceTimersByTimeAsync(101);
+      const response = await promise;
+
+      expect(response.partial.timeoutPillars).toEqual(['media']);
+      expect(response.partial.respondedPillars).toEqual(['finance']);
+      expect(response.partial.failedPillars).toEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('omits unregistered pillars from requestedPillars entirely', async () => {
+    const invoker: SearchAdapterInvoker = () => Promise.resolve([]);
+
+    const response = await runFederatedSearch({
+      query: { text: 'pizza' },
+      invoker,
+      discovery: [snapshot('finance', ['transactions']), snapshot('media', ['movies'], false)],
+    });
+
+    expect(response.partial.requestedPillars).toEqual(['finance']);
+    expect(response.partial.respondedPillars).toEqual(['finance']);
+  });
+
+  it('reports requested but no responded pillars when every adapter fails', async () => {
+    const invoker: SearchAdapterInvoker = () => Promise.reject(new Error('total outage'));
+
+    const response = await runFederatedSearch({
+      query: { text: 'pizza' },
+      invoker,
+      discovery: [snapshot('finance', ['transactions']), snapshot('media', ['movies'])],
+    });
+
+    expect(response.results).toEqual([]);
+    expect(response.partial.requestedPillars).toEqual(['finance', 'media']);
+    expect(response.partial.respondedPillars).toEqual([]);
+    expect(response.partial.failedPillars).toEqual([
+      { pillar: 'finance', reason: 'total outage' },
+      { pillar: 'media', reason: 'total outage' },
+    ]);
+  });
+});

--- a/packages/pillar-sdk/src/orchestrator/__tests__/partial.test.ts
+++ b/packages/pillar-sdk/src/orchestrator/__tests__/partial.test.ts
@@ -18,6 +18,7 @@ function result(score: number, entityName: string): ScoredResult {
 const target = (pillarId: string, adapterName: string): PillarAdapterTarget => ({
   pillarId,
   adapterName,
+  procedurePath: `${pillarId}.routerA.${adapterName}`,
 });
 
 describe('summarisePartialFailures', () => {

--- a/packages/pillar-sdk/src/orchestrator/index.ts
+++ b/packages/pillar-sdk/src/orchestrator/index.ts
@@ -18,3 +18,5 @@ export type {
   PillarAdapterTarget,
   SearchAdapterInvoker,
 } from './types.js';
+export { summarisePartialFailures } from './partial.js';
+export type { PartialFailureSummary, FailedPillarSummary } from './partial.js';

--- a/packages/pillar-sdk/src/orchestrator/partial.ts
+++ b/packages/pillar-sdk/src/orchestrator/partial.ts
@@ -1,0 +1,109 @@
+/**
+ * Federated search partial-failure summary (PRD-199).
+ *
+ * Layered on top of {@link FederatedSearchResponse}'s per-target
+ * `failures` list (PRD-197), the `partial` block surfaces a per-pillar
+ * view that the UI can render as an "X of Y sources" indicator without
+ * having to re-derive pillar membership from a flat list of
+ * `{ pillarId, adapterName, reason }` records.
+ *
+ * The block is included on **every** response — even when every pillar
+ * responded successfully — so consumers can rely on its presence without
+ * a null check (per the PRD's "Every response includes `partial` block"
+ * rule). When all adapters succeed, `failedPillars` and `timeoutPillars`
+ * are empty arrays and `respondedPillars === requestedPillars`.
+ */
+
+import type { PillarAdapterTarget, FederatedSearchFailure } from './types.js';
+
+export interface PartialFailureSummary {
+  /** Pillar ids the orchestrator attempted to query, in fan-out order. */
+  readonly requestedPillars: readonly string[];
+  /**
+   * Pillar ids that returned at least one adapter result without any
+   * adapter failing. A pillar appears here only if *every* adapter it
+   * advertised either resolved with results or resolved with an empty
+   * array — any rejection (timeout or error) demotes the pillar to
+   * `failedPillars` / `timeoutPillars`.
+   */
+  readonly respondedPillars: readonly string[];
+  /**
+   * Pillar ids that had at least one adapter reject with a non-timeout
+   * error. Each entry carries the first error reason string the
+   * orchestrator saw for that pillar so the UI can render a tooltip.
+   */
+  readonly failedPillars: readonly FailedPillarSummary[];
+  /**
+   * Pillar ids that had at least one adapter abort via the per-adapter
+   * timeout (PRD-197 default 3s). Disjoint from `failedPillars` —
+   * timeout wins when both classes are present for the same pillar.
+   */
+  readonly timeoutPillars: readonly string[];
+}
+
+export interface FailedPillarSummary {
+  readonly pillar: string;
+  readonly reason: string;
+}
+
+/**
+ * Build the partial-failure summary from the orchestrator's fan-out
+ * inputs (the target list) and outputs (the failure list).
+ *
+ * The function is intentionally pure so it can be reused outside the
+ * runner — e.g. by a tRPC handler that wants to re-derive the summary
+ * after dropping certain failures, or by a test asserting the
+ * derivation in isolation.
+ */
+export function summarisePartialFailures(
+  targets: readonly PillarAdapterTarget[],
+  failures: readonly FederatedSearchFailure[]
+): PartialFailureSummary {
+  const requestedPillars = uniqueInOrder(targets.map((target) => target.pillarId));
+
+  const timeoutSet = new Set<string>();
+  const errorReasonByPillar = new Map<string, string>();
+
+  for (const failure of failures) {
+    if (failure.reason === 'timeout') {
+      timeoutSet.add(failure.pillarId);
+      continue;
+    }
+    if (!errorReasonByPillar.has(failure.pillarId)) {
+      errorReasonByPillar.set(failure.pillarId, describeError(failure.error));
+    }
+  }
+
+  const timeoutPillars = requestedPillars.filter((pillarId) => timeoutSet.has(pillarId));
+  const failedPillars: FailedPillarSummary[] = requestedPillars
+    .filter((pillarId) => errorReasonByPillar.has(pillarId) && !timeoutSet.has(pillarId))
+    .map((pillarId) => ({
+      pillar: pillarId,
+      reason: errorReasonByPillar.get(pillarId) ?? 'unknown error',
+    }));
+
+  const failedOrTimedOut = new Set<string>([
+    ...timeoutPillars,
+    ...failedPillars.map((entry) => entry.pillar),
+  ]);
+  const respondedPillars = requestedPillars.filter((pillarId) => !failedOrTimedOut.has(pillarId));
+
+  return { requestedPillars, respondedPillars, failedPillars, timeoutPillars };
+}
+
+function uniqueInOrder(values: readonly string[]): readonly string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const value of values) {
+    if (seen.has(value)) continue;
+    seen.add(value);
+    out.push(value);
+  }
+  return out;
+}
+
+function describeError(error: unknown): string {
+  if (error instanceof Error) return error.message || error.name;
+  if (typeof error === 'string') return error;
+  return 'unknown error';
+}

--- a/packages/pillar-sdk/src/orchestrator/runner.ts
+++ b/packages/pillar-sdk/src/orchestrator/runner.ts
@@ -13,9 +13,9 @@
  * orchestrator does not need to know how the underlying procedure is
  * transported.
  *
- * See {@link FederatedSearchQuery} for the interim-shape limitation note
- * (the manifest currently exposes only adapter names; PRD-196 will add
- * `procedurePath` + `queryShape` so the orchestrator can pre-filter).
+ * See {@link FederatedSearchQuery} for the remaining limitation note
+ * (the manifest already carries `procedurePath` and `queryShape`, but
+ * the orchestrator does not yet pre-filter targets by `queryShape`).
  */
 
 import { mergeResults } from '../ranking/merge.js';
@@ -198,7 +198,11 @@ function collectTargets(
     if (allowed !== undefined && !allowed.has(pillar.pillarId)) continue;
 
     for (const adapter of pillar.manifest.search.adapters) {
-      targets.push({ pillarId: pillar.pillarId, adapterName: adapter.name });
+      targets.push({
+        pillarId: pillar.pillarId,
+        adapterName: adapter.name,
+        procedurePath: adapter.procedurePath,
+      });
     }
   }
 

--- a/packages/pillar-sdk/src/orchestrator/runner.ts
+++ b/packages/pillar-sdk/src/orchestrator/runner.ts
@@ -19,6 +19,7 @@
  */
 
 import { mergeResults } from '../ranking/merge.js';
+import { summarisePartialFailures, type PartialFailureSummary } from './partial.js';
 
 import type { PillarSnapshot } from '../discovery/types.js';
 import type { MergedResult, PillarWeights, ScoredResult } from '../ranking/types.js';
@@ -62,6 +63,12 @@ export interface FederatedSearchOptions {
 export interface FederatedSearchResponse {
   readonly results: readonly MergedResult[];
   readonly failures: readonly FederatedSearchFailure[];
+  /**
+   * PRD-199 partial-failure summary. Always present, even when every
+   * pillar responded — empty `failedPillars` / `timeoutPillars` mean
+   * "no degradation, show the full result set".
+   */
+  readonly partial: PartialFailureSummary;
 }
 
 export class EmptyFederatedQueryError extends Error {
@@ -118,7 +125,9 @@ export async function runFederatedSearch(
     onWarn,
   });
 
-  return { results: merged, failures };
+  const partial = summarisePartialFailures(targets, failures);
+
+  return { results: merged, failures, partial };
 }
 
 interface CollectedOutcomes {

--- a/packages/pillar-sdk/src/orchestrator/types.ts
+++ b/packages/pillar-sdk/src/orchestrator/types.ts
@@ -5,7 +5,8 @@
  * whose manifest advertises at least one search adapter
  * (`manifest.search.adapters`), merges the per-pillar `ScoredResult[]`
  * lists via {@link mergeResults} (PRD-198), and returns a single ranked
- * response plus a per-pillar partial-failure list (PRD-199).
+ * response plus a per-pillar partial-failure list (PRD-197 `failures`) and
+ * a per-pillar partial-failure summary block (PRD-199 `partial`).
  *
  * **Known limitation (interim shape).** As of this PRD-197 cut, the
  * manifest schema's `search.adapters` field is `readonly string[]` —

--- a/packages/pillar-sdk/src/orchestrator/types.ts
+++ b/packages/pillar-sdk/src/orchestrator/types.ts
@@ -8,16 +8,16 @@
  * response plus a per-pillar partial-failure list (PRD-197 `failures`) and
  * a per-pillar partial-failure summary block (PRD-199 `partial`).
  *
- * **Known limitation (interim shape).** As of this PRD-197 cut, the
- * manifest schema's `search.adapters` field is `readonly string[]` —
- * adapter names only. PRD-196's richer descriptor (`procedurePath`,
- * `queryShape`, `entityType`, `rankFieldName`) has not landed. Until it
- * does, the orchestrator cannot reject queries against an adapter that
- * does not advertise the requested dimensions (text / tags / dateRange /
- * scope) — every adapter is invoked unconditionally and is responsible
- * for returning `[]` if the query is unsupported. When PRD-196 lands,
- * the pre-filter belongs in {@link runFederatedSearch} so each adapter
- * does not pay the parse-and-reject cost.
+ * **Known limitation.** The manifest schema's `search.adapters` field now
+ * carries the full PRD-196 descriptor (`name`, `entityType`, `queryShape`,
+ * `procedurePath`, optional `rankFieldName`) and the orchestrator forwards
+ * `procedurePath` to the invoker. The remaining gap is that the
+ * orchestrator does not yet *use* `queryShape` to pre-filter targets:
+ * every adapter is invoked unconditionally and is responsible for
+ * returning `[]` if it cannot answer the requested dimensions
+ * (text / tags / dateRange / scope). Wiring the pre-filter into
+ * {@link runFederatedSearch} avoids paying the per-adapter parse-and-reject
+ * cost.
  *
  * Dispatch is delegated to a {@link SearchAdapterInvoker} so the
  * orchestrator does not need to know how the underlying procedure is
@@ -58,11 +58,14 @@ export interface FederatedSearchQuery {
  * One pillar's contribution to the fan-out. `pillarId` is a kebab-case
  * identifier (per the manifest schema's pillar id constraint);
  * `adapterName` is camelCase (PRD-196's manifest schema constraint on
- * `search.adapters`).
+ * `search.adapters`); `procedurePath` is the dotted tRPC path the
+ * invoker should dispatch to (carried verbatim from the manifest so
+ * invokers do not have to re-derive it from `pillarId`/`adapterName`).
  */
 export interface PillarAdapterTarget {
   readonly pillarId: string;
   readonly adapterName: string;
+  readonly procedurePath: string;
 }
 
 /**
@@ -75,11 +78,9 @@ export interface PillarAdapterTarget {
  * swappable. The orchestrator only requires that rejecting the
  * returned promise — including via abort — is treated as a failure.
  *
- * In production the invoker is expected to resolve `(pillarId,
- * adapterName)` to a procedure path. The current `search.adapters`
- * shape (PRD-197 interim — adapter names only) does not carry the
- * path itself; until PRD-196 lands, callers compose it by convention
- * (e.g. `${pillarId}.${adapterName}.search`).
+ * Targets carry the manifest's `procedurePath` directly, so invokers
+ * can dispatch without independently resolving `(pillarId, adapterName)`
+ * back to a path or duplicating registry state.
  */
 export type SearchAdapterInvoker = (
   target: PillarAdapterTarget,


### PR DESCRIPTION
## Summary

- Adds the PRD-199 `partial` block to `FederatedSearchResponse` — a per-pillar summary derived from the orchestrator's per-target `failures` list. Always present so consumers can rely on `partial.respondedPillars.length` etc. without a null check.
- Exports `summarisePartialFailures(targets, failures)` as a pure helper. Timeout wins over error when the same pillar has both classes of failure; the first error message per pillar is kept for the tooltip.
- Drive-by fix: `manifest.search.adapters` is now an array of adapter descriptors (PRD-196 #3046), not strings. `collectTargets` reads `adapter.name` and test fixtures emit the new shape. `main` typecheck was broken before this; both commits land together.

Covers US-01 (response shape) and US-02 (orchestrator tracks failures) from PRD-199. US-03 (shell UI indicator) is unblocked but out of scope.

## Test plan

- [x] `pnpm --filter @pops/pillar-sdk test` (369 tests, 25 files)
- [x] `pnpm typecheck` (all 66 packages)
- [x] `pnpm lint` (no new warnings/errors)
- [ ] CI green
