### PR TITLE
feat(pillar-sdk): add usePillarQueries (PR #3163 deferred unblock)

### DIFF
--- a/packages/pillar-sdk/src/react/__tests__/use-pillar-queries.test.tsx
+++ b/packages/pillar-sdk/src/react/__tests__/use-pillar-queries.test.tsx
@@ -1,0 +1,211 @@
+// @vitest-environment jsdom
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  discoveredPillar,
+  fakeFetch,
+  FakeRegistryTransport,
+  jsonResponse,
+} from '../../client/__tests__/fixtures.js';
+import { __resetSharedPillarClient } from '../../client/factory.js';
+import { pillarQueryArg, usePillarQueries } from '../hooks.js';
+import { PillarSdkProvider } from '../provider.js';
+
+import type { ReactNode } from 'react';
+
+import type { PillarClientOptions } from '../../client/factory.js';
+
+type Ingredient = { id: string; name: string };
+type Unit = { id: string; symbol: string };
+
+type FetchScript = (url: string, body: unknown) => Response | Promise<Response>;
+
+type Harness = {
+  wrapper: (props: { children: ReactNode }) => ReactNode;
+  queryClient: QueryClient;
+  calls: { url: string; body: unknown }[];
+};
+
+function buildHarness(transport: FakeRegistryTransport, script: FetchScript): Harness {
+  const calls: { url: string; body: unknown }[] = [];
+  const fetchImpl = fakeFetch(async (url, init) => {
+    let parsed: unknown = null;
+    if (init?.body && typeof init.body === 'string') {
+      try {
+        parsed = JSON.parse(init.body);
+      } catch {
+        parsed = init.body;
+      }
+    }
+    calls.push({ url, body: parsed });
+    return script(url, parsed);
+  });
+  const options: PillarClientOptions = { transport, fetchImpl };
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  const wrapper = ({ children }: { children: ReactNode }): ReactNode => (
+    <QueryClientProvider client={queryClient}>
+      <PillarSdkProvider options={options}>{children}</PillarSdkProvider>
+    </QueryClientProvider>
+  );
+  return { wrapper, queryClient, calls };
+}
+
+describe('usePillarQueries', () => {
+  beforeEach(() => __resetSharedPillarClient());
+  afterEach(() => __resetSharedPillarClient());
+
+  it('runs each descriptor in parallel and returns results in matching order', async () => {
+    const transport = new FakeRegistryTransport({ pillars: [discoveredPillar()] });
+    const harness = buildHarness(transport, (_url, body) => {
+      const input = body as { id: string };
+      if (input.id === 'a') return jsonResponse({ result: { data: { id: 'a', name: 'apple' } } });
+      return jsonResponse({ result: { data: { id: 'b', name: 'banana' } } });
+    });
+
+    const { result } = renderHook(
+      () =>
+        usePillarQueries([
+          pillarQueryArg<Ingredient>({
+            pillarId: 'finance',
+            path: ['wishlist', 'get'],
+            input: { id: 'a' },
+          }),
+          pillarQueryArg<Ingredient>({
+            pillarId: 'finance',
+            path: ['wishlist', 'get'],
+            input: { id: 'b' },
+          }),
+        ]),
+      { wrapper: harness.wrapper }
+    );
+
+    await waitFor(() => {
+      expect(result.current[0].isSuccess).toBe(true);
+      expect(result.current[1].isSuccess).toBe(true);
+    });
+
+    expect(result.current).toHaveLength(2);
+    expect(result.current[0].data).toEqual({ id: 'a', name: 'apple' });
+    expect(result.current[1].data).toEqual({ id: 'b', name: 'banana' });
+    expect(harness.calls).toHaveLength(2);
+  });
+
+  it('preserves per-element output types via the pillarQueryArg builder', async () => {
+    const transport = new FakeRegistryTransport({ pillars: [discoveredPillar()] });
+    const harness = buildHarness(transport, (_url, body) => {
+      const input = body as { id: string };
+      if (input.id === 'ing-1') {
+        return jsonResponse({ result: { data: { id: 'ing-1', name: 'flour' } } });
+      }
+      return jsonResponse({ result: { data: { id: 'unit-1', symbol: 'g' } } });
+    });
+
+    const { result } = renderHook(
+      () => {
+        const queries = usePillarQueries([
+          pillarQueryArg<Ingredient>({
+            pillarId: 'finance',
+            path: ['ingredients', 'get'],
+            input: { id: 'ing-1' },
+          }),
+          pillarQueryArg<Unit>({
+            pillarId: 'finance',
+            path: ['units', 'get'],
+            input: { id: 'unit-1' },
+          }),
+        ]);
+        return queries;
+      },
+      { wrapper: harness.wrapper }
+    );
+
+    await waitFor(() => {
+      expect(result.current[0].isSuccess).toBe(true);
+      expect(result.current[1].isSuccess).toBe(true);
+    });
+
+    const ing: Ingredient | undefined = result.current[0].data;
+    const unit: Unit | undefined = result.current[1].data;
+    expect(ing?.name).toBe('flour');
+    expect(unit?.symbol).toBe('g');
+  });
+
+  it('handles an empty queries array without issuing any calls', async () => {
+    const transport = new FakeRegistryTransport({ pillars: [discoveredPillar()] });
+    const harness = buildHarness(transport, () => jsonResponse({}));
+
+    const { result } = renderHook(() => usePillarQueries([]), { wrapper: harness.wrapper });
+
+    expect(result.current).toEqual([]);
+    expect(harness.calls).toHaveLength(0);
+  });
+
+  it('surfaces failure flags per element when one pillar is unavailable', async () => {
+    const transport = new FakeRegistryTransport({ pillars: [discoveredPillar()] });
+    const harness = buildHarness(transport, (_url, body) => {
+      return jsonResponse({ result: { data: { id: (body as { id: string }).id, name: 'ok' } } });
+    });
+
+    const { result } = renderHook(
+      () =>
+        usePillarQueries([
+          pillarQueryArg<Ingredient>({
+            pillarId: 'finance',
+            path: ['wishlist', 'get'],
+            input: { id: 'a' },
+          }),
+          pillarQueryArg<Ingredient>({
+            pillarId: 'missing-pillar',
+            path: ['wishlist', 'get'],
+            input: { id: 'b' },
+          }),
+        ]),
+      { wrapper: harness.wrapper }
+    );
+
+    await waitFor(() => {
+      expect(result.current[0].isSuccess).toBe(true);
+      expect(result.current[1].isError).toBe(true);
+    });
+
+    expect(result.current[0].isUnavailable).toBe(false);
+    expect(result.current[1].isUnavailable).toBe(true);
+  });
+
+  it('forwards per-query options (enabled: false skips the call)', async () => {
+    const transport = new FakeRegistryTransport({ pillars: [discoveredPillar()] });
+    const harness = buildHarness(transport, () =>
+      jsonResponse({ result: { data: { id: 'a', name: 'apple' } } })
+    );
+
+    const { result } = renderHook(
+      () =>
+        usePillarQueries([
+          pillarQueryArg<Ingredient>({
+            pillarId: 'finance',
+            path: ['wishlist', 'get'],
+            input: { id: 'a' },
+          }),
+          pillarQueryArg<Ingredient>({
+            pillarId: 'finance',
+            path: ['wishlist', 'get'],
+            input: { id: 'b' },
+            options: { enabled: false },
+          }),
+        ]),
+      { wrapper: harness.wrapper }
+    );
+
+    await waitFor(() => expect(result.current[0].isSuccess).toBe(true));
+    expect(result.current[1].fetchStatus).toBe('idle');
+    expect(result.current[1].isPending).toBe(true);
+    expect(harness.calls).toHaveLength(1);
+  });
+});

