### PR TITLE
docs(theme-13): scaffold PRD-229 HA bridge pillar (ADR-032 first bridge)

### DIFF
--- a/docs/themes/13-pillar-finale/README.md
+++ b/docs/themes/13-pillar-finale/README.md
@@ -38,8 +38,9 @@ Theme 13 finishes the architecture. Every pillar registers itself on boot with a
 | 09  | [Drop pops.db](epics/09-drop-pops-db.md)                                        | Audit, drop, retire the shared DB and its boot-time backfill                                           | Not started |
 | 10  | [FE pillar SDK + dispatcher generator](epics/10-fe-sdk-dispatcher-generator.md) | React hooks against the registry; PillarGuard rewrite; nginx config generated from registry            | Not started |
 | 12  | [CI leanness](epics/12-ci-leanness.md)                                          | Path-filter audit, affected-rebuild orchestrator, docs fast-path, pillar isolation, budget enforcement | In progress |
+| 13  | [Bridge pillars (HA, MQTT, ESPHome)](epics/13-bridge-pillars.md)                | Bridge-pillar pattern per ADR-032 — `pops-ha-bridge-api` first, MQTT + ESPHome follow                  | Not started |
 
-**Dependencies:** E00 → E01 → E02 → E05 is the critical foundation path. E03 (slice migrations) can run in parallel against the foundation. E04 (batching) gates legacy router deletion. E08a is independent and can ship as a Theme 12 postscript before Theme 13 starts proper. E08b is gated on ADR-029. E09 + E10 are finishing moves.
+**Dependencies:** E00 → E01 → E02 → E05 is the critical foundation path. E03 (slice migrations) can run in parallel against the foundation. E04 (batching) gates legacy router deletion. E08a is independent and can ship as a Theme 12 postscript before Theme 13 starts proper. E08b is gated on ADR-029. E09 + E10 are finishing moves. E13 is a follow-on that depends on E00 / E01 / E02 / E06 / E07 — it implements the additive integration story ADR-032 declared, not part of Theme 13's main critical path.
 
 ## Key Decisions
 

--- a/docs/themes/13-pillar-finale/epics/13-bridge-pillars.md
+++ b/docs/themes/13-pillar-finale/epics/13-bridge-pillars.md
@@ -1,0 +1,35 @@
+# Epic 13: Bridge pillars (HA, MQTT, ESPHome)
+
+> Theme: [Pillar finale](../README.md)
+
+## Scope
+
+Implement the "bridge pillar" pattern declared by [ADR-032](../../../architecture/adr-032-positioning-vs-self-hosted-os-family.md): thin POPS pillars whose job is to subscribe to an upstream system (Home Assistant WebSocket, MQTT broker, ESPHome devices) and expose that data through POPS's standard `searchAdapter` + `aiTools` manifest dimensions. Bridge pillars are also the route for outbound flows — POPS publishing events back to the upstream becomes a new `sinks` manifest dimension.
+
+This epic is a follow-on to Theme 13's main goals (which finish the federated runtime). It implements the additive integration story ADR-032 declared: POPS does not compete with HA on device count; instead, every HA entity becomes searchable + AI-callable inside POPS through a single bridge pillar.
+
+The first bridge — Home Assistant — proves the pattern. MQTT and ESPHome follow the same shape and reuse the manifest-dimension work.
+
+## PRDs
+
+| #   | PRD                                                        | Summary                                                                                                                            | Status      |
+| --- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| 229 | [HA bridge pillar](../prds/229-ha-bridge-pillar/README.md) | `pops-ha-bridge-api` — subscribe to HA WebSocket, mirror entities, expose via `searchAdapter` + `aiTools` + new `sinks` dimension  | Not started |
+| TBD | MQTT bridge pillar                                         | `pops-mqtt-bridge-api` — subscribe to MQTT broker, mirror topics as entities                                                       | Not started |
+| TBD | ESPHome bridge pillar                                      | `pops-esphome-bridge-api` — subscribe to ESPHome native API, mirror devices                                                        | Not started |
+| TBD | Manifest `sinks` dimension                                 | Generalised manifest schema + dispatcher routing for outbound event flows (split out of PRD-229 once a second sink consumer ships) | Not started |
+
+PRD-229 (HA) is the reference implementation. MQTT and ESPHome PRDs are deferred until PRD-229 lands — they fork from the HA shape rather than designed from scratch.
+
+## Dependencies
+
+- **Requires:** Epic 00 (contract packages — bridge pillars publish a `@pops/contract-ha-bridge`), Epic 01 (pillar SDK boot helper), Epic 02 (central registry — bridge pillar registers like every other pillar), Epic 06 (search registry — bridge pillar's `searchAdapter` is discovered via the registry), Epic 07 (AI registry — bridge pillar's `aiTools` are discovered via the registry).
+- **Unlocks:** the "typed federation for self-hosted apps" writeup framing; cerebrum chat can answer "is the kitchen light on?" and "turn off the office heater"; POPS becomes additive to existing HA installs rather than a competitor.
+
+## Out of Scope
+
+- Replacing HA's automation engine — automations stay in HA, POPS only observes + controls
+- Per-device drivers (Zigbee, Z-Wave, Matter) — HA owns the integration layer; the bridge consumes HA's entity model, not the raw device protocols
+- Bidirectional state ownership conflicts — HA is authoritative for HA-managed entities; POPS does not try to "own" an entity's state
+- The `sinks` manifest dimension's full generalisation — PRD-229 ships the HA-specific shape; a follow-up PRD splits the generic mechanism out once a second bridge needs it
+- Voice / wake-word / TTS — that is HA's job (and Rhasspy / Whisper); POPS consumes the resulting transcript via the existing cerebrum chat surface

