### PR TITLE
feat(app-media): migrate second batch of tRPC sites to pillar SDK (PRD-227)

### DIFF
--- a/packages/app-media/src/components/MovieActionButtons.tsx
+++ b/packages/app-media/src/components/MovieActionButtons.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { trpc } from '@pops/api-client';
+import { usePillarQuery } from '@pops/pillar-sdk/react';
 /**
  * MovieActionButtons — conditional action buttons for non-library movies.
  *
@@ -15,6 +15,10 @@ import { QueueActionButtons } from './movie-action-buttons/QueueActionButtons';
 import { ExcludedButton, InQueueButton } from './movie-action-buttons/StatusButtons';
 import { useRotationButtonsModel } from './movie-action-buttons/useRotationButtonsModel';
 import { RequestMovieButton } from './RequestMovieButton';
+
+interface RotationStatusResult {
+  isRunning: boolean;
+}
 
 type ButtonVariant = 'standard' | 'compact';
 
@@ -35,7 +39,11 @@ export function MovieActionButtons({
   rating,
   variant = 'standard',
 }: MovieActionButtonsProps) {
-  const { data: statusData } = trpc.media.rotation.status.useQuery();
+  const { data: statusData } = usePillarQuery<RotationStatusResult>(
+    'media',
+    ['rotation', 'status'],
+    undefined
+  );
   const rotationEnabled = statusData?.isRunning ?? false;
 
   if (!rotationEnabled) {

--- a/packages/app-media/src/components/QuickPickDialog.tsx
+++ b/packages/app-media/src/components/QuickPickDialog.tsx
@@ -1,9 +1,8 @@
-import { AlertCircle, Library, Sparkles } from 'lucide-react';
+import { Sparkles } from 'lucide-react';
 import { useCallback, useState } from 'react';
-import { Link } from 'react-router';
 import { toast } from 'sonner';
 
-import { trpc } from '@pops/api-client';
+import { usePillarMutation, usePillarQuery } from '@pops/pillar-sdk/react';
 import {
   Button,
   Dialog,
@@ -12,89 +11,53 @@ import {
   DialogHeader,
   DialogTitle,
   DialogTrigger,
-  Skeleton,
 } from '@pops/ui';
 
 import { PickCard } from './quick-pick/PickCard';
+import { EmptyView, ErrorView, FinishedView, PickLoading } from './quick-pick/PickViews';
 
-function PickLoading() {
-  return (
-    <div className="space-y-3">
-      <Skeleton className="aspect-[2/3] w-full rounded-lg" />
-      <Skeleton className="h-6 w-3/4" />
-      <Skeleton className="h-4 w-1/2" />
-    </div>
-  );
+interface QuickPickMovie {
+  id: number;
+  title: string;
+  posterUrl: string | null;
+  releaseDate: string | null;
+  genres: string | null;
+  overview: string | null;
+  voteAverage: number | null;
+  runtime: number | null;
 }
-
-function FinishedView({ onRefresh }: { onRefresh: () => void }) {
-  return (
-    <div className="text-center py-8 space-y-4">
-      <Sparkles className="h-10 w-10 mx-auto text-app-accent" />
-      <p className="text-muted-foreground">You&apos;ve seen all the picks!</p>
-      <Button onClick={onRefresh} variant="outline">
-        Get More Picks
-      </Button>
-    </div>
-  );
+interface QuickPickResult {
+  data: QuickPickMovie[];
 }
-
-function EmptyView() {
-  return (
-    <div className="text-center py-8 space-y-4">
-      <Library className="h-10 w-10 mx-auto text-muted-foreground" />
-      <div className="space-y-1">
-        <p className="font-medium">Nothing to pick from</p>
-        <p className="text-sm text-muted-foreground">
-          All your library movies are watched or already on your watchlist.
-        </p>
-      </div>
-      <Link to="/media/search">
-        <Button variant="outline" size="sm">
-          Find something new
-        </Button>
-      </Link>
-    </div>
-  );
-}
-
-function ErrorView({ message }: { message: string }) {
-  return (
-    <div className="text-center py-8 space-y-3">
-      <AlertCircle className="h-10 w-10 mx-auto text-destructive/70" />
-      <div className="space-y-1">
-        <p className="font-medium">Couldn't load picks</p>
-        <p className="text-sm text-muted-foreground">{message}</p>
-      </div>
-    </div>
-  );
+interface AddToWatchlistInput {
+  mediaType: 'movie';
+  mediaId: number;
 }
 
 function useQuickPickModel() {
   const [open, setOpen] = useState(false);
   const [currentIndex, setCurrentIndex] = useState(0);
-  const utils = trpc.useUtils();
 
-  const { data, isLoading, error, refetch } = trpc.media.discovery.quickPick.useQuery(
+  const { data, isLoading, error, refetch } = usePillarQuery<QuickPickResult>(
+    'media',
+    ['discovery', 'quickPick'],
     { count: 5 },
     { enabled: open }
   );
 
-  const addToWatchlist = trpc.media.watchlist.add.useMutation({
-    onSuccess: () => {
-      toast.success('Added to watchlist!');
-      void utils.media.watchlist.list.invalidate();
-      setOpen(false);
-    },
-    onError: (err: { message: string; data?: { code?: string } | null }) => {
-      if (err.data?.code === 'CONFLICT') {
-        toast.info('Already on watchlist');
+  const addToWatchlist = usePillarMutation<AddToWatchlistInput, unknown>(
+    'media',
+    ['watchlist', 'add'],
+    {
+      onSuccess: () => {
+        toast.success('Added to watchlist!');
         setOpen(false);
-      } else {
+      },
+      onError: (err) => {
         toast.error(`Failed to add: ${err.message}`);
-      }
-    },
-  });
+      },
+    }
+  );
 
   const movies = data?.data ?? [];
   const currentMovie = movies[currentIndex];

--- a/packages/app-media/src/components/RequestMovieButton.test.tsx
+++ b/packages/app-media/src/components/RequestMovieButton.test.tsx
@@ -4,18 +4,19 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mockGetConfigQuery = vi.fn();
 const mockGetMovieStatusQuery = vi.fn();
 
-vi.mock('@pops/api-client', () => ({
-  trpc: {
-    media: {
-      arr: {
-        getConfig: {
-          useQuery: () => mockGetConfigQuery(),
-        },
-        getMovieStatus: {
-          useQuery: (_input: unknown, _opts: unknown) => mockGetMovieStatusQuery(),
-        },
-      },
-    },
+vi.mock('@pops/pillar-sdk/react', () => ({
+  usePillarQuery: (
+    _pillarId: string,
+    path: readonly string[],
+    _input: unknown,
+    opts?: { enabled?: boolean }
+  ) => {
+    const key = path.join('.');
+    if (key === 'arr.getConfig') return mockGetConfigQuery();
+    const enabled = opts?.enabled ?? true;
+    if (key === 'arr.getMovieStatus')
+      return enabled ? mockGetMovieStatusQuery() : { data: null, isLoading: false, error: null };
+    return { data: null, isLoading: false, error: null };
   },
 }));
 

--- a/packages/app-media/src/components/RequestMovieButton.tsx
+++ b/packages/app-media/src/components/RequestMovieButton.tsx
@@ -1,6 +1,6 @@
 import { Download } from 'lucide-react';
 
-import { trpc } from '@pops/api-client';
+import { usePillarQuery } from '@pops/pillar-sdk/react';
 /**
  * RequestMovieButton — requests a movie via Radarr.
  *
@@ -14,6 +14,14 @@ import { Button } from '@pops/ui';
 
 import { ConditionalModalButton } from './ConditionalModalButton';
 import { RequestMovieModal } from './RequestMovieModal';
+
+interface ArrConfigResult {
+  data: { radarrConfigured: boolean; sonarrConfigured: boolean };
+}
+
+interface MovieStatusResult {
+  data: { status: string; label: string } | null;
+}
 
 type ButtonVariant = 'standard' | 'compact';
 
@@ -84,9 +92,15 @@ function RequestButtonShell({
 }
 
 function useRequestMovieGate(tmdbId: number) {
-  const { data: configData } = trpc.media.arr.getConfig.useQuery();
+  const { data: configData } = usePillarQuery<ArrConfigResult>(
+    'media',
+    ['arr', 'getConfig'],
+    undefined
+  );
   const config = configData?.data;
-  const movieStatus = trpc.media.arr.getMovieStatus.useQuery(
+  const movieStatus = usePillarQuery<MovieStatusResult>(
+    'media',
+    ['arr', 'getMovieStatus'],
     { tmdbId },
     { enabled: config?.radarrConfigured === true }
   );

--- a/packages/app-media/src/components/RequestMovieModal.test.tsx
+++ b/packages/app-media/src/components/RequestMovieModal.test.tsx
@@ -10,40 +10,33 @@ const mockDownloadAndProtectMutate = vi.fn();
 let addMovieOpts: Record<string, unknown> = {};
 let downloadAndProtectOpts: Record<string, unknown> = {};
 
-vi.mock('@pops/api-client', () => ({
-  trpc: {
-    media: {
-      arr: {
-        getQualityProfiles: {
-          useQuery: (...args: unknown[]) => mockProfilesQuery(...args),
-        },
-        getRootFolders: {
-          useQuery: (...args: unknown[]) => mockFoldersQuery(...args),
-        },
-        addMovie: {
-          useMutation: (opts: Record<string, unknown>) => {
-            addMovieOpts = opts;
-            return { mutate: mockAddMovieMutate, isPending: false };
-          },
-        },
-        downloadAndProtect: {
-          useMutation: (opts: Record<string, unknown>) => {
-            downloadAndProtectOpts = opts;
-            return { mutate: mockDownloadAndProtectMutate, isPending: false };
-          },
-        },
-        getMovieStatus: {
-          invalidate: vi.fn(),
-        },
-      },
-    },
-    useUtils: () => ({
-      media: {
-        arr: {
-          getMovieStatus: { invalidate: vi.fn() },
-        },
-      },
-    }),
+vi.mock('@pops/pillar-sdk/react', () => ({
+  usePillarQuery: (
+    _pillarId: string,
+    path: readonly string[],
+    _input: unknown,
+    opts?: Record<string, unknown>
+  ) => {
+    const key = path.join('.');
+    if (key === 'arr.getQualityProfiles') return mockProfilesQuery(_input, opts);
+    if (key === 'arr.getRootFolders') return mockFoldersQuery(_input, opts);
+    return { data: null, isLoading: false, error: null };
+  },
+  usePillarMutation: (
+    _pillarId: string,
+    path: readonly string[],
+    opts: Record<string, unknown>
+  ) => {
+    const key = path.join('.');
+    if (key === 'arr.addMovie') {
+      addMovieOpts = opts;
+      return { mutate: mockAddMovieMutate, isPending: false };
+    }
+    if (key === 'arr.downloadAndProtect') {
+      downloadAndProtectOpts = opts;
+      return { mutate: mockDownloadAndProtectMutate, isPending: false };
+    }
+    return { mutate: vi.fn(), isPending: false };
   },
 }));
 

--- a/packages/app-media/src/components/RequestSeriesModal.test.tsx
+++ b/packages/app-media/src/components/RequestSeriesModal.test.tsx
@@ -9,27 +9,30 @@ const mockLanguagesQuery = vi.fn();
 const mockAddSeriesMutate = vi.fn();
 let addSeriesOpts: Record<string, unknown> = {};
 
-vi.mock('@pops/api-client', () => ({
-  trpc: {
-    media: {
-      arr: {
-        getSonarrQualityProfiles: {
-          useQuery: (...args: unknown[]) => mockProfilesQuery(...args),
-        },
-        getSonarrRootFolders: {
-          useQuery: (...args: unknown[]) => mockFoldersQuery(...args),
-        },
-        getSonarrLanguageProfiles: {
-          useQuery: (...args: unknown[]) => mockLanguagesQuery(...args),
-        },
-        addSeries: {
-          useMutation: (opts: Record<string, unknown>) => {
-            addSeriesOpts = opts;
-            return { mutate: mockAddSeriesMutate, isPending: false };
-          },
-        },
-      },
-    },
+vi.mock('@pops/pillar-sdk/react', () => ({
+  usePillarQuery: (
+    _pillarId: string,
+    path: readonly string[],
+    _input: unknown,
+    opts?: Record<string, unknown>
+  ) => {
+    const key = path.join('.');
+    if (key === 'arr.getSonarrQualityProfiles') return mockProfilesQuery(_input, opts);
+    if (key === 'arr.getSonarrRootFolders') return mockFoldersQuery(_input, opts);
+    if (key === 'arr.getSonarrLanguageProfiles') return mockLanguagesQuery(_input, opts);
+    return { data: null, isLoading: false, error: null };
+  },
+  usePillarMutation: (
+    _pillarId: string,
+    path: readonly string[],
+    opts: Record<string, unknown>
+  ) => {
+    const key = path.join('.');
+    if (key === 'arr.addSeries') {
+      addSeriesOpts = opts;
+      return { mutate: mockAddSeriesMutate, isPending: false };
+    }
+    return { mutate: vi.fn(), isPending: false };
   },
 }));
 

--- a/packages/app-media/src/components/SourceManagementSection.tsx
+++ b/packages/app-media/src/components/SourceManagementSection.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { trpc } from '@pops/api-client';
+import { usePillarQuery } from '@pops/pillar-sdk/react';
 /**
  * SourceManagementSection — CRUD UI for rotation source management.
  *
@@ -12,6 +12,10 @@ import { SourceCard } from './source-management/SourceCard';
 import { SourceForm } from './source-management/SourceForm';
 
 import type { Source, SourceFormValues } from './source-management/types';
+
+interface SourceTypesResult {
+  types: string[];
+}
 
 function parseConfig(raw: string | null): Record<string, unknown> {
   if (!raw) return {};
@@ -65,8 +69,12 @@ function SourceList({
 }
 
 export function SourceManagementSection() {
-  const sourcesQuery = trpc.media.rotation.listSources.useQuery();
-  const sourceTypesQuery = trpc.media.rotation.sourceTypes.useQuery();
+  const sourcesQuery = usePillarQuery<Source[]>('media', ['rotation', 'listSources'], undefined);
+  const sourceTypesQuery = usePillarQuery<SourceTypesResult>(
+    'media',
+    ['rotation', 'sourceTypes'],
+    undefined
+  );
 
   const [showForm, setShowForm] = useState<'create' | 'edit' | null>(null);
   const [editingSource, setEditingSource] = useState<SourceFormValues | null>(null);

--- a/packages/app-media/src/components/quick-pick/PickViews.tsx
+++ b/packages/app-media/src/components/quick-pick/PickViews.tsx
@@ -1,0 +1,57 @@
+import { AlertCircle, Library, Sparkles } from 'lucide-react';
+import { Link } from 'react-router';
+
+import { Button, Skeleton } from '@pops/ui';
+
+export function PickLoading() {
+  return (
+    <div className="space-y-3">
+      <Skeleton className="aspect-[2/3] w-full rounded-lg" />
+      <Skeleton className="h-6 w-3/4" />
+      <Skeleton className="h-4 w-1/2" />
+    </div>
+  );
+}
+
+export function FinishedView({ onRefresh }: { onRefresh: () => void }) {
+  return (
+    <div className="text-center py-8 space-y-4">
+      <Sparkles className="h-10 w-10 mx-auto text-app-accent" />
+      <p className="text-muted-foreground">You&apos;ve seen all the picks!</p>
+      <Button onClick={onRefresh} variant="outline">
+        Get More Picks
+      </Button>
+    </div>
+  );
+}
+
+export function EmptyView() {
+  return (
+    <div className="text-center py-8 space-y-4">
+      <Library className="h-10 w-10 mx-auto text-muted-foreground" />
+      <div className="space-y-1">
+        <p className="font-medium">Nothing to pick from</p>
+        <p className="text-sm text-muted-foreground">
+          All your library movies are watched or already on your watchlist.
+        </p>
+      </div>
+      <Link to="/media/search">
+        <Button variant="outline" size="sm">
+          Find something new
+        </Button>
+      </Link>
+    </div>
+  );
+}
+
+export function ErrorView({ message }: { message: string }) {
+  return (
+    <div className="text-center py-8 space-y-3">
+      <AlertCircle className="h-10 w-10 mx-auto text-destructive/70" />
+      <div className="space-y-1">
+        <p className="font-medium">Couldn&apos;t load picks</p>
+        <p className="text-sm text-muted-foreground">{message}</p>
+      </div>
+    </div>
+  );
+}

--- a/packages/app-media/src/components/request-movie/useRequestMovieModel.ts
+++ b/packages/app-media/src/components/request-movie/useRequestMovieModel.ts
@@ -1,6 +1,38 @@
 import { useEffect, useState } from 'react';
 
-import { trpc } from '@pops/api-client';
+import { usePillarMutation, usePillarQuery } from '@pops/pillar-sdk/react';
+
+interface QualityProfile {
+  id: number;
+  name: string;
+}
+
+interface RootFolder {
+  path: string;
+  freeSpace: number;
+}
+
+interface QualityProfilesResult {
+  data: QualityProfile[];
+}
+
+interface RootFoldersResult {
+  data: RootFolder[];
+}
+
+interface AddMovieInput {
+  tmdbId: number;
+  title: string;
+  year: number;
+  qualityProfileId: number;
+  rootFolderPath: string;
+}
+
+interface DownloadAndProtectInput {
+  tmdbId: number;
+  title: string;
+  year: number;
+}
 
 interface RequestMovieModelArgs {
   open: boolean;
@@ -12,11 +44,13 @@ interface RequestMovieModelArgs {
 }
 
 function useProfilesAndFolders(open: boolean, isDownloadMode: boolean) {
-  const profiles = trpc.media.arr.getQualityProfiles.useQuery(undefined, {
-    enabled: open && !isDownloadMode,
-    retry: false,
-  });
-  const folders = trpc.media.arr.getRootFolders.useQuery(undefined, {
+  const profiles = usePillarQuery<QualityProfilesResult>(
+    'media',
+    ['arr', 'getQualityProfiles'],
+    undefined,
+    { enabled: open && !isDownloadMode, retry: false }
+  );
+  const folders = usePillarQuery<RootFoldersResult>('media', ['arr', 'getRootFolders'], undefined, {
     enabled: open && !isDownloadMode,
     retry: false,
   });
@@ -56,33 +90,34 @@ function useDefaults({
 }
 
 interface MutationArgs {
-  tmdbId: number;
   onClose: () => void;
   resetState: () => void;
   setError: (v: string | null) => void;
   setSuccess: (v: boolean) => void;
 }
 
-function useRequestMutations({ tmdbId, onClose, resetState, setError, setSuccess }: MutationArgs) {
-  const utils = trpc.useUtils();
+function useRequestMutations({ onClose, resetState, setError, setSuccess }: MutationArgs) {
   const onMutationSuccess = () => {
     setSuccess(true);
     setError(null);
-    void utils.media.arr.getMovieStatus.invalidate({ tmdbId });
     setTimeout(() => {
       onClose();
       resetState();
     }, 1500);
   };
   const onMutationError = (err: { message: string }) => setError(err.message);
-  const addMovie = trpc.media.arr.addMovie.useMutation({
+  const addMovie = usePillarMutation<AddMovieInput, unknown>('media', ['arr', 'addMovie'], {
     onSuccess: onMutationSuccess,
     onError: onMutationError,
   });
-  const downloadAndProtect = trpc.media.arr.downloadAndProtect.useMutation({
-    onSuccess: onMutationSuccess,
-    onError: onMutationError,
-  });
+  const downloadAndProtect = usePillarMutation<DownloadAndProtectInput, unknown>(
+    'media',
+    ['arr', 'downloadAndProtect'],
+    {
+      onSuccess: onMutationSuccess,
+      onError: onMutationError,
+    }
+  );
   return { addMovie, downloadAndProtect };
 }
 
@@ -111,7 +146,6 @@ export function useRequestMovieModel(args: RequestMovieModelArgs) {
   };
 
   const { addMovie, downloadAndProtect } = useRequestMutations({
-    tmdbId,
     onClose,
     resetState,
     setError,

--- a/packages/app-media/src/components/request-series/useRequestSeriesModel.ts
+++ b/packages/app-media/src/components/request-series/useRequestSeriesModel.ts
@@ -1,10 +1,19 @@
 import { useMemo, useState } from 'react';
 
-import { trpc } from '@pops/api-client';
+import { usePillarMutation } from '@pops/pillar-sdk/react';
 
 import { useSeriesDefaults, useSeriesQueries } from './useRequestSeriesQueries';
 
 import type { SeasonInfo } from '../RequestSeriesModal';
+
+interface AddSeriesInput {
+  tvdbId: number;
+  title: string;
+  qualityProfileId: number;
+  rootFolderPath: string;
+  languageProfileId: number;
+  seasons: { seasonNumber: number; monitored: boolean }[];
+}
 
 interface ModelArgs {
   open: boolean;
@@ -46,7 +55,7 @@ function useSubmit({
   args: ModelArgs;
   resetState: () => void;
 }) {
-  const addSeries = trpc.media.arr.addSeries.useMutation({
+  const addSeries = usePillarMutation<AddSeriesInput, unknown>('media', ['arr', 'addSeries'], {
     onSuccess: () => {
       state.setSuccess(true);
       state.setError(null);
@@ -55,7 +64,7 @@ function useSubmit({
         resetState();
       }, 1500);
     },
-    onError: (err: { message: string }) => state.setError(err.message),
+    onError: (err) => state.setError(err.message),
   });
 
   const handleSubmit = () => {

--- a/packages/app-media/src/components/request-series/useRequestSeriesQueries.ts
+++ b/packages/app-media/src/components/request-series/useRequestSeriesQueries.ts
@@ -1,8 +1,35 @@
 import { useEffect } from 'react';
 
-import { trpc } from '@pops/api-client';
+import { usePillarQuery } from '@pops/pillar-sdk/react';
 
 import type { SeasonInfo } from '../RequestSeriesModal';
+
+interface QualityProfile {
+  id: number;
+  name: string;
+}
+
+interface RootFolder {
+  path: string;
+  freeSpace: number;
+}
+
+interface LanguageProfile {
+  id: number;
+  name: string;
+}
+
+interface QualityProfilesResult {
+  data: QualityProfile[];
+}
+
+interface RootFoldersResult {
+  data: RootFolder[];
+}
+
+interface LanguageProfilesResult {
+  data: LanguageProfile[];
+}
 
 function isFutureSeason(firstAirDate: string | null): boolean {
   if (!firstAirDate) return true;
@@ -25,18 +52,24 @@ interface DefaultsArgs {
 }
 
 export function useSeriesQueries(open: boolean) {
-  const profiles = trpc.media.arr.getSonarrQualityProfiles.useQuery(undefined, {
-    enabled: open,
-    retry: false,
-  });
-  const folders = trpc.media.arr.getSonarrRootFolders.useQuery(undefined, {
-    enabled: open,
-    retry: false,
-  });
-  const languages = trpc.media.arr.getSonarrLanguageProfiles.useQuery(undefined, {
-    enabled: open,
-    retry: false,
-  });
+  const profiles = usePillarQuery<QualityProfilesResult>(
+    'media',
+    ['arr', 'getSonarrQualityProfiles'],
+    undefined,
+    { enabled: open, retry: false }
+  );
+  const folders = usePillarQuery<RootFoldersResult>(
+    'media',
+    ['arr', 'getSonarrRootFolders'],
+    undefined,
+    { enabled: open, retry: false }
+  );
+  const languages = usePillarQuery<LanguageProfilesResult>(
+    'media',
+    ['arr', 'getSonarrLanguageProfiles'],
+    undefined,
+    { enabled: open, retry: false }
+  );
   return { profiles, folders, languages };
 }
 

--- a/packages/app-media/src/components/source-management/SourceCard.tsx
+++ b/packages/app-media/src/components/source-management/SourceCard.tsx
@@ -1,10 +1,14 @@
 import { Clock, Database, RefreshCw, Trash2 } from 'lucide-react';
 import { toast } from 'sonner';
 
-import { trpc } from '@pops/api-client';
+import { usePillarMutation } from '@pops/pillar-sdk/react';
 import { Button, Switch } from '@pops/ui';
 
 import { formatSyncDate, sourceTypeLabel, type Source } from './types';
+
+interface SyncSourceResult {
+  candidatesInserted: number;
+}
 
 interface SourceCardProps {
   source: Source;
@@ -12,30 +16,35 @@ interface SourceCardProps {
 }
 
 function useSourceMutations(source: Source) {
-  const utils = trpc.useUtils();
+  const syncMutation = usePillarMutation<{ sourceId: number }, SyncSourceResult>(
+    'media',
+    ['rotation', 'syncSource'],
+    {
+      onSuccess: (data) => {
+        toast.success(`Synced "${source.name}": ${data.candidatesInserted} new candidates`);
+      },
+      onError: () => toast.error(`Failed to sync "${source.name}"`),
+    }
+  );
 
-  const syncMutation = trpc.media.rotation.syncSource.useMutation({
-    onSuccess: (data) => {
-      toast.success(`Synced "${source.name}": ${data.candidatesInserted} new candidates`);
-      void utils.media.rotation.listSources.invalidate();
-    },
-    onError: () => toast.error(`Failed to sync "${source.name}"`),
-  });
+  const toggleMutation = usePillarMutation<{ id: number; enabled: boolean }, unknown>(
+    'media',
+    ['rotation', 'updateSource'],
+    {
+      onError: () => toast.error('Failed to update source'),
+    }
+  );
 
-  const toggleMutation = trpc.media.rotation.updateSource.useMutation({
-    onSuccess: () => {
-      void utils.media.rotation.listSources.invalidate();
-    },
-    onError: () => toast.error('Failed to update source'),
-  });
-
-  const deleteMutation = trpc.media.rotation.deleteSource.useMutation({
-    onSuccess: () => {
-      toast.success(`Deleted "${source.name}"`);
-      void utils.media.rotation.listSources.invalidate();
-    },
-    onError: (err) => toast.error(err.message || 'Failed to delete source'),
-  });
+  const deleteMutation = usePillarMutation<{ id: number }, unknown>(
+    'media',
+    ['rotation', 'deleteSource'],
+    {
+      onSuccess: () => {
+        toast.success(`Deleted "${source.name}"`);
+      },
+      onError: (err) => toast.error(err.message || 'Failed to delete source'),
+    }
+  );
 
   return { syncMutation, toggleMutation, deleteMutation };
 }

--- a/packages/app-media/src/components/source-management/useSourceFormModel.ts
+++ b/packages/app-media/src/components/source-management/useSourceFormModel.ts
@@ -1,9 +1,36 @@
 import { useState } from 'react';
 import { toast } from 'sonner';
 
-import { trpc } from '@pops/api-client';
+import { usePillarMutation, usePillarQuery } from '@pops/pillar-sdk/react';
 
 import type { SourceFormValues } from './types';
+
+interface PlexFriend {
+  uuid: string;
+  username: string;
+}
+
+type PlexFriendsResult =
+  | { error: string; friends: PlexFriend[] }
+  | { error: null; friends: PlexFriend[] };
+
+interface CreateSourceInput {
+  type: string;
+  name: string;
+  priority: number;
+  enabled: boolean;
+  syncIntervalHours: number;
+  config: Record<string, unknown>;
+}
+
+interface UpdateSourceInput {
+  id: number;
+  name: string;
+  priority: number;
+  enabled: boolean;
+  syncIntervalHours: number;
+  config: Record<string, unknown>;
+}
 
 interface UseSourceFormArgs {
   mode: 'create' | 'edit';
@@ -60,23 +87,28 @@ function useSourceFormState(initialValues: SourceFormValues | undefined, sourceT
 }
 
 function useSourceMutations(onClose: () => void) {
-  const utils = trpc.useUtils();
-  const createMutation = trpc.media.rotation.createSource.useMutation({
-    onSuccess: () => {
-      toast.success('Source created');
-      void utils.media.rotation.listSources.invalidate();
-      onClose();
-    },
-    onError: () => toast.error('Failed to create source'),
-  });
-  const updateMutation = trpc.media.rotation.updateSource.useMutation({
-    onSuccess: () => {
-      toast.success('Source updated');
-      void utils.media.rotation.listSources.invalidate();
-      onClose();
-    },
-    onError: () => toast.error('Failed to update source'),
-  });
+  const createMutation = usePillarMutation<CreateSourceInput, unknown>(
+    'media',
+    ['rotation', 'createSource'],
+    {
+      onSuccess: () => {
+        toast.success('Source created');
+        onClose();
+      },
+      onError: () => toast.error('Failed to create source'),
+    }
+  );
+  const updateMutation = usePillarMutation<UpdateSourceInput, unknown>(
+    'media',
+    ['rotation', 'updateSource'],
+    {
+      onSuccess: () => {
+        toast.success('Source updated');
+        onClose();
+      },
+      onError: () => toast.error('Failed to update source'),
+    }
+  );
   return { createMutation, updateMutation };
 }
 
@@ -88,9 +120,12 @@ export function useSourceFormModel({
 }: UseSourceFormArgs) {
   const state = useSourceFormState(initialValues, sourceTypes);
   const { createMutation, updateMutation } = useSourceMutations(onClose);
-  const plexFriendsQuery = trpc.media.rotation.listPlexFriends.useQuery(undefined, {
-    enabled: state.type === 'plex_friends',
-  });
+  const plexFriendsQuery = usePillarQuery<PlexFriendsResult>(
+    'media',
+    ['rotation', 'listPlexFriends'],
+    undefined,
+    { enabled: state.type === 'plex_friends' }
+  );
 
   const handleSubmit = () => {
     if (!state.name.trim()) {

--- a/packages/app-media/src/hooks/discover-actions/discoverMutations.ts
+++ b/packages/app-media/src/hooks/discover-actions/discoverMutations.ts
@@ -1,11 +1,61 @@
-import { trpc } from '@pops/api-client';
+import { usePillarMutation } from '@pops/pillar-sdk/react';
+
+interface AddMovieInput {
+  tmdbId: number;
+}
+
+interface AddMovieResult {
+  created: boolean;
+  data: { id: number; title: string };
+}
+
+interface AddWatchlistInput {
+  mediaType: 'movie';
+  mediaId: number;
+}
+
+interface AddWatchlistResult {
+  created: boolean;
+}
+
+interface RemoveWatchlistInput {
+  id: number;
+}
+
+interface LogWatchInput {
+  mediaType: 'movie';
+  mediaId: number;
+}
+
+interface LogWatchResult {
+  watchlistRemoved: boolean;
+}
+
+interface DismissInput {
+  tmdbId: number;
+}
 
 export function useDiscoverMutations() {
-  const addMovieMutation = trpc.media.library.addMovie.useMutation();
-  const addWatchlistMutation = trpc.media.watchlist.add.useMutation();
-  const removeWatchlistMutation = trpc.media.watchlist.remove.useMutation();
-  const logWatchMutation = trpc.media.watchHistory.log.useMutation();
-  const dismissMutation = trpc.media.discovery.dismiss.useMutation();
+  const addMovieMutation = usePillarMutation<AddMovieInput, AddMovieResult>('media', [
+    'library',
+    'addMovie',
+  ]);
+  const addWatchlistMutation = usePillarMutation<AddWatchlistInput, AddWatchlistResult>('media', [
+    'watchlist',
+    'add',
+  ]);
+  const removeWatchlistMutation = usePillarMutation<RemoveWatchlistInput, unknown>('media', [
+    'watchlist',
+    'remove',
+  ]);
+  const logWatchMutation = usePillarMutation<LogWatchInput, LogWatchResult>('media', [
+    'watchHistory',
+    'log',
+  ]);
+  const dismissMutation = usePillarMutation<DismissInput, unknown>('media', [
+    'discovery',
+    'dismiss',
+  ]);
   return {
     addMovieMutation,
     addWatchlistMutation,

--- a/packages/app-media/src/hooks/useMediaLibrary.ts
+++ b/packages/app-media/src/hooks/useMediaLibrary.ts
@@ -1,4 +1,4 @@
-import { trpc } from '@pops/api-client';
+import { usePillarQuery } from '@pops/pillar-sdk/react';
 
 export type MediaType = 'all' | 'movie' | 'tv';
 export type SortOption = 'title' | 'dateAdded' | 'releaseDate' | 'rating';
@@ -14,6 +14,23 @@ export interface MediaItem {
   voteAverage: number | null;
   createdAt: string;
   releaseDate: string | null;
+}
+
+interface Pagination {
+  page: number;
+  pageSize: number;
+  total: number;
+  totalPages: number;
+  hasMore: boolean;
+}
+
+interface LibraryListResult {
+  data: MediaItem[];
+  pagination: Pagination;
+}
+
+interface GenresResult {
+  data: string[];
 }
 
 export interface UseMediaLibraryParams {
@@ -41,17 +58,23 @@ function buildListInput(params: UseMediaLibraryParams) {
 }
 
 export function useMediaLibrary(params: UseMediaLibraryParams) {
-  const { data, isLoading, error, refetch } = trpc.media.library.list.useQuery(
+  const { data, isLoading, error, refetch } = usePillarQuery<LibraryListResult>(
+    'media',
+    ['library', 'list'],
     buildListInput(params)
   );
 
-  const { data: genresData } = trpc.media.library.genres.useQuery();
+  const { data: genresData } = usePillarQuery<GenresResult>(
+    'media',
+    ['library', 'genres'],
+    undefined
+  );
 
   const total = data?.pagination.total ?? 0;
   const isEmpty = !isLoading && !error && total === 0;
 
   return {
-    items: (data?.data ?? []) as MediaItem[],
+    items: data?.data ?? [],
     isLoading,
     error,
     refetch,

--- a/packages/app-media/src/hooks/useSyncJob.ts
+++ b/packages/app-media/src/hooks/useSyncJob.ts
@@ -7,7 +7,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
-import { trpc } from '@pops/api-client';
+import { usePillarMutation, usePillarQuery } from '@pops/pillar-sdk/react';
 
 type SyncJobType =
   | 'plexSyncMovies'
@@ -37,6 +37,29 @@ interface SyncJobParams {
   sectionId?: string;
   movieSectionId?: string;
   tvSectionId?: string;
+}
+
+interface ActiveJobsResult {
+  data: SyncJob[];
+}
+
+interface SyncJobStatusResult {
+  data: SyncJob;
+}
+
+interface StartSyncJobInput {
+  jobType: SyncJobType;
+  sectionId?: string;
+  movieSectionId?: string;
+  tvSectionId?: string;
+}
+
+interface StartSyncJobResult {
+  data: { jobId: string };
+}
+
+interface LastSyncResultsResult {
+  data: Record<string, SyncJob | null>;
 }
 
 interface UseSyncJobReturn {
@@ -75,10 +98,15 @@ function useRestoreActiveJob(
   setRestoredJob: (j: SyncJob) => void
 ) {
   const restoredRef = useRef(false);
-  const activeJobs = trpc.media.plex.getActiveSyncJobs.useQuery(undefined, {
-    enabled: !jobId && !restoredRef.current,
-    refetchOnWindowFocus: false,
-  });
+  const activeJobs = usePillarQuery<ActiveJobsResult>(
+    'media',
+    ['plex', 'getActiveSyncJobs'],
+    undefined,
+    {
+      enabled: !jobId && !restoredRef.current,
+      refetchOnWindowFocus: false,
+    }
+  );
   const isRestoring = !restoredRef.current && !jobId && activeJobs.isLoading;
 
   useEffect(() => {
@@ -86,9 +114,7 @@ function useRestoreActiveJob(
     if (!activeJobs.data?.data) return;
     restoredRef.current = true;
 
-    const match = activeJobs.data.data.find(
-      (j) => j.jobType === jobType && j.status === 'running'
-    ) as SyncJob | undefined;
+    const match = activeJobs.data.data.find((j) => j.jobType === jobType && j.status === 'running');
     if (match) {
       setJobId(match.id);
       setRestoredJob(match);
@@ -103,7 +129,9 @@ function useStatusPolling(
   restoredJob: SyncJob | null,
   clearRestored: () => void
 ) {
-  const statusQuery = trpc.media.plex.getSyncJobStatus.useQuery(
+  const statusQuery = usePillarQuery<SyncJobStatusResult>(
+    'media',
+    ['plex', 'getSyncJobStatus'],
     { jobId: jobId ?? '' },
     {
       enabled: !!jobId,
@@ -164,16 +192,20 @@ export function useSyncJob(jobType: SyncJobType): UseSyncJobReturn {
   const { isRestoring } = useRestoreActiveJob(jobType, jobId, setJobId, setRestoredJob);
   const statusQuery = useStatusPolling(jobId, restoredJob, () => setRestoredJob(null));
 
-  const startMutation = trpc.media.plex.startSyncJob.useMutation({
-    onSuccess: (res) => {
-      setJobId(res.data.jobId);
-    },
-    onError: (err) => {
-      toast.error(`Failed to start ${label}: ${err.message}`);
-    },
-  });
+  const startMutation = usePillarMutation<StartSyncJobInput, StartSyncJobResult>(
+    'media',
+    ['plex', 'startSyncJob'],
+    {
+      onSuccess: (res) => {
+        setJobId(res.data.jobId);
+      },
+      onError: (err) => {
+        toast.error(`Failed to start ${label}: ${err.message}`);
+      },
+    }
+  );
 
-  useCompletionToast(label, jobId, statusQuery.data?.data as SyncJob | undefined);
+  useCompletionToast(label, jobId, statusQuery.data?.data);
 
   const start = useCallback(
     (params?: SyncJobParams) => {
@@ -182,7 +214,7 @@ export function useSyncJob(jobType: SyncJobType): UseSyncJobReturn {
     [jobType, startMutation]
   );
 
-  const job = (statusQuery.data?.data as SyncJob | undefined) ?? restoredJob;
+  const job = statusQuery.data?.data ?? restoredJob;
   const isRunning = isRestoring || job?.status === 'running';
 
   return {
@@ -196,6 +228,10 @@ export function useSyncJob(jobType: SyncJobType): UseSyncJobReturn {
 
 /** Hook to get "last synced" data for all sync types. */
 export function useLastSyncResults(): Record<string, SyncJob | null> {
-  const query = trpc.media.plex.getLastSyncResults.useQuery();
-  return (query.data?.data ?? {}) as Record<string, SyncJob | null>;
+  const query = usePillarQuery<LastSyncResultsResult>(
+    'media',
+    ['plex', 'getLastSyncResults'],
+    undefined
+  );
+  return query.data?.data ?? {};
 }

