### PR TITLE
feat(core): route corrections handlers through getFinanceDrizzle (Theme 13 PR4 prep)

### DIFF
--- a/apps/pops-api/src/modules/core/corrections/handlers/ai-revise.ts
+++ b/apps/pops-api/src/modules/core/corrections/handlers/ai-revise.ts
@@ -2,7 +2,8 @@ import Anthropic from '@anthropic-ai/sdk';
 
 import { transactionCorrections } from '@pops/db-types';
 
-import { getDrizzle, isNamedEnvContext } from '../../../../db.js';
+import { isNamedEnvContext } from '../../../../db.js';
+import { getFinanceDrizzle } from '../../../../db/finance-handle.js';
 import { withRateLimitRetry } from '../../../../lib/ai-retry.js';
 import { getAnthropicApiKey } from '../../../../lib/anthropic-api-key.js';
 import { trackInference } from '../../../../lib/inference-middleware.js';
@@ -146,7 +147,7 @@ function parseAndValidate(text: string): { changeSet: ChangeSet; rationale: stri
 }
 
 export async function reviseChangeSet(args: ReviseArgs): Promise<ReviseResult> {
-  const rulesBefore = getDrizzle().select().from(transactionCorrections).all();
+  const rulesBefore = getFinanceDrizzle().select().from(transactionCorrections).all();
 
   if (isNamedEnvContext()) {
     return {

--- a/apps/pops-api/src/modules/core/corrections/handlers/changeset-impact.ts
+++ b/apps/pops-api/src/modules/core/corrections/handlers/changeset-impact.ts
@@ -2,7 +2,7 @@ import { sql } from 'drizzle-orm';
 
 import { transactionCorrections, transactions } from '@pops/db-types';
 
-import { getDrizzle } from '../../../../db.js';
+import { getFinanceDrizzle } from '../../../../db/finance-handle.js';
 import { parseJsonStringArray } from '../../../../shared/json.js';
 import {
   applyChangeSetToRules,
@@ -42,7 +42,7 @@ function fetchCandidates(
   const sqlPrefilterExpression =
     matchType === 'regex' ? sqlNormalizedDescription : sqlCollapsedSpaces;
 
-  return getDrizzle()
+  return getFinanceDrizzle()
     .select({
       id: transactions.id,
       description: transactions.description,
@@ -114,7 +114,7 @@ export function computeChangeSetImpact(args: ImpactPreviewArgs): {
   rulesBefore: CorrectionRow[];
 } {
   const candidates = fetchCandidates(args.matchType, args.normalizedPattern, args.maxPreviewItems);
-  const rulesBefore = getDrizzle().select().from(transactionCorrections).all();
+  const rulesBefore = getFinanceDrizzle().select().from(transactionCorrections).all();
   const rulesAfter = applyChangeSetToRules(rulesBefore, args.changeSet);
 
   const affected: ChangeSetImpactItem[] = [];

--- a/apps/pops-api/src/modules/core/corrections/handlers/compute-changeset.ts
+++ b/apps/pops-api/src/modules/core/corrections/handlers/compute-changeset.ts
@@ -2,7 +2,7 @@ import { and, eq } from 'drizzle-orm';
 
 import { transactionCorrections } from '@pops/db-types';
 
-import { getDrizzle } from '../../../../db.js';
+import { getFinanceDrizzle } from '../../../../db/finance-handle.js';
 import { buildTargetRulesMap } from '../pure-service.js';
 import { normalizeDescription } from '../types.js';
 import { interpretRejectionFeedback, loadLatestRejectedFeedback } from './ai-inference.js';
@@ -44,7 +44,7 @@ function findExistingRule(
   matchType: 'exact' | 'contains' | 'regex',
   normalizedPattern: string
 ): CorrectionRow | undefined {
-  return getDrizzle()
+  return getFinanceDrizzle()
     .select()
     .from(transactionCorrections)
     .where(

--- a/apps/pops-api/src/modules/core/corrections/handlers/preview-matches.ts
+++ b/apps/pops-api/src/modules/core/corrections/handlers/preview-matches.ts
@@ -17,7 +17,7 @@ import { desc } from 'drizzle-orm';
 
 import { transactions } from '@pops/db-types';
 
-import { getDrizzle } from '../../../../db.js';
+import { getFinanceDrizzle } from '../../../../db/finance-handle.js';
 import { parseJsonStringArray } from '../../../../shared/json.js';
 import { patternMatchesDescription } from '../lib/pattern-match.js';
 
@@ -77,7 +77,7 @@ function toMatchTransaction(row: TransactionRow): PreviewMatchTransaction {
  */
 export function previewMatches(input: PreviewMatchInput): PreviewMatchResult {
   const limit = Math.min(input.limit ?? DEFAULT_LIMIT, HARD_LIMIT);
-  const db = getDrizzle();
+  const db = getFinanceDrizzle();
 
   const rows = db.select().from(transactions).orderBy(desc(transactions.date)).all();
 

--- a/apps/pops-api/src/modules/core/corrections/lib/tag-loader.ts
+++ b/apps/pops-api/src/modules/core/corrections/lib/tag-loader.ts
@@ -2,7 +2,7 @@ import { and, isNotNull, ne } from 'drizzle-orm';
 
 import { transactions as transactionsTable } from '@pops/db-types';
 
-import { getDrizzle } from '../../../../db.js';
+import { getFinanceDrizzle } from '../../../../db/finance-handle.js';
 
 function parseTagsColumn(raw: string): string[] {
   try {
@@ -18,7 +18,7 @@ function parseTagsColumn(raw: string): string[] {
 
 export function loadAvailableTagsFromDb(): string[] {
   try {
-    const rows = getDrizzle()
+    const rows = getFinanceDrizzle()
       .select({ tags: transactionsTable.tags })
       .from(transactionsTable)
       .where(and(isNotNull(transactionsTable.tags), ne(transactionsTable.tags, '[]')))


### PR DESCRIPTION
## Summary

Implements option (a) from the PR #3085 corrections audit: flips the five remaining `core.corrections` sites that read `transactions` / `transaction_corrections` from `getDrizzle()` (shared pops.db) to `getFinanceDrizzle()` (per-pillar finance.db). Sibling `handlers/apply-corrections.ts` already used the finance handle — this aligns the rest of the module with that template.

Sites changed:

- `apps/pops-api/src/modules/core/corrections/handlers/preview-matches.ts`
- `apps/pops-api/src/modules/core/corrections/handlers/changeset-impact.ts` (both `transactions` and `transaction_corrections` reads)
- `apps/pops-api/src/modules/core/corrections/handlers/ai-revise.ts` (kept `isNamedEnvContext` import from `db.js`)
- `apps/pops-api/src/modules/core/corrections/handlers/compute-changeset.ts`
- `apps/pops-api/src/modules/core/corrections/lib/tag-loader.ts`

Schema imports stay on `@pops/db-types` — those are shared row/insert types used by both pillar DBs, not the table location.

After this lands, the finance PR4 super-bundle (#3080) becomes eligible to drop `transactions` and `transaction_corrections` from the shared schema.

## Test plan

- [x] `pnpm --filter @pops/api test src/modules/core/corrections` — 4 files / 99 tests passing
- [x] `pnpm typecheck` at root — 66/66 packages green
- [x] Full husky chain on commit (oxlint, oxfmt) — clean
- [ ] CI green on the PR
