### PR TITLE
feat(app-media): migrate batch 6 (8 sites · discover/quick-pick/search reads · PRD-227)

### DIFF
--- a/packages/app-media/src/pages/DiscoverPage.test.tsx
+++ b/packages/app-media/src/pages/DiscoverPage.test.tsx
@@ -9,24 +9,21 @@ const mockAssembleSessionRefetch = vi.fn();
 const mockProfileQuery = vi.fn();
 const mockGetDismissedQuery = vi.fn();
 
-vi.mock('@pops/api-client', () => ({
-  trpc: {
-    media: {
-      discovery: {
-        assembleSession: {
-          useQuery: (...args: unknown[]) => {
-            const result = mockAssembleSessionQuery(...args);
-            return { ...result, refetch: mockAssembleSessionRefetch };
-          },
-        },
-        profile: {
-          useQuery: (...args: unknown[]) => mockProfileQuery(...args),
-        },
-        getDismissed: {
-          useQuery: (...args: unknown[]) => mockGetDismissedQuery(...args),
-        },
-      },
-    },
+vi.mock('@pops/pillar-sdk/react', () => ({
+  usePillarQuery: (
+    _pillarId: string,
+    path: readonly string[],
+    input: unknown,
+    options: unknown
+  ) => {
+    const key = path.join('.');
+    if (key === 'discovery.assembleSession') {
+      const result = mockAssembleSessionQuery(input, options);
+      return { ...result, refetch: mockAssembleSessionRefetch };
+    }
+    if (key === 'discovery.profile') return mockProfileQuery(input, options);
+    if (key === 'discovery.getDismissed') return mockGetDismissedQuery(input, options);
+    return { data: undefined, isLoading: false, error: null };
   },
 }));
 

--- a/packages/app-media/src/pages/DiscoverPage.tsx
+++ b/packages/app-media/src/pages/DiscoverPage.tsx
@@ -1,7 +1,7 @@
 import { Compass, Loader2 } from 'lucide-react';
 import { useMemo } from 'react';
 
-import { trpc } from '@pops/api-client';
+import { usePillarQuery } from '@pops/pillar-sdk/react';
 /**
  * DiscoverPage — dynamic shelf-based movie discovery.
  */
@@ -16,16 +16,40 @@ import {
   DiscoverSkeleton,
 } from './discover/DiscoverPageParts';
 
+import type { ComponentProps } from 'react';
+
+type DiscoverShelf = ComponentProps<typeof DiscoverShelves>['shelves'][number];
+
+interface AssembleSessionResult {
+  shelves: DiscoverShelf[];
+}
+
+type PreferenceProfileData = NonNullable<ComponentProps<typeof PreferenceProfile>['data']>;
+
+interface ProfileEnvelope {
+  data: PreferenceProfileData | undefined;
+}
+
+interface DismissedEnvelope {
+  data: number[];
+}
+
 function useDiscoverPageModel() {
-  const session = trpc.media.discovery.assembleSession.useQuery(undefined, {
-    staleTime: 0,
-  });
-  const profile = trpc.media.discovery.profile.useQuery(undefined, {
+  const session = usePillarQuery<AssembleSessionResult>(
+    'media',
+    ['discovery', 'assembleSession'],
+    undefined,
+    { staleTime: 0 }
+  );
+  const profile = usePillarQuery<ProfileEnvelope>('media', ['discovery', 'profile'], undefined, {
     staleTime: 5 * 60 * 1000,
   });
-  const dismissed = trpc.media.discovery.getDismissed.useQuery(undefined, {
-    staleTime: 5 * 60 * 1000,
-  });
+  const dismissed = usePillarQuery<DismissedEnvelope>(
+    'media',
+    ['discovery', 'getDismissed'],
+    undefined,
+    { staleTime: 5 * 60 * 1000 }
+  );
   const actions = useDiscoverCardActions();
 
   const totalComparisons = profile.data?.data?.totalComparisons ?? 0;

--- a/packages/app-media/src/pages/QuickPickPage.test.tsx
+++ b/packages/app-media/src/pages/QuickPickPage.test.tsx
@@ -5,19 +5,19 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mockQuickPickQuery = vi.fn();
 const mockRefetch = vi.fn();
 
-vi.mock('@pops/api-client', () => ({
-  trpc: {
-    media: {
-      library: {
-        quickPick: {
-          useQuery: (...args: unknown[]) => {
-            const result = mockQuickPickQuery(...args);
-            return { ...result, refetch: mockRefetch };
-          },
-        },
-      },
-    },
-    useUtils: () => ({}),
+vi.mock('@pops/pillar-sdk/react', () => ({
+  usePillarQuery: (
+    _pillarId: string,
+    path: readonly string[],
+    input: unknown,
+    options: unknown
+  ) => {
+    const key = path.join('.');
+    if (key === 'library.quickPick') {
+      const result = mockQuickPickQuery(input, options);
+      return { ...result, refetch: mockRefetch };
+    }
+    return { data: undefined, isLoading: false };
   },
 }));
 

--- a/packages/app-media/src/pages/QuickPickPage.tsx
+++ b/packages/app-media/src/pages/QuickPickPage.tsx
@@ -1,7 +1,7 @@
 import { RefreshCw, Search, Sparkles } from 'lucide-react';
 import { useNavigate, useSearchParams } from 'react-router';
 
-import { trpc } from '@pops/api-client';
+import { usePillarQuery } from '@pops/pillar-sdk/react';
 import { Button, Skeleton } from '@pops/ui';
 
 import { MediaCard } from '../components/MediaCard';
@@ -15,12 +15,25 @@ function parseCount(raw: string | null): number {
   return DEFAULT_COUNT;
 }
 
+interface QuickPickMovie {
+  id: number;
+  title: string;
+  releaseDate: string | null;
+  posterUrl: string | null;
+}
+
+interface QuickPickEnvelope {
+  data: QuickPickMovie[];
+}
+
 export function QuickPickPage() {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const count = parseCount(searchParams.get('count'));
 
-  const { data, isLoading, refetch } = trpc.media.library.quickPick.useQuery(
+  const { data, isLoading, refetch } = usePillarQuery<QuickPickEnvelope>(
+    'media',
+    ['library', 'quickPick'],
     { count },
     { refetchOnWindowFocus: false }
   );
@@ -116,13 +129,6 @@ function QuickPickHeader({
       </div>
     </div>
   );
-}
-
-interface QuickPickMovie {
-  id: number;
-  title: string;
-  releaseDate: string | null;
-  posterUrl: string | null;
 }
 
 function QuickPickGrid({

--- a/packages/app-media/src/pages/SearchPage.test.tsx
+++ b/packages/app-media/src/pages/SearchPage.test.tsx
@@ -32,16 +32,6 @@ const {
 vi.mock('@pops/api-client', () => ({
   trpc: {
     media: {
-      search: {
-        movies: { useQuery: (...args: unknown[]) => mockMovieSearch(...args) },
-        tvShows: { useQuery: (...args: unknown[]) => mockTvSearch(...args) },
-      },
-      movies: {
-        list: { useQuery: (...args: unknown[]) => mockLibraryMovies(...args) },
-      },
-      tvShows: {
-        list: { useQuery: (...args: unknown[]) => mockLibraryTv(...args) },
-      },
       library: {
         addMovie: { useMutation: () => ({ mutate: mockAddMovieMutation, isPending: false }) },
         addTvShow: { useMutation: () => ({ mutate: mockAddTvMutation, isPending: false }) },
@@ -53,6 +43,22 @@ vi.mock('@pops/api-client', () => ({
         log: { useMutation: () => ({ mutate: mockWatchHistoryLogMutation, isPending: false }) },
       },
     },
+  },
+}));
+
+vi.mock('@pops/pillar-sdk/react', () => ({
+  usePillarQuery: (
+    _pillarId: string,
+    path: readonly string[],
+    input: unknown,
+    options: unknown
+  ) => {
+    const key = path.join('.');
+    if (key === 'search.movies') return mockMovieSearch(input, options);
+    if (key === 'search.tvShows') return mockTvSearch(input, options);
+    if (key === 'movies.list') return mockLibraryMovies(input, options);
+    if (key === 'tvShows.list') return mockLibraryTv(input, options);
+    return { data: undefined, isLoading: false, error: null };
   },
 }));
 

--- a/packages/app-media/src/pages/SearchPage.tsx
+++ b/packages/app-media/src/pages/SearchPage.tsx
@@ -15,7 +15,7 @@
 import { Search } from 'lucide-react';
 import { useState } from 'react';
 
-import { trpc } from '@pops/api-client';
+import { usePillarQuery } from '@pops/pillar-sdk/react';
 
 import { MovieSearchSection } from './search/MovieSearchSection';
 import { SearchInput } from './search/SearchInput';
@@ -28,6 +28,14 @@ import type { MovieSearchResult, SearchMode, TvSearchResult } from './search/typ
 
 const MAX_RESULTS_PER_SECTION = 20;
 const STALE_TIME_MS = 60_000;
+
+interface MovieSearchResponse {
+  results: MovieSearchResult[];
+}
+
+interface TvSearchResponse {
+  results: TvSearchResult[];
+}
 
 function SearchEmptyPrompt() {
   return (
@@ -50,11 +58,15 @@ function useSearchQueries(debouncedQuery: string, mode: SearchMode) {
   const shouldSearchMovies = debouncedQuery.length > 0 && (mode === 'movies' || mode === 'both');
   const shouldSearchTv = debouncedQuery.length > 0 && (mode === 'tv' || mode === 'both');
 
-  const movieSearch = trpc.media.search.movies.useQuery(
+  const movieSearch = usePillarQuery<MovieSearchResponse>(
+    'media',
+    ['search', 'movies'],
     { query: debouncedQuery },
     { enabled: shouldSearchMovies, staleTime: STALE_TIME_MS }
   );
-  const tvSearch = trpc.media.search.tvShows.useQuery(
+  const tvSearch = usePillarQuery<TvSearchResponse>(
+    'media',
+    ['search', 'tvShows'],
     { query: debouncedQuery },
     { enabled: shouldSearchTv, staleTime: STALE_TIME_MS }
   );

--- a/packages/app-media/src/pages/search/useLibraryLookups.ts
+++ b/packages/app-media/src/pages/search/useLibraryLookups.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 
-import { trpc } from '@pops/api-client';
+import { usePillarQuery } from '@pops/pillar-sdk/react';
 
 import type { RotationInfo } from './types';
 
@@ -21,16 +21,28 @@ interface LibraryTvShow {
   tvdbId: number;
 }
 
+interface LibraryMoviesEnvelope {
+  data: LibraryMovie[];
+}
+
+interface LibraryTvShowsEnvelope {
+  data: LibraryTvShow[];
+}
+
 /**
  * Fetches existing-library movies and TV shows so the search results can
  * mark items as "in library" and link to their detail pages.
  */
 export function useLibraryLookups({ shouldSearchMovies, shouldSearchTv }: UseLibraryLookupsArgs) {
-  const libraryMovies = trpc.media.movies.list.useQuery(
+  const libraryMovies = usePillarQuery<LibraryMoviesEnvelope>(
+    'media',
+    ['movies', 'list'],
     { limit: 1000 },
     { enabled: shouldSearchMovies, staleTime: 30_000 }
   );
-  const libraryTvShows = trpc.media.tvShows.list.useQuery(
+  const libraryTvShows = usePillarQuery<LibraryTvShowsEnvelope>(
+    'media',
+    ['tvShows', 'list'],
     { limit: 1000 },
     { enabled: shouldSearchTv, staleTime: 30_000 }
   );


### PR DESCRIPTION
## Summary

Swaps `trpc.media.*` for `usePillarQuery` across three read-only browse pages and the search-page library lookups hook.

### Slice — discover / quick-pick / search reads (4 src files · 8 sites)

- `pages/DiscoverPage.tsx` — `discovery.assembleSession`, `discovery.profile`, `discovery.getDismissed`
- `pages/QuickPickPage.tsx` — `library.quickPick`
- `pages/SearchPage.tsx` — `search.movies`, `search.tvShows`
- `pages/search/useLibraryLookups.ts` — `movies.list`, `tvShows.list`

Test mocks updated to dispatch `usePillarQuery` by `path.join('.')`. `SearchPage.test.tsx` keeps its `@pops/api-client` mock for the mutation surface owned by `useSearchAddActions` (`addMovie`, `addTvShow`, `watchlist.add`, `watchHistory.log`) — those mutations are out of scope for this batch.

### Cumulative app-media progress (PRD-227)

| Batch | PR | Sites |
| --- | --- | --- |
| 1 | #3128 | first batch |
| 2 | #3141 | second batch |
| risky-3 | #3145 | 3 optimistic-update sites |
| 3 | #3156 | 26 sites |
| 4 | #3164 | 7 sites (candidate-queue) |
| compare-arena | #3169 | compare-arena cluster |
| 5 | #3174 | 13 sites (season-detail) |
| **6** | this PR | **8 sites (discover/quick-pick/search reads)** |

Post-merge: ~135/151 trivial sites migrated.

## Test plan

- [x] `pnpm --filter @pops/app-media test` — 698/698 passing
- [x] `pnpm typecheck` — 71/71 packages clean
- [x] `npx oxlint packages/app-media/src` — 0 errors