### PR TITLE
feat(ha-bridge): PRD-229 US-05 ha-native sinks (ha.notify + ha.event.fire)

### DIFF
--- a/apps/pops-ha-bridge-api/src/app.ts
+++ b/apps/pops-ha-bridge-api/src/app.ts
@@ -57,6 +57,7 @@ export function createHaBridgeApiApp(deps: HaBridgeAppDeps): Express {
     createSinkRouter({
       fireEvent: (eventType, haEventName, eventData) =>
         deps.subscriber.sinks.send(eventType, haEventName, eventData),
+      sendBody: (eventType, body) => deps.subscriber.sinks.sendBody(eventType, body),
       logger: deps.logger,
     })
   );

--- a/apps/pops-ha-bridge-api/src/sinks/__tests__/ha-native-sinks.test.ts
+++ b/apps/pops-ha-bridge-api/src/sinks/__tests__/ha-native-sinks.test.ts
@@ -1,0 +1,366 @@
+/**
+ * PRD-229 US-05: HA-native sinks (`ha.notify.send` + `ha.event.fire`).
+ *
+ * Proves that:
+ *   - the bridge manifest projects both ha-native sinks alongside the
+ *     PRD-237 mappings,
+ *   - publishing to `/_sinks/ha.notify.send` writes a `call_service`
+ *     frame on `notify.<service>` with the supplied target/data,
+ *   - publishing to `/_sinks/ha.event.fire` writes a `fire_event` frame
+ *     with the publisher-supplied event_type and event_data,
+ *   - malformed payloads are rejected at the Zod boundary with 400,
+ *   - while the WS is reconnecting, both ha-native sinks enqueue and
+ *     drain on the next handshake — sharing the existing reconnect
+ *     queue.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { z } from 'zod';
+
+import { openHaBridgeDb, type OpenedHaBridgeDb } from '@pops/ha-bridge-db';
+
+import { createHaBridgeApiApp } from '../../app.js';
+import { buildHaBridgeManifest } from '../../manifest.js';
+import {
+  HaWebSocketSubscriber,
+  type HaWebSocketFactory,
+  type HaWebSocketLike,
+} from '../../ws-subscriber.js';
+import { mappings } from '../mapping.js';
+import { sinkPayloadSchemas } from '../schemas.js';
+
+interface FakeSocket extends HaWebSocketLike {
+  sent: string[];
+  emitOpen(): void;
+  emitMessage(payload: unknown): void;
+  emitClose(code?: number, reason?: string): void;
+}
+
+function createFakeSocket(): FakeSocket {
+  const listeners: Record<string, ((...args: unknown[]) => void)[]> = {
+    open: [],
+    message: [],
+    close: [],
+    error: [],
+  };
+  const sent: string[] = [];
+  return {
+    sent,
+    send(data: string) {
+      sent.push(data);
+    },
+    close() {
+      const ls = listeners['close'] ?? [];
+      for (const l of ls) l(1000, Buffer.from(''));
+    },
+    on(event, listener) {
+      const arr = listeners[event];
+      if (arr !== undefined) arr.push(listener as (...args: unknown[]) => void);
+    },
+    emitOpen() {
+      const ls = listeners['open'] ?? [];
+      for (const l of ls) l();
+    },
+    emitMessage(payload) {
+      const serialised = typeof payload === 'string' ? payload : JSON.stringify(payload);
+      const ls = listeners['message'] ?? [];
+      for (const l of ls) l(serialised);
+    },
+    emitClose(code = 1006, reason = 'closed') {
+      const ls = listeners['close'] ?? [];
+      for (const l of ls) l(code, Buffer.from(reason));
+    },
+  };
+}
+
+function handshake(fake: FakeSocket): void {
+  fake.emitOpen();
+  fake.emitMessage({ type: 'auth_required' });
+  fake.emitMessage({ type: 'auth_ok' });
+  fake.emitMessage({ id: 1, type: 'result', success: true, result: [] });
+}
+
+const CallServiceFrameSchema = z.object({
+  id: z.number(),
+  type: z.literal('call_service'),
+  domain: z.string(),
+  service: z.string(),
+  service_data: z.record(z.string(), z.unknown()).optional(),
+  target: z.object({ entity_id: z.union([z.string(), z.array(z.string())]) }).optional(),
+});
+
+const FireEventFrameSchema = z.object({
+  id: z.number(),
+  type: z.literal('fire_event'),
+  event_type: z.string(),
+  event_data: z.record(z.string(), z.unknown()),
+});
+
+function findCallServiceFrame(
+  fake: FakeSocket
+): z.infer<typeof CallServiceFrameSchema> | undefined {
+  for (const raw of fake.sent) {
+    const parsed = CallServiceFrameSchema.safeParse(JSON.parse(raw));
+    if (parsed.success) return parsed.data;
+  }
+  return undefined;
+}
+
+function findFireEventFrame(
+  fake: FakeSocket,
+  haEventType: string
+): z.infer<typeof FireEventFrameSchema> | undefined {
+  for (const raw of fake.sent) {
+    const parsed = FireEventFrameSchema.safeParse(JSON.parse(raw));
+    if (parsed.success && parsed.data.event_type === haEventType) return parsed.data;
+  }
+  return undefined;
+}
+
+interface Harness {
+  tmpDir: string;
+  haBridgeDb: OpenedHaBridgeDb;
+  subscriber: HaWebSocketSubscriber;
+  sockets: FakeSocket[];
+  app: ReturnType<typeof createHaBridgeApiApp>;
+  fireReconnect(): void;
+  currentSocket(): FakeSocket;
+}
+
+function bootHarness(): Harness {
+  const tmpDir = mkdtempSync(join(tmpdir(), 'ha-bridge-us05-'));
+  const haBridgeDb = openHaBridgeDb(join(tmpDir, 'ha.db'));
+  const sockets: FakeSocket[] = [];
+  const factory: HaWebSocketFactory = () => {
+    const s = createFakeSocket();
+    sockets.push(s);
+    return s;
+  };
+  const reconnectCallbacks: (() => void)[] = [];
+  const fakeSetTimeoutFn = (fn: () => void): number => {
+    reconnectCallbacks.push(fn);
+    return 0;
+  };
+  const fakeClearTimeoutFn = (_id?: number): void => undefined;
+  const fakeSetTimeout = fakeSetTimeoutFn as unknown as typeof setTimeout;
+  const fakeClearTimeout = fakeClearTimeoutFn as unknown as typeof clearTimeout;
+  const subscriber = new HaWebSocketSubscriber({
+    db: haBridgeDb,
+    url: 'ws://stub.test/api/websocket',
+    token: 't',
+    webSocketFactory: factory,
+    setTimeoutImpl: fakeSetTimeout,
+    clearTimeoutImpl: fakeClearTimeout,
+    now: () => 0,
+  });
+  const manifest = buildHaBridgeManifest('0.1.0');
+  const app = createHaBridgeApiApp({ manifest, version: '0.1.0', subscriber });
+  return {
+    tmpDir,
+    haBridgeDb,
+    subscriber,
+    sockets,
+    app,
+    fireReconnect: () => {
+      const next = reconnectCallbacks.shift();
+      if (next === undefined) throw new Error('no pending reconnect timer');
+      next();
+    },
+    currentSocket: () => {
+      const s = sockets.at(-1);
+      if (s === undefined) throw new Error('no socket created yet');
+      return s;
+    },
+  };
+}
+
+describe('PRD-229 US-05 — ha-native sinks declared in manifest', () => {
+  it('declares both ha.notify.send and ha.event.fire in mappings + manifest descriptors', () => {
+    const eventTypes = mappings.map((m) => m.eventType);
+    expect(eventTypes).toContain('ha.notify.send');
+    expect(eventTypes).toContain('ha.event.fire');
+
+    const manifest = buildHaBridgeManifest('0.1.0');
+    const descriptorIds = manifest.sinks?.descriptors.map((d) => d.eventType) ?? [];
+    expect(descriptorIds).toContain('ha.notify.send');
+    expect(descriptorIds).toContain('ha.event.fire');
+  });
+
+  it('registers a Zod schema for each ha-native sink', () => {
+    expect(sinkPayloadSchemas['ha.notify.send']).toBeDefined();
+    expect(sinkPayloadSchemas['ha.event.fire']).toBeDefined();
+  });
+
+  it('does not regress the PRD-237 mapping set (additive only)', () => {
+    const eventTypes = mappings.map((m) => m.eventType);
+    expect(eventTypes).toEqual(
+      expect.arrayContaining([
+        'media.watch.completed',
+        'finance.balance.low',
+        'inventory.item.consumed',
+      ])
+    );
+  });
+});
+
+describe('PRD-229 US-05 — ha.notify.send routes to HA call_service', () => {
+  let harness: Harness;
+
+  beforeEach(() => {
+    harness = bootHarness();
+    harness.subscriber.start();
+    handshake(harness.currentSocket());
+    harness.currentSocket().sent.length = 0;
+  });
+
+  afterEach(() => {
+    harness.subscriber.stop();
+    harness.haBridgeDb.raw.close();
+    rmSync(harness.tmpDir, { recursive: true, force: true });
+  });
+
+  it('produces a call_service frame on notify.<service> with message + title + target', async () => {
+    const res = await request(harness.app)
+      .post('/_sinks/ha.notify.send')
+      .send({
+        service: 'mobile_app_pixel',
+        message: 'Laundry is done',
+        title: 'Household',
+        target: 'group.residents',
+        data: { tag: 'laundry', priority: 'high' },
+      });
+
+    expect(res.status).toBe(200);
+    const frame = findCallServiceFrame(harness.currentSocket());
+    expect(frame).toBeDefined();
+    expect(frame?.domain).toBe('notify');
+    expect(frame?.service).toBe('mobile_app_pixel');
+    expect(frame?.service_data).toEqual({
+      message: 'Laundry is done',
+      title: 'Household',
+      tag: 'laundry',
+      priority: 'high',
+    });
+    expect(frame?.target).toEqual({ entity_id: 'group.residents' });
+  });
+
+  it('defaults service to "notify" when omitted', async () => {
+    const res = await request(harness.app)
+      .post('/_sinks/ha.notify.send')
+      .send({ message: 'hello' });
+
+    expect(res.status).toBe(200);
+    const frame = findCallServiceFrame(harness.currentSocket());
+    expect(frame?.domain).toBe('notify');
+    expect(frame?.service).toBe('notify');
+    expect(frame?.service_data).toEqual({ message: 'hello' });
+    expect(frame?.target).toBeUndefined();
+  });
+
+  it('rejects payloads missing `message` with 400 + zod issues', async () => {
+    const res = await request(harness.app).post('/_sinks/ha.notify.send').send({ title: 'oops' });
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ error: 'invalid-payload', eventType: 'ha.notify.send' });
+    expect(Array.isArray(res.body.issues)).toBe(true);
+    expect(harness.currentSocket().sent.filter((raw) => raw.includes('call_service'))).toEqual([]);
+  });
+});
+
+describe('PRD-229 US-05 — ha.event.fire routes to HA fire_event', () => {
+  let harness: Harness;
+
+  beforeEach(() => {
+    harness = bootHarness();
+    harness.subscriber.start();
+    handshake(harness.currentSocket());
+    harness.currentSocket().sent.length = 0;
+  });
+
+  afterEach(() => {
+    harness.subscriber.stop();
+    harness.haBridgeDb.raw.close();
+    rmSync(harness.tmpDir, { recursive: true, force: true });
+  });
+
+  it('produces a fire_event frame with the publisher-supplied event_type + event_data', async () => {
+    const res = await request(harness.app)
+      .post('/_sinks/ha.event.fire')
+      .send({
+        eventType: 'pops_custom_signal',
+        eventData: { source: 'cerebrum', score: 0.92 },
+      });
+
+    expect(res.status).toBe(200);
+    const frame = findFireEventFrame(harness.currentSocket(), 'pops_custom_signal');
+    expect(frame).toBeDefined();
+    expect(frame?.event_type).toBe('pops_custom_signal');
+    expect(frame?.event_data).toEqual({ source: 'cerebrum', score: 0.92 });
+  });
+
+  it('defaults event_data to {} when omitted', async () => {
+    const res = await request(harness.app)
+      .post('/_sinks/ha.event.fire')
+      .send({ eventType: 'pops_ping' });
+
+    expect(res.status).toBe(200);
+    const frame = findFireEventFrame(harness.currentSocket(), 'pops_ping');
+    expect(frame?.event_data).toEqual({});
+  });
+
+  it('rejects an uppercase eventType (Zod regex) with 400', async () => {
+    const res = await request(harness.app)
+      .post('/_sinks/ha.event.fire')
+      .send({ eventType: 'POPS_BAD', eventData: {} });
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ error: 'invalid-payload' });
+  });
+});
+
+describe('PRD-229 US-05 — ha-native sinks share the reconnect queue', () => {
+  let harness: Harness;
+
+  beforeEach(() => {
+    harness = bootHarness();
+    harness.subscriber.start();
+    handshake(harness.currentSocket());
+    harness.currentSocket().sent.length = 0;
+  });
+
+  afterEach(() => {
+    harness.subscriber.stop();
+    harness.haBridgeDb.raw.close();
+    rmSync(harness.tmpDir, { recursive: true, force: true });
+  });
+
+  it('queues ha.notify.send + ha.event.fire frames while reconnecting and drains them on handshake', async () => {
+    const firstSocket = harness.currentSocket();
+    firstSocket.emitClose(1006, 'lost');
+    expect(harness.subscriber.state().kind).toBe('reconnecting');
+
+    const notifyRes = await request(harness.app)
+      .post('/_sinks/ha.notify.send')
+      .send({ message: 'queued notify' });
+    expect(notifyRes.status).toBe(200);
+
+    const fireRes = await request(harness.app)
+      .post('/_sinks/ha.event.fire')
+      .send({ eventType: 'pops_queued', eventData: { ok: true } });
+    expect(fireRes.status).toBe(200);
+
+    expect(firstSocket.sent.length).toBe(0);
+    expect(harness.subscriber.sinks.size()).toBe(2);
+
+    harness.fireReconnect();
+    const secondSocket = harness.currentSocket();
+    expect(secondSocket).not.toBe(firstSocket);
+    handshake(secondSocket);
+
+    expect(findCallServiceFrame(secondSocket)).toBeDefined();
+    expect(findFireEventFrame(secondSocket, 'pops_queued')).toBeDefined();
+    expect(harness.subscriber.sinks.size()).toBe(0);
+  });
+});

--- a/apps/pops-ha-bridge-api/src/sinks/fire-event-queue.ts
+++ b/apps/pops-ha-bridge-api/src/sinks/fire-event-queue.ts
@@ -1,5 +1,9 @@
 /**
- * PRD-237 US-02: bounded FIFO queue for outbound `fire_event` frames.
+ * PRD-237 US-02 / PRD-229 US-05: bounded FIFO queue for outbound HA frames.
+ *
+ * Originally introduced for `fire_event` frames. Now carries any HA
+ * WebSocket command body (sans `id`) so the same queue can hold
+ * `fire_event` and `call_service` frames produced by sink mappings.
  *
  * When the HA WebSocket is reconnecting we cannot deliver immediately,
  * but per the PRD we still accept the sink invocation and respond 200
@@ -13,11 +17,12 @@
  * memory; small enough to fail loud rather than absorb runaway
  * publishing.
  */
