### PR TITLE
feat(core-db): ai_alerts + ai_alert_rules PR4 — move tables + ATTACH backfill + flip 7 handler sites (Wave 5)

### DIFF
--- a/apps/pops-api/src/db/backfill-core-from-shared.test.ts
+++ b/apps/pops-api/src/db/backfill-core-from-shared.test.ts
@@ -3,13 +3,15 @@
  *
  * Exercises the ATTACH-based copy from the shared `pops.db` to the
  * core pillar's `core.db` against on-disk SQLite files (in-memory DBs
- * can't be ATTACHed). The trio covered by this PR is `ai_model_pricing`,
- * `sync_job_results`, and `ai_usage` — the writer cutover that lets us
- * retire each entry happens in the follow-up PR; until then this bridge
- * runs on every boot. Confirms:
- *   - first run carries existing rows across for all three tables,
+ * can't be ATTACHed). The set covered by this bridge is
+ * `ai_model_pricing`, `sync_job_results`, `ai_usage`, `ai_alert_rules`,
+ * and `ai_alerts` — the writer cutover that lets us retire each entry
+ * happens once the handler flip lands; until then this bridge runs on
+ * every boot. Confirms:
+ *   - first run carries existing rows across for all tables,
  *   - second run is a no-op (idempotent — the per-table NOT EXISTS dedupes),
  *   - composite-key dedup honours (provider_id, model_id) for ai_model_pricing,
+ *   - ai_alerts.rule_id FK survives the ATTACH copy,
  *   - missing source table is tolerated without throwing.
  */
 import { mkdtempSync, rmSync } from 'node:fs';
