### PR TITLE
feat(pillar-sdk): scaffold ./settings subpath re-exporting module-registry manifests (PRD-238 prerequisite)

### DIFF
--- a/docs/themes/13-pillar-finale/prds/238-settings-known-modules-surface/README.md
+++ b/docs/themes/13-pillar-finale/prds/238-settings-known-modules-surface/README.md
@@ -2,25 +2,18 @@
 
 > Epic: [FE pillar SDK + dispatcher generator](../../epics/10-fe-sdk-dispatcher-generator.md)
 >
-> Status: **Blocked — target exports missing**
+> Status: **Unblocked — prerequisite landed; US-01 ready**
 
 ## Status note (2026-06-14)
 
-US-01 cannot proceed as written. Both candidate migration targets are unavailable today:
+The Option B prerequisite shipped — `packages/pillar-sdk/src/settings/index.ts` now re-exports the 10 manifests (`aiConfigManifest`, `coreOperationalManifest`, `inventoryManifest`, `financeManifest`, `cerebrumManifest`, `egoManifest`, `arrManifest`, `plexManifest`, `rotationManifest`, `mediaOperationalManifest`) from `@pops/module-registry/settings`, the `./settings` subpath is declared in `pillar-sdk/package.json`'s `exports`, and pillar-sdk picks up a workspace dep on `@pops/module-registry`.
 
-- **Option A (per-pillar packages)** — no `@pops/pillar-core`, `@pops/pillar-media`, `@pops/pillar-cerebrum`, `@pops/pillar-inventory`, or `@pops/pillar-finance` package exists under `packages/`. Only `@pops/pillar-sdk` is published. The per-pillar contract packages (`@pops/<pillar>-contract`) exist but do not export `SettingsManifest` values.
-- **Option B (`@pops/pillar-sdk/settings`)** — `packages/pillar-sdk/src` has no `settings/` subpath and no `Manifest` exports today. The precedent (PR #3090) only added `ALL_MODULE_IDS` / `isKnownPillarId` / `isModuleId`; it did not introduce a settings surface.
+Status of the two options going into US-01:
 
-The per-pillar `SettingsManifest` values currently live only in `@pops/module-registry/src/settings/{core,inventory,finance,cerebrum,ego,media}/...` and are re-exported through `@pops/module-registry/settings`. Flipping the 8 consumers requires the target exports to exist first.
+- **Option A (per-pillar packages)** — still unavailable. No `@pops/pillar-core`, `@pops/pillar-media`, `@pops/pillar-cerebrum`, `@pops/pillar-inventory`, or `@pops/pillar-finance` package exists under `packages/`; the per-pillar contract packages (`@pops/<pillar>-contract`) do not export `SettingsManifest` values. Picking Option A still requires scaffolding those packages first.
+- **Option B (`@pops/pillar-sdk/settings`)** — landed. US-01 can flip the 8 consumers to `import { … } from '@pops/pillar-sdk/settings'` today.
 
-**Prerequisite work** before this PRD can resume:
-
-1. Pick the target (decision is still A vs B per the original PRD).
-2. Land that target as its own PR — for Option B, scaffold `packages/pillar-sdk/src/settings/` with the 10 manifest re-exports (`aiConfigManifest`, `coreOperationalManifest`, `inventoryManifest`, `financeManifest`, `cerebrumManifest`, `egoManifest`, `arrManifest`, `plexManifest`, `rotationManifest`, `mediaOperationalManifest`) sourced from the canonical files in `@pops/module-registry/src/settings/**`, add the `./settings` export in `pillar-sdk/package.json`, extend the import-discipline allow-list in `eslint-config-pops`. For Option A, the same work multiplied by N new pillar packages.
-3. Then re-run US-01 to flip the 8 consumers.
-4. US-02 (delete `@pops/module-registry/settings`) follows unchanged.
-
-This PR records the block; no consumer changes ship in it.
+US-01 picks the available target (Option B) and runs the mechanical sweep. US-02 (delete `@pops/module-registry/settings`) follows unchanged.
 
 ## Overview
 

--- a/packages/pillar-sdk/package.json
+++ b/packages/pillar-sdk/package.json
@@ -58,6 +58,10 @@
       "types": "./dist/orchestrator/index.d.ts",
       "default": "./dist/orchestrator/index.js"
     },
