### PR TITLE
docs(theme-13): PRD-193 React hooks status update

### DIFF
--- a/docs/themes/13-pillar-finale/epics/05-unified-consumption-sdk.md
+++ b/docs/themes/13-pillar-finale/epics/05-unified-consumption-sdk.md
@@ -24,7 +24,7 @@ React hooks layer on top: `usePillarQuery(...)`, `usePillarMutation(...)` for th
 | --- | ------------------------ | --------------------------------------------------------------------------------------- | ----------- |
 | 191 | Client surface           | The `pillar('id').router.proc(...)` proxy + failure-mode discriminants                  | Not started |
 | 192 | Server surface           | Same SDK for sibling pillars + worker calling each other                                | Done        |
-| 193 | React hooks              | `usePillarQuery`, `usePillarMutation` with React Query integration                      | Not started |
+| 193 | React hooks              | `usePillarQuery`, `usePillarMutation` with React Query integration                      | Partial     |
 | 194 | Caching + invalidation   | Registry snapshot TTL, change-subscription invalidation, per-procedure response caching | Not started |
 | 195 | Type generation pipeline | Generate the consumer-side typings from each pillar's contract                          | Not started |
 

--- a/docs/themes/13-pillar-finale/prds/193-react-hooks/README.md
+++ b/docs/themes/13-pillar-finale/prds/193-react-hooks/README.md
@@ -1,6 +1,8 @@
 # PRD-193: React hooks
 
 > Epic: [Unified consumption SDK](../../epics/05-unified-consumption-sdk.md)
+>
+> Status: **Partial**
 
 ## Overview
 
@@ -44,14 +46,26 @@ Internally calls `pillar('finance').wishlist.list({...}).orThrow()` and lets Rea
 | Pillar becomes unavailable mid-session                        | `isError` flips true; React Query retries per config; eventually surfaces error to UI. |
 | Subscription event fires for the pillar's registration change | Discovery cache invalidates; next query re-resolves.                                   |
 
+## Acceptance Criteria
+
+- [x] `usePillarQuery(pillarId, path, input, options?)` exists, walks the `pillar()` proxy by `path`, returns a React Query result, and surfaces pillar failures via `isError` (the query function throws on any non-`ok` `CallResult`, equivalent to `.orThrow()` semantics).
+- [x] `usePillarMutation(pillarId, path, options?)` exists, runs the same call through React Query's mutation lifecycle, and on success invalidates every cache entry under the same router prefix (`[pillarId, ...path.slice(0, -1)]`; single-segment paths invalidate the whole `[pillarId]` prefix).
+- [x] Both hooks decorate the React Query result with `isContractMismatch`, `isUnavailable`, and `isDegraded` flags derived from the underlying `CallFailure.kind` so call sites can branch without unpacking the error.
+- [x] React Query options (`onMutate`, `onError`, retry, stale time, etc.) pass through unchanged on both hooks; optimistic-update and rollback are supported via the host's React Query options (the PRD scopes extra optimistic helpers out — see _Out of Scope_).
+- [x] Query keys are produced by a single helper, `pillarQueryKey(pillarId, path, input)`, with shape `[pillarId, ...path, stableJson(input)]`. Two structurally-equal inputs (different key order or nested key order) hash to the same key; `undefined` inputs collapse to `null`.
+- [x] A `PillarSdkProvider` threads `PillarClientOptions` into context, composes cleanly under an existing host `QueryClientProvider`, optionally wraps one when a `queryClient` prop is supplied, and gates the SSE subscription bridge behind an opt-in `subscribe` prop. When no provider is mounted the hooks fall back to empty options.
+- [x] An SSE → cache-invalidation bridge consumes registry events: `pillar.registered` / `deregistered` / `health-changed` invalidate the `[pillarId]` prefix, and `pillar.snapshot` invalidates every cache entry whose first key segment looks like a pillar id (so pillars deregistered during a reconnect gap also drop their stale data).
+- [x] All of the above is covered by tests under `packages/pillar-sdk/src/react/__tests__/` (hooks, provider, query-key, subscription-bridge).
+- [ ] At least one shell page is migrated from a direct `pillar()` / tRPC call to `usePillarQuery` with behavioural parity verified. No consumers in `apps/` reference the hooks yet — US-04 is open.
+
 ## User Stories
 
