### PR TITLE
docs(theme-13): PRD-216 PillarGuard status update

### DIFF
--- a/docs/themes/13-pillar-finale/epics/10-fe-sdk-dispatcher-generator.md
+++ b/docs/themes/13-pillar-finale/epics/10-fe-sdk-dispatcher-generator.md
@@ -15,7 +15,7 @@ Make the front-end registry-aware end-to-end. Three pieces:
 | #   | PRD                                 | Summary                                                                                      | Status      |
 | --- | ----------------------------------- | -------------------------------------------------------------------------------------------- | ----------- |
 | 215 | React SDK                           | `usePillar`, `useUriResolver`, `usePillarQuery`, `usePillarMutation` hooks                   | Not started |
-| 216 | `PillarGuard` rewrite               | Reads live registry; subscribes to changes; per-route unavailable placeholders               | Not started |
+| 216 | `PillarGuard` rewrite               | Reads live registry; subscribes to changes; per-route unavailable placeholders               | Partial     |
 | 217 | nginx config generator              | Generated `default.conf` from registry snapshot; init container OR sidecar strategy          | Not started |
 | 218 | `@pops/module-registry` deprecation | The build-time registry becomes a thin wrapper around the runtime one (offline-dev fallback) | Not started |
 | 227 | SDK consumer migration audit        | Punch list of every `trpc.*` consumer with its `pillar()` migration target + preconditions   | Not started |

--- a/docs/themes/13-pillar-finale/prds/216-pillar-guard-rewrite/README.md
+++ b/docs/themes/13-pillar-finale/prds/216-pillar-guard-rewrite/README.md
@@ -1,6 +1,8 @@
 # PRD-216: PillarGuard rewrite
 
 > Epic: [FE pillar SDK + dispatcher generator](../../epics/10-fe-sdk-dispatcher-generator.md)
+>
+> Status: **Partial** — a shell-local `PillarGuard` + `PillarStatusProvider` + `PillarUnavailableRoute` already ship under `apps/pops-shell/src/app/pillars/` (ADR-026 P3) and cover the healthy / unavailable branches with i18n + retry. The gap is the live subscription path: there is no `usePillarRegistry` hook in `@pops/pillar-sdk/react` yet (blocked on PRD-215), so the snapshot only refreshes on a user-triggered `refresh()` rather than re-rendering on registry change events. The `'unknown'` branch deliberately falls through to children (no skeleton) as an anti-flash measure during slow boots — this diverges from the PRD's "skeleton + retry message" and needs reconciling once subscription invalidation lands.
 
 ## Overview
 
@@ -38,13 +40,30 @@ Behaviour:
 | Pillar registers mid-session                        | Guard re-renders; content appears.            |
 | Pillar flaps healthy → unavailable → healthy in <2s | One brief unavailable render; no UX disaster. |
 
+## Acceptance Criteria
+
+US files referenced below were never authored; AC live inline. Status is per criterion:
+
+- [x] `PillarGuard` accepts a pillar identifier and consults a shell-side snapshot of registry status (rather than a static module config). **Done.** _Partial deviation:_ the shipped prop name is `pillarId`, not `pillar`.
+- [x] Status `'healthy'` renders children. **Done.**
+- [x] Status `'unavailable'` renders the default placeholder. **Done.**
+- [ ] Status `'unknown'` renders a skeleton + retry message. **Dropped** — current implementation deliberately falls through to children on `'unknown'` to avoid placeholder flashes during slow boots (ADR-026 P3 rationale). Reconcile the PRD wording with the shipped behaviour, or revisit the design.
+- [ ] Reads the live registry snapshot via `usePillarRegistry`. **Not started** — shell-local provider reads a snapshot stored in shell context. `@pops/pillar-sdk/react` currently exposes query / mutation / subscription-bridge hooks but no `usePillarRegistry`. Lands with PRD-215.
+- [ ] Status changes re-render via subscription invalidation (pillar registers mid-session → guard re-renders; content appears). **Not started** — the provider only refetches on a manual `refresh()` (Retry button). Blocked on PRD-215.
+- [ ] Customisable placeholder per pillar (optional `fallback` prop on `PillarGuard`). **Not started** — `PillarGuard` accepts only `pillarId` and `children`; no `fallback` slot.
+- [x] Default unavailable placeholder exists and is reusable. **Done** — i18n-ready (`shell.pillarUnavailable*`), has a retry affordance, exported from the pillars module. _Partial deviation:_ component is named `PillarUnavailableRoute` (route-shaped) rather than `UnavailablePlaceholder`.
+- [ ] Pillar flap (healthy → unavailable → healthy in <2s) shows one brief unavailable render with no UX disaster. **Not started** — no debounce / hysteresis and no live subscription to exercise flap behaviour end-to-end.
+- [ ] Playwright e2e: pillar down → placeholder; pillar up → content. **Not started** — no e2e spec exercises the placeholder ↔ content swap on a live `/pillars/health` change. Existing coverage is RTL unit-level only.
+
 ## User Stories
 
-| #   | Story                                                   | Summary                                                    |
-| --- | ------------------------------------------------------- | ---------------------------------------------------------- |
-| 01  | [us-01-component-rewrite](us-01-component-rewrite.md)   | Update PillarGuard to use registry hook                    |
-| 02  | [us-02-fallback-component](us-02-fallback-component.md) | Default + customisable placeholder                         |
-| 03  | [us-03-e2e-test](us-03-e2e-test.md)                     | Playwright: pillar down → placeholder; pillar up → content |
+The three US files originally referenced were never authored; per the theme doc protocol, AC now live inline above. Historical scope table kept for traceability.
+
+| #   | Story                                                      | Status                              |
+| --- | ---------------------------------------------------------- | ----------------------------------- |
+| 01  | Update PillarGuard to use registry hook                    | Partial — shell-local snapshot only |
+| 02  | Default + customisable placeholder                         | Partial — default ships, no slot    |
+| 03  | Playwright: pillar down → placeholder; pillar up → content | Not started                         |
 
 ## Out of Scope
 


### PR DESCRIPTION
## Summary

- Audit-only status update for PRD-216 (`PillarGuard` rewrite). A shell-local `PillarGuard` + `PillarStatusProvider` + `PillarUnavailableRoute` already ship under `apps/pops-shell/src/app/pillars/` (ADR-026 P3): healthy renders children, unavailable renders the default i18n placeholder with a Retry button, unknown deliberately falls through to children to avoid flashing placeholders during slow boots. The boot context exposes a manual `refresh()` but no live subscription.
- Outstanding work is blocked on PRD-215 (no `usePillarRegistry` hook in `@pops/pillar-sdk/react` yet). Missing pieces: subscription-driven re-render on registry events, optional `fallback` prop on `PillarGuard`, flap hysteresis, and the Playwright e2e exercising the placeholder ↔ content swap.
- Adds inline acceptance criteria to the PRD with per-AC Done / Partial / Not-started / Dropped verdicts so the gap is auditable without chasing source files. PRD status + epic 10 PRD table both demoted from `Not started` to `Partial`. No code changes.

## Test plan

- [x] `pnpm oxfmt --check` on the two touched markdown files
- [x] Husky `lint-staged` ran on commit (no `--no-verify`)