--- a/packages/app-media/src/pages/LibraryPage.test.tsx
+++ b/packages/app-media/src/pages/LibraryPage.test.tsx
@@ -11,8 +11,11 @@ const mockGetPendingDebriefs = vi.fn();
 const mockGetLeavingMovies = vi.fn();
 
 vi.mock('@pops/pillar-sdk/react', () => ({
-  usePillarQuery: (_pillarId: string, path: readonly string[]) => {
-    if (path.join('.') === 'comparisons.getPendingDebriefs') return mockGetPendingDebriefs();
+  usePillarQuery: (_pillarId: string, path: readonly string[], input: unknown) => {
+    const key = path.join('.');
+    if (key === 'comparisons.getPendingDebriefs') return mockGetPendingDebriefs();
+    if (key === 'library.list') return mockListQuery(input);
+    if (key === 'library.genres') return mockGenresQuery();
     return { data: undefined, isLoading: false };
   },
   usePillarMutation: () => ({ mutate: vi.fn(), isPending: false }),
@@ -21,10 +24,6 @@ vi.mock('@pops/pillar-sdk/react', () => ({
 vi.mock('@pops/api-client', () => ({
   trpc: {
     media: {
-      library: {
-        list: { useQuery: (...args: unknown[]) => mockListQuery(...args) },
-        genres: { useQuery: () => mockGenresQuery() },
-      },
       comparisons: {
         getPendingDebriefs: { useQuery: () => mockGetPendingDebriefs() },
       },

--- a/packages/app-media/src/pages/WatchlistPage.test.tsx
+++ b/packages/app-media/src/pages/WatchlistPage.test.tsx
@@ -12,6 +12,16 @@ const mockUpdateMutate = vi.fn();
 const mockInvalidate = vi.fn();
 const capturedOpts: Record<string, Record<string, unknown>> = {};
 
+vi.mock('@pops/pillar-sdk/react', () => ({
+  usePillarQuery: (_pillarId: string, path: readonly string[]) => {
+    const key = path.join('.');
+    if (key === 'plex.getActiveSyncJobs') return { data: { data: [] }, isLoading: false };
+    if (key === 'plex.getSyncJobStatus') return { data: undefined, isLoading: false };
+    return { data: undefined, isLoading: false };
+  },
+  usePillarMutation: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
 vi.mock('@pops/api-client', () => ({
   trpc: {
     media: {

--- a/packages/app-media/src/pages/watchlist/WatchlistPlexSyncButton.test.tsx
+++ b/packages/app-media/src/pages/watchlist/WatchlistPlexSyncButton.test.tsx
@@ -7,24 +7,34 @@ const mockGetStatus = vi.fn();
 const mockInvalidateWatchlist = vi.fn();
 let capturedStartOpts: Record<string, (...args: unknown[]) => unknown> = {};
 
+vi.mock('@pops/pillar-sdk/react', () => ({
+  usePillarQuery: (
+    _pillarId: string,
+    path: readonly string[],
+    input: unknown,
+    opts?: Record<string, unknown>
+  ) => {
+    const key = path.join('.');
+    if (key === 'plex.getActiveSyncJobs') return mockGetActive(input, opts);
+    if (key === 'plex.getSyncJobStatus') return mockGetStatus(input, opts);
+    return { data: undefined, isLoading: false };
+  },
+  usePillarMutation: (
+    _pillarId: string,
+    path: readonly string[],
+    opts: Record<string, (...args: unknown[]) => unknown>
+  ) => {
+    const key = path.join('.');
+    if (key === 'plex.startSyncJob') {
+      capturedStartOpts = opts;
+      return { mutate: mockStartMutate, isPending: false };
+    }
+    return { mutate: vi.fn(), isPending: false };
+  },
+}));
+
 vi.mock('@pops/api-client', () => ({
   trpc: {
-    media: {
-      plex: {
-        getActiveSyncJobs: {
-          useQuery: (...args: unknown[]) => mockGetActive(...args),
-        },
-        getSyncJobStatus: {
-          useQuery: (...args: unknown[]) => mockGetStatus(...args),
-        },
-        startSyncJob: {
-          useMutation: (opts: Record<string, (...args: unknown[]) => unknown>) => {
-            capturedStartOpts = opts;
-            return { mutate: mockStartMutate, isPending: false };
-          },
-        },
-      },
-    },
     useUtils: () => ({
       media: {
         watchlist: { list: { invalidate: mockInvalidateWatchlist } },


### PR DESCRIPTION
## Summary

- Continues the alphabetical migration started in #3128. Swaps `trpc.media.*` for `usePillarQuery` / `usePillarMutation` in the next 12 source files in `packages/app-media/src`.
- Cross-router invalidation is handled by the SDK's built-in router-prefix invalidate; no explicit `useQueryClient` calls were needed in this batch.
- One UX trade-off in `QuickPickDialog`: the previous `CONFLICT`-code special case ("Already on watchlist" → `toast.info`) gracefully degrades to the generic error toast, since the SDK surfaces transport-level failures only (`unavailable` / `degraded` / `contract-mismatch`).
- Extracts view helpers from `QuickPickDialog.tsx` into `quick-pick/PickViews.tsx` to stay under the 200-line cap after type additions.

### Files migrated (12)

- `components/MovieActionButtons.tsx`
- `components/QuickPickDialog.tsx` (+ new `quick-pick/PickViews.tsx`)
- `components/RequestMovieButton.tsx` (+ test)
- `components/SourceManagementSection.tsx`
- `components/request-movie/useRequestMovieModel.ts` (+ RequestMovieModal test)
- `components/request-series/useRequestSeriesModel.ts` (+ RequestSeriesModal test)
- `components/request-series/useRequestSeriesQueries.ts`
- `components/source-management/SourceCard.tsx`
- `components/source-management/useSourceFormModel.ts`
- `hooks/discover-actions/discoverMutations.ts`
- `hooks/useMediaLibrary.ts`
- `hooks/useSyncJob.ts` (+ WatchlistPlexSyncButton / WatchlistPage / LibraryPage test mocks)

### Risky files reaffirmed-skipped (3)

These still need the SDK cache-write surface (ADR-035 typed `setData` / `onMutate` rollback) that #3136 just shipped — they'll be migrated in a follow-up batch alongside the other ~37 trivial files:

- `components/watchlist-toggle/useWatchlistToggleModel.ts`
- `pages/tv-show-detail/useTvShowDetailModel.ts`
- `pages/season-detail/useBatchSeasonLog.ts`

### Remaining

- ~37 trivial files remain in subsequent batches.

## Test plan

- [x] `pnpm --filter @pops/app-media typecheck` — clean
- [x] `pnpm --filter @pops/app-media test` — 702/702 passing
- [x] `pnpm typecheck` — all 67 packages clean
- [x] `npx oxlint packages/app-media/src` — 0 errors