### PR TITLE
fix(finance/imports): ai-categorizer-disk integration test (wire core-db handle alongside shared db)

### DIFF
--- a/apps/pops-api/src/modules/finance/imports/lib/ai-categorizer-disk.integration.test.ts
+++ b/apps/pops-api/src/modules/finance/imports/lib/ai-categorizer-disk.integration.test.ts
@@ -21,13 +21,21 @@ vi.mock('@anthropic-ai/sdk', () => ({
 
 // Mock the database
 const mockDbRun = vi.fn();
-vi.mock('../../../../db.js', () => ({
-  getDrizzle: vi.fn(() => ({
+vi.mock('../../../../db.js', () => {
+  const stubDrizzle = {
     insert: vi.fn(() => ({
       values: vi.fn(() => ({ run: mockDbRun })),
     })),
-  })),
-  isNamedEnvContext: vi.fn().mockReturnValue(false),
+  };
+  return {
+    getDrizzle: vi.fn(() => stubDrizzle),
+    getCoreDrizzle: vi.fn(() => stubDrizzle),
+    isNamedEnvContext: vi.fn().mockReturnValue(false),
+  };
+});
+
+vi.mock('../../../../lib/inference-middleware.js', () => ({
+  trackInference: <T>(_params: unknown, fn: () => Promise<T>) => fn(),
 }));
 
 let tmpDir: string;


### PR DESCRIPTION
## Summary

The 3 pre-existing failures in `apps/pops-api/src/modules/finance/imports/lib/ai-categorizer-disk.integration.test.ts` on `main` are a **test bug**, not a production bug. The fix is mock-only — same diagnostic shape as #3194 (`rule-generator`) and the parallel `ai-categorizer.test.ts` fix being dispatched alongside this one.

Despite the file name, "disk" here refers to the AI entity-name cache being persisted to disk (`ai_entity_cache.json`) — the database itself is still stubbed via `vi.mock('../../../../db.js', ...)`, same as the unit tests. There is no `setupTestContext()` / real SQLite handle involved, so the shape of the fix is identical to #3194.

## Root cause

The test mocks predate two pieces of inference-middleware infrastructure that were added after the suite was written:

1. **#2629** — `trackInference` now runs `enforceBudgets` *before* the live provider call, which calls `getCoreDrizzle()`.
2. **PRD-186 PR3** (#3025) — inference audit log writes now go through `getCoreDrizzle()` instead of `getDrizzle()`.

The test's `vi.mock('../../../../db.js', ...)` only stubbed `getDrizzle` and `isNamedEnvContext`, leaving `getCoreDrizzle` undefined. The first `getCoreDrizzle()` call inside `listApplicableBudgets` (via `enforceBudgets` → `trackInference`) threw the standard vitest `No "getCoreDrizzle" export is defined on the "../../../../db.js" mock` error, which then bubbled up through `callApi` → `callApiOrThrow` and surfaced as `AiCategorizationError: Failed to categorize: ...`.

Failing tests (3 of 4):

| # | Test | Failure |
|---|---|---|
| 1 | `writes cache to disk after a successful API call` | `AiCategorizationError` thrown by `callApiOrThrow` |
| 2 | `handles corrupted cache file gracefully` | same |
| 3 | `handles missing cache file gracefully` | same |

The fourth test (`loads cache from disk on first access after clearCache`) was passing because it short-circuits as a cache hit and never reaches the live AI path.

## Fix

`apps/pops-api/src/modules/finance/imports/lib/ai-categorizer-disk.integration.test.ts`:

- Extend the `db.js` mock to expose `getCoreDrizzle` alongside `getDrizzle` (both return the same in-process stub). Keeps `isNamedEnvContext` untouched.
- Mock `lib/inference-middleware.js` so `trackInference` is a pass-through that just invokes its second argument. This bypasses budget enforcement and audit-log inserts entirely — the existing dedicated test suites at `lib/inference-middleware.test.ts` and `modules/core/ai-budgets/*` cover that behaviour, so re-exercising it from a disk-cache integration test is noise.

No SUT changes. No `as any` / `as unknown as`. No suppressions.

## Verification

- `pnpm --filter @pops/api test:integration src/modules/finance/imports/lib/ai-categorizer-disk.integration.test.ts` — 4/4 pass (was 1/4).
- `pnpm --filter @pops/api test:integration` — 81/81 pass across all 6 integration files.
- `pnpm --filter @pops/api exec tsc --noEmit` — clean.
- Husky pre-commit ran clean (`oxlint --fix`, `oxfmt --write`).

## Test plan

- [x] Failing suite now passes locally
- [x] Wider integration suite still green
- [x] No type regressions
- [x] No production-code changes (mock-only)
