### PR TITLE
docs(theme-13): app-cerebrum/food/lists/ai consumer audit (PRD-227 round 2)

### DIFF
--- a/docs/themes/13-pillar-finale/notes/app-ai-consumer-inventory.md
+++ b/docs/themes/13-pillar-finale/notes/app-ai-consumer-inventory.md
@@ -1,0 +1,78 @@
+# app-ai Consumer Inventory (PRD-227 round 2)
+
+Static audit of `packages/app-ai/src/` for tRPC consumer call sites that will
+need to be cut over to per-pillar SDKs. Unlike the other app packages, every
+call in `app-ai` lives under the `core.*` namespace — the package is a
+front-end for cross-pillar AI infrastructure (budgets, providers, usage,
+observability, cache), not a pillar-local UI.
+
+This document is **audit-only**. No migration in this PR.
+
+## Summary
+
+| Metric                                              | Value   |
+| --------------------------------------------------- | ------- |
+| Total tRPC call sites (`useQuery` / `useMutation`)  | **14**  |
+| Files containing at least one call site             | **6**   |
+| `trpc.useUtils()` consumers (cache invalidation)    | 3 files |
+| Calls into pillar-local namespace                   | **0**   |
+| Cross-pillar calls (`trpc.core.*`)                  | **14**  |
+| Direct `getDrizzle()` usage                         | 0       |
+| Raw `fetch('/trpc/…')` usage                        | 0       |
+| Optimistic updates (`utils.*.setData` / `onMutate`) | 0       |
+| `useSuspenseQuery` / `useInfiniteQuery`             | 0       |
+
+The package consumes `@pops/api-client` only (no deep `@pops/api/modules/**`
+type imports detected).
+
+## Triage
+
+| Bucket      | Count | Definition                                                                                | Notes                                                                |
+| ----------- | ----- | ----------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| **Trivial** | 0     | —                                                                                         | Nothing is pillar-local.                                             |
+| **Medium**  | 14    | `trpc.core.*` cross-pillar call, plain query / mutation with `utils.invalidate` only      | Entire package. Blocked on `@pops/core-sdk` (AI sub-surface) ship.   |
+| **Risky**   | 0     | —                                                                                         | No optimistic, suspense, or infinite queries.                        |
+
+Total = 0 + 14 + 0 = 14 (matches call-site count).
+
+## Call sites by router
+
+| Router                    | Calls |
+| ------------------------- | ----- |
+| `core.aiUsage`            | 7     |
+| `core.aiObservability`    | 4     |
+| `core.aiProviders`        | 2     |
+| `core.aiBudgets`          | 1     |
+
+## Call sites by file
+
+- `pages/AiUsagePage.tsx` —
+  `core.aiObservability.{getStats,getHistory,getQualityMetrics}` (3).
+- `pages/cache-management/useCacheManagementModel.ts` —
+  `core.aiUsage.{clearStaleCache,clearAllCache,cacheStats,getStats}` (4).
+- `pages/ai-usage/cache-management/useCacheCardModel.ts` —
+  `core.aiUsage.{clearStaleCache,clearAllCache,cacheStats}` (3, duplicate
+  surface of the previous file in a card variant).
+- `pages/ai-usage/budget-status-section.tsx` —
+  `core.aiBudgets.getBudgetStatus` (1).
+- `pages/ai-usage/provider-status-section.tsx` —
+  `core.aiProviders.{list,healthCheck}` (2).
+- `pages/ai-usage/latency-section.tsx` —
+  `core.aiObservability.getLatencyStats` (1).
+
+## Migration ordering
+
+1. **Medium (14)** — entire package blocked on `@pops/core-sdk` exposing the
+   AI sub-surface (`aiUsage`, `aiObservability`, `aiProviders`, `aiBudgets`).
+   Once those land, this is a mechanical one-pass migration; all 14 sites
+   are plain queries / mutations with at most a single
+   `utils.core.aiUsage.invalidate()` chain.
+
+## Caveats / unknowns
+
+- Test files excluded from counts.
+- `useCacheManagementModel.ts` and `useCacheCardModel.ts` duplicate the
+  cache-management surface — investigate consolidation as part of the
+  migration (out of scope for this audit).
+- This package can ship behind the core SDK without coordinating with any
+  pillar SDK — it's a leaf consumer of `core.*` only.

