### PR TITLE
feat(ha-bridge): scaffold pops-ha-bridge-api (PRD-229 US-01 — first bridge pillar)

### DIFF
--- a/apps/pops-core-api/Dockerfile
+++ b/apps/pops-core-api/Dockerfile
@@ -4,12 +4,17 @@ WORKDIR /app
 # Copy workspace root files
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json .oxfmtrc.json ./
 
-# Copy workspace package.json files (for dep resolution)
+# Copy workspace package.json files (for dep resolution).
+# wire-conformance is included even though @pops/core-api does not depend on
+# it: pnpm's --legacy deploy resolves the full workspace graph from
+# pnpm-workspace.yaml and fails ERR_PNPM_WORKSPACE_PKG_NOT_FOUND when a
+# listed member is absent from the build context.
 COPY packages/db-types/package.json ./packages/db-types/
 COPY packages/types/package.json ./packages/types/
 COPY packages/core-db/package.json ./packages/core-db/
 COPY packages/finance-contract/package.json ./packages/finance-contract/
 COPY packages/pillar-sdk/package.json ./packages/pillar-sdk/
+COPY packages/wire-conformance/package.json ./packages/wire-conformance/
 COPY apps/pops-core-api/package.json ./apps/pops-core-api/
 
 # Install pnpm and all workspace dependencies

--- a/apps/pops-ha-bridge-api/Dockerfile
+++ b/apps/pops-ha-bridge-api/Dockerfile
@@ -1,0 +1,53 @@
+FROM node:22-slim AS builder
+WORKDIR /app
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json .oxfmtrc.json ./
+
+COPY packages/ha-bridge-db/package.json ./packages/ha-bridge-db/
+COPY packages/finance-contract/package.json ./packages/finance-contract/
+COPY packages/pillar-sdk/package.json ./packages/pillar-sdk/
+COPY apps/pops-ha-bridge-api/package.json ./apps/pops-ha-bridge-api/
+
+RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
+    corepack enable && pnpm install --frozen-lockfile
+
+COPY packages/ha-bridge-db/src ./packages/ha-bridge-db/src
+COPY packages/ha-bridge-db/tsconfig.json ./packages/ha-bridge-db/
+COPY packages/ha-bridge-db/migrations ./packages/ha-bridge-db/migrations
+COPY packages/finance-contract/ ./packages/finance-contract/
+COPY packages/pillar-sdk/ ./packages/pillar-sdk/
+
+COPY apps/pops-ha-bridge-api/tsconfig.json ./apps/pops-ha-bridge-api/
+COPY apps/pops-ha-bridge-api/src ./apps/pops-ha-bridge-api/src
+
+WORKDIR /app/packages/ha-bridge-db
+RUN pnpm build
+WORKDIR /app/packages/finance-contract
+RUN pnpm build
+WORKDIR /app/packages/pillar-sdk
+RUN pnpm build
+
+WORKDIR /app/apps/pops-ha-bridge-api
+RUN pnpm build
+
+RUN pnpm --filter @pops/ha-bridge-api deploy --prod --legacy /app/deploy
+
+FROM node:22-slim
+WORKDIR /app
+RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder --chown=node:node /app/deploy ./
+COPY --from=builder --chown=node:node /app/apps/pops-ha-bridge-api/dist ./dist
+
+# The opener resolves the migrations folder via import.meta.url-relative
+# lookup (`<pkg>/dist/open-ha-bridge-db.js` → `<pkg>/migrations/`). Copy
+# the journal next to the built dist inside @pops/ha-bridge-db so the
+# runtime layout matches the dev layout.
+COPY --from=builder --chown=node:node /app/packages/ha-bridge-db/migrations ./node_modules/@pops/ha-bridge-db/migrations
+
+ARG BUILD_VERSION=dev
+ENV BUILD_VERSION=$BUILD_VERSION
+
+EXPOSE 3008
+USER node
+CMD ["node", "dist/server.js"]

--- a/apps/pops-ha-bridge-api/package.json
+++ b/apps/pops-ha-bridge-api/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@pops/ha-bridge-api",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsx watch --clear-screen=false src/server.ts",
+    "start": "node dist/server.js",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@pops/ha-bridge-db": "workspace:*",
+    "@pops/pillar-sdk": "workspace:*",
+    "express": "^5.1.0",
+    "ws": "^8.18.0"
+  },
+  "devDependencies": {
+    "@types/express": "^5.0.4",
+    "@types/node": "^25.9.3",
+    "@types/supertest": "^6.0.3",
+    "@types/ws": "^8.5.13",
+    "@vitest/coverage-v8": "^4.1.8",
+    "supertest": "^7.1.4",
+    "tsx": "^4.22.4",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.8"
+  }
+}

--- a/apps/pops-ha-bridge-api/src/__tests__/ha-frame.test.ts
+++ b/apps/pops-ha-bridge-api/src/__tests__/ha-frame.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseFrame } from '../ha-frame.js';
+
+describe('parseFrame', () => {
+  const payload = { type: 'auth_required', ha_version: '2025.10.1' };
+  const text = JSON.stringify(payload);
+
+  it('parses a plain string payload', () => {
+    expect(parseFrame(text)).toEqual(payload);
+  });
+
+  it('parses a Node Buffer payload', () => {
+    expect(parseFrame(Buffer.from(text, 'utf8'))).toEqual(payload);
+  });
+
+  it('parses an ArrayBuffer payload', () => {
+    const buf = Buffer.from(text, 'utf8');
+    const ab = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
+    expect(parseFrame(ab)).toEqual(payload);
+  });
+
+  it('parses a Uint8Array payload', () => {
+    const bytes = new Uint8Array(Buffer.from(text, 'utf8'));
+    expect(parseFrame(bytes)).toEqual(payload);
+  });
+
+  it('parses a Uint8Array view that is a slice of a larger ArrayBuffer', () => {
+    const full = Buffer.from(`xx${text}yy`, 'utf8');
+    const view = new Uint8Array(full.buffer, full.byteOffset + 2, text.length);
+    expect(parseFrame(view)).toEqual(payload);
+  });
+
+  it('parses a fragmented Buffer[] payload by concatenating chunks', () => {
+    const split = Math.floor(text.length / 2);
+    const chunks = [
+      Buffer.from(text.slice(0, split), 'utf8'),
+      Buffer.from(text.slice(split), 'utf8'),
+    ];
+    expect(parseFrame(chunks)).toEqual(payload);
+  });
+
+  it('returns undefined for unknown payload shapes', () => {
+    expect(parseFrame(42)).toBeUndefined();
+    expect(parseFrame(undefined)).toBeUndefined();
+    expect(parseFrame({ already: 'object' })).toBeUndefined();
+  });
+
+  it('returns undefined when JSON is malformed', () => {
+    expect(parseFrame('not json')).toBeUndefined();
+    expect(parseFrame(Buffer.from('also not json'))).toBeUndefined();
+  });
+});

--- a/apps/pops-ha-bridge-api/src/__tests__/manifest.test.ts
+++ b/apps/pops-ha-bridge-api/src/__tests__/manifest.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+
+import { ManifestPayloadSchema } from '@pops/pillar-sdk/manifest-schema';
+
+import { buildHaBridgeManifest, HA_BRIDGE_PILLAR_ID } from '../manifest.js';
+
+describe('buildHaBridgeManifest', () => {
+  it('produces a payload that passes the central manifest schema', () => {
+    const manifest = buildHaBridgeManifest('0.1.0');
+    const parsed = ManifestPayloadSchema.parse(manifest);
+    expect(parsed.pillar).toBe(HA_BRIDGE_PILLAR_ID);
+    expect(parsed.contract.tag).toBe('contract-ha-bridge@v0.1.0');
+    expect(parsed.search.adapters).toEqual([]);
+    expect(parsed.ai.tools).toEqual([]);
+    expect(parsed.sinks?.descriptors).toEqual([]);
+  });
+
+  it('rejects non-semver versions at the schema boundary', () => {
+    const manifest = buildHaBridgeManifest('not-a-semver');
+    expect(() => ManifestPayloadSchema.parse(manifest)).toThrow();
+  });
+});

