### PR TITLE
docs(theme-13): scaffold PRD-231 cross-language wire-format spec (Wave 6)

### DIFF
--- a/docs/themes/13-pillar-finale/README.md
+++ b/docs/themes/13-pillar-finale/README.md
@@ -39,8 +39,9 @@ Theme 13 finishes the architecture. Every pillar registers itself on boot with a
 | 10  | [FE pillar SDK + dispatcher generator](epics/10-fe-sdk-dispatcher-generator.md) | React hooks against the registry; PillarGuard rewrite; nginx config generated from registry            | Not started |
 | 12  | [CI leanness](epics/12-ci-leanness.md)                                          | Path-filter audit, affected-rebuild orchestrator, docs fast-path, pillar isolation, budget enforcement | In progress |
 | 13  | [Bridge pillars (HA, MQTT, ESPHome)](epics/13-bridge-pillars.md)                | Bridge-pillar pattern per ADR-032 — `pops-ha-bridge-api` first, MQTT + ESPHome follow                  | Not started |
+| 14  | [Cross-language interop](epics/14-cross-language-interop.md)                    | Wire-format spec + conformance suite that lets non-TS pillars (Rust, Go, Python) drop in as peers      | Not started |
 
-**Dependencies:** E00 → E01 → E02 → E05 is the critical foundation path. E03 (slice migrations) can run in parallel against the foundation. E04 (batching) gates legacy router deletion. E08a is independent and can ship as a Theme 12 postscript before Theme 13 starts proper. E08b is gated on ADR-029. E09 + E10 are finishing moves. E13 is a follow-on that depends on E00 / E01 / E02 / E06 / E07 — it implements the additive integration story ADR-032 declared, not part of Theme 13's main critical path.
+**Dependencies:** E00 → E01 → E02 → E05 is the critical foundation path. E03 (slice migrations) can run in parallel against the foundation. E04 (batching) gates legacy router deletion. E08a is independent and can ship as a Theme 12 postscript before Theme 13 starts proper. E08b is gated on ADR-029. E09 + E10 are finishing moves. E13 is a follow-on that depends on E00 / E01 / E02 / E06 / E07 — it implements the additive integration story ADR-032 declared, not part of Theme 13's main critical path. E14 is the Wave 6 cross-language enabler — it documents the wire format ADR-033 commits to and gates any future non-TS pillar.
 
 ## Key Decisions
 

--- a/docs/themes/13-pillar-finale/epics/14-cross-language-interop.md
+++ b/docs/themes/13-pillar-finale/epics/14-cross-language-interop.md
@@ -1,0 +1,31 @@
+# Epic 14: Cross-language interop
+
+> Theme: [Pillar finale](../README.md)
+
+## Scope
+
+The wire-level specification, conformance harness, and reference materials that let a pillar written in Rust, Go, Python, or any other language drop into POPS as a peer of TypeScript pillars. [ADR-033](../../../architecture/adr-033-cross-language-pillar-contracts.md) commits to OpenAPI snapshots as the canonical cross-language contract surface, but OpenAPI does not fully describe the POPS tRPC-shaped wire envelope, batched-call format, subscription stream, manifest endpoint convention, or registration handshake. This epic documents that wire format precisely enough that a non-TS engineer can build a compliant pillar from the doc alone, then provides a conformance suite the pillar runs against itself to prove compliance.
+
+"Done" looks like: a Rust/Go/Python engineer reads one document, implements the required HTTP surface, points the conformance suite at their pillar, gets green, registers with the runtime registry, and TS consumers reach them via `pillar('rust-thing').something.list(...)` with no consumer-side awareness of the implementation language.
+
+## PRDs
+
+| #   | PRD                                                                                          | Summary                                                                                                                                | Status      |
+| --- | -------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| 231 | [Cross-language SDK wire-format spec](../prds/231-cross-language-wire-format-spec/README.md) | Single-page wire-format spec covering envelope, batching, subscription, manifest, registration, health + a black-box conformance suite | Not started |
+
+Parallelisation: PRD-231's user stories split into spec authoring (US-01), publication target (US-02), and the conformance harness (US-03). US-01 must land first; US-02 + US-03 can ship in parallel against the frozen spec.
+
+## Dependencies
+
+- **Requires:** [ADR-033](../../../architecture/adr-033-cross-language-pillar-contracts.md) (commits to OpenAPI as cross-language contract; this epic specifies the wire-level shape ADR-033 references), Epic 00 (contract packages — the manifest and OpenAPI snapshot this epic specs are part of the contract package surface), Epic 01 (pillar SDK is the reference TS implementation that the spec must agree with), Epic 02 (registration endpoint shape lives in this spec; the runtime endpoint lives in Epic 02), Epic 04 (`splitLink` batching strategy informs the batched-call format the spec documents)
+- **Unlocks:** PRD-233 (external Rust pillar example), any future non-TS pillar, external-repo TS consumers that prefer the OpenAPI surface over npm contract packages
+
+## Out of Scope
+
+- Per-language SDK implementations (Rust crate, Go module, Python package). [ADR-033](../../../architecture/adr-033-cross-language-pillar-contracts.md) explicitly rejects POPS-owned per-language ports. Anyone wanting an idiomatic SDK builds it themselves on top of the spec.
+- Authoring or maintaining OpenAPI codegen tooling for any language. The ecosystem already has mature generators; the spec points at them.
+- Service-mesh features (mTLS between pillars, request signing, OAuth token exchange). The docker network is the trust boundary per ADR-027.
+- Multi-instance pillar registration / load balancing. Single-instance per pillar id is the operating assumption across Theme 13.
+- Sample non-TS pillars beyond a single reference (Rust). The reference impl is PRD-233's deliverable, not this epic's.
+- Cross-host federation between POPS deployments. Single-host is the platform assumption.

