### PR TITLE
feat(api/core/corrections): flip handler sites to getFinanceDrizzle (Wave 5 N6 cleanup)

### DIFF
--- a/apps/pops-api/src/modules/core/corrections/handlers/pattern-match.ts
+++ b/apps/pops-api/src/modules/core/corrections/handlers/pattern-match.ts
@@ -2,14 +2,12 @@
  * Thin shims that forward the in-tree pattern-match read API to
  * `@pops/finance-db`'s `transactionCorrectionsService`.
  *
- * Track N3 phase 1 PR 3 routing flip — see `query-helpers.ts` for the
- * full rationale. The `getDrizzle()` handle still resolves to the shared
- * `pops.db` so the in-tree imports pipeline (the other consumer) keeps
- * seeing the same rows.
+ * Reads route through `getFinanceDrizzle()` — the finance-owned
+ * `transaction_corrections` table lives in `finance.db`.
  */
 import { transactionCorrectionsService } from '@pops/finance-db';
 
-import { getDrizzle } from '../../../../db.js';
+import { getFinanceDrizzle } from '../../../../db/finance-handle.js';
 import { classifyCorrectionMatch } from '../types.js';
 
 import type { CorrectionMatchResult, CorrectionRow } from '../types.js';
@@ -19,7 +17,7 @@ export function findAllMatchingCorrectionFromDB(
   minConfidence: number = 0.7
 ): CorrectionRow[] {
   return transactionCorrectionsService.findAllMatchingTransactionCorrectionsFromDb(
-    getDrizzle(),
+    getFinanceDrizzle(),
     description,
     minConfidence
   );
@@ -37,7 +35,7 @@ export function findMatchingCorrection(
 
 export function findAllMatchingCorrections(description: string): CorrectionRow[] {
   return transactionCorrectionsService.findAllMatchingTransactionCorrections(
-    getDrizzle(),
+    getFinanceDrizzle(),
     description
   );
 }

--- a/apps/pops-api/src/modules/core/corrections/handlers/query-helpers.ts
+++ b/apps/pops-api/src/modules/core/corrections/handlers/query-helpers.ts
@@ -2,13 +2,8 @@
  * Thin shims that forward CRUD operations on `transaction_corrections` to
  * `@pops/finance-db`'s `transactionCorrectionsService`.
  *
- * Track N3 phase 1 PR 3 routing flip: the underlying drizzle handle (and
- * the on-disk SQLite file) is unchanged — `getDrizzle()` still resolves to
- * the shared `pops.db` so the in-tree imports pipeline (the other consumer
- * of this table) keeps reading and writing the same rows. Only the code
- * path moves from the in-tree implementation to the package one. PR 4 of
- * phase 1 will delete this shim once the imports pipeline (N6) is also on
- * the package and the handle can shift to `getFinanceDrizzle()`.
+ * Reads and writes route through `getFinanceDrizzle()` — the finance-owned
+ * `transaction_corrections` table lives in `finance.db`.
  *
  * Domain errors thrown by the package (`TransactionCorrectionNotFoundError`)
  * are translated to `NotFoundError` so the existing router layer (and the
@@ -22,7 +17,7 @@ import {
   type UpdateTransactionCorrectionInput,
 } from '@pops/finance-db';
 
-import { getDrizzle } from '../../../../db.js';
+import { getFinanceDrizzle } from '../../../../db/finance-handle.js';
 import { NotFoundError } from '../../../../shared/errors.js';
 
 import type { CorrectionRow, CreateCorrectionInput, UpdateCorrectionInput } from '../types.js';
@@ -40,7 +35,7 @@ export function listCorrections(
   offset: number = 0,
   matchType?: 'exact' | 'contains' | 'regex'
 ): { rows: CorrectionRow[]; total: number } {
-  return transactionCorrectionsService.listTransactionCorrections(getDrizzle(), {
+  return transactionCorrectionsService.listTransactionCorrections(getFinanceDrizzle(), {
     minConfidence,
     matchType,
     limit,
@@ -50,7 +45,7 @@ export function listCorrections(
 
 export function getCorrection(id: string): CorrectionRow {
   try {
-    return transactionCorrectionsService.getTransactionCorrection(getDrizzle(), id);
+    return transactionCorrectionsService.getTransactionCorrection(getFinanceDrizzle(), id);
   } catch (err) {
     rethrowAsNotFound(err, id);
   }
@@ -68,7 +63,7 @@ export function createOrUpdateCorrection(input: CreateCorrectionInput): Correcti
     priority: input.priority,
   };
   return transactionCorrectionsService.createOrUpdateTransactionCorrection(
-    getDrizzle(),
+    getFinanceDrizzle(),
     packageInput
   );
 }
@@ -88,7 +83,7 @@ export function updateCorrection(id: string, input: UpdateCorrectionInput): Corr
   };
   try {
     return transactionCorrectionsService.updateTransactionCorrection(
-      getDrizzle(),
+      getFinanceDrizzle(),
       id,
       packageInput
     );
@@ -99,19 +94,23 @@ export function updateCorrection(id: string, input: UpdateCorrectionInput): Corr
 
 export function deleteCorrection(id: string): void {
   try {
-    transactionCorrectionsService.deleteTransactionCorrection(getDrizzle(), id);
+    transactionCorrectionsService.deleteTransactionCorrection(getFinanceDrizzle(), id);
   } catch (err) {
     rethrowAsNotFound(err, id);
   }
 }
 
 export function incrementCorrectionUsage(id: string): void {
-  transactionCorrectionsService.incrementTransactionCorrectionUsage(getDrizzle(), id);
+  transactionCorrectionsService.incrementTransactionCorrectionUsage(getFinanceDrizzle(), id);
 }
 
 export function adjustConfidence(id: string, delta: number): void {
   try {
-    transactionCorrectionsService.adjustTransactionCorrectionConfidence(getDrizzle(), id, delta);
+    transactionCorrectionsService.adjustTransactionCorrectionConfidence(
+      getFinanceDrizzle(),
+      id,
+      delta
+    );
   } catch (err) {
     rethrowAsNotFound(err, id);
   }


### PR DESCRIPTION
## Summary

- Wave 5 N6 cleanup: flip the remaining `getDrizzle()` callsites in `apps/pops-api/src/modules/core/corrections/handlers/*` that read/write finance-owned tables onto `getFinanceDrizzle()`.
- Same latent split-brain risk the ai-observability audit fixed in #3191 — corrections was the last surface still routing the finance schema through the shared handle.

## Per-file site count

| File | callsites flipped | notes |
|---|---|---|
| `pattern-match.ts` | 2 | also rewrote stale JSDoc block referring to N3 phase 1 |
| `query-helpers.ts` | 7 | also rewrote stale JSDoc block referring to N3 phase 1 |
| **Total** | **9** | matches audit |

Count delta on this PR's diff: **9 `getDrizzle()` → `getFinanceDrizzle()`** replacements (plus the matching import swap in each file).

## Already done on `main` (no change required)

The audit's prose said "9 sites in `core/corrections/handlers/*`" — when I grepped the worktree, 8 handler files contained `getDrizzle()` invocations. Of those, the following 5 had already been flipped to `getFinanceDrizzle()` (or to `getCoreDrizzle()` where appropriate) by prior Wave 5 PRs:

- `apply-corrections.ts`
- `ai-revise.ts`
- `changeset-impact.ts`
- `compute-changeset.ts`
- `preview-matches.ts`

## Skipped (intentional)

- `ai-inference.ts` — on `main` this file already uses `getCoreDrizzle` and `settingsService` from `@pops/core-db`. Its only reads/writes target the `settings` table, which is core-db owned, not finance-db. No flip needed; not in scope.

## Verification

- `pnpm --filter @pops/api typecheck` — clean.
- `pnpm --filter @pops/api test src/modules/core/corrections` — 94 passed, 5 pre-existing failures in `lib/rule-generator.test.ts` (reproduce on `origin/main` with the handler files reverted; not caused by this PR).

## Test plan

- [ ] CI green on `@pops/api` typecheck + test pipelines.
- [ ] Spot-check that the corrections router still serves `listCorrections` / `applyChangeSet` against the same finance-db rows in dev.