--- a/docs/themes/13-pillar-finale/prds/229-ha-bridge-pillar/README.md
+++ b/docs/themes/13-pillar-finale/prds/229-ha-bridge-pillar/README.md
@@ -1,0 +1,115 @@
+# PRD-229: Home Assistant bridge pillar
+
+> Epic: [Bridge pillars (HA, MQTT, ESPHome)](../../epics/13-bridge-pillars.md)
+
+## Status
+
+Not started
+
+## Overview
+
+Stand up `pops-ha-bridge-api` — the first "bridge pillar" per [ADR-032](../../../../architecture/adr-032-positioning-vs-self-hosted-os-family.md). The pillar subscribes to a Home Assistant instance's WebSocket API, mirrors every entity + its state into a local per-pillar SQLite, and exposes the data through POPS's standard `searchAdapter` + `aiTools` manifest dimensions. Outbound flows (POPS turning off a light, sending a notification through HA) ship through a new `sinks` manifest dimension introduced by this PRD.
+
+The pillar has the same shape as `pops-finance-api` / `pops-media-api`: a self-contained container, a per-pillar SQLite, a contract package (`@pops/contract-ha-bridge`), and a manifest registered with the central registry on boot. The only thing that makes it a "bridge" is that its source of truth is upstream (HA), not user-entered data.
+
+## Data Model
+
+Per-pillar SQLite at `apps/pops-ha-bridge-api/data/ha-bridge.db`. Two tables.
+
+### `ha_entities`
+
+Current snapshot of every HA entity the bridge knows about. One row per entity. Upserted on every state change.
+
+| Column          | Type               | Notes                                                                      |
+| --------------- | ------------------ | -------------------------------------------------------------------------- |
+| `entity_id`     | `TEXT PRIMARY KEY` | HA's entity id (`light.kitchen_ceiling`)                                   |
+| `domain`        | `TEXT NOT NULL`    | Derived from `entity_id` prefix (`light`, `sensor`, `switch`, ...)         |
+| `friendly_name` | `TEXT`             | From HA's `attributes.friendly_name`                                       |
+| `area`          | `TEXT`             | Resolved area name via HA area registry (`kitchen`, `office`)              |
+| `device_class`  | `TEXT`             | From `attributes.device_class` (`temperature`, `motion`, ...)              |
+| `unit`          | `TEXT`             | From `attributes.unit_of_measurement`                                      |
+| `state`         | `TEXT NOT NULL`    | Last known state string (`on`, `off`, `23.4`)                              |
+| `attributes`    | `TEXT NOT NULL`    | Full JSON blob of `attributes` from the last state-changed event           |
+| `last_changed`  | `INTEGER NOT NULL` | Unix epoch ms — when HA reported the state-changed event                   |
+| `last_seen`     | `INTEGER NOT NULL` | Unix epoch ms — when the bridge last received any signal about this entity |
+
+Indexes: `(domain)`, `(area)`, `(device_class)`. FTS5 virtual table `ha_entities_fts(entity_id, friendly_name, area, device_class)` for the `searchAdapter`.
+
+### `ha_state_history`
+
+Append-only log of every state-changed event the bridge observes after debouncing. Used for trend queries and time-series-shaped questions ("what was the kitchen temperature an hour ago?").
+
+| Column        | Type                                | Notes                                                                      |
+| ------------- | ----------------------------------- | -------------------------------------------------------------------------- |
+| `id`          | `INTEGER PRIMARY KEY AUTOINCREMENT` |                                                                            |
+| `entity_id`   | `TEXT NOT NULL`                     | FK → `ha_entities.entity_id` (logical; not enforced for retention reasons) |
+| `state`       | `TEXT NOT NULL`                     |                                                                            |
+| `attributes`  | `TEXT NOT NULL`                     | JSON                                                                       |
+| `observed_at` | `INTEGER NOT NULL`                  | Unix epoch ms                                                              |
+
+Indexes: `(entity_id, observed_at DESC)`. Retention enforced by a periodic worker — see Business Rules.
+
+## API Surface
+
+### Read endpoints (tRPC on `pops-ha-bridge-api`)
+
+| Procedure           | Input                                                      | Output                                                                      |
+| ------------------- | ---------------------------------------------------------- | --------------------------------------------------------------------------- |
+| `entities.list`     | `{ domain?: string; area?: string; deviceClass?: string }` | `{ entities: HaEntity[] }`                                                  |
+| `entities.get`      | `{ entityId: string }`                                     | `{ entity: HaEntity } \| { kind: 'not-found' }`                             |
+| `entities.history`  | `{ entityId: string; sinceMs: number; untilMs?: number }`  | `{ samples: { state: string; observedAt: number }[] }`                      |
+| `connection.status` | `{}`                                                       | `{ kind: 'connected' \| 'reconnecting' \| 'offline'; lastEventAt: number }` |
+
+### New manifest dimensions
+
+The bridge pillar's manifest (consumed by the central registry) declares three dimensions; the first two reuse existing infrastructure, the third is new.
+
+| Dimension       | Shape                                                                                                     | Notes                                                                                                                                                         |
+| --------------- | --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `searchAdapter` | `{ id: 'ha-entities', label: 'Home Assistant entities' }`                                                 | Discovered by Epic 06's search registry; queries hit FTS5 over `ha_entities`. Matches on friendly name + area + device class.                                 |
+| `aiTools`       | `[ 'ha.entity.list', 'ha.entity.getState', 'ha.entity.callService' ]`                                     | Discovered by Epic 07's AI registry. First two are read; `callService` is the outbound control surface.                                                       |
+| `sinks` _(new)_ | `[ { id: 'ha.notify', accepts: { kind: 'notification', schema: <zod> } }, { id: 'ha.event.fire', ... } ]` | Declares which event shapes the pillar accepts from other pillars and forwards to HA. Manifest-only in this PRD; full generalisation deferred to its own PRD. |
+
+### Outbound control
+
+`ha.entity.callService` AI-tool input: `{ domain: string; service: string; entityId?: string; data?: Record<string, unknown> }`. Bridge translates to HA WebSocket `call_service` message. Output: `{ kind: 'ok' } | { kind: 'rejected'; reason: 'pillar-unavailable' | 'ha-offline' | 'service-not-found' }`.
+
+## Business Rules
+
+- **HA reconnect on disconnect.** The WebSocket client uses exponential backoff (1s, 2s, 4s, ... capped at 60s). On reconnect, the bridge re-subscribes to `state_changed` and runs a full snapshot fetch (`get_states`) to reconcile any missed state during the outage. `connection.status` reflects the live state for observability.
+- **State-change debouncing.** State-changed events are debounced per `entity_id` at 200ms — if HA fires three updates for the same entity inside 200ms (common for sensors), only the last is written to `ha_state_history`. The `ha_entities` upsert always reflects the latest. Debouncing is per-entity, not global.
+- **Secret management.** `HA_URL` and `HA_TOKEN` are read from env at boot. `HA_TOKEN` is a long-lived HA access token; it is never logged, never returned by any tRPC procedure, and never written to the manifest. If `HA_TOKEN` is missing or rejected on connect, the pillar boots in degraded mode — manifest still registers, `connection.status` returns `offline`, all read endpoints return empty, `callService` returns `{ kind: 'rejected', reason: 'ha-offline' }`.
+- **Retention.** `ha_state_history` is pruned by a periodic worker (default: rows older than 30 days deleted; configurable via `HA_HISTORY_RETENTION_DAYS`). The current-state row in `ha_entities` is never pruned.
+- **Registration.** On boot, the pillar registers with `core.registry` like every other pillar (Epic 02). Manifest includes the three dimensions above plus standard `id: 'ha-bridge'`, `baseUrl`, `health`, contract version.
+- **Search ranking.** The `searchAdapter` boosts matches where the query token matches `area` or `device_class` exactly. "kitchen temperature" → exact-match `area=kitchen` + `device_class=temperature` ranks above any friendly-name match.
+
+## Edge Cases
+
+| Case                                        | Behaviour                                                                                                                                                                                                                                                                                                             |
+| ------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| HA offline at boot                          | Pillar boots in degraded mode (see Secret management). Health endpoint reports `degraded`; central registry surfaces this to consumers. Reconnect loop runs until HA is reachable.                                                                                                                                    |
+| HA offline mid-session                      | `connection.status` flips to `reconnecting`; read endpoints continue to serve cached `ha_entities` snapshot; `callService` returns `{ kind: 'rejected', reason: 'ha-offline' }`.                                                                                                                                      |
+| Entity renamed in HA                        | HA sends `entity_registry_updated`; bridge updates `friendly_name` / `area` on the existing row. The `entity_id` itself does not change unless explicitly renamed in HA — in that case the old row is left and a new row inserted; a daily reconciliation worker (see retention) drops orphans not seen for >30 days. |
+| Entity removed in HA                        | `entity_registry_removed` event → bridge sets `last_seen` to current time but leaves the row until the daily reconciliation prunes it. History rows are retained until the global retention window applies.                                                                                                           |
+| Large state history (high-frequency sensor) | Debouncing at 200ms caps insert rate per entity. Retention worker prunes older than the configured window. Index on `(entity_id, observed_at DESC)` keeps history queries O(log n + k).                                                                                                                               |
+| `callService` to unknown service            | Bridge does not pre-validate against HA's service registry — HA's response (`service_not_found`) is mapped to `{ kind: 'rejected', reason: 'service-not-found' }`.                                                                                                                                                    |
+| `HA_TOKEN` rotated without restart          | Bridge detects auth-required frame on next reconnect, attempts the new token from env (if container has been re-deployed). If still rejected: stays in degraded mode and surfaces `connection.status: 'offline'`.                                                                                                     |
+| Search query before first snapshot          | If `ha_entities` is empty (cold boot, HA not yet contacted), `searchAdapter` returns `{ items: [] }`; AI tools return `{ kind: 'pillar-unavailable' }` so cerebrum can degrade gracefully.                                                                                                                            |
+
+## User Stories
+
+| #   | Story                                                       | Summary                                                                                                                                       | Parallelisable   |
+| --- | ----------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| 01  | [us-01-ws-subscriber-mirror](us-01-ws-subscriber-mirror.md) | WebSocket subscriber + entity mirror — connect to HA, subscribe to `state_changed`, write `ha_entities` + `ha_state_history`; reconnect loop. | Foundation       |
+| 02  | [us-02-search-adapter](us-02-search-adapter.md)             | `searchAdapter` over `ha_entities` with FTS5 + area/device-class ranking; registered via manifest.                                            | Blocked by us-01 |
+| 03  | [us-03-ai-tools-read](us-03-ai-tools-read.md)               | `ha.entity.list` + `ha.entity.getState` AI tools — read-only surface registered via manifest.                                                 | Blocked by us-01 |
+| 04  | [us-04-ai-tool-call-service](us-04-ai-tool-call-service.md) | `ha.entity.callService` AI tool — outbound control via HA WebSocket `call_service`; rejection-shape discriminants.                            | Blocked by us-01 |
+| 05  | [us-05-sinks-outbound](us-05-sinks-outbound.md)             | `sinks` manifest dimension — pillar accepts `ha.notify` + `ha.event.fire` events from other pillars and forwards to HA.                       | Blocked by us-04 |
+
+## Out of Scope
+
+- MQTT and ESPHome bridges — own PRDs once the HA shape is proven
+- Bidirectional ownership / write-back of POPS-managed data into HA entities (e.g. exposing `finance.budgets.list` as HA sensors) — that direction is for a later PRD once `sinks` is generalised
+- HA add-on packaging — the bridge runs as a normal POPS pillar container; no HA-supervisor integration
+- Replacing HA's UI — Lovelace stays; POPS surfaces HA entities through search + chat, not as a dashboard
+- Multi-HA-instance fan-out — single HA instance per bridge container; multi-instance support is a deployment concern, not a PRD

