### PR TITLE
fix(cerebrum/glia): toml-config test mocks (mirror #3194/#3202/#3203 silent-failure pattern)

### DIFF
--- a/apps/pops-api/src/modules/cerebrum/glia/__tests__/toml-config.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/glia/__tests__/toml-config.test.ts
@@ -20,7 +20,9 @@ import { join } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { closeDb, setDb } from '../../../../db.js';
+import { openCoreDb, type OpenedCoreDb } from '@pops/core-db';
+
+import { closeDb, setCoreDb, setDb } from '../../../../db.js';
 import { createTestDb } from '../../../../shared/test-utils.js';
 import { setRawSetting } from '../../../core/settings/service.js';
 import { resetCerebrumCache } from '../../instance.js';
@@ -292,6 +294,7 @@ propose_to_act_report_min_approved = 99
 describe('getGliaThresholds precedence', () => {
   let root: string;
   let db: Database;
+  let coreHandle: OpenedCoreDb | null = null;
   let originalEnv: string | undefined;
 
   beforeEach(() => {
@@ -302,9 +305,14 @@ describe('getGliaThresholds precedence', () => {
     resetGliaTomlCache();
     db = createTestDb();
     setDb(db);
+    coreHandle = openCoreDb(':memory:');
+    setCoreDb(coreHandle);
   });
 
   afterEach(() => {
+    setCoreDb(null);
+    coreHandle?.raw.close();
+    coreHandle = null;
     closeDb();
     rmSync(root, { recursive: true, force: true });
     if (originalEnv === undefined) delete process.env[ENV_KEY];


### PR DESCRIPTION
## Summary

Pre-existing stale-mock failure in `apps/pops-api/src/modules/cerebrum/glia/__tests__/toml-config.test.ts` on `origin/main`. Same shape as the three fixes that just landed:

- #3194 — corrections rule-generator: 5 silent failures masked behind 16 null-expected tests
- #3202 — finance ai-categorizer: 22 failures hidden behind 14 passes
- #3203 — finance ai-categorizer-disk: 3 failures hidden behind 1 pass

This PR closes the set for cerebrum/glia.

## Failure count

**1 test** — `getGliaThresholds precedence > returns hardcoded defaults when neither toml nor settings DB exist`. Latent on first execution against a clean checkout because the leak only manifests once `data/core.db` has been touched. Reproduces reliably on the second run, on CI runners that cache `data/`, and under `--reporter=verbose` (which forces a deterministic order that exposes the leak from `falls back to settings DB`).

## Root cause

`getGliaThresholds()` reads via `getSettingValue(...)` → `settingsService.getSettingValue(getCoreDrizzle(), ...)`. After PRD-186 PR3 the settings traffic routes through the **core pillar handle**, not the shared `pops.db`. The test only swapped the shared handle via `setDb()`, so `getCoreDrizzle()` lazily opened the real on-disk `apps/pops-api/data/core.db`. The `falls back to settings DB` test wrote `cerebrum.glia.proposeMinApproved=42` and `cerebrum.glia.demotionWindowDays=21` to that file via `setRawSetting`; on the next test (or the next process), `returns hardcoded defaults...` saw those rows and asserted `42` / `21` instead of the ADR-021 defaults `20` / `7`.

## Fix (mock-only — no production change)

Mirror the pattern from `apps/pops-api/src/modules/food/__tests__/ai-router.test.ts` and the cutover precedent in #3203: open an in-memory core handle per test.

```diff
+import { openCoreDb, type OpenedCoreDb } from '@pops/core-db';
+
-import { closeDb, setDb } from '../../../../db.js';
+import { closeDb, setCoreDb, setDb } from '../../../../db.js';
 ...
+let coreHandle: OpenedCoreDb | null = null;
 beforeEach(() => {
   ...
   setDb(db);
+  coreHandle = openCoreDb(':memory:');
+  setCoreDb(coreHandle);
 });

 afterEach(() => {
+  setCoreDb(null);
+  coreHandle?.raw.close();
+  coreHandle = null;
   closeDb();
   ...
 });
```

## Test plan

- [x] `pnpm --filter @pops/api test src/modules/cerebrum/glia/__tests__/toml-config.test.ts` — 18/18 pass
- [x] Re-run with `--reporter=verbose --sequence.shuffle.tests=false` — still 18/18 pass (was 1/18 fail before)
- [x] Re-run twice with `data/core.db` retained between runs — still 18/18 (regression-proof against the dirty-file path)
- [x] `pnpm --filter @pops/api typecheck` clean
- [x] `pnpm --filter @pops/api test --run` — only pre-existing flake in `cerebrum/thalamus/watcher.test.ts` (unrelated FS-watch race; passes in isolation)