### PR TITLE
feat(core-db): PRD-186 PR4 — move ai_model_pricing + sync_job_results + ai_usage to core-db (Wave 5 unblock)

### DIFF
--- a/apps/pops-api/src/db.ts
+++ b/apps/pops-api/src/db.ts
@@ -6,6 +6,7 @@ import { type BetterSQLite3Database, drizzle } from 'drizzle-orm/better-sqlite3'
 
 import { openCoreDb, type CoreDb, type OpenedCoreDb } from '@pops/core-db';
 
+import { backfillCoreFromShared } from './db/backfill-core-from-shared.js';
 import { createPreMigrationBackup, isFreshDatabase } from './db/backup.js';
 import { closeCerebrumDb } from './db/cerebrum-handle.js';
 import { resolveCoreSqlitePath } from './db/core-sqlite-path.js';
@@ -294,6 +295,18 @@ export function setCoreDb(next: OpenedCoreDb | null): OpenedCoreDb | null {
   const prev = coreDb;
   coreDb = next;
   return prev;
+}
+
+/**
+ * Run the one-shot ATTACH backfill from the legacy shared pops.db into
+ * the core pillar's core.db for the PRD-186 PR4 trio (`ai_model_pricing`,
+ * `sync_job_results`, `ai_usage`). No-op if the core handle isn't open.
+ * Idempotent against repeated boots via per-table `WHERE NOT EXISTS (...)`
+ * filters. See `backfill-core-from-shared.ts` for the table catalogue.
+ */
+export function backfillCoreFromSharedDb(sharedPath: string): void {
+  if (!coreDb) return;
+  backfillCoreFromShared(coreDb, sharedPath);
 }
 
 // `getMediaDrizzle` / `closeMediaDb` / `setMediaDb` live in

