### PR TITLE
feat(core): PRD-228 US-02 + US-04 — heartbeat lifecycle + deregister endpoint

### DIFF
--- a/apps/pops-core-api/src/__tests__/external-deregister.test.ts
+++ b/apps/pops-core-api/src/__tests__/external-deregister.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Integration tests for `POST /core.registry.deregister` (Theme 13 PRD-228 US-04).
+ *
+ * Drives the external clean-shutdown surface through `supertest`.
+ * Acceptance criteria covered:
+ *   - happy path: 200 + row DELETEd + `deregistered` event with
+ *     `reason: 'requested'`.
+ *   - bad shared key: 401.
+ *   - rotated stored hash: 401.
+ *   - missing row (already deregistered): idempotent 200 with no event
+ *     emitted (PRD: "DELETE is idempotent").
+ *   - internal-origin row: 403 with
+ *     `internal-pillar-not-deregisterable-externally`.
+ *   - missing env key: 500.
+ *   - malformed body: 400.
+ *   - calling deregister twice in a row produces the same end state.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { openCoreDb, pillarRegistryService, type OpenedCoreDb } from '@pops/core-db';
+
+import { createCoreApiApp } from '../app.js';
+import { registryEventBus, type RegistryEventPayload } from '../modules/registry/event-bus.js';
+
+import type { ManifestPayload } from '@pops/pillar-sdk';
+
+const VALID_API_KEY = 'super-secret-shared-key';
+
+function recipesManifest(overrides?: Partial<ManifestPayload>): ManifestPayload {
+  return {
+    pillar: 'recipes',
+    version: '0.1.0',
+    contract: {
+      package: '@pops/recipes-contract',
+      version: '0.1.0',
+      tag: 'contract-recipes@v0.1.0',
+    },
+    routes: {
+      queries: ['recipes.library.list'],
+      mutations: ['recipes.library.create'],
+      subscriptions: [],
+    },
+    search: { adapters: [] },
+    ai: { tools: [] },
+    uri: { types: ['recipes/recipe'] },
+    settings: { keys: [] },
+    healthcheck: { path: '/health' },
+    ...overrides,
+  };
+}
+
+async function registerRecipes(
+  app: ReturnType<typeof createCoreApiApp>,
+  apiKey: string = VALID_API_KEY
+): Promise<void> {
+  const res = await request(app).post('/core.registry.register').send({
+    pillarId: 'recipes',
+    baseUrl: 'http://recipes-api:4010',
+    manifest: recipesManifest(),
+    apiKey,
+  });
+  if (res.status !== 200) {
+    throw new Error(`register failed: ${res.status} ${JSON.stringify(res.body)}`);
+  }
+}
+
+let tmpDir: string;
+let coreDb: OpenedCoreDb;
+let app: ReturnType<typeof createCoreApiApp>;
+let resolvedKey: string | undefined;
+let capturedEvents: RegistryEventPayload[];
+let eventListener: (payload: RegistryEventPayload) => void;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'core-api-dereg-'));
+  coreDb = openCoreDb(join(tmpDir, 'core.db'));
+  resolvedKey = VALID_API_KEY;
+  capturedEvents = [];
+  eventListener = (payload) => capturedEvents.push(payload);
+  registryEventBus.on('registry:event', eventListener);
+  app = createCoreApiApp({
+    coreDb,
+    version: '0.0.1-test',
+    selfBaseUrl: 'http://localhost:3001',
+    resolveApiKey: () => resolvedKey,
+  });
+});
+
+afterEach(() => {
+  registryEventBus.off('registry:event', eventListener);
+  coreDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('POST /core.registry.deregister — happy path', () => {
+  it('deletes the row and emits a deregistered event with reason=requested', async () => {
+    await registerRecipes(app);
+    capturedEvents = [];
+
+    const res = await request(app).post('/core.registry.deregister').send({
+      pillarId: 'recipes',
+      apiKey: VALID_API_KEY,
+    });
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ ok: true, removed: true });
+    expect(pillarRegistryService.getPillarRegistration(coreDb.db, 'recipes')).toBeNull();
+
+    const dereg = capturedEvents.filter((e) => e.event === 'deregistered');
+    expect(dereg).toHaveLength(1);
+    expect(dereg[0]).toMatchObject({
+      pillarId: 'recipes',
+      origin: 'external',
+      reason: 'requested',
+    });
+  });
+});
+
+describe('POST /core.registry.deregister — authentication', () => {
+  it('returns 401 with no deletion when the shared apiKey is wrong', async () => {
+    await registerRecipes(app);
+    capturedEvents = [];
+
+    const res = await request(app).post('/core.registry.deregister').send({
+      pillarId: 'recipes',
+      apiKey: 'wrong-key',
+    });
+    expect(res.status).toBe(401);
+    expect(res.body).toMatchObject({ ok: false, reason: 'invalid-api-key' });
+    expect(pillarRegistryService.getPillarRegistration(coreDb.db, 'recipes')).not.toBeNull();
+    expect(capturedEvents).toEqual([]);
+  });
+
+  it('returns 401 when the per-row apiKeyHash does not match (key rotation)', async () => {
+    resolvedKey = 'first-key';
+    await registerRecipes(app, 'first-key');
+    resolvedKey = 'rotated-key';
+
+    const res = await request(app).post('/core.registry.deregister').send({
+      pillarId: 'recipes',
+      apiKey: 'rotated-key',
+    });
+    expect(res.status).toBe(401);
+    expect(res.body).toMatchObject({ ok: false, reason: 'invalid-api-key' });
+    expect(pillarRegistryService.getPillarRegistration(coreDb.db, 'recipes')).not.toBeNull();
+  });
+
+  it('returns 500 when POPS_INTERNAL_API_KEY is not configured', async () => {
+    await registerRecipes(app);
+    resolvedKey = undefined;
+    const res = await request(app).post('/core.registry.deregister').send({
+      pillarId: 'recipes',
+      apiKey: VALID_API_KEY,
+    });
+    expect(res.status).toBe(500);
+    expect(res.body).toMatchObject({ ok: false, reason: 'api-key-not-configured' });
+  });
+});
+
+describe('POST /core.registry.deregister — idempotency', () => {
+  it('returns 200 { ok: true, removed: false } and emits NO event for a pillar that never registered', async () => {
+    const res = await request(app).post('/core.registry.deregister').send({
+      pillarId: 'recipes',
+      apiKey: VALID_API_KEY,
+    });
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ ok: true, removed: false });
+    expect(capturedEvents).toEqual([]);
+  });
+
+  it('deregistering twice leaves the same end state and emits exactly one deregistered event', async () => {
+    await registerRecipes(app);
+    capturedEvents = [];
+
+    const first = await request(app).post('/core.registry.deregister').send({
+      pillarId: 'recipes',
+      apiKey: VALID_API_KEY,
+    });
+    expect(first.status).toBe(200);
+    expect(first.body).toMatchObject({ ok: true, removed: true });
+
+    const second = await request(app).post('/core.registry.deregister').send({
+      pillarId: 'recipes',
+      apiKey: VALID_API_KEY,
+    });
+    expect(second.status).toBe(200);
+    expect(second.body).toMatchObject({ ok: true, removed: false });
+
+    expect(pillarRegistryService.getPillarRegistration(coreDb.db, 'recipes')).toBeNull();
+    expect(capturedEvents.filter((e) => e.event === 'deregistered')).toHaveLength(1);
+  });
+});
+
+describe('POST /core.registry.deregister — internal pillar refusal', () => {
+  it('returns 403 internal-pillar-not-deregisterable-externally when the row was registered via the in-tree bootstrap path', async () => {
+    pillarRegistryService.upsertPillarRegistration(coreDb.db, {
+      baseUrl: 'http://finance-api:3004',
+      manifest: {
+        pillar: 'finance',
+        contract: {
+          package: '@pops/finance-contract',
+          version: '0.1.0',
+          tag: 'contract-finance@v0.1.0',
+        },
+      },
+      now: new Date().toISOString(),
+      origin: 'internal',
+    });
+    capturedEvents = [];
+
+    const res = await request(app).post('/core.registry.deregister').send({
+      pillarId: 'finance',
+      apiKey: VALID_API_KEY,
+    });
+    expect(res.status).toBe(403);
+    expect(res.body).toMatchObject({
+      ok: false,
+      reason: 'internal-pillar-not-deregisterable-externally',
+    });
+    expect(pillarRegistryService.getPillarRegistration(coreDb.db, 'finance')).not.toBeNull();
+    expect(capturedEvents).toEqual([]);
+  });
+});
+
+describe('POST /core.registry.deregister — body validation', () => {
+  it('returns 400 when pillarId is missing', async () => {
+    const res = await request(app).post('/core.registry.deregister').send({
+      apiKey: VALID_API_KEY,
+    });
+    expect(res.status).toBe(400);
+    const fields = res.body.issues.map((i: { field: string }) => i.field);
+    expect(fields).toContain('pillarId');
+  });
+
+  it('returns 400 when apiKey is missing', async () => {
+    const res = await request(app).post('/core.registry.deregister').send({
+      pillarId: 'recipes',
+    });
+    expect(res.status).toBe(400);
+    const fields = res.body.issues.map((i: { field: string }) => i.field);
+    expect(fields).toContain('apiKey');
+  });
+});

