### PR TITLE
ci(_pkg-check): build @pops/wire-conformance before tests (unblock #3152 + future)

### DIFF
--- a/.github/workflows/_pkg-check.yml
+++ b/.github/workflows/_pkg-check.yml
@@ -57,6 +57,7 @@ jobs:
           pnpm --filter @pops/app-food-db build
           pnpm --filter @pops/finance-contract build
           pnpm --filter @pops/pillar-sdk build
+          pnpm --filter @pops/wire-conformance build
           pnpm --filter @pops/media-contract build
           pnpm --filter @pops/inventory-contract build
           pnpm --filter @pops/cerebrum-contract build
@@ -103,6 +104,7 @@ jobs:
           pnpm --filter @pops/app-food-db build
           pnpm --filter @pops/finance-contract build
           pnpm --filter @pops/pillar-sdk build
+          pnpm --filter @pops/wire-conformance build
           pnpm --filter @pops/media-contract build
           pnpm --filter @pops/inventory-contract build
           pnpm --filter @pops/cerebrum-contract build


### PR DESCRIPTION
The reusable _pkg-check.yml workflow's 'Build shared packages' step (both typecheck and test jobs) explicitly lists every workspace package to build before the target package's own checks. `@pops/wire-conformance` was missing.

#3150 (PRD-228 US-05 e2e drop-in test) imports `@pops/wire-conformance/fixture` and started running in core-api's quality workflow. The test was passing on main only because CI's cached pnpm store still had the previously-built dist artifacts; once a clean cache rolled in (e.g. on the #3152 HA bridge branch which adds new packages), the import resolves to a missing `dist/fixture/index.js` and the test crashes with `ERR_MODULE_NOT_FOUND`.

One-line fix: add `pnpm --filter @pops/wire-conformance build` after the pillar-sdk build (both jobs).

Unblocks #3152 and any future PR running core-api tests on a fresh CI cache.