### PR TITLE
feat(media): route thetvdb seasons+episodes upserts through getMediaDrizzle (Theme 13)

### DIFF
--- a/apps/pops-api/src/modules/media/thetvdb/refresh-episodes.ts
+++ b/apps/pops-api/src/modules/media/thetvdb/refresh-episodes.ts
@@ -1,8 +1,8 @@
 import { eq } from 'drizzle-orm';
 
-import { episodes, seasons } from '@pops/db-types';
+import { episodes, seasons } from '@pops/media-db';
 
-import { getDrizzle } from '../../../db.js';
+import { getMediaDrizzle } from '../../../db/media-db-handle.js';
 import * as tvShowsService from '../tv-shows/service.js';
 
 import type { TheTvdbClient } from './client.js';
@@ -10,7 +10,7 @@ import type { TvdbEpisode } from './types.js';
 
 function updateSeasonEpisodeCount(seasonId: number, episodeCount: number): void {
   if (episodeCount <= 0) return;
-  const db = getDrizzle();
+  const db = getMediaDrizzle();
   db.update(seasons).set({ episodeCount }).where(eq(seasons.id, seasonId)).run();
 }
 
@@ -19,7 +19,7 @@ function upsertEpisodeRow(
   seasonId: number,
   counters: { added: number; updated: number }
 ): void {
-  const db = getDrizzle();
+  const db = getMediaDrizzle();
   const existingEp = db.select().from(episodes).where(eq(episodes.tvdbId, ep.tvdbId)).get();
   if (existingEp) {
     db.update(episodes)
@@ -83,7 +83,7 @@ export async function refreshEpisodesForAllSeasons(
     updateSeasonEpisodeCount(seasonId, tvdbEpisodes.length);
   }
 
-  const db = getDrizzle();
+  const db = getMediaDrizzle();
   const totalEpisodes = db
     .select()
     .from(episodes)

--- a/apps/pops-api/src/modules/media/thetvdb/service.ts
+++ b/apps/pops-api/src/modules/media/thetvdb/service.ts
@@ -6,10 +6,14 @@ import { eq } from 'drizzle-orm';
  *
  * Implementation is split across:
  *  - `refresh-episodes.ts` — episode upsert + season episode-count update
+ *
+ * As of Theme 13 PR4 round 4 prep, the `seasons` upserts run against the
+ * media pillar handle (`getMediaDrizzle()`) — `seasons` now lives in
+ * `@pops/media-db`, mirroring the `addTvShow` cutover (#3098).
  */
-import { seasons } from '@pops/db-types';
+import { seasons } from '@pops/media-db';
 
-import { getDrizzle } from '../../../db.js';
+import { getMediaDrizzle } from '../../../db/media-db-handle.js';
 import { selectBestArtwork } from '../library/tv-show-service.js';
 import * as tvShowsService from '../tv-shows/service.js';
 import { refreshEpisodesForAllSeasons } from './refresh-episodes.js';
@@ -41,7 +45,7 @@ function upsertSeason(
   showId: number,
   seasonSummary: TvdbSeasonSummary
 ): { seasonId: number; added: boolean } {
-  const db = getDrizzle();
+  const db = getMediaDrizzle();
   const existing = db.select().from(seasons).where(eq(seasons.tvdbId, seasonSummary.tvdbId)).get();
   const episodeCount = seasonSummary.episodeCount || null;
 


### PR DESCRIPTION
## Summary

- Route `thetvdb/service.ts` season upserts and `thetvdb/refresh-episodes.ts` season + episode upserts through `getMediaDrizzle()` instead of the shared `getDrizzle()`.
- Switch the `seasons` / `episodes` schema imports to `@pops/media-db` (re-export landed in #3096); `addTvShow` already runs on the media handle as of #3098, so the refresh path now talks to a single store end-to-end.
- Unblocks Theme 13 MEDIA PR4 round 4: `seasons` and `episodes` can be dropped from the shared `pops.db` journal alongside the rest of the media pillar's exit set.

## Test plan

- [x] `pnpm vitest run src/modules/media/thetvdb` (6 files, 90 tests green) — exercises `refreshTvShow`, season upsert, episode upsert, and the cross-handle `numberOfEpisodes` update.
- [x] `pnpm typecheck` (root, turbo) — all 66 tasks green.
- [x] Husky chain (`lint-staged` → `oxlint --fix` → `oxfmt --write`) ran on commit; no suppressions, no `as any`, no `as unknown as`.
