### PR TITLE
docs(theme-13): PRD-217 nginx generator status update

### DIFF
--- a/docs/themes/13-pillar-finale/prds/217-nginx-config-generator/README.md
+++ b/docs/themes/13-pillar-finale/prds/217-nginx-config-generator/README.md
@@ -58,3 +58,67 @@ PRD picks **image build time** initially — simpler, no runtime dep.
 - Runtime nginx reload (image-build-time only).
 - Per-host config overrides (single-host assumption).
 - TLS termination changes.
+
+## Implementation Status
+
+> Audit date: 2026-06-13. Compares the PRD against shipped code on `main`.
+> Branch under audit: `feat/theme13-prd-217-status-update`.
+
+### Shipped state
+
+- `apps/pops-shell/nginx.conf` is hand-written and committed. It carries one
+  prefix-match `location /trpc-<pillar>/` block per pillar (core, inventory,
+  media, finance, food, lists, cerebrum) plus the legacy `/trpc` catch-all,
+  the `/pillars` registry proxy, `/media/images/`, `/health`, `/docs/`, and
+  the SPA fallback. That file is the artefact PRD-190 produced.
+- `apps/pops-shell/nginx/conf.d/_pillar-proxy.conf` carries the shared
+  proxy directives every per-pillar block `include`s.
+- `apps/pops-shell/Dockerfile` `COPY`s `nginx.conf` straight into
+  `/etc/nginx/conf.d/default.conf` and the partial into
+  `/etc/nginx/snippets/_pillar-proxy.conf`. No generator step runs at image
+  build time.
+- `apps/pops-shell/scripts/validate-nginx-conf.sh` runs `nginx -t` on the
+  hand-written conf inside `nginx:alpine`. It skips when Docker is absent
+  unless `REQUIRE_DOCKER=1`.
+- No `scripts/generate-nginx-conf.ts` exists anywhere in the repo. The
+  registry-driven generator path is not started.
+
+### Acceptance Criteria
+
+The PRD uses the US pattern (four stories listed under `## User Stories`),
+but none of `us-01-generator-script.md` / `us-02-dockerfile-integration.md`
+/ `us-03-validation.md` / `us-04-tests.md` exist on disk yet — the PRD
+folder contains only `README.md`. Status is therefore audited against the
+PRD-level deliverables described in `## API Surface`, `## Business Rules`,
+and `## User Stories` directly.
+
+| Status      | Item                                                                             | Evidence / Gap                                                                                                                                                                                                                   |
+| ----------- | -------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Not started | `scripts/generate-nginx-conf.ts` reads registry snapshot → emits `default.conf`  | No file exists. No code reads `POPS_REGISTRY_URL` or a seed JSON to emit nginx config. `nginx.conf` is hand-maintained per PRD-190.                                                                                              |
+| Not started | Operating mode: image build time (generator runs inside `pops-shell` Dockerfile) | `apps/pops-shell/Dockerfile` does `COPY apps/pops-shell/nginx.conf …` directly. No `RUN tsx scripts/generate-nginx-conf.ts` step, no `BUILDKIT` mount of a registry snapshot.                                                    |
+| Not started | Deterministic output (same registry snapshot → identical conf)                   | N/A until the generator exists. Determinism property cannot be verified yet.                                                                                                                                                     |
+| Partial     | Legacy `/trpc` fallback to pops-api                                              | The fallback **does** exist in the hand-written `nginx.conf` (`location /trpc { proxy_pass http://pops-api:3000/trpc; … }`). Once the generator lands it has to preserve this block, but the shipped behaviour is already there. |
+| Not started | Generated conf not committed to git                                              | Moot — nothing is generated. `apps/pops-shell/nginx.conf` is committed and is the production source.                                                                                                                             |
+| Partial     | `nginx -t` validation in CI on the generator output                              | `apps/pops-shell/scripts/validate-nginx-conf.sh` runs `nginx -t` against the hand-written `nginx.conf` + partial. The harness is there; it just isn't wired to a generator output. It also silently skips when Docker is absent. |
+| Not started | Edge case — empty registry at build time emits only the legacy fallback          | No generator, no behaviour to test.                                                                                                                                                                                              |
+| Not started | Edge case — `nginx -t` failure during build fails image push                     | The script only skips when Docker is absent; the `REQUIRE_DOCKER=1` lever exists but is not wired into the pops-shell image-build pipeline. CI gating against the generator output is not started.                               |
+| Not started | US-01 — TS generator script reads registry, emits conf                           | File does not exist; US file `us-01-generator-script.md` also does not exist.                                                                                                                                                    |
+| Not started | US-02 — Dockerfile integration runs the generator at image-build time            | Dockerfile copies the hand-written conf directly; US file `us-02-dockerfile-integration.md` does not exist.                                                                                                                      |
+| Partial     | US-03 — `nginx -t` validation in CI                                              | Validation script exists for the hand-written conf; not yet exercising generator output. US file `us-03-validation.md` does not exist.                                                                                           |
+| Not started | US-04 — generator tests against synthetic registry snapshots                     | No generator → no tests. US file `us-04-tests.md` does not exist.                                                                                                                                                                |
+
+### Overall
+
+- **PRD-190 (dispatcher simplification) shipped first and is doing the work
+  PRD-217 was meant to remove.** The hand-written prefix-match conf is
+  small, DRY (via `_pillar-proxy.conf`), and validated by
+  `validate-nginx-conf.sh`. Adding a pillar today requires editing
+  `nginx.conf` by hand.
+- **PRD-217 has not started.** No generator script, no Dockerfile
+  generator step, no registry-snapshot input path, no US files on disk.
+- **Open question for the next planner:** with PRD-190's prefix-match
+  layout in place, the PRD-217 generator is now a small templating job
+  (loop over pillars → emit a `location /trpc-<id>/` block per the existing
+  shape). Re-scoping the PRD around the post-190 reality (instead of the
+  pre-190 regex-dispatcher world) may be worth doing before the four US
+  files get drafted.


