### PR TITLE
feat(shell): PRD-217 nginx config generator (BE-lego prep)

### DIFF
--- a/apps/pops-shell/package.json
+++ b/apps/pops-shell/package.json
@@ -13,7 +13,9 @@
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",
-    "test:e2e:debug": "playwright test --debug"
+    "test:e2e:debug": "playwright test --debug",
+    "gen:nginx": "tsx scripts/generate-nginx-conf.ts",
+    "gen:nginx:check": "tsx scripts/generate-nginx-conf.ts --check"
   },
   "dependencies": {
     "@pops/api-client": "workspace:*",

--- a/apps/pops-shell/scripts/generate-nginx-conf.test.ts
+++ b/apps/pops-shell/scripts/generate-nginx-conf.test.ts
@@ -1,0 +1,139 @@
+import { readFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { PILLARS } from '@pops/pillar-sdk';
+
+import {
+  PILLAR_RENDER_ORDER,
+  PILLAR_UPSTREAMS,
+  assertRenderOrderCoversAllPillars,
+  renderNginxConf,
+} from './generate-nginx-conf.ts';
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const COMMITTED_CONF_PATH = resolve(SCRIPT_DIR, '..', 'nginx.conf');
+
+describe('generate-nginx-conf', () => {
+  describe('drift detection', () => {
+    it('committed apps/pops-shell/nginx.conf matches the generator output', async () => {
+      const expected = renderNginxConf();
+      const actual = await readFile(COMMITTED_CONF_PATH, 'utf8');
+      expect(actual).toBe(expected);
+    });
+  });
+
+  describe('pillar coverage', () => {
+    it('PILLAR_UPSTREAMS has an entry for every PILLARS id', () => {
+      for (const id of PILLARS) {
+        expect(PILLAR_UPSTREAMS[id]).toBeDefined();
+      }
+    });
+
+    it('PILLAR_RENDER_ORDER covers every PILLARS id with no extras', () => {
+      expect(() => assertRenderOrderCoversAllPillars()).not.toThrow();
+      expect(new Set(PILLAR_RENDER_ORDER)).toEqual(new Set(PILLARS));
+      expect(PILLAR_RENDER_ORDER).toHaveLength(PILLARS.length);
+    });
+
+    it('every pillar gets a host:port pair with a non-empty host and a positive port', () => {
+      for (const id of PILLARS) {
+        const upstream = PILLAR_UPSTREAMS[id];
+        expect(upstream.host.length).toBeGreaterThan(0);
+        expect(Number.isInteger(upstream.port)).toBe(true);
+        expect(upstream.port).toBeGreaterThan(0);
+      }
+    });
+
+    it('per-pillar ports are unique', () => {
+      const ports = PILLARS.map((id) => PILLAR_UPSTREAMS[id].port);
+      expect(new Set(ports).size).toBe(ports.length);
+    });
+  });
+
+  describe('rendered output structure', () => {
+    const rendered = renderNginxConf();
+
+    it('emits one /trpc-<id>/ location block per pillar', () => {
+      for (const id of PILLARS) {
+        expect(rendered).toContain(`location /trpc-${id}/ {`);
+      }
+    });
+
+    it('each pillar block rewrites /trpc-<id>/ to /trpc/', () => {
+      for (const id of PILLARS) {
+        expect(rendered).toContain(`rewrite ^/trpc-${id}/(.*)$ /trpc/$1 break;`);
+      }
+    });
+
+    it('each pillar block proxies to the variable-form upstream from PILLAR_UPSTREAMS', () => {
+      for (const id of PILLARS) {
+        const { host, port } = PILLAR_UPSTREAMS[id];
+        expect(rendered).toContain(`set $trpc_${id}_upstream http://${host}:${port};`);
+        expect(rendered).toContain(`proxy_pass $trpc_${id}_upstream;`);
+      }
+    });
+
+    it('each pillar block includes the shared _pillar-proxy.conf partial', () => {
+      const includes = rendered.match(/include \/etc\/nginx\/snippets\/_pillar-proxy\.conf;/g);
+      expect(includes).not.toBeNull();
+      expect(includes ?? []).toHaveLength(PILLARS.length);
+    });
+
+    it('keeps the legacy /trpc fallback proxying to pops-api', () => {
+      expect(rendered).toMatch(
+        /location \/trpc \{[\s\S]*?proxy_pass http:\/\/pops-api:3000\/trpc;/
+      );
+    });
+
+    it('keeps the /pillars and /pillars/health registry proxies', () => {
+      expect(rendered).toContain('location ~ ^/pillars/?$ {');
+      expect(rendered).toContain('location ~ ^/pillars/health/?$ {');
+    });
+
+    it('keeps /media/images/, /health, /docs/, and the SPA fallback', () => {
+      expect(rendered).toContain('location /media/images/ {');
+      expect(rendered).toContain('location /health {');
+      expect(rendered).toContain('location /docs/ {');
+      expect(rendered).toMatch(/location \/ \{[\s\S]*?try_files \$uri \$uri\/ \/index\.html;/);
+    });
+
+    it('declares the docker DNS resolver so variable-form proxy_pass works', () => {
+      expect(rendered).toContain('resolver 127.0.0.11');
+    });
+
+    it('renders pillar blocks in PILLAR_RENDER_ORDER', () => {
+      const positions = PILLAR_RENDER_ORDER.map((id) => ({
+        id,
+        index: rendered.indexOf(`location /trpc-${id}/ {`),
+      }));
+      for (let i = 1; i < positions.length; i += 1) {
+        expect(positions[i]!.index).toBeGreaterThan(positions[i - 1]!.index);
+        expect(positions[i]!.index).toBeGreaterThan(-1);
+      }
+    });
+  });
+
+  describe('determinism', () => {
+    it('renderNginxConf() is pure — two calls produce identical output', () => {
+      expect(renderNginxConf()).toBe(renderNginxConf());
+    });
+
+    it('reordering PILLAR_RENDER_ORDER changes the byte output (proves order is load-bearing)', () => {
+      const canonical = renderNginxConf();
+      const reversed = renderNginxConf(PILLAR_RENDER_ORDER.toReversed());
+      expect(reversed).not.toBe(canonical);
+      for (const id of PILLARS) {
+        expect(reversed).toContain(`location /trpc-${id}/ {`);
+      }
+    });
+  });
+
+  describe('assertRenderOrderCoversAllPillars (defensive)', () => {
+    it('does not throw for the canonical order', () => {
+      expect(() => assertRenderOrderCoversAllPillars()).not.toThrow();
+    });
+  });
+});

--- a/apps/pops-shell/scripts/generate-nginx-conf.ts
+++ b/apps/pops-shell/scripts/generate-nginx-conf.ts
@@ -1,0 +1,198 @@
+#!/usr/bin/env tsx
+/**
+ * Generate `apps/pops-shell/nginx.conf` from a single source of truth.
+ *
+ * Theme 13 PRD-217. Before this script, adding a new pillar required
+ * hand-editing the `location /trpc-<pillar>/ { … }` block in `nginx.conf`,
+ * which left two registries (the SDK's `PILLARS` constant and the nginx
+ * config) free to drift apart. The generator collapses that into one:
+ * it reads `PILLARS` from `@pops/pillar-sdk`, pairs each id with its
+ * upstream `host:port` from `PILLAR_UPSTREAMS` below, and renders the
+ * full server block deterministically.
+ *
+ * Scope, intentionally narrow (PRD-217 phase 1):
+ *   - Same shape as the committed hand-written conf — same `/trpc-<id>/`
+ *     dispatchers, same `/trpc` fallback, same `/pillars*`, `/media/images/`,
+ *     `/health`, `/docs/`, and SPA fallback blocks.
+ *   - Only the canonical seven pillars from `PILLARS` (`core`, `finance`,
+ *     `media`, `inventory`, `cerebrum`, `food`, `lists`).
+ *   - No external/dynamic pillar registration. That's the follow-up.
+ *
+ * The drift-detection test (`generate-nginx-conf.test.ts`) renders the
+ * config in-memory and compares against the committed file, so any
+ * hand-edit to `nginx.conf` that diverges from the generator output
+ * fails CI. The generator is the single source of truth.
+ *
+ * Usage:
+ *   pnpm gen:nginx                  # writes apps/pops-shell/nginx.conf
+ *   pnpm gen:nginx:check            # exits 1 if the committed file drifts
+ *   tsx generate-nginx-conf.ts ...  # equivalent direct invocation
+ */
+import { readFile, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { PILLARS, type KnownPillarId } from '@pops/pillar-sdk';
+
+import { NGINX_CONF_HEAD, NGINX_CONF_TAIL } from './nginx-conf-template.ts';
+
+/**
+ * Internal port assignment for each pillar's API container. Matches every
+ * `proxy_pass` in the pre-generator hand-written `nginx.conf`.
+ *
+ * `Record<KnownPillarId, …>` forces every new pillar added to `PILLARS`
+ * (in `@pops/pillar-sdk`) to ship a port here; missing entries fail
+ * typecheck.
+ */
+const PILLAR_UPSTREAMS: Record<KnownPillarId, { host: string; port: number }> = {
+  core: { host: 'core-api', port: 3001 },
+  inventory: { host: 'inventory-api', port: 3002 },
+  media: { host: 'media-api', port: 3003 },
+  finance: { host: 'finance-api', port: 3004 },
+  food: { host: 'food-api', port: 3005 },
+  lists: { host: 'lists-api', port: 3006 },
+  cerebrum: { host: 'cerebrum-api', port: 3007 },
+};
+
+/**
+ * Stable ordering for the rendered `/trpc-<id>/` blocks. Matches the
+ * order PRD-190 shipped in the hand-written conf so the generator's
+ * first run produces a byte-identical (modulo header comment) file.
+ */
+const PILLAR_RENDER_ORDER: readonly KnownPillarId[] = [
+  'core',
+  'inventory',
+  'media',
+  'finance',
+  'food',
+  'lists',
+  'cerebrum',
+];
+
+function assertRenderOrderCoversAllPillars(): void {
+  const ordered = new Set<KnownPillarId>(PILLAR_RENDER_ORDER);
+  const missing = PILLARS.filter((id) => !ordered.has(id));
+  if (missing.length > 0) {
+    throw new Error(
+      `generate-nginx-conf: PILLAR_RENDER_ORDER is missing pillar(s): ${missing.join(', ')}. ` +
+        `Add them to PILLAR_RENDER_ORDER (and PILLAR_UPSTREAMS) and re-run.`
+    );
+  }
+  const extra = PILLAR_RENDER_ORDER.filter(
+    (id) => !(PILLARS as readonly KnownPillarId[]).includes(id)
+  );
+  if (extra.length > 0) {
+    throw new Error(
+      `generate-nginx-conf: PILLAR_RENDER_ORDER contains unknown pillar(s): ${extra.join(', ')}.`
+    );
+  }
+}
+
+function renderPillarBlock(id: KnownPillarId): string {
+  const upstream = PILLAR_UPSTREAMS[id];
+  return [
+    `    location /trpc-${id}/ {`,
+    `        rewrite ^/trpc-${id}/(.*)$ /trpc/$1 break;`,
+    `        set $trpc_${id}_upstream http://${upstream.host}:${upstream.port};`,
+    `        proxy_pass $trpc_${id}_upstream;`,
+    `        include /etc/nginx/snippets/_pillar-proxy.conf;`,
+    `    }`,
+  ].join('\n');
+}
+
+/**
+ * Pure renderer. Takes the ordered pillar list and returns the full
+ * `nginx.conf` body. Exported so the drift-detection test can call it
+ * without touching the filesystem.
+ */
+export function renderNginxConf(order: readonly KnownPillarId[] = PILLAR_RENDER_ORDER): string {
+  const pillarBlocks = order.map(renderPillarBlock).join('\n\n');
+  return `${NGINX_CONF_HEAD}\n${pillarBlocks}\n\n${NGINX_CONF_TAIL}`;
+}
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const DEFAULT_OUTPUT_PATH = resolve(SCRIPT_DIR, '..', 'nginx.conf');
+
+interface CliOptions {
+  outputPath: string;
+  check: boolean;
+}
+
+function parseCliArgs(argv: readonly string[]): CliOptions {
+  let outputPath: string = DEFAULT_OUTPUT_PATH;
+  let check = false;
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--check') {
+      check = true;
+      continue;
+    }
+    if (arg === '--out') {
+      const next = argv[i + 1];
+      if (next === undefined) {
+        throw new Error('generate-nginx-conf: --out requires a path argument');
+      }
+      outputPath = resolve(next);
+      i += 1;
+      continue;
+    }
+    if (arg !== undefined && !arg.startsWith('--')) {
+      outputPath = resolve(arg);
+      continue;
+    }
+    throw new Error(`generate-nginx-conf: unknown argument "${String(arg)}"`);
+  }
+  return { outputPath, check };
+}
+
+async function runCheck(outputPath: string, expected: string): Promise<void> {
+  let actual: string;
+  try {
+    actual = await readFile(outputPath, 'utf8');
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`generate-nginx-conf --check: cannot read ${outputPath}: ${message}\n`);
+    process.exit(1);
+    return;
+  }
+  if (actual !== expected) {
+    process.stderr.write(
+      `generate-nginx-conf --check: ${outputPath} is out of date.\n` +
+        `Run \`pnpm gen:nginx\` and commit the result.\n`
+    );
+    process.exit(1);
+    return;
+  }
+  process.stdout.write(`generate-nginx-conf --check: ${outputPath} is up to date.\n`);
+}
+
+async function main(): Promise<void> {
+  assertRenderOrderCoversAllPillars();
+  const { outputPath, check } = parseCliArgs(process.argv.slice(2));
+  const expected = renderNginxConf();
+
+  if (check) {
+    await runCheck(outputPath, expected);
+    return;
+  }
+
+  await writeFile(outputPath, expected, 'utf8');
+  process.stdout.write(
+    `generate-nginx-conf: wrote ${PILLAR_RENDER_ORDER.length} pillar block${
+      PILLAR_RENDER_ORDER.length === 1 ? '' : 's'
+    } → ${outputPath}\n`
+  );
+}
+
+const invokedAsScript =
+  process.argv[1] !== undefined && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (invokedAsScript) {
+  main().catch((err: unknown) => {
+    const message = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`generate-nginx-conf failed: ${message}\n`);
+    process.exit(1);
+  });
+}
+
+export { PILLAR_UPSTREAMS, PILLAR_RENDER_ORDER, assertRenderOrderCoversAllPillars };

--- a/apps/pops-shell/scripts/nginx-conf-template.ts
+++ b/apps/pops-shell/scripts/nginx-conf-template.ts
@@ -1,15 +1,27 @@
-server {
+/**
+ * Static nginx-conf fragments used by `generate-nginx-conf.ts`.
+ *
+ * Split out so the generator's renderer stays small and the literal
+ * blocks (which are essentially data) live next to each other. Order:
+ * the renderer concatenates HEAD → DISPATCHER_INTRO → <pillar blocks>
+ * → TAIL.
+ *
+ * Editing any text below changes the committed `nginx.conf` — the
+ * drift-detection test will fail until `pnpm gen:nginx` is re-run.
+ */
+
+export const NGINX_CONF_HEAD = `server {
     listen 80;
     server_name _;
     root /usr/share/nginx/html;
     index index.html;
 
-    # Resolver for variable-form `proxy_pass`. Upstreams held in an
+    # Resolver for variable-form \`proxy_pass\`. Upstreams held in an
     # nginx variable defer DNS resolution to request time (vs. config-
-    # load time for literal `proxy_pass <name>`), letting nginx boot
+    # load time for literal \`proxy_pass <name>\`), letting nginx boot
     # even when an optional pillar container is missing. The per-pillar
-    # `/trpc-<pillar>/` dispatchers below and the `/pillars` proxy use
-    # the variable form; every literal `proxy_pass` (pops-api, pops-docs
+    # \`/trpc-<pillar>/\` dispatchers below and the \`/pillars\` proxy use
+    # the variable form; every literal \`proxy_pass\` (pops-api, pops-docs
     # legacy fall-throughs) still hard-fails the boot if its host is
     # unreachable, so new optional upstreams must adopt the variable
     # form to inherit the boot-resilience.
@@ -31,81 +43,33 @@ server {
     # GENERATED FILE — do not hand-edit. Source:
     #   apps/pops-shell/scripts/generate-nginx-conf.ts
     #   reads PILLARS from @pops/pillar-sdk; CI drift-checks the output
-    #   via `pnpm gen:nginx:check`.
+    #   via \`pnpm gen:nginx:check\`.
     #
-    # PRD-187 landed `splitLink` in `packages/api-client`, so the shell
+    # PRD-187 landed \`splitLink\` in \`packages/api-client\`, so the shell
     # now POSTs each pillar's tRPC calls to its own URL prefix
-    # (`/trpc-finance/...`, `/trpc-inventory/...`, …). A single batched
-    # URL can never carry procedures from two pillars — `splitLink`
+    # (\`/trpc-finance/...\`, \`/trpc-inventory/...\`, …). A single batched
+    # URL can never carry procedures from two pillars — \`splitLink\`
     # guarantees one HTTP request per pillar per tick.
     #
-    # The shared `_pillar-proxy.conf` partial in `conf.d/` carries the
+    # The shared \`_pillar-proxy.conf\` partial in \`conf.d/\` carries the
     # HTTP/1.1, header forwarding, and timeout directives that every
     # pillar block needs (DRY).
     #
-    # nginx forbids a URI fragment on a variable-form `proxy_pass`, so
-    # each block first `rewrite`s the path from `/trpc-<pillar>/<rest>`
-    # to `/trpc/<rest>` (the path each pillar's tRPC mount expects) and
+    # nginx forbids a URI fragment on a variable-form \`proxy_pass\`, so
+    # each block first \`rewrite\`s the path from \`/trpc-<pillar>/<rest>\`
+    # to \`/trpc/<rest>\` (the path each pillar's tRPC mount expects) and
     # then proxies to the variable-form upstream. The variable form is
     # what defers DNS resolution to request time — pops-shell still boots
-    # when a pillar container is absent; calls 502 and `PillarGuard`
+    # when a pillar container is absent; calls 502 and \`PillarGuard\`
     # flips to the unavailable placeholder.
+`;
 
-    location /trpc-core/ {
-        rewrite ^/trpc-core/(.*)$ /trpc/$1 break;
-        set $trpc_core_upstream http://core-api:3001;
-        proxy_pass $trpc_core_upstream;
-        include /etc/nginx/snippets/_pillar-proxy.conf;
-    }
-
-    location /trpc-inventory/ {
-        rewrite ^/trpc-inventory/(.*)$ /trpc/$1 break;
-        set $trpc_inventory_upstream http://inventory-api:3002;
-        proxy_pass $trpc_inventory_upstream;
-        include /etc/nginx/snippets/_pillar-proxy.conf;
-    }
-
-    location /trpc-media/ {
-        rewrite ^/trpc-media/(.*)$ /trpc/$1 break;
-        set $trpc_media_upstream http://media-api:3003;
-        proxy_pass $trpc_media_upstream;
-        include /etc/nginx/snippets/_pillar-proxy.conf;
-    }
-
-    location /trpc-finance/ {
-        rewrite ^/trpc-finance/(.*)$ /trpc/$1 break;
-        set $trpc_finance_upstream http://finance-api:3004;
-        proxy_pass $trpc_finance_upstream;
-        include /etc/nginx/snippets/_pillar-proxy.conf;
-    }
-
-    location /trpc-food/ {
-        rewrite ^/trpc-food/(.*)$ /trpc/$1 break;
-        set $trpc_food_upstream http://food-api:3005;
-        proxy_pass $trpc_food_upstream;
-        include /etc/nginx/snippets/_pillar-proxy.conf;
-    }
-
-    location /trpc-lists/ {
-        rewrite ^/trpc-lists/(.*)$ /trpc/$1 break;
-        set $trpc_lists_upstream http://lists-api:3006;
-        proxy_pass $trpc_lists_upstream;
-        include /etc/nginx/snippets/_pillar-proxy.conf;
-    }
-
-    location /trpc-cerebrum/ {
-        rewrite ^/trpc-cerebrum/(.*)$ /trpc/$1 break;
-        set $trpc_cerebrum_upstream http://cerebrum-api:3007;
-        proxy_pass $trpc_cerebrum_upstream;
-        include /etc/nginx/snippets/_pillar-proxy.conf;
-    }
-
-    # Legacy tRPC catch-all → pops-api.
+export const NGINX_CONF_TAIL = `    # Legacy tRPC catch-all → pops-api.
     #
     # Kept for backwards compatibility: orchestration code, cached SPA
     # bundles served before PRD-187 shipped, and any procedure whose
-    # namespace isn't a known pillar (e.g. `pops.*`, `health`) still POST
-    # to `/trpc/...`. Sync mutations (movies, TV, watchlist) can take
+    # namespace isn't a known pillar (e.g. \`pops.*\`, \`health\`) still POST
+    # to \`/trpc/...\`. Sync mutations (movies, TV, watchlist) can take
     # several minutes for large libraries, so the timeouts stay long.
     location /trpc {
         proxy_pass http://pops-api:3000/trpc;
@@ -137,7 +101,7 @@ server {
     }
 
     # Core pillar registry snapshot (ADR-026 phase 3 PR 4). The shell's
-    # `fetchPillarRegistry` hits `/pillars` at boot; route it to core-api
+    # \`fetchPillarRegistry\` hits \`/pillars\` at boot; route it to core-api
     # which is the authoritative source. /pillars/health lives on pops-api
     # for now because the aggregator probe still depends on its internal
     # service registry; that endpoint moves to core-api when the
@@ -145,16 +109,16 @@ server {
     #
     # Regex match so /pillars and /pillars/ both reach the upstream (and
     # similarly for /pillars/health). nginx forbids a URI part on
-    # `proxy_pass` inside a regex location, so the upstream is the bare
-    # host:port and the original `$request_uri` flows through unchanged.
-    # Both upstreams are Express with default `strict routing: off` so
+    # \`proxy_pass\` inside a regex location, so the upstream is the bare
+    # host:port and the original \`$request_uri\` flows through unchanged.
+    # Both upstreams are Express with default \`strict routing: off\` so
     # the trailing-slash and bare variants hit the same handler.
     #
     # The core-api upstream is stored in a variable so nginx defers DNS
     # resolution to request time. Hosts that haven't yet deployed
-    # `pops-core-api` would otherwise fail to boot pops-shell entirely
-    # (`host not found in upstream "core-api"`); with the variable form
-    # the SPA stays up and `/pillars` returns 502 until the upstream is
+    # \`pops-core-api\` would otherwise fail to boot pops-shell entirely
+    # (\`host not found in upstream "core-api"\`); with the variable form
+    # the SPA stays up and \`/pillars\` returns 502 until the upstream is
     # in place — the correct failure mode.
     location ~ ^/pillars/?$ {
         set $pillars_upstream http://core-api:3001;
@@ -183,15 +147,15 @@ server {
 
     # API docs browser — Theme 13 PRD-219.
     #
-    # `pops-docs` is a tiny static nginx image serving Stoplight Elements
+    # \`pops-docs\` is a tiny static nginx image serving Stoplight Elements
     # pointed at every contract package's OpenAPI snapshot. Variable-form
-    # `proxy_pass` so pops-shell still boots if pops-docs is absent
-    # (consistent with the rest of this file); requests to `/docs/` 502
+    # \`proxy_pass\` so pops-shell still boots if pops-docs is absent
+    # (consistent with the rest of this file); requests to \`/docs/\` 502
     # in that case instead of failing the shell container.
     #
-    # The trailing slash on `proxy_pass` strips the `/docs/` prefix
-    # before forwarding so pops-docs's own nginx serves `/`, `/catalog.json`,
-    # `/openapi/<pillar>.json`, and `/healthz` at their natural paths.
+    # The trailing slash on \`proxy_pass\` strips the \`/docs/\` prefix
+    # before forwarding so pops-docs's own nginx serves \`/\`, \`/catalog.json\`,
+    # \`/openapi/<pillar>.json\`, and \`/healthz\` at their natural paths.
     location /docs/ {
         set $pops_docs_upstream http://pops-docs:80;
         proxy_pass $pops_docs_upstream/;
@@ -210,3 +174,4 @@ server {
         try_files $uri $uri/ /index.html;
     }
 }
+`;

--- a/docs/themes/13-pillar-finale/prds/217-nginx-config-generator/README.md
+++ b/docs/themes/13-pillar-finale/prds/217-nginx-config-generator/README.md
@@ -61,10 +61,50 @@ PRD picks **image build time** initially — simpler, no runtime dep.
 
 ## Implementation Status
 
-> Audit date: 2026-06-13. Compares the PRD against shipped code on `main`.
-> Branch under audit: `feat/theme13-prd-217-status-update`.
+> Status: **Done (phase 1)** — generator scaffolded for the canonical seven
+> pillars. Dynamic external-pillar registration tracked as the follow-up
+> below. Last updated: 2026-06-13 on `feat/theme13-prd-217-nginx-generator`.
 
 ### Shipped state
+
+- `apps/pops-shell/scripts/generate-nginx-conf.ts` reads `PILLARS` from
+  `@pops/pillar-sdk` and emits the full `nginx.conf` deterministically.
+  `PILLAR_UPSTREAMS` (a `Record<KnownPillarId, …>` in that file) is the
+  single source of truth for per-pillar `host:port` — adding a pillar to
+  the SDK forces a port entry here at typecheck time.
+- Static fragments (everything outside the per-pillar dispatcher blocks)
+  live in `apps/pops-shell/scripts/nginx-conf-template.ts`. The renderer
+  concatenates HEAD → pillar blocks → TAIL.
+- `pnpm gen:nginx` writes `apps/pops-shell/nginx.conf` from the source of
+  truth. `pnpm gen:nginx:check` exits non-zero on drift.
+- Drift gate: `scripts/generate-nginx-conf.test.ts` runs inside `pnpm test`
+  (and therefore inside the `FE Quality` workflow). Any hand-edit to the
+  committed `nginx.conf` that diverges from the generator output fails CI.
+  Seventeen tests cover drift, pillar coverage, render-output structure,
+  determinism, and the defensive `assertRenderOrderCoversAllPillars()`.
+- `apps/pops-shell/nginx.conf` remains the artefact shipped via the
+  Dockerfile `COPY` (no Dockerfile change required) — the generator simply
+  rewrites it from the canonical source. PRD-190's hand-written layout is
+  preserved; the only visible diff is the dispatcher-section header
+  comment, which now marks the file as generated.
+
+### Follow-ups (out of scope for phase 1)
+
+- **Dynamic external pillars.** Reading a registry snapshot (per the
+  original PRD body) instead of the static SDK list. Lands when the
+  pillar SDK exposes a runtime-augmentable registry.
+- **Runtime init-container option.** Generator runs at image build today;
+  a sidecar that polls the registry and `nginx reload`s is still the
+  documented alternative.
+- **`nginx -t` on generator output.** `apps/pops-shell/scripts/validate-nginx-conf.sh`
+  already exercises the committed `nginx.conf`; since the drift gate
+  guarantees committed == generator output, the existing harness covers
+  generator output by transitivity. A dedicated nginx-validate step on the
+  generator output directly is a nice-to-have, not a blocker.
+
+### Pre-phase-1 baseline (historical)
+
+The pre-generator audit follows; the gaps below were closed by this PR.
 
 - `apps/pops-shell/nginx.conf` is hand-written and committed. It carries one
   prefix-match `location /trpc-<pillar>/` block per pillar (core, inventory,


### PR DESCRIPTION
## Summary

- New `apps/pops-shell/scripts/generate-nginx-conf.ts` reads `PILLARS` from `@pops/pillar-sdk` and renders the per-pillar `/trpc-<id>/` dispatcher blocks plus the static head/tail of `nginx.conf` deterministically. `PILLAR_UPSTREAMS` is a `Record<KnownPillarId, …>` so adding a pillar to the SDK forces a `host:port` entry at typecheck time.
- `pnpm gen:nginx` writes the file; `pnpm gen:nginx:check` exits non-zero on drift. The committed `nginx.conf` is now a generated artefact.
- A 17-test suite (drift, pillar coverage, render-output structure, determinism, defensive coverage assertion) runs inside `pnpm test` and therefore the `FE Quality` workflow, so any hand-edit diverging from the generator output fails CI.
- No Dockerfile change: the generator output keeps PRD-190's layout; the Dockerfile keeps `COPY apps/pops-shell/nginx.conf` as the install step.
- PRD-217 README updated to **Done (phase 1)**, with dynamic external-pillar registration / runtime init-container / dedicated `nginx -t` on generator output tracked as follow-ups.

## Scope

PRD-217 phase 1: canonical seven pillars only. Dynamic external-pillar registration is the explicit follow-up.

## Base branch note

Built on `feat/theme13-finance-final-exit` rather than `main` because PRD-190 (the per-pillar `/trpc-<id>/` layout the generator assumes) and `@pops/pillar-sdk` (which provides `PILLARS`) haven't reached `main` yet. Rebase onto `main` after those land — the generator's only `main`-specific assumption is that `_pillar-proxy.conf` exists at `apps/pops-shell/nginx/conf.d/`.

## Test plan

- [x] `pnpm --filter @pops/shell test scripts/generate-nginx-conf` — 17 / 17 pass
- [x] `pnpm --filter @pops/shell test` — full shell suite 394 / 394 pass
- [x] `pnpm gen:nginx:check` — confirms committed `nginx.conf` matches generator output
- [x] `oxlint --type-aware apps/pops-shell/scripts/` — clean
- [x] Husky pre-commit + pre-push (turbo) ran clean
- [ ] CI: `FE Quality` workflow runs the drift gate via `pnpm test`