### PR TITLE
fix(ci): copy pillar-sdk + finance-contract into every API/MCP Dockerfile

### DIFF
--- a/apps/pops-api/Dockerfile
+++ b/apps/pops-api/Dockerfile
@@ -2,7 +2,7 @@ FROM node:22-slim AS builder
 WORKDIR /app
 
 # Copy workspace root files
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json .oxfmtrc.json ./
 
 # Copy all workspace packages
 COPY packages/db-types/package.json ./packages/db-types/
@@ -13,6 +13,8 @@ COPY packages/app-food-db/package.json ./packages/app-food-db/
 COPY packages/app-lists-db/package.json ./packages/app-lists-db/
 COPY packages/core-db/package.json ./packages/core-db/
 COPY packages/finance-db/package.json ./packages/finance-db/
+COPY packages/finance-contract/package.json ./packages/finance-contract/
+COPY packages/pillar-sdk/package.json ./packages/pillar-sdk/
 COPY packages/media-db/package.json ./packages/media-db/
 COPY packages/food-contracts/package.json ./packages/food-contracts/
 COPY packages/inventory-db/package.json ./packages/inventory-db/
@@ -59,6 +61,8 @@ COPY packages/food-db/migrations ./packages/food-db/migrations
 COPY packages/lists-db/src ./packages/lists-db/src
 COPY packages/lists-db/tsconfig.json ./packages/lists-db/
 COPY packages/lists-db/migrations ./packages/lists-db/migrations
+COPY packages/finance-contract/ ./packages/finance-contract/
+COPY packages/pillar-sdk/ ./packages/pillar-sdk/
 COPY apps/pops-api/tsconfig.json ./apps/pops-api/
 COPY apps/pops-api/src ./apps/pops-api/src
 
@@ -88,6 +92,10 @@ RUN pnpm build
 WORKDIR /app/packages/app-lists-db
 RUN pnpm build
 WORKDIR /app/packages/app-food-db
+RUN pnpm build
+WORKDIR /app/packages/finance-contract
+RUN pnpm build
+WORKDIR /app/packages/pillar-sdk
 RUN pnpm build
 
 # Build pops-api

--- a/apps/pops-cerebrum-api/Dockerfile
+++ b/apps/pops-cerebrum-api/Dockerfile
@@ -2,13 +2,15 @@ FROM node:22-slim AS builder
 WORKDIR /app
 
 # Copy workspace root files
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json .oxfmtrc.json ./
 
 # Copy workspace package.json files (for dep resolution)
 COPY packages/db-types/package.json ./packages/db-types/
 COPY packages/types/package.json ./packages/types/
 COPY packages/core-db/package.json ./packages/core-db/
 COPY packages/cerebrum-db/package.json ./packages/cerebrum-db/
+COPY packages/finance-contract/package.json ./packages/finance-contract/
+COPY packages/pillar-sdk/package.json ./packages/pillar-sdk/
 COPY apps/pops-cerebrum-api/package.json ./apps/pops-cerebrum-api/
 
 # Install pnpm and all workspace dependencies
@@ -26,6 +28,8 @@ COPY packages/core-db/migrations ./packages/core-db/migrations
 COPY packages/cerebrum-db/src ./packages/cerebrum-db/src
 COPY packages/cerebrum-db/tsconfig.json ./packages/cerebrum-db/
 COPY packages/cerebrum-db/migrations ./packages/cerebrum-db/migrations
+COPY packages/finance-contract/ ./packages/finance-contract/
+COPY packages/pillar-sdk/ ./packages/pillar-sdk/
 
 # Copy cerebrum-api source
 COPY apps/pops-cerebrum-api/tsconfig.json ./apps/pops-cerebrum-api/
@@ -39,6 +43,10 @@ RUN pnpm build
 WORKDIR /app/packages/core-db
 RUN pnpm build
 WORKDIR /app/packages/cerebrum-db
+RUN pnpm build
+WORKDIR /app/packages/finance-contract
+RUN pnpm build
+WORKDIR /app/packages/pillar-sdk
 RUN pnpm build
 
 # Build cerebrum-api

