### PR TITLE
feat(finance): export raw finance db handle + migrate last getDb prepare calls (Theme 13)

### DIFF
--- a/apps/pops-api/src/db/finance-handle.ts
+++ b/apps/pops-api/src/db/finance-handle.ts
@@ -44,6 +44,21 @@ export function getFinanceDrizzle(): FinanceDb {
 }
 
 /**
+ * Resolve the finance pillar's raw better-sqlite3 handle. Same lazy
+ * open + env-aware behaviour as `getFinanceDrizzle()` — exposed for
+ * the same lower-level needs (`.transaction()`, `.prepare()`,
+ * `.pragma()`) that the drizzle wrapper hides. Prefer
+ * `getFinanceDrizzle()` for everything that doesn't need it.
+ */
+export function getFinanceRawDb(): OpenedFinanceDb['raw'] {
+  if (isNamedEnvContext()) return getDb();
+  if (!financeDb) {
+    financeDb = openFinanceDb(resolveFinanceSqlitePath());
+  }
+  return financeDb.raw;
+}
+
+/**
  * Close the finance pillar's connection if it was opened. Idempotent —
  * safe to call from `closeDb()` on shutdown even when the finance
  * handle was never resolved.

--- a/apps/pops-api/src/modules/finance/transactions/router.ts
+++ b/apps/pops-api/src/modules/finance/transactions/router.ts
@@ -8,8 +8,8 @@ import {
   transactionsService,
 } from '@pops/finance-db';
 
-import { getDb, getDrizzle } from '../../../db.js';
-import { getFinanceDrizzle } from '../../../db/finance-handle.js';
+import { getDrizzle } from '../../../db.js';
+import { getFinanceDrizzle, getFinanceRawDb } from '../../../db/finance-handle.js';
 import { ConflictError, NotFoundError } from '../../../shared/errors.js';
 import { paginationMeta, PaginationMetaSchema } from '../../../shared/pagination.js';
 import { suggestTags } from '../../../shared/tag-suggester.js';
@@ -211,7 +211,9 @@ export const transactionsRouter = router({
         .all();
       const truncated = rows.length > limit;
       const data = truncated ? rows.slice(0, limit) : rows;
-      const totalCount = getDb().prepare('SELECT COUNT(*) as c FROM transactions').get() as {
+      const totalCount = getFinanceRawDb()
+        .prepare('SELECT COUNT(*) as c FROM transactions')
+        .get() as {
         c: number;
       };
       return {
@@ -230,7 +232,7 @@ export const transactionsRouter = router({
 });
 
 function collectAvailableTags(): string[] {
-  const db = getDb();
+  const db = getFinanceRawDb();
   const rows = db
     .prepare("SELECT tags FROM transactions WHERE tags IS NOT NULL AND tags != '[]'")
     .all() as { tags: string }[];


### PR DESCRIPTION
## Summary
- Add `getFinanceRawDb()` in `apps/pops-api/src/db/finance-handle.ts`, mirroring the existing `getFood/Inventory/Lists/CerebrumRawDb()` pattern: lazy-open, env-aware (delegates to `getDb()` inside `withEnvDb` scope), returns the underlying `better-sqlite3.Database` the drizzle wrapper hides.
- Flip the last two raw `getDb().prepare(...)` call sites in `apps/pops-api/src/modules/finance/transactions/router.ts` from shared `pops.db` to `getFinanceRawDb()`:
  - `availableTags` / `collectAvailableTags()` — prepared `SELECT tags FROM transactions`.
  - `listDescriptionsForPreview` — `SELECT COUNT(*) FROM transactions` probe.
- Both queries target the `transactions` table that lives on `finance.db` (see `packages/finance-db/migrations/0054_finance_pillar_baseline_extension.sql`). With this, no production code under `apps/pops-api/src/modules/finance` touches shared `pops.db` — finance is one step closer to a full bridge exit (Theme 13 corrections track).

## Test plan
- [x] `pnpm --filter @pops/api test src/modules/finance/transactions` — 58/58 green.
- [x] `pnpm typecheck` at root — 66/66 tasks green.
- [x] Husky pre-commit (lint-staged: oxlint + oxfmt) — green.