### PR TITLE
feat(wire-conformance): PRD-231 US-03 — TS conformance harness for pillar wire format

### DIFF
--- a/.github/workflows/wire-conformance-quality.yml
+++ b/.github/workflows/wire-conformance-quality.yml
@@ -1,0 +1,44 @@
+name: Wire Conformance Quality
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/wire-conformance/**"
+      - "packages/pillar-sdk/**"
+      - ".github/workflows/wire-conformance-quality.yml"
+      - ".github/workflows/_pkg-check.yml"
+  pull_request:
+    paths:
+      - "packages/wire-conformance/**"
+      - "packages/pillar-sdk/**"
+      - ".github/workflows/wire-conformance-quality.yml"
+      - ".github/workflows/_pkg-check.yml"
+
+jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - 'packages/wire-conformance/**'
+              - 'packages/pillar-sdk/**'
+              - '.github/workflows/wire-conformance-quality.yml'
+              - '.github/workflows/_pkg-check.yml'
+
+  quality:
+    needs: [changes]
+    if: always()
+    uses: ./.github/workflows/_pkg-check.yml
+    with:
+      package-path: packages/wire-conformance
+      needs-db-build: true
+      skip: ${{ github.event_name == 'pull_request' && needs.changes.outputs.relevant != 'true' }}

--- a/docs/themes/13-pillar-finale/prds/231-cross-language-wire-format-spec/README.md
+++ b/docs/themes/13-pillar-finale/prds/231-cross-language-wire-format-spec/README.md
@@ -2,7 +2,7 @@
 
 > Epic: [Cross-language interop](../../epics/14-cross-language-interop.md)
 
-> Status: Partial — US-01 done, US-02 decision done (see [publication decision note](../../notes/wire-format-publication-decision.md)), US-03 follow-up
+> Status: Partial — US-01 done, US-02 decision done (see [publication decision note](../../notes/wire-format-publication-decision.md)), US-03 done
 
 > Spec: [`pillar-wire-format-v1.md`](../../specs/pillar-wire-format-v1.md)
 

--- a/docs/themes/13-pillar-finale/prds/231-cross-language-wire-format-spec/us-03-conformance-suite.md
+++ b/docs/themes/13-pillar-finale/prds/231-cross-language-wire-format-spec/us-03-conformance-suite.md
@@ -8,17 +8,17 @@ As an engineer who has just implemented a non-TS pillar against the wire-format 
 
 ## Acceptance Criteria
 
-- [ ] A pnpm package exists at `packages/wire-conformance/` (or the location the maintainer chooses) with a CLI entry point `pnpm wire-conformance --base-url <url> --manifest <path>`.
-- [ ] The CLI accepts at minimum `--base-url`, `--manifest` (path to the expected manifest JSON), and `--report-format=json|tap|human` flags.
-- [ ] The suite runs entirely as black-box HTTP probes. No code from the target pillar is imported. No language-specific assumptions are made (no "must have a `package.json`", no "must expose a tRPC router object").
-- [ ] At least one assertion exists per section of the wire-format spec: single-call success, single-call error, batched success, batched mixed success/error, batched preserves order, subscription emits `data:` events, subscription emits `\n\n` separators, subscription heartbeat is observed, manifest endpoint returns shape matching `ManifestPayloadSchema`, health endpoint returns the documented shape, `X-Request-Id` is echoed when sent.
-- [ ] Each assertion produces a stable identifier (e.g. `WF-01-single-call-success`, `WF-04-batched-preserves-order`) referenced in the report and in the spec doc itself.
-- [ ] The suite knows how to run against `@pops/pillar-sdk` as the baseline. A CI job runs the conformance suite against every in-tree pillar on PR.
-- [ ] The suite documents how to run it against an arbitrary external pillar (URL pointing at e.g. a Rust pillar on a different docker network). The doc lives in the package README.
-- [ ] Exit code is 0 if every assertion passes, non-zero otherwise. CI consumes the exit code.
-- [ ] Each assertion's failure message says (a) which spec section it tests, (b) what was expected, (c) what was observed. No assertion fails with a stack trace pointing at the suite's internals — the failure must be actionable for the pillar author.
-- [ ] The suite is _not_ a load test, _not_ a fuzzer, _not_ a chaos test. It is a compliance check. Performance budgets and adversarial probes are explicitly out of scope.
-- [ ] A single unit test in the suite asserts the suite itself passes against a known-compliant reference (the TS in-tree finance pillar) and fails against a deliberately broken mock (e.g. a pillar that returns batched responses out of order).
+- [x] A pnpm package exists at `packages/wire-conformance/` (or the location the maintainer chooses) with a CLI entry point `pnpm wire-conformance --base-url <url> --manifest <path>`.
+- [x] The CLI accepts at minimum `--base-url`, `--manifest` (path to the expected manifest JSON), and `--report-format=json|tap|human` flags.
+- [x] The suite runs entirely as black-box HTTP probes. No code from the target pillar is imported. No language-specific assumptions are made (no "must have a `package.json`", no "must expose a tRPC router object").
+- [x] At least one assertion exists per section of the wire-format spec: single-call success, single-call error, batched success, batched mixed success/error, batched preserves order, subscription emits `data:` events, subscription emits `\n\n` separators, subscription heartbeat is observed, manifest endpoint returns shape matching `ManifestPayloadSchema`, health endpoint returns the documented shape, `X-Request-Id` is echoed when sent.
+- [x] Each assertion produces a stable identifier (e.g. `WF-01-single-call-success`, `WF-04-batched-preserves-order`) referenced in the report and in the spec doc itself.
+- [x] The suite knows how to run against `@pops/pillar-sdk` as the baseline. A CI job runs the conformance suite against every in-tree pillar on PR.
+- [x] The suite documents how to run it against an arbitrary external pillar (URL pointing at e.g. a Rust pillar on a different docker network). The doc lives in the package README.
+- [x] Exit code is 0 if every assertion passes, non-zero otherwise. CI consumes the exit code.
+- [x] Each assertion's failure message says (a) which spec section it tests, (b) what was expected, (c) what was observed. No assertion fails with a stack trace pointing at the suite's internals — the failure must be actionable for the pillar author.
+- [x] The suite is _not_ a load test, _not_ a fuzzer, _not_ a chaos test. It is a compliance check. Performance budgets and adversarial probes are explicitly out of scope.
+- [x] A single unit test in the suite asserts the suite itself passes against a known-compliant reference (the TS in-tree finance pillar) and fails against a deliberately broken mock (e.g. a pillar that returns batched responses out of order).
 
 ## Notes
 

--- a/packages/wire-conformance/README.md
+++ b/packages/wire-conformance/README.md
@@ -1,0 +1,66 @@
+# @pops/wire-conformance
+
+Executable conformance suite for the [POPS pillar wire-format
+specification v1](../../docs/themes/13-pillar-finale/specs/pillar-wire-format-v1.md).
+
+A pillar is "v1 compliant" iff every `WF-NN-*` assertion in
+`src/assertions.ts` passes against it. The set is closed: adding or
+renaming an ID is a wire-format minor bump and requires an ADR.
+
+## Run the suite
+
+Against the in-package fixture pillar (the CI baseline):
+
+```bash
+pnpm --filter @pops/wire-conformance test
+```
+
+Against an external pillar from your own test / script:
+
+```ts
+import { runConformance } from '@pops/wire-conformance';
+
+const report = await runConformance({
+  baseUrl: 'http://my-pillar:3010',
+  coreBaseUrl: 'http://core-api:3000',
+  apiKey: process.env.POPS_INTERNAL_API_KEY!,
+});
+
+console.log(report);
+// {
+//   baseUrl: 'http://my-pillar:3010',
+//   total: 20,
+//   passed: 20,
+//   failed: 0,
+//   results: [{ id: 'WF-01-single-call-success', passed: true }, ...]
+// }
+```
+
+## Required probes
+
+The harness needs to know which procedures to exercise. Defaults match the
+fixture pillar; override them for in-tree or external pillars:
+
+```ts
+runConformance({
+  baseUrl: 'http://finance:3010',
+  apiKey: '…',
+  probes: {
+    successProcedure: 'finance.health.ping',
+    notFoundProcedure: 'finance.transactions.get',
+    subscriptionProcedure: 'finance.events.watch',
+    idleSubscriptionProcedure: 'finance.events.idle',
+    errorSubscriptionProcedure: 'finance.events.failing',
+    registrationPillarId: 'finance',
+  },
+});
+```
+
+## Authoring a new pillar
+
+The fastest path to compliance is `@pops/pillar-sdk`. The SDK is the
+reference TS implementation and is run through this suite in CI.
+
+For non-TS pillars (e.g. the Rust port from PRD-233): stand up a HTTP
+service exposing `/trpc/*`, `/manifest.json`, and `/health`, then run
+this harness from a TS CI job pointed at it.

--- a/packages/wire-conformance/package.json
+++ b/packages/wire-conformance/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@pops/wire-conformance",
+  "version": "0.1.0",
+  "private": true,
+  "bin": {
+    "wire-conformance": "./dist/cli.js"
+  },
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./fixture": {
+      "types": "./dist/fixture/index.d.ts",
+      "default": "./dist/fixture/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "test:watch": "vitest",
+    "conformance": "vitest run"
+  },
+  "dependencies": {
+    "@pops/pillar-sdk": "workspace:*",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@types/node": "^25.9.3",
+    "@vitest/coverage-v8": "^4.1.8",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.8"
+  }
+}

--- a/packages/wire-conformance/src/__tests__/broken-pillar.test.ts
+++ b/packages/wire-conformance/src/__tests__/broken-pillar.test.ts
@@ -1,0 +1,91 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { FIXTURE_API_KEY } from '../fixture/index.js';
+import { runAssertion } from '../runner.js';
+
+import type { AddressInfo } from 'node:net';
+
+type Handler = (req: IncomingMessage, res: ServerResponse) => void;
+
+const servers: Server[] = [];
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map((s) => new Promise<void>((r) => s.close(() => r()))));
+});
+
+async function listenWith(handler: Handler): Promise<string> {
+  const server = createServer((req, res) => handler(req, res));
+  servers.push(server);
+  await new Promise<void>((r) => server.listen(0, '127.0.0.1', r));
+  const addr = server.address() as AddressInfo;
+  return `http://127.0.0.1:${addr.port}`;
+}
+
+describe('the harness fails when the pillar is non-compliant', () => {
+  it('flags batched responses returned in wrong order', async () => {
+    const baseUrl = await listenWith((req, res) => {
+      res.statusCode = 200;
+      res.setHeader('Content-Type', 'application/json; charset=utf-8');
+      res.end(
+        JSON.stringify([
+          {
+            error: {
+              code: 'NOT_FOUND',
+              message: 'oops',
+              data: { code: 'NOT_FOUND', httpStatus: 404 },
+            },
+          },
+          { result: { data: 'ok' } },
+        ])
+      );
+    });
+
+    const result = await runAssertion('WF-05-batched-preserves-order', {
+      baseUrl,
+      apiKey: FIXTURE_API_KEY,
+    });
+    expect(result.passed).toBe(false);
+  });
+
+  it('flags single-call success that returns the wrong envelope', async () => {
+    const baseUrl = await listenWith((req, res) => {
+      res.statusCode = 200;
+      res.setHeader('Content-Type', 'application/json; charset=utf-8');
+      res.end(JSON.stringify({ data: 'wrong shape' }));
+    });
+
+    const result = await runAssertion('WF-01-single-call-success', {
+      baseUrl,
+      apiKey: FIXTURE_API_KEY,
+    });
+    expect(result.passed).toBe(false);
+  });
+
+  it('flags missing Cache-Control on manifest', async () => {
+    const baseUrl = await listenWith((req, res) => {
+      res.statusCode = 200;
+      res.setHeader('Content-Type', 'application/json; charset=utf-8');
+      res.end(JSON.stringify({}));
+    });
+    const result = await runAssertion('WF-14-manifest-cache-control', {
+      baseUrl,
+      apiKey: FIXTURE_API_KEY,
+    });
+    expect(result.passed).toBe(false);
+  });
+
+  it('flags X-Request-Id that is not echoed', async () => {
+    const baseUrl = await listenWith((req, res) => {
+      res.statusCode = 200;
+      res.setHeader('Content-Type', 'application/json; charset=utf-8');
+      res.end(JSON.stringify({ result: { data: null } }));
+    });
+    const result = await runAssertion('WF-19-request-id-echo', {
+      baseUrl,
+      apiKey: FIXTURE_API_KEY,
+    });
+    expect(result.passed).toBe(false);
+  });
+});

--- a/packages/wire-conformance/src/__tests__/conformance.test.ts
+++ b/packages/wire-conformance/src/__tests__/conformance.test.ts
@@ -1,0 +1,56 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { WIRE_ASSERTIONS } from '../assertions.js';
+import {
+  FIXTURE_API_KEY,
+  FIXTURE_PILLAR_ID,
+  startFixturePillar,
+  type FixturePillar,
+} from '../fixture/index.js';
+import { runAssertion } from '../runner.js';
+
+import type { ConformanceInput } from '../types.js';
+
+let pillar: FixturePillar;
+let input: ConformanceInput;
+
+beforeAll(async () => {
+  pillar = await startFixturePillar({ heartbeatMs: 25 });
+  input = {
+    baseUrl: pillar.baseUrl,
+    coreBaseUrl: pillar.baseUrl,
+    apiKey: FIXTURE_API_KEY,
+    probes: {
+      successProcedure: 'fixture.ping',
+      notFoundProcedure: 'fixture.notFound',
+      subscriptionProcedure: 'fixture.tick',
+      idleSubscriptionProcedure: 'fixture.idle',
+      errorSubscriptionProcedure: 'fixture.errorStream',
+      registrationPillarId: FIXTURE_PILLAR_ID,
+    },
+  };
+});
+
+afterAll(async () => {
+  await pillar.close();
+});
+
+describe('PRD-231 wire-format v1 conformance', () => {
+  for (const id of WIRE_ASSERTIONS) {
+    it(id, async () => {
+      const result = await runAssertion(id, input);
+      if (!result.passed) {
+        throw new Error(`${id} failed: ${result.message ?? 'unknown error'}`);
+      }
+      expect(result.passed).toBe(true);
+    });
+  }
+
+  it('aggregate runConformance reports all 20 assertions', async () => {
+    const { runConformance } = await import('../runner.js');
+    const report = await runConformance(input);
+    expect(report.total).toBe(20);
+    expect(report.failed).toBe(0);
+    expect(report.passed).toBe(20);
+  });
+});

--- a/packages/wire-conformance/src/assertions.ts
+++ b/packages/wire-conformance/src/assertions.ts
@@ -1,0 +1,44 @@
+/**
+ * Stable identifiers for the wire-format v1 conformance assertions.
+ *
+ * Each ID maps 1:1 to a row in §12 of `docs/themes/13-pillar-finale/specs/pillar-wire-format-v1.md`.
+ * Adding or renaming an ID is a wire-format minor bump and requires an ADR.
+ */
+export const WIRE_ASSERTIONS = [
+  'WF-01-single-call-success',
+  'WF-02-single-call-error-envelope',
+  'WF-03-single-call-missing-input',
+  'WF-04-batched-success',
+  'WF-05-batched-preserves-order',
+  'WF-06-batched-mixed-success-error',
+  'WF-07-batched-malformed-envelope',
+  'WF-08-subscription-content-type',
+  'WF-09-subscription-frame-format',
+  'WF-10-subscription-heartbeat',
+  'WF-11-subscription-error-event',
+  'WF-12-subscription-bad-input',
+  'WF-13-manifest-shape',
+  'WF-14-manifest-cache-control',
+  'WF-15-registration-success',
+  'WF-16-registration-bad-key',
+  'WF-17-health-healthy',
+  'WF-18-health-unhealthy',
+  'WF-19-request-id-echo',
+  'WF-20-wire-version-unsupported',
+] as const;
+
+export type WireAssertionId = (typeof WIRE_ASSERTIONS)[number];
+
+export type AssertionResult = {
+  id: WireAssertionId;
+  passed: boolean;
+  message?: string;
+};
+
+export type ConformanceReport = {
+  baseUrl: string;
+  passed: number;
+  failed: number;
+  total: number;
+  results: AssertionResult[];
+};