-| #   | Story                                                         | Summary                                                               |
-| --- | ------------------------------------------------------------- | --------------------------------------------------------------------- |
-| 01  | [us-01-usePillarQuery](us-01-usePillarQuery.md)               | Hook signature + impl                                                 |
-| 02  | [us-02-usePillarMutation](us-02-usePillarMutation.md)         | Mutation hook with optimistic + rollback                              |
-| 03  | [us-03-query-key-strategy](us-03-query-key-strategy.md)       | Stable query keys; input hashing                                      |
-| 04  | [us-04-shell-migration-pilot](us-04-shell-migration-pilot.md) | Migrate one shell page to `usePillarQuery`; verify behavioural parity |
+| #   | Story                                                                               | Status      |
+| --- | ----------------------------------------------------------------------------------- | ----------- |
+| 01  | usePillarQuery — hook signature + impl                                              | Done        |
+| 02  | usePillarMutation — mutation hook (React Query's native `onMutate` / rollback flow) | Done        |
+| 03  | Stable query keys; input hashing                                                    | Done        |
+| 04  | Migrate one shell page to `usePillarQuery`; verify behavioural parity               | Not started |
 
 ## Out of Scope
 


### PR DESCRIPTION
## Summary

Audits `packages/pillar-sdk/src/react` against PRD-193 (React hooks) acceptance criteria. The four core pieces — `usePillarQuery`, `usePillarMutation`, `pillarQueryKey`, `PillarSdkProvider` — are shipped with tests, plus the opt-in `usePillarSubscriptionBridge` / `applySubscriptionEvent` SSE → cache invalidation bridge. The shell-migration pilot (US-04) is still open: no consumer in `apps/` references the hooks yet.

- Adds a `Status: **Partial**` header to the PRD
- Adds inline `## Acceptance Criteria` checkboxes (8 done, 1 open for US-04)
- Replaces the user-stories description column with a Status column (US-01 Done, US-02 Done, US-03 Done, US-04 Not started)
- Flips the PRD-193 row in `epics/05-unified-consumption-sdk.md` from `Not started` to `Partial`

`useFederatedSearch` was mentioned in the audit brief but lives under `orchestrator/` (PRD-198/199), not under `react/`, so it is intentionally out of scope here.

## AC Summary

| AC                                                                                | Status      |
| --------------------------------------------------------------------------------- | ----------- |
| `usePillarQuery` walks proxy, throws on non-`ok` (orThrow semantics)              | Done        |
| `usePillarMutation` invalidates `[pillarId, ...path[:-1]]` on success             | Done        |
| Failure-flag decoration (`isContractMismatch` / `isUnavailable` / `isDegraded`)   | Done        |
| React Query options pass-through (`onMutate` / `onError` / retry / stale time)    | Done        |
| `pillarQueryKey` — recursive stable JSON, `undefined → null`                      | Done        |
| `PillarSdkProvider` — context, host-`QueryClientProvider` composition, opt-in SSE | Done        |
| SSE subscription bridge — per-pillar + snapshot-wide invalidation                 | Done        |
| Tests under `packages/pillar-sdk/src/react/__tests__/`                            | Done        |
| Shell page migrated to `usePillarQuery` (US-04 pilot)                             | Not started |

## Test plan

- [ ] CI passes (husky + lint-staged ran locally on commit)
- [ ] Reviewer confirms US-04 scoping — open it as a follow-up PR against a real shell page (likely a finance or media list view) once consumer call sites are ready to migrate
