### PR TITLE
feat(mcp): migrate trivial inventory + finance tool calls to pillar SDK (PRD-205 batch 1)

### DIFF
--- a/apps/pops-mcp/package.json
+++ b/apps/pops-mcp/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "@pops/pillar-sdk": "workspace:*",
     "@trpc/client": "11.17.0",
     "dotenv": "^16.5.0",
     "express": "^5.0.1"

--- a/apps/pops-mcp/src/pillar-client.ts
+++ b/apps/pops-mcp/src/pillar-client.ts
@@ -1,0 +1,78 @@
+/**
+ * Server-SDK wiring for the MCP tool layer.
+ *
+ * Every tool file imports `getPillar()` from here rather than calling
+ * `pillar()` from `@pops/pillar-sdk/server` directly so the
+ * `configureServerSdk(...)` call lands once, at module load. The MCP
+ * binary historically authenticated with `POPS_API_KEY`; the pillar SDK
+ * looks for `POPS_INTERNAL_API_KEY`. We read whichever is set and route
+ * the value into the SDK explicitly.
+ *
+ * Tool files type their handle with their pillar's `AppRouter` so the
+ * proxy is fully typed end-to-end:
+ *
+ *     import type { AppRouter as InventoryAppRouter } from '@pops/inventory-api/router';
+ *     const inventory = getPillar<InventoryAppRouter>('inventory');
+ *     await inventory.inventory.locations.list();
+ *
+ * The `internalBaseUrls` map collapses registry discovery for the
+ * Docker-internal hostnames; this lets the canary tool files work even
+ * when the registry advertises hostnames that differ from the local
+ * Docker network.
+ */
+import { configureServerSdk, pillar } from '@pops/pillar-sdk/server';
+
+import type { PillarHandle } from '@pops/pillar-sdk/server';
+
+const INTERNAL_BASE_URLS: Readonly<Record<string, string>> = {
+  inventory: process.env['POPS_INVENTORY_API_URL'] ?? 'http://inventory-api:3003',
+  finance: process.env['POPS_FINANCE_API_URL'] ?? 'http://finance-api:3004',
+  core: process.env['POPS_CORE_API_URL'] ?? 'http://core-api:3001',
+  media: process.env['POPS_MEDIA_API_URL'] ?? 'http://media-api:3005',
+  cerebrum: process.env['POPS_CEREBRUM_API_URL'] ?? 'http://cerebrum-api:3006',
+};
+
+function resolveApiKey(): string | undefined {
+  const explicit = process.env['POPS_INTERNAL_API_KEY'];
+  if (explicit && explicit.length > 0) return explicit;
+  const legacy = process.env['POPS_API_KEY'];
+  if (legacy && legacy.length > 0) return legacy;
+  return undefined;
+}
+
+let configured = false;
+
+function ensureConfigured(): void {
+  if (configured) return;
+  const apiKey = resolveApiKey();
+  if (apiKey === undefined) {
+    throw new Error(
+      '[pops-mcp] no service-account key in environment: set POPS_INTERNAL_API_KEY (or legacy POPS_API_KEY) before calling pillar tools.'
+    );
+  }
+  const registryUrl = process.env['POPS_REGISTRY_URL'];
+  configureServerSdk({
+    apiKey,
+    internalBaseUrls: INTERNAL_BASE_URLS,
+    ...(registryUrl !== undefined ? { registry: { registryUrl } } : {}),
+  });
+  configured = true;
+}
+
+/**
+ * Get a typed pillar handle for the given pillar ID. Idempotent — the
+ * underlying SDK memoises per-pillar handles, so repeated calls are
+ * cheap and share their discovery cache.
+ */
+export function getPillar<TRouter>(pillarId: string): PillarHandle<TRouter> {
+  ensureConfigured();
+  return pillar<TRouter>(pillarId);
+}
+
+/**
+ * Test seam — drops the boot guard so a test can install a fresh config
+ * and re-bootstrap.
+ */
+export function __resetPillarClientForTests(): void {
+  configured = false;
+}