+    "./settings": {
+      "types": "./dist/settings/index.d.ts",
+      "default": "./dist/settings/index.js"
+    },
     "./package.json": "./package.json"
   },
   "scripts": {
@@ -68,6 +72,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@pops/module-registry": "workspace:*",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/packages/pillar-sdk/src/settings/__tests__/index.test.ts
+++ b/packages/pillar-sdk/src/settings/__tests__/index.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  aiConfigManifest,
+  arrManifest,
+  cerebrumManifest,
+  coreOperationalManifest,
+  egoManifest,
+  financeManifest,
+  inventoryManifest,
+  mediaOperationalManifest,
+  plexManifest,
+  rotationManifest,
+} from '../index.js';
+
+describe('@pops/pillar-sdk/settings re-export surface', () => {
+  it('exposes all ten pillar settings manifests', () => {
+    const manifests = {
+      aiConfigManifest,
+      coreOperationalManifest,
+      inventoryManifest,
+      financeManifest,
+      cerebrumManifest,
+      egoManifest,
+      arrManifest,
+      plexManifest,
+      rotationManifest,
+      mediaOperationalManifest,
+    };
+
+    for (const [name, manifest] of Object.entries(manifests)) {
+      expect(manifest, `${name} is reachable`).toBeDefined();
+      expect(manifest, `${name} is non-null`).not.toBeNull();
+      expect(typeof manifest.id, `${name}.id is a string`).toBe('string');
+    }
+  });
+});

--- a/packages/pillar-sdk/src/settings/index.ts
+++ b/packages/pillar-sdk/src/settings/index.ts
@@ -1,0 +1,21 @@
+/**
+ * Pillar-scoped settings manifests, re-exported from `@pops/module-registry`
+ * so consumers can migrate off the legacy `@pops/module-registry/settings`
+ * subpath onto the SDK surface (PRD-238 US-01, Option B).
+ *
+ * Pure re-export — no shape change, no runtime behaviour change. The legacy
+ * subpath is retired once US-01 flips all eight call sites and US-02 deletes
+ * `@pops/module-registry/settings`.
+ */
+export {
+  aiConfigManifest,
+  coreOperationalManifest,
+  inventoryManifest,
+  financeManifest,
+  cerebrumManifest,
+  egoManifest,
+  arrManifest,
+  plexManifest,
+  rotationManifest,
+  mediaOperationalManifest,
+} from '@pops/module-registry/settings';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2272,6 +2272,9 @@ importers:
 
   packages/pillar-sdk:
     dependencies:
+      '@pops/module-registry':
+        specifier: workspace:*
+        version: link:../module-registry
       zod:
         specifier: ^4.4.3
         version: 4.4.3


### PR DESCRIPTION
## Summary

Lands the Option B prerequisite that PR #3171 parked PRD-238 on. Pure scaffolding — no consumer migration.

- `packages/pillar-sdk/src/settings/index.ts` re-exports the 10 manifests (`aiConfigManifest`, `coreOperationalManifest`, `inventoryManifest`, `financeManifest`, `cerebrumManifest`, `egoManifest`, `arrManifest`, `plexManifest`, `rotationManifest`, `mediaOperationalManifest`) from `@pops/module-registry/settings`.
- `packages/pillar-sdk/package.json` exposes the `./settings` subpath and picks up a workspace dep on `@pops/module-registry`.
- Smoke test asserts every named export is reachable and shaped like a `SettingsManifest` (`id` is a string).
- PRD-238 README status flips from "Blocked — target exports missing" to "Unblocked — prerequisite landed; US-01 ready". The status note section is rewritten to reflect Option B as the available target.

## Out of scope (US-01 / US-02 in follow-up PRs)

- Migrating the 8 `apps/pops-api` consumers off `@pops/module-registry/settings` — PRD-238 US-01.
- Deleting `@pops/module-registry/settings` — PRD-238 US-02.

## Note on the "eslint allow-list" item in the task brief

The brief calls for extending an `eslint-config-pops` allow-list to permit `@pops/pillar-sdk/settings` imports. The repo has no such package: import discipline runs through `dependency-cruiser` (`.dependency-cruiser.cjs` + `.dependency-cruiser.rules.generated.cjs`), and no existing rule blocks `@pops/pillar-sdk/*` from `apps/pops-api/**`. Nothing to extend here; if US-01 trips a future rule, it gets handled in that PR.

## Test plan

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm --filter @pops/pillar-sdk... build`
- [x] `pnpm --filter @pops/pillar-sdk test` (35 files, 492 tests pass)
- [x] `pnpm typecheck` (71 tasks green)
- [x] `pnpm format:check`
- [x] `pnpm lint` (no new errors; only pre-existing warnings)
- [x] Husky `pre-commit` (lint-staged) + `pre-push` (typecheck + rebase check) clean

## References

- PR #3171 — parked PRD-238 as "Blocked — target exports missing"; this PR is its concrete next step.
- PRD-238: `docs/themes/13-pillar-finale/prds/238-settings-known-modules-surface/README.md`
