### PR TITLE
feat(app-media): migrate batch 5 (13 sites · season-detail · PRD-227)

### DIFF
--- a/packages/app-media/src/pages/SeasonDetailPage.test.tsx
+++ b/packages/app-media/src/pages/SeasonDetailPage.test.tsx
@@ -2,6 +2,8 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { PillarCallError } from '@pops/pillar-sdk/client';
+
 import { SeasonDetailPage } from './SeasonDetailPage';
 
 const {
@@ -36,110 +38,18 @@ const {
   mockSetData: vi.fn(),
 }));
 
-vi.mock('@pops/api-client', () => ({
-  trpc: {
-    media: {
-      tvShows: {
-        get: {
-          useQuery: (...args: unknown[]) => mockShowQuery(...args),
-        },
-        listSeasons: {
-          useQuery: (...args: unknown[]) => mockSeasonsQuery(...args),
-        },
-        listEpisodes: {
-          useQuery: (...args: unknown[]) => mockEpisodesQuery(...args),
-        },
-      },
-      watchHistory: {
-        list: {
-          useQuery: (...args: unknown[]) => mockWatchHistoryQuery(...args),
-        },
-        progress: {
-          useQuery: (...args: unknown[]) => mockProgressQuery(...args),
-        },
-        log: {
-          useMutation: (opts: Record<string, unknown>) => {
-            mockLogMutation.mockImplementation(() => {
-              if (typeof opts.onSuccess === 'function') (opts.onSuccess as () => void)();
-            });
-            return { mutate: mockLogMutation, isPending: false };
-          },
-        },
-        delete: {
-          useMutation: (opts: Record<string, unknown>) => {
-            mockDeleteMutation.mockImplementation(() => {
-              if (typeof opts.onSuccess === 'function') (opts.onSuccess as () => void)();
-            });
-            return { mutate: mockDeleteMutation, isPending: false };
-          },
-        },
-        invalidate: mockInvalidate,
-      },
-      arr: {
-        checkSeries: {
-          useQuery: (...args: unknown[]) => mockCheckSeriesQuery(...args),
-        },
-        getSeriesEpisodes: {
-          useQuery: (...args: unknown[]) => mockSonarrEpisodesQuery(...args),
-          invalidate: mockInvalidate,
-        },
-        updateSeasonMonitoring: {
-          useMutation: (opts: Record<string, unknown>) => {
-            mockSeasonMonitorMutation.mockImplementation(() => {
-              if (typeof opts.onSuccess === 'function') (opts.onSuccess as () => void)();
-            });
-            return { mutate: mockSeasonMonitorMutation, isPending: false };
-          },
-        },
-        updateEpisodeMonitoring: {
-          useMutation: (opts: Record<string, unknown>) => {
-            mockEpisodeMonitorMutation.mockImplementation(
-              (variables: { episodeIds: number[]; monitored: boolean }) => {
-                if (typeof opts.onSuccess === 'function') (opts.onSuccess as () => void)();
-                if (typeof opts.onSettled === 'function')
-                  (opts.onSettled as (d: unknown, e: unknown, v: typeof variables) => void)(
-                    undefined,
-                    undefined,
-                    variables
-                  );
-              }
-            );
-            return { mutate: mockEpisodeMonitorMutation, isPending: false };
-          },
-        },
-      },
-    },
-    useUtils: () => ({
-      media: {
-        watchHistory: {
-          list: {
-            invalidate: mockInvalidate,
-            cancel: vi.fn().mockResolvedValue(undefined),
-            getData: vi.fn(),
-            setData: vi.fn(),
-          },
-          progress: {
-            invalidate: mockInvalidate,
-            cancel: vi.fn().mockResolvedValue(undefined),
-            getData: vi.fn(),
-            setData: vi.fn(),
-          },
-          invalidate: mockInvalidate,
-        },
-        tvShows: {
-          listSeasons: { invalidate: mockInvalidate },
-        },
-        arr: {
-          checkSeries: { invalidate: mockInvalidate },
-          getSeriesEpisodes: { invalidate: mockInvalidate },
-        },
-      },
-    }),
-  },
-}));
-
 vi.mock('@pops/pillar-sdk/react', () => ({
-  usePillarQuery: () => ({ data: undefined, isLoading: false }),
+  usePillarQuery: (_pillarId: string, path: readonly string[], input: unknown) => {
+    const key = path.join('.');
+    if (key === 'tvShows.get') return mockShowQuery(input);
+    if (key === 'tvShows.listSeasons') return mockSeasonsQuery(input);
+    if (key === 'tvShows.listEpisodes') return mockEpisodesQuery(input);
+    if (key === 'watchHistory.list') return mockWatchHistoryQuery(input);
+    if (key === 'watchHistory.progress') return mockProgressQuery(input);
+    if (key === 'arr.checkSeries') return mockCheckSeriesQuery(input);
+    if (key === 'arr.getSeriesEpisodes') return mockSonarrEpisodesQuery(input);
+    return { data: undefined, isLoading: false };
+  },
   usePillarMutation: (
     _pillarId: string,
     path: readonly string[],
@@ -154,6 +64,38 @@ vi.mock('@pops/pillar-sdk/react', () => ({
         if (typeof opts.onSettled === 'function') (opts.onSettled as () => void)();
       });
       return { mutate: mockBatchLogMutation, isPending: false };
+    }
+    if (key === 'watchHistory.log') {
+      mockLogMutation.mockImplementation(() => {
+        if (typeof opts.onSuccess === 'function') (opts.onSuccess as () => void)();
+      });
+      return { mutate: mockLogMutation, isPending: false };
+    }
+    if (key === 'watchHistory.delete') {
+      mockDeleteMutation.mockImplementation(() => {
+        if (typeof opts.onSuccess === 'function') (opts.onSuccess as () => void)();
+      });
+      return { mutate: mockDeleteMutation, isPending: false };
+    }
+    if (key === 'arr.updateSeasonMonitoring') {
+      mockSeasonMonitorMutation.mockImplementation(() => {
+        if (typeof opts.onSuccess === 'function') (opts.onSuccess as () => void)();
+      });
+      return { mutate: mockSeasonMonitorMutation, isPending: false };
+    }
+    if (key === 'arr.updateEpisodeMonitoring') {
+      mockEpisodeMonitorMutation.mockImplementation(
+        (variables: { episodeIds: number[]; monitored: boolean }) => {
+          if (typeof opts.onSuccess === 'function') (opts.onSuccess as () => void)();
+          if (typeof opts.onSettled === 'function')
+            (opts.onSettled as (d: unknown, e: unknown, v: typeof variables) => void)(
+              undefined,
+              undefined,
+              variables
+            );
+        }
+      );
+      return { mutate: mockEpisodeMonitorMutation, isPending: false };
     }
     return { mutate: vi.fn(), isPending: false };
   },
@@ -516,7 +458,7 @@ describe('SeasonDetailPage — monitoring', () => {
       mockShowQuery.mockReturnValue({
         data: null,
         isLoading: false,
-        error: { data: { code: 'NOT_FOUND' }, message: 'Not found' },
+        error: new PillarCallError('media', { kind: 'not-found', pillar: 'media' }),
       });
       renderPage('999');
       expect(screen.getByText('Show not found')).toBeInTheDocument();

--- a/packages/app-media/src/pages/SeasonDetailPage.tsx
+++ b/packages/app-media/src/pages/SeasonDetailPage.tsx
@@ -1,5 +1,6 @@
 import { Link, useParams } from 'react-router';
 
+import { isNotFound as isPillarNotFound } from '@pops/pillar-sdk/client';
 import { PageHeader, Skeleton } from '@pops/ui';
 
 import { EpisodeList } from '../components/EpisodeList';
@@ -67,9 +68,8 @@ export function SeasonDetailPage() {
   if (Number.isNaN(showId) || Number.isNaN(seasonNum)) return <InvalidParamsError />;
   if (m.showLoading || m.seasonsLoading) return <SeasonDetailSkeleton />;
   if (m.showError) {
-    return (
-      <ShowError is404={m.showError.data?.code === 'NOT_FOUND'} message={m.showError.message} />
-    );
+    const is404 = isPillarNotFound(m.showError);
+    return <ShowError is404={is404} message={m.showError.message} />;
   }
 
   const show = m.show;

--- a/packages/app-media/src/pages/season-detail/useEpisodeMonitoring.ts
+++ b/packages/app-media/src/pages/season-detail/useEpisodeMonitoring.ts
@@ -1,13 +1,18 @@
 import { useCallback, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 
-import { trpc } from '@pops/api-client';
+import { usePillarMutation } from '@pops/pillar-sdk/react';
 
 interface SonarrEpisode {
   id: number;
   episodeNumber: number;
   monitored: boolean;
   hasFile: boolean;
+}
+
+interface UpdateEpisodeMonitoringInput {
+  episodeIds: number[];
+  monitored: boolean;
 }
 
 function useDerivedMaps(sonarrEpisodes: SonarrEpisode[], optimistic: Map<number, boolean>) {
@@ -39,36 +44,34 @@ function useMonitorMutation(
   setOptimisticEpMonitoring: React.Dispatch<React.SetStateAction<Map<number, boolean>>>,
   setPendingEpMonitoring: React.Dispatch<React.SetStateAction<Set<number>>>
 ) {
-  const utils = trpc.useUtils();
-  return trpc.media.arr.updateEpisodeMonitoring.useMutation({
-    onSuccess: () => {
-      void utils.media.arr.getSeriesEpisodes.invalidate();
-    },
-    onError: (
-      err: { message: string },
-      variables: { episodeIds: number[]; monitored: boolean }
-    ) => {
-      setOptimisticEpMonitoring((prev) => {
-        const next = new Map(prev);
-        const affectedIds = new Set(variables.episodeIds);
-        for (const ep of sonarrEpisodes) {
-          if (affectedIds.has(ep.id)) next.set(ep.episodeNumber, !variables.monitored);
-        }
-        return next;
-      });
-      toast.error(`Failed to update monitoring: ${err.message}`);
-    },
-    onSettled: (_data: unknown, _err: unknown, variables: { episodeIds: number[] }) => {
-      setPendingEpMonitoring((prev) => {
-        const next = new Set(prev);
-        const affectedIds = new Set(variables.episodeIds);
-        for (const ep of sonarrEpisodes) {
-          if (affectedIds.has(ep.id)) next.delete(ep.episodeNumber);
-        }
-        return next;
-      });
-    },
-  });
+  return usePillarMutation<UpdateEpisodeMonitoringInput, unknown>(
+    'media',
+    ['arr', 'updateEpisodeMonitoring'],
+    {
+      onError: (err, variables) => {
+        setOptimisticEpMonitoring((prev) => {
+          const next = new Map(prev);
+          const affectedIds = new Set(variables.episodeIds);
+          for (const ep of sonarrEpisodes) {
+            if (affectedIds.has(ep.id)) next.set(ep.episodeNumber, !variables.monitored);
+          }
+          return next;
+        });
+        toast.error(`Failed to update monitoring: ${err.message}`);
+      },
+      onSettled: (_data, _err, variables) => {
+        if (!variables) return;
+        setPendingEpMonitoring((prev) => {
+          const next = new Set(prev);
+          const affectedIds = new Set(variables.episodeIds);
+          for (const ep of sonarrEpisodes) {
+            if (affectedIds.has(ep.id)) next.delete(ep.episodeNumber);
+          }
+          return next;
+        });
+      },
+    }
+  );
 }
 
 export function useEpisodeMonitoring(sonarrEpisodes: SonarrEpisode[]) {

--- a/packages/app-media/src/pages/season-detail/useEpisodeToggle.ts
+++ b/packages/app-media/src/pages/season-detail/useEpisodeToggle.ts
@@ -1,54 +1,73 @@
 import { useCallback, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
-import { trpc } from '@pops/api-client';
+import { usePillarMutation, usePillarUtils } from '@pops/pillar-sdk/react';
+
+import type { UsePillarUtilsResult } from '@pops/pillar-sdk/react';
 
 interface UseEpisodeToggleArgs {
   watchHistory: Array<{ id: number; mediaId: number }> | undefined;
 }
 
-export function useEpisodeToggle({ watchHistory }: UseEpisodeToggleArgs) {
-  const utils = trpc.useUtils();
-  const [togglingIds, setTogglingIds] = useState<Set<number>>(new Set());
-  const deleteEntryToEpisode = useRef<Map<number, number>>(new Map());
+interface LogInput {
+  mediaType: 'episode';
+  mediaId: number;
+}
 
-  const removeToggling = (episodeId: number) => {
-    setTogglingIds((prev) => {
-      const next = new Set(prev);
-      next.delete(episodeId);
-      return next;
-    });
-  };
+interface DeleteInput {
+  id: number;
+}
 
-  const logMutation = trpc.media.watchHistory.log.useMutation({
+function useLogMutation(utils: UsePillarUtilsResult, removeToggling: (id: number) => void) {
+  return usePillarMutation<LogInput, unknown>('media', ['watchHistory', 'log'], {
     onSuccess: () => {
-      void utils.media.watchHistory.list.invalidate();
-      void utils.media.watchHistory.progress.invalidate();
-      void utils.media.tvShows.listSeasons.invalidate();
+      void utils.invalidate(['tvShows', 'listSeasons']);
     },
-    onError: (err: { message: string }) => {
+    onError: (err) => {
       toast.error(`Failed to log watch: ${err.message}`);
     },
-    onSettled: (_data: unknown, _err: unknown, variables: { mediaId: number }) => {
-      removeToggling(variables.mediaId);
+    onSettled: (_data, _err, variables) => {
+      if (variables) removeToggling(variables.mediaId);
     },
   });
+}
 
-  const deleteMutation = trpc.media.watchHistory.delete.useMutation({
+function useDeleteMutation(
+  utils: UsePillarUtilsResult,
+  deleteEntryToEpisode: React.RefObject<Map<number, number>>,
+  removeToggling: (id: number) => void
+) {
+  return usePillarMutation<DeleteInput, unknown>('media', ['watchHistory', 'delete'], {
     onSuccess: () => {
-      void utils.media.watchHistory.list.invalidate();
-      void utils.media.watchHistory.progress.invalidate();
-      void utils.media.tvShows.listSeasons.invalidate();
+      void utils.invalidate(['tvShows', 'listSeasons']);
     },
-    onError: (err: { message: string }) => {
+    onError: (err) => {
       toast.error(`Failed to remove watch: ${err.message}`);
     },
-    onSettled: (_data: unknown, _err: unknown, variables: { id: number }) => {
+    onSettled: (_data, _err, variables) => {
+      if (!variables) return;
       const episodeId = deleteEntryToEpisode.current.get(variables.id);
       deleteEntryToEpisode.current.delete(variables.id);
       if (episodeId != null) removeToggling(episodeId);
     },
   });
+}
+
+export function useEpisodeToggle({ watchHistory }: UseEpisodeToggleArgs) {
+  const utils = usePillarUtils('media');
+  const [togglingIds, setTogglingIds] = useState<Set<number>>(new Set());
+  const deleteEntryToEpisode = useRef<Map<number, number>>(new Map());
+
+  const removeToggling = useCallback((episodeId: number) => {
+    setTogglingIds((prev) => {
+      const next = new Set(prev);
+      next.delete(episodeId);
+      return next;
+    });
+  }, []);
+
+  const logMutation = useLogMutation(utils, removeToggling);
+  const deleteMutation = useDeleteMutation(utils, deleteEntryToEpisode, removeToggling);
 
   const handleToggleWatched = useCallback(
     (episodeId: number, watched: boolean) => {
@@ -67,7 +86,7 @@ export function useEpisodeToggle({ watchHistory }: UseEpisodeToggleArgs) {
         removeToggling(episodeId);
       }
     },
-    [logMutation, deleteMutation, watchHistory]
+    [logMutation, deleteMutation, watchHistory, removeToggling]
   );
 
   return { togglingIds, handleToggleWatched };

--- a/packages/app-media/src/pages/season-detail/useSeasonDetailModel.ts
+++ b/packages/app-media/src/pages/season-detail/useSeasonDetailModel.ts
@@ -1,19 +1,80 @@
 import { useMemo } from 'react';
 
-import { trpc } from '@pops/api-client';
 import { useSetPageContext } from '@pops/navigation';
+import { usePillarQuery } from '@pops/pillar-sdk/react';
 
 import { useEpisodeWatchState } from './useEpisodeWatchState';
 import { useSonarrMonitoring } from './useSonarrMonitoring';
 
+interface ShowEnvelope {
+  data: { id: number; name: string; tvdbId?: number } | null;
+}
+
+interface SeasonItem {
+  id: number;
+  seasonNumber: number;
+  name: string;
+  posterUrl: string | null;
+  airDate: string | null;
+  overview: string | null;
+}
+
+interface SeasonsEnvelope {
+  data: SeasonItem[];
+}
+
+interface EpisodeItem {
+  id: number;
+  episodeNumber: number;
+  name: string | null;
+  overview: string | null;
+  airDate: string | null;
+  runtime: number | null;
+}
+
+interface EpisodesEnvelope {
+  data: EpisodeItem[];
+}
+
+interface WatchHistoryItem {
+  id: number;
+  mediaId: number;
+}
+
+interface WatchHistoryEnvelope {
+  data: WatchHistoryItem[];
+}
+
+interface ProgressSeason {
+  seasonNumber: number;
+  watched: number;
+  total: number;
+}
+
+interface ProgressEnvelope {
+  data: {
+    seasons?: ProgressSeason[];
+  } | null;
+}
+
 function useSeasonQueries(showId: number, seasonNum: number) {
   const enabled = !Number.isNaN(showId);
-  const showQuery = trpc.media.tvShows.get.useQuery({ id: showId }, { enabled });
-  const seasonsQuery = trpc.media.tvShows.listSeasons.useQuery({ tvShowId: showId }, { enabled });
-  const season = seasonsQuery.data?.data?.find(
-    (s: { seasonNumber: number }) => s.seasonNumber === seasonNum
+  const showQuery = usePillarQuery<ShowEnvelope>(
+    'media',
+    ['tvShows', 'get'],
+    { id: showId },
+    { enabled }
   );
-  const episodesQuery = trpc.media.tvShows.listEpisodes.useQuery(
+  const seasonsQuery = usePillarQuery<SeasonsEnvelope>(
+    'media',
+    ['tvShows', 'listSeasons'],
+    { tvShowId: showId },
+    { enabled }
+  );
+  const season = seasonsQuery.data?.data?.find((s) => s.seasonNumber === seasonNum);
+  const episodesQuery = usePillarQuery<EpisodesEnvelope>(
+    'media',
+    ['tvShows', 'listEpisodes'],
     { seasonId: season?.id ?? 0 },
     { enabled: !!season?.id }
   );
@@ -21,11 +82,15 @@ function useSeasonQueries(showId: number, seasonNum: number) {
 }
 
 function useWatchHistoryAndProgress(showId: number, episodeIds: number[]) {
-  const watchHistoryQuery = trpc.media.watchHistory.list.useQuery(
+  const watchHistoryQuery = usePillarQuery<WatchHistoryEnvelope>(
+    'media',
+    ['watchHistory', 'list'],
     { mediaType: 'episode', limit: 500 },
     { enabled: episodeIds.length > 0 }
   );
-  const progressQuery = trpc.media.watchHistory.progress.useQuery(
+  const progressQuery = usePillarQuery<ProgressEnvelope>(
+    'media',
+    ['watchHistory', 'progress'],
     { tvShowId: showId },
     { enabled: !Number.isNaN(showId) }
   );
@@ -81,12 +146,12 @@ export function useSeasonDetailModel(showId: number, seasonNum: number) {
   const { showQuery, seasonsQuery, season, episodesQuery } = useSeasonQueries(showId, seasonNum);
 
   const episodes = episodesQuery.data?.data ?? [];
-  const episodeIds = useMemo(() => episodes.map((ep: { id: number }) => ep.id), [episodes]);
+  const episodeIds = useMemo(() => episodes.map((ep) => ep.id), [episodes]);
 
   const { watchHistoryQuery, progressQuery } = useWatchHistoryAndProgress(showId, episodeIds);
 
   const seasonProgress = progressQuery.data?.data?.seasons?.find(
-    (s: { seasonNumber: number }) => s.seasonNumber === seasonNum
+    (s) => s.seasonNumber === seasonNum
   );
 
   const { sonarr, watch } = useSeasonInteractions({

--- a/packages/app-media/src/pages/season-detail/useSonarrMonitoring.ts
+++ b/packages/app-media/src/pages/season-detail/useSonarrMonitoring.ts
@@ -1,7 +1,7 @@
 import { useCallback, useState } from 'react';
 import { toast } from 'sonner';
 
-import { trpc } from '@pops/api-client';
+import { usePillarMutation, usePillarQuery } from '@pops/pillar-sdk/react';
 
 import { useEpisodeMonitoring } from './useEpisodeMonitoring';
 
@@ -9,6 +9,27 @@ interface SonarrSeries {
   exists: boolean;
   sonarrId?: number;
   seasons?: Array<{ seasonNumber: number; monitored: boolean }>;
+}
+
+interface CheckSeriesEnvelope {
+  data?: SonarrSeries;
+}
+
+interface SonarrEpisodeItem {
+  id: number;
+  episodeNumber: number;
+  monitored: boolean;
+  hasFile: boolean;
+}
+
+interface GetSeriesEpisodesEnvelope {
+  data: SonarrEpisodeItem[];
+}
+
+interface UpdateSeasonMonitoringInput {
+  sonarrId: number;
+  seasonNumber: number;
+  monitored: boolean;
 }
 
 interface UseSonarrMonitoringArgs {
@@ -20,7 +41,9 @@ interface UseSonarrMonitoringArgs {
  * Hook owning Sonarr (Arr) monitoring state for a single season.
  */
 export function useSonarrMonitoring({ tvdbId, seasonNum }: UseSonarrMonitoringArgs) {
-  const { data: sonarrData } = trpc.media.arr.checkSeries.useQuery(
+  const { data: sonarrData } = usePillarQuery<CheckSeriesEnvelope>(
+    'media',
+    ['arr', 'checkSeries'],
     { tvdbId: tvdbId ?? 0 },
     { enabled: !!tvdbId }
   );
@@ -30,15 +53,21 @@ export function useSonarrMonitoring({ tvdbId, seasonNum }: UseSonarrMonitoringAr
   const [seasonMonitored, setSeasonMonitored] = useState<boolean | null>(null);
   const effectiveMonitored = seasonMonitored ?? sonarrSeasonData?.monitored ?? false;
 
-  const seasonMonitorMutation = trpc.media.arr.updateSeasonMonitoring.useMutation({
-    onError: (err: { message: string }) => {
-      setSeasonMonitored((prev) => (prev != null ? !prev : null));
-      toast.error(`Failed to update monitoring: ${err.message}`);
-    },
-  });
+  const seasonMonitorMutation = usePillarMutation<UpdateSeasonMonitoringInput, unknown>(
+    'media',
+    ['arr', 'updateSeasonMonitoring'],
+    {
+      onError: (err) => {
+        setSeasonMonitored((prev) => (prev != null ? !prev : null));
+        toast.error(`Failed to update monitoring: ${err.message}`);
+      },
+    }
+  );
 
   const sonarrId = sonarrSeries?.sonarrId;
-  const { data: sonarrEpisodesData } = trpc.media.arr.getSeriesEpisodes.useQuery(
+  const { data: sonarrEpisodesData } = usePillarQuery<GetSeriesEpisodesEnvelope>(
+    'media',
+    ['arr', 'getSeriesEpisodes'],
     { sonarrId: sonarrId ?? 0, seasonNumber: seasonNum },
     { enabled: !!sonarrId }
   );


### PR DESCRIPTION
## Summary

- Migrates the season-detail page surface in `@pops/app-media` from `@pops/api-client` (tRPC) to `@pops/pillar-sdk` (`usePillarQuery` / `usePillarMutation` / `usePillarUtils`).
- 13 sites across 5 source files: show / seasons / episodes queries, watch-history + progress queries, Sonarr check + episodes queries, plus the season + episode monitoring + episode toggle mutations.
- Switches the show-not-found branch in `SeasonDetailPage.tsx` from `error.data?.code === 'NOT_FOUND'` to `isNotFound(error)` from `@pops/pillar-sdk/client`.

## Slice (5 source files)

- `pages/season-detail/useSeasonDetailModel.ts`
- `pages/season-detail/useSonarrMonitoring.ts`
- `pages/season-detail/useEpisodeToggle.ts`
- `pages/season-detail/useEpisodeMonitoring.ts`
- `pages/SeasonDetailPage.tsx`

Plus the page-level test `SeasonDetailPage.test.tsx` whose mocks now dispatch on the SDK path instead of the tRPC namespace; the NOT_FOUND case constructs a real `PillarCallError` with `kind: 'not-found'`.

## Notes

- `usePillarMutation` auto-invalidates the mutation's router prefix on success, so the previous explicit `watchHistory.list` / `watchHistory.progress` and `arr.getSeriesEpisodes` invalidations are subsumed by the prefix invalidation.
- The cross-router `tvShows.listSeasons` invalidate is kept explicit via `usePillarUtils('media').invalidate(['tvShows', 'listSeasons'])`.
- No overlap with PRs #3128 / #3141 / #3145 / #3156 / #3164 / #3169 (verified via `gh pr view --json files`).

## Cumulative app-media progress

Post #3169 + this PR: ~127 / 151 trivial tRPC sites migrated.

## Test plan

- [x] `pnpm --filter @pops/app-media test` — 698/698 passing
- [x] `pnpm typecheck` — 71/71 packages clean
- [x] `npx oxlint --type-aware packages/app-media/src` — 0 errors
- [x] `npx oxfmt --check` on touched files — clean

PRD-227