### PR TITLE
feat(workspaces): finish PRD-218 US-02 batch 3 — type-level + settings consumers

### DIFF
--- a/apps/pops-api/src/router.ts
+++ b/apps/pops-api/src/router.ts
@@ -26,13 +26,13 @@ import { listsRouter } from './modules/lists/index.js';
 import { mediaRouter } from './modules/media/index.js';
 import { router } from './trpc.js';
 
-import type { MODULES } from '@pops/module-registry';
+import type { InstalledModule } from '@pops/module-registry';
 
 /**
  * The full mapping of module id → tRPC router for every module the API
  * binary knows how to mount. Keys must match the corresponding manifest
  * `id`. `core` is included so the same lookup table powers the composition
- * step below; it's always mounted regardless of `MODULES`.
+ * step below; it's always mounted regardless of `InstalledModule`.
  *
  * Per-property types are preserved (not widened to a common Router base)
  * so the literal shape we project to `appRouter` carries the exact nested
@@ -59,7 +59,7 @@ type KnownRouterId = keyof KnownRouters;
  * this collapses to `'core' | 'finance'` and the `AppRouter` type below
  * narrows automatically.
  */
-type InstalledRouterId = ('core' | (typeof MODULES)[number]['id']) & KnownRouterId;
+type InstalledRouterId = ('core' | InstalledModule['id']) & KnownRouterId;
 
 /**
  * The precise install set the root router exposes. `Pick` narrows the

--- a/packages/module-registry/src/index.test.ts
+++ b/packages/module-registry/src/index.test.ts
@@ -4,6 +4,11 @@ import { findModule, isModuleId, KNOWN_MODULES, MODULES } from './index.js';
 
 import type { SettingsManifest } from '@pops/types';
 
+import type { InstalledModule, RegisteredModule } from './index.js';
+
+type AssertEqual<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+
 describe('@pops/module-registry exports', () => {
   it('MODULES is non-empty after the registry build', () => {
     // Sanity check: the registry build is the prerequisite for any consumer
@@ -97,6 +102,16 @@ describe('findModule', () => {
 
   it('returns undefined for an unknown id (string overload)', () => {
     expect(findModule('nope')).toBeUndefined();
+  });
+});
+
+describe('InstalledModule type alias', () => {
+  it('mirrors RegisteredModule structurally (PRD-218 US-02)', () => {
+    // Type-level assertion: `InstalledModule` is the semantic alias paired
+    // with the runtime `INSTALLED_MODULES` shim. Both must resolve to the
+    // same build-time entry shape so consumers can swap freely.
+    const ok: AssertEqual<InstalledModule, RegisteredModule> = true;
+    expect(ok).toBe(true);
   });
 });
 

--- a/packages/module-registry/src/index.ts
+++ b/packages/module-registry/src/index.ts
@@ -35,6 +35,22 @@ export type ModuleId = (typeof MODULES)[number]['id'];
 export type RegisteredModule = (typeof MODULES)[number];
 
 /**
+ * Type-level pair for the runtime `INSTALLED_MODULES` shim (PRD-218 US-02).
+ *
+ * Structurally identical to `RegisteredModule`, but named to match the
+ * `INSTALLED_MODULES` runtime export so consumers that need the build-time
+ * install-set shape at the type level can read `InstalledModule` instead of
+ * re-deriving `(typeof MODULES)[number]` at every call site.
+ *
+ * Runtime `POPS_APPS` / `POPS_OVERLAYS` narrowing cannot reflect into the
+ * type system without per-deploy codegen, so this alias still resolves to
+ * the build-time superset (same as `RegisteredModule`). It exists to give
+ * downstream code (e.g. `apps/pops-api/src/router.ts`) a stable, semantic
+ * name aligned with the install-set vocabulary.
+ */
+export type InstalledModule = (typeof MODULES)[number];
+
+/**
  * Find an installed module by id. Returns `undefined` when the id is not in
  * the install set — call sites are expected to handle "module absent" as a
  * first-class state (placeholder UI, NOT_FOUND, etc.) rather than throwing.


### PR DESCRIPTION
## Summary

Closes out PRD-218 US-02 (runtime install-set shim migration) by adding the type-level pair for the runtime `INSTALLED_MODULES` shim and swapping the last type-only `MODULES` consumer onto it. Batch 2 (#3126) covered the 11 runtime consumers; this batch covers the type-level holdout.

## Changes

### `packages/module-registry`
- `src/index.ts`: new `InstalledModule` type alias — structurally identical to `RegisteredModule` (the build-time superset cannot reflect runtime `POPS_APPS` / `POPS_OVERLAYS` narrowing without per-deploy codegen), but named to match the `INSTALLED_MODULES` runtime export so consumers stop re-deriving `(typeof MODULES)[number]` at every call site.
- `src/index.test.ts`: type-level assertion that `InstalledModule` matches `RegisteredModule` structurally, guarding the alias against drift.

### `apps/pops-api`
- `src/router.ts`: swap `import type { MODULES }` for `import type { InstalledModule }`. `InstalledRouterId` now reads `('core' | InstalledModule['id']) & KnownRouterId` and the docblock aligns with the install-set vocabulary.

## Settings-subpath consumers (out of scope)

The 6 `@pops/module-registry/settings` imports (`apps/pops-api/src/modules/{core,inventory,finance,cerebrum,cerebrum/ego,media}/index.ts`) are left in place. They load per-pillar `SettingsManifest` exports, which is a distinct concern from the install-set shim — purely a settings/manifest loading pattern. Consolidating the settings surface (probably onto `@pops/pillar-sdk` or a dedicated `@pops/settings` package) belongs to a separate PRD; tracked as follow-up.

## Dependency cleanup

`@pops/module-registry` remains a dependency of both `@pops/api` and `@pops/shell`:
- `@pops/api`: still consumes the install-set shim (`INSTALLED_MODULES`, `isInstalledModule`, `MODULES`, `InstalledModule`) **and** the settings subpath.
- `@pops/shell`: still consumes `INSTALLED_MODULES` / `MODULES`.

No `package.json` deps can be dropped in this batch.

## PRD-218 US-02 closeout

- Batch 1 (#3116): runtime shim landed.
- Batch 2 (#3126): 11 runtime consumers migrated.
- Batch 3 (this PR): type-level consumer migrated, settings-subpath consumers triaged as separate scope.

## Test plan

- [x] `pnpm typecheck` — passes (66 tasks).
- [x] `pnpm --filter @pops/module-registry test` — 77/77 pass; new type-equality assertion green.
- [x] `pnpm --filter @pops/api test -- --run src/router` — 4876/4876 pass.
- [x] `pnpm lint` — no new errors (only pre-existing warnings).
- [x] `pnpm build` — full monorepo build clean.
- [x] Husky pre-commit (lint-staged + typecheck) passed without `--no-verify`.