### PR TITLE
feat(core): route entities handlers through getFinanceDrizzle (Theme 13 FINANCE final unblock)

### DIFF
--- a/apps/pops-api/src/modules/core/entities/search-adapter.test.ts
+++ b/apps/pops-api/src/modules/core/entities/search-adapter.test.ts
@@ -4,8 +4,8 @@ import type { SearchContext } from '../search/types.js';
 
 const mockAll = vi.fn().mockReturnValue([]);
 
-vi.mock('../../../db.js', () => ({
-  getDrizzle: () => ({
+vi.mock('../../../db/finance-handle.js', () => ({
+  getFinanceDrizzle: () => ({
     select: () => ({
       from: () => ({
         where: () => ({ all: mockAll }),

--- a/apps/pops-api/src/modules/core/entities/search-adapter.ts
+++ b/apps/pops-api/src/modules/core/entities/search-adapter.ts
@@ -2,7 +2,7 @@ import { like } from 'drizzle-orm';
 
 import { entities } from '@pops/db-types';
 
-import { getDrizzle } from '../../../db.js';
+import { getFinanceDrizzle } from '../../../db/finance-handle.js';
 
 import type { Query, SearchAdapter, SearchContext, SearchHit } from '../search/types.js';
 
@@ -46,7 +46,7 @@ export const entitiesSearchAdapter: SearchAdapter<EntityHitData> = {
     const text = query.text.trim();
     if (!text) return [];
 
-    const db = getDrizzle();
+    const db = getFinanceDrizzle();
     const rows = db
       .select()
       .from(entities)

--- a/apps/pops-api/src/modules/core/entities/service.ts
+++ b/apps/pops-api/src/modules/core/entities/service.ts
@@ -8,7 +8,7 @@ import { and, count, eq, like, ne, sql } from 'drizzle-orm';
  */
 import { entities, transactions } from '@pops/db-types';
 
-import { getDrizzle } from '../../../db.js';
+import { getFinanceDrizzle } from '../../../db/finance-handle.js';
 import { ConflictError, NotFoundError } from '../../../shared/errors.js';
 
 import type { CreateEntityInput, EntityRow, UpdateEntityInput } from './types.js';
@@ -43,7 +43,7 @@ function fetchEntitiesPage(
   whereClause: ReturnType<typeof and> | undefined,
   opts: ListEntitiesOptions
 ): EntityWithCount[] {
-  let query = getDrizzle()
+  let query = getFinanceDrizzle()
     .select({
       id: entities.id,
       notionId: entities.notionId,
@@ -72,7 +72,7 @@ function countEntities(
   whereClause: ReturnType<typeof and> | undefined,
   orphanedOnly?: boolean
 ): number {
-  const db = getDrizzle();
+  const db = getFinanceDrizzle();
   if (orphanedOnly) {
     const countRows = db
       .select({ id: entities.id })
@@ -99,7 +99,7 @@ export function listEntities(opts: ListEntitiesOptions): EntityListResult {
 
 /** Get a single entity by id. Throws NotFoundError if missing. */
 export function getEntity(id: string): EntityRow {
-  const db = getDrizzle();
+  const db = getFinanceDrizzle();
   const [row] = db.select().from(entities).where(eq(entities.id, id)).all();
 
   if (!row) throw new NotFoundError('Entity', id);
@@ -111,7 +111,7 @@ export function getEntity(id: string): EntityRow {
  * Generates a local UUID and inserts directly into SQLite.
  */
 export function createEntity(input: CreateEntityInput): EntityRow {
-  const db = getDrizzle();
+  const db = getFinanceDrizzle();
 
   const [existing] = db
     .select({ id: entities.id })
@@ -145,7 +145,7 @@ export function createEntity(input: CreateEntityInput): EntityRow {
 
 function assertNoDuplicateName(id: string, name: string | undefined): void {
   if (name === undefined) return;
-  const [existing] = getDrizzle()
+  const [existing] = getFinanceDrizzle()
     .select({ id: entities.id })
     .from(entities)
     .where(and(eq(entities.name, name), ne(entities.id, id)))
@@ -195,7 +195,7 @@ export function updateEntity(id: string, input: UpdateEntityInput): EntityRow {
   const updates = buildEntityUpdates(input);
   if (Object.keys(updates).length > 0) {
     updates.lastEditedTime = new Date().toISOString();
-    getDrizzle().update(entities).set(updates).where(eq(entities.id, id)).run();
+    getFinanceDrizzle().update(entities).set(updates).where(eq(entities.id, id)).run();
   }
 
   return getEntity(id);
@@ -209,7 +209,7 @@ export function deleteEntity(id: string): void {
   // Verify it exists first
   getEntity(id);
 
-  const db = getDrizzle();
+  const db = getFinanceDrizzle();
   const result = db.delete(entities).where(eq(entities.id, id)).run();
   if (result.changes === 0) throw new NotFoundError('Entity', id);
 }


### PR DESCRIPTION
## Summary

The `core.entities` module reads/writes `entities` (and joins `transactions`) through `getDrizzle()` (the shared `pops.db` handle), keeping the core pillar coupled to finance tables in the legacy DB. With FINANCE PR4 round 2 (#3101) having dropped four tables, `entities` + `transactions` are the final two blocking the FINANCE full exit (5th pillar).

This mirrors the corrections cutover (#3088 — `core.corrections` → `getFinanceDrizzle`) which already unblocked `transaction_corrections`.

### Sites flipped

- `apps/pops-api/src/modules/core/entities/service.ts` — eight reads/writes across list / get / create / update / delete + duplicate-name check, including the `entities` ⨝ `transactions` count query.
- `apps/pops-api/src/modules/core/entities/search-adapter.ts` — entity-name `LIKE` search.
- `apps/pops-api/src/modules/core/entities/search-adapter.test.ts` — mock target follows the import (`db.js` → `db/finance-handle.js`).

Schema imports stay on `@pops/db-types` (shared row/insert types used by both pillar DBs). No `as any`, no suppressions.

### Follow-up

After this lands, FINANCE round 3 can drop the final two tables (`entities`, `transactions`) from the shared `pops.db` schema and complete the FINANCE pillar exit.

## Test plan

- [x] `pnpm --filter @pops/api test src/modules/core/entities` — 45/45 pass (entities.test.ts + search-adapter.test.ts).
- [x] `pnpm --filter @pops/api typecheck` — clean.
- [x] `pnpm typecheck` (root) — all 66 tasks pass.
- [x] Full husky chain on commit + pre-push.
