### PR TITLE
feat(pillar-sdk): add callDynamic affordance for runtime procedure paths (PRD-204 risky sites unblock)

### DIFF
--- a/apps/pops-shell/src/app/pages/settings-page/useTestActionHandler.ts
+++ b/apps/pops-shell/src/app/pages/settings-page/useTestActionHandler.ts
@@ -13,7 +13,13 @@ function assertConnected(result: unknown): void {
   }
 }
 
-/** Dynamic traversal is unavoidable — procedure paths come from manifest data at runtime. */
+/**
+ * Dynamic traversal is unavoidable — procedure paths come from manifest data at runtime.
+ *
+ * PRD-204 follow-up: now unblocked by `@pops/pillar-sdk` `pillar(id).callDynamic(router, proc, input, kind)`
+ * plus `usePillarCallDynamic` / `usePillarCallDynamicMutation`. Migration is tracked separately
+ * so the SDK addition can ship in isolation.
+ */
 export function useTestActionHandler() {
   const utils = trpc.useUtils();
 

--- a/apps/pops-shell/src/components/settings/section-renderer/useTrpcOptionsLoaders.ts
+++ b/apps/pops-shell/src/components/settings/section-renderer/useTrpcOptionsLoaders.ts
@@ -7,6 +7,12 @@ import type { SettingsManifest } from '@pops/types';
 type Options = { value: string; label: string }[];
 type Loaders = Record<string, () => Promise<Options>>;
 
+/**
+ * PRD-204 follow-up: this site builds tRPC procedure paths from manifest data at runtime,
+ * which is now supported by `@pops/pillar-sdk` `pillar(id).callDynamic(router, proc, input)`.
+ * Migration off the legacy `@/lib/trpc` traversal helper is tracked separately so the SDK
+ * affordance can ship in isolation.
+ */
 export function useTrpcOptionsLoaders(manifest: SettingsManifest): Loaders {
   const utils = trpc.useUtils();
   // Keep a ref so loader closures always see the latest utils without causing

--- a/packages/pillar-sdk/src/client/__tests__/call-dynamic.test.ts
+++ b/packages/pillar-sdk/src/client/__tests__/call-dynamic.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { isOk } from '../errors.js';
+import { __resetSharedPillarClient, pillar } from '../factory.js';
+import {
+  discoveredPillar,
+  fakeFetch,
+  FakeRegistryTransport,
+  jsonResponse,
+  type FakeFetchHandler,
+} from './fixtures.js';
+
+type FetchCall = { url: string; body: unknown };
+
+function recordingFetch(responder: (url: string, body: unknown) => Response | Promise<Response>): {
+  fetchImpl: typeof fetch;
+  calls: FetchCall[];
+} {
+  const calls: FetchCall[] = [];
+  const handler: FakeFetchHandler = async (url, init) => {
+    let parsed: unknown = null;
+    if (init?.body) {
+      const raw = typeof init.body === 'string' ? init.body : '';
+      try {
+        parsed = raw ? JSON.parse(raw) : null;
+      } catch {
+        parsed = raw;
+      }
+    }
+    calls.push({ url, body: parsed });
+    return responder(url, parsed);
+  };
+  return { fetchImpl: fakeFetch(handler), calls };
+}
+
+describe('pillar().callDynamic — runtime path dispatch', () => {
+  beforeEach(() => __resetSharedPillarClient());
+  afterEach(() => __resetSharedPillarClient());
+
+  it('dispatches to <baseUrl>/trpc/<pillar>.<router>.<proc> matching the typed proxy', async () => {
+    const transport = new FakeRegistryTransport({ pillars: [discoveredPillar()] });
+    const { fetchImpl, calls } = recordingFetch(() =>
+      jsonResponse({ result: { data: [{ id: 'wish-1' }] } })
+    );
+    const finance = pillar('finance', { transport, fetchImpl });
+    const result = await finance.callDynamic('wishlist', 'list', { limit: 5 });
+    expect(isOk(result)).toBe(true);
+    if (result.kind === 'ok') {
+      expect(result.value).toEqual([{ id: 'wish-1' }]);
+    }
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.url).toBe('http://finance-api:3004/trpc/finance.wishlist.list');
+    expect(calls[0]?.body).toEqual({ limit: 5 });
+  });
+
+  it('passes input through verbatim — no zod / shape validation in the SDK layer', async () => {
+    const transport = new FakeRegistryTransport({ pillars: [discoveredPillar()] });
+    const { fetchImpl, calls } = recordingFetch(() =>
+      jsonResponse({ result: { data: { ok: true } } })
+    );
+    const finance = pillar('finance', { transport, fetchImpl });
+    const weirdInput = { nested: { deeply: [1, 2, 3] }, flag: false };
+    await finance.callDynamic('wishlist', 'list', weirdInput);
+    expect(calls[0]?.body).toEqual(weirdInput);
+  });
+
+  it('serialises an omitted input as null (matches typed proxy)', async () => {
+    const transport = new FakeRegistryTransport({ pillars: [discoveredPillar()] });
+    const { fetchImpl, calls } = recordingFetch(() => jsonResponse({ result: { data: null } }));
+    const finance = pillar('finance', { transport, fetchImpl });
+    await finance.callDynamic('wishlist', 'list');
+    expect(calls[0]?.body).toBeNull();
+  });
+
+  it("kind='mutation' routes through the same transport as kind='query'", async () => {
+    const transport = new FakeRegistryTransport({ pillars: [discoveredPillar()] });
+    const { fetchImpl, calls } = recordingFetch(() =>
+      jsonResponse({ result: { data: { id: 'created' } } })
+    );
+    const finance = pillar('finance', { transport, fetchImpl });
+    const result = await finance.callDynamic('wishlist', 'create', { name: 'x' }, 'mutation');
+    expect(result.kind).toBe('ok');
+    expect(calls[0]?.url).toBe('http://finance-api:3004/trpc/finance.wishlist.create');
+  });
+
+  it("returns 'unavailable' when the pillar is offline", async () => {
+    const transport = new FakeRegistryTransport({ pillars: [] });
+    const { fetchImpl } = recordingFetch(() => jsonResponse({}));
+    const finance = pillar('finance', { transport, fetchImpl });
+    const result = await finance.callDynamic('wishlist', 'list', {});
+    expect(result.kind).toBe('unavailable');
+    if (result.kind === 'unavailable') expect(result.pillar).toBe('finance');
+  });
+
+  it("returns 'contract-mismatch' when the procedure path doesn't exist (404)", async () => {
+    const transport = new FakeRegistryTransport({ pillars: [discoveredPillar()] });
+    const fetchImpl = fakeFetch(() => new Response('not found', { status: 404 }));
+    const finance = pillar('finance', { transport, fetchImpl });
+    const result = await finance.callDynamic('wishlist', 'doesNotExist', {});
+    expect(result.kind).toBe('contract-mismatch');
+    if (result.kind === 'contract-mismatch') {
+      expect(result.expected).toBe('finance.wishlist.doesNotExist');
+    }
+  });
+
+  it('shares the discovery cache with the typed proxy (single lookup for both)', async () => {
+    const transport = new FakeRegistryTransport({ pillars: [discoveredPillar()] });
+    const { fetchImpl } = recordingFetch(() => jsonResponse({ result: { data: null } }));
+    const finance = pillar('finance', { transport, fetchImpl, cacheTtlMs: 60_000 });
+    await finance.wishlist.list({});
+    await finance.callDynamic('wishlist', 'list', {});
+    await finance.callDynamic('budgets', 'list', {});
+    expect(transport.callCount).toBe(1);
+  });
+});

--- a/packages/pillar-sdk/src/client/index.ts
+++ b/packages/pillar-sdk/src/client/index.ts
@@ -1,6 +1,6 @@
 export { pillar, __resetSharedPillarClient } from './factory.js';
 export type { PillarClientOptions } from './factory.js';
-export type { PillarHandle, CallableProcedure } from './proxy.js';
+export type { CallableProcedure, CallDynamicFn, PillarHandle, ProcedureKind } from './proxy.js';
 export { DiscoveryCache } from './cache.js';
 export {
   HttpDiscoveryTransport,

--- a/packages/pillar-sdk/src/client/proxy.ts
+++ b/packages/pillar-sdk/src/client/proxy.ts
@@ -11,12 +11,36 @@ type ProcedureNode<T> = T extends (...args: infer Args) => infer Ret
     ? { [K in keyof T]: ProcedureNode<T[K]> }
     : CallableProcedure<readonly unknown[], unknown>;
 
-export type PillarHandle<TRouter> =
-  TRouter extends Record<string, unknown>
-    ? { [K in keyof TRouter]: ProcedureNode<TRouter[K]> }
-    : Record<string, ProcedureNode<unknown>>;
+/** Hint to React Query whether the runtime call is a read (query) or write (mutation). */
+export type ProcedureKind = 'query' | 'mutation';
+
+/**
+ * Runtime escape hatch for call sites that build procedure paths from
+ * config (e.g. a settings manifest names `routerName` + `procName`).
+ *
+ * Prefer the typed proxy (`pillar('finance').wishlist.list(input)`) when
+ * the path is known at compile time. The result is always
+ * `CallResult<unknown>` because the output shape cannot be derived from a
+ * runtime path.
+ */
+export type CallDynamicFn = {
+  (
+    routerName: string,
+    procName: string,
+    input?: unknown,
+    kind?: ProcedureKind
+  ): Promise<CallResult<unknown>>;
+};
+
+export type PillarHandle<TRouter> = (TRouter extends Record<string, unknown>
+  ? { [K in keyof TRouter]: ProcedureNode<TRouter[K]> }
+  : Record<string, ProcedureNode<unknown>>) & {
+  callDynamic: CallDynamicFn;
+};
 
 export type InvokeFn = (path: readonly string[], input: unknown) => Promise<CallResult<unknown>>;
+
+const CALL_DYNAMIC_KEY = 'callDynamic';
 
 export function buildPillarProxy(pillarId: string, invoke: InvokeFn): unknown {
   return buildBranch(pillarId, [], invoke);
@@ -27,9 +51,24 @@ function buildBranch(pillarId: string, path: readonly string[], invoke: InvokeFn
   return new Proxy(target, {
     get(_t, prop) {
       if (typeof prop !== 'string' || prop === 'then') return undefined;
+      if (path.length === 0 && prop === CALL_DYNAMIC_KEY) {
+        return buildCallDynamic(invoke);
+      }
       return buildCallable(pillarId, [...path, prop], invoke);
     },
   });
+}
+
+function buildCallDynamic(invoke: InvokeFn): CallDynamicFn {
+  return (
+    routerName: string,
+    procName: string,
+    input?: unknown,
+    kind: ProcedureKind = 'query'
+  ): Promise<CallResult<unknown>> => {
+    void kind;
+    return invoke([routerName, procName], input);
+  };
 }
 
 function buildCallable(pillarId: string, path: readonly string[], invoke: InvokeFn): unknown {

--- a/packages/pillar-sdk/src/react/__tests__/call-dynamic.test.tsx
+++ b/packages/pillar-sdk/src/react/__tests__/call-dynamic.test.tsx
@@ -1,0 +1,180 @@
+// @vitest-environment jsdom
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  discoveredPillar,
+  fakeFetch,
+  FakeRegistryTransport,
+  jsonResponse,
+} from '../../client/__tests__/fixtures.js';
+import { __resetSharedPillarClient } from '../../client/factory.js';
+import { usePillarCallDynamic, usePillarCallDynamicMutation } from '../hooks.js';
+import { PillarSdkProvider } from '../provider.js';
+
+import type { ReactNode } from 'react';
+
+import type { PillarClientOptions } from '../../client/factory.js';
+
+type FetchScript = (url: string, body: unknown) => Response | Promise<Response>;
+
+type Harness = {
+  wrapper: (props: { children: ReactNode }) => ReactNode;
+  queryClient: QueryClient;
+  calls: { url: string; body: unknown }[];
+};
+
+function buildHarness(transport: FakeRegistryTransport, script: FetchScript): Harness {
+  const calls: { url: string; body: unknown }[] = [];
+  const fetchImpl = fakeFetch(async (url, init) => {
+    let parsed: unknown = null;
+    if (init?.body && typeof init.body === 'string') {
+      try {
+        parsed = JSON.parse(init.body);
+      } catch {
+        parsed = init.body;
+      }
+    }
+    calls.push({ url, body: parsed });
+    return script(url, parsed);
+  });
+  const options: PillarClientOptions = { transport, fetchImpl };
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  const wrapper = ({ children }: { children: ReactNode }): ReactNode => (
+    <QueryClientProvider client={queryClient}>
+      <PillarSdkProvider options={options}>{children}</PillarSdkProvider>
+    </QueryClientProvider>
+  );
+  return { wrapper, queryClient, calls };
+}
+
+describe('usePillarCallDynamic — query path', () => {
+  beforeEach(() => __resetSharedPillarClient());
+  afterEach(() => __resetSharedPillarClient());
+
+  it('runs a runtime-path query and returns the data', async () => {
+    const transport = new FakeRegistryTransport({ pillars: [discoveredPillar()] });
+    const harness = buildHarness(transport, () =>
+      jsonResponse({ result: { data: [{ id: 'wish-1' }] } })
+    );
+    const { result } = renderHook(
+      () =>
+        usePillarCallDynamic({
+          pillarId: 'finance',
+          routerName: 'wishlist',
+          procName: 'list',
+          input: { limit: 10 },
+        }),
+      { wrapper: harness.wrapper }
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([{ id: 'wish-1' }]);
+    expect(result.current.isUnavailable).toBe(false);
+    expect(result.current.isContractMismatch).toBe(false);
+    expect(result.current.isDegraded).toBe(false);
+  });
+
+  it('surfaces `unavailable` via isUnavailable flag', async () => {
+    const transport = new FakeRegistryTransport({ pillars: [] });
+    const harness = buildHarness(transport, () => jsonResponse({}));
+    const { result } = renderHook(
+      () =>
+        usePillarCallDynamic({
+          pillarId: 'finance',
+          routerName: 'wishlist',
+          procName: 'list',
+          input: {},
+        }),
+      { wrapper: harness.wrapper }
+    );
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.isUnavailable).toBe(true);
+  });
+
+  it('surfaces a 404 path-not-found via isContractMismatch', async () => {
+    const transport = new FakeRegistryTransport({ pillars: [discoveredPillar()] });
+    const calls: { url: string; body: unknown }[] = [];
+    const fetchImpl = fakeFetch(async (url) => {
+      calls.push({ url, body: null });
+      return new Response('not found', { status: 404 });
+    });
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: ReactNode }): ReactNode => (
+      <QueryClientProvider client={queryClient}>
+        <PillarSdkProvider options={{ transport, fetchImpl }}>{children}</PillarSdkProvider>
+      </QueryClientProvider>
+    );
+    const { result } = renderHook(
+      () =>
+        usePillarCallDynamic({
+          pillarId: 'finance',
+          routerName: 'wishlist',
+          procName: 'nope',
+          input: {},
+        }),
+      { wrapper }
+    );
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.isContractMismatch).toBe(true);
+    expect(calls[0]?.url).toBe('http://finance-api:3004/trpc/finance.wishlist.nope');
+  });
+});
+
+describe('usePillarCallDynamicMutation', () => {
+  beforeEach(() => __resetSharedPillarClient());
+  afterEach(() => __resetSharedPillarClient());
+
+  it('returns a mutation handle that POSTs the input to the dynamic path', async () => {
+    const transport = new FakeRegistryTransport({ pillars: [discoveredPillar()] });
+    const harness = buildHarness(transport, () =>
+      jsonResponse({ result: { data: { id: 'created' } } })
+    );
+    const { result } = renderHook(
+      () =>
+        usePillarCallDynamicMutation({
+          pillarId: 'finance',
+          routerName: 'wishlist',
+          procName: 'create',
+        }),
+      { wrapper: harness.wrapper }
+    );
+    await act(async () => {
+      await result.current.mutateAsync({ name: 'new wish' });
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual({ id: 'created' });
+    expect(harness.calls[0]?.url).toBe('http://finance-api:3004/trpc/finance.wishlist.create');
+    expect(harness.calls[0]?.body).toEqual({ name: 'new wish' });
+  });
+
+  it('surfaces unavailable via isUnavailable on error', async () => {
+    const transport = new FakeRegistryTransport({ pillars: [] });
+    const harness = buildHarness(transport, () => jsonResponse({}));
+    const { result } = renderHook(
+      () =>
+        usePillarCallDynamicMutation({
+          pillarId: 'finance',
+          routerName: 'wishlist',
+          procName: 'create',
+        }),
+      { wrapper: harness.wrapper }
+    );
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({});
+      } catch {
+        // PillarCallError expected
+      }
+    });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.isUnavailable).toBe(true);
+  });
+});