--- a/apps/pops-core-api/Dockerfile
+++ b/apps/pops-core-api/Dockerfile
@@ -2,12 +2,13 @@ FROM node:22-slim AS builder
 WORKDIR /app
 
 # Copy workspace root files
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json .oxfmtrc.json ./
 
 # Copy workspace package.json files (for dep resolution)
 COPY packages/db-types/package.json ./packages/db-types/
 COPY packages/types/package.json ./packages/types/
 COPY packages/core-db/package.json ./packages/core-db/
+COPY packages/finance-contract/package.json ./packages/finance-contract/
 COPY packages/pillar-sdk/package.json ./packages/pillar-sdk/
 COPY apps/pops-core-api/package.json ./apps/pops-core-api/
 
@@ -23,6 +24,7 @@ COPY packages/types/tsconfig.json packages/types/tsconfig.build.json ./packages/
 COPY packages/core-db/src ./packages/core-db/src
 COPY packages/core-db/tsconfig.json ./packages/core-db/
 COPY packages/core-db/migrations ./packages/core-db/migrations
+COPY packages/finance-contract/ ./packages/finance-contract/
 COPY packages/pillar-sdk/src ./packages/pillar-sdk/src
 COPY packages/pillar-sdk/tsconfig.json ./packages/pillar-sdk/
 
@@ -36,6 +38,8 @@ RUN pnpm build
 WORKDIR /app/packages/types
 RUN pnpm build
 WORKDIR /app/packages/core-db
+RUN pnpm build
+WORKDIR /app/packages/finance-contract
 RUN pnpm build
 WORKDIR /app/packages/pillar-sdk
 RUN pnpm build

--- a/apps/pops-finance-api/Dockerfile
+++ b/apps/pops-finance-api/Dockerfile
@@ -2,13 +2,14 @@ FROM node:22-slim AS builder
 WORKDIR /app
 
 # Copy workspace root files
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json .oxfmtrc.json ./
 
 # Copy workspace package.json files (for dep resolution)
 COPY packages/db-types/package.json ./packages/db-types/
 COPY packages/types/package.json ./packages/types/
 COPY packages/core-db/package.json ./packages/core-db/
 COPY packages/finance-db/package.json ./packages/finance-db/
+COPY packages/finance-contract/package.json ./packages/finance-contract/
 COPY packages/pillar-sdk/package.json ./packages/pillar-sdk/
 COPY apps/pops-finance-api/package.json ./apps/pops-finance-api/
 
@@ -27,6 +28,7 @@ COPY packages/core-db/migrations ./packages/core-db/migrations
 COPY packages/finance-db/src ./packages/finance-db/src
 COPY packages/finance-db/tsconfig.json ./packages/finance-db/
 COPY packages/finance-db/migrations ./packages/finance-db/migrations
+COPY packages/finance-contract/ ./packages/finance-contract/
 COPY packages/pillar-sdk/src ./packages/pillar-sdk/src
 COPY packages/pillar-sdk/tsconfig.json ./packages/pillar-sdk/
 
@@ -42,6 +44,8 @@ RUN pnpm build
 WORKDIR /app/packages/core-db
 RUN pnpm build
 WORKDIR /app/packages/finance-db
+RUN pnpm build
+WORKDIR /app/packages/finance-contract
 RUN pnpm build
 WORKDIR /app/packages/pillar-sdk
 RUN pnpm build

--- a/apps/pops-food-api/Dockerfile
+++ b/apps/pops-food-api/Dockerfile
@@ -2,12 +2,14 @@ FROM node:22-slim AS builder
 WORKDIR /app
 
 # Copy workspace root files
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json .oxfmtrc.json ./
 
 # Copy workspace package.json files (for dep resolution)
 COPY packages/db-types/package.json ./packages/db-types/
 COPY packages/types/package.json ./packages/types/
 COPY packages/food-db/package.json ./packages/food-db/
+COPY packages/finance-contract/package.json ./packages/finance-contract/
+COPY packages/pillar-sdk/package.json ./packages/pillar-sdk/
 COPY apps/pops-food-api/package.json ./apps/pops-food-api/
 
 # Install pnpm and all workspace dependencies
