### PR TITLE
feat(pillar-sdk): add ALL_MODULE_IDS + isKnownPillarId + isModuleId (PRD-218 prep)

### DIFF
--- a/packages/pillar-sdk/src/capabilities/__tests__/modules.test.ts
+++ b/packages/pillar-sdk/src/capabilities/__tests__/modules.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+
+import { PILLARS, type KnownPillarId } from '../known-pillar-id.js';
+import {
+  ALL_MODULE_IDS,
+  MODULE_PARENT_PILLAR,
+  isKnownPillarId,
+  isModuleId,
+  type ModuleId,
+} from '../module-id.js';
+
+describe('ALL_MODULE_IDS', () => {
+  it('is a 9-element superset of PILLARS plus ai + ego', () => {
+    expect(ALL_MODULE_IDS).toHaveLength(9);
+    for (const pillar of PILLARS) {
+      expect(ALL_MODULE_IDS).toContain(pillar);
+    }
+    expect(ALL_MODULE_IDS).toContain('ai');
+    expect(ALL_MODULE_IDS).toContain('ego');
+  });
+
+  it('contains no duplicates', () => {
+    const unique = new Set<string>(ALL_MODULE_IDS);
+    expect(unique.size).toBe(ALL_MODULE_IDS.length);
+  });
+
+  it('typed as readonly tuple narrowing to ModuleId', () => {
+    expectTypeOf<(typeof ALL_MODULE_IDS)[number]>().toEqualTypeOf<ModuleId>();
+  });
+});
+
+describe('isKnownPillarId', () => {
+  it('returns true for every entry in PILLARS', () => {
+    for (const pillar of PILLARS) {
+      expect(isKnownPillarId(pillar)).toBe(true);
+    }
+  });
+
+  it('returns false for the transitional sub-module ids', () => {
+    expect(isKnownPillarId('ai')).toBe(false);
+    expect(isKnownPillarId('ego')).toBe(false);
+  });
+
+  it('returns false for unrelated strings', () => {
+    expect(isKnownPillarId('')).toBe(false);
+    expect(isKnownPillarId('shopping')).toBe(false);
+    expect(isKnownPillarId('CORE')).toBe(false);
+  });
+
+  it('narrows the input to KnownPillarId when true', () => {
+    const value: string = 'finance';
+    if (isKnownPillarId(value)) {
+      expectTypeOf(value).toEqualTypeOf<KnownPillarId>();
+    }
+  });
+});
+
+describe('isModuleId', () => {
+  it('returns true for every pillar', () => {
+    for (const pillar of PILLARS) {
+      expect(isModuleId(pillar)).toBe(true);
+    }
+  });
+
+  it('returns true for the transitional sub-module ids', () => {
+    expect(isModuleId('ai')).toBe(true);
+    expect(isModuleId('ego')).toBe(true);
+  });
+
+  it('returns false for unrelated strings', () => {
+    expect(isModuleId('')).toBe(false);
+    expect(isModuleId('shopping')).toBe(false);
+    expect(isModuleId('Core')).toBe(false);
+  });
+
+  it('narrows the input to ModuleId when true', () => {
+    const value: string = 'ai';
+    if (isModuleId(value)) {
+      expectTypeOf(value).toEqualTypeOf<ModuleId>();
+    }
+  });
+});
+
+describe('MODULE_PARENT_PILLAR', () => {
+  it('maps every pillar to itself', () => {
+    for (const pillar of PILLARS) {
+      expect(MODULE_PARENT_PILLAR[pillar]).toBe(pillar);
+    }
+  });
+
+  it('maps ai to core and ego to cerebrum per ADR-026', () => {
+    expect(MODULE_PARENT_PILLAR.ai).toBe('core');
+    expect(MODULE_PARENT_PILLAR.ego).toBe('cerebrum');
+  });
+
+  it('has an entry for every ModuleId', () => {
+    for (const id of ALL_MODULE_IDS) {
+      expect(MODULE_PARENT_PILLAR[id]).toBeDefined();
+      expect(isKnownPillarId(MODULE_PARENT_PILLAR[id])).toBe(true);
+    }
+  });
+
+  it('value type is exactly KnownPillarId', () => {
+    expectTypeOf(MODULE_PARENT_PILLAR).toEqualTypeOf<Record<ModuleId, KnownPillarId>>();
+  });
+});

--- a/packages/pillar-sdk/src/capabilities/index.ts
+++ b/packages/pillar-sdk/src/capabilities/index.ts
@@ -29,3 +29,5 @@ export { PillarCallError } from './call-result.js';
 export type { CallablePillar } from './callable-pillar.js';
 export type { KnownPillarId } from './known-pillar-id.js';
 export { PILLARS } from './known-pillar-id.js';
+export type { ModuleId } from './module-id.js';
+export { ALL_MODULE_IDS, MODULE_PARENT_PILLAR, isKnownPillarId, isModuleId } from './module-id.js';

