### PR TITLE
feat(core-db): ai_providers PR4 — move table + ATTACH backfill + flip 5+1 sites (Wave 5 cascade)

### DIFF
--- a/apps/pops-api/src/db/backfill-core-from-shared.test.ts
+++ b/apps/pops-api/src/db/backfill-core-from-shared.test.ts
@@ -5,9 +5,9 @@
  * core pillar's `core.db` against on-disk SQLite files (in-memory DBs
  * can't be ATTACHed). The set covered by this bridge is
  * `ai_model_pricing`, `sync_job_results`, `ai_usage`, `ai_alert_rules`,
- * and `ai_alerts` — the writer cutover that lets us retire each entry
- * happens once the handler flip lands; until then this bridge runs on
- * every boot. Confirms:
+ * `ai_alerts`, and `ai_providers` — the writer cutover that lets us
+ * retire each entry happens once the handler flip lands; until then
+ * this bridge runs on every boot. Confirms:
  *   - first run carries existing rows across for all tables,
  *   - second run is a no-op (idempotent — the per-table NOT EXISTS dedupes),
  *   - composite-key dedup honours (provider_id, model_id) for ai_model_pricing,
@@ -100,6 +100,23 @@ CREATE INDEX idx_ai_alert_rules_type ON ai_alert_rules (type);
 CREATE INDEX idx_ai_alert_rules_enabled ON ai_alert_rules (enabled);
 `;
 
+const AI_PROVIDERS_SQL = `
+CREATE TABLE ai_providers (
+  id text PRIMARY KEY NOT NULL,
+  name text NOT NULL,
+  type text NOT NULL,
+  base_url text,
+  api_key_ref text,
+  status text DEFAULT 'active' NOT NULL,
+  last_health_check text,
+  last_latency_ms integer,
+  created_at text NOT NULL,
+  updated_at text NOT NULL
+);
+CREATE INDEX idx_ai_providers_type ON ai_providers (type);
+CREATE INDEX idx_ai_providers_status ON ai_providers (status);
+`;
+
 const AI_ALERTS_SQL = `
 CREATE TABLE ai_alerts (
   id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
@@ -129,9 +146,20 @@ function openSharedWithSeed(seed: (raw: BetterSqlite3.Database) => void): string
   raw.exec(AI_USAGE_SQL);
   raw.exec(AI_ALERT_RULES_SQL);
   raw.exec(AI_ALERTS_SQL);
+  raw.exec(AI_PROVIDERS_SQL);
   seed(raw);
   raw.close();
   return path;
+}
+
+function insertProvider(raw: BetterSqlite3.Database, id: string, type: string): void {
+  raw
+    .prepare(
+      `INSERT INTO ai_providers
+        (id, name, type, base_url, api_key_ref, status, created_at, updated_at)
+       VALUES (?, ?, ?, NULL, NULL, 'active', datetime('now'), datetime('now'))`
+    )
+    .run(id, `${id} provider`, type);
 }
 
 function insertPricing(raw: BetterSqlite3.Database, providerId: string, modelId: string): void {
@@ -187,13 +215,14 @@ function insertAlert(raw: BetterSqlite3.Database, ruleId: number, type: string):
 }
 
 describe('backfillCoreFromShared', () => {
-  it('copies ai_model_pricing, sync_job_results, ai_usage, ai_alert_rules, and ai_alerts rows from shared on first run', () => {
+  it('copies ai_model_pricing, sync_job_results, ai_usage, ai_alert_rules, ai_alerts, and ai_providers rows from shared on first run', () => {
     const sharedPath = openSharedWithSeed((raw) => {
       insertPricing(raw, 'claude', 'claude-haiku-4-5');
       insertSync(raw, 'job-a');
       insertUsage(raw, 'seed-usage');
       const ruleId = insertAlertRule(raw, 'budget-threshold');
       insertAlert(raw, ruleId, 'budget-threshold');
+      insertProvider(raw, 'claude', 'cloud');
     });
 
     const core = openCoreDb(join(tmpDir, 'core.db'));
@@ -238,6 +267,13 @@ describe('backfillCoreFromShared', () => {
           metric_value: 81,
         },
       ]);
+
+      const providers = core.raw
+        .prepare('SELECT id, name, type, status FROM ai_providers')
+        .all() as { id: string; name: string; type: string; status: string }[];
+      expect(providers).toEqual([
+        { id: 'claude', name: 'claude provider', type: 'cloud', status: 'active' },
+      ]);
     } finally {
       core.raw.close();
     }
@@ -250,6 +286,7 @@ describe('backfillCoreFromShared', () => {
       insertUsage(raw, 'seed-usage');
       const ruleId = insertAlertRule(raw, 'budget-threshold');
       insertAlert(raw, ruleId, 'budget-threshold');
+      insertProvider(raw, 'claude', 'cloud');
     });
 
     const core = openCoreDb(join(tmpDir, 'core.db'));
@@ -272,11 +309,46 @@ describe('backfillCoreFromShared', () => {
       const alertCount = (
         core.raw.prepare('SELECT count(*) AS n FROM ai_alerts').get() as { n: number }
       ).n;
+      const providerCount = (
+        core.raw.prepare('SELECT count(*) AS n FROM ai_providers').get() as { n: number }
+      ).n;
       expect(pricingCount).toBe(1);
       expect(syncCount).toBe(1);
       expect(usageCount).toBe(1);
       expect(ruleCount).toBe(1);
       expect(alertCount).toBe(1);
+      expect(providerCount).toBe(1);
+    } finally {
+      core.raw.close();
+    }
+  });
+
+  it('skips ai_providers rows whose id already exists in core', () => {
+    const sharedPath = openSharedWithSeed((raw) => {
+      insertProvider(raw, 'claude', 'cloud');
+      insertProvider(raw, 'ollama', 'local');
+    });
+
+    const core = openCoreDb(join(tmpDir, 'core.db'));
+    try {
+      core.raw
+        .prepare(
+          `INSERT INTO ai_providers
+            (id, name, type, base_url, api_key_ref, status, created_at, updated_at)
+           VALUES ('claude', 'Core overrides shared', 'cloud', NULL, NULL, 'active', datetime('now'), datetime('now'))`
+        )
+        .run();
+
+      backfillCoreFromShared(core, sharedPath);
+
+      const rows = core.raw.prepare('SELECT id, name FROM ai_providers ORDER BY id').all() as {
+        id: string;
+        name: string;
+      }[];
+      expect(rows).toEqual([
+        { id: 'claude', name: 'Core overrides shared' },
+        { id: 'ollama', name: 'ollama provider' },
+      ]);
     } finally {
       core.raw.close();
     }
@@ -371,11 +443,15 @@ describe('backfillCoreFromShared', () => {
       const alertCount = (
         core.raw.prepare('SELECT count(*) AS n FROM ai_alerts').get() as { n: number }
       ).n;
+      const providerCount = (
+        core.raw.prepare('SELECT count(*) AS n FROM ai_providers').get() as { n: number }
+      ).n;
       expect(pricingCount).toBe(0);
       expect(syncCount).toBe(0);
       expect(usageCount).toBe(0);
       expect(ruleCount).toBe(0);
       expect(alertCount).toBe(0);
+      expect(providerCount).toBe(0);
     } finally {
       core.raw.close();
     }

--- a/apps/pops-api/src/db/backfill-core-from-shared.ts
+++ b/apps/pops-api/src/db/backfill-core-from-shared.ts
@@ -2,10 +2,10 @@
  * Boot-time backfill from the legacy shared `pops.db` into the core
  * pillar's `core.db` for the tables PRD-186 PR4 lands in core-db:
  * `ai_model_pricing`, `sync_job_results`, `ai_usage`, `ai_alert_rules`,
- * and `ai_alerts`.
+ * `ai_alerts`, and `ai_providers`.
  *
  * Phase context: PR4 establishes the per-pillar table home for these
- * tables (`packages/core-db/migrations/0059..0063_*.sql`) ahead of the
+ * tables (`packages/core-db/migrations/0059..0064_*.sql`) ahead of the
  * hot-path writer cutover that flips the per-table writers from
  * `getDrizzle()` to `getCoreDrizzle()` in the same / next PR. Until each
  * cutover lands, writers still target `pops.db` — so this backfill
@@ -126,6 +126,22 @@ const TABLE_COPIES: readonly TableCopy[] = [
       'acknowledged',
       'acknowledged_at',
       'created_at',
+    ],
+  },
+  {
+    table: 'ai_providers',
+    idColumns: ['id'],
+    columns: [
+      'id',
+      'name',
+      'type',
+      'base_url',
+      'api_key_ref',
+      'status',
+      'last_health_check',
+      'last_latency_ms',
+      'created_at',
+      'updated_at',
     ],
   },
 ];

--- a/apps/pops-api/src/db/per-pillar-migrations.test.ts
+++ b/apps/pops-api/src/db/per-pillar-migrations.test.ts
@@ -210,11 +210,15 @@ describe('runPerPillarMigrations', () => {
     // 0058_pillar_registry_external_origin, the PRD-186 PR4 trio
     // 0059_ai_model_pricing + 0060_sync_job_results + 0061_ai_usage
     // (Wave 5 unblock — the remaining AI Ops + sync-result tables land
-    // in core-db ahead of the hot-path writer cutover), and the
+    // in core-db ahead of the hot-path writer cutover), the
     // PRD-186 PR4 ai-alerts slice 0062_ai_alert_rules + 0063_ai_alerts
     // (Wave 5 — moves the evaluator's tables and flips the 7
     // `core/ai-alerts/{alerts-store,evaluator,service}.ts` handler sites
-    // to `getCoreDrizzle()`);
+    // to `getCoreDrizzle()`), and the PRD-186 PR4 ai_providers slice
+    // 0064_ai_providers (Wave 5 cascade — moves the providers table and
+    // flips the 5 `core/ai-providers/service.ts` handler sites plus the
+    // `core/ai-budgets/enforcement.ts` mixed-DB pin to
+    // `getCoreDrizzle()`);
     // `media` owns `packages/media-db/migrations/`
     // with 0021_spooky_lockheed (media pillar Phase 1 PR 2),
     // 0022_media_movies_baseline (Theme 13 PRD-165 US-01 — movies baseline),
@@ -280,6 +284,7 @@ describe('runPerPillarMigrations', () => {
         '0061_ai_usage',
         '0062_ai_alert_rules',
         '0063_ai_alerts',
+        '0064_ai_providers',
       ]);
       expect([...result.pillarsApplied].toSorted()).toEqual([
         'cerebrum',

--- a/apps/pops-api/src/modules/core/ai-budgets/enforcement.ts
+++ b/apps/pops-api/src/modules/core/ai-budgets/enforcement.ts
@@ -5,20 +5,19 @@
  * `core.aiBudgets`) and the inference-middleware enforcement path can each
  * stay under the project's max-lines lint budget.
  *
- * Routing: `listApplicableBudgets`, the per-scope usage aggregation, and the
- * conflict-detection read in `migrateLegacyBudgetSettings` all forward into
- * `@pops/core-db`'s `aiUsageService` against `getCoreDrizzle()`, so reads
- * land on `core.db`. `findFallbackProvider` stays on the shared
- * `getDrizzle()` handle because it joins `ai_providers` and
- * `ai_model_pricing`, which are not part of the core-db package surface
- * yet — a future PR can lift those tables too.
+ * Routing: `listApplicableBudgets`, the per-scope usage aggregation, the
+ * conflict-detection read in `migrateLegacyBudgetSettings`, and the
+ * `findFallbackProvider` join over `ai_providers` + `ai_model_pricing`
+ * all forward into `@pops/core-db` against `getCoreDrizzle()` — both
+ * joined tables now live on `core.db` (PRD-186 PR4: `ai_model_pricing`
+ * from #3148, `ai_providers` from the ai_providers cascade).
  */
 import { and, asc, desc, eq } from 'drizzle-orm';
 
 import { aiUsageService, type AiBudgetRow } from '@pops/core-db';
 import { aiModelPricing, aiProviders } from '@pops/db-types';
 
-import { getCoreDrizzle, getDrizzle } from '../../../db.js';
+import { getCoreDrizzle } from '../../../db.js';
 import { logger } from '../../../lib/logger.js';
 import { getSettingOrNull, setRawSetting } from '../settings/service.js';
 import { upsertBudget } from './service.js';
@@ -224,13 +223,12 @@ export function migrateLegacyBudgetSettings(): void {
  * `null` when no candidate is available — the middleware then treats fallback
  * as block.
  *
- * Stays on `getDrizzle()` (shared `pops.db`) because this query joins
- * `ai_providers` + `ai_model_pricing`, neither of which lives in
- * `@pops/core-db`. A future PR can lift those tables into the package
- * surface and complete the cutover.
+ * Joins `ai_providers` + `ai_model_pricing` — both now live in
+ * `@pops/core-db` (PRD-186 PR4 cascade), so the query resolves through
+ * `getCoreDrizzle()`.
  */
 export function findFallbackProvider(): { provider: string; model: string } | null {
-  const db = getDrizzle();
+  const db = getCoreDrizzle();
   const row = db
     .select({
       providerId: aiProviders.id,

--- a/apps/pops-api/src/modules/core/ai-providers/service.ts
+++ b/apps/pops-api/src/modules/core/ai-providers/service.ts
@@ -2,7 +2,7 @@ import { eq } from 'drizzle-orm';
 
 import { aiModelPricing, aiProviders } from '@pops/db-types';
 
-import { getDrizzle } from '../../../db.js';
+import { getCoreDrizzle } from '../../../db.js';
 import { getAnthropicApiKey } from '../../../lib/anthropic-api-key.js';
 import { logger } from '../../../lib/logger.js';
 
@@ -59,7 +59,7 @@ function rowToModel(row: typeof aiModelPricing.$inferSelect): ModelPricing {
 }
 
 export function listProviders(): ProviderWithModels[] {
-  const db = getDrizzle();
+  const db = getCoreDrizzle();
   const providers = db.select().from(aiProviders).all();
   const allModels = db.select().from(aiModelPricing).all();
 
@@ -70,7 +70,7 @@ export function listProviders(): ProviderWithModels[] {
 }
 
 export function getProvider(providerId: string): ProviderWithModels | null {
-  const db = getDrizzle();
+  const db = getCoreDrizzle();
   const [provider] = db.select().from(aiProviders).where(eq(aiProviders.id, providerId)).all();
   if (!provider) return null;
   const models = db
@@ -86,7 +86,7 @@ type ModelInput = NonNullable<UpsertProviderInput['models']>[number];
 function upsertProviderRow(input: UpsertProviderInput, now: string): void {
   const baseUrl = input.baseUrl ?? null;
   const apiKeyRef = input.apiKeyRef ?? null;
-  getDrizzle()
+  getCoreDrizzle()
     .insert(aiProviders)
     .values({
       id: input.id,
@@ -118,7 +118,7 @@ function upsertModelRow(providerId: string, model: ModelInput, now: string): voi
   const outputCostPerMtok = model.outputCostPerMtok ?? 0;
   const contextWindow = model.contextWindow ?? null;
   const isDefault = model.isDefault ? 1 : 0;
-  getDrizzle()
+  getCoreDrizzle()
     .insert(aiModelPricing)
     .values({
       providerId,
@@ -196,7 +196,7 @@ export async function runHealthCheck(
   const latencyMs = Date.now() - start;
   const now = new Date().toISOString();
 
-  getDrizzle()
+  getCoreDrizzle()
     .update(aiProviders)
     .set({ status, lastHealthCheck: now, lastLatencyMs: latencyMs, updatedAt: now })
     .where(eq(aiProviders.id, providerId))

--- a/packages/core-db/migrations/0064_ai_providers.sql
+++ b/packages/core-db/migrations/0064_ai_providers.sql
@@ -1,0 +1,15 @@
+CREATE TABLE `ai_providers` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`type` text NOT NULL,
+	`base_url` text,
+	`api_key_ref` text,
+	`status` text DEFAULT 'active' NOT NULL,
+	`last_health_check` text,
+	`last_latency_ms` integer,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `idx_ai_providers_type` ON `ai_providers` (`type`);--> statement-breakpoint
+CREATE INDEX `idx_ai_providers_status` ON `ai_providers` (`status`);

--- a/packages/core-db/migrations/meta/_journal.json
+++ b/packages/core-db/migrations/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1782172800001,
       "tag": "0063_ai_alerts",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1782259200000,
+      "tag": "0064_ai_providers",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core-db/src/__tests__/open-core-db.test.ts
+++ b/packages/core-db/src/__tests__/open-core-db.test.ts
@@ -135,6 +135,44 @@ describe('openCoreDb', () => {
     }
   });
 
+  it('applies the PRD-186 PR4 ai_providers migration', () => {
+    const path = join(tmpDir, 'core.db');
+    const { raw } = openCoreDb(path);
+    try {
+      const tables = new Set(
+        (
+          raw.prepare("SELECT name FROM sqlite_master WHERE type='table'").all() as {
+            name: string;
+          }[]
+        ).map((r) => r.name)
+      );
+      expect(tables.has('ai_providers')).toBe(true);
+
+      const indexes = new Set(
+        (
+          raw.prepare("SELECT name FROM sqlite_master WHERE type='index'").all() as {
+            name: string;
+          }[]
+        ).map((r) => r.name)
+      );
+      expect(indexes.has('idx_ai_providers_type')).toBe(true);
+      expect(indexes.has('idx_ai_providers_status')).toBe(true);
+
+      raw
+        .prepare(
+          `INSERT INTO ai_providers
+            (id, name, type, base_url, api_key_ref, status, created_at, updated_at)
+           VALUES ('claude', 'Anthropic Claude', 'cloud', NULL, 'anthropic.apiKey', 'active', datetime('now'), datetime('now'))`
+        )
+        .run();
+      const count = (raw.prepare('SELECT count(*) AS n FROM ai_providers').get() as { n: number })
+        .n;
+      expect(count).toBe(1);
+    } finally {
+      raw.close();
+    }
+  });
+
   it('is idempotent — re-opening the same DB does not re-apply migrations', async () => {
     const path = join(tmpDir, 'core.db');
     const first = openCoreDb(path);

--- a/packages/core-db/src/schema.ts
+++ b/packages/core-db/src/schema.ts
@@ -17,6 +17,7 @@ export {
   aiInferenceDaily,
   aiInferenceLog,
   aiModelPricing,
+  aiProviders,
   aiUsage,
   pillarRegistry,
   serviceAccounts,


### PR DESCRIPTION
## Summary

PRD-186 PR4 cascade — surfaced explicitly by the Wave 5 audit in #3191 as `ai_providers PR4 → 5 sites in ai-providers/service.ts + the enforcement.ts:233 mixed-DB pin`. Mirrors the canonical pattern from #3192 (ai_alerts + ai_alert_rules) and #3148 (ai_model_pricing + sync_job_results + ai_usage): lands the `ai_providers` table under `@pops/core-db`, ships an idempotent ATTACH backfill from the legacy shared `pops.db`, and flips the 5 service-handler call-sites plus the 1 mixed-DB pin in `ai-budgets/enforcement.ts` from `getDrizzle()` to `getCoreDrizzle()` in the same PR.

## What lands

### Migrations + schema (core-db)
- `packages/core-db/migrations/0064_ai_providers.sql` (indexes `type`, `status` — both filtered by `findFallbackProvider`'s `WHERE` clause)
- `packages/core-db/migrations/meta/_journal.json` — appended idx 10
- `packages/core-db/src/schema.ts` — re-exports `aiProviders` (canonical def stays in `@pops/db-types`)

### Backfill (apps/pops-api)
- `backfill-core-from-shared.ts` — extends `TABLE_COPIES` with `ai_providers`, keyed on `id`. Existing ATTACH / non-fatal / idempotent semantics unchanged.

### Handler flips (apps/pops-api)
Per the #3191 audit — 5 service-handler sites + 1 mixed-DB pin:
- `modules/core/ai-providers/service.ts` — 5 sites: `listProviders`, `getProvider`, `upsertProviderRow`, `upsertModelRow`, `runHealthCheck`. Import widened from `getDrizzle` to `getCoreDrizzle`.
- `modules/core/ai-budgets/enforcement.ts` — `findFallbackProvider`'s `ai_providers JOIN ai_model_pricing` lookup. Both joined tables now live in core-db (`ai_model_pricing` via #3148, `ai_providers` here), so the mixed-DB pin from #3191's audit is gone. Module-level `getDrizzle` import retired.

`getDrizzle()` → `getCoreDrizzle()` delta in the touched modules: **0 remaining `getDrizzle()` call-sites** in `ai-providers/service.ts` (was 5, now 5 `getCoreDrizzle()`) and **0 remaining `getDrizzle()` call-sites** in `ai-budgets/enforcement.ts` (was 1, now 1 `getCoreDrizzle()` plus the pre-existing 3 core call-sites unchanged).

### Smoke + unit tests
- `apps/pops-api/src/db/per-pillar-migrations.test.ts` — expected `applied` list extended with `0064_ai_providers` (per the lesson from #3160 / #3144 — when a new core-db migration lands the on-disk smoke test must be updated in the same PR)
- `packages/core-db/src/__tests__/open-core-db.test.ts` — new case asserts `ai_providers` lands with both indexes and accepts inserts
- `apps/pops-api/src/db/backfill-core-from-shared.test.ts` — extended seed helper (`insertProvider`) + dedicated id-key dedup test; existing first-run / idempotent / missing-source-tolerance cases now assert on the six tables.

## Why both DBs keep the table for now

Per the cerebrum/finance/media pattern (and #3192's playbook), the shared `pops.db` copy stays in place as the fallback. The corresponding `TABLE_COPIES` entry retires in a follow-up PR after prod verification — not here.

## Test plan

- [x] `pnpm --filter @pops/core-db test` — 129 / 129 pass (8 files)
- [x] `pnpm --filter @pops/api test src/modules/core/ai-providers src/modules/core/ai-budgets src/db/backfill-core-from-shared src/db/per-pillar-migrations` — 41 / 41 pass (4 files)
- [x] `pnpm typecheck` — 71 / 71 packages clean
- [x] `pnpm format:check` — clean
- [x] `pnpm lint:boundaries` — 3 pre-existing known violations unchanged; no new ones introduced
- [x] Husky pre-commit + pre-push hooks ran clean without `--no-verify`
- [ ] CI green on this PR before merge

## References

- #3191 — Wave 5 7-pillar audit (this PR closes the `ai_providers` cascade)
- #3192 — canonical PRD-186 PR4 pattern (`ai_alerts` / `ai_alert_rules`)
- #3148 — PRD-186 PR4 trio (`ai_model_pricing` / `sync_job_results` / `ai_usage`) — the joined table on the other side of the `findFallbackProvider` mixed-DB pin
- #3160 — per-pillar-migrations smoke test fix (lesson applied)
