### PR TITLE
feat(app-food): drop @pops/api-client dep (re-source AppRouter from @pops/api · PRD-227)

### DIFF
--- a/packages/app-food/package.json
+++ b/packages/app-food/package.json
@@ -22,7 +22,7 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@lezer/highlight": "^1.2.3",
     "@lezer/lr": "^1.4.10",
-    "@pops/api-client": "workspace:*",
+    "@pops/api": "workspace:*",
     "@pops/app-food-db": "workspace:*",
     "@pops/app-lists": "workspace:*",
     "@pops/db-types": "workspace:*",

--- a/packages/app-food/src/components/cook/BatchOverridePicker.tsx
+++ b/packages/app-food/src/components/cook/BatchOverridePicker.tsx
@@ -27,7 +27,7 @@ import { useSubstitutionResolution } from './useSubstitutionResolution.js';
 import type { inferRouterOutputs } from '@trpc/server';
 import type { ReactNode } from 'react';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 import type { BatchForConsumeRow } from '@pops/app-food-db';
 
 import type { SubCandidate, SubCandidateBatch } from './useSubstitutionResolution.js';

--- a/packages/app-food/src/components/cook/CookModalShell.tsx
+++ b/packages/app-food/src/components/cook/CookModalShell.tsx
@@ -20,7 +20,7 @@ import { CookModalContent } from './CookModalContent.js';
 
 import type { inferRouterOutputs } from '@trpc/server';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 import type { CookPreparation } from '@pops/app-food-db';
 
 import type { CookModalProps } from './CookModal.js';

--- a/packages/app-food/src/components/cook/__tests__/CookModal.test.tsx
+++ b/packages/app-food/src/components/cook/__tests__/CookModal.test.tsx
@@ -1,7 +1,7 @@
 /**
  * PRD-144 — RTL coverage for `CookModal`.
  *
- * Mocks `@pops/api-client` so `prepareCook` and `markCooked` are both
+ * Mocks `@pops/pillar-sdk` so `prepareCook` and `markCooked` are both
  * controllable per test. Covers: open-from-recipe-detail pre-fill,
  * yieldless-recipe field hiding, submit happy path, server-error
  * surfacing, submit-disabled when scale is empty.

--- a/packages/app-food/src/components/cook/useMarkCookedMutation.ts
+++ b/packages/app-food/src/components/cook/useMarkCookedMutation.ts
@@ -17,7 +17,7 @@ import { usePillarMutation, usePillarUtils } from '@pops/pillar-sdk/react';
 
 import type { inferRouterInputs, inferRouterOutputs } from '@trpc/server';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 
 import type { buildSubmitInput } from './cook-modal-helpers.js';
 import type { CookedSuccess } from './CookModal.js';

--- a/packages/app-food/src/components/cook/useSubstitutionResolution.ts
+++ b/packages/app-food/src/components/cook/useSubstitutionResolution.ts
@@ -18,7 +18,7 @@ import { rankSubstitutionCandidates, type RankableCandidate } from './substituti
 
 import type { inferRouterOutputs } from '@trpc/server';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 
 type SubResolution = inferRouterOutputs<AppRouter>['food']['substitutions']['resolveForLine'];
 

--- a/packages/app-food/src/components/dsl-editor/use-dsl-autocomplete-sources.ts
+++ b/packages/app-food/src/components/dsl-editor/use-dsl-autocomplete-sources.ts
@@ -24,7 +24,7 @@ import { usePillarCall } from '../../lib/pillar-call.js';
 
 import type { inferRouterOutputs } from '@trpc/server';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 
 import type {
   DslAutocompleteSources,

--- a/packages/app-food/src/components/hero-image-uploader/useHeroMutations.ts
+++ b/packages/app-food/src/components/hero-image-uploader/useHeroMutations.ts
@@ -12,7 +12,7 @@ import { HERO_ALLOWED_MIME_TYPES } from '../../storage/hero-paths';
 
 import type { inferRouterInputs, inferRouterOutputs } from '@trpc/server';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 
 type HeroImageUploadInput = inferRouterInputs<AppRouter>['food']['heroImage']['upload'];
 type HeroImageUploadOutput = inferRouterOutputs<AppRouter>['food']['heroImage']['upload'];

--- a/packages/app-food/src/pages/data/GlobalSearchBar.tsx
+++ b/packages/app-food/src/pages/data/GlobalSearchBar.tsx
@@ -7,7 +7,7 @@ import { Label, TextInput, useDebouncedValue } from '@pops/ui';
 
 import type { inferRouterOutputs } from '@trpc/server';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 
 type SlugSearchOutput = inferRouterOutputs<AppRouter>['food']['slugs']['search'];
 

--- a/packages/app-food/src/pages/data/aliases/AliasTargetPicker.tsx
+++ b/packages/app-food/src/pages/data/aliases/AliasTargetPicker.tsx
@@ -20,7 +20,7 @@ import { Button, Input } from '@pops/ui';
 
 import type { inferRouterOutputs } from '@trpc/server';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 
 import type { AliasTarget } from './types';
 

--- a/packages/app-food/src/pages/data/aliases/__tests__/AliasesTabContent.test.tsx
+++ b/packages/app-food/src/pages/data/aliases/__tests__/AliasesTabContent.test.tsx
@@ -1,7 +1,7 @@
 /**
  * RTL coverage for `/food/data/aliases` (PRD-122-C).
  *
- * `vi.mock('@pops/api-client', ...)` is declared at the top level so
+ * `vi.mock('@pops/pillar-sdk/react', ...)` is declared at the top level so
  * vitest can hoist it (a helper function-wrapped mock works but
  * produces a deprecation warning). Each procedure's behaviour reads
  * from the module-scoped `state` object so tests can seed + assert

--- a/packages/app-food/src/pages/data/aliases/use-aliases-data.ts
+++ b/packages/app-food/src/pages/data/aliases/use-aliases-data.ts
@@ -13,7 +13,7 @@ import { sortAliases } from './format.js';
 
 import type { inferRouterOutputs } from '@trpc/server';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 
 import type {
   AliasesFilter,

--- a/packages/app-food/src/pages/data/aliases/use-aliases-mutations.ts
+++ b/packages/app-food/src/pages/data/aliases/use-aliases-mutations.ts
@@ -18,7 +18,7 @@ import { usePillarMutation, usePillarUtils } from '@pops/pillar-sdk/react';
 
 import type { inferRouterInputs, inferRouterOutputs } from '@trpc/server';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 
 import type { AliasSource, AliasTarget } from './types.js';
 

--- a/packages/app-food/src/pages/data/conversions-tab/CreateWeightDialog.tsx
+++ b/packages/app-food/src/pages/data/conversions-tab/CreateWeightDialog.tsx
@@ -14,7 +14,7 @@ import { NumberFieldRow, SelectFieldRow, TextareaFieldRow, TextFieldRow } from '
 
 import type { inferRouterOutputs } from '@trpc/server';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 
 type IngredientsGetOutput = inferRouterOutputs<AppRouter>['food']['ingredients']['get'];
 

--- a/packages/app-food/src/pages/data/conversions-tab/UnitsSection.tsx
+++ b/packages/app-food/src/pages/data/conversions-tab/UnitsSection.tsx
@@ -15,7 +15,7 @@ import { useUnitMutations } from './useUnitMutations';
 
 import type { inferRouterOutputs } from '@trpc/server';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 
 import type { UnitConversionRow } from './types';
 

--- a/packages/app-food/src/pages/data/conversions-tab/WeightsSection.tsx
+++ b/packages/app-food/src/pages/data/conversions-tab/WeightsSection.tsx
@@ -16,7 +16,7 @@ import { WeightsTable } from './WeightsTable';
 
 import type { inferRouterOutputs } from '@trpc/server';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 
 import type { IngredientWeightRow } from './types';
 

--- a/packages/app-food/src/pages/data/conversions-tab/__tests__/UnitsSection.test.tsx
+++ b/packages/app-food/src/pages/data/conversions-tab/__tests__/UnitsSection.test.tsx
@@ -1,7 +1,7 @@
 /**
  * PRD-123 Phase C — UnitsSection smoke tests.
  *
- * Mocks `@pops/api-client` so the section renders against controlled data
+ * Mocks `@pops/pillar-sdk` so the section renders against controlled data
  * and asserts:
  *   - the seeded badge + disabled delete render for seeded rows
  *   - the search input feeds into the listUnits query input

--- a/packages/app-food/src/pages/data/conversions-tab/__tests__/WeightsSection.test.tsx
+++ b/packages/app-food/src/pages/data/conversions-tab/__tests__/WeightsSection.test.tsx
@@ -1,7 +1,7 @@
 /**
  * PRD-123 Phase C — WeightsSection smoke tests.
  *
- * Mocks `@pops/api-client` so the section renders against controlled data
+ * Mocks `@pops/pillar-sdk` so the section renders against controlled data
  * and asserts:
  *   - rows render with the resolved ingredient + variant labels
  *   - the seeded badge + disabled delete render for seeded rows

--- a/packages/app-food/src/pages/data/conversions-tab/types.ts
+++ b/packages/app-food/src/pages/data/conversions-tab/types.ts
@@ -6,7 +6,7 @@
  */
 import type { inferRouterOutputs } from '@trpc/server';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 
 type ConversionsOutputs = inferRouterOutputs<AppRouter>['food']['conversions'];
 

