### PR TITLE
fix(pillar-sdk): make PillarQueryArg covariant on TOutput (PR #3185 follow-up)

### DIFF
--- a/packages/pillar-sdk/src/react/__tests__/use-pillar-queries.test.tsx
+++ b/packages/pillar-sdk/src/react/__tests__/use-pillar-queries.test.tsx
@@ -10,7 +10,7 @@ import {
   jsonResponse,
 } from '../../client/__tests__/fixtures.js';
 import { __resetSharedPillarClient } from '../../client/factory.js';
-import { pillarQueryArg, usePillarQueries } from '../hooks.js';
+import { pillarQueryArg, usePillarQueries, type PillarQueryArg } from '../hooks.js';
 import { PillarSdkProvider } from '../provider.js';
 
 import type { ReactNode } from 'react';
@@ -207,5 +207,28 @@ describe('usePillarQueries', () => {
     expect(result.current[1].fetchStatus).toBe('idle');
     expect(result.current[1].isPending).toBe(true);
     expect(harness.calls).toHaveLength(1);
+  });
+
+  it('is covariant on TOutput so .map()-produced arrays satisfy the readonly PillarQueryArg<unknown>[] constraint', () => {
+    type IngredientsGetOutput = { id: string; variants: readonly { id: number; name: string }[] };
+
+    const ids: readonly number[] = [1, 2, 3];
+    const args = ids.map((id) =>
+      pillarQueryArg<IngredientsGetOutput>({
+        pillarId: 'food',
+        path: ['ingredients', 'get'],
+        input: { idOrSlug: id },
+      })
+    ) satisfies readonly PillarQueryArg<unknown>[];
+
+    const single: PillarQueryArg<IngredientsGetOutput> = pillarQueryArg<IngredientsGetOutput>({
+      pillarId: 'food',
+      path: ['ingredients', 'get'],
+      input: { idOrSlug: 1 },
+    });
+    const widened: PillarQueryArg<unknown> = single;
+
+    expect(args).toHaveLength(3);
+    expect(widened.pillarId).toBe('food');
   });
 });

--- a/packages/pillar-sdk/src/react/hooks.ts
+++ b/packages/pillar-sdk/src/react/hooks.ts
@@ -148,7 +148,12 @@ export {
   type UsePillarInfiniteQueryResult,
 } from './use-pillar-infinite-query.js';
 
-export { pillarQueryArg, usePillarQueries, type PillarQueryArg } from './use-pillar-queries.js';
+export {
+  pillarQueryArg,
+  usePillarQueries,
+  type PillarParallelQueryOptions,
+  type PillarQueryArg,
+} from './use-pillar-queries.js';
 
 export type UsePillarCallDynamicQueryOptions = UsePillarQueryOptions<unknown>;
 export type UsePillarCallDynamicQueryResult = UsePillarQueryResult<unknown>;

