### PR TITLE
feat(ha-bridge): retention worker cron (closes PRD-229 US-01)

### DIFF
--- a/apps/pops-ha-bridge-api/src/__tests__/retention-worker.test.ts
+++ b/apps/pops-ha-bridge-api/src/__tests__/retention-worker.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { HaBridgeDb } from '@pops/ha-bridge-db';
+
+const pruneHistoryMock = vi.fn<(db: HaBridgeDb, cutoffMs: number) => number>();
+
+vi.mock('@pops/ha-bridge-db', () => ({
+  pruneHistory: (db: HaBridgeDb, cutoffMs: number) => pruneHistoryMock(db, cutoffMs),
+}));
+
+const { startRetentionWorker } = await import('../retention-worker.js');
+
+const fakeDb = { __tag: 'fake-db' } as unknown as HaBridgeDb;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-06-01T00:00:00Z'));
+  pruneHistoryMock.mockReset();
+  pruneHistoryMock.mockReturnValue(0);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('startRetentionWorker (PRD-229 US-01)', () => {
+  it('runs pruneHistory immediately on start with the configured cutoff', () => {
+    const handle = startRetentionWorker({ db: fakeDb, retentionDays: 30 });
+
+    expect(pruneHistoryMock).toHaveBeenCalledTimes(1);
+    const expectedCutoff = Date.now() - 30 * 24 * 60 * 60 * 1000;
+    expect(pruneHistoryMock).toHaveBeenLastCalledWith(fakeDb, expectedCutoff);
+
+    handle.stop();
+  });
+
+  it('reschedules at intervalMs', () => {
+    const intervalMs = 60_000;
+    const handle = startRetentionWorker({ db: fakeDb, intervalMs, retentionDays: 7 });
+
+    expect(pruneHistoryMock).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(intervalMs);
+    expect(pruneHistoryMock).toHaveBeenCalledTimes(2);
+
+    vi.advanceTimersByTime(intervalMs * 2);
+    expect(pruneHistoryMock).toHaveBeenCalledTimes(4);
+
+    handle.stop();
+  });
+
+  it('survives a failing prune and reschedules the next run', () => {
+    pruneHistoryMock.mockImplementationOnce(() => {
+      throw new Error('boom');
+    });
+    pruneHistoryMock.mockReturnValueOnce(5);
+
+    const warn = vi.fn();
+    const intervalMs = 1_000;
+    const handle = startRetentionWorker({
+      db: fakeDb,
+      intervalMs,
+      retentionDays: 30,
+      logger: { warn },
+    });
+
+    expect(pruneHistoryMock).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(
+      'ha-bridge retention prune failed',
+      expect.objectContaining({ error: 'boom' })
+    );
+
+    vi.advanceTimersByTime(intervalMs);
+    expect(pruneHistoryMock).toHaveBeenCalledTimes(2);
+
+    handle.stop();
+  });
+
+  it('stop() prevents future runs', () => {
+    const intervalMs = 1_000;
+    const handle = startRetentionWorker({ db: fakeDb, intervalMs, retentionDays: 30 });
+
+    expect(pruneHistoryMock).toHaveBeenCalledTimes(1);
+
+    handle.stop();
+    vi.advanceTimersByTime(intervalMs * 10);
+
+    expect(pruneHistoryMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs deleted count via info logger after a successful prune', () => {
+    pruneHistoryMock.mockReturnValueOnce(42);
+    const info = vi.fn();
+
+    const handle = startRetentionWorker({
+      db: fakeDb,
+      retentionDays: 14,
+      logger: { info },
+    });
+
+    expect(info).toHaveBeenCalledWith(
+      'ha-bridge retention prune complete',
+      expect.objectContaining({ deleted: 42, retentionDays: 14 })
+    );
+
+    handle.stop();
+  });
+});

--- a/apps/pops-ha-bridge-api/src/retention-worker.ts
+++ b/apps/pops-ha-bridge-api/src/retention-worker.ts
@@ -1,0 +1,65 @@
+/**
+ * Daily retention worker for the HA bridge history table (PRD-229 US-01).
+ *
+ * Runs `pruneHistory` on a recursive `setTimeout` schedule. The recursive
+ * pattern (vs `setInterval`) makes the worker easier to test with fake
+ * timers and guarantees the next tick is only armed after the current
+ * run resolves — so a slow prune cannot pile up overlapping invocations.
+ *
+ * Errors are logged and the next tick is still scheduled; a transient
+ * SQLite failure must not crash the pillar.
+ */
+import { pruneHistory, type HaBridgeDb } from '@pops/ha-bridge-db';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export interface RetentionWorkerLogger {
+  info?: (msg: string, meta?: Record<string, unknown>) => void;
+  warn?: (msg: string, meta?: Record<string, unknown>) => void;
+}
+
+export interface RetentionWorkerOptions {
+  db: HaBridgeDb;
+  intervalMs?: number;
+  retentionDays?: number;
+  logger?: RetentionWorkerLogger;
+  now?: () => number;
+}
+
+export interface RetentionWorkerHandle {
+  stop: () => void;
+}
+
+export function startRetentionWorker(options: RetentionWorkerOptions): RetentionWorkerHandle {
+  const intervalMs = options.intervalMs ?? DAY_MS;
+  const retentionDays = options.retentionDays ?? 30;
+  const now = options.now ?? Date.now;
+  const logger = options.logger;
+
+  let timer: NodeJS.Timeout | undefined;
+  let stopped = false;
+
+  const tick = (): void => {
+    try {
+      const cutoffMs = now() - retentionDays * DAY_MS;
+      const deleted = pruneHistory(options.db, cutoffMs);
+      logger?.info?.('ha-bridge retention prune complete', { deleted, retentionDays });
+    } catch (err) {
+      logger?.warn?.('ha-bridge retention prune failed', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+    if (!stopped) {
+      timer = setTimeout(tick, intervalMs);
+    }
+  };
+
+  tick();
+
+  return {
+    stop: () => {
+      stopped = true;
+      if (timer !== undefined) clearTimeout(timer);
+    },
+  };
+}

--- a/apps/pops-ha-bridge-api/src/server.ts
+++ b/apps/pops-ha-bridge-api/src/server.ts
@@ -24,6 +24,11 @@ import { bootstrapPillar, type PillarBootstrapHandle } from '@pops/pillar-sdk/bo
 import { createHaBridgeApiApp } from './app.js';
 import { resolveHaBridgeSqlitePath } from './ha-bridge-sqlite-path.js';
 import { buildHaBridgeManifest } from './manifest.js';
+import {
+  startRetentionWorker,
+  type RetentionWorkerHandle,
+  type RetentionWorkerLogger,
+} from './retention-worker.js';
 import { HaWebSocketSubscriber, type HaWebSocketLike } from './ws-subscriber.js';
 
 function resolvePort(): number {
@@ -99,6 +104,33 @@ if (process.env['POPS_REGISTRY_ENABLED'] === 'true') {
 
 subscriber.start();
 
+function resolveRetentionDays(): number | undefined {
+  const raw = process.env['HA_BRIDGE_RETENTION_DAYS'];
+  if (raw === undefined || raw === '') return undefined;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(
+      `[ha-bridge] HA_BRIDGE_RETENTION_DAYS must be a non-negative integer; got '${raw}'`
+    );
+  }
+  return parsed;
+}
+
+const retentionDaysOverride = resolveRetentionDays();
+const retentionLogger: RetentionWorkerLogger = {
+  info: (msg, meta) => console.warn(`[ha-bridge] ${msg}`, meta ?? {}),
+  warn: (msg, meta) => console.warn(`[ha-bridge] ${msg}`, meta ?? {}),
+};
+
+let retentionHandle: RetentionWorkerHandle | undefined;
+if (retentionDaysOverride !== 0) {
+  retentionHandle = startRetentionWorker({
+    db: haBridgeDb.db,
+    retentionDays: retentionDaysOverride,
+    logger: retentionLogger,
+  });
+}
+
 const server = app.listen(port, () => {
   console.warn(`[ha-bridge] Listening on port ${port}`);
 });
@@ -109,6 +141,7 @@ function shutdown(signal: NodeJS.Signals): void {
   shuttingDown = true;
   console.warn(`[ha-bridge] Shutting down (${signal})`);
   subscriber.stop();
+  retentionHandle?.stop();
   void (pillarHandle?.stop() ?? Promise.resolve()).finally(() => {
     server.close(() => {
       haBridgeDb.raw.close();


### PR DESCRIPTION
## Summary
- Adds `startRetentionWorker` (recursive `setTimeout` — no cron lib) that runs `pruneHistory` daily on the HA bridge SQLite to drop `ha_state_history` rows older than `HA_BRIDGE_RETENTION_DAYS` (default 30).
- Wires the worker into `apps/pops-ha-bridge-api/src/server.ts` after registry registration, stops it on SIGTERM/SIGINT alongside the subscriber, and skips boot entirely when `HA_BRIDGE_RETENTION_DAYS=0`.
- 5 new vitest cases under `vi.useFakeTimers()` cover immediate run, reschedule cadence, surviving a failing prune, `stop()` cancellation, and successful-prune logging.

## PRD-229 status
This closes the US-01 leftover noted in PR #3152's report ("retention worker on a daily schedule … cron wiring is not scheduled in `server.ts` yet"). Theme 13 PRD-229 is now 5/5 user stories complete.

## Config
| Env | Default | Notes |
| --- | --- | --- |
| `HA_BRIDGE_RETENTION_DAYS` | `30` | History rows older than this are deleted on each tick. Set to `0` to disable the worker. Non-integer or negative values throw at boot. |
| `intervalMs` (programmatic) | 24h | Override via `startRetentionWorker({ intervalMs })` — production uses the default. |

## Test plan
- [x] `pnpm --filter @pops/ha-bridge-api test` (11 files / 82 tests pass — 5 new)
- [x] `pnpm --filter @pops/ha-bridge-api typecheck`
- [x] `pnpm lint`, `pnpm format:check`, `pnpm lint:boundaries:verify`, `pnpm lint:boundaries`
- [ ] CI on this PR