### PR TITLE
feat(app-food): migrate 5 deferred sites + drop api-client dep (PRD-227 follow-up to #3163)

### DIFF
--- a/packages/app-food/src/pages/data/conversions-tab/__tests__/WeightsSection.test.tsx
+++ b/packages/app-food/src/pages/data/conversions-tab/__tests__/WeightsSection.test.tsx
@@ -51,12 +51,6 @@ const mockUpdateMutate = vi.fn();
 const mockDeleteMutate = vi.fn();
 let createOpts: MutationOpts = {};
 
-vi.mock('@pops/api-client', () => ({
-  trpc: {
-    useQueries: (builder: unknown) => mockUseQueries(builder),
-  },
-}));
-
 vi.mock('@pops/pillar-sdk/react', () => ({
   usePillarQuery: (_pillarId: string, path: readonly string[], input: unknown, opts: unknown) => {
     const key = path.join('.');
@@ -65,6 +59,8 @@ vi.mock('@pops/pillar-sdk/react', () => ({
     if (key === 'ingredients.get') return mockGetIngredient(input, opts);
     throw new Error(`Unexpected pillar query: ${key}`);
   },
+  usePillarQueries: (args: readonly unknown[]) => mockUseQueries(args),
+  pillarQueryArg: <T,>(arg: T) => arg,
   usePillarMutation: (_pillarId: string, path: readonly string[], opts: MutationOpts) => {
     const key = path.join('.');
     if (key === 'conversions.createWeight') {

--- a/packages/app-food/src/pages/data/conversions-tab/useWeightRowViews.ts
+++ b/packages/app-food/src/pages/data/conversions-tab/useWeightRowViews.ts
@@ -9,10 +9,16 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { trpc } from '@pops/api-client';
+import { pillarQueryArg, usePillarQueries, type PillarQueryArg } from '@pops/pillar-sdk/react';
+
+import type { inferRouterOutputs } from '@trpc/server';
+
+import type { AppRouter } from '@pops/api-client';
 
 import type { IngredientWeightRow } from './types';
 import type { WeightRowView } from './WeightsTable';
+
+type IngredientsGetOutput = inferRouterOutputs<AppRouter>['food']['ingredients']['get'];
 
 interface IngredientLookup {
   byId: Map<number, { name: string; slug: string }>;
@@ -24,18 +30,28 @@ function uniqueIngredientIds(rows: readonly IngredientWeightRow[]): readonly num
   return Array.from(set);
 }
 
+function isIngredientsGetOutput(data: unknown): data is IngredientsGetOutput {
+  if (data === null || typeof data !== 'object') return false;
+  return 'variants' in data && Array.isArray((data as { variants: unknown }).variants);
+}
+
 function useVariantLookup(ingredientIds: readonly number[]): Map<number, string> {
-  // `trpc.useQueries` runs a known-length array in parallel; the array
+  // `usePillarQueries` runs a known-length array in parallel; the array
   // shape is stable across renders (memoised by caller). React Query
   // dedupes identical queries so repeated mounts are free.
-  const queries = trpc.useQueries((tt) =>
-    ingredientIds.map((id) => tt.food.ingredients.get({ idOrSlug: id }))
+  const args: readonly PillarQueryArg<unknown>[] = ingredientIds.map((id) =>
+    pillarQueryArg<unknown>({
+      pillarId: 'food',
+      path: ['ingredients', 'get'],
+      input: { idOrSlug: id },
+    })
   );
+  const queries = usePillarQueries(args);
   return useMemo(() => {
     const map = new Map<number, string>();
     for (const q of queries) {
       const data = q.data;
-      if (data === undefined) continue;
+      if (!isIngredientsGetOutput(data)) continue;
       for (const variant of data.variants) map.set(variant.id, `${variant.name} (${variant.slug})`);
     }
     return map;

--- a/packages/app-food/src/pages/inbox/__tests__/FailedTab.test.tsx
+++ b/packages/app-food/src/pages/inbox/__tests__/FailedTab.test.tsx
@@ -24,14 +24,11 @@ import type { FailedRow } from '../inbox-types';
 const mockListFailed = vi.fn();
 const mockFailedCodes = vi.fn();
 const mockSetData = vi.fn();
-const mockGetData = vi.fn();
-const mockCancel = vi.fn();
 const mockInvalidate = vi.fn();
-const mockInvalidateCodes = vi.fn();
 const mockRetryMutate = vi.fn();
 let mockRetryOpts:
   | {
-      onMutate?: (input: { sourceId: number }) => Promise<{ snapshot: unknown }>;
+      onMutate?: (input: { sourceId: number }) => { snapshot: unknown };
       onError?: (err: Error, input: { sourceId: number }, ctx: { snapshot: unknown }) => void;
       onSuccess?: () => void;
       onSettled?: () => void;
@@ -44,36 +41,29 @@ beforeEach(() => {
   window.HTMLElement.prototype.scrollIntoView = vi.fn();
 });
 
-vi.mock('@pops/api-client', () => ({
-  trpc: {
-    useUtils: () => ({
-      food: {
-        inbox: {
-          listFailed: {
-            cancel: mockCancel,
-            getData: mockGetData,
-            setData: mockSetData,
-            invalidate: mockInvalidate,
-          },
-          failedErrorCodes: { invalidate: mockInvalidateCodes },
-        },
-      },
-    }),
-    food: {
-      inbox: {
-        listFailed: { useQuery: (input: unknown) => mockListFailed(input) },
-        failedErrorCodes: { useQuery: () => mockFailedCodes() },
-      },
-      ingest: {
-        retry: {
-          useMutation: (opts: NonNullable<typeof mockRetryOpts>) => {
-            mockRetryOpts = opts;
-            return { mutate: mockRetryMutate, isPending: false, variables: undefined };
-          },
-        },
-      },
-    },
+vi.mock('@pops/pillar-sdk/react', () => ({
+  usePillarQuery: (_pillarId: string, path: readonly string[], input: unknown) => {
+    const key = path.join('.');
+    if (key === 'inbox.listFailed') return mockListFailed(input);
+    if (key === 'inbox.failedErrorCodes') return mockFailedCodes();
+    throw new Error(`Unexpected pillar query: ${key}`);
   },
+  usePillarMutation: (
+    _pillarId: string,
+    path: readonly string[],
+    opts: NonNullable<typeof mockRetryOpts>
+  ) => {
+    const key = path.join('.');
+    if (key === 'ingest.retry') {
+      mockRetryOpts = opts;
+      return { mutate: mockRetryMutate, isPending: false, variables: undefined };
+    }
+    throw new Error(`Unexpected pillar mutation: ${key}`);
+  },
+  usePillarUtils: () => ({
+    setData: mockSetData,
+    invalidate: mockInvalidate,
+  }),
 }));
 
 import { FailedTab } from '../FailedTab.js';
@@ -165,7 +155,6 @@ describe('FailedTab — PRD-138', () => {
       error: null,
     });
     mockFailedCodes.mockReturnValue({ data: ['InstagramRateLimited'] });
-    mockGetData.mockReturnValue({ items: [makeRow()], nextCursor: null });
     render(
       <Wrapper>
         <FailedTab now={FIXED_NOW} />
@@ -189,7 +178,6 @@ describe('FailedTab — PRD-138', () => {
       error: null,
     });
     mockFailedCodes.mockReturnValue({ data: ['InstagramRateLimited'] });
-    mockGetData.mockReturnValue(snapshot);
     render(
       <Wrapper>
         <FailedTab now={FIXED_NOW} />
@@ -198,7 +186,11 @@ describe('FailedTab — PRD-138', () => {
     const user = userEvent.setup();
     await user.click(screen.getByRole('button', { name: /Retry ingest/i }));
     mockRetryOpts?.onError?.(new Error('queue down'), { sourceId: 100 }, { snapshot });
-    expect(mockSetData).toHaveBeenCalledWith(expect.objectContaining({}), snapshot);
+    expect(mockSetData).toHaveBeenCalledWith(
+      ['inbox', 'listFailed'],
+      expect.objectContaining({}),
+      expect.any(Function)
+    );
     await waitFor(() => {
       expect(screen.getByText(/Couldn’t re-queue: queue down/i)).toBeInTheDocument();
     });

--- a/packages/app-food/src/pages/inbox/__tests__/InboxPage.test.tsx
+++ b/packages/app-food/src/pages/inbox/__tests__/InboxPage.test.tsx
@@ -44,51 +44,18 @@ const mockPendingCount = vi.fn(() => ({
 }));
 const mockFailedErrorCodes = vi.fn(() => ({ data: [], isLoading: false }));
 
-vi.mock('@pops/api-client', () => ({
-  trpc: {
-    useUtils: () => ({
-      food: {
-        inbox: {
-          listRejected: {
-            cancel: vi.fn(),
-            getData: vi.fn(),
-            setData: vi.fn(),
-            invalidate: vi.fn(),
-          },
-          listFailed: {
-            cancel: vi.fn(),
-            getData: vi.fn(),
-            setData: vi.fn(),
-            invalidate: vi.fn(),
-          },
-        },
-      },
-    }),
-    food: {
-      inbox: {
-        listRejected: { useQuery: (i: unknown) => mockListRejected(i) },
-        listFailed: { useQuery: (i: unknown) => mockListFailed(i) },
-        failedErrorCodes: { useQuery: () => mockFailedErrorCodes() },
-        unreject: {
-          useMutation: () => ({ mutate: vi.fn(), isPending: false, variables: undefined }),
-        },
-      },
-      ingest: {
-        retry: {
-          useMutation: () => ({ mutate: vi.fn(), isPending: false, variables: undefined }),
-        },
-      },
-    },
-  },
-}));
-
 vi.mock('@pops/pillar-sdk/react', () => ({
   usePillarQuery: (_pillarId: string, path: readonly string[], input: unknown) => {
     const key = path.join('.');
     if (key === 'inbox.list') return mockListQuery(input);
     if (key === 'inbox.pendingCount') return mockPendingCount();
+    if (key === 'inbox.listRejected') return mockListRejected(input);
+    if (key === 'inbox.listFailed') return mockListFailed(input);
+    if (key === 'inbox.failedErrorCodes') return mockFailedErrorCodes();
     throw new Error(`Unexpected pillar query: ${key}`);
   },
+  usePillarMutation: () => ({ mutate: vi.fn(), isPending: false, variables: undefined }),
+  usePillarUtils: () => ({ setData: vi.fn(), invalidate: vi.fn() }),
 }));
 
 import { InboxPage } from '../InboxPage.js';

--- a/packages/app-food/src/pages/inbox/__tests__/RejectedTab.test.tsx
+++ b/packages/app-food/src/pages/inbox/__tests__/RejectedTab.test.tsx
@@ -23,45 +23,39 @@ import type { RejectedRow } from '../inbox-types';
 
 const mockListRejected = vi.fn();
 const mockSetData = vi.fn();
-const mockGetData = vi.fn();
-const mockCancel = vi.fn();
 const mockInvalidate = vi.fn();
 const mockUnrejectMutate = vi.fn();
 let mockUnrejectOpts:
   | {
-      onMutate?: (input: { versionId: number }) => Promise<{ snapshot: unknown }>;
+      onMutate?: (input: { versionId: number }) => { snapshot: unknown };
       onError?: (err: Error, input: { versionId: number }, ctx: { snapshot: unknown }) => void;
       onSuccess?: (res: { ok: boolean; reason?: string }) => void;
       onSettled?: () => void;
     }
   | undefined;
 
-vi.mock('@pops/api-client', () => ({
-  trpc: {
-    useUtils: () => ({
-      food: {
-        inbox: {
-          listRejected: {
-            cancel: mockCancel,
-            getData: mockGetData,
-            setData: mockSetData,
-            invalidate: mockInvalidate,
-          },
-        },
-      },
-    }),
-    food: {
-      inbox: {
-        listRejected: { useQuery: (input: unknown) => mockListRejected(input) },
-        unreject: {
-          useMutation: (opts: NonNullable<typeof mockUnrejectOpts>) => {
-            mockUnrejectOpts = opts;
-            return { mutate: mockUnrejectMutate, isPending: false, variables: undefined };
-          },
-        },
-      },
-    },
+vi.mock('@pops/pillar-sdk/react', () => ({
+  usePillarQuery: (_pillarId: string, path: readonly string[], input: unknown) => {
+    const key = path.join('.');
+    if (key === 'inbox.listRejected') return mockListRejected(input);
+    throw new Error(`Unexpected pillar query: ${key}`);
   },
+  usePillarMutation: (
+    _pillarId: string,
+    path: readonly string[],
+    opts: NonNullable<typeof mockUnrejectOpts>
+  ) => {
+    const key = path.join('.');
+    if (key === 'inbox.unreject') {
+      mockUnrejectOpts = opts;
+      return { mutate: mockUnrejectMutate, isPending: false, variables: undefined };
+    }
+    throw new Error(`Unexpected pillar mutation: ${key}`);
+  },
+  usePillarUtils: () => ({
+    setData: mockSetData,
+    invalidate: mockInvalidate,
+  }),
 }));
 
 import { RejectedTab } from '../RejectedTab.js';
@@ -154,7 +148,6 @@ describe('RejectedTab — PRD-138', () => {
       isError: false,
       error: null,
     });
-    mockGetData.mockReturnValue({ items: [makeRow()], nextCursor: null });
     render(
       <Wrapper>
         <RejectedTab now={FIXED_NOW} />
@@ -177,7 +170,6 @@ describe('RejectedTab — PRD-138', () => {
       isError: false,
       error: null,
     });
-    mockGetData.mockReturnValue(snapshot);
     render(
       <Wrapper>
         <RejectedTab now={FIXED_NOW} />
@@ -186,7 +178,11 @@ describe('RejectedTab — PRD-138', () => {
     const user = userEvent.setup();
     await user.click(screen.getByRole('button', { name: /Undo rejection/i }));
     mockUnrejectOpts?.onError?.(new Error('boom'), { versionId: 1 }, { snapshot });
-    expect(mockSetData).toHaveBeenCalledWith(expect.objectContaining({}), snapshot);
+    expect(mockSetData).toHaveBeenCalledWith(
+      ['inbox', 'listRejected'],
+      expect.objectContaining({}),
+      expect.any(Function)
+    );
     await waitFor(() => {
       expect(screen.getByText(/Couldn’t undo: boom/i)).toBeInTheDocument();
     });

--- a/packages/app-food/src/pages/inbox/useFailedTab.ts
+++ b/packages/app-food/src/pages/inbox/useFailedTab.ts
@@ -9,39 +9,49 @@
 import { useCallback } from 'react';
 import { toast } from 'sonner';
 
-import { trpc } from '@pops/api-client';
+import { usePillarMutation, usePillarQuery, usePillarUtils } from '@pops/pillar-sdk/react';
 
 import { type FailedFiltersState } from './FailedFilters.js';
 
+import type { inferRouterOutputs } from '@trpc/server';
+
+import type { AppRouter } from '@pops/api-client';
+import type { UsePillarUtilsResult } from '@pops/pillar-sdk/react';
+
+type ListFailedOutput = inferRouterOutputs<AppRouter>['food']['inbox']['listFailed'];
+type FailedErrorCodesOutput = inferRouterOutputs<AppRouter>['food']['inbox']['failedErrorCodes'];
+type RetryOutput = inferRouterOutputs<AppRouter>['food']['ingest']['retry'];
+
+type RetryInput = { sourceId: number };
+type RetryContext = { snapshot: ListFailedOutput | undefined };
+type Translate = (key: string, opts?: Record<string, unknown>) => string;
+type QueryInput = {
+  errorCodes: readonly string[] | undefined;
+  kinds: readonly string[] | undefined;
+  sinceDays: FailedFiltersState['sinceDays'];
+};
+
 interface UseFailedTabOpts {
   filters: FailedFiltersState;
-  t: (key: string, opts?: Record<string, unknown>) => string;
+  t: Translate;
 }
 
-export function useFailedTab({ filters, t }: UseFailedTabOpts) {
-  const utils = trpc.useUtils();
-  const queryInput = {
-    errorCodes: filters.errorCodes.length > 0 ? [...filters.errorCodes] : undefined,
-    kinds: filters.kinds.length > 0 ? [...filters.kinds] : undefined,
-    sinceDays: filters.sinceDays,
-  };
-  const query = trpc.food.inbox.listFailed.useQuery(queryInput);
-  const errorCodesQuery = trpc.food.inbox.failedErrorCodes.useQuery();
-  const retryMutation = trpc.food.ingest.retry.useMutation({
-    onMutate: async ({ sourceId }) => {
-      await utils.food.inbox.listFailed.cancel();
-      const snapshot = utils.food.inbox.listFailed.getData(queryInput);
-      if (snapshot !== undefined) {
-        utils.food.inbox.listFailed.setData(queryInput, {
-          ...snapshot,
-          items: snapshot.items.filter((row) => row.sourceId !== sourceId),
-        });
-      }
+function useRetryMutation(utils: UsePillarUtilsResult, queryInput: QueryInput, t: Translate) {
+  return usePillarMutation<RetryInput, RetryOutput, RetryContext>('food', ['ingest', 'retry'], {
+    onMutate: ({ sourceId }) => {
+      const snapshot = utils.setData<ListFailedOutput>(
+        ['inbox', 'listFailed'],
+        queryInput,
+        (prev) =>
+          prev === undefined
+            ? prev
+            : { ...prev, items: prev.items.filter((row) => row.sourceId !== sourceId) }
+      );
       return { snapshot };
     },
     onError: (err, _input, ctx) => {
       if (ctx?.snapshot !== undefined) {
-        utils.food.inbox.listFailed.setData(queryInput, ctx.snapshot);
+        utils.setData<ListFailedOutput>(['inbox', 'listFailed'], queryInput, () => ctx.snapshot);
       }
       toast.error(t('inbox.failed.retry.error', { message: err.message }));
     },
@@ -49,10 +59,26 @@ export function useFailedTab({ filters, t }: UseFailedTabOpts) {
       toast.success(t('inbox.failed.retry.success'));
     },
     onSettled: () => {
-      void utils.food.inbox.listFailed.invalidate();
-      void utils.food.inbox.failedErrorCodes.invalidate();
+      void utils.invalidate(['inbox', 'listFailed']);
+      void utils.invalidate(['inbox', 'failedErrorCodes']);
     },
   });
+}
+
+export function useFailedTab({ filters, t }: UseFailedTabOpts) {
+  const utils = usePillarUtils('food');
+  const queryInput: QueryInput = {
+    errorCodes: filters.errorCodes.length > 0 ? [...filters.errorCodes] : undefined,
+    kinds: filters.kinds.length > 0 ? [...filters.kinds] : undefined,
+    sinceDays: filters.sinceDays,
+  };
+  const query = usePillarQuery<ListFailedOutput>('food', ['inbox', 'listFailed'], queryInput);
+  const errorCodesQuery = usePillarQuery<FailedErrorCodesOutput>(
+    'food',
+    ['inbox', 'failedErrorCodes'],
+    undefined
+  );
+  const retryMutation = useRetryMutation(utils, queryInput, t);
   const retry = useCallback(
     (sourceId: number) => retryMutation.mutate({ sourceId }),
     [retryMutation]

--- a/packages/app-food/src/pages/inbox/useRejectedTab.ts
+++ b/packages/app-food/src/pages/inbox/useRejectedTab.ts
@@ -9,55 +9,81 @@
 import { useCallback } from 'react';
 import { toast } from 'sonner';
 
-import { trpc } from '@pops/api-client';
+import { usePillarMutation, usePillarQuery, usePillarUtils } from '@pops/pillar-sdk/react';
 
 import { type RejectedFiltersState } from './RejectedFilters.js';
 
+import type { inferRouterOutputs } from '@trpc/server';
+
+import type { AppRouter } from '@pops/api-client';
+import type { UsePillarUtilsResult } from '@pops/pillar-sdk/react';
+
+type ListRejectedOutput = inferRouterOutputs<AppRouter>['food']['inbox']['listRejected'];
+type UnrejectOutput = inferRouterOutputs<AppRouter>['food']['inbox']['unreject'];
+
+type UnrejectInput = { versionId: number };
+type UnrejectContext = { snapshot: ListRejectedOutput | undefined };
+type Translate = (key: string, opts?: Record<string, unknown>) => string;
+type QueryInput = {
+  reasons: readonly string[] | undefined;
+  kinds: readonly string[] | undefined;
+  sinceDays: RejectedFiltersState['sinceDays'];
+};
+
 interface UseRejectedTabOpts {
   filters: RejectedFiltersState;
-  t: (key: string, opts?: Record<string, unknown>) => string;
+  t: Translate;
+}
+
+function useUndoMutation(utils: UsePillarUtilsResult, queryInput: QueryInput, t: Translate) {
+  return usePillarMutation<UnrejectInput, UnrejectOutput, UnrejectContext>(
+    'food',
+    ['inbox', 'unreject'],
+    {
+      onMutate: ({ versionId }) => {
+        const snapshot = utils.setData<ListRejectedOutput>(
+          ['inbox', 'listRejected'],
+          queryInput,
+          (prev) =>
+            prev === undefined
+              ? prev
+              : { ...prev, items: prev.items.filter((row) => row.versionId !== versionId) }
+        );
+        return { snapshot };
+      },
+      onError: (err, _input, ctx) => {
+        if (ctx?.snapshot !== undefined) {
+          utils.setData<ListRejectedOutput>(
+            ['inbox', 'listRejected'],
+            queryInput,
+            () => ctx.snapshot
+          );
+        }
+        toast.error(t('inbox.rejected.undo.error', { message: err.message }));
+      },
+      onSuccess: (result) => {
+        if (result.ok) {
+          toast.success(t('inbox.rejected.undo.success'));
+        } else {
+          toast.error(t(`inbox.rejected.undo.failure.${result.reason}` as const));
+        }
+      },
+      onSettled: () => {
+        void utils.invalidate(['inbox', 'listRejected']);
+      },
+    }
+  );
 }
 
 export function useRejectedTab({ filters, t }: UseRejectedTabOpts) {
-  const utils = trpc.useUtils();
-  const queryInput = {
+  const utils = usePillarUtils('food');
+  const queryInput: QueryInput = {
     reasons: filters.reasons.length > 0 ? [...filters.reasons] : undefined,
     kinds: filters.kinds.length > 0 ? [...filters.kinds] : undefined,
     sinceDays: filters.sinceDays,
   };
-  const query = trpc.food.inbox.listRejected.useQuery(queryInput);
-  const undoMutation = trpc.food.inbox.unreject.useMutation({
-    onMutate: async ({ versionId }) => {
-      await utils.food.inbox.listRejected.cancel();
-      const snapshot = utils.food.inbox.listRejected.getData(queryInput);
-      if (snapshot !== undefined) {
-        utils.food.inbox.listRejected.setData(queryInput, {
-          ...snapshot,
-          items: snapshot.items.filter((row) => row.versionId !== versionId),
-        });
-      }
-      return { snapshot };
-    },
-    onError: (err, _input, ctx) => {
-      if (ctx?.snapshot !== undefined) {
-        utils.food.inbox.listRejected.setData(queryInput, ctx.snapshot);
-      }
-      toast.error(t('inbox.rejected.undo.error', { message: err.message }));
-    },
-    onSuccess: (result) => {
-      if (result.ok) {
-        toast.success(t('inbox.rejected.undo.success'));
-      } else {
-        toast.error(t(`inbox.rejected.undo.failure.${result.reason}` as const));
-      }
-    },
-    // Single invalidation in onSettled covers both branches — onSuccess +
-    // onError both end here, so doing it twice on the `{ ok: false }` path
-    // would trigger a redundant refetch.
-    onSettled: () => {
-      void utils.food.inbox.listRejected.invalidate();
-    },
-  });
+  const query = usePillarQuery<ListRejectedOutput>('food', ['inbox', 'listRejected'], queryInput);
+  const undoMutation = useUndoMutation(utils, queryInput, t);
   const undo = useCallback(
     (versionId: number) => undoMutation.mutate({ versionId }),
     [undoMutation]

--- a/packages/app-food/src/pages/recipes/__tests__/RecipeListPage.test.tsx
+++ b/packages/app-food/src/pages/recipes/__tests__/RecipeListPage.test.tsx
@@ -13,15 +13,16 @@ import type { RecipeListItemView } from '../useRecipeListQuery.js';
 
 const mockListInfinite = vi.fn();
 
-vi.mock('@pops/api-client', () => ({
-  trpc: {
-    food: {
-      recipes: {
-        list: {
-          useInfiniteQuery: (input: unknown, opts: unknown) => mockListInfinite(input, opts),
-        },
-      },
-    },
+vi.mock('@pops/pillar-sdk/react', () => ({
+  usePillarInfiniteQuery: (
+    _pillarId: string,
+    path: readonly string[],
+    input: unknown,
+    opts: unknown
+  ) => {
+    const key = path.join('.');
+    if (key === 'recipes.list') return mockListInfinite(input, opts);
+    throw new Error(`Unexpected pillar infinite query: ${key}`);
   },
 }));
 

--- a/packages/app-food/src/pages/recipes/send-to-list/__tests__/SendToListModal.test.tsx
+++ b/packages/app-food/src/pages/recipes/send-to-list/__tests__/SendToListModal.test.tsx
@@ -57,22 +57,13 @@ let capturedSendOptions: {
 } = {};
 let mockSendPending = false;
 
-vi.mock('@pops/api-client', () => ({
-  trpc: {
-    food: {
-      recipes: {
-        prepareSendToList: { useQuery: (...args: unknown[]) => mockPrepare(...args) },
-      },
-    },
-    lists: {
-      list: {
-        list: { useQuery: (...args: unknown[]) => mockListsList(...args) },
-      },
-    },
-  },
-}));
-
 vi.mock('@pops/pillar-sdk/react', () => ({
+  usePillarQuery: (pillarId: string, path: readonly string[], input: unknown, opts: unknown) => {
+    const key = `${pillarId}.${path.join('.')}`;
+    if (key === 'food.recipes.prepareSendToList') return mockPrepare(input, opts);
+    if (key === 'lists.list.list') return mockListsList(input, opts);
+    throw new Error(`Unexpected pillar query: ${key}`);
+  },
   usePillarMutation: (
     _pillarId: string,
     path: readonly string[],

--- a/packages/app-food/src/pages/recipes/send-to-list/useSendToListData.ts
+++ b/packages/app-food/src/pages/recipes/send-to-list/useSendToListData.ts
@@ -6,14 +6,15 @@
  * both resolve. Both queries are scoped to enabled=open so the modal pays
  * nothing while closed.
  */
-import { trpc } from '@pops/api-client';
+import { usePillarQuery } from '@pops/pillar-sdk/react';
 
 import type { inferRouterOutputs } from '@trpc/server';
 
 import type { AppRouter } from '@pops/api-client';
 
 export type PrepareOutput = inferRouterOutputs<AppRouter>['food']['recipes']['prepareSendToList'];
-export type ShoppingList = inferRouterOutputs<AppRouter>['lists']['list']['list']['items'][number];
+type ListsListOutput = inferRouterOutputs<AppRouter>['lists']['list']['list'];
+export type ShoppingList = ListsListOutput['items'][number];
 
 export interface SendToListDataState {
   preview: PrepareOutput | undefined;
@@ -30,11 +31,15 @@ interface Args {
 }
 
 export function useSendToListData({ versionId, scaleFactor, enabled }: Args): SendToListDataState {
-  const prepare = trpc.food.recipes.prepareSendToList.useQuery(
+  const prepare = usePillarQuery<PrepareOutput>(
+    'food',
+    ['recipes', 'prepareSendToList'],
     { versionId, scaleFactor },
     { enabled }
   );
-  const lists = trpc.lists.list.list.useQuery(
+  const lists = usePillarQuery<ListsListOutput>(
+    'lists',
+    ['list', 'list'],
     { kinds: ['shopping'], includeArchived: false, sort: 'updated' },
     { enabled }
   );
@@ -42,7 +47,7 @@ export function useSendToListData({ versionId, scaleFactor, enabled }: Args): Se
     preview: prepare.data,
     shoppingLists: lists.data?.items ?? [],
     isLoading: prepare.isLoading || lists.isLoading,
-    error: (prepare.error as Error | null) ?? (lists.error as Error | null) ?? null,
+    error: prepare.error ?? lists.error ?? null,
     refetch: () => {
       void prepare.refetch();
       void lists.refetch();

--- a/packages/app-food/src/pages/recipes/useRecipeListQuery.ts
+++ b/packages/app-food/src/pages/recipes/useRecipeListQuery.ts
@@ -1,8 +1,15 @@
 import { useMemo } from 'react';
 
-import { trpc } from '@pops/api-client';
+import { usePillarInfiniteQuery } from '@pops/pillar-sdk/react';
+
+import type { inferRouterOutputs } from '@trpc/server';
+
+import type { AppRouter } from '@pops/api-client';
 
 import type { RecipeListFilterState, RecipeType } from './recipe-list-types.js';
+
+type RecipeListOutput = inferRouterOutputs<AppRouter>['food']['recipes']['list'];
+type RecipeListCursor = string | null;
 
 export interface UseRecipeListQueryArgs {
   filters: RecipeListFilterState;
@@ -34,10 +41,10 @@ export interface UseRecipeListQueryResult {
 }
 
 /**
- * Wraps `trpc.food.recipes.list.useInfiniteQuery` so the page component
- * stays declarative. The hook is keyed off the filter state plus a
- * pre-debounced search string — the caller owns debouncing so this hook
- * doesn't re-trigger on every keystroke.
+ * Wraps `food.recipes.list` paginated reads via `usePillarInfiniteQuery`
+ * so the page component stays declarative. The hook is keyed off the
+ * filter state plus a pre-debounced search string — the caller owns
+ * debouncing so this hook doesn't re-trigger on every keystroke.
  */
 export function useRecipeListQuery({
   filters,
@@ -55,9 +62,15 @@ export function useRecipeListQuery({
     [debouncedSearch, filters]
   );
 
-  const query = trpc.food.recipes.list.useInfiniteQuery(input, {
-    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
-  });
+  const query = usePillarInfiniteQuery<RecipeListOutput, RecipeListCursor>(
+    'food',
+    ['recipes', 'list'],
+    input,
+    {
+      initialPageParam: null as RecipeListCursor,
+      getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+    }
+  );
 
   const items = useMemo(
     () => (query.data?.pages ?? []).flatMap((page) => page.items),
@@ -68,7 +81,7 @@ export function useRecipeListQuery({
     items,
     isLoading: query.isLoading,
     isFetchingNextPage: query.isFetchingNextPage,
-    hasNextPage: query.hasNextPage ?? false,
+    hasNextPage: query.hasNextPage,
     fetchNextPage: () => {
       void query.fetchNextPage();
     },


### PR DESCRIPTION
## Summary

Follow-up to #3163 which migrated 118 trivial tRPC sites in `app-food` to the pillar SDK and deferred 5 sites pending SDK affordances. All 5 are now migrated:

| Site | SDK affordance that unblocked it |
| --- | --- |
| `pages/inbox/useFailedTab.ts` | `usePillarUtils().setData` + `usePillarMutation` `TContext` rollback generic (already shipped — pattern from #3145, #3157) |
| `pages/inbox/useRejectedTab.ts` | same as above |
| `pages/recipes/useRecipeListQuery.ts` | `usePillarInfiniteQuery` (#3173) |
| `pages/recipes/send-to-list/useSendToListData.ts` | cross-pillar `usePillarQuery('lists', ['list', 'list'], …)` (no new SDK affordance, just removing the tRPC coupling) |
| `pages/data/conversions-tab/useWeightRowViews.ts` | `usePillarQueries` + `pillarQueryArg` (#3177) |

Each migrated site keeps its existing behaviour:

- **Failed / Rejected tabs** — optimistic row removal via `utils.setData(routerPath, input, updater)`; rollback via the typed `TContext = { snapshot: ListOutput \| undefined }` generic; toast on success / failure.
- **`useRecipeListQuery`** — default `buildInput` (spread + `cursor: pageParam`) matches `food.recipes.list`'s cursor-pagination shape; no override needed.
- **`useSendToListData`** — two parallel `usePillarQuery` calls, one against `food`, one against `lists`. Identical semantics to the pre-migration paired `trpc.*.useQuery` calls.
- **`useWeightRowViews`** — variable-length parallel fan-out via `usePillarQueries(ingredientIds.map(pillarQueryArg<unknown>(…)))`. The output is structurally guarded (`isIngredientsGetOutput`) before reading `variants` because `PillarQueryArg<TOutput>` is invariant on `TOutput` (the `options?.select: (data: T) => unknown` field) which blocks the obvious typed form for `.map()`-produced arrays.

## Test plan

- [x] `pnpm --filter @pops/app-food typecheck` — clean
- [x] `pnpm --filter @pops/app-food test` — 638 / 638 passing
- [x] Test files updated to mock `@pops/pillar-sdk/react` instead of `@pops/api-client`. `setData` assertions updated to the `(routerPath, input, updater)` signature.
- [ ] CI green (food-quality)

## Notes

- `@pops/api-client` is **not** dropped from `packages/app-food/package.json` — 78 other files in `app-food/src` still import it for `AppRouter` types and untouched runtime call paths.
- No `as any`, no `as unknown as T`, no `eslint-disable`, no `ts-ignore`. Optimistic rollback uses the typed `TContext` third generic.