### PR TITLE
docs(theme-13): app-finance/media/inventory consumer audit (PRD-227 follow-up)

### DIFF
--- a/docs/themes/13-pillar-finale/notes/app-finance-consumer-inventory.md
+++ b/docs/themes/13-pillar-finale/notes/app-finance-consumer-inventory.md
@@ -1,0 +1,108 @@
+# app-finance Consumer Inventory (PRD-227 follow-up)
+
+Static audit of `packages/app-finance/src/` for tRPC consumer call sites that will
+need to be cut over to per-pillar SDKs as part of the finale (PRD-228 dynamic
+pillar registration and the planned `@pops/finance-sdk` / `@pops/core-sdk`
+clients).
+
+This document is **audit-only**. No migration in this PR. Subsequent PRs will
+move trivial call sites first, then medium, then risky.
+
+## Summary
+
+| Metric                                              | Value   |
+| --------------------------------------------------- | ------- |
+| Total tRPC call sites (`useQuery` / `useMutation`)  | **47**  |
+| Files containing at least one call site             | **26**  |
+| `trpc.useUtils()` consumers (cache invalidation)    | 9 files |
+| Calls into `trpc.finance.*` (pillar-local)          | **24**  |
+| Calls into `trpc.core.*` (cross-pillar)             | **23**  |
+| Direct `getDrizzle()` usage                         | 0       |
+| Raw `fetch('/trpc/…')` usage                        | 0       |
+| Optimistic updates (`utils.*.setData` / `onMutate`) | 0       |
+| `useSuspenseQuery` / `useInfiniteQuery`             | 0       |
+
+The package consumes `@pops/api-client` (the monorepo-wide tRPC client) and
+imports `AppRouter` plus several `@pops/api/modules/**` type modules. Type-only
+imports from `@pops/api/modules/**` are listed for completeness in the section
+below but are not call-site work — they will be replaced by SDK type re-exports
+when the contract packages ship.
+
+## Triage
+
+| Bucket      | Count | Definition                                                                                                       | Notes                                                                |
+| ----------- | ----- | ---------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| **Trivial** | 24    | Single-pillar `trpc.finance.*` call, ≤5 LOC delta, plain query or mutation with `utils.invalidate` only          | Migrate first via the planned `@pops/finance-sdk` React adapter.     |
+| **Medium**  | 23    | `trpc.core.*` call (cross-pillar, depends on core SDK), or call inside a `useUtils()`-invalidation chain crossing routers | Blocked on `@pops/core-sdk` ship; mechanical once it lands.          |
+| **Risky**   | 0     | Optimistic updates, suspense, infinite queries, or any cross-pillar coordination                                 | None in this package.                                                |
+
+Total trivial + medium + risky = 47 (matches call-site count).
+
+## Call sites by area
+
+### `trpc.finance.*` (Trivial, 24)
+
+- `pages/DashboardPage.tsx` — `finance.transactions.list`, `finance.budgets.list`.
+- `pages/TransactionsPage.tsx` — `finance.transactions.update`.
+- `pages/transactions/useTransactionsPage.ts` — `finance.transactions.list`, `finance.transactions.availableTags`.
+- `pages/transactions/useTransactionMutations.ts` — `finance.transactions.{create,update,restore,delete}`.
+- `pages/budgets/useBudgetsPage.ts` — `finance.budgets.{create,update,delete,list}`.
+- `pages/wishlist/useWishlistPage.ts` — `finance.wishlist.{create,update,delete,list}`.
+- `components/imports/final-review/useFinalReview.ts` — `finance.imports.commitImport`.
+- `components/imports/processing/useProcessing.ts` — `finance.imports.processImport`, `finance.imports.getImportProgress`.
+- `components/imports/hooks/useTransactionReview.ts` — `finance.imports.reevaluateWithPendingRules`.
+- `components/imports/review/ReviewDialogs.tsx` — `finance.imports.reevaluateWithPendingRules`.
+- `components/imports/tag-review/useTagReviewState.ts` — `finance.transactions.availableTags`.
+- `components/imports/correction-proposal/rule-manager/useRuleManagerHooks.ts` — `finance.transactions.listDescriptionsForPreview`.
+
+### `trpc.core.*` (Medium, 23)
+
+These all flow through `core` routers (`corrections`, `tagRules`, `entities`) and
+must wait on the cross-pillar `@pops/core-sdk` to ship before they can be moved.
+
+- `pages/entities/useEntitiesPage.ts` — `core.entities.{create,update,delete,list}`.
+- `pages/rules-browser/useRulesBrowserModel.ts` — `core.corrections.{delete,list}`.
+- `pages/rules-browser/rule-form/useRuleFormState.ts` — `core.corrections.{createOrUpdate,update}`, `core.entities.list`.
+- `pages/rules-browser/rule-form/useRulePreview.ts` — `core.corrections.previewMatches`.
+- `pages/transactions/useTransactionsPage.ts` — `core.entities.list`.
+- `components/ConfidenceSlider.tsx` — `core.corrections.adjustConfidence`.
+- `components/imports/RulePicker.tsx` — `core.corrections.list`.
+- `components/imports/hooks/useProposalGeneration.ts` — `core.corrections.analyzeCorrection`.
+- `components/imports/hooks/usePreviewEffects.ts` — `core.corrections.previewChangeSet`.
+- `components/imports/hooks/useApplyRejectMutations.ts` — `core.corrections.{rejectChangeSet,reviseChangeSet}`.
+- `components/imports/hooks/bulk-assignment/use-accept.ts` — `core.entities.list`.
+- `components/imports/tag-rule-dialog/useTagRuleProposal.ts` — `core.tagRules.proposeTagRuleChangeSet`.
+- `components/imports/tag-rule-dialog/useTagRuleMutations.ts` — `core.tagRules.{applyTagRuleChangeSet,rejectTagRuleChangeSet}`.
+- `components/imports/correction-proposal/rule-manager/useBrowseRules.ts` — `core.corrections.listMerged`.
+- `components/imports/correction-proposal/workflow/useWorkflowHooks.ts` — `core.corrections.proposeChangeSet`.
+
+### Type-only imports (no call-site work, listed for tracking)
+
+`@pops/api/modules/finance/imports`, `@pops/api/modules/finance/transactions/types`,
+`@pops/api/modules/finance/budgets/types`, `@pops/api/modules/core/corrections/types`,
+`@pops/api/modules/core/corrections/pure-service`, `@pops/api/modules/core/entities/types`,
+`@pops/api/modules/core/tag-rules/types`. ~30 files import types only — these will
+be re-exported from `@pops/finance-contract` / `@pops/core-contract`.
+
+## Migration ordering
+
+1. **Trivial (24)** — once `@pops/finance-sdk` React adapter ships, swap
+   `trpc.finance.*` for the equivalent SDK hook. Tests already mock
+   `@pops/api-client`; mocks will need to flip to the SDK module.
+2. **Medium (23)** — once `@pops/core-sdk` ships, move `trpc.core.*` calls in
+   the same mechanical pass. Watch for `utils.invalidate()` chains: nine files
+   pull `trpc.useUtils()` and invalidate sibling queries across both `finance`
+   and `core` namespaces. Either the SDKs must expose a unified invalidation
+   surface or these chains need to be split per-namespace.
+3. **Risky (0)** — nothing in this package is blocked by SDK gaps for
+   suspense, optimistic updates, or infinite queries.
+
+## Caveats / unknowns
+
+- The audit excludes test files (`*.test.ts`, `*.test.tsx`, `*.stories.tsx`).
+  Tests currently mock `@pops/api-client`; they will need to switch to the SDK
+  module name when each call site is migrated.
+- Type-only imports from `@pops/api/modules/**` are not counted as call sites
+  but are a real coupling and must be re-exported by the contract packages.
+- `trpc.useUtils()` is counted at the file level, not per invalidation
+  expression. Some files invalidate up to four sibling queries.