@@ -22,6 +24,8 @@ COPY packages/types/tsconfig.json packages/types/tsconfig.build.json ./packages/
 COPY packages/food-db/src ./packages/food-db/src
 COPY packages/food-db/tsconfig.json ./packages/food-db/
 COPY packages/food-db/migrations ./packages/food-db/migrations
+COPY packages/finance-contract/ ./packages/finance-contract/
+COPY packages/pillar-sdk/ ./packages/pillar-sdk/
 
 # Copy food-api source
 COPY apps/pops-food-api/tsconfig.json ./apps/pops-food-api/
@@ -33,6 +37,10 @@ RUN pnpm build
 WORKDIR /app/packages/types
 RUN pnpm build
 WORKDIR /app/packages/food-db
+RUN pnpm build
+WORKDIR /app/packages/finance-contract
+RUN pnpm build
+WORKDIR /app/packages/pillar-sdk
 RUN pnpm build
 
 # Build food-api

--- a/apps/pops-inventory-api/Dockerfile
+++ b/apps/pops-inventory-api/Dockerfile
@@ -2,13 +2,15 @@ FROM node:22-slim AS builder
 WORKDIR /app
 
 # Copy workspace root files
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json .oxfmtrc.json ./
 
 # Copy workspace package.json files (for dep resolution)
 COPY packages/db-types/package.json ./packages/db-types/
 COPY packages/types/package.json ./packages/types/
 COPY packages/core-db/package.json ./packages/core-db/
 COPY packages/inventory-db/package.json ./packages/inventory-db/
+COPY packages/finance-contract/package.json ./packages/finance-contract/
+COPY packages/pillar-sdk/package.json ./packages/pillar-sdk/
 COPY apps/pops-inventory-api/package.json ./apps/pops-inventory-api/
 
 # Install pnpm and all workspace dependencies
@@ -26,6 +28,8 @@ COPY packages/core-db/migrations ./packages/core-db/migrations
 COPY packages/inventory-db/src ./packages/inventory-db/src
 COPY packages/inventory-db/tsconfig.json ./packages/inventory-db/
 COPY packages/inventory-db/migrations ./packages/inventory-db/migrations
+COPY packages/finance-contract/ ./packages/finance-contract/
+COPY packages/pillar-sdk/ ./packages/pillar-sdk/
 
 # Copy inventory-api source
 COPY apps/pops-inventory-api/tsconfig.json ./apps/pops-inventory-api/
@@ -39,6 +43,10 @@ RUN pnpm build
 WORKDIR /app/packages/core-db
 RUN pnpm build
 WORKDIR /app/packages/inventory-db
+RUN pnpm build
+WORKDIR /app/packages/finance-contract
+RUN pnpm build
+WORKDIR /app/packages/pillar-sdk
 RUN pnpm build
 
 # Build inventory-api

--- a/apps/pops-lists-api/Dockerfile
+++ b/apps/pops-lists-api/Dockerfile
@@ -2,12 +2,14 @@ FROM node:22-slim AS builder
 WORKDIR /app
 
 # Copy workspace root files
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json .oxfmtrc.json ./
 
 # Copy workspace package.json files (for dep resolution)
 COPY packages/db-types/package.json ./packages/db-types/
 COPY packages/types/package.json ./packages/types/
 COPY packages/lists-db/package.json ./packages/lists-db/
+COPY packages/finance-contract/package.json ./packages/finance-contract/
+COPY packages/pillar-sdk/package.json ./packages/pillar-sdk/
 COPY apps/pops-lists-api/package.json ./apps/pops-lists-api/
 
 # Install pnpm and all workspace dependencies
@@ -22,6 +24,8 @@ COPY packages/types/tsconfig.json packages/types/tsconfig.build.json ./packages/
 COPY packages/lists-db/src ./packages/lists-db/src
 COPY packages/lists-db/tsconfig.json ./packages/lists-db/
 COPY packages/lists-db/migrations ./packages/lists-db/migrations
