### PR TITLE
docs(theme-13): scaffold PRD-239 physical manifest relocation (PRD-238 US-02 unblock)

### DIFF
--- a/docs/themes/13-pillar-finale/epics/10-fe-sdk-dispatcher-generator.md
+++ b/docs/themes/13-pillar-finale/epics/10-fe-sdk-dispatcher-generator.md
@@ -12,14 +12,15 @@ Make the front-end registry-aware end-to-end. Three pieces:
 
 ## PRDs
 
-| #   | PRD                                  | Summary                                                                                                                 | Status      |
-| --- | ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------- | ----------- |
-| 215 | React SDK                            | `usePillar`, `useUriResolver`, `usePillarQuery`, `usePillarMutation` hooks                                              | Partial     |
-| 216 | `PillarGuard` rewrite                | Reads live registry; subscribes to changes; per-route unavailable placeholders                                          | Partial     |
-| 217 | nginx config generator               | Generated `default.conf` from registry snapshot; init container OR sidecar strategy                                     | Not started |
-| 218 | `@pops/module-registry` deprecation  | The build-time registry becomes a thin wrapper around the runtime one (offline-dev fallback)                            | Not started |
-| 227 | SDK consumer migration audit         | Punch list of every `trpc.*` consumer with its `pillar()` migration target + preconditions                              | Not started |
-| 238 | Settings-imports off module-registry | Migrate the 8 `apps/pops-api` sites still importing per-pillar `SettingsManifest` from `@pops/module-registry/settings` | Not started |
+| #   | PRD                                   | Summary                                                                                                                                                       | Status                                                                                    |
+| --- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| 215 | React SDK                             | `usePillar`, `useUriResolver`, `usePillarQuery`, `usePillarMutation` hooks                                                                                    | Partial                                                                                   |
+| 216 | `PillarGuard` rewrite                 | Reads live registry; subscribes to changes; per-route unavailable placeholders                                                                                | Partial                                                                                   |
+| 217 | nginx config generator                | Generated `default.conf` from registry snapshot; init container OR sidecar strategy                                                                           | Not started                                                                               |
+| 218 | `@pops/module-registry` deprecation   | The build-time registry becomes a thin wrapper around the runtime one (offline-dev fallback)                                                                  | Not started                                                                               |
+| 227 | SDK consumer migration audit          | Punch list of every `trpc.*` consumer with its `pillar()` migration target + preconditions                                                                    | Not started                                                                               |
+| 238 | Settings-imports off module-registry  | Migrate the 8 `apps/pops-api` sites still importing per-pillar `SettingsManifest` from `@pops/module-registry/settings`                                       | Partial — US-01 done (consumers on `@pops/pillar-sdk/settings`); US-02 blocked on PRD-239 |
+| 239 | Settings-manifest physical relocation | Move the 10 manifests out of `@pops/module-registry/src/settings` into per-pillar contract packages; repoint `@pops/pillar-sdk/settings`; close PRD-238 US-02 | Not started                                                                               |
 
 ## Dependencies
 

