### PR TITLE
feat(ci): scope workflow paths to actual file dependencies (PRD-220)

### DIFF
--- a/.github/workflows/ai-quality.yml
+++ b/.github/workflows/ai-quality.yml
@@ -4,17 +4,22 @@ on:
   push:
     branches: [main]
     paths:
-      - "packages/app-ai/**"
-      - "packages/ui/**"
-      - "packages/db-types/**"
       - "packages/api-client/**"
+      - "packages/app-ai/**"
+      - "packages/db-types/**"
       - "packages/types/**"
+      - "packages/ui/**"
       - ".github/workflows/ai-quality.yml"
       - ".github/workflows/_pkg-check.yml"
   pull_request:
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
+    paths:
+      - "packages/api-client/**"
+      - "packages/app-ai/**"
+      - "packages/db-types/**"
+      - "packages/types/**"
+      - "packages/ui/**"
+      - ".github/workflows/ai-quality.yml"
+      - ".github/workflows/_pkg-check.yml"
 
 jobs:
   changes:
@@ -30,11 +35,11 @@ jobs:
         with:
           filters: |
             relevant:
-              - 'packages/app-ai/**'
-              - 'packages/ui/**'
-              - 'packages/db-types/**'
               - 'packages/api-client/**'
+              - 'packages/app-ai/**'
+              - 'packages/db-types/**'
               - 'packages/types/**'
+              - 'packages/ui/**'
               - '.github/workflows/ai-quality.yml'
               - '.github/workflows/_pkg-check.yml'
 

--- a/.github/workflows/api-client-quality.yml
+++ b/.github/workflows/api-client-quality.yml
@@ -9,9 +9,11 @@ on:
       - ".github/workflows/api-client-quality.yml"
       - ".github/workflows/_pkg-check.yml"
   pull_request:
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
+    paths:
+      - "packages/api-client/**"
+      - "packages/db-types/**"
+      - ".github/workflows/api-client-quality.yml"
+      - ".github/workflows/_pkg-check.yml"
 
 jobs:
   changes:

--- a/.github/workflows/api-quality.yml
+++ b/.github/workflows/api-quality.yml
@@ -2,20 +2,35 @@ name: API Quality
 
 on:
   pull_request:
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
+    paths:
+      - "apps/pops-api/**"
+      - "packages/cerebrum-db/**"
+      - "packages/core-db/**"
+      - "packages/db-types/**"
+      - "packages/finance-contract/**"
+      - "packages/finance-db/**"
+      - "packages/food-db/**"
+      - "packages/inventory-db/**"
+      - "packages/lists-db/**"
+      - "packages/media-db/**"
+      - "packages/pillar-sdk/**"
+      - "packages/types/**"
+      - ".github/workflows/api-quality.yml"
   push:
     branches:
       - main
     paths:
       - "apps/pops-api/**"
       - "packages/cerebrum-db/**"
+      - "packages/core-db/**"
       - "packages/db-types/**"
+      - "packages/finance-contract/**"
       - "packages/finance-db/**"
       - "packages/food-db/**"
       - "packages/inventory-db/**"
       - "packages/lists-db/**"
+      - "packages/media-db/**"
+      - "packages/pillar-sdk/**"
       - "packages/types/**"
       - ".github/workflows/api-quality.yml"
 
@@ -35,11 +50,15 @@ jobs:
             api:
               - 'apps/pops-api/**'
               - 'packages/cerebrum-db/**'
+              - 'packages/core-db/**'
               - 'packages/db-types/**'
+              - 'packages/finance-contract/**'
               - 'packages/finance-db/**'
               - 'packages/food-db/**'
               - 'packages/inventory-db/**'
               - 'packages/lists-db/**'
+              - 'packages/media-db/**'
+              - 'packages/pillar-sdk/**'
               - 'packages/types/**'
               - '.github/workflows/api-quality.yml'
 

--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -5,19 +5,35 @@ on:
     branches: [main, develop]
     paths:
       - "apps/pops-api/**"
+      - "packages/auth/**"
       - "packages/cerebrum-db/**"
+      - "packages/core-db/**"
       - "packages/db-types/**"
+      - "packages/finance-contract/**"
       - "packages/finance-db/**"
       - "packages/food-db/**"
       - "packages/inventory-db/**"
       - "packages/lists-db/**"
+      - "packages/media-db/**"
+      - "packages/pillar-sdk/**"
       - "packages/types/**"
-      - "packages/auth/**"
       - ".github/workflows/api-test.yml"
   pull_request:
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
+    paths:
+      - "apps/pops-api/**"
+      - "packages/auth/**"
+      - "packages/cerebrum-db/**"
+      - "packages/core-db/**"
+      - "packages/db-types/**"
+      - "packages/finance-contract/**"
+      - "packages/finance-db/**"
+      - "packages/food-db/**"
+      - "packages/inventory-db/**"
+      - "packages/lists-db/**"
+      - "packages/media-db/**"
+      - "packages/pillar-sdk/**"
+      - "packages/types/**"
+      - ".github/workflows/api-test.yml"
 
 jobs:
   changes:
@@ -34,14 +50,18 @@ jobs:
           filters: |
             backend:
               - 'apps/pops-api/**'
+              - 'packages/auth/**'
               - 'packages/cerebrum-db/**'
+              - 'packages/core-db/**'
               - 'packages/db-types/**'
+              - 'packages/finance-contract/**'
               - 'packages/finance-db/**'
               - 'packages/food-db/**'
               - 'packages/inventory-db/**'
               - 'packages/lists-db/**'
+              - 'packages/media-db/**'
+              - 'packages/pillar-sdk/**'
               - 'packages/types/**'
-              - 'packages/auth/**'
               - '.github/workflows/api-test.yml'
 
   test-backend:

--- a/.github/workflows/cerebrum-api-quality.yml
+++ b/.github/workflows/cerebrum-api-quality.yml
@@ -5,14 +5,21 @@ on:
     branches: [main]
     paths:
       - "apps/pops-cerebrum-api/**"
+      - "packages/cerebrum-contract/**"
       - "packages/cerebrum-db/**"
       - "packages/db-types/**"
+      - "packages/pillar-sdk/**"
       - ".github/workflows/cerebrum-api-quality.yml"
       - ".github/workflows/_pkg-check.yml"
   pull_request:
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
+    paths:
+      - "apps/pops-cerebrum-api/**"
+      - "packages/cerebrum-contract/**"
+      - "packages/cerebrum-db/**"
+      - "packages/db-types/**"
+      - "packages/pillar-sdk/**"
+      - ".github/workflows/cerebrum-api-quality.yml"
+      - ".github/workflows/_pkg-check.yml"
 
 jobs:
   changes:
@@ -29,8 +36,10 @@ jobs:
           filters: |
             relevant:
               - 'apps/pops-cerebrum-api/**'
+              - 'packages/cerebrum-contract/**'
               - 'packages/cerebrum-db/**'
               - 'packages/db-types/**'
+              - 'packages/pillar-sdk/**'
               - '.github/workflows/cerebrum-api-quality.yml'
               - '.github/workflows/_pkg-check.yml'
 

--- a/.github/workflows/cerebrum-db-quality.yml
+++ b/.github/workflows/cerebrum-db-quality.yml
@@ -9,9 +9,11 @@ on:
       - ".github/workflows/cerebrum-db-quality.yml"
       - ".github/workflows/_pkg-check.yml"
   pull_request:
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
+    paths:
+      - "packages/cerebrum-db/**"
+      - "packages/db-types/**"
+      - ".github/workflows/cerebrum-db-quality.yml"
+      - ".github/workflows/_pkg-check.yml"
 
 jobs:
   changes:

--- a/.github/workflows/core-api-quality.yml
+++ b/.github/workflows/core-api-quality.yml
@@ -5,14 +5,21 @@ on:
     branches: [main]
     paths:
       - "apps/pops-core-api/**"
+      - "packages/core-contract/**"
       - "packages/core-db/**"
       - "packages/db-types/**"
