### PR TITLE
feat(cerebrum-db): debrief* PR4 + media mixed-tx writer cutover (Wave 5 cascade)

### DIFF
--- a/apps/pops-api/src/db/backfill-cerebrum-from-shared.test.ts
+++ b/apps/pops-api/src/db/backfill-cerebrum-from-shared.test.ts
@@ -66,14 +66,75 @@ CREATE UNIQUE INDEX uq_embeddings_source_chunk
   ON embeddings (source_type, source_id, chunk_index);
 `;
 
+const DEBRIEF_SQL = `
+CREATE TABLE debrief_sessions (
+  id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  watch_history_id integer NOT NULL,
+  media_type text,
+  media_id integer,
+  status text DEFAULT 'pending' NOT NULL,
+  created_at text DEFAULT (datetime('now')) NOT NULL
+);
+CREATE INDEX idx_debrief_sessions_media ON debrief_sessions (media_type, media_id);
+CREATE TABLE debrief_results (
+  id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  session_id integer NOT NULL,
+  dimension_id integer NOT NULL,
+  comparison_id integer,
+  created_at text DEFAULT (datetime('now')) NOT NULL
+);
+CREATE TABLE debrief_status (
+  id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  media_type text NOT NULL,
+  media_id integer NOT NULL,
+  dimension_id integer NOT NULL,
+  debriefed integer DEFAULT 0 NOT NULL,
+  dismissed integer DEFAULT 0 NOT NULL,
+  created_at text DEFAULT (datetime('now')) NOT NULL,
+  updated_at text DEFAULT (datetime('now')) NOT NULL
+);
+CREATE UNIQUE INDEX debrief_status_media_dimension_idx
+  ON debrief_status (media_type, media_id, dimension_id);
+`;
+
 function openSharedWithSeed(seed: (raw: BetterSqlite3.Database) => void): string {
   const path = join(tmpDir, 'pops.db');
   const raw = new BetterSqlite3(path);
   raw.exec(NUDGE_LOG_SQL);
   raw.exec(EMBEDDINGS_SQL);
+  raw.exec(DEBRIEF_SQL);
   seed(raw);
   raw.close();
   return path;
+}
+
+function insertDebriefSession(
+  raw: BetterSqlite3.Database,
+  watchHistoryId: number,
+  mediaId: number
+): number {
+  const result = raw
+    .prepare(
+      `INSERT INTO debrief_sessions
+        (watch_history_id, media_type, media_id, status, created_at)
+       VALUES (?, 'movie', ?, 'pending', '2026-06-13T00:00:00Z')`
+    )
+    .run(watchHistoryId, mediaId);
+  return Number(result.lastInsertRowid);
+}
+
+function insertDebriefStatus(
+  raw: BetterSqlite3.Database,
+  mediaId: number,
+  dimensionId: number
+): void {
+  raw
+    .prepare(
+      `INSERT INTO debrief_status
+        (media_type, media_id, dimension_id, debriefed, dismissed, created_at, updated_at)
+       VALUES ('movie', ?, ?, 0, 0, '2026-06-13T00:00:00Z', '2026-06-13T00:00:00Z')`
+    )
+    .run(mediaId, dimensionId);
 }
 
 function insertEmbedding(raw: BetterSqlite3.Database, sourceId: string, chunkIndex = 0): void {
@@ -186,6 +247,100 @@ describe('backfillCerebrumFromShared', () => {
         n: number;
       };
       expect(n).toBe(0);
+    } finally {
+      cerebrum.raw.close();
+    }
+  });
+
+  it('copies debrief_sessions / debrief_results / debrief_status rows on first run', () => {
+    const sharedPath = openSharedWithSeed((raw) => {
+      const sessionId = insertDebriefSession(raw, 11, 101);
+      raw
+        .prepare(
+          `INSERT INTO debrief_results (session_id, dimension_id, comparison_id, created_at)
+           VALUES (?, 1, NULL, '2026-06-13T00:00:00Z')`
+        )
+        .run(sessionId);
+      insertDebriefStatus(raw, 101, 1);
+    });
+
+    const cerebrum = openCerebrumDb(join(tmpDir, 'cerebrum.db'), { loadVec: false });
+    try {
+      backfillCerebrumFromShared(cerebrum, sharedPath);
+      const sessions = cerebrum.raw.prepare('SELECT count(*) AS n FROM debrief_sessions').get() as {
+        n: number;
+      };
+      const results = cerebrum.raw.prepare('SELECT count(*) AS n FROM debrief_results').get() as {
+        n: number;
+      };
+      const status = cerebrum.raw.prepare('SELECT count(*) AS n FROM debrief_status').get() as {
+        n: number;
+      };
+      expect(sessions.n).toBe(1);
+      expect(results.n).toBe(1);
+      expect(status.n).toBe(1);
+
+      const result = cerebrum.raw.prepare('SELECT session_id FROM debrief_results').get() as {
+        session_id: number;
+      };
+      const session = cerebrum.raw.prepare('SELECT id FROM debrief_sessions').get() as {
+        id: number;
+      };
+      expect(result.session_id).toBe(session.id);
+    } finally {
+      cerebrum.raw.close();
+    }
+  });
+
+  it('debrief backfill is idempotent across re-runs', () => {
+    const sharedPath = openSharedWithSeed((raw) => {
+      insertDebriefSession(raw, 11, 101);
+      insertDebriefStatus(raw, 101, 1);
+      insertDebriefStatus(raw, 101, 2);
+    });
+
+    const cerebrum = openCerebrumDb(join(tmpDir, 'cerebrum.db'), { loadVec: false });
+    try {
+      backfillCerebrumFromShared(cerebrum, sharedPath);
+      backfillCerebrumFromShared(cerebrum, sharedPath);
+
+      const { n: sessions } = cerebrum.raw
+        .prepare('SELECT count(*) AS n FROM debrief_sessions')
+        .get() as { n: number };
+      const { n: status } = cerebrum.raw
+        .prepare('SELECT count(*) AS n FROM debrief_status')
+        .get() as { n: number };
+      expect(sessions).toBe(1);
+      expect(status).toBe(2);
+    } finally {
+      cerebrum.raw.close();
+    }
+  });
+
+  it('debrief_status dedupes on (media_type, media_id, dimension_id) under mixed state', () => {
+    const sharedPath = openSharedWithSeed((raw) => {
+      insertDebriefStatus(raw, 101, 1);
+      insertDebriefStatus(raw, 101, 2);
+    });
+
+    const cerebrum = openCerebrumDb(join(tmpDir, 'cerebrum.db'), { loadVec: false });
+    try {
+      cerebrum.raw
+        .prepare(
+          `INSERT INTO debrief_status (media_type, media_id, dimension_id) VALUES ('movie', 101, 1)`
+        )
+        .run();
+      backfillCerebrumFromShared(cerebrum, sharedPath);
+
+      const rows = cerebrum.raw
+        .prepare(
+          'SELECT media_id, dimension_id FROM debrief_status ORDER BY media_id, dimension_id'
+        )
+        .all() as { media_id: number; dimension_id: number }[];
+      expect(rows).toEqual([
+        { media_id: 101, dimension_id: 1 },
+        { media_id: 101, dimension_id: 2 },
+      ]);
     } finally {
       cerebrum.raw.close();
     }

--- a/apps/pops-api/src/db/backfill-cerebrum-from-shared.ts
+++ b/apps/pops-api/src/db/backfill-cerebrum-from-shared.ts
@@ -8,9 +8,13 @@
  * (PRD-182) entries have been retired from the backfill — their PR3
  * writer cutovers were verified in prod, so no further rows can land
  * on the shared `pops.db` for those tables. The remaining bridges are
- * `nudge_log` (until Track M5 / PRD-149 flips the nudges writer) and
- * `embeddings` (PRD-076 / theme-13 wave-5 — the slice scaffold landed
- * here, hot-path writer cutover follows in a subsequent PR).
+ * `nudge_log` (until Track M5 / PRD-149 flips the nudges writer),
+ * `embeddings` (PRD-076 / theme-13 wave-5 — slice already cut over),
+ * and the debrief slice (`debrief_sessions`, `debrief_results`,
+ * `debrief_status`) — Theme-13 Wave 5 cascade per PR #3191's MEDIA
+ * exit audit. The shared `pops.db` copies of the debrief tables stay
+ * in place until prod verification, then the bridge entries retire in
+ * the same pattern as the other slices.
  *
  * Subsequent boots find the cerebrum copy already populated and become
  * a no-op via the `WHERE NOT EXISTS (...)` existence filter.
@@ -95,6 +99,50 @@ const TABLE_COPIES: readonly TableCopy[] = [
       'model',
       'dimensions',
       'created_at',
+    ],
+  },
+  {
+    /**
+     * `id` is preserved so the dependent `debrief_results.session_id`
+     * foreign-key references continue to resolve after the bridge runs.
+     * The cerebrum.db is freshly empty on first boot, so there is no
+     * autoincrement collision risk; the SQLite sequence picks up from
+     * `MAX(id)+1` after the copy. Dedupe on `id` keeps subsequent boots
+     * idempotent.
+     */
+    table: 'debrief_sessions',
+    idColumns: ['id'],
+    columns: ['id', 'watch_history_id', 'media_type', 'media_id', 'status', 'created_at'],
+  },
+  {
+    /**
+     * Dedupe on `id` for the same reason as `debrief_sessions` — the
+     * row's `session_id` is the load-bearing identity, copying it across
+     * keeps history intact for any in-flight debrief that already had
+     * partial results on the shared pops.db.
+     */
+    table: 'debrief_results',
+    idColumns: ['id'],
+    columns: ['id', 'session_id', 'dimension_id', 'comparison_id', 'created_at'],
+  },
+  {
+    /**
+     * Composite natural key from `debrief_status_media_dimension_idx`
+     * (UNIQUE on `(media_type, media_id, dimension_id)`) — re-runs only
+     * insert tuples the cerebrum copy is missing. `debriefed` /
+     * `dismissed` flags follow whatever the shared row had at backfill
+     * time; subsequent writer activity on cerebrum.db wins.
+     */
+    table: 'debrief_status',
+    idColumns: ['media_type', 'media_id', 'dimension_id'],
+    columns: [
+      'media_type',
+      'media_id',
+      'dimension_id',
+      'debriefed',
+      'dismissed',
+      'created_at',
+      'updated_at',
     ],
   },
 ];

--- a/apps/pops-api/src/db/migration-ownership.ts
+++ b/apps/pops-api/src/db/migration-ownership.ts
@@ -43,9 +43,14 @@ export const MIGRATION_OWNERS: Readonly<Record<string, string>> = {
   '0015_condemned_anthem': 'media',
   '0016_certain_namor': 'media',
   '0017_loose_doomsday': 'media',
-  '0018_high_excalibur': 'media',
+  // Theme-13 Wave-5 cascade — debrief_results + debrief_sessions originally
+  // shipped under 0018; the cerebrum baseline (`0055_debrief_baseline.sql`)
+  // now mirrors them on the cerebrum handle. Marked cerebrum-owned so the
+  // shared journal entry retires when the table copies drop from pops.db.
+  '0018_high_excalibur': 'cerebrum',
   '0019_little_diamondback': 'media',
-  '0020_melodic_major_mapleleaf': 'media',
+  // Theme-13 Wave-5 cascade — debrief_status. Same reasoning as 0018.
+  '0020_melodic_major_mapleleaf': 'cerebrum',
   '0022_elo_deltas': 'media',
   '0023_kind_james_howlett': 'media',
   '0024_dedupe_comparisons': 'media',

--- a/apps/pops-api/src/db/per-pillar-migrations.test.ts
+++ b/apps/pops-api/src/db/per-pillar-migrations.test.ts
@@ -246,9 +246,11 @@ describe('runPerPillarMigrations', () => {
     // engrams baseline), 0051_glia_baseline (PRD-181 US-01 — glia
     // baseline), 0052_conversations_baseline (PRD-182 US-01 —
     // conversations baseline), 0053_plexus_baseline (PRD-180 US-01 —
-    // plexus baseline), and 0054_embeddings_baseline (PRD-186 Wave 5 unblock
-    // — embeddings + embeddings_vec slice). Pillars without their own journal
-    // yet still skip cleanly.
+    // plexus baseline), 0054_embeddings_baseline (PRD-186 Wave 5 unblock
+    // — embeddings + embeddings_vec slice), and 0055_debrief_baseline
+    // (Theme-13 Wave 5 cascade — debrief_sessions + debrief_results +
+    // debrief_status mirrored from the shared journal ahead of the MEDIA
+    // exit). Pillars without their own journal yet still skip cleanly.
     await withDb((db) => {
       const realPillars: PillarDescriptor[] = [
         { id: 'core', dbPackageDir: 'packages/core-db' },
@@ -279,6 +281,7 @@ describe('runPerPillarMigrations', () => {
         '0053_plexus_baseline',
         '0054_embeddings_baseline',
         '0054_service_accounts',
+        '0055_debrief_baseline',
         '0055_pillar_registry',
         '0056_settings_baseline',
         '0057_ai_usage_baseline',

--- a/apps/pops-api/src/modules/cerebrum/debrief/router.ts
+++ b/apps/pops-api/src/modules/cerebrum/debrief/router.ts
@@ -24,10 +24,10 @@
  * onto the shared pops.db connection so the writes are genuinely atomic
  * today, and in production it becomes a real cross-table boundary once
  * step 3 lands and `debrief_sessions` / `debrief_status` are physically
- * owned by `cerebrum.db`. Until then the inner services continue to
- * resolve `getDrizzle()` (pops.db) directly — the transaction is a
- * forward-compatible scaffold, not a runtime atomicity guarantee on
- * production yet.
+ * owned by `cerebrum.db`. After the Theme-13 Wave-5 cascade the inner
+ * services resolve `getCerebrumDrizzle()` themselves — atomicity within
+ * the cerebrum-side fan-out is therefore guaranteed on the same singleton
+ * connection.
  */
 import { z } from 'zod';
 

--- a/apps/pops-api/src/modules/cerebrum/migrations.ts
+++ b/apps/pops-api/src/modules/cerebrum/migrations.ts
@@ -15,6 +15,13 @@ import { drizzleMigrations } from '../../db/load-drizzle-migration.js';
 import type { MigrationDescriptor } from '@pops/types';
 
 export const cerebrumMigrationTags: readonly string[] = [
+  // debrief_results + debrief_sessions — Theme-13 Wave-5 cascade ownership
+  // flip. The shared journal entry remains while the table copies stay on
+  // pops.db; the cerebrum baseline `0055_debrief_baseline.sql` mirrors the
+  // shape and the boot-time backfill bridges existing rows across.
+  '0018_high_excalibur',
+  // debrief_status — same Theme-13 Wave-5 cascade flip as 0018.
+  '0020_melodic_major_mapleleaf',
   // engram_index — knowledge graph file metadata table.
   '0031_romantic_hannibal_king',
   // embeddings — dense vector storage.

--- a/apps/pops-api/src/modules/media/comparisons/lib/debrief-dismiss.ts
+++ b/apps/pops-api/src/modules/media/comparisons/lib/debrief-dismiss.ts
@@ -1,19 +1,17 @@
 import { and, count, eq } from 'drizzle-orm';
 
-import {
-  comparisonDimensions,
-  debriefResults,
-  debriefSessions,
-  debriefStatus,
-  watchHistory,
-} from '@pops/db-types';
+import { debriefResults, debriefSessions, debriefStatus } from '@pops/cerebrum-db';
+import { comparisonDimensions } from '@pops/db-types';
+import { watchHistory } from '@pops/media-db';
 
 import { getDrizzle } from '../../../../db.js';
+import { getCerebrumDrizzle } from '../../../../db/cerebrum-handle.js';
+import { getMediaDrizzle } from '../../../../db/media-db-handle.js';
 import { ConflictError, NotFoundError, ValidationError } from '../../../../shared/errors.js';
 import { getDimension } from '../dimensions.service.js';
 
 function loadValidSession(sessionId: number): { watchHistoryId: number } {
-  const db = getDrizzle();
+  const db = getCerebrumDrizzle();
   const session = db.select().from(debriefSessions).where(eq(debriefSessions.id, sessionId)).get();
   if (!session) {
     throw new NotFoundError('Debrief session', String(sessionId));
@@ -25,7 +23,7 @@ function loadValidSession(sessionId: number): { watchHistoryId: number } {
 }
 
 function ensureNoExistingResult(sessionId: number, dimensionId: number): void {
-  const db = getDrizzle();
+  const db = getCerebrumDrizzle();
   const existing = db
     .select()
     .from(debriefResults)
@@ -41,14 +39,16 @@ function ensureNoExistingResult(sessionId: number, dimensionId: number): void {
 }
 
 function markDebriefStatusDismissed(watchHistoryId: number, dimensionId: number): void {
-  const db = getDrizzle();
-  const watchEntry = db
+  const mediaDb = getMediaDrizzle();
+  const cerebrumDb = getCerebrumDrizzle();
+  const watchEntry = mediaDb
     .select()
     .from(watchHistory)
     .where(eq(watchHistory.id, watchHistoryId))
     .get();
   if (!watchEntry) return;
-  db.update(debriefStatus)
+  cerebrumDb
+    .update(debriefStatus)
     .set({ dismissed: 1 })
     .where(
       and(
@@ -61,21 +61,23 @@ function markDebriefStatusDismissed(watchHistoryId: number, dimensionId: number)
 }
 
 function autoCompleteIfFinished(sessionId: number): void {
-  const db = getDrizzle();
-  const activeDims = db
+  const sharedDb = getDrizzle();
+  const cerebrumDb = getCerebrumDrizzle();
+  const activeDims = sharedDb
     .select({ id: comparisonDimensions.id })
     .from(comparisonDimensions)
     .where(eq(comparisonDimensions.active, 1))
     .all();
 
-  const resultCount = db
+  const resultCount = cerebrumDb
     .select({ cnt: count() })
     .from(debriefResults)
     .where(eq(debriefResults.sessionId, sessionId))
     .get();
 
   if (resultCount && resultCount.cnt >= activeDims.length) {
-    db.update(debriefSessions)
+    cerebrumDb
+      .update(debriefSessions)
       .set({ status: 'complete' })
       .where(eq(debriefSessions.id, sessionId))
       .run();
@@ -86,9 +88,13 @@ function autoCompleteIfFinished(sessionId: number): void {
  * Dismiss a debrief dimension — inserts a debrief_result with comparison_id=null
  * (marks the dimension as skipped). Auto-completes the session when all active
  * dimensions have results.
+ *
+ * Theme-13 Wave-5 cascade: debrief* tables routed via `getCerebrumDrizzle()`;
+ * `watch_history` lookup hops to `getMediaDrizzle()`; `comparison_dimensions`
+ * stays on the shared `pops.db` until that slice cuts over.
  */
 export function dismissDebriefDimension(sessionId: number, dimensionId: number): void {
-  const db = getDrizzle();
+  const db = getCerebrumDrizzle();
   const { watchHistoryId } = loadValidSession(sessionId);
   getDimension(dimensionId);
   ensureNoExistingResult(sessionId, dimensionId);

--- a/apps/pops-api/src/modules/media/comparisons/lib/debrief-pending.ts
+++ b/apps/pops-api/src/modules/media/comparisons/lib/debrief-pending.ts
@@ -1,14 +1,12 @@
 import { count, desc, eq, or } from 'drizzle-orm';
 
-import {
-  comparisonDimensions,
-  debriefResults,
-  debriefSessions,
-  movies,
-  watchHistory,
-} from '@pops/db-types';
+import { debriefResults, debriefSessions } from '@pops/cerebrum-db';
+import { comparisonDimensions } from '@pops/db-types';
+import { movies, watchHistory } from '@pops/media-db';
 
 import { getDrizzle } from '../../../../db.js';
+import { getCerebrumDrizzle } from '../../../../db/cerebrum-handle.js';
+import { getMediaDrizzle } from '../../../../db/media-db-handle.js';
 import { resolveMoviePoster } from '../pairs/movie-helpers.js';
 
 import type { PendingDebrief } from '../types.js';
@@ -21,7 +19,7 @@ interface SessionRow {
 }
 
 function fetchPendingSessions(): SessionRow[] {
-  const db = getDrizzle();
+  const db = getCerebrumDrizzle();
   return db
     .select({
       sessionId: debriefSessions.id,
@@ -47,7 +45,7 @@ function getActiveDimensionCount(): number {
 }
 
 function getCompletedResultCount(sessionId: number): number {
-  const db = getDrizzle();
+  const db = getCerebrumDrizzle();
   return (
     db
       .select({ total: count() })
@@ -61,8 +59,8 @@ function buildPendingFromSession(
   session: SessionRow,
   activeDimCount: number
 ): PendingDebrief | null {
-  const db = getDrizzle();
-  const whEntry = db
+  const mediaDb = getMediaDrizzle();
+  const whEntry = mediaDb
     .select({
       mediaType: watchHistory.mediaType,
       mediaId: watchHistory.mediaId,
@@ -73,7 +71,7 @@ function buildPendingFromSession(
 
   if (!whEntry || whEntry.mediaType !== 'movie') return null;
 
-  const movieRow = db
+  const movieRow = mediaDb
     .select({
       id: movies.id,
       title: movies.title,

--- a/apps/pops-api/src/modules/media/comparisons/lib/debrief-record.ts
+++ b/apps/pops-api/src/modules/media/comparisons/lib/debrief-record.ts
@@ -1,14 +1,12 @@
 import { and, count, eq } from 'drizzle-orm';
 
-import {
-  comparisonDimensions,
-  debriefResults,
-  debriefSessions,
-  debriefStatus,
-  watchHistory,
-} from '@pops/db-types';
+import { debriefResults, debriefSessions, debriefStatus } from '@pops/cerebrum-db';
+import { comparisonDimensions } from '@pops/db-types';
+import { watchHistory } from '@pops/media-db';
 
 import { getDb, getDrizzle } from '../../../../db.js';
+import { getCerebrumDrizzle } from '../../../../db/cerebrum-handle.js';
+import { getMediaDrizzle } from '../../../../db/media-db-handle.js';
 import { ConflictError, NotFoundError, ValidationError } from '../../../../shared/errors.js';
 
 import type {
@@ -23,8 +21,9 @@ interface ValidationResult {
 }
 
 function loadAndValidate(input: RecordDebriefComparisonInput): ValidationResult {
-  const drizzleDb = getDrizzle();
-  const session = drizzleDb
+  const cerebrumDb = getCerebrumDrizzle();
+  const mediaDb = getMediaDrizzle();
+  const session = cerebrumDb
     .select()
     .from(debriefSessions)
     .where(eq(debriefSessions.id, input.sessionId))
@@ -34,14 +33,14 @@ function loadAndValidate(input: RecordDebriefComparisonInput): ValidationResult 
     throw new ValidationError('Debrief session is already complete');
   }
 
-  const watchEntry = drizzleDb
+  const watchEntry = mediaDb
     .select()
     .from(watchHistory)
     .where(eq(watchHistory.id, session.watchHistoryId))
     .get();
   if (!watchEntry) throw new NotFoundError('Watch history entry', String(session.watchHistoryId));
 
-  const existingResult = drizzleDb
+  const existingResult = cerebrumDb
     .select()
     .from(debriefResults)
     .where(
@@ -82,8 +81,8 @@ function recordComparisonForDebrief(
 }
 
 function markDebriefed(watchEntry: typeof watchHistory.$inferSelect, dimensionId: number): void {
-  const drizzleDb = getDrizzle();
-  drizzleDb
+  const cerebrumDb = getCerebrumDrizzle();
+  cerebrumDb
     .update(debriefStatus)
     .set({ debriefed: 1 })
     .where(
@@ -98,8 +97,8 @@ function markDebriefed(watchEntry: typeof watchHistory.$inferSelect, dimensionId
 
 function activateIfPending(sessionId: number, sessionStatus: string): void {
   if (sessionStatus !== 'pending') return;
-  const drizzleDb = getDrizzle();
-  drizzleDb
+  const cerebrumDb = getCerebrumDrizzle();
+  cerebrumDb
     .update(debriefSessions)
     .set({ status: 'active' })
     .where(eq(debriefSessions.id, sessionId))
@@ -107,13 +106,14 @@ function activateIfPending(sessionId: number, sessionStatus: string): void {
 }
 
 function checkAndCompleteSession(sessionId: number): boolean {
-  const drizzleDb = getDrizzle();
-  const activeDimCount = drizzleDb
+  const sharedDb = getDrizzle();
+  const cerebrumDb = getCerebrumDrizzle();
+  const activeDimCount = sharedDb
     .select({ cnt: count() })
     .from(comparisonDimensions)
     .where(eq(comparisonDimensions.active, 1))
     .get();
-  const resultCount = drizzleDb
+  const resultCount = cerebrumDb
     .select({ cnt: count() })
     .from(debriefResults)
     .where(eq(debriefResults.sessionId, sessionId))
@@ -123,7 +123,7 @@ function checkAndCompleteSession(sessionId: number): boolean {
     resultCount !== undefined &&
     resultCount.cnt >= activeDimCount.cnt;
   if (sessionComplete) {
-    drizzleDb
+    cerebrumDb
       .update(debriefSessions)
       .set({ status: 'complete' })
       .where(eq(debriefSessions.id, sessionId))
@@ -146,12 +146,12 @@ export function recordDebriefComparison(
   sessionComplete: boolean;
 } {
   const { watchEntry, sessionStatus } = loadAndValidate(input);
-  const drizzleDb = getDrizzle();
+  const cerebrumDb = getCerebrumDrizzle();
   const rawDb = getDb();
 
   return rawDb.transaction(() => {
     const comparisonId = recordComparisonForDebrief(input, watchEntry, recordFn);
-    drizzleDb
+    cerebrumDb
       .insert(debriefResults)
       .values({
         sessionId: input.sessionId,

--- a/apps/pops-api/src/modules/media/debrief/queue-status.ts
+++ b/apps/pops-api/src/modules/media/debrief/queue-status.ts
@@ -1,19 +1,25 @@
 import { eq } from 'drizzle-orm';
 
-import { comparisonDimensions, debriefStatus } from '@pops/db-types';
+import { debriefStatus } from '@pops/cerebrum-db';
+import { comparisonDimensions } from '@pops/db-types';
 
 import { getDrizzle } from '../../../db.js';
+import { getCerebrumDrizzle } from '../../../db/cerebrum-handle.js';
 
 /**
  * Queue debrief status rows for a media item — one per active dimension.
  *
- * On conflict (re-watch), resets debriefed and dismissed to 0 so the
- * user is prompted to debrief again.
+ * Side-by-side handles (Theme-13 Wave-5 cascade): `comparison_dimensions`
+ * still lives on the shared `pops.db` and is read through `getDrizzle()`;
+ * the `debrief_status` upserts target the cerebrum handle. On conflict
+ * (re-watch), `debriefed` / `dismissed` reset to 0 so the user is prompted
+ * to debrief again.
  */
 export function queueDebriefStatus(mediaType: string, mediaId: number): number {
-  const db = getDrizzle();
+  const sharedDb = getDrizzle();
+  const cerebrumDb = getCerebrumDrizzle();
 
-  const dims = db
+  const dims = sharedDb
     .select({ id: comparisonDimensions.id })
     .from(comparisonDimensions)
     .where(eq(comparisonDimensions.active, 1))
@@ -23,7 +29,8 @@ export function queueDebriefStatus(mediaType: string, mediaId: number): number {
 
   const now = new Date().toISOString();
   for (const dim of dims) {
-    db.insert(debriefStatus)
+    cerebrumDb
+      .insert(debriefStatus)
       .values({
         mediaType,
         mediaId,

--- a/apps/pops-api/src/modules/media/debrief/service.ts
+++ b/apps/pops-api/src/modules/media/debrief/service.ts
@@ -2,18 +2,23 @@ import { and, asc, eq, inArray } from 'drizzle-orm';
 
 /**
  * Debrief service — auto-queue and manage post-watch debrief sessions.
+ * Theme-13 Wave-5 cascade: debrief tables routed through
+ * `getCerebrumDrizzle()`, `watch_history` / `movies` via `getMediaDrizzle()`,
+ * `comparison_dimensions` still on shared `getDrizzle()`.
  */
-import {
-  comparisonDimensions,
-  debriefResults,
-  debriefSessions,
-  movies,
-  watchHistory,
-} from '@pops/db-types';
+import { debriefResults, debriefSessions } from '@pops/cerebrum-db';
+import { comparisonDimensions } from '@pops/db-types';
+import { movies, watchHistory } from '@pops/media-db';
 
 import { getDrizzle } from '../../../db.js';
+import { getCerebrumDrizzle } from '../../../db/cerebrum-handle.js';
+import { getMediaDrizzle } from '../../../db/media-db-handle.js';
 import { NotFoundError } from '../../../shared/errors.js';
 import { getDebriefOpponent } from '../comparisons/service.js';
+
+import type { DebriefDimension, DebriefResponse, MovieMetaRow } from './types.js';
+
+export type { DebriefDimension, DebriefResponse } from './types.js';
 
 /**
  * Create a pending debrief session for a watch history entry.
@@ -23,17 +28,19 @@ import { getDebriefOpponent } from '../comparisons/service.js';
  * Returns the new session ID.
  */
 export function createDebriefSession(watchHistoryId: number): number {
-  const db = getDrizzle();
+  const mediaDb = getMediaDrizzle();
+  const cerebrumDb = getCerebrumDrizzle();
 
-  // Look up the watch history entry to find media info
-  const entry = db.select().from(watchHistory).where(eq(watchHistory.id, watchHistoryId)).get();
+  const entry = mediaDb
+    .select()
+    .from(watchHistory)
+    .where(eq(watchHistory.id, watchHistoryId))
+    .get();
   if (!entry) {
     throw new Error(`Watch history entry ${watchHistoryId} not found`);
   }
 
-  // Find and delete any existing pending/active sessions for this same media
-  // (re-watch resets debrief state)
-  const existingWatchIds = db
+  const existingWatchIds = mediaDb
     .select({ id: watchHistory.id })
     .from(watchHistory)
     .where(
@@ -43,7 +50,8 @@ export function createDebriefSession(watchHistoryId: number): number {
     .map((r) => r.id);
 
   if (existingWatchIds.length > 0) {
-    db.delete(debriefSessions)
+    cerebrumDb
+      .delete(debriefSessions)
       .where(
         and(
           inArray(debriefSessions.watchHistoryId, existingWatchIds),
@@ -53,7 +61,7 @@ export function createDebriefSession(watchHistoryId: number): number {
       .run();
   }
 
-  const result = db
+  const result = cerebrumDb
     .insert(debriefSessions)
     .values({
       watchHistoryId,
@@ -66,52 +74,21 @@ export function createDebriefSession(watchHistoryId: number): number {
   return Number(result.lastInsertRowid);
 }
 
-/** Response shape for a debrief dimension entry. */
-export interface DebriefDimension {
-  dimensionId: number;
-  name: string;
-  status: 'pending' | 'complete';
-  comparisonId: number | null;
-  opponent: {
-    id: number;
-    title: string;
-    posterPath: string | null;
-    posterUrl: string | null;
-  } | null;
-}
-
-/** Response shape for the getDebrief endpoint. */
-export interface DebriefResponse {
-  sessionId: number;
-  status: 'pending' | 'active' | 'complete';
-  movie: {
-    mediaType: string;
-    mediaId: number;
-    title: string;
-    posterPath: string | null;
-    posterUrl: string | null;
-  };
-  dimensions: DebriefDimension[];
-}
-
-interface MovieMetaRow {
-  id: number;
-  title: string;
-  posterPath: string | null;
-  tmdbId: number;
-  posterOverridePath: string | null;
-}
-
 function loadDebriefSessionEntities(sessionId: number): {
   session: typeof debriefSessions.$inferSelect;
   watchEntry: typeof watchHistory.$inferSelect;
   movieRow: MovieMetaRow;
 } {
-  const db = getDrizzle();
-  const session = db.select().from(debriefSessions).where(eq(debriefSessions.id, sessionId)).get();
+  const cerebrumDb = getCerebrumDrizzle();
+  const mediaDb = getMediaDrizzle();
+  const session = cerebrumDb
+    .select()
+    .from(debriefSessions)
+    .where(eq(debriefSessions.id, sessionId))
+    .get();
   if (!session) throw new NotFoundError('Debrief session', String(sessionId));
 
-  const watchEntry = db
+  const watchEntry = mediaDb
     .select()
     .from(watchHistory)
     .where(eq(watchHistory.id, session.watchHistoryId))
@@ -120,7 +97,7 @@ function loadDebriefSessionEntities(sessionId: number): {
     throw new NotFoundError('Watch history entry', String(session.watchHistoryId));
   }
 
-  const movieRow = db
+  const movieRow = mediaDb
     .select({
       id: movies.id,
       title: movies.title,
@@ -140,15 +117,16 @@ function buildDebriefDimensions(
   sessionId: number,
   watchEntry: typeof watchHistory.$inferSelect
 ): DebriefDimension[] {
-  const db = getDrizzle();
-  const dims = db
+  const sharedDb = getDrizzle();
+  const cerebrumDb = getCerebrumDrizzle();
+  const dims = sharedDb
     .select()
     .from(comparisonDimensions)
     .where(eq(comparisonDimensions.active, 1))
     .orderBy(asc(comparisonDimensions.sortOrder))
     .all();
 
-  const results = db
+  const results = cerebrumDb
     .select()
     .from(debriefResults)
     .where(eq(debriefResults.sessionId, sessionId))
@@ -180,8 +158,9 @@ function activateIfPending(
   status: typeof debriefSessions.$inferSelect.status
 ): typeof debriefSessions.$inferSelect.status {
   if (status !== 'pending') return status;
-  const db = getDrizzle();
-  db.update(debriefSessions)
+  const cerebrumDb = getCerebrumDrizzle();
+  cerebrumDb
+    .update(debriefSessions)
     .set({ status: 'active' })
     .where(eq(debriefSessions.id, sessionId))
     .run();
@@ -220,24 +199,14 @@ export function getDebrief(sessionId: number): DebriefResponse {
 
 /**
  * Look up the most recent pending/active/complete debrief session for a
- * media item and return its full debrief response.
- *
- * PR #3119 (Option D step 1) denormalised `(media_type, media_id)` onto
- * `debrief_sessions`; this read now hits the row directly instead of
- * inner-joining `watch_history`. That removes the only cross-pillar join
- * blocking the MEDIA pillar exit — the cerebrum-side write surface that
- * populates the columns lives in the `cerebrum.debrief.logWatchCompletion`
- * router (Option D step 2). Existing rows were backfilled by the
- * `0071_debrief_media_denorm` migration; `createDebriefSession` sets both
- * columns on insert for new rows.
- *
- * Throws NotFoundError if no session exists for this media.
+ * media item via the denormalised `(media_type, media_id)` columns (PR
+ * #3119). Throws NotFoundError if no session exists for this media.
  */
 export function getDebriefByMedia(
   mediaType: 'movie' | 'episode',
   mediaId: number
 ): DebriefResponse {
-  const db = getDrizzle();
+  const db = getCerebrumDrizzle();
 
   const session = db
     .select({ id: debriefSessions.id })

--- a/apps/pops-api/src/modules/media/debrief/types.ts
+++ b/apps/pops-api/src/modules/media/debrief/types.ts
@@ -1,0 +1,38 @@
+/**
+ * Shared response shapes for the debrief surface. Extracted from
+ * `service.ts` to keep that file under the max-lines cap after the
+ * Theme-13 Wave-5 cerebrum cutover.
+ */
+export interface DebriefDimension {
+  dimensionId: number;
+  name: string;
+  status: 'pending' | 'complete';
+  comparisonId: number | null;
+  opponent: {
+    id: number;
+    title: string;
+    posterPath: string | null;
+    posterUrl: string | null;
+  } | null;
+}
+
+export interface DebriefResponse {
+  sessionId: number;
+  status: 'pending' | 'active' | 'complete';
+  movie: {
+    mediaType: string;
+    mediaId: number;
+    title: string;
+    posterPath: string | null;
+    posterUrl: string | null;
+  };
+  dimensions: DebriefDimension[];
+}
+
+export interface MovieMetaRow {
+  id: number;
+  title: string;
+  posterPath: string | null;
+  tmdbId: number;
+  posterOverridePath: string | null;
+}

--- a/apps/pops-api/src/modules/media/migrations.ts
+++ b/apps/pops-api/src/modules/media/migrations.ts
@@ -33,12 +33,8 @@ export const mediaMigrationTags: readonly string[] = [
   '0016_certain_namor',
   // comparison_staleness.
   '0017_loose_doomsday',
-  // debrief_results / debrief_sessions.
-  '0018_high_excalibur',
   // tier_overrides.
   '0019_little_diamondback',
-  // debrief_status.
-  '0020_melodic_major_mapleleaf',
   // comparisons elo deltas.
   '0022_elo_deltas',
   // comparisons source column.

--- a/apps/pops-api/src/modules/media/watch-history/handlers/query-helpers.ts
+++ b/apps/pops-api/src/modules/media/watch-history/handlers/query-helpers.ts
@@ -1,50 +1,28 @@
 /**
- * Watch-history read/write surface — PRD-168 PR2 + PR3 cutover.
+ * Watch-history read/write surface.
  *
- * Read/write split during the migration window:
- *  - `listWatchHistory` and `getWatchHistoryEntry` are routed through
- *    `getMediaDrizzle()` (the media pillar's `media.db.watch_history`).
- *    These are the simple reads called out by PRD-168 PR2.
- *  - Every write path — `logWatch` in `./log-watch-event.ts`,
- *    `deleteWatchHistoryEntry` below, `batchLogWatch`, the cascade
- *    deletes for `debrief_sessions` / `debrief_results` — still goes
- *    through `getDrizzle()` (the shared `pops.db`). PR3 audit confirmed
- *    every writer in the pops-api watch-history surface is a mixed-table
- *    transaction spanning `watch_history` plus at least one of
- *    `episodes`, `seasons`, `mediaWatchlist`, `debrief_sessions`, or
- *    `debrief_results`. None of those tables live in `@pops/media-db`
- *    yet, so flipping `watch_history` alone would split a single
- *    transaction across two SQLite files. PR3 therefore defers the
- *    writes cutover until the dependent slices ship their own
- *    `getMediaDrizzle()` / `getCerebrumDrizzle()` handles. See the
- *    per-handler headers in `./log-watch-event.ts` and
- *    `./batch-operations.ts` for the table-by-table breakdown.
- *
- * Cross-store consistency relies on `backfillMediaFromShared()` in
- * `apps/pops-api/src/db/media-backfill.ts`: a one-way, boot-time copy
- * from `pops.db` -> `media.db` that idempotently fills missing rows.
- * Between boots, newly-logged events live only in `pops.db` and won't
- * appear in list/get results until the next deploy reruns the backfill.
- * This is the same trade-off taken by the movies (PRD-165) and
- * tv-shows (PRD-166) cutovers; the full read-your-writes consistency
- * lands when the write paths also cut over.
- *
- * TOCTOU fix: `deleteWatchHistoryEntry` deletes from `pops.db`, so its
- * existence check must read from the same store. The function relies on
- * the in-transaction `result.changes === 0` signal (against `pops.db`)
- * rather than `getWatchHistoryEntry` (against `media.db`) to avoid a
- * race where the row exists on one side but not the other.
+ * `listWatchHistory` and `getWatchHistoryEntry` route through
+ * `getMediaDrizzle()`; `deleteWatchHistoryEntry` runs the media-side delete
+ * inside a media transaction and then fans out the dependent
+ * `debrief_sessions` / `debrief_results` cleanup against the cerebrum
+ * handle. The cross-pillar atomicity is bounded per-pillar (same trade-off
+ * as `logWatch` / `cerebrum.debrief.logWatchCompletion`): a transient
+ * failure leaves orphaned debrief rows for a deleted watch_history entry,
+ * which are tolerable because the read surface filters by the
+ * denormalised `(media_type, media_id)` tuple anyway. Idempotent on
+ * `watch_history_id`.
  */
 import { eq, inArray } from 'drizzle-orm';
 
-import { debriefResults, debriefSessions, watchHistory } from '@pops/db-types';
+import { debriefResults, debriefSessions } from '@pops/cerebrum-db';
 import {
   type WatchHistoryMediaType,
   watchHistoryService,
   WatchHistoryNotFoundError,
 } from '@pops/media-db';
+import { watchHistory } from '@pops/media-db';
 
-import { getDrizzle } from '../../../../db.js';
+import { getCerebrumDrizzle } from '../../../../db/cerebrum-handle.js';
 import { getMediaDrizzle } from '../../../../db/media-db-handle.js';
 import { NotFoundError } from '../../../../shared/errors.js';
 
@@ -95,28 +73,28 @@ export function getWatchHistoryEntry(id: number): WatchHistoryRow {
 }
 
 export function deleteWatchHistoryEntry(id: number): void {
-  getDrizzle().transaction((tx) => {
-    const existing = tx
-      .select({ id: watchHistory.id })
-      .from(watchHistory)
-      .where(eq(watchHistory.id, id))
-      .get();
-    if (!existing) throw new NotFoundError('WatchHistoryEntry', String(id));
+  const cerebrumDb = getCerebrumDrizzle();
+  const mediaDb = getMediaDrizzle();
 
-    const sessionIds = tx
-      .select({ id: debriefSessions.id })
-      .from(debriefSessions)
-      .where(eq(debriefSessions.watchHistoryId, id))
-      .all()
-      .map((r) => r.id);
+  const existing = mediaDb
+    .select({ id: watchHistory.id })
+    .from(watchHistory)
+    .where(eq(watchHistory.id, id))
+    .get();
+  if (!existing) throw new NotFoundError('WatchHistoryEntry', String(id));
 
-    if (sessionIds.length > 0) {
-      tx.delete(debriefResults).where(inArray(debriefResults.sessionId, sessionIds)).run();
-    }
+  const sessionIds = cerebrumDb
+    .select({ id: debriefSessions.id })
+    .from(debriefSessions)
+    .where(eq(debriefSessions.watchHistoryId, id))
+    .all()
+    .map((r) => r.id);
 
-    tx.delete(debriefSessions).where(eq(debriefSessions.watchHistoryId, id)).run();
+  if (sessionIds.length > 0) {
+    cerebrumDb.delete(debriefResults).where(inArray(debriefResults.sessionId, sessionIds)).run();
+  }
+  cerebrumDb.delete(debriefSessions).where(eq(debriefSessions.watchHistoryId, id)).run();
 
-    const result = tx.delete(watchHistory).where(eq(watchHistory.id, id)).run();
-    if (result.changes === 0) throw new NotFoundError('WatchHistoryEntry', String(id));
-  });
+  const result = mediaDb.delete(watchHistory).where(eq(watchHistory.id, id)).run();
+  if (result.changes === 0) throw new NotFoundError('WatchHistoryEntry', String(id));
 }

--- a/packages/cerebrum-db/migrations/0055_debrief_baseline.sql
+++ b/packages/cerebrum-db/migrations/0055_debrief_baseline.sql
@@ -1,0 +1,53 @@
+-- Cerebrum pillar baseline for the debrief slice (Theme-13 Wave 5 / MEDIA exit
+-- prep). Mirrors the shared `pops.db` shape from the drizzle-migrations
+-- ancestry: `0018_high_excalibur` (debrief_results + debrief_sessions) +
+-- `0020_melodic_major_mapleleaf` (debrief_status) + `0071_debrief_media_denorm`
+-- (media_type + media_id columns + the supporting index on debrief_sessions).
+--
+-- Cross-pillar reference: `watch_history_id` is a soft pointer into
+-- `media.db.watch_history` once that table physically lives there. We do NOT
+-- enforce the FK at the SQLite level — the cerebrum baseline drops it
+-- intentionally so the two databases can be opened independently without
+-- triggering FK violations. `comparison_dimensions` / `comparisons` live in
+-- `media.db` too; same reasoning applies to those references. The original
+-- shared-journal migrations expressed FKs because everything was on a single
+-- `pops.db`; the moment cerebrum becomes its own SQLite file, those FKs
+-- cannot cross databases.
+--
+-- `media_type` + `media_id` carry the denormalised media tuple from PR #3119
+-- so the cross-pillar `getDebriefByMedia` read no longer has to inner-join
+-- `watch_history`. They remain NULLable for the migration window — the
+-- writer (`createDebriefSession`) sets them on insert, and the existing
+-- shared rows are backfilled into cerebrum.db via the ATTACH bridge in
+-- `apps/pops-api/src/db/backfill-cerebrum-from-shared.ts`.
+
+CREATE TABLE `debrief_sessions` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`watch_history_id` integer NOT NULL,
+	`media_type` text,
+	`media_id` integer,
+	`status` text DEFAULT 'pending' NOT NULL,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `idx_debrief_sessions_media` ON `debrief_sessions` (`media_type`,`media_id`);--> statement-breakpoint
+CREATE TABLE `debrief_results` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`session_id` integer NOT NULL,
+	`dimension_id` integer NOT NULL,
+	`comparison_id` integer,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `debrief_status` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`media_type` text NOT NULL,
+	`media_id` integer NOT NULL,
+	`dimension_id` integer NOT NULL,
+	`debriefed` integer DEFAULT 0 NOT NULL,
+	`dismissed` integer DEFAULT 0 NOT NULL,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL,
+	`updated_at` text DEFAULT (datetime('now')) NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `debrief_status_media_dimension_idx` ON `debrief_status` (`media_type`,`media_id`,`dimension_id`);

--- a/packages/cerebrum-db/migrations/meta/_journal.json
+++ b/packages/cerebrum-db/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1782172800000,
       "tag": "0054_embeddings_baseline",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1782259200000,
+      "tag": "0055_debrief_baseline",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cerebrum-db/src/__tests__/open-cerebrum-db.test.ts
+++ b/packages/cerebrum-db/src/__tests__/open-cerebrum-db.test.ts
@@ -13,7 +13,14 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { openCerebrumDb } from '../open-cerebrum-db.js';
-import { embeddings, engramIndex, nudgeLog } from '../schema.js';
+import {
+  debriefResults,
+  debriefSessions,
+  debriefStatus,
+  embeddings,
+  engramIndex,
+  nudgeLog,
+} from '../schema.js';
 import { upsertEngramIndex } from '../services/engrams.js';
 import { persistCandidates } from '../services/nudge-log.js';
 
@@ -145,6 +152,51 @@ describe('openCerebrumDb', () => {
           })
           .run()
       ).toThrow(/UNIQUE/i);
+    } finally {
+      raw.close();
+    }
+  });
+
+  it('applies the debrief baseline with sessions/results/status tables and indexes', () => {
+    const path = join(tmpDir, 'cerebrum.db');
+    const { db, raw } = openCerebrumDb(path, { loadVec: false });
+    try {
+      expect(db.select().from(debriefSessions).all()).toHaveLength(0);
+      expect(db.select().from(debriefResults).all()).toHaveLength(0);
+      expect(db.select().from(debriefStatus).all()).toHaveLength(0);
+
+      const session = db
+        .insert(debriefSessions)
+        .values({
+          watchHistoryId: 42,
+          mediaType: 'movie',
+          mediaId: 7,
+          status: 'pending',
+        })
+        .returning({ id: debriefSessions.id })
+        .all();
+      expect(session).toHaveLength(1);
+
+      db.insert(debriefResults)
+        .values({ sessionId: session[0].id, dimensionId: 1, comparisonId: null })
+        .run();
+
+      db.insert(debriefStatus).values({ mediaType: 'movie', mediaId: 7, dimensionId: 1 }).run();
+      expect(() =>
+        db.insert(debriefStatus).values({ mediaType: 'movie', mediaId: 7, dimensionId: 1 }).run()
+      ).toThrow(/UNIQUE/i);
+
+      const sessionIndexes = raw
+        .prepare(
+          `SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='debrief_sessions'`
+        )
+        .all() as { name: string }[];
+      expect(sessionIndexes.map((r) => r.name)).toContain('idx_debrief_sessions_media');
+
+      const statusIndexes = raw
+        .prepare(`SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='debrief_status'`)
+        .all() as { name: string }[];
+      expect(statusIndexes.map((r) => r.name)).toContain('debrief_status_media_dimension_idx');
     } finally {
       raw.close();
     }

--- a/packages/cerebrum-db/src/schema.ts
+++ b/packages/cerebrum-db/src/schema.ts
@@ -26,11 +26,20 @@
  *     when the extension is available; it has no drizzle table object
  *     because virtual tables cannot be represented in the schema
  *     builder.
+ *   - `debriefSessions` / `debriefResults` / `debriefStatus` — Theme-13
+ *     Wave 5 debrief slice (post-watch reflection, see
+ *     `0055_debrief_baseline.sql`). The cross-pillar `watch_history_id`
+ *     reference is a soft pointer into `media.db.watch_history`;
+ *     `media_type` + `media_id` carry the denormalised media tuple per
+ *     PR #3119 so the `getDebriefByMedia` read no longer joins media.
  */
 export { engramIndex, engramLinks, engramScopes, engramTags, nudgeLog } from '@pops/db-types';
 export {
   conversationContext,
   conversations,
+  debriefResults,
+  debriefSessions,
+  debriefStatus,
   embeddings,
   gliaActions,
   gliaTrustState,


### PR DESCRIPTION
## Summary

- Lands the three debrief tables (`debrief_sessions`, `debrief_results`, `debrief_status`) under `@pops/cerebrum-db` with a fresh baseline migration that mirrors the shared journal's shape, including the `(media_type, media_id)` denormalisation from #3119. Cross-pillar FK constraints intentionally dropped — they cannot cross SQLite files.
- Adds an idempotent ATTACH backfill bridge from the legacy `pops.db` so existing debrief rows carry over on first cerebrum-db boot. Keyed on `id` for the session/results pair (preserving `session_id` linkage) and on `(media_type, media_id, dimension_id)` for status.
- Flips every debrief writer in pops-api off `getDrizzle()` and onto `getCerebrumDrizzle()` using the side-by-side handles pattern from #3147. `watch_history` / `movies` reads hop to `getMediaDrizzle()`; `comparison_dimensions` stays on the shared handle until that slice cuts over.

Closes the MEDIA full-exit blocker called out in #3191's Wave-5 audit ("Media mixed-tx writer cutover (3 sites) — blocked behind cerebrum `debrief*` tables shipping to `@pops/cerebrum-db`"). The mixed-tx writer count in practice is **5 sites** (`createDebriefSession` + `queueDebriefStatus` inside the cerebrum SDK fan-out, plus `recordDebriefComparison`, `dismissDebriefDimension`, `deleteWatchHistoryEntry`), with `getPendingDebriefs` and `getDebriefByMedia` as the corresponding cross-pillar readers — all flipped in this PR.

## Schema + migrations

- `packages/cerebrum-db/migrations/0055_debrief_baseline.sql` — `debrief_sessions` + `debrief_results` + `debrief_status` with the `(media_type, media_id)` columns + `idx_debrief_sessions_media` from #3119 baked in. FK references removed (cross-DB).
- `packages/cerebrum-db/migrations/meta/_journal.json` — appended idx 7.
- `packages/cerebrum-db/src/schema.ts` — re-exports the three drizzle tables from `@pops/db-types/schema`.

## ATTACH backfill

- `apps/pops-api/src/db/backfill-cerebrum-from-shared.ts` — extends `TABLE_COPIES` with `debrief_sessions` / `debrief_results` (`id` key) and `debrief_status` (composite natural key). Existing ATTACH / non-fatal / idempotent semantics preserved.

## Migration ownership

- `MIGRATION_OWNERS` — flips `0018_high_excalibur` and `0020_melodic_major_mapleleaf` from `media` → `cerebrum` (the corresponding shared journal entries retire when the table copies drop from pops.db).
- `modules/media/migrations.ts` — drops the two tags.
- `modules/cerebrum/migrations.ts` — adopts them.

## Writer flips (mixed-tx cutover)

| Site | Handle |
|------|--------|
| `media/debrief/service.ts` — createDebriefSession / loadDebriefSessionEntities / buildDebriefDimensions / activateIfPending / getDebriefByMedia | `getCerebrumDrizzle()` for debrief\*, `getMediaDrizzle()` for watch_history + movies, `getDrizzle()` for comparison_dimensions |
| `media/debrief/queue-status.ts` — queueDebriefStatus | `getCerebrumDrizzle()` for debrief_status, `getDrizzle()` for comparison_dimensions |
| `media/comparisons/lib/debrief-record.ts` — recordDebriefComparison | `getCerebrumDrizzle()` for debrief\*, `getMediaDrizzle()` for watch_history, `getDrizzle()` for comparison_dimensions |
| `media/comparisons/lib/debrief-dismiss.ts` — dismissDebriefDimension | same shape |
| `media/comparisons/lib/debrief-pending.ts` — getPendingDebriefs | `getCerebrumDrizzle()` for debrief\*, `getMediaDrizzle()` for watch_history + movies |
| `media/watch-history/handlers/query-helpers.ts` — deleteWatchHistoryEntry | split into media-handle delete + cerebrum-handle cascade |

Named imports from `@pops/cerebrum-db` throughout (#3196 gotcha respected).

`modules/media/debrief/types.ts` is new — `DebriefDimension`, `DebriefResponse`, and `MovieMetaRow` extracted from `service.ts` to keep that file under the max-lines lint cap after the cutover.

## Tests

- `apps/pops-api/src/db/per-pillar-migrations.test.ts` — expected `applied` list extended with `0055_debrief_baseline`.
- `packages/cerebrum-db/src/__tests__/open-cerebrum-db.test.ts` — new case asserts the baseline lands the three tables, accepts inserts, exposes `idx_debrief_sessions_media` + `debrief_status_media_dimension_idx`, and enforces the `(media_type, media_id, dimension_id)` unique constraint.
- `apps/pops-api/src/db/backfill-cerebrum-from-shared.test.ts` — seed helpers for `debrief_sessions` / `debrief_status` + 3 dedicated cases (first-run copy preserves session_id linkage, idempotency, mixed-state dedup).
- Existing `debrief`, `comparisons`, `watch-history`, and `cerebrum.debrief.logWatchCompletion` suites pass unchanged (482 tests across `src/db`, `media/watch-history`, `media/comparisons`, `media/debrief`, `cerebrum/debrief`).

## Honest scoping

- The cerebrum-db baseline drops the `debrief_sessions.watch_history_id → watch_history(id)` and `debrief_results.dimension_id → comparison_dimensions(id)` FKs. They cannot cross SQLite files; `(media_type, media_id)` covers the cross-pillar read path per #3119 / the watch-history mixed-tx design doc, and the writer fan-out is idempotent on `(watchHistoryId, mediaType, mediaId)`.
- `recordDebriefComparison` keeps its `rawDb.transaction(...)` wrapper. The wrapper now bounds only the comparisons-side writes; the debrief writes commit independently against the cerebrum handle. The audit doc accepts this — both child writers are individually idempotent.
- KEEPING TABLES IN BOTH DBs per the cerebrum/finance/media playbook; the shared `pops.db` copies retire after prod verification.

## References

- #3191 — Wave 5 7-pillar audit (this PR closes the media mixed-tx debrief cascade).
- #3119 — debrief_sessions `(media_type, media_id)` denormalisation.
- #3144 — cerebrum embeddings slice baseline (recent cerebrum-db shape).
- #3147 — side-by-side clients pattern for mixed-pillar writers.
- #3196 — named-import gotcha when consuming `@pops/cerebrum-db`.
- `docs/themes/13-pillar-finale/notes/media-watch-history-mixed-tx-design.md`

## Test plan

- [x] `pnpm --filter @pops/cerebrum-db test`
- [x] `pnpm --filter @pops/api test src/db src/modules/media/watch-history src/modules/media/comparisons src/modules/media/debrief src/modules/cerebrum/debrief`
- [x] `pnpm --filter @pops/api typecheck`
- [x] `pnpm -r typecheck`