### PR TITLE
feat(pillar-sdk): add fetchQuery to usePillarUtils (PRD-191)

### DIFF
--- a/packages/pillar-sdk/src/react/__tests__/cache-write.test.tsx
+++ b/packages/pillar-sdk/src/react/__tests__/cache-write.test.tsx
@@ -9,6 +9,7 @@ import {
   FakeRegistryTransport,
   jsonResponse,
 } from '../../client/__tests__/fixtures.js';
+import { PillarCallError } from '../../client/errors.js';
 import { __resetSharedPillarClient } from '../../client/factory.js';
 import { usePillarMutation, usePillarQuery, usePillarUtils } from '../hooks.js';
 import { PillarSdkProvider } from '../provider.js';
@@ -162,6 +163,134 @@ describe('usePillarUtils.invalidate', () => {
       const after = harness.calls.filter((c) => c.url.endsWith('finance.wishlist.list')).length;
       expect(after).toBeGreaterThan(before);
     });
+  });
+});
+
+describe('usePillarUtils.fetchQuery', () => {
+  beforeEach(() => __resetSharedPillarClient());
+  afterEach(() => __resetSharedPillarClient());
+
+  it('resolves with the procedure output and caches it under the pillar query key', async () => {
+    const transport = new FakeRegistryTransport({ pillars: [discoveredPillar()] });
+    const payload = [{ id: 'wl-1', checked: false }];
+    const harness = buildHarness(transport, () => jsonResponse({ result: { data: payload } }));
+
+    const { result } = renderHook(() => usePillarUtils('finance'), { wrapper: harness.wrapper });
+
+    let value: readonly Item[] | undefined;
+    await act(async () => {
+      value = await result.current.fetchQuery<readonly Item[]>(['watchlist', 'list'], {
+        limit: 10,
+      });
+    });
+
+    expect(value).toEqual(payload);
+    const key = pillarQueryKey('finance', ['watchlist', 'list'], { limit: 10 });
+    expect(harness.queryClient.getQueryData(key)).toEqual(payload);
+  });
+
+  it('keys distinct inputs into separate cache slots', async () => {
+    const transport = new FakeRegistryTransport({ pillars: [discoveredPillar()] });
+    let next = 0;
+    const harness = buildHarness(transport, () => {
+      next += 1;
+      return jsonResponse({ result: { data: [{ id: `wl-${next}`, checked: false }] } });
+    });
+
+    const { result } = renderHook(() => usePillarUtils('finance'), { wrapper: harness.wrapper });
+
+    await act(async () => {
+      await result.current.fetchQuery<readonly Item[]>(['watchlist', 'list'], { limit: 5 });
+      await result.current.fetchQuery<readonly Item[]>(['watchlist', 'list'], { limit: 25 });
+    });
+
+    const keyA = pillarQueryKey('finance', ['watchlist', 'list'], { limit: 5 });
+    const keyB = pillarQueryKey('finance', ['watchlist', 'list'], { limit: 25 });
+    const a = harness.queryClient.getQueryData<readonly Item[]>(keyA);
+    const b = harness.queryClient.getQueryData<readonly Item[]>(keyB);
+    expect(a).toEqual([{ id: 'wl-1', checked: false }]);
+    expect(b).toEqual([{ id: 'wl-2', checked: false }]);
+  });
+
+  it('serves the cached value without issuing a new network call when staleTime keeps it fresh', async () => {
+    const transport = new FakeRegistryTransport({ pillars: [discoveredPillar()] });
+    const harness = buildHarness(transport, () =>
+      jsonResponse({ result: { data: [{ id: 'x' }] } })
+    );
+
+    const { result } = renderHook(() => usePillarUtils('finance'), { wrapper: harness.wrapper });
+
+    await act(async () => {
+      await result.current.fetchQuery<readonly { id: string }[]>(
+        ['watchlist', 'list'],
+        { limit: 10 },
+        { staleTime: 60_000 }
+      );
+    });
+    const callsAfterFirst = harness.calls.length;
+
+    await act(async () => {
+      await result.current.fetchQuery<readonly { id: string }[]>(
+        ['watchlist', 'list'],
+        { limit: 10 },
+        { staleTime: 60_000 }
+      );
+    });
+
+    expect(harness.calls.length).toBe(callsAfterFirst);
+  });
+
+  it('rejects with PillarCallError when the call fails', async () => {
+    const transport = new FakeRegistryTransport({ pillars: [discoveredPillar()] });
+    const harness = buildHarness(
+      transport,
+      () =>
+        new Response(
+          JSON.stringify({ error: { code: 'INTERNAL_SERVER_ERROR', message: 'boom' } }),
+          { status: 500, headers: { 'content-type': 'application/json' } }
+        )
+    );
+
+    const { result } = renderHook(() => usePillarUtils('finance'), { wrapper: harness.wrapper });
+
+    let captured: unknown;
+    await act(async () => {
+      try {
+        await result.current.fetchQuery<readonly Item[]>(['watchlist', 'list'], { limit: 10 });
+      } catch (e) {
+        captured = e;
+      }
+    });
+
+    expect(captured).toBeInstanceOf(PillarCallError);
+  });
+
+  it('forwards retry: false via opts so failing calls reject immediately', async () => {
+    const transport = new FakeRegistryTransport({ pillars: [discoveredPillar()] });
+    const harness = buildHarness(
+      transport,
+      () =>
+        new Response(
+          JSON.stringify({ error: { code: 'INTERNAL_SERVER_ERROR', message: 'boom' } }),
+          { status: 500, headers: { 'content-type': 'application/json' } }
+        )
+    );
+
+    const { result } = renderHook(() => usePillarUtils('finance'), { wrapper: harness.wrapper });
+
+    await act(async () => {
+      try {
+        await result.current.fetchQuery<readonly Item[]>(
+          ['watchlist', 'list'],
+          { limit: 10 },
+          { retry: false }
+        );
+      } catch {
+        // expected
+      }
+    });
+
+    expect(harness.calls.length).toBe(1);
   });
 });
 

