### PR TITLE
docs(theme-13): PRD-192 server surface status update

### DIFF
--- a/docs/themes/13-pillar-finale/epics/05-unified-consumption-sdk.md
+++ b/docs/themes/13-pillar-finale/epics/05-unified-consumption-sdk.md
@@ -23,7 +23,7 @@ React hooks layer on top: `usePillarQuery(...)`, `usePillarMutation(...)` for th
 | #   | PRD                      | Summary                                                                                 | Status      |
 | --- | ------------------------ | --------------------------------------------------------------------------------------- | ----------- |
 | 191 | Client surface           | The `pillar('id').router.proc(...)` proxy + failure-mode discriminants                  | Not started |
-| 192 | Server surface           | Same SDK for sibling pillars + worker calling each other                                | Done        |
+| 192 | Server surface           | Same SDK for sibling pillars + worker calling each other                                | Partial     |
 | 193 | React hooks              | `usePillarQuery`, `usePillarMutation` with React Query integration                      | Partial     |
 | 194 | Caching + invalidation   | Registry snapshot TTL, change-subscription invalidation, per-procedure response caching | Not started |
 | 195 | Type generation pipeline | Generate the consumer-side typings from each pillar's contract                          | Not started |

--- a/docs/themes/13-pillar-finale/prds/192-server-surface/README.md
+++ b/docs/themes/13-pillar-finale/prds/192-server-surface/README.md
@@ -1,6 +1,8 @@
 # PRD-192: `pillar()` server surface
 
 > Epic: [Unified consumption SDK](../../epics/05-unified-consumption-sdk.md)