### PR DESCRIPTION
## Summary

Audit-only status update for [PRD-217 nginx config generator](../blob/main/docs/themes/13-pillar-finale/prds/217-nginx-config-generator/README.md), comparing the PRD against the shipped state in `apps/pops-shell/`.

Adds an `## Implementation Status` section to the PRD README. The PRD describes a `scripts/generate-nginx-conf.ts` that reads the registry snapshot and emits `default.conf` at image-build time, wired through the pops-shell Dockerfile and gated by `nginx -t` in CI.

### Headline findings

- **PRD-217 is Not started.** No `scripts/generate-nginx-conf.ts` exists. `apps/pops-shell/Dockerfile` `COPY`s the hand-written `nginx.conf` straight into the image — no generator step at build time.
- **PRD-190 shipped the work PRD-217 was meant to remove.** `apps/pops-shell/nginx.conf` carries one prefix-match `location /trpc-<pillar>/` block per pillar (core, inventory, media, finance, food, lists, cerebrum), the legacy `/trpc` catch-all, plus `/pillars`, `/media/images/`, `/health`, `/docs/`, and the SPA fallback. The shared proxy directives live in `apps/pops-shell/nginx/conf.d/_pillar-proxy.conf`. Adding a pillar today is a hand edit.
- **Validation harness is Partial.** `apps/pops-shell/scripts/validate-nginx-conf.sh` runs `nginx -t` inside `nginx:alpine` against the hand-written conf + partial. It silently skips when Docker is absent unless `REQUIRE_DOCKER=1`. The harness exists; it just isn't pointed at any generator output yet.
- **Legacy `/trpc` fallback is Partial.** The fallback block PRD-217 requires already exists in the hand-written conf; any future generator must preserve it.
- **PRD references four US files that don't exist on disk** (`us-01-generator-script.md`, `us-02-dockerfile-integration.md`, `us-03-validation.md`, `us-04-tests.md`); the folder only has `README.md`. Audit rates the PRD-level deliverables instead.

### Open question for the next planner

With PRD-190's prefix-match layout already in place, the PRD-217 generator becomes a templating job (loop pillars → emit a `location /trpc-<id>/` block per the existing shape). Worth re-scoping the PRD around the post-190 reality before drafting the four US files.

### Out of scope

No code changes. Only the PRD README is modified.

## Test plan

- [ ] Confirm the audit table accurately reflects the shipped state in `apps/pops-shell/nginx.conf`, `apps/pops-shell/Dockerfile`, `apps/pops-shell/scripts/validate-nginx-conf.sh`, and `apps/pops-shell/nginx/conf.d/_pillar-proxy.conf`.
- [ ] Decide whether to re-scope PRD-217 around the post-PRD-190 prefix-match layout before drafting US-01..US-04.