--- a/packages/pillar-sdk/src/react/index.ts
+++ b/packages/pillar-sdk/src/react/index.ts
@@ -12,6 +12,7 @@ export {
 } from './hooks.js';
 export type {
   PillarInfiniteBuildInput,
+  PillarParallelQueryOptions,
   PillarQueryArg,
   PillarUpdater,
   UsePillarCallDynamicMutationArgs,

--- a/packages/pillar-sdk/src/react/use-pillar-queries.ts
+++ b/packages/pillar-sdk/src/react/use-pillar-queries.ts
@@ -10,9 +10,44 @@ import {
 import { usePillarSdkOptions } from './provider.js';
 import { pillarQueryKey } from './query-key.js';
 
-import type { UsePillarQueryOptions, UsePillarQueryResult } from './hooks.js';
+import type { NetworkMode, QueryMeta } from '@tanstack/react-query';
+
+import type { UsePillarQueryResult } from './hooks.js';
+
+type RetryValue = boolean | number | ((failureCount: number, error: PillarCallError) => boolean);
+type RetryDelayValue = number | ((failureCount: number, error: PillarCallError) => number);
 
 declare const pillarQueryArgOutput: unique symbol;
+
+/**
+ * Per-element React Query options accepted by {@link pillarQueryArg}.
+ *
+ * Deliberately narrower than `UsePillarQueryOptions<TOutput>` so that
+ * `PillarQueryArg<TOutput>` is covariant on `TOutput`. The omitted fields
+ * (`select`, `placeholderData`, the function form of `enabled`, the
+ * function form of `refetchOn{Mount,WindowFocus,Reconnect}`, etc.) all
+ * place `TOutput` in a contravariant callback argument position. Including
+ * any of them collapses the type to invariant, which breaks the common
+ * `ids.map((id) => pillarQueryArg<T>(...))` pattern (the resulting
+ * `PillarQueryArg<T>[]` would not satisfy `readonly PillarQueryArg<unknown>[]`).
+ *
+ * Consumers needing those callbacks should reach for the single-query
+ * `usePillarQuery` hook — those features are awkward in a parallel-array
+ * context anyway (per-element memoised projection, etc.).
+ */
+export type PillarParallelQueryOptions<out TOutput> = {
+  enabled?: boolean;
+  staleTime?: number;
+  gcTime?: number;
+  refetchInterval?: number | false;
+  refetchIntervalInBackground?: boolean;
+  retry?: RetryValue;
+  retryDelay?: RetryDelayValue;
+  networkMode?: NetworkMode;
+  initialData?: TOutput | (() => TOutput | undefined);
+  initialDataUpdatedAt?: number | (() => number | undefined);
+  meta?: QueryMeta;
+};
 
 /**
  * A typed descriptor for a single query inside {@link usePillarQueries}.
@@ -21,12 +56,19 @@ declare const pillarQueryArgOutput: unique symbol;
  * (`[pillarQueryArgOutput]`) — it never exists at runtime, but lets the
  * compiler propagate per-element output types through the `usePillarQueries`
  * tuple result. Build one with {@link pillarQueryArg}.
+ *
+ * Marked `out TOutput` so the type is covariant — a
+ * `PillarQueryArg<Ingredient>` is assignable to `PillarQueryArg<unknown>`,
+ * which is the constraint `usePillarQueries` requires. This is why
+ * {@link PillarParallelQueryOptions} omits callback fields that take
+ * `TOutput` in contravariant position; if any of them were re-introduced
+ * the variance modifier would force a type error.
  */
-export type PillarQueryArg<TOutput> = {
+export type PillarQueryArg<out TOutput> = {
   pillarId: string;
   path: ProcedurePath;
   input: unknown;
-  options?: UsePillarQueryOptions<TOutput>;
+  options?: PillarParallelQueryOptions<TOutput>;
   readonly [pillarQueryArgOutput]?: TOutput;
 };
 
@@ -44,12 +86,16 @@ export type PillarQueryArg<TOutput> = {
  * // results[0]: UsePillarQueryResult<Ingredient>
  * // results[1]: UsePillarQueryResult<Unit>
  * ```
+ *
+ * Because `PillarQueryArg<TOutput>` is covariant on `TOutput`, the
+ * `ids.map((id) => pillarQueryArg<T>(...))` pattern also works without
+ * a structural cast at the call site.
  */
 export function pillarQueryArg<TOutput>(arg: {
   pillarId: string;
   path: ProcedurePath;
   input: unknown;
-  options?: UsePillarQueryOptions<TOutput>;
+  options?: PillarParallelQueryOptions<TOutput>;
 }): PillarQueryArg<TOutput> {
   return arg as PillarQueryArg<TOutput>;
 }


### PR DESCRIPTION
Closes the variance issue flagged in PR #3185's body: `PillarQueryArg<TOutput>` was invariant on TOutput, blocking `ids.map(id => pillarQueryArg<T>(...))` patterns from satisfying the `readonly PillarQueryArg<unknown>[]` constraint on `usePillarQueries`.

Agent stalled at PR-open step but the commit + push completed cleanly. Opening the PR manually from the parent loop.

See diff: 4 files / 81 insertions / 6 deletions.