--- a/apps/pops-ha-bridge-api/src/__tests__/ws-subscriber.test.ts
+++ b/apps/pops-ha-bridge-api/src/__tests__/ws-subscriber.test.ts
@@ -1,0 +1,226 @@
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getEntity, openHaBridgeDb, type OpenedHaBridgeDb } from '@pops/ha-bridge-db';
+import { haStateHistory } from '@pops/ha-bridge-db';
+
+import {
+  HaWebSocketSubscriber,
+  type HaWebSocketFactory,
+  type HaWebSocketLike,
+} from '../ws-subscriber.js';
+
+interface FakeSocket extends HaWebSocketLike {
+  sent: string[];
+  emitOpen(): void;
+  emitMessage(payload: unknown): void;
+  emitClose(code?: number, reason?: string): void;
+  emitError(err: Error): void;
+}
+
+function createFakeSocket(): FakeSocket {
+  const listeners: Record<string, ((...args: unknown[]) => void)[]> = {
+    open: [],
+    message: [],
+    close: [],
+    error: [],
+  };
+  const sent: string[] = [];
+  return {
+    sent,
+    send(data: string) {
+      sent.push(data);
+    },
+    close() {
+      const ls = listeners['close'] ?? [];
+      for (const l of ls) l(1000, Buffer.from(''));
+    },
+    on(event, listener) {
+      const arr = listeners[event];
+      if (arr !== undefined) arr.push(listener as (...args: unknown[]) => void);
+    },
+    emitOpen() {
+      const ls = listeners['open'] ?? [];
+      for (const l of ls) l();
+    },
+    emitMessage(payload) {
+      const serialised = typeof payload === 'string' ? payload : JSON.stringify(payload);
+      const ls = listeners['message'] ?? [];
+      for (const l of ls) l(serialised);
+    },
+    emitClose(code = 1006, reason = 'closed') {
+      const ls = listeners['close'] ?? [];
+      for (const l of ls) l(code, Buffer.from(reason));
+    },
+    emitError(err) {
+      const ls = listeners['error'] ?? [];
+      for (const l of ls) l(err);
+    },
+  };
+}
+
+describe('HaWebSocketSubscriber', () => {
+  let opened: OpenedHaBridgeDb;
+
+  beforeEach(() => {
+    const dir = mkdtempSync(join(tmpdir(), 'ha-bridge-api-'));
+    opened = openHaBridgeDb(join(dir, 'ha-bridge.db'));
+  });
+
+  afterEach(() => {
+    opened.raw.close();
+  });
+
+  it('boots in degraded mode when HA env is missing', () => {
+    const factory = vi.fn<HaWebSocketFactory>();
+    const sub = new HaWebSocketSubscriber({
+      db: opened,
+      url: undefined,
+      token: undefined,
+      webSocketFactory: factory,
+    });
+    sub.start();
+    expect(factory).not.toHaveBeenCalled();
+    expect(sub.state()).toEqual({ kind: 'offline', reason: 'no-config', lastEventAt: 0 });
+  });
+
+  it('authenticates, snapshots, then subscribes — and never logs the token', () => {
+    const fake = createFakeSocket();
+    const factory: HaWebSocketFactory = () => fake;
+    const sub = new HaWebSocketSubscriber({
+      db: opened,
+      url: 'ws://ha.local/api/websocket',
+      token: 'secret-token-xyz',
+      webSocketFactory: factory,
+      now: () => 1_000,
+    });
+    sub.start();
+
+    fake.emitOpen();
+    fake.emitMessage({ type: 'auth_required' });
+    expect(fake.sent[0]).toContain('"type":"auth"');
+    expect(fake.sent[0]).toContain('"access_token":"secret-token-xyz"');
+
+    fake.emitMessage({ type: 'auth_ok' });
+    expect(sub.state().kind).toBe('connected');
+
+    // snapshot response: HA returns an array of state objects
+    fake.emitMessage({
+      id: 1,
+      type: 'result',
+      success: true,
+      result: [
+        {
+          entity_id: 'light.kitchen_ceiling',
+          state: 'on',
+          last_changed: new Date(900).toISOString(),
+          attributes: { friendly_name: 'Kitchen Ceiling', area_name: 'kitchen' },
+        },
+      ],
+    });
+
+    const row = getEntity(opened.db, 'light.kitchen_ceiling');
+    expect(row?.state).toBe('on');
+    expect(row?.area).toBe('kitchen');
+
+    // After snapshot the subscriber should have requested the subscription.
+    const sentSubscribe = fake.sent.some((s) => s.includes('subscribe_events'));
+    expect(sentSubscribe).toBe(true);
+  });
+
+  it('debounces per-entity history writes inside the window', async () => {
+    const fake = createFakeSocket();
+    const sub = new HaWebSocketSubscriber({
+      db: opened,
+      url: 'ws://ha/api/websocket',
+      token: 't',
+      webSocketFactory: () => fake,
+      debounceMs: 20,
+      now: () => 5_000,
+    });
+    sub.start();
+    fake.emitOpen();
+    fake.emitMessage({ type: 'auth_required' });
+    fake.emitMessage({ type: 'auth_ok' });
+    fake.emitMessage({ id: 1, type: 'result', success: true, result: [] });
+
+    for (let i = 0; i < 3; i += 1) {
+      fake.emitMessage({
+        type: 'event',
+        event: {
+          event_type: 'state_changed',
+          data: {
+            entity_id: 'sensor.kitchen_temperature',
+            new_state: {
+              entity_id: 'sensor.kitchen_temperature',
+              state: String(20 + i),
+              last_changed: new Date(5_000 + i).toISOString(),
+              attributes: { friendly_name: 'Kitchen Temp' },
+            },
+          },
+        },
+      });
+    }
+
+    const mid = opened.db.select().from(haStateHistory).all();
+    expect(mid).toHaveLength(0);
+
+    await new Promise((resolve) => setTimeout(resolve, 60));
+
+    const final = opened.db.select().from(haStateHistory).all();
+    expect(final).toHaveLength(1);
+    expect(final[0]?.state).toBe('22');
+
+    sub.stop();
+  });
+
+  it('uses exponential backoff with the configured cap on reconnect', () => {
+    const sockets: FakeSocket[] = [];
+    const factory: HaWebSocketFactory = () => {
+      const s = createFakeSocket();
+      sockets.push(s);
+      return s;
+    };
+    const reconnectCallbacks: (() => void)[] = [];
+    const fakeSetTimeout = vi.fn<typeof setTimeout>((fn, _delay) => {
+      reconnectCallbacks.push(fn as () => void);
+      return 0 as unknown as ReturnType<typeof setTimeout>;
+    });
+    const fakeClearTimeout = vi.fn<typeof clearTimeout>(() => undefined);
+    const sub = new HaWebSocketSubscriber({
+      db: opened,
+      url: 'ws://ha/api/websocket',
+      token: 't',
+      webSocketFactory: factory,
+      initialBackoffMs: 1_000,
+      maxBackoffMs: 8_000,
+      setTimeoutImpl: fakeSetTimeout,
+      clearTimeoutImpl: fakeClearTimeout,
+      now: () => 0,
+    });
+    sub.start();
+
+    const delays: number[] = [];
+    for (let i = 0; i < 6; i += 1) {
+      const socket = sockets.at(-1);
+      if (socket === undefined) throw new Error('no socket');
+      // Drop immediately on connect — never authenticate — so reconnectAttempt
+      // is never reset and we observe the raw backoff progression.
+      socket.emitClose(1006, 'lost');
+      const lastCall = fakeSetTimeout.mock.calls.at(-1);
+      if (lastCall === undefined) throw new Error('expected setTimeout call');
+      const delay = lastCall[1];
+      delays.push(typeof delay === 'number' ? delay : 0);
+      // Fire the reconnect timer so the next iteration has a fresh socket
+      // with listeners attached and the per-iteration close lands on it.
+      const next = reconnectCallbacks.pop();
+      if (next !== undefined) next();
+    }
+
+    expect(delays).toEqual([1_000, 2_000, 4_000, 8_000, 8_000, 8_000]);
+    sub.stop();
+  });
+});

--- a/apps/pops-ha-bridge-api/src/app.ts
+++ b/apps/pops-ha-bridge-api/src/app.ts
@@ -1,0 +1,54 @@
+/**
+ * Express app factory for the HA bridge pillar (PRD-229 US-01).
+ *
+ * Surfaces only the minimal probe endpoints in this PR: `/health` for
+ * the standard pillar-runtime check and `/manifest.json` so deployers /
+ * tests can introspect what dimensions the pillar declares. The tRPC
+ * read surface (`entities.list` / `entities.get` / `entities.history` /
+ * `connection.status`) lands with US-02 / US-03.
+ */
+import express, { type Express, type Request, type Response } from 'express';
+
+import type { ManifestPayload } from '@pops/pillar-sdk/manifest-schema';
+
+import type { ConnectionState, HaWebSocketSubscriber } from './ws-subscriber.js';
+
+export interface HaBridgeAppDeps {
+  manifest: ManifestPayload;
+  version: string;
+  subscriber: Pick<HaWebSocketSubscriber, 'state'>;
+}
+
+export interface HealthResponse {
+  ok: true;
+  status: 'ok' | 'degraded';
+  pillar: 'ha-bridge';
+  version: string;
+  connection: ConnectionState;
+  ts: string;
+}
+
+export function createHaBridgeApiApp(deps: HaBridgeAppDeps): Express {
+  const app = express();
+  app.disable('x-powered-by');
+
+  app.get('/health', (_req: Request, res: Response) => {
+    const connection = deps.subscriber.state();
+    const status: HealthResponse['status'] = connection.kind === 'connected' ? 'ok' : 'degraded';
+    const body: HealthResponse = {
+      ok: true,
+      status,
+      pillar: 'ha-bridge',
+      version: deps.version,
+      connection,
+      ts: new Date().toISOString(),
+    };
+    res.json(body);
+  });
+
+  app.get('/manifest.json', (_req: Request, res: Response) => {
+    res.json(deps.manifest);
+  });
+
+  return app;
+}

