### PR TITLE
feat(workspaces): migrate @pops/module-registry consumers to @pops/pillar-sdk (PRD-218 batch 1)

### DIFF
--- a/apps/pops-shell/src/app/router.tsx
+++ b/apps/pops-shell/src/app/router.tsx
@@ -10,7 +10,7 @@
 import { Suspense } from 'react';
 import { createBrowserRouter, Link, Navigate, Outlet, useLocation } from 'react-router';
 
-import { KNOWN_MODULES } from '@pops/module-registry';
+import { ALL_MODULE_IDS } from '@pops/pillar-sdk';
 
 import { IndexRedirect } from './IndexRedirect';
 import { installedAppManifests } from './installed-modules';
@@ -24,19 +24,20 @@ import { PillarGuard, pillarIdForModule } from './pillars';
 import type { RouteObject } from 'react-router';
 
 /**
- * Catch-all element: if the URL's first path segment names a known
- * buildable module (`KNOWN_MODULES`) that isn't installed in this build,
+ * Catch-all element: if the URL's first path segment names a routable
+ * module id (`ALL_MODULE_IDS`) that isn't installed in this build,
  * render `NotInstalledPage`. Otherwise fall through to `NotFoundPage`.
  *
- * Using the full `KNOWN_MODULES` set (rather than just `MODULES`) here
+ * Using the full `ALL_MODULE_IDS` set (rather than just `MODULES`) here
  * means the "not installed" message fires for any module the codebase
  * could ship — including ones excluded by `POPS_APPS` — while truly
- * unknown paths still get a proper 404.
+ * unknown paths still get a proper 404. The superset includes the two
+ * transitional sub-module ids (`ai`, `ego`) so they remain routable.
  */
 function UnmatchedRoute() {
   const { pathname } = useLocation();
   const first = pathname.split('/').find((s) => s.length > 0) ?? '';
-  const knownModules: readonly string[] = KNOWN_MODULES;
+  const knownModules: readonly string[] = ALL_MODULE_IDS;
   if (first.length > 0 && knownModules.includes(first)) {
     return <NotInstalledPage />;
   }
@@ -118,8 +119,8 @@ export const router = createBrowserRouter([
       { path: 'cerebrum/admin/cache', element: <Navigate to="/ai/cache" replace /> },
       { path: 'settings', element: <SettingsPage /> },
       { path: 'features', element: <FeaturesPage /> },
-      // Catch-all: if the first path segment names a buildable module
-      // (`KNOWN_MODULES`) the operator excluded via `POPS_APPS`, render
+      // Catch-all: if the first path segment names a routable module id
+      // (`ALL_MODULE_IDS`) the operator excluded via `POPS_APPS`, render
       // NotInstalledPage. Genuinely unknown paths render NotFoundPage.
       // Both decisions happen inside `UnmatchedRoute` so the route table
       // stays free of inline module-id literals.

--- a/packages/navigation/package.json
+++ b/packages/navigation/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@pops/api-client": "workspace:*",
-    "@pops/module-registry": "workspace:*",
+    "@pops/pillar-sdk": "workspace:*",
     "@pops/ui": "workspace:*",
     "lucide-react": "^1.17.0",
     "react": "^19.2.7",

--- a/packages/navigation/src/search-input/installed-module.test.ts
+++ b/packages/navigation/src/search-input/installed-module.test.ts
@@ -8,17 +8,17 @@ import { describe, expect, it } from 'vitest';
  * engine is the primary filter; this hook prevents stale or
  * misconfigured payloads from rendering links into uninstalled apps.
  */
-import { KNOWN_MODULES } from '@pops/module-registry';
+import { ALL_MODULE_IDS } from '@pops/pillar-sdk';
 
 import { isInstalledModule } from './installed-module';
 
 describe('isInstalledModule', () => {
-  it('treats core as always installed (it is the shell module, not in MODULES)', () => {
+  it('treats core as always installed (it is the shell module)', () => {
     expect(isInstalledModule('core')).toBe(true);
   });
 
-  it('returns true for every id in the build-time MODULES set', () => {
-    for (const id of KNOWN_MODULES) {
+  it('returns true for every id in the canonical ALL_MODULE_IDS set', () => {
+    for (const id of ALL_MODULE_IDS) {
       expect(isInstalledModule(id)).toBe(true);
     }
   });

--- a/packages/navigation/src/search-input/installed-module.ts
+++ b/packages/navigation/src/search-input/installed-module.ts
@@ -7,12 +7,13 @@
  * build, a stale cache, or a future code path that bypasses the engine still
  * can't render results that link into a module the shell doesn't mount.
  */
-import { isModuleId } from '@pops/module-registry';
+import { isModuleId } from '@pops/pillar-sdk';
 
 /**
- * `core` is the always-mounted shell module (PRD-100) — its id is not in the
- * `MODULES` constant (which lists optional modules), so the filter exempts
- * it explicitly. Any other id must pass `isModuleId`.
+ * `core` is the always-mounted shell module (PRD-100). `isModuleId` checks
+ * membership of the static `ALL_MODULE_IDS` superset (pillars plus the two
+ * transitional sub-modules `ai`/`ego`), so `core` is already covered; the
+ * explicit branch is kept for clarity at the call boundary.
  */
 export function isInstalledModule(moduleId: string): boolean {
   return moduleId === 'core' || isModuleId(moduleId);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2082,9 +2082,9 @@ importers:
       '@pops/api-client':
         specifier: workspace:*
         version: link:../api-client
-      '@pops/module-registry':
+      '@pops/pillar-sdk':
         specifier: workspace:*
-        version: link:../module-registry
+        version: link:../pillar-sdk
       '@pops/ui':
         specifier: workspace:*
         version: link:../ui


### PR DESCRIPTION
## Summary

First-batch consumer migration toward retiring `@pops/module-registry` (PRD-218). Unblocked by #3090, which added `ALL_MODULE_IDS`, `ModuleId`, `isKnownPillarId`, `isModuleId`, and `MODULE_PARENT_PILLAR` to `@pops/pillar-sdk`.

- `apps/pops-shell/src/app/router.tsx`: `KNOWN_MODULES` → `ALL_MODULE_IDS`. Routable superset is byte-identical (pillars plus the two transitional sub-module ids `ai`, `ego`), so `/ai` and `/ego` stay routable as intended by the previous batch-1 attempt.
- `packages/navigation/src/search-input/installed-module.ts`: `isModuleId` sourced from `@pops/pillar-sdk`. Check moves from the build-time install set to the static superset; engine-side install-set filtering remains the primary gate, this hook keeps the same defence-in-depth shape.
- `packages/navigation/src/search-input/installed-module.test.ts`: `KNOWN_MODULES` → `ALL_MODULE_IDS` test input. Today both arrays are identical.
- `packages/navigation/package.json`: drop `@pops/module-registry` workspace dependency, add `@pops/pillar-sdk`. `pnpm-lock.yaml` reflects the swap only.

### Migrated (3 of 23)

| Workspace            | File                                                |
| -------------------- | --------------------------------------------------- |
| `apps/pops-shell`    | `src/app/router.tsx`                                |
| `packages/navigation`| `src/search-input/installed-module.ts`              |
| `packages/navigation`| `src/search-input/installed-module.test.ts`         |

### Deliberately skipped — substantive `POPS_APPS`-narrowing coupling

These consumers read `MODULES` (build-time install set, env-narrowable by `POPS_APPS` / `POPS_OVERLAYS`) or call `isModuleId` against it. Swapping to the static `ALL_MODULE_IDS` superset would silently disable that narrowing — best handled by the runtime registry shim under US-01.

- `apps/pops-shell`: `installed-modules.ts`, `overlays/registry.ts`, `pages/SettingsPage.tsx`, `pages/SettingsPage.test.tsx`, `scripts/build-registry-snapshot.ts`, `playwright.config.ts`, `vite.config.ts`.
- `apps/pops-api`: `router.ts`, `modules/installed-modules.ts`, `modules/search-adapters.ts`, `modules/manifests.ts`, `modules/core/uri/resolver.ts`, `modules/core/features/credentials.ts`, `modules/core/features/service.test.ts`, `modules/core/index.ts`, `modules/finance/index.ts`, `modules/inventory/index.ts`, `modules/cerebrum/index.ts`, `modules/cerebrum/ego/index.ts`, `modules/media/index.ts`.

### Remaining after this PR

20 of 23 consumers still depend on `@pops/module-registry`. `apps/pops-shell` and `apps/pops-api` retain the workspace dependency; only `packages/navigation` drops it.

## Test plan

- [x] `pnpm turbo run typecheck --filter=@pops/navigation --filter=@pops/shell`
- [x] `pnpm turbo run test --filter=@pops/navigation --filter=@pops/shell` (all 19 task pass, 377 shell tests, navigation suite green)
- [x] `pnpm typecheck` (root, full graph — 66 successful)
- [x] Husky chain (oxlint, oxfmt, lint-staged) green on commit