### PR TITLE
feat(pillar-apis): per-pillar /health includes status + ts (Theme 13)

### DIFF
--- a/apps/pops-api/src/routes/health.ts
+++ b/apps/pops-api/src/routes/health.ts
@@ -26,13 +26,15 @@ router.get('/health', (_req, res) => {
     if (rows[0]?.ok === 1) {
       const redisStatus = getRedisStatus();
       // `ok: true` and `pillar` are the ADR-026 P2 pillar-health contract
-      // fields. `status: 'ok'`, `version`, `redis` are kept for backwards
-      // compatibility with existing Docker healthchecks and dashboards.
+      // fields. `status: 'ok'`, `version`, `ts`, `redis` are kept for
+      // backwards compatibility with existing Docker healthchecks and
+      // dashboards.
       res.json({
         ok: true,
         pillar: SELF_PILLAR_ID,
         status: 'ok',
         version: apiVersion,
+        ts: new Date().toISOString(),
         redis: redisStatus === 'ready' ? 'ok' : 'down',
       });
     } else {

--- a/apps/pops-cerebrum-api/src/__tests__/health.test.ts
+++ b/apps/pops-cerebrum-api/src/__tests__/health.test.ts
@@ -3,7 +3,7 @@
  *
  * Boots the app against a per-test temp-dir cerebrum.db (mkdtemp +
  * cleanup in afterEach) and confirms the `/health` route returns the
- * agreed `{ ok, pillar, version }` shape.
+ * agreed `{ ok, status, pillar, version, ts }` shape.
  */
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -34,11 +34,18 @@ afterEach(() => {
 });
 
 describe('GET /health', () => {
-  it('returns ok + pillar + version', async () => {
+  it('returns ok + status + pillar + version + ts', async () => {
     const app = createCerebrumApiApp({ cerebrumDb, coreDb, version: '0.0.1-test' });
     const res = await request(app).get('/health');
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ ok: true, pillar: 'cerebrum', version: '0.0.1-test' });
+    expect(res.body).toEqual({
+      ok: true,
+      status: 'ok',
+      pillar: 'cerebrum',
+      version: '0.0.1-test',
+      ts: expect.any(String),
+    });
+    expect(new Date(res.body.ts as string).toISOString()).toBe(res.body.ts);
   });
 
   it('fails closed when the cerebrum handle is closed', async () => {

--- a/apps/pops-cerebrum-api/src/handlers.ts
+++ b/apps/pops-cerebrum-api/src/handlers.ts
@@ -28,8 +28,10 @@ export interface CerebrumApiDeps {
 
 export interface HealthResponse {
   ok: true;
+  status: 'ok';
   pillar: 'cerebrum';
   version: string;
+  ts: string;
 }
 
 export function makeRequestHandler(deps: CerebrumApiDeps): {
@@ -41,7 +43,13 @@ export function makeRequestHandler(deps: CerebrumApiDeps): {
       // (caught by the Express error pipeline -> 500) rather than a
       // bogus 200 OK that hides a broken connection.
       deps.cerebrumDb.raw.prepare('SELECT 1').get();
-      return { ok: true, pillar: 'cerebrum', version: deps.version };
+      return {
+        ok: true,
+        status: 'ok',
+        pillar: 'cerebrum',
+        version: deps.version,
+        ts: new Date().toISOString(),
+      };
     },
   };
 }

--- a/apps/pops-core-api/src/__tests__/health.test.ts
+++ b/apps/pops-core-api/src/__tests__/health.test.ts
@@ -3,7 +3,7 @@
  *
  * Boots the app against a per-test temp-dir core.db (mkdtemp + cleanup
  * in afterEach) and confirms the `/health` route returns the agreed
- * `{ ok, pillar, version }` shape.
+ * `{ ok, status, pillar, version, ts }` shape.
  */
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -30,7 +30,7 @@ afterEach(() => {
 });
 
 describe('GET /health', () => {
-  it('returns ok + pillar + version', async () => {
+  it('returns ok + status + pillar + version + ts', async () => {
     const app = createCoreApiApp({
       coreDb,
       version: '0.0.1-test',
@@ -38,7 +38,15 @@ describe('GET /health', () => {
     });
     const res = await request(app).get('/health');
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ ok: true, pillar: 'core', version: '0.0.1-test' });
+    expect(res.body).toEqual({
+      ok: true,
+      status: 'ok',
+      pillar: 'core',
+      version: '0.0.1-test',
+      ts: expect.any(String),
+    });
+    expect(() => new Date(res.body.ts as string).toISOString()).not.toThrow();
+    expect(new Date(res.body.ts as string).toISOString()).toBe(res.body.ts);
   });
 
   it('fails closed when the core handle is closed', async () => {

--- a/apps/pops-core-api/src/handlers.ts
+++ b/apps/pops-core-api/src/handlers.ts
@@ -25,8 +25,10 @@ export interface CoreApiDeps {
 
 export interface HealthResponse {
   ok: true;
+  status: 'ok';
   pillar: 'core';
   version: string;
+  ts: string;
 }
 
 export interface PillarsResponse {
@@ -43,7 +45,13 @@ export function makeRequestHandler(deps: CoreApiDeps): {
       // (caught by the Express error pipeline -> 500) rather than a
       // bogus 200 OK that hides a broken connection.
       deps.coreDb.raw.prepare('SELECT 1').get();
-      return { ok: true, pillar: 'core', version: deps.version };
+      return {
+        ok: true,
+        status: 'ok',
+        pillar: 'core',
+        version: deps.version,
+        ts: new Date().toISOString(),
+      };
     },
     pillars(): PillarsResponse {
       return { pillars: getPillarRegistry({ selfBaseUrl: deps.selfBaseUrl }) };

--- a/apps/pops-finance-api/src/__tests__/health.test.ts
+++ b/apps/pops-finance-api/src/__tests__/health.test.ts
@@ -3,7 +3,7 @@
  *
  * Boots the app against a per-test temp-dir finance.db (mkdtemp +
  * cleanup in afterEach) and confirms the `/health` route returns the
- * agreed `{ ok, pillar, version }` shape.
+ * agreed `{ ok, status, pillar, version, ts }` shape.
  *
  * Mirrors `apps/pops-media-api/src/__tests__/health.test.ts`.
  */
@@ -32,11 +32,18 @@ afterEach(() => {
 });
 
 describe('GET /health', () => {
-  it('returns ok + pillar + version', async () => {
+  it('returns ok + status + pillar + version + ts', async () => {
     const app = createFinanceApiApp({ financeDb, version: '0.0.1-test' });
     const res = await request(app).get('/health');
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ ok: true, pillar: 'finance', version: '0.0.1-test' });
+    expect(res.body).toEqual({
+      ok: true,
+      status: 'ok',
+      pillar: 'finance',
+      version: '0.0.1-test',
+      ts: expect.any(String),
+    });
+    expect(new Date(res.body.ts as string).toISOString()).toBe(res.body.ts);
   });
 
   it('fails closed when the finance handle is closed', async () => {

--- a/apps/pops-finance-api/src/handlers.ts
+++ b/apps/pops-finance-api/src/handlers.ts
@@ -30,8 +30,10 @@ export interface FinanceApiDeps {
 
 export interface HealthResponse {
   ok: true;
+  status: 'ok';
   pillar: 'finance';
   version: string;
+  ts: string;
 }
 
 export function makeRequestHandler(deps: FinanceApiDeps): {
@@ -43,7 +45,13 @@ export function makeRequestHandler(deps: FinanceApiDeps): {
       // (caught by the Express error pipeline -> 500) rather than a
       // bogus 200 OK that hides a broken connection.
       deps.financeDb.raw.prepare('SELECT 1').get();
-      return { ok: true, pillar: 'finance', version: deps.version };
+      return {
+        ok: true,
+        status: 'ok',
+        pillar: 'finance',
+        version: deps.version,
+        ts: new Date().toISOString(),
+      };
     },
   };
 }

--- a/apps/pops-food-api/src/__tests__/health.test.ts
+++ b/apps/pops-food-api/src/__tests__/health.test.ts
@@ -3,7 +3,7 @@
  *
  * Boots the app against a per-test temp-dir food.db (mkdtemp +
  * cleanup in afterEach) and confirms the `/health` route returns the
- * agreed `{ ok, pillar, version }` shape.
+ * agreed `{ ok, status, pillar, version, ts }` shape.
  */
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -30,7 +30,7 @@ afterEach(() => {
 });
 
 describe('GET /health', () => {
-  it('returns ok + pillar + version', async () => {
+  it('returns ok + status + pillar + version + ts', async () => {
     const app = createFoodApiApp({
       foodDb,
       version: '0.0.1-test',
@@ -38,7 +38,14 @@ describe('GET /health', () => {
     });
     const res = await request(app).get('/health');
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ ok: true, pillar: 'food', version: '0.0.1-test' });
+    expect(res.body).toEqual({
+      ok: true,
+      status: 'ok',
+      pillar: 'food',
+      version: '0.0.1-test',
+      ts: expect.any(String),
+    });
+    expect(new Date(res.body.ts as string).toISOString()).toBe(res.body.ts);
   });
 
   it('fails closed when the food handle is closed', async () => {

--- a/apps/pops-food-api/src/handlers.ts
+++ b/apps/pops-food-api/src/handlers.ts
@@ -26,8 +26,10 @@ export interface FoodApiDeps {
 
 export interface HealthResponse {
   ok: true;
+  status: 'ok';
   pillar: 'food';
   version: string;
+  ts: string;
 }
 
 export interface PillarsResponse {
@@ -44,7 +46,13 @@ export function makeRequestHandler(deps: FoodApiDeps): {
       // (caught by the Express error pipeline -> 500) rather than a
       // bogus 200 OK that hides a broken connection.
       deps.foodDb.raw.prepare('SELECT 1').get();
-      return { ok: true, pillar: 'food', version: deps.version };
+      return {
+        ok: true,
+        status: 'ok',
+        pillar: 'food',
+        version: deps.version,
+        ts: new Date().toISOString(),
+      };
     },
     pillars(): PillarsResponse {
       return { pillars: getPillarRegistry({ selfBaseUrl: deps.selfBaseUrl }) };

--- a/apps/pops-inventory-api/src/__tests__/health.test.ts
+++ b/apps/pops-inventory-api/src/__tests__/health.test.ts
@@ -3,7 +3,7 @@
  *
  * Boots the app against a per-test temp-dir inventory.db (mkdtemp +
  * cleanup in afterEach) and confirms the `/health` route returns the
- * agreed `{ ok, pillar, version }` shape.
+ * agreed `{ ok, status, pillar, version, ts }` shape.
  */
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -30,7 +30,7 @@ afterEach(() => {
 });
 
 describe('GET /health', () => {
-  it('returns ok + pillar + version', async () => {
+  it('returns ok + status + pillar + version + ts', async () => {
     const app = createInventoryApiApp({
       inventoryDb,
       version: '0.0.1-test',
@@ -38,7 +38,14 @@ describe('GET /health', () => {
     });
     const res = await request(app).get('/health');
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ ok: true, pillar: 'inventory', version: '0.0.1-test' });
+    expect(res.body).toEqual({
+      ok: true,
+      status: 'ok',
+      pillar: 'inventory',
+      version: '0.0.1-test',
+      ts: expect.any(String),
+    });
+    expect(new Date(res.body.ts as string).toISOString()).toBe(res.body.ts);
   });
 
   it('fails closed when the inventory handle is closed', async () => {

--- a/apps/pops-inventory-api/src/handlers.ts
+++ b/apps/pops-inventory-api/src/handlers.ts
@@ -36,8 +36,10 @@ export interface InventoryApiDeps {
 
 export interface HealthResponse {
   ok: true;
+  status: 'ok';
   pillar: 'inventory';
   version: string;
+  ts: string;
 }
 
 export interface PillarsResponse {
@@ -54,7 +56,13 @@ export function makeRequestHandler(deps: InventoryApiDeps): {
       // (caught by the Express error pipeline -> 500) rather than a
       // bogus 200 OK that hides a broken connection.
       deps.inventoryDb.raw.prepare('SELECT 1').get();
-      return { ok: true, pillar: 'inventory', version: deps.version };
+      return {
+        ok: true,
+        status: 'ok',
+        pillar: 'inventory',
+        version: deps.version,
+        ts: new Date().toISOString(),
+      };
     },
     pillars(): PillarsResponse {
       return { pillars: getPillarRegistry({ selfBaseUrl: deps.selfBaseUrl }) };

--- a/apps/pops-lists-api/src/__tests__/health.test.ts
+++ b/apps/pops-lists-api/src/__tests__/health.test.ts
@@ -3,7 +3,7 @@
  *
  * Boots the app against a per-test temp-dir lists.db (mkdtemp +
  * cleanup in afterEach) and confirms the `/health` route returns the
- * agreed `{ ok, pillar, version }` shape.
+ * agreed `{ ok, status, pillar, version, ts }` shape.
  */
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -30,7 +30,7 @@ afterEach(() => {
 });
 
 describe('GET /health', () => {
-  it('returns ok + pillar + version', async () => {
+  it('returns ok + status + pillar + version + ts', async () => {
     const app = createListsApiApp({
       listsDb,
       version: '0.0.1-test',
@@ -38,7 +38,14 @@ describe('GET /health', () => {
     });
     const res = await request(app).get('/health');
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ ok: true, pillar: 'lists', version: '0.0.1-test' });
+    expect(res.body).toEqual({
+      ok: true,
+      status: 'ok',
+      pillar: 'lists',
+      version: '0.0.1-test',
+      ts: expect.any(String),
+    });
+    expect(new Date(res.body.ts as string).toISOString()).toBe(res.body.ts);
   });
 
   it('fails closed when the lists handle is closed', async () => {

--- a/apps/pops-lists-api/src/handlers.ts
+++ b/apps/pops-lists-api/src/handlers.ts
@@ -26,8 +26,10 @@ export interface ListsApiDeps {
 
 export interface HealthResponse {
   ok: true;
+  status: 'ok';
   pillar: 'lists';
   version: string;
+  ts: string;
 }
 
 export interface PillarsResponse {
@@ -44,7 +46,13 @@ export function makeRequestHandler(deps: ListsApiDeps): {
       // (caught by the Express error pipeline -> 500) rather than a
       // bogus 200 OK that hides a broken connection.
       deps.listsDb.raw.prepare('SELECT 1').get();
-      return { ok: true, pillar: 'lists', version: deps.version };
+      return {
+        ok: true,
+        status: 'ok',
+        pillar: 'lists',
+        version: deps.version,
+        ts: new Date().toISOString(),
+      };
     },
     pillars(): PillarsResponse {
       return { pillars: getPillarRegistry({ selfBaseUrl: deps.selfBaseUrl }) };

--- a/apps/pops-media-api/src/__tests__/health.test.ts
+++ b/apps/pops-media-api/src/__tests__/health.test.ts
@@ -3,7 +3,7 @@
  *
  * Boots the app against a per-test temp-dir media.db (mkdtemp + cleanup
  * in afterEach) and confirms the `/health` route returns the agreed
- * `{ ok, pillar, version }` shape.
+ * `{ ok, status, pillar, version, ts }` shape.
  *
  * Mirrors `apps/pops-core-api/src/__tests__/health.test.ts`.
  */
@@ -32,11 +32,18 @@ afterEach(() => {
 });
 
 describe('GET /health', () => {
-  it('returns ok + pillar + version', async () => {
+  it('returns ok + status + pillar + version + ts', async () => {
     const app = createMediaApiApp({ mediaDb, version: '0.0.1-test' });
     const res = await request(app).get('/health');
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ ok: true, pillar: 'media', version: '0.0.1-test' });
+    expect(res.body).toEqual({
+      ok: true,
+      status: 'ok',
+      pillar: 'media',
+      version: '0.0.1-test',
+      ts: expect.any(String),
+    });
+    expect(new Date(res.body.ts as string).toISOString()).toBe(res.body.ts);
   });
 
   it('fails closed when the media handle is closed', async () => {

--- a/apps/pops-media-api/src/handlers.ts
+++ b/apps/pops-media-api/src/handlers.ts
@@ -20,8 +20,10 @@ export interface MediaApiDeps {
 
 export interface HealthResponse {
   ok: true;
+  status: 'ok';
   pillar: 'media';
   version: string;
+  ts: string;
 }
 
 export function makeRequestHandler(deps: MediaApiDeps): {
@@ -33,7 +35,13 @@ export function makeRequestHandler(deps: MediaApiDeps): {
       // (caught by the Express error pipeline -> 500) rather than a
       // bogus 200 OK that hides a broken connection.
       deps.mediaDb.raw.prepare('SELECT 1').get();
-      return { ok: true, pillar: 'media', version: deps.version };
+      return {
+        ok: true,
+        status: 'ok',
+        pillar: 'media',
+        version: deps.version,
+        ts: new Date().toISOString(),
+      };
     },
   };
 }

--- a/packages/pillar-sdk/package.json
+++ b/packages/pillar-sdk/package.json
@@ -58,10 +58,6 @@
       "types": "./dist/orchestrator/index.d.ts",
       "default": "./dist/orchestrator/index.js"
     },
-    "./ai-tools": {
-      "types": "./dist/ai-tools/index.d.ts",
-      "default": "./dist/ai-tools/index.js"
-    },
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/packages/pillar-sdk/src/ai-tools/index.ts
+++ b/packages/pillar-sdk/src/ai-tools/index.ts
@@ -10,9 +10,4 @@ export {
   type AnthropicToolResultBlock,
   type OpenAiToolMessage,
 } from './provider-adapter.js';
-export type {
-  Tool,
-  BuildToolListOptions,
-  ToolResult,
-  InvokeToolOptions,
-} from './types.js';
+export type { Tool, BuildToolListOptions, ToolResult, InvokeToolOptions } from './types.js';

--- a/packages/pillar-sdk/src/bootstrap/health-route.ts
+++ b/packages/pillar-sdk/src/bootstrap/health-route.ts
@@ -22,8 +22,10 @@ export function mountHealthRoute(
     app.get(manifest.healthcheck.path, (_req, res) => {
       res.json({
         ok: true,
+        status: 'ok',
         pillar: manifest.pillar,
         version: manifest.version,
+        ts: new Date().toISOString(),
         contract: {
           package: manifest.contract.package,
           version: manifest.contract.version,


### PR DESCRIPTION
## Summary

Audit confirmed all eight pillar APIs (`pops-api`, `pops-core-api`, `pops-finance-api`, `pops-media-api`, `pops-inventory-api`, `pops-cerebrum-api`, `pops-food-api`, `pops-lists-api`) already expose `/health`. None required auth gating — every pillar app registers the route before any auth middleware, and `pops-api`'s auth middleware skip is asserted in `auth.test.ts`.

Existing shape was the ADR-026 contract: `{ ok: true, pillar, version }`. This PR **extends** that shape on every `/health` response with two additional fields the Theme 13 "pops is healthy" goal clause + deployment-state queries depend on:

- `status: 'ok'` — explicit human-readable health string consumed by the shell / goal-clause evaluator without parsing the boolean `ok`.
- `ts: <ISO8601>` — server-side timestamp on every probe response so deployment-state queries can detect stuck / cached health bodies.

The legacy ADR-026 fields (`ok: true`, `pillar`) are preserved verbatim so Docker healthchecks, the cross-pillar `health-probe`, and registry boot reconciliation keep working unchanged.

The pillar-sdk's `mountHealthRoute` helper is updated to mirror the new shape so any future pillar that opts into the SDK-mounted route gets the same contract for free.

## Files touched

- `apps/pops-core-api/src/handlers.ts` (+ test)
- `apps/pops-finance-api/src/handlers.ts` (+ test)
- `apps/pops-media-api/src/handlers.ts` (+ test)
- `apps/pops-inventory-api/src/handlers.ts` (+ test)
- `apps/pops-cerebrum-api/src/handlers.ts` (+ test)
- `apps/pops-food-api/src/handlers.ts` (+ test)
- `apps/pops-lists-api/src/handlers.ts` (+ test)
- `apps/pops-api/src/routes/health.ts`
- `packages/pillar-sdk/src/bootstrap/health-route.ts`

## Test plan

- [x] `pnpm turbo test --filter=@pops/core-api …@pops/lists-api` — all 7 pillar suites green (each `health.test.ts` now asserts the full `{ ok, status, pillar, version, ts }` shape + round-trips `new Date(ts).toISOString() === ts`).
- [x] `pnpm --filter @pops/api test` — 4925/4925 green.
- [x] `pnpm --filter @pops/pillar-sdk test` — 390/390 green.
- [x] `pnpm turbo typecheck` — green across modified packages.
- [x] `pnpm format:check` — green (no drift introduced).