--- a/apps/pops-ha-bridge-api/src/ha-bridge-sqlite-path.ts
+++ b/apps/pops-ha-bridge-api/src/ha-bridge-sqlite-path.ts
@@ -1,0 +1,24 @@
+import { dirname, join } from 'node:path';
+
+/**
+ * Resolver for the HA bridge pillar's SQLite path. Mirrors the
+ * per-pillar resolver convention used by finance-api / lists-api /
+ * media-api so a deployer who only sets `SQLITE_PATH` still ends up
+ * with `ha-bridge.db` next to the other pillar files.
+ *
+ * Resolution order:
+ *   1. `HA_BRIDGE_SQLITE_PATH` (absolute or relative)
+ *   2. `<dirname(SQLITE_PATH)>/ha-bridge.db` if the shared path is set
+ *   3. `./data/ha-bridge.db`
+ */
+export const DEFAULT_HA_BRIDGE_SQLITE_PATH = './data/ha-bridge.db';
+
+export function resolveHaBridgeSqlitePath(): string {
+  const envPath = process.env['HA_BRIDGE_SQLITE_PATH'];
+  if (envPath !== undefined && envPath !== '') return envPath;
+  const sharedPath = process.env['SQLITE_PATH'];
+  if (sharedPath !== undefined && sharedPath !== '') {
+    return join(dirname(sharedPath), 'ha-bridge.db');
+  }
+  return DEFAULT_HA_BRIDGE_SQLITE_PATH;
+}

--- a/apps/pops-ha-bridge-api/src/ha-frame.ts
+++ b/apps/pops-ha-bridge-api/src/ha-frame.ts
@@ -1,0 +1,75 @@
+/**
+ * Frame parsing + state-object → mirror-input conversion helpers for the
+ * HA WebSocket subscriber. Extracted from `ws-subscriber.ts` so the
+ * subscriber class stays focused on the connection state machine and
+ * the per-file complexity budget keeps room for US-02 expansions.
+ */
+import type { HaEntityMirrorInput } from '@pops/ha-bridge-db';
+
+export interface HaFrame {
+  id?: number;
+  type?: string;
+  success?: boolean;
+  message?: string;
+  result?: unknown;
+  event?: {
+    event_type?: string;
+    data?: {
+      entity_id?: string;
+      new_state?: HaStateObject | null;
+    };
+  };
+}
+
+export interface HaStateObject {
+  entity_id?: string;
+  state?: string;
+  last_changed?: string;
+  last_updated?: string;
+  attributes?: Record<string, unknown>;
+}
+
+export function parseFrame(raw: unknown): HaFrame | undefined {
+  const text = toJsonText(raw);
+  if (text === undefined) return undefined;
+  try {
+    const parsed: unknown = JSON.parse(text);
+    if (parsed !== null && typeof parsed === 'object') return parsed as HaFrame;
+  } catch {
+    return undefined;
+  }
+  return undefined;
+}
+
+function toJsonText(raw: unknown): string | undefined {
+  if (typeof raw === 'string') return raw;
+  if (raw instanceof Buffer) return raw.toString('utf8');
+  return undefined;
+}
+
+export function stateObjectToMirrorInput(
+  state: HaStateObject,
+  lastSeenMs: number
+): HaEntityMirrorInput | undefined {
+  if (state.entity_id === undefined || state.state === undefined) return undefined;
+  const lastChangedRaw = state.last_changed ?? state.last_updated;
+  const lastChanged = lastChangedRaw !== undefined ? Date.parse(lastChangedRaw) : lastSeenMs;
+  const attributes = state.attributes ?? {};
+  const area = readArea(attributes);
+  return {
+    entityId: state.entity_id,
+    state: state.state,
+    attributes,
+    area,
+    lastChanged: Number.isFinite(lastChanged) ? lastChanged : lastSeenMs,
+    lastSeen: lastSeenMs,
+  };
+}
+
+function readArea(attributes: Record<string, unknown>): string | null {
+  const fromAttr = attributes['area'];
+  if (typeof fromAttr === 'string' && fromAttr.length > 0) return fromAttr;
+  const fromAreaName = attributes['area_name'];
+  if (typeof fromAreaName === 'string' && fromAreaName.length > 0) return fromAreaName;
+  return null;
+}

--- a/apps/pops-ha-bridge-api/src/ha-frame.ts
+++ b/apps/pops-ha-bridge-api/src/ha-frame.ts
@@ -41,9 +41,24 @@ export function parseFrame(raw: unknown): HaFrame | undefined {
   return undefined;
 }
 
+/**
+ * Normalises every `ws` `RawData` shape — `string`, `Buffer`, `ArrayBuffer`,
+ * `Uint8Array`, or `Buffer[]` (fragmented frame) — to a UTF-8 string ready
+ * for `JSON.parse`. `ws` does not collapse fragments for us when the
+ * `WebSocket` is configured with the default `binaryType`, so frames that
+ * span multiple TCP reads arrive as `Buffer[]` and must be concatenated
+ * before parsing or they would be silently dropped.
+ */
 function toJsonText(raw: unknown): string | undefined {
   if (typeof raw === 'string') return raw;
-  if (raw instanceof Buffer) return raw.toString('utf8');
+  if (Buffer.isBuffer(raw)) return raw.toString('utf8');
+  if (raw instanceof ArrayBuffer) return Buffer.from(raw).toString('utf8');
+  if (ArrayBuffer.isView(raw)) {
+    return Buffer.from(raw.buffer, raw.byteOffset, raw.byteLength).toString('utf8');
+  }
+  if (Array.isArray(raw) && raw.every((chunk): chunk is Buffer => Buffer.isBuffer(chunk))) {
+    return Buffer.concat(raw).toString('utf8');
+  }
   return undefined;
 }
 

--- a/apps/pops-ha-bridge-api/src/history-debouncer.ts
+++ b/apps/pops-ha-bridge-api/src/history-debouncer.ts
@@ -1,0 +1,68 @@
+/**
+ * Per-entity 200ms debounce for `ha_state_history` writes (PRD-229
+ * § Business Rules — State-change debouncing). Extracted from
+ * `ws-subscriber.ts` so the connection state machine and the buffering
+ * mechanic can be reviewed / tested independently.
+ *
+ * Behaviour: the first state-change for an entity arms a timer for
+ * `debounceMs`. Subsequent state-changes for the same entity inside the
+ * window replace the buffered observation but do NOT reset the timer —
+ * so a hot sensor firing once per ms still drains at a steady cadence.
+ * When the timer fires the latest observation is flushed and the entry
+ * is removed from the table.
+ */
+export interface HistoryObservation {
+  entityId: string;
+  state: string;
+  attributes: Record<string, unknown>;
+  observedAt: number;
+}
+
+export interface HistoryDebouncerOptions {
+  debounceMs: number;
+  setTimeoutImpl: typeof setTimeout;
+  clearTimeoutImpl: typeof clearTimeout;
+  flush(observation: HistoryObservation): void;
+}
+
+interface Pending {
+  timer: ReturnType<typeof setTimeout>;
+  latest: HistoryObservation;
+}
+
+export class HistoryDebouncer {
+  private readonly debounceMs: number;
+  private readonly setTimeoutImpl: typeof setTimeout;
+  private readonly clearTimeoutImpl: typeof clearTimeout;
+  private readonly flush: (observation: HistoryObservation) => void;
+  private readonly pending = new Map<string, Pending>();
+
+  constructor(options: HistoryDebouncerOptions) {
+    this.debounceMs = options.debounceMs;
+    this.setTimeoutImpl = options.setTimeoutImpl;
+    this.clearTimeoutImpl = options.clearTimeoutImpl;
+    this.flush = options.flush;
+  }
+
+  observe(observation: HistoryObservation): void {
+    const existing = this.pending.get(observation.entityId);
+    if (existing !== undefined) {
+      existing.latest = observation;
+      return;
+    }
+    const timer = this.setTimeoutImpl(() => {
+      const pending = this.pending.get(observation.entityId);
+      this.pending.delete(observation.entityId);
+      if (pending === undefined) return;
+      this.flush(pending.latest);
+    }, this.debounceMs);
+    this.pending.set(observation.entityId, { timer, latest: observation });
+  }
+
+  cancelAll(): void {
+    for (const pending of this.pending.values()) {
+      this.clearTimeoutImpl(pending.timer);
+    }
+    this.pending.clear();
+  }
+}