--- a/docs/themes/13-pillar-finale/notes/app-inventory-consumer-inventory.md
+++ b/docs/themes/13-pillar-finale/notes/app-inventory-consumer-inventory.md
@@ -1,0 +1,75 @@
+# app-inventory Consumer Inventory (PRD-227 follow-up)
+
+Static audit of `packages/app-inventory/src/` for tRPC consumer call sites that
+will need to be cut over to per-pillar SDKs (`@pops/inventory-sdk`).
+
+This document is **audit-only**. No migration in this PR.
+
+## Summary
+
+| Metric                                              | Value   |
+| --------------------------------------------------- | ------- |
+| Total tRPC call sites (`useQuery` / `useMutation`)  | **48**  |
+| Files containing at least one call site             | **19**  |
+| `trpc.useUtils()` consumers (cache invalidation)    | 7 files |
+| Calls into `trpc.inventory.*` (pillar-local)        | **48**  |
+| Cross-pillar calls (`trpc.core.*`, others)          | **0**   |
+| Direct `getDrizzle()` usage                         | 0       |
+| Raw `fetch('/trpc/…')` usage                        | 0       |
+| Optimistic updates (`utils.*.setData` / `onMutate`) | 0       |
+| `useSuspenseQuery` / `useInfiniteQuery`             | 0       |
+
+Self-contained against the `inventory` namespace. No cross-pillar coupling, no
+risky cache patterns.
+
+## Triage
+
+| Bucket      | Count | Definition                                          | Notes                        |
+| ----------- | ----- | --------------------------------------------------- | ---------------------------- |
+| **Trivial** | 48    | Single-pillar `trpc.inventory.*` call, ≤5 LOC delta | All 48 call sites fall here. |
+| **Medium**  | 0     | —                                                   | None.                        |
+| **Risky**   | 0     | —                                                   | None.                        |
+
+Total = 48 + 0 + 0 = 48 (matches call-site count).
+
+## Call sites by router
+
+- `inventory.items.*` — list, get, create, update, delete, distinctTypes
+  (~13 calls; spans items page, item-form-page, item-detail-page,
+  LocationContentsPanel, ConnectDialog, ConnectionsSection).
+- `inventory.locations.*` — tree, create, update, delete, getPath
+  (~9 calls; location-tree-page, item-form-page, insurance report).
+- `inventory.connections.*` — connect, disconnect, listForItem, graph, trace
+  (~7 calls; ConnectDialog, ConnectionGraph, ConnectionTracePanel,
+  item-detail-page).
+- `inventory.documents.*` — listForItem, link, unlink (~3 calls;
+  DocumentsSection, LinkDocumentDialog).
+- `inventory.documentFiles.*` — listForItem, upload, removeUpload (~3 calls;
+  useDocumentUpload).
+- `inventory.photos.*` — listForItem, upload, remove, reorder (~5 calls;
+  usePhotoUpload, item-detail-page).
+- `inventory.paperless.*` — status, search (~3 calls; DocumentsSection,
+  LinkDocumentDialog, WarrantiesPage).
+- `inventory.reports.*` — dashboard, valueByType, valueByLocation, warranties,
+  insuranceReport (~5 calls; DashboardWidgets, ValueBreakdown, WarrantiesPage,
+  insurance-report-page).
+
+## Migration ordering
+
+1. **Trivial (48)** — once `@pops/inventory-sdk` ships, swap `trpc.inventory.*`
+   for the equivalent SDK hook in one mechanical pass. The 7 files using
+   `trpc.useUtils()` are still trivial; every invalidated key sits inside
+   `inventory.*`, so the SDK invalidate helper covers them.
+
+## Caveats / unknowns
+
+- Test files excluded from counts. They mock `@pops/api-client` today and will
+  need to switch mock targets when the SDK lands.
+- `document-upload-helpers.ts` and `photo-upload-helpers.ts` contain
+  `ReturnType<typeof trpc.inventory.*.useMutation>` type annotations — these
+  are not separate call sites (the mutation is passed in from the parent
+  hook), but the type re-exports from the SDK must support this pattern or
+  these helper signatures need updating.
+- This package is the cleanest of the three audited: small surface, no
+  cross-pillar coupling, no optimistic cache writes. Highest leverage for a
+  first end-to-end SDK-cutover dry run.

