### PR TITLE
feat(finance): drop PR4-ready finance tables from backfill bridge (Theme 13)

### DIFF
--- a/apps/pops-api/src/db/backfill-finance-from-shared.test.ts
+++ b/apps/pops-api/src/db/backfill-finance-from-shared.test.ts
@@ -29,7 +29,6 @@ import {
   TRANSACTION_CORRECTIONS_TABLE_SQL,
   TRANSACTION_TAG_RULES_TABLE_SQL,
   TRANSACTIONS_TABLE_SQL,
-  WISH_LIST_TABLE_SQL,
 } from './backfill-test-fixtures.js';
 
 const ALL_FINANCE_TABLES_SQL = [
@@ -39,7 +38,6 @@ const ALL_FINANCE_TABLES_SQL = [
   TRANSACTION_TAG_RULES_TABLE_SQL,
   TAG_VOCABULARY_TABLE_SQL,
   BUDGETS_TABLE_SQL,
-  WISH_LIST_TABLE_SQL,
 ].join('\n');
 
 let tmpDir: string;
@@ -71,9 +69,11 @@ function countRows(raw: BetterSqlite3.Database, table: string): number {
  * in-flight N2 cutover PR will introduce via its own baseline migration.
  * The current finance baseline (entities, transaction_corrections,
  * transaction_tag_rules, tag_vocabulary, budgets, wish_list) already
- * covers everything else. The backfill must already be ready for the
- * transactions cutover before that PR lands — this helper simulates the
- * post-cutover finance.db so the tests exercise the full TABLE_COPIES set.
+ * covers everything else; `wish_list` is no longer carried by the
+ * bridge (Theme 13 PR4) but its finance.db table is still part of the
+ * baseline. The backfill must already be ready for the transactions
+ * cutover before that PR lands — this helper simulates the post-cutover
+ * finance.db so the tests exercise the full TABLE_COPIES set.
  *
  * The DDL is rewritten to `IF NOT EXISTS` so this helper stays safe once
  * the N2 cutover lands and `openFinanceDb()` starts creating the
@@ -93,79 +93,6 @@ function openFinanceForCutover(path: string): ReturnType<typeof openFinanceDb> {
 }
 
 describe('backfillFinanceFromShared', () => {
-  it('copies wish_list rows from the shared DB on first run', () => {
-    const sharedPath = openSharedWithSeed((raw) => {
-      raw.exec(
-        `INSERT INTO wish_list (id, item, last_edited_time) VALUES ('wish-1', 'Espresso machine', '2026-06-10T00:00:00Z')`
-      );
-      raw.exec(
-        `INSERT INTO wish_list (id, item, last_edited_time) VALUES ('wish-2', 'Headphones', '2026-06-10T00:00:00Z')`
-      );
-    });
-
-    const finance = openFinanceDb(join(tmpDir, 'finance.db'));
-    try {
-      backfillFinanceFromShared(finance, sharedPath);
-      const rows = finance.raw.prepare('SELECT id, item FROM wish_list ORDER BY id').all() as {
-        id: string;
-        item: string;
-      }[];
-      expect(rows).toEqual([
-        { id: 'wish-1', item: 'Espresso machine' },
-        { id: 'wish-2', item: 'Headphones' },
-      ]);
-    } finally {
-      finance.raw.close();
-    }
-  });
-
-  it('is idempotent — a second run does not duplicate rows', () => {
-    const sharedPath = openSharedWithSeed((raw) => {
-      raw.exec(
-        `INSERT INTO wish_list (id, item, last_edited_time) VALUES ('wish-1', 'Espresso machine', '2026-06-10T00:00:00Z')`
-      );
-    });
-
-    const finance = openFinanceDb(join(tmpDir, 'finance.db'));
-    try {
-      backfillFinanceFromShared(finance, sharedPath);
-      backfillFinanceFromShared(finance, sharedPath);
-      const count = finance.raw.prepare('SELECT count(*) AS n FROM wish_list').get() as {
-        n: number;
-      };
-      expect(count.n).toBe(1);
-    } finally {
-      finance.raw.close();
-    }
-  });
-
-  it('only inserts rows missing from the finance copy (mixed state)', () => {
-    const sharedPath = openSharedWithSeed((raw) => {
-      raw.exec(
-        `INSERT INTO wish_list (id, item, last_edited_time) VALUES ('wish-shared-only', 'Bike rack', '2026-06-10T00:00:00Z')`
-      );
-      raw.exec(
-        `INSERT INTO wish_list (id, item, last_edited_time) VALUES ('wish-both', 'Espresso machine', '2026-06-10T00:00:00Z')`
-      );
-    });
-
-    const finance = openFinanceDb(join(tmpDir, 'finance.db'));
-    try {
-      // Pre-seed the finance.db with one of the rows that also lives in
-      // the shared DB; the backfill must skip it but pick up the other.
-      finance.raw.exec(
-        `INSERT INTO wish_list (id, item, last_edited_time) VALUES ('wish-both', 'Espresso machine', '2026-06-10T00:00:00Z')`
-      );
-      backfillFinanceFromShared(finance, sharedPath);
-      const rows = finance.raw.prepare('SELECT id FROM wish_list ORDER BY id').all() as {
-        id: string;
-      }[];
-      expect(rows.map((r) => r.id)).toEqual(['wish-both', 'wish-shared-only']);
-    } finally {
-      finance.raw.close();
-    }
-  });
-
   it('tolerates a shared DB with no finance-owned tables (post-PR-4 drop scenario)', () => {
     const sharedPath = join(tmpDir, 'pops.db');
     const raw = new BetterSqlite3(sharedPath);
@@ -175,7 +102,6 @@ describe('backfillFinanceFromShared', () => {
     const finance = openFinanceForCutover(join(tmpDir, 'finance.db'));
     try {
       expect(() => backfillFinanceFromShared(finance, sharedPath)).not.toThrow();
-      expect(countRows(finance.raw, 'wish_list')).toBe(0);
       expect(countRows(finance.raw, 'entities')).toBe(0);
       expect(countRows(finance.raw, 'transactions')).toBe(0);
       expect(countRows(finance.raw, 'transaction_corrections')).toBe(0);
@@ -189,19 +115,15 @@ describe('backfillFinanceFromShared', () => {
     }
   });
 
-  it('tolerates a shared DB missing only some finance tables (partial legacy)', () => {
-    // Shared DB has wish_list + entities but no transactions / corrections /
-    // tag rules / tag vocabulary / budgets. Backfill must copy what's there
-    // and skip the rest without throwing.
+  it('tolerates a shared DB missing some finance tables (partial legacy)', () => {
+    // Shared DB only has entities — transactions / corrections / tag rules
+    // / tag vocabulary / budgets are absent. Backfill must copy what's
+    // there and skip the rest without throwing.
     const sharedPath = join(tmpDir, 'pops.db');
     const raw = new BetterSqlite3(sharedPath);
     raw.exec(ENTITIES_TABLE_SQL);
-    raw.exec(WISH_LIST_TABLE_SQL);
     raw.exec(
       `INSERT INTO entities (id, name, last_edited_time) VALUES ('ent-1', 'Acme', '2026-06-10T00:00:00Z')`
-    );
-    raw.exec(
-      `INSERT INTO wish_list (id, item, last_edited_time) VALUES ('wish-1', 'Coffee grinder', '2026-06-10T00:00:00Z')`
     );
     raw.close();
 
@@ -209,7 +131,6 @@ describe('backfillFinanceFromShared', () => {
     try {
       expect(() => backfillFinanceFromShared(finance, sharedPath)).not.toThrow();
       expect(countRows(finance.raw, 'entities')).toBe(1);
-      expect(countRows(finance.raw, 'wish_list')).toBe(1);
       expect(countRows(finance.raw, 'transactions')).toBe(0);
     } finally {
       finance.raw.close();

--- a/apps/pops-api/src/db/backfill-finance-from-shared.ts
+++ b/apps/pops-api/src/db/backfill-finance-from-shared.ts
@@ -16,7 +16,9 @@
  *     → transaction_tag_rules (FK → entities)
  *   tag_vocabulary (no FK, PK is `tag`)
  *   budgets (no FK, UNIQUE on category+period)
- *   wish_list (no FK)
+ *
+ * `wish_list` was retired from the bridge once its read + write surface
+ * landed entirely on `finance.db` (Theme 13, PRD-212 PR4).
  *
  * Each table is wrapped in `tryCopyTable` so a missing source table
  * (post-PR-4 drop scenario, or a stale on-disk pops.db) doesn't bring
@@ -135,21 +137,6 @@ const TABLE_COPIES: readonly TableCopy[] = [
       'period',
       'amount',
       'active',
-      'notes',
-      'last_edited_time',
-    ],
-  },
-  {
-    table: 'wish_list',
-    idColumn: 'id',
-    columns: [
-      'id',
-      'notion_id',
-      'item',
-      'target_amount',
-      'saved',
-      'priority',
-      'url',
       'notes',
       'last_edited_time',
     ],

--- a/apps/pops-api/src/db/backfill-test-fixtures-finance.ts
+++ b/apps/pops-api/src/db/backfill-test-fixtures-finance.ts
@@ -3,21 +3,6 @@
  * `backfill-test-fixtures.ts` to keep each file under the 200-line cap.
  * See that module's header for why these DDLs live alongside the tests.
  */
-export const WISH_LIST_TABLE_SQL = `
-CREATE TABLE wish_list (
-  id text PRIMARY KEY NOT NULL,
-  notion_id text,
-  item text NOT NULL,
-  target_amount real,
-  saved real,
-  priority text,
-  url text,
-  notes text,
-  last_edited_time text NOT NULL
-);
-CREATE UNIQUE INDEX wish_list_notion_id_unique ON wish_list (notion_id);
-`;
-
 export const ENTITIES_TABLE_SQL = `
 CREATE TABLE entities (
   id text PRIMARY KEY NOT NULL,

--- a/apps/pops-api/src/db/backfill-test-fixtures.ts
+++ b/apps/pops-api/src/db/backfill-test-fixtures.ts
@@ -33,5 +33,4 @@ export {
   TRANSACTION_CORRECTIONS_TABLE_SQL,
   TRANSACTION_TAG_RULES_TABLE_SQL,
   TRANSACTIONS_TABLE_SQL,
-  WISH_LIST_TABLE_SQL,
 } from './backfill-test-fixtures-finance.js';


### PR DESCRIPTION
## Summary

Theme 13 PR4 for the finance pillar: drop the boot-time `pops.db -> finance.db` backfill entry for tables whose read + write surface has fully cut over to `finance.db`.

After auditing every finance-table call site in `apps/pops-api/src/` (excluding `modules/finance/*` matches against `@pops/finance-db`), only `wish_list` is PR4-ready. The other six tables still have shared-DB consumers and stay on the bridge.

### Tables dropped (1)

- **`wish_list`** — only consumers are `modules/finance/wishlist/router.ts` and `modules/finance/wishlist/search-adapter.ts`, both via `getFinanceDrizzle()`.

### Tables blocked (6) + blockers

| Table | Read blockers (still `getDrizzle()` against `pops.db`) | Write blockers |
|---|---|---|
| `entities` | `modules/core/entities/service.ts`, `modules/core/entities/search-adapter.ts`, `shared/tag-suggester.ts` | `modules/core/entities/service.ts` (insert/update/delete) |
| `transactions` | `modules/finance/transactions/router.ts`, `modules/finance/transactions/search-adapter.ts`, `modules/core/corrections/handlers/preview-matches.ts`, `modules/core/corrections/handlers/changeset-impact.ts`, `modules/core/corrections/lib/tag-loader.ts`, `modules/cerebrum/retrieval/semantic-search-metadata.ts`, `jobs/handlers/embeddings-source.ts` | — |
| `transaction_corrections` | `modules/core/corrections/handlers/ai-revise.ts`, `modules/core/corrections/handlers/compute-changeset.ts`, `modules/core/corrections/handlers/changeset-impact.ts` | — |
| `transaction_tag_rules` | `shared/tag-suggester.ts` | — |
| `tag_vocabulary` | `modules/finance/imports/lib/tag-management.ts` | — |
| `budgets` | `modules/finance/budgets/search-adapter.ts` | — |

Every blocker above represents a `getDrizzle()` call site that still reads/writes the finance-owned table on the shared `pops.db`. Until those callers move to `getFinanceDrizzle()`, the boot-time backfill must keep carrying the table across — otherwise rows landing on `pops.db` after the cutover would be stranded.

### Changes

- Drop the `wish_list` entry from `TABLE_COPIES` in `apps/pops-api/src/db/backfill-finance-from-shared.ts`.
- Remove the three top-level `wish_list` test blocks (first-run, idempotent, mixed-state) from `backfill-finance-from-shared.test.ts` — they exercise the now-removed copy path.
- Trim `wish_list` from the post-PR-4 drop scenario + partial-legacy test assertions.
- Remove `WISH_LIST_TABLE_SQL` from `backfill-test-fixtures-finance.ts` + the re-export barrel.

Mirrors the `feat(media): drop movies backfill entry` (#3050) and `feat(cerebrum): drop engrams/plexus/glia/conversations backfill (PR4)` (#3043) precedents.

### Deploy order

Depends on the wishlist PR3 deploy having shipped to prod first — otherwise late-arriving rows on `pops.db.wish_list` would be stranded.

## Test plan

- [x] `pnpm --filter @pops/api typecheck`
- [x] `pnpm typecheck` (root)
- [x] `pnpm --filter @pops/api exec vitest run src/db/backfill-finance-from-shared.test.ts` — 14 tests passing
- [x] `pnpm --filter @pops/api exec vitest run src/modules/finance` — 638 finance tests passing
- [x] Full husky pre-commit chain (lint-staged: oxlint + oxfmt)
- [ ] Verify wishlist PR3 deploy has reached prod before merging
