### PR TITLE
feat(app-inventory): migrate first batch of tRPC sites to pillar SDK (PRD-227)

### DIFF
--- a/packages/app-inventory/package.json
+++ b/packages/app-inventory/package.json
@@ -18,6 +18,7 @@
     "@pops/api-client": "workspace:*",
     "@pops/db-types": "workspace:*",
     "@pops/navigation": "workspace:*",
+    "@pops/pillar-sdk": "workspace:*",
     "@pops/types": "workspace:*",
     "@pops/ui": "workspace:*",
     "@tanstack/react-query": "5.101.0",

--- a/packages/app-inventory/src/components/ConnectDialog.test.tsx
+++ b/packages/app-inventory/src/components/ConnectDialog.test.tsx
@@ -6,17 +6,14 @@ const mockItemsListQuery = vi.fn();
 const mockConnectMutate = vi.fn();
 const mockConnectMutation = vi.fn();
 
-vi.mock('@pops/api-client', () => ({
-  trpc: {
-    inventory: {
-      items: {
-        list: { useQuery: (...args: unknown[]) => mockItemsListQuery(...args) },
-      },
-      connections: {
-        connect: { useMutation: (...args: unknown[]) => mockConnectMutation(...args) },
-      },
-    },
-  },
+vi.mock('@pops/pillar-sdk/react', () => ({
+  usePillarQuery: (pillarId: string, path: readonly string[], input: unknown) =>
+    mockItemsListQuery({ pillarId, path: [...path], input }),
+  usePillarMutation: (
+    pillarId: string,
+    path: readonly string[],
+    opts?: { onSuccess?: () => void; onError?: (e: { message: string }) => void }
+  ) => mockConnectMutation({ pillarId, path: [...path], ...opts }),
 }));
 
 import { ConnectDialog } from './ConnectDialog';

--- a/packages/app-inventory/src/components/ConnectDialog.tsx
+++ b/packages/app-inventory/src/components/ConnectDialog.tsx
@@ -2,10 +2,16 @@ import { Link2 } from 'lucide-react';
 import { useState } from 'react';
 import { toast } from 'sonner';
 
-import { trpc } from '@pops/api-client';
+import { usePillarMutation, usePillarQuery } from '@pops/pillar-sdk/react';
 import { AssetIdBadge, Button, SearchPickerDialog, TypeBadge } from '@pops/ui';
 
 import type { InventoryItem } from '@pops/api/modules/inventory/items/types';
+
+interface ItemsListResult {
+  data: InventoryItem[];
+}
+
+type ConnectInput = { itemAId: string; itemBId: string };
 
 interface ConnectDialogProps {
   currentItemId: string;
@@ -48,29 +54,35 @@ function ConnectResultRow({ item, disabled, onConnect }: ConnectResultRowProps) 
   );
 }
 
-export function ConnectDialog({ currentItemId, onConnected }: ConnectDialogProps) {
-  const [open, setOpen] = useState(false);
-  const [search, setSearch] = useState('');
-
-  const { data, isLoading } = trpc.inventory.items.list.useQuery(
-    { search, limit: 10 },
-    { enabled: open && search.length >= 2 }
-  );
-
-  const connectMutation = trpc.inventory.connections.connect.useMutation({
-    onSuccess: () => {
-      toast.success('Items connected');
-      onConnected();
-      setOpen(false);
-      setSearch('');
-    },
+function useConnectMutation(onSuccess: () => void) {
+  return usePillarMutation<ConnectInput, unknown>('inventory', ['connections', 'connect'], {
+    onSuccess,
     onError: (err) => {
-      if (err.data?.code === 'CONFLICT') {
+      if (err.message.toLowerCase().includes('conflict')) {
         toast.error('These items are already connected');
       } else {
         toast.error(`Failed to connect: ${err.message}`);
       }
     },
+  });
+}
+
+export function ConnectDialog({ currentItemId, onConnected }: ConnectDialogProps) {
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState('');
+
+  const { data, isLoading } = usePillarQuery<ItemsListResult>(
+    'inventory',
+    ['items', 'list'],
+    { search, limit: 10 },
+    { enabled: open && search.length >= 2 }
+  );
+
+  const connectMutation = useConnectMutation(() => {
+    toast.success('Items connected');
+    onConnected();
+    setOpen(false);
+    setSearch('');
   });
 
   const results = data?.data.filter((item: InventoryItem) => item.id !== currentItemId) ?? [];

--- a/packages/app-inventory/src/components/ConnectionGraph.tsx
+++ b/packages/app-inventory/src/components/ConnectionGraph.tsx
@@ -1,13 +1,20 @@
 import { useRef } from 'react';
 import { useNavigate } from 'react-router';
 
-import { trpc } from '@pops/api-client';
+import { usePillarQuery } from '@pops/pillar-sdk/react';
 import { Skeleton } from '@pops/ui';
 
 import { useGraphInteraction } from './connection-graph/useGraphInteraction';
 import { useGraphSimulation } from './connection-graph/useGraphSimulation';
 
 import type { GraphLink, GraphNode, Transform } from './connection-graph/types';
+
+interface GraphResult {
+  data: {
+    nodes: Array<{ id: string; itemName: string; assetId: string | null; type: string | null }>;
+    edges: Array<{ source: string; target: string }>;
+  };
+}
 
 export interface ConnectionGraphProps {
   itemId: string;
@@ -21,7 +28,12 @@ function GraphCanvas({ itemId }: { itemId: string }): React.ReactElement {
   const linksRef = useRef<GraphLink[]>([]);
   const transformRef = useRef<Transform>({ x: 0, y: 0, k: 1 });
 
-  const { data } = trpc.inventory.connections.graph.useQuery({ itemId }, { enabled: !!itemId });
+  const { data } = usePillarQuery<GraphResult>(
+    'inventory',
+    ['connections', 'graph'],
+    { itemId },
+    { enabled: !!itemId }
+  );
 
   useGraphSimulation({
     rawData: data?.data ?? null,
@@ -55,12 +67,17 @@ function GraphCanvas({ itemId }: { itemId: string }): React.ReactElement {
 }
 
 export function ConnectionGraph({ itemId }: ConnectionGraphProps): React.ReactElement {
-  const { data, isLoading, error } = trpc.inventory.connections.graph.useQuery(
+  const { data, isLoading, error, isUnavailable, isContractMismatch } = usePillarQuery<GraphResult>(
+    'inventory',
+    ['connections', 'graph'],
     { itemId },
     { enabled: !!itemId }
   );
 
   if (isLoading) return <Skeleton className="h-100 w-full rounded-lg" />;
+  if (isUnavailable || isContractMismatch) {
+    return <p className="text-sm text-muted-foreground">Connection graph unavailable.</p>;
+  }
   if (error) return <p className="text-sm text-destructive">Failed to load connection graph.</p>;
   if (!data?.data.nodes.length || data.data.nodes.length < 2) {
     return (

--- a/packages/app-inventory/src/components/ConnectionTracePanel.test.tsx
+++ b/packages/app-inventory/src/components/ConnectionTracePanel.test.tsx
@@ -10,14 +10,9 @@ vi.mock('react-router', async (importOriginal) => {
   return { ...actual, useNavigate: () => mockNavigate };
 });
 
-vi.mock('@pops/api-client', () => ({
-  trpc: {
-    inventory: {
-      connections: {
-        trace: { useQuery: (...args: unknown[]) => mockTraceQuery(...args) },
-      },
-    },
-  },
+vi.mock('@pops/pillar-sdk/react', () => ({
+  usePillarQuery: (pillarId: string, path: readonly string[], input: unknown) =>
+    mockTraceQuery({ pillarId, path: [...path], input }),
 }));
 
 vi.mock('@pops/ui', async (importOriginal) => {
@@ -62,9 +57,20 @@ function renderPanel(itemId = 'item-1') {
   );
 }
 
+function queryResult(extra: Record<string, unknown>) {
+  return {
+    data: undefined,
+    isLoading: false,
+    error: null,
+    isUnavailable: false,
+    isContractMismatch: false,
+    ...extra,
+  };
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
-  mockTraceQuery.mockReturnValue({ data: undefined, isLoading: false, error: null });
+  mockTraceQuery.mockReturnValue(queryResult({}));
 });
 
 describe('ConnectionTracePanel — loading', () => {

--- a/packages/app-inventory/src/components/ConnectionTracePanel.tsx
+++ b/packages/app-inventory/src/components/ConnectionTracePanel.tsx
@@ -2,7 +2,7 @@ import { ChevronDown, ChevronRight } from 'lucide-react';
 import { useState } from 'react';
 import { useNavigate } from 'react-router';
 
-import { trpc } from '@pops/api-client';
+import { usePillarQuery } from '@pops/pillar-sdk/react';
 /**
  * ConnectionTracePanel — displays connection chain as an expandable tree.
  *
@@ -137,12 +137,15 @@ export interface ConnectionTracePanelProps {
 }
 
 export function ConnectionTracePanel({ itemId }: ConnectionTracePanelProps) {
-  const { data, isLoading, error } = trpc.inventory.connections.trace.useQuery(
-    { itemId },
-    { enabled: !!itemId }
-  );
+  const { data, isLoading, error, isUnavailable, isContractMismatch } = usePillarQuery<{
+    data: TraceNode;
+  }>('inventory', ['connections', 'trace'], { itemId }, { enabled: !!itemId });
 
   if (isLoading) return <TraceSkeleton />;
+
+  if (isUnavailable || isContractMismatch) {
+    return <p className="text-sm text-muted-foreground">Connection chain unavailable.</p>;
+  }
 
   if (error) {
     return <p className="text-sm text-destructive">Failed to load connection trace.</p>;

--- a/packages/app-inventory/src/components/DashboardWidgets.tsx
+++ b/packages/app-inventory/src/components/DashboardWidgets.tsx
@@ -2,7 +2,7 @@ import { Clock, Shield } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router';
 
-import { trpc } from '@pops/api-client';
+import { usePillarQuery } from '@pops/pillar-sdk/react';
 import {
   Card,
   CardContent,
@@ -56,6 +56,16 @@ interface RecentItem {
   type: string | null;
   assetId: string | null;
   lastEditedTime: string;
+}
+
+interface DashboardResult {
+  data: {
+    itemCount: number;
+    totalReplacementValue: number;
+    totalResaleValue: number;
+    warrantiesExpiringSoon: number;
+    recentlyAdded: RecentItem[];
+  };
 }
 
 function RecentItemRow({ item, onOpen }: { item: RecentItem; onOpen: (id: string) => void }) {
@@ -115,10 +125,14 @@ function RecentlyAddedCard({
 export function DashboardWidgets() {
   const { t } = useTranslation('inventory');
   const navigate = useNavigate();
-  const { data, isLoading } = trpc.inventory.reports.dashboard.useQuery();
+  const { data, isLoading, isUnavailable, isContractMismatch } = usePillarQuery<DashboardResult>(
+    'inventory',
+    ['reports', 'dashboard'],
+    undefined
+  );
 
   if (isLoading) return <DashboardSkeleton />;
-  if (!data?.data) return null;
+  if (isUnavailable || isContractMismatch || !data?.data) return null;
 
   const {
     itemCount,

--- a/packages/app-inventory/src/components/LinkDocumentDialog.tsx
+++ b/packages/app-inventory/src/components/LinkDocumentDialog.tsx
@@ -2,8 +2,19 @@ import { FileText, Link2 } from 'lucide-react';
 import { useState } from 'react';
 import { toast } from 'sonner';
 
-import { trpc } from '@pops/api-client';
+import { usePillarMutation, usePillarQuery } from '@pops/pillar-sdk/react';
 import { Button, SearchPickerDialog, Select } from '@pops/ui';
+
+interface PaperlessSearchResult {
+  data: PaperlessDocResult[];
+}
+
+type LinkDocumentInput = {
+  itemId: string;
+  paperlessDocumentId: number;
+  documentType: string;
+  title: string;
+};
 
 interface PaperlessDocResult {
   id: number;
@@ -92,7 +103,7 @@ function useLinkDocumentMutation(
   setSearch: (v: string) => void,
   setLinkingId: (v: number | null) => void
 ) {
-  return trpc.inventory.documents.link.useMutation({
+  return usePillarMutation<LinkDocumentInput, unknown>('inventory', ['documents', 'link'], {
     onSuccess: () => {
       toast.success('Document linked');
       onLinked();
@@ -102,7 +113,7 @@ function useLinkDocumentMutation(
     },
     onError: (err) => {
       setLinkingId(null);
-      if (err.data?.code === 'CONFLICT') {
+      if (err.message.toLowerCase().includes('conflict')) {
         toast.error('This document is already linked to this item');
       } else {
         toast.error(`Failed to link: ${err.message}`);
@@ -117,7 +128,9 @@ export function LinkDocumentDialog({ itemId, onLinked }: LinkDocumentDialogProps
   const [docType, setDocType] = useState<DocType>('receipt');
   const [linkingId, setLinkingId] = useState<number | null>(null);
 
-  const { data, isLoading } = trpc.inventory.paperless.search.useQuery(
+  const { data, isLoading } = usePillarQuery<PaperlessSearchResult>(
+    'inventory',
+    ['paperless', 'search'],
     { query: search },
     { enabled: open && search.length >= 2 }
   );

--- a/packages/app-inventory/src/components/LocationContentsPanel.tsx
+++ b/packages/app-inventory/src/components/LocationContentsPanel.tsx
@@ -2,67 +2,19 @@ import { Package, Plus } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router';
 
-import { trpc } from '@pops/api-client';
 import { AssetIdBadge, Button, ContainerPanel, formatAUD, Skeleton, TypeBadge } from '@pops/ui';
+
+import { collectDescendantIds, useLocationItems } from './location-contents-panel-data';
 
 import type { InventoryItem } from '@pops/api/modules/inventory/items/types';
 
-interface LocationTreeNode {
-  id: string;
-  name: string;
-  parentId: string | null;
-  sortOrder: number;
-  children: LocationTreeNode[];
-}
-
-function collectDescendantIds(node: LocationTreeNode): string[] {
-  const ids: string[] = [];
-  for (const child of node.children) {
-    ids.push(child.id);
-    ids.push(...collectDescendantIds(child));
-  }
-  return ids;
-}
+import type { LocationTreeNode } from './location-contents-panel-data';
 
 export interface LocationContentsPanelProps {
   locationId: string;
   locationName: string;
   breadcrumb: string[];
   node: LocationTreeNode;
-}
-
-function useLocationItems(
-  locationId: string,
-  descendantIds: string[],
-  includeSubLocations: boolean
-) {
-  const hasSubLocations = descendantIds.length > 0;
-  const { data: directData, isLoading: directLoading } = trpc.inventory.items.list.useQuery({
-    locationId,
-    limit: 200,
-  });
-  const subLocationQueries = trpc.useQueries((t) =>
-    includeSubLocations && hasSubLocations
-      ? descendantIds.map((id) => t.inventory.items.list({ locationId: id, limit: 200 }))
-      : []
-  );
-
-  const subLocationItems = useMemo(() => {
-    if (!includeSubLocations || !hasSubLocations) return [];
-    return subLocationQueries.flatMap((q) => q.data?.data ?? []);
-  }, [includeSubLocations, hasSubLocations, subLocationQueries]);
-
-  const allItems = useMemo(() => {
-    const direct = directData?.data ?? [];
-    if (!includeSubLocations) return direct;
-    return [...direct, ...subLocationItems];
-  }, [directData, includeSubLocations, subLocationItems]);
-
-  const isLoading =
-    directLoading ||
-    (includeSubLocations && hasSubLocations && subLocationQueries.some((q) => q.isLoading));
-
-  return { allItems, isLoading, hasSubLocations };
 }
 
 function ItemsList({

--- a/packages/app-inventory/src/components/ValueBreakdown.test.tsx
+++ b/packages/app-inventory/src/components/ValueBreakdown.test.tsx
@@ -58,14 +58,12 @@ vi.mock('react-router', async () => {
 const mockValueByTypeQuery = vi.fn();
 const mockValueByLocationQuery = vi.fn();
 
-vi.mock('@pops/api-client', () => ({
-  trpc: {
-    inventory: {
-      reports: {
-        valueByType: { useQuery: () => mockValueByTypeQuery() },
-        valueByLocation: { useQuery: () => mockValueByLocationQuery() },
-      },
-    },
+vi.mock('@pops/pillar-sdk/react', () => ({
+  usePillarQuery: (pillarId: string, path: readonly string[]) => {
+    const leaf = path[path.length - 1];
+    if (leaf === 'valueByType') return mockValueByTypeQuery();
+    if (leaf === 'valueByLocation') return mockValueByLocationQuery();
+    throw new Error(`Unexpected pillar query: ${pillarId}.${path.join('.')}`);
   },
 }));
 

--- a/packages/app-inventory/src/components/ValueBreakdown.tsx
+++ b/packages/app-inventory/src/components/ValueBreakdown.tsx
@@ -2,12 +2,16 @@ import { AlertCircle, MapPin, RefreshCw, Tag } from 'lucide-react';
 import { useNavigate } from 'react-router';
 import { Bar, BarChart, Cell, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 
-import { trpc } from '@pops/api-client';
+import { usePillarQuery } from '@pops/pillar-sdk/react';
 /**
  * Value breakdown cards — horizontal bar charts showing replacement value
  * grouped by item type or location.
  */
 import { Alert, AlertDescription, Button, Card, CardContent, Skeleton } from '@pops/ui';
+
+interface BreakdownResult {
+  data: BreakdownEntry[];
+}
 
 import { formatCurrency } from '../lib/utils';
 
@@ -115,8 +119,11 @@ export function ValueByTypeCard({ className }: { className?: string }) {
     isLoading: typeLoading,
     isError: typeError,
     refetch: refetchType,
-  } = trpc.inventory.reports.valueByType.useQuery();
+    isUnavailable: typeUnavailable,
+    isContractMismatch: typeContractMismatch,
+  } = usePillarQuery<BreakdownResult>('inventory', ['reports', 'valueByType'], undefined);
 
+  if (typeUnavailable || typeContractMismatch) return null;
   if (typeLoading) {
     return (
       <Card className={className}>
@@ -167,8 +174,11 @@ export function ValueByLocationCard({ className }: { className?: string }) {
     isLoading: locationLoading,
     isError: locationError,
     refetch: refetchLocation,
-  } = trpc.inventory.reports.valueByLocation.useQuery();
+    isUnavailable: locationUnavailable,
+    isContractMismatch: locationContractMismatch,
+  } = usePillarQuery<BreakdownResult>('inventory', ['reports', 'valueByLocation'], undefined);
 
+  if (locationUnavailable || locationContractMismatch) return null;
   if (locationLoading) {
     return (
       <Card className={className}>

--- a/packages/app-inventory/src/components/location-contents-panel-data.ts
+++ b/packages/app-inventory/src/components/location-contents-panel-data.ts
@@ -1,0 +1,79 @@
+import { useQueries } from '@tanstack/react-query';
+import { useMemo } from 'react';
+
+import { pillar, PillarCallError } from '@pops/pillar-sdk/client';
+import { pillarQueryKey, usePillarQuery, usePillarSdkOptions } from '@pops/pillar-sdk/react';
+
+import type { InventoryItem } from '@pops/api/modules/inventory/items/types';
+
+export interface ItemsListResult {
+  data: InventoryItem[];
+}
+
+export interface LocationTreeNode {
+  id: string;
+  name: string;
+  parentId: string | null;
+  sortOrder: number;
+  children: LocationTreeNode[];
+}
+
+export function collectDescendantIds(node: LocationTreeNode): string[] {
+  const ids: string[] = [];
+  for (const child of node.children) {
+    ids.push(child.id);
+    ids.push(...collectDescendantIds(child));
+  }
+  return ids;
+}
+
+export function useLocationItems(
+  locationId: string,
+  descendantIds: string[],
+  includeSubLocations: boolean
+) {
+  const hasSubLocations = descendantIds.length > 0;
+  const sdkOptions = usePillarSdkOptions();
+  const { data: directData, isLoading: directLoading } = usePillarQuery<ItemsListResult>(
+    'inventory',
+    ['items', 'list'],
+    { locationId, limit: 200 }
+  );
+
+  const subLocationQueries = useQueries({
+    queries:
+      includeSubLocations && hasSubLocations
+        ? descendantIds.map((id) => {
+            const input = { locationId: id, limit: 200 };
+            return {
+              queryKey: pillarQueryKey('inventory', ['items', 'list'], input),
+              queryFn: async (): Promise<ItemsListResult> => {
+                const handle = pillar<{
+                  items: { list: (i: unknown) => Promise<unknown> };
+                }>('inventory', sdkOptions);
+                const result = await handle.items.list(input);
+                if (result.kind === 'ok') return result.value as ItemsListResult;
+                throw new PillarCallError('inventory', result);
+              },
+            };
+          })
+        : [],
+  });
+
+  const subLocationItems = useMemo(() => {
+    if (!includeSubLocations || !hasSubLocations) return [];
+    return subLocationQueries.flatMap((q) => q.data?.data ?? []);
+  }, [includeSubLocations, hasSubLocations, subLocationQueries]);
+
+  const allItems = useMemo(() => {
+    const direct = directData?.data ?? [];
+    if (!includeSubLocations) return direct;
+    return [...direct, ...subLocationItems];
+  }, [directData, includeSubLocations, subLocationItems]);
+
+  const isLoading =
+    directLoading ||
+    (includeSubLocations && hasSubLocations && subLocationQueries.some((q) => q.isLoading));
+
+  return { allItems, isLoading, hasSubLocations };
+}

--- a/packages/app-inventory/src/lib/pillar-call.ts
+++ b/packages/app-inventory/src/lib/pillar-call.ts
@@ -1,0 +1,49 @@
+import { useCallback } from 'react';
+
+import { pillar, type CallResult } from '@pops/pillar-sdk/client';
+import { usePillarSdkOptions } from '@pops/pillar-sdk/react';
+
+type ProcedurePath = readonly [string, ...string[]];
+
+/**
+ * Imperative one-shot call against a pillar procedure. Mirrors the discontinued
+ * `trpc.useUtils().<pillar>.<path>.fetch(input)` pattern (no caching, no
+ * suspense) so existing call sites that need an ad-hoc lookup — e.g. asset-id
+ * uniqueness checks fired from a form blur — can continue to work without
+ * pulling React Query state into the flow.
+ *
+ * Returns the raw `CallResult` so callers can branch on `kind === 'ok'`
+ * versus the `unavailable` / `contract-mismatch` / `degraded` discriminants.
+ */
+export function usePillarCall(): <TOutput>(
+  pillarId: string,
+  path: ProcedurePath,
+  input: unknown
+) => Promise<CallResult<TOutput>> {
+  const sdkOptions = usePillarSdkOptions();
+  return useCallback(
+    async <TOutput>(
+      pillarId: string,
+      path: ProcedurePath,
+      input: unknown
+    ): Promise<CallResult<TOutput>> => {
+      const handle = pillar<unknown>(pillarId, sdkOptions);
+      let node: unknown = handle;
+      for (let i = 0; i < path.length - 1; i += 1) {
+        const segment = path[i] as string;
+        node = (node as Record<string, unknown>)[segment];
+      }
+      const leafName = path[path.length - 1] as string;
+      const leaf = (node as Record<string, unknown>)[leafName];
+      if (typeof leaf !== 'function') {
+        return {
+          kind: 'contract-mismatch',
+          pillar: pillarId,
+          actual: path.join('.'),
+        };
+      }
+      return (leaf as (i: unknown) => Promise<CallResult<TOutput>>)(input);
+    },
+    [sdkOptions]
+  );
+}

--- a/packages/app-inventory/src/pages/InsuranceReportPage.test.tsx
+++ b/packages/app-inventory/src/pages/InsuranceReportPage.test.tsx
@@ -14,20 +14,12 @@ vi.mock('react-router', async () => {
   };
 });
 
-vi.mock('@pops/api-client', () => ({
-  trpc: {
-    inventory: {
-      reports: {
-        insuranceReport: {
-          useQuery: (...args: unknown[]) => mockInsuranceReportQuery(...args),
-        },
-      },
-      locations: {
-        tree: {
-          useQuery: (...args: unknown[]) => mockLocationsTreeQuery(...args),
-        },
-      },
-    },
+vi.mock('@pops/pillar-sdk/react', () => ({
+  usePillarQuery: (_pillarId: string, path: readonly string[], input: unknown) => {
+    const key = path.join('.');
+    if (key === 'reports.insuranceReport') return mockInsuranceReportQuery(input);
+    if (key === 'locations.tree') return mockLocationsTreeQuery();
+    throw new Error(`Unexpected pillar query: ${key}`);
   },
 }));
 

--- a/packages/app-inventory/src/pages/ItemDetailPage.test.tsx
+++ b/packages/app-inventory/src/pages/ItemDetailPage.test.tsx
@@ -60,6 +60,20 @@ vi.mock('../components/ConnectionGraph', () => ({
   ConnectionGraph: () => <div data-testid="connection-graph" />,
 }));
 
+vi.mock('@pops/pillar-sdk/react', () => ({
+  usePillarQuery: (_pillarId: string, path: readonly string[], input: unknown) => {
+    const key = path.join('.');
+    if (key === 'items.get') return mockItemQuery(input);
+    if (key === 'connections.listForItem') return mockConnectionsQuery(input);
+    return { data: undefined, isLoading: false, isUnavailable: false, isContractMismatch: false };
+  },
+  usePillarMutation: (_pillarId: string, path: readonly string[], opts?: unknown) => {
+    const key = path.join('.');
+    if (key === 'connections.disconnect') return mockDisconnectMutation(opts);
+    return { mutate: vi.fn(), isPending: false };
+  },
+}));
+
 // Mock react-markdown
 vi.mock('react-markdown', () => ({
   default: ({ children }: { children: string }) => (

--- a/packages/app-inventory/src/pages/ReportDashboardPage.test.tsx
+++ b/packages/app-inventory/src/pages/ReportDashboardPage.test.tsx
@@ -7,14 +7,12 @@ const mocks = vi.hoisted(() => ({
   valueByTypeQuery: vi.fn(),
 }));
 
-vi.mock('@pops/api-client', () => ({
-  trpc: {
-    inventory: {
-      reports: {
-        dashboard: { useQuery: () => mocks.dashboardQuery() },
-        valueByType: { useQuery: () => mocks.valueByTypeQuery() },
-      },
-    },
+vi.mock('@pops/pillar-sdk/react', () => ({
+  usePillarQuery: (_pillarId: string, path: readonly string[]) => {
+    const key = path.join('.');
+    if (key === 'reports.dashboard') return mocks.dashboardQuery();
+    if (key === 'reports.valueByType') return mocks.valueByTypeQuery();
+    throw new Error(`Unexpected pillar query: ${key}`);
   },
 }));
 

--- a/packages/app-inventory/src/pages/WarrantiesPage.test.tsx
+++ b/packages/app-inventory/src/pages/WarrantiesPage.test.tsx
@@ -5,20 +5,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mockWarrantiesQuery = vi.fn();
 const mockPaperlessStatusQuery = vi.fn();
 
-vi.mock('@pops/api-client', () => ({
-  trpc: {
-    inventory: {
-      reports: {
-        warranties: {
-          useQuery: (...args: unknown[]) => mockWarrantiesQuery(...args),
-        },
-      },
-      paperless: {
-        status: {
-          useQuery: (...args: unknown[]) => mockPaperlessStatusQuery(...args),
-        },
-      },
-    },
+vi.mock('@pops/pillar-sdk/react', () => ({
+  usePillarQuery: (pillarId: string, path: readonly string[]) => {
+    const key = path.join('.');
+    if (key === 'reports.warranties') return mockWarrantiesQuery();
+    if (key === 'paperless.status') return mockPaperlessStatusQuery();
+    throw new Error(`Unexpected pillar query: ${pillarId}.${key}`);
   },
 }));
 

--- a/packages/app-inventory/src/pages/WarrantiesPage.tsx
+++ b/packages/app-inventory/src/pages/WarrantiesPage.tsx
@@ -3,13 +3,27 @@ import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router';
 
-import { trpc } from '@pops/api-client';
+import { usePillarQuery } from '@pops/pillar-sdk/react';
 import { PageHeader } from '@pops/ui';
 
 import { CollapsibleSection, ExpiringSection } from './warranties-page/sections';
 import { EmptyState, ErrorState, WarrantySkeleton } from './warranties-page/states';
 import { categorizeWarranties, type WarrantyTiers } from './warranties-page/utils';
 import { WarrantyRow } from './warranties-page/WarrantyRow';
+
+import type { WarrantyItem } from './warranties-page/types';
+
+interface WarrantiesResult {
+  data: WarrantyItem[];
+}
+
+interface PaperlessStatusResult {
+  data: {
+    configured: boolean;
+    available: boolean;
+    baseUrl: string | null;
+  };
+}
 
 interface WarrantyContentProps {
   tiers: WarrantyTiers;
@@ -108,8 +122,13 @@ function WarrantiesBody({
 export function WarrantiesPage() {
   const { t } = useTranslation('inventory');
   const navigate = useNavigate();
-  const { data, isLoading, isError, refetch } = trpc.inventory.reports.warranties.useQuery();
-  const { data: paperlessData } = trpc.inventory.paperless.status.useQuery();
+  const { data, isLoading, isError, refetch, isUnavailable, isContractMismatch } =
+    usePillarQuery<WarrantiesResult>('inventory', ['reports', 'warranties'], undefined);
+  const { data: paperlessData } = usePillarQuery<PaperlessStatusResult>(
+    'inventory',
+    ['paperless', 'status'],
+    undefined
+  );
   const paperlessBaseUrl = paperlessData?.data?.available ? paperlessData.data.baseUrl : null;
   const tiers = useMemo(() => categorizeWarranties(data?.data ?? []), [data]);
 
@@ -125,7 +144,7 @@ export function WarrantiesPage() {
       />
       <WarrantiesBody
         isLoading={isLoading}
-        isError={isError}
+        isError={isError || isUnavailable || isContractMismatch}
         tiers={tiers}
         paperlessBaseUrl={paperlessBaseUrl}
         onRetry={() => refetch()}

--- a/packages/app-inventory/src/pages/insurance-report-page/useReportModel.ts
+++ b/packages/app-inventory/src/pages/insurance-report-page/useReportModel.ts
@@ -1,23 +1,29 @@
 import { useCallback } from 'react';
 import { useSearchParams } from 'react-router';
 
-import { trpc } from '@pops/api-client';
+import { usePillarQuery } from '@pops/pillar-sdk/react';
+
+import type { LocationTreeNode } from '../../components/LocationPicker';
+import type { ReportGroup } from './csv';
 
 type SortBy = 'value' | 'name' | 'type';
 
-export function useReportModel() {
-  const [searchParams, setSearchParams] = useSearchParams();
-  const locationId = searchParams.get('locationId') ?? undefined;
-  const includeChildren = searchParams.get('includeChildren') !== 'false';
-  const sortBy = (searchParams.get('sortBy') as SortBy) || 'value';
+interface InsuranceReport {
+  totalItems: number;
+  totalValue: number;
+  groups: ReportGroup[];
+}
 
-  const { data, isLoading } = trpc.inventory.reports.insuranceReport.useQuery({
-    locationId,
-    includeChildren: locationId ? includeChildren : undefined,
-    sortBy,
-  });
-  const { data: locationsData } = trpc.inventory.locations.tree.useQuery();
-  const locationTree = locationsData?.data ?? [];
+interface InsuranceReportResult {
+  data: InsuranceReport;
+}
+
+interface LocationsTreeResult {
+  data: LocationTreeNode[];
+}
+
+function useSearchParamHelpers() {
+  const [, setSearchParams] = useSearchParams();
 
   const updateParam = useCallback(
     (key: string, value: string | null) => {
@@ -53,13 +59,34 @@ export function useReportModel() {
     [setSearchParams]
   );
 
+  return { updateParam, handleLocationChange };
+}
+
+export function useReportModel() {
+  const [searchParams] = useSearchParams();
+  const locationId = searchParams.get('locationId') ?? undefined;
+  const includeChildren = searchParams.get('includeChildren') !== 'false';
+  const sortBy = (searchParams.get('sortBy') as SortBy) || 'value';
+
+  const { data, isLoading } = usePillarQuery<InsuranceReportResult>(
+    'inventory',
+    ['reports', 'insuranceReport'],
+    { locationId, includeChildren: locationId ? includeChildren : undefined, sortBy }
+  );
+  const { data: locationsData } = usePillarQuery<LocationsTreeResult>(
+    'inventory',
+    ['locations', 'tree'],
+    undefined
+  );
+  const { updateParam, handleLocationChange } = useSearchParamHelpers();
+
   return {
     locationId,
     includeChildren,
     sortBy,
     report: data?.data,
     isLoading,
-    locationTree,
+    locationTree: locationsData?.data ?? [],
     updateParam,
     handleLocationChange,
   };

--- a/packages/app-inventory/src/pages/item-detail-page/sections/ConnectionsSection.tsx
+++ b/packages/app-inventory/src/pages/item-detail-page/sections/ConnectionsSection.tsx
@@ -2,7 +2,7 @@ import { GitBranch, Link2, Network, Unlink } from 'lucide-react';
 import { useState } from 'react';
 import { Link } from 'react-router';
 
-import { trpc } from '@pops/api-client';
+import { usePillarQuery } from '@pops/pillar-sdk/react';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -34,7 +34,14 @@ function ConnectionRow({
   onDisconnect: () => void;
   isDisconnecting: boolean;
 }) {
-  const { data } = trpc.inventory.items.get.useQuery({ id: connectedItemId });
+  const { data } = usePillarQuery<{
+    data: {
+      itemName: string;
+      brand: string | null;
+      assetId: string | null;
+      type: string | null;
+    } | null;
+  }>('inventory', ['items', 'get'], { id: connectedItemId });
   const item = data?.data;
   const itemName = item?.itemName ?? connectedItemId;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1429,6 +1429,9 @@ importers:
       '@pops/navigation':
         specifier: workspace:*
         version: link:../navigation
+      '@pops/pillar-sdk':
+        specifier: workspace:*
+        version: link:../pillar-sdk
       '@pops/types':
         specifier: workspace:*
         version: link:../types


### PR DESCRIPTION
## Summary

Migrates the alphabetically-first 10 source files in `packages/app-inventory/src/` from `@pops/api-client` (tRPC) to `@pops/pillar-sdk` (PRD-227 first half).

- Each callsite now uses `usePillarQuery<T>` / `usePillarMutation<T>` and surfaces graceful-degrade via `isUnavailable` / `isContractMismatch` flags.
- Adds `src/lib/pillar-call.ts` for the imperative `trpc.useUtils().fetch()` shape the form-page batch will need next.
- Page-level tests for partially-migrated pages (`InsuranceReportPage`, `ReportDashboardPage`, `ItemDetailPage`) flip their `@pops/api-client` mock to a `@pops/pillar-sdk/react` path mock. `ItemDetailPage` keeps both mocks because `useItemDetailPageModel` still calls tRPC until batch 2.

Files migrated (10):

- `components/ConnectDialog.tsx` (+ test)
- `components/ConnectionGraph.tsx`
- `components/ConnectionTracePanel.tsx` (+ test)
- `components/DashboardWidgets.tsx`
- `components/LinkDocumentDialog.tsx`
- `components/LocationContentsPanel.tsx`
- `components/ValueBreakdown.tsx` (+ test)
- `pages/WarrantiesPage.tsx` (+ test)
- `pages/insurance-report-page/useReportModel.ts`
- `pages/item-detail-page/sections/ConnectionsSection.tsx`

`@pops/api-client` stays in deps for the 11 remaining tRPC sites (batch 2 will drop it).

## Test plan

- [x] `pnpm --filter @pops/app-inventory typecheck` (clean)
- [x] `pnpm --filter @pops/app-inventory test` (372/372 passing)
- [x] `pnpm typecheck` (66/66 packages clean)