--- a/docs/themes/13-pillar-finale/prds/229-ha-bridge-pillar/us-01-ws-subscriber-mirror.md
+++ b/docs/themes/13-pillar-finale/prds/229-ha-bridge-pillar/us-01-ws-subscriber-mirror.md
@@ -1,0 +1,27 @@
+# US-01: WebSocket subscriber + entity mirror
+
+> PRD: [HA bridge pillar](README.md)
+
+## Description
+
+As `pops-ha-bridge-api`, I want to connect to a Home Assistant instance over WebSocket, subscribe to `state_changed`, and mirror every entity into a per-pillar SQLite so that downstream stories (search, AI tools, sinks) have a local, queryable copy of HA state without going back to HA for every request.
+
+## Acceptance Criteria
+
+- [ ] Pillar boots, reads `HA_URL` + `HA_TOKEN` from env, opens a WebSocket connection to HA and completes the auth handshake.
+- [ ] On connect, the pillar fetches a full snapshot via `get_states` and upserts every entity into `ha_entities` (schema per PRD § Data Model).
+- [ ] After snapshot, the pillar subscribes to `state_changed` and updates `ha_entities` + appends to `ha_state_history` for every event.
+- [ ] State-changed events are debounced per `entity_id` at 200ms before they hit `ha_state_history` (only the latest event in a 200ms window is recorded).
+- [ ] On disconnect, the pillar reconnects with exponential backoff (1s → 2s → 4s → ..., capped at 60s) and re-runs the snapshot reconciliation before re-subscribing.
+- [ ] `HA_TOKEN` never appears in logs, tRPC responses, or the registered manifest.
+- [ ] If `HA_URL` / `HA_TOKEN` are missing or rejected, the pillar still boots, registers with the central registry, and `connection.status` returns `{ kind: 'offline' }`.
+- [ ] Unit tests cover: snapshot upsert, state-change upsert + history append, debouncing window, reconnect backoff, degraded-mode boot.
+- [ ] A retention worker deletes `ha_state_history` rows older than `HA_HISTORY_RETENTION_DAYS` (default 30) on a daily schedule.
+
+## Notes
+
+- This story stands the pillar up but does not expose any read endpoints or AI tools. Those are US-02 / US-03.
+- Follow the shape of `apps/pops-finance-api` and `apps/pops-media-api` for container layout and SQLite handling.
+- Use `home-assistant-js-websocket` (or a thin in-house client if dependency footprint is a concern) — decision is implementation-level, not a PRD constraint.
+- Registration with `core.registry` uses the standard pillar SDK bootstrap helper from Epic 01 (PRD-158).
+- See [ADR-032](../../../../architecture/adr-032-positioning-vs-self-hosted-os-family.md) for the positioning context.

