### PR TITLE
feat(core): PRD-228 US-01 — dynamic pillar registration endpoint

### DIFF
--- a/apps/pops-api/src/db/per-pillar-migrations.test.ts
+++ b/apps/pops-api/src/db/per-pillar-migrations.test.ts
@@ -264,6 +264,7 @@ describe('runPerPillarMigrations', () => {
         '0055_pillar_registry',
         '0056_settings_baseline',
         '0057_ai_usage_baseline',
+        '0058_pillar_registry_external_origin',
       ]);
       expect([...result.pillarsApplied].toSorted()).toEqual([
         'cerebrum',

--- a/apps/pops-core-api/src/__tests__/external-register.test.ts
+++ b/apps/pops-core-api/src/__tests__/external-register.test.ts
@@ -1,0 +1,360 @@
+/**
+ * Integration tests for `POST /core.registry.register` (Theme 13 PRD-228 US-01).
+ *
+ * Boots the full Express factory against a temp-dir core.db with an
+ * injected `resolveApiKey` callback, then drives the wire surface end
+ * to end via `supertest`. Asserts the contract from the user-story
+ * acceptance criteria:
+ *   - happy path: 200 + persisted row + emitted `registered` event.
+ *   - bad key: 401, no persistence, no event.
+ *   - malformed manifest: 400 with per-field issues.
+ *   - reserved pillar id: 409 with `pillar-id-reserved`.
+ *   - bad pillar slug: 400 with the regex reason.
+ *   - cross-field mismatch (`manifest.pillar !== pillarId`): 400.
+ *   - duplicate registration: `registeredAt` preserved, `apiKeyHash`
+ *     refreshed on key rotation.
+ *   - missing fields: 400 with structured issues.
+ *   - missing env key: 500 (mis-deployed core-api refuses to register
+ *     anyone rather than silently accepting every request).
+ */
+import { createHash } from 'node:crypto';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { openCoreDb, pillarRegistryService, type OpenedCoreDb } from '@pops/core-db';
+
+import { createCoreApiApp } from '../app.js';
+import { registryEventBus, type RegistryEventPayload } from '../modules/registry/event-bus.js';
+
+import type { ManifestPayload } from '@pops/pillar-sdk';
+
+const VALID_API_KEY = 'super-secret-shared-key';
+
+function recipesManifest(overrides?: Partial<ManifestPayload>): ManifestPayload {
+  return {
+    pillar: 'recipes',
+    version: '0.1.0',
+    contract: {
+      package: '@pops/recipes-contract',
+      version: '0.1.0',
+      tag: 'contract-recipes@v0.1.0',
+    },
+    routes: {
+      queries: ['recipes.library.list'],
+      mutations: ['recipes.library.create'],
+      subscriptions: [],
+    },
+    search: { adapters: [] },
+    ai: { tools: [] },
+    uri: { types: ['recipes/recipe'] },
+    settings: { keys: [] },
+    healthcheck: { path: '/health' },
+    ...overrides,
+  };
+}
+
+let tmpDir: string;
+let coreDb: OpenedCoreDb;
+let app: ReturnType<typeof createCoreApiApp>;
+let resolvedKey: string | undefined;
+let capturedEvents: RegistryEventPayload[];
+let eventListener: (payload: RegistryEventPayload) => void;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'core-api-extreg-'));
+  coreDb = openCoreDb(join(tmpDir, 'core.db'));
+  resolvedKey = VALID_API_KEY;
+  capturedEvents = [];
+  eventListener = (payload) => capturedEvents.push(payload);
+  registryEventBus.on('registry:event', eventListener);
+  app = createCoreApiApp({
+    coreDb,
+    version: '0.0.1-test',
+    selfBaseUrl: 'http://localhost:3001',
+    resolveApiKey: () => resolvedKey,
+  });
+});
+
+afterEach(() => {
+  registryEventBus.off('registry:event', eventListener);
+  coreDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('POST /core.registry.register — happy path', () => {
+  it('persists the row with origin=external + sha256 key hash + healthy status and emits a registered event', async () => {
+    const manifest = recipesManifest();
+    const res = await request(app).post('/core.registry.register').send({
+      pillarId: 'recipes',
+      baseUrl: 'http://recipes-api:4010',
+      manifest,
+      apiKey: VALID_API_KEY,
+    });
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      ok: true,
+      pillarId: 'recipes',
+      heartbeatIntervalMs: 10_000,
+    });
+    expect(typeof res.body.registeredAt).toBe('string');
+    expect(() => new Date(res.body.registeredAt).toISOString()).not.toThrow();
+
+    const persisted = pillarRegistryService.getPillarRegistration(coreDb.db, 'recipes');
+    expect(persisted).not.toBeNull();
+    expect(persisted?.origin).toBe('external');
+    expect(persisted?.status).toBe('healthy');
+    expect(persisted?.evictedAt).toBeNull();
+    expect(persisted?.apiKeyHash).toBe(
+      createHash('sha256').update(VALID_API_KEY, 'utf8').digest('hex')
+    );
+
+    const registered = capturedEvents.filter((e) => e.event === 'registered');
+    expect(registered).toHaveLength(1);
+    expect(registered[0].pillarId).toBe('recipes');
+  });
+
+  it('accepts a multi-segment kebab pillar slug', async () => {
+    const manifest = recipesManifest({
+      pillar: 'home-brew',
+      contract: {
+        package: '@pops/home-brew-contract',
+        version: '0.1.0',
+        tag: 'contract-home-brew@v0.1.0',
+      },
+      routes: {
+        queries: ['homebrew.library.list'],
+        mutations: ['homebrew.library.create'],
+        subscriptions: [],
+      },
+      uri: { types: ['home-brew/recipe'] },
+    });
+    const res = await request(app).post('/core.registry.register').send({
+      pillarId: 'home-brew',
+      baseUrl: 'http://home-brew-api:4010',
+      manifest,
+      apiKey: VALID_API_KEY,
+    });
+    expect(res.status).toBe(200);
+    expect(res.body.pillarId).toBe('home-brew');
+  });
+});
+
+describe('POST /core.registry.register — authentication', () => {
+  it('returns 401 with no persistence when the apiKey does not match', async () => {
+    const res = await request(app).post('/core.registry.register').send({
+      pillarId: 'recipes',
+      baseUrl: 'http://recipes-api:4010',
+      manifest: recipesManifest(),
+      apiKey: 'wrong-key',
+    });
+    expect(res.status).toBe(401);
+    expect(res.body).toMatchObject({ ok: false, reason: 'invalid-api-key' });
+    expect(pillarRegistryService.getPillarRegistration(coreDb.db, 'recipes')).toBeNull();
+    expect(capturedEvents).toEqual([]);
+  });
+
+  it('returns 401 when the apiKey has a different length (no length oracle)', async () => {
+    const res = await request(app).post('/core.registry.register').send({
+      pillarId: 'recipes',
+      baseUrl: 'http://recipes-api:4010',
+      manifest: recipesManifest(),
+      apiKey: 'x',
+    });
+    expect(res.status).toBe(401);
+    expect(res.body).toMatchObject({ ok: false, reason: 'invalid-api-key' });
+  });
+
+  it('returns 500 when POPS_INTERNAL_API_KEY is not configured on core-api', async () => {
+    resolvedKey = undefined;
+    const res = await request(app).post('/core.registry.register').send({
+      pillarId: 'recipes',
+      baseUrl: 'http://recipes-api:4010',
+      manifest: recipesManifest(),
+      apiKey: VALID_API_KEY,
+    });
+    expect(res.status).toBe(500);
+    expect(res.body).toMatchObject({ ok: false, reason: 'api-key-not-configured' });
+  });
+});
+
+describe('POST /core.registry.register — pillar id validation', () => {
+  for (const reserved of ['core', 'finance', 'media', 'inventory', 'cerebrum', 'food', 'lists']) {
+    it(`returns 409 pillar-id-reserved for the in-tree id '${reserved}'`, async () => {
+      const manifest = recipesManifest({
+        pillar: reserved,
+        contract: {
+          package: `@pops/${reserved}-contract`,
+          version: '0.1.0',
+          tag: `contract-${reserved}@v0.1.0`,
+        },
+        routes: {
+          queries: [`${reserved}.library.list`],
+          mutations: [`${reserved}.library.create`],
+          subscriptions: [],
+        },
+        uri: { types: [`${reserved}/recipe`] },
+      });
+      const res = await request(app).post('/core.registry.register').send({
+        pillarId: reserved,
+        baseUrl: 'http://x:4010',
+        manifest,
+        apiKey: VALID_API_KEY,
+      });
+      expect(res.status).toBe(409);
+      expect(res.body).toMatchObject({
+        ok: false,
+        reason: 'pillar-id-reserved',
+        pillarId: reserved,
+      });
+    });
+  }
+
+  it('rejects a pillarId that starts with a digit', async () => {
+    const res = await request(app)
+      .post('/core.registry.register')
+      .send({
+        pillarId: '1recipes',
+        baseUrl: 'http://x:4010',
+        manifest: recipesManifest({ pillar: '1recipes' }),
+        apiKey: VALID_API_KEY,
+      });
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.issues[0].field).toBe('pillarId');
+  });
+
+  it('rejects a pillarId with uppercase letters', async () => {
+    const res = await request(app)
+      .post('/core.registry.register')
+      .send({
+        pillarId: 'Recipes',
+        baseUrl: 'http://x:4010',
+        manifest: recipesManifest({ pillar: 'Recipes' }),
+        apiKey: VALID_API_KEY,
+      });
+    expect(res.status).toBe(400);
+    expect(res.body.issues[0].field).toBe('pillarId');
+  });
+});
+
+describe('POST /core.registry.register — manifest validation', () => {
+  it('returns 400 with structured issues when the manifest is malformed', async () => {
+    const res = await request(app)
+      .post('/core.registry.register')
+      .send({
+        pillarId: 'recipes',
+        baseUrl: 'http://recipes-api:4010',
+        manifest: {
+          pillar: 'recipes',
+          version: 'not-semver',
+          contract: { package: 'wrong', version: 'not-semver', tag: 'wrong' },
+          routes: { queries: [], mutations: [], subscriptions: [] },
+          search: { adapters: [] },
+          ai: { tools: [] },
+          uri: { types: [] },
+          settings: { keys: [] },
+          healthcheck: { path: '/' },
+        },
+        apiKey: VALID_API_KEY,
+      });
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+    expect(Array.isArray(res.body.issues)).toBe(true);
+    expect(res.body.issues.length).toBeGreaterThan(0);
+    expect(pillarRegistryService.getPillarRegistration(coreDb.db, 'recipes')).toBeNull();
+  });
+
+  it('rejects pillarId / manifest.pillar mismatch with a cross-field issue', async () => {
+    const res = await request(app)
+      .post('/core.registry.register')
+      .send({
+        pillarId: 'recipes',
+        baseUrl: 'http://recipes-api:4010',
+        manifest: recipesManifest({
+          pillar: 'something-else',
+          contract: {
+            package: '@pops/something-else-contract',
+            version: '0.1.0',
+            tag: 'contract-something-else@v0.1.0',
+          },
+        }),
+        apiKey: VALID_API_KEY,
+      });
+    expect(res.status).toBe(400);
+    const fields = res.body.issues.map((i: { field: string }) => i.field);
+    expect(fields).toContain('manifest.pillar');
+  });
+
+  it('rejects a missing manifest field', async () => {
+    const res = await request(app).post('/core.registry.register').send({
+      pillarId: 'recipes',
+      baseUrl: 'http://recipes-api:4010',
+      apiKey: VALID_API_KEY,
+    });
+    expect(res.status).toBe(400);
+    const fields = res.body.issues.map((i: { field: string }) => i.field);
+    expect(fields).toContain('manifest');
+  });
+
+  it('rejects a non-URL baseUrl', async () => {
+    const res = await request(app).post('/core.registry.register').send({
+      pillarId: 'recipes',
+      baseUrl: 'not-a-url',
+      manifest: recipesManifest(),
+      apiKey: VALID_API_KEY,
+    });
+    expect(res.status).toBe(400);
+    const fields = res.body.issues.map((i: { field: string }) => i.field);
+    expect(fields).toContain('baseUrl');
+  });
+});
+
+describe('POST /core.registry.register — duplicate registration', () => {
+  it('preserves registeredAt on re-registration and refreshes apiKeyHash on key rotation', async () => {
+    const first = await request(app).post('/core.registry.register').send({
+      pillarId: 'recipes',
+      baseUrl: 'http://recipes-api:4010',
+      manifest: recipesManifest(),
+      apiKey: VALID_API_KEY,
+    });
+    expect(first.status).toBe(200);
+    const firstRegisteredAt = first.body.registeredAt;
+
+    await new Promise((r) => setTimeout(r, 5));
+
+    const rotatedKey = 'rotated-shared-key';
+    resolvedKey = rotatedKey;
+    const second = await request(app)
+      .post('/core.registry.register')
+      .send({
+        pillarId: 'recipes',
+        baseUrl: 'http://recipes-api:9999',
+        manifest: recipesManifest({
+          version: '0.2.0',
+          contract: {
+            package: '@pops/recipes-contract',
+            version: '0.2.0',
+            tag: 'contract-recipes@v0.2.0',
+          },
+        }),
+        apiKey: rotatedKey,
+      });
+    expect(second.status).toBe(200);
+    expect(second.body.registeredAt).toBe(firstRegisteredAt);
+
+    const persisted = pillarRegistryService.getPillarRegistration(coreDb.db, 'recipes');
+    expect(persisted?.baseUrl).toBe('http://recipes-api:9999');
+    expect(persisted?.contractVersion).toBe('0.2.0');
+    expect(persisted?.apiKeyHash).toBe(
+      createHash('sha256').update(rotatedKey, 'utf8').digest('hex')
+    );
+    expect(persisted?.origin).toBe('external');
+
+    const registered = capturedEvents.filter((e) => e.event === 'registered');
+    expect(registered).toHaveLength(2);
+  });
+});

