### PR TITLE
feat(media): drop PR4-ready media tables (Theme 13 round 2)

### DIFF
--- a/apps/pops-api/src/db/backfill-media-from-shared.test.ts
+++ b/apps/pops-api/src/db/backfill-media-from-shared.test.ts
@@ -16,7 +16,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import BetterSqlite3 from 'better-sqlite3';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { openMediaDb } from '@pops/media-db';
 
@@ -44,88 +44,10 @@ afterEach(() => {
   else process.env['SQLITE_PATH'] = originalSharedPath;
 });
 
-function openSharedWithRows(rows: { shelfId: string; shownAt: string }[]): string {
-  const path = join(tmpDir, 'pops.db');
-  const raw = new BetterSqlite3(path);
-  raw.exec(SHELF_IMPRESSIONS_TABLE_SQL);
-  const insert = raw.prepare('INSERT INTO shelf_impressions (shelf_id, shown_at) VALUES (?, ?)');
-  for (const row of rows) {
-    insert.run(row.shelfId, row.shownAt);
-  }
-  raw.close();
-  process.env['SQLITE_PATH'] = path;
-  return path;
-}
-
 describe('backfillMediaFromShared', () => {
   it('returns silently when the media handle is closed', () => {
     setMediaDb(null);
     expect(() => backfillMediaFromShared()).not.toThrow();
-  });
-
-  it('copies fresh rows on first run and is a no-op on the second', () => {
-    openSharedWithRows([
-      { shelfId: 'trending', shownAt: '2026-06-09 12:00:00' },
-      { shelfId: 'because-you-watched:42', shownAt: '2026-06-09 12:00:01' },
-    ]);
-    const media = openMediaDb(join(tmpDir, 'media.db'));
-    setMediaDb(media);
-
-    backfillMediaFromShared();
-    const after = media.raw
-      .prepare('SELECT id, shelf_id FROM shelf_impressions ORDER BY id')
-      .all() as { id: number; shelf_id: string }[];
-    expect(after.map((r) => r.shelf_id)).toEqual(['trending', 'because-you-watched:42']);
-
-    backfillMediaFromShared();
-    const second = media.raw.prepare('SELECT count(*) AS n FROM shelf_impressions').get() as {
-      n: number;
-    };
-    expect(second.n).toBe(2);
-  });
-
-  it('only inserts rows missing from the media copy', () => {
-    openSharedWithRows([
-      { shelfId: 'trending', shownAt: '2026-06-09 12:00:00' },
-      { shelfId: 'because-you-watched:42', shownAt: '2026-06-09 12:00:01' },
-    ]);
-    const media = openMediaDb(join(tmpDir, 'media.db'));
-    setMediaDb(media);
-    // Pre-seed id=1 in media so the backfill should skip it and only carry id=2 across.
-    media.raw
-      .prepare('INSERT INTO shelf_impressions (id, shelf_id, shown_at) VALUES (?, ?, ?)')
-      .run(1, 'pre-existing', '2026-06-08 09:00:00');
-
-    backfillMediaFromShared();
-    const rows = media.raw
-      .prepare('SELECT id, shelf_id FROM shelf_impressions ORDER BY id')
-      .all() as { id: number; shelf_id: string }[];
-    expect(rows).toEqual([
-      { id: 1, shelf_id: 'pre-existing' },
-      { id: 2, shelf_id: 'because-you-watched:42' },
-    ]);
-  });
-
-  it('tolerates a shared DB without the shelf_impressions table', () => {
-    const path = join(tmpDir, 'pops.db');
-    const raw = new BetterSqlite3(path);
-    raw.close();
-    process.env['SQLITE_PATH'] = path;
-
-    const media = openMediaDb(join(tmpDir, 'media.db'));
-    setMediaDb(media);
-
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
-    try {
-      expect(() => backfillMediaFromShared()).not.toThrow();
-      expect(warn).not.toHaveBeenCalled();
-    } finally {
-      warn.mockRestore();
-    }
-    const count = media.raw.prepare('SELECT count(*) AS n FROM shelf_impressions').get() as {
-      n: number;
-    };
-    expect(count.n).toBe(0);
   });
 
   describe('tv_shows (PRD-166 PR 1)', () => {
@@ -134,7 +56,6 @@ describe('backfillMediaFromShared', () => {
     ): string {
       const path = join(tmpDir, 'pops.db');
       const raw = new BetterSqlite3(path);
-      raw.exec(SHELF_IMPRESSIONS_TABLE_SQL);
       raw.exec(TV_SHOWS_TABLE_SQL);
       const insert = raw.prepare(
         'INSERT INTO tv_shows (tvdb_id, name, first_air_date) VALUES (?, ?, ?)'
@@ -192,7 +113,6 @@ describe('backfillMediaFromShared', () => {
     it('carries every column across (full-shape roundtrip)', () => {
       const path = join(tmpDir, 'pops.db');
       const raw = new BetterSqlite3(path);
-      raw.exec(SHELF_IMPRESSIONS_TABLE_SQL);
       raw.exec(TV_SHOWS_TABLE_SQL);
       raw
         .prepare(
@@ -274,7 +194,6 @@ describe('backfillMediaFromShared', () => {
     it('tolerates a shared DB without the tv_shows table', () => {
       const path = join(tmpDir, 'pops.db');
       const raw = new BetterSqlite3(path);
-      raw.exec(SHELF_IMPRESSIONS_TABLE_SQL);
       raw.close();
       process.env['SQLITE_PATH'] = path;
 
@@ -299,7 +218,6 @@ describe('backfillMediaFromShared', () => {
     function openSharedWithWatchHistory(rows: WatchHistorySeed[]): string {
       const path = join(tmpDir, 'pops.db');
       const raw = new BetterSqlite3(path);
-      raw.exec(SHELF_IMPRESSIONS_TABLE_SQL);
       raw.exec(WATCH_HISTORY_TABLE_SQL);
       const insert = raw.prepare(
         'INSERT INTO watch_history (media_type, media_id, watched_at, completed, blacklisted) VALUES (?, ?, ?, ?, ?)'
@@ -392,11 +310,8 @@ describe('backfillMediaFromShared', () => {
     });
 
     it('tolerates a shared DB without the watch_history table', () => {
-      // Shared DB has shelf_impressions but no watch_history — backfill
-      // copies shelf rows and skips watch_history without throwing.
       const path = join(tmpDir, 'pops.db');
       const raw = new BetterSqlite3(path);
-      raw.exec(SHELF_IMPRESSIONS_TABLE_SQL);
       raw.close();
       process.env['SQLITE_PATH'] = path;
 
@@ -424,7 +339,6 @@ describe('backfillMediaFromShared', () => {
     function openSharedWithWatchlist(rows: WatchlistSeed[]): string {
       const path = join(tmpDir, 'pops.db');
       const raw = new BetterSqlite3(path);
-      raw.exec(SHELF_IMPRESSIONS_TABLE_SQL);
       raw.exec(WATCHLIST_TABLE_SQL);
       const insert = raw.prepare(
         'INSERT INTO watchlist (media_type, media_id, priority, notes, source, plex_rating_key) VALUES (?, ?, ?, ?, ?, ?)'
@@ -518,11 +432,8 @@ describe('backfillMediaFromShared', () => {
     });
 
     it('tolerates a shared DB without the watchlist table', () => {
-      // Shared DB has shelf_impressions but no watchlist — backfill copies
-      // shelf rows and skips watchlist without throwing.
       const path = join(tmpDir, 'pops.db');
       const raw = new BetterSqlite3(path);
-      raw.exec(SHELF_IMPRESSIONS_TABLE_SQL);
       raw.close();
       process.env['SQLITE_PATH'] = path;
 

--- a/apps/pops-api/src/db/media-backfill.ts
+++ b/apps/pops-api/src/db/media-backfill.ts
@@ -19,6 +19,13 @@ import { resolveSqlitePath } from './sqlite-path.js';
  * to prod first; otherwise late-arriving rows on `pops.db.movies` would
  * be stranded.
  *
+ * PRD-170 shelf_impressions has the same story: every read and write of
+ * `shelf_impressions` routes through `shelfImpressionsService` on the
+ * media pillar handle (Phase 2 PR 3). The boot bridge no longer has a
+ * source of new rows to carry across, so the `shelf_impressions` entry
+ * is retired here. Same deploy-order constraint as movies — the writer
+ * cutover must be live in prod before this drop ships.
+ *
  * No FK relationships exist between the listed media tables, so order
  * is independent — but each entry is wrapped in `tryCopyTable` so a
  * missing source table (post-PR-4 drop scenario, or a stale on-disk
@@ -67,11 +74,6 @@ interface TableCopy {
 }
 
 const TABLE_COPIES: readonly TableCopy[] = [
-  {
-    table: 'shelf_impressions',
-    idColumn: 'id',
-    columns: ['id', 'shelf_id', 'shown_at'],
-  },
   {
     table: 'tv_shows',
     idColumn: 'id',


### PR DESCRIPTION
## Summary

- Retires `shelf_impressions` from the media boot-time backfill bridge (`TABLE_COPIES` in `apps/pops-api/src/db/media-backfill.ts`). PRD-170 already cut every shelf-impressions read and write to `getMediaDrizzle()` via `shelfImpressionsService` on `@pops/media-db`, so the bridge has nothing left to carry forward for this slice.
- Drops the corresponding `shelf_impressions` test block from `backfill-media-from-shared.test.ts` and the now-unused `SHELF_IMPRESSIONS_TABLE_SQL` exec calls in the remaining `tv_shows` / `watch_history` / `watchlist` fixtures.
- Updates the file-level docblock to note shelf_impressions' retirement and the same deploy-order constraint as the movies PR4 (#3050).

## Audit (which other media tables were considered, why they did NOT make this bundle)

| Table             | PR4-ready? | Blocker                                                                                                                                                                                                                                                                                                          |
| ----------------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| shelf_impressions | YES        | -                                                                                                                                                                                                                                                                                                                |
| tv_shows          | No         | `library/tv-show-service.ts::addTvShow` runs a mixed-table `getDrizzle().transaction(...)` over `tv_shows` + `seasons` + `episodes` + `movies`. Moving `tv_shows` would split the atomic insert across two SQLite files.                                                                                          |
| watch_history     | No         | `watch-history/handlers/log-watch-event.ts::logWatch` is the documented PRD-167 blocker: a single `getDrizzle().transaction(...)` over `watchHistory` + `episodes` + `seasons` + `mediaWatchlist` + `debrief*`. Additionally `comparisons/service.ts::blacklistMovie` runs raw `UPDATE watch_history` on pops.db. |
| watchlist         | No         | Bound to the same mixed-tx as watch_history. PRD-167 PR2 docs in `watchlist/service.ts` confirm every write path (`addToWatchlist`, `updateWatchlistEntry`, `removeFromWatchlist`, `reorderWatchlist`, `removeByMedia`, `resequencePriorities`) still targets `pops.db` via `getDrizzle()`.                        |

Non-media `getDrizzle()` / `getDb()` readers of these tables (e.g. `routes/media/images.ts` selecting from `pops.db.tv_shows`) read from the legacy store directly — they don't depend on the backfill bridge, so they don't block PR4. They block PRD-213 (final pops.db drop).

`TABLE_COPIES` still contains tv_shows / watch_history / watchlist after this PR, so `media-backfill.ts` stays. Follows the same precedent as movies PR4 (#3050) — only the retired entry is removed.

## Test plan

- [x] `pnpm -F @pops/api typecheck`
- [x] `pnpm -F @pops/api exec vitest run src/modules/media src/db/backfill-media-from-shared.test.ts` (91 files, 1455 tests pass)
- [x] `pnpm -F @pops/media-db test` (7 files, 133 tests pass)
- [ ] CI green