--- a/docs/themes/13-pillar-finale/notes/app-cerebrum-consumer-inventory.md
+++ b/docs/themes/13-pillar-finale/notes/app-cerebrum-consumer-inventory.md
@@ -1,0 +1,89 @@
+# app-cerebrum Consumer Inventory (PRD-227 round 2)
+
+Static audit of `packages/app-cerebrum/src/` for tRPC consumer call sites that
+will need to be cut over to per-pillar SDKs (`@pops/cerebrum-sdk`).
+
+This document is **audit-only**. No migration in this PR.
+
+## Summary
+
+| Metric                                              | Value    |
+| --------------------------------------------------- | -------- |
+| Total tRPC call sites (`useQuery` / `useMutation`)  | **45**   |
+| Files containing at least one call site             | **17**   |
+| `trpc.useUtils()` consumers (cache invalidation)    | 10 files |
+| Calls into `trpc.cerebrum.*` (pillar-local)         | **45**   |
+| Cross-pillar calls (`trpc.core.*`, others)          | **0**    |
+| Direct `getDrizzle()` usage                         | 0        |
+| Raw `fetch('/trpc/…')` usage                        | 0        |
+| Optimistic updates (`utils.*.setData` / `onMutate`) | 0        |
+| `useSuspenseQuery` / `useInfiniteQuery`             | 0        |
+
+Self-contained against the `cerebrum` namespace. No cross-pillar coupling, no
+risky cache patterns, no optimistic writes.
+
+The package consumes `@pops/api-client` only (no deep `@pops/api/modules/**`
+type imports detected).
+
+## Triage
+
+| Bucket      | Count | Definition                                          | Notes                        |
+| ----------- | ----- | --------------------------------------------------- | ---------------------------- |
+| **Trivial** | 45    | Single-pillar `trpc.cerebrum.*` call, ≤5 LOC delta  | All 45 call sites fall here. |
+| **Medium**  | 0     | —                                                   | None.                        |
+| **Risky**   | 0     | —                                                   | None.                        |
+
+Total = 45 + 0 + 0 = 45 (matches call-site count).
+
+## Call sites by router
+
+| Router                  | Calls |
+| ----------------------- | ----- |
+| `cerebrum.reflex`       | 8     |
+| `cerebrum.glia`         | 8     |
+| `cerebrum.plexus`       | 7     |
+| `cerebrum.engrams`      | 7     |
+| `cerebrum.ingest`       | 6     |
+| `cerebrum.nudges`       | 4     |
+| `cerebrum.scopes`       | 2     |
+| `cerebrum.emit`         | 2     |
+| `cerebrum.templates`    | 1     |
+| `cerebrum.tags`         | 1     |
+| `cerebrum.retrieval`    | 1     |
+
+## Call sites by file
+
+- `engrams/useEngramListModel.ts`, `engrams/useEngramDetailModel.ts` —
+  `cerebrum.engrams.*` (list, detail, mutations) and supporting
+  `cerebrum.tags` / `cerebrum.retrieval`.
+- `documents/useDocumentsModel.ts` — `cerebrum.engrams.*` document views.
+- `components/EnrichmentChips.tsx`, `components/ContradictionsPanel.tsx` —
+  `cerebrum.engrams.*` enrichment and contradiction queries.
+- `pages/ReflexListPage.tsx`, `pages/ReflexDetailPage.tsx` —
+  `cerebrum.reflex.*` list/detail/run mutations.
+- `pages/PlexusListPage.tsx`, `pages/PlexusDetailPage.tsx` —
+  `cerebrum.plexus.*` list/detail.
+- `pages/ProposalQueuePage.tsx` — `cerebrum.plexus.*` proposals.
+- `pages/NudgesPage.tsx` — `cerebrum.nudges.*` (4 calls).
+- `pages/ingest-page/useSubmission.ts`,
+  `pages/ingest-page/useTemplateAndScopeData.ts` — `cerebrum.ingest.*`,
+  `cerebrum.templates`, `cerebrum.scopes`.
+- `pages/glia-dashboard/TrustStatePanel.tsx`,
+  `pages/glia-dashboard/AuditTrailPanel.tsx`,
+  `pages/glia-dashboard/WorkerPanel.tsx` — `cerebrum.glia.*` (8 calls combined).
+- `query/mutations.ts` — `cerebrum.emit.*` emit helpers.
+
+## Migration ordering
+
+1. **Trivial (45)** — once `@pops/cerebrum-sdk` ships, swap `trpc.cerebrum.*`
+   for the equivalent SDK hook in one mechanical pass. The 10 files using
+   `trpc.useUtils()` are still trivial; every invalidated key sits inside
+   `cerebrum.*`, so the SDK invalidate helper covers them.
+
+## Caveats / unknowns
+
+- Test files excluded from counts. They mock `@pops/api-client` today and will
+  need to switch mock targets when the SDK lands.
+- No optimistic cache writes, no suspense, no infinite queries — this package
+  is structurally identical to `app-inventory` and is a good candidate for an
+  early end-to-end SDK-cutover dry run alongside `cerebrum-sdk` delivery.

