### PR TITLE
feat(app-media): migrate batch 3 tRPC sites to pillar SDK (11 files · 26 sites · PRD-227)

### DIFF
--- a/packages/app-media/src/pages/CalendarPage.test.tsx
+++ b/packages/app-media/src/pages/CalendarPage.test.tsx
@@ -5,18 +5,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mockGetConfigQuery = vi.fn();
 const mockGetCalendarQuery = vi.fn();
 
-vi.mock('@pops/api-client', () => ({
-  trpc: {
-    media: {
-      arr: {
-        getConfig: {
-          useQuery: () => mockGetConfigQuery(),
-        },
-        getCalendar: {
-          useQuery: (_input: unknown, _opts: unknown) => mockGetCalendarQuery(),
-        },
-      },
-    },
+vi.mock('@pops/pillar-sdk/react', () => ({
+  usePillarQuery: (_pillarId: string, path: readonly string[]) => {
+    const key = path.join('.');
+    if (key === 'arr.getConfig') return mockGetConfigQuery();
+    if (key === 'arr.getCalendar') return mockGetCalendarQuery();
+    return { data: undefined, isLoading: false };
   },
 }));
 

--- a/packages/app-media/src/pages/CalendarPage.tsx
+++ b/packages/app-media/src/pages/CalendarPage.tsx
@@ -2,7 +2,7 @@ import { Calendar } from 'lucide-react';
 import { useMemo } from 'react';
 import { Link } from 'react-router';
 
-import { trpc } from '@pops/api-client';
+import { usePillarQuery } from '@pops/pillar-sdk/react';
 /**
  * CalendarPage — upcoming episodes calendar from Sonarr.
  */
@@ -66,8 +66,20 @@ interface CalendarEpisode {
   posterUrl: string | null;
 }
 
+interface ArrConfigResult {
+  data: { sonarrConfigured: boolean; radarrConfigured: boolean };
+}
+
+interface CalendarResult {
+  data: CalendarEpisode[];
+}
+
 function useCalendarPageModel() {
-  const { data: configData } = trpc.media.arr.getConfig.useQuery();
+  const { data: configData } = usePillarQuery<ArrConfigResult>(
+    'media',
+    ['arr', 'getConfig'],
+    undefined
+  );
   const config = configData?.data;
 
   const now = new Date();
@@ -78,7 +90,9 @@ function useCalendarPageModel() {
     data: calendarData,
     isLoading,
     error,
-  } = trpc.media.arr.getCalendar.useQuery(
+  } = usePillarQuery<CalendarResult>(
+    'media',
+    ['arr', 'getCalendar'],
     { start, end },
     {
       enabled: config?.sonarrConfigured === true,

--- a/packages/app-media/src/pages/ComparisonHistoryPage.test.tsx
+++ b/packages/app-media/src/pages/ComparisonHistoryPage.test.tsx
@@ -19,50 +19,42 @@ vi.mock('sonner', () => ({
   }),
 }));
 
-// Mock trpc
+// Mock pillar SDK
 const mockListAllQuery = vi.fn();
 const mockDimensionsQuery = vi.fn();
 const mockMovieGetQuery = vi.fn();
 const mockDeleteMutate = vi.fn();
-const mockInvalidateListAll = vi.fn();
-const mockInvalidateScores = vi.fn();
-const mockInvalidateRankings = vi.fn();
+const mockInvalidateComparisons = vi.fn();
 const mockRefetch = vi.fn();
 let deleteMutationOpts: Record<string, (...args: unknown[]) => unknown> = {};
 
-vi.mock('@pops/api-client', () => ({
-  trpc: {
-    media: {
-      comparisons: {
-        listAll: {
-          useQuery: (...args: unknown[]) => mockListAllQuery(...args),
-        },
-        listDimensions: {
-          useQuery: (...args: unknown[]) => mockDimensionsQuery(...args),
-        },
-        delete: {
-          useMutation: (opts: Record<string, (...args: unknown[]) => unknown>) => {
-            deleteMutationOpts = opts;
-            return { mutate: mockDeleteMutate, isPending: false };
-          },
-        },
-      },
-      movies: {
-        get: {
-          useQuery: (...args: unknown[]) => mockMovieGetQuery(...args),
-        },
-      },
-    },
-    useUtils: () => ({
-      media: {
-        comparisons: {
-          listAll: { invalidate: mockInvalidateListAll },
-          scores: { invalidate: mockInvalidateScores },
-          rankings: { invalidate: mockInvalidateRankings },
-        },
-      },
-    }),
+vi.mock('@pops/pillar-sdk/react', () => ({
+  usePillarQuery: (_pillarId: string, path: readonly string[], input: unknown) => {
+    const key = path.join('.');
+    if (key === 'comparisons.listAll') return mockListAllQuery(input);
+    if (key === 'comparisons.listDimensions') return mockDimensionsQuery(input);
+    if (key === 'movies.get') return mockMovieGetQuery(input);
+    return { data: undefined, isLoading: false };
   },
+  usePillarMutation: (
+    _pillarId: string,
+    path: readonly string[],
+    opts: Record<string, (...args: unknown[]) => unknown>
+  ) => {
+    const key = path.join('.');
+    if (key === 'comparisons.delete') {
+      deleteMutationOpts = opts;
+      return { mutate: mockDeleteMutate, isPending: false };
+    }
+    return { mutate: vi.fn(), isPending: false };
+  },
+  usePillarUtils: () => ({
+    setData: vi.fn(),
+    invalidate: (path?: readonly string[]) => {
+      const key = path?.join('.') ?? '';
+      if (key === 'comparisons') mockInvalidateComparisons();
+    },
+  }),
 }));
 
 const DIMENSION = { id: 1, name: 'Overall' };
@@ -244,9 +236,7 @@ describe('ComparisonHistoryPage', () => {
       deleteMutationOpts.onSuccess?.(undefined, { id: COMPARISON.id });
     });
 
-    expect(mockInvalidateListAll).toHaveBeenCalled();
-    expect(mockInvalidateScores).toHaveBeenCalled();
-    expect(mockInvalidateRankings).toHaveBeenCalled();
+    expect(mockInvalidateComparisons).toHaveBeenCalled();
   });
 
   it('filters by dimension', () => {

--- a/packages/app-media/src/pages/ComparisonHistoryPage.tsx
+++ b/packages/app-media/src/pages/ComparisonHistoryPage.tsx
@@ -143,9 +143,7 @@ export function ComparisonHistoryPage() {
   const model = useComparisonHistoryModel(renderUndoToast);
 
   const allComparisons = model.data?.data ?? [];
-  const comparisons = allComparisons.filter(
-    (c: { id: number }) => !model.pendingDeletes.has(c.id)
-  ) as (ComparisonRowData & { dimensionId: number })[];
+  const comparisons = allComparisons.filter((c) => !model.pendingDeletes.has(c.id));
 
   const dimensionOptions = [
     { label: 'All dimensions', value: '' },

--- a/packages/app-media/src/pages/DebriefPage.test.tsx
+++ b/packages/app-media/src/pages/DebriefPage.test.tsx
@@ -37,93 +37,60 @@ const mockInvalidatePending = vi.fn();
 const mockInvalidateWatchlist = vi.fn();
 
 vi.mock('@pops/pillar-sdk/react', () => ({
-  usePillarQuery: () => ({ data: undefined, isLoading: false, error: null }),
+  usePillarQuery: (_pillarId: string, path: readonly string[], input: unknown) => {
+    const key = path.join('.');
+    if (key === 'comparisons.getDebrief') {
+      const result = mockDebriefQuery(input);
+      return { ...result, refetch: vi.fn() };
+    }
+    if (key === 'comparisons.listForMedia') return mockListForMediaQuery(input);
+    if (key === 'watchlist.list') return mockWatchlistQuery(input);
+    return { data: undefined, isLoading: false, error: null };
+  },
   usePillarMutation: (
     _pillarId: string,
     path: readonly string[],
     opts?: Record<string, unknown>
   ) => {
-    if (path.join('.') === 'comparisons.dismissDebriefDimension') {
+    const key = path.join('.');
+    if (key === 'comparisons.recordDebriefComparison') {
+      mockRecordMutate._opts = opts;
+      return { mutate: mockRecordMutate, isPending: false };
+    }
+    if (key === 'comparisons.dismissDebriefDimension') {
       mockDismissMutate._opts = opts;
       return { mutate: mockDismissMutate, isPending: false };
     }
+    if (key === 'comparisons.markStale') {
+      mockMarkStaleMutate._opts = opts;
+      return { mutate: mockMarkStaleMutate, isPending: false };
+    }
+    if (key === 'comparisons.excludeFromDimension') {
+      return { mutate: mockExcludeMutate, isPending: false };
+    }
+    if (key === 'comparisons.blacklistMovie') {
+      mockBlacklistMutate._opts = opts;
+      return { mutate: mockBlacklistMutate, isPending: false };
+    }
+    if (key === 'watchlist.add') {
+      mockAddToWatchlistMutate._opts = opts;
+      return { mutate: mockAddToWatchlistMutate, isPending: false };
+    }
+    if (key === 'watchlist.remove') {
+      mockRemoveFromWatchlistMutate._opts = opts;
+      return { mutate: mockRemoveFromWatchlistMutate, isPending: false };
+    }
     return { mutate: vi.fn(), isPending: false };
   },
-}));
-
-vi.mock('@pops/api-client', () => ({
-  trpc: {
-    media: {
-      comparisons: {
-        getDebrief: {
-          useQuery: (...args: unknown[]) => {
-            const result = mockDebriefQuery(...args);
-            return { ...result, refetch: vi.fn() };
-          },
-        },
-        recordDebriefComparison: {
-          useMutation: (opts: Record<string, unknown>) => {
-            mockRecordMutate._opts = opts;
-            return { mutate: mockRecordMutate, isPending: false };
-          },
-        },
-        dismissDebriefDimension: {
-          useMutation: (opts: Record<string, unknown>) => {
-            mockDismissMutate._opts = opts;
-            return { mutate: mockDismissMutate, isPending: false };
-          },
-        },
-        markStale: {
-          useMutation: (opts: Record<string, unknown>) => {
-            mockMarkStaleMutate._opts = opts;
-            return { mutate: mockMarkStaleMutate, isPending: false };
-          },
-        },
-        excludeFromDimension: {
-          useMutation: () => {
-            return { mutate: mockExcludeMutate, isPending: false };
-          },
-        },
-        blacklistMovie: {
-          useMutation: (opts: Record<string, unknown>) => {
-            mockBlacklistMutate._opts = opts;
-            return { mutate: mockBlacklistMutate, isPending: false };
-          },
-        },
-        listForMedia: {
-          useQuery: (...args: unknown[]) => mockListForMediaQuery(...args),
-        },
-      },
-      watchlist: {
-        list: {
-          useQuery: (...args: unknown[]) => mockWatchlistQuery(...args),
-        },
-        add: {
-          useMutation: (opts: Record<string, unknown>) => {
-            mockAddToWatchlistMutate._opts = opts;
-            return { mutate: mockAddToWatchlistMutate, isPending: false };
-          },
-        },
-        remove: {
-          useMutation: (opts: Record<string, unknown>) => {
-            mockRemoveFromWatchlistMutate._opts = opts;
-            return { mutate: mockRemoveFromWatchlistMutate, isPending: false };
-          },
-        },
-      },
+  usePillarUtils: () => ({
+    setData: vi.fn(),
+    invalidate: (path?: readonly string[]) => {
+      const key = path?.join('.') ?? '';
+      if (key === 'comparisons.getDebrief') mockInvalidateDebrief();
+      if (key === 'comparisons.getPendingDebriefs') mockInvalidatePending();
+      if (key === 'watchlist') mockInvalidateWatchlist();
     },
-    useUtils: () => ({
-      media: {
-        comparisons: {
-          getDebrief: { invalidate: mockInvalidateDebrief },
-          getPendingDebriefs: { invalidate: mockInvalidatePending },
-        },
-        watchlist: {
-          list: { invalidate: mockInvalidateWatchlist },
-        },
-      },
-    }),
-  },
+  }),
 }));
 
 vi.mock('sonner', () => ({

--- a/packages/app-media/src/pages/HistoryPage.test.tsx
+++ b/packages/app-media/src/pages/HistoryPage.test.tsx
@@ -18,38 +18,36 @@ const mockGetPendingDebriefs = vi.fn();
 const mockDeleteMutate = vi.fn();
 let deleteMutationOpts: Record<string, (...args: unknown[]) => unknown> = {};
 let deleteMutationPending = false;
-const mockInvalidateListRecent = vi.fn();
-const mockInvalidateList = vi.fn();
+const mockInvalidateWatchHistory = vi.fn();
 const mockInvalidateWatchlist = vi.fn();
 
-vi.mock('@pops/api-client', () => ({
-  trpc: {
-    media: {
-      watchHistory: {
-        listRecent: { useQuery: (...args: unknown[]) => mockListRecentQuery(...args) },
-        delete: {
-          useMutation: (opts: Record<string, (...args: unknown[]) => unknown>) => {
-            deleteMutationOpts = opts;
-            return { mutate: mockDeleteMutate, isPending: deleteMutationPending };
-          },
-        },
-      },
-      comparisons: {
-        getPendingDebriefs: { useQuery: () => mockGetPendingDebriefs() },
-      },
-    },
-    useUtils: () => ({
-      media: {
-        watchHistory: {
-          listRecent: { invalidate: mockInvalidateListRecent },
-          list: { invalidate: mockInvalidateList },
-        },
-        watchlist: {
-          list: { invalidate: mockInvalidateWatchlist },
-        },
-      },
-    }),
+vi.mock('@pops/pillar-sdk/react', () => ({
+  usePillarQuery: (_pillarId: string, path: readonly string[], input: unknown) => {
+    const key = path.join('.');
+    if (key === 'watchHistory.listRecent') return mockListRecentQuery(input);
+    if (key === 'comparisons.getPendingDebriefs') return mockGetPendingDebriefs();
+    return { data: undefined, isLoading: false };
   },
+  usePillarMutation: (
+    _pillarId: string,
+    path: readonly string[],
+    opts: Record<string, (...args: unknown[]) => unknown>
+  ) => {
+    const key = path.join('.');
+    if (key === 'watchHistory.delete') {
+      deleteMutationOpts = opts;
+      return { mutate: mockDeleteMutate, isPending: deleteMutationPending };
+    }
+    return { mutate: vi.fn(), isPending: false };
+  },
+  usePillarUtils: () => ({
+    setData: vi.fn(),
+    invalidate: (path?: readonly string[]) => {
+      const key = path?.join('.') ?? '';
+      if (key === 'watchHistory') mockInvalidateWatchHistory();
+      if (key === 'watchlist') mockInvalidateWatchlist();
+    },
+  }),
 }));
 
 import { HistoryPage } from './HistoryPage';
@@ -238,8 +236,7 @@ describe('HistoryPage', () => {
     it('invalidates queries on success', () => {
       renderPage();
       deleteMutationOpts.onSuccess?.();
-      expect(mockInvalidateListRecent).toHaveBeenCalled();
-      expect(mockInvalidateList).toHaveBeenCalled();
+      expect(mockInvalidateWatchHistory).toHaveBeenCalled();
       expect(mockInvalidateWatchlist).toHaveBeenCalled();
     });
   });

--- a/packages/app-media/src/pages/RankingsPage.test.tsx
+++ b/packages/app-media/src/pages/RankingsPage.test.tsx
@@ -6,14 +6,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mockRankingsQuery = vi.fn();
 const mockDimensionsQuery = vi.fn();
 
-vi.mock('@pops/api-client', () => ({
-  trpc: {
-    media: {
-      comparisons: {
-        rankings: { useQuery: (...args: unknown[]) => mockRankingsQuery(...args) },
-        listDimensions: { useQuery: () => mockDimensionsQuery() },
-      },
-    },
+vi.mock('@pops/pillar-sdk/react', () => ({
+  usePillarQuery: (_pillarId: string, path: readonly string[], input: unknown) => {
+    const key = path.join('.');
+    if (key === 'comparisons.rankings') return mockRankingsQuery(input);
+    if (key === 'comparisons.listDimensions') return mockDimensionsQuery();
+    return { data: undefined, isLoading: false };
   },
 }));
 

--- a/packages/app-media/src/pages/RankingsPage.tsx
+++ b/packages/app-media/src/pages/RankingsPage.tsx
@@ -2,7 +2,7 @@ import { Trophy } from 'lucide-react';
 import { useCallback, useMemo } from 'react';
 import { useSearchParams } from 'react-router';
 
-import { trpc } from '@pops/api-client';
+import { usePillarQuery } from '@pops/pillar-sdk/react';
 /**
  * RankingsPage — leaderboard of media items ranked by Elo score.
  */
@@ -80,11 +80,14 @@ export function RankingsPage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const dimensionParam = searchParams.get('dimension') ?? 'overall';
 
-  const { data: dimensionsData, isLoading: dimsLoading } =
-    trpc.media.comparisons.listDimensions.useQuery();
+  const { data: dimensionsData, isLoading: dimsLoading } = usePillarQuery<{ data: Dimension[] }>(
+    'media',
+    ['comparisons', 'listDimensions'],
+    undefined
+  );
 
   const activeDimensions = useMemo<Dimension[]>(
-    () => (dimensionsData?.data ?? []).filter((d: Dimension) => d.active),
+    () => (dimensionsData?.data ?? []).filter((d) => d.active),
     [dimensionsData?.data]
   );
 

--- a/packages/app-media/src/pages/RotationLogPage.tsx
+++ b/packages/app-media/src/pages/RotationLogPage.tsx
@@ -2,7 +2,7 @@ import { ChevronLeft, ChevronRight, ScrollText } from 'lucide-react';
 import { useState } from 'react';
 import { Link } from 'react-router';
 
-import { trpc } from '@pops/api-client';
+import { usePillarQuery } from '@pops/pillar-sdk/react';
 /**
  * RotationLogPage — paginated history of rotation cycle events.
  *
@@ -84,18 +84,33 @@ function LogList({ isLoading, items }: { isLoading: boolean; items: LogEntryData
   );
 }
 
+interface RotationLogResult {
+  items: LogEntryData[];
+  total: number;
+}
+
+interface RotationLogStats {
+  totalRotated: number;
+  avgPerDay: number;
+  streak: number;
+}
+
 export function RotationLogPage() {
   const [page, setPage] = useState(0);
 
-  const { data, isLoading } = trpc.media.rotation.listRotationLog.useQuery({
-    limit: PAGE_SIZE,
-    offset: page * PAGE_SIZE,
-  });
+  const { data, isLoading } = usePillarQuery<RotationLogResult>(
+    'media',
+    ['rotation', 'listRotationLog'],
+    { limit: PAGE_SIZE, offset: page * PAGE_SIZE }
+  );
 
-  const { data: stats, isLoading: statsLoading } =
-    trpc.media.rotation.getRotationLogStats.useQuery();
+  const { data: stats, isLoading: statsLoading } = usePillarQuery<RotationLogStats>(
+    'media',
+    ['rotation', 'getRotationLogStats'],
+    undefined
+  );
 
-  const items = (data?.items ?? []) as LogEntryData[];
+  const items = data?.items ?? [];
   const totalPages = data ? Math.ceil(data.total / PAGE_SIZE) : 0;
 
   return (

--- a/packages/app-media/src/pages/comparison-history/MovieTitle.tsx
+++ b/packages/app-media/src/pages/comparison-history/MovieTitle.tsx
@@ -1,9 +1,13 @@
 import { Link } from 'react-router';
 
-import { trpc } from '@pops/api-client';
+import { usePillarQuery } from '@pops/pillar-sdk/react';
+
+interface MovieGetResult {
+  data: { title: string } | null;
+}
 
 export function MovieTitle({ mediaId, className }: { mediaId: number; className?: string }) {
-  const { data } = trpc.media.movies.get.useQuery({ id: mediaId });
+  const { data } = usePillarQuery<MovieGetResult>('media', ['movies', 'get'], { id: mediaId });
   const title = data?.data?.title ?? `Movie #${mediaId}`;
   return (
     <Link to={`/media/movies/${mediaId}`} className={className}>

--- a/packages/app-media/src/pages/comparison-history/useComparisonHistoryModel.ts
+++ b/packages/app-media/src/pages/comparison-history/useComparisonHistoryModel.ts
@@ -1,15 +1,36 @@
 import { useCallback, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
-import { trpc } from '@pops/api-client';
+import { usePillarMutation, usePillarQuery, usePillarUtils } from '@pops/pillar-sdk/react';
 import { useDebouncedValue } from '@pops/ui';
 
 import { UNDO_DELAY_MS } from './UndoToast';
 
+import type { ComparisonRowData } from './ComparisonRow';
+
 const PAGE_SIZE = 20;
 
+interface ComparisonRowWithDimension extends ComparisonRowData {
+  dimensionId: number;
+}
+
+interface ComparisonsListAllResult {
+  data: ComparisonRowWithDimension[];
+  pagination?: { total: number };
+}
+
+interface Dimension {
+  id: number;
+  name: string;
+  active: boolean;
+}
+
+interface DimensionsListResult {
+  data: Dimension[];
+}
+
 export interface UseComparisonHistoryModelReturn {
-  data: ReturnType<typeof trpc.media.comparisons.listAll.useQuery>['data'];
+  data: ComparisonsListAllResult | undefined;
   isLoading: boolean;
   page: number;
   setPage: React.Dispatch<React.SetStateAction<number>>;
@@ -18,24 +39,22 @@ export interface UseComparisonHistoryModelReturn {
   searchInput: string;
   setSearchInput: (v: string) => void;
   pendingDeletes: Set<number>;
-  dimensions: { id: number; name: string }[];
+  dimensions: Dimension[];
   totalPages: number;
   handleDelete: (id: number) => void;
   handleUndo: (id: number, toastId: string | number) => void;
 }
 
 function useDeleteMutation(setPendingDeletes: React.Dispatch<React.SetStateAction<Set<number>>>) {
-  const utils = trpc.useUtils();
-  return trpc.media.comparisons.delete.useMutation({
+  const utils = usePillarUtils('media');
+  return usePillarMutation<{ id: number }, unknown>('media', ['comparisons', 'delete'], {
     onSuccess: (_data, variables) => {
       setPendingDeletes((prev) => {
         const next = new Set(prev);
         next.delete(variables.id);
         return next;
       });
-      void utils.media.comparisons.listAll.invalidate();
-      void utils.media.comparisons.scores.invalidate();
-      void utils.media.comparisons.rankings.invalidate();
+      void utils.invalidate(['comparisons']);
     },
     onError: (_error, variables) => {
       setPendingDeletes((prev) => {
@@ -102,19 +121,27 @@ function useDeleteFlow(
 
 export function useComparisonHistoryModel(
   renderToast: (id: number, onUndo: (toastId: string | number) => void) => string | number
-) {
+): UseComparisonHistoryModelReturn {
   const filters = useFilters();
   const { pendingDeletes, handleDelete, handleUndo } = useDeleteFlow(renderToast);
 
-  const { data: dimensionsData } = trpc.media.comparisons.listDimensions.useQuery();
+  const { data: dimensionsData } = usePillarQuery<DimensionsListResult>(
+    'media',
+    ['comparisons', 'listDimensions'],
+    undefined
+  );
   const dimensions = dimensionsData?.data ?? [];
 
-  const { data, isLoading } = trpc.media.comparisons.listAll.useQuery({
-    dimensionId: filters.dimensionFilter ? Number(filters.dimensionFilter) : undefined,
-    search: filters.debouncedSearch.trim() || undefined,
-    limit: PAGE_SIZE,
-    offset: filters.page * PAGE_SIZE,
-  });
+  const { data, isLoading } = usePillarQuery<ComparisonsListAllResult>(
+    'media',
+    ['comparisons', 'listAll'],
+    {
+      dimensionId: filters.dimensionFilter ? Number(filters.dimensionFilter) : undefined,
+      search: filters.debouncedSearch.trim() || undefined,
+      limit: PAGE_SIZE,
+      offset: filters.page * PAGE_SIZE,
+    }
+  );
 
   const totalPages = data?.pagination ? Math.ceil(data.pagination.total / PAGE_SIZE) : 0;
 

--- a/packages/app-media/src/pages/debrief/useDebriefDestructiveActions.ts
+++ b/packages/app-media/src/pages/debrief/useDebriefDestructiveActions.ts
@@ -1,18 +1,37 @@
 import { useCallback, useState } from 'react';
 import { toast } from 'sonner';
 
-import { trpc } from '@pops/api-client';
+import { usePillarMutation, usePillarQuery, usePillarUtils } from '@pops/pillar-sdk/react';
 
 interface UseDebriefDestructiveActionsArgs {
-  movieId: number;
   currentDimensionId: number | null;
   resolveTitle: (id: number) => string;
 }
 
-/**
- * markStale, N/A exclude, and blacklist (Not Watched) mutations for the
- * Debrief flow. Returns mutation handlers and blacklist dialog state.
- */
+interface MarkStaleResult {
+  data: { staleness: number };
+}
+
+interface MarkStaleInput {
+  mediaType: 'movie';
+  mediaId: number;
+}
+
+interface ExcludeInput {
+  mediaType: 'movie';
+  mediaId: number;
+  dimensionId: number;
+}
+
+interface BlacklistInput {
+  mediaType: 'movie';
+  mediaId: number;
+}
+
+interface ComparisonsListResult {
+  pagination?: { total: number };
+}
+
 function useStaleAndExclude({
   invalidateDebrief,
   resolveTitle,
@@ -22,14 +41,18 @@ function useStaleAndExclude({
   resolveTitle: (id: number) => string;
   currentDimensionId: number | null;
 }) {
-  const markStaleMutation = trpc.media.comparisons.markStale.useMutation({
-    onSuccess: (data: { data: { staleness: number } }, variables: { mediaId: number }) => {
-      const staleness = data.data.staleness;
-      const timesMarked = Math.round(Math.log(staleness) / Math.log(0.5));
-      toast.success(`${resolveTitle(variables.mediaId)} marked stale (×${timesMarked})`);
-      invalidateDebrief();
-    },
-  });
+  const markStaleMutation = usePillarMutation<MarkStaleInput, MarkStaleResult>(
+    'media',
+    ['comparisons', 'markStale'],
+    {
+      onSuccess: (data, variables) => {
+        const staleness = data.data.staleness;
+        const timesMarked = Math.round(Math.log(staleness) / Math.log(0.5));
+        toast.success(`${resolveTitle(variables.mediaId)} marked stale (×${timesMarked})`);
+        invalidateDebrief();
+      },
+    }
+  );
 
   const handleMarkStale = useCallback(
     (id: number) => {
@@ -39,7 +62,10 @@ function useStaleAndExclude({
     [markStaleMutation]
   );
 
-  const excludeMutation = trpc.media.comparisons.excludeFromDimension.useMutation();
+  const excludeMutation = usePillarMutation<ExcludeInput, unknown>('media', [
+    'comparisons',
+    'excludeFromDimension',
+  ]);
 
   const handleNA = useCallback(
     (id: number) => {
@@ -71,19 +97,25 @@ function useBlacklistFlow({
     null
   );
 
-  const { data: blacklistComparisonData } = trpc.media.comparisons.listForMedia.useQuery(
+  const { data: blacklistComparisonData } = usePillarQuery<ComparisonsListResult>(
+    'media',
+    ['comparisons', 'listForMedia'],
     { mediaType: 'movie', mediaId: blacklistTarget?.id ?? 0, limit: 1 },
     { enabled: blacklistTarget !== null }
   );
   const comparisonsToPurge = blacklistComparisonData?.pagination?.total ?? null;
 
-  const blacklistMutation = trpc.media.comparisons.blacklistMovie.useMutation({
-    onSuccess: (_data, variables) => {
-      toast.success(`${resolveTitle(variables.mediaId)} marked as not watched`);
-      setBlacklistTarget(null);
-      invalidateDebrief();
-    },
-  });
+  const blacklistMutation = usePillarMutation<BlacklistInput, unknown>(
+    'media',
+    ['comparisons', 'blacklistMovie'],
+    {
+      onSuccess: (_data, variables) => {
+        toast.success(`${resolveTitle(variables.mediaId)} marked as not watched`);
+        setBlacklistTarget(null);
+        invalidateDebrief();
+      },
+    }
+  );
 
   const openBlacklist = useCallback((movie: { id: number; title: string }) => {
     setBlacklistTarget(movie);
@@ -105,15 +137,14 @@ function useBlacklistFlow({
 }
 
 export function useDebriefDestructiveActions({
-  movieId,
   currentDimensionId,
   resolveTitle,
 }: UseDebriefDestructiveActionsArgs) {
-  const utils = trpc.useUtils();
+  const utils = usePillarUtils('media');
 
   const invalidateDebrief = useCallback(() => {
-    void utils.media.comparisons.getDebrief.invalidate({ mediaType: 'movie', mediaId: movieId });
-  }, [utils, movieId]);
+    void utils.invalidate(['comparisons', 'getDebrief']);
+  }, [utils]);
 
   const stale = useStaleAndExclude({ invalidateDebrief, resolveTitle, currentDimensionId });
   const blacklist = useBlacklistFlow({ invalidateDebrief, resolveTitle });

--- a/packages/app-media/src/pages/debrief/useDebriefPageModel.ts
+++ b/packages/app-media/src/pages/debrief/useDebriefPageModel.ts
@@ -2,7 +2,7 @@ import { useCallback } from 'react';
 import { useNavigate } from 'react-router';
 import { toast } from 'sonner';
 
-import { trpc } from '@pops/api-client';
+import { usePillarMutation, usePillarQuery, usePillarUtils } from '@pops/pillar-sdk/react';
 
 import { useDebriefDestructiveActions } from './useDebriefDestructiveActions';
 import { useDebriefWatchlist } from './useDebriefWatchlist';
@@ -16,6 +16,14 @@ interface DebriefRecordVars {
   opponentId: number;
   winnerId: number;
   drawTier?: 'high' | 'mid' | 'low';
+}
+
+interface RecordResult {
+  data: { sessionComplete: boolean };
+}
+
+interface GetDebriefResult {
+  data: Debrief | undefined;
 }
 
 function useRecordHandlers({
@@ -60,13 +68,15 @@ function useRecordHandlers({
 }
 
 function useDebriefData(movieId: number) {
-  const utils = trpc.useUtils();
+  const utils = usePillarUtils('media');
   const {
     data: debriefData,
     isLoading,
     error,
     refetch,
-  } = trpc.media.comparisons.getDebrief.useQuery(
+  } = usePillarQuery<GetDebriefResult>(
+    'media',
+    ['comparisons', 'getDebrief'],
     { mediaType: 'movie', mediaId: movieId },
     { enabled: !Number.isNaN(movieId) && movieId > 0 }
   );
@@ -76,14 +86,18 @@ function useDebriefData(movieId: number) {
   const allComplete = debrief ? pendingDimensions.length === 0 : false;
   const currentDimension = pendingDimensions[0] ?? null;
 
-  const recordMutation = trpc.media.comparisons.recordDebriefComparison.useMutation({
-    onSuccess: (result) => {
-      toast.success(result.data.sessionComplete ? 'Debrief complete!' : 'Comparison recorded');
-      void utils.media.comparisons.getDebrief.invalidate({ mediaType: 'movie', mediaId: movieId });
-      void utils.media.comparisons.getPendingDebriefs.invalidate();
-    },
-    onError: (err) => toast.error(err.message),
-  });
+  const recordMutation = usePillarMutation<DebriefRecordVars, RecordResult>(
+    'media',
+    ['comparisons', 'recordDebriefComparison'],
+    {
+      onSuccess: (result) => {
+        toast.success(result.data.sessionComplete ? 'Debrief complete!' : 'Comparison recorded');
+        void utils.invalidate(['comparisons', 'getDebrief']);
+        void utils.invalidate(['comparisons', 'getPendingDebriefs']);
+      },
+      onError: (err) => toast.error(err.message),
+    }
+  );
 
   return {
     utils,
@@ -114,7 +128,6 @@ export function useDebriefPageModel(movieId: number) {
 
   const watchlist = useDebriefWatchlist({ enabled: !!debrief, resolveTitle });
   const destructive = useDebriefDestructiveActions({
-    movieId,
     currentDimensionId: currentDimension?.dimensionId ?? null,
     resolveTitle,
   });
@@ -126,8 +139,8 @@ export function useDebriefPageModel(movieId: number) {
   });
 
   const handleDimensionSkipped = useCallback(() => {
-    void utils.media.comparisons.getDebrief.invalidate({ mediaType: 'movie', mediaId: movieId });
-  }, [utils, movieId]);
+    void utils.invalidate(['comparisons', 'getDebrief']);
+  }, [utils]);
 
   const handleDoAnother = useCallback(() => navigate('/media/compare'), [navigate]);
 

--- a/packages/app-media/src/pages/debrief/useDebriefWatchlist.ts
+++ b/packages/app-media/src/pages/debrief/useDebriefWatchlist.ts
@@ -1,47 +1,70 @@
 import { useCallback, useMemo } from 'react';
 import { toast } from 'sonner';
 
-import { trpc } from '@pops/api-client';
+import { usePillarMutation, usePillarQuery, usePillarUtils } from '@pops/pillar-sdk/react';
 
 interface UseDebriefWatchlistArgs {
   enabled: boolean;
   resolveTitle: (mediaId: number) => string;
 }
 
-export function useDebriefWatchlist({ enabled, resolveTitle }: UseDebriefWatchlistArgs) {
-  const utils = trpc.useUtils();
+interface WatchlistEntry {
+  id: number;
+  mediaType: string;
+  mediaId: number;
+}
 
-  const { data: watchlistData } = trpc.media.watchlist.list.useQuery(
+interface WatchlistListResult {
+  data: WatchlistEntry[];
+}
+
+interface AddInput {
+  mediaType: 'movie';
+  mediaId: number;
+}
+
+export function useDebriefWatchlist({ enabled, resolveTitle }: UseDebriefWatchlistArgs) {
+  const utils = usePillarUtils('media');
+
+  const { data: watchlistData } = usePillarQuery<WatchlistListResult>(
+    'media',
+    ['watchlist', 'list'],
     { mediaType: 'movie' },
     { enabled }
   );
 
   const watchlistedMovies = useMemo(
     () =>
-      new Map(
+      new Map<number, number>(
         (watchlistData?.data ?? [])
-          .filter((e: { mediaType: string }) => e.mediaType === 'movie')
-          .map((e: { mediaId: number; id: number }) => [e.mediaId, e.id])
+          .filter((e) => e.mediaType === 'movie')
+          .map((e) => [e.mediaId, e.id])
       ),
     [watchlistData]
   );
 
-  const addMutation = trpc.media.watchlist.add.useMutation({
+  const addMutation = usePillarMutation<AddInput, unknown>('media', ['watchlist', 'add'], {
     onSuccess: (_data, variables) => {
-      void utils.media.watchlist.list.invalidate();
+      void utils.invalidate(['watchlist']);
       toast.success(`${resolveTitle(variables.mediaId)} added to watchlist`);
     },
   });
 
-  const removeMutation = trpc.media.watchlist.remove.useMutation({
-    onSuccess: (_data, variables) => {
-      void utils.media.watchlist.list.invalidate();
-      const mediaId = [...watchlistedMovies.entries()].find(
-        ([, entryId]) => entryId === variables.id
-      )?.[0];
-      toast.success(`${mediaId != null ? resolveTitle(mediaId) : 'Movie'} removed from watchlist`);
-    },
-  });
+  const removeMutation = usePillarMutation<{ id: number }, unknown>(
+    'media',
+    ['watchlist', 'remove'],
+    {
+      onSuccess: (_data, variables) => {
+        void utils.invalidate(['watchlist']);
+        const mediaId = [...watchlistedMovies.entries()].find(
+          ([, entryId]) => entryId === variables.id
+        )?.[0];
+        toast.success(
+          `${mediaId != null ? resolveTitle(mediaId) : 'Movie'} removed from watchlist`
+        );
+      },
+    }
+  );
 
   const handleToggleWatchlist = useCallback(
     (mediaId: number) => {

--- a/packages/app-media/src/pages/history/useHistoryPageModel.ts
+++ b/packages/app-media/src/pages/history/useHistoryPageModel.ts
@@ -1,9 +1,23 @@
 import { useCallback, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 
-import { trpc } from '@pops/api-client';
+import { usePillarMutation, usePillarQuery, usePillarUtils } from '@pops/pillar-sdk/react';
 
-import { PAGE_SIZE, type MediaTypeFilter } from './types';
+import { PAGE_SIZE, type HistoryEntry, type MediaTypeFilter } from './types';
+
+interface WatchHistoryListResult {
+  data: HistoryEntry[];
+  pagination?: { total: number };
+}
+
+interface PendingDebriefEntry {
+  movieId: number;
+  sessionId: number;
+}
+
+interface PendingDebriefsResult {
+  data: PendingDebriefEntry[];
+}
 
 function useDeleteFlow({
   entriesLength,
@@ -14,23 +28,26 @@ function useDeleteFlow({
   offset: number;
   setOffset: React.Dispatch<React.SetStateAction<number>>;
 }) {
-  const utils = trpc.useUtils();
+  const utils = usePillarUtils('media');
   const [deleteTarget, setDeleteTarget] = useState<number | null>(null);
 
-  const deleteMutation = trpc.media.watchHistory.delete.useMutation({
-    onSuccess: () => {
-      toast.success('Watch event removed');
-      void utils.media.watchHistory.listRecent.invalidate();
-      void utils.media.watchHistory.list.invalidate();
-      void utils.media.watchlist.list.invalidate();
-      if (entriesLength === 1 && offset > 0) {
-        setOffset(Math.max(0, offset - PAGE_SIZE));
-      }
-    },
-    onError: (err) => {
-      toast.error(`Failed to delete watch event: ${err.message}`);
-    },
-  });
+  const deleteMutation = usePillarMutation<{ id: number }, unknown>(
+    'media',
+    ['watchHistory', 'delete'],
+    {
+      onSuccess: () => {
+        toast.success('Watch event removed');
+        void utils.invalidate(['watchHistory']);
+        void utils.invalidate(['watchlist']);
+        if (entriesLength === 1 && offset > 0) {
+          setOffset(Math.max(0, offset - PAGE_SIZE));
+        }
+      },
+      onError: (err) => {
+        toast.error(`Failed to delete watch event: ${err.message}`);
+      },
+    }
+  );
 
   const handleDeleteClick = useCallback((id: number) => setDeleteTarget(id), []);
   const handleDeleteConfirm = useCallback(() => {
@@ -52,8 +69,16 @@ export function useHistoryPageModel() {
     offset,
   };
 
-  const { data, isLoading, error } = trpc.media.watchHistory.listRecent.useQuery(queryInput);
-  const { data: pendingDebriefs } = trpc.media.comparisons.getPendingDebriefs.useQuery();
+  const { data, isLoading, error } = usePillarQuery<WatchHistoryListResult>(
+    'media',
+    ['watchHistory', 'listRecent'],
+    queryInput
+  );
+  const { data: pendingDebriefs } = usePillarQuery<PendingDebriefsResult>(
+    'media',
+    ['comparisons', 'getPendingDebriefs'],
+    undefined
+  );
 
   const debriefByMovieId = useMemo(() => {
     const map = new Map<number, number>();

--- a/packages/app-media/src/pages/rankings/RankingsList.tsx
+++ b/packages/app-media/src/pages/rankings/RankingsList.tsx
@@ -1,7 +1,7 @@
 import { Trophy } from 'lucide-react';
 import { useState } from 'react';
 
-import { trpc } from '@pops/api-client';
+import { usePillarQuery } from '@pops/pillar-sdk/react';
 import { Alert, AlertDescription, AlertTitle } from '@pops/ui';
 
 import { RankingRow } from './RankingRow';
@@ -72,14 +72,19 @@ function PaginationFooter({
   );
 }
 
+interface RankingsResult {
+  data: RankingEntry[];
+  pagination?: { total: number; hasMore: boolean };
+}
+
 export function RankingsList({ dimensionId }: { dimensionId?: number }) {
   const [offset, setOffset] = useState(0);
 
-  const { data, isLoading, error } = trpc.media.comparisons.rankings.useQuery({
-    dimensionId,
-    limit: PAGE_SIZE,
-    offset,
-  });
+  const { data, isLoading, error } = usePillarQuery<RankingsResult>(
+    'media',
+    ['comparisons', 'rankings'],
+    { dimensionId, limit: PAGE_SIZE, offset }
+  );
 
   if (error) {
     return (
@@ -91,7 +96,7 @@ export function RankingsList({ dimensionId }: { dimensionId?: number }) {
   }
   if (isLoading) return <RankingsSkeleton />;
 
-  const entries = (data?.data ?? []) as RankingEntry[];
+  const entries = data?.data ?? [];
   const pagination = data?.pagination;
 
   if (entries.length === 0 && offset === 0) return <EmptyState />;


### PR DESCRIPTION
## Summary

Continues the alphabetical migration after #3128 (batch 1, 12 files), #3141 (batch 2, 12 files), and #3145 (3 risky optimistic sites). Swaps `trpc.media.*` for `usePillarQuery` / `usePillarMutation` / `usePillarUtils` across the comparison-history, rankings, calendar, history, debrief, and rotation-log page surfaces.

### Slice scope — "comparison & history pages" cluster

11 source files, ~26 trivial call sites:

- `pages/comparison-history/MovieTitle.tsx`
- `pages/comparison-history/useComparisonHistoryModel.ts`
- `pages/ComparisonHistoryPage.tsx` (drops a redundant `as` cast that was only there because the trpc utils type widened the row shape — the SDK-typed model now narrows it correctly)
- `pages/RankingsPage.tsx`
- `pages/rankings/RankingsList.tsx`
- `pages/RotationLogPage.tsx`
- `pages/CalendarPage.tsx`
- `pages/history/useHistoryPageModel.ts`
- `pages/debrief/useDebriefWatchlist.ts`
- `pages/debrief/useDebriefDestructiveActions.ts` (drops unused `movieId` arg)
- `pages/debrief/useDebriefPageModel.ts`

Plus 5 page-level test files re-mocked against `@pops/pillar-sdk/react`.

### Invalidation semantics

Cross-procedure invalidation that previously hit named procedures (`utils.media.watchHistory.list.invalidate()` + `…listRecent.invalidate()`) now widens to a router-prefix invalidate (`utils.invalidate(['watchHistory'])`). This invalidates one extra unrelated procedure in each router but is safe — every place we used to invalidate sibling procedures, we still do.

### Skipped (deferred to a later batch)

The compare-arena cluster (`useArenaActions`, `useArenaRecord`, `useScoreDelta`, `useStaleAndExclude`, `useArenaBlacklist`, `useArenaWatchlist`, `CompareArenaPage`) was scoped in but **deferred**: `useFetchScoreDelta` calls `utils.media.comparisons.scores.fetch(...)` — an imperative one-shot query against tRPC's `utils` proxy. The pillar SDK's `usePillarUtils` only exposes `setData` and `invalidate`; there is no `fetchQuery` equivalent yet. Pulling that wire would either need a new SDK surface or a `useQueryClient().fetchQuery(pillarQueryKey(...))` workaround that breaks the abstraction. Better as its own follow-up PR with intent.

### Cumulative app-media migration progress

| Batch | PR    | Sites | Files |
| ----- | ----- | ----- | ----- |
| 1     | #3128 | ~30   | 12    |
| 2     | #3141 | ~15   | 12    |
| 3 (risky) | #3145 | 14 | 3 |
| 4 (this) | this PR | ~26 | 11 |

Running total: ~85 sites / ~38 files migrated. `@pops/api-client` remains in `packages/app-media` deps — ~30 files still use it.

## Test plan

- [x] `pnpm --filter @pops/app-media test` — 41 files, **699/699 passing**
- [x] `pnpm --filter @pops/app-media typecheck` — no new errors in touched files (baseline 42 pre-existing → 24 after; this batch fully rewrote some files that carried inferred-`any` errors, dropping them along the way)
- [x] `pnpm typecheck` — 68/68 packages clean
- [x] `npx oxlint packages/app-media/src` — 0 errors
- [x] `npx oxfmt --check` on touched files — clean
- [x] Husky pre-commit + pre-push passed (no `--no-verify`)
