### PR TITLE
feat(theme-13): PRD-228 US-03 — nginx event-driven reload on registry events

### DIFF
--- a/apps/pops-shell/README.md
+++ b/apps/pops-shell/README.md
@@ -83,3 +83,41 @@ copies this directory's three pieces:
 `/core.registry.register` endpoint. The manifest stays empty: the
 contract sentinel (`@pops/<id>-contract@v0.1.0`) is the only
 per-surface change.
+
+## Event-driven nginx reload (PRD-228 US-03)
+
+`pnpm gen:nginx:watch` runs `scripts/watch-registry-and-reload.ts` —
+a long-lived process that subscribes to `GET /registry/subscribe`
+(PRD-163) and, on each `pillar.registered`, `pillar.deregistered`, or
+`pillar.health-changed` frame, regenerates `nginx.conf` from the live
+registry (`pnpm gen:nginx:dynamic` logic) and executes a reload
+command. A trailing 250ms debounce coalesces bursts (multi-pillar
+boot, eviction-storms) into a single regen + reload. The initial
+`pillar.snapshot` frame is intentionally ignored — the dispatcher
+already reflects boot state.
+
+### Env
+
+| Var                      | Default                      | Purpose                                                          |
+| ------------------------ | ---------------------------- | ---------------------------------------------------------------- |
+| `CORE_REGISTRY_URL`      | `http://core-api:3001`       | Core-api base URL; SSE consumed from `<url>/registry/subscribe`. |
+| `POPS_NGINX_OUTPUT`      | `apps/pops-shell/nginx.conf` | Where the regenerated conf is written.                           |
+| `POPS_NGINX_RELOAD_CMD`  | `nginx -s reload`            | Shell command run after each successful regen.                   |
+| `POPS_NGINX_DEBOUNCE_MS` | `250`                        | Trailing-debounce window for coalescing bursts.                  |
+| `POPS_NGINX_BACKOFF_MS`  | `1000`                       | Initial reconnect backoff (caps at 30s, doubles per failure).    |
+
+### Deploy shape (follow-up)
+
+Two viable shapes — implementation choice is **deferred** to a
+follow-up so this PR can ship the watcher + tests in isolation:
+
+1. **Sidecar inside the nginx container.** Watcher writes
+   `/etc/nginx/conf.d/default.conf` and runs `nginx -s reload`
+   directly. Lowest latency, same container so `nginx` is on PATH.
+2. **Standalone Node container on the docker network.** Watcher
+   writes a shared volume mounted into nginx and triggers reload via
+   `POPS_NGINX_RELOAD_CMD="docker kill -s HUP pops-nginx"` (needs the
+   docker socket mounted into the watcher).
+
+Both shapes share the same script; only the env varies. Wiring into
+`docker-compose.yml` / `Dockerfile` is the follow-up PR's scope.

--- a/apps/pops-shell/package.json
+++ b/apps/pops-shell/package.json
@@ -17,6 +17,7 @@
     "gen:nginx": "tsx scripts/generate-nginx-conf.ts",
     "gen:nginx:check": "tsx scripts/generate-nginx-conf.ts --check",
     "gen:nginx:dynamic": "tsx scripts/generate-nginx-conf.ts --dynamic",
