### PR TITLE
feat(api): PRD-238 US-01 migrate 6 settings imports to pillar-sdk/settings

### DIFF
--- a/apps/pops-api/package.json
+++ b/apps/pops-api/package.json
@@ -88,6 +88,7 @@
     "@pops/lists-db": "workspace:*",
     "@pops/media-db": "workspace:*",
     "@pops/module-registry": "workspace:*",
+    "@pops/pillar-sdk": "workspace:*",
     "@pops/types": "workspace:*",
     "@trpc/client": "11.17.0",
     "@trpc/server": "^11.17.0",

--- a/apps/pops-api/src/modules/cerebrum/ego/index.ts
+++ b/apps/pops-api/src/modules/cerebrum/ego/index.ts
@@ -7,7 +7,7 @@
  *   ego.context.setScopes                    — explicit scope override (US-04)
  *   ego.context.getActive                    — current context state (US-03)
  */
-import { egoManifest } from '@pops/module-registry/settings';
+import { egoManifest } from '@pops/pillar-sdk/settings';
 
 import { mergeRouters, router } from '../../../trpc.js';
 import { contextRouter } from './router-context.js';

--- a/apps/pops-api/src/modules/cerebrum/index.ts
+++ b/apps/pops-api/src/modules/cerebrum/index.ts
@@ -2,7 +2,7 @@
  * Cerebrum domain — engram storage and retrieval.
  * See docs/themes/06-cerebrum for the full spec.
  */
-import { cerebrumManifest } from '@pops/module-registry/settings';
+import { cerebrumManifest } from '@pops/pillar-sdk/settings';
 
 import { mergeRouters, router } from '../../trpc.js';
 import { cerebrumAiTools } from './ai-tools/index.js';

--- a/apps/pops-api/src/modules/core/index.ts
+++ b/apps/pops-api/src/modules/core/index.ts
@@ -1,4 +1,4 @@
-import { aiConfigManifest, coreOperationalManifest } from '@pops/module-registry/settings';
+import { aiConfigManifest, coreOperationalManifest } from '@pops/pillar-sdk/settings';
 
 /**
  * Core domain — cross-cutting concerns shared across finance & inventory.

--- a/apps/pops-api/src/modules/core/uri/resolver.ts
+++ b/apps/pops-api/src/modules/core/uri/resolver.ts
@@ -13,8 +13,8 @@ import { parseUri } from './parse.js';
  *
  * The registry view is passed as an argument rather than imported as a global
  * so the unit tests can supply minimal fakes without a full backend stand-up.
- * Once `@pops/module-registry` (PRD-101 US-02) ships, the production wiring
- * just substitutes the generated `MODULES` constant.
+ * Production wiring substitutes the live `installedManifests()` aggregator
+ * (see `apps/pops-api/src/modules/installed-modules.ts`).
  */
 import type { ModuleManifest, UriResolverResult } from '@pops/types';
 

--- a/apps/pops-api/src/modules/finance/index.ts
+++ b/apps/pops-api/src/modules/finance/index.ts
@@ -1,4 +1,4 @@
-import { financeManifest } from '@pops/module-registry/settings';
+import { financeManifest } from '@pops/pillar-sdk/settings';
 
 /**
  * Finance domain — transactions, budgets, imports, wishlist.

--- a/apps/pops-api/src/modules/inventory/index.ts
+++ b/apps/pops-api/src/modules/inventory/index.ts
@@ -1,4 +1,4 @@
-import { inventoryManifest } from '@pops/module-registry/settings';
+import { inventoryManifest } from '@pops/pillar-sdk/settings';
 
 /**
  * Inventory domain — home inventory items, locations, connections, and photos.

--- a/apps/pops-api/src/modules/manifests.ts
+++ b/apps/pops-api/src/modules/manifests.ts
@@ -4,9 +4,9 @@ import { installedManifests } from './installed-modules.js';
  * Backend module manifests — convenience wrapper around `installedManifests()`
  * (PRD-101 US-05) for cross-cutting aggregators that need the live module
  * manifests with their code-bearing slots attached (router, URI handler,
- * AI tools, …). Settings have moved to `@pops/module-registry`'s `MODULES`
- * constant (PRD-101 US-04 follow-up) — consumers read them directly via
- * `MODULES.flatMap(m => m.settings ?? [])`.
+ * AI tools, …). Settings live on each module's `SettingsManifest` export
+ * surfaced via `@pops/pillar-sdk/settings`; consumers that just need the
+ * settings shape read it directly from there.
  */
 import type { ModuleManifest } from '@pops/types';
 