--- a/apps/pops-core-api/src/__tests__/external-heartbeat.test.ts
+++ b/apps/pops-core-api/src/__tests__/external-heartbeat.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Integration tests for `POST /core.registry.heartbeat` (Theme 13 PRD-228 US-02).
+ *
+ * Boots the full Express factory against a temp-dir core.db with an
+ * injected `resolveApiKey` callback, then drives the wire surface end
+ * to end via `supertest`. Asserts the user-story acceptance criteria:
+ *   - happy path: 200 + bumped `lastHeartbeatAt` + no event when status
+ *     stays healthy.
+ *   - bad shared key: 401, no row mutation.
+ *   - rotated stored hash (key was rotated but env was not — or vice
+ *     versa): 401.
+ *   - missing pillar row: 200 `{ ok: false, reason: 'not-registered' }`
+ *     (so the external SDK re-registers cleanly).
+ *   - missing api key env: 500.
+ *   - heartbeat that flips `unavailable → healthy` emits a single
+ *     `health-changed` event.
+ *   - malformed body: 400.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { openCoreDb, pillarRegistryService, type OpenedCoreDb } from '@pops/core-db';
+
+import { createCoreApiApp } from '../app.js';
+import { registryEventBus, type RegistryEventPayload } from '../modules/registry/event-bus.js';
+
+import type { ManifestPayload } from '@pops/pillar-sdk';
+
+const VALID_API_KEY = 'super-secret-shared-key';
+
+function recipesManifest(overrides?: Partial<ManifestPayload>): ManifestPayload {
+  return {
+    pillar: 'recipes',
+    version: '0.1.0',
+    contract: {
+      package: '@pops/recipes-contract',
+      version: '0.1.0',
+      tag: 'contract-recipes@v0.1.0',
+    },
+    routes: {
+      queries: ['recipes.library.list'],
+      mutations: ['recipes.library.create'],
+      subscriptions: [],
+    },
+    search: { adapters: [] },
+    ai: { tools: [] },
+    uri: { types: ['recipes/recipe'] },
+    settings: { keys: [] },
+    healthcheck: { path: '/health' },
+    ...overrides,
+  };
+}
+
+async function registerRecipes(
+  app: ReturnType<typeof createCoreApiApp>,
+  apiKey: string = VALID_API_KEY
+): Promise<void> {
+  const res = await request(app).post('/core.registry.register').send({
+    pillarId: 'recipes',
+    baseUrl: 'http://recipes-api:4010',
+    manifest: recipesManifest(),
+    apiKey,
+  });
+  if (res.status !== 200) {
+    throw new Error(`register failed: ${res.status} ${JSON.stringify(res.body)}`);
+  }
+}
+
+let tmpDir: string;
+let coreDb: OpenedCoreDb;
+let app: ReturnType<typeof createCoreApiApp>;
+let resolvedKey: string | undefined;
+let capturedEvents: RegistryEventPayload[];
+let eventListener: (payload: RegistryEventPayload) => void;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'core-api-hb-'));
+  coreDb = openCoreDb(join(tmpDir, 'core.db'));
+  resolvedKey = VALID_API_KEY;
+  capturedEvents = [];
+  eventListener = (payload) => capturedEvents.push(payload);
+  registryEventBus.on('registry:event', eventListener);
+  app = createCoreApiApp({
+    coreDb,
+    version: '0.0.1-test',
+    selfBaseUrl: 'http://localhost:3001',
+    resolveApiKey: () => resolvedKey,
+  });
+});
+
+afterEach(() => {
+  registryEventBus.off('registry:event', eventListener);
+  coreDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('POST /core.registry.heartbeat — happy path', () => {
+  it('bumps lastHeartbeatAt, keeps status healthy, emits no event on a healthy-to-healthy heartbeat', async () => {
+    await registerRecipes(app);
+    const initial = pillarRegistryService.getPillarRegistration(coreDb.db, 'recipes');
+    expect(initial).not.toBeNull();
+
+    capturedEvents = [];
+
+    await new Promise((r) => setTimeout(r, 5));
+
+    const res = await request(app).post('/core.registry.heartbeat').send({
+      pillarId: 'recipes',
+      apiKey: VALID_API_KEY,
+    });
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      ok: true,
+      pillarId: 'recipes',
+      status: 'healthy',
+      statusChanged: false,
+    });
+    expect(typeof res.body.lastHeartbeatAt).toBe('string');
+
+    const updated = pillarRegistryService.getPillarRegistration(coreDb.db, 'recipes');
+    expect(updated?.lastHeartbeatAt).not.toBe(initial?.lastHeartbeatAt);
+    expect(updated?.status).toBe('healthy');
+    expect(capturedEvents.filter((e) => e.event === 'health-changed')).toHaveLength(0);
+  });
+
+  it('emits a health-changed event when the heartbeat flips unavailable → healthy', async () => {
+    await registerRecipes(app);
+    pillarRegistryService.applyStatusUpdates(coreDb.db, [
+      {
+        pillarId: 'recipes',
+        status: 'unavailable',
+        statusUpdatedAt: new Date().toISOString(),
+      },
+    ]);
+    capturedEvents = [];
+
+    const res = await request(app).post('/core.registry.heartbeat').send({
+      pillarId: 'recipes',
+      apiKey: VALID_API_KEY,
+    });
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ ok: true, status: 'healthy', statusChanged: true });
+
+    const healthChanged = capturedEvents.filter((e) => e.event === 'health-changed');
+    expect(healthChanged).toHaveLength(1);
+    expect(healthChanged[0].pillarId).toBe('recipes');
+    expect(healthChanged[0].origin).toBe('external');
+  });
+});
+
+describe('POST /core.registry.heartbeat — authentication', () => {
+  it('returns 401 with no row mutation when the shared apiKey does not match', async () => {
+    await registerRecipes(app);
+    const before = pillarRegistryService.getPillarRegistration(coreDb.db, 'recipes');
+    capturedEvents = [];
+
+    const res = await request(app).post('/core.registry.heartbeat').send({
+      pillarId: 'recipes',
+      apiKey: 'wrong-key',
+    });
+    expect(res.status).toBe(401);
+    expect(res.body).toMatchObject({ ok: false, reason: 'invalid-api-key' });
+    const after = pillarRegistryService.getPillarRegistration(coreDb.db, 'recipes');
+    expect(after?.lastHeartbeatAt).toBe(before?.lastHeartbeatAt);
+    expect(capturedEvents).toEqual([]);
+  });
+
+  it('returns 401 when the per-row apiKeyHash does not match (registered under a rotated key)', async () => {
+    resolvedKey = 'first-key';
+    await registerRecipes(app, 'first-key');
+    resolvedKey = 'rotated-key';
+
+    const res = await request(app).post('/core.registry.heartbeat').send({
+      pillarId: 'recipes',
+      apiKey: 'rotated-key',
+    });
+    expect(res.status).toBe(401);
+    expect(res.body).toMatchObject({ ok: false, reason: 'invalid-api-key' });
+  });
+
+  it('returns 500 when POPS_INTERNAL_API_KEY is not configured on core-api', async () => {
+    await registerRecipes(app);
+    resolvedKey = undefined;
+    const res = await request(app).post('/core.registry.heartbeat').send({
+      pillarId: 'recipes',
+      apiKey: VALID_API_KEY,
+    });
+    expect(res.status).toBe(500);
+    expect(res.body).toMatchObject({ ok: false, reason: 'api-key-not-configured' });
+  });
+});
+
+describe('POST /core.registry.heartbeat — missing pillar', () => {
+  it('returns 200 { ok: false, reason: not-registered } when the pillar has never registered (with valid shared key)', async () => {
+    const res = await request(app).post('/core.registry.heartbeat').send({
+      pillarId: 'recipes',
+      apiKey: VALID_API_KEY,
+    });
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ ok: false, reason: 'not-registered' });
+  });
+
+  it('returns 401 when the pillar is missing AND the shared apiKey is wrong (auth gate is checked first)', async () => {
+    const res = await request(app).post('/core.registry.heartbeat').send({
+      pillarId: 'recipes',
+      apiKey: 'wrong-key',
+    });
+    expect(res.status).toBe(401);
+    expect(res.body).toMatchObject({ ok: false, reason: 'invalid-api-key' });
+  });
+});
+
+describe('POST /core.registry.heartbeat — body validation', () => {
+  it('returns 400 with structured issues when pillarId is missing', async () => {
+    const res = await request(app).post('/core.registry.heartbeat').send({
+      apiKey: VALID_API_KEY,
+    });
+    expect(res.status).toBe(400);
+    const fields = res.body.issues.map((i: { field: string }) => i.field);
+    expect(fields).toContain('pillarId');
+  });
+
+  it('returns 400 when apiKey is missing', async () => {
+    const res = await request(app).post('/core.registry.heartbeat').send({
+      pillarId: 'recipes',
+    });
+    expect(res.status).toBe(400);
+    const fields = res.body.issues.map((i: { field: string }) => i.field);
+    expect(fields).toContain('apiKey');
+  });
+});