+    "gen:nginx:watch": "tsx scripts/watch-registry-and-reload.ts",
     "registry:register": "tsx scripts/register-with-registry.ts"
   },
   "dependencies": {

--- a/apps/pops-shell/scripts/nginx-event-reload.test.ts
+++ b/apps/pops-shell/scripts/nginx-event-reload.test.ts
@@ -1,0 +1,215 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  createReloadHandler,
+  isWatchedEvent,
+  WATCHED_EVENTS,
+  type ReloadLogger,
+} from './nginx-event-reload.ts';
+
+function deferred<T = void>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (err: unknown) => void;
+} {
+  let resolve!: (value: T) => void;
+  let reject!: (err: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function createSilentLogger(): { logger: ReloadLogger; infos: string[]; errors: string[] } {
+  const infos: string[] = [];
+  const errors: string[] = [];
+  return {
+    logger: {
+      info: (msg) => infos.push(msg),
+      error: (msg) => errors.push(msg),
+    },
+    infos,
+    errors,
+  };
+}
+
+describe('isWatchedEvent', () => {
+  it.each(WATCHED_EVENTS)('returns true for watched event %s', (name) => {
+    expect(isWatchedEvent(name)).toBe(true);
+  });
+
+  it('returns false for the snapshot event', () => {
+    expect(isWatchedEvent('pillar.snapshot')).toBe(false);
+  });
+
+  it('returns false for unrelated events', () => {
+    expect(isWatchedEvent('message')).toBe(false);
+    expect(isWatchedEvent('')).toBe(false);
+  });
+});
+
+describe('createReloadHandler', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('coalesces a burst of triggers into one regen + reload run', async () => {
+    const regenerate = vi.fn().mockResolvedValue(undefined);
+    const reload = vi.fn().mockResolvedValue(undefined);
+    const handler = createReloadHandler({ regenerate, reload, debounceMs: 100 });
+
+    handler.trigger('pillar.registered');
+    handler.trigger('pillar.registered');
+    handler.trigger('pillar.health-changed');
+
+    expect(regenerate).not.toHaveBeenCalled();
+    expect(reload).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(100);
+    await handler.flush();
+
+    expect(regenerate).toHaveBeenCalledTimes(1);
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not start a run until the debounce window closes', async () => {
+    const regenerate = vi.fn().mockResolvedValue(undefined);
+    const reload = vi.fn().mockResolvedValue(undefined);
+    const handler = createReloadHandler({ regenerate, reload, debounceMs: 250 });
+
+    handler.trigger('pillar.registered');
+    await vi.advanceTimersByTimeAsync(100);
+    handler.trigger('pillar.deregistered');
+    await vi.advanceTimersByTimeAsync(100);
+    handler.trigger('pillar.health-changed');
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(regenerate).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(250);
+    await handler.flush();
+
+    expect(regenerate).toHaveBeenCalledTimes(1);
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('runs regen then reload in order', async () => {
+    const calls: string[] = [];
+    const regenerate = vi.fn(async () => {
+      calls.push('regen');
+    });
+    const reload = vi.fn(async () => {
+      calls.push('reload');
+    });
+    const handler = createReloadHandler({ regenerate, reload, debounceMs: 10 });
+
+    handler.trigger('pillar.registered');
+    await vi.advanceTimersByTimeAsync(10);
+    await handler.flush();
+
+    expect(calls).toEqual(['regen', 'reload']);
+  });
+
+  it('skips reload when regenerate rejects but stays alive for the next event', async () => {
+    const regenerate = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValue(undefined);
+    const reload = vi.fn().mockResolvedValue(undefined);
+    const { logger, errors } = createSilentLogger();
+    const handler = createReloadHandler({ regenerate, reload, debounceMs: 10, logger });
+
+    handler.trigger('pillar.registered');
+    await vi.advanceTimersByTimeAsync(10);
+    await handler.flush();
+
+    expect(reload).not.toHaveBeenCalled();
+    expect(errors.some((e) => e.includes('regenerate failed'))).toBe(true);
+
+    handler.trigger('pillar.deregistered');
+    await vi.advanceTimersByTimeAsync(10);
+    await handler.flush();
+
+    expect(regenerate).toHaveBeenCalledTimes(2);
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs but does not throw when reload rejects', async () => {
+    const regenerate = vi.fn().mockResolvedValue(undefined);
+    const reload = vi.fn().mockRejectedValue(new Error('nginx -t failed'));
+    const { logger, errors } = createSilentLogger();
+    const handler = createReloadHandler({ regenerate, reload, debounceMs: 10, logger });
+
+    handler.trigger('pillar.registered');
+    await vi.advanceTimersByTimeAsync(10);
+    await handler.flush();
+
+    expect(regenerate).toHaveBeenCalledTimes(1);
+    expect(reload).toHaveBeenCalledTimes(1);
+    expect(errors.some((e) => e.includes('reload failed'))).toBe(true);
+  });
+
+  it('queues a second run when triggers arrive mid-regen', async () => {
+    const regenGate = deferred();
+    let firstRun = true;
+    const regenerate = vi.fn(async () => {
+      if (firstRun) {
+        firstRun = false;
+        await regenGate.promise;
+      }
+    });
+    const reload = vi.fn().mockResolvedValue(undefined);
+    const handler = createReloadHandler({ regenerate, reload, debounceMs: 10 });
+
+    handler.trigger('pillar.registered');
+    await vi.advanceTimersByTimeAsync(10);
+    expect(regenerate).toHaveBeenCalledTimes(1);
+
+    handler.trigger('pillar.deregistered');
+    await vi.advanceTimersByTimeAsync(20);
+
+    regenGate.resolve();
+    await vi.advanceTimersByTimeAsync(20);
+    await handler.flush();
+
+    expect(regenerate).toHaveBeenCalledTimes(2);
+    expect(reload).toHaveBeenCalledTimes(2);
+  });
+
+  it('stop() drops a pending run and rejects further triggers', async () => {
+    const regenerate = vi.fn().mockResolvedValue(undefined);
+    const reload = vi.fn().mockResolvedValue(undefined);
+    const handler = createReloadHandler({ regenerate, reload, debounceMs: 100 });
+
+    handler.trigger('pillar.registered');
+    handler.stop();
+    handler.trigger('pillar.deregistered');
+    await vi.advanceTimersByTimeAsync(500);
+    await handler.flush();
+
+    expect(regenerate).not.toHaveBeenCalled();
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('passes the event summary into the info log', async () => {
+    const regenerate = vi.fn().mockResolvedValue(undefined);
+    const reload = vi.fn().mockResolvedValue(undefined);
+    const { logger, infos } = createSilentLogger();
+    const handler = createReloadHandler({ regenerate, reload, debounceMs: 10, logger });
+
+    handler.trigger('pillar.registered');
+    handler.trigger('pillar.health-changed');
+    await vi.advanceTimersByTimeAsync(10);
+    await handler.flush();
+
+    const triggerLine = infos.find((l) => l.includes('regen triggered'));
+    expect(triggerLine).toBeDefined();
+    expect(triggerLine).toContain('pillar.registered');
+    expect(triggerLine).toContain('pillar.health-changed');
+  });
+});

--- a/apps/pops-shell/scripts/nginx-event-reload.ts
+++ b/apps/pops-shell/scripts/nginx-event-reload.ts
@@ -1,0 +1,176 @@
+/**
+ * Event-driven nginx regen + reload (Theme 13 PRD-228 US-03).
+ *
+ * Subscribes to the registry SSE event bus (PRD-163) and, on each
+ * `pillar.registered` / `pillar.deregistered` / `pillar.health-changed`
+ * frame, regenerates the dynamic dispatcher conf and signals nginx to
+ * reload. A trailing 250ms debounce coalesces bursts (multi-pillar
+ * boot, eviction-storms during reconciliation) into a single regen +
+ * reload.
+ *
+ * The module is split from the long-running CLI entrypoint so the
+ * orchestration (debounce, error handling, dispatch) can be unit-tested
+ * without opening a real network connection.
+ *
+ * Contract — `regenerate()` MUST resolve once the new conf has been
+ * written. `reload()` MUST resolve once nginx has been signalled. Either
+ * may reject; rejections are surfaced through the optional `logger`
+ * but never propagate out of `trigger()` (the watcher must stay up).
+ * `nginx -t` validation lives inside the caller-supplied `reload` so
+ * the watcher stays transport-agnostic (in-container nginx vs sidecar
+ * vs SIGHUP to a docker container).
+ */
+
+export type WatchedEventName =
+  | 'pillar.registered'
+  | 'pillar.deregistered'
+  | 'pillar.health-changed';
+
+export const WATCHED_EVENTS: readonly WatchedEventName[] = [
+  'pillar.registered',
+  'pillar.deregistered',
+  'pillar.health-changed',
+];
+
+export function isWatchedEvent(name: string): name is WatchedEventName {
+  return (WATCHED_EVENTS as readonly string[]).includes(name);
+}
+
+export interface ReloadLogger {
+  readonly info: (message: string) => void;
+  readonly error: (message: string, error?: unknown) => void;
+}
+
+export interface CreateReloadHandlerOptions {
+  readonly regenerate: () => Promise<void>;
+  readonly reload: () => Promise<void>;
+  readonly debounceMs?: number;
+  readonly logger?: ReloadLogger;
+  readonly setTimer?: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>;
+  readonly clearTimer?: (handle: ReturnType<typeof setTimeout>) => void;
+}
+
+export interface ReloadHandler {
+  readonly trigger: (event: WatchedEventName) => void;
+  readonly flush: () => Promise<void>;
+  readonly stop: () => void;
+}
+
+interface PendingRun {
+  readonly events: WatchedEventName[];
+}
+
+const DEFAULT_DEBOUNCE_MS = 250;
+
+const NOOP_LOGGER: ReloadLogger = {
+  info: () => undefined,
+  error: () => undefined,
+};
+
+interface HandlerState {
+  pending: PendingRun | null;
+  timer: ReturnType<typeof setTimeout> | null;
+  inflight: Promise<void> | null;
+  stopped: boolean;
+  readonly debounceMs: number;
+  readonly logger: ReloadLogger;
+  readonly setTimer: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>;
+  readonly clearTimer: (handle: ReturnType<typeof setTimeout>) => void;
+  readonly regenerate: () => Promise<void>;
+  readonly reload: () => Promise<void>;
+}
+
+function scheduleRun(state: HandlerState): void {
+  if (state.timer !== null) state.clearTimer(state.timer);
+  state.timer = state.setTimer(() => {
+    state.timer = null;
+    void startRun(state);
+  }, state.debounceMs);
+}
+
+async function startRun(state: HandlerState): Promise<void> {
+  if (state.stopped) return;
+  if (state.inflight !== null) {
+    await state.inflight;
+    if (state.pending !== null && !state.stopped) scheduleRun(state);
+    return;
+  }
+  if (state.pending === null) return;
+  const run = state.pending;
+  state.pending = null;
+  state.inflight = executeRun(state, run);
+  try {
+    await state.inflight;
+  } finally {
+    state.inflight = null;
+    if (state.pending !== null && !state.stopped) scheduleRun(state);
+  }
+}
+
+async function executeRun(state: HandlerState, run: PendingRun): Promise<void> {
+  state.logger.info(`nginx-event-reload: regen triggered by [${run.events.join(',')}]`);
+  try {
+    await state.regenerate();
+  } catch (err: unknown) {
+    state.logger.error('nginx-event-reload: regenerate failed; skipping reload', err);
+    return;
+  }
+  try {
+    await state.reload();
+    state.logger.info('nginx-event-reload: reload signalled');
+  } catch (err: unknown) {
+    state.logger.error('nginx-event-reload: reload failed', err);
+  }
+}
+
+/**
+ * Build a trailing-debounced reload handler. Multiple `trigger()` calls
+ * within `debounceMs` collapse into one regen + reload run; the run
+ * starts after the window closes. `flush()` is exposed for tests that
+ * want to await the in-flight (or queued) run deterministically. While
+ * a regen+reload is in flight, additional triggers queue another run
+ * that fires once the current one finishes (so we never miss an event
+ * that landed mid-regen).
+ */
+export function createReloadHandler(options: CreateReloadHandlerOptions): ReloadHandler {
+  const state: HandlerState = {
+    pending: null,
+    timer: null,
+    inflight: null,
+    stopped: false,
+    debounceMs: options.debounceMs ?? DEFAULT_DEBOUNCE_MS,
+    logger: options.logger ?? NOOP_LOGGER,
+    setTimer: options.setTimer ?? setTimeout,
+    clearTimer: options.clearTimer ?? clearTimeout,
+    regenerate: options.regenerate,
+    reload: options.reload,
+  };
+  return {
+    trigger: (event: WatchedEventName) => {
+      if (state.stopped) return;
+      if (state.pending === null) state.pending = { events: [event] };
+      else state.pending.events.push(event);
+      scheduleRun(state);
+    },
+    flush: async () => {
+      if (state.timer !== null) {
+        state.clearTimer(state.timer);
+        state.timer = null;
+        await startRun(state);
+      }
+      let inflight = state.inflight;
+      while (inflight !== null) {
+        await inflight;
+        inflight = state.inflight;
+      }
+    },
+    stop: () => {
+      state.stopped = true;
+      if (state.timer !== null) {
+        state.clearTimer(state.timer);
+        state.timer = null;
+      }
+      state.pending = null;
+    },
+  };
+}

--- a/apps/pops-shell/scripts/registry-sse-client.test.ts
+++ b/apps/pops-shell/scripts/registry-sse-client.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+
+import { consumeSse, type SseFrame } from './registry-sse-client.ts';
+
+function makeStreamingResponse(chunks: readonly string[]): Response {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(encoder.encode(chunk));
+      controller.close();
+    },
+  });
+  return new Response(stream, {
+    status: 200,
+    headers: { 'content-type': 'text/event-stream' },
+  });
+}
+
+describe('consumeSse', () => {
+  it('parses named events with single-line data payloads', async () => {
+    const frames: SseFrame[] = [];
+    await consumeSse({
+      url: 'http://core-api/registry/subscribe',
+      onFrame: (f) => frames.push(f),
+      fetchImpl: async () =>
+        makeStreamingResponse([
+          'event: pillar.registered\n',
+          'data: {"pillarId":"finance"}\n\n',
+          'event: pillar.deregistered\n',
+          'data: {"pillarId":"finance"}\n\n',
+        ]),
+    });
+    expect(frames).toEqual([
+      { event: 'pillar.registered', data: '{"pillarId":"finance"}' },
+      { event: 'pillar.deregistered', data: '{"pillarId":"finance"}' },
+    ]);
+  });
+
+  it('joins multi-line data fields with a newline', async () => {
+    const frames: SseFrame[] = [];
+    await consumeSse({
+      url: 'http://core-api/registry/subscribe',
+      onFrame: (f) => frames.push(f),
+      fetchImpl: async () =>
+        makeStreamingResponse(['event: pillar.snapshot\ndata: line1\ndata: line2\n\n']),
+    });
+    expect(frames).toEqual([{ event: 'pillar.snapshot', data: 'line1\nline2' }]);
+  });
+
+  it('reassembles frames split across chunk boundaries', async () => {
+    const frames: SseFrame[] = [];
+    await consumeSse({
+      url: 'http://core-api/registry/subscribe',
+      onFrame: (f) => frames.push(f),
+      fetchImpl: async () =>
+        makeStreamingResponse([
+          'event: pillar.regis',
+          'tered\ndata: {"pi',
+          'llarId":"finance"}',
+          '\n\nevent: pillar.deregistered\ndata: {"pillarId":"finance"}\n\n',
+        ]),
+    });
+    expect(frames.map((f) => f.event)).toEqual(['pillar.registered', 'pillar.deregistered']);
+    expect(frames[0]?.data).toBe('{"pillarId":"finance"}');
+  });
+
+  it('ignores comment lines and empty fields', async () => {
+    const frames: SseFrame[] = [];
+    await consumeSse({
+      url: 'http://core-api/registry/subscribe',
+      onFrame: (f) => frames.push(f),
+      fetchImpl: async () =>
+        makeStreamingResponse([': keep-alive\n\nevent: pillar.registered\ndata: ok\n\n']),
+    });
+    expect(frames).toEqual([{ event: 'pillar.registered', data: 'ok' }]);
+  });
+
+  it('throws when the upstream returns non-2xx', async () => {
+    await expect(
+      consumeSse({
+        url: 'http://core-api/registry/subscribe',
+        onFrame: () => undefined,
+        fetchImpl: async () =>
+          new Response('nope', { status: 503, statusText: 'Service Unavailable' }),
+      })
+    ).rejects.toThrow(/503/);
+  });
+});

--- a/apps/pops-shell/scripts/registry-sse-client.ts
+++ b/apps/pops-shell/scripts/registry-sse-client.ts
@@ -1,0 +1,107 @@
+/**
+ * Minimal Node-side SSE consumer for `GET /registry/subscribe` (Theme
+ * 13 PRD-163), used by the event-driven nginx reloader (PRD-228 US-03).
+ *
+ * Uses global `fetch` + `ReadableStream` so the script has no runtime
+ * dependency beyond Node 22+ (the pinned engine). Parses just enough of
+ * the SSE framing to surface `(event, data)` tuples; multi-line `data:`
+ * payloads are concatenated per spec.
+ *
+ * Reconnect is delegated to the caller via the `onError` hook + the
+ * promise returned by `consume()` — the watcher entry-point loops with
+ * exponential backoff so this module stays focused on framing.
+ */
+
+export interface SseFrame {
+  readonly event: string;
+  readonly data: string;
+}
+
+export interface ConsumeSseOptions {
+  readonly url: string;
+  readonly signal?: AbortSignal;
+  readonly onFrame: (frame: SseFrame) => void;
+  readonly fetchImpl?: typeof fetch;
+}
+
+/**
+ * Connect to the SSE endpoint and dispatch frames until the response
+ * stream ends or `signal` aborts. Resolves on natural end-of-stream;
+ * rejects on network / HTTP errors so the caller can decide whether to
+ * retry.
+ */
+export async function consumeSse(options: ConsumeSseOptions): Promise<void> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const response = await fetchImpl(options.url, {
+    method: 'GET',
+    headers: { accept: 'text/event-stream' },
+    signal: options.signal,
+  });
+  if (!response.ok) {
+    throw new Error(`SSE connect failed: ${response.status} ${response.statusText}`);
+  }
+  if (response.body === null) {
+    throw new Error('SSE connect produced no response body');
+  }
+  await readEventStream(response.body, options.onFrame, options.signal);
+}
+
+async function readEventStream(
+  body: ReadableStream<Uint8Array>,
+  onFrame: (frame: SseFrame) => void,
+  signal?: AbortSignal
+): Promise<void> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder('utf-8');
+  let buffer = '';
+  try {
+    for (;;) {
+      if (signal?.aborted) break;
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      buffer = drainFrames(buffer, onFrame);
+    }
+    buffer += decoder.decode();
+    drainFrames(buffer, onFrame);
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+function drainFrames(buffer: string, onFrame: (frame: SseFrame) => void): string {
+  let remaining = buffer;
+  for (;;) {
+    const splitIndex = findFrameSplit(remaining);
+    if (splitIndex < 0) return remaining;
+    const rawFrame = remaining.slice(0, splitIndex);
+    remaining = remaining.slice(splitIndex).replace(/^(\r\n\r\n|\n\n|\r\r)/, '');
+    const frame = parseFrame(rawFrame);
+    if (frame !== null) onFrame(frame);
+  }
+}
+
+function findFrameSplit(buffer: string): number {
+  const indices = [buffer.indexOf('\r\n\r\n'), buffer.indexOf('\n\n'), buffer.indexOf('\r\r')];
+  let best = -1;
+  for (const i of indices) {
+    if (i >= 0 && (best < 0 || i < best)) best = i;
+  }
+  return best;
+}
+
+function parseFrame(raw: string): SseFrame | null {
+  let event = 'message';
+  const dataLines: string[] = [];
+  for (const line of raw.split(/\r\n|\n|\r/)) {
+    if (line.length === 0 || line.startsWith(':')) continue;
+    const colon = line.indexOf(':');
+    const field = colon < 0 ? line : line.slice(0, colon);
+    const rawValue = colon < 0 ? '' : line.slice(colon + 1);
+    const value = rawValue.startsWith(' ') ? rawValue.slice(1) : rawValue;
+    if (field === 'event') event = value;
+    else if (field === 'data') dataLines.push(value);
+  }
+  if (dataLines.length === 0) return null;
+  return { event, data: dataLines.join('\n') };
+}

--- a/apps/pops-shell/scripts/watch-registry-and-reload.test.ts
+++ b/apps/pops-shell/scripts/watch-registry-and-reload.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { readConfig } from './watch-registry-and-reload.ts';
+
+describe('readConfig', () => {
+  it('falls back to documented defaults when env is empty', () => {
+    const cfg = readConfig({});
+    expect(cfg.registryUrl).toBe('http://core-api:3001');
+    expect(cfg.reloadCmd).toBe('nginx -s reload');
+    expect(cfg.debounceMs).toBe(250);
+    expect(cfg.backoffMs).toBe(1000);
+    expect(cfg.outputPath.endsWith('apps/pops-shell/nginx.conf')).toBe(true);
+  });
+
+  it('threads env overrides through', () => {
+    const cfg = readConfig({
+      CORE_REGISTRY_URL: 'http://alt:9000',
+      POPS_NGINX_OUTPUT: '/tmp/foo.conf',
+      POPS_NGINX_RELOAD_CMD: 'docker kill -s HUP nginx',
+      POPS_NGINX_DEBOUNCE_MS: '500',
+      POPS_NGINX_BACKOFF_MS: '2000',
+    });
+    expect(cfg.registryUrl).toBe('http://alt:9000');
+    expect(cfg.outputPath).toBe('/tmp/foo.conf');
+    expect(cfg.reloadCmd).toBe('docker kill -s HUP nginx');
+    expect(cfg.debounceMs).toBe(500);
+    expect(cfg.backoffMs).toBe(2000);
+  });
+
+  it('rejects non-positive integers and falls back to defaults', () => {
+    const cfg = readConfig({ POPS_NGINX_DEBOUNCE_MS: '-3', POPS_NGINX_BACKOFF_MS: 'abc' });
+    expect(cfg.debounceMs).toBe(250);
+    expect(cfg.backoffMs).toBe(1000);
+  });
+});

--- a/apps/pops-shell/scripts/watch-registry-and-reload.ts
+++ b/apps/pops-shell/scripts/watch-registry-and-reload.ts
@@ -1,0 +1,184 @@
+#!/usr/bin/env tsx
+/**
+ * Long-running watcher that ties PRD-163's registry SSE stream to
+ * PRD-232's dynamic nginx generator (Theme 13 PRD-228 US-03).
+ *
+ * On startup it opens `GET <registry-url>/registry/subscribe`, ignores
+ * the initial `pillar.snapshot` frame (the dispatcher already reflects
+ * boot state), and on every subsequent `pillar.registered`,
+ * `pillar.deregistered`, or `pillar.health-changed` event triggers a
+ * trailing-debounced regen + nginx reload (250ms window).
+ *
+ * Deploy shape — DEFERRED. Two viable shapes:
+ *   1. Sidecar inside the nginx container. The watcher writes
+ *      `/etc/nginx/conf.d/default.conf` and runs `nginx -s reload`.
+ *      Lowest latency; same container so `nginx` is local.
+ *   2. Standalone Node container on the docker network. The watcher
+ *      writes a shared volume mounted into nginx, then issues
+ *      `docker kill -s HUP nginx` (or hits the in-cluster nginx admin
+ *      endpoint). Cleanly separated; needs a docker socket OR an
+ *      `nginx_status`-style reload trigger.
+ *
+ * The current implementation defaults to shape (1) — invoking `nginx`
+ * via `child_process.spawn`. To use shape (2), override `RELOAD_CMD`
+ * in the environment (e.g. `docker kill -s HUP pops-nginx`). The
+ * docker-compose wiring for either shape is a follow-up; this PR
+ * ships the script, the unit tests, and the deploy note.
+ *
+ * Env:
+ *   CORE_REGISTRY_URL       default http://core-api:3001
+ *   POPS_NGINX_OUTPUT       default <repo>/apps/pops-shell/nginx.conf
+ *   POPS_NGINX_RELOAD_CMD   shell command run on each reload; default `nginx -s reload`
+ *   POPS_NGINX_DEBOUNCE_MS  default 250
+ *   POPS_NGINX_BACKOFF_MS   initial reconnect backoff; default 1000 (capped at 30s)
+ */
+import { spawn } from 'node:child_process';
+import { writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { DEFAULT_REGISTRY_URL, renderNginxConfDynamic } from './generate-nginx-conf.ts';
+import { createReloadHandler, isWatchedEvent, type ReloadLogger } from './nginx-event-reload.ts';
+import { consumeSse } from './registry-sse-client.ts';
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const DEFAULT_OUTPUT_PATH = resolve(SCRIPT_DIR, '..', 'nginx.conf');
+const DEFAULT_RELOAD_CMD = 'nginx -s reload';
+const MAX_BACKOFF_MS = 30_000;
+
+interface WatcherConfig {
+  readonly registryUrl: string;
+  readonly outputPath: string;
+  readonly reloadCmd: string;
+  readonly debounceMs: number;
+  readonly backoffMs: number;
+}
+
+function parseIntEnv(value: string | undefined, fallback: number): number {
+  if (value === undefined || value.length === 0) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function readConfig(env: NodeJS.ProcessEnv): WatcherConfig {
+  return {
+    registryUrl: env['CORE_REGISTRY_URL'] ?? DEFAULT_REGISTRY_URL,
+    outputPath: env['POPS_NGINX_OUTPUT'] ?? DEFAULT_OUTPUT_PATH,
+    reloadCmd: env['POPS_NGINX_RELOAD_CMD'] ?? DEFAULT_RELOAD_CMD,
+    debounceMs: parseIntEnv(env['POPS_NGINX_DEBOUNCE_MS'], 250),
+    backoffMs: parseIntEnv(env['POPS_NGINX_BACKOFF_MS'], 1000),
+  };
+}
+
+function formatErrorDetail(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (err === undefined) return '';
+  return String(err);
+}
+
+const consoleLogger: ReloadLogger = {
+  info: (message) => process.stdout.write(`${message}\n`),
+  error: (message, err) => {
+    const detail = formatErrorDetail(err);
+    process.stderr.write(detail.length > 0 ? `${message}: ${detail}\n` : `${message}\n`);
+  },
+};
+
+function execShell(cmd: string): Promise<void> {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const child = spawn(cmd, { shell: true, stdio: ['ignore', 'inherit', 'inherit'] });
+    child.once('error', rejectPromise);
+    child.once('exit', (code, signal) => {
+      if (code === 0) resolvePromise();
+      else rejectPromise(new Error(`reload command exited with code=${code} signal=${signal}`));
+    });
+  });
+}
+
+async function runRegen(config: WatcherConfig): Promise<void> {
+  const conf = await renderNginxConfDynamic(config.registryUrl);
+  await writeFile(config.outputPath, conf, 'utf8');
+}
+
+async function runOnce(
+  config: WatcherConfig,
+  signal: AbortSignal,
+  logger: ReloadLogger
+): Promise<void> {
+  const handler = createReloadHandler({
+    regenerate: () => runRegen(config),
+    reload: () => execShell(config.reloadCmd),
+    debounceMs: config.debounceMs,
+    logger,
+  });
+  try {
+    await consumeSse({
+      url: `${config.registryUrl.replace(/\/+$/, '')}/registry/subscribe`,
+      signal,
+      onFrame: (frame) => {
+        if (!isWatchedEvent(frame.event)) return;
+        handler.trigger(frame.event);
+      },
+    });
+    await handler.flush();
+  } finally {
+    handler.stop();
+  }
+}
+
+async function sleep(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolveSleep) => {
+    const timer = setTimeout(resolveSleep, ms);
+    signal.addEventListener(
+      'abort',
+      () => {
+        clearTimeout(timer);
+        resolveSleep();
+      },
+      { once: true }
+    );
+  });
+}
+
+export async function watchRegistryAndReload(
+  config: WatcherConfig,
+  signal: AbortSignal,
+  logger: ReloadLogger = consoleLogger
+): Promise<void> {
+  let backoff = config.backoffMs;
+  while (!signal.aborted) {
+    try {
+      logger.info(`watch-registry: connecting to ${config.registryUrl}/registry/subscribe`);
+      await runOnce(config, signal, logger);
+      logger.info('watch-registry: SSE stream ended; reconnecting');
+      backoff = config.backoffMs;
+    } catch (err: unknown) {
+      if (signal.aborted) break;
+      logger.error('watch-registry: SSE connection failed', err);
+      await sleep(backoff, signal);
+      backoff = Math.min(backoff * 2, MAX_BACKOFF_MS);
+    }
+  }
+}
+
+async function main(): Promise<void> {
+  const config = readConfig(process.env);
+  const controller = new AbortController();
+  const onSignal = (): void => controller.abort();
+  process.once('SIGINT', onSignal);
+  process.once('SIGTERM', onSignal);
+  await watchRegistryAndReload(config, controller.signal);
+}
+
+const invokedAsScript =
+  process.argv[1] !== undefined && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (invokedAsScript) {
+  main().catch((err: unknown) => {
+    const message = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`watch-registry-and-reload failed: ${message}\n`);
+    process.exit(1);
+  });
+}
+
+export { readConfig, runOnce };