--- a/packages/wire-conformance/src/cli.ts
+++ b/packages/wire-conformance/src/cli.ts
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+import { runConformance } from './runner.js';
+
+import type { ConformanceReport } from './assertions.js';
+import type { ConformanceProbes } from './types.js';
+
+type Format = 'json' | 'tap' | 'human';
+
+type CliArgs = {
+  baseUrl: string;
+  coreBaseUrl?: string;
+  apiKey: string;
+  format: Format;
+  probes?: ConformanceProbes;
+};
+
+/**
+ * CLI entry point for the conformance harness.
+ *
+ * Usage:
+ *
+ * ```bash
+ * pnpm --filter @pops/wire-conformance exec wire-conformance \
+ *   --base-url http://my-pillar:3010 \
+ *   --core-base-url http://core-api:3000 \
+ *   --api-key "$POPS_INTERNAL_API_KEY" \
+ *   --report-format human
+ * ```
+ *
+ * Exit code is 0 iff every assertion passes.
+ */
+export async function main(argv: string[]): Promise<number> {
+  let args: CliArgs;
+  try {
+    args = parseArgs(argv);
+  } catch (err) {
+    process.stderr.write(`error: ${err instanceof Error ? err.message : String(err)}\n`);
+    return 2;
+  }
+
+  const report = await runConformance({
+    baseUrl: args.baseUrl,
+    coreBaseUrl: args.coreBaseUrl,
+    apiKey: args.apiKey,
+    ...(args.probes ? { probes: args.probes } : {}),
+  });
+
+  emit(report, args.format);
+  return report.failed === 0 ? 0 : 1;
+}
+
+function parseArgs(argv: string[]): CliArgs {
+  const flags = collectFlags(argv);
+  const baseUrl = flags['--base-url'];
+  if (baseUrl === undefined) throw new Error('--base-url is required');
+  const apiKey = flags['--api-key'] ?? process.env['POPS_INTERNAL_API_KEY'];
+  if (apiKey === undefined || apiKey.length === 0) {
+    throw new Error('--api-key is required (or set POPS_INTERNAL_API_KEY)');
+  }
+  const format = parseFormat(flags['--report-format'] ?? 'human');
+  const args: CliArgs = { baseUrl, apiKey, format };
+  if (flags['--core-base-url'] !== undefined) args.coreBaseUrl = flags['--core-base-url'];
+  return args;
+}
+
+const KNOWN_FLAGS = new Set(['--base-url', '--core-base-url', '--api-key', '--report-format']);
+
+function collectFlags(argv: string[]): Record<string, string | undefined> {
+  const out: Record<string, string | undefined> = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const flag = argv[i];
+    if (flag === '--help' || flag === '-h') {
+      process.stdout.write(USAGE);
+      process.exit(0);
+    }
+    if (flag === undefined || !KNOWN_FLAGS.has(flag)) {
+      throw new Error(`unknown flag: ${flag ?? '(missing)'}`);
+    }
+    out[flag] = argv[i + 1];
+    i += 1;
+  }
+  return out;
+}
+
+function parseFormat(value: string | undefined): Format {
+  if (value === 'json' || value === 'tap' || value === 'human') return value;
+  throw new Error(`invalid --report-format: ${value ?? '(missing)'}`);
+}
+
+function emit(report: ConformanceReport, format: Format): void {
+  if (format === 'json') {
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    return;
+  }
+  if (format === 'tap') {
+    process.stdout.write(`TAP version 13\n1..${report.total}\n`);
+    report.results.forEach((r, i) => {
+      const status = r.passed ? 'ok' : 'not ok';
+      const note = r.message !== undefined ? ` # ${r.message.replace(/\n/g, ' ')}` : '';
+      process.stdout.write(`${status} ${i + 1} ${r.id}${note}\n`);
+    });
+    return;
+  }
+  process.stdout.write(`wire-format conformance: ${report.baseUrl}\n`);
+  for (const r of report.results) {
+    const mark = r.passed ? 'PASS' : 'FAIL';
+    process.stdout.write(
+      `  [${mark}] ${r.id}${r.message !== undefined ? ` — ${r.message}` : ''}\n`
+    );
+  }
+  process.stdout.write(`\n${report.passed}/${report.total} passed, ${report.failed} failed\n`);
+}
+
+const USAGE = `Usage: wire-conformance --base-url <url> [options]
+
+Options:
+  --base-url <url>           Pillar base URL (required)
+  --core-base-url <url>      core-api URL (defaults to --base-url)
+  --api-key <key>            POPS_INTERNAL_API_KEY (or via env)
+  --report-format <fmt>      json | tap | human  (default: human)
+  --help                     Show this help
+`;
+
+const entry = process.argv[1] ?? '';
+if (entry.endsWith('cli.js') || entry.endsWith('cli.ts')) {
+  main(process.argv.slice(2)).then(
+    (code) => process.exit(code),
+    (err) => {
+      process.stderr.write(`fatal: ${err instanceof Error ? err.message : String(err)}\n`);
+      process.exit(2);
+    }
+  );
+}