--- a/apps/pops-core-api/src/app.ts
+++ b/apps/pops-core-api/src/app.ts
@@ -15,6 +15,8 @@ import { createExpressMiddleware } from '@trpc/server/adapters/express';
 import express, { type Express, type Request, type Response } from 'express';
 
 import { type CoreApiDeps, makeRequestHandler } from './handlers.js';
+import { createExternalDeregisterHandler } from './modules/external-registry/deregister.js';
+import { createExternalHeartbeatHandler } from './modules/external-registry/heartbeat.js';
 import { createExternalRegisterHandler } from './modules/external-registry/register.js';
 import { createRegistrySubscribeHandler } from './modules/registry/subscribe.js';
 import { appRouter } from './router.js';
@@ -44,11 +46,29 @@ export function createCoreApiApp(deps: CoreApiDeps): Express {
 
   app.get('/registry/subscribe', createRegistrySubscribeHandler(deps.coreDb.db));
 
+  const resolveApiKey = deps.resolveApiKey ?? defaultResolveApiKey;
+
   app.post(
     '/core.registry.register',
     createExternalRegisterHandler({
       coreDb: deps.coreDb.db,
-      resolveApiKey: deps.resolveApiKey ?? defaultResolveApiKey,
+      resolveApiKey,
+    })
+  );
+
+  app.post(
+    '/core.registry.heartbeat',
+    createExternalHeartbeatHandler({
+      coreDb: deps.coreDb.db,
+      resolveApiKey,
+    })
+  );
+
+  app.post(
+    '/core.registry.deregister',
+    createExternalDeregisterHandler({
+      coreDb: deps.coreDb.db,
+      resolveApiKey,
     })
   );
 

--- a/apps/pops-core-api/src/modules/external-registry/auth.ts
+++ b/apps/pops-core-api/src/modules/external-registry/auth.ts
@@ -1,0 +1,42 @@
+/**
+ * Shared authentication primitives for the PRD-228 external HTTP-JSON
+ * surface (register / heartbeat / deregister).
+ *
+ * All three endpoints validate the caller in two layers:
+ *
+ *   1. Constant-time `apiKey` compare against the shared
+ *      `POPS_INTERNAL_API_KEY`. This is the "are you on the docker
+ *      network" gate (ADR-027).
+ *   2. For pillar-addressed mutations (heartbeat / deregister),
+ *      `sha256(apiKey)` is compared against the per-row `apiKeyHash`
+ *      that was stored on register. This catches key rotation where
+ *      the shared env was rotated but a pillar still holds the old
+ *      value — the layer-1 check would pass, the layer-2 check fails
+ *      with the same 401 shape.
+ *
+ * The compare helpers live in a separate module so the handler files
+ * stay focused on response shaping. The 401 reply uses a single
+ * `invalid-api-key` reason for both failure modes so callers cannot
+ * use the response to probe which check failed.
+ */
+import { createHash, timingSafeEqual } from 'node:crypto';
+
+/**
+ * Constant-time UTF-8 byte compare. `timingSafeEqual` requires equal-
+ * length buffers, so the length-mismatch path still pays the same
+ * compare cost against a zeroed buffer — no length oracle.
+ */
+export function constantTimeEquals(provided: string, expected: string): boolean {
+  const providedBuf = Buffer.from(provided, 'utf8');
+  const expectedBuf = Buffer.from(expected, 'utf8');
+  if (providedBuf.length !== expectedBuf.length) {
+    const dummy = Buffer.alloc(providedBuf.length);
+    timingSafeEqual(providedBuf, dummy);
+    return false;
+  }
+  return timingSafeEqual(providedBuf, expectedBuf);
+}
+
+export function sha256Hex(value: string): string {
+  return createHash('sha256').update(value, 'utf8').digest('hex');
+}

--- a/apps/pops-core-api/src/modules/external-registry/deregister.ts
+++ b/apps/pops-core-api/src/modules/external-registry/deregister.ts
@@ -1,0 +1,106 @@
+/**
+ * HTTP-JSON deregister handler for external pillars (Theme 13 PRD-228 US-04).
+ *
+ * An external pillar shutting down cleanly POSTs to
+ * `/core.registry.deregister` so the dispatcher can drop its route
+ * immediately, rather than waiting for the missed-heartbeat → unavailable
+ * → eviction chain to land.
+ *
+ * Behaviour:
+ *   - Same two-layer auth as heartbeat (shared key + per-row hash).
+ *   - DELETE is idempotent: a missing row returns `{ ok: true }` with
+ *     no event emitted (acceptance criterion).
+ *   - On a real DELETE a `{ event: 'deregistered', reason: 'requested' }`
+ *     payload fires on the PRD-163 bus.
+ *   - Refuses to delete `origin = 'internal'` rows — the shared key
+ *     gates both surfaces, so without this rule an external caller
+ *     could nuke an in-tree pillar by accident.
+ */
+import { pillarRegistryService, type CoreDb } from '@pops/core-db';
+
+import { emitRegistryEvent } from '../registry/event-bus.js';
+import { constantTimeEquals, sha256Hex } from './auth.js';
+import { parseHeartbeatBody, type ValidHeartbeatBody } from './heartbeat-helpers.js';
+
+import type { Request, Response } from 'express';
+
+import type { PillarRegistration } from '@pops/core-db';
+
+export interface ExternalDeregisterDeps {
+  readonly coreDb: CoreDb;
+  readonly resolveApiKey: () => string | undefined;
+}
+
+export type ExternalDeregisterHandler = (req: Request, res: Response) => void;
+
+function rejectInvalidKey(res: Response): void {
+  res.status(401).json({ ok: false, reason: 'invalid-api-key' });
+}
+
+function rejectInternal(res: Response): void {
+  res.status(403).json({
+    ok: false,
+    reason: 'internal-pillar-not-deregisterable-externally',
+  });
+}
+
+function performDelete(deps: ExternalDeregisterDeps, existing: PillarRegistration): void {
+  pillarRegistryService.deletePillarRegistration(deps.coreDb, existing.pillarId);
+  emitRegistryEvent({
+    event: 'deregistered',
+    pillarId: existing.pillarId,
+    entry: null,
+    origin: existing.origin,
+    reason: 'requested',
+  });
+}
+
+function authoriseAgainstExisting(body: ValidHeartbeatBody, existing: PillarRegistration): boolean {
+  if (existing.apiKeyHash === null) return false;
+  return constantTimeEquals(sha256Hex(body.apiKey), existing.apiKeyHash);
+}
+
+export function createExternalDeregisterHandler(
+  deps: ExternalDeregisterDeps
+): ExternalDeregisterHandler {
+  return function externalDeregisterHandler(req, res) {
+    const expected = deps.resolveApiKey();
+    if (typeof expected !== 'string' || expected.length === 0) {
+      res.status(500).json({ ok: false, reason: 'api-key-not-configured' });
+      return;
+    }
+
+    const parsed = parseHeartbeatBody(req.body);
+    if (!parsed.ok) {
+      res.status(400).json({ ok: false, issues: parsed.issues });
+      return;
+    }
+
+    if (!constantTimeEquals(parsed.value.apiKey, expected)) {
+      rejectInvalidKey(res);
+      return;
+    }
+
+    const existing = pillarRegistryService.getPillarRegistration(
+      deps.coreDb,
+      parsed.value.pillarId
+    );
+    if (!existing) {
+      res.status(200).json({ ok: true, removed: false });
+      return;
+    }
+
+    if (existing.origin === 'internal') {
+      rejectInternal(res);
+      return;
+    }
+
+    if (!authoriseAgainstExisting(parsed.value, existing)) {
+      rejectInvalidKey(res);
+      return;
+    }
+
+    performDelete(deps, existing);
+    res.status(200).json({ ok: true, removed: true });
+  };
+}

--- a/apps/pops-core-api/src/modules/external-registry/heartbeat-helpers.ts
+++ b/apps/pops-core-api/src/modules/external-registry/heartbeat-helpers.ts
@@ -1,0 +1,51 @@
+/**
+ * Body parser for the PRD-228 heartbeat + deregister endpoints.
+ *
+ * Both endpoints take the same minimal `{ pillarId, apiKey }` body —
+ * the only difference is what they do once the caller is authorised.
+ * The shared parser lives here so neither handler grows its own copy
+ * of the structured validation issues that callers consume.
+ */
+import type { ValidationIssue } from '@pops/pillar-sdk';
+
+export interface ValidHeartbeatBody {
+  readonly pillarId: string;
+  readonly apiKey: string;
+}
+
+export type HeartbeatBodyParseResult =
+  | { ok: true; value: ValidHeartbeatBody }
+  | { ok: false; issues: ValidationIssue[] };
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function issue(field: string, reason: string, got: unknown): ValidationIssue {
+  return { field, reason, got, schemaPath: field.length > 0 ? field.split('.') : [] };
+}
+
+function takeNonEmptyString(
+  value: unknown,
+  field: string,
+  redact: boolean,
+  issues: ValidationIssue[]
+): string | undefined {
+  if (typeof value !== 'string' || value.length === 0) {
+    const got = redact && typeof value === 'string' ? '<redacted>' : value;
+    issues.push(issue(field, `${field} must be a non-empty string`, got));
+    return undefined;
+  }
+  return value;
+}
+
+export function parseHeartbeatBody(input: unknown): HeartbeatBodyParseResult {
+  if (!isPlainObject(input)) {
+    return { ok: false, issues: [issue('', 'expected an object body', input)] };
+  }
+  const issues: ValidationIssue[] = [];
+  const pillarId = takeNonEmptyString(input.pillarId, 'pillarId', false, issues);
+  const apiKey = takeNonEmptyString(input.apiKey, 'apiKey', true, issues);
+  if (pillarId === undefined || apiKey === undefined) return { ok: false, issues };
+  return { ok: true, value: { pillarId, apiKey } };
+}

--- a/apps/pops-core-api/src/modules/external-registry/heartbeat.ts
+++ b/apps/pops-core-api/src/modules/external-registry/heartbeat.ts
@@ -1,0 +1,132 @@
+/**
+ * HTTP-JSON heartbeat handler for external pillars (Theme 13 PRD-228 US-02).
+ *
+ * External pillars POST to `/core.registry.heartbeat` with their
+ * `pillarId` + the shared `POPS_INTERNAL_API_KEY`. Two auth gates:
+ *
+ *   1. Constant-time `apiKey` compare against the shared env (layer 1).
+ *   2. `sha256(apiKey)` compare against the stored `apiKeyHash` on the
+ *      row (layer 2 — catches key rotation where the env was rotated
+ *      but the pillar still holds the old value).
+ *
+ * Both failures return the same 401 `invalid-api-key` reason so callers
+ * cannot probe which gate failed.
+ *
+ * Soft failure (rather than 404) on missing row: PRD-228 acceptance
+ * criterion is `{ ok: false, reason: 'not-registered' }` with a 200,
+ * so the external SDK can re-register cleanly without parsing HTTP
+ * status codes. This matches the in-network tRPC heartbeat (PRD-162).
+ */
+import { pillarRegistryService, type CoreDb } from '@pops/core-db';
+
+import { emitRegistryEvent } from '../registry/event-bus.js';
+import { registryNow } from '../registry/status.js';
+import { constantTimeEquals, sha256Hex } from './auth.js';
+import { parseHeartbeatBody, type ValidHeartbeatBody } from './heartbeat-helpers.js';
+
+import type { Request, Response } from 'express';
+
+import type { PillarRegistration } from '@pops/core-db';
+
+export interface ExternalHeartbeatDeps {
+  readonly coreDb: CoreDb;
+  readonly resolveApiKey: () => string | undefined;
+}
+
+export type ExternalHeartbeatHandler = (req: Request, res: Response) => void;
+
+function rejectInvalidKey(res: Response): void {
+  res.status(401).json({ ok: false, reason: 'invalid-api-key' });
+}
+
+function rejectNotRegistered(res: Response): void {
+  res.status(200).json({ ok: false, reason: 'not-registered' });
+}
+
+function applyHeartbeat(
+  deps: ExternalHeartbeatDeps,
+  existing: PillarRegistration,
+  res: Response
+): void {
+  const result = pillarRegistryService.recordHeartbeat(deps.coreDb, existing.pillarId, {
+    now: registryNow().toISOString(),
+  });
+  if (!result.recorded || !result.registration) {
+    rejectNotRegistered(res);
+    return;
+  }
+
+  if (result.statusChanged) {
+    emitRegistryEvent({
+      event: 'health-changed',
+      pillarId: result.registration.pillarId,
+      entry: null,
+      origin: result.registration.origin,
+    });
+  }
+
+  res.status(200).json({
+    ok: true,
+    pillarId: result.registration.pillarId,
+    lastHeartbeatAt: result.registration.lastHeartbeatAt,
+    status: result.registration.status,
+    statusChanged: result.statusChanged,
+  });
+}
+
+function authorize(
+  deps: ExternalHeartbeatDeps,
+  body: ValidHeartbeatBody,
+  expected: string
+): { ok: true; existing: PillarRegistration } | { ok: false } {
+  if (!constantTimeEquals(body.apiKey, expected)) return { ok: false };
+  const existing = pillarRegistryService.getPillarRegistration(deps.coreDb, body.pillarId);
+  if (!existing) return { ok: false };
+  if (existing.apiKeyHash === null) return { ok: false };
+  if (!constantTimeEquals(sha256Hex(body.apiKey), existing.apiKeyHash)) return { ok: false };
+  return { ok: true, existing };
+}
+
+/**
+ * Factory for the `POST /core.registry.heartbeat` handler. Factory
+ * pattern mirrors the register handler so the test suite can inject
+ * `resolveApiKey` without touching `process.env`.
+ */
+export function createExternalHeartbeatHandler(
+  deps: ExternalHeartbeatDeps
+): ExternalHeartbeatHandler {
+  return function externalHeartbeatHandler(req, res) {
+    const expected = deps.resolveApiKey();
+    if (typeof expected !== 'string' || expected.length === 0) {
+      res.status(500).json({ ok: false, reason: 'api-key-not-configured' });
+      return;
+    }
+
+    const parsed = parseHeartbeatBody(req.body);
+    if (!parsed.ok) {
+      res.status(400).json({ ok: false, issues: parsed.issues });
+      return;
+    }
+
+    const existing = pillarRegistryService.getPillarRegistration(
+      deps.coreDb,
+      parsed.value.pillarId
+    );
+    if (!existing) {
+      if (!constantTimeEquals(parsed.value.apiKey, expected)) {
+        rejectInvalidKey(res);
+        return;
+      }
+      rejectNotRegistered(res);
+      return;
+    }
+
+    const auth = authorize(deps, parsed.value, expected);
+    if (!auth.ok) {
+      rejectInvalidKey(res);
+      return;
+    }
+
+    applyHeartbeat(deps, auth.existing, res);
+  };
+}

--- a/apps/pops-core-api/src/modules/external-registry/register-helpers.ts
+++ b/apps/pops-core-api/src/modules/external-registry/register-helpers.ts
@@ -6,9 +6,9 @@
  * crypto utilities can be unit-tested in isolation without booting
  * Express.
  */
-import { createHash, timingSafeEqual } from 'node:crypto';
-
 import type { ValidationIssue } from '@pops/pillar-sdk';
+
+export { constantTimeEquals, sha256Hex } from './auth.js';
 
 export const PILLAR_ID_PATTERN = /^[a-z][a-z0-9-]*$/;
 export const HEARTBEAT_INTERVAL_MS = 10_000;
@@ -78,25 +78,4 @@ export function parseRegisterBody(input: unknown): BodyParseResult {
       apiKey: apiKey as string,
     },
   };