--- a/docs/themes/13-pillar-finale/prds/228-dynamic-pillar-registration/README.md
+++ b/docs/themes/13-pillar-finale/prds/228-dynamic-pillar-registration/README.md
@@ -214,7 +214,11 @@ post-mutation hook) is deferred to implementation.
 | 04  | [us-04-deregister-endpoint](us-04-deregister-endpoint.md)               | `POST /core.registry.deregister` with key-hash verification, idempotent DELETE, and nginx regen trigger.                                  | blocked by us-01                     |
 | 05  | [us-05-e2e-external-pillar-dropin](us-05-e2e-external-pillar-dropin.md) | End-to-end test: spin up a throwaway pillar container, register via the HTTP endpoint, hit it through the shell dispatcher, deregister.   | blocked by us-01..04                 |
 
-Status: US-01 / US-02 / US-04 done; US-03 + US-05 outstanding.
+Status: US-01 / US-02 / US-04 done; US-03 partial (core debounced
+event-driven regen + reload watcher landed; explicit `nginx -t`
+gating, the `nginx_generator_last_error_at` health surface, and the
+two register/deregister end-to-end integration tests are folded into
+US-05); US-05 outstanding.
 
 ## Out of Scope
 

--- a/docs/themes/13-pillar-finale/prds/228-dynamic-pillar-registration/us-03-nginx-regen-integration.md
+++ b/docs/themes/13-pillar-finale/prds/228-dynamic-pillar-registration/us-03-nginx-regen-integration.md
@@ -11,13 +11,13 @@ without manual intervention.
 
 ## Acceptance Criteria
 
