### PR TITLE
fix(api): update per-pillar-migrations smoke test for tables added after #3148

### DIFF
--- a/apps/pops-api/src/db/per-pillar-migrations.test.ts
+++ b/apps/pops-api/src/db/per-pillar-migrations.test.ts
@@ -233,9 +233,10 @@ describe('runPerPillarMigrations', () => {
     // PR 2 — nudge_log slice), 0050_engrams_baseline (PRD-179 US-01 —
     // engrams baseline), 0051_glia_baseline (PRD-181 US-01 — glia
     // baseline), 0052_conversations_baseline (PRD-182 US-01 —
-    // conversations baseline), and 0053_plexus_baseline (PRD-180 US-01 —
-    // plexus baseline). Pillars without their own journal yet still skip
-    // cleanly.
+    // conversations baseline), 0053_plexus_baseline (PRD-180 US-01 —
+    // plexus baseline), and 0054_embeddings_baseline (PRD-186 Wave 5 unblock
+    // — embeddings + embeddings_vec slice). Pillars without their own journal
+    // yet still skip cleanly.
     await withDb((db) => {
       const realPillars: PillarDescriptor[] = [
         { id: 'core', dbPackageDir: 'packages/core-db' },
@@ -264,6 +265,7 @@ describe('runPerPillarMigrations', () => {
         '0051_glia_baseline',
         '0052_conversations_baseline',
         '0053_plexus_baseline',
+        '0054_embeddings_baseline',
         '0054_service_accounts',
         '0055_pillar_registry',
         '0056_settings_baseline',


### PR DESCRIPTION
## Summary
- `apps/pops-api/src/db/per-pillar-migrations.test.ts > falls back to the real repo root when no override is supplied` fails on `main` because PR #3144 (cerebrum-db embeddings + embeddings_vec slice) added `0054_embeddings_baseline.sql` to `packages/cerebrum-db/migrations/` and the cerebrum journal but did not extend the test's expected applied-tag list.
- Several recent PRs (e.g. #3157) noted this failure as "fails on main, unrelated to my change" — confirmed reproducible on `origin/main @ 42501ad8` after `pnpm install --frozen-lockfile` and `pnpm --filter @pops/pillar-sdk build`.
- Add the missing tag to the expected list and update the inline pillar-inventory comment to mention `0054_embeddings_baseline`.

## Repro
```
git checkout origin/main
pnpm install --frozen-lockfile
pnpm --filter @pops/pillar-sdk build
pnpm --filter @pops/api test src/db/per-pillar-migrations.test.ts
```
Before fix: 1 failed / 6 passed. After fix: 7 passed.

## Test plan
- [x] `pnpm --filter @pops/api test src/db/per-pillar-migrations.test.ts` passes locally (7/7)
- [x] `pnpm typecheck` passes locally (68/68 tasks)
- [x] oxlint + oxfmt clean on the touched file