### PR TITLE
feat(examples): PRD-233 Rust reference pillar (cross-language proof-of-concept)

### DIFF
--- a/docs/themes/13-pillar-finale/epics/14-cross-language-interop.md
+++ b/docs/themes/13-pillar-finale/epics/14-cross-language-interop.md
@@ -12,9 +12,10 @@ The wire-level specification, conformance harness, and reference materials that 
 
 | #   | PRD                                                                                          | Summary                                                                                                                                | Status      |
 | --- | -------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| 231 | [Cross-language SDK wire-format spec](../prds/231-cross-language-wire-format-spec/README.md) | Single-page wire-format spec covering envelope, batching, subscription, manifest, registration, health + a black-box conformance suite | Not started |
+| 231 | [Cross-language SDK wire-format spec](../prds/231-cross-language-wire-format-spec/README.md) | Single-page wire-format spec covering envelope, batching, subscription, manifest, registration, health + a black-box conformance suite | Done        |
+| 233 | [External pillar example (Rust)](../prds/233-external-pillar-example-repo/README.md)         | Minimal Rust reference pillar that implements the wire-format spec and proves it is implementable from scratch in a non-TS language    | In progress |
 
-Parallelisation: PRD-231's user stories split into spec authoring (US-01), publication target (US-02), and the conformance harness (US-03). US-01 must land first; US-02 + US-03 can ship in parallel against the frozen spec.
+Parallelisation: PRD-231's user stories split into spec authoring (US-01), publication target (US-02), and the conformance harness (US-03). US-01 must land first; US-02 + US-03 can ship in parallel against the frozen spec. PRD-233 depends on US-01 being frozen.
 
 ## Dependencies
 

--- a/docs/themes/13-pillar-finale/prds/233-external-pillar-example-repo/README.md
+++ b/docs/themes/13-pillar-finale/prds/233-external-pillar-example-repo/README.md
@@ -1,0 +1,63 @@
+# PRD-233: External pillar example (Rust reference)
+
+> Epic: [Cross-language interop](../../epics/14-cross-language-interop.md)
+
+> Status: In progress — proof-of-concept scaffolded
+
+> Spec: [`pillar-wire-format-v1.md`](../../specs/pillar-wire-format-v1.md)
+
+## Overview
+
+A minimal Rust pillar that implements the [wire-format spec v1](../../specs/pillar-wire-format-v1.md) end-to-end. It exists to prove the spec is implementable from scratch in a non-TS language, validate the registration endpoint shipped in PRD-228, and serve as the canonical worked example for future Go / Python / Swift pillars. It is **not a deployment target** — it never runs in the home-lab docker-compose. Its only job is to pass `@pops/wire-conformance` end-to-end.
+
+If `@pops/pillar-sdk` and this implementation disagree, the [spec](../../specs/pillar-wire-format-v1.md) is the tie-breaker — not either implementation.
+
+## Source layout
+
+```
+examples/pops-pillar-rust-example/
+├── Cargo.toml
+├── Dockerfile
+├── README.md
+└── src/
+    └── main.rs
+```
+
+Out-of-tree from `pnpm-workspace.yaml`. No crate-level publishing.
+
+## API Surface
+
+The example implements the subset of v1 needed to demonstrate end-to-end correctness:
+
+| Endpoint                             | Purpose                                                                  |
+| ------------------------------------ | ------------------------------------------------------------------------ |
+| `GET  /manifest.json`                | `ManifestPayload` for pillar id `example-rust`, empty capability arrays. |
+| `GET  /health`                       | `{ ok, status, pillar, version, ts }` healthy / unhealthy per §7.        |
+| `POST /trpc/examplerust.hello.greet` | Reference success procedure — returns `{ greeting: "hello from rust" }`. |
+
+On boot, the pillar POSTs `core.registry.register` per §6 using `POPS_INTERNAL_API_KEY`. Full-jitter exponential backoff up to 5 minutes per §6.5.
+
+## Business Rules
+
+- The manifest returned by `GET /manifest.json` MUST match the body sent at registration time.
+- Pillar id is `example-rust` (kebab); procedure namespace is `examplerust` (no hyphens, per the `PROCEDURE_PATH` regex in `@pops/pillar-sdk/manifest-schema`).
+- The example does NOT need to implement every `WF-*` assertion — subscriptions, batching, error-envelope edge cases are out of scope for the proof-of-concept. The README documents which assertions are covered.
+- No persistence, no DB, no config files. Env vars only.
+
+## Acceptance Criteria
+
+- [x] `cargo build --release` succeeds against the pinned `axum` toolchain.
+- [x] `GET /manifest.json` returns a body that parses with `@pops/pillar-sdk/manifest-schema` `ManifestPayloadSchema`.
+- [x] `GET /health` returns `200 { ok: true, status: "healthy", pillar: "example-rust", ... }`.
+- [x] `POST /trpc/examplerust.hello.greet` with `{ "input": null }` returns `{ result: { data: { greeting: "hello from rust" } } }`.
+- [x] On boot, POSTs `core.registry.register` with `X-Internal-API-Key` and retries with backoff on transient failure.
+- [x] README documents how to run `@pops/wire-conformance` against the running container.
+- [ ] `WF-13-manifest-shape`, `WF-14-manifest-cache-control`, `WF-17-health-healthy`, `WF-01-single-call-success` pass when run from `@pops/wire-conformance` (covered subset).
+
+## Out of Scope
+
+- Subscriptions (`WF-08`…`WF-12`).
+- Batched call shape (`WF-04`…`WF-07`).
+- Production deployment, CI image publication, watchtower auto-rollout.
+- A second non-TS language (Go / Python). Defer until this one is stable.
+- Search adapter / AI tool / sink contributions. The example declares empty capabilities.