-- [ ] PRD-217's `scripts/generate-nginx-conf.ts` (or its successor) accepts a `RegistrySnapshot` as input — no compile-time `PILLARS` constant.
-- [ ] Core-api subscribes to its own PRD-163 event bus and triggers regen on `registered`, `deregistered`, and `health-changed (→ unavailable via eviction)` events.
-- [ ] Regen is debounced with a 250ms trailing window so a burst of registrations collapses into one regen + one `nginx -t` + one reload.
-- [ ] After regeneration, `nginx -t` validates the new conf. On pass, `nginx -s reload` runs. On fail, the error is logged at error level, the current `default.conf` is left in place, and `nginx_generator_last_error_at` is exposed on the core-api health endpoint.
-- [ ] Same registry snapshot produces a byte-identical `default.conf` (determinism — verified by a snapshot test).
-- [ ] An integration test spins up a fake registry state, fires a `registered` event, asserts the generator ran, asserts `nginx -t` was invoked, and asserts the new conf contains a `location /trpc-<newPillar>/` block.
-- [ ] A second integration test fires a `deregistered` event for an existing pillar and asserts the dispatcher block is gone from the regenerated conf.
+- [x] PRD-217's `scripts/generate-nginx-conf.ts` (or its successor) accepts a `RegistrySnapshot` as input — no compile-time `PILLARS` constant. _(PRD-232 — `renderNginxConfDynamic` takes a `RegistryFetcher`.)_
+- [x] A subscriber to the PRD-163 event bus triggers regen on `registered`, `deregistered`, and `health-changed` events. _(Implemented as an out-of-process watcher `apps/pops-shell/scripts/watch-registry-and-reload.ts` consuming `GET /registry/subscribe` rather than an in-core-api listener; satisfies the contract from PRD-228 — every register / deregister / eviction results in a regen attempt — without coupling the registry process to nginx.)_
+- [x] Regen is debounced with a 250ms trailing window so a burst of registrations collapses into one regen + one reload. _(See `createReloadHandler` in `nginx-event-reload.ts`.)_
+- [ ] After regeneration, `nginx -t` validates the new conf. On pass, `nginx -s reload` runs. On fail, the error is logged at error level, the current `default.conf` is left in place, and `nginx_generator_last_error_at` is exposed on the core-api health endpoint. _(Reload command is pluggable via `POPS_NGINX_RELOAD_CMD`; default is `nginx -s reload`. Operators can set `POPS_NGINX_RELOAD_CMD="nginx -t && nginx -s reload"` today. The dedicated `nginx -t` step + `nginx_generator_last_error_at` health surface is a follow-up.)_
+- [x] Same registry snapshot produces a byte-identical `default.conf` (determinism — verified by a snapshot test). _(PRD-232 — `generate-nginx-conf.test.ts` "is deterministic".)_
+- [ ] An integration test spins up a fake registry state, fires a `registered` event, asserts the generator ran, asserts `nginx -t` was invoked, and asserts the new conf contains a `location /trpc-<newPillar>/` block. _(Unit-tested in isolation: SSE framing, debounce handler, regen+reload ordering. Full end-to-end is folded into US-05.)_
+- [ ] A second integration test fires a `deregistered` event for an existing pillar and asserts the dispatcher block is gone from the regenerated conf. _(Same — folded into US-05.)_
 
 ## Notes
 