--- a/packages/pillar-sdk/src/react/hooks.ts
+++ b/packages/pillar-sdk/src/react/hooks.ts
@@ -165,3 +165,54 @@ export function usePillarMutation<TInput = unknown, TOutput = unknown>(
 
   return { ...mutation, ...flags } as UsePillarMutationResult<TInput, TOutput>;
 }
+
+export type UsePillarCallDynamicQueryOptions = UsePillarQueryOptions<unknown>;
+export type UsePillarCallDynamicQueryResult = UsePillarQueryResult<unknown>;
+export type UsePillarCallDynamicMutationOptions = UsePillarMutationOptions<unknown, unknown>;
+export type UsePillarCallDynamicMutationResult = UsePillarMutationResult<unknown, unknown>;
+
+export type UsePillarCallDynamicQueryArgs = {
+  pillarId: string;
+  routerName: string;
+  procName: string;
+  input?: unknown;
+  options?: UsePillarCallDynamicQueryOptions;
+};
+
+export type UsePillarCallDynamicMutationArgs = {
+  pillarId: string;
+  routerName: string;
+  procName: string;
+  options?: UsePillarCallDynamicMutationOptions;
+};
+
+/**
+ * Runtime-path React Query hook. Use only when `routerName` / `procName`
+ * are not known at compile time (e.g. paths come from a settings
+ * manifest). For statically-known paths prefer
+ * {@link usePillarQuery} so call sites get end-to-end typing. Output is
+ * always `unknown` because the shape cannot be inferred from a runtime
+ * path; the caller is responsible for validating it.
+ *
+ * For mutations, see {@link usePillarCallDynamicMutation}. The two are
+ * separate hooks (not a `kind`-switched single hook) so React's
+ * rules-of-hooks aren't violated when call sites change their mind.
+ */
+export function usePillarCallDynamic(
+  args: UsePillarCallDynamicQueryArgs
+): UsePillarCallDynamicQueryResult {
+  const path: ProcedurePath = [args.routerName, args.procName];
+  return usePillarQuery<unknown>(args.pillarId, path, args.input, args.options ?? {});
+}
+
+/**
+ * Mutation-mode counterpart to {@link usePillarCallDynamic}. Returns
+ * `unknown` for both input and output; callers should validate the
+ * input shape before invoking `mutateAsync`.
+ */
+export function usePillarCallDynamicMutation(
+  args: UsePillarCallDynamicMutationArgs
+): UsePillarCallDynamicMutationResult {
+  const path: ProcedurePath = [args.routerName, args.procName];
+  return usePillarMutation<unknown, unknown>(args.pillarId, path, args.options ?? {});
+}