@@ -82,12 +84,51 @@ CREATE INDEX idx_ai_usage_created_at ON ai_usage (created_at);
 CREATE INDEX idx_ai_usage_batch ON ai_usage (import_batch_id);
 `;
 
+const AI_ALERT_RULES_SQL = `
+CREATE TABLE ai_alert_rules (
+  id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  type text NOT NULL,
+  scope_provider text,
+  scope_model text,
+  threshold_value real NOT NULL,
+  window_minutes integer,
+  enabled integer DEFAULT 1 NOT NULL,
+  created_at text NOT NULL,
+  updated_at text NOT NULL
+);
+CREATE INDEX idx_ai_alert_rules_type ON ai_alert_rules (type);
+CREATE INDEX idx_ai_alert_rules_enabled ON ai_alert_rules (enabled);
+`;
+
+const AI_ALERTS_SQL = `
+CREATE TABLE ai_alerts (
+  id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  rule_id integer REFERENCES ai_alert_rules(id) ON DELETE SET NULL,
+  type text NOT NULL,
+  message text NOT NULL,
+  severity text NOT NULL,
+  scope_detail text,
+  metric_value real NOT NULL,
+  threshold_value real NOT NULL,
+  acknowledged integer DEFAULT 0 NOT NULL,
+  acknowledged_at text,
+  created_at text NOT NULL
+);
+CREATE INDEX idx_ai_alerts_created_at ON ai_alerts (created_at);
+CREATE INDEX idx_ai_alerts_type ON ai_alerts (type);
+CREATE INDEX idx_ai_alerts_severity ON ai_alerts (severity);
+CREATE INDEX idx_ai_alerts_acknowledged ON ai_alerts (acknowledged);
+CREATE INDEX idx_ai_alerts_dedupe ON ai_alerts (type, scope_detail, created_at);
+`;
+
 function openSharedWithSeed(seed: (raw: BetterSqlite3.Database) => void): string {
   const path = join(tmpDir, 'pops.db');
   const raw = new BetterSqlite3(path);
   raw.exec(AI_MODEL_PRICING_SQL);
   raw.exec(SYNC_JOB_RESULTS_SQL);
   raw.exec(AI_USAGE_SQL);
+  raw.exec(AI_ALERT_RULES_SQL);
+  raw.exec(AI_ALERTS_SQL);
   seed(raw);
   raw.close();
   return path;
@@ -123,12 +164,36 @@ function insertUsage(raw: BetterSqlite3.Database, description: string): void {
     .run(description);
 }
 
+function insertAlertRule(raw: BetterSqlite3.Database, type: string): number {
+  const row = raw
+    .prepare(
+      `INSERT INTO ai_alert_rules
+        (type, scope_provider, scope_model, threshold_value, window_minutes, enabled, created_at, updated_at)
+       VALUES (?, NULL, NULL, 80, 60, 1, datetime('now'), datetime('now'))
+       RETURNING id`
+    )
+    .get(type) as { id: number };
+  return row.id;
+}
+
+function insertAlert(raw: BetterSqlite3.Database, ruleId: number, type: string): void {
+  raw
+    .prepare(
+      `INSERT INTO ai_alerts
+        (rule_id, type, message, severity, scope_detail, metric_value, threshold_value, acknowledged, created_at)
+       VALUES (?, ?, ?, 'warning', ?, 81, 80, 0, datetime('now'))`
+    )
+    .run(ruleId, type, `${type} fired`, `scope:${type}`);
+}
+
 describe('backfillCoreFromShared', () => {
-  it('copies ai_model_pricing, sync_job_results, and ai_usage rows from shared on first run', () => {
+  it('copies ai_model_pricing, sync_job_results, ai_usage, ai_alert_rules, and ai_alerts rows from shared on first run', () => {
     const sharedPath = openSharedWithSeed((raw) => {
       insertPricing(raw, 'claude', 'claude-haiku-4-5');
       insertSync(raw, 'job-a');
       insertUsage(raw, 'seed-usage');
+      const ruleId = insertAlertRule(raw, 'budget-threshold');
+      insertAlert(raw, ruleId, 'budget-threshold');
     });
 
     const core = openCoreDb(join(tmpDir, 'core.db'));
@@ -151,6 +216,28 @@ describe('backfillCoreFromShared', () => {
         input_tokens: number;
       }[];
       expect(usage).toEqual([{ description: 'seed-usage', input_tokens: 100 }]);
+
+      const rules = core.raw
+        .prepare('SELECT id, type, threshold_value FROM ai_alert_rules')
+        .all() as { id: number; type: string; threshold_value: number }[];
+      expect(rules).toEqual([{ id: 1, type: 'budget-threshold', threshold_value: 80 }]);
+
+      const alerts = core.raw
+        .prepare('SELECT rule_id, type, scope_detail, metric_value FROM ai_alerts')
+        .all() as {
+        rule_id: number;
+        type: string;
+        scope_detail: string;
+        metric_value: number;
+      }[];
+      expect(alerts).toEqual([
+        {
+          rule_id: 1,
+          type: 'budget-threshold',
+          scope_detail: 'scope:budget-threshold',
+          metric_value: 81,
+        },
+      ]);
     } finally {
       core.raw.close();
     }
@@ -161,6 +248,8 @@ describe('backfillCoreFromShared', () => {
       insertPricing(raw, 'claude', 'claude-haiku-4-5');
       insertSync(raw, 'job-a');
       insertUsage(raw, 'seed-usage');
+      const ruleId = insertAlertRule(raw, 'budget-threshold');
+      insertAlert(raw, ruleId, 'budget-threshold');
     });
 
     const core = openCoreDb(join(tmpDir, 'core.db'));
@@ -177,9 +266,46 @@ describe('backfillCoreFromShared', () => {
       const usageCount = (
         core.raw.prepare('SELECT count(*) AS n FROM ai_usage').get() as { n: number }
       ).n;
+      const ruleCount = (
+        core.raw.prepare('SELECT count(*) AS n FROM ai_alert_rules').get() as { n: number }
+      ).n;
+      const alertCount = (
+        core.raw.prepare('SELECT count(*) AS n FROM ai_alerts').get() as { n: number }
+      ).n;
       expect(pricingCount).toBe(1);
       expect(syncCount).toBe(1);
       expect(usageCount).toBe(1);
+      expect(ruleCount).toBe(1);
+      expect(alertCount).toBe(1);
+    } finally {
+      core.raw.close();
+    }
+  });
+
+  it('preserves ai_alerts.rule_id FK to ai_alert_rules.id across the ATTACH copy', () => {
+    const sharedPath = openSharedWithSeed((raw) => {
+      const errorSpikeRuleId = insertAlertRule(raw, 'error-spike');
+      const latencyRuleId = insertAlertRule(raw, 'latency-degradation');
+      insertAlert(raw, latencyRuleId, 'latency-degradation');
+      insertAlert(raw, errorSpikeRuleId, 'error-spike');
+    });
+
+    const core = openCoreDb(join(tmpDir, 'core.db'));
+    try {
+      backfillCoreFromShared(core, sharedPath);
+
+      const joined = core.raw
+        .prepare(
+          `SELECT a.type AS alert_type, r.type AS rule_type
+             FROM ai_alerts a
+             JOIN ai_alert_rules r ON r.id = a.rule_id
+             ORDER BY a.type`
+        )
+        .all() as { alert_type: string; rule_type: string }[];
+      expect(joined).toEqual([
+        { alert_type: 'error-spike', rule_type: 'error-spike' },
+        { alert_type: 'latency-degradation', rule_type: 'latency-degradation' },
+      ]);
     } finally {
       core.raw.close();
     }
@@ -239,9 +365,17 @@ describe('backfillCoreFromShared', () => {
       const usageCount = (
         core.raw.prepare('SELECT count(*) AS n FROM ai_usage').get() as { n: number }
       ).n;
+      const ruleCount = (
+        core.raw.prepare('SELECT count(*) AS n FROM ai_alert_rules').get() as { n: number }
+      ).n;
+      const alertCount = (
+        core.raw.prepare('SELECT count(*) AS n FROM ai_alerts').get() as { n: number }
+      ).n;
       expect(pricingCount).toBe(0);
       expect(syncCount).toBe(0);
       expect(usageCount).toBe(0);
+      expect(ruleCount).toBe(0);
+      expect(alertCount).toBe(0);
     } finally {
       core.raw.close();
     }

--- a/apps/pops-api/src/db/backfill-core-from-shared.ts
+++ b/apps/pops-api/src/db/backfill-core-from-shared.ts
@@ -1,18 +1,19 @@
 /**
  * Boot-time backfill from the legacy shared `pops.db` into the core
- * pillar's `core.db` for the three tables PRD-186 PR4 lands in core-db:
- * `ai_model_pricing`, `sync_job_results`, and `ai_usage`.
+ * pillar's `core.db` for the tables PRD-186 PR4 lands in core-db:
+ * `ai_model_pricing`, `sync_job_results`, `ai_usage`, `ai_alert_rules`,
+ * and `ai_alerts`.
  *
  * Phase context: PR4 establishes the per-pillar table home for these
- * tables (`packages/core-db/migrations/0059..0061_*.sql`) ahead of the
- * hot-path writer cutover that flips `inference-pricing.ts`,
- * `inference-middleware.ts`, and `jobs/sync-results.ts` from
- * `getDrizzle()` to `getCoreDrizzle()` in the next PR. Until that cutover
- * lands, writers still target `pops.db` — so this backfill carries the
- * existing rows across on every boot so the new core table isn't a ghost.
- * After the cutover lands and is verified in prod, the corresponding
- * `TABLE_COPIES` entry is retired (matching the cerebrum/finance/media
- * pattern documented in `backfill-cerebrum-from-shared.ts`).
+ * tables (`packages/core-db/migrations/0059..0063_*.sql`) ahead of the
+ * hot-path writer cutover that flips the per-table writers from
+ * `getDrizzle()` to `getCoreDrizzle()` in the same / next PR. Until each
+ * cutover lands, writers still target `pops.db` — so this backfill
+ * carries the existing rows across on every boot so the new core table
+ * isn't a ghost. After a cutover lands and is verified in prod, the
+ * corresponding `TABLE_COPIES` entry is retired (matching the
+ * cerebrum/finance/media pattern documented in
+ * `backfill-cerebrum-from-shared.ts`).
  *
  * Subsequent boots find the core copy already populated and become a
  * no-op via the `WHERE NOT EXISTS (...)` existence filter.
@@ -92,6 +93,38 @@ const TABLE_COPIES: readonly TableCopy[] = [
       'cost_usd',
       'cached',
       'import_batch_id',
+      'created_at',
+    ],
+  },
+  {
+    table: 'ai_alert_rules',
+    idColumns: ['id'],
+    columns: [
+      'id',
+      'type',
+      'scope_provider',
+      'scope_model',
+      'threshold_value',
+      'window_minutes',
+      'enabled',
+      'created_at',
+      'updated_at',
+    ],
+  },
+  {
+    table: 'ai_alerts',
+    idColumns: ['id'],
+    columns: [
+      'id',
+      'rule_id',
+      'type',
+      'message',
+      'severity',
+      'scope_detail',
+      'metric_value',
+      'threshold_value',
+      'acknowledged',
+      'acknowledged_at',
       'created_at',
     ],
   },

--- a/apps/pops-api/src/db/per-pillar-migrations.test.ts
+++ b/apps/pops-api/src/db/per-pillar-migrations.test.ts
@@ -207,10 +207,14 @@ describe('runPerPillarMigrations', () => {
     // registry endpoints), 0056_settings_baseline (PRD-183 US-01 —
     // settings baseline), 0057_ai_usage_baseline (PRD-186 US-01 —
     // ai_inference_log + ai_inference_daily + ai_budgets baseline),
-    // 0058_pillar_registry_external_origin, and the PRD-186 PR4 trio
+    // 0058_pillar_registry_external_origin, the PRD-186 PR4 trio
     // 0059_ai_model_pricing + 0060_sync_job_results + 0061_ai_usage
     // (Wave 5 unblock — the remaining AI Ops + sync-result tables land
-    // in core-db ahead of the hot-path writer cutover);
+    // in core-db ahead of the hot-path writer cutover), and the
+    // PRD-186 PR4 ai-alerts slice 0062_ai_alert_rules + 0063_ai_alerts
+    // (Wave 5 — moves the evaluator's tables and flips the 7
+    // `core/ai-alerts/{alerts-store,evaluator,service}.ts` handler sites
+    // to `getCoreDrizzle()`);
     // `media` owns `packages/media-db/migrations/`
     // with 0021_spooky_lockheed (media pillar Phase 1 PR 2),
     // 0022_media_movies_baseline (Theme 13 PRD-165 US-01 — movies baseline),
@@ -274,6 +278,8 @@ describe('runPerPillarMigrations', () => {
         '0059_ai_model_pricing',
         '0060_sync_job_results',
         '0061_ai_usage',
+        '0062_ai_alert_rules',
+        '0063_ai_alerts',
       ]);
       expect([...result.pillarsApplied].toSorted()).toEqual([
         'cerebrum',

--- a/apps/pops-api/src/modules/core/ai-alerts/alerts-store.ts
+++ b/apps/pops-api/src/modules/core/ai-alerts/alerts-store.ts
@@ -3,12 +3,15 @@
  *
  * Separated from the evaluator orchestrator so each module stays focused
  * and within the project's max-lines lint budget.
+ *
+ * Reads + writes resolve against `getCoreDrizzle()` now that PRD-186 PR 4
+ * lands `ai_alerts` + `ai_alert_rules` in `@pops/core-db`.
  */
 import { and, desc, eq, gte, lte, sql, type SQL } from 'drizzle-orm';
 
 import { aiAlerts } from '@pops/db-types';
 
-import { getDrizzle } from '../../../db.js';
+import { getCoreDrizzle } from '../../../db.js';
 import { alertRowToAlert } from './mappers.js';
 
 import type { AlertCandidate, AlertRuleType, AlertSeverity, FiredAlert } from './types.js';
@@ -17,7 +20,7 @@ export const DEDUP_WINDOW_MINUTES = 60;
 
 /** Has an alert with the same `(type, scope_detail)` already fired in the dedup window? */
 export function isDuplicate(
-  db: ReturnType<typeof getDrizzle>,
+  db: ReturnType<typeof getCoreDrizzle>,
   candidate: AlertCandidate,
   now: Date
 ): boolean {
@@ -38,7 +41,7 @@ export function isDuplicate(
 }
 
 export function insertAlert(
-  db: ReturnType<typeof getDrizzle>,
+  db: ReturnType<typeof getCoreDrizzle>,
   candidate: AlertCandidate,
   now: Date
 ): FiredAlert {
@@ -73,7 +76,7 @@ export function insertAlert(
  * pass the duplicate check and double-fire.
  */
 export function insertAlertIfNotDuplicate(
-  db: ReturnType<typeof getDrizzle>,
+  db: ReturnType<typeof getCoreDrizzle>,
   candidate: AlertCandidate,
   now: Date
 ): FiredAlert | null {
@@ -109,7 +112,7 @@ export function listAlerts(filters: ListAlertsFilters = {}): {
   alerts: FiredAlert[];
   total: number;
 } {
-  const db = getDrizzle();
+  const db = getCoreDrizzle();
   const where = buildListConditions(filters);
   const baseQuery = db.select().from(aiAlerts);
   const limit = filters.limit ?? 100;
@@ -128,7 +131,7 @@ export function listAlerts(filters: ListAlertsFilters = {}): {
 }
 
 export function acknowledgeAlert(id: number, now: Date = new Date()): FiredAlert | null {
-  const db = getDrizzle();
+  const db = getCoreDrizzle();
   const result = db
     .update(aiAlerts)
     .set({ acknowledged: 1, acknowledgedAt: now.toISOString() })

--- a/apps/pops-api/src/modules/core/ai-alerts/evaluator.ts
+++ b/apps/pops-api/src/modules/core/ai-alerts/evaluator.ts
@@ -9,12 +9,17 @@
  * The orchestrator is invoked from the BullMQ scheduled worker every 5
  * minutes — see `scheduler.ts`. Tests drive `runEvaluation` directly
  * against a seeded DB.
+ *
+ * Reads + writes resolve against `getCoreDrizzle()` now that PRD-186 PR 4
+ * lands `ai_alerts` + `ai_alert_rules` in `@pops/core-db`. The per-rule
+ * evaluator helpers (`evaluators/*`) still receive the same drizzle
+ * handle for ergonomics — the orchestrator owns the handle resolution.
  */
 import { eq } from 'drizzle-orm';
 
 import { aiAlertRules } from '@pops/db-types';
 