--- a/docs/themes/13-pillar-finale/notes/app-food-consumer-inventory.md
+++ b/docs/themes/13-pillar-finale/notes/app-food-consumer-inventory.md
@@ -1,0 +1,120 @@
+# app-food Consumer Inventory (PRD-227 round 2)
+
+Static audit of `packages/app-food/src/` for tRPC consumer call sites that will
+need to be cut over to per-pillar SDKs (`@pops/food-sdk`, plus a thin
+`@pops/lists-sdk` dependency for one cross-pillar call).
+
+This document is **audit-only**. No migration in this PR.
+
+## Summary
+
+| Metric                                              | Value    |
+| --------------------------------------------------- | -------- |
+| Total tRPC call sites (`useQuery` / `useMutation`)  | **124**  |
+| Files containing at least one call site             | **63**   |
+| `trpc.useUtils()` consumers (cache invalidation)    | 30 files |
+| Calls into `trpc.food.*` (pillar-local)             | **123**  |
+| Cross-pillar calls (`trpc.lists.*`)                 | **1**    |
+| Direct `getDrizzle()` usage                         | 0        |
+| Raw `fetch('/trpc/…')` usage                        | 0        |
+| Optimistic updates (`utils.*.setData` / `onMutate`) | 2 files  |
+| `useSuspenseQuery` / `useInfiniteQuery`             | 1        |
+
+The package consumes `@pops/api-client` and the pillar's contract package
+(`@pops/food-contracts`). No deep `@pops/api/modules/**` imports detected.
+
+## Triage
+
+| Bucket      | Count | Definition                                                                                       | Notes                                                                |
+| ----------- | ----- | ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------- |
+| **Trivial** | 118   | Single-router `trpc.food.*` call, plain query or mutation, plain `utils.invalidate` only         | Bulk of the package. Migrate first.                                  |
+| **Medium**  | 3     | Cross-pillar call (`trpc.lists.list.list`, 1) or `useInfiniteQuery` wrapper (`recipes.list`, 2)  | Need `usePillarQuery`-style wrapping for the infinite query.         |
+| **Risky**   | 3     | Optimistic `onMutate` + `utils.food.inbox.list*.setData` rollback chains                         | 2 files (`useFailedTab`, `useRejectedTab`) holding 3 mutation sites. |
+
+Total = 118 + 3 + 3 = 124 (matches call-site count).
+
+## Call sites by router
+
+| Router                | Calls |
+| --------------------- | ----- |
+| `food.recipes`        | 22    |
+| `food.plan`           | 20    |
+| `food.ingredients`    | 20    |
+| `food.inbox`          | 10    |
+| `food.batches`        | 10    |
+| `food.conversions`    | 8     |
+| `food.substitutions`  | 6     |
+| `food.aliases`        | 6     |
+| `food.prepStates`     | 4     |
+| `food.variants`       | 3     |
+| `food.slugs`          | 3     |
+| `food.shopping`       | 2     |
+| `food.ingest`         | 2     |
+| `food.heroImage`      | 2     |
+| `food.fridge`         | 2     |
+| `food.cook`           | 2     |
+| `food.solver`         | 1     |
+| `lists.list`          | 1     |
+
+## Risky sites detail
+
+### Optimistic mutations (3 calls, 2 files)
+
+- `pages/inbox/useFailedTab.ts` — `food.inbox.discard` mutation with
+  `onMutate` that snapshots and writes through
+  `utils.food.inbox.listFailed.setData(...)`; rollback on error and
+  invalidate on settle.
+- `pages/inbox/useRejectedTab.ts` — `food.inbox.restore` mutation with the
+  same optimistic-update + rollback pattern against
+  `utils.food.inbox.listRejected.setData(...)`.
+
+These need the `@pops/food-sdk` adapter to expose either:
+1. An `setQueryData`-equivalent helper keyed on the same input shape, or
+2. A thin `usePillarOptimisticMutation` wrapper that hides the
+   `setData`/snapshot/rollback choreography.
+
+Without one of those, these sites can't move without losing the
+zero-latency UX they currently provide.
+
+### Cross-pillar (1 call, 1 file)
+
+- `pages/recipes/send-to-list/useSendToListData.ts` — calls
+  `trpc.lists.list.list.useQuery(...)` to populate the "send to" list
+  picker. Blocked on `@pops/lists-sdk` ship; otherwise mechanical.
+
+### Infinite query (2 call sites, 1 file)
+
+- `pages/recipes/useRecipeListQuery.ts` —
+  `trpc.food.recipes.list.useInfiniteQuery(...)`. The hook is already
+  encapsulated, so once `@pops/food-sdk` exposes an equivalent infinite
+  helper this becomes mechanical.
+
+(Note: `dsl-editor/use-dsl-autocomplete-sources.ts` uses
+`trpc.useUtils().*.fetch` imperatively rather than via a hook — counted under
+the Trivial bucket because it's a single sync call that maps 1:1 to an SDK
+imperative fetch helper.)
+
+## Migration ordering
+
+1. **Trivial (118)** — once `@pops/food-sdk` React adapter ships, swap
+   `trpc.food.*` for the equivalent SDK hook. The 30 files using
+   `trpc.useUtils()` are still trivial; every invalidated key sits inside
+   `food.*`.
+2. **Medium (3)** — pull in `@pops/lists-sdk` for the single
+   `trpc.lists.list.list` call; cut the two `useInfiniteQuery` sites once the
+   SDK exposes the equivalent. Easy if the SDK design copies tRPC's
+   `useInfiniteQuery` shape.
+3. **Risky (3)** — the two `useFailedTab` / `useRejectedTab` optimistic
+   mutations need either an SDK setData helper or an optimistic-mutation
+   wrapper. Coordinate with `food-sdk` design before migrating these.
+
+## Caveats / unknowns
+
+- Test files excluded from counts. They mock `@pops/api-client` today and will
+  need to switch mock targets when the SDK lands.
+- `@pops/food-contracts` is already in place and re-exported from the package
+  index; SDK type re-exports must keep that compatibility.
+- This package is the largest of the four audited in round 2 by a wide
+  margin (124 calls vs 14–45 elsewhere). Best to chunk migrations
+  per-router (recipes/plan/ingredients first — they account for ~50% of the
+  surface).

