### PR TITLE
feat(shell): register as UI pillar at boot (ADR-035 + PRD-228 first non-internal pillar)

### DIFF
--- a/apps/pops-shell/README.md
+++ b/apps/pops-shell/README.md
@@ -1,0 +1,85 @@
+# pops-shell
+
+Vite/React web UI for pops.
+
+## UI-pillar registration (ADR-035 + PRD-228)
+
+ADR-035 carves pillars into three variants — `data`, `UI`, and `bridge`.
+The shell is the first **UI pillar**: it owns no data, exposes no
+procedures, and ships an empty manifest (no `routes.queries`, no
+`search.adapters`, no `ai.tools`, no `uri.types`, no `settings.keys`,
+no `sinks`). It still announces itself to `pops-core-api`'s pillar
+registry so the federation has a single, dynamic list of every running
+surface — UI included.
+
+PRD-228 US-01 ships the `POST /core.registry.register` endpoint. The
+shell calls it via a Node CLI rather than the browser bundle because:
+
+- the shared `POPS_INTERNAL_API_KEY` (ADR-027 docker-network trust
+  boundary) must not reach the client bundle;
+- the production image is `nginx:alpine` and has no Node at request
+  time, so registration happens at deploy time, not request time.
+
+### Wire shape
+
+```jsonc
+POST /core.registry.register
+{
+  "pillarId": "shell",
+  "baseUrl":  "https://pops.local",
+  "manifest": {
+    "pillar":      "shell",
+    "version":     "0.1.0",
+    "contract":    { "package": "@pops/shell-contract", "version": "0.1.0", "tag": "contract-shell@v0.1.0" },
+    "routes":      { "queries": [], "mutations": [], "subscriptions": [] },
+    "search":      { "adapters": [] },
+    "ai":          { "tools": [] },
+    "uri":         { "types": [] },
+    "settings":    { "keys": [] },
+    "healthcheck": { "path": "/health" }
+  },
+  "apiKey": "<POPS_INTERNAL_API_KEY>"
+}
+```
+
+### Invoking the CLI
+
+```bash
+POPS_REGISTRY_URL=http://core-api:3001 \
+SHELL_BASE_URL=https://pops.local \
+POPS_INTERNAL_API_KEY=… \
+  tsx apps/pops-shell/scripts/register-with-registry.ts
+```
+
+Behaviour:
+
+- **All env vars present** → `POST` to the registry, prints
+  `{ kind: 'registered', pillarId, registeredAt }` on success.
+- **Any env var missing** → silent skip (same `INVENTORY_BASE_URL`
+  discipline as the data pillars). The script prints
+  `{ kind: 'skipped', reason: 'missing-env', missing: [...] }` and
+  exits 0 so a partially-configured deploy still boots.
+- **Registry unreachable** → logs a warning, prints
+  `{ kind: 'unreachable', error }`, and exits 0. Registration is
+  best-effort — a UI pillar that fails to announce itself is degraded,
+  not broken.
+- **Registry returns non-2xx** → prints `{ kind: 'failed', status, body }`
+  with the structured error payload (e.g. `{ ok: false, reason:
+'invalid-api-key' }`).
+
+### Reusing this pattern for iOS / kiosk / future UI surfaces
+
+Each new UI surface that needs to appear in the federated registry
+copies this directory's three pieces:
+
+1. `src/lib/register-with-registry.ts` — the pure registration function
+   with deps-injected transport + logger.
+2. `scripts/register-with-registry.ts` — the thin Node entrypoint that
+   reads env and calls the lib.
+3. This README section.
+
+…then swaps the `SHELL_PILLAR_ID` / `SHELL_BASE_URL` env var prefix
+(`IOS_BASE_URL`, `KIOSK_BASE_URL`, …) and points at the same
+`/core.registry.register` endpoint. The manifest stays empty: the
+contract sentinel (`@pops/<id>-contract@v0.1.0`) is the only
+per-surface change.

--- a/apps/pops-shell/package.json
+++ b/apps/pops-shell/package.json
@@ -15,7 +15,8 @@
     "test:e2e:headed": "playwright test --headed",
     "test:e2e:debug": "playwright test --debug",
     "gen:nginx": "tsx scripts/generate-nginx-conf.ts",
