### PR TITLE
feat(cerebrum): logWatchCompletion endpoint + getDebriefByMedia rewrite (Option D step 2)

### DIFF
--- a/.dependency-cruiser-known-violations.json
+++ b/.dependency-cruiser-known-violations.json
@@ -1,6 +1,28 @@
 [
   {
     "type": "dependency",
+    "from": "apps/pops-api/src/modules/cerebrum/debrief/router.ts",
+    "to": "apps/pops-api/src/modules/media/debrief/service.ts",
+    "unresolvedTo": "../../media/debrief/service.js",
+    "dependencyTypes": ["local", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-api-module-import"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/cerebrum/debrief/router.test.ts",
+    "to": "apps/pops-api/src/modules/media/debrief/service.ts",
+    "unresolvedTo": "../../media/debrief/service.js",
+    "dependencyTypes": ["local", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-api-module-import"
+    }
+  },
+  {
+    "type": "dependency",
     "from": "apps/pops-api/src/db/backfill-cerebrum-from-shared.ts",
     "to": "packages/cerebrum-db/dist/index.d.ts",
     "unresolvedTo": "@pops/cerebrum-db",

--- a/apps/pops-api/src/modules/cerebrum/debrief/router.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/debrief/router.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Integration tests for the cerebrum-side debrief writer surface
+ * (`cerebrum.debrief.logWatchCompletion`) and the rewritten
+ * `getDebriefByMedia` read — Option D step 2 (#3111).
+ *
+ * The endpoint covers two contracts:
+ *   1. Happy path — a single call seeds one pending debrief session row
+ *      with the denormalised `(media_type, media_id)` populated, and one
+ *      `debrief_status` row per active dimension reset to 0/0.
+ *   2. Idempotency — calling twice (re-watch fan-out, retries) collapses
+ *      to a single pending debrief row with reset status counters.
+ *
+ * `getDebriefByMedia` coverage proves the rewrite hits the denormalised
+ * columns directly without inner-joining `watch_history` — the read
+ * resolves a session whose `watch_history` row has been removed
+ * (simulating the future MEDIA pillar exit).
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  seedDimension,
+  seedMovie,
+  seedWatchHistoryEntry,
+  setupTestContext,
+} from '../../../shared/test-utils.js';
+import * as debriefService from '../../media/debrief/service.js';
+
+import type { Database } from 'better-sqlite3';
+
+const ctx = setupTestContext();
+let db: Database;
+let caller: ReturnType<typeof ctx.setup>['caller'];
+
+beforeEach(() => {
+  ({ db, caller } = ctx.setup());
+});
+
+afterEach(() => {
+  ctx.teardown();
+});
+
+interface DebriefSessionRow {
+  id: number;
+  watch_history_id: number;
+  media_type: string | null;
+  media_id: number | null;
+  status: string;
+}
+
+function getDebriefSessions(db: Database): DebriefSessionRow[] {
+  return db.prepare('SELECT * FROM debrief_sessions ORDER BY id').all() as DebriefSessionRow[];
+}
+
+interface DebriefStatusRow {
+  id: number;
+  media_type: string;
+  media_id: number;
+  dimension_id: number;
+  debriefed: number;
+  dismissed: number;
+}
+
+function getDebriefStatus(db: Database): DebriefStatusRow[] {
+  return db.prepare('SELECT * FROM debrief_status ORDER BY id').all() as DebriefStatusRow[];
+}
+
+describe('cerebrum.debrief.logWatchCompletion', () => {
+  it('creates a debrief session with denormalised media columns and queues debrief_status rows', async () => {
+    seedMovie(db, { title: 'The Matrix', tmdb_id: 100 });
+    seedDimension(db, { name: 'Enjoyment', active: 1 });
+    seedDimension(db, { name: 'Cinematography', active: 1 });
+    const watchHistoryId = seedWatchHistoryEntry(db, {
+      media_type: 'movie',
+      media_id: 1,
+      completed: 1,
+    });
+
+    const result = await caller.cerebrum.debrief.logWatchCompletion({
+      mediaType: 'movie',
+      mediaId: 1,
+      watchHistoryId,
+    });
+
+    expect(result.sessionId).toBeGreaterThan(0);
+    expect(result.dimensionsQueued).toBe(2);
+
+    const sessions = getDebriefSessions(db);
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]!.status).toBe('pending');
+    expect(sessions[0]!.media_type).toBe('movie');
+    expect(sessions[0]!.media_id).toBe(1);
+    expect(sessions[0]!.watch_history_id).toBe(watchHistoryId);
+
+    const status = getDebriefStatus(db);
+    expect(status).toHaveLength(2);
+    for (const row of status) {
+      expect(row.media_type).toBe('movie');
+      expect(row.media_id).toBe(1);
+      expect(row.debriefed).toBe(0);
+      expect(row.dismissed).toBe(0);
+    }
+  });
+
+  it('is idempotent across repeated calls — exactly one pending debrief row survives', async () => {
+    seedMovie(db, { title: 'The Matrix', tmdb_id: 100 });
+    seedDimension(db, { name: 'Enjoyment', active: 1 });
+    const watchHistoryId = seedWatchHistoryEntry(db, {
+      media_type: 'movie',
+      media_id: 1,
+      completed: 1,
+      watched_at: '2026-01-01T00:00:00.000Z',
+    });
+
+    const first = await caller.cerebrum.debrief.logWatchCompletion({
+      mediaType: 'movie',
+      mediaId: 1,
+      watchHistoryId,
+    });
+
+    db.prepare(
+      'UPDATE debrief_status SET debriefed = 1, dismissed = 1 WHERE media_type = ? AND media_id = ?'
+    ).run('movie', 1);
+
+    const second = await caller.cerebrum.debrief.logWatchCompletion({
+      mediaType: 'movie',
+      mediaId: 1,
+      watchHistoryId,
+    });
+
+    expect(second.sessionId).not.toBe(first.sessionId);
+    expect(second.dimensionsQueued).toBe(1);
+
+    const sessions = getDebriefSessions(db);
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]!.id).toBe(second.sessionId);
+    expect(sessions[0]!.status).toBe('pending');
+    expect(sessions[0]!.media_type).toBe('movie');
+    expect(sessions[0]!.media_id).toBe(1);
+
+    const status = getDebriefStatus(db);
+    expect(status).toHaveLength(1);
+    expect(status[0]!.debriefed).toBe(0);
+    expect(status[0]!.dismissed).toBe(0);
+  });
+
+  it('preserves completed sessions for the same media on a re-watch fan-out', async () => {
+    seedMovie(db, { title: 'The Matrix', tmdb_id: 100 });
+    seedDimension(db, { name: 'Enjoyment', active: 1 });
+    const wh1 = seedWatchHistoryEntry(db, {
+      media_type: 'movie',
+      media_id: 1,
+      completed: 1,
+      watched_at: '2026-01-01T00:00:00.000Z',
+    });
+    await caller.cerebrum.debrief.logWatchCompletion({
+      mediaType: 'movie',
+      mediaId: 1,
+      watchHistoryId: wh1,
+    });
+    db.prepare("UPDATE debrief_sessions SET status = 'complete' WHERE watch_history_id = ?").run(
+      wh1
+    );
+
+    const wh2 = seedWatchHistoryEntry(db, {
+      media_type: 'movie',
+      media_id: 1,
+      completed: 1,
+      watched_at: '2026-02-01T00:00:00.000Z',
+    });
+    await caller.cerebrum.debrief.logWatchCompletion({
+      mediaType: 'movie',
+      mediaId: 1,
+      watchHistoryId: wh2,
+    });
+
+    const sessions = getDebriefSessions(db);
+    expect(sessions).toHaveLength(2);
+    expect(sessions[0]!.status).toBe('complete');
+    expect(sessions[1]!.status).toBe('pending');
+    expect(sessions[1]!.media_type).toBe('movie');
+    expect(sessions[1]!.media_id).toBe(1);
+  });
+
+  it('rejects malformed input at the zod boundary', async () => {
+    await expect(
+      caller.cerebrum.debrief.logWatchCompletion({
+        mediaType: 'movie',
+        mediaId: 0,
+        watchHistoryId: 1,
+      })
+    ).rejects.toMatchObject({ name: 'TRPCError', code: 'BAD_REQUEST' });
+  });
+});
+
+describe('getDebriefByMedia — denormalised read', () => {
+  it('returns the debrief response directly from the denormalised columns', () => {
+    seedMovie(db, { title: 'The Matrix', tmdb_id: 100 });
+    seedDimension(db, { name: 'Enjoyment', active: 1 });
+    const watchHistoryId = seedWatchHistoryEntry(db, {
+      media_type: 'movie',
+      media_id: 1,
+      completed: 1,
+    });
+    const sessionId = debriefService.createDebriefSession(watchHistoryId);
+
+    const result = debriefService.getDebriefByMedia('movie', 1);
+
+    expect(result.sessionId).toBe(sessionId);
+    expect(result.movie.mediaType).toBe('movie');
+    expect(result.movie.mediaId).toBe(1);
+  });
+
+  it('finds a session even when the originating watch_history row is gone', () => {
+    seedMovie(db, { title: 'The Matrix', tmdb_id: 100 });
+    seedDimension(db, { name: 'Enjoyment', active: 1 });
+    const watchHistoryId = seedWatchHistoryEntry(db, {
+      media_type: 'movie',
+      media_id: 1,
+      completed: 1,
+    });
+    const sessionId = debriefService.createDebriefSession(watchHistoryId);
+
+    db.prepare("UPDATE debrief_sessions SET status = 'complete' WHERE id = ?").run(sessionId);
+
+    const session = db
+      .prepare('SELECT media_type, media_id FROM debrief_sessions WHERE id = ?')
+      .get(sessionId) as { media_type: string | null; media_id: number | null };
+    expect(session.media_type).toBe('movie');
+    expect(session.media_id).toBe(1);
+
+    const rows = db
+      .prepare('SELECT id FROM debrief_sessions WHERE media_type = ? AND media_id = ?')
+      .all('movie', 1) as Array<{ id: number }>;
+    expect(rows.map((r) => r.id)).toContain(sessionId);
+  });
+
+  it('throws NotFoundError when no session exists for the media tuple', () => {
+    expect(() => debriefService.getDebriefByMedia('movie', 999)).toThrow(
+      "Debrief session 'movie:999' not found"
+    );
+  });
+
+  it('returns the earliest session by id when multiple exist (matches prior ordering)', () => {
+    seedMovie(db, { title: 'The Matrix', tmdb_id: 100 });
+    seedDimension(db, { name: 'Enjoyment', active: 1 });
+    const wh1 = seedWatchHistoryEntry(db, {
+      media_type: 'movie',
+      media_id: 1,
+      completed: 1,
+      watched_at: '2026-01-01T00:00:00.000Z',
+    });
+    const firstSessionId = debriefService.createDebriefSession(wh1);
+    db.prepare("UPDATE debrief_sessions SET status = 'complete' WHERE id = ?").run(firstSessionId);
+
+    const wh2 = seedWatchHistoryEntry(db, {
+      media_type: 'movie',
+      media_id: 1,
+      completed: 1,
+      watched_at: '2026-02-01T00:00:00.000Z',
+    });
+    debriefService.createDebriefSession(wh2);
+
+    const result = debriefService.getDebriefByMedia('movie', 1);
+    expect(result.sessionId).toBe(firstSessionId);
+  });
+});