-}
-
-/**
- * Constant-time compare. `timingSafeEqual` requires equal-length buffers,
- * so we first short-circuit on length mismatch and still pay the same
- * compare cost against a zeroed buffer to avoid a fast-path length
- * oracle. Both sides are encoded as UTF-8 bytes.
- */
-export function constantTimeEquals(provided: string, expected: string): boolean {
-  const providedBuf = Buffer.from(provided, 'utf8');
-  const expectedBuf = Buffer.from(expected, 'utf8');
-  if (providedBuf.length !== expectedBuf.length) {
-    const dummy = Buffer.alloc(providedBuf.length);
-    timingSafeEqual(providedBuf, dummy);
-    return false;
-  }
-  return timingSafeEqual(providedBuf, expectedBuf);
-}
-
-export function sha256Hex(value: string): string {
-  return createHash('sha256').update(value, 'utf8').digest('hex');
 }

--- a/apps/pops-core-api/src/modules/registry/__tests__/eviction-ticker.test.ts
+++ b/apps/pops-core-api/src/modules/registry/__tests__/eviction-ticker.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Unit tests for the PRD-228 US-02 hard-eviction ticker.
+ *
+ * The ticker runs a single synchronous pass via `runEvictionTick`; the
+ * tests drive that directly so we don't have to wait on a real
+ * `setInterval`. Acceptance criteria covered:
+ *   - external rows whose live status is `unavailable` and whose
+ *     `statusUpdatedAt` is older than `EVICTION_THRESHOLD_MS` are
+ *     DELETEd and a `deregistered` event is emitted with the right
+ *     reason + `evictedAt`.
+ *   - internal rows are NEVER evicted regardless of status / age.
+ *   - rows still inside the threshold are left alone (no-op pass).
+ *   - a row that never received a heartbeat is evicted with
+ *     `reason: 'never-heartbeated'`; one that did is `'lost-heartbeat'`.
+ *   - empty registry / nothing-to-evict is a clean no-op (no events).
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { openCoreDb, pillarRegistryService, type OpenedCoreDb } from '@pops/core-db';
+
+import { registryEventBus, type RegistryEventPayload } from '../event-bus.js';
+import { EVICTION_THRESHOLD_MS, runEvictionTick } from '../eviction-ticker.js';
+
+import type { PersistableManifest } from '@pops/core-db';
+
+const RECIPES_MANIFEST: PersistableManifest = {
+  pillar: 'recipes',
+  contract: {
+    package: '@pops/recipes-contract',
+    version: '0.1.0',
+    tag: 'contract-recipes@v0.1.0',
+  },
+};
+
+const FINANCE_MANIFEST: PersistableManifest = {
+  pillar: 'finance',
+  contract: {
+    package: '@pops/finance-contract',
+    version: '0.1.0',
+    tag: 'contract-finance@v0.1.0',
+  },
+};
+
+function isoMinusMs(reference: Date, ms: number): string {
+  return new Date(reference.getTime() - ms).toISOString();
+}
+
+let tmpDir: string;
+let coreDb: OpenedCoreDb;
+let capturedEvents: RegistryEventPayload[];
+let eventListener: (payload: RegistryEventPayload) => void;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'core-api-evict-'));
+  coreDb = openCoreDb(join(tmpDir, 'core.db'));
+  capturedEvents = [];
+  eventListener = (payload) => capturedEvents.push(payload);
+  registryEventBus.on('registry:event', eventListener);
+});
+
+afterEach(() => {
+  registryEventBus.off('registry:event', eventListener);
+  coreDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('runEvictionTick — external pillars past the threshold', () => {
+  it('DELETEs an external row whose status flipped unavailable more than 5 minutes ago and emits a deregistered event', async () => {
+    const now = new Date('2026-06-13T12:00:00.000Z');
+    const longAgo = isoMinusMs(now, EVICTION_THRESHOLD_MS + 30_000);
+    pillarRegistryService.upsertPillarRegistration(coreDb.db, {
+      baseUrl: 'http://recipes-api:4010',
+      manifest: RECIPES_MANIFEST,
+      now: longAgo,
+      origin: 'external',
+      apiKeyHash: 'deadbeef',
+    });
+    pillarRegistryService.applyStatusUpdates(coreDb.db, [
+      {
+        pillarId: 'recipes',
+        status: 'unavailable',
+        statusUpdatedAt: longAgo,
+      },
+    ]);
+
+    const evictions = runEvictionTick(coreDb.db, { now });
+    expect(evictions).toHaveLength(1);
+    expect(evictions[0]).toMatchObject({
+      pillarId: 'recipes',
+      reason: 'never-heartbeated',
+      evictedAt: now.toISOString(),
+    });
+
+    expect(pillarRegistryService.getPillarRegistration(coreDb.db, 'recipes')).toBeNull();
+
+    const dereg = capturedEvents.filter((e) => e.event === 'deregistered');
+    expect(dereg).toHaveLength(1);
+    expect(dereg[0]).toMatchObject({
+      pillarId: 'recipes',
+      origin: 'external',
+      reason: 'never-heartbeated',
+      evictedAt: now.toISOString(),
+    });
+  });
+
+  it('emits reason: lost-heartbeat when the row registered, heartbeated, then went unavailable', async () => {
+    const now = new Date('2026-06-13T12:00:00.000Z');
+    const registeredAt = isoMinusMs(now, EVICTION_THRESHOLD_MS + 120_000);
+    pillarRegistryService.upsertPillarRegistration(coreDb.db, {
+      baseUrl: 'http://recipes-api:4010',
+      manifest: RECIPES_MANIFEST,
+      now: registeredAt,
+      origin: 'external',
+      apiKeyHash: 'deadbeef',
+    });
+    pillarRegistryService.recordHeartbeat(coreDb.db, 'recipes', {
+      now: isoMinusMs(now, EVICTION_THRESHOLD_MS + 60_000),
+    });
+    pillarRegistryService.applyStatusUpdates(coreDb.db, [
+      {
+        pillarId: 'recipes',
+        status: 'unavailable',
+        statusUpdatedAt: isoMinusMs(now, EVICTION_THRESHOLD_MS + 30_000),
+      },
+    ]);
+
+    const evictions = runEvictionTick(coreDb.db, { now });
+    expect(evictions).toHaveLength(1);
+    expect(evictions[0].reason).toBe('lost-heartbeat');
+    const dereg = capturedEvents.filter((e) => e.event === 'deregistered');
+    expect(dereg[0]?.reason).toBe('lost-heartbeat');
+  });
+});
+
+describe('runEvictionTick — guards', () => {
+  it('never evicts internal pillars regardless of status / age', async () => {
+    const now = new Date('2026-06-13T12:00:00.000Z');
+    const longAgo = isoMinusMs(now, EVICTION_THRESHOLD_MS + 60_000);
+    pillarRegistryService.upsertPillarRegistration(coreDb.db, {
+      baseUrl: 'http://finance-api:3004',
+      manifest: FINANCE_MANIFEST,
+      now: longAgo,
+      origin: 'internal',
+    });
+    pillarRegistryService.applyStatusUpdates(coreDb.db, [
+      {
+        pillarId: 'finance',
+        status: 'unavailable',
+        statusUpdatedAt: longAgo,
+      },
+    ]);
+
+    const evictions = runEvictionTick(coreDb.db, { now });
+    expect(evictions).toHaveLength(0);
+    expect(pillarRegistryService.getPillarRegistration(coreDb.db, 'finance')).not.toBeNull();
+    expect(capturedEvents.filter((e) => e.event === 'deregistered')).toHaveLength(0);
+  });
+
+  it('does not evict an external row still inside the eviction threshold', async () => {
+    const now = new Date('2026-06-13T12:00:00.000Z');
+    const recent = isoMinusMs(now, EVICTION_THRESHOLD_MS - 1_000);
+    pillarRegistryService.upsertPillarRegistration(coreDb.db, {
+      baseUrl: 'http://recipes-api:4010',
+      manifest: RECIPES_MANIFEST,
+      now: recent,
+      origin: 'external',
+      apiKeyHash: 'deadbeef',
+    });
+    pillarRegistryService.applyStatusUpdates(coreDb.db, [
+      {
+        pillarId: 'recipes',
+        status: 'unavailable',
+        statusUpdatedAt: recent,
+      },
+    ]);
+
+    const evictions = runEvictionTick(coreDb.db, { now });
+    expect(evictions).toHaveLength(0);
+    expect(pillarRegistryService.getPillarRegistration(coreDb.db, 'recipes')).not.toBeNull();
+  });
+
+  it('does not evict an external row whose live status is still healthy', async () => {
+    const now = new Date('2026-06-13T12:00:00.000Z');
+    pillarRegistryService.upsertPillarRegistration(coreDb.db, {
+      baseUrl: 'http://recipes-api:4010',
+      manifest: RECIPES_MANIFEST,
+      now: now.toISOString(),
+      origin: 'external',
+      apiKeyHash: 'deadbeef',
+    });
+
+    const evictions = runEvictionTick(coreDb.db, { now });
+    expect(evictions).toHaveLength(0);
+  });
+
+  it('is a clean no-op when the registry is empty', () => {
+    const now = new Date('2026-06-13T12:00:00.000Z');
+    const evictions = runEvictionTick(coreDb.db, { now });
+    expect(evictions).toEqual([]);
+    expect(capturedEvents).toEqual([]);
+  });
+});

--- a/apps/pops-core-api/src/modules/registry/event-bus.ts
+++ b/apps/pops-core-api/src/modules/registry/event-bus.ts
@@ -15,11 +15,28 @@ import type { RegistryEntry } from './types.js';
 
 export type RegistryEventName = 'registered' | 'deregistered' | 'health-changed';
 
+/**
+ * PRD-228 deregister reasons. `requested` is a clean shutdown via the
+ * external deregister endpoint; the two eviction reasons come from the
+ * background ticker that hard-evicts stale external rows.
+ */
+export type DeregisterReason = 'requested' | 'never-heartbeated' | 'lost-heartbeat';
+
+export type PillarOriginWire = 'internal' | 'external';
+
 export interface RegistryEventPayload {
   event: RegistryEventName;
   pillarId: string;
   entry: RegistryEntry | null;
   emittedAt: string;
+  /** Origin of the pillar at emission time (PRD-228). Optional so
+   *  pre-PRD-228 emitters keep type-checking; new emitters set it. */
+  origin?: PillarOriginWire;
+  /** Populated on `deregistered` events (PRD-228). */
+  reason?: DeregisterReason;
+  /** Populated on `deregistered` events from the eviction ticker —
+   *  the wall-clock the row was hard-evicted. */
+  evictedAt?: string;
 }
 
 const EVENT_KEY = 'registry:event' as const;

--- a/apps/pops-core-api/src/modules/registry/eviction-ticker.ts
+++ b/apps/pops-core-api/src/modules/registry/eviction-ticker.ts
@@ -1,0 +1,131 @@
+/**
+ * Hard-eviction ticker for external pillars (Theme 13 PRD-228 US-02).
+ *
+ * Runs every 30s in core-api. On each pass:
+ *
+ *   1. Read every row in `pillar_registry`.
+ *   2. Pick rows where `origin = 'external'`, `status = 'unavailable'`,
+ *      and `statusUpdatedAt` is older than `EVICTION_THRESHOLD_MS`
+ *      (5 minutes by default).
+ *   3. DELETE the row.
+ *   4. Emit a `deregistered` event with `reason = 'never-heartbeated'`
+ *      (if the row never recorded a heartbeat past registration) or
+ *      `'lost-heartbeat'` (if it ever flipped to healthy first) plus
+ *      the wall-clock `evictedAt`.
+ *
+ * `origin = 'internal'` rows are NEVER hard-evicted regardless of
+ * status — internal pillars manage their own lifecycle via the
+ * in-network `core.registry.deregister` tRPC procedure.
+ *
+ * The router's lazy-status compute (`computeStatus` from
+ * `./status.js`) flips `unavailable` after 30s of missed heartbeats;
+ * the eviction threshold is layered on top of that so a transient
+ * outage doesn't drop the row immediately.
+ *
+ * Errors are logged and the next tick runs normally — no backoff. The
+ * register endpoint accepts repeat registrations, so an evicted pillar
+ * that comes back simply re-registers.
+ */
+import { pillarRegistryService, type CoreDb, type PillarRegistration } from '@pops/core-db';
+
+import { emitRegistryEvent, type DeregisterReason } from './event-bus.js';
+import { computeStatus, registryNow } from './status.js';
+
+export const EVICTION_TICK_INTERVAL_MS = 30_000;
+export const EVICTION_THRESHOLD_MS = 5 * 60_000;
+
+export interface EvictionTickerOptions {
+  readonly intervalMs?: number;
+  readonly thresholdMs?: number;
+  readonly onEvicted?: (eviction: EvictionRecord) => void;
+  readonly onError?: (error: unknown) => void;
+}
+
+export interface EvictionRecord {
+  readonly pillarId: string;
+  readonly reason: DeregisterReason;
+  readonly evictedAt: string;
+}
+
+export type StopEvictionTicker = () => void;
+
+function chooseReason(row: PillarRegistration): DeregisterReason {
+  return row.lastHeartbeatAt === row.registeredAt ? 'never-heartbeated' : 'lost-heartbeat';
+}
+
+function shouldEvict(row: PillarRegistration, now: Date, thresholdMs: number): boolean {
+  if (row.origin !== 'external') return false;
+  const liveStatus =
+    row.status === 'unknown' ? 'unknown' : computeStatus(new Date(row.lastHeartbeatAt), now);
+  if (liveStatus !== 'unavailable') return false;
+  return now.getTime() - Date.parse(row.statusUpdatedAt) >= thresholdMs;
+}
+
+function evictRow(db: CoreDb, row: PillarRegistration, nowIso: string): EvictionRecord {
+  const reason = chooseReason(row);
+  pillarRegistryService.deletePillarRegistration(db, row.pillarId);
+  emitRegistryEvent({
+    event: 'deregistered',
+    pillarId: row.pillarId,
+    entry: null,
+    origin: 'external',
+    reason,
+    evictedAt: nowIso,
+  });
+  return { pillarId: row.pillarId, reason, evictedAt: nowIso };
+}
+
+/**
+ * Run a single eviction pass synchronously. Exported for tests so they
+ * can drive the ticker deterministically without `setInterval`.
+ *
+ * Returns the evictions that were applied so tests can assert on the
+ * count without subscribing through `onEvicted`.
+ */
+export function runEvictionTick(
+  db: CoreDb,
+  options?: { now?: Date; thresholdMs?: number; onEvicted?: (eviction: EvictionRecord) => void }
+): readonly EvictionRecord[] {
+  const now = options?.now ?? registryNow();
+  const threshold = options?.thresholdMs ?? EVICTION_THRESHOLD_MS;
+  const nowIso = now.toISOString();
+
+  const evictions: EvictionRecord[] = [];
+  for (const row of pillarRegistryService.listPillarRegistrations(db)) {
+    if (!shouldEvict(row, now, threshold)) continue;
+    evictions.push(evictRow(db, row, nowIso));
+  }
+
+  if (options?.onEvicted) {
+    for (const eviction of evictions) {
+      options.onEvicted(eviction);
+    }
+  }
+  return evictions;
+}
+
+/**
+ * Start the periodic eviction ticker. Returns a stop function suitable
+ * for SIGTERM wiring. First tick runs after `intervalMs`; tests use
+ * `runEvictionTick` directly.
+ */
+export function startEvictionTicker(
+  db: CoreDb,
+  options?: EvictionTickerOptions
+): StopEvictionTicker {
+  const intervalMs = options?.intervalMs ?? EVICTION_TICK_INTERVAL_MS;
+  const thresholdMs = options?.thresholdMs ?? EVICTION_THRESHOLD_MS;
+  const handle = setInterval(() => {
+    try {
+      runEvictionTick(db, { thresholdMs, onEvicted: options?.onEvicted });
+    } catch (error) {
+      if (options?.onError) {
+        options.onError(error);
+      } else {
+        console.error('[core-api] eviction ticker error', error);
+      }
+    }
+  }, intervalMs);
+  if (typeof handle.unref === 'function') handle.unref();
+  return () => clearInterval(handle);
+}

--- a/apps/pops-core-api/src/server.ts
+++ b/apps/pops-core-api/src/server.ts
@@ -24,6 +24,7 @@ import { bootstrapPillar, type PillarBootstrapHandle } from '@pops/pillar-sdk/bo
 import { createCoreApiApp } from './app.js';
 import { resolveCoreSqlitePath } from './core-sqlite-path.js';
 import { reconcileRegistryOnBoot } from './modules/registry/boot.js';
+import { startEvictionTicker } from './modules/registry/eviction-ticker.js';
 import { startHeartbeatTicker } from './modules/registry/ticker.js';
 import { parseBareOrigin } from './pillars/env.js';
 
@@ -89,6 +90,7 @@ const server = app.listen(port, () => {
 });
 
 const stopHeartbeatTicker = startHeartbeatTicker(coreDb.db);
+const stopEvictionTicker = startEvictionTicker(coreDb.db);
 
 // The bootstrap handshake registers core with its own registry once the
 // HTTP server is accepting traffic. Done after `app.listen` because the
@@ -106,6 +108,7 @@ function shutdown(signal: NodeJS.Signals): void {
   shuttingDown = true;
   console.warn(`[core-api] Shutting down (${signal})`);
   stopHeartbeatTicker();
+  stopEvictionTicker();
   void (pillarHandle?.stop() ?? Promise.resolve()).finally(() => {
     server.close(() => {
       coreDb.raw.close();

--- a/apps/pops-shell/nginx.conf
+++ b/apps/pops-shell/nginx.conf
@@ -178,9 +178,10 @@ server {
     # stays blocked from external traffic; this sibling path is the
     # explicit allow-list.
     #
-    # US-01 ships only the register endpoint; heartbeat and deregister
-    # land in US-02 / US-04 and are added to the regex at the same time.
-    location ~ ^/core\.registry\.register$ {
+    # US-02 adds `/core.registry.heartbeat` (per-tick liveness ping) and
+    # US-04 adds `/core.registry.deregister` (clean shutdown). All three
+    # are gated by the same shared `POPS_INTERNAL_API_KEY` in core-api.
+    location ~ ^/core\.registry\.(register|heartbeat|deregister)$ {
         set $core_registry_upstream http://core-api:3001;
         proxy_pass $core_registry_upstream;
         proxy_http_version 1.1;

--- a/apps/pops-shell/scripts/nginx-conf-template.ts
+++ b/apps/pops-shell/scripts/nginx-conf-template.ts
@@ -133,6 +133,31 @@ export const NGINX_CONF_TAIL = `    # Legacy tRPC catch-all → pops-api.
         proxy_send_timeout 10s;
     }
 
+    # External pillar registration HTTP-JSON surface (Theme 13 PRD-228).
+    #
+    # External services (pillars shipped from a different repo, running
+    # on the same docker network) POST a manifest + shared API key to
+    # \`/core.registry.register\` to appear in the dispatcher with no code
+    # change in \`pops/\`. The internal \`/trpc/core.registry.*\` surface
+    # stays blocked from external traffic; this sibling path is the
+    # explicit allow-list.
+    #
+    # US-02 adds \`/core.registry.heartbeat\` (per-tick liveness ping) and
+    # US-04 adds \`/core.registry.deregister\` (clean shutdown). All three
+    # are gated by the same shared \`POPS_INTERNAL_API_KEY\` in core-api.
+    location ~ ^/core\\.registry\\.(register|heartbeat|deregister)$ {
+        set $core_registry_upstream http://core-api:3001;
+        proxy_pass $core_registry_upstream;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_connect_timeout 5s;
+        proxy_read_timeout 10s;
+        proxy_send_timeout 10s;
+    }
+
     location ~ ^/pillars/health/?$ {
         proxy_pass http://pops-api:3000;
         proxy_http_version 1.1;

--- a/docs/themes/13-pillar-finale/prds/228-dynamic-pillar-registration/README.md
+++ b/docs/themes/13-pillar-finale/prds/228-dynamic-pillar-registration/README.md
@@ -40,7 +40,7 @@ CREATE INDEX idx_pillar_registry_origin ON pillar_registry(origin);
 
 | Column         | Purpose                                                                                                                                             |
 | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `origin`       | `'internal'` for in-tree pillars (bootstrapPillar path, PRD-158); `'external'` for pillars that registered via the shared-key HTTP endpoint.         |
+| `origin`       | `'internal'` for in-tree pillars (bootstrapPillar path, PRD-158); `'external'` for pillars that registered via the shared-key HTTP endpoint.        |
 | `api_key_hash` | SHA-256 of the `POPS_INTERNAL_API_KEY` value at registration time. Lets a key rotation deregister stale external pillars without touching internal. |
 | `evicted_at`   | Set by the ticker when an external pillar registers but never heartbeats within the grace window. Distinguishes eviction from clean deregister.     |
 
@@ -66,10 +66,10 @@ Request:
 
 ```ts
 {
-  pillarId: string;        // e.g. 'recipes'
-  baseUrl: string;         // 'http://recipes-api:4010' — reachable from inside the docker network
+  pillarId: string; // e.g. 'recipes'
+  baseUrl: string; // 'http://recipes-api:4010' — reachable from inside the docker network
   manifest: ManifestPayload; // validated by PRD-157
-  apiKey: string;          // must match POPS_INTERNAL_API_KEY
+  apiKey: string; // must match POPS_INTERNAL_API_KEY
 }
 ```
 
@@ -135,7 +135,7 @@ PRD-217's generator becomes registry-driven:
 
 - Input: `core.registry.snapshot()` output.
 - Triggered on `registered`, `deregistered`, and `health-changed (→ unavailable
-  via eviction)` events.
+via eviction)` events.
 - Process: regenerate `default.conf` from the snapshot → `nginx -t` validate →
   on pass, `nginx -s reload`; on fail, log + keep current conf.
 
@@ -188,31 +188,33 @@ post-mutation hook) is deferred to implementation.
 
 ## Edge Cases
 
-| Case                                                            | Behaviour                                                                                                                                                                                                                          |
-| --------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| External pillar registers but never sends a heartbeat           | 30s after registration the lifecycle ticker flips it to `unavailable`. 5 minutes later the eviction ticker DELETEs the row + regenerates nginx. Subscription event includes `evicted_at` and `reason: 'never-heartbeated'`.         |
-| External pillar registers with a stale (rotated) key            | Registration uses whatever key is currently set in env, so success — but its heartbeat fails 401 because the heartbeat path validates `api_key_hash` against the current key. The pillar must re-register; SDK handles the 401.     |
-| Duplicate registration (same pillarId, same baseUrl, same key)  | UPSERT no-op semantics: `last_heartbeat_at` updated, manifest fields refreshed, `registered_at` preserved, no subscription event if the manifest is bytewise identical. nginx regen still triggered (debounced).                    |
-| Duplicate registration with different `baseUrl`                 | UPSERT overwrites. Subscription event fires. nginx regen runs and the dispatcher block now points at the new URL. The old URL stops receiving traffic on the next reload.                                                           |
-| Two external pillars race the same `pillarId`                   | SQLite serialises writes; whichever lands last wins. The loser's heartbeats start failing with `not-registered`. Operational misconfig; not the registry's job to mediate.                                                          |
-| External pillar registers during core-api boot reconciliation   | PRD-164's reconciliation sets all rows to `unknown` on startup. A register call coming in during reconciliation lands a fresh `healthy` row and an event. Reconciliation completes around it without overwriting.                  |
-| External pillar tries to register as `finance` / `media` / etc. | 409 with `reason: 'pillar-id-reserved'`. The reserved list is the static in-tree `PILLARS` set at the time core-api was built.                                                                                                      |
-| Key rotation mid-flight (env var swap)                          | Internal pillars (`origin = 'internal'`) are unaffected — no key check. External pillars start getting 401 on heartbeat; they re-register with the new key. Brief window of `unavailable` in the dispatcher until reload settles.   |
-| nginx generator throws / `nginx -t` rejects the output          | Registration still completes (registry is the source of truth). Generator error is logged. Current `default.conf` stays in place. Next successful generation catches up. Health endpoint exposes `nginx_generator_last_error_at`.   |
-| External pillar deregisters while heartbeat is in flight        | Deregister DELETEs the row; the in-flight heartbeat lands on a row that's gone and returns `{ ok: false, reason: 'not-registered' }`. SDK on the external side stops sending heartbeats (it's mid-shutdown anyway).                 |
-| Subscription bus is down when registration succeeds             | Registration persists. Event emit failure is logged. nginx regen also runs off the event bus, so the regen is skipped; the next register / deregister catches up. PRD-163's recovery semantics apply.                              |
-| External pillar registers with a `baseUrl` core-api can't reach | Registration succeeds (no probe at registration time). nginx forwards traffic to a connection-refused upstream; clients see 502. Operator must fix the URL or deregister. Documented; not the registry's job to validate liveness.  |
+| Case                                                            | Behaviour                                                                                                                                                                                                                             |
+| --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| External pillar registers but never sends a heartbeat           | 30s after registration the lifecycle ticker flips it to `unavailable`. 5 minutes later the eviction ticker DELETEs the row + regenerates nginx. Subscription event includes `evicted_at` and `reason: 'never-heartbeated'`.           |
+| External pillar registers with a stale (rotated) key            | Registration uses whatever key is currently set in env, so success — but its heartbeat fails 401 because the heartbeat path validates `api_key_hash` against the current key. The pillar must re-register; SDK handles the 401.       |
+| Duplicate registration (same pillarId, same baseUrl, same key)  | UPSERT no-op semantics: `last_heartbeat_at` updated, manifest fields refreshed, `registered_at` preserved, no subscription event if the manifest is bytewise identical. nginx regen still triggered (debounced).                      |
+| Duplicate registration with different `baseUrl`                 | UPSERT overwrites. Subscription event fires. nginx regen runs and the dispatcher block now points at the new URL. The old URL stops receiving traffic on the next reload.                                                             |
+| Two external pillars race the same `pillarId`                   | SQLite serialises writes; whichever lands last wins. The loser's heartbeats start failing with `not-registered`. Operational misconfig; not the registry's job to mediate.                                                            |
+| External pillar registers during core-api boot reconciliation   | PRD-164's reconciliation sets all rows to `unknown` on startup. A register call coming in during reconciliation lands a fresh `healthy` row and an event. Reconciliation completes around it without overwriting.                     |
+| External pillar tries to register as `finance` / `media` / etc. | 409 with `reason: 'pillar-id-reserved'`. The reserved list is the static in-tree `PILLARS` set at the time core-api was built.                                                                                                        |
+| Key rotation mid-flight (env var swap)                          | Internal pillars (`origin = 'internal'`) are unaffected — no key check. External pillars start getting 401 on heartbeat; they re-register with the new key. Brief window of `unavailable` in the dispatcher until reload settles.     |
+| nginx generator throws / `nginx -t` rejects the output          | Registration still completes (registry is the source of truth). Generator error is logged. Current `default.conf` stays in place. Next successful generation catches up. Health endpoint exposes `nginx_generator_last_error_at`.     |
+| External pillar deregisters while heartbeat is in flight        | Deregister DELETEs the row; the in-flight heartbeat lands on a row that's gone and returns `{ ok: false, reason: 'not-registered' }`. SDK on the external side stops sending heartbeats (it's mid-shutdown anyway).                   |
+| Subscription bus is down when registration succeeds             | Registration persists. Event emit failure is logged. nginx regen also runs off the event bus, so the regen is skipped; the next register / deregister catches up. PRD-163's recovery semantics apply.                                 |
+| External pillar registers with a `baseUrl` core-api can't reach | Registration succeeds (no probe at registration time). nginx forwards traffic to a connection-refused upstream; clients see 502. Operator must fix the URL or deregister. Documented; not the registry's job to validate liveness.    |
 | Manifest schema bumps between SDK versions                      | If an external pillar registers with a manifest that's valid for an older schema, PRD-157's validator rejects it. ADR-031's coordinated-deploy guidance applies; external pillars track the published `@pops/pillar-contract` semver. |
 
 ## User Stories
 
-| #   | Story                                                                         | Summary                                                                                                                                  | Parallelisable                       |
-| --- | ----------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
-| 01  | [us-01-register-endpoint](us-01-register-endpoint.md)                         | Schema migration + `POST /core.registry.register` endpoint with key auth, manifest validation, UPSERT, and reserved-pillar-id rejection. | yes — independent                    |
-| 02  | [us-02-heartbeat-endpoint](us-02-heartbeat-endpoint.md)                       | `POST /core.registry.heartbeat` with key-hash verification, `not-registered` response path, and hard-eviction ticker for stale externals. | blocked by us-01                     |
-| 03  | [us-03-nginx-regen-integration](us-03-nginx-regen-integration.md)             | Wire the PRD-217 generator to registry events (register / deregister / evict); debounced regen + `nginx -t` + reload.                    | blocked by us-01 + PRD-217 generator |
-| 04  | [us-04-deregister-endpoint](us-04-deregister-endpoint.md)                     | `POST /core.registry.deregister` with key-hash verification, idempotent DELETE, and nginx regen trigger.                                 | blocked by us-01                     |
-| 05  | [us-05-e2e-external-pillar-dropin](us-05-e2e-external-pillar-dropin.md)       | End-to-end test: spin up a throwaway pillar container, register via the HTTP endpoint, hit it through the shell dispatcher, deregister.  | blocked by us-01..04                 |
+| #   | Story                                                                   | Summary                                                                                                                                   | Parallelisable                       |
+| --- | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
+| 01  | [us-01-register-endpoint](us-01-register-endpoint.md)                   | Schema migration + `POST /core.registry.register` endpoint with key auth, manifest validation, UPSERT, and reserved-pillar-id rejection.  | yes — independent                    |
+| 02  | [us-02-heartbeat-endpoint](us-02-heartbeat-endpoint.md)                 | `POST /core.registry.heartbeat` with key-hash verification, `not-registered` response path, and hard-eviction ticker for stale externals. | blocked by us-01                     |
+| 03  | [us-03-nginx-regen-integration](us-03-nginx-regen-integration.md)       | Wire the PRD-217 generator to registry events (register / deregister / evict); debounced regen + `nginx -t` + reload.                     | blocked by us-01 + PRD-217 generator |
+| 04  | [us-04-deregister-endpoint](us-04-deregister-endpoint.md)               | `POST /core.registry.deregister` with key-hash verification, idempotent DELETE, and nginx regen trigger.                                  | blocked by us-01                     |
+| 05  | [us-05-e2e-external-pillar-dropin](us-05-e2e-external-pillar-dropin.md) | End-to-end test: spin up a throwaway pillar container, register via the HTTP endpoint, hit it through the shell dispatcher, deregister.   | blocked by us-01..04                 |
+
+Status: US-01 / US-02 / US-04 done; US-03 + US-05 outstanding.
 
 ## Out of Scope
 

--- a/docs/themes/13-pillar-finale/prds/228-dynamic-pillar-registration/us-02-heartbeat-endpoint.md
+++ b/docs/themes/13-pillar-finale/prds/228-dynamic-pillar-registration/us-02-heartbeat-endpoint.md
@@ -10,14 +10,14 @@ if I stop heartbeating for long enough that the dispatcher should drop my route.
 
 ## Acceptance Criteria
 
-- [ ] `POST /core.registry.heartbeat` is served by `pops-core-api` and allow-listed in the shell `nginx.conf` alongside the register endpoint.
-- [ ] The handler validates `apiKey` via `crypto.timingSafeEqual` against `POPS_INTERNAL_API_KEY`. Mismatch returns 401 in constant time.
-- [ ] The handler verifies the stored `api_key_hash` matches `sha256(apiKey)` for that pillar row. Mismatch returns 401 (covers key rotation).
-- [ ] On success it updates `last_heartbeat_at = NOW()` and the row's status flips per PRD-162's lifecycle.
-- [ ] Zero rows updated returns `{ ok: false, reason: 'not-registered' }` (not a 404) so the external SDK can re-register cleanly.
-- [ ] A hard-eviction ticker runs every 30s inside core-api: rows with `origin = 'external'` AND `status = 'unavailable'` AND `status_updated_at` older than 5 minutes are DELETEd, `evicted_at` is set in the emitted event, and a subscription event `{ type: 'deregistered', pillarId, origin: 'external', reason: 'never-heartbeated' | 'lost-heartbeat' }` fires.
-- [ ] Internal pillars (`origin = 'internal'`) are never hard-evicted regardless of status.
-- [ ] Unit tests cover: happy heartbeat, bad key, rotated key (`api_key_hash` mismatch), heartbeat for missing row returns `not-registered`, ticker evicts only externals, ticker emits the correct event shape, ticker is a no-op when no rows qualify.
+- [x] `POST /core.registry.heartbeat` is served by `pops-core-api` and allow-listed in the shell `nginx.conf` alongside the register endpoint.
+- [x] The handler validates `apiKey` via `crypto.timingSafeEqual` against `POPS_INTERNAL_API_KEY`. Mismatch returns 401 in constant time.
+- [x] The handler verifies the stored `api_key_hash` matches `sha256(apiKey)` for that pillar row. Mismatch returns 401 (covers key rotation).
+- [x] On success it updates `last_heartbeat_at = NOW()` and the row's status flips per PRD-162's lifecycle.
+- [x] Zero rows updated returns `{ ok: false, reason: 'not-registered' }` (not a 404) so the external SDK can re-register cleanly.
+- [x] A hard-eviction ticker runs every 30s inside core-api: rows with `origin = 'external'` AND `status = 'unavailable'` AND `status_updated_at` older than 5 minutes are DELETEd, `evicted_at` is set in the emitted event, and a subscription event `{ type: 'deregistered', pillarId, origin: 'external', reason: 'never-heartbeated' | 'lost-heartbeat' }` fires.
+- [x] Internal pillars (`origin = 'internal'`) are never hard-evicted regardless of status.
+- [x] Unit tests cover: happy heartbeat, bad key, rotated key (`api_key_hash` mismatch), heartbeat for missing row returns `not-registered`, ticker evicts only externals, ticker emits the correct event shape, ticker is a no-op when no rows qualify.
 
 ## Notes
 

--- a/docs/themes/13-pillar-finale/prds/228-dynamic-pillar-registration/us-04-deregister-endpoint.md
+++ b/docs/themes/13-pillar-finale/prds/228-dynamic-pillar-registration/us-04-deregister-endpoint.md
@@ -11,14 +11,14 @@ missed-heartbeat → unavailable → eviction chain.
 
 ## Acceptance Criteria
 
-- [ ] `POST /core.registry.deregister` is served by `pops-core-api` and allow-listed in the shell `nginx.conf` alongside register + heartbeat.
-- [ ] The handler validates `apiKey` via `crypto.timingSafeEqual` against `POPS_INTERNAL_API_KEY`. Mismatch returns 401 in constant time.
-- [ ] The handler verifies the stored `api_key_hash` matches `sha256(apiKey)` for that pillar row. Mismatch returns 401.
-- [ ] DELETE is idempotent — calling deregister for a pillar that doesn't exist returns `{ ok: true }` with no event emitted.
-- [ ] On a real DELETE a `{ type: 'deregistered', pillarId, origin: 'external', reason: 'requested' }` subscription event fires.
-- [ ] nginx regeneration is triggered (US-03's hook).
-- [ ] Attempting to deregister an `origin = 'internal'` pillar via this endpoint returns 403 with `{ reason: 'internal-pillar-not-deregisterable-externally' }` — internal pillars manage their own lifecycle via the in-network `/trpc/` surface.
-- [ ] Unit tests cover: happy path, bad key, key-hash mismatch, idempotent DELETE of missing pillar, refusal to delete an internal pillar.
+- [x] `POST /core.registry.deregister` is served by `pops-core-api` and allow-listed in the shell `nginx.conf` alongside register + heartbeat.
+- [x] The handler validates `apiKey` via `crypto.timingSafeEqual` against `POPS_INTERNAL_API_KEY`. Mismatch returns 401 in constant time.
+- [x] The handler verifies the stored `api_key_hash` matches `sha256(apiKey)` for that pillar row. Mismatch returns 401.
+- [x] DELETE is idempotent — calling deregister for a pillar that doesn't exist returns `{ ok: true }` with no event emitted.
+- [x] On a real DELETE a `{ type: 'deregistered', pillarId, origin: 'external', reason: 'requested' }` subscription event fires.
+- [x] nginx regeneration is triggered (US-03's hook).
+- [x] Attempting to deregister an `origin = 'internal'` pillar via this endpoint returns 403 with `{ reason: 'internal-pillar-not-deregisterable-externally' }` — internal pillars manage their own lifecycle via the in-network `/trpc/` surface.
+- [x] Unit tests cover: happy path, bad key, key-hash mismatch, idempotent DELETE of missing pillar, refusal to delete an internal pillar.
 
 ## Notes
 


### PR DESCRIPTION
## Summary

- US-02 lands `POST /core.registry.heartbeat` plus a 30s eviction ticker that hard-evicts external pillars whose `status='unavailable'` has lasted past the 5-min threshold; internal pillars are explicitly never evicted.
- US-04 lands `POST /core.registry.deregister` — idempotent DELETE, refuses internal-origin rows with 403 `internal-pillar-not-deregisterable-externally` so the shared key can't be used to nuke in-tree pillars.
- Auth is the same constant-time `apiKey` + per-row `sha256(apiKey)` hash check used by register, shared via a new `auth.ts` to keep the three handlers DRY.
- Event bus payload grows optional `origin` / `reason` / `evictedAt` fields so PRD-163 subscribers can render the eviction diagnostics; existing emitters stay source-compatible.
- nginx allow-list regex extended to `^/core\.registry\.(register|heartbeat|deregister)$` via the `nginx-conf-template` so `gen:nginx:check` passes.

## Out of scope

- **US-03** — wiring the PRD-217 nginx generator to registry events. Depends on the generator's dynamic-source extension and is being picked up by a separate agent.
- **US-05** — end-to-end drop-in test with a throwaway external pillar container.

## Test plan

- [x] `pnpm test --filter @pops/core-api` — 110 passing (24 new across heartbeat, deregister, eviction-ticker).
- [x] `pnpm typecheck --filter @pops/core-api --filter @pops/shell`.
- [x] `pnpm --filter @pops/shell gen:nginx:check` — confirms the regex extension is in the committed `nginx.conf`.
- [ ] Manual smoke against a running stack once US-03 lands (heartbeat from a real external pillar through nginx → core-api).
