### PR TITLE
feat(module-registry): PRD-218 US-01 runtime install-set shim

### DIFF
--- a/docs/themes/13-pillar-finale/prds/218-module-registry-deprecation/README.md
+++ b/docs/themes/13-pillar-finale/prds/218-module-registry-deprecation/README.md
@@ -64,21 +64,21 @@ Offline seed is a JSON file committed for dev use; production reads the runtime 
 
 ### `apps/pops-api` — 13 files
 
-| File                                        | Symbols used                                                  | Migration target                                         | Status      |
-| ------------------------------------------- | ------------------------------------------------------------- | -------------------------------------------------------- | ----------- |
-| `src/router.ts`                             | `type MODULES`                                                | `RegisteredModule` / runtime registry type               | Not started |
-| `src/modules/installed-modules.ts`          | `MODULES`                                                     | runtime registry aggregator                              | Not started |
-| `src/modules/search-adapters.ts`            | `isModuleId`                                                  | `isKnownPillarId` from `@pops/pillar-sdk`                | Not started |
-| `src/modules/manifests.ts`                  | (comment ref)                                                 | update docstring after shim lands                        | Not started |
-| `src/modules/core/uri/resolver.ts`          | (comment ref)                                                 | update docstring after shim lands                        | Not started |
-| `src/modules/core/features/credentials.ts`  | `MODULES`                                                     | runtime registry                                         | Not started |
-| `src/modules/core/features/service.test.ts` | `vi.mock(...)`                                                | mock runtime registry                                    | Not started |
+| File                                        | Symbols used                                                   | Migration target                                         | Status      |
+| ------------------------------------------- | -------------------------------------------------------------- | -------------------------------------------------------- | ----------- |
+| `src/router.ts`                             | `type MODULES`                                                 | `RegisteredModule` / runtime registry type               | Not started |
+| `src/modules/installed-modules.ts`          | `MODULES`                                                      | runtime registry aggregator                              | Not started |
+| `src/modules/search-adapters.ts`            | `isModuleId`                                                   | `isKnownPillarId` from `@pops/pillar-sdk`                | Not started |
+| `src/modules/manifests.ts`                  | (comment ref)                                                  | update docstring after shim lands                        | Not started |
+| `src/modules/core/uri/resolver.ts`          | (comment ref)                                                  | update docstring after shim lands                        | Not started |
+| `src/modules/core/features/credentials.ts`  | `MODULES`                                                      | runtime registry                                         | Not started |
+| `src/modules/core/features/service.test.ts` | `vi.mock(...)`                                                 | mock runtime registry                                    | Not started |
 | `src/modules/core/index.ts`                 | `coreOperationalManifest`, `aiConfigManifest` from `/settings` | per-pillar settings module (post-Epic 02 settings split) | Not started |
-| `src/modules/finance/index.ts`              | `financeManifest` from `/settings`                            | finance pillar's own settings module                     | Not started |
-| `src/modules/inventory/index.ts`            | `inventoryManifest` from `/settings`                          | inventory pillar's own settings module                   | Not started |
-| `src/modules/cerebrum/index.ts`             | `cerebrumManifest` from `/settings`                           | cerebrum pillar's own settings module                    | Not started |
-| `src/modules/cerebrum/ego/index.ts`         | `egoManifest` from `/settings`                                | cerebrum pillar's own settings module                    | Not started |
-| `src/modules/media/index.ts`                | settings manifests from `/settings`                           | media pillar's own settings module                       | Not started |
+| `src/modules/finance/index.ts`              | `financeManifest` from `/settings`                             | finance pillar's own settings module                     | Not started |
+| `src/modules/inventory/index.ts`            | `inventoryManifest` from `/settings`                           | inventory pillar's own settings module                   | Not started |
+| `src/modules/cerebrum/index.ts`             | `cerebrumManifest` from `/settings`                            | cerebrum pillar's own settings module                    | Not started |
+| `src/modules/cerebrum/ego/index.ts`         | `egoManifest` from `/settings`                                 | cerebrum pillar's own settings module                    | Not started |
+| `src/modules/media/index.ts`                | settings manifests from `/settings`                            | media pillar's own settings module                       | Not started |
 
 ### `packages/navigation` — 2 files
 
