### PR TITLE
test(corrections): fix stale mocks in rule-generator analyzeCorrection suite

### DIFF
--- a/apps/pops-api/src/modules/core/corrections/lib/rule-generator.test.ts
+++ b/apps/pops-api/src/modules/core/corrections/lib/rule-generator.test.ts
@@ -12,15 +12,19 @@ vi.mock('../../../../env.js', () => ({
   getEnv: vi.fn((key: string) => (key === 'ANTHROPIC_API_KEY' ? 'test-key' : undefined)),
 }));
 
-vi.mock('../../../../db.js', () => ({
-  getDrizzle: () => ({
+vi.mock('../../../../db.js', () => {
+  const stubDrizzle = {
     insert: () => ({
       values: () => ({
         run: vi.fn(),
       }),
     }),
-  }),
-}));
+  };
+  return {
+    getDrizzle: () => stubDrizzle,
+    getCoreDrizzle: () => stubDrizzle,
+  };
+});
 
 vi.mock('@pops/db-types', () => ({
   aiUsage: {},
@@ -33,6 +37,10 @@ vi.mock('../../../../lib/logger.js', () => ({
     warn: vi.fn(),
     error: vi.fn(),
   },
+}));
+
+vi.mock('../../../../lib/inference-middleware.js', () => ({
+  trackInference: <T>(_params: unknown, fn: () => Promise<T>) => fn(),
 }));
 
 import { analyzeCorrection, patternMatchesDescription } from './rule-generator.js';


### PR DESCRIPTION
## Summary

The 5 pre-existing failures in `apps/pops-api/src/modules/core/corrections/lib/rule-generator.test.ts` — flagged as unrelated by both PR #3192 and PR #3193 — are a **test bug**, not a production bug. The fix is mock-only.

## Root cause

The test mocks predate two pieces of inference-middleware infrastructure that were added after the suite was written:

1. **#2629** — `trackInference` now runs `enforceBudgets` *before* the live provider call, which calls `getCoreDrizzle()`.
2. **PRD-186 PR3** (#3025) — inference audit log writes now go through `getCoreDrizzle()` instead of `getDrizzle()`.

The test's `vi.mock('../../../../db.js', ...)` only stubbed `getDrizzle`, leaving `getCoreDrizzle` undefined. Calling an undefined function throws synchronously, the exception is caught inside `callClaude`'s `try/catch`, and the function returns `null`.

The 16 tests that already expected `null` (no API key, AI throws, invalid match type, confidence out of range, etc.) silently kept passing — the breakage was invisible to them. Only the 5 happy-path tests that expected a non-null `CorrectionAnalysis` surfaced the failure:

| # | Test | Expected | Actual |
|---|---|---|---|
| 1 | `returns AI-suggested pattern when entity name is present in description` | `{contains, WOOLWORTHS, 0.9}` | `null` |
| 2 | `handles contains matchType when entity appears after prefix` | `{contains, NETFLIX, 0.85}` | `null` |
| 3 | `accepts the full description as the pattern when no shorter identifier exists` | `{exact, MEMBERSHIP FEE, 0.7}` | `null` |
| 4 | `accepts a regex matchType that matches the description` | `{regex, WOOLWORTHS.*, 0.8}` | `null` |
| 5 | `strips markdown code fences from response` | `{contains, WOOLWORTHS, 0.9}` | `null` |

## Fix

`apps/pops-api/src/modules/core/corrections/lib/rule-generator.test.ts`:

- Extend the `db.js` mock to expose `getCoreDrizzle` alongside `getDrizzle` (both return the same stub).
- Mock `lib/inference-middleware.js` so `trackInference` is a pass-through that just invokes its second argument. This bypasses budget enforcement + audit-log inserts entirely — the existing dedicated test suites at `lib/inference-middleware.test.ts` and `modules/core/ai-budgets/*` cover that behaviour, so re-exercising it from the rule-generator unit tests is noise.

No SUT changes. No `as any` / `as unknown as`. No suppressions.

## Verification

- `pnpm --filter @pops/api test src/modules/core/corrections/lib/rule-generator.test.ts` — 21/21 pass (was 16/21).
- `pnpm --filter @pops/api test src/modules/core/corrections` — 99/99 pass across all 4 corrections suites.
- `pnpm --filter @pops/api exec tsc --noEmit` — clean.
- Husky `oxlint --fix` + `oxfmt --write` ran clean on the pre-commit hook.

## Test plan

- [x] Failing suite now passes locally
- [x] Wider corrections module test suite still passes
- [x] No type regressions
- [x] No production-code changes (mock-only)