### PR TITLE
fix(pillar-sdk): align discovery transport with core.registry.list

### DIFF
--- a/apps/pops-core-api/src/__tests__/registry-sdk-interop.test.ts
+++ b/apps/pops-core-api/src/__tests__/registry-sdk-interop.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Integration smoke for the SDK ↔ registry procedure-name contract
+ * (PRD-227 precondition #1).
+ *
+ * The discovery SDK (`@pops/pillar-sdk`) historically called the
+ * registry via `core.registry.snapshot` while the router exposed
+ * `core.registry.list`, so any FE/MCP canary that asked the SDK to
+ * fetch the snapshot got a 404. This test pins the URL contract
+ * end-to-end:
+ *
+ *   1. Boot `createCoreApiApp` against a per-test in-memory core.db.
+ *   2. Listen on an ephemeral port via `http.createServer(app).listen(0)`.
+ *   3. Inject a tracing `fetchImpl` into `HttpDiscoveryTransport` to
+ *      capture the URL the SDK constructs.
+ *   4. Assert the URL is `/trpc/core.registry.list` and the HTTP
+ *      transport's `fetch` returns a 200 with the registry's tRPC
+ *      envelope shape (`{ result: { data: { pillars, fetchedAt } } }`).
+ *
+ * The SDK's runtime parser (`parseRegistryEntry`) currently expects a
+ * `lastSeenAt` field that the router does not emit — that field-name
+ * mismatch is tracked as a separate precondition and is intentionally
+ * NOT exercised here: this test guards the procedure-name fix in
+ * isolation so it can fail loudly if either side regresses.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { createServer, type Server } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { openCoreDb, type OpenedCoreDb } from '@pops/core-db';
+import { HttpDiscoveryTransport } from '@pops/pillar-sdk/client';
+
+import { createCoreApiApp } from '../app.js';
+import { appRouter } from '../router.js';
+import { type Context } from '../trpc.js';
+
+import type { AddressInfo } from 'node:net';
+
+import type { ManifestPayload } from '@pops/pillar-sdk';
+
+let tmpDir: string;
+let coreDb: OpenedCoreDb;
+let server: Server;
+let baseUrl: string;
+
+beforeEach(async () => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'core-api-sdk-interop-test-'));
+  coreDb = openCoreDb(join(tmpDir, 'core.db'));
+  const app = createCoreApiApp({
+    coreDb,
+    version: '0.0.1-test',
+    selfBaseUrl: 'http://localhost:0',
+  });
+  server = createServer(app);
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const addr = server.address() as AddressInfo;
+  baseUrl = `http://127.0.0.1:${addr.port}`;
+});
+
+afterEach(async () => {
+  await new Promise<void>((resolve, reject) =>
+    server.close((err) => (err ? reject(err) : resolve()))
+  );
+  coreDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function caller(): ReturnType<typeof appRouter.createCaller> {
+  const ctx: Context = {
+    user: { email: 'dev@example.com' },
+    serviceAccount: null,
+    coreDb: coreDb.db,
+  };
+  return appRouter.createCaller(ctx);
+}
+
+function financeManifest(): ManifestPayload {
+  return {
+    pillar: 'finance',
+    version: '0.1.0',
+    contract: {
+      package: '@pops/finance-contract',
+      version: '0.1.0',
+      tag: 'contract-finance@v0.1.0',
+    },
+    routes: {
+      queries: ['finance.transactions.list'],
+      mutations: ['finance.transactions.create'],
+      subscriptions: [],
+    },
+    search: { adapters: [] },
+    ai: { tools: [] },
+    uri: { types: ['finance/transaction'] },
+    settings: { keys: ['finance.defaultCurrency'] },
+    healthcheck: { path: '/healthz' },
+  };
+}
+
+describe('SDK ↔ core.registry procedure-name interop', () => {
+  it('HttpDiscoveryTransport hits /trpc/core.registry.list on the live server', async () => {
+    await caller().core.registry.register({
+      baseUrl: 'http://finance-api:3004',
+      manifest: financeManifest(),
+    });
+
+    const seenUrls: string[] = [];
+    let lastResponse: Response | undefined;
+    const tracingFetch: typeof fetch = async (input, init) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      seenUrls.push(url);
+      const res = await fetch(input, init);
+      lastResponse = res.clone();
+      return res;
+    };
+
+    const transport = new HttpDiscoveryTransport({
+      registryUrl: baseUrl,
+      fetchImpl: tracingFetch,
+    });
+
+    await transport.fetchSnapshot().catch(() => {
+      // Parser-level mismatches (e.g. `lastSeenAt` vs `lastHeartbeatAt`)
+      // are out of scope for this test — we only pin the wire URL and
+      // confirm the registry served the request. Body-level fixes land
+      // in their own change.
+    });
+
+    expect(seenUrls).toEqual([`${baseUrl}/trpc/core.registry.list`]);
+    expect(lastResponse).toBeDefined();
+    expect(lastResponse?.status).toBe(200);
+
+    const body = (await lastResponse?.json()) as {
+      result: { data: { pillars: unknown[]; fetchedAt: string } };
+    };
+    expect(Array.isArray(body.result.data.pillars)).toBe(true);
+    expect(body.result.data.pillars).toHaveLength(1);
+    expect(typeof body.result.data.fetchedAt).toBe('string');
+  });
+
+  it('returns an empty pillar list on a fresh registry (no 404)', async () => {
+    const seenUrls: string[] = [];
+    const tracingFetch: typeof fetch = async (input, init) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      seenUrls.push(url);
+      return fetch(input, init);
+    };
+
+    const transport = new HttpDiscoveryTransport({
+      registryUrl: baseUrl,
+      fetchImpl: tracingFetch,
+    });
+
+    await transport.fetchSnapshot().catch(() => {
+      // see above — parser-shape issues tracked separately.
+    });
+
+    expect(seenUrls).toEqual([`${baseUrl}/trpc/core.registry.list`]);
+  });
+});