--- a/apps/pops-ha-bridge-api/src/manifest.ts
+++ b/apps/pops-ha-bridge-api/src/manifest.ts
@@ -1,0 +1,41 @@
+/**
+ * HA bridge pillar manifest (PRD-229).
+ *
+ * US-01 ships the scaffolding — the pillar registers with the central
+ * registry on boot, declares `pillar: 'ha-bridge'`, and pins its
+ * contract. The new manifest dimensions PRD-229 introduces
+ * (`searchAdapter` / `aiTools` / `sinks`) land in subsequent stories:
+ *
+ *   - US-02 fills `search.adapters` with `ha-entities` over the FTS5
+ *     virtual table.
+ *   - US-03 fills `ai.tools` with the read-only `ha.entity.list` and
+ *     `ha.entity.getState` entries.
+ *   - US-04 adds `ha.entity.callService` to `ai.tools`.
+ *   - US-05 fills `sinks.descriptors` with `ha.notify` + `ha.event.fire`.
+ *
+ * Until those stories land, every dimension is empty — but the manifest
+ * is still validated by `bootstrapPillar`, so the schema gates on this
+ * shape now.
+ */
+import type { ManifestPayload } from '@pops/pillar-sdk/manifest-schema';
+
+export const HA_BRIDGE_PILLAR_ID = 'ha-bridge' as const;
+
+export function buildHaBridgeManifest(version: string): ManifestPayload {
+  return {
+    pillar: HA_BRIDGE_PILLAR_ID,
+    version,
+    contract: {
+      package: '@pops/ha-bridge-contract',
+      version,
+      tag: `contract-ha-bridge@v${version}`,
+    },
+    routes: { queries: [], mutations: [], subscriptions: [] },
+    search: { adapters: [] },
+    ai: { tools: [] },
+    sinks: { descriptors: [] },
+    uri: { types: [] },
+    settings: { keys: [] },
+    healthcheck: { path: '/health' },
+  };
+}

--- a/apps/pops-ha-bridge-api/src/server.ts
+++ b/apps/pops-ha-bridge-api/src/server.ts
@@ -1,0 +1,106 @@
+import { WebSocket as WsWebSocket, type RawData } from 'ws';
+
+/**
+ * Entry point for the HA bridge pillar HTTP server (PRD-229 US-01).
+ *
+ * Boot order:
+ *   1. Resolve env (`HA_URL`, `HA_TOKEN`, `HA_BRIDGE_SQLITE_PATH`, …).
+ *   2. Open the per-pillar SQLite + apply migrations.
+ *   3. Construct the WebSocket subscriber (degrades silently if HA env
+ *      missing per PRD § Secret management).
+ *   4. Start the Express app (`/health`, `/manifest.json`).
+ *   5. Register with the central registry when `POPS_REGISTRY_ENABLED=true`.
+ *   6. Start the subscriber — `start()` is a no-op in degraded mode so
+ *      the pillar still boots cleanly.
+ *
+ * On SIGTERM / SIGINT the server is closed, the subscriber is stopped
+ * (cancels reconnect timers + closes the socket), the registry handle
+ * is stopped (clears heartbeat + deregisters), and the SQLite handle
+ * is closed.
+ */
+import { openHaBridgeDb } from '@pops/ha-bridge-db';
+import { bootstrapPillar, type PillarBootstrapHandle } from '@pops/pillar-sdk/bootstrap';
+
+import { createHaBridgeApiApp } from './app.js';
+import { resolveHaBridgeSqlitePath } from './ha-bridge-sqlite-path.js';
+import { buildHaBridgeManifest } from './manifest.js';
+import { HaWebSocketSubscriber, type HaWebSocketLike } from './ws-subscriber.js';
+
+function resolvePort(): number {
+  // 3001 core, 3002 inventory, 3003 media, 3004 finance, 3005 food,
+  // 3006 lists, 3007 cerebrum, 3008 ha-bridge.
+  const raw = process.env['PORT'];
+  if (raw === undefined || raw === '') return 3008;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed <= 0 || parsed > 65535) {
+    throw new Error(`[ha-bridge] PORT must be a positive integer in 1-65535; got '${raw}'`);
+  }
+  return parsed;
+}
+
+function defaultWebSocketFactory(url: string): HaWebSocketLike {
+  const ws = new WsWebSocket(url);
+  return {
+    send: (data) => {
+      ws.send(data);
+    },
+    close: (code, reason) => {
+      ws.close(code, reason);
+    },
+    on: (event, listener) => {
+      if (event === 'open') {
+        ws.on('open', listener as () => void);
+      } else if (event === 'message') {
+        ws.on('message', listener as (data: RawData) => void);
+      } else if (event === 'close') {
+        ws.on('close', listener as (code: number, reason: Buffer) => void);
+      } else {
+        ws.on('error', listener as (err: Error) => void);
+      }
+    },
+  };
+}
+
+const port = resolvePort();
+const version = process.env['BUILD_VERSION'] ?? '0.1.0';
+const haUrl = process.env['HA_URL'];
+const haToken = process.env['HA_TOKEN'];
+
+const haBridgeDb = openHaBridgeDb(resolveHaBridgeSqlitePath());
+
+const subscriber = new HaWebSocketSubscriber({
+  db: haBridgeDb,
+  url: haUrl,
+  token: haToken,
+  webSocketFactory: defaultWebSocketFactory,
+});
+
+const manifest = buildHaBridgeManifest(version);
+const app = createHaBridgeApiApp({ manifest, version, subscriber });
+
+let pillarHandle: PillarBootstrapHandle | undefined;
+if (process.env['POPS_REGISTRY_ENABLED'] === 'true') {
+  pillarHandle = await bootstrapPillar({ manifest });
+}
+
+subscriber.start();
+
+const server = app.listen(port, () => {
+  console.warn(`[ha-bridge] Listening on port ${port}`);
+});
+
+let shuttingDown = false;
+function shutdown(signal: NodeJS.Signals): void {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  console.warn(`[ha-bridge] Shutting down (${signal})`);
+  subscriber.stop();
+  void (pillarHandle?.stop() ?? Promise.resolve()).finally(() => {
+    server.close(() => {
+      haBridgeDb.raw.close();
+    });
+  });
+}
+
+process.on('SIGTERM', shutdown);
+process.on('SIGINT', shutdown);

--- a/apps/pops-ha-bridge-api/src/server.ts
+++ b/apps/pops-ha-bridge-api/src/server.ts
@@ -68,11 +68,25 @@ const haToken = process.env['HA_TOKEN'];
 
 const haBridgeDb = openHaBridgeDb(resolveHaBridgeSqlitePath());
 
+// Opt-in subscriber logging. Default is silent ("degrades silently" per
+// PRD-229) so unconfigured deployments stay quiet; set HA_BRIDGE_LOG=warn
+// to surface connection / auth events on the container's stdout.
+const subscriberLogger =
+  process.env['HA_BRIDGE_LOG'] === 'warn'
+    ? {
+        info: (msg: string, meta?: Record<string, unknown>) =>
+          console.warn(`[ha-bridge] ${msg}`, meta ?? {}),
+        warn: (msg: string, meta?: Record<string, unknown>) =>
+          console.warn(`[ha-bridge] ${msg}`, meta ?? {}),
+      }
+    : undefined;
+
 const subscriber = new HaWebSocketSubscriber({
   db: haBridgeDb,
   url: haUrl,
   token: haToken,
   webSocketFactory: defaultWebSocketFactory,
+  logger: subscriberLogger,
 });
 
 const manifest = buildHaBridgeManifest(version);

--- a/apps/pops-ha-bridge-api/src/ws-subscriber-types.ts
+++ b/apps/pops-ha-bridge-api/src/ws-subscriber-types.ts
@@ -1,0 +1,45 @@
+/**
+ * Public type surface for the HA WebSocket subscriber. Kept in a sibling
+ * module so `ws-subscriber.ts` stays focused on the state machine and
+ * fits the per-file LOC ceiling. Consumers import from this module
+ * directly OR from `./ws-subscriber.ts` via the re-export.
+ */
+import type { OpenedHaBridgeDb } from '@pops/ha-bridge-db';
+
+export type ConnectionState =
+  | { kind: 'connecting' }
+  | { kind: 'connected'; lastEventAt: number }
+  | { kind: 'reconnecting'; lastEventAt: number; nextAttemptInMs: number }
+  | { kind: 'offline'; reason: 'no-config' | 'auth-failed' | 'disconnected'; lastEventAt: number };
+
+export interface HaWebSocketLike {
+  send(data: string): void;
+  close(code?: number, reason?: string): void;
+  on(event: 'open', listener: () => void): void;
+  on(event: 'message', listener: (data: unknown) => void): void;
+  on(event: 'close', listener: (code: number, reason: Buffer) => void): void;
+  on(event: 'error', listener: (err: Error) => void): void;
+}
+
+export interface HaWebSocketFactory {
+  (url: string): HaWebSocketLike;
+}
+
+export interface SubscriberLogger {
+  info(msg: string, meta?: Record<string, unknown>): void;
+  warn(msg: string, meta?: Record<string, unknown>): void;
+}
+
+export interface HaWebSocketSubscriberOptions {
+  db: OpenedHaBridgeDb;
+  url: string | undefined;
+  token: string | undefined;
+  webSocketFactory: HaWebSocketFactory;
+  debounceMs?: number;
+  initialBackoffMs?: number;
+  maxBackoffMs?: number;
+  setTimeoutImpl?: typeof setTimeout;
+  clearTimeoutImpl?: typeof clearTimeout;
+  now?: () => number;
+  logger?: SubscriberLogger;
+}