--- a/apps/pops-api/src/db/backfill-core-from-shared.test.ts
+++ b/apps/pops-api/src/db/backfill-core-from-shared.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Boot-time backfill tests for `backfillCoreFromShared` (PRD-186 PR4).
+ *
+ * Exercises the ATTACH-based copy from the shared `pops.db` to the
+ * core pillar's `core.db` against on-disk SQLite files (in-memory DBs
+ * can't be ATTACHed). The trio covered by this PR is `ai_model_pricing`,
+ * `sync_job_results`, and `ai_usage` — the writer cutover that lets us
+ * retire each entry happens in the follow-up PR; until then this bridge
+ * runs on every boot. Confirms:
+ *   - first run carries existing rows across for all three tables,
+ *   - second run is a no-op (idempotent — the per-table NOT EXISTS dedupes),
+ *   - composite-key dedup honours (provider_id, model_id) for ai_model_pricing,
+ *   - missing source table is tolerated without throwing.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import BetterSqlite3 from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { openCoreDb } from '@pops/core-db';
+
+import { backfillCoreFromShared } from './backfill-core-from-shared.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'core-backfill-'));
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+const AI_MODEL_PRICING_SQL = `
+CREATE TABLE ai_model_pricing (
+  id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  provider_id text NOT NULL,
+  model_id text NOT NULL,
+  display_name text,
+  input_cost_per_mtok real DEFAULT 0 NOT NULL,
+  output_cost_per_mtok real DEFAULT 0 NOT NULL,
+  context_window integer,
+  is_default integer DEFAULT 0 NOT NULL,
+  created_at text NOT NULL,
+  updated_at text NOT NULL
+);
+CREATE UNIQUE INDEX uq_ai_model_pricing_provider_model ON ai_model_pricing (provider_id, model_id);
+`;
+
+const SYNC_JOB_RESULTS_SQL = `
+CREATE TABLE sync_job_results (
+  id text PRIMARY KEY NOT NULL,
+  job_type text NOT NULL,
+  status text NOT NULL,
+  started_at text NOT NULL,
+  completed_at text,
+  duration_ms integer,
+  progress text,
+  result text,
+  error text,
+  created_at text DEFAULT (datetime('now')) NOT NULL
+);
+CREATE INDEX idx_sync_job_results_type_completed ON sync_job_results (job_type, completed_at);
+`;
+
+const AI_USAGE_SQL = `
+CREATE TABLE ai_usage (
+  id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  description text NOT NULL,
+  entity_name text,
+  category text,
+  input_tokens integer NOT NULL,
+  output_tokens integer NOT NULL,
+  cost_usd real NOT NULL,
+  cached integer DEFAULT 0 NOT NULL,
+  import_batch_id text,
+  created_at text NOT NULL
+);
+CREATE INDEX idx_ai_usage_created_at ON ai_usage (created_at);
+CREATE INDEX idx_ai_usage_batch ON ai_usage (import_batch_id);
+`;
+
+function openSharedWithSeed(seed: (raw: BetterSqlite3.Database) => void): string {
+  const path = join(tmpDir, 'pops.db');
+  const raw = new BetterSqlite3(path);
+  raw.exec(AI_MODEL_PRICING_SQL);
+  raw.exec(SYNC_JOB_RESULTS_SQL);
+  raw.exec(AI_USAGE_SQL);
+  seed(raw);
+  raw.close();
+  return path;
+}
+
+function insertPricing(raw: BetterSqlite3.Database, providerId: string, modelId: string): void {
+  raw
+    .prepare(
+      `INSERT INTO ai_model_pricing
+        (provider_id, model_id, display_name, input_cost_per_mtok, output_cost_per_mtok, context_window, is_default, created_at, updated_at)
+       VALUES (?, ?, ?, 1.0, 5.0, 200000, 0, datetime('now'), datetime('now'))`
+    )
+    .run(providerId, modelId, `${providerId}/${modelId}`);
+}
+
+function insertSync(raw: BetterSqlite3.Database, id: string): void {
+  raw
+    .prepare(
+      `INSERT INTO sync_job_results
+        (id, job_type, status, started_at)
+       VALUES (?, 'plex_sync', 'completed', datetime('now'))`
+    )
+    .run(id);
+}
+
+function insertUsage(raw: BetterSqlite3.Database, description: string): void {
+  raw
+    .prepare(
+      `INSERT INTO ai_usage
+        (description, input_tokens, output_tokens, cost_usd, created_at)
+       VALUES (?, 100, 50, 0.001, datetime('now'))`
+    )
+    .run(description);
+}
+
+describe('backfillCoreFromShared', () => {
+  it('copies ai_model_pricing, sync_job_results, and ai_usage rows from shared on first run', () => {
+    const sharedPath = openSharedWithSeed((raw) => {
+      insertPricing(raw, 'claude', 'claude-haiku-4-5');
+      insertSync(raw, 'job-a');
+      insertUsage(raw, 'seed-usage');
+    });
+
+    const core = openCoreDb(join(tmpDir, 'core.db'));
+    try {
+      backfillCoreFromShared(core, sharedPath);
+
+      const pricing = core.raw
+        .prepare('SELECT provider_id, model_id FROM ai_model_pricing')
+        .all() as { provider_id: string; model_id: string }[];
+      expect(pricing).toEqual([{ provider_id: 'claude', model_id: 'claude-haiku-4-5' }]);
+
+      const sync = core.raw.prepare('SELECT id, status FROM sync_job_results').all() as {
+        id: string;
+        status: string;
+      }[];
+      expect(sync).toEqual([{ id: 'job-a', status: 'completed' }]);
+
+      const usage = core.raw.prepare('SELECT description, input_tokens FROM ai_usage').all() as {
+        description: string;
+        input_tokens: number;
+      }[];
+      expect(usage).toEqual([{ description: 'seed-usage', input_tokens: 100 }]);
+    } finally {
+      core.raw.close();
+    }
+  });
+
+  it('is idempotent — a second run does not duplicate rows', () => {
+    const sharedPath = openSharedWithSeed((raw) => {
+      insertPricing(raw, 'claude', 'claude-haiku-4-5');
+      insertSync(raw, 'job-a');
+      insertUsage(raw, 'seed-usage');
+    });
+
+    const core = openCoreDb(join(tmpDir, 'core.db'));
+    try {
+      backfillCoreFromShared(core, sharedPath);
+      backfillCoreFromShared(core, sharedPath);
+
+      const pricingCount = (
+        core.raw.prepare('SELECT count(*) AS n FROM ai_model_pricing').get() as { n: number }
+      ).n;
+      const syncCount = (
+        core.raw.prepare('SELECT count(*) AS n FROM sync_job_results').get() as { n: number }
+      ).n;
+      const usageCount = (
+        core.raw.prepare('SELECT count(*) AS n FROM ai_usage').get() as { n: number }
+      ).n;
+      expect(pricingCount).toBe(1);
+      expect(syncCount).toBe(1);
+      expect(usageCount).toBe(1);
+    } finally {
+      core.raw.close();
+    }
+  });
+
+  it('skips ai_model_pricing rows whose (provider_id, model_id) already exists in core', () => {
+    const sharedPath = openSharedWithSeed((raw) => {
+      insertPricing(raw, 'claude', 'claude-sonnet-4-6');
+      insertPricing(raw, 'claude', 'claude-opus-4');
+    });
+
+    const core = openCoreDb(join(tmpDir, 'core.db'));
+    try {
+      core.raw
+        .prepare(
+          `INSERT INTO ai_model_pricing
+            (provider_id, model_id, display_name, input_cost_per_mtok, output_cost_per_mtok, context_window, is_default, created_at, updated_at)
+           VALUES ('claude', 'claude-sonnet-4-6', 'Core overrides shared', 3.0, 15.0, 200000, 0, datetime('now'), datetime('now'))`
+        )
+        .run();
+
+      backfillCoreFromShared(core, sharedPath);
+
+      const rows = core.raw
+        .prepare(
+          'SELECT provider_id, model_id, display_name FROM ai_model_pricing ORDER BY model_id'
+        )
+        .all() as { provider_id: string; model_id: string; display_name: string }[];
+      expect(rows).toEqual([
+        { provider_id: 'claude', model_id: 'claude-opus-4', display_name: 'claude/claude-opus-4' },
+        {
+          provider_id: 'claude',
+          model_id: 'claude-sonnet-4-6',
+          display_name: 'Core overrides shared',
+        },
+      ]);
+    } finally {
+      core.raw.close();
+    }
+  });
+
+  it('tolerates a shared DB without the PR4 tables', () => {
+    const sharedPath = join(tmpDir, 'pops.db');
+    const raw = new BetterSqlite3(sharedPath);
+    raw.exec(`CREATE TABLE other_table (id integer PRIMARY KEY)`);
+    raw.close();
+
+    const core = openCoreDb(join(tmpDir, 'core.db'));
+    try {
+      expect(() => backfillCoreFromShared(core, sharedPath)).not.toThrow();
+      const pricingCount = (
+        core.raw.prepare('SELECT count(*) AS n FROM ai_model_pricing').get() as { n: number }
+      ).n;
+      const syncCount = (
+        core.raw.prepare('SELECT count(*) AS n FROM sync_job_results').get() as { n: number }
+      ).n;
+      const usageCount = (
+        core.raw.prepare('SELECT count(*) AS n FROM ai_usage').get() as { n: number }
+      ).n;
+      expect(pricingCount).toBe(0);
+      expect(syncCount).toBe(0);
+      expect(usageCount).toBe(0);
+    } finally {
+      core.raw.close();
+    }
+  });
+});