--- a/docs/themes/13-pillar-finale/prds/229-ha-bridge-pillar/us-02-search-adapter.md
+++ b/docs/themes/13-pillar-finale/prds/229-ha-bridge-pillar/us-02-search-adapter.md
@@ -1,0 +1,23 @@
+# US-02: `searchAdapter` over HA entities
+
+> PRD: [HA bridge pillar](README.md)
+
+## Description
+
+As a user querying federated POPS search for "kitchen temperature", I want the HA bridge pillar to return matching HA entities — ranked so that exact `area` + `device_class` matches beat partial friendly-name matches — so that the search surface treats HA entities as first-class POPS data.
+
+## Acceptance Criteria
+
+- [ ] An FTS5 virtual table `ha_entities_fts(entity_id, friendly_name, area, device_class)` exists, populated by triggers on `ha_entities` insert / update / delete.
+- [ ] The pillar's manifest declares `searchAdapter: { id: 'ha-entities', label: 'Home Assistant entities' }` and is discovered by the central registry (Epic 02) and the search registry (Epic 06).
+- [ ] The adapter implements the `SearchAdapter` interface from `@pops/pillar-sdk`: takes a query string, returns `{ items: { id: string; label: string; score: number; metadata: { domain, area, deviceClass, state } }[] }`.
+- [ ] Ranking: exact-match `area` token raises score; exact-match `device_class` token raises score; friendly-name FTS5 rank is the baseline.
+- [ ] Query "kitchen temperature" against a seeded fixture (`sensor.kitchen_temperature` with `area=kitchen`, `device_class=temperature`) returns that entity as the top result.
+- [ ] If `ha_entities` is empty (cold boot), the adapter returns `{ items: [] }` without error.
+- [ ] Unit tests cover: tokenisation, ranking, area/device-class boosts, empty-table case, FTS rebuild after entity rename.
+
+## Notes
+
+- Depends on US-01 — `ha_entities` must be populated.
+- The exact `SearchAdapter` interface is defined by Epic 06 / PRD-197. This story consumes it; no SDK changes here.
+- Ranking weights are starting values — tune from real queries later. PRD-229 is not the place to lock weights.