-    "gen:nginx:check": "tsx scripts/generate-nginx-conf.ts --check"
+    "gen:nginx:check": "tsx scripts/generate-nginx-conf.ts --check",
+    "registry:register": "tsx scripts/register-with-registry.ts"
   },
   "dependencies": {
     "@pops/api-client": "workspace:*",

--- a/apps/pops-shell/scripts/register-with-registry.ts
+++ b/apps/pops-shell/scripts/register-with-registry.ts
@@ -1,0 +1,44 @@
+#!/usr/bin/env tsx
+/**
+ * Ops CLI: register the running shell with `pops-core-api`'s pillar
+ * registry (Theme 13 PRD-228 US-01 + ADR-035).
+ *
+ * The shell's production image is `nginx:alpine` — there is no Node
+ * runtime at request time. This script is invoked from outside the
+ * shell container (a deploy step, a Compose `oneshot` service, or
+ * `mise run shell:register`) with the same secrets every other pillar
+ * uses:
+ *
+ *     POPS_REGISTRY_URL     http://core-api:3001
+ *     SHELL_BASE_URL        https://pops.local
+ *     POPS_INTERNAL_API_KEY <shared docker-network key>
+ *
+ * The script delegates to `registerShellWithRegistry` so the boot
+ * behaviour is identical to whatever a future in-process caller would
+ * see. Exit code is 0 for `registered` and `skipped` (silent skip is a
+ * normal outcome for envs that do not yet have a registry), and 0 for
+ * `unreachable`/`failed` too — registry hiccups MUST NOT block a
+ * deploy. The structured outcome is printed to stdout so a wrapper can
+ * decide otherwise.
+ *
+ * This is the same iOS / kiosk / future-UI-pillar pattern: copy the
+ * script, swap the env var prefix, point at the same endpoint.
+ */
+import { registerShellWithRegistry } from '../src/lib/register-with-registry.ts';
+
+async function main(): Promise<void> {
+  const outcome = await registerShellWithRegistry({
+    env: {
+      registryBaseUrl: process.env.POPS_REGISTRY_URL,
+      shellBaseUrl: process.env.SHELL_BASE_URL,
+      internalApiKey: process.env.POPS_INTERNAL_API_KEY,
+    },
+  });
+
+  process.stdout.write(`${JSON.stringify(outcome)}\n`);
+}
+
+main().catch((error: unknown) => {
+  process.stderr.write(`[shell-registry] unexpected failure: ${String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/apps/pops-shell/src/lib/register-with-registry.test.ts
+++ b/apps/pops-shell/src/lib/register-with-registry.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { validateManifestPayload } from '@pops/pillar-sdk';
+
+import {
+  SHELL_PILLAR_ID,
+  buildShellManifest,
+  registerShellWithRegistry,
+  type RegisterShellEnv,
+} from './register-with-registry';
+
+const VALID_ENV: RegisterShellEnv = {
+  registryBaseUrl: 'http://core-api:3001',
+  shellBaseUrl: 'https://pops.local',
+  internalApiKey: 'shared-internal-key',
+};
+
+function silentLogger() {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+}
+
+describe('buildShellManifest', () => {
+  it('produces a payload that the manifest validator accepts', () => {
+    const result = validateManifestPayload(buildShellManifest());
+    expect(result.ok).toBe(true);
+  });
+
+  it('declares no procedures, search adapters, ai tools, uri types, or settings', () => {
+    const manifest = buildShellManifest();
+    expect(manifest.routes.queries).toEqual([]);
+    expect(manifest.routes.mutations).toEqual([]);
+    expect(manifest.routes.subscriptions).toEqual([]);
+    expect(manifest.search.adapters).toEqual([]);
+    expect(manifest.ai.tools).toEqual([]);
+    expect(manifest.uri.types).toEqual([]);
+    expect(manifest.settings.keys).toEqual([]);
+  });
+});
+
+describe('registerShellWithRegistry — happy path', () => {
+  it('POSTs the canonical register payload to /core.registry.register and reports registered', async () => {
+    const fetchStub = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          ok: true,
+          pillarId: SHELL_PILLAR_ID,
+          registeredAt: '2026-06-13T13:00:00.000Z',
+          heartbeatIntervalMs: 10_000,
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      )
+    );
+    const logger = silentLogger();
+
+    const outcome = await registerShellWithRegistry({
+      env: VALID_ENV,
+      fetch: fetchStub,
+      logger,
+    });
+
+    expect(outcome).toEqual({
+      kind: 'registered',
+      pillarId: SHELL_PILLAR_ID,
+      registeredAt: '2026-06-13T13:00:00.000Z',
+    });
+
+    expect(fetchStub).toHaveBeenCalledTimes(1);
+    const call = fetchStub.mock.calls[0] ?? [];
+    const url = call[0] as string | URL;
+    const init = call[1] as RequestInit | undefined;
+    expect(url).toBe('http://core-api:3001/core.registry.register');
+    expect(init?.method).toBe('POST');
+    expect(init?.headers).toMatchObject({ 'content-type': 'application/json' });
+
+    const sentBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+    expect(sentBody.pillarId).toBe(SHELL_PILLAR_ID);
+    expect(sentBody.baseUrl).toBe('https://pops.local');
+    expect(sentBody.apiKey).toBe('shared-internal-key');
+    expect(sentBody.manifest).toMatchObject({
+      pillar: SHELL_PILLAR_ID,
+      version: '0.1.0',
+      routes: { queries: [], mutations: [], subscriptions: [] },
+      search: { adapters: [] },
+      ai: { tools: [] },
+      uri: { types: [] },
+      settings: { keys: [] },
+      healthcheck: { path: '/health' },
+    });
+  });
+
+  it('joins base URL and path cleanly when the base ends in a slash', async () => {
+    const fetchStub = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ ok: true, pillarId: SHELL_PILLAR_ID }), { status: 200 })
+      );
+    await registerShellWithRegistry({
+      env: { ...VALID_ENV, registryBaseUrl: 'http://core-api:3001/' },
+      fetch: fetchStub,
+      logger: silentLogger(),
+    });
+    const firstCall = fetchStub.mock.calls[0] ?? [];
+    expect(firstCall[0]).toBe('http://core-api:3001/core.registry.register');
+  });
+});
+
+describe('registerShellWithRegistry — silent skip', () => {
+  it('returns skipped + does not call fetch when all env vars are missing', async () => {
+    const fetchStub = vi.fn();
+    const logger = silentLogger();
+
+    const outcome = await registerShellWithRegistry({
+      env: { registryBaseUrl: undefined, shellBaseUrl: undefined, internalApiKey: undefined },
+      fetch: fetchStub,
+      logger,
+    });
+
+    expect(outcome).toEqual({
+      kind: 'skipped',
+      reason: 'missing-env',
+      missing: ['POPS_REGISTRY_URL', 'SHELL_BASE_URL', 'POPS_INTERNAL_API_KEY'],
+    });
+    expect(fetchStub).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    ['POPS_REGISTRY_URL', { ...VALID_ENV, registryBaseUrl: undefined }],
+    ['SHELL_BASE_URL', { ...VALID_ENV, shellBaseUrl: undefined }],
+    ['POPS_INTERNAL_API_KEY', { ...VALID_ENV, internalApiKey: undefined }],
+  ])('skips when %s alone is missing', async (name, env) => {
+    const fetchStub = vi.fn();
+    const outcome = await registerShellWithRegistry({
+      env,
+      fetch: fetchStub,
+      logger: silentLogger(),
+    });
+    expect(outcome.kind).toBe('skipped');
+    if (outcome.kind === 'skipped') {
+      expect(outcome.missing).toEqual([name]);
+    }
+    expect(fetchStub).not.toHaveBeenCalled();
+  });
+
+  it('treats empty strings as missing — defends against unset-but-defined env quirks', async () => {
+    const fetchStub = vi.fn();
+    const outcome = await registerShellWithRegistry({
+      env: { registryBaseUrl: '', shellBaseUrl: '', internalApiKey: '' },
+      fetch: fetchStub,
+      logger: silentLogger(),
+    });
+    expect(outcome.kind).toBe('skipped');
+    expect(fetchStub).not.toHaveBeenCalled();
+  });
+});
+
+describe('registerShellWithRegistry — registry unreachable', () => {
+  it('logs a warning and returns unreachable when fetch throws', async () => {
+    const boom = new Error('ECONNREFUSED');
+    const fetchStub = vi.fn().mockRejectedValue(boom);
+    const logger = silentLogger();
+
+    const outcome = await registerShellWithRegistry({
+      env: VALID_ENV,
+      fetch: fetchStub,
+      logger,
+    });
+
+    expect(outcome).toEqual({ kind: 'unreachable', error: boom });
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[shell-registry] registry unreachable — continuing boot',
+      boom
+    );
+  });
+
+  it('returns failed (not unreachable) for a non-2xx response and surfaces the body', async () => {
+    const fetchStub = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: false, reason: 'invalid-api-key' }), {
+        status: 401,
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+    const logger = silentLogger();
+
+    const outcome = await registerShellWithRegistry({
+      env: VALID_ENV,
+      fetch: fetchStub,
+      logger,
+    });
+
+    expect(outcome).toEqual({
+      kind: 'failed',
+      status: 401,
+      body: { ok: false, reason: 'invalid-api-key' },
+    });
+    expect(logger.warn).toHaveBeenCalledOnce();
+  });
+
+  it('survives a non-JSON failure body without throwing', async () => {
+    const fetchStub = vi.fn().mockResolvedValue(new Response('upstream offline', { status: 503 }));
+
+    const outcome = await registerShellWithRegistry({
+      env: VALID_ENV,
+      fetch: fetchStub,
+      logger: silentLogger(),
+    });
+
+    expect(outcome.kind).toBe('failed');
+    if (outcome.kind === 'failed') {
+      expect(outcome.status).toBe(503);
+      expect(outcome.body).toBeUndefined();
+    }
+  });
+});

--- a/apps/pops-shell/src/lib/register-with-registry.ts
+++ b/apps/pops-shell/src/lib/register-with-registry.ts
@@ -1,0 +1,191 @@
+/**
+ * Shell self-registration with `pops-core-api`'s pillar registry
+ * (Theme 13 PRD-228 US-01 + ADR-035 UI-pillar variant).
+ *
+ * The shell is the first **UI pillar** to register itself: a pillar that
+ * owns no data, exposes no procedures, and ships an empty manifest
+ * (no `routes`, no `search` adapters, no `ai` tools, no `sinks`, no
+ * `uri` types, no `settings`). It still registers so the federation
+ * has a single, dynamic list of every running surface — UI included —
+ * which downstream tooling (status pages, ops dashboards, MCP tool
+ * inspection) can consume without baking shell URLs into env files
+ * for every consumer.
+ *
+ * Trust model — registration uses the shared `POPS_INTERNAL_API_KEY`
+ * (ADR-027 docker-network boundary). The shell does NOT register from
+ * the browser; the API key never reaches the client bundle. The
+ * `scripts/register-with-registry.ts` CLI runs this from a Node
+ * container entrypoint (or an ops console) with the key sourced from
+ * the same secret store every other pillar uses.
+ *
+ * Failure policy — registration is a *best-effort* boot step. If the
+ * registry is unreachable, slow, or returns an error, the shell still
+ * boots: a UI pillar that fails to announce itself is degraded, not
+ * broken. Missing env vars short-circuit before the network call (the
+ * same `INVENTORY_BASE_URL`-style discipline applied to the data
+ * pillars in PRD-187).
+ */
+import type { ManifestPayload } from '@pops/pillar-sdk';
+
+export const SHELL_PILLAR_ID = 'shell' as const;
+export const SHELL_PILLAR_VERSION = '0.1.0' as const;
+
+/**
+ * Sentinel contract triplet for the shell. ADR-035 carves UI pillars
+ * out of the per-pillar contract-package discipline, but the registry
+ * endpoint still requires the strings to match the
+ * `@pops/<pillar>-contract` / `contract-<pillar>@v<semver>` shape so
+ * the cross-field validator (`checkContractPackageMatchesPillar`)
+ * succeeds. The package is a placeholder — it does not need to exist
+ * in the workspace, only to be lexically consistent.
+ */
+export const SHELL_CONTRACT_PACKAGE = '@pops/shell-contract' as const;
+export const SHELL_CONTRACT_TAG = `contract-${SHELL_PILLAR_ID}@v${SHELL_PILLAR_VERSION}` as const;
+
+/**
+ * The empty manifest a UI pillar publishes. Every capability array is
+ * empty; healthcheck still points at `/health` because the registry's
+ * heartbeat checker (PRD-228 US-02) probes it. `sinks` is intentionally
+ * omitted — it is optional in the manifest schema and a UI pillar
+ * neither emits nor consumes federated events directly.
+ */
+export function buildShellManifest(): ManifestPayload {
+  return {
+    pillar: SHELL_PILLAR_ID,
+    version: SHELL_PILLAR_VERSION,
+    contract: {
+      package: SHELL_CONTRACT_PACKAGE,
+      version: SHELL_PILLAR_VERSION,
+      tag: SHELL_CONTRACT_TAG,
+    },
+    routes: { queries: [], mutations: [], subscriptions: [] },
+    search: { adapters: [] },
+    ai: { tools: [] },
+    uri: { types: [] },
+    settings: { keys: [] },
+    healthcheck: { path: '/health' },
+  };
+}
+
+export interface RegisterShellEnv {
+  readonly registryBaseUrl: string | undefined;
+  readonly shellBaseUrl: string | undefined;
+  readonly internalApiKey: string | undefined;
+}
+
+export type RegisterShellOutcome =
+  | {
+      readonly kind: 'skipped';
+      readonly reason: 'missing-env';
+      readonly missing: readonly string[];
+    }
+  | { readonly kind: 'registered'; readonly pillarId: string; readonly registeredAt: string }
+  | { readonly kind: 'failed'; readonly status: number; readonly body: unknown }
+  | { readonly kind: 'unreachable'; readonly error: unknown };
+
+export interface RegisterShellDeps {
+  readonly env: RegisterShellEnv;
+  /**
+   * Transport seam. Defaults to global `fetch` so production code uses
+   * the platform implementation; tests inject a stub that never touches
+   * the network.
+   */
+  readonly fetch?: typeof fetch;
+  /**
+   * Optional logger seam. Defaults to `console`; tests pass a stub to
+   * assert the unreachable-branch message without polluting stdout.
+   */
+  readonly logger?: Pick<Console, 'info' | 'warn' | 'error'>;
+}
+
+interface RegisterResponseBody {
+  readonly ok: boolean;
+  readonly pillarId?: string;
+  readonly registeredAt?: string;
+}
+
+function collectMissingEnv(env: RegisterShellEnv): string[] {
+  const missing: string[] = [];
+  if (!env.registryBaseUrl) missing.push('POPS_REGISTRY_URL');
+  if (!env.shellBaseUrl) missing.push('SHELL_BASE_URL');
+  if (!env.internalApiKey) missing.push('POPS_INTERNAL_API_KEY');
+  return missing;
+}
+
+function buildRegisterRequestBody(env: RegisterShellEnv): {
+  pillarId: string;
+  baseUrl: string;
+  manifest: ManifestPayload;
+  apiKey: string;
+} {
+  return {
+    pillarId: SHELL_PILLAR_ID,
+    baseUrl: env.shellBaseUrl ?? '',
+    manifest: buildShellManifest(),
+    apiKey: env.internalApiKey ?? '',
+  };
+}
+
+async function interpretResponse(
+  res: Response,
+  logger: Pick<Console, 'info' | 'warn' | 'error'>
+): Promise<RegisterShellOutcome> {
+  if (!res.ok) {
+    const payload: unknown = await safeReadJson(res);
+    logger.warn(`[shell-registry] registry rejected registration: ${String(res.status)}`, payload);
+    return { kind: 'failed', status: res.status, body: payload };
+  }
+  const parsed = (await res.json()) as RegisterResponseBody;
+  const pillarId = parsed.pillarId ?? SHELL_PILLAR_ID;
+  const registeredAt = parsed.registeredAt ?? new Date().toISOString();
+  logger.info(`[shell-registry] registered as '${pillarId}' at ${registeredAt}`);
+  return { kind: 'registered', pillarId, registeredAt };
+}
+
+/**
+ * Run the shell's self-registration once. Resolves to a structured
+ * outcome rather than throwing so a caller (boot script, test) can
+ * react to every branch — including the silent skip — without
+ * try/catch noise.
+ */
+export async function registerShellWithRegistry(
+  deps: RegisterShellDeps
+): Promise<RegisterShellOutcome> {
+  const { env } = deps;
+  const logger = deps.logger ?? console;
+
+  const missing = collectMissingEnv(env);
+  if (missing.length > 0) {
+    logger.info(`[shell-registry] skipping registration — missing env: ${missing.join(', ')}`);
+    return { kind: 'skipped', reason: 'missing-env', missing };
+  }
+
+  const fetchImpl = deps.fetch ?? globalThis.fetch;
+  const endpoint = joinUrl(env.registryBaseUrl ?? '', '/core.registry.register');
+
+  try {
+    const res = await fetchImpl(endpoint, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(buildRegisterRequestBody(env)),
+    });
+    return await interpretResponse(res, logger);
+  } catch (error) {
+    logger.warn('[shell-registry] registry unreachable — continuing boot', error);
+    return { kind: 'unreachable', error };
+  }
+}
+
+function joinUrl(base: string, path: string): string {
+  if (base.endsWith('/') && path.startsWith('/')) return base + path.slice(1);
+  if (!base.endsWith('/') && !path.startsWith('/')) return `${base}/${path}`;
+  return base + path;
+}
+
+async function safeReadJson(res: Response): Promise<unknown> {
+  try {
+    return await res.json();
+  } catch {
+    return undefined;
+  }
+}


### PR DESCRIPTION
## Summary

The shell is the first non-data pillar to self-register with `pops-core-api`'s pillar registry. **ADR-035** carved out UI-variant pillars that own no data, expose no procedures, and ship empty manifests; **PRD-228 US-01** shipped the `POST /core.registry.register` endpoint they call. This PR exercises both for the first time.

## What lands

- **`src/lib/register-with-registry.ts`** — pure registration function with deps-injected `fetch` and `logger` seams. The empty UI-pillar manifest validates against the shared `ManifestPayloadSchema` (`pillar='shell'`, `contract=@pops/shell-contract@v0.1.0`, every capability array empty).
- **`scripts/register-with-registry.ts`** — Node CLI consumed at deploy time. The shell ships in `nginx:alpine` and has no Node at request time, so the registration runs from an ops/compose entrypoint with `POPS_REGISTRY_URL` / `SHELL_BASE_URL` / `POPS_INTERNAL_API_KEY` from the same secret store every pillar uses.
- **`src/lib/register-with-registry.test.ts`** — 12 tests covering manifest validation against the live schema, the happy-path wire shape, URL joining with trailing slashes, per-var missing-env skip, total missing-env skip, unreachable registry (fetch rejects), non-2xx rejection, and non-JSON failure bodies.
- **`README.md`** — UI-pillar registration pattern doc with wire shape + iOS/kiosk reuse recipe.
- **`package.json`** — `registry:register` script entry.

## Behavioural contract

| Condition | Outcome | Exit code |
|---|---|---|
| All env vars present, registry 200 | `{ kind: 'registered', pillarId, registeredAt }` | 0 |
| Any env var missing/empty | `{ kind: 'skipped', reason: 'missing-env', missing: [...] }` | 0 |
| Registry unreachable (fetch throws) | `{ kind: 'unreachable', error }` + `logger.warn` | 0 |
| Registry returns non-2xx | `{ kind: 'failed', status, body }` + `logger.warn` | 0 |

A UI pillar that fails to announce itself is degraded, not broken — boot continues either way (same `INVENTORY_BASE_URL`-style discipline applied to the data pillars in PRD-187).

## Test plan

- [x] `pnpm test src/lib/register-with-registry.test.ts` — 12 / 12 pass
- [x] `pnpm turbo typecheck --filter=@pops/shell` — passes (includes `^build` of pillar-sdk)
- [x] Pre-push hook (`pnpm typecheck` whole repo) — green
- [ ] Smoke: run the CLI against a local `pops-core-api` with the shared key, confirm row appears in `pillar_registrations` with `origin='external'` and `status='healthy'`