--- a/examples/pops-pillar-rust-example/.gitignore
+++ b/examples/pops-pillar-rust-example/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/examples/pops-pillar-rust-example/Cargo.toml
+++ b/examples/pops-pillar-rust-example/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "pops-pillar-rust-example"
+version = "0.1.0"
+edition = "2021"
+publish = false
+description = "Reference Rust pillar implementing the POPS wire-format v1 spec (PRD-233)."
+
+[[bin]]
+name = "pops-pillar-rust-example"
+path = "src/main.rs"
+
+[dependencies]
+axum = "0.7"
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "time", "signal"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+time = { version = "0.3", features = ["serde-well-known", "formatting"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+rand = "0.8"
+uuid = { version = "1", features = ["v4"] }
+
+[profile.release]
+opt-level = "z"
+lto = true
+codegen-units = 1
+strip = true

--- a/examples/pops-pillar-rust-example/Dockerfile
+++ b/examples/pops-pillar-rust-example/Dockerfile
@@ -1,0 +1,35 @@
+# syntax=docker/dockerfile:1.7
+# Reference Rust pillar — see docs/themes/13-pillar-finale/prds/233-external-pillar-example-repo/
+
+FROM rust:1.83-slim-bookworm AS builder
+WORKDIR /build
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends pkg-config \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY Cargo.toml ./
+RUN mkdir src \
+  && echo 'fn main() {}' > src/main.rs \
+  && cargo build --release \
+  && rm -rf src target/release/deps/pops_pillar_rust_example*
+
+COPY src ./src
+RUN cargo build --release
+
+FROM debian:bookworm-slim AS runtime
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates \
+  && rm -rf /var/lib/apt/lists/* \
+  && useradd --system --uid 10001 --no-create-home pops
+
+COPY --from=builder /build/target/release/pops-pillar-rust-example /usr/local/bin/pops-pillar-rust-example
+
+USER pops
+ENV PORT=3010
+EXPOSE 3010
+
+HEALTHCHECK --interval=10s --timeout=2s --start-period=5s --retries=3 \
+  CMD ["/bin/sh", "-c", "wget -q -O /dev/null http://127.0.0.1:${PORT:-3010}/health || exit 1"]
+
+ENTRYPOINT ["/usr/local/bin/pops-pillar-rust-example"]

--- a/examples/pops-pillar-rust-example/README.md
+++ b/examples/pops-pillar-rust-example/README.md
@@ -1,0 +1,126 @@
+# pops-pillar-rust-example
+
+Reference [POPS wire-format v1](../../docs/themes/13-pillar-finale/specs/pillar-wire-format-v1.md)
+pillar written in Rust. Built directly against the spec — never against the
+`@pops/pillar-sdk` source — to prove the spec is implementable from scratch
+in a non-TypeScript language.
+
+This crate is **not a deployment target**. It is a worked example used to
+validate the spec and the conformance suite (`@pops/wire-conformance`).
+
+PRD: [`docs/themes/13-pillar-finale/prds/233-external-pillar-example-repo/`](../../docs/themes/13-pillar-finale/prds/233-external-pillar-example-repo/README.md).
+
+## What it implements
+
+| Endpoint                             | Spec section | Notes                                                                            |
+| ------------------------------------ | ------------ | -------------------------------------------------------------------------------- |
+| `GET /manifest.json`                 | §5           | Returns a valid `ManifestPayload` for pillar `example-rust`, empty capabilities. |
+| `GET /health`                        | §7           | Healthy by default; pass `?simulate=unhealthy` to get a `503` for `WF-18`.       |
+| `POST /trpc/examplerust.hello.greet` | §3           | Returns `{ result: { data: { greeting: "hello from rust" } } }`.                 |
+| Boot-time registration               | §6           | POSTs `core.registry.register` with full-jitter backoff, 5-minute deadline.      |
+
+Each response echoes `X-Request-Id` (spec §9.2) and rejects `X-Pops-Wire-Version`
+values outside `[1]` with `METHOD_NOT_SUPPORTED` and a `supportedVersions` array
+(spec §9.1).
+
+## Why Rust, why these crates
+
+- **`axum 0.7`** — most idiomatic minimal HTTP framework in the Rust ecosystem
+  with first-class `tokio` integration. `warp` was the alternative; `axum`
+  wins on ergonomics for a routing-heavy service.
+- **`reqwest`** — boot-time registration client. `rustls-tls` keeps the runtime
+  image free of OpenSSL.
+- **`serde_json::Value`** — the manifest is a tree of JSON, not a Rust struct.
+  Treating it as `Value` keeps the example tiny and matches what an external
+  language SDK would do.
+
+## Build
+
+```bash
+cd examples/pops-pillar-rust-example
+cargo build --release
+```
+
+Or with Docker:
+
+```bash
+docker build -t pops-pillar-rust-example:dev .
+```
+
+## Run
+
+```bash
+PORT=3010 \
+POPS_PILLAR_BASE_URL=http://localhost:3010 \
+POPS_CORE_BASE_URL=http://core-api:3000 \
+POPS_INTERNAL_API_KEY=$(grep POPS_INTERNAL_API_KEY ../../apps/pops-api/.env | cut -d= -f2-) \
+cargo run --release
+```
+
+`POPS_CORE_BASE_URL` is **optional**. When unset the pillar starts but skips
+registration — useful when running the conformance harness against a
+standalone fixture pillar (no `core-api` in scope).
+
+## Verify with `@pops/wire-conformance`
+
+In a second terminal, with the pillar running on `:3010`:
+
+```bash
+# From the repo root:
+pnpm --filter @pops/wire-conformance build
+node -e '
+  import("./packages/wire-conformance/dist/index.js").then(async (m) => {
+    const report = await m.runConformance({
+      baseUrl: "http://localhost:3010",
+      coreBaseUrl: process.env.POPS_CORE_BASE_URL ?? "http://localhost:3010",
+      apiKey: process.env.POPS_INTERNAL_API_KEY ?? "dev-key",
+      probes: {
+        successProcedure: "examplerust.hello.greet",
+        notFoundProcedure: "examplerust.hello.greet",
+        subscriptionProcedure: "examplerust.hello.greet",
+        idleSubscriptionProcedure: "examplerust.hello.greet",
+        errorSubscriptionProcedure: "examplerust.hello.greet",
+        registrationPillarId: "example-rust",
+      },
+    });
+    console.log(JSON.stringify(report, null, 2));
+  });
+'
+```
+
+### Assertions covered by this scaffold
+
+This proof-of-concept implements the **happy path** subset only. Expect these
+to pass:
+
+- `WF-01-single-call-success` — `examplerust.hello.greet` returns a valid
+  envelope.
+- `WF-13-manifest-shape` — manifest parses against `ManifestPayloadSchema`.
+- `WF-14-manifest-cache-control` — manifest sends `Cache-Control: no-store`.
+- `WF-17-health-healthy` — `/health` returns the spec-shaped healthy payload.
+- `WF-18-health-unhealthy` — `/health?simulate=unhealthy` returns `503` with
+  `ok: false`.
+- `WF-19-request-id-echo` — every response echoes inbound `X-Request-Id`.
+- `WF-20-wire-version-unsupported` — `X-Pops-Wire-Version: 999` returns
+  `METHOD_NOT_SUPPORTED` with `supportedVersions`.
+- `WF-15-registration-success` — only when run against a real `core-api`
+  with a valid `POPS_INTERNAL_API_KEY`.
+
+### Explicitly NOT covered
+
+Subscriptions (`WF-08`…`WF-12`), batched calls (`WF-04`…`WF-07`), and the
+error-envelope edge cases (`WF-02`, `WF-03`, `WF-16`) are deliberately out of
+scope for this scaffold. They are tracked under the PRD's "Out of Scope"
+section and are the obvious next iteration if a real non-TS pillar is ever
+needed.
+
+## Layout
+
+```
+src/main.rs    single-file implementation; ~250 lines
+Cargo.toml     dependency manifest
+Dockerfile     multi-stage build → distroless-ish debian-slim runtime
+```
+
+If this grows beyond a single file, split routes into a `handlers/` module
+before reaching for crates.

--- a/examples/pops-pillar-rust-example/src/main.rs
+++ b/examples/pops-pillar-rust-example/src/main.rs
@@ -1,0 +1,335 @@
+//! POPS wire-format v1 reference pillar (Rust).
+//!
+//! See `docs/themes/13-pillar-finale/specs/pillar-wire-format-v1.md` for the
+//! canonical spec this implements. If anything here disagrees with the spec,
+//! the spec wins.
+
+use std::{env, net::SocketAddr, sync::Arc, time::Duration};
+
+use axum::{
+    extract::{Query, State},
+    http::{header, HeaderMap, HeaderValue, StatusCode},
+    response::{IntoResponse, Response},
+    routing::{get, post},
+    Json, Router,
+};
+use rand::Rng;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use time::{format_description::well_known::Rfc3339, OffsetDateTime};
+use tracing::{error, info, warn};
+
+const PILLAR_ID: &str = "example-rust";
+const PILLAR_VERSION: &str = "0.1.0";
+const WIRE_VERSION_HEADER: &str = "x-pops-wire-version";
+const REQUEST_ID_HEADER: &str = "x-request-id";
+const INTERNAL_KEY_HEADER: &str = "X-Internal-API-Key";
+const SUPPORTED_WIRE_VERSIONS: &[u32] = &[1];
+
+#[derive(Clone)]
+struct AppState {
+    manifest: Arc<Value>,
+}
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
+
+    let port: u16 = env::var("PORT")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(3010);
+    let addr: SocketAddr = ([0, 0, 0, 0], port).into();
+
+    let manifest = Arc::new(build_manifest());
+    let state = AppState {
+        manifest: manifest.clone(),
+    };
+
+    let app = Router::new()
+        .route("/manifest.json", get(manifest_handler))
+        .route("/health", get(health_handler))
+        .route("/trpc/examplerust.hello.greet", post(greet_handler))
+        .with_state(state);
+
+    let listener = tokio::net::TcpListener::bind(addr)
+        .await
+        .expect("bind listener");
+    info!(%addr, pillar = PILLAR_ID, "rust reference pillar listening");
+
+    let base_url = env::var("POPS_PILLAR_BASE_URL")
+        .unwrap_or_else(|_| format!("http://{}:{}", PILLAR_ID, port));
+    tokio::spawn(register_on_boot(base_url, manifest));
+
+    axum::serve(listener, app).await.expect("serve");
+}
+
+// ---------------------------------------------------------------------------
+// Manifest
+// ---------------------------------------------------------------------------
+
+fn build_manifest() -> Value {
+    json!({
+        "pillar": PILLAR_ID,
+        "version": PILLAR_VERSION,
+        "contract": {
+            "package": "@pops/example-rust-contract",
+            "version": PILLAR_VERSION,
+            "tag": format!("contract-example-rust@v{}", PILLAR_VERSION),
+        },
+        "routes": {
+            "queries": ["examplerust.hello.greet"],
+            "mutations": [],
+            "subscriptions": [],
+        },
+        "search": { "adapters": [] },
+        "ai": { "tools": [] },
+        "uri": { "types": [] },
+        "settings": { "keys": [] },
+        "healthcheck": { "path": "/health" },
+    })
+}
+
+async fn manifest_handler(State(state): State<AppState>, headers: HeaderMap) -> Response {
+    if let Some(rejection) = enforce_wire_version(&headers) {
+        return rejection;
+    }
+    let mut response = Json(state.manifest.as_ref().clone()).into_response();
+    let h = response.headers_mut();
+    h.insert(header::CACHE_CONTROL, HeaderValue::from_static("no-store"));
+    echo_request_id(&headers, h);
+    response
+}
+
+// ---------------------------------------------------------------------------
+// Health
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize)]
+struct HealthQuery {
+    simulate: Option<String>,
+}
+
+async fn health_handler(Query(q): Query<HealthQuery>, headers: HeaderMap) -> Response {
+    let now = OffsetDateTime::now_utc()
+        .format(&Rfc3339)
+        .unwrap_or_else(|_| "1970-01-01T00:00:00Z".into());
+
+    if q.simulate.as_deref() == Some("unhealthy") {
+        let body = json!({
+            "ok": false,
+            "status": "unhealthy",
+            "pillar": PILLAR_ID,
+            "version": PILLAR_VERSION,
+            "ts": now,
+            "reason": "simulated by ?simulate=unhealthy",
+        });
+        let mut response = (StatusCode::SERVICE_UNAVAILABLE, Json(body)).into_response();
+        echo_request_id(&headers, response.headers_mut());
+        return response;
+    }
+
+    let body = json!({
+        "ok": true,
+        "status": "healthy",
+        "pillar": PILLAR_ID,
+        "version": PILLAR_VERSION,
+        "ts": now,
+    });
+    let mut response = Json(body).into_response();
+    echo_request_id(&headers, response.headers_mut());
+    response
+}
+
+// ---------------------------------------------------------------------------
+// Greet procedure — the minimal happy-path tRPC handler
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize)]
+struct TrpcBody {
+    input: Option<Value>,
+}
+
+async fn greet_handler(headers: HeaderMap, body: Option<Json<Value>>) -> Response {
+    if let Some(rejection) = enforce_wire_version(&headers) {
+        return rejection;
+    }
+    let parsed: TrpcBody = match body {
+        Some(Json(raw)) => match serde_json::from_value(raw) {
+            Ok(v) => v,
+            Err(_) => return trpc_error(StatusCode::OK, "BAD_REQUEST", "malformed envelope", &headers),
+        },
+        None => return trpc_error(StatusCode::OK, "BAD_REQUEST", "missing body", &headers),
+    };
+    if parsed.input.is_none() {
+        return trpc_error(StatusCode::OK, "BAD_REQUEST", "missing input field", &headers);
+    }
+    let body = json!({
+        "result": {
+            "data": { "greeting": "hello from rust" }
+        }
+    });
+    let mut response = Json(body).into_response();
+    echo_request_id(&headers, response.headers_mut());
+    response
+}
+
+fn trpc_error(status: StatusCode, code: &str, message: &str, req_headers: &HeaderMap) -> Response {
+    let body = json!({
+        "error": {
+            "code": code,
+            "message": message,
+            "data": {
+                "code": code,
+                "httpStatus": status.as_u16(),
+                "path": "examplerust.hello.greet",
+            }
+        }
+    });
+    let mut response = (status, Json(body)).into_response();
+    echo_request_id(req_headers, response.headers_mut());
+    response
+}
+
+fn enforce_wire_version(headers: &HeaderMap) -> Option<Response> {
+    let raw = headers.get(WIRE_VERSION_HEADER)?.to_str().ok()?;
+    let version: u32 = raw.parse().ok()?;
+    if SUPPORTED_WIRE_VERSIONS.contains(&version) {
+        return None;
+    }
+    let body = json!({
+        "error": {
+            "code": "METHOD_NOT_SUPPORTED",
+            "message": format!("wire version {} is not supported", version),
+            "data": {
+                "code": "METHOD_NOT_SUPPORTED",
+                "httpStatus": 405,
+                "supportedVersions": SUPPORTED_WIRE_VERSIONS,
+            }
+        }
+    });
+    let mut response = (StatusCode::OK, Json(body)).into_response();
+    echo_request_id(headers, response.headers_mut());
+    Some(response)
+}
+
+fn echo_request_id(req_headers: &HeaderMap, out: &mut HeaderMap) {
+    if let Some(rid) = req_headers.get(REQUEST_ID_HEADER) {
+        out.insert(REQUEST_ID_HEADER, rid.clone());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Boot-time registration — §6 of the spec
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+struct RegisterPayload<'a> {
+    input: RegisterInput<'a>,
+}
+
+#[derive(Serialize)]
+struct RegisterInput<'a> {
+    #[serde(rename = "pillarId")]
+    pillar_id: &'a str,
+    #[serde(rename = "baseUrl")]
+    base_url: &'a str,
+    manifest: &'a Value,
+    #[serde(rename = "apiKey")]
+    api_key: &'a str,
+}
+
+async fn register_on_boot(base_url: String, manifest: Arc<Value>) {
+    let core_base = match env::var("POPS_CORE_BASE_URL") {
+        Ok(v) => v,
+        Err(_) => {
+            warn!("POPS_CORE_BASE_URL not set — skipping registration (run-as-fixture mode)");
+            return;
+        }
+    };
+    let api_key = match env::var("POPS_INTERNAL_API_KEY") {
+        Ok(v) => v,
+        Err(_) => {
+            error!("POPS_INTERNAL_API_KEY not set — aborting registration");
+            return;
+        }
+    };
+
+    let url = format!("{}/trpc/core.registry.register", core_base.trim_end_matches('/'));
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .expect("reqwest client");
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(5 * 60);
+    let mut attempt: u32 = 0;
+    let mut base_delay_ms: u64 = 1_000;
+
+    loop {
+        attempt += 1;
+        let payload = RegisterPayload {
+            input: RegisterInput {
+                pillar_id: PILLAR_ID,
+                base_url: &base_url,
+                manifest: manifest.as_ref(),
+                api_key: &api_key,
+            },
+        };
+        let req = client
+            .post(&url)
+            .header(INTERNAL_KEY_HEADER, &api_key)
+            .header(WIRE_VERSION_HEADER, "1")
+            .header(REQUEST_ID_HEADER, uuid::Uuid::new_v4().to_string())
+            .json(&payload);
+
+        match req.send().await {
+            Ok(res) => {
+                let status = res.status();
+                let body: Value = res.json().await.unwrap_or_else(|_| Value::Null);
+                if status.is_success() && registration_ok(&body) {
+                    info!(attempt, "registration succeeded");
+                    return;
+                }
+                if let Some(code) = body
+                    .get("error")
+                    .and_then(|e| e.get("code"))
+                    .and_then(|c| c.as_str())
+                {
+                    if code == "UNAUTHORIZED" {
+                        error!("registration rejected with UNAUTHORIZED — fix POPS_INTERNAL_API_KEY; not retrying");
+                        return;
+                    }
+                    if code == "BAD_REQUEST" {
+                        error!(?body, "registration rejected with BAD_REQUEST — manifest invalid; not retrying");
+                        return;
+                    }
+                }
+                warn!(attempt, ?status, ?body, "registration failed; will retry");
+            }
+            Err(err) => {
+                warn!(attempt, %err, "registration network error; will retry");
+            }
+        }
+
+        if std::time::Instant::now() >= deadline {
+            error!("registration deadline (5 minutes) exhausted — giving up");
+            return;
+        }
+        let jitter_ms: u64 = rand::thread_rng().gen_range(0..=base_delay_ms);
+        tokio::time::sleep(Duration::from_millis(jitter_ms)).await;
+        base_delay_ms = (base_delay_ms.saturating_mul(2)).min(30_000);
+    }
+}
+
+fn registration_ok(body: &Value) -> bool {
+    body.get("result")
+        .and_then(|r| r.get("data"))
+        .and_then(|d| d.get("ok"))
+        .and_then(|ok| ok.as_bool())
+        .unwrap_or(false)
+}


### PR DESCRIPTION
## Summary

- New `examples/pops-pillar-rust-example/` — minimal axum-based pillar built **directly against the wire-format v1 spec**, with zero exposure to `@pops/pillar-sdk`. Proves the spec is implementable from scratch in a non-TS language, which was the whole point of PRD-231 + PRD-233.
- Boot-time registration against `core.registry.register` (PRD-228 endpoint) with full-jitter exponential backoff and the 5-minute deadline from spec §6.5. `UNAUTHORIZED` and `BAD_REQUEST` short-circuit per spec.
- README documents the `@pops/wire-conformance` invocation needed to verify the running container.

## What it implements

| Endpoint                                | Spec  | Status |
| --------------------------------------- | ----- | ------ |
| `GET /manifest.json`                    | §5    | Done   |
| `GET /health` + `?simulate=unhealthy`   | §7    | Done   |
| `POST /trpc/examplerust.hello.greet`    | §3    | Done   |
| Boot-time `core.registry.register`      | §6    | Done   |
| `X-Request-Id` echo                     | §9.2  | Done   |
| `X-Pops-Wire-Version` rejection         | §9.1  | Done   |

## Crate choices

- `axum 0.7` over `warp` — better ergonomics for typed extractors, idiomatic `tokio` integration.
- `reqwest` (rustls-tls) for registration — keeps the runtime image free of OpenSSL.
- `serde_json::Value` for the manifest — matches what a real non-TS SDK would emit and keeps the example to a single source file.

## Conformance assertions

Verified locally via curl smoke tests:

- `WF-01-single-call-success` — passes
- `WF-13-manifest-shape` — passes (`ManifestPayloadSchema.safeParse(...)` returns `OK` against the live manifest)
- `WF-14-manifest-cache-control` — passes (`cache-control: no-store`)
- `WF-17-health-healthy` — passes
- `WF-18-health-unhealthy` — passes (503 + `ok: false`)
- `WF-19-request-id-echo` — passes
- `WF-20-wire-version-unsupported` — passes (`METHOD_NOT_SUPPORTED` + `supportedVersions: [1]`)
- `WF-15-registration-success` — only when run against a live `core-api`; documented in the README

Subscriptions (`WF-08`–`WF-12`), batched calls (`WF-04`–`WF-07`), and full error-envelope edges (`WF-02`, `WF-03`, `WF-16`) are **explicitly out of scope** per the PRD — covered by "Out of Scope" in both the PRD README and the crate README.

## Test plan

- [x] `cargo check --release` clean
- [x] `cargo build --release` clean
- [x] Manual `curl` against every endpoint matches the spec-mandated shape
- [x] Live manifest parses against `ManifestPayloadSchema` from `@pops/pillar-sdk/manifest-schema`
- [x] Husky `pre-commit` (lint-staged) ran clean
- [x] Husky `pre-push` (`pnpm typecheck`) ran clean — 67/67 turbo tasks succeeded
- [ ] Wire-conformance harness pointed at the running container in a follow-up (out of scope for the proof-of-concept commit)
