### PR TITLE
feat(app-media): migrate batch 7 final slice (19 sites · PRD-227)

### DIFF
--- a/packages/app-media/package.json
+++ b/packages/app-media/package.json
@@ -14,7 +14,6 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
-    "@pops/api-client": "workspace:*",
     "@pops/navigation": "workspace:*",
     "@pops/pillar-sdk": "workspace:*",
     "@pops/types": "workspace:*",

--- a/packages/app-media/src/components/ShelfSection.test.tsx
+++ b/packages/app-media/src/components/ShelfSection.test.tsx
@@ -5,18 +5,17 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 // ── Mocks ─────────────────────────────────────────────────────────────────────
 
 const mockGetShelfPageFetch = vi.fn();
-const mockUseUtils = vi.fn().mockReturnValue({
-  media: {
-    discovery: {
-      getShelfPage: { fetch: mockGetShelfPageFetch },
-    },
-  },
-});
 
-vi.mock('@pops/api-client', () => ({
-  trpc: {
-    useUtils: () => mockUseUtils(),
-  },
+vi.mock('@pops/pillar-sdk/react', () => ({
+  usePillarUtils: () => ({
+    setData: vi.fn(),
+    invalidate: vi.fn(),
+    fetchQuery: (path: readonly string[], input: unknown) => {
+      const key = path.join('.');
+      if (key === 'discovery.getShelfPage') return mockGetShelfPageFetch(input);
+      return Promise.resolve(undefined);
+    },
+  }),
 }));
 
 // Mock IntersectionObserver — trigger callback immediately to make sections visible

--- a/packages/app-media/src/components/shelf-section/useShelfPagination.ts
+++ b/packages/app-media/src/components/shelf-section/useShelfPagination.ts
@@ -1,11 +1,17 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
-import { trpc } from '@pops/api-client';
+import { usePillarUtils } from '@pops/pillar-sdk/react';
 
 import type { ShelfItem } from './types';
 
 const LOAD_MORE_LIMIT = 20;
+
+interface ShelfPageResponse {
+  items: ShelfItem[];
+  hasMore: boolean;
+  totalCount: number | null;
+}
 
 function useVisibilityObserver() {
   const sentinelRef = useRef<HTMLDivElement>(null);
@@ -42,7 +48,7 @@ export function useShelfPagination({
   const [loadingMore, setLoadingMore] = useState(false);
   const [offset, setOffset] = useState(initialItems.length);
 
-  const utils = trpc.useUtils();
+  const utils = usePillarUtils('media');
 
   const patchItem = useCallback((tmdbId: number, patch: Partial<ShelfItem>) => {
     setItems((prev) => prev.map((i) => (i.tmdbId === tmdbId ? { ...i, ...patch } : i)));
@@ -51,7 +57,7 @@ export function useShelfPagination({
   const handleShowMore = useCallback(async () => {
     setLoadingMore(true);
     try {
-      const data = await utils.media.discovery.getShelfPage.fetch({
+      const data = await utils.fetchQuery<ShelfPageResponse>(['discovery', 'getShelfPage'], {
         shelfId,
         limit: LOAD_MORE_LIMIT,
         offset,

--- a/packages/app-media/src/hooks/discover-actions/handlers.ts
+++ b/packages/app-media/src/hooks/discover-actions/handlers.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import { toast } from 'sonner';
 
-import type { trpc } from '@pops/api-client';
+import type { UsePillarUtilsResult } from '@pops/pillar-sdk/react';
 
 import type { DiscoverActionResult } from '../useDiscoverCardActions';
 import type { useDiscoverMutations } from './discoverMutations';
@@ -9,11 +9,16 @@ import type { usePendingSet } from './usePendingSet';
 
 type Mutations = ReturnType<typeof useDiscoverMutations>;
 type Pending = ReturnType<typeof usePendingSet>;
-type TrpcUtils = ReturnType<typeof trpc.useUtils>;
+type PillarUtils = UsePillarUtilsResult;
+
+interface WatchlistStatusResponse {
+  onWatchlist: boolean;
+  entryId: number | null;
+}
 
 interface AddDeps {
   mutations: Mutations;
-  utils: TrpcUtils;
+  utils: PillarUtils;
   pending: Pending;
 }
 
@@ -49,7 +54,7 @@ export function useAddToWatchlist({ mutations, utils, pending }: AddDeps) {
         });
         if (wlResult.created) toast.success(`Added "${libResult.data.title}" to watchlist`);
         else toast.info(`"${libResult.data.title}" is already on watchlist`);
-        void utils.media.watchlist.list.invalidate();
+        void utils.invalidate(['watchlist', 'list']);
         return { ok: true, inLibrary: true, onWatchlist: true };
       } catch {
         toast.error('Failed to add to watchlist');
@@ -68,7 +73,7 @@ export function useRemoveFromWatchlist({ mutations, utils, pending }: AddDeps) {
       pending.add(tmdbId);
       try {
         const libResult = await mutations.addMovieMutation.mutateAsync({ tmdbId });
-        const status = await utils.media.watchlist.status.fetch({
+        const status = await utils.fetchQuery<WatchlistStatusResponse>(['watchlist', 'status'], {
           mediaType: 'movie',
           mediaId: libResult.data.id,
         });
@@ -78,7 +83,7 @@ export function useRemoveFromWatchlist({ mutations, utils, pending }: AddDeps) {
         }
         await mutations.removeWatchlistMutation.mutateAsync({ id: status.entryId });
         toast.success(`Removed "${libResult.data.title}" from watchlist`);
-        void utils.media.watchlist.list.invalidate();
+        void utils.invalidate(['watchlist', 'list']);
         return { ok: true, inLibrary: true, onWatchlist: false };
       } catch {
         toast.error('Failed to remove from watchlist');
@@ -103,9 +108,9 @@ export function useMarkWatched({ mutations, utils, pending }: AddDeps) {
         });
         toast.success(`Marked "${libResult.data.title}" as watched`);
         if (watchResult.watchlistRemoved) {
-          void utils.media.watchlist.list.invalidate();
+          void utils.invalidate(['watchlist', 'list']);
         }
-        void utils.media.comparisons.getPendingDebriefs.invalidate();
+        void utils.invalidate(['comparisons', 'getPendingDebriefs']);
         return {
           ok: true,
           inLibrary: true,
@@ -134,7 +139,7 @@ export function useMarkRewatched({ mutations, utils, pending }: AddDeps) {
           mediaId: libResult.data.id,
         });
         toast.success(`Logged rewatch of "${libResult.data.title}"`);
-        void utils.media.comparisons.getPendingDebriefs.invalidate();
+        void utils.invalidate(['comparisons', 'getPendingDebriefs']);
         return { ok: true, inLibrary: true, isWatched: true };
       } catch {
         toast.error('Failed to log rewatch');
@@ -154,7 +159,7 @@ export function useNotInterested({
   optimistic,
 }: {
   mutations: Mutations;
-  utils: TrpcUtils;
+  utils: PillarUtils;
   dismissing: Pending;
   optimistic: Pending;
 }) {
@@ -164,7 +169,7 @@ export function useNotInterested({
       dismissing.add(tmdbId);
       try {
         await mutations.dismissMutation.mutateAsync({ tmdbId });
-        void utils.media.discovery.getDismissed.invalidate();
+        void utils.invalidate(['discovery', 'getDismissed']);
         return { ok: true };
       } catch {
         optimistic.remove(tmdbId);

--- a/packages/app-media/src/hooks/useDiscoverCardActions.ts
+++ b/packages/app-media/src/hooks/useDiscoverCardActions.ts
@@ -4,7 +4,7 @@
  * Encapsulates add-to-library, watchlist, watched, rewatch, and dismiss mutations
  * so they can be reused across the discover page and dynamic shelf sections.
  */
-import { trpc } from '@pops/api-client';
+import { usePillarUtils } from '@pops/pillar-sdk/react';
 
 import { useDiscoverMutations } from './discover-actions/discoverMutations';
 import {
@@ -53,7 +53,7 @@ export interface DiscoverCardActions {
 }
 
 export function useDiscoverCardActions(): DiscoverCardActions {
-  const utils = trpc.useUtils();
+  const utils = usePillarUtils('media');
   const mutations = useDiscoverMutations();
 
   const addingToLibrary = usePendingSet();

--- a/packages/app-media/src/hooks/useTierListSubmit.ts
+++ b/packages/app-media/src/hooks/useTierListSubmit.ts
@@ -1,12 +1,12 @@
 /**
  * useTierListSubmit — mutation hook for submitting tier list placements.
  *
- * Wraps the submitTierList tRPC mutation with cache invalidation
+ * Wraps the submitTierList pillar mutation with cache invalidation
  * and title enrichment for the summary display.
  */
 import { useCallback, useState } from 'react';
 
-import { trpc } from '@pops/api-client';
+import { usePillarMutation, usePillarUtils } from '@pops/pillar-sdk/react';
 
 export type Tier = 'S' | 'A' | 'B' | 'C' | 'D';
 
@@ -33,26 +33,46 @@ interface UseTierListSubmitOptions {
   onSuccess?: (result: TierListResult) => void;
 }
 
+interface SubmitTierListInput {
+  dimensionId: number;
+  placements: TierPlacement[];
+}
+
+interface SubmitTierListResponse {
+  data: {
+    comparisonsRecorded: number;
+    scoreChanges: Array<{
+      movieId: number;
+      oldScore: number;
+      newScore: number;
+    }>;
+  };
+}
+
 export function useTierListSubmit({ movieTitles, onSuccess }: UseTierListSubmitOptions) {
   const [result, setResult] = useState<TierListResult | null>(null);
-  const utils = trpc.useUtils();
+  const utils = usePillarUtils('media');
 
-  const mutation = trpc.media.comparisons.submitTierList.useMutation({
-    onSuccess: (response) => {
-      const enriched: TierListResult = {
-        comparisonsRecorded: response.data.comparisonsRecorded,
-        scoreChanges: response.data.scoreChanges.map((sc) => ({
-          ...sc,
-          title: movieTitles.get(sc.movieId) ?? `Movie #${sc.movieId}`,
-        })),
-      };
-      setResult(enriched);
-      void utils.media.comparisons.getTierListMovies.invalidate();
-      void utils.media.comparisons.listAll.invalidate();
-      void utils.media.comparisons.scores.invalidate();
-      onSuccess?.(enriched);
-    },
-  });
+  const mutation = usePillarMutation<SubmitTierListInput, SubmitTierListResponse>(
+    'media',
+    ['comparisons', 'submitTierList'],
+    {
+      onSuccess: (response) => {
+        const enriched: TierListResult = {
+          comparisonsRecorded: response.data.comparisonsRecorded,
+          scoreChanges: response.data.scoreChanges.map((sc) => ({
+            ...sc,
+            title: movieTitles.get(sc.movieId) ?? `Movie #${sc.movieId}`,
+          })),
+        };
+        setResult(enriched);
+        void utils.invalidate(['comparisons', 'getTierListMovies']);
+        void utils.invalidate(['comparisons', 'listAll']);
+        void utils.invalidate(['comparisons', 'scores']);
+        onSuccess?.(enriched);
+      },
+    }
+  );
 
   const submit = useCallback(
     (dimensionId: number, placements: TierPlacement[]) => {

--- a/packages/app-media/src/pages/LibraryPage.test.tsx
+++ b/packages/app-media/src/pages/LibraryPage.test.tsx
@@ -8,8 +8,6 @@ const mockGenresQuery = vi.fn();
 const mockRefetch = vi.fn();
 const mockGetPendingDebriefs = vi.fn();
 
-const mockGetLeavingMovies = vi.fn();
-
 vi.mock('@pops/pillar-sdk/react', () => ({
   usePillarQuery: (_pillarId: string, path: readonly string[], input: unknown) => {
     const key = path.join('.');
@@ -19,22 +17,11 @@ vi.mock('@pops/pillar-sdk/react', () => ({
     return { data: undefined, isLoading: false };
   },
   usePillarMutation: () => ({ mutate: vi.fn(), isPending: false }),
-}));
-
-vi.mock('@pops/api-client', () => ({
-  trpc: {
-    media: {
-      comparisons: {
-        getPendingDebriefs: { useQuery: () => mockGetPendingDebriefs() },
-      },
-      rotation: {
-        getLeavingMovies: { useQuery: () => mockGetLeavingMovies() },
-        cancelLeaving: {
-          useMutation: () => ({ mutate: vi.fn(), isPending: false }),
-        },
-      },
-    },
-  },
+  usePillarUtils: () => ({
+    setData: vi.fn(),
+    invalidate: vi.fn(),
+    fetchQuery: vi.fn(),
+  }),
 }));
 
 vi.mock('../components/MediaGrid', () => ({
@@ -120,7 +107,6 @@ describe('LibraryPage', () => {
     vi.clearAllMocks();
     mockGenresQuery.mockReturnValue({ data: { data: ['Drama', 'Sci-Fi'] } });
     mockGetPendingDebriefs.mockReturnValue({ data: null });
-    mockGetLeavingMovies.mockReturnValue({ data: [], isLoading: false });
   });
 
   describe('Loading state', () => {

--- a/packages/app-media/src/pages/MovieDetailPage.test.tsx
+++ b/packages/app-media/src/pages/MovieDetailPage.test.tsx
@@ -2,28 +2,21 @@ import { render, screen } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-// Mock trpc hooks
+import { PillarCallError } from '@pops/pillar-sdk/client';
+
 const mockMovieQuery = vi.fn();
 const mockWatchHistoryQuery = vi.fn();
 const mockGetStalenessQuery = vi.fn();
 const mockGetPendingDebriefsQuery = vi.fn();
 
-vi.mock('@pops/api-client', () => ({
-  trpc: {
-    media: {
-      movies: {
-        get: { useQuery: (...args: unknown[]) => mockMovieQuery(...args) },
-      },
-      watchHistory: {
-        list: { useQuery: (...args: unknown[]) => mockWatchHistoryQuery(...args) },
-      },
-      comparisons: {
-        getStaleness: { useQuery: (...args: unknown[]) => mockGetStalenessQuery(...args) },
-        getPendingDebriefs: {
-          useQuery: (...args: unknown[]) => mockGetPendingDebriefsQuery(...args),
-        },
-      },
-    },
+vi.mock('@pops/pillar-sdk/react', () => ({
+  usePillarQuery: (_pillarId: string, path: readonly string[], input: unknown) => {
+    const key = path.join('.');
+    if (key === 'movies.get') return mockMovieQuery(input);
+    if (key === 'watchHistory.list') return mockWatchHistoryQuery(input);
+    if (key === 'comparisons.getStaleness') return mockGetStalenessQuery(input);
+    if (key === 'comparisons.getPendingDebriefs') return mockGetPendingDebriefsQuery();
+    return { data: undefined, isLoading: false };
   },
 }));
 
@@ -266,7 +259,7 @@ describe('MovieDetailPage', () => {
       mockMovieQuery.mockReturnValue({
         data: null,
         isLoading: false,
-        error: { data: { code: 'NOT_FOUND' }, message: 'Not found' },
+        error: new PillarCallError('media', { kind: 'not-found', pillar: 'media' }),
       });
       renderAtRoute('/media/movies/999');
       expect(screen.getByText('Movie not found')).toBeInTheDocument();
@@ -274,21 +267,22 @@ describe('MovieDetailPage', () => {
     });
 
     it('shows generic error for other errors', () => {
+      const err = new PillarCallError('media', { kind: 'unavailable', pillar: 'media' });
       mockMovieQuery.mockReturnValue({
         data: null,
         isLoading: false,
-        error: { data: { code: 'INTERNAL_SERVER_ERROR' }, message: 'Something broke' },
+        error: err,
       });
       renderAtRoute('/media/movies/1');
       expect(screen.getByText('Error')).toBeInTheDocument();
-      expect(screen.getByText('Something broke')).toBeInTheDocument();
+      expect(screen.getByText(err.message)).toBeInTheDocument();
     });
 
     it('shows back to library link on error', () => {
       mockMovieQuery.mockReturnValue({
         data: null,
         isLoading: false,
-        error: { data: { code: 'NOT_FOUND' }, message: 'Not found' },
+        error: new PillarCallError('media', { kind: 'not-found', pillar: 'media' }),
       });
       renderAtRoute('/media/movies/999');
       expect(screen.getByText('Back to library')).toHaveAttribute('href', '/media');

--- a/packages/app-media/src/pages/MovieDetailPage.tsx
+++ b/packages/app-media/src/pages/MovieDetailPage.tsx
@@ -1,5 +1,6 @@
 import { Link, useParams } from 'react-router';
 
+import { isNotFound } from '@pops/pillar-sdk/client';
 import { Alert, AlertDescription, AlertTitle } from '@pops/ui';
 
 import { MovieDetailContent } from './movie-detail/MovieDetailContent';
@@ -18,14 +19,15 @@ function InvalidIdView() {
   );
 }
 
-function ErrorView({ error }: { error: { data?: { code?: string } | null; message: string } }) {
-  const is404 = error.data?.code === 'NOT_FOUND';
+function ErrorView({ error }: { error: unknown }) {
+  const is404 = isNotFound(error);
+  const message = error instanceof Error ? error.message : String(error);
   return (
     <div className="p-6">
       <Alert variant="destructive">
         <AlertTitle>{is404 ? 'Movie not found' : 'Error'}</AlertTitle>
         <AlertDescription>
-          {is404 ? "This movie doesn't exist in your library." : error.message}
+          {is404 ? "This movie doesn't exist in your library." : message}
         </AlertDescription>
       </Alert>
       <Link to="/media" className="mt-4 inline-block text-sm text-primary underline">

--- a/packages/app-media/src/pages/SearchPage.test.tsx
+++ b/packages/app-media/src/pages/SearchPage.test.tsx
@@ -29,23 +29,6 @@ const {
   mockTvRefetch: vi.fn(),
 }));
 
-vi.mock('@pops/api-client', () => ({
-  trpc: {
-    media: {
-      library: {
-        addMovie: { useMutation: () => ({ mutate: mockAddMovieMutation, isPending: false }) },
-        addTvShow: { useMutation: () => ({ mutate: mockAddTvMutation, isPending: false }) },
-      },
-      watchlist: {
-        add: { useMutation: () => ({ mutate: mockWatchlistAddMutation, isPending: false }) },
-      },
-      watchHistory: {
-        log: { useMutation: () => ({ mutate: mockWatchHistoryLogMutation, isPending: false }) },
-      },
-    },
-  },
-}));
-
 vi.mock('@pops/pillar-sdk/react', () => ({
   usePillarQuery: (
     _pillarId: string,
@@ -60,6 +43,20 @@ vi.mock('@pops/pillar-sdk/react', () => ({
     if (key === 'tvShows.list') return mockLibraryTv(input, options);
     return { data: undefined, isLoading: false, error: null };
   },
+  usePillarMutation: (_pillarId: string, path: readonly string[]) => {
+    const key = path.join('.');
+    if (key === 'library.addMovie') return { mutate: mockAddMovieMutation, isPending: false };
+    if (key === 'library.addTvShow') return { mutate: mockAddTvMutation, isPending: false };
+    if (key === 'watchlist.add') return { mutate: mockWatchlistAddMutation, isPending: false };
+    if (key === 'watchHistory.log')
+      return { mutate: mockWatchHistoryLogMutation, isPending: false };
+    return { mutate: vi.fn(), isPending: false };
+  },
+  usePillarUtils: () => ({
+    setData: vi.fn(),
+    invalidate: vi.fn(),
+    fetchQuery: vi.fn(),
+  }),
 }));
 
 // Capture props passed to SearchResultCard for assertion

--- a/packages/app-media/src/pages/TierListPage.test.tsx
+++ b/packages/app-media/src/pages/TierListPage.test.tsx
@@ -61,63 +61,31 @@ const mockRefetch = vi.fn();
 const mockMutate = vi.fn();
 const mockCreateDimension = vi.fn();
 
-vi.mock('@pops/api-client', () => ({
-  trpc: {
-    useUtils: () => ({
-      media: {
-        comparisons: {
-          getTierListMovies: { invalidate: vi.fn() },
-          getSmartPair: { invalidate: vi.fn() },
-          listDimensions: { invalidate: vi.fn() },
-        },
-      },
-    }),
-    media: {
-      comparisons: {
-        listDimensions: {
-          useQuery: (...args: unknown[]) => mockDimensionsQuery(...args),
-        },
-        getTierListMovies: {
-          useQuery: (...args: unknown[]) => {
-            const result = mockTierListQuery(...args);
-            return { ...result, refetch: mockRefetch, isFetching: false };
-          },
-        },
-        submitTierList: {
-          useMutation: () => ({
-            mutate: mockMutate,
-            isPending: false,
-            error: null,
-          }),
-        },
-        markStale: {
-          useMutation: () => ({
-            mutate: vi.fn(),
-            isPending: false,
-          }),
-        },
-        excludeFromDimension: {
-          useMutation: () => ({
-            mutate: vi.fn(),
-            isPending: false,
-          }),
-        },
-        blacklistMovie: {
-          useMutation: () => ({
-            mutate: vi.fn(),
-            isPending: false,
-          }),
-        },
-        createDimension: {
-          useMutation: () => ({
-            mutate: mockCreateDimension,
-            isPending: false,
-            error: null,
-          }),
-        },
-      },
-    },
+vi.mock('@pops/pillar-sdk/react', () => ({
+  usePillarQuery: (_pillarId: string, path: readonly string[], input: unknown, opts?: unknown) => {
+    const key = path.join('.');
+    if (key === 'comparisons.listDimensions') return mockDimensionsQuery(input);
+    if (key === 'comparisons.getTierListMovies') {
+      const result = mockTierListQuery(input, opts ?? {});
+      return { ...result, refetch: mockRefetch, isFetching: false };
+    }
+    return { data: undefined, isLoading: false };
   },
+  usePillarMutation: (_pillarId: string, path: readonly string[]) => {
+    const key = path.join('.');
+    if (key === 'comparisons.submitTierList') {
+      return { mutate: mockMutate, isPending: false, error: null };
+    }
+    if (key === 'comparisons.createDimension') {
+      return { mutate: mockCreateDimension, isPending: false, error: null };
+    }
+    return { mutate: vi.fn(), isPending: false, error: null };
+  },
+  usePillarUtils: () => ({
+    setData: vi.fn(),
+    invalidate: vi.fn(),
+    fetchQuery: vi.fn(),
+  }),
 }));
 
 import { TierListPage } from './TierListPage';

--- a/packages/app-media/src/pages/WatchlistPage.test.tsx
+++ b/packages/app-media/src/pages/WatchlistPage.test.tsx
@@ -13,63 +13,40 @@ const mockInvalidate = vi.fn();
 const capturedOpts: Record<string, Record<string, unknown>> = {};
 
 vi.mock('@pops/pillar-sdk/react', () => ({
-  usePillarQuery: (_pillarId: string, path: readonly string[]) => {
+  usePillarQuery: (_pillarId: string, path: readonly string[], input: unknown) => {
     const key = path.join('.');
     if (key === 'plex.getActiveSyncJobs') return { data: { data: [] }, isLoading: false };
     if (key === 'plex.getSyncJobStatus') return { data: undefined, isLoading: false };
+    if (key === 'watchlist.list') return mockWatchlistQuery(input);
+    if (key === 'movies.list') return mockMoviesQuery(input);
+    if (key === 'tvShows.list') return mockTvShowsQuery(input);
     return { data: undefined, isLoading: false };
   },
-  usePillarMutation: () => ({ mutate: vi.fn(), isPending: false }),
-}));
-
-vi.mock('@pops/api-client', () => ({
-  trpc: {
-    media: {
-      watchlist: {
-        list: { useQuery: (...args: unknown[]) => mockWatchlistQuery(...args) },
-        remove: {
-          useMutation: (opts: Record<string, unknown>) => {
-            capturedOpts.remove = opts;
-            return { mutate: mockRemoveMutate, isPending: false };
-          },
-        },
-        reorder: {
-          useMutation: (opts: Record<string, unknown>) => {
-            capturedOpts.reorder = opts;
-            return { mutate: mockReorderMutate, isPending: false };
-          },
-        },
-        update: {
-          useMutation: (opts: Record<string, unknown>) => {
-            capturedOpts.update = opts;
-            return { mutate: mockUpdateMutate, isPending: false, variables: null };
-          },
-        },
-      },
-      movies: {
-        list: { useQuery: (...args: unknown[]) => mockMoviesQuery(...args) },
-      },
-      tvShows: {
-        list: { useQuery: (...args: unknown[]) => mockTvShowsQuery(...args) },
-      },
-      plex: {
-        getActiveSyncJobs: {
-          useQuery: () => ({ data: { data: [] }, isLoading: false }),
-        },
-        getSyncJobStatus: {
-          useQuery: () => ({ data: undefined, isLoading: false }),
-        },
-        startSyncJob: {
-          useMutation: () => ({ mutate: vi.fn(), isPending: false }),
-        },
-      },
-    },
-    useUtils: () => ({
-      media: {
-        watchlist: { list: { invalidate: mockInvalidate } },
-      },
-    }),
+  usePillarMutation: (
+    _pillarId: string,
+    path: readonly string[],
+    opts: Record<string, unknown> = {}
+  ) => {
+    const key = path.join('.');
+    if (key === 'watchlist.remove') {
+      capturedOpts.remove = opts;
+      return { mutate: mockRemoveMutate, isPending: false };
+    }
+    if (key === 'watchlist.reorder') {
+      capturedOpts.reorder = opts;
+      return { mutate: mockReorderMutate, isPending: false };
+    }
+    if (key === 'watchlist.update') {
+      capturedOpts.update = opts;
+      return { mutate: mockUpdateMutate, isPending: false, variables: null };
+    }
+    return { mutate: vi.fn(), isPending: false };
   },
+  usePillarUtils: () => ({
+    setData: vi.fn(),
+    invalidate: mockInvalidate,
+    fetchQuery: vi.fn(),
+  }),
 }));
 
 vi.mock('sonner', () => ({

--- a/packages/app-media/src/pages/movie-detail/useMovieDetailModel.ts
+++ b/packages/app-media/src/pages/movie-detail/useMovieDetailModel.ts
@@ -1,20 +1,81 @@
 import { useMemo } from 'react';
 
-import { trpc } from '@pops/api-client';
 import { useSetPageContext } from '@pops/navigation';
+import { usePillarQuery } from '@pops/pillar-sdk/react';
+
+interface Movie {
+  id: number;
+  tmdbId: number;
+  title: string;
+  tagline: string | null;
+  runtime: number | null;
+  voteAverage: number | null;
+  voteCount: number | null;
+  posterPath: string | null;
+  posterUrl: string | null;
+  backdropUrl: string | null;
+  logoUrl: string | null;
+  rotationStatus: string | null;
+  rotationExpiresAt: string | null;
+  releaseDate: string | null;
+  status: string | null;
+  originalLanguage: string | null;
+  budget: number | null;
+  revenue: number | null;
+  overview: string | null;
+  genres: string[];
+}
+
+interface MovieGetResponse {
+  data: Movie | null;
+}
+
+interface WatchHistoryListResponse {
+  data: Array<{
+    id: number;
+    mediaType: 'movie' | 'tv_show';
+    mediaId: number;
+    watchedAt: string;
+    completed: number;
+  }>;
+}
+
+interface StalenessResponse {
+  data: { staleness: number };
+}
+
+interface PendingDebriefRow {
+  movieId: number;
+  status: string;
+}
+
+interface PendingDebriefsResponse {
+  data: PendingDebriefRow[];
+}
 
 function useMovieQueries(movieId: number) {
   const enabled = !Number.isNaN(movieId);
-  const { data, isLoading, error } = trpc.media.movies.get.useQuery({ id: movieId }, { enabled });
-  const { data: watchHistoryData } = trpc.media.watchHistory.list.useQuery(
+  const { data, isLoading, error } = usePillarQuery<MovieGetResponse>(
+    'media',
+    ['movies', 'get'],
+    { id: movieId },
+    { enabled }
+  );
+  const { data: watchHistoryData } = usePillarQuery<WatchHistoryListResponse>(
+    'media',
+    ['watchHistory', 'list'],
     { mediaType: 'movie', mediaId: movieId },
     { enabled }
   );
-  const { data: stalenessData } = trpc.media.comparisons.getStaleness.useQuery(
+  const { data: stalenessData } = usePillarQuery<StalenessResponse>(
+    'media',
+    ['comparisons', 'getStaleness'],
     { mediaType: 'movie', mediaId: movieId },
     { enabled }
   );
-  const { data: pendingDebriefData } = trpc.media.comparisons.getPendingDebriefs.useQuery(
+  const { data: pendingDebriefData } = usePillarQuery<PendingDebriefsResponse>(
+    'media',
+    ['comparisons', 'getPendingDebriefs'],
     undefined,
     { enabled }
   );
@@ -49,8 +110,7 @@ export function useMovieDetailModel(movieId: number) {
 
   const pendingDebrief = movie
     ? (queries.pendingDebriefData?.data ?? []).find(
-        (d: { movieId: number; status: string }) =>
-          d.movieId === movie.id && (d.status === 'pending' || d.status === 'active')
+        (d) => d.movieId === movie.id && (d.status === 'pending' || d.status === 'active')
       )
     : undefined;
 

--- a/packages/app-media/src/pages/search/useSearchAddActions.ts
+++ b/packages/app-media/src/pages/search/useSearchAddActions.ts
@@ -1,4 +1,4 @@
-import { trpc } from '@pops/api-client';
+import { usePillarMutation } from '@pops/pillar-sdk/react';
 
 import {
   makeKey,
@@ -10,6 +10,36 @@ import {
 } from './useSearchAddHandlers';
 import { useSearchAddState } from './useSearchAddState';
 
+interface AddMovieInput {
+  tmdbId: number;
+}
+
+interface AddMovieResponse {
+  data: { id: number; title: string };
+  created: boolean;
+  message?: string;
+}
+
+interface AddTvShowInput {
+  tvdbId: number;
+}
+
+interface AddTvShowResponse {
+  data: { show: { id: number; name: string } };
+  created: boolean;
+  message?: string;
+}
+
+interface WatchlistAddInput {
+  mediaType: 'movie';
+  mediaId: number;
+}
+
+interface WatchHistoryLogInput {
+  mediaType: 'movie';
+  mediaId: number;
+}
+
 /**
  * Encapsulates "Add to library" mutations for movies and TV shows, plus
  * compound flows ("watchlist + library", "watched + library") and the
@@ -17,10 +47,22 @@ import { useSearchAddState } from './useSearchAddState';
  */
 export function useSearchAddActions() {
   const state = useSearchAddState();
-  const addMovieMutation = trpc.media.library.addMovie.useMutation();
-  const addTvShowMutation = trpc.media.library.addTvShow.useMutation();
-  const watchlistAddMutation = trpc.media.watchlist.add.useMutation();
-  const watchHistoryLogMutation = trpc.media.watchHistory.log.useMutation();
+  const addMovieMutation = usePillarMutation<AddMovieInput, AddMovieResponse>('media', [
+    'library',
+    'addMovie',
+  ]);
+  const addTvShowMutation = usePillarMutation<AddTvShowInput, AddTvShowResponse>('media', [
+    'library',
+    'addTvShow',
+  ]);
+  const watchlistAddMutation = usePillarMutation<WatchlistAddInput, unknown>('media', [
+    'watchlist',
+    'add',
+  ]);
+  const watchHistoryLogMutation = usePillarMutation<WatchHistoryLogInput, unknown>('media', [
+    'watchHistory',
+    'log',
+  ]);
 
   const handlerArgs = {
     state,

--- a/packages/app-media/src/pages/search/useSearchAddHandlers.ts
+++ b/packages/app-media/src/pages/search/useSearchAddHandlers.ts
@@ -1,19 +1,49 @@
 import { useCallback } from 'react';
 import { toast } from 'sonner';
 
-import type { trpc } from '@pops/api-client';
+import type { UsePillarMutationResult } from '@pops/pillar-sdk/react';
 
 import type { SearchResultType } from '../../components/SearchResultCard';
 import type { useSearchAddState } from './useSearchAddState';
 
 export const makeKey = (type: SearchResultType, id: number) => `${type}:${id}`;
 
+interface AddMovieInput {
+  tmdbId: number;
+}
+
+interface AddMovieResponse {
+  data: { id: number; title: string };
+  created: boolean;
+  message?: string;
+}
+
+interface AddTvShowInput {
+  tvdbId: number;
+}
+
+interface AddTvShowResponse {
+  data: { show: { id: number; name: string } };
+  created: boolean;
+  message?: string;
+}
+
+interface WatchlistAddInput {
+  mediaType: 'movie';
+  mediaId: number;
+}
+
+interface WatchHistoryLogInput {
+  mediaType: 'movie';
+  mediaId: number;
+}
+
 interface HandlerArgs {
   state: ReturnType<typeof useSearchAddState>;
-  addMovieMutation: ReturnType<typeof trpc.media.library.addMovie.useMutation>;
-  addTvShowMutation: ReturnType<typeof trpc.media.library.addTvShow.useMutation>;
-  watchlistAddMutation: ReturnType<typeof trpc.media.watchlist.add.useMutation>;
-  watchHistoryLogMutation: ReturnType<typeof trpc.media.watchHistory.log.useMutation>;
+  addMovieMutation: UsePillarMutationResult<AddMovieInput, AddMovieResponse>;
+  addTvShowMutation: UsePillarMutationResult<AddTvShowInput, AddTvShowResponse>;
+  watchlistAddMutation: UsePillarMutationResult<WatchlistAddInput, unknown>;
+  watchHistoryLogMutation: UsePillarMutationResult<WatchHistoryLogInput, unknown>;
 }
 
 export function useAddMovieHandler({ state, addMovieMutation }: HandlerArgs) {
@@ -29,7 +59,7 @@ export function useAddMovieHandler({ state, addMovieMutation }: HandlerArgs) {
             state.setSessionMovieLocalIds((prev) => new Map(prev).set(tmdbId, result.data.id));
             toast.success('Movie added to library');
           },
-          onError: (err: { message: string }) => toast.error(`Failed to add movie: ${err.message}`),
+          onError: (err) => toast.error(`Failed to add movie: ${err.message}`),
           onSettled: () => state.removeAdding(key),
         }
       );
@@ -51,8 +81,7 @@ export function useAddTvShowHandler({ state, addTvShowMutation }: HandlerArgs) {
             state.setSessionTvLocalIds((prev) => new Map(prev).set(tvdbId, result.data.show.id));
             toast.success('TV show added to library');
           },
-          onError: (err: { message: string }) =>
-            toast.error(`Failed to add TV show: ${err.message}`),
+          onError: (err) => toast.error(`Failed to add TV show: ${err.message}`),
           onSettled: () => state.removeAdding(key),
         }
       );
@@ -82,13 +111,13 @@ export function useAddToWatchlistAndLibraryHandler({
               { mediaType: 'movie', mediaId: movieId },
               {
                 onSuccess: () => toast.success('Added to watchlist and library'),
-                onError: (err: { message: string }) =>
+                onError: (err) =>
                   toast.error(`Movie added to library but watchlist failed: ${err.message}`),
                 onSettled: () => state.removeFromSet(state.setAddingToWatchlistIds, tmdbId),
               }
             );
           },
-          onError: (err: { message: string }) => {
+          onError: (err) => {
             toast.error(`Failed to add movie: ${err.message}`);
             state.removeFromSet(state.setAddingToWatchlistIds, tmdbId);
           },
@@ -121,13 +150,13 @@ export function useMarkWatchedAndLibraryHandler({
               { mediaType: 'movie', mediaId: movieId },
               {
                 onSuccess: () => toast.success('Marked as watched and added to library'),
-                onError: (err: { message: string }) =>
+                onError: (err) =>
                   toast.error(`Movie added to library but watch log failed: ${err.message}`),
                 onSettled: () => state.removeFromSet(state.setMarkingWatchedTmdbIds, tmdbId),
               }
             );
           },
-          onError: (err: { message: string }) => {
+          onError: (err) => {
             toast.error(`Failed to add movie: ${err.message}`);
             state.removeFromSet(state.setMarkingWatchedTmdbIds, tmdbId);
           },
@@ -147,7 +176,7 @@ export function useMarkWatchedHandler({ state, watchHistoryLogMutation }: Handle
         { mediaType: 'movie', mediaId },
         {
           onSuccess: () => toast.success('Marked as watched'),
-          onError: (err: { message: string }) => toast.error(`Failed to log watch: ${err.message}`),
+          onError: (err) => toast.error(`Failed to log watch: ${err.message}`),
           onSettled: () => state.removeFromSet(state.setMarkingWatchedMediaIds, mediaId),
         }
       );

--- a/packages/app-media/src/pages/tier-list/useTierListMutations.ts
+++ b/packages/app-media/src/pages/tier-list/useTierListMutations.ts
@@ -1,9 +1,22 @@
 import { useCallback, useState } from 'react';
 import { toast } from 'sonner';
 
-import { trpc } from '@pops/api-client';
+import { usePillarMutation, usePillarUtils } from '@pops/pillar-sdk/react';
 
 import type { TierMovie } from '../../components/TierListBoard';
+
+interface MediaVars {
+  mediaType: 'movie';
+  mediaId: number;
+}
+
+interface MarkStaleResponse {
+  data: { staleness: number };
+}
+
+interface ExcludeFromDimensionInput extends MediaVars {
+  dimensionId: number;
+}
 
 function useStaleAndNa({
   movies,
@@ -14,18 +27,19 @@ function useStaleAndNa({
   effectiveDimension: number | null;
   refetch: () => void;
 }) {
-  const markStaleMutation = trpc.media.comparisons.markStale.useMutation({
-    onSuccess: (
-      data: { data: { staleness: number } },
-      variables: { mediaType: string; mediaId: number }
-    ) => {
-      const movie = movies.find((m) => m.mediaId === variables.mediaId);
-      const staleness = data.data.staleness;
-      const timesMarked = Math.round(Math.log(staleness) / Math.log(0.5));
-      toast.success(`${movie?.title ?? 'Movie'} marked stale (×${timesMarked})`);
-      refetch();
-    },
-  });
+  const markStaleMutation = usePillarMutation<MediaVars, MarkStaleResponse>(
+    'media',
+    ['comparisons', 'markStale'],
+    {
+      onSuccess: (data, variables) => {
+        const movie = movies.find((m) => m.mediaId === variables.mediaId);
+        const staleness = data.data.staleness;
+        const timesMarked = Math.round(Math.log(staleness) / Math.log(0.5));
+        toast.success(`${movie?.title ?? 'Movie'} marked stale (×${timesMarked})`);
+        refetch();
+      },
+    }
+  );
 
   const handleMarkStale = useCallback(
     (movieId: number) => {
@@ -35,9 +49,13 @@ function useStaleAndNa({
     [markStaleMutation]
   );
 
-  const excludeMutation = trpc.media.comparisons.excludeFromDimension.useMutation({
-    onSuccess: () => refetch(),
-  });
+  const excludeMutation = usePillarMutation<ExcludeFromDimensionInput, unknown>(
+    'media',
+    ['comparisons', 'excludeFromDimension'],
+    {
+      onSuccess: () => refetch(),
+    }
+  );
 
   const handleNA = useCallback(
     (movieId: number) => {
@@ -59,20 +77,24 @@ function useStaleAndNa({
 }
 
 function useBlacklistFlow({ movies, refetch }: { movies: TierMovie[]; refetch: () => void }) {
-  const utils = trpc.useUtils();
+  const utils = usePillarUtils('media');
   const [blacklistTarget, setBlacklistTarget] = useState<{ id: number; title: string } | null>(
     null
   );
 
-  const blacklistMutation = trpc.media.comparisons.blacklistMovie.useMutation({
-    onSuccess: (_data: unknown, variables: { mediaType: string; mediaId: number }) => {
-      const movie = movies.find((m) => m.mediaId === variables.mediaId);
-      toast.success(`${movie?.title ?? 'Movie'} marked as not watched`);
-      setBlacklistTarget(null);
-      refetch();
-      void utils.media.comparisons.getSmartPair.invalidate();
-    },
-  });
+  const blacklistMutation = usePillarMutation<MediaVars, unknown>(
+    'media',
+    ['comparisons', 'blacklistMovie'],
+    {
+      onSuccess: (_data, variables) => {
+        const movie = movies.find((m) => m.mediaId === variables.mediaId);
+        toast.success(`${movie?.title ?? 'Movie'} marked as not watched`);
+        setBlacklistTarget(null);
+        refetch();
+        void utils.invalidate(['comparisons', 'getSmartPair']);
+      },
+    }
+  );
 
   const handleNotWatched = useCallback(
     (movieId: number) => {

--- a/packages/app-media/src/pages/tier-list/useTierListPageModel.ts
+++ b/packages/app-media/src/pages/tier-list/useTierListPageModel.ts
@@ -2,7 +2,7 @@ import { useCallback, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router';
 import { toast } from 'sonner';
 
-import { trpc } from '@pops/api-client';
+import { usePillarMutation, usePillarQuery, usePillarUtils } from '@pops/pillar-sdk/react';
 
 import { type Tier, type TierMovie } from '../../components/TierListBoard';
 import { useTierListSubmit } from '../../hooks/useTierListSubmit';
@@ -13,20 +13,54 @@ interface CreateDimensionInput {
   description: string | null;
 }
 
+interface DimensionRow {
+  id: number;
+  name: string;
+  description: string | null;
+  active: boolean;
+  sortOrder: number;
+}
+
+interface ListDimensionsResponse {
+  data: DimensionRow[];
+}
+
+interface TierMovieRow {
+  id: number;
+  title: string;
+  posterUrl: string | null;
+  score: number;
+  comparisonCount: number;
+  tierOverride: string | null;
+}
+
+interface TierListMoviesResponse {
+  data: TierMovieRow[];
+}
+
+interface CreateDimensionResponse {
+  data: { id: number };
+}
+
 function useDimensionsAndMovies() {
   const [selectedDimension, setSelectedDimension] = useState<number | null>(null);
 
-  const { data: dimensionsData, isLoading: dimsLoading } =
-    trpc.media.comparisons.listDimensions.useQuery();
+  const { data: dimensionsData, isLoading: dimsLoading } = usePillarQuery<ListDimensionsResponse>(
+    'media',
+    ['comparisons', 'listDimensions'],
+    undefined
+  );
 
   const activeDimensions = useMemo(
-    () => (dimensionsData?.data ?? []).filter((d: { active: boolean }) => d.active),
+    () => (dimensionsData?.data ?? []).filter((d) => d.active),
     [dimensionsData?.data]
   );
 
   const effectiveDimension = selectedDimension ?? activeDimensions[0]?.id ?? null;
 
-  const tierMoviesQuery = trpc.media.comparisons.getTierListMovies.useQuery(
+  const tierMoviesQuery = usePillarQuery<TierListMoviesResponse>(
+    'media',
+    ['comparisons', 'getTierListMovies'],
     { dimensionId: effectiveDimension ?? 0 },
     { enabled: effectiveDimension != null, staleTime: Infinity }
   );
@@ -56,6 +90,12 @@ function useDimensionsAndMovies() {
   };
 }
 
+interface CreateDimensionMutationInput {
+  name: string;
+  description: string | null;
+  active: boolean;
+}
+
 /**
  * Wires the `createDimension` mutation, dialog open state, and post-create
  * book-keeping. On success: invalidate `listDimensions`, select the new
@@ -65,10 +105,13 @@ function useCreateDimension(args: {
   setSelectedDimension: (id: number) => void;
   setDialogOpen: (open: boolean) => void;
 }) {
-  const utils = trpc.useUtils();
-  const createDimensionMutation = trpc.media.comparisons.createDimension.useMutation({
+  const utils = usePillarUtils('media');
+  const createDimensionMutation = usePillarMutation<
+    CreateDimensionMutationInput,
+    CreateDimensionResponse
+  >('media', ['comparisons', 'createDimension'], {
     onSuccess: (result) => {
-      void utils.media.comparisons.listDimensions.invalidate();
+      void utils.invalidate(['comparisons', 'listDimensions']);
       const newId = result?.data?.id;
       if (typeof newId === 'number') args.setSelectedDimension(newId);
       args.setDialogOpen(false);

--- a/packages/app-media/src/pages/watchlist/WatchlistPlexSyncButton.test.tsx
+++ b/packages/app-media/src/pages/watchlist/WatchlistPlexSyncButton.test.tsx
@@ -31,16 +31,11 @@ vi.mock('@pops/pillar-sdk/react', () => ({
     }
     return { mutate: vi.fn(), isPending: false };
   },
-}));
-
-vi.mock('@pops/api-client', () => ({
-  trpc: {
-    useUtils: () => ({
-      media: {
-        watchlist: { list: { invalidate: mockInvalidateWatchlist } },
-      },
-    }),
-  },
+  usePillarUtils: () => ({
+    setData: vi.fn(),
+    invalidate: mockInvalidateWatchlist,
+    fetchQuery: vi.fn(),
+  }),
 }));
 
 const mockToastSuccess = vi.fn();

--- a/packages/app-media/src/pages/watchlist/WatchlistPlexSyncButton.tsx
+++ b/packages/app-media/src/pages/watchlist/WatchlistPlexSyncButton.tsx
@@ -13,13 +13,13 @@
 import { Loader2, RefreshCw } from 'lucide-react';
 import { useEffect, useRef } from 'react';
 
-import { trpc } from '@pops/api-client';
+import { usePillarUtils } from '@pops/pillar-sdk/react';
 import { Button } from '@pops/ui';
 
 import { useSyncJob } from '../../hooks/useSyncJob';
 
 export function WatchlistPlexSyncButton() {
-  const utils = trpc.useUtils();
+  const utils = usePillarUtils('media');
   const sync = useSyncJob('plexSyncWatchlist');
   const previousStatusRef = useRef(sync.status);
 
@@ -30,7 +30,7 @@ export function WatchlistPlexSyncButton() {
   // history.
   useEffect(() => {
     if (previousStatusRef.current === 'running' && sync.status === 'completed') {
-      void utils.media.watchlist.list.invalidate();
+      void utils.invalidate(['watchlist', 'list']);
     }
     previousStatusRef.current = sync.status;
   }, [sync.status, utils]);

--- a/packages/app-media/src/pages/watchlist/useWatchlistMutations.ts
+++ b/packages/app-media/src/pages/watchlist/useWatchlistMutations.ts
@@ -1,7 +1,9 @@
 import { useState } from 'react';
 import { toast } from 'sonner';
 
-import { trpc } from '@pops/api-client';
+import { usePillarMutation, usePillarUtils } from '@pops/pillar-sdk/react';
+
+import type { UsePillarUtilsResult } from '@pops/pillar-sdk/react';
 
 import type { WatchlistEntry } from './types';
 
@@ -10,50 +12,77 @@ interface MutationsArgs {
   setOptimisticOrder: (v: WatchlistEntry[] | null) => void;
 }
 
-export function useWatchlistMutations({ setIsReordering, setOptimisticOrder }: MutationsArgs) {
-  const utils = trpc.useUtils();
-  const [removingId, setRemovingId] = useState<number | null>(null);
-  const [updateErrorId, setUpdateErrorId] = useState<number | null>(null);
-  const [updateErrorMsg, setUpdateErrorMsg] = useState<string | null>(null);
+interface RemoveInput {
+  id: number;
+}
 
-  const removeMutation = trpc.media.watchlist.remove.useMutation({
+interface UpdateInput {
+  id: number;
+  data: { notes: string | null };
+}
+
+interface ReorderInput {
+  items: Array<{ id: number; priority: number }>;
+}
+
+function useRemoveMutation(utils: UsePillarUtilsResult, setRemovingId: (v: number | null) => void) {
+  return usePillarMutation<RemoveInput, unknown>('media', ['watchlist', 'remove'], {
     onSuccess: () => {
       setRemovingId(null);
       toast.success('Removed from watchlist');
-      void utils.media.watchlist.list.invalidate();
+      void utils.invalidate(['watchlist', 'list']);
     },
-    onError: (err: { message: string }) => {
+    onError: (err) => {
       setRemovingId(null);
       toast.error(`Failed to remove: ${err.message}`);
     },
   });
+}
 
-  const updateMutation = trpc.media.watchlist.update.useMutation({
+function useUpdateMutation(
+  utils: UsePillarUtilsResult,
+  setUpdateErrorId: (v: number | null) => void,
+  setUpdateErrorMsg: (v: string | null) => void
+) {
+  return usePillarMutation<UpdateInput, unknown>('media', ['watchlist', 'update'], {
     onSuccess: () => {
       setUpdateErrorId(null);
       setUpdateErrorMsg(null);
       toast.success('Notes saved');
-      void utils.media.watchlist.list.invalidate();
+      void utils.invalidate(['watchlist', 'list']);
     },
-    onError: (error: { message: string }) => {
+    onError: (error) => {
       setUpdateErrorMsg(error.message ?? 'Failed to save notes');
       toast.error(`Failed to save notes: ${error.message}`);
     },
   });
+}
 
-  const reorderMutation = trpc.media.watchlist.reorder.useMutation({
+function useReorderMutation(utils: UsePillarUtilsResult, args: MutationsArgs) {
+  return usePillarMutation<ReorderInput, unknown>('media', ['watchlist', 'reorder'], {
     onSuccess: () => {
-      setOptimisticOrder(null);
-      void utils.media.watchlist.list.invalidate();
+      args.setOptimisticOrder(null);
+      void utils.invalidate(['watchlist', 'list']);
     },
-    onError: (err: { message: string }) => {
-      setOptimisticOrder(null);
+    onError: (err) => {
+      args.setOptimisticOrder(null);
       toast.error(`Failed to reorder: ${err.message}`);
     },
     onSettled: () => {
-      setIsReordering(false);
+      args.setIsReordering(false);
     },
   });
+}
+
+export function useWatchlistMutations(args: MutationsArgs) {
+  const utils = usePillarUtils('media');
+  const [removingId, setRemovingId] = useState<number | null>(null);
+  const [updateErrorId, setUpdateErrorId] = useState<number | null>(null);
+  const [updateErrorMsg, setUpdateErrorMsg] = useState<string | null>(null);
+
+  const removeMutation = useRemoveMutation(utils, setRemovingId);
+  const updateMutation = useUpdateMutation(utils, setUpdateErrorId, setUpdateErrorMsg);
+  const reorderMutation = useReorderMutation(utils, args);
 
   return {
     removeMutation,

--- a/packages/app-media/src/pages/watchlist/useWatchlistPageModel.ts
+++ b/packages/app-media/src/pages/watchlist/useWatchlistPageModel.ts
@@ -1,12 +1,40 @@
 import { useCallback, useState } from 'react';
 import { useSearchParams } from 'react-router';
 
-import { trpc } from '@pops/api-client';
+import { usePillarQuery } from '@pops/pillar-sdk/react';
 
 import { parseTypeParam, type WatchlistEntry, type WatchlistFilter } from './types';
 import { useWatchlistDnd } from './useWatchlistDnd';
 import { useWatchlistMediaMaps } from './useWatchlistMediaMaps';
 import { useWatchlistMutations } from './useWatchlistMutations';
+
+interface WatchlistListResponse {
+  data: WatchlistEntry[];
+}
+
+interface MovieRow {
+  id: number;
+  title: string;
+  releaseDate: string | null;
+  posterUrl: string | null;
+  rotationStatus?: 'leaving' | 'protected' | null;
+  rotationExpiresAt?: string | null;
+}
+
+interface TvRow {
+  id: number;
+  name: string;
+  firstAirDate: string | null;
+  posterUrl: string | null;
+}
+
+interface MoviesListResponse {
+  data: MovieRow[];
+}
+
+interface TvShowsListResponse {
+  data: TvRow[];
+}
 
 function useFilterState() {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -25,16 +53,20 @@ function useWatchlistData(filter: WatchlistFilter) {
     data: watchlistData,
     isLoading,
     error: watchlistError,
-  } = trpc.media.watchlist.list.useQuery({
+  } = usePillarQuery<WatchlistListResponse>('media', ['watchlist', 'list'], {
     ...(filter !== 'all' ? { mediaType: filter } : {}),
     limit: 500,
   });
-  const { data: moviesData, isLoading: moviesLoading } = trpc.media.movies.list.useQuery({
-    limit: 500,
-  });
-  const { data: tvShowsData, isLoading: tvShowsLoading } = trpc.media.tvShows.list.useQuery({
-    limit: 500,
-  });
+  const { data: moviesData, isLoading: moviesLoading } = usePillarQuery<MoviesListResponse>(
+    'media',
+    ['movies', 'list'],
+    { limit: 500 }
+  );
+  const { data: tvShowsData, isLoading: tvShowsLoading } = usePillarQuery<TvShowsListResponse>(
+    'media',
+    ['tvShows', 'list'],
+    { limit: 500 }
+  );
   return {
     watchlistData,
     isLoading,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1691,9 +1691,6 @@ importers:
       '@dnd-kit/utilities':
         specifier: ^3.2.2
         version: 3.2.2(react@19.2.7)
-      '@pops/api-client':
-        specifier: workspace:*
-        version: link:../api-client
       '@pops/navigation':
         specifier: workspace:*
         version: link:../navigation


### PR DESCRIPTION
## Summary

- Swaps the remaining 19 `@pops/api-client` sites in `packages/app-media/src` for `usePillarQuery` / `usePillarMutation` / `usePillarUtils` (`@pops/pillar-sdk/react`) — covers tier-list, watchlist, movie-detail, search add actions, shelf pagination, discover card actions, and the plex sync button.
- After this batch the package has zero `@pops/api-client` imports, so the dependency is dropped from `packages/app-media/package.json`.
- `MovieDetailPage.tsx` switches `error.data?.code === 'NOT_FOUND'` to `isNotFound(error)` from `@pops/pillar-sdk/client`.

## Slice (12 source files)

- `components/shelf-section/useShelfPagination.ts` (discovery.getShelfPage via `usePillarUtils.fetchQuery`)
- `hooks/discover-actions/handlers.ts` (watchlist/comparisons invalidations + watchlist.status fetch)
- `hooks/useDiscoverCardActions.ts` (`trpc.useUtils()` → `usePillarUtils('media')`)
- `hooks/useTierListSubmit.ts` (`comparisons.submitTierList`)
- `pages/MovieDetailPage.tsx` (`isNotFound` from `@pops/pillar-sdk/client`)
- `pages/movie-detail/useMovieDetailModel.ts` (movies.get / watchHistory.list / comparisons.getStaleness / comparisons.getPendingDebriefs)
- `pages/search/useSearchAddActions.ts` (library.addMovie / library.addTvShow / watchlist.add / watchHistory.log)
- `pages/search/useSearchAddHandlers.ts` (mutation type plumbing)
- `pages/tier-list/useTierListMutations.ts` (markStale / excludeFromDimension / blacklistMovie)
- `pages/tier-list/useTierListPageModel.ts` (listDimensions / getTierListMovies / createDimension)
- `pages/watchlist/WatchlistPlexSyncButton.tsx` (`utils.invalidate(['watchlist','list'])`)
- `pages/watchlist/useWatchlistMutations.ts` (remove / update / reorder)
- `pages/watchlist/useWatchlistPageModel.ts` (watchlist.list / movies.list / tvShows.list)

## Tests

7 test files updated to dispatch by path on `usePillarQuery` / `usePillarMutation` / `usePillarUtils`:

- `components/ShelfSection.test.tsx`
- `pages/LibraryPage.test.tsx` (dead `@pops/api-client` mock removed; source already pillar)
- `pages/MovieDetailPage.test.tsx` (errors now built with real `PillarCallError`)
- `pages/SearchPage.test.tsx`
- `pages/TierListPage.test.tsx`
- `pages/WatchlistPage.test.tsx`
- `pages/watchlist/WatchlistPlexSyncButton.test.tsx`

## Cumulative

- Cumulative migrated post-#3178: ~135/151 → **final** with this batch (+19 sites).
- `@pops/api-client` import count in `packages/app-media/src`: **0**.
- `@pops/api-client` dropped from `packages/app-media/package.json`: **yes**.

## Test plan

- [x] `pnpm --filter @pops/app-media test` — 41 files / 698 tests pass
- [x] `pnpm typecheck` — clean across the workspace
- [x] `pnpm install` lockfile regenerated; pre-commit (oxlint + oxfmt) clean

## References

- Prior batches: #3128, #3141, #3145, #3156, #3164, #3169, #3174, #3178
- SDK affordances used: `fetchQuery` (#3166), `usePillarUtils` invalidate prefix