--- a/apps/pops-ha-bridge-api/src/ws-subscriber.ts
+++ b/apps/pops-ha-bridge-api/src/ws-subscriber.ts
@@ -1,0 +1,243 @@
+/**
+ * Home Assistant WebSocket subscriber (PRD-229 US-01).
+ *
+ * Subscribes to a Home Assistant instance, completes the auth handshake
+ * with the long-lived access token, fetches the full snapshot of states
+ * via `get_states`, and subscribes to `state_changed` events. Every event
+ * upserts the entity row in `ha_entities`; the per-entity 200ms debounce
+ * window batches bursts so only the latest observation lands in
+ * `ha_state_history`.
+ *
+ * Reconnect uses exponential backoff (1s → 2s → 4s → ... → 60s capped).
+ * On every reconnect the snapshot pass runs again so missed state during
+ * the outage is reconciled rather than silently dropped.
+ *
+ * The subscriber is implemented around an injectable WebSocket factory
+ * so the unit tests can drive the handshake / event stream with a
+ * stub instead of standing up a real HA instance.
+ *
+ * `HA_TOKEN` is never logged, never returned, and never serialised into
+ * the manifest — it is only ever passed to the auth frame.
+ */
+import {
+  appendHistory,
+  upsertEntity,
+  type HaEntityMirrorInput,
+  type OpenedHaBridgeDb,
+} from '@pops/ha-bridge-db';
+
+import {
+  parseFrame,
+  stateObjectToMirrorInput,
+  type HaFrame,
+  type HaStateObject,
+} from './ha-frame.js';
+import { HistoryDebouncer } from './history-debouncer.js';
+
+import type {
+  ConnectionState,
+  HaWebSocketFactory,
+  HaWebSocketLike,
+  HaWebSocketSubscriberOptions,
+  SubscriberLogger,
+} from './ws-subscriber-types.js';
+
+export type {
+  ConnectionState,
+  HaWebSocketFactory,
+  HaWebSocketLike,
+  HaWebSocketSubscriberOptions,
+} from './ws-subscriber-types.js';
+
+const DEFAULT_DEBOUNCE_MS = 200;
+const DEFAULT_INITIAL_BACKOFF_MS = 1_000;
+const DEFAULT_MAX_BACKOFF_MS = 60_000;
+
+export class HaWebSocketSubscriber {
+  private readonly db: OpenedHaBridgeDb;
+  private readonly url: string | undefined;
+  private readonly token: string | undefined;
+  private readonly factory: HaWebSocketFactory;
+  private readonly debounceMs: number;
+  private readonly initialBackoffMs: number;
+  private readonly maxBackoffMs: number;
+  private readonly setTimeoutImpl: typeof setTimeout;
+  private readonly clearTimeoutImpl: typeof clearTimeout;
+  private readonly now: () => number;
+  private readonly logger: SubscriberLogger;
+
+  private socket: HaWebSocketLike | undefined;
+  private connectionState: ConnectionState;
+  private reconnectAttempt = 0;
+  private reconnectTimer: ReturnType<typeof setTimeout> | undefined;
+  private commandId = 1;
+  private readonly debouncer: HistoryDebouncer;
+  private stopped = false;
+  private subscribed = false;
+
+  constructor(options: HaWebSocketSubscriberOptions) {
+    this.db = options.db;
+    this.url = options.url;
+    this.token = options.token;
+    this.factory = options.webSocketFactory;
+    this.debounceMs = options.debounceMs ?? DEFAULT_DEBOUNCE_MS;
+    this.initialBackoffMs = options.initialBackoffMs ?? DEFAULT_INITIAL_BACKOFF_MS;
+    this.maxBackoffMs = options.maxBackoffMs ?? DEFAULT_MAX_BACKOFF_MS;
+    this.setTimeoutImpl = options.setTimeoutImpl ?? setTimeout;
+    this.clearTimeoutImpl = options.clearTimeoutImpl ?? clearTimeout;
+    this.now = options.now ?? (() => Date.now());
+    this.logger = options.logger ?? {
+      info: (msg, meta) => console.warn(`[ha-bridge] ${msg}`, meta ?? {}),
+      warn: (msg, meta) => console.warn(`[ha-bridge] ${msg}`, meta ?? {}),
+    };
+    this.connectionState =
+      this.url === undefined || this.token === undefined
+        ? { kind: 'offline', reason: 'no-config', lastEventAt: 0 }
+        : { kind: 'connecting' };
+    this.debouncer = new HistoryDebouncer({
+      debounceMs: this.debounceMs,
+      setTimeoutImpl: this.setTimeoutImpl,
+      clearTimeoutImpl: this.clearTimeoutImpl,
+      flush: (observation) => {
+        appendHistory(this.db.db, observation);
+      },
+    });
+  }
+
+  state(): ConnectionState {
+    return { ...this.connectionState };
+  }
+
+  start(): void {
+    if (this.url === undefined || this.token === undefined) {
+      this.logger.warn('HA_URL or HA_TOKEN missing — bridge starting in degraded mode');
+      return;
+    }
+    this.openSocket();
+  }
+
+  stop(): void {
+    this.stopped = true;
+    if (this.reconnectTimer !== undefined) {
+      this.clearTimeoutImpl(this.reconnectTimer);
+      this.reconnectTimer = undefined;
+    }
+    this.debouncer.cancelAll();
+    this.socket?.close();
+    this.socket = undefined;
+  }
+
+  private openSocket(): void {
+    if (this.stopped || this.url === undefined || this.token === undefined) return;
+    this.subscribed = false;
+    this.commandId = 1;
+    const socket = this.factory(this.url);
+    this.socket = socket;
+    // HA sends `auth_required` immediately on open; the auth response
+    // is sent by handleMessage when that frame arrives.
+    socket.on('open', () => undefined);
+    socket.on('message', (data) => this.handleMessage(data));
+    socket.on('close', (code, reason) => this.handleClose(code, reason.toString('utf8')));
+    socket.on('error', (err) => this.logger.warn('socket error', { err: err.message }));
+  }
+
+  private handleMessage(raw: unknown): void {
+    const frame = parseFrame(raw);
+    if (frame === undefined) return;
+    if (this.handleAuthFrame(frame)) return;
+    if (this.handleSnapshotFrame(frame)) return;
+    this.handleEventFrame(frame);
+  }
+
+  private handleAuthFrame(frame: HaFrame): boolean {
+    if (frame.type === 'auth_required') {
+      this.socket?.send(JSON.stringify({ type: 'auth', access_token: this.token }));
+      return true;
+    }
+    if (frame.type === 'auth_invalid') {
+      this.markAuthFailed();
+      return true;
+    }
+    if (frame.type === 'auth_ok') {
+      this.connectionState = { kind: 'connected', lastEventAt: this.now() };
+      this.reconnectAttempt = 0;
+      this.sendCommand({ type: 'get_states' });
+      return true;
+    }
+    return false;
+  }
+
+  private handleSnapshotFrame(frame: HaFrame): boolean {
+    if (frame.type !== 'result' || frame.success !== true || !Array.isArray(frame.result)) {
+      return false;
+    }
+    for (const state of frame.result as HaStateObject[]) {
+      const input = stateObjectToMirrorInput(state, this.now());
+      if (input !== undefined) upsertEntity(this.db.db, input);
+    }
+    if (!this.subscribed) {
+      this.subscribed = true;
+      this.sendCommand({ type: 'subscribe_events', event_type: 'state_changed' });
+    }
+    return true;
+  }
+
+  private handleEventFrame(frame: HaFrame): void {
+    if (frame.type !== 'event' || frame.event?.event_type !== 'state_changed') return;
+    const newState = frame.event.data?.new_state;
+    if (newState === undefined || newState === null) return;
+    const now = this.now();
+    const input = stateObjectToMirrorInput(newState, now);
+    if (input === undefined) return;
+    upsertEntity(this.db.db, input);
+    this.connectionState = { kind: 'connected', lastEventAt: now };
+    this.scheduleHistoryDebounced(input);
+  }
+
+  private markAuthFailed(): void {
+    this.logger.warn('HA auth rejected — switching to degraded mode');
+    const lastEventAt =
+      this.connectionState.kind === 'offline' ? this.connectionState.lastEventAt : 0;
+    this.connectionState = { kind: 'offline', reason: 'auth-failed', lastEventAt };
+    this.socket?.close();
+    this.socket = undefined;
+  }
+
+  private handleClose(code: number, reason: string): void {
+    this.socket = undefined;
+    if (this.stopped) return;
+    if (this.connectionState.kind === 'offline' && this.connectionState.reason === 'auth-failed') {
+      return;
+    }
+    const lastEventAt =
+      this.connectionState.kind === 'connected' ? this.connectionState.lastEventAt : 0;
+    const delay = this.nextBackoffMs();
+    this.connectionState = { kind: 'reconnecting', lastEventAt, nextAttemptInMs: delay };
+    this.logger.warn('HA socket closed — scheduling reconnect', { code, reason, delay });
+    this.reconnectTimer = this.setTimeoutImpl(() => {
+      this.reconnectTimer = undefined;
+      this.openSocket();
+    }, delay);
+  }
+
+  private nextBackoffMs(): number {
+    const exp = Math.min(this.maxBackoffMs, this.initialBackoffMs * 2 ** this.reconnectAttempt);
+    this.reconnectAttempt += 1;
+    return exp;
+  }
+
+  private sendCommand(payload: Record<string, unknown>): void {
+    const id = this.commandId;
+    this.commandId += 1;
+    this.socket?.send(JSON.stringify({ id, ...payload }));
+  }
+
+  private scheduleHistoryDebounced(input: HaEntityMirrorInput): void {
+    this.debouncer.observe({
+      entityId: input.entityId,
+      state: input.state,
+      attributes: input.attributes,
+      observedAt: input.lastChanged,
+    });
+  }
+}