+COPY packages/finance-contract/ ./packages/finance-contract/
+COPY packages/pillar-sdk/ ./packages/pillar-sdk/
 
 # Copy lists-api source
 COPY apps/pops-lists-api/tsconfig.json ./apps/pops-lists-api/
@@ -33,6 +37,10 @@ RUN pnpm build
 WORKDIR /app/packages/types
 RUN pnpm build
 WORKDIR /app/packages/lists-db
+RUN pnpm build
+WORKDIR /app/packages/finance-contract
+RUN pnpm build
+WORKDIR /app/packages/pillar-sdk
 RUN pnpm build
 
 # Build lists-api

--- a/apps/pops-mcp/Dockerfile
+++ b/apps/pops-mcp/Dockerfile
@@ -2,7 +2,7 @@ FROM node:22-slim AS builder
 WORKDIR /app
 
 # Copy workspace root files
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json .oxfmtrc.json ./
 
 # Copy workspace package.json files (for dep resolution)
 COPY packages/db-types/package.json ./packages/db-types/
@@ -13,6 +13,8 @@ COPY packages/app-food-db/package.json ./packages/app-food-db/
 COPY packages/app-lists-db/package.json ./packages/app-lists-db/
 COPY packages/core-db/package.json ./packages/core-db/
 COPY packages/finance-db/package.json ./packages/finance-db/
+COPY packages/finance-contract/package.json ./packages/finance-contract/
+COPY packages/pillar-sdk/package.json ./packages/pillar-sdk/
 COPY packages/media-db/package.json ./packages/media-db/
 COPY packages/food-contracts/package.json ./packages/food-contracts/
 COPY packages/inventory-db/package.json ./packages/inventory-db/
@@ -60,6 +62,8 @@ COPY packages/food-db/migrations ./packages/food-db/migrations
 COPY packages/lists-db/src ./packages/lists-db/src
 COPY packages/lists-db/tsconfig.json ./packages/lists-db/
 COPY packages/lists-db/migrations ./packages/lists-db/migrations
+COPY packages/finance-contract/ ./packages/finance-contract/
+COPY packages/pillar-sdk/ ./packages/pillar-sdk/
 
 # Copy pops-api source (needed only for AppRouter type resolution at compile time)
 COPY apps/pops-api/tsconfig.json ./apps/pops-api/
@@ -96,6 +100,10 @@ RUN pnpm build
 WORKDIR /app/packages/app-lists-db
 RUN pnpm build
 WORKDIR /app/packages/app-food-db
+RUN pnpm build
+WORKDIR /app/packages/finance-contract
+RUN pnpm build
+WORKDIR /app/packages/pillar-sdk
 RUN pnpm build
 
 # Build pops-mcp

--- a/apps/pops-media-api/Dockerfile
+++ b/apps/pops-media-api/Dockerfile
@@ -2,12 +2,14 @@ FROM node:22-slim AS builder
 WORKDIR /app
 
 # Copy workspace root files
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json .oxfmtrc.json ./
 
 # Copy workspace package.json files (for dep resolution)
 COPY packages/db-types/package.json ./packages/db-types/
 COPY packages/types/package.json ./packages/types/
 COPY packages/media-db/package.json ./packages/media-db/
+COPY packages/finance-contract/package.json ./packages/finance-contract/
+COPY packages/pillar-sdk/package.json ./packages/pillar-sdk/
 COPY apps/pops-media-api/package.json ./apps/pops-media-api/
 
 # Install pnpm and all workspace dependencies
@@ -22,6 +24,8 @@ COPY packages/types/tsconfig.json packages/types/tsconfig.build.json ./packages/
 COPY packages/media-db/src ./packages/media-db/src
 COPY packages/media-db/tsconfig.json ./packages/media-db/
 COPY packages/media-db/migrations ./packages/media-db/migrations
+COPY packages/finance-contract/ ./packages/finance-contract/
+COPY packages/pillar-sdk/ ./packages/pillar-sdk/
 
 # Copy media-api source
 COPY apps/pops-media-api/tsconfig.json ./apps/pops-media-api/