--- a/packages/pillar-sdk/src/react/hooks.ts
+++ b/packages/pillar-sdk/src/react/hooks.ts
@@ -2,7 +2,12 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback } from 'react';
 
 import { PillarCallError } from '../client/errors.js';
-import { pillar } from '../client/factory.js';
+import {
+  callProcedure,
+  failureFlagsFrom,
+  NO_FAILURE,
+  type ProcedurePath,
+} from './internal/call-procedure.js';
 import { usePillarSdkOptions } from './provider.js';
 import { pillarQueryKey } from './query-key.js';
 
@@ -13,52 +18,7 @@ import type {
   UseQueryResult,
 } from '@tanstack/react-query';
 
-import type { CallFailure, CallResult } from '../client/errors.js';
-
-type ProcedurePath = readonly [string, ...string[]];
-
-type FailureFlags = {
-  isContractMismatch: boolean;
-  isUnavailable: boolean;
-  isDegraded: boolean;
-};
-
-const NO_FAILURE: FailureFlags = {
-  isContractMismatch: false,
-  isUnavailable: false,
-  isDegraded: false,
-};
-
-function failureFlagsFrom(failure: CallFailure): FailureFlags {
-  return {
-    isContractMismatch: failure.kind === 'contract-mismatch',
-    isUnavailable: failure.kind === 'unavailable',
-    isDegraded: failure.kind === 'degraded',
-  };
-}
-
-function callProcedure<TOutput>(
-  pillarId: string,
-  path: ProcedurePath,
-  input: unknown,
-  options: ReturnType<typeof usePillarSdkOptions>
-): Promise<CallResult<TOutput>> {
-  const handle = pillar<unknown>(pillarId, options);
-  let node: unknown = handle;
-  for (let i = 0; i < path.length - 1; i += 1) {
-    const segment = path[i] as string;
-    node = (node as Record<string, unknown>)[segment];
-  }
-  const leaf = (node as Record<string, unknown>)[path[path.length - 1] as string];
-  if (typeof leaf !== 'function') {
-    throw new PillarCallError(pillarId, {
-      kind: 'contract-mismatch',
-      pillar: pillarId,
-      actual: path.join('.'),
-    });
-  }
-  return (leaf as (i: unknown) => Promise<CallResult<TOutput>>)(input);
-}
+import type { FailureFlags } from './internal/call-procedure.js';
 
 export type UsePillarQueryOptions<TOutput> = Omit<
   UseQueryOptions<TOutput, PillarCallError, TOutput, readonly unknown[]>,
@@ -125,7 +85,7 @@ export type UsePillarMutationResult<TInput, TOutput, TContext = unknown> = UseMu
  * (single-segment paths) invalidate the entire `[pillarId]` prefix.
  *
  * Optimistic updates: pass `onMutate` to snapshot + apply optimistic
- * cache writes (typically through {@link usePillarUtils}) and return a
+ * cache writes (typically through `usePillarUtils`) and return a
  * `previousData` blob. `onError` then receives that blob as its third
  * argument so callers can roll back. `onSettled` fires on both success
  * and failure paths. All four lifecycle callbacks (`onMutate`,
@@ -174,91 +134,12 @@ export function usePillarMutation<TInput = unknown, TOutput = unknown, TContext 
   return { ...mutation, ...flags } as UsePillarMutationResult<TInput, TOutput, TContext>;
 }
 
