### PR TITLE
fix(docker): include @pops/wire-conformance in core-api deploy context (unblocks #3152)

### DIFF
--- a/apps/pops-core-api/Dockerfile
+++ b/apps/pops-core-api/Dockerfile
@@ -4,12 +4,17 @@ WORKDIR /app
 # Copy workspace root files
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json .oxfmtrc.json ./
 
-# Copy workspace package.json files (for dep resolution)
+# Copy workspace package.json files (for dep resolution).
+# wire-conformance is included even though @pops/core-api does not depend on
+# it: pnpm's --legacy deploy resolves the full workspace graph from
+# pnpm-workspace.yaml and fails ERR_PNPM_WORKSPACE_PKG_NOT_FOUND when a
+# listed member is absent from the build context.
 COPY packages/db-types/package.json ./packages/db-types/
 COPY packages/types/package.json ./packages/types/
 COPY packages/core-db/package.json ./packages/core-db/
 COPY packages/finance-contract/package.json ./packages/finance-contract/
 COPY packages/pillar-sdk/package.json ./packages/pillar-sdk/
+COPY packages/wire-conformance/package.json ./packages/wire-conformance/
 COPY apps/pops-core-api/package.json ./apps/pops-core-api/
 
 # Install pnpm and all workspace dependencies


### PR DESCRIPTION
## Summary

- CI job `Validate Docker builds` fails on PR #3152 with `ERR_PNPM_WORKSPACE_PKG_NOT_FOUND` for `@pops/wire-conformance` during `pnpm --filter @pops/core-api deploy --prod --legacy /app/deploy`.
- `@pops/core-api` does not depend on `@pops/wire-conformance`, but pnpm's `--legacy` deploy resolver walks every workspace member declared in `pnpm-workspace.yaml`. When a listed member's `package.json` is absent from the Docker build context, the resolver aborts.
- Fix: copy `packages/wire-conformance/package.json` into the core-api Docker build context. No core-api source change.

## Why a separate PR

#3152 is open and the bridge agent may still iterate on it. A tiny chained fix PR keeps the bridge branch untouched and lets reviewers see the docker delta in isolation.

## Test plan

- [x] `docker build --no-cache --target builder -f apps/pops-core-api/Dockerfile .` succeeds locally.
- [x] `pnpm --filter @pops/core-api typecheck` passes.
- [ ] CI `Validate Docker builds` green on this PR.