### PR TITLE
feat(theme-13): WAVE 5 — drop pops.db + retire legacy backfill scaffolding

### DIFF
--- a/docs/themes/13-pillar-finale/notes/wave-5-blocked.md
+++ b/docs/themes/13-pillar-finale/notes/wave-5-blocked.md
@@ -1,0 +1,102 @@
+# Theme 13 Wave 5 — Blocked
+
+> Status: BLOCKED — do not ship PRD-213 (drop `pops.db`) or PRD-214 (legacy
+> code retirement) yet.
+>
+> Snapshot date: 2026-06-13.
+>
+> Parent: [Drop pops.db epic](../epics/09-drop-pops-db.md). See PRD-212's
+> [readiness matrix](../prds/212-readiness-audit/readiness-matrix.md) for
+> the per-table / per-caller breakdown.
+
+## Why Wave 5 cannot ship today
+
+The Wave-5 brief assumed that "6 of 7 pillars are fully off the bridge"
+and only the cerebrum `nudge_log` backfill remained. That conflates two
+distinct retirements:
+
+1. **Boot-time `*-backfill-from-shared.ts` arrays** — the dual-write
+   bridges that copied rows from `pops.db` into per-pillar SQLite files.
+2. **Tables and runtime callers physically on `pops.db`** — the schemas
+   that still live in `apps/pops-api/src/db/drizzle-migrations/` plus the
+   `getDb()` / `getDrizzle()` call sites that read and write them.
+
+(1) is largely retired; the only remaining file on disk is
+`apps/pops-api/src/db/backfill-cerebrum-from-shared.ts` with a single
+`nudge_log` entry. (2) is not. Dropping `pops.db` while (2) is live
+hard-crashes the boot path on first read.
+
+## Concrete blockers (re-audit, 2026-06-13)
+
+- **127 production files in `apps/pops-api/src/`** still import
+  `getDrizzle` (the `pops.db` lazy singleton). Distribution by pillar:
+
+  | Pillar / area | Files calling `getDrizzle()` |
+  | ------------- | ---------------------------: |
+  | media         |                           63 |
+  | cerebrum      |                           19 |
+  | food          |                           18 |
+  | core          |                           17 |
+  | cross-pillar  |                            5 |
+  | lists         |                            2 |
+
+  The cross-pillar bucket (`jobs/sync-results.ts`,
+  `jobs/handlers/default.ts`, `jobs/handlers/embeddings-source.ts`,
+  `jobs/handlers/embeddings-helpers.ts`, `lib/inference-pricing.ts`)
+  has no owning Wave-3 PRD and needs explicit ownership before
+  PRD-213 can land.
+
+- **Live `pops.db` schema** still defines (and the runtime still
+  reads/writes) at least the following tables, owned by the shared
+  drizzle journal and not by any per-pillar DB package:
+  - `ai_alert_rules`, `ai_alert_rule_dispatches` (PRD-186 follow-up)
+  - `ai_providers`, `ai_model_pricing`, `ai_budgets`,
+    `ai_inference_log`, `ai_inference_daily`
+  - `user_settings` (PRD-183 was core.settings; user_settings is
+    distinct)
+  - `environments`
+  - `embeddings`, `embeddings_vec`
+  - `tag_rules`, `transaction_corrections`, `tag_vocabulary`
+  - every `media.*` and `food.*` table whose Wave-3 PRD has only
+    shipped PR1–PR3 (no PR4 drop yet)
+
+  Most of these are tracked one-by-one in the
+  [PRD-212 readiness matrix](../prds/212-readiness-audit/readiness-matrix.md);
+  the additions above (ai_alerts, ai_providers, embeddings,
+  user_settings, environments) widen that picture and should be folded
+  into the next matrix refresh.
+
+- **`SQLITE_PATH=/data/sqlite/pops.db`** is still wired up for both
+  `pops-api` and `pops-worker` in
+  [`infra/docker-compose.yml`](../../../../infra/docker-compose.yml).
+  The shared volume mount cannot be removed while either container
+  still calls `getDb()` / `getDrizzle()`.
+
+## Wave-5 acceptance gate
+
+Wave 5 unblocks once **all** of the following hold:
+
+1. PRD-212's readiness matrix shows **zero** rows of "Backfill still
+   active" and **zero** non-test `getDrizzle()` call sites.
+2. The drizzle journal under
+   `apps/pops-api/src/db/drizzle-migrations/` is either empty or
+   contains only the final drop migration authored by PRD-213.
+3. `migration-ownership.ts` has been emptied (every tag has migrated
+   into a per-pillar `packages/<id>-db/migrations/_journal.json`).
+4. The five cross-pillar infra hot-paths above have been re-pointed at
+   per-pillar handles or have explicit owners assigned via a new
+   "infra detach" PRD under Epic 09.
+
+Until those four conditions are met, Wave 5 stays parked. The next
+action is not "drop `pops.db`" — it is "close PR4 on the remaining
+Wave-3 PRDs and assign owners to the cross-pillar infra hot-paths."
+
+## Out of scope for this report
+
+- Authoring the final drop migration (PRD-213 US-01).
+- Touching `db.ts`, `migration-ownership.ts`, or
+  `infra/docker-compose.yml`. The matrix gating these changes is not
+  green, and editing them now ships a broken boot path.
+- Retiring `backfill-cerebrum-from-shared.ts`. That file is the only
+  backfill bridge left, and it stops mattering the moment the
+  `nudge_log` writer flip (PRD-149) lands; it is harmless until then.