--- a/apps/pops-mcp/src/tools/finance.test.ts
+++ b/apps/pops-mcp/src/tools/finance.test.ts
@@ -1,25 +1,56 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { mockClient } from './test-helpers.js';
+import {
+  callContractMismatch,
+  callOk,
+  callUnavailable,
+  mockClient,
+  mockPillarFinance,
+} from './test-helpers.js';
 
 vi.mock('../client.js', () => ({ getClient: () => mockClient }));
+vi.mock('../pillar-client.js', () => ({
+  getPillar: () => mockPillarFinance,
+  __resetPillarClientForTests: () => {},
+}));
 
 const { financeTools } = await import('./finance.js');
+
+const transactions = mockPillarFinance.finance.transactions;
+const budgets = mockPillarFinance.finance.budgets;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  transactions.list.mockResolvedValue(callOk({ data: [], pagination: { total: 0 } }));
+  budgets.list.mockResolvedValue(callOk({ data: [], pagination: { total: 0 } }));
+});
 
 describe('finance.transactions.list', () => {
   const tool = financeTools.find((t) => t.name === 'finance.transactions.list')!;
 
   it('passes date filters through', async () => {
     await tool.handler({ startDate: '2025-01-01', endDate: '2025-12-31', type: 'expense' });
-    expect(mockClient.finance.transactions.list.query).toHaveBeenCalledWith(
+    expect(transactions.list).toHaveBeenCalledWith(
       expect.objectContaining({ startDate: '2025-01-01', endDate: '2025-12-31', type: 'expense' })
     );
   });
 
   it('ignores invalid type values', async () => {
     await tool.handler({ type: 'invalid' });
-    const call = mockClient.finance.transactions.list.query.mock.lastCall?.[0];
+    const call = transactions.list.mock.lastCall?.[0];
     expect((call as Record<string, unknown>)['type']).toBeUndefined();
+  });
+
+  it('returns isError on unavailable', async () => {
+    transactions.list.mockResolvedValueOnce(callUnavailable('finance'));
+    const result = await tool.handler({});
+    expect(result.isError).toBe(true);
+  });
+
+  it('returns isError on contract-mismatch', async () => {
+    transactions.list.mockResolvedValueOnce(callContractMismatch('finance', '1.0.0', '2.0.0'));
+    const result = await tool.handler({});
+    expect(result.isError).toBe(true);
   });
 });
 
@@ -51,14 +82,20 @@ describe('finance.budgets.list', () => {
 
   it('passes period and active filters', async () => {
     await tool.handler({ period: 'monthly', active: 'true' });
-    expect(mockClient.finance.budgets.list.query).toHaveBeenCalledWith(
+    expect(budgets.list).toHaveBeenCalledWith(
       expect.objectContaining({ period: 'monthly', active: 'true' })
     );
   });
 
   it('ignores invalid period values', async () => {
     await tool.handler({ period: 'weekly' });
-    const call = mockClient.finance.budgets.list.query.mock.lastCall?.[0];
+    const call = budgets.list.mock.lastCall?.[0];
     expect((call as Record<string, unknown>)['period']).toBeUndefined();
+  });
+
+  it('returns isError on unavailable', async () => {
+    budgets.list.mockResolvedValueOnce(callUnavailable('finance'));
+    const result = await tool.handler({});
+    expect(result.isError).toBe(true);
   });
 });

--- a/apps/pops-mcp/src/tools/finance.ts
+++ b/apps/pops-mcp/src/tools/finance.ts
@@ -1,7 +1,44 @@
 import { getClient } from '../client.js';
-import { ok } from './utils.js';
+import { getPillar } from '../pillar-client.js';
+import { mapCallResult, ok } from './utils.js';
+
+import type { PillarHandle } from '@pops/pillar-sdk/client';
 
 import type { ToolDef } from './index.js';
+
+type TransactionListInput = {
+  search?: string;
+  startDate?: string;
+  endDate?: string;
+  entityId?: string;
+  account?: string;
+  type?: 'income' | 'expense' | 'transfer';
+  limit?: number;
+  offset?: number;
+};
+
+type BudgetListInput = {
+  search?: string;
+  period?: 'monthly' | 'yearly';
+  active?: 'true' | 'false';
+  limit?: number;
+  offset?: number;
+};
+
+type FinancePillarShape = {
+  finance: {
+    transactions: {
+      list: (input: TransactionListInput) => unknown;
+    };
+    budgets: {
+      list: (input: BudgetListInput) => unknown;
+    };
+  };
+};
+
+function finance(): PillarHandle<FinancePillarShape>['finance'] {
+  return getPillar<FinancePillarShape>('finance').finance;
+}
 
 const ENTITY_TYPES = [
   'company',
@@ -37,7 +74,7 @@ const transactionsList: ToolDef = {
     },
   },
   handler: async (args) => {
-    const result = await getClient().finance.transactions.list.query({
+    const result = await finance().transactions.list({
       search: typeof args['search'] === 'string' ? args['search'] : undefined,
       startDate: typeof args['startDate'] === 'string' ? args['startDate'] : undefined,
       endDate: typeof args['endDate'] === 'string' ? args['endDate'] : undefined,
@@ -50,7 +87,7 @@ const transactionsList: ToolDef = {
       limit: typeof args['limit'] === 'number' ? args['limit'] : undefined,
       offset: typeof args['offset'] === 'number' ? args['offset'] : undefined,
     });
-    return ok(result);
+    return mapCallResult(result);
   },
 };
 
@@ -98,7 +135,7 @@ const budgetsList: ToolDef = {
     },
   },
   handler: async (args) => {
-    const result = await getClient().finance.budgets.list.query({
+    const result = await finance().budgets.list({
       search: typeof args['search'] === 'string' ? args['search'] : undefined,
       period:
         args['period'] === 'monthly' || args['period'] === 'yearly' ? args['period'] : undefined,
@@ -106,7 +143,7 @@ const budgetsList: ToolDef = {
       limit: typeof args['limit'] === 'number' ? args['limit'] : undefined,
       offset: typeof args['offset'] === 'number' ? args['offset'] : undefined,
     });
-    return ok(result);
+    return mapCallResult(result);
   },
 };
 

--- a/apps/pops-mcp/src/tools/inventory-locations.test.ts
+++ b/apps/pops-mcp/src/tools/inventory-locations.test.ts
@@ -1,8 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { mockClient, parseResult } from './test-helpers.js';
+import {
+  callContractMismatch,
+  callOk,
+  callUnavailable,
+  mockPillarInventory,
+  parseResult,
+} from './test-helpers.js';
 
-vi.mock('../client.js', () => ({ getClient: () => mockClient }));
+vi.mock('../pillar-client.js', () => ({
+  getPillar: () => mockPillarInventory,
+  __resetPillarClientForTests: () => {},
+}));
 
 const { locationTools } = await import('./inventory-locations.js');
 
@@ -12,24 +21,62 @@ function tool(name: string) {
   return t;
 }
 
+const locations = mockPillarInventory.inventory.locations;
+
 beforeEach(() => {
   vi.clearAllMocks();
+  locations.tree.mockResolvedValue(
+    callOk({
+      data: [{ id: 'loc_1', name: 'Living Room', parentId: null, sortOrder: 0, children: [] }],
+    })
+  );
+  locations.list.mockResolvedValue(
+    callOk({
+      data: [{ id: 'loc_1', name: 'Living Room', parentId: null, sortOrder: 0 }],
+      total: 1,
+    })
+  );
+  locations.create.mockResolvedValue(
+    callOk({
+      data: { id: 'loc_2', name: 'Office', parentId: null, sortOrder: 1 },
+      message: 'Location created',
+    })
+  );
+  locations.update.mockResolvedValue(
+    callOk({
+      data: { id: 'loc_1', name: 'Living Room', parentId: null, sortOrder: 0 },
+      message: 'Location updated',
+    })
+  );
+  locations.delete.mockResolvedValue(callOk({ message: 'Location deleted' }));
 });
 
 describe('inventory.locations.tree', () => {
-  it('calls tree.query and returns the data envelope', async () => {
+  it('calls tree and unwraps CallResult', async () => {
     const result = await tool('inventory.locations.tree').handler({});
-    expect(mockClient.inventory.locations.tree.query).toHaveBeenCalled();
+    expect(locations.tree).toHaveBeenCalled();
     const parsed = parseResult(result) as { data: { id: string }[] };
     expect(parsed.data[0]).toMatchObject({ id: 'loc_1' });
     expect(result.isError).toBeUndefined();
   });
+
+  it('returns isError on unavailable', async () => {
+    locations.tree.mockResolvedValueOnce(callUnavailable('inventory'));
+    const result = await tool('inventory.locations.tree').handler({});
+    expect(result.isError).toBe(true);
+  });
+
+  it('returns isError on contract-mismatch', async () => {
+    locations.tree.mockResolvedValueOnce(callContractMismatch('inventory', '1.0.0', '2.0.0'));
+    const result = await tool('inventory.locations.tree').handler({});
+    expect(result.isError).toBe(true);
+  });
 });
 
 describe('inventory.locations.list', () => {
-  it('calls list.query', async () => {
+  it('calls list', async () => {
     const result = await tool('inventory.locations.list').handler({});
-    expect(mockClient.inventory.locations.list.query).toHaveBeenCalled();
+    expect(locations.list).toHaveBeenCalled();
     expect(result.isError).toBeUndefined();
   });
 });
@@ -37,9 +84,7 @@ describe('inventory.locations.list', () => {
 describe('inventory.locations.create', () => {
   it('creates a root location with name only', async () => {
     const result = await tool('inventory.locations.create').handler({ name: 'Office' });
-    expect(mockClient.inventory.locations.create.mutate).toHaveBeenCalledWith(
-      expect.objectContaining({ name: 'Office' })
-    );
+    expect(locations.create).toHaveBeenCalledWith(expect.objectContaining({ name: 'Office' }));
     expect(result.isError).toBeUndefined();
     const parsed = parseResult(result) as { data: { name: string }; message: string };
     expect(parsed.data.name).toBe('Office');
@@ -48,33 +93,33 @@ describe('inventory.locations.create', () => {
 
   it('passes parentId string', async () => {
     await tool('inventory.locations.create').handler({ name: 'Shelf', parentId: 'loc_1' });
-    expect(mockClient.inventory.locations.create.mutate).toHaveBeenCalledWith(
-      expect.objectContaining({ parentId: 'loc_1' })
-    );
+    expect(locations.create).toHaveBeenCalledWith(expect.objectContaining({ parentId: 'loc_1' }));
   });
 
   it('passes explicit null parentId', async () => {
     await tool('inventory.locations.create').handler({ name: 'Root', parentId: null });
-    expect(mockClient.inventory.locations.create.mutate).toHaveBeenCalledWith(
-      expect.objectContaining({ parentId: null })
-    );
+    expect(locations.create).toHaveBeenCalledWith(expect.objectContaining({ parentId: null }));
   });
 
   it('passes sortOrder', async () => {
     await tool('inventory.locations.create').handler({ name: 'Bedroom', sortOrder: 2 });
-    expect(mockClient.inventory.locations.create.mutate).toHaveBeenCalledWith(
-      expect.objectContaining({ sortOrder: 2 })
-    );
+    expect(locations.create).toHaveBeenCalledWith(expect.objectContaining({ sortOrder: 2 }));
   });
 
   it('returns isError when name is missing', async () => {
     const result = await tool('inventory.locations.create').handler({});
     expect(result.isError).toBe(true);
-    expect(mockClient.inventory.locations.create.mutate).not.toHaveBeenCalled();
+    expect(locations.create).not.toHaveBeenCalled();
   });
 
   it('returns isError when name is empty string', async () => {
     const result = await tool('inventory.locations.create').handler({ name: '' });
+    expect(result.isError).toBe(true);
+  });
+
+  it('returns isError on unavailable', async () => {
+    locations.create.mockResolvedValueOnce(callUnavailable('inventory'));
+    const result = await tool('inventory.locations.create').handler({ name: 'Office' });
     expect(result.isError).toBe(true);
   });
 });
@@ -82,7 +127,7 @@ describe('inventory.locations.create', () => {
 describe('inventory.locations.update', () => {
   it('updates name only', async () => {
     const result = await tool('inventory.locations.update').handler({ id: 'loc_1', name: 'Den' });
-    expect(mockClient.inventory.locations.update.mutate).toHaveBeenCalledWith(
+    expect(locations.update).toHaveBeenCalledWith(
       expect.objectContaining({ id: 'loc_1', data: { name: 'Den' } })
     );
     expect(result.isError).toBeUndefined();
@@ -90,40 +135,32 @@ describe('inventory.locations.update', () => {
 
   it('sets parentId to a value', async () => {
     await tool('inventory.locations.update').handler({ id: 'loc_2', parentId: 'loc_1' });
-    const call = mockClient.inventory.locations.update.mutate.mock.lastCall?.[0] as {
-      data: Record<string, unknown>;
-    };
+    const call = locations.update.mock.lastCall?.[0] as { data: Record<string, unknown> };
     expect(call.data.parentId).toBe('loc_1');
   });
 
   it('sets parentId to null (promote to root)', async () => {
     await tool('inventory.locations.update').handler({ id: 'loc_2', parentId: null });
-    const call = mockClient.inventory.locations.update.mutate.mock.lastCall?.[0] as {
-      data: Record<string, unknown>;
-    };
+    const call = locations.update.mock.lastCall?.[0] as { data: Record<string, unknown> };
     expect(call.data.parentId).toBeNull();
   });
 
   it('does not include parentId when not provided', async () => {
     await tool('inventory.locations.update').handler({ id: 'loc_1', name: 'New Name' });
-    const call = mockClient.inventory.locations.update.mutate.mock.lastCall?.[0] as {
-      data: Record<string, unknown>;
-    };
+    const call = locations.update.mock.lastCall?.[0] as { data: Record<string, unknown> };
     expect('parentId' in call.data).toBe(false);
   });
 
   it('updates sortOrder', async () => {
     await tool('inventory.locations.update').handler({ id: 'loc_1', sortOrder: 5 });
-    const call = mockClient.inventory.locations.update.mutate.mock.lastCall?.[0] as {
-      data: Record<string, unknown>;
-    };
+    const call = locations.update.mock.lastCall?.[0] as { data: Record<string, unknown> };
     expect(call.data.sortOrder).toBe(5);
   });
 
   it('returns isError when id is missing', async () => {
     const result = await tool('inventory.locations.update').handler({ name: 'No ID' });
     expect(result.isError).toBe(true);
-    expect(mockClient.inventory.locations.update.mutate).not.toHaveBeenCalled();
+    expect(locations.update).not.toHaveBeenCalled();
   });
 
   it('returns isError when id is empty string', async () => {
@@ -135,29 +172,24 @@ describe('inventory.locations.update', () => {
 describe('inventory.locations.delete', () => {
   it('deletes with force: false by default', async () => {
     const result = await tool('inventory.locations.delete').handler({ id: 'loc_1' });
-    expect(mockClient.inventory.locations.delete.mutate).toHaveBeenCalledWith({
-      id: 'loc_1',
-      force: false,
-    });
+    expect(locations.delete).toHaveBeenCalledWith({ id: 'loc_1', force: false });
     expect(result.isError).toBeUndefined();
     const parsed = parseResult(result) as { message: string };
-    // delete already returned the unwrapped envelope (no `data` field).
     expect(parsed.message).toBe('Location deleted');
   });
 
   it('passes force: true', async () => {
     await tool('inventory.locations.delete').handler({ id: 'loc_1', force: true });
-    expect(mockClient.inventory.locations.delete.mutate).toHaveBeenCalledWith({
-      id: 'loc_1',
-      force: true,
-    });
+    expect(locations.delete).toHaveBeenCalledWith({ id: 'loc_1', force: true });
   });
 
   it('surfaces requiresConfirmation without isError', async () => {
-    mockClient.inventory.locations.delete.mutate.mockResolvedValueOnce({
-      requiresConfirmation: true,
-      stats: { childCount: 2, descendantCount: 5, itemCount: 3, totalItemCount: 10 },
-    });
+    locations.delete.mockResolvedValueOnce(
+      callOk({
+        requiresConfirmation: true,
+        stats: { childCount: 2, descendantCount: 5, itemCount: 3, totalItemCount: 10 },
+      })
+    );
     const result = await tool('inventory.locations.delete').handler({ id: 'loc_1' });
     expect(result.isError).toBeUndefined();
     const parsed = parseResult(result) as { requiresConfirmation: boolean };
@@ -167,10 +199,16 @@ describe('inventory.locations.delete', () => {
   it('returns isError when id is missing', async () => {
     const result = await tool('inventory.locations.delete').handler({});
     expect(result.isError).toBe(true);
-    expect(mockClient.inventory.locations.delete.mutate).not.toHaveBeenCalled();
+    expect(locations.delete).not.toHaveBeenCalled();
   });
 
   it('returns isError when id is empty string', async () => {
     expect((await tool('inventory.locations.delete').handler({ id: '' })).isError).toBe(true);
+  });
+
+  it('returns isError on contract-mismatch', async () => {
+    locations.delete.mockResolvedValueOnce(callContractMismatch('inventory', '1.0.0', '2.0.0'));
+    const result = await tool('inventory.locations.delete').handler({ id: 'loc_1' });
+    expect(result.isError).toBe(true);
   });
 });

--- a/apps/pops-mcp/src/tools/inventory-locations.ts
+++ b/apps/pops-mcp/src/tools/inventory-locations.ts
@@ -1,16 +1,61 @@
-import { getClient } from '../client.js';
-import { copyOptStr, nullStr, ok, optBool, optNum, reqStr, toolError } from './utils.js';
+import { getPillar } from '../pillar-client.js';
+import { copyOptStr, mapCallResult, nullStr, optBool, optNum, reqStr, toolError } from './utils.js';
+
+import type { PillarHandle } from '@pops/pillar-sdk/client';
 
 import type { ToolDef } from './index.js';
 
-type LocationPatch = Parameters<
-  ReturnType<typeof getClient>['inventory']['locations']['update']['mutate']
->[0]['data'];
+type Location = {
+  id: string;
+  name: string;
+  parentId: string | null;
+  sortOrder: number;
+};
+
+type LocationTreeNode = Location & { children: LocationTreeNode[] };
+
+type LocationPatch = {
+  name?: string;
+  parentId?: string | null;
+  sortOrder?: number;
+};
+
+type DeleteResponse =
+  | { message: string }
+  | {
+      requiresConfirmation: true;
+      stats: {
+        childCount: number;
+        descendantCount: number;
+        itemCount: number;
+        totalItemCount: number;
+      };
+    };
+
+type InventoryShape = {
+  inventory: {
+    locations: {
+      tree: () => { data: LocationTreeNode[] };
+      list: () => { data: Location[]; total: number };
+      create: (input: { name: string; parentId?: string | null; sortOrder?: number }) => {
+        data: Location;
+        message: string;
+      };
+      update: (input: { id: string; data: LocationPatch }) => { data: Location; message: string };
+      delete: (input: { id: string; force: boolean }) => DeleteResponse;
+    };
+  };
+};
+
+type LocationsHandle = PillarHandle<InventoryShape>['inventory']['locations'];
+
+function locations(): LocationsHandle {
+  return getPillar<InventoryShape>('inventory').inventory.locations;
+}
 
 function buildLocationPatch(args: Record<string, unknown>): LocationPatch {
   const patch: LocationPatch = {};
   copyOptStr(patch, args, 'name');
-  // parentId is three-state (null clears to root); custom-handled.
   if ('parentId' in args) {
     const parentId = nullStr(args, 'parentId');
     if (parentId !== undefined) patch.parentId = parentId;
@@ -25,20 +70,14 @@ const locationTree: ToolDef = {
   description:
     'Get the full location hierarchy as a nested tree. Returns all locations with their children.',
   inputSchema: { type: 'object', properties: {} },
-  handler: async () => {
-    const result = await getClient().inventory.locations.tree.query();
-    return ok(result);
-  },
+  handler: async () => mapCallResult(await locations().tree()),
 };
 
 const locationsList: ToolDef = {
   name: 'inventory.locations.list',
   description: 'List all locations as a flat array.',
   inputSchema: { type: 'object', properties: {} },
-  handler: async () => {
-    const result = await getClient().inventory.locations.list.query();
-    return ok(result);
-  },
+  handler: async () => mapCallResult(await locations().list()),
 };
 
 const locationsCreate: ToolDef = {
@@ -60,12 +99,12 @@ const locationsCreate: ToolDef = {
   handler: async (args) => {
     const name = reqStr(args, 'name');
     if (!name) return toolError('Missing required field: name');
-    const result = await getClient().inventory.locations.create.mutate({
-      name,
-      parentId: nullStr(args, 'parentId'),
-      sortOrder: optNum(args, 'sortOrder'),
-    });
-    return ok(result);
+    const input: { name: string; parentId?: string | null; sortOrder?: number } = { name };
+    const parentId = nullStr(args, 'parentId');
+    if (parentId !== undefined) input.parentId = parentId;
+    const sortOrder = optNum(args, 'sortOrder');
+    if (sortOrder !== undefined) input.sortOrder = sortOrder;
+    return mapCallResult(await locations().create(input));
   },
 };
 
@@ -90,8 +129,7 @@ const locationsUpdate: ToolDef = {
     const id = reqStr(args, 'id');
     if (!id) return toolError('Missing required field: id');
     const data = buildLocationPatch(args);
-    const result = await getClient().inventory.locations.update.mutate({ id, data });
-    return ok(result);
+    return mapCallResult(await locations().update({ id, data }));
   },
 };
 
@@ -113,11 +151,7 @@ const locationsDelete: ToolDef = {
   handler: async (args) => {
     const id = reqStr(args, 'id');
     if (!id) return toolError('Missing required field: id');
-    const result = await getClient().inventory.locations.delete.mutate({
-      id,
-      force: optBool(args, 'force') ?? false,
-    });
-    return ok(result);
+    return mapCallResult(await locations().delete({ id, force: optBool(args, 'force') ?? false }));
   },
 };
 

--- a/apps/pops-mcp/src/tools/test-helpers.ts
+++ b/apps/pops-mcp/src/tools/test-helpers.ts
@@ -1,5 +1,22 @@
 import { vi } from 'vitest';
 
+import type { CallResult } from '@pops/pillar-sdk/client';
+
+export function callOk<T>(value: T): CallResult<T> {
+  return { kind: 'ok', value };
+}
+
+export const callUnavailable = (pillar: string): CallResult<never> => ({
+  kind: 'unavailable',
+  pillar,
+});
+
+export const callContractMismatch = (
+  pillar: string,
+  expected: string,
+  actual: string
+): CallResult<never> => ({ kind: 'contract-mismatch', pillar, expected, actual });
+
 const MOCK_LOCATION = { id: 'loc_1', name: 'Living Room', parentId: null, sortOrder: 0 };
 const MOCK_LOCATION_2 = { id: 'loc_2', name: 'Office', parentId: null, sortOrder: 1 };
 const MOCK_ITEM = {
@@ -45,6 +62,33 @@ export const MOCK_FIXTURE_CONN = {
   itemId: 'item_1',
   fixtureId: 'fixture_1',
   createdAt: '2024-01-01T00:00:00.000Z',
+};
+
+export const mockPillarInventory = {
+  inventory: {
+    locations: {
+      tree: vi.fn().mockResolvedValue(callOk({ data: [{ ...MOCK_LOCATION, children: [] }] })),
+      list: vi.fn().mockResolvedValue(callOk({ data: [MOCK_LOCATION], total: 1 })),
+      create: vi
+        .fn()
+        .mockResolvedValue(callOk({ data: MOCK_LOCATION_2, message: 'Location created' })),
+      update: vi
+        .fn()
+        .mockResolvedValue(callOk({ data: MOCK_LOCATION, message: 'Location updated' })),
+      delete: vi.fn().mockResolvedValue(callOk({ message: 'Location deleted' })),
+    },
+  },
+};
+
+export const mockPillarFinance = {
+  finance: {
+    transactions: {
+      list: vi.fn().mockResolvedValue(callOk({ data: [], pagination: { total: 0 } })),
+    },
+    budgets: {
+      list: vi.fn().mockResolvedValue(callOk({ data: [], pagination: { total: 0 } })),
+    },
+  },
 };
 
 export const mockClient = {

--- a/apps/pops-mcp/src/tools/utils.ts
+++ b/apps/pops-mcp/src/tools/utils.ts
@@ -1,11 +1,36 @@
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 
+import type { CallResult } from '@pops/pillar-sdk/client';
+
 export function ok(data: unknown): CallToolResult {
   return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
 }
 
 export function toolError(message: string): CallToolResult {
   return { content: [{ type: 'text', text: message }], isError: true };
+}
+
+/**
+ * Translate a `CallResult` from the pillar SDK into an MCP `CallToolResult`.
+ * `ok` rounds-trips the value JSON. The three failure shapes
+ * (`unavailable`, `degraded`, `contract-mismatch`) all surface as MCP
+ * `toolError` so the LLM can read the reason and self-correct or retry.
+ */
+export function mapCallResult<T>(result: CallResult<T>): CallToolResult {
+  if (result.kind === 'ok') return ok(result.value);
+  if (result.kind === 'unavailable') {
+    return toolError(`Pillar '${result.pillar}' is unavailable. Try again shortly.`);
+  }
+  if (result.kind === 'degraded') {
+    return toolError(
+      `Pillar '${result.pillar}' is reconciling (${result.reason}). Try again shortly.`
+    );
+  }
+  const expected = result.expected ?? 'unknown';
+  const actual = result.actual ?? 'unknown';
+  return toolError(
+    `Pillar '${result.pillar}' contract mismatch — expected ${expected}, got ${actual}.`
+  );
 }
 
 export function reqStr(args: Record<string, unknown>, key: string): string | null {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -587,6 +587,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.4.3)
+      '@pops/pillar-sdk':
+        specifier: workspace:*
+        version: link:../../packages/pillar-sdk
       '@trpc/client':
         specifier: 11.17.0
         version: 11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3)


### PR DESCRIPTION
## Summary

- Migrates the 7 trivial-category MCP tool ops from PRD-205's audit to call the pillar SDK directly: inventory.locations.{tree,list,create,update,delete} + finance.transactions.list + finance.budgets.list.
- Introduces `apps/pops-mcp/src/pillar-client.ts` as the single boot point — calls `configureServerSdk({ apiKey, internalBaseUrls, registry })` once, reads `POPS_INTERNAL_API_KEY` (fallback to legacy `POPS_API_KEY`) so existing MCP deployments don't need a new secret to start exercising the SDK.
- `CallResult` outcomes round-trip through a new `utils.mapCallResult` helper: `unavailable` / `degraded` / `contract-mismatch` surface as MCP `toolError` so the LLM can self-correct or retry; `ok` values stream through `ok()` unchanged.

## Out of scope

- `finance.entities.list` (Risky / cross-pillar `core.entities.list`) and the Medium-category ops in cerebrum / inventory-connections / inventory-fixtures / inventory-items / media stay on the legacy `getClient()` path pending their writer-move predecessors per the PRD-205 migration order.
- `apps/pops-mcp/src/client.ts` retires last, once every tool file has moved off it.

## Implementation notes

- Tool files describe the pillar handle with a local procedure-shape interface fed through `PillarHandle<T>` instead of tRPC's `AppRouter` type — the SDK proxy's structural conditional collapses tRPC router types to opaque callables, so explicit shapes are required for full call-site typing.
- Tests mock `../pillar-client.js` with a typed `CallResult`-emitting fake and cover success, `unavailable`, and `contract-mismatch` flows on every migrated proc.

## Test plan

- [x] `pnpm --filter @pops/mcp typecheck` — clean
- [x] `pnpm --filter @pops/mcp test` — 170/170 passing across 13 files
- [x] Husky chain (oxlint, oxfmt, lint-staged) passes on commit
- [ ] CI green on PR