--- a/apps/pops-core-api/src/__tests__/registry-sdk-interop.test.ts
+++ b/apps/pops-core-api/src/__tests__/registry-sdk-interop.test.ts
@@ -8,7 +8,8 @@
  * fetch the snapshot got a 404. This test pins the URL contract
  * end-to-end:
  *
- *   1. Boot `createCoreApiApp` against a per-test in-memory core.db.
+ *   1. Boot `createCoreApiApp` against a per-test file-backed core.db
+ *      in an OS temp directory.
  *   2. Listen on an ephemeral port via `http.createServer(app).listen(0)`.
  *   3. Inject a tracing `fetchImpl` into `HttpDiscoveryTransport` to
  *      capture the URL the SDK constructs.
@@ -60,12 +61,29 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
-  await new Promise<void>((resolve, reject) =>
-    server.close((err) => (err ? reject(err) : resolve()))
-  );
-  coreDb.raw.close();
-  rmSync(tmpDir, { recursive: true, force: true });
+  if (server) {
+    await new Promise<void>((resolve, reject) =>
+      server.close((err) => (err ? reject(err) : resolve()))
+    ).catch(() => undefined);
+  }
+  if (coreDb) {
+    try {
+      coreDb.raw.close();
+    } catch {
+      // surface the original beforeEach failure instead of swallowing cleanup noise
+    }
+  }
+  if (tmpDir) {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
 });