-export type PillarUpdater<TData> = (previous: TData | undefined) => TData | undefined;
-
-export type UsePillarUtilsResult = {
-  /**
-   * Imperatively write to the cache slot keyed by
-   * `pillarQueryKey(pillarId, routerPath, input)`. `updater` receives the
-   * current value (or `undefined` if the slot is empty) and returns the
-   * next value. Returning `undefined` removes the slot.
-   *
-   * Returns the snapshot of the previous value, suitable to stash in the
-   * `onMutate` context for rollback.
-   */
-  setData: <TData>(
-    routerPath: ProcedurePath,
-    input: unknown,
-    updater: PillarUpdater<TData>
-  ) => TData | undefined;
-  /**
-   * Invalidate cached queries under this pillar. With no argument,
-   * invalidates everything under `[pillarId]`. With `routerPath`,
-   * invalidates everything under `[pillarId, ...routerPath]` — pass the
-   * router prefix (e.g. `['wishlist']`) or the full procedure path
-   * (e.g. `['wishlist', 'list']`).
-   *
-   * Returns the underlying React Query promise so callers can `await`
-   * the invalidation if they want refetches to settle before continuing.
-   */
-  invalidate: (routerPath?: readonly string[]) => Promise<void>;
-};
-
-/**
- * Cache-write surface for a given pillar. Use alongside
- * {@link usePillarQuery} / {@link usePillarMutation} to drive optimistic
- * updates without hand-rolling query keys at the call site.
- *
- * Typical optimistic-update flow:
- * ```ts
- * const utils = usePillarUtils('media');
- * usePillarMutation<Input, Output, { previous: Item[] | undefined }>(
- *   'media',
- *   ['watchlist', 'toggle'],
- *   {
- *     onMutate: (vars) => {
- *       const previous = utils.setData<Item[]>(
- *         ['watchlist', 'list'],
- *         { limit: 10 },
- *         (prev) => applyToggle(prev, vars)
- *       );
- *       return { previous };
- *     },
- *     onError: (_err, _vars, ctx) => {
- *       utils.setData(['watchlist', 'list'], { limit: 10 }, () => ctx?.previous);
- *     },
- *   }
- * );
- * ```
- */
-export function usePillarUtils(pillarId: string): UsePillarUtilsResult {
-  const queryClient = useQueryClient();
-
-  const setData = useCallback(
-    <TData>(
-      routerPath: ProcedurePath,
-      input: unknown,
-      updater: PillarUpdater<TData>
-    ): TData | undefined => {
-      const key = pillarQueryKey(pillarId, routerPath, input);
-      const previous = queryClient.getQueryData<TData>(key);
-      const next = updater(previous);
-      queryClient.setQueryData<TData>(key, next);
-      return previous;
-    },
-    [queryClient, pillarId]
-  );
-
-  const invalidate = useCallback(
-    async (routerPath?: readonly string[]): Promise<void> => {
-      const queryKey = routerPath && routerPath.length > 0 ? [pillarId, ...routerPath] : [pillarId];
-      await queryClient.invalidateQueries({ queryKey });
-    },
-    [queryClient, pillarId]
-  );
-
-  return { setData, invalidate };
-}
+export {
+  usePillarUtils,
+  type PillarUpdater,
+  type UsePillarUtilsFetchQueryOptions,
+  type UsePillarUtilsResult,
+} from './use-pillar-utils.js';
 
 export type UsePillarCallDynamicQueryOptions = UsePillarQueryOptions<unknown>;
 export type UsePillarCallDynamicQueryResult = UsePillarQueryResult<unknown>;

--- a/packages/pillar-sdk/src/react/index.ts
+++ b/packages/pillar-sdk/src/react/index.ts
@@ -19,6 +19,7 @@ export type {
   UsePillarMutationResult,
   UsePillarQueryOptions,
   UsePillarQueryResult,
+  UsePillarUtilsFetchQueryOptions,
   UsePillarUtilsResult,
 } from './hooks.js';
 export { pillarQueryKey } from './query-key.js';