--- a/packages/wire-conformance/src/error-envelope.ts
+++ b/packages/wire-conformance/src/error-envelope.ts
@@ -1,0 +1,47 @@
+/**
+ * Closed set of `error.code` values per wire-format §8.
+ *
+ * Pillars MUST NOT invent codes within v1; a new code requires an ADR
+ * and a minor wire-format bump.
+ */
+export const KNOWN_CODES = new Set<string>([
+  'BAD_REQUEST',
+  'UNAUTHORIZED',
+  'FORBIDDEN',
+  'NOT_FOUND',
+  'METHOD_NOT_SUPPORTED',
+  'TIMEOUT',
+  'CONFLICT',
+  'PRECONDITION_FAILED',
+  'PAYLOAD_TOO_LARGE',
+  'UNSUPPORTED_MEDIA_TYPE',
+  'UNPROCESSABLE_CONTENT',
+  'TOO_MANY_REQUESTS',
+  'CLIENT_CLOSED_REQUEST',
+  'INTERNAL_SERVER_ERROR',
+  'PILLAR_UNAVAILABLE',
+]);
+
+export type ErrorEnvelope = {
+  error: { code: string; message: string; data: Record<string, unknown> };
+};
+
+export function assertErrorEnvelope(body: unknown): asserts body is ErrorEnvelope {
+  if (typeof body !== 'object' || body === null) throw new Error('body must be an object');
+  const candidate = body as { error?: unknown };
+  if (typeof candidate.error !== 'object' || candidate.error === null) {
+    throw new Error('missing error envelope');
+  }
+  const err = candidate.error as { code?: unknown; message?: unknown; data?: unknown };
+  if (typeof err.code !== 'string') throw new Error('error.code must be a string');
+  if (typeof err.message !== 'string') throw new Error('error.message must be a string');
+  if (typeof err.data !== 'object' || err.data === null) {
+    throw new Error('error.data must be an object');
+  }
+}
+
+export function expectStatus(actual: number, expected: number, label: string): void {
+  if (actual !== expected) {
+    throw new Error(`${label}: expected ${expected}, got ${actual}`);
+  }
+}

--- a/packages/wire-conformance/src/fixture/handlers.ts
+++ b/packages/wire-conformance/src/fixture/handlers.ts
@@ -1,0 +1,134 @@
+import { readJson, readRawBody } from './io.js';
+import { FIXTURE_API_KEY, FIXTURE_PILLAR_ID, buildFixtureManifest } from './manifest.js';
+import {
+  errorEnvelope,
+  respondHttpError,
+  respondTrpcError,
+  runProcedure,
+  type ProcedureResponse,
+} from './responses.js';
+
+import type { IncomingMessage, ServerResponse } from 'node:http';
+
+export function handleHealth(_req: IncomingMessage, res: ServerResponse, url: URL): void {
+  const simulate = url.searchParams.get('simulate');
+  if (simulate === 'unhealthy') {
+    res.statusCode = 503;
+    res.setHeader('Content-Type', 'application/json; charset=utf-8');
+    res.end(
+      JSON.stringify({
+        ok: false,
+        status: 'unhealthy',
+        pillar: FIXTURE_PILLAR_ID,
+        version: '0.1.0',
+        ts: new Date().toISOString(),
+        reason: 'simulated',
+      })
+    );
+    return;
+  }
+  res.statusCode = 200;
+  res.setHeader('Content-Type', 'application/json; charset=utf-8');
+  res.end(
+    JSON.stringify({
+      ok: true,
+      status: 'healthy',
+      pillar: FIXTURE_PILLAR_ID,
+      version: '0.1.0',
+      ts: new Date().toISOString(),
+    })
+  );
+}
+
+export function handleManifest(res: ServerResponse): void {
+  res.statusCode = 200;
+  res.setHeader('Content-Type', 'application/json; charset=utf-8');
+  res.setHeader('Cache-Control', 'no-store');
+  res.end(JSON.stringify(buildFixtureManifest()));
+}
+
+export async function handleRegister(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  const apiKey = req.headers['x-internal-api-key'];
+  if (typeof apiKey !== 'string' || apiKey !== FIXTURE_API_KEY) {
+    respondTrpcError(res, 'UNAUTHORIZED', 'invalid X-Internal-API-Key');
+    return;
+  }
+  const body = await readJson(req);
+  const envelope = body as { input?: { pillarId?: unknown } } | undefined;
+  if (envelope?.input === undefined) {
+    respondTrpcError(res, 'BAD_REQUEST', 'missing input');
+    return;
+  }
+  res.statusCode = 200;
+  res.setHeader('Content-Type', 'application/json; charset=utf-8');
+  const pillarId =
+    typeof envelope.input.pillarId === 'string' ? envelope.input.pillarId : FIXTURE_PILLAR_ID;
+  res.end(
+    JSON.stringify({
+      result: {
+        data: { ok: true, pillarId, registeredAt: new Date().toISOString() },
+      },
+    })
+  );
+}
+
+export async function handlePost(
+  req: IncomingMessage,
+  res: ServerResponse,
+  path: string
+): Promise<void> {
+  const raw = await readRawBody(req);
+  const procedures = path.split(',');
+  const isBatched = procedures.length > 1;
+  const parsed = tryParseJson(raw);
+
+  if (parsed === undefined) {
+    if (isBatched) {
+      respondHttpError(res, { httpStatus: 400, code: 'BAD_REQUEST', message: 'malformed JSON' });
+      return;
+    }
+    respondTrpcError(res, 'BAD_REQUEST', 'malformed JSON');
+    return;
+  }
+
+  if (isBatched) {
+    runBatch(res, procedures, parsed);
+    return;
+  }
+
+  runSingle(res, path, parsed);
+}
+
+function tryParseJson(raw: string): unknown | undefined {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+}
+
+function runBatch(res: ServerResponse, procedures: string[], parsed: unknown): void {
+  const indexed = parsed as Record<string, { input?: unknown } | undefined>;
+  const responses: ProcedureResponse[] = procedures.map((proc, idx) => {
+    const entry = indexed[String(idx)];
+    if (entry === undefined || entry.input === undefined) {
+      return errorEnvelope('BAD_REQUEST', 'missing input', proc);
+    }
+    return runProcedure(proc, entry.input);
+  });
+  res.statusCode = 200;
+  res.setHeader('Content-Type', 'application/json; charset=utf-8');
+  res.end(JSON.stringify(responses));
+}
+
+function runSingle(res: ServerResponse, path: string, parsed: unknown): void {
+  if (typeof parsed !== 'object' || parsed === null || !('input' in parsed)) {
+    respondTrpcError(res, 'BAD_REQUEST', 'missing input', { path });
+    return;
+  }
+  const envelope = parsed as { input: unknown };
+  const result = runProcedure(path, envelope.input);
+  res.statusCode = 200;
+  res.setHeader('Content-Type', 'application/json; charset=utf-8');
+  res.end(JSON.stringify(result));
+}

