### PR TITLE
feat(app-finance): migrate single-pillar tRPC sites to pillar SDK (PRD-227)

### DIFF
--- a/packages/app-finance/package.json
+++ b/packages/app-finance/package.json
@@ -19,6 +19,7 @@
     "@pops/api-client": "workspace:*",
     "@pops/db-types": "workspace:*",
     "@pops/navigation": "workspace:*",
+    "@pops/pillar-sdk": "workspace:*",
     "@pops/types": "workspace:*",
     "@pops/ui": "workspace:*",
     "@tanstack/react-query": "5.101.0",

--- a/packages/app-finance/src/components/imports/FinalReviewStep.test.tsx
+++ b/packages/app-finance/src/components/imports/FinalReviewStep.test.tsx
@@ -23,21 +23,17 @@ let mutationCallbacks: {
 } = {};
 let mockIsPending = false;
 
-vi.mock('@pops/api-client', () => ({
-  trpc: {
-    finance: {
-      imports: {
-        commitImport: {
-          useMutation: (opts: typeof mutationCallbacks) => {
-            mutationCallbacks = opts;
-            return {
-              mutate: mockMutate,
-              isPending: mockIsPending,
-            };
-          },
-        },
-      },
-    },
+vi.mock('@pops/pillar-sdk/react', () => ({
+  usePillarMutation: (
+    _pillarId: string,
+    path: readonly string[],
+    opts?: typeof mutationCallbacks
+  ) => {
+    if (path.join('.') === 'imports.commitImport') {
+      mutationCallbacks = opts ?? {};
+      return { mutate: mockMutate, isPending: mockIsPending };
+    }
+    return { mutate: vi.fn(), isPending: false };
   },
 }));
 

--- a/packages/app-finance/src/components/imports/ProcessingStep.test.tsx
+++ b/packages/app-finance/src/components/imports/ProcessingStep.test.tsx
@@ -6,21 +6,17 @@ const mockReset = vi.fn();
 const mockMutation = vi.fn();
 const mockProgressQuery = vi.fn();
 
-vi.mock('@pops/api-client', () => ({
-  trpc: {
-    finance: {
-      imports: {
-        processImport: {
-          useMutation: (opts: unknown) => {
-            mockMutation(opts);
-            return mockMutationReturn();
-          },
-        },
-        getImportProgress: {
-          useQuery: (...args: unknown[]) => mockProgressQuery(...args),
-        },
-      },
-    },
+vi.mock('@pops/pillar-sdk/react', () => ({
+  usePillarMutation: (_pillarId: string, path: readonly string[], opts?: unknown) => {
+    if (path.join('.') === 'imports.processImport') {
+      mockMutation(opts);
+      return mockMutationReturn();
+    }
+    return { mutate: vi.fn(), reset: vi.fn(), isPending: false, isSuccess: false, isError: false };
+  },
+  usePillarQuery: (_pillarId: string, path: readonly string[], input?: unknown) => {
+    if (path.join('.') === 'imports.getImportProgress') return mockProgressQuery(input);
+    return { data: undefined };
   },
 }));
 

--- a/packages/app-finance/src/components/imports/ReviewStep.test.tsx
+++ b/packages/app-finance/src/components/imports/ReviewStep.test.tsx
@@ -7,6 +7,31 @@ const mockAnalyzeCorrectionMutateAsync = vi.fn();
 const mockEntitiesQuery = vi.fn();
 const mockReevaluateMutate = vi.fn();
 
+vi.mock('@pops/pillar-sdk/react', () => ({
+  usePillarQuery: (_pillarId: string, path: readonly string[]) => {
+    if (path.join('.') === 'transactions.listDescriptionsForPreview') {
+      return { data: { data: [], total: 0, truncated: false }, isLoading: false };
+    }
+    return { data: undefined };
+  },
+  usePillarMutation: (_pillarId: string, path: readonly string[]) => {
+    if (path.join('.') === 'imports.reevaluateWithPendingRules') {
+      return {
+        mutate: (
+          _input: unknown,
+          opts?: {
+            onSuccess?: (data: { result: unknown; affectedCount: number }) => void;
+            onError?: (err: Error) => void;
+          }
+        ) => mockReevaluateMutate(_input, opts),
+        mutateAsync: vi.fn(),
+        isPending: false,
+      };
+    }
+    return { mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false };
+  },
+}));
+
 vi.mock('@pops/api-client', () => ({
   trpc: {
     core: {
@@ -51,28 +76,6 @@ vi.mock('@pops/api-client', () => ({
         },
         rejectChangeSet: {
           useMutation: () => ({ mutate: vi.fn(), isPending: false }),
-        },
-      },
-    },
-    finance: {
-      imports: {
-        reevaluateWithPendingRules: {
-          useMutation: () => ({
-            mutate: (
-              _input: unknown,
-              opts?: {
-                onSuccess?: (data: { result: unknown; affectedCount: number }) => void;
-                onError?: (err: Error) => void;
-              }
-            ) => mockReevaluateMutate(_input, opts),
-            mutateAsync: vi.fn(),
-            isPending: false,
-          }),
-        },
-      },
-      transactions: {
-        listDescriptionsForPreview: {
-          useQuery: () => ({ data: { data: [], total: 0, truncated: false }, isLoading: false }),
         },
       },
     },

--- a/packages/app-finance/src/components/imports/TagReviewStep.test.tsx
+++ b/packages/app-finance/src/components/imports/TagReviewStep.test.tsx
@@ -33,15 +33,18 @@ vi.mock('../../store/importStore', () => ({
 // Mock trpc
 // ---------------------------------------------------------------------------
 
+vi.mock('@pops/pillar-sdk/react', () => ({
+  usePillarQuery: (_pillarId: string, path: readonly string[]) => {
+    if (path.join('.') === 'transactions.availableTags') {
+      return { data: ['Groceries', 'Transport', 'Subscriptions'] };
+    }
+    return { data: undefined };
+  },
+  usePillarMutation: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
 vi.mock('@pops/api-client', () => ({
   trpc: {
-    finance: {
-      transactions: {
-        availableTags: {
-          useQuery: () => ({ data: ['Groceries', 'Transport', 'Subscriptions'] }),
-        },
-      },
-    },
     core: {
       tagRules: {
         proposeTagRuleChangeSet: {

--- a/packages/app-finance/src/components/imports/correction-proposal/rule-manager/useRuleManagerHooks.ts
+++ b/packages/app-finance/src/components/imports/correction-proposal/rule-manager/useRuleManagerHooks.ts
@@ -1,8 +1,14 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 
-import { trpc } from '@pops/api-client';
+import { usePillarQuery } from '@pops/pillar-sdk/react';
 
 import { useImportStore } from '../../../../store/importStore';
+
+interface DescriptionsForPreviewResult {
+  data: Array<{ description: string; checksum: string }>;
+  total: number;
+  truncated: boolean;
+}
 import { type PreviewView } from '../../CorrectionProposalDialogPanels';
 import { useLocalOps } from '../../hooks/useLocalOps';
 import { usePreviewEffects } from '../../hooks/usePreviewEffects';
@@ -43,10 +49,15 @@ export function useRuleManagerHooks(props: RuleManagerInputs) {
     proposeData: undefined,
   });
   const dialogState = useDialogState(open);
-  const dbTxnsQuery = trpc.finance.transactions.listDescriptionsForPreview.useQuery(undefined, {
-    enabled: open,
-    staleTime: 60_000,
-  });
+  const dbTxnsQuery = usePillarQuery<DescriptionsForPreviewResult>(
+    'finance',
+    ['transactions', 'listDescriptionsForPreview'],
+    undefined,
+    {
+      enabled: open,
+      staleTime: 60_000,
+    }
+  );
   const previewHook = usePreviewEffects(
     {
       open,

--- a/packages/app-finance/src/components/imports/final-review/useFinalReview.ts
+++ b/packages/app-finance/src/components/imports/final-review/useFinalReview.ts
@@ -1,9 +1,15 @@
 import { useMemo, useState } from 'react';
 
-import { trpc } from '@pops/api-client';
+import { usePillarMutation } from '@pops/pillar-sdk/react';
 
-import { buildCommitPayload } from '../../../lib/commit-payload';
+import { buildCommitPayload, type CommitPayload } from '../../../lib/commit-payload';
 import { useImportStore } from '../../../store/importStore';
+
+import type { CommitResult } from '@pops/api/modules/finance/imports';
+
+interface CommitResponse {
+  data: CommitResult;
+}
 
 function useStoreSlice() {
   return {
@@ -58,16 +64,20 @@ export function useFinalReview() {
   const slice = useStoreSlice();
   const counts = useDerivedCounts(slice);
   const [commitError, setCommitError] = useState<string | null>(null);
-  const commitMutation = trpc.finance.imports.commitImport.useMutation({
-    onSuccess: (response) => {
-      slice.setCommitResult(response.data);
-      setCommitError(null);
-      // SummaryStep owns the post-commit UI; auto-advance there instead of
-      // showing an inline panel + manual Continue click.
-      slice.nextStep();
-    },
-    onError: (err) => setCommitError(err.message),
-  });
+  const commitMutation = usePillarMutation<CommitPayload, CommitResponse>(
+    'finance',
+    ['imports', 'commitImport'],
+    {
+      onSuccess: (response) => {
+        slice.setCommitResult(response.data);
+        setCommitError(null);
+        // SummaryStep owns the post-commit UI; auto-advance there instead of
+        // showing an inline panel + manual Continue click.
+        slice.nextStep();
+      },
+      onError: (err) => setCommitError(err.message),
+    }
+  );
   const handleCommit = () => {
     setCommitError(null);
     commitMutation.mutate(

--- a/packages/app-finance/src/components/imports/hooks/useTransactionReview.ts
+++ b/packages/app-finance/src/components/imports/hooks/useTransactionReview.ts
@@ -1,10 +1,23 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
-import { trpc } from '@pops/api-client';
+import { usePillarMutation } from '@pops/pillar-sdk/react';
 
 import { groupTransactionsByEntity } from '../../../lib/transaction-utils';
 import { useImportStore } from '../../../store/importStore';
+
+import type { ChangeSet } from '@pops/api/modules/core/corrections/types';
+import type { ProcessImportOutput } from '@pops/api/modules/finance/imports';
+
+interface ReevaluateInput {
+  sessionId: string;
+  minConfidence: number;
+  pendingChangeSets: Array<{ changeSet: ChangeSet }>;
+}
+interface ReevaluateResponse {
+  result: ProcessImportOutput;
+  affectedCount: number;
+}
 
 export type ViewMode = 'list' | 'grouped';
 
@@ -38,7 +51,10 @@ function useReevalOnChangeSets(
   sessionId: string | null
 ) {
   const prevChangeSetsRef = useRef(pendingChangeSets);
-  const reevaluateMutation = trpc.finance.imports.reevaluateWithPendingRules.useMutation();
+  const reevaluateMutation = usePillarMutation<ReevaluateInput, ReevaluateResponse>('finance', [
+    'imports',
+    'reevaluateWithPendingRules',
+  ]);
   useEffect(() => {
     if (prevChangeSetsRef.current === pendingChangeSets) return;
     prevChangeSetsRef.current = pendingChangeSets;

--- a/packages/app-finance/src/components/imports/processing/useProcessing.ts
+++ b/packages/app-finance/src/components/imports/processing/useProcessing.ts
@@ -1,10 +1,31 @@
 import { useEffect, useState } from 'react';
 
-import { trpc } from '@pops/api-client';
+import { usePillarMutation, usePillarQuery } from '@pops/pillar-sdk/react';
 
 import { useImportStore } from '../../../store/importStore';
 
-import type { ImportWarning, ProcessImportOutput } from '@pops/api/modules/finance/imports';
+import type {
+  ImportWarning,
+  ParsedTransaction,
+  ProcessImportOutput,
+} from '@pops/api/modules/finance/imports';
+
+interface ProcessImportInput {
+  transactions: ParsedTransaction[];
+  account: string;
+}
+interface ProcessImportResponse {
+  sessionId: string;
+}
+interface GetProgressInput {
+  sessionId: string;
+}
+interface ImportProgressShape {
+  sessionId: string;
+  status: 'processing' | 'completed' | 'failed';
+  result?: ProcessImportOutput;
+  errors?: Array<{ description: string; error: string }>;
+}
 
 export function useHasAlreadyProcessed(): boolean {
   const { processedTransactions, processedForFingerprint, parsedTransactionsFingerprint } =
@@ -25,15 +46,21 @@ export function useHasAlreadyProcessed(): boolean {
 export function useProcessingMutations() {
   const { setProcessSessionId, processSessionId } = useImportStore();
   const [pollingEnabled, setPollingEnabled] = useState(false);
-  const processImportMutation = trpc.finance.imports.processImport.useMutation({
-    onSuccess: (data) => {
-      setProcessSessionId(data.sessionId);
-      setPollingEnabled(true);
-    },
-    onError: (error) => console.error('Processing error:', error),
-  });
-  const progressQuery = trpc.finance.imports.getImportProgress.useQuery(
-    { sessionId: processSessionId ?? '' },
+  const processImportMutation = usePillarMutation<ProcessImportInput, ProcessImportResponse>(
+    'finance',
+    ['imports', 'processImport'],
+    {
+      onSuccess: (data) => {
+        setProcessSessionId(data.sessionId);
+        setPollingEnabled(true);
+      },
+      onError: (error) => console.error('Processing error:', error),
+    }
+  );
+  const progressQuery = usePillarQuery<ImportProgressShape | null>(
+    'finance',
+    ['imports', 'getImportProgress'],
+    { sessionId: processSessionId ?? '' } satisfies GetProgressInput,
     {
       enabled: pollingEnabled && !!processSessionId,
       refetchInterval: 1000,
@@ -51,7 +78,7 @@ export function useCompletionHandler(state: ProcessingState): void {
   useEffect(() => {
     if (progressQuery.data?.status === 'completed' && progressQuery.data.result) {
       setPollingEnabled(false);
-      const result = progressQuery.data.result as ProcessImportOutput;
+      const result = progressQuery.data.result;
       setProcessedTransactions(result);
       const hasCriticalError = result.warnings?.some(
         (w: ImportWarning) => w.type === 'AI_API_ERROR'

--- a/packages/app-finance/src/components/imports/review/ReviewDialogs.tsx
+++ b/packages/app-finance/src/components/imports/review/ReviewDialogs.tsx
@@ -1,14 +1,27 @@
 import { toast } from 'sonner';
 
-import { trpc } from '@pops/api-client';
+import { usePillarMutation } from '@pops/pillar-sdk/react';
 
 import { useImportStore } from '../../../store/importStore';
 import { CorrectionProposalDialog } from '../CorrectionProposalDialog';
 import { EntityCreateDialog } from '../EntityCreateDialog';
 
+import type { ChangeSet } from '@pops/api/modules/core/corrections/types';
+import type { ProcessImportOutput } from '@pops/api/modules/finance/imports';
+
 import type { useBulkAssignment } from '../hooks/useBulkAssignment';
 import type { useProposalGeneration } from '../hooks/useProposalGeneration';
 import type { useTransactionReview } from '../hooks/useTransactionReview';
+
+interface ReevaluateInput {
+  sessionId: string;
+  minConfidence: number;
+  pendingChangeSets: Array<{ changeSet: ChangeSet }>;
+}
+interface ReevaluateResponse {
+  result: ProcessImportOutput;
+  affectedCount: number;
+}
 
 interface BrowseDialogProps {
   open: boolean;
@@ -26,7 +39,10 @@ function BrowseDialog({
   setLocalTransactions,
 }: BrowseDialogProps) {
   const pendingChangeSets = useImportStore((s) => s.pendingChangeSets);
-  const reevaluateMutation = trpc.finance.imports.reevaluateWithPendingRules.useMutation();
+  const reevaluateMutation = usePillarMutation<ReevaluateInput, ReevaluateResponse>('finance', [
+    'imports',
+    'reevaluateWithPendingRules',
+  ]);
   const onClose = (hadChanges: boolean) => {
     if (!hadChanges || !sessionId || pendingChangeSets.length === 0) return;
     reevaluateMutation.mutate(

--- a/packages/app-finance/src/components/imports/tag-review/useTagReviewState.ts
+++ b/packages/app-finance/src/components/imports/tag-review/useTagReviewState.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import { trpc } from '@pops/api-client';
+import { usePillarQuery } from '@pops/pillar-sdk/react';
 
 import { useImportStore } from '../../../store/importStore';
 import { groupByEntity } from './tagReviewUtils';
@@ -75,7 +75,11 @@ function useLocalTagsSync(confirmedTransactions: ConfirmedTransaction[]): LocalT
 }
 
 function useAvailableTags(localTags: Record<string, string[]>): string[] {
-  const { data: serverTags } = trpc.finance.transactions.availableTags.useQuery();
+  const { data: serverTags } = usePillarQuery<string[]>(
+    'finance',
+    ['transactions', 'availableTags'],
+    undefined
+  );
   return useMemo(() => {
     const local = Object.values(localTags).flat();
     return [...new Set([...(serverTags ?? []), ...local])].toSorted();

--- a/packages/app-finance/src/lib/pillar-call.ts
+++ b/packages/app-finance/src/lib/pillar-call.ts
@@ -1,0 +1,48 @@
+import { useCallback } from 'react';
+
+import { pillar, type CallResult } from '@pops/pillar-sdk/client';
+import { usePillarSdkOptions } from '@pops/pillar-sdk/react';
+
+type ProcedurePath = readonly [string, ...string[]];
+
+/**
+ * Imperative one-shot call against a pillar procedure. Mirrors the discontinued
+ * `trpc.useUtils().<pillar>.<path>.fetch(input)` pattern (no caching, no
+ * suspense) so existing call sites that need an ad-hoc lookup can continue to
+ * work without pulling React Query state into the flow.
+ *
+ * Returns the raw `CallResult` so callers can branch on `kind === 'ok'`
+ * versus the `unavailable` / `contract-mismatch` / `degraded` discriminants.
+ */
+export function usePillarCall(): <TOutput>(
+  pillarId: string,
+  path: ProcedurePath,
+  input: unknown
+) => Promise<CallResult<TOutput>> {
+  const sdkOptions = usePillarSdkOptions();
+  return useCallback(
+    async <TOutput>(
+      pillarId: string,
+      path: ProcedurePath,
+      input: unknown
+    ): Promise<CallResult<TOutput>> => {
+      const handle = pillar<unknown>(pillarId, sdkOptions);
+      let node: unknown = handle;
+      for (let i = 0; i < path.length - 1; i += 1) {
+        const segment = path[i] as string;
+        node = (node as Record<string, unknown>)[segment];
+      }
+      const leafName = path[path.length - 1] as string;
+      const leaf = (node as Record<string, unknown>)[leafName];
+      if (typeof leaf !== 'function') {
+        return {
+          kind: 'contract-mismatch',
+          pillar: pillarId,
+          actual: path.join('.'),
+        };
+      }
+      return (leaf as (i: unknown) => Promise<CallResult<TOutput>>)(input);
+    },
+    [sdkOptions]
+  );
+}

--- a/packages/app-finance/src/pages/DashboardPage.tsx
+++ b/packages/app-finance/src/pages/DashboardPage.tsx
@@ -1,11 +1,22 @@
 import { useTranslation } from 'react-i18next';
 
-import { trpc } from '@pops/api-client';
+import { usePillarQuery } from '@pops/pillar-sdk/react';
 import { ErrorAlert, PageHeader } from '@pops/ui';
 
 import { ActiveBudgets } from './dashboard/ActiveBudgets';
 import { RecentTransactions } from './dashboard/RecentTransactions';
 import { computeStats, StatsGrid } from './dashboard/StatsGrid';
+
+import type { Budget } from '@pops/api/modules/finance/budgets/types';
+import type { Transaction } from '@pops/api/modules/finance/transactions/types';
+
+interface TransactionsListResult {
+  data: Transaction[];
+  pagination: { total: number };
+}
+interface BudgetsListResult {
+  data: Budget[];
+}
 
 export function DashboardPage() {
   const { t } = useTranslation('finance');
@@ -13,10 +24,12 @@ export function DashboardPage() {
     data: transactions,
     isLoading: transactionsLoading,
     error: transactionsError,
-  } = trpc.finance.transactions.list.useQuery({ limit: 10 });
-  const { data: budgets, isLoading: budgetsLoading } = trpc.finance.budgets.list.useQuery({
-    limit: 5,
-  });
+  } = usePillarQuery<TransactionsListResult>('finance', ['transactions', 'list'], { limit: 10 });
+  const { data: budgets, isLoading: budgetsLoading } = usePillarQuery<BudgetsListResult>(
+    'finance',
+    ['budgets', 'list'],
+    { limit: 5 }
+  );
 
   const stats = computeStats(transactions?.data, transactions?.pagination.total);
 

--- a/packages/app-finance/src/pages/TransactionsPage.tsx
+++ b/packages/app-finance/src/pages/TransactionsPage.tsx
@@ -2,10 +2,11 @@ import { Plus } from 'lucide-react';
 import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { trpc } from '@pops/api-client';
 import { useSetPageContext } from '@pops/navigation';
+import { usePillarMutation } from '@pops/pillar-sdk/react';
 import { Alert, Button, DataTable, PageHeader, Skeleton } from '@pops/ui';
 
+import { usePillarCall } from '../lib/pillar-call';
 import { buildColumns, buildTransactionFilters, type Transaction } from './transactions/columns';
 import { DeleteTransactionDialog } from './transactions/DeleteTransactionDialog';
 import { TransactionFormDialog } from './transactions/TransactionFormDialog';
@@ -82,11 +83,20 @@ function useSubtitle(t: TFunction<'finance'>, total: number | undefined) {
   return { description, setFilteredCount };
 }
 
+interface UpdateInput {
+  id: string;
+  data: { tags: string[] };
+}
+interface SuggestTagsResult {
+  tags: string[];
+}
+
 function useTagHandlers() {
-  const utils = trpc.useUtils();
-  const updateMutation = trpc.finance.transactions.update.useMutation({
-    onSuccess: () => void utils.finance.transactions.list.invalidate(),
-  });
+  const pillarCall = usePillarCall();
+  const updateMutation = usePillarMutation<UpdateInput, unknown>('finance', [
+    'transactions',
+    'update',
+  ]);
   const onTagSave = useCallback(
     (transactionId: string, _entityId: string | null, _description: string) =>
       async (tags: string[]) => {
@@ -96,13 +106,15 @@ function useTagHandlers() {
   );
   const onTagSuggest = useCallback(
     (description: string, entityId: string | null) => async () => {
-      const result = await utils.finance.transactions.suggestTags.fetch({
-        description,
-        entityId: entityId ?? null,
-      });
-      return result.tags;
+      const result = await pillarCall<SuggestTagsResult>(
+        'finance',
+        ['transactions', 'suggestTags'],
+        { description, entityId: entityId ?? null }
+      );
+      if (result.kind !== 'ok') return [];
+      return result.value.tags;
     },
-    [utils]
+    [pillarCall]
   );
   return { onTagSave, onTagSuggest };
 }

--- a/packages/app-finance/src/pages/budgets/useBudgetsPage.ts
+++ b/packages/app-finance/src/pages/budgets/useBudgetsPage.ts
@@ -3,9 +3,29 @@ import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 
-import { trpc } from '@pops/api-client';
+import { usePillarMutation, usePillarQuery } from '@pops/pillar-sdk/react';
 
 import { type Budget, BudgetFormSchema, type BudgetFormValues, DEFAULT_FORM_VALUES } from './types';
+
+interface BudgetsListResult {
+  data: Budget[];
+  pagination: { total: number };
+}
+
+interface CreateBudgetInput {
+  category: string;
+  period: string | null;
+  amount: number | null;
+  active: boolean;
+  notes: string | null;
+}
+interface UpdateBudgetInput {
+  id: string;
+  data: CreateBudgetInput;
+}
+interface DeleteBudgetInput {
+  id: string;
+}
 
 interface UseBudgetMutationsArgs {
   setIsDialogOpen: (v: boolean) => void;
@@ -14,32 +34,40 @@ interface UseBudgetMutationsArgs {
 }
 
 function useBudgetMutations(args: UseBudgetMutationsArgs) {
-  const utils = trpc.useUtils();
-  const createMutation = trpc.finance.budgets.create.useMutation({
-    onSuccess: () => {
-      toast.success('Budget created');
-      void utils.finance.budgets.list.invalidate();
-      args.setIsDialogOpen(false);
-    },
-    onError: (err) => toast.error(err.message),
-  });
-  const updateMutation = trpc.finance.budgets.update.useMutation({
-    onSuccess: () => {
-      toast.success('Budget updated');
-      void utils.finance.budgets.list.invalidate();
-      args.setIsDialogOpen(false);
-      args.setEditingBudget(null);
-    },
-    onError: (err) => toast.error(err.message),
-  });
-  const deleteMutation = trpc.finance.budgets.delete.useMutation({
-    onSuccess: () => {
-      toast.success('Budget deleted');
-      void utils.finance.budgets.list.invalidate();
-      args.setDeletingId(null);
-    },
-    onError: (err) => toast.error(err.message),
-  });
+  const createMutation = usePillarMutation<CreateBudgetInput, unknown>(
+    'finance',
+    ['budgets', 'create'],
+    {
+      onSuccess: () => {
+        toast.success('Budget created');
+        args.setIsDialogOpen(false);
+      },
+      onError: (err) => toast.error(err.message),
+    }
+  );
+  const updateMutation = usePillarMutation<UpdateBudgetInput, unknown>(
+    'finance',
+    ['budgets', 'update'],
+    {
+      onSuccess: () => {
+        toast.success('Budget updated');
+        args.setIsDialogOpen(false);
+        args.setEditingBudget(null);
+      },
+      onError: (err) => toast.error(err.message),
+    }
+  );
+  const deleteMutation = usePillarMutation<DeleteBudgetInput, unknown>(
+    'finance',
+    ['budgets', 'delete'],
+    {
+      onSuccess: () => {
+        toast.success('Budget deleted');
+        args.setDeletingId(null);
+      },
+      onError: (err) => toast.error(err.message),
+    }
+  );
   return { createMutation, updateMutation, deleteMutation };
 }
 
@@ -49,7 +77,7 @@ function buildSubmitHandler(
   updateMutation: ReturnType<typeof useBudgetMutations>['updateMutation']
 ) {
   return (values: BudgetFormValues) => {
-    const payload = {
+    const payload: CreateBudgetInput = {
       category: values.category,
       period: values.period || null,
       amount: values.amount ? Number(values.amount) : null,
@@ -66,7 +94,7 @@ export function useBudgetsPage() {
   const [editingBudget, setEditingBudget] = useState<Budget | null>(null);
   const [deletingId, setDeletingId] = useState<string | null>(null);
 
-  const query = trpc.finance.budgets.list.useQuery({ limit: 100 });
+  const query = usePillarQuery<BudgetsListResult>('finance', ['budgets', 'list'], { limit: 100 });
   const { createMutation, updateMutation, deleteMutation } = useBudgetMutations({
     setIsDialogOpen,
     setEditingBudget,

--- a/packages/app-finance/src/pages/transactions/useTransactionMutations.ts
+++ b/packages/app-finance/src/pages/transactions/useTransactionMutations.ts
@@ -1,8 +1,10 @@
 import { toast } from 'sonner';
 
-import { trpc } from '@pops/api-client';
+import { usePillarMutation } from '@pops/pillar-sdk/react';
 
 import { type Transaction } from './types';
+
+import type { TransactionSnapshot } from '@pops/api/modules/finance/transactions/types';
 
 export interface MutationDeps {
   setIsDialogOpen: (v: boolean) => void;
@@ -10,48 +12,87 @@ export interface MutationDeps {
   setDeletingTx: (t: Transaction | null) => void;
 }
 
+interface CreateInput {
+  description: string;
+  account: string;
+  amount: number;
+  date: string;
+  type: string;
+  tags: string[];
+  entityId: string | null;
+  entityName: string | null;
+  notes: string | null;
+}
+interface UpdateInput {
+  id: string;
+  data: Partial<CreateInput>;
+}
+interface DeleteInput {
+  id: string;
+}
+interface MutationResponse {
+  data?: Transaction;
+  message?: string;
+}
+interface DeleteResponse {
+  message: string;
+  snapshot: TransactionSnapshot;
+}
+
+function useCreateUpdateMutations(deps: MutationDeps) {
+  const createMutation = usePillarMutation<CreateInput, MutationResponse>(
+    'finance',
+    ['transactions', 'create'],
+    {
+      onSuccess: () => {
+        toast.success('Transaction created');
+        deps.setIsDialogOpen(false);
+      },
+      onError: (err) => toast.error(err.message),
+    }
+  );
+  const updateMutation = usePillarMutation<UpdateInput, MutationResponse>(
+    'finance',
+    ['transactions', 'update'],
+    {
+      onSuccess: () => {
+        toast.success('Transaction updated');
+        deps.setIsDialogOpen(false);
+        deps.setEditingTransaction(null);
+      },
+      onError: (err) => toast.error(err.message),
+    }
+  );
+  return { createMutation, updateMutation };
+}
+
+function useRestoreDeleteMutations(deps: MutationDeps) {
+  const restoreMutation = usePillarMutation<TransactionSnapshot, MutationResponse>(
+    'finance',
+    ['transactions', 'restore'],
+    {
+      onSuccess: () => {
+        toast.success('Transaction restored');
+      },
+      onError: (err) => toast.error(`Failed to restore transaction: ${err.message}`),
+    }
+  );
+  const deleteMutation = usePillarMutation<DeleteInput, DeleteResponse>(
+    'finance',
+    ['transactions', 'delete'],
+    {
+      onSuccess: () => {
+        deps.setDeletingTx(null);
+      },
+      onError: (err) => toast.error(err.message),
+    }
+  );
+  return { restoreMutation, deleteMutation };
+}
+
 export function useTransactionMutations(deps: MutationDeps) {
-  const utils = trpc.useUtils();
-  const createMutation = trpc.finance.transactions.create.useMutation({
-    onSuccess: () => {
-      toast.success('Transaction created');
-      void utils.finance.transactions.list.invalidate();
-      void utils.finance.transactions.availableTags.invalidate();
-      deps.setIsDialogOpen(false);
-    },
-    onError: (err) => toast.error(err.message),
-  });
-  const updateMutation = trpc.finance.transactions.update.useMutation({
-    onSuccess: () => {
-      toast.success('Transaction updated');
-      void utils.finance.transactions.list.invalidate();
-      void utils.finance.transactions.availableTags.invalidate();
-      deps.setIsDialogOpen(false);
-      deps.setEditingTransaction(null);
-    },
-    onError: (err) => toast.error(err.message),
-  });
-
-  // Restore re-inserts via a dedicated server endpoint that preserves the
-  // original id, checksum, raw_row, and notion_id — fields that the list
-  // shape strips. Routing through `create` would generate a fresh id and
-  // drop dedup metadata, breaking re-import deduplication.
-  const restoreMutation = trpc.finance.transactions.restore.useMutation({
-    onSuccess: () => {
-      toast.success('Transaction restored');
-      void utils.finance.transactions.list.invalidate();
-      void utils.finance.transactions.availableTags.invalidate();
-    },
-    onError: (err) => toast.error(`Failed to restore transaction: ${err.message}`),
-  });
-
-  const deleteMutation = trpc.finance.transactions.delete.useMutation({
-    onSuccess: () => {
-      void utils.finance.transactions.list.invalidate();
-      deps.setDeletingTx(null);
-    },
-    onError: (err) => toast.error(err.message),
-  });
+  const { createMutation, updateMutation } = useCreateUpdateMutations(deps);
+  const { restoreMutation, deleteMutation } = useRestoreDeleteMutations(deps);
 
   /**
    * Confirm a delete: hard-delete on the server, capture the full snapshot

--- a/packages/app-finance/src/pages/transactions/useTransactionsPage.test.ts
+++ b/packages/app-finance/src/pages/transactions/useTransactionsPage.test.ts
@@ -11,58 +11,40 @@ const mockEntitiesListQuery = vi.fn();
 const mockCreateMutate = vi.fn();
 const mockUpdateMutate = vi.fn();
 const mockDeleteMutate = vi.fn();
-const mockInvalidate = vi.fn();
-const mockSuggestTagsFetch = vi.fn();
 const mockRestoreMutate = vi.fn();
+
+vi.mock('@pops/pillar-sdk/react', () => ({
+  usePillarQuery: (_pillarId: string, path: readonly string[], input?: unknown) => {
+    const key = path.join('.');
+    if (key === 'transactions.list') return mockListQuery(input);
+    if (key === 'transactions.availableTags') return mockAvailableTagsQuery(input);
+    return { data: undefined, isLoading: false };
+  },
+  usePillarMutation: (_pillarId: string, path: readonly string[]) => {
+    const key = path.join('.');
+    if (key === 'transactions.create') {
+      return { mutate: (...args: unknown[]) => mockCreateMutate(...args), isPending: false };
+    }
+    if (key === 'transactions.update') {
+      return { mutate: (...args: unknown[]) => mockUpdateMutate(...args), isPending: false };
+    }
+    if (key === 'transactions.delete') {
+      return { mutate: (...args: unknown[]) => mockDeleteMutate(...args), isPending: false };
+    }
+    if (key === 'transactions.restore') {
+      return { mutate: (...args: unknown[]) => mockRestoreMutate(...args), isPending: false };
+    }
+    return { mutate: vi.fn(), isPending: false };
+  },
+}));
 
 vi.mock('@pops/api-client', () => ({
   trpc: {
-    finance: {
-      transactions: {
-        list: { useQuery: (...args: unknown[]) => mockListQuery(...args) },
-        availableTags: {
-          useQuery: (...args: unknown[]) => mockAvailableTagsQuery(...args),
-        },
-        create: {
-          useMutation: () => ({
-            mutate: (...args: unknown[]) => mockCreateMutate(...args),
-            isPending: false,
-          }),
-        },
-        update: {
-          useMutation: () => ({
-            mutate: (...args: unknown[]) => mockUpdateMutate(...args),
-            isPending: false,
-          }),
-        },
-        delete: {
-          useMutation: () => ({
-            mutate: (...args: unknown[]) => mockDeleteMutate(...args),
-            isPending: false,
-          }),
-        },
-        restore: {
-          useMutation: () => ({
-            mutate: (...args: unknown[]) => mockRestoreMutate(...args),
-            isPending: false,
-          }),
-        },
-      },
-    },
     core: {
       entities: {
         list: { useQuery: (...args: unknown[]) => mockEntitiesListQuery(...args) },
       },
     },
-    useUtils: () => ({
-      finance: {
-        transactions: {
-          list: { invalidate: mockInvalidate },
-          availableTags: { invalidate: mockInvalidate },
-          suggestTags: { fetch: (...args: unknown[]) => mockSuggestTagsFetch(...args) },
-        },
-      },
-    }),
   },
 }));
 

--- a/packages/app-finance/src/pages/transactions/useTransactionsPage.ts
+++ b/packages/app-finance/src/pages/transactions/useTransactionsPage.ts
@@ -3,6 +3,7 @@ import { useCallback, useState } from 'react';
 import { useForm } from 'react-hook-form';
 
 import { trpc } from '@pops/api-client';
+import { usePillarQuery } from '@pops/pillar-sdk/react';
 
 import {
   DEFAULT_TRANSACTION_VALUES,
@@ -11,6 +12,13 @@ import {
   TransactionFormSchema,
 } from './types';
 import { useTransactionMutations } from './useTransactionMutations';
+
+import type { Transaction as ApiTransaction } from '@pops/api/modules/finance/transactions/types';
+
+interface TransactionsListResult {
+  data: ApiTransaction[];
+  pagination: { total: number };
+}
 
 /**
  * Build the API payload from the form values.
@@ -102,14 +110,25 @@ function useDialogHandlers(deps: DialogHandlersDeps) {
   return { handleAdd, handleEdit };
 }
 
+function useTransactionsPageQueries() {
+  const query = usePillarQuery<TransactionsListResult>('finance', ['transactions', 'list'], {
+    limit: 100,
+  });
+  const { data: availableTagsData } = usePillarQuery<string[]>(
+    'finance',
+    ['transactions', 'availableTags'],
+    undefined
+  );
+  const entitiesQuery = trpc.core.entities.list.useQuery({ limit: 500 });
+  return { query, availableTagsData, entitiesQuery };
+}
+
 export function useTransactionsPage() {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [editingTransaction, setEditingTransaction] = useState<Transaction | null>(null);
   const [deletingTx, setDeletingTx] = useState<Transaction | null>(null);
 
-  const query = trpc.finance.transactions.list.useQuery({ limit: 100 });
-  const { data: availableTagsData } = trpc.finance.transactions.availableTags.useQuery();
-  const entitiesQuery = trpc.core.entities.list.useQuery({ limit: 500 });
+  const { query, availableTagsData, entitiesQuery } = useTransactionsPageQueries();
 
   const { createMutation, updateMutation, deleteMutation, confirmDelete } = useTransactionMutations(
     {

--- a/packages/app-finance/src/pages/wishlist/useWishlistPage.test.ts
+++ b/packages/app-finance/src/pages/wishlist/useWishlistPage.test.ts
@@ -9,40 +9,25 @@ const mockListQuery = vi.fn();
 const mockCreateMutate = vi.fn();
 const mockUpdateMutate = vi.fn();
 const mockDeleteMutate = vi.fn();
-const mockInvalidate = vi.fn();
 
-vi.mock('@pops/api-client', () => ({
-  trpc: {
-    finance: {
-      wishlist: {
-        list: { useQuery: (...args: unknown[]) => mockListQuery(...args) },
-        create: {
-          useMutation: () => ({
-            mutate: (...args: unknown[]) => mockCreateMutate(...args),
-            isPending: false,
-          }),
-        },
-        update: {
-          useMutation: () => ({
-            mutate: (...args: unknown[]) => mockUpdateMutate(...args),
-            isPending: false,
-          }),
-        },
-        delete: {
-          useMutation: () => ({
-            mutate: (...args: unknown[]) => mockDeleteMutate(...args),
-            isPending: false,
-          }),
-        },
-      },
-    },
-    useUtils: () => ({
-      finance: {
-        wishlist: {
-          list: { invalidate: mockInvalidate },
-        },
-      },
-    }),
+vi.mock('@pops/pillar-sdk/react', () => ({
+  usePillarQuery: (_pillarId: string, path: readonly string[], input?: unknown) => {
+    const key = path.join('.');
+    if (key === 'wishlist.list') return mockListQuery(input);
+    return { data: undefined, isLoading: false };
+  },
+  usePillarMutation: (_pillarId: string, path: readonly string[]) => {
+    const key = path.join('.');
+    if (key === 'wishlist.create') {
+      return { mutate: (...args: unknown[]) => mockCreateMutate(...args), isPending: false };
+    }
+    if (key === 'wishlist.update') {
+      return { mutate: (...args: unknown[]) => mockUpdateMutate(...args), isPending: false };
+    }
+    if (key === 'wishlist.delete') {
+      return { mutate: (...args: unknown[]) => mockDeleteMutate(...args), isPending: false };
+    }
+    return { mutate: vi.fn(), isPending: false };
   },
 }));
 

--- a/packages/app-finance/src/pages/wishlist/useWishlistPage.ts
+++ b/packages/app-finance/src/pages/wishlist/useWishlistPage.ts
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 
-import { trpc } from '@pops/api-client';
+import { usePillarMutation, usePillarQuery } from '@pops/pillar-sdk/react';
 
 import {
   DEFAULT_WISHLIST_VALUES,
@@ -12,6 +12,27 @@ import {
   type WishlistItem,
 } from './types';
 
+interface WishlistListResult {
+  data: WishlistItem[];
+  pagination: { total: number };
+}
+
+interface CreateWishlistInput {
+  item: string;
+  targetAmount: number | null;
+  saved: number | null;
+  priority: WishlistFormValues['priority'];
+  url: string | null;
+  notes: string | null;
+}
+interface UpdateWishlistInput {
+  id: string;
+  data: CreateWishlistInput;
+}
+interface DeleteWishlistInput {
+  id: string;
+}
+
 interface MutationDeps {
   setIsDialogOpen: (v: boolean) => void;
   setEditingItem: (item: WishlistItem | null) => void;
@@ -19,54 +40,51 @@ interface MutationDeps {
 }
 
 function useWishlistMutations(deps: MutationDeps) {
-  const utils = trpc.useUtils();
-  const createMutation = trpc.finance.wishlist.create.useMutation({
-    onSuccess: () => {
-      toast.success('Item added to wishlist');
-      void utils.finance.wishlist.list.invalidate();
-      deps.setIsDialogOpen(false);
-    },
-    onError: (err) => toast.error(err.message),
-  });
-  const updateMutation = trpc.finance.wishlist.update.useMutation({
-    onSuccess: () => {
-      toast.success('Item updated');
-      void utils.finance.wishlist.list.invalidate();
-      deps.setIsDialogOpen(false);
-      deps.setEditingItem(null);
-    },
-    onError: (err) => toast.error(err.message),
-  });
-  const deleteMutation = trpc.finance.wishlist.delete.useMutation({
-    onSuccess: () => {
-      toast.success('Item removed');
-      void utils.finance.wishlist.list.invalidate();
-      deps.setDeletingId(null);
-    },
-    onError: (err) => toast.error(err.message),
-  });
+  const createMutation = usePillarMutation<CreateWishlistInput, unknown>(
+    'finance',
+    ['wishlist', 'create'],
+    {
+      onSuccess: () => {
+        toast.success('Item added to wishlist');
+        deps.setIsDialogOpen(false);
+      },
+      onError: (err) => toast.error(err.message),
+    }
+  );
+  const updateMutation = usePillarMutation<UpdateWishlistInput, unknown>(
+    'finance',
+    ['wishlist', 'update'],
+    {
+      onSuccess: () => {
+        toast.success('Item updated');
+        deps.setIsDialogOpen(false);
+        deps.setEditingItem(null);
+      },
+      onError: (err) => toast.error(err.message),
+    }
+  );
+  const deleteMutation = usePillarMutation<DeleteWishlistInput, unknown>(
+    'finance',
+    ['wishlist', 'delete'],
+    {
+      onSuccess: () => {
+        toast.success('Item removed');
+        deps.setDeletingId(null);
+      },
+      onError: (err) => toast.error(err.message),
+    }
+  );
   return { createMutation, updateMutation, deleteMutation };
 }
 
-export function useWishlistPage() {
-  const [isDialogOpen, setIsDialogOpen] = useState(false);
-  const [editingItem, setEditingItem] = useState<WishlistItem | null>(null);
-  const [deletingId, setDeletingId] = useState<string | null>(null);
+interface DialogHandlersDeps {
+  form: ReturnType<typeof useForm<WishlistFormValues>>;
+  setEditingItem: (item: WishlistItem | null) => void;
+  setIsDialogOpen: (v: boolean) => void;
+}
 
-  const query = trpc.finance.wishlist.list.useQuery({ limit: 100 });
-  const { createMutation, updateMutation, deleteMutation } = useWishlistMutations({
-    setIsDialogOpen,
-    setEditingItem,
-    setDeletingId,
-  });
-
-  const form = useForm<WishlistFormValues>({
-    // Zod 4 implements Standard Schema v1, so we use the generic resolver —
-    // the dedicated `zodResolver` overloads are currently broken under Zod 4.
-    resolver: standardSchemaResolver(WishlistItemSchema),
-    defaultValues: DEFAULT_WISHLIST_VALUES,
-  });
-
+function useDialogHandlers(deps: DialogHandlersDeps) {
+  const { form, setEditingItem, setIsDialogOpen } = deps;
   const handleAdd = () => {
     setEditingItem(null);
     form.reset(DEFAULT_WISHLIST_VALUES);
@@ -84,12 +102,42 @@ export function useWishlistPage() {
     });
     setIsDialogOpen(true);
   };
+  return { handleAdd, handleEdit };
+}
+
+export function useWishlistPage() {
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [editingItem, setEditingItem] = useState<WishlistItem | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  const query = usePillarQuery<WishlistListResult>('finance', ['wishlist', 'list'], { limit: 100 });
+  const { createMutation, updateMutation, deleteMutation } = useWishlistMutations({
+    setIsDialogOpen,
+    setEditingItem,
+    setDeletingId,
+  });
+
+  const form = useForm<WishlistFormValues>({
+    // Zod 4 implements Standard Schema v1, so we use the generic resolver —
+    // the dedicated `zodResolver` overloads are currently broken under Zod 4.
+    resolver: standardSchemaResolver(WishlistItemSchema),
+    defaultValues: DEFAULT_WISHLIST_VALUES,
+  });
+
+  const { handleAdd, handleEdit } = useDialogHandlers({
+    form,
+    setEditingItem,
+    setIsDialogOpen,
+  });
   const onSubmit = (values: WishlistFormValues) => {
     // The server rejects empty strings for `url` (must pass `z.string().url()`).
     // Coerce empty strings to `null` so the strict server contract holds without
     // forcing the form input to use a `null`-valued state.
-    const payload = {
-      ...values,
+    const payload: CreateWishlistInput = {
+      item: values.item,
+      targetAmount: values.targetAmount ?? null,
+      saved: values.saved ?? null,
+      priority: values.priority,
       url: values.url === '' ? null : (values.url ?? null),
       notes: values.notes === '' ? null : (values.notes ?? null),
     };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1135,6 +1135,9 @@ importers:
       '@pops/navigation':
         specifier: workspace:*
         version: link:../navigation
+      '@pops/pillar-sdk':
+        specifier: workspace:*
+        version: link:../pillar-sdk
       '@pops/types':
         specifier: workspace:*
         version: link:../types


### PR DESCRIPTION
## Summary

PRD-227 follow-up to PR #3113 audit: migrates the 12 finance-only files (24 single-pillar `trpc.finance.*` call sites) in `packages/app-finance` to the pillar SDK. Uses the same `usePillarQuery` / `usePillarMutation` / `usePillarCall` pattern as app-inventory batches #3118 / #3121, with failure discriminants (`isUnavailable`, `isContractMismatch`, `isDegraded`) surfaced via the SDK hook return.

## Migrated files

- `pages/DashboardPage.tsx`
- `pages/TransactionsPage.tsx`
- `pages/transactions/useTransactionsPage.ts` (finance-only calls; `core.entities.list` stays on trpc — see deferred)
- `pages/transactions/useTransactionMutations.ts`
- `pages/budgets/useBudgetsPage.ts`
- `pages/wishlist/useWishlistPage.ts`
- `components/imports/final-review/useFinalReview.ts`
- `components/imports/processing/useProcessing.ts`
- `components/imports/hooks/useTransactionReview.ts`
- `components/imports/review/ReviewDialogs.tsx`
- `components/imports/tag-review/useTagReviewState.ts`
- `components/imports/correction-proposal/rule-manager/useRuleManagerHooks.ts`

Adds `packages/app-finance/src/lib/pillar-call.ts` (mirrors the app-inventory helper) for the imperative one-shot pattern (`onTagSuggest`).

## Deferred — cross-pillar (PRD-227 next batch)

Blocked on `@pops/core-sdk` shipping. These call `trpc.core.{corrections,tagRules,entities}.*` and must wait per the audit:

- `pages/entities/useEntitiesPage.ts`
- `pages/rules-browser/useRulesBrowserModel.ts`
- `pages/rules-browser/rule-form/useRuleFormState.ts`
- `pages/rules-browser/rule-form/useRulePreview.ts`
- `pages/transactions/useTransactionsPage.ts` (`core.entities.list` only)
- `components/ConfidenceSlider.tsx`
- `components/imports/RulePicker.tsx`
- `components/imports/hooks/useProposalGeneration.ts`
- `components/imports/hooks/usePreviewEffects.ts`
- `components/imports/hooks/useApplyRejectMutations.ts`
- `components/imports/hooks/bulk-assignment/use-accept.ts`
- `components/imports/tag-rule-dialog/useTagRuleProposal.ts`
- `components/imports/tag-rule-dialog/useTagRuleMutations.ts`
- `components/imports/correction-proposal/rule-manager/useBrowseRules.ts`
- `components/imports/correction-proposal/workflow/useWorkflowHooks.ts`

`@pops/api-client` stays as a dependency for the same reason — it gets dropped in the cross-pillar batch.

## Status

- 24 of 47 audited call sites migrated (single-pillar bucket fully cleared).
- 23 cross-pillar call sites remain, deferred.

## Test plan

- [x] `pnpm --filter @pops/app-finance typecheck` — clean
- [x] `pnpm --filter @pops/app-finance test` — 379/379 pass
- [x] `pnpm typecheck` (root) — 66/66 succeed
- [x] `pnpm lint` — no new errors
- [x] `pnpm lint:boundaries` — no new violations
- [ ] CI green