--- a/docs/themes/13-pillar-finale/notes/app-media-consumer-inventory.md
+++ b/docs/themes/13-pillar-finale/notes/app-media-consumer-inventory.md
@@ -1,0 +1,93 @@
+# app-media Consumer Inventory (PRD-227 follow-up)
+
+Static audit of `packages/app-media/src/` for tRPC consumer call sites that will
+need to be cut over to per-pillar SDKs (`@pops/media-sdk`) during the finale.
+
+This document is **audit-only**. No migration in this PR.
+
+## Summary
+
+| Metric                                                                | Value                          |
+| --------------------------------------------------------------------- | ------------------------------ |
+| Total tRPC call sites (`useQuery` / `useMutation`)                    | **151**                        |
+| Files containing at least one call site                               | **61**                         |
+| `trpc.useUtils()` consumers (cache invalidation)                      | 32 files                       |
+| Calls into `trpc.media.*` (pillar-local)                              | **151**                        |
+| Cross-pillar calls (`trpc.core.*`, others)                            | **0**                          |
+| Direct `getDrizzle()` usage                                           | 0                              |
+| Raw `fetch('/trpc/…')` usage                                          | 0                              |
+| Optimistic updates (`utils.*.setData` / `onMutate` for cache writes)  | **14 occurrences across 3 files** |
+| `useSuspenseQuery` / `useInfiniteQuery`                               | 0                              |
+
+The package consumes `@pops/api-client` and is otherwise self-contained against
+the `media` tRPC namespace. There is no cross-pillar coupling at the call-site
+level — every call is `trpc.media.*`.
+
+## Triage
+
+| Bucket      | Count | Definition                                                                                                              | Notes                                                                                                                              |
+| ----------- | ----- | ----------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| **Trivial** | 137   | Single-pillar `trpc.media.*` call, ≤5 LOC delta, query or mutation with at most `utils.media.*.invalidate()`            | The bulk; suitable for the first migration sweep.                                                                                  |
+| **Medium**  | 0     | Wrapper-required (cross-router invalidation chain, or `usePillarQuery`-style adapter)                                   | Many `useUtils()` consumers exist, but they all stay inside `media.*` namespace, so they remain trivial for the SDK swap.          |
+| **Risky**   | 14    | Optimistic updates via `utils.media.*.setData(...)` and `onMutate` rollback in three files                              | Needs the SDK to expose a typed cache-write surface, or keep `utils` on raw tRPC for these hooks.                                  |
+
+Total = 137 + 0 + 14 = 151 (matches call-site count).
+
+## Risky sites (optimistic cache writes)
+
+These three files perform optimistic updates with `utils.media.*.setData()`
+followed by `onMutate`/`onError` rollback. They must wait for the
+`@pops/media-sdk` adapter to expose a typed `setData` / cache-write API, or
+they need to keep raw tRPC plus a thin compatibility shim.
+
+- `components/watchlist-toggle/useWatchlistToggleModel.ts`
+  - Lines 15, 18, 29 (`add` mutation): optimistic toggle of
+    `media.watchlist.status` cache.
+  - Lines 48, 51, 62 (`remove` mutation): mirror pattern with rollback.
+- `pages/tv-show-detail/useTvShowDetailModel.ts`
+  - Lines 64, 67, 93 (`batchLog` mutation): optimistic update of
+    `media.watchHistory.progress` cache with a snapshot-on-error rollback.
+- `pages/season-detail/useBatchSeasonLog.ts`
+  - Lines 50, 53, 93, 96, 110 (`onMutate: apply`): batch-season optimistic
+    progress and list updates with snapshot rollback.
+
+## Call sites by router (Trivial bucket)
+
+The Trivial bucket spans these `trpc.media.*` sub-routers (call counts
+approximate; regenerate from `packages/app-media/src/` if needed):
+
+- `media.arr.*` — Sonarr/Radarr integration; config, queue, calendar, season
+  monitoring, request flows (~25 calls across calendar, request-movie,
+  request-series, source-management, tv-show detail, season detail).
+- `media.comparisons.*` — debrief, dimensions, smart-pair, rankings, tier
+  list, blacklist (~40 calls; the largest router).
+- `media.discovery.*` — quick-pick, assemble-session, profile, dismiss
+  (~7 calls).
+- `media.library.*` — list, addMovie, addTvShow, quickPick, genres (~7 calls).
+- `media.movies.*` / `media.tvShows.*` — get/list/seasons/episodes (~10 calls).
+- `media.plex.*` — sync jobs, status, last results (~4 calls).
+- `media.rotation.*` — sources, candidates, exclusions, leaving, rotation log,
+  add-to-queue (~25 calls).
+- `media.search.*` — movies / tvShows (~2 calls).
+- `media.watchHistory.*` — list, log, batchLog, progress, delete, listRecent
+  (~12 calls; three of these are the Risky optimistic-update sites).
+- `media.watchlist.*` — add, remove, status, list, update, reorder (~15 calls;
+  the toggle file is Risky).
+
+## Migration ordering
+
+1. **Trivial (137)** — once `@pops/media-sdk` ships, swap `trpc.media.*` for
+   the equivalent SDK hook. The 32 files using `trpc.useUtils()` for
+   invalidation are still trivial because all invalidated keys live in
+   `media.*`; the SDK invalidate helper covers them directly.
+2. **Risky (14)** — defer until the SDK exposes typed `setData` (or accept a
+   short-lived hybrid where these three files keep raw tRPC).
+
+## Caveats / unknowns
+
+- Test files (`*.test.ts(x)`) are excluded from the count. They currently mock
+  `@pops/api-client` and will need to switch mock targets when the SDK lands.
+- `trpc.useUtils()` is counted per file, not per invalidation expression. Some
+  files invalidate many sibling queries inside one `useUtils()` block.
+- No raw fetch to `/trpc/…` and no `getDrizzle()` — all access goes through
+  the typed client.