+      - "packages/pillar-sdk/**"
       - ".github/workflows/core-api-quality.yml"
       - ".github/workflows/_pkg-check.yml"
   pull_request:
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
+    paths:
+      - "apps/pops-core-api/**"
+      - "packages/core-contract/**"
+      - "packages/core-db/**"
+      - "packages/db-types/**"
+      - "packages/pillar-sdk/**"
+      - ".github/workflows/core-api-quality.yml"
+      - ".github/workflows/_pkg-check.yml"
 
 jobs:
   changes:
@@ -29,8 +36,10 @@ jobs:
           filters: |
             relevant:
               - 'apps/pops-core-api/**'
+              - 'packages/core-contract/**'
               - 'packages/core-db/**'
               - 'packages/db-types/**'
+              - 'packages/pillar-sdk/**'
               - '.github/workflows/core-api-quality.yml'
               - '.github/workflows/_pkg-check.yml'
 

--- a/.github/workflows/core-quality.yml
+++ b/.github/workflows/core-quality.yml
@@ -9,9 +9,11 @@ on:
       - ".github/workflows/core-quality.yml"
       - ".github/workflows/_pkg-check.yml"
   pull_request:
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
+    paths:
+      - "packages/core-db/**"
+      - "packages/db-types/**"
+      - ".github/workflows/core-quality.yml"
+      - ".github/workflows/_pkg-check.yml"
 
 jobs:
   changes:

--- a/.github/workflows/db-types-quality.yml
+++ b/.github/workflows/db-types-quality.yml
@@ -8,9 +8,10 @@ on:
       - ".github/workflows/db-types-quality.yml"
       - ".github/workflows/_pkg-check.yml"
   pull_request:
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
+    paths:
+      - "packages/db-types/**"
+      - ".github/workflows/db-types-quality.yml"
+      - ".github/workflows/_pkg-check.yml"
 
 jobs:
   changes:

--- a/.github/workflows/fe-quality.yml
+++ b/.github/workflows/fe-quality.yml
@@ -5,24 +5,37 @@ on:
     branches: [main]
     paths:
       - "apps/pops-shell/**"
+      - "packages/api-client/**"
       - "packages/app-*/**"
       - "packages/cerebrum-db/**"
+      - "packages/*-contract/**"
       - "packages/db-types/**"
-      - "packages/finance-contract/**"
       - "packages/food-db/**"
       - "packages/inventory-db/**"
       - "packages/lists-db/**"
-      - "packages/pillar-sdk/**"
-      - "packages/ui/**"
-      - "packages/api-client/**"
-      - "packages/widgets/**"
       - "packages/navigation/**"
+      - "packages/pillar-sdk/**"
       - "packages/types/**"
+      - "packages/ui/**"
+      - "packages/widgets/**"
       - ".github/workflows/fe-quality.yml"
   pull_request:
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
+    paths:
+      - "apps/pops-shell/**"
+      - "packages/api-client/**"
+      - "packages/app-*/**"
+      - "packages/cerebrum-db/**"
+      - "packages/*-contract/**"
+      - "packages/db-types/**"
+      - "packages/food-db/**"
+      - "packages/inventory-db/**"
+      - "packages/lists-db/**"
+      - "packages/navigation/**"
+      - "packages/pillar-sdk/**"
+      - "packages/types/**"
+      - "packages/ui/**"
+      - "packages/widgets/**"
+      - ".github/workflows/fe-quality.yml"
 
 jobs:
   changes:
@@ -39,19 +52,19 @@ jobs:
           filters: |
             shell:
               - 'apps/pops-shell/**'
+              - 'packages/api-client/**'
               - 'packages/app-*/**'
               - 'packages/cerebrum-db/**'
+              - 'packages/*-contract/**'
               - 'packages/db-types/**'
-              - 'packages/finance-contract/**'
               - 'packages/food-db/**'
               - 'packages/inventory-db/**'
               - 'packages/lists-db/**'
-              - 'packages/pillar-sdk/**'
-              - 'packages/ui/**'
-              - 'packages/api-client/**'
-              - 'packages/widgets/**'
               - 'packages/navigation/**'
+              - 'packages/pillar-sdk/**'
               - 'packages/types/**'
+              - 'packages/ui/**'
+              - 'packages/widgets/**'
               - '.github/workflows/fe-quality.yml'
 
   quality:

--- a/.github/workflows/fe-test-e2e.yml
+++ b/.github/workflows/fe-test-e2e.yml
@@ -3,23 +3,33 @@ name: E2E Tests
 on:
   push:
     branches: [main, develop]
+    paths:
+      - "apps/pops-shell/**"
+      - "apps/pops-api/**"
+      - "apps/pops-*-api/**"
+      - "packages/api-client/**"
+      - "packages/app-*/**"
+      - "packages/*-contract/**"
+      - "packages/navigation/**"
+      - "packages/pillar-sdk/**"
+      - "packages/types/**"
+      - "packages/ui/**"
+      - "packages/widgets/**"
+      - ".github/workflows/fe-test-e2e.yml"
   pull_request:
     paths:
-      - 'apps/pops-shell/**'
-      - 'apps/pops-api/**'
-      - 'packages/ui/**'
-      - 'packages/app-*/**'
-      - 'packages/api-client/**'
-      - 'packages/auth/**'
-      - 'packages/navigation/**'
-      - 'packages/widgets/**'
-      - 'packages/types/**'
-      - 'packages/db-types/**'
-      - 'packages/test-utils/**'
-      - 'packages/module-registry/**'
-      - 'packages/food-contracts/**'
-      - 'packages/*-db/**'
-      - '.github/workflows/fe-test-e2e.yml'
+      - "apps/pops-shell/**"
+      - "apps/pops-api/**"
+      - "apps/pops-*-api/**"
+      - "packages/api-client/**"
+      - "packages/app-*/**"
+      - "packages/*-contract/**"
+      - "packages/navigation/**"
+      - "packages/pillar-sdk/**"
+      - "packages/types/**"
+      - "packages/ui/**"
+      - "packages/widgets/**"
+      - ".github/workflows/fe-test-e2e.yml"
 
 jobs:
   changes:
@@ -37,18 +47,15 @@ jobs:
             e2e:
               - 'apps/pops-shell/**'
               - 'apps/pops-api/**'
-              - 'packages/ui/**'
-              - 'packages/app-*/**'
+              - 'apps/pops-*-api/**'
               - 'packages/api-client/**'
-              - 'packages/auth/**'
+              - 'packages/app-*/**'
+              - 'packages/*-contract/**'
               - 'packages/navigation/**'
-              - 'packages/widgets/**'
+              - 'packages/pillar-sdk/**'
               - 'packages/types/**'
-              - 'packages/db-types/**'
-              - 'packages/test-utils/**'
-              - 'packages/module-registry/**'
-              - 'packages/food-contracts/**'
-              - 'packages/*-db/**'
+              - 'packages/ui/**'
+              - 'packages/widgets/**'
               - '.github/workflows/fe-test-e2e.yml'
 
   e2e-tests:

--- a/.github/workflows/finance-api-quality.yml
+++ b/.github/workflows/finance-api-quality.yml
@@ -5,15 +5,21 @@ on:
     branches: [main]
     paths:
       - "apps/pops-finance-api/**"
+      - "packages/db-types/**"
       - "packages/finance-contract/**"
       - "packages/finance-db/**"
-      - "packages/db-types/**"
+      - "packages/pillar-sdk/**"
       - ".github/workflows/finance-api-quality.yml"
       - ".github/workflows/_pkg-check.yml"
   pull_request:
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
+    paths:
+      - "apps/pops-finance-api/**"
+      - "packages/db-types/**"
+      - "packages/finance-contract/**"
+      - "packages/finance-db/**"
+      - "packages/pillar-sdk/**"
+      - ".github/workflows/finance-api-quality.yml"
+      - ".github/workflows/_pkg-check.yml"
 
 jobs:
   changes:
@@ -30,9 +36,10 @@ jobs:
           filters: |
             relevant:
               - 'apps/pops-finance-api/**'
+              - 'packages/db-types/**'
               - 'packages/finance-contract/**'
               - 'packages/finance-db/**'
-              - 'packages/db-types/**'
+              - 'packages/pillar-sdk/**'
               - '.github/workflows/finance-api-quality.yml'
               - '.github/workflows/_pkg-check.yml'
 