+
+function extractFetchUrl(input: Parameters<typeof fetch>[0]): string {
+  if (typeof input === 'string') return input;
+  if (input instanceof URL) return input.toString();
+  if (input instanceof Request) return input.url;
+  return String(input);
+}
 
 function caller(): ReturnType<typeof appRouter.createCaller> {
   const ctx: Context = {
@@ -108,7 +126,7 @@ describe('SDK ↔ core.registry procedure-name interop', () => {
     const seenUrls: string[] = [];
     let lastResponse: Response | undefined;
     const tracingFetch: typeof fetch = async (input, init) => {
-      const url = typeof input === 'string' ? input : input.toString();
+      const url = extractFetchUrl(input);
       seenUrls.push(url);
       const res = await fetch(input, init);
       lastResponse = res.clone();
@@ -142,7 +160,7 @@ describe('SDK ↔ core.registry procedure-name interop', () => {
   it('returns an empty pillar list on a fresh registry (no 404)', async () => {
     const seenUrls: string[] = [];
     const tracingFetch: typeof fetch = async (input, init) => {
-      const url = typeof input === 'string' ? input : input.toString();
+      const url = extractFetchUrl(input);
       seenUrls.push(url);
       return fetch(input, init);
     };

--- a/docs/themes/13-pillar-finale/prds/189-batch-call-site-audit/README.md
+++ b/docs/themes/13-pillar-finale/prds/189-batch-call-site-audit/README.md
@@ -42,12 +42,12 @@ Audit produces a report at `docs/themes/13-pillar-finale/prds/189-batch-call-sit
 
 ## User Stories
 
-| #   | Story                                                                                                       | Status      |
-| --- | ----------------------------------------------------------------------------------------------------------- | ----------- |
-| 01  | Scan every shell + app-package source file for `trpc.<pillar>.*` calls; emit per-file report                | Done        |
+| #   | Story                                                                                                        | Status      |
+| --- | ------------------------------------------------------------------------------------------------------------ | ----------- |
+| 01  | Scan every shell + app-package source file for `trpc.<pillar>.*` calls; emit per-file report                 | Done        |
 | 02  | For each cross-pillar site, classify: single-pillar / cross-pillar-documented / cross-pillar-refactor-needed | Done        |
-| 03  | Refactor the 3-5 highest-volume cross-pillar pages (likely Dashboard, Cerebrum context view, etc.)          | Not started |
-| 04  | Final report committed alongside this PRD ([`inventory.md`](./inventory.md))                                | Done        |
+| 03  | Refactor the 3-5 highest-volume cross-pillar pages (likely Dashboard, Cerebrum context view, etc.)           | Not started |
+| 04  | Final report committed alongside this PRD ([`inventory.md`](./inventory.md))                                 | Done        |
 
 ## Out of Scope
 

--- a/packages/pillar-sdk/package.json
+++ b/packages/pillar-sdk/package.json
@@ -58,10 +58,6 @@
       "types": "./dist/orchestrator/index.d.ts",
       "default": "./dist/orchestrator/index.js"
     },
-    "./ai-tools": {
-      "types": "./dist/ai-tools/index.d.ts",
-      "default": "./dist/ai-tools/index.js"
-    },
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/packages/pillar-sdk/src/ai-tools/index.ts
+++ b/packages/pillar-sdk/src/ai-tools/index.ts
@@ -10,9 +10,4 @@ export {
   type AnthropicToolResultBlock,
   type OpenAiToolMessage,
 } from './provider-adapter.js';
-export type {
-  Tool,
-  BuildToolListOptions,
-  ToolResult,
-  InvokeToolOptions,
-} from './types.js';
+export type { Tool, BuildToolListOptions, ToolResult, InvokeToolOptions } from './types.js';

--- a/packages/pillar-sdk/src/client/__tests__/discovery.test.ts
+++ b/packages/pillar-sdk/src/client/__tests__/discovery.test.ts
@@ -25,7 +25,7 @@ describe('HttpDiscoveryTransport', () => {
     });
 
     const snapshot = await transport.fetchSnapshot();
-    expect(calledUrl).toBe('http://core-api:3001/trpc/core.registry.snapshot');
+    expect(calledUrl).toBe('http://core-api:3001/trpc/core.registry.list');
     expect(snapshot).toHaveLength(1);
     expect(snapshot[0]?.pillarId).toBe('finance');
   });
@@ -50,7 +50,7 @@ describe('HttpDiscoveryTransport', () => {
       fetchImpl,
     });
     await transport.fetchSnapshot();
-    expect(calledUrl).toBe('http://core-api:3001/trpc/core.registry.snapshot');
+    expect(calledUrl).toBe('http://core-api:3001/trpc/core.registry.list');
   });
 
   it('throws PillarSdkError on a non-2xx HTTP response', async () => {

--- a/packages/pillar-sdk/src/client/discovery.ts
+++ b/packages/pillar-sdk/src/client/discovery.ts
@@ -3,7 +3,7 @@ import { PillarSdkError } from './errors.js';
 import type { ManifestPayload } from '../manifest-schema/index.js';
 
 /**
- * The shape returned by `core.registry.snapshot` (PRD-161 / PRD-159).
+ * The shape returned by `core.registry.list` (PRD-161 / PRD-159).
  * One entry per registered pillar.
  */
 export type DiscoveredPillar = {
@@ -17,7 +17,7 @@ export type DiscoveredPillar = {
 
 /**
  * The transport the client uses to fetch the registry snapshot. The
- * default HTTP impl talks to `core.registry.snapshot`; tests inject a
+ * default HTTP impl talks to `core.registry.list`; tests inject a
  * fake. Decoupling the transport keeps the client unit-testable without
  * a live registry and lets future deployments swap to an SSE / file /
  * in-process variant without touching `pillar()`.
@@ -38,11 +38,11 @@ const DEFAULT_REGISTRY_URL = 'http://core-api:3001';
 const DEFAULT_FETCH_TIMEOUT_MS = 5_000;
 
 /**
- * Default HTTP transport. Calls `core.registry.snapshot` over the tRPC
+ * Default HTTP transport. Calls `core.registry.list` over the tRPC
  * GET wire format and reshapes the response into `DiscoveredPillar[]`.
  *
  * tRPC's HTTP GET shape:
- *   GET /trpc/core.registry.snapshot
+ *   GET /trpc/core.registry.list
  *   → { result: { data: { pillars: [...], fetchedAt: ... } } }
  */
 export class HttpDiscoveryTransport implements DiscoveryTransport {
@@ -59,7 +59,7 @@ export class HttpDiscoveryTransport implements DiscoveryTransport {
   }
 
   async fetchSnapshot(): Promise<readonly DiscoveredPillar[]> {
-    const url = `${this.registryUrl.replace(/\/$/, '')}/trpc/core.registry.snapshot`;
+    const url = `${this.registryUrl.replace(/\/$/, '')}/trpc/core.registry.list`;
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), this.timeoutMs);
 

--- a/packages/pillar-sdk/src/client/discovery.ts
+++ b/packages/pillar-sdk/src/client/discovery.ts
@@ -112,9 +112,22 @@ function parseRegistryEntry(entry: unknown, index: number): DiscoveredPillar {
     baseUrl: requireString(entry, 'baseUrl', index),
     status: requireStatus(entry['status'], index),
     manifest: requireManifest(entry['manifest'], index),
-    lastSeenAt: requireString(entry, 'lastSeenAt', index),
+    lastSeenAt: requireLastSeenAt(entry, index),
     registered: requireRegistered(entry['registered'], index),
   };
+}
+
+/**
+ * Core-api emits `lastHeartbeatAt`; older / mocked surfaces emit
+ * `lastSeenAt`. Accept either and normalise to `lastSeenAt` so callers
+ * keep a single field name.
+ */
+function requireLastSeenAt(entry: Record<string, unknown>, index: number): string {
+  const seen = entry['lastSeenAt'];
+  if (typeof seen === 'string' && seen.length > 0) return seen;
+  const heartbeat = entry['lastHeartbeatAt'];
+  if (typeof heartbeat === 'string' && heartbeat.length > 0) return heartbeat;
+  throw new PillarSdkError(`registry snapshot entry ${index} missing lastSeenAt / lastHeartbeatAt`);
 }
 
 function requireString(entry: Record<string, unknown>, key: string, index: number): string {

--- a/packages/pillar-sdk/src/discovery/__tests__/fetcher.test.ts
+++ b/packages/pillar-sdk/src/discovery/__tests__/fetcher.test.ts
@@ -15,7 +15,7 @@ describe('fetchRegistrySnapshot', () => {
     });
 
     expect(fetchImpl).toHaveBeenCalledWith(
-      'http://core-api:3001/trpc/core.registry.snapshot',
+      'http://core-api:3001/trpc/core.registry.list',
       expect.objectContaining({ method: 'GET' })
     );
     expect(result.pillars).toHaveLength(2);
@@ -54,7 +54,7 @@ describe('fetchRegistrySnapshot', () => {
       fetchImpl,
     });
     expect(fetchImpl).toHaveBeenCalledWith(
-      'http://core-api:3001/trpc/core.registry.snapshot',
+      'http://core-api:3001/trpc/core.registry.list',
       expect.anything()
     );
   });

--- a/packages/pillar-sdk/src/discovery/__tests__/fixtures.ts
+++ b/packages/pillar-sdk/src/discovery/__tests__/fixtures.ts
@@ -36,7 +36,7 @@ export function fetchResult(...pillars: PillarSnapshot[]): RegistryFetchResult {
 
 /**
  * Build the registry-side wire payload as PRD-161 emits it from
- * `core.registry.snapshot`. Tests that exercise the HTTP fetcher use
+ * `core.registry.list`. Tests that exercise the HTTP fetcher use
  * this to round-trip the schema.
  */
 export function wirePayload(...pillars: PillarSnapshot[]): unknown {

--- a/packages/pillar-sdk/src/discovery/fetcher.ts
+++ b/packages/pillar-sdk/src/discovery/fetcher.ts
@@ -20,7 +20,7 @@ export type RegistryFetchResult = {
 export const DEFAULT_FETCH_TIMEOUT_MS = 5_000;
 
 /**
- * One-shot fetch of `core.registry.snapshot` (PRD-161).
+ * One-shot fetch of `core.registry.list` (PRD-161).
  *
  * - 5s timeout via `AbortController` (configurable, but 5s is the default
  *   the PRD-159 contract calls out).
@@ -37,7 +37,7 @@ export async function fetchRegistrySnapshot(options: FetcherOptions): Promise<Re
   const timeoutMs = options.timeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS;
   const now = options.now ?? Date.now;
 
-  const url = buildSnapshotUrl(options.registryUrl);
+  const url = buildRegistryListUrl(options.registryUrl);
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(new Error('discovery fetch timeout')), timeoutMs);
 
@@ -65,8 +65,8 @@ export async function fetchRegistrySnapshot(options: FetcherOptions): Promise<Re
   };
 }
 
-function buildSnapshotUrl(registryUrl: string): string {
-  return `${registryUrl.replace(/\/$/, '')}/trpc/core.registry.snapshot`;
+function buildRegistryListUrl(registryUrl: string): string {
+  return `${registryUrl.replace(/\/$/, '')}/trpc/core.registry.list`;
 }
 
 async function readJson(response: Response): Promise<unknown> {

--- a/packages/pillar-sdk/src/discovery/snapshot-schema.ts
+++ b/packages/pillar-sdk/src/discovery/snapshot-schema.ts
@@ -21,7 +21,7 @@ const RegistrySnapshotPayloadSchema = z
   .loose();
 
 /**
- * Validates the JSON body returned by `core.registry.snapshot` (PRD-161).
+ * Validates the JSON body returned by `core.registry.list` (PRD-161).
  *
  * Accepts both the bare payload shape and the tRPC-wrapped
  * `{ result: { data: ... } }` envelope so the fetcher can talk to either

--- a/packages/pillar-sdk/src/discovery/snapshot-schema.ts
+++ b/packages/pillar-sdk/src/discovery/snapshot-schema.ts
@@ -7,11 +7,20 @@ const PillarRegistryEntrySchema = z
     pillarId: z.string().min(1),
     baseUrl: z.string().min(1),
     manifest: ManifestPayloadSchema,
-    lastSeenAt: z.string().min(1),
+    lastSeenAt: z.string().min(1).optional(),
+    lastHeartbeatAt: z.string().min(1).optional(),
     registered: z.boolean().optional(),
     status: z.enum(['healthy', 'unavailable', 'unknown']).optional(),
   })
-  .loose();
+  .loose()
+  .refine((entry) => Boolean(entry.lastSeenAt ?? entry.lastHeartbeatAt), {
+    message: 'registry entry must include lastSeenAt or lastHeartbeatAt',
+    path: ['lastSeenAt'],
+  })
+  .transform((entry) => {
+    const resolved = entry.lastSeenAt ?? entry.lastHeartbeatAt ?? '';
+    return { ...entry, lastSeenAt: resolved };
+  });
 
 const RegistrySnapshotPayloadSchema = z
   .object({


### PR DESCRIPTION
## Summary

Fixes **PRD-227 precondition #1** (SDK ↔ registry name mismatch). The discovery SDK called `core.registry.snapshot` over the tRPC HTTP wire, but `pops-core-api` exposes the procedure as `core.registry.list`. Any FE/MCP canary that asked the SDK to boot or refresh against the live registry got a 404 on the snapshot URL.

- Rename the SDK side to `core.registry.list` across `HttpDiscoveryTransport`, `fetchRegistrySnapshot`, their unit tests, and the surrounding JSDoc.
- Add `apps/pops-core-api/src/__tests__/registry-sdk-interop.test.ts` — boots `createCoreApiApp` on an ephemeral port, points `HttpDiscoveryTransport` at it via a tracing `fetchImpl`, and asserts the URL hits `/trpc/core.registry.list` with a 200 tRPC envelope. The test catches `fetchSnapshot()` rejections so it pins the procedure-name contract in isolation, independent of the unrelated parser-shape mismatch noted below.

## Preconditions #2 and #3 — still need design decisions

- **#2 Browser cannot reach registry baseUrls.** `PillarRegistryEntry.baseUrl` stores the container-network origin (e.g. `http://finance-api:3004`). The browser cannot resolve those hostnames. Two viable shapes:
  - (a) Registry stores the container origin internally but `core.registry.list` projects browser-reachable URLs (`https://<host>/trpc-<id>`) before serving.
  - (b) SDK transport rewrites the registry-provided `baseUrl` based on a runtime base origin.
  Picking between them affects PRD-187 (`splitLink`) and the nginx dispatcher map; needs an owner call before code lands.

- **#3 URL shape doubles `/trpc/`.** SDK builds `${baseUrl}/trpc/${pillarId}.${path}`; nginx maps `/trpc-<id>/X` → `/trpc/X`. After applying #2, the SDK's per-pillar URL construction either has to drop the leading `/trpc/` (if registry projects `/trpc-<id>` URLs) or the nginx rewrite drops in scope. Same decision tree as #2; the two should land together.

## Adjacent wire-shape mismatch (not blocking #1, but worth flagging)

`apps/pops-core-api/src/modules/registry/types.ts → RegistryEntrySchema` returns `lastHeartbeatAt`/`statusUpdatedAt`/`registeredAt`. The SDK's `parseRegistryEntry` (and `PillarRegistryEntrySchema` in `packages/pillar-sdk/src/discovery/snapshot-schema.ts`) require `lastSeenAt`. After this PR the SDK reaches the registry but `transport.fetchSnapshot()` still throws on the missing `lastSeenAt` field. Pick one name and align — either rename the SDK parser to `lastHeartbeatAt`, or add a `lastSeenAt` alias to the registry output schema.

## Test plan

- [x] `pnpm --filter @pops/pillar-sdk test` — 390 tests pass (URL assertions updated)
- [x] `pnpm --filter @pops/core-api test` — 67 tests pass (new interop test included)
- [x] `pnpm --filter @pops/core-api typecheck`
- [x] `pnpm --filter @pops/pillar-sdk typecheck`
- [x] `pnpm lint` — no new errors (warnings on unrelated files pre-existed on main)
- [x] `pnpm format:check` on the touched files — clean