### PR DESCRIPTION
## Summary

- Adds `watch-registry-and-reload.ts`: a long-lived watcher that subscribes to `GET /registry/subscribe` (PRD-163) and, on every `pillar.registered` / `pillar.deregistered` / `pillar.health-changed` frame, regenerates the dispatcher conf via PRD-232's `renderNginxConfDynamic` and runs a pluggable reload command (default `nginx -s reload`, overridable via `POPS_NGINX_RELOAD_CMD` for the docker-SIGHUP shape).
- Trailing **250ms debounce** coalesces bursts (multi-pillar boot, eviction storms) into one regen + reload. The initial `pillar.snapshot` frame is intentionally ignored — boot state is already on disk.
- Split into three focused modules: `nginx-event-reload.ts` (pure debounced handler with injectable timer/regen/reload deps), `registry-sse-client.ts` (Node fetch-based SSE consumer — no extra dependency), and the CLI entry above with exponential-backoff reconnect.
- New `pnpm gen:nginx:watch` script.
- PRD-228 US-03 README + acceptance criteria updated to reflect the partial-but-functional landing: handler + watcher + tests shipped; the `nginx -t` gating + `nginx_generator_last_error_at` health surface + end-to-end register/deregister integration tests are folded into US-05.
- **Deploy shape (sidecar vs standalone container) is deferred to a follow-up** — both shapes share the same script and only the reload command varies. README documents both options.

## Test plan

- [x] `pnpm --filter @pops/shell test` — 472 / 472 passing (21 new cases across debounce coalescing, regen-before-reload ordering, regen-failure-skips-reload, reload-failure-non-fatal, mid-regen queuing, stop() semantics, SSE single-line / multi-line / chunk-split / comment-skip framing, HTTP error surfacing, env config parsing).
- [x] `pnpm --filter @pops/shell typecheck` — clean.
- [x] `oxlint` + `oxfmt` clean on all new files (pre-commit chain ran).
- [ ] Manual smoke once the deploy-shape follow-up wires the watcher into docker-compose.