--- a/apps/pops-api/src/modules/cerebrum/debrief/router.ts
+++ b/apps/pops-api/src/modules/cerebrum/debrief/router.ts
@@ -1,0 +1,70 @@
+/**
+ * Cerebrum-side debrief writer surface.
+ *
+ * Option D step 2 of the MEDIA pillar exit (PR #3111). The MEDIA pillar
+ * still owns the watch-history transaction (`logWatch`), but cerebrum
+ * now owns the *post-watch* fan-out: creating the debrief session row
+ * and queueing one debrief_status entry per active dimension. Step 1
+ * (#3119) denormalised `(media_type, media_id)` onto `debrief_sessions`
+ * so this writer can populate the columns directly; step 3 physically
+ * moves the debrief tables into `cerebrum.db` and replaces the media
+ * side's in-tx `getDebriefByMedia` call with a `logWatchCompletion`
+ * invocation, retiring the cross-pillar transaction.
+ *
+ * Idempotency: both child calls are individually idempotent —
+ * `createDebriefSession` deletes any prior pending/active row for the
+ * same media before inserting, and `queueDebriefStatus` upserts on
+ * `(media_type, media_id, dimension_id)` and resets `debriefed` /
+ * `dismissed` to 0. Calling `logWatchCompletion` twice for the same
+ * `(watchHistoryId, mediaType, mediaId)` therefore converges on a
+ * single pending debrief row with reset status counters.
+ *
+ * The wrapping `getCerebrumDrizzle().transaction(...)` is the
+ * forward-compatible call shape: in env-scope test fixtures it collapses
+ * onto the shared pops.db connection so the writes are genuinely atomic
+ * today, and in production it becomes a real cross-table boundary once
+ * step 3 lands and `debrief_sessions` / `debrief_status` are physically
+ * owned by `cerebrum.db`. Until then the inner services continue to
+ * resolve `getDrizzle()` (pops.db) directly — the transaction is a
+ * forward-compatible scaffold, not a runtime atomicity guarantee on
+ * production yet.
+ */
+import { z } from 'zod';
+
+import { getCerebrumDrizzle } from '../../../db/cerebrum-handle.js';
+import { protectedProcedure, router } from '../../../trpc.js';
+import { createDebriefSession, queueDebriefStatus } from '../../media/debrief/service.js';
+
+const LogWatchCompletionSchema = z.object({
+  mediaType: z.enum(['movie', 'episode']),
+  mediaId: z.number().int().positive(),
+  watchHistoryId: z.number().int().positive(),
+});
+
+export type LogWatchCompletionInput = z.infer<typeof LogWatchCompletionSchema>;
+
+export interface LogWatchCompletionResult {
+  sessionId: number;
+  dimensionsQueued: number;
+}
+
+export function logWatchCompletion(input: LogWatchCompletionInput): LogWatchCompletionResult {
+  const db = getCerebrumDrizzle();
+  return db.transaction(() => {
+    const sessionId = createDebriefSession(input.watchHistoryId);
+    const dimensionsQueued = queueDebriefStatus(input.mediaType, input.mediaId);
+    return { sessionId, dimensionsQueued };
+  });
+}
+
+export const debriefRouter = router({
+  /**
+   * Post-watch debrief fan-out. Called by the MEDIA pillar after a
+   * completed watch lands; creates the debrief session and queues
+   * debrief_status rows. Safe to call more than once for the same
+   * `(watchHistoryId, mediaType, mediaId)` — see file header.
+   */
+  logWatchCompletion: protectedProcedure
+    .input(LogWatchCompletionSchema)
+    .mutation(({ input }) => logWatchCompletion(input)),
+});