--- a/apps/pops-ha-bridge-api/src/ws-subscriber.ts
+++ b/apps/pops-ha-bridge-api/src/ws-subscriber.ts
@@ -86,9 +86,14 @@ export class HaWebSocketSubscriber {
     this.setTimeoutImpl = options.setTimeoutImpl ?? setTimeout;
     this.clearTimeoutImpl = options.clearTimeoutImpl ?? clearTimeout;
     this.now = options.now ?? (() => Date.now());
+    // Default to a no-op logger so degraded mode (missing config / auth
+    // failure / reconnect churn) really is silent unless the caller opts
+    // in by injecting their own logger. The PR/PRD describe this surface
+    // as "degrades silently" — wiring `console.warn` here contradicted
+    // that contract and spammed unconfigured deployments.
     this.logger = options.logger ?? {
-      info: (msg, meta) => console.warn(`[ha-bridge] ${msg}`, meta ?? {}),
-      warn: (msg, meta) => console.warn(`[ha-bridge] ${msg}`, meta ?? {}),
+      info: () => undefined,
+      warn: () => undefined,
     };
     this.connectionState =
       this.url === undefined || this.token === undefined

--- a/apps/pops-ha-bridge-api/tsconfig.json
+++ b/apps/pops-ha-bridge-api/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "sourceMap": true,
+    "types": ["node"]
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/__tests__/**"]
+}

--- a/apps/pops-ha-bridge-api/vitest.config.ts
+++ b/apps/pops-ha-bridge-api/vitest.config.ts
@@ -1,0 +1,15 @@
+/// <reference types="vitest/config" />
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json-summary', 'html'],
+      reportsDirectory: 'coverage',
+      include: ['src/**/*.ts'],
+      exclude: ['**/node_modules/**', '**/dist/**', '**/*.test.ts'],
+    },
+  },
+});

