### PR TITLE
feat(food): route sendToList writes through getListsDrizzle (Theme 13 cross-pillar unblock)

### DIFF
--- a/apps/pops-api/src/modules/food/__tests__/send-to-list.test.ts
+++ b/apps/pops-api/src/modules/food/__tests__/send-to-list.test.ts
@@ -9,9 +9,11 @@
  * append + truncation, target resolution + error mapping.
  */
 import { type Database } from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { closeDb, setDb } from '../../../db.js';
+import { setListsDb } from '../../../db/lists-handle.js';
 import { createCaller } from '../../../shared/test-utils.js';
 import { MAX_NOTES_LENGTH } from '../recipes/send-to-list/notes-helpers.js';
 import {
@@ -32,11 +34,13 @@ let caller: ReturnType<typeof createCaller>;
 beforeEach(() => {
   db = createSendToListTestDb();
   setDb(db);
+  setListsDb({ db: drizzle(db), raw: db });
   caller = createCaller(true);
 });
 
 afterEach(() => {
   closeDb();
+  setListsDb(null);
 });
 
 interface BasicSeed {

--- a/apps/pops-api/src/modules/food/recipes/router.ts
+++ b/apps/pops-api/src/modules/food/recipes/router.ts
@@ -27,6 +27,7 @@
 import { TRPCError } from '@trpc/server';
 
 import { getDrizzle } from '../../../db.js';
+import { getListsDrizzle } from '../../../db/lists-handle.js';
 import { protectedProcedure, router } from '../../../trpc.js';
 import { createNewDraftForSlug, createNewRecipe, restoreVersionAsDraft } from './create.js';
 import { getForRendering } from './get-for-rendering.js';
@@ -111,11 +112,11 @@ export const recipesRouter = router({
   }),
 
   prepareSendToList: protectedProcedure.input(PrepareSendToListInputSchema).query(({ input }) => {
-    return prepareSendToList(getDrizzle(), input.versionId, input.scaleFactor);
+    return prepareSendToList(getDrizzle(), getListsDrizzle(), input.versionId, input.scaleFactor);
   }),
 
   sendToList: protectedProcedure.input(SendToListInputSchema).mutation(({ input }) => {
-    return sendToList(getDrizzle(), {
+    return sendToList(getDrizzle(), getListsDrizzle(), {
       versionId: input.versionId,
       scaleFactor: input.scaleFactor,
       target: input.target,

--- a/apps/pops-api/src/modules/food/recipes/send-to-list/already-sent.ts
+++ b/apps/pops-api/src/modules/food/recipes/send-to-list/already-sent.ts
@@ -10,12 +10,11 @@
  */
 import { and, eq, isNotNull, isNull, sql } from 'drizzle-orm';
 
-import { type FoodDb } from '@pops/app-food-db';
-import { listItems, lists } from '@pops/app-lists-db';
+import { type ListsDb, listItems, lists } from '@pops/app-lists-db';
 
 import { escapeLike } from './notes-helpers.js';
 
-export function findListsAlreadyMentioning(db: FoodDb, recipeTitle: string): number[] {
+export function findListsAlreadyMentioning(db: ListsDb, recipeTitle: string): number[] {
   if (recipeTitle.length === 0) return [];
   const pattern = `%${escapeLike(recipeTitle)}%`;
   const rows = db

--- a/apps/pops-api/src/modules/food/recipes/send-to-list/merge.ts
+++ b/apps/pops-api/src/modules/food/recipes/send-to-list/merge.ts
@@ -8,8 +8,7 @@
  */
 import { and, eq } from 'drizzle-orm';
 
-import { type FoodDb } from '@pops/app-food-db';
-import { addItem, listItems } from '@pops/app-lists-db';
+import { addItem, type ListsDb, listItems } from '@pops/app-lists-db';
 
 import { appendNote, MAX_NOTES_LENGTH } from './notes-helpers.js';
 import { relabelAfterMerge, type SendItem } from './send-items.js';
@@ -19,7 +18,7 @@ export interface MergeOutcome {
 }
 
 export function processItem(
-  tx: FoodDb,
+  tx: ListsDb,
   listId: number,
   item: SendItem,
   recipeTitle: string
@@ -43,7 +42,7 @@ interface ExistingRow {
 }
 
 function findExistingMatch(
-  tx: FoodDb,
+  tx: ListsDb,
   listId: number,
   refKind: 'ingredient' | 'variant' | 'free',
   refId: number
@@ -61,7 +60,7 @@ function findExistingMatch(
 }
 
 function mergeIntoExisting(
-  tx: FoodDb,
+  tx: ListsDb,
   existing: ExistingRow,
   item: SendItem,
   noteFragment: string
@@ -79,7 +78,7 @@ function mergeIntoExisting(
     .run();
 }
 
-function insertFresh(tx: FoodDb, listId: number, item: SendItem, noteFragment: string): void {
+function insertFresh(tx: ListsDb, listId: number, item: SendItem, noteFragment: string): void {
   addItem(tx, {
     listId,
     label: item.preview.label,

--- a/apps/pops-api/src/modules/food/recipes/send-to-list/prepare.ts
+++ b/apps/pops-api/src/modules/food/recipes/send-to-list/prepare.ts
@@ -9,6 +9,7 @@
 import { TRPCError } from '@trpc/server';
 
 import { type FoodDb } from '@pops/app-food-db';
+import { type ListsDb } from '@pops/app-lists-db';
 
 import { aggregateLinesForSend } from './aggregate.js';
 import { findListsAlreadyMentioning } from './already-sent.js';
@@ -17,11 +18,12 @@ import { type SendPreview } from './types.js';
 import { clampScaleFactor, loadVersionForSend } from './version-load.js';
 
 export function prepareSendToList(
-  db: FoodDb,
+  foodDb: FoodDb,
+  listsDb: ListsDb,
   versionId: number,
   scaleFactorIn: number | undefined
 ): SendPreview {
-  const loaded = loadVersionForSend(db, versionId);
+  const loaded = loadVersionForSend(foodDb, versionId);
   if (!loaded.ok) {
     if (loaded.reason === 'CompileNotReady') {
       throw new TRPCError({
@@ -35,7 +37,7 @@ export function prepareSendToList(
     });
   }
   const scaleFactor = clampScaleFactor(scaleFactorIn);
-  const aggregate = aggregateLinesForSend(db, versionId, scaleFactor);
+  const aggregate = aggregateLinesForSend(foodDb, versionId, scaleFactor);
   const canonicalItems = aggregate.canonical.map(buildCanonicalItem);
   const unconvertedItems = aggregate.unconverted.map(buildUnconvertedItem);
   return {
@@ -43,6 +45,6 @@ export function prepareSendToList(
     scaleFactor,
     canonicalItems,
     unconvertedItems,
-    alreadySentToListIds: findListsAlreadyMentioning(db, loaded.version.title),
+    alreadySentToListIds: findListsAlreadyMentioning(listsDb, loaded.version.title),
   };
 }

--- a/apps/pops-api/src/modules/food/recipes/send-to-list/send.ts
+++ b/apps/pops-api/src/modules/food/recipes/send-to-list/send.ts
@@ -7,6 +7,7 @@
  * insert/merge loop runs inside a single Drizzle transaction per PRD §AC.
  */
 import { type FoodDb } from '@pops/app-food-db';
+import { type ListsDb } from '@pops/app-lists-db';
 
 import { aggregateLinesForSend } from './aggregate.js';
 import { processItem } from './merge.js';
@@ -21,18 +22,22 @@ export interface SendToListInput {
   target: SendTarget;
 }
 
-export function sendToList(db: FoodDb, input: SendToListInput): SendToListResult {
-  const loaded = loadVersionForSend(db, input.versionId);
+export function sendToList(
+  foodDb: FoodDb,
+  listsDb: ListsDb,
+  input: SendToListInput
+): SendToListResult {
+  const loaded = loadVersionForSend(foodDb, input.versionId);
   if (!loaded.ok) return { ok: false, reason: loaded.reason };
   const scaleFactor = clampScaleFactor(input.scaleFactor);
-  const aggregate = aggregateLinesForSend(db, input.versionId, scaleFactor);
+  const aggregate = aggregateLinesForSend(foodDb, input.versionId, scaleFactor);
   const items = buildSendItems(aggregate);
   if (items.length === 0) return { ok: false, reason: 'NoIngredients' };
-  return db.transaction((tx) => writeItems(tx, items, input.target, loaded.version.title));
+  return listsDb.transaction((tx) => writeItems(tx, items, input.target, loaded.version.title));
 }
 
 function writeItems(
-  tx: FoodDb,
+  tx: ListsDb,
   items: readonly SendItem[],
   target: SendTarget,
   recipeTitle: string

--- a/apps/pops-api/src/modules/food/recipes/send-to-list/target-resolve.ts
+++ b/apps/pops-api/src/modules/food/recipes/send-to-list/target-resolve.ts
@@ -7,8 +7,7 @@
  */
 import { eq } from 'drizzle-orm';
 
-import { type FoodDb } from '@pops/app-food-db';
-import { createList, lists } from '@pops/app-lists-db';
+import { createList, type ListsDb, lists } from '@pops/app-lists-db';
 
 import { type SendTarget, type SendToListError } from './types.js';
 
@@ -16,14 +15,14 @@ export type ResolveTargetResult =
   | { ok: true; listId: number; isNew: boolean }
   | { ok: false; reason: SendToListError };
 
-export function resolveTarget(db: FoodDb, target: SendTarget): ResolveTargetResult {
+export function resolveTarget(db: ListsDb, target: SendTarget): ResolveTargetResult {
   if (target.kind === 'existing') {
     return resolveExisting(db, target.listId);
   }
   return resolveNew(db, target.name);
 }
 
-function resolveExisting(db: FoodDb, listId: number): ResolveTargetResult {
+function resolveExisting(db: ListsDb, listId: number): ResolveTargetResult {
   const row = db.select().from(lists).where(eq(lists.id, listId)).all()[0];
   if (row === undefined) return { ok: false, reason: 'TargetListNotFound' };
   if (row.archivedAt !== null) return { ok: false, reason: 'TargetListArchived' };
@@ -31,7 +30,7 @@ function resolveExisting(db: FoodDb, listId: number): ResolveTargetResult {
   return { ok: true, listId, isNew: false };
 }
 
-function resolveNew(db: FoodDb, rawName: string): ResolveTargetResult {
+function resolveNew(db: ListsDb, rawName: string): ResolveTargetResult {
   const name = rawName.trim();
   if (name.length === 0) return { ok: false, reason: 'NameRequiredForNew' };
   const row = createList(db, { name, kind: 'shopping', ownerApp: 'food' });


### PR DESCRIPTION
## Summary

- Splits `food.recipes.prepareSendToList` + `sendToList` so recipe reads go through the food handle (`FoodDb`) and list/list_items reads + writes go through the lists handle (`ListsDb`). The transactional insert/merge loop now runs inside `listsDb.transaction()`.
- Router passes both `getDrizzle()` (food side) and `getListsDrizzle()` (lists side); `target-resolve` / `merge` / `already-sent` are typed against `ListsDb` and no longer touch `@pops/app-food-db`.
- Removes the last food → lists cross-pillar dependency on the shared `pops.db` handle. Unblocks LISTS PR4 (2-table migration becomes ship-ready).

## Test plan

- [x] `pnpm test send-to-list` — all 21 PRD-142 integration tests pass (the suite now also wires `setListsDb` to the in-memory test DB)
- [x] `pnpm test src/modules/food` — all 339 food module tests pass
- [x] `pnpm typecheck` — clean
- [x] husky pre-commit + pre-push ran (no `--no-verify`)
