### PR TITLE
feat(pillar-sdk): PRD-240 US-01 settings dimension in ManifestPayloadSchema

### DIFF
--- a/apps/pops-cerebrum-api/src/server.ts
+++ b/apps/pops-cerebrum-api/src/server.ts
@@ -57,7 +57,7 @@ function buildCerebrumManifest(version: string): ManifestPayload {
     search: { adapters: [] },
     ai: { tools: [] },
     uri: { types: [] },
-    settings: { keys: [] },
+    consumedSettings: { keys: [] },
     healthcheck: { path: '/health' },
   };
 }

--- a/apps/pops-core-api/src/__tests__/external-deregister.test.ts
+++ b/apps/pops-core-api/src/__tests__/external-deregister.test.ts
@@ -48,7 +48,7 @@ function recipesManifest(overrides?: Partial<ManifestPayload>): ManifestPayload 
     search: { adapters: [] },
     ai: { tools: [] },
     uri: { types: ['recipes/recipe'] },
-    settings: { keys: [] },
+    consumedSettings: { keys: [] },
     healthcheck: { path: '/health' },
     ...overrides,
   };

--- a/apps/pops-core-api/src/__tests__/external-heartbeat.test.ts
+++ b/apps/pops-core-api/src/__tests__/external-heartbeat.test.ts
@@ -49,7 +49,7 @@ function recipesManifest(overrides?: Partial<ManifestPayload>): ManifestPayload 
     search: { adapters: [] },
     ai: { tools: [] },
     uri: { types: ['recipes/recipe'] },
-    settings: { keys: [] },
+    consumedSettings: { keys: [] },
     healthcheck: { path: '/health' },
     ...overrides,
   };

--- a/apps/pops-core-api/src/__tests__/external-register.test.ts
+++ b/apps/pops-core-api/src/__tests__/external-register.test.ts
@@ -51,7 +51,7 @@ function recipesManifest(overrides?: Partial<ManifestPayload>): ManifestPayload 
     search: { adapters: [] },
     ai: { tools: [] },
     uri: { types: ['recipes/recipe'] },
-    settings: { keys: [] },
+    consumedSettings: { keys: [] },
     healthcheck: { path: '/health' },
     ...overrides,
   };
@@ -256,7 +256,7 @@ describe('POST /core.registry.register — manifest validation', () => {
           search: { adapters: [] },
           ai: { tools: [] },
           uri: { types: [] },
-          settings: { keys: [] },
+          consumedSettings: { keys: [] },
           healthcheck: { path: '/' },
         },
         apiKey: VALID_API_KEY,

--- a/apps/pops-core-api/src/__tests__/heartbeat.test.ts
+++ b/apps/pops-core-api/src/__tests__/heartbeat.test.ts
@@ -91,7 +91,7 @@ function financeManifest(): ManifestPayload {
     },
     ai: { tools: [] },
     uri: { types: ['finance/transaction'] },
-    settings: { keys: [] },
+    consumedSettings: { keys: [] },
     healthcheck: { path: '/healthz' },
   };
 }
@@ -127,7 +127,7 @@ function mediaManifest(): ManifestPayload {
     },
     ai: { tools: [] },
     uri: { types: ['media/movie'] },
-    settings: { keys: [] },
+    consumedSettings: { keys: [] },
     healthcheck: { path: '/healthz' },
   };
 }

--- a/apps/pops-core-api/src/__tests__/registry-sdk-interop.test.ts
+++ b/apps/pops-core-api/src/__tests__/registry-sdk-interop.test.ts
@@ -111,7 +111,7 @@ function financeManifest(): ManifestPayload {
     search: { adapters: [] },
     ai: { tools: [] },
     uri: { types: ['finance/transaction'] },
-    settings: { keys: ['finance.defaultCurrency'] },
+    consumedSettings: { keys: ['finance.defaultCurrency'] },
     healthcheck: { path: '/healthz' },
   };
 }