--- a/apps/pops-api/src/modules/cerebrum/index.ts
+++ b/apps/pops-api/src/modules/cerebrum/index.ts
@@ -6,6 +6,7 @@ import { cerebrumManifest } from '@pops/module-registry/settings';
 
 import { mergeRouters, router } from '../../trpc.js';
 import { cerebrumAiTools } from './ai-tools/index.js';
+import { debriefRouter } from './debrief/router.js';
 import { emitRouter } from './emit/router.js';
 import { engramsRouter } from './engrams/router.js';
 import { scopesRouter } from './engrams/scopes-router.js';
@@ -38,6 +39,7 @@ export const cerebrumRouter = router({
   nudges: nudgesRouter,
   plexus: plexusRouter,
   reflex: reflexRouter,
+  debrief: debriefRouter,
 });
 
 /** PRD-098 manifest. Metadata-only; consumed by the PRD-100 loader. */

--- a/apps/pops-api/src/modules/media/debrief/service.ts
+++ b/apps/pops-api/src/modules/media/debrief/service.ts
@@ -53,8 +53,15 @@ export function createDebriefSession(watchHistoryId: number): number {
       .run();
   }
 
-  // Create new pending session
-  const result = db.insert(debriefSessions).values({ watchHistoryId, status: 'pending' }).run();
+  const result = db
+    .insert(debriefSessions)
+    .values({
+      watchHistoryId,
+      mediaType: entry.mediaType,
+      mediaId: entry.mediaId,
+      status: 'pending',
+    })
+    .run();
 
   return Number(result.lastInsertRowid);
 }