--- a/packages/pillar-sdk/src/react/internal/call-procedure.ts
+++ b/packages/pillar-sdk/src/react/internal/call-procedure.ts
@@ -1,0 +1,50 @@
+import { PillarCallError } from '../../client/errors.js';
+import { pillar } from '../../client/factory.js';
+
+import type { CallFailure, CallResult } from '../../client/errors.js';
+import type { PillarClientOptions } from '../../client/factory.js';
+
+export type ProcedurePath = readonly [string, ...string[]];
+
+export type FailureFlags = {
+  isContractMismatch: boolean;
+  isUnavailable: boolean;
+  isDegraded: boolean;
+};
+
+export const NO_FAILURE: FailureFlags = {
+  isContractMismatch: false,
+  isUnavailable: false,
+  isDegraded: false,
+};
+
+export function failureFlagsFrom(failure: CallFailure): FailureFlags {
+  return {
+    isContractMismatch: failure.kind === 'contract-mismatch',
+    isUnavailable: failure.kind === 'unavailable',
+    isDegraded: failure.kind === 'degraded',
+  };
+}
+
+export function callProcedure<TOutput>(
+  pillarId: string,
+  path: ProcedurePath,
+  input: unknown,
+  options: PillarClientOptions
+): Promise<CallResult<TOutput>> {
+  const handle = pillar<unknown>(pillarId, options);
+  let node: unknown = handle;
+  for (let i = 0; i < path.length - 1; i += 1) {
+    const segment = path[i] as string;
+    node = (node as Record<string, unknown>)[segment];
+  }
+  const leaf = (node as Record<string, unknown>)[path[path.length - 1] as string];
+  if (typeof leaf !== 'function') {
+    throw new PillarCallError(pillarId, {
+      kind: 'contract-mismatch',
+      pillar: pillarId,
+      actual: path.join('.'),
+    });
+  }
+  return (leaf as (i: unknown) => Promise<CallResult<TOutput>>)(input);
+}