+>
+> Status: Partial — see [Acceptance Criteria](#acceptance-criteria).
 
 ## Overview
 
@@ -39,11 +41,29 @@ The proxy and HTTP semantics are identical to PRD-191. The differences:
 
 ## User Stories
 
-| #   | Story                                                   | Summary                                                           |
-| --- | ------------------------------------------------------- | ----------------------------------------------------------------- |
-| 01  | [us-01-server-config](us-01-server-config.md)           | Server-side configuration: env-driven auth + base URL handling    |
-| 02  | [us-02-connection-pooling](us-02-connection-pooling.md) | Undici-based connection pool for worker high-throughput           |
-| 03  | [us-03-tests](us-03-tests.md)                           | Server-side integration tests against in-memory pillar containers |
+| #   | Story                    | Summary                                                           | Status      |
+| --- | ------------------------ | ----------------------------------------------------------------- | ----------- |
+| 01  | us-01-server-config      | Server-side configuration: env-driven auth + base URL handling    | Done        |
+| 02  | us-02-connection-pooling | Undici-based connection pool for worker high-throughput           | Not started |
+| 03  | us-03-tests              | Server-side integration tests against in-memory pillar containers | Partial     |
+
+US-01/02/03 files were never created; status is tracked inline against shipped code in `packages/pillar-sdk/src/server/`.
+
+## Acceptance Criteria
+
+Status of the contract spelled out in API Surface / Business Rules / Edge Cases above, audited against `packages/pillar-sdk/src/server/` and its `__tests__/`.
+
+- [x] **Same `pillar()` proxy as PRD-191, re-exported from `@pops/pillar-sdk/server`** — Done. `src/server/index.ts` re-exports `pillar`, `PillarHandle`, `CallResult`, etc. from `../client`; `package.json` exposes the `./server` subpath.
+- [x] **Auth source is the `POPS_INTERNAL_API_KEY` env var** — Done. `resolveApiKey` reads `POPS_INTERNAL_API_KEY` with config override; `SERVER_SDK_API_KEY_ENV` constant exported.
+- [x] **`X-API-Key: <env>` header injected automatically on every outbound call** — Done. `factory.ts` wires `authHeaders` into the client; covered by `factory.test.ts` (`sends the service-account key as 'X-API-Key'`).
+- [x] **Service-account key resolved at call time so rotated env values are picked up** — Done. `authHeaders` calls `resolveApiKey()` per invocation; covered by `factory.test.ts` (`reads the env-supplied key at call time`).
+- [x] **Base URL resolution targets Docker internal hostnames, not nginx** — Done. Transport uses the registry-advertised `baseUrl` directly (e.g. `http://finance-api:3004`); covered by `factory.test.ts` (`does not pass through nginx`).
+- [x] **First call throws explicit error when `POPS_INTERNAL_API_KEY` is unset** — Done. `PillarServerSdkError` thrown with message mentioning both the env var and `configureServerSdk`; covered by `factory.test.ts` (`throws PillarServerSdkError when neither config nor env supplies a key`).
+- [x] **External `http://localhost:...` base URLs work in dev** — Done. `configureServerSdk({ internalBaseUrls })` plus `InternalBaseUrlTransport` rewrite per-pillar; covered by `factory.test.ts` (`routes calls to the override URL`) and `transport.test.ts`.
+- [x] **Per-pillar handle (and discovery cache) reused across `pillar()` calls in-process** — Done. `factory.ts` memoises by cache key; covered by `factory.test.ts` (`memoises the per-pillar handle so the discovery cache survives`).
+- [x] **Error-mapping parity with the client surface (`unavailable`, `contract-mismatch`, etc.)** — Done. Covered by `factory.test.ts` (`error-mapping parity with client` describe block).
+- [ ] **Optional `undici` connection pool / `configureServerSdk({ poolSize, keepalive })` for worker high-throughput** — Not started. `ServerSdkConfig` documents `fetchImpl` as the seam for a keepalive-enabled fetch, but no `undici` agent, no `poolSize`/`keepalive` knobs, and no worker pool wiring ship today. Maps to US-02.
+- [ ] **Server-side integration tests against in-memory pillar containers** — Partial. Unit-level coverage in `src/server/__tests__/` exercises auth, base-URL rewrites, handle reuse, and error mapping against fake transports / `recordingFetch`. No end-to-end test boots a real pillar container (or in-memory equivalent) and round-trips through it. Maps to US-03.
 
 ## Out of Scope
 


### PR DESCRIPTION
## Summary

Audit-only update for PRD-192 (`pillar()` server surface).

Inlines an `## Acceptance Criteria` section derived from the PRD's API Surface, Business Rules, Edge Cases, and User Stories, and marks each against the shipped `packages/pillar-sdk/src/server/` code.

## AC verdict

- **Done (9 ACs):** `@pops/pillar-sdk/server` subpath re-exports the client `pillar()` proxy, `POPS_INTERNAL_API_KEY` auth resolution (config-override + env), automatic `X-API-Key` injection, call-time key resolution for rotation, Docker-internal base-URL routing (no nginx hop), explicit `PillarServerSdkError` when the key is missing, `configureServerSdk({ internalBaseUrls })` + `InternalBaseUrlTransport` for dev localhost, per-pillar handle memoisation with discovery cache reuse, and `unavailable` / `contract-mismatch` error-mapping parity with the client. All covered in `src/server/__tests__/{config,factory,transport}.test.ts`.
- **Not started (1 AC):** optional `undici` connection pool. `ServerSdkConfig.fetchImpl` documents the seam but no agent, no `poolSize`/`keepalive` knobs, and no worker pool wiring exist. Maps to the never-written US-02.
- **Partial (1 AC):** server-side integration tests against in-memory pillar containers. Unit-level coverage via `FakeRegistryTransport` + `recordingFetch` is comprehensive; no end-to-end harness boots a real pillar (or in-memory equivalent) and round-trips through it. Maps to the never-written US-03.

PRD status moves from implied Done to **Partial**; epic 05 PRD-192 row updated to match.

## Test plan

- [ ] Render the PRD-192 README on GitHub and confirm the AC checklist renders correctly
- [ ] Confirm epic 05 PRD table shows PRD-192 as Partial