--- a/packages/app-food/src/pages/data/conversions-tab/useUnitMutations.ts
+++ b/packages/app-food/src/pages/data/conversions-tab/useUnitMutations.ts
@@ -13,7 +13,7 @@ import { usePillarMutation, usePillarUtils } from '@pops/pillar-sdk/react';
 import type { inferRouterInputs, inferRouterOutputs } from '@trpc/server';
 import type { TFunction } from 'i18next';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 
 import type { CreateUnitInput, UpdateUnitInput } from './types';
 

--- a/packages/app-food/src/pages/data/conversions-tab/useWeightMutations.ts
+++ b/packages/app-food/src/pages/data/conversions-tab/useWeightMutations.ts
@@ -14,7 +14,7 @@ import { usePillarMutation, usePillarUtils } from '@pops/pillar-sdk/react';
 import type { inferRouterInputs, inferRouterOutputs } from '@trpc/server';
 import type { TFunction } from 'i18next';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 
 import type { CreateWeightInput, UpdateWeightInput } from './types';
 

--- a/packages/app-food/src/pages/data/conversions-tab/useWeightRowViews.ts
+++ b/packages/app-food/src/pages/data/conversions-tab/useWeightRowViews.ts
@@ -13,7 +13,7 @@ import { pillarQueryArg, usePillarQueries, type PillarQueryArg } from '@pops/pil
 
 import type { inferRouterOutputs } from '@trpc/server';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 
 import type { IngredientWeightRow } from './types';
 import type { WeightRowView } from './WeightsTable';

--- a/packages/app-food/src/pages/data/ingredients-tab/IngredientTagsEditor.tsx
+++ b/packages/app-food/src/pages/data/ingredients-tab/IngredientTagsEditor.tsx
@@ -17,7 +17,7 @@ import { useTagsDraft, type TagsDraft } from './useTagsDraft.js';
 
 import type { inferRouterOutputs } from '@trpc/server';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 
 type TagsListOutput = inferRouterOutputs<AppRouter>['food']['ingredients']['tags']['list'];
 type TagsDistinctOutput = inferRouterOutputs<AppRouter>['food']['ingredients']['tags']['distinct'];

