### PR TITLE
feat(ha-bridge): PRD-229 US-04 ha.entity.callService outbound AI tool

### DIFF
--- a/apps/pops-ha-bridge-api/src/__tests__/call-service.test.ts
+++ b/apps/pops-ha-bridge-api/src/__tests__/call-service.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  callServiceInputSchema,
+  CallServiceSender,
+  type CallServiceLiveSocket,
+  type CallServiceResultFrame,
+} from '../ai-tools/index.js';
+import { NOOP_SUBSCRIBER_LOGGER } from '../ws-subscriber-types.js';
+
+interface Harness {
+  sender: CallServiceSender;
+  sent: string[];
+  setLive(value: boolean): void;
+  nextId(): number;
+}
+
+function createHarness(options: { timeoutMs?: number } = {}): Harness {
+  let live = true;
+  const sent: string[] = [];
+  let id = 0;
+  const liveSocket: CallServiceLiveSocket = {
+    isReady: () => live,
+    send: (data) => {
+      sent.push(data);
+    },
+  };
+  const sender = new CallServiceSender({
+    liveSocket,
+    nextCommandId: () => {
+      id += 1;
+      return id;
+    },
+    logger: NOOP_SUBSCRIBER_LOGGER,
+    timeoutMs: options.timeoutMs ?? 10_000,
+  });
+  return {
+    sender,
+    sent,
+    setLive: (value) => {
+      live = value;
+    },
+    nextId: () => id,
+  };
+}
+
+function parseFrame(json: string): Record<string, unknown> {
+  const parsed = JSON.parse(json) as unknown;
+  if (parsed === null || typeof parsed !== 'object') {
+    throw new Error('expected object frame');
+  }
+  return parsed as Record<string, unknown>;
+}
+
+describe('callServiceInputSchema', () => {
+  it('rejects non-snake-case domains', () => {
+    const result = callServiceInputSchema.safeParse({ domain: 'Light', service: 'turn_off' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects non-snake-case services', () => {
+    const result = callServiceInputSchema.safeParse({ domain: 'light', service: 'TurnOff' });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts a well-formed light.turn_off without entityId', () => {
+    const result = callServiceInputSchema.safeParse({ domain: 'light', service: 'turn_off' });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects malformed entityId (no dot)', () => {
+    const result = callServiceInputSchema.safeParse({
+      domain: 'light',
+      service: 'turn_off',
+      entityId: 'kitchen_ceiling',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('strips unknown top-level fields via strict()', () => {
+    const result = callServiceInputSchema.safeParse({
+      domain: 'light',
+      service: 'turn_off',
+      extra: 'nope',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('CallServiceSender', () => {
+  it('serialises a successful call_service frame and resolves ok on HA ack', async () => {
+    const h = createHarness();
+    const promise = h.sender.call({
+      domain: 'light',
+      service: 'turn_off',
+      entityId: 'light.kitchen_ceiling',
+      serviceData: { transition: 2 },
+    });
+
+    expect(h.sent).toHaveLength(1);
+    const frame = parseFrame(h.sent[0] ?? '');
+    expect(frame['id']).toBe(1);
+    expect(frame['type']).toBe('call_service');
+    expect(frame['domain']).toBe('light');
+    expect(frame['service']).toBe('turn_off');
+    expect(frame['target']).toEqual({ entity_id: 'light.kitchen_ceiling' });
+    expect(frame['service_data']).toEqual({ transition: 2 });
+
+    const result: CallServiceResultFrame = { id: 1, success: true };
+    expect(h.sender.handleResult(result)).toBe(true);
+    await expect(promise).resolves.toEqual({ kind: 'ok' });
+    expect(h.sender.pendingCount()).toBe(0);
+  });
+
+  it('rejects with ha-offline when the socket is not ready', async () => {
+    const h = createHarness();
+    h.setLive(false);
+    const outcome = await h.sender.call({ domain: 'light', service: 'turn_off' });
+    expect(outcome).toEqual({ kind: 'rejected', reason: 'ha-offline' });
+    expect(h.sent).toHaveLength(0);
+  });
+
+  it('rejects with invalid-input on schema violation without touching the socket', async () => {
+    const h = createHarness();
+    const outcome = await h.sender.call({ domain: 'LIGHT', service: 'turn_off' });
+    expect(outcome.kind).toBe('rejected');
+    if (outcome.kind === 'rejected') expect(outcome.reason).toBe('invalid-input');
+    expect(h.sent).toHaveLength(0);
+  });
+
+  it('maps HA service_not_found error code to rejected/service-not-found', async () => {
+    const h = createHarness();
+    const promise = h.sender.call({ domain: 'light', service: 'no_such_service' });
+    h.sender.handleResult({
+      id: 1,
+      success: false,
+      error: { code: 'service_not_found', message: 'Unknown service' },
+    });
+    const outcome = await promise;
+    expect(outcome).toEqual({
+      kind: 'rejected',
+      reason: 'service-not-found',
+      message: 'Unknown service',
+    });
+  });
+
+  it('treats unknown HA error codes as ha-offline (catch-all)', async () => {
+    const h = createHarness();
+    const promise = h.sender.call({ domain: 'light', service: 'turn_off' });
+    h.sender.handleResult({ id: 1, success: false, error: { code: 'internal_error' } });
+    const outcome = await promise;
+    expect(outcome.kind).toBe('rejected');
+    if (outcome.kind === 'rejected') expect(outcome.reason).toBe('ha-offline');
+  });
+
+  it('times out and resolves ha-offline if HA does not respond in window', async () => {
+    vi.useFakeTimers();
+    try {
+      const h = createHarness({ timeoutMs: 100 });
+      const promise = h.sender.call({ domain: 'light', service: 'turn_off' });
+      vi.advanceTimersByTime(100);
+      const outcome = await promise;
+      expect(outcome).toEqual({ kind: 'rejected', reason: 'ha-offline', message: 'timeout' });
+      expect(h.sender.pendingCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('ignores result frames for unknown ids (no pending entry)', () => {
+    const h = createHarness();
+    expect(h.sender.handleResult({ id: 999, success: true })).toBe(false);
+  });
+
+  it('cancelAll resolves every pending call with the supplied outcome', async () => {
+    const h = createHarness();
+    const a = h.sender.call({ domain: 'light', service: 'turn_off' });
+    const b = h.sender.call({ domain: 'switch', service: 'toggle' });
+    expect(h.sender.pendingCount()).toBe(2);
+    h.sender.cancelAll({ kind: 'rejected', reason: 'ha-offline' });
+    await expect(a).resolves.toEqual({ kind: 'rejected', reason: 'ha-offline' });
+    await expect(b).resolves.toEqual({ kind: 'rejected', reason: 'ha-offline' });
+    expect(h.sender.pendingCount()).toBe(0);
+  });
+});

--- a/apps/pops-ha-bridge-api/src/__tests__/manifest.test.ts
+++ b/apps/pops-ha-bridge-api/src/__tests__/manifest.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from 'vitest';
 
 import { ManifestPayloadSchema, validateManifestPayload } from '@pops/pillar-sdk/manifest-schema';
 
-import { ENTITY_GET_STATE_TOOL_NAME, ENTITY_LIST_TOOL_NAME } from '../ai-tools/index.js';
+import {
+  CALL_SERVICE_TOOL_NAME,
+  ENTITY_GET_STATE_TOOL_NAME,
+  ENTITY_LIST_TOOL_NAME,
+} from '../ai-tools/index.js';
 import { buildHaBridgeManifest, HA_BRIDGE_PILLAR_ID } from '../manifest.js';
 import {
   HA_ENTITIES_ADAPTER_NAME,
@@ -16,10 +20,9 @@ describe('buildHaBridgeManifest', () => {
     const parsed = ManifestPayloadSchema.parse(manifest);
     expect(parsed.pillar).toBe(HA_BRIDGE_PILLAR_ID);
     expect(parsed.contract.tag).toBe('contract-ha-bridge@v0.1.0');
-    expect(parsed.ai.tools.map((t) => t.name)).toEqual([
-      ENTITY_LIST_TOOL_NAME,
-      ENTITY_GET_STATE_TOOL_NAME,
-    ]);
+    expect(parsed.ai.tools.map((t) => t.name).toSorted()).toEqual(
+      [ENTITY_LIST_TOOL_NAME, ENTITY_GET_STATE_TOOL_NAME, CALL_SERVICE_TOOL_NAME].toSorted()
+    );
     expect(parsed.sinks?.descriptors.length).toBeGreaterThan(0);
   });
 
@@ -47,6 +50,21 @@ describe('buildHaBridgeManifest', () => {
     const props = parameters.properties ?? {};
     expect(Object.keys(props).toSorted()).toEqual(['entityId']);
     expect(parameters.required).toContain('entityId');
+  });
+
+  it('publishes the entityCallService AI tool descriptor (US-04)', () => {
+    const manifest = buildHaBridgeManifest('0.1.0');
+    const tool = manifest.ai.tools.find((t) => t.name === CALL_SERVICE_TOOL_NAME);
+    if (tool === undefined) throw new Error('entityCallService descriptor missing');
+    expect(tool.description.length).toBeGreaterThanOrEqual(10);
+    expect(tool.parameters).toMatchObject({ type: 'object' });
+    const parameters = tool.parameters as {
+      properties?: Record<string, unknown>;
+      required?: string[];
+    };
+    const props = parameters.properties ?? {};
+    expect(Object.keys(props).toSorted()).toEqual(['domain', 'entityId', 'service', 'serviceData']);
+    expect((parameters.required ?? []).toSorted()).toEqual(['domain', 'service']);
   });
 
   it('every published AI tool name matches the manifest schema camelCase regex', () => {

--- a/apps/pops-ha-bridge-api/src/ai-tools/call-service-sender.ts
+++ b/apps/pops-ha-bridge-api/src/ai-tools/call-service-sender.ts
@@ -1,0 +1,142 @@
+/**
+ * PRD-229 US-04: outbound `call_service` sender.
+ *
+ * Manages the per-frame WS write and the pending-id → resolver map for
+ * `ha.entity.callService`. Kept separate from the WebSocket subscriber so
+ * the subscriber's inbound state machine stays focused and this module
+ * can be unit-tested in isolation.
+ *
+ * Unlike `FireEventSender`, no queue: an LLM tool call cannot be
+ * deferred — the model has already committed the call to its turn and
+ * needs a synchronous outcome. When the socket is not ready we resolve
+ * `ha-offline` immediately.
+ *
+ * A pending request is dropped + rejected with `ha-offline` if HA does
+ * not respond within `timeoutMs` (default 10s per the PRD).
+ */
+import {
+  callServiceInputSchema,
+  type CallServiceInput,
+  type CallServiceOutcome,
+  type CallServiceRejectionReason,
+} from './call-service.js';
+
+import type { SubscriberLogger } from '../ws-subscriber-types.js';
+
+export const CALL_SERVICE_DEFAULT_TIMEOUT_MS = 10_000;
+
+export interface CallServiceLiveSocket {
+  readonly isReady: () => boolean;
+  readonly send: (data: string) => void;
+}
+
+export interface CallServiceSenderDeps {
+  readonly liveSocket: CallServiceLiveSocket;
+  readonly nextCommandId: () => number;
+  readonly logger: SubscriberLogger;
+  readonly setTimeoutImpl?: typeof setTimeout;
+  readonly clearTimeoutImpl?: typeof clearTimeout;
+  readonly timeoutMs?: number;
+}
+
+interface PendingCall {
+  resolve(outcome: CallServiceOutcome): void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+export interface CallServiceResultFrame {
+  readonly id: number;
+  readonly success: boolean;
+  readonly error?: { code?: string; message?: string };
+}
+
+export class CallServiceSender {
+  private readonly liveSocket: CallServiceLiveSocket;
+  private readonly nextCommandId: () => number;
+  private readonly logger: SubscriberLogger;
+  private readonly setTimeoutImpl: typeof setTimeout;
+  private readonly clearTimeoutImpl: typeof clearTimeout;
+  private readonly timeoutMs: number;
+  private readonly pending = new Map<number, PendingCall>();
+
+  constructor(deps: CallServiceSenderDeps) {
+    this.liveSocket = deps.liveSocket;
+    this.nextCommandId = deps.nextCommandId;
+    this.logger = deps.logger;
+    this.setTimeoutImpl = deps.setTimeoutImpl ?? setTimeout;
+    this.clearTimeoutImpl = deps.clearTimeoutImpl ?? clearTimeout;
+    this.timeoutMs = deps.timeoutMs ?? CALL_SERVICE_DEFAULT_TIMEOUT_MS;
+  }
+
+  async call(input: unknown): Promise<CallServiceOutcome> {
+    const parsed = callServiceInputSchema.safeParse(input);
+    if (!parsed.success) {
+      return { kind: 'rejected', reason: 'invalid-input', message: parsed.error.message };
+    }
+    if (!this.liveSocket.isReady()) {
+      return { kind: 'rejected', reason: 'ha-offline' };
+    }
+    const id = this.nextCommandId();
+    const frame = this.serialise(id, parsed.data);
+    return new Promise<CallServiceOutcome>((resolve) => {
+      const timer = this.setTimeoutImpl(() => {
+        if (!this.pending.has(id)) return;
+        this.pending.delete(id);
+        this.logger.warn('ha call_service timed out', { id, timeoutMs: this.timeoutMs });
+        resolve({ kind: 'rejected', reason: 'ha-offline', message: 'timeout' });
+      }, this.timeoutMs);
+      this.pending.set(id, { resolve, timer });
+      this.liveSocket.send(frame);
+    });
+  }
+
+  handleResult(frame: CallServiceResultFrame): boolean {
+    const entry = this.pending.get(frame.id);
+    if (entry === undefined) return false;
+    this.pending.delete(frame.id);
+    this.clearTimeoutImpl(entry.timer);
+    if (frame.success) {
+      entry.resolve({ kind: 'ok' });
+      return true;
+    }
+    entry.resolve({
+      kind: 'rejected',
+      reason: this.mapErrorCode(frame.error?.code),
+      message: frame.error?.message,
+    });
+    return true;
+  }
+
+  cancelAll(reason: CallServiceOutcome): void {
+    for (const [, entry] of this.pending) {
+      this.clearTimeoutImpl(entry.timer);
+      entry.resolve(reason);
+    }
+    this.pending.clear();
+  }
+
+  pendingCount(): number {
+    return this.pending.size;
+  }
+
+  private mapErrorCode(code: string | undefined): CallServiceRejectionReason {
+    if (code === 'service_not_found' || code === 'not_found') return 'service-not-found';
+    return 'ha-offline';
+  }
+
+  private serialise(id: number, input: CallServiceInput): string {
+    const frame: Record<string, unknown> = {
+      id,
+      type: 'call_service',
+      domain: input.domain,
+      service: input.service,
+    };
+    if (input.entityId !== undefined) {
+      frame['target'] = { entity_id: input.entityId };
+    }
+    if (input.serviceData !== undefined) {
+      frame['service_data'] = input.serviceData;
+    }
+    return JSON.stringify(frame);
+  }
+}

--- a/apps/pops-ha-bridge-api/src/ai-tools/call-service.ts
+++ b/apps/pops-ha-bridge-api/src/ai-tools/call-service.ts
@@ -1,0 +1,56 @@
+/**
+ * `ha.entity.callService` — outbound AI tool (PRD-229 US-04).
+ *
+ * Allows the LLM to invoke a Home Assistant service (`light.turn_off`,
+ * `switch.toggle`, `scene.turn_on`, ...) via the existing HA WebSocket
+ * connection. The bridge frames the call as a `call_service` command,
+ * awaits HA's `{ type: 'result', id, success }` acknowledgement, and
+ * returns a discriminated outcome.
+ *
+ * Domain/service identifiers are validated as lowercase snake_case to
+ * match HA's own naming. Invalid input is rejected at the Zod boundary
+ * before any frame is sent. When the bridge is in degraded mode (no
+ * live socket) the tool returns `{ kind: 'rejected', reason: 'ha-offline' }`
+ * immediately — call_service requests are NOT queued for later delivery
+ * because the LLM has already factored the response into its turn.
+ */
+import { z } from 'zod';
+
+export const CALL_SERVICE_TOOL_NAME = 'entityCallService' as const;
+
+const HA_IDENTIFIER = /^[a-z][a-z0-9_]*$/;
+
+export const callServiceInputSchema = z
+  .object({
+    domain: z.string().min(1).max(64).regex(HA_IDENTIFIER, 'domain must be lowercase snake_case'),
+    service: z.string().min(1).max(64).regex(HA_IDENTIFIER, 'service must be lowercase snake_case'),
+    entityId: z
+      .string()
+      .min(3)
+      .max(255)
+      .regex(/^[a-z][a-z0-9_]*\.[a-z0-9_]+$/, 'entityId must be <domain>.<object_id>')
+      .optional(),
+    serviceData: z.record(z.string(), z.unknown()).optional(),
+  })
+  .strict();
+
+export type CallServiceInput = z.infer<typeof callServiceInputSchema>;
+
+export type CallServiceRejectionReason =
+  | 'pillar-unavailable'
+  | 'ha-offline'
+  | 'service-not-found'
+  | 'invalid-input';
+
+export type CallServiceOutcome =
+  | { kind: 'ok' }
+  | { kind: 'rejected'; reason: CallServiceRejectionReason; message?: string };
+
+export const CALL_SERVICE_TOOL_DESCRIPTION =
+  'Invoke a Home Assistant service to control an entity. Examples: ' +
+  '`light.turn_off` on `light.kitchen`, `switch.toggle` on `switch.heater`, ' +
+  '`scene.turn_on` on `scene.movie_night`. `serviceData` is forwarded to HA ' +
+  'verbatim for service-specific options (e.g. `{ brightness_pct: 60 }`). ' +
+  'Returns `{ kind: "ok" }` on success, or `{ kind: "rejected", reason }` ' +
+  'on failure where reason is one of: `ha-offline`, `service-not-found`, ' +
+  '`invalid-input`, `pillar-unavailable`.';

--- a/apps/pops-ha-bridge-api/src/ai-tools/index.ts
+++ b/apps/pops-ha-bridge-api/src/ai-tools/index.ts
@@ -1,5 +1,5 @@
 /**
- * HA bridge AI tool registry (PRD-229 US-03).
+ * HA bridge AI tool registry (PRD-229 US-03, US-04).
  *
  * Each descriptor projects an internal Zod input schema to the
  * JSON-Schema-shaped `parameters` field expected by the pillar manifest's
@@ -7,11 +7,17 @@
  * the future tool-router binding — adding a tool is one entry, no core
  * edit.
  *
- * US-03 ships the read-only `entityList` + `entityGetState` pair.
- * `ha.entity.callService` (US-04) stays out of scope.
+ * US-03 ships the read-only `entityList` + `entityGetState` pair. US-04
+ * adds `entityCallService` — the first outbound tool that lets the LLM
+ * drive HA via `call_service` over the existing WebSocket connection.
  */
 import { z } from 'zod';
 
+import {
+  CALL_SERVICE_TOOL_DESCRIPTION,
+  CALL_SERVICE_TOOL_NAME,
+  callServiceInputSchema,
+} from './call-service.js';
 import { ENTITY_GET_STATE_TOOL_NAME, entityGetStateInputSchema } from './entity-get-state.js';
 import { ENTITY_LIST_TOOL_NAME, entityListInputSchema } from './entity-list.js';
 
@@ -37,6 +43,11 @@ const sources: AiToolSource[] = [
     description:
       'Fetch the current mirrored state of a single Home Assistant entity by `entityId` (e.g. "light.kitchen"). Returns the full row — state, attributes, area, device class, timestamps — or a `not-found` discriminant if the entity is not mirrored. Read-only.',
     inputSchema: entityGetStateInputSchema,
+  },
+  {
+    name: CALL_SERVICE_TOOL_NAME,
+    description: CALL_SERVICE_TOOL_DESCRIPTION,
+    inputSchema: callServiceInputSchema,
   },
 ];
 
@@ -74,3 +85,19 @@ export {
   type EntityGetStateInput,
   type EntityGetStateOutput,
 } from './entity-get-state.js';
+
+export {
+  CALL_SERVICE_TOOL_DESCRIPTION,
+  CALL_SERVICE_TOOL_NAME,
+  callServiceInputSchema,
+  type CallServiceInput,
+  type CallServiceOutcome,
+  type CallServiceRejectionReason,
+} from './call-service.js';
+export {
+  CALL_SERVICE_DEFAULT_TIMEOUT_MS,
+  CallServiceSender,
+  type CallServiceLiveSocket,
+  type CallServiceResultFrame,
+  type CallServiceSenderDeps,
+} from './call-service-sender.js';

--- a/apps/pops-ha-bridge-api/src/ha-frame.ts
+++ b/apps/pops-ha-bridge-api/src/ha-frame.ts
@@ -12,6 +12,7 @@ export interface HaFrame {
   success?: boolean;
   message?: string;
   result?: unknown;
+  error?: { code?: string; message?: string };
   event?: {
     event_type?: string;
     data?: {

--- a/apps/pops-ha-bridge-api/src/manifest.ts
+++ b/apps/pops-ha-bridge-api/src/manifest.ts
@@ -17,8 +17,10 @@ import { validateSinkMappings } from './sinks/validator.js';
  * dimensions land in subsequent stories:
  *
  *   - US-03 fills `ai.tools` with the read-only `entityList` and
- *     `entityGetState` descriptors. `ha.entity.callService` (US-04)
- *     stays out of scope.
+ *     `entityGetState` descriptors.
+ *   - US-04 adds the outbound `entityCallService` descriptor — the first
+ *     tool that lets the LLM drive HA via `call_service` over the
+ *     existing WebSocket connection.
  *
  * PRD-237 US-01 derives the `sinks.descriptors` block from the mapping
  * config (`src/sinks/mapping.ts`) — the same array drives the runtime

--- a/apps/pops-ha-bridge-api/src/ws-inbound.ts
+++ b/apps/pops-ha-bridge-api/src/ws-inbound.ts
@@ -1,0 +1,96 @@
+/**
+ * Inbound HA frame routing for the WebSocket subscriber.
+ *
+ * Houses the per-frame-type handlers (auth, snapshot, call_service
+ * result, state-changed event) as pure-ish free functions that operate
+ * on a small `InboundContext` slice of the subscriber. Kept here so
+ * `ws-subscriber.ts` stays under the per-file LOC ceiling and the
+ * frame router can be evolved without touching the connection-state
+ * machine.
+ */
+import { upsertEntity } from '@pops/ha-bridge-db';
+
+import { stateObjectToMirrorInput, type HaFrame, type HaStateObject } from './ha-frame.js';
+
+import type { OpenedHaBridgeDb } from '@pops/ha-bridge-db';
+
+import type { CallServiceSender } from './ai-tools/call-service-sender.js';
+import type { HistoryDebouncer } from './history-debouncer.js';
+import type { FireEventSender } from './sinks/fire-event-sender.js';
+import type { ConnectionState } from './ws-subscriber-types.js';
+
+export interface InboundContext {
+  readonly db: OpenedHaBridgeDb;
+  readonly token: string | undefined;
+  readonly now: () => number;
+  readonly debouncer: HistoryDebouncer;
+  readonly fireEventSender: FireEventSender;
+  readonly callServiceSender: CallServiceSender;
+  send(data: string): void;
+  sendCommand(payload: Record<string, unknown>): void;
+  setConnectionState(state: ConnectionState): void;
+  onAuthOk(): void;
+  onAuthInvalid(): void;
+  isSubscribed(): boolean;
+  markSubscribed(): void;
+}
+
+export function handleCallServiceResultFrame(ctx: InboundContext, frame: HaFrame): boolean {
+  if (frame.type !== 'result' || frame.id === undefined) return false;
+  return ctx.callServiceSender.handleResult({
+    id: frame.id,
+    success: frame.success === true,
+    error: frame.error,
+  });
+}
+
+export function handleAuthFrame(ctx: InboundContext, frame: HaFrame): boolean {
+  if (frame.type === 'auth_required') {
+    ctx.send(JSON.stringify({ type: 'auth', access_token: ctx.token }));
+    return true;
+  }
+  if (frame.type === 'auth_invalid') {
+    ctx.onAuthInvalid();
+    return true;
+  }
+  if (frame.type === 'auth_ok') {
+    ctx.setConnectionState({ kind: 'connected', lastEventAt: ctx.now() });
+    ctx.onAuthOk();
+    ctx.sendCommand({ type: 'get_states' });
+    return true;
+  }
+  return false;
+}
+
+export function handleSnapshotFrame(ctx: InboundContext, frame: HaFrame): boolean {
+  if (frame.type !== 'result' || frame.success !== true || !Array.isArray(frame.result)) {
+    return false;
+  }
+  for (const state of frame.result as HaStateObject[]) {
+    const input = stateObjectToMirrorInput(state, ctx.now());
+    if (input !== undefined) upsertEntity(ctx.db.db, input);
+  }
+  if (!ctx.isSubscribed()) {
+    ctx.markSubscribed();
+    ctx.sendCommand({ type: 'subscribe_events', event_type: 'state_changed' });
+    ctx.fireEventSender.flush();
+  }
+  return true;
+}
+
+export function handleEventFrame(ctx: InboundContext, frame: HaFrame): void {
+  if (frame.type !== 'event' || frame.event?.event_type !== 'state_changed') return;
+  const newState = frame.event.data?.new_state;
+  if (newState === undefined || newState === null) return;
+  const now = ctx.now();
+  const input = stateObjectToMirrorInput(newState, now);
+  if (input === undefined) return;
+  upsertEntity(ctx.db.db, input);
+  ctx.setConnectionState({ kind: 'connected', lastEventAt: now });
+  ctx.debouncer.observe({
+    entityId: input.entityId,
+    state: input.state,
+    attributes: input.attributes,
+    observedAt: input.lastChanged,
+  });
+}

--- a/apps/pops-ha-bridge-api/src/ws-senders.ts
+++ b/apps/pops-ha-bridge-api/src/ws-senders.ts
@@ -1,0 +1,54 @@
+/**
+ * Outbound-sender composition for the HA WebSocket subscriber.
+ *
+ * Bundles the `fire_event` sink sender (PRD-237 US-02) and the
+ * `call_service` AI-tool sender (PRD-229 US-04) so the subscriber's
+ * constructor stays inside its per-file complexity budget. Both senders
+ * share the same live-socket gate, `nextCommandId` counter and logger —
+ * the bundle composes them around those shared deps.
+ */
+import { CallServiceSender } from './ai-tools/call-service-sender.js';
+import {
+  createFireEventSenderForSubscriber,
+  type FireEventSender,
+} from './sinks/fire-event-sender.js';
+
+import type { SubscriberLogger } from './ws-subscriber-types.js';
+
+export interface SenderBundleDeps {
+  readonly isLive: () => boolean;
+  readonly sendOnSocket: (data: string) => void;
+  readonly nextCommandId: () => number;
+  readonly logger: SubscriberLogger;
+  readonly now: () => number;
+  readonly setTimeoutImpl: typeof setTimeout;
+  readonly clearTimeoutImpl: typeof clearTimeout;
+  readonly sinkQueueCap: number | undefined;
+  readonly callServiceTimeoutMs: number | undefined;
+}
+
+export interface SenderBundle {
+  readonly fireEventSender: FireEventSender;
+  readonly callServiceSender: CallServiceSender;
+}
+
+export function createSenderBundle(deps: SenderBundleDeps): SenderBundle {
+  const liveSocket = { isReady: deps.isLive, send: deps.sendOnSocket };
+  return {
+    fireEventSender: createFireEventSenderForSubscriber({
+      liveSocket,
+      nextCommandId: deps.nextCommandId,
+      logger: deps.logger,
+      now: deps.now,
+      queueCap: deps.sinkQueueCap,
+    }),
+    callServiceSender: new CallServiceSender({
+      liveSocket,
+      nextCommandId: deps.nextCommandId,
+      logger: deps.logger,
+      setTimeoutImpl: deps.setTimeoutImpl,
+      clearTimeoutImpl: deps.clearTimeoutImpl,
+      timeoutMs: deps.callServiceTimeoutMs,
+    }),
+  };
+}

--- a/apps/pops-ha-bridge-api/src/ws-subscriber-types.ts
+++ b/apps/pops-ha-bridge-api/src/ws-subscriber-types.ts
@@ -54,4 +54,11 @@ export interface HaWebSocketSubscriberOptions {
    * the PRD heuristic.
    */
   sinkQueueCap?: number;
+  /**
+   * PRD-229 US-04: timeout (ms) for outbound `call_service` requests.
+   * If HA does not acknowledge within the window the call resolves with
+   * `{ kind: 'rejected', reason: 'ha-offline' }`. Defaults to 10s per
+   * the PRD acceptance criteria.
+   */
+  callServiceTimeoutMs?: number;
 }

--- a/apps/pops-ha-bridge-api/src/ws-subscriber.ts
+++ b/apps/pops-ha-bridge-api/src/ws-subscriber.ts
@@ -19,19 +19,20 @@
  * `HA_TOKEN` is never logged, never returned, and never serialised into
  * the manifest — it is only ever passed to the auth frame.
  */
-import { appendHistory, upsertEntity, type OpenedHaBridgeDb } from '@pops/ha-bridge-db';
+import { appendHistory, type OpenedHaBridgeDb } from '@pops/ha-bridge-db';
 
-import {
-  parseFrame,
-  stateObjectToMirrorInput,
-  type HaFrame,
-  type HaStateObject,
-} from './ha-frame.js';
+import { type CallServiceSender } from './ai-tools/call-service-sender.js';
+import { parseFrame } from './ha-frame.js';
 import { HistoryDebouncer } from './history-debouncer.js';
+import { type FireEventSender } from './sinks/fire-event-sender.js';
 import {
-  createFireEventSenderForSubscriber,
-  type FireEventSender,
-} from './sinks/fire-event-sender.js';
+  handleAuthFrame,
+  handleCallServiceResultFrame,
+  handleEventFrame,
+  handleSnapshotFrame,
+  type InboundContext,
+} from './ws-inbound.js';
+import { createSenderBundle } from './ws-senders.js';
 import {
   isPostAuthFailureClose,
   transitionToAuthFailed,
@@ -73,6 +74,7 @@ export class HaWebSocketSubscriber {
   private readonly logger: SubscriberLogger;
   private readonly debouncer: HistoryDebouncer;
   private readonly fireEventSender: FireEventSender;
+  private readonly callServiceSender: CallServiceSender;
   private socket: HaWebSocketLike | undefined;
   private connectionState: ConnectionState;
   private reconnectAttempt = 0;
@@ -105,12 +107,10 @@ export class HaWebSocketSubscriber {
         appendHistory(this.db.db, observation);
       },
     });
-    this.fireEventSender = createFireEventSenderForSubscriber({
-      liveSocket: {
-        isReady: () =>
-          this.connectionState.kind === 'connected' && this.socket !== undefined && this.subscribed,
-        send: (data) => this.socket?.send(data),
-      },
+    const bundle = createSenderBundle({
+      isLive: () =>
+        this.connectionState.kind === 'connected' && this.socket !== undefined && this.subscribed,
+      sendOnSocket: (data) => this.socket?.send(data),
       nextCommandId: () => {
         const id = this.commandId;
         this.commandId += 1;
@@ -118,8 +118,13 @@ export class HaWebSocketSubscriber {
       },
       logger: this.logger,
       now: this.now,
-      queueCap: options.sinkQueueCap,
+      setTimeoutImpl: this.setTimeoutImpl,
+      clearTimeoutImpl: this.clearTimeoutImpl,
+      sinkQueueCap: options.sinkQueueCap,
+      callServiceTimeoutMs: options.callServiceTimeoutMs,
     });
+    this.fireEventSender = bundle.fireEventSender;
+    this.callServiceSender = bundle.callServiceSender;
   }
 
   state(): ConnectionState {
@@ -129,6 +134,11 @@ export class HaWebSocketSubscriber {
   /** PRD-237 US-02: outbound sink — `sendFireEvent` + queue introspection. */
   get sinks(): FireEventSender {
     return this.fireEventSender;
+  }
+
+  /** PRD-229 US-04: outbound `ha.entity.callService` AI tool. */
+  get aiTools(): { callService: CallServiceSender } {
+    return { callService: this.callServiceSender };
   }
 
   start(): void {
@@ -145,6 +155,7 @@ export class HaWebSocketSubscriber {
       this.reconnectTimer = undefined;
     }
     this.debouncer.cancelAll();
+    this.callServiceSender.cancelAll({ kind: 'rejected', reason: 'ha-offline' });
     this.socket?.close();
     this.socket = undefined;
   }
@@ -166,60 +177,35 @@ export class HaWebSocketSubscriber {
   private handleMessage(raw: unknown): void {
     const frame = parseFrame(raw);
     if (frame === undefined) return;
-    if (this.handleAuthFrame(frame)) return;
-    if (this.handleSnapshotFrame(frame)) return;
-    this.handleEventFrame(frame);
+    const ctx = this.inboundContext();
+    if (handleAuthFrame(ctx, frame)) return;
+    if (handleSnapshotFrame(ctx, frame)) return;
+    if (handleCallServiceResultFrame(ctx, frame)) return;
+    handleEventFrame(ctx, frame);
   }
 
-  private handleAuthFrame(frame: HaFrame): boolean {
-    if (frame.type === 'auth_required') {
-      this.socket?.send(JSON.stringify({ type: 'auth', access_token: this.token }));
-      return true;
-    }
-    if (frame.type === 'auth_invalid') {
-      this.markAuthFailed();
-      return true;
-    }
-    if (frame.type === 'auth_ok') {
-      this.connectionState = { kind: 'connected', lastEventAt: this.now() };
-      this.reconnectAttempt = 0;
-      this.sendCommand({ type: 'get_states' });
-      return true;
-    }
-    return false;
-  }
-
-  private handleSnapshotFrame(frame: HaFrame): boolean {
-    if (frame.type !== 'result' || frame.success !== true || !Array.isArray(frame.result)) {
-      return false;
-    }
-    for (const state of frame.result as HaStateObject[]) {
-      const input = stateObjectToMirrorInput(state, this.now());
-      if (input !== undefined) upsertEntity(this.db.db, input);
-    }
-    if (!this.subscribed) {
-      this.subscribed = true;
-      this.sendCommand({ type: 'subscribe_events', event_type: 'state_changed' });
-      this.fireEventSender.flush();
-    }
-    return true;
-  }
-
-  private handleEventFrame(frame: HaFrame): void {
-    if (frame.type !== 'event' || frame.event?.event_type !== 'state_changed') return;
-    const newState = frame.event.data?.new_state;
-    if (newState === undefined || newState === null) return;
-    const now = this.now();
-    const input = stateObjectToMirrorInput(newState, now);
-    if (input === undefined) return;
-    upsertEntity(this.db.db, input);
-    this.connectionState = { kind: 'connected', lastEventAt: now };
-    this.debouncer.observe({
-      entityId: input.entityId,
-      state: input.state,
-      attributes: input.attributes,
-      observedAt: input.lastChanged,
-    });
+  private inboundContext(): InboundContext {
+    return {
+      db: this.db,
+      token: this.token,
+      now: this.now,
+      debouncer: this.debouncer,
+      fireEventSender: this.fireEventSender,
+      callServiceSender: this.callServiceSender,
+      send: (data) => this.socket?.send(data),
+      sendCommand: (payload) => this.sendCommand(payload),
+      setConnectionState: (state) => {
+        this.connectionState = state;
+      },
+      onAuthOk: () => {
+        this.reconnectAttempt = 0;
+      },
+      onAuthInvalid: () => this.markAuthFailed(),
+      isSubscribed: () => this.subscribed,
+      markSubscribed: () => {
+        this.subscribed = true;
+      },
+    };
   }
 
   private markAuthFailed(): void {


### PR DESCRIPTION
## Summary
- First outbound aiTool in the HA bridge pillar manifest. The LLM can now invoke HA services (`light.turn_off`, `switch.toggle`, `scene.turn_on`, ...) via the existing WebSocket connection — the bridge frames a `call_service` command, awaits HA's `{ type: 'result' }` ack, and resolves `{ kind: 'ok' } | { kind: 'rejected', reason }`.
- `entityCallService` descriptor wired into `ai.tools` alongside US-03's `entityList` + `entityGetState`. Zod input (`domain`, `service`, `entityId?`, `serviceData?`) projected to draft-7 JSON Schema via `z.toJSONSchema`.
- `CallServiceSender` owns the WS write + pending-id resolver map. When the socket is not ready the call resolves `ha-offline` immediately — call_service requests are NOT queued (unlike the fire_event sink), because an LLM tool call cannot be deferred.
- HA error codes mapped: `service_not_found` → `service-not-found`; catch-all → `ha-offline`. 10s timeout per the PRD acceptance criteria.
- `ws-subscriber.ts` refactored: sender construction extracted to `ws-senders.ts`, inbound frame router extracted to `ws-inbound.ts`. Keeps the per-file LOC ceiling and unblocks US-05 from adding more composed senders later.

## Manifest excerpt
```ts
ai: {
  tools: [
    { name: 'entityList',        /* US-03 */ },
    { name: 'entityGetState',    /* US-03 */ },
    {
      name: 'entityCallService',
      description:
        'Invoke a Home Assistant service to control an entity. Examples: ' +
        '`light.turn_off` on `light.kitchen`, `switch.toggle` on `switch.heater`, ' +
        '`scene.turn_on` on `scene.movie_night`. ...',
      parameters: { /* draft-7 JSON Schema: domain, service, entityId?, serviceData? */ },
    },
  ],
},
```

## PRD-229 US-04 status
- [x] Manifest declares `aiTools` includes `ha.entity.callService` (additive to US-03's list)
- [x] Input schema `{ domain, service, entityId?, serviceData? }`; output `{ kind: 'ok' } | { kind: 'rejected', reason: 'pillar-unavailable' | 'ha-offline' | 'service-not-found' | 'invalid-input' }`
- [x] Sends an HA WebSocket `call_service` frame and awaits the result; success returns `{ kind: 'ok' }`
- [x] HA error mapping: `service_not_found` → `service-not-found`; auth/connection errors → `ha-offline`
- [x] Degraded mode returns `{ kind: 'rejected', reason: 'ha-offline' }` immediately, without enqueueing
- [x] Tool description lists `light.turn_off`, `switch.toggle`, `scene.turn_on` as safe-control examples
- [x] Unit tests cover: success, `service_not_found` mapping, degraded mode, invalid input, 10s timeout

Out of scope: US-05 sinks. `entityGetState` was completed in main between US-03 (partial) and this PR.

## Test plan
- [x] `pnpm --filter @pops/ha-bridge-api test` — 67/67 pass (13 new for call-service: 5 schema + 8 sender, 1 new manifest case)
- [x] `pnpm typecheck` clean — 71 packages
- [x] `oxlint` clean on changed files (max-lines respected on `ws-subscriber.ts` after extraction)
- [x] Rebased onto current `origin/main` (resolved conflicts with US-03 `entityGetState` follow-up shipped concurrently)
