### PR TITLE
feat(shell): PRD-232 nginx generator dynamic-source mode (Wave 6 BE-lego)

### DIFF
--- a/apps/pops-shell/package.json
+++ b/apps/pops-shell/package.json
@@ -16,6 +16,7 @@
     "test:e2e:debug": "playwright test --debug",
     "gen:nginx": "tsx scripts/generate-nginx-conf.ts",
     "gen:nginx:check": "tsx scripts/generate-nginx-conf.ts --check",
+    "gen:nginx:dynamic": "tsx scripts/generate-nginx-conf.ts --dynamic",
     "registry:register": "tsx scripts/register-with-registry.ts"
   },
   "dependencies": {

--- a/apps/pops-shell/scripts/generate-nginx-conf.test.ts
+++ b/apps/pops-shell/scripts/generate-nginx-conf.test.ts
@@ -7,14 +7,31 @@ import { describe, expect, it } from 'vitest';
 import { PILLARS } from '@pops/pillar-sdk';
 
 import {
+  DEFAULT_REGISTRY_URL,
   PILLAR_RENDER_ORDER,
   PILLAR_UPSTREAMS,
   assertRenderOrderCoversAllPillars,
+  orderUpstreams,
+  parseCliArgsForGenerator,
   renderNginxConf,
+  renderNginxConfDynamic,
+  renderNginxConfFromUpstreams,
+  resolveUpstreamForEntry,
+  type PillarUpstream,
 } from './generate-nginx-conf.ts';
+import {
+  parseRegistryListResponse,
+  type RegistryFetcher,
+  type RegistryListEntry,
+  type RegistryListResponse,
+} from './nginx-registry-client.ts';
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const COMMITTED_CONF_PATH = resolve(SCRIPT_DIR, '..', 'nginx.conf');
+
+function makeFetcher(response: RegistryListResponse): RegistryFetcher {
+  return async () => response;
+}
 
 describe('generate-nginx-conf', () => {
   describe('drift detection', () => {
@@ -134,6 +151,233 @@ describe('generate-nginx-conf', () => {
   describe('assertRenderOrderCoversAllPillars (defensive)', () => {
     it('does not throw for the canonical order', () => {
       expect(() => assertRenderOrderCoversAllPillars()).not.toThrow();
+    });
+  });
+
+  describe('parseRegistryListResponse (PRD-232)', () => {
+    it('accepts a minimal well-formed response and drops unrelated fields', () => {
+      const parsed = parseRegistryListResponse({
+        pillars: [{ pillarId: 'finance', baseUrl: 'http://finance-api:3004', extra: 'ignored' }],
+        fetchedAt: '2026-06-13T00:00:00Z',
+      });
+      expect(parsed.pillars).toHaveLength(1);
+      expect(parsed.pillars[0]).toEqual({
+        pillarId: 'finance',
+        baseUrl: 'http://finance-api:3004',
+      });
+    });
+
+    it('accepts an empty pillars array (empty registry)', () => {
+      const parsed = parseRegistryListResponse({ pillars: [] });
+      expect(parsed.pillars).toEqual([]);
+    });
+
+    it('rejects payloads that are not objects', () => {
+      expect(() => parseRegistryListResponse(null)).toThrow(/not an object/);
+      expect(() => parseRegistryListResponse('nope')).toThrow(/not an object/);
+    });
+
+    it('rejects payloads missing the pillars array', () => {
+      expect(() => parseRegistryListResponse({})).toThrow(/missing `pillars`/);
+      expect(() => parseRegistryListResponse({ pillars: 'not-an-array' })).toThrow(
+        /missing `pillars`/
+      );
+    });
+
+    it('rejects entries with missing or empty pillarId / baseUrl', () => {
+      expect(() => parseRegistryListResponse({ pillars: [{ baseUrl: 'http://x:1' }] })).toThrow(
+        /pillarId/
+      );
+      expect(() =>
+        parseRegistryListResponse({ pillars: [{ pillarId: '', baseUrl: 'http://x:1' }] })
+      ).toThrow(/pillarId/);
+      expect(() => parseRegistryListResponse({ pillars: [{ pillarId: 'x' }] })).toThrow(/baseUrl/);
+      expect(() =>
+        parseRegistryListResponse({ pillars: [{ pillarId: 'x', baseUrl: '' }] })
+      ).toThrow(/baseUrl/);
+    });
+  });
+
+  describe('resolveUpstreamForEntry (PRD-232)', () => {
+    it('returns the canonical PILLAR_UPSTREAMS host:port for known pillars regardless of baseUrl', () => {
+      const entry: RegistryListEntry = {
+        pillarId: 'finance',
+        baseUrl: 'http://localhost:9999',
+      };
+      const upstream = resolveUpstreamForEntry(entry);
+      expect(upstream).toEqual({
+        pillarId: 'finance',
+        host: PILLAR_UPSTREAMS.finance.host,
+        port: PILLAR_UPSTREAMS.finance.port,
+      });
+    });
+
+    it('parses host:port from baseUrl for unknown pillars', () => {
+      const upstream = resolveUpstreamForEntry({
+        pillarId: 'plugin-fitness',
+        baseUrl: 'http://fitness-api:4200',
+      });
+      expect(upstream).toEqual({ pillarId: 'plugin-fitness', host: 'fitness-api', port: 4200 });
+    });
+
+    it('defaults port 80 for plain http baseUrl without explicit port', () => {
+      const upstream = resolveUpstreamForEntry({
+        pillarId: 'plugin-x',
+        baseUrl: 'http://x-api',
+      });
+      expect(upstream.port).toBe(80);
+    });
+
+    it('defaults port 443 for https baseUrl without explicit port', () => {
+      const upstream = resolveUpstreamForEntry({
+        pillarId: 'plugin-y',
+        baseUrl: 'https://y-api',
+      });
+      expect(upstream.port).toBe(443);
+    });
+
+    it('throws for malformed baseUrl on unknown pillars', () => {
+      expect(() =>
+        resolveUpstreamForEntry({ pillarId: 'plugin-bad', baseUrl: 'not a url' })
+      ).toThrow(/invalid baseUrl/);
+    });
+  });
+
+  describe('orderUpstreams (PRD-232)', () => {
+    it('places known pillars first in PILLAR_RENDER_ORDER, then unknowns alphabetically', () => {
+      const upstreams: PillarUpstream[] = [
+        { pillarId: 'plugin-z', host: 'z', port: 1 },
+        { pillarId: 'finance', host: 'finance-api', port: 3004 },
+        { pillarId: 'plugin-a', host: 'a', port: 1 },
+        { pillarId: 'core', host: 'core-api', port: 3001 },
+      ];
+      const ordered = orderUpstreams(upstreams).map((u) => u.pillarId);
+      expect(ordered).toEqual(['core', 'finance', 'plugin-a', 'plugin-z']);
+    });
+  });
+
+  describe('renderNginxConfFromUpstreams (PRD-232)', () => {
+    it('renders zero pillar blocks for an empty registry but keeps head + tail', () => {
+      const rendered = renderNginxConfFromUpstreams([]);
+      expect(rendered).not.toMatch(/location \/trpc-[a-z]/);
+      expect(rendered).toContain('resolver 127.0.0.11');
+      expect(rendered).toContain('location /trpc {');
+      expect(rendered).toContain('location ~ ^/pillars/?$ {');
+      expect(rendered).toContain('location /docs/ {');
+      expect(rendered).toMatch(/location \/ \{[\s\S]*?try_files \$uri \$uri\/ \/index\.html;/);
+    });
+
+    it('handles hyphenated pillar ids by sanitising the nginx variable name', () => {
+      const rendered = renderNginxConfFromUpstreams([
+        { pillarId: 'plugin-fitness', host: 'fitness-api', port: 4200 },
+      ]);
+      expect(rendered).toContain('location /trpc-plugin-fitness/ {');
+      expect(rendered).toContain('set $trpc_plugin_fitness_upstream http://fitness-api:4200;');
+      expect(rendered).toContain('proxy_pass $trpc_plugin_fitness_upstream;');
+    });
+  });
+
+  describe('renderNginxConfDynamic (PRD-232)', () => {
+    it('emits a config that mirrors the static output when the registry advertises every known pillar', async () => {
+      const fetcher = makeFetcher({
+        pillars: PILLARS.map((id) => ({
+          pillarId: id,
+          baseUrl: `http://${PILLAR_UPSTREAMS[id].host}:${PILLAR_UPSTREAMS[id].port}`,
+        })),
+      });
+      const rendered = await renderNginxConfDynamic('http://core-api:3001', fetcher);
+      expect(rendered).toBe(renderNginxConf());
+    });
+
+    it('emits zero pillar blocks for an empty registry (snapshot)', async () => {
+      const rendered = await renderNginxConfDynamic(
+        'http://core-api:3001',
+        makeFetcher({ pillars: [] })
+      );
+      for (const id of PILLARS) {
+        expect(rendered).not.toContain(`location /trpc-${id}/ {`);
+      }
+      expect(rendered).toContain('location /trpc {');
+    });
+
+    it('renders a single external pillar with parsed host:port', async () => {
+      const fetcher = makeFetcher({
+        pillars: [{ pillarId: 'plugin-fitness', baseUrl: 'http://fitness-api:4242' }],
+      });
+      const rendered = await renderNginxConfDynamic('http://core-api:3001', fetcher);
+      expect(rendered).toContain('location /trpc-plugin-fitness/ {');
+      expect(rendered).toContain('set $trpc_plugin_fitness_upstream http://fitness-api:4242;');
+      expect(rendered).not.toContain('location /trpc-finance/ {');
+    });
+
+    it('mixes known + external pillars and orders known first', async () => {
+      const fetcher = makeFetcher({
+        pillars: [
+          { pillarId: 'plugin-fitness', baseUrl: 'http://fitness-api:4242' },
+          { pillarId: 'finance', baseUrl: 'http://localhost:9999' },
+        ],
+      });
+      const rendered = await renderNginxConfDynamic('http://core-api:3001', fetcher);
+      const financeIdx = rendered.indexOf('location /trpc-finance/ {');
+      const fitnessIdx = rendered.indexOf('location /trpc-plugin-fitness/ {');
+      expect(financeIdx).toBeGreaterThan(-1);
+      expect(fitnessIdx).toBeGreaterThan(-1);
+      expect(financeIdx).toBeLessThan(fitnessIdx);
+      const { host, port } = PILLAR_UPSTREAMS.finance;
+      expect(rendered).toContain(`set $trpc_finance_upstream http://${host}:${port};`);
+    });
+
+    it('is deterministic — fetcher returning the same payload yields byte-identical output', async () => {
+      const payload: RegistryListResponse = {
+        pillars: [
+          { pillarId: 'finance', baseUrl: 'http://finance-api:3004' },
+          { pillarId: 'plugin-z', baseUrl: 'http://z:1' },
+        ],
+      };
+      const a = await renderNginxConfDynamic('http://core-api:3001', makeFetcher(payload));
+      const b = await renderNginxConfDynamic('http://core-api:3001', makeFetcher(payload));
+      expect(a).toBe(b);
+    });
+  });
+
+  describe('parseCliArgs (PRD-232)', () => {
+    it('defaults: static mode, default output, default registry url', () => {
+      const opts = parseCliArgsForGenerator([]);
+      expect(opts.dynamic).toBe(false);
+      expect(opts.check).toBe(false);
+      expect(opts.registryUrl).toBe(process.env['CORE_REGISTRY_URL'] ?? DEFAULT_REGISTRY_URL);
+    });
+
+    it('parses --dynamic', () => {
+      expect(parseCliArgsForGenerator(['--dynamic']).dynamic).toBe(true);
+    });
+
+    it('parses --check', () => {
+      expect(parseCliArgsForGenerator(['--check']).check).toBe(true);
+    });
+
+    it('parses --registry-url with a separate value', () => {
+      const opts = parseCliArgsForGenerator(['--registry-url', 'http://other:9000']);
+      expect(opts.registryUrl).toBe('http://other:9000');
+    });
+
+    it('parses --registry-url=… inline', () => {
+      const opts = parseCliArgsForGenerator(['--registry-url=http://inline:1234']);
+      expect(opts.registryUrl).toBe('http://inline:1234');
+    });
+
+    it('parses --out with a separate path and --out= inline', () => {
+      expect(parseCliArgsForGenerator(['--out', '/tmp/a.conf']).outputPath).toBe('/tmp/a.conf');
+      expect(parseCliArgsForGenerator(['--out=/tmp/b.conf']).outputPath).toBe('/tmp/b.conf');
+    });
+
+    it('throws on unknown flags', () => {
+      expect(() => parseCliArgsForGenerator(['--what'])).toThrow(/unknown argument/);
+    });
+
+    it('throws when --registry-url has no value', () => {
+      expect(() => parseCliArgsForGenerator(['--registry-url'])).toThrow(/--registry-url/);
+      expect(() => parseCliArgsForGenerator(['--registry-url='])).toThrow(/non-empty URL/);
     });
   });
 });

--- a/apps/pops-shell/scripts/generate-nginx-conf.ts
+++ b/apps/pops-shell/scripts/generate-nginx-conf.ts
@@ -2,39 +2,56 @@
 /**
  * Generate `apps/pops-shell/nginx.conf` from a single source of truth.
  *
- * Theme 13 PRD-217. Before this script, adding a new pillar required
- * hand-editing the `location /trpc-<pillar>/ { … }` block in `nginx.conf`,
- * which left two registries (the SDK's `PILLARS` constant and the nginx
- * config) free to drift apart. The generator collapses that into one:
- * it reads `PILLARS` from `@pops/pillar-sdk`, pairs each id with its
- * upstream `host:port` from `PILLAR_UPSTREAMS` below, and renders the
- * full server block deterministically.
+ * Theme 13 PRD-217 + PRD-232. Two render modes share the same template:
  *
- * Scope, intentionally narrow (PRD-217 phase 1):
- *   - Same shape as the committed hand-written conf — same `/trpc-<id>/`
- *     dispatchers, same `/trpc` fallback, same `/pillars*`, `/media/images/`,
- *     `/health`, `/docs/`, and SPA fallback blocks.
- *   - Only the canonical seven pillars from `PILLARS` (`core`, `finance`,
- *     `media`, `inventory`, `cerebrum`, `food`, `lists`).
- *   - No external/dynamic pillar registration. That's the follow-up.
+ *   - **Static** (default) — reads `PILLARS` from `@pops/pillar-sdk` and
+ *     `PILLAR_UPSTREAMS` below. Used at image-build time so the committed
+ *     `nginx.conf` is reproducible without a live core-api. The drift
+ *     test guards this output.
  *
- * The drift-detection test (`generate-nginx-conf.test.ts`) renders the
- * config in-memory and compares against the committed file, so any
- * hand-edit to `nginx.conf` that diverges from the generator output
- * fails CI. The generator is the single source of truth.
+ *   - **Dynamic** (`--dynamic`) — PRD-232, Wave 6 BE-lego. Reads the
+ *     live `pillar_registry` via `core.registry.list` (HTTP tRPC GET)
+ *     and emits one `/trpc-<pillar>/` block per registered pillar. Used
+ *     at boot-time inside the cluster: an init container (or a future
+ *     subscription-bus watcher, PRD-163) runs the script with
+ *     `--dynamic` so newly-registered external pillars (PRD-228) pick
+ *     up routing without a fresh shell image.
+ *
+ *     Known core pillars (those in `PILLAR_UPSTREAMS`) keep their
+ *     canonical docker `host:port` even when the registry advertises a
+ *     different `baseUrl`; this protects the in-cluster routing from
+ *     drift if a pillar registers itself with a `localhost`-shaped URL
+ *     during development. Unknown pillars fall back to parsing
+ *     `host:port` out of their registry `baseUrl`.
+ *
+ * The drift-detection test renders the static mode in-memory and
+ * compares against the committed file. The dynamic mode is exercised
+ * with an injected registry fetcher so the test suite never needs a
+ * live core-api.
  *
  * Usage:
- *   pnpm gen:nginx                  # writes apps/pops-shell/nginx.conf
- *   pnpm gen:nginx:check            # exits 1 if the committed file drifts
- *   tsx generate-nginx-conf.ts ...  # equivalent direct invocation
+ *   pnpm gen:nginx                              # static, writes apps/pops-shell/nginx.conf
+ *   pnpm gen:nginx:check                        # static, exits 1 on drift
+ *   pnpm gen:nginx:dynamic                      # dynamic, renders from live registry
+ *   tsx generate-nginx-conf.ts --dynamic --out … --registry-url=http://core-api:3001
+ *
+ * The event-driven `nginx -s reload` wrapper that re-runs the dynamic
+ * mode on each `core.registry` subscription event is intentionally NOT
+ * shipped here; see PRD-163 follow-up.
  */
-import { readFile, writeFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { PILLARS, type KnownPillarId } from '@pops/pillar-sdk';
 
+import { parseCliArgs, type CliOptions } from './nginx-cli-args.ts';
+import { assertDynamicNotCheck, runDynamic, runStatic } from './nginx-cli-main.ts';
 import { NGINX_CONF_HEAD, NGINX_CONF_TAIL } from './nginx-conf-template.ts';
+import {
+  fetchRegistryViaTrpc,
+  type RegistryFetcher,
+  type RegistryListEntry,
+} from './nginx-registry-client.ts';
 
 /**
  * Internal port assignment for each pillar's API container. Matches every
@@ -69,6 +86,14 @@ const PILLAR_RENDER_ORDER: readonly KnownPillarId[] = [
   'cerebrum',
 ];
 
+const DEFAULT_REGISTRY_URL = 'http://core-api:3001';
+
+export interface PillarUpstream {
+  readonly pillarId: string;
+  readonly host: string;
+  readonly port: number;
+}
+
 function assertRenderOrderCoversAllPillars(): void {
   const ordered = new Set<KnownPillarId>(PILLAR_RENDER_ORDER);
   const missing = PILLARS.filter((id) => !ordered.has(id));
@@ -88,100 +113,152 @@ function assertRenderOrderCoversAllPillars(): void {
   }
 }
 
-function renderPillarBlock(id: KnownPillarId): string {
-  const upstream = PILLAR_UPSTREAMS[id];
+function isKnownPillarId(id: string): id is KnownPillarId {
+  return (PILLARS as readonly string[]).includes(id);
+}
+
+function nginxVarName(pillarId: string): string {
+  return pillarId.replace(/-/g, '_');
+}
+
+function renderPillarBlockFromUpstream(upstream: PillarUpstream): string {
+  const varName = nginxVarName(upstream.pillarId);
   return [
-    `    location /trpc-${id}/ {`,
-    `        rewrite ^/trpc-${id}/(.*)$ /trpc/$1 break;`,
-    `        set $trpc_${id}_upstream http://${upstream.host}:${upstream.port};`,
-    `        proxy_pass $trpc_${id}_upstream;`,
+    `    location /trpc-${upstream.pillarId}/ {`,
+    `        rewrite ^/trpc-${upstream.pillarId}/(.*)$ /trpc/$1 break;`,
+    `        set $trpc_${varName}_upstream http://${upstream.host}:${upstream.port};`,
+    `        proxy_pass $trpc_${varName}_upstream;`,
     `        include /etc/nginx/snippets/_pillar-proxy.conf;`,
     `    }`,
   ].join('\n');
 }
 
+function renderPillarBlock(id: KnownPillarId): string {
+  const upstream = PILLAR_UPSTREAMS[id];
+  return renderPillarBlockFromUpstream({ pillarId: id, host: upstream.host, port: upstream.port });
+}
+
 /**
- * Pure renderer. Takes the ordered pillar list and returns the full
- * `nginx.conf` body. Exported so the drift-detection test can call it
- * without touching the filesystem.
+ * Pure renderer (static mode). Takes the ordered pillar list and returns
+ * the full `nginx.conf` body. Exported so the drift-detection test can
+ * call it without touching the filesystem.
  */
 export function renderNginxConf(order: readonly KnownPillarId[] = PILLAR_RENDER_ORDER): string {
   const pillarBlocks = order.map(renderPillarBlock).join('\n\n');
   return `${NGINX_CONF_HEAD}\n${pillarBlocks}\n\n${NGINX_CONF_TAIL}`;
 }
 
+/**
+ * Pure renderer (dynamic mode). Takes an explicit list of upstreams in
+ * the order they should appear in the output. Empty input is valid and
+ * produces a config with zero `/trpc-<pillar>/` dispatchers (the legacy
+ * `/trpc` catch-all in the tail still routes to pops-api).
+ */
+export function renderNginxConfFromUpstreams(upstreams: readonly PillarUpstream[]): string {
+  if (upstreams.length === 0) {
+    return `${NGINX_CONF_HEAD}\n${NGINX_CONF_TAIL}`;
+  }
+  const pillarBlocks = upstreams.map(renderPillarBlockFromUpstream).join('\n\n');
+  return `${NGINX_CONF_HEAD}\n${pillarBlocks}\n\n${NGINX_CONF_TAIL}`;
+}
+
+/**
+ * Map a registry entry to its `host:port` pair.
+ *
+ * For known pillars (those baked into `PILLAR_UPSTREAMS`) the canonical
+ * in-cluster upstream wins — registering with a localhost URL during
+ * development must not break docker-network routing. Unknown pillars
+ * fall back to parsing the registry's `baseUrl`.
+ */
+export function resolveUpstreamForEntry(entry: RegistryListEntry): PillarUpstream {
+  if (isKnownPillarId(entry.pillarId)) {
+    const known = PILLAR_UPSTREAMS[entry.pillarId];
+    return { pillarId: entry.pillarId, host: known.host, port: known.port };
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(entry.baseUrl);
+  } catch {
+    throw new Error(
+      `generate-nginx-conf: pillar "${entry.pillarId}" has invalid baseUrl "${entry.baseUrl}"`
+    );
+  }
+  if (parsed.hostname.length === 0) {
+    throw new Error(
+      `generate-nginx-conf: pillar "${entry.pillarId}" baseUrl "${entry.baseUrl}" has no host`
+    );
+  }
+  const defaultPort = parsed.protocol === 'https:' ? '443' : '80';
+  const portString = parsed.port.length > 0 ? parsed.port : defaultPort;
+  const port = Number.parseInt(portString, 10);
+  if (!Number.isInteger(port) || port <= 0) {
+    throw new Error(
+      `generate-nginx-conf: pillar "${entry.pillarId}" baseUrl "${entry.baseUrl}" has invalid port`
+    );
+  }
+  return { pillarId: entry.pillarId, host: parsed.hostname, port };
+}
+
+/**
+ * Sort entries deterministically for stable rendered output. Known
+ * pillars appear first in `PILLAR_RENDER_ORDER`, then any unknown ones
+ * in ascending alphabetical order by pillarId.
+ */
+export function orderUpstreams(upstreams: readonly PillarUpstream[]): readonly PillarUpstream[] {
+  const indexOf = new Map<string, number>();
+  PILLAR_RENDER_ORDER.forEach((id, i) => indexOf.set(id, i));
+  return upstreams.toSorted((a, b) => {
+    const ia = indexOf.get(a.pillarId);
+    const ib = indexOf.get(b.pillarId);
+    if (ia !== undefined && ib !== undefined) return ia - ib;
+    if (ia !== undefined) return -1;
+    if (ib !== undefined) return 1;
+    return a.pillarId.localeCompare(b.pillarId, 'en');
+  });
+}
+
+export async function renderNginxConfDynamic(
+  registryUrl: string,
+  fetcher: RegistryFetcher = fetchRegistryViaTrpc
+): Promise<string> {
+  const response = await fetcher(registryUrl);
+  const upstreams = response.pillars.map(resolveUpstreamForEntry);
+  const ordered = orderUpstreams(upstreams);
+  return renderNginxConfFromUpstreams(ordered);
+}
+
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const DEFAULT_OUTPUT_PATH = resolve(SCRIPT_DIR, '..', 'nginx.conf');
 
-interface CliOptions {
-  outputPath: string;
-  check: boolean;
+function cliDefaults(): { outputPath: string; registryUrl: string } {
+  return {
+    outputPath: DEFAULT_OUTPUT_PATH,
+    registryUrl: process.env['CORE_REGISTRY_URL'] ?? DEFAULT_REGISTRY_URL,
+  };
 }
 
-function parseCliArgs(argv: readonly string[]): CliOptions {
-  let outputPath: string = DEFAULT_OUTPUT_PATH;
-  let check = false;
-  for (let i = 0; i < argv.length; i += 1) {
-    const arg = argv[i];
-    if (arg === '--check') {
-      check = true;
-      continue;
-    }
-    if (arg === '--out') {
-      const next = argv[i + 1];
-      if (next === undefined) {
-        throw new Error('generate-nginx-conf: --out requires a path argument');
-      }
-      outputPath = resolve(next);
-      i += 1;
-      continue;
-    }
-    if (arg !== undefined && !arg.startsWith('--')) {
-      outputPath = resolve(arg);
-      continue;
-    }
-    throw new Error(`generate-nginx-conf: unknown argument "${String(arg)}"`);
-  }
-  return { outputPath, check };
-}
-
-async function runCheck(outputPath: string, expected: string): Promise<void> {
-  let actual: string;
-  try {
-    actual = await readFile(outputPath, 'utf8');
-  } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : String(err);
-    process.stderr.write(`generate-nginx-conf --check: cannot read ${outputPath}: ${message}\n`);
-    process.exit(1);
-    return;
-  }
-  if (actual !== expected) {
-    process.stderr.write(
-      `generate-nginx-conf --check: ${outputPath} is out of date.\n` +
-        `Run \`pnpm gen:nginx\` and commit the result.\n`
-    );
-    process.exit(1);
-    return;
-  }
-  process.stdout.write(`generate-nginx-conf --check: ${outputPath} is up to date.\n`);
+export function parseCliArgsForGenerator(argv: readonly string[]): CliOptions {
+  return parseCliArgs(argv, cliDefaults());
 }
 
 async function main(): Promise<void> {
   assertRenderOrderCoversAllPillars();
-  const { outputPath, check } = parseCliArgs(process.argv.slice(2));
-  const expected = renderNginxConf();
-
-  if (check) {
-    await runCheck(outputPath, expected);
+  const opts = parseCliArgsForGenerator(process.argv.slice(2));
+  assertDynamicNotCheck(opts);
+  if (opts.dynamic) {
+    await runDynamic({
+      outputPath: opts.outputPath,
+      registryUrl: opts.registryUrl,
+      render: renderNginxConfDynamic,
+    });
     return;
   }
-
-  await writeFile(outputPath, expected, 'utf8');
-  process.stdout.write(
-    `generate-nginx-conf: wrote ${PILLAR_RENDER_ORDER.length} pillar block${
-      PILLAR_RENDER_ORDER.length === 1 ? '' : 's'
-    } → ${outputPath}\n`
-  );
+  await runStatic({
+    outputPath: opts.outputPath,
+    check: opts.check,
+    expected: renderNginxConf(),
+    pillarCount: PILLAR_RENDER_ORDER.length,
+  });
 }
 
 const invokedAsScript =
@@ -195,4 +272,9 @@ if (invokedAsScript) {
   });
 }
 
-export { PILLAR_UPSTREAMS, PILLAR_RENDER_ORDER, assertRenderOrderCoversAllPillars };
+export {
+  PILLAR_UPSTREAMS,
+  PILLAR_RENDER_ORDER,
+  DEFAULT_REGISTRY_URL,
+  assertRenderOrderCoversAllPillars,
+};

--- a/apps/pops-shell/scripts/nginx-cli-args.ts
+++ b/apps/pops-shell/scripts/nginx-cli-args.ts
@@ -1,0 +1,120 @@
+/**
+ * CLI argument parser for `generate-nginx-conf.ts` (Theme 13 PRD-217 +
+ * PRD-232). Split out so the generator's renderer stays small and the
+ * complexity budget of `parseCliArgs` does not grow with every new flag.
+ *
+ * The parser is intentionally hand-written (no commander/yargs) because
+ * the surface is tiny and pulling in a CLI framework for four flags is
+ * not worth the dep weight.
+ */
+import { resolve } from 'node:path';
+
+export interface CliOptions {
+  outputPath: string;
+  check: boolean;
+  dynamic: boolean;
+  registryUrl: string;
+}
+
+export interface CliDefaults {
+  outputPath: string;
+  registryUrl: string;
+}
+
+function parseInlineFlagValue(arg: string, prefix: string): string | undefined {
+  if (!arg.startsWith(`${prefix}=`)) return undefined;
+  return arg.slice(prefix.length + 1);
+}
+
+function readValueAfter(argv: readonly string[], i: number, flag: string): string {
+  const next = argv[i + 1];
+  if (next === undefined) {
+    throw new Error(`generate-nginx-conf: ${flag} requires a value`);
+  }
+  return next;
+}
+
+interface Cursor {
+  index: number;
+  readonly options: CliOptions;
+}
+
+function handleSimpleFlag(arg: string, cursor: Cursor): boolean {
+  if (arg === '--check') {
+    cursor.options.check = true;
+    return true;
+  }
+  if (arg === '--dynamic') {
+    cursor.options.dynamic = true;
+    return true;
+  }
+  return false;
+}
+
+function handleValuedFlag(arg: string, argv: readonly string[], cursor: Cursor): boolean {
+  if (arg === '--out') {
+    cursor.options.outputPath = resolve(readValueAfter(argv, cursor.index, '--out'));
+    cursor.index += 1;
+    return true;
+  }
+  if (arg === '--registry-url') {
+    cursor.options.registryUrl = readValueAfter(argv, cursor.index, '--registry-url');
+    cursor.index += 1;
+    return true;
+  }
+  return false;
+}
+
+function handleInlineFlag(arg: string, cursor: Cursor): boolean {
+  const inlineOut = parseInlineFlagValue(arg, '--out');
+  if (inlineOut !== undefined) {
+    if (inlineOut.length === 0) {
+      throw new Error('generate-nginx-conf: --out= requires a non-empty path');
+    }
+    cursor.options.outputPath = resolve(inlineOut);
+    return true;
+  }
+  const inlineUrl = parseInlineFlagValue(arg, '--registry-url');
+  if (inlineUrl !== undefined) {
+    if (inlineUrl.length === 0) {
+      throw new Error('generate-nginx-conf: --registry-url= requires a non-empty URL');
+    }
+    cursor.options.registryUrl = inlineUrl;
+    return true;
+  }
+  return false;
+}
+
+export function parseCliArgs(argv: readonly string[], defaults: CliDefaults): CliOptions {
+  const cursor: Cursor = {
+    index: 0,
+    options: {
+      outputPath: defaults.outputPath,
+      check: false,
+      dynamic: false,
+      registryUrl: defaults.registryUrl,
+    },
+  };
+  while (cursor.index < argv.length) {
+    const arg = argv[cursor.index];
+    if (arg === undefined) {
+      cursor.index += 1;
+      continue;
+    }
+    if (
+      handleSimpleFlag(arg, cursor) ||
+      handleValuedFlag(arg, argv, cursor) ||
+      handleInlineFlag(arg, cursor)
+    ) {
+      cursor.index += 1;
+      continue;
+    }
+    if (!arg.startsWith('--')) {
+      cursor.options.outputPath = resolve(arg);
+      cursor.index += 1;
+      continue;
+    }
+    throw new Error(`generate-nginx-conf: unknown argument "${arg}"`);
+  }
+  return cursor.options;
+}

--- a/apps/pops-shell/scripts/nginx-cli-main.ts
+++ b/apps/pops-shell/scripts/nginx-cli-main.ts
@@ -1,0 +1,69 @@
+/**
+ * CLI entry-point helpers for `generate-nginx-conf.ts` (Theme 13 PRD-217
+ * + PRD-232). Lives in a sibling file so the renderer module stays under
+ * the 200-line budget and so the main-loop logic can be unit-tested
+ * without forking a subprocess.
+ */
+import { readFile, writeFile } from 'node:fs/promises';
+
+import { type CliOptions } from './nginx-cli-args.ts';
+
+export interface StaticRunDeps {
+  readonly outputPath: string;
+  readonly check: boolean;
+  readonly expected: string;
+  readonly pillarCount: number;
+}
+
+export interface DynamicRunDeps {
+  readonly outputPath: string;
+  readonly registryUrl: string;
+  readonly render: (registryUrl: string) => Promise<string>;
+}
+
+async function runCheck(outputPath: string, expected: string): Promise<void> {
+  let actual: string;
+  try {
+    actual = await readFile(outputPath, 'utf8');
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`generate-nginx-conf --check: cannot read ${outputPath}: ${message}\n`);
+    process.exit(1);
+    return;
+  }
+  if (actual !== expected) {
+    process.stderr.write(
+      `generate-nginx-conf --check: ${outputPath} is out of date.\n` +
+        `Run \`pnpm gen:nginx\` and commit the result.\n`
+    );
+    process.exit(1);
+    return;
+  }
+  process.stdout.write(`generate-nginx-conf --check: ${outputPath} is up to date.\n`);
+}
+
+export async function runStatic(deps: StaticRunDeps): Promise<void> {
+  if (deps.check) {
+    await runCheck(deps.outputPath, deps.expected);
+    return;
+  }
+  await writeFile(deps.outputPath, deps.expected, 'utf8');
+  const noun = deps.pillarCount === 1 ? 'block' : 'blocks';
+  process.stdout.write(
+    `generate-nginx-conf: wrote ${deps.pillarCount} pillar ${noun} → ${deps.outputPath}\n`
+  );
+}
+
+export async function runDynamic(deps: DynamicRunDeps): Promise<void> {
+  const rendered = await deps.render(deps.registryUrl);
+  await writeFile(deps.outputPath, rendered, 'utf8');
+  process.stdout.write(
+    `generate-nginx-conf --dynamic: wrote conf from ${deps.registryUrl} → ${deps.outputPath}\n`
+  );
+}
+
+export function assertDynamicNotCheck(opts: CliOptions): void {
+  if (opts.dynamic && opts.check) {
+    throw new Error('generate-nginx-conf: --check is not supported with --dynamic');
+  }
+}

--- a/apps/pops-shell/scripts/nginx-registry-client.ts
+++ b/apps/pops-shell/scripts/nginx-registry-client.ts
@@ -1,0 +1,72 @@
+/**
+ * Registry client used by the `--dynamic` mode of
+ * `generate-nginx-conf.ts` (Theme 13 PRD-232).
+ *
+ * Defines the wire schema for `core.registry.list` (just enough to keep
+ * the nginx generator happy — pillarId + baseUrl), a hand-rolled type
+ * guard, and a tRPC HTTP GET adapter. Lives in its own module so the
+ * generator stays focused on rendering and so the test suite can swap
+ * in an in-memory fetcher without touching the network.
+ */
+
+export interface RegistryListEntry {
+  readonly pillarId: string;
+  readonly baseUrl: string;
+}
+
+export interface RegistryListResponse {
+  readonly pillars: readonly RegistryListEntry[];
+}
+
+export type RegistryFetcher = (registryUrl: string) => Promise<RegistryListResponse>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function parseEntry(raw: unknown, index: number): RegistryListEntry {
+  if (!isRecord(raw)) {
+    throw new Error(`registry response pillars[${index}] is not an object`);
+  }
+  const { pillarId, baseUrl } = raw;
+  if (typeof pillarId !== 'string' || pillarId.length === 0) {
+    throw new Error(`registry response pillars[${index}].pillarId is not a non-empty string`);
+  }
+  if (typeof baseUrl !== 'string' || baseUrl.length === 0) {
+    throw new Error(`registry response pillars[${index}].baseUrl is not a non-empty string`);
+  }
+  return { pillarId, baseUrl };
+}
+
+export function parseRegistryListResponse(payload: unknown): RegistryListResponse {
+  if (!isRecord(payload)) {
+    throw new Error('registry response is not an object');
+  }
+  const pillars = payload['pillars'];
+  if (!Array.isArray(pillars)) {
+    throw new Error('registry response is missing `pillars` array');
+  }
+  return { pillars: pillars.map(parseEntry) };
+}
+
+/**
+ * tRPC HTTP GET adapter for `core.registry.list`. tRPC encodes a no-input
+ * query as `?input=%7B%7D`; the procedure returns `{ result: { data: … } }`.
+ */
+export async function fetchRegistryViaTrpc(registryUrl: string): Promise<RegistryListResponse> {
+  const base = registryUrl.replace(/\/+$/, '');
+  const url = `${base}/trpc/core.registry.list?input=${encodeURIComponent('{}')}`;
+  const res = await fetch(url, { headers: { accept: 'application/json' } });
+  if (!res.ok) {
+    throw new Error(`registry fetch failed: ${res.status} ${res.statusText} for ${url}`);
+  }
+  const body: unknown = await res.json();
+  if (!isRecord(body)) {
+    throw new Error('registry response body is not an object');
+  }
+  const result = body['result'];
+  if (!isRecord(result)) {
+    throw new Error('registry response is missing `result`');
+  }
+  return parseRegistryListResponse(result['data']);
+}


### PR DESCRIPTION
## Summary

- **PRD-232 Wave 6 BE-lego**: extends the PRD-217 nginx generator with a `--dynamic` mode that reads the live `pillar_registry` (populated by PRD-228 US-01 register endpoint, US-02/04 heartbeat + deregister) via `core.registry.list` instead of the static SDK `PILLARS` constant.
- Static mode stays the default for image-build reproducibility; the drift test still guards the committed `nginx.conf`. Dynamic mode is opt-in via `--dynamic`.
- New `gen:nginx:dynamic` pnpm script; new `--registry-url=` / env `CORE_REGISTRY_URL` (default `http://core-api:3001`).

## Approach

- Pure renderer takes a list of `{ pillarId, host, port }` and emits the same `/trpc-<pillar>/` block format as the static path. Empty registry → zero dispatcher blocks but head + tail intact (the legacy `/trpc` catch-all still routes to pops-api).
- Dynamic renderer takes a `RegistryFetcher` injection so the test suite never needs a live core-api. Default fetcher is a tRPC HTTP GET adapter against `/trpc/core.registry.list?input=%7B%7D`.
- Known core pillars (`PILLAR_UPSTREAMS`) keep their canonical docker `host:port` even when the registry advertises a divergent `baseUrl` — protects in-cluster routing from devbox `localhost` registrations. Unknown pillars fall back to parsing `baseUrl`.
- Pillars rendered deterministically: known ones first in `PILLAR_RENDER_ORDER`, then unknowns alphabetically.
- CLI parsing, registry client, and main-loop helpers split into sibling modules (`nginx-cli-args.ts`, `nginx-cli-main.ts`, `nginx-registry-client.ts`) so the renderer stays under the 200-line budget.

## Tests

- Total in the file: **43** (was 19). New coverage:
  - Wire-schema validator: well-formed, empty, malformed payloads.
  - `resolveUpstreamForEntry`: known-pillar override, baseUrl parsing for unknowns, http/https default ports, malformed-URL rejection.
  - `orderUpstreams`: known-first, then alpha.
  - `renderNginxConfFromUpstreams`: empty-registry snapshot, hyphenated pillar id → sanitised nginx variable name.
  - `renderNginxConfDynamic`: registry advertising all known pillars produces byte-identical output to static mode, empty registry snapshot, single external pillar, mixed known+external ordering, determinism.
  - `parseCliArgs`: defaults, `--dynamic`, `--check`, `--registry-url` (separate + inline), `--out` (separate + inline), unknown-flag rejection, missing-value rejection.

## Out of scope (follow-up)

- Event-driven `nginx -s reload` wrapper that watches the PRD-163 `core.registry` subscription bus and re-runs the dynamic mode on each register / deregister / health-changed event. The current PR ships the `--dynamic` flag + tRPC fetch; the eventer is a one-PR follow-up.

## Test plan

- [x] `pnpm vitest run generate-nginx-conf` — 43 / 43 pass
- [x] `pnpm gen:nginx:check` — no drift between committed `nginx.conf` and the template
- [x] `pnpm gen:nginx` rewrite produces a byte-identical file
- [x] `tsx generate-nginx-conf.ts --dynamic --out /tmp/x --registry-url=http://127.0.0.1:1` fails cleanly with `fetch failed` (registry unreachable)
- [x] `oxlint` + `oxfmt` clean on every new/modified file
- [x] Husky pre-commit + pre-push chain ran in full
