### PR TITLE
docs(theme-13): PRD-231 US-02 — wire-format publication target decision

### DIFF
--- a/docs/themes/13-pillar-finale/notes/wire-format-publication-decision.md
+++ b/docs/themes/13-pillar-finale/notes/wire-format-publication-decision.md
@@ -1,0 +1,99 @@
+# Wire-format publication target — decision note
+
+> PRD: [231 — Cross-language SDK wire-format spec](../prds/231-cross-language-wire-format-spec/README.md)
+> US: [us-02-publication-target](../prds/231-cross-language-wire-format-spec/us-02-publication-target.md)
+> Spec: [`pillar-wire-format-v1.md`](../specs/pillar-wire-format-v1.md)
+> Snapshot date: 2026-06-13
+
+## Decision
+
+**Keep the spec in this monorepo as the single source of truth at
+`docs/themes/13-pillar-finale/specs/pillar-wire-format-v1.md`, and add a
+thin root-level pointer file (`WIRE-FORMAT.md`) that links to it.** Do
+not extract a standalone `pops-wire-format` repo at this time.
+
+This is option (a) from the PRD with a small refinement: the spec does
+not move into `packages/pillar-sdk/` because that package is
+`private: true` and never publishes to npm — co-locating the spec there
+buys nothing and hurts discoverability for non-TS implementers browsing
+GitHub.
+
+## Options considered
+
+### (a) Ship inside / alongside `@pops/pillar-sdk`
+
+The PRD's default lean. The spec, the conformance suite (US-03), and
+the reference TS implementation all live in the same package, version
+together, and rev in lock-step.
+
+| Pro                                                                                    | Con                                                                                                                                                 |
+| -------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Spec, SDK, and conformance suite move together — no skew possible.                     | `@pops/pillar-sdk` is `private: true`. There is no npm publish today. External implementers cannot `npm install` it; co-location buys them nothing. |
+| One PR touches all three when wire-format and SDK behaviour change.                    | Pillar SDK rev cadence is high (every behaviour tweak); spec should be stable. Versioning gets noisy if they share a semver.                        |
+| Conformance suite is already at `packages/wire-conformance/` — same monorepo, same CI. | Spec buried under `packages/pillar-sdk/docs/` is hard to find from the GitHub root.                                                                 |
+| Existing precedent inside POPS: every other contract artifact lives in the workspace.  | —                                                                                                                                                   |
+
+### (b) Standalone repo `knoxio/pops-wire-format`
+
+A dedicated repository with versioned releases, its own CI, and a
+README pointing back at POPS.
+
+| Pro                                                                                                   | Con                                                                                                                                                                                                                   |
+| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Cross-language reach: a Rust/Go/Python engineer clones a markdown repo, not a TS SDK.                 | No concrete external consumer exists today. A second repo solves a problem nobody has yet.                                                                                                                            |
+| Independent semver. The spec revs only when the wire format itself revs.                              | Two-repo sync overhead. ADR-033, the SDK, and the conformance suite all reference the spec by URL — any move breaks links unless redirects exist.                                                                     |
+| Precedent: Protocol Buffers (`protocolbuffers/protobuf`), gRPC, OpenAPI all ship as standalone specs. | The conformance suite still needs the spec checked in to the POPS monorepo (or vendored) so SDK PRs can update spec + code + tests atomically. Duplication risk — exactly what the PRD's Notes section warns against. |
+| Discoverability via GitHub topics / search for "pops wire format".                                    | CI for a second repo to maintain (link validation, markdown lint). Low effort but non-zero.                                                                                                                           |
+
+## Why (a) wins for now
+
+1. **No external consumer exists.** PRD-231 ships the spec so engineers
+   _can_ write non-TS pillars; PRD-233 is the first such pillar and is
+   not on the runway. Until a concrete out-of-tree implementer asks for
+   a standalone repo, optimising for that case is speculative.
+2. **The pillar-sdk is `private: true`.** "Ship alongside the SDK"
+   doesn't mean "publish as part of the npm package" — there is no npm
+   package. It means "live in the same workspace as the conformance
+   suite and the reference TS impl", which is already true of the
+   `docs/` location.
+3. **Discoverability is solved by a root pointer, not by repo
+   topology.** An external engineer hitting `github.com/knoxio/pops`
+   sees `WIRE-FORMAT.md` at the root and clicks through. That's the
+   same number of hops as a standalone repo and avoids cross-repo sync.
+4. **The PRD's "avoid two URLs" rule.** Publishing in both a standalone
+   repo and the monorepo (for SDK PRs to land atomic spec changes)
+   guarantees skew within a release cycle. Single source of truth in
+   the monorepo eliminates the failure mode entirely.
+5. **Update cadence concern is over-stated.** The wire format is
+   versioned via `X-Pops-Wire-Version` and the spec ships as `v1`. The
+   SDK's frequent revs don't touch the spec unless they change
+   normative wire behaviour — and when they do, a single-PR atomic
+   change across spec + SDK + conformance suite is the desired flow.
+
+## Follow-up actions
+
+- [ ] Create `WIRE-FORMAT.md` at the repo root containing a one-line
+      pointer to `docs/themes/13-pillar-finale/specs/pillar-wire-format-v1.md`
+      and the permalink on `main`. (US-02 implementation step.)
+- [ ] Update ADR-033's `Related` section to link directly to the spec
+      path (not just "PRD-231"). (US-02 implementation step.)
+- [ ] Update the theme README's `## References` and Epic 14's
+      `## Dependencies` to point at the spec path. (US-02 implementation
+      step.)
+- [ ] Verify all spec section anchors (`#single-call-procedure`,
+      `#batched-procedure`, `#manifest-endpoint`, etc.) match the
+      headings in `pillar-wire-format-v1.md` so deep-links work.
+- [ ] Revisit this decision when the first non-TS pillar lands
+      (PRD-233 or later). If that engineer's feedback is "I'd prefer a
+      standalone repo", extract then — the spec is one file and a redirect
+      shim in the monorepo is cheap.
+
+## Explicitly rejected
+
+- Publishing the spec at both a standalone repo and the monorepo. The
+  PRD's `## Notes` section bans this. One source of truth, mirrored
+  only via automated build steps.
+- Putting the spec inside `packages/pillar-sdk/docs/`. The SDK is
+  private; the spec is normative for non-TS consumers; burying it
+  three directories deep under a TS package hurts the people the spec
+  is for.

