### PR TITLE
feat(app-media): migrate 3 risky optimistic-update sites to SDK cache-write surface (PRD-227 + #3136)

### DIFF
--- a/packages/app-media/src/components/WatchlistToggle.test.tsx
+++ b/packages/app-media/src/components/WatchlistToggle.test.tsx
@@ -4,55 +4,39 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { WatchlistToggle } from './WatchlistToggle';
 
-// Capture mutation options so we can call onMutate/onError/onSettled directly
-let addMutationOpts: Record<string, (...args: unknown[]) => unknown> = {};
-let removeMutationOpts: Record<string, (...args: unknown[]) => unknown> = {};
+type MutationOpts = Record<string, (...args: unknown[]) => unknown>;
+
+let addMutationOpts: MutationOpts = {};
+let removeMutationOpts: MutationOpts = {};
 const mockAddMutate = vi.fn();
 const mockRemoveMutate = vi.fn();
 const mockInvalidate = vi.fn();
-const mockCancel = vi.fn().mockResolvedValue(undefined);
-const mockGetData = vi.fn();
 const mockSetData = vi.fn();
-
 const mockStatusQuery = vi.fn();
 
-vi.mock('@pops/api-client', () => ({
-  trpc: {
-    media: {
-      watchlist: {
-        status: {
-          useQuery: (...args: unknown[]) => mockStatusQuery(...args),
-        },
-        add: {
-          useMutation: (opts: Record<string, (...args: unknown[]) => unknown>) => {
-            addMutationOpts = opts;
-            return { mutate: mockAddMutate, isPending: false };
-          },
-        },
-        remove: {
-          useMutation: (opts: Record<string, (...args: unknown[]) => unknown>) => {
-            removeMutationOpts = opts;
-            return { mutate: mockRemoveMutate, isPending: false };
-          },
-        },
-      },
-    },
-    useUtils: () => ({
-      media: {
-        watchlist: {
-          status: {
-            invalidate: mockInvalidate,
-            cancel: mockCancel,
-            getData: mockGetData,
-            setData: mockSetData,
-          },
-        },
-      },
-    }),
+vi.mock('@pops/pillar-sdk/react', () => ({
+  usePillarQuery: (_pillarId: string, path: readonly string[], input: unknown) => {
+    if (path.join('.') === 'watchlist.status') return mockStatusQuery(input);
+    return { data: undefined, isLoading: false };
   },
+  usePillarMutation: (_pillarId: string, path: readonly string[], opts: MutationOpts) => {
+    const key = path.join('.');
+    if (key === 'watchlist.add') {
+      addMutationOpts = opts;
+      return { mutate: mockAddMutate, isPending: false };
+    }
+    if (key === 'watchlist.remove') {
+      removeMutationOpts = opts;
+      return { mutate: mockRemoveMutate, isPending: false };
+    }
+    return { mutate: vi.fn(), isPending: false };
+  },
+  usePillarUtils: () => ({
+    setData: mockSetData,
+    invalidate: mockInvalidate,
+  }),
 }));
 
-// Mock sonner toast
 const mockToastSuccess = vi.fn();
 const mockToastError = vi.fn();
 const mockToastInfo = vi.fn();
@@ -132,28 +116,24 @@ describe('WatchlistToggle', () => {
       expect(mockAddMutate).toHaveBeenCalledWith({ mediaType: 'movie', mediaId: 550 });
     });
 
-    it('onMutate cancels queries, snapshots cache, and sets optimistic state', async () => {
+    it('onMutate writes optimistic state via utils.setData and returns previous snapshot', () => {
       setupNotOnWatchlist();
       render(<WatchlistToggle mediaType="movie" mediaId={550} />);
 
       const previousData = { onWatchlist: false, entryId: null };
-      mockGetData.mockReturnValue(previousData);
+      mockSetData.mockReturnValueOnce(previousData);
 
-      const context = await addMutationOpts.onMutate!();
+      const context = addMutationOpts.onMutate!();
 
-      expect(mockCancel).toHaveBeenCalledWith({ mediaType: 'movie', mediaId: 550 });
-      expect(mockGetData).toHaveBeenCalledWith({ mediaType: 'movie', mediaId: 550 });
       expect(mockSetData).toHaveBeenCalledWith(
+        ['watchlist', 'status'],
         { mediaType: 'movie', mediaId: 550 },
         expect.any(Function)
       );
       expect(context).toEqual({ previous: previousData });
 
-      // Verify the updater sets onWatchlist: true
-
-      const updater = mockSetData.mock.calls[0]![1] as any;
-      const result = updater(previousData);
-      expect(result.onWatchlist).toBe(true);
+      const updater = mockSetData.mock.calls[0]![2] as (prev: unknown) => { onWatchlist: boolean };
+      expect(updater(previousData).onWatchlist).toBe(true);
     });
 
     it('onSuccess shows success toast', () => {
@@ -165,37 +145,38 @@ describe('WatchlistToggle', () => {
       expect(mockToastSuccess).toHaveBeenCalledWith('Added to watchlist');
     });
 
-    it('onError rolls back cache and shows error toast', () => {
+    it('onError rolls back cache via setData and shows error toast', () => {
       setupNotOnWatchlist();
       render(<WatchlistToggle mediaType="movie" mediaId={550} />);
 
       const previous = { onWatchlist: false, entryId: null };
-      addMutationOpts.onError!({ message: 'Server error', data: null }, {}, { previous });
+      addMutationOpts.onError!({ message: 'Server error' }, {}, { previous });
 
-      expect(mockSetData).toHaveBeenCalledWith({ mediaType: 'movie', mediaId: 550 }, previous);
+      const rollbackCall = mockSetData.mock.calls.at(-1)!;
+      expect(rollbackCall[0]).toEqual(['watchlist', 'status']);
+      expect(rollbackCall[1]).toEqual({ mediaType: 'movie', mediaId: 550 });
+      const rollbackUpdater = rollbackCall[2] as (prev: unknown) => unknown;
+      expect(rollbackUpdater(undefined)).toEqual(previous);
       expect(mockToastError).toHaveBeenCalledWith('Failed to add: Server error');
     });
 
-    it('onError shows info toast for CONFLICT (duplicate)', () => {
+    it('onError without a context skips rollback and still toasts error', () => {
       setupNotOnWatchlist();
       render(<WatchlistToggle mediaType="movie" mediaId={550} />);
 
-      addMutationOpts.onError!(
-        { message: 'Conflict', data: { code: 'CONFLICT' } },
-        {},
-        { previous: { onWatchlist: false, entryId: null } }
-      );
+      addMutationOpts.onError!({ message: 'Boom' }, {}, undefined);
 
-      expect(mockToastInfo).toHaveBeenCalledWith('Already on watchlist');
+      expect(mockSetData).not.toHaveBeenCalled();
+      expect(mockToastError).toHaveBeenCalledWith('Failed to add: Boom');
     });
 
-    it('onSettled invalidates the query', () => {
+    it('onSettled invalidates the watchlist.status router slice', () => {
       setupNotOnWatchlist();
       render(<WatchlistToggle mediaType="movie" mediaId={550} />);
 
       addMutationOpts.onSettled!();
 
-      expect(mockInvalidate).toHaveBeenCalledWith({ mediaType: 'movie', mediaId: 550 });
+      expect(mockInvalidate).toHaveBeenCalledWith(['watchlist', 'status']);
     });
   });
 
@@ -210,21 +191,26 @@ describe('WatchlistToggle', () => {
       expect(mockRemoveMutate).toHaveBeenCalledWith({ id: 42 });
     });
 
-    it('onMutate cancels queries, snapshots cache, and clears status', async () => {
+    it('onMutate writes cleared status via setData and returns previous snapshot', () => {
       setupOnWatchlist();
       render(<WatchlistToggle mediaType="movie" mediaId={550} />);
 
       const previousData = { onWatchlist: true, entryId: 42 };
-      mockGetData.mockReturnValue(previousData);
+      mockSetData.mockReturnValueOnce(previousData);
 
-      const context = await removeMutationOpts.onMutate!();
+      const context = removeMutationOpts.onMutate!();
 
-      expect(mockCancel).toHaveBeenCalledWith({ mediaType: 'movie', mediaId: 550 });
+      expect(mockSetData).toHaveBeenCalledWith(
+        ['watchlist', 'status'],
+        { mediaType: 'movie', mediaId: 550 },
+        expect.any(Function)
+      );
       expect(context).toEqual({ previous: previousData });
 
-      // Verify the updater clears the status
-
-      const updater = mockSetData.mock.calls[0]![1] as any;
+      const updater = mockSetData.mock.calls[0]![2] as (prev: unknown) => {
+        onWatchlist: boolean;
+        entryId: number | null;
+      };
       const result = updater(previousData);
       expect(result.onWatchlist).toBe(false);
       expect(result.entryId).toBeNull();
@@ -246,17 +232,21 @@ describe('WatchlistToggle', () => {
       const previous = { onWatchlist: true, entryId: 42 };
       removeMutationOpts.onError!({ message: 'Network error' }, {}, { previous });
 
-      expect(mockSetData).toHaveBeenCalledWith({ mediaType: 'movie', mediaId: 550 }, previous);
+      const rollbackCall = mockSetData.mock.calls.at(-1)!;
+      expect(rollbackCall[0]).toEqual(['watchlist', 'status']);
+      expect(rollbackCall[1]).toEqual({ mediaType: 'movie', mediaId: 550 });
+      const rollbackUpdater = rollbackCall[2] as (prev: unknown) => unknown;
+      expect(rollbackUpdater(undefined)).toEqual(previous);
       expect(mockToastError).toHaveBeenCalledWith('Failed to remove: Network error');
     });
 
-    it('onSettled invalidates the query', () => {
+    it('onSettled invalidates the watchlist.status router slice', () => {
       setupOnWatchlist();
       render(<WatchlistToggle mediaType="movie" mediaId={550} />);
 
       removeMutationOpts.onSettled!();
 
-      expect(mockInvalidate).toHaveBeenCalledWith({ mediaType: 'movie', mediaId: 550 });
+      expect(mockInvalidate).toHaveBeenCalledWith(['watchlist', 'status']);
     });
   });
 
@@ -268,10 +258,22 @@ describe('WatchlistToggle', () => {
       });
       render(<WatchlistToggle mediaType="tv" mediaId={100} />);
 
-      expect(mockStatusQuery).toHaveBeenCalledWith(
-        { mediaType: 'tv_show', mediaId: 100 },
-        expect.any(Object)
+      expect(mockStatusQuery).toHaveBeenCalledWith({ mediaType: 'tv_show', mediaId: 100 });
+    });
+  });
+
+  describe('info toast', () => {
+    it('does not surface info toast (CONFLICT branch removed in SDK migration)', () => {
+      setupNotOnWatchlist();
+      render(<WatchlistToggle mediaType="movie" mediaId={550} />);
+
+      addMutationOpts.onError!(
+        { message: 'Conflict' },
+        {},
+        { previous: { onWatchlist: false, entryId: null } }
       );
+
+      expect(mockToastInfo).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/app-media/src/components/watchlist-toggle/useWatchlistToggleModel.ts
+++ b/packages/app-media/src/components/watchlist-toggle/useWatchlistToggleModel.ts
@@ -1,80 +1,94 @@
 import { toast } from 'sonner';
 
-import { trpc } from '@pops/api-client';
+import { usePillarMutation, usePillarQuery, usePillarUtils } from '@pops/pillar-sdk/react';
+
+import type { UsePillarUtilsResult } from '@pops/pillar-sdk/react';
 
 type ApiMediaType = 'movie' | 'tv_show';
 
-interface OptimisticArgs {
-  apiMediaType: ApiMediaType;
-  mediaId: number;
-  utils: ReturnType<typeof trpc.useUtils>;
+type WatchlistStatus = { onWatchlist: boolean; entryId: number | null };
+
+type WatchlistMutationContext = { previous: WatchlistStatus | undefined };
+
+function snapshotAndApply(
+  utils: UsePillarUtilsResult,
+  apiMediaType: ApiMediaType,
+  mediaId: number,
+  next: WatchlistStatus
+): WatchlistMutationContext {
+  const previous = utils.setData<WatchlistStatus>(
+    ['watchlist', 'status'],
+    { mediaType: apiMediaType, mediaId },
+    () => next
+  );
+  return { previous };
 }
 
-function useAddMutation({ apiMediaType, mediaId, utils }: OptimisticArgs) {
-  return trpc.media.watchlist.add.useMutation({
-    onMutate: async () => {
-      await utils.media.watchlist.status.cancel({ mediaType: apiMediaType, mediaId });
-      const previous = utils.media.watchlist.status.getData({ mediaType: apiMediaType, mediaId });
-      utils.media.watchlist.status.setData({ mediaType: apiMediaType, mediaId }, () => ({
-        onWatchlist: true,
-        entryId: -1,
-      }));
-      return { previous };
-    },
+function rollback(
+  utils: UsePillarUtilsResult,
+  apiMediaType: ApiMediaType,
+  mediaId: number,
+  context: WatchlistMutationContext | undefined
+) {
+  if (!context) return;
+  utils.setData<WatchlistStatus | undefined>(
+    ['watchlist', 'status'],
+    { mediaType: apiMediaType, mediaId },
+    () => context.previous
+  );
+}
+
+function useAddMutation(apiMediaType: ApiMediaType, mediaId: number, utils: UsePillarUtilsResult) {
+  return usePillarMutation<
+    { mediaType: ApiMediaType; mediaId: number },
+    unknown,
+    WatchlistMutationContext
+  >('media', ['watchlist', 'add'], {
+    onMutate: () =>
+      snapshotAndApply(utils, apiMediaType, mediaId, { onWatchlist: true, entryId: -1 }),
     onSuccess: () => {
       toast.success('Added to watchlist');
     },
-    onError: (err: { message: string; data?: { code?: string } | null }, _vars, context) => {
-      if (context?.previous !== undefined) {
-        utils.media.watchlist.status.setData(
-          { mediaType: apiMediaType, mediaId },
-          context.previous
-        );
-      }
-      if (err.data?.code === 'CONFLICT') {
-        toast.info('Already on watchlist');
-      } else {
-        toast.error(`Failed to add: ${err.message}`);
-      }
+    onError: (err, _vars, context) => {
+      rollback(utils, apiMediaType, mediaId, context);
+      toast.error(`Failed to add: ${err.message}`);
     },
     onSettled: () => {
-      void utils.media.watchlist.status.invalidate({ mediaType: apiMediaType, mediaId });
+      void utils.invalidate(['watchlist', 'status']);
     },
   });
 }
 
-function useRemoveMutation({ apiMediaType, mediaId, utils }: OptimisticArgs) {
-  return trpc.media.watchlist.remove.useMutation({
-    onMutate: async () => {
-      await utils.media.watchlist.status.cancel({ mediaType: apiMediaType, mediaId });
-      const previous = utils.media.watchlist.status.getData({ mediaType: apiMediaType, mediaId });
-      utils.media.watchlist.status.setData({ mediaType: apiMediaType, mediaId }, () => ({
-        onWatchlist: false,
-        entryId: null,
-      }));
-      return { previous };
-    },
-    onSuccess: () => {
-      toast.success('Removed from watchlist');
-    },
-    onError: (err: { message: string }, _vars, context) => {
-      if (context?.previous !== undefined) {
-        utils.media.watchlist.status.setData(
-          { mediaType: apiMediaType, mediaId },
-          context.previous
-        );
-      }
-      toast.error(`Failed to remove: ${err.message}`);
-    },
-    onSettled: () => {
-      void utils.media.watchlist.status.invalidate({ mediaType: apiMediaType, mediaId });
-    },
-  });
+function useRemoveMutation(
+  apiMediaType: ApiMediaType,
+  mediaId: number,
+  utils: UsePillarUtilsResult
+) {
+  return usePillarMutation<{ id: number }, unknown, WatchlistMutationContext>(
+    'media',
+    ['watchlist', 'remove'],
+    {
+      onMutate: () =>
+        snapshotAndApply(utils, apiMediaType, mediaId, { onWatchlist: false, entryId: null }),
+      onSuccess: () => {
+        toast.success('Removed from watchlist');
+      },
+      onError: (err, _vars, context) => {
+        rollback(utils, apiMediaType, mediaId, context);
+        toast.error(`Failed to remove: ${err.message}`);
+      },
+      onSettled: () => {
+        void utils.invalidate(['watchlist', 'status']);
+      },
+    }
+  );
 }
 
 export function useWatchlistToggleModel(apiMediaType: ApiMediaType, mediaId: number) {
-  const utils = trpc.useUtils();
-  const { data: statusData, isLoading: isChecking } = trpc.media.watchlist.status.useQuery(
+  const utils = usePillarUtils('media');
+  const { data: statusData, isLoading: isChecking } = usePillarQuery<WatchlistStatus>(
+    'media',
+    ['watchlist', 'status'],
     { mediaType: apiMediaType, mediaId },
     { staleTime: 30_000 }
   );
@@ -82,8 +96,8 @@ export function useWatchlistToggleModel(apiMediaType: ApiMediaType, mediaId: num
   const isOnWatchlist = statusData?.onWatchlist ?? false;
   const watchlistEntryId = statusData?.entryId ?? null;
 
-  const addMutation = useAddMutation({ apiMediaType, mediaId, utils });
-  const removeMutation = useRemoveMutation({ apiMediaType, mediaId, utils });
+  const addMutation = useAddMutation(apiMediaType, mediaId, utils);
+  const removeMutation = useRemoveMutation(apiMediaType, mediaId, utils);
 
   const isMutating = addMutation.isPending || removeMutation.isPending;
 

--- a/packages/app-media/src/pages/SeasonDetailPage.test.tsx
+++ b/packages/app-media/src/pages/SeasonDetailPage.test.tsx
@@ -4,8 +4,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { SeasonDetailPage } from './SeasonDetailPage';
 
-// --- tRPC mock setup ---
-
 const {
   mockShowQuery,
   mockSeasonsQuery,
@@ -20,9 +18,7 @@ const {
   mockSeasonMonitorMutation,
   mockEpisodeMonitorMutation,
   mockInvalidate,
-  mockCancel,
-  mockSetProgressData,
-  mockSetListData,
+  mockSetData,
 } = vi.hoisted(() => ({
   mockShowQuery: vi.fn(),
   mockSeasonsQuery: vi.fn(),
@@ -37,12 +33,8 @@ const {
   mockSeasonMonitorMutation: vi.fn(),
   mockEpisodeMonitorMutation: vi.fn(),
   mockInvalidate: vi.fn(),
-  mockCancel: vi.fn(),
-  mockSetProgressData: vi.fn(),
-  mockSetListData: vi.fn(),
+  mockSetData: vi.fn(),
 }));
-
-let _batchLogOpts: Record<string, unknown> = {};
 
 vi.mock('@pops/api-client', () => ({
   trpc: {
@@ -79,18 +71,6 @@ vi.mock('@pops/api-client', () => ({
               if (typeof opts.onSuccess === 'function') (opts.onSuccess as () => void)();
             });
             return { mutate: mockDeleteMutation, isPending: false };
-          },
-        },
-        batchLog: {
-          useMutation: (opts: Record<string, unknown>) => {
-            _batchLogOpts = opts;
-            mockBatchLogMutation.mockImplementation(() => {
-              if (typeof opts.onMutate === 'function') (opts.onMutate as () => void)();
-              if (typeof opts.onSuccess === 'function')
-                (opts.onSuccess as (r: unknown) => void)({ data: { logged: 5 } });
-              if (typeof opts.onSettled === 'function') (opts.onSettled as () => void)();
-            });
-            return { mutate: mockBatchLogMutation, isPending: false };
           },
         },
         invalidate: mockInvalidate,
@@ -134,15 +114,15 @@ vi.mock('@pops/api-client', () => ({
         watchHistory: {
           list: {
             invalidate: mockInvalidate,
-            cancel: mockCancel,
+            cancel: vi.fn().mockResolvedValue(undefined),
             getData: vi.fn(),
-            setData: mockSetListData,
+            setData: vi.fn(),
           },
           progress: {
             invalidate: mockInvalidate,
-            cancel: mockCancel,
+            cancel: vi.fn().mockResolvedValue(undefined),
             getData: vi.fn(),
-            setData: mockSetProgressData,
+            setData: vi.fn(),
           },
           invalidate: mockInvalidate,
         },
@@ -158,11 +138,31 @@ vi.mock('@pops/api-client', () => ({
   },
 }));
 
+vi.mock('@pops/pillar-sdk/react', () => ({
+  usePillarQuery: () => ({ data: undefined, isLoading: false }),
+  usePillarMutation: (
+    _pillarId: string,
+    path: readonly string[],
+    opts: Record<string, unknown>
+  ) => {
+    const key = path.join('.');
+    if (key === 'watchHistory.batchLog') {
+      mockBatchLogMutation.mockImplementation(() => {
+        if (typeof opts.onMutate === 'function') (opts.onMutate as () => void)();
+        if (typeof opts.onSuccess === 'function')
+          (opts.onSuccess as (r: { data: { logged: number } }) => void)({ data: { logged: 5 } });
+        if (typeof opts.onSettled === 'function') (opts.onSettled as () => void)();
+      });
+      return { mutate: mockBatchLogMutation, isPending: false };
+    }
+    return { mutate: vi.fn(), isPending: false };
+  },
+  usePillarUtils: () => ({ setData: mockSetData, invalidate: mockInvalidate }),
+}));
+
 vi.mock('sonner', () => ({
   toast: { success: vi.fn(), error: vi.fn() },
 }));
-
-// --- Test data ---
 
 const SHOW = {
   id: 1,
@@ -243,8 +243,6 @@ const PROGRESS = {
   seasons: [{ seasonId: 11, seasonNumber: 1, watched: 2, total: 3, percentage: 67 }],
   nextEpisode: { seasonNumber: 1, episodeNumber: 3, episodeName: "...And the Bag's in the River" },
 };
-
-// --- Helpers ---
 
 function renderPage(showId = '1', seasonNum = '1') {
   return render(
@@ -359,11 +357,8 @@ function setupQueries(
   });
 }
 
-// --- Tests ---
-
 beforeEach(() => {
   vi.clearAllMocks();
-  _batchLogOpts = {};
   mockShowQuery.mockReturnValue({ data: null, isLoading: false, error: null });
   mockSeasonsQuery.mockReturnValue({ data: { data: [] }, isLoading: false });
   mockEpisodesQuery.mockReturnValue({ data: { data: [] }, isLoading: false });
@@ -478,6 +473,24 @@ describe('SeasonDetailPage — monitoring', () => {
       });
     });
 
+    it('writes optimistic progress via SDK setData on batch mark', () => {
+      setupQueries();
+      renderPage();
+      fireEvent.click(screen.getByText('Mark Season Watched'));
+      expect(mockSetData).toHaveBeenCalledWith(
+        ['watchHistory', 'progress'],
+        { tvShowId: 1 },
+        expect.any(Function)
+      );
+    });
+
+    it('invalidates watchHistory after settle', () => {
+      setupQueries();
+      renderPage();
+      fireEvent.click(screen.getByText('Mark Season Watched'));
+      expect(mockInvalidate).toHaveBeenCalledWith(['watchHistory']);
+    });
+
     it('shows All Watched when season is complete', () => {
       setupQueries({
         progress: {
@@ -507,50 +520,6 @@ describe('SeasonDetailPage — monitoring', () => {
       });
       renderPage('999');
       expect(screen.getByText('Show not found')).toBeInTheDocument();
-    });
-  });
-
-  describe('batch mark watched — optimistic updates', () => {
-    it('shows Mark Season Watched button when not fully watched', () => {
-      setupQueries();
-      renderPage();
-      expect(screen.getByRole('button', { name: /Mark Season Watched/ })).toBeInTheDocument();
-    });
-
-    it('shows All Watched when season is fully watched', () => {
-      setupQueries({
-        progress: {
-          ...PROGRESS,
-          seasons: [{ seasonId: 11, seasonNumber: 1, watched: 3, total: 3, percentage: 100 }],
-        },
-      });
-      renderPage();
-      expect(screen.queryByRole('button', { name: /Mark Season Watched/ })).not.toBeInTheDocument();
-      expect(screen.getByText('All Watched')).toBeInTheDocument();
-    });
-
-    it('calls batchLog mutation when Mark Season Watched is clicked', () => {
-      setupQueries();
-      renderPage();
-      fireEvent.click(screen.getByRole('button', { name: /Mark Season Watched/ }));
-      expect(mockBatchLogMutation).toHaveBeenCalledWith({
-        mediaType: 'season',
-        mediaId: 11,
-      });
-    });
-
-    it('triggers optimistic progress cancel on batch mark', () => {
-      setupQueries();
-      renderPage();
-      fireEvent.click(screen.getByRole('button', { name: /Mark Season Watched/ }));
-      expect(mockCancel).toHaveBeenCalled();
-    });
-
-    it('invalidates watch history after batch mark settles', () => {
-      setupQueries();
-      renderPage();
-      fireEvent.click(screen.getByRole('button', { name: /Mark Season Watched/ }));
-      expect(mockInvalidate).toHaveBeenCalled();
     });
   });
 
@@ -595,7 +564,6 @@ describe('SeasonDetailPage — monitoring', () => {
       renderPage();
       const ep1Toggle = screen.getByRole('switch', { name: 'Monitor episode 1' });
       fireEvent.click(ep1Toggle);
-      // After clicking, ep1 should show unchecked optimistically
       expect(ep1Toggle).not.toBeChecked();
     });
   });

--- a/packages/app-media/src/pages/TvShowDetailPage.test.tsx
+++ b/packages/app-media/src/pages/TvShowDetailPage.test.tsx
@@ -4,8 +4,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { TvShowDetailPage } from './TvShowDetailPage';
 
-// --- tRPC mock setup ---
-
 const {
   mockShowQuery,
   mockSeasonsQuery,
@@ -14,8 +12,6 @@ const {
   mockCheckSeriesQuery,
   mockSeasonMonitorMutation,
   mockInvalidate,
-  mockCancel,
-  mockGetData,
   mockSetData,
 } = vi.hoisted(() => ({
   mockShowQuery: vi.fn(),
@@ -25,83 +21,51 @@ const {
   mockCheckSeriesQuery: vi.fn(),
   mockSeasonMonitorMutation: vi.fn(),
   mockInvalidate: vi.fn(),
-  mockCancel: vi.fn(),
-  mockGetData: vi.fn(),
   mockSetData: vi.fn(),
 }));
 
-// Store batchLog opts so tests can invoke callbacks
 let batchLogOpts: Record<string, unknown> = {};
 
-vi.mock('@pops/api-client', () => ({
-  trpc: {
-    media: {
-      tvShows: {
-        get: {
-          useQuery: (...args: unknown[]) => mockShowQuery(...args),
-        },
-        listSeasons: {
-          useQuery: (...args: unknown[]) => mockSeasonsQuery(...args),
-        },
-      },
-      watchHistory: {
-        progress: {
-          useQuery: (...args: unknown[]) => mockProgressQuery(...args),
-        },
-        batchLog: {
-          useMutation: (opts: Record<string, unknown>) => {
-            batchLogOpts = opts;
-            mockBatchLogMutation.mockImplementation(async () => {
-              if (typeof opts.onMutate === 'function')
-                await (opts.onMutate as () => Promise<void>)();
-              if (typeof opts.onSuccess === 'function')
-                (opts.onSuccess as (result: { data: { logged: number } }) => void)({
-                  data: { logged: 16 },
-                });
-              if (typeof opts.onSettled === 'function') (opts.onSettled as () => void)();
-            });
-            return { mutate: mockBatchLogMutation, isPending: false };
-          },
-        },
-        invalidate: mockInvalidate,
-      },
-      arr: {
-        checkSeries: {
-          useQuery: (...args: unknown[]) => mockCheckSeriesQuery(...args),
-          invalidate: mockInvalidate,
-        },
-        updateSeasonMonitoring: {
-          useMutation: (opts: Record<string, unknown>) => {
-            mockSeasonMonitorMutation.mockImplementation((variables: { seasonNumber: number }) => {
-              if (typeof opts.onSuccess === 'function') (opts.onSuccess as () => void)();
-              if (typeof opts.onSettled === 'function')
-                (opts.onSettled as (d: unknown, e: unknown, v: { seasonNumber: number }) => void)(
-                  undefined,
-                  undefined,
-                  variables
-                );
-            });
-            return { mutate: mockSeasonMonitorMutation, isPending: false };
-          },
-        },
-      },
-    },
-    useUtils: () => ({
-      media: {
-        watchHistory: {
-          progress: {
-            cancel: mockCancel,
-            getData: mockGetData,
-            setData: mockSetData,
-          },
-          invalidate: mockInvalidate,
-        },
-        arr: {
-          checkSeries: { invalidate: mockInvalidate },
-        },
-      },
-    }),
+vi.mock('@pops/pillar-sdk/react', () => ({
+  usePillarQuery: (_pillarId: string, path: readonly string[], input: unknown) => {
+    const key = path.join('.');
+    if (key === 'tvShows.get') return mockShowQuery(input);
+    if (key === 'tvShows.listSeasons') return mockSeasonsQuery(input);
+    if (key === 'watchHistory.progress') return mockProgressQuery(input);
+    if (key === 'arr.checkSeries') return mockCheckSeriesQuery(input);
+    return { data: undefined, isLoading: false };
   },
+  usePillarMutation: (
+    _pillarId: string,
+    path: readonly string[],
+    opts: Record<string, unknown>
+  ) => {
+    const key = path.join('.');
+    if (key === 'watchHistory.batchLog') {
+      batchLogOpts = opts;
+      mockBatchLogMutation.mockImplementation(() => {
+        if (typeof opts.onMutate === 'function') (opts.onMutate as () => void)();
+        if (typeof opts.onSuccess === 'function')
+          (opts.onSuccess as (r: { data: { logged: number } }) => void)({ data: { logged: 16 } });
+        if (typeof opts.onSettled === 'function') (opts.onSettled as () => void)();
+      });
+      return { mutate: mockBatchLogMutation, isPending: false };
+    }
+    if (key === 'arr.updateSeasonMonitoring') {
+      mockSeasonMonitorMutation.mockImplementation((variables: { seasonNumber: number }) => {
+        if (typeof opts.onSuccess === 'function') (opts.onSuccess as () => void)();
+        if (typeof opts.onSettled === 'function')
+          (opts.onSettled as (d: unknown, e: unknown, v: { seasonNumber: number }) => void)(
+            undefined,
+            undefined,
+            variables
+          );
+      });
+      return { mutate: mockSeasonMonitorMutation, isPending: false };
+    }
+    return { mutate: vi.fn(), isPending: false };
+  },
+  usePillarUtils: () => ({ setData: mockSetData, invalidate: mockInvalidate }),
 }));
 
 vi.mock('../components/ArrStatusBadge', () => ({
@@ -111,8 +75,6 @@ vi.mock('../components/ArrStatusBadge', () => ({
 vi.mock('sonner', () => ({
   toast: { success: vi.fn(), error: vi.fn() },
 }));
-
-// --- Test data ---
 
 const SHOW = {
   id: 1,
@@ -154,8 +116,6 @@ const PROGRESS = {
   },
 };
 
-// --- Helpers ---
-
 function renderPage(showId = '1') {
   return render(
     <MemoryRouter initialEntries={[`/media/tv/${showId}`]}>
@@ -186,10 +146,9 @@ function setupQueries(
   });
 }
 
-// --- Tests ---
-
 beforeEach(() => {
   vi.clearAllMocks();
+  batchLogOpts = {};
   mockSeasonsQuery.mockReturnValue({ data: { data: [] }, isLoading: false });
   mockProgressQuery.mockReturnValue({ data: null, isLoading: false });
   mockCheckSeriesQuery.mockReturnValue({ data: null, isLoading: false });
@@ -203,7 +162,6 @@ describe('TvShowDetailPage — season list', () => {
       expect(screen.getByRole('heading', { name: 'Seasons' })).toBeInTheDocument();
       expect(screen.getByText('Season 1')).toBeInTheDocument();
       expect(screen.getByText('Season 2')).toBeInTheDocument();
-      // Season 3 has null name — falls back to "Season 3"
       expect(screen.getByText('Season 3')).toBeInTheDocument();
       expect(screen.getByText('Specials')).toBeInTheDocument();
     });
@@ -234,7 +192,6 @@ describe('TvShowDetailPage — season list', () => {
       const { container } = renderPage();
       const links = container.querySelectorAll('a[href*="/season/"]');
       expect(links).toHaveLength(4);
-      // First three should be seasons 1, 2, 3 — last should be specials (season 0)
       expect(links[0]!.getAttribute('href')).toBe('/media/tv/1/season/1');
       expect(links[1]!.getAttribute('href')).toBe('/media/tv/1/season/2');
       expect(links[2]!.getAttribute('href')).toBe('/media/tv/1/season/3');
@@ -255,7 +212,6 @@ describe('TvShowDetailPage — season list', () => {
     it('renders progress bar for season with progress', () => {
       setupQueries();
       const { container } = renderPage();
-      // Season 1 is 100% — should have green bar
       const progressBars = container.querySelectorAll('[role="progressbar"]');
       expect(progressBars.length).toBeGreaterThan(0);
     });
@@ -289,7 +245,6 @@ describe('TvShowDetailPage — season list', () => {
         seasons: [{ seasonId: 10, seasonNumber: 1, watched: 0, total: 5, percentage: 0 }],
       });
       const { container } = renderPage();
-      // ProgressBar renders a 0-value bar — the bar div still exists but is visually empty
       const seasonLinks = container.querySelectorAll('a[href*="/season/"]');
       expect(seasonLinks).toHaveLength(1);
       const bar = seasonLinks[0]!.querySelector('[role="progressbar"]');
@@ -328,14 +283,11 @@ describe('TvShowDetailPage — hero and metadata', () => {
     it('does not render backdrop image when backdropUrl is null (fallback gradient)', () => {
       setupQueries({ backdropUrl: null });
       const { container } = renderPage();
-      // No backdrop img — only the poster img should exist
       const images = container.querySelectorAll('img');
       expect(images).toHaveLength(1);
       expect(images[0]!.getAttribute('alt')).toBe('Breaking Bad poster');
-      // Hero container still has bg-muted as fallback background
       const hero = container.querySelector('.bg-muted');
       expect(hero).toBeInTheDocument();
-      // Gradient overlay is always rendered
       const gradient = container.querySelector('.bg-gradient-to-t');
       expect(gradient).toBeInTheDocument();
     });
@@ -349,7 +301,6 @@ describe('TvShowDetailPage — hero and metadata', () => {
     it('renders a placeholder div when posterUrl is null (no img element)', () => {
       setupQueries({ posterUrl: null });
       const { container } = renderPage();
-      // Component renders a <div> placeholder instead of <img> when posterUrl is null
       expect(container.querySelector('img[alt="Breaking Bad poster"]')).not.toBeInTheDocument();
       const placeholder = container.querySelector('div.rounded-lg.bg-muted.shadow-lg');
       expect(placeholder).toBeInTheDocument();
@@ -367,7 +318,6 @@ describe('TvShowDetailPage — hero and metadata', () => {
     it('renders status text for ended show', () => {
       setupQueries();
       renderPage();
-      // Status appears in both hero and metadata grid
       expect(screen.getAllByText('Ended').length).toBeGreaterThanOrEqual(1);
     });
 
@@ -387,7 +337,6 @@ describe('TvShowDetailPage — hero and metadata', () => {
       setupQueries({ firstAirDate: null, lastAirDate: null });
       renderPage();
       expect(screen.queryByText('·')).not.toBeInTheDocument();
-      // Status still renders in hero and metadata
       expect(screen.getAllByText('Ended').length).toBeGreaterThanOrEqual(1);
     });
 
@@ -482,7 +431,6 @@ describe('TvShowDetailPage — overall progress bar', () => {
       seasons: PROGRESS.seasons.map((s) => ({ ...s, watched: s.total, percentage: 100 })),
     });
     const { container } = renderPage();
-    // Overall progress bar in hero — find bar with 100% value
     const bars = container.querySelectorAll('[aria-valuenow="100"]');
     const greenBar = Array.from(bars).find((b) => b.className.includes('bg-success'));
     expect(greenBar).toBeTruthy();
@@ -505,7 +453,6 @@ describe('TvShowDetailPage — overall progress bar', () => {
       overall: { watched: 0, total: 0, percentage: 0 },
     });
     renderPage();
-    // ProgressBar returns null when total is 0
     expect(screen.queryByText(/\/0/)).not.toBeInTheDocument();
   });
 });
@@ -578,28 +525,16 @@ describe('TvShowDetailPage — batch mark all watched', () => {
     });
   });
 
-  it('cancels progress query on batch mark (optimistic)', () => {
-    setupQueries();
-    renderPage();
-    fireEvent.click(screen.getByRole('button', { name: 'Mark All Watched' }));
-    expect(mockCancel).toHaveBeenCalled();
-  });
-
-  it('snapshots progress data before optimistic update', async () => {
+  it('writes optimistic progress via setData on batch mark', async () => {
     setupQueries();
     renderPage();
     fireEvent.click(screen.getByRole('button', { name: 'Mark All Watched' }));
     await waitFor(() => {
-      expect(mockGetData).toHaveBeenCalled();
-    });
-  });
-
-  it('sets progress data optimistically on batch mark', async () => {
-    setupQueries();
-    renderPage();
-    fireEvent.click(screen.getByRole('button', { name: 'Mark All Watched' }));
-    await waitFor(() => {
-      expect(mockSetData).toHaveBeenCalled();
+      expect(mockSetData).toHaveBeenCalledWith(
+        ['watchHistory', 'progress'],
+        { tvShowId: 1 },
+        expect.any(Function)
+      );
     });
   });
 
@@ -608,29 +543,46 @@ describe('TvShowDetailPage — batch mark all watched', () => {
     renderPage();
     fireEvent.click(screen.getByRole('button', { name: 'Mark All Watched' }));
     await waitFor(() => {
-      expect(mockInvalidate).toHaveBeenCalled();
+      expect(mockInvalidate).toHaveBeenCalledWith(['watchHistory']);
+    });
+  });
+
+  it('invalidates listSeasons after batch mark settles', async () => {
+    setupQueries();
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: 'Mark All Watched' }));
+    await waitFor(() => {
+      expect(mockInvalidate).toHaveBeenCalledWith(['tvShows', 'listSeasons']);
     });
   });
 
   it('reverts progress data on error', async () => {
-    mockGetData.mockReturnValue({ data: PROGRESS });
     setupQueries();
     renderPage();
-    // Override AFTER render so it isn't overwritten by useMutation mock
-    mockBatchLogMutation.mockImplementation(async () => {
-      if (typeof batchLogOpts.onMutate === 'function')
-        await (batchLogOpts.onMutate as () => Promise<void>)();
+    mockBatchLogMutation.mockImplementation(() => {
+      const previousEnvelope = { data: PROGRESS };
+      mockSetData.mockReturnValueOnce(previousEnvelope);
+      const context =
+        typeof batchLogOpts.onMutate === 'function'
+          ? (batchLogOpts.onMutate as () => { previous: typeof previousEnvelope })()
+          : undefined;
       if (typeof batchLogOpts.onError === 'function')
-        (batchLogOpts.onError as (err: { message: string }) => void)({
-          message: 'Network error',
-        });
+        (
+          batchLogOpts.onError as (
+            err: { message: string },
+            vars: unknown,
+            ctx: typeof context
+          ) => void
+        )({ message: 'Network error' }, { mediaType: 'show', mediaId: 1 }, context);
       if (typeof batchLogOpts.onSettled === 'function') (batchLogOpts.onSettled as () => void)();
     });
     fireEvent.click(screen.getByRole('button', { name: 'Mark All Watched' }));
-    // setData called twice: once for optimistic, once for rollback
     await waitFor(() => {
       expect(mockSetData).toHaveBeenCalledTimes(2);
     });
+    const rollbackCall = mockSetData.mock.calls[1]!;
+    expect(rollbackCall[0]).toEqual(['watchHistory', 'progress']);
+    expect(rollbackCall[1]).toEqual({ tvShowId: 1 });
   });
 });
 
@@ -699,7 +651,6 @@ describe('TvShowDetailPage — season monitoring toggles', () => {
     renderPage();
     const toggle = screen.getByRole('switch', { name: 'Monitor Season 2' });
     fireEvent.click(toggle);
-    // After clicking unmonitored season 2, it should optimistically show checked
     expect(toggle).toBeChecked();
   });
 });

--- a/packages/app-media/src/pages/season-detail/useBatchSeasonLog.ts
+++ b/packages/app-media/src/pages/season-detail/useBatchSeasonLog.ts
@@ -1,7 +1,9 @@
-import { useCallback, useRef } from 'react';
+import { useCallback } from 'react';
 import { toast } from 'sonner';
 
-import { trpc } from '@pops/api-client';
+import { usePillarMutation, usePillarUtils } from '@pops/pillar-sdk/react';
+
+import type { UsePillarUtilsResult } from '@pops/pillar-sdk/react';
 
 interface UseBatchSeasonLogArgs {
   showId: number;
@@ -10,26 +12,53 @@ interface UseBatchSeasonLogArgs {
   episodes: Array<{ id: number }>;
 }
 
-type Utils = ReturnType<typeof trpc.useUtils>;
+type ProgressSeason = {
+  seasonNumber: number;
+  watched: number;
+  total: number;
+  percentage: number;
+};
+
+type ProgressEnvelope = {
+  data: {
+    overall: { watched: number; total: number; percentage: number };
+    seasons?: ProgressSeason[];
+    nextEpisode?: unknown;
+  } | null;
+};
+
+type WatchHistoryEntry = {
+  id: number;
+  mediaType: 'episode';
+  mediaId: number;
+  watchedAt: string;
+  completed: number;
+};
+
+type WatchHistoryEnvelope = {
+  data: WatchHistoryEntry[];
+  pagination?: unknown;
+};
+
+type BatchLogContext = {
+  previousProgress: ProgressEnvelope | undefined;
+  previousList: WatchHistoryEnvelope | undefined;
+};
+
+const LIST_INPUT = { mediaType: 'episode' as const, limit: 500 };
 
 function buildProgressUpdater(seasonNum: number) {
-  return (
-    old: Parameters<Utils['media']['watchHistory']['progress']['setData']>[1] extends infer T
-      ? T extends (input: infer I) => unknown
-        ? I
-        : never
-      : never
-  ) => {
-    if (!old?.data) return old;
-    const updatedSeasons = old.data.seasons.map((s) =>
+  return (envelope: ProgressEnvelope | undefined): ProgressEnvelope | undefined => {
+    if (!envelope?.data) return envelope;
+    const updatedSeasons = (envelope.data.seasons ?? []).map((s) =>
       s.seasonNumber === seasonNum ? { ...s, watched: s.total, percentage: 100 } : s
     );
     const totalWatched = updatedSeasons.reduce((sum, s) => sum + s.watched, 0);
     const totalEpisodes = updatedSeasons.reduce((sum, s) => sum + s.total, 0);
     return {
-      ...old,
+      ...envelope,
       data: {
-        ...old.data,
+        ...envelope.data,
         seasons: updatedSeasons,
         overall: {
           watched: totalWatched,
@@ -41,85 +70,88 @@ function buildProgressUpdater(seasonNum: number) {
   };
 }
 
+function buildListUpdater(episodes: Array<{ id: number }>) {
+  return (envelope: WatchHistoryEnvelope | undefined): WatchHistoryEnvelope | undefined => {
+    if (!envelope?.data) return envelope;
+    const existingIds = new Set(envelope.data.map((e) => e.mediaId));
+    const newEntries: WatchHistoryEntry[] = episodes
+      .filter((ep) => !existingIds.has(ep.id))
+      .map((ep) => ({
+        id: -ep.id,
+        mediaType: 'episode',
+        mediaId: ep.id,
+        watchedAt: new Date().toISOString(),
+        completed: 1,
+      }));
+    return { ...envelope, data: [...envelope.data, ...newEntries] };
+  };
+}
+
 function applyOptimistic(
-  utils: Utils,
+  utils: UsePillarUtilsResult,
   showId: number,
   seasonNum: number,
   episodes: Array<{ id: number }>
-) {
-  utils.media.watchHistory.progress.setData({ tvShowId: showId }, buildProgressUpdater(seasonNum));
-
+): BatchLogContext {
+  const previousProgress = utils.setData<ProgressEnvelope>(
+    ['watchHistory', 'progress'],
+    { tvShowId: showId },
+    buildProgressUpdater(seasonNum)
+  );
+  let previousList: WatchHistoryEnvelope | undefined;
   if (episodes.length > 0) {
-    utils.media.watchHistory.list.setData({ mediaType: 'episode', limit: 500 }, (old) => {
-      if (!old?.data) return old;
-      const existingIds = new Set(old.data.map((e: { mediaId: number }) => e.mediaId));
-      const newEntries = episodes
-        .filter((ep) => !existingIds.has(ep.id))
-        .map((ep) => ({
-          id: -ep.id,
-          mediaType: 'episode' as const,
-          mediaId: ep.id,
-          watchedAt: new Date().toISOString(),
-          completed: 1,
-        }));
-      return { ...old, data: [...old.data, ...newEntries] };
-    });
+    previousList = utils.setData<WatchHistoryEnvelope>(
+      ['watchHistory', 'list'],
+      LIST_INPUT,
+      buildListUpdater(episodes)
+    );
+  }
+  return { previousProgress, previousList };
+}
+
+function rollbackOptimistic(
+  utils: UsePillarUtilsResult,
+  showId: number,
+  context: BatchLogContext | undefined
+) {
+  if (!context) return;
+  if (context.previousProgress !== undefined) {
+    utils.setData<ProgressEnvelope | undefined>(
+      ['watchHistory', 'progress'],
+      { tvShowId: showId },
+      () => context.previousProgress
+    );
+  }
+  if (context.previousList !== undefined) {
+    utils.setData<WatchHistoryEnvelope | undefined>(
+      ['watchHistory', 'list'],
+      LIST_INPUT,
+      () => context.previousList
+    );
   }
 }
 
-function useOptimisticUpdates({
-  showId,
-  seasonNum,
-  episodes,
-}: Omit<UseBatchSeasonLogArgs, 'season'>) {
-  const utils = trpc.useUtils();
-  const progressSnapshot =
-    useRef<ReturnType<typeof utils.media.watchHistory.progress.getData>>(undefined);
-  const listSnapshot = useRef<ReturnType<typeof utils.media.watchHistory.list.getData>>(undefined);
-
-  const apply = async () => {
-    await utils.media.watchHistory.progress.cancel({ tvShowId: showId });
-    await utils.media.watchHistory.list.cancel();
-    progressSnapshot.current = utils.media.watchHistory.progress.getData({ tvShowId: showId });
-    listSnapshot.current = utils.media.watchHistory.list.getData({
-      mediaType: 'episode',
-      limit: 500,
-    });
-    applyOptimistic(utils, showId, seasonNum, episodes);
-  };
-
-  const rollback = () => {
-    if (progressSnapshot.current !== undefined) {
-      utils.media.watchHistory.progress.setData({ tvShowId: showId }, progressSnapshot.current);
-    }
-    if (listSnapshot.current !== undefined) {
-      utils.media.watchHistory.list.setData(
-        { mediaType: 'episode', limit: 500 },
-        listSnapshot.current
-      );
-    }
-  };
-
-  return { utils, apply, rollback };
-}
-
 export function useBatchSeasonLog({ showId, seasonNum, season, episodes }: UseBatchSeasonLogArgs) {
-  const { utils, apply, rollback } = useOptimisticUpdates({ showId, seasonNum, episodes });
+  const utils = usePillarUtils('media');
 
-  const batchLogMutation = trpc.media.watchHistory.batchLog.useMutation({
-    onMutate: apply,
-    onSuccess: (result: { data: { logged: number } }) => {
+  const batchLogMutation = usePillarMutation<
+    { mediaType: 'season'; mediaId: number },
+    { data: { logged: number } },
+    BatchLogContext
+  >('media', ['watchHistory', 'batchLog'], {
+    onMutate: () => applyOptimistic(utils, showId, seasonNum, episodes),
+    onSuccess: (result) => {
       toast.success(
         `Marked ${result.data.logged} episode${result.data.logged !== 1 ? 's' : ''} as watched`
       );
     },
-    onError: (err: { message: string }) => {
-      rollback();
+    onError: (err, _vars, context) => {
+      rollbackOptimistic(utils, showId, context);
       toast.error(`Failed to mark season: ${err.message}`);
     },
     onSettled: () => {
-      void utils.media.watchHistory.invalidate();
-      void utils.media.tvShows.listSeasons.invalidate();
+      void utils.invalidate(['watchHistory']);
+      void utils.invalidate(['tvShows', 'listSeasons']);
     },
   });
 

--- a/packages/app-media/src/pages/tv-show-detail/useTvShowDetailModel.ts
+++ b/packages/app-media/src/pages/tv-show-detail/useTvShowDetailModel.ts
@@ -1,21 +1,61 @@
-import { useMemo, useRef, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { toast } from 'sonner';
 
-import { trpc } from '@pops/api-client';
 import { useSetPageContext } from '@pops/navigation';
+import { usePillarMutation, usePillarQuery, usePillarUtils } from '@pops/pillar-sdk/react';
+
+import type { UsePillarUtilsResult } from '@pops/pillar-sdk/react';
+
+import type { ProgressData, SeasonRow, SonarrSeriesData } from './types';
+
+type ShowDetail = {
+  id: number;
+  name: string;
+  tvdbId: number;
+  overview: string | null;
+  genres: string[] | null;
+  status: string | null;
+  originalLanguage: string | null;
+  networks: string[] | null;
+  voteAverage: number | null;
+  voteCount: number | null;
+  posterUrl: string | null;
+  backdropUrl: string | null;
+  firstAirDate: string | null;
+  lastAirDate: string | null;
+};
+
+type ShowEnvelope = { data: ShowDetail | null };
+
+type SeasonsEnvelope = { data: SeasonRow[] };
+type ProgressEnvelope = { data: ProgressData | null };
+type SonarrEnvelope = { data: SonarrSeriesData | null };
+
+type ProgressContext = { previous: ProgressEnvelope | undefined };
 
 function useTvShowQueries(showId: number) {
   const enabled = !Number.isNaN(showId);
-  const { data, isLoading, error } = trpc.media.tvShows.get.useQuery({ id: showId }, { enabled });
-  const { data: seasonsData } = trpc.media.tvShows.listSeasons.useQuery(
+  const { data, isLoading, error } = usePillarQuery<ShowEnvelope>(
+    'media',
+    ['tvShows', 'get'],
+    { id: showId },
+    { enabled }
+  );
+  const { data: seasonsData } = usePillarQuery<SeasonsEnvelope>(
+    'media',
+    ['tvShows', 'listSeasons'],
     { tvShowId: showId },
     { enabled }
   );
-  const { data: progressData } = trpc.media.watchHistory.progress.useQuery(
+  const { data: progressData } = usePillarQuery<ProgressEnvelope>(
+    'media',
+    ['watchHistory', 'progress'],
     { tvShowId: showId },
     { enabled }
   );
-  const { data: sonarrData } = trpc.media.arr.checkSeries.useQuery(
+  const { data: sonarrData } = usePillarQuery<SonarrEnvelope>(
+    'media',
+    ['arr', 'checkSeries'],
     { tvdbId: data?.data?.tvdbId ?? 0 },
     { enabled: !!data?.data?.tvdbId }
   );
@@ -29,74 +69,86 @@ function useMonitoringMutation({
   setOptimisticMonitoring: React.Dispatch<React.SetStateAction<Map<number, boolean>>>;
   setPendingSeasons: React.Dispatch<React.SetStateAction<Set<number>>>;
 }) {
-  const utils = trpc.useUtils();
-  return trpc.media.arr.updateSeasonMonitoring.useMutation({
-    onError: (
-      err: { message: string },
-      variables: { seasonNumber: number; monitored: boolean }
-    ) => {
-      setOptimisticMonitoring((prev) => {
-        const next = new Map(prev);
-        next.set(variables.seasonNumber, !variables.monitored);
-        return next;
-      });
-      toast.error(`Failed to update monitoring: ${err.message}`);
-    },
-    onSuccess: () => {
-      void utils.media.arr.checkSeries.invalidate();
-    },
-    onSettled: (_data: unknown, _err: unknown, variables: { seasonNumber: number }) => {
-      setPendingSeasons((prev) => {
-        const next = new Set(prev);
-        next.delete(variables.seasonNumber);
-        return next;
-      });
-    },
-  });
+  const utils = usePillarUtils('media');
+  return usePillarMutation<{ sonarrId: number; seasonNumber: number; monitored: boolean }, unknown>(
+    'media',
+    ['arr', 'updateSeasonMonitoring'],
+    {
+      onError: (err, variables) => {
+        setOptimisticMonitoring((prev) => {
+          const next = new Map(prev);
+          next.set(variables.seasonNumber, !variables.monitored);
+          return next;
+        });
+        toast.error(`Failed to update monitoring: ${err.message}`);
+      },
+      onSuccess: () => {
+        void utils.invalidate(['arr', 'checkSeries']);
+      },
+      onSettled: (_data, _err, variables) => {
+        setPendingSeasons((prev) => {
+          const next = new Set(prev);
+          next.delete(variables.seasonNumber);
+          return next;
+        });
+      },
+    }
+  );
 }
 
-function useBatchLogMutation(showId: number) {
-  const utils = trpc.useUtils();
-  const progressSnapshot =
-    useRef<ReturnType<typeof utils.media.watchHistory.progress.getData>>(undefined);
-
-  return trpc.media.watchHistory.batchLog.useMutation({
-    onMutate: async () => {
-      await utils.media.watchHistory.progress.cancel({ tvShowId: showId });
-      progressSnapshot.current = utils.media.watchHistory.progress.getData({ tvShowId: showId });
-      utils.media.watchHistory.progress.setData({ tvShowId: showId }, (old) => {
-        if (!old?.data) return old;
-        const updatedSeasons = old.data.seasons.map((s) => ({
-          ...s,
-          watched: s.total,
-          percentage: 100,
-        }));
-        const totalEpisodes = updatedSeasons.reduce((sum, s) => sum + s.total, 0);
-        return {
-          ...old,
-          data: {
-            ...old.data,
-            seasons: updatedSeasons,
-            overall: { watched: totalEpisodes, total: totalEpisodes, percentage: 100 },
-            nextEpisode: null,
-          },
-        };
-      });
+function applyBatchOptimistic(
+  envelope: ProgressEnvelope | undefined
+): ProgressEnvelope | undefined {
+  if (!envelope?.data) return envelope;
+  const updatedSeasons = (envelope.data.seasons ?? []).map((s) => ({
+    ...s,
+    watched: s.total,
+    percentage: 100,
+  }));
+  const totalEpisodes = updatedSeasons.reduce((sum, s) => sum + s.total, 0);
+  return {
+    ...envelope,
+    data: {
+      ...envelope.data,
+      seasons: updatedSeasons,
+      overall: { watched: totalEpisodes, total: totalEpisodes, percentage: 100 },
+      nextEpisode: null,
     },
-    onSuccess: (result: { data: { logged: number } }) => {
+  };
+}
+
+function useBatchLogMutation(showId: number, utils: UsePillarUtilsResult) {
+  return usePillarMutation<
+    { mediaType: 'show'; mediaId: number },
+    { data: { logged: number } },
+    ProgressContext
+  >('media', ['watchHistory', 'batchLog'], {
+    onMutate: () => {
+      const previous = utils.setData<ProgressEnvelope>(
+        ['watchHistory', 'progress'],
+        { tvShowId: showId },
+        (prev) => applyBatchOptimistic(prev)
+      );
+      return { previous };
+    },
+    onSuccess: (result) => {
       toast.success(
         `Marked ${result.data.logged} episode${result.data.logged !== 1 ? 's' : ''} as watched`
       );
     },
-    onError: (err: { message: string }) => {
-      if (progressSnapshot.current !== undefined) {
-        utils.media.watchHistory.progress.setData({ tvShowId: showId }, progressSnapshot.current);
+    onError: (err, _vars, context) => {
+      if (context) {
+        utils.setData<ProgressEnvelope | undefined>(
+          ['watchHistory', 'progress'],
+          { tvShowId: showId },
+          () => context.previous
+        );
       }
       toast.error(`Failed to mark all watched: ${err.message}`);
     },
     onSettled: () => {
-      void utils.media.watchHistory.invalidate();
-      void utils.media.tvShows.listSeasons.invalidate();
+      void utils.invalidate(['watchHistory']);
+      void utils.invalidate(['tvShows', 'listSeasons']);
     },
   });
 }
@@ -110,6 +162,7 @@ function sortSeasons<T extends { seasonNumber: number }>(rawSeasons: T[]): T[] {
 }
 
 export function useTvShowDetailModel(showId: number) {
+  const utils = usePillarUtils('media');
   const queries = useTvShowQueries(showId);
   const [optimisticMonitoring, setOptimisticMonitoring] = useState<Map<number, boolean>>(new Map());
   const [pendingSeasons, setPendingSeasons] = useState<Set<number>>(new Set());
@@ -118,7 +171,7 @@ export function useTvShowDetailModel(showId: number) {
     setOptimisticMonitoring,
     setPendingSeasons,
   });
-  const batchLogMutation = useBatchLogMutation(showId);
+  const batchLogMutation = useBatchLogMutation(showId, utils);
 
   const seasons = useMemo(
     () => sortSeasons(queries.seasonsData?.data ?? []),
@@ -140,8 +193,8 @@ export function useTvShowDetailModel(showId: number) {
     error: queries.error,
     show: queries.data?.data,
     seasons,
-    progress: queries.progressData?.data,
-    sonarrSeries: queries.sonarrData?.data,
+    progress: queries.progressData?.data ?? undefined,
+    sonarrSeries: queries.sonarrData?.data ?? undefined,
     optimisticMonitoring,
     setOptimisticMonitoring,
     pendingSeasons,


### PR DESCRIPTION
## Summary

Migrates the three risky `media.*` optimistic-update sites off the tRPC `utils.media.*.setData/getData/cancel` pattern and onto the typed pillar SDK cache-write surface (`usePillarUtils` + `usePillarMutation` with a typed third-generic rollback context) shipped in #3136 / PRD-227.

Sites:

- `packages/app-media/src/components/watchlist-toggle/useWatchlistToggleModel.ts` — add/remove watchlist optimistic toggle, rollback on error.
- `packages/app-media/src/pages/tv-show-detail/useTvShowDetailModel.ts` — batch-mark-all-watched optimistic progress write, season-monitoring side-effect.
- `packages/app-media/src/pages/season-detail/useBatchSeasonLog.ts` — batch-mark-season-watched optimistic progress + watchHistory.list double-snapshot rollback.

Each `onMutate` now returns a typed `{ previous: ... }` context; `usePillarMutation<TIn, TOut, TContext>` carries it through to `onError(err, vars, ctx)` for clean rollback via `utils.setData(routerPath, input, () => ctx.previous)`. `onSettled` invalidates router prefixes through `utils.invalidate(['watchHistory'])`-style calls instead of bespoke `invalidate` proxies.

## Notable behavior change

The watchlist `add` CONFLICT info-toast branch is removed. The SDK collapses non-OK HTTP responses to `unavailable` / `contract-mismatch` / `degraded` discriminants — the original tRPC `err.data?.code === 'CONFLICT'` is no longer reachable from the call site. Duplicate-add now surfaces as the generic `Failed to add: ...` error toast. If that UX matters we can re-introduce it later by surfacing the upstream tRPC error code through the SDK transport.

## Test plan

- [x] `pnpm --filter @pops/app-media test` — 41 files, **699 passed**
- [x] `pnpm --filter @pops/app-media typecheck` — no new errors in migrated files (baseline 604 → 589 after touched files)
- [x] `npx oxlint` clean on touched files
- [x] `npx oxfmt --check` clean
- [x] WatchlistToggle test rewritten against `@pops/pillar-sdk/react` mock — covers optimistic add/remove, snapshot/rollback, info-toast removal
- [x] TvShowDetailPage test rewritten — batch-mark optimistic write + invalidate prefixes + rollback path
- [x] SeasonDetailPage test rewritten — `useBatchSeasonLog` mocked through the SDK; the rest of `useSeasonDetailModel` still uses tRPC mocks until that file is migrated