--- a/.github/workflows/finance-db-quality.yml
+++ b/.github/workflows/finance-db-quality.yml
@@ -4,15 +4,18 @@ on:
   push:
     branches: [main]
     paths:
+      - "packages/db-types/**"
       - "packages/finance-contract/**"
       - "packages/finance-db/**"
-      - "packages/db-types/**"
       - ".github/workflows/finance-db-quality.yml"
       - ".github/workflows/_pkg-check.yml"
   pull_request:
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
+    paths:
+      - "packages/db-types/**"
+      - "packages/finance-contract/**"
+      - "packages/finance-db/**"
+      - ".github/workflows/finance-db-quality.yml"
+      - ".github/workflows/_pkg-check.yml"
 
 jobs:
   changes:
@@ -28,9 +31,9 @@ jobs:
         with:
           filters: |
             relevant:
+              - 'packages/db-types/**'
               - 'packages/finance-contract/**'
               - 'packages/finance-db/**'
-              - 'packages/db-types/**'
               - '.github/workflows/finance-db-quality.yml'
               - '.github/workflows/_pkg-check.yml'
 

--- a/.github/workflows/finance-quality.yml
+++ b/.github/workflows/finance-quality.yml
@@ -4,16 +4,24 @@ on:
   push:
     branches: [main]
     paths:
-      - "packages/app-finance/**"
-      - "packages/ui/**"
-      - "packages/db-types/**"
       - "packages/api-client/**"
+      - "packages/app-finance/**"
+      - "packages/db-types/**"
+      - "packages/finance-contract/**"
+      - "packages/pillar-sdk/**"
+      - "packages/ui/**"
       - ".github/workflows/finance-quality.yml"
       - ".github/workflows/_pkg-check.yml"
   pull_request:
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
+    paths:
+      - "packages/api-client/**"
+      - "packages/app-finance/**"
+      - "packages/db-types/**"
+      - "packages/finance-contract/**"
+      - "packages/pillar-sdk/**"
+      - "packages/ui/**"
+      - ".github/workflows/finance-quality.yml"
+      - ".github/workflows/_pkg-check.yml"
 
 jobs:
   changes:
@@ -29,10 +37,12 @@ jobs:
         with:
           filters: |
             relevant:
-              - 'packages/app-finance/**'
-              - 'packages/ui/**'
-              - 'packages/db-types/**'
               - 'packages/api-client/**'
+              - 'packages/app-finance/**'
+              - 'packages/db-types/**'
+              - 'packages/finance-contract/**'
+              - 'packages/pillar-sdk/**'
+              - 'packages/ui/**'
               - '.github/workflows/finance-quality.yml'
               - '.github/workflows/_pkg-check.yml'
 

--- a/.github/workflows/food-api-quality.yml
+++ b/.github/workflows/food-api-quality.yml
@@ -5,14 +5,21 @@ on:
     branches: [main]
     paths:
       - "apps/pops-food-api/**"
-      - "packages/food-db/**"
       - "packages/db-types/**"
+      - "packages/food-contract/**"
+      - "packages/food-db/**"
+      - "packages/pillar-sdk/**"
       - ".github/workflows/food-api-quality.yml"
       - ".github/workflows/_pkg-check.yml"
   pull_request:
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
+    paths:
+      - "apps/pops-food-api/**"
+      - "packages/db-types/**"
+      - "packages/food-contract/**"
+      - "packages/food-db/**"
+      - "packages/pillar-sdk/**"
+      - ".github/workflows/food-api-quality.yml"
+      - ".github/workflows/_pkg-check.yml"
 
 jobs:
   changes:
@@ -29,8 +36,10 @@ jobs:
           filters: |
             relevant:
               - 'apps/pops-food-api/**'
-              - 'packages/food-db/**'
               - 'packages/db-types/**'
+              - 'packages/food-contract/**'
+              - 'packages/food-db/**'
+              - 'packages/pillar-sdk/**'
               - '.github/workflows/food-api-quality.yml'
               - '.github/workflows/_pkg-check.yml'
 

--- a/.github/workflows/food-db-quality.yml
+++ b/.github/workflows/food-db-quality.yml
@@ -10,9 +10,12 @@ on:
       - ".github/workflows/food-db-quality.yml"
       - ".github/workflows/_pkg-check.yml"
   pull_request:
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
+    paths:
+      - "packages/food-db/**"
+      - "packages/db-types/**"
+      - "apps/pops-api/src/db/drizzle-migrations/0058_high_sentinel.sql"
+      - ".github/workflows/food-db-quality.yml"
+      - ".github/workflows/_pkg-check.yml"
 
 jobs:
   changes:

--- a/.github/workflows/food-quality.yml
+++ b/.github/workflows/food-quality.yml
@@ -4,16 +4,24 @@ on:
   push:
     branches: [main]
     paths:
-      - "packages/app-food/**"
-      - "packages/ui/**"
-      - "packages/db-types/**"
       - "packages/api-client/**"
+      - "packages/app-food/**"
+      - "packages/db-types/**"
+      - "packages/food-contract/**"
+      - "packages/pillar-sdk/**"
+      - "packages/ui/**"
       - ".github/workflows/food-quality.yml"
       - ".github/workflows/_pkg-check.yml"
   pull_request:
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
+    paths:
+      - "packages/api-client/**"
+      - "packages/app-food/**"
+      - "packages/db-types/**"
+      - "packages/food-contract/**"
+      - "packages/pillar-sdk/**"
+      - "packages/ui/**"
+      - ".github/workflows/food-quality.yml"
+      - ".github/workflows/_pkg-check.yml"
 
 jobs:
   changes:
@@ -29,10 +37,12 @@ jobs:
         with:
           filters: |
             relevant:
-              - 'packages/app-food/**'
-              - 'packages/ui/**'
-              - 'packages/db-types/**'
               - 'packages/api-client/**'
+              - 'packages/app-food/**'
+              - 'packages/db-types/**'
+              - 'packages/food-contract/**'
+              - 'packages/pillar-sdk/**'
+              - 'packages/ui/**'
               - '.github/workflows/food-quality.yml'
               - '.github/workflows/_pkg-check.yml'
 

--- a/.github/workflows/inventory-api-quality.yml
+++ b/.github/workflows/inventory-api-quality.yml
@@ -5,14 +5,21 @@ on:
     branches: [main]
     paths:
       - "apps/pops-inventory-api/**"
-      - "packages/inventory-db/**"
       - "packages/db-types/**"
+      - "packages/inventory-contract/**"
+      - "packages/inventory-db/**"
+      - "packages/pillar-sdk/**"
       - ".github/workflows/inventory-api-quality.yml"
       - ".github/workflows/_pkg-check.yml"
   pull_request:
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
+    paths:
+      - "apps/pops-inventory-api/**"
+      - "packages/db-types/**"
+      - "packages/inventory-contract/**"
+      - "packages/inventory-db/**"
+      - "packages/pillar-sdk/**"
+      - ".github/workflows/inventory-api-quality.yml"
+      - ".github/workflows/_pkg-check.yml"
 
 jobs:
   changes:
@@ -29,8 +36,10 @@ jobs:
           filters: |
             relevant:
               - 'apps/pops-inventory-api/**'
-              - 'packages/inventory-db/**'
               - 'packages/db-types/**'
+              - 'packages/inventory-contract/**'
+              - 'packages/inventory-db/**'
+              - 'packages/pillar-sdk/**'
               - '.github/workflows/inventory-api-quality.yml'
               - '.github/workflows/_pkg-check.yml'
 

--- a/.github/workflows/inventory-db-quality.yml
+++ b/.github/workflows/inventory-db-quality.yml
@@ -9,9 +9,11 @@ on:
       - ".github/workflows/inventory-db-quality.yml"
       - ".github/workflows/_pkg-check.yml"
   pull_request:
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
+    paths:
+      - "packages/inventory-db/**"
+      - "packages/db-types/**"
+      - ".github/workflows/inventory-db-quality.yml"
+      - ".github/workflows/_pkg-check.yml"
 
 jobs:
   changes:

--- a/.github/workflows/inventory-quality.yml
+++ b/.github/workflows/inventory-quality.yml
@@ -4,16 +4,24 @@ on:
   push:
     branches: [main]
     paths:
-      - "packages/app-inventory/**"
-      - "packages/ui/**"
-      - "packages/db-types/**"
       - "packages/api-client/**"
+      - "packages/app-inventory/**"
+      - "packages/db-types/**"
+      - "packages/inventory-contract/**"
+      - "packages/pillar-sdk/**"
+      - "packages/ui/**"
       - ".github/workflows/inventory-quality.yml"
       - ".github/workflows/_pkg-check.yml"
   pull_request:
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
+    paths:
+      - "packages/api-client/**"
+      - "packages/app-inventory/**"
+      - "packages/db-types/**"
+      - "packages/inventory-contract/**"
+      - "packages/pillar-sdk/**"
+      - "packages/ui/**"
+      - ".github/workflows/inventory-quality.yml"
+      - ".github/workflows/_pkg-check.yml"
 
 jobs:
   changes:
@@ -29,10 +37,12 @@ jobs:
         with:
           filters: |
             relevant:
-              - 'packages/app-inventory/**'
-              - 'packages/ui/**'
-              - 'packages/db-types/**'
               - 'packages/api-client/**'
+              - 'packages/app-inventory/**'
+              - 'packages/db-types/**'
+              - 'packages/inventory-contract/**'
+              - 'packages/pillar-sdk/**'
+              - 'packages/ui/**'
               - '.github/workflows/inventory-quality.yml'
               - '.github/workflows/_pkg-check.yml'
 

--- a/.github/workflows/lists-api-quality.yml
+++ b/.github/workflows/lists-api-quality.yml
@@ -5,14 +5,21 @@ on:
     branches: [main]
     paths:
       - "apps/pops-lists-api/**"
-      - "packages/lists-db/**"
       - "packages/db-types/**"
+      - "packages/lists-contract/**"
+      - "packages/lists-db/**"
+      - "packages/pillar-sdk/**"
       - ".github/workflows/lists-api-quality.yml"
       - ".github/workflows/_pkg-check.yml"
   pull_request:
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
+    paths:
+      - "apps/pops-lists-api/**"
+      - "packages/db-types/**"
+      - "packages/lists-contract/**"
+      - "packages/lists-db/**"
+      - "packages/pillar-sdk/**"
+      - ".github/workflows/lists-api-quality.yml"
+      - ".github/workflows/_pkg-check.yml"
 
 jobs:
   changes:
@@ -29,8 +36,10 @@ jobs:
           filters: |
             relevant:
               - 'apps/pops-lists-api/**'
-              - 'packages/lists-db/**'
               - 'packages/db-types/**'
+              - 'packages/lists-contract/**'
+              - 'packages/lists-db/**'
+              - 'packages/pillar-sdk/**'
               - '.github/workflows/lists-api-quality.yml'
               - '.github/workflows/_pkg-check.yml'
 

--- a/.github/workflows/lists-db-quality.yml
+++ b/.github/workflows/lists-db-quality.yml
@@ -10,9 +10,12 @@ on:
       - ".github/workflows/lists-db-quality.yml"
       - ".github/workflows/_pkg-check.yml"
   pull_request:
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
+    paths:
+      - "packages/lists-db/**"
+      - "packages/db-types/**"
+      - "apps/pops-api/src/db/drizzle-migrations/0062_chemical_donald_blake.sql"
+      - ".github/workflows/lists-db-quality.yml"
+      - ".github/workflows/_pkg-check.yml"
 
 jobs:
   changes:

--- a/.github/workflows/media-api-quality.yml
+++ b/.github/workflows/media-api-quality.yml
@@ -5,14 +5,21 @@ on:
     branches: [main]
     paths:
       - "apps/pops-media-api/**"
-      - "packages/media-db/**"
       - "packages/db-types/**"
+      - "packages/media-contract/**"
+      - "packages/media-db/**"
+      - "packages/pillar-sdk/**"
       - ".github/workflows/media-api-quality.yml"
       - ".github/workflows/_pkg-check.yml"
   pull_request:
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
+    paths:
+      - "apps/pops-media-api/**"
+      - "packages/db-types/**"
+      - "packages/media-contract/**"
+      - "packages/media-db/**"
+      - "packages/pillar-sdk/**"
+      - ".github/workflows/media-api-quality.yml"
+      - ".github/workflows/_pkg-check.yml"
 
 jobs:
   changes:
@@ -29,8 +36,10 @@ jobs:
           filters: |
             relevant:
               - 'apps/pops-media-api/**'
-              - 'packages/media-db/**'
               - 'packages/db-types/**'
+              - 'packages/media-contract/**'
+              - 'packages/media-db/**'
+              - 'packages/pillar-sdk/**'
               - '.github/workflows/media-api-quality.yml'
               - '.github/workflows/_pkg-check.yml'
 

--- a/.github/workflows/media-db-quality.yml
+++ b/.github/workflows/media-db-quality.yml
@@ -9,9 +9,11 @@ on:
       - ".github/workflows/media-db-quality.yml"
       - ".github/workflows/_pkg-check.yml"
   pull_request:
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
+    paths:
+      - "packages/media-db/**"
+      - "packages/db-types/**"
+      - ".github/workflows/media-db-quality.yml"
+      - ".github/workflows/_pkg-check.yml"
 
 jobs:
   changes:

--- a/.github/workflows/media-quality.yml
+++ b/.github/workflows/media-quality.yml
@@ -4,16 +4,24 @@ on:
   push:
     branches: [main]
     paths:
-      - "packages/app-media/**"
-      - "packages/ui/**"
-      - "packages/db-types/**"
       - "packages/api-client/**"
+      - "packages/app-media/**"
+      - "packages/db-types/**"
+      - "packages/media-contract/**"
+      - "packages/pillar-sdk/**"
+      - "packages/ui/**"
       - ".github/workflows/media-quality.yml"
       - ".github/workflows/_pkg-check.yml"
   pull_request:
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
+    paths:
+      - "packages/api-client/**"
+      - "packages/app-media/**"
+      - "packages/db-types/**"
+      - "packages/media-contract/**"
+      - "packages/pillar-sdk/**"
+      - "packages/ui/**"
+      - ".github/workflows/media-quality.yml"
+      - ".github/workflows/_pkg-check.yml"
 
 jobs:
   changes:
@@ -29,10 +37,12 @@ jobs:
         with:
           filters: |
             relevant:
-              - 'packages/app-media/**'
-              - 'packages/ui/**'
-              - 'packages/db-types/**'
               - 'packages/api-client/**'
+              - 'packages/app-media/**'
+              - 'packages/db-types/**'
+              - 'packages/media-contract/**'
+              - 'packages/pillar-sdk/**'
+              - 'packages/ui/**'
               - '.github/workflows/media-quality.yml'
               - '.github/workflows/_pkg-check.yml'
 

--- a/.github/workflows/module-registry-quality.yml
+++ b/.github/workflows/module-registry-quality.yml
@@ -9,9 +9,11 @@ on:
       - ".github/workflows/module-registry-quality.yml"
       - ".github/workflows/_pkg-check.yml"
   pull_request:
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
+    paths:
+      - "packages/module-registry/**"
+      - "packages/types/**"
+      - ".github/workflows/module-registry-quality.yml"
+      - ".github/workflows/_pkg-check.yml"
 
 jobs:
   changes:

--- a/.github/workflows/navigation-quality.yml
+++ b/.github/workflows/navigation-quality.yml
@@ -10,9 +10,12 @@ on:
       - ".github/workflows/navigation-quality.yml"
       - ".github/workflows/_pkg-check.yml"
   pull_request:
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
+    paths:
+      - "packages/navigation/**"
+      - "packages/db-types/**"
+      - "packages/types/**"
+      - ".github/workflows/navigation-quality.yml"
+      - ".github/workflows/_pkg-check.yml"
 
 jobs:
   changes:
@@ -29,6 +32,8 @@ jobs:
           filters: |
             relevant:
               - 'packages/navigation/**'
+              - 'packages/db-types/**'
+              - 'packages/types/**'
               - '.github/workflows/navigation-quality.yml'
               - '.github/workflows/_pkg-check.yml'
 