--- a/docs/themes/13-pillar-finale/prds/239-settings-manifest-physical-relocation/README.md
+++ b/docs/themes/13-pillar-finale/prds/239-settings-manifest-physical-relocation/README.md
@@ -1,0 +1,121 @@
+# PRD-239: Settings-manifest physical relocation to per-pillar packages
+
+> Epic: [FE pillar SDK + dispatcher generator](../../epics/10-fe-sdk-dispatcher-generator.md)
+>
+> Status: **Not started**
+
+## Overview
+
+The ten per-pillar `SettingsManifest` exports (`aiConfigManifest`, `coreOperationalManifest`, `inventoryManifest`, `financeManifest`, `cerebrumManifest`, `egoManifest`, `arrManifest`, `plexManifest`, `rotationManifest`, `mediaOperationalManifest`) still physically live under `packages/module-registry/src/settings/`. This PRD moves each manifest's source into its owning pillar's contract package, re-points `@pops/pillar-sdk/settings` at the per-pillar barrels, and deletes the `@pops/module-registry/settings` subpath. The deliverable is a pure relocation — no shape change, no rename, no contents change.
+
+## Background
+
+The two adjacent PRs landed the indirection layer:
+
+- **PR [#3175](https://github.com/knoxio/pops/pull/3175)** scaffolded `packages/pillar-sdk/src/settings/index.ts`, which re-exports the ten manifests from `@pops/module-registry/settings`. The `./settings` subpath was added to `pillar-sdk`'s `exports` map and a workspace dep on `@pops/module-registry` was added to `pillar-sdk`.
+- **PR [#3176](https://github.com/knoxio/pops/pull/3176)** migrated the eight `apps/pops-api` consumers off `@pops/module-registry/settings` and onto `@pops/pillar-sdk/settings` (PRD-238 US-01, Option B).
+
+[PRD-238 US-02](../238-settings-known-modules-surface/us-02-delete-legacy-settings-subpath.md) — drop the `@pops/module-registry/settings` subpath — was deferred because `pillar-sdk/settings` still re-exports from there. Deleting the subpath today self-breaks the SDK barrel.
+
+The unblock is physical relocation: each manifest's source file moves out of `module-registry` into its owning pillar's contract package; `pillar-sdk/settings` then re-exports from the per-pillar packages; the legacy subpath has zero remaining consumers and can be deleted. That is the work this PRD specifies.
+
+## Target homes
+
+The ten manifests partition into five pillars. Each manifest moves to its owning pillar's contract package:
+
+| Manifest                   | Today's source                                                        | Target package                                                                                                           |
+| -------------------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `aiConfigManifest`         | `packages/module-registry/src/settings/core/ai-manifest.ts`           | `@pops/core-contract` (sub-barrel `./settings`)                                                                          |
+| `coreOperationalManifest`  | `packages/module-registry/src/settings/core/operational-manifest.ts`  | `@pops/core-contract` (sub-barrel `./settings`)                                                                          |
+| `inventoryManifest`        | `packages/module-registry/src/settings/inventory/index.ts`            | `@pops/inventory-contract` (sub-barrel `./settings`)                                                                     |
+| `financeManifest`          | `packages/module-registry/src/settings/finance/index.ts`              | `@pops/finance-contract` (sub-barrel `./settings`)                                                                       |
+| `cerebrumManifest`         | `packages/module-registry/src/settings/cerebrum/**`                   | `@pops/cerebrum-contract` (sub-barrel `./settings`) — includes the group sub-files                                       |
+| `egoManifest`              | `packages/module-registry/src/settings/ego/index.ts`                  | `@pops/cerebrum-contract` (sub-manifest under the cerebrum settings barrel; per ADR-026 ego is a sub-domain of cerebrum) |
+| `arrManifest`              | `packages/module-registry/src/settings/media/manifests.ts`            | `@pops/media-contract` (sub-barrel `./settings`)                                                                         |
+| `plexManifest`             | `packages/module-registry/src/settings/media/manifests.ts`            | `@pops/media-contract` (sub-barrel `./settings`)                                                                         |
+| `rotationManifest`         | `packages/module-registry/src/settings/media/manifests.ts`            | `@pops/media-contract` (sub-barrel `./settings`)                                                                         |
+| `mediaOperationalManifest` | `packages/module-registry/src/settings/media/operational-manifest.ts` | `@pops/media-contract` (sub-barrel `./settings`)                                                                         |
+
+Each target package gains a `./settings` subpath in its `exports` map. `aiConfigManifest` parks on `@pops/core-contract` for the same ADR-026 reasoning that places `egoManifest` under cerebrum — `ai` is a sub-domain of `core` today; a future split into a dedicated `@pops/ai-contract` is a non-goal here.
+
+## API Surface
+
+After relocation, the import graph is:
+
+```
+@pops/core-contract/settings        →  aiConfigManifest, coreOperationalManifest
+@pops/inventory-contract/settings   →  inventoryManifest
+@pops/finance-contract/settings     →  financeManifest
+@pops/cerebrum-contract/settings    →  cerebrumManifest, egoManifest
+@pops/media-contract/settings       →  arrManifest, plexManifest, rotationManifest, mediaOperationalManifest
+
+@pops/pillar-sdk/settings           →  re-exports all 10 from the per-pillar barrels above
+```
+
+Consumers continue to import from `@pops/pillar-sdk/settings` — the eight call sites flipped by PR #3176 do not move again. The relocation is invisible to them.
+
+## Business Rules
+
+- **Pure physical move.** File contents, `SettingsManifest` shape, export names, and `id` / `title` / `icon` / `order` fields are unchanged. Diff per move is one source file relocated + import paths within that file repointed at the new package's neighbours.
+- **No new public surface.** Each pillar contract package adds exactly one new subpath: `./settings`. Nothing else moves.
+- **`pillar-sdk/settings` re-export shape stays identical.** Same named exports, same order. Only the internal import specifiers change (from `@pops/module-registry/settings` to the five per-pillar `./settings` subpaths).
+- **`@pops/module-registry/settings` deletes once all five pillar moves have shipped.** The final US owns the delete and closes [PRD-238 US-02](../238-settings-known-modules-surface/us-02-delete-legacy-settings-subpath.md) in the same PR.
+- **`pillar-sdk` drops its workspace dep on `@pops/module-registry`** as part of the final US, once the SDK no longer re-exports from there.
+- **Tests are smoke-only.** Each pillar US adds (or extends) a one-line import-and-assert test inside the receiving package proving the manifest still loads with the same `id`. Manifest contents are not under test in this PRD.
+
+## Edge Cases
+
+| Case                                                                                                                                         | Behaviour                                                                                                                                                                                                                                                              |
+| -------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Cerebrum manifest is split across four files (`subsystem-manifest.ts`, `query-emit-manifest.ts`, `retrieval-ingest-manifest.ts`, `index.ts`) | Move the whole `cerebrum/` directory as a unit into `packages/cerebrum-contract/src/settings/`. The internal relative imports stay valid because the directory moves together.                                                                                         |
+| `ai-manifest.test.ts` lives next to `core/ai-manifest.ts`                                                                                    | The test moves with the source into `@pops/core-contract` (placed under that package's existing test layout — alongside the manifest file or under `__tests__`, whichever matches the package's convention).                                                           |
+| A pillar contract package doesn't have a `./settings` subpath in `exports` yet                                                               | The pillar US adds it (TS source + `package.json` exports entry + matching `dist` paths). Mirrors the existing pattern (`./types`, `./schemas`).                                                                                                                       |
+| `pillar-sdk/settings/index.ts` would form a circular dep through any per-pillar package                                                      | Should not happen — pillar contract packages do not depend on `pillar-sdk`. If a circle does appear during implementation, surface it on the US and pause the merge; the relocation choice for that pillar is wrong.                                                   |
+| Build-time consumer (`scripts/known-modules.ts` inside `module-registry`) reads a manifest                                                   | That script is internal to `module-registry` and falls under [PRD-218](../218-module-registry-deprecation/README.md) US-03's package-deletion finishing move. Out of scope for this PRD — `module-registry`'s internal consumers go away with the package, not before. |
+| Docstring references to `@pops/module-registry/settings` in `apps/pops-api`                                                                  | Already handled by [PRD-238 US-01](../238-settings-known-modules-surface/us-01-pick-target-and-migrate.md). No new docstring sweep needed here.                                                                                                                        |
+
+## User Stories
+
+| #   | Story                                                                     | Summary                                                                                                                                                               | Parallelisable           |
+| --- | ------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| 01  | [us-01-relocate-core-manifests](us-01-relocate-core-manifests.md)         | Move `aiConfigManifest` + `coreOperationalManifest` into `@pops/core-contract/settings`. Repoint `pillar-sdk/settings` for those two named exports.                   | Yes                      |
+| 02  | [us-02-relocate-inventory-manifest](us-02-relocate-inventory-manifest.md) | Move `inventoryManifest` into `@pops/inventory-contract/settings`. Repoint `pillar-sdk/settings` for that one named export.                                           | Yes                      |
+| 03  | [us-03-relocate-finance-manifest](us-03-relocate-finance-manifest.md)     | Move `financeManifest` into `@pops/finance-contract/settings`. Repoint `pillar-sdk/settings` for that one named export.                                               | Yes                      |
+| 04  | [us-04-relocate-cerebrum-manifests](us-04-relocate-cerebrum-manifests.md) | Move `cerebrumManifest` (and its four sub-files) + `egoManifest` into `@pops/cerebrum-contract/settings`. Repoint `pillar-sdk/settings`.                              | Yes                      |
+| 05  | [us-05-relocate-media-manifests](us-05-relocate-media-manifests.md)       | Move `arrManifest`, `plexManifest`, `rotationManifest`, `mediaOperationalManifest` into `@pops/media-contract/settings`. Repoint `pillar-sdk/settings`.               | Yes                      |
+| 06  | [us-06-drop-legacy-subpath](us-06-drop-legacy-subpath.md)                 | Delete `packages/module-registry/src/settings/` + `./settings` exports entry. Drop `pillar-sdk`'s `@pops/module-registry` workspace dep. Close PRD-238 US-02 as Done. | Blocked by us-01 … us-05 |
+
+US-01 … US-05 are mutually independent — each touches one source directory in `module-registry`, one target contract package, and the same `pillar-sdk/settings/index.ts` for its own re-exports (the SDK barrel is mechanically conflict-resolvable as a single line per manifest). US-06 cannot start until all five have merged.
+
+## Acceptance Criteria
+
+Tracked per-US — summary here for orientation:
+
+- All ten manifests' source files live in their owning pillar contract package's `src/settings/` directory.
+- Each receiving contract package exposes a `./settings` subpath in its `exports` map, with corresponding `dist` paths.
+- `@pops/pillar-sdk/settings/index.ts` re-exports all ten manifests from the per-pillar packages — zero references to `@pops/module-registry`.
+- `packages/pillar-sdk/package.json` no longer lists `@pops/module-registry` as a workspace dependency.
+- `packages/module-registry/src/settings/` is deleted; the `./settings` entry is removed from `packages/module-registry/package.json`'s `exports`.
+- `grep -rn "@pops/module-registry/settings" packages apps` returns zero matches under `src/`.
+- [PRD-238 US-02](../238-settings-known-modules-surface/us-02-delete-legacy-settings-subpath.md) is marked Done by the final US's PR.
+- `pnpm --filter @pops/pillar-sdk typecheck/test/build`, `pnpm --filter @pops/core-contract …`, `…/inventory-contract`, `…/finance-contract`, `…/cerebrum-contract`, `…/media-contract`, `…/module-registry`, and `pnpm --filter @pops/api typecheck/test` all pass clean.
+- Husky pre-commit + pre-push pass without `--no-verify`.
+
+## Out of Scope
+
+- **Changing any manifest's contents** — `id`, `title`, `icon`, `order`, `groups`, or any field inside them. Pure relocation.
+- **Renaming the manifest exports** — `aiConfigManifest` stays `aiConfigManifest`. No `aiManifest`, no `coreAiManifest`.
+- **Changing the `SettingsManifest` contract shape** in `@pops/types`.
+- **Splitting `ai` out of `core` into its own `@pops/ai-contract` package.** Mentioned as a future possibility; not part of this PRD.
+- **Retiring `@pops/module-registry` itself.** This PRD removes the `./settings` subpath; the package's runtime install-set shim (`INSTALLED_MODULES`, `isInstalledModule`, `MODULES`) and the package-deletion finishing move belong to [PRD-218](../218-module-registry-deprecation/README.md) US-03.
+- **Touching `apps/pops-shell` or `apps/pops-api` consumer code.** The eight call sites already import from `@pops/pillar-sdk/settings` after PR #3176; the SDK barrel's internal re-exports change, the public surface does not.
+- **Adding a `./settings` export to any pillar contract package that doesn't host a manifest** (e.g. `@pops/food-contract`, `@pops/lists-contract`).
+
+## References
+
+- PR [#3175](https://github.com/knoxio/pops/pull/3175) — scaffolded `@pops/pillar-sdk/settings` re-exporting from `@pops/module-registry/settings`.
+- PR [#3176](https://github.com/knoxio/pops/pull/3176) — migrated the eight `apps/pops-api` consumers onto `@pops/pillar-sdk/settings` (PRD-238 US-01, Option B).
+- PR [#3171](https://github.com/knoxio/pops/pull/3171) — scaffolded PRD-238 (settings-imports-off-module-registry).
+- [PRD-238](../238-settings-known-modules-surface/README.md) — parent migration tracker. This PRD unblocks its US-02.
+- [PRD-218](../218-module-registry-deprecation/README.md) — `@pops/module-registry` deprecation tracker; US-03 retires the runtime shim consumers and the package itself.
+- [ADR-026](../../../../architecture/adr-026-pillar-architecture.md) — pillar ownership model that motivates parking `egoManifest` under cerebrum and `aiConfigManifest` under core.

--- a/docs/themes/13-pillar-finale/prds/239-settings-manifest-physical-relocation/us-01-relocate-core-manifests.md
+++ b/docs/themes/13-pillar-finale/prds/239-settings-manifest-physical-relocation/us-01-relocate-core-manifests.md
@@ -1,0 +1,42 @@
+# US-01: Relocate `aiConfigManifest` + `coreOperationalManifest` into `@pops/core-contract/settings`
+
+> PRD: [PRD-239 — Settings-manifest physical relocation](README.md)
+
+## Description
+
+As a maintainer dismantling `@pops/module-registry/settings`, I want the two core-pillar manifests (`aiConfigManifest`, `coreOperationalManifest`) to live in `@pops/core-contract` so the pillar owns its own settings surface and the SDK barrel can re-export from a pillar-scoped package.
+
+## Acceptance Criteria
+
+- [ ] `packages/module-registry/src/settings/core/ai-manifest.ts` moves to `packages/core-contract/src/settings/ai-manifest.ts`.
+- [ ] `packages/module-registry/src/settings/core/operational-manifest.ts` moves to `packages/core-contract/src/settings/operational-manifest.ts`.
+- [ ] `packages/module-registry/src/settings/core/ai-manifest.test.ts` moves alongside its source (under `packages/core-contract/src/settings/` or the package's existing test layout — match the convention already used in `core-contract`).
+- [ ] `packages/core-contract/src/settings/index.ts` exports both manifests:
+
+      ```ts
+      export { aiConfigManifest } from './ai-manifest.js';
+      export { coreOperationalManifest } from './operational-manifest.js';
+      ```
+
+- [ ] `packages/core-contract/package.json` declares the new subpath in `exports`:
+
+      ```json
+      "./settings": {
+        "types": "./dist/settings/index.d.ts",
+        "default": "./dist/settings/index.js"
+      }
+      ```
+
+- [ ] `packages/pillar-sdk/src/settings/index.ts` re-exports `aiConfigManifest` and `coreOperationalManifest` from `@pops/core-contract/settings` instead of `@pops/module-registry/settings`. The other eight named exports stay on `@pops/module-registry/settings` for now (other US-NNs flip them).
+- [ ] `packages/module-registry/src/settings/index.ts` removes the two corresponding re-export lines, and `packages/module-registry/src/settings/core/` is deleted.
+- [ ] A smoke test in `core-contract` asserts `aiConfigManifest.id === 'ai'` and `coreOperationalManifest.id === 'core'` (matching today's values — adjust if the source disagrees).
+- [ ] No new `as any` / `as unknown as Type` casts; no `eslint-disable` / `ts-ignore` added.
+- [ ] `pnpm --filter @pops/core-contract typecheck/test/build`, `pnpm --filter @pops/pillar-sdk typecheck/test/build`, `pnpm --filter @pops/module-registry typecheck/test/build`, `pnpm --filter @pops/api typecheck/test` all pass clean.
+- [ ] Husky pre-commit + pre-push pass without `--no-verify`.
+
+## Notes
+
+- Pure relocation — `SettingsManifest` shape, export names, group contents are not touched.
+- `@pops/core-contract` already has the `./types`, `./schemas`, `./router`, `./errors` sub-export pattern in its `package.json`; the new `./settings` entry mirrors that shape.
+- `aiConfigManifest` parks under core because `ai` is a sub-domain of `core` today (per ADR-026). A future `@pops/ai-contract` split is out of scope.
+- Parallelisable with US-02 … US-05 — they touch disjoint source directories and disjoint target packages. Only the same `pillar-sdk/settings/index.ts` is edited by all five; conflicts there are mechanical (one named export line per US).

--- a/docs/themes/13-pillar-finale/prds/239-settings-manifest-physical-relocation/us-02-relocate-inventory-manifest.md
+++ b/docs/themes/13-pillar-finale/prds/239-settings-manifest-physical-relocation/us-02-relocate-inventory-manifest.md
@@ -1,0 +1,38 @@
+# US-02: Relocate `inventoryManifest` into `@pops/inventory-contract/settings`
+
+> PRD: [PRD-239 — Settings-manifest physical relocation](README.md)
+
+## Description
+
+As a maintainer dismantling `@pops/module-registry/settings`, I want `inventoryManifest` to live in `@pops/inventory-contract` so the pillar owns its own settings surface and the SDK barrel can re-export from a pillar-scoped package.
+
+## Acceptance Criteria
+
+- [ ] `packages/module-registry/src/settings/inventory/index.ts` moves to `packages/inventory-contract/src/settings/inventory-manifest.ts` (rename the file from `index.ts` to a descriptive name when it lands next to its peers — the in-package barrel is `settings/index.ts`).
+- [ ] `packages/inventory-contract/src/settings/index.ts` re-exports the manifest:
+
+      ```ts
+      export { inventoryManifest } from './inventory-manifest.js';
+      ```
+
+- [ ] `packages/inventory-contract/package.json` declares the new subpath in `exports`:
+
+      ```json
+      "./settings": {
+        "types": "./dist/settings/index.d.ts",
+        "default": "./dist/settings/index.js"
+      }
+      ```
+
+- [ ] `packages/pillar-sdk/src/settings/index.ts` re-exports `inventoryManifest` from `@pops/inventory-contract/settings` instead of `@pops/module-registry/settings`.
+- [ ] `packages/module-registry/src/settings/index.ts` removes the corresponding re-export line, and `packages/module-registry/src/settings/inventory/` is deleted.
+- [ ] A smoke test in `inventory-contract` asserts `inventoryManifest.id === 'inventory'` (matching today's value — adjust if the source disagrees).
+- [ ] No new `as any` / `as unknown as Type` casts; no `eslint-disable` / `ts-ignore` added.
+- [ ] `pnpm --filter @pops/inventory-contract typecheck/test/build`, `pnpm --filter @pops/pillar-sdk typecheck/test/build`, `pnpm --filter @pops/module-registry typecheck/test/build`, `pnpm --filter @pops/api typecheck/test` all pass clean.
+- [ ] Husky pre-commit + pre-push pass without `--no-verify`.
+
+## Notes
+
+- Pure relocation — `SettingsManifest` shape, export name, group contents are not touched.
+- `@pops/inventory-contract` already has the standard sub-export pattern; the new `./settings` entry mirrors it.
+- Parallelisable with US-01, US-03, US-04, US-05.

--- a/docs/themes/13-pillar-finale/prds/239-settings-manifest-physical-relocation/us-03-relocate-finance-manifest.md
+++ b/docs/themes/13-pillar-finale/prds/239-settings-manifest-physical-relocation/us-03-relocate-finance-manifest.md
@@ -1,0 +1,38 @@
+# US-03: Relocate `financeManifest` into `@pops/finance-contract/settings`
+
+> PRD: [PRD-239 — Settings-manifest physical relocation](README.md)
+
+## Description
+
+As a maintainer dismantling `@pops/module-registry/settings`, I want `financeManifest` to live in `@pops/finance-contract` so the pillar owns its own settings surface and the SDK barrel can re-export from a pillar-scoped package.
+
+## Acceptance Criteria
+
+- [ ] `packages/module-registry/src/settings/finance/index.ts` moves to `packages/finance-contract/src/settings/finance-manifest.ts` (the in-package barrel is `settings/index.ts`).
+- [ ] `packages/finance-contract/src/settings/index.ts` re-exports the manifest:
+
+      ```ts
+      export { financeManifest } from './finance-manifest.js';
+      ```
+
+- [ ] `packages/finance-contract/package.json` declares the new subpath in `exports`:
+
+      ```json
+      "./settings": {
+        "types": "./dist/settings/index.d.ts",
+        "default": "./dist/settings/index.js"
+      }
+      ```
+
+- [ ] `packages/pillar-sdk/src/settings/index.ts` re-exports `financeManifest` from `@pops/finance-contract/settings` instead of `@pops/module-registry/settings`.
+- [ ] `packages/module-registry/src/settings/index.ts` removes the corresponding re-export line, and `packages/module-registry/src/settings/finance/` is deleted.
+- [ ] A smoke test in `finance-contract` asserts `financeManifest.id === 'finance'` (matching today's value — adjust if the source disagrees).
+- [ ] No new `as any` / `as unknown as Type` casts; no `eslint-disable` / `ts-ignore` added.
+- [ ] `pnpm --filter @pops/finance-contract typecheck/test/build`, `pnpm --filter @pops/pillar-sdk typecheck/test/build`, `pnpm --filter @pops/module-registry typecheck/test/build`, `pnpm --filter @pops/api typecheck/test` all pass clean.
+- [ ] Husky pre-commit + pre-push pass without `--no-verify`.
+
+## Notes
+
+- Pure relocation — `SettingsManifest` shape, export name, group contents are not touched.
+- `@pops/finance-contract` already has the standard sub-export pattern; the new `./settings` entry mirrors it.
+- Parallelisable with US-01, US-02, US-04, US-05.

--- a/docs/themes/13-pillar-finale/prds/239-settings-manifest-physical-relocation/us-04-relocate-cerebrum-manifests.md
+++ b/docs/themes/13-pillar-finale/prds/239-settings-manifest-physical-relocation/us-04-relocate-cerebrum-manifests.md
@@ -1,0 +1,45 @@
+# US-04: Relocate `cerebrumManifest` + `egoManifest` into `@pops/cerebrum-contract/settings`
+
+> PRD: [PRD-239 — Settings-manifest physical relocation](README.md)
+
+## Description
+
+As a maintainer dismantling `@pops/module-registry/settings`, I want `cerebrumManifest` (with its four group sub-files) and `egoManifest` to live in `@pops/cerebrum-contract` so the pillar owns its own settings surface — including the `ego` sub-domain — and the SDK barrel can re-export from a pillar-scoped package.
+
+## Acceptance Criteria
+
+- [ ] The entire `packages/module-registry/src/settings/cerebrum/` directory moves to `packages/cerebrum-contract/src/settings/cerebrum/`, preserving the four group files:
+  - [ ] `index.ts` (`cerebrumManifest`)
+  - [ ] `query-emit-manifest.ts`
+  - [ ] `retrieval-ingest-manifest.ts`
+  - [ ] `subsystem-manifest.ts`
+- [ ] `packages/module-registry/src/settings/ego/index.ts` moves to `packages/cerebrum-contract/src/settings/ego/index.ts` (sub-manifest under the cerebrum settings barrel; per ADR-026, ego is a sub-domain of cerebrum).
+- [ ] `packages/cerebrum-contract/src/settings/index.ts` re-exports both manifests:
+
+      ```ts
+      export { cerebrumManifest } from './cerebrum/index.js';
+      export { egoManifest } from './ego/index.js';
+      ```
+
+- [ ] `packages/cerebrum-contract/package.json` declares the new subpath in `exports`:
+
+      ```json
+      "./settings": {
+        "types": "./dist/settings/index.d.ts",
+        "default": "./dist/settings/index.js"
+      }
+      ```
+
+- [ ] `packages/pillar-sdk/src/settings/index.ts` re-exports `cerebrumManifest` and `egoManifest` from `@pops/cerebrum-contract/settings` instead of `@pops/module-registry/settings`.
+- [ ] `packages/module-registry/src/settings/index.ts` removes the two corresponding re-export lines, and both `packages/module-registry/src/settings/cerebrum/` and `packages/module-registry/src/settings/ego/` are deleted.
+- [ ] A smoke test in `cerebrum-contract` asserts `cerebrumManifest.id === 'cerebrum'` and `egoManifest.id === 'ego'` (matching today's values — adjust if the source disagrees).
+- [ ] No new `as any` / `as unknown as Type` casts; no `eslint-disable` / `ts-ignore` added.
+- [ ] `pnpm --filter @pops/cerebrum-contract typecheck/test/build`, `pnpm --filter @pops/pillar-sdk typecheck/test/build`, `pnpm --filter @pops/module-registry typecheck/test/build`, `pnpm --filter @pops/api typecheck/test` all pass clean.
+- [ ] Husky pre-commit + pre-push pass without `--no-verify`.
+
+## Notes
+
+- The `cerebrum/` directory's internal relative imports (`./query-emit-manifest.js`, `./retrieval-ingest-manifest.js`, `./subsystem-manifest.js`) stay valid because the directory moves as a unit. Do not flatten the four files into one — the split exists to stay under the `max-lines` lint rule.
+- `egoManifest` does not get its own contract package. It rides on `@pops/cerebrum-contract` per ADR-026 — both `ego` and `ai` are transitional sub-domains today.
+- Pure relocation — `SettingsManifest` shape, export names, group contents are not touched.
+- Parallelisable with US-01, US-02, US-03, US-05.

--- a/docs/themes/13-pillar-finale/prds/239-settings-manifest-physical-relocation/us-05-relocate-media-manifests.md
+++ b/docs/themes/13-pillar-finale/prds/239-settings-manifest-physical-relocation/us-05-relocate-media-manifests.md
@@ -1,0 +1,41 @@
+# US-05: Relocate the four media manifests into `@pops/media-contract/settings`
+
+> PRD: [PRD-239 — Settings-manifest physical relocation](README.md)
+
+## Description
+
+As a maintainer dismantling `@pops/module-registry/settings`, I want the four media-pillar manifests (`arrManifest`, `plexManifest`, `rotationManifest`, `mediaOperationalManifest`) to live in `@pops/media-contract` so the pillar owns its own settings surface and the SDK barrel can re-export from a pillar-scoped package.
+
+## Acceptance Criteria
+
+- [ ] `packages/module-registry/src/settings/media/manifests.ts` (hosting `arrManifest`, `plexManifest`, `rotationManifest`) moves to `packages/media-contract/src/settings/manifests.ts`.
+- [ ] `packages/module-registry/src/settings/media/operational-manifest.ts` moves to `packages/media-contract/src/settings/operational-manifest.ts`.
+- [ ] `packages/module-registry/src/settings/media/comparisons-manifest.ts`, `discovery-manifest.ts`, `integrations-manifest.ts` move with them — they are internal collaborators of `manifests.ts` and the directory moves as a unit. Confirm during implementation by inspecting imports inside `manifests.ts`.
+- [ ] `packages/media-contract/src/settings/index.ts` re-exports the four named manifests:
+
+      ```ts
+      export { arrManifest, plexManifest, rotationManifest } from './manifests.js';
+      export { mediaOperationalManifest } from './operational-manifest.js';
+      ```
+
+- [ ] `packages/media-contract/package.json` declares the new subpath in `exports`:
+
+      ```json
+      "./settings": {
+        "types": "./dist/settings/index.d.ts",
+        "default": "./dist/settings/index.js"
+      }
+      ```
+
+- [ ] `packages/pillar-sdk/src/settings/index.ts` re-exports the four media manifests from `@pops/media-contract/settings` instead of `@pops/module-registry/settings`.
+- [ ] `packages/module-registry/src/settings/index.ts` removes the corresponding re-export lines, and `packages/module-registry/src/settings/media/` is deleted.
+- [ ] A smoke test in `media-contract` asserts each manifest's `id` (`arr`, `plex`, `rotation`, `media`-or-`media-operational` — match today's source).
+- [ ] No new `as any` / `as unknown as Type` casts; no `eslint-disable` / `ts-ignore` added.
+- [ ] `pnpm --filter @pops/media-contract typecheck/test/build`, `pnpm --filter @pops/pillar-sdk typecheck/test/build`, `pnpm --filter @pops/module-registry typecheck/test/build`, `pnpm --filter @pops/api typecheck/test` all pass clean.
+- [ ] Husky pre-commit + pre-push pass without `--no-verify`.
+
+## Notes
+
+- The media directory has three additional source files (`comparisons-manifest.ts`, `discovery-manifest.ts`, `integrations-manifest.ts`) that are not directly re-exported from `module-registry/src/settings/index.ts` but feed `manifests.ts` and `operational-manifest.ts` internally. Move them together — splitting the directory would break the relative imports.
+- Pure relocation — `SettingsManifest` shape, export names, group contents are not touched.
+- Parallelisable with US-01, US-02, US-03, US-04.

--- a/docs/themes/13-pillar-finale/prds/239-settings-manifest-physical-relocation/us-06-drop-legacy-subpath.md
+++ b/docs/themes/13-pillar-finale/prds/239-settings-manifest-physical-relocation/us-06-drop-legacy-subpath.md
@@ -1,0 +1,27 @@
+# US-06: Drop the `@pops/module-registry/settings` subpath and close PRD-238 US-02
+
+> PRD: [PRD-239 — Settings-manifest physical relocation](README.md)
+
+## Description
+
+As a maintainer retiring `@pops/module-registry`, I want the `./settings` subpath gone now that all ten manifests live in their owning pillar packages, so the legacy surface shrinks toward the [PRD-218](../218-module-registry-deprecation/README.md) US-03 package-deletion finishing move. The same PR closes the long-deferred [PRD-238 US-02](../238-settings-known-modules-surface/us-02-delete-legacy-settings-subpath.md).
+
+## Acceptance Criteria
+
+- [ ] `packages/module-registry/src/settings/` is deleted (the directory is already emptied by US-01 … US-05; only `index.ts` remains — delete it too).
+- [ ] The `./settings` entry is removed from `packages/module-registry/package.json`'s `exports` map.
+- [ ] `packages/module-registry`'s root barrel (`src/index.ts`) does not re-export anything from the deleted directory — confirm and remove any stale lines.
+- [ ] `packages/pillar-sdk/package.json` removes `@pops/module-registry` from `dependencies` — the SDK no longer references it for any reason.
+- [ ] `packages/pillar-sdk/src/settings/index.ts` has zero references to `@pops/module-registry` (already true after US-01 … US-05 land; verify).
+- [ ] `grep -rn "@pops/module-registry/settings" packages apps` returns zero matches under any `src/` directory (build artefacts under `dist/` are ignored).
+- [ ] [PRD-238 US-02](../238-settings-known-modules-surface/us-02-delete-legacy-settings-subpath.md) is marked **Done** in its checkboxes and the PRD-238 status table.
+- [ ] `pnpm --filter @pops/module-registry typecheck/test/build`, `pnpm --filter @pops/pillar-sdk typecheck/test/build`, and the full monorepo `pnpm typecheck`, `pnpm lint`, `pnpm build` all pass clean.
+- [ ] `pnpm --filter @pops/api test` passes.
+- [ ] Husky pre-commit + pre-push pass without `--no-verify`.
+
+## Notes
+
+- **Blocked by US-01 … US-05.** Do not start until all five pillar relocations have merged. If any US is still open, this one waits — the legacy subpath cannot be deleted while it still has consumers.
+- This US does **not** delete `@pops/module-registry` itself. The package still hosts the runtime install-set shim (`INSTALLED_MODULES`, `isInstalledModule`, `MODULES`) plus `KNOWN_MODULES` — retired separately by [PRD-218](../218-module-registry-deprecation/README.md) US-03.
+- The PR description should call out the PRD-238 US-02 closure explicitly so the parent PRD's tracker can be updated in the same merge.
+- If `packages/module-registry/src/index.ts` re-exports anything from `./settings/`, those re-exports also go away. Verify before deleting `src/settings/index.ts`.


### PR DESCRIPTION
## Summary

- Scaffolds **PRD-239** under Theme 13 / Epic 10 specifying the physical relocation of the 10 per-pillar `SettingsManifest` exports out of `packages/module-registry/src/settings/` into their owning pillar contract packages (`@pops/core-contract`, `@pops/inventory-contract`, `@pops/finance-contract`, `@pops/cerebrum-contract`, `@pops/media-contract`), then dropping the `@pops/module-registry/settings` subpath and closing PRD-238 US-02.
- Six user stories: five mutually-parallelisable per-pillar relocations (US-01 … US-05) plus a finishing US-06 that deletes the legacy subpath and `@pops/module-registry` workspace dep from `pillar-sdk`.
- Updates the epic table in `docs/themes/13-pillar-finale/epics/10-fe-sdk-dispatcher-generator.md` — PRD-238 marked Partial, PRD-239 listed.

Docs only. No source / config / package.json changes outside `docs/`.

## Context

- PR #3175 — scaffolded `@pops/pillar-sdk/settings` re-exporting from `@pops/module-registry/settings`.
- PR #3176 — migrated the 8 `apps/pops-api` consumers off `@pops/module-registry/settings` and onto `@pops/pillar-sdk/settings` (PRD-238 US-01, Option B).
- PR #3171 — scaffolded PRD-238 (settings-imports-off-module-registry).

PRD-238 US-02 is blocked because `pillar-sdk/settings` still re-exports from `@pops/module-registry/settings` internally. PRD-239 is the unblock: relocate the source physically, then the subpath has no consumer and can be dropped.

## Test plan

- [ ] Spot-check rendering on GitHub for the README and 6 US files.
- [ ] Confirm epic table renders correctly (PRD-238 status, PRD-239 new row).
- [ ] Verify links to PRD-218, PRD-238, ADR-026 resolve.