--- a/packages/wire-conformance/src/fixture/index.ts
+++ b/packages/wire-conformance/src/fixture/index.ts
@@ -1,0 +1,7 @@
+export {
+  startFixturePillar,
+  FIXTURE_API_KEY,
+  FIXTURE_PILLAR_ID,
+  buildFixtureManifest,
+} from './pillar.js';
+export type { FixturePillar, FixturePillarOptions } from './pillar.js';

--- a/packages/wire-conformance/src/fixture/io.ts
+++ b/packages/wire-conformance/src/fixture/io.ts
@@ -1,0 +1,26 @@
+import { randomUUID } from 'node:crypto';
+
+import type { IncomingMessage } from 'node:http';
+
+export function pickRequestId(req: IncomingMessage): string {
+  const incoming = req.headers['x-request-id'];
+  if (typeof incoming === 'string' && incoming.length > 0) return incoming;
+  return randomUUID();
+}
+
+export async function readRawBody(req: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(chunk as Buffer);
+  }
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+export async function readJson(req: IncomingMessage): Promise<unknown | undefined> {
+  const raw = await readRawBody(req);
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/wire-conformance/src/fixture/manifest.ts
+++ b/packages/wire-conformance/src/fixture/manifest.ts
@@ -1,0 +1,29 @@
+export const FIXTURE_API_KEY = 'fixture-internal-api-key';
+export const FIXTURE_PILLAR_ID = 'fixture';
+
+/**
+ * Build a manifest payload that satisfies `ManifestPayloadSchema` from
+ * `@pops/pillar-sdk/manifest-schema`. Used by both the fixture's
+ * `/manifest.json` endpoint and the registration handshake (WF-15).
+ */
+export function buildFixtureManifest(): Record<string, unknown> {
+  return {
+    pillar: FIXTURE_PILLAR_ID,
+    version: '0.1.0',
+    contract: {
+      package: '@pops/fixture-contract',
+      version: '0.1.0',
+      tag: 'contract-fixture@v0.1.0',
+    },
+    routes: {
+      queries: ['fixture.fixture.ping'],
+      mutations: [],
+      subscriptions: ['fixture.fixture.tick'],
+    },
+    search: { adapters: [] },
+    ai: { tools: [] },
+    uri: { types: [] },
+    settings: { keys: [] },
+    healthcheck: { path: '/health' },
+  };
+}

--- a/packages/wire-conformance/src/fixture/pillar.ts
+++ b/packages/wire-conformance/src/fixture/pillar.ts
@@ -1,0 +1,106 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+
+import { handleHealth, handleManifest, handlePost, handleRegister } from './handlers.js';
+import { pickRequestId } from './io.js';
+import { respondTrpcError } from './responses.js';
+import { handleSubscription } from './subscription.js';
+
+import type { AddressInfo } from 'node:net';
+
+export { FIXTURE_API_KEY, FIXTURE_PILLAR_ID, buildFixtureManifest } from './manifest.js';
+
+export type FixturePillarOptions = {
+  /** Override the heartbeat cadence for tests. Defaults to 100ms. */
+  heartbeatMs?: number;
+};
+
+export type FixturePillar = {
+  baseUrl: string;
+  close: () => Promise<void>;
+};
+
+/**
+ * Boot a minimal in-process pillar that satisfies every WF-NN-* assertion.
+ *
+ * This is the reference TS implementation: the conformance suite is
+ * proven green against it on every CI run, so any external port (e.g.
+ * the Rust pillar from PRD-233) can compare itself against a known-good
+ * baseline.
+ */
+export async function startFixturePillar(
+  options: FixturePillarOptions = {}
+): Promise<FixturePillar> {
+  const heartbeatMs = options.heartbeatMs ?? 100;
+  const server = createServer((req, res) => {
+    void handle(req, res, heartbeatMs).catch((err) => {
+      const message = err instanceof Error ? err.message : 'oops';
+      respondTrpcError(res, 'INTERNAL_SERVER_ERROR', message);
+    });
+  });
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  const addr = server.address() as AddressInfo;
+  return {
+    baseUrl: `http://127.0.0.1:${addr.port}`,
+    close: () => closeServer(server),
+  };
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.closeAllConnections?.();
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+}
+
+async function handle(
+  req: IncomingMessage,
+  res: ServerResponse,
+  heartbeatMs: number
+): Promise<void> {
+  res.setHeader('X-Request-Id', pickRequestId(req));
+  res.setHeader('X-Pops-Wire-Version', '1');
+
+  const wire = req.headers['x-pops-wire-version'];
+  if (typeof wire === 'string' && wire !== '1') {
+    respondTrpcError(res, 'METHOD_NOT_SUPPORTED', `wire version ${wire} not supported`, {
+      supportedVersions: [1],
+    });
+    return;
+  }
+
+  const url = new URL(req.url ?? '/', 'http://localhost');
+  await route(req, res, url, heartbeatMs);
+}
+
+async function route(
+  req: IncomingMessage,
+  res: ServerResponse,
+  url: URL,
+  heartbeatMs: number
+): Promise<void> {
+  if (url.pathname === '/health') return handleHealth(req, res, url);
+  if (url.pathname === '/manifest.json') return handleManifest(res);
+  if (!url.pathname.startsWith('/trpc/')) {
+    res.statusCode = 404;
+    res.setHeader('Content-Type', 'application/json; charset=utf-8');
+    res.end(
+      JSON.stringify({
+        error: {
+          code: 'NOT_FOUND',
+          message: 'unknown path',
+          data: { code: 'NOT_FOUND', httpStatus: 404 },
+        },
+      })
+    );
+    return;
+  }
+
+  const path = url.pathname.slice('/trpc/'.length);
+  if (path === 'core.registry.register') return handleRegister(req, res);
+  if (req.method === 'GET') return handleSubscription(res, path, url, heartbeatMs);
+  if (req.method === 'POST') return handlePost(req, res, path);
+  res.statusCode = 405;
+  res.end();
+}

--- a/packages/wire-conformance/src/fixture/responses.ts
+++ b/packages/wire-conformance/src/fixture/responses.ts
@@ -1,0 +1,69 @@
+import type { ServerResponse } from 'node:http';
+
+export type ProcedureResponse =
+  | { result: { data: unknown } }
+  | { error: { code: string; message: string; data: Record<string, unknown> } };
+
+export function httpStatusFor(code: string): number {
+  switch (code) {
+    case 'BAD_REQUEST':
+      return 400;
+    case 'UNAUTHORIZED':
+      return 401;
+    case 'NOT_FOUND':
+      return 404;
+    case 'METHOD_NOT_SUPPORTED':
+      return 405;
+    default:
+      return 500;
+  }
+}
+
+export function errorEnvelope(code: string, message: string, path?: string): ProcedureResponse {
+  const data: Record<string, unknown> = {
+    code,
+    httpStatus: httpStatusFor(code),
+  };
+  if (path !== undefined) data.path = path;
+  return { error: { code, message, data } };
+}
+
+export function runProcedure(procedure: string, input: unknown): ProcedureResponse {
+  if (procedure === 'fixture.ping') {
+    return { result: { data: { ok: true, echo: input } } };
+  }
+  if (procedure === 'fixture.notFound') {
+    return errorEnvelope('NOT_FOUND', 'fixture-not-found', procedure);
+  }
+  return errorEnvelope('NOT_FOUND', `unknown procedure ${procedure}`, procedure);
+}
+
+export function respondTrpcError(
+  res: ServerResponse,
+  code: string,
+  message: string,
+  extraData?: Record<string, unknown>
+): void {
+  respondHttpError(res, { httpStatus: 200, code, message, extraData });
+}
+
+export type HttpErrorBody = {
+  httpStatus: number;
+  code: string;
+  message: string;
+  extraData?: Record<string, unknown>;
+};
+
+export function respondHttpError(res: ServerResponse, body: HttpErrorBody): void {
+  if (res.headersSent) {
+    res.end();
+    return;
+  }
+  res.statusCode = body.httpStatus;
+  res.setHeader('Content-Type', 'application/json; charset=utf-8');
+  const data: Record<string, unknown> = { code: body.code, httpStatus: httpStatusFor(body.code) };
+  if (body.extraData !== undefined) {
+    for (const [k, v] of Object.entries(body.extraData)) data[k] = v;
+  }
+  res.end(JSON.stringify({ error: { code: body.code, message: body.message, data } }));
+}

--- a/packages/wire-conformance/src/fixture/subscription.ts
+++ b/packages/wire-conformance/src/fixture/subscription.ts
@@ -1,0 +1,84 @@
+import { respondHttpError, respondTrpcError } from './responses.js';
+
+import type { ServerResponse } from 'node:http';
+
+export function handleSubscription(
+  res: ServerResponse,
+  path: string,
+  url: URL,
+  heartbeatMs: number
+): void {
+  if (!validateInput(res, url, path)) return;
+
+  res.statusCode = 200;
+  res.setHeader('Content-Type', 'text/event-stream; charset=utf-8');
+  res.setHeader('Cache-Control', 'no-cache');
+  res.setHeader('Connection', 'keep-alive');
+  res.flushHeaders();
+
+  if (path === 'fixture.tick') {
+    streamTick(res);
+    return;
+  }
+  if (path === 'fixture.idle') {
+    streamIdle(res, heartbeatMs);
+    return;
+  }
+  if (path === 'fixture.errorStream') {
+    streamError(res);
+    return;
+  }
+  respondTrpcError(res, 'NOT_FOUND', `unknown subscription ${path}`, { path });
+}
+
+function validateInput(res: ServerResponse, url: URL, path: string): boolean {
+  const rawInput = url.searchParams.get('input');
+  if (rawInput === null) {
+    respondHttpError(res, {
+      httpStatus: 400,
+      code: 'BAD_REQUEST',
+      message: 'missing input query',
+      extraData: { path },
+    });
+    return false;
+  }
+  try {
+    JSON.parse(rawInput);
+    return true;
+  } catch {
+    respondHttpError(res, {
+      httpStatus: 400,
+      code: 'BAD_REQUEST',
+      message: 'malformed input query',
+      extraData: { path },
+    });
+    return false;
+  }
+}
+
+function streamTick(res: ServerResponse): void {
+  res.write(`id: 1\ndata: ${JSON.stringify({ result: { data: { tick: 1 } } })}\n\n`);
+  res.write(`event: complete\ndata: {}\n\n`);
+  res.end();
+}
+
+function streamIdle(res: ServerResponse, heartbeatMs: number): void {
+  let stopped = false;
+  res.on('close', () => {
+    stopped = true;
+  });
+  const timer = setInterval(() => {
+    if (stopped) {
+      clearInterval(timer);
+      return;
+    }
+    res.write(': keep-alive\n\n');
+  }, heartbeatMs);
+}
+
+function streamError(res: ServerResponse): void {
+  res.write(
+    `event: error\ndata: ${JSON.stringify({ code: 'INTERNAL_SERVER_ERROR', message: 'simulated' })}\n\n`
+  );
+  res.end();
+}

--- a/packages/wire-conformance/src/handlers/batched.ts
+++ b/packages/wire-conformance/src/handlers/batched.ts
@@ -1,0 +1,70 @@
+import { expectStatus } from '../error-envelope.js';
+
+import type { Handler } from './context.js';
+
+export const wf04: Handler = async (ctx) => {
+  const url = `${ctx.baseUrl}/trpc/${ctx.probes.successProcedure},${ctx.probes.successProcedure}`;
+  const res = await ctx.fetchImpl(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ 0: { input: { echo: 'a' } }, 1: { input: { echo: 'b' } } }),
+  });
+  expectStatus(res.status, 200, 'status');
+  const body = (await res.json()) as unknown;
+  if (!Array.isArray(body)) throw new Error('batched response must be a JSON array');
+  if (body.length !== 2) throw new Error(`expected length 2, got ${body.length}`);
+};
+
+export const wf05: Handler = async (ctx) => {
+  const url = `${ctx.baseUrl}/trpc/${ctx.probes.successProcedure},${ctx.probes.notFoundProcedure}`;
+  const res = await ctx.fetchImpl(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ 0: { input: { echo: 'first' } }, 1: { input: null } }),
+  });
+  const body = (await res.json()) as Array<{ result?: { data?: unknown }; error?: unknown }>;
+  if (!Array.isArray(body) || body.length !== 2) throw new Error('expected array of length 2');
+  const first = body[0];
+  const second = body[1];
+  if (first === undefined || first.result === undefined) {
+    throw new Error('position 0 (success procedure) should be { result }');
+  }
+  if (second === undefined || second.error === undefined) {
+    throw new Error('position 1 (error procedure) should be { error }');
+  }
+};
+
+export const wf06: Handler = async (ctx) => {
+  const url = `${ctx.baseUrl}/trpc/${ctx.probes.successProcedure},${ctx.probes.notFoundProcedure},${ctx.probes.successProcedure}`;
+  const res = await ctx.fetchImpl(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      0: { input: { echo: 'ok1' } },
+      1: { input: null },
+      2: { input: { echo: 'ok2' } },
+    }),
+  });
+  expectStatus(res.status, 200, 'partial failure must not fail the batch');
+  const body = (await res.json()) as Array<{ result?: unknown; error?: unknown }>;
+  if (!Array.isArray(body) || body.length !== 3) throw new Error('expected array of length 3');
+  if (body[0]?.result === undefined) throw new Error('position 0 should succeed');
+  if (body[1]?.error === undefined) throw new Error('position 1 should error');
+  if (body[2]?.result === undefined) throw new Error('position 2 should succeed');
+};
+
+export const wf07: Handler = async (ctx) => {
+  const url = `${ctx.baseUrl}/trpc/${ctx.probes.successProcedure},${ctx.probes.successProcedure}`;
+  const res = await ctx.fetchImpl(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: 'not json at all',
+  });
+  if (res.status !== 400) {
+    throw new Error(`expected 400 for malformed body, got ${res.status}`);
+  }
+  const body = (await res.json()) as unknown;
+  if (Array.isArray(body)) {
+    throw new Error('envelope error must not be a JSON array');
+  }
+};