--- a/docs/themes/13-pillar-finale/prds/231-cross-language-wire-format-spec/README.md
+++ b/docs/themes/13-pillar-finale/prds/231-cross-language-wire-format-spec/README.md
@@ -1,0 +1,163 @@
+# PRD-231: Cross-language SDK wire-format spec
+
+> Epic: [Cross-language interop](../../epics/14-cross-language-interop.md)
+
+> Status: Not started
+
+## Overview
+
+[ADR-033](../../../../architecture/adr-033-cross-language-pillar-contracts.md) commits POPS to OpenAPI snapshots as the canonical cross-language contract surface, but OpenAPI does not fully describe the POPS wire envelope. tRPC v11's batched httpBatchLink call shape, the SSE subscription stream, the manifest endpoint convention, the registration handshake, and the health probe are all conventions that sit _above_ the OpenAPI schema — a Rust engineer reading only `finance.openapi.json` would not know the right URL pattern for a batched call, the exact response array shape, or how to register their pillar with `core-api` on boot.
+
+This PRD ships a single-page wire-format specification: enough detail that an engineer in Rust, Go, Python, or any other language can implement a compliant pillar from the doc alone without ever reading the TypeScript SDK source. It also ships a language-agnostic conformance test suite (TS-implemented, language-agnostic in shape) that any pillar can point at itself to prove its HTTP surface is compliant before it tries to register.
+
+## Data Model
+
+This PRD has no database surface. The artifacts are documents and a test harness.
+
+### Spec artifact
+
+A single markdown file, `wire-format-spec.md` (US-02 decides publication target), with the following sections:
+
+| Section                | Content                                                                                                                             |
+| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| Versioning             | Spec semver, deprecation policy, the `X-Pops-Wire-Version` header convention                                                        |
+| Transport              | HTTP/1.1 + HTTP/2, `Content-Type: application/json; charset=utf-8`, `Content-Encoding: gzip` permitted on responses, never required |
+| Envelope               | The `{ result: { data } }` success shape and `{ error: { code, message, data } }` failure shape, with all known `code` values       |
+| Single-call procedure  | URL path, method, body shape, response shape, abort semantics                                                                       |
+| Batched procedure      | URL path encoding rules, body shape (`{"0": ..., "1": ...}`), response array shape, partial-failure semantics                       |
+| Subscription           | SSE format, event encoding, disconnect + reconnect behaviour, `Last-Event-ID` handling                                              |
+| Manifest endpoint      | `GET /manifest.json` shape, required and optional fields, JSON Schema reference, validation rules                                   |
+| Registration handshake | `POST <core_baseurl>/core.registry.register` body + headers; retry, backoff, idempotency                                            |
+| Health endpoint        | `GET /health` shape; readiness vs. liveness distinction                                                                             |
+| Error code taxonomy    | Full enum of `code` values + when each is emitted + how a compliant client should react                                             |
+| Request correlation    | `X-Request-Id` propagation rules, generation, logging convention                                                                    |
+| Conformance            | Pointer to the suite; the "compliant pillar" definition                                                                             |
+
+### Conformance suite
+
+`packages/wire-conformance/` (US-03 may relocate). A pnpm package exposing a CLI:
+
+```
+pnpm wire-conformance --base-url http://my-rust-pillar:3010 --manifest ./manifest.json
+```
+
+Runs a battery of black-box HTTP probes against the target. Outputs a green/red report per assertion (e.g. "batched response array length matches request length", "subscription emits `data:` events with trailing `\n\n`", "manifest endpoint returns a body matching `ManifestPayloadSchema`"). Exits non-zero on any failure. The suite knows nothing about the pillar's implementation language — only what bytes go on the wire.
+
+## API Surface
+
+The wire-format spec specifies the HTTP surface a compliant pillar exposes. Reproduced here in summary; the spec doc carries the full normative detail.
+
+### Single-call procedure (mutation or query)
+
+| Aspect  | Value                                                                                                                 |
+| ------- | --------------------------------------------------------------------------------------------------------------------- |
+| URL     | `POST <base_url>/trpc/<router>.<procedure>`                                                                           |
+| Headers | `Content-Type: application/json`, optional `X-Request-Id: <uuid>`, optional `X-Pops-Wire-Version: 1`                  |
+| Body    | `{ "input": <T> }` where `<T>` matches the procedure's input schema. Empty-input procedures send `{ "input": null }`. |
+| Success | `200 OK` with body `{ "result": { "data": <T> } }`                                                                    |
+| Error   | `200 OK` (tRPC errors are HTTP 200) with body `{ "error": { "code": "<ENUM>", "message": "<string>", "data": ... } }` |
+| Abort   | Client closes the TCP connection; server should observe the abort signal and stop work where possible                 |
+
+### Batched procedures (tRPC v11 httpBatchLink)
+
+| Aspect    | Value                                                                                                                            |
+| --------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| URL       | `POST <base_url>/trpc/<routerA>.<procA>,<routerB>.<procB>` — comma-separated, URL-encoded                                        |
+| Headers   | Same as single-call                                                                                                              |
+| Body      | `{ "0": { "input": <T0> }, "1": { "input": <T1> } }` — string indices matching the URL position order                            |
+| Response  | JSON array; each element is `{ "result": { "data": ... } }` OR `{ "error": ... }`, indexed by position. Status remains `200 OK`. |
+| Streaming | Out of scope for V1; the batched response is a single JSON document                                                              |
+
+### Subscription (SSE)
+
+| Aspect    | Value                                                                                                                                   |
+| --------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| URL       | `GET <base_url>/trpc/<router>.<procedure>?input=<url-encoded JSON>`                                                                     |
+| Headers   | `Accept: text/event-stream`, optional `Last-Event-ID`                                                                                   |
+| Response  | `200 OK` with `Content-Type: text/event-stream; charset=utf-8`; body is a stream of `data: <json>\n\n` events terminated by `\n\n`      |
+| Heartbeat | Server emits a comment line `: keep-alive\n\n` every 15s (configurable) to keep proxies from timing out                                 |
+| Errors    | Mid-stream errors emitted as a single event `event: error\ndata: { "code": ..., "message": ... }\n\n` then the server closes the stream |
+| Reconnect | Client may reconnect with `Last-Event-ID` to resume; the spec defines best-effort delivery, not guaranteed                              |
+
+### Manifest endpoint
+
+| Aspect   | Value                                                                                                                                       |
+| -------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| URL      | `GET <base_url>/manifest.json`                                                                                                              |
+| Headers  | None required                                                                                                                               |
+| Response | `200 OK` with body matching `ManifestPayloadSchema` (PRD-157): `pillarId`, `contract`, `searchAdapters`, `aiTools`, `sinks`, `capabilities` |
+| Caching  | `Cache-Control: no-store` — the manifest may change on every restart                                                                        |
+| Auth     | None — the manifest is public-by-design within the docker network                                                                           |
+
+All fields use shapes compatible with the published Zod schemas in `@pops/contract-<pillar>`. A non-TS pillar generates the equivalent shape from its own type system; the conformance suite validates.
+
+### Registration
+
+| Aspect   | Value                                                                                                                                  |
+| -------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| URL      | `POST <core_base_url>/trpc/core.registry.register`                                                                                     |
+| Headers  | `Content-Type: application/json`, `X-Internal-API-Key: <POPS_INTERNAL_API_KEY>` (PRD-228)                                              |
+| Body     | `{ "input": { "pillarId": <string>, "baseUrl": <string>, "manifest": <ManifestPayload>, "apiKey": <string> } }`                        |
+| Response | `{ "result": { "data": { "ok": true, "pillarId": <string>, "registeredAt": <ISO8601> } } }`                                            |
+| Retry    | Client retries with full jitter; backoff 1s → 2s → 4s → 8s → 16s capped at 30s; aborts after 5 minutes and surfaces a fatal boot error |
+
+### Health
+
+| Aspect   | Value                                                                                                                            |
+| -------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| URL      | `GET <base_url>/health`                                                                                                          |
+| Response | `200 OK` with body `{ "ok": true, "status": "healthy" \| "degraded", "pillar": <string>, "version": <string>, "ts": <ISO8601> }` |
+| Failure  | Server emits `503 Service Unavailable` with body `{ "ok": false, "status": "unhealthy", ... }` when not ready                    |
+
+## Business Rules
+
+- **Wire-format versioning is independent of contract semver.** The contract package (`@pops/contract-finance`) follows its own semver per ADR-030. The wire format itself is versioned via `X-Pops-Wire-Version`; the current spec ships as version `1`. A future `2` requires its own ADR and deprecation window.
+- **The wire format is normative for cross-language interop, even if the TS SDK diverges.** If the TS SDK and this spec disagree, the spec wins. PRs that change SDK behaviour must update the spec and the conformance suite in the same change.
+- **Content encoding is opt-in.** Servers MAY accept and emit `gzip`; clients MUST NOT require it. `Content-Encoding: identity` is always acceptable.
+- **`X-Request-Id` propagation is mandatory across the chain.** A pillar receiving a request with `X-Request-Id` MUST echo it on the response and forward it on any downstream calls. A pillar receiving a request _without_ one MUST generate a UUIDv4 and use it for logging; whether to echo it on the response is implementation-defined.
+- **Error codes use the tRPC v11 taxonomy** (`BAD_REQUEST`, `UNAUTHORIZED`, `FORBIDDEN`, `NOT_FOUND`, `METHOD_NOT_SUPPORTED`, `TIMEOUT`, `CONFLICT`, `PRECONDITION_FAILED`, `PAYLOAD_TOO_LARGE`, `UNPROCESSABLE_CONTENT`, `TOO_MANY_REQUESTS`, `CLIENT_CLOSED_REQUEST`, `INTERNAL_SERVER_ERROR`), plus a POPS-specific `PILLAR_UNAVAILABLE` for orchestrator use. New codes require a wire-format minor bump and an ADR.
+- **Batched responses preserve request order.** Position `i` in the response array corresponds to position `i` in the URL path. Out-of-order responses are non-compliant.
+- **A single bad procedure in a batched request does not fail the whole batch.** Each position is independent — successful procedures still return `{ result: { data } }`, the failing one returns `{ error }` at its index.
+- **The manifest endpoint is the source of truth for the registration payload.** A pillar's registration call MUST send a manifest that matches what `GET /manifest.json` would return at that moment. The registry trusts the pillar to be consistent.
+- **Health distinguishes liveness from readiness.** `/health` returning `200 OK` with `status: 'healthy'` means the pillar is ready for traffic. A pillar that is alive but not yet ready (e.g. running migrations) SHOULD return `503` with `status: 'unhealthy'` until it is ready. Once ready, it MUST register; the registration is the readiness signal to the registry.
+- **Conformance is a suite, not a single assertion.** A pillar is "compliant with wire-format v1" iff every assertion in the v1 conformance suite passes against it. There is no informal compliance.
+
+## Edge Cases
+
+| Case                                                                                             | Behaviour                                                                                                                                                                                       |
+| ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Batched request with a malformed entry (e.g. `{"0": "not an object"}`)                           | The entire batch fails with `400 Bad Request` and a body explaining which positions were malformed. Partial parsing is not attempted because the wire format is meant to be machine-generated.  |
+| Batched URL with one procedure that doesn't exist on the pillar                                  | The response array has `{ error: { code: 'NOT_FOUND', message: '...', data: { code: 'NOT_FOUND' } } }` at that position; other positions resolve normally.                                      |
+| Subscription disconnects mid-stream (client TCP close)                                           | Server observes the disconnect, stops emitting events, releases resources. No reconnect is attempted by the server — that is the client's responsibility.                                       |
+| Subscription disconnects mid-stream (server TCP close)                                           | Client sees the stream end without a terminal `event: complete` event. Client SHOULD reconnect with `Last-Event-ID` if it cares about best-effort delivery; the spec does not guarantee replay. |
+| Registration arrives at `core-api` with an `apiKey` that doesn't match the configured shared key | `core.registry.register` returns `{ error: { code: 'UNAUTHORIZED', message: 'invalid api key' } }`. Client SHOULD NOT retry — this is a config error.                                           |
+| Registration succeeds but heartbeats fail with `not-registered`                                  | Per PRD-161/162, the pillar re-runs the registration flow. The conformance suite asserts the retry happens.                                                                                     |
+| Manifest validation fails on registration                                                        | `core.registry.register` returns `{ error: { code: 'BAD_REQUEST', message: '...', data: { issues: [...] } } }`. Client SHOULD log and exit — a malformed manifest is a build-time bug.          |
+| Manifest endpoint returns a body that does not match `ManifestPayloadSchema`                     | Conformance suite assertion fails. The pillar is non-compliant. The registry would reject this manifest at registration time anyway.                                                            |
+| Health endpoint returns `200 OK` but body is not the expected shape                              | Conformance suite assertion fails. Compose's healthcheck probably also fails depending on how it parses the response.                                                                           |
+| Pillar receives a request with `X-Pops-Wire-Version: 2` (a future version it doesn't support)    | Pillar SHOULD respond with `{ error: { code: 'METHOD_NOT_SUPPORTED', message: 'wire version 2 not supported', data: { supportedVersions: [1] } } }`.                                            |
+| Pillar receives a request with no `X-Pops-Wire-Version` header                                   | Pillar treats it as version 1 (the floor). Clients SHOULD send the header explicitly once v2 ships, but pre-v2 absence is forgiven.                                                             |
+| Subscription request URL has malformed `input=<json>`                                            | `400 Bad Request` with `Content-Type: application/json` and body `{ error: { code: 'BAD_REQUEST', ... } }`. The response is NOT an SSE stream in this case.                                     |
+| Gzip-encoded request body sent to a pillar that doesn't support it                               | Pillar returns `{ error: { code: 'UNSUPPORTED_MEDIA_TYPE', message: 'gzip encoding not supported' } }`. Conformance suite asserts the failure mode is graceful.                                 |
+| Conformance suite is run against a TS pillar built on `@pops/pillar-sdk`                         | All assertions pass. This is the baseline compliance check that ships with the SDK's own CI.                                                                                                    |
+
+## User Stories
+
+| #   | Story                                                   | Summary                                                                                                                                                           | Parallelisable          |
+| --- | ------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- |
+| 01  | [us-01-spec-document](us-01-spec-document.md)           | Author `wire-format-spec.md` covering every section in the Data Model table. Single-page, Rust/Go/Python-readable, normative.                                     | yes — first deliverable |
+| 02  | [us-02-publication-target](us-02-publication-target.md) | Decide and execute the publication location: ship as a deliverable inside `@pops/pillar-sdk`, or as a standalone repo. Trade-offs documented.                     | blocked by us-01        |
+| 03  | [us-03-conformance-suite](us-03-conformance-suite.md)   | Build the TS-implemented, language-agnostic conformance harness as `packages/wire-conformance` with a CLI entry point and a battery of black-box HTTP assertions. | blocked by us-01        |
+
+## Out of Scope
+
+- Per-language SDK implementations. [ADR-033](../../../../architecture/adr-033-cross-language-pillar-contracts.md) explicitly rejects POPS-owned per-language ports. The spec exists so engineers can build their own.
+- OpenAPI codegen tooling recommendations beyond a pointer to mature generators (`openapi-typescript`, `openapi-codegen` for Rust, `openapi-python-client`).
+- A wire-format v2. This PRD ships v1. A future v2 needs its own ADR and a deprecation window for v1.
+- WebSocket transport for subscriptions. SSE is the only subscription mechanism in scope; WebSocket may revisit if a real-time use case justifies it.
+- Binary serialisation (Protobuf, MessagePack, CBOR). JSON-over-HTTP is the wire format. Period.
+- Cross-host authentication (mTLS, JWT, OAuth). The docker network is the trust boundary per ADR-027.
+- Streaming responses for non-subscription procedures (e.g. paginated `query` results that emit chunks). Out of scope for v1.
+- A reference Rust pillar implementation. That's PRD-233's job; this PRD only ships the spec it implements against.
+- Conformance certification or third-party validation. The suite is self-service and the result is binary green/red.
+- Performance benchmarks or SLO definitions for the wire format. Latency budgets live in the pillar SDK, not here.

--- a/docs/themes/13-pillar-finale/prds/231-cross-language-wire-format-spec/us-01-spec-document.md
+++ b/docs/themes/13-pillar-finale/prds/231-cross-language-wire-format-spec/us-01-spec-document.md
@@ -1,0 +1,31 @@
+# US-01: Author the wire-format spec document
+
+> PRD: [Cross-language SDK wire-format spec](README.md)
+
+## Description
+
+As a Rust, Go, or Python engineer wanting to ship a POPS-compatible pillar in my language of choice, I want a single normative document describing the HTTP wire format precisely so that I can implement a compliant pillar without reading the TypeScript SDK source.
+
+## Acceptance Criteria
+
+- [ ] `wire-format-spec.md` exists at the publication target chosen by US-02 and reads end-to-end on a single page (no transcluded sections, no chained references to other docs to understand the protocol).
+- [ ] Document carries a `Version: 1` header and a `Status: Stable` marker.
+- [ ] Single-call procedure section specifies the exact URL pattern (`POST /trpc/<router>.<procedure>`), the body shape (`{ "input": <T> }`), the success response (`{ "result": { "data": <T> } }`), and the error response (`{ "error": { "code", "message", "data" } }`) with worked examples.
+- [ ] Batched-procedure section specifies the URL pattern with comma-separated procedures, the body shape `{"0": ..., "1": ...}`, the response array shape, and the position-preserving rule.
+- [ ] Subscription section specifies the URL pattern, `Accept: text/event-stream`, the `data: <json>\n\n` event format, the heartbeat convention, the mid-stream error event, and the reconnect semantics.
+- [ ] Manifest endpoint section specifies `GET /manifest.json`, the required and optional fields, references `ManifestPayloadSchema` from PRD-157, and the no-store caching rule.
+- [ ] Registration handshake section specifies `POST <core>/trpc/core.registry.register`, the `X-Internal-API-Key` header, the body shape, the retry/backoff policy, and idempotency.
+- [ ] Health endpoint section specifies `GET /health`, the readiness vs. liveness distinction, and the `503` failure shape.
+- [ ] Error code section enumerates every valid `code` value (tRPC v11 codes + `PILLAR_UNAVAILABLE`) with one sentence on when each is emitted and how a compliant client should react.
+- [ ] Versioning section defines `X-Pops-Wire-Version`, the v1 floor rule, and the deprecation window policy for future versions.
+- [ ] Document explicitly disclaims OpenAPI's role and references [ADR-033](../../../../architecture/adr-033-cross-language-pillar-contracts.md): OpenAPI is the schema-level contract; this spec is the wire-level contract.
+- [ ] At least one worked example per shape (single-call, batched, subscription, manifest, registration, health) with real JSON, not pseudocode.
+- [ ] A "Compliance" section pointing at the PRD-231 conformance suite (US-03) as the binary green/red check.
+
+## Notes
+
+This document is normative for cross-language interop and will be referenced by ADRs and future PRDs. Write it precisely. The audience reads it once before writing code; ambiguity becomes a bug in someone else's runtime.
+
+Resist the temptation to include implementation guidance (e.g. "here's how to do this in Rust with `axum`"). Specify the bytes on the wire, full stop. The wire-format spec is language-agnostic by definition.
+
+When in doubt about a behaviour the TS SDK exhibits, treat the TS SDK as one implementation among many — describe what bytes a _compliant_ implementation produces, not what `@pops/pillar-sdk` happens to produce. If the SDK diverges from the spec, the SDK is the bug.

--- a/docs/themes/13-pillar-finale/prds/231-cross-language-wire-format-spec/us-02-publication-target.md
+++ b/docs/themes/13-pillar-finale/prds/231-cross-language-wire-format-spec/us-02-publication-target.md
@@ -1,0 +1,23 @@
+# US-02: Decide and execute the publication target
+
+> PRD: [Cross-language SDK wire-format spec](README.md)
+
+## Description
+
+As a maintainer needing to point external pillar authors at the wire-format spec, I want `wire-format-spec.md` published at a stable, discoverable URL so that I can link to it from ADR-033, the README, the registry's docs, and external repos without breaking when internal directory layouts change.
+
+## Acceptance Criteria
+
+- [ ] A short trade-off note exists at the top of this US's PR describing the two candidates: (a) ship as a deliverable inside `@pops/pillar-sdk` so it travels with the contract package, or (b) ship as a standalone `pops-wire-format` repo so it can be referenced without npm-installing the SDK.
+- [ ] One option is chosen with a one-paragraph justification. Default lean: (a) — co-location with the SDK keeps the spec, the conformance suite (US-03), and the reference TS implementation in lock-step. (b) is justified if and only if a concrete external consumer needs to reference the spec without depending on the SDK.
+- [ ] The spec is published at the chosen target with stable internal anchor links (`#single-call-procedure`, `#batched-procedure`, etc.) so future docs can deep-link.
+- [ ] ADR-033's `Related` section is updated to link directly to `wire-format-spec.md` at the chosen URL (currently it only references "PRD-231" by number).
+- [ ] The theme README's `## References` and Epic 14's `## Dependencies` are updated to reference the spec at the chosen URL.
+- [ ] If option (a) is chosen: a top-level `WIRE-FORMAT.md` or equivalent visible-from-the-repo-root pointer exists so engineers browsing the GitHub repo find the spec without spelunking through `packages/pillar-sdk/docs/`.
+- [ ] If option (b) is chosen: the standalone repo is initialised with a README pointing at POPS, a license, and the spec doc itself. CI is set up to validate links inside the spec.
+
+## Notes
+
+Avoid publishing the spec at two URLs. If it ends up in both a package and a docs site, one becomes stale within a release cycle. Single source of truth, mirrored _only_ via automated build steps (not by hand).
+
+The publication target is load-bearing because [ADR-033](../../../../architecture/adr-033-cross-language-pillar-contracts.md) names PRD-231 as the canonical wire-format spec. Anyone implementing a non-TS pillar follows that reference chain — make sure the destination is stable for years.

--- a/docs/themes/13-pillar-finale/prds/231-cross-language-wire-format-spec/us-03-conformance-suite.md
+++ b/docs/themes/13-pillar-finale/prds/231-cross-language-wire-format-spec/us-03-conformance-suite.md
@@ -1,0 +1,29 @@
+# US-03: Wire-format conformance suite
+
+> PRD: [Cross-language SDK wire-format spec](README.md)
+
+## Description
+
+As an engineer who has just implemented a non-TS pillar against the wire-format spec, I want to point a black-box conformance harness at my running pillar and get a binary green/red answer about whether it complies with v1, so that I know my pillar will work with the registry, the consumption SDK, and existing TS consumers before I attempt to register it.
+
+## Acceptance Criteria
+
+- [ ] A pnpm package exists at `packages/wire-conformance/` (or the location the maintainer chooses) with a CLI entry point `pnpm wire-conformance --base-url <url> --manifest <path>`.
+- [ ] The CLI accepts at minimum `--base-url`, `--manifest` (path to the expected manifest JSON), and `--report-format=json|tap|human` flags.
+- [ ] The suite runs entirely as black-box HTTP probes. No code from the target pillar is imported. No language-specific assumptions are made (no "must have a `package.json`", no "must expose a tRPC router object").
+- [ ] At least one assertion exists per section of the wire-format spec: single-call success, single-call error, batched success, batched mixed success/error, batched preserves order, subscription emits `data:` events, subscription emits `\n\n` separators, subscription heartbeat is observed, manifest endpoint returns shape matching `ManifestPayloadSchema`, health endpoint returns the documented shape, `X-Request-Id` is echoed when sent.
+- [ ] Each assertion produces a stable identifier (e.g. `WF-01-single-call-success`, `WF-04-batched-preserves-order`) referenced in the report and in the spec doc itself.
+- [ ] The suite knows how to run against `@pops/pillar-sdk` as the baseline. A CI job runs the conformance suite against every in-tree pillar on PR.
+- [ ] The suite documents how to run it against an arbitrary external pillar (URL pointing at e.g. a Rust pillar on a different docker network). The doc lives in the package README.
+- [ ] Exit code is 0 if every assertion passes, non-zero otherwise. CI consumes the exit code.
+- [ ] Each assertion's failure message says (a) which spec section it tests, (b) what was expected, (c) what was observed. No assertion fails with a stack trace pointing at the suite's internals — the failure must be actionable for the pillar author.
+- [ ] The suite is _not_ a load test, _not_ a fuzzer, _not_ a chaos test. It is a compliance check. Performance budgets and adversarial probes are explicitly out of scope.
+- [ ] A single unit test in the suite asserts the suite itself passes against a known-compliant reference (the TS in-tree finance pillar) and fails against a deliberately broken mock (e.g. a pillar that returns batched responses out of order).
+
+## Notes
+
+Implement assertions against `fetch` and `EventSource` (or `undici`'s equivalents). Avoid pulling in a heavyweight test framework — the suite needs to run from a CLI and report to CI; vitest or jest are overkill. A simple async function per assertion + a runner that aggregates results is enough.
+
+Stable assertion identifiers matter. They go into changelogs ("PR #N adds assertion WF-12-subscription-reconnect") and into the spec doc so spec readers can cross-reference. Pick an identifier scheme and stick with it.
+
+The conformance suite is the executable contract. The spec document is the human-readable version. If they disagree, fix the suite first (it's the testable artifact), then update the spec to match.


### PR DESCRIPTION
## Summary

Scaffolds **PRD-231: Cross-language SDK wire-format spec** under a new **Epic 14: Cross-language interop** in theme 13. Docs-only. No code, no acceptance criteria implemented — this is the Wave 6 PRD that makes cross-language pillars (Rust, Go, Python) actually achievable.

[ADR-033](https://github.com/knoxio/pops/blob/main/docs/architecture/adr-033-cross-language-pillar-contracts.md) commits POPS to OpenAPI snapshots as the canonical cross-language contract surface, but OpenAPI does not fully describe POPS's tRPC-shaped wire envelope, batched-call format, SSE subscription stream, manifest endpoint convention, registration handshake, or health probe. PRD-231 documents that wire format precisely enough that an engineer in Rust/Go/Python can build a compliant pillar from the doc alone without ever reading the TypeScript SDK source.

Includes:

- Single-call procedure shape (`POST /trpc/<router>.<procedure>`, `{ input }` body, `{ result: { data } }` / `{ error: { code, message, data } }` response)
- Batched tRPC v11 httpBatchLink shape (comma-separated URL, `{"0": ..., "1": ...}` body, position-preserving array response, partial-failure semantics)
- SSE subscription transport (URL, headers, `data: <json>\n\n` events, heartbeat, mid-stream error, reconnect)
- Manifest endpoint (`GET /manifest.json` matching `ManifestPayloadSchema`)
- Registration handshake (`POST <core>/trpc/core.registry.register`, `X-Internal-API-Key`, retry/backoff policy)
- Health endpoint (readiness vs. liveness, `503` failure shape)
- Wire-format versioning via `X-Pops-Wire-Version`, content-encoding rules, `X-Request-Id` propagation
- Full error code taxonomy (tRPC v11 codes + `PILLAR_UNAVAILABLE`)
- 13 documented edge cases
- A black-box, language-agnostic conformance suite that any pillar runs against itself to prove compliance

**3 user stories:** US-01 author the spec, US-02 decide and execute the publication target, US-03 build the conformance harness.

## Epic placement justification

PRD-231 sits under a **new Epic 14 (cross-language interop)** rather than Epic 02 (central registry).

Reasoning: the wire-format spec spans more surface than registration alone — it specifies the SDK envelope, the batched httpBatchLink shape, SSE subscriptions, the manifest endpoint, health, *and* registration. Epic 02's scope is the registry's own data layer + endpoints (`pillar_registry` table, `register`/`heartbeat`/`snapshot`/`subscribe` procedures). Cramming a normative cross-language wire-format spec underneath the registry epic would mis-scope both: the spec ends up listed as a sibling of "registry SQL schema" PRDs, and the registry epic loses its single-responsibility framing.

A dedicated cross-language epic also gives Wave 6's remaining PRDs (e.g. PRD-233 external Rust pillar example referenced from ADR-033) a natural home, and surfaces "cross-language pillars are a first-class concern" at the theme-README level rather than burying it as one PRD among twenty in the registry epic.

## Test plan

- [ ] Confirm `docs/themes/13-pillar-finale/epics/14-cross-language-interop.md` renders correctly on GitHub
- [ ] Confirm PRD-231 README and three US files render correctly on GitHub
- [ ] Confirm theme README's epic table includes the new Epic 14 row and the dependencies paragraph mentions E14
- [ ] No CI checks expected to run (docs-only paths-ignore on quality workflows)
