### PR TITLE
docs(theme-13): Wave 5 handler state audit — food + lists rows

### DIFF
--- a/docs/themes/13-pillar-finale/notes/wave-5-handler-state-audit.md
+++ b/docs/themes/13-pillar-finale/notes/wave-5-handler-state-audit.md
@@ -75,14 +75,14 @@ Raw `getDrizzle()` references under `apps/pops-api/src/modules/inventory/`: **0*
 
 Breakdown:
 
-| Category                              | Count | Notes                                                                                                                                                                                                                        |
-| ------------------------------------- | ----- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Handler-real callers                  | 0     | Every production handler under `inventory/{items,locations,connections,documents,document-files,fixtures,photos,reports,paperless}` already resolves via `getInventoryDrizzle()` from `../../../db/inventory-handle.js`.     |
-| Documented intentional pins           | 0     | No inline JSDoc cross-pillar-pin rationale found.                                                                                                                                                                            |
-| Shared-only schema pins               | 0     | No reads/writes against shared-only tables. Every table consumed by inventory services is exposed by `@pops/inventory-db`.                                                                                                   |
-| JSDoc-only comment lines              | 0     | The JSDoc in `connections/service.ts`, `documents/service.ts`, `items/service.ts`, and `__integration__/inventory-handle-coverage.test.ts` references `getInventoryDrizzle()` (the pillar handle), not the shared handle.    |
-| Test-mock callers                     | 0     | No `vi.mock('.../db.js', () => ({ getDrizzle: ... }))` shapes under `inventory/`.                                                                                                                                            |
-| **Real handler migration candidates** | **0** | Pillar cutover is complete; no follow-up flips required.                                                                                                                                                                     |
+| Category                              | Count | Notes                                                                                                                                                                                                                     |
+| ------------------------------------- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Handler-real callers                  | 0     | Every production handler under `inventory/{items,locations,connections,documents,document-files,fixtures,photos,reports,paperless}` already resolves via `getInventoryDrizzle()` from `../../../db/inventory-handle.js`.  |
+| Documented intentional pins           | 0     | No inline JSDoc cross-pillar-pin rationale found.                                                                                                                                                                         |
+| Shared-only schema pins               | 0     | No reads/writes against shared-only tables. Every table consumed by inventory services is exposed by `@pops/inventory-db`.                                                                                                |
+| JSDoc-only comment lines              | 0     | The JSDoc in `connections/service.ts`, `documents/service.ts`, `items/service.ts`, and `__integration__/inventory-handle-coverage.test.ts` references `getInventoryDrizzle()` (the pillar handle), not the shared handle. |
+| Test-mock callers                     | 0     | No `vi.mock('.../db.js', () => ({ getDrizzle: ... }))` shapes under `inventory/`.                                                                                                                                         |
+| **Real handler migration candidates** | **0** | Pillar cutover is complete; no follow-up flips required.                                                                                                                                                                  |
 
 The only `apps/pops-api/src/db.js` reference inside the inventory tree
 is `__integration__/inventory-handle-coverage.test.ts` importing
@@ -91,6 +91,44 @@ harness — these are lifecycle helpers, not `getDrizzle()` callers.
 
 **Count delta: 0 → 0** (audit-doc row only; no code changes shipped on
 this branch).