--- a/packages/app-food/src/pages/data/ingredients-tab/RecipeRefsSection.tsx
+++ b/packages/app-food/src/pages/data/ingredients-tab/RecipeRefsSection.tsx
@@ -15,7 +15,7 @@ import { Button } from '@pops/ui';
 
 import type { inferRouterOutputs } from '@trpc/server';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 
 type RecipeRefsOutput = inferRouterOutputs<AppRouter>['food']['ingredients']['recipeRefs'];
 

--- a/packages/app-food/src/pages/data/ingredients-tab/__tests__/IngredientTagsEditor.test.tsx
+++ b/packages/app-food/src/pages/data/ingredients-tab/__tests__/IngredientTagsEditor.test.tsx
@@ -1,7 +1,7 @@
 /**
  * PRD-151 — IngredientTagsEditor unit tests.
  *
- * Mocks `@pops/api-client` so the component is exercised against a fully
+ * Mocks `@pops/pillar-sdk` so the component is exercised against a fully
  * synchronous tRPC stand-in. Covers:
  *   - initial render hydrates from the server-side list
  *   - adding a chip is local until Save

--- a/packages/app-food/src/pages/data/ingredients-tab/__tests__/IngredientsTab.test.tsx
+++ b/packages/app-food/src/pages/data/ingredients-tab/__tests__/IngredientsTab.test.tsx
@@ -1,7 +1,7 @@
 /**
  * PRD-122-B / PRD-122-B2 — ingredients tab UI smoke tests.
  *
- * Mocks `@pops/api-client` so the tree renders against a controlled
+ * Mocks `@pops/pillar-sdk` so the tree renders against a controlled
  * dataset; asserts:
  *   - the tree groups children under their parents
  *   - selecting a node renders the detail panel

--- a/packages/app-food/src/pages/data/ingredients-tab/ingredient-tab-queries.ts
+++ b/packages/app-food/src/pages/data/ingredients-tab/ingredient-tab-queries.ts
@@ -13,7 +13,7 @@ import { usePillarQuery } from '@pops/pillar-sdk/react';
 
 import type { inferRouterOutputs } from '@trpc/server';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 import type { DeleteBlockerSummary, IngredientRow } from '@pops/app-food-db';
 
 type BlockersOutput = inferRouterOutputs<AppRouter>['food']['ingredients']['blockers'];

--- a/packages/app-food/src/pages/data/ingredients-tab/useIngredientActionMutations.ts
+++ b/packages/app-food/src/pages/data/ingredients-tab/useIngredientActionMutations.ts
@@ -20,7 +20,7 @@ import { mapMutationError } from './errors';
 import type { inferRouterInputs, inferRouterOutputs } from '@trpc/server';
 import type { TFunction } from 'i18next';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 
 type RenameInput = inferRouterInputs<AppRouter>['food']['ingredients']['rename'];
 type RenameOutput = inferRouterOutputs<AppRouter>['food']['ingredients']['rename'];

--- a/packages/app-food/src/pages/data/ingredients-tab/useIngredientsTab.ts
+++ b/packages/app-food/src/pages/data/ingredients-tab/useIngredientsTab.ts
@@ -16,7 +16,7 @@ import { mapMutationError } from './errors';
 
 import type { inferRouterInputs, inferRouterOutputs } from '@trpc/server';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 
 import type { CreateIngredientInput } from './CreateIngredientDialog';
 

--- a/packages/app-food/src/pages/data/ingredients-tab/useTagsDraft.ts
+++ b/packages/app-food/src/pages/data/ingredients-tab/useTagsDraft.ts
@@ -19,7 +19,7 @@ import { usePillarMutation, usePillarUtils } from '@pops/pillar-sdk/react';
 
 import type { inferRouterInputs, inferRouterOutputs } from '@trpc/server';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 
 type TagsSetInput = inferRouterInputs<AppRouter>['food']['ingredients']['tags']['set'];
 type TagsSetOutput = inferRouterOutputs<AppRouter>['food']['ingredients']['tags']['set'];

--- a/packages/app-food/src/pages/data/ingredients-tab/useVariantActionMutations.ts
+++ b/packages/app-food/src/pages/data/ingredients-tab/useVariantActionMutations.ts
@@ -13,7 +13,7 @@ import { mapVariantMutationError } from './errors';
 
 import type { inferRouterInputs, inferRouterOutputs } from '@trpc/server';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 
 type CreateVariantInput = inferRouterInputs<AppRouter>['food']['variants']['create'];
 type CreateVariantOutput = inferRouterOutputs<AppRouter>['food']['variants']['create'];

--- a/packages/app-food/src/pages/data/prep-states/PrepStatesTabContent.tsx
+++ b/packages/app-food/src/pages/data/prep-states/PrepStatesTabContent.tsx
@@ -30,7 +30,7 @@ import { AddPrepStateDialog } from './AddPrepStateDialog.js';
 
 import type { inferRouterInputs, inferRouterOutputs } from '@trpc/server';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 
 type PrepStatesListOutput = inferRouterOutputs<AppRouter>['food']['prepStates']['list'];
 type PrepStatesCreateInput = inferRouterInputs<AppRouter>['food']['prepStates']['create'];

--- a/packages/app-food/src/pages/data/substitutions-graph/SubGraphPage.tsx
+++ b/packages/app-food/src/pages/data/substitutions-graph/SubGraphPage.tsx
@@ -26,7 +26,7 @@ import { useSubGraphState } from './useSubGraphState';
 
 import type { inferRouterOutputs } from '@trpc/server';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 
 import type { ForceGraphInternalProps } from './ForceGraphCanvas';
 import type { SubGraphView } from './types';

--- a/packages/app-food/src/pages/data/substitutions-graph/__tests__/SubGraphPage.test.tsx
+++ b/packages/app-food/src/pages/data/substitutions-graph/__tests__/SubGraphPage.test.tsx
@@ -3,8 +3,8 @@
  *
  * Drives the page through `createMemoryRouter` so the `useSearchParams`
  * + URL-state machinery exercises React Router's real resolution path.
- * The `food.substitutions.graphView` tRPC query is mocked at the
- * `@pops/api-client` module boundary; the force-directed canvas is
+ * The `food.substitutions.graphView` query is mocked at the
+ * `@pops/pillar-sdk` module boundary; the force-directed canvas is
  * substituted via `forceGraphRenderImpl` so vitest doesn't need a real
  * `HTMLCanvasElement`.
  */

