### PR TITLE
feat(ha-bridge): PRD-229 US-02 FTS5 search adapter over ha_entities

### DIFF
--- a/apps/pops-ha-bridge-api/src/__tests__/entities-adapter.test.ts
+++ b/apps/pops-ha-bridge-api/src/__tests__/entities-adapter.test.ts
@@ -1,0 +1,140 @@
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { openHaBridgeDb, upsertEntity, type OpenedHaBridgeDb } from '@pops/ha-bridge-db';
+
+import {
+  HA_ENTITIES_ADAPTER_NAME,
+  HA_ENTITIES_ENTITY_TYPE,
+  HA_ENTITIES_PROCEDURE_PATH,
+  runHaEntitiesSearch,
+  type HaEntityHitData,
+} from '../search/entities-adapter.js';
+
+function isHaEntityHitData(value: unknown): value is HaEntityHitData {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v['id'] === 'string' &&
+    typeof v['label'] === 'string' &&
+    typeof v['domain'] === 'string' &&
+    typeof v['state'] === 'string' &&
+    typeof v['snippet'] === 'string'
+  );
+}
+
+describe('ha bridge entities-adapter', () => {
+  let opened: OpenedHaBridgeDb;
+
+  beforeEach(() => {
+    const dir = mkdtempSync(join(tmpdir(), 'ha-bridge-adapter-'));
+    opened = openHaBridgeDb(join(dir, 'ha-bridge.db'));
+  });
+
+  afterEach(() => {
+    opened.raw.close();
+  });
+
+  it('exports stable identifiers', () => {
+    expect(HA_ENTITIES_ADAPTER_NAME).toBe('haEntities');
+    expect(HA_ENTITIES_ENTITY_TYPE).toBe('ha-entity');
+    expect(HA_ENTITIES_PROCEDURE_PATH).toBe('habridge.entities.search');
+  });
+
+  it('returns [] for missing / empty / whitespace-only text', () => {
+    upsertEntity(opened.db, {
+      entityId: 'sensor.kitchen_temperature',
+      state: '21',
+      attributes: { friendly_name: 'Kitchen Temp', device_class: 'temperature' },
+      area: 'kitchen',
+      lastChanged: 1,
+      lastSeen: 1,
+    });
+
+    expect(runHaEntitiesSearch(opened.db, {})).toEqual([]);
+    expect(runHaEntitiesSearch(opened.db, { text: '' })).toEqual([]);
+    expect(runHaEntitiesSearch(opened.db, { text: '   ' })).toEqual([]);
+  });
+
+  it('returns ScoredResult-shaped rows the orchestrator can consume', () => {
+    upsertEntity(opened.db, {
+      entityId: 'sensor.kitchen_temperature',
+      state: '21.4',
+      attributes: { friendly_name: 'Kitchen Temp', device_class: 'temperature' },
+      area: 'kitchen',
+      lastChanged: 1,
+      lastSeen: 1,
+    });
+
+    const results = runHaEntitiesSearch(opened.db, { text: 'kitchen temperature' });
+    expect(results.length).toBeGreaterThan(0);
+    const top = results[0];
+    expect(top).toBeDefined();
+    expect(typeof top?.score).toBe('number');
+    expect(top?.entityName).toBe('Kitchen Temp');
+    expect(isHaEntityHitData(top?.data)).toBe(true);
+    if (top !== undefined && isHaEntityHitData(top.data)) {
+      expect(top.data.id).toBe('sensor.kitchen_temperature');
+      expect(top.data.area).toBe('kitchen');
+      expect(top.data.deviceClass).toBe('temperature');
+      expect(top.data.state).toBe('21.4');
+      expect(top.data.domain).toBe('sensor');
+    }
+  });
+
+  it('falls back to entity_id when the friendly name is missing', () => {
+    upsertEntity(opened.db, {
+      entityId: 'sensor.cellar_humidity',
+      state: '55',
+      attributes: { device_class: 'humidity' },
+      area: 'cellar',
+      lastChanged: 1,
+      lastSeen: 1,
+    });
+    const results = runHaEntitiesSearch(opened.db, { text: 'cellar' });
+    expect(results[0]?.entityName).toBe('sensor.cellar_humidity');
+  });
+
+  it('ranks an exact area+device-class match above a pure name match', () => {
+    upsertEntity(opened.db, {
+      entityId: 'sensor.kitchen_temperature',
+      state: '21.4',
+      attributes: { friendly_name: 'Kitchen Temp', device_class: 'temperature' },
+      area: 'kitchen',
+      lastChanged: 1,
+      lastSeen: 1,
+    });
+    upsertEntity(opened.db, {
+      entityId: 'sensor.garage_outdoor',
+      state: '8',
+      attributes: {
+        friendly_name: 'Garage Outdoor Kitchen Temperature Probe',
+        device_class: 'temperature',
+      },
+      area: 'garage',
+      lastChanged: 1,
+      lastSeen: 1,
+    });
+
+    const results = runHaEntitiesSearch(opened.db, { text: 'kitchen temperature' });
+    expect(results[0]?.entityName).toBe('Kitchen Temp');
+  });
+
+  it('honours the limit option', () => {
+    for (let i = 0; i < 5; i += 1) {
+      upsertEntity(opened.db, {
+        entityId: `sensor.kitchen_probe_${i}`,
+        state: String(i),
+        attributes: { friendly_name: `Kitchen Probe ${i}`, device_class: 'temperature' },
+        area: 'kitchen',
+        lastChanged: 1,
+        lastSeen: 1,
+      });
+    }
+    const results = runHaEntitiesSearch(opened.db, { text: 'kitchen', limit: 2 });
+    expect(results).toHaveLength(2);
+  });
+});

