### PR TITLE
feat(ha-bridge): PRD-229 US-03 (partial) — ha.entity.list AI tool

### DIFF
--- a/apps/pops-ha-bridge-api/package.json
+++ b/apps/pops-ha-bridge-api/package.json
@@ -15,7 +15,8 @@
     "@pops/ha-bridge-db": "workspace:*",
     "@pops/pillar-sdk": "workspace:*",
     "express": "^5.1.0",
-    "ws": "^8.18.0"
+    "ws": "^8.18.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/express": "^5.0.4",

--- a/apps/pops-ha-bridge-api/src/__tests__/entity-list.test.ts
+++ b/apps/pops-ha-bridge-api/src/__tests__/entity-list.test.ts
@@ -1,0 +1,166 @@
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { openHaBridgeDb, upsertEntity, type OpenedHaBridgeDb } from '@pops/ha-bridge-db';
+
+import {
+  decodeEntityCursor,
+  encodeEntityCursor,
+  ENTITY_LIST_DEFAULT_LIMIT,
+  ENTITY_LIST_MAX_LIMIT,
+  entityListInputSchema,
+  runEntityList,
+} from '../ai-tools/entity-list.js';
+
+interface SeedSpec {
+  entityId: string;
+  state?: string;
+  area?: string | null;
+  friendlyName?: string;
+  deviceClass?: string;
+}
+
+function seed(opened: OpenedHaBridgeDb, specs: SeedSpec[]): void {
+  for (const spec of specs) {
+    const attributes: Record<string, unknown> = {};
+    if (spec.friendlyName !== undefined) attributes['friendly_name'] = spec.friendlyName;
+    if (spec.deviceClass !== undefined) attributes['device_class'] = spec.deviceClass;
+    upsertEntity(opened.db, {
+      entityId: spec.entityId,
+      state: spec.state ?? 'on',
+      attributes,
+      area: spec.area ?? null,
+      lastChanged: 1,
+      lastSeen: 1,
+    });
+  }
+}
+
+describe('ha bridge entity-list AI tool', () => {
+  let opened: OpenedHaBridgeDb;
+
+  beforeEach(() => {
+    const dir = mkdtempSync(join(tmpdir(), 'ha-bridge-entity-list-'));
+    opened = openHaBridgeDb(join(dir, 'ha-bridge.db'));
+  });
+
+  afterEach(() => {
+    opened.raw.close();
+  });
+
+  it('returns every entity when no filter is supplied, sorted by entity_id', () => {
+    seed(opened, [
+      { entityId: 'light.kitchen' },
+      { entityId: 'light.living_room' },
+      { entityId: 'sensor.bedroom_temperature' },
+    ]);
+
+    const result = runEntityList(opened.db, {});
+    expect(result.entities.map((e) => e.entityId)).toEqual([
+      'light.kitchen',
+      'light.living_room',
+      'sensor.bedroom_temperature',
+    ]);
+    expect(result.nextCursor).toBeNull();
+  });
+
+  it('filters by domain', () => {
+    seed(opened, [
+      { entityId: 'light.kitchen', area: 'kitchen' },
+      { entityId: 'light.bedroom', area: 'bedroom' },
+      { entityId: 'sensor.kitchen_temperature', area: 'kitchen' },
+    ]);
+
+    const result = runEntityList(opened.db, { domain: 'light' });
+    expect(result.entities.map((e) => e.entityId)).toEqual(['light.bedroom', 'light.kitchen']);
+    expect(result.entities.every((e) => e.domain === 'light')).toBe(true);
+  });
+
+  it('filters by area', () => {
+    seed(opened, [
+      { entityId: 'light.kitchen', area: 'kitchen' },
+      { entityId: 'sensor.kitchen_humidity', area: 'kitchen' },
+      { entityId: 'light.bedroom', area: 'bedroom' },
+    ]);
+
+    const result = runEntityList(opened.db, { area: 'kitchen' });
+    expect(result.entities.map((e) => e.entityId)).toEqual([
+      'light.kitchen',
+      'sensor.kitchen_humidity',
+    ]);
+  });
+
+  it('combines domain + area filters with AND semantics', () => {
+    seed(opened, [
+      { entityId: 'light.kitchen', area: 'kitchen' },
+      { entityId: 'light.bedroom', area: 'bedroom' },
+      { entityId: 'sensor.kitchen_humidity', area: 'kitchen' },
+    ]);
+
+    const result = runEntityList(opened.db, { domain: 'light', area: 'kitchen' });
+    expect(result.entities.map((e) => e.entityId)).toEqual(['light.kitchen']);
+  });
+
+  it('paginates with a stable cursor that survives upserts between pages', () => {
+    const ids = ['a', 'b', 'c', 'd', 'e', 'f'].map((suffix) => `light.${suffix}`);
+    seed(
+      opened,
+      ids.map((entityId) => ({ entityId }))
+    );
+
+    const page1 = runEntityList(opened.db, { limit: 2 });
+    expect(page1.entities.map((e) => e.entityId)).toEqual(['light.a', 'light.b']);
+    expect(page1.nextCursor).not.toBeNull();
+
+    upsertEntity(opened.db, {
+      entityId: 'light.a',
+      state: 'off',
+      attributes: {},
+      area: null,
+      lastChanged: 2,
+      lastSeen: 2,
+    });
+
+    const cursor = page1.nextCursor;
+    expect(cursor).not.toBeNull();
+    const page2 = runEntityList(opened.db, { limit: 2, cursor: cursor ?? undefined });
+    expect(page2.entities.map((e) => e.entityId)).toEqual(['light.c', 'light.d']);
+
+    const page3 = runEntityList(opened.db, { limit: 2, cursor: page2.nextCursor ?? undefined });
+    expect(page3.entities.map((e) => e.entityId)).toEqual(['light.e', 'light.f']);
+    expect(page3.nextCursor).toBeNull();
+  });
+
+  it('clamps limit to the default and respects the max', () => {
+    seed(
+      opened,
+      Array.from({ length: ENTITY_LIST_DEFAULT_LIMIT + 5 }, (_, i) => ({
+        entityId: `light.l_${i.toString().padStart(3, '0')}`,
+      }))
+    );
+
+    const defaulted = runEntityList(opened.db, {});
+    expect(defaulted.entities).toHaveLength(ENTITY_LIST_DEFAULT_LIMIT);
+    expect(defaulted.nextCursor).not.toBeNull();
+
+    const parseLargeLimit = entityListInputSchema.safeParse({ limit: ENTITY_LIST_MAX_LIMIT + 1 });
+    expect(parseLargeLimit.success).toBe(false);
+  });
+
+  it('rejects malformed input at the Zod boundary', () => {
+    expect(entityListInputSchema.safeParse({ domain: 'Light' }).success).toBe(false);
+    expect(entityListInputSchema.safeParse({ limit: 0 }).success).toBe(false);
+    expect(entityListInputSchema.safeParse({ unknown: 1 }).success).toBe(false);
+    expect(entityListInputSchema.safeParse({ domain: 'light' }).success).toBe(true);
+  });
+
+  it('round-trips the entity-id cursor encoding', () => {
+    const cursor = encodeEntityCursor('sensor.kitchen.temperature');
+    expect(cursor).not.toContain('.');
+    expect(decodeEntityCursor(cursor)).toBe('sensor.kitchen.temperature');
+    expect(decodeEntityCursor('')).toBeNull();
+  });
+});

