### PR TITLE
feat(jobs): flip embeddings hot-paths to getCerebrumDrizzle (Wave 5 progress)

### DIFF
--- a/apps/pops-api/src/jobs/handlers/embeddings-helpers.ts
+++ b/apps/pops-api/src/jobs/handlers/embeddings-helpers.ts
@@ -1,8 +1,10 @@
 import { and, eq, gt } from 'drizzle-orm';
 
-import { aiUsage, embeddings } from '@pops/db-types';
+import { embeddings } from '@pops/cerebrum-db';
+import { aiUsage } from '@pops/db-types';
 
-import { getDb, getDrizzle } from '../../db.js';
+import { getDrizzle } from '../../db.js';
+import { getCerebrumDrizzle, getCerebrumRawDb } from '../../db/cerebrum-handle.js';
 import { CONTENT_PREVIEW_LENGTH, hashContent } from '../../shared/chunker.js';
 import {
   estimateEmbeddingCost,
@@ -27,7 +29,7 @@ interface ExistingEmbedding {
 }
 
 function loadExisting(ctx: ChunkContext, chunkIndex: number): ExistingEmbedding | undefined {
-  const db = getDrizzle();
+  const db = getCerebrumDrizzle();
   return db
     .select({ id: embeddings.id, contentHash: embeddings.contentHash })
     .from(embeddings)
@@ -79,7 +81,7 @@ export async function obtainEmbedding(
 }
 
 function persistVector(rowId: number, vector: number[]): void {
-  const rawDb = getDb();
+  const rawDb = getCerebrumRawDb();
   const vectorBlob = Buffer.from(new Float32Array(vector).buffer);
   rawDb.prepare('DELETE FROM embeddings_vec WHERE rowid = ?').run(rowId);
   rawDb.prepare('INSERT INTO embeddings_vec (rowid, vector) VALUES (?, ?)').run(rowId, vectorBlob);
@@ -96,7 +98,7 @@ export interface UpsertChunkArgs {
 
 export function upsertChunkEmbedding(args: UpsertChunkArgs): void {
   const { ctx, chunk, contentHash, contentPreview, vector, existing } = args;
-  const db = getDrizzle();
+  const db = getCerebrumDrizzle();
   const now = new Date().toISOString();
 
   if (existing) {
@@ -129,7 +131,7 @@ export function upsertChunkEmbedding(args: UpsertChunkArgs): void {
     .returning({ id: embeddings.id })
     .get();
 
-  const rawDb = getDb();
+  const rawDb = getCerebrumRawDb();
   const vectorBlob = Buffer.from(new Float32Array(vector).buffer);
   rawDb
     .prepare('INSERT INTO embeddings_vec (rowid, vector) VALUES (?, ?)')
@@ -163,8 +165,8 @@ export function pruneOrphanChunks(
   sourceId: string,
   validChunkCount: number
 ): number {
-  const db = getDrizzle();
-  const rawDb = getDb();
+  const db = getCerebrumDrizzle();
+  const rawDb = getCerebrumRawDb();
 
   const orphans = db
     .select({ id: embeddings.id })

--- a/apps/pops-api/src/jobs/handlers/embeddings-source.ts
+++ b/apps/pops-api/src/jobs/handlers/embeddings-source.ts
@@ -1,8 +1,9 @@
 import { and, eq } from 'drizzle-orm';
 
-import { embeddings } from '@pops/db-types';
+import { embeddings } from '@pops/cerebrum-db';
 
-import { getDb, getDrizzle } from '../../db.js';
+import { getDb } from '../../db.js';
+import { getCerebrumDrizzle, getCerebrumRawDb } from '../../db/cerebrum-handle.js';
 
 export async function fetchContent(sourceType: string, sourceId: string): Promise<string | null> {
   const db = getDb();
@@ -25,8 +26,8 @@ export async function deleteEmbeddingsForSource(
   sourceType: string,
   sourceId: string
 ): Promise<void> {
-  const db = getDrizzle();
-  const rawDb = getDb();
+  const db = getCerebrumDrizzle();
+  const rawDb = getCerebrumRawDb();
 
   const rows = db
     .select({ id: embeddings.id })

--- a/apps/pops-api/src/jobs/handlers/embeddings.test.ts
+++ b/apps/pops-api/src/jobs/handlers/embeddings.test.ts
@@ -34,6 +34,11 @@ vi.mock('../../db.js', () => ({
   closeDb: vi.fn(),
 }));
 
+vi.mock('../../db/cerebrum-handle.js', () => ({
+  getCerebrumDrizzle: () => testDrizzle,
+  getCerebrumRawDb: () => testDb,
+}));
+
 import { processEmbeddingJob } from './embeddings.js';
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Flips the four hot-path embeddings sites in `apps/pops-api/src/jobs/handlers/embeddings-source.ts` and `embeddings-helpers.ts` from the legacy shared `getDrizzle()` to the cerebrum pillar's `getCerebrumDrizzle()`, now that #3144 shipped the embeddings slice in `@pops/cerebrum-db`.
- Routes the `embeddings_vec` virtual-table reads/writes through `getCerebrumRawDb()` so vector blobs land on cerebrum.db alongside their metadata rows.
- `recordEmbeddingUsage` keeps `getDrizzle()` because `ai_usage` still lives on the shared db (separate concern, separate slice). `fetchContent`'s `transactions` read also stays on `getDb()` for now — finance-raw migration is a separate concern per the brief.
- `getDrizzle()` call-site count: 493 -> 489 (delta of -4 sites).

## Sites flipped

| Function | File | Was | Now |
| --- | --- | --- | --- |
| `loadExisting` | `embeddings-helpers.ts` | `getDrizzle()` | `getCerebrumDrizzle()` |
| `upsertChunkEmbedding` / `persistVector` | `embeddings-helpers.ts` | `getDrizzle()` + `getDb()` | `getCerebrumDrizzle()` + `getCerebrumRawDb()` |
| `pruneOrphanChunks` | `embeddings-helpers.ts` | `getDrizzle()` + `getDb()` | `getCerebrumDrizzle()` + `getCerebrumRawDb()` |
| `deleteEmbeddingsForSource` | `embeddings-source.ts` | `getDrizzle()` + `getDb()` | `getCerebrumDrizzle()` + `getCerebrumRawDb()` |

## Test plan

- [x] `pnpm --filter @pops/api test src/jobs/handlers` -> 25/25 pass (handler suite includes embeddings + curation)
- [x] `pnpm typecheck` clean at root (67/67 tasks successful)
- [x] Test mocks updated to stub `../../db/cerebrum-handle.js` with the same in-memory drizzle/raw-db handles the suite already used for the shared module