--- a/docs/themes/13-pillar-finale/prds/229-ha-bridge-pillar/us-03-ai-tools-read.md
+++ b/docs/themes/13-pillar-finale/prds/229-ha-bridge-pillar/us-03-ai-tools-read.md
@@ -1,0 +1,23 @@
+# US-03: AI tools for HA reads (`entity.list`, `entity.getState`)
+
+> PRD: [HA bridge pillar](README.md)
+
+## Description
+
+As cerebrum's chat surface, I want to call `ha.entity.list` and `ha.entity.getState` as registered AI tools so that the LLM can answer "what HA entities are in the kitchen?" and "is the kitchen light on?" without any custom integration code.
+
+## Acceptance Criteria
+
+- [ ] The pillar's manifest declares `aiTools: ['ha.entity.list', 'ha.entity.getState']` and is discovered by the AI registry (Epic 07).
+- [ ] `ha.entity.list` input schema (Zod): `{ domain?: string; area?: string; deviceClass?: string }`. Output: `{ entities: { entityId, friendlyName, area, deviceClass, state }[] }`. Caps response at 200 entities; if more match, returns `{ entities: [...], truncated: true }`.
+- [ ] `ha.entity.getState` input: `{ entityId: string }`. Output: `{ entityId, friendlyName, state, attributes, lastChanged }` or `{ kind: 'not-found' }`.
+- [ ] Both tools have JSON-schema-compatible descriptions for the LLM (`description`, `parameters`) — sourced from the contract package `@pops/contract-ha-bridge`.
+- [ ] Calling either tool when the bridge is in degraded mode (HA offline) returns `{ kind: 'pillar-unavailable' }` per the standard SDK discriminant — does not throw.
+- [ ] Unit tests cover: domain/area/deviceClass filtering, truncation at 200, not-found, degraded mode.
+- [ ] Integration test: register the manifest with a stub AI registry, invoke each tool via the registry-discovered handle, assert response shape.
+
+## Notes
+
+- Depends on US-01.
+- Outbound control (`ha.entity.callService`) is US-04 — strictly read-only here.
+- The AI registry's tool-discovery shape is defined by Epic 07 / PRD-202. This story consumes it.

