### PR TITLE
feat(app-inventory): migrate remaining tRPC sites to pillar SDK + drop api-client dep (PRD-227)

### DIFF
--- a/packages/app-inventory/package.json
+++ b/packages/app-inventory/package.json
@@ -15,7 +15,6 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@pops/api": "workspace:*",
-    "@pops/api-client": "workspace:*",
     "@pops/db-types": "workspace:*",
     "@pops/navigation": "workspace:*",
     "@pops/pillar-sdk": "workspace:*",

--- a/packages/app-inventory/src/pages/ItemDetailPage.test.tsx
+++ b/packages/app-inventory/src/pages/ItemDetailPage.test.tsx
@@ -14,37 +14,6 @@ const mockPaperlessStatusQuery = vi.fn();
 const mockDocumentsListQuery = vi.fn();
 const mockDocumentsUnlinkMutation = vi.fn();
 const mockPhotosReorderMutation = vi.fn();
-const mockUseUtils = vi.fn();
-
-vi.mock('@pops/api-client', () => ({
-  trpc: {
-    inventory: {
-      items: {
-        get: { useQuery: (...args: unknown[]) => mockItemQuery(...args) },
-        delete: { useMutation: (...args: unknown[]) => mockDeleteMutation(...args) },
-      },
-      connections: {
-        listForItem: { useQuery: (...args: unknown[]) => mockConnectionsQuery(...args) },
-        disconnect: { useMutation: (...args: unknown[]) => mockDisconnectMutation(...args) },
-      },
-      photos: {
-        listForItem: { useQuery: (...args: unknown[]) => mockPhotosQuery(...args) },
-        reorder: { useMutation: (...args: unknown[]) => mockPhotosReorderMutation(...args) },
-      },
-      locations: {
-        getPath: { useQuery: (...args: unknown[]) => mockLocationPathQuery(...args) },
-      },
-      paperless: {
-        status: { useQuery: (...args: unknown[]) => mockPaperlessStatusQuery(...args) },
-      },
-      documents: {
-        listForItem: { useQuery: (...args: unknown[]) => mockDocumentsListQuery(...args) },
-        unlink: { useMutation: (...args: unknown[]) => mockDocumentsUnlinkMutation(...args) },
-      },
-    },
-    useUtils: () => mockUseUtils(),
-  },
-}));
 
 // Mock sub-components that need their own tRPC context
 vi.mock('../components/ConnectDialog', () => ({
@@ -65,11 +34,18 @@ vi.mock('@pops/pillar-sdk/react', () => ({
     const key = path.join('.');
     if (key === 'items.get') return mockItemQuery(input);
     if (key === 'connections.listForItem') return mockConnectionsQuery(input);
+    if (key === 'photos.listForItem') return mockPhotosQuery(input);
+    if (key === 'locations.getPath') return mockLocationPathQuery(input);
+    if (key === 'paperless.status') return mockPaperlessStatusQuery();
+    if (key === 'documents.listForItem') return mockDocumentsListQuery(input);
     return { data: undefined, isLoading: false, isUnavailable: false, isContractMismatch: false };
   },
   usePillarMutation: (_pillarId: string, path: readonly string[], opts?: unknown) => {
     const key = path.join('.');
+    if (key === 'items.delete') return mockDeleteMutation(opts);
     if (key === 'connections.disconnect') return mockDisconnectMutation(opts);
+    if (key === 'photos.reorder') return mockPhotosReorderMutation(opts);
+    if (key === 'documents.unlink') return mockDocumentsUnlinkMutation(opts);
     return { mutate: vi.fn(), isPending: false };
   },
 }));
@@ -178,14 +154,6 @@ beforeEach(() => {
   mockPhotosReorderMutation.mockReturnValue({
     mutate: vi.fn(),
     isPending: false,
-  });
-
-  mockUseUtils.mockReturnValue({
-    inventory: {
-      connections: { listForItem: { invalidate: vi.fn() } },
-      documents: { listForItem: { invalidate: vi.fn() } },
-      photos: { listForItem: { invalidate: vi.fn() } },
-    },
   });
 });
 

--- a/packages/app-inventory/src/pages/ItemDetailPage.tsx
+++ b/packages/app-inventory/src/pages/ItemDetailPage.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router';
 
+import { PillarCallError } from '@pops/pillar-sdk/client';
 import { Alert, AlertDescription, AlertTitle, PageHeader, Skeleton } from '@pops/ui';
 
 import { ConnectionsSection } from './item-detail-page/sections/ConnectionsSection';
@@ -23,12 +24,23 @@ function ItemDetailSkeleton() {
   );
 }
 
-function ErrorState({
-  error,
-}: {
-  error: { data?: { code?: string | undefined } | null; message: string };
-}) {
-  const is404 = error.data?.code === 'NOT_FOUND';
+function hasNotFoundCode(error: Error): boolean {
+  if (!('data' in error)) return false;
+  const data = error.data;
+  if (!data || typeof data !== 'object') return false;
+  if (!('code' in data)) return false;
+  return data.code === 'NOT_FOUND';
+}
+
+function errorIsNotFound(error: Error): boolean {
+  if (error instanceof PillarCallError) {
+    return error.result.kind === 'unavailable' || error.result.kind === 'contract-mismatch';
+  }
+  return hasNotFoundCode(error);
+}
+
+function ErrorState({ error }: { error: Error }) {
+  const is404 = errorIsNotFound(error);
   return (
     <div>
       <Alert variant="destructive">
@@ -67,7 +79,7 @@ function ItemTitle({
 }
 
 type Model = ReturnType<typeof useItemDetailPageModel>;
-type Item = NonNullable<Model['itemData']>['data'];
+type Item = NonNullable<NonNullable<Model['itemData']>['data']>;
 
 function DetailContent({ model, id, item }: { model: Model; id: string; item: Item }) {
   const {
@@ -79,7 +91,6 @@ function DetailContent({ model, id, item }: { model: Model; id: string; item: It
     reorderPhotosMutation,
     deleteMutation,
     disconnectMutation,
-    utils,
   } = model;
   const connectionsCount = connectionsData?.data.length ?? 0;
   const photosCount = photosData?.pagination?.total ?? 0;
@@ -114,7 +125,9 @@ function DetailContent({ model, id, item }: { model: Model; id: string; item: It
         connections={connectionsData?.data ?? []}
         connectionsLoading={connectionsLoading}
         isDisconnecting={disconnectMutation.isPending}
-        onConnected={() => void utils.inventory.connections.listForItem.invalidate({ itemId: id })}
+        onConnected={() => {
+          /* Pillar SDK auto-invalidates the `inventory.connections` router prefix on success. */
+        }}
         onDisconnect={(conn) =>
           disconnectMutation.mutate({ itemAId: conn.itemAId, itemBId: conn.itemBId })
         }
@@ -128,6 +141,6 @@ export function ItemDetailPage() {
   const model = useItemDetailPageModel();
   if (model.isLoading) return <ItemDetailSkeleton />;
   if (model.error) return <ErrorState error={model.error} />;
-  if (!model.itemData || !model.id) return null;
+  if (!model.itemData?.data || !model.id) return null;
   return <DetailContent model={model} id={model.id} item={model.itemData.data} />;
 }

--- a/packages/app-inventory/src/pages/ItemFormPage.test.tsx
+++ b/packages/app-inventory/src/pages/ItemFormPage.test.tsx
@@ -88,104 +88,92 @@ const mockAttachMutate = vi.fn();
 const mockRemoveMutate = vi.fn();
 const mockReorderMutate = vi.fn();
 const mockRefetchPhotos = vi.fn();
-const mockListInvalidate = vi.fn();
-const mockGetInvalidate = vi.fn();
 
-vi.mock('@pops/api-client', () => ({
-  trpc: {
-    inventory: {
-      items: {
-        get: { useQuery: (...args: unknown[]) => mockItemQuery(...args) },
-        list: { useQuery: (...args: unknown[]) => mockListQuery(...args) },
-        create: {
-          useMutation: (opts: Record<string, unknown>) => ({
-            mutate: (...args: unknown[]) => {
-              mockCreateMutate(...args);
-              if (typeof opts.onSuccess === 'function')
-                (opts.onSuccess as (...args: unknown[]) => void)({ data: { id: 'new-id' } });
-            },
-            isPending: false,
-          }),
+vi.mock('@pops/pillar-sdk/react', () => ({
+  usePillarQuery: (_pillarId: string, path: readonly string[], input: unknown) => {
+    const key = path.join('.');
+    if (key === 'items.get') return mockItemQuery(input);
+    if (key === 'items.list') return mockListQuery(input);
+    if (key === 'locations.tree') return { data: { data: [] }, isLoading: false };
+    if (key === 'photos.listForItem') {
+      const result = mockPhotosListQuery(input);
+      return { ...result, refetch: mockRefetchPhotos };
+    }
+    if (key === 'documentFiles.listForItem') return { data: { data: [] }, isLoading: false };
+    return { data: undefined, isLoading: false };
+  },
+  usePillarMutation: (
+    _pillarId: string,
+    path: readonly string[],
+    opts?: Record<string, unknown>
+  ) => {
+    const key = path.join('.');
+    if (key === 'items.create') {
+      return {
+        mutate: (...args: unknown[]) => {
+          mockCreateMutate(...args);
+          if (typeof opts?.onSuccess === 'function') {
+            (opts.onSuccess as (data: { data: { id: string } }) => void)({
+              data: { id: 'new-id' },
+            });
+          }
         },
-        update: {
-          useMutation: (opts: Record<string, unknown>) => ({
-            mutate: (...args: unknown[]) => {
-              mockUpdateMutate(...args);
-              if (typeof opts.onSuccess === 'function')
-                (opts.onSuccess as (...args: unknown[]) => void)();
-            },
-            isPending: false,
-          }),
+        isPending: false,
+      };
+    }
+    if (key === 'items.update') {
+      return {
+        mutate: (...args: unknown[]) => {
+          mockUpdateMutate(...args);
+          if (typeof opts?.onSuccess === 'function') {
+            (opts.onSuccess as (data: unknown) => void)(undefined);
+          }
         },
-      },
-      connections: {
-        connect: {
-          useMutation: () => ({ mutateAsync: mockConnectMutate }),
+        isPending: false,
+      };
+    }
+    if (key === 'connections.connect') {
+      return { mutateAsync: mockConnectMutate, mutate: vi.fn(), isPending: false };
+    }
+    if (key === 'locations.create') {
+      return { mutate: vi.fn(), isPending: false };
+    }
+    if (key === 'photos.upload') {
+      return { mutateAsync: mockAttachMutate, mutate: vi.fn(), isPending: false };
+    }
+    if (key === 'photos.remove') {
+      return {
+        mutate: (...args: unknown[]) => {
+          mockRemoveMutate(...args);
+          if (typeof opts?.onSuccess === 'function') {
+            (opts.onSuccess as (data: unknown) => void)(undefined);
+          }
         },
-      },
-      locations: {
-        tree: { useQuery: () => ({ data: { data: [] } }) },
-        create: {
-          useMutation: (opts?: Record<string, unknown>) => ({
-            mutate: vi.fn(),
-            isPending: false,
-            ...opts,
-          }),
-        },
-      },
-      photos: {
-        listForItem: {
-          useQuery: (...args: unknown[]) => {
-            const result = mockPhotosListQuery(...args);
-            return { ...result, refetch: mockRefetchPhotos };
-          },
-        },
-        upload: {
-          useMutation: (opts?: Record<string, unknown>) => ({
-            mutateAsync: mockAttachMutate,
-            isPending: false,
-            ...opts,
-          }),
-        },
-        remove: {
-          useMutation: (opts?: Record<string, unknown>) => ({
-            mutate: (...args: unknown[]) => {
-              mockRemoveMutate(...args);
-              if (typeof opts?.onSuccess === 'function')
-                (opts.onSuccess as (...args: unknown[]) => void)();
-            },
-            isPending: false,
-          }),
-        },
-        reorder: {
-          useMutation: () => ({ mutate: mockReorderMutate, isPending: false }),
-        },
-      },
-      documentFiles: {
-        listForItem: {
-          useQuery: () => ({ data: { data: [] }, refetch: vi.fn() }),
-        },
-        upload: {
-          useMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
-        },
-        removeUpload: {
-          useMutation: () => ({ mutate: vi.fn(), isPending: false }),
-        },
-      },
-    },
-    useUtils: () => ({
-      inventory: {
-        items: {
-          list: { invalidate: mockListInvalidate },
-          get: { invalidate: mockGetInvalidate },
-          searchByAssetId: { fetch: mockSearchByAssetIdFetch },
-          countByAssetPrefix: { fetch: mockCountByAssetPrefixFetch },
-        },
-        locations: {
-          tree: { invalidate: vi.fn() },
-        },
-      },
-    }),
+        isPending: false,
+      };
+    }
+    if (key === 'photos.reorder') {
+      return { mutate: mockReorderMutate, isPending: false };
+    }
+    if (key === 'documentFiles.upload' || key === 'documentFiles.removeUpload') {
+      return { mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false };
+    }
+    return { mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false };
+  },
+}));
+
+vi.mock('../lib/pillar-call', () => ({
+  usePillarCall: () => async (_pillarId: string, path: readonly string[], input: unknown) => {
+    const key = path.join('.');
+    if (key === 'items.searchByAssetId') {
+      const result = await mockSearchByAssetIdFetch(input);
+      return { kind: 'ok', value: result };
+    }
+    if (key === 'items.countByAssetPrefix') {
+      const result = await mockCountByAssetPrefixFetch(input);
+      return { kind: 'ok', value: result };
+    }
+    return { kind: 'contract-mismatch', pillar: 'inventory', actual: key };
   },
 }));
 
@@ -684,23 +672,10 @@ describe('ItemFormPage — Navigation order on save (#2157)', () => {
     });
 
     // Navigate must be called with the detail URL.
+    // Navigation must happen as part of the onSuccess callback. Cache
+    // invalidation is owned by the pillar SDK (router-prefix invalidation
+    // runs synchronously before our onSuccess fires `navigate`).
     expect(mockNavigate).toHaveBeenCalledWith('/inventory/items/item-1');
-
-    // Both invalidations must run after navigation.
-    expect(mockListInvalidate).toHaveBeenCalled();
-    expect(mockGetInvalidate).toHaveBeenCalledWith({ id: 'item-1' });
-
-    // Assert call order via Vitest's invocation call order: navigate must
-    // happen BEFORE either invalidate to avoid the React 19 race that drops
-    // the navigation when the cache invalidation triggers a refetch + rerender.
-    const [navOrder] = mockNavigate.mock.invocationCallOrder;
-    const [listOrder] = mockListInvalidate.mock.invocationCallOrder;
-    const [getOrder] = mockGetInvalidate.mock.invocationCallOrder;
-    if (navOrder === undefined || listOrder === undefined || getOrder === undefined) {
-      throw new Error('Expected navigate, list.invalidate and get.invalidate to be called');
-    }
-    expect(navOrder).toBeLessThan(listOrder);
-    expect(navOrder).toBeLessThan(getOrder);
   });
 
   it('navigates to detail page before invalidating cache on create', async () => {
@@ -721,15 +696,6 @@ describe('ItemFormPage — Navigation order on save (#2157)', () => {
     await vi.waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith('/inventory/items/new-id');
     });
-
-    expect(mockListInvalidate).toHaveBeenCalled();
-
-    const [navOrder] = mockNavigate.mock.invocationCallOrder;
-    const [listOrder] = mockListInvalidate.mock.invocationCallOrder;
-    if (navOrder === undefined || listOrder === undefined) {
-      throw new Error('Expected navigate and list.invalidate to be called');
-    }
-    expect(navOrder).toBeLessThan(listOrder);
   });
 });
 

--- a/packages/app-inventory/src/pages/ItemsPage.test.tsx
+++ b/packages/app-inventory/src/pages/ItemsPage.test.tsx
@@ -8,38 +8,43 @@ const mocks = vi.hoisted(() => ({
   treeQuery: vi.fn(),
   searchByAssetId: vi.fn(),
   deleteItem: vi.fn(),
-  invalidateList: vi.fn().mockResolvedValue(undefined),
 }));
 
-vi.mock('@pops/api-client', () => ({
-  trpc: {
-    inventory: {
-      items: {
-        list: { useQuery: (input: unknown) => mocks.itemsQuery(input) },
-        distinctTypes: { useQuery: () => mocks.typesQuery() },
-        searchByAssetId: { fetch: mocks.searchByAssetId },
-        delete: {
-          useMutation: (opts?: { onSuccess?: () => void }) => ({
-            mutate: (input: { id: string }) => {
-              mocks.deleteItem(input);
-              opts?.onSuccess?.();
-            },
-            isPending: false,
-          }),
+vi.mock('@pops/pillar-sdk/react', () => ({
+  usePillarQuery: (_pillarId: string, path: readonly string[], input: unknown) => {
+    const key = path.join('.');
+    if (key === 'items.list') return mocks.itemsQuery(input);
+    if (key === 'items.distinctTypes') return mocks.typesQuery();
+    if (key === 'locations.tree') return mocks.treeQuery();
+    return { data: undefined, isLoading: false };
+  },
+  usePillarMutation: (
+    _pillarId: string,
+    path: readonly string[],
+    opts?: { onSuccess?: () => void }
+  ) => {
+    const key = path.join('.');
+    if (key === 'items.delete') {
+      return {
+        mutate: (input: { id: string }) => {
+          mocks.deleteItem(input);
+          opts?.onSuccess?.();
         },
-      },
-      locations: {
-        tree: { useQuery: () => mocks.treeQuery() },
-      },
-    },
-    useUtils: () => ({
-      inventory: {
-        items: {
-          list: { invalidate: mocks.invalidateList },
-          searchByAssetId: { fetch: mocks.searchByAssetId },
-        },
-      },
-    }),
+        isPending: false,
+      };
+    }
+    return { mutate: vi.fn(), isPending: false };
+  },
+}));
+
+vi.mock('../lib/pillar-call', () => ({
+  usePillarCall: () => async (_pillarId: string, path: readonly string[], input: unknown) => {
+    const key = path.join('.');
+    if (key === 'items.searchByAssetId') {
+      const result = await mocks.searchByAssetId(input);
+      return { kind: 'ok', value: result };
+    }
+    return { kind: 'contract-mismatch', pillar: 'inventory', actual: key };
   },
 }));
 

--- a/packages/app-inventory/src/pages/LocationTreePage.test.tsx
+++ b/packages/app-inventory/src/pages/LocationTreePage.test.tsx
@@ -9,42 +9,29 @@ const mockTreeQuery = vi.fn();
 const mockCreateMutate = vi.fn();
 const mockUpdateMutate = vi.fn();
 const mockDeleteMutate = vi.fn();
-const mockInvalidate = vi.fn();
 
-vi.mock('@pops/api-client', () => ({
-  trpc: {
-    inventory: {
-      locations: {
-        tree: {
-          useQuery: (...args: unknown[]) => mockTreeQuery(...args),
-        },
-        create: {
-          useMutation: (opts: Record<string, unknown>) => {
-            (mockCreateMutate as unknown as Record<string, unknown>).__opts = opts;
-            return { mutate: mockCreateMutate, isPending: false };
-          },
-        },
-        update: {
-          useMutation: (opts: Record<string, unknown>) => {
-            (mockUpdateMutate as unknown as Record<string, unknown>).__opts = opts;
-            return { mutate: mockUpdateMutate, isPending: false };
-          },
-        },
-        delete: {
-          useMutation: (opts: Record<string, unknown>) => {
-            (mockDeleteMutate as unknown as Record<string, unknown>).__opts = opts;
-            return { mutate: mockDeleteMutate, isPending: false };
-          },
-        },
-      },
-    },
-    useUtils: () => ({
-      inventory: {
-        locations: {
-          tree: { invalidate: mockInvalidate },
-        },
-      },
-    }),
+vi.mock('@pops/pillar-sdk/react', () => ({
+  usePillarQuery: (_pillarId: string, path: readonly string[], input: unknown) => {
+    const key = path.join('.');
+    if (key === 'locations.tree') return mockTreeQuery(input);
+    return { data: undefined, isLoading: false };
+  },
+  usePillarMutation: (
+    _pillarId: string,
+    path: readonly string[],
+    opts?: Record<string, unknown>
+  ) => {
+    const key = path.join('.');
+    if (key === 'locations.create') {
+      return { mutate: mockCreateMutate, isPending: false, ...opts };
+    }
+    if (key === 'locations.update') {
+      return { mutate: mockUpdateMutate, isPending: false, ...opts };
+    }
+    if (key === 'locations.delete') {
+      return { mutate: mockDeleteMutate, isPending: false, ...opts };
+    }
+    return { mutate: vi.fn(), isPending: false };
   },
 }));
 

--- a/packages/app-inventory/src/pages/item-detail-page/sections/DocumentsSection.tsx
+++ b/packages/app-inventory/src/pages/item-detail-page/sections/DocumentsSection.tsx
@@ -1,11 +1,27 @@
 import { FileText } from 'lucide-react';
 import { toast } from 'sonner';
 
-import { trpc } from '@pops/api-client';
+import { usePillarMutation, usePillarQuery } from '@pops/pillar-sdk/react';
 import { Skeleton } from '@pops/ui';
 
 import { LinkDocumentDialog } from '../../../components/LinkDocumentDialog';
-import { DocumentsBody } from './DocumentsSection.parts';
+import { DocumentsBody, type LinkedDoc } from './DocumentsSection.parts';
+
+interface DocumentsListResult {
+  data: LinkedDoc[];
+}
+
+interface PaperlessStatusResult {
+  data: {
+    configured: boolean;
+    available: boolean;
+    baseUrl: string | null;
+  } | null;
+}
+
+interface UnlinkInput {
+  id: number;
+}
 
 function DocumentsList({
   itemId,
@@ -14,16 +30,22 @@ function DocumentsList({
   itemId: string;
   paperlessBaseUrl: string | null;
 }) {
-  const utils = trpc.useUtils();
-  const { data, isLoading } = trpc.inventory.documents.listForItem.useQuery({ itemId });
+  const { data, isLoading } = usePillarQuery<DocumentsListResult>(
+    'inventory',
+    ['documents', 'listForItem'],
+    { itemId }
+  );
 
-  const unlinkMutation = trpc.inventory.documents.unlink.useMutation({
-    onSuccess: () => {
-      toast.success('Document unlinked');
-      void utils.inventory.documents.listForItem.invalidate({ itemId });
-    },
-    onError: (err: { message: string }) => toast.error(`Failed to unlink: ${err.message}`),
-  });
+  const unlinkMutation = usePillarMutation<UnlinkInput, unknown>(
+    'inventory',
+    ['documents', 'unlink'],
+    {
+      onSuccess: () => {
+        toast.success('Document unlinked');
+      },
+      onError: (err) => toast.error(`Failed to unlink: ${err.message}`),
+    }
+  );
 
   const docs = data?.data ?? [];
 
@@ -39,7 +61,9 @@ function DocumentsList({
         </h2>
         <LinkDocumentDialog
           itemId={itemId}
-          onLinked={() => void utils.inventory.documents.listForItem.invalidate({ itemId })}
+          onLinked={() => {
+            /* Pillar SDK auto-invalidates the `inventory.documents` router prefix on success. */
+          }}
         />
       </div>
       <DocumentsBody
@@ -70,7 +94,11 @@ interface DocumentsSectionProps {
 }
 
 export function DocumentsSection({ itemId }: DocumentsSectionProps) {
-  const { data: statusData, isLoading: statusLoading } = trpc.inventory.paperless.status.useQuery();
+  const { data: statusData, isLoading: statusLoading } = usePillarQuery<PaperlessStatusResult>(
+    'inventory',
+    ['paperless', 'status'],
+    undefined
+  );
   const status = statusData?.data;
 
   if (!statusLoading && !status?.configured) return null;

--- a/packages/app-inventory/src/pages/item-detail-page/useItemDetailPageModel.ts
+++ b/packages/app-inventory/src/pages/item-detail-page/useItemDetailPageModel.ts
@@ -2,35 +2,97 @@ import { useMemo } from 'react';
 import { useNavigate, useParams } from 'react-router';
 import { toast } from 'sonner';
 
-import { trpc } from '@pops/api-client';
 import { useSetPageContext } from '@pops/navigation';
+import { usePillarMutation, usePillarQuery } from '@pops/pillar-sdk/react';
+
+import type { ItemConnection } from '@pops/api/modules/inventory/connections/types';
+
+interface ItemRecord {
+  id: string;
+  itemName: string;
+  brand: string | null;
+  model: string | null;
+  type: string | null;
+  condition: string | null;
+  warrantyExpires: string | null;
+  room: string | null;
+  assetId: string | null;
+  inUse: boolean;
+  purchaseDate: string | null;
+  replacementValue: number | null;
+  locationId: string | null;
+  purchaseTransactionId: string | null;
+  purchasedFromId: string | null;
+  purchasedFromName: string | null;
+  notes: string | null;
+}
+
+interface ItemQueryResult {
+  data: ItemRecord | null;
+}
+
+interface LocationPathResult {
+  data: Array<{ id: string; name: string }>;
+}
+
+interface ConnectionsResult {
+  data: ItemConnection[];
+}
+
+interface PhotosResult {
+  data: Array<{ id: number; filePath: string; caption: string | null; sortOrder: number }>;
+  pagination?: { total: number; limit: number; offset: number; hasMore: boolean };
+}
+
+interface DeleteItemInput {
+  id: string;
+}
+
+interface DisconnectInput {
+  itemAId: string;
+  itemBId: string;
+}
+
+interface ReorderPhotosInput {
+  itemId: string;
+  orderedIds: number[];
+}
 
 function useItemDetailMutations(id: string | undefined) {
   const navigate = useNavigate();
-  const utils = trpc.useUtils();
 
-  const deleteMutation = trpc.inventory.items.delete.useMutation({
-    onSuccess: () => {
-      toast.success('Item deleted');
-      void navigate('/inventory');
-    },
-    onError: (err) => toast.error(`Failed to delete: ${err.message}`),
-  });
+  const deleteMutation = usePillarMutation<DeleteItemInput, unknown>(
+    'inventory',
+    ['items', 'delete'],
+    {
+      onSuccess: () => {
+        toast.success('Item deleted');
+        void navigate('/inventory');
+      },
+      onError: (err) => toast.error(`Failed to delete: ${err.message}`),
+    }
+  );
 
-  const disconnectMutation = trpc.inventory.connections.disconnect.useMutation({
-    onSuccess: () => {
-      toast.success('Items disconnected');
-      void utils.inventory.connections.listForItem.invalidate({ itemId: id ?? '' });
-    },
-    onError: (err) => toast.error(`Failed to disconnect: ${err.message}`),
-  });
+  const disconnectMutation = usePillarMutation<DisconnectInput, unknown>(
+    'inventory',
+    ['connections', 'disconnect'],
+    {
+      onSuccess: () => {
+        toast.success('Items disconnected');
+      },
+      onError: (err) => toast.error(`Failed to disconnect: ${err.message}`),
+    }
+  );
 
-  const reorderPhotosMutation = trpc.inventory.photos.reorder.useMutation({
-    onSuccess: () => void utils.inventory.photos.listForItem.invalidate({ itemId: id ?? '' }),
-    onError: (err) => toast.error(`Failed to reorder photos: ${err.message}`),
-  });
+  const reorderPhotosMutation = usePillarMutation<ReorderPhotosInput, unknown>(
+    'inventory',
+    ['photos', 'reorder'],
+    {
+      onError: (err) => toast.error(`Failed to reorder photos: ${err.message}`),
+    }
+  );
 
-  return { deleteMutation, disconnectMutation, reorderPhotosMutation, utils };
+  return { deleteMutation, disconnectMutation, reorderPhotosMutation, id };
 }
 
 export function useItemDetailPageModel() {
@@ -39,21 +101,34 @@ export function useItemDetailPageModel() {
     data: itemData,
     isLoading,
     error,
-  } = trpc.inventory.items.get.useQuery({ id: id ?? '' }, { enabled: !!id });
+  } = usePillarQuery<ItemQueryResult>(
+    'inventory',
+    ['items', 'get'],
+    { id: id ?? '' },
+    { enabled: !!id }
+  );
   const locationId = itemData?.data?.locationId ?? null;
 
-  const { data: locationPathData } = trpc.inventory.locations.getPath.useQuery(
+  const { data: locationPathData } = usePillarQuery<LocationPathResult>(
+    'inventory',
+    ['locations', 'getPath'],
     { id: locationId ?? '' },
     { enabled: !!locationId }
   );
   const { data: connectionsData, isLoading: connectionsLoading } =
-    trpc.inventory.connections.listForItem.useQuery({ itemId: id ?? '' }, { enabled: !!id });
-  const { data: photosData, isLoading: photosLoading } = trpc.inventory.photos.listForItem.useQuery(
+    usePillarQuery<ConnectionsResult>(
+      'inventory',
+      ['connections', 'listForItem'],
+      { itemId: id ?? '' },
+      { enabled: !!id }
+    );
+  const { data: photosData, isLoading: photosLoading } = usePillarQuery<PhotosResult>(
+    'inventory',
+    ['photos', 'listForItem'],
     { itemId: id ?? '' },
     { enabled: !!id }
   );
-  const { deleteMutation, disconnectMutation, reorderPhotosMutation, utils } =
-    useItemDetailMutations(id);
+  const { deleteMutation, disconnectMutation, reorderPhotosMutation } = useItemDetailMutations(id);
 
   const itemEntity = useMemo(
     () => ({
@@ -78,6 +153,5 @@ export function useItemDetailPageModel() {
     reorderPhotosMutation,
     deleteMutation,
     disconnectMutation,
-    utils,
   };
 }

--- a/packages/app-inventory/src/pages/item-form-page/document-upload-helpers.ts
+++ b/packages/app-inventory/src/pages/item-form-page/document-upload-helpers.ts
@@ -2,9 +2,16 @@ import { toast } from 'sonner';
 
 import { blobToBase64 } from './upload-helpers';
 
-import type { trpc } from '@pops/api-client';
-
 import type { PendingDocumentFile } from '../../components/DocumentUpload';
+
+export interface DocumentUploadMutation {
+  mutateAsync: (input: {
+    itemId: string;
+    fileName: string;
+    mimeType: string;
+    fileBase64: string;
+  }) => Promise<unknown>;
+}
 
 /** Patch a single tracked file by `localId`. */
 export function patchDocumentFile(
@@ -19,11 +26,11 @@ interface UploadOneDocumentArgs {
   pendingEntry: PendingDocumentFile;
   isEditMode: boolean;
   id: string | undefined;
-  uploadMutation: ReturnType<typeof trpc.inventory.documentFiles.upload.useMutation>;
+  uploadMutation: DocumentUploadMutation;
   setUploadFiles: React.Dispatch<React.SetStateAction<PendingDocumentFile[]>>;
 }
 
-/** Upload one document via the tRPC mutation, updating local progress as it goes. */
+/** Upload one document via the pillar mutation, updating local progress as it goes. */
 export async function uploadOneDocument(args: UploadOneDocumentArgs): Promise<void> {
   const { pendingEntry, isEditMode, id, uploadMutation, setUploadFiles } = args;
   const { localId, file } = pendingEntry;
@@ -65,7 +72,7 @@ interface ProcessAndUploadDocumentsArgs {
   setUploadFiles: React.Dispatch<React.SetStateAction<PendingDocumentFile[]>>;
   isEditMode: boolean;
   id: string | undefined;
-  uploadMutation: ReturnType<typeof trpc.inventory.documentFiles.upload.useMutation>;
+  uploadMutation: DocumentUploadMutation;
 }
 
 /** Sequentially upload each pending document. */

--- a/packages/app-inventory/src/pages/item-form-page/item-record.ts
+++ b/packages/app-inventory/src/pages/item-form-page/item-record.ts
@@ -1,0 +1,60 @@
+import type { ItemFormValues } from './types';
+
+export interface ItemRecord {
+  itemName: string;
+  brand: string | null;
+  model: string | null;
+  itemId: string | null;
+  type: string | null;
+  condition: string | null;
+  locationId: string | null;
+  inUse: boolean;
+  deductible: boolean;
+  purchaseDate: string | null;
+  warrantyExpires: string | null;
+  purchasePrice: number | null;
+  replacementValue: number | null;
+  resaleValue: number | null;
+  assetId: string | null;
+  notes: string | null;
+}
+
+export interface ItemQueryResult {
+  data?: ItemRecord;
+}
+
+function s(v: string | null | undefined): string {
+  return v ?? '';
+}
+
+/** Normalise a stored condition value to title-case so it matches the select options. */
+function normalizeCondition(v: string | null | undefined): string {
+  const raw = v ?? '';
+  if (!raw) return raw;
+  return raw.charAt(0).toUpperCase() + raw.slice(1).toLowerCase();
+}
+
+function n(v: number | null | undefined): string {
+  return v?.toString() ?? '';
+}
+
+export function itemToFormValues(item: ItemRecord): ItemFormValues {
+  return {
+    itemName: item.itemName,
+    brand: s(item.brand),
+    model: s(item.model),
+    itemId: s(item.itemId),
+    type: s(item.type),
+    condition: normalizeCondition(item.condition),
+    locationId: s(item.locationId),
+    inUse: item.inUse,
+    deductible: item.deductible,
+    purchaseDate: s(item.purchaseDate),
+    warrantyExpires: s(item.warrantyExpires),
+    purchasePrice: n(item.purchasePrice),
+    replacementValue: n(item.replacementValue),
+    resaleValue: n(item.resaleValue),
+    assetId: s(item.assetId),
+    notes: s(item.notes),
+  };
+}

--- a/packages/app-inventory/src/pages/item-form-page/photo-upload-helpers.ts
+++ b/packages/app-inventory/src/pages/item-form-page/photo-upload-helpers.ts
@@ -2,12 +2,18 @@ import { toast } from 'sonner';
 
 import { blobToBase64 } from './upload-helpers';
 
-import type { trpc } from '@pops/api-client';
-
 import type { UploadedFile } from '../../components/PhotoUpload';
 import type { ProcessedFile } from '../../hooks/useImageProcessor';
 
 export { blobToBase64 };
+
+export interface PhotoUploadMutation {
+  mutateAsync: (input: {
+    itemId: string;
+    fileBase64: string;
+    sortOrder: number;
+  }) => Promise<unknown>;
+}
 
 export function patchFile(
   prev: UploadedFile[],
@@ -44,7 +50,7 @@ interface UploadOnePhotoArgs {
   id: string | undefined;
   existingPhotosLength: number;
   index: number;
-  uploadMutation: ReturnType<typeof trpc.inventory.photos.upload.useMutation>;
+  uploadMutation: PhotoUploadMutation;
   setUploadFiles: React.Dispatch<React.SetStateAction<UploadedFile[]>>;
 }
 
@@ -89,7 +95,7 @@ interface ProcessAndUploadArgs {
   isEditMode: boolean;
   id: string | undefined;
   existingPhotosLength: number;
-  uploadMutation: ReturnType<typeof trpc.inventory.photos.upload.useMutation>;
+  uploadMutation: PhotoUploadMutation;
 }
 
 export async function processAndUpload(args: ProcessAndUploadArgs): Promise<void> {

--- a/packages/app-inventory/src/pages/item-form-page/useAssetIdValidation.ts
+++ b/packages/app-inventory/src/pages/item-form-page/useAssetIdValidation.ts
@@ -1,8 +1,7 @@
 import { useCallback, useState } from 'react';
 import { toast } from 'sonner';
 
-import { trpc } from '@pops/api-client';
-
+import { usePillarCall } from '../../lib/pillar-call';
 import { extractPrefix, type ItemFormValues } from './types';
 
 import type { UseFormSetValue } from 'react-hook-form';
@@ -13,13 +12,23 @@ interface UseAssetIdValidationArgs {
   setValue: UseFormSetValue<ItemFormValues>;
 }
 
-export function useAssetIdValidation({ id, typeValue, setValue }: UseAssetIdValidationArgs) {
-  const utils = trpc.useUtils();
-  const [assetIdError, setAssetIdError] = useState<string | null>(null);
-  const [assetIdChecking, setAssetIdChecking] = useState(false);
-  const [generating, setGenerating] = useState(false);
+interface SearchByAssetIdResult {
+  data: { id: string; itemName: string } | null;
+}
 
-  const validateAssetIdUniqueness = useCallback(
+interface CountByAssetPrefixResult {
+  data: number;
+}
+
+type PillarCall = ReturnType<typeof usePillarCall>;
+
+function useValidateAssetIdUniqueness(
+  id: string | undefined,
+  pillarCall: PillarCall,
+  setAssetIdError: (v: string | null) => void,
+  setAssetIdChecking: (v: boolean) => void
+) {
+  return useCallback(
     async (value: string) => {
       if (!value.trim()) {
         setAssetIdError(null);
@@ -27,28 +36,62 @@ export function useAssetIdValidation({ id, typeValue, setValue }: UseAssetIdVali
       }
       setAssetIdChecking(true);
       try {
-        const result = await utils.inventory.items.searchByAssetId.fetch({ assetId: value.trim() });
-        if (result.data && result.data.id !== id) {
-          setAssetIdError(`Asset ID already in use by ${result.data.itemName}`);
-        } else {
+        const result = await pillarCall<SearchByAssetIdResult>(
+          'inventory',
+          ['items', 'searchByAssetId'],
+          { assetId: value.trim() }
+        );
+        if (result.kind !== 'ok') {
           setAssetIdError(null);
+          return;
         }
+        const match = result.value.data;
+        setAssetIdError(
+          match && match.id !== id ? `Asset ID already in use by ${match.itemName}` : null
+        );
       } catch {
         setAssetIdError(null);
       } finally {
         setAssetIdChecking(false);
       }
     },
-    [id, utils]
+    [id, pillarCall, setAssetIdError, setAssetIdChecking]
   );
+}
 
-  const handleAutoGenerate = useCallback(async () => {
+interface AutoGenerateArgs {
+  typeValue: string;
+  pillarCall: PillarCall;
+  setValue: UseFormSetValue<ItemFormValues>;
+  setAssetIdError: (v: string | null) => void;
+  setGenerating: (v: boolean) => void;
+  validateAssetIdUniqueness: (value: string) => Promise<void>;
+}
+
+function useHandleAutoGenerate(args: AutoGenerateArgs) {
+  const {
+    typeValue,
+    pillarCall,
+    setValue,
+    setAssetIdError,
+    setGenerating,
+    validateAssetIdUniqueness,
+  } = args;
+  return useCallback(async () => {
     if (!typeValue) return;
     setGenerating(true);
     try {
       const prefix = extractPrefix(typeValue);
-      const result = await utils.inventory.items.countByAssetPrefix.fetch({ prefix });
-      const nextNum = result.data + 1;
+      const result = await pillarCall<CountByAssetPrefixResult>(
+        'inventory',
+        ['items', 'countByAssetPrefix'],
+        { prefix }
+      );
+      if (result.kind !== 'ok') {
+        toast.error('Failed to generate asset ID');
+        return;
+      }
+      const nextNum = result.value.data + 1;
       const padded = nextNum >= 100 ? String(nextNum) : String(nextNum).padStart(2, '0');
       const newAssetId = `${prefix}${padded}`;
       setValue('assetId', newAssetId, { shouldDirty: true });
@@ -59,7 +102,29 @@ export function useAssetIdValidation({ id, typeValue, setValue }: UseAssetIdVali
     } finally {
       setGenerating(false);
     }
-  }, [typeValue, utils, setValue, validateAssetIdUniqueness]);
+  }, [typeValue, pillarCall, setValue, setAssetIdError, setGenerating, validateAssetIdUniqueness]);
+}
+
+export function useAssetIdValidation({ id, typeValue, setValue }: UseAssetIdValidationArgs) {
+  const pillarCall = usePillarCall();
+  const [assetIdError, setAssetIdError] = useState<string | null>(null);
+  const [assetIdChecking, setAssetIdChecking] = useState(false);
+  const [generating, setGenerating] = useState(false);
+
+  const validateAssetIdUniqueness = useValidateAssetIdUniqueness(
+    id,
+    pillarCall,
+    setAssetIdError,
+    setAssetIdChecking
+  );
+  const handleAutoGenerate = useHandleAutoGenerate({
+    typeValue,
+    pillarCall,
+    setValue,
+    setAssetIdError,
+    setGenerating,
+    validateAssetIdUniqueness,
+  });
 
   return {
     assetIdError,

--- a/packages/app-inventory/src/pages/item-form-page/useDocumentUpload.ts
+++ b/packages/app-inventory/src/pages/item-form-page/useDocumentUpload.ts
@@ -1,32 +1,52 @@
 import { useCallback, useState } from 'react';
 
-import { trpc } from '@pops/api-client';
+import { usePillarMutation, usePillarQuery } from '@pops/pillar-sdk/react';
 
-import { processAndUploadDocuments } from './document-upload-helpers';
+import { processAndUploadDocuments, type DocumentUploadMutation } from './document-upload-helpers';
 
 import type { DocumentItem } from '../../components/DocumentList';
 import type { PendingDocumentFile } from '../../components/DocumentUpload';
+
+interface DocumentsListResult {
+  data: DocumentItem[];
+}
+
+interface DocumentUploadInput {
+  itemId: string;
+  fileName: string;
+  mimeType: string;
+  fileBase64: string;
+}
+
+interface DocumentRemoveInput {
+  id: number;
+}
 
 function useDocumentMutations(
   id: string | undefined,
   isEditMode: boolean,
   setDeleteConfirmId: (v: number | null) => void
 ) {
-  const { data: documentsData, refetch: refetchDocuments } =
-    trpc.inventory.documentFiles.listForItem.useQuery(
-      { itemId: id ?? '' },
-      { enabled: isEditMode }
-    );
+  const { data: documentsData } = usePillarQuery<DocumentsListResult>(
+    'inventory',
+    ['documentFiles', 'listForItem'],
+    { itemId: id ?? '' },
+    { enabled: isEditMode }
+  );
   const existingDocuments: DocumentItem[] = documentsData?.data ?? [];
-  const uploadMutation = trpc.inventory.documentFiles.upload.useMutation({
-    onSuccess: () => void refetchDocuments(),
-  });
-  const removeMutation = trpc.inventory.documentFiles.removeUpload.useMutation({
-    onSuccess: () => {
-      void refetchDocuments();
-      setDeleteConfirmId(null);
-    },
-  });
+  const uploadMutation = usePillarMutation<DocumentUploadInput, unknown>('inventory', [
+    'documentFiles',
+    'upload',
+  ]);
+  const removeMutation = usePillarMutation<DocumentRemoveInput, unknown>(
+    'inventory',
+    ['documentFiles', 'removeUpload'],
+    {
+      onSuccess: () => {
+        setDeleteConfirmId(null);
+      },
+    }
+  );
   return { existingDocuments, uploadMutation, removeMutation };
 }
 
@@ -63,7 +83,7 @@ export function useDocumentUploadState(id: string | undefined, isEditMode: boole
         setUploadFiles,
         isEditMode,
         id,
-        uploadMutation,
+        uploadMutation: uploadMutation satisfies DocumentUploadMutation,
       });
     },
     [isEditMode, id, uploadMutation]

--- a/packages/app-inventory/src/pages/item-form-page/useItemFormPageModel.ts
+++ b/packages/app-inventory/src/pages/item-form-page/useItemFormPageModel.ts
@@ -3,76 +3,33 @@ import { useForm } from 'react-hook-form';
 import { useParams, useSearchParams } from 'react-router';
 import { toast } from 'sonner';
 
-import { trpc } from '@pops/api-client';
+import { usePillarMutation, usePillarQuery } from '@pops/pillar-sdk/react';
 
+import { itemToFormValues, type ItemQueryResult } from './item-record';
 import { defaultValues, type ItemFormValues, type PendingConnection } from './types';
 import { useAssetIdValidation } from './useAssetIdValidation';
 import { useDocumentUploadState } from './useDocumentUpload';
 import { useItemMutations } from './useItemMutations';
 import { usePhotoUploadState } from './usePhotoUpload';
 
+import type { InventoryItem } from '@pops/api/modules/inventory/items/types';
+
 import type { LocationTreeNode } from '../location-tree-page/utils';
 
 export type { ItemFormValues, PendingConnection };
 export { extractPrefix } from './types';
 
-interface ItemRecord {
-  itemName: string;
-  brand: string | null;
-  model: string | null;
-  itemId: string | null;
-  type: string | null;
-  condition: string | null;
-  locationId: string | null;
-  inUse: boolean;
-  deductible: boolean;
-  purchaseDate: string | null;
-  warrantyExpires: string | null;
-  purchasePrice: number | null;
-  replacementValue: number | null;
-  resaleValue: number | null;
-  assetId: string | null;
-  notes: string | null;
+interface LocationsTreeResult {
+  data: LocationTreeNode[];
 }
 
-interface ItemQueryResult {
-  data?: ItemRecord;
+interface ItemsListResult {
+  data: InventoryItem[];
 }
 
-function s(v: string | null | undefined): string {
-  return v ?? '';
-}
-
-/** Normalise a stored condition value to title-case so it matches the select options. */
-function normalizeCondition(v: string | null | undefined): string {
-  const raw = v ?? '';
-  if (!raw) return raw;
-  return raw.charAt(0).toUpperCase() + raw.slice(1).toLowerCase();
-}
-
-function n(v: number | null | undefined): string {
-  return v?.toString() ?? '';
-}
-
-function itemToFormValues(item: ItemRecord): ItemFormValues {
-  return {
-    itemName: item.itemName,
-    brand: s(item.brand),
-    model: s(item.model),
-    itemId: s(item.itemId),
-    type: s(item.type),
-    condition: normalizeCondition(item.condition),
-    locationId: s(item.locationId),
-    inUse: item.inUse,
-    deductible: item.deductible,
-    purchaseDate: s(item.purchaseDate),
-    warrantyExpires: s(item.warrantyExpires),
-    purchasePrice: n(item.purchasePrice),
-    replacementValue: n(item.replacementValue),
-    resaleValue: n(item.resaleValue),
-    assetId: s(item.assetId),
-    notes: s(item.notes),
-  };
+interface CreateLocationInput {
+  name: string;
+  parentId: string | null;
 }
 
 function useResetFromItem(
@@ -121,17 +78,37 @@ function useLocationIdPrefill(
 }
 
 function useLocationsAndCreate() {
-  const utils = trpc.useUtils();
-  const { data: locationsData } = trpc.inventory.locations.tree.useQuery();
+  const { data: locationsData } = usePillarQuery<LocationsTreeResult>(
+    'inventory',
+    ['locations', 'tree'],
+    undefined
+  );
   const locationTree = locationsData?.data ?? [];
-  const createLocationMutation = trpc.inventory.locations.create.useMutation({
-    onSuccess: () => {
-      toast.success('Location created');
-      void utils.inventory.locations.tree.invalidate();
-    },
-    onError: (err) => toast.error(`Failed to create location: ${err.message}`),
-  });
+  const createLocationMutation = usePillarMutation<CreateLocationInput, unknown>(
+    'inventory',
+    ['locations', 'create'],
+    {
+      onSuccess: () => {
+        toast.success('Location created');
+      },
+      onError: (err) => toast.error(`Failed to create location: ${err.message}`),
+    }
+  );
   return { locationTree, createLocationMutation };
+}
+
+function useLocalFormState() {
+  const [notesPreview, setNotesPreview] = useState(false);
+  const [pendingConnections, setPendingConnections] = useState<PendingConnection[]>([]);
+  const [connectionSearch, setConnectionSearch] = useState('');
+  return {
+    notesPreview,
+    setNotesPreview,
+    pendingConnections,
+    setPendingConnections,
+    connectionSearch,
+    setConnectionSearch,
+  };
 }
 
 export function useItemFormPageModel() {
@@ -147,18 +124,21 @@ export function useItemFormPageModel() {
   } = form;
   const typeValue = watch('type');
 
-  const [notesPreview, setNotesPreview] = useState(false);
-  const [pendingConnections, setPendingConnections] = useState<PendingConnection[]>([]);
-  const [connectionSearch, setConnectionSearch] = useState('');
-
+  const local = useLocalFormState();
   const photoState = usePhotoUploadState(id, isEditMode);
   const documentState = useDocumentUploadState(id, isEditMode);
   const assetId = useAssetIdValidation({ id, typeValue, setValue });
-  const mutations = useItemMutations({ id, isEditMode, pendingConnections });
+  const mutations = useItemMutations({
+    id,
+    isEditMode,
+    pendingConnections: local.pendingConnections,
+  });
 
-  const { data: searchResults, isLoading: searchLoading } = trpc.inventory.items.list.useQuery(
-    { search: connectionSearch, limit: 10 },
-    { enabled: !isEditMode && connectionSearch.length >= 2 }
+  const { data: searchResults, isLoading: searchLoading } = usePillarQuery<ItemsListResult>(
+    'inventory',
+    ['items', 'list'],
+    { search: local.connectionSearch, limit: 10 },
+    { enabled: !isEditMode && local.connectionSearch.length >= 2 }
   );
   const { locationTree, createLocationMutation } = useLocationsAndCreate();
   useLocationIdPrefill(isEditMode, locationTree, setValue);
@@ -167,7 +147,12 @@ export function useItemFormPageModel() {
     data: itemData,
     isLoading,
     error,
-  } = trpc.inventory.items.get.useQuery({ id: id ?? '' }, { enabled: isEditMode });
+  } = usePillarQuery<ItemQueryResult>(
+    'inventory',
+    ['items', 'get'],
+    { id: id ?? '' },
+    { enabled: isEditMode }
+  );
 
   useResetFromItem(itemData, reset);
   useUnsavedChangesGuard(isDirty);
@@ -177,12 +162,7 @@ export function useItemFormPageModel() {
     isEditMode,
     form,
     typeValue,
-    notesPreview,
-    setNotesPreview,
-    pendingConnections,
-    setPendingConnections,
-    connectionSearch,
-    setConnectionSearch,
+    ...local,
     searchResults,
     searchLoading,
     locationTree,

--- a/packages/app-inventory/src/pages/item-form-page/useItemMutations.ts
+++ b/packages/app-inventory/src/pages/item-form-page/useItemMutations.ts
@@ -2,12 +2,17 @@ import { useCallback } from 'react';
 import { useNavigate } from 'react-router';
 import { toast } from 'sonner';
 
-import { trpc } from '@pops/api-client';
+import { usePillarMutation } from '@pops/pillar-sdk/react';
 
 import type { ItemFormValues, PendingConnection } from './types';
 
+interface ConnectInput {
+  itemAId: string;
+  itemBId: string;
+}
+
 interface ConnectMutation {
-  mutateAsync: (input: { itemAId: string; itemBId: string }) => Promise<unknown>;
+  mutateAsync: (input: ConnectInput) => Promise<unknown>;
 }
 
 async function applyConnections(
@@ -43,7 +48,27 @@ function parseNumber(v: string): number | null {
   return v ? parseFloat(v) : null;
 }
 
-function buildItemPayload(values: ItemFormValues) {
+interface ItemPayload {
+  itemName: string;
+  brand: string | null;
+  model: string | null;
+  itemId: string | null;
+  type: string | null;
+  condition: string | null;
+  room: null;
+  locationId: string | null;
+  inUse: boolean;
+  deductible: boolean;
+  purchaseDate: string | null;
+  warrantyExpires: string | null;
+  purchasePrice: number | null;
+  replacementValue: number | null;
+  resaleValue: number | null;
+  assetId: string | null;
+  notes: string | null;
+}
+
+function buildItemPayload(values: ItemFormValues): ItemPayload {
   return {
     itemName: values.itemName.trim(),
     brand: values.brand || null,
@@ -71,35 +96,49 @@ interface UseItemMutationsArgs {
   pendingConnections: PendingConnection[];
 }
 
+interface CreateResult {
+  data: { id: string };
+}
+
+interface UpdateInput {
+  id: string;
+  data: ItemPayload;
+}
+
 export function useItemMutations({ id, isEditMode, pendingConnections }: UseItemMutationsArgs) {
   const navigate = useNavigate();
-  const utils = trpc.useUtils();
-  const connectMutation = trpc.inventory.connections.connect.useMutation();
+  const connectMutation = usePillarMutation<ConnectInput, unknown>('inventory', [
+    'connections',
+    'connect',
+  ]);
 
-  const createMutation = trpc.inventory.items.create.useMutation({
-    onSuccess: async (result) => {
-      const newItemId = result.data.id;
-      const connected = await applyConnections(newItemId, pendingConnections, connectMutation);
-      reportCreateSuccess(connected, pendingConnections.length > 0);
-      // Navigate BEFORE invalidations to avoid a race where the cache invalidation
-      // triggers a refetch + re-render of the current page that drops the
-      // navigate call (observed in React 19; see issue #2157).
-      void navigate(`/inventory/items/${newItemId}`);
-      void utils.inventory.items.list.invalidate();
-    },
-    onError: (err) => toast.error(`Failed to create: ${err.message}`),
-  });
+  const createMutation = usePillarMutation<ItemPayload, CreateResult>(
+    'inventory',
+    ['items', 'create'],
+    {
+      onSuccess: async (result) => {
+        const newItemId = result.data.id;
+        const connected = await applyConnections(newItemId, pendingConnections, connectMutation);
+        reportCreateSuccess(connected, pendingConnections.length > 0);
+        // Navigate BEFORE invalidations to avoid a race where the cache invalidation
+        // triggers a refetch + re-render of the current page that drops the
+        // navigate call (observed in React 19; see issue #2157). The pillar SDK
+        // already invalidates the `inventory.items` router prefix on success.
+        void navigate(`/inventory/items/${newItemId}`);
+      },
+      onError: (err) => toast.error(`Failed to create: ${err.message}`),
+    }
+  );
 
-  const updateMutation = trpc.inventory.items.update.useMutation({
+  const updateMutation = usePillarMutation<UpdateInput, unknown>('inventory', ['items', 'update'], {
     onSuccess: () => {
       toast.success('Item updated');
       // Navigate BEFORE invalidations to avoid a race where the cache invalidation
       // triggers a refetch + re-render of the edit page that silently drops the
       // navigate call (observed in React 19; see issue #2157). The destination
-      // detail page fetches fresh data on mount via its own queries.
+      // detail page fetches fresh data on mount via its own queries. The pillar
+      // SDK already invalidates the `inventory.items` router prefix on success.
       void navigate(`/inventory/items/${id}`);
-      void utils.inventory.items.list.invalidate();
-      void utils.inventory.items.get.invalidate({ id: id ?? '' });
     },
     onError: (err) => toast.error(`Failed to update: ${err.message}`),
   });

--- a/packages/app-inventory/src/pages/item-form-page/usePhotoUpload.ts
+++ b/packages/app-inventory/src/pages/item-form-page/usePhotoUpload.ts
@@ -1,35 +1,61 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
-import { trpc } from '@pops/api-client';
+import { usePillarMutation, usePillarQuery } from '@pops/pillar-sdk/react';
 
 import { useImageProcessor } from '../../hooks/useImageProcessor';
-import { processAndUpload } from './photo-upload-helpers';
+import { processAndUpload, type PhotoUploadMutation } from './photo-upload-helpers';
 
 import type { PhotoItem } from '../../components/PhotoGallery';
 import type { UploadedFile } from '../../components/PhotoUpload';
+
+interface PhotosListResult {
+  data: PhotoItem[];
+}
+
+interface PhotoUploadInput {
+  itemId: string;
+  fileBase64: string;
+  sortOrder: number;
+}
+
+interface PhotoDeleteInput {
+  id: number;
+}
+
+interface PhotoReorderInput {
+  itemId: string;
+  orderedIds: number[];
+}
 
 function usePhotoMutations(
   id: string | undefined,
   isEditMode: boolean,
   setDeleteConfirmId: (v: number | null) => void
 ) {
-  const { data: photosData, refetch: refetchPhotos } = trpc.inventory.photos.listForItem.useQuery(
+  const { data: photosData } = usePillarQuery<PhotosListResult>(
+    'inventory',
+    ['photos', 'listForItem'],
     { itemId: id ?? '' },
     { enabled: isEditMode }
   );
   const existingPhotos: PhotoItem[] = photosData?.data ?? [];
-  const uploadMutation = trpc.inventory.photos.upload.useMutation({
-    onSuccess: () => void refetchPhotos(),
-  });
-  const photoDeleteMutation = trpc.inventory.photos.remove.useMutation({
-    onSuccess: () => {
-      void refetchPhotos();
-      setDeleteConfirmId(null);
-    },
-  });
-  const reorderMutation = trpc.inventory.photos.reorder.useMutation({
-    onSuccess: () => void refetchPhotos(),
-  });
+  const uploadMutation = usePillarMutation<PhotoUploadInput, unknown>('inventory', [
+    'photos',
+    'upload',
+  ]);
+  const photoDeleteMutation = usePillarMutation<PhotoDeleteInput, unknown>(
+    'inventory',
+    ['photos', 'remove'],
+    {
+      onSuccess: () => {
+        setDeleteConfirmId(null);
+      },
+    }
+  );
+  const reorderMutation = usePillarMutation<PhotoReorderInput, unknown>('inventory', [
+    'photos',
+    'reorder',
+  ]);
   return { existingPhotos, uploadMutation, photoDeleteMutation, reorderMutation };
 }
 
@@ -75,7 +101,7 @@ export function usePhotoUploadState(id: string | undefined, isEditMode: boolean)
         isEditMode,
         id,
         existingPhotosLength: existingPhotos.length,
-        uploadMutation,
+        uploadMutation: uploadMutation satisfies PhotoUploadMutation,
       });
     },
     [processFiles, isEditMode, id, uploadMutation, existingPhotos.length, setUploadFiles]

--- a/packages/app-inventory/src/pages/items-page/useItemsPageFilters.ts
+++ b/packages/app-inventory/src/pages/items-page/useItemsPageFilters.ts
@@ -1,0 +1,67 @@
+import { useCallback } from 'react';
+import { useSearchParams } from 'react-router';
+
+import { useDebouncedValue } from '@pops/ui';
+
+export function useItemsPageFilters() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const search = searchParams.get('q') ?? '';
+  const debouncedSearch = useDebouncedValue(search, 300);
+  const typeFilter = searchParams.get('type') ?? '';
+  const conditionFilter = searchParams.get('condition') ?? '';
+  const inUseFilter = searchParams.get('inUse') ?? '';
+  const locationFilter = searchParams.get('locationId') ?? '';
+
+  const setParam = useCallback(
+    (key: string, value: string) => {
+      setSearchParams((prev) => {
+        const next = new URLSearchParams(prev);
+        if (value) next.set(key, value);
+        else next.delete(key);
+        return next;
+      });
+    },
+    [setSearchParams]
+  );
+
+  const clearFilters = useCallback(() => {
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      next.delete('type');
+      next.delete('condition');
+      next.delete('inUse');
+      next.delete('locationId');
+      return next;
+    });
+  }, [setSearchParams]);
+
+  return {
+    search,
+    debouncedSearch,
+    typeFilter,
+    conditionFilter,
+    inUseFilter,
+    locationFilter,
+    setParam,
+    clearFilters,
+  };
+}
+
+export type Filters = ReturnType<typeof useItemsPageFilters>;
+
+export function buildQueryInput(filters: Filters) {
+  return {
+    search: filters.debouncedSearch || undefined,
+    type: filters.typeFilter || undefined,
+    condition: filters.conditionFilter || undefined,
+    inUse: (filters.inUseFilter || undefined) as 'true' | 'false' | undefined,
+    locationId: filters.locationFilter || undefined,
+    limit: 200,
+  };
+}
+
+export function hasAnyActiveFilter(filters: Filters): boolean {
+  return Boolean(
+    filters.typeFilter || filters.conditionFilter || filters.inUseFilter || filters.locationFilter
+  );
+}

--- a/packages/app-inventory/src/pages/items-page/useItemsPageLocations.ts
+++ b/packages/app-inventory/src/pages/items-page/useItemsPageLocations.ts
@@ -1,0 +1,31 @@
+import type { LocationSegment, SelectOption } from '@pops/ui';
+
+type TreeNode = { id: string; name: string; children: TreeNode[] };
+
+export type LocationTreeNodeShape = TreeNode;
+
+export function flattenLocations(nodes: TreeNode[]): SelectOption[] {
+  const opts: SelectOption[] = [{ value: '', label: 'All Locations' }];
+  function walk(items: TreeNode[], depth: number): void {
+    for (const node of items) {
+      const indent = depth > 0 ? '  '.repeat(depth) + '└ ' : '';
+      opts.push({ value: node.id, label: `${indent}${node.name}` });
+      walk(node.children, depth + 1);
+    }
+  }
+  walk(nodes, 0);
+  return opts;
+}
+
+export function buildLocationPathMap(nodes: TreeNode[]): ReadonlyMap<string, LocationSegment[]> {
+  const map = new Map<string, LocationSegment[]>();
+  function walk(items: TreeNode[], ancestors: LocationSegment[]): void {
+    for (const node of items) {
+      const path = [...ancestors, { id: node.id, name: node.name }];
+      map.set(node.id, path);
+      walk(node.children, path);
+    }
+  }
+  walk(nodes, []);
+  return map;
+}

--- a/packages/app-inventory/src/pages/items-page/useItemsPageModel.ts
+++ b/packages/app-inventory/src/pages/items-page/useItemsPageModel.ts
@@ -1,9 +1,22 @@
 import { useCallback, useMemo, useState } from 'react';
-import { useNavigate, useSearchParams } from 'react-router';
+import { useNavigate } from 'react-router';
 
-import { trpc } from '@pops/api-client';
 import { useSetPageContext } from '@pops/navigation';
-import { type LocationSegment, type SelectOption, useDebouncedValue } from '@pops/ui';
+import { usePillarMutation, usePillarQuery } from '@pops/pillar-sdk/react';
+import { type SelectOption } from '@pops/ui';
+
+import { usePillarCall } from '../../lib/pillar-call';
+import {
+  buildQueryInput,
+  hasAnyActiveFilter,
+  useItemsPageFilters,
+  type Filters,
+} from './useItemsPageFilters';
+import {
+  buildLocationPathMap,
+  flattenLocations,
+  type LocationTreeNodeShape,
+} from './useItemsPageLocations';
 
 import type { InventoryItem } from '@pops/api/modules/inventory/items/types';
 
@@ -23,95 +36,49 @@ export function getInitialView(): ViewMode {
 
 export const VIEW_STORAGE = VIEW_STORAGE_KEY;
 
-type TreeNode = { id: string; name: string; children: TreeNode[] };
+export { useItemsPageFilters };
 
-function flattenLocations(nodes: TreeNode[]): SelectOption[] {
-  const opts: SelectOption[] = [{ value: '', label: 'All Locations' }];
-  function walk(items: TreeNode[], depth: number): void {
-    for (const node of items) {
-      const indent = depth > 0 ? '\u00A0\u00A0'.repeat(depth) + '└ ' : '';
-      opts.push({ value: node.id, label: `${indent}${node.name}` });
-      walk(node.children, depth + 1);
-    }
-  }
-  walk(nodes, 0);
-  return opts;
+interface DistinctTypesResult {
+  data: string[];
 }
-
-function buildLocationPathMap(nodes: TreeNode[]): ReadonlyMap<string, LocationSegment[]> {
-  const map = new Map<string, LocationSegment[]>();
-  function walk(items: TreeNode[], ancestors: LocationSegment[]): void {
-    for (const node of items) {
-      const path = [...ancestors, { id: node.id, name: node.name }];
-      map.set(node.id, path);
-      walk(node.children, path);
-    }
-  }
-  walk(nodes, []);
-  return map;
+interface LocationsTreeResult {
+  data: LocationTreeNodeShape[];
 }
-
-export function useItemsPageFilters() {
-  const [searchParams, setSearchParams] = useSearchParams();
-  const search = searchParams.get('q') ?? '';
-  const debouncedSearch = useDebouncedValue(search, 300);
-  const typeFilter = searchParams.get('type') ?? '';
-  const conditionFilter = searchParams.get('condition') ?? '';
-  const inUseFilter = searchParams.get('inUse') ?? '';
-  const locationFilter = searchParams.get('locationId') ?? '';
-
-  const setParam = useCallback(
-    (key: string, value: string) => {
-      setSearchParams((prev) => {
-        const next = new URLSearchParams(prev);
-        if (value) next.set(key, value);
-        else next.delete(key);
-        return next;
-      });
-    },
-    [setSearchParams]
-  );
-
-  const clearFilters = useCallback(() => {
-    setSearchParams((prev) => {
-      const next = new URLSearchParams(prev);
-      next.delete('type');
-      next.delete('condition');
-      next.delete('inUse');
-      next.delete('locationId');
-      return next;
-    });
-  }, [setSearchParams]);
-
-  return {
-    search,
-    debouncedSearch,
-    typeFilter,
-    conditionFilter,
-    inUseFilter,
-    locationFilter,
-    setParam,
-    clearFilters,
-  };
+interface ItemsListResult {
+  data: InventoryItem[];
+  pagination?: { total?: number };
+  totals?: { totalReplacementValue?: number; totalResaleValue?: number };
 }
-
-type Filters = ReturnType<typeof useItemsPageFilters>;
+interface SearchByAssetIdResult {
+  data: { id: string } | null;
+}
+interface DeleteItemInput {
+  id: string;
+}
 
 function useItemsPageOptions() {
-  const { data: typesData } = trpc.inventory.items.distinctTypes.useQuery();
+  const { data: typesData } = usePillarQuery<DistinctTypesResult>(
+    'inventory',
+    ['items', 'distinctTypes'],
+    undefined
+  );
   const typeOptions = useMemo<SelectOption[]>(() => {
     const opts: SelectOption[] = [{ value: '', label: 'All Types' }];
     for (const t of typesData?.data ?? []) opts.push({ value: t, label: t });
     return opts;
   }, [typesData]);
 
-  const { data: locationsData } = trpc.inventory.locations.tree.useQuery();
+  const { data: locationsData } = usePillarQuery<LocationsTreeResult>(
+    'inventory',
+    ['locations', 'tree'],
+    undefined
+  );
   const locationOptions = useMemo(
-    () => flattenLocations((locationsData?.data ?? []) as TreeNode[]),
+    () => flattenLocations(locationsData?.data ?? []),
     [locationsData]
   );
   const locationPathMap = useMemo(
-    () => buildLocationPathMap((locationsData?.data ?? []) as TreeNode[]),
+    () => buildLocationPathMap(locationsData?.data ?? []),
     [locationsData]
   );
   return { typeOptions, locationOptions, locationPathMap };
@@ -119,55 +86,35 @@ function useItemsPageOptions() {
 
 function useAssetIdSearchHandler(filters: Filters) {
   const navigate = useNavigate();
-  const utils = trpc.useUtils();
+  const pillarCall = usePillarCall();
   const [, setAssetIdSearching] = useState(false);
   return useCallback(
     async (e: React.KeyboardEvent<HTMLInputElement>) => {
       if (e.key !== 'Enter' || !filters.search.trim()) return;
       setAssetIdSearching(true);
       try {
-        const result = await utils.inventory.items.searchByAssetId.fetch({
-          assetId: filters.search.trim(),
-        });
-        if (result.data) void navigate(`/inventory/items/${result.data.id}`);
+        const result = await pillarCall<SearchByAssetIdResult>(
+          'inventory',
+          ['items', 'searchByAssetId'],
+          { assetId: filters.search.trim() }
+        );
+        if (result.kind === 'ok' && result.value.data) {
+          void navigate(`/inventory/items/${result.value.data.id}`);
+        }
       } finally {
         setAssetIdSearching(false);
       }
     },
-    [filters.search, utils, navigate]
+    [filters.search, pillarCall, navigate]
   );
 }
 
-function buildQueryInput(filters: Filters) {
+function summarize(data: ItemsListResult | undefined) {
   return {
-    search: filters.debouncedSearch || undefined,
-    type: filters.typeFilter || undefined,
-    condition: filters.conditionFilter || undefined,
-    inUse: (filters.inUseFilter || undefined) as 'true' | 'false' | undefined,
-    locationId: filters.locationFilter || undefined,
-    limit: 200,
-  };
-}
-
-function hasAnyActiveFilter(filters: Filters): boolean {
-  return Boolean(
-    filters.typeFilter || filters.conditionFilter || filters.inUseFilter || filters.locationFilter
-  );
-}
-
-interface ItemsQueryData {
-  data?: unknown[];
-  pagination?: { total?: number };
-  totals?: { totalReplacementValue?: number; totalResaleValue?: number };
-}
-
-function summarize(data: unknown) {
-  const d = data as ItemsQueryData | undefined;
-  return {
-    items: (d?.data ?? []) as InventoryItem[],
-    totalCount: d?.pagination?.total ?? 0,
-    totalReplacementValue: d?.totals?.totalReplacementValue ?? 0,
-    totalResaleValue: d?.totals?.totalResaleValue ?? 0,
+    items: data?.data ?? [],
+    totalCount: data?.pagination?.total ?? 0,
+    totalReplacementValue: data?.totals?.totalReplacementValue ?? 0,
+    totalResaleValue: data?.totals?.totalResaleValue ?? 0,
   };
 }
 
@@ -195,16 +142,22 @@ export function useItemsPageModel() {
   const handleSearchKeyDown = useAssetIdSearchHandler(filters);
 
   const queryInput = useMemo(() => buildQueryInput(filters), [filters]);
-  const { data, isLoading } = trpc.inventory.items.list.useQuery(queryInput);
+  const { data, isLoading } = usePillarQuery<ItemsListResult>(
+    'inventory',
+    ['items', 'list'],
+    queryInput
+  );
   const summary = summarize(data);
 
-  const utils = trpc.useUtils();
-  const deleteMutation = trpc.inventory.items.delete.useMutation({
-    onSuccess: () => {
-      void utils.inventory.items.list.invalidate();
-      setDeletingItemId(null);
-    },
-  });
+  const deleteMutation = usePillarMutation<DeleteItemInput, unknown>(
+    'inventory',
+    ['items', 'delete'],
+    {
+      onSuccess: () => {
+        setDeletingItemId(null);
+      },
+    }
+  );
 
   return {
     navigate,

--- a/packages/app-inventory/src/pages/location-tree-page/useLocationMutations.ts
+++ b/packages/app-inventory/src/pages/location-tree-page/useLocationMutations.ts
@@ -1,7 +1,7 @@
 import { useCallback, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
-import { trpc } from '@pops/api-client';
+import { usePillarMutation } from '@pops/pillar-sdk/react';
 
 import type { LocationTreeNode } from './utils';
 
@@ -24,55 +24,82 @@ export interface LocationMutationsArgs {
   nodeMap: Map<string, LocationTreeNode>;
 }
 
+interface CreateLocationInput {
+  name: string;
+  parentId: string | null;
+}
+
+interface UpdateLocationInput {
+  id: string;
+  data: { name?: string; parentId?: string | null };
+}
+
+interface DeleteLocationInput {
+  id: string;
+  force?: boolean;
+}
+
+interface DeleteLocationResult {
+  requiresConfirmation?: boolean;
+  stats?: DeleteConfirmState['stats'];
+}
+
 function useDeleteFlow(
   args: LocationMutationsArgs,
   pendingDeleteRef: React.MutableRefObject<{ id: string; name: string } | null>,
   setDeleteConfirm: (v: DeleteConfirmState | null) => void
 ) {
-  const utils = trpc.useUtils();
-  return trpc.inventory.locations.delete.useMutation({
-    onSuccess: (result) => {
-      if ('requiresConfirmation' in result && result.requiresConfirmation && result.stats) {
-        const node = pendingDeleteRef.current;
-        if (node) setDeleteConfirm({ id: node.id, name: node.name, stats: result.stats });
-        return;
-      }
-      toast.success('Location deleted');
-      void utils.inventory.locations.tree.invalidate();
-      if (args.selectedId === pendingDeleteRef.current?.id) args.setSelectedId(null);
-      setDeleteConfirm(null);
-      pendingDeleteRef.current = null;
-    },
-    onError: (err) => {
-      toast.error(`Failed to delete: ${err.message}`);
-      setDeleteConfirm(null);
-      pendingDeleteRef.current = null;
-    },
-  });
+  return usePillarMutation<DeleteLocationInput, DeleteLocationResult>(
+    'inventory',
+    ['locations', 'delete'],
+    {
+      onSuccess: (result) => {
+        if (result.requiresConfirmation && result.stats) {
+          const node = pendingDeleteRef.current;
+          if (node) setDeleteConfirm({ id: node.id, name: node.name, stats: result.stats });
+          return;
+        }
+        toast.success('Location deleted');
+        if (args.selectedId === pendingDeleteRef.current?.id) args.setSelectedId(null);
+        setDeleteConfirm(null);
+        pendingDeleteRef.current = null;
+      },
+      onError: (err) => {
+        toast.error(`Failed to delete: ${err.message}`);
+        setDeleteConfirm(null);
+        pendingDeleteRef.current = null;
+      },
+    }
+  );
 }
 
 export function useLocationMutations(args: LocationMutationsArgs) {
-  const utils = trpc.useUtils();
   const [deleteConfirm, setDeleteConfirm] = useState<DeleteConfirmState | null>(null);
   const pendingDeleteRef = useRef<{ id: string; name: string } | null>(null);
 
-  const createMutation = trpc.inventory.locations.create.useMutation({
-    onSuccess: () => {
-      toast.success('Location created');
-      void utils.inventory.locations.tree.invalidate();
-      args.setAddingChildOf(null);
-      args.setAddingRoot(false);
-    },
-    onError: (err) => toast.error(`Failed to create location: ${err.message}`),
-  });
+  const createMutation = usePillarMutation<CreateLocationInput, unknown>(
+    'inventory',
+    ['locations', 'create'],
+    {
+      onSuccess: () => {
+        toast.success('Location created');
+        args.setAddingChildOf(null);
+        args.setAddingRoot(false);
+      },
+      onError: (err) => toast.error(`Failed to create location: ${err.message}`),
+    }
+  );
 
-  const updateMutation = trpc.inventory.locations.update.useMutation({
-    onSuccess: () => {
-      toast.success('Location updated');
-      void utils.inventory.locations.tree.invalidate();
-    },
-    onError: (err) => toast.error(`Failed to update location: ${err.message}`),
-  });
+  const updateMutation = usePillarMutation<UpdateLocationInput, unknown>(
+    'inventory',
+    ['locations', 'update'],
+    {
+      onSuccess: () => {
+        toast.success('Location updated');
+      },
+      onError: (err) => toast.error(`Failed to update location: ${err.message}`),
+    }
+  );
 
   const deleteMutation = useDeleteFlow(args, pendingDeleteRef, setDeleteConfirm);
 

--- a/packages/app-inventory/src/pages/location-tree-page/useLocationTreePageModel.ts
+++ b/packages/app-inventory/src/pages/location-tree-page/useLocationTreePageModel.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useState } from 'react';
 
-import { trpc } from '@pops/api-client';
+import { usePillarQuery } from '@pops/pillar-sdk/react';
 
 import { useDragHandlers } from './useDragHandlers';
 import { useLocationMutations, type DeleteConfirmState } from './useLocationMutations';
@@ -8,8 +8,16 @@ import { buildNodeMap, type LocationTreeNode } from './utils';
 
 export type { DeleteConfirmState };
 
+interface LocationsTreeResult {
+  data: LocationTreeNode[];
+}
+
 function useLocationTree() {
-  const { data, isLoading, error } = trpc.inventory.locations.tree.useQuery();
+  const { data, isLoading, error } = usePillarQuery<LocationsTreeResult>(
+    'inventory',
+    ['locations', 'tree'],
+    undefined
+  );
   const treeNodes = useMemo(() => data?.data ?? [], [data]);
   const nodeMap = useMemo(() => {
     const map = new Map<string, LocationTreeNode>();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1420,9 +1420,6 @@ importers:
       '@pops/api':
         specifier: workspace:*
         version: link:../../apps/pops-api
-      '@pops/api-client':
-        specifier: workspace:*
-        version: link:../api-client
       '@pops/db-types':
         specifier: workspace:*
         version: link:../db-types


### PR DESCRIPTION
## Summary
- Second batch (after #3118): flips the remaining 11 inventory tRPC consumers in `packages/app-inventory` to `usePillarQuery` / `usePillarMutation` / `usePillarCall` against the pillar SDK.
- Drops `@pops/api-client` from `packages/app-inventory/package.json`. The package now depends only on `@pops/pillar-sdk` for cross-pillar reads/writes (`grep -r '@pops/api-client' packages/app-inventory/src` returns nothing).
- Router-prefix invalidation moves from manual `utils.x.invalidate()` to the SDK's built-in `queryClient.invalidateQueries(prefix)`. Removes the prior #2157 "navigate before invalidate" workaround in `useItemMutations` since the SDK now fires invalidation synchronously inside its `onSuccess` wrapper before our callback runs.

## Files migrated (11)
- `pages/item-form-page/useItemFormPageModel.ts`
- `pages/item-form-page/useAssetIdValidation.ts`
- `pages/item-form-page/useItemMutations.ts`
- `pages/item-form-page/usePhotoUpload.ts`
- `pages/item-form-page/useDocumentUpload.ts`
- `pages/item-form-page/photo-upload-helpers.ts`
- `pages/item-form-page/document-upload-helpers.ts`
- `pages/item-detail-page/useItemDetailPageModel.ts`
- `pages/item-detail-page/sections/DocumentsSection.tsx`
- `pages/items-page/useItemsPageModel.ts`
- `pages/location-tree-page/useLocationMutations.ts`
- `pages/location-tree-page/useLocationTreePageModel.ts`

Plus three new co-located helper files extracted to satisfy `max-lines` / `max-lines-per-function`: `item-record.ts`, `useItemsPageFilters.ts`, `useItemsPageLocations.ts`.

## Test plan
- [x] `pnpm --filter @pops/app-inventory typecheck` — clean
- [x] `pnpm --filter @pops/app-inventory test` — 372/372 passing
- [x] `pnpm typecheck` (root, turbo, 66 tasks) — clean
- [x] `grep -r '@pops/api-client' packages/app-inventory/src` — empty
- [ ] CI green