--- a/docs/themes/13-pillar-finale/notes/app-lists-consumer-inventory.md
+++ b/docs/themes/13-pillar-finale/notes/app-lists-consumer-inventory.md
@@ -1,0 +1,91 @@
+# app-lists Consumer Inventory (PRD-227 round 2)
+
+Static audit of `packages/app-lists/src/` for tRPC consumer call sites that
+will need to be cut over to per-pillar SDKs (`@pops/lists-sdk`).
+
+This document is **audit-only**. No migration in this PR.
+
+## Summary
+
+| Metric                                              | Value   |
+| --------------------------------------------------- | ------- |
+| Total tRPC call sites (`useQuery` / `useMutation`)  | **17**  |
+| Files containing at least one call site             | **6**   |
+| `trpc.useUtils()` consumers (cache invalidation)    | 4 files |
+| Calls into `trpc.lists.*` (pillar-local)            | **17**  |
+| Cross-pillar calls                                  | **0**   |
+| Direct `getDrizzle()` usage                         | 0       |
+| Raw `fetch('/trpc/…')` usage                        | 0       |
+| Optimistic updates (`utils.*.setData` / `onMutate`) | 3 calls |
+| `useSuspenseQuery` / `useInfiniteQuery`             | 0       |
+
+Self-contained against the `lists` namespace. No cross-pillar coupling. The
+only `useSuspenseQuery` / `useInfiniteQuery` match in the package is inside a
+doc comment, not a real call.
+
+## Triage
+
+| Bucket      | Count | Definition                                                              | Notes                                                                |
+| ----------- | ----- | ----------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| **Trivial** | 14    | Single-router `trpc.lists.*` call, plain `utils.invalidate` only        | Standard query / mutation hooks across the 6 files.                  |
+| **Medium**  | 0     | —                                                                       | None.                                                                |
+| **Risky**   | 3     | Optimistic `setData` writes on `lists.list.get` with snapshot rollback  | 1 file (`useShoppingBulkMutations.ts`) holding 3 `setData` calls.    |
+
+Total = 14 + 0 + 3 = 17 (matches call-site count).
+
+## Call sites by router
+
+| Router          | Calls |
+| --------------- | ----- |
+| `lists.list`    | 9     |
+| `lists.items`   | 8     |
+
+## Call sites by file
+
+- `pages/ListDetailPage.tsx` — `lists.list.get.useQuery` (1).
+- `pages/lists-index/useListsIndexQuery.ts` — `lists.list.list.useQuery` (1).
+- `pages/lists-index/ListNewModal.tsx` — `lists.list.create.useMutation` (1).
+- `pages/detail/useDetailMutations.ts` — `lists.list.{update,archive,unarchive,delete}` (4).
+- `pages/detail/useItemMutations.ts` — `lists.items.{add,check,uncheck,update,remove,reorder}` (6).
+- `pages/components/shopping/useShoppingBulkMutations.ts` —
+  `lists.items.{uncheckAll,removeChecked}` (2 mutations) with **3 optimistic
+  `setData` calls** against `utils.lists.list.get` (snapshot + apply +
+  rollback).
+
+## Risky sites detail
+
+### Optimistic mutations (3 setData calls, 1 file)
+
+- `pages/components/shopping/useShoppingBulkMutations.ts` — bulk
+  uncheck-all and remove-checked actions. The mutation handler:
+  1. `get.setData({ id }, previous)` (rollback path on error).
+  2. `get.setData({ id }, (prev) => mapDetail(prev, mapItem))` (apply mapItem).
+  3. `get.setData({ id }, (prev) => filterDetail(prev, predicate))` (filter).
+
+  Bulk-list semantics: the page mutates dozens of items at once, so the
+  optimistic UX is load-bearing — falling back to invalidate-only would
+  show a visible empty-then-refresh flash.
+
+  Same SDK ask as `app-food`: the `@pops/lists-sdk` adapter needs an
+  equivalent `setQueryData` helper or a `usePillarOptimisticMutation`
+  wrapper that preserves snapshot + rollback.
+
+## Migration ordering
+
+1. **Trivial (14)** — once `@pops/lists-sdk` ships, swap `trpc.lists.*`
+   for the equivalent SDK hook in one mechanical pass.
+2. **Risky (3)** — the bulk-mutations site must wait until the SDK exposes
+   an optimistic-write surface. Coordinate with `lists-sdk` design.
+
+## Caveats / unknowns
+
+- Test files excluded from counts.
+- `useDetailMutations.ts` exports a `ReturnType<typeof trpc.lists.list.update.useMutation>`
+  type alias and a `ReturnType<typeof trpc.useUtils>` parameter type. Not
+  separate call sites, but the SDK type surface must support these patterns
+  or the helper signatures need updating.
+- `useShoppingBulkMutations.ts` declares
+  `type DetailQueryUtils = ReturnType<typeof trpc.useUtils>['lists']['list']['get']`
+  — same caveat.
+- This package and `app-cerebrum` together total 62 trivial calls — a clean
+  staging ground for end-to-end `lists-sdk` + `cerebrum-sdk` cutover dry runs.


