### PR TITLE
feat(core): drop remaining PR4-ready core tables (Theme 13 round 2)

### DIFF
--- a/apps/pops-api/src/db/backfill-core-from-shared.test.ts
+++ b/apps/pops-api/src/db/backfill-core-from-shared.test.ts
@@ -8,6 +8,12 @@
  *   - second run is a no-op (idempotent — the WHERE filter dedupes),
  *   - mixed state (some rows already in core) only inserts the missing ones,
  *   - missing source table is tolerated without throwing.
+ *
+ * Theme 13 round 2 retired the `service_accounts`, `settings`,
+ * `ai_inference_daily`, and `ai_budgets` entries from `TABLE_COPIES`
+ * — their writer cutovers have shipped end-to-end. Only
+ * `ai_inference_log` remains on the bridge because
+ * `modules/food/routers/ai.ts` still writes via the shared handle.
  */
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -19,13 +25,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { openCoreDb } from '@pops/core-db';
 
 import { backfillCoreFromShared, closeCoreDb, setCoreDb } from '../db.js';
-import {
-  AI_BUDGETS_TABLE_SQL,
-  AI_INFERENCE_DAILY_TABLE_SQL,
-  AI_INFERENCE_LOG_TABLE_SQL,
-  SERVICE_ACCOUNTS_TABLE_SQL,
-  SETTINGS_TABLE_SQL,
-} from './backfill-test-fixtures.js';
+import { AI_INFERENCE_LOG_TABLE_SQL } from './backfill-test-fixtures.js';
 
 let tmpDir: string;
 
@@ -42,19 +42,40 @@ afterEach(() => {
   else process.env['SQLITE_PATH'] = originalSharedPath;
 });
 
