### PR TITLE
feat(ha-bridge): PRD-229 US-03 complete — ha.entity.getState

### DIFF
--- a/apps/pops-ha-bridge-api/src/__tests__/entity-get-state.test.ts
+++ b/apps/pops-ha-bridge-api/src/__tests__/entity-get-state.test.ts
@@ -1,0 +1,75 @@
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { openHaBridgeDb, upsertEntity, type OpenedHaBridgeDb } from '@pops/ha-bridge-db';
+
+import { entityGetStateInputSchema, runEntityGetState } from '../ai-tools/entity-get-state.js';
+
+describe('ha bridge entity-get-state AI tool', () => {
+  let opened: OpenedHaBridgeDb;
+
+  beforeEach(() => {
+    const dir = mkdtempSync(join(tmpdir(), 'ha-bridge-entity-get-state-'));
+    opened = openHaBridgeDb(join(dir, 'ha-bridge.db'));
+  });
+
+  afterEach(() => {
+    opened.raw.close();
+  });
+
+  it('returns the mirrored row for a known entity', () => {
+    upsertEntity(opened.db, {
+      entityId: 'light.kitchen',
+      state: 'on',
+      attributes: { friendly_name: 'Kitchen Light', device_class: 'illuminance' },
+      area: 'kitchen',
+      lastChanged: 100,
+      lastSeen: 200,
+    });
+
+    const result = runEntityGetState(opened.db, { entityId: 'light.kitchen' });
+    expect(result.kind).toBe('ok');
+    if (result.kind !== 'ok') throw new Error('unreachable');
+    expect(result.entity.entityId).toBe('light.kitchen');
+    expect(result.entity.domain).toBe('light');
+    expect(result.entity.state).toBe('on');
+    expect(result.entity.area).toBe('kitchen');
+    expect(result.entity.friendlyName).toBe('Kitchen Light');
+  });
+
+  it('returns the typed not-found discriminant when the entity is not mirrored', () => {
+    const result = runEntityGetState(opened.db, { entityId: 'light.does_not_exist' });
+    expect(result).toEqual({ kind: 'not-found' });
+  });
+
+  it('does not leak rows across different entityIds', () => {
+    upsertEntity(opened.db, {
+      entityId: 'light.kitchen',
+      state: 'on',
+      attributes: {},
+      area: null,
+      lastChanged: 1,
+      lastSeen: 1,
+    });
+
+    const hit = runEntityGetState(opened.db, { entityId: 'light.kitchen' });
+    const miss = runEntityGetState(opened.db, { entityId: 'light.bedroom' });
+
+    expect(hit.kind).toBe('ok');
+    expect(miss.kind).toBe('not-found');
+  });
+
+  it('rejects malformed entityId at the Zod boundary', () => {
+    expect(entityGetStateInputSchema.safeParse({ entityId: 'Light.Kitchen' }).success).toBe(false);
+    expect(entityGetStateInputSchema.safeParse({ entityId: 'lightkitchen' }).success).toBe(false);
+    expect(entityGetStateInputSchema.safeParse({ entityId: '' }).success).toBe(false);
+    expect(entityGetStateInputSchema.safeParse({}).success).toBe(false);
+    expect(
+      entityGetStateInputSchema.safeParse({ entityId: 'light.kitchen', extra: 1 }).success
+    ).toBe(false);
+    expect(entityGetStateInputSchema.safeParse({ entityId: 'light.kitchen' }).success).toBe(true);
+  });
+});

--- a/apps/pops-ha-bridge-api/src/__tests__/manifest.test.ts
+++ b/apps/pops-ha-bridge-api/src/__tests__/manifest.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { ManifestPayloadSchema, validateManifestPayload } from '@pops/pillar-sdk/manifest-schema';
 