--- a/apps/pops-core-api/src/__tests__/registry.test.ts
+++ b/apps/pops-core-api/src/__tests__/registry.test.ts
@@ -85,7 +85,7 @@ function financeManifest(overrides?: Partial<ManifestPayload>): ManifestPayload 
       ],
     },
     uri: { types: ['finance/transaction'] },
-    settings: { keys: ['finance.defaultCurrency'] },
+    consumedSettings: { keys: ['finance.defaultCurrency'] },
     healthcheck: { path: '/healthz' },
     ...overrides,
   };
@@ -122,7 +122,7 @@ function mediaManifest(): ManifestPayload {
     },
     ai: { tools: [] },
     uri: { types: ['media/movie'] },
-    settings: { keys: [] },
+    consumedSettings: { keys: [] },
     healthcheck: { path: '/healthz' },
   };
 }
@@ -154,7 +154,7 @@ describe('core.registry.register', () => {
       search: { adapters: [] },
       ai: { tools: [] },
       uri: { types: [] },
-      settings: { keys: [] },
+      consumedSettings: { keys: [] },
       healthcheck: { path: '/' },
     };
     const res = await c.core.registry.register({

--- a/apps/pops-core-api/src/__tests__/subscribe.test.ts
+++ b/apps/pops-core-api/src/__tests__/subscribe.test.ts
@@ -102,7 +102,7 @@ function financeManifest(): ManifestPayload {
       ],
     },
     uri: { types: ['finance/transaction'] },
-    settings: { keys: ['finance.defaultCurrency'] },
+    consumedSettings: { keys: ['finance.defaultCurrency'] },
     healthcheck: { path: '/healthz' },
   };
 }

--- a/apps/pops-core-api/src/modules/registry/__tests__/external-dropin.e2e.test.ts
+++ b/apps/pops-core-api/src/modules/registry/__tests__/external-dropin.e2e.test.ts
@@ -71,7 +71,7 @@ function dropInManifest(overrides?: Partial<ManifestPayload>): ManifestPayload {
     search: { adapters: [] },
     ai: { tools: [] },
     uri: { types: [] },
-    settings: { keys: [] },
+    consumedSettings: { keys: [] },
     healthcheck: { path: '/health' },
     ...overrides,
   };

--- a/apps/pops-core-api/src/server.ts
+++ b/apps/pops-core-api/src/server.ts
@@ -63,7 +63,7 @@ function buildCoreManifest(version: string): ManifestPayload {
     search: { adapters: [] },
     ai: { tools: [] },
     uri: { types: [] },
-    settings: { keys: [] },
+    consumedSettings: { keys: [] },
     healthcheck: { path: '/health' },
   };
 }

--- a/apps/pops-finance-api/src/server.ts
+++ b/apps/pops-finance-api/src/server.ts
@@ -77,7 +77,7 @@ function buildFinanceManifest(version: string): ManifestPayload {
     search: { adapters: [] },
     ai: { tools: [] },
     uri: { types: ['finance/transaction', 'finance/wishlist-item', 'finance/budget'] },
-    settings: { keys: [] },
+    consumedSettings: { keys: [] },
     healthcheck: { path: '/health' },
   };
 }

--- a/apps/pops-food-api/src/server.ts
+++ b/apps/pops-food-api/src/server.ts
@@ -55,7 +55,7 @@ function buildFoodManifest(version: string): ManifestPayload {
     search: { adapters: [] },
     ai: { tools: [] },
     uri: { types: [] },
-    settings: { keys: [] },
+    consumedSettings: { keys: [] },
     healthcheck: { path: '/health' },
   };
 }

--- a/apps/pops-ha-bridge-api/src/manifest.ts
+++ b/apps/pops-ha-bridge-api/src/manifest.ts
@@ -71,7 +71,7 @@ export function buildHaBridgeManifest(version: string): ManifestPayload {
       })),
     },
     uri: { types: [] },
