### PR TITLE
feat(core-db): user_settings PR4 — move table + flip 3 sites (Wave 5 cascade)

### DIFF
--- a/apps/pops-api/src/db/backfill-core-from-shared.test.ts
+++ b/apps/pops-api/src/db/backfill-core-from-shared.test.ts
@@ -138,6 +138,16 @@ CREATE INDEX idx_ai_alerts_acknowledged ON ai_alerts (acknowledged);
 CREATE INDEX idx_ai_alerts_dedupe ON ai_alerts (type, scope_detail, created_at);
 `;
 
+const USER_SETTINGS_SQL = `
+CREATE TABLE user_settings (
+  user_email text NOT NULL,
+  key text NOT NULL,
+  value text NOT NULL,
+  PRIMARY KEY (user_email, key)
+);
+CREATE INDEX idx_user_settings_user ON user_settings (user_email);
+`;
+
 function openSharedWithSeed(seed: (raw: BetterSqlite3.Database) => void): string {
   const path = join(tmpDir, 'pops.db');
   const raw = new BetterSqlite3(path);
@@ -147,6 +157,7 @@ function openSharedWithSeed(seed: (raw: BetterSqlite3.Database) => void): string
   raw.exec(AI_ALERT_RULES_SQL);
   raw.exec(AI_ALERTS_SQL);
   raw.exec(AI_PROVIDERS_SQL);
+  raw.exec(USER_SETTINGS_SQL);
   seed(raw);
   raw.close();
   return path;
@@ -214,8 +225,19 @@ function insertAlert(raw: BetterSqlite3.Database, ruleId: number, type: string):
     .run(ruleId, type, `${type} fired`, `scope:${type}`);
 }
 
+function insertUserSetting(
+  raw: BetterSqlite3.Database,
+  userEmail: string,
+  key: string,
+  value: string
+): void {
+  raw
+    .prepare(`INSERT INTO user_settings (user_email, key, value) VALUES (?, ?, ?)`)
+    .run(userEmail, key, value);
+}
+
 describe('backfillCoreFromShared', () => {
-  it('copies ai_model_pricing, sync_job_results, ai_usage, ai_alert_rules, ai_alerts, and ai_providers rows from shared on first run', () => {
+  it('copies ai_model_pricing, sync_job_results, ai_usage, ai_alert_rules, ai_alerts, ai_providers, and user_settings rows from shared on first run', () => {
     const sharedPath = openSharedWithSeed((raw) => {
       insertPricing(raw, 'claude', 'claude-haiku-4-5');
       insertSync(raw, 'job-a');
@@ -223,6 +245,7 @@ describe('backfillCoreFromShared', () => {
       const ruleId = insertAlertRule(raw, 'budget-threshold');
       insertAlert(raw, ruleId, 'budget-threshold');
       insertProvider(raw, 'claude', 'cloud');
+      insertUserSetting(raw, 'alice@example.com', 'feature.test.simple', 'true');
     });
 
     const core = openCoreDb(join(tmpDir, 'core.db'));
@@ -274,6 +297,13 @@ describe('backfillCoreFromShared', () => {
       expect(providers).toEqual([
         { id: 'claude', name: 'claude provider', type: 'cloud', status: 'active' },
       ]);
+
+      const userSettingsRows = core.raw
+        .prepare('SELECT user_email, key, value FROM user_settings')
+        .all() as { user_email: string; key: string; value: string }[];
+      expect(userSettingsRows).toEqual([
+        { user_email: 'alice@example.com', key: 'feature.test.simple', value: 'true' },
+      ]);
     } finally {
       core.raw.close();
     }
@@ -287,6 +317,7 @@ describe('backfillCoreFromShared', () => {
       const ruleId = insertAlertRule(raw, 'budget-threshold');
       insertAlert(raw, ruleId, 'budget-threshold');
       insertProvider(raw, 'claude', 'cloud');
+      insertUserSetting(raw, 'alice@example.com', 'feature.test.simple', 'true');
     });
 
     const core = openCoreDb(join(tmpDir, 'core.db'));
@@ -312,12 +343,16 @@ describe('backfillCoreFromShared', () => {
       const providerCount = (
         core.raw.prepare('SELECT count(*) AS n FROM ai_providers').get() as { n: number }
       ).n;
+      const userSettingsCount = (
+        core.raw.prepare('SELECT count(*) AS n FROM user_settings').get() as { n: number }
+      ).n;
       expect(pricingCount).toBe(1);
       expect(syncCount).toBe(1);
       expect(usageCount).toBe(1);
       expect(ruleCount).toBe(1);
       expect(alertCount).toBe(1);
       expect(providerCount).toBe(1);
+      expect(userSettingsCount).toBe(1);
     } finally {
       core.raw.close();
     }
@@ -446,12 +481,49 @@ describe('backfillCoreFromShared', () => {
       const providerCount = (
         core.raw.prepare('SELECT count(*) AS n FROM ai_providers').get() as { n: number }
       ).n;
+      const userSettingsCount = (
+        core.raw.prepare('SELECT count(*) AS n FROM user_settings').get() as { n: number }
+      ).n;
       expect(pricingCount).toBe(0);
       expect(syncCount).toBe(0);
       expect(usageCount).toBe(0);
       expect(ruleCount).toBe(0);
       expect(alertCount).toBe(0);
       expect(providerCount).toBe(0);
+      expect(userSettingsCount).toBe(0);
+    } finally {
+      core.raw.close();
+    }
+  });
+
+  it('skips user_settings rows whose (user_email, key) already exists in core', () => {
+    const sharedPath = openSharedWithSeed((raw) => {
+      insertUserSetting(raw, 'alice@example.com', 'feature.test.simple', 'true');
+      insertUserSetting(raw, 'bob@example.com', 'feature.test.simple', 'false');
+    });
+
+    const core = openCoreDb(join(tmpDir, 'core.db'));
+    try {
+      core.raw
+        .prepare(
+          `INSERT INTO user_settings (user_email, key, value)
+           VALUES ('alice@example.com', 'feature.test.simple', 'core-overrides-shared')`
+        )
+        .run();
+
+      backfillCoreFromShared(core, sharedPath);
+
+      const rows = core.raw
+        .prepare('SELECT user_email, key, value FROM user_settings ORDER BY user_email')
+        .all() as { user_email: string; key: string; value: string }[];
+      expect(rows).toEqual([
+        {
+          user_email: 'alice@example.com',
+          key: 'feature.test.simple',
+          value: 'core-overrides-shared',
+        },
+        { user_email: 'bob@example.com', key: 'feature.test.simple', value: 'false' },
+      ]);
     } finally {
       core.raw.close();
     }

--- a/apps/pops-api/src/db/backfill-core-from-shared.ts
+++ b/apps/pops-api/src/db/backfill-core-from-shared.ts
@@ -2,10 +2,11 @@
  * Boot-time backfill from the legacy shared `pops.db` into the core
  * pillar's `core.db` for the tables PRD-186 PR4 lands in core-db:
  * `ai_model_pricing`, `sync_job_results`, `ai_usage`, `ai_alert_rules`,
- * `ai_alerts`, and `ai_providers`.
+ * `ai_alerts`, `ai_providers`, and `user_settings`.
  *
  * Phase context: PR4 establishes the per-pillar table home for these
- * tables (`packages/core-db/migrations/0059..0064_*.sql`) ahead of the
+ * tables (`packages/core-db/migrations/0059..0064_*.sql` plus
+ * `0066_user_settings.sql`) ahead of the
  * hot-path writer cutover that flips the per-table writers from
  * `getDrizzle()` to `getCoreDrizzle()` in the same / next PR. Until each
  * cutover lands, writers still target `pops.db` — so this backfill
@@ -143,6 +144,11 @@ const TABLE_COPIES: readonly TableCopy[] = [
       'created_at',
       'updated_at',
     ],
+  },
+  {
+    table: 'user_settings',
+    idColumns: ['user_email', 'key'],
+    columns: ['user_email', 'key', 'value'],
   },
 ];
 

--- a/apps/pops-api/src/db/per-pillar-migrations.test.ts
+++ b/apps/pops-api/src/db/per-pillar-migrations.test.ts
@@ -218,6 +218,10 @@ describe('runPerPillarMigrations', () => {
     // 0064_ai_providers (Wave 5 cascade — moves the providers table and
     // flips the 5 `core/ai-providers/service.ts` handler sites plus the
     // `core/ai-budgets/enforcement.ts` mixed-DB pin to
+    // `getCoreDrizzle()`), and the PRD-186 PR4 user_settings slice
+    // 0066_user_settings (Wave 5 cascade — moves the per-user
+    // preferences table and flips the 3
+    // `core/features/user-settings.ts` handler sites to
     // `getCoreDrizzle()`);
     // `media` owns `packages/media-db/migrations/`
     // with 0021_spooky_lockheed (media pillar Phase 1 PR 2),
@@ -285,6 +289,7 @@ describe('runPerPillarMigrations', () => {
         '0062_ai_alert_rules',
         '0063_ai_alerts',
         '0064_ai_providers',
+        '0066_user_settings',
       ]);
       expect([...result.pillarsApplied].toSorted()).toEqual([
         'cerebrum',

--- a/apps/pops-api/src/modules/core/features/user-settings.ts
+++ b/apps/pops-api/src/modules/core/features/user-settings.ts
@@ -2,7 +2,7 @@ import { and, eq } from 'drizzle-orm';
 
 import { userSettings } from '@pops/db-types/schema';
 
-import { getDrizzle } from '../../../db.js';
+import { getCoreDrizzle } from '../../../db.js';
 
 /**
  * Per-user settings storage helpers. Backs `scope: 'user'` features and any
@@ -10,7 +10,7 @@ import { getDrizzle } from '../../../db.js';
  */
 
 export function getUserSetting(userEmail: string, key: string): string | null {
-  const db = getDrizzle();
+  const db = getCoreDrizzle();
   const row = db
     .select()
     .from(userSettings)
@@ -20,7 +20,7 @@ export function getUserSetting(userEmail: string, key: string): string | null {
 }
 
 export function setUserSetting(userEmail: string, key: string, value: string): void {
-  const db = getDrizzle();
+  const db = getCoreDrizzle();
   db.insert(userSettings)
     .values({ userEmail, key, value })
     .onConflictDoUpdate({
@@ -31,7 +31,7 @@ export function setUserSetting(userEmail: string, key: string, value: string): v
 }
 
 export function deleteUserSetting(userEmail: string, key: string): boolean {
-  const db = getDrizzle();
+  const db = getCoreDrizzle();
   const result = db
     .delete(userSettings)
     .where(and(eq(userSettings.userEmail, userEmail), eq(userSettings.key, key)))

--- a/packages/core-db/migrations/0066_user_settings.sql
+++ b/packages/core-db/migrations/0066_user_settings.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `user_settings` (
+	`user_email` text NOT NULL,
+	`key` text NOT NULL,
+	`value` text NOT NULL,
+	PRIMARY KEY(`user_email`, `key`)
+);
+--> statement-breakpoint
+CREATE INDEX `idx_user_settings_user` ON `user_settings` (`user_email`);

--- a/packages/core-db/migrations/meta/_journal.json
+++ b/packages/core-db/migrations/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1782259200000,
       "tag": "0064_ai_providers",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1782345600000,
+      "tag": "0066_user_settings",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core-db/src/__tests__/open-core-db.test.ts
+++ b/packages/core-db/src/__tests__/open-core-db.test.ts
@@ -173,6 +173,42 @@ describe('openCoreDb', () => {
     }
   });
 
+  it('applies the PRD-186 PR4 user_settings migration', () => {
+    const path = join(tmpDir, 'core.db');
+    const { raw } = openCoreDb(path);
+    try {
+      const tables = new Set(
+        (
+          raw.prepare("SELECT name FROM sqlite_master WHERE type='table'").all() as {
+            name: string;
+          }[]
+        ).map((r) => r.name)
+      );
+      expect(tables.has('user_settings')).toBe(true);
+
+      const indexes = new Set(
+        (
+          raw.prepare("SELECT name FROM sqlite_master WHERE type='index'").all() as {
+            name: string;
+          }[]
+        ).map((r) => r.name)
+      );
+      expect(indexes.has('idx_user_settings_user')).toBe(true);
+
+      raw
+        .prepare(
+          `INSERT INTO user_settings (user_email, key, value)
+           VALUES ('alice@example.com', 'feature.test.simple', 'true')`
+        )
+        .run();
+      const count = (raw.prepare('SELECT count(*) AS n FROM user_settings').get() as { n: number })
+        .n;
+      expect(count).toBe(1);
+    } finally {
+      raw.close();
+    }
+  });
+
   it('is idempotent — re-opening the same DB does not re-apply migrations', async () => {
     const path = join(tmpDir, 'core.db');
     const first = openCoreDb(path);

--- a/packages/core-db/src/schema.ts
+++ b/packages/core-db/src/schema.ts
@@ -23,4 +23,5 @@ export {
   serviceAccounts,
   settings,
   syncJobResults,
+  userSettings,
 } from '@pops/db-types';

--- a/packages/db-types/src/index.ts
+++ b/packages/db-types/src/index.ts
@@ -138,6 +138,7 @@ export {
   transactions,
   transactionTagRules,
   tvShows,
+  userSettings,
   watchHistory,
   wishList,
 } from './schema/index.js';


### PR DESCRIPTION
## Summary

PRD-186 PR4 cascade — surfaced by the Wave 5 audit in #3191 as `userSettings PR4 -> 3 sites in features/user-settings.ts`. Mirrors the canonical pattern from #3195 (ai_providers) and #3192 (ai_alerts/ai_alert_rules): lands the `user_settings` table under `@pops/core-db`, ships an idempotent ATTACH backfill from the legacy shared `pops.db`, and flips the 3 handler call-sites in `features/user-settings.ts` from `getDrizzle()` to `getCoreDrizzle()` in the same PR.

### Migration + schema (core-db)
- `packages/core-db/migrations/0066_user_settings.sql` (composite PK on `(user_email, key)` + `idx_user_settings_user` on `user_email`). Slot 0065 is reserved for the parallel embeddings PR4; this slice registers at idx 12 with tag `0066_user_settings`.
- `packages/core-db/migrations/meta/_journal.json` — appended idx 12.
- `packages/core-db/src/schema.ts` — re-exports `userSettings` (canonical def stays in `@pops/db-types`).
- `packages/db-types/src/index.ts` — re-exports `userSettings` from the root barrel so `@pops/core-db` picks it up via the same import surface as every other PR4 table.

### Backfill (apps/pops-api)
- `backfill-core-from-shared.ts` — extends `TABLE_COPIES` with `user_settings`, keyed on `(user_email, key)` (composite business key, mirrors the `ai_model_pricing` `(provider_id, model_id)` precedent). Existing ATTACH / non-fatal / idempotent semantics unchanged.

### Handler flips (apps/pops-api)
- `modules/core/features/user-settings.ts` — 3 sites: `getUserSetting`, `setUserSetting`, `deleteUserSetting`. Import widened from `getDrizzle` to `getCoreDrizzle`. The feature-toggle framework's `scope: 'user'` overrides resolve via these helpers, so the cutover lands the per-user preference read+write path on the core handle in one PR.

`getDrizzle()` -> `getCoreDrizzle()` delta:
0 remaining `getDrizzle()` call-sites in `features/user-settings.ts` (was 3, now 3 `getCoreDrizzle()`); the module-level import is the only type-only widening.

### Smoke + unit tests
- `apps/pops-api/src/db/per-pillar-migrations.test.ts` — expected `applied` list extended with `0066_user_settings`.
- `packages/core-db/src/__tests__/open-core-db.test.ts` — new case asserts `user_settings` lands with `idx_user_settings_user` and accepts inserts.
- `apps/pops-api/src/db/backfill-core-from-shared.test.ts` — new `insertUserSetting` seed helper, dedicated `(user_email, key)` dedup test, and the existing first-run / idempotent / missing-source-tolerance cases now assert on the seven tables.

### Why both DBs keep the table for now
Per the cerebrum/finance/media pattern (and the #3192/#3195 playbook), the shared `pops.db` copy stays in place as the fallback. The corresponding `TABLE_COPIES` entry retires in a follow-up PR after prod verification.

### References
- #3191 — Wave 5 7-pillar audit (this PR closes the userSettings cascade item)
- #3195 — most recent canonical PRD-186 PR4 pattern (ai_providers)
- #3192 — multi-table PR4 variant (ai_alerts / ai_alert_rules)

## Test plan

- [x] `pnpm --filter @pops/core-db test` — 130 / 130 pass
- [x] `pnpm --filter @pops/api test src/db/per-pillar-migrations src/db/backfill-core-from-shared src/modules/core/features` — 40 / 40 pass
- [x] `pnpm typecheck` — 71 / 71 packages clean
- [x] `pnpm lint` — exit 0 (warnings only, all pre-existing)
- [x] `pnpm format:check` — clean
- [x] Husky pre-commit + pre-push pass without --no-verify