### PR TITLE
feat(workspaces): migrate module-registry consumers to runtime shim (PRD-218 US-02 batch 2)

### DIFF
--- a/apps/pops-api/src/modules/core/features/credentials.ts
+++ b/apps/pops-api/src/modules/core/features/credentials.ts
@@ -1,4 +1,4 @@
-import { MODULES } from '@pops/module-registry';
+import { INSTALLED_MODULES, MODULES } from '@pops/module-registry';
 
 import { getEnv } from '../../../env.js';
 import { getSettingOrNull } from '../settings/service.js';
@@ -13,15 +13,19 @@ import type {
 /**
  * Find the `SettingsField` for a given key by scanning every installed
  * module's declared settings sections. Reads from the build-time module
- * registry (PRD-101 US-04 follow-up): `MODULES.flatMap(m => m.settings ?? [])`.
+ * registry (PRD-101 US-04 follow-up) intersected with the runtime
+ * `INSTALLED_MODULES` shim (PRD-218 US-01) so a deploy that gates a
+ * module out via `POPS_APPS` / `POPS_OVERLAYS` cannot leak that module's
+ * setting field schema into credential resolution.
  *
  * The flatMap callback widens each module's narrow `settings` tuple back to
  * the contract type — the `satisfies readonly SettingsManifest[]` clause in
  * `generated.ts` already guards structural compatibility at codegen time.
  */
 function findSettingsField(key: string): SettingsField | null {
-  const sections = MODULES.flatMap((m): readonly SettingsManifest[] =>
-    'settings' in m && m.settings !== undefined ? m.settings : []
+  const sections = MODULES.filter((m) => INSTALLED_MODULES.includes(m.id)).flatMap(
+    (m): readonly SettingsManifest[] =>
+      'settings' in m && m.settings !== undefined ? m.settings : []
   );
   for (const manifest of sections) {
     for (const group of manifest.groups) {

--- a/apps/pops-api/src/modules/core/features/service.test.ts
+++ b/apps/pops-api/src/modules/core/features/service.test.ts
@@ -3,14 +3,21 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { seedSetting, setupTestContext } from '../../../shared/test-utils.js';
 
 // `credentials.ts` reads settings fields from `@pops/module-registry`'s
-// build-time `MODULES` constant (PRD-101 US-04 follow-up). Tests inject
+// build-time `MODULES` constant (PRD-101 US-04 follow-up), intersected
+// with the runtime `INSTALLED_MODULES` shim (PRD-218 US-01). Tests inject
 // synthetic settings manifests through a mocked registry; the mutable
-// `mockModules` array (kept hoisted so the factory captures it) lets each
-// test push manifests with `registerSettingsManifest()` and have
-// `findSettingsField()` resolve them.
-const { mockModules } = vi.hoisted(() => ({ mockModules: [] as { settings?: unknown }[] }));
+// `mockModules` array (kept hoisted so the factory captures it) lets
+// each test push manifests with `registerSettingsManifest()`.
+// `mockInstalledIds` is kept in lock-step with `mockModules` so the
+// runtime filter sees every test-pushed module as installed; install-set
+// gating is exercised separately in the search-engine matrix tests.
+const { mockModules, mockInstalledIds } = vi.hoisted(() => ({
+  mockModules: [] as { id: string; settings?: unknown }[],
+  mockInstalledIds: [] as string[],
+}));
 vi.mock('@pops/module-registry', () => ({
   MODULES: mockModules,
+  INSTALLED_MODULES: mockInstalledIds,
 }));
 
 import {
@@ -52,6 +59,7 @@ beforeEach(() => {
   installed = [];
   applyInstalled();
   mockModules.length = 0;
+  mockInstalledIds.length = 0;
 });
 
 afterEach(() => {
@@ -59,6 +67,7 @@ afterEach(() => {
   ctx.teardown();
   vi.unstubAllEnvs();
   mockModules.length = 0;
+  mockInstalledIds.length = 0;
 });
 
 /**
@@ -112,10 +121,12 @@ function registerSettingsManifest(fieldKeys: { key: string; envFallback?: string
       },
     ],
   };
-  // `credentials.ts` reads from the mocked `MODULES` (see top-of-file
-  // `vi.mock`). `installed`/`installedManifests` still drives the feature
-  // aggregator path; both surfaces have to agree on what's installed.
-  mockModules.push({ settings: [manifest] });
+  // `credentials.ts` reads from the mocked `MODULES` intersected with
+  // `INSTALLED_MODULES` (see top-of-file `vi.mock`).
+  // `installed`/`installedManifests` still drives the feature aggregator
+  // path; both surfaces have to agree on what's installed.
+  mockModules.push({ id: manifest.id, settings: [manifest] });
+  mockInstalledIds.push(manifest.id);
   installed.push({
     id: manifest.id,
     name: manifest.title,

--- a/apps/pops-api/src/modules/installed-modules.ts
+++ b/apps/pops-api/src/modules/installed-modules.ts
@@ -17,7 +17,7 @@
  *     (m) => m.features ?? []
  *   );
  */
-import { MODULES } from '@pops/module-registry';
+import { INSTALLED_MODULES, MODULES } from '@pops/module-registry';
 
 import { manifest as egoManifest } from './cerebrum/ego/index.js';
 import { manifest as cerebrumManifest } from './cerebrum/index.js';
@@ -61,31 +61,35 @@ function liveManifestById(id: string): ModuleManifest | undefined {
 
 /**
  * Test-only override. When set, `installedManifests()` returns this list
- * verbatim instead of computing from the build-time registry. Must be reset
- * between tests via `__resetInstalledManifestsOverride()`.
+ * verbatim instead of computing from the registry intersection. Must be
+ * reset between tests via `__resetInstalledManifestsOverride()`.
  *
- * The override exists because `MODULES` is `as const` literal data emitted
- * at build time — there is no public API for tests to inject synthetic
- * module manifests into it. This shim is the smallest seam that lets unit
- * tests exercise the resolver against arbitrary feature manifests without
- * spinning up the whole module graph.
+ * The override exists because `MODULES` / `INSTALLED_MODULES` are
+ * computed at build / module-load time — there is no public API for
+ * tests to inject synthetic module manifests into either. This shim is
+ * the smallest seam that lets unit tests exercise the resolver against
+ * arbitrary feature manifests without spinning up the whole module graph.
  */
 let testOverride: readonly ModuleManifest[] | null = null;
 
 /**
  * The list of manifests considered "installed" for this process — i.e.
- * present both in `MODULES` (build-time install set) and in the local
- * `LIVE_MANIFESTS` map.
+ * present in `MODULES` (build-time superset), inside `INSTALLED_MODULES`
+ * (the runtime `POPS_APPS` / `POPS_OVERLAYS` install set per PRD-218
+ * US-01), and bound in the local `LIVE_MANIFESTS` map.
  *
  * Intersection semantics: anything in `MODULES` that has no live
  * counterpart is silently skipped (not an error — frontend-only modules
  * such as `ai` are valid registry entries with no backend manifest).
+ * Anything gated out of `INSTALLED_MODULES` by env is also skipped so a
+ * deploy with `POPS_APPS=finance` mounts only `core` + `finance` here.
  */
 export function installedManifests(): readonly ModuleManifest[] {
   if (testOverride !== null) return testOverride;
 
   const out: ModuleManifest[] = [];
   for (const m of MODULES) {
+    if (!INSTALLED_MODULES.includes(m.id)) continue;
     const live = liveManifestById(m.id);
     if (live !== undefined) out.push(live);
   }
@@ -94,7 +98,8 @@ export function installedManifests(): readonly ModuleManifest[] {
 
 /**
  * Test-only: replace the installed-manifest source with `manifests`. Pass
- * `null` to restore the production behaviour (read from `MODULES`).
+ * `null` to restore the production behaviour (read from `MODULES`
+ * intersected with `INSTALLED_MODULES`).
  */
 export function __setInstalledManifestsOverride(manifests: readonly ModuleManifest[] | null): void {
   testOverride = manifests;

--- a/apps/pops-api/src/modules/search-adapters.test.ts
+++ b/apps/pops-api/src/modules/search-adapters.test.ts
@@ -54,17 +54,18 @@ describe('getOwnedAdapters', () => {
   });
 
   it('only emits adapters whose owning module is in the install set', () => {
-    // The build-time MODULES projection (sourced from KNOWN_MODULES) is the
-    // ground truth. With every module installed (default state in this test
-    // run) the aggregator emits every adapter. The opposite case — a build
-    // with `POPS_APPS=finance` — is exercised by the search engine matrix in
-    // PRD-101 US-11; verifying it here would require a separate registry
-    // build, which is out of scope for a unit test.
+    // The runtime `INSTALLED_MODULES` shim (PRD-218 US-01) is the ground
+    // truth. With every module installed (default state in this test run —
+    // no `POPS_APPS` / `POPS_OVERLAYS` narrowing) the aggregator emits every
+    // adapter. The opposite case — a deploy with `POPS_APPS=finance` — is
+    // exercised by the search engine matrix in PRD-101 US-11; verifying it
+    // here would require process-level env manipulation, which is out of
+    // scope for a unit test.
     const owned = getOwnedAdapters();
     const moduleIds = new Set(owned.map((o) => o.moduleId));
-    // Every emitted module id must be `core` (always installed) or one that
-    // `isModuleId` accepts. Stale bindings would surface as a non-installed
-    // module id slipping through.
+    // Every emitted module id must be `core` (always installed) or one
+    // `isInstalledModule` accepts. Stale bindings would surface as a
+    // non-installed module id slipping through.
     for (const id of moduleIds) {
       if (id === 'core') continue;
       expect(moduleIds.has(id)).toBe(true);

--- a/apps/pops-api/src/modules/search-adapters.ts
+++ b/apps/pops-api/src/modules/search-adapters.ts
@@ -19,7 +19,7 @@
  * cycle while the manifest stays the canonical declaration site
  * (cross-checked by `manifests.test.ts`).
  */
-import { isModuleId } from '@pops/module-registry';
+import { isInstalledModule } from '@pops/module-registry';
 
 import { entitiesSearchAdapter } from './core/entities/search-adapter.js';
 import { budgetsSearchAdapter } from './finance/budgets/search-adapter.js';
@@ -42,8 +42,9 @@ export interface OwnedAdapter {
  * match the corresponding module manifest's `search` slot —
  * `manifests.test.ts` is the cross-check.
  *
- * `core` is always installed (PRD-100); domain modules are gated against the
- * `MODULES` install set in `getOwnedAdapters`.
+ * `core` is always installed (PRD-100); domain modules are gated against
+ * the runtime `INSTALLED_MODULES` shim (PRD-218 US-01) in
+ * `getOwnedAdapters` so per-deploy `POPS_APPS` narrowing wins.
  */
 const ADAPTER_BINDINGS: readonly { moduleId: string; adapters: readonly SearchAdapter[] }[] = [
   { moduleId: 'core', adapters: [entitiesSearchAdapter] },
@@ -61,14 +62,16 @@ const ADAPTER_BINDINGS: readonly { moduleId: string; adapters: readonly SearchAd
  * — except the build-time `MODULES` constant carries metadata only, so this
  * helper joins the static adapter bindings to the install set.
  *
- * Filters out modules whose id is not in `MODULES` so a build with
- * `POPS_APPS=finance` never fans out to media or inventory adapters. `core`
- * is always installed and always passes the gate.
+ * Filters out modules whose id is not in `INSTALLED_MODULES` so a deploy
+ * with `POPS_APPS=finance` never fans out to media or inventory adapters.
+ * `core` is always installed and always passes the gate (it's also
+ * always present in `INSTALLED_MODULES`, but the explicit short-circuit
+ * documents the contract).
  */
 export function getOwnedAdapters(): readonly OwnedAdapter[] {
   const owned: OwnedAdapter[] = [];
   for (const { moduleId, adapters } of ADAPTER_BINDINGS) {
-    if (moduleId !== 'core' && !isModuleId(moduleId)) continue;
+    if (moduleId !== 'core' && !isInstalledModule(moduleId)) continue;
     for (const adapter of adapters) {
       owned.push({ moduleId, adapter });
     }

--- a/apps/pops-shell/scripts/build-registry-snapshot.ts
+++ b/apps/pops-shell/scripts/build-registry-snapshot.ts
@@ -19,9 +19,11 @@
  *
  * Output shape mirrors `@pops/module-registry`'s public surface that
  * the shell actually imports (`KNOWN_MODULES`, `MODULES`, `findModule`,
- * `isModuleId`). Settings sub-exports are intentionally not emitted —
- * the shell does not consume them at runtime; only the API does, and
- * the API does not switch install sets per Playwright project.
+ * `isModuleId`, plus `INSTALLED_MODULES` / `isInstalledModule` from the
+ * PRD-218 US-01 runtime shim). Settings sub-exports are intentionally
+ * not emitted — the shell does not consume them at runtime; only the
+ * API does, and the API does not switch install sets per Playwright
+ * project.
  *
  * Usage:
  *   tsx scripts/build-registry-snapshot.ts <output-file>
@@ -46,9 +48,11 @@ import {
 
 function renderSnapshot(
   projected: readonly SerialisableModule[],
-  knownIds: readonly string[]
+  knownIds: readonly string[],
+  installedIds: readonly string[]
 ): string {
   const knownIdsLiteral = JSON.stringify(knownIds);
+  const installedIdsLiteral = JSON.stringify(installedIds);
   const modulesLiteral = JSON.stringify(projected, null, 2);
   return `/**
  * GENERATED — E2E install-set snapshot for @pops/module-registry.
@@ -61,12 +65,18 @@ export const KNOWN_MODULES = Object.freeze(${knownIdsLiteral});
 
 export const MODULES = Object.freeze(${modulesLiteral});
 
+export const INSTALLED_MODULES = Object.freeze(${installedIdsLiteral});
+
 export function findModule(id) {
   return MODULES.find((m) => m.id === id);
 }
 
 export function isModuleId(value) {
   return MODULES.some((m) => m.id === value);
+}
+
+export function isInstalledModule(value) {
+  return INSTALLED_MODULES.includes(value);
 }
 `;
 }
@@ -80,12 +90,12 @@ async function main(): Promise<void> {
   const outputPath = resolve(outputArg);
 
   validateManifests(MANIFEST_SOURCES);
-  const installed = new Set(
-    resolveInstalledIds(KNOWN_MODULE_IDS, process.env, ALWAYS_INSTALLED_IDS)
-  );
+  const installedIds = resolveInstalledIds(KNOWN_MODULE_IDS, process.env, ALWAYS_INSTALLED_IDS);
+  const installed = new Set(installedIds);
   const selected = MANIFEST_SOURCES.filter((m) => installed.has(m.id));
   const sorted = selected.toSorted((a, b) => a.id.localeCompare(b.id, 'en'));
   const projected = sorted.map(project);
+  const installedIdsSorted = [...installedIds].toSorted((a, b) => a.localeCompare(b, 'en'));
 
   // Emit `KNOWN_MODULES` as the FULL known id list (every module the
   // monorepo can build) rather than just the install set. The shell's
@@ -98,7 +108,11 @@ async function main(): Promise<void> {
   const knownIdsSorted = [...KNOWN_MODULE_IDS].toSorted((a, b) => a.localeCompare(b, 'en'));
 
   await mkdir(dirname(outputPath), { recursive: true });
-  await writeFile(outputPath, renderSnapshot(projected, knownIdsSorted), 'utf8');
+  await writeFile(
+    outputPath,
+    renderSnapshot(projected, knownIdsSorted, installedIdsSorted),
+    'utf8'
+  );
   process.stdout.write(
     `build-registry-snapshot: wrote ${projected.length} module${
       projected.length === 1 ? '' : 's'

--- a/apps/pops-shell/src/app/installed-modules.ts
+++ b/apps/pops-shell/src/app/installed-modules.ts
@@ -23,7 +23,7 @@ import { manifest as foodManifest } from '@pops/app-food';
 import { manifest as inventoryManifest } from '@pops/app-inventory';
 import { manifest as listsManifest } from '@pops/app-lists';
 import { manifest as mediaManifest } from '@pops/app-media';
-import { MODULES } from '@pops/module-registry';
+import { INSTALLED_MODULES, MODULES } from '@pops/module-registry';
 import { manifest as egoManifest } from '@pops/overlay-ego';
 
 import type { RouteObject } from 'react-router';
@@ -71,25 +71,28 @@ function findKnownManifest(id: string): FrontendManifest | undefined {
 
 /**
  * Test-only override. When set, `installedFrontendManifests()` returns
- * this list verbatim instead of computing from the build-time registry.
+ * this list verbatim instead of computing from the registry intersection.
  * Reset between tests via `__resetInstalledFrontendManifestsOverride()`.
  *
- * The override exists because `MODULES` is `as const` literal data emitted
- * at build time — there is no public API for tests to inject synthetic
- * module manifests into it.
+ * The override exists because `MODULES` / `INSTALLED_MODULES` are
+ * computed at build / module-load time — there is no public API for
+ * tests to inject synthetic module manifests into either.
  */
 let testOverride: readonly FrontendManifest[] | null = null;
 
 /**
- * Frontend manifests considered "installed" for this build — present both
- * in `MODULES` (the build-time install set) and in `KNOWN_FRONTEND_MANIFESTS`.
- * Backend-only modules (`core`) are skipped at this layer: the shell has
- * no React routes to mount for them.
+ * Frontend manifests considered "installed" for this build — present in
+ * `MODULES` (the build-time superset), inside `INSTALLED_MODULES` (the
+ * runtime `POPS_APPS` / `POPS_OVERLAYS` install set per PRD-218 US-01),
+ * and bound in `KNOWN_FRONTEND_MANIFESTS`. Backend-only modules (`core`)
+ * are skipped at this layer: the shell has no React routes to mount for
+ * them.
  */
 export function installedFrontendManifests(): readonly FrontendManifest[] {
   if (testOverride !== null) return testOverride;
   const out: FrontendManifest[] = [];
   for (const m of MODULES) {
+    if (!INSTALLED_MODULES.includes(m.id)) continue;
     const live = findKnownManifest(m.id);
     if (live !== undefined) out.push(live);
   }
@@ -113,7 +116,8 @@ export function installedAppManifests(): readonly (FrontendManifest & {
 
 /**
  * Test-only: replace the installed-manifest source with `manifests`.
- * Pass `null` to restore the production behaviour (read from `MODULES`).
+ * Pass `null` to restore the production behaviour (read from `MODULES`
+ * intersected with `INSTALLED_MODULES`).
  */
 export function __setInstalledFrontendManifestsOverride(
   manifests: readonly FrontendManifest[] | null

--- a/apps/pops-shell/src/app/overlays/registry.test.ts
+++ b/apps/pops-shell/src/app/overlays/registry.test.ts
@@ -2,10 +2,11 @@
  * Tests for the shell-level overlay registry (PRD-101 US-07).
  *
  * The runtime export `installedOverlays` is the join of the live overlay
- * manifests and the build-time `MODULES` install set. The pure helper
- * `selectInstalledOverlays` is exposed so we can exercise both the
- * "installed" and "absent" branches without mocking the generated module
- * registry (which is build-time constant).
+ * manifests and the runtime `INSTALLED_MODULES` install set (PRD-218
+ * US-01: `POPS_APPS` / `POPS_OVERLAYS` are re-evaluated at module load).
+ * The pure helper `selectInstalledOverlays` is exposed so we can exercise
+ * both the "installed" and "absent" branches without mocking the
+ * generated module registry.
  */
 import { describe, expect, it } from 'vitest';
 

--- a/apps/pops-shell/src/app/overlays/registry.ts
+++ b/apps/pops-shell/src/app/overlays/registry.ts
@@ -1,4 +1,4 @@
-import { MODULES } from '@pops/module-registry';
+import { INSTALLED_MODULES } from '@pops/module-registry';
 /**
  * Shell-level overlay registry (PRD-101 US-07).
  *
@@ -64,12 +64,13 @@ export function selectInstalledOverlays(
 
 /**
  * Overlay modules that are both registered in this shell build AND in the
- * env-narrowed install set emitted by `@pops/module-registry`. Re-evaluated
- * once at module load; the install set is build-time constant.
+ * runtime install set emitted by `@pops/module-registry` (PRD-218 US-01:
+ * the `INSTALLED_MODULES` shim re-evaluates `POPS_APPS` / `POPS_OVERLAYS`
+ * at module load against the build-time `KNOWN_MODULES` superset).
  */
 export const installedOverlays: readonly InstalledOverlay[] = selectInstalledOverlays(
   SHELL_OVERLAY_MANIFESTS,
-  new Set(MODULES.map((m) => m.id))
+  new Set(INSTALLED_MODULES)
 );
 
 export { SHELL_OVERLAY_MANIFESTS };

--- a/apps/pops-shell/src/app/pages/SettingsPage.test.tsx
+++ b/apps/pops-shell/src/app/pages/SettingsPage.test.tsx
@@ -21,6 +21,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('@pops/module-registry', () => ({
   MODULES: [{ id: 'mock', settings: mocks.manifests }],
+  INSTALLED_MODULES: ['mock'],
 }));
 
 vi.mock('@/lib/trpc', () => ({

--- a/apps/pops-shell/src/app/pages/SettingsPage.tsx
+++ b/apps/pops-shell/src/app/pages/SettingsPage.tsx
@@ -2,7 +2,7 @@ import { SectionRenderer } from '@/components/settings/SectionRenderer';
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { MODULES } from '@pops/module-registry';
+import { INSTALLED_MODULES, MODULES } from '@pops/module-registry';
 import { Select } from '@pops/ui';
 
 import { SectionNav } from './settings-page/SectionNav';
@@ -29,15 +29,19 @@ function ManifestPanel({
 
 /**
  * Aggregate every installed module's settings sections (PRD-101 US-04 follow-up).
- * `MODULES` is the build-time install set — sections from absent modules are
- * elided at compile time, not filtered at runtime. The per-module narrow
- * tuple types are widened back to `SettingsManifest` via the inner-callback
- * return annotation so the sort comparator gets the contract type.
+ * `MODULES` carries the build-time data; `INSTALLED_MODULES` (PRD-218 US-01)
+ * is the per-deploy install set computed from `POPS_APPS` / `POPS_OVERLAYS`
+ * at module load. The intersection means a deploy that gates out a module
+ * never renders its settings sections. The per-module narrow tuple types
+ * are widened back to `SettingsManifest` via the inner-callback return
+ * annotation so the sort comparator gets the contract type.
  */
 function getManifests(): SettingsManifest[] {
-  return MODULES.flatMap((m): readonly SettingsManifest[] =>
-    'settings' in m && m.settings !== undefined ? m.settings : []
-  ).toSorted((a, b) => a.order - b.order);
+  return MODULES.filter((m) => INSTALLED_MODULES.includes(m.id))
+    .flatMap((m): readonly SettingsManifest[] =>
+      'settings' in m && m.settings !== undefined ? m.settings : []
+    )
+    .toSorted((a, b) => a.order - b.order);
 }
 
 export function SettingsPage() {


### PR DESCRIPTION
## Summary

- Migrate the install-set consumers of `@pops/module-registry` from the build-time `MODULES` / `isModuleId` to the runtime `INSTALLED_MODULES` / `isInstalledModule` shim (PRD-218 US-01, #3116) so per-deploy `POPS_APPS` / `POPS_OVERLAYS` narrowing wins at module load instead of being baked at registry build.
- Shell (5 files): `installed-modules.ts`, `overlays/registry.ts`, `pages/SettingsPage.tsx` + test, and the Playwright `scripts/build-registry-snapshot.ts` so the E2E install-set switcher mirrors the real registry surface.
- API (4 files): `modules/installed-modules.ts`, `modules/search-adapters.ts` + test comment, `modules/core/features/credentials.ts` + matching test mock.

## Remaining for batch 3

- `apps/pops-api/src/router.ts` — `MODULES` is referenced at type level only (`(typeof MODULES)[number]['id']` powers `InstalledRouterId`). The runtime shim is `readonly string[]` and can't replace a type-level constant; needs a paired type export to unblock.
- `apps/pops-api/src/modules/{manifests.ts, core/index.ts, core/uri/resolver.ts, finance/index.ts, inventory/index.ts, cerebrum/index.ts, cerebrum/ego/index.ts, media/index.ts}` — these import per-pillar settings schemas from `@pops/module-registry/settings`. Not install-set semantics; out of US-02 scope.

## Test plan

- [x] `pnpm typecheck` — pops-shell + pops-api clean
- [x] `pnpm test` — pops-shell 394/394, pops-api 4876/4876
- [x] `pnpm lint` — exit 0 (pre-existing warnings only, none introduced)
- [x] Husky pre-commit + pre-push chain green
- [ ] CI confirms the snapshot path still boots under Playwright install-set switching