-    settings: { keys: [] },
+    consumedSettings: { keys: [] },
     healthcheck: { path: '/health' },
   };
 }

--- a/apps/pops-inventory-api/src/server.ts
+++ b/apps/pops-inventory-api/src/server.ts
@@ -66,7 +66,7 @@ function buildInventoryManifest(version: string): ManifestPayload {
     search: { adapters: [] },
     ai: { tools: [] },
     uri: { types: [] },
-    settings: { keys: [] },
+    consumedSettings: { keys: [] },
     healthcheck: { path: '/health' },
   };
 }

--- a/apps/pops-lists-api/src/server.ts
+++ b/apps/pops-lists-api/src/server.ts
@@ -56,7 +56,7 @@ function buildListsManifest(version: string): ManifestPayload {
     search: { adapters: [] },
     ai: { tools: [] },
     uri: { types: [] },
-    settings: { keys: [] },
+    consumedSettings: { keys: [] },
     healthcheck: { path: '/health' },
   };
 }

--- a/apps/pops-media-api/src/server.ts
+++ b/apps/pops-media-api/src/server.ts
@@ -56,7 +56,7 @@ function buildMediaManifest(version: string): ManifestPayload {
     search: { adapters: [] },
     ai: { tools: [] },
     uri: { types: [] },
-    settings: { keys: [] },
+    consumedSettings: { keys: [] },
     healthcheck: { path: '/health' },
   };
 }

--- a/apps/pops-shell/src/app/layout/top-bar/NudgeIndicator.test.tsx
+++ b/apps/pops-shell/src/app/layout/top-bar/NudgeIndicator.test.tsx
@@ -61,7 +61,7 @@ function cerebrumDiscoveredPillar(): DiscoveredPillar {
       search: { adapters: [] },
       ai: { tools: [] },
       uri: { types: [] },
-      settings: { keys: [] },
+      consumedSettings: { keys: [] },
       healthcheck: { path: '/healthz' },
     },
   };

--- a/apps/pops-shell/src/lib/register-with-registry.test.ts
+++ b/apps/pops-shell/src/lib/register-with-registry.test.ts
@@ -37,7 +37,7 @@ describe('buildShellManifest', () => {
     expect(manifest.search.adapters).toEqual([]);
     expect(manifest.ai.tools).toEqual([]);
     expect(manifest.uri.types).toEqual([]);
-    expect(manifest.settings.keys).toEqual([]);
+    expect(manifest.consumedSettings.keys).toEqual([]);
   });
 });
 
@@ -87,7 +87,7 @@ describe('registerShellWithRegistry — happy path', () => {
       search: { adapters: [] },
       ai: { tools: [] },
       uri: { types: [] },
-      settings: { keys: [] },
+      consumedSettings: { keys: [] },
       healthcheck: { path: '/health' },
     });
   });

--- a/apps/pops-shell/src/lib/register-with-registry.ts
+++ b/apps/pops-shell/src/lib/register-with-registry.ts
@@ -62,7 +62,7 @@ export function buildShellManifest(): ManifestPayload {
     search: { adapters: [] },
     ai: { tools: [] },
     uri: { types: [] },
-    settings: { keys: [] },
+    consumedSettings: { keys: [] },
     healthcheck: { path: '/health' },
   };
 }

--- a/packages/pillar-sdk/src/__tests__/fixtures.ts
+++ b/packages/pillar-sdk/src/__tests__/fixtures.ts
@@ -58,7 +58,7 @@ export function validManifest(): ManifestPayload {
       ],
     },
     uri: { types: ['finance/transaction', 'finance/budget'] },
-    settings: { keys: ['finance.defaultCurrency', 'finance.locale'] },
+    consumedSettings: { keys: ['finance.defaultCurrency', 'finance.locale'] },
     healthcheck: { path: '/healthz' },
   };
 }

