### PR TITLE
feat(pillar-sdk): typed cache-write surface for optimistic updates (PRD-227 risky unblock)

### DIFF
--- a/packages/pillar-sdk/src/react/__tests__/cache-write.test.tsx
+++ b/packages/pillar-sdk/src/react/__tests__/cache-write.test.tsx
@@ -1,0 +1,281 @@
+// @vitest-environment jsdom
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  discoveredPillar,
+  fakeFetch,
+  FakeRegistryTransport,
+  jsonResponse,
+} from '../../client/__tests__/fixtures.js';
+import { __resetSharedPillarClient } from '../../client/factory.js';
+import { usePillarMutation, usePillarQuery, usePillarUtils } from '../hooks.js';
+import { PillarSdkProvider } from '../provider.js';
+import { pillarQueryKey } from '../query-key.js';
+
+import type { ReactNode } from 'react';
+
+import type { PillarClientOptions } from '../../client/factory.js';
+
+type FetchScript = (url: string, body: unknown) => Response | Promise<Response>;
+
+type Harness = {
+  wrapper: (props: { children: ReactNode }) => ReactNode;
+  queryClient: QueryClient;
+  calls: { url: string; body: unknown }[];
+};
+
+function buildHarness(transport: FakeRegistryTransport, script: FetchScript): Harness {
+  const calls: { url: string; body: unknown }[] = [];
+  const fetchImpl = fakeFetch(async (url, init) => {
+    let parsed: unknown = null;
+    if (init?.body && typeof init.body === 'string') {
+      try {
+        parsed = JSON.parse(init.body);
+      } catch {
+        parsed = init.body;
+      }
+    }
+    calls.push({ url, body: parsed });
+    return script(url, parsed);
+  });
+  const options: PillarClientOptions = { transport, fetchImpl };
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  const wrapper = ({ children }: { children: ReactNode }): ReactNode => (
+    <QueryClientProvider client={queryClient}>
+      <PillarSdkProvider options={options}>{children}</PillarSdkProvider>
+    </QueryClientProvider>
+  );
+  return { wrapper, queryClient, calls };
+}
+
+type Item = { id: string; checked: boolean };
+
+describe('usePillarUtils.setData', () => {
+  beforeEach(() => __resetSharedPillarClient());
+  afterEach(() => __resetSharedPillarClient());
+
+  it('writes directly to the slot keyed by pillarQueryKey', async () => {
+    const transport = new FakeRegistryTransport({ pillars: [discoveredPillar()] });
+    const harness = buildHarness(transport, () => jsonResponse({ result: { data: [] } }));
+
+    const { result } = renderHook(() => usePillarUtils('media'), { wrapper: harness.wrapper });
+
+    act(() => {
+      result.current.setData<readonly Item[]>(['watchlist', 'list'], { limit: 10 }, () => [
+        { id: 'wl-1', checked: false },
+      ]);
+    });
+
+    const key = pillarQueryKey('media', ['watchlist', 'list'], { limit: 10 });
+    expect(harness.queryClient.getQueryData(key)).toEqual([{ id: 'wl-1', checked: false }]);
+  });
+
+  it('returns the previous value as the snapshot before applying the updater', async () => {
+    const transport = new FakeRegistryTransport({ pillars: [discoveredPillar()] });
+    const harness = buildHarness(transport, () => jsonResponse({ result: { data: [] } }));
+
+    const { result } = renderHook(() => usePillarUtils('media'), { wrapper: harness.wrapper });
+
+    const key = pillarQueryKey('media', ['watchlist', 'list'], { limit: 10 });
+    harness.queryClient.setQueryData<readonly Item[]>(key, [{ id: 'wl-1', checked: false }]);
+
+    let snapshot: readonly Item[] | undefined;
+    act(() => {
+      snapshot = result.current.setData<readonly Item[]>(
+        ['watchlist', 'list'],
+        { limit: 10 },
+        (prev) => (prev ?? []).map((it) => ({ ...it, checked: true }))
+      );
+    });
+
+    expect(snapshot).toEqual([{ id: 'wl-1', checked: false }]);
+    expect(harness.queryClient.getQueryData(key)).toEqual([{ id: 'wl-1', checked: true }]);
+  });
+});
+
+describe('usePillarUtils.invalidate', () => {
+  beforeEach(() => __resetSharedPillarClient());
+  afterEach(() => __resetSharedPillarClient());
+
+  it('invalidates a specific router prefix', async () => {
+    const transport = new FakeRegistryTransport({ pillars: [discoveredPillar()] });
+    const harness = buildHarness(transport, (url) => {
+      if (url.endsWith('finance.wishlist.list')) {
+        return jsonResponse({ result: { data: [{ id: 'a' }] } });
+      }
+      return jsonResponse({ result: { data: [] } });
+    });
+
+    const { result: queryResult } = renderHook(
+      () =>
+        usePillarQuery<readonly { id: string }[]>('finance', ['wishlist', 'list'], { limit: 10 }),
+      { wrapper: harness.wrapper }
+    );
+    await waitFor(() => expect(queryResult.current.isSuccess).toBe(true));
+    const before = harness.calls.filter((c) => c.url.endsWith('finance.wishlist.list')).length;
+
+    const { result: utilsResult } = renderHook(() => usePillarUtils('finance'), {
+      wrapper: harness.wrapper,
+    });
+    await act(async () => {
+      await utilsResult.current.invalidate(['wishlist']);
+    });
+
+    await waitFor(() => {
+      const after = harness.calls.filter((c) => c.url.endsWith('finance.wishlist.list')).length;
+      expect(after).toBeGreaterThan(before);
+    });
+  });
+
+  it('invalidates the entire pillar when called with no routerPath', async () => {
+    const transport = new FakeRegistryTransport({ pillars: [discoveredPillar()] });
+    const harness = buildHarness(transport, (url) => {
+      if (url.endsWith('finance.wishlist.list')) {
+        return jsonResponse({ result: { data: [{ id: 'a' }] } });
+      }
+      return jsonResponse({ result: { data: [] } });
+    });
+
+    const { result: queryResult } = renderHook(
+      () =>
+        usePillarQuery<readonly { id: string }[]>('finance', ['wishlist', 'list'], { limit: 10 }),
+      { wrapper: harness.wrapper }
+    );
+    await waitFor(() => expect(queryResult.current.isSuccess).toBe(true));
+    const before = harness.calls.filter((c) => c.url.endsWith('finance.wishlist.list')).length;
+
+    const { result: utilsResult } = renderHook(() => usePillarUtils('finance'), {
+      wrapper: harness.wrapper,
+    });
+    await act(async () => {
+      await utilsResult.current.invalidate();
+    });
+
+    await waitFor(() => {
+      const after = harness.calls.filter((c) => c.url.endsWith('finance.wishlist.list')).length;
+      expect(after).toBeGreaterThan(before);
+    });
+  });
+});
+
+describe('usePillarMutation optimistic updates', () => {
+  beforeEach(() => __resetSharedPillarClient());
+  afterEach(() => __resetSharedPillarClient());
+
+  it('updates the cache during onMutate and rolls back from previousData on error', async () => {
+    const transport = new FakeRegistryTransport({ pillars: [discoveredPillar()] });
+    const harness = buildHarness(transport, (url) => {
+      if (url.endsWith('finance.wishlist.toggle')) {
+        return new Response(
+          JSON.stringify({ error: { code: 'INTERNAL_SERVER_ERROR', message: 'boom' } }),
+          { status: 500, headers: { 'content-type': 'application/json' } }
+        );
+      }
+      return jsonResponse({ result: { data: [] } });
+    });
+
+    const key = pillarQueryKey('finance', ['wishlist', 'list'], { limit: 10 });
+    const initial: readonly Item[] = [{ id: 'wl-1', checked: false }];
+    harness.queryClient.setQueryData<readonly Item[]>(key, initial);
+
+    type Ctx = { previous: readonly Item[] | undefined };
+    const { result } = renderHook(
+      () => {
+        const utils = usePillarUtils('finance');
+        const mutation = usePillarMutation<{ id: string }, { ok: true }, Ctx>(
+          'finance',
+          ['wishlist', 'toggle'],
+          {
+            onMutate: (vars) => {
+              const previous = utils.setData<readonly Item[]>(
+                ['wishlist', 'list'],
+                { limit: 10 },
+                (prev) =>
+                  (prev ?? []).map((it) =>
+                    it.id === vars.id ? { ...it, checked: !it.checked } : it
+                  )
+              );
+              return { previous };
+            },
+            onError: (_err, _vars, ctx) => {
+              if (ctx) {
+                utils.setData<readonly Item[]>(
+                  ['wishlist', 'list'],
+                  { limit: 10 },
+                  () => ctx.previous
+                );
+              }
+            },
+          }
+        );
+        return { utils, mutation };
+      },
+      { wrapper: harness.wrapper }
+    );
+
+    const optimisticPromise = act(async () => {
+      try {
+        await result.current.mutation.mutateAsync({ id: 'wl-1' });
+      } catch {
+        // expected — request fails so the rollback fires
+      }
+    });
+
+    await waitFor(() => {
+      const mid = harness.queryClient.getQueryData<readonly Item[]>(key);
+      expect(mid).toEqual([{ id: 'wl-1', checked: true }]);
+    });
+
+    await optimisticPromise;
+
+    await waitFor(() => expect(result.current.mutation.isError).toBe(true));
+    expect(harness.queryClient.getQueryData(key)).toEqual(initial);
+  });
+
+  it('forwards onSettled on both success and failure paths', async () => {
+    const transport = new FakeRegistryTransport({ pillars: [discoveredPillar()] });
+    let mode: 'ok' | 'fail' = 'ok';
+    const harness = buildHarness(transport, () => {
+      if (mode === 'fail') {
+        return new Response(
+          JSON.stringify({ error: { code: 'INTERNAL_SERVER_ERROR', message: 'boom' } }),
+          { status: 500, headers: { 'content-type': 'application/json' } }
+        );
+      }
+      return jsonResponse({ result: { data: { ok: true } } });
+    });
+
+    const settledCalls: Array<{ ok: boolean }> = [];
+    const { result } = renderHook(
+      () =>
+        usePillarMutation<{ id: string }, { ok: true }>('finance', ['wishlist', 'toggle'], {
+          onSettled: (data, error) => {
+            settledCalls.push({ ok: data !== undefined && !error });
+          },
+        }),
+      { wrapper: harness.wrapper }
+    );
+
+    await act(async () => {
+      await result.current.mutateAsync({ id: 'a' });
+    });
+
+    mode = 'fail';
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({ id: 'b' });
+      } catch {
+        // expected
+      }
+    });
+
+    expect(settledCalls).toEqual([{ ok: true }, { ok: false }]);
+  });
+});