--- a/apps/pops-core-api/src/app.ts
+++ b/apps/pops-core-api/src/app.ts
@@ -15,13 +15,22 @@ import { createExpressMiddleware } from '@trpc/server/adapters/express';
 import express, { type Express, type Request, type Response } from 'express';
 
 import { type CoreApiDeps, makeRequestHandler } from './handlers.js';
+import { createExternalRegisterHandler } from './modules/external-registry/register.js';
 import { createRegistrySubscribeHandler } from './modules/registry/subscribe.js';
 import { appRouter } from './router.js';
 import { createCoreTrpcContextFactory } from './trpc.js';
 
+const SERVER_API_KEY_ENV = 'POPS_INTERNAL_API_KEY';
+
+function defaultResolveApiKey(): string | undefined {
+  const raw = process.env[SERVER_API_KEY_ENV];
+  return typeof raw === 'string' && raw.length > 0 ? raw : undefined;
+}
+
 export function createCoreApiApp(deps: CoreApiDeps): Express {
   const app = express();
   app.disable('x-powered-by');
+  app.use(express.json({ limit: '512kb' }));
 
   const handlers = makeRequestHandler(deps);
 
@@ -34,6 +43,14 @@ export function createCoreApiApp(deps: CoreApiDeps): Express {
   });
 
   app.get('/registry/subscribe', createRegistrySubscribeHandler(deps.coreDb.db));
