### PR TITLE
feat(app-media): migrate batch 4 (7 sites · candidate-queue · PRD-227)

### DIFF
--- a/packages/app-media/src/pages/CandidateQueuePage.tsx
+++ b/packages/app-media/src/pages/CandidateQueuePage.tsx
@@ -1,6 +1,6 @@
 import { Link, useSearchParams } from 'react-router';
 
-import { trpc } from '@pops/api-client';
+import { usePillarQuery } from '@pops/pillar-sdk/react';
 /**
  * CandidateQueuePage — tabbed view of rotation candidate queue.
  *
@@ -11,11 +11,18 @@ import { Badge, PageHeader, Tabs, TabsContent, TabsList, TabsTrigger } from '@po
 import { CandidateList } from './candidate-queue/CandidateList';
 import { ExclusionList } from './candidate-queue/ExclusionList';
 
+interface PendingCountResult {
+  total: number;
+}
+
 export function CandidateQueuePage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const tab = searchParams.get('tab') ?? 'pending';
 
-  const pendingCount = trpc.media.rotation.listCandidates.useQuery({ status: 'pending', limit: 1 });
+  const pendingCount = usePillarQuery<PendingCountResult>('media', ['rotation', 'listCandidates'], {
+    status: 'pending',
+    limit: 1,
+  });
 
   return (
     <div className="space-y-6 p-6">

--- a/packages/app-media/src/pages/candidate-queue/CandidateList.tsx
+++ b/packages/app-media/src/pages/candidate-queue/CandidateList.tsx
@@ -1,11 +1,13 @@
 import { Search } from 'lucide-react';
 import { useState } from 'react';
 
-import { trpc } from '@pops/api-client';
+import { usePillarQuery } from '@pops/pillar-sdk/react';
 import { Skeleton } from '@pops/ui';
 
 import { CandidateCard } from './CandidateCard';
 import { Pagination } from './Pagination';
+
+import type { Candidate } from './CandidateCard';
 
 const PAGE_SIZE = 20;
 
@@ -40,11 +42,16 @@ function CandidateLoading() {
   );
 }
 
+interface ListCandidatesResult {
+  items: Candidate[];
+  total: number;
+}
+
 export function CandidateList({ status, actions }: CandidateListProps) {
   const [page, setPage] = useState(0);
   const [search, setSearch] = useState('');
 
-  const query = trpc.media.rotation.listCandidates.useQuery({
+  const query = usePillarQuery<ListCandidatesResult>('media', ['rotation', 'listCandidates'], {
     status,
     search: search || undefined,
     limit: PAGE_SIZE,

--- a/packages/app-media/src/pages/candidate-queue/ExclusionList.tsx
+++ b/packages/app-media/src/pages/candidate-queue/ExclusionList.tsx
@@ -2,7 +2,7 @@ import { RotateCcw } from 'lucide-react';
 import { useState } from 'react';
 import { toast } from 'sonner';
 
-import { trpc } from '@pops/api-client';
+import { usePillarMutation, usePillarQuery, usePillarUtils } from '@pops/pillar-sdk/react';
 import { Button, Skeleton } from '@pops/ui';
 
 import { Pagination } from './Pagination';
@@ -48,23 +48,32 @@ function ExclusionRow({
   );
 }
 
+interface ListExclusionsResult {
+  items: Exclusion[];
+  total: number;
+}
+
 export function ExclusionList() {
   const [page, setPage] = useState(0);
-  const utils = trpc.useUtils();
+  const utils = usePillarUtils('media');
 
-  const query = trpc.media.rotation.listExclusions.useQuery({
+  const query = usePillarQuery<ListExclusionsResult>('media', ['rotation', 'listExclusions'], {
     limit: PAGE_SIZE,
     offset: page * PAGE_SIZE,
   });
 
-  const unexcludeMutation = trpc.media.rotation.removeExclusion.useMutation({
-    onSuccess: () => {
-      toast.success('Exclusion removed');
-      void utils.media.rotation.listExclusions.invalidate();
-      void utils.media.rotation.listCandidates.invalidate();
-    },
-    onError: (err) => toast.error(err.message || 'Failed to remove exclusion'),
-  });
+  const unexcludeMutation = usePillarMutation<{ tmdbId: number }, unknown>(
+    'media',
+    ['rotation', 'removeExclusion'],
+    {
+      onSuccess: () => {
+        toast.success('Exclusion removed');
+        void utils.invalidate(['rotation', 'listExclusions']);
+        void utils.invalidate(['rotation', 'listCandidates']);
+      },
+      onError: (err) => toast.error(err.message || 'Failed to remove exclusion'),
+    }
+  );
 
   const totalPages = Math.max(1, Math.ceil((query.data?.total ?? 0) / PAGE_SIZE));
 

--- a/packages/app-media/src/pages/candidate-queue/useCardMutations.ts
+++ b/packages/app-media/src/pages/candidate-queue/useCardMutations.ts
@@ -1,34 +1,60 @@
 import { toast } from 'sonner';
 
-import { trpc } from '@pops/api-client';
+import { usePillarMutation, usePillarUtils } from '@pops/pillar-sdk/react';
 
 import type { Candidate } from './CandidateCard';
 
+interface DownloadInput {
+  candidateId: number;
+}
+
+interface ExcludeInput {
+  tmdbId: number;
+  title: string;
+  reason?: string;
+}
+
+interface UnexcludeInput {
+  tmdbId: number;
+}
+
 export function useCardMutations(candidate: Candidate, setPopoverOpen: (v: boolean) => void) {
-  const utils = trpc.useUtils();
-  const downloadMutation = trpc.media.rotation.downloadCandidate.useMutation({
-    onSuccess: () => {
-      toast.success(`Downloading "${candidate.title}"`);
-      void utils.media.rotation.listCandidates.invalidate();
-    },
-    onError: (err) => toast.error(err.message || 'Failed to download'),
-  });
-  const excludeMutation = trpc.media.rotation.excludeCandidate.useMutation({
-    onSuccess: () => {
-      toast.success(`Excluded "${candidate.title}"`);
-      void utils.media.rotation.listCandidates.invalidate();
-      void utils.media.rotation.listExclusions.invalidate();
-      setPopoverOpen(false);
-    },
-    onError: (err) => toast.error(err.message || 'Failed to exclude'),
-  });
-  const unexcludeMutation = trpc.media.rotation.removeExclusion.useMutation({
-    onSuccess: () => {
-      toast.success(`Restored "${candidate.title}" to queue`);
-      void utils.media.rotation.listCandidates.invalidate();
-      void utils.media.rotation.listExclusions.invalidate();
-    },
-    onError: (err) => toast.error(err.message || 'Failed to restore'),
-  });
+  const utils = usePillarUtils('media');
+  const downloadMutation = usePillarMutation<DownloadInput, unknown>(
+    'media',
+    ['rotation', 'downloadCandidate'],
+    {
+      onSuccess: () => {
+        toast.success(`Downloading "${candidate.title}"`);
+        void utils.invalidate(['rotation', 'listCandidates']);
+      },
+      onError: (err) => toast.error(err.message || 'Failed to download'),
+    }
+  );
+  const excludeMutation = usePillarMutation<ExcludeInput, unknown>(
+    'media',
+    ['rotation', 'excludeCandidate'],
+    {
+      onSuccess: () => {
+        toast.success(`Excluded "${candidate.title}"`);
+        void utils.invalidate(['rotation', 'listCandidates']);
+        void utils.invalidate(['rotation', 'listExclusions']);
+        setPopoverOpen(false);
+      },
+      onError: (err) => toast.error(err.message || 'Failed to exclude'),
+    }
+  );
+  const unexcludeMutation = usePillarMutation<UnexcludeInput, unknown>(
+    'media',
+    ['rotation', 'removeExclusion'],
+    {
+      onSuccess: () => {
+        toast.success(`Restored "${candidate.title}" to queue`);
+        void utils.invalidate(['rotation', 'listCandidates']);
+        void utils.invalidate(['rotation', 'listExclusions']);
+      },
+      onError: (err) => toast.error(err.message || 'Failed to restore'),
+    }
+  );
   return { downloadMutation, excludeMutation, unexcludeMutation };
 }


### PR DESCRIPTION
## Summary

- Migrates the **candidate-queue** surface in `apps`-style page `apps/app-media` from `@pops/api-client` to `@pops/pillar-sdk` (PRD-227).
- 7 tRPC sites across 4 source files swapped to `usePillarQuery` / `usePillarMutation` / `usePillarUtils`.
- Intentionally small batch after the prior batch-4 attempt stalled deep in test-mock work; this slice has no page-level test mocks to update.

### Slice

- `pages/CandidateQueuePage.tsx`
- `pages/candidate-queue/CandidateList.tsx`
- `pages/candidate-queue/ExclusionList.tsx`
- `pages/candidate-queue/useCardMutations.ts`

### Cumulative progress

~92/151 app-media trivial sites migrated (after #3128 / #3141 / #3145 / #3156 + this PR).

Risky optimistic-update sites (`useWatchlistToggleModel`, `useTvShowDetailModel`, `useBatchSeasonLog`) remain deferred until the SDK exposes typed `setData`. Compare-arena is still deferred too.

`@pops/api-client` remains a runtime dep — ~26 source files still reference it across the package.

## Test plan

- [x] `pnpm --filter @pops/app-media test` — 699/699 passing
- [x] `pnpm typecheck` — 71/71 packages clean
- [x] `pnpm --filter @pops/app-media typecheck` — file-local errors 25 (baseline) → 19 after this batch; no new errors introduced
- [x] `npx oxlint packages/app-media/src/pages/candidate-queue …` — no new findings (only pre-existing `no-array-index-key` warnings)