### PR TITLE
feat(api/core/embeddings): flip 2 sites to getCerebrumDrizzle (cerebrum writer cutover · Wave 5 cascade)

### DIFF
--- a/apps/pops-api/src/modules/core/embeddings/service.test.ts
+++ b/apps/pops-api/src/modules/core/embeddings/service.test.ts
@@ -2,7 +2,7 @@ import BetterSqlite3 from 'better-sqlite3';
 import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import * as dbTypes from '@pops/db-types';
+import { embeddings } from '@pops/cerebrum-db';
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -33,6 +33,11 @@ vi.mock('../../../db.js', () => ({
   getDrizzle: () => testDrizzle,
   getDb: () => testDb,
   isVecAvailable: () => vecAvailable,
+}));
+
+vi.mock('../../../db/cerebrum-handle.js', () => ({
+  getCerebrumDrizzle: () => testDrizzle,
+  getCerebrumRawDb: () => testDb,
 }));
 
 import { semanticSearch, getEmbeddingStatus, reindexEmbeddings } from './service.js';
@@ -96,7 +101,7 @@ function seedEmbedding(
 
 beforeEach(() => {
   testDb = createSearchTestDb();
-  testDrizzle = drizzle(testDb, { schema: dbTypes });
+  testDrizzle = drizzle(testDb, { schema: { embeddings } });
   vecAvailable = true;
   vi.clearAllMocks();
 });

--- a/apps/pops-api/src/modules/core/embeddings/service.ts
+++ b/apps/pops-api/src/modules/core/embeddings/service.ts
@@ -2,9 +2,10 @@ import { createHash } from 'node:crypto';
 
 import { eq, sql } from 'drizzle-orm';
 
-import { embeddings } from '@pops/db-types';
+import { embeddings } from '@pops/cerebrum-db';
 
-import { getDrizzle, getDb, isVecAvailable } from '../../../db.js';
+import { getDb, isVecAvailable } from '../../../db.js';
+import { getCerebrumDrizzle } from '../../../db/cerebrum-handle.js';
 import { embedContent } from '../../../jobs/embed-content.js';
 import { logger } from '../../../lib/logger.js';
 import { getEmbeddingConfig, getEmbedding } from '../../../shared/embedding-client.js';
@@ -115,7 +116,7 @@ export async function semanticSearch(
 
 /** Return embedding coverage stats for a source type (or all types). */
 export function getEmbeddingStatus(sourceType?: string): EmbeddingStatus {
-  const db = getDrizzle();
+  const db = getCerebrumDrizzle();
   const baseQuery = db.select({ count: sql<number>`count(*)` }).from(embeddings);
   const rows = sourceType
     ? baseQuery.where(eq(embeddings.sourceType, sourceType)).all()
@@ -134,7 +135,7 @@ export function getEmbeddingStatus(sourceType?: string): EmbeddingStatus {
  * Returns the number of jobs enqueued.
  */
 export async function reindexEmbeddings(sourceType: string, sourceIds?: string[]): Promise<number> {
-  const db = getDrizzle();
+  const db = getCerebrumDrizzle();
 
   let ids: string[];
   if (sourceIds && sourceIds.length > 0) {


### PR DESCRIPTION
## Summary

- Flip `getEmbeddingStatus` + `reindexEmbeddings` in `apps/pops-api/src/modules/core/embeddings/service.ts` from `getDrizzle()` to `getCerebrumDrizzle()`.
- Switch the `embeddings` schema import from `@pops/db-types` to `@pops/cerebrum-db` (mirrors PR #3147 which did the embeddings hot-paths).
- Update the test mock to stub `getCerebrumDrizzle` / `getCerebrumRawDb` so it does not silently fall through to the old handle (the lesson from PR #3194).

The `embeddings` table is cerebrum-owned per `apps/pops-api/src/db/migration-ownership.ts:56-57`, the cerebrum slice already exists via PR #3144 (`packages/cerebrum-db/migrations/0054_embeddings_baseline.sql`), and the ATTACH backfill from shared `pops.db` to `cerebrum.db` is wired in `apps/pops-api/src/db/backfill-cerebrum-from-shared.ts`.

This closes the "subsequent PR" the cerebrum backfill comment in `backfill-cerebrum-from-shared.ts` mentions, and resolves the entry that #3191's Wave 5 audit mis-labelled as "embeddings PR4" — only the 2 read sites in this service file were left after PR #3147 did the hot-paths.

The ATTACH backfill entry stays in place until prod-verify, matching the cerebrum / finance / media pattern.

## Test plan

- [x] `pnpm --filter @pops/api test src/modules/core/embeddings` — 11/11 pass
- [x] `pnpm --filter @pops/api typecheck`
- [x] `pnpm lint apps/pops-api/src/modules/core/embeddings`
- [x] `pnpm format:check apps/pops-api/src/modules/core/embeddings`
- [x] husky pre-commit (lint-staged) + pre-push (turbo typecheck) green