### PR TITLE
feat(mcp): migrate medium tRPC call sites to pillar SDK (PRD-205 batch 2)

### DIFF
--- a/apps/pops-mcp/src/tools/cerebrum.test.ts
+++ b/apps/pops-mcp/src/tools/cerebrum.test.ts
@@ -1,42 +1,72 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { extractText, mockClient, parseResult } from './test-helpers.js';
+import {
+  callContractMismatch,
+  callOk,
+  callUnavailable,
+  extractText,
+  mockPillarCerebrum,
+  parseResult,
+} from './test-helpers.js';
 
-vi.mock('../client.js', () => ({ getClient: () => mockClient }));
-
-beforeEach(() => vi.clearAllMocks());
+vi.mock('../pillar-client.js', () => ({
+  getPillar: () => mockPillarCerebrum,
+  __resetPillarClientForTests: () => {},
+}));
 
 const { cerebrumTools } = await import('./cerebrum.js');
+
+const engrams = mockPillarCerebrum.cerebrum.engrams;
+const retrieval = mockPillarCerebrum.cerebrum.retrieval;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  engrams.list.mockResolvedValue(callOk({ engrams: [], total: 0 }));
+  engrams.get.mockResolvedValue(callOk({ id: 'eng_1', title: 'Test', body: 'content' }));
+  retrieval.search.mockResolvedValue(callOk({ results: [] }));
+});
 
 describe('cerebrum.engrams.list', () => {
   const tool = cerebrumTools.find((t) => t.name === 'cerebrum.engrams.list')!;
 
   it('passes scope and tag arrays correctly', async () => {
     await tool.handler({ scopes: ['work', 'personal'], tags: ['important'] });
-    expect(mockClient.cerebrum.engrams.list.query).toHaveBeenCalledWith(
+    expect(engrams.list).toHaveBeenCalledWith(
       expect.objectContaining({ scopes: ['work', 'personal'], tags: ['important'] })
     );
   });
 
   it('filters non-string elements from scope and tag arrays', async () => {
     await tool.handler({ scopes: ['valid', 42, null, 'also-valid'] });
-    const call = mockClient.cerebrum.engrams.list.query.mock.lastCall?.[0];
+    const call = engrams.list.mock.lastCall?.[0];
     expect((call as Record<string, unknown>)['scopes']).toEqual(['valid', 'also-valid']);
   });
 
   it('ignores invalid status values', async () => {
     await tool.handler({ status: 'deleted' });
-    const call = mockClient.cerebrum.engrams.list.query.mock.lastCall?.[0];
+    const call = engrams.list.mock.lastCall?.[0];
     expect((call as Record<string, unknown>)['status']).toBeUndefined();
+  });
+
+  it('returns isError on unavailable', async () => {
+    engrams.list.mockResolvedValueOnce(callUnavailable('cerebrum'));
+    const result = await tool.handler({});
+    expect(result.isError).toBe(true);
+  });
+
+  it('returns isError on contract-mismatch', async () => {
+    engrams.list.mockResolvedValueOnce(callContractMismatch('cerebrum', '1.0.0', '2.0.0'));
+    const result = await tool.handler({});
+    expect(result.isError).toBe(true);
   });
 });
 
 describe('cerebrum.engrams.get', () => {
   const tool = cerebrumTools.find((t) => t.name === 'cerebrum.engrams.get')!;
 
-  it('calls engrams.get.query with the id', async () => {
+  it('calls engrams.get with the id', async () => {
     const result = await tool.handler({ id: 'eng_1' });
-    expect(mockClient.cerebrum.engrams.get.query).toHaveBeenCalledWith({ id: 'eng_1' });
+    expect(engrams.get).toHaveBeenCalledWith({ id: 'eng_1' });
     expect(result.isError).toBeUndefined();
     const text = extractText(result);
     expect(text).toContain('eng_1');
@@ -51,23 +81,27 @@ describe('cerebrum.engrams.get', () => {
     const result = await tool.handler({ id: '' });
     expect(result.isError).toBe(true);
   });
+
+  it('returns isError on unavailable', async () => {
+    engrams.get.mockResolvedValueOnce(callUnavailable('cerebrum'));
+    const result = await tool.handler({ id: 'eng_1' });
+    expect(result.isError).toBe(true);
+  });
 });
 
 describe('cerebrum.search', () => {
   const tool = cerebrumTools.find((t) => t.name === 'cerebrum.search')!;
 
-  it('calls retrieval.search.query with query and defaults to hybrid', async () => {
+  it('calls retrieval.search with query and defaults to hybrid', async () => {
     await tool.handler({ query: 'home automation' });
-    expect(mockClient.cerebrum.retrieval.search.query).toHaveBeenCalledWith(
+    expect(retrieval.search).toHaveBeenCalledWith(
       expect.objectContaining({ query: 'home automation', mode: 'hybrid' })
     );
   });
 
   it('passes explicit mode', async () => {
     await tool.handler({ query: 'test', mode: 'semantic' });
-    expect(mockClient.cerebrum.retrieval.search.query).toHaveBeenCalledWith(
-      expect.objectContaining({ mode: 'semantic' })
-    );
+    expect(retrieval.search).toHaveBeenCalledWith(expect.objectContaining({ mode: 'semantic' }));
   });
 
   it('returns isError for missing query', async () => {
@@ -77,6 +111,12 @@ describe('cerebrum.search', () => {
 
   it('returns isError for blank query', async () => {
     const result = await tool.handler({ query: '   ' });
+    expect(result.isError).toBe(true);
+  });
+
+  it('returns isError on contract-mismatch', async () => {
+    retrieval.search.mockResolvedValueOnce(callContractMismatch('cerebrum', '1.0.0', '2.0.0'));
+    const result = await tool.handler({ query: 'test' });
     expect(result.isError).toBe(true);
   });
 });

--- a/apps/pops-mcp/src/tools/cerebrum.ts
+++ b/apps/pops-mcp/src/tools/cerebrum.ts
@@ -1,7 +1,41 @@
-import { getClient } from '../client.js';
-import { ok, toolError } from './utils.js';
+import { getPillar } from '../pillar-client.js';
+import { mapCallResult, toolError } from './utils.js';
+
+import type { PillarHandle } from '@pops/pillar-sdk/client';
 
 import type { ToolDef } from './index.js';
+
+type EngramListInput = {
+  search?: string;
+  type?: string;
+  scopes?: string[];
+  tags?: string[];
+  status?: 'active' | 'archived';
+  limit?: number;
+  offset?: number;
+};
+
+type SearchInput = {
+  query: string;
+  mode: 'semantic' | 'structured' | 'hybrid';
+  limit?: number;
+};
+
+type CerebrumShape = {
+  cerebrum: {
+    engrams: {
+      list: (input: EngramListInput) => unknown;
+      get: (input: { id: string }) => unknown;
+    };
+    retrieval: {
+      search: (input: SearchInput) => unknown;
+    };
+  };
+};
+
+function cerebrum(): PillarHandle<CerebrumShape>['cerebrum'] {
+  return getPillar<CerebrumShape>('cerebrum').cerebrum;
+}
 
 const engramsList: ToolDef = {
   name: 'cerebrum.engrams.list',
@@ -39,17 +73,16 @@ const engramsList: ToolDef = {
       ? (args['tags'] as unknown[]).filter((t): t is string => typeof t === 'string')
       : undefined;
 
-    const result = await getClient().cerebrum.engrams.list.query({
-      search: typeof args['search'] === 'string' ? args['search'] : undefined,
-      type: typeof args['type'] === 'string' ? args['type'] : undefined,
-      scopes,
-      tags,
-      status:
-        args['status'] === 'active' || args['status'] === 'archived' ? args['status'] : undefined,
-      limit: typeof args['limit'] === 'number' ? args['limit'] : undefined,
-      offset: typeof args['offset'] === 'number' ? args['offset'] : undefined,
-    });
-    return ok(result);
+    const input: EngramListInput = {};
+    if (typeof args['search'] === 'string') input.search = args['search'];
+    if (typeof args['type'] === 'string') input.type = args['type'];
+    if (scopes !== undefined) input.scopes = scopes;
+    if (tags !== undefined) input.tags = tags;
+    if (args['status'] === 'active' || args['status'] === 'archived') input.status = args['status'];
+    if (typeof args['limit'] === 'number') input.limit = args['limit'];
+    if (typeof args['offset'] === 'number') input.offset = args['offset'];
+
+    return mapCallResult(await cerebrum().engrams.list(input));
   },
 };
 
@@ -67,8 +100,7 @@ const engramGet: ToolDef = {
     if (typeof args['id'] !== 'string' || args['id'].length === 0) {
       return toolError('Invalid "id"');
     }
-    const result = await getClient().cerebrum.engrams.get.query({ id: args['id'] });
-    return ok(result);
+    return mapCallResult(await cerebrum().engrams.get({ id: args['id'] }));
   },
 };
 
@@ -93,15 +125,13 @@ const cerebrumSearch: ToolDef = {
     if (typeof args['query'] !== 'string' || args['query'].trim().length === 0) {
       return toolError('Invalid "query"');
     }
-    const result = await getClient().cerebrum.retrieval.search.query({
-      query: args['query'],
-      mode:
-        args['mode'] === 'semantic' || args['mode'] === 'structured' || args['mode'] === 'hybrid'
-          ? args['mode']
-          : 'hybrid',
-      limit: typeof args['limit'] === 'number' ? args['limit'] : undefined,
-    });
-    return ok(result);
+    const mode: 'semantic' | 'structured' | 'hybrid' =
+      args['mode'] === 'semantic' || args['mode'] === 'structured' || args['mode'] === 'hybrid'
+        ? args['mode']
+        : 'hybrid';
+    const input: SearchInput = { query: args['query'], mode };
+    if (typeof args['limit'] === 'number') input.limit = args['limit'];
+    return mapCallResult(await cerebrum().retrieval.search(input));
   },
 };
 

--- a/apps/pops-mcp/src/tools/inventory-connections.test.ts
+++ b/apps/pops-mcp/src/tools/inventory-connections.test.ts
@@ -1,8 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { mockClient, parseResult } from './test-helpers.js';
+import {
+  callContractMismatch,
+  callOk,
+  callUnavailable,
+  mockPillarInventory,
+  parseResult,
+  pillarMockGetter,
+} from './test-helpers.js';
 
-vi.mock('../client.js', () => ({ getClient: () => mockClient }));
+vi.mock('../pillar-client.js', () => ({
+  getPillar: pillarMockGetter,
+  __resetPillarClientForTests: () => {},
+}));
 
 const { connectionTools } = await import('./inventory-connections.js');
 
@@ -12,58 +22,77 @@ function tool(name: string) {
   return t;
 }
 
+const connections = mockPillarInventory.inventory.connections;
+
 beforeEach(() => {
   vi.clearAllMocks();
+  connections.listForItem.mockResolvedValue(
+    callOk({
+      data: [{ id: 1, itemAId: 'item_1', itemBId: 'item_2', createdAt: '2025-01-01' }],
+      pagination: { total: 1, limit: 50, offset: 0, hasMore: false },
+    })
+  );
+  connections.graph.mockResolvedValue(
+    callOk({
+      data: {
+        nodes: [{ id: 'item_1' }, { id: 'item_2' }],
+        edges: [{ source: 'item_1', target: 'item_2' }],
+      },
+    })
+  );
+  connections.connect.mockResolvedValue(
+    callOk({
+      data: { id: 1, itemAId: 'item_1', itemBId: 'item_2', createdAt: '2025-01-01' },
+      message: 'Items connected',
+    })
+  );
+  connections.disconnect.mockResolvedValue(callOk({ message: 'Items disconnected' }));
 });
-
-// ---------------------------------------------------------------------------
-// Read
-// ---------------------------------------------------------------------------
 
 describe('inventory.connections.list', () => {
   it('passes itemId and optional pagination', async () => {
     await tool('inventory.connections.list').handler({ itemId: 'item_1', limit: 20, offset: 10 });
-    expect(mockClient.inventory.connections.listForItem.query).toHaveBeenCalledWith(
+    expect(connections.listForItem).toHaveBeenCalledWith(
       expect.objectContaining({ itemId: 'item_1', limit: 20, offset: 10 })
     );
   });
 
   it('omits limit and offset when absent', async () => {
     await tool('inventory.connections.list').handler({ itemId: 'item_1' });
-    const call = mockClient.inventory.connections.listForItem.query.mock.lastCall?.[0] as Record<
-      string,
-      unknown
-    >;
-    expect(call['limit']).toBeUndefined();
-    expect(call['offset']).toBeUndefined();
+    const call = connections.listForItem.mock.lastCall?.[0] as Record<string, unknown>;
+    expect('limit' in call).toBe(false);
+    expect('offset' in call).toBe(false);
   });
 
   it('returns isError when itemId is missing', async () => {
     const result = await tool('inventory.connections.list').handler({});
     expect(result.isError).toBe(true);
-    expect(mockClient.inventory.connections.listForItem.query).not.toHaveBeenCalled();
+    expect(connections.listForItem).not.toHaveBeenCalled();
   });
 
   it('returns isError when itemId is empty string', async () => {
     expect((await tool('inventory.connections.list').handler({ itemId: '' })).isError).toBe(true);
+  });
+
+  it('returns isError on unavailable', async () => {
+    connections.listForItem.mockResolvedValueOnce(callUnavailable('inventory'));
+    const result = await tool('inventory.connections.list').handler({ itemId: 'item_1' });
+    expect(result.isError).toBe(true);
   });
 });
 
 describe('inventory.connections.graph', () => {
   it('passes itemId and maxDepth', async () => {
     await tool('inventory.connections.graph').handler({ itemId: 'item_2', maxDepth: 2 });
-    expect(mockClient.inventory.connections.graph.query).toHaveBeenCalledWith(
+    expect(connections.graph).toHaveBeenCalledWith(
       expect.objectContaining({ itemId: 'item_2', maxDepth: 2 })
     );
   });
 
   it('omits maxDepth when absent', async () => {
     await tool('inventory.connections.graph').handler({ itemId: 'item_1' });
-    const call = mockClient.inventory.connections.graph.query.mock.lastCall?.[0] as Record<
-      string,
-      unknown
-    >;
-    expect(call['maxDepth']).toBeUndefined();
+    const call = connections.graph.mock.lastCall?.[0] as Record<string, unknown>;
+    expect('maxDepth' in call).toBe(false);
   });
 
   it('returns graph data wrapped in the data envelope', async () => {
@@ -77,7 +106,7 @@ describe('inventory.connections.graph', () => {
   it('returns isError when itemId is missing', async () => {
     const result = await tool('inventory.connections.graph').handler({});
     expect(result.isError).toBe(true);
-    expect(mockClient.inventory.connections.graph.query).not.toHaveBeenCalled();
+    expect(connections.graph).not.toHaveBeenCalled();
   });
 
   it('returns isError when itemId is empty string', async () => {
@@ -85,20 +114,13 @@ describe('inventory.connections.graph', () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// Write
-// ---------------------------------------------------------------------------
-
 describe('inventory.connections.connect', () => {
   it('connects two items and returns connection record', async () => {
     const result = await tool('inventory.connections.connect').handler({
       itemAId: 'item_1',
       itemBId: 'item_2',
     });
-    expect(mockClient.inventory.connections.connect.mutate).toHaveBeenCalledWith({
-      itemAId: 'item_1',
-      itemBId: 'item_2',
-    });
+    expect(connections.connect).toHaveBeenCalledWith({ itemAId: 'item_1', itemBId: 'item_2' });
     expect(result.isError).toBeUndefined();
     const parsed = parseResult(result) as { data: { itemAId: string; itemBId: string } };
     expect(parsed.data.itemAId).toBe('item_1');
@@ -108,13 +130,13 @@ describe('inventory.connections.connect', () => {
   it('returns isError when itemAId is missing', async () => {
     const result = await tool('inventory.connections.connect').handler({ itemBId: 'item_2' });
     expect(result.isError).toBe(true);
-    expect(mockClient.inventory.connections.connect.mutate).not.toHaveBeenCalled();
+    expect(connections.connect).not.toHaveBeenCalled();
   });
 
   it('returns isError when itemBId is missing', async () => {
     const result = await tool('inventory.connections.connect').handler({ itemAId: 'item_1' });
     expect(result.isError).toBe(true);
-    expect(mockClient.inventory.connections.connect.mutate).not.toHaveBeenCalled();
+    expect(connections.connect).not.toHaveBeenCalled();
   });
 
   it('returns isError when itemAId is empty string', async () => {
@@ -131,14 +153,22 @@ describe('inventory.connections.connect', () => {
     ).toBe(true);
   });
 
-  it('propagates tRPC errors (handled by MCP framework)', async () => {
-    const err = Object.assign(new Error('Connection already exists'), {
-      data: { code: 'CONFLICT' },
+  it('returns isError on unavailable', async () => {
+    connections.connect.mockResolvedValueOnce(callUnavailable('inventory'));
+    const result = await tool('inventory.connections.connect').handler({
+      itemAId: 'item_1',
+      itemBId: 'item_2',
     });
-    mockClient.inventory.connections.connect.mutate.mockRejectedValueOnce(err);
-    await expect(
-      tool('inventory.connections.connect').handler({ itemAId: 'item_1', itemBId: 'item_2' })
-    ).rejects.toThrow('Connection already exists');
+    expect(result.isError).toBe(true);
+  });
+
+  it('returns isError on contract-mismatch', async () => {
+    connections.connect.mockResolvedValueOnce(callContractMismatch('inventory', '1.0.0', '2.0.0'));
+    const result = await tool('inventory.connections.connect').handler({
+      itemAId: 'item_1',
+      itemBId: 'item_2',
+    });
+    expect(result.isError).toBe(true);
   });
 });
 
@@ -148,10 +178,7 @@ describe('inventory.connections.disconnect', () => {
       itemAId: 'item_1',
       itemBId: 'item_2',
     });
-    expect(mockClient.inventory.connections.disconnect.mutate).toHaveBeenCalledWith({
-      itemAId: 'item_1',
-      itemBId: 'item_2',
-    });
+    expect(connections.disconnect).toHaveBeenCalledWith({ itemAId: 'item_1', itemBId: 'item_2' });
     expect(result.isError).toBeUndefined();
     const parsed = parseResult(result) as { message: string };
     expect(parsed.message).toBe('Items disconnected');
@@ -160,36 +187,12 @@ describe('inventory.connections.disconnect', () => {
   it('returns isError when itemAId is missing', async () => {
     const result = await tool('inventory.connections.disconnect').handler({ itemBId: 'item_2' });
     expect(result.isError).toBe(true);
-    expect(mockClient.inventory.connections.disconnect.mutate).not.toHaveBeenCalled();
+    expect(connections.disconnect).not.toHaveBeenCalled();
   });
 
   it('returns isError when itemBId is missing', async () => {
     const result = await tool('inventory.connections.disconnect').handler({ itemAId: 'item_1' });
     expect(result.isError).toBe(true);
-    expect(mockClient.inventory.connections.disconnect.mutate).not.toHaveBeenCalled();
-  });
-
-  it('returns isError when itemAId is empty string', async () => {
-    expect(
-      (await tool('inventory.connections.disconnect').handler({ itemAId: '', itemBId: 'item_2' }))
-        .isError
-    ).toBe(true);
-  });
-
-  it('returns isError when itemBId is empty string', async () => {
-    expect(
-      (await tool('inventory.connections.disconnect').handler({ itemAId: 'item_1', itemBId: '' }))
-        .isError
-    ).toBe(true);
-  });
-
-  it('propagates tRPC errors (handled by MCP framework)', async () => {
-    const err = Object.assign(new Error('Connection not found'), {
-      data: { code: 'NOT_FOUND' },
-    });
-    mockClient.inventory.connections.disconnect.mutate.mockRejectedValueOnce(err);
-    await expect(
-      tool('inventory.connections.disconnect').handler({ itemAId: 'item_1', itemBId: 'item_2' })
-    ).rejects.toThrow('Connection not found');
+    expect(connections.disconnect).not.toHaveBeenCalled();
   });
 });

--- a/apps/pops-mcp/src/tools/inventory-connections.ts
+++ b/apps/pops-mcp/src/tools/inventory-connections.ts
@@ -1,7 +1,28 @@
-import { getClient } from '../client.js';
-import { ok, optNum, reqStr, toolError } from './utils.js';
+import { getPillar } from '../pillar-client.js';
+import { mapCallResult, optNum, reqStr, toolError } from './utils.js';
+
+import type { PillarHandle } from '@pops/pillar-sdk/client';
 
 import type { ToolDef } from './index.js';
+
+type ListForItemInput = { itemId: string; limit?: number; offset?: number };
+type GraphInput = { itemId: string; maxDepth?: number };
+type PairInput = { itemAId: string; itemBId: string };
+
+type ConnectionsShape = {
+  inventory: {
+    connections: {
+      listForItem: (input: ListForItemInput) => unknown;
+      graph: (input: GraphInput) => unknown;
+      connect: (input: PairInput) => unknown;
+      disconnect: (input: PairInput) => unknown;
+    };
+  };
+};
+
+function connections(): PillarHandle<ConnectionsShape>['inventory']['connections'] {
+  return getPillar<ConnectionsShape>('inventory').inventory.connections;
+}
 
 const connectionsList: ToolDef = {
   name: 'inventory.connections.list',
@@ -19,12 +40,12 @@ const connectionsList: ToolDef = {
   handler: async (args) => {
     const itemId = reqStr(args, 'itemId');
     if (!itemId) return toolError('Missing required field: itemId');
-    const result = await getClient().inventory.connections.listForItem.query({
-      itemId,
-      limit: optNum(args, 'limit'),
-      offset: optNum(args, 'offset'),
-    });
-    return ok(result);
+    const input: ListForItemInput = { itemId };
+    const limit = optNum(args, 'limit');
+    if (limit !== undefined) input.limit = limit;
+    const offset = optNum(args, 'offset');
+    if (offset !== undefined) input.offset = offset;
+    return mapCallResult(await connections().listForItem(input));
   },
 };
 
@@ -43,11 +64,10 @@ const connectionsGraph: ToolDef = {
   handler: async (args) => {
     const itemId = reqStr(args, 'itemId');
     if (!itemId) return toolError('Missing required field: itemId');
-    const result = await getClient().inventory.connections.graph.query({
-      itemId,
-      maxDepth: optNum(args, 'maxDepth'),
-    });
-    return ok(result);
+    const input: GraphInput = { itemId };
+    const maxDepth = optNum(args, 'maxDepth');
+    if (maxDepth !== undefined) input.maxDepth = maxDepth;
+    return mapCallResult(await connections().graph(input));
   },
 };
 
@@ -68,8 +88,7 @@ const connectionsConnect: ToolDef = {
     if (!itemAId) return toolError('Missing required field: itemAId');
     const itemBId = reqStr(args, 'itemBId');
     if (!itemBId) return toolError('Missing required field: itemBId');
-    const result = await getClient().inventory.connections.connect.mutate({ itemAId, itemBId });
-    return ok(result);
+    return mapCallResult(await connections().connect({ itemAId, itemBId }));
   },
 };
 
@@ -90,8 +109,7 @@ const connectionsDisconnect: ToolDef = {
     if (!itemAId) return toolError('Missing required field: itemAId');
     const itemBId = reqStr(args, 'itemBId');
     if (!itemBId) return toolError('Missing required field: itemBId');
-    const result = await getClient().inventory.connections.disconnect.mutate({ itemAId, itemBId });
-    return ok(result);
+    return mapCallResult(await connections().disconnect({ itemAId, itemBId }));
   },
 };
 

--- a/apps/pops-mcp/src/tools/inventory-fixtures-write.ts
+++ b/apps/pops-mcp/src/tools/inventory-fixtures-write.ts
@@ -1,11 +1,45 @@
-import { getClient } from '../client.js';
-import { copyNullStr, copyOptStr, ok, optStr, reqStr, toolError } from './utils.js';
+import { getPillar } from '../pillar-client.js';
+import { copyNullStr, copyOptStr, mapCallResult, optStr, reqStr, toolError } from './utils.js';
+
+import type { PillarHandle } from '@pops/pillar-sdk/client';
 
 import type { ToolDef } from './index.js';
 
-type FixturePatch = Parameters<
-  ReturnType<typeof getClient>['inventory']['fixtures']['update']['mutate']
->[0]['data'];
+export type FixturePatch = {
+  name?: string;
+  type?: string;
+  locationId?: string | null;
+  notes?: string | null;
+};
+
+export type FixturesShape = {
+  inventory: {
+    fixtures: {
+      list: (input: {
+        locationId?: string;
+        type?: string;
+        limit?: number;
+        offset?: number;
+      }) => unknown;
+      get: (input: { id: string }) => unknown;
+      listForItem: (input: { itemId: string; limit?: number; offset?: number }) => unknown;
+      create: (input: {
+        name: string;
+        type: string;
+        locationId?: string;
+        notes?: string;
+      }) => unknown;
+      update: (input: { id: string; data: FixturePatch }) => unknown;
+      delete: (input: { id: string }) => unknown;
+      connect: (input: { itemId: string; fixtureId: string }) => unknown;
+      disconnect: (input: { itemId: string; fixtureId: string }) => unknown;
+    };
+  };
+};
+
+export function fixtures(): PillarHandle<FixturesShape>['inventory']['fixtures'] {
+  return getPillar<FixturesShape>('inventory').inventory.fixtures;
+}
 
 function buildFixturePatch(args: Record<string, unknown>): FixturePatch {
   const patch: FixturePatch = {};
@@ -38,13 +72,15 @@ const fixturesCreate: ToolDef = {
     if (!name) return toolError('Missing required field: name');
     const type = reqStr(args, 'type');
     if (!type) return toolError('Missing required field: type');
-    const result = await getClient().inventory.fixtures.create.mutate({
+    const input: { name: string; type: string; locationId?: string; notes?: string } = {
       name,
       type,
-      locationId: optStr(args, 'locationId'),
-      notes: optStr(args, 'notes'),
-    });
-    return ok(result);
+    };
+    const locationId = optStr(args, 'locationId');
+    if (locationId !== undefined) input.locationId = locationId;
+    const notes = optStr(args, 'notes');
+    if (notes !== undefined) input.notes = notes;
+    return mapCallResult(await fixtures().create(input));
   },
 };
 
@@ -63,15 +99,12 @@ const fixturesUpdate: ToolDef = {
     },
     required: ['id'],
   },
-  // Note: empty-patch rejection happens at the tRPC layer via
-  // UpdateFixtureSchema.refine, so we don't duplicate the guard here. The
-  // backend returns BAD_REQUEST which propagates through the tRPC client.
+  // Empty-patch rejection happens at the tRPC layer via UpdateFixtureSchema.refine.
   handler: async (args) => {
     const id = reqStr(args, 'id');
     if (!id) return toolError('Missing required field: id');
     const data = buildFixturePatch(args);
-    const result = await getClient().inventory.fixtures.update.mutate({ id, data });
-    return ok(result);
+    return mapCallResult(await fixtures().update({ id, data }));
   },
 };
 
@@ -86,8 +119,7 @@ const fixturesDelete: ToolDef = {
   handler: async (args) => {
     const id = reqStr(args, 'id');
     if (!id) return toolError('Missing required field: id');
-    const result = await getClient().inventory.fixtures.delete.mutate({ id });
-    return ok(result);
+    return mapCallResult(await fixtures().delete({ id }));
   },
 };
 
@@ -107,8 +139,7 @@ const fixturesConnect: ToolDef = {
     if (!itemId) return toolError('Missing required field: itemId');
     const fixtureId = reqStr(args, 'fixtureId');
     if (!fixtureId) return toolError('Missing required field: fixtureId');
-    const result = await getClient().inventory.fixtures.connect.mutate({ itemId, fixtureId });
-    return ok(result);
+    return mapCallResult(await fixtures().connect({ itemId, fixtureId }));
   },
 };
 
@@ -128,8 +159,7 @@ const fixturesDisconnect: ToolDef = {
     if (!itemId) return toolError('Missing required field: itemId');
     const fixtureId = reqStr(args, 'fixtureId');
     if (!fixtureId) return toolError('Missing required field: fixtureId');
-    const result = await getClient().inventory.fixtures.disconnect.mutate({ itemId, fixtureId });
-    return ok(result);
+    return mapCallResult(await fixtures().disconnect({ itemId, fixtureId }));
   },
 };
 

--- a/apps/pops-mcp/src/tools/inventory-fixtures.test.ts
+++ b/apps/pops-mcp/src/tools/inventory-fixtures.test.ts
@@ -1,8 +1,20 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { MOCK_FIXTURE, MOCK_FIXTURE_CONN, mockClient, parseResult } from './test-helpers.js';
+import {
+  callContractMismatch,
+  callOk,
+  callUnavailable,
+  MOCK_FIXTURE,
+  MOCK_FIXTURE_CONN,
+  mockPillarInventory,
+  parseResult,
+  pillarMockGetter,
+} from './test-helpers.js';
 
-vi.mock('../client.js', () => ({ getClient: () => mockClient }));
+vi.mock('../pillar-client.js', () => ({
+  getPillar: pillarMockGetter,
+  __resetPillarClientForTests: () => {},
+}));
 
 const { fixtureTools } = await import('./inventory-fixtures.js');
 
@@ -12,30 +24,25 @@ function getTool(name: string) {
   return tool;
 }
 
+const fixtures = mockPillarInventory.inventory.fixtures;
+
 beforeEach(() => {
   vi.clearAllMocks();
-  mockClient.inventory.fixtures.list.query.mockResolvedValue({ data: [MOCK_FIXTURE], total: 1 });
-  mockClient.inventory.fixtures.get.query.mockResolvedValue({ data: MOCK_FIXTURE });
-  mockClient.inventory.fixtures.create.mutate.mockResolvedValue({
-    data: MOCK_FIXTURE,
-    message: 'Fixture created',
-  });
-  mockClient.inventory.fixtures.update.mutate.mockResolvedValue({
-    data: MOCK_FIXTURE,
-    message: 'Fixture updated',
-  });
-  mockClient.inventory.fixtures.delete.mutate.mockResolvedValue({ message: 'Fixture deleted' });
-  mockClient.inventory.fixtures.connect.mutate.mockResolvedValue({
-    data: MOCK_FIXTURE_CONN,
-    message: 'Item connected to fixture',
-  });
-  mockClient.inventory.fixtures.disconnect.mutate.mockResolvedValue({
-    message: 'Item disconnected from fixture',
-  });
-  mockClient.inventory.fixtures.listForItem.query.mockResolvedValue({
-    data: [MOCK_FIXTURE_CONN],
-    pagination: { total: 1, limit: 50, offset: 0, hasMore: false },
-  });
+  fixtures.list.mockResolvedValue(callOk({ data: [MOCK_FIXTURE], total: 1 }));
+  fixtures.get.mockResolvedValue(callOk({ data: MOCK_FIXTURE }));
+  fixtures.create.mockResolvedValue(callOk({ data: MOCK_FIXTURE, message: 'Fixture created' }));
+  fixtures.update.mockResolvedValue(callOk({ data: MOCK_FIXTURE, message: 'Fixture updated' }));
+  fixtures.delete.mockResolvedValue(callOk({ message: 'Fixture deleted' }));
+  fixtures.connect.mockResolvedValue(
+    callOk({ data: MOCK_FIXTURE_CONN, message: 'Item connected to fixture' })
+  );
+  fixtures.disconnect.mockResolvedValue(callOk({ message: 'Item disconnected from fixture' }));
+  fixtures.listForItem.mockResolvedValue(
+    callOk({
+      data: [MOCK_FIXTURE_CONN],
+      pagination: { total: 1, limit: 50, offset: 0, hasMore: false },
+    })
+  );
 });
 
 describe('inventory.fixtures.list', () => {
@@ -44,39 +51,29 @@ describe('inventory.fixtures.list', () => {
   it('returns fixture list without filters', async () => {
     const result = await tool.handler({});
     const data = parseResult(result);
-    expect(mockClient.inventory.fixtures.list.query).toHaveBeenCalledWith({
-      locationId: undefined,
-      type: undefined,
-      limit: undefined,
-      offset: undefined,
-    });
+    expect(fixtures.list).toHaveBeenCalled();
     expect(data).toMatchObject({ data: [MOCK_FIXTURE], total: 1 });
   });
 
   it('passes locationId filter', async () => {
     await tool.handler({ locationId: 'loc_1' });
-    expect(mockClient.inventory.fixtures.list.query).toHaveBeenCalledWith(
-      expect.objectContaining({ locationId: 'loc_1' })
-    );
+    expect(fixtures.list).toHaveBeenCalledWith(expect.objectContaining({ locationId: 'loc_1' }));
   });
 
   it('passes type filter', async () => {
     await tool.handler({ type: 'outlet' });
-    expect(mockClient.inventory.fixtures.list.query).toHaveBeenCalledWith(
-      expect.objectContaining({ type: 'outlet' })
-    );
+    expect(fixtures.list).toHaveBeenCalledWith(expect.objectContaining({ type: 'outlet' }));
   });
 
   it('passes pagination args', async () => {
     await tool.handler({ limit: 10, offset: 20 });
-    expect(mockClient.inventory.fixtures.list.query).toHaveBeenCalledWith(
-      expect.objectContaining({ limit: 10, offset: 20 })
-    );
+    expect(fixtures.list).toHaveBeenCalledWith(expect.objectContaining({ limit: 10, offset: 20 }));
   });
 
-  it('propagates tRPC errors', async () => {
-    mockClient.inventory.fixtures.list.query.mockRejectedValue(new Error('DB error'));
-    await expect(tool.handler({})).rejects.toThrow('DB error');
+  it('returns isError on unavailable', async () => {
+    fixtures.list.mockResolvedValueOnce(callUnavailable('inventory'));
+    const result = await tool.handler({});
+    expect(result.isError).toBe(true);
   });
 });
 
@@ -85,14 +82,14 @@ describe('inventory.fixtures.get', () => {
 
   it('returns fixture by id wrapped in the data envelope', async () => {
     const result = await tool.handler({ id: 'fixture_1' });
-    expect(mockClient.inventory.fixtures.get.query).toHaveBeenCalledWith({ id: 'fixture_1' });
+    expect(fixtures.get).toHaveBeenCalledWith({ id: 'fixture_1' });
     expect(parseResult(result)).toMatchObject({ data: { id: 'fixture_1' } });
   });
 
   it('returns toolError for missing id', async () => {
     const result = await tool.handler({});
     expect(result.isError).toBe(true);
-    expect(mockClient.inventory.fixtures.get.query).not.toHaveBeenCalled();
+    expect(fixtures.get).not.toHaveBeenCalled();
   });
 
   it('returns toolError for empty string id', async () => {
@@ -100,9 +97,10 @@ describe('inventory.fixtures.get', () => {
     expect(result.isError).toBe(true);
   });
 
-  it('propagates NOT_FOUND tRPC errors', async () => {
-    mockClient.inventory.fixtures.get.query.mockRejectedValue(new Error('NOT_FOUND'));
-    await expect(tool.handler({ id: 'missing' })).rejects.toThrow('NOT_FOUND');
+  it('returns isError on contract-mismatch', async () => {
+    fixtures.get.mockResolvedValueOnce(callContractMismatch('inventory', '1.0.0', '2.0.0'));
+    const result = await tool.handler({ id: 'fixture_1' });
+    expect(result.isError).toBe(true);
   });
 });
 
@@ -111,7 +109,7 @@ describe('inventory.fixtures.create', () => {
 
   it('creates fixture with required fields', async () => {
     const result = await tool.handler({ name: 'Outlet A', type: 'outlet' });
-    expect(mockClient.inventory.fixtures.create.mutate).toHaveBeenCalledWith(
+    expect(fixtures.create).toHaveBeenCalledWith(
       expect.objectContaining({ name: 'Outlet A', type: 'outlet' })
     );
     expect(parseResult(result)).toMatchObject({ data: MOCK_FIXTURE, message: 'Fixture created' });
@@ -124,7 +122,7 @@ describe('inventory.fixtures.create', () => {
       locationId: 'loc_2',
       notes: 'rack A',
     });
-    expect(mockClient.inventory.fixtures.create.mutate).toHaveBeenCalledWith({
+    expect(fixtures.create).toHaveBeenCalledWith({
       name: 'Panel',
       type: 'patch_panel',
       locationId: 'loc_2',
@@ -141,6 +139,12 @@ describe('inventory.fixtures.create', () => {
     const result = await tool.handler({ name: 'Outlet A' });
     expect(result.isError).toBe(true);
   });
+
+  it('returns isError on unavailable', async () => {
+    fixtures.create.mockResolvedValueOnce(callUnavailable('inventory'));
+    const result = await tool.handler({ name: 'Outlet A', type: 'outlet' });
+    expect(result.isError).toBe(true);
+  });
 });
 
 describe('inventory.fixtures.update', () => {
@@ -148,7 +152,7 @@ describe('inventory.fixtures.update', () => {
 
   it('updates name', async () => {
     const result = await tool.handler({ id: 'fixture_1', name: 'New Name' });
-    expect(mockClient.inventory.fixtures.update.mutate).toHaveBeenCalledWith({
+    expect(fixtures.update).toHaveBeenCalledWith({
       id: 'fixture_1',
       data: { name: 'New Name' },
     });
@@ -157,7 +161,7 @@ describe('inventory.fixtures.update', () => {
 
   it('clears locationId when passed null', async () => {
     await tool.handler({ id: 'fixture_1', locationId: null });
-    expect(mockClient.inventory.fixtures.update.mutate).toHaveBeenCalledWith({
+    expect(fixtures.update).toHaveBeenCalledWith({
       id: 'fixture_1',
       data: { locationId: null },
     });
@@ -165,7 +169,7 @@ describe('inventory.fixtures.update', () => {
 
   it('clears notes when passed null', async () => {
     await tool.handler({ id: 'fixture_1', notes: null });
-    expect(mockClient.inventory.fixtures.update.mutate).toHaveBeenCalledWith({
+    expect(fixtures.update).toHaveBeenCalledWith({
       id: 'fixture_1',
       data: { notes: null },
     });
@@ -173,7 +177,7 @@ describe('inventory.fixtures.update', () => {
 
   it('omits absent fields from patch (no-op for absent keys)', async () => {
     await tool.handler({ id: 'fixture_1', name: 'Updated' });
-    const call = mockClient.inventory.fixtures.update.mutate.mock.calls[0]?.[0];
+    const call = fixtures.update.mock.calls[0]?.[0] as { data: Record<string, unknown> };
     expect(call?.data).not.toHaveProperty('locationId');
     expect(call?.data).not.toHaveProperty('notes');
     expect(call?.data).not.toHaveProperty('type');
@@ -182,22 +186,7 @@ describe('inventory.fixtures.update', () => {
   it('returns toolError for missing id', async () => {
     const result = await tool.handler({ name: 'Updated' });
     expect(result.isError).toBe(true);
-    expect(mockClient.inventory.fixtures.update.mutate).not.toHaveBeenCalled();
-  });
-
-  // Empty-patch rejection happens at the tRPC layer (UpdateFixtureSchema.refine).
-  // The MCP adapter forwards the call; the tRPC client surfaces a BAD_REQUEST
-  // which `handler` rethrows. Assert the rethrow rather than re-implementing
-  // a parallel guard at the MCP layer.
-  it('forwards an empty patch and lets the backend reject it', async () => {
-    mockClient.inventory.fixtures.update.mutate.mockRejectedValueOnce(
-      Object.assign(new Error('At least one field required'), { code: 'BAD_REQUEST' })
-    );
-    await expect(tool.handler({ id: 'fixture_1' })).rejects.toThrow(/At least one field required/);
-    expect(mockClient.inventory.fixtures.update.mutate).toHaveBeenCalledWith({
-      id: 'fixture_1',
-      data: {},
-    });
+    expect(fixtures.update).not.toHaveBeenCalled();
   });
 });
 
@@ -206,19 +195,14 @@ describe('inventory.fixtures.delete', () => {
 
   it('deletes fixture by id', async () => {
     const result = await tool.handler({ id: 'fixture_1' });
-    expect(mockClient.inventory.fixtures.delete.mutate).toHaveBeenCalledWith({ id: 'fixture_1' });
+    expect(fixtures.delete).toHaveBeenCalledWith({ id: 'fixture_1' });
     expect(parseResult(result)).toMatchObject({ message: 'Fixture deleted' });
   });
 
   it('returns toolError for missing id', async () => {
     const result = await tool.handler({});
     expect(result.isError).toBe(true);
-    expect(mockClient.inventory.fixtures.delete.mutate).not.toHaveBeenCalled();
-  });
-
-  it('propagates NOT_FOUND tRPC errors', async () => {
-    mockClient.inventory.fixtures.delete.mutate.mockRejectedValue(new Error('NOT_FOUND'));
-    await expect(tool.handler({ id: 'missing' })).rejects.toThrow('NOT_FOUND');
+    expect(fixtures.delete).not.toHaveBeenCalled();
   });
 });
 
@@ -227,7 +211,7 @@ describe('inventory.fixtures.connect', () => {
 
   it('connects item to fixture', async () => {
     const result = await tool.handler({ itemId: 'item_1', fixtureId: 'fixture_1' });
-    expect(mockClient.inventory.fixtures.connect.mutate).toHaveBeenCalledWith({
+    expect(fixtures.connect).toHaveBeenCalledWith({
       itemId: 'item_1',
       fixtureId: 'fixture_1',
     });
@@ -244,18 +228,10 @@ describe('inventory.fixtures.connect', () => {
     expect(result.isError).toBe(true);
   });
 
-  it('propagates CONFLICT tRPC errors', async () => {
-    mockClient.inventory.fixtures.connect.mutate.mockRejectedValue(new Error('CONFLICT'));
-    await expect(tool.handler({ itemId: 'item_1', fixtureId: 'fixture_1' })).rejects.toThrow(
-      'CONFLICT'
-    );
-  });
-
-  it('propagates NOT_FOUND tRPC errors', async () => {
-    mockClient.inventory.fixtures.connect.mutate.mockRejectedValue(new Error('NOT_FOUND'));
-    await expect(tool.handler({ itemId: 'item_bad', fixtureId: 'fixture_1' })).rejects.toThrow(
-      'NOT_FOUND'
-    );
+  it('returns isError on unavailable', async () => {
+    fixtures.connect.mockResolvedValueOnce(callUnavailable('inventory'));
+    const result = await tool.handler({ itemId: 'item_1', fixtureId: 'fixture_1' });
+    expect(result.isError).toBe(true);
   });
 });
 
@@ -264,7 +240,7 @@ describe('inventory.fixtures.disconnect', () => {
 
   it('disconnects item from fixture', async () => {
     const result = await tool.handler({ itemId: 'item_1', fixtureId: 'fixture_1' });
-    expect(mockClient.inventory.fixtures.disconnect.mutate).toHaveBeenCalledWith({
+    expect(fixtures.disconnect).toHaveBeenCalledWith({
       itemId: 'item_1',
       fixtureId: 'fixture_1',
     });
@@ -280,13 +256,6 @@ describe('inventory.fixtures.disconnect', () => {
     const result = await tool.handler({ itemId: 'item_1' });
     expect(result.isError).toBe(true);
   });
-
-  it('propagates NOT_FOUND tRPC errors', async () => {
-    mockClient.inventory.fixtures.disconnect.mutate.mockRejectedValue(new Error('NOT_FOUND'));
-    await expect(tool.handler({ itemId: 'item_1', fixtureId: 'fixture_missing' })).rejects.toThrow(
-      'NOT_FOUND'
-    );
-  });
 });
 
 describe('inventory.fixtures.listForItem', () => {
@@ -294,7 +263,7 @@ describe('inventory.fixtures.listForItem', () => {
 
   it('returns fixture connections for item', async () => {
     const result = await tool.handler({ itemId: 'item_1' });
-    expect(mockClient.inventory.fixtures.listForItem.query).toHaveBeenCalledWith({
+    expect(fixtures.listForItem).toHaveBeenCalledWith({
       itemId: 'item_1',
       limit: undefined,
       offset: undefined,
@@ -304,7 +273,7 @@ describe('inventory.fixtures.listForItem', () => {
 
   it('passes pagination args', async () => {
     await tool.handler({ itemId: 'item_1', limit: 5, offset: 10 });
-    expect(mockClient.inventory.fixtures.listForItem.query).toHaveBeenCalledWith({
+    expect(fixtures.listForItem).toHaveBeenCalledWith({
       itemId: 'item_1',
       limit: 5,
       offset: 10,
@@ -314,11 +283,6 @@ describe('inventory.fixtures.listForItem', () => {
   it('returns toolError for missing itemId', async () => {
     const result = await tool.handler({});
     expect(result.isError).toBe(true);
-    expect(mockClient.inventory.fixtures.listForItem.query).not.toHaveBeenCalled();
-  });
-
-  it('propagates tRPC errors', async () => {
-    mockClient.inventory.fixtures.listForItem.query.mockRejectedValue(new Error('NOT_FOUND'));
-    await expect(tool.handler({ itemId: 'item_bad' })).rejects.toThrow('NOT_FOUND');
+    expect(fixtures.listForItem).not.toHaveBeenCalled();
   });
 });

--- a/apps/pops-mcp/src/tools/inventory-fixtures.ts
+++ b/apps/pops-mcp/src/tools/inventory-fixtures.ts
@@ -1,6 +1,5 @@
-import { getClient } from '../client.js';
-import { fixtureWriteTools } from './inventory-fixtures-write.js';
-import { ok, optNum, optStr, reqStr, toolError } from './utils.js';
+import { fixtureWriteTools, fixtures } from './inventory-fixtures-write.js';
+import { mapCallResult, optNum, optStr, reqStr, toolError } from './utils.js';
 
 import type { ToolDef } from './index.js';
 
@@ -20,13 +19,14 @@ const fixturesList: ToolDef = {
     },
   },
   handler: async (args) => {
-    const result = await getClient().inventory.fixtures.list.query({
-      locationId: optStr(args, 'locationId'),
-      type: optStr(args, 'type'),
-      limit: optNum(args, 'limit'),
-      offset: optNum(args, 'offset'),
-    });
-    return ok(result);
+    return mapCallResult(
+      await fixtures().list({
+        locationId: optStr(args, 'locationId'),
+        type: optStr(args, 'type'),
+        limit: optNum(args, 'limit'),
+        offset: optNum(args, 'offset'),
+      })
+    );
   },
 };
 
@@ -41,8 +41,7 @@ const fixturesGet: ToolDef = {
   handler: async (args) => {
     const id = reqStr(args, 'id');
     if (!id) return toolError('Missing required field: id');
-    const result = await getClient().inventory.fixtures.get.query({ id });
-    return ok(result);
+    return mapCallResult(await fixtures().get({ id }));
   },
 };
 
@@ -61,12 +60,13 @@ const fixturesListForItem: ToolDef = {
   handler: async (args) => {
     const itemId = reqStr(args, 'itemId');
     if (!itemId) return toolError('Missing required field: itemId');
-    const result = await getClient().inventory.fixtures.listForItem.query({
-      itemId,
-      limit: optNum(args, 'limit'),
-      offset: optNum(args, 'offset'),
-    });
-    return ok(result);
+    return mapCallResult(
+      await fixtures().listForItem({
+        itemId,
+        limit: optNum(args, 'limit'),
+        offset: optNum(args, 'offset'),
+      })
+    );
   },
 };
 

--- a/apps/pops-mcp/src/tools/inventory-items-write.ts
+++ b/apps/pops-mcp/src/tools/inventory-items-write.ts
@@ -1,52 +1,88 @@
-import { getClient } from '../client.js';
+import { getPillar } from '../pillar-client.js';
 import {
   copyNullNum,
   copyNullStr,
   copyOptBool,
   copyOptStr,
-  nullNum,
-  nullStr,
-  ok,
-  optBool,
+  mapCallResult,
   reqStr,
   toolError,
 } from './utils.js';
 
+import type { PillarHandle } from '@pops/pillar-sdk/client';
+
 import type { ToolDef } from './index.js';
 
-// Hoist the patch type from the tRPC mutation signature so it tracks the
-// backend schema automatically — no manual interface duplication, no escape
-// `as` cast at the call site.
-type ItemPatch = Parameters<
-  ReturnType<typeof getClient>['inventory']['items']['update']['mutate']
->[0]['data'];
+export type ItemPatch = {
+  itemName?: string;
+  brand?: string | null;
+  model?: string | null;
+  itemId?: string | null;
+  room?: string | null;
+  type?: string | null;
+  condition?: string | null;
+  locationId?: string | null;
+  assetId?: string | null;
+  notes?: string | null;
+  purchaseDate?: string | null;
+  warrantyExpires?: string | null;
+  purchasedFromName?: string | null;
+  replacementValue?: number | null;
+  resaleValue?: number | null;
+  purchasePrice?: number | null;
+  inUse?: boolean;
+  deductible?: boolean;
+};
+
+type ItemCreateInput = ItemPatch & { itemName: string };
+
+export type ItemsShape = {
+  inventory: {
+    items: {
+      list: (input: {
+        search?: string;
+        locationId?: string;
+        includeChildren?: boolean;
+        type?: string;
+        condition?: string;
+        limit?: number;
+        offset?: number;
+      }) => unknown;
+      get: (input: { id: string }) => unknown;
+      create: (input: ItemCreateInput) => unknown;
+      update: (input: { id: string; data: ItemPatch }) => unknown;
+      delete: (input: { id: string }) => unknown;
+    };
+  };
+};
+
+const NULL_STR_FIELDS = [
+  'brand',
+  'model',
+  'itemId',
+  'room',
+  'type',
+  'condition',
+  'locationId',
+  'assetId',
+  'notes',
+  'purchaseDate',
+  'warrantyExpires',
+  'purchasedFromName',
+] as const;
+const NULL_NUM_FIELDS = ['replacementValue', 'resaleValue', 'purchasePrice'] as const;
+const OPT_BOOL_FIELDS = ['inUse', 'deductible'] as const;
+
+export function items(): PillarHandle<ItemsShape>['inventory']['items'] {
+  return getPillar<ItemsShape>('inventory').inventory.items;
+}
 
 function buildItemPatch(args: Record<string, unknown>): ItemPatch {
   const patch: ItemPatch = {};
-  // itemName is NOT NULL in the backend schema, so use copyOptStr (drops nulls).
   copyOptStr(patch, args, 'itemName');
-  for (const k of [
-    'brand',
-    'model',
-    'itemId',
-    'room',
-    'type',
-    'condition',
-    'locationId',
-    'assetId',
-    'notes',
-    'purchaseDate',
-    'warrantyExpires',
-    'purchasedFromName',
-  ]) {
-    copyNullStr(patch, args, k);
-  }
-  for (const k of ['replacementValue', 'resaleValue', 'purchasePrice']) {
-    copyNullNum(patch, args, k);
-  }
-  for (const k of ['inUse', 'deductible']) {
-    copyOptBool(patch, args, k);
-  }
+  for (const k of NULL_STR_FIELDS) copyNullStr(patch, args, k);
+  for (const k of NULL_NUM_FIELDS) copyNullNum(patch, args, k);
+  for (const k of OPT_BOOL_FIELDS) copyOptBool(patch, args, k);
   return patch;
 }
 
@@ -81,27 +117,8 @@ const itemsCreate: ToolDef = {
   handler: async (args) => {
     const itemName = reqStr(args, 'itemName');
     if (!itemName) return toolError('Missing required field: itemName');
-    const result = await getClient().inventory.items.create.mutate({
-      itemName,
-      brand: nullStr(args, 'brand'),
-      model: nullStr(args, 'model'),
-      itemId: nullStr(args, 'itemId'),
-      room: nullStr(args, 'room'),
-      type: nullStr(args, 'type'),
-      condition: nullStr(args, 'condition'),
-      locationId: nullStr(args, 'locationId'),
-      inUse: optBool(args, 'inUse'),
-      deductible: optBool(args, 'deductible'),
-      assetId: nullStr(args, 'assetId'),
-      notes: nullStr(args, 'notes'),
-      purchaseDate: nullStr(args, 'purchaseDate'),
-      warrantyExpires: nullStr(args, 'warrantyExpires'),
-      replacementValue: nullNum(args, 'replacementValue'),
-      resaleValue: nullNum(args, 'resaleValue'),
-      purchasePrice: nullNum(args, 'purchasePrice'),
-      purchasedFromName: nullStr(args, 'purchasedFromName'),
-    });
-    return ok(result);
+    const input: ItemCreateInput = { itemName, ...buildItemPatch(args) };
+    return mapCallResult(await items().create(input));
   },
 };
 
@@ -147,8 +164,7 @@ const itemsUpdate: ToolDef = {
     const id = reqStr(args, 'id');
     if (!id) return toolError('Missing required field: id');
     const data = buildItemPatch(args);
-    const result = await getClient().inventory.items.update.mutate({ id, data });
-    return ok(result);
+    return mapCallResult(await items().update({ id, data }));
   },
 };
 
@@ -163,8 +179,7 @@ const itemsDelete: ToolDef = {
   handler: async (args) => {
     const id = reqStr(args, 'id');
     if (!id) return toolError('Missing required field: id');
-    const result = await getClient().inventory.items.delete.mutate({ id });
-    return ok(result);
+    return mapCallResult(await items().delete({ id }));
   },
 };
 

--- a/apps/pops-mcp/src/tools/inventory-items.test.ts
+++ b/apps/pops-mcp/src/tools/inventory-items.test.ts
@@ -1,8 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { mockClient, parseResult } from './test-helpers.js';
+import {
+  callContractMismatch,
+  callOk,
+  callUnavailable,
+  mockPillarInventory,
+  parseResult,
+  pillarMockGetter,
+} from './test-helpers.js';
 
-vi.mock('../client.js', () => ({ getClient: () => mockClient }));
+vi.mock('../pillar-client.js', () => ({
+  getPillar: pillarMockGetter,
+  __resetPillarClientForTests: () => {},
+}));
 
 const { itemTools } = await import('./inventory-items.js');
 
@@ -12,13 +22,42 @@ function tool(name: string) {
   return t;
 }
 
+const items = mockPillarInventory.inventory.items;
+
+const MOCK_ITEM = {
+  id: 'item_1',
+  itemName: 'MacBook',
+  brand: 'Apple',
+  model: 'MacBook Pro 14"',
+  type: 'electronics',
+  condition: 'good',
+  locationId: 'loc_1',
+  inUse: true,
+  deductible: false,
+  assetId: 'MBP01',
+  notes: null,
+  purchaseDate: null,
+  warrantyExpires: null,
+  replacementValue: 3000,
+  resaleValue: 1500,
+  purchasePrice: 3200,
+  purchasedFromName: 'Apple Store',
+  lastEditedTime: '2025-01-01T00:00:00.000Z',
+};
+
 beforeEach(() => {
   vi.clearAllMocks();
+  items.list.mockResolvedValue(
+    callOk({
+      data: [MOCK_ITEM],
+      pagination: { total: 1, limit: 50, offset: 0, hasMore: false },
+    })
+  );
+  items.get.mockResolvedValue(callOk({ data: MOCK_ITEM }));
+  items.create.mockResolvedValue(callOk({ data: MOCK_ITEM, message: 'Inventory item created' }));
+  items.update.mockResolvedValue(callOk({ data: MOCK_ITEM, message: 'Inventory item updated' }));
+  items.delete.mockResolvedValue(callOk({ message: 'Inventory item deleted' }));
 });
-
-// ---------------------------------------------------------------------------
-// Read
-// ---------------------------------------------------------------------------
 
 describe('inventory.items.list', () => {
   it('passes optional filters', async () => {
@@ -30,7 +69,7 @@ describe('inventory.items.list', () => {
       limit: 10,
       offset: 5,
     });
-    expect(mockClient.inventory.items.list.query).toHaveBeenCalledWith(
+    expect(items.list).toHaveBeenCalledWith(
       expect.objectContaining({
         search: 'mac',
         locationId: 'loc_1',
@@ -44,17 +83,23 @@ describe('inventory.items.list', () => {
 
   it('passes undefined for absent optional fields (not null)', async () => {
     await tool('inventory.items.list').handler({});
-    const call = mockClient.inventory.items.list.query.mock.lastCall?.[0];
+    const call = items.list.mock.lastCall?.[0];
     for (const value of Object.values(call as Record<string, unknown>)) {
       expect(value).not.toBeNull();
     }
   });
+
+  it('returns isError on unavailable', async () => {
+    items.list.mockResolvedValueOnce(callUnavailable('inventory'));
+    const result = await tool('inventory.items.list').handler({});
+    expect(result.isError).toBe(true);
+  });
 });
 
 describe('inventory.items.get', () => {
-  it('passes id to tRPC and returns the data envelope', async () => {
+  it('passes id and returns the data envelope', async () => {
     const result = await tool('inventory.items.get').handler({ id: 'item_1' });
-    expect(mockClient.inventory.items.get.query).toHaveBeenCalledWith({ id: 'item_1' });
+    expect(items.get).toHaveBeenCalledWith({ id: 'item_1' });
     const parsed = parseResult(result) as { data: { itemName: string } };
     expect(parsed.data.itemName).toBe('MacBook');
   });
@@ -68,16 +113,10 @@ describe('inventory.items.get', () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// Create
-// ---------------------------------------------------------------------------
-
 describe('inventory.items.create', () => {
   it('creates with only itemName', async () => {
     const result = await tool('inventory.items.create').handler({ itemName: 'Sony TV' });
-    expect(mockClient.inventory.items.create.mutate).toHaveBeenCalledWith(
-      expect.objectContaining({ itemName: 'Sony TV' })
-    );
+    expect(items.create).toHaveBeenCalledWith(expect.objectContaining({ itemName: 'Sony TV' }));
     expect(result.isError).toBeUndefined();
     const parsed = parseResult(result) as { data: { id: string }; message: string };
     expect(parsed.data.id).toBe('item_1');
@@ -98,7 +137,7 @@ describe('inventory.items.create', () => {
       warrantyExpires: '2027-01-15',
       purchasedFromName: 'JB Hi-Fi',
     });
-    expect(mockClient.inventory.items.create.mutate).toHaveBeenCalledWith(
+    expect(items.create).toHaveBeenCalledWith(
       expect.objectContaining({
         brand: 'Sony',
         model: 'A95L',
@@ -114,7 +153,7 @@ describe('inventory.items.create', () => {
       inUse: true,
       deductible: false,
     });
-    expect(mockClient.inventory.items.create.mutate).toHaveBeenCalledWith(
+    expect(items.create).toHaveBeenCalledWith(
       expect.objectContaining({ inUse: true, deductible: false })
     );
   });
@@ -126,7 +165,7 @@ describe('inventory.items.create', () => {
       resaleValue: 5.5,
       purchasePrice: 12.99,
     });
-    expect(mockClient.inventory.items.create.mutate).toHaveBeenCalledWith(
+    expect(items.create).toHaveBeenCalledWith(
       expect.objectContaining({ replacementValue: 0, resaleValue: 5.5, purchasePrice: 12.99 })
     );
   });
@@ -134,64 +173,56 @@ describe('inventory.items.create', () => {
   it('returns isError when itemName is missing', async () => {
     const result = await tool('inventory.items.create').handler({ brand: 'Sony' });
     expect(result.isError).toBe(true);
-    expect(mockClient.inventory.items.create.mutate).not.toHaveBeenCalled();
+    expect(items.create).not.toHaveBeenCalled();
   });
 
   it('returns isError when itemName is empty string', async () => {
     expect((await tool('inventory.items.create').handler({ itemName: '' })).isError).toBe(true);
   });
-});
 
-// ---------------------------------------------------------------------------
-// Update
-// ---------------------------------------------------------------------------
+  it('returns isError on unavailable', async () => {
+    items.create.mockResolvedValueOnce(callUnavailable('inventory'));
+    const result = await tool('inventory.items.create').handler({ itemName: 'TV' });
+    expect(result.isError).toBe(true);
+  });
+});
 
 describe('inventory.items.update', () => {
   it('updates itemName only', async () => {
     await tool('inventory.items.update').handler({ id: 'item_1', itemName: 'MacBook Pro' });
-    expect(mockClient.inventory.items.update.mutate).toHaveBeenCalledWith(
+    expect(items.update).toHaveBeenCalledWith(
       expect.objectContaining({ id: 'item_1', data: { itemName: 'MacBook Pro' } })
     );
   });
 
   it('clears a nullable string field with null', async () => {
     await tool('inventory.items.update').handler({ id: 'item_1', notes: null });
-    const call = mockClient.inventory.items.update.mutate.mock.lastCall?.[0] as {
-      data: Record<string, unknown>;
-    };
+    const call = items.update.mock.lastCall?.[0] as { data: Record<string, unknown> };
     expect(call.data.notes).toBeNull();
   });
 
   it('clears a nullable number field with null', async () => {
     await tool('inventory.items.update').handler({ id: 'item_1', replacementValue: null });
-    const call = mockClient.inventory.items.update.mutate.mock.lastCall?.[0] as {
-      data: Record<string, unknown>;
-    };
+    const call = items.update.mock.lastCall?.[0] as { data: Record<string, unknown> };
     expect(call.data.replacementValue).toBeNull();
   });
 
   it('does not include absent fields in data', async () => {
     await tool('inventory.items.update').handler({ id: 'item_1', itemName: 'MacBook Pro' });
-    const call = mockClient.inventory.items.update.mutate.mock.lastCall?.[0] as {
-      data: Record<string, unknown>;
-    };
+    const call = items.update.mock.lastCall?.[0] as { data: Record<string, unknown> };
     expect('brand' in call.data).toBe(false);
     expect('replacementValue' in call.data).toBe(false);
   });
 
   it('passes number 0 as valid (not omitted)', async () => {
     await tool('inventory.items.update').handler({ id: 'item_1', resaleValue: 0 });
-    const call = mockClient.inventory.items.update.mutate.mock.lastCall?.[0] as {
-      data: Record<string, unknown>;
-    };
+    const call = items.update.mock.lastCall?.[0] as { data: Record<string, unknown> };
     expect(call.data.resaleValue).toBe(0);
   });
 
   it('passes boolean fields correctly', async () => {
     await tool('inventory.items.update').handler({ id: 'item_1', inUse: false, deductible: true });
-    const call = mockClient.inventory.items.update.mutate.mock.lastCall?.[0] as {
-      data: Record<string, unknown>;
-    };
+    const call = items.update.mock.lastCall?.[0] as { data: Record<string, unknown> };
     expect(call.data.inUse).toBe(false);
     expect(call.data.deductible).toBe(true);
   });
@@ -199,22 +230,27 @@ describe('inventory.items.update', () => {
   it('returns isError when id is missing', async () => {
     const result = await tool('inventory.items.update').handler({ itemName: 'No ID' });
     expect(result.isError).toBe(true);
-    expect(mockClient.inventory.items.update.mutate).not.toHaveBeenCalled();
+    expect(items.update).not.toHaveBeenCalled();
   });
 
   it('returns isError when id is empty string', async () => {
     expect((await tool('inventory.items.update').handler({ id: '' })).isError).toBe(true);
   });
-});
 
-// ---------------------------------------------------------------------------
-// Delete
-// ---------------------------------------------------------------------------
+  it('returns isError on contract-mismatch', async () => {
+    items.update.mockResolvedValueOnce(callContractMismatch('inventory', '1.0.0', '2.0.0'));
+    const result = await tool('inventory.items.update').handler({
+      id: 'item_1',
+      itemName: 'New',
+    });
+    expect(result.isError).toBe(true);
+  });
+});
 
 describe('inventory.items.delete', () => {
   it('deletes item by id', async () => {
     const result = await tool('inventory.items.delete').handler({ id: 'item_1' });
-    expect(mockClient.inventory.items.delete.mutate).toHaveBeenCalledWith({ id: 'item_1' });
+    expect(items.delete).toHaveBeenCalledWith({ id: 'item_1' });
     expect(result.isError).toBeUndefined();
     expect((parseResult(result) as { message: string }).message).toBe('Inventory item deleted');
   });
@@ -222,7 +258,7 @@ describe('inventory.items.delete', () => {
   it('returns isError when id is missing', async () => {
     const result = await tool('inventory.items.delete').handler({});
     expect(result.isError).toBe(true);
-    expect(mockClient.inventory.items.delete.mutate).not.toHaveBeenCalled();
+    expect(items.delete).not.toHaveBeenCalled();
   });
 
   it('returns isError when id is empty string', async () => {

--- a/apps/pops-mcp/src/tools/inventory-items.ts
+++ b/apps/pops-mcp/src/tools/inventory-items.ts
@@ -1,6 +1,5 @@
-import { getClient } from '../client.js';
-import { itemWriteTools } from './inventory-items-write.js';
-import { ok, optBool, optNum, optStr, reqStr, toolError } from './utils.js';
+import { items, itemWriteTools } from './inventory-items-write.js';
+import { mapCallResult, optBool, optNum, optStr, reqStr, toolError } from './utils.js';
 
 import type { ToolDef } from './index.js';
 
@@ -24,16 +23,17 @@ const itemsList: ToolDef = {
     },
   },
   handler: async (args) => {
-    const result = await getClient().inventory.items.list.query({
-      search: optStr(args, 'search'),
-      locationId: optStr(args, 'locationId'),
-      includeChildren: optBool(args, 'includeChildren'),
-      type: optStr(args, 'type'),
-      condition: optStr(args, 'condition'),
-      limit: optNum(args, 'limit'),
-      offset: optNum(args, 'offset'),
-    });
-    return ok(result);
+    return mapCallResult(
+      await items().list({
+        search: optStr(args, 'search'),
+        locationId: optStr(args, 'locationId'),
+        includeChildren: optBool(args, 'includeChildren'),
+        type: optStr(args, 'type'),
+        condition: optStr(args, 'condition'),
+        limit: optNum(args, 'limit'),
+        offset: optNum(args, 'offset'),
+      })
+    );
   },
 };
 
@@ -48,8 +48,7 @@ const itemGet: ToolDef = {
   handler: async (args) => {
     const id = reqStr(args, 'id');
     if (!id) return toolError('Missing required field: id');
-    const result = await getClient().inventory.items.get.query({ id });
-    return ok(result);
+    return mapCallResult(await items().get({ id }));
   },
 };
 

--- a/apps/pops-mcp/src/tools/media.test.ts
+++ b/apps/pops-mcp/src/tools/media.test.ts
@@ -1,33 +1,59 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { mockClient } from './test-helpers.js';
+import {
+  callContractMismatch,
+  callOk,
+  callUnavailable,
+  mockPillarMedia,
+  pillarMockGetter,
+} from './test-helpers.js';
 
-vi.mock('../client.js', () => ({ getClient: () => mockClient }));
+vi.mock('../pillar-client.js', () => ({
+  getPillar: pillarMockGetter,
+  __resetPillarClientForTests: () => {},
+}));
 
 const { mediaTools } = await import('./media.js');
+
+const library = mockPillarMedia.media.library;
+const watchlist = mockPillarMedia.media.watchlist;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  library.list.mockResolvedValue(callOk({ items: [], total: 0 }));
+  watchlist.list.mockResolvedValue(callOk({ data: [], pagination: { total: 0 } }));
+});
 
 describe('media.library.list', () => {
   const tool = mediaTools.find((t) => t.name === 'media.library.list')!;
 
   it('defaults type to "all" when not provided', async () => {
     await tool.handler({});
-    expect(mockClient.media.library.list.query).toHaveBeenCalledWith(
-      expect.objectContaining({ type: 'all' })
-    );
+    expect(library.list).toHaveBeenCalledWith(expect.objectContaining({ type: 'all' }));
   });
 
   it('passes movie filter through', async () => {
     await tool.handler({ type: 'movie', search: 'godfather' });
-    expect(mockClient.media.library.list.query).toHaveBeenCalledWith(
+    expect(library.list).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'movie', search: 'godfather' })
     );
   });
 
   it('ignores invalid type values and falls back to "all"', async () => {
     await tool.handler({ type: 'podcast' });
-    expect(mockClient.media.library.list.query).toHaveBeenCalledWith(
-      expect.objectContaining({ type: 'all' })
-    );
+    expect(library.list).toHaveBeenCalledWith(expect.objectContaining({ type: 'all' }));
+  });
+
+  it('returns isError on unavailable', async () => {
+    library.list.mockResolvedValueOnce(callUnavailable('media'));
+    const result = await tool.handler({});
+    expect(result.isError).toBe(true);
+  });
+
+  it('returns isError on contract-mismatch', async () => {
+    library.list.mockResolvedValueOnce(callContractMismatch('media', '1.0.0', '2.0.0'));
+    const result = await tool.handler({});
+    expect(result.isError).toBe(true);
   });
 });
 
@@ -36,14 +62,18 @@ describe('media.watchlist.list', () => {
 
   it('passes mediaType filter', async () => {
     await tool.handler({ mediaType: 'movie' });
-    expect(mockClient.media.watchlist.list.query).toHaveBeenCalledWith(
-      expect.objectContaining({ mediaType: 'movie' })
-    );
+    expect(watchlist.list).toHaveBeenCalledWith(expect.objectContaining({ mediaType: 'movie' }));
   });
 
   it('ignores invalid mediaType values', async () => {
     await tool.handler({ mediaType: 'podcast' });
-    const call = mockClient.media.watchlist.list.query.mock.lastCall?.[0];
+    const call = watchlist.list.mock.lastCall?.[0];
     expect((call as Record<string, unknown>)['mediaType']).toBeUndefined();
+  });
+
+  it('returns isError on unavailable', async () => {
+    watchlist.list.mockResolvedValueOnce(callUnavailable('media'));
+    const result = await tool.handler({});
+    expect(result.isError).toBe(true);
   });
 });

--- a/apps/pops-mcp/src/tools/media.ts
+++ b/apps/pops-mcp/src/tools/media.ts
@@ -1,7 +1,38 @@
-import { getClient } from '../client.js';
-import { ok } from './utils.js';
+import { getPillar } from '../pillar-client.js';
+import { mapCallResult } from './utils.js';
+
+import type { PillarHandle } from '@pops/pillar-sdk/client';
 
 import type { ToolDef } from './index.js';
+
+type LibraryListInput = {
+  type: 'all' | 'movie' | 'tv';
+  search?: string;
+  genre?: string;
+  page?: number;
+  pageSize?: number;
+};
+
+type WatchlistListInput = {
+  mediaType?: 'movie' | 'tv_show';
+  limit?: number;
+  offset?: number;
+};
+
+type MediaShape = {
+  media: {
+    library: {
+      list: (input: LibraryListInput) => unknown;
+    };
+    watchlist: {
+      list: (input: WatchlistListInput) => unknown;
+    };
+  };
+};
+
+function media(): PillarHandle<MediaShape>['media'] {
+  return getPillar<MediaShape>('media').media;
+}
 
 const libraryList: ToolDef = {
   name: 'media.library.list',
@@ -26,19 +57,16 @@ const libraryList: ToolDef = {
     },
   },
   handler: async (args) => {
-    let type: 'all' | 'movie' | 'tv' = 'all';
-    if (args['type'] === 'movie' || args['type'] === 'tv') {
-      type = args['type'];
-    }
+    const type: 'all' | 'movie' | 'tv' =
+      args['type'] === 'movie' || args['type'] === 'tv' ? args['type'] : 'all';
 
-    const result = await getClient().media.library.list.query({
-      type,
-      search: typeof args['search'] === 'string' ? args['search'] : undefined,
-      genre: typeof args['genre'] === 'string' ? args['genre'] : undefined,
-      page: typeof args['page'] === 'number' ? args['page'] : undefined,
-      pageSize: typeof args['pageSize'] === 'number' ? args['pageSize'] : undefined,
-    });
-    return ok(result);
+    const input: LibraryListInput = { type };
+    if (typeof args['search'] === 'string') input.search = args['search'];
+    if (typeof args['genre'] === 'string') input.genre = args['genre'];
+    if (typeof args['page'] === 'number') input.page = args['page'];
+    if (typeof args['pageSize'] === 'number') input.pageSize = args['pageSize'];
+
+    return mapCallResult(await media().library.list(input));
   },
 };
 
@@ -58,15 +86,14 @@ const watchlistList: ToolDef = {
     },
   },
   handler: async (args) => {
-    const result = await getClient().media.watchlist.list.query({
-      mediaType:
-        args['mediaType'] === 'movie' || args['mediaType'] === 'tv_show'
-          ? args['mediaType']
-          : undefined,
-      limit: typeof args['limit'] === 'number' ? args['limit'] : undefined,
-      offset: typeof args['offset'] === 'number' ? args['offset'] : undefined,
-    });
-    return ok(result);
+    const input: WatchlistListInput = {};
+    if (args['mediaType'] === 'movie' || args['mediaType'] === 'tv_show') {
+      input.mediaType = args['mediaType'];
+    }
+    if (typeof args['limit'] === 'number') input.limit = args['limit'];
+    if (typeof args['offset'] === 'number') input.offset = args['offset'];
+
+    return mapCallResult(await media().watchlist.list(input));
   },
 };
 

--- a/apps/pops-mcp/src/tools/test-helpers.ts
+++ b/apps/pops-mcp/src/tools/test-helpers.ts
@@ -17,9 +17,9 @@ export const callContractMismatch = (
   actual: string
 ): CallResult<never> => ({ kind: 'contract-mismatch', pillar, expected, actual });
 
-const MOCK_LOCATION = { id: 'loc_1', name: 'Living Room', parentId: null, sortOrder: 0 };
-const MOCK_LOCATION_2 = { id: 'loc_2', name: 'Office', parentId: null, sortOrder: 1 };
-const MOCK_ITEM = {
+const LOC = { id: 'loc_1', name: 'Living Room', parentId: null, sortOrder: 0 };
+const LOC2 = { id: 'loc_2', name: 'Office', parentId: null, sortOrder: 1 };
+const ITEM = {
   id: 'item_1',
   itemName: 'MacBook',
   brand: 'Apple',
@@ -39,13 +39,8 @@ const MOCK_ITEM = {
   purchasedFromName: 'Apple Store',
   lastEditedTime: '2025-01-01T00:00:00.000Z',
 };
-const MOCK_ITEM_2 = { ...MOCK_ITEM, id: 'item_2', itemName: 'Dell Monitor', assetId: 'MON01' };
-const MOCK_CONNECTION = {
-  id: 1,
-  itemAId: 'item_1',
-  itemBId: 'item_2',
-  createdAt: '2025-01-01T00:00:00.000Z',
-};
+const ITEM2 = { ...ITEM, id: 'item_2', itemName: 'Dell Monitor', assetId: 'MON01' };
+const CONN = { id: 1, itemAId: 'item_1', itemBId: 'item_2', createdAt: '2025-01-01' };
 
 export const MOCK_FIXTURE = {
   id: 'fixture_1',
@@ -64,18 +59,47 @@ export const MOCK_FIXTURE_CONN = {
   createdAt: '2024-01-01T00:00:00.000Z',
 };
 
+const PAGED1 = { pagination: { total: 1, limit: 50, offset: 0, hasMore: false } };
+
 export const mockPillarInventory = {
   inventory: {
     locations: {
-      tree: vi.fn().mockResolvedValue(callOk({ data: [{ ...MOCK_LOCATION, children: [] }] })),
-      list: vi.fn().mockResolvedValue(callOk({ data: [MOCK_LOCATION], total: 1 })),
-      create: vi
-        .fn()
-        .mockResolvedValue(callOk({ data: MOCK_LOCATION_2, message: 'Location created' })),
-      update: vi
-        .fn()
-        .mockResolvedValue(callOk({ data: MOCK_LOCATION, message: 'Location updated' })),
+      tree: vi.fn().mockResolvedValue(callOk({ data: [{ ...LOC, children: [] }] })),
+      list: vi.fn().mockResolvedValue(callOk({ data: [LOC], total: 1 })),
+      create: vi.fn().mockResolvedValue(callOk({ data: LOC2, message: 'Location created' })),
+      update: vi.fn().mockResolvedValue(callOk({ data: LOC, message: 'Location updated' })),
       delete: vi.fn().mockResolvedValue(callOk({ message: 'Location deleted' })),
+    },
+    items: {
+      list: vi.fn().mockResolvedValue(callOk({ data: [ITEM], ...PAGED1 })),
+      get: vi.fn().mockResolvedValue(callOk({ data: ITEM })),
+      create: vi.fn().mockResolvedValue(callOk({ data: ITEM, message: 'Inventory item created' })),
+      update: vi.fn().mockResolvedValue(callOk({ data: ITEM, message: 'Inventory item updated' })),
+      delete: vi.fn().mockResolvedValue(callOk({ message: 'Inventory item deleted' })),
+    },
+    connections: {
+      listForItem: vi.fn().mockResolvedValue(callOk({ data: [CONN], ...PAGED1 })),
+      graph: vi.fn().mockResolvedValue(
+        callOk({
+          data: { nodes: [ITEM, ITEM2], edges: [{ source: 'item_1', target: 'item_2' }] },
+        })
+      ),
+      connect: vi.fn().mockResolvedValue(callOk({ data: CONN, message: 'Items connected' })),
+      disconnect: vi.fn().mockResolvedValue(callOk({ message: 'Items disconnected' })),
+    },
+    fixtures: {
+      list: vi.fn().mockResolvedValue(callOk({ data: [MOCK_FIXTURE], total: 1 })),
+      get: vi.fn().mockResolvedValue(callOk({ data: MOCK_FIXTURE })),
+      create: vi.fn().mockResolvedValue(callOk({ data: MOCK_FIXTURE, message: 'Fixture created' })),
+      update: vi.fn().mockResolvedValue(callOk({ data: MOCK_FIXTURE, message: 'Fixture updated' })),
+      delete: vi.fn().mockResolvedValue(callOk({ message: 'Fixture deleted' })),
+      connect: vi
+        .fn()
+        .mockResolvedValue(
+          callOk({ data: MOCK_FIXTURE_CONN, message: 'Item connected to fixture' })
+        ),
+      disconnect: vi.fn().mockResolvedValue(callOk({ message: 'Item disconnected from fixture' })),
+      listForItem: vi.fn().mockResolvedValue(callOk({ data: [MOCK_FIXTURE_CONN], ...PAGED1 })),
     },
   },
 };
@@ -85,110 +109,50 @@ export const mockPillarFinance = {
     transactions: {
       list: vi.fn().mockResolvedValue(callOk({ data: [], pagination: { total: 0 } })),
     },
-    budgets: {
-      list: vi.fn().mockResolvedValue(callOk({ data: [], pagination: { total: 0 } })),
-    },
+    budgets: { list: vi.fn().mockResolvedValue(callOk({ data: [], pagination: { total: 0 } })) },
   },
 };
 
+export const mockPillarMedia = {
+  media: {
+    library: { list: vi.fn().mockResolvedValue(callOk({ items: [], total: 0 })) },
+    watchlist: { list: vi.fn().mockResolvedValue(callOk({ data: [], pagination: { total: 0 } })) },
+  },
+};
+
+export const mockPillarCerebrum = {
+  cerebrum: {
+    engrams: {
+      list: vi.fn().mockResolvedValue(callOk({ engrams: [], total: 0 })),
+      get: vi.fn().mockResolvedValue(callOk({ id: 'eng_1', title: 'Test', body: 'content' })),
+    },
+    retrieval: { search: vi.fn().mockResolvedValue(callOk({ results: [] })) },
+  },
+};
+
+const PILLAR_MOCKS = {
+  inventory: mockPillarInventory,
+  finance: mockPillarFinance,
+  media: mockPillarMedia,
+  cerebrum: mockPillarCerebrum,
+} as const;
+
+/** Used as the `getPillar` mock implementation in tool tests: dispatches by pillarId. */
+export function pillarMockGetter<TRouter>(pillarId: string): TRouter {
+  const handle = PILLAR_MOCKS[pillarId as keyof typeof PILLAR_MOCKS];
+  if (!handle) throw new Error(`No mock pillar handle for '${pillarId}'`);
+  return handle as TRouter;
+}
+
+// `mockClient` still mocks the legacy `getClient()` surface for the lone
+// remaining risky cross-pillar call site (`finance.entities.list` → core)
+// and the registry sanity tests that need `getClient` to be importable. New
+// tool tests should mock `../pillar-client.js` and use `mockPillar*`.
 export const mockClient = {
-  inventory: {
-    locations: {
-      tree: { query: vi.fn().mockResolvedValue({ data: [{ ...MOCK_LOCATION, children: [] }] }) },
-      list: { query: vi.fn().mockResolvedValue({ data: [MOCK_LOCATION], total: 1 }) },
-      create: {
-        mutate: vi.fn().mockResolvedValue({ data: MOCK_LOCATION_2, message: 'Location created' }),
-      },
-      update: {
-        mutate: vi.fn().mockResolvedValue({ data: MOCK_LOCATION, message: 'Location updated' }),
-      },
-      delete: { mutate: vi.fn().mockResolvedValue({ message: 'Location deleted' }) },
-    },
-    items: {
-      list: {
-        query: vi.fn().mockResolvedValue({
-          data: [MOCK_ITEM],
-          pagination: { total: 1, limit: 50, offset: 0, hasMore: false },
-        }),
-      },
-      get: { query: vi.fn().mockResolvedValue({ data: MOCK_ITEM }) },
-      create: {
-        mutate: vi.fn().mockResolvedValue({ data: MOCK_ITEM, message: 'Inventory item created' }),
-      },
-      update: {
-        mutate: vi.fn().mockResolvedValue({ data: MOCK_ITEM, message: 'Inventory item updated' }),
-      },
-      delete: { mutate: vi.fn().mockResolvedValue({ message: 'Inventory item deleted' }) },
-    },
-    connections: {
-      listForItem: {
-        query: vi.fn().mockResolvedValue({
-          data: [MOCK_CONNECTION],
-          pagination: { total: 1, limit: 50, offset: 0, hasMore: false },
-        }),
-      },
-      graph: {
-        query: vi.fn().mockResolvedValue({
-          data: {
-            nodes: [MOCK_ITEM, MOCK_ITEM_2],
-            edges: [{ source: 'item_1', target: 'item_2' }],
-          },
-        }),
-      },
-      connect: {
-        mutate: vi.fn().mockResolvedValue({ data: MOCK_CONNECTION, message: 'Items connected' }),
-      },
-      disconnect: { mutate: vi.fn().mockResolvedValue({ message: 'Items disconnected' }) },
-    },
-    fixtures: {
-      list: { query: vi.fn().mockResolvedValue({ data: [MOCK_FIXTURE], total: 1 }) },
-      get: { query: vi.fn().mockResolvedValue({ data: MOCK_FIXTURE }) },
-      create: {
-        mutate: vi.fn().mockResolvedValue({ data: MOCK_FIXTURE, message: 'Fixture created' }),
-      },
-      update: {
-        mutate: vi.fn().mockResolvedValue({ data: MOCK_FIXTURE, message: 'Fixture updated' }),
-      },
-      delete: { mutate: vi.fn().mockResolvedValue({ message: 'Fixture deleted' }) },
-      connect: {
-        mutate: vi
-          .fn()
-          .mockResolvedValue({ data: MOCK_FIXTURE_CONN, message: 'Item connected to fixture' }),
-      },
-      disconnect: {
-        mutate: vi.fn().mockResolvedValue({ message: 'Item disconnected from fixture' }),
-      },
-      listForItem: {
-        query: vi.fn().mockResolvedValue({
-          data: [MOCK_FIXTURE_CONN],
-          pagination: { total: 1, limit: 50, offset: 0, hasMore: false },
-        }),
-      },
-    },
-  },
-  finance: {
-    transactions: {
-      list: { query: vi.fn().mockResolvedValue({ data: [], pagination: { total: 0 } }) },
-    },
-    budgets: { list: { query: vi.fn().mockResolvedValue({ data: [], pagination: { total: 0 } }) } },
-  },
   core: {
     entities: {
       list: { query: vi.fn().mockResolvedValue({ data: [], pagination: { total: 0 } }) },
     },
-  },
-  media: {
-    library: { list: { query: vi.fn().mockResolvedValue({ items: [], total: 0 }) } },
-    watchlist: {
-      list: { query: vi.fn().mockResolvedValue({ data: [], pagination: { total: 0 } }) },
-    },
-  },
-  cerebrum: {
-    engrams: {
-      list: { query: vi.fn().mockResolvedValue({ engrams: [], total: 0 }) },
-      get: { query: vi.fn().mockResolvedValue({ id: 'eng_1', title: 'Test', body: 'content' }) },
-    },
-    retrieval: { search: { query: vi.fn().mockResolvedValue({ results: [] }) } },
   },
 };
 


### PR DESCRIPTION
## Summary

PRD-205 batch 2: migrate 22 medium-category MCP tool call sites from `getClient()` (mono `pops-api` tRPC) to `pillar()` from `@pops/pillar-sdk`. Follows the pattern landed in PR #3083 (batch 1, 7 trivial sites): `mapCallResult` translates the SDK's `CallResult<T>` into MCP `CallToolResult`, with `unavailable` / `degraded` / `contract-mismatch` surfacing as `toolError` so the LLM can self-correct.

### Migrated (22 ops across 7 files)

| File | Ops |
| --- | --- |
| `cerebrum.ts` | `engrams.list`, `engrams.get`, `retrieval.search` |
| `inventory-connections.ts` | `listForItem`, `graph`, `connect`, `disconnect` |
| `inventory-fixtures.ts` | `list`, `get`, `listForItem` |
| `inventory-fixtures-write.ts` | `create`, `update`, `delete`, `connect`, `disconnect` |
| `inventory-items.ts` | `list`, `get` |
| `inventory-items-write.ts` | `create`, `update`, `delete` |
| `media.ts` | `library.list`, `watchlist.list` |

### Skipped (deferred to a follow-up)

- `finance.ts` `core.entities.list` — Risky cross-pillar fan-out from a `finance.*` tool binary; needs the file-split decision per PRD-205 §"Risky tally".
- `apps/pops-mcp/src/client.ts` — shared legacy singleton; retires only after every tool file is on the SDK.
- `apps/pops-cli/src/api-client.ts` + the 2 CLI command sites (`cerebrum.query.ask`, `cerebrum.ingest.quickCapture`) — separate binary, separate transport story (Risky per PRD-205).

### Remaining after this PR

| Bucket | Count |
| --- | --- |
| Trivial | 0 |
| Medium | 0 (all 22 done in this batch + 1 Risky cross-pillar deferred) |
| Risky | 3 (cross-pillar `core.entities.list`, shared `client.ts`, CLI `api-client.ts`) |

### Tests

Each tool file's test mocks `../pillar-client.js` with `vi.mock`, asserting the success path plus the `unavailable` and `contract-mismatch` failure paths. New shared helpers in `test-helpers.ts`:

- `mockPillarInventory` / `mockPillarFinance` / `mockPillarMedia` / `mockPillarCerebrum`
- `pillarMockGetter(pillarId)` dispatcher
- `callOk` / `callUnavailable` / `callContractMismatch`

`mockClient` was trimmed to the only remaining legacy caller (`core.entities.list` via the deferred risky finance tool).

## Test plan

- [x] `pnpm --filter @pops/mcp typecheck` — clean
- [x] `pnpm --filter @pops/mcp test` — 175 passed (13 files)
- [x] `pnpm lint apps/pops-mcp` — no new errors (pre-existing `no-underscore-dangle` warning on `__resetPillarClientForTests`)
- [x] `pnpm format:check` — clean
- [x] Pre-commit hook (lint-staged) — passed