--- a/docs/themes/13-pillar-finale/prds/229-ha-bridge-pillar/us-04-ai-tool-call-service.md
+++ b/docs/themes/13-pillar-finale/prds/229-ha-bridge-pillar/us-04-ai-tool-call-service.md
@@ -1,0 +1,24 @@
+# US-04: AI tool for HA control (`entity.callService`)
+
+> PRD: [HA bridge pillar](README.md)
+
+## Description
+
+As cerebrum's chat surface, I want to call `ha.entity.callService` as an AI tool so that the LLM can turn off a light, toggle a switch, or trigger an HA scene in response to "turn off the office heater" without bypassing the bridge pillar's discipline.
+
+## Acceptance Criteria
+
+- [ ] The pillar's manifest declares `aiTools` includes `ha.entity.callService` (additive to US-03's list).
+- [ ] Input schema (Zod): `{ domain: string; service: string; entityId?: string; data?: Record<string, unknown> }`. Output: `{ kind: 'ok' } | { kind: 'rejected'; reason: 'pillar-unavailable' | 'ha-offline' | 'service-not-found' | 'invalid-input' }`.
+- [ ] On invocation, the bridge sends an HA WebSocket `call_service` frame and awaits the result; success returns `{ kind: 'ok' }`.
+- [ ] HA's error responses are mapped: `service_not_found` → `service-not-found`; auth / connection errors → `ha-offline`.
+- [ ] When the bridge is in degraded mode, the tool returns `{ kind: 'rejected', reason: 'ha-offline' }` immediately without enqueueing.
+- [ ] The tool's JSON-schema description for the LLM lists common safe-control examples (`light.turn_off`, `switch.toggle`, `scene.turn_on`) — exposed via the contract package.
+- [ ] Unit tests cover: success, `service_not_found` mapping, degraded mode, invalid input, timeout (HA does not respond within 10s — treat as `ha-offline`).
+
+## Notes
+
+- Depends on US-01.
+- This is the first outbound surface from POPS → HA. The pattern it establishes is reused by US-05's `sinks`.
+- The tool is not gated by an allowlist in this PRD — that policy belongs to the AI orchestrator (Epic 07), not the bridge.
+- Audit logging of every `callService` invocation to `ha_state_history` (with a synthetic entity id) is a candidate follow-up but out of scope here.