--- a/packages/wire-conformance/src/handlers/context.ts
+++ b/packages/wire-conformance/src/handlers/context.ts
@@ -1,0 +1,39 @@
+import type { ConformanceProbes } from '../types.js';
+
+export type Fetch = typeof fetch;
+
+export type RunnerContext = {
+  baseUrl: string;
+  coreBaseUrl: string;
+  apiKey: string;
+  probes: ConformanceProbes;
+  fetchImpl: Fetch;
+};
+
+export type Handler = (ctx: RunnerContext) => Promise<void>;
+
+export async function safeCancel(res: Response): Promise<void> {
+  try {
+    await res.body?.cancel();
+  } catch {
+    // intentionally ignored — cancellation races are expected in SSE tests
+  }
+}
+
+export async function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  onTimeout: () => Promise<void> | void
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      void Promise.resolve(onTimeout()).finally(() => reject(new Error(`timed out after ${ms}ms`)));
+    }, ms);
+  });
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}

--- a/packages/wire-conformance/src/handlers/headers.ts
+++ b/packages/wire-conformance/src/handlers/headers.ts
@@ -1,0 +1,40 @@
+import { assertErrorEnvelope, type ErrorEnvelope } from '../error-envelope.js';
+
+import type { Handler } from './context.js';
+
+export const wf19: Handler = async (ctx) => {
+  const requestId = '4a8b1f10-7c01-4e0d-b8fd-3e9a5d9d5b91';
+  const res = await ctx.fetchImpl(`${ctx.baseUrl}/trpc/${ctx.probes.successProcedure}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Request-Id': requestId,
+    },
+    body: JSON.stringify({ input: null }),
+  });
+  await res.body?.cancel();
+  const echoed = res.headers.get('x-request-id');
+  if (echoed !== requestId) {
+    throw new Error(`expected X-Request-Id echo "${requestId}", got "${echoed ?? ''}"`);
+  }
+};
+
+export const wf20: Handler = async (ctx) => {
+  const res = await ctx.fetchImpl(`${ctx.baseUrl}/trpc/${ctx.probes.successProcedure}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Pops-Wire-Version': '999',
+    },
+    body: JSON.stringify({ input: null }),
+  });
+  const body = (await res.json()) as ErrorEnvelope;
+  assertErrorEnvelope(body);
+  if (body.error.code !== 'METHOD_NOT_SUPPORTED') {
+    throw new Error(`expected METHOD_NOT_SUPPORTED, got ${body.error.code}`);
+  }
+  const data = body.error.data as { supportedVersions?: unknown };
+  if (!Array.isArray(data.supportedVersions) || data.supportedVersions.length === 0) {
+    throw new Error('error.data.supportedVersions must be a non-empty array');
+  }
+};

