### PR TITLE
feat(app-media): migrate first batch of tRPC sites to pillar SDK (PRD-227)

### DIFF
--- a/packages/app-media/package.json
+++ b/packages/app-media/package.json
@@ -16,6 +16,7 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@pops/api-client": "workspace:*",
     "@pops/navigation": "workspace:*",
+    "@pops/pillar-sdk": "workspace:*",
     "@pops/types": "workspace:*",
     "@pops/ui": "workspace:*",
     "@tanstack/react-query": "5.101.0",

--- a/packages/app-media/src/components/ArrStatusBadge.test.tsx
+++ b/packages/app-media/src/components/ArrStatusBadge.test.tsx
@@ -7,21 +7,21 @@ const mockGetConfig = vi.fn();
 const mockGetMovieStatus = vi.fn();
 const mockGetShowStatus = vi.fn();
 
-vi.mock('@pops/api-client', () => ({
-  trpc: {
-    media: {
-      arr: {
-        getConfig: { useQuery: () => mockGetConfig() },
-        getMovieStatus: {
-          useQuery: (_input: unknown, opts: { enabled: boolean }) =>
-            opts.enabled ? mockGetMovieStatus() : { data: null, isLoading: false, error: null },
-        },
-        getShowStatus: {
-          useQuery: (_input: unknown, opts: { enabled: boolean }) =>
-            opts.enabled ? mockGetShowStatus() : { data: null, isLoading: false, error: null },
-        },
-      },
-    },
+vi.mock('@pops/pillar-sdk/react', () => ({
+  usePillarQuery: (
+    _pillarId: string,
+    path: readonly string[],
+    _input: unknown,
+    opts?: { enabled?: boolean }
+  ) => {
+    const key = path.join('.');
+    if (key === 'arr.getConfig') return mockGetConfig();
+    const enabled = opts?.enabled ?? true;
+    if (key === 'arr.getMovieStatus')
+      return enabled ? mockGetMovieStatus() : { data: null, isLoading: false, error: null };
+    if (key === 'arr.getShowStatus')
+      return enabled ? mockGetShowStatus() : { data: null, isLoading: false, error: null };
+    return { data: null, isLoading: false, error: null };
   },
 }));
 

--- a/packages/app-media/src/components/ArrStatusBadge.tsx
+++ b/packages/app-media/src/components/ArrStatusBadge.tsx
@@ -1,4 +1,4 @@
-import { trpc } from '@pops/api-client';
+import { usePillarQuery } from '@pops/pillar-sdk/react';
 /**
  * ArrStatusBadge — shows Radarr/Sonarr monitoring and download status.
  *
@@ -16,16 +16,34 @@ interface ArrStatusBadgeProps {
   externalId: number;
 }
 
+interface ArrConfigResult {
+  data: { radarrConfigured: boolean; sonarrConfigured: boolean };
+}
+
+type ArrStatus = keyof typeof ARR_STATUS_STYLES;
+
+interface ArrStatusResult {
+  data: { status: ArrStatus; label: string } | null;
+}
+
 function useArrStatus({ kind, externalId }: ArrStatusBadgeProps) {
-  const { data: configData } = trpc.media.arr.getConfig.useQuery();
+  const { data: configData } = usePillarQuery<ArrConfigResult>(
+    'media',
+    ['arr', 'getConfig'],
+    undefined
+  );
   const config = configData?.data;
   const isConfigured = kind === 'movie' ? config?.radarrConfigured : config?.sonarrConfigured;
 
-  const movieStatus = trpc.media.arr.getMovieStatus.useQuery(
+  const movieStatus = usePillarQuery<ArrStatusResult>(
+    'media',
+    ['arr', 'getMovieStatus'],
     { tmdbId: externalId },
     { enabled: kind === 'movie' && isConfigured === true }
   );
-  const showStatus = trpc.media.arr.getShowStatus.useQuery(
+  const showStatus = usePillarQuery<ArrStatusResult>(
+    'media',
+    ['arr', 'getShowStatus'],
     { tvdbId: externalId },
     { enabled: kind === 'show' && isConfigured === true }
   );

--- a/packages/app-media/src/components/ComparisonScores.test.tsx
+++ b/packages/app-media/src/components/ComparisonScores.test.tsx
@@ -23,14 +23,12 @@ vi.mock('recharts', () => ({
 const mockScoresQuery = vi.fn();
 const mockDimensionsQuery = vi.fn();
 
-vi.mock('@pops/api-client', () => ({
-  trpc: {
-    media: {
-      comparisons: {
-        scores: { useQuery: (...args: unknown[]) => mockScoresQuery(...args) },
-        listDimensions: { useQuery: () => mockDimensionsQuery() },
-      },
-    },
+vi.mock('@pops/pillar-sdk/react', () => ({
+  usePillarQuery: (_pillarId: string, path: readonly string[], input: unknown) => {
+    const key = path.join('.');
+    if (key === 'comparisons.scores') return mockScoresQuery(input);
+    if (key === 'comparisons.listDimensions') return mockDimensionsQuery();
+    return { data: undefined, isLoading: false };
   },
 }));
 

--- a/packages/app-media/src/components/ComparisonScores.tsx
+++ b/packages/app-media/src/components/ComparisonScores.tsx
@@ -7,7 +7,7 @@ import {
   Tooltip,
 } from 'recharts';
 
-import { trpc } from '@pops/api-client';
+import { usePillarQuery } from '@pops/pillar-sdk/react';
 /**
  * ComparisonScores — radar chart showing Elo scores across comparison dimensions.
  * Queries scores and dimensions, merges them, and renders a recharts RadarChart.
@@ -109,12 +109,22 @@ function ScoresChart({ radarData }: { radarData: RadarDatum[] }) {
   );
 }
 
+interface ScoresResult {
+  data: (ScoreEntry & { excluded?: boolean })[];
+}
+
+interface DimensionsResult {
+  data: DimensionEntry[];
+}
+
 export function ComparisonScores({ mediaType, mediaId }: ComparisonScoresProps) {
-  const { data: scoresResponse, isLoading: scoresLoading } = trpc.media.comparisons.scores.useQuery(
+  const { data: scoresResponse, isLoading: scoresLoading } = usePillarQuery<ScoresResult>(
+    'media',
+    ['comparisons', 'scores'],
     { mediaType, mediaId }
   );
   const { data: dimensionsResponse, isLoading: dimensionsLoading } =
-    trpc.media.comparisons.listDimensions.useQuery();
+    usePillarQuery<DimensionsResult>('media', ['comparisons', 'listDimensions'], undefined);
 
   if (scoresLoading || dimensionsLoading) {
     return (

--- a/packages/app-media/src/components/DebriefBanner.test.tsx
+++ b/packages/app-media/src/components/DebriefBanner.test.tsx
@@ -5,13 +5,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockGetPendingDebriefs = vi.fn();
 
-vi.mock('@pops/api-client', () => ({
-  trpc: {
-    media: {
-      comparisons: {
-        getPendingDebriefs: { useQuery: () => mockGetPendingDebriefs() },
-      },
-    },
+vi.mock('@pops/pillar-sdk/react', () => ({
+  usePillarQuery: (_pillarId: string, path: readonly string[]) => {
+    if (path.join('.') === 'comparisons.getPendingDebriefs') return mockGetPendingDebriefs();
+    return { data: undefined };
   },
 }));
 

--- a/packages/app-media/src/components/DebriefBanner.tsx
+++ b/packages/app-media/src/components/DebriefBanner.tsx
@@ -2,7 +2,7 @@ import { ClipboardList, X } from 'lucide-react';
 import { useState } from 'react';
 import { Link } from 'react-router';
 
-import { trpc } from '@pops/api-client';
+import { usePillarQuery } from '@pops/pillar-sdk/react';
 /**
  * DebriefBanner — shows a notification when movies are pending debrief.
  *
@@ -10,9 +10,21 @@ import { trpc } from '@pops/api-client';
  */
 import { Alert, AlertDescription, AlertTitle } from '@pops/ui';
 
+interface PendingDebrief {
+  movieId: number;
+}
+
+interface PendingDebriefsResult {
+  data: PendingDebrief[];
+}
+
 export function DebriefBanner() {
   const [dismissed, setDismissed] = useState(false);
-  const { data } = trpc.media.comparisons.getPendingDebriefs.useQuery();
+  const { data } = usePillarQuery<PendingDebriefsResult>(
+    'media',
+    ['comparisons', 'getPendingDebriefs'],
+    undefined
+  );
 
   const debriefs = data?.data;
   if (!debriefs || debriefs.length === 0 || dismissed) return null;

--- a/packages/app-media/src/components/DebriefControls.test.tsx
+++ b/packages/app-media/src/components/DebriefControls.test.tsx
@@ -7,25 +7,17 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 let dismissOpts: Record<string, (...args: unknown[]) => unknown> = {};
 const mockDismissMutate = vi.fn();
 
-vi.mock('@pops/api-client', () => ({
-  trpc: {
-    media: {
-      comparisons: {
-        dismissDebriefDimension: {
-          useMutation: (opts: Record<string, (...args: unknown[]) => unknown>) => {
-            dismissOpts = opts;
-            return { mutate: mockDismissMutate, isPending: false };
-          },
-        },
-      },
-    },
-    useUtils: () => ({
-      media: {
-        comparisons: {
-          getPendingDebriefs: { invalidate: vi.fn() },
-        },
-      },
-    }),
+vi.mock('@pops/pillar-sdk/react', () => ({
+  usePillarMutation: (
+    _pillarId: string,
+    path: readonly string[],
+    opts: Record<string, (...args: unknown[]) => unknown>
+  ) => {
+    if (path.join('.') === 'comparisons.dismissDebriefDimension') {
+      dismissOpts = opts;
+      return { mutate: mockDismissMutate, isPending: false };
+    }
+    return { mutate: vi.fn(), isPending: false };
   },
 }));
 

--- a/packages/app-media/src/components/DebriefControls.tsx
+++ b/packages/app-media/src/components/DebriefControls.tsx
@@ -2,7 +2,7 @@ import { DoorOpen, SkipForward } from 'lucide-react';
 import { useNavigate } from 'react-router';
 import { toast } from 'sonner';
 
-import { trpc } from '@pops/api-client';
+import { usePillarMutation } from '@pops/pillar-sdk/react';
 /**
  * Debrief session controls: skip dimension, bail out (done for now),
  * and completion summary.
@@ -28,24 +28,30 @@ interface SkipDimensionButtonProps {
   onSkipped?: () => void;
 }
 
+interface DismissDebriefDimensionInput {
+  sessionId: number;
+  dimensionId: number;
+}
+
 export function SkipDimensionButton({
   sessionId,
   dimensionId,
   dimensionName,
   onSkipped,
 }: SkipDimensionButtonProps) {
-  const utils = trpc.useUtils();
-
-  const dismissMutation = trpc.media.comparisons.dismissDebriefDimension.useMutation({
-    onSuccess: () => {
-      toast.success(`Skipped ${dimensionName}`);
-      void utils.media.comparisons.getPendingDebriefs.invalidate();
-      onSkipped?.();
-    },
-    onError: (err) => {
-      toast.error(err.message);
-    },
-  });
+  const dismissMutation = usePillarMutation<DismissDebriefDimensionInput, unknown>(
+    'media',
+    ['comparisons', 'dismissDebriefDimension'],
+    {
+      onSuccess: () => {
+        toast.success(`Skipped ${dimensionName}`);
+        onSkipped?.();
+      },
+      onError: (err) => {
+        toast.error(err.message);
+      },
+    }
+  );
 
   return (
     <Button

--- a/packages/app-media/src/components/DebriefResultsSummary.test.tsx
+++ b/packages/app-media/src/components/DebriefResultsSummary.test.tsx
@@ -5,18 +5,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mockGetDebrief = vi.fn();
 const mockScores = vi.fn();
 
-vi.mock('@pops/api-client', () => ({
-  trpc: {
-    media: {
-      comparisons: {
-        getDebrief: {
-          useQuery: (...args: unknown[]) => mockGetDebrief(...args),
-        },
-        scores: {
-          useQuery: (...args: unknown[]) => mockScores(...args),
-        },
-      },
-    },
+vi.mock('@pops/pillar-sdk/react', () => ({
+  usePillarQuery: (_pillarId: string, path: readonly string[], input: unknown, opts?: unknown) => {
+    const key = path.join('.');
+    if (key === 'comparisons.getDebrief') return mockGetDebrief(input, opts);
+    if (key === 'comparisons.scores') return mockScores(input, opts);
+    return { data: undefined, isLoading: false, error: null };
   },
 }));
 

--- a/packages/app-media/src/components/DebriefResultsSummary.tsx
+++ b/packages/app-media/src/components/DebriefResultsSummary.tsx
@@ -1,7 +1,7 @@
 import { ArrowLeft, CheckCircle, Clock, Trophy, XCircle } from 'lucide-react';
 import { useNavigate } from 'react-router';
 
-import { trpc } from '@pops/api-client';
+import { usePillarQuery } from '@pops/pillar-sdk/react';
 /**
  * DebriefResultsSummary — shows per-dimension results and ELO score
  * changes after completing a debrief session.
@@ -143,16 +143,29 @@ function ResultsBody({
   );
 }
 
+interface GetDebriefResult {
+  data: DebriefData;
+}
+
+interface ScoresResult {
+  data: { dimensionId: number; score: number }[];
+}
+
 export function DebriefResultsSummary({ mediaType, mediaId }: DebriefResultsSummaryProps) {
   const {
     data: debriefData,
     isLoading,
     error,
-  } = trpc.media.comparisons.getDebrief.useQuery({ mediaType, mediaId });
+  } = usePillarQuery<GetDebriefResult>('media', ['comparisons', 'getDebrief'], {
+    mediaType,
+    mediaId,
+  });
 
   const debrief = debriefData?.data;
 
-  const { data: scoresData } = trpc.media.comparisons.scores.useQuery(
+  const { data: scoresData } = usePillarQuery<ScoresResult>(
+    'media',
+    ['comparisons', 'scores'],
     { mediaType: 'movie', mediaId: debrief?.movie.mediaId ?? 0 },
     { enabled: !!debrief }
   );

--- a/packages/app-media/src/components/DownloadQueue.tsx
+++ b/packages/app-media/src/components/DownloadQueue.tsx
@@ -1,4 +1,4 @@
-import { trpc } from '@pops/api-client';
+import { usePillarQuery } from '@pops/pillar-sdk/react';
 /**
  * DownloadQueue — shows active downloads from Radarr + Sonarr.
  *
@@ -7,16 +7,62 @@ import { trpc } from '@pops/api-client';
  */
 import { Badge } from '@pops/ui';
 
-export function DownloadQueue() {
-  const { data: configData } = trpc.media.arr.getConfig.useQuery();
-  const config = configData?.data;
+interface ArrConfigResult {
+  data: { radarrConfigured: boolean; sonarrConfigured: boolean };
+}
 
+interface DownloadQueueItem {
+  id: string | number;
+  mediaType: string;
+  title: string;
+  episodeLabel?: string;
+  progress: number;
+}
+
+interface DownloadQueueResult {
+  data: DownloadQueueItem[];
+}
+
+function DownloadRow({ item }: { item: DownloadQueueItem }) {
+  return (
+    <div className="flex items-center gap-3 rounded-lg border bg-card p-3">
+      <Badge variant="outline" className="text-2xs uppercase shrink-0">
+        {item.mediaType === 'movie' ? 'Movie' : 'Episode'}
+      </Badge>
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium truncate">
+          {item.title}
+          {item.episodeLabel && (
+            <span className="text-muted-foreground ml-1.5">{item.episodeLabel}</span>
+          )}
+        </p>
+        <div className="mt-1 h-1.5 rounded-full bg-muted overflow-hidden">
+          <div
+            className="h-full rounded-full bg-app-accent transition-all duration-500"
+            style={{ width: `${item.progress}%` }}
+          />
+        </div>
+      </div>
+      <span className="text-xs text-muted-foreground tabular-nums shrink-0">{item.progress}%</span>
+    </div>
+  );
+}
+
+export function DownloadQueue() {
+  const { data: configData } = usePillarQuery<ArrConfigResult>(
+    'media',
+    ['arr', 'getConfig'],
+    undefined
+  );
+  const config = configData?.data;
   const hasAnyService = config?.radarrConfigured ?? config?.sonarrConfigured;
 
-  const { data } = trpc.media.arr.getDownloadQueue.useQuery(undefined, {
-    enabled: hasAnyService === true,
-    refetchInterval: 30_000,
-  });
+  const { data } = usePillarQuery<DownloadQueueResult>(
+    'media',
+    ['arr', 'getDownloadQueue'],
+    undefined,
+    { enabled: hasAnyService === true, refetchInterval: 30_000 }
+  );
 
   const items = data?.data;
   if (!items || items.length === 0) return null;
@@ -27,42 +73,9 @@ export function DownloadQueue() {
         Downloading
       </h2>
       <div className="space-y-1.5">
-        {items.map(
-          (item: {
-            id: string | number;
-            mediaType: string;
-            title: string;
-            episodeLabel?: string;
-            progress: number;
-          }) => (
-            <div key={item.id} className="flex items-center gap-3 rounded-lg border bg-card p-3">
-              <Badge variant="outline" className="text-2xs uppercase shrink-0">
-                {item.mediaType === 'movie' ? 'Movie' : 'Episode'}
-              </Badge>
-
-              <div className="flex-1 min-w-0">
-                <p className="text-sm font-medium truncate">
-                  {item.title}
-                  {item.episodeLabel && (
-                    <span className="text-muted-foreground ml-1.5">{item.episodeLabel}</span>
-                  )}
-                </p>
-
-                {/* Progress bar */}
-                <div className="mt-1 h-1.5 rounded-full bg-muted overflow-hidden">
-                  <div
-                    className="h-full rounded-full bg-app-accent transition-all duration-500"
-                    style={{ width: `${item.progress}%` }}
-                  />
-                </div>
-              </div>
-
-              <span className="text-xs text-muted-foreground tabular-nums shrink-0">
-                {item.progress}%
-              </span>
-            </div>
-          )
-        )}
+        {items.map((item) => (
+          <DownloadRow key={item.id} item={item} />
+        ))}
       </div>
     </section>
   );

--- a/packages/app-media/src/components/ExcludedDimensions.test.tsx
+++ b/packages/app-media/src/components/ExcludedDimensions.test.tsx
@@ -6,27 +6,14 @@ const mockScoresQuery = vi.fn();
 const mockDimensionsQuery = vi.fn();
 const mockIncludeMutate = vi.fn();
 
-vi.mock('@pops/api-client', () => ({
-  trpc: {
-    useUtils: () => ({
-      media: {
-        comparisons: {
-          scores: { invalidate: vi.fn() },
-        },
-      },
-    }),
-    media: {
-      comparisons: {
-        scores: { useQuery: (...args: unknown[]) => mockScoresQuery(...args) },
-        listDimensions: { useQuery: () => mockDimensionsQuery() },
-        includeInDimension: {
-          useMutation: () => {
-            return { mutate: mockIncludeMutate, isPending: false };
-          },
-        },
-      },
-    },
+vi.mock('@pops/pillar-sdk/react', () => ({
+  usePillarQuery: (_pillarId: string, path: readonly string[], input: unknown) => {
+    const key = path.join('.');
+    if (key === 'comparisons.scores') return mockScoresQuery(input);
+    if (key === 'comparisons.listDimensions') return mockDimensionsQuery();
+    return { data: undefined, isLoading: false };
   },
+  usePillarMutation: () => ({ mutate: mockIncludeMutate, isPending: false }),
 }));
 
 import { ExcludedDimensions } from './ExcludedDimensions';

--- a/packages/app-media/src/components/ExcludedDimensions.tsx
+++ b/packages/app-media/src/components/ExcludedDimensions.tsx
@@ -1,6 +1,6 @@
 import { toast } from 'sonner';
 
-import { trpc } from '@pops/api-client';
+import { usePillarMutation, usePillarQuery } from '@pops/pillar-sdk/react';
 /**
  * ExcludedDimensions — shows which comparison dimensions a movie is excluded from
  * and provides an "Include" button to restore it.
@@ -12,37 +12,99 @@ export interface ExcludedDimensionsProps {
   mediaId: number;
 }
 
-export function ExcludedDimensions({ mediaType, mediaId }: ExcludedDimensionsProps) {
-  const utils = trpc.useUtils();
+interface ScoreEntry {
+  dimensionId: number;
+  excluded: boolean;
+}
 
-  const { data: scoresResponse } = trpc.media.comparisons.scores.useQuery({
-    mediaType,
-    mediaId,
-  });
+interface DimensionEntry {
+  id: number;
+  name: string;
+}
 
-  const { data: dimensionsResponse } = trpc.media.comparisons.listDimensions.useQuery();
+interface ScoresResult {
+  data: ScoreEntry[];
+}
 
-  const includeMutation = trpc.media.comparisons.includeInDimension.useMutation({
-    onSuccess: (_data, variables) => {
-      const dimName = dimensions.find((d) => d.id === variables.dimensionId)?.name ?? 'dimension';
-      toast.success(`Included in ${dimName}`);
-      void utils.media.comparisons.scores.invalidate({ mediaType, mediaId });
-    },
-    onError: (err) => {
-      toast.error(`Failed to include: ${err.message}`);
-    },
-  });
+interface DimensionsResult {
+  data: DimensionEntry[];
+}
+
+interface IncludeInDimensionInput {
+  mediaType: 'movie' | 'tv_show';
+  mediaId: number;
+  dimensionId: number;
+}
+
+function useExcludedDimensionsModel(mediaType: 'movie' | 'tv_show', mediaId: number) {
+  const { data: scoresResponse } = usePillarQuery<ScoresResult>(
+    'media',
+    ['comparisons', 'scores'],
+    { mediaType, mediaId }
+  );
+
+  const { data: dimensionsResponse } = usePillarQuery<DimensionsResult>(
+    'media',
+    ['comparisons', 'listDimensions'],
+    undefined
+  );
 
   const scores = scoresResponse?.data ?? [];
   const dimensions = dimensionsResponse?.data ?? [];
 
-  // Find excluded dimensions by matching scores with excluded=true
-  const excludedScores = scores.filter((s: { excluded: boolean }) => s.excluded);
+  const includeMutation = usePillarMutation<IncludeInDimensionInput, unknown>(
+    'media',
+    ['comparisons', 'includeInDimension'],
+    {
+      onSuccess: (_data, variables) => {
+        const dimName = dimensions.find((d) => d.id === variables.dimensionId)?.name ?? 'dimension';
+        toast.success(`Included in ${dimName}`);
+      },
+      onError: (err) => {
+        toast.error(`Failed to include: ${err.message}`);
+      },
+    }
+  );
 
+  return { scores, dimensions, includeMutation };
+}
+
+function ExcludedRow({
+  score,
+  dimensionMap,
+  isPending,
+  onInclude,
+}: {
+  score: ScoreEntry;
+  dimensionMap: Map<number, string>;
+  isPending: boolean;
+  onInclude: (dimensionId: number) => void;
+}) {
+  return (
+    <div className="flex items-center justify-between py-1.5 px-2 rounded-md bg-muted/50">
+      <span className="text-sm font-medium">
+        {dimensionMap.get(score.dimensionId) ?? `Dimension ${score.dimensionId}`}
+      </span>
+      <Button
+        variant="outline"
+        size="sm"
+        disabled={isPending}
+        onClick={() => {
+          onInclude(score.dimensionId);
+        }}
+      >
+        Include
+      </Button>
+    </div>
+  );
+}
+
+export function ExcludedDimensions({ mediaType, mediaId }: ExcludedDimensionsProps) {
+  const { scores, dimensions, includeMutation } = useExcludedDimensionsModel(mediaType, mediaId);
+  const excludedScores = scores.filter((s) => s.excluded);
   if (excludedScores.length === 0) return null;
 
-  // Build dimension name lookup
-  const dimensionMap = new Map(dimensions.map((d: { id: number; name: string }) => [d.id, d.name]));
+  const dimensionMap = new Map(dimensions.map((d) => [d.id, d.name]));
 
   return (
     <section>
@@ -51,29 +113,16 @@ export function ExcludedDimensions({ mediaType, mediaId }: ExcludedDimensionsPro
         <p className="text-sm text-muted-foreground mb-3">
           This movie is excluded from the following comparison dimensions:
         </p>
-        {excludedScores.map((s: { dimensionId: number }) => (
-          <div
+        {excludedScores.map((s) => (
+          <ExcludedRow
             key={s.dimensionId}
-            className="flex items-center justify-between py-1.5 px-2 rounded-md bg-muted/50"
-          >
-            <span className="text-sm font-medium">
-              {dimensionMap.get(s.dimensionId) ?? `Dimension ${s.dimensionId}`}
-            </span>
-            <Button
-              variant="outline"
-              size="sm"
-              disabled={includeMutation.isPending}
-              onClick={() => {
-                includeMutation.mutate({
-                  mediaType,
-                  mediaId,
-                  dimensionId: s.dimensionId,
-                });
-              }}
-            >
-              Include
-            </Button>
-          </div>
+            score={s}
+            dimensionMap={dimensionMap}
+            isPending={includeMutation.isPending}
+            onInclude={(dimensionId) => {
+              includeMutation.mutate({ mediaType, mediaId, dimensionId });
+            }}
+          />
         ))}
       </div>
     </section>

--- a/packages/app-media/src/components/LeavingSoonShelf.tsx
+++ b/packages/app-media/src/components/LeavingSoonShelf.tsx
@@ -1,7 +1,7 @@
 import { X } from 'lucide-react';
 import { toast } from 'sonner';
 
-import { trpc } from '@pops/api-client';
+import { usePillarMutation, usePillarQuery } from '@pops/pillar-sdk/react';
 /**
  * LeavingSoonShelf — horizontal shelf showing movies scheduled for removal.
  * Used on the Library page above the main grid.
@@ -82,17 +82,25 @@ function LeavingMovieCard({
 }
 
 export function LeavingSoonShelf() {
-  const { data: movies, isLoading, refetch } = trpc.media.rotation.getLeavingMovies.useQuery();
-  const cancelMutation = trpc.media.rotation.cancelLeaving.useMutation({
-    onSuccess: (_data, variables) => {
-      const movie = movies?.find((m) => m.id === variables.movieId);
-      toast.success(`Kept "${movie?.title ?? 'movie'}" in library`);
-      void refetch();
-    },
-    onError: () => {
-      toast.error('Failed to cancel leaving status');
-    },
-  });
+  const {
+    data: movies,
+    isLoading,
+    refetch,
+  } = usePillarQuery<LeavingMovie[]>('media', ['rotation', 'getLeavingMovies'], undefined);
+  const cancelMutation = usePillarMutation<{ movieId: number }, unknown>(
+    'media',
+    ['rotation', 'cancelLeaving'],
+    {
+      onSuccess: (_data, variables) => {
+        const movie = movies?.find((m) => m.id === variables.movieId);
+        toast.success(`Kept "${movie?.title ?? 'movie'}" in library`);
+        void refetch();
+      },
+      onError: () => {
+        toast.error('Failed to cancel leaving status');
+      },
+    }
+  );
 
   if (isLoading) return <LeavingSkeleton />;
   if (!movies || movies.length === 0) return null;

--- a/packages/app-media/src/components/MarkAsWatchedButton.test.tsx
+++ b/packages/app-media/src/components/MarkAsWatchedButton.test.tsx
@@ -15,45 +15,60 @@ const mockInvalidatePendingDebriefs = vi.fn();
 
 const mockHistoryQuery = vi.fn();
 
-vi.mock('@pops/api-client', () => ({
-  trpc: {
-    media: {
-      watchHistory: {
-        list: {
-          useQuery: (...args: unknown[]) => mockHistoryQuery(...args),
-        },
-        log: {
-          useMutation: (opts: Record<string, (...args: unknown[]) => unknown>) => {
-            logMutationOpts = opts;
-            return { mutate: mockLogMutate, isPending: false };
-          },
-        },
-        delete: {
-          useMutation: (opts: Record<string, (...args: unknown[]) => unknown>) => {
-            _deleteMutationOpts = opts;
-            return { mutate: mockDeleteMutate, isPending: false };
-          },
-        },
-      },
-      watchlist: {
-        add: {
-          useMutation: () => ({ mutate: mockWatchlistAddMutate, isPending: false }),
-        },
-      },
-    },
-    useUtils: () => ({
-      media: {
-        watchHistory: {
-          list: { invalidate: mockInvalidateHistory },
-        },
-        watchlist: {
-          list: { invalidate: mockInvalidateWatchlist },
-        },
-        comparisons: {
-          getPendingDebriefs: { invalidate: mockInvalidatePendingDebriefs },
-        },
+vi.mock('@tanstack/react-query', async () => {
+  const actual =
+    await vi.importActual<typeof import('@tanstack/react-query')>('@tanstack/react-query');
+  return {
+    ...actual,
+    useQueryClient: () => ({
+      invalidateQueries: ({ queryKey }: { queryKey: readonly string[] }) => {
+        const router = queryKey[1];
+        if (router === 'watchHistory') mockInvalidateHistory();
+        if (router === 'watchlist') mockInvalidateWatchlist();
+        if (router === 'comparisons') mockInvalidatePendingDebriefs();
       },
     }),
+  };
+});
+
+function wrapOpts(
+  path: readonly string[],
+  opts?: Record<string, (...args: unknown[]) => unknown>
+): Record<string, (...args: unknown[]) => unknown> {
+  const router = path[0];
+  return {
+    ...opts,
+    onSuccess: (...args: unknown[]) => {
+      if (router === 'watchHistory') mockInvalidateHistory();
+      return opts?.onSuccess?.(...args);
+    },
+  };
+}
+
+vi.mock('@pops/pillar-sdk/react', () => ({
+  usePillarQuery: (_pillarId: string, path: readonly string[], input: unknown) => {
+    if (path.join('.') === 'watchHistory.list') return mockHistoryQuery(input);
+    return { data: undefined, isLoading: false };
+  },
+  usePillarMutation: (
+    _pillarId: string,
+    path: readonly string[],
+    opts?: Record<string, (...args: unknown[]) => unknown>
+  ) => {
+    const key = path.join('.');
+    const wrapped = wrapOpts(path, opts);
+    if (key === 'watchHistory.log') {
+      logMutationOpts = wrapped;
+      return { mutate: mockLogMutate, isPending: false };
+    }
+    if (key === 'watchHistory.delete') {
+      _deleteMutationOpts = wrapped;
+      return { mutate: mockDeleteMutate, isPending: false };
+    }
+    if (key === 'watchlist.add') {
+      return { mutate: mockWatchlistAddMutate, isPending: false };
+    }
+    return { mutate: vi.fn(), isPending: false };
   },
 }));
 
@@ -178,10 +193,7 @@ describe('MarkAsWatchedButton', () => {
     const deleteOpts = deleteCall?.[1] as { onSuccess?: () => void };
     deleteOpts?.onSuccess?.();
 
-    expect(mockWatchlistAddMutate).toHaveBeenCalledWith(
-      { mediaType: 'movie', mediaId: 550 },
-      expect.any(Object)
-    );
+    expect(mockWatchlistAddMutate).toHaveBeenCalledWith({ mediaType: 'movie', mediaId: 550 });
   });
 
   it('undo does not re-add to watchlist when watchlistRemoved=false', () => {

--- a/packages/app-media/src/components/dimension-manager/useDimensionManagerModel.ts
+++ b/packages/app-media/src/components/dimension-manager/useDimensionManagerModel.ts
@@ -1,6 +1,6 @@
 import { useCallback, useState } from 'react';
 
-import { trpc } from '@pops/api-client';
+import { usePillarQuery } from '@pops/pillar-sdk/react';
 
 import { reorderDimension, useDimensionMutations } from './useDimensionMutations';
 
@@ -56,10 +56,16 @@ export function useDimensionManagerModel(): DimensionManagerModel {
   const [addDescription, setAddDescription] = useState('');
   const [editing, setEditing] = useState<EditState | null>(null);
 
-  const { data: dimensionsData, isLoading } = trpc.media.comparisons.listDimensions.useQuery(
-    undefined,
-    { enabled: open }
-  );
+  const { data: dimensionsData, isLoading } = usePillarQuery<{
+    data: ReadonlyArray<{
+      id: number;
+      name: string;
+      description: string | null;
+      active: boolean | number;
+      sortOrder: number;
+      weight: number | null;
+    }>;
+  }>('media', ['comparisons', 'listDimensions'], undefined, { enabled: open });
 
   const dimensions = normalizeDimensions(dimensionsData?.data ?? []);
 

--- a/packages/app-media/src/components/dimension-manager/useDimensionMutations.ts
+++ b/packages/app-media/src/components/dimension-manager/useDimensionMutations.ts
@@ -1,7 +1,7 @@
 import { useCallback, useState } from 'react';
 import { toast } from 'sonner';
 
-import { trpc } from '@pops/api-client';
+import { usePillarMutation, type UsePillarMutationResult } from '@pops/pillar-sdk/react';
 
 import type { Dimension, EditState } from './types';
 
@@ -16,36 +16,57 @@ interface MutationsArgs {
   setShowAddForm: (v: boolean) => void;
 }
 
+interface CreateDimensionInput {
+  name: string;
+  description: string | null;
+  sortOrder: number;
+}
+
+interface UpdateDimensionInput {
+  id: number;
+  data: {
+    name?: string;
+    description?: string | null;
+    active?: boolean;
+    sortOrder?: number;
+    weight?: number;
+  };
+}
+
+type UpdateMutation = UsePillarMutationResult<UpdateDimensionInput, unknown>;
+
 function useCoreMutations(
   args: Pick<MutationsArgs, 'setEditing' | 'setAddName' | 'setAddDescription'>
 ) {
-  const utils = trpc.useUtils();
-  const createMutation = trpc.media.comparisons.createDimension.useMutation({
-    onSuccess: () => {
-      void utils.media.comparisons.listDimensions.invalidate();
-      args.setAddName('');
-      args.setAddDescription('');
-      toast.success('Dimension created');
-    },
-    onError: (err: { message: string }) => toast.error(err.message),
-  });
+  const createMutation = usePillarMutation<CreateDimensionInput, unknown>(
+    'media',
+    ['comparisons', 'createDimension'],
+    {
+      onSuccess: () => {
+        args.setAddName('');
+        args.setAddDescription('');
+        toast.success('Dimension created');
+      },
+      onError: (err) => toast.error(err.message),
+    }
+  );
 
-  const updateMutation = trpc.media.comparisons.updateDimension.useMutation({
-    onSuccess: () => {
-      void utils.media.comparisons.listDimensions.invalidate();
-      args.setEditing(null);
-      toast.success('Dimension updated');
-    },
-    onError: (err: { message: string }) => toast.error(err.message),
-  });
+  const updateMutation = usePillarMutation<UpdateDimensionInput, unknown>(
+    'media',
+    ['comparisons', 'updateDimension'],
+    {
+      onSuccess: () => {
+        args.setEditing(null);
+        toast.success('Dimension updated');
+      },
+      onError: (err) => toast.error(err.message),
+    }
+  );
 
   return { createMutation, updateMutation };
 }
 
-function useEditHandlers(
-  args: MutationsArgs,
-  updateMutation: ReturnType<typeof trpc.media.comparisons.updateDimension.useMutation>
-) {
+function useEditHandlers(args: MutationsArgs, updateMutation: UpdateMutation) {
   const handleToggleActive = useCallback(
     (dim: Dimension) => {
       updateMutation.mutate({ id: dim.id, data: { active: !dim.active } });
@@ -77,9 +98,7 @@ function useEditHandlers(
   return { handleToggleActive, handleStartEdit, handleSaveEdit };
 }
 
-function useWeightHandlers(
-  updateMutation: ReturnType<typeof trpc.media.comparisons.updateDimension.useMutation>
-) {
+function useWeightHandlers(updateMutation: UpdateMutation) {
   const [localWeights, setLocalWeights] = useState<Map<number, number>>(new Map());
 
   const handleWeightDrag = useCallback((dimId: number, value: number) => {

--- a/packages/app-media/src/components/mark-as-watched/useMarkAsWatched.ts
+++ b/packages/app-media/src/components/mark-as-watched/useMarkAsWatched.ts
@@ -1,21 +1,62 @@
+import { useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
 import { toast } from 'sonner';
 
-import { trpc } from '@pops/api-client';
+import { usePillarMutation, usePillarQuery } from '@pops/pillar-sdk/react';
+
+interface WatchHistoryEntry {
+  id: number;
+  watchedAt: string;
+}
+
+interface WatchHistoryListResult {
+  data: WatchHistoryEntry[];
+}
+
+interface LogResult {
+  data: { id: number };
+  watchlistRemoved: boolean;
+}
+
+interface LogInput {
+  mediaType: 'movie';
+  mediaId: number;
+  completed?: number;
+  watchedAt?: string;
+}
+
+interface AddToWatchlistInput {
+  mediaType: 'movie';
+  mediaId: number;
+}
+
+function useCrossRouterInvalidation() {
+  const queryClient = useQueryClient();
+  return () => {
+    void queryClient.invalidateQueries({ queryKey: ['media', 'watchlist'] });
+    void queryClient.invalidateQueries({ queryKey: ['media', 'comparisons'] });
+  };
+}
 
 function useUndoMutation(mediaId: number) {
-  const utils = trpc.useUtils();
-  const addToWatchlistMutation = trpc.media.watchlist.add.useMutation();
-  const deleteMutation = trpc.media.watchHistory.delete.useMutation({
-    onSuccess: () => {
-      toast.success('Watch entry undone');
-      void utils.media.watchHistory.list.invalidate();
-      void utils.media.watchlist.list.invalidate();
-    },
-    onError: (err: { message: string }) => {
-      toast.error(`Failed to undo: ${err.message}`);
-    },
-  });
+  const invalidateCross = useCrossRouterInvalidation();
+  const addToWatchlistMutation = usePillarMutation<AddToWatchlistInput, unknown>('media', [
+    'watchlist',
+    'add',
+  ]);
+  const deleteMutation = usePillarMutation<{ id: number }, unknown>(
+    'media',
+    ['watchHistory', 'delete'],
+    {
+      onSuccess: () => {
+        toast.success('Watch entry undone');
+        invalidateCross();
+      },
+      onError: (err) => {
+        toast.error(`Failed to undo: ${err.message}`);
+      },
+    }
+  );
 
   const handleUndo = (entryId: number, watchlistRemoved: boolean) => {
     deleteMutation.mutate(
@@ -23,14 +64,7 @@ function useUndoMutation(mediaId: number) {
       {
         onSuccess: () => {
           if (watchlistRemoved) {
-            addToWatchlistMutation.mutate(
-              { mediaType: 'movie', mediaId },
-              {
-                onSuccess: () => {
-                  void utils.media.watchlist.list.invalidate();
-                },
-              }
-            );
+            addToWatchlistMutation.mutate({ mediaType: 'movie', mediaId });
           }
         },
       }
@@ -49,9 +83,9 @@ function useLogMutation({
   setShowDatePicker: (v: boolean) => void;
   setCustomDate: (v: string) => void;
 }) {
-  const utils = trpc.useUtils();
-  return trpc.media.watchHistory.log.useMutation({
-    onSuccess: (result: { data: { id: number }; watchlistRemoved: boolean }) => {
+  const invalidateCross = useCrossRouterInvalidation();
+  return usePillarMutation<LogInput, LogResult>('media', ['watchHistory', 'log'], {
+    onSuccess: (result) => {
       toast.success('Marked as watched', {
         duration: 5000,
         action: {
@@ -61,13 +95,11 @@ function useLogMutation({
           },
         },
       });
-      void utils.media.watchHistory.list.invalidate();
-      void utils.media.watchlist.list.invalidate();
-      void utils.media.comparisons.getPendingDebriefs.invalidate();
+      invalidateCross();
       setShowDatePicker(false);
       setCustomDate('');
     },
-    onError: (err: { message: string }) => {
+    onError: (err) => {
       toast.error(`Failed to log watch: ${err.message}`);
     },
   });
@@ -77,7 +109,9 @@ export function useMarkAsWatched(mediaId: number) {
   const [showDatePicker, setShowDatePicker] = useState(false);
   const [customDate, setCustomDate] = useState('');
 
-  const { data: historyData } = trpc.media.watchHistory.list.useQuery(
+  const { data: historyData } = usePillarQuery<WatchHistoryListResult>(
+    'media',
+    ['watchHistory', 'list'],
     { mediaType: 'movie', mediaId, limit: 100 },
     { staleTime: 30_000 }
   );

--- a/packages/app-media/src/components/movie-action-buttons/useRotationButtonsModel.ts
+++ b/packages/app-media/src/components/movie-action-buttons/useRotationButtonsModel.ts
@@ -1,44 +1,72 @@
 import { toast } from 'sonner';
 
-import { trpc } from '@pops/api-client';
+import { usePillarMutation, usePillarQuery } from '@pops/pillar-sdk/react';
+
+interface ArrConfigResult {
+  data: { radarrConfigured: boolean; sonarrConfigured: boolean };
+}
+
+interface MovieStatusResult {
+  data: { status: string; label: string } | null;
+}
+
+interface CandidateStatusResult {
+  inQueue?: boolean;
+  isExcluded?: boolean;
+}
+
+interface AddToQueueInput {
+  tmdbId: number;
+  title?: string;
+  year?: number;
+  posterPath?: string;
+  rating?: number;
+}
 
 export function useRotationButtonsModel(tmdbId: number) {
-  const utils = trpc.useUtils();
-
-  const { data: configData } = trpc.media.arr.getConfig.useQuery();
+  const { data: configData } = usePillarQuery<ArrConfigResult>(
+    'media',
+    ['arr', 'getConfig'],
+    undefined
+  );
   const radarrConfigured = configData?.data?.radarrConfigured === true;
 
-  const movieStatus = trpc.media.arr.getMovieStatus.useQuery(
+  const movieStatus = usePillarQuery<MovieStatusResult>(
+    'media',
+    ['arr', 'getMovieStatus'],
     { tmdbId },
     { enabled: radarrConfigured }
   );
 
   const { data: candidateData, isLoading: candidateLoading } =
-    trpc.media.rotation.getCandidateStatus.useQuery({ tmdbId });
+    usePillarQuery<CandidateStatusResult>('media', ['rotation', 'getCandidateStatus'], { tmdbId });
 
-  const addToQueueMutation = trpc.media.rotation.addToQueue.useMutation({
-    onSuccess: () => {
-      toast.success('Added to rotation queue');
-      void utils.media.rotation.getCandidateStatus.invalidate({ tmdbId });
-    },
-    onError: () => toast.error('Failed to add to queue'),
-  });
+  const addToQueueMutation = usePillarMutation<AddToQueueInput, unknown>(
+    'media',
+    ['rotation', 'addToQueue'],
+    {
+      onSuccess: () => toast.success('Added to rotation queue'),
+      onError: () => toast.error('Failed to add to queue'),
+    }
+  );
 
-  const removeFromQueueMutation = trpc.media.rotation.removeFromQueue.useMutation({
-    onSuccess: () => {
-      toast.success('Removed from queue');
-      void utils.media.rotation.getCandidateStatus.invalidate({ tmdbId });
-    },
-    onError: () => toast.error('Failed to remove from queue'),
-  });
+  const removeFromQueueMutation = usePillarMutation<{ tmdbId: number }, unknown>(
+    'media',
+    ['rotation', 'removeFromQueue'],
+    {
+      onSuccess: () => toast.success('Removed from queue'),
+      onError: () => toast.error('Failed to remove from queue'),
+    }
+  );
 
-  const removeExclusionMutation = trpc.media.rotation.removeExclusion.useMutation({
-    onSuccess: () => {
-      toast.success('Exclusion removed');
-      void utils.media.rotation.getCandidateStatus.invalidate({ tmdbId });
-    },
-    onError: () => toast.error('Failed to remove exclusion'),
-  });
+  const removeExclusionMutation = usePillarMutation<{ tmdbId: number }, unknown>(
+    'media',
+    ['rotation', 'removeExclusion'],
+    {
+      onSuccess: () => toast.success('Exclusion removed'),
+      onError: () => toast.error('Failed to remove exclusion'),
+    }
+  );
 
   return {
     radarrConfigured,

--- a/packages/app-media/src/pages/DebriefPage.test.tsx
+++ b/packages/app-media/src/pages/DebriefPage.test.tsx
@@ -36,6 +36,21 @@ const mockInvalidateDebrief = vi.fn();
 const mockInvalidatePending = vi.fn();
 const mockInvalidateWatchlist = vi.fn();
 
+vi.mock('@pops/pillar-sdk/react', () => ({
+  usePillarQuery: () => ({ data: undefined, isLoading: false, error: null }),
+  usePillarMutation: (
+    _pillarId: string,
+    path: readonly string[],
+    opts?: Record<string, unknown>
+  ) => {
+    if (path.join('.') === 'comparisons.dismissDebriefDimension') {
+      mockDismissMutate._opts = opts;
+      return { mutate: mockDismissMutate, isPending: false };
+    }
+    return { mutate: vi.fn(), isPending: false };
+  },
+}));
+
 vi.mock('@pops/api-client', () => ({
   trpc: {
     media: {

--- a/packages/app-media/src/pages/LibraryPage.test.tsx
+++ b/packages/app-media/src/pages/LibraryPage.test.tsx
@@ -10,6 +10,14 @@ const mockGetPendingDebriefs = vi.fn();
 
 const mockGetLeavingMovies = vi.fn();
 
+vi.mock('@pops/pillar-sdk/react', () => ({
+  usePillarQuery: (_pillarId: string, path: readonly string[]) => {
+    if (path.join('.') === 'comparisons.getPendingDebriefs') return mockGetPendingDebriefs();
+    return { data: undefined, isLoading: false };
+  },
+  usePillarMutation: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
 vi.mock('@pops/api-client', () => ({
   trpc: {
     media: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1642,6 +1642,9 @@ importers:
       '@pops/navigation':
         specifier: workspace:*
         version: link:../navigation
+      '@pops/pillar-sdk':
+        specifier: workspace:*
+        version: link:../pillar-sdk
       '@pops/types':
         specifier: workspace:*
         version: link:../types


### PR DESCRIPTION
## Summary

- Migrates 12 alphabetically-first `trpc.media.*` consumer files in `packages/app-media/src` to `@pops/pillar-sdk` (`usePillarQuery` / `usePillarMutation`).
- Adds `@pops/pillar-sdk` to `packages/app-media` deps; `@pops/api-client` stays for the remaining ~49 files (future batches).
- Cross-router invalidation in `useMarkAsWatched` is handled with an explicit `useQueryClient` over the `pillarQueryKey` prefix; everything else relies on the SDK's built-in router-prefix invalidate.

### Files migrated

- `components/ArrStatusBadge.tsx` (+ test)
- `components/ComparisonScores.tsx` (+ test)
- `components/DebriefBanner.tsx` (+ test)
- `components/DebriefControls.tsx` (+ test)
- `components/DebriefResultsSummary.tsx` (+ test)
- `components/DownloadQueue.tsx`
- `components/ExcludedDimensions.tsx` (+ test)
- `components/LeavingSoonShelf.tsx`
- `components/dimension-manager/useDimensionManagerModel.ts`
- `components/dimension-manager/useDimensionMutations.ts`
- `components/mark-as-watched/useMarkAsWatched.ts` (+ MarkAsWatchedButton test)
- `components/movie-action-buttons/useRotationButtonsModel.ts`

### Risky files explicitly skipped (3)

Per the `app-media-consumer-inventory` audit on main — these need an SDK cache-write surface (typed `setData` / `onMutate` rollback) that doesn't exist yet:

- `components/watchlist-toggle/useWatchlistToggleModel.ts`
- `pages/tv-show-detail/useTvShowDetailModel.ts`
- `pages/season-detail/useBatchSeasonLog.ts`

### Remaining

- ~49 trivial files left (out of the 61 with `trpc.media.*` call sites; the 3 risky ones blocked) — covered by subsequent batches.

## Test plan

- [x] `pnpm --filter @pops/app-media typecheck` — clean
- [x] `pnpm --filter @pops/app-media test` — 702/702 passing
- [x] `pnpm typecheck` — 66/66 packages clean
- [x] `npx oxlint packages/app-media/src` — 0 errors
