### PR TITLE
docs(theme-13): PRD-238 blocked status note (target exports missing)

### DIFF
--- a/docs/themes/13-pillar-finale/prds/238-settings-known-modules-surface/README.md
+++ b/docs/themes/13-pillar-finale/prds/238-settings-known-modules-surface/README.md
@@ -2,7 +2,25 @@
 
 > Epic: [FE pillar SDK + dispatcher generator](../../epics/10-fe-sdk-dispatcher-generator.md)
 >
-> Status: **Not started**
+> Status: **Blocked — target exports missing**
+
+## Status note (2026-06-14)
+
+US-01 cannot proceed as written. Both candidate migration targets are unavailable today:
+
+- **Option A (per-pillar packages)** — no `@pops/pillar-core`, `@pops/pillar-media`, `@pops/pillar-cerebrum`, `@pops/pillar-inventory`, or `@pops/pillar-finance` package exists under `packages/`. Only `@pops/pillar-sdk` is published. The per-pillar contract packages (`@pops/<pillar>-contract`) exist but do not export `SettingsManifest` values.
+- **Option B (`@pops/pillar-sdk/settings`)** — `packages/pillar-sdk/src` has no `settings/` subpath and no `Manifest` exports today. The precedent (PR #3090) only added `ALL_MODULE_IDS` / `isKnownPillarId` / `isModuleId`; it did not introduce a settings surface.
+
+The per-pillar `SettingsManifest` values currently live only in `@pops/module-registry/src/settings/{core,inventory,finance,cerebrum,ego,media}/...` and are re-exported through `@pops/module-registry/settings`. Flipping the 8 consumers requires the target exports to exist first.
+
+**Prerequisite work** before this PRD can resume:
+
+1. Pick the target (decision is still A vs B per the original PRD).
+2. Land that target as its own PR — for Option B, scaffold `packages/pillar-sdk/src/settings/` with the 10 manifest re-exports (`aiConfigManifest`, `coreOperationalManifest`, `inventoryManifest`, `financeManifest`, `cerebrumManifest`, `egoManifest`, `arrManifest`, `plexManifest`, `rotationManifest`, `mediaOperationalManifest`) sourced from the canonical files in `@pops/module-registry/src/settings/**`, add the `./settings` export in `pillar-sdk/package.json`, extend the import-discipline allow-list in `eslint-config-pops`. For Option A, the same work multiplied by N new pillar packages.
+3. Then re-run US-01 to flip the 8 consumers.
+4. US-02 (delete `@pops/module-registry/settings`) follows unchanged.
+
+This PR records the block; no consumer changes ship in it.
 
 ## Overview
 

--- a/docs/themes/13-pillar-finale/prds/238-settings-known-modules-surface/us-01-pick-target-and-migrate.md
+++ b/docs/themes/13-pillar-finale/prds/238-settings-known-modules-surface/us-01-pick-target-and-migrate.md
@@ -1,6 +1,8 @@
 # US-01: Pick the new settings-manifest home and migrate the eight call sites
 
 > PRD: [PRD-238 — Settings-imports migration off `@pops/module-registry`](README.md)
+>
+> Status: **Blocked** — see the status note in the [parent PRD](README.md#status-note-2026-06-14). Neither Option A nor Option B has its target exports in place today; prerequisite work must land before this US can ship.
 
 ## Description
 


### PR DESCRIPTION
## Summary

PRD-238 US-01 cannot ship as written. Both candidate migration targets are missing today:

- **Option A (per-pillar packages):** no `@pops/pillar-core`, `@pops/pillar-media`, `@pops/pillar-cerebrum`, `@pops/pillar-inventory`, or `@pops/pillar-finance` package exists. Only `@pops/pillar-sdk` is published. The `@pops/<pillar>-contract` packages do not export `SettingsManifest` values.
- **Option B (`@pops/pillar-sdk/settings`):** `packages/pillar-sdk/src` has no `settings/` subpath and no `Manifest` exports today. PR #3090 added `ALL_MODULE_IDS` / `isKnownPillarId` / `isModuleId` only.

The per-pillar `SettingsManifest` values live only in `@pops/module-registry/src/settings/**`. Flipping the 8 consumers requires the target exports to exist first, which is prerequisite work outside this PRD's scope.

This PR records the block:
- Sets the PRD-238 status to **Blocked — target exports missing**.
- Adds a "Status note (2026-06-14)" section to the PRD README explaining the finding and the prerequisite steps.
- Marks US-01 as **Blocked** with a pointer to the PRD status note.

No consumer code is touched; no `@pops/module-registry` imports are flipped.

## Next step

Land a prerequisite PR that scaffolds the chosen target (recommended: Option B — `@pops/pillar-sdk/settings` re-exporting the 10 manifests from `@pops/module-registry/src/settings/**`, plus the `./settings` `exports` entry in `pillar-sdk/package.json` and the import-discipline allow-list update in `eslint-config-pops`). Then re-run US-01 to flip the 8 consumers.

## Test plan

- [ ] PRD README renders with the new status note
- [ ] US-01 shows the Blocked banner and links back to the PRD status note
- [ ] No code under `apps/pops-api/` or `packages/` changed
