### PR TITLE
docs(theme-13): scaffold PRD-237 pops → HA event publisher (sinks first consumer)

### DIFF
--- a/docs/themes/13-pillar-finale/epics/13-bridge-pillars.md
+++ b/docs/themes/13-pillar-finale/epics/13-bridge-pillars.md
@@ -12,12 +12,13 @@ The first bridge — Home Assistant — proves the pattern. MQTT and ESPHome fol
 
 ## PRDs
 
-| #   | PRD                                                                        | Summary                                                                                                                           | Status      |
-| --- | -------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| 229 | [HA bridge pillar](../prds/229-ha-bridge-pillar/README.md)                 | `pops-ha-bridge-api` — subscribe to HA WebSocket, mirror entities, expose via `searchAdapter` + `aiTools` + new `sinks` dimension | Not started |
-| TBD | MQTT bridge pillar                                                         | `pops-mqtt-bridge-api` — subscribe to MQTT broker, mirror topics as entities                                                      | Not started |
-| TBD | ESPHome bridge pillar                                                      | `pops-esphome-bridge-api` — subscribe to ESPHome native API, mirror devices                                                       | Not started |
-| 236 | [Sinks manifest dimension](../prds/236-sinks-manifest-dimension/README.md) | First-class `sinks` manifest field + `publishEvent` orchestrator + `/_sinks/<eventType>` endpoint convention (per ADR-034)        | In progress |
+| #   | PRD                                                                                    | Summary                                                                                                                           | Status      |
+| --- | -------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| 229 | [HA bridge pillar](../prds/229-ha-bridge-pillar/README.md)                             | `pops-ha-bridge-api` — subscribe to HA WebSocket, mirror entities, expose via `searchAdapter` + `aiTools` + new `sinks` dimension | Not started |
+| TBD | MQTT bridge pillar                                                                     | `pops-mqtt-bridge-api` — subscribe to MQTT broker, mirror topics as entities                                                      | Not started |
+| TBD | ESPHome bridge pillar                                                                  | `pops-esphome-bridge-api` — subscribe to ESPHome native API, mirror devices                                                       | Not started |
+| 236 | [Sinks manifest dimension](../prds/236-sinks-manifest-dimension/README.md)             | First-class `sinks` manifest field + `publishEvent` orchestrator + `/_sinks/<eventType>` endpoint convention (per ADR-034)        | In progress |
+| 237 | [pops → HA outbound event publisher](../prds/237-pops-to-ha-event-publisher/README.md) | Wire the HA bridge as the first `sinks` consumer — `publishEvent('media.watch.completed', ...)` becomes an HA `fire_event` call   | Not started |
 
 PRD-229 (HA) is the reference implementation. MQTT and ESPHome PRDs are deferred until PRD-229 lands — they fork from the HA shape rather than designed from scratch.
 