--- a/apps/pops-api/src/db/backfill-core-from-shared.ts
+++ b/apps/pops-api/src/db/backfill-core-from-shared.ts
@@ -1,0 +1,140 @@
+/**
+ * Boot-time backfill from the legacy shared `pops.db` into the core
+ * pillar's `core.db` for the three tables PRD-186 PR4 lands in core-db:
+ * `ai_model_pricing`, `sync_job_results`, and `ai_usage`.
+ *
+ * Phase context: PR4 establishes the per-pillar table home for these
+ * tables (`packages/core-db/migrations/0059..0061_*.sql`) ahead of the
+ * hot-path writer cutover that flips `inference-pricing.ts`,
+ * `inference-middleware.ts`, and `jobs/sync-results.ts` from
+ * `getDrizzle()` to `getCoreDrizzle()` in the next PR. Until that cutover
+ * lands, writers still target `pops.db` — so this backfill carries the
+ * existing rows across on every boot so the new core table isn't a ghost.
+ * After the cutover lands and is verified in prod, the corresponding
+ * `TABLE_COPIES` entry is retired (matching the cerebrum/finance/media
+ * pattern documented in `backfill-cerebrum-from-shared.ts`).
+ *
+ * Subsequent boots find the core copy already populated and become a
+ * no-op via the `WHERE NOT EXISTS (...)` existence filter.
+ *
+ * Non-fatal: ATTACH or INSERT failures are logged and swallowed so a
+ * stale on-disk pops.db never bricks the boot path. Partial failures
+ * leave the core copy partially populated; the next deploy retries and
+ * the idempotent filter picks up only the still-missing rows.
+ *
+ * Mirrors `backfill-cerebrum-from-shared.ts` /
+ * `backfill-finance-from-shared.ts` / `backfill-media-from-shared.ts`.
+ */
+import type Database from 'better-sqlite3';
+
+import type { OpenedCoreDb } from '@pops/core-db';
+
+interface TableCopy {
+  readonly table: string;
+  /**
+   * Explicit column list keeps the backfill robust against a stale
+   * on-disk pops.db that already widened or narrowed since the boot
+   * image was built.
+   */
+  readonly columns: readonly string[];
+  /**
+   * Identifier column(s) used in the existence filter. A single entry
+   * covers tables with a surrogate or natural single-column PK; multiple
+   * entries express the business-key tuple for tables whose PK is an
+   * autoincrement integer (e.g. `ai_model_pricing` keyed on
+   * `(provider_id, model_id)`).
+   */
+  readonly idColumns: readonly [string, ...string[]];
+}
+
+const TABLE_COPIES: readonly TableCopy[] = [
+  {
+    table: 'ai_model_pricing',
+    idColumns: ['provider_id', 'model_id'],
+    columns: [
+      'provider_id',
+      'model_id',
+      'display_name',
+      'input_cost_per_mtok',
+      'output_cost_per_mtok',
+      'context_window',
+      'is_default',
+      'created_at',
+      'updated_at',
+    ],
+  },
+  {
+    table: 'sync_job_results',
+    idColumns: ['id'],
+    columns: [
+      'id',
+      'job_type',
+      'status',
+      'started_at',
+      'completed_at',
+      'duration_ms',
+      'progress',
+      'result',
+      'error',
+      'created_at',
+    ],
+  },
+  {
+    table: 'ai_usage',
+    idColumns: ['id'],
+    columns: [
+      'id',
+      'description',
+      'entity_name',
+      'category',
+      'input_tokens',
+      'output_tokens',
+      'cost_usd',
+      'cached',
+      'import_batch_id',
+      'created_at',
+    ],
+  },
+];
+
+function tryCopyTable(raw: Database.Database, copy: TableCopy): void {
+  try {
+    const hasTable = raw
+      .prepare(`SELECT 1 FROM pops.sqlite_master WHERE type='table' AND name=?`)
+      .get(copy.table);
+    if (!hasTable) return;
+    const cols = copy.columns.join(', ');
+    const keyMatch = copy.idColumns
+      .map((col) => `target.${col} = pops.${copy.table}.${col}`)
+      .join(' AND ');
+    raw.exec(`
+      INSERT INTO ${copy.table} (${cols})
+      SELECT ${cols}
+      FROM pops.${copy.table}
+      WHERE NOT EXISTS (
+        SELECT 1 FROM ${copy.table} AS target WHERE ${keyMatch}
+      )
+    `);
+  } catch (err) {
+    console.warn(`[db] Core backfill of ${copy.table} failed (non-fatal):`, err);
+  }
+}
+
+/**
+ * Copy every PRD-186-PR4-owned table's rows from `pops.db` into
+ * `core.db`, idempotent against re-runs. Caller supplies the open core
+ * handle (so this module stays decoupled from the singleton in
+ * `db.ts`) and the path to the legacy shared pops.db.
+ */
+export function backfillCoreFromShared(core: OpenedCoreDb, sharedPath: string): void {
+  try {
+    core.raw.prepare('ATTACH DATABASE ? AS pops').run(sharedPath);
+    try {
+      for (const copy of TABLE_COPIES) tryCopyTable(core.raw, copy);
+    } finally {
+      core.raw.exec('DETACH DATABASE pops');
+    }
+  } catch (err) {
+    console.warn('[db] Core backfill ATTACH failed (non-fatal):', err);
+  }
+}

