### PR TITLE
docs(theme-13): scaffold PRD-238 settings-known-modules-surface (PRD-218 follow-up)

### DIFF
--- a/docs/themes/13-pillar-finale/epics/10-fe-sdk-dispatcher-generator.md
+++ b/docs/themes/13-pillar-finale/epics/10-fe-sdk-dispatcher-generator.md
@@ -12,13 +12,14 @@ Make the front-end registry-aware end-to-end. Three pieces:
 
 ## PRDs
 
-| #   | PRD                                 | Summary                                                                                      | Status      |
-| --- | ----------------------------------- | -------------------------------------------------------------------------------------------- | ----------- |
-| 215 | React SDK                           | `usePillar`, `useUriResolver`, `usePillarQuery`, `usePillarMutation` hooks                   | Partial     |
-| 216 | `PillarGuard` rewrite               | Reads live registry; subscribes to changes; per-route unavailable placeholders               | Partial     |
-| 217 | nginx config generator              | Generated `default.conf` from registry snapshot; init container OR sidecar strategy          | Not started |
-| 218 | `@pops/module-registry` deprecation | The build-time registry becomes a thin wrapper around the runtime one (offline-dev fallback) | Not started |
-| 227 | SDK consumer migration audit        | Punch list of every `trpc.*` consumer with its `pillar()` migration target + preconditions   | Not started |
+| #   | PRD                                  | Summary                                                                                                                 | Status      |
+| --- | ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------- | ----------- |
+| 215 | React SDK                            | `usePillar`, `useUriResolver`, `usePillarQuery`, `usePillarMutation` hooks                                              | Partial     |
+| 216 | `PillarGuard` rewrite                | Reads live registry; subscribes to changes; per-route unavailable placeholders                                          | Partial     |
+| 217 | nginx config generator               | Generated `default.conf` from registry snapshot; init container OR sidecar strategy                                     | Not started |
+| 218 | `@pops/module-registry` deprecation  | The build-time registry becomes a thin wrapper around the runtime one (offline-dev fallback)                            | Not started |
+| 227 | SDK consumer migration audit         | Punch list of every `trpc.*` consumer with its `pillar()` migration target + preconditions                              | Not started |
+| 238 | Settings-imports off module-registry | Migrate the 8 `apps/pops-api` sites still importing per-pillar `SettingsManifest` from `@pops/module-registry/settings` | Not started |
 
 ## Dependencies
 