--- a/apps/pops-api/src/modules/media/index.ts
+++ b/apps/pops-api/src/modules/media/index.ts
@@ -9,7 +9,7 @@ import {
   mediaOperationalManifest,
   plexManifest,
   rotationManifest,
-} from '@pops/module-registry/settings';
+} from '@pops/pillar-sdk/settings';
 
 import { router } from '../../trpc.js';
 import { arrRouter } from './arr/index.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,9 @@ importers:
       '@pops/module-registry':
         specifier: workspace:*
         version: link:../../packages/module-registry
+      '@pops/pillar-sdk':
+        specifier: workspace:*
+        version: link:../../packages/pillar-sdk
       '@pops/types':
         specifier: workspace:*
         version: link:../../packages/types


### PR DESCRIPTION
## Summary

PRD-238 US-01. Flips the six active `@pops/module-registry/settings` import sites in `apps/pops-api` onto `@pops/pillar-sdk/settings` (Option B — the re-export landed by #3175) and rewrites the two docstring-only references to drop the `@pops/module-registry` mention. Adds `@pops/pillar-sdk` to `apps/pops-api`'s workspace deps.

Sites migrated (6 active + 2 docstring):

- `apps/pops-api/src/modules/core/index.ts`
- `apps/pops-api/src/modules/inventory/index.ts`
- `apps/pops-api/src/modules/finance/index.ts`
- `apps/pops-api/src/modules/cerebrum/index.ts`
- `apps/pops-api/src/modules/cerebrum/ego/index.ts`
- `apps/pops-api/src/modules/media/index.ts`
- `apps/pops-api/src/modules/manifests.ts` (docstring)
- `apps/pops-api/src/modules/core/uri/resolver.ts` (docstring)

## US-02 status: deferred

US-02 (delete `@pops/module-registry/settings` subpath export) is **not** in this PR.

After flipping all eight sites, the only remaining consumer of `@pops/module-registry/settings` is `packages/pillar-sdk/src/settings/index.ts` itself — it re-exports the ten manifests from the legacy subpath:

```ts
export {
  aiConfigManifest, coreOperationalManifest, inventoryManifest,
  financeManifest, cerebrumManifest, egoManifest,
  arrManifest, plexManifest, rotationManifest, mediaOperationalManifest,
} from '@pops/module-registry/settings';
```

Dropping the `./settings` subpath today would break pillar-sdk. The clean path is to re-point pillar-sdk at the underlying per-pillar manifest modules (`@pops/module-registry/src/settings/{core,finance,inventory,…}`) so the subpath has zero consumers — that's its own piece of work and is out of scope for this PR per the PRD-238 STOP rule.

## Before / after (one site)

`apps/pops-api/src/modules/finance/index.ts`:

```diff
-import { financeManifest } from '@pops/module-registry/settings';
+import { financeManifest } from '@pops/pillar-sdk/settings';
```

## Verification

- [x] `pnpm --filter @pops/api typecheck` clean
- [x] `pnpm --filter @pops/api test` — same pre-existing failures as `main` (`ai-categorizer.test.ts`, `rule-generator.test.ts`); unrelated to this change
- [x] `pnpm --filter @pops/module-registry test` clean (77/77)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (warnings only, no new ones)
- [x] Husky pre-commit + pre-push passed (no `--no-verify`)
- [x] No `as any` / `as unknown as` / `eslint-disable` / `ts-ignore` introduced

## Test plan

- [ ] CI green on the new branch
- [ ] `apps/pops-api` boots and the per-pillar manifests load the same as before (pure import-specifier flip, no runtime change)

## References

- PRD: `docs/themes/13-pillar-finale/prds/238-settings-known-modules-surface/README.md`
- US-01: `docs/themes/13-pillar-finale/prds/238-settings-known-modules-surface/us-01-pick-target-and-migrate.md`
- Prerequisite PR: #3175