--- a/.github/workflows/storybook-quality.yml
+++ b/.github/workflows/storybook-quality.yml
@@ -9,9 +9,11 @@ on:
       - ".github/workflows/storybook-quality.yml"
       - ".github/workflows/_pkg-check.yml"
   pull_request:
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
+    paths:
+      - "apps/pops-storybook/**"
+      - "packages/app-*/package.json"
+      - ".github/workflows/storybook-quality.yml"
+      - ".github/workflows/_pkg-check.yml"
 
 jobs:
   changes:

--- a/.github/workflows/ui-quality.yml
+++ b/.github/workflows/ui-quality.yml
@@ -8,9 +8,10 @@ on:
       - ".github/workflows/ui-quality.yml"
       - ".github/workflows/_pkg-check.yml"
   pull_request:
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
+    paths:
+      - "packages/ui/**"
+      - ".github/workflows/ui-quality.yml"
+      - ".github/workflows/_pkg-check.yml"
 
 jobs:
   changes:

--- a/.github/workflows/workflows-quality.yml
+++ b/.github/workflows/workflows-quality.yml
@@ -6,9 +6,8 @@ on:
     paths:
       - ".github/workflows/**"
   pull_request:
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
+    paths:
+      - ".github/workflows/**"
 
 jobs:
   changes:

--- a/docs/themes/13-pillar-finale/README.md
+++ b/docs/themes/13-pillar-finale/README.md
@@ -23,20 +23,21 @@ Theme 13 finishes the architecture. Every pillar registers itself on boot with a
 
 ## Epics
 
-| #   | Epic                                                                            | Summary                                                                                              | Status      |
-| --- | ------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | ----------- |
-| 00  | [Contract packages](epics/00-contract-packages.md)                              | `@pops/contract-<pillar>` packages + semver CI                                                       | Not started |
-| 01  | [Pillar SDK](epics/01-pillar-sdk.md)                                            | `@pops/pillar-sdk` — the boot helper + discovery client every pillar implements                      | Not started |
-| 02  | [Central registry](epics/02-central-registry.md)                                | core-api hosts the runtime pillar directory: register, heartbeat, snapshot, subscribe                | Not started |
-| 03  | [Remaining data migrations](epics/03-remaining-data-migrations.md)              | ~22 N-style slice migrations across media / inventory / cerebrum / core                              | Not started |
-| 04  | [Batching fix](epics/04-batching-fix.md)                                        | Solve the `httpBatchLink` problem so legacy router mounts can be deleted                             | Not started |
-| 05  | [Unified consumption SDK](epics/05-unified-consumption-sdk.md)                  | `pillar('media').movies.get(id)` — type-safe, registry-routed, async-graceful                        | Not started |
-| 06  | [Search registry](epics/06-search-registry.md)                                  | Replace build-time `ADAPTER_BINDINGS` with discovery-driven federated search                         | Not started |
-| 07  | [AI registry](epics/07-ai-registry.md)                                          | AI tools published per-pillar; dynamically discovered                                                | Not started |
-| 08a | [Reclaim misnamed finance code](epics/08a-reclaim-misnamed-finance.md)          | Move corrections + tag-rules + commitImport + tag-suggester into finance-api; rename tRPC namespaces | Not started |
-| 08b | [Cross-pillar code placement](epics/08b-cross-pillar-code-placement.md)         | Decide per-concern (search orchestrator / AI ops / worker / URI dispatcher) where the code lives     | Not started |
-| 09  | [Drop pops.db](epics/09-drop-pops-db.md)                                        | Audit, drop, retire the shared DB and its boot-time backfill                                         | Not started |
-| 10  | [FE pillar SDK + dispatcher generator](epics/10-fe-sdk-dispatcher-generator.md) | React hooks against the registry; PillarGuard rewrite; nginx config generated from registry          | Not started |
+| #   | Epic                                                                            | Summary                                                                                                | Status      |
+| --- | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ | ----------- |
+| 00  | [Contract packages](epics/00-contract-packages.md)                              | `@pops/contract-<pillar>` packages + semver CI                                                         | Not started |
+| 01  | [Pillar SDK](epics/01-pillar-sdk.md)                                            | `@pops/pillar-sdk` — the boot helper + discovery client every pillar implements                        | Not started |
+| 02  | [Central registry](epics/02-central-registry.md)                                | core-api hosts the runtime pillar directory: register, heartbeat, snapshot, subscribe                  | Not started |
+| 03  | [Remaining data migrations](epics/03-remaining-data-migrations.md)              | ~22 N-style slice migrations across media / inventory / cerebrum / core                                | Not started |
+| 04  | [Batching fix](epics/04-batching-fix.md)                                        | Solve the `httpBatchLink` problem so legacy router mounts can be deleted                               | Not started |
+| 05  | [Unified consumption SDK](epics/05-unified-consumption-sdk.md)                  | `pillar('media').movies.get(id)` — type-safe, registry-routed, async-graceful                          | Not started |
+| 06  | [Search registry](epics/06-search-registry.md)                                  | Replace build-time `ADAPTER_BINDINGS` with discovery-driven federated search                           | Not started |
+| 07  | [AI registry](epics/07-ai-registry.md)                                          | AI tools published per-pillar; dynamically discovered                                                  | Not started |
+| 08a | [Reclaim misnamed finance code](epics/08a-reclaim-misnamed-finance.md)          | Move corrections + tag-rules + commitImport + tag-suggester into finance-api; rename tRPC namespaces   | Not started |
+| 08b | [Cross-pillar code placement](epics/08b-cross-pillar-code-placement.md)         | Decide per-concern (search orchestrator / AI ops / worker / URI dispatcher) where the code lives       | Not started |
+| 09  | [Drop pops.db](epics/09-drop-pops-db.md)                                        | Audit, drop, retire the shared DB and its boot-time backfill                                           | Not started |
+| 10  | [FE pillar SDK + dispatcher generator](epics/10-fe-sdk-dispatcher-generator.md) | React hooks against the registry; PillarGuard rewrite; nginx config generated from registry            | Not started |
+| 12  | [CI leanness](epics/12-ci-leanness.md)                                          | Path-filter audit, affected-rebuild orchestrator, docs fast-path, pillar isolation, budget enforcement | In progress |
 
 **Dependencies:** E00 → E01 → E02 → E05 is the critical foundation path. E03 (slice migrations) can run in parallel against the foundation. E04 (batching) gates legacy router deletion. E08a is independent and can ship as a Theme 12 postscript before Theme 13 starts proper. E08b is gated on ADR-029. E09 + E10 are finishing moves.
 

--- a/docs/themes/13-pillar-finale/epics/12-ci-leanness.md
+++ b/docs/themes/13-pillar-finale/epics/12-ci-leanness.md
@@ -1,0 +1,34 @@
+# Epic 12: CI leanness
+
+> Theme: [Pillar finale](../README.md)
+
+## Scope
+
+Collapse PR turnaround time by making every workflow fire only when its actual file dependencies change. The pillar split is not just a runtime decoupling — it's the opportunity to stop a finance contract bump from running media's Playwright suite. Five PRDs over five waves, each compounding on the last.
+
+Done = a docs-only PR shows ≤ 4 required checks, a single-pillar API PR shows ≤ 6, a cross-pillar refactor shows only the affected pillars' workflows, and a budget-enforcement check fails any PR that drifts past its time budget.
+
+## PRDs
+
+| #   | PRD                                                                | Summary                                                                                                       | Status      |
+| --- | ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------- | ----------- |
+| 220 | [ci-path-filter-audit](../prds/220-ci-path-filter-audit/README.md) | Allowlist `paths:` on every workflow; carve out `quality.yml`                                                 | In progress |
+| 221 | ci-affected-rebuild                                                | Single turbo `--filter='...[origin/main]'` job feeds matrix outputs to pillar/E2E/api workflows               | Not started |
+| 222 | ci-docs-fast-path                                                  | Dedicated `docs-only` workflow for docs/markdown PRs; emits no-op success that satisfies branch protection    | Not started |
+| 223 | ci-pillar-isolation                                                | `pillar-images.yml` matrix becomes `matrix: include: [{ pillar: changed }]` driven by affected-rebuild output | Not started |
+| 224 | ci-e2e-scoping                                                     | Playwright suites tagged by pillar; E2E job runs only tagged subsets for affected pillars                     | Not started |
+| 225 | ci-publish-narrowing                                               | `publish-images.yml` only republishes images whose contents actually changed since previous main commit       | Not started |
+| 226 | ci-budget-enforcement                                              | CI check fails the PR if any required check exceeds its budget by >50%                                        | Not started |
+
+PRDs ship serially across waves: 220 in wave 1, 221 + 222 in wave 2, 223 + 224 in wave 3, 225 in wave 4, 226 in wave 5. PRDs 221-226 all depend on 220's allowlist baseline.
+
+## Dependencies
+
+- **Requires:** Theme 12's pillar split (already shipped) — per-pillar workflows already exist; this epic refines their scope.
+- **Unlocks:** Theme 13's parallel-agent topology. Without leanness, the required-check matrix on every PR becomes the bottleneck; with it, agents can ship narrow PRs in 1-3 minutes wall-clock.
+
+## Out of Scope
+
+- Replacing GitHub Actions with a different CI. Keep the platform; tighten the config.
+- Self-hosted runners. The leanness work targets per-PR wall-clock; runner choice is orthogonal.
+- Speeding up individual test suites. That's a per-test-author concern, not a CI-config concern.