### PR DESCRIPTION
## Summary

Static audit (no migration) of `packages/app-{finance,media,inventory}/src/` for tRPC consumer call sites that will need to be cut over to per-pillar SDKs as part of the Theme 13 finale. Follow-up to PRD-227.

Three new inventory documents under `docs/themes/13-pillar-finale/notes/`:

- **app-finance** — 47 call sites across 26 files. 24 Trivial (`trpc.finance.*`), 23 Medium (`trpc.core.*` cross-pillar), 0 Risky.
- **app-media** — 151 call sites across 61 files. 137 Trivial, 0 Medium, 14 Risky (optimistic `setData` / `onMutate` in 3 files: watchlist toggle, tv-show detail, season detail).
- **app-inventory** — 48 call sites across 19 files. All Trivial. Cleanest of the three.

**Total: 246 call sites. Trivial 209 / Medium 23 / Risky 14.**

Subsequent PRs will do the trivial migrations once the per-pillar SDKs ship.

## Test plan

- [ ] Spot-check the call-site counts by re-running the grep:
  `grep -rn -E "trpc\.[a-zA-Z]+\.[a-zA-Z]+\.[a-zA-Z]+\.(useQuery|useMutation)" packages/app-finance/src packages/app-media/src packages/app-inventory/src --include='*.ts' --include='*.tsx' | grep -v '\.test\.' | grep -v 'typeof trpc\.' | wc -l` (expect 246).
- [ ] Confirm no `getDrizzle()` or raw `/trpc/` fetch usage in any of the three packages.
- [ ] Confirm three risky-site files in app-media really do call `utils.media.*.setData(...)` with `onMutate` rollback.