### PR TITLE
feat(media): migrate discovery writes to media.db (PRD-170 PR3)

### DIFF
--- a/apps/pops-api/src/db/backfill-media-from-shared.test.ts
+++ b/apps/pops-api/src/db/backfill-media-from-shared.test.ts
@@ -22,6 +22,7 @@ import { openMediaDb } from '@pops/media-db';
 
 import { backfillMediaFromShared, closeMediaDb, setMediaDb } from '../db/media-db-handle.js';
 import {
+  DISMISSED_DISCOVER_TABLE_SQL,
   SHELF_IMPRESSIONS_TABLE_SQL,
   TV_SHOWS_TABLE_SQL,
   WATCH_HISTORY_TABLE_SQL,
@@ -530,6 +531,100 @@ describe('backfillMediaFromShared', () => {
 
       expect(() => backfillMediaFromShared()).not.toThrow();
       const count = media.raw.prepare('SELECT count(*) AS n FROM watchlist').get() as {
+        n: number;
+      };
+      expect(count.n).toBe(0);
+    });
+  });
+
+  describe('dismissed_discover (PRD-170 PR 3)', () => {
+    interface DismissedSeed {
+      tmdbId: number;
+      dismissedAt?: string;
+    }
+
+    function openSharedWithDismissed(rows: DismissedSeed[]): string {
+      const path = join(tmpDir, 'pops.db');
+      const raw = new BetterSqlite3(path);
+      raw.exec(SHELF_IMPRESSIONS_TABLE_SQL);
+      raw.exec(DISMISSED_DISCOVER_TABLE_SQL);
+      const insert = raw.prepare(
+        'INSERT INTO dismissed_discover (tmdb_id, dismissed_at) VALUES (?, ?)'
+      );
+      for (const row of rows) {
+        insert.run(row.tmdbId, row.dismissedAt ?? '2026-06-10 12:00:00');
+      }
+      raw.close();
+      process.env['SQLITE_PATH'] = path;
+      return path;
+    }
+
+    it('copies fresh dismissed rows on first run and is a no-op on the second', () => {
+      openSharedWithDismissed([
+        { tmdbId: 550, dismissedAt: '2026-06-10 12:00:00' },
+        { tmdbId: 603, dismissedAt: '2026-06-10 12:00:01' },
+      ]);
+      const media = openMediaDb(join(tmpDir, 'media.db'));
+      setMediaDb(media);
+
+      backfillMediaFromShared();
+      const after = media.raw
+        .prepare('SELECT tmdb_id, dismissed_at FROM dismissed_discover ORDER BY tmdb_id')
+        .all() as { tmdb_id: number; dismissed_at: string }[];
+      expect(after.map((r) => r.tmdb_id)).toEqual([550, 603]);
+
+      backfillMediaFromShared();
+      const second = media.raw.prepare('SELECT count(*) AS n FROM dismissed_discover').get() as {
+        n: number;
+      };
+      expect(second.n).toBe(2);
+    });
+
+    it('only inserts dismissed rows missing from the media copy', () => {
+      openSharedWithDismissed([
+        { tmdbId: 550, dismissedAt: '2026-06-10 12:00:00' },
+        { tmdbId: 603, dismissedAt: '2026-06-10 12:00:01' },
+      ]);
+      const media = openMediaDb(join(tmpDir, 'media.db'));
+      setMediaDb(media);
+      media.raw
+        .prepare('INSERT INTO dismissed_discover (tmdb_id, dismissed_at) VALUES (?, ?)')
+        .run(550, '2026-06-09 09:00:00');
+
+      backfillMediaFromShared();
+      const rows = media.raw
+        .prepare('SELECT tmdb_id, dismissed_at FROM dismissed_discover ORDER BY tmdb_id')
+        .all() as { tmdb_id: number; dismissed_at: string }[];
+      expect(rows).toEqual([
+        { tmdb_id: 550, dismissed_at: '2026-06-09 09:00:00' },
+        { tmdb_id: 603, dismissed_at: '2026-06-10 12:00:01' },
+      ]);
+    });
+
+    it('carries the dismissed_at timestamp across (full-shape roundtrip)', () => {
+      openSharedWithDismissed([{ tmdbId: 42, dismissedAt: '2026-06-10 23:59:59' }]);
+      const media = openMediaDb(join(tmpDir, 'media.db'));
+      setMediaDb(media);
+      backfillMediaFromShared();
+
+      const row = media.raw
+        .prepare('SELECT * FROM dismissed_discover WHERE tmdb_id = ?')
+        .get(42) as Record<string, unknown>;
+      expect(row).toMatchObject({ tmdb_id: 42, dismissed_at: '2026-06-10 23:59:59' });
+    });
+
+    it('tolerates a shared DB without the dismissed_discover table', () => {
+      const path = join(tmpDir, 'pops.db');
+      const raw = new BetterSqlite3(path);
+      raw.exec(SHELF_IMPRESSIONS_TABLE_SQL);
+      raw.close();
+      process.env['SQLITE_PATH'] = path;
+
+      const media = openMediaDb(join(tmpDir, 'media.db'));
+      setMediaDb(media);
+
+      expect(() => backfillMediaFromShared()).not.toThrow();
+      const count = media.raw.prepare('SELECT count(*) AS n FROM dismissed_discover').get() as {
         n: number;
       };
       expect(count.n).toBe(0);

--- a/apps/pops-api/src/db/backfill-test-fixtures-media.ts
+++ b/apps/pops-api/src/db/backfill-test-fixtures-media.ts
@@ -105,3 +105,10 @@ CREATE TABLE watchlist (
 );
 CREATE UNIQUE INDEX idx_watchlist_media ON watchlist (media_type, media_id);
 `;
+
+export const DISMISSED_DISCOVER_TABLE_SQL = `
+CREATE TABLE dismissed_discover (
+  tmdb_id integer PRIMARY KEY,
+  dismissed_at text NOT NULL DEFAULT (datetime('now'))
+);
+`;

--- a/apps/pops-api/src/db/backfill-test-fixtures.ts
+++ b/apps/pops-api/src/db/backfill-test-fixtures.ts
@@ -20,6 +20,7 @@ export {
   SETTINGS_TABLE_SQL,
 } from './backfill-test-fixtures-core.js';
 export {
+  DISMISSED_DISCOVER_TABLE_SQL,
   MOVIES_TABLE_SQL,
   SHELF_IMPRESSIONS_TABLE_SQL,
   TV_SHOWS_TABLE_SQL,

--- a/apps/pops-api/src/db/media-backfill.ts
+++ b/apps/pops-api/src/db/media-backfill.ts
@@ -120,6 +120,11 @@ const TABLE_COPIES: readonly TableCopy[] = [
       'plex_rating_key',
     ],
   },
+  {
+    table: 'dismissed_discover',
+    idColumn: 'tmdb_id',
+    columns: ['tmdb_id', 'dismissed_at'],
+  },
 ];
 
 function tryCopyTable(raw: Database.Database, copy: TableCopy): void {

--- a/apps/pops-api/src/modules/media/discovery/flags.test.ts
+++ b/apps/pops-api/src/modules/media/discovery/flags.test.ts
@@ -1,8 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-// Mock dependencies before imports
+const mockMediaDb = { __mediaDb: true };
+
 vi.mock('../../../db.js', () => ({
   getDrizzle: vi.fn(),
+}));
+
+vi.mock('../../../db/media-db-handle.js', () => ({
+  getMediaDrizzle: vi.fn(() => mockMediaDb),
 }));
 
 vi.mock('@pops/db-types', () => ({
@@ -11,14 +16,25 @@ vi.mock('@pops/db-types', () => ({
   mediaWatchlist: { mediaId: 'media_id', mediaType: 'media_type' },
 }));
 
+vi.mock('@pops/media-db', () => ({
+  dismissedDiscoverService: {
+    getDismissedTmdbIdSet: vi.fn(),
+  },
+}));
+
 vi.mock('drizzle-orm', () => ({
   eq: vi.fn((col, val) => ({ col, val })),
 }));
 
+import { dismissedDiscoverService } from '@pops/media-db';
+
 import { getDrizzle } from '../../../db.js';
+import { getMediaDrizzle } from '../../../db/media-db-handle.js';
 import { getDismissedTmdbIds, getWatchedTmdbIds, getWatchlistTmdbIds } from './flags.js';
 
 const mockGetDrizzle = vi.mocked(getDrizzle);
+const mockGetMediaDrizzle = vi.mocked(getMediaDrizzle);
+const mockGetDismissedTmdbIdSet = vi.mocked(dismissedDiscoverService.getDismissedTmdbIdSet);
 
 function createMockDb(rows: { tmdbId: number }[]) {
   const mockAll = vi.fn().mockReturnValue(rows);
@@ -86,29 +102,25 @@ describe('getDismissedTmdbIds', () => {
   });
 
   it('returns empty Set when no dismissed movies', () => {
-    const mockAll = vi.fn().mockReturnValue([]);
-    mockGetDrizzle.mockReturnValue({ all: mockAll } as unknown as ReturnType<typeof getDrizzle>);
+    mockGetDismissedTmdbIdSet.mockReturnValue(new Set());
     const result = getDismissedTmdbIds();
     expect(result).toBeInstanceOf(Set);
     expect(result.size).toBe(0);
   });
 
-  it('returns Set of dismissed TMDB IDs from raw SQL', () => {
-    const mockAll = vi.fn().mockReturnValue([{ tmdb_id: 500 }, { tmdb_id: 600 }]);
-    mockGetDrizzle.mockReturnValue({ all: mockAll } as unknown as ReturnType<typeof getDrizzle>);
+  it('returns Set of dismissed TMDB IDs from dismissedDiscoverService', () => {
+    mockGetDismissedTmdbIdSet.mockReturnValue(new Set([500, 600]));
     const result = getDismissedTmdbIds();
     expect(result.has(500)).toBe(true);
     expect(result.has(600)).toBe(true);
     expect(result.has(999)).toBe(false);
   });
 
-  it('returns empty Set when table does not exist yet', () => {
-    const mockAll = vi.fn().mockImplementation(() => {
-      throw new Error('no such table: dismissed_discover');
-    });
-    mockGetDrizzle.mockReturnValue({ all: mockAll } as unknown as ReturnType<typeof getDrizzle>);
-    const result = getDismissedTmdbIds();
-    expect(result).toBeInstanceOf(Set);
-    expect(result.size).toBe(0);
+  it('resolves the media-pillar drizzle handle and forwards it to the service', () => {
+    mockGetDismissedTmdbIdSet.mockReturnValue(new Set([42]));
+    getDismissedTmdbIds();
+    expect(mockGetMediaDrizzle).toHaveBeenCalledTimes(1);
+    expect(mockGetDismissedTmdbIdSet).toHaveBeenCalledWith(mockMediaDb);
+    expect(mockGetDrizzle).not.toHaveBeenCalled();
   });
 });

--- a/apps/pops-api/src/modules/media/discovery/flags.ts
+++ b/apps/pops-api/src/modules/media/discovery/flags.ts
@@ -3,10 +3,20 @@ import { eq } from 'drizzle-orm';
 /**
  * Shared helpers for building Sets of TMDB IDs used by discovery services
  * to filter and annotate DiscoverResult objects.
+ *
+ * `getDismissedTmdbIds` reads from `media.db.dismissed_discover` via
+ * `dismissedDiscoverService` after PRD-170 PR 3 cut both the dismiss
+ * writers (`./service.ts`) and this single dismiss-pile reader to the
+ * per-pillar handle. The other two helpers stay on `getDrizzle()` while
+ * their backing tables (`mediaWatchlist`, `watchHistory`, `movies`) are
+ * still pinned to the shared journal — flipping them belongs with each
+ * table's own slice cutover, not this dismiss-pile move.
  */
 import { mediaWatchlist, movies, watchHistory } from '@pops/db-types';
+import { dismissedDiscoverService } from '@pops/media-db';
 
 import { getDrizzle } from '../../../db.js';
+import { getMediaDrizzle } from '../../../db/media-db-handle.js';
 
 /** Build a Set of TMDB IDs the user has watched (any entry in watch_history). */
 export function getWatchedTmdbIds(): Set<number> {
@@ -33,15 +43,12 @@ export function getWatchlistTmdbIds(): Set<number> {
 }
 
 /**
- * Build a Set of dismissed TMDB IDs from dismissed_discover.
- * Returns an empty set if the table doesn't exist yet.
+ * Build a Set of dismissed TMDB IDs from `media.db.dismissed_discover`
+ * via `dismissedDiscoverService` (PRD-170 PR 3). The package guarantees
+ * the table exists once `openMediaDb()` has run its baseline migration,
+ * so the legacy table-missing fallback that the raw-SQL implementation
+ * needed is no longer necessary.
  */
 export function getDismissedTmdbIds(): Set<number> {
-  try {
-    const db = getDrizzle();
-    const rows = db.all<{ tmdb_id: number }>(/* sql */ `SELECT tmdb_id FROM dismissed_discover`);
-    return new Set(rows.map((r) => r.tmdb_id));
-  } catch {
-    return new Set();
-  }
+  return dismissedDiscoverService.getDismissedTmdbIdSet(getMediaDrizzle());
 }

--- a/apps/pops-api/src/modules/media/discovery/plex-service.test.ts
+++ b/apps/pops-api/src/modules/media/discovery/plex-service.test.ts
@@ -16,6 +16,7 @@ vi.mock('@pops/db-types', () => ({
 }));
 
 vi.mock('./flags.js', () => ({
+  getDismissedTmdbIds: vi.fn().mockReturnValue(new Set()),
   getWatchedTmdbIds: vi.fn().mockReturnValue(new Set()),
   getWatchlistTmdbIds: vi.fn().mockReturnValue(new Set()),
 }));
@@ -23,11 +24,12 @@ vi.mock('./flags.js', () => ({
 // Now import mocked modules
 import { getDrizzle } from '../../../db.js';
 import { getPlexClient } from '../plex/service.js';
-import { getWatchedTmdbIds, getWatchlistTmdbIds } from './flags.js';
+import { getDismissedTmdbIds, getWatchedTmdbIds, getWatchlistTmdbIds } from './flags.js';
 import { getTrendingFromPlex } from './plex-service.js';
 
 const mockGetPlexClient = vi.mocked(getPlexClient);
 const mockGetDrizzle = vi.mocked(getDrizzle);
+const mockGetDismissedTmdbIds = vi.mocked(getDismissedTmdbIds);
 const mockGetWatchedTmdbIds = vi.mocked(getWatchedTmdbIds);
 const mockGetWatchlistTmdbIds = vi.mocked(getWatchlistTmdbIds);
 
@@ -61,18 +63,19 @@ function makePlexItem(overrides: Partial<PlexMediaItem> = {}): PlexMediaItem {
   };
 }
 
-/** Create a mock DB that returns empty results for both queries. */
+/**
+ * Create a mock DB for the `getLibraryTmdbIds` drizzle query — the
+ * dismissed-discover read now lives behind `flags.ts::getDismissedTmdbIds`
+ * (mocked at module level), so this fixture only needs to cover the
+ * library-ids select chain.
+ */
 function createMockDb(libraryTmdbIds: number[] = []) {
   const mockAll = vi.fn().mockReturnValue(libraryTmdbIds.map((id) => ({ tmdbId: id })));
   const mockFrom = vi.fn().mockReturnValue({ all: mockAll });
   const mockSelect = vi.fn().mockReturnValue({ from: mockFrom });
 
-  // For raw SQL query (dismissed_discover)
-  const mockDbAll = vi.fn().mockReturnValue([]);
-
   return {
     select: mockSelect,
-    all: mockDbAll,
   } as unknown as ReturnType<typeof getDrizzle>;
 }
 
@@ -195,10 +198,8 @@ describe('getTrendingFromPlex', () => {
       mockClient as unknown as ReturnType<typeof getPlexClient> & object
     );
 
-    const mockDb = createMockDb();
-    // Override the raw SQL query to return dismissed IDs
-    (mockDb.all as ReturnType<typeof vi.fn>).mockReturnValue([{ tmdb_id: 200 }]);
-    mockGetDrizzle.mockReturnValue(mockDb);
+    mockGetDrizzle.mockReturnValue(createMockDb());
+    mockGetDismissedTmdbIds.mockReturnValueOnce(new Set([200]));
 
     const result = await getTrendingFromPlex();
     expect(result).toHaveLength(1);

--- a/apps/pops-api/src/modules/media/discovery/plex-service.ts
+++ b/apps/pops-api/src/modules/media/discovery/plex-service.ts
@@ -6,7 +6,7 @@ import { movies } from '@pops/db-types';
 
 import { getDrizzle } from '../../../db.js';
 import { getPlexClient } from '../plex/service.js';
-import { getWatchedTmdbIds, getWatchlistTmdbIds } from './flags.js';
+import { getDismissedTmdbIds, getWatchedTmdbIds, getWatchlistTmdbIds } from './flags.js';
 
 import type { PlexMediaItem } from '../plex/types.js';
 import type { DiscoverResult } from './types.js';
@@ -63,18 +63,6 @@ function toDiscoverResult(
     isWatched: watchedIds.has(tmdbId),
     onWatchlist: watchlistIds.has(tmdbId),
   };
-}
-
-/** Get dismissed TMDB IDs for filtering. Returns empty set if table doesn't exist yet. */
-function getDismissedTmdbIds(): Set<number> {
-  try {
-    const db = getDrizzle();
-    const rows = db.all<{ tmdb_id: number }>(/* sql */ `SELECT tmdb_id FROM dismissed_discover`);
-    return new Set(rows.map((r) => r.tmdb_id));
-  } catch {
-    // Table may not exist yet (tb-115 creates it)
-    return new Set();
-  }
 }
 
 /**

--- a/apps/pops-api/src/modules/media/discovery/service.ts
+++ b/apps/pops-api/src/modules/media/discovery/service.ts
@@ -3,12 +3,20 @@
  * dismissal, and rewatch suggestions.
  *
  * The implementation is split into focused modules under `service-*.ts`.
+ *
+ * Dismiss-pile cutover (PRD-170 PR 3): `dismiss`, `undismiss`, and
+ * `getDismissed` now forward to `@pops/media-db`'s
+ * `dismissedDiscoverService`, resolving the media pillar's per-pillar
+ * SQLite handle via `getMediaDrizzle()`. Reads of the same table in
+ * `./flags.ts::getDismissedTmdbIds` flip in the same PR so the writer
+ * never races a stale read off `pops.db`. The boot-time
+ * `backfillMediaFromShared()` bridge carries existing rows across on
+ * first deploy; PRD-170 PR 4 drops `dismissed_discover` from the shared
+ * journal and retires the bridge entry.
  */
-import { eq } from 'drizzle-orm';
+import { dismissedDiscoverService } from '@pops/media-db';
 
-import { dismissedDiscover } from '@pops/db-types';
-
-import { getDrizzle } from '../../../db.js';
+import { getMediaDrizzle } from '../../../db/media-db-handle.js';
 
 export { getPreferenceProfile } from './service-preference-profile.js';
 export { getQuickPickMovies, getUnwatchedLibraryMovies } from './service-library.js';
@@ -17,19 +25,15 @@ export { getRewatchSuggestions } from './service-rewatch.js';
 
 /** Dismiss a movie by tmdbId (idempotent — ON CONFLICT DO NOTHING). */
 export function dismiss(tmdbId: number): void {
-  const db = getDrizzle();
-  db.insert(dismissedDiscover).values({ tmdbId }).onConflictDoNothing().run();
+  dismissedDiscoverService.dismiss(getMediaDrizzle(), tmdbId);
 }
 
 /** Undismiss a movie by tmdbId. */
 export function undismiss(tmdbId: number): void {
-  const db = getDrizzle();
-  db.delete(dismissedDiscover).where(eq(dismissedDiscover.tmdbId, tmdbId)).run();
+  dismissedDiscoverService.undismiss(getMediaDrizzle(), tmdbId);
 }
 
 /** Get all dismissed tmdbIds. */
 export function getDismissed(): number[] {
-  const db = getDrizzle();
-  const rows = db.select({ tmdbId: dismissedDiscover.tmdbId }).from(dismissedDiscover).all();
-  return rows.map((r) => r.tmdbId);
+  return dismissedDiscoverService.listDismissedTmdbIds(getMediaDrizzle());
 }


### PR DESCRIPTION
## Summary

- Cuts every `dismissed_discover` reader and writer in pops-api to `getMediaDrizzle()` so reads and writes land on the same store: `service.ts::dismiss/undismiss/getDismissed` now forward to `@pops/media-db`'s `dismissedDiscoverService` (scaffolded in PRD-170 PR 1 / #3037).
- `flags.ts::getDismissedTmdbIds` flips to `dismissedDiscoverService.getDismissedTmdbIdSet`; the raw-SQL + try/catch table-missing fallback is dropped — `openMediaDb()`'s baseline migration guarantees the table exists. `plex-service.ts` had a private copy of the same function; replaced with an import from `flags.ts` to remove the duplication and route through the media handle.
- Backfill bridge: `apps/pops-api/src/db/media-backfill.ts` gains a `dismissed_discover` entry (idColumn `tmdb_id`, columns `[tmdb_id, dismissed_at]`) so the first boot after deploy carries existing rows from `pops.db` into `media.db`. PRD-170 PR 4 drops the entry once the shared-journal copy is retired.

`flags.ts::getWatchedTmdbIds` / `getWatchlistTmdbIds` and `plex-service.ts::getLibraryTmdbIds` stay on `getDrizzle()` — they cross-join `movies` against `watchHistory` / `mediaWatchlist`, all still pinned to the shared journal, and belong with each table's own slice cutover (PRD-167 PR 4 / PRD-168), not this dismiss-pile move.

## Test plan

- [x] `pnpm -F @pops/api test src/modules/media/discovery src/db` — 540 pass (was 536; +4 `dismissed_discover` backfill cases covering fresh copy, second-run no-op, missing-only insert, full-shape roundtrip, missing-table tolerance).
- [x] `pnpm -w typecheck` — green across 66 workspace tasks.
- [x] `pnpm oxfmt --check` on touched files — clean.
- [x] Full husky pre-commit + pre-push chain on commit (`lint-staged`: oxlint+oxfmt) and push (`pnpm typecheck`) — clean.
- [ ] Verify after first prod deploy that `media.db.dismissed_discover` is populated from `pops.db.dismissed_discover` via `backfillMediaFromShared()` (idempotent — second boot is a no-op).
