### PR TITLE
docs(theme-13): scaffold PRD-228 dynamic pillar registration (final BE-lego step)

### DIFF
--- a/docs/themes/13-pillar-finale/IMPLEMENTATION-PLAN.md
+++ b/docs/themes/13-pillar-finale/IMPLEMENTATION-PLAN.md
@@ -152,6 +152,7 @@ Five waves. Each wave is a set of PRDs that can ship concurrently. Waves are gat
 | 217 nginx config generator         | follows Wave 3                   | `a:nginx-gen`                   |
 | 218 module-registry deprecation    | follows 215                      | `a:module-registry-deprecation` |
 | 227 SDK consumer migration audit   | follows Wave 2 (parallel w/ 215) | `a:sdk-consumer-audit`          |
+| 228 dynamic pillar registration    | follows 217 (final BE-lego step) | `a:dynamic-registration`        |
 
 **Wave 4 exit criteria:**
 
@@ -239,6 +240,7 @@ Each gate must hold before the next wave starts. **Don't paper over a failed gat
 - [ ] AI tool list dynamically reflects registered pillars
 - [ ] PillarGuard renders unavailable placeholder when a pillar is stopped; route stays usable when pillar restarts
 - [ ] nginx config generated from registry on image build; no hand-maintained per-pillar dispatcher rules
+- [ ] PRD-228 closes the final BE-lego gap: an external repo can register a pillar via `POST /core.registry.register` and that pillar appears in the dispatcher with no code change in `pops/`
 - [ ] Worker no longer imports `@pops/<pillar>-db` from sibling pillars (uses SDK)
 
 ### Gate 5 (theme complete)
@@ -399,6 +401,7 @@ Status legend: ⏳ Not started · 🔄 In progress · ✅ Done · ⛔ Blocked
 | 225     | ci-publish-narrowing             | 4    | ⏳     | 221                    | CI leanness wave 4             |
 | 226     | ci-budget-enforcement            | 5    | ⏳     | 220-225                | CI leanness wave 5             |
 | 227     | sdk-consumer-migration-audit     | 4    | ⏳     | 193, 215               | FE + Node `pillar()` rollout   |
+| 228     | dynamic-pillar-registration      | 4    | ⏳     | 161, 162, 163, 217     | external-pillar drop-in (final BE-lego step) |
 
 ---
 

--- a/docs/themes/13-pillar-finale/epics/02-central-registry.md
+++ b/docs/themes/13-pillar-finale/epics/02-central-registry.md
@@ -23,11 +23,12 @@ The registry is the source of truth for _what's running and what it can do_. Con
 | 162 | Heartbeat lifecycle                | TTL semantics, missed-heartbeat → unavailable transition, recovery on reconnect | Not started |
 | 163 | Subscription model                 | SSE channel for change notifications; consumers invalidate caches on receive    | Not started |
 | 164 | Reconciliation on core-api restart | Initial `unknown` state, grace window, eventually-consistent recovery           | Not started |
+| 228 | Dynamic pillar registration        | External-pillar drop-in: shared-key register/heartbeat/deregister + nginx regen | Not started |
 
 ## Dependencies
 
 - **Requires:** Epic 00 (contract packages — the registry serves contract versions per pillar), Epic 01 (SDK provides the `register` + `heartbeat` client side), ADR-027 (registry shape)
-- **Unlocks:** Epic 05 (consumption SDK can route via registry), Epic 06 + 07 (search + AI read registry to discover capabilities), Epic 10 (nginx dispatcher generated from registry)
+- **Unlocks:** Epic 05 (consumption SDK can route via registry), Epic 06 + 07 (search + AI read registry to discover capabilities), Epic 10 (nginx dispatcher generated from registry). PRD-228 is the final BE-lego step — once it ships, an external repo can drop a pillar onto the docker network with no code change in `pops/`.
 
 ## Out of Scope
 

--- a/docs/themes/13-pillar-finale/prds/217-nginx-config-generator/README.md
+++ b/docs/themes/13-pillar-finale/prds/217-nginx-config-generator/README.md
@@ -61,9 +61,12 @@ PRD picks **image build time** initially — simpler, no runtime dep.
 
 ## Implementation Status
 
-> Status: **Done (phase 1)** — generator scaffolded for the canonical seven
-> pillars. Dynamic external-pillar registration tracked as the follow-up
-> below. Last updated: 2026-06-13 on `feat/theme13-prd-217-nginx-generator`.
+> Status: **Partial** — static-pillars half done in #3110 (the canonical
+> seven, generated from the SDK's `PILLARS` constant). Dynamic
+> external-pillar registration deferred to
+> [PRD-228](../228-dynamic-pillar-registration/README.md), which makes the
+> generator read from the runtime registry instead of the compile-time SDK
+> list. Last updated: 2026-06-13.
 
 ### Shipped state
 
