### PR TITLE
feat(api/finance): migrate handlers from getDrizzle to getFinanceDrizzle (Wave 5 long-tail)

### DIFF
--- a/apps/pops-api/src/modules/finance/budgets/budgets.test.ts
+++ b/apps/pops-api/src/modules/finance/budgets/budgets.test.ts
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { budgets as budgetsTable } from '@pops/db-types';
 
-import { getDrizzle } from '../../../db.js';
+import { getFinanceDrizzle } from '../../../db/finance-handle.js';
 import { createCaller, seedBudget, setupTestContext } from '../../../shared/test-utils.js';
 
 import type { Database } from 'better-sqlite3';
@@ -278,7 +278,7 @@ describe('budgets.create', () => {
   it('persists to the database', async () => {
     await caller.finance.budgets.create({ category: 'New Budget' });
 
-    const row = getDrizzle()
+    const row = getFinanceDrizzle()
       .select()
       .from(budgetsTable)
       .where(eq(budgetsTable.category, 'New Budget'))
@@ -296,7 +296,7 @@ describe('budgets.create', () => {
     });
 
     // Verify all fields persisted in SQLite
-    const row = getDrizzle()
+    const row = getFinanceDrizzle()
       .select()
       .from(budgetsTable)
       .where(eq(budgetsTable.id, result.data.id))
@@ -370,7 +370,7 @@ describe('budgets.update', () => {
 
     await caller.finance.budgets.update({ id, data: { amount: 500 } });
 
-    const row = getDrizzle()
+    const row = getFinanceDrizzle()
       .select({ lastEditedTime: budgetsTable.lastEditedTime })
       .from(budgetsTable)
       .where(eq(budgetsTable.id, id))
@@ -401,7 +401,7 @@ describe('budgets.update', () => {
     await caller.finance.budgets.update({ id, data: { amount: 600 } });
 
     // Verify SQLite was updated
-    const row = getDrizzle()
+    const row = getFinanceDrizzle()
       .select({ amount: budgetsTable.amount })
       .from(budgetsTable)
       .where(eq(budgetsTable.id, id))
@@ -418,7 +418,11 @@ describe('budgets.delete', () => {
     expect(result.message).toBe('Budget deleted');
 
     // Verify gone from DB
-    const row = getDrizzle().select().from(budgetsTable).where(eq(budgetsTable.id, id)).get();
+    const row = getFinanceDrizzle()
+      .select()
+      .from(budgetsTable)
+      .where(eq(budgetsTable.id, id))
+      .get();
     expect(row).toBeUndefined();
   });
 
@@ -447,7 +451,11 @@ describe('budgets.delete', () => {
     await caller.finance.budgets.delete({ id });
 
     // Verify row is gone from SQLite
-    const row = getDrizzle().select().from(budgetsTable).where(eq(budgetsTable.id, id)).get();
+    const row = getFinanceDrizzle()
+      .select()
+      .from(budgetsTable)
+      .where(eq(budgetsTable.id, id))
+      .get();
     expect(row).toBeUndefined();
   });
 });

--- a/apps/pops-api/src/modules/finance/imports/router.test.ts
+++ b/apps/pops-api/src/modules/finance/imports/router.test.ts
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { entities as entitiesTable } from '@pops/db-types';
 
-import { getDrizzle } from '../../../db.js';
+import { getFinanceDrizzle } from '../../../db/finance-handle.js';
 import {
   createCaller,
   seedEntity,
@@ -380,7 +380,7 @@ describe('imports.createEntity', () => {
       name: 'SQLite Test Entity',
     });
 
-    const row = getDrizzle()
+    const row = getFinanceDrizzle()
       .select()
       .from(entitiesTable)
       .where(eq(entitiesTable.id, result.entityId))

--- a/apps/pops-api/src/modules/finance/transactions/transactions.test.ts
+++ b/apps/pops-api/src/modules/finance/transactions/transactions.test.ts
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { transactions as transactionsTable } from '@pops/db-types';
 
-import { getDrizzle } from '../../../db.js';
+import { getFinanceDrizzle } from '../../../db/finance-handle.js';
 import {
   createCaller,
   seedEntity,
@@ -440,7 +440,7 @@ describe('transactions.update', () => {
 
     await caller.finance.transactions.update({ id, data: { amount: 100.0 } });
 
-    const row = getDrizzle()
+    const row = getFinanceDrizzle()
       .select({ lastEditedTime: transactionsTable.lastEditedTime })
       .from(transactionsTable)
       .where(eq(transactionsTable.id, id))
@@ -487,7 +487,7 @@ describe('transactions.delete', () => {
     expect(result.message).toBe('Transaction deleted');
 
     // Verify gone from DB
-    const row = getDrizzle()
+    const row = getFinanceDrizzle()
       .select()
       .from(transactionsTable)
       .where(eq(transactionsTable.id, id))

--- a/apps/pops-api/src/modules/finance/wishlist/wishlist.test.ts
+++ b/apps/pops-api/src/modules/finance/wishlist/wishlist.test.ts
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { wishList as wishListTable } from '@pops/db-types';
 
-import { getDrizzle } from '../../../db.js';
+import { getFinanceDrizzle } from '../../../db/finance-handle.js';
 import { createCaller, seedWishListItem, setupTestContext } from '../../../shared/test-utils.js';
 
 import type { Database } from 'better-sqlite3';
@@ -270,7 +270,7 @@ describe('wishlist.create', () => {
   it('persists to the database', async () => {
     await caller.finance.wishlist.create({ item: 'New Item' });
 
-    const row = getDrizzle()
+    const row = getFinanceDrizzle()
       .select()
       .from(wishListTable)
       .where(eq(wishListTable.item, 'New Item'))
@@ -337,7 +337,7 @@ describe('wishlist.update', () => {
 
     await caller.finance.wishlist.update({ id, data: { priority: 'Needing' } });
 
-    const row = getDrizzle()
+    const row = getFinanceDrizzle()
       .select({ lastEditedTime: wishListTable.lastEditedTime })
       .from(wishListTable)
       .where(eq(wishListTable.id, id))
@@ -397,7 +397,11 @@ describe('wishlist.delete', () => {
     expect(result.message).toBe('Wish list item deleted');
 
     // Verify gone from DB
-    const row = getDrizzle().select().from(wishListTable).where(eq(wishListTable.id, id)).get();
+    const row = getFinanceDrizzle()
+      .select()
+      .from(wishListTable)
+      .where(eq(wishListTable.id, id))
+      .get();
     expect(row).toBeUndefined();
   });
 


### PR DESCRIPTION
## Summary

Wave 5 long-tail cleanup. Flips finance module test assertions from the shared `getDrizzle()` handle to the pillar-scoped `getFinanceDrizzle()` handle so the read path matches the production handlers that already cut over.

- Handlers under `apps/pops-api/src/modules/finance/**` already use `getFinanceDrizzle()` for every read/write — only the verify-side queries in the test suites still imported `getDrizzle()` from the shared `db.js`.
- Both handles resolve to the same in-memory DB inside `setupTestContext` (which wires `setFinanceDb({ db: drizzle(db), raw: db })`), so the swap is behaviour-preserving and surfaces correct pillar ownership at the call site.

Touched: `budgets`, `transactions`, `wishlist`, `imports/router` test files.

## Count delta

`apps/pops-api/src/modules/finance/**` `getDrizzle()` occurrences: **18 -> 2**.

## Remaining (intentionally skipped)

The 2 remaining occurrences live in:

- `apps/pops-api/src/modules/finance/imports/lib/ai-categorizer.test.ts`
- `apps/pops-api/src/modules/finance/imports/lib/ai-categorizer-disk.integration.test.ts`

Both are vestigial entries inside `vi.mock('../../../../db.js', ...)`:

```ts
vi.mock('../../../../db.js', () => ({
  getDrizzle: vi.fn(() => ({ insert: vi.fn(() => ({ values: vi.fn(() => ({ run: mockDbRun })) })) })),
  isNamedEnvContext: vi.fn().mockReturnValue(false),
}));
```

The underlying `ai-categorizer.ts` no longer calls `getDrizzle()`; inference logging flows through `trackInference -> getCoreDrizzle()` (`inference-middleware.ts:35`). Those mock keys are dead code in the test fixture. These suites are also pre-existing failures on `main` because the same mock omits `getCoreDrizzle` entirely (the partial-mock pattern eats every other export of `db.js`). A separate slice should both fix the mock surface and drop the dead `getDrizzle` key — kept out of this PR to keep scope tight per the Wave 5 reframe.

No mixed-tx handlers in the flipped set — every modified call site queries a finance-owned table (`budgets`, `wishList`, `transactions`, `entities`).

## Test plan

- [x] `pnpm install --frozen-lockfile && pnpm --filter @pops/pillar-sdk build`
- [x] `pnpm typecheck` in `apps/pops-api` — clean
- [x] `npx vitest run` on the 4 modified test files — 209/209 passing
- [x] Pre-existing failure set on `main` unchanged (same 29 unrelated failures with/without this PR)
- [x] `oxlint` + `oxfmt` clean (husky pre-commit pass, no `--no-verify`)