--- a/apps/pops-ha-bridge-api/src/__tests__/manifest.test.ts
+++ b/apps/pops-ha-bridge-api/src/__tests__/manifest.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, it } from 'vitest';
 
-import { ManifestPayloadSchema } from '@pops/pillar-sdk/manifest-schema';
+import { ManifestPayloadSchema, validateManifestPayload } from '@pops/pillar-sdk/manifest-schema';
 
 import { buildHaBridgeManifest, HA_BRIDGE_PILLAR_ID } from '../manifest.js';
+import {
+  HA_ENTITIES_ADAPTER_NAME,
+  HA_ENTITIES_ENTITY_TYPE,
+  HA_ENTITIES_PROCEDURE_PATH,
+} from '../search/entities-adapter.js';
 
 describe('buildHaBridgeManifest', () => {
   it('produces a payload that passes the central manifest schema', () => {
@@ -10,9 +15,29 @@ describe('buildHaBridgeManifest', () => {
     const parsed = ManifestPayloadSchema.parse(manifest);
     expect(parsed.pillar).toBe(HA_BRIDGE_PILLAR_ID);
     expect(parsed.contract.tag).toBe('contract-ha-bridge@v0.1.0');
-    expect(parsed.search.adapters).toEqual([]);
     expect(parsed.ai.tools).toEqual([]);
     expect(parsed.sinks?.descriptors).toEqual([]);
+  });
+
+  it('declares the haEntities search adapter (US-02)', () => {
+    const manifest = buildHaBridgeManifest('0.1.0');
+    expect(manifest.search.adapters).toHaveLength(1);
+    const adapter = manifest.search.adapters[0];
+    expect(adapter?.name).toBe(HA_ENTITIES_ADAPTER_NAME);
+    expect(adapter?.entityType).toBe(HA_ENTITIES_ENTITY_TYPE);
+    expect(adapter?.procedurePath).toBe(HA_ENTITIES_PROCEDURE_PATH);
+    expect(adapter?.queryShape).toEqual({
+      supportsText: true,
+      supportsTags: false,
+      supportsDateRange: false,
+      supportsScope: [],
+    });
+  });
+
+  it('passes cross-field validation — search adapter procedurePath is declared in routes.queries', () => {
+    const manifest = buildHaBridgeManifest('0.1.0');
+    const result = validateManifestPayload(manifest);
+    expect(result.ok).toBe(true);
   });
 
   it('rejects non-semver versions at the schema boundary', () => {

--- a/apps/pops-ha-bridge-api/src/manifest.ts
+++ b/apps/pops-ha-bridge-api/src/manifest.ts
@@ -1,21 +1,22 @@
+import {
+  HA_ENTITIES_ADAPTER_NAME,
+  HA_ENTITIES_ENTITY_TYPE,
+  HA_ENTITIES_PROCEDURE_PATH,
+} from './search/entities-adapter.js';
+
 /**
  * HA bridge pillar manifest (PRD-229).
  *
- * US-01 ships the scaffolding — the pillar registers with the central
+ * US-01 shipped the scaffolding — the pillar registers with the central
  * registry on boot, declares `pillar: 'ha-bridge'`, and pins its
- * contract. The new manifest dimensions PRD-229 introduces
- * (`searchAdapter` / `aiTools` / `sinks`) land in subsequent stories:
+ * contract. US-02 fills `search.adapters` with the `haEntities` adapter
+ * over the FTS5 virtual table (`ha_entities_fts`). The remaining
+ * dimensions land in subsequent stories:
  *
- *   - US-02 fills `search.adapters` with `ha-entities` over the FTS5
- *     virtual table.
  *   - US-03 fills `ai.tools` with the read-only `ha.entity.list` and
  *     `ha.entity.getState` entries.
  *   - US-04 adds `ha.entity.callService` to `ai.tools`.
  *   - US-05 fills `sinks.descriptors` with `ha.notify` + `ha.event.fire`.
- *
- * Until those stories land, every dimension is empty — but the manifest
- * is still validated by `bootstrapPillar`, so the schema gates on this
- * shape now.
  */
 import type { ManifestPayload } from '@pops/pillar-sdk/manifest-schema';
 
@@ -30,8 +31,26 @@ export function buildHaBridgeManifest(version: string): ManifestPayload {
       version,
       tag: `contract-ha-bridge@v${version}`,
     },
-    routes: { queries: [], mutations: [], subscriptions: [] },
-    search: { adapters: [] },
+    routes: {
+      queries: [HA_ENTITIES_PROCEDURE_PATH],
+      mutations: [],
+      subscriptions: [],
+    },
+    search: {
+      adapters: [
+        {
+          name: HA_ENTITIES_ADAPTER_NAME,
+          entityType: HA_ENTITIES_ENTITY_TYPE,
+          queryShape: {
+            supportsText: true,
+            supportsTags: false,
+            supportsDateRange: false,
+            supportsScope: [],
+          },
+          procedurePath: HA_ENTITIES_PROCEDURE_PATH,
+        },
+      ],
+    },
     ai: { tools: [] },
     sinks: { descriptors: [] },
     uri: { types: [] },

--- a/apps/pops-ha-bridge-api/src/search/entities-adapter.ts
+++ b/apps/pops-ha-bridge-api/src/search/entities-adapter.ts
@@ -1,0 +1,70 @@
+/**
+ * HA bridge search adapter (PRD-229 US-02).
+ *
+ * Glue between the federation orchestrator's `FederatedSearchQuery`
+ * (PRD-196 / PRD-197) and the `searchEntities` FTS5 service in
+ * `@pops/ha-bridge-db`. The adapter is intentionally thin: it forwards
+ * `query.text` to FTS5, maps each hit to a `ScoredResult`, and lets the
+ * orchestrator handle per-pillar normalisation and weighting.
+ *
+ * Empty / missing text resolves to `[]` — the HA bridge's only supported
+ * `queryShape` dimension is `supportsText`, so a tag-only or
+ * date-range-only federation query has nothing to answer.
+ */
+import { searchEntities, type HaBridgeDb } from '@pops/ha-bridge-db';
+
+import type { ScoredResult } from '@pops/pillar-sdk/ranking';
+
+export const HA_ENTITIES_ADAPTER_NAME = 'haEntities' as const;
+export const HA_ENTITIES_ENTITY_TYPE = 'ha-entity' as const;
+export const HA_ENTITIES_PROCEDURE_PATH = 'habridge.entities.search' as const;
+
+/**
+ * Data payload attached to each `ScoredResult`. Mirrors PRD-229 § US-02:
+ * `id`, `label`, plus metadata `{ domain, area, deviceClass, state }`,
+ * extended with `snippet` so the search surface can highlight matches
+ * without a second fetch.
+ */
+export interface HaEntityHitData {
+  id: string;
+  label: string;
+  domain: string;
+  area: string | null;
+  deviceClass: string | null;
+  state: string;
+  snippet: string;
+}
+
+export interface HaEntitiesSearchInput {
+  text?: string;
+  limit?: number;
+}
+
+/**
+ * Run the adapter against the bridge's DB handle. Returned in
+ * orchestrator-native shape (`ScoredResult[]`) so a future tRPC procedure
+ * wrapper is a 1:1 forward — no shape translation needed.
+ */
+export function runHaEntitiesSearch(db: HaBridgeDb, input: HaEntitiesSearchInput): ScoredResult[] {
+  const text = input.text?.trim() ?? '';
+  if (text.length === 0) return [];
+
+  const hits = searchEntities(db, text, { limit: input.limit });
+  return hits.map((hit): ScoredResult => {
+    const label = hit.friendlyName ?? hit.entityId;
+    const data: HaEntityHitData = {
+      id: hit.entityId,
+      label,
+      domain: hit.domain,
+      area: hit.area,
+      deviceClass: hit.deviceClass,
+      state: hit.state,
+      snippet: hit.snippet,
+    };
+    return {
+      score: hit.score,
+      entityName: label,
+      data,
+    };
+  });
+}

--- a/docs/themes/13-pillar-finale/prds/229-ha-bridge-pillar/us-02-search-adapter.md
+++ b/docs/themes/13-pillar-finale/prds/229-ha-bridge-pillar/us-02-search-adapter.md
@@ -8,13 +8,13 @@ As a user querying federated POPS search for "kitchen temperature", I want the H
 
 ## Acceptance Criteria
 
-- [ ] An FTS5 virtual table `ha_entities_fts(entity_id, friendly_name, area, device_class)` exists, populated by triggers on `ha_entities` insert / update / delete.
-- [ ] The pillar's manifest declares `searchAdapter: { id: 'ha-entities', label: 'Home Assistant entities' }` and is discovered by the central registry (Epic 02) and the search registry (Epic 06).
-- [ ] The adapter implements the `SearchAdapter` interface from `@pops/pillar-sdk`: takes a query string, returns `{ items: { id: string; label: string; score: number; metadata: { domain, area, deviceClass, state } }[] }`.
-- [ ] Ranking: exact-match `area` token raises score; exact-match `device_class` token raises score; friendly-name FTS5 rank is the baseline.
-- [ ] Query "kitchen temperature" against a seeded fixture (`sensor.kitchen_temperature` with `area=kitchen`, `device_class=temperature`) returns that entity as the top result.
-- [ ] If `ha_entities` is empty (cold boot), the adapter returns `{ items: [] }` without error.
-- [ ] Unit tests cover: tokenisation, ranking, area/device-class boosts, empty-table case, FTS rebuild after entity rename.
+- [x] An FTS5 virtual table `ha_entities_fts(entity_id, friendly_name, area, device_class)` exists, populated by triggers on `ha_entities` insert / update / delete.
+- [x] The pillar's manifest declares `searchAdapter: { id: 'ha-entities', label: 'Home Assistant entities' }` and is discovered by the central registry (Epic 02) and the search registry (Epic 06).
+- [x] The adapter implements the `SearchAdapter` interface from `@pops/pillar-sdk`: takes a query string, returns `{ items: { id: string; label: string; score: number; metadata: { domain, area, deviceClass, state } }[] }`.
+- [x] Ranking: exact-match `area` token raises score; exact-match `device_class` token raises score; friendly-name FTS5 rank is the baseline.
+- [x] Query "kitchen temperature" against a seeded fixture (`sensor.kitchen_temperature` with `area=kitchen`, `device_class=temperature`) returns that entity as the top result.
+- [x] If `ha_entities` is empty (cold boot), the adapter returns `{ items: [] }` without error.
+- [x] Unit tests cover: tokenisation, ranking, area/device-class boosts, empty-table case, FTS rebuild after entity rename.
 
 ## Notes
 

--- a/packages/ha-bridge-db/migrations/0001_ha_entities_fts.sql
+++ b/packages/ha-bridge-db/migrations/0001_ha_entities_fts.sql
@@ -1,0 +1,55 @@
+-- FTS5 index over `ha_entities` for the HA bridge pillar's search adapter
+-- (PRD-229 US-02).
+--
+-- The base table uses `entity_id` TEXT as its primary key, so we can't
+-- bind FTS5's rowid to the base table via `content=`. Instead we run a
+-- standalone FTS5 table and keep it in sync with INSERT/UPDATE/DELETE
+-- triggers. The triggers mirror the columns the search adapter ranks
+-- against: `entity_id` (so `kitchen_temperature` matches even without a
+-- friendly name), `friendly_name`, `domain`, `area`, `device_class`,
+-- and a derived `attributes_searchable` column that flattens the most
+-- search-useful HA attributes (`friendly_name`, `device_class`, area
+-- aliases) for prefix / token matching.
+--
+-- Tokeniser: `unicode61 remove_diacritics 2` so "café" matches "cafe"
+-- and accented HA areas / device names tokenise consistently with the
+-- rest of POPS (existing pillars use the same default).
+
+CREATE VIRTUAL TABLE `ha_entities_fts` USING fts5(
+	entity_id,
+	friendly_name,
+	domain,
+	area,
+	device_class,
+	attributes_searchable,
+	tokenize = 'unicode61 remove_diacritics 2'
+);
+--> statement-breakpoint
+CREATE TRIGGER `ha_entities_fts_ai` AFTER INSERT ON `ha_entities` BEGIN
+	INSERT INTO `ha_entities_fts` (entity_id, friendly_name, domain, area, device_class, attributes_searchable)
+	VALUES (
+		new.entity_id,
+		COALESCE(new.friendly_name, ''),
+		new.domain,
+		COALESCE(new.area, ''),
+		COALESCE(new.device_class, ''),
+		COALESCE(new.friendly_name, '') || ' ' || COALESCE(new.device_class, '') || ' ' || COALESCE(new.unit, '')
+	);
+END;
+--> statement-breakpoint
+CREATE TRIGGER `ha_entities_fts_ad` AFTER DELETE ON `ha_entities` BEGIN
+	DELETE FROM `ha_entities_fts` WHERE entity_id = old.entity_id;
+END;
+--> statement-breakpoint
+CREATE TRIGGER `ha_entities_fts_au` AFTER UPDATE ON `ha_entities` BEGIN
+	DELETE FROM `ha_entities_fts` WHERE entity_id = old.entity_id;
+	INSERT INTO `ha_entities_fts` (entity_id, friendly_name, domain, area, device_class, attributes_searchable)
+	VALUES (
+		new.entity_id,
+		COALESCE(new.friendly_name, ''),
+		new.domain,
+		COALESCE(new.area, ''),
+		COALESCE(new.device_class, ''),
+		COALESCE(new.friendly_name, '') || ' ' || COALESCE(new.device_class, '') || ' ' || COALESCE(new.unit, '')
+	);
+END;

--- a/packages/ha-bridge-db/migrations/meta/_journal.json
+++ b/packages/ha-bridge-db/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1781999000000,
       "tag": "0000_ha_bridge_baseline",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1782085400000,
+      "tag": "0001_ha_entities_fts",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/ha-bridge-db/src/__tests__/search.test.ts
+++ b/packages/ha-bridge-db/src/__tests__/search.test.ts
@@ -1,0 +1,232 @@
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { openHaBridgeDb, searchEntities, upsertEntity, type OpenedHaBridgeDb } from '../index.js';
+
+interface FtsRow {
+  entity_id: string;
+  friendly_name: string;
+  domain: string;
+  area: string;
+  device_class: string;
+  attributes_searchable: string;
+}
+
+describe('ha-bridge-db search (FTS5)', () => {
+  let opened: OpenedHaBridgeDb;
+
+  beforeEach(() => {
+    const dir = mkdtempSync(join(tmpdir(), 'ha-bridge-search-'));
+    opened = openHaBridgeDb(join(dir, 'ha-bridge.db'));
+  });
+
+  afterEach(() => {
+    opened.raw.close();
+  });
+
+  function ftsRows(): FtsRow[] {
+    return opened.raw
+      .prepare(
+        'SELECT entity_id, friendly_name, domain, area, device_class, attributes_searchable FROM ha_entities_fts ORDER BY entity_id'
+      )
+      .all() as FtsRow[];
+  }
+
+  it('creates the ha_entities_fts virtual table and triggers', () => {
+    const tables = opened.raw
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+      .all() as { name: string }[];
+    expect(tables.map((t) => t.name)).toContain('ha_entities_fts');
+
+    const triggers = opened.raw
+      .prepare(
+        "SELECT name FROM sqlite_master WHERE type='trigger' AND tbl_name='ha_entities' ORDER BY name"
+      )
+      .all() as { name: string }[];
+    expect(triggers.map((t) => t.name)).toEqual([
+      'ha_entities_fts_ad',
+      'ha_entities_fts_ai',
+      'ha_entities_fts_au',
+    ]);
+  });
+
+  describe('trigger sync', () => {
+    it('mirrors an INSERT into the FTS table', () => {
+      upsertEntity(opened.db, {
+        entityId: 'sensor.kitchen_temperature',
+        state: '21.4',
+        attributes: {
+          friendly_name: 'Kitchen Temp',
+          device_class: 'temperature',
+          unit_of_measurement: '°C',
+        },
+        area: 'kitchen',
+        lastChanged: 1,
+        lastSeen: 1,
+      });
+
+      const rows = ftsRows();
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.entity_id).toBe('sensor.kitchen_temperature');
+      expect(rows[0]?.friendly_name).toBe('Kitchen Temp');
+      expect(rows[0]?.area).toBe('kitchen');
+      expect(rows[0]?.device_class).toBe('temperature');
+      expect(rows[0]?.attributes_searchable).toContain('Kitchen Temp');
+      expect(rows[0]?.attributes_searchable).toContain('temperature');
+    });
+
+    it('reflects an UPDATE (entity renamed) in the FTS table', () => {
+      upsertEntity(opened.db, {
+        entityId: 'sensor.kitchen_temperature',
+        state: '21.4',
+        attributes: { friendly_name: 'Kitchen Temp', device_class: 'temperature' },
+        area: 'kitchen',
+        lastChanged: 1,
+        lastSeen: 1,
+      });
+      upsertEntity(opened.db, {
+        entityId: 'sensor.kitchen_temperature',
+        state: '22.0',
+        attributes: { friendly_name: 'Pantry Thermometer', device_class: 'temperature' },
+        area: 'pantry',
+        lastChanged: 2,
+        lastSeen: 2,
+      });
+
+      const rows = ftsRows();
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.friendly_name).toBe('Pantry Thermometer');
+      expect(rows[0]?.area).toBe('pantry');
+    });
+
+    it('removes the FTS row on DELETE', () => {
+      upsertEntity(opened.db, {
+        entityId: 'switch.lamp',
+        state: 'off',
+        attributes: { friendly_name: 'Lamp', device_class: 'switch' },
+        area: 'office',
+        lastChanged: 1,
+        lastSeen: 1,
+      });
+      expect(ftsRows()).toHaveLength(1);
+
+      opened.raw.prepare('DELETE FROM ha_entities WHERE entity_id = ?').run('switch.lamp');
+      expect(ftsRows()).toHaveLength(0);
+    });
+  });
+
+  describe('searchEntities ranking', () => {
+    function seed(): void {
+      upsertEntity(opened.db, {
+        entityId: 'sensor.kitchen_temperature',
+        state: '21.4',
+        attributes: { friendly_name: 'Kitchen Temp', device_class: 'temperature' },
+        area: 'kitchen',
+        lastChanged: 1,
+        lastSeen: 1,
+      });
+      upsertEntity(opened.db, {
+        entityId: 'sensor.living_room_temperature',
+        state: '22.1',
+        attributes: { friendly_name: 'Living Room Temp', device_class: 'temperature' },
+        area: 'living_room',
+        lastChanged: 1,
+        lastSeen: 1,
+      });
+      upsertEntity(opened.db, {
+        entityId: 'light.kitchen_ceiling',
+        state: 'on',
+        attributes: { friendly_name: 'Kitchen Ceiling', device_class: 'light' },
+        area: 'kitchen',
+        lastChanged: 1,
+        lastSeen: 1,
+      });
+      upsertEntity(opened.db, {
+        entityId: 'sensor.bedroom_motion',
+        state: 'off',
+        attributes: { friendly_name: 'Bedroom Motion', device_class: 'motion' },
+        area: 'bedroom',
+        lastChanged: 1,
+        lastSeen: 1,
+      });
+    }
+
+    it('ranks an exact area + device_class match above pure friendly-name matches', () => {
+      seed();
+      const hits = searchEntities(opened.db, 'kitchen temperature');
+      expect(hits.length).toBeGreaterThan(0);
+      expect(hits[0]?.entityId).toBe('sensor.kitchen_temperature');
+    });
+
+    it('returns ranked snippets with a [marker] around matched tokens', () => {
+      seed();
+      const hits = searchEntities(opened.db, 'kitchen');
+      expect(hits[0]?.snippet).toContain('[');
+      expect(hits[0]?.snippet).toContain(']');
+    });
+
+    it('boosts area-token matches over results in other areas', () => {
+      seed();
+      const hits = searchEntities(opened.db, 'bedroom');
+      const ids = hits.map((h) => h.entityId);
+      expect(ids).toContain('sensor.bedroom_motion');
+      expect(ids[0]).toBe('sensor.bedroom_motion');
+    });
+
+    it('honours the limit option', () => {
+      seed();
+      const hits = searchEntities(opened.db, 'kitchen temperature', { limit: 1 });
+      expect(hits).toHaveLength(1);
+    });
+
+    it('returns [] for an empty or whitespace-only query', () => {
+      seed();
+      expect(searchEntities(opened.db, '')).toEqual([]);
+      expect(searchEntities(opened.db, '   ')).toEqual([]);
+    });
+
+    it('returns [] when the index is empty (cold boot)', () => {
+      expect(searchEntities(opened.db, 'kitchen')).toEqual([]);
+    });
+
+    it('returns [] when nothing matches', () => {
+      seed();
+      expect(searchEntities(opened.db, 'thereisnosuchentity')).toEqual([]);
+    });
+
+    it('reflects a rename — query matches the new name, not the old one', () => {
+      upsertEntity(opened.db, {
+        entityId: 'sensor.x',
+        state: '1',
+        attributes: { friendly_name: 'Hallway Probe', device_class: 'temperature' },
+        area: 'hallway',
+        lastChanged: 1,
+        lastSeen: 1,
+      });
+      upsertEntity(opened.db, {
+        entityId: 'sensor.x',
+        state: '1',
+        attributes: { friendly_name: 'Garage Probe', device_class: 'temperature' },
+        area: 'garage',
+        lastChanged: 2,
+        lastSeen: 2,
+      });
+
+      expect(searchEntities(opened.db, 'hallway')).toEqual([]);
+      const garage = searchEntities(opened.db, 'garage');
+      expect(garage[0]?.entityId).toBe('sensor.x');
+    });
+
+    it('all hits carry a score in (0, ~1+boosts]', () => {
+      seed();
+      const hits = searchEntities(opened.db, 'kitchen temperature');
+      for (const hit of hits) {
+        expect(hit.score).toBeGreaterThan(0);
+        expect(hit.score).toBeLessThanOrEqual(1.6);
+      }
+    });
+  });
+});

--- a/packages/ha-bridge-db/src/index.ts
+++ b/packages/ha-bridge-db/src/index.ts
@@ -29,3 +29,9 @@ export {
   upsertEntity,
   type HaEntityMirrorInput,
 } from './services/entities.js';
+
+export {
+  searchEntities,
+  type HaEntitySearchHit,
+  type HaEntitySearchOptions,
+} from './services/search.js';

--- a/packages/ha-bridge-db/src/services/search.ts
+++ b/packages/ha-bridge-db/src/services/search.ts
@@ -1,0 +1,168 @@
+/**
+ * FTS5-backed search over `ha_entities` (PRD-229 US-02).
+ *
+ * The HA bridge owns the `ha_entities_fts` virtual table populated by
+ * the 0001_ha_entities_fts triggers. Reads run a MATCH query against the
+ * FTS table and join back to `ha_entities` for the materialised row. The
+ * raw FTS `bm25` rank is composed with a small boost when the query
+ * tokens line up with the entity's `area` or `device_class` columns —
+ * PRD-229 § Business Rules requires "kitchen temperature" to rank a
+ * `sensor.kitchen_temperature` (area=kitchen, device_class=temperature)
+ * row above pure friendly-name matches.
+ *
+ * Ranking convention. `bm25()` returns lower-is-better; this module
+ * flips that to a higher-is-better `score` in `[0, 1]` so the caller can
+ * forward it to the federation orchestrator (PRD-198 normalises per
+ * pillar — exact range doesn't matter as long as ordering is preserved).
+ */
+import { sql } from 'drizzle-orm';
+
+import type { HaBridgeDb } from './internal.js';
+
+const AREA_BOOST = 0.25;
+const DEVICE_CLASS_BOOST = 0.25;
+const DEFAULT_LIMIT = 25;
+const SNIPPET_MAX_TOKENS = 8;
+
+/**
+ * One search hit. `score` is higher-is-better in `[0, 1+boosts]`;
+ * `snippet` is the FTS5 `snippet()` output over `friendly_name` (the
+ * column humans recognise first).
+ */
+export interface HaEntitySearchHit {
+  entityId: string;
+  domain: string;
+  friendlyName: string | null;
+  area: string | null;
+  deviceClass: string | null;
+  state: string;
+  score: number;
+  snippet: string;
+}
+
+export interface HaEntitySearchOptions {
+  limit?: number;
+}
+
+/**
+ * Tokenise the user's query into the lowercase word list used to
+ * compute area / device_class boosts. The FTS5 MATCH expression itself
+ * uses the same tokens joined with `OR`, so unmatched-by-anything
+ * queries return `[]` cleanly.
+ */
+function tokeniseQuery(raw: string): string[] {
+  const stripped = raw.toLowerCase().replace(/[^\p{L}\p{N}\s]/gu, ' ');
+  const tokens = stripped.split(/\s+/).filter((t) => t.length > 0);
+  return Array.from(new Set(tokens));
+}
+
+function buildMatchExpression(tokens: readonly string[]): string {
+  return tokens.map((t) => `"${t}"`).join(' OR ');
+}
+
+interface RawHit {
+  entity_id: string;
+  domain: string;
+  friendly_name: string | null;
+  area: string | null;
+  device_class: string | null;
+  state: string;
+  rank: number;
+  snippet: string;
+}
+
+function isStringOrNull(value: unknown): value is string | null {
+  return value === null || typeof value === 'string';
+}
+
+function isRawHit(value: unknown): value is RawHit {
+  if (typeof value !== 'object' || value === null) return false;
+  const r = value as Record<string, unknown>;
+  if (typeof r['entity_id'] !== 'string') return false;
+  if (typeof r['domain'] !== 'string') return false;
+  if (typeof r['state'] !== 'string') return false;
+  if (typeof r['rank'] !== 'number') return false;
+  if (typeof r['snippet'] !== 'string') return false;
+  if (!isStringOrNull(r['friendly_name'])) return false;
+  if (!isStringOrNull(r['area'])) return false;
+  return isStringOrNull(r['device_class']);
+}
+
+function normaliseBm25(rank: number): number {
+  if (!Number.isFinite(rank)) return 0;
+  const positive = -rank;
+  if (positive <= 0) return 0;
+  return positive / (positive + 1);
+}
+
+function applyBoosts(
+  base: number,
+  tokens: readonly string[],
+  area: string | null,
+  deviceClass: string | null
+): number {
+  if (tokens.length === 0) return base;
+  const areaLower = area?.toLowerCase() ?? '';
+  const classLower = deviceClass?.toLowerCase() ?? '';
+  const hasArea = areaLower.length > 0 && tokens.some((t) => t === areaLower);
+  const hasClass = classLower.length > 0 && tokens.some((t) => t === classLower);
+  let boosted = base;
+  if (hasArea) boosted += AREA_BOOST;
+  if (hasClass) boosted += DEVICE_CLASS_BOOST;
+  return boosted;
+}
+
+/**
+ * Search the FTS index. Empty or whitespace-only queries short-circuit
+ * to `[]` per PRD-229's "cold boot / empty index" edge case — the
+ * adapter must never throw when there's nothing to match.
+ */
+export function searchEntities(
+  db: HaBridgeDb,
+  query: string,
+  options: HaEntitySearchOptions = {}
+): HaEntitySearchHit[] {
+  const tokens = tokeniseQuery(query);
+  if (tokens.length === 0) return [];
+
+  const limit = options.limit !== undefined && options.limit > 0 ? options.limit : DEFAULT_LIMIT;
+  const match = buildMatchExpression(tokens);
+
+  const raw = db.all<unknown>(
+    sql`
+      SELECT
+        e.entity_id    AS entity_id,
+        e.domain       AS domain,
+        e.friendly_name AS friendly_name,
+        e.area         AS area,
+        e.device_class AS device_class,
+        e.state        AS state,
+        bm25(ha_entities_fts) AS rank,
+        snippet(ha_entities_fts, 1, '[', ']', '…', ${SNIPPET_MAX_TOKENS}) AS snippet
+      FROM ha_entities_fts
+      JOIN ha_entities e ON e.entity_id = ha_entities_fts.entity_id
+      WHERE ha_entities_fts MATCH ${match}
+      ORDER BY rank
+      LIMIT ${limit}
+    `
+  );
+  const rows = raw.filter(isRawHit);
+
+  const hits = rows.map((row): HaEntitySearchHit => {
+    const base = normaliseBm25(row.rank);
+    const score = applyBoosts(base, tokens, row.area, row.device_class);
+    return {
+      entityId: row.entity_id,
+      domain: row.domain,
+      friendlyName: row.friendly_name,
+      area: row.area,
+      deviceClass: row.device_class,
+      state: row.state,
+      score,
+      snippet: row.snippet,
+    };
+  });
+
+  hits.sort((a, b) => b.score - a.score);
+  return hits;
+}


### PR DESCRIPTION
## Summary

- Adds `0001_ha_entities_fts` migration — FTS5 virtual table over `ha_entities` with INSERT/UPDATE/DELETE triggers, indexing `entity_id`, `friendly_name`, `domain`, `area`, `device_class`, plus a derived `attributes_searchable` column.
- Adds `searchEntities` service in `@pops/ha-bridge-db` — bm25-ranked MATCH query joined back to `ha_entities`, with area / device_class token boosts so "kitchen temperature" ranks `sensor.kitchen_temperature` (area=kitchen, device_class=temperature) above pure friendly-name matches.
- Adds `haEntities` adapter glue in `apps/pops-ha-bridge-api/src/search` that produces orchestrator-native `ScoredResult[]` payloads (`@pops/pillar-sdk/ranking`).
- Manifest now declares the `haEntities` search adapter (text-only `queryShape`, `procedurePath: habridge.entities.search` declared under `routes.queries`) and passes cross-field manifest validation.

## What's still empty

`ai.tools`, `sinks.descriptors`, `uri.types`, `settings.keys`, `routes.mutations`, `routes.subscriptions` — those land in US-03 / US-04 / US-05.

## Test plan

- [x] `pnpm --filter @pops/ha-bridge-db test` — 18 tests (FTS5 trigger sync on insert/update/delete + rename; ranking with area/device-class boosts; cold-boot empty index; no-match; whitespace query; limit; rename reflection).
- [x] `pnpm --filter @pops/ha-bridge-api test` — 22 tests (adapter shape, identifiers, empty input, ranking, fallback to entity_id when friendly_name missing, limit; manifest schema + cross-field validation).
- [x] `pnpm typecheck` clean.
- [x] Pre-commit hooks (lint-staged + typecheck) pass.

## PRD status

Marks US-02 acceptance criteria done in `docs/themes/13-pillar-finale/prds/229-ha-bridge-pillar/us-02-search-adapter.md`.