@@ -33,6 +37,10 @@ RUN pnpm build
 WORKDIR /app/packages/types
 RUN pnpm build
 WORKDIR /app/packages/media-db
+RUN pnpm build
+WORKDIR /app/packages/finance-contract
+RUN pnpm build
+WORKDIR /app/packages/pillar-sdk
 RUN pnpm build
 
 # Build media-api

--- a/apps/pops-shell/Dockerfile
+++ b/apps/pops-shell/Dockerfile
@@ -2,7 +2,7 @@ FROM node:22-alpine AS builder
 WORKDIR /app
 
 # Copy workspace root files
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json .oxfmtrc.json ./
 
 # Copy all workspace package.json files needed by pops-shell
 COPY apps/pops-shell/package.json ./apps/pops-shell/

--- a/packages/pillar-sdk/package.json
+++ b/packages/pillar-sdk/package.json
@@ -58,10 +58,6 @@
       "types": "./dist/orchestrator/index.d.ts",
       "default": "./dist/orchestrator/index.js"
     },
-    "./ai-tools": {
-      "types": "./dist/ai-tools/index.d.ts",
-      "default": "./dist/ai-tools/index.js"
-    },
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/packages/pillar-sdk/src/ai-tools/index.ts
+++ b/packages/pillar-sdk/src/ai-tools/index.ts
@@ -10,9 +10,4 @@ export {
   type AnthropicToolResultBlock,
   type OpenAiToolMessage,
 } from './provider-adapter.js';
-export type {
-  Tool,
-  BuildToolListOptions,
-  ToolResult,
-  InvokeToolOptions,
-} from './types.js';
+export type { Tool, BuildToolListOptions, ToolResult, InvokeToolOptions } from './types.js';


### PR DESCRIPTION
## Summary

- `publish-images.yml` has been failing for 6 consecutive `main` pushes. Active failure on `pops-api` at `pnpm deploy`: `ERR_PNPM_WORKSPACE_PKG_NOT_FOUND  In ../../packages/api-client: '@pops/pillar-sdk@workspace:*' is in the dependencies but no package named '@pops/pillar-sdk' is present in the workspace`.
- Root cause: `packages/api-client` depends on `@pops/pillar-sdk@workspace:*`, and `pillar-sdk` in turn imports types from `@pops/finance-contract/{manifest,types,errors}`. Every Dockerfile that materialises a partial workspace tree by COPYing `packages/*/package.json` files needs both packages present, otherwise pnpm aborts during install or deploy.
- Fix mirrors precedent from #3001 (pops-shell) and #2995 (api-quality / api-test workflows): COPY both `package.json`s before `pnpm install`, COPY full sources before build, and `pnpm build` `finance-contract` before `pillar-sdk`. Also COPY `.oxfmtrc.json` so `finance-contract`'s `verify-manifest` step (which formats with `oxfmt` before byte-compare) doesn't diverge against the committed `manifest.generated.ts`.

## Dockerfiles touched

| File | Was missing |
| --- | --- |
| `apps/pops-api/Dockerfile` | both (active failure) |
| `apps/pops-mcp/Dockerfile` | both |
| `apps/pops-core-api/Dockerfile` | `finance-contract` |
| `apps/pops-finance-api/Dockerfile` | `finance-contract` |
| `apps/pops-media-api/Dockerfile` | both |
| `apps/pops-inventory-api/Dockerfile` | both |
| `apps/pops-cerebrum-api/Dockerfile` | both |
| `apps/pops-food-api/Dockerfile` | both |
| `apps/pops-lists-api/Dockerfile` | both |

`apps/pops-shell/Dockerfile` was already correct after #3001 and is unchanged. `apps/pops-worker-food/` has no Dockerfile.

## Test plan

- [x] `docker buildx build -f apps/pops-core-api/Dockerfile --target builder .` completes (install + every shared-package build + the app build + `pnpm deploy --prod --legacy`)
- [x] `docker buildx build -f apps/pops-api/Dockerfile --target builder .` completes (this was the actively failing image)
- [ ] `publish-images.yml` goes green on the merge commit; watchtower can roll the new images.