--- a/apps/pops-ha-bridge-api/src/__tests__/manifest.test.ts
+++ b/apps/pops-ha-bridge-api/src/__tests__/manifest.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { ManifestPayloadSchema, validateManifestPayload } from '@pops/pillar-sdk/manifest-schema';
 
+import { ENTITY_LIST_TOOL_NAME } from '../ai-tools/index.js';
 import { buildHaBridgeManifest, HA_BRIDGE_PILLAR_ID } from '../manifest.js';
 import {
   HA_ENTITIES_ADAPTER_NAME,
@@ -15,8 +16,19 @@ describe('buildHaBridgeManifest', () => {
     const parsed = ManifestPayloadSchema.parse(manifest);
     expect(parsed.pillar).toBe(HA_BRIDGE_PILLAR_ID);
     expect(parsed.contract.tag).toBe('contract-ha-bridge@v0.1.0');
-    expect(parsed.ai.tools).toEqual([]);
+    expect(parsed.ai.tools.map((t) => t.name)).toEqual([ENTITY_LIST_TOOL_NAME]);
     expect(parsed.sinks?.descriptors.length).toBeGreaterThan(0);
+  });
+
+  it('publishes the entityList AI tool descriptor (US-03 partial)', () => {
+    const manifest = buildHaBridgeManifest('0.1.0');
+    const tool = manifest.ai.tools.find((t) => t.name === ENTITY_LIST_TOOL_NAME);
+    if (tool === undefined) throw new Error('entityList descriptor missing');
+    expect(tool.description.length).toBeGreaterThanOrEqual(10);
+    expect(tool.parameters).toMatchObject({ type: 'object' });
+    const parameters = tool.parameters as { properties?: Record<string, unknown> };
+    const props = parameters.properties ?? {};
+    expect(Object.keys(props).toSorted()).toEqual(['area', 'cursor', 'domain', 'limit']);
   });
 
   it('declares the haEntities search adapter (US-02)', () => {

--- a/apps/pops-ha-bridge-api/src/ai-tools/entity-list.ts
+++ b/apps/pops-ha-bridge-api/src/ai-tools/entity-list.ts
@@ -1,0 +1,74 @@
+/**
+ * `ha.entity.list` — read-only AI tool (PRD-229 US-03).
+ *
+ * Lists HA entities the bridge currently mirrors, optionally filtered by
+ * `domain` and/or `area`. Pagination uses a stable, opaque cursor over the
+ * primary key (`entity_id`) so concurrent upserts cannot shift the page
+ * boundary across the result set.
+ *
+ * The cursor is the last `entityId` of the previous page, base64-url
+ * encoded so the LLM treats it as an opaque token. We slice using
+ * `entityId > cursor` after the sort by `entityId ASC`, which is the only
+ * ordering that survives the source-of-truth being upstream (the bridge
+ * never picks a stable `created_at`).
+ */
+import { z } from 'zod';
+
+import { listEntities, type HaBridgeDb, type HaEntityRow } from '@pops/ha-bridge-db';
+
+export const ENTITY_LIST_TOOL_NAME = 'entityList' as const;
+
+export const ENTITY_LIST_DEFAULT_LIMIT = 50;
+export const ENTITY_LIST_MAX_LIMIT = 200;
+
+export const entityListInputSchema = z
+  .object({
+    domain: z
+      .string()
+      .min(1)
+      .max(64)
+      .regex(/^[a-z][a-z0-9_]*$/, 'domain must be lowercase snake_case')
+      .optional(),
+    area: z.string().min(1).max(128).optional(),
+    limit: z.number().int().min(1).max(ENTITY_LIST_MAX_LIMIT).optional(),
+    cursor: z.string().min(1).max(512).optional(),
+  })
+  .strict();
+
+export type EntityListInput = z.infer<typeof entityListInputSchema>;
+
+export interface EntityListOutput {
+  entities: HaEntityRow[];
+  nextCursor: string | null;
+}
+
+export function encodeEntityCursor(entityId: string): string {
+  return Buffer.from(entityId, 'utf8').toString('base64url');
+}
+
+export function decodeEntityCursor(cursor: string): string | null {
+  try {
+    const decoded = Buffer.from(cursor, 'base64url').toString('utf8');
+    return decoded.length > 0 ? decoded : null;
+  } catch {
+    return null;
+  }
+}
+
+export function runEntityList(db: HaBridgeDb, input: EntityListInput): EntityListOutput {
+  const limit = input.limit ?? ENTITY_LIST_DEFAULT_LIMIT;
+  const after =
+    input.cursor !== undefined ? (decodeEntityCursor(input.cursor) ?? undefined) : undefined;
+
+  const { entities, hasMore } = listEntities(db, {
+    domain: input.domain,
+    area: input.area,
+    limit,
+    after,
+  });
+
+  const last = entities[entities.length - 1];
+  const nextCursor = hasMore && last !== undefined ? encodeEntityCursor(last.entityId) : null;
+
+  return { entities, nextCursor };
+}

--- a/apps/pops-ha-bridge-api/src/ai-tools/index.ts
+++ b/apps/pops-ha-bridge-api/src/ai-tools/index.ts
@@ -1,0 +1,59 @@
+/**
+ * HA bridge AI tool registry (PRD-229 US-03).
+ *
+ * Each descriptor projects an internal Zod input schema to the
+ * JSON-Schema-shaped `parameters` field expected by the pillar manifest's
+ * `ai.tools` slot. The same descriptor list is the source of truth for
+ * the future tool-router binding — adding a tool is one entry, no core
+ * edit.
+ *
+ * US-03 ships `entityList` only. `entityGetState` lands in a follow-up.
+ */
+import { z } from 'zod';
+
+import { ENTITY_LIST_TOOL_NAME, entityListInputSchema } from './entity-list.js';
+
+import type { ManifestPayload } from '@pops/pillar-sdk/manifest-schema';
+
+type AiToolDescriptor = ManifestPayload['ai']['tools'][number];
+
+interface AiToolSource {
+  name: string;
+  description: string;
+  inputSchema: z.ZodType;
+}
+
+const sources: AiToolSource[] = [
+  {
+    name: ENTITY_LIST_TOOL_NAME,
+    description:
+      'List Home Assistant entities the bridge currently mirrors. Optionally filter by `domain` (e.g. "light", "sensor") and/or `area` (e.g. "kitchen"). Results are paginated by `entity_id` — pass `nextCursor` back as `cursor` to fetch the next page. Read-only.',
+    inputSchema: entityListInputSchema,
+  },
+];
+
+function toParameters(schema: z.ZodType): Record<string, unknown> {
+  const projected = z.toJSONSchema(schema, { target: 'draft-7', unrepresentable: 'any' });
+  if (typeof projected !== 'object' || projected === null) {
+    throw new Error('z.toJSONSchema returned a non-object schema');
+  }
+  return projected as Record<string, unknown>;
+}
+
+export const haBridgeAiTools: AiToolDescriptor[] = sources.map((source) => ({
+  name: source.name,
+  description: source.description,
+  parameters: toParameters(source.inputSchema),
+}));
+
+export { ENTITY_LIST_TOOL_NAME } from './entity-list.js';
+export {
+  decodeEntityCursor,
+  encodeEntityCursor,
+  ENTITY_LIST_DEFAULT_LIMIT,
+  ENTITY_LIST_MAX_LIMIT,
+  entityListInputSchema,
+  runEntityList,
+  type EntityListInput,
+  type EntityListOutput,
+} from './entity-list.js';

--- a/apps/pops-ha-bridge-api/src/manifest.ts
+++ b/apps/pops-ha-bridge-api/src/manifest.ts
@@ -1,3 +1,4 @@
+import { haBridgeAiTools } from './ai-tools/index.js';
 import {
   HA_ENTITIES_ADAPTER_NAME,
   HA_ENTITIES_ENTITY_TYPE,
@@ -15,9 +16,9 @@ import { validateSinkMappings } from './sinks/validator.js';
  * over the FTS5 virtual table (`ha_entities_fts`). The remaining
  * dimensions land in subsequent stories:
  *
- *   - US-03 fills `ai.tools` with the read-only `ha.entity.list` and
- *     `ha.entity.getState` entries.
- *   - US-04 adds `ha.entity.callService` to `ai.tools`.
+ *   - US-03 (this slice — partial) fills `ai.tools` with the
+ *     read-only `entityList` descriptor. `entityGetState` lands in a
+ *     follow-up; `ha.entity.callService` (US-04) stays out of scope.
  *
  * PRD-237 US-01 derives the `sinks.descriptors` block from the mapping
  * config (`src/sinks/mapping.ts`) — the same array drives the runtime
@@ -59,7 +60,7 @@ export function buildHaBridgeManifest(version: string): ManifestPayload {
         },
       ],
     },
-    ai: { tools: [] },
+    ai: { tools: haBridgeAiTools },
     sinks: {
       descriptors: mappings.map((mapping) => ({
         eventType: mapping.eventType,

--- a/packages/ha-bridge-db/src/index.ts
+++ b/packages/ha-bridge-db/src/index.ts
@@ -35,3 +35,9 @@ export {
   type HaEntitySearchHit,
   type HaEntitySearchOptions,
 } from './services/search.js';
+
+export {
+  listEntities,
+  type ListEntitiesOptions,
+  type ListEntitiesResult,
+} from './services/list.js';

--- a/packages/ha-bridge-db/src/services/list.ts
+++ b/packages/ha-bridge-db/src/services/list.ts
@@ -1,0 +1,46 @@
+/**
+ * Filtered, paginated read over `ha_entities` (PRD-229 US-03).
+ *
+ * Pagination uses an opaque `after` token over the primary key
+ * (`entity_id`) so concurrent upserts cannot shift the page boundary —
+ * the bridge's source of truth is upstream and there is no stable
+ * `created_at` ordering to lean on.
+ */
+import { and, asc, eq, gt, type SQL } from 'drizzle-orm';
+
+import { haEntities, type HaEntityRow } from '../schema.js';
+
+import type { HaBridgeDb } from './internal.js';
+
+export interface ListEntitiesOptions {
+  domain?: string;
+  area?: string;
+  limit: number;
+  after?: string;
+}
+
+export interface ListEntitiesResult {
+  entities: HaEntityRow[];
+  hasMore: boolean;
+}
+
+export function listEntities(db: HaBridgeDb, options: ListEntitiesOptions): ListEntitiesResult {
+  const conditions: SQL[] = [];
+  if (options.domain !== undefined) conditions.push(eq(haEntities.domain, options.domain));
+  if (options.area !== undefined) conditions.push(eq(haEntities.area, options.area));
+  if (options.after !== undefined) conditions.push(gt(haEntities.entityId, options.after));
+
+  const where = conditions.length > 0 ? and(...conditions) : undefined;
+
+  const rows = db
+    .select()
+    .from(haEntities)
+    .where(where)
+    .orderBy(asc(haEntities.entityId))
+    .limit(options.limit + 1)
+    .all();
+
+  const hasMore = rows.length > options.limit;
+  const entities = hasMore ? rows.slice(0, options.limit) : rows;
+  return { entities, hasMore };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -498,6 +498,9 @@ importers:
       ws:
         specifier: ^8.18.0
         version: 8.21.0
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@types/express':
         specifier: ^5.0.4


### PR DESCRIPTION
## Summary
- First descriptor in the HA bridge pillar manifest's `ai.tools` slot: read-only `entityList` (`ha.entity.list`) with Zod-defined input projected to draft-7 JSON Schema via `z.toJSONSchema`.
- Pagination uses an opaque base64url cursor over the `entity_id` primary key — concurrent upserts between pages cannot shift the page boundary across the result set.
- Filter query lives in `@pops/ha-bridge-db` (`listEntities`) so the API app does not import drizzle-orm directly; the ai-tool layer is a thin Zod + cursor wrapper.

## Manifest excerpt
```ts
ai: {
  tools: [
    {
      name: 'entityList',
      description: 'List Home Assistant entities the bridge currently mirrors...',
      parameters: { /* draft-7 JSON Schema with domain, area, limit, cursor */ },
    },
  ],
},
```

## PRD-229 US-03 status
- [x] `ha.entity.list` — shipped here (filter by `domain`, `area`; paginated)
- [ ] `ha.entity.getState` — separate follow-up
- US-04 / US-05 — out of scope

## Test plan
- [x] `pnpm --filter @pops/ha-bridge-api test` — 43/43 pass (7 new for `entity-list`, 1 new for manifest)
- [x] `pnpm --filter @pops/ha-bridge-db test` — 18/18 pass
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` no errors on changed files