--- a/apps/pops-api/src/db/per-pillar-migrations.test.ts
+++ b/apps/pops-api/src/db/per-pillar-migrations.test.ts
@@ -205,8 +205,12 @@ describe('runPerPillarMigrations', () => {
     // `core` owns `packages/core-db/migrations/` with 0054_service_accounts
     // (core pillar Phase 1 PR 2), 0055_pillar_registry (Theme 13 PRD-161
     // registry endpoints), 0056_settings_baseline (PRD-183 US-01 —
-    // settings baseline), and 0057_ai_usage_baseline (PRD-186 US-01 —
-    // ai_inference_log + ai_inference_daily + ai_budgets baseline);
+    // settings baseline), 0057_ai_usage_baseline (PRD-186 US-01 —
+    // ai_inference_log + ai_inference_daily + ai_budgets baseline),
+    // 0058_pillar_registry_external_origin, and the PRD-186 PR4 trio
+    // 0059_ai_model_pricing + 0060_sync_job_results + 0061_ai_usage
+    // (Wave 5 unblock — the remaining AI Ops + sync-result tables land
+    // in core-db ahead of the hot-path writer cutover);
     // `media` owns `packages/media-db/migrations/`
     // with 0021_spooky_lockheed (media pillar Phase 1 PR 2),
     // 0022_media_movies_baseline (Theme 13 PRD-165 US-01 — movies baseline),
@@ -265,6 +269,9 @@ describe('runPerPillarMigrations', () => {
         '0056_settings_baseline',
         '0057_ai_usage_baseline',
         '0058_pillar_registry_external_origin',
+        '0059_ai_model_pricing',
+        '0060_sync_job_results',
+        '0061_ai_usage',
       ]);
       expect([...result.pillarsApplied].toSorted()).toEqual([
         'cerebrum',

--- a/apps/pops-api/src/index.ts
+++ b/apps/pops-api/src/index.ts
@@ -6,7 +6,7 @@ config(); // loads apps/pops-api/.env if it exists
 config({ path: '../../.env', override: false }); // loads root .env without overriding
 
 import { createApp } from './app.js';
-import { closeDb, getCoreDrizzle } from './db.js';
+import { backfillCoreFromSharedDb, closeDb, getCoreDrizzle } from './db.js';
 import { backfillCerebrumFromSharedDb, getCerebrumDrizzle } from './db/cerebrum-handle.js';
 import { getFinanceDrizzle } from './db/finance-handle.js';
 import { getFoodDrizzle } from './db/food-handle.js';
@@ -43,12 +43,17 @@ const port = Number(process.env['PORT'] ?? 3000);
 const app = createApp();
 
 // Eagerly open the core pillar's SQLite + apply its journal at boot so
-// the per-pillar migrations land before any request hits the API. After
-// the theme-13 core PR4 drop wave (service_accounts / settings /
-// ai-usage tables), every core-owned slice writes directly to core.db
-// and no bridge from the shared pops.db remains.
+// the per-pillar migrations land before any request hits the API. PRD-186
+// PR4 lands `ai_model_pricing`, `sync_job_results`, and `ai_usage` in
+// core.db; the writers still target the shared pops.db until the next
+// hot-path cutover PR flips them to `getCoreDrizzle()`, so the one-shot
+// `backfillCoreFromSharedDb` bridge carries any rows already written to
+// pops.db across each boot. It's idempotent (per-table `WHERE NOT EXISTS
+// (...)` filters) and non-fatal (partial failure logs + continues).
+// Retire the bridge once the cutover lands and is verified in prod.
 try {
   getCoreDrizzle();
+  backfillCoreFromSharedDb(resolveSqlitePath());
 } catch (err) {
   console.error('[db] Failed to bootstrap the core pillar SQLite:', err);
   throw err;

--- a/packages/core-db/migrations/0059_ai_model_pricing.sql
+++ b/packages/core-db/migrations/0059_ai_model_pricing.sql
@@ -1,0 +1,14 @@
+CREATE TABLE `ai_model_pricing` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`provider_id` text NOT NULL,
+	`model_id` text NOT NULL,
+	`display_name` text,
+	`input_cost_per_mtok` real DEFAULT 0 NOT NULL,
+	`output_cost_per_mtok` real DEFAULT 0 NOT NULL,
+	`context_window` integer,
+	`is_default` integer DEFAULT 0 NOT NULL,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `uq_ai_model_pricing_provider_model` ON `ai_model_pricing` (`provider_id`,`model_id`);

--- a/packages/core-db/migrations/0060_sync_job_results.sql
+++ b/packages/core-db/migrations/0060_sync_job_results.sql
@@ -1,0 +1,14 @@
+CREATE TABLE `sync_job_results` (
+	`id` text PRIMARY KEY NOT NULL,
+	`job_type` text NOT NULL,
+	`status` text NOT NULL,
+	`started_at` text NOT NULL,
+	`completed_at` text,
+	`duration_ms` integer,
+	`progress` text,
+	`result` text,
+	`error` text,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `idx_sync_job_results_type_completed` ON `sync_job_results` (`job_type`,`completed_at`);

--- a/packages/core-db/migrations/0061_ai_usage.sql
+++ b/packages/core-db/migrations/0061_ai_usage.sql
@@ -1,0 +1,15 @@
+CREATE TABLE `ai_usage` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`description` text NOT NULL,
+	`entity_name` text,
+	`category` text,
+	`input_tokens` integer NOT NULL,
+	`output_tokens` integer NOT NULL,
+	`cost_usd` real NOT NULL,
+	`cached` integer DEFAULT 0 NOT NULL,
+	`import_batch_id` text,
+	`created_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `idx_ai_usage_created_at` ON `ai_usage` (`created_at`);--> statement-breakpoint
+CREATE INDEX `idx_ai_usage_batch` ON `ai_usage` (`import_batch_id`);

--- a/packages/core-db/migrations/meta/_journal.json
+++ b/packages/core-db/migrations/meta/_journal.json
@@ -36,6 +36,27 @@
       "when": 1781999999999,
       "tag": "0058_pillar_registry_external_origin",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1782086400000,
+      "tag": "0059_ai_model_pricing",
+      "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1782086400001,
+      "tag": "0060_sync_job_results",
+      "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1782086400002,
+      "tag": "0061_ai_usage",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core-db/src/__tests__/open-core-db.test.ts
+++ b/packages/core-db/src/__tests__/open-core-db.test.ts
@@ -51,6 +51,37 @@ describe('openCoreDb', () => {
     }
   });
 
+  it('applies the PRD-186 PR4 ai_model_pricing, sync_job_results, and ai_usage migrations', () => {
+    const path = join(tmpDir, 'core.db');
+    const { raw } = openCoreDb(path);
+    try {
+      const tables = new Set(
+        (
+          raw.prepare("SELECT name FROM sqlite_master WHERE type='table'").all() as {
+            name: string;
+          }[]
+        ).map((r) => r.name)
+      );
+      expect(tables.has('ai_model_pricing')).toBe(true);
+      expect(tables.has('sync_job_results')).toBe(true);
+      expect(tables.has('ai_usage')).toBe(true);
+
+      const indexes = new Set(
+        (
+          raw.prepare("SELECT name FROM sqlite_master WHERE type='index'").all() as {
+            name: string;
+          }[]
+        ).map((r) => r.name)
+      );
+      expect(indexes.has('uq_ai_model_pricing_provider_model')).toBe(true);
+      expect(indexes.has('idx_sync_job_results_type_completed')).toBe(true);
+      expect(indexes.has('idx_ai_usage_created_at')).toBe(true);
+      expect(indexes.has('idx_ai_usage_batch')).toBe(true);
+    } finally {
+      raw.close();
+    }
+  });
+
   it('is idempotent — re-opening the same DB does not re-apply migrations', async () => {
     const path = join(tmpDir, 'core.db');
     const first = openCoreDb(path);

--- a/packages/core-db/src/schema.ts
+++ b/packages/core-db/src/schema.ts
@@ -15,6 +15,7 @@ export {
   aiInferenceDaily,
   aiInferenceLog,
   aiModelPricing,
+  aiUsage,
   pillarRegistry,
   serviceAccounts,
   settings,


### PR DESCRIPTION
## Summary

Establishes the per-pillar table home in `packages/core-db/migrations/` for three tables that were defined in `@pops/db-types` but had no migration under core-db's journal: `ai_model_pricing`, `sync_job_results`, and `ai_usage`. Adds a one-shot ATTACH backfill from the shared `pops.db` into `core.db` so the next PR can flip the hot-path writers from `getDrizzle()` to `getCoreDrizzle()` without losing rows.

## What lands

- `packages/core-db/migrations/0059_ai_model_pricing.sql` (uniq `provider_id`, `model_id`)
- `packages/core-db/migrations/0060_sync_job_results.sql` (idx `job_type`, `completed_at`)
- `packages/core-db/migrations/0061_ai_usage.sql` (idx `created_at` + `import_batch_id`)
- `packages/core-db/src/schema.ts` — adds `aiUsage` to the re-export barrel (the other two were already re-exported).
- `apps/pops-api/src/db/backfill-core-from-shared.ts` — new ATTACH bridge with composite-key dedup for `ai_model_pricing` and id-keyed dedup for the other two. Mirrors `backfill-cerebrum-from-shared.ts`.
- `apps/pops-api/src/db.ts` — exports `backfillCoreFromSharedDb` wrapper.
- `apps/pops-api/src/index.ts` — wires the backfill into boot after `getCoreDrizzle()`.

The shared drizzle journal still owns the original CREATE TABLE entries (`0000_naive_chameleon` for `ai_usage`, `0010_gifted_firestar` for `sync_job_results`, `0034_ai_observability` + `0049_sonnet_4_6_model_pricing` + `0056_ai_observability_repair` for `ai_model_pricing`), so existing deployments keep working unchanged.

## Hot-paths this unblocks (next agent's PR)

- `apps/pops-api/src/jobs/sync-results.ts` (sync_job_results)
- `apps/pops-api/src/lib/inference-pricing.ts` (ai_model_pricing) — already imports from `@pops/core-db`, just needs `getDrizzle()` -> `getCoreDrizzle()`
- `apps/pops-api/src/lib/inference-middleware.ts` (ai_usage)

After the writer cutover lands and is verified in prod, the corresponding entries in `TABLE_COPIES` retire (matching the cerebrum/finance/media pattern).

## Test plan

- [x] `packages/core-db` — new `open-core-db.test.ts` case asserts the 3 tables and 4 indexes land on a fresh open. (8 files / 127 tests pass.)
- [x] `apps/pops-api` `backfill-core-from-shared.test.ts` — 4 new cases: initial copy, idempotency, composite-key dedup, missing-source-table tolerance.
- [x] `apps/pops-api` `per-pillar-migrations.test.ts` — extends the on-disk smoke expectations with `0059`/`0060`/`0061`.
- [x] Full `pnpm --filter @pops/api test` — 309 files / 4880 tests pass (with a clean `CORE_SQLITE_PATH`; the one pre-existing toml-config flake reproduces on `main` and is environmental).
- [x] `pnpm typecheck` — 67 tasks pass.
- [x] `pnpm lint` — exit 0 (warnings only, all pre-existing).
- [x] `pnpm build` — 35 tasks pass.