--- a/packages/ha-bridge-db/migrations/0000_ha_bridge_baseline.sql
+++ b/packages/ha-bridge-db/migrations/0000_ha_bridge_baseline.sql
@@ -1,0 +1,25 @@
+CREATE TABLE `ha_entities` (
+	`entity_id` text PRIMARY KEY NOT NULL,
+	`domain` text NOT NULL,
+	`friendly_name` text,
+	`area` text,
+	`device_class` text,
+	`unit` text,
+	`state` text NOT NULL,
+	`attributes` text NOT NULL,
+	`last_changed` integer NOT NULL,
+	`last_seen` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `idx_ha_entities_domain` ON `ha_entities` (`domain`);--> statement-breakpoint
+CREATE INDEX `idx_ha_entities_area` ON `ha_entities` (`area`);--> statement-breakpoint
+CREATE INDEX `idx_ha_entities_device_class` ON `ha_entities` (`device_class`);--> statement-breakpoint
+CREATE TABLE `ha_state_history` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`entity_id` text NOT NULL,
+	`state` text NOT NULL,
+	`attributes` text NOT NULL,
+	`observed_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `idx_ha_state_history_entity_observed` ON `ha_state_history` (`entity_id`,`observed_at`);

--- a/packages/ha-bridge-db/migrations/meta/_journal.json
+++ b/packages/ha-bridge-db/migrations/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "6",
+      "when": 1781999000000,
+      "tag": "0000_ha_bridge_baseline",
+      "breakpoints": true
+    }
+  ]
+}

--- a/packages/ha-bridge-db/package.json
+++ b/packages/ha-bridge-db/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@pops/ha-bridge-db",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "better-sqlite3": "^12.10.0",
+    "drizzle-orm": "^0.45.2"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.12",
+    "@vitest/coverage-v8": "^4.1.8",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.8"
+  }
+}

--- a/packages/ha-bridge-db/src/__tests__/entities.test.ts
+++ b/packages/ha-bridge-db/src/__tests__/entities.test.ts
@@ -1,0 +1,143 @@
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  appendHistory,
+  getEntity,
+  openHaBridgeDb,
+  pruneHistory,
+  upsertEntity,
+  type OpenedHaBridgeDb,
+} from '../index.js';
+import { haStateHistory } from '../schema.js';
+
+describe('ha-bridge-db entities service', () => {
+  let opened: OpenedHaBridgeDb;
+
+  beforeEach(() => {
+    const dir = mkdtempSync(join(tmpdir(), 'ha-bridge-db-'));
+    opened = openHaBridgeDb(join(dir, 'ha-bridge.db'));
+  });
+
+  afterEach(() => {
+    opened.raw.close();
+  });
+
+  it('runs the baseline migration and creates ha_entities + ha_state_history', () => {
+    const tables = opened.raw
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+      .all() as { name: string }[];
+    const names = tables.map((t) => t.name);
+    expect(names).toContain('ha_entities');
+    expect(names).toContain('ha_state_history');
+  });
+
+  it('upserts an entity, derives the domain, and lifts standard attributes', () => {
+    const row = upsertEntity(opened.db, {
+      entityId: 'light.kitchen_ceiling',
+      state: 'on',
+      attributes: {
+        friendly_name: 'Kitchen Ceiling',
+        device_class: 'light',
+        unit_of_measurement: '%',
+      },
+      area: 'kitchen',
+      lastChanged: 1_700_000_000_000,
+      lastSeen: 1_700_000_000_500,
+    });
+    expect(row.domain).toBe('light');
+    expect(row.friendlyName).toBe('Kitchen Ceiling');
+    expect(row.deviceClass).toBe('light');
+    expect(row.unit).toBe('%');
+    expect(row.area).toBe('kitchen');
+    expect(row.state).toBe('on');
+
+    const fromMirror = getEntity(opened.db, 'light.kitchen_ceiling');
+    expect(fromMirror?.state).toBe('on');
+  });
+
+  it('replaces state + attributes on a second upsert of the same entity', () => {
+    upsertEntity(opened.db, {
+      entityId: 'sensor.kitchen_temperature',
+      state: '21.0',
+      attributes: {
+        friendly_name: 'Kitchen Temp',
+        device_class: 'temperature',
+        unit_of_measurement: '°C',
+      },
+      area: 'kitchen',
+      lastChanged: 1,
+      lastSeen: 1,
+    });
+    upsertEntity(opened.db, {
+      entityId: 'sensor.kitchen_temperature',
+      state: '22.4',
+      attributes: {
+        friendly_name: 'Kitchen Temp',
+        device_class: 'temperature',
+        unit_of_measurement: '°C',
+      },
+      area: 'kitchen',
+      lastChanged: 2,
+      lastSeen: 2,
+    });
+
+    const row = getEntity(opened.db, 'sensor.kitchen_temperature');
+    expect(row?.state).toBe('22.4');
+    expect(row?.lastChanged).toBe(2);
+
+    const count = opened.raw
+      .prepare('SELECT count(*) as c FROM ha_entities WHERE entity_id = ?')
+      .get('sensor.kitchen_temperature') as { c: number };
+    expect(count.c).toBe(1);
+  });
+
+  it('appends history rows and prunes by cutoff', () => {
+    appendHistory(opened.db, {
+      entityId: 'sensor.x',
+      state: 'a',
+      attributes: {},
+      observedAt: 100,
+    });
+    appendHistory(opened.db, {
+      entityId: 'sensor.x',
+      state: 'b',
+      attributes: {},
+      observedAt: 200,
+    });
+    appendHistory(opened.db, {
+      entityId: 'sensor.x',
+      state: 'c',
+      attributes: {},
+      observedAt: 300,
+    });
+
+    const before = opened.db.select().from(haStateHistory).all();
+    expect(before).toHaveLength(3);
+
+    const removed = pruneHistory(opened.db, 250);
+    expect(removed).toBe(2);
+
+    const after = opened.db.select().from(haStateHistory).all();
+    expect(after).toHaveLength(1);
+    expect(after[0]?.state).toBe('c');
+  });
+
+  it('opens an existing db idempotently (no double-migrate)', () => {
+    const path = opened.raw.name;
+    opened.raw.close();
+    const reopened = openHaBridgeDb(path);
+    try {
+      const tables = reopened.raw
+        .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+        .all() as { name: string }[];
+      expect(tables.map((t) => t.name)).toContain('ha_entities');
+    } finally {
+      reopened.raw.close();
+      opened = reopened;
+    }
+  });
+});

--- a/packages/ha-bridge-db/src/index.ts
+++ b/packages/ha-bridge-db/src/index.ts
@@ -1,0 +1,31 @@
+/**
+ * Backend-safe barrel for the HA bridge pillar's persistence layer.
+ *
+ * The HA bridge is the first "bridge pillar" per ADR-032 / PRD-229 — its
+ * source of truth is upstream (Home Assistant), not user-entered data.
+ * The schema is defined locally rather than in `@pops/db-types` because
+ * no other pillar reads these tables directly; consumers reach the data
+ * through the bridge's tRPC surface, its `searchAdapter`, and its AI
+ * tools (US-02 / US-03 / US-04).
+ */
+export {
+  haEntities,
+  haStateHistory,
+  type HaEntityInsert,
+  type HaEntityRow,
+  type HaStateHistoryInsert,
+  type HaStateHistoryRow,
+} from './schema.js';
+
+export type { HaBridgeDb } from './services/internal.js';
+
+export { openHaBridgeDb, type OpenedHaBridgeDb } from './open-ha-bridge-db.js';
+
+export * as entitiesService from './services/entities.js';
+export {
+  appendHistory,
+  getEntity,
+  pruneHistory,
+  upsertEntity,
+  type HaEntityMirrorInput,
+} from './services/entities.js';

--- a/packages/ha-bridge-db/src/open-ha-bridge-db.ts
+++ b/packages/ha-bridge-db/src/open-ha-bridge-db.ts
@@ -1,0 +1,50 @@
+/**
+ * Standalone opener for the HA bridge pillar's SQLite database.
+ *
+ * Mirrors the per-pillar opener pattern used by `@pops/finance-db`,
+ * `@pops/lists-db`, `@pops/media-db`, etc. — open the file, set the
+ * standard pragmas, apply the in-package drizzle migrations journal,
+ * and return both the typed handle and the raw better-sqlite3 connection
+ * so the caller can close it cleanly on shutdown.
+ */
+import { mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+
+import type { HaBridgeDb } from './services/internal.js';
+
+function migrationsDir(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  return join(here, '..', 'migrations');
+}
+
+export interface OpenedHaBridgeDb {
+  db: HaBridgeDb;
+  raw: Database.Database;
+}
+
+/**
+ * Open the HA bridge SQLite at `path`, configure WAL + busy-timeout +
+ * foreign-keys, run the migrations journal, and return both handles.
+ *
+ * The caller owns lifecycle — on shutdown, call `raw.close()`.
+ */
+export function openHaBridgeDb(path: string): OpenedHaBridgeDb {
+  mkdirSync(dirname(path), { recursive: true });
+  const raw = new Database(path);
+  raw.pragma('journal_mode = WAL');
+  raw.pragma('foreign_keys = ON');
+  raw.pragma('busy_timeout = 5000');
+  const db = drizzle(raw) as HaBridgeDb;
+  try {
+    migrate(db, { migrationsFolder: migrationsDir() });
+  } catch (err) {
+    raw.close();
+    throw err;
+  }
+  return { db, raw };
+}

--- a/packages/ha-bridge-db/src/schema.ts
+++ b/packages/ha-bridge-db/src/schema.ts
@@ -1,0 +1,63 @@
+/**
+ * Schema for the HA bridge pillar's per-pillar SQLite store
+ * (PRD-229 § Data Model).
+ *
+ * Defined inline in this package (not in `@pops/db-types`) because the HA
+ * bridge is the first "bridge pillar" — its source of truth is upstream
+ * (Home Assistant), not user data. Nothing in the rest of the platform
+ * references these tables directly; consumers reach the data through the
+ * bridge's tRPC surface, its `searchAdapter`, or its AI tools. Keeping
+ * the schema local avoids polluting the cross-pillar barrel with rows
+ * that exist only inside this container's SQLite file.
+ */
+import { index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+
+/**
+ * Current snapshot of every HA entity the bridge knows about. One row per
+ * entity, upserted on every state-changed event. The `attributes` blob is
+ * the raw JSON from HA's `attributes` payload — never trimmed, so that
+ * downstream search / AI tools have the full surface to draw from.
+ */
+export const haEntities = sqliteTable(
+  'ha_entities',
+  {
+    entityId: text('entity_id').primaryKey(),
+    domain: text('domain').notNull(),
+    friendlyName: text('friendly_name'),
+    area: text('area'),
+    deviceClass: text('device_class'),
+    unit: text('unit'),
+    state: text('state').notNull(),
+    attributes: text('attributes').notNull(),
+    lastChanged: integer('last_changed').notNull(),
+    lastSeen: integer('last_seen').notNull(),
+  },
+  (t) => [
+    index('idx_ha_entities_domain').on(t.domain),
+    index('idx_ha_entities_area').on(t.area),
+    index('idx_ha_entities_device_class').on(t.deviceClass),
+  ]
+);
+
+/**
+ * Append-only log of state-changed events the bridge observes after
+ * debouncing. Used by trend / time-series queries from cerebrum (US-03
+ * and beyond). Pruned by a periodic worker per `HA_HISTORY_RETENTION_DAYS`
+ * — the table is allowed to grow unboundedly inside the retention window.
+ */
+export const haStateHistory = sqliteTable(
+  'ha_state_history',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    entityId: text('entity_id').notNull(),
+    state: text('state').notNull(),
+    attributes: text('attributes').notNull(),
+    observedAt: integer('observed_at').notNull(),
+  },
+  (t) => [index('idx_ha_state_history_entity_observed').on(t.entityId, t.observedAt)]
+);
+
+export type HaEntityRow = typeof haEntities.$inferSelect;
+export type HaEntityInsert = typeof haEntities.$inferInsert;
+export type HaStateHistoryRow = typeof haStateHistory.$inferSelect;
+export type HaStateHistoryInsert = typeof haStateHistory.$inferInsert;

--- a/packages/ha-bridge-db/src/services/entities.ts
+++ b/packages/ha-bridge-db/src/services/entities.ts
@@ -1,0 +1,143 @@
+/**
+ * Service helpers for the HA bridge's entity mirror.
+ *
+ * The mirror is intentionally tiny — the WebSocket subscriber owns all
+ * write logic and there are no read endpoints in US-01 (those land in
+ * US-02 / US-03). What lives here is the upsert path used by both the
+ * snapshot reconciliation (`get_states` after connect) and the per-event
+ * state-change handler, plus the history append used after debouncing.
+ *
+ * Keeping the writes here (instead of inline in the subscriber) lets the
+ * unit tests cover them against an in-memory SQLite without standing up
+ * a WebSocket. It also makes the snapshot vs. event paths share the same
+ * code, which is the bug-class the PRD's "reconcile after reconnect"
+ * rule cares about.
+ */
+import { eq, lt } from 'drizzle-orm';
+
+import { haEntities, haStateHistory, type HaEntityRow } from '../schema.js';
+
+import type { HaBridgeDb } from './internal.js';
+
+/**
+ * Minimal snapshot shape the WebSocket layer passes in. Mirrors the
+ * fields the PRD's `ha_entities` table carries; the raw `attributes`
+ * blob is the full HA payload serialised to JSON.
+ */
+export interface HaEntityMirrorInput {
+  entityId: string;
+  state: string;
+  attributes: Record<string, unknown>;
+  lastChanged: number;
+  lastSeen: number;
+  area?: string | null;
+}
+
+function domainFromEntityId(entityId: string): string {
+  const idx = entityId.indexOf('.');
+  if (idx <= 0) return entityId;
+  return entityId.slice(0, idx);
+}
+
+function asOptionalString(value: unknown): string | null {
+  if (typeof value === 'string' && value.length > 0) return value;
+  return null;
+}
+
+/**
+ * Upsert a single HA entity into the mirror. Used by both the snapshot
+ * pass (full reconciliation on (re)connect) and the per-event handler.
+ * Returns the resulting row so tests and the subscriber can assert on
+ * the persisted shape.
+ */
+export function upsertEntity(db: HaBridgeDb, input: HaEntityMirrorInput): HaEntityRow {
+  const domain = domainFromEntityId(input.entityId);
+  const friendlyName = asOptionalString(input.attributes['friendly_name']);
+  const deviceClass = asOptionalString(input.attributes['device_class']);
+  const unit = asOptionalString(input.attributes['unit_of_measurement']);
+  const area = input.area ?? null;
+  const attributesJson = JSON.stringify(input.attributes);
+
+  const rows = db
+    .insert(haEntities)
+    .values({
+      entityId: input.entityId,
+      domain,
+      friendlyName,
+      area,
+      deviceClass,
+      unit,
+      state: input.state,
+      attributes: attributesJson,
+      lastChanged: input.lastChanged,
+      lastSeen: input.lastSeen,
+    })
+    .onConflictDoUpdate({
+      target: haEntities.entityId,
+      set: {
+        domain,
+        friendlyName,
+        area,
+        deviceClass,
+        unit,
+        state: input.state,
+        attributes: attributesJson,
+        lastChanged: input.lastChanged,
+        lastSeen: input.lastSeen,
+      },
+    })
+    .returning()
+    .all();
+
+  const row = rows[0];
+  if (row === undefined) {
+    throw new Error(`upsertEntity: no row returned for ${input.entityId}`);
+  }
+  return row;
+}
+
+/**
+ * Append a single observation to `ha_state_history`. Called by the
+ * subscriber after the per-entity 200ms debounce window has elapsed and
+ * the latest state has been settled. Snapshot reconciliation does NOT
+ * call this — the snapshot is a point-in-time refresh, not a stream of
+ * observations.
+ */
+export function appendHistory(
+  db: HaBridgeDb,
+  input: {
+    entityId: string;
+    state: string;
+    attributes: Record<string, unknown>;
+    observedAt: number;
+  }
+): void {
+  db.insert(haStateHistory)
+    .values({
+      entityId: input.entityId,
+      state: input.state,
+      attributes: JSON.stringify(input.attributes),
+      observedAt: input.observedAt,
+    })
+    .run();
+}
+
+/**
+ * Prune history rows older than `cutoffMs` (unix epoch ms). Used by the
+ * retention worker. Returns the number of deleted rows so the caller can
+ * log a single "pruned N rows" summary instead of one-per-entity noise.
+ */
+export function pruneHistory(db: HaBridgeDb, cutoffMs: number): number {
+  const result = db.delete(haStateHistory).where(lt(haStateHistory.observedAt, cutoffMs)).run();
+  return result.changes;
+}
+
+/**
+ * Get a single entity by id — used by US-02 / US-03 once they land. Kept
+ * here in US-01 so the subscriber's tests can assert "the row I just
+ * upserted is readable" without depending on the future read surface.
+ */
+export function getEntity(db: HaBridgeDb, entityId: string): HaEntityRow | undefined {
+  const rows = db.select().from(haEntities).where(eq(haEntities.entityId, entityId)).all();
+  return rows[0];
+}

--- a/packages/ha-bridge-db/src/services/internal.ts
+++ b/packages/ha-bridge-db/src/services/internal.ts
@@ -1,0 +1,11 @@
+/**
+ * Shared types for the HA bridge persistence layer.
+ *
+ * Mirrors the `@pops/lists-db` / `@pops/finance-db` convention so that
+ * subsequent slices can drop typed service modules under `src/services/*`
+ * without re-importing drizzle internals every time.
+ */
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+
+/** A drizzle handle — either the top-level db or a transaction. */
+export type HaBridgeDb = BetterSQLite3Database<Record<string, unknown>>;

--- a/packages/ha-bridge-db/tsconfig.json
+++ b/packages/ha-bridge-db/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "lib": ["ES2023"],
+    "types": [],
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/__tests__/**", "**/*.test.ts"]
+}