--- a/packages/app-food/src/pages/data/substitutions-tab/EndpointPicker.tsx
+++ b/packages/app-food/src/pages/data/substitutions-tab/EndpointPicker.tsx
@@ -6,7 +6,7 @@ import { Label, useDebouncedValue } from '@pops/ui';
 
 import type { inferRouterOutputs } from '@trpc/server';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 
 type SlugSearchOutput = inferRouterOutputs<AppRouter>['food']['slugs']['search'];
 type IngredientsGetOutput = inferRouterOutputs<AppRouter>['food']['ingredients']['get'];

--- a/packages/app-food/src/pages/data/substitutions-tab/useSubstitutionsTab.ts
+++ b/packages/app-food/src/pages/data/substitutions-tab/useSubstitutionsTab.ts
@@ -13,7 +13,7 @@ import {
 
 import type { inferRouterInputs, inferRouterOutputs } from '@trpc/server';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 
 type ListHydratedOutput = inferRouterOutputs<AppRouter>['food']['substitutions']['listHydrated'];
 type CreateInput = inferRouterInputs<AppRouter>['food']['substitutions']['create'];

--- a/packages/app-food/src/pages/data/tags-tab/TagsTab.tsx
+++ b/packages/app-food/src/pages/data/tags-tab/TagsTab.tsx
@@ -19,7 +19,7 @@ import { Button } from '@pops/ui';
 
 import type { inferRouterOutputs } from '@trpc/server';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 import type { TagDistinctRow } from '@pops/app-food-db';
 
 type TagsDistinctOutput = inferRouterOutputs<AppRouter>['food']['ingredients']['tags']['distinct'];

--- a/packages/app-food/src/pages/fridge/CookNowPicker.tsx
+++ b/packages/app-food/src/pages/fridge/CookNowPicker.tsx
@@ -16,7 +16,7 @@ import { formatQty } from './format.js';
 
 import type { inferRouterOutputs } from '@trpc/server';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 import type { BatchUnit, RecipeForCookRow } from '@pops/app-food-db';
 
 type RecipesUsingBatchOutput = inferRouterOutputs<AppRouter>['food']['fridge']['recipesUsingBatch'];

--- a/packages/app-food/src/pages/fridge/DeleteBatchConfirm.tsx
+++ b/packages/app-food/src/pages/fridge/DeleteBatchConfirm.tsx
@@ -14,7 +14,7 @@ import { formatQty } from './format.js';
 
 import type { inferRouterInputs, inferRouterOutputs } from '@trpc/server';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 import type { BatchDetail } from '@pops/app-food-db';
 
 type BatchesGetOutput = inferRouterOutputs<AppRouter>['food']['batches']['get'];

--- a/packages/app-food/src/pages/fridge/RelocateBatchModal.tsx
+++ b/packages/app-food/src/pages/fridge/RelocateBatchModal.tsx
@@ -14,7 +14,7 @@ import { FormError } from './form-controls.js';
 
 import type { inferRouterInputs, inferRouterOutputs } from '@trpc/server';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 import type { BatchLocation } from '@pops/app-food-db';
 
 type BatchesGetOutput = inferRouterOutputs<AppRouter>['food']['batches']['get'];

--- a/packages/app-food/src/pages/fridge/useAddBatchForm.ts
+++ b/packages/app-food/src/pages/fridge/useAddBatchForm.ts
@@ -13,7 +13,7 @@ import { toIsoFromDateInput } from './form-controls.js';
 
 import type { inferRouterInputs, inferRouterOutputs } from '@trpc/server';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 import type { BatchLocation, BatchUnit, ManualBatchSourceType } from '@pops/app-food-db';
 
 type IngredientsListOutput = inferRouterOutputs<AppRouter>['food']['ingredients']['list'];

--- a/packages/app-food/src/pages/fridge/useAdjustQtyState.ts
+++ b/packages/app-food/src/pages/fridge/useAdjustQtyState.ts
@@ -8,7 +8,7 @@ import { usePillarMutation, usePillarQuery, usePillarUtils } from '@pops/pillar-
 
 import type { inferRouterInputs, inferRouterOutputs } from '@trpc/server';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 import type { BatchAdjustReason } from '@pops/app-food-db';
 
 type BatchesGetOutput = inferRouterOutputs<AppRouter>['food']['batches']['get'];

--- a/packages/app-food/src/pages/fridge/useEditBatchState.ts
+++ b/packages/app-food/src/pages/fridge/useEditBatchState.ts
@@ -9,7 +9,7 @@ import { usePillarMutation, usePillarQuery, usePillarUtils } from '@pops/pillar-
 
 import type { inferRouterInputs, inferRouterOutputs } from '@trpc/server';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 
 type BatchesGetOutput = inferRouterOutputs<AppRouter>['food']['batches']['get'];
 type PrepStatesListOutput = inferRouterOutputs<AppRouter>['food']['prepStates']['list'];

--- a/packages/app-food/src/pages/fridge/useFridgeView.ts
+++ b/packages/app-food/src/pages/fridge/useFridgeView.ts
@@ -8,7 +8,7 @@ import { usePillarQuery } from '@pops/pillar-sdk/react';
 
 import type { inferRouterOutputs } from '@trpc/server';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 import type { FridgeView } from '@pops/app-food-db';
 
 type FridgeViewOutput = inferRouterOutputs<AppRouter>['food']['fridge']['view'];

--- a/packages/app-food/src/pages/inbox/InboxPage.tsx
+++ b/packages/app-food/src/pages/inbox/InboxPage.tsx
@@ -24,7 +24,7 @@ import { RejectedTab } from './RejectedTab.js';
 import type { inferRouterOutputs } from '@trpc/server';
 import type { NavigateFunction } from 'react-router';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 
 type InboxPendingCountOutput = inferRouterOutputs<AppRouter>['food']['inbox']['pendingCount'];
 

--- a/packages/app-food/src/pages/inbox/inspector/ApproveDialog.tsx
+++ b/packages/app-food/src/pages/inbox/inspector/ApproveDialog.tsx
@@ -13,7 +13,7 @@ import { Button, Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle 
 
 import type { inferRouterInputs, inferRouterOutputs } from '@trpc/server';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 
 type InboxApproveInput = inferRouterInputs<AppRouter>['food']['inbox']['approve'];
 type InboxApproveOutput = inferRouterOutputs<AppRouter>['food']['inbox']['approve'];

--- a/packages/app-food/src/pages/inbox/inspector/DecisionPane.tsx
+++ b/packages/app-food/src/pages/inbox/inspector/DecisionPane.tsx
@@ -23,7 +23,7 @@ import { RejectDialog } from './RejectDialog.js';
 
 import type { inferRouterInputs, inferRouterOutputs } from '@trpc/server';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 import type {
   InspectorDraftView,
   InspectorProposedSlugRow,

--- a/packages/app-food/src/pages/inbox/inspector/EditorPane.tsx
+++ b/packages/app-food/src/pages/inbox/inspector/EditorPane.tsx
@@ -23,7 +23,7 @@ import { InspectorRenderer } from './InspectorRenderer.js';
 
 import type { inferRouterInputs, inferRouterOutputs } from '@trpc/server';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 import type { InspectorDraftView } from '@pops/app-food-db';
 
 type SaveDraftInput = inferRouterInputs<AppRouter>['food']['recipes']['saveDraft'];

--- a/packages/app-food/src/pages/inbox/inspector/InspectorRenderer.tsx
+++ b/packages/app-food/src/pages/inbox/inspector/InspectorRenderer.tsx
@@ -15,7 +15,7 @@ import { RecipeRenderer } from '../../../components/RecipeRenderer.js';
 
 import type { inferRouterOutputs } from '@trpc/server';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 
 type GetForRenderingOutput = inferRouterOutputs<AppRouter>['food']['recipes']['getForRendering'];
 

--- a/packages/app-food/src/pages/inbox/inspector/RejectDialog.tsx
+++ b/packages/app-food/src/pages/inbox/inspector/RejectDialog.tsx
@@ -14,7 +14,7 @@ import { Button, Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle 
 
 import type { inferRouterInputs, inferRouterOutputs } from '@trpc/server';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 
 type InboxRejectInput = inferRouterInputs<AppRouter>['food']['inbox']['reject'];
 type InboxRejectOutput = inferRouterOutputs<AppRouter>['food']['inbox']['reject'];

--- a/packages/app-food/src/pages/inbox/inspector/__tests__/InspectorPage.test.tsx
+++ b/packages/app-food/src/pages/inbox/inspector/__tests__/InspectorPage.test.tsx
@@ -1,7 +1,7 @@
 /**
  * PRD-135 — RTL coverage for the per-draft inspector page.
  *
- * Mocks `@pops/api-client` so the page renders against a synthetic
+ * Mocks `@pops/pillar-sdk` so the page renders against a synthetic
  * `food.inbox.getForReview` payload and asserts:
  *   - 404 renders for `{ ok: false, reason: 'SourceNotFound' }`
  *   - pending source (draft = null) shows the no-draft body

--- a/packages/app-food/src/pages/inbox/inspector/useInspector.ts
+++ b/packages/app-food/src/pages/inbox/inspector/useInspector.ts
@@ -14,7 +14,7 @@ import { usePillarQuery, usePillarUtils } from '@pops/pillar-sdk/react';
 
 import type { inferRouterOutputs } from '@trpc/server';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 
 type InboxGetForReviewOutput = inferRouterOutputs<AppRouter>['food']['inbox']['getForReview'];
 

--- a/packages/app-food/src/pages/inbox/useDraftsTab.ts
+++ b/packages/app-food/src/pages/inbox/useDraftsTab.ts
@@ -13,7 +13,7 @@ import { type DraftsFiltersState, toQueryInput } from './drafts-filters.js';
 
 import type { inferRouterOutputs } from '@trpc/server';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 
 type InboxListOutput = inferRouterOutputs<AppRouter>['food']['inbox']['list'];
 

--- a/packages/app-food/src/pages/inbox/useFailedTab.ts
+++ b/packages/app-food/src/pages/inbox/useFailedTab.ts
@@ -15,7 +15,7 @@ import { type FailedFiltersState } from './FailedFilters.js';
 
 import type { inferRouterOutputs } from '@trpc/server';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 import type { UsePillarUtilsResult } from '@pops/pillar-sdk/react';
 
 type ListFailedOutput = inferRouterOutputs<AppRouter>['food']['inbox']['listFailed'];

--- a/packages/app-food/src/pages/inbox/useRejectedTab.ts
+++ b/packages/app-food/src/pages/inbox/useRejectedTab.ts
@@ -15,7 +15,7 @@ import { type RejectedFiltersState } from './RejectedFilters.js';
 
 import type { inferRouterOutputs } from '@trpc/server';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 import type { UsePillarUtilsResult } from '@pops/pillar-sdk/react';
 
 type ListRejectedOutput = inferRouterOutputs<AppRouter>['food']['inbox']['listRejected'];

--- a/packages/app-food/src/pages/plan/PlanEntryEditSheet.tsx
+++ b/packages/app-food/src/pages/plan/PlanEntryEditSheet.tsx
@@ -18,7 +18,7 @@ import { usePlanEntryEdit } from './usePlanEntryEdit.js';
 
 import type { inferRouterOutputs } from '@trpc/server';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 import type { WirePlanEntryRow } from '@pops/app-food-db';
 
 type PlanWeekViewOutput = inferRouterOutputs<AppRouter>['food']['plan']['weekView'];

--- a/packages/app-food/src/pages/plan/SlotManagementDrawer.tsx
+++ b/packages/app-food/src/pages/plan/SlotManagementDrawer.tsx
@@ -15,7 +15,7 @@ import { SlotRow } from './SlotRow.js';
 
 import type { inferRouterInputs, inferRouterOutputs } from '@trpc/server';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 
 type PlanListSlotsOutput = inferRouterOutputs<AppRouter>['food']['plan']['listSlots'];
 type PlanUpdateSlotInput = inferRouterInputs<AppRouter>['food']['plan']['updateSlot'];

--- a/packages/app-food/src/pages/plan/useAddPlanEntry.ts
+++ b/packages/app-food/src/pages/plan/useAddPlanEntry.ts
@@ -8,7 +8,7 @@ import { usePillarMutation, usePillarQuery, usePillarUtils } from '@pops/pillar-
 
 import type { inferRouterInputs, inferRouterOutputs } from '@trpc/server';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 
 type RecipesListOutput = inferRouterOutputs<AppRouter>['food']['recipes']['list'];
 type PlanAddEntryInput = inferRouterInputs<AppRouter>['food']['plan']['addEntry'];

--- a/packages/app-food/src/pages/plan/usePlanDnd.ts
+++ b/packages/app-food/src/pages/plan/usePlanDnd.ts
@@ -23,7 +23,7 @@ import { resolveGridDrop } from './plan-grid-dnd.js';
 
 import type { inferRouterInputs, inferRouterOutputs } from '@trpc/server';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 import type { WirePlanEntryRow } from '@pops/app-food-db';
 
 type PlanMoveEntryInput = inferRouterInputs<AppRouter>['food']['plan']['moveEntry'];

--- a/packages/app-food/src/pages/plan/usePlanEntryEdit.ts
+++ b/packages/app-food/src/pages/plan/usePlanEntryEdit.ts
@@ -8,7 +8,7 @@ import { usePillarMutation, usePillarUtils } from '@pops/pillar-sdk/react';
 
 import type { inferRouterInputs, inferRouterOutputs } from '@trpc/server';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 
 type PlanUpdateEntryInput = inferRouterInputs<AppRouter>['food']['plan']['updateEntry'];
 type PlanUpdateEntryOutput = inferRouterOutputs<AppRouter>['food']['plan']['updateEntry'];

--- a/packages/app-food/src/pages/plan/usePlanPage.ts
+++ b/packages/app-food/src/pages/plan/usePlanPage.ts
@@ -12,7 +12,7 @@ import { BadClientDateError, toIsoMonday } from './iso-week.js';
 
 import type { inferRouterInputs, inferRouterOutputs } from '@trpc/server';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 
 type PlanWeekViewOutput = inferRouterOutputs<AppRouter>['food']['plan']['weekView'];
 type PlanListSlotsOutput = inferRouterOutputs<AppRouter>['food']['plan']['listSlots'];

--- a/packages/app-food/src/pages/recipes/DraftRowCard.tsx
+++ b/packages/app-food/src/pages/recipes/DraftRowCard.tsx
@@ -7,7 +7,7 @@ import { Button } from '@pops/ui';
 
 import type { inferRouterInputs, inferRouterOutputs } from '@trpc/server';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 
 type PromoteInput = inferRouterInputs<AppRouter>['food']['recipes']['promote'];
 type PromoteOutput = inferRouterOutputs<AppRouter>['food']['recipes']['promote'];

--- a/packages/app-food/src/pages/recipes/RecipeDetailPage.tsx
+++ b/packages/app-food/src/pages/recipes/RecipeDetailPage.tsx
@@ -9,7 +9,7 @@ import { RecipeRenderer } from '../../components/RecipeRenderer.js';
 
 import type { inferRouterInputs, inferRouterOutputs } from '@trpc/server';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 
 type ArchiveRecipeInput = inferRouterInputs<AppRouter>['food']['recipes']['archiveRecipe'];
 type ArchiveRecipeOutput = inferRouterOutputs<AppRouter>['food']['recipes']['archiveRecipe'];

--- a/packages/app-food/src/pages/recipes/RecipeDraftEditPage.tsx
+++ b/packages/app-food/src/pages/recipes/RecipeDraftEditPage.tsx
@@ -9,7 +9,7 @@ import { RecipeEditShell } from './RecipeEditPage.js';
 
 import type { inferRouterOutputs } from '@trpc/server';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 
 type ListDraftsOutput = inferRouterOutputs<AppRouter>['food']['recipes']['listDrafts'];
 

--- a/packages/app-food/src/pages/recipes/RecipeDraftsPage.tsx
+++ b/packages/app-food/src/pages/recipes/RecipeDraftsPage.tsx
@@ -10,7 +10,7 @@ import { DraftRowCard } from './DraftRowCard.js';
 
 import type { inferRouterOutputs } from '@trpc/server';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 
 type ListDraftsOutput = inferRouterOutputs<AppRouter>['food']['recipes']['listDrafts'];
 

--- a/packages/app-food/src/pages/recipes/RecipeEditPage.tsx
+++ b/packages/app-food/src/pages/recipes/RecipeEditPage.tsx
@@ -14,7 +14,7 @@ import { useRecipeEditMutations } from './useRecipeEditMutations.js';
 
 import type { inferRouterInputs, inferRouterOutputs } from '@trpc/server';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 import type { CompileResult } from '@pops/app-food-db';
 
 type GetForRenderingOutput = inferRouterOutputs<AppRouter>['food']['recipes']['getForRendering'];

--- a/packages/app-food/src/pages/recipes/RecipeNewPage.tsx
+++ b/packages/app-food/src/pages/recipes/RecipeNewPage.tsx
@@ -10,7 +10,7 @@ import { DslEditor } from '../../components/DslEditor.js';
 
 import type { inferRouterInputs, inferRouterOutputs } from '@trpc/server';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 
 import type { CompileEditorIssue } from '../../components/dsl-editor/issues-types.js';
 

--- a/packages/app-food/src/pages/recipes/RecipeVersionDetailPage.tsx
+++ b/packages/app-food/src/pages/recipes/RecipeVersionDetailPage.tsx
@@ -9,7 +9,7 @@ import { RecipeRenderer } from '../../components/RecipeRenderer.js';
 
 import type { inferRouterInputs, inferRouterOutputs } from '@trpc/server';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 import type { RecipeVersionWithCompiledData } from '@pops/app-food-db';
 
 type RecipeVersionRow = RecipeVersionWithCompiledData['version'];

--- a/packages/app-food/src/pages/recipes/__tests__/RecipeDetailPage.test.tsx
+++ b/packages/app-food/src/pages/recipes/__tests__/RecipeDetailPage.test.tsx
@@ -17,28 +17,6 @@ let mockArchivePending = false;
 let mockArchiveOnSuccess: (() => void) | undefined;
 let mockArchiveOnError: ((err: Error) => void) | undefined;
 
-const idleQuery = {
-  isLoading: false as const,
-  data: undefined,
-  error: null,
-  refetch: vi.fn(),
-};
-
-vi.mock('@pops/api-client', () => ({
-  trpc: {
-    food: {
-      recipes: {
-        prepareSendToList: { useQuery: () => idleQuery },
-      },
-    },
-    lists: {
-      list: {
-        list: { useQuery: () => idleQuery },
-      },
-    },
-  },
-}));
-
 vi.mock('@pops/pillar-sdk/react', () => ({
   usePillarQuery: (_pillarId: string, path: readonly string[], input: unknown) => {
     const key = path.join('.');

--- a/packages/app-food/src/pages/recipes/send-to-list/__tests__/SendToListModal.test.tsx
+++ b/packages/app-food/src/pages/recipes/send-to-list/__tests__/SendToListModal.test.tsx
@@ -1,7 +1,7 @@
 /**
  * PRD-142 — RTL coverage for the send-to-list modal.
  *
- * Mocks `@pops/api-client` so the prepare query, lists query, and send
+ * Mocks `@pops/pillar-sdk` so the prepare query, lists query, and send
  * mutation are all controllable per test. Covers the modal contract: the
  * preview, picker (existing vs new), submit-disabled rules, success +
  * error paths, and the close-mid-flight non-cancellation behaviour.

--- a/packages/app-food/src/pages/recipes/send-to-list/useSendToListData.ts
+++ b/packages/app-food/src/pages/recipes/send-to-list/useSendToListData.ts
@@ -10,7 +10,7 @@ import { usePillarQuery } from '@pops/pillar-sdk/react';
 
 import type { inferRouterOutputs } from '@trpc/server';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 
 export type PrepareOutput = inferRouterOutputs<AppRouter>['food']['recipes']['prepareSendToList'];
 type ListsListOutput = inferRouterOutputs<AppRouter>['lists']['list']['list'];

--- a/packages/app-food/src/pages/recipes/send-to-list/useSendToListMutation.ts
+++ b/packages/app-food/src/pages/recipes/send-to-list/useSendToListMutation.ts
@@ -13,7 +13,7 @@ import { usePillarMutation } from '@pops/pillar-sdk/react';
 import type { inferRouterInputs, inferRouterOutputs } from '@trpc/server';
 import type { TFunction } from 'i18next';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 
 import type { SendError } from './types.js';
 

--- a/packages/app-food/src/pages/recipes/useRecipeDetailData.ts
+++ b/packages/app-food/src/pages/recipes/useRecipeDetailData.ts
@@ -2,7 +2,7 @@ import { usePillarQuery } from '@pops/pillar-sdk/react';
 
 import type { inferRouterOutputs } from '@trpc/server';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 import type { RecipeVersionWithCompiledData } from '@pops/app-food-db';
 
 type GetForRenderingOutput = inferRouterOutputs<AppRouter>['food']['recipes']['getForRendering'];

--- a/packages/app-food/src/pages/recipes/useRecipeEditMutations.ts
+++ b/packages/app-food/src/pages/recipes/useRecipeEditMutations.ts
@@ -7,7 +7,7 @@ import { usePillarMutation, usePillarUtils } from '@pops/pillar-sdk/react';
 
 import type { inferRouterInputs, inferRouterOutputs } from '@trpc/server';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 import type { CompileResult } from '@pops/app-food-db';
 
 type SaveDraftInput = inferRouterInputs<AppRouter>['food']['recipes']['saveDraft'];

--- a/packages/app-food/src/pages/recipes/useRecipeListQuery.ts
+++ b/packages/app-food/src/pages/recipes/useRecipeListQuery.ts
@@ -4,7 +4,7 @@ import { usePillarInfiniteQuery } from '@pops/pillar-sdk/react';
 
 import type { inferRouterOutputs } from '@trpc/server';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 
 import type { RecipeListFilterState, RecipeType } from './recipe-list-types.js';
 

--- a/packages/app-food/src/pages/shopping/types.ts
+++ b/packages/app-food/src/pages/shopping/types.ts
@@ -5,7 +5,7 @@ import type { inferRouterOutputs } from '@trpc/server';
  * inferred router outputs so they always stay in lockstep with the
  * `food.shopping.*` procedures (PRD-152).
  */
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 
 type ShoppingOutputs = inferRouterOutputs<AppRouter>['food']['shopping'];
 

--- a/packages/app-food/src/pages/shopping/useFromPlanPage.ts
+++ b/packages/app-food/src/pages/shopping/useFromPlanPage.ts
@@ -14,7 +14,7 @@ import { validateRange } from './range-helpers.js';
 
 import type { inferRouterInputs, inferRouterOutputs } from '@trpc/server';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 
 type PreviewFromPlanOutput = inferRouterOutputs<AppRouter>['food']['shopping']['previewFromPlan'];
 type GenerateFromPlanInput = inferRouterInputs<AppRouter>['food']['shopping']['generateFromPlan'];

--- a/packages/app-food/src/pages/solve/useSolveResult.ts
+++ b/packages/app-food/src/pages/solve/useSolveResult.ts
@@ -10,7 +10,7 @@ import { usePillarQuery } from '@pops/pillar-sdk/react';
 
 import type { inferRouterOutputs } from '@trpc/server';
 
-import type { AppRouter } from '@pops/api-client';
+import type { AppRouter } from '@pops/api';
 
 type CanICookOutput = inferRouterOutputs<AppRouter>['food']['solver']['canICook'];
 

--- a/packages/app-food/src/routes.tsx
+++ b/packages/app-food/src/routes.tsx
@@ -7,7 +7,7 @@ import type { RouteObject } from 'react-router';
  * Local mirror of the shell's `IconName` union. The shell owns the canonical
  * vocabulary in `@pops/navigation/src/types.ts`; this copy is kept in sync
  * because depending on `@pops/navigation` would re-introduce a build cycle
- * with `@pops/api` via `@pops/api-client`. If a new icon ships in
+ * with `@pops/api`. If a new icon ships in
  * `@pops/navigation`, mirror it here when this package needs to reference it.
  */
 type IconName =

--- a/packages/app-food/vitest.config.ts
+++ b/packages/app-food/vitest.config.ts
@@ -8,10 +8,8 @@ export default defineConfig({
     setupFiles: ['./src/test-setup.ts'],
     // Force forked child processes per test file so vi.mock factories
     // don't leak across files. Required because multiple test suites
-    // mock `@pops/api-client` with different shapes (HeroImageUploader
-    // mocks only `food.heroImage`; IngredientsTab mocks `food.ingredients`)
-    // and the default worker-thread pool was leaking lazy-import
-    // module state across runs.
+    // mock `@pops/pillar-sdk` with different shapes and the default
+    // worker-thread pool was leaking lazy-import module state across runs.
     pool: 'forks',
     coverage: {
       provider: 'v8',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1314,9 +1314,9 @@ importers:
       '@lezer/lr':
         specifier: ^1.4.10
         version: 1.4.10
-      '@pops/api-client':
+      '@pops/api':
         specifier: workspace:*
-        version: link:../api-client
+        version: link:../../apps/pops-api
       '@pops/app-food-db':
         specifier: workspace:*
         version: link:../app-food-db


### PR DESCRIPTION
## Summary

Drops `@pops/api-client` from `packages/app-food/`, executing the migration plan from the PR #3201 audit in a single PR (the audit had scoped 4 sequential slices, but since every residual reference was either an `import type { AppRouter }` or a comment, there was no behavioural risk to landing them together).

Per the audit:

- **67 / 78** files were identical `import type { AppRouter } from '@pops/api-client'` lines, used only to derive `inferRouterOutputs<AppRouter>['food'][…]` types. Re-sourced from `@pops/api`, which `@pops/api-client` itself re-exports (`packages/api-client/src/index.ts:96`).
- **11 / 78** files had comment-only references: 10 stale docstrings (test headers + `vitest.config.ts` pool-forks rationale + `routes.tsx` build-cycle note) and 1 stale `vi.mock('@pops/api-client', …)` block in `RecipeDetailPage.test.tsx` already shadowed by a pillar-sdk mock.
- **0** runtime callsites. **0** helper re-exports.

After this PR, `packages/app-food/package.json` no longer depends on `@pops/api-client`, closing the food-app's leg of the PRD-227 consumer migration.

## Changes

- Replaced `@pops/api-client` with `@pops/api` in 67 `import type { AppRouter }` sites under `packages/app-food/src/`.
- Removed the stale `vi.mock('@pops/api-client', …)` block + its orphan `idleQuery` helper from `pages/recipes/__tests__/RecipeDetailPage.test.tsx`.
- Updated 11 docstring references to point at the now-relevant module (`@pops/pillar-sdk` for test mocks; `@pops/api` for the routes build-cycle note).
- Swapped `@pops/api-client` for `@pops/api` in `packages/app-food/package.json` dependencies.

## Test plan

- [x] `pnpm install` — lockfile updated cleanly, `@pops/api-client` no longer linked into `packages/app-food/node_modules/@pops/`
- [x] `pnpm --filter @pops/app-food test` — **638 / 638** passing (parity with pre-PR)
- [x] `pnpm typecheck` — clean across all 71 packages
- [x] `grep -rn '@pops/api-client' packages/app-food/` — empty
- [x] husky pre-commit (oxlint + oxfmt) passed without `--no-verify`