@@ -91,8 +94,10 @@ PRD picks **image build time** initially — simpler, no runtime dep.
 ### Follow-ups (out of scope for phase 1)
 
 - **Dynamic external pillars.** Reading a registry snapshot (per the
-  original PRD body) instead of the static SDK list. Lands when the
-  pillar SDK exposes a runtime-augmentable registry.
+  original PRD body) instead of the static SDK list. Tracked as
+  [PRD-228](../228-dynamic-pillar-registration/README.md) — the final
+  BE-lego step that makes an external repo's pillar appear in the
+  dispatcher without a code change in `pops/`.
 - **Runtime init-container option.** Generator runs at image build today;
   a sidecar that polls the registry and `nginx reload`s is still the
   documented alternative.

--- a/docs/themes/13-pillar-finale/prds/228-dynamic-pillar-registration/README.md
+++ b/docs/themes/13-pillar-finale/prds/228-dynamic-pillar-registration/README.md
@@ -1,0 +1,236 @@
+# PRD-228: Dynamic pillar registration (external-pillar drop-in)
+
+> Epic: [Central registry](../../epics/02-central-registry.md)
+
+> Status: Not started
+
+## Overview
+
+PRD-217's nginx generator wires the dispatcher to the static `PILLARS` constant
+exported by the pillar SDK. That works for in-tree pillars and only those —
+adding a pillar shipped from a different repository still requires editing the
+constant and rebuilding `pops-shell`. PRD-228 closes that gap: it makes the
+registry (PRD-161 + 162) the single source of truth for which pillars exist,
+exposes a runtime register / heartbeat / deregister API that external services
+can call with a shared internal key, and wires the nginx generator to read from
+the registry snapshot on every registration event instead of from a compile-time
+constant. End-to-end deliverable: drop a containerised pillar onto the same
+docker network, point it at `core-api`, give it the shared key — it appears in
+the dispatcher and starts serving traffic with no code change in `pops/`.
+
+This is the final BE-lego unblock for external pillars. Implementation is
+deferred; this PR is documentation only.
+
+## Data Model
+
+### Extensions to `core.db.pillar_registry` (PRD-161)
+
+PRD-161 already provisions the table. PRD-228 adds three columns:
+
+```sql
+ALTER TABLE pillar_registry
+  ADD COLUMN origin         TEXT NOT NULL DEFAULT 'internal'; -- 'internal' | 'external'
+ALTER TABLE pillar_registry
+  ADD COLUMN api_key_hash   TEXT;                              -- SHA-256 of the key used to register; NULL for 'internal'
+ALTER TABLE pillar_registry
+  ADD COLUMN evicted_at     TEXT;                              -- ISO8601; set when ticker evicts a never-heartbeating registration
+
+CREATE INDEX idx_pillar_registry_origin ON pillar_registry(origin);
+```
+
+| Column         | Purpose                                                                                                                                             |
+| -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `origin`       | `'internal'` for in-tree pillars (bootstrapPillar path, PRD-158); `'external'` for pillars that registered via the shared-key HTTP endpoint.         |
+| `api_key_hash` | SHA-256 of the `POPS_INTERNAL_API_KEY` value at registration time. Lets a key rotation deregister stale external pillars without touching internal. |
+| `evicted_at`   | Set by the ticker when an external pillar registers but never heartbeats within the grace window. Distinguishes eviction from clean deregister.     |
+
+No new tables. The registry stays one row per pillar.
+
+### Migration
+
+`packages/core-db/migrations/00YY_pillar_registry_external_origin.sql` — adds
+the three columns + index. Existing rows backfill to `origin = 'internal'`,
+`api_key_hash = NULL`, `evicted_at = NULL`.
+
+## API Surface
+
+PRD-161 ships the `core.registry.*` tRPC procedures over the in-network
+boundary, gated by nginx. PRD-228 adds a **public-but-key-gated HTTP surface**
+specifically for external services. Two layers, one persistence:
+
+### HTTP endpoints on `pops-core-api` (exposed through nginx)
+
+#### `POST /core.registry.register`
+
+Request:
+
+```ts
+{
+  pillarId: string;        // e.g. 'recipes'
+  baseUrl: string;         // 'http://recipes-api:4010' — reachable from inside the docker network
+  manifest: ManifestPayload; // validated by PRD-157
+  apiKey: string;          // must match POPS_INTERNAL_API_KEY
+}
+```
+
+Behaviour:
+
+1. Constant-time compare `apiKey` against `POPS_INTERNAL_API_KEY`. Mismatch → 401.
+2. Validate `manifest` per PRD-157. Failure → 400 with per-field issues.
+3. Cross-field: `manifest.pillar === pillarId`. Mismatch → 400.
+4. UPSERT into `pillar_registry` with `origin = 'external'`, `api_key_hash = sha256(apiKey)`, `evicted_at = NULL`, status `healthy`. Re-registration preserves the original `registered_at`.
+5. Emit subscription event `{ type: 'registered', pillarId, manifest, origin: 'external' }`.
+6. Trigger nginx regeneration (see Business Rules — nginx regen).
+
+Response: `{ ok: true, pillarId, registeredAt: string, heartbeatIntervalMs: 10000 }`.
+
+#### `POST /core.registry.heartbeat`
+
+Request: `{ pillarId: string; apiKey: string }`.
+
+Behaviour:
+
+1. Constant-time compare `apiKey`. Mismatch → 401.
+2. Verify the pillar row's `api_key_hash` matches `sha256(apiKey)`. Mismatch → 401 (a rotated key invalidates old registrations).
+3. UPDATE `last_heartbeat_at = NOW()`. If 0 rows → `{ ok: false, reason: 'not-registered' }` (external SDK re-runs register).
+4. PRD-162's lifecycle handles `unavailable → healthy` transition + event emission.
+
+Response: `{ ok: true, lastHeartbeatAt: string } | { ok: false, reason: 'not-registered' }`.
+
+#### `POST /core.registry.deregister`
+
+Request: `{ pillarId: string; apiKey: string }`.
+
+Behaviour:
+
+1. Constant-time compare `apiKey`. Mismatch → 401.
+2. Verify the pillar row's `api_key_hash` matches. Mismatch → 401.
+3. DELETE the row.
+4. Emit `{ type: 'deregistered', pillarId, origin: 'external' }`.
+5. Trigger nginx regeneration.
+
+Response: `{ ok: true }` (idempotent).
+
+### nginx dispatcher rules
+
+The block introduced by PRD-161 stays — internal mutating calls to
+`/trpc/core.registry.(register|heartbeat|deregister)` continue to be blocked
+from external traffic. The PRD-228 endpoints live at a **different path prefix**
+(`/core.registry.*`, no `/trpc/` prefix, served as plain HTTP-JSON by core-api)
+and are explicitly allow-listed:
+
+```nginx
+location ~ ^/core\.registry\.(register|heartbeat|deregister)$ {
+    proxy_pass http://core-api:3001;
+    # standard proxy headers
+}
+```
+
+The internal `/trpc/core.registry.*` surface and the external
+`/core.registry.*` surface call the same underlying persistence layer.
+
+### nginx generator hook
+
+PRD-217's generator becomes registry-driven:
+
+- Input: `core.registry.snapshot()` output.
+- Triggered on `registered`, `deregistered`, and `health-changed (→ unavailable
+  via eviction)` events.
+- Process: regenerate `default.conf` from the snapshot → `nginx -t` validate →
+  on pass, `nginx -s reload`; on fail, log + keep current conf.
+
+Concrete trigger surface lives in PRD-217's updated scope; PRD-228 specifies the
+**contract**: every successful register / deregister / eviction MUST result in
+the nginx generator running. Implementation choice (subscription listener vs
+post-mutation hook) is deferred to implementation.
+
+## Business Rules
+
+- **Auth is a single shared key, not per-pillar.** `POPS_INTERNAL_API_KEY` is
+  the only credential. ADR-027 already treats the docker network as the trust
+  boundary; the key exists so an external service running outside the host
+  cannot accidentally register.
+- **Constant-time comparison only.** Use `crypto.timingSafeEqual` on the raw
+  bytes; never `===`. Both string comparisons (`apiKey === stored`) and naive
+  `Buffer.compare` are timing-attack surfaces.
+- **Key rotation evicts external registrations.** A rotated key means the
+  hashed `api_key_hash` no longer matches incoming heartbeats; those pillars
+  flip to `not-registered` and must re-register with the new key. Internal
+  pillars (`origin = 'internal'`, `api_key_hash = NULL`) are unaffected.
+- **Heartbeat cadence is 10s** (matches PRD-162's internal cadence). The
+  registration response includes `heartbeatIntervalMs` so the external SDK
+  doesn't hard-code it; the registry can lengthen this in the future without a
+  client-side change.
+- **Eviction policy.** PRD-162's miss-threshold (3 × 10s = 30s) flips a pillar
+  to `unavailable`. PRD-228 adds a **hard-eviction** for external pillars: if
+  `origin = 'external'` AND `status = 'unavailable'` for >5 minutes, the row is
+  DELETEd, `evicted_at` is recorded in the subscription event, and the nginx
+  generator is re-run. Internal pillars are never hard-evicted (they're
+  expected to come back when the container restarts).
+- **nginx regen is debounced.** Multiple registrations in a short window
+  collapse to a single regen + reload (250ms debounce). Prevents a thundering
+  herd at core-api startup or during a multi-pillar deploy.
+- **nginx regen is idempotent and validated.** Same registry snapshot → same
+  `default.conf`. `nginx -t` always runs before reload. A regen that fails
+  validation logs at error level and leaves the current conf in place; the
+  registry still records the registration (degraded mode: registry knows about
+  the pillar, dispatcher doesn't yet).
+- **External pillars cannot register as core pillars.** `pillarId` matching one
+  of the in-tree pillar ids (`finance`, `media`, `inventory`, `cerebrum`,
+  `core`, `food`, `lists`) is rejected with 409. Prevents accidental shadowing.
+- **No multi-instance.** One row per `pillarId`; second registration overwrites.
+  Matches PRD-161's single-instance assumption.
+- **Manifest changes between registrations regenerate nginx.** The dispatcher
+  block per pillar depends only on `baseUrl` today, but future enhancements
+  (per-pillar timeouts, websocket upgrades) may key off manifest fields; the
+  generator MUST re-run on every register so a no-op snapshot diff is harmless
+  but a real change is never missed.
+
+## Edge Cases
+
+| Case                                                            | Behaviour                                                                                                                                                                                                                          |
+| --------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| External pillar registers but never sends a heartbeat           | 30s after registration the lifecycle ticker flips it to `unavailable`. 5 minutes later the eviction ticker DELETEs the row + regenerates nginx. Subscription event includes `evicted_at` and `reason: 'never-heartbeated'`.         |
+| External pillar registers with a stale (rotated) key            | Registration uses whatever key is currently set in env, so success — but its heartbeat fails 401 because the heartbeat path validates `api_key_hash` against the current key. The pillar must re-register; SDK handles the 401.     |
+| Duplicate registration (same pillarId, same baseUrl, same key)  | UPSERT no-op semantics: `last_heartbeat_at` updated, manifest fields refreshed, `registered_at` preserved, no subscription event if the manifest is bytewise identical. nginx regen still triggered (debounced).                    |
+| Duplicate registration with different `baseUrl`                 | UPSERT overwrites. Subscription event fires. nginx regen runs and the dispatcher block now points at the new URL. The old URL stops receiving traffic on the next reload.                                                           |
+| Two external pillars race the same `pillarId`                   | SQLite serialises writes; whichever lands last wins. The loser's heartbeats start failing with `not-registered`. Operational misconfig; not the registry's job to mediate.                                                          |
+| External pillar registers during core-api boot reconciliation   | PRD-164's reconciliation sets all rows to `unknown` on startup. A register call coming in during reconciliation lands a fresh `healthy` row and an event. Reconciliation completes around it without overwriting.                  |
+| External pillar tries to register as `finance` / `media` / etc. | 409 with `reason: 'pillar-id-reserved'`. The reserved list is the static in-tree `PILLARS` set at the time core-api was built.                                                                                                      |
+| Key rotation mid-flight (env var swap)                          | Internal pillars (`origin = 'internal'`) are unaffected — no key check. External pillars start getting 401 on heartbeat; they re-register with the new key. Brief window of `unavailable` in the dispatcher until reload settles.   |
+| nginx generator throws / `nginx -t` rejects the output          | Registration still completes (registry is the source of truth). Generator error is logged. Current `default.conf` stays in place. Next successful generation catches up. Health endpoint exposes `nginx_generator_last_error_at`.   |
+| External pillar deregisters while heartbeat is in flight        | Deregister DELETEs the row; the in-flight heartbeat lands on a row that's gone and returns `{ ok: false, reason: 'not-registered' }`. SDK on the external side stops sending heartbeats (it's mid-shutdown anyway).                 |
+| Subscription bus is down when registration succeeds             | Registration persists. Event emit failure is logged. nginx regen also runs off the event bus, so the regen is skipped; the next register / deregister catches up. PRD-163's recovery semantics apply.                              |
+| External pillar registers with a `baseUrl` core-api can't reach | Registration succeeds (no probe at registration time). nginx forwards traffic to a connection-refused upstream; clients see 502. Operator must fix the URL or deregister. Documented; not the registry's job to validate liveness.  |
+| Manifest schema bumps between SDK versions                      | If an external pillar registers with a manifest that's valid for an older schema, PRD-157's validator rejects it. ADR-031's coordinated-deploy guidance applies; external pillars track the published `@pops/pillar-contract` semver. |
+
+## User Stories
+
+| #   | Story                                                                         | Summary                                                                                                                                  | Parallelisable                       |
+| --- | ----------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
+| 01  | [us-01-register-endpoint](us-01-register-endpoint.md)                         | Schema migration + `POST /core.registry.register` endpoint with key auth, manifest validation, UPSERT, and reserved-pillar-id rejection. | yes — independent                    |
+| 02  | [us-02-heartbeat-endpoint](us-02-heartbeat-endpoint.md)                       | `POST /core.registry.heartbeat` with key-hash verification, `not-registered` response path, and hard-eviction ticker for stale externals. | blocked by us-01                     |
+| 03  | [us-03-nginx-regen-integration](us-03-nginx-regen-integration.md)             | Wire the PRD-217 generator to registry events (register / deregister / evict); debounced regen + `nginx -t` + reload.                    | blocked by us-01 + PRD-217 generator |
+| 04  | [us-04-deregister-endpoint](us-04-deregister-endpoint.md)                     | `POST /core.registry.deregister` with key-hash verification, idempotent DELETE, and nginx regen trigger.                                 | blocked by us-01                     |
+| 05  | [us-05-e2e-external-pillar-dropin](us-05-e2e-external-pillar-dropin.md)       | End-to-end test: spin up a throwaway pillar container, register via the HTTP endpoint, hit it through the shell dispatcher, deregister.  | blocked by us-01..04                 |
+
+## Out of Scope
+
+- Per-pillar API keys / scoped tokens. ADR-027's trust model is a single shared
+  key. If multi-tenant external pillars become a real use case, write a new ADR.
+- Active liveness probing of `baseUrl` at registration time. Heartbeat is the
+  liveness signal; trusting the pillar at registration matches PRD-161.
+- TLS / mTLS between external pillars and core-api. Docker network remains the
+  trust boundary; external pillars must run on the same network.
+- A discovery UI / admin console for listing external pillars. The
+  `core.registry.snapshot` endpoint already exposes the data; UI is a separate
+  PRD if anyone wants it.
+- Versioned compatibility checks (e.g. "external pillar contract is too new for
+  this core-api"). ADR-031's coordinated-deploy guidance covers this without
+  bespoke handshake logic.
+- Multi-instance pillar registration (HA). One row per pillarId, last write
+  wins. Inherits PRD-161's stance.
+- Soft delete or audit history of registration events. The subscription stream
+  (PRD-163) is the audit trail; consumers tail it if they need history.
+- Rate limiting on the register / heartbeat endpoints. Single-host single-user
+  with a shared key in a docker network; not a realistic abuse surface.

--- a/docs/themes/13-pillar-finale/prds/228-dynamic-pillar-registration/us-01-register-endpoint.md
+++ b/docs/themes/13-pillar-finale/prds/228-dynamic-pillar-registration/us-01-register-endpoint.md
@@ -1,0 +1,35 @@
+# US-01: External register endpoint + schema migration
+
+> PRD: [Dynamic pillar registration](README.md)
+
+## Description
+
+As an external service running on the same docker network, I want to register
+my pillar with `pops-core-api` via a single HTTP call so that my pillar appears
+in the registry and can be discovered by consumers without any code change in
+`pops/`.
+
+## Acceptance Criteria
+
+- [ ] Migration `00YY_pillar_registry_external_origin.sql` lands in `packages/core-db/migrations/` and adds `origin TEXT NOT NULL DEFAULT 'internal'`, `api_key_hash TEXT`, `evicted_at TEXT`, plus an index on `origin`. Existing rows backfill to `origin = 'internal'`.
+- [ ] `POST /core.registry.register` is served by `pops-core-api` outside the `/trpc/` namespace and is allow-listed in the shell's `nginx.conf`.
+- [ ] The handler validates `apiKey` against `POPS_INTERNAL_API_KEY` using `crypto.timingSafeEqual`. Mismatch returns 401 within a constant-time bound.
+- [ ] The handler validates `manifest` via PRD-157's `validateManifestPayload`. Failures return 400 with the per-field issues array.
+- [ ] Cross-field validation rejects `pillarId !== manifest.pillar` with 400.
+- [ ] Registration with a `pillarId` from the reserved in-tree set (`finance`, `media`, `inventory`, `cerebrum`, `core`, `food`, `lists`) returns 409 with `{ reason: 'pillar-id-reserved' }`.
+- [ ] On success the row is UPSERTed with `origin = 'external'`, `api_key_hash = sha256(apiKey)`, `status = 'healthy'`, `evicted_at = NULL`, `registered_at` preserved across re-registration.
+- [ ] Response includes `{ ok: true, pillarId, registeredAt, heartbeatIntervalMs: 10000 }`.
+- [ ] A `{ type: 'registered', pillarId, manifest, origin: 'external' }` subscription event is emitted (PRD-163 bus).
+- [ ] Unit tests cover: happy path, bad key, malformed manifest, reserved pillarId, cross-field mismatch, re-registration preserves `registered_at`.
+
+## Notes
+
+The shell's `nginx.conf` already proxies `/trpc/core.registry.snapshot` and
+`/trpc/core.registry.subscribe` through. PRD-228 adds a sibling allow-list at
+`^/core\.registry\.(register|heartbeat|deregister)$`. Don't put this under
+`/trpc/` — PRD-161 explicitly blocks mutating `/trpc/core.registry.*` from
+external traffic, and we don't want to fork that rule. Keep the external
+surface plain HTTP-JSON.
+
+ADR-027 is the trust model; reference it if a reviewer asks why a single shared
+key is sufficient.

--- a/docs/themes/13-pillar-finale/prds/228-dynamic-pillar-registration/us-02-heartbeat-endpoint.md
+++ b/docs/themes/13-pillar-finale/prds/228-dynamic-pillar-registration/us-02-heartbeat-endpoint.md
@@ -1,0 +1,30 @@
+# US-02: External heartbeat endpoint + eviction ticker
+
+> PRD: [Dynamic pillar registration](README.md)
+
+## Description
+
+As an external pillar, I want to send periodic heartbeats to `pops-core-api` so
+that the registry knows I'm still alive, and so the registry can hard-evict me
+if I stop heartbeating for long enough that the dispatcher should drop my route.
+
+## Acceptance Criteria
+
+- [ ] `POST /core.registry.heartbeat` is served by `pops-core-api` and allow-listed in the shell `nginx.conf` alongside the register endpoint.
+- [ ] The handler validates `apiKey` via `crypto.timingSafeEqual` against `POPS_INTERNAL_API_KEY`. Mismatch returns 401 in constant time.
+- [ ] The handler verifies the stored `api_key_hash` matches `sha256(apiKey)` for that pillar row. Mismatch returns 401 (covers key rotation).
+- [ ] On success it updates `last_heartbeat_at = NOW()` and the row's status flips per PRD-162's lifecycle.
+- [ ] Zero rows updated returns `{ ok: false, reason: 'not-registered' }` (not a 404) so the external SDK can re-register cleanly.
+- [ ] A hard-eviction ticker runs every 30s inside core-api: rows with `origin = 'external'` AND `status = 'unavailable'` AND `status_updated_at` older than 5 minutes are DELETEd, `evicted_at` is set in the emitted event, and a subscription event `{ type: 'deregistered', pillarId, origin: 'external', reason: 'never-heartbeated' | 'lost-heartbeat' }` fires.
+- [ ] Internal pillars (`origin = 'internal'`) are never hard-evicted regardless of status.
+- [ ] Unit tests cover: happy heartbeat, bad key, rotated key (`api_key_hash` mismatch), heartbeat for missing row returns `not-registered`, ticker evicts only externals, ticker emits the correct event shape, ticker is a no-op when no rows qualify.
+
+## Notes
+
+PRD-162 already specifies the in-network heartbeat cadence + miss threshold;
+this US extends behaviour for external pillars without changing PRD-162's
+contract. The eviction ticker is independent of PRD-162's status ticker — both
+run in core-api, both touch the registry, both are SQLite-transaction-safe.
+
+`heartbeatIntervalMs` lives in the register response so the cadence isn't
+hard-coded client-side. Don't expose it as a separate endpoint.

--- a/docs/themes/13-pillar-finale/prds/228-dynamic-pillar-registration/us-03-nginx-regen-integration.md
+++ b/docs/themes/13-pillar-finale/prds/228-dynamic-pillar-registration/us-03-nginx-regen-integration.md
@@ -1,0 +1,35 @@
+# US-03: Wire nginx generator to the registry
+
+> PRD: [Dynamic pillar registration](README.md)
+
+## Description
+
+As an operator, I want the nginx dispatcher to be regenerated and reloaded
+automatically whenever a pillar registers, deregisters, or is evicted, so that
+new pillars are routable within seconds and stale ones stop receiving traffic
+without manual intervention.
+
+## Acceptance Criteria
+
+- [ ] PRD-217's `scripts/generate-nginx-conf.ts` (or its successor) accepts a `RegistrySnapshot` as input — no compile-time `PILLARS` constant.
+- [ ] Core-api subscribes to its own PRD-163 event bus and triggers regen on `registered`, `deregistered`, and `health-changed (→ unavailable via eviction)` events.
+- [ ] Regen is debounced with a 250ms trailing window so a burst of registrations collapses into one regen + one `nginx -t` + one reload.
+- [ ] After regeneration, `nginx -t` validates the new conf. On pass, `nginx -s reload` runs. On fail, the error is logged at error level, the current `default.conf` is left in place, and `nginx_generator_last_error_at` is exposed on the core-api health endpoint.
+- [ ] Same registry snapshot produces a byte-identical `default.conf` (determinism — verified by a snapshot test).
+- [ ] An integration test spins up a fake registry state, fires a `registered` event, asserts the generator ran, asserts `nginx -t` was invoked, and asserts the new conf contains a `location /trpc-<newPillar>/` block.
+- [ ] A second integration test fires a `deregistered` event for an existing pillar and asserts the dispatcher block is gone from the regenerated conf.
+
+## Notes
+
+PRD-217 shipped the static-pillars half. The audit table inside PRD-217's
+README is now extended (PR description references the parallel update). Don't
+rewrite the generator from scratch — extend it to take a snapshot argument and
+move the snapshot-fetch call out of the build step into the event handler.
+
+The trigger surface (event-bus subscription vs post-mutation hook) is an
+implementation choice. The contract is: every register / deregister / eviction
+MUST result in a regen attempt. If you pick the post-mutation hook, document
+the trade-off (simpler, but loses the debounce benefit unless you add a queue).
+
+Reload races: nginx handles `nginx -s reload` gracefully under load; no
+in-flight requests are dropped. No need to coordinate with active connections.

--- a/docs/themes/13-pillar-finale/prds/228-dynamic-pillar-registration/us-04-deregister-endpoint.md
+++ b/docs/themes/13-pillar-finale/prds/228-dynamic-pillar-registration/us-04-deregister-endpoint.md
@@ -1,0 +1,33 @@
+# US-04: External deregister endpoint
+
+> PRD: [Dynamic pillar registration](README.md)
+
+## Description
+
+As an external pillar shutting down cleanly, I want to call a deregister
+endpoint on `pops-core-api` so that the registry drops my row and the
+dispatcher removes my route immediately — without waiting for the
+missed-heartbeat → unavailable → eviction chain.
+
+## Acceptance Criteria
+
+- [ ] `POST /core.registry.deregister` is served by `pops-core-api` and allow-listed in the shell `nginx.conf` alongside register + heartbeat.
+- [ ] The handler validates `apiKey` via `crypto.timingSafeEqual` against `POPS_INTERNAL_API_KEY`. Mismatch returns 401 in constant time.
+- [ ] The handler verifies the stored `api_key_hash` matches `sha256(apiKey)` for that pillar row. Mismatch returns 401.
+- [ ] DELETE is idempotent — calling deregister for a pillar that doesn't exist returns `{ ok: true }` with no event emitted.
+- [ ] On a real DELETE a `{ type: 'deregistered', pillarId, origin: 'external', reason: 'requested' }` subscription event fires.
+- [ ] nginx regeneration is triggered (US-03's hook).
+- [ ] Attempting to deregister an `origin = 'internal'` pillar via this endpoint returns 403 with `{ reason: 'internal-pillar-not-deregisterable-externally' }` — internal pillars manage their own lifecycle via the in-network `/trpc/` surface.
+- [ ] Unit tests cover: happy path, bad key, key-hash mismatch, idempotent DELETE of missing pillar, refusal to delete an internal pillar.
+
+## Notes
+
+Symmetry with US-01 and US-02 is the goal: same auth model, same hashing,
+same allow-list. The `internal-pillar-not-deregisterable-externally` rule
+exists because the shared key is the same for both surfaces — without it, an
+external caller could nuke `finance` or `media` rows by accident. The
+`/trpc/core.registry.deregister` route stays the path for internal pillars.
+
+`reason: 'requested'` distinguishes clean shutdown from `reason:
+'never-heartbeated'` and `reason: 'lost-heartbeat'` in US-02's eviction
+events. Consumers tailing the subscription can use this for diagnostics.

--- a/docs/themes/13-pillar-finale/prds/228-dynamic-pillar-registration/us-05-e2e-external-pillar-dropin.md
+++ b/docs/themes/13-pillar-finale/prds/228-dynamic-pillar-registration/us-05-e2e-external-pillar-dropin.md
@@ -1,0 +1,35 @@
+# US-05: End-to-end external pillar drop-in test
+
+> PRD: [Dynamic pillar registration](README.md)
+
+## Description
+
+As the maintainer of this theme, I want one integration test that exercises the
+entire BE-lego promise — "drop a pillar in from another repo and it Just Works"
+— so that regressions in any of US-01 through US-04 surface as a single,
+unambiguous failure.
+
+## Acceptance Criteria
+
+- [ ] A new test under `apps/pops-core-api/src/modules/registry/__tests__/external-dropin.e2e.test.ts` boots a throwaway HTTP server inside the test process that serves a minimal tRPC manifest at `http://localhost:<port>/trpc` and behaves as a registered external pillar.
+- [ ] The test calls `POST /core.registry.register` with a synthetic manifest (pillarId `e2e-drop-in`), a valid `POPS_INTERNAL_API_KEY`, and the local baseUrl. Asserts 200 + `{ ok: true }`.
+- [ ] The test polls `core.registry.snapshot` until the new pillar appears with `status: 'healthy'`. Times out after 2s.
+- [ ] The test invokes the nginx generator with the current snapshot and asserts the output contains a `location` block for `e2e-drop-in`. `nginx -t` validation is run when Docker is available; skipped (not failed) when not.
+- [ ] The test sends a heartbeat and asserts `lastHeartbeatAt` advances in the snapshot.
+- [ ] The test stops sending heartbeats and asserts the pillar flips to `status: 'unavailable'` within (intervalMs × missThreshold) + jitter.
+- [ ] The test calls `POST /core.registry.deregister` and asserts the row is gone from the snapshot. The generator re-run no longer contains the `location` block.
+- [ ] The test cleans up: shuts down the throwaway server, restores the registry to its pre-test state, restores `POPS_INTERNAL_API_KEY` env if it was overridden.
+- [ ] Test runs in <10 seconds in CI (heartbeat intervals are dependency-injected for the test, not the real 10s ticker).
+
+## Notes
+
+This is the regression net for PRD-228 as a whole. If any single US ships
+broken, this test should fail in an obvious way pointing at the specific step.
+
+Use the same per-pillar smoke-harness pattern Theme 12 PRD-2920 established
+— spin up a real HTTP server, exercise the contract end-to-end, tear down.
+Don't mock the registry; use a real `core.db` against an in-memory or temp-dir
+SQLite.
+
+Avoid Playwright timeouts longer than necessary. The flip-to-unavailable check
+should use the dependency-injected interval, not a real-world sleep.


### PR DESCRIPTION
## Summary

- Scaffolds **PRD-228 — Dynamic pillar registration** under Epic 02 (central registry). This is the final BE-lego unblock: PR #3110 (PRD-217 nginx generator) shipped the static-pillars half, but external pillars still require editing the SDK's PILLARS constant. PRD-228 makes the registry the single source of truth, exposes a shared-key register / heartbeat / deregister HTTP surface, and wires the nginx generator to read from registry snapshots on every registration event.
- Extends \`pillar_registry\` (PRD-161) with \`origin\`, \`api_key_hash\`, and \`evicted_at\` columns; specifies hard-eviction of stale externals, debounced nginx regen, and key rotation semantics.
- Adds 5 user stories: US-01 register endpoint + migration, US-02 heartbeat + eviction ticker, US-03 nginx regen integration, US-04 deregister endpoint, US-05 end-to-end drop-in test.
- Updates Epic 02's PRD table, the theme-13 IMPLEMENTATION-PLAN (Wave 4 row + Gate 4→5 criterion + checklist), and PRD-217's status from "Done (phase 1)" to "Partial" with a forward reference to PRD-228.

**Docs only.** No implementation; implementation is the follow-up.

## Test plan

- [ ] Review PRD-228 \`README.md\` for correctness against PRD-161 / 162 / 217.
- [ ] Confirm Epic 02 table now lists PRD-228 and the unblocks blurb makes sense.
- [ ] Confirm IMPLEMENTATION-PLAN.md Wave 4 row, Gate 4→5 criterion, and the full PRD checklist row are present and the dependency chain (161, 162, 163, 217) is correct.
- [ ] Confirm PRD-217 status now reads "Partial" with a link to PRD-228.