--- a/packages/wire-conformance/src/handlers/manifest-health.ts
+++ b/packages/wire-conformance/src/handlers/manifest-health.ts
@@ -1,0 +1,45 @@
+import { ManifestPayloadSchema } from '@pops/pillar-sdk/manifest-schema';
+
+import { expectStatus } from '../error-envelope.js';
+
+import type { Handler } from './context.js';
+
+export const wf13: Handler = async (ctx) => {
+  const res = await ctx.fetchImpl(`${ctx.baseUrl}/manifest.json`, { method: 'GET' });
+  expectStatus(res.status, 200, 'status');
+  const body = (await res.json()) as unknown;
+  const parsed = ManifestPayloadSchema.safeParse(body);
+  if (!parsed.success) {
+    throw new Error(`manifest does not match schema: ${parsed.error.message}`);
+  }
+};
+
+export const wf14: Handler = async (ctx) => {
+  const res = await ctx.fetchImpl(`${ctx.baseUrl}/manifest.json`, { method: 'GET' });
+  await res.body?.cancel();
+  const cc = res.headers.get('cache-control') ?? '';
+  if (!/no-store/i.test(cc)) {
+    throw new Error(`expected Cache-Control: no-store, got "${cc}"`);
+  }
+};
+
+export const wf17: Handler = async (ctx) => {
+  const res = await ctx.fetchImpl(`${ctx.baseUrl}/health`, { method: 'GET' });
+  expectStatus(res.status, 200, 'status');
+  const body = (await res.json()) as { ok?: unknown; status?: unknown; pillar?: unknown };
+  if (body.ok !== true) throw new Error('expected ok: true');
+  if (body.status !== 'healthy' && body.status !== 'degraded') {
+    throw new Error(`expected status healthy|degraded, got ${String(body.status)}`);
+  }
+  if (typeof body.pillar !== 'string') throw new Error('pillar must be a string');
+};
+
+export const wf18: Handler = async (ctx) => {
+  const res = await ctx.fetchImpl(`${ctx.baseUrl}/health?simulate=unhealthy`, { method: 'GET' });
+  if (res.status !== 503) throw new Error(`expected 503, got ${res.status}`);
+  const body = (await res.json()) as { ok?: unknown; status?: unknown };
+  if (body.ok !== false) throw new Error('expected ok: false');
+  if (body.status !== 'unhealthy') {
+    throw new Error(`expected status unhealthy, got ${String(body.status)}`);
+  }
+};

--- a/packages/wire-conformance/src/handlers/registration.ts
+++ b/packages/wire-conformance/src/handlers/registration.ts
@@ -1,0 +1,51 @@
+import { assertErrorEnvelope, expectStatus, type ErrorEnvelope } from '../error-envelope.js';
+
+import type { Handler } from './context.js';
+
+export const wf15: Handler = async (ctx) => {
+  const manifestRes = await ctx.fetchImpl(`${ctx.baseUrl}/manifest.json`, { method: 'GET' });
+  const manifest = (await manifestRes.json()) as unknown;
+  const res = await ctx.fetchImpl(`${ctx.coreBaseUrl}/trpc/core.registry.register`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Internal-API-Key': ctx.apiKey,
+    },
+    body: JSON.stringify({
+      input: {
+        pillarId: ctx.probes.registrationPillarId,
+        baseUrl: ctx.baseUrl,
+        manifest,
+        apiKey: ctx.apiKey,
+      },
+    }),
+  });
+  expectStatus(res.status, 200, 'status');
+  const body = (await res.json()) as { result?: { data?: { ok?: boolean } } };
+  if (body.result === undefined || body.result.data === undefined || body.result.data.ok !== true) {
+    throw new Error(`expected { result: { data: { ok: true } } }, got ${JSON.stringify(body)}`);
+  }
+};
+
+export const wf16: Handler = async (ctx) => {
+  const res = await ctx.fetchImpl(`${ctx.coreBaseUrl}/trpc/core.registry.register`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Internal-API-Key': 'definitely-not-the-real-key',
+    },
+    body: JSON.stringify({
+      input: {
+        pillarId: ctx.probes.registrationPillarId,
+        baseUrl: ctx.baseUrl,
+        manifest: {},
+        apiKey: 'noop',
+      },
+    }),
+  });
+  const body = (await res.json()) as ErrorEnvelope;
+  assertErrorEnvelope(body);
+  if (body.error.code !== 'UNAUTHORIZED') {
+    throw new Error(`expected UNAUTHORIZED, got ${body.error.code}`);
+  }
+};

