### PR TITLE
feat(ha-bridge): PRD-237 US-01 sink mapping config + manifest projection

### DIFF
--- a/apps/pops-ha-bridge-api/src/__tests__/manifest.test.ts
+++ b/apps/pops-ha-bridge-api/src/__tests__/manifest.test.ts
@@ -16,7 +16,7 @@ describe('buildHaBridgeManifest', () => {
     expect(parsed.pillar).toBe(HA_BRIDGE_PILLAR_ID);
     expect(parsed.contract.tag).toBe('contract-ha-bridge@v0.1.0');
     expect(parsed.ai.tools).toEqual([]);
-    expect(parsed.sinks?.descriptors).toEqual([]);
+    expect(parsed.sinks?.descriptors.length).toBeGreaterThan(0);
   });
 
   it('declares the haEntities search adapter (US-02)', () => {

--- a/apps/pops-ha-bridge-api/src/__tests__/sinks.test.ts
+++ b/apps/pops-ha-bridge-api/src/__tests__/sinks.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildHaBridgeManifest } from '../manifest.js';
+import { mappings, type SinkMapping } from '../sinks/mapping.js';
+import {
+  SINK_EVENT_TYPE_REGEX,
+  SinkMappingConfigError,
+  validateSinkMappings,
+} from '../sinks/validator.js';
+
+function makeMapping(overrides: Partial<SinkMapping> = {}): SinkMapping {
+  return {
+    eventType: 'media.watch.completed',
+    description: 'A test mapping description with enough characters.',
+    haEventName: 'pops_media_watch_completed',
+    schema: { type: 'object' },
+    transformInline: (payload) => payload,
+    ...overrides,
+  };
+}
+
+describe('validateSinkMappings (PRD-237 US-01)', () => {
+  it('accepts the shipped first-cut mappings', () => {
+    expect(() => validateSinkMappings(mappings)).not.toThrow();
+  });
+
+  it('throws SinkMappingConfigError on duplicate eventType', () => {
+    const config = [
+      makeMapping({ eventType: 'media.watch.completed' }),
+      makeMapping({ eventType: 'media.watch.completed' }),
+    ];
+    expect(() => validateSinkMappings(config)).toThrow(SinkMappingConfigError);
+  });
+
+  it('error message names the offending eventType for duplicates', () => {
+    const config = [
+      makeMapping({ eventType: 'finance.balance.low' }),
+      makeMapping({ eventType: 'finance.balance.low' }),
+    ];
+    expect(() => validateSinkMappings(config)).toThrow(/finance\.balance\.low/);
+  });
+
+  it('throws on an eventType that violates the <source>.<entity>.<action> regex', () => {
+    const config = [makeMapping({ eventType: 'Media.Watch.Completed' })];
+    expect(() => validateSinkMappings(config)).toThrow(SinkMappingConfigError);
+  });
+
+  it('throws on an eventType missing a segment', () => {
+    const config = [makeMapping({ eventType: 'media.completed' })];
+    expect(() => validateSinkMappings(config)).toThrow(SinkMappingConfigError);
+  });
+
+  it('throws on an eventType with hyphens', () => {
+    const config = [makeMapping({ eventType: 'media.watch-progress.completed' })];
+    expect(() => validateSinkMappings(config)).toThrow(SinkMappingConfigError);
+  });
+
+  it('exposes a regex that matches every shipped mapping eventType', () => {
+    for (const mapping of mappings) {
+      expect(SINK_EVENT_TYPE_REGEX.test(mapping.eventType)).toBe(true);
+    }
+  });
+
+  it('accepts an empty mappings array', () => {
+    expect(() => validateSinkMappings([])).not.toThrow();
+  });
+});
+
+describe('buildHaBridgeManifest sinks projection (PRD-237 US-01)', () => {
+  it('projects exactly mappings.length descriptors', () => {
+    const manifest = buildHaBridgeManifest('0.1.0');
+    expect(manifest.sinks?.descriptors).toHaveLength(mappings.length);
+  });
+
+  it('round-trips every mapping eventType into the manifest', () => {
+    const manifest = buildHaBridgeManifest('0.1.0');
+    const descriptorEventTypes = manifest.sinks?.descriptors.map((d) => d.eventType) ?? [];
+    for (const mapping of mappings) {
+      expect(descriptorEventTypes).toContain(mapping.eventType);
+    }
+  });
+
+  it('omits haEventName and transformInline from the manifest projection', () => {
+    const manifest = buildHaBridgeManifest('0.1.0');
+    for (const descriptor of manifest.sinks?.descriptors ?? []) {
+      expect(Object.keys(descriptor).toSorted()).toEqual(['description', 'eventType', 'schema']);
+    }
+  });
+
+  it('ships the three first-cut mappings from the PRD', () => {
+    const eventTypes = mappings.map((m) => m.eventType);
+    expect(eventTypes).toContain('media.watch.completed');
+    expect(eventTypes).toContain('finance.balance.low');
+    expect(eventTypes).toContain('inventory.item.consumed');
+  });
+});

--- a/apps/pops-ha-bridge-api/src/manifest.ts
+++ b/apps/pops-ha-bridge-api/src/manifest.ts
@@ -3,6 +3,8 @@ import {
   HA_ENTITIES_ENTITY_TYPE,
   HA_ENTITIES_PROCEDURE_PATH,
 } from './search/entities-adapter.js';
+import { mappings } from './sinks/mapping.js';
+import { validateSinkMappings } from './sinks/validator.js';
 
 /**
  * HA bridge pillar manifest (PRD-229).
@@ -16,11 +18,17 @@ import {
  *   - US-03 fills `ai.tools` with the read-only `ha.entity.list` and
  *     `ha.entity.getState` entries.
  *   - US-04 adds `ha.entity.callService` to `ai.tools`.
- *   - US-05 fills `sinks.descriptors` with `ha.notify` + `ha.event.fire`.
+ *
+ * PRD-237 US-01 derives the `sinks.descriptors` block from the mapping
+ * config (`src/sinks/mapping.ts`) — the same array drives the runtime
+ * `/_sinks/<eventType>` handler registry (US-02), so manifest and
+ * runtime cannot drift.
  */
 import type { ManifestPayload } from '@pops/pillar-sdk/manifest-schema';
 
 export const HA_BRIDGE_PILLAR_ID = 'ha-bridge' as const;
+
+validateSinkMappings(mappings);
 
 export function buildHaBridgeManifest(version: string): ManifestPayload {
   return {
@@ -52,7 +60,13 @@ export function buildHaBridgeManifest(version: string): ManifestPayload {
       ],
     },
     ai: { tools: [] },
-    sinks: { descriptors: [] },
+    sinks: {
+      descriptors: mappings.map((mapping) => ({
+        eventType: mapping.eventType,
+        description: mapping.description,
+        schema: mapping.schema,
+      })),
+    },
     uri: { types: [] },
     settings: { keys: [] },
     healthcheck: { path: '/health' },

--- a/apps/pops-ha-bridge-api/src/sinks/mapping.ts
+++ b/apps/pops-ha-bridge-api/src/sinks/mapping.ts
@@ -1,0 +1,84 @@
+/**
+ * PRD-237 US-01: HA sink mapping config.
+ *
+ * Each entry maps a POPS `eventType` (`<source>.<entity>.<action>`) to:
+ *   - the HA event name forwarded over the WebSocket `fire_event` frame,
+ *   - the JSON-Schema-shaped payload contract advertised in the
+ *     pillar manifest's `sinks.descriptors` block,
+ *   - a pure `transformInline` that maps the POPS payload to the HA
+ *     `event_data` object.
+ *
+ * The same array is the source of truth for both manifest derivation
+ * (`apps/pops-ha-bridge-api/src/manifest.ts`) and the runtime handler
+ * registry (US-02). Adding a mapping = adding an entry; no core edit.
+ */
+
+export type SinkMappingTransform = (payload: Record<string, unknown>) => Record<string, unknown>;
+
+export interface SinkMapping {
+  eventType: string;
+  description: string;
+  haEventName: string;
+  schema: Record<string, unknown>;
+  transformInline: SinkMappingTransform;
+}
+
+const identityTransform: SinkMappingTransform = (payload) => payload;
+
+export const mappings: SinkMapping[] = [
+  {
+    eventType: 'media.watch.completed',
+    description:
+      'Fires when a user finishes watching a media item. HA automations may use this to dim the lights or stop ambient audio.',
+    haEventName: 'pops_media_watch_completed',
+    schema: {
+      type: 'object',
+      required: ['mediaId', 'userId', 'occurredAt'],
+      properties: {
+        mediaId: { type: 'string' },
+        userId: { type: 'string' },
+        occurredAt: { type: 'string', format: 'date-time' },
+        durationSeconds: { type: 'number' },
+      },
+      additionalProperties: false,
+    },
+    transformInline: identityTransform,
+  },
+  {
+    eventType: 'finance.balance.low',
+    description:
+      'Fires when an account balance crosses below the configured threshold. HA automations may push a notification or trigger an alert light.',
+    haEventName: 'pops_finance_balance_low',
+    schema: {
+      type: 'object',
+      required: ['accountId', 'balance', 'threshold', 'occurredAt'],
+      properties: {
+        accountId: { type: 'string' },
+        balance: { type: 'number' },
+        threshold: { type: 'number' },
+        currency: { type: 'string' },
+        occurredAt: { type: 'string', format: 'date-time' },
+      },
+      additionalProperties: false,
+    },
+    transformInline: identityTransform,
+  },
+  {
+    eventType: 'inventory.item.consumed',
+    description:
+      'Fires when a tracked inventory item is consumed. HA automations may add the item to a shopping list or notify a resident.',
+    haEventName: 'pops_inventory_item_consumed',
+    schema: {
+      type: 'object',
+      required: ['itemId', 'quantity', 'occurredAt'],
+      properties: {
+        itemId: { type: 'string' },
+        quantity: { type: 'number' },
+        unit: { type: 'string' },
+        occurredAt: { type: 'string', format: 'date-time' },
+      },
+      additionalProperties: false,
+    },
+    transformInline: identityTransform,
+  },
+];

--- a/apps/pops-ha-bridge-api/src/sinks/validator.ts
+++ b/apps/pops-ha-bridge-api/src/sinks/validator.ts
@@ -1,0 +1,48 @@
+/**
+ * PRD-237 US-01: Boot-time validator for the sink mapping config.
+ *
+ * Fails fast (throws) on:
+ *   - duplicate `eventType` entries — two mappings cannot claim the same POPS
+ *     event in the same bridge.
+ *   - `eventType` strings that do not match the `<source>.<entity>.<action>`
+ *     convention defined by PRD-236 US-01.
+ *
+ * Called from `manifest.ts` at module load so an invalid config crashes the
+ * pillar before it can register a broken manifest.
+ */
+
+import type { SinkMapping } from './mapping.js';
+
+export const SINK_EVENT_TYPE_REGEX = /^[a-z][a-z0-9]*\.[a-z][a-z0-9]*\.[a-z][a-z0-9]*$/;
+
+export class SinkMappingConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SinkMappingConfigError';
+  }
+}
+
+export function validateSinkMappings(mappings: readonly SinkMapping[]): void {
+  const seen = new Set<string>();
+  const duplicates: string[] = [];
+
+  for (const mapping of mappings) {
+    if (!SINK_EVENT_TYPE_REGEX.test(mapping.eventType)) {
+      throw new SinkMappingConfigError(
+        `Invalid sink mapping eventType '${mapping.eventType}': must match <source>.<entity>.<action> (lowercase dotted).`
+      );
+    }
+    if (seen.has(mapping.eventType)) {
+      duplicates.push(mapping.eventType);
+    } else {
+      seen.add(mapping.eventType);
+    }
+  }
+
+  if (duplicates.length > 0) {
+    const unique = Array.from(new Set(duplicates));
+    throw new SinkMappingConfigError(
+      `Duplicate sink mapping eventType(s): ${unique.join(', ')}. Each POPS eventType may have at most one mapping per bridge.`
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Lands PRD-237 US-01 — the typed `SinkMapping` config + the manifest-side derivation. Three first-cut mappings (`media.watch.completed`, `finance.balance.low`, `inventory.item.consumed`) ship as the array of record; the HA bridge manifest's `sinks.descriptors` block is now derived from the same array, so the manifest and the (US-02) runtime handler registry cannot drift.

- `apps/pops-ha-bridge-api/src/sinks/mapping.ts` — `SinkMapping` type + the first-cut `mappings: SinkMapping[]`.
- `apps/pops-ha-bridge-api/src/sinks/validator.ts` — `validateSinkMappings()` rejects duplicate `eventType` entries and rejects any `eventType` that does not match the PRD-236 US-01 `<source>.<entity>.<action>` regex.
- `apps/pops-ha-bridge-api/src/manifest.ts` — derives `sinks.descriptors` from `mappings.map(m => ({ eventType, description, schema }))`.
- `apps/pops-ha-bridge-api/src/__tests__/sinks.test.ts` — 12 tests covering the validator + manifest projection.

## Acceptance criteria

- [x] `SinkMapping` type with `eventType`, `description`, `haEventName`, `schema`, `transformInline`.
- [x] First-cut `mappings: SinkMapping[]` for media/finance/inventory.
- [x] Manifest `sinks.descriptors` derived from `mappings` — no hand-maintained list.
- [x] Boot-time validator rejects duplicate `eventType`.
- [x] Boot-time validator rejects malformed `eventType` (regex check).

## Out of scope (US-02)

- `sendFireEvent(haEventName, eventData)` on the HA WebSocket client.
- Mounting `createSinkHandler` at `POST /_sinks/<eventType>`.
- Reconnect queue + drop-oldest behaviour.

## Test plan

- [x] `pnpm --filter @pops/ha-bridge-api test` — 34/34 passing (12 new in `sinks.test.ts`).
- [x] `pnpm typecheck` — full repo clean.
- [x] Lint + format clean via lint-staged pre-commit.