### PR TITLE
feat(finance): route remaining module reads through getFinanceDrizzle (Theme 13 PR4 prep)

### DIFF
--- a/apps/pops-api/src/modules/finance/budgets/search-adapter.ts
+++ b/apps/pops-api/src/modules/finance/budgets/search-adapter.ts
@@ -2,7 +2,7 @@ import { like } from 'drizzle-orm';
 
 import { budgets } from '@pops/db-types';
 
-import { getDrizzle } from '../../../db.js';
+import { getFinanceDrizzle } from '../../../db/finance-handle.js';
 
 import type { Query, SearchAdapter, SearchContext, SearchHit } from '../../core/search/index.js';
 
@@ -38,7 +38,7 @@ export const budgetsSearchAdapter: SearchAdapter<BudgetHitData> = {
     const text = query.text.trim();
     if (!text) return [];
 
-    const db = getDrizzle();
+    const db = getFinanceDrizzle();
     const limit = options?.limit ?? 20;
 
     const rows = db

--- a/apps/pops-api/src/modules/finance/imports/lib/tag-management.ts
+++ b/apps/pops-api/src/modules/finance/imports/lib/tag-management.ts
@@ -2,7 +2,7 @@ import { and, eq, isNotNull, ne } from 'drizzle-orm';
 
 import { tagVocabulary, transactions } from '@pops/db-types';
 
-import { getDrizzle } from '../../../../db.js';
+import { getFinanceDrizzle } from '../../../../db/finance-handle.js';
 import { suggestTags } from '../../tag-suggester/index.js';
 
 import type { SuggestedTag } from '../types.js';
@@ -26,7 +26,7 @@ export function parseCorrectionTags(raw: string): string[] {
  * repeated identical queries for every transaction.
  */
 export function loadKnownTags(): string[] {
-  const db = getDrizzle();
+  const db = getFinanceDrizzle();
   const rows = db
     .select({ tags: transactions.tags })
     .from(transactions)

--- a/apps/pops-api/src/modules/finance/transactions/router.ts
+++ b/apps/pops-api/src/modules/finance/transactions/router.ts
@@ -8,7 +8,6 @@ import {
   transactionsService,
 } from '@pops/finance-db';
 
-import { getDrizzle } from '../../../db.js';
 import { getFinanceDrizzle, getFinanceRawDb } from '../../../db/finance-handle.js';
 import { ConflictError, NotFoundError } from '../../../shared/errors.js';
 import { paginationMeta, PaginationMetaSchema } from '../../../shared/pagination.js';
@@ -200,7 +199,7 @@ export const transactionsRouter = router({
     )
     .query(({ input }) => {
       const limit = input?.limit ?? PREVIEW_DESCRIPTIONS_LIMIT;
-      const db = getDrizzle();
+      const db = getFinanceDrizzle();
       const rows = db
         .select({
           description: transactionsTable.description,

--- a/apps/pops-api/src/modules/finance/transactions/search-adapter.test.ts
+++ b/apps/pops-api/src/modules/finance/transactions/search-adapter.test.ts
@@ -1,7 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { closeDb, setDb } from '../../../db.js';
-import { createTestDb, seedTransaction } from '../../../shared/test-utils.js';
+import { seedTransaction, setupTestContext } from '../../../shared/test-utils.js';
 import {
   normalizeTransactionType,
   type TransactionHitData,
@@ -12,15 +11,15 @@ import type { Database } from 'better-sqlite3';
 
 import type { SearchHit } from '../../core/search/index.js';
 
+const ctx = setupTestContext();
 let db: Database;
 
 beforeEach(() => {
-  db = createTestDb();
-  setDb(db);
+  ({ db } = ctx.setup());
 });
 
 afterEach(() => {
-  closeDb();
+  ctx.teardown();
 });
 
 const adapter = transactionsSearchAdapter;

--- a/apps/pops-api/src/modules/finance/transactions/search-adapter.ts
+++ b/apps/pops-api/src/modules/finance/transactions/search-adapter.ts
@@ -2,7 +2,7 @@ import { like, sql } from 'drizzle-orm';
 
 import { transactions } from '@pops/db-types';
 
-import { getDrizzle } from '../../../db.js';
+import { getFinanceDrizzle } from '../../../db/finance-handle.js';
 
 import type { Query, SearchAdapter, SearchContext, SearchHit } from '../../core/search/index.js';
 
@@ -64,7 +64,7 @@ export const transactionsSearchAdapter: SearchAdapter<TransactionHitData> = {
     const text = query.text.trim();
     if (!text) return [];
 
-    const db = getDrizzle();
+    const db = getFinanceDrizzle();
     const rows = db
       .select({
         id: transactions.id,


### PR DESCRIPTION
## Summary

Routes the four remaining `getDrizzle()` reads inside `apps/pops-api/src/modules/finance/` through `getFinanceDrizzle()` so PR4 of the finance pillar shim retirement (PRD-153) can land without a stale-handle landmine.

The PR #3080 audit flagged these sites as still hitting shared `pops.db` even though the underlying tables (`transactions`, `budgets`, `tag_vocabulary`) already live in `@pops/finance-db`:

- `transactions/router.ts` - `listDescriptionsForPreview` drizzle call
- `transactions/search-adapter.ts` - `search()` drizzle call
- `budgets/search-adapter.ts` - `search()` drizzle call
- `imports/lib/tag-management.ts` - `loadKnownTags()` drizzle call

`wishlist/search-adapter.ts` was verified already on `getFinanceDrizzle()` - no change.

Schema imports stay on `@pops/db-types` (the canonical source `@pops/finance-db/schema.ts` re-exports), matching the existing wishlist adapter pattern.

## Notes

- The two remaining raw `getDb().prepare(...)` calls in `transactions/router.ts` (`availableTags` + the `COUNT(*)` probe inside `listDescriptionsForPreview`) are intentionally out of scope - they predate the audit, are not on its list, and will be unified at the data layer when the finance shim retires.
- `transactions/search-adapter.test.ts` was wired through `setDb()` alone, which left the new finance-handle reads pointing at an empty uninjected DB. Switched it to `setupTestContext()` to mirror the wishlist/budgets adapter tests (they already inject every pillar handle at the same in-memory fixture).

## Test plan

- [x] `pnpm --filter @pops/api test src/modules/finance` - 24 files, 624 tests green
- [x] `pnpm typecheck` at root - 66/66 tasks green
- [x] Full husky chain (oxlint + oxfmt + commit-msg) ran on the commit
