### PR TITLE
feat(ha-bridge): PRD-237 US-02 WS fire_event + sink endpoint + reconnect queue + e2e

### DIFF
--- a/apps/pops-ha-bridge-api/package.json
+++ b/apps/pops-ha-bridge-api/package.json
@@ -15,7 +15,8 @@
     "@pops/ha-bridge-db": "workspace:*",
     "@pops/pillar-sdk": "workspace:*",
     "express": "^5.1.0",
-    "ws": "^8.18.0"
+    "ws": "^8.18.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/express": "^5.0.4",

--- a/apps/pops-ha-bridge-api/src/app.ts
+++ b/apps/pops-ha-bridge-api/src/app.ts
@@ -9,6 +9,8 @@
  */
 import express, { type Express, type Request, type Response } from 'express';
 
+import { createSinkRouter } from './sinks/router.js';
+
 import type { ManifestPayload } from '@pops/pillar-sdk/manifest-schema';
 
 import type { ConnectionState, HaWebSocketSubscriber } from './ws-subscriber.js';
@@ -16,7 +18,8 @@ import type { ConnectionState, HaWebSocketSubscriber } from './ws-subscriber.js'
 export interface HaBridgeAppDeps {
   manifest: ManifestPayload;
   version: string;
-  subscriber: Pick<HaWebSocketSubscriber, 'state'>;
+  subscriber: Pick<HaWebSocketSubscriber, 'state' | 'sinks'>;
+  logger?: { warn(msg: string, meta?: Record<string, unknown>): void };
 }
 
 export interface HealthResponse {
@@ -49,6 +52,14 @@ export function createHaBridgeApiApp(deps: HaBridgeAppDeps): Express {
   app.get('/manifest.json', (_req: Request, res: Response) => {
     res.json(deps.manifest);
   });
+
+  app.use(
+    createSinkRouter({
+      fireEvent: (eventType, haEventName, eventData) =>
+        deps.subscriber.sinks.send(eventType, haEventName, eventData),
+      logger: deps.logger,
+    })
+  );
 
   return app;
 }

--- a/apps/pops-ha-bridge-api/src/sinks/__tests__/e2e.test.ts
+++ b/apps/pops-ha-bridge-api/src/sinks/__tests__/e2e.test.ts
@@ -1,0 +1,307 @@
+/**
+ * PRD-237 US-02 end-to-end test.
+ *
+ * Proves the full pops → HA path:
+ *
+ *   orchestrator.publishEvent('media.watch.completed', payload)
+ *     → discovery snapshot routes to the ha-bridge pillar
+ *     → poster does POST /_sinks/media.watch.completed on the bridge
+ *     → bridge router validates + transforms + calls subscriber.sendFireEvent
+ *     → ws-subscriber writes the HA `fire_event` frame on the stub socket
+ *     → stub socket captures the JSON frame
+ *     → assertion: event_type === 'pops_media_watch_completed' AND
+ *       event_data deep-equals the transformed payload.
+ *
+ * Also covers the reconnect-queue path (socket forced into reconnecting,
+ * publish → 200 queued, reconnect → drain → frame received) and the
+ * boundary rejection path (invalid payload → 400 + pillar-offline
+ * recorded by the orchestrator).
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { z } from 'zod';
+
+import { openHaBridgeDb, type OpenedHaBridgeDb } from '@pops/ha-bridge-db';
+import { publishEvent, type SinkPoster } from '@pops/pillar-sdk/orchestrator';
+
+import { createHaBridgeApiApp } from '../../app.js';
+import { buildHaBridgeManifest } from '../../manifest.js';
+import {
+  HaWebSocketSubscriber,
+  type HaWebSocketFactory,
+  type HaWebSocketLike,
+} from '../../ws-subscriber.js';
+import { sinkPayloadSchemas } from '../schemas.js';
+
+import type { PillarSnapshot } from '@pops/pillar-sdk/discovery';
+
+interface FakeSocket extends HaWebSocketLike {
+  sent: string[];
+  emitOpen(): void;
+  emitMessage(payload: unknown): void;
+  emitClose(code?: number, reason?: string): void;
+  emitError(err: Error): void;
+}
+
+function createFakeSocket(): FakeSocket {
+  const listeners: Record<string, ((...args: unknown[]) => void)[]> = {
+    open: [],
+    message: [],
+    close: [],
+    error: [],
+  };
+  const sent: string[] = [];
+  return {
+    sent,
+    send(data: string) {
+      sent.push(data);
+    },
+    close() {
+      const ls = listeners['close'] ?? [];
+      for (const l of ls) l(1000, Buffer.from(''));
+    },
+    on(event, listener) {
+      const arr = listeners[event];
+      if (arr !== undefined) arr.push(listener as (...args: unknown[]) => void);
+    },
+    emitOpen() {
+      const ls = listeners['open'] ?? [];
+      for (const l of ls) l();
+    },
+    emitMessage(payload) {
+      const serialised = typeof payload === 'string' ? payload : JSON.stringify(payload);
+      const ls = listeners['message'] ?? [];
+      for (const l of ls) l(serialised);
+    },
+    emitClose(code = 1006, reason = 'closed') {
+      const ls = listeners['close'] ?? [];
+      for (const l of ls) l(code, Buffer.from(reason));
+    },
+    emitError(err) {
+      const ls = listeners['error'] ?? [];
+      for (const l of ls) l(err);
+    },
+  };
+}
+
+function handshake(fake: FakeSocket): void {
+  fake.emitOpen();
+  fake.emitMessage({ type: 'auth_required' });
+  fake.emitMessage({ type: 'auth_ok' });
+  fake.emitMessage({ id: 1, type: 'result', success: true, result: [] });
+}
+
+function findFireEventFrame(
+  fake: FakeSocket,
+  haEventName: string
+): { event_type: string; event_data: Record<string, unknown> } | undefined {
+  const FireEventFrameSchema = z.object({
+    type: z.literal('fire_event'),
+    event_type: z.string(),
+    event_data: z.record(z.string(), z.unknown()),
+  });
+  for (const raw of fake.sent) {
+    const parsed = FireEventFrameSchema.safeParse(JSON.parse(raw));
+    if (parsed.success && parsed.data.event_type === haEventName) {
+      return { event_type: parsed.data.event_type, event_data: parsed.data.event_data };
+    }
+  }
+  return undefined;
+}
+
+function bridgeSnapshot(manifest: ReturnType<typeof buildHaBridgeManifest>): PillarSnapshot {
+  return {
+    pillarId: 'ha-bridge',
+    baseUrl: 'http://ha-bridge.test',
+    manifest,
+    registered: true,
+    lastSeenAt: new Date('2026-06-14T00:00:00Z'),
+  };
+}
+
+interface Harness {
+  tmpDir: string;
+  haBridgeDb: OpenedHaBridgeDb;
+  subscriber: HaWebSocketSubscriber;
+  sockets: FakeSocket[];
+  app: ReturnType<typeof createHaBridgeApiApp>;
+  poster: SinkPoster;
+  fireReconnect(): void;
+  currentSocket(): FakeSocket;
+}
+
+function bootHarness(): Harness {
+  const tmpDir = mkdtempSync(join(tmpdir(), 'ha-bridge-sinks-e2e-'));
+  const haBridgeDb = openHaBridgeDb(join(tmpDir, 'ha.db'));
+  const sockets: FakeSocket[] = [];
+  const factory: HaWebSocketFactory = () => {
+    const s = createFakeSocket();
+    sockets.push(s);
+    return s;
+  };
+  const reconnectCallbacks: (() => void)[] = [];
+  const fakeSetTimeout = ((fn: () => void) => {
+    reconnectCallbacks.push(fn);
+    return 0;
+  }) as unknown as typeof setTimeout;
+  const fakeClearTimeout = (() => undefined) as unknown as typeof clearTimeout;
+  const subscriber = new HaWebSocketSubscriber({
+    db: haBridgeDb,
+    url: 'ws://stub.test/api/websocket',
+    token: 't',
+    webSocketFactory: factory,
+    setTimeoutImpl: fakeSetTimeout,
+    clearTimeoutImpl: fakeClearTimeout,
+    now: () => 0,
+  });
+  const manifest = buildHaBridgeManifest('0.1.0');
+  const app = createHaBridgeApiApp({ manifest, version: '0.1.0', subscriber });
+
+  const poster: SinkPoster = async ({ eventType, payload }) => {
+    const res = await request(app).post(`/_sinks/${eventType}`).send(payload);
+    if (res.status >= 400) {
+      throw new Error(
+        `bridge sink rejected ${eventType}: ${res.status} ${JSON.stringify(res.body)}`
+      );
+    }
+  };
+
+  return {
+    tmpDir,
+    haBridgeDb,
+    subscriber,
+    sockets,
+    app,
+    poster,
+    fireReconnect: () => {
+      const next = reconnectCallbacks.shift();
+      if (next === undefined) throw new Error('no pending reconnect timer');
+      next();
+    },
+    currentSocket: () => {
+      const s = sockets.at(-1);
+      if (s === undefined) throw new Error('no socket created yet');
+      return s;
+    },
+  };
+}
+
+describe('PRD-237 US-02 end-to-end: orchestrator → bridge → HA fire_event', () => {
+  let harness: Harness;
+
+  beforeEach(() => {
+    harness = bootHarness();
+    harness.subscriber.start();
+    handshake(harness.currentSocket());
+    harness.currentSocket().sent.length = 0;
+  });
+
+  afterEach(() => {
+    harness.subscriber.stop();
+    harness.haBridgeDb.raw.close();
+    rmSync(harness.tmpDir, { recursive: true, force: true });
+  });
+
+  it('routes one orchestrator publish into one HA fire_event frame (happy path)', async () => {
+    const payload = {
+      mediaId: 'media-123',
+      userId: 'user-1',
+      occurredAt: '2026-06-14T10:00:00Z',
+      durationSeconds: 90,
+    };
+
+    const result = await publishEvent({
+      eventType: 'media.watch.completed',
+      payload,
+      discovery: [bridgeSnapshot(buildHaBridgeManifest('0.1.0'))],
+      schemas: new Map([['media.watch.completed', sinkPayloadSchemas['media.watch.completed']]]),
+      poster: harness.poster,
+    });
+
+    expect(result.failures).toEqual([]);
+    expect(result.delivered).toEqual([
+      { pillarId: 'ha-bridge', eventType: 'media.watch.completed' },
+    ]);
+
+    const frame = findFireEventFrame(harness.currentSocket(), 'pops_media_watch_completed');
+    expect(frame).toBeDefined();
+    expect(frame?.event_type).toBe('pops_media_watch_completed');
+    expect(frame?.event_data).toEqual(payload);
+  });
+
+  it('queues frames while the socket is reconnecting and drains them on reconnect', async () => {
+    const firstSocket = harness.currentSocket();
+    firstSocket.emitClose(1006, 'lost');
+    expect(harness.subscriber.state().kind).toBe('reconnecting');
+
+    const payload = {
+      accountId: 'acct-7',
+      balance: 12.5,
+      threshold: 50,
+      currency: 'USD',
+      occurredAt: '2026-06-14T10:05:00Z',
+    };
+
+    const result = await publishEvent({
+      eventType: 'finance.balance.low',
+      payload,
+      discovery: [bridgeSnapshot(buildHaBridgeManifest('0.1.0'))],
+      schemas: new Map([['finance.balance.low', sinkPayloadSchemas['finance.balance.low']]]),
+      poster: harness.poster,
+    });
+
+    expect(result.failures).toEqual([]);
+    expect(result.delivered).toHaveLength(1);
+    expect(findFireEventFrame(firstSocket, 'pops_finance_balance_low')).toBeUndefined();
+    expect(harness.subscriber.sinks.size()).toBe(1);
+
+    harness.fireReconnect();
+    const secondSocket = harness.currentSocket();
+    expect(secondSocket).not.toBe(firstSocket);
+    handshake(secondSocket);
+
+    const frame = findFireEventFrame(secondSocket, 'pops_finance_balance_low');
+    expect(frame).toBeDefined();
+    expect(frame?.event_data).toEqual(payload);
+    expect(harness.subscriber.sinks.size()).toBe(0);
+  });
+
+  it('rejects a payload that fails the mapping schema with 400 (recorded as pillar-offline)', async () => {
+    let bridgeStatus = 0;
+    const permissiveRegistry = new Map([['inventory.item.consumed', z.unknown()]]);
+    const result = await publishEvent({
+      eventType: 'inventory.item.consumed',
+      payload: { itemId: 'i-1', quantity: 'not-a-number' },
+      discovery: [bridgeSnapshot(buildHaBridgeManifest('0.1.0'))],
+      schemas: permissiveRegistry,
+      poster: async ({ eventType, payload }) => {
+        const res = await request(harness.app).post(`/_sinks/${eventType}`).send(payload);
+        bridgeStatus = res.status;
+        if (res.status >= 400) {
+          throw new Error(`bridge rejected ${eventType} with ${res.status}`);
+        }
+      },
+    });
+
+    expect(bridgeStatus).toBe(400);
+    expect(result.delivered).toEqual([]);
+    expect(result.failures).toHaveLength(1);
+    const failure = result.failures[0];
+    expect(failure?.reason).toBe('pillar-offline');
+    expect(
+      findFireEventFrame(harness.currentSocket(), 'pops_inventory_item_consumed')
+    ).toBeUndefined();
+  });
+
+  it('returns 404 for unknown eventType paths', async () => {
+    const res = await request(harness.app)
+      .post('/_sinks/totally.unknown.event')
+      .send({ anything: true });
+    expect(res.status).toBe(404);
+    expect(res.body).toMatchObject({ error: 'unknown-event-type' });
+  });
+});

--- a/apps/pops-ha-bridge-api/src/sinks/fire-event-queue.ts
+++ b/apps/pops-ha-bridge-api/src/sinks/fire-event-queue.ts
@@ -1,0 +1,80 @@
+/**
+ * PRD-237 US-02: bounded FIFO queue for outbound `fire_event` frames.
+ *
+ * When the HA WebSocket is reconnecting we cannot deliver immediately,
+ * but per the PRD we still accept the sink invocation and respond 200
+ * to the orchestrator. The frame is enqueued here and flushed in FIFO
+ * order on the next successful auth + subscribe handshake.
+ *
+ * The queue is bounded (default 100, configurable via
+ * `HA_SINK_QUEUE_CAP`) — at-cap pushes drop the oldest entry,
+ * increment the `ha_sink_dropped_total{event_type}` counter, and emit
+ * a structured warning. Bounded so a sustained HA outage cannot exhaust
+ * memory; small enough to fail loud rather than absorb runaway
+ * publishing.
+ */
+export interface FireEventFrame {
+  readonly eventType: string;
+  readonly haEventName: string;
+  readonly eventData: Record<string, unknown>;
+}
+
+export interface DroppedFrameEvent {
+  readonly eventType: string;
+  readonly queueDepth: number;
+  readonly droppedAt: number;
+}
+
+export interface FireEventQueueOptions {
+  readonly cap?: number;
+  readonly now?: () => number;
+  readonly onDropped?: (event: DroppedFrameEvent) => void;
+}
+
+const DEFAULT_CAP = 100;
+
+export class FireEventQueue {
+  private readonly cap: number;
+  private readonly buffer: FireEventFrame[] = [];
+  private readonly droppedByEventType = new Map<string, number>();
+  private readonly now: () => number;
+  private readonly onDropped: (event: DroppedFrameEvent) => void;
+
+  constructor(options: FireEventQueueOptions = {}) {
+    this.cap = options.cap ?? DEFAULT_CAP;
+    this.now = options.now ?? (() => Date.now());
+    this.onDropped = options.onDropped ?? (() => undefined);
+  }
+
+  enqueue(frame: FireEventFrame): void {
+    if (this.buffer.length >= this.cap) {
+      const dropped = this.buffer.shift();
+      if (dropped !== undefined) {
+        const prev = this.droppedByEventType.get(dropped.eventType) ?? 0;
+        this.droppedByEventType.set(dropped.eventType, prev + 1);
+        this.onDropped({
+          eventType: dropped.eventType,
+          queueDepth: this.buffer.length,
+          droppedAt: this.now(),
+        });
+      }
+    }
+    this.buffer.push(frame);
+  }
+
+  drain(visit: (frame: FireEventFrame) => void): void {
+    while (this.buffer.length > 0) {
+      const next = this.buffer.shift();
+      if (next === undefined) return;
+      visit(next);
+    }
+  }
+
+  size(): number {
+    return this.buffer.length;
+  }
+
+  droppedTotal(eventType: string): number {
+    return this.droppedByEventType.get(eventType) ?? 0;
+  }
+}

--- a/apps/pops-ha-bridge-api/src/sinks/fire-event-sender.ts
+++ b/apps/pops-ha-bridge-api/src/sinks/fire-event-sender.ts
@@ -1,0 +1,110 @@
+/**
+ * PRD-237 US-02: outbound `fire_event` sender.
+ *
+ * Owns the bounded reconnect queue and the per-frame WS write logic.
+ * The HA WebSocket subscriber composes this — when the socket is up,
+ * `send` writes immediately; while reconnecting, frames are queued and
+ * `flush` drains them in FIFO order on the next successful handshake.
+ *
+ * Kept separate from the subscriber so the subscriber file stays
+ * focused on the inbound state machine (per the per-file LOC ceiling)
+ * and so the queue + frame-serialisation logic can be unit-tested in
+ * isolation.
+ */
+import { FireEventQueue, type FireEventFrame } from './fire-event-queue.js';
+
+import type { SubscriberLogger } from '../ws-subscriber-types.js';
+
+export type SendFireEventOutcome = 'sent' | 'queued';
+
+export interface FireEventSenderDeps {
+  readonly nextCommandId: () => number;
+  readonly write: (frameJson: string) => boolean;
+  readonly logger: SubscriberLogger;
+  readonly now: () => number;
+  readonly queueCap?: number;
+}
+
+export interface LiveSocketHandle {
+  readonly isReady: () => boolean;
+  readonly send: (data: string) => void;
+}
+
+export class FireEventSender {
+  private readonly queue: FireEventQueue;
+  private readonly nextCommandId: () => number;
+  private readonly write: (frameJson: string) => boolean;
+
+  constructor(deps: FireEventSenderDeps) {
+    this.nextCommandId = deps.nextCommandId;
+    this.write = deps.write;
+    const logger = deps.logger;
+    this.queue = new FireEventQueue({
+      cap: deps.queueCap,
+      now: deps.now,
+      onDropped: (event) => {
+        logger.warn('ha sink frame dropped (queue at cap)', {
+          eventType: event.eventType,
+          queueDepth: event.queueDepth,
+          droppedAt: event.droppedAt,
+        });
+      },
+    });
+  }
+
+  send(
+    eventType: string,
+    haEventName: string,
+    eventData: Record<string, unknown>
+  ): SendFireEventOutcome {
+    const frame: FireEventFrame = { eventType, haEventName, eventData };
+    const ok = this.write(this.serialise(frame));
+    if (ok) return 'sent';
+    this.queue.enqueue(frame);
+    return 'queued';
+  }
+
+  flush(): void {
+    if (this.queue.size() === 0) return;
+    this.queue.drain((frame) => {
+      this.write(this.serialise(frame));
+    });
+  }
+
+  size(): number {
+    return this.queue.size();
+  }
+
+  droppedTotal(eventType: string): number {
+    return this.queue.droppedTotal(eventType);
+  }
+
+  private serialise(frame: FireEventFrame): string {
+    return JSON.stringify({
+      id: this.nextCommandId(),
+      type: 'fire_event',
+      event_type: frame.haEventName,
+      event_data: frame.eventData,
+    });
+  }
+}
+
+export function createFireEventSenderForSubscriber(args: {
+  readonly liveSocket: LiveSocketHandle;
+  readonly nextCommandId: () => number;
+  readonly logger: SubscriberLogger;
+  readonly now: () => number;
+  readonly queueCap?: number;
+}): FireEventSender {
+  return new FireEventSender({
+    nextCommandId: args.nextCommandId,
+    write: (frameJson) => {
+      if (!args.liveSocket.isReady()) return false;
+      args.liveSocket.send(frameJson);
+      return true;
+    },
+    logger: args.logger,
+    now: args.now,
+    queueCap: args.queueCap,
+  });
+}

--- a/apps/pops-ha-bridge-api/src/sinks/router.ts
+++ b/apps/pops-ha-bridge-api/src/sinks/router.ts
@@ -1,0 +1,106 @@
+/**
+ * PRD-237 US-02: Express router for `POST /_sinks/<eventType>`.
+ *
+ * Mounts one POST endpoint per shipped {@link SinkMapping} entry. Each
+ * endpoint:
+ *
+ *   1. Looks up the mapping by its `eventType` (the route path).
+ *   2. Validates the inbound JSON body against the Zod schema
+ *      registered in `./schemas.ts`. Failure → 400 with Zod issues.
+ *   3. Applies `mapping.transformInline` to the validated payload to
+ *      get the HA `event_data` object.
+ *   4. Calls the WS subscriber's `sendFireEvent(...)` helper. If the WS
+ *      is connected the frame is delivered and the response is 200. If
+ *      the WS is reconnecting the frame is enqueued and the response
+ *      is still 200 (per the PRD — the orchestrator's contract is
+ *      "accepted by the bridge").
+ *
+ * Unknown `eventType` paths fall through to Express's default 404 — a
+ * mapping not in the config means the manifest never advertised it, so
+ * a publisher hitting that path is a bug upstream, not here.
+ */
+import express, { type Router, type Request, type Response } from 'express';
+
+import { mappings, type SinkMapping } from './mapping.js';
+import { getSinkPayloadSchema } from './schemas.js';
+
+import type { SendFireEventOutcome } from '../ws-subscriber.js';
+
+export interface SinkFireEventFn {
+  (
+    eventType: string,
+    haEventName: string,
+    eventData: Record<string, unknown>
+  ): SendFireEventOutcome;
+}
+
+export interface SinkRouterDeps {
+  readonly fireEvent: SinkFireEventFn;
+  readonly logger?: { warn(msg: string, meta?: Record<string, unknown>): void };
+}
+
+export interface SinkRouterOptions extends SinkRouterDeps {
+  readonly mappings?: readonly SinkMapping[];
+}
+
+interface InvocationFailure {
+  readonly status: number;
+  readonly body: Record<string, unknown>;
+}
+
+export function createSinkRouter(options: SinkRouterOptions): Router {
+  const router = express.Router();
+  router.use(express.json({ limit: '64kb' }));
+  const list = options.mappings ?? mappings;
+
+  for (const mapping of list) {
+    router.post(`/_sinks/${mapping.eventType}`, (req: Request, res: Response) => {
+      const outcome = invokeMapping(mapping, req.body, options);
+      if (typeof outcome === 'object') {
+        res.status(outcome.status).json(outcome.body);
+        return;
+      }
+      res.status(200).json({ outcome });
+    });
+  }
+
+  router.post('/_sinks/:eventType', (req: Request, res: Response) => {
+    res.status(404).json({ error: 'unknown-event-type', eventType: req.params['eventType'] });
+  });
+
+  return router;
+}
+
+function invokeMapping(
+  mapping: SinkMapping,
+  body: unknown,
+  deps: SinkRouterDeps
+): SendFireEventOutcome | InvocationFailure {
+  const schema = getSinkPayloadSchema(mapping.eventType);
+  if (schema === undefined) {
+    deps.logger?.warn('sink endpoint missing zod schema', { eventType: mapping.eventType });
+    return {
+      status: 500,
+      body: { error: 'schema-not-registered', eventType: mapping.eventType },
+    };
+  }
+  const parsed = schema.safeParse(body);
+  if (!parsed.success) {
+    return {
+      status: 400,
+      body: {
+        error: 'invalid-payload',
+        eventType: mapping.eventType,
+        issues: parsed.error.issues.map((issue) => ({
+          path: issue.path.map((segment) =>
+            typeof segment === 'number' ? segment : String(segment)
+          ),
+          message: issue.message,
+        })),
+      },
+    };
+  }
+  const data = parsed.data as Record<string, unknown>;
+  const eventData = mapping.transformInline(data);
+  return deps.fireEvent(mapping.eventType, mapping.haEventName, eventData);
+}

--- a/apps/pops-ha-bridge-api/src/sinks/schemas.ts
+++ b/apps/pops-ha-bridge-api/src/sinks/schemas.ts
@@ -1,0 +1,49 @@
+/**
+ * PRD-237 US-02: runtime Zod schemas for inbound sink payloads.
+ *
+ * The mapping config (`./mapping.ts`) declares the JSON-Schema-shaped
+ * payload contract used in the manifest projection. The orchestrator
+ * (PRD-236) and the inbound `POST /_sinks/<eventType>` endpoint both
+ * need a live Zod instance to validate against — this module is the
+ * single source of truth for those schemas, keyed by the same
+ * `eventType` strings the mapping uses.
+ *
+ * Keeping the Zod registry next to the mapping (but in a separate file)
+ * lets US-02 ship validation without mutating US-01's shipped config.
+ */
+import { z } from 'zod';
+
+export const sinkPayloadSchemas = {
+  'media.watch.completed': z
+    .object({
+      mediaId: z.string(),
+      userId: z.string(),
+      occurredAt: z.string(),
+      durationSeconds: z.number().optional(),
+    })
+    .strict(),
+  'finance.balance.low': z
+    .object({
+      accountId: z.string(),
+      balance: z.number(),
+      threshold: z.number(),
+      currency: z.string().optional(),
+      occurredAt: z.string(),
+    })
+    .strict(),
+  'inventory.item.consumed': z
+    .object({
+      itemId: z.string(),
+      quantity: z.number(),
+      unit: z.string().optional(),
+      occurredAt: z.string(),
+    })
+    .strict(),
+} as const;
+
+export type SinkPayloadSchemaMap = typeof sinkPayloadSchemas;
+
+export function getSinkPayloadSchema(eventType: string): z.ZodType<unknown> | undefined {
+  if (!Object.prototype.hasOwnProperty.call(sinkPayloadSchemas, eventType)) return undefined;
+  return sinkPayloadSchemas[eventType as keyof SinkPayloadSchemaMap];
+}

--- a/apps/pops-ha-bridge-api/src/ws-state.ts
+++ b/apps/pops-ha-bridge-api/src/ws-state.ts
@@ -1,0 +1,26 @@
+/**
+ * Pure state transitions for the HA WebSocket subscriber.
+ *
+ * Splitting these out of `ws-subscriber.ts` keeps the subscriber file
+ * under the per-file LOC ceiling. Each helper takes the previous
+ * connection state + inputs and returns the next state; the
+ * subscriber owns the side-effects (timer scheduling, socket close).
+ */
+import type { ConnectionState } from './ws-subscriber-types.js';
+
+export function transitionToAuthFailed(prev: ConnectionState): ConnectionState {
+  const lastEventAt = prev.kind === 'offline' ? prev.lastEventAt : 0;
+  return { kind: 'offline', reason: 'auth-failed', lastEventAt };
+}
+
+export function transitionToReconnecting(
+  prev: ConnectionState,
+  nextAttemptInMs: number
+): ConnectionState {
+  const lastEventAt = prev.kind === 'connected' ? prev.lastEventAt : 0;
+  return { kind: 'reconnecting', lastEventAt, nextAttemptInMs };
+}
+
+export function isPostAuthFailureClose(prev: ConnectionState): boolean {
+  return prev.kind === 'offline' && prev.reason === 'auth-failed';
+}

--- a/apps/pops-ha-bridge-api/src/ws-subscriber-types.ts
+++ b/apps/pops-ha-bridge-api/src/ws-subscriber-types.ts
@@ -30,6 +30,11 @@ export interface SubscriberLogger {
   warn(msg: string, meta?: Record<string, unknown>): void;
 }
 
+export const NOOP_SUBSCRIBER_LOGGER: SubscriberLogger = {
+  info: () => undefined,
+  warn: () => undefined,
+};
+
 export interface HaWebSocketSubscriberOptions {
   db: OpenedHaBridgeDb;
   url: string | undefined;
@@ -42,4 +47,11 @@ export interface HaWebSocketSubscriberOptions {
   clearTimeoutImpl?: typeof clearTimeout;
   now?: () => number;
   logger?: SubscriberLogger;
+  /**
+   * PRD-237 US-02: cap for the outbound `fire_event` reconnect queue.
+   * Frames pushed while the WS is reconnecting are buffered up to this
+   * many entries; at-cap pushes drop the oldest. Defaults to 100 per
+   * the PRD heuristic.
+   */
+  sinkQueueCap?: number;
 }

--- a/apps/pops-ha-bridge-api/src/ws-subscriber.ts
+++ b/apps/pops-ha-bridge-api/src/ws-subscriber.ts
@@ -19,12 +19,7 @@
  * `HA_TOKEN` is never logged, never returned, and never serialised into
  * the manifest — it is only ever passed to the auth frame.
  */
-import {
-  appendHistory,
-  upsertEntity,
-  type HaEntityMirrorInput,
-  type OpenedHaBridgeDb,
-} from '@pops/ha-bridge-db';
+import { appendHistory, upsertEntity, type OpenedHaBridgeDb } from '@pops/ha-bridge-db';
 
 import {
   parseFrame,
@@ -33,13 +28,22 @@ import {
   type HaStateObject,
 } from './ha-frame.js';
 import { HistoryDebouncer } from './history-debouncer.js';
-
-import type {
-  ConnectionState,
-  HaWebSocketFactory,
-  HaWebSocketLike,
-  HaWebSocketSubscriberOptions,
-  SubscriberLogger,
+import {
+  createFireEventSenderForSubscriber,
+  type FireEventSender,
+} from './sinks/fire-event-sender.js';
+import {
+  isPostAuthFailureClose,
+  transitionToAuthFailed,
+  transitionToReconnecting,
+} from './ws-state.js';
+import {
+  NOOP_SUBSCRIBER_LOGGER,
+  type ConnectionState,
+  type HaWebSocketFactory,
+  type HaWebSocketLike,
+  type HaWebSocketSubscriberOptions,
+  type SubscriberLogger,
 } from './ws-subscriber-types.js';
 
 export type {
@@ -48,6 +52,8 @@ export type {
   HaWebSocketLike,
   HaWebSocketSubscriberOptions,
 } from './ws-subscriber-types.js';
+
+export type { SendFireEventOutcome } from './sinks/fire-event-sender.js';
 
 const DEFAULT_DEBOUNCE_MS = 200;
 const DEFAULT_INITIAL_BACKOFF_MS = 1_000;
@@ -65,13 +71,13 @@ export class HaWebSocketSubscriber {
   private readonly clearTimeoutImpl: typeof clearTimeout;
   private readonly now: () => number;
   private readonly logger: SubscriberLogger;
-
+  private readonly debouncer: HistoryDebouncer;
+  private readonly fireEventSender: FireEventSender;
   private socket: HaWebSocketLike | undefined;
   private connectionState: ConnectionState;
   private reconnectAttempt = 0;
   private reconnectTimer: ReturnType<typeof setTimeout> | undefined;
   private commandId = 1;
-  private readonly debouncer: HistoryDebouncer;
   private stopped = false;
   private subscribed = false;
 
@@ -86,15 +92,7 @@ export class HaWebSocketSubscriber {
     this.setTimeoutImpl = options.setTimeoutImpl ?? setTimeout;
     this.clearTimeoutImpl = options.clearTimeoutImpl ?? clearTimeout;
     this.now = options.now ?? (() => Date.now());
-    // Default to a no-op logger so degraded mode (missing config / auth
-    // failure / reconnect churn) really is silent unless the caller opts
-    // in by injecting their own logger. The PR/PRD describe this surface
-    // as "degrades silently" — wiring `console.warn` here contradicted
-    // that contract and spammed unconfigured deployments.
-    this.logger = options.logger ?? {
-      info: () => undefined,
-      warn: () => undefined,
-    };
+    this.logger = options.logger ?? NOOP_SUBSCRIBER_LOGGER;
     this.connectionState =
       this.url === undefined || this.token === undefined
         ? { kind: 'offline', reason: 'no-config', lastEventAt: 0 }
@@ -107,10 +105,30 @@ export class HaWebSocketSubscriber {
         appendHistory(this.db.db, observation);
       },
     });
+    this.fireEventSender = createFireEventSenderForSubscriber({
+      liveSocket: {
+        isReady: () =>
+          this.connectionState.kind === 'connected' && this.socket !== undefined && this.subscribed,
+        send: (data) => this.socket?.send(data),
+      },
+      nextCommandId: () => {
+        const id = this.commandId;
+        this.commandId += 1;
+        return id;
+      },
+      logger: this.logger,
+      now: this.now,
+      queueCap: options.sinkQueueCap,
+    });
   }
 
   state(): ConnectionState {
     return { ...this.connectionState };
+  }
+
+  /** PRD-237 US-02: outbound sink — `sendFireEvent` + queue introspection. */
+  get sinks(): FireEventSender {
+    return this.fireEventSender;
   }
 
   start(): void {
@@ -120,7 +138,6 @@ export class HaWebSocketSubscriber {
     }
     this.openSocket();
   }
-
   stop(): void {
     this.stopped = true;
     if (this.reconnectTimer !== undefined) {
@@ -183,6 +200,7 @@ export class HaWebSocketSubscriber {
     if (!this.subscribed) {
       this.subscribed = true;
       this.sendCommand({ type: 'subscribe_events', event_type: 'state_changed' });
+      this.fireEventSender.flush();
     }
     return true;
   }
@@ -196,53 +214,35 @@ export class HaWebSocketSubscriber {
     if (input === undefined) return;
     upsertEntity(this.db.db, input);
     this.connectionState = { kind: 'connected', lastEventAt: now };
-    this.scheduleHistoryDebounced(input);
-  }
-
-  private markAuthFailed(): void {
-    this.logger.warn('HA auth rejected — switching to degraded mode');
-    const lastEventAt =
-      this.connectionState.kind === 'offline' ? this.connectionState.lastEventAt : 0;
-    this.connectionState = { kind: 'offline', reason: 'auth-failed', lastEventAt };
-    this.socket?.close();
-    this.socket = undefined;
-  }
-
-  private handleClose(code: number, reason: string): void {
-    this.socket = undefined;
-    if (this.stopped) return;
-    if (this.connectionState.kind === 'offline' && this.connectionState.reason === 'auth-failed') {
-      return;
-    }
-    const lastEventAt =
-      this.connectionState.kind === 'connected' ? this.connectionState.lastEventAt : 0;
-    const delay = this.nextBackoffMs();
-    this.connectionState = { kind: 'reconnecting', lastEventAt, nextAttemptInMs: delay };
-    this.logger.warn('HA socket closed — scheduling reconnect', { code, reason, delay });
-    this.reconnectTimer = this.setTimeoutImpl(() => {
-      this.reconnectTimer = undefined;
-      this.openSocket();
-    }, delay);
-  }
-
-  private nextBackoffMs(): number {
-    const exp = Math.min(this.maxBackoffMs, this.initialBackoffMs * 2 ** this.reconnectAttempt);
-    this.reconnectAttempt += 1;
-    return exp;
-  }
-
-  private sendCommand(payload: Record<string, unknown>): void {
-    const id = this.commandId;
-    this.commandId += 1;
-    this.socket?.send(JSON.stringify({ id, ...payload }));
-  }
-
-  private scheduleHistoryDebounced(input: HaEntityMirrorInput): void {
     this.debouncer.observe({
       entityId: input.entityId,
       state: input.state,
       attributes: input.attributes,
       observedAt: input.lastChanged,
     });
+  }
+
+  private markAuthFailed(): void {
+    this.logger.warn('HA auth rejected — switching to degraded mode');
+    this.connectionState = transitionToAuthFailed(this.connectionState);
+    this.socket?.close();
+    this.socket = undefined;
+  }
+  private handleClose(code: number, reason: string): void {
+    this.socket = undefined;
+    if (this.stopped || isPostAuthFailureClose(this.connectionState)) return;
+    const delay = Math.min(this.maxBackoffMs, this.initialBackoffMs * 2 ** this.reconnectAttempt);
+    this.reconnectAttempt += 1;
+    this.connectionState = transitionToReconnecting(this.connectionState, delay);
+    this.logger.warn('HA socket closed — scheduling reconnect', { code, reason, delay });
+    this.reconnectTimer = this.setTimeoutImpl(() => {
+      this.reconnectTimer = undefined;
+      this.openSocket();
+    }, delay);
+  }
+  private sendCommand(payload: Record<string, unknown>): void {
+    const id = this.commandId;
+    this.commandId += 1;
+    this.socket?.send(JSON.stringify({ id, ...payload }));
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -498,6 +498,9 @@ importers:
       ws:
         specifier: ^8.18.0
         version: 8.21.0
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@types/express':
         specifier: ^5.0.4


### PR DESCRIPTION
## Summary

- Closes [PRD-237](docs/themes/13-pillar-finale/prds/237-pops-to-ha-event-publisher/README.md) by wiring the pops → HA outbound publisher path end-to-end on top of the US-01 mapping config.
- `POST /_sinks/<eventType>` Express router validates inbound JSON against the mapping's Zod schema (`sinks/schemas.ts`), applies `transformInline`, and hands the result to the WS subscriber. Unknown eventTypes → 404; invalid payloads → 400 with Zod issues.
- `sendFireEvent` lands on the HA WebSocket subscriber via a composed `FireEventSender` that writes the `fire_event` frame on a live socket or appends to a bounded FIFO (`HA_SINK_QUEUE_CAP`, default 100) when reconnecting. Drain happens FIFO after the next successful auth/subscribe handshake. At-cap pushes drop the oldest, log a structured warning, and bump a per-eventType counter.
- US-01 surface (`mapping.ts`, `validator.ts`, `manifest.ts`) is untouched. Existing `ws-subscriber` tests still pass.

## User stories closed

- [x] US-02 — `sendFireEvent` + reconnect queue + end-to-end mapping test

PRD-237 is now fully done — US-01 (#3172) + US-02.

## Test plan

- [x] `pnpm --filter @pops/ha-bridge-api test` — 38/38 pass (4 new e2e cases + 34 existing).
- [x] `pnpm --filter @pops/ha-bridge-api typecheck` — clean.
- [x] `pnpm typecheck` — 71/71 packages clean.
- [x] `pnpm oxlint apps/pops-ha-bridge-api/src` — clean (per-file LOC ceiling preserved by extracting `ws-state.ts`).
- [ ] Manual smoke test against the homelab HA instance (post-merge — out of scope for CI per the PRD note).
