### PR TITLE
feat(api/cerebrum): migrate handlers + audit (Wave 5 long-tail)

### DIFF
--- a/apps/pops-api/src/modules/cerebrum/glia/digest-channels.ts
+++ b/apps/pops-api/src/modules/cerebrum/glia/digest-channels.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'node:crypto';
 
 import { nudgeLog } from '@pops/db-types';
 
-import { getDrizzle } from '../../../db.js';
+import { getCerebrumDrizzle } from '../../../db/cerebrum-handle.js';
 import { logger } from '../../../lib/logger.js';
 import {
   escapeTelegramMarkdownV2,
@@ -42,7 +42,7 @@ export function deliverShellDigest(
   body: string,
   now: Date = new Date()
 ): boolean {
-  const db = getDrizzle();
+  const db = getCerebrumDrizzle();
   const id = buildShellNudgeId(now);
   const title = `Glia ${report.period} digest — ${report.totalAutonomousActions} autonomous actions`;
   const engramIds = collectEngramIds(report);

--- a/apps/pops-api/src/modules/cerebrum/retrieval/router.ts
+++ b/apps/pops-api/src/modules/cerebrum/retrieval/router.ts
@@ -14,6 +14,7 @@ import { z } from 'zod';
 import { embeddings, engramIndex } from '@pops/db-types';
 
 import { getDrizzle } from '../../../db.js';
+import { getCerebrumDrizzle } from '../../../db/cerebrum-handle.js';
 import { trpcError } from '../../../shared/trpc-error.js';
 import { protectedProcedure, router } from '../../../trpc.js';
 import { ContextAssemblyService } from './context-assembly.js';
@@ -166,7 +167,7 @@ export const retrievalRouter = router({
    * Retrieval layer health and coverage counts.
    */
   stats: protectedProcedure.query(() => {
-    const db = getDrizzle();
+    const db = getCerebrumDrizzle();
 
     const [indexedRow] = db.select({ count: count() }).from(engramIndex).all();
     const indexed = indexedRow?.count ?? 0;

--- a/docs/themes/13-pillar-finale/notes/wave-5-handler-state-audit.md
+++ b/docs/themes/13-pillar-finale/notes/wave-5-handler-state-audit.md
@@ -1,0 +1,123 @@
+# Wave 5 handler-state audit
+
+Snapshot date: 2026-06-14.
+
+Context: PR #3162 (finance) and this branch (cerebrum) audit the actual
+state of `getDrizzle()` callers per pillar so Wave 5 can be sized off
+real handler-real-callers rather than raw grep counts that conflate
+production handlers with test-side `vi.mock(..., { getDrizzle })`
+fixtures.
+
+## Methodology
+
+The Wave 5 long-tail estimate ("~485 callers") was a raw grep over
+`apps/pops-api/src/`. That grep does not distinguish between:
+
+1. **Handler-real callers** — production code that resolves the shared
+   `getDrizzle()` at runtime and would actually move bytes through the
+   shared `pops.db` file in deployed builds.
+2. **Test-mock callers** — `vi.mock('../../../../db.js', () => ({
+getDrizzle: ... }))` shapes whose keys exist only to satisfy the
+   mock surface. These do not exercise the shared handle in production
+   and migrating them is a test-suite verification fix, not a pillar
+   cutover.
+3. **Documented intentional pinning** — call sites with inline JSDoc
+   explaining why the shared handle is required (typically cross-pillar
+   SQL joins against tables that have not migrated yet).
+
+Sizing Wave 5 off raw grep inflates the work by every test mock and
+every documented intentional pin. The two pillars audited so far both
+came in dramatically smaller than the raw grep suggested.
+
+## Per-pillar findings
+
+### Finance (PR #3162)
+
+- Raw grep before: 18 occurrences under `apps/pops-api/src/modules/finance/`.
+- Handler-real callers: **0**. Every production handler was already on
+  `getFinanceDrizzle()` from the original infra-first cutover.
+- Test-mock + verify-side callers: **16**. Flipped in #3162 so test
+  assertions read from the pillar handle, matching the production
+  surface.
+- Remaining 2: dead-code `vi.mock` entries inside
+  `ai-categorizer{,-disk}.{test,integration.test}.ts` whose underlying
+  source no longer calls `getDrizzle()`; deferred to a follow-up that
+  also fixes the broken `getCoreDrizzle` mock omission.
+- **Count delta: 18 → 2.**
+
+### Cerebrum (this branch)
+
+Raw `getDrizzle()` references under `apps/pops-api/src/modules/cerebrum/`: 26.
+
+Breakdown:
+
+| Category                                                 | Count | Notes                                                                                                                                                                                                                                                                                                          |
+| -------------------------------------------------------- | ----- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Inline JSDoc comments (no call)                          | 7     | Cross-pillar-pin rationale in `retrieval/*.ts`, `nudges/router.ts`, `__integration__/cerebrum-handle-coverage.test.ts`, `debrief/router.ts`, `engrams/service.ts`.                                                                                                                                             |
+| HybridSearchService instantiations (pinned, PRD-179 PR4) | 11    | `ego/engine.ts:173`, `ai-tools/search.ts:80`, `retrieval/router.ts:60,127,157`, `workers/router.ts:33`, `workers/handler.ts:29`, `emit/generation-service.ts:192`, `query/query-service.ts:174,213`, `nudges/router.ts:52`. Cross-pillar joins against `transactions`, `movies`, `tv_shows`, `home_inventory`. |
+| `thalamus/router.ts:80` — `CrossSourceIndexer`           | 1     | Pinned: indexer scans cross-pillar source types by definition.                                                                                                                                                                                                                                                 |
+| `reflex_executions` shared-only table reads/writes       | 4     | `reflex/reflex-queries.ts:24`, `reflex/reflex-io.ts:145,178`, `reflex/reflex-service.ts:195`. Schema lives only in shared `pops.db`; not in `@pops/cerebrum-db`.                                                                                                                                               |
+| Test-mock callers                                        | 1     | `__integration__/cerebrum-handle-coverage.test.ts` plus 7 module-test `vi.mock` shapes under `__tests__/`.                                                                                                                                                                                                     |
+| **Real handler migration candidates**                    | **2** | `glia/digest-channels.ts:45` (`nudgeLog` writes — schema lives in cerebrum-db) and `retrieval/router.ts:169` (stats procedure reads `engramIndex` + `embeddings` — both in cerebrum-db).                                                                                                                       |
+
+Both migration candidates were flipped on this branch. The 11
+HybridSearchService sites stay on the shared handle because the
+documented PRD-179 PR 4 plan requires restructuring cross-pillar
+enrichment joins first; flipping them in isolation would break
+semantic search metadata resolution.
+
+**Count delta: 26 → 24** (the 2 migrated, the remaining 24 are either
+documented-pinned, on shared-only tables, or test-mocks).
+
+## Methodology lesson
+
+When sizing future pillar cutovers off `getDrizzle()` grep counts:
+
+1. Subtract `__tests__/`, `__integration__/`, `*.test.ts`, and
+   `*.integration.test.ts` matches up front — these are test fixtures,
+   not handler callers.
+2. Read inline JSDoc on each remaining hit. Documented pins (cross-
+   pillar joins, shared-only schema tables) are work for the dependent
+   PRD, not the current pillar.
+3. For each handler-real caller, check whether every table it touches
+   is exposed by the per-pillar `*-db` package. If even one table is
+   shared-only, the call site cannot move until that table migrates or
+   the join is refactored to per-pillar SDK lookups.
+
+Applying this filter to finance and cerebrum reduced raw counts from
+18 and 26 to **0 + 2 real handler-real-caller migrations** across both
+pillars. The original "~485 callers" Wave 5 sizing is almost certainly
+inflated by an order of magnitude.
+
+## Recommendation for next audits
+
+Before opening any further Wave 5 migration PR:
+
+1. Re-run the raw grep against the remaining pillars
+   (`core`, `media`, `inventory`, `lists`, `food`, `app-*`).
+2. Bucket every hit into the four categories above (test-mock,
+   documented-pin, shared-only schema, real-handler-candidate).
+3. Only the **real-handler-candidate** bucket is in scope for the
+   pillar cutover commit. Test-mock work belongs in a separate
+   "verify-side handle hygiene" PR per pillar; documented pins belong
+   to the PRD that owns the cross-pillar refactor.
+4. Publish the per-pillar table so Wave 5 sizing converges to a real
+   number rather than a grep total.
+
+## What this branch changed
+
+Two real handler-real-caller migrations:
+
+- `apps/pops-api/src/modules/cerebrum/glia/digest-channels.ts:45`
+  — `deliverShellDigest` writes to `nudgeLog` (a table re-exported by
+  `@pops/cerebrum-db`); now resolves via `getCerebrumDrizzle()`.
+- `apps/pops-api/src/modules/cerebrum/retrieval/router.ts:169`
+  — `cerebrum.retrieval.stats` reads `engramIndex` row counts and
+  `embeddings` source-type counts; both tables live in
+  `@pops/cerebrum-db`, so the procedure now resolves via
+  `getCerebrumDrizzle()`.
+
+Both are behaviour-preserving: under `setupTestContext` both handles
+resolve to the same in-memory DB, and in production the cerebrum
+handle owns the same tables on disk via the cerebrum-db schema +
+backfill.


### PR DESCRIPTION
## Summary

- Audits `apps/pops-api/src/modules/cerebrum/**` for `getDrizzle()` vs `getCerebrumDrizzle()` state ahead of Wave 5 sizing, mirroring the methodology from PR #3162 (finance).
- Flips the **two real handler-real-caller** sites whose tables already live in `@pops/cerebrum-db`:
  - `glia/digest-channels.ts` — `nudgeLog` writes in `deliverShellDigest`.
  - `retrieval/router.ts` — `cerebrum.retrieval.stats` reads on `engramIndex` + `embeddings`.
- Adds `docs/themes/13-pillar-finale/notes/wave-5-handler-state-audit.md` with the full per-pillar table (finance + cerebrum), the methodology lesson, and the recommended bucketing rule for next audits.

## Why the rest stays on `getDrizzle()`

Raw grep returns 26 hits under the cerebrum module. After bucketing:

| Bucket | Count | Notes |
| --- | --- | --- |
| JSDoc comments (no call) | 7 | Documented cross-pillar rationale. |
| HybridSearchService pins (PRD-179 PR 4) | 11 | Cross-pillar joins against `transactions`/`movies`/`tv_shows`/`home_inventory`. |
| `CrossSourceIndexer` (thalamus) | 1 | Cross-pillar by definition. |
| `reflex_executions` (shared-only schema) | 4 | Table not in `@pops/cerebrum-db`. |
| Test mocks | 1 + 7 `vi.mock` shapes | Verify-side, not production. |
| **Real handler candidates** | **2** | Migrated in this PR. |

Methodology lesson (validates #3162): raw `getDrizzle()` grep over a pillar conflates production handlers with `vi.mock` keys and documented cross-pillar pins. Both finance (18 → 0) and cerebrum (26 → 2) show real-handler counts an order of magnitude below the raw totals. The original "~485 callers" Wave 5 estimate is likely inflated by the same factor.

## Test plan

- [ ] `pnpm --filter @pops/api typecheck`
- [ ] `pnpm vitest run src/modules/cerebrum/glia src/modules/cerebrum/retrieval` (within `apps/pops-api`)
- [ ] Confirm both migrated handlers continue to resolve to the same in-memory DB under `setupTestContext` (both pillar getters fall back to the env DB inside `isNamedEnvContext()`).
- [ ] Verify no behaviour change in production: `cerebrum.db` already owns `nudgeLog`, `engramIndex`, and `embeddings` via `@pops/cerebrum-db` + boot backfill.