### PR DESCRIPTION
## Summary

Static tRPC consumer audit for the four `app-*` packages that PR #3113 did
not cover (which audited `app-finance`, `app-media`, `app-inventory`).

Adds four inventory docs under `docs/themes/13-pillar-finale/notes/`,
following the same format and triage buckets (Trivial / Medium / Risky)
as the round-1 docs.

## Totals

200 call sites across 92 files.

| Package      | Calls | Trivial | Medium | Risky | Notes                                                          |
| ------------ | ----- | ------- | ------ | ----- | -------------------------------------------------------------- |
| app-cerebrum | 45    | 45      | 0      | 0     | Self-contained `cerebrum.*`.                                   |
| app-food     | 124   | 118     | 3      | 3     | 1 cross-pillar (lists), 1 infinite, 2 optimistic-update files. |
| app-lists    | 17    | 14      | 0      | 3     | 1 bulk-mutations file with optimistic `setData` rollback.      |
| app-ai       | 14    | 0       | 14     | 0     | Entire package consumes `core.*` only.                         |

Zero-consumer packages: none. All four have at least one tRPC site.

## Notable findings

- `app-ai` is the only fully cross-pillar consumer — every call lands in
  `core.{aiUsage,aiObservability,aiProviders,aiBudgets}`. Blocked entirely
  on the `@pops/core-sdk` AI sub-surface.
- `app-food` has the only cross-pillar straggler in an otherwise
  pillar-local set: `useSendToListData.ts` calls `trpc.lists.list.list`.
- Optimistic-update sites (3 in `app-food` inbox tabs, 3 in `app-lists`
  shopping bulk mutations) need the per-pillar SDK to expose a
  `setQueryData`-equivalent helper, or a thin
  `usePillarOptimisticMutation` wrapper, before they can move.
- `app-cerebrum` mirrors `app-inventory`: zero risky patterns, zero
  cross-pillar coupling — a clean candidate for an early end-to-end
  `cerebrum-sdk` cutover dry run.

## Out of scope

- No migration in this PR. Subsequent PRs cut over Trivial first, then
  Medium, then Risky.
- Test files and `*.stories.tsx` excluded from counts (same convention
  as the round-1 docs).

## Test plan

- [ ] Docs render correctly on GitHub.
- [ ] Counts cross-checked against `rg` output in the PR description.