-function openSharedWithRows(rows: { id: string; name: string }[]): string {
+interface InferenceLogRow {
+  id: number;
+  provider: string;
+  model: string;
+  operation: string;
+  domain: string | null;
+  input_tokens: number;
+  output_tokens: number;
+  cost_usd: number;
+  latency_ms: number;
+  status: string;
+  cached: number;
+  context_id: string | null;
+  error_message: string | null;
+  metadata: string | null;
+  created_at: string;
+}
+
+interface SeedLog {
+  id: number;
+  provider: string;
+  model: string;
+  operation: string;
+  createdAt: string;
+}
+
+function openSharedWithLogs(logs: SeedLog[]): string {
   const path = join(tmpDir, 'pops.db');
-  // Create the shared file via openCoreDb's helper would conflict because
-  // openCoreDb applies the core migrations; instead seed a raw SQLite
-  // with the canonical service_accounts DDL + the test rows.
   const raw = new BetterSqlite3(path);
-  raw.exec(SERVICE_ACCOUNTS_TABLE_SQL);
+  raw.exec(AI_INFERENCE_LOG_TABLE_SQL);
   const insert = raw.prepare(
-    `INSERT INTO service_accounts (id, name, key_prefix, key_hash) VALUES (?, ?, ?, ?)`
+    'INSERT INTO ai_inference_log (id, provider, model, operation, created_at) VALUES (?, ?, ?, ?, ?)'
   );
-  for (const row of rows) {
-    insert.run(row.id, row.name, `pfx${row.id.slice(0, 5)}`, 'scrypt$x$y');
-  }
+  for (const r of logs) insert.run(r.id, r.provider, r.model, r.operation, r.createdAt);
   raw.close();
   process.env['SQLITE_PATH'] = path;
   return path;
@@ -66,51 +87,78 @@ describe('backfillCoreFromShared', () => {
     expect(() => backfillCoreFromShared()).not.toThrow();
   });
 
-  it('copies fresh rows on first run and is a no-op on the second', () => {
-    openSharedWithRows([
-      { id: 'sa_a', name: 'alpha' },
-      { id: 'sa_b', name: 'beta' },
+  it('copies fresh ai_inference_log rows on first run and is a no-op on the second', () => {
+    openSharedWithLogs([
+      {
+        id: 1,
+        provider: 'claude',
+        model: 'sonnet',
+        operation: 'classify',
+        createdAt: '2026-06-01T00:00:00.000Z',
+      },
+      {
+        id: 2,
+        provider: 'openai',
+        model: 'gpt-4',
+        operation: 'embed',
+        createdAt: '2026-06-02T00:00:00.000Z',
+      },
     ]);
     const core = openCoreDb(join(tmpDir, 'core.db'));
     setCoreDb(core);
 
     backfillCoreFromShared();
-    const after = core.raw.prepare('SELECT id, name FROM service_accounts ORDER BY id').all() as {
-      id: string;
-      name: string;
-    }[];
-    expect(after.map((r) => r.id)).toEqual(['sa_a', 'sa_b']);
+    const after = core.raw
+      .prepare('SELECT id, provider, operation FROM ai_inference_log ORDER BY id')
+      .all() as { id: number; provider: string; operation: string }[];
+    expect(after).toEqual([
+      { id: 1, provider: 'claude', operation: 'classify' },
+      { id: 2, provider: 'openai', operation: 'embed' },
+    ]);
 
     backfillCoreFromShared();
-    const second = core.raw.prepare('SELECT count(*) AS n FROM service_accounts').get() as {
+    const second = core.raw.prepare('SELECT count(*) AS n FROM ai_inference_log').get() as {
       n: number;
     };
     expect(second.n).toBe(2);
   });
 
-  it('only inserts rows missing from the core copy', () => {
-    openSharedWithRows([
-      { id: 'sa_a', name: 'alpha' },
-      { id: 'sa_b', name: 'beta' },
+  it('only inserts ai_inference_log rows missing from the core copy', () => {
+    openSharedWithLogs([
+      {
+        id: 1,
+        provider: 'claude',
+        model: 'sonnet',
+        operation: 'classify',
+        createdAt: '2026-06-01T00:00:00.000Z',
+      },
+      {
+        id: 2,
+        provider: 'openai',
+        model: 'gpt-4',
+        operation: 'embed',
+        createdAt: '2026-06-02T00:00:00.000Z',
+      },
     ]);
     const core = openCoreDb(join(tmpDir, 'core.db'));
     setCoreDb(core);
     core.raw
-      .prepare(`INSERT INTO service_accounts (id, name, key_prefix, key_hash) VALUES (?, ?, ?, ?)`)
-      .run('sa_b', 'beta-old', 'pfxBB', 'scrypt$x$y');
+      .prepare(
+        'INSERT INTO ai_inference_log (id, provider, model, operation, created_at) VALUES (?, ?, ?, ?, ?)'
+      )
+      .run(2, 'pre-existing', 'pre-existing', 'pre-existing', '2026-06-02T00:00:00.000Z');
 
     backfillCoreFromShared();
-    const rows = core.raw.prepare('SELECT id, name FROM service_accounts ORDER BY id').all() as {
-      id: string;
-      name: string;
-    }[];
+    const rows = core.raw
+      .prepare('SELECT id, provider FROM ai_inference_log ORDER BY id')
+      .all() as { id: number; provider: string }[];
     expect(rows).toEqual([
-      { id: 'sa_a', name: 'alpha' },
-      { id: 'sa_b', name: 'beta-old' },
+      { id: 1, provider: 'claude' },
+      { id: 2, provider: 'pre-existing' },
     ]);
   });
 
-  it('tolerates a shared DB without the service_accounts table', () => {
+  it('tolerates a shared DB without the ai_inference_log table', () => {
     const path = join(tmpDir, 'pops.db');
     const raw = new BetterSqlite3(path);
     raw.close();
@@ -126,382 +174,66 @@ describe('backfillCoreFromShared', () => {
     } finally {
       warn.mockRestore();
     }
-    const count = core.raw.prepare('SELECT count(*) AS n FROM service_accounts').get() as {
+    const count = core.raw.prepare('SELECT count(*) AS n FROM ai_inference_log').get() as {
       n: number;
     };
     expect(count.n).toBe(0);
   });
 
-  describe('settings (PRD-183 PR 1)', () => {
-    function openSharedWithSettings(rows: { key: string; value: string }[]): string {
-      const path = join(tmpDir, 'pops.db');
-      const raw = new BetterSqlite3(path);
-      raw.exec(SERVICE_ACCOUNTS_TABLE_SQL);
-      raw.exec(SETTINGS_TABLE_SQL);
-      const insert = raw.prepare('INSERT INTO settings (key, value) VALUES (?, ?)');
-      for (const row of rows) insert.run(row.key, row.value);
-      raw.close();
-      process.env['SQLITE_PATH'] = path;
-      return path;
-    }
-
-    it('copies fresh settings rows on first run and is a no-op on the second', () => {
-      openSharedWithSettings([
-        { key: 'ui.theme', value: 'dark' },
-        { key: 'ai.model', value: 'sonnet' },
-      ]);
-      const core = openCoreDb(join(tmpDir, 'core.db'));
-      setCoreDb(core);
-
-      backfillCoreFromShared();
-      const after = core.raw.prepare('SELECT key, value FROM settings ORDER BY key').all() as {
-        key: string;
-        value: string;
-      }[];
-      expect(after).toEqual([
-        { key: 'ai.model', value: 'sonnet' },
-        { key: 'ui.theme', value: 'dark' },
-      ]);
-
-      backfillCoreFromShared();
-      const second = core.raw.prepare('SELECT count(*) AS n FROM settings').get() as {
-        n: number;
-      };
-      expect(second.n).toBe(2);
-    });
-
-    it('only inserts settings rows missing from the core copy (preserves existing values)', () => {
-      openSharedWithSettings([
-        { key: 'ui.theme', value: 'dark' },
-        { key: 'ai.model', value: 'sonnet' },
-      ]);
-      const core = openCoreDb(join(tmpDir, 'core.db'));
-      setCoreDb(core);
-      core.raw
-        .prepare('INSERT INTO settings (key, value) VALUES (?, ?)')
-        .run('ui.theme', 'pre-existing-value');
-
-      backfillCoreFromShared();
-      const rows = core.raw.prepare('SELECT key, value FROM settings ORDER BY key').all() as {
-        key: string;
-        value: string;
-      }[];
-      expect(rows).toEqual([
-        { key: 'ai.model', value: 'sonnet' },
-        { key: 'ui.theme', value: 'pre-existing-value' },
-      ]);
-    });
-
-    it('tolerates a shared DB without the settings table', () => {
-      const path = join(tmpDir, 'pops.db');
-      const raw = new BetterSqlite3(path);
-      raw.exec(SERVICE_ACCOUNTS_TABLE_SQL);
-      raw.close();
-      process.env['SQLITE_PATH'] = path;
-
-      const core = openCoreDb(join(tmpDir, 'core.db'));
-      setCoreDb(core);
-
-      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
-      try {
-        expect(() => backfillCoreFromShared()).not.toThrow();
-        expect(warn).not.toHaveBeenCalled();
-      } finally {
-        warn.mockRestore();
-      }
-      const count = core.raw.prepare('SELECT count(*) AS n FROM settings').get() as {
-        n: number;
-      };
-      expect(count.n).toBe(0);
-    });
-
-    it('carries every column across (full-shape roundtrip)', () => {
-      openSharedWithSettings([
-        { key: 'ai.modelOverrides.query', value: 'haiku' },
-        { key: 'cerebrum.auditor.contradictionModel', value: 'opus' },
-      ]);
-      const core = openCoreDb(join(tmpDir, 'core.db'));
-      setCoreDb(core);
-
-      backfillCoreFromShared();
-      const row = core.raw
-        .prepare('SELECT key, value FROM settings WHERE key = ?')
-        .get('ai.modelOverrides.query') as { key: string; value: string };
-      expect(row).toEqual({ key: 'ai.modelOverrides.query', value: 'haiku' });
-    });
-  });
-
-  describe('ai-usage (PRD-186 PR 1)', () => {
-    interface InferenceLogRow {
-      id: number;
-      provider: string;
-      model: string;
-      operation: string;
-      domain: string | null;
-      input_tokens: number;
-      output_tokens: number;
-      cost_usd: number;
-      latency_ms: number;
-      status: string;
-      cached: number;
-      context_id: string | null;
-      error_message: string | null;
-      metadata: string | null;
-      created_at: string;
-    }
-
-    function openSharedWithAiUsage(opts: {
-      logs?: {
-        id: number;
-        provider: string;
-        model: string;
-        operation: string;
-        createdAt: string;
-      }[];
-      daily?: {
-        id: number;
-        date: string;
-        provider: string;
-        model: string;
-        operation: string;
-        totalCalls: number;
-      }[];
-      budgets?: { id: string; scopeType: string; action: string }[];
-    }): string {
-      const path = join(tmpDir, 'pops.db');
-      const raw = new BetterSqlite3(path);
-      raw.exec(SERVICE_ACCOUNTS_TABLE_SQL);
-      raw.exec(AI_INFERENCE_LOG_TABLE_SQL);
-      raw.exec(AI_INFERENCE_DAILY_TABLE_SQL);
-      raw.exec(AI_BUDGETS_TABLE_SQL);
-      if (opts.logs) {
-        const stmt = raw.prepare(
-          'INSERT INTO ai_inference_log (id, provider, model, operation, created_at) VALUES (?, ?, ?, ?, ?)'
-        );
-        for (const r of opts.logs) stmt.run(r.id, r.provider, r.model, r.operation, r.createdAt);
-      }
-      if (opts.daily) {
-        const stmt = raw.prepare(
-          'INSERT INTO ai_inference_daily (id, date, provider, model, operation, total_calls) VALUES (?, ?, ?, ?, ?, ?)'
-        );
-        for (const r of opts.daily)
-          stmt.run(r.id, r.date, r.provider, r.model, r.operation, r.totalCalls);
-      }
-      if (opts.budgets) {
-        const stmt = raw.prepare(
-          'INSERT INTO ai_budgets (id, scope_type, action, created_at, updated_at) VALUES (?, ?, ?, ?, ?)'
-        );
-        const now = '2026-06-01T00:00:00.000Z';
-        for (const r of opts.budgets) stmt.run(r.id, r.scopeType, r.action, now, now);
-      }
-      raw.close();
-      process.env['SQLITE_PATH'] = path;
-      return path;
-    }
-
-    it('copies fresh ai_inference_log rows on first run and is a no-op on the second', () => {
-      openSharedWithAiUsage({
-        logs: [
-          {
-            id: 1,
-            provider: 'claude',
-            model: 'sonnet',
-            operation: 'classify',
-            createdAt: '2026-06-01T00:00:00.000Z',
-          },
-          {
-            id: 2,
-            provider: 'openai',
-            model: 'gpt-4',
-            operation: 'embed',
-            createdAt: '2026-06-02T00:00:00.000Z',
-          },
-        ],
-      });
-      const core = openCoreDb(join(tmpDir, 'core.db'));
-      setCoreDb(core);
-
-      backfillCoreFromShared();
-      const after = core.raw
-        .prepare('SELECT id, provider, operation FROM ai_inference_log ORDER BY id')
-        .all() as { id: number; provider: string; operation: string }[];
-      expect(after).toEqual([
-        { id: 1, provider: 'claude', operation: 'classify' },
-        { id: 2, provider: 'openai', operation: 'embed' },
-      ]);
-
-      backfillCoreFromShared();
-      const second = core.raw.prepare('SELECT count(*) AS n FROM ai_inference_log').get() as {
-        n: number;
-      };
-      expect(second.n).toBe(2);
-    });
-
-    it('only inserts ai_inference_log rows missing from the core copy', () => {
-      openSharedWithAiUsage({
-        logs: [
-          {
-            id: 1,
-            provider: 'claude',
-            model: 'sonnet',
-            operation: 'classify',
-            createdAt: '2026-06-01T00:00:00.000Z',
-          },
-          {
-            id: 2,
-            provider: 'openai',
-            model: 'gpt-4',
-            operation: 'embed',
-            createdAt: '2026-06-02T00:00:00.000Z',
-          },
-        ],
-      });
-      const core = openCoreDb(join(tmpDir, 'core.db'));
-      setCoreDb(core);
-      core.raw
-        .prepare(
-          'INSERT INTO ai_inference_log (id, provider, model, operation, created_at) VALUES (?, ?, ?, ?, ?)'
-        )
-        .run(2, 'pre-existing', 'pre-existing', 'pre-existing', '2026-06-02T00:00:00.000Z');
-
-      backfillCoreFromShared();
-      const rows = core.raw
-        .prepare('SELECT id, provider FROM ai_inference_log ORDER BY id')
-        .all() as { id: number; provider: string }[];
-      expect(rows).toEqual([
-        { id: 1, provider: 'claude' },
-        { id: 2, provider: 'pre-existing' },
-      ]);
-    });
-
-    it('copies ai_inference_daily aggregate rows across', () => {
-      openSharedWithAiUsage({
-        daily: [
-          {
-            id: 1,
-            date: '2026-05-01',
-            provider: 'claude',
-            model: 'sonnet',
-            operation: 'classify',
-            totalCalls: 10,
-          },
-        ],
-      });
-      const core = openCoreDb(join(tmpDir, 'core.db'));
-      setCoreDb(core);
-
-      backfillCoreFromShared();
-      const row = core.raw
-        .prepare('SELECT date, provider, total_calls FROM ai_inference_daily WHERE id = 1')
-        .get() as { date: string; provider: string; total_calls: number };
-      expect(row).toEqual({ date: '2026-05-01', provider: 'claude', total_calls: 10 });
-    });
-
-    it('copies ai_budgets rows across and preserves the unique id constraint', () => {
-      openSharedWithAiUsage({
-        budgets: [
-          { id: 'global', scopeType: 'global', action: 'warn' },
-          { id: 'claude', scopeType: 'provider', action: 'block' },
-        ],
-      });
-      const core = openCoreDb(join(tmpDir, 'core.db'));
-      setCoreDb(core);
-
-      backfillCoreFromShared();
-      const rows = core.raw
-        .prepare('SELECT id, scope_type, action FROM ai_budgets ORDER BY id')
-        .all() as { id: string; scope_type: string; action: string }[];
-      expect(rows).toEqual([
-        { id: 'claude', scope_type: 'provider', action: 'block' },
-        { id: 'global', scope_type: 'global', action: 'warn' },
-      ]);
-    });
-
-    it('tolerates a shared DB without the ai_inference_log / ai_budgets tables', () => {
-      const path = join(tmpDir, 'pops.db');
-      const raw = new BetterSqlite3(path);
-      raw.exec(SERVICE_ACCOUNTS_TABLE_SQL);
-      raw.close();
-      process.env['SQLITE_PATH'] = path;
-
-      const core = openCoreDb(join(tmpDir, 'core.db'));
-      setCoreDb(core);
-
-      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
-      try {
-        expect(() => backfillCoreFromShared()).not.toThrow();
-        expect(warn).not.toHaveBeenCalled();
-      } finally {
-        warn.mockRestore();
-      }
-      const logCount = core.raw.prepare('SELECT count(*) AS n FROM ai_inference_log').get() as {
-        n: number;
-      };
-      const budgetCount = core.raw.prepare('SELECT count(*) AS n FROM ai_budgets').get() as {
-        n: number;
-      };
-      expect(logCount.n).toBe(0);
-      expect(budgetCount.n).toBe(0);
-    });
-
-    it('carries every column across (full-shape roundtrip)', () => {
-      const path = join(tmpDir, 'pops.db');
-      const raw = new BetterSqlite3(path);
-      raw.exec(SERVICE_ACCOUNTS_TABLE_SQL);
-      raw.exec(AI_INFERENCE_LOG_TABLE_SQL);
-      raw.exec(AI_INFERENCE_DAILY_TABLE_SQL);
-      raw.exec(AI_BUDGETS_TABLE_SQL);
-      raw
-        .prepare(
-          `INSERT INTO ai_inference_log
+  it('carries every column across (full-shape roundtrip)', () => {
+    const path = join(tmpDir, 'pops.db');
+    const raw = new BetterSqlite3(path);
+    raw.exec(AI_INFERENCE_LOG_TABLE_SQL);
+    raw
+      .prepare(
+        `INSERT INTO ai_inference_log
             (id, provider, model, operation, domain, input_tokens, output_tokens, cost_usd,
              latency_ms, status, cached, context_id, error_message, metadata, created_at)
            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-        )
-        .run(
-          42,
-          'claude',
-          'sonnet',
-          'classify',
-          'finance',
-          1000,
-          500,
-          0.0123,
-          250,
-          'success',
-          1,
-          'ctx_abc',
-          null,
-          '{"k":"v"}',
-          '2026-06-03T10:11:12.000Z'
-        );
-      raw.close();
-      process.env['SQLITE_PATH'] = path;
+      )
+      .run(
+        42,
+        'claude',
+        'sonnet',
+        'classify',
+        'finance',
+        1000,
+        500,
+        0.0123,
+        250,
+        'success',
+        1,
+        'ctx_abc',
+        null,
+        '{"k":"v"}',
+        '2026-06-03T10:11:12.000Z'
+      );
+    raw.close();
+    process.env['SQLITE_PATH'] = path;
 
-      const core = openCoreDb(join(tmpDir, 'core.db'));
-      setCoreDb(core);
+    const core = openCoreDb(join(tmpDir, 'core.db'));
+    setCoreDb(core);
 
-      backfillCoreFromShared();
-      const row = core.raw
-        .prepare('SELECT * FROM ai_inference_log WHERE id = 42')
-        .get() as InferenceLogRow;
-      expect(row).toEqual({
-        id: 42,
-        provider: 'claude',
-        model: 'sonnet',
-        operation: 'classify',
-        domain: 'finance',
-        input_tokens: 1000,
-        output_tokens: 500,
-        cost_usd: 0.0123,
-        latency_ms: 250,
-        status: 'success',
-        cached: 1,
-        context_id: 'ctx_abc',
-        error_message: null,
-        metadata: '{"k":"v"}',
-        created_at: '2026-06-03T10:11:12.000Z',
-      });
+    backfillCoreFromShared();
+    const row = core.raw
+      .prepare('SELECT * FROM ai_inference_log WHERE id = 42')
+      .get() as InferenceLogRow;
+    expect(row).toEqual({
+      id: 42,
+      provider: 'claude',
+      model: 'sonnet',
+      operation: 'classify',
+      domain: 'finance',
+      input_tokens: 1000,
+      output_tokens: 500,
+      cost_usd: 0.0123,
+      latency_ms: 250,
+      status: 'success',
+      cached: 1,
+      context_id: 'ctx_abc',
+      error_message: null,
+      metadata: '{"k":"v"}',
+      created_at: '2026-06-03T10:11:12.000Z',
     });
   });
 });

--- a/apps/pops-api/src/db/backfill-test-fixtures-core.ts
+++ b/apps/pops-api/src/db/backfill-test-fixtures-core.ts
@@ -2,32 +2,11 @@
  * SQL fixtures for the core-pillar backfill suite. Split out of
  * `backfill-test-fixtures.ts` to keep each file under the 200-line cap.
  * See that module's header for why these DDLs live alongside the tests.
+ *
+ * Theme 13 round 2 retired the `service_accounts`, `settings`,
+ * `ai_inference_daily`, and `ai_budgets` fixtures alongside their
+ * `TABLE_COPIES` entries — only `ai_inference_log` is still bridged.
  */
-export const SERVICE_ACCOUNTS_TABLE_SQL = `
-CREATE TABLE service_accounts (
-  id text PRIMARY KEY NOT NULL,
-  name text NOT NULL,
-  key_prefix text NOT NULL,
-  key_hash text NOT NULL,
-  scopes text DEFAULT '[]' NOT NULL,
-  created_at text DEFAULT (datetime('now')) NOT NULL,
-  last_used_at text,
-  revoked_at text,
-  created_by text
-);
-CREATE UNIQUE INDEX service_accounts_name_unique ON service_accounts (name);
-CREATE UNIQUE INDEX service_accounts_key_prefix_unique ON service_accounts (key_prefix);
-CREATE INDEX idx_service_accounts_key_prefix ON service_accounts (key_prefix);
-CREATE INDEX idx_service_accounts_revoked_at ON service_accounts (revoked_at);
-`;
-
-export const SETTINGS_TABLE_SQL = `
-CREATE TABLE settings (
-  key text PRIMARY KEY NOT NULL,
-  value text NOT NULL
-);
-`;
-
 export const AI_INFERENCE_LOG_TABLE_SQL = `
 CREATE TABLE ai_inference_log (
   id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
@@ -52,40 +31,4 @@ CREATE INDEX idx_ai_inference_log_operation ON ai_inference_log (operation);
 CREATE INDEX idx_ai_inference_log_domain ON ai_inference_log (domain);
 CREATE INDEX idx_ai_inference_log_context_id ON ai_inference_log (context_id);
 CREATE INDEX idx_ai_inference_log_status ON ai_inference_log (status);
-`;
-
-export const AI_INFERENCE_DAILY_TABLE_SQL = `
-CREATE TABLE ai_inference_daily (
-  id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
-  date text NOT NULL,
-  provider text NOT NULL,
-  model text NOT NULL,
-  operation text NOT NULL,
-  domain text,
-  total_calls integer DEFAULT 0 NOT NULL,
-  total_input_tokens integer DEFAULT 0 NOT NULL,
-  total_output_tokens integer DEFAULT 0 NOT NULL,
-  total_cost_usd real DEFAULT 0 NOT NULL,
-  avg_latency_ms integer DEFAULT 0 NOT NULL,
-  error_count integer DEFAULT 0 NOT NULL,
-  timeout_count integer DEFAULT 0 NOT NULL,
-  cache_hit_count integer DEFAULT 0 NOT NULL,
-  budget_blocked_count integer DEFAULT 0 NOT NULL
-);
-CREATE UNIQUE INDEX idx_ai_inference_daily_key ON ai_inference_daily (date, provider, model, operation, domain);
-CREATE INDEX idx_ai_inference_daily_date ON ai_inference_daily (date);
-CREATE INDEX idx_ai_inference_daily_provider_model ON ai_inference_daily (provider, model);
-`;
-
-export const AI_BUDGETS_TABLE_SQL = `
-CREATE TABLE ai_budgets (
-  id text PRIMARY KEY NOT NULL,
-  scope_type text NOT NULL,
-  scope_value text,
-  monthly_token_limit integer,
-  monthly_cost_limit real,
-  action text DEFAULT 'warn' NOT NULL,
-  created_at text NOT NULL,
-  updated_at text NOT NULL
-);
 `;

--- a/apps/pops-api/src/db/backfill-test-fixtures.ts
+++ b/apps/pops-api/src/db/backfill-test-fixtures.ts
@@ -12,13 +12,7 @@
  * `-media.ts`, `-finance.ts`) so each file stays under the 200-line
  * lint cap. This barrel keeps the existing import surface stable.
  */
-export {
-  AI_BUDGETS_TABLE_SQL,
-  AI_INFERENCE_DAILY_TABLE_SQL,
-  AI_INFERENCE_LOG_TABLE_SQL,
-  SERVICE_ACCOUNTS_TABLE_SQL,
-  SETTINGS_TABLE_SQL,
-} from './backfill-test-fixtures-core.js';
+export { AI_INFERENCE_LOG_TABLE_SQL } from './backfill-test-fixtures-core.js';
 export {
   MOVIES_TABLE_SQL,
   SHELF_IMPRESSIONS_TABLE_SQL,

--- a/apps/pops-api/src/db/core-backfill.ts
+++ b/apps/pops-api/src/db/core-backfill.ts
@@ -4,12 +4,23 @@ import { resolveSqlitePath } from './sqlite-path.js';
  * Boot-time backfill from the legacy shared `pops.db` into the core
  * pillar's `core.db`.
  *
- * Each slice cutover (Phase 2 PR 3 service-accounts, PRD-183 settings, …)
- * flips its handle to `getCoreDrizzle()`. The first deploy after each
- * cutover needs to carry the existing rows from the shared DB across
- * before any reads come from the new file. Subsequent boots find the
- * core copy already populated and become a no-op via the
- * `WHERE <id> NOT IN (...)` existence filter on every table.
+ * Each slice cutover (Phase 2 PR 3 service-accounts, PRD-183 settings,
+ * PRD-186 ai-usage, …) flips its handle to `getCoreDrizzle()`. The
+ * first deploy after each cutover needs to carry the existing rows
+ * from the shared DB across before any reads come from the new file.
+ * Subsequent boots find the core copy already populated and become a
+ * no-op via the `WHERE <id> NOT IN (...)` existence filter on every
+ * table.
+ *
+ * Theme 13 round 2 retired the `service_accounts`, `settings`,
+ * `ai_inference_daily`, and `ai_budgets` entries from `TABLE_COPIES`
+ * — every write site for those tables now lands on `core.db` via
+ * `getCoreDrizzle()`. `ai_inference_log` stays on the bridge because
+ * `modules/food/routers/ai.ts` still writes to it via the shared
+ * `getDrizzle()` handle (food-pillar PR 3 follow-up). Depends on the
+ * settings + ai-usage + service-accounts PR 3 deploys having shipped
+ * to prod before the retired entries are dropped; otherwise late
+ * rows on `pops.db` would be stranded.
  *
  * No FK relationships exist between the listed core tables, so order
  * is independent — but each entry is wrapped in `tryCopyTable` so a
@@ -39,26 +50,6 @@ interface TableCopy {
 
 const TABLE_COPIES: readonly TableCopy[] = [
   {
-    table: 'service_accounts',
-    idColumn: 'id',
-    columns: [
-      'id',
-      'name',
-      'key_prefix',
-      'key_hash',
-      'scopes',
-      'created_at',
-      'last_used_at',
-      'revoked_at',
-      'created_by',
-    ],
-  },
-  {
-    table: 'settings',
-    idColumn: 'key',
-    columns: ['key', 'value'],
-  },
-  {
     table: 'ai_inference_log',
     idColumn: 'id',
     columns: [
@@ -77,41 +68,6 @@ const TABLE_COPIES: readonly TableCopy[] = [
       'error_message',
       'metadata',
       'created_at',
-    ],
-  },
-  {
-    table: 'ai_inference_daily',
-    idColumn: 'id',
-    columns: [
-      'id',
-      'date',
-      'provider',
-      'model',
-      'operation',
-      'domain',
-      'total_calls',
-      'total_input_tokens',
-      'total_output_tokens',
-      'total_cost_usd',
-      'avg_latency_ms',
-      'error_count',
-      'timeout_count',
-      'cache_hit_count',
-      'budget_blocked_count',
-    ],
-  },
-  {
-    table: 'ai_budgets',
-    idColumn: 'id',
-    columns: [
-      'id',
-      'scope_type',
-      'scope_value',
-      'monthly_token_limit',
-      'monthly_cost_limit',
-      'action',
-      'created_at',
-      'updated_at',
     ],
   },
 ];


### PR DESCRIPTION
## Summary

Drops the four PR4-ready entries (`service_accounts`, `settings`, `ai_inference_daily`, `ai_budgets`) from `apps/pops-api/src/db/core-backfill.ts`. Their PR3 writer cutovers have shipped — every write site lands on `core.db` via `getCoreDrizzle()`, so the ATTACH bridge has nothing left to carry forward. `ai_inference_log` stays on the bridge because `apps/pops-api/src/modules/food/routers/ai.ts:69` still writes to it via the shared `getDrizzle()` handle.

Mirrors the movies (#3050) and cerebrum (#3043) precedent: drop the `TABLE_COPIES` entry plus the corresponding test block, leave drizzle-migrations alone. There are no per-table shim wrappers to delete in this codebase.

## Audit

Grepped `apps/pops-api/src/` (excluding `modules/core/`), `apps/pops-shell`, `apps/pops-mcp`, `apps/pops-cli`, `apps/pops-worker-*` for `getDrizzle()` reads/writes against each candidate:

- `service_accounts` — only `modules/core/service-accounts` + `trpc.ts` `authenticateServiceAccount`, both on `getCoreDrizzle()`.
- `settings` — every non-core caller (media/rotation, media/plex, media/arr, cerebrum, inventory document-files, food, finance, comparisons) uses `getCoreDrizzle()` via `settingsService`.
- `ai_inference_daily` / `ai_budgets` — only `modules/core/ai-usage` + `modules/core/ai-budgets`, both on `getCoreDrizzle()`.
- `ai_inference_log` — **blocked**. `modules/food/routers/ai.ts:69` still writes via `getDrizzle()`. Kept on the bridge.

## Deploy order

Depends on PR3 deploys for service-accounts, settings, and ai-usage being in prod before this lands — otherwise late-arriving rows on `pops.db` for those tables would be stranded.

## Test plan

- [x] `pnpm --filter @pops/api typecheck` — clean.
- [x] `pnpm vitest run src/db/backfill-core-from-shared.test.ts src/modules/core/` in `apps/pops-api` — 536 passed.
- [x] Root `pnpm typecheck` — 66/66 successful.
- [x] Pre-push hook (root typecheck) — green.
- [ ] CI `API Tests` workflow on the PR.