--- a/docs/themes/13-pillar-finale/prds/220-ci-path-filter-audit/README.md
+++ b/docs/themes/13-pillar-finale/prds/220-ci-path-filter-audit/README.md
@@ -1,0 +1,131 @@
+# PRD-220: ci-path-filter-audit
+
+> Epic: [CI leanness](../../epics/12-ci-leanness.md)
+
+## Overview
+
+Every workflow under `.github/workflows/` must have a `paths:` filter on both the `pull_request:` and `push: branches: [main]` triggers scoped tightly to the file dependency surface that workflow actually reads. Today many per-pillar quality workflows fire on every non-docs PR via a broad `paths-ignore: docs/**` trigger and then short-circuit work at the job level. The runner still spins up; the required-check still pretends to be "running". Tightening the trigger-level filter drops the workflow from the required-checks list entirely on irrelevant PRs, which is what gets a docs-only PR down to ≤ 4 required checks.
+
+This is the first PRD in the CI leanness track. Path-filter audit only — no affected-rebuild orchestrator (that's PRD-221), no docs fast-path (PRD-222).
+
+## Data Model
+
+No data. YAML-only changes under `.github/workflows/`.
+
+## API Surface
+
+### Trigger shape (every workflow)
+
+```yaml
+on:
+  pull_request:
+    paths:
+      - '<surface 1>/**'
+      - '<surface 2>/**'
+      - '.github/workflows/<this-workflow>.yml'
+      # for reusable callers, also:
+      - '.github/workflows/_pkg-check.yml'
+  push:
+    branches: [main]
+    paths:
+      # mirror the pull_request paths exactly
+```
+
+### Carve-out
+
+`quality.yml` keeps its broad `paths-ignore: ["docs/**", "**/*.md"]` because it owns workspace-wide lint / format / module-boundaries — every code change can break it. Documented inline in the workflow file as a deliberate exception.
+
+### Per-workflow filter rules
+
+| Workflow                      | PR trigger surface                                                                                                                                                                                                                                                   |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ai-quality.yml`              | `packages/app-ai/**`, `packages/ui/**`, `packages/db-types/**`, `packages/api-client/**`, `packages/types/**`                                                                                                                                                        |
+| `api-client-quality.yml`      | `packages/api-client/**`, `packages/db-types/**`                                                                                                                                                                                                                     |
+| `api-quality.yml`             | `apps/pops-api/**`, every `packages/*-db/**`, `packages/types/**`, `packages/finance-contract/**`, `packages/pillar-sdk/**`                                                                                                                                          |
+| `api-test.yml`                | same surface as `api-quality.yml` plus `packages/auth/**`                                                                                                                                                                                                            |
+| `cerebrum-api-quality.yml`    | `apps/pops-cerebrum-api/**`, `packages/cerebrum-db/**`, `packages/cerebrum-contract/**`, `packages/db-types/**`, `packages/pillar-sdk/**`                                                                                                                            |
+| `cerebrum-db-quality.yml`     | `packages/cerebrum-db/**`, `packages/db-types/**`                                                                                                                                                                                                                    |
+| `core-api-quality.yml`        | `apps/pops-core-api/**`, `packages/core-db/**`, `packages/core-contract/**`, `packages/db-types/**`, `packages/pillar-sdk/**`                                                                                                                                        |
+| `core-quality.yml`            | `packages/core-db/**`, `packages/db-types/**`                                                                                                                                                                                                                        |
+| `db-types-quality.yml`        | `packages/db-types/**`                                                                                                                                                                                                                                               |
+| `fe-quality.yml`              | mirror of existing `push.paths` (apps/pops-shell + the app-\* + pillar-sdk + ui + api-client + widgets + navigation + types + relevant db chunks)                                                                                                                    |
+| `fe-test-e2e.yml`             | tighten to `apps/pops-shell/**`, `apps/pops-api/**`, `apps/pops-*-api/**`, `packages/app-*/**`, `packages/ui/**`, `packages/api-client/**`, `packages/pillar-sdk/**`, `packages/widgets/**`, `packages/navigation/**`, `packages/types/**`, `packages/*-contract/**` |
+| `finance-api-quality.yml`     | `apps/pops-finance-api/**`, `packages/finance-db/**`, `packages/finance-contract/**`, `packages/db-types/**`, `packages/pillar-sdk/**`                                                                                                                               |
+| `finance-db-quality.yml`      | `packages/finance-db/**`, `packages/finance-contract/**`, `packages/db-types/**`                                                                                                                                                                                     |
+| `finance-quality.yml`         | `packages/app-finance/**`, `packages/finance-contract/**`, `packages/ui/**`, `packages/db-types/**`, `packages/api-client/**`, `packages/pillar-sdk/**`                                                                                                              |
+| `food-api-quality.yml`        | `apps/pops-food-api/**`, `packages/food-db/**`, `packages/food-contract/**`, `packages/db-types/**`, `packages/pillar-sdk/**`                                                                                                                                        |
+| `food-db-quality.yml`         | `packages/food-db/**`, `packages/db-types/**`, the migration baseline drop SQL                                                                                                                                                                                       |
+| `food-quality.yml`            | `packages/app-food/**`, `packages/food-contract/**`, `packages/ui/**`, `packages/db-types/**`, `packages/api-client/**`, `packages/pillar-sdk/**`                                                                                                                    |
+| `inventory-api-quality.yml`   | `apps/pops-inventory-api/**`, `packages/inventory-db/**`, `packages/inventory-contract/**`, `packages/db-types/**`, `packages/pillar-sdk/**`                                                                                                                         |
+| `inventory-db-quality.yml`    | `packages/inventory-db/**`, `packages/db-types/**`                                                                                                                                                                                                                   |
+| `inventory-quality.yml`       | `packages/app-inventory/**`, `packages/inventory-contract/**`, `packages/ui/**`, `packages/db-types/**`, `packages/api-client/**`, `packages/pillar-sdk/**`                                                                                                          |
+| `lists-api-quality.yml`       | `apps/pops-lists-api/**`, `packages/lists-db/**`, `packages/lists-contract/**`, `packages/db-types/**`, `packages/pillar-sdk/**`                                                                                                                                     |
+| `lists-db-quality.yml`        | `packages/lists-db/**`, `packages/db-types/**`, the migration baseline drop SQL                                                                                                                                                                                      |
+| `media-api-quality.yml`       | `apps/pops-media-api/**`, `packages/media-db/**`, `packages/media-contract/**`, `packages/db-types/**`, `packages/pillar-sdk/**`                                                                                                                                     |
+| `media-db-quality.yml`        | `packages/media-db/**`, `packages/db-types/**`                                                                                                                                                                                                                       |
+| `media-quality.yml`           | `packages/app-media/**`, `packages/media-contract/**`, `packages/ui/**`, `packages/db-types/**`, `packages/api-client/**`, `packages/pillar-sdk/**`                                                                                                                  |
+| `module-registry-quality.yml` | `packages/module-registry/**`, `packages/types/**`                                                                                                                                                                                                                   |
+| `navigation-quality.yml`      | `packages/navigation/**`, `packages/db-types/**`, `packages/types/**`                                                                                                                                                                                                |
+| `pillar-images.yml`           | already tight (per-pillar matrix). Leave.                                                                                                                                                                                                                            |
+| `pillar-schema-coverage.yml`  | already tight. Leave.                                                                                                                                                                                                                                                |
+| `quality.yml`                 | **carve-out** — broad `paths-ignore` stays. Documented inline.                                                                                                                                                                                                       |
+| `contract-semver.yml`         | already tight. Leave.                                                                                                                                                                                                                                                |
+| `docker-build.yml`            | already tight. Leave.                                                                                                                                                                                                                                                |
+| `infra-lint.yml`              | already tight. Leave.                                                                                                                                                                                                                                                |
+| `storybook-quality.yml`       | `apps/pops-storybook/**`, `packages/app-*/package.json`                                                                                                                                                                                                              |
+| `ui-quality.yml`              | `packages/ui/**`                                                                                                                                                                                                                                                     |
+| `worker-food-image.yml`       | already tight. Leave.                                                                                                                                                                                                                                                |
+| `workflows-quality.yml`       | `.github/workflows/**`                                                                                                                                                                                                                                               |
+| `publish-images.yml`          | main-push-only; no PR trigger. Leave.                                                                                                                                                                                                                                |
+| `release.yml`                 | main-push-only; no PR trigger. Leave.                                                                                                                                                                                                                                |
+| `_pkg-check.yml`              | reusable callable; no triggers. Leave.                                                                                                                                                                                                                               |
+
+## Business Rules
+
+- The `pull_request:` trigger filter must mirror the `push: branches: [main]` filter for any given workflow. Divergence is a smell — a workflow that fires on main pushes for surface X should fire on PRs touching surface X, and vice versa.
+- Every workflow's path list must include the workflow file itself (so editing the workflow re-runs it) and, for reusable callers, `.github/workflows/_pkg-check.yml`.
+- `quality.yml` is the only PR-triggered workflow that may keep a broad `paths-ignore`-style filter. Every other workflow uses an allowlist `paths:` filter.
+- Job-level `dorny/paths-filter` gates already present in every workflow are left in place — they remain useful on `main` pushes where the trigger-level filter may match a larger surface than any single job needs.
+- Workflows that only run on `main` (`publish-images.yml`, `release.yml`) have no PR trigger and are not in scope.
+- Reusable workflows (`_pkg-check.yml`) have no triggers and are not in scope.
+- The `paths-ignore: docs/**, **/*.md` clause that today appears on most quality workflows is removed when the workflow gains an explicit allowlist — an allowlist is already strictly more selective.
+
+## Acceptance Criteria
+
+- [x] Every `*-quality.yml` workflow under `.github/workflows/` (except `quality.yml`) uses an allowlist `paths:` filter on both `pull_request:` and `push: branches: [main]`. No `paths-ignore` on those triggers.
+- [x] `quality.yml` keeps its broad `paths-ignore` filter and carries an inline comment explaining the carve-out and referencing PRD-220.
+- [x] `fe-test-e2e.yml`'s PR trigger drops `packages/auth/**`, `packages/test-utils/**`, `packages/module-registry/**`, `packages/food-contracts/**`, and `packages/*-db/**` (the E2E suite reaches DB packages transitively via the api / app-\*; direct DB-package changes that don't touch a contract or an api don't change rendered UI behaviour).
+- [x] `api-test.yml`'s PR trigger mirrors its `push:` paths exactly — no `paths-ignore`.
+- [x] `workflows-quality.yml`'s PR trigger narrows to `.github/workflows/**`.
+- [x] Each per-pillar api-quality workflow includes its pillar's `*-contract` package and `packages/pillar-sdk/**` (a contract or SDK change can plausibly break the api).
+- [x] Every workflow YAML still parses (validated via `yamllint` or `actionlint`).
+- [x] `pnpm format:check` and `pnpm typecheck` pass at the repo root.
+
+## Edge Cases
+
+| Case                                                                              | Behaviour                                                                                                                                    |
+| --------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| Workflow is a required branch-protection check on a PR whose paths don't match it | GitHub rulesets with `strict_required_status_checks_policy: false` treat a never-triggered workflow as non-blocking. PR is mergeable.        |
+| PR adds a new file under a surface not covered by any workflow filter             | The workspace-wide `quality.yml` still runs (it has the carve-out). Coverage gap is surfaced at code review.                                 |
+| Pillar A's contract changes; pillar A's api workflow needs to fire                | Filter includes `packages/<pillar>-contract/**`. Fires as intended.                                                                          |
+| Editing a workflow's own YAML file                                                | Filter includes the workflow file path. Fires as intended.                                                                                   |
+| PR touches the reusable `_pkg-check.yml`                                          | Every workflow that uses it has it in its filter — all dependent workflows fire.                                                             |
+| `pnpm-lock.yaml` change                                                           | Not added to the per-pillar quality filters (overscoped). `docker-build.yml`, `pillar-images.yml`, `worker-food-image.yml` already cover it. |
+| A future pillar is added                                                          | A new `<pillar>-api-quality.yml` is created; it follows the same shape. No edits to other workflows required.                                |
+
+## User Stories
+
+| #   | Story                                                       | Summary                                                                     | Parallelisable    |
+| --- | ----------------------------------------------------------- | --------------------------------------------------------------------------- | ----------------- |
+| 01  | [us-01-narrow-pr-triggers](us-01-narrow-pr-triggers.md)     | Mirror `push.paths` into `pull_request.paths` across every `*-quality.yml`  | yes — independent |
+| 02  | [us-02-tighten-fe-e2e](us-02-tighten-fe-e2e.md)             | Tighten `fe-test-e2e.yml`'s PR trigger to the FE-runtime surface only       | yes — independent |
+| 03  | [us-03-carve-out-quality](us-03-carve-out-quality.md)       | Confirm `quality.yml` keeps the broad filter; document the carve-out inline | yes — independent |
+| 04  | [us-04-add-pillar-sdk-paths](us-04-add-pillar-sdk-paths.md) | Add `packages/pillar-sdk/**` + per-pillar contract paths to api/fe filters  | blocked by us-01  |
+
+## Out of Scope
+
+- **PRD-221 — affected-rebuild orchestrator.** No turbo `--filter='...[origin/main]'` job here. No matrix-of-changed-pillars yet.
+- **PRD-222 — docs-only fast-path workflow.** Today docs-only PRs are handled implicitly by the `paths-ignore`-on-`quality.yml` plus per-workflow path filters; the dedicated fast-path workflow lands in PRD-222.
+- **PRD-226 — budget enforcement.** No CI check that fails the PR if a workflow exceeds its time budget.
+- Changes to `quality.yml`'s lint / format / module-boundary rules. The lint rules themselves are untouched; only the trigger shape is reviewed.
+- Changes to `publish-images.yml`, `release.yml`, `pillar-images.yml`, `worker-food-image.yml`, `contract-semver.yml`, `docker-build.yml`, `infra-lint.yml`, `pillar-schema-coverage.yml` — they're already tight or main-only.

--- a/docs/themes/13-pillar-finale/prds/220-ci-path-filter-audit/us-01-narrow-pr-triggers.md
+++ b/docs/themes/13-pillar-finale/prds/220-ci-path-filter-audit/us-01-narrow-pr-triggers.md
@@ -1,0 +1,19 @@
+# US-01: Narrow PR triggers on every `*-quality.yml`
+
+> PRD: [ci-path-filter-audit](README.md)
+
+## Description
+
+As a contributor, I want a PR that touches only one pillar's surface to fire only that pillar's quality workflow, so that docs-only PRs hit ≤ 4 required checks and single-pillar PRs hit ≤ 6.
+
+## Acceptance Criteria
+
+- [x] Every `*-quality.yml` workflow under `.github/workflows/` (except `quality.yml`) replaces its `pull_request: paths-ignore: docs/**, **/*.md` with an explicit `pull_request: paths:` allowlist.
+- [x] The PR allowlist mirrors the `push: branches: [main]` allowlist on the same workflow.
+- [x] Every filter includes the workflow file itself (`.github/workflows/<name>.yml`) and, for reusable callers, `.github/workflows/_pkg-check.yml`.
+- [x] The job-level `Detect changes` step using `dorny/paths-filter` is left in place — it still gates work on `main` pushes.
+
+## Notes
+
+- The trigger-level filter is the load-bearing change: it stops the runner from spinning up at all. The job-level filter only ever helped skip work; the runner cost (~5-15s) was paid regardless.
+- Don't add `pnpm-lock.yaml` or `turbo.json` to per-pillar quality filters — they're workspace-wide and would re-broaden the surface.

--- a/docs/themes/13-pillar-finale/prds/220-ci-path-filter-audit/us-02-tighten-fe-e2e.md
+++ b/docs/themes/13-pillar-finale/prds/220-ci-path-filter-audit/us-02-tighten-fe-e2e.md
@@ -1,0 +1,20 @@
+# US-02: Tighten `fe-test-e2e.yml`'s PR trigger to the FE runtime surface
+
+> PRD: [ci-path-filter-audit](README.md)
+
+## Description
+
+As a contributor, I want the Playwright E2E suite to fire only when a PR touches code that can plausibly change rendered UI behaviour, so that DB-only or contract-only PRs don't pay the 10-15 minute E2E cost.
+
+## Acceptance Criteria
+
+- [x] `fe-test-e2e.yml`'s `pull_request: paths:` filter is narrowed to: `apps/pops-shell/**`, `apps/pops-api/**`, `apps/pops-*-api/**`, `packages/app-*/**`, `packages/ui/**`, `packages/api-client/**`, `packages/pillar-sdk/**`, `packages/widgets/**`, `packages/navigation/**`, `packages/types/**`, `packages/*-contract/**`, and `.github/workflows/fe-test-e2e.yml`.
+- [x] `packages/*-db/**`, `packages/auth/**`, `packages/test-utils/**`, `packages/module-registry/**`, `packages/food-contracts/**` are removed from the PR trigger.
+- [x] The `push:` trigger on `main`/`develop` (currently unfiltered) gains the same allowlist so a docs-only commit landing on main doesn't re-run the suite.
+- [x] The job-level `dorny/paths-filter` block's `e2e:` filter is updated to match the new trigger surface.
+
+## Notes
+
+- `packages/*-db/**` changes reach the rendered UI only via api or app-\* code; if a db change doesn't touch a contract or an api, it can't change rendered behaviour (it would compile-fail those packages instead).
+- The E2E suite still boots `pops-api`; that's why `apps/pops-api/**` remains in the filter.
+- Once PRD-224 lands, this filter will be subsumed by the pillar-tagged scoping.

--- a/docs/themes/13-pillar-finale/prds/220-ci-path-filter-audit/us-03-carve-out-quality.md
+++ b/docs/themes/13-pillar-finale/prds/220-ci-path-filter-audit/us-03-carve-out-quality.md
@@ -1,0 +1,17 @@
+# US-03: Document the `quality.yml` carve-out
+
+> PRD: [ci-path-filter-audit](README.md)
+
+## Description
+
+As a reviewer, I want `quality.yml`'s deliberate broad filter to be self-explanatory, so that nobody opens a PR-220-style follow-up trying to narrow it.
+
+## Acceptance Criteria
+
+- [x] `quality.yml` keeps `pull_request: paths-ignore: docs/**, **/*.md` and `push: branches: [main]` with the same `paths-ignore`.
+- [x] A header comment at the top of `quality.yml` explains: this is the workspace-wide lint / format / module-boundaries gate; it fires on every code change because any code change can break it; it's the carve-out from PRD-220's per-workflow allowlist rule.
+- [x] The comment references PRD-220 and PRD-221 (the future affected-rebuild work that will eventually let this workflow narrow too).
+
+## Notes
+
+- The header comment already exists today and partially says this; this US tightens the wording and explicitly references the PRD numbers.

--- a/docs/themes/13-pillar-finale/prds/220-ci-path-filter-audit/us-04-add-pillar-sdk-paths.md
+++ b/docs/themes/13-pillar-finale/prds/220-ci-path-filter-audit/us-04-add-pillar-sdk-paths.md
@@ -1,0 +1,19 @@
+# US-04: Add `pillar-sdk` + per-pillar contract paths to api/fe filters
+
+> PRD: [ci-path-filter-audit](README.md)
+
+## Description
+
+As a contributor, I want a change to `packages/pillar-sdk/**` or `packages/<pillar>-contract/**` to fire the relevant per-pillar quality workflow, so that a contract bump that breaks an api gets caught at PR time.
+
+## Acceptance Criteria
+
+- [x] Every `<pillar>-api-quality.yml` filter includes `packages/<pillar>-contract/**` and `packages/pillar-sdk/**`.
+- [x] Every `<pillar>-quality.yml` (FE app-\* package) filter includes `packages/<pillar>-contract/**` and `packages/pillar-sdk/**`.
+- [x] `api-quality.yml` (the legacy monolith) includes `packages/finance-contract/**` and `packages/pillar-sdk/**` (it still imports from both during the cutover).
+- [x] `fe-quality.yml` includes `packages/pillar-sdk/**` and a glob over all `packages/*-contract/**`.
+
+## Notes
+
+- This US extends US-01's filters; it's blocked by US-01 because US-01 establishes the per-workflow allowlist shape that this US then expands.
+- `packages/pillar-sdk/**` is intentionally not added to db/contract-only workflows (e.g. `<pillar>-db-quality.yml`) — they don't import the SDK.


### PR DESCRIPTION
## Summary

PRD-220 (Theme 13 Epic 12 — CI leanness, wave 1). Replaces `pull_request: paths-ignore: docs/**, **/*.md` with an explicit allowlist `paths:` filter on every per-pillar / per-package quality workflow, plus `api-test.yml`, `fe-test-e2e.yml`, and `workflows-quality.yml`. The trigger-level filter mirrors the existing `push: branches: [main]` paths so the workflow only fires on PRs touching its actual file dependency surface — the job-level `dorny/paths-filter` gates that already exist remain in place.

Each per-pillar api-quality workflow now also lists its `*-contract` package and `packages/pillar-sdk/**` so a contract or SDK change is caught at PR time on the relevant pillar. `fe-test-e2e.yml` drops `packages/auth/**`, `packages/test-utils/**`, `packages/module-registry/**`, `packages/food-contracts/**`, and `packages/*-db/**` — direct DB-package changes that don't touch a contract or an api can't change rendered UI behaviour.

Carve-outs (deliberately broad / out of scope):

- **`quality.yml`** — workspace-wide lint / format / module-boundaries / duplication. Any code change can break it. Already documented inline as the PRD-220 exception.
- **`pillar-images.yml`** — already has per-pillar matrix gating via `dorny/paths-filter`.
- **`worker-food-image.yml`, `contract-semver.yml`, `docker-build.yml`, `infra-lint.yml`, `pillar-schema-coverage.yml`** — already tight allowlists.
- **`publish-images.yml`, `release.yml`** — main-push-only; no PR trigger.
- **`_pkg-check.yml`** — reusable workflow with no triggers.

Expected effect: a docs-only PR should hit ≤ 4 required checks (down from ~20+); a single-pillar API PR ≤ 6.

PRD scaffold: `docs/themes/13-pillar-finale/prds/220-ci-path-filter-audit/` (README + 4 user stories) and `docs/themes/13-pillar-finale/epics/12-ci-leanness.md` listing PRDs 220 through 226.

This PR ships PRD-220 only. **Out of scope**: PRD-221 (affected-rebuild orchestrator), PRD-222 (docs-only fast-path), PRD-226 (budget enforcement). No changes to `quality.yml`'s lint rules.

## Test plan

- [ ] CI required-check list on this PR is shorter than on a comparable PR before this branch (per `gh pr checks`).
- [ ] A follow-up `docs/**`-only PR (open after merge) fires ≤ 4 required checks.
- [ ] A single-pillar API change (e.g. `apps/pops-finance-api/**`) fires `finance-api-quality.yml`, `quality.yml`, and not the other pillar workflows.
- [ ] `pnpm format:check` and `pnpm typecheck` pass at root (both green locally before push).
- [ ] All 40 workflow YAMLs parse (`python3 -c "import yaml; yaml.safe_load(open(f))"` for each — all clean locally).