+
+### Food (this branch — `docs/theme-13-wave5-food-lists-audit`)
+
+Raw `getDrizzle()` references under `apps/pops-api/src/modules/food/`: **183**.
+
+Production-side breakdown (test-side counted separately below):
+
+| Category                                         | Count | Notes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| ------------------------------------------------ | ----- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| JSDoc-only comment lines                         | 2     | `routers/slugs.ts:30` (cross-DB partition rationale) and `routers/ingest-router.ts:52` (return-type comment on the `foodDb` alias).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| Documented intentional pins (mixed-DB)           | 1     | `routers/slugs.ts:48` — `slugSearchService.searchSlugs(getDrizzle(), …)` is the legacy half of the `searchSlugsAcrossPillars` partition that pairs with `getFoodDrizzle()` on line 57. The `kind in ('ingredient','recipe')` rows still live in shared `pops.db`; flipping requires the per-table PR4 cutover for ingredients + recipes to ship first.                                                                                                                                                                                                                                                                                                   |
+| Shared-only schema pins (awaiting per-table PR4) | 89    | Every other production hit. Touches tables not yet re-exported from `@pops/food-db` (only `prepStates`, `ingredients`, `ingredient_variants`, `ingredient_aliases`, `slug_registry` exist in the food-db migration journal; only `prepStates` is exposed via the barrel). Routers affected: `recipes` (13), `ingredients` (9), `inbox` (9), `conversions` (9), `substitutions` (7), `aliases` (7), `plan/router` (7), `batches` (7), `ingredient-tags` (4), `plan/slot-procedures` (4), `variants` (3), `hero-image/service` (3), `shopping/router` (2), `fridge/router` (2), `cook/router` (2), `solver/router` (1), `routers/ingest-router.ts:55` (1). |
+| Test-side direct callers (not `vi.mock` shapes)  | 91    | 15 files under `__tests__/`. Food tests don't `vi.mock` the db module — they exercise routers against the in-memory shared DB seeded by `setupTestContext()`, calling `getDrizzle()` directly for setup/assert. Each fixture suite is a candidate for the "verify-side handle hygiene" follow-up PR when the matching table's PR4 cutover ships.                                                                                                                                                                                                                                                                                                         |
+| **Real handler migration candidates**            | **0** | The food pillar has only completed PR4 for `prep_states` (commit 3439c8d3) + the `kind='prep_state'` slice of `slug_registry`. Every other food-owned table (recipes, batches, plan, substitutions, aliases, conversions, inbox, cook, fridge, shopping, hero-image, solver, variants, ingredient-tags, ingredients) is still write-pinned to shared `pops.db`. Flipping any of them without its per-table backfill PR would silently lose writes in production.                                                                                                                                                                                         |
+
+**Count delta: 183 → 183** (audit-doc row only; no code changes shipped on
+this branch). The 92 production lines are not migration candidates today;
+they unblock incrementally as each food sub-slice's PR4 (backfill + barrel +
+shared drop) ships, on the same pattern as `prep_states` already did.
+
+### Lists (this branch — `docs/theme-13-wave5-food-lists-audit`)
+
+Raw `getDrizzle()` references under `apps/pops-api/src/modules/lists/`: **3**.
+
+| Category                              | Count | Notes                                                                                                                                                                                         |
+| ------------------------------------- | ----- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| JSDoc-only comment lines              | 3     | `routers/items.ts:20`, `routers/list.ts:17`, `__tests__/lists-router.test.ts:59`. All three reference the legacy `getDrizzle()` core handle in prose explaining that the cutover is complete. |
+| Documented intentional pins           | 0     | None — every production read/write resolves through `getListsDrizzle()`.                                                                                                                      |
+| Shared-only schema pins               | 0     | `lists` + `list_items` are owned end-to-end by `@pops/lists-db` (migration 0062, package-local journal).                                                                                      |
+| Test-mock callers                     | 0     | No `vi.mock('.../db.js', () => ({ getDrizzle: ... }))` shapes under `lists/`.                                                                                                                 |
+| **Real handler migration candidates** | **0** | Pillar cutover is complete; no follow-up flips required.                                                                                                                                      |
+
+The lists pillar is the cleanest of the five audited so far: every
+production handler already resolves through `getListsDrizzle()`, and the
+only remaining `getDrizzle()` mentions are doc-block prose explaining the
+historical cutover. Matches the inventory pattern from `#3180`.
+
+**Count delta: 3 → 3** (audit-doc row only; no code changes required).
 
 ## Methodology lesson
 
@@ -107,17 +145,24 @@ When sizing future pillar cutovers off `getDrizzle()` grep counts:
    shared-only, the call site cannot move until that table migrates or
    the join is refactored to per-pillar SDK lookups.
 
-Applying this filter to finance, cerebrum, and inventory reduced raw
-counts from 18, 26, and 0 to **0 + 2 + 0 real handler-real-caller
-migrations** across all three pillars. The original "~485 callers"
-Wave 5 sizing is almost certainly inflated by an order of magnitude.
+Applying this filter to finance, cerebrum, inventory, food, and lists
+reduced raw counts from 18, 26, 0, 183, and 3 (total: **230**) to
+**0 + 2 + 0 + 0 + 0 = 2 real handler-real-caller migrations** across
+all five pillars audited. The original "~485 callers" Wave 5 sizing is
+inflated by **two orders of magnitude** against the real
+handler-candidate surface, and even the raw-grep total across the long
+tail does not approach the original estimate. The dominant cost in the
+food pillar is per-table backfill PR4 ships, not handler flips — the
+89 shared-only schema pins each move one-by-one as their underlying
+table migrates into `@pops/food-db` and the shared `pops.db` copy is
+dropped.
 
 ## Recommendation for next audits
 
 Before opening any further Wave 5 migration PR:
 
 1. Re-run the raw grep against the remaining pillars
