### PR TITLE
docs: add root WIRE-FORMAT.md pointer to canonical spec (PRD-231 US-02)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ External APIs
   Media:   Plex (local + Discover) | TMDB | TheTVDB | Radarr | Sonarr
 ```
 
+### Wire Format
+
+Pillar-to-pillar and consumer-to-pillar communication uses a versioned JSON-over-HTTP wire format. See [`WIRE-FORMAT.md`](WIRE-FORMAT.md) for the TL;DR and the canonical spec.
+
 ### Docker Networks
 
 | Network          | Services                       | Purpose                      |

--- a/WIRE-FORMAT.md
+++ b/WIRE-FORMAT.md
@@ -1,0 +1,17 @@
+# POPS Wire Format
+
+POPS uses a typed wire format for pillar-to-pillar and consumer-to-pillar communication. The canonical, normative specification lives in [`docs/themes/13-pillar-finale/specs/pillar-wire-format-v1.md`](docs/themes/13-pillar-finale/specs/pillar-wire-format-v1.md).
+
+**Current version:** v1.0 (Stable) — wire header `X-Pops-Wire-Version: 1`.
+
+## TL;DR
+
+- **Envelope** — JSON-over-HTTP with `{ "result": { "data": <T> } }` on success and `{ "error": { "code", "message", "data" } }` on failure (tRPC v11 taxonomy). Single-call procedures hit `POST /trpc/<router>.<procedure>` with body `{ "input": <T> }`.
+- **Batching** — `httpBatchLink`-shaped: comma-separated procedures in the URL, indexed entries (`{ "0": ..., "1": ... }`) in the body, response is a position-ordered JSON array where each entry independently succeeds or fails.
+- **Subscriptions** — Server-Sent Events at `GET /trpc/<router>.<procedure>?input=<json>`. `data:` events terminated by `\n\n`, heartbeat comments to defeat proxies, `Last-Event-ID` for best-effort resume.
+- **Manifest** — `GET /manifest.json` returns the pillar's `ManifestPayload` (id, contract, search adapters, AI tools, sinks, capabilities). Public within the docker network, `Cache-Control: no-store`.
+- **Registration** — `POST <core>/trpc/core.registry.register` with `X-Internal-API-Key`, full-jitter exponential backoff up to 5 minutes. The manifest sent at registration MUST match what `GET /manifest.json` would return at that moment.
+
+## For external implementations
+
+External implementations should target this spec, not the TS SDK source. If `@pops/pillar-sdk` and the specification disagree, the specification wins and the SDK is the bug. A pillar is "compliant with wire-format v1" only when every assertion in the v1 conformance suite passes against it.

--- a/docs/themes/13-pillar-finale/prds/231-cross-language-wire-format-spec/README.md
+++ b/docs/themes/13-pillar-finale/prds/231-cross-language-wire-format-spec/README.md
@@ -2,7 +2,7 @@
 
 > Epic: [Cross-language interop](../../epics/14-cross-language-interop.md)
 
-> Status: Partial — US-01 done, US-02 decision done (see [publication decision note](../../notes/wire-format-publication-decision.md)), US-03 done
+> Status: Done — US-01 done, US-02 done (decision + root `WIRE-FORMAT.md` pointer shipped; see [publication decision note](../../notes/wire-format-publication-decision.md)), US-03 done
 
 > Spec: [`pillar-wire-format-v1.md`](../../specs/pillar-wire-format-v1.md)
 
@@ -148,7 +148,7 @@ All fields use shapes compatible with the published Zod schemas in `@pops/contra
 | #   | Story                                                   | Summary                                                                                                                                                           | Parallelisable          |
 | --- | ------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- |
 | 01  | [us-01-spec-document](us-01-spec-document.md)           | Author `wire-format-spec.md` covering every section in the Data Model table. Single-page, Rust/Go/Python-readable, normative.                                     | yes — first deliverable |
-| 02  | [us-02-publication-target](us-02-publication-target.md) | Decide and execute the publication location: ship as a deliverable inside `@pops/pillar-sdk`, or as a standalone repo. Trade-offs documented.                     | blocked by us-01        |
+| 02  | [us-02-publication-target](us-02-publication-target.md) | Decide and execute the publication location: ship as a deliverable inside `@pops/pillar-sdk`, or as a standalone repo. Trade-offs documented. **Done** — spec stays in the monorepo; root [`WIRE-FORMAT.md`](../../../../../WIRE-FORMAT.md) pointer added for discoverability. | done                    |
 | 03  | [us-03-conformance-suite](us-03-conformance-suite.md)   | Build the TS-implemented, language-agnostic conformance harness as `packages/wire-conformance` with a CLI entry point and a battery of black-box HTTP assertions. | blocked by us-01        |
 
 ## Out of Scope

--- a/docs/themes/13-pillar-finale/prds/231-cross-language-wire-format-spec/us-02-publication-target.md
+++ b/docs/themes/13-pillar-finale/prds/231-cross-language-wire-format-spec/us-02-publication-target.md
@@ -21,7 +21,7 @@ As a maintainer needing to point external pillar authors at the wire-format spec
 - [ ] The spec is published at the chosen target with stable internal anchor links (`#single-call-procedure`, `#batched-procedure`, etc.) so future docs can deep-link.
 - [ ] ADR-033's `Related` section is updated to link directly to `wire-format-spec.md` at the chosen URL (currently it only references "PRD-231" by number).
 - [ ] The theme README's `## References` and Epic 14's `## Dependencies` are updated to reference the spec at the chosen URL.
-- [ ] If option (a) is chosen: a top-level `WIRE-FORMAT.md` or equivalent visible-from-the-repo-root pointer exists so engineers browsing the GitHub repo find the spec without spelunking through `packages/pillar-sdk/docs/`.
+- [x] If option (a) is chosen: a top-level `WIRE-FORMAT.md` or equivalent visible-from-the-repo-root pointer exists so engineers browsing the GitHub repo find the spec without spelunking through `packages/pillar-sdk/docs/`.
 - [ ] If option (b) is chosen: the standalone repo is initialised with a README pointing at POPS, a license, and the spec doc itself. CI is set up to validate links inside the spec.
 
 ## Notes


### PR DESCRIPTION
## Summary

- Adds a root-level `WIRE-FORMAT.md` pointing at the canonical spec at `docs/themes/13-pillar-finale/specs/pillar-wire-format-v1.md` (5-bullet TL;DR + "target the spec, not the SDK" note).
- Links it from `README.md` so the spec is discoverable from the GitHub front page.
- Marks PRD-231 US-02 as Done in the PRD index and ticks the corresponding acceptance criterion.

Implements the discoverability follow-up from #3127 (option (a) — canonical source stays in the monorepo, with a root pointer for external implementers).

## Test plan

- [ ] `WIRE-FORMAT.md` renders on the GitHub repo home tab.
- [ ] The relative link from `WIRE-FORMAT.md` to the canonical spec resolves.
- [ ] The relative link from `README.md` to `WIRE-FORMAT.md` resolves.
- [ ] PRD-231 README shows US-02 as Done.
