### PR TITLE
fix(finance/imports): ai-categorizer test mocks (mirror PR #3194 stale-mock fix)

### DIFF
--- a/apps/pops-api/src/modules/finance/imports/lib/ai-categorizer.test.ts
+++ b/apps/pops-api/src/modules/finance/imports/lib/ai-categorizer.test.ts
@@ -26,18 +26,24 @@ vi.mock('@anthropic-ai/sdk', () => {
 // Mock the database
 const mockDbRun = vi.fn();
 vi.mock('../../../../db.js', () => {
-  return {
-    getDrizzle: vi.fn(() => ({
-      insert: vi.fn(() => ({
-        values: vi.fn(() => ({
-          run: mockDbRun,
-        })),
+  const stubDrizzle = {
+    insert: vi.fn(() => ({
+      values: vi.fn(() => ({
+        run: mockDbRun,
       })),
     })),
+  };
+  return {
+    getDrizzle: vi.fn(() => stubDrizzle),
+    getCoreDrizzle: vi.fn(() => stubDrizzle),
     // Always return false: tests exercise the real API path, not the named-env skip
     isNamedEnvContext: vi.fn().mockReturnValue(false),
   };
 });
+
+vi.mock('../../../../lib/inference-middleware.js', () => ({
+  trackInference: <T>(_params: unknown, fn: () => Promise<T>) => fn(),
+}));
 
 // Mock node:fs so disk I/O doesn't interfere with unit tests
 vi.mock('node:fs', () => ({


### PR DESCRIPTION
## Summary

The 22 pre-existing failures in `apps/pops-api/src/modules/finance/imports/lib/ai-categorizer.test.ts` — flagged as unrelated by both PR #3162 and PR #3192 — are a **test bug**, not a production bug. This mirrors the diagnosis and fix from PR #3194 (`rule-generator.test.ts`).

## Root cause

The same shape #3194 already documented: the test mocks predate two pieces of inference-middleware infrastructure that were added after the suite was written:

1. **#2629** — `trackInference` now runs `enforceBudgets` *before* the live provider call, which calls `getCoreDrizzle()`.
2. **PRD-186 PR3** (#3025) — inference audit log writes now go through `getCoreDrizzle()` instead of `getDrizzle()`.

On top of that, `categorizeWithAi` calls `getSettingValue('finance.aiCategorizer.model', ...)` and `getSettingValue('finance.aiCategorizer.maxTokens', ...)` which both reach into `getCoreDrizzle()` via `modules/core/settings/service.ts`.

The test's `vi.mock('../../../../db.js', ...)` only stubbed `getDrizzle`, leaving `getCoreDrizzle` undefined. Calling an undefined export throws synchronously, the exception bubbles out as `AiCategorizationError: Failed to categorize: ... No "getCoreDrizzle" export is defined on the "../../../../db.js" mock`, and every test that exercised the API path (cache miss → API call) failed.

Of 36 tests in the suite, **22 failed and 14 passed** on `origin/main`. The 14 passing tests were paths that short-circuit before touching the broken mock (`normalizeCacheKey` pure-function tests, `NO_API_KEY` early throws, cache-hit paths populated via a prior call inside the same `it`).

## Fix

`apps/pops-api/src/modules/finance/imports/lib/ai-categorizer.test.ts` — mock-only:

- Extend the `db.js` mock to expose `getCoreDrizzle` alongside `getDrizzle` (both return the same stub drizzle handle that already had `insert -> values -> run` wired).
- Mock `lib/inference-middleware.js` so `trackInference` is a pass-through that just invokes its second argument. Budget enforcement + audit-log inserts are covered by the dedicated suites at `lib/inference-middleware.test.ts` and `modules/core/ai-budgets/*` — re-exercising them from the ai-categorizer unit tests is noise.

No SUT changes. No `as any` / `as unknown as`. No suppressions.

## Verification

- `pnpm --filter @pops/api test src/modules/finance/imports/lib/ai-categorizer.test.ts` — **36/36 pass** (was 14/36 on `origin/main`).
- `pnpm --filter @pops/api exec tsc --noEmit` — clean.
- Husky `oxlint --fix` + `oxfmt --write` ran clean on the pre-commit hook.

## Test plan

- [x] Failing suite now passes locally
- [x] No type regressions
- [x] No production-code changes (mock-only)