--- a/packages/pillar-sdk/src/react/hooks.ts
+++ b/packages/pillar-sdk/src/react/hooks.ts
@@ -103,15 +103,16 @@ export function usePillarQuery<TOutput>(
   return { ...query, ...flags } as UsePillarQueryResult<TOutput>;
 }
 
-export type UsePillarMutationOptions<TInput, TOutput> = Omit<
-  UseMutationOptions<TOutput, PillarCallError, TInput>,
+export type UsePillarMutationOptions<TInput, TOutput, TContext = unknown> = Omit<
+  UseMutationOptions<TOutput, PillarCallError, TInput, TContext>,
   'mutationFn'
 >;
 
-export type UsePillarMutationResult<TInput, TOutput> = UseMutationResult<
+export type UsePillarMutationResult<TInput, TOutput, TContext = unknown> = UseMutationResult<
   TOutput,
   PillarCallError,
-  TInput
+  TInput,
+  TContext
 > &
   FailureFlags;
 
@@ -123,22 +124,29 @@ export type UsePillarMutationResult<TInput, TOutput> = UseMutationResult<
  * invalidates `wishlist.list`, `wishlist.get`, etc. Top-level procedures
  * (single-segment paths) invalidate the entire `[pillarId]` prefix.
  *
- * Pass `options.onSuccess` to layer additional behaviour; the built-in
- * invalidation runs first. The hook does not maintain its own cache —
- * only the mutation lifecycle (pending / error) plus the failure-flag
- * mapping.
+ * Optimistic updates: pass `onMutate` to snapshot + apply optimistic
+ * cache writes (typically through {@link usePillarUtils}) and return a
+ * `previousData` blob. `onError` then receives that blob as its third
+ * argument so callers can roll back. `onSettled` fires on both success
+ * and failure paths. All four lifecycle callbacks (`onMutate`,
+ * `onSuccess`, `onError`, `onSettled`) are forwarded verbatim to React
+ * Query; the SDK only layers the prefix-invalidation onto `onSuccess`.
+ *
+ * The third generic, `TContext`, types the value returned from
+ * `onMutate` (i.e. the rollback blob) so the call site doesn't have to
+ * cast inside `onError`.
  */