@@ -99,11 +99,11 @@ All three remain in place until the shim ships (US-01) and consumers move (US-03
 
 ## User Stories
 
-| #   | Story                                                     | Summary                                                       | Status      |
-| --- | --------------------------------------------------------- | ------------------------------------------------------------- | ----------- |
-| 01  | [us-01-shim-implementation](us-01-shim-implementation.md) | Rewrite `@pops/module-registry` to fetch + fallback           | Not started |
-| 02  | [us-02-deprecation-notice](us-02-deprecation-notice.md)   | Mark exports as `@deprecated` with migration notes            | Not started |
-| 03  | [us-03-consumer-migration](us-03-consumer-migration.md)   | Migrate shell consumers from `MODULES` to `PILLARS` + runtime | Not started |
+| #   | Story                                                     | Summary                                                                   | Status      |
+| --- | --------------------------------------------------------- | ------------------------------------------------------------------------- | ----------- |
+| 01  | [us-01-shim-implementation](us-01-shim-implementation.md) | Runtime install-set shim: `INSTALLED_MODULES` + `isInstalledModule`       | Done        |
+| 02  | [us-02-deprecation-notice](us-02-deprecation-notice.md)   | Migrate the 20 deferred consumers from `KNOWN_MODULES` filter to the shim | Not started |
+| 03  | [us-03-consumer-migration](us-03-consumer-migration.md)   | Migrate shell consumers from `MODULES` to `PILLARS` + runtime             | Not started |
 
 ## Out of Scope
 

--- a/docs/themes/13-pillar-finale/prds/218-module-registry-deprecation/us-01-shim-implementation.md
+++ b/docs/themes/13-pillar-finale/prds/218-module-registry-deprecation/us-01-shim-implementation.md
@@ -1,0 +1,37 @@
+# PRD-218 US-01: Runtime install-set shim
+
+> Parent: [PRD-218 `@pops/module-registry` deprecation](README.md)
+>
+> Status: **Done**
+
+## Goal
+
+Extend `@pops/module-registry` with a runtime-evaluated install set so consumers can stop reading `POPS_APPS` directly and re-implementing the env gate inline. Unblocks the 20 deferred batch-2 consumers (PR #3104) that previously called `KNOWN_MODULES.filter(...)` against `process.env.POPS_APPS`.
+
+## Deliverable
+
+Three additions to `@pops/module-registry`:
+
+| Export                  | Shape                        | Semantics                                                                                                                                 |
+| ----------------------- | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `INSTALLED_MODULES`     | `readonly string[]`          | `POPS_APPS` ∪ `POPS_OVERLAYS` ∩ `KNOWN_MODULES`. Empty env returns `KNOWN_MODULES` verbatim. `core` is always included regardless of env. |
+| `isInstalledModule(id)` | `(value: string) => boolean` | Runtime equivalent of `isModuleId`. Returns true only when `id` is in the per-deploy install set.                                         |
+| `KNOWN_MODULES`         | unchanged                    | Stays as the full build-time superset alias for backwards compatibility.                                                                  |
+
+Filtering logic is centralised in `packages/module-registry/src/install-set.ts` (`resolveInstalledIds`) and reused by both the build script (`scripts/build.ts` → `scripts/lib.ts`) and the runtime exports — single source of truth for the `POPS_APPS` / `POPS_OVERLAYS` contract.
+
+## Acceptance Criteria
+
+- [x] `INSTALLED_MODULES` exported from `@pops/module-registry` root entry, evaluated at module load against `process.env`.
+- [x] `isInstalledModule(id)` exported, returns `INSTALLED_MODULES.includes(id)`.
+- [x] `core` always included in `INSTALLED_MODULES` even when `POPS_APPS` would exclude it.
+- [x] Unknown ids in `POPS_APPS` are silently dropped (matches build-time semantics).
+- [x] Existing `KNOWN_MODULES`, `MODULES`, `isModuleId`, `findModule` exports unchanged.
+- [x] Build script and runtime shim share one resolver (no duplication).
+- [x] Tests cover unset env, `POPS_APPS` subset, `POPS_OVERLAYS` union, unknown-id drop, whitespace handling, `core` always-installed behaviour.
+
+## Out of Scope
+
+- Migrating the 20 deferred consumers — that is US-02 in a follow-up PR.
+- Fetching the install set from a runtime registry endpoint — that is the longer-term direction documented in the parent PRD's "API Surface" section.
+- `@deprecated` JSDoc tags — also a follow-up step.

--- a/packages/module-registry/scripts/lib.ts
+++ b/packages/module-registry/scripts/lib.ts
@@ -5,7 +5,10 @@
  */
 import { assertModuleManifest, type ModuleManifest, type SettingsManifest } from '@pops/types';
 
+import { resolveInstalledIds } from '../src/install-set.js';
 import { warnUnknownChromeSlots } from './chrome-slots.js';
+
+export { resolveInstalledIds };
 
 /**
  * Project the serialisable subset of a `ModuleManifest` — id, name,
@@ -134,51 +137,6 @@ export function project(m: ModuleManifest): SerialisableModule {
         : undefined,
     settings: m.settings !== undefined ? [...m.settings] : undefined,
   };
-}
-
-/**
- * Resolve which modules are "installed" for this build. Mirrors PRD-100
- * `POPS_APPS` / `POPS_OVERLAYS` semantics: unset / empty = install all
- * known modules; comma-separated list = install only those (intersected
- * with `KNOWN_MODULES`).
- *
- * `alwaysInstalled` ids stay in the result regardless of env restrictions —
- * `core` is the always-mounted platform shell (PRD-100), so excluding it
- * from `MODULES` via `POPS_APPS=finance` would amount to "no core" which is
- * never the intent.
- *
- * Unknown ids in the env vars are silently dropped at this layer because
- * `apps/pops-api/src/modules/env-modules.ts` is the canonical strict
- * validator at boot. The registry build only needs to know the resulting
- * id set.
- */
-export function resolveInstalledIds(
-  knownIds: readonly string[],
-  env: Readonly<Record<string, string | undefined>>,
-  alwaysInstalled: readonly string[] = []
-): readonly string[] {
-  const fromEnv = (raw: string | undefined): readonly string[] => {
-    if (raw === undefined || raw.trim() === '') return [];
-    return raw
-      .split(',')
-      .map((s) => s.trim())
-      .filter((s) => s.length > 0);
-  };
-
-  const appsRaw = env.POPS_APPS;
-  const overlaysRaw = env.POPS_OVERLAYS;
-
-  if (appsRaw === undefined && overlaysRaw === undefined) {
-    return knownIds;
-  }
-
-  const envSet = new Set<string>([
-    ...fromEnv(appsRaw),
-    ...fromEnv(overlaysRaw),
-    ...alwaysInstalled,
-  ]);
-  const known = new Set(knownIds);
-  return knownIds.filter((id) => envSet.has(id) && known.has(id));
 }
 
 export { renderFile } from './render.js';

--- a/packages/module-registry/src/index.ts
+++ b/packages/module-registry/src/index.ts
@@ -1,17 +1,24 @@
 /**
- * @pops/module-registry — build-time module registry (PRD-101 US-02).
+ * @pops/module-registry — build-time module registry (PRD-101 US-02) with
+ * a runtime install-set shim layered on top (PRD-218 US-01).
  *
- * Re-exports the generated `MODULES` constant aggregating every installed
- * module manifest, plus consumer helpers. The aggregation logic, validation,
- * and emission live in `scripts/build.ts`; this entry point is read-only at
- * runtime and tree-shakeable.
+ * `MODULES` / `KNOWN_MODULES` come from `generated.ts` and reflect the set
+ * of modules selected at registry build time (see `scripts/build.ts`).
+ *
+ * `INSTALLED_MODULES` / `isInstalledModule` re-evaluate `POPS_APPS` /
+ * `POPS_OVERLAYS` at module-load time so consumers that need the live
+ * install set (per-deploy gating) do not have to read `process.env`
+ * themselves and risk semantic drift. The runtime shim is necessary
+ * because a single registry build is reused across deploys that may scope
+ * the install set differently via env.
  *
  * The `MODULES` constant is `as const` so consumers narrow on the exact
  * installed module-id union via `(typeof MODULES)[number]['id']`.
  */
 export { KNOWN_MODULES, MODULES } from './generated.js';
 
-import { MODULES } from './generated.js';
+import { MODULES, KNOWN_MODULES } from './generated.js';
+import { resolveInstalledIds } from './install-set.js';
 
 /**
  * Exact union of installed module ids. Narrows automatically when a module
@@ -49,4 +56,46 @@ export function findModule(id: string): RegisteredModule | undefined {
  */
 export function isModuleId(value: string): value is ModuleId {
   return MODULES.some((m) => m.id === value);
+}
+
+/**
+ * `core` is the always-mounted platform shell (PRD-100). It stays in the
+ * runtime install set even when `POPS_APPS` would otherwise exclude it.
+ */
+const ALWAYS_INSTALLED: readonly string[] = ['core'];
+
+interface MaybeProcess {
+  readonly env?: Readonly<Record<string, string | undefined>>;
+}
+
+function readEnv(): Readonly<Record<string, string | undefined>> {
+  const globals: { process?: MaybeProcess } = globalThis;
+  return globals.process?.env ?? {};
+}
+
+/**
+ * Runtime-filtered module ids. Computed once at module load from
+ * `POPS_APPS` / `POPS_OVERLAYS` against the build-time `KNOWN_MODULES`
+ * superset. Unset env → returns `KNOWN_MODULES` verbatim.
+ *
+ * This is the export PRD-218 batch-2 consumers should switch to when they
+ * need "is this module live on this deploy?". They previously read
+ * `KNOWN_MODULES` directly and re-implemented the env gate inline.
+ */
+export const INSTALLED_MODULES: readonly string[] = resolveInstalledIds(
+  KNOWN_MODULES,
+  readEnv(),
+  ALWAYS_INSTALLED
+);
+
+/**
+ * Runtime equivalent of `isModuleId`. Returns true only when `id` is in
+ * the per-deploy install set computed from `POPS_APPS` / `POPS_OVERLAYS`.
+ *
+ * Prefer this over `isModuleId` for install-set gating (feature
+ * availability, navigation, search adapter dispatch). Use `isModuleId`
+ * when you need the type-level narrowing to `ModuleId`.
+ */
+export function isInstalledModule(value: string): boolean {
+  return INSTALLED_MODULES.includes(value);
 }

--- a/packages/module-registry/src/install-set.test.ts
+++ b/packages/module-registry/src/install-set.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveInstalledIds } from './install-set.js';
+
+describe('resolveInstalledIds', () => {
+  const known = ['ai', 'cerebrum', 'core', 'finance', 'inventory', 'media'] as const;
+
+  it('returns every known id when POPS_APPS and POPS_OVERLAYS are both unset', () => {
+    expect(resolveInstalledIds(known, {})).toEqual(known);
+  });
+
+  it('intersects POPS_APPS with known ids and preserves source order', () => {
+    expect(resolveInstalledIds(known, { POPS_APPS: 'finance,inventory' })).toEqual([
+      'finance',
+      'inventory',
+    ]);
+  });
+
+  it('unions POPS_APPS with POPS_OVERLAYS', () => {
+    const knownPlusEgo = [...known, 'ego'] as const;
+    expect(
+      resolveInstalledIds(knownPlusEgo, { POPS_APPS: 'finance', POPS_OVERLAYS: 'ego' })
+    ).toEqual(['finance', 'ego']);
+  });
+
+  it('drops unknown ids from POPS_APPS silently', () => {
+    expect(resolveInstalledIds(known, { POPS_APPS: 'finance,not-real' })).toEqual(['finance']);
+  });
+
+  it('treats whitespace-only env values as empty', () => {
+    expect(resolveInstalledIds(known, { POPS_APPS: '   ', POPS_OVERLAYS: '' })).toEqual([]);
+  });
+
+  it('keeps alwaysInstalled ids even when POPS_APPS would exclude them', () => {
+    expect(resolveInstalledIds(known, { POPS_APPS: 'finance' }, ['core'])).toEqual([
+      'core',
+      'finance',
+    ]);
+  });
+
+  it('ignores alwaysInstalled when no env restrictions are active', () => {
+    expect(resolveInstalledIds(known, {}, ['finance'])).toEqual(known);
+  });
+
+  it('trims whitespace around CSV entries', () => {
+    expect(resolveInstalledIds(known, { POPS_APPS: '  finance , inventory  ' })).toEqual([
+      'finance',
+      'inventory',
+    ]);
+  });
+
+  it('drops empty CSV entries from trailing commas', () => {
+    expect(resolveInstalledIds(known, { POPS_APPS: 'finance,,inventory,' })).toEqual([
+      'finance',
+      'inventory',
+    ]);
+  });
+});

--- a/packages/module-registry/src/install-set.ts
+++ b/packages/module-registry/src/install-set.ts
@@ -1,0 +1,44 @@
+/**
+ * Install-set resolver shared by the build script (`scripts/build.ts`) and
+ * the runtime `INSTALLED_MODULES` export (PRD-218 US-01).
+ *
+ * Mirrors the PRD-100 `POPS_APPS` / `POPS_OVERLAYS` env contract:
+ *
+ *   - Both env vars unset  → install every known id.
+ *   - At least one set     → install only the union of their CSV entries,
+ *                            intersected with the known id list.
+ *   - `alwaysInstalled` ids stay in the result regardless. `core` is the
+ *     canonical example — it is the platform shell and must never be gated.
+ *
+ * Unknown ids in the env vars are silently dropped here because
+ * `apps/pops-api/src/modules/env-modules.ts` is the canonical strict
+ * validator at boot. This resolver only needs to know the resulting id set.
+ */
+export function resolveInstalledIds(
+  knownIds: readonly string[],
+  env: Readonly<Record<string, string | undefined>>,
+  alwaysInstalled: readonly string[] = []
+): readonly string[] {
+  const fromEnv = (raw: string | undefined): readonly string[] => {
+    if (raw === undefined || raw.trim() === '') return [];
+    return raw
+      .split(',')
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+  };
+
+  const appsRaw = env.POPS_APPS;
+  const overlaysRaw = env.POPS_OVERLAYS;
+
+  if (appsRaw === undefined && overlaysRaw === undefined) {
+    return knownIds;
+  }
+
+  const envSet = new Set<string>([
+    ...fromEnv(appsRaw),
+    ...fromEnv(overlaysRaw),
+    ...alwaysInstalled,
+  ]);
+  const known = new Set(knownIds);
+  return knownIds.filter((id) => envSet.has(id) && known.has(id));
+}

--- a/packages/module-registry/src/installed-modules.test.ts
+++ b/packages/module-registry/src/installed-modules.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+  vi.resetModules();
+  delete process.env.POPS_APPS;
+  delete process.env.POPS_OVERLAYS;
+});
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+});
+
+async function loadRegistry(): Promise<typeof import('./index.js')> {
+  return import('./index.js');
+}
+
+describe('INSTALLED_MODULES (runtime install-set shim, PRD-218 US-01)', () => {
+  it('equals KNOWN_MODULES when POPS_APPS and POPS_OVERLAYS are unset', async () => {
+    const mod = await loadRegistry();
+    expect([...mod.INSTALLED_MODULES]).toEqual([...mod.KNOWN_MODULES]);
+  });
+
+  it('filters to the POPS_APPS subset when set', async () => {
+    process.env.POPS_APPS = 'finance,media';
+    const mod = await loadRegistry();
+    expect([...mod.INSTALLED_MODULES].toSorted()).toEqual(['core', 'finance', 'media']);
+  });
+
+  it('always includes core even when POPS_APPS excludes it', async () => {
+    process.env.POPS_APPS = 'finance';
+    const mod = await loadRegistry();
+    expect(mod.INSTALLED_MODULES).toContain('core');
+    expect(mod.INSTALLED_MODULES).toContain('finance');
+    expect(mod.INSTALLED_MODULES).not.toContain('media');
+  });
+
+  it('drops ids that are not in KNOWN_MODULES', async () => {
+    process.env.POPS_APPS = 'finance,definitely-not-a-real-module';
+    const mod = await loadRegistry();
+    expect(mod.INSTALLED_MODULES).not.toContain('definitely-not-a-real-module');
+    expect(mod.INSTALLED_MODULES).toContain('finance');
+  });
+
+  it('unions POPS_APPS with POPS_OVERLAYS', async () => {
+    process.env.POPS_APPS = 'finance';
+    process.env.POPS_OVERLAYS = 'ego';
+    const mod = await loadRegistry();
+    expect(mod.INSTALLED_MODULES).toContain('finance');
+    expect(mod.INSTALLED_MODULES).toContain('ego');
+  });
+
+  it('treats whitespace-only POPS_APPS as empty (only core remains)', async () => {
+    process.env.POPS_APPS = '   ';
+    const mod = await loadRegistry();
+    expect([...mod.INSTALLED_MODULES]).toEqual(['core']);
+  });
+});
+
+describe('isInstalledModule (runtime install-set predicate, PRD-218 US-01)', () => {
+  it('returns true for ids in the install set', async () => {
+    process.env.POPS_APPS = 'finance';
+    const mod = await loadRegistry();
+    expect(mod.isInstalledModule('finance')).toBe(true);
+    expect(mod.isInstalledModule('core')).toBe(true);
+  });
+
+  it('returns false for ids excluded by POPS_APPS even when they are known at build time', async () => {
+    process.env.POPS_APPS = 'finance';
+    const mod = await loadRegistry();
+    expect(mod.isInstalledModule('media')).toBe(false);
+  });
+
+  it('returns false for completely unknown ids', async () => {
+    const mod = await loadRegistry();
+    expect(mod.isInstalledModule('definitely-not-a-real-module')).toBe(false);
+  });
+
+  it('returns true for every KNOWN_MODULES id when env is unset', async () => {
+    const mod = await loadRegistry();
+    for (const id of mod.KNOWN_MODULES) {
+      expect(mod.isInstalledModule(id)).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `INSTALLED_MODULES` (`readonly string[]`) and `isInstalledModule(id)` exports to `@pops/module-registry`, re-evaluating `POPS_APPS` / `POPS_OVERLAYS` against the build-time `KNOWN_MODULES` superset at module load. `core` is always included.
- Centralises the install-set resolver in `packages/module-registry/src/install-set.ts` (shared with the build path via `scripts/lib.ts`) — single source of truth for the PRD-100 env contract.
- Marks PRD-218 US-01 as Done in `docs/themes/13-pillar-finale/prds/218-module-registry-deprecation/` and adds the matching US file (the README already linked to it).

## Why

PRD-218 batch 1 (#3104) migrated 3 trivial consumers but stopped because 20 others have install-set semantics — they read `KNOWN_MODULES` and filter by `POPS_APPS` inline. A direct rename to `ALL_MODULE_IDS` (or `PILLARS`) would have dropped the env gate. With this shim, batch 2 can simply swap `isModuleId(id)` → `isInstalledModule(id)` and preserve semantics.

`KNOWN_MODULES`, `MODULES`, `isModuleId`, `findModule` remain unchanged. No consumers are migrated in this PR — that is US-02.

## Test plan

- [x] `pnpm --filter @pops/module-registry typecheck` (clean)
- [x] `pnpm --filter @pops/module-registry test` — 76 tests pass (added 24: 9 in `install-set.test.ts`, 10 in `installed-modules.test.ts`, existing `scripts/lib.test.ts` continues to pass against the relocated resolver)
- [x] `pnpm --filter @pops/module-registry build` and `pnpm registry:build` (generated.ts unchanged)
- [x] Downstream `pnpm turbo typecheck --filter @pops/api --filter @pops/shell` passes