--- a/docs/themes/13-pillar-finale/prds/229-ha-bridge-pillar/us-05-sinks-outbound.md
+++ b/docs/themes/13-pillar-finale/prds/229-ha-bridge-pillar/us-05-sinks-outbound.md
@@ -1,0 +1,26 @@
+# US-05: `sinks` manifest dimension for outbound events
+
+> PRD: [HA bridge pillar](README.md)
+
+## Description
+
+As another POPS pillar (e.g. `pops-cerebrum-api` emitting a notification, or `pops-finance-api` raising a "low balance" event), I want to publish that event to a named sink (`ha.notify`, `ha.event.fire`) and have the HA bridge forward it to HA so that POPS-originated signals reach the user through HA's existing notification surfaces (mobile app, persistent_notification, automations).
+
+## Acceptance Criteria
+
+- [ ] The pillar's manifest declares a new `sinks` dimension: `[ { id: 'ha.notify', accepts: { schema: <zod> } }, { id: 'ha.event.fire', accepts: { schema: <zod> } } ]`.
+- [ ] The central registry exposes the `sinks` dimension to discovery clients (additive to existing dimensions).
+- [ ] `ha.notify` schema: `{ service?: string; message: string; title?: string; target?: string | string[]; data?: Record<string, unknown> }`. Default service: `notify.notify`. The bridge translates to `call_service` with the supplied target.
+- [ ] `ha.event.fire` schema: `{ eventType: string; eventData?: Record<string, unknown> }`. The bridge translates to a `fire_event` WebSocket frame.
+- [ ] A sink invocation returns `{ kind: 'ok' } | { kind: 'rejected'; reason: 'pillar-unavailable' | 'ha-offline' | 'invalid-payload' }` — same shape as US-04's `callService`.
+- [ ] Sink invocations are validated against the published Zod schema before they hit HA. Invalid payload → `{ kind: 'rejected', reason: 'invalid-payload' }`.
+- [ ] When the bridge is in degraded mode, all sinks return `{ kind: 'rejected', reason: 'ha-offline' }` immediately.
+- [ ] Unit tests cover: schema validation, default service for `ha.notify`, event-fire mapping, degraded mode.
+- [ ] Integration test: stand up a stub upstream pillar that publishes to `ha.notify`, assert the bridge dispatches the expected `call_service` frame.
+
+## Notes
+
+- Depends on US-04 — reuses the outbound `call_service` plumbing.
+- This story ships the HA-specific shape of the `sinks` dimension. Full generalisation of the dimension (so MQTT and ESPHome bridges can implement it without duplication) is deferred to its own PRD once a second bridge consumes it — explicitly called out as out of scope in the epic.
+- The bridge does not own delivery guarantees beyond "WebSocket frame sent". At-least-once / retries / dead-letter is for the calling pillar to handle (or for a future PRD if a generalised sink dispatcher emerges).
+- See [ADR-032](../../../../architecture/adr-032-positioning-vs-self-hosted-os-family.md) — `sinks` is the manifest dimension that enables the outbound half of the bridge-pillar pattern.