-   (`core`, `media`, `lists`, `food`, `app-*`).
+   (`core`, `media`, `app-*`).
 2. Bucket every hit into the four categories above (test-mock,
    documented-pin, shared-only schema, real-handler-candidate).
 3. Only the **real-handler-candidate** bucket is in scope for the
@@ -129,18 +174,20 @@ Before opening any further Wave 5 migration PR:
 
 ## What this branch changed
 
-Two real handler-real-caller migrations:
+`docs/theme-13-wave5-food-lists-audit` is documentation-only — both
+food and lists came in with **0 real handler-real-caller migration
+candidates** under the audit rules:
 
-- `apps/pops-api/src/modules/cerebrum/glia/digest-channels.ts:45`
-  — `deliverShellDigest` writes to `nudgeLog` (a table re-exported by
-  `@pops/cerebrum-db`); now resolves via `getCerebrumDrizzle()`.
-- `apps/pops-api/src/modules/cerebrum/retrieval/router.ts:169`
-  — `cerebrum.retrieval.stats` reads `engramIndex` row counts and
-  `embeddings` source-type counts; both tables live in
-  `@pops/cerebrum-db`, so the procedure now resolves via
-  `getCerebrumDrizzle()`.
+- Lists: every production handler is already on `getListsDrizzle()`;
+  the three raw-grep hits are all JSDoc prose referencing the legacy
+  shared handle.
+- Food: only the `prep_states` slice has completed its PR4 cutover.
+  The remaining 89 production-side `getDrizzle()` calls each await
+  their own per-table backfill PR (the same shape as commit
+  `3439c8d3` for prep_states) before they become safely flippable. One
+  documented mixed-DB pin (`routers/slugs.ts:48`) is intentional and
+  unlocks when ingredients + recipes complete their PR4s. Flipping any
+  of these in isolation today would silently lose writes in production.
 
-Both are behaviour-preserving: under `setupTestContext` both handles
-resolve to the same in-memory DB, and in production the cerebrum
-handle owns the same tables on disk via the cerebrum-db schema +
-backfill.
+Prior branches in this audit series shipped two real migrations
+(both on the cerebrum pillar — see the cerebrum section above).


### PR DESCRIPTION
## Summary

- Appends per-pillar findings for the **food** and **lists** pillars to `docs/themes/13-pillar-finale/notes/wave-5-handler-state-audit.md`, extending the audit series begun in #3162 (finance), continued in #3167 (cerebrum), and #3180 (inventory).
- Both pillars come in with **0 real handler-real-caller migration candidates** under the audit rules. No code changes ship on this branch.
- Total across the five pillars audited so far: **230 raw `getDrizzle()` hits → 2 real handler-real-caller migrations**. The original "~485 callers" Wave 5 sizing is inflated by two orders of magnitude.

## Per-pillar buckets

### Food (raw 183)

| Bucket | Count |
| --- | --- |
| JSDoc-only comment lines | 2 |
| Documented mixed-DB pin (`slugs.ts:48`) | 1 |
| Shared-only schema pins (awaiting per-table PR4) | 89 |
| Test-side direct callers (`__tests__/`, not `vi.mock`) | 91 |
| **Real handler migration candidates** | **0** |

Only the `prep_states` slice has completed its PR4 cutover (commit `3439c8d3`). Every other food-owned table (recipes, batches, plan, substitutions, aliases, conversions, inbox, cook, fridge, shopping, hero-image, solver, variants, ingredient-tags, ingredients) is still write-pinned to shared `pops.db`. Flipping any of them in isolation today would silently lose writes in production.

### Lists (raw 3)

| Bucket | Count |
| --- | --- |
| JSDoc-only comment lines | 3 |
| Documented intentional pins | 0 |
| Shared-only schema pins | 0 |
| Test-mock callers | 0 |
| **Real handler migration candidates** | **0** |

Pillar cutover is complete; every production read/write already resolves through `getListsDrizzle()`.

## Rollup after this PR

| Pillar | Raw grep | Real migrations |
| --- | --- | --- |
| Finance | 18 | 0 |
| Cerebrum | 26 | 2 |
| Inventory | 0 | 0 |
| Food | 183 | 0 |
| Lists | 3 | 0 |
| **Total** | **230** | **2** |

## Test plan

- [x] `oxfmt --check` passes on the audit doc
- [x] Husky pre-commit hook passes (oxfmt --write on the markdown)
- [x] Doc-only branch — no code paths touched, no tests required