-import { getDrizzle } from '../../../db.js';
+import { getCoreDrizzle } from '../../../db.js';
 import { logger } from '../../../lib/logger.js';
 import { insertAlertIfNotDuplicate } from './alerts-store.js';
 import { dispatchAlert } from './dispatch.js';
@@ -29,7 +34,7 @@ export { DEDUP_WINDOW_MINUTES, acknowledgeAlert, listAlerts } from './alerts-sto
 export type { ListAlertsFilters } from './alerts-store.js';
 
 interface EvaluatorDeps {
-  db: ReturnType<typeof getDrizzle>;
+  db: ReturnType<typeof getCoreDrizzle>;
   now: Date;
 }
 
@@ -60,7 +65,7 @@ export function evaluateRule(rule: AlertRule, deps: EvaluatorDeps): AlertCandida
 }
 
 /** List enabled rules from the DB. */
-export function loadEnabledRules(db: ReturnType<typeof getDrizzle>): AlertRule[] {
+export function loadEnabledRules(db: ReturnType<typeof getCoreDrizzle>): AlertRule[] {
   return db.select().from(aiAlertRules).where(eq(aiAlertRules.enabled, 1)).all().map(ruleRowToRule);
 }
 
@@ -81,7 +86,7 @@ async function dispatchPersistedAlert(
 export async function runEvaluation(
   options: RunEvaluationOptions = {}
 ): Promise<RunEvaluationResult> {
-  const db = getDrizzle();
+  const db = getCoreDrizzle();
   const now = options.now ?? new Date();
   const dispatchEnabled = options.dispatch ?? true;
   const rules = loadEnabledRules(db);

--- a/apps/pops-api/src/modules/core/ai-alerts/evaluators/budget.ts
+++ b/apps/pops-api/src/modules/core/ai-alerts/evaluators/budget.ts
@@ -10,7 +10,7 @@ import { and, eq, gte, sql } from 'drizzle-orm';
 
 import { aiBudgets, aiInferenceLog } from '@pops/db-types';
 
-import type { getDrizzle } from '../../../../db.js';
+import type { getCoreDrizzle } from '../../../../db.js';
 import type { AlertCandidate, AlertRule, AlertSeverity } from '../types.js';
 
 interface BudgetMetrics {
@@ -28,7 +28,7 @@ function monthStart(now: Date): string {
 }
 
 function getUsage(
-  db: ReturnType<typeof getDrizzle>,
+  db: ReturnType<typeof getCoreDrizzle>,
   budget: typeof aiBudgets.$inferSelect,
   start: string
 ): { totalTokens: number; totalCost: number } {
@@ -79,7 +79,7 @@ function computeMetrics(
 
 export function evaluateBudgetThreshold(
   rule: AlertRule,
-  db: ReturnType<typeof getDrizzle>,
+  db: ReturnType<typeof getCoreDrizzle>,
   now: Date
 ): AlertCandidate[] {
   const budgets = db.select().from(aiBudgets).all();

--- a/apps/pops-api/src/modules/core/ai-alerts/evaluators/error-spike.ts
+++ b/apps/pops-api/src/modules/core/ai-alerts/evaluators/error-spike.ts
@@ -11,7 +11,7 @@ import { aiInferenceLog } from '@pops/db-types';
 
 import { rollingWindowStart } from './shared.js';
 
-import type { getDrizzle } from '../../../../db.js';
+import type { getCoreDrizzle } from '../../../../db.js';
 import type { AlertCandidate, AlertRule, AlertSeverity } from '../types.js';
 
 function severity(rate: number, threshold: number): AlertSeverity {
@@ -20,7 +20,7 @@ function severity(rate: number, threshold: number): AlertSeverity {
 
 export function evaluateErrorSpike(
   rule: AlertRule,
-  db: ReturnType<typeof getDrizzle>,
+  db: ReturnType<typeof getCoreDrizzle>,
   now: Date
 ): AlertCandidate[] {
   const windowMinutes = rule.windowMinutes ?? 60;

--- a/apps/pops-api/src/modules/core/ai-alerts/evaluators/latency.ts
+++ b/apps/pops-api/src/modules/core/ai-alerts/evaluators/latency.ts
@@ -12,7 +12,7 @@ import { aiInferenceLog } from '@pops/db-types';
 
 import { rollingWindowStart } from './shared.js';
 
-import type { getDrizzle } from '../../../../db.js';
+import type { getCoreDrizzle } from '../../../../db.js';
 import type { AlertCandidate, AlertRule, AlertSeverity } from '../types.js';
 
 /**
@@ -49,7 +49,7 @@ function baseLatencyConditions(rule: AlertRule, start: string): SQL[] {
 
 function evaluateForModel(
   rule: AlertRule,
-  db: ReturnType<typeof getDrizzle>,
+  db: ReturnType<typeof getCoreDrizzle>,
   now: Date,
   model: string
 ): AlertCandidate | null {
@@ -79,7 +79,7 @@ function evaluateForModel(
 
 function listModelsInWindow(
   rule: AlertRule,
-  db: ReturnType<typeof getDrizzle>,
+  db: ReturnType<typeof getCoreDrizzle>,
   now: Date
 ): string[] {
   const windowMinutes = rule.windowMinutes ?? 60;
@@ -95,7 +95,7 @@ function listModelsInWindow(
 
 export function evaluateLatencyDegradation(
   rule: AlertRule,
-  db: ReturnType<typeof getDrizzle>,
+  db: ReturnType<typeof getCoreDrizzle>,
   now: Date
 ): AlertCandidate[] {
   if (rule.scopeModel) {

--- a/apps/pops-api/src/modules/core/ai-alerts/service.ts
+++ b/apps/pops-api/src/modules/core/ai-alerts/service.ts
@@ -2,12 +2,15 @@
  * CRUD service for `ai_alert_rules` (PRD-092 US-07).
  *
  * Exposes pure functions used by the tRPC router and seeding scripts.
+ *
+ * Reads + writes resolve against `getCoreDrizzle()` now that PRD-186 PR 4
+ * lands `ai_alert_rules` in `@pops/core-db`.
  */
 import { eq } from 'drizzle-orm';
 
 import { aiAlertRules } from '@pops/db-types';
 
-import { getDrizzle } from '../../../db.js';
+import { getCoreDrizzle } from '../../../db.js';
 import { ruleRowToRule } from './mappers.js';
 
 import type { AlertRule, AlertRuleType } from './types.js';
@@ -36,17 +39,17 @@ function nowIso(): string {
 }
 
 export function listRules(): AlertRule[] {
-  return getDrizzle().select().from(aiAlertRules).all().map(ruleRowToRule);
+  return getCoreDrizzle().select().from(aiAlertRules).all().map(ruleRowToRule);
 }
 
 export function getRule(id: number): AlertRule | null {
-  const [row] = getDrizzle().select().from(aiAlertRules).where(eq(aiAlertRules.id, id)).all();
+  const [row] = getCoreDrizzle().select().from(aiAlertRules).where(eq(aiAlertRules.id, id)).all();
   return row ? ruleRowToRule(row) : null;
 }
 
 export function createRule(input: CreateAlertRuleInput): AlertRule {
   const now = nowIso();
-  const db = getDrizzle();
+  const db = getCoreDrizzle();
   const result = db
     .insert(aiAlertRules)
     .values({
@@ -73,7 +76,7 @@ export function createRule(input: CreateAlertRuleInput): AlertRule {
  */
 export function updateRule(input: UpdateAlertRuleInput): AlertRule {
   const now = nowIso();
-  const db = getDrizzle();
+  const db = getCoreDrizzle();
   const patch: Partial<typeof aiAlertRules.$inferInsert> = { updatedAt: now };
   if (input.type !== undefined) patch.type = input.type;
   if (input.scopeProvider !== undefined) patch.scopeProvider = input.scopeProvider;
@@ -97,7 +100,7 @@ export function setRuleEnabled(id: number, enabled: boolean): AlertRule {
 }
 
 export function deleteRule(id: number): { success: boolean } {
-  const result = getDrizzle().delete(aiAlertRules).where(eq(aiAlertRules.id, id)).run();
+  const result = getCoreDrizzle().delete(aiAlertRules).where(eq(aiAlertRules.id, id)).run();
   return { success: result.changes > 0 };
 }
 
@@ -116,7 +119,7 @@ export function seedDefaultRules(): number {
     { type: 'error-spike', thresholdValue: 10, windowMinutes: 60 },
     { type: 'latency-degradation', thresholdValue: 10_000, windowMinutes: 60 },
   ];
-  const db = getDrizzle();
+  const db = getCoreDrizzle();
   const existingTypes = new Set(listRules().map((r) => r.type));
   const missing = defaults.filter((d) => !existingTypes.has(d.type));
   if (missing.length === 0) return 0;

--- a/packages/core-db/migrations/0062_ai_alert_rules.sql
+++ b/packages/core-db/migrations/0062_ai_alert_rules.sql
@@ -1,0 +1,14 @@
+CREATE TABLE `ai_alert_rules` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`type` text NOT NULL,
+	`scope_provider` text,
+	`scope_model` text,
+	`threshold_value` real NOT NULL,
+	`window_minutes` integer,
+	`enabled` integer DEFAULT 1 NOT NULL,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `idx_ai_alert_rules_type` ON `ai_alert_rules` (`type`);--> statement-breakpoint
+CREATE INDEX `idx_ai_alert_rules_enabled` ON `ai_alert_rules` (`enabled`);

--- a/packages/core-db/migrations/0063_ai_alerts.sql
+++ b/packages/core-db/migrations/0063_ai_alerts.sql
@@ -1,0 +1,20 @@
+CREATE TABLE `ai_alerts` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`rule_id` integer,
+	`type` text NOT NULL,
+	`message` text NOT NULL,
+	`severity` text NOT NULL,
+	`scope_detail` text,
+	`metric_value` real NOT NULL,
+	`threshold_value` real NOT NULL,
+	`acknowledged` integer DEFAULT 0 NOT NULL,
+	`acknowledged_at` text,
+	`created_at` text NOT NULL,
+	FOREIGN KEY (`rule_id`) REFERENCES `ai_alert_rules`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE INDEX `idx_ai_alerts_created_at` ON `ai_alerts` (`created_at`);--> statement-breakpoint
+CREATE INDEX `idx_ai_alerts_type` ON `ai_alerts` (`type`);--> statement-breakpoint
+CREATE INDEX `idx_ai_alerts_severity` ON `ai_alerts` (`severity`);--> statement-breakpoint
+CREATE INDEX `idx_ai_alerts_acknowledged` ON `ai_alerts` (`acknowledged`);--> statement-breakpoint
+CREATE INDEX `idx_ai_alerts_dedupe` ON `ai_alerts` (`type`,`scope_detail`,`created_at`);

--- a/packages/core-db/migrations/meta/_journal.json
+++ b/packages/core-db/migrations/meta/_journal.json
@@ -57,6 +57,20 @@
       "when": 1782086400002,
       "tag": "0061_ai_usage",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1782172800000,
+      "tag": "0062_ai_alert_rules",
+      "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1782172800001,
+      "tag": "0063_ai_alerts",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core-db/src/__tests__/open-core-db.test.ts
+++ b/packages/core-db/src/__tests__/open-core-db.test.ts
@@ -82,6 +82,59 @@ describe('openCoreDb', () => {
     }
   });
 
+  it('applies the PRD-186 PR4 ai_alert_rules + ai_alerts migrations', () => {
+    const path = join(tmpDir, 'core.db');
+    const { raw } = openCoreDb(path);
+    try {
+      const tables = new Set(
+        (
+          raw.prepare("SELECT name FROM sqlite_master WHERE type='table'").all() as {
+            name: string;
+          }[]
+        ).map((r) => r.name)
+      );
+      expect(tables.has('ai_alert_rules')).toBe(true);
+      expect(tables.has('ai_alerts')).toBe(true);
+
+      const indexes = new Set(
+        (
+          raw.prepare("SELECT name FROM sqlite_master WHERE type='index'").all() as {
+            name: string;
+          }[]
+        ).map((r) => r.name)
+      );
+      expect(indexes.has('idx_ai_alert_rules_type')).toBe(true);
+      expect(indexes.has('idx_ai_alert_rules_enabled')).toBe(true);
+      expect(indexes.has('idx_ai_alerts_created_at')).toBe(true);
+      expect(indexes.has('idx_ai_alerts_type')).toBe(true);
+      expect(indexes.has('idx_ai_alerts_severity')).toBe(true);
+      expect(indexes.has('idx_ai_alerts_acknowledged')).toBe(true);
+      expect(indexes.has('idx_ai_alerts_dedupe')).toBe(true);
+
+      const ruleId = (
+        raw
+          .prepare(
+            `INSERT INTO ai_alert_rules
+              (type, scope_provider, scope_model, threshold_value, window_minutes, enabled, created_at, updated_at)
+             VALUES ('budget-threshold', NULL, NULL, 80, NULL, 1, datetime('now'), datetime('now'))
+             RETURNING id`
+          )
+          .get() as { id: number }
+      ).id;
+      raw
+        .prepare(
+          `INSERT INTO ai_alerts
+            (rule_id, type, message, severity, scope_detail, metric_value, threshold_value, acknowledged, created_at)
+           VALUES (?, 'budget-threshold', 'over budget', 'warning', 'budget:global', 81, 80, 0, datetime('now'))`
+        )
+        .run(ruleId);
+      const count = (raw.prepare('SELECT count(*) AS n FROM ai_alerts').get() as { n: number }).n;
+      expect(count).toBe(1);
+    } finally {
+      raw.close();
+    }
+  });
+
   it('is idempotent — re-opening the same DB does not re-apply migrations', async () => {
     const path = join(tmpDir, 'core.db');
     const first = openCoreDb(path);

--- a/packages/core-db/src/schema.ts
+++ b/packages/core-db/src/schema.ts
@@ -11,6 +11,8 @@
  * Mirrors the `@pops/app-food-db` schema re-export pattern.
  */
 export {
+  aiAlertRules,
+  aiAlerts,
   aiBudgets,
   aiInferenceDaily,
   aiInferenceLog,


### PR DESCRIPTION
## Summary

PRD-186 PR4 cascade #4 of 7 — surfaced explicitly by the Wave 5 audit in #3191 as `ai_alerts / ai_alert_rules PR4 → 7 sites in ai-alerts/{alerts-store,evaluator,service}.ts`. Mirrors the canonical pattern from #3148 (`ai_model_pricing` / `sync_job_results` / `ai_usage`): lands the two ai-alerts tables under `@pops/core-db`, ships an idempotent ATTACH backfill from the legacy shared `pops.db`, and flips the 7 handler call-sites surfaced by the audit from `getDrizzle()` to `getCoreDrizzle()` in the same PR (matching the consolidated shape from the cerebrum embeddings slice in #3144).

## What lands

### Migrations + schema (core-db)
- `packages/core-db/migrations/0062_ai_alert_rules.sql` (indexes `type`, `enabled`)
- `packages/core-db/migrations/0063_ai_alerts.sql` (FK `rule_id` -> `ai_alert_rules.id` `ON DELETE SET NULL` + 5 indexes incl. the dedupe composite on `(type, scope_detail, created_at)`)
- `packages/core-db/migrations/meta/_journal.json` — appended entries idx 8 + 9
- `packages/core-db/src/schema.ts` — re-exports `aiAlertRules` + `aiAlerts` (canonical defs remain in `@pops/db-types`)

### Backfill (apps/pops-api)
- `backfill-core-from-shared.ts` — extends `TABLE_COPIES` with `ai_alert_rules` + `ai_alerts`, both keyed on `id`. Carrying `id` verbatim preserves the shared autoincrement sequence so the `ai_alerts.rule_id` FK survives the copy. Existing ATTACH / non-fatal / idempotent semantics unchanged.

### Handler flips (apps/pops-api/src/modules/core/ai-alerts)
Per the #3191 audit — 7 sites total:
- `alerts-store.ts` — 5 sites: `isDuplicate`, `insertAlert`, `insertAlertIfNotDuplicate`, `listAlerts`, `acknowledgeAlert`
- `evaluator.ts` — 1 runtime site (`runEvaluation`) + the `loadEnabledRules` typed parameter
- `service.ts` — 7 `getCoreDrizzle()` callsites for the rules CRUD + `seedDefaultRules`
- `evaluators/{budget,error-spike,latency}.ts` — type-only `getDrizzle` import widened to `getCoreDrizzle` so the per-rule helpers accept the orchestrator's `CoreDb` handle. They do not call the function — only the type changes.

`getDrizzle()` -> `getCoreDrizzle()` delta in `apps/pops-api/src/modules/core/ai-alerts/**`: **0 remaining `getDrizzle()` callsites** (was 14, now 14 `getCoreDrizzle()` callsites + type uses).

### Smoke + unit tests
- `apps/pops-api/src/db/per-pillar-migrations.test.ts` — expected `applied` list extended with `0062_ai_alert_rules` + `0063_ai_alerts` (per the lesson from #3160 / #3144 — when a new core-db migration lands the on-disk smoke test must be updated in the same PR)
- `packages/core-db/src/__tests__/open-core-db.test.ts` — new case asserts both tables + all 7 indexes land and `ai_alerts.rule_id` FK accepts inserts
- `apps/pops-api/src/db/backfill-core-from-shared.test.ts` — extended seed helpers (`insertAlertRule`, `insertAlert`) + 1 new dedicated test for FK preservation across the ATTACH copy; existing first-run / idempotent / missing-source-tolerance cases now assert on all five tables.

## Why both DBs keep the tables for now

Per the cerebrum/finance/media pattern, the shared `pops.db` copies stay in place as the fallback. The corresponding `TABLE_COPIES` entries retire in a follow-up PR after prod verification — not here.

## Test plan

- [x] `pnpm --filter @pops/core-db test` — 128 / 128 pass (8 files)
- [x] `pnpm --filter @pops/api test src/modules/core/ai-alerts src/db/backfill-core-from-shared src/db/per-pillar-migrations` — 38 / 38 pass (3 files)
- [x] `pnpm typecheck` — 71 / 71 packages clean
- [x] `pnpm lint` — exit 0 (warnings only, all pre-existing)
- [x] `pnpm format:check` — clean
- [x] `pnpm lint:boundaries` — 3 pre-existing known violations unchanged; no new ones introduced
- [x] Husky pre-commit + pre-push hooks ran clean without `--no-verify`
- [ ] CI green on this PR before merge

## References

- #3191 — Wave 5 7-pillar audit (this PR closes the ai_alerts / ai_alert_rules cascade)
- #3148 — canonical PRD-186 PR4 pattern (ai_model_pricing / sync_job_results / ai_usage)
- #3151 — hot-paths flip follow-up for #3148 (handler-flip side mirrored here)
- #3144 — cerebrum embeddings slice (similar shape; combined migration + flip)
- #3160 — per-pillar-migrations smoke test fix (lesson applied)