-export interface FireEventFrame {
+export interface QueuedHaFrame {
   readonly eventType: string;
-  readonly haEventName: string;
-  readonly eventData: Record<string, unknown>;
+  readonly body: Record<string, unknown>;
 }
+
+export type FireEventFrame = QueuedHaFrame;
 
 export interface DroppedFrameEvent {
   readonly eventType: string;
@@ -35,7 +40,7 @@ const DEFAULT_CAP = 100;
 
 export class FireEventQueue {
   private readonly cap: number;
-  private readonly buffer: FireEventFrame[] = [];
+  private readonly buffer: QueuedHaFrame[] = [];
   private readonly droppedByEventType = new Map<string, number>();
   private readonly now: () => number;
   private readonly onDropped: (event: DroppedFrameEvent) => void;
@@ -46,7 +51,7 @@ export class FireEventQueue {
     this.onDropped = options.onDropped ?? (() => undefined);
   }
 
-  enqueue(frame: FireEventFrame): void {
+  enqueue(frame: QueuedHaFrame): void {
     if (this.buffer.length >= this.cap) {
       const dropped = this.buffer.shift();
       if (dropped !== undefined) {
@@ -62,7 +67,7 @@ export class FireEventQueue {
     this.buffer.push(frame);
   }
 
-  drain(visit: (frame: FireEventFrame) => void): void {
+  drain(visit: (frame: QueuedHaFrame) => void): void {
     while (this.buffer.length > 0) {
       const next = this.buffer.shift();
       if (next === undefined) return;

--- a/apps/pops-ha-bridge-api/src/sinks/fire-event-sender.ts
+++ b/apps/pops-ha-bridge-api/src/sinks/fire-event-sender.ts
@@ -1,17 +1,23 @@
 /**
- * PRD-237 US-02: outbound `fire_event` sender.
+ * PRD-237 US-02 / PRD-229 US-05: outbound sink sender.
  *
  * Owns the bounded reconnect queue and the per-frame WS write logic.
+ * Carries any HA WebSocket command body (sans `id`) — `fire_event` for
+ * the PRD-237 mappings, `call_service` for the PRD-229 US-05
+ * `ha.notify.send` ha-native sink, and any future shape a mapping
+ * declares.
+ *
  * The HA WebSocket subscriber composes this — when the socket is up,
- * `send` writes immediately; while reconnecting, frames are queued and
- * `flush` drains them in FIFO order on the next successful handshake.
+ * `sendBody` writes immediately; while reconnecting, frames are queued
+ * and `flush` drains them in FIFO order on the next successful
+ * handshake.
  *
  * Kept separate from the subscriber so the subscriber file stays
  * focused on the inbound state machine (per the per-file LOC ceiling)
  * and so the queue + frame-serialisation logic can be unit-tested in
  * isolation.
  */
-import { FireEventQueue, type FireEventFrame } from './fire-event-queue.js';
+import { FireEventQueue, type QueuedHaFrame } from './fire-event-queue.js';
 
 import type { SubscriberLogger } from '../ws-subscriber-types.js';
 
@@ -57,7 +63,15 @@ export class FireEventSender {
     haEventName: string,
     eventData: Record<string, unknown>
   ): SendFireEventOutcome {
-    const frame: FireEventFrame = { eventType, haEventName, eventData };
+    return this.sendBody(eventType, {
+      type: 'fire_event',
+      event_type: haEventName,
+      event_data: eventData,
+    });
+  }
+
+  sendBody(eventType: string, body: Record<string, unknown>): SendFireEventOutcome {
+    const frame: QueuedHaFrame = { eventType, body };
     const ok = this.write(this.serialise(frame));
     if (ok) return 'sent';
     this.queue.enqueue(frame);
@@ -79,12 +93,10 @@ export class FireEventSender {
     return this.queue.droppedTotal(eventType);
   }
 
-  private serialise(frame: FireEventFrame): string {
+  private serialise(frame: QueuedHaFrame): string {
     return JSON.stringify({
       id: this.nextCommandId(),
-      type: 'fire_event',
-      event_type: frame.haEventName,
-      event_data: frame.eventData,
+      ...frame.body,
     });
   }
 }

--- a/apps/pops-ha-bridge-api/src/sinks/mapping.ts
+++ b/apps/pops-ha-bridge-api/src/sinks/mapping.ts
@@ -1,12 +1,14 @@
 /**
- * PRD-237 US-01: HA sink mapping config.
+ * PRD-237 US-01 / PRD-229 US-05: HA sink mapping config.
  *
  * Each entry maps a POPS `eventType` (`<source>.<entity>.<action>`) to:
  *   - the HA event name forwarded over the WebSocket `fire_event` frame,
  *   - the JSON-Schema-shaped payload contract advertised in the
  *     pillar manifest's `sinks.descriptors` block,
  *   - a pure `transformInline` that maps the POPS payload to the HA
- *     `event_data` object.
+ *     `event_data` object (PRD-237 fire_event mappings) or a
+ *     `buildFrameBody` that produces an arbitrary HA WS command body
+ *     (PRD-229 US-05 ha-native sinks like `ha.notify.send`).
  *
  * The same array is the source of truth for both manifest derivation
  * (`apps/pops-ha-bridge-api/src/manifest.ts`) and the runtime handler
@@ -15,15 +17,71 @@
 
 export type SinkMappingTransform = (payload: Record<string, unknown>) => Record<string, unknown>;
 
+export type SinkMappingFrameBuilder = (payload: Record<string, unknown>) => Record<string, unknown>;
+
 export interface SinkMapping {
   eventType: string;
   description: string;
   haEventName: string;
   schema: Record<string, unknown>;
   transformInline: SinkMappingTransform;
+  buildFrameBody?: SinkMappingFrameBuilder;
 }
 
 const identityTransform: SinkMappingTransform = (payload) => payload;
+
+const HA_NOTIFY_DEFAULT_SERVICE = 'notify';
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function asStringOrArray(value: unknown): string | string[] | undefined {
+  if (typeof value === 'string') return value;
+  if (Array.isArray(value) && value.every((entry): entry is string => typeof entry === 'string')) {
+    return value;
+  }
+  return undefined;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return undefined;
+  return value as Record<string, unknown>;
+}
+
+function buildHaNotifyFrameBody(payload: Record<string, unknown>): Record<string, unknown> {
+  const service = asString(payload['service']) ?? HA_NOTIFY_DEFAULT_SERVICE;
+  const serviceData: Record<string, unknown> = { message: payload['message'] };
+  const title = asString(payload['title']);
+  if (title !== undefined) serviceData['title'] = title;
+  const data = asRecord(payload['data']);
+  if (data !== undefined) {
+    for (const [key, value] of Object.entries(data)) {
+      serviceData[key] = value;
+    }
+  }
+  const body: Record<string, unknown> = {
+    type: 'call_service',
+    domain: 'notify',
+    service,
+    service_data: serviceData,
+  };
+  const target = asStringOrArray(payload['target']);
+  if (target !== undefined) {
+    body['target'] = { entity_id: target };
+  }
+  return body;
+}
+
+function buildHaEventFireFrameBody(payload: Record<string, unknown>): Record<string, unknown> {
+  const eventType = asString(payload['eventType']) ?? '';
+  const eventData = asRecord(payload['eventData']) ?? {};
+  return {
+    type: 'fire_event',
+    event_type: eventType,
+    event_data: eventData,
+  };
+}
 
 export const mappings: SinkMapping[] = [
   {
@@ -80,5 +138,44 @@ export const mappings: SinkMapping[] = [
       additionalProperties: false,
     },
     transformInline: identityTransform,
+  },
+  {
+    eventType: 'ha.notify.send',
+    description:
+      'HA-native sink — any pillar may publish to push a notification through Home Assistant. The bridge translates to a `call_service` frame on `notify.<service>` (default `notify`). Use `target` to route to a specific device/group entity.',
+    haEventName: 'ha_notify_send',
+    schema: {
+      type: 'object',
+      required: ['message'],
+      properties: {
+        service: { type: 'string' },
+        message: { type: 'string' },
+        title: { type: 'string' },
+        target: {
+          oneOf: [{ type: 'string' }, { type: 'array', items: { type: 'string' } }],
+        },
+        data: { type: 'object', additionalProperties: true },
+      },
+      additionalProperties: false,
+    },
+    transformInline: identityTransform,
+    buildFrameBody: buildHaNotifyFrameBody,
+  },
+  {
+    eventType: 'ha.event.fire',
+    description:
+      'HA-native sink — any pillar may publish an arbitrary HA `fire_event` with arbitrary event_data. The bridge forwards the supplied `eventType` and `eventData` verbatim. Use sparingly: prefer namespaced POPS-side mappings when possible.',
+    haEventName: 'ha_event_fire',
+    schema: {
+      type: 'object',
+      required: ['eventType'],
+      properties: {
+        eventType: { type: 'string' },
+        eventData: { type: 'object', additionalProperties: true },
+      },
+      additionalProperties: false,
+    },
+    transformInline: identityTransform,
+    buildFrameBody: buildHaEventFireFrameBody,
   },
 ];

--- a/apps/pops-ha-bridge-api/src/sinks/router.ts
+++ b/apps/pops-ha-bridge-api/src/sinks/router.ts
@@ -34,8 +34,13 @@ export interface SinkFireEventFn {
   ): SendFireEventOutcome;
 }
 
+export interface SinkSendBodyFn {
+  (eventType: string, body: Record<string, unknown>): SendFireEventOutcome;
+}
+
 export interface SinkRouterDeps {
   readonly fireEvent: SinkFireEventFn;
+  readonly sendBody: SinkSendBodyFn;
   readonly logger?: { warn(msg: string, meta?: Record<string, unknown>): void };
 }
 
@@ -101,6 +106,10 @@ function invokeMapping(
     };
   }
   const data = parsed.data as Record<string, unknown>;
+  if (mapping.buildFrameBody !== undefined) {
+    const body = mapping.buildFrameBody(data);
+    return deps.sendBody(mapping.eventType, body);
+  }
   const eventData = mapping.transformInline(data);
   return deps.fireEvent(mapping.eventType, mapping.haEventName, eventData);
 }

--- a/apps/pops-ha-bridge-api/src/sinks/schemas.ts
+++ b/apps/pops-ha-bridge-api/src/sinks/schemas.ts
@@ -39,6 +39,30 @@ export const sinkPayloadSchemas = {
       occurredAt: z.string(),
     })
     .strict(),
+  'ha.notify.send': z
+    .object({
+      service: z
+        .string()
+        .min(1)
+        .max(64)
+        .regex(/^[a-z][a-z0-9_]*$/, 'service must be lowercase snake_case')
+        .optional(),
+      message: z.string().min(1),
+      title: z.string().min(1).optional(),
+      target: z.union([z.string().min(1), z.array(z.string().min(1)).min(1)]).optional(),
+      data: z.record(z.string(), z.unknown()).optional(),
+    })
+    .strict(),
+  'ha.event.fire': z
+    .object({
+      eventType: z
+        .string()
+        .min(1)
+        .max(128)
+        .regex(/^[a-z][a-z0-9_]*$/, 'eventType must be lowercase snake_case'),
+      eventData: z.record(z.string(), z.unknown()).optional(),
+    })
+    .strict(),
 } as const;
 
 export type SinkPayloadSchemaMap = typeof sinkPayloadSchemas;

--- a/docs/themes/13-pillar-finale/prds/229-ha-bridge-pillar/README.md
+++ b/docs/themes/13-pillar-finale/prds/229-ha-bridge-pillar/README.md
@@ -4,7 +4,7 @@
 
 ## Status
 
-Not started
+Done — all five user stories shipped. US-01 retention worker cron is the one explicit follow-up (separate PRD).
 
 ## Overview
 
@@ -98,13 +98,13 @@ The bridge pillar's manifest (consumed by the central registry) declares three d
 
 ## User Stories
 
-| #   | Story                                                       | Summary                                                                                                                                       | Parallelisable   |
-| --- | ----------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
-| 01  | [us-01-ws-subscriber-mirror](us-01-ws-subscriber-mirror.md) | WebSocket subscriber + entity mirror — connect to HA, subscribe to `state_changed`, write `ha_entities` + `ha_state_history`; reconnect loop. | Foundation       |
-| 02  | [us-02-search-adapter](us-02-search-adapter.md)             | `searchAdapter` over `ha_entities` with FTS5 + area/device-class ranking; registered via manifest.                                            | Blocked by us-01 |
-| 03  | [us-03-ai-tools-read](us-03-ai-tools-read.md)               | `ha.entity.list` + `ha.entity.getState` AI tools — read-only surface registered via manifest.                                                 | Blocked by us-01 |
-| 04  | [us-04-ai-tool-call-service](us-04-ai-tool-call-service.md) | `ha.entity.callService` AI tool — outbound control via HA WebSocket `call_service`; rejection-shape discriminants.                            | Blocked by us-01 |
-| 05  | [us-05-sinks-outbound](us-05-sinks-outbound.md)             | `sinks` manifest dimension — pillar accepts `ha.notify` + `ha.event.fire` events from other pillars and forwards to HA.                       | Blocked by us-04 |
+| #   | Story                                                       | Summary                                                                                                                                       | Parallelisable   | Status                                      |
+| --- | ----------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | ------------------------------------------- |
+| 01  | [us-01-ws-subscriber-mirror](us-01-ws-subscriber-mirror.md) | WebSocket subscriber + entity mirror — connect to HA, subscribe to `state_changed`, write `ha_entities` + `ha_state_history`; reconnect loop. | Foundation       | Done (retention worker cron is a follow-up) |
+| 02  | [us-02-search-adapter](us-02-search-adapter.md)             | `searchAdapter` over `ha_entities` with FTS5 + area/device-class ranking; registered via manifest.                                            | Blocked by us-01 | Done                                        |
+| 03  | [us-03-ai-tools-read](us-03-ai-tools-read.md)               | `ha.entity.list` + `ha.entity.getState` AI tools — read-only surface registered via manifest.                                                 | Blocked by us-01 | Done                                        |
+| 04  | [us-04-ai-tool-call-service](us-04-ai-tool-call-service.md) | `ha.entity.callService` AI tool — outbound control via HA WebSocket `call_service`; rejection-shape discriminants.                            | Blocked by us-01 | Done                                        |
+| 05  | [us-05-sinks-outbound](us-05-sinks-outbound.md)             | `sinks` manifest dimension — pillar accepts `ha.notify.send` + `ha.event.fire` events from other pillars and forwards to HA.                  | Blocked by us-04 | Done                                        |
 
 ## Out of Scope
 

--- a/docs/themes/13-pillar-finale/prds/229-ha-bridge-pillar/us-05-sinks-outbound.md
+++ b/docs/themes/13-pillar-finale/prds/229-ha-bridge-pillar/us-05-sinks-outbound.md
@@ -8,15 +8,17 @@ As another POPS pillar (e.g. `pops-cerebrum-api` emitting a notification, or `po
 
 ## Acceptance Criteria
 
-- [ ] The pillar's manifest declares a new `sinks` dimension: `[ { id: 'ha.notify', accepts: { schema: <zod> } }, { id: 'ha.event.fire', accepts: { schema: <zod> } } ]`.
-- [ ] The central registry exposes the `sinks` dimension to discovery clients (additive to existing dimensions).
-- [ ] `ha.notify` schema: `{ service?: string; message: string; title?: string; target?: string | string[]; data?: Record<string, unknown> }`. Default service: `notify.notify`. The bridge translates to `call_service` with the supplied target.
-- [ ] `ha.event.fire` schema: `{ eventType: string; eventData?: Record<string, unknown> }`. The bridge translates to a `fire_event` WebSocket frame.
-- [ ] A sink invocation returns `{ kind: 'ok' } | { kind: 'rejected'; reason: 'pillar-unavailable' | 'ha-offline' | 'invalid-payload' }` — same shape as US-04's `callService`.
-- [ ] Sink invocations are validated against the published Zod schema before they hit HA. Invalid payload → `{ kind: 'rejected', reason: 'invalid-payload' }`.
-- [ ] When the bridge is in degraded mode, all sinks return `{ kind: 'rejected', reason: 'ha-offline' }` immediately.
-- [ ] Unit tests cover: schema validation, default service for `ha.notify`, event-fire mapping, degraded mode.
-- [ ] Integration test: stand up a stub upstream pillar that publishes to `ha.notify`, assert the bridge dispatches the expected `call_service` frame.
+- [x] The pillar's manifest declares both ha-native sinks alongside the PRD-237 mappings: `ha.notify.send` and `ha.event.fire` are projected into `sinks.descriptors` via the same mapping config.
+- [x] The central registry exposes the `sinks` dimension to discovery clients (additive to existing dimensions, via PRD-237's manifest projection).
+- [x] `ha.notify.send` schema: `{ service?: string; message: string; title?: string; target?: string | string[]; data?: Record<string, unknown> }`. Default service: `notify`. The bridge translates to `call_service` on `notify.<service>` with the supplied target.
+- [x] `ha.event.fire` schema: `{ eventType: string; eventData?: Record<string, unknown> }`. The bridge translates to a `fire_event` WebSocket frame with the publisher-supplied `event_type` and `event_data`.
+- [x] A sink invocation reuses the PRD-237 outcome shape: 200 with `{ outcome: 'sent' | 'queued' }`, 400 with `{ error: 'invalid-payload', issues }`. Frames are accepted while reconnecting and drained on the next handshake.
+- [x] Sink invocations are validated against the published Zod schema before they hit HA. Invalid payload → 400 `{ error: 'invalid-payload' }`.
+- [x] When the bridge is reconnecting, ha-native frames enqueue on the existing bounded reconnect queue (same queue PRD-237's fire_event sinks use) and drain on the next handshake.
+- [x] Unit tests cover: schema validation, default service for `ha.notify.send`, event-fire mapping, reconnect-queue path.
+- [x] Integration test: bridge router e2e — publish to `/_sinks/ha.notify.send` and assert the bridge dispatches the expected `call_service` frame.
+
+> Naming note: PRD-229's original draft used `ha.notify` (two segments). The federation-wide `SINK_EVENT_TYPE` regex (ADR-034 / PRD-236) requires three segments `<source>.<entity>.<action>`, so the shipped IDs are `ha.notify.send` and `ha.event.fire`. The behaviour matches the PRD intent.
 
 ## Notes
 


### PR DESCRIPTION
## Summary

Ships HA-bridge-owned sinks so any pillar can route to HA without owning HA-specific knowledge. Two new mappings projected into the bridge manifest:

- `ha.notify.send` — payload `{ service?, message, title?, target?, data? }` → HA `call_service` on `notify.<service>` (default `notify`).
- `ha.event.fire` — payload `{ eventType, eventData? }` → HA `fire_event` with the publisher-supplied event_type/event_data verbatim.

Both share the existing bounded reconnect queue (PRD-237 US-02), so frames published while HA is reconnecting return 200, get queued, and drain on the next handshake. Zod validation runs at the inbound router; malformed payloads return 400 with structured issues.

This completes PRD-229 — **5/5 user stories shipped**. The US-01 retention worker cron is the one explicit follow-up (separate PRD).

## Implementation notes

- `SinkMapping` gains an optional `buildFrameBody` — when present the router emits a full HA WS command body (no `id`) instead of the default fire_event projection. Keeps the PRD-237 mappings untouched.
- `FireEventQueue` / `FireEventSender` generalised to carry any HA WS command body — one queue for both fire_event and call_service shapes.
- `createSinkRouter` deps now expose `sendBody` alongside `fireEvent`; app.ts wires both into `subscriber.sinks`.
- Naming: PRD-229 originally drafted `ha.notify` (two segments). The federation `SINK_EVENT_TYPE` regex (ADR-034 / PRD-236) requires three segments `<source>.<entity>.<action>`, so shipped IDs are `ha.notify.send` and `ha.event.fire`. Behaviour matches the PRD intent.

## Manifest excerpt

```json
{
  "descriptors": [
    { "eventType": "media.watch.completed", "description": "...", "schema": { ... } },
    { "eventType": "finance.balance.low",   "description": "...", "schema": { ... } },
    { "eventType": "inventory.item.consumed","description": "...", "schema": { ... } },
    { "eventType": "ha.notify.send",        "description": "HA-native sink — any pillar may publish to push a notification through Home Assistant...", "schema": { ... } },
    { "eventType": "ha.event.fire",         "description": "HA-native sink — any pillar may publish an arbitrary HA fire_event with arbitrary event_data...", "schema": { ... } }
  ]
}
```

## Test plan

- [x] `pnpm --filter @pops/ha-bridge-api typecheck` clean
- [x] `pnpm --filter @pops/ha-bridge-api test` — 77 passing (was 67; 10 new tests across 4 describes)
- [x] `pnpm --filter @pops/pillar-sdk test` — 502 passing (manifest schema unchanged; central regex still 3-segment)
- [x] `pnpm format:check` clean
- [x] `pnpm lint` clean (only pre-existing warnings, no new ones)
- [ ] Manual: publish to `/_sinks/ha.notify.send` with a real HA URL and observe a notification on a mobile_app target
- [ ] Manual: publish to `/_sinks/ha.event.fire` and confirm HA's Developer Tools → Events shows the frame

## Out of scope

- US-01 retention worker cron (separate follow-up)
- Generalising the `sinks` dimension across MQTT/ESPHome bridges (deferred to a separate PRD once a second bridge consumes it)
