### PR TITLE
feat(cerebrum-db): scaffold embeddings + embeddings_vec slice (Wave 5 unblock)

### DIFF
--- a/apps/pops-api/src/db/backfill-cerebrum-from-shared.test.ts
+++ b/apps/pops-api/src/db/backfill-cerebrum-from-shared.test.ts
@@ -50,13 +50,40 @@ CREATE TABLE nudge_log (
 );
 `;
 
+const EMBEDDINGS_SQL = `
+CREATE TABLE embeddings (
+  id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  source_type text NOT NULL,
+  source_id text NOT NULL,
+  chunk_index integer DEFAULT 0 NOT NULL,
+  content_hash text NOT NULL,
+  content_preview text NOT NULL,
+  model text NOT NULL,
+  dimensions integer NOT NULL,
+  created_at text NOT NULL
+);
+CREATE UNIQUE INDEX uq_embeddings_source_chunk
+  ON embeddings (source_type, source_id, chunk_index);
+`;
+
 function openSharedWithSeed(seed: (raw: BetterSqlite3.Database) => void): string {
   const path = join(tmpDir, 'pops.db');
   const raw = new BetterSqlite3(path);
   raw.exec(NUDGE_LOG_SQL);
+  raw.exec(EMBEDDINGS_SQL);
   seed(raw);
   raw.close();
   return path;
+}
+
+function insertEmbedding(raw: BetterSqlite3.Database, sourceId: string, chunkIndex = 0): void {
+  raw
+    .prepare(
+      `INSERT INTO embeddings
+        (source_type, source_id, chunk_index, content_hash, content_preview, model, dimensions, created_at)
+       VALUES ('transactions', ?, ?, 'h', 'preview', 'text-embedding-3-small', 1536, '2026-06-13T00:00:00Z')`
+    )
+    .run(sourceId, chunkIndex);
 }
 
 function insertNudge(raw: BetterSqlite3.Database, id: string): void {
@@ -115,6 +142,32 @@ describe('backfillCerebrumFromShared', () => {
         id: string;
       }[];
       expect(rows.map((r) => r.id)).toEqual(['nudge-both', 'nudge-shared-only']);
+    } finally {
+      cerebrum.raw.close();
+    }
+  });
+
+  it('copies embeddings rows and dedupes on (source_type, source_id, chunk_index)', () => {
+    const sharedPath = openSharedWithSeed((raw) => {
+      insertEmbedding(raw, 'tx-shared-only', 0);
+      insertEmbedding(raw, 'tx-both', 0);
+      insertEmbedding(raw, 'tx-both', 1);
+    });
+
+    const cerebrum = openCerebrumDb(join(tmpDir, 'cerebrum.db'), { loadVec: false });
+    try {
+      insertEmbedding(cerebrum.raw, 'tx-both', 0);
+      backfillCerebrumFromShared(cerebrum, sharedPath);
+      backfillCerebrumFromShared(cerebrum, sharedPath);
+
+      const rows = cerebrum.raw
+        .prepare('SELECT source_id, chunk_index FROM embeddings ORDER BY source_id, chunk_index')
+        .all() as { source_id: string; chunk_index: number }[];
+      expect(rows).toEqual([
+        { source_id: 'tx-both', chunk_index: 0 },
+        { source_id: 'tx-both', chunk_index: 1 },
+        { source_id: 'tx-shared-only', chunk_index: 0 },
+      ]);
     } finally {
       cerebrum.raw.close();
     }

--- a/apps/pops-api/src/db/backfill-cerebrum-from-shared.ts
+++ b/apps/pops-api/src/db/backfill-cerebrum-from-shared.ts
@@ -7,9 +7,10 @@
  * (PRD-179), plexus (PRD-180), glia (PRD-181), and conversations
  * (PRD-182) entries have been retired from the backfill — their PR3
  * writer cutovers were verified in prod, so no further rows can land
- * on the shared `pops.db` for those tables. The only remaining bridge
- * is `nudge_log`, which carries forward until the nudges pillar flips
- * its writer (Track M5 / PRD-149).
+ * on the shared `pops.db` for those tables. The remaining bridges are
+ * `nudge_log` (until Track M5 / PRD-149 flips the nudges writer) and
+ * `embeddings` (PRD-076 / theme-13 wave-5 — the slice scaffold landed
+ * here, hot-path writer cutover follows in a subsequent PR).
  *
  * Subsequent boots find the cerebrum copy already populated and become
  * a no-op via the `WHERE NOT EXISTS (...)` existence filter.
@@ -61,6 +62,39 @@ const TABLE_COPIES: readonly TableCopy[] = [
       'action_type',
       'action_label',
       'action_params',
+    ],
+  },
+  {
+    table: 'embeddings',
+    /**
+     * `id` is intentionally omitted from the column list. The shared
+     * pops.db assigns integer autoincrement IDs that may collide with
+     * IDs the cerebrum copy has already assigned via its own
+     * autoincrement sequence — copying the PK across would corrupt the
+     * sequence and risk INSERT failures that abort the whole batch.
+     *
+     * The trade-off: the cerebrum `embeddings.id` no longer matches
+     * the shared `embeddings_vec.rowid` after the copy. That's
+     * acceptable here because the companion `embeddings_vec` virtual
+     * table is NOT copied by this backfill (vector blobs stay on the
+     * shared pops.db until writer cutover) — the next-PR writer
+     * migration rebuilds `embeddings_vec` on cerebrum.db from fresh
+     * embedding requests, keyed against the new IDs.
+     *
+     * The existence filter dedupes on
+     * (source_type, source_id, chunk_index), which is the natural
+     * business key per the `uq_embeddings_source_chunk` unique index.
+     */
+    idColumns: ['source_type', 'source_id', 'chunk_index'],
+    columns: [
+      'source_type',
+      'source_id',
+      'chunk_index',
+      'content_hash',
+      'content_preview',
+      'model',
+      'dimensions',
+      'created_at',
     ],
   },
 ];

--- a/packages/cerebrum-db/migrations/0054_embeddings_baseline.sql
+++ b/packages/cerebrum-db/migrations/0054_embeddings_baseline.sql
@@ -1,0 +1,33 @@
+-- Cerebrum pillar baseline for the embeddings slice (PRD-076 / theme-13).
+--
+-- Mirrors the embeddings metadata schema as it stands in the shared
+-- pops.db (drizzle-migrations/0032_embeddings.sql). Column definitions
+-- and indexes are copied verbatim so a fresh cerebrum.db matches the
+-- shared shape byte-for-byte; the boot-time backfill ATTACHes pops.db
+-- and copies rows across without column-rename gymnastics.
+--
+-- The companion `embeddings_vec` virtual table is NOT created via this
+-- migration — it requires the sqlite-vec extension and is created
+-- imperatively by `ensureEmbeddingsVecTable` after the extension loads
+-- in `openCerebrumDb`. Drizzle's schema builder cannot express virtual
+-- tables, and keeping the create-virtual-table call out of the
+-- migration journal lets the embeddings baseline still succeed on
+-- builds where sqlite-vec is unavailable (the metadata table is useful
+-- on its own for sweeps and dedupe; vector search is the only feature
+-- that needs the extension).
+
+CREATE TABLE `embeddings` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`source_type` text NOT NULL,
+	`source_id` text NOT NULL,
+	`chunk_index` integer DEFAULT 0 NOT NULL,
+	`content_hash` text NOT NULL,
+	`content_preview` text NOT NULL,
+	`model` text NOT NULL,
+	`dimensions` integer NOT NULL,
+	`created_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `uq_embeddings_source_chunk` ON `embeddings` (`source_type`,`source_id`,`chunk_index`);--> statement-breakpoint
+CREATE INDEX `idx_embeddings_source_type` ON `embeddings` (`source_type`);--> statement-breakpoint
+CREATE INDEX `idx_embeddings_content_hash` ON `embeddings` (`content_hash`);