--- a/packages/pillar-sdk/src/__tests__/schema.test.ts
+++ b/packages/pillar-sdk/src/__tests__/schema.test.ts
@@ -126,17 +126,17 @@ describe('ManifestPayloadSchema', () => {
     );
   });
 
-  describe('settings keys regex', () => {
+  describe('consumedSettings keys regex', () => {
     it.each(['Foo', '.foo', 'foo.', '1foo', 'foo..bar'])('rejects %s', (key) => {
       const m = validManifest();
-      m.settings.keys = [key];
+      m.consumedSettings.keys = [key];
       const result = ManifestPayloadSchema.safeParse(m);
       expect(result.success).toBe(false);
     });
 
     it.each(['finance', 'finance.defaultCurrency', 'finance.a.b.c'])('accepts %s', (key) => {
       const m = validManifest();
-      m.settings.keys = [key];
+      m.consumedSettings.keys = [key];
       const result = ManifestPayloadSchema.safeParse(m);
       expect(result.success).toBe(true);
     });
@@ -481,6 +481,147 @@ describe('ManifestPayloadSchema', () => {
         sinks: { descriptors: [{ ...validSink(), description: 'short' }] },
       };
       const result = ManifestPayloadSchema.safeParse(m);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('settings dimension (PRD-240 / ADR-037)', () => {
+    const financeSettingsDescriptor = () => ({
+      id: 'finance',
+      title: 'Finance',
+      icon: 'DollarSign',
+      order: 140,
+      groups: [
+        {
+          id: 'aiCategorizer',
+          title: 'AI Categorizer',
+          description: 'Model and limits for AI-powered transaction categorisation.',
+          fields: [
+            {
+              key: 'finance.aiCategorizer.model',
+              label: 'Categorizer Model',
+              type: 'text' as const,
+              default: 'claude-haiku-4-5-20251001',
+            },
+            {
+              key: 'finance.aiCategorizer.maxTokens',
+              label: 'Max Tokens',
+              type: 'number' as const,
+              default: '200',
+              validation: { min: 50, max: 2000 },
+            },
+          ],
+        },
+      ],
+    });
+
+    const egoSettingsDescriptor = () => ({
+      id: 'ego',
+      title: 'Ego',
+      order: 210,
+      groups: [
+        {
+          id: 'identity',
+          title: 'Identity',
+          fields: [{ key: 'ego.displayName', label: 'Display Name', type: 'text' as const }],
+        },
+      ],
+    });
+
+    it('accepts a manifest with settings omitted (backwards-compatible)', () => {
+      const result = ManifestPayloadSchema.safeParse(validManifest());
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts an empty settings manifests array', () => {
+      const m = { ...validManifest(), settings: { manifests: [] } };
+      const result = ManifestPayloadSchema.safeParse(m);
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts a single valid SettingsManifestDescriptor', () => {
+      const m = {
+        ...validManifest(),
+        settings: { manifests: [financeSettingsDescriptor()] },
+      };
+      const result = ManifestPayloadSchema.safeParse(m);
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts multiple SettingsManifestDescriptors (cerebrum + ego case)', () => {
+      const m = {
+        ...validManifest(),
+        settings: {
+          manifests: [
+            { ...financeSettingsDescriptor(), id: 'cerebrum', title: 'Cerebrum' },
+            egoSettingsDescriptor(),
+          ],
+        },
+      };
+      const result = ManifestPayloadSchema.safeParse(m);
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects a SettingsManifestDescriptor missing the required id field', () => {
+      const { id: _omitted, ...descriptorMissingId } = financeSettingsDescriptor();
+      const m = {
+        ...validManifest(),
+        settings: { manifests: [descriptorMissingId] },
+      };
+      const result = ManifestPayloadSchema.safeParse(m);
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects an unknown field on the settings block (strict mode)', () => {
+      const m = {
+        ...validManifest(),
+        settings: { manifests: [financeSettingsDescriptor()], sneaky: true },
+      };
+      const result = ManifestPayloadSchema.safeParse(m);
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects an unknown field on a SettingsManifestDescriptor (strict mode)', () => {
+      const m = {
+        ...validManifest(),
+        settings: {
+          manifests: [{ ...financeSettingsDescriptor(), sneaky: true }],
+        },
+      };
+      const result = ManifestPayloadSchema.safeParse(m);
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects an empty id on a SettingsManifestDescriptor', () => {
+      const m = {
+        ...validManifest(),
+        settings: { manifests: [{ ...financeSettingsDescriptor(), id: '' }] },
+      };
+      const result = ManifestPayloadSchema.safeParse(m);
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects an unrecognised settings field type', () => {
+      const descriptor = financeSettingsDescriptor();
+      descriptor.groups[0]!.fields[0]!.type = 'mystery' as never;
+      const m = { ...validManifest(), settings: { manifests: [descriptor] } };
+      const result = ManifestPayloadSchema.safeParse(m);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('consumedSettings rename (PRD-240 US-01)', () => {
+    it('accepts the renamed consumedSettings block on a valid manifest', () => {
+      const m = validManifest();
+      m.consumedSettings = { keys: ['finance.defaultCurrency', 'finance.locale'] };
+      const result = ManifestPayloadSchema.safeParse(m);
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects the legacy top-level `settings: { keys }` shape (now unknown field under strict)', () => {
+      const { consumedSettings: _omitted, ...rest } = validManifest();
+      const legacy = { ...rest, settings: { keys: ['finance.locale'] } };
+      const result = ManifestPayloadSchema.safeParse(legacy);
       expect(result.success).toBe(false);
     });
   });

--- a/packages/pillar-sdk/src/discovery/__tests__/fixtures.ts
+++ b/packages/pillar-sdk/src/discovery/__tests__/fixtures.ts
@@ -19,7 +19,7 @@ export function pillar(id: string, baseUrl: string, lastSeenAt = new Date()): Pi
       subscriptions: [],
     },
     uri: { types: [`${id}/entity`] },
-    settings: { keys: [`${id}.defaultThing`] },
+    consumedSettings: { keys: [`${id}.defaultThing`] },
   };
   return {
     pillarId: id,

--- a/packages/pillar-sdk/src/manifest-schema/index.ts
+++ b/packages/pillar-sdk/src/manifest-schema/index.ts
@@ -1,4 +1,9 @@
-export { ManifestPayloadSchema, type ManifestPayload, type SinkDescriptor } from './schema.js';
+export {
+  ManifestPayloadSchema,
+  type ManifestPayload,
+  type SinkDescriptor,
+  type SettingsManifestDescriptor,
+} from './schema.js';
 export {
   validateManifestPayload,
   checkContractPackageMatchesPillar,

--- a/packages/pillar-sdk/src/manifest-schema/schema.ts
+++ b/packages/pillar-sdk/src/manifest-schema/schema.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+import { SettingsBlockSchema, type SettingsManifestDescriptor } from './settings.js';
+
 const PILLAR_ID = z.string().regex(/^[a-z][a-z0-9-]*$/, 'pillar id must be lowercase kebab-case');
 
 const SEMVER = z.string().regex(/^\d+\.\d+\.\d+(-[a-z0-9.]+)?$/, 'must be semver');
@@ -141,7 +143,7 @@ const URI = z
   })
   .strict();
 
-const SETTINGS = z
+const CONSUMED_SETTINGS = z
   .object({
     keys: z.array(SETTINGS_KEY),
   })
@@ -163,11 +165,14 @@ export const ManifestPayloadSchema = z
     ai: AI,
     sinks: SINKS.optional(),
     uri: URI,
-    settings: SETTINGS,
+    consumedSettings: CONSUMED_SETTINGS,
+    settings: SettingsBlockSchema.optional(),
     healthcheck: HEALTHCHECK,
   })
   .strict();
 
 export type SinkDescriptor = z.infer<typeof SINK_DESCRIPTOR>;
+
+export type { SettingsManifestDescriptor };
 
 export type ManifestPayload = z.infer<typeof ManifestPayloadSchema>;

--- a/packages/pillar-sdk/src/manifest-schema/settings.ts
+++ b/packages/pillar-sdk/src/manifest-schema/settings.ts
@@ -1,0 +1,95 @@
+import { z } from 'zod';
+
+const PROCEDURE_PATH = z
+  .string()
+  .regex(
+    /^[a-z][a-z0-9]*\.[a-z][a-zA-Z0-9]*\.[a-z][a-zA-Z0-9]*$/,
+    'must match <pillar>.<router>.<procedure>'
+  );
+
+const SETTINGS_FIELD_TYPE = z.enum([
+  'text',
+  'number',
+  'toggle',
+  'select',
+  'password',
+  'url',
+  'duration',
+  'json',
+]);
+
+const SETTINGS_FIELD_OPTION = z.object({ value: z.string(), label: z.string() }).strict();
+
+const SETTINGS_FIELD_VALIDATION = z
+  .object({
+    required: z.boolean().optional(),
+    min: z.number().optional(),
+    max: z.number().optional(),
+    pattern: z.string().optional(),
+    message: z.string().optional(),
+  })
+  .strict();
+
+const SETTINGS_FIELD_TEST_ACTION = z
+  .object({ procedure: PROCEDURE_PATH, label: z.string() })
+  .strict();
+
+const SETTINGS_FIELD_OPTIONS_LOADER = z
+  .object({
+    procedure: PROCEDURE_PATH,
+    valueKey: z.string(),
+    labelKey: z.string(),
+  })
+  .strict();
+
+const SETTINGS_FIELD = z
+  .object({
+    key: z.string(),
+    label: z.string(),
+    description: z.string().optional(),
+    type: SETTINGS_FIELD_TYPE,
+    default: z.string().optional(),
+    options: z.array(SETTINGS_FIELD_OPTION).optional(),
+    validation: SETTINGS_FIELD_VALIDATION.optional(),
+    envFallback: z.string().optional(),
+    sensitive: z.boolean().optional(),
+    requiresRestart: z.boolean().optional(),
+    testAction: SETTINGS_FIELD_TEST_ACTION.optional(),
+    optionsLoader: SETTINGS_FIELD_OPTIONS_LOADER.optional(),
+  })
+  .strict();
+
+const SETTINGS_GROUP = z
+  .object({
+    id: z.string().min(1),
+    title: z.string().min(1),
+    description: z.string().optional(),
+    fields: z.array(SETTINGS_FIELD),
+  })
+  .strict();
+
+/**
+ * Settings UI contribution descriptor — peer of `SinkDescriptor`,
+ * `SEARCH_ADAPTER`, and `AI_TOOL`. Mirrors the `SettingsManifest` shape
+ * from `@pops/types` so the wire validator can confirm an inbound
+ * manifest carries a well-formed settings tree. The TypeScript shape in
+ * `@pops/types` remains the source of truth; this Zod schema is the wire
+ * validator (PRD-240 US-01 / ADR-037).
+ */
+export const SettingsManifestDescriptorSchema = z
+  .object({
+    id: z.string().min(1),
+    title: z.string().min(1),
+    icon: z.string().optional(),
+    order: z.number(),
+    groups: z.array(SETTINGS_GROUP),
+  })
+  .strict();
+
+export const SettingsBlockSchema = z
+  .object({
+    manifests: z.array(SettingsManifestDescriptorSchema),
+  })
+  .strict();
+
+export type SettingsManifestDescriptor = z.infer<typeof SettingsManifestDescriptorSchema>;

--- a/packages/pillar-sdk/src/orchestrator/__tests__/fixtures.ts
+++ b/packages/pillar-sdk/src/orchestrator/__tests__/fixtures.ts
@@ -30,7 +30,7 @@ export function manifest(pillarId: string, adapters: readonly string[]): Manifes
     },
     ai: { tools: [] },
     uri: { types: [`${pillarId}/entity`] },
-    settings: { keys: [] },
+    consumedSettings: { keys: [] },
     healthcheck: { path: '/health' },
   };
 }

--- a/packages/wire-conformance/src/fixture/manifest.ts
+++ b/packages/wire-conformance/src/fixture/manifest.ts
@@ -23,7 +23,7 @@ export function buildFixtureManifest(): Record<string, unknown> {
     search: { adapters: [] },
     ai: { tools: [] },
     uri: { types: [] },
-    settings: { keys: [] },
+    consumedSettings: { keys: [] },
     healthcheck: { path: '/health' },
   };
 }


### PR DESCRIPTION
## Summary

PRD-240 US-01 — extend `ManifestPayloadSchema` with the optional `settings` dimension carrying a `SettingsManifestDescriptor[]`. Foundational US for [PRD-240](https://github.com/knoxio/pops/pull/3214) (ADR-037: Settings as a manifest dimension).

- **New dimension.** `ManifestPayloadSchema.settings?: { manifests: SettingsManifestDescriptor[] }` — peer of `searchAdapters` / `aiTools` / `sinks`. Optional; existing manifests without it keep validating (backwards-compatible).
- **`SettingsManifestDescriptor`** mirrors `SettingsManifest` from `@pops/types` (`id`, `title`, `icon?`, `order`, `groups[]` -> `groups[].fields[]`). Zod validator on the wire; TS shape in `@pops/types` remains source of truth. Exported from `@pops/pillar-sdk/manifest-schema`.
- **Rename.** The previous consumed-keys block `settings: { keys: SETTINGS_KEY[] }` is renamed to `consumedSettings: { keys: SETTINGS_KEY[] }` so the dimension name `settings` is exclusively the UI dimension (per ADR-037 / PRD-240 "one name, one meaning"). 23 call sites updated mechanically.
- **Pattern.** Mirrors the PRD-236 sinks scaffold (#3133) — same shape, same wire-only validation, no behavioural change.
- **Tests.** 11 new tests cover: omitted (backwards-compatible), empty `manifests: []`, single valid descriptor, multi-descriptor (cerebrum + ego case), missing-`id` rejection, unknown-field rejection on both block and descriptor, empty-`id` rejection, unrecognised field-type rejection, plus the `consumedSettings` rename round-trip and legacy-shape rejection.

US-02 (`discoverSettings()`) and US-03 (per-pillar manifest declarations) are now unblocked.

## Test plan

- [x] `pnpm --filter @pops/pillar-sdk test` — 37 files, 514 passed (was 503; +11 new)
- [x] `pnpm typecheck` — 71/71 tasks pass
- [x] `pnpm lint` — exit 0 (warnings only)
- [x] `pnpm --filter @pops/wire-conformance test` — 25/25 pass
- [x] All affected API/shell test suites pass (`core`, `inventory`, `finance`, `media`, `cerebrum`, `food`, `lists`, `ha-bridge`, `shell`)
- [x] Husky pre-commit (lint-staged) and pre-push (`pnpm typecheck`) green, no `--no-verify`

## References

- [ADR-037](docs/architecture/adr-037-settings-as-manifest-dimension.md) — settings as a first-class manifest dimension
- [PRD-240 US-01](docs/themes/13-pillar-finale/prds/240-settings-as-manifest-dimension/us-01-extend-manifest-schema.md)
- PR #3214 — ADR-037 + PRD-240 scaffold (just merged)
- PR #3133 — PRD-236 sinks scaffold; the canonical "add a new dimension" pattern this PR mirrors