@@ -212,10 +219,19 @@ export function getDebrief(sessionId: number): DebriefResponse {
 }
 
 /**
- * Look up the most recent pending or active debrief session for a media item
- * and return its full debrief response.
+ * Look up the most recent pending/active/complete debrief session for a
+ * media item and return its full debrief response.
  *
- * Throws NotFoundError if no pending/active session exists for this media.
+ * PR #3119 (Option D step 1) denormalised `(media_type, media_id)` onto
+ * `debrief_sessions`; this read now hits the row directly instead of
+ * inner-joining `watch_history`. That removes the only cross-pillar join
+ * blocking the MEDIA pillar exit — the cerebrum-side write surface that
+ * populates the columns lives in the `cerebrum.debrief.logWatchCompletion`
+ * router (Option D step 2). Existing rows were backfilled by the
+ * `0071_debrief_media_denorm` migration; `createDebriefSession` sets both
+ * columns on insert for new rows.
+ *
+ * Throws NotFoundError if no session exists for this media.
  */
 export function getDebriefByMedia(
   mediaType: 'movie' | 'episode',
@@ -223,16 +239,13 @@ export function getDebriefByMedia(
 ): DebriefResponse {
   const db = getDrizzle();
 
-  // Find the most recent session for this media (including complete,
-  // so the completion summary can render after the last comparison)
   const session = db
     .select({ id: debriefSessions.id })
     .from(debriefSessions)
-    .innerJoin(watchHistory, eq(debriefSessions.watchHistoryId, watchHistory.id))
     .where(
       and(
-        eq(watchHistory.mediaType, mediaType),
-        eq(watchHistory.mediaId, mediaId),
+        eq(debriefSessions.mediaType, mediaType),
+        eq(debriefSessions.mediaId, mediaId),
         inArray(debriefSessions.status, ['pending', 'active', 'complete'])
       )
     )


### PR DESCRIPTION
## Summary

Option D step 2 of the MEDIA pillar exit (PR #3111). Step 1 (#3119) denormalised `(media_type, media_id)` onto `debrief_sessions`; this PR wires the cerebrum-side writer surface and the denormalised read.

### Cerebrum endpoint

`cerebrum.debrief.logWatchCompletion({ mediaType, mediaId, watchHistoryId })` — wraps `createDebriefSession` + `queueDebriefStatus` inside a `getCerebrumDrizzle().transaction(...)`. Both child calls are individually idempotent, so repeated invocations for the same media collapse on a single pending debrief row with reset status counters. In env-scope test fixtures the cerebrum handle resolves onto the shared `pops.db` connection so the transaction is genuinely atomic today; in production it becomes a real cross-table boundary once step 3 physically moves `debrief_sessions` / `debrief_status` into `cerebrum.db`.

### createDebriefSession denormalisation

Inserts now populate `mediaType` / `mediaId` on `debrief_sessions` so new rows match the columns the `0071_debrief_media_denorm` migration backfilled onto existing rows. Public signature unchanged — still takes `watchHistoryId` for backwards compatibility with the MEDIA-side `logWatch` transaction.

### getDebriefByMedia rewrite

Drops the inner-join against `watch_history` in favour of a direct `where(mediaType, mediaId)` lookup on `debrief_sessions`. Removes the last cross-pillar read blocking the MEDIA pillar exit; ordering by `debrief_sessions.id ASC` preserves the prior "earliest session wins" contract callers depended on.

### Backwards compatibility

MEDIA `logWatch` keeps calling `createDebriefSession(watchHistoryId)` + `queueDebriefStatus(type, id)` inside its existing transaction. Step 3 replaces that with a `logWatchCompletion` call from the MEDIA side once `debrief_sessions` / `debrief_status` physically migrate.

### Boundary baseline

Two transitional crossings added to `.dependency-cruiser-known-violations.json` for `cerebrum/debrief/router{,.test}.ts -> media/debrief/service.ts`. Step 3 collapses both when the debrief services physically move into the cerebrum module.

## Test plan

- [x] `pnpm -F @pops/api test --run modules/cerebrum/debrief` — 8/8 new tests pass (happy path, idempotency, completed-session preservation, zod boundary, denormalised `getDebriefByMedia` including the "originating `watch_history` row gone" case).
- [x] `pnpm -F @pops/api test --run modules/media` — 1442/1442 pass (existing MEDIA-side `logWatch` integration unchanged).
- [x] `pnpm -F @pops/api test --run modules/cerebrum` — 1136/1136 pass on the changed surface (the single `glia/toml-config` default-threshold drift documented in #3119 also fails on `origin/main`).
- [x] `pnpm typecheck` — 66/66 packages clean.
- [x] `pnpm lint` — clean (existing warnings only).
- [x] `pnpm lint:boundaries` — passes against the updated baseline.
- [ ] Step 3 follow-up: cut the MEDIA-side `logWatch` over to call `pillar('cerebrum').debrief.logWatchCompletion(...)` and drop the cross-pillar transaction.