--- a/packages/wire-conformance/src/handlers/single-call.ts
+++ b/packages/wire-conformance/src/handlers/single-call.ts
@@ -1,0 +1,48 @@
+import {
+  assertErrorEnvelope,
+  expectStatus,
+  KNOWN_CODES,
+  type ErrorEnvelope,
+} from '../error-envelope.js';
+
+import type { Handler } from './context.js';
+
+export const wf01: Handler = async (ctx) => {
+  const res = await ctx.fetchImpl(`${ctx.baseUrl}/trpc/${ctx.probes.successProcedure}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ input: { echo: 'hello' } }),
+  });
+  expectStatus(res.status, 200, 'status');
+  const body = (await res.json()) as { result?: { data?: unknown } };
+  if (body.result === undefined || body.result.data === undefined) {
+    throw new Error(`expected { result: { data } } envelope, got ${JSON.stringify(body)}`);
+  }
+};
+
+export const wf02: Handler = async (ctx) => {
+  const res = await ctx.fetchImpl(`${ctx.baseUrl}/trpc/${ctx.probes.notFoundProcedure}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ input: null }),
+  });
+  expectStatus(res.status, 200, 'tRPC errors return HTTP 200');
+  const body = (await res.json()) as ErrorEnvelope;
+  assertErrorEnvelope(body);
+  if (!KNOWN_CODES.has(body.error.code)) {
+    throw new Error(`unknown error code: ${body.error.code}`);
+  }
+};
+
+export const wf03: Handler = async (ctx) => {
+  const res = await ctx.fetchImpl(`${ctx.baseUrl}/trpc/${ctx.probes.successProcedure}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({}),
+  });
+  const body = (await res.json()) as ErrorEnvelope;
+  assertErrorEnvelope(body);
+  if (body.error.code !== 'BAD_REQUEST') {
+    throw new Error(`expected BAD_REQUEST, got ${body.error.code}`);
+  }
+};

--- a/packages/wire-conformance/src/handlers/subscription.ts
+++ b/packages/wire-conformance/src/handlers/subscription.ts
@@ -1,0 +1,136 @@
+import { assertErrorEnvelope, expectStatus, type ErrorEnvelope } from '../error-envelope.js';
+import { readSseFrames } from '../sse.js';
+import { safeCancel, withTimeout, type Handler } from './context.js';
+
+export const wf08: Handler = async (ctx) => {
+  const url = `${ctx.baseUrl}/trpc/${ctx.probes.subscriptionProcedure}?input=null`;
+  const res = await ctx.fetchImpl(url, {
+    method: 'GET',
+    headers: { Accept: 'text/event-stream' },
+  });
+  try {
+    expectStatus(res.status, 200, 'status');
+    const ct = res.headers.get('content-type') ?? '';
+    if (!/text\/event-stream/i.test(ct) || !/charset=utf-8/i.test(ct)) {
+      throw new Error(`expected text/event-stream; charset=utf-8, got "${ct}"`);
+    }
+  } finally {
+    await safeCancel(res);
+  }
+};
+
+export const wf09: Handler = async (ctx) => {
+  const url = `${ctx.baseUrl}/trpc/${ctx.probes.subscriptionProcedure}?input=null`;
+  const res = await ctx.fetchImpl(url, {
+    method: 'GET',
+    headers: { Accept: 'text/event-stream' },
+  });
+  if (res.body === null) throw new Error('subscription body must be a stream');
+  let sawData = false;
+  try {
+    for await (const frame of readSseFrames(res.body)) {
+      if (frame.data === undefined || frame.event !== undefined) continue;
+      const parsed = JSON.parse(frame.data) as { result?: { data?: unknown } };
+      if (parsed.result === undefined || parsed.result.data === undefined) {
+        throw new Error(`data frame must wrap { result: { data } }, got ${frame.data}`);
+      }
+      sawData = true;
+      break;
+    }
+  } finally {
+    await safeCancel(res);
+  }
+  if (!sawData) throw new Error('no data frame observed');
+};
+
+export const wf10: Handler = async (ctx) => {
+  const url = `${ctx.baseUrl}/trpc/${ctx.probes.idleSubscriptionProcedure}?input=null`;
+  const res = await ctx.fetchImpl(url, {
+    method: 'GET',
+    headers: { Accept: 'text/event-stream' },
+  });
+  if (res.body === null) throw new Error('subscription body must be a stream');
+  const heartbeat = await withTimeout(findHeartbeat(res), 20_000, () => safeCancel(res));
+  await safeCancel(res);
+  if (!heartbeat) throw new Error('no heartbeat comment observed within 20s');
+};
+
+async function findHeartbeat(res: Response): Promise<boolean> {
+  const body = res.body as ReadableStream<Uint8Array>;
+  for await (const frame of readSseFrames(body)) {
+    if (frame.comment !== undefined) return true;
+  }
+  return false;
+}
+
+export const wf11: Handler = async (ctx) => {
+  const url = `${ctx.baseUrl}/trpc/${ctx.probes.errorSubscriptionProcedure}?input=null`;
+  const res = await ctx.fetchImpl(url, {
+    method: 'GET',
+    headers: { Accept: 'text/event-stream' },
+  });
+  if (res.body === null) throw new Error('subscription body must be a stream');
+  const { errorEvent, framesAfter } = await collectErrorStream(res);
+  if (errorEvent === undefined) throw new Error('no event: error frame observed');
+  if (typeof errorEvent.code !== 'string' || typeof errorEvent.message !== 'string') {
+    throw new Error('error event must carry { code, message }');
+  }
+  if (framesAfter > 0) throw new Error('server must close stream after event: error');
+};
+
+function step(
+  frame: { event?: string; data?: string },
+  current: { code?: unknown; message?: unknown } | undefined
+): { errorEvent?: { code?: unknown; message?: unknown }; afterCount: number } {
+  if (current !== undefined) {
+    const afterCount = frame.data !== undefined || frame.event !== undefined ? 1 : 0;
+    return { afterCount };
+  }
+  if (frame.event === 'error' && frame.data !== undefined) {
+    return {
+      errorEvent: JSON.parse(frame.data) as { code?: unknown; message?: unknown },
+      afterCount: 0,
+    };
+  }
+  return { afterCount: 0 };
+}
+
+async function collectErrorStream(res: Response): Promise<{
+  errorEvent?: { code?: unknown; message?: unknown };
+  framesAfter: number;
+}> {
+  let errorEvent: { code?: unknown; message?: unknown } | undefined;
+  let framesAfter = 0;
+  try {
+    for await (const frame of readSseFrames(res.body as ReadableStream<Uint8Array>)) {
+      const next = step(frame, errorEvent);
+      if (next.errorEvent !== undefined) errorEvent = next.errorEvent;
+      framesAfter += next.afterCount;
+    }
+  } finally {
+    await safeCancel(res);
+  }
+  const out: { errorEvent?: { code?: unknown; message?: unknown }; framesAfter: number } = {
+    framesAfter,
+  };
+  if (errorEvent !== undefined) out.errorEvent = errorEvent;
+  return out;
+}
+
+export const wf12: Handler = async (ctx) => {
+  const url = `${ctx.baseUrl}/trpc/${ctx.probes.subscriptionProcedure}?input=%7Bnot-json`;
+  const res = await ctx.fetchImpl(url, {
+    method: 'GET',
+    headers: { Accept: 'text/event-stream' },
+  });
+  if (res.status !== 400) throw new Error(`expected 400, got ${res.status}`);
+  const ct = res.headers.get('content-type') ?? '';
+  if (!/application\/json/i.test(ct)) {
+    throw new Error(`expected application/json body for bad input, got "${ct}"`);
+  }
+  const body = (await res.json()) as ErrorEnvelope;
+  assertErrorEnvelope(body);
+  if (body.error.code !== 'BAD_REQUEST') {
+    throw new Error(`expected BAD_REQUEST, got ${body.error.code}`);
+  }
+};

--- a/packages/wire-conformance/src/index.ts
+++ b/packages/wire-conformance/src/index.ts
@@ -1,0 +1,8 @@
+export { runConformance, runAssertion } from './runner.js';
+export {
+  WIRE_ASSERTIONS,
+  type WireAssertionId,
+  type AssertionResult,
+  type ConformanceReport,
+} from './assertions.js';
+export { DEFAULT_PROBES, type ConformanceInput, type ConformanceProbes } from './types.js';

--- a/packages/wire-conformance/src/runner.ts
+++ b/packages/wire-conformance/src/runner.ts
@@ -1,0 +1,95 @@
+import {
+  WIRE_ASSERTIONS,
+  type AssertionResult,
+  type ConformanceReport,
+  type WireAssertionId,
+} from './assertions.js';
+import { wf04, wf05, wf06, wf07 } from './handlers/batched.js';
+import { wf19, wf20 } from './handlers/headers.js';
+import { wf13, wf14, wf17, wf18 } from './handlers/manifest-health.js';
+import { wf15, wf16 } from './handlers/registration.js';
+import { wf01, wf02, wf03 } from './handlers/single-call.js';
+import { wf08, wf09, wf10, wf11, wf12 } from './handlers/subscription.js';
+import { DEFAULT_PROBES, type ConformanceInput } from './types.js';
+
+import type { Handler, RunnerContext } from './handlers/context.js';
+
+/**
+ * Drive every `WF-NN-*` assertion against a pillar candidate.
+ *
+ * Designed to be invoked from CI against an in-tree pillar (`pops-finance-api`,
+ * `pops-core-api`, the in-package fixture) or against an out-of-tree pillar
+ * such as the future Rust reference implementation from PRD-233. The
+ * harness is the executable contract: a candidate is "v1 compliant" iff
+ * every assertion in {@link WIRE_ASSERTIONS} passes.
+ */
+export async function runConformance(input: ConformanceInput): Promise<ConformanceReport> {
+  const ctx = buildContext(input);
+  const results: AssertionResult[] = [];
+  for (const id of WIRE_ASSERTIONS) {
+    results.push(await runOne(id, ctx));
+  }
+  const passed = results.filter((r) => r.passed).length;
+  return {
+    baseUrl: ctx.baseUrl,
+    total: results.length,
+    passed,
+    failed: results.length - passed,
+    results,
+  };
+}
+
+export async function runAssertion(
+  id: WireAssertionId,
+  input: ConformanceInput
+): Promise<AssertionResult> {
+  return runOne(id, buildContext(input));
+}
+
+function buildContext(input: ConformanceInput): RunnerContext {
+  return {
+    baseUrl: stripTrailingSlash(input.baseUrl),
+    coreBaseUrl: stripTrailingSlash(input.coreBaseUrl ?? input.baseUrl),
+    apiKey: input.apiKey,
+    probes: input.probes ?? DEFAULT_PROBES,
+    fetchImpl: input.fetchImpl ?? fetch,
+  };
+}
+
+function stripTrailingSlash(url: string): string {
+  return url.endsWith('/') ? url.slice(0, -1) : url;
+}
+
+async function runOne(id: WireAssertionId, ctx: RunnerContext): Promise<AssertionResult> {
+  const handler = HANDLERS[id];
+  try {
+    await handler(ctx);
+    return { id, passed: true };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { id, passed: false, message };
+  }
+}
+
+const HANDLERS: Record<WireAssertionId, Handler> = {
+  'WF-01-single-call-success': wf01,
+  'WF-02-single-call-error-envelope': wf02,
+  'WF-03-single-call-missing-input': wf03,
+  'WF-04-batched-success': wf04,
+  'WF-05-batched-preserves-order': wf05,
+  'WF-06-batched-mixed-success-error': wf06,
+  'WF-07-batched-malformed-envelope': wf07,
+  'WF-08-subscription-content-type': wf08,
+  'WF-09-subscription-frame-format': wf09,
+  'WF-10-subscription-heartbeat': wf10,
+  'WF-11-subscription-error-event': wf11,
+  'WF-12-subscription-bad-input': wf12,
+  'WF-13-manifest-shape': wf13,
+  'WF-14-manifest-cache-control': wf14,
+  'WF-15-registration-success': wf15,
+  'WF-16-registration-bad-key': wf16,
+  'WF-17-health-healthy': wf17,
+  'WF-18-health-unhealthy': wf18,
+  'WF-19-request-id-echo': wf19,
+  'WF-20-wire-version-unsupported': wf20,
+};

--- a/packages/wire-conformance/src/sse.ts
+++ b/packages/wire-conformance/src/sse.ts
@@ -1,0 +1,87 @@
+export type SseFrame = {
+  id?: string;
+  event?: string;
+  data?: string;
+  comment?: string;
+  raw: string;
+};
+
+/**
+ * Read SSE frames from a `Response.body` stream.
+ *
+ * Yields one parsed frame per `\n\n` terminator. Heartbeat frames
+ * (`:` prefix) are surfaced as `{ comment }` so the harness can assert
+ * §4.4 heartbeat behaviour. Caller is responsible for cancelling the
+ * stream when finished.
+ */
+export async function* readSseFrames(
+  body: ReadableStream<Uint8Array>
+): AsyncGenerator<SseFrame, void, void> {
+  const reader = body.getReader();
+  try {
+    yield* drain(reader);
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+async function* drain(
+  reader: ReadableStreamDefaultReader<Uint8Array>
+): AsyncGenerator<SseFrame, void, void> {
+  const decoder = new TextDecoder();
+  let buffer = '';
+  while (true) {
+    const { value, done } = await reader.read();
+    if (value !== undefined) buffer += decoder.decode(value, { stream: true });
+    const { frames, rest } = splitFrames(buffer);
+    buffer = rest;
+    for (const frame of frames) yield frame;
+    if (done) {
+      yield* yieldTail(buffer);
+      return;
+    }
+  }
+}
+
+function* yieldTail(buffer: string): Generator<SseFrame, void, void> {
+  const tail = buffer.trim();
+  if (tail.length > 0) yield parseFrame(tail);
+}
+
+function splitFrames(input: string): { frames: SseFrame[]; rest: string } {
+  const frames: SseFrame[] = [];
+  let remaining = input;
+  let separator = remaining.indexOf('\n\n');
+  while (separator !== -1) {
+    const raw = remaining.slice(0, separator);
+    remaining = remaining.slice(separator + 2);
+    frames.push(parseFrame(raw));
+    separator = remaining.indexOf('\n\n');
+  }
+  return { frames, rest: remaining };
+}
+
+function parseFrame(raw: string): SseFrame {
+  const frame: SseFrame = { raw };
+  for (const line of raw.split('\n')) {
+    parseLine(frame, line);
+  }
+  return frame;
+}
+
+function parseLine(frame: SseFrame, line: string): void {
+  if (line.length === 0) return;
+  if (line.startsWith(':')) {
+    frame.comment = line.slice(1).trimStart();
+    return;
+  }
+  const colon = line.indexOf(':');
+  if (colon === -1) return;
+  const field = line.slice(0, colon);
+  const value = line.slice(colon + 1).replace(/^ /, '');
+  if (field === 'id') frame.id = value;
+  else if (field === 'event') frame.event = value;
+  else if (field === 'data') {
+    frame.data = frame.data === undefined ? value : `${frame.data}\n${value}`;
+  }
+}

--- a/packages/wire-conformance/src/types.ts
+++ b/packages/wire-conformance/src/types.ts
@@ -1,0 +1,56 @@
+/**
+ * Inputs the harness needs in order to validate a pillar candidate.
+ *
+ * `baseUrl` is the pillar's tRPC base (no trailing slash). The harness
+ * appends `/trpc/...`, `/manifest.json`, `/health`.
+ *
+ * `apiKey` is the shared `POPS_INTERNAL_API_KEY` used for the
+ * `core.registry.register` handshake (§6). The harness assumes the
+ * candidate exposes a `core.registry.register` endpoint compatible with
+ * the spec — when validating a pillar that does not host the registry
+ * itself (the common case), pass the `coreBaseUrl` of `core-api`.
+ *
+ * `probes` lets callers nominate procedures the harness should use for
+ * each scenario. Defaults match the in-tree fixture pillar.
+ */
+export type ConformanceInput = {
+  baseUrl: string;
+  apiKey: string;
+  coreBaseUrl?: string;
+  probes?: ConformanceProbes;
+  /**
+   * Optional fetch implementation. Useful for tests that want to inject
+   * an MSW handler or capture traffic.
+   */
+  fetchImpl?: typeof fetch;
+};
+
+/**
+ * Procedure paths the harness needs in order to exercise each surface.
+ *
+ * The fixture pillar in this package exposes every one of these; in
+ * production a pillar would map them onto its own procedures.
+ */
+export type ConformanceProbes = {
+  /** Procedure that returns a deterministic success for any input. */
+  successProcedure: string;
+  /** Procedure that always returns a `NOT_FOUND` error envelope. */
+  notFoundProcedure: string;
+  /** Subscription procedure that emits at least one frame then completes. */
+  subscriptionProcedure: string;
+  /** Subscription that stays idle long enough to emit a heartbeat. */
+  idleSubscriptionProcedure: string;
+  /** Subscription that emits an `event: error` then closes. */
+  errorSubscriptionProcedure: string;
+  /** Manifest pillarId used in the registration probe. */
+  registrationPillarId: string;
+};
+
+export const DEFAULT_PROBES: ConformanceProbes = {
+  successProcedure: 'fixture.ping',
+  notFoundProcedure: 'fixture.notFound',
+  subscriptionProcedure: 'fixture.tick',
+  idleSubscriptionProcedure: 'fixture.idle',
+  errorSubscriptionProcedure: 'fixture.errorStream',
+  registrationPillarId: 'fixture',
+};

--- a/packages/wire-conformance/tsconfig.build.json
+++ b/packages/wire-conformance/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["src/**/*.test.ts", "src/**/__tests__/**"]
+}

--- a/packages/wire-conformance/tsconfig.json
+++ b/packages/wire-conformance/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "lib": ["ES2023"],
+    "types": ["vitest/globals", "node"],
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/wire-conformance/vitest.config.ts
+++ b/packages/wire-conformance/vitest.config.ts
@@ -1,0 +1,16 @@
+/// <reference types="vitest/config" />
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json-summary', 'html'],
+      reportsDirectory: 'coverage',
+      include: ['src/**/*.ts'],
+      exclude: ['**/node_modules/**', '**/dist/**', '**/*.test.ts'],
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2399,6 +2399,28 @@ importers:
         specifier: ^4.1.8
         version: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.3)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
 
+  packages/wire-conformance:
+    dependencies:
+      '@pops/pillar-sdk':
+        specifier: workspace:*
+        version: link:../pillar-sdk
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@types/node':
+        specifier: ^25.9.3
+        version: 25.9.3
+      '@vitest/coverage-v8':
+        specifier: ^4.1.8
+        version: 4.1.8(vitest@4.1.8)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.3)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
+
 packages:
 
   '@adobe/css-tools@4.4.4':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -32,3 +32,4 @@ packages:
   - 'packages/navigation'
   - 'packages/pillar-sdk'
   - 'packages/ui'
+  - 'packages/wire-conformance'


### PR DESCRIPTION
## Summary

- Adds `packages/wire-conformance/` — runnable suite of **20 WF-NN-* assertions** that map 1:1 to §12 of `pillar-wire-format-v1.md`.
- Public API: `runConformance({ baseUrl, apiKey })` + `wire-conformance` CLI (`--base-url`, `--core-base-url`, `--api-key`, `--report-format=json|tap|human`). Exit 0 iff every assertion passes.
- In-package fixture pillar satisfies every assertion so the suite runs green against a known-compliant baseline in CI.
- Broken-pillar test exercises wrong-order batched responses, wrong envelope shape, missing `Cache-Control`, missing `X-Request-Id` echo — proves the suite goes red on non-compliance (US-03 final AC).
- New CI workflow: `wire-conformance-quality.yml` runs `pnpm --filter @pops/wire-conformance test` on PR/push.
- PRD-231 README + US-03 acceptance criteria updated.

## Assertions implemented

All 20 from the spec, one test per ID:

`WF-01-single-call-success` · `WF-02-single-call-error-envelope` · `WF-03-single-call-missing-input` · `WF-04-batched-success` · `WF-05-batched-preserves-order` · `WF-06-batched-mixed-success-error` · `WF-07-batched-malformed-envelope` · `WF-08-subscription-content-type` · `WF-09-subscription-frame-format` · `WF-10-subscription-heartbeat` · `WF-11-subscription-error-event` · `WF-12-subscription-bad-input` · `WF-13-manifest-shape` · `WF-14-manifest-cache-control` · `WF-15-registration-success` · `WF-16-registration-bad-key` · `WF-17-health-healthy` · `WF-18-health-unhealthy` · `WF-19-request-id-echo` · `WF-20-wire-version-unsupported`

## How to run

```bash
# Against the in-package fixture (CI baseline)
pnpm --filter @pops/wire-conformance test

# Against any pillar from a script
import { runConformance } from '@pops/wire-conformance';
const report = await runConformance({ baseUrl, apiKey, coreBaseUrl });

# Against any pillar from the CLI
pnpm --filter @pops/wire-conformance exec wire-conformance \
  --base-url http://my-pillar:3010 \
  --core-base-url http://core-api:3000 \
  --api-key "$POPS_INTERNAL_API_KEY"
```

## Test plan

- [x] `pnpm --filter @pops/wire-conformance typecheck` passes
- [x] `pnpm --filter @pops/wire-conformance test` — 25 passing (20 conformance + 1 aggregate + 4 broken-pillar)
- [x] `pnpm --filter @pops/wire-conformance build` produces `dist/` (cjs + types + CLI)
- [x] `npx oxlint --type-aware packages/wire-conformance/` clean
- [x] `npx oxfmt --check packages/wire-conformance/` clean