### PR DESCRIPTION
## Summary

- Adds **Epic 13: Bridge pillars (HA, MQTT, ESPHome)** under Theme 13 as a follow-on epic per ADR-032's positioning decision (POPS additive to HA, not competitive).
- Scaffolds **PRD-229: `pops-ha-bridge-api`** — the first bridge pillar. Subscribes to HA's WebSocket API, mirrors entity state into a per-pillar SQLite (`ha_entities` + `ha_state_history` with FTS5), and exposes the data through `searchAdapter` + `aiTools` + a new `sinks` manifest dimension for outbound POPS → HA events.
- 5 user stories: WS subscriber + entity mirror, searchAdapter, AI read tools (`entity.list` / `getState`), AI control tool (`callService`), and `sinks` for outbound events.

## What's in this PR

- `docs/themes/13-pillar-finale/epics/13-bridge-pillars.md` — new epic, lists PRD-229 + 3 TBD follow-on PRDs (MQTT, ESPHome, generalised sinks dimension).
- `docs/themes/13-pillar-finale/prds/229-ha-bridge-pillar/README.md` — PRD with data model, API surface, business rules (reconnect, debounce, secret management, retention), edge cases, US table.
- `us-01` … `us-05` — one US per buildable unit, each with testable acceptance criteria.
- Theme 13 README updated — adds Epic 13 row + dependency note clarifying E13 is a follow-on (not on the main critical path).

## Notes

- Implementation deferred — this PR is PRD documentation only.
- ADR-032 lives in a separate concurrent session/PR; the docs reference it by filename, which resolves once ADR-032 lands.

## Test plan

- [ ] Markdown lint passes (oxfmt ran via lint-staged on commit).
- [ ] Skim PRD-229 — data model, three manifest dimensions, US table reads cleanly.
- [ ] Confirm epic + theme README cross-links resolve.