-export function usePillarMutation<TInput = unknown, TOutput = unknown>(
+export function usePillarMutation<TInput = unknown, TOutput = unknown, TContext = unknown>(
   pillarId: string,
   path: ProcedurePath,
-  options: UsePillarMutationOptions<TInput, TOutput> = {}
-): UsePillarMutationResult<TInput, TOutput> {
+  options: UsePillarMutationOptions<TInput, TOutput, TContext> = {}
+): UsePillarMutationResult<TInput, TOutput, TContext> {
   const sdkOptions = usePillarSdkOptions();
   const queryClient = useQueryClient();
   const { onSuccess, ...rest } = options;
 
   const handleSuccess = useCallback<
-    NonNullable<UseMutationOptions<TOutput, PillarCallError, TInput>['onSuccess']>
+    NonNullable<UseMutationOptions<TOutput, PillarCallError, TInput, TContext>['onSuccess']>
   >(
     (data, variables, onMutateResult, context) => {
       const routerPrefix = path.length > 1 ? [pillarId, ...path.slice(0, -1)] : [pillarId];
@@ -148,7 +156,7 @@ export function usePillarMutation<TInput = unknown, TOutput = unknown>(
     [queryClient, pillarId, path, onSuccess]
   );
 
-  const mutation = useMutation<TOutput, PillarCallError, TInput>({
+  const mutation = useMutation<TOutput, PillarCallError, TInput, TContext>({
     mutationFn: async (input: TInput) => {
       const result = await callProcedure<TOutput>(pillarId, path, input, sdkOptions);
       if (result.kind === 'ok') return result.value;
@@ -163,7 +171,93 @@ export function usePillarMutation<TInput = unknown, TOutput = unknown>(
       ? failureFlagsFrom(mutation.error.result)
       : NO_FAILURE;
 
-  return { ...mutation, ...flags } as UsePillarMutationResult<TInput, TOutput>;
+  return { ...mutation, ...flags } as UsePillarMutationResult<TInput, TOutput, TContext>;
+}
+
+export type PillarUpdater<TData> = (previous: TData | undefined) => TData | undefined;
+
+export type UsePillarUtilsResult = {
+  /**
+   * Imperatively write to the cache slot keyed by
+   * `pillarQueryKey(pillarId, routerPath, input)`. `updater` receives the
+   * current value (or `undefined` if the slot is empty) and returns the
+   * next value. Returning `undefined` removes the slot.
+   *
+   * Returns the snapshot of the previous value, suitable to stash in the
+   * `onMutate` context for rollback.
+   */
+  setData: <TData>(
+    routerPath: ProcedurePath,
+    input: unknown,
+    updater: PillarUpdater<TData>
+  ) => TData | undefined;
+  /**
+   * Invalidate cached queries under this pillar. With no argument,
+   * invalidates everything under `[pillarId]`. With `routerPath`,
+   * invalidates everything under `[pillarId, ...routerPath]` — pass the
+   * router prefix (e.g. `['wishlist']`) or the full procedure path
+   * (e.g. `['wishlist', 'list']`).
+   *
+   * Returns the underlying React Query promise so callers can `await`
+   * the invalidation if they want refetches to settle before continuing.
+   */
+  invalidate: (routerPath?: readonly string[]) => Promise<void>;
+};
+
+/**
+ * Cache-write surface for a given pillar. Use alongside
+ * {@link usePillarQuery} / {@link usePillarMutation} to drive optimistic
+ * updates without hand-rolling query keys at the call site.
+ *
+ * Typical optimistic-update flow:
+ * ```ts
+ * const utils = usePillarUtils('media');
+ * usePillarMutation<Input, Output, { previous: Item[] | undefined }>(
+ *   'media',
+ *   ['watchlist', 'toggle'],
+ *   {
+ *     onMutate: (vars) => {
+ *       const previous = utils.setData<Item[]>(
+ *         ['watchlist', 'list'],
+ *         { limit: 10 },
+ *         (prev) => applyToggle(prev, vars)
+ *       );
+ *       return { previous };
+ *     },
+ *     onError: (_err, _vars, ctx) => {
+ *       utils.setData(['watchlist', 'list'], { limit: 10 }, () => ctx?.previous);
+ *     },
+ *   }
+ * );
+ * ```
+ */
+export function usePillarUtils(pillarId: string): UsePillarUtilsResult {
+  const queryClient = useQueryClient();
+
+  const setData = useCallback(
+    <TData>(
+      routerPath: ProcedurePath,
+      input: unknown,
+      updater: PillarUpdater<TData>
+    ): TData | undefined => {
+      const key = pillarQueryKey(pillarId, routerPath, input);
+      const previous = queryClient.getQueryData<TData>(key);
+      const next = updater(previous);
+      queryClient.setQueryData<TData>(key, next);
+      return previous;
+    },
+    [queryClient, pillarId]
+  );
+
+  const invalidate = useCallback(
+    async (routerPath?: readonly string[]): Promise<void> => {
+      const queryKey = routerPath && routerPath.length > 0 ? [pillarId, ...routerPath] : [pillarId];
+      await queryClient.invalidateQueries({ queryKey });
+    },
+    [queryClient, pillarId]
+  );
+
+  return { setData, invalidate };
 }
 
 export type UsePillarCallDynamicQueryOptions = UsePillarQueryOptions<unknown>;

--- a/packages/pillar-sdk/src/react/index.ts
+++ b/packages/pillar-sdk/src/react/index.ts
@@ -5,8 +5,10 @@ export {
   usePillarCallDynamicMutation,
   usePillarMutation,
   usePillarQuery,
+  usePillarUtils,
 } from './hooks.js';
 export type {
+  PillarUpdater,
   UsePillarCallDynamicMutationArgs,
   UsePillarCallDynamicMutationOptions,
   UsePillarCallDynamicMutationResult,
@@ -17,6 +19,7 @@ export type {
   UsePillarMutationResult,
   UsePillarQueryOptions,
   UsePillarQueryResult,
+  UsePillarUtilsResult,
 } from './hooks.js';
 export { pillarQueryKey } from './query-key.js';
 export { usePillarSubscriptionBridge, applySubscriptionEvent } from './subscription-bridge.js';


### PR DESCRIPTION
## Summary

- Adds `usePillarUtils(pillarId)` — `setData` / `invalidate` helpers operating on `pillarQueryKey`-keyed cache slots.
- Threads a third `TContext` generic through `usePillarMutation` so `onMutate` can return a typed rollback blob that `onError` receives without casts. The `onMutate` / `onError` / `onSettled` callbacks were already forwarded to React Query; the type now reflects that contract.
- 6 new tests in `cache-write.test.tsx` covering direct `setData`, snapshot return, `invalidate` with and without a router path, the full optimistic-update + rollback flow when the request fails, and the `onSettled` success+failure paths.

## Why

Unblocks the three risky `app-media` PRD-227 sites that need the equivalent of `utils.media.*.setData()` from tRPC:

- `useWatchlistToggleModel`
- `useTvShowDetailModel`
- `useBatchSeasonLog`

Migration of those sites is a follow-up PR — this PR ships the SDK affordance only.

## API added

```ts
// new hook
export function usePillarUtils(pillarId: string): {
  setData: <TData>(
    routerPath: ProcedurePath,
    input: unknown,
    updater: (previous: TData | undefined) => TData | undefined
  ) => TData | undefined; // returns previous value for rollback
  invalidate: (routerPath?: readonly string[]) => Promise<void>;
};

// usePillarMutation gains TContext
usePillarMutation<TInput, TOutput, TContext>(pillarId, path, { onMutate, onError, onSettled, ... })
```

## Test plan

- [x] `pnpm --filter @pops/pillar-sdk test` — 438 pass (was 432, +6 new)
- [x] `pnpm typecheck` — green
- [x] `pnpm lint` — green