### PR TITLE
feat(api): flip 3 hot-paths (sync_job_results, ai_model_pricing, ai_usage) to core-db (Wave 5)

### DIFF
--- a/apps/pops-api/src/jobs/sync-results.ts
+++ b/apps/pops-api/src/jobs/sync-results.ts
@@ -2,7 +2,7 @@ import pino from 'pino';
 
 import { PERSISTED_SYNC_TYPES, syncResultsService } from '@pops/core-db';
 
-import { getDrizzle } from '../db.js';
+import { getCoreDrizzle } from '../db.js';
 
 import type { SyncQueueJobData } from './types.js';
 
@@ -25,10 +25,9 @@ export interface PersistSyncResultParams {
  * Plex job types in {@link PERSISTED_SYNC_TYPES} are written; everything
  * else is observed via Redis and short-circuits here.
  *
- * The handle is the shared `pops.db` for now because the underlying
- * table cutover into `core.db` is sequenced behind PRD-186 PR 4. After
- * that lands the only line that changes is `getDrizzle()` ->
- * `getCoreDrizzle()`.
+ * Writes resolve against the core pillar handle (`getCoreDrizzle()`)
+ * now that PRD-186 PR 4 cut the `sync_job_results` table over into
+ * `core.db`. The shared `pops.db` copy still exists for fallback.
  */
 export function persistSyncResult(params: PersistSyncResultParams): void {
   const { jobId, data, status, result, error, processedOn, finishedOn, progress } = params;
@@ -42,7 +41,7 @@ export function persistSyncResult(params: PersistSyncResultParams): void {
       progress != null ? JSON.stringify(progress) : JSON.stringify({ processed: 0, total: 0 });
     const resultJson = result != null ? JSON.stringify(result) : null;
 
-    syncResultsService.persist(getDrizzle(), {
+    syncResultsService.persist(getCoreDrizzle(), {
       id: jobId,
       jobType: data.type,
       status,

--- a/apps/pops-api/src/lib/inference-pricing.ts
+++ b/apps/pops-api/src/lib/inference-pricing.ts
@@ -1,22 +1,21 @@
 /**
  * Thin re-export of the `@pops/core-db` pricing cache, bound to the
- * shared drizzle handle. The cache + DB SELECT logic lives in
+ * core pillar drizzle handle. The cache + DB SELECT logic lives in
  * `@pops/core-db`'s `ai-model-pricing` service per the Theme 13
  * hot-path migration audit (row 5).
  *
- * The handle is the shared `pops.db` for now because the underlying
- * `ai_model_pricing` table cutover into `core.db` is sequenced behind
- * PRD-186 PR 4. After that lands the only line that changes is
- * `getDrizzle()` -> `getCoreDrizzle()`.
+ * Reads resolve against `getCoreDrizzle()` now that PRD-186 PR 4 cut
+ * the `ai_model_pricing` table over into `core.db`. The shared
+ * `pops.db` copy still exists for fallback.
  */
 import { aiModelPricingService, type PricingCache } from '@pops/core-db';
 
-import { getDrizzle } from '../db.js';
+import { getCoreDrizzle } from '../db.js';
 
 let cache: PricingCache | null = null;
 
 function getCache(): PricingCache {
-  cache ??= aiModelPricingService.createPricingCache(getDrizzle());
+  cache ??= aiModelPricingService.createPricingCache(getCoreDrizzle());
   return cache;
 }
 


### PR DESCRIPTION
## Summary

Flips the 3 unowned hot-paths that read/write `sync_job_results`, `ai_model_pricing`, and `ai_usage` from the shared `getDrizzle()` (pops.db) to `getCoreDrizzle()` (core.db), now that PRD-186 PR 4 (#3148) shipped migrations 0059/0060/0061 and the idempotent ATTACH backfill in `backfill-core-from-shared.ts`.

- `apps/pops-api/src/jobs/sync-results.ts` — `persistSyncResult` (sync_job_results) flipped.
- `apps/pops-api/src/lib/inference-pricing.ts` — pricing cache (ai_model_pricing) flipped.
- `apps/pops-api/src/lib/inference-middleware.ts` — `ai_usage` writes already on `getCoreDrizzle()` from an earlier commit in this wave; no edit needed.

Mirrors the embeddings flip pattern from #3147 (cerebrum-db). The shared `pops.db` copies of these tables still exist as a fallback.

`getDrizzle()` occurrences in the tree: **489 -> 485** (delta -4: 2 real call-sites swapped to `getCoreDrizzle()`, plus 2 JSDoc mentions updated in the same two files).

## Test plan

- [x] `pnpm --filter @pops/api test src/jobs src/lib` — 57 tests pass across 5 files.
- [x] `pnpm typecheck` (root) — 67/67 packages clean.
- [x] Husky pre-commit + pre-push hooks pass without `--no-verify`.
- [ ] CI green on this PR before merge.