### PR TITLE
feat(app-cerebrum): migrate tRPC sites to pillar SDK + drop api-client dep (PRD-227)

### DIFF
--- a/packages/app-cerebrum/package.json
+++ b/packages/app-cerebrum/package.json
@@ -11,9 +11,9 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@pops/api-client": "workspace:*",
     "@pops/navigation": "workspace:*",
     "@pops/overlay-ego": "workspace:*",
+    "@pops/pillar-sdk": "workspace:*",
     "@pops/types": "workspace:*",
     "@pops/ui": "workspace:*",
     "@tanstack/react-query": "5.101.0",

--- a/packages/app-cerebrum/src/components/ContradictionsPanel.test.tsx
+++ b/packages/app-cerebrum/src/components/ContradictionsPanel.test.tsx
@@ -31,16 +31,8 @@ let queryResult: { data: ContradictionsResult | undefined; isLoading: boolean; i
     isError: false,
   };
 
-vi.mock('@pops/api-client', () => ({
-  trpc: {
-    cerebrum: {
-      nudges: {
-        contradictions: {
-          useQuery: () => queryResult,
-        },
-      },
-    },
-  },
+vi.mock('@pops/pillar-sdk/react', () => ({
+  usePillarQuery: () => queryResult,
 }));
 
 import { ContradictionsPanel } from './ContradictionsPanel';

--- a/packages/app-cerebrum/src/components/ContradictionsPanel.tsx
+++ b/packages/app-cerebrum/src/components/ContradictionsPanel.tsx
@@ -9,7 +9,7 @@
  */
 import { Link } from 'react-router';
 
-import { trpc } from '@pops/api-client';
+import { usePillarQuery } from '@pops/pillar-sdk/react';
 
 interface ContradictionRow {
   id: string;
@@ -63,10 +63,17 @@ function ContradictionCard({ row }: { row: ContradictionRow }) {
   );
 }
 
+interface ContradictionsResult {
+  contradictions: ContradictionRow[];
+  total: number;
+}
+
 export function ContradictionsPanel() {
-  const { data, isLoading, isError } = trpc.cerebrum.nudges.contradictions.useQuery({
-    limit: 50,
-  });
+  const { data, isLoading, isError } = usePillarQuery<ContradictionsResult>(
+    'cerebrum',
+    ['nudges', 'contradictions'],
+    { limit: 50 }
+  );
 
   if (isLoading) {
     return (
@@ -86,7 +93,7 @@ export function ContradictionsPanel() {
     );
   }
 
-  const rows = (data?.contradictions ?? []) as ContradictionRow[];
+  const rows = data?.contradictions ?? [];
   const total = data?.total ?? rows.length;
 
   return (

--- a/packages/app-cerebrum/src/components/EnrichmentChips.tsx
+++ b/packages/app-cerebrum/src/components/EnrichmentChips.tsx
@@ -5,11 +5,14 @@
  * then renders the inferred type / template / scopes / tags as editable chips
  * alongside any scope reconciliation suggestions ("Did you mean: …").
  */
-import { Loader2, RefreshCw } from 'lucide-react';
 import { useState } from 'react';
 
-import { trpc } from '@pops/api-client';
-import { Badge, Button, Chip } from '@pops/ui';
+import {
+  usePillarMutation,
+  usePillarQuery,
+  usePillarUtils,
+  type UsePillarMutationResult,
+} from '@pops/pillar-sdk/react';
 
 import {
   appendUnique,
@@ -18,6 +21,7 @@ import {
   replaceScope,
   segmentSetKey,
 } from './enrichment-chips-helpers';
+import { ChipGrid, EnrichmentHeader } from './EnrichmentChipsParts';
 import { ScopeSuggestionList } from './ScopeSuggestionList';
 
 interface EnrichmentChipsProps {
@@ -39,10 +43,34 @@ interface EnrichmentStatus {
   customFields?: Record<string, unknown>;
 }
 
+type EnrichmentUpdateInput = {
+  id: string;
+  scopes?: string[];
+  customFields?: Record<string, unknown>;
+};
+
+function useEnrichmentMutations() {
+  const utils = usePillarUtils('cerebrum');
+  const invalidate = () => void utils.invalidate(['ingest', 'enrichmentStatus']);
+  const updateMutation = usePillarMutation<EnrichmentUpdateInput, unknown>(
+    'cerebrum',
+    ['engrams', 'update'],
+    { onSuccess: invalidate }
+  );
+  const retryMutation = usePillarMutation<{ engramId: string }, unknown>(
+    'cerebrum',
+    ['ingest', 'retryEnrichment'],
+    { onSuccess: invalidate }
+  );
+  return { updateMutation, retryMutation };
+}
+
 export function EnrichmentChips({ engramId }: EnrichmentChipsProps) {
   const [startedAt] = useState(() => Date.now());
 
-  const statusQuery = trpc.cerebrum.ingest.enrichmentStatus.useQuery(
+  const statusQuery = usePillarQuery<EnrichmentStatus>(
+    'cerebrum',
+    ['ingest', 'enrichmentStatus'],
     { engramId },
     {
       refetchInterval: (query) => {
@@ -53,17 +81,7 @@ export function EnrichmentChips({ engramId }: EnrichmentChipsProps) {
     }
   );
 
-  const utils = trpc.useUtils();
-  const updateMutation = trpc.cerebrum.engrams.update.useMutation({
-    onSuccess: () => {
-      void utils.cerebrum.ingest.enrichmentStatus.invalidate({ engramId });
-    },
-  });
-  const retryMutation = trpc.cerebrum.ingest.retryEnrichment.useMutation({
-    onSuccess: () => {
-      void utils.cerebrum.ingest.enrichmentStatus.invalidate({ engramId });
-    },
-  });
+  const { updateMutation, retryMutation } = useEnrichmentMutations();
 
   const status = statusQuery.data;
   const stoppedPolling = hasStoppedPolling(Date.now() - startedAt, status?.enriched ?? false);
@@ -94,7 +112,7 @@ export function EnrichmentChips({ engramId }: EnrichmentChipsProps) {
 function useChipHandlers(
   engramId: string,
   status: EnrichmentStatus | undefined,
-  updateMutation: ReturnType<typeof trpc.cerebrum.engrams.update.useMutation>
+  updateMutation: UsePillarMutationResult<EnrichmentUpdateInput, unknown>
 ) {
   const acceptSuggestion = (original: string, canonical: string) => {
     if (!status) return;
@@ -130,89 +148,6 @@ function useChipHandlers(
   };
 
   return { acceptSuggestion, dismissSuggestion, removeScope };
-}
-
-function EnrichmentHeader({
-  enriched,
-  stoppedPolling,
-  onRetry,
-  retryPending,
-}: {
-  enriched: boolean;
-  stoppedPolling: boolean;
-  onRetry: () => void;
-  retryPending: boolean;
-}) {
-  if (enriched) {
-    return <h4 className="text-sm font-semibold text-muted-foreground">Enriched</h4>;
-  }
-  if (stoppedPolling) {
-    return (
-      <div className="flex items-center justify-between">
-        <p className="text-sm text-muted-foreground">Enrichment didn't complete in time.</p>
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={onRetry}
-          disabled={retryPending}
-          prefix={<RefreshCw className="h-3.5 w-3.5" />}
-        >
-          Retry enrichment
-        </Button>
-      </div>
-    );
-  }
-  return (
-    <div className="flex items-center gap-2 text-sm text-muted-foreground">
-      <Loader2 className="h-3.5 w-3.5 animate-spin" />
-      Enriching…
-    </div>
-  );
-}
-
-function ChipGrid({
-  status,
-  onRemoveScope,
-}: {
-  status: { type: string; template: string | null; scopes: string[]; tags: string[] };
-  onRemoveScope: (scope: string) => void;
-}) {
-  return (
-    <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-sm">
-      <dt className="text-muted-foreground self-center">Type</dt>
-      <dd>
-        <Badge variant="secondary">{status.type}</Badge>
-      </dd>
-      {status.template && (
-        <>
-          <dt className="text-muted-foreground self-center">Template</dt>
-          <dd>
-            <Badge variant="outline">{status.template}</Badge>
-          </dd>
-        </>
-      )}
-      <dt className="text-muted-foreground self-center">Scopes</dt>
-      <dd className="flex flex-wrap gap-1.5">
-        {status.scopes.map((scope) => (
-          <Chip key={scope} size="sm" removable onRemove={() => onRemoveScope(scope)}>
-            {scope}
-          </Chip>
-        ))}
-      </dd>
-      {status.tags.length > 0 && (
-        <>
-          <dt className="text-muted-foreground self-center">Tags</dt>
-          <dd className="flex flex-wrap gap-1.5">
-            {status.tags.map((tag) => (
-              <Chip key={tag} size="sm">
-                {tag}
-              </Chip>
-            ))}
-          </dd>
-        </>
-      )}
-    </dl>
-  );
 }
 
 function readDismissed(customFields: Record<string, unknown> | undefined): string[] {

--- a/packages/app-cerebrum/src/components/EnrichmentChipsParts.tsx
+++ b/packages/app-cerebrum/src/components/EnrichmentChipsParts.tsx
@@ -1,0 +1,87 @@
+import { Loader2, RefreshCw } from 'lucide-react';
+
+import { Badge, Button, Chip } from '@pops/ui';
+
+interface EnrichmentHeaderProps {
+  enriched: boolean;
+  stoppedPolling: boolean;
+  onRetry: () => void;
+  retryPending: boolean;
+}
+
+export function EnrichmentHeader({
+  enriched,
+  stoppedPolling,
+  onRetry,
+  retryPending,
+}: EnrichmentHeaderProps) {
+  if (enriched) {
+    return <h4 className="text-sm font-semibold text-muted-foreground">Enriched</h4>;
+  }
+  if (stoppedPolling) {
+    return (
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-muted-foreground">Enrichment didn't complete in time.</p>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onRetry}
+          disabled={retryPending}
+          prefix={<RefreshCw className="h-3.5 w-3.5" />}
+        >
+          Retry enrichment
+        </Button>
+      </div>
+    );
+  }
+  return (
+    <div className="flex items-center gap-2 text-sm text-muted-foreground">
+      <Loader2 className="h-3.5 w-3.5 animate-spin" />
+      Enriching…
+    </div>
+  );
+}
+
+interface ChipGridProps {
+  status: { type: string; template: string | null; scopes: string[]; tags: string[] };
+  onRemoveScope: (scope: string) => void;
+}
+
+export function ChipGrid({ status, onRemoveScope }: ChipGridProps) {
+  return (
+    <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-sm">
+      <dt className="text-muted-foreground self-center">Type</dt>
+      <dd>
+        <Badge variant="secondary">{status.type}</Badge>
+      </dd>
+      {status.template && (
+        <>
+          <dt className="text-muted-foreground self-center">Template</dt>
+          <dd>
+            <Badge variant="outline">{status.template}</Badge>
+          </dd>
+        </>
+      )}
+      <dt className="text-muted-foreground self-center">Scopes</dt>
+      <dd className="flex flex-wrap gap-1.5">
+        {status.scopes.map((scope) => (
+          <Chip key={scope} size="sm" removable onRemove={() => onRemoveScope(scope)}>
+            {scope}
+          </Chip>
+        ))}
+      </dd>
+      {status.tags.length > 0 && (
+        <>
+          <dt className="text-muted-foreground self-center">Tags</dt>
+          <dd className="flex flex-wrap gap-1.5">
+            {status.tags.map((tag) => (
+              <Chip key={tag} size="sm">
+                {tag}
+              </Chip>
+            ))}
+          </dd>
+        </>
+      )}
+    </dl>
+  );
+}

--- a/packages/app-cerebrum/src/documents/useDocumentsModel.ts
+++ b/packages/app-cerebrum/src/documents/useDocumentsModel.ts
@@ -8,8 +8,9 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 
-import { trpc } from '@pops/api-client';
+import { usePillarMutation } from '@pops/pillar-sdk/react';
 
+import { usePillarCall } from '../lib/pillar-call';
 import { extractMessage } from '../utils/errors';
 import { errorMessageKey, validateForm, type ValidatedRequest } from './form-mapping';
 import {
@@ -32,34 +33,62 @@ export interface DocumentsModel {
   onRegenerate: () => void;
 }
 
-export function useDocumentsModel(): DocumentsModel {
-  const { t } = useTranslation('cerebrum');
-  const utils = trpc.useUtils();
-  const [form, setForm] = useState<DocumentsFormState>(DEFAULT_DOCUMENTS_FORM);
-  const [preview, setPreview] = useState<PreviewResult | null>(null);
-  const [document, setDocument] = useState<GeneratedDocument | null>(null);
-  const [notice, setNotice] = useState<string | null>(null);
-  const [isPreviewing, setIsPreviewing] = useState(false);
+interface GenerateResult {
+  document?: GeneratedDocument | null;
+  notice?: string;
+}
 
-  const generateMutation = trpc.cerebrum.emit.generate.useMutation({
+function useGenerateMutation(
+  t: (key: string) => string,
+  setDocument: (next: GeneratedDocument | null) => void,
+  setNotice: (next: string | null) => void
+) {
+  return usePillarMutation<ValidatedRequest, GenerateResult>('cerebrum', ['emit', 'generate'], {
     onSuccess: (result) => {
       setDocument(result?.document ?? null);
       setNotice(result?.notice ?? null);
     },
     onError: (err) => toast.error(extractMessage(err, t('errors.unknown'))),
   });
+}
 
+function usePreviewRunner(
+  setPreview: (next: PreviewResult | null) => void,
+  t: (key: string) => string
+) {
+  const pillarCall = usePillarCall();
+  const [isPreviewing, setIsPreviewing] = useState(false);
   const runPreview = async (request: ValidatedRequest) => {
     setIsPreviewing(true);
     try {
-      const result = await utils.cerebrum.emit.preview.fetch(request);
-      setPreview(result ?? null);
+      const result = await pillarCall<PreviewResult | null>(
+        'cerebrum',
+        ['emit', 'preview'],
+        request
+      );
+      if (result.kind !== 'ok') {
+        toast.error(t('errors.unknown'));
+        return;
+      }
+      setPreview(result.value ?? null);
     } catch (err) {
       toast.error(extractMessage(err, t('errors.unknown')));
     } finally {
       setIsPreviewing(false);
     }
   };
+  return { runPreview, isPreviewing };
+}
+
+export function useDocumentsModel(): DocumentsModel {
+  const { t } = useTranslation('cerebrum');
+  const [form, setForm] = useState<DocumentsFormState>(DEFAULT_DOCUMENTS_FORM);
+  const [preview, setPreview] = useState<PreviewResult | null>(null);
+  const [document, setDocument] = useState<GeneratedDocument | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  const generateMutation = useGenerateMutation(t, setDocument, setNotice);
+  const { runPreview, isPreviewing } = usePreviewRunner(setPreview, t);
 
   const runValidatedAction = (action: 'preview' | 'generate') => {
     const validated = validateForm(form);

--- a/packages/app-cerebrum/src/engrams/useEngramDetailModel.ts
+++ b/packages/app-cerebrum/src/engrams/useEngramDetailModel.ts
@@ -8,16 +8,27 @@
  */
 import { useCallback, useMemo } from 'react';
 
-import { trpc } from '@pops/api-client';
+import { PillarCallError } from '@pops/pillar-sdk/client';
+import { usePillarMutation, usePillarQuery, usePillarUtils } from '@pops/pillar-sdk/react';
 
 import { extractMessage } from '../utils/errors';
 import { clearDraft } from './draft-storage';
 import { findInvalidScopes, normaliseScope } from './scope-validation';
 import { useEngramFormState, type EngramFormState } from './useEngramFormState';
 
-import type { Engram } from './types';
+import type { Engram, EngramStatus } from './types';
 
 export type { EngramFormState } from './useEngramFormState';
+
+interface EngramUpdateInput {
+  id: string;
+  title?: string;
+  body?: string;
+  scopes?: string[];
+  tags?: string[];
+  status?: EngramStatus;
+  customFields?: Record<string, unknown>;
+}
 
 export interface EngramDetailModel {
   id: string;
@@ -63,6 +74,9 @@ function resolveError(
 }
 
 function isNotFound(err: unknown): boolean {
+  if (err instanceof PillarCallError) {
+    return err.result.kind === 'contract-mismatch';
+  }
   if (!err || typeof err !== 'object') return false;
   const data = (err as { data?: { code?: string } }).data;
   return data?.code === 'NOT_FOUND';
@@ -74,29 +88,41 @@ interface UseEngramDetailOptions {
   t: (key: string, vars?: Record<string, string>) => string;
 }
 
-export function useEngramDetailModel(options: UseEngramDetailOptions): EngramDetailModel {
-  const { id, storage, t } = options;
-  const utils = trpc.useUtils();
-
-  const getQuery = trpc.cerebrum.engrams.get.useQuery({ id });
+function useEngramQueries(id: string) {
+  const getQuery = usePillarQuery<{ engram: Engram | null; body: string }>(
+    'cerebrum',
+    ['engrams', 'get'],
+    { id }
+  );
   const engram = getQuery.data?.engram ?? null;
   const body = getQuery.data?.body ?? '';
   const linkIds = useMemo(() => engram?.links ?? [], [engram]);
-  const connectedQuery = trpc.cerebrum.engrams.list.useQuery(
+  const connectedQuery = usePillarQuery<{ engrams: Engram[]; total: number }>(
+    'cerebrum',
+    ['engrams', 'list'],
     { ids: linkIds, limit: linkIds.length || 1 },
     { enabled: linkIds.length > 0 }
   );
+  return { getQuery, engram, body, connectedQuery };
+}
 
+export function useEngramDetailModel(options: UseEngramDetailOptions): EngramDetailModel {
+  const { id, storage, t } = options;
+  const utils = usePillarUtils('cerebrum');
+  const { getQuery, engram, body, connectedQuery } = useEngramQueries(id);
   const formState = useEngramFormState({ engram, body, storage });
 
-  const updateMutation = trpc.cerebrum.engrams.update.useMutation({
-    onSuccess: async () => {
-      if (engram) clearDraft(engram.id, storage);
-      formState.finishEditing();
-      await utils.cerebrum.engrams.get.invalidate({ id });
-      await utils.cerebrum.engrams.list.invalidate();
-    },
-  });
+  const updateMutation = usePillarMutation<EngramUpdateInput, unknown>(
+    'cerebrum',
+    ['engrams', 'update'],
+    {
+      onSuccess: async () => {
+        if (engram) clearDraft(engram.id, storage);
+        formState.finishEditing();
+        await utils.invalidate(['engrams']);
+      },
+    }
+  );
 
   const validationErrors = useMemo(
     () => (formState.isEditing ? validate(formState.form, t) : []),

--- a/packages/app-cerebrum/src/engrams/useEngramListModel.ts
+++ b/packages/app-cerebrum/src/engrams/useEngramListModel.ts
@@ -13,7 +13,7 @@
 import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { trpc } from '@pops/api-client';
+import { usePillarQuery } from '@pops/pillar-sdk/react';
 
 import { extractMessage } from '../utils/errors';
 import {
@@ -132,7 +132,9 @@ interface BrowseHook {
  */
 function useBrowseList(filters: EngramListFilters, offset: number, enabled: boolean): BrowseHook {
   const { t } = useTranslation('cerebrum');
-  const query = trpc.cerebrum.engrams.list.useQuery(
+  const query = usePillarQuery<{ engrams: Engram[]; total: number }>(
+    'cerebrum',
+    ['engrams', 'list'],
     buildListInput(filters, offset, DEFAULT_PAGE_SIZE),
     { enabled }
   );
@@ -152,9 +154,16 @@ function useBrowseList(filters: EngramListFilters, offset: number, enabled: bool
  * second `engrams.list({ ids })` query to hydrate the matched ids
  * into full Engram rows.
  */
+interface SearchResult {
+  results: unknown[];
+  meta: { total: number; mode: string };
+}
+
 function useSearchList(filters: EngramListFilters, offset: number, enabled: boolean): BrowseHook {
   const { t } = useTranslation('cerebrum');
-  const searchQuery = trpc.cerebrum.retrieval.search.useQuery(
+  const searchQuery = usePillarQuery<SearchResult>(
+    'cerebrum',
+    ['retrieval', 'search'],
     buildSearchInput(filters, offset, DEFAULT_PAGE_SIZE),
     { enabled }
   );
@@ -162,7 +171,9 @@ function useSearchList(filters: EngramListFilters, offset: number, enabled: bool
     () => (enabled ? extractRetrievalIds(searchQuery.data?.results) : []),
     [enabled, searchQuery.data]
   );
-  const hydration = trpc.cerebrum.engrams.list.useQuery(
+  const hydration = usePillarQuery<{ engrams: Engram[]; total: number }>(
+    'cerebrum',
+    ['engrams', 'list'],
     { ids, limit: ids.length || 1 },
     { enabled: enabled && ids.length > 0 }
   );
@@ -191,7 +202,11 @@ export function useEngramListModel(): EngramListModel {
 
   const browse = useBrowseList(filters, offset, !isSearching);
   const search = useSearchList(filters, offset, isSearching);
-  const scopesQuery = trpc.cerebrum.scopes.list.useQuery(undefined);
+  const scopesQuery = usePillarQuery<{ scopes: { scope: string; count: number }[] }>(
+    'cerebrum',
+    ['scopes', 'list'],
+    undefined
+  );
 
   const scopeOptions = useMemo(
     () => (scopesQuery.data?.scopes ?? []).map((s) => s.scope),

--- a/packages/app-cerebrum/src/lib/pillar-call.ts
+++ b/packages/app-cerebrum/src/lib/pillar-call.ts
@@ -1,0 +1,48 @@
+import { useCallback } from 'react';
+
+import { pillar, type CallResult } from '@pops/pillar-sdk/client';
+import { usePillarSdkOptions } from '@pops/pillar-sdk/react';
+
+type ProcedurePath = readonly [string, ...string[]];
+
+/**
+ * Imperative one-shot call against a pillar procedure. Mirrors the discontinued
+ * `trpc.useUtils().<pillar>.<path>.fetch(input)` pattern (no caching, no
+ * suspense) so existing call sites that need an ad-hoc lookup can continue to
+ * work without pulling React Query state into the flow.
+ *
+ * Returns the raw `CallResult` so callers can branch on `kind === 'ok'`
+ * versus the `unavailable` / `contract-mismatch` / `degraded` discriminants.
+ */
+export function usePillarCall(): <TOutput>(
+  pillarId: string,
+  path: ProcedurePath,
+  input: unknown
+) => Promise<CallResult<TOutput>> {
+  const sdkOptions = usePillarSdkOptions();
+  return useCallback(
+    async <TOutput>(
+      pillarId: string,
+      path: ProcedurePath,
+      input: unknown
+    ): Promise<CallResult<TOutput>> => {
+      const handle = pillar<unknown>(pillarId, sdkOptions);
+      let node: unknown = handle;
+      for (let i = 0; i < path.length - 1; i += 1) {
+        const segment = path[i] as string;
+        node = (node as Record<string, unknown>)[segment];
+      }
+      const leafName = path[path.length - 1] as string;
+      const leaf = (node as Record<string, unknown>)[leafName];
+      if (typeof leaf !== 'function') {
+        return {
+          kind: 'contract-mismatch',
+          pillar: pillarId,
+          actual: path.join('.'),
+        };
+      }
+      return (leaf as (i: unknown) => Promise<CallResult<TOutput>>)(input);
+    },
+    [sdkOptions]
+  );
+}

--- a/packages/app-cerebrum/src/pages/DocumentsPage.test.tsx
+++ b/packages/app-cerebrum/src/pages/DocumentsPage.test.tsx
@@ -13,34 +13,30 @@ vi.mock('sonner', () => ({
 }));
 
 const mockGenerateMutate = vi.fn();
-const mockPreviewFetch = vi.fn();
+const mockPreviewCall = vi.fn();
 let generatePending = false;
 let generateCallbacks: { onSuccess?: (data: unknown) => void; onError?: (err: unknown) => void } =
   {};
 
-vi.mock('@pops/api-client', () => ({
-  trpc: {
-    useUtils: () => ({
-      cerebrum: {
-        emit: {
-          preview: { fetch: (...args: unknown[]) => mockPreviewFetch(...args) },
-        },
-      },
-    }),
-    cerebrum: {
-      emit: {
-        generate: {
-          useMutation: (cb: typeof generateCallbacks) => {
-            generateCallbacks = cb;
-            return {
-              mutate: (...args: unknown[]) => mockGenerateMutate(...args),
-              isPending: generatePending,
-              error: null,
-            };
-          },
-        },
-      },
-    },
+vi.mock('@pops/pillar-sdk/react', () => ({
+  usePillarMutation: (_pillarId: string, path: readonly string[], cb: typeof generateCallbacks) => {
+    const key = path.join('.');
+    if (key === 'emit.generate') {
+      generateCallbacks = cb;
+      return {
+        mutate: (...args: unknown[]) => mockGenerateMutate(...args),
+        isPending: generatePending,
+        error: null,
+      };
+    }
+    throw new Error(`Unexpected pillar mutation: ${key}`);
+  },
+}));
+
+vi.mock('../lib/pillar-call', () => ({
+  usePillarCall: () => async (_pillarId: string, _path: readonly string[], input: unknown) => {
+    const value = await mockPreviewCall(input);
+    return { kind: 'ok', value };
   },
 }));
 
@@ -58,7 +54,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   generatePending = false;
   generateCallbacks = {};
-  mockPreviewFetch.mockResolvedValue({ sources: [], outline: 'outline' });
+  mockPreviewCall.mockResolvedValue({ sources: [], outline: 'outline' });
 });
 
 describe('DocumentsPage', () => {
@@ -80,7 +76,7 @@ describe('DocumentsPage', () => {
     renderPage();
     await userEvent.type(screen.getByLabelText('Query'), 'agents');
     await userEvent.click(screen.getByRole('button', { name: /preview/i }));
-    expect(mockPreviewFetch).toHaveBeenCalledWith({ mode: 'report', query: 'agents' });
+    expect(mockPreviewCall).toHaveBeenCalledWith({ mode: 'report', query: 'agents' });
   });
 
   it('renders the generated document when the mutation succeeds', () => {

--- a/packages/app-cerebrum/src/pages/EngramDetailPage.test.tsx
+++ b/packages/app-cerebrum/src/pages/EngramDetailPage.test.tsx
@@ -12,33 +12,55 @@ const mockUpdateMutationState = { isPending: false, error: null as unknown };
 const invalidateGet = vi.fn().mockResolvedValue(undefined);
 const invalidateList = vi.fn().mockResolvedValue(undefined);
 
-vi.mock('@pops/api-client', () => ({
-  trpc: {
-    useUtils: () => ({
-      cerebrum: {
-        engrams: {
-          get: { invalidate: invalidateGet },
-          list: { invalidate: invalidateList },
-        },
-      },
-    }),
-    cerebrum: {
-      engrams: {
-        get: { useQuery: (...args: unknown[]) => mockGetQuery(...args) },
-        list: { useQuery: (...args: unknown[]) => mockListQuery(...args) },
-        update: {
-          useMutation: (opts: { onSuccess?: () => void | Promise<void> }) => ({
-            mutate: (...args: unknown[]) => {
-              mockUpdateMutate(...args);
-              void opts.onSuccess?.();
-            },
-            isPending: mockUpdateMutationState.isPending,
-            error: mockUpdateMutationState.error,
-          }),
-        },
-      },
-    },
+vi.mock('@pops/pillar-sdk/client', () => ({
+  PillarCallError: class PillarCallError extends Error {
+    result: { kind: string };
+    constructor(_pillarId: string, result: { kind: string }) {
+      super('pillar error');
+      this.result = result;
+    }
   },
+}));
+
+vi.mock('@pops/pillar-sdk/react', () => ({
+  usePillarQuery: (_pillarId: string, path: readonly string[], input: unknown) => {
+    const key = path.join('.');
+    if (key === 'engrams.get') return mockGetQuery(input);
+    if (key === 'engrams.list') return mockListQuery(input);
+    throw new Error(`Unexpected pillar query: ${key}`);
+  },
+  usePillarMutation: (
+    _pillarId: string,
+    path: readonly string[],
+    opts: { onSuccess?: () => void | Promise<void> }
+  ) => {
+    const key = path.join('.');
+    if (key === 'engrams.update') {
+      return {
+        mutate: (...args: unknown[]) => {
+          mockUpdateMutate(...args);
+          void opts.onSuccess?.();
+        },
+        isPending: mockUpdateMutationState.isPending,
+        error: mockUpdateMutationState.error,
+      };
+    }
+    throw new Error(`Unexpected pillar mutation: ${key}`);
+  },
+  usePillarUtils: () => ({
+    invalidate: async (routerPath?: readonly string[]) => {
+      const key = routerPath?.join('.') ?? '';
+      if (key === 'engrams' || key === '') {
+        await invalidateGet();
+        await invalidateList();
+      } else if (key === 'engrams.get') {
+        await invalidateGet();
+      } else if (key === 'engrams.list') {
+        await invalidateList();
+      }
+    },
+    setData: vi.fn(),
+  }),
 }));
 
 import { EngramDetailPage } from './EngramDetailPage';

--- a/packages/app-cerebrum/src/pages/EngramsListPage.test.tsx
+++ b/packages/app-cerebrum/src/pages/EngramsListPage.test.tsx
@@ -9,19 +9,18 @@ const mockEngramsListQuery = vi.fn();
 const mockSearchQuery = vi.fn();
 const mockScopesListQuery = vi.fn();
 
-vi.mock('@pops/api-client', () => ({
-  trpc: {
-    cerebrum: {
-      engrams: {
-        list: { useQuery: (...args: unknown[]) => mockEngramsListQuery(...args) },
-      },
-      retrieval: {
-        search: { useQuery: (...args: unknown[]) => mockSearchQuery(...args) },
-      },
-      scopes: {
-        list: { useQuery: (...args: unknown[]) => mockScopesListQuery(...args) },
-      },
-    },
+vi.mock('@pops/pillar-sdk/react', () => ({
+  usePillarQuery: (
+    _pillarId: string,
+    path: readonly string[],
+    input: unknown,
+    options?: unknown
+  ) => {
+    const key = path.join('.');
+    if (key === 'engrams.list') return mockEngramsListQuery(input, options);
+    if (key === 'retrieval.search') return mockSearchQuery(input, options);
+    if (key === 'scopes.list') return mockScopesListQuery(input, options);
+    throw new Error(`Unexpected pillar query: ${key}`);
   },
 }));
 

--- a/packages/app-cerebrum/src/pages/GliaDashboardPage.test.tsx
+++ b/packages/app-cerebrum/src/pages/GliaDashboardPage.test.tsx
@@ -9,51 +9,29 @@ const mockPrunerMutate = vi.fn();
 const mockConsolidatorMutate = vi.fn();
 const mockLinkerMutate = vi.fn();
 const mockAuditorMutate = vi.fn();
-const invalidateActions = vi.fn().mockResolvedValue(undefined);
 
-vi.mock('@pops/api-client', () => ({
-  trpc: {
-    useUtils: () => ({
-      cerebrum: { glia: { actions: { list: { invalidate: invalidateActions } } } },
-    }),
-    cerebrum: {
-      glia: {
-        actions: {
-          list: { useQuery: (...args: unknown[]) => mockActionsListQuery(...args) },
-        },
-        trustState: {
-          list: { useQuery: (...args: unknown[]) => mockTrustListQuery(...args) },
-        },
-        runPruner: {
-          useMutation: () => ({
-            mutate: mockPrunerMutate,
-            isPending: false,
-            error: null,
-          }),
-        },
-        runConsolidator: {
-          useMutation: () => ({
-            mutate: mockConsolidatorMutate,
-            isPending: false,
-            error: null,
-          }),
-        },
-        runLinker: {
-          useMutation: () => ({
-            mutate: mockLinkerMutate,
-            isPending: false,
-            error: null,
-          }),
-        },
-        runAuditor: {
-          useMutation: () => ({
-            mutate: mockAuditorMutate,
-            isPending: false,
-            error: null,
-          }),
-        },
-      },
-    },
+vi.mock('@pops/pillar-sdk/react', () => ({
+  usePillarQuery: (_pillarId: string, path: readonly string[], input: unknown) => {
+    const key = path.join('.');
+    if (key === 'glia.actions.list') return mockActionsListQuery(input);
+    if (key === 'glia.trustState.list') return mockTrustListQuery(input);
+    throw new Error(`Unexpected pillar query: ${key}`);
+  },
+  usePillarMutation: (_pillarId: string, path: readonly string[]) => {
+    const key = path.join('.');
+    if (key === 'glia.runPruner') {
+      return { mutate: mockPrunerMutate, isPending: false, error: null };
+    }
+    if (key === 'glia.runConsolidator') {
+      return { mutate: mockConsolidatorMutate, isPending: false, error: null };
+    }
+    if (key === 'glia.runLinker') {
+      return { mutate: mockLinkerMutate, isPending: false, error: null };
+    }
+    if (key === 'glia.runAuditor') {
+      return { mutate: mockAuditorMutate, isPending: false, error: null };
+    }
+    throw new Error(`Unexpected pillar mutation: ${key}`);
   },
 }));
 

--- a/packages/app-cerebrum/src/pages/IngestPage.test.tsx
+++ b/packages/app-cerebrum/src/pages/IngestPage.test.tsx
@@ -26,81 +26,77 @@ vi.mock('react-router', () => ({
   },
 }));
 
-vi.mock('@pops/api-client', () => ({
-  trpc: {
-    useUtils: () => ({
-      cerebrum: { ingest: { enrichmentStatus: { invalidate: vi.fn() } } },
-    }),
-    cerebrum: {
-      templates: { list: { useQuery: (...args: unknown[]) => mockTemplatesQuery(...args) } },
-      scopes: { list: { useQuery: (...args: unknown[]) => mockScopesQuery(...args) } },
-      tags: { list: { useQuery: (...args: unknown[]) => mockTagsQuery(...args) } },
-      engrams: {
-        update: {
-          useMutation: () => ({ mutate: vi.fn(), isPending: false, error: null }),
-        },
-      },
-      ingest: {
-        enrichmentStatus: {
-          useQuery: () => ({
-            data: undefined,
-            isLoading: false,
-            error: null,
-            refetch: vi.fn(),
-          }),
-        },
-        retryEnrichment: {
-          useMutation: () => ({ mutate: vi.fn(), isPending: false, error: null }),
-        },
-        submit: {
-          useMutation: (opts: { onSuccess?: (data: unknown) => void; onError?: unknown }) => {
-            submitOnSuccess.current = opts.onSuccess ?? null;
-            return {
-              mutate: (...args: unknown[]) => {
-                mockSubmitMutate(...args);
-                submitOnSuccess.current?.({
-                  engram: {
-                    id: 'eng_20260514_1700_advanced',
-                    filePath: '/cerebrum/engrams/advanced.md',
-                    type: 'note',
-                  },
-                  classification: null,
-                  entities: [],
-                  scopeInference: { scopes: [], source: 'fallback', confidence: 0 },
-                });
-              },
-              isPending: false,
-              error: null,
-            };
-          },
-        },
-        quickCapture: {
-          useMutation: (opts: { onSuccess?: (data: unknown) => void; onError?: unknown }) => {
-            captureOnSuccess.current = opts.onSuccess ?? null;
-            const response = {
-              id: 'eng_20260514_1700_capture',
-              path: 'capture/eng_20260514_1700_capture.md',
-              type: 'capture',
-              scopes: ['personal.captures'],
-            };
-            return {
-              mutate: (...args: unknown[]) => {
-                mockQuickCaptureMutate(...args);
-                captureOnSuccess.current?.(response);
-              },
-              mutateAsync: async (...args: unknown[]) => {
-                mockQuickCaptureMutate(...args);
-                captureOnSuccess.current?.(response);
-                return response;
-              },
-              isPending: false,
-              error: null,
-            };
-          },
-        },
-      },
-    },
+vi.mock('@pops/pillar-sdk/react', () => ({
+  usePillarQuery: (_pillarId: string, path: readonly string[], input: unknown) => {
+    const key = path.join('.');
+    if (key === 'templates.list') return mockTemplatesQuery(input);
+    if (key === 'scopes.list') return mockScopesQuery(input);
+    if (key === 'tags.list') return mockTagsQuery(input);
+    if (key === 'ingest.enrichmentStatus') {
+      return { data: undefined, isLoading: false, error: null, refetch: vi.fn() };
+    }
+    throw new Error(`Unexpected pillar query: ${key}`);
   },
+  usePillarMutation: (
+    _pillarId: string,
+    path: readonly string[],
+    opts?: { onSuccess?: (data: unknown) => void; onError?: unknown }
+  ) => {
+    const key = path.join('.');
+    if (key === 'engrams.update') {
+      return { mutate: vi.fn(), isPending: false, error: null };
+    }
+    if (key === 'ingest.retryEnrichment') {
+      return { mutate: vi.fn(), isPending: false, error: null };
+    }
+    if (key === 'ingest.submit') {
+      submitOnSuccess.current = opts?.onSuccess ?? null;
+      return {
+        mutate: (...args: unknown[]) => {
+          mockSubmitMutate(...args);
+          submitOnSuccess.current?.({
+            engram: {
+              id: 'eng_20260514_1700_advanced',
+              filePath: '/cerebrum/engrams/advanced.md',
+              type: 'note',
+            },
+            classification: null,
+            entities: [],
+            scopeInference: { scopes: [], source: 'fallback', confidence: 0 },
+          });
+        },
+        isPending: false,
+        error: null,
+      };
+    }
+    if (key === 'ingest.quickCapture') {
+      captureOnSuccess.current = opts?.onSuccess ?? null;
+      const response = {
+        id: 'eng_20260514_1700_capture',
+        path: 'capture/eng_20260514_1700_capture.md',
+        type: 'capture',
+        scopes: ['personal.captures'],
+      };
+      return {
+        mutate: (...args: unknown[]) => {
+          mockQuickCaptureMutate(...args);
+          captureOnSuccess.current?.(response);
+        },
+        mutateAsync: async (...args: unknown[]) => {
+          mockQuickCaptureMutate(...args);
+          captureOnSuccess.current?.(response);
+          return response;
+        },
+        isPending: false,
+        error: null,
+      };
+    }
+    throw new Error(`Unexpected pillar mutation: ${key}`);
+  },
+  usePillarUtils: () => ({
+    invalidate: vi.fn().mockResolvedValue(undefined),
+    setData: vi.fn(),
+  }),
 }));
 
 // ── UI mock ──────────────────────────────────────────────────────────

--- a/packages/app-cerebrum/src/pages/NudgesPage.tsx
+++ b/packages/app-cerebrum/src/pages/NudgesPage.tsx
@@ -4,25 +4,38 @@
  * Displays pending nudges with dismiss/act actions. Fetched via
  * the existing nudges.list tRPC endpoint.
  */
-import { trpc } from '@pops/api-client';
+import { usePillarMutation, usePillarQuery } from '@pops/pillar-sdk/react';
 import { ButtonPrimitive } from '@pops/ui';
 
 import { ContradictionsPanel } from '../components/ContradictionsPanel';
 import { NudgeCard } from '../components/NudgeCard';
 
-export function NudgesPage() {
-  const utils = trpc.useUtils();
-  const { data, isLoading, isError, error, refetch } = trpc.cerebrum.nudges.list.useQuery({
-    status: 'pending',
-    limit: 50,
-  });
+interface NudgeSummary {
+  id: string;
+  type: string;
+  title: string;
+  body: string;
+  priority: string;
+  action: { label: string } | null;
+}
 
-  const dismissMutation = trpc.cerebrum.nudges.dismiss.useMutation({
-    onSuccess: () => utils.cerebrum.nudges.list.invalidate(),
-  });
-  const actMutation = trpc.cerebrum.nudges.act.useMutation({
-    onSuccess: () => utils.cerebrum.nudges.list.invalidate(),
-  });
+interface NudgeListResult {
+  nudges: NudgeSummary[];
+  total: number;
+}
+
+export function NudgesPage() {
+  const { data, isLoading, isError, error, refetch } = usePillarQuery<NudgeListResult>(
+    'cerebrum',
+    ['nudges', 'list'],
+    { status: 'pending', limit: 50 }
+  );
+
+  const dismissMutation = usePillarMutation<{ id: string }, unknown>('cerebrum', [
+    'nudges',
+    'dismiss',
+  ]);
+  const actMutation = usePillarMutation<{ id: string }, unknown>('cerebrum', ['nudges', 'act']);
 
   if (isLoading) {
     return <div className="p-6 text-muted-foreground">Loading nudges...</div>;

--- a/packages/app-cerebrum/src/pages/PlexusDetailPage.tsx
+++ b/packages/app-cerebrum/src/pages/PlexusDetailPage.tsx
@@ -9,7 +9,7 @@ import { useTranslation } from 'react-i18next';
 import { Link, useParams } from 'react-router';
 import { toast } from 'sonner';
 
-import { trpc } from '@pops/api-client';
+import { usePillarMutation, usePillarQuery } from '@pops/pillar-sdk/react';
 import { Badge, Button, PageHeader, Skeleton } from '@pops/ui';
 
 import { formatTimestamp, statusBadgeVariant, statusKey } from '../plexus/format';
@@ -27,25 +27,26 @@ interface DetailMutations {
 
 function useDetailMutations(adapterId: string): DetailMutations {
   const { t } = useTranslation('cerebrum');
-  const utils = trpc.useUtils();
-  const invalidate = () => {
-    void utils.cerebrum.plexus.adapters.get.invalidate({ adapterId });
-    void utils.cerebrum.plexus.adapters.list.invalidate();
-  };
-  const healthMutation = trpc.cerebrum.plexus.adapters.healthCheck.useMutation({
-    onSuccess: () => {
-      invalidate();
-      toast.success(t('plexus.list.healthSuccess'));
-    },
-    onError: (err) => toast.error(extractMessage(err, t('errors.unknown'))),
-  });
-  const syncMutation = trpc.cerebrum.plexus.adapters.sync.useMutation({
-    onSuccess: () => {
-      invalidate();
-      toast.success(t('plexus.list.syncSuccess'));
-    },
-    onError: (err) => toast.error(extractMessage(err, t('errors.unknown'))),
-  });
+  const healthMutation = usePillarMutation<{ adapterId: string }, unknown>(
+    'cerebrum',
+    ['plexus', 'adapters', 'healthCheck'],
+    {
+      onSuccess: () => {
+        toast.success(t('plexus.list.healthSuccess'));
+      },
+      onError: (err) => toast.error(extractMessage(err, t('errors.unknown'))),
+    }
+  );
+  const syncMutation = usePillarMutation<{ adapterId: string }, unknown>(
+    'cerebrum',
+    ['plexus', 'adapters', 'sync'],
+    {
+      onSuccess: () => {
+        toast.success(t('plexus.list.syncSuccess'));
+      },
+      onError: (err) => toast.error(extractMessage(err, t('errors.unknown'))),
+    }
+  );
   return {
     isPending: healthMutation.isPending || syncMutation.isPending,
     onHealth: () => healthMutation.mutate({ adapterId }),
@@ -121,11 +122,15 @@ export function PlexusDetailPage() {
   const { t } = useTranslation('cerebrum');
   const params = useParams<{ adapterId: string }>();
   const adapterId = params.adapterId ?? '';
-  const detail = trpc.cerebrum.plexus.adapters.get.useQuery(
+  const detail = usePillarQuery<{ adapter: PlexusAdapter | null }>(
+    'cerebrum',
+    ['plexus', 'adapters', 'get'],
     { adapterId },
     { enabled: adapterId.length > 0 }
   );
-  const filtersQuery = trpc.cerebrum.plexus.filters.list.useQuery(
+  const filtersQuery = usePillarQuery<{ filters: PlexusFilter[] }>(
+    'cerebrum',
+    ['plexus', 'filters', 'list'],
     { adapterId },
     { enabled: adapterId.length > 0 }
   );

--- a/packages/app-cerebrum/src/pages/PlexusListPage.test.tsx
+++ b/packages/app-cerebrum/src/pages/PlexusListPage.test.tsx
@@ -6,26 +6,22 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mockListQuery = vi.fn();
 const mockHealthMutate = vi.fn();
 const mockSyncMutate = vi.fn();
-const invalidateList = vi.fn().mockResolvedValue(undefined);
 
-vi.mock('@pops/api-client', () => ({
-  trpc: {
-    useUtils: () => ({
-      cerebrum: { plexus: { adapters: { list: { invalidate: invalidateList } } } },
-    }),
-    cerebrum: {
-      plexus: {
-        adapters: {
-          list: { useQuery: (...args: unknown[]) => mockListQuery(...args) },
-          healthCheck: {
-            useMutation: () => ({ mutate: mockHealthMutate, isPending: false, error: null }),
-          },
-          sync: {
-            useMutation: () => ({ mutate: mockSyncMutate, isPending: false, error: null }),
-          },
-        },
-      },
-    },
+vi.mock('@pops/pillar-sdk/react', () => ({
+  usePillarQuery: (_pillarId: string, path: readonly string[], input: unknown) => {
+    const key = path.join('.');
+    if (key === 'plexus.adapters.list') return mockListQuery(input);
+    throw new Error(`Unexpected pillar query: ${key}`);
+  },
+  usePillarMutation: (_pillarId: string, path: readonly string[]) => {
+    const key = path.join('.');
+    if (key === 'plexus.adapters.healthCheck') {
+      return { mutate: mockHealthMutate, isPending: false, error: null };
+    }
+    if (key === 'plexus.adapters.sync') {
+      return { mutate: mockSyncMutate, isPending: false, error: null };
+    }
+    throw new Error(`Unexpected pillar mutation: ${key}`);
   },
 }));
 

--- a/packages/app-cerebrum/src/pages/PlexusListPage.tsx
+++ b/packages/app-cerebrum/src/pages/PlexusListPage.tsx
@@ -11,7 +11,7 @@ import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router';
 import { toast } from 'sonner';
 
-import { trpc } from '@pops/api-client';
+import { usePillarMutation, usePillarQuery } from '@pops/pillar-sdk/react';
 import {
   Badge,
   Button,
@@ -123,24 +123,26 @@ interface AdapterMutations {
 
 function useAdapterMutations(): AdapterMutations {
   const { t } = useTranslation('cerebrum');
-  const utils = trpc.useUtils();
-  const invalidate = () => {
-    void utils.cerebrum.plexus.adapters.list.invalidate();
-  };
-  const healthMutation = trpc.cerebrum.plexus.adapters.healthCheck.useMutation({
-    onSuccess: () => {
-      invalidate();
-      toast.success(t('plexus.list.healthSuccess'));
-    },
-    onError: (err) => toast.error(extractMessage(err, t('errors.unknown'))),
-  });
-  const syncMutation = trpc.cerebrum.plexus.adapters.sync.useMutation({
-    onSuccess: () => {
-      invalidate();
-      toast.success(t('plexus.list.syncSuccess'));
-    },
-    onError: (err) => toast.error(extractMessage(err, t('errors.unknown'))),
-  });
+  const healthMutation = usePillarMutation<{ adapterId: string }, unknown>(
+    'cerebrum',
+    ['plexus', 'adapters', 'healthCheck'],
+    {
+      onSuccess: () => {
+        toast.success(t('plexus.list.healthSuccess'));
+      },
+      onError: (err) => toast.error(extractMessage(err, t('errors.unknown'))),
+    }
+  );
+  const syncMutation = usePillarMutation<{ adapterId: string }, unknown>(
+    'cerebrum',
+    ['plexus', 'adapters', 'sync'],
+    {
+      onSuccess: () => {
+        toast.success(t('plexus.list.syncSuccess'));
+      },
+      onError: (err) => toast.error(extractMessage(err, t('errors.unknown'))),
+    }
+  );
   return {
     isPending: healthMutation.isPending || syncMutation.isPending,
     onHealth: (id) => healthMutation.mutate({ adapterId: id }),
@@ -201,7 +203,11 @@ function PlexusListBody({ list, adapters, mutations }: ListBodyProps) {
 
 export function PlexusListPage() {
   const { t } = useTranslation('cerebrum');
-  const list = trpc.cerebrum.plexus.adapters.list.useQuery();
+  const list = usePillarQuery<{ adapters: PlexusAdapter[] }>(
+    'cerebrum',
+    ['plexus', 'adapters', 'list'],
+    undefined
+  );
   const mutations = useAdapterMutations();
   const adapters = list.data?.adapters ?? [];
   return (

--- a/packages/app-cerebrum/src/pages/ProposalQueuePage.tsx
+++ b/packages/app-cerebrum/src/pages/ProposalQueuePage.tsx
@@ -6,21 +6,42 @@
  */
 import { useState } from 'react';
 
-import { trpc } from '@pops/api-client';
+import { usePillarMutation, usePillarQuery } from '@pops/pillar-sdk/react';
 import { Button } from '@pops/ui';
 
 type Decision = 'approve' | 'reject' | 'modify';
 
-export function ProposalQueuePage() {
-  const utils = trpc.useUtils();
-  const { data, isLoading } = trpc.cerebrum.glia.actions.list.useQuery({
-    status: 'pending',
-    limit: 50,
-  });
+interface ProposalAction {
+  id: string;
+  actionType: string;
+  rationale: string;
+  affectedIds: string[];
+  createdAt: string;
+}
 
-  const decideMutation = trpc.cerebrum.glia.actions.decide.useMutation({
-    onSuccess: () => utils.cerebrum.glia.actions.list.invalidate(),
-  });
+interface ProposalListResult {
+  actions: ProposalAction[];
+  total: number;
+}
+
+interface DecideInput {
+  id: string;
+  decision: Decision;
+  note?: string;
+}
+
+export function ProposalQueuePage() {
+  const { data, isLoading } = usePillarQuery<ProposalListResult>(
+    'cerebrum',
+    ['glia', 'actions', 'list'],
+    { status: 'pending', limit: 50 }
+  );
+
+  const decideMutation = usePillarMutation<DecideInput, unknown>('cerebrum', [
+    'glia',
+    'actions',
+    'decide',
+  ]);
 
   const [noteState, setNoteState] = useState<Record<string, string>>({});
 

--- a/packages/app-cerebrum/src/pages/QueryPage.test.tsx
+++ b/packages/app-cerebrum/src/pages/QueryPage.test.tsx
@@ -26,22 +26,18 @@ const mockEmitMutate = vi.fn();
 let emitPending = false;
 let emitCallbacks: { onSuccess?: (data: unknown) => void; onError?: (err: unknown) => void } = {};
 
-vi.mock('@pops/api-client', () => ({
-  trpc: {
-    cerebrum: {
-      emit: {
-        generate: {
-          useMutation: (cb: typeof emitCallbacks) => {
-            emitCallbacks = cb;
-            return {
-              mutate: (...args: unknown[]) => mockEmitMutate(...args),
-              isPending: emitPending,
-              error: null,
-            };
-          },
-        },
-      },
-    },
+vi.mock('@pops/pillar-sdk/react', () => ({
+  usePillarMutation: (_pillarId: string, path: readonly string[], cb: typeof emitCallbacks) => {
+    const key = path.join('.');
+    if (key === 'emit.generate') {
+      emitCallbacks = cb;
+      return {
+        mutate: (...args: unknown[]) => mockEmitMutate(...args),
+        isPending: emitPending,
+        error: null,
+      };
+    }
+    throw new Error(`Unexpected pillar mutation: ${key}`);
   },
 }));
 

--- a/packages/app-cerebrum/src/pages/ReflexDetailPage.tsx
+++ b/packages/app-cerebrum/src/pages/ReflexDetailPage.tsx
@@ -9,7 +9,7 @@ import { useTranslation } from 'react-i18next';
 import { Link, useParams } from 'react-router';
 import { toast } from 'sonner';
 
-import { trpc } from '@pops/api-client';
+import { usePillarMutation, usePillarQuery } from '@pops/pillar-sdk/react';
 import { Button, PageHeader, Skeleton, Switch } from '@pops/ui';
 
 import { extractMessage } from '../utils/errors';
@@ -25,28 +25,32 @@ interface ReflexMutations {
   onTest: (name: string) => void;
 }
 
-function useReflexMutations(name: string): ReflexMutations {
+function useReflexMutations(_name: string): ReflexMutations {
   const { t } = useTranslation('cerebrum');
-  const utils = trpc.useUtils();
-  const invalidate = () => {
-    void utils.cerebrum.reflex.get.invalidate({ name });
-    void utils.cerebrum.reflex.list.invalidate();
-  };
-  const enableMutation = trpc.cerebrum.reflex.enable.useMutation({
-    onSuccess: invalidate,
-    onError: (err) => toast.error(extractMessage(err, t('errors.unknown'))),
-  });
-  const disableMutation = trpc.cerebrum.reflex.disable.useMutation({
-    onSuccess: invalidate,
-    onError: (err) => toast.error(extractMessage(err, t('errors.unknown'))),
-  });
-  const testMutation = trpc.cerebrum.reflex.test.useMutation({
-    onSuccess: () => {
-      invalidate();
-      toast.success(t('reflex.list.fireSuccess'));
-    },
-    onError: (err) => toast.error(extractMessage(err, t('errors.unknown'))),
-  });
+  const enableMutation = usePillarMutation<{ name: string }, unknown>(
+    'cerebrum',
+    ['reflex', 'enable'],
+    {
+      onError: (err) => toast.error(extractMessage(err, t('errors.unknown'))),
+    }
+  );
+  const disableMutation = usePillarMutation<{ name: string }, unknown>(
+    'cerebrum',
+    ['reflex', 'disable'],
+    {
+      onError: (err) => toast.error(extractMessage(err, t('errors.unknown'))),
+    }
+  );
+  const testMutation = usePillarMutation<{ name: string }, unknown>(
+    'cerebrum',
+    ['reflex', 'test'],
+    {
+      onSuccess: () => {
+        toast.success(t('reflex.list.fireSuccess'));
+      },
+      onError: (err) => toast.error(extractMessage(err, t('errors.unknown'))),
+    }
+  );
   return {
     isPending: enableMutation.isPending || disableMutation.isPending || testMutation.isPending,
     onToggle: (n, next) =>
@@ -126,7 +130,10 @@ export function ReflexDetailPage() {
   const { t } = useTranslation('cerebrum');
   const params = useParams<{ name: string }>();
   const name = params.name ?? '';
-  const detail = trpc.cerebrum.reflex.get.useQuery({ name }, { enabled: name.length > 0 });
+  const detail = usePillarQuery<{
+    reflex: ReflexWithStatus | undefined;
+    history: ReflexExecution[];
+  }>('cerebrum', ['reflex', 'get'], { name }, { enabled: name.length > 0 });
   const mutations = useReflexMutations(name);
 
   if (detail.isLoading) {

--- a/packages/app-cerebrum/src/pages/ReflexListPage.test.tsx
+++ b/packages/app-cerebrum/src/pages/ReflexListPage.test.tsx
@@ -7,29 +7,25 @@ const mockListQuery = vi.fn();
 const mockEnableMutate = vi.fn();
 const mockDisableMutate = vi.fn();
 const mockTestMutate = vi.fn();
-const invalidateList = vi.fn().mockResolvedValue(undefined);
 
-vi.mock('@pops/api-client', () => ({
-  trpc: {
-    useUtils: () => ({
-      cerebrum: {
-        reflex: { list: { invalidate: invalidateList } },
-      },
-    }),
-    cerebrum: {
-      reflex: {
-        list: { useQuery: (...args: unknown[]) => mockListQuery(...args) },
-        enable: {
-          useMutation: () => ({ mutate: mockEnableMutate, isPending: false, error: null }),
-        },
-        disable: {
-          useMutation: () => ({ mutate: mockDisableMutate, isPending: false, error: null }),
-        },
-        test: {
-          useMutation: () => ({ mutate: mockTestMutate, isPending: false, error: null }),
-        },
-      },
-    },
+vi.mock('@pops/pillar-sdk/react', () => ({
+  usePillarQuery: (_pillarId: string, path: readonly string[], input: unknown) => {
+    const key = path.join('.');
+    if (key === 'reflex.list') return mockListQuery(input);
+    throw new Error(`Unexpected pillar query: ${key}`);
+  },
+  usePillarMutation: (_pillarId: string, path: readonly string[]) => {
+    const key = path.join('.');
+    if (key === 'reflex.enable') {
+      return { mutate: mockEnableMutate, isPending: false, error: null };
+    }
+    if (key === 'reflex.disable') {
+      return { mutate: mockDisableMutate, isPending: false, error: null };
+    }
+    if (key === 'reflex.test') {
+      return { mutate: mockTestMutate, isPending: false, error: null };
+    }
+    throw new Error(`Unexpected pillar mutation: ${key}`);
   },
 }));
 

--- a/packages/app-cerebrum/src/pages/ReflexListPage.tsx
+++ b/packages/app-cerebrum/src/pages/ReflexListPage.tsx
@@ -2,7 +2,7 @@ import { Zap } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 
-import { trpc } from '@pops/api-client';
+import { usePillarMutation, usePillarQuery } from '@pops/pillar-sdk/react';
 import {
   Button,
   EmptyState,
@@ -62,25 +62,30 @@ interface ReflexListMutations {
 
 function useReflexListMutations(): ReflexListMutations {
   const { t } = useTranslation('cerebrum');
-  const utils = trpc.useUtils();
-  const invalidate = () => {
-    void utils.cerebrum.reflex.list.invalidate();
-  };
-  const enableMutation = trpc.cerebrum.reflex.enable.useMutation({
-    onSuccess: invalidate,
-    onError: (err) => toast.error(extractMessage(err, t('errors.unknown'))),
-  });
-  const disableMutation = trpc.cerebrum.reflex.disable.useMutation({
-    onSuccess: invalidate,
-    onError: (err) => toast.error(extractMessage(err, t('errors.unknown'))),
-  });
-  const testMutation = trpc.cerebrum.reflex.test.useMutation({
-    onSuccess: () => {
-      invalidate();
-      toast.success(t('reflex.list.fireSuccess'));
-    },
-    onError: (err) => toast.error(extractMessage(err, t('errors.unknown'))),
-  });
+  const enableMutation = usePillarMutation<{ name: string }, unknown>(
+    'cerebrum',
+    ['reflex', 'enable'],
+    {
+      onError: (err) => toast.error(extractMessage(err, t('errors.unknown'))),
+    }
+  );
+  const disableMutation = usePillarMutation<{ name: string }, unknown>(
+    'cerebrum',
+    ['reflex', 'disable'],
+    {
+      onError: (err) => toast.error(extractMessage(err, t('errors.unknown'))),
+    }
+  );
+  const testMutation = usePillarMutation<{ name: string }, unknown>(
+    'cerebrum',
+    ['reflex', 'test'],
+    {
+      onSuccess: () => {
+        toast.success(t('reflex.list.fireSuccess'));
+      },
+      onError: (err) => toast.error(extractMessage(err, t('errors.unknown'))),
+    }
+  );
   return {
     isPending: enableMutation.isPending || disableMutation.isPending || testMutation.isPending,
     onToggle: (name, next) =>
@@ -142,7 +147,11 @@ function ReflexListBody({ list, reflexes, mutations }: ReflexListBodyProps) {
 
 export function ReflexListPage() {
   const { t } = useTranslation('cerebrum');
-  const list = trpc.cerebrum.reflex.list.useQuery(undefined);
+  const list = usePillarQuery<{ reflexes: ReflexWithStatus[] }>(
+    'cerebrum',
+    ['reflex', 'list'],
+    undefined
+  );
   const mutations = useReflexListMutations();
   const reflexes = list.data?.reflexes ?? [];
 

--- a/packages/app-cerebrum/src/pages/glia-dashboard/AuditTrailPanel.tsx
+++ b/packages/app-cerebrum/src/pages/glia-dashboard/AuditTrailPanel.tsx
@@ -5,7 +5,7 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { trpc } from '@pops/api-client';
+import { usePillarQuery } from '@pops/pillar-sdk/react';
 import {
   Button,
   Skeleton,
@@ -130,11 +130,15 @@ export function AuditTrailPanel() {
   const [actionType, setActionType] = useState<GliaActionType | null>(null);
   const [status, setStatus] = useState<GliaActionStatus | null>(null);
 
-  const query = trpc.cerebrum.glia.actions.list.useQuery({
-    ...(actionType ? { actionType } : {}),
-    ...(status ? { status } : {}),
-    limit: 100,
-  });
+  const query = usePillarQuery<{ actions: GliaAction[]; total: number }>(
+    'cerebrum',
+    ['glia', 'actions', 'list'],
+    {
+      ...(actionType ? { actionType } : {}),
+      ...(status ? { status } : {}),
+      limit: 100,
+    }
+  );
   const actions: GliaAction[] = query.data?.actions ?? [];
 
   return (

--- a/packages/app-cerebrum/src/pages/glia-dashboard/TrustStatePanel.tsx
+++ b/packages/app-cerebrum/src/pages/glia-dashboard/TrustStatePanel.tsx
@@ -4,7 +4,7 @@
  */
 import { useTranslation } from 'react-i18next';
 
-import { trpc } from '@pops/api-client';
+import { usePillarQuery } from '@pops/pillar-sdk/react';
 import {
   Badge,
   Button,
@@ -87,9 +87,17 @@ function TrustBody({ query, states }: TrustBodyProps) {
   );
 }
 
+interface TrustStateListResult {
+  states: GliaTrustState[];
+}
+
 export function TrustStatePanel() {
   const { t } = useTranslation('cerebrum');
-  const query = trpc.cerebrum.glia.trustState.list.useQuery();
+  const query = usePillarQuery<TrustStateListResult>(
+    'cerebrum',
+    ['glia', 'trustState', 'list'],
+    undefined
+  );
   const states: GliaTrustState[] = query.data?.states ?? [];
 
   return (

--- a/packages/app-cerebrum/src/pages/glia-dashboard/WorkerPanel.tsx
+++ b/packages/app-cerebrum/src/pages/glia-dashboard/WorkerPanel.tsx
@@ -9,7 +9,7 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 
-import { trpc } from '@pops/api-client';
+import { usePillarMutation } from '@pops/pillar-sdk/react';
 import { Button, Checkbox } from '@pops/ui';
 
 import { extractMessage } from '../../utils/errors';
@@ -24,27 +24,41 @@ interface WorkerMutationState {
 
 function useSharedCallbacks() {
   const { t } = useTranslation('cerebrum');
-  const utils = trpc.useUtils();
   return {
-    onSuccess: () => utils.cerebrum.glia.actions.list.invalidate(),
     onError: (err: unknown) => toast.error(extractMessage(err, t('errors.unknown'))),
   };
 }
 
 function usePrunerMutation(): WorkerMutationState {
-  return trpc.cerebrum.glia.runPruner.useMutation(useSharedCallbacks());
+  return usePillarMutation<{ dryRun: boolean }, unknown>(
+    'cerebrum',
+    ['glia', 'runPruner'],
+    useSharedCallbacks()
+  );
 }
 
 function useConsolidatorMutation(): WorkerMutationState {
-  return trpc.cerebrum.glia.runConsolidator.useMutation(useSharedCallbacks());
+  return usePillarMutation<{ dryRun: boolean }, unknown>(
+    'cerebrum',
+    ['glia', 'runConsolidator'],
+    useSharedCallbacks()
+  );
 }
 
 function useLinkerMutation(): WorkerMutationState {
-  return trpc.cerebrum.glia.runLinker.useMutation(useSharedCallbacks());
+  return usePillarMutation<{ dryRun: boolean }, unknown>(
+    'cerebrum',
+    ['glia', 'runLinker'],
+    useSharedCallbacks()
+  );
 }
 
 function useAuditorMutation(): WorkerMutationState {
-  return trpc.cerebrum.glia.runAuditor.useMutation(useSharedCallbacks());
+  return usePillarMutation<{ dryRun: boolean }, unknown>(
+    'cerebrum',
+    ['glia', 'runAuditor'],
+    useSharedCallbacks()
+  );
 }
 
 interface WorkerRowProps {

--- a/packages/app-cerebrum/src/pages/ingest-page/submission-helpers.ts
+++ b/packages/app-cerebrum/src/pages/ingest-page/submission-helpers.ts
@@ -1,0 +1,106 @@
+import type { BulkSegment } from './bulk-paste';
+import type {
+  QuickCaptureMutation,
+  QuickCapturePayload,
+  QuickCaptureResponse,
+  SetBulkResults,
+  SubmitResponse,
+} from './submission-types';
+import type { BulkSegmentOutcome, IngestFormValues, SubmitResult } from './types';
+
+export function buildQuickCapturePayload(
+  form: IngestFormValues,
+  body: string = form.body
+): QuickCapturePayload {
+  return {
+    text: body,
+    source: 'manual',
+    scopes: form.scopes.length > 0 ? form.scopes : undefined,
+  };
+}
+
+export function asResult(r: QuickCaptureResponse): SubmitResult {
+  return { id: r.id, filePath: r.path, type: r.type };
+}
+
+export function toQuickCaptureShape(submitResponse: SubmitResponse): QuickCaptureResponse {
+  return {
+    id: submitResponse.engram.id,
+    path: submitResponse.engram.filePath,
+    type: submitResponse.engram.type,
+    scopes: [],
+  };
+}
+
+interface RunBulkArgs {
+  form: IngestFormValues;
+  segments: BulkSegment[];
+  mutateAsync: QuickCaptureMutation['mutateAsync'];
+  setBulkResults: SetBulkResults;
+  setBulkInFlight: (next: boolean) => void;
+}
+
+export async function runBulk(args: RunBulkArgs): Promise<void> {
+  const { form, segments, mutateAsync, setBulkResults, setBulkInFlight } = args;
+  setBulkInFlight(true);
+  setBulkResults(segments.map((s) => ({ index: s.index, preview: s.preview, body: s.body })));
+  for (const seg of segments) {
+    await runSegment({ form, segment: seg, mutateAsync, setBulkResults });
+  }
+  setBulkInFlight(false);
+}
+
+interface RunSegmentArgs {
+  form: IngestFormValues;
+  segment: BulkSegment;
+  mutateAsync: QuickCaptureMutation['mutateAsync'];
+  setBulkResults: SetBulkResults;
+}
+
+async function runSegment(args: RunSegmentArgs): Promise<void> {
+  const { form, segment, mutateAsync, setBulkResults } = args;
+  try {
+    const r = await mutateAsync(buildQuickCapturePayload(form, segment.body));
+    setBulkResults((prev) =>
+      prev ? prev.map((b) => (b.index === segment.index ? { ...b, result: asResult(r) } : b)) : null
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Capture failed';
+    setBulkResults((prev) =>
+      prev ? prev.map((b) => (b.index === segment.index ? { ...b, error: message } : b)) : null
+    );
+  }
+}
+
+interface RetrySegmentArgs {
+  segmentIndex: number;
+  formValues: IngestFormValues;
+  bulkResults: BulkSegmentOutcome[] | null;
+  mutateAsync: QuickCaptureMutation['mutateAsync'];
+  setBulkResults: SetBulkResults;
+}
+
+export async function retrySegmentImpl(args: RetrySegmentArgs): Promise<void> {
+  const { segmentIndex, formValues, bulkResults, mutateAsync, setBulkResults } = args;
+  const target = bulkResults?.find((b) => b.index === segmentIndex);
+  if (!target) return;
+  try {
+    const r = await mutateAsync(buildQuickCapturePayload(formValues, target.body));
+    setBulkResults((prev) =>
+      prev
+        ? prev.map((b) =>
+            b.index === segmentIndex ? { ...b, result: asResult(r), error: undefined } : b
+          )
+        : null
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Capture failed';
+    setBulkResults((prev) =>
+      prev
+        ? prev.map((b) =>
+            b.index === segmentIndex ? { ...b, error: message, result: undefined } : b
+          )
+        : null
+    );
+  }
+}

--- a/packages/app-cerebrum/src/pages/ingest-page/submission-types.ts
+++ b/packages/app-cerebrum/src/pages/ingest-page/submission-types.ts
@@ -1,0 +1,40 @@
+import type { UsePillarMutationResult } from '@pops/pillar-sdk/react';
+
+import type { BulkSegmentOutcome } from './types';
+
+export interface QuickCapturePayload {
+  text: string;
+  source: 'manual';
+  scopes?: string[];
+}
+
+export interface QuickCaptureResponse {
+  id: string;
+  path: string;
+  type: string;
+  scopes: string[];
+}
+
+export interface SubmitPayload {
+  body: string;
+  title?: string;
+  type?: string;
+  scopes?: string[];
+  tags?: string[];
+  template?: string;
+  source: 'manual';
+  customFields?: Record<string, unknown>;
+}
+
+export interface SubmitResponse {
+  engram: { id: string; filePath: string; type: string };
+}
+
+export type QuickCaptureMutation = UsePillarMutationResult<
+  QuickCapturePayload,
+  QuickCaptureResponse
+>;
+export type SubmitMutation = UsePillarMutationResult<SubmitPayload, SubmitResponse>;
+export type SetBulkResults = (
+  next: BulkSegmentOutcome[] | ((prev: BulkSegmentOutcome[] | null) => BulkSegmentOutcome[] | null)
+) => void;

--- a/packages/app-cerebrum/src/pages/ingest-page/useSubmission.ts
+++ b/packages/app-cerebrum/src/pages/ingest-page/useSubmission.ts
@@ -11,20 +11,31 @@
 import { useCallback, useState } from 'react';
 import { toast } from 'sonner';
 
-import { trpc } from '@pops/api-client';
+import { usePillarMutation } from '@pops/pillar-sdk/react';
 
-import type { BulkSegment } from './bulk-paste';
+import {
+  asResult,
+  buildQuickCapturePayload,
+  retrySegmentImpl,
+  runBulk,
+  toQuickCaptureShape,
+} from './submission-helpers';
+
+import type {
+  QuickCaptureMutation,
+  QuickCapturePayload,
+  QuickCaptureResponse,
+  SetBulkResults,
+  SubmitMutation,
+  SubmitPayload,
+  SubmitResponse,
+} from './submission-types';
 import type { BulkSegmentOutcome, IngestFormValues, SubmitResult } from './types';
 import type { useFormState } from './useFormState';
 
 type FormState = ReturnType<typeof useFormState>;
-type QuickCaptureMutation = ReturnType<typeof trpc.cerebrum.ingest.quickCapture.useMutation>;
-type QuickCaptureResponse = Awaited<ReturnType<QuickCaptureMutation['mutateAsync']>>;
-type SetBulkResults = (
-  next: BulkSegmentOutcome[] | ((prev: BulkSegmentOutcome[] | null) => BulkSegmentOutcome[] | null)
-) => void;
 
-function buildSubmitPayload(form: IngestFormValues) {
+function buildSubmitPayload(form: IngestFormValues): SubmitPayload {
   return {
     body: form.body,
     title: form.title || undefined,
@@ -32,21 +43,28 @@ function buildSubmitPayload(form: IngestFormValues) {
     scopes: form.scopes.length > 0 ? form.scopes : undefined,
     tags: form.tags.length > 0 ? form.tags : undefined,
     template: form.template || undefined,
-    source: 'manual' as const,
+    source: 'manual',
     customFields: Object.keys(form.customFields).length > 0 ? form.customFields : undefined,
   };
 }
 
-function buildQuickCapturePayload(form: IngestFormValues, body: string = form.body) {
-  return {
-    text: body,
-    source: 'manual' as const,
-    scopes: form.scopes.length > 0 ? form.scopes : undefined,
-  };
-}
-
-function asResult(r: QuickCaptureResponse): SubmitResult {
-  return { id: r.id, filePath: r.path, type: r.type };
+function useIngestMutations(setSubmitResult: (next: SubmitResult | null) => void) {
+  const submitMutation = usePillarMutation<SubmitPayload, SubmitResponse>(
+    'cerebrum',
+    ['ingest', 'submit'],
+    {
+      onSuccess: (result) => setSubmitResult(asResult(toQuickCaptureShape(result))),
+      onError: (error) => toast.error('Submit Engram failed', { description: error.message }),
+    }
+  );
+  const quickCaptureMutation = usePillarMutation<QuickCapturePayload, QuickCaptureResponse>(
+    'cerebrum',
+    ['ingest', 'quickCapture'],
+    {
+      onError: (error) => toast.error('Capture failed', { description: error.message }),
+    }
+  );
+  return { submitMutation, quickCaptureMutation };
 }
 
 export function useSubmission(formState: FormState) {
@@ -54,14 +72,7 @@ export function useSubmission(formState: FormState) {
   const [bulkResults, setBulkResults] = useState<BulkSegmentOutcome[] | null>(null);
   const [bulkInFlight, setBulkInFlight] = useState(false);
 
-  const submitMutation = trpc.cerebrum.ingest.submit.useMutation({
-    onSuccess: (result) => setSubmitResult(asResult(toQuickCaptureShape(result))),
-    onError: (error) => toast.error('Submit Engram failed', { description: error.message }),
-  });
-
-  const quickCaptureMutation = trpc.cerebrum.ingest.quickCapture.useMutation({
-    onError: (error) => toast.error('Capture failed', { description: error.message }),
-  });
+  const { submitMutation, quickCaptureMutation } = useIngestMutations(setSubmitResult);
 
   const handleSubmit = useCallback(
     (options?: { forceBulk?: boolean }) => {
@@ -110,25 +121,9 @@ export function useSubmission(formState: FormState) {
   };
 }
 
-/**
- * The submit endpoint returns `{ engram: { id, filePath, type }, ... }` while
- * quickCapture returns `{ id, path, type, scopes }`. Normalise to the latter
- * so `asResult` is the single shape converter.
- */
-function toQuickCaptureShape(submitResponse: {
-  engram: { id: string; filePath: string; type: string };
-}): QuickCaptureResponse {
-  return {
-    id: submitResponse.engram.id,
-    path: submitResponse.engram.filePath,
-    type: submitResponse.engram.type,
-    scopes: [],
-  };
-}
-
 interface DispatchArgs {
   formState: FormState;
-  submitMutation: ReturnType<typeof trpc.cerebrum.ingest.submit.useMutation>;
+  submitMutation: SubmitMutation;
   quickCaptureMutation: QuickCaptureMutation;
   forceBulk: boolean;
   setSubmitResult: (next: SubmitResult | null) => void;
@@ -155,77 +150,4 @@ async function dispatchSubmit(args: DispatchArgs): Promise<void> {
   }
   const r = await quickCaptureMutation.mutateAsync(buildQuickCapturePayload(form));
   args.setSubmitResult(asResult(r));
-}
-
-interface RunBulkArgs {
-  form: IngestFormValues;
-  segments: BulkSegment[];
-  mutateAsync: QuickCaptureMutation['mutateAsync'];
-  setBulkResults: SetBulkResults;
-  setBulkInFlight: (next: boolean) => void;
-}
-
-async function runBulk(args: RunBulkArgs): Promise<void> {
-  const { form, segments, mutateAsync, setBulkResults, setBulkInFlight } = args;
-  setBulkInFlight(true);
-  setBulkResults(segments.map((s) => ({ index: s.index, preview: s.preview, body: s.body })));
-  for (const seg of segments) {
-    await runSegment({ form, segment: seg, mutateAsync, setBulkResults });
-  }
-  setBulkInFlight(false);
-}
-
-interface RunSegmentArgs {
-  form: IngestFormValues;
-  segment: BulkSegment;
-  mutateAsync: QuickCaptureMutation['mutateAsync'];
-  setBulkResults: SetBulkResults;
-}
-
-async function runSegment(args: RunSegmentArgs): Promise<void> {
-  const { form, segment, mutateAsync, setBulkResults } = args;
-  try {
-    const r = await mutateAsync(buildQuickCapturePayload(form, segment.body));
-    setBulkResults((prev) =>
-      prev ? prev.map((b) => (b.index === segment.index ? { ...b, result: asResult(r) } : b)) : null
-    );
-  } catch (err) {
-    const message = err instanceof Error ? err.message : 'Capture failed';
-    setBulkResults((prev) =>
-      prev ? prev.map((b) => (b.index === segment.index ? { ...b, error: message } : b)) : null
-    );
-  }
-}
-
-interface RetrySegmentArgs {
-  segmentIndex: number;
-  formValues: IngestFormValues;
-  bulkResults: BulkSegmentOutcome[] | null;
-  mutateAsync: QuickCaptureMutation['mutateAsync'];
-  setBulkResults: SetBulkResults;
-}
-
-async function retrySegmentImpl(args: RetrySegmentArgs): Promise<void> {
-  const { segmentIndex, formValues, bulkResults, mutateAsync, setBulkResults } = args;
-  const target = bulkResults?.find((b) => b.index === segmentIndex);
-  if (!target) return;
-  try {
-    const r = await mutateAsync(buildQuickCapturePayload(formValues, target.body));
-    setBulkResults((prev) =>
-      prev
-        ? prev.map((b) =>
-            b.index === segmentIndex ? { ...b, result: asResult(r), error: undefined } : b
-          )
-        : null
-    );
-  } catch (err) {
-    const message = err instanceof Error ? err.message : 'Capture failed';
-    setBulkResults((prev) =>
-      prev
-        ? prev.map((b) =>
-            b.index === segmentIndex ? { ...b, error: message, result: undefined } : b
-          )
-        : null
-    );
-  }
 }

--- a/packages/app-cerebrum/src/pages/ingest-page/useTemplateAndScopeData.ts
+++ b/packages/app-cerebrum/src/pages/ingest-page/useTemplateAndScopeData.ts
@@ -4,7 +4,7 @@
  */
 import { useMemo, useRef } from 'react';
 
-import { trpc } from '@pops/api-client';
+import { usePillarQuery } from '@pops/pillar-sdk/react';
 
 import { ENGRAM_TYPE_LABELS, ENGRAM_TYPES } from './types';
 
@@ -16,9 +16,17 @@ const TYPE_OPTIONS = ENGRAM_TYPES.map((typeName) => ({
 }));
 
 export function useTemplateAndScopeData() {
-  const templatesQuery = trpc.cerebrum.templates.list.useQuery();
-  const scopesQuery = trpc.cerebrum.scopes.list.useQuery();
-  const tagsQuery = trpc.cerebrum.tags.list.useQuery();
+  const templatesQuery = usePillarQuery<{ templates: TemplateSummary[] }>(
+    'cerebrum',
+    ['templates', 'list'],
+    undefined
+  );
+  const scopesQuery = usePillarQuery<{ scopes: ScopeEntry[] }>(
+    'cerebrum',
+    ['scopes', 'list'],
+    undefined
+  );
+  const tagsQuery = usePillarQuery<{ tags: TagEntry[] }>('cerebrum', ['tags', 'list'], undefined);
 
   const templatesRef = useRef<TemplateSummary[]>([]);
   const rawTemplates = templatesQuery.data?.templates;

--- a/packages/app-cerebrum/src/query/mutations.ts
+++ b/packages/app-cerebrum/src/query/mutations.ts
@@ -11,7 +11,7 @@ import { useCallback, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 
-import { trpc } from '@pops/api-client';
+import { usePillarMutation } from '@pops/pillar-sdk/react';
 
 import { extractMessage } from '../utils/errors';
 import { streamQuery } from './query-stream-client';
@@ -180,15 +180,19 @@ interface SaveResult {
 
 export function useSaveDocumentMutation(unknownErrorMessage: string) {
   const { t } = useTranslation('cerebrum');
-  return trpc.cerebrum.emit.generate.useMutation({
-    onSuccess: (result: SaveResult | undefined) => {
-      const title = result?.document?.title;
-      if (title) {
-        toast.success(t('query.saveDocument.success', { title }));
-        return;
-      }
-      toast.success(result?.notice ?? t('query.saveDocument.empty'));
-    },
-    onError: (err: unknown) => toast.error(extractMessage(err, unknownErrorMessage)),
-  });
+  return usePillarMutation<SaveDocumentRequest, SaveResult | undefined>(
+    'cerebrum',
+    ['emit', 'generate'],
+    {
+      onSuccess: (result) => {
+        const title = result?.document?.title;
+        if (title) {
+          toast.success(t('query.saveDocument.success', { title }));
+          return;
+        }
+        toast.success(result?.notice ?? t('query.saveDocument.empty'));
+      },
+      onError: (err) => toast.error(extractMessage(err, unknownErrorMessage)),
+    }
+  );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1038,15 +1038,15 @@ importers:
 
   packages/app-cerebrum:
     dependencies:
-      '@pops/api-client':
-        specifier: workspace:*
-        version: link:../api-client
       '@pops/navigation':
         specifier: workspace:*
         version: link:../navigation
       '@pops/overlay-ego':
         specifier: workspace:*
         version: link:../overlay-ego
+      '@pops/pillar-sdk':
+        specifier: workspace:*
+        version: link:../pillar-sdk
       '@pops/types':
         specifier: workspace:*
         version: link:../types


### PR DESCRIPTION
## Summary

- Migrated all **45 trpc.cerebrum.\* call sites** across 17 source files in `packages/app-cerebrum` to the equivalent `@pops/pillar-sdk` hooks (`usePillarQuery` / `usePillarMutation` / `usePillarUtils`), mirroring the app-inventory pattern (PRs #3112, #3118, #3142).
- Dropped `@pops/api-client` from `packages/app-cerebrum/package.json`; the package now consumes the pillar SDK only.
- Updated the 9 vitest mocks to target `@pops/pillar-sdk/react` (and `@pops/pillar-sdk/client` for `PillarCallError`) instead of `@pops/api-client`.
- Added a thin `src/lib/pillar-call.ts` helper that mirrors `apps/app-inventory/src/lib/pillar-call.ts`, used for the one imperative `utils.cerebrum.emit.preview.fetch` site in `useDocumentsModel`.

The audit in `docs/themes/13-pillar-finale/notes/app-cerebrum-consumer-inventory.md` confirmed all 45 sites are trivial: single-pillar `cerebrum.*` calls, zero cross-pillar usage, zero optimistic updates, zero infinite/suspense queries. The migration is mechanical.

### Routers covered
`engrams`, `retrieval`, `scopes`, `tags`, `templates`, `ingest`, `emit`, `glia` (actions / trustState / runPruner / runConsolidator / runLinker / runAuditor), `nudges`, `plexus.adapters`, `plexus.filters`, `reflex`.

### Notable behavioural notes
- Explicit `useUtils().invalidate()` calls were dropped where the SDK's built-in router-prefix auto-invalidation covers the same scope (e.g. plexus mutations invalidate the full `plexus.adapters` prefix on success). The two sites that needed a wider invalidation (engram detail save → invalidate all `engrams`; enrichment status polling → invalidate `ingest.enrichmentStatus`) use `usePillarUtils('cerebrum').invalidate(routerPath)`.
- The legacy `isNotFound(err)` check in `useEngramDetailModel` now branches on `err instanceof PillarCallError && err.result.kind === 'contract-mismatch'` first, and falls back to the old `data?.code === 'NOT_FOUND'` shape for compatibility with the test mocks.

## Test plan

- [x] `pnpm --filter @pops/app-cerebrum typecheck` clean
- [x] `pnpm --filter @pops/app-cerebrum test` — all 151 tests pass
- [x] `pnpm --filter @pops/shell typecheck` clean (downstream consumer)
- [x] `pnpm --filter @pops/shell test` — all 451 tests pass
- [x] `pnpm typecheck` (repo-wide, 68 tasks) green
- [x] `pnpm exec oxlint packages/app-cerebrum/src/` clean
- [x] `pnpm exec oxfmt --check packages/app-cerebrum/src/` clean