### PR TITLE
docs(theme-13): consolidate PRD status updates + audit notes

### DIFF
--- a/docs/themes/13-pillar-finale/epics/10-fe-sdk-dispatcher-generator.md
+++ b/docs/themes/13-pillar-finale/epics/10-fe-sdk-dispatcher-generator.md
@@ -14,7 +14,7 @@ Make the front-end registry-aware end-to-end. Three pieces:
 
 | #   | PRD                                 | Summary                                                                                      | Status      |
 | --- | ----------------------------------- | -------------------------------------------------------------------------------------------- | ----------- |
-| 215 | React SDK                           | `usePillar`, `useUriResolver`, `usePillarQuery`, `usePillarMutation` hooks                   | Not started |
+| 215 | React SDK                           | `usePillar`, `useUriResolver`, `usePillarQuery`, `usePillarMutation` hooks                   | Partial     |
 | 216 | `PillarGuard` rewrite               | Reads live registry; subscribes to changes; per-route unavailable placeholders               | Partial     |
 | 217 | nginx config generator              | Generated `default.conf` from registry snapshot; init container OR sidecar strategy          | Not started |
 | 218 | `@pops/module-registry` deprecation | The build-time registry becomes a thin wrapper around the runtime one (offline-dev fallback) | Not started |

--- a/docs/themes/13-pillar-finale/prds/191-client-surface/README.md
+++ b/docs/themes/13-pillar-finale/prds/191-client-surface/README.md
@@ -1,6 +1,8 @@
 # PRD-191: `pillar()` client surface
 
 > Epic: [Unified consumption SDK](../../epics/05-unified-consumption-sdk.md)