+
+  app.post(
+    '/core.registry.register',
+    createExternalRegisterHandler({
+      coreDb: deps.coreDb.db,
+      resolveApiKey: deps.resolveApiKey ?? defaultResolveApiKey,
+    })
+  );
 
   app.use(
     '/trpc',

--- a/apps/pops-core-api/src/handlers.ts
+++ b/apps/pops-core-api/src/handlers.ts
@@ -21,6 +21,12 @@ export interface CoreApiDeps {
    * case the host pillar.
    */
   selfBaseUrl: string;
+  /**
+   * Optional shared-key resolver for the PRD-228 external register
+   * endpoint. Production wiring falls back to `POPS_INTERNAL_API_KEY`
+   * from the process env; tests inject a deterministic value.
+   */
+  resolveApiKey?: () => string | undefined;
 }
 
 export interface HealthResponse {

--- a/apps/pops-core-api/src/modules/external-registry/register-helpers.ts
+++ b/apps/pops-core-api/src/modules/external-registry/register-helpers.ts
@@ -1,0 +1,102 @@
+/**
+ * Pure helpers for the PRD-228 register HTTP endpoint.
+ *
+ * Split out of `register.ts` so the handler stays focused on the
+ * response shape + persistence orchestration and the body-parser /
+ * crypto utilities can be unit-tested in isolation without booting
+ * Express.
+ */
+import { createHash, timingSafeEqual } from 'node:crypto';
+
+import type { ValidationIssue } from '@pops/pillar-sdk';
+
+export const PILLAR_ID_PATTERN = /^[a-z][a-z0-9-]*$/;
+export const HEARTBEAT_INTERVAL_MS = 10_000;
+
+export interface ValidRegisterBody {
+  readonly pillarId: string;
+  readonly baseUrl: string;
+  readonly manifest: unknown;
+  readonly apiKey: string;
+}
+
+export type BodyParseResult =
+  | { ok: true; value: ValidRegisterBody }
+  | { ok: false; issues: ValidationIssue[] };
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function issue(field: string, reason: string, got: unknown): ValidationIssue {
+  return { field, reason, got, schemaPath: field.length > 0 ? field.split('.') : [] };
+}
+
+function validateStringField(value: unknown, field: string, issues: ValidationIssue[]): boolean {
+  if (typeof value !== 'string' || value.length === 0) {
+    issues.push(issue(field, `${field} must be a non-empty string`, value));
+    return false;
+  }
+  return true;
+}
+
+function validateBaseUrl(value: unknown, issues: ValidationIssue[]): void {
+  if (!validateStringField(value, 'baseUrl', issues)) return;
+  try {
+    new URL(value as string);
+  } catch {
+    issues.push(issue('baseUrl', 'baseUrl must be a valid URL', value));
+  }
+}
+
+function validateApiKey(value: unknown, issues: ValidationIssue[]): void {
+  if (typeof value !== 'string' || value.length === 0) {
+    const got = typeof value === 'string' ? '<redacted>' : value;
+    issues.push(issue('apiKey', 'apiKey must be a non-empty string', got));
+  }
+}
+
+export function parseRegisterBody(input: unknown): BodyParseResult {
+  if (!isPlainObject(input)) {
+    return { ok: false, issues: [issue('', 'expected an object body', input)] };
+  }
+  const issues: ValidationIssue[] = [];
+  const { pillarId, baseUrl, manifest, apiKey } = input;
+  validateStringField(pillarId, 'pillarId', issues);
+  validateBaseUrl(baseUrl, issues);
+  validateApiKey(apiKey, issues);
+  if (manifest === undefined) {
+    issues.push(issue('manifest', 'manifest is required', manifest));
+  }
+  if (issues.length > 0) return { ok: false, issues };
+  return {
+    ok: true,
+    value: {
+      pillarId: pillarId as string,
+      baseUrl: baseUrl as string,
+      manifest,
+      apiKey: apiKey as string,
+    },
+  };
+}
+
+/**
+ * Constant-time compare. `timingSafeEqual` requires equal-length buffers,
+ * so we first short-circuit on length mismatch and still pay the same
+ * compare cost against a zeroed buffer to avoid a fast-path length
+ * oracle. Both sides are encoded as UTF-8 bytes.
+ */
+export function constantTimeEquals(provided: string, expected: string): boolean {
+  const providedBuf = Buffer.from(provided, 'utf8');
+  const expectedBuf = Buffer.from(expected, 'utf8');
+  if (providedBuf.length !== expectedBuf.length) {
+    const dummy = Buffer.alloc(providedBuf.length);
+    timingSafeEqual(providedBuf, dummy);
+    return false;
+  }
+  return timingSafeEqual(providedBuf, expectedBuf);
+}
+
+export function sha256Hex(value: string): string {
+  return createHash('sha256').update(value, 'utf8').digest('hex');
+}

--- a/apps/pops-core-api/src/modules/external-registry/register.ts
+++ b/apps/pops-core-api/src/modules/external-registry/register.ts
@@ -1,0 +1,179 @@
+/**
+ * HTTP-JSON register handler for external pillars (Theme 13 PRD-228 US-01).
+ *
+ * External pillars — those that ship from a different repository and run
+ * outside the in-tree `bootstrapPillar` path — register themselves with
+ * `pops-core-api` by POSTing to `/core.registry.register` with the shared
+ * `POPS_INTERNAL_API_KEY`. The endpoint deliberately sits OUTSIDE the
+ * `/trpc/` namespace because PRD-161's nginx block explicitly blocks
+ * mutating `/trpc/core.registry.*` from external traffic; PRD-228 carves
+ * a sibling allow-list at `^/core\.registry\.(register|heartbeat|deregister)$`
+ * for this plain HTTP-JSON surface.
+ *
+ * Trust model (ADR-027): the docker network is the boundary. The shared
+ * key exists so an external service running outside the host cannot
+ * accidentally register; it is NOT a per-pillar credential. Comparison
+ * is constant-time via `crypto.timingSafeEqual` on equal-length buffers
+ * so the bad-key reply does not leak character-level timing.
+ *
+ * Heartbeat / deregister / eviction live in US-02..04 and are NOT in
+ * this PR's scope.
+ */
+import { pillarRegistryService, type CoreDb } from '@pops/core-db';
+import { PILLARS, validateManifestPayload } from '@pops/pillar-sdk';
+
+import { emitRegistryEvent } from '../registry/event-bus.js';
+import { computeStatus, registryNow } from '../registry/status.js';
+import { RegistryEntrySchema, type RegistryEntry } from '../registry/types.js';
+import {
+  HEARTBEAT_INTERVAL_MS,
+  PILLAR_ID_PATTERN,
+  constantTimeEquals,
+  parseRegisterBody,
+  sha256Hex,
+  type ValidRegisterBody,
+} from './register-helpers.js';
+
+import type { Request, Response } from 'express';
+
+import type { PillarRegistration } from '@pops/core-db';
+
+const RESERVED_PILLAR_IDS: ReadonlySet<string> = new Set(PILLARS);
+
+export interface ExternalRegisterDeps {
+  readonly coreDb: CoreDb;
+  /**
+   * Resolves the shared internal API key at request time. Reading lazily
+   * (rather than capturing at handler-construction time) lets a key
+   * rotation take effect without restarting core-api in tests.
+   */
+  readonly resolveApiKey: () => string | undefined;
+}
+
+function toRegistryEntry(reg: PillarRegistration, now: Date): RegistryEntry {
+  const manifest = RegistryEntrySchema.shape.manifest.parse(reg.manifest);
+  const status =
+    reg.status === 'unknown' ? 'unknown' : computeStatus(new Date(reg.lastHeartbeatAt), now);
+  return {
+    pillarId: reg.pillarId,
+    baseUrl: reg.baseUrl,
+    manifest,
+    contract: {
+      package: reg.contractPackage,
+      version: reg.contractVersion,
+      tag: reg.contractTag,
+    },
+    registeredAt: reg.registeredAt,
+    lastHeartbeatAt: reg.lastHeartbeatAt,
+    status,
+    statusUpdatedAt: reg.statusUpdatedAt,
+  };
+}
+
+function rejectPillarIdShape(res: Response, pillarId: string): boolean {
+  if (PILLAR_ID_PATTERN.test(pillarId)) return false;
+  res.status(400).json({
+    ok: false,
+    issues: [
+      {
+        field: 'pillarId',
+        reason: `pillarId must match ${PILLAR_ID_PATTERN.toString()}`,
+        got: pillarId,
+        schemaPath: ['pillarId'],
+      },
+    ],
+  });
+  return true;
+}
+
+function rejectReservedPillarId(res: Response, pillarId: string): boolean {
+  if (!RESERVED_PILLAR_IDS.has(pillarId)) return false;
+  res.status(409).json({ ok: false, reason: 'pillar-id-reserved', pillarId });
+  return true;
+}
+
+function rejectManifestPillarMismatch(
+  res: Response,
+  pillarId: string,
+  manifestPillar: string
+): boolean {
+  if (manifestPillar === pillarId) return false;
+  res.status(400).json({
+    ok: false,
+    issues: [
+      {
+        field: 'manifest.pillar',
+        reason: 'manifest.pillar must equal pillarId',
+        got: manifestPillar,
+        schemaPath: ['manifest', 'pillar'],
+      },
+    ],
+  });
+  return true;
+}
+
+function persistAndRespond(
+  deps: ExternalRegisterDeps,
+  body: ValidRegisterBody,
+  res: Response
+): void {
+  const { pillarId, baseUrl, manifest, apiKey } = body;
+  const validation = validateManifestPayload(manifest);
+  if (!validation.ok) {
+    res.status(400).json({ ok: false, issues: validation.issues });
+    return;
+  }
+  if (rejectManifestPillarMismatch(res, pillarId, validation.payload.pillar)) return;
+
+  const now = registryNow();
+  const persisted = pillarRegistryService.upsertPillarRegistration(deps.coreDb, {
+    baseUrl,
+    manifest: validation.payload,
+    now: now.toISOString(),
+    origin: 'external',
+    apiKeyHash: sha256Hex(apiKey),
+  });
+
+  const entry = toRegistryEntry(persisted, now);
+  emitRegistryEvent({ event: 'registered', pillarId: entry.pillarId, entry });
+
+  res.status(200).json({
+    ok: true,
+    pillarId: persisted.pillarId,
+    registeredAt: persisted.registeredAt,
+    heartbeatIntervalMs: HEARTBEAT_INTERVAL_MS,
+  });
+}
+
+export type ExternalRegisterHandler = (req: Request, res: Response) => void;
+
+/**
+ * Factory for the `POST /core.registry.register` handler. The factory
+ * pattern lets the test suite wire its own `resolveApiKey` callback
+ * without monkey-patching `process.env`.
+ */
+export function createExternalRegisterHandler(deps: ExternalRegisterDeps): ExternalRegisterHandler {
+  return function externalRegisterHandler(req, res) {
+    const expected = deps.resolveApiKey();
+    if (typeof expected !== 'string' || expected.length === 0) {
+      res.status(500).json({ ok: false, reason: 'api-key-not-configured' });
+      return;
+    }
+
+    const parsed = parseRegisterBody(req.body);
+    if (!parsed.ok) {
+      res.status(400).json({ ok: false, issues: parsed.issues });
+      return;
+    }
+
+    if (!constantTimeEquals(parsed.value.apiKey, expected)) {
+      res.status(401).json({ ok: false, reason: 'invalid-api-key' });
+      return;
+    }
+
+    if (rejectPillarIdShape(res, parsed.value.pillarId)) return;
+    if (rejectReservedPillarId(res, parsed.value.pillarId)) return;
+
+    persistAndRespond(deps, parsed.value, res);
+  };
+}

--- a/apps/pops-shell/nginx.conf
+++ b/apps/pops-shell/nginx.conf
@@ -169,6 +169,30 @@ server {
         proxy_send_timeout 10s;
     }
 
+    # External pillar registration HTTP-JSON surface (Theme 13 PRD-228).
+    #
+    # External services (pillars shipped from a different repo, running
+    # on the same docker network) POST a manifest + shared API key to
+    # `/core.registry.register` to appear in the dispatcher with no code
+    # change in `pops/`. The internal `/trpc/core.registry.*` surface
+    # stays blocked from external traffic; this sibling path is the
+    # explicit allow-list.
+    #
+    # US-01 ships only the register endpoint; heartbeat and deregister
+    # land in US-02 / US-04 and are added to the regex at the same time.
+    location ~ ^/core\.registry\.register$ {
+        set $core_registry_upstream http://core-api:3001;
+        proxy_pass $core_registry_upstream;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_connect_timeout 5s;
+        proxy_read_timeout 10s;
+        proxy_send_timeout 10s;
+    }
+
     location ~ ^/pillars/health/?$ {
         proxy_pass http://pops-api:3000;
         proxy_http_version 1.1;

--- a/packages/core-db/migrations/0058_pillar_registry_external_origin.sql
+++ b/packages/core-db/migrations/0058_pillar_registry_external_origin.sql
@@ -1,0 +1,4 @@
+ALTER TABLE `pillar_registry` ADD COLUMN `origin` text DEFAULT 'internal' NOT NULL;--> statement-breakpoint
+ALTER TABLE `pillar_registry` ADD COLUMN `api_key_hash` text;--> statement-breakpoint
+ALTER TABLE `pillar_registry` ADD COLUMN `evicted_at` text;--> statement-breakpoint
+CREATE INDEX `idx_pillar_registry_origin` ON `pillar_registry` (`origin`);

--- a/packages/core-db/migrations/meta/_journal.json
+++ b/packages/core-db/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1781913600000,
       "tag": "0057_ai_usage_baseline",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1781999999999,
+      "tag": "0058_pillar_registry_external_origin",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core-db/src/__tests__/pillar-registry.test.ts
+++ b/packages/core-db/src/__tests__/pillar-registry.test.ts
@@ -22,15 +22,20 @@ import {
 
 import type { CoreDb } from '../services/internal.js';
 
-const MIGRATION_PATH = join(__dirname, '../../migrations/0055_pillar_registry.sql');
+const MIGRATION_PATHS = [
+  join(__dirname, '../../migrations/0055_pillar_registry.sql'),
+  join(__dirname, '../../migrations/0058_pillar_registry_external_origin.sql'),
+];
 
 function freshDb(): CoreDb {
   const raw = new Database(':memory:');
   raw.pragma('foreign_keys = ON');
-  const sql = readFileSync(MIGRATION_PATH, 'utf8');
-  for (const stmt of sql.split('--> statement-breakpoint')) {
-    const trimmed = stmt.trim();
-    if (trimmed.length > 0) raw.exec(trimmed);
+  for (const path of MIGRATION_PATHS) {
+    const sql = readFileSync(path, 'utf8');
+    for (const stmt of sql.split('--> statement-breakpoint')) {
+      const trimmed = stmt.trim();
+      if (trimmed.length > 0) raw.exec(trimmed);
+    }
   }
   return drizzle(raw);
 }

--- a/packages/core-db/src/services/pillar-registry-status.ts
+++ b/packages/core-db/src/services/pillar-registry-status.ts
@@ -1,0 +1,47 @@
+/**
+ * Background-ticker hooks for the pillar registry (Theme 13 PRD-162).
+ *
+ * Kept in a sibling file from the core CRUD so the main
+ * `pillar-registry.ts` stays under the per-file line cap as the
+ * registry accrues new columns (PRD-228 origin/key-hash/eviction).
+ */
+import { eq } from 'drizzle-orm';
+
+import { pillarRegistry } from '../schema.js';
+
+import type { CoreDb } from './internal.js';
+import type { PillarStatus } from './pillar-registry.js';
+
+export interface StatusTransition {
+  readonly pillarId: string;
+  readonly previousStatus: PillarStatus;
+  readonly nextStatus: PillarStatus;
+  readonly at: string;
+}
+
+export interface ApplyStatusUpdate {
+  readonly pillarId: string;
+  readonly status: PillarStatus;
+  readonly statusUpdatedAt: string;
+}
+
+/**
+ * Persist a batch of status updates emitted by the background ticker
+ * (Theme 13 PRD-162). One UPDATE per row, all inside a single SQLite
+ * transaction so a tick is atomic relative to concurrent heartbeats /
+ * registrations.
+ */
+export function applyStatusUpdates(db: CoreDb, updates: readonly ApplyStatusUpdate[]): void {
+  if (updates.length === 0) return;
+  db.transaction((tx) => {
+    for (const update of updates) {
+      tx.update(pillarRegistry)
+        .set({
+          status: update.status,
+          statusUpdatedAt: update.statusUpdatedAt,
+        })
+        .where(eq(pillarRegistry.pillarId, update.pillarId))
+        .run();
+    }
+  });
+}

--- a/packages/core-db/src/services/pillar-registry.ts
+++ b/packages/core-db/src/services/pillar-registry.ts
@@ -26,6 +26,9 @@ import type { CoreDb } from './internal.js';
 
 export type PillarStatus = 'healthy' | 'unavailable' | 'unknown';
 
+/** PRD-228: `'internal'` is the bootstrap path; `'external'` is HTTP-key registration. */
+export type PillarOrigin = 'internal' | 'external';
+
 /**
  * Storage-facing manifest contract. Structurally compatible with the
  * `ManifestPayload` type from `@pops/pillar-sdk/manifest-schema` but
@@ -46,6 +49,10 @@ export interface UpsertPillarRegistrationInput {
   readonly baseUrl: string;
   readonly manifest: PersistableManifest;
   readonly now?: string;
+  /** Defaults to `'internal'` (bootstrap path); HTTP endpoint passes `'external'`. */
+  readonly origin?: PillarOrigin;
+  /** SHA-256 hex of the API key. Required when `origin === 'external'`. */
+  readonly apiKeyHash?: string;
 }
 
 export interface PillarRegistration {
@@ -59,6 +66,9 @@ export interface PillarRegistration {
   readonly lastHeartbeatAt: string;
   readonly status: PillarStatus;
   readonly statusUpdatedAt: string;
+  readonly origin: PillarOrigin;
+  readonly apiKeyHash: string | null;
+  readonly evictedAt: string | null;
 }
 
 interface PillarRegistryRow {
@@ -72,11 +82,18 @@ interface PillarRegistryRow {
   lastHeartbeatAt: string;
   status: string;
   statusUpdatedAt: string;
+  origin: string;
+  apiKeyHash: string | null;
+  evictedAt: string | null;
 }
 
 function parseStatus(raw: string): PillarStatus {
   if (raw === 'healthy' || raw === 'unavailable' || raw === 'unknown') return raw;
   return 'unknown';
+}
+
+function parseOrigin(raw: string): PillarOrigin {
+  return raw === 'external' ? 'external' : 'internal';
 }
 
 function parseManifestBlob(raw: string): unknown {
@@ -99,6 +116,9 @@ function rowToRegistration(row: PillarRegistryRow): PillarRegistration {
     lastHeartbeatAt: row.lastHeartbeatAt,
     status: parseStatus(row.status),
     statusUpdatedAt: row.statusUpdatedAt,
+    origin: parseOrigin(row.origin),
+    apiKeyHash: row.apiKeyHash,
+    evictedAt: row.evictedAt,
   };
 }
 
@@ -109,6 +129,8 @@ export function upsertPillarRegistration(
   const now = input.now ?? new Date().toISOString();
   const pillarId = input.manifest.pillar;
   const manifestJson = JSON.stringify(input.manifest);
+  const origin: PillarOrigin = input.origin ?? 'internal';
+  const apiKeyHash = origin === 'external' ? (input.apiKeyHash ?? null) : null;
 
   db.insert(pillarRegistry)
     .values({
@@ -122,6 +144,9 @@ export function upsertPillarRegistration(
       lastHeartbeatAt: now,
       status: 'healthy',
       statusUpdatedAt: now,
+      origin,
+      apiKeyHash,
+      evictedAt: null,
     })
     .onConflictDoUpdate({
       target: pillarRegistry.pillarId,
@@ -134,6 +159,9 @@ export function upsertPillarRegistration(
         lastHeartbeatAt: sql`excluded.last_heartbeat_at`,
         status: sql`excluded.status`,
         statusUpdatedAt: sql`excluded.status_updated_at`,
+        origin: sql`excluded.origin`,
+        apiKeyHash: sql`excluded.api_key_hash`,
+        evictedAt: sql`excluded.evicted_at`,
       },
     })
     .run();
@@ -223,36 +251,5 @@ export function recordHeartbeat(
   };
 }
 
-export interface StatusTransition {
-  readonly pillarId: string;
-  readonly previousStatus: PillarStatus;
-  readonly nextStatus: PillarStatus;
-  readonly at: string;
-}
-
-export interface ApplyStatusUpdate {
-  readonly pillarId: string;
-  readonly status: PillarStatus;
-  readonly statusUpdatedAt: string;
-}
-
-/**
- * Persist a batch of status updates emitted by the background ticker
- * (Theme 13 PRD-162). One UPDATE per row, all inside a single SQLite
- * transaction so a tick is atomic relative to concurrent heartbeats /
- * registrations.
- */
-export function applyStatusUpdates(db: CoreDb, updates: readonly ApplyStatusUpdate[]): void {
-  if (updates.length === 0) return;
-  db.transaction((tx) => {
-    for (const update of updates) {
-      tx.update(pillarRegistry)
-        .set({
-          status: update.status,
-          statusUpdatedAt: update.statusUpdatedAt,
-        })
-        .where(eq(pillarRegistry.pillarId, update.pillarId))
-        .run();
-    }
-  });
-}
+export type { ApplyStatusUpdate, StatusTransition } from './pillar-registry-status.js';
+export { applyStatusUpdates } from './pillar-registry-status.js';

--- a/packages/db-types/src/schema/pillar-registry.ts
+++ b/packages/db-types/src/schema/pillar-registry.ts
@@ -22,6 +22,13 @@ import { index, sqliteTable, text } from 'drizzle-orm/sqlite-core';
  *   as `'healthy'` on register; transitions to `'unavailable'` via the
  *   missed-heartbeat logic in PRD-162; transitions to `'unknown'` only
  *   after core-api restart reconciliation (PRD-164).
+ * - `origin` distinguishes `'internal'` (in-tree bootstrap path, PRD-158)
+ *   from `'external'` (registered via the shared-key HTTP endpoint,
+ *   PRD-228). `apiKeyHash` carries the SHA-256 of the key used at
+ *   registration time so a rotated key invalidates stale external
+ *   registrations without affecting internal ones. `evictedAt` is set
+ *   by the hard-eviction ticker for external pillars that never
+ *   heartbeated; internal pillars are never hard-evicted.
  */
 export const pillarRegistry = sqliteTable(
   'pillar_registry',
@@ -36,6 +43,12 @@ export const pillarRegistry = sqliteTable(
     lastHeartbeatAt: text('last_heartbeat_at').notNull(),
     status: text('status').notNull(),
     statusUpdatedAt: text('status_updated_at').notNull(),
+    origin: text('origin').notNull().default('internal'),
+    apiKeyHash: text('api_key_hash'),
+    evictedAt: text('evicted_at'),
   },
-  (table) => [index('idx_pillar_registry_status').on(table.status)]
+  (table) => [
+    index('idx_pillar_registry_status').on(table.status),
+    index('idx_pillar_registry_origin').on(table.origin),
+  ]
 );


### PR DESCRIPTION
## Summary

- Lands the BE-lego load-bearing piece of PRD-228: the dynamic-pillar register HTTP endpoint, so an external pillar can join the registry with no code change in `pops/`.
- Migration `0058_pillar_registry_external_origin.sql` adds `origin` (default `'internal'`), `api_key_hash`, `evicted_at` columns + an index on `origin` to `pillar_registry`. Existing rows backfill cleanly.
- New `POST /core.registry.register` on `pops-core-api`, served outside the `/trpc/` namespace (PRD-161's nginx block stays untouched). Allow-listed in `apps/pops-shell/nginx.conf` at `^/core\.registry\.register$`.

### What the endpoint does

1. Constant-time compares `apiKey` against `POPS_INTERNAL_API_KEY` via `crypto.timingSafeEqual` on equal-length UTF-8 buffers — zero-buffer compare on length mismatch so the bad-key reply does not leak a length oracle.
2. Validates the manifest via PRD-157's `validateManifestPayload`. Cross-field mismatch (`pillarId !== manifest.pillar`) returns 400.
3. Rejects reserved in-tree pillar ids (the 7 `PILLARS`) with `409 { reason: 'pillar-id-reserved' }`. Slug validation enforces `[a-z][a-z0-9-]*` for everyone else.
4. UPSERTs with `origin = 'external'`, `apiKeyHash = sha256(apiKey)`, `status = 'healthy'`, `evictedAt = null`. `registeredAt` preserved across re-registration. Emits a `registered` event on the PRD-163 bus.
5. Responds `{ ok: true, pillarId, registeredAt, heartbeatIntervalMs: 10000 }`.

### Scope

Heartbeat, deregister, nginx-regen wiring, and hard-eviction stay deferred to US-02..04. The PRD body and the rest of the user-story files are unchanged.

## Test plan

- [x] `pnpm --filter @pops/core-db test` — 126/126 pass (existing pillar-registry tests rerun against the combined migration).
- [x] `pnpm --filter @pops/core-api test` — 86/86 pass, including 19 new cases under `external-register.test.ts` (happy path, auth + length-oracle, reserved-id table-test for all 7, slug rejection, manifest validation, cross-field check, duplicate registration with key rotation, missing-env).
- [x] `pnpm --filter @pops/api test src/db/per-pillar-migrations.test.ts` — updated to expect migration `0058`.
- [x] `pnpm typecheck` — clean across the workspace.
- [x] `pnpm lint` — no errors in the new files (only pre-existing warnings remain).