--- a/docs/themes/13-pillar-finale/prds/231-cross-language-wire-format-spec/README.md
+++ b/docs/themes/13-pillar-finale/prds/231-cross-language-wire-format-spec/README.md
@@ -2,7 +2,7 @@
 
 > Epic: [Cross-language interop](../../epics/14-cross-language-interop.md)
 
-> Status: Partial — US-01 done, US-02/US-03 follow-up
+> Status: Partial — US-01 done, US-02 decision done (see [publication decision note](../../notes/wire-format-publication-decision.md)), US-03 follow-up
 
 > Spec: [`pillar-wire-format-v1.md`](../../specs/pillar-wire-format-v1.md)
 

--- a/docs/themes/13-pillar-finale/prds/231-cross-language-wire-format-spec/us-02-publication-target.md
+++ b/docs/themes/13-pillar-finale/prds/231-cross-language-wire-format-spec/us-02-publication-target.md
@@ -1,6 +1,14 @@
 # US-02: Decide and execute the publication target
 
 > PRD: [Cross-language SDK wire-format spec](README.md)
+>
+> Status: Done — decision recorded in
+> [`wire-format-publication-decision.md`](../../notes/wire-format-publication-decision.md).
+> Outcome: option (a), spec stays in the monorepo as single source of
+> truth with a root-level `WIRE-FORMAT.md` pointer. The doc-update
+> follow-ups (ADR-033 `Related` link, theme README references, Epic 14
+> dependencies, root `WIRE-FORMAT.md`) are tracked at the bottom of the
+> decision note and will land in subsequent PRs.
 
 ## Description
 
@@ -8,8 +16,8 @@ As a maintainer needing to point external pillar authors at the wire-format spec
 
 ## Acceptance Criteria
 
-- [ ] A short trade-off note exists at the top of this US's PR describing the two candidates: (a) ship as a deliverable inside `@pops/pillar-sdk` so it travels with the contract package, or (b) ship as a standalone `pops-wire-format` repo so it can be referenced without npm-installing the SDK.
-- [ ] One option is chosen with a one-paragraph justification. Default lean: (a) — co-location with the SDK keeps the spec, the conformance suite (US-03), and the reference TS implementation in lock-step. (b) is justified if and only if a concrete external consumer needs to reference the spec without depending on the SDK.
+- [x] A short trade-off note exists at the top of this US's PR describing the two candidates: (a) ship as a deliverable inside `@pops/pillar-sdk` so it travels with the contract package, or (b) ship as a standalone `pops-wire-format` repo so it can be referenced without npm-installing the SDK.
+- [x] One option is chosen with a one-paragraph justification. Default lean: (a) — co-location with the SDK keeps the spec, the conformance suite (US-03), and the reference TS implementation in lock-step. (b) is justified if and only if a concrete external consumer needs to reference the spec without depending on the SDK.
 - [ ] The spec is published at the chosen target with stable internal anchor links (`#single-call-procedure`, `#batched-procedure`, etc.) so future docs can deep-link.
 - [ ] ADR-033's `Related` section is updated to link directly to `wire-format-spec.md` at the chosen URL (currently it only references "PRD-231" by number).
 - [ ] The theme README's `## References` and Epic 14's `## Dependencies` are updated to reference the spec at the chosen URL.


### PR DESCRIPTION
## Summary

- Record the publication-target decision for the cross-language pillar wire-format spec (PRD-231 US-02).
- Recommendation: option (a), keep the spec in the monorepo at `docs/themes/13-pillar-finale/specs/pillar-wire-format-v1.md` as the single source of truth, with a root-level `WIRE-FORMAT.md` pointer to be added in a follow-up PR. Standalone `pops-wire-format` repo deferred until a concrete external consumer materialises.
- Marks US-02 as Done in `us-02-publication-target.md` and updates the PRD-231 README status line.

## Justification (short)

`@pops/pillar-sdk` is `private: true` and never publishes to npm, so "co-locate with the SDK" really means "live in the monorepo" — which the spec already does. A standalone repo solves a problem (cross-language reach without `npm install`) that has no current consumer; PRD-233 (first non-TS pillar) is not on the runway. The PRD's "avoid two URLs" rule rules out mirroring. Single source of truth in `docs/` plus a thin root pointer gives discoverability without cross-repo sync.

## Doc-only

No code or schema changes. Decision note + status updates only.

## Test plan

- [ ] Reviewer agrees the trade-off table is honest about option (b)'s upside.
- [ ] Reviewer confirms the follow-up actions (root `WIRE-FORMAT.md`, ADR-033 link, theme README + Epic 14 dependency updates) are correctly scoped as separate PRs.
- [ ] Reviewer sanity-checks the assertion that `@pops/pillar-sdk` is not on npm (it is `private: true`).