### PR TITLE
docs(theme-13): PRD-195 type generation status update

### DIFF
--- a/docs/themes/13-pillar-finale/prds/195-type-generation-pipeline/README.md
+++ b/docs/themes/13-pillar-finale/prds/195-type-generation-pipeline/README.md
@@ -1,6 +1,8 @@
 # PRD-195: Type generation pipeline
 
 > Epic: [Unified consumption SDK](../../epics/05-unified-consumption-sdk.md)
+>
+> Status: **Not started**
 
 ## Overview
 
@@ -47,11 +49,26 @@ A type-only call that augments the SDK's `ContractFor<P>` mapping; consumers get
 
 ## User Stories
 
-| #   | Story                                                         | Summary                                 |
-| --- | ------------------------------------------------------------- | --------------------------------------- |
-| 01  | [us-01-declare-helper](us-01-declare-helper.md)               | The `declareContracts` type-only helper |
-| 02  | [us-02-app-pilot-integration](us-02-app-pilot-integration.md) | Wire it into pops-shell first           |
-| 03  | [us-03-author-docs](us-03-author-docs.md)                     | Documentation on adding a new contract  |
+| #   | Story                                                         | Summary                                 | Status      |
+| --- | ------------------------------------------------------------- | --------------------------------------- | ----------- |
+| 01  | [us-01-declare-helper](us-01-declare-helper.md)               | The `declareContracts` type-only helper | Not started |
+| 02  | [us-02-app-pilot-integration](us-02-app-pilot-integration.md) | Wire it into pops-shell first           | Not started |
+| 03  | [us-03-author-docs](us-03-author-docs.md)                     | Documentation on adding a new contract  | Not started |
+
+## Implementation Audit (2026-06-13)
+
+Audit-only sweep against `packages/*-contract`, `packages/pillar-sdk`, and consuming apps. PRD-155 (manifest type generation) is referenced as the upstream codegen dependency.
+
+| AC / Story                                       | Status      | Evidence                                                                                                                                                                                                                                                                                                                                  |
+| ------------------------------------------------ | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| US-01 — `declareContracts` type-only helper      | Not started | No `declare`/`declareContracts` symbol exists in `packages/pillar-sdk/src`. No `./declare` subpath in `packages/pillar-sdk/package.json#exports`. No `ContractFor<P>` mapping or augmentable interface found.                                                                                                                              |
+| US-02 — pops-shell pilot integration             | Not started | Repo-wide grep for `declareContracts` and `ContractFor` returns zero matches across `apps/*` and `packages/*`. `packages/pillar-sdk/src/contracts/index.ts` only re-exports `FinanceContract` types directly — there is no per-app declaration site.                                                                                       |
+| US-03 — Author docs for adding a new contract    | Not started | No documentation in `packages/pillar-sdk` describing how to register a new pillar via `declareContracts`. Existing contract READMEs cover authoring the contract itself (PRD-155 territory), not consumer-side type wiring.                                                                                                                |
+| Codegen pipeline (PRD-155 upstream dependency)   | Partial     | PRD-155's codegen (`manifest.generated.ts`, `verify:manifest`, `generate:openapi`, extractors under `scripts/contract/`) is live in `packages/finance-contract` only. Other `*-contract` packages (cerebrum, core, food, inventory, lists, media) have not yet been wired through the pipeline — PRD-195 cannot light up until they exist. |
+| OpenAPI snapshot per contract                    | Partial     | `packages/finance-contract/openapi/finance.openapi.json` plus `etc/finance-contract.api.json` / `.zod.json` snapshots are produced by `pnpm build`. No equivalent snapshots in the other contract packages.                                                                                                                                |
+| Declaration bundling into consumer-side typings  | Not started | No bundling step takes each contract's `dist/manifest.d.ts` and surfaces it as a typed `pillar('<id>')` entry. The `pillar()` client surface itself (PRD-191) is also not started, so there is nothing to type-augment.                                                                                                                    |
+
+**Verdict:** PRD-195 is **Not started**. The build-time codegen primitives it depends on (PRD-155) exist for finance only; the consumer-side `declareContracts` helper, the SDK augmentation point, and the pilot integration in pops-shell are all absent.
 
 ## Out of Scope
 


### PR DESCRIPTION
## Summary

Audit-only status update for [PRD-195 — Type generation pipeline](../tree/feat/theme13-prd-195-status-update/docs/themes/13-pillar-finale/prds/195-type-generation-pipeline/README.md). No code changes.

- Added `Status: Not started` at the PRD level
- Added a `Status` column to the user-stories table (all three: Not started)
- Added an `Implementation Audit (2026-06-13)` section with per-AC verdicts and code-level evidence (paths, missing exports, grep results)

## Findings

- `declareContracts` helper, `./declare` subpath export, and `ContractFor<P>` mapping are absent from `packages/pillar-sdk`
- No `apps/*` or `packages/*` call site references `declareContracts` or `ContractFor`
- PRD-155's upstream codegen is live for `packages/finance-contract` only; other contract packages have no `manifest.generated.ts` / OpenAPI snapshot / extractor wiring
- `pillar()` client surface (PRD-191) is also not started, so there is no augmentation target yet

## Test plan

- [ ] Docs render correctly on GitHub
- [ ] Status column matches sibling PRD conventions (PRD-155 pattern)