--- a/packages/pillar-sdk/src/capabilities/module-id.ts
+++ b/packages/pillar-sdk/src/capabilities/module-id.ts
@@ -1,0 +1,78 @@
+/**
+ * Module-id projections — superset of `KnownPillarId` that includes the two
+ * transitional sub-module ids the shell still routes on (`ai`, `ego`).
+ *
+ * Per ADR-026 the platform is carved into seven pillars: `core`, `finance`,
+ * `media`, `inventory`, `cerebrum`, `food`, `lists`. AI Ops (`ai`) is a
+ * sub-system of `core`; Ego is a sub-system of `cerebrum`. They are NOT
+ * pillars. However `@pops/module-registry`'s build-time `KNOWN_MODULES`
+ * still emits them as routable ids because the shell, the settings UI, and
+ * a handful of cross-pillar URI consumers have not yet folded them into
+ * their parent pillars.
+ *
+ * The `ai` and `ego` entries here are transitional. Once the FE migration
+ * tracked under PRD-218 completes and every routable surface dispatches on
+ * the parent pillar, these two ids drop out of the SDK and `ModuleId`
+ * collapses back into `KnownPillarId`.
+ */
+
+import { PILLARS, type KnownPillarId } from './known-pillar-id.js';
+
+/**
+ * Canonical superset of routable module ids. Matches the order and
+ * contents of `@pops/module-registry`'s `KNOWN_MODULES` — kept in lock-step
+ * by the test in `__tests__/modules.test.ts`.
+ */
+export const ALL_MODULE_IDS = [
+  'ai',
+  'cerebrum',
+  'core',
+  'ego',
+  'finance',
+  'food',
+  'inventory',
+  'lists',
+  'media',
+] as const;
+
+/**
+ * Union of every routable module id. Superset of `KnownPillarId` that adds
+ * the two transitional sub-module ids (`ai`, `ego`).
+ */
+export type ModuleId = (typeof ALL_MODULE_IDS)[number];
+
+/**
+ * Runtime type guard narrowing an arbitrary string to `KnownPillarId`.
+ * Use at the boundary of untyped inputs (URL params, env vars, untyped
+ * tRPC inputs) before routing on the value.
+ */
+export function isKnownPillarId(id: string): id is KnownPillarId {
+  return (PILLARS as readonly string[]).includes(id);
+}
+
+/**
+ * Runtime type guard narrowing an arbitrary string to the `ModuleId`
+ * superset (pillars + `ai` + `ego`).
+ */
+export function isModuleId(id: string): id is ModuleId {
+  return (ALL_MODULE_IDS as readonly string[]).includes(id);
+}
+
+/**
+ * Maps every `ModuleId` to its owning pillar. Pillars map to themselves;
+ * `ai → core` and `ego → cerebrum` per ADR-026.
+ *
+ * Used by routers and the shell to dispatch a sub-module id onto the
+ * pillar that physically owns its contract.
+ */
+export const MODULE_PARENT_PILLAR: Record<ModuleId, KnownPillarId> = {
+  ai: 'core',
+  cerebrum: 'cerebrum',
+  core: 'core',
+  ego: 'cerebrum',
+  finance: 'finance',
+  food: 'food',
+  inventory: 'inventory',
+  lists: 'lists',
+  media: 'media',
+};


### PR DESCRIPTION
## Summary

Adds module-id projections to \`@pops/pillar-sdk/capabilities\` so consumers of \`@pops/module-registry\` can narrow on the same 9-id superset without taking a build-time dependency on module-registry. Unblocks PRD-218 batch 1 migration.

New exports (all from \`@pops/pillar-sdk/capabilities\`, re-exported from the package root):

- \`ALL_MODULE_IDS: readonly ModuleId[]\` — 9-element superset matching \`KNOWN_MODULES\`.
- \`ModuleId\` — \`KnownPillarId | 'ai' | 'ego'\`.
- \`isKnownPillarId(id): id is KnownPillarId\` — runtime narrowing guard for pillars.
- \`isModuleId(id): id is ModuleId\` — runtime narrowing guard for the superset.
- \`MODULE_PARENT_PILLAR: Record<ModuleId, KnownPillarId>\` — \`ai → core\`, \`ego → cerebrum\`, every pillar → itself. Useful for sub-module → pillar dispatch.

JSDoc flags \`ai\` and \`ego\` as transitional per ADR-026 — they live inside \`core\` and \`cerebrum\` respectively, and will drop out of the SDK once the FE migration tracked by PRD-218 finishes routing on the parent pillar.

## Test plan

- [x] New \`packages/pillar-sdk/src/capabilities/__tests__/modules.test.ts\` — 15 tests covering the 4 type guards, the parent-pillar mapping, and type-level assertions.
- [x] \`pnpm --filter @pops/pillar-sdk typecheck\` clean.
- [x] \`pnpm --filter @pops/pillar-sdk build\` clean.
- [x] \`pnpm typecheck\` (repo) — 66/66 turbo tasks pass.