--- a/packages/pillar-sdk/src/react/use-pillar-utils.ts
+++ b/packages/pillar-sdk/src/react/use-pillar-utils.ts
@@ -1,0 +1,144 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
+
+import { PillarCallError } from '../client/errors.js';
+import { callProcedure } from './internal/call-procedure.js';
+import { usePillarSdkOptions } from './provider.js';
+import { pillarQueryKey } from './query-key.js';
+
+import type { FetchQueryOptions } from '@tanstack/react-query';
+
+import type { ProcedurePath } from './internal/call-procedure.js';
+
+export type PillarUpdater<TData> = (previous: TData | undefined) => TData | undefined;
+
+export type UsePillarUtilsFetchQueryOptions<TOutput> = Omit<
+  FetchQueryOptions<TOutput, PillarCallError, TOutput, readonly unknown[]>,
+  'queryKey' | 'queryFn'
+>;
+
+export type UsePillarUtilsResult = {
+  /**
+   * Imperatively write to the cache slot keyed by
+   * `pillarQueryKey(pillarId, routerPath, input)`. `updater` receives the
+   * current value (or `undefined` if the slot is empty) and returns the
+   * next value. Returning `undefined` removes the slot.
+   *
+   * Returns the snapshot of the previous value, suitable to stash in the
+   * `onMutate` context for rollback.
+   */
+  setData: <TData>(
+    routerPath: ProcedurePath,
+    input: unknown,
+    updater: PillarUpdater<TData>
+  ) => TData | undefined;
+  /**
+   * Invalidate cached queries under this pillar. With no argument,
+   * invalidates everything under `[pillarId]`. With `routerPath`,
+   * invalidates everything under `[pillarId, ...routerPath]` — pass the
+   * router prefix (e.g. `['wishlist']`) or the full procedure path
+   * (e.g. `['wishlist', 'list']`).
+   *
+   * Returns the underlying React Query promise so callers can `await`
+   * the invalidation if they want refetches to settle before continuing.
+   */
+  invalidate: (routerPath?: readonly string[]) => Promise<void>;
+  /**
+   * Imperatively fetch a query for the slot keyed by
+   * `pillarQueryKey(pillarId, routerPath, input)`. Mirrors
+   * `queryClient.fetchQuery` semantics: returns the cached value if it
+   * is still fresh (respecting `staleTime`), otherwise issues the
+   * underlying pillar call and caches the result.
+   *
+   * Use this for one-shot imperative reads — e.g. fetching data inside
+   * an event handler — where the React Query `usePillarQuery` hook is
+   * not appropriate. Rejects with a `PillarCallError` on failure.
+   *
+   * `opts` is forwarded to the underlying `queryClient.fetchQuery`,
+   * minus `queryKey` and `queryFn` which are derived from `routerPath`
+   * + `input`.
+   */
+  fetchQuery: <TOutput>(
+    routerPath: ProcedurePath,
+    input: unknown,
+    opts?: UsePillarUtilsFetchQueryOptions<TOutput>
+  ) => Promise<TOutput>;
+};
+
+/**
+ * Cache-write surface for a given pillar. Use alongside
+ * `usePillarQuery` / `usePillarMutation` to drive optimistic updates
+ * without hand-rolling query keys at the call site, and to issue
+ * imperative one-shot reads through `fetchQuery`.
+ *
+ * Typical optimistic-update flow:
+ * ```ts
+ * const utils = usePillarUtils('media');
+ * usePillarMutation<Input, Output, { previous: Item[] | undefined }>(
+ *   'media',
+ *   ['watchlist', 'toggle'],
+ *   {
+ *     onMutate: (vars) => {
+ *       const previous = utils.setData<Item[]>(
+ *         ['watchlist', 'list'],
+ *         { limit: 10 },
+ *         (prev) => applyToggle(prev, vars)
+ *       );
+ *       return { previous };
+ *     },
+ *     onError: (_err, _vars, ctx) => {
+ *       utils.setData(['watchlist', 'list'], { limit: 10 }, () => ctx?.previous);
+ *     },
+ *   }
+ * );
+ * ```
+ */
+export function usePillarUtils(pillarId: string): UsePillarUtilsResult {
+  const queryClient = useQueryClient();
+  const sdkOptions = usePillarSdkOptions();
+
+  const setData = useCallback(
+    <TData>(
+      routerPath: ProcedurePath,
+      input: unknown,
+      updater: PillarUpdater<TData>
+    ): TData | undefined => {
+      const key = pillarQueryKey(pillarId, routerPath, input);
+      const previous = queryClient.getQueryData<TData>(key);
+      const next = updater(previous);
+      queryClient.setQueryData<TData>(key, next);
+      return previous;
+    },
+    [queryClient, pillarId]
+  );
+
+  const invalidate = useCallback(
+    async (routerPath?: readonly string[]): Promise<void> => {
+      const queryKey = routerPath && routerPath.length > 0 ? [pillarId, ...routerPath] : [pillarId];
+      await queryClient.invalidateQueries({ queryKey });
+    },
+    [queryClient, pillarId]
+  );
+
+  const fetchQuery = useCallback(
+    <TOutput>(
+      routerPath: ProcedurePath,
+      input: unknown,
+      opts?: UsePillarUtilsFetchQueryOptions<TOutput>
+    ): Promise<TOutput> => {
+      const queryKey = pillarQueryKey(pillarId, routerPath, input);
+      return queryClient.fetchQuery<TOutput, PillarCallError, TOutput, readonly unknown[]>({
+        ...opts,
+        queryKey,
+        queryFn: async () => {
+          const result = await callProcedure<TOutput>(pillarId, routerPath, input, sdkOptions);
+          if (result.kind === 'ok') return result.value;
+          throw new PillarCallError(pillarId, result);
+        },
+      });
+    },
+    [queryClient, pillarId, sdkOptions]
+  );
+
+  return { setData, invalidate, fetchQuery };
+}


### PR DESCRIPTION
## Summary

- Adds `fetchQuery<TOutput>(routerPath, input, opts?): Promise<TOutput>` to `usePillarUtils` in `@pops/pillar-sdk/react`, mirroring `queryClient.fetchQuery` semantics.
- Reuses the same query key (`pillarQueryKey(pillarId, routerPath, input)`) and call mechanism as `usePillarQuery`, so cached values served by either path are interchangeable. Errors surface as `PillarCallError`; `staleTime` / `retry` / other `FetchQueryOptions` are forwarded.
- Extracts the shared `callProcedure` + failure-flag helpers to `react/internal/call-procedure.ts`, and moves `usePillarUtils` to its own `use-pillar-utils.ts` (re-exported from `hooks.ts` so the public surface is unchanged). This keeps both files under the 200-line lint cap.

## Why

PR #3156 (app-media batch 3) flagged the gap: `usePillarUtils()` exposed `setData` + `invalidate` but not `fetchQuery`, so imperative one-shot reads (e.g. `useFetchScoreDelta` in `compare-arena/*`) couldn't be migrated to the SDK without dropping back to a raw `pillar()` call. This PR is the SDK-side affordance only — no consumer migration here. A follow-up will flip the compare-arena call sites.

## Test plan

- [x] `pnpm --filter @pops/pillar-sdk typecheck`
- [x] `pnpm --filter @pops/pillar-sdk test` — 476 tests pass (5 new unit tests for `fetchQuery`)
- [x] `pnpm --filter @pops/pillar-sdk build`
- [x] husky/lint-staged on commit
- [x] no consumer touched