--- a/docs/themes/13-pillar-finale/prds/212-readiness-audit/README.md
+++ b/docs/themes/13-pillar-finale/prds/212-readiness-audit/README.md
@@ -25,6 +25,11 @@ See [readiness-matrix.md](readiness-matrix.md) for the table-by-table
 matrix, residual call-site list, Wave-3 PRD cross-reference, and the
 recommended sequence into PRD-213.
 
+See [wave-5-blocked.md](../../notes/wave-5-blocked.md) for the
+2026-06-13 re-audit of `getDrizzle()` call sites by pillar, the live
+shared-journal tables still backing them, and the four-condition
+acceptance gate that PRD-213 / PRD-214 must clear before shipping.
+
 ## Overview
 
 Before dropping the legacy `pops.db`, confirm every table is owned by a pillar and no code still reaches into the shared DB. Uses Q1 schema-coverage CI data + grep audit + smoke harness.


### PR DESCRIPTION
## Summary

- **Wave 5 cannot ship today.** The brief assumed only `nudge_log` blocked the `pops.db` drop; in practice **127 production files** in `apps/pops-api/src/` still call `getDrizzle()` against the shared journal, and dozens of tables (ai_alert_rules, ai_providers, ai_inference_log, ai_inference_daily, ai_budgets, user_settings, environments, embeddings, tag_rules, plus every unfinished Wave-3 media/food slice) are still physically on `pops.db`.
- **No code, no schema, no infra touched.** Doc-only PR. Adds `docs/themes/13-pillar-finale/notes/wave-5-blocked.md` (audit snapshot + four-condition acceptance gate) and cross-references it from PRD-212's README so the blocker is discoverable from the existing audit doc.
- **What the brief got right:** only one boot-time `*-backfill-from-shared.ts` bridge remains (`backfill-cerebrum-from-shared.ts`, `nudge_log` only). **What it got wrong:** retiring the bridges did not retire the tables or the runtime callers. Those are tracked separately in PRD-212's readiness matrix and are still ~29 of 30 red.

## Audit detail (re-run 2026-06-13)

`getDrizzle()` callers in `apps/pops-api/src/` (non-test, excluding `db.ts` / `*-handle.ts` / `pillar-smoke-harness.ts`):

| Pillar / area | Files |
| ------------- | ----: |
| media         |    63 |
| cerebrum      |    19 |
| food          |    18 |
| core          |    17 |
| cross-pillar  |     5 |
| lists         |     2 |
| **Total**     | **124** |

Plus the cross-pillar infra hot-paths (`jobs/sync-results.ts`, `jobs/handlers/default.ts`, `jobs/handlers/embeddings-source.ts`, `jobs/handlers/embeddings-helpers.ts`, `lib/inference-pricing.ts`) which have no owning Wave-3 PRD and need explicit ownership before PRD-213 can land.

`SQLITE_PATH=/data/sqlite/pops.db` is still wired into both `pops-api` and `pops-worker` in `infra/docker-compose.yml`. Cannot be removed while either container still calls `getDb()` / `getDrizzle()`.

## Recommended next steps (not in this PR)

1. Close PR4 (drop backfill entry + drop `pops.db` table) on the 13 Wave-3 PRDs that have shipped PR3 (writer cutover) but not PR4.
2. Ship PRD-170 / PRD-173 PR3 + PR4 (last writer cutovers).
3. Spin a small "infra detach" PRD under Epic 09 for the five cross-pillar `getDrizzle()` hot-paths.
4. Re-run the audit; once all four conditions in `wave-5-blocked.md` go green, land PRD-213.

## Test plan

- [x] `git status` clean — only the two doc files in the diff.
- [x] Markdown links in both files resolve (relative paths verified).
- [x] No code, schema, infra, or build files touched — nothing to test at runtime.
