### PR TITLE
docs(theme-13): PRD-210 worker partitioning status update

### DIFF
--- a/docs/themes/13-pillar-finale/epics/08b-cross-pillar-code-placement.md
+++ b/docs/themes/13-pillar-finale/epics/08b-cross-pillar-code-placement.md
@@ -23,13 +23,13 @@ Recommendation per the theme README: separate concerns (B). `pops-search-api`, `
 
 ## PRDs
 
-| #   | PRD                            | Summary                                                                                 | Status      |
-| --- | ------------------------------ | --------------------------------------------------------------------------------------- | ----------- |
-| 207 | ADR-029 decision matrix        | The per-concern decision; this PRD captures the rationale and writes the ADR            | Not started |
-| 208 | Search orchestrator relocation | Implement whichever option ADR-029 picked for search                                    | Not started |
-| 209 | AI Ops orchestrator relocation | Same for AI                                                                             | Not started |
-| 210 | Worker partitioning audit      | Worker calls become SDK calls; remove in-process DB access; or split worker per concern | Not started |
-| 211 | URI dispatcher relocation      | Fold dispatcher into registry; pillar-specific resolvers stay co-located                | Not started |
+| #   | PRD                            | Summary                                                                                 | Status                                                                                                     |
+| --- | ------------------------------ | --------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| 207 | ADR-029 decision matrix        | The per-concern decision; this PRD captures the rationale and writes the ADR            | Not started                                                                                                |
+| 208 | Search orchestrator relocation | Implement whichever option ADR-029 picked for search                                    | Not started                                                                                                |
+| 209 | AI Ops orchestrator relocation | Same for AI                                                                             | Not started                                                                                                |
+| 210 | Worker partitioning audit      | Worker calls become SDK calls; remove in-process DB access; or split worker per concern | Partial (audit done — only `pops-worker-food` exists and is already SDK-partitioned; no migration backlog) |
+| 211 | URI dispatcher relocation      | Fold dispatcher into registry; pillar-specific resolvers stay co-located                | Not started                                                                                                |
 
 ## Dependencies
 

--- a/docs/themes/13-pillar-finale/prds/210-worker-partitioning-audit/README.md
+++ b/docs/themes/13-pillar-finale/prds/210-worker-partitioning-audit/README.md
@@ -32,11 +32,43 @@ Per-job audit. Examples:
 
 ## User Stories
 
-| #   | Story                                                       | Summary                                                |
-| --- | ----------------------------------------------------------- | ------------------------------------------------------ |
-| 01  | [us-01-audit-jobs](us-01-audit-jobs.md)                     | Catalogue every job + its DB-touch pattern             |
-| 02  | [us-02-job-by-job-migration](us-02-job-by-job-migration.md) | One PR per job: convert in-process writes to SDK calls |
-| 03  | [us-03-bulk-procedures](us-03-bulk-procedures.md)           | Author bulk procedures where needed for perf           |
+| #   | Story                      | Summary                                                | Status                                                                      |
+| --- | -------------------------- | ------------------------------------------------------ | --------------------------------------------------------------------------- |
+| 01  | us-01-audit-jobs           | Catalogue every job + its DB-touch pattern             | Done (inline, see Audit Findings)                                           |
+| 02  | us-02-job-by-job-migration | One PR per job: convert in-process writes to SDK calls | Not started (no in-process writes remain to migrate)                        |
+| 03  | us-03-bulk-procedures      | Author bulk procedures where needed for perf           | Not started (no batched job currently bottlenecked by per-record SDK calls) |
+
+Story files were never authored — US-01's deliverable is captured inline under **Audit Findings** below; US-02/03 are gated on a job actually needing migration or a bulk path.
+
+## Audit Findings
+
+Status snapshot from the worker tree as of this audit. Audit only — no code changes.
+
+### Worker inventory
+
+| Worker             | Pillar(s) touched | Queue / job kinds                                                                                                      | DB access pattern                                                                                                                                                                  | Partitioning verdict        |
+| ------------------ | ----------------- | ---------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------- |
+| `pops-worker-food` | food (only)       | `food.ingest` queue: `web-url`, `screenshot`, `text`, `instagram*`, `web-llm-*` handlers (see `src/handlers/index.ts`) | tRPC HTTP only — `client.food.ingest.workerComplete.mutate(...)` against pops-api with `x-pops-internal-token` (PRD-125). No drizzle, no `@pops/*-db` workspace imports in `src/`. | Single-pillar, SDK-correct. |
+
+`apps/pops-worker-*` glob returns exactly one directory; the PRD's `bullmq:plex-sync` (media), `bullmq:ai-categorize` (finance + core/aiUsage), and `*arr ingest` jobs referenced in the parent epic do not exist in code — no worker writes those tables today.
+
+### Cross-pillar offenders
+
+None. `pops-worker-food`'s runtime `package.json` dependencies are scoped to `@pops/food-contracts`; the only other workspace import is a `devDependencies` reference to `@pops/app-food-db` consumed in `src/__tests__/*` to reuse `parseRecipeDsl` for fixture parsing. That is a same-pillar test-only dep, not a cross-pillar runtime DB write.
+
+### Implications for ADR-029 / Epic 08b
+
+- The "convert in-process pillar-DB writes to SDK calls" workstream this PRD anticipated has nothing to convert in `pops-worker-food`. The worker was authored against the PRD-125/126 callback contract from the start.
+- Future workers (plex-sync, ai-categorize, \*arr ingest) are still hypothetical. When they are scaffolded, this PRD's per-job audit rubric still applies; until then it has no active migration backlog.
+- Bulk pillar procedures (US-03) are only justified by an observed throughput bottleneck — none today.
+
+### Re-audit triggers
+
+Reopen this PRD when any of the following lands:
+
+- A new `apps/pops-worker-*` directory.
+- A `package.json` dependency on `@pops/*-db` (any pillar) inside an existing worker's runtime (non-`devDependencies`) section.
+- A handler that imports `drizzle-orm` or a `db` client directly under `apps/pops-worker-*/src/` (excluding tests).
 
 ## Out of Scope
 


### PR DESCRIPTION
## Summary

Audit of `apps/pops-worker-*` against PRD-210's job-by-job pillar-write catalogue.

- Only `pops-worker-food` exists today. Its src/ has no `@pops/*-db` workspace imports and no direct drizzle — it writes back to `food.ingest.workerComplete` over tRPC HTTP (the PRD-125/126 callback contract), which is exactly the SDK-call pattern PRD-210 anticipated migrating toward.
- The PRD's example jobs (`bullmq:plex-sync` for media, `bullmq:ai-categorize` for finance+core, `*arr ingest`) do not exist in code; there is no in-process pillar-DB write to convert.
- Marked PRD-210 **Partial** in epic 08b: audit (US-01) is done inline; US-02 (per-job migration) and US-03 (bulk procedures) are **Not started** because they have no migration target today. Documented re-audit triggers so the PRD reopens automatically when a new worker dir, a `@pops/*-db` runtime dep, or a direct drizzle import lands.

## Test plan

- [x] `oxfmt --write` clean on both edited markdown files (ran via husky `lint-staged` pre-commit)
- [x] Husky pre-commit hook ran end-to-end (no `--no-verify`)
- [ ] Reviewer confirms `pops-worker-food` is the only `apps/pops-worker-*` dir on `main` at PR open
- [ ] Reviewer agrees the "Partial" verdict matches reality (no plex-sync / ai-categorize / *arr workers in tree)