### PR TITLE
docs(theme-13): PRD-208 search orchestrator status update

### DIFF
--- a/docs/themes/13-pillar-finale/prds/208-search-orchestrator-relocation/README.md
+++ b/docs/themes/13-pillar-finale/prds/208-search-orchestrator-relocation/README.md
@@ -1,6 +1,8 @@
 # PRD-208: Search orchestrator relocation
 
 > Epic: [Cross-pillar code placement](../../epics/08b-cross-pillar-code-placement.md)
+>
+> Status: **Not started**
 
 ## Overview
 
@@ -30,14 +32,35 @@ New container `pops-search-api` listens on port 3008 (or next available). Expose
 | pillar-sdk version skew with a contract | Caught by contract semver (ADR-031) compatibility checks. |
 | Search container down                   | nginx 502 + PillarGuard fallback.                         |
 
+## Acceptance Criteria
+
+- [ ] `apps/pops-search-api/` package exists with its own `package.json`, `tsconfig`, entrypoint and Dockerfile, and is wired into the workspace + image-publish pipeline.
+- [ ] The federated search router (currently `apps/pops-api/src/modules/core/search/`: `router.ts`, `engine.ts`, `query-parser.ts`, `domain-app-mapping.ts`) is hosted by `pops-search-api`, calling `runFederatedSearch` from `@pops/pillar-sdk/orchestrator` against the discovery registry — no direct pillar imports.
+- [ ] The legacy `core.search.*` mount is removed from `pops-api` once the new container is wired, with a single source of truth for the `search.*` namespace.
+- [ ] nginx routes `/trpc/search.*` (and `/trpc-search` if adopted) to `pops-search-api`; `GET /health` on the new container reports orchestrator readiness.
+- [ ] `pops-search-api` is added to the production compose file, boots after `pops-core-api`, and end-to-end federated search returns merged results from every pillar adapter on capivara.
+- [ ] All four user stories below are Done.
+
 ## User Stories
 
-| #   | Story                                                         | Summary                                                                |
-| --- | ------------------------------------------------------------- | ---------------------------------------------------------------------- |
-| 01  | [us-01-container-scaffold](us-01-container-scaffold.md)       | New `apps/pops-search-api/` package + Dockerfile                       |
-| 02  | [us-02-relocate-orchestrator](us-02-relocate-orchestrator.md) | Move PRD-197's orchestrator from pops-api to new container             |
-| 03  | [us-03-nginx-dispatch](us-03-nginx-dispatch.md)               | Route `/trpc/search.*` to pops-search-api                              |
-| 04  | [us-04-deploy](us-04-deploy.md)                               | Add to compose; deploy to capivara; verify federated search end-to-end |
+| #   | Story                                                         | Summary                                                                | Status      |
+| --- | ------------------------------------------------------------- | ---------------------------------------------------------------------- | ----------- |
+| 01  | [us-01-container-scaffold](us-01-container-scaffold.md)       | New `apps/pops-search-api/` package + Dockerfile                       | Not started |
+| 02  | [us-02-relocate-orchestrator](us-02-relocate-orchestrator.md) | Move PRD-197's orchestrator from pops-api to new container             | Not started |
+| 03  | [us-03-nginx-dispatch](us-03-nginx-dispatch.md)               | Route `/trpc/search.*` to pops-search-api                              | Not started |
+| 04  | [us-04-deploy](us-04-deploy.md)                               | Add to compose; deploy to capivara; verify federated search end-to-end | Not started |
+
+## Implementation Snapshot
+
+Audited against `origin/main` on 2026-06-13. None of the relocation work has begun; everything below documents the starting state.
+
+| Concern                              | Current location                                                                                      | Target location                                                                                                             | Notes                                                                                                                       |
+| ------------------------------------ | ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| Federated runner (PRD-197)           | `packages/pillar-sdk/src/orchestrator/{index,runner,types}.ts`                                        | Unchanged — stays in SDK; new container consumes it                                                                         | Already the cross-pillar fan-out primitive. PRD-208 does not move this.                                                     |
+| Search router + engine               | `apps/pops-api/src/modules/core/search/{router,engine,query-parser,domain-app-mapping,types}.ts`      | `apps/pops-search-api/src/...`                                                                                              | Currently wired into the `core` namespace on `pops-api`; must be cut over to its own container before legacy mount removal. |
+| Per-pillar search adapters (PRD-196) | `apps/pops-api/src/modules/{finance,inventory,media,...}/.../search-adapter.ts`                       | One per pillar API container, surfaced through the discovery registry                                                       | Still on `pops-api`; move tracked by per-pillar cutover PRDs, not this one.                                                 |
+| nginx dispatch for `search.*`        | `apps/pops-shell/nginx.conf` + `nginx/conf.d/_pillar-proxy.conf` exist but contain no `search` route. | New route in the shell's nginx config sending `/trpc/search.*` (and any `/trpc-search` prefix adopted) to `pops-search-api` | Slots into the per-pillar URL prefix pattern landing in PRD-190 (nginx dispatcher simplification).                          |
+| Compose / deploy                     | `infra/docker-compose.yml` ships every pillar API today (no `search-api` service).                    | New `pops-search-api` service added to `infra/docker-compose.yml`, deployed to capivara                                     | Depends on the publish-images Dockerfile fix tracked in the health-and-deployment audit.                                    |
 
 ## Out of Scope
 


### PR DESCRIPTION
## Summary

Status audit of PRD-208 (Search orchestrator relocation) against `origin/main`. None of the relocation work has started — all four user stories stay `Not started`.

What changed in the PRD README:

- Added `Status: Not started` header and inline `## Acceptance Criteria` checkboxes (all unchecked).
- Added a `Status` column to the User Stories table.
- Added an `Implementation Snapshot` table mapping current vs target location for each concern.

## Audit findings

| Concern | Current | AC status |
| --- | --- | --- |
| `apps/pops-search-api/` package | Does not exist | Not started |
| Search router + engine (`apps/pops-api/src/modules/core/search/{router,engine,query-parser,domain-app-mapping,types}.ts`) | Still hosted by `pops-api` | Not started |
| Federated runner (`runFederatedSearch`) | Already in `packages/pillar-sdk/src/orchestrator/{index,runner,types}.ts` per PRD-197 — unchanged | n/a (out of scope for 208) |
| nginx dispatch for `search.*` | `apps/pops-shell/nginx.conf` + `nginx/conf.d/_pillar-proxy.conf` exist with no `search` route | Not started |
| Compose / deploy | `infra/docker-compose.yml` has no `search-api` service | Not started |
| Per-pillar adapters | Still on `pops-api` under each pillar module (out of scope for 208) | n/a |

Note: PRD-203 (AI orchestrator relocation) is BLOCKED on Issue #2965 — recorded here only for cross-reference; this PR does not touch PRD-203.

## Test plan

- [x] `pnpm typecheck` runs via the `pre-push` hook before the branch is pushed.
- [x] `oxfmt --write` (via `lint-staged`) runs against the touched markdown file at commit time.
- [ ] Docs-only change — no runtime tests applicable.