--- a/packages/pillar-sdk/src/react/index.ts
+++ b/packages/pillar-sdk/src/react/index.ts
@@ -1,11 +1,22 @@
 export { PillarSdkProvider, usePillarSdkOptions } from './provider.js';
 export type { PillarSdkProviderProps } from './provider.js';
-export { usePillarQuery, usePillarMutation } from './hooks.js';
+export {
+  usePillarCallDynamic,
+  usePillarCallDynamicMutation,
+  usePillarMutation,
+  usePillarQuery,
+} from './hooks.js';
 export type {
-  UsePillarQueryOptions,
-  UsePillarQueryResult,
+  UsePillarCallDynamicMutationArgs,
+  UsePillarCallDynamicMutationOptions,
+  UsePillarCallDynamicMutationResult,
+  UsePillarCallDynamicQueryArgs,
+  UsePillarCallDynamicQueryOptions,
+  UsePillarCallDynamicQueryResult,
   UsePillarMutationOptions,
   UsePillarMutationResult,
+  UsePillarQueryOptions,
+  UsePillarQueryResult,
 } from './hooks.js';
 export { pillarQueryKey } from './query-key.js';
 export { usePillarSubscriptionBridge, applySubscriptionEvent } from './subscription-bridge.js';


### PR DESCRIPTION
## Summary