--- a/packages/pillar-sdk/src/react/hooks.ts
+++ b/packages/pillar-sdk/src/react/hooks.ts
@@ -148,6 +148,8 @@ export {
   type UsePillarInfiniteQueryResult,
 } from './use-pillar-infinite-query.js';
 
+export { pillarQueryArg, usePillarQueries, type PillarQueryArg } from './use-pillar-queries.js';
+
 export type UsePillarCallDynamicQueryOptions = UsePillarQueryOptions<unknown>;
 export type UsePillarCallDynamicQueryResult = UsePillarQueryResult<unknown>;
 export type UsePillarCallDynamicMutationOptions = UsePillarMutationOptions<unknown, unknown>;

--- a/packages/pillar-sdk/src/react/index.ts
+++ b/packages/pillar-sdk/src/react/index.ts
@@ -1,15 +1,18 @@
 export { PillarSdkProvider, usePillarSdkOptions } from './provider.js';
 export type { PillarSdkProviderProps } from './provider.js';
 export {
+  pillarQueryArg,
   usePillarCallDynamic,
   usePillarCallDynamicMutation,
   usePillarInfiniteQuery,
   usePillarMutation,
+  usePillarQueries,
   usePillarQuery,
   usePillarUtils,
 } from './hooks.js';
 export type {
   PillarInfiniteBuildInput,
+  PillarQueryArg,
   PillarUpdater,
   UsePillarCallDynamicMutationArgs,
   UsePillarCallDynamicMutationOptions,

--- a/packages/pillar-sdk/src/react/use-pillar-queries.ts
+++ b/packages/pillar-sdk/src/react/use-pillar-queries.ts
@@ -1,0 +1,101 @@
+import { useQueries } from '@tanstack/react-query';
+
+import { PillarCallError } from '../client/errors.js';
+import {
+  callProcedure,
+  failureFlagsFrom,
+  NO_FAILURE,
+  type ProcedurePath,
+} from './internal/call-procedure.js';
+import { usePillarSdkOptions } from './provider.js';
+import { pillarQueryKey } from './query-key.js';
+
+import type { UsePillarQueryOptions, UsePillarQueryResult } from './hooks.js';
+
+declare const pillarQueryArgOutput: unique symbol;
+
+/**
+ * A typed descriptor for a single query inside {@link usePillarQueries}.
+ *
+ * The output type `TOutput` is carried via a phantom field
+ * (`[pillarQueryArgOutput]`) — it never exists at runtime, but lets the
+ * compiler propagate per-element output types through the `usePillarQueries`
+ * tuple result. Build one with {@link pillarQueryArg}.
+ */
+export type PillarQueryArg<TOutput> = {
+  pillarId: string;
+  path: ProcedurePath;
+  input: unknown;
+  options?: UsePillarQueryOptions<TOutput>;
+  readonly [pillarQueryArgOutput]?: TOutput;
+};
+
+/**
+ * Builder that produces a {@link PillarQueryArg} carrying its output type.
+ *
+ * Use inside `usePillarQueries` so each element of the input array
+ * contributes its own `TOutput` to the result tuple:
+ *
+ * ```ts
+ * const results = usePillarQueries([
+ *   pillarQueryArg<Ingredient>({ pillarId: 'food', path: ['ingredients', 'get'], input: { id: 'a' } }),
+ *   pillarQueryArg<Unit>({ pillarId: 'food', path: ['units', 'get'], input: { id: 'b' } }),
+ * ]);
+ * // results[0]: UsePillarQueryResult<Ingredient>
+ * // results[1]: UsePillarQueryResult<Unit>
+ * ```
+ */
+export function pillarQueryArg<TOutput>(arg: {
+  pillarId: string;
+  path: ProcedurePath;
+  input: unknown;
+  options?: UsePillarQueryOptions<TOutput>;
+}): PillarQueryArg<TOutput> {
+  return arg as PillarQueryArg<TOutput>;
+}
+
+type ResultsFor<T extends readonly PillarQueryArg<unknown>[]> = {
+  [K in keyof T]: T[K] extends PillarQueryArg<infer U> ? UsePillarQueryResult<U> : never;
+};
+
+/**
+ * Parallel-array React Query hook that issues one `pillar(pillarId).path(input)`
+ * call per descriptor and returns a tuple of {@link UsePillarQueryResult}s
+ * in matching order.
+ *
+ * Each descriptor is built with {@link pillarQueryArg} so its `TOutput`
+ * propagates to the corresponding result element. The number and order
+ * of results is stable across renders as long as the `queries` array
+ * length is stable — same constraint as React Query's `useQueries`.
+ *
+ * Each result carries the same `FailureFlags` (`isContractMismatch`,
+ * `isUnavailable`, `isDegraded`, `isNotFound`, `isConflict`,
+ * `isBadRequest`) as the single-query `usePillarQuery` hook.
+ *
+ * Cache keys are computed via `pillarQueryKey(pillarId, path, input)`
+ * per element, so results de-duplicate against other `usePillarQuery`
+ * call sites on the same key.
+ */
+export function usePillarQueries<T extends readonly PillarQueryArg<unknown>[]>(
+  queries: readonly [...T]
+): ResultsFor<T> {
+  const sdkOptions = usePillarSdkOptions();
+
+  const results = useQueries({
+    queries: queries.map((q) => ({
+      queryKey: pillarQueryKey(q.pillarId, q.path, q.input),
+      queryFn: async () => {
+        const result = await callProcedure<unknown>(q.pillarId, q.path, q.input, sdkOptions);
+        if (result.kind === 'ok') return result.value;
+        throw new PillarCallError(q.pillarId, result);
+      },
+      ...q.options,
+    })),
+  });
+
+  return results.map((query) => {
+    const flags =
+      query.error instanceof PillarCallError ? failureFlagsFrom(query.error.result) : NO_FAILURE;
+    return { ...query, ...flags };
+  }) as ResultsFor<T>;
+}


### PR DESCRIPTION
## Summary

Adds `usePillarQueries` — a parallel-array React Query hook for fanning out N pillar calls in a single render. Paired with a `pillarQueryArg<TOutput>` builder so each descriptor carries its own output type into the result tuple. Same ergonomics as `trpc.useQueries`, no proxy generics.

```ts
const results = usePillarQueries(
  ids.map((id) =>
    pillarQueryArg<Ingredient>({ pillarId: 'food', path: ['ingredients', 'get'], input: { id } })
  )
);
// results[i]: UsePillarQueryResult<Ingredient>
```

## Why

PR #3163 (`feat(app-food): migrate trivial tRPC sites to pillar SDK`) had to defer `pages/data/conversions-tab/useWeightRowViews.ts` because the SDK had no `trpc.useQueries` analogue. That row of the deferred-table now has an SDK landing spot — a follow-up migration PR can swap `useWeightRowViews` over without touching the SDK again.

## Shape

- `pillarQueryArg<TOutput>({ pillarId, path, input, options? }): PillarQueryArg<TOutput>` — typed builder. Output type is carried via a phantom field so per-element inference works without proxy generics.
- `usePillarQueries(queries): { [K in keyof T]: UsePillarQueryResult<U> }` — wraps `@tanstack/react-query` `useQueries`, computes cache keys via `pillarQueryKey`, maps `PillarCallError` failure flags onto every result element.
- Re-exports added to `src/react/hooks.ts` and `src/react/index.ts`.

## SDK only

No consumer migration in this PR. Follow-up PR will migrate `useWeightRowViews` and any other parallel-array call sites.

## Test plan

- [x] `pnpm --filter @pops/pillar-sdk test` — 37 files / 502 tests pass (+5 new)
- [x] `pnpm turbo typecheck --filter=@pops/pillar-sdk` — clean
- [x] `pnpm typecheck` (full repo, pre-push) — 71/71 tasks
- [x] `npx oxlint` on touched files — clean
- [x] Husky `pre-commit` + `pre-push` pass

## References

- PR #3163 — original deferred row ("`useWeightRowViews.ts` · `trpc.useQueries` parallel-array — no SDK equivalent")
- `usePillarQuery`, `usePillarInfiniteQuery` (PR #3157-ish) — sibling hooks; same `FailureFlags` + `pillarQueryKey` shape