### PR TITLE
feat(core-db): migrate health + sync-results + inference-pricing data access (Theme 13 hot-path batch 1)

### DIFF
--- a/apps/pops-api/src/jobs/sync-results.ts
+++ b/apps/pops-api/src/jobs/sync-results.ts
@@ -1,20 +1,12 @@
 import pino from 'pino';
 
-import { syncJobResults } from '@pops/db-types';
+import { PERSISTED_SYNC_TYPES, syncResultsService } from '@pops/core-db';
 
 import { getDrizzle } from '../db.js';
 
 import type { SyncQueueJobData } from './types.js';
 
 const logger = pino({ name: 'pops-worker:sync-results' });
-
-const PERSISTED_SYNC_TYPES = new Set([
-  'plexSyncMovies',
-  'plexSyncTvShows',
-  'plexSyncWatchlist',
-  'plexSyncWatchHistory',
-  'plexSyncDiscoverWatches',
-]);
 
 export interface PersistSyncResultParams {
   jobId: string | undefined;
@@ -27,12 +19,22 @@ export interface PersistSyncResultParams {
   progress?: unknown;
 }
 
+/**
+ * Thin caller that adapts the BullMQ worker callback shape into the
+ * `@pops/core-db` `syncResultsService.persist` contract. Only the five
+ * Plex job types in {@link PERSISTED_SYNC_TYPES} are written; everything
+ * else is observed via Redis and short-circuits here.
+ *
+ * The handle is the shared `pops.db` for now because the underlying
+ * table cutover into `core.db` is sequenced behind PRD-186 PR 4. After
+ * that lands the only line that changes is `getDrizzle()` ->
+ * `getCoreDrizzle()`.
+ */
 export function persistSyncResult(params: PersistSyncResultParams): void {
   const { jobId, data, status, result, error, processedOn, finishedOn, progress } = params;
   if (!jobId || !PERSISTED_SYNC_TYPES.has(data.type)) return;
 
   try {
-    const db = getDrizzle();
     const startedAt = processedOn ? new Date(processedOn).toISOString() : new Date().toISOString();
     const completedAt = finishedOn ? new Date(finishedOn).toISOString() : new Date().toISOString();
     const durationMs = processedOn && finishedOn ? finishedOn - processedOn : null;
@@ -40,30 +42,17 @@ export function persistSyncResult(params: PersistSyncResultParams): void {
       progress != null ? JSON.stringify(progress) : JSON.stringify({ processed: 0, total: 0 });
     const resultJson = result != null ? JSON.stringify(result) : null;
 
-    db.insert(syncJobResults)
-      .values({
-        id: jobId,
-        jobType: data.type,
-        status,
-        startedAt,
-        completedAt,
-        durationMs,
-        progress: progressJson,
-        result: resultJson,
-        error,
-      })
-      .onConflictDoUpdate({
-        target: syncJobResults.id,
-        set: {
-          status,
-          completedAt,
-          durationMs,
-          progress: progressJson,
-          result: resultJson,
-          error,
-        },
-      })
-      .run();
+    syncResultsService.persist(getDrizzle(), {
+      id: jobId,
+      jobType: data.type,
+      status,
+      startedAt,
+      completedAt,
+      durationMs,
+      progressJson,
+      resultJson,
+      error,
+    });
   } catch (err) {
     logger.error({ err }, 'Failed to persist sync result');
   }

--- a/apps/pops-api/src/lib/inference-pricing.ts
+++ b/apps/pops-api/src/lib/inference-pricing.ts
@@ -1,47 +1,25 @@
-import { aiModelPricing } from '@pops/db-types';
+/**
+ * Thin re-export of the `@pops/core-db` pricing cache, bound to the
+ * shared drizzle handle. The cache + DB SELECT logic lives in
+ * `@pops/core-db`'s `ai-model-pricing` service per the Theme 13
+ * hot-path migration audit (row 5).
+ *
+ * The handle is the shared `pops.db` for now because the underlying
+ * `ai_model_pricing` table cutover into `core.db` is sequenced behind
+ * PRD-186 PR 4. After that lands the only line that changes is
+ * `getDrizzle()` -> `getCoreDrizzle()`.
+ */
+import { aiModelPricingService, type PricingCache } from '@pops/core-db';
 
 import { getDrizzle } from '../db.js';
 
-interface PricingEntry {
-  inputCostPerMtok: number;
-  outputCostPerMtok: number;
-  cachedAt: number;
-}
+let cache: PricingCache | null = null;
 
-const pricingCache = new Map<string, PricingEntry>();
-const PRICING_TTL_MS = 5 * 60 * 1000;
-
-function refreshPricingCache(now: number): void {
-  const rows = getDrizzle()
-    .select({
-      providerId: aiModelPricing.providerId,
-      modelId: aiModelPricing.modelId,
-      inputCostPerMtok: aiModelPricing.inputCostPerMtok,
-      outputCostPerMtok: aiModelPricing.outputCostPerMtok,
-    })
-    .from(aiModelPricing)
-    .all();
-  for (const row of rows) {
-    pricingCache.set(`${row.providerId}:${row.modelId}`, {
-      inputCostPerMtok: row.inputCostPerMtok,
-      outputCostPerMtok: row.outputCostPerMtok,
-      cachedAt: now,
-    });
-  }
+function getCache(): PricingCache {
+  cache ??= aiModelPricingService.createPricingCache(getDrizzle());
+  return cache;
 }
 
 export function lookupPricing(provider: string, model: string): { input: number; output: number } {
-  const key = `${provider}:${model}`;
-  const cached = pricingCache.get(key);
-  if (cached && Date.now() - cached.cachedAt < PRICING_TTL_MS) {
-    return { input: cached.inputCostPerMtok, output: cached.outputCostPerMtok };
-  }
-  try {
-    refreshPricingCache(Date.now());
-    const entry = pricingCache.get(key);
-    if (entry) return { input: entry.inputCostPerMtok, output: entry.outputCostPerMtok };
-  } catch {
-    // pricing lookup is best-effort
-  }
-  return { input: 1.0, output: 5.0 };
+  return getCache().lookup(provider, model);
 }

--- a/apps/pops-api/src/routes/health.ts
+++ b/apps/pops-api/src/routes/health.ts
@@ -1,7 +1,7 @@
 import { sql } from 'drizzle-orm';
 import { type Router as ExpressRouter, Router } from 'express';
 
-import { getDrizzle } from '../db.js';
+import { getCoreDrizzle } from '../db.js';
 import { getRedisStatus } from '../redis.js';
 
 const router: ExpressRouter = Router();
@@ -21,7 +21,7 @@ const SELF_PILLAR_ID = 'core';
 
 router.get('/health', (_req, res) => {
   try {
-    const db = getDrizzle();
+    const db = getCoreDrizzle();
     const rows = db.all<{ ok: number }>(sql`SELECT 1 AS ok`);
     if (rows[0]?.ok === 1) {
       const redisStatus = getRedisStatus();

--- a/packages/core-db/src/__tests__/ai-model-pricing.test.ts
+++ b/packages/core-db/src/__tests__/ai-model-pricing.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Invariant tests for the ai-model-pricing cache against an in-memory
+ * SQLite seeded with the `ai_model_pricing` schema inline. The table
+ * has no core-db migration file yet (PRD-186 sibling cutover owns
+ * that), so the test boots the schema directly from the canonical
+ * shape.
+ *
+ * Cache-hit + cache-miss + TTL invalidation + DB-error fallback are
+ * driven via the `now` injection point so the test is deterministic
+ * without sleeping.
+ */
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { aiModelPricing } from '../schema.js';
+import { createPricingCache } from '../services/ai-model-pricing.js';
+
+import type { CoreDb } from '../services/internal.js';
+
+const CREATE_TABLE_SQL = `
+  CREATE TABLE ai_model_pricing (
+    id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+    provider_id text NOT NULL,
+    model_id text NOT NULL,
+    display_name text,
+    input_cost_per_mtok real DEFAULT 0 NOT NULL,
+    output_cost_per_mtok real DEFAULT 0 NOT NULL,
+    context_window integer,
+    is_default integer DEFAULT 0 NOT NULL,
+    created_at text NOT NULL,
+    updated_at text NOT NULL,
+    UNIQUE(provider_id, model_id)
+  );
+`;
+
+function freshDb(): CoreDb {
+  const raw = new Database(':memory:');
+  raw.pragma('foreign_keys = ON');
+  raw.exec(CREATE_TABLE_SQL);
+  return drizzle(raw);
+}
+
+function seedClaude(db: CoreDb): void {
+  db.insert(aiModelPricing)
+    .values({
+      providerId: 'claude',
+      modelId: 'sonnet-4-5',
+      displayName: 'Claude Sonnet 4.5',
+      inputCostPerMtok: 3.0,
+      outputCostPerMtok: 15.0,
+      contextWindow: 200_000,
+      isDefault: 1,
+      createdAt: '2026-06-01T00:00:00.000Z',
+      updatedAt: '2026-06-01T00:00:00.000Z',
+    })
+    .run();
+}
+
+describe('createPricingCache', () => {
+  let db: CoreDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  describe('lookup', () => {
+    it('returns the persisted cost-per-Mtok pair on first call (cache miss -> DB refresh)', () => {
+      seedClaude(db);
+      const cache = createPricingCache(db);
+      expect(cache.lookup('claude', 'sonnet-4-5')).toEqual({ input: 3.0, output: 15.0 });
+    });
+
+    it('returns the fallback for unknown (provider, model) keys', () => {
+      seedClaude(db);
+      const cache = createPricingCache(db, { fallback: { input: 0.1, output: 0.2 } });
+      expect(cache.lookup('claude', 'unknown-model')).toEqual({ input: 0.1, output: 0.2 });
+    });
+
+    it('returns the default fallback when nothing matches and no override is supplied', () => {
+      seedClaude(db);
+      const cache = createPricingCache(db);
+      expect(cache.lookup('claude', 'unknown-model')).toEqual({ input: 1.0, output: 5.0 });
+    });
+
+    it('serves a cache hit without re-reading the DB while within the TTL window', () => {
+      seedClaude(db);
+      const selectSpy = vi.spyOn(db, 'select');
+      const cache = createPricingCache(db, { ttlMs: 1_000, now: () => 1_000 });
+      expect(cache.lookup('claude', 'sonnet-4-5')).toEqual({ input: 3.0, output: 15.0 });
+      const callsAfterFirst = selectSpy.mock.calls.length;
+      expect(cache.lookup('claude', 'sonnet-4-5')).toEqual({ input: 3.0, output: 15.0 });
+      expect(selectSpy.mock.calls.length).toBe(callsAfterFirst);
+    });
+
+    it('treats an entry older than the TTL as a miss and re-reads the DB', () => {
+      seedClaude(db);
+      let now = 1_000;
+      const cache = createPricingCache(db, { ttlMs: 1_000, now: () => now });
+      cache.lookup('claude', 'sonnet-4-5');
+      const selectSpy = vi.spyOn(db, 'select');
+
+      now = 1_500;
+      cache.lookup('claude', 'sonnet-4-5');
+      expect(selectSpy).not.toHaveBeenCalled();
+
+      now = 2_500;
+      cache.lookup('claude', 'sonnet-4-5');
+      expect(selectSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('picks up pricing edits on the next miss after the TTL expires', () => {
+      seedClaude(db);
+      let now = 0;
+      const cache = createPricingCache(db, { ttlMs: 1_000, now: () => now });
+      expect(cache.lookup('claude', 'sonnet-4-5').input).toBe(3.0);
+
+      db.$client.exec(`UPDATE ai_model_pricing SET input_cost_per_mtok = 4.0`);
+
+      now = 5_000;
+      expect(cache.lookup('claude', 'sonnet-4-5').input).toBe(4.0);
+    });
+
+    it('falls back when the DB refresh throws and the cache is cold', () => {
+      const cache = createPricingCache(db, { fallback: { input: 9, output: 99 } });
+      vi.spyOn(db, 'select').mockImplementationOnce(() => {
+        throw new Error('boom');
+      });
+      expect(cache.lookup('claude', 'sonnet-4-5')).toEqual({ input: 9, output: 99 });
+    });
+  });
+
+  describe('clear', () => {
+    it('drops the cache so the next lookup triggers a DB refresh', () => {
+      seedClaude(db);
+      const cache = createPricingCache(db, { ttlMs: 60_000 });
+      cache.lookup('claude', 'sonnet-4-5');
+      cache.clear();
+      const selectSpy = vi.spyOn(db, 'select');
+      cache.lookup('claude', 'sonnet-4-5');
+      expect(selectSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/core-db/src/__tests__/sync-results.test.ts
+++ b/packages/core-db/src/__tests__/sync-results.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Invariant tests for the sync-results service against an in-memory
+ * SQLite seeded with the `sync_job_results` schema inline. The table
+ * has no core-db migration file yet (PRD-186 sibling cutover owns
+ * that), so the test boots the schema directly from the canonical
+ * shape.
+ */
+import Database from 'better-sqlite3';
+import { eq } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { syncJobResults } from '../schema.js';
+import {
+  PERSISTED_SYNC_TYPES,
+  persist,
+  type PersistSyncResultInput,
+} from '../services/sync-results.js';
+
+import type { CoreDb } from '../services/internal.js';
+
+const CREATE_TABLE_SQL = `
+  CREATE TABLE sync_job_results (
+    id text PRIMARY KEY NOT NULL,
+    job_type text NOT NULL,
+    status text NOT NULL,
+    started_at text NOT NULL,
+    completed_at text,
+    duration_ms integer,
+    progress text,
+    result text,
+    error text,
+    created_at text NOT NULL DEFAULT (datetime('now'))
+  );
+  CREATE INDEX idx_sync_job_results_type_completed ON sync_job_results (job_type, completed_at);
+`;
+
+function freshDb(): CoreDb {
+  const raw = new Database(':memory:');
+  raw.pragma('foreign_keys = ON');
+  raw.exec(CREATE_TABLE_SQL);
+  return drizzle(raw);
+}
+
+function baseInput(overrides: Partial<PersistSyncResultInput> = {}): PersistSyncResultInput {
+  return {
+    id: 'job-1',
+    jobType: 'plexSyncMovies',
+    status: 'completed',
+    startedAt: '2026-06-01T10:00:00.000Z',
+    completedAt: '2026-06-01T10:00:30.000Z',
+    durationMs: 30_000,
+    progressJson: JSON.stringify({ processed: 10, total: 10 }),
+    resultJson: JSON.stringify({ added: 5, updated: 5 }),
+    error: null,
+    ...overrides,
+  };
+}
+
+describe('PERSISTED_SYNC_TYPES', () => {
+  it('contains the five Plex sync job types', () => {
+    expect([...PERSISTED_SYNC_TYPES].toSorted()).toEqual([
+      'plexSyncDiscoverWatches',
+      'plexSyncMovies',
+      'plexSyncTvShows',
+      'plexSyncWatchHistory',
+      'plexSyncWatchlist',
+    ]);
+  });
+});
+
+describe('persist', () => {
+  let db: CoreDb;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('inserts a completed row with the supplied fields', () => {
+    persist(db, baseInput());
+    const row = db.select().from(syncJobResults).where(eq(syncJobResults.id, 'job-1')).get();
+    expect(row).toMatchObject({
+      id: 'job-1',
+      jobType: 'plexSyncMovies',
+      status: 'completed',
+      startedAt: '2026-06-01T10:00:00.000Z',
+      completedAt: '2026-06-01T10:00:30.000Z',
+      durationMs: 30_000,
+      progress: JSON.stringify({ processed: 10, total: 10 }),
+      result: JSON.stringify({ added: 5, updated: 5 }),
+      error: null,
+    });
+  });
+
+  it('inserts a failed row with the error message and null result', () => {
+    persist(db, baseInput({ status: 'failed', error: 'boom', resultJson: null }));
+    const row = db.select().from(syncJobResults).where(eq(syncJobResults.id, 'job-1')).get();
+    expect(row?.status).toBe('failed');
+    expect(row?.error).toBe('boom');
+    expect(row?.result).toBeNull();
+  });
+
+  it('upserts on the second call with the same id (overwrites status + result)', () => {
+    persist(db, baseInput({ status: 'failed', error: 'transient', resultJson: null }));
+    persist(
+      db,
+      baseInput({
+        status: 'completed',
+        error: null,
+        resultJson: JSON.stringify({ added: 1 }),
+        completedAt: '2026-06-01T10:00:45.000Z',
+        durationMs: 45_000,
+      })
+    );
+    const rows = db.select().from(syncJobResults).all();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      id: 'job-1',
+      status: 'completed',
+      error: null,
+      completedAt: '2026-06-01T10:00:45.000Z',
+      durationMs: 45_000,
+      result: JSON.stringify({ added: 1 }),
+    });
+  });
+
+  it('persists a null duration and null result without falling back to defaults', () => {
+    persist(db, baseInput({ durationMs: null, resultJson: null }));
+    const row = db.select().from(syncJobResults).where(eq(syncJobResults.id, 'job-1')).get();
+    expect(row?.durationMs).toBeNull();
+    expect(row?.result).toBeNull();
+  });
+
+  it('keeps separate rows for distinct ids', () => {
+    persist(db, baseInput({ id: 'job-1' }));
+    persist(db, baseInput({ id: 'job-2', jobType: 'plexSyncTvShows' }));
+    const rows = db.select().from(syncJobResults).all();
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => r.id).toSorted()).toEqual(['job-1', 'job-2']);
+  });
+});

--- a/packages/core-db/src/index.ts
+++ b/packages/core-db/src/index.ts
@@ -22,6 +22,13 @@ export * as serviceAccountKeys from './services/service-account-keys.js';
 export * as pillarRegistryService from './services/pillar-registry.js';
 export * as settingsService from './services/settings.js';
 export * as aiUsageService from './services/ai-usage.js';
+export * as syncResultsService from './services/sync-results.js';
+export * as aiModelPricingService from './services/ai-model-pricing.js';
+
+export type { PersistSyncResultInput } from './services/sync-results.js';
+export { PERSISTED_SYNC_TYPES } from './services/sync-results.js';
+
+export type { ModelPrice, PricingCache } from './services/ai-model-pricing.js';
 
 export type {
   ApplyStatusUpdate,

--- a/packages/core-db/src/schema.ts
+++ b/packages/core-db/src/schema.ts
@@ -14,7 +14,9 @@ export {
   aiBudgets,
   aiInferenceDaily,
   aiInferenceLog,
+  aiModelPricing,
   pillarRegistry,
   serviceAccounts,
   settings,
+  syncJobResults,
 } from '@pops/db-types';

--- a/packages/core-db/src/services/ai-model-pricing.ts
+++ b/packages/core-db/src/services/ai-model-pricing.ts
@@ -1,0 +1,122 @@
+/**
+ * `ai_model_pricing` lookup with a per-process in-memory cache.
+ *
+ * The inference middleware needs cheap, synchronous access to the
+ * (input, output) cost-per-Mtok pair on every provider call. A bare
+ * SELECT-all into a `Map` keyed by `${providerId}:${modelId}` is
+ * sufficient — the table is small (one row per priced model) and the
+ * cache TTL (default 5 minutes) bounds staleness when ops edit pricing
+ * via the dashboard.
+ *
+ * Per `docs/themes/13-pillar-finale/notes/infra-hot-path-migration.md`
+ * row 5 the `ai_model_pricing` table is owned by the core pillar (per
+ * PRD-186). This module is the SDK surface for that ownership; the
+ * physical table cutover from the shared `pops.db` into `core.db` lands
+ * with the PRD-186 sibling PR.
+ *
+ * Cache invariants:
+ *   - Each `(providerId, modelId)` key remembers the timestamp at which
+ *     it was populated.
+ *   - A cache hit on a non-expired key skips the DB entirely.
+ *   - A miss (either no entry or an expired one) triggers a full
+ *     SELECT-all refresh; the refresh re-stamps every populated key, so
+ *     subsequent unrelated lookups within the TTL window remain hits.
+ *   - On DB error the lookup returns the configured fallback price —
+ *     pricing data is best-effort because the inference call itself is
+ *     more important than precise cost attribution.
+ */
+import { aiModelPricing } from '../schema.js';
+
+import type { CoreDb } from './internal.js';
+
+/** Cost-per-million-tokens pair for a single (provider, model). */
+export interface ModelPrice {
+  readonly input: number;
+  readonly output: number;
+}
+
+/** Public API of a pricing cache returned from {@link createPricingCache}. */
+export interface PricingCache {
+  /**
+   * Resolve `(input, output)` cost-per-Mtok for the given provider + model pair.
+   * Returns the configured fallback on cache miss + DB failure or on an unknown key.
+   */
+  lookup(provider: string, model: string): ModelPrice;
+  /** Drop every cached entry; the next lookup forces a DB refresh. */
+  clear(): void;
+}
+
+interface PricingEntry {
+  inputCostPerMtok: number;
+  outputCostPerMtok: number;
+  cachedAt: number;
+}
+
+const DEFAULT_TTL_MS = 5 * 60 * 1000;
+const DEFAULT_FALLBACK: ModelPrice = { input: 1.0, output: 5.0 };
+
+/**
+ * Build a process-local pricing lookup bound to the given core DB
+ * handle. Each call to `lookup(provider, model)` either hits the cache
+ * or refreshes the entire pricing table from SQLite.
+ *
+ * @param db - Core drizzle handle. Captured by closure; the same handle
+ *   is used for every refresh against this cache.
+ * @param options.ttlMs - Cache freshness window in milliseconds.
+ *   Defaults to 5 minutes.
+ * @param options.fallback - Returned when the cache is empty AND a
+ *   refresh fails OR the requested key is unknown. Defaults to
+ *   `{ input: 1.0, output: 5.0 }` to preserve historical behaviour.
+ * @param options.now - Optional clock override; tests use this to drive
+ *   the TTL deterministically. Defaults to `Date.now`.
+ */
+export function createPricingCache(
+  db: CoreDb,
+  options: { ttlMs?: number; fallback?: ModelPrice; now?: () => number } = {}
+): PricingCache {
+  const ttlMs = options.ttlMs ?? DEFAULT_TTL_MS;
+  const fallback = options.fallback ?? DEFAULT_FALLBACK;
+  const now = options.now ?? Date.now;
+  const cache = new Map<string, PricingEntry>();
+
+  function refresh(timestamp: number): void {
+    const rows = db
+      .select({
+        providerId: aiModelPricing.providerId,
+        modelId: aiModelPricing.modelId,
+        inputCostPerMtok: aiModelPricing.inputCostPerMtok,
+        outputCostPerMtok: aiModelPricing.outputCostPerMtok,
+      })
+      .from(aiModelPricing)
+      .all();
+    for (const row of rows) {
+      cache.set(`${row.providerId}:${row.modelId}`, {
+        inputCostPerMtok: row.inputCostPerMtok,
+        outputCostPerMtok: row.outputCostPerMtok,
+        cachedAt: timestamp,
+      });
+    }
+  }
+
+  return {
+    lookup(provider: string, model: string): ModelPrice {
+      const key = `${provider}:${model}`;
+      const cached = cache.get(key);
+      const currentNow = now();
+      if (cached && currentNow - cached.cachedAt < ttlMs) {
+        return { input: cached.inputCostPerMtok, output: cached.outputCostPerMtok };
+      }
+      try {
+        refresh(currentNow);
+        const entry = cache.get(key);
+        if (entry) return { input: entry.inputCostPerMtok, output: entry.outputCostPerMtok };
+      } catch {
+        // pricing lookup is best-effort
+      }
+      return fallback;
+    },
+    clear(): void {
+      cache.clear();
+    },
+  };
+}

--- a/packages/core-db/src/services/sync-results.ts
+++ b/packages/core-db/src/services/sync-results.ts
@@ -1,0 +1,101 @@
+/**
+ * BullMQ sync-job result persistence against the core pillar's SQLite.
+ *
+ * Mirrors the structure used by every other core service in this package:
+ * the function takes a `CoreDb` handle as its first argument and performs
+ * a single UPSERT against `sync_job_results`. The caller (the pops-api
+ * worker queue handler) resolves the appropriate drizzle handle.
+ *
+ * Per `docs/themes/13-pillar-finale/notes/infra-hot-path-migration.md`
+ * row 4 the `sync_job_results` table is a cross-pillar BullMQ result table
+ * owned by the core pillar (lives next to `pillarRegistry`). This module
+ * is the SDK surface for that ownership; the physical table cutover from
+ * the shared `pops.db` into `core.db` lands with the PRD-186 sibling PR.
+ *
+ * Only the five Plex sync job types are persisted today — the
+ * caller-side filter is preserved as `PERSISTED_SYNC_TYPES` so consumers
+ * can short-circuit before constructing the row payload.
+ */
+import { syncJobResults } from '../schema.js';
+
+import type { CoreDb } from './internal.js';
+
+/**
+ * Job type identifiers whose terminal state is mirrored into
+ * `sync_job_results` for the dashboard's sync history view. All other
+ * BullMQ jobs are observed only via Redis and never reach the table.
+ */
+export const PERSISTED_SYNC_TYPES: ReadonlySet<string> = new Set([
+  'plexSyncMovies',
+  'plexSyncTvShows',
+  'plexSyncWatchlist',
+  'plexSyncWatchHistory',
+  'plexSyncDiscoverWatches',
+]);
+
+/** Single-call payload describing a job's terminal outcome. */
+export interface PersistSyncResultInput {
+  /** BullMQ job id. Used as the primary key. */
+  readonly id: string;
+  /** The BullMQ job type. Must be one of {@link PERSISTED_SYNC_TYPES}. */
+  readonly jobType: string;
+  /** Terminal status. */
+  readonly status: 'completed' | 'failed';
+  /** ISO-8601 timestamp the job started running. */
+  readonly startedAt: string;
+  /** ISO-8601 timestamp the job reached a terminal state. */
+  readonly completedAt: string;
+  /** End-to-end duration in milliseconds, or `null` if either bound is unknown. */
+  readonly durationMs: number | null;
+  /** JSON-encoded progress snapshot at completion (`{ processed, total }`). */
+  readonly progressJson: string;
+  /** JSON-encoded result payload (shape varies by jobType). `null` on failure. */
+  readonly resultJson: string | null;
+  /** Failure message, or `null` on success. */
+  readonly error: string | null;
+}
+
+/**
+ * UPSERT a terminal sync-job result row. Idempotent — replays of the
+ * same `id` overwrite the mutable columns and leave the primary key
+ * stable so the dashboard's `ORDER BY completed_at DESC` query reflects
+ * the latest run.
+ */
+export function persist(db: CoreDb, input: PersistSyncResultInput): void {
+  const {
+    id,
+    jobType,
+    status,
+    startedAt,
+    completedAt,
+    durationMs,
+    progressJson,
+    resultJson,
+    error,
+  } = input;
+
+  db.insert(syncJobResults)
+    .values({
+      id,
+      jobType,
+      status,
+      startedAt,
+      completedAt,
+      durationMs,
+      progress: progressJson,
+      result: resultJson,
+      error,
+    })
+    .onConflictDoUpdate({
+      target: syncJobResults.id,
+      set: {
+        status,
+        completedAt,
+        durationMs,
+        progress: progressJson,
+        result: resultJson,
+        error,
+      },
+    })
+    .run();
+}


### PR DESCRIPTION
## Summary

Ships the three trivial hot-path migrations from the PRD-212 follow-up audit (`docs/themes/13-pillar-finale/notes/infra-hot-path-migration.md`) in a single PR — all core-pillar, all mechanical.

- **Row 6 — `apps/pops-api/src/routes/health.ts`**: swap `getDrizzle()` for `getCoreDrizzle()` so the `/health` probe exercises the core pillar's own SQLite handle (matches the existing `SELF_PILLAR_ID = 'core'` declaration).
- **Row 4 — `apps/pops-api/src/jobs/sync-results.ts`**: move the `sync_job_results` UPSERT into `@pops/core-db` as `syncResultsService.persist(db, input)` and re-export `PERSISTED_SYNC_TYPES`. The job handler becomes a thin caller. The drizzle handle stays on `getDrizzle()` for now because the physical `sync_job_results` cutover into `core.db` is sequenced behind PRD-186 PR 4.
- **Row 5 — `apps/pops-api/src/lib/inference-pricing.ts`**: move the `ai_model_pricing` SELECT-all + 5-minute in-memory cache into `@pops/core-db` as `aiModelPricingService.createPricingCache(db, options)`. The pops-api caller becomes a thin lazy re-export. Same table-cutover sequencing note as sync-results.

After this lands, the bridge no longer holds those tables on behalf of these hot-paths — the smoke-test + health + budget paths are clear.

## Tests

Adds 14 unit tests in `packages/core-db/src/__tests__/`:

- **`sync-results.test.ts`** (6 tests): `PERSISTED_SYNC_TYPES` membership, insert success/failure, UPSERT semantics, null-passthrough, multi-row isolation.
- **`ai-model-pricing.test.ts`** (8 tests): cache miss → DB refresh, cache hit short-circuits the DB, TTL invalidation triggers a re-read, post-TTL refresh picks up edits, fallback on cold cache + DB error, default + override fallback, `clear()` forces a refresh.

`pnpm --filter @pops/core-db test` → **126 passing** (up from 112).

## Test plan

- [x] `pnpm --filter @pops/core-db test` green (126 / 126)
- [x] `pnpm --filter @pops/api typecheck` clean
- [x] `pnpm typecheck` at root clean (66 tasks)
- [x] `pnpm lint` clean (warnings pre-existing on main)
- [ ] CI green