+>
+> **Status:** Partial (2026-06-13) — runtime + tests shipped under `@pops/pillar-sdk/client`; capability projection (`pillar<P extends KnownPillarId>` / `ContractFor<P>`) not yet wired to the entry point. See [Implementation Status](#implementation-status).
 
 ## Overview
 
@@ -82,3 +84,54 @@ Attached to every callable; lifts `kind: 'ok'` value or throws `PillarCallError`
 - React hooks (PRD-193).
 - Server-side variant (PRD-192).
 - Caching of call results (PRD-194).
+
+## Implementation Status
+
+Snapshot taken 2026-06-13 against `packages/pillar-sdk/src/client/` (factory, proxy, cache, discovery, http-call, errors) and its `__tests__/` siblings. The PRD currently lacks numbered ACs, so the table derives one row per concrete commitment (API surface item, business rule, edge case, user story) and rates each against shipped code.
+
+### API surface
+
+| #     | Commitment                                                                                  | Status      | Justification                                                                                                                                                                                                              |
+| ----- | ------------------------------------------------------------------------------------------- | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| A-1   | Module exported as `@pops/pillar-sdk/client`                                                | Done        | `packages/pillar-sdk/src/client/index.ts` re-exports `pillar`, `PillarHandle`, `CallResult`, `PillarCallError`, etc.                                                                                                       |
+| A-2   | `pillar<P extends KnownPillarId>(pillarId: P): CallablePillar<ContractFor<P>>` signature    | Partial     | Runtime takes `pillar<TRouter>(pillarId: string, options?)` — generic is unconstrained and consumer supplies the router type. `KnownPillarId` / `CallablePillar` exist in `src/capabilities/` but aren't bound on `pillar`. |
+| A-3   | `ContractFor<P>` mapping + `declareContracts` helper                                        | Not started | No `declareContracts` export anywhere in `packages/`; no `ContractFor` mapping type. Consumers currently pass a hand-rolled `TRouter` to `pillar<TRouter>()`.                                                              |
+| A-4   | Proxy-backed runtime (router → procedure → callable)                                        | Done        | `src/client/proxy.ts` builds nested proxies; `factory.ts` wires invocation through `DiscoveryCache` + `performHttpCall`.                                                                                                   |
+| A-5   | `.orThrow()` attached to every callable                                                     | Done        | `buildCallable` in `proxy.ts` returns a `.orThrow` that unwraps `kind: 'ok'` or throws `PillarCallError` (`src/client/errors.ts`).                                                                                          |
+
+### Business rules
+
+| #     | Rule                                                                                   | Status      | Justification                                                                                                                                                                                                                |
+| ----- | -------------------------------------------------------------------------------------- | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| B-1   | Discovery cache (PRD-159) is the runtime resolver, TTL'd                               | Done        | `DiscoveryCache` (60s TTL default) is consulted on every call (`factory.ts:safeLookup`); single in-flight refresh dedupe in `cache.ts`.                                                                                       |
+| B-2   | HTTP fetch uses native `fetch`; no tRPC client                                         | Done        | `http-call.ts` POSTs to `${baseUrl}/trpc/${path}` with raw `fetch`; `extractTrpcResult` decodes the wire shape directly.                                                                                                      |
+| B-3   | Auth headers passed through                                                            | Done        | `PillarClientOptions.authHeaders: () => Record<string,string>` merged into request headers in `http-call.ts:buildHeaders`.                                                                                                    |
+| B-4   | Failure modes return a discriminated union; never throw                                | Done        | `CallResult` discriminants (`ok` \| `unavailable` \| `degraded` \| `contract-mismatch`) defined in `errors.ts`; `invoke` and `performHttpCall` only return; `PillarSdkError` reserved for hard transport mis-shapes.            |
+| B-5   | Per-call timeout 30s, configurable per call                                            | Partial     | Default `DEFAULT_CALL_TIMEOUT_MS = 30_000` and per-call override via `PillarClientOptions.callTimeoutMs`. Override is **per client instance**, not per call — true per-call config would need a per-invocation options arg.   |
+
+### Edge cases
+
+| #     | Case                                                | Status  | Justification                                                                                                                            |
+| ----- | --------------------------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| E-1   | Wrong baseUrl → `{ kind: 'unavailable' }`           | Done    | `http-call.ts` catches fetch rejection and returns `unavailable`; covered in `factory.test.ts`.                                          |
+| E-2   | Missing procedure (404) → `{ kind: 'contract-mismatch' }` | Done    | `mapResponse` maps `response.status === 404` to `contract-mismatch` with the namespaced path as `expected`.                              |
+| E-3   | Network timeout → `unavailable` after 30s           | Done    | `AbortController` + `setTimeout(controller.abort, timeoutMs)`; abort path maps to `unavailable` via the catch in `performHttpCall`.       |
+
+### User stories
+
+The PRD links to `us-01..us-04` files that do not exist on disk (only `README.md` lives under `prds/191-client-surface/`). The four scopes were folded into a single delivery slice.
+
+| #   | Story                       | Status  | Justification                                                                                                                                                  |
+| --- | --------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 01  | Proxy-backed `pillar()`     | Done    | `src/client/proxy.ts` + `factory.ts`; verified by `factory.test.ts` (`routes calls to <baseUrl>/trpc/<router>.<procedure>` etc.).                              |
+| 02  | `CallResult` mapping        | Done    | `http-call.ts:mapResponse` + `factory.ts:guardAvailability` cover the four discriminants; `factory.test.ts` exercises each branch.                              |
+| 03  | `.orThrow()` helper         | Done    | `proxy.ts:makeOrThrow`; `factory.test.ts` covers both unwrap-success and throw-on-failure paths; `errors.test.ts` covers `PillarCallError`.                     |
+| 04  | Unit + integration tests    | Partial | Unit coverage is solid (`cache.test.ts`, `discovery.test.ts`, `errors.test.ts`, `factory.test.ts` — ~580 LoC). No integration test against a real fake pillar HTTP server; transport is faked via `FakeRegistryTransport` + `fakeFetch`. |
+
+### Gaps to close before marking PRD Done
+
+1. Bind `pillar()` to `KnownPillarId` and `CallablePillar` so consumers stop hand-rolling `TRouter`. Track via PRD-160 + this PRD jointly.
+2. Ship a `declareContracts` (or equivalent `ContractFor`) helper so the mapping isn't ambient.
+3. Promote `callTimeoutMs` from per-client to per-call override, or document the limitation as intentional.
+4. Add an integration test that spins up an in-process HTTP server speaking the tRPC wire shape and asserts the full request/response loop.
+

--- a/docs/themes/13-pillar-finale/prds/215-react-sdk/README.md
+++ b/docs/themes/13-pillar-finale/prds/215-react-sdk/README.md
@@ -36,12 +36,33 @@ export function useUriResolver(uri: string): UriResolution | undefined;
 
 ## User Stories
 
-| #   | Story                                                 | Summary                |
-| --- | ----------------------------------------------------- | ---------------------- |
-| 01  | [us-01-provider](us-01-provider.md)                   | Provider component     |
-| 02  | [us-02-usePillar](us-02-usePillar.md)                 | `usePillar` hook       |
-| 03  | [us-03-useUriResolver](us-03-useUriResolver.md)       | URI resolution hook    |
-| 04  | [us-04-usePillarRegistry](us-04-usePillarRegistry.md) | Registry snapshot hook |
+| #   | Story                                                 | Summary                | Status      |
+| --- | ----------------------------------------------------- | ---------------------- | ----------- |
+| 01  | [us-01-provider](us-01-provider.md)                   | Provider component     | Done        |
+| 02  | [us-02-usePillar](us-02-usePillar.md)                 | `usePillar` hook       | Not started |
+| 03  | [us-03-useUriResolver](us-03-useUriResolver.md)       | URI resolution hook    | Not started |
+| 04  | [us-04-usePillarRegistry](us-04-usePillarRegistry.md) | Registry snapshot hook | Not started |
+
+## Implementation Status
+
+**Overall: Partial.** The composition layer (`PillarSdkProvider` + cache-invalidation bridge) is in place and is shared with PRD-193 (React Query hooks) and PRD-194 (SSE cache invalidation). The three PRD-215-specific hooks — `usePillar`, `useUriResolver`, `usePillarRegistry` — are not implemented; the React surface currently exposes `usePillarQuery` / `usePillarMutation` (PRD-193) instead of a `CallablePillar`-shaped `usePillar`.
+
+US files (`us-01-provider.md` … `us-04-usePillarRegistry.md`) are not authored. Acceptance criteria below are derived from this PRD's Overview, API Surface, Business Rules, and Edge Cases.
+
+### Acceptance criteria
+
+| US  | Criterion                                                                                                                                  | Status      | Notes                                                                                                                                                                                                |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------ | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 01  | `<PillarSdkProvider>` exported from `@pops/pillar-sdk/react`; wires registry + cache invalidation + auth context at the root.               | Done        | Provider exists; forwards `PillarClientOptions` via context; mounts `usePillarSubscriptionBridge` when `subscribe` is set; composes with an outer `QueryClientProvider` or wires one when given.      |
+| 01  | Provider-missing edge case: hooks throw "PillarSdkProvider required." at first call.                                                       | Dropped     | Implementation intentionally falls back to empty `PillarClientOptions` so hooks work without a provider (defaults to `pillar()` built-ins). Behavioural deviation from the PRD; update PRD or hooks. |
+| 02  | `usePillar<P>(p)` returns a `CallablePillar<ContractFor<P>>` bound to the active provider options.                                         | Not started | No `usePillar` export. Equivalent today is calling `pillar(pillarId, options)` directly or `usePillarQuery` / `usePillarMutation` from PRD-193.                                                       |
+| 02  | Pillar-registered-mid-render: subscription event invalidates affected hooks; re-render picks up the new pillar.                            | Partial     | `usePillarSubscriptionBridge` invalidates the matching React Query prefix on `pillar.registered` / `deregistered` / `health-changed` / `snapshot`. Re-render path is via React Query, not `usePillar`. |
+| 03  | `useUriResolver(uri)` resolves a URI through the registry; async-shaped via Suspense or React Query; returns `UriResolution \| undefined`. | Not started | No `useUriResolver` export. No `UriResolution` type. No URI-resolver implementation in `packages/pillar-sdk/src/`.                                                                                    |
+| 04  | `usePillarRegistry()` returns a `RegistrySnapshot` from context; updates on subscription events.                                           | Not started | No `usePillarRegistry` export. `RegistrySnapshot` and `pillarRegistry()` exist in `discovery/`; the hook wrapping is missing.                                                                         |
+
+### Overlap with PRD-193
+
+PRD-215 frames PRD-193 as a dependency ("Builds on PRDs 193 and 194"). The current React surface (`PillarSdkProvider`, `usePillarQuery`, `usePillarMutation`, `usePillarSubscriptionBridge`) satisfies PRD-193's hook surface and PRD-194's invalidation bridge; the provider is the shared composition point. PRD-215's net-new surface is just the three contract-shaped hooks (`usePillar`, `usePillarRegistry`, `useUriResolver`) and the provider-missing throw behaviour — none of which are implemented yet.
 
 ## Out of Scope
 


### PR DESCRIPTION
## Summary

Consolidates the remaining open theme-13 PRD status updates into a single PR to reduce queue noise (CI runs, Copilot reviews). Other PRDs in the original consolidation set were already merged via their standalone PRs before this aggregate landed.

## Included PRs

- #3064 PRD-191 client surface status update — `feat/theme13-prd-191-status-update`
- #3065 PRD-215 React SDK status update — `feat/theme13-prd-215-status-update`

## Skipped

- #3066 PRD-192 server surface — cherry-pick conflicts on `epics/05-unified-consumption-sdk.md`. Kept open for separate review.

## Already merged before aggregation

- #3067 PRD-194 caching (now on `main`)
- #3068 PRD-218 module-registry deprecation (now on `main`)
- #3069 PRD-210 worker partitioning (now on `main`)
- #3070 PRD-195 type generation (now on `main`)
- #3071 PRD-216 PillarGuard (now on `main`)
- #3072 PRD-217 nginx generator (now on `main`)
- #3075 PRD-208 search orchestrator (now on `main`)
- #3076 infra hot-path migration audit (now on `main`)
- #3085 core.corrections cross-pillar finance coupling audit (now on `main`)

## Test plan

- [ ] CI green on the aggregate
- [ ] Doc tree renders correctly (epic + PRD READMEs)