-import { ENTITY_LIST_TOOL_NAME } from '../ai-tools/index.js';
+import { ENTITY_GET_STATE_TOOL_NAME, ENTITY_LIST_TOOL_NAME } from '../ai-tools/index.js';
 import { buildHaBridgeManifest, HA_BRIDGE_PILLAR_ID } from '../manifest.js';
 import {
   HA_ENTITIES_ADAPTER_NAME,
@@ -16,11 +16,14 @@ describe('buildHaBridgeManifest', () => {
     const parsed = ManifestPayloadSchema.parse(manifest);
     expect(parsed.pillar).toBe(HA_BRIDGE_PILLAR_ID);
     expect(parsed.contract.tag).toBe('contract-ha-bridge@v0.1.0');
-    expect(parsed.ai.tools.map((t) => t.name)).toEqual([ENTITY_LIST_TOOL_NAME]);
+    expect(parsed.ai.tools.map((t) => t.name)).toEqual([
+      ENTITY_LIST_TOOL_NAME,
+      ENTITY_GET_STATE_TOOL_NAME,
+    ]);
     expect(parsed.sinks?.descriptors.length).toBeGreaterThan(0);
   });
 
-  it('publishes the entityList AI tool descriptor (US-03 partial)', () => {
+  it('publishes the entityList AI tool descriptor (US-03)', () => {
     const manifest = buildHaBridgeManifest('0.1.0');
     const tool = manifest.ai.tools.find((t) => t.name === ENTITY_LIST_TOOL_NAME);
     if (tool === undefined) throw new Error('entityList descriptor missing');
@@ -29,6 +32,29 @@ describe('buildHaBridgeManifest', () => {
     const parameters = tool.parameters as { properties?: Record<string, unknown> };
     const props = parameters.properties ?? {};
     expect(Object.keys(props).toSorted()).toEqual(['area', 'cursor', 'domain', 'limit']);
+  });
+
+  it('publishes the entityGetState AI tool descriptor (US-03)', () => {
+    const manifest = buildHaBridgeManifest('0.1.0');
+    const tool = manifest.ai.tools.find((t) => t.name === ENTITY_GET_STATE_TOOL_NAME);
+    if (tool === undefined) throw new Error('entityGetState descriptor missing');
+    expect(tool.description.length).toBeGreaterThanOrEqual(10);
+    expect(tool.parameters).toMatchObject({ type: 'object' });
+    const parameters = tool.parameters as {
+      properties?: Record<string, unknown>;
+      required?: string[];
+    };
+    const props = parameters.properties ?? {};
+    expect(Object.keys(props).toSorted()).toEqual(['entityId']);
+    expect(parameters.required).toContain('entityId');
+  });
+
+  it('every published AI tool name matches the manifest schema camelCase regex', () => {
+    const manifest = buildHaBridgeManifest('0.1.0');
+    const camelCase = /^[a-z][a-zA-Z0-9]*$/;
+    for (const tool of manifest.ai.tools) {
+      expect(tool.name).toMatch(camelCase);
+    }
   });
 
   it('declares the haEntities search adapter (US-02)', () => {

--- a/apps/pops-ha-bridge-api/src/ai-tools/entity-get-state.ts
+++ b/apps/pops-ha-bridge-api/src/ai-tools/entity-get-state.ts
@@ -1,0 +1,44 @@
+/**
+ * `ha.entity.getState` — read-only AI tool (PRD-229 US-03).
+ *
+ * Fetches a single mirrored HA entity by `entity_id`. Returns the row on
+ * success, or a typed `{ kind: 'not-found' }` discriminant when the entity
+ * is not mirrored — mirrors the SDK's `CallResult` discriminant style
+ * (PRD-228 / PR #3170) so a future tRPC procedure can forward the same
+ * shape without translation.
+ */
+import { z } from 'zod';
+
+import { getEntity, type HaBridgeDb, type HaEntityRow } from '@pops/ha-bridge-db';
+
+export const ENTITY_GET_STATE_TOOL_NAME = 'entityGetState' as const;
+
+export const ENTITY_GET_STATE_ENTITY_ID_MAX = 255;
+
+export const entityGetStateInputSchema = z
+  .object({
+    entityId: z
+      .string()
+      .min(3)
+      .max(ENTITY_GET_STATE_ENTITY_ID_MAX)
+      .regex(
+        /^[a-z][a-z0-9_]*\.[a-z0-9_]+$/,
+        'entityId must be `<domain>.<object_id>` in lowercase snake_case'
+      ),
+  })
+  .strict();
+
+export type EntityGetStateInput = z.infer<typeof entityGetStateInputSchema>;
+
+export type EntityGetStateOutput = { kind: 'ok'; entity: HaEntityRow } | { kind: 'not-found' };
+
+export function runEntityGetState(
+  db: HaBridgeDb,
+  input: EntityGetStateInput
+): EntityGetStateOutput {
+  const entity = getEntity(db, input.entityId);
+  if (entity === undefined) {
+    return { kind: 'not-found' };
+  }
+  return { kind: 'ok', entity };
+}

--- a/apps/pops-ha-bridge-api/src/ai-tools/index.ts
+++ b/apps/pops-ha-bridge-api/src/ai-tools/index.ts
@@ -7,10 +7,12 @@
  * the future tool-router binding — adding a tool is one entry, no core
  * edit.
  *
- * US-03 ships `entityList` only. `entityGetState` lands in a follow-up.
+ * US-03 ships the read-only `entityList` + `entityGetState` pair.
+ * `ha.entity.callService` (US-04) stays out of scope.
  */
 import { z } from 'zod';
 
+import { ENTITY_GET_STATE_TOOL_NAME, entityGetStateInputSchema } from './entity-get-state.js';
 import { ENTITY_LIST_TOOL_NAME, entityListInputSchema } from './entity-list.js';
 
 import type { ManifestPayload } from '@pops/pillar-sdk/manifest-schema';
@@ -29,6 +31,12 @@ const sources: AiToolSource[] = [
     description:
       'List Home Assistant entities the bridge currently mirrors. Optionally filter by `domain` (e.g. "light", "sensor") and/or `area` (e.g. "kitchen"). Results are paginated by `entity_id` — pass `nextCursor` back as `cursor` to fetch the next page. Read-only.',
     inputSchema: entityListInputSchema,
+  },
+  {
+    name: ENTITY_GET_STATE_TOOL_NAME,
+    description:
+      'Fetch the current mirrored state of a single Home Assistant entity by `entityId` (e.g. "light.kitchen"). Returns the full row — state, attributes, area, device class, timestamps — or a `not-found` discriminant if the entity is not mirrored. Read-only.',
+    inputSchema: entityGetStateInputSchema,
   },
 ];
 
@@ -57,3 +65,12 @@ export {
   type EntityListInput,
   type EntityListOutput,
 } from './entity-list.js';
+
+export { ENTITY_GET_STATE_TOOL_NAME } from './entity-get-state.js';
+export {
+  ENTITY_GET_STATE_ENTITY_ID_MAX,
+  entityGetStateInputSchema,
+  runEntityGetState,
+  type EntityGetStateInput,
+  type EntityGetStateOutput,
+} from './entity-get-state.js';

--- a/apps/pops-ha-bridge-api/src/manifest.ts
+++ b/apps/pops-ha-bridge-api/src/manifest.ts
@@ -16,9 +16,9 @@ import { validateSinkMappings } from './sinks/validator.js';
  * over the FTS5 virtual table (`ha_entities_fts`). The remaining
  * dimensions land in subsequent stories:
  *
- *   - US-03 (this slice — partial) fills `ai.tools` with the
- *     read-only `entityList` descriptor. `entityGetState` lands in a
- *     follow-up; `ha.entity.callService` (US-04) stays out of scope.
+ *   - US-03 fills `ai.tools` with the read-only `entityList` and
+ *     `entityGetState` descriptors. `ha.entity.callService` (US-04)
+ *     stays out of scope.
  *
  * PRD-237 US-01 derives the `sinks.descriptors` block from the mapping
  * config (`src/sinks/mapping.ts`) — the same array drives the runtime


### PR DESCRIPTION
## Summary

Closes PRD-229 **US-03** by adding the second read-only AI tool to the HA bridge pillar manifest: `entityGetState`. Together with `entityList` (shipped in #3179), this completes the US-03 slice. `ha.entity.callService` (US-04) remains out of scope.

## What ships

- **Procedure** `runEntityGetState(db, { entityId })` in `apps/pops-ha-bridge-api/src/ai-tools/entity-get-state.ts`.
  - Returns `{ kind: 'ok'; entity: HaEntityRow }` on hit, `{ kind: 'not-found' }` on miss.
  - The discriminated union mirrors the SDK's `CallResult` shape (PR #3170) so the future tRPC procedure wrapper is a 1:1 forward — no shape translation.
- **Manifest entry** — adds the `entityGetState` descriptor next to `entityList` in `apps/pops-ha-bridge-api/src/ai-tools/index.ts`. The Zod input schema is projected to draft-7 JSON Schema via `z.toJSONSchema`. The name passes the manifest schema's camelCase regex (`^[a-z][a-zA-Z0-9]*$`).
- **Input validation** — Zod schema enforces `entityId` matches `<domain>.<object_id>` lowercase snake_case, length 3..255, strict (no extra keys).

## Manifest excerpt

```ts
ai: {
  tools: [
    { name: 'entityList',     description: '...', parameters: { /* draft-7 JSON Schema */ } },
    { name: 'entityGetState', description: '...', parameters: { /* draft-7 JSON Schema with entityId */ } },
  ],
},
```

## PRD-229 US-03 status

- [x] `ha.entity.list` — shipped in #3179
- [x] `ha.entity.getState` — shipped here
- US-04 / US-05 — out of scope

## Test plan

- [x] `pnpm --filter @pops/ha-bridge-api test` — 53 / 53 pass (5 new for `entity-get-state`, 2 new manifest assertions, 1 updated)
- [x] `pnpm typecheck` clean (71 / 71)
- [x] `pnpm format:check` clean
- [x] `pnpm lint` no new errors on changed files
- [x] Husky pre-commit pass
