### PR TITLE
feat(finance): move tag-suggester from shared to finance module (PRD-212 hot-path)

### DIFF
--- a/apps/pops-api/src/modules/finance/imports/lib/tag-management.ts
+++ b/apps/pops-api/src/modules/finance/imports/lib/tag-management.ts
@@ -3,7 +3,7 @@ import { and, eq, isNotNull, ne } from 'drizzle-orm';
 import { tagVocabulary, transactions } from '@pops/db-types';
 
 import { getDrizzle } from '../../../../db.js';
-import { suggestTags } from '../../../../shared/tag-suggester.js';
+import { suggestTags } from '../../tag-suggester/index.js';
 
 import type { SuggestedTag } from '../types.js';
 

--- a/apps/pops-api/src/modules/finance/imports/service.rule-provenance.test.ts
+++ b/apps/pops-api/src/modules/finance/imports/service.rule-provenance.test.ts
@@ -8,7 +8,7 @@ vi.mock('../../core/corrections/service.js', () => {
   };
 });
 
-vi.mock('../../../shared/tag-suggester.js', () => {
+vi.mock('../tag-suggester/index.js', () => {
   return {
     suggestTags: () => [],
   };

--- a/apps/pops-api/src/modules/finance/tag-suggester/index.test.ts
+++ b/apps/pops-api/src/modules/finance/tag-suggester/index.test.ts
@@ -1,13 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { suggestTags } from './tag-suggester.js';
+import { suggestTags } from './index.js';
 
-// Mock entity lookup and tag-rules queries via DB
+// Mock entity lookup and tag-rules queries via the finance DB handle.
 const mockEntityGet = vi.fn<() => { defaultTags: string | null } | null>(() => null);
 const mockTagRulesAll = vi.fn<() => { tags: string; descriptionPattern: string }[]>(() => []);
 
-vi.mock('../db.js', () => ({
-  getDrizzle: vi.fn(() => ({
+vi.mock('../../../db/finance-handle.js', () => ({
+  getFinanceDrizzle: vi.fn(() => ({
     select: vi.fn(() => ({
       from: vi.fn(() => ({
         where: vi.fn(() => ({
@@ -25,7 +25,7 @@ vi.mock('../db.js', () => ({
 const mockFindAllMatchingCorrections = vi.fn<
   () => { tags: string; descriptionPattern: string | null }[]
 >(() => []);
-vi.mock('../modules/core/corrections/service.js', () => ({
+vi.mock('../../core/corrections/service.js', () => ({
   findAllMatchingCorrections: (...args: unknown[]) =>
     mockFindAllMatchingCorrections(...(args as [])),
 }));

--- a/apps/pops-api/src/modules/finance/tag-suggester/index.ts
+++ b/apps/pops-api/src/modules/finance/tag-suggester/index.ts
@@ -6,18 +6,27 @@
  * 2. Tag rules — tags from transaction_tag_rules (source: "rule")
  * 3. AI tags — returned directly by AI or validated category string (source: "ai")
  * 4. Entity defaults — from entity.default_tags (source: "entity")
+ *
+ * PRD-212 hot-path move: this module is finance-owned (it reads
+ * `transaction_tag_rules` and `entities`, both finance-pillar tables) so it
+ * lives next to the finance routers and reads through `getFinanceDrizzle()`.
+ * Corrections are owned by the finance pillar too (the `transaction_corrections`
+ * table lives in finance-db); the in-tree `findAllMatchingCorrections` helper
+ * — a thin shim over `@pops/finance-db`'s `transactionCorrectionsService` —
+ * stays the call site so the core/corrections namespace keeps its single
+ * read-API entry point.
  */
 import { and, desc, eq, isNull, or, sql } from 'drizzle-orm';
 
 import { entities, transactionTagRules } from '@pops/db-types';
 
-import { getDrizzle } from '../db.js';
-import { logger } from '../lib/logger.js';
-import { findAllMatchingCorrections } from '../modules/core/corrections/service.js';
-import { normalizeDescription } from '../modules/core/corrections/types-base.js';
-import { parseJsonStringArray } from './json.js';
+import { getFinanceDrizzle } from '../../../db/finance-handle.js';
+import { logger } from '../../../lib/logger.js';
+import { parseJsonStringArray } from '../../../shared/json.js';
+import { findAllMatchingCorrections } from '../../core/corrections/service.js';
+import { normalizeDescription } from '../../core/corrections/types-base.js';
 
-import type { SuggestedTag } from '../modules/finance/imports/types.js';
+import type { SuggestedTag } from '../imports/types.js';
 
 export interface SuggestTagsOptions {
   description: string;
@@ -65,7 +74,7 @@ function buildEntityFilter(entityId: string | null): ReturnType<typeof or> {
 }
 
 function findMatchingTagRules(description: string, entityId: string | null): TagRuleRow[] {
-  const db = getDrizzle();
+  const db = getFinanceDrizzle();
   const norm = normalizeDescription(description);
   const ef = buildEntityFilter(entityId);
   const cols = {
@@ -167,7 +176,7 @@ function addAiTags(args: AddAiTagsArgs): void {
 
 function addEntityTags(entityId: string | null, seen: Set<string>, result: SuggestedTag[]): void {
   if (!entityId) return;
-  const entity = getDrizzle()
+  const entity = getFinanceDrizzle()
     .select({ defaultTags: entities.defaultTags })
     .from(entities)
     .where(eq(entities.id, entityId))

--- a/apps/pops-api/src/modules/finance/transactions/router.ts
+++ b/apps/pops-api/src/modules/finance/transactions/router.ts
@@ -12,9 +12,9 @@ import { getDb, getDrizzle } from '../../../db.js';
 import { getFinanceDrizzle } from '../../../db/finance-handle.js';
 import { ConflictError, NotFoundError } from '../../../shared/errors.js';
 import { paginationMeta, PaginationMetaSchema } from '../../../shared/pagination.js';
-import { suggestTags } from '../../../shared/tag-suggester.js';
 import { mapDomainErrors } from '../../../shared/trpc-error-mapper.js';
 import { protectedProcedure, router } from '../../../trpc.js';
+import { suggestTags } from '../tag-suggester/index.js';
 import {
   CreateTransactionSchema,
   toTransaction,

--- a/apps/pops-finance-api/src/modules/transactions/router.ts
+++ b/apps/pops-finance-api/src/modules/transactions/router.ts
@@ -13,9 +13,10 @@
  * router as fall-through because their implementations reach into
  * cross-pillar surfaces still living in pops-api:
  *
- *   - `suggestTags`               — uses `shared/tag-suggester.ts`, which
- *     pulls in `core/corrections/{service,types-base}` and the entities
- *     table via the legacy unified-db drizzle handle.
+ *   - `suggestTags`               — uses `modules/finance/tag-suggester`,
+ *     which pulls in `core/corrections/{service,types-base}` and now reads
+ *     `entities` + `transaction_tag_rules` via the finance pillar handle
+ *     (PRD-212 hot-path move).
  *   - `listDescriptionsForPreview` — issues raw drizzle reads against the
  *     `transactions` table via `getDrizzle()` (legacy pops.db); the
  *     equivalent helper isn't exposed by `@pops/finance-db` yet.

--- a/apps/pops-finance-api/src/router.ts
+++ b/apps/pops-finance-api/src/router.ts
@@ -14,7 +14,7 @@
  * / `availableTags` and the entire `imports` subrouter stay on the
  * legacy pops-api router as fall-through because they reach into
  * cross-pillar surfaces (`core/corrections`, `core/tag-rules`,
- * `core/ai-usage`, `core/settings`, `shared/tag-suggester`, and the
+ * `core/ai-usage`, `core/settings`, `finance/tag-suggester`, and the
  * legacy unified `pops.db` drizzle handle) that haven't moved yet —
  * see the procedure-by-procedure breakdown in `modules/transactions/router.ts`.
  */

--- a/apps/pops-finance-api/src/router.ts
+++ b/apps/pops-finance-api/src/router.ts
@@ -14,7 +14,7 @@
  * / `availableTags` and the entire `imports` subrouter stay on the
  * legacy pops-api router as fall-through because they reach into
  * cross-pillar surfaces (`core/corrections`, `core/tag-rules`,
- * `core/ai-usage`, `core/settings`, `finance/tag-suggester`, and the
+ * `core/ai-usage`, `core/settings`, `modules/finance/tag-suggester`, and the
  * legacy unified `pops.db` drizzle handle) that haven't moved yet —
  * see the procedure-by-procedure breakdown in `modules/transactions/router.ts`.
  */


### PR DESCRIPTION
## Summary

PRD-212 readiness audit (PR #3076) mapped `apps/pops-api/src/shared/tag-suggester.ts` as a finance-owned hot path — it reads `transaction_tag_rules` and `entities`, both finance-pillar tables. Its `shared/` location was a leftover from the unified pops.db era.

- Move `shared/tag-suggester.{ts,test.ts}` -> `modules/finance/tag-suggester/{index.ts,index.test.ts}` so the file sits next to its only consumers (`transactions/router.ts`, `imports/lib/tag-management.ts`).
- Flip both finance-table reads (`transaction_tag_rules` and `entities`) from `getDrizzle()` to `getFinanceDrizzle()`.
- Corrections stay on the in-tree `findAllMatchingCorrections` shim, which already forwards to `@pops/finance-db`'s `transactionCorrectionsService` — keeps `core/corrections` as the single read-API entry point.
- Update the 4 call sites in pops-api (router, lib helper, 2 tests) and refresh 2 pops-finance-api docstring references.

No module-boundary lint rule added — the repo has no ESLint config in place yet; ownership stays implicit via directory layout.

## Files moved

- `apps/pops-api/src/shared/tag-suggester.ts` -> `apps/pops-api/src/modules/finance/tag-suggester/index.ts`
- `apps/pops-api/src/shared/tag-suggester.test.ts` -> `apps/pops-api/src/modules/finance/tag-suggester/index.test.ts`

## Import sites updated

- `apps/pops-api/src/modules/finance/transactions/router.ts`
- `apps/pops-api/src/modules/finance/imports/lib/tag-management.ts`
- `apps/pops-api/src/modules/finance/imports/service.rule-provenance.test.ts` (`vi.mock` path)
- `apps/pops-api/src/modules/finance/tag-suggester/index.test.ts` (`vi.mock` flipped from `../db.js#getDrizzle` to `../../../db/finance-handle.js#getFinanceDrizzle`)
- `apps/pops-finance-api/src/router.ts`, `apps/pops-finance-api/src/modules/transactions/router.ts` (docstring refs to the new path)

## Test plan

- [x] `pnpm --filter @pops/api typecheck` — clean.
- [x] Root `pnpm typecheck` — 66/66 tasks clean.
- [x] `pnpm --filter @pops/api test src/modules/finance --run` — 313 files / 4925 tests passing.
- [x] Full husky chain on commit (oxlint + oxfmt) green; no `--no-verify`.
