### PR TITLE
feat(media): route addTvShow tx through getMediaDrizzle (Theme 13 PR4 unblock)

### DIFF
--- a/.dependency-cruiser-known-violations.json
+++ b/.dependency-cruiser-known-violations.json
@@ -342,6 +342,17 @@
   },
   {
     "type": "dependency",
+    "from": "apps/pops-api/src/lib/inference-pricing.ts",
+    "to": "packages/core-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/core-db",
+    "dependencyTypes": ["undetermined", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-core"
+    }
+  },
+  {
+    "type": "dependency",
     "from": "apps/pops-api/src/modules/core/ai-budgets/enforcement.ts",
     "to": "packages/core-db/dist/index.d.ts",
     "unresolvedTo": "@pops/core-db",
@@ -397,6 +408,17 @@
   },
   {
     "type": "dependency",
+    "from": "apps/pops-api/src/modules/core/ai-usage/service.ts",
+    "to": "packages/core-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/core-db",
+    "dependencyTypes": ["undetermined", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-core"
+    }
+  },
+  {
+    "type": "dependency",
     "from": "apps/pops-api/src/modules/core/corrections/handlers/ai-inference.ts",
     "to": "packages/core-db/dist/index.d.ts",
     "unresolvedTo": "@pops/core-db",
@@ -409,6 +431,17 @@
   {
     "type": "dependency",
     "from": "apps/pops-api/src/modules/core/settings/service.ts",
+    "to": "packages/core-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/core-db",
+    "dependencyTypes": ["undetermined", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-core"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/food/__tests__/ai-router.test.ts",
     "to": "packages/core-db/dist/index.d.ts",
     "unresolvedTo": "@pops/core-db",
     "dependencyTypes": ["undetermined", "import"],
@@ -793,6 +826,28 @@
   },
   {
     "type": "dependency",
+    "from": "apps/pops-api/src/modules/inventory/connections/service.ts",
+    "to": "packages/inventory-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/inventory-db",
+    "dependencyTypes": ["undetermined", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-inventory"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/inventory/documents/service.ts",
+    "to": "packages/inventory-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/inventory-db",
+    "dependencyTypes": ["undetermined", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-inventory"
+    }
+  },
+  {
+    "type": "dependency",
     "from": "apps/pops-api/src/modules/inventory/items/service.ts",
     "to": "packages/inventory-db/dist/index.d.ts",
     "unresolvedTo": "@pops/inventory-db",
@@ -892,6 +947,28 @@
   },
   {
     "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/discovery/flags.test.ts",
+    "to": "packages/media-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["undetermined", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-media"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/discovery/flags.ts",
+    "to": "packages/media-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["undetermined", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-media"
+    }
+  },
+  {
+    "type": "dependency",
     "from": "apps/pops-api/src/modules/media/discovery/router-shelf.ts",
     "to": "packages/media-db/dist/index.d.ts",
     "unresolvedTo": "@pops/media-db",
@@ -904,6 +981,17 @@
   {
     "type": "dependency",
     "from": "apps/pops-api/src/modules/media/discovery/router.assemble-session.test.ts",
+    "to": "packages/media-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["undetermined", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-media"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/discovery/service.ts",
     "to": "packages/media-db/dist/index.d.ts",
     "unresolvedTo": "@pops/media-db",
     "dependencyTypes": ["undetermined", "import"],
@@ -936,6 +1024,17 @@
   },
   {
     "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/library/tv-show-service.ts",
+    "to": "packages/media-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["undetermined", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-media"
+    }
+  },
+  {
+    "type": "dependency",
     "from": "apps/pops-api/src/modules/media/movies/service.ts",
     "to": "packages/media-db/dist/index.d.ts",
     "unresolvedTo": "@pops/media-db",
@@ -951,6 +1050,17 @@
     "to": "packages/media-db/dist/index.d.ts",
     "unresolvedTo": "@pops/media-db",
     "dependencyTypes": ["undetermined", "type-only", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-media"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/plex/sync-discover-show.ts",
+    "to": "packages/media-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["undetermined", "import"],
     "rule": {
       "severity": "error",
       "name": "no-cross-pillar-runtime-import-media"

--- a/apps/pops-api/src/modules/media/library/tv-show-service.ts
+++ b/apps/pops-api/src/modules/media/library/tv-show-service.ts
@@ -1,33 +1,29 @@
 import { eq } from 'drizzle-orm';
 
-import { episodes, seasons, tvShows } from '@pops/db-types';
+import { episodes, seasons, tvShows } from '@pops/media-db';
 
-import { getDrizzle } from '../../../db.js';
+import { getMediaDrizzle } from '../../../db/media-db-handle.js';
 import { getTvShowByTvdbId } from '../tv-shows/service.js';
 
+import type { SeasonRow } from '@pops/db-types';
 /**
  * Add TV show to library — fetches TheTVDB metadata and inserts
- * show + seasons + episodes in a single transaction.
+ * show + seasons + episodes in a single transaction on `media.db`.
  *
- * Cross-store note (PRD-169): `addTvShow` stays on the shared
- * `getDrizzle()` handle. The atomic insert spans `tv_shows`, `seasons`,
- * and `episodes` — seasons and episodes have not been migrated to
- * `@pops/media-db` yet (see the doc on `tv-shows/tv-shows-base.ts` —
- * "Out of scope (per PRD-166): seasons-service.ts and episodes-service.ts
- * still route through getDrizzle()"). Wrapping the show insert on the
- * media handle and the seasons/episodes inserts on the shared handle
- * would split the transaction across two SQLite files and break the
- * atomicity guarantee callers rely on.
+ * As of Theme 13 PR4, `seasons` and `episodes` join `tv_shows` in
+ * `@pops/media-db`, so the whole atomic unit moves to
+ * `getMediaDrizzle()`. This preserves the all-or-nothing guarantee the
+ * library ingestion path relies on (a crash mid-transaction can't leave
+ * a parent `tv_shows` row without `seasons`/`episodes` children) while
+ * removing the last cross-store dependency that kept the library list /
+ * quick-picks reads on the shared handle.
  *
- * The library list-/quick-picks-side reads in `service.ts` and
- * `list-service.ts` therefore also stay on `getDrizzle()` until the
- * seasons/episodes (PRD-166 follow-up) and watch-history (PRD-168 PR 3)
- * writer cutovers land. Flipping just the reads would make newly-added
- * TV shows and watch events invisible to the library list, genres list,
- * and quick-picks until the next boot-time `backfillMediaFromShared()`.
- * The handle flip happens once the matching writers are on `media.db`.
+ * Callers that need to update the newly-inserted `tv_shows` row (notably
+ * `plex/sync-discover-show.ts`'s `discoverRatingKey` follow-up) must now
+ * also target `getMediaDrizzle()` — the row no longer lands in `pops.db`
+ * at all.
  */
-import type { SeasonRow, TvShowRow } from '@pops/db-types';
+import type { TvShowRow } from '@pops/media-db';
 
 import type { TheTvdbClient } from '../thetvdb/client.js';
 import type { TvdbArtwork, TvdbEpisode } from '../thetvdb/types.js';
@@ -58,7 +54,7 @@ async function fetchSeasonEpisodes(
 }
 
 interface InsertShowArgs {
-  tx: Parameters<Parameters<ReturnType<typeof getDrizzle>['transaction']>[0]>[0];
+  tx: Parameters<Parameters<ReturnType<typeof getMediaDrizzle>['transaction']>[0]>[0];
   detail: Awaited<ReturnType<TheTvdbClient['getSeriesExtended']>>;
   seasonEpisodes: Map<number, TvdbEpisode[]>;
   posterUrl: string | null;
@@ -172,34 +168,9 @@ function downloadShowImages(args: DownloadShowImagesArgs): void {
  *
  * - Idempotent: returns existing show if already in library.
  * - Fetches full detail + episodes from TheTVDB.
- * - Inserts show, seasons, and episodes in a single transaction.
- *
- * Cross-store note (PRD-166 PR 3): the `tv_shows` writer surface
- * migrated to `getMediaDrizzle()` in PR #3007, but this one transaction
- * stays on `getDrizzle()` (shared `pops.db`) because it co-mutates
- * `seasons` and `episodes` in the same atomic unit, and those tables
- * have not yet moved to `@pops/media-db`. Splitting the transaction
- * across two SQLite files would lose atomicity (a crash between the
- * `tv_shows` insert on media.db and the `seasons`/`episodes` inserts on
- * pops.db could leave a parent row without children, surfacing as
- * empty shows in the UI). Mirrors the mixed-table strategy used by
- * `rotation/download-candidate.ts` in PRD-165 PR 3.
- *
- * Until the migration completes, callers that need to update the
- * `tv_shows` row immediately after creation must address the row on
- * the SAME handle the insert landed on — i.e. `getDrizzle()` — or the
- * update will silently no-op (the `backfillMediaFromShared` bridge is
- * insert-only and only runs at boot, so a media.db update against an
- * id that lives only in pops.db hits zero rows). The post-`addTvShow`
- * `discoverRatingKey` update in `plex/sync-discover-show.ts` is
- * routed through `getDrizzle()` for this reason.
- *
- * TODO(PRD-166 follow-up): once `seasons` + `episodes` join `tv_shows`
- * in `@pops/media-db` (PRD-166 currently lists all three but only
- * `tv_shows` has shipped), flip this transaction to
- * `getMediaDrizzle()` and collapse the `tv_shows` entry in
- * `media-backfill.ts` along with the matching shared-journal table
- * drop.
+ * - Inserts show, seasons, and episodes in a single transaction on
+ *   `media.db` (Theme 13 PR4 cutover — all three tables now live in
+ *   `@pops/media-db`).
  */
 export async function addTvShow(
   tvdbId: number,
@@ -208,7 +179,7 @@ export async function addTvShow(
 ): Promise<AddTvShowResult> {
   const existing = getTvShowByTvdbId(tvdbId);
   if (existing) {
-    const db = getDrizzle();
+    const db = getMediaDrizzle();
     const showSeasons = db.select().from(seasons).where(eq(seasons.tvShowId, existing.id)).all();
     return { show: existing, seasons: showSeasons, created: false };
   }
@@ -217,7 +188,7 @@ export async function addTvShow(
   const seasonEpisodes = await fetchSeasonEpisodes(tvdbId, client, detail);
   const { posterUrl, backdropUrl } = selectBestArtwork(detail.artworks);
 
-  const db = getDrizzle();
+  const db = getMediaDrizzle();
   const now = new Date().toISOString();
 
   const result = db.transaction((tx) => {

--- a/apps/pops-api/src/modules/media/plex/sync-discover-show.ts
+++ b/apps/pops-api/src/modules/media/plex/sync-discover-show.ts
@@ -1,8 +1,7 @@
 import { eq } from 'drizzle-orm';
 
-import { tvShows } from '@pops/db-types';
+import { tvShows } from '@pops/media-db';
 
-import { getDrizzle } from '../../../db.js';
 import { getMediaDrizzle } from '../../../db/media-db-handle.js';
 import { addTvShow } from '../library/tv-show-service.js';
 import {
@@ -84,12 +83,7 @@ export async function resolveShow(
 
     const { show: newShow } = await addTvShow(tvdbId, tvdbClient, imageCache);
     if (ratingKey) {
-      // addTvShow inserts via getDrizzle() (mixed-table tx with
-      // seasons + episodes — see tv-show-service.ts JSDoc). The new
-      // row lives only on pops.db until the next boot's backfill
-      // copies it across, so this update must hit the same handle or
-      // it would silently no-op against media.db.
-      getDrizzle()
+      mediaDb
         .update(tvShows)
         .set({ discoverRatingKey: ratingKey })
         .where(eq(tvShows.id, newShow.id))


### PR DESCRIPTION
## Summary

- Flips `addTvShow` and its existing-row idempotent read in `apps/pops-api/src/modules/media/library/tv-show-service.ts` from `getDrizzle()` to `getMediaDrizzle()`. The atomic transaction over `tv_shows` + `seasons` + `episodes` now lands entirely in `media.db` — all three schemas live in `@pops/media-db` after #3096.
- Updates the matching post-insert `discoverRatingKey` write in `plex/sync-discover-show.ts` to the same `mediaDb` handle (previously it had to dual-write to `pops.db` because `addTvShow`'s tx didn't reach `media.db`).
- Drops the multi-paragraph cross-store JSDoc on `addTvShow` and the inline comment in `sync-discover-show.ts` that documented the now-removed mixed-handle workaround.
- Switches table imports from `@pops/db-types` to `@pops/media-db` for `tvShows`/`seasons`/`episodes`, and `TvShowRow` to `@pops/media-db`.
- Refreshes the depcruise baseline to register the two new media-pillar imports.

## Dependency

Depends on #3096 (`feat(media-db): scaffold seasons + episodes schemas`) — merged at 07:37 UTC. This branch rebased onto main after the merge, so PR #3096's commits are now part of `main`.

## Follow-up

After this lands, MEDIA PR4 round 3 can drop `tv_shows` from `apps/pops-api/src/db/media-backfill.ts` — the legacy `pops.db → media.db` boot-time bridge is no longer needed for `tv_shows` because the only remaining writer (`addTvShow`) now writes directly to `media.db`.

## Test plan

- [x] `pnpm --filter @pops/api test src/modules/media/library` — 3 files, 53 tests, all pass.
- [x] `pnpm --filter @pops/api test src/modules/media` — 90 files, 1442 tests, all pass.
- [x] `pnpm --filter @pops/api typecheck` clean.
- [x] `pnpm lint`, `pnpm format:check`, `pnpm lint:boundaries`, `pnpm lint:boundaries:verify` clean.

## Test-confidence caveat

`setupTestContext()` in `apps/pops-api/src/shared/test-utils.ts` points the core and media pillar handles at the same in-memory `Database`, so the existing `addTvShow` integration tests cannot distinguish whether the transaction landed on `pops.db` or `media.db` — both handles resolve the same SQLite. The tests confirm correctness of the flow but are not a strong assertion about handle separation. A media-db-only test context would be needed to truly prove the cutover; that belongs in a follow-up if we want stricter coverage.