- Adds `pillar(pillarId).callDynamic(routerName, procName, input?, kind?)` to `@pops/pillar-sdk` so call sites that build procedure paths at runtime (e.g. from settings-manifest data) can dispatch through the SDK instead of the legacy `@/lib/trpc` traversal helper. Output type is `unknown` because the path is not statically known; failures use the same `CallResult<unknown>` shape as the typed proxy.
- Adds `usePillarCallDynamic` and `usePillarCallDynamicMutation` React Query hook wrappers. Split into two hooks so call sites cannot accidentally violate rules-of-hooks by toggling `kind` across renders.
- Tags the 3 risky shell sites identified in the PRD-204 audit (`useTestActionHandler`, `useTrpcOptionsLoaders`) with a docblock pointing at `callDynamic` as their unblock path. Migration is intentionally left to a follow-up PR so the SDK addition can ship in isolation.

## API

```ts
// Client surface
pillar('finance').callDynamic('wishlist', 'list', { limit: 10 });
// => Promise<CallResult<unknown>>

pillar('finance').callDynamic('wishlist', 'create', { name: 'x' }, 'mutation');
// => Promise<CallResult<unknown>>

// React Query hooks
const q = usePillarCallDynamic({
  pillarId: 'finance',
  routerName: 'wishlist',
  procName: 'list',
  input: { limit: 10 },
});

const m = usePillarCallDynamicMutation({
  pillarId: 'finance',
  routerName: 'wishlist',
  procName: 'create',
});
```

Both hooks return the same failure-flag shape (`isUnavailable` / `isContractMismatch` / `isDegraded`) as `usePillarQuery` / `usePillarMutation`.

## Test plan

- [x] `pnpm --filter @pops/pillar-sdk typecheck` — clean
- [x] `pnpm --filter @pops/pillar-sdk test` — 432/432 passing, including 7 new client tests + 5 new React hook tests covering happy path, mutation routing, missing input (null body), unavailable, contract-mismatch (path 404), input passthrough, and discovery-cache sharing with the typed proxy.
- [x] `pnpm typecheck` across the workspace — 66/66 packages clean.
- [x] Husky pre-commit (lint-staged: oxlint + oxfmt) and pre-push (workspace typecheck) ran clean.

## Follow-ups

- PRD-204 migration of `useTestActionHandler` and `useTrpcOptionsLoaders` off `@/lib/trpc` onto `usePillarCallDynamic` (now unblocked).
