### PR TITLE
feat(pillar-sdk): add usePillarInfiniteQuery (PR #3163 deferred unblock)

### DIFF
--- a/packages/pillar-sdk/src/react/__tests__/use-pillar-infinite-query.test.tsx
+++ b/packages/pillar-sdk/src/react/__tests__/use-pillar-infinite-query.test.tsx
@@ -1,0 +1,222 @@
+// @vitest-environment jsdom
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  discoveredPillar,
+  fakeFetch,
+  FakeRegistryTransport,
+  jsonResponse,
+} from '../../client/__tests__/fixtures.js';
+import { __resetSharedPillarClient } from '../../client/factory.js';
+import { usePillarInfiniteQuery } from '../hooks.js';
+import { PillarSdkProvider } from '../provider.js';
+
+import type { ReactNode } from 'react';
+
+import type { PillarClientOptions } from '../../client/factory.js';
+
+type Page = { items: readonly { id: string }[]; nextCursor: string | null };
+
+type FetchScript = (url: string, body: unknown) => Response | Promise<Response>;
+
+type Harness = {
+  wrapper: (props: { children: ReactNode }) => ReactNode;
+  queryClient: QueryClient;
+  calls: { url: string; body: unknown }[];
+};
+
+function buildHarness(transport: FakeRegistryTransport, script: FetchScript): Harness {
+  const calls: { url: string; body: unknown }[] = [];
+  const fetchImpl = fakeFetch(async (url, init) => {
+    let parsed: unknown = null;
+    if (init?.body && typeof init.body === 'string') {
+      try {
+        parsed = JSON.parse(init.body);
+      } catch {
+        parsed = init.body;
+      }
+    }
+    calls.push({ url, body: parsed });
+    return script(url, parsed);
+  });
+  const options: PillarClientOptions = { transport, fetchImpl };
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  const wrapper = ({ children }: { children: ReactNode }): ReactNode => (
+    <QueryClientProvider client={queryClient}>
+      <PillarSdkProvider options={options}>{children}</PillarSdkProvider>
+    </QueryClientProvider>
+  );
+  return { wrapper, queryClient, calls };
+}
+
+describe('usePillarInfiniteQuery', () => {
+  beforeEach(() => __resetSharedPillarClient());
+  afterEach(() => __resetSharedPillarClient());
+
+  it('fetches the first page and then a subsequent page via fetchNextPage', async () => {
+    const transport = new FakeRegistryTransport({ pillars: [discoveredPillar()] });
+    const pages: Record<string, Page> = {
+      'cursor-a': { items: [{ id: '1' }], nextCursor: 'cursor-b' },
+      'cursor-b': { items: [{ id: '2' }], nextCursor: null },
+    };
+    const harness = buildHarness(transport, (_url, body) => {
+      const cursor = (body as { cursor: string }).cursor;
+      return jsonResponse({ result: { data: pages[cursor] } });
+    });
+
+    const { result } = renderHook(
+      () =>
+        usePillarInfiniteQuery<Page, string>(
+          'finance',
+          ['wishlist', 'list'],
+          { limit: 10 },
+          {
+            initialPageParam: 'cursor-a',
+            getNextPageParam: (last) => last.nextCursor ?? undefined,
+          }
+        ),
+      { wrapper: harness.wrapper }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.pages).toHaveLength(1);
+    expect(result.current.data?.pages[0]?.items[0]?.id).toBe('1');
+    expect(result.current.hasNextPage).toBe(true);
+
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+
+    await waitFor(() => expect(result.current.data?.pages).toHaveLength(2));
+    expect(result.current.data?.pages[1]?.items[0]?.id).toBe('2');
+    expect(result.current.hasNextPage).toBe(false);
+  });
+
+  it('stops paging once getNextPageParam returns undefined', async () => {
+    const transport = new FakeRegistryTransport({ pillars: [discoveredPillar()] });
+    const harness = buildHarness(transport, () =>
+      jsonResponse({ result: { data: { items: [{ id: 'only' }], nextCursor: null } } })
+    );
+
+    const { result } = renderHook(
+      () =>
+        usePillarInfiniteQuery<Page, string | null>(
+          'finance',
+          ['wishlist', 'list'],
+          {},
+          {
+            initialPageParam: null,
+            getNextPageParam: (last) => last.nextCursor,
+          }
+        ),
+      { wrapper: harness.wrapper }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.hasNextPage).toBe(false);
+    expect(result.current.data?.pages).toHaveLength(1);
+  });
+
+  it('surfaces failure flags when the pillar is unavailable', async () => {
+    const transport = new FakeRegistryTransport({ pillars: [] });
+    const harness = buildHarness(transport, () => jsonResponse({}));
+
+    const { result } = renderHook(
+      () =>
+        usePillarInfiniteQuery<Page, string | null>(
+          'finance',
+          ['wishlist', 'list'],
+          {},
+          {
+            initialPageParam: null,
+            getNextPageParam: () => undefined,
+          }
+        ),
+      { wrapper: harness.wrapper }
+    );
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.isUnavailable).toBe(true);
+    expect(result.current.isDegraded).toBe(false);
+  });
+
+  it('refetch reissues the first-page request', async () => {
+    const transport = new FakeRegistryTransport({ pillars: [discoveredPillar()] });
+    const harness = buildHarness(transport, () =>
+      jsonResponse({ result: { data: { items: [{ id: 'x' }], nextCursor: null } } })
+    );
+
+    const { result } = renderHook(
+      () =>
+        usePillarInfiniteQuery<Page, string | null>(
+          'finance',
+          ['wishlist', 'list'],
+          {},
+          {
+            initialPageParam: null,
+            getNextPageParam: () => undefined,
+          }
+        ),
+      { wrapper: harness.wrapper }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    const callsBefore = harness.calls.length;
+
+    await act(async () => {
+      await result.current.refetch();
+    });
+
+    await waitFor(() => expect(harness.calls.length).toBeGreaterThan(callsBefore));
+  });
+
+  it('honours a custom buildInput when paging', async () => {
+    const transport = new FakeRegistryTransport({ pillars: [discoveredPillar()] });
+    const harness = buildHarness(transport, () =>
+      jsonResponse({ result: { data: { items: [{ id: 'y' }], nextCursor: 'next' } } })
+    );
+
+    const { result } = renderHook(
+      () =>
+        usePillarInfiniteQuery<Page, number>(
+          'finance',
+          ['wishlist', 'list'],
+          { limit: 5 },
+          {
+            initialPageParam: 0,
+            getNextPageParam: (_last, _pages, lastParam) =>
+              lastParam < 1 ? lastParam + 1 : undefined,
+            buildInput: (inp, page) => ({
+              ...(inp as Record<string, unknown>),
+              offset: page,
+            }),
+          }
+        ),
+      { wrapper: harness.wrapper }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(harness.calls).toHaveLength(1);
+    expect(harness.calls[0]?.body).toEqual({
+      limit: 5,
+      offset: 0,
+    });
+
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+
+    await waitFor(() => expect(harness.calls.length).toBe(2));
+    expect(harness.calls[1]?.body).toEqual({
+      limit: 5,
+      offset: 1,
+    });
+  });
+});

--- a/packages/pillar-sdk/src/react/hooks.ts
+++ b/packages/pillar-sdk/src/react/hooks.ts
@@ -141,6 +141,13 @@ export {
   type UsePillarUtilsResult,
 } from './use-pillar-utils.js';
 
+export {
+  usePillarInfiniteQuery,
+  type PillarInfiniteBuildInput,
+  type UsePillarInfiniteQueryOptions,
+  type UsePillarInfiniteQueryResult,
+} from './use-pillar-infinite-query.js';
+
 export type UsePillarCallDynamicQueryOptions = UsePillarQueryOptions<unknown>;
 export type UsePillarCallDynamicQueryResult = UsePillarQueryResult<unknown>;
 export type UsePillarCallDynamicMutationOptions = UsePillarMutationOptions<unknown, unknown>;

--- a/packages/pillar-sdk/src/react/index.ts
+++ b/packages/pillar-sdk/src/react/index.ts
@@ -3,11 +3,13 @@ export type { PillarSdkProviderProps } from './provider.js';
 export {
   usePillarCallDynamic,
   usePillarCallDynamicMutation,
+  usePillarInfiniteQuery,
   usePillarMutation,
   usePillarQuery,
   usePillarUtils,
 } from './hooks.js';
 export type {
+  PillarInfiniteBuildInput,
   PillarUpdater,
   UsePillarCallDynamicMutationArgs,
   UsePillarCallDynamicMutationOptions,
@@ -15,6 +17,8 @@ export type {
   UsePillarCallDynamicQueryArgs,
   UsePillarCallDynamicQueryOptions,
   UsePillarCallDynamicQueryResult,
+  UsePillarInfiniteQueryOptions,
+  UsePillarInfiniteQueryResult,
   UsePillarMutationOptions,
   UsePillarMutationResult,
   UsePillarQueryOptions,

--- a/packages/pillar-sdk/src/react/use-pillar-infinite-query.ts
+++ b/packages/pillar-sdk/src/react/use-pillar-infinite-query.ts
@@ -1,0 +1,107 @@
+import { useInfiniteQuery } from '@tanstack/react-query';
+
+import { PillarCallError } from '../client/errors.js';
+import {
+  callProcedure,
+  failureFlagsFrom,
+  NO_FAILURE,
+  type ProcedurePath,
+} from './internal/call-procedure.js';
+import { usePillarSdkOptions } from './provider.js';
+import { pillarQueryKey } from './query-key.js';
+
+import type {
+  InfiniteData,
+  QueryFunctionContext,
+  UseInfiniteQueryOptions,
+  UseInfiniteQueryResult,
+} from '@tanstack/react-query';
+
+import type { FailureFlags } from './internal/call-procedure.js';
+
+/**
+ * Adapter that produces the per-page input from the user-supplied `input`
+ * and the React Query `pageParam`. Defaults to
+ * `{ ...input, cursor: pageParam }` when `input` is an object, otherwise
+ * `{ cursor: pageParam }`.
+ */
+export type PillarInfiniteBuildInput<TPageParam> = (
+  input: unknown,
+  pageParam: TPageParam
+) => unknown;
+
+export type UsePillarInfiniteQueryOptions<TOutput, TPageParam> = Omit<
+  UseInfiniteQueryOptions<
+    TOutput,
+    PillarCallError,
+    InfiniteData<TOutput, TPageParam>,
+    readonly unknown[],
+    TPageParam
+  >,
+  'queryKey' | 'queryFn'
+> & {
+  buildInput?: PillarInfiniteBuildInput<TPageParam>;
+};
+
+export type UsePillarInfiniteQueryResult<TOutput, TPageParam> = UseInfiniteQueryResult<
+  InfiniteData<TOutput, TPageParam>,
+  PillarCallError
+> &
+  FailureFlags;
+
+const defaultBuildInput: PillarInfiniteBuildInput<unknown> = (input, pageParam) => {
+  if (input !== null && typeof input === 'object' && !Array.isArray(input)) {
+    return { ...(input as Record<string, unknown>), cursor: pageParam };
+  }
+  return { cursor: pageParam };
+};
+
+/**
+ * React Query hook that wraps a paginated `pillar(pillarId).path(input)` call.
+ *
+ * Mirrors `useInfiniteQuery` from `@tanstack/react-query`, typed through
+ * the pillar contract. Each page invokes the procedure with input derived
+ * from `buildInput(input, pageParam)`. The default `buildInput` spreads
+ * `input` and overrides `cursor` with the page param — appropriate for
+ * the common `{ cursor, limit }` cursor-pagination shape. Override
+ * `buildInput` to use a different field name (e.g. `offset`, `nextToken`).
+ *
+ * `initialPageParam` and `getNextPageParam` are required by React Query
+ * and forwarded verbatim. Cache key matches `pillarQueryKey(pillarId,
+ * path, input)` — note that pageParam does not participate in the key;
+ * it is part of the per-page request body instead.
+ */
+export function usePillarInfiniteQuery<TOutput, TPageParam = unknown>(
+  pillarId: string,
+  path: ProcedurePath,
+  input: unknown,
+  options: UsePillarInfiniteQueryOptions<TOutput, TPageParam>
+): UsePillarInfiniteQueryResult<TOutput, TPageParam> {
+  const sdkOptions = usePillarSdkOptions();
+  const queryKey = pillarQueryKey(pillarId, path, input);
+  const { buildInput, ...rest } = options;
+  const effectiveBuildInput: PillarInfiniteBuildInput<TPageParam> = buildInput ?? defaultBuildInput;
+
+  const query = useInfiniteQuery<
+    TOutput,
+    PillarCallError,
+    InfiniteData<TOutput, TPageParam>,
+    readonly unknown[],
+    TPageParam
+  >({
+    ...rest,
+    queryKey,
+    queryFn: async (ctx: QueryFunctionContext<readonly unknown[], TPageParam>) => {
+      const pageParam = ctx.pageParam as TPageParam;
+      const perPageInput = effectiveBuildInput(input, pageParam);
+      const result = await callProcedure<TOutput>(pillarId, path, perPageInput, sdkOptions);
+      if (result.kind === 'ok') return result.value;
+      throw new PillarCallError(pillarId, result);
+    },
+  });
+
+  const flags =
+    query.error instanceof PillarCallError ? failureFlagsFrom(query.error.result) : NO_FAILURE;
+
+  return { ...query, ...flags } as UsePillarInfiniteQueryResult<TOutput, TPageParam>;
+}


### PR DESCRIPTION
## Summary

- Adds `usePillarInfiniteQuery` to `@pops/pillar-sdk/react` — a paginated counterpart to `usePillarQuery` that mirrors React Query's `useInfiniteQuery`, typed through the pillar contract.
- `initialPageParam` + `getNextPageParam` are required (per React Query). Default `buildInput` spreads `input` and overrides `cursor` with `pageParam`; callers can override `buildInput` for `offset` / `nextToken` / etc.
- Cache key reuses `pillarQueryKey(pillarId, path, input)` — `pageParam` does not participate in the key; it lives in the per-page request body. Failure flags (`isUnavailable`, `isDegraded`, ...) surface the same way as `usePillarQuery`.

## Why

Unblocks the `useRecipeListQuery` infinite-pagination case that was deferred in PR #3163. That PR migrated tRPC sites to the pillar SDK but had to leave the recipe list query on the legacy api-client because the SDK had no infinite-query primitive. This hook restores parity so the follow-up consumer migration can land.

`usePillarQueries` (parallel-array) is intentionally not included here — it's a separate hook with its own type-level concerns and will ship in a follow-up so this PR stays single-focus.

## Scope

- 1 new file: `src/react/use-pillar-infinite-query.ts` (~110 lines).
- 1 new test file: `src/react/__tests__/use-pillar-infinite-query.test.tsx` (5 tests).
- Re-exports added to `src/react/hooks.ts` and `src/react/index.ts`.
- No existing signatures changed; fully backwards compatible.

## Test plan

- [x] `pnpm --filter @pops/pillar-sdk test` — 496/496 pass (5 new in `use-pillar-infinite-query.test.tsx`).
- [x] `pnpm --filter @pops/pillar-sdk build` — clean.
- [x] `oxlint` clean.
- [x] Tests cover: first-page → next-page paging, terminating `getNextPageParam`, `unavailable` failure-flag mapping, refetch reissues page-zero, custom `buildInput` (offset-style pagination).