--- a/docs/themes/13-pillar-finale/prds/237-pops-to-ha-event-publisher/README.md
+++ b/docs/themes/13-pillar-finale/prds/237-pops-to-ha-event-publisher/README.md
@@ -1,0 +1,114 @@
+# PRD-237: pops → HA outbound event publisher
+
+> Epic: [Bridge pillars](../../epics/13-bridge-pillars.md)
+
+> Status: Not started
+
+> ADR: [ADR-034](../../../../architecture/adr-034-sinks-manifest-dimension.md), [ADR-032](../../../../architecture/adr-032-positioning-vs-self-hosted-os-family.md)
+
+## Overview
+
+Wire the HA bridge pillar (PRD-229) as the first real consumer of the `sinks` manifest dimension scaffolded by [PRD-236](../236-sinks-manifest-dimension/README.md). When any source pillar calls `publishEvent('media.watch.completed', payload)`, the orchestrator routes to the HA bridge's `POST /_sinks/media.watch.completed`, and the bridge translates the payload into a Home Assistant `event.fire` WebSocket call.
+
+This PRD closes the loop on the bidirectional bridge model declared by [ADR-034](../../../../architecture/adr-034-sinks-manifest-dimension.md): inbound flow (HA → POPS) was scaffolded by PRD-229 US-01; outbound flow (POPS → HA) lands here. The deliverable is one end-to-end mapping path proven in tests against an in-process registry + stub HA WebSocket, plus a small mapping config so additional event types can be added without code changes to the bridge's core. A live HA instance is available for integration validation (the operator runs HA on a homelab node), but no test in this PRD depends on it.
+
+## Data Model
+
+No database surface. The artifacts are:
+
+1. A manifest extension on `apps/pops-ha-bridge-api` declaring one or more `sinks.descriptors` entries.
+2. A mapping config file shipped with the bridge that maps each POPS `eventType` to an HA event name and a payload transform.
+3. Reuse of the WebSocket client + reconnect state machine already shipped by PRD-229 US-01 — no new persistent state.
+
+### Mapping config shape
+
+| Field             | Type                                                        | Notes                                                                                                                                           |
+| ----------------- | ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `eventType`       | `string`                                                    | POPS event type — must match `<source>.<entity>.<action>` per PRD-236.                                                                          |
+| `haEventName`     | `string`                                                    | HA event name forwarded over the WebSocket `fire_event` message (`pops_media_watch_completed`, `pops_finance_balance_low`).                     |
+| `transformInline` | `(payload) => Record<string, unknown>`                      | Pure function that maps the POPS payload to the `event_data` object HA receives. Defaults to identity when omitted.                             |
+| `schema`          | `Record<string, unknown>` (JSON-Schema-shaped, per PRD-231) | The same `schema` the bridge declares in its manifest `sinks.descriptors` entry. Used by both manifest validation and the inbound 400 boundary. |
+
+The config lives at `apps/pops-ha-bridge-api/src/sinks/mappings.ts` as a typed `SinkMapping[]` array. Adding a new mapping = adding an entry + adding a contract test asserting the round-trip. No core-code edit required.
+
+### First-cut mappings shipped by this PRD
+
+| POPS `eventType`          | HA event name                  | Notes                                                                                         |
+| ------------------------- | ------------------------------ | --------------------------------------------------------------------------------------------- |
+| `media.watch.completed`   | `pops_media_watch_completed`   | Payload identity-mapped. Use case: HA automation rings the lights down when a movie finishes. |
+| `finance.balance.low`     | `pops_finance_balance_low`     | Payload identity-mapped. Use case: HA notification when an account drops below the threshold. |
+| `inventory.item.consumed` | `pops_inventory_item_consumed` | Payload identity-mapped. Use case: HA shopping-list automation tops up consumables.           |
+
+## API Surface
+
+### Manifest extension on `pops-ha-bridge-api`
+
+The pillar's existing manifest gains a `sinks` block whose `descriptors` array is derived from the mapping config at boot:
+
+```ts
+sinks: {
+  descriptors: mappings.map(m => ({
+    eventType: m.eventType,
+    description: m.description,
+    schema: m.schema,
+  })),
+}
+```
+
+No new HTTP endpoint surface beyond what PRD-236 US-03 already specifies (`POST /_sinks/<eventType>`). Each mapping wires `createSinkHandler({ eventType, schema, handler })` where `handler` runs the transform and pushes the result onto the HA WebSocket via the existing connection-managed `sendFireEvent(haEventName, eventData)` helper.
+
+### Bridge-side handler contract
+
+| Aspect      | Value                                                                                                                                                                                                                                                                       |
+| ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Trigger     | `POST /_sinks/<eventType>` from the orchestrator dispatcher (PRD-236 US-02).                                                                                                                                                                                                |
+| Validation  | Zod schema (registered in-process at boot from the mapping `schema` field) — invalid payloads return `400` per the PRD-236 helper contract.                                                                                                                                 |
+| HA delivery | The handler calls `sendFireEvent(mapping.haEventName, mapping.transformInline(payload))`. The helper queues the message when the WebSocket is `reconnecting` and flushes on reconnect. When the WebSocket is `offline` for more than the queue cap, the queue drops oldest. |
+| Success     | `200 OK` once the WebSocket frame is written (or queued).                                                                                                                                                                                                                   |
+| Failure     | Handler throws — surfaces `500` to the dispatcher per PRD-236; dispatcher records `pillar-offline`. Caller retries per its own retry loop (publisher concern, per ADR-034).                                                                                                 |
+
+### No publisher-side API change
+
+Source pillars (media, finance, inventory) call `publishEvent('media.watch.completed', payload, ...)` per PRD-236 US-02. This PRD does not introduce a new publisher API; it relies on the existing one. The publisher does not know HA exists.
+
+## Business Rules
+
+- **One mapping per `eventType` per bridge.** A second mapping for the same POPS `eventType` in the same bridge config is a config error — the boot-time validator throws. Two pillars _can_ declare sinks for the same `eventType` (per PRD-236 edge case); two mappings inside the HA bridge for the same `eventType` cannot.
+- **The mapping config is the source of truth for both manifest and runtime.** The manifest's `sinks.descriptors` array is derived from the same `mappings` array that the runtime handler registry reads from. Drift is structurally impossible.
+- **Transforms are pure functions.** Mapping `transformInline` must be synchronous, deterministic, side-effect-free. No I/O, no clock reads (use the payload's `occurredAt` if a timestamp is needed in the HA event). Enforced by code review and by a contract test that calls each transform twice with the same input and asserts deep equality.
+- **WebSocket offline does not block the sink handler.** When the HA WebSocket is `reconnecting`, `sendFireEvent` enqueues; the handler returns `200`. When the WebSocket is `offline` and the queue cap is hit, the handler still returns `200` (and the oldest enqueued message is dropped with a structured log line). This honours the at-least-once contract from ADR-034 — the publisher does not see a 500 just because HA is temporarily down. A separate ops metric counts dropped messages.
+- **Reconnect reuses PRD-229 US-01 backoff.** No new reconnect logic. The outbound queue is owned by the same WebSocket-client module; flush-on-reconnect is part of that module's lifecycle.
+- **Idempotency is the receiver's concern.** ADR-034 pins at-least-once. The bridge does not dedupe — every dispatched event becomes an HA event. Automations that mutate state on receipt (turn a light on) must tolerate duplicate fires within a small window. Documented in the mapping config's per-entry description.
+- **`event_data` is whatever the transform returns.** No envelope, no metadata injection. If a mapping needs the POPS event type echoed into the HA `event_data`, its transform spells that out. Keeps the cross-language wire contract (PRD-231) tight.
+- **No per-user policy.** The first cut is 1:1 fan-out — every published event of the matched type produces exactly one HA event. Filtering, per-user routing, or per-area gating is deferred (see Out of Scope).
+
+## Edge Cases
+
+| Case                                                            | Behaviour                                                                                                                                                                                                                                       |
+| --------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| HA WebSocket disconnected at dispatch time                      | Sink handler enqueues via the PRD-229 US-01 reconnect queue, returns `200`. Queue flushes on reconnect. At-least-once preserved.                                                                                                                |
+| HA WebSocket offline past queue cap                             | Oldest queued event dropped with a structured warning log (`eventType`, `queueDepth`, `droppedAt`). Handler still returns `200` — publisher does not retry. Ops metric `ha_sink_dropped_total{event_type}` increments.                          |
+| HA rejects the `fire_event` frame (auth required, invalid name) | WebSocket client surfaces the error; handler logs it and returns `200` — the publisher is not the right caller to retry, and the error is operator-actionable. Health endpoint reflects the underlying connection state per PRD-229.            |
+| Mapping transform throws                                        | Handler surfaces the exception → `500` to dispatcher → `pillar-offline` failure record. This is a code bug in the transform — flagged by the contract test, not expected in production.                                                         |
+| Payload passes the publisher-side Zod but fails the bridge-side | Both schemas are derived from the same mapping `schema`. A mismatch is a deployment / version-skew bug. The bridge returns `400`; dispatcher records `pillar-offline`; ops follow up. Manifest validator catches the common case at boot.       |
+| Two published events arrive concurrently                        | Each runs the handler independently. `sendFireEvent` serialises writes onto the single WebSocket; there is no ordering guarantee across event types, only FIFO within a single mapping's queued backlog after a reconnect.                      |
+| Source pillar emits an `eventType` no mapping covers            | Per PRD-236, the orchestrator only routes to bridges that declare a matching `sinks` descriptor. The HA bridge never sees the event. Inert; no error.                                                                                           |
+| Mapping config has a syntactically invalid `eventType`          | Boot-time manifest validator rejects via the PRD-236 US-01 regex (`<source>.<entity>.<action>`). Pillar fails to start with a structured error pointing at the offending entry.                                                                 |
+| Cerebrum publishes during HA bridge cold start                  | Until the bridge registers + the registry snapshot refreshes, the bridge is invisible to the orchestrator — the event has zero subscribers. PRD-236 edge case ("brand-new sink may miss the first few events") applies. Acceptable per ADR-034. |
+
+## User Stories
+
+| #   | Story                                                             | Summary                                                                                                                                                                                          | Parallelisable   |
+| --- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------- |
+| 01  | [us-01-mapping-config-manifest](us-01-mapping-config-manifest.md) | Add the `SinkMapping` type, the first-cut mappings array, derive the manifest `sinks.descriptors` block from it at boot, wire `createSinkHandler` per mapping into the bridge's HTTP surface.    | Foundation       |
+| 02  | [us-02-ws-fire-event-and-e2e](us-02-ws-fire-event-and-e2e.md)     | Implement `sendFireEvent(haEventName, eventData)` on the WebSocket client with reconnect-queue support, plus an end-to-end test (in-process registry + stub HA WS) that proves one full mapping. | Blocked by us-01 |
+
+## Out of Scope
+
+- **Outbound HA service calls (`ha.entity.callService`).** That flow is the `aiTools` dimension — see PRD-229 US-04. Sinks are for event-bus-shaped fan-out, not RPC-shaped commands.
+- **Per-user / per-area filtering of outbound events.** First cut is 1:1 fan-out. A future PRD can add a `condition` field to the mapping config once a real use case demands it.
+- **Bidirectional payload schema sharing across languages.** PRD-231 owns the cross-language wire-format spec; this PRD consumes whatever JSON-Schema shape PRD-236 lands on.
+- **Persistent durable queue.** The reconnect queue is in-process and bounded. A future ADR can revisit if at-least-once-under-restart becomes a hard requirement.
+- **Replay / backfill of historical POPS events into HA.** Sinks deliver live events from the moment of subscription. No history catch-up.
+- **MQTT / ESPHome equivalents.** Those bridges land in their own PRDs once the HA shape is proven here.
+- **HA Automation editor integration.** The bridge fires HA events; the operator wires HA-side automations against `pops_*` event names by hand. No `automation.yaml` generation in scope.

--- a/docs/themes/13-pillar-finale/prds/237-pops-to-ha-event-publisher/us-01-mapping-config-manifest.md
+++ b/docs/themes/13-pillar-finale/prds/237-pops-to-ha-event-publisher/us-01-mapping-config-manifest.md
@@ -1,0 +1,26 @@
+# US-01: Mapping config + manifest derivation + sink-handler wiring
+
+> PRD: [pops → HA outbound event publisher](README.md)
+
+## Description
+
+As the HA bridge pillar, I want a typed mapping config that drives both the manifest `sinks.descriptors` block and the runtime `/_sinks/<eventType>` handler registry, so that adding a new POPS → HA event mapping is a single-file edit with no risk of drift between what the bridge advertises and what it actually accepts.
+
+## Acceptance Criteria
+
+- [ ] A `SinkMapping` type lives at `apps/pops-ha-bridge-api/src/sinks/types.ts` with the fields `eventType`, `description`, `haEventName`, `schema`, and `transformInline` (optional; defaults to identity).
+- [ ] A `mappings: SinkMapping[]` array at `apps/pops-ha-bridge-api/src/sinks/mappings.ts` ships the three first-cut entries listed in the PRD (`media.watch.completed`, `finance.balance.low`, `inventory.item.consumed`) with valid Zod-paired JSON-Schema-shaped payload contracts.
+- [ ] The bridge's manifest derives its `sinks.descriptors` block from `mappings.map(m => ({ eventType, description, schema }))` — no hand-maintained second list of event types.
+- [ ] For each mapping, the bridge HTTP layer wires `createSinkHandler({ eventType, schema, handler })` from `@pops/pillar-sdk/server` and mounts it at `POST /_sinks/<eventType>`.
+- [ ] A boot-time validator rejects duplicate `eventType` entries in `mappings` with a structured error pointing at the offending entries.
+- [ ] A unit test asserts every mapping's `eventType` matches the `<source>.<entity>.<action>` regex from PRD-236 US-01.
+- [ ] A unit test asserts every mapping's `transformInline` is pure: same input → deep-equal output across two consecutive calls.
+- [ ] A unit test asserts the manifest `sinks.descriptors` block is exactly `mappings.length` long and round-trips each `eventType`.
+
+## Notes
+
+- Reference [PRD-236](../236-sinks-manifest-dimension/README.md) for the `sinks.descriptors` schema shape and the `createSinkHandler` contract. Reuse — do not re-derive.
+- Reference [PRD-229](../229-ha-bridge-pillar/README.md) US-05 for the pillar's existing manifest registration code path; this story plugs into it.
+- The runtime Zod registry (PRD-236 US-02) needs every `mapping.eventType` to have an in-process Zod instance. Register them at boot in the same module that exports `mappings` to avoid drift.
+- The transform default — when `transformInline` is omitted — should be `(payload) => payload`. Spell this out in code (not via TypeScript optional chaining trickery) so the contract test catches a missing transform as a config bug, not a silent identity.
+- The HA WebSocket client + queue logic ships in US-02. This story stubs `sendFireEvent` as a function whose signature is fixed (`(haEventName: string, eventData: Record<string, unknown>) => Promise<void>`) and whose body throws `not-implemented`. US-02 fills it in.

--- a/docs/themes/13-pillar-finale/prds/237-pops-to-ha-event-publisher/us-02-ws-fire-event-and-e2e.md
+++ b/docs/themes/13-pillar-finale/prds/237-pops-to-ha-event-publisher/us-02-ws-fire-event-and-e2e.md
@@ -1,0 +1,27 @@
+# US-02: `sendFireEvent` + reconnect queue + end-to-end mapping test
+
+> PRD: [pops → HA outbound event publisher](README.md)
+
+## Description
+
+As the HA bridge pillar, I want a `sendFireEvent(haEventName, eventData)` helper on the WebSocket client that delivers HA `fire_event` frames with reconnect-aware queueing, plus an end-to-end test that wires an in-process orchestrator + a stub HA WebSocket and proves one POPS event becomes one HA event over the full path.
+
+## Acceptance Criteria
+
+- [ ] `sendFireEvent(haEventName: string, eventData: Record<string, unknown>): Promise<void>` is implemented on the HA bridge's WebSocket-client module (the same module that owns the PRD-229 US-01 inbound subscriber + reconnect loop).
+- [ ] When the WebSocket is `connected`, `sendFireEvent` writes the HA WS protocol's `fire_event` frame and resolves once the frame is on the wire.
+- [ ] When the WebSocket is `reconnecting`, `sendFireEvent` enqueues onto a bounded in-memory queue (cap configurable via `HA_SINK_QUEUE_CAP`, default 100) and resolves immediately.
+- [ ] When the queue is at cap, the oldest enqueued message is dropped, a structured warning is logged with `{ eventType, queueDepth, droppedAt }`, and an ops metric `ha_sink_dropped_total{event_type}` increments.
+- [ ] On reconnect, the queue flushes in FIFO order before any new `sendFireEvent` is accepted onto the live socket.
+- [ ] An end-to-end test in `apps/pops-ha-bridge-api/src/sinks/__tests__/e2e.test.ts` constructs an in-process registry with the HA bridge manifest, calls the orchestrator's `publishEvent('media.watch.completed', samplePayload)`, and asserts the stub HA WS receives exactly one `fire_event` frame whose `event_type === 'pops_media_watch_completed'` and whose `event_data` deep-equals the (transformed) payload.
+- [ ] The same E2E test covers the reconnect-queue path: the WebSocket is forced into `reconnecting`, `publishEvent` is called, the stub HA WS receives nothing yet; after reconnect, the stub receives the queued frame.
+- [ ] The E2E test asserts that a payload failing the mapping's Zod schema is rejected with `400` at the bridge boundary and recorded as `pillar-offline` in the dispatcher result — no HA frame is sent.
+
+## Notes
+
+- Reference [PRD-229 US-01](../229-ha-bridge-pillar/us-01-ws-subscriber-mirror.md) for the WebSocket client shape — `sendFireEvent` lives in the same module and shares the reconnect state machine. Do not stand up a second WS client.
+- Reference [PRD-236 US-02](../236-sinks-manifest-dimension/us-02-orchestrator-publish-event.md) for the dispatcher contract — the E2E test uses the real `publishEvent` against the real orchestrator with an injected HTTP poster pointed at the bridge's Express/Fastify/Hono test harness.
+- The stub HA WebSocket is a `ws` server in-process; the bridge connects to it on a random port. No external HA dependency in tests. A real HA instance (`ssh capivara`, topology in `../homelab-infra`) is available for manual smoke-testing post-merge but is not part of CI.
+- The queue cap of 100 is a heuristic — small enough to fail loud under sustained HA outage, large enough to ride out a 30-second reconnect with a high-frequency sensor's worth of events. Tune later; document in the env var's JSDoc.
+- The metric increments should reuse whatever Prometheus / OpenTelemetry plumbing the bridge already uses for inbound stats. If none exists, a `console.warn` structured line is acceptable for this PRD and a follow-up tracks proper metrics.
+- The E2E test is the linchpin acceptance criterion for the whole PRD — if it passes, the bidirectional bridge model is proven.


### PR DESCRIPTION
## Summary

- Scaffolds PRD-237 (pops → HA outbound event publisher) — the first real consumer of the `sinks` manifest dimension introduced by [ADR-034](https://github.com/knoxio/pops/blob/main/docs/architecture/adr-034-sinks-manifest-dimension.md) and scaffolded by PRD-236 (#3133).
- Wires the HA bridge pillar (PRD-229 scaffold #3152) as the receiving side: `publishEvent('media.watch.completed', ...)` → orchestrator dispatch → `POST /_sinks/media.watch.completed` on the HA bridge → HA WebSocket `fire_event` frame.
- Adds two user stories: US-01 mapping config + manifest derivation + sink-handler wiring; US-02 `sendFireEvent` with reconnect queue + end-to-end test against an in-process registry and stub HA WebSocket.
- Updates the Bridge pillars epic table to reference PRD-237.

Docs-only, no code. Closes the loop on the bidirectional bridge model: PRD-229 ships inbound (HA → POPS), PRD-237 proves outbound (POPS → HA).

## Acceptance criteria (rolled up from US files)

- HA bridge manifest declares ≥1 sink, derived from a single `mappings: SinkMapping[]` array (no drift between manifest and runtime).
- Boot-time validator rejects duplicate `eventType` entries and entries that fail the `<source>.<entity>.<action>` regex.
- Orchestrator `publishEvent` routes a real event to the bridge's `/_sinks/<eventType>` endpoint; transform runs; HA WebSocket receives one `fire_event` frame with the matching `event_type` and transformed `event_data`.
- Reconnect-queue path: when the WS is `reconnecting`, sink handler returns `200`, queues the frame; on reconnect, the queue flushes in FIFO order.
- Queue at cap drops oldest with a structured warning + `ha_sink_dropped_total` metric.
- E2E test in `apps/pops-ha-bridge-api/src/sinks/__tests__/e2e.test.ts` proves one full mapping over the in-process registry + stub HA WS.

## References

- ADR-034: sinks manifest dimension
- ADR-032: positioning vs self-hosted OS family (bridge pillar pattern)
- PRD-236 (#3133): sinks scaffold (manifest field, `publishEvent`, `/_sinks/<eventType>`, `createSinkHandler`)
- PRD-229 (#3152): HA bridge pillar scaffold

## Test plan

- [ ] `pnpm lint` passes on docs
- [ ] Markdown renders correctly on GitHub (tables, code blocks, relative links)
- [ ] PRD number 237 is unique (verified — next free was 237; 238 already taken by settings-known-modules-surface)