--- a/docs/themes/13-pillar-finale/prds/238-settings-known-modules-surface/README.md
+++ b/docs/themes/13-pillar-finale/prds/238-settings-known-modules-surface/README.md
@@ -1,0 +1,91 @@
+# PRD-238: Settings-imports migration off `@pops/module-registry`
+
+> Epic: [FE pillar SDK + dispatcher generator](../../epics/10-fe-sdk-dispatcher-generator.md)
+>
+> Status: **Not started**
+
+## Overview
+
+[PRD-218](../218-module-registry-deprecation/README.md) US-02 shipped the runtime install-set shim (`INSTALLED_MODULES` / `isInstalledModule`) and migrated every consumer whose semantics match "is this module live on this deploy?". Eight call sites in `apps/pops-api` were explicitly **deferred** because they load per-pillar `SettingsManifest` exports from `@pops/module-registry/settings` (or only reference the package in docstrings). That surface is a settings/manifest loading concern, not an install-set concern, and needs its own home before the legacy package can be fully retired. This PRD covers that migration.
+
+## Background
+
+The deferral was called out in PR #3137 (PRD-218 US-02 batch 3 closeout):
+
+> The 6 `@pops/module-registry/settings` imports (`apps/pops-api/src/modules/{core,inventory,finance,cerebrum,cerebrum/ego,media}/index.ts`) are left in place. They load per-pillar `SettingsManifest` exports, which is a distinct concern from the install-set shim — purely a settings/manifest loading pattern. Consolidating the settings surface (probably onto `@pops/pillar-sdk` or a dedicated `@pops/settings` package) belongs to a separate PRD; tracked as follow-up.
+
+PR #3126's "remaining for batch 3" list paired those 6 import sites with 2 additional files (`modules/manifests.ts`, `modules/core/uri/resolver.ts`) whose only reference to `@pops/module-registry` is a stale docstring — together: **the 8 deferred sites this PRD tracks**.
+
+Until these eight references are gone, `apps/pops-api/package.json` cannot drop its `@pops/module-registry` workspace dependency and PRD-218's "delete the package" finishing move cannot ship.
+
+## API Surface
+
+Two viable migration targets exist; this PRD picks one and migrates the eight sites onto it:
+
+| Option                                                                                                                                | Shape                                                                      | Trade-off                                                                                                                |
+| ------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| **A. Co-locate** each pillar's `SettingsManifest` export inside its own pillar package                                                | `import { mediaManifest } from '@pops/pillar-media/settings'` (or similar) | Aligns with ADR-026 ("each pillar owns its contract surface"); zero shared registry coupling. Requires per-pillar moves. |
+| **B. Move the settings surface to `@pops/pillar-sdk`** alongside the existing `ALL_MODULE_IDS` / `isKnownPillarId` helpers (PR #3090) | `import { mediaManifest } from '@pops/pillar-sdk/settings'`                | One central surface, mirrors the module-id helpers PR #3090 already added. Couples pillars through the SDK package.      |
+
+The implementation in US-01 picks one option, justifies it inline, and applies it uniformly across all eight sites. **Option A is the recommended default** — it matches the pillar-ownership direction Theme 13 is steering toward (each pillar publishes its own contract; consumers reach into pillar-scoped subpaths). Option B is the fallback if per-pillar relocation introduces a circular dep with the SDK.
+
+## Business Rules
+
+- The migration is **mechanical**: same `SettingsManifest` shape, same export names, only the import specifier changes.
+- No behavioural change at runtime. `pnpm --filter @pops/api test` must remain green before and after.
+- `@pops/module-registry/settings` is **deleted** once the eight sites flip — it has no consumers outside this list.
+- `@pops/module-registry` itself stays alive for the duration of [PRD-218](../218-module-registry-deprecation/README.md) US-03 (the runtime shim consumers), but its `./settings` subpath is removed.
+
+## Edge Cases
+
+| Case                                                                                                              | Behaviour                                                                                                                                                                                                                                                  |
+| ----------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| A pillar package doesn't exist yet to host its `SettingsManifest` (Option A)                                      | Fall back to Option B for that pillar, document in the US Notes. The pillar packages are scaffolded by Theme 13 Epic 00 — if a pillar isn't packaged yet, parking its settings on `@pops/pillar-sdk` is the pragmatic move.                                |
+| Two pillars share a settings manifest (e.g. `core` exports both `aiConfigManifest` and `coreOperationalManifest`) | Each manifest lives next to the domain it belongs to — `aiConfigManifest` ships from the `ai` pillar package (or, transitionally, from `core` per ADR-026 since `ai` is a sub-module of `core` today), `coreOperationalManifest` from `core`. No bundling. |
+| `modules/manifests.ts` and `modules/core/uri/resolver.ts` carry stale docstrings                                  | Comment-only refs — strip the `@pops/module-registry` mention from the docstring as part of the same change. No runtime impact.                                                                                                                            |
+| Husky / lint-staged complains about the import-discipline rule (PRD-156)                                          | The import-discipline ESLint rule lives in `eslint-config-pops` — extend its allow-list to permit the new import path before flipping any consumer.                                                                                                        |
+
+## The 8 deferred files
+
+| #   | File                                                 | Today's reference                                                                                                         | Migration target (Option A)                     |
+| --- | ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| 1   | `apps/pops-api/src/modules/core/index.ts:1`          | `import { aiConfigManifest, coreOperationalManifest } from '@pops/module-registry/settings';`                             | `@pops/pillar-core/settings`                    |
+| 2   | `apps/pops-api/src/modules/inventory/index.ts:1`     | `import { inventoryManifest } from '@pops/module-registry/settings';`                                                     | `@pops/pillar-inventory/settings`               |
+| 3   | `apps/pops-api/src/modules/finance/index.ts:1`       | `import { financeManifest } from '@pops/module-registry/settings';`                                                       | `@pops/pillar-finance/settings`                 |
+| 4   | `apps/pops-api/src/modules/cerebrum/index.ts:5`      | `import { cerebrumManifest } from '@pops/module-registry/settings';`                                                      | `@pops/pillar-cerebrum/settings`                |
+| 5   | `apps/pops-api/src/modules/cerebrum/ego/index.ts:10` | `import { egoManifest } from '@pops/module-registry/settings';`                                                           | `@pops/pillar-cerebrum/settings` (sub-manifest) |
+| 6   | `apps/pops-api/src/modules/media/index.ts:7-12`      | `import { arrManifest, mediaOperationalManifest, plexManifest, rotationManifest } from '@pops/module-registry/settings';` | `@pops/pillar-media/settings`                   |
+| 7   | `apps/pops-api/src/modules/manifests.ts:7`           | Docstring only — `Settings have moved to '@pops/module-registry's MODULES constant ...`                                   | Rewrite docstring; no runtime change            |
+| 8   | `apps/pops-api/src/modules/core/uri/resolver.ts:16`  | Docstring only — `Once '@pops/module-registry' (PRD-101 US-02) ships ...`                                                 | Rewrite docstring; no runtime change            |
+
+## User Stories
+
+| #   | Story                                                                           | Summary                                                                                                                       | Parallelisable                                  |
+| --- | ------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| 01  | [us-01-pick-target-and-migrate](us-01-pick-target-and-migrate.md)               | Pick Option A or B, host the per-pillar `SettingsManifest` exports there, flip all 6 active import sites and 2 docstring refs | No — single mechanical sweep across the 8 files |
+| 02  | [us-02-delete-legacy-settings-subpath](us-02-delete-legacy-settings-subpath.md) | Delete `@pops/module-registry/settings` subpath + exports; confirm no consumers remain                                        | Blocked by us-01                                |
+
+## Acceptance Criteria
+
+Tracked per-US — summary here for orientation:
+
+- All eight files listed above no longer reference `@pops/module-registry` (import or docstring).
+- `@pops/module-registry/settings` subpath is removed from the package's `exports` map and `src/settings/`.
+- `apps/pops-api/package.json` may still declare `@pops/module-registry` ([PRD-218](../218-module-registry-deprecation/README.md) US-03 retires the runtime shim consumers); this PRD only removes the `/settings` consumers.
+- `pnpm --filter @pops/api test`, `pnpm typecheck`, `pnpm lint`, `pnpm build` all clean.
+- Husky pre-commit + pre-push pass without `--no-verify`.
+
+## Out of Scope
+
+- The runtime install-set shim consumers — [PRD-218](../218-module-registry-deprecation/README.md) US-03 handles those.
+- The build-time `MODULES` / `KNOWN_MODULES` retirement — same PRD-218.
+- Frontend `apps/pops-shell` consumers — none of them import `/settings`; this PRD touches `apps/pops-api` only.
+- Changing the `SettingsManifest` contract shape (defined in `@pops/types`) — pure relocation, not redesign.
+
+## References
+
+- PR [#3090](https://github.com/knoxio/pops/pull/3090) — added `ALL_MODULE_IDS` + `isKnownPillarId` + `isModuleId` to `@pops/pillar-sdk` (the precedent for Option B).
+- PR [#3126](https://github.com/knoxio/pops/pull/3126) — PRD-218 US-02 batch 2; first listed the 8 deferred files in its "Remaining for batch 3" section.
+- PR [#3137](https://github.com/knoxio/pops/pull/3137) — PRD-218 US-02 batch 3 closeout; explicitly carved out the `/settings` consumers as a separate PRD.
+- [PRD-218](../218-module-registry-deprecation/README.md) — parent deprecation tracker; this PRD removes one of its blocking dependencies.
+- [ADR-026](../../../../architecture/adr-026-pillar-architecture.md) — pillar ownership model that motivates Option A.

--- a/docs/themes/13-pillar-finale/prds/238-settings-known-modules-surface/us-01-pick-target-and-migrate.md
+++ b/docs/themes/13-pillar-finale/prds/238-settings-known-modules-surface/us-01-pick-target-and-migrate.md
@@ -1,0 +1,34 @@
+# US-01: Pick the new settings-manifest home and migrate the eight call sites
+
+> PRD: [PRD-238 — Settings-imports migration off `@pops/module-registry`](README.md)
+
+## Description
+
+As a maintainer retiring `@pops/module-registry`, I want every per-pillar `SettingsManifest` export to live next to its owning pillar (or, fallback, on `@pops/pillar-sdk`) so that `apps/pops-api` stops importing from a soon-to-be-deleted package.
+
+## Acceptance Criteria
+
+- [ ] One target is chosen and recorded inline in this US's Notes section: **Option A** (per-pillar package, default) or **Option B** (`@pops/pillar-sdk/settings`, fallback).
+- [ ] Each pillar's `SettingsManifest` is exported from the chosen target with the same export name as today (`mediaOperationalManifest`, `arrManifest`, `plexManifest`, `rotationManifest`, `inventoryManifest`, `financeManifest`, `cerebrumManifest`, `egoManifest`, `aiConfigManifest`, `coreOperationalManifest`).
+- [ ] All six active import sites are flipped:
+  - [ ] `apps/pops-api/src/modules/core/index.ts`
+  - [ ] `apps/pops-api/src/modules/inventory/index.ts`
+  - [ ] `apps/pops-api/src/modules/finance/index.ts`
+  - [ ] `apps/pops-api/src/modules/cerebrum/index.ts`
+  - [ ] `apps/pops-api/src/modules/cerebrum/ego/index.ts`
+  - [ ] `apps/pops-api/src/modules/media/index.ts`
+- [ ] Both docstring-only references are rewritten to drop the `@pops/module-registry` mention:
+  - [ ] `apps/pops-api/src/modules/manifests.ts`
+  - [ ] `apps/pops-api/src/modules/core/uri/resolver.ts`
+- [ ] No new `as any` / `as unknown as Type` casts introduced; no `eslint-disable` / `ts-ignore` added.
+- [ ] `pnpm --filter @pops/api typecheck`, `pnpm --filter @pops/api test`, `pnpm lint`, `pnpm build` all pass clean.
+- [ ] Husky pre-commit + pre-push pass without `--no-verify`.
+
+## Notes
+
+- The eight files are listed with line numbers in [the parent PRD](README.md#the-8-deferred-files).
+- Manifest contract type is `SettingsManifest` from `@pops/types` — that import stays put.
+- Option A requires per-pillar packages to exist. Inventory which pillar packages are scaffolded today (Theme 13 Epic 00) before committing to Option A for every pillar; mix-and-match per pillar is allowed.
+- The import-discipline ESLint rule (PRD-156) may need its allow-list extended for whichever target gets picked. Adjust `eslint-config-pops` first, then flip consumers, otherwise lint-staged blocks the commit.
+- The `egoManifest` lives under `cerebrum/ego/` today because `ego` is a sub-module of `cerebrum` (per ADR-026, `ego` is transitional alongside `ai`). Co-locate it inside the `cerebrum` pillar package as a sub-manifest, not its own package.
+- Do not touch the `SettingsManifest` shape, the per-pillar manifest contents, or the `apps/pops-shell` consumers — those are explicitly out of scope.

--- a/docs/themes/13-pillar-finale/prds/238-settings-known-modules-surface/us-02-delete-legacy-settings-subpath.md
+++ b/docs/themes/13-pillar-finale/prds/238-settings-known-modules-surface/us-02-delete-legacy-settings-subpath.md
@@ -1,0 +1,23 @@
+# US-02: Delete the `@pops/module-registry/settings` subpath
+
+> PRD: [PRD-238 — Settings-imports migration off `@pops/module-registry`](README.md)
+
+## Description
+
+As a maintainer retiring `@pops/module-registry`, I want the `./settings` subpath gone once nothing imports from it, so the package surface shrinks toward the PRD-218 finishing move (delete the package entirely).
+
+## Acceptance Criteria
+
+- [ ] `grep -rn "@pops/module-registry/settings" apps packages` returns zero matches in `src/` (build artefacts under `dist/` are ignored).
+- [ ] The `./settings` entry is removed from `packages/module-registry/package.json`'s `exports` map.
+- [ ] The corresponding source directory (today: `packages/module-registry/src/settings/`) is deleted.
+- [ ] `packages/module-registry`'s own tests still pass — the subpath retirement should not break anything else in the package.
+- [ ] `pnpm --filter @pops/module-registry typecheck`, `pnpm --filter @pops/module-registry test`, `pnpm --filter @pops/module-registry build` all clean.
+- [ ] Full monorepo `pnpm typecheck`, `pnpm lint`, `pnpm build` clean.
+- [ ] Husky pre-commit + pre-push pass without `--no-verify`.
+
+## Notes
+
+- Blocked by [US-01](us-01-pick-target-and-migrate.md). Do not start until every import site is flipped and on `main`.
+- This US does **not** drop the `@pops/module-registry` workspace dependency from `apps/pops-api/package.json` — runtime shim consumers (`INSTALLED_MODULES`, `isInstalledModule`, `MODULES`, `InstalledModule`) still live there and are retired by [PRD-218](../218-module-registry-deprecation/README.md) US-03.
+- If the package re-exports anything from `src/settings/` via the root entry, those re-exports also go away. Confirm `src/index.ts` references before deleting the directory.


### PR DESCRIPTION
## Summary

Scaffolds **PRD-238** as the dedicated follow-up to PRD-218 US-02 for the 8 `apps/pops-api` call sites that were explicitly deferred from the runtime install-set shim migration. Those sites load per-pillar `SettingsManifest` exports from `@pops/module-registry/settings` (or reference the package in stale docstrings) — distinct semantics from the install-set, so they need their own contract decision before `@pops/module-registry` can be retired.

## Why now

- PR #3090 added `ALL_MODULE_IDS` / `isKnownPillarId` / `isModuleId` to `@pops/pillar-sdk` — the precedent for centralised pillar-id surface (Option B in this PRD).
- PR #3126 (PRD-218 US-02 batch 2) first listed these 8 files in its "Remaining for batch 3" section.
- PR #3137 (PRD-218 US-02 batch 3 closeout) shipped the type-level pair (`InstalledModule`) and explicitly carved out the `/settings` consumers as a separate PRD ("Settings-subpath consumers (out of scope)").

Without this PRD, the `apps/pops-api` → `@pops/module-registry/settings` link stays orphaned and PRD-218's "delete the package" finishing move can't ship.

## Contents

- `docs/themes/13-pillar-finale/prds/238-settings-known-modules-surface/README.md` — PRD with the 8-file inventory (paths + line numbers), API surface options (per-pillar vs `@pops/pillar-sdk`), business rules, edge cases.
- `us-01-pick-target-and-migrate.md` — pick the target, migrate the 6 active imports + rewrite the 2 docstring refs.
- `us-02-delete-legacy-settings-subpath.md` — once US-01 lands, delete the `/settings` subpath from `@pops/module-registry`.
- `docs/themes/13-pillar-finale/epics/10-fe-sdk-dispatcher-generator.md` — added PRD-238 to the epic's PRD table.

PRD number 238 is the next free slot (236 is taken by `sinks-manifest-dimension`; 237 is reserved by ADR-034 for the pops → HA event publisher).

## Test plan

- [x] `pnpm format` over the new docs
- [x] Husky pre-commit + pre-push (turbo typecheck across 71 tasks) — all green
- [x] No `--no-verify` used
- [ ] CI green on the docs-only path filter