--- a/packages/cerebrum-db/migrations/meta/_journal.json
+++ b/packages/cerebrum-db/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1782086400000,
       "tag": "0053_plexus_baseline",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1782172800000,
+      "tag": "0054_embeddings_baseline",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cerebrum-db/src/__tests__/open-cerebrum-db.test.ts
+++ b/packages/cerebrum-db/src/__tests__/open-cerebrum-db.test.ts
@@ -13,7 +13,7 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { openCerebrumDb } from '../open-cerebrum-db.js';
-import { engramIndex, nudgeLog } from '../schema.js';
+import { embeddings, engramIndex, nudgeLog } from '../schema.js';
 import { upsertEngramIndex } from '../services/engrams.js';
 import { persistCandidates } from '../services/nudge-log.js';
 
@@ -94,6 +94,57 @@ describe('openCerebrumDb', () => {
         links: [],
       });
       expect(db.select().from(engramIndex).all()).toHaveLength(1);
+    } finally {
+      raw.close();
+    }
+  });
+
+  it('applies the embeddings baseline with the documented schema (PRD-076)', () => {
+    const path = join(tmpDir, 'cerebrum.db');
+    const { db, raw } = openCerebrumDb(path, { loadVec: false });
+    try {
+      expect(db.select().from(embeddings).all()).toHaveLength(0);
+
+      const inserted = db
+        .insert(embeddings)
+        .values({
+          sourceType: 'transactions',
+          sourceId: 'tx-1',
+          chunkIndex: 0,
+          contentHash: 'h',
+          contentPreview: 'preview',
+          model: 'text-embedding-3-small',
+          dimensions: 1536,
+          createdAt: '2026-06-13T00:00:00Z',
+        })
+        .returning({ id: embeddings.id })
+        .all();
+      expect(inserted).toHaveLength(1);
+      expect(typeof inserted[0].id).toBe('number');
+
+      const indexes = raw
+        .prepare(`SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='embeddings'`)
+        .all() as { name: string }[];
+      const names = indexes.map((r) => r.name).toSorted();
+      expect(names).toContain('uq_embeddings_source_chunk');
+      expect(names).toContain('idx_embeddings_source_type');
+      expect(names).toContain('idx_embeddings_content_hash');
+
+      expect(() =>
+        db
+          .insert(embeddings)
+          .values({
+            sourceType: 'transactions',
+            sourceId: 'tx-1',
+            chunkIndex: 0,
+            contentHash: 'h2',
+            contentPreview: 'preview2',
+            model: 'text-embedding-3-small',
+            dimensions: 1536,
+            createdAt: '2026-06-13T00:00:00Z',
+          })
+          .run()
+      ).toThrow(/UNIQUE/i);
     } finally {
       raw.close();
     }

--- a/packages/cerebrum-db/src/index.ts
+++ b/packages/cerebrum-db/src/index.ts
@@ -33,8 +33,13 @@
  *     config loading, the per-adapter HTTP clients, the lifecycle
  *     orchestrator and the encrypted-config envelope all stay in
  *     pops-api until PRD-180 US-03.
+ *   - Theme-13 wave-5 added the embeddings slice — schema re-export,
+ *     baseline migration (`0054_embeddings_baseline.sql`), and the
+ *     `embeddings` table copied into the backfill bridge. The hot-path
+ *     handlers in `apps/pops-api/src/jobs/handlers/embeddings-source.ts`
+ *     and `embeddings-helpers.ts` migrate over to `getCerebrumDrizzle()`
+ *     in the next PR.
  *
- * The remaining slice (embeddings) follows in a subsequent PR.
  * Cerebrum's load-bearing surgery is the URI dispatcher round-trip
  * (engrams reference other pillars' entities by URI) — that lands when
  * the consumers cut over, not in this scaffold.

--- a/packages/cerebrum-db/src/schema.ts
+++ b/packages/cerebrum-db/src/schema.ts
@@ -20,14 +20,18 @@
  *     conversation → engram junction table.
  *   - `plexusAdapters` / `plexusFilters` — PRD-180 external adapter
  *     registry + per-adapter ingestion filter rules (PRD-090).
- *
- * Downstream slices (embeddings) will add their tables here as their
- * service code lands.
+ *   - `embeddings` — PRD-076 dense-vector metadata table (one row per
+ *     content chunk). The companion `embeddings_vec` virtual table
+ *     (sqlite-vec `vec0`) is created imperatively in `openCerebrumDb`
+ *     when the extension is available; it has no drizzle table object
+ *     because virtual tables cannot be represented in the schema
+ *     builder.
  */
 export { engramIndex, engramLinks, engramScopes, engramTags, nudgeLog } from '@pops/db-types';
 export {
   conversationContext,
   conversations,
+  embeddings,
   gliaActions,
   gliaTrustState,
   messages,


### PR DESCRIPTION
## Summary

Lands the embeddings slice scaffold in `@pops/cerebrum-db`, unblocking the Wave 5 hot-path migrations of `apps/pops-api/src/jobs/handlers/embeddings-source.ts` and `embeddings-helpers.ts`. These two handlers were the last cerebrum consumers still reaching for `getDrizzle()` / `getDb()` against the legacy shared pops.db because the embeddings tables had not been replicated in the cerebrum pillar yet — per the cerebrum-db schema doc, *"downstream slices (embeddings) will add their tables here as their service code lands."*

## Changes

- `packages/cerebrum-db/migrations/0054_embeddings_baseline.sql` — mirrors the shared pops.db `embeddings` metadata schema byte-for-byte (column defs + indexes copied from `drizzle-migrations/0032_embeddings.sql`).
- `packages/cerebrum-db/migrations/meta/_journal.json` — journal entry for `0054_embeddings_baseline`.
- `packages/cerebrum-db/src/schema.ts` — re-exports `embeddings` from `@pops/db-types/schema`.
- `packages/cerebrum-db/src/index.ts` — barrel docstring updated to record the slice landing.
- `apps/pops-api/src/db/backfill-cerebrum-from-shared.ts` — `embeddings` added to the bridge. PK `id` is intentionally omitted from the carried columns (the shared autoincrement sequence would collide with cerebrum's); dedupe key is `(source_type, source_id, chunk_index)` per the unique index.

## Extension handling

The companion `embeddings_vec` virtual table stays out of the drizzle journal — virtual tables aren't representable in the schema builder. It continues to be created imperatively by `ensureEmbeddingsVecTable` inside `openCerebrumDb` after `tryLoadVecExtension` succeeds. When sqlite-vec isn't available the metadata table still applies cleanly; only vector search is gated. The vec blobs are NOT bridged — they're rebuilt by the writer-cutover PR against the new cerebrum-side PKs.

## Hot-paths unblocked

- `apps/pops-api/src/jobs/handlers/embeddings-source.ts` — `fetchContent` + `deleteEmbeddingsForSource`.
- `apps/pops-api/src/jobs/handlers/embeddings-helpers.ts` — `findExistingEmbedding`, `upsertEmbedding`, `pruneOrphanChunks`, `writeAiUsage`, and the `embeddings_vec` rowid inserts/deletes.

Both are ready to cut over from `getDrizzle()` / `getDb()` to `getCerebrumDrizzle()` / the cerebrum raw handle in the next PR.

## Test plan

- [x] cerebrum-db: new `applies the embeddings baseline` test exercises insert via the drizzle table object, verifies the unique constraint, and checks all three indexes are present (`pnpm --filter @pops/cerebrum-db test` — 120 passed).
- [x] pops-api: new backfill case covers mixed-state copy + idempotent re-run + dedupe on `(source_type, source_id, chunk_index)` (`pnpm vitest run src/db/backfill-cerebrum-from-shared.test.ts` — 5 passed).
- [x] pops-api: existing `embeddings.test.ts` still passes (9/9) — no regression on the legacy callers.
- [x] `pnpm --filter @pops/cerebrum-db typecheck` clean.
- [x] `pnpm --filter @pops/api typecheck` clean.