--- a/packages/ha-bridge-db/vitest.config.ts
+++ b/packages/ha-bridge-db/vitest.config.ts
@@ -1,0 +1,15 @@
+/// <reference types="vitest/config" />
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json-summary', 'html'],
+      reportsDirectory: 'coverage',
+      include: ['src/**/*.ts'],
+      exclude: ['**/node_modules/**', '**/dist/**', '**/*.test.ts'],
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -481,6 +481,49 @@ importers:
         specifier: ^4.1.8
         version: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.3)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
 
+  apps/pops-ha-bridge-api:
+    dependencies:
+      '@pops/ha-bridge-db':
+        specifier: workspace:*
+        version: link:../../packages/ha-bridge-db
+      '@pops/pillar-sdk':
+        specifier: workspace:*
+        version: link:../../packages/pillar-sdk
+      express:
+        specifier: ^5.1.0
+        version: 5.2.1
+      ws:
+        specifier: ^8.18.0
+        version: 8.21.0
+    devDependencies:
+      '@types/express':
+        specifier: ^5.0.4
+        version: 5.0.6
+      '@types/node':
+        specifier: ^25.9.3
+        version: 25.9.3
+      '@types/supertest':
+        specifier: ^6.0.3
+        version: 6.0.3
+      '@types/ws':
+        specifier: ^8.5.13
+        version: 8.18.1
+      '@vitest/coverage-v8':
+        specifier: ^4.1.8
+        version: 4.1.8(vitest@4.1.8)
+      supertest:
+        specifier: ^7.1.4
+        version: 7.2.2
+      tsx:
+        specifier: ^4.22.4
+        version: 4.22.4
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.3)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
+
   apps/pops-inventory-api:
     dependencies:
       '@pops/core-db':
@@ -1903,6 +1946,28 @@ importers:
       '@pops/db-types':
         specifier: workspace:*
         version: link:../db-types
+      better-sqlite3:
+        specifier: ^12.10.0
+        version: 12.10.0
+      drizzle-orm:
+        specifier: ^0.45.2
+        version: 0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.10.0)
+    devDependencies:
+      '@types/better-sqlite3':
+        specifier: ^7.6.12
+        version: 7.6.13
+      '@vitest/coverage-v8':
+        specifier: ^4.1.8
+        version: 4.1.8(vitest@4.1.8)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.3)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
+
+  packages/ha-bridge-db:
+    dependencies:
       better-sqlite3:
         specifier: ^12.10.0
         version: 12.10.0
@@ -5583,6 +5648,9 @@ packages:
 
   '@types/validate-npm-package-name@4.0.2':
     resolution: {integrity: sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
@@ -11493,6 +11561,10 @@ snapshots:
   '@types/use-sync-external-store@0.0.6': {}
 
   '@types/validate-npm-package-name@4.0.2': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 25.9.3
 
   '@ungap/structured-clone@1.3.0': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -27,6 +27,7 @@ packages:
   - 'packages/lists-contract'
   - 'packages/food-contract'
   - 'packages/lists-db'
+  - 'packages/ha-bridge-db'
   - 'packages/types'
   - 'packages/module-registry'
   - 'packages/navigation'


### PR DESCRIPTION
## Summary

Scaffolds the Home Assistant bridge pillar per PRD-229 / ADR-032 — the first "bridge pillar" whose source of truth is upstream (HA) rather than user-entered data. Ships **US-01 only**: WebSocket subscriber + entity mirror + manifest bootstrap. The new manifest dimensions PRD-229 introduces (`searchAdapter` / `aiTools` / `sinks`) are declared empty here; US-02 / US-03 / US-04 / US-05 fill them in.

- New per-pillar DB package `@pops/ha-bridge-db` (schema inline — not in `@pops/db-types` — because no other pillar reads these tables directly).
- New container `apps/pops-ha-bridge-api` exposing `/health` + `/manifest.json`, registers with `core.registry` when `POPS_REGISTRY_ENABLED=true`.
- `HaWebSocketSubscriber` handles auth handshake, `get_states` snapshot, `state_changed` subscription, per-entity 200ms history debouncing, and exponential reconnect backoff (1s → 60s cap).
- Degrades silently when `HA_URL` / `HA_TOKEN` are missing or auth fails. `HA_TOKEN` never reaches logs, tRPC responses, or the manifest.

## Out of scope (follow-up stories)

| Story | Deliverable |
| --- | --- |
| US-02 | `searchAdapter` over `ha_entities` (FTS5 + area / device-class ranking) |
| US-03 | `ha.entity.list` + `ha.entity.getState` AI tools |
| US-04 | `ha.entity.callService` outbound control |
| US-05 | `sinks` manifest dimension (`ha.notify`, `ha.event.fire`) |

## Test plan

- [x] `pnpm --filter @pops/ha-bridge-db test` — 5 passing (migrations, upsert, history append + prune, idempotent open)
- [x] `pnpm --filter @pops/ha-bridge-api test` — 6 passing (degraded boot, auth + snapshot + subscribe handshake, per-entity debouncing, reconnect backoff progression, manifest schema validation)
- [x] `pnpm typecheck` — green
- [x] `pnpm lint` — green
- [ ] Deploy + verify container boots + `/manifest.json` returns the expected pillar shape
- [ ] Deploy with real HA env + observe entity mirror populates from `state_changed`
