### PR TITLE
feat(media-db): comparisons + sync_logs PR4 + cross-pillar JOIN unblock (Wave 5 cascade close)

### DIFF
--- a/.dependency-cruiser-known-violations.json
+++ b/.dependency-cruiser-known-violations.json
@@ -408,6 +408,72 @@
   },
   {
     "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/comparisons/lib/debrief-dismiss.ts",
+    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/cerebrum-db",
+    "dependencyTypes": ["undetermined", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-cerebrum"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/comparisons/lib/debrief-pending.ts",
+    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/cerebrum-db",
+    "dependencyTypes": ["undetermined", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-cerebrum"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/comparisons/lib/debrief-record.ts",
+    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/cerebrum-db",
+    "dependencyTypes": ["undetermined", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-cerebrum"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/debrief/queue-status.ts",
+    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/cerebrum-db",
+    "dependencyTypes": ["undetermined", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-cerebrum"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/debrief/service.ts",
+    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/cerebrum-db",
+    "dependencyTypes": ["undetermined", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-cerebrum"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/watch-history/handlers/query-helpers.ts",
+    "to": "packages/cerebrum-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/cerebrum-db",
+    "dependencyTypes": ["undetermined", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-cerebrum"
+    }
+  },
+  {
+    "type": "dependency",
     "from": "apps/pops-api/src/db.ts",
     "to": "packages/core-db/dist/index.d.ts",
     "unresolvedTo": "@pops/core-db",
@@ -442,6 +508,17 @@
   {
     "type": "dependency",
     "from": "apps/pops-api/src/lib/inference-pricing.ts",
+    "to": "packages/core-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/core-db",
+    "dependencyTypes": ["undetermined", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-core"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/cerebrum/glia/__tests__/toml-config.test.ts",
     "to": "packages/core-db/dist/index.d.ts",
     "unresolvedTo": "@pops/core-db",
     "dependencyTypes": ["undetermined", "import"],
@@ -1024,7 +1101,84 @@
   },
   {
     "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/comparisons/dimensions.service.ts",
+    "to": "packages/media-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["undetermined", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-media"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/comparisons/global-count.ts",
+    "to": "packages/media-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["undetermined", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-media"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/comparisons/lib/batch-record.ts",
+    "to": "packages/media-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["undetermined", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-media"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/comparisons/lib/comparison-queries.ts",
+    "to": "packages/media-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["undetermined", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-media"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/comparisons/lib/debrief-dismiss.ts",
+    "to": "packages/media-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["undetermined", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-media"
+    }
+  },
+  {
+    "type": "dependency",
     "from": "apps/pops-api/src/modules/media/comparisons/lib/debrief-opponent.ts",
+    "to": "packages/media-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["undetermined", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-media"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/comparisons/lib/debrief-pending.ts",
+    "to": "packages/media-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["undetermined", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-media"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/comparisons/lib/debrief-record.ts",
     "to": "packages/media-db/dist/index.d.ts",
     "unresolvedTo": "@pops/media-db",
     "dependencyTypes": ["undetermined", "import"],
@@ -1057,7 +1211,51 @@
   },
   {
     "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/comparisons/lib/skip-cooloff.ts",
+    "to": "packages/media-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["undetermined", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-media"
+    }
+  },
+  {
+    "type": "dependency",
     "from": "apps/pops-api/src/modules/media/comparisons/lib/submit-tier-list.ts",
+    "to": "packages/media-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["undetermined", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-media"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/comparisons/pairs/random-pair.ts",
+    "to": "packages/media-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["undetermined", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-media"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/comparisons/pairs/smart-pair-fetch.ts",
+    "to": "packages/media-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["undetermined", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-media"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/comparisons/rankings-overall.ts",
     "to": "packages/media-db/dist/index.d.ts",
     "unresolvedTo": "@pops/media-db",
     "dependencyTypes": ["undetermined", "import"],
@@ -1079,10 +1277,43 @@
   },
   {
     "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/comparisons/service.ts",
+    "to": "packages/media-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["undetermined", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-media"
+    }
+  },
+  {
+    "type": "dependency",
     "from": "apps/pops-api/src/modules/media/comparisons/staleness.ts",
     "to": "packages/media-db/dist/index.d.ts",
     "unresolvedTo": "@pops/media-db",
     "dependencyTypes": ["undetermined", "type-only", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-media"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/debrief/queue-status.ts",
+    "to": "packages/media-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["undetermined", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-media"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/debrief/service.ts",
+    "to": "packages/media-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["undetermined", "import"],
     "rule": {
       "severity": "error",
       "name": "no-cross-pillar-runtime-import-media"
@@ -1124,6 +1355,17 @@
   {
     "type": "dependency",
     "from": "apps/pops-api/src/modules/media/discovery/router.assemble-session.test.ts",
+    "to": "packages/media-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["undetermined", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-media"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/discovery/service-preference-profile.ts",
     "to": "packages/media-db/dist/index.d.ts",
     "unresolvedTo": "@pops/media-db",
     "dependencyTypes": ["undetermined", "import"],
@@ -1270,6 +1512,17 @@
     "to": "packages/media-db/dist/index.d.ts",
     "unresolvedTo": "@pops/media-db",
     "dependencyTypes": ["undetermined", "type-only", "import"],
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-pillar-runtime-import-media"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/media/plex/scheduler-sync-logs.ts",
+    "to": "packages/media-db/dist/index.d.ts",
+    "unresolvedTo": "@pops/media-db",
+    "dependencyTypes": ["undetermined", "import"],
     "rule": {
       "severity": "error",
       "name": "no-cross-pillar-runtime-import-media"

--- a/apps/pops-api/src/db/backfill-media-from-shared.test.ts
+++ b/apps/pops-api/src/db/backfill-media-from-shared.test.ts
@@ -104,14 +104,97 @@ CREATE TABLE rotation_exclusions (
 CREATE UNIQUE INDEX idx_rotation_exclusions_tmdb_id ON rotation_exclusions (tmdb_id);
 `;
 
+const COMPARISON_DIMENSIONS_SQL = `
+CREATE TABLE comparison_dimensions (
+  id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  name text NOT NULL,
+  description text,
+  active integer DEFAULT 1 NOT NULL,
+  sort_order integer DEFAULT 0 NOT NULL,
+  weight real DEFAULT 1 NOT NULL,
+  created_at text DEFAULT (datetime('now')) NOT NULL
+);
+CREATE UNIQUE INDEX idx_comparison_dimensions_name ON comparison_dimensions (name);
+`;
+
+const COMPARISONS_SQL = `
+CREATE TABLE comparisons (
+  id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  dimension_id integer NOT NULL REFERENCES comparison_dimensions(id),
+  media_a_type text NOT NULL,
+  media_a_id integer NOT NULL,
+  media_b_type text NOT NULL,
+  media_b_id integer NOT NULL,
+  winner_type text NOT NULL,
+  winner_id integer NOT NULL,
+  draw_tier text,
+  source text,
+  delta_a integer,
+  delta_b integer,
+  compared_at text DEFAULT (datetime('now')) NOT NULL
+);
+`;
+
+const COMPARISON_SKIP_COOLOFFS_SQL = `
+CREATE TABLE comparison_skip_cooloffs (
+  id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  dimension_id integer NOT NULL REFERENCES comparison_dimensions(id),
+  media_a_type text NOT NULL,
+  media_a_id integer NOT NULL,
+  media_b_type text NOT NULL,
+  media_b_id integer NOT NULL,
+  skip_until integer NOT NULL,
+  created_at text DEFAULT (datetime('now')) NOT NULL
+);
+CREATE UNIQUE INDEX idx_comparison_skip_cooloffs_pair ON comparison_skip_cooloffs (dimension_id, media_a_type, media_a_id, media_b_type, media_b_id);
+`;
+
+const SYNC_LOGS_SQL = `
+CREATE TABLE sync_logs (
+  id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  synced_at text NOT NULL,
+  movies_synced integer DEFAULT 0 NOT NULL,
+  tv_shows_synced integer DEFAULT 0 NOT NULL,
+  errors text,
+  duration_ms integer
+);
+`;
+
 function seedSharedDb(): string {
   const sharedPath = join(tmpDir, 'pops.db');
   const shared = new BetterSqlite3(sharedPath);
+  shared.exec(COMPARISON_DIMENSIONS_SQL);
+  shared.exec(COMPARISONS_SQL);
+  shared.exec(COMPARISON_SKIP_COOLOFFS_SQL);
   shared.exec(MEDIA_SCORES_SQL);
   shared.exec(ROTATION_LOG_SQL);
   shared.exec(ROTATION_SOURCES_SQL);
   shared.exec(ROTATION_CANDIDATES_SQL);
   shared.exec(ROTATION_EXCLUSIONS_SQL);
+  shared.exec(SYNC_LOGS_SQL);
+
+  shared
+    .prepare(
+      `INSERT INTO comparison_dimensions (name, description, active, sort_order, weight) VALUES (?, ?, 1, 0, 1.0)`
+    )
+    .run('Cinematography', 'visual quality');
+  shared
+    .prepare(
+      `INSERT INTO comparison_dimensions (name, description, active, sort_order, weight) VALUES (?, ?, 1, 1, 0.8)`
+    )
+    .run('Soundtrack', 'audio quality');
+
+  shared
+    .prepare(
+      `INSERT INTO comparisons (id, dimension_id, media_a_type, media_a_id, media_b_type, media_b_id, winner_type, winner_id, draw_tier, source, delta_a, delta_b, compared_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, datetime('now'))`
+    )
+    .run(1, 1, 'movie', 1, 'movie', 2, 'movie', 1, 'arena', 16, -16);
+
+  shared
+    .prepare(
+      `INSERT INTO comparison_skip_cooloffs (dimension_id, media_a_type, media_a_id, media_b_type, media_b_id, skip_until, created_at) VALUES (?, ?, ?, ?, ?, ?, datetime('now'))`
+    )
+    .run(1, 'movie', 3, 'movie', 4, 100);
 
   shared
     .prepare(
@@ -147,6 +230,12 @@ function seedSharedDb(): string {
       `INSERT INTO rotation_exclusions (tmdb_id, title, reason, excluded_at) VALUES (?, ?, ?, datetime('now'))`
     )
     .run(222, 'Excluded Movie', 'manual');
+
+  shared
+    .prepare(
+      `INSERT INTO sync_logs (id, synced_at, movies_synced, tv_shows_synced, errors, duration_ms) VALUES (?, datetime('now'), ?, ?, NULL, ?)`
+    )
+    .run(1, 10, 4, 2500);
 
   shared.close();
   return sharedPath;
@@ -191,6 +280,32 @@ describe('backfillMediaFromShared', () => {
       }[];
       expect(exclusions).toHaveLength(1);
       expect(exclusions[0]?.tmdb_id).toBe(222);
+
+      const dimensions = media.raw
+        .prepare(`SELECT id, name, weight FROM comparison_dimensions ORDER BY id`)
+        .all() as { id: number; name: string; weight: number }[];
+      expect(dimensions).toHaveLength(2);
+      expect(dimensions[0]?.name).toBe('Cinematography');
+      expect(dimensions[1]?.weight).toBe(0.8);
+
+      const comparisons = media.raw
+        .prepare(`SELECT id, dimension_id, source FROM comparisons`)
+        .all() as { id: number; dimension_id: number; source: string | null }[];
+      expect(comparisons).toHaveLength(1);
+      expect(comparisons[0]?.source).toBe('arena');
+
+      const cooloffs = media.raw
+        .prepare(`SELECT dimension_id, media_a_id, skip_until FROM comparison_skip_cooloffs`)
+        .all() as { dimension_id: number; media_a_id: number; skip_until: number }[];
+      expect(cooloffs).toHaveLength(1);
+      expect(cooloffs[0]?.skip_until).toBe(100);
+
+      const syncLogs = media.raw.prepare(`SELECT id, movies_synced FROM sync_logs`).all() as {
+        id: number;
+        movies_synced: number;
+      }[];
+      expect(syncLogs).toHaveLength(1);
+      expect(syncLogs[0]?.movies_synced).toBe(10);
     } finally {
       media.raw.close();
     }
@@ -230,9 +345,15 @@ describe('backfillMediaFromShared', () => {
     const mediaPath = join(tmpDir, 'media.db');
     const media = openMediaDb(mediaPath);
     try {
-      // Pre-seed media.db with one of the score rows already present so the
-      // existence filter has to recognise the business-key collision instead
-      // of just the surrogate id.
+      // Pre-seed media.db with the dimension (the new intra-pillar FK on
+      // media_scores.dimension_id requires it) and one of the score rows so
+      // the existence filter has to recognise the business-key collision
+      // instead of just the surrogate id.
+      media.raw
+        .prepare(
+          `INSERT INTO comparison_dimensions (id, name, description, active, sort_order, weight) VALUES (?, ?, ?, ?, ?, ?)`
+        )
+        .run(1, 'Cinematography', 'visual quality', 1, 0, 1.0);
       media.raw
         .prepare(
           `INSERT INTO media_scores (media_type, media_id, dimension_id, score, comparison_count, excluded) VALUES (?, ?, ?, ?, ?, ?)`
@@ -259,7 +380,13 @@ describe('backfillMediaFromShared', () => {
   it('is non-fatal when the shared pops.db is missing the source tables', () => {
     const sharedPath = join(tmpDir, 'pops.db');
     const shared = new BetterSqlite3(sharedPath);
+    shared.exec(COMPARISON_DIMENSIONS_SQL);
     shared.exec(MEDIA_SCORES_SQL);
+    shared
+      .prepare(
+        `INSERT INTO comparison_dimensions (id, name, description, active, sort_order, weight) VALUES (1, 'Cinematography', NULL, 1, 0, 1.0)`
+      )
+      .run();
     shared
       .prepare(
         `INSERT INTO media_scores (media_type, media_id, dimension_id, score, comparison_count, excluded, updated_at) VALUES ('movie', 1, 1, 1500, 0, 0, datetime('now'))`

--- a/apps/pops-api/src/db/backfill-media-from-shared.ts
+++ b/apps/pops-api/src/db/backfill-media-from-shared.ts
@@ -1,15 +1,17 @@
 /**
  * Boot-time backfill from the legacy shared `pops.db` into the media
  * pillar's `media.db` for the Theme-13 Wave-5 PR4 tables: `media_scores`,
- * `rotation_log`, `rotation_sources`, `rotation_candidates`, and
- * `rotation_exclusions`.
+ * `rotation_log`, `rotation_sources`, `rotation_candidates`,
+ * `rotation_exclusions`, `comparison_dimensions`, `comparisons`,
+ * `comparison_skip_cooloffs`, and `sync_logs`.
  *
  * Phase context: the earlier media slices (movies / tv_shows / seasons /
  * episodes / watchlist / watch_history / dismissed_discover /
  * shelf_impressions / comparison_staleness) finished their PR4 writer
  * cutovers in earlier rounds, so the original `media-backfill.ts` was
  * retired. This module brings the bridge back for the new tables landing
- * in `0030_media_scores_baseline.sql` and `0031_rotation_baseline.sql`.
+ * in `0030_media_scores_baseline.sql`, `0031_rotation_baseline.sql`,
+ * `0032_comparisons_baseline.sql`, and `0033_sync_logs_baseline.sql`.
  * Each TABLE_COPIES entry retires after its writer cutover is verified in
  * prod and the shared `pops.db` stops receiving new rows.
  *
@@ -45,6 +47,73 @@ interface TableCopy {
 }
 
 const TABLE_COPIES: readonly TableCopy[] = [
+  {
+    /**
+     * `comparison_dimensions` must land before `comparisons`,
+     * `comparison_skip_cooloffs`, and `media_scores` because each of those
+     * has a FK on `dimension_id`. We copy `id` from the shared side so the
+     * FK linkage from the rows we're about to copy into `comparisons` /
+     * `comparison_skip_cooloffs` / `media_scores` (each carrying the
+     * original shared `dimension_id`) keeps working. The (name) uniqueness
+     * index doubles as the dedup key against `seedDefaultDimensions()` —
+     * if media-db already auto-seeded "Cinematography" at id=1 the shared
+     * row collides on name and gets skipped by the NOT EXISTS filter; in
+     * the steady state both sides agree on (id, name) pairs because the
+     * seed list is stable.
+     */
+    table: 'comparison_dimensions',
+    idColumns: ['name'],
+    columns: ['id', 'name', 'description', 'active', 'sort_order', 'weight', 'created_at'],
+  },
+  {
+    /**
+     * `id` is intentionally omitted — surrogate PKs are owned per-DB.
+     * The composite (dimension_id, media_a_type, media_a_id, media_b_type,
+     * media_b_id, compared_at) is enough to identify a row but
+     * `comparisons` has no natural-key UNIQUE index, so we fall back to
+     * the surrogate id from the shared side. Realistically `comparisons`
+     * is append-only and the shared id space is dense, so collisions with
+     * the media autoincrement (which starts at 1 against a freshly seeded
+     * dimensions table) only matter if writers double up on both sides.
+     * The writer cutover in this PR closes that window.
+     */
+    table: 'comparisons',
+    idColumns: ['id'],
+    columns: [
+      'id',
+      'dimension_id',
+      'media_a_type',
+      'media_a_id',
+      'media_b_type',
+      'media_b_id',
+      'winner_type',
+      'winner_id',
+      'draw_tier',
+      'source',
+      'delta_a',
+      'delta_b',
+      'compared_at',
+    ],
+  },
+  {
+    /**
+     * Skip cooloffs are short-lived and the unique tuple
+     * (dimension_id, media_a_type, media_a_id, media_b_type, media_b_id)
+     * serves as the business key — copy on that so the upsert semantics
+     * in `lib/skip-cooloff.ts` survive a partial backfill.
+     */
+    table: 'comparison_skip_cooloffs',
+    idColumns: ['dimension_id', 'media_a_type', 'media_a_id', 'media_b_type', 'media_b_id'],
+    columns: [
+      'dimension_id',
+      'media_a_type',
+      'media_a_id',
+      'media_b_type',
+      'media_b_id',
+      'skip_until',
+      'created_at',
+    ],
+  },
   {
     table: 'media_scores',
     /**
@@ -125,6 +194,17 @@ const TABLE_COPIES: readonly TableCopy[] = [
     table: 'rotation_exclusions',
     idColumns: ['tmdb_id'],
     columns: ['tmdb_id', 'title', 'reason', 'excluded_at'],
+  },
+  {
+    /**
+     * `sync_logs` is append-only (Plex sync ledger) and has no natural
+     * UNIQUE key — fall back to the surrogate id from the shared side,
+     * same shape as `rotation_log`. The writer cutover in this PR closes
+     * the dual-write window so the id space stops splitting.
+     */
+    table: 'sync_logs',
+    idColumns: ['id'],
+    columns: ['id', 'synced_at', 'movies_synced', 'tv_shows_synced', 'errors', 'duration_ms'],
   },
 ];
 

--- a/apps/pops-api/src/db/media-db-handle.ts
+++ b/apps/pops-api/src/db/media-db-handle.ts
@@ -17,6 +17,8 @@ import { openMediaDb, type MediaDb, type OpenedMediaDb } from '@pops/media-db';
 import { backfillMediaFromShared } from './backfill-media-from-shared.js';
 import { resolveMediaSqlitePath } from './media-sqlite-path.js';
 
+import type BetterSqlite3 from 'better-sqlite3';
+
 let mediaDb: OpenedMediaDb | null = null;
 
 /**
@@ -29,6 +31,20 @@ export function getMediaDrizzle(): MediaDb {
     mediaDb = openMediaDb(resolveMediaSqlitePath());
   }
   return mediaDb.db;
+}
+
+/**
+ * Lazily open the media pillar's SQLite file and return the raw
+ * better-sqlite3 handle. Used by hot paths that compose multi-statement
+ * SQL — e.g. the overall rankings join across `media_scores`,
+ * `comparison_dimensions`, `movies`, and `tv_shows` — where drizzle's
+ * query builder loses too much fidelity to be useful.
+ */
+export function getMediaRawDb(): BetterSqlite3.Database {
+  if (!mediaDb) {
+    mediaDb = openMediaDb(resolveMediaSqlitePath());
+  }
+  return mediaDb.raw;
 }
 
 /**

--- a/apps/pops-api/src/db/per-pillar-migrations.test.ts
+++ b/apps/pops-api/src/db/per-pillar-migrations.test.ts
@@ -241,7 +241,15 @@ describe('runPerPillarMigrations', () => {
     // 0031_rotation_baseline (Theme 13 Wave-5 cascade — rotation_log +
     // rotation_sources + rotation_candidates + rotation_exclusions mirrored
     // from shared `0028_needy_terror` + `0029_curved_revanche`; intra-pillar
-    // `rotation_candidates.source_id → rotation_sources.id` FK preserved);
+    // `rotation_candidates.source_id → rotation_sources.id` FK preserved),
+    // 0032_comparisons_baseline (Theme 13 Wave-5 cascade — comparison_dimensions
+    // + comparisons + comparison_skip_cooloffs mirrored from the shared journal
+    // ancestry, restoring the intra-pillar
+    // `media_scores.dimension_id → comparison_dimensions.id` FK that #3212
+    // dropped because the cross-SQLite-file constraint was impossible), and
+    // 0033_sync_logs_baseline (Theme 13 Wave-5 cascade — sync_logs Plex
+    // ledger mirrored from shared `0009_red_quasimodo` ahead of the
+    // scheduler writer cutover);
     // `inventory` owns `packages/inventory-db/migrations/` with
     // 0005_fancy_crystal (inventory pillar Phase 1 PR 2),
     // 0006_inventory_pillar_baseline (inventory pillar Phase 2 PR 3 —
@@ -283,6 +291,8 @@ describe('runPerPillarMigrations', () => {
         '0029_media_comparison_staleness_baseline',
         '0030_media_scores_baseline',
         '0031_rotation_baseline',
+        '0032_comparisons_baseline',
+        '0033_sync_logs_baseline',
         '0039_dry_fabian_cortez',
         '0044_nudge_log',
         '0050_engrams_baseline',

--- a/apps/pops-api/src/modules/media/__integration__/media-handle-coverage.test.ts
+++ b/apps/pops-api/src/modules/media/__integration__/media-handle-coverage.test.ts
@@ -31,9 +31,6 @@ import { createCaller, createTestDb } from '../../../shared/test-utils.js';
  * removes the entry once the call resolves via `getMediaDrizzle()`.
  */
 const MEDIA_IGNORE = new Set<string>([
-  // `sync_logs` lives on shared (`src/db/schema.ts`), not in createTestDb's
-  // synthetic schema. Pillar handle not involved.
-  'media.plex.getSyncLogs',
   // `sync_job_results` lives on shared, not in createTestDb. Pillar
   // handle not involved.
   'media.plex.getLastSyncResults',

--- a/apps/pops-api/src/modules/media/comparisons/dimensions.service.ts
+++ b/apps/pops-api/src/modules/media/comparisons/dimensions.service.ts
@@ -1,8 +1,8 @@
 import { asc, eq } from 'drizzle-orm';
 
-import { comparisonDimensions } from '@pops/db-types';
+import { comparisonDimensions } from '@pops/media-db';
 
-import { getDrizzle } from '../../../db.js';
+import { getMediaDrizzle } from '../../../db/media-db-handle.js';
 import { ConflictError, NotFoundError } from '../../../shared/errors.js';
 
 import type {
@@ -25,7 +25,7 @@ const DEFAULT_DIMENSIONS = [
 
 /** Seed default dimensions if none exist. Returns true if seeded. */
 export function seedDefaultDimensions(): boolean {
-  const db = getDrizzle();
+  const db = getMediaDrizzle();
   const existing = db.select({ id: comparisonDimensions.id }).from(comparisonDimensions).get();
   if (existing) return false;
 
@@ -38,7 +38,7 @@ export function seedDefaultDimensions(): boolean {
 }
 
 export function listDimensions(): ComparisonDimensionRow[] {
-  const db = getDrizzle();
+  const db = getMediaDrizzle();
   const rows = db
     .select()
     .from(comparisonDimensions)
@@ -56,14 +56,14 @@ export function listDimensions(): ComparisonDimensionRow[] {
 }
 
 export function getDimension(id: number): ComparisonDimensionRow {
-  const db = getDrizzle();
+  const db = getMediaDrizzle();
   const row = db.select().from(comparisonDimensions).where(eq(comparisonDimensions.id, id)).get();
   if (!row) throw new NotFoundError('Dimension', String(id));
   return row;
 }
 
 export function createDimension(input: CreateDimensionInput): ComparisonDimensionRow {
-  const db = getDrizzle();
+  const db = getMediaDrizzle();
 
   const existing = db
     .select({ id: comparisonDimensions.id })
@@ -89,7 +89,7 @@ export function createDimension(input: CreateDimensionInput): ComparisonDimensio
 }
 
 export function updateDimension(id: number, input: UpdateDimensionInput): ComparisonDimensionRow {
-  const db = getDrizzle();
+  const db = getMediaDrizzle();
   getDimension(id); // verify exists
 
   const updates: Partial<typeof comparisonDimensions.$inferInsert> = {};

--- a/apps/pops-api/src/modules/media/comparisons/global-count.ts
+++ b/apps/pops-api/src/modules/media/comparisons/global-count.ts
@@ -1,9 +1,11 @@
-import { getDb } from '../../../db.js';
+import { count } from 'drizzle-orm';
+
+import { comparisons } from '@pops/media-db';
+
+import { getMediaDrizzle } from '../../../db/media-db-handle.js';
 
 export function getGlobalComparisonCount(): number {
-  const rawDb = getDb();
-  const row = rawDb.prepare(`SELECT COUNT(*) as cnt FROM comparisons`).get() as
-    | { cnt: number }
-    | undefined;
+  const db = getMediaDrizzle();
+  const row = db.select({ cnt: count() }).from(comparisons).get();
   return row?.cnt ?? 0;
 }

--- a/apps/pops-api/src/modules/media/comparisons/lib/batch-record.ts
+++ b/apps/pops-api/src/modules/media/comparisons/lib/batch-record.ts
@@ -1,8 +1,8 @@
 import { eq } from 'drizzle-orm';
 
-import { comparisons } from '@pops/db-types';
+import { comparisons } from '@pops/media-db';
 
-import { getDb, getDrizzle } from '../../../../db.js';
+import { getMediaDrizzle } from '../../../../db/media-db-handle.js';
 import { ValidationError } from '../../../../shared/errors.js';
 import { getDimension } from '../dimensions.service.js';
 import { findExistingComparison } from './comparison-queries.js';
@@ -40,7 +40,7 @@ function insertWithoutDelta(
   item: BatchComparisonItem,
   source: string | null | undefined
 ): void {
-  const drizzleDb = getDrizzle();
+  const drizzleDb = getMediaDrizzle();
   drizzleDb
     .insert(comparisons)
     .values({
@@ -62,7 +62,7 @@ function insertWithDelta(
   item: BatchComparisonItem,
   source: string | null | undefined
 ): void {
-  const drizzleDb = getDrizzle();
+  const drizzleDb = getMediaDrizzle();
   const comparisonInput: RecordComparisonInput = {
     dimensionId,
     mediaAType: item.mediaAType,
@@ -94,7 +94,7 @@ function insertWithDelta(
 
 function processItem(args: ProcessItemArgs): void {
   const { dimensionId, item, source, state } = args;
-  const drizzleDb = getDrizzle();
+  const drizzleDb = getMediaDrizzle();
   const existing = findExistingComparison({
     dimensionId,
     mediaAType: item.mediaAType,
@@ -141,15 +141,15 @@ export function batchRecordComparisons(
   }
 
   const state: BatchState = { insertedCount: 0, skippedCount: 0, hasOverrides: false };
-  const rawDb = getDb();
-  rawDb.transaction(() => {
+  const db = getMediaDrizzle();
+  db.transaction(() => {
     for (const item of items) {
       processItem({ dimensionId, item, source, state });
     }
     if (state.hasOverrides) {
       recalcDimensionElo(dimensionId);
     }
-  })();
+  });
 
   return { count: state.insertedCount, skipped: state.skippedCount };
 }

--- a/apps/pops-api/src/modules/media/comparisons/lib/comparison-queries.ts
+++ b/apps/pops-api/src/modules/media/comparisons/lib/comparison-queries.ts
@@ -1,8 +1,8 @@
 import { and, count, desc, eq, inArray, like, or, type SQL } from 'drizzle-orm';
 
-import { comparisons, movies } from '@pops/db-types';
+import { comparisons, movies } from '@pops/media-db';
 
-import { getDrizzle } from '../../../../db.js';
+import { getMediaDrizzle } from '../../../../db/media-db-handle.js';
 
 import type { ComparisonRow } from '../types.js';
 
@@ -43,7 +43,7 @@ export function findExistingComparison(
   input: FindExistingComparisonInput
 ): ComparisonRow | undefined {
   const { dimensionId, mediaAType, mediaAId, mediaBType, mediaBId } = input;
-  const drizzleDb = getDrizzle();
+  const drizzleDb = getMediaDrizzle();
   const [normAType, normAId, normBType, normBId] = normalizePairOrder(
     mediaAType,
     mediaAId,
@@ -85,7 +85,7 @@ export interface ListComparisonsForMediaInput {
 
 export function listComparisonsForMedia(input: ListComparisonsForMediaInput): ComparisonListResult {
   const { mediaType, mediaId, dimensionId, limit, offset } = input;
-  const db = getDrizzle();
+  const db = getMediaDrizzle();
 
   const mediaCondition = or(
     and(eq(comparisons.mediaAType, mediaType), eq(comparisons.mediaAId, mediaId)),
@@ -120,7 +120,7 @@ export function listAllComparisons(
   limit: number,
   offset: number
 ): ComparisonListResult {
-  const db = getDrizzle();
+  const db = getMediaDrizzle();
 
   const conditions: SQL[] = [];
   if (dimensionId) conditions.push(eq(comparisons.dimensionId, dimensionId));

--- a/apps/pops-api/src/modules/media/comparisons/lib/debrief-dismiss.ts
+++ b/apps/pops-api/src/modules/media/comparisons/lib/debrief-dismiss.ts
@@ -1,10 +1,8 @@
 import { and, count, eq } from 'drizzle-orm';
 
 import { debriefResults, debriefSessions, debriefStatus } from '@pops/cerebrum-db';
-import { comparisonDimensions } from '@pops/db-types';
-import { watchHistory } from '@pops/media-db';
+import { comparisonDimensions, watchHistory } from '@pops/media-db';
 
-import { getDrizzle } from '../../../../db.js';
 import { getCerebrumDrizzle } from '../../../../db/cerebrum-handle.js';
 import { getMediaDrizzle } from '../../../../db/media-db-handle.js';
 import { ConflictError, NotFoundError, ValidationError } from '../../../../shared/errors.js';
@@ -61,9 +59,9 @@ function markDebriefStatusDismissed(watchHistoryId: number, dimensionId: number)
 }
 
 function autoCompleteIfFinished(sessionId: number): void {
-  const sharedDb = getDrizzle();
+  const mediaDb = getMediaDrizzle();
   const cerebrumDb = getCerebrumDrizzle();
-  const activeDims = sharedDb
+  const activeDims = mediaDb
     .select({ id: comparisonDimensions.id })
     .from(comparisonDimensions)
     .where(eq(comparisonDimensions.active, 1))
@@ -90,8 +88,9 @@ function autoCompleteIfFinished(sessionId: number): void {
  * dimensions have results.
  *
  * Theme-13 Wave-5 cascade: debrief* tables routed via `getCerebrumDrizzle()`;
- * `watch_history` lookup hops to `getMediaDrizzle()`; `comparison_dimensions`
- * stays on the shared `pops.db` until that slice cuts over.
+ * `watch_history` + `comparison_dimensions` reads now hop to
+ * `getMediaDrizzle()` (closing the cross-pillar JOIN that previously routed
+ * `comparison_dimensions` through the shared `pops.db`).
  */
 export function dismissDebriefDimension(sessionId: number, dimensionId: number): void {
   const db = getCerebrumDrizzle();

--- a/apps/pops-api/src/modules/media/comparisons/lib/debrief-opponent.ts
+++ b/apps/pops-api/src/modules/media/comparisons/lib/debrief-opponent.ts
@@ -1,9 +1,7 @@
 import { and, asc, eq } from 'drizzle-orm';
 
-import { comparisons } from '@pops/db-types';
-import { mediaScores, movies, watchHistory } from '@pops/media-db';
+import { comparisons, mediaScores, movies, watchHistory } from '@pops/media-db';
 
-import { getDrizzle } from '../../../../db.js';
 import { getMediaDrizzle } from '../../../../db/media-db-handle.js';
 import { getDimension } from '../dimensions.service.js';
 import { resolveMoviePoster } from '../pairs/movie-helpers.js';
@@ -51,7 +49,7 @@ function fetchComparedAgainstIds(
   mediaId: number,
   dimensionId: number
 ): Set<number> {
-  const db = getDrizzle();
+  const db = getMediaDrizzle();
   const ids = new Set<number>();
   const compsA = db
     .select({ mediaBId: comparisons.mediaBId })

--- a/apps/pops-api/src/modules/media/comparisons/lib/debrief-pending.ts
+++ b/apps/pops-api/src/modules/media/comparisons/lib/debrief-pending.ts
@@ -1,10 +1,8 @@
 import { count, desc, eq, or } from 'drizzle-orm';
 
 import { debriefResults, debriefSessions } from '@pops/cerebrum-db';
-import { comparisonDimensions } from '@pops/db-types';
-import { movies, watchHistory } from '@pops/media-db';
+import { comparisonDimensions, movies, watchHistory } from '@pops/media-db';
 
-import { getDrizzle } from '../../../../db.js';
 import { getCerebrumDrizzle } from '../../../../db/cerebrum-handle.js';
 import { getMediaDrizzle } from '../../../../db/media-db-handle.js';
 import { resolveMoviePoster } from '../pairs/movie-helpers.js';
@@ -34,7 +32,7 @@ function fetchPendingSessions(): SessionRow[] {
 }
 
 function getActiveDimensionCount(): number {
-  const db = getDrizzle();
+  const db = getMediaDrizzle();
   return (
     db
       .select({ total: count() })

--- a/apps/pops-api/src/modules/media/comparisons/lib/debrief-record.ts
+++ b/apps/pops-api/src/modules/media/comparisons/lib/debrief-record.ts
@@ -1,10 +1,8 @@
 import { and, count, eq } from 'drizzle-orm';
 
 import { debriefResults, debriefSessions, debriefStatus } from '@pops/cerebrum-db';
-import { comparisonDimensions } from '@pops/db-types';
-import { watchHistory } from '@pops/media-db';
+import { comparisonDimensions, watchHistory } from '@pops/media-db';
 
-import { getDb, getDrizzle } from '../../../../db.js';
 import { getCerebrumDrizzle } from '../../../../db/cerebrum-handle.js';
 import { getMediaDrizzle } from '../../../../db/media-db-handle.js';
 import { ConflictError, NotFoundError, ValidationError } from '../../../../shared/errors.js';
@@ -106,9 +104,9 @@ function activateIfPending(sessionId: number, sessionStatus: string): void {
 }
 
 function checkAndCompleteSession(sessionId: number): boolean {
-  const sharedDb = getDrizzle();
+  const mediaDb = getMediaDrizzle();
   const cerebrumDb = getCerebrumDrizzle();
-  const activeDimCount = sharedDb
+  const activeDimCount = mediaDb
     .select({ cnt: count() })
     .from(comparisonDimensions)
     .where(eq(comparisonDimensions.active, 1))
@@ -147,9 +145,8 @@ export function recordDebriefComparison(
 } {
   const { watchEntry, sessionStatus } = loadAndValidate(input);
   const cerebrumDb = getCerebrumDrizzle();
-  const rawDb = getDb();
 
-  return rawDb.transaction(() => {
+  return cerebrumDb.transaction(() => {
     const comparisonId = recordComparisonForDebrief(input, watchEntry, recordFn);
     cerebrumDb
       .insert(debriefResults)
@@ -163,5 +160,5 @@ export function recordDebriefComparison(
     activateIfPending(input.sessionId, sessionStatus);
     const sessionComplete = checkAndCompleteSession(input.sessionId);
     return { comparisonId, sessionComplete };
-  })();
+  });
 }

--- a/apps/pops-api/src/modules/media/comparisons/lib/dimension-exclusion.ts
+++ b/apps/pops-api/src/modules/media/comparisons/lib/dimension-exclusion.ts
@@ -1,9 +1,7 @@
 import { and, eq, or } from 'drizzle-orm';
 
-import { comparisons } from '@pops/db-types';
-import { mediaScores } from '@pops/media-db';
+import { comparisons, mediaScores } from '@pops/media-db';
 
-import { getDb, getDrizzle } from '../../../../db.js';
 import { getMediaDrizzle } from '../../../../db/media-db-handle.js';
 import { NotFoundError } from '../../../../shared/errors.js';
 import { getDimension } from '../dimensions.service.js';
@@ -21,12 +19,10 @@ export function excludeFromDimension(
 ): { comparisonsDeleted: number } {
   getDimension(dimensionId); // verify exists
   const mediaDb = getMediaDrizzle();
-  const sharedDb = getDrizzle();
-  const rawDb = getDb();
 
   let comparisonsDeleted = 0;
 
-  rawDb.transaction(() => {
+  mediaDb.transaction(() => {
     const existing = mediaDb
       .select()
       .from(mediaScores)
@@ -59,7 +55,7 @@ export function excludeFromDimension(
         .run();
     }
 
-    const result = sharedDb
+    const result = mediaDb
       .delete(comparisons)
       .where(
         and(
@@ -75,7 +71,7 @@ export function excludeFromDimension(
     comparisonsDeleted = result.changes;
 
     recalcDimensionElo(dimensionId);
-  })();
+  });
 
   return { comparisonsDeleted };
 }

--- a/apps/pops-api/src/modules/media/comparisons/lib/score-management.ts
+++ b/apps/pops-api/src/modules/media/comparisons/lib/score-management.ts
@@ -1,9 +1,7 @@
 import { and, asc, eq } from 'drizzle-orm';
 
-import { comparisonDimensions, comparisons } from '@pops/db-types';
-import { mediaScores } from '@pops/media-db';
+import { comparisonDimensions, comparisons, mediaScores } from '@pops/media-db';
 
-import { getDrizzle } from '../../../../db.js';
 import { getMediaDrizzle } from '../../../../db/media-db-handle.js';
 import { drawTierOutcome, expectedScore, getEloK } from './elo-calculator.js';
 
@@ -111,7 +109,6 @@ export function updateEloScores(input: RecordComparisonInput): { deltaA: number;
  */
 export function recalcDimensionElo(dimensionId: number): void {
   const mediaDb = getMediaDrizzle();
-  const sharedDb = getDrizzle();
 
   mediaDb
     .update(mediaScores)
@@ -119,7 +116,7 @@ export function recalcDimensionElo(dimensionId: number): void {
     .where(eq(mediaScores.dimensionId, dimensionId))
     .run();
 
-  const remaining = sharedDb
+  const remaining = mediaDb
     .select()
     .from(comparisons)
     .where(eq(comparisons.dimensionId, dimensionId))
@@ -138,7 +135,7 @@ export function recalcDimensionElo(dimensionId: number): void {
       drawTier: comp.drawTier as 'high' | 'mid' | 'low' | null,
     });
 
-    sharedDb.update(comparisons).set({ deltaA, deltaB }).where(eq(comparisons.id, comp.id)).run();
+    mediaDb.update(comparisons).set({ deltaA, deltaB }).where(eq(comparisons.id, comp.id)).run();
   }
 }
 
@@ -147,8 +144,8 @@ export function recalcDimensionElo(dimensionId: number): void {
  * Used after bulk data changes (e.g. dedupe migration).
  */
 export function recalcAllDimensions(): number {
-  const drizzleDb = getDrizzle();
-  const dims = drizzleDb
+  const db = getMediaDrizzle();
+  const dims = db
     .select({ id: comparisonDimensions.id })
     .from(comparisonDimensions)
     .where(eq(comparisonDimensions.active, 1))

--- a/apps/pops-api/src/modules/media/comparisons/lib/skip-cooloff.ts
+++ b/apps/pops-api/src/modules/media/comparisons/lib/skip-cooloff.ts
@@ -1,8 +1,8 @@
 import { and, eq } from 'drizzle-orm';
 
-import { comparisonSkipCooloffs } from '@pops/db-types';
+import { comparisonSkipCooloffs } from '@pops/media-db';
 
-import { getDrizzle } from '../../../../db.js';
+import { getMediaDrizzle } from '../../../../db/media-db-handle.js';
 import { getGlobalComparisonCount } from '../global-count.js';
 import { normalizePairOrder } from './comparison-queries.js';
 
@@ -21,7 +21,7 @@ export interface SkipCooloffPair {
  */
 export function recordSkip(input: SkipCooloffPair): number {
   const { dimensionId, mediaAType, mediaAId, mediaBType, mediaBId } = input;
-  const db = getDrizzle();
+  const db = getMediaDrizzle();
   const globalCount = getGlobalComparisonCount();
   const skipUntil = globalCount + 10;
 
@@ -74,7 +74,7 @@ export function recordSkip(input: SkipCooloffPair): number {
  */
 export function isPairOnCooloff(input: SkipCooloffPair): boolean {
   const { dimensionId, mediaAType, mediaAId, mediaBType, mediaBId } = input;
-  const db = getDrizzle();
+  const db = getMediaDrizzle();
   const globalCount = getGlobalComparisonCount();
 
   const [normAType, normAId, normBType, normBId] = normalizePairOrder(

--- a/apps/pops-api/src/modules/media/comparisons/lib/tier-list-selection.ts
+++ b/apps/pops-api/src/modules/media/comparisons/lib/tier-list-selection.ts
@@ -1,4 +1,4 @@
-import { getDb } from '../../../../db.js';
+import { getMediaRawDb } from '../../../../db/media-db-handle.js';
 import { getSettingValue } from '../../../core/settings/service.js';
 import { getDimension } from '../dimensions.service.js';
 import { getTierOverrides } from '../tier-overrides.js';
@@ -52,7 +52,7 @@ function toTierListMovie(row: ScoreRow, tierOverrideMap: Map<number, string>): T
 }
 
 function fetchEligibleRows(dimensionId: number): ScoreRow[] {
-  const rawDb = getDb();
+  const rawDb = getMediaRawDb();
   return rawDb
     .prepare(
       `SELECT
@@ -78,7 +78,7 @@ function fetchEligibleRows(dimensionId: number): ScoreRow[] {
 }
 
 function fetchExistingPairKeys(dimensionId: number): Set<string> {
-  const rawDb = getDb();
+  const rawDb = getMediaRawDb();
   const pairRows = rawDb
     .prepare(
       `SELECT media_a_type, media_a_id, media_b_type, media_b_id

--- a/apps/pops-api/src/modules/media/comparisons/pairs/random-pair.ts
+++ b/apps/pops-api/src/modules/media/comparisons/pairs/random-pair.ts
@@ -1,15 +1,15 @@
 import { and, desc, eq } from 'drizzle-orm';
 
-import { comparisons, mediaWatchlist, watchHistory } from '@pops/db-types';
+import { comparisons, mediaWatchlist, watchHistory } from '@pops/media-db';
 
-import { getDrizzle } from '../../../../db.js';
+import { getMediaDrizzle } from '../../../../db/media-db-handle.js';
 import { getDimension } from '../dimensions.service.js';
 import { fetchMovieRow, toRandomPairMovie } from './movie-helpers.js';
 
 import type { RandomPair } from '../types.js';
 
 function getEligibleWatchedMovieIds(): number[] {
-  const db = getDrizzle();
+  const db = getMediaDrizzle();
   const allWatchedIds = db
     .select({ mediaId: watchHistory.mediaId })
     .from(watchHistory)
@@ -33,7 +33,7 @@ function getEligibleWatchedMovieIds(): number[] {
 function getRecentPairs(dimensionId: number, avoidRecent: number): Set<string> {
   const recentPairs = new Set<string>();
   if (avoidRecent <= 0) return recentPairs;
-  const db = getDrizzle();
+  const db = getMediaDrizzle();
   const recent = db
     .select({
       mediaAId: comparisons.mediaAId,

--- a/apps/pops-api/src/modules/media/comparisons/pairs/smart-pair-fetch.ts
+++ b/apps/pops-api/src/modules/media/comparisons/pairs/smart-pair-fetch.ts
@@ -1,8 +1,8 @@
 import { eq } from 'drizzle-orm';
 
-import { mediaWatchlist } from '@pops/db-types';
+import { mediaWatchlist } from '@pops/media-db';
 
-import { getDb, getDrizzle } from '../../../../db.js';
+import { getMediaDrizzle, getMediaRawDb } from '../../../../db/media-db-handle.js';
 import { getGlobalComparisonCount } from '../global-count.js';
 
 export interface WatchedMovie {
@@ -25,7 +25,7 @@ export interface ScoreRow {
 }
 
 export function fetchWatchedMovies(): WatchedMovie[] {
-  const rawDb = getDb();
+  const rawDb = getMediaRawDb();
   return rawDb
     .prepare(
       `SELECT wh.media_id as mediaId,
@@ -40,7 +40,7 @@ export function fetchWatchedMovies(): WatchedMovie[] {
 }
 
 export function fetchWatchlistedIds(): Set<number> {
-  const db = getDrizzle();
+  const db = getMediaDrizzle();
   return new Set(
     db
       .select({ mediaId: mediaWatchlist.mediaId })
@@ -52,7 +52,7 @@ export function fetchWatchlistedIds(): Set<number> {
 }
 
 export function fetchExcludedIds(dimensionId: number): Set<number> {
-  const rawDb = getDb();
+  const rawDb = getMediaRawDb();
   const rows = rawDb
     .prepare(
       `SELECT media_id FROM media_scores
@@ -63,7 +63,7 @@ export function fetchExcludedIds(dimensionId: number): Set<number> {
 }
 
 export function fetchCooloffPairs(dimensionId: number): Set<string> {
-  const rawDb = getDb();
+  const rawDb = getMediaRawDb();
   const globalCount = getGlobalComparisonCount();
   const rows = rawDb
     .prepare(
@@ -85,7 +85,7 @@ export function fetchScoreMap(
   movieIds: number[]
 ): Map<number, { score: number; comparisonCount: number }> {
   if (movieIds.length === 0) return new Map();
-  const rawDb = getDb();
+  const rawDb = getMediaRawDb();
   const placeholders = movieIds.map(() => '?').join(',');
   const scoreRows = rawDb
     .prepare(
@@ -103,7 +103,7 @@ export function fetchScoreMap(
 
 export function fetchPairCountMap(dimensionId: number, movieIds: number[]): Map<string, number> {
   if (movieIds.length === 0) return new Map();
-  const rawDb = getDb();
+  const rawDb = getMediaRawDb();
   const placeholders = movieIds.map(() => '?').join(',');
   const rows = rawDb
     .prepare(
@@ -131,7 +131,7 @@ export function fetchPairCountMap(dimensionId: number, movieIds: number[]): Map<
 
 export function fetchMovieMetaMap(movieIds: number[]): Map<number, MovieMeta> {
   if (movieIds.length === 0) return new Map();
-  const rawDb = getDb();
+  const rawDb = getMediaRawDb();
   const placeholders = movieIds.map(() => '?').join(',');
   const rows = rawDb
     .prepare(

--- a/apps/pops-api/src/modules/media/comparisons/rankings-overall.ts
+++ b/apps/pops-api/src/modules/media/comparisons/rankings-overall.ts
@@ -1,8 +1,8 @@
 import { eq } from 'drizzle-orm';
 
-import { comparisonDimensions } from '@pops/db-types';
+import { comparisonDimensions } from '@pops/media-db';
 
-import { getDb, getDrizzle } from '../../../db.js';
+import { getMediaDrizzle, getMediaRawDb } from '../../../db/media-db-handle.js';
 import { resolvePosterUrl, type RankingRowBase } from './rankings-helpers.js';
 import { calculateOverallConfidence, type RankedMediaEntry } from './types.js';
 
@@ -22,7 +22,7 @@ interface OverallRow extends RankingRowBase {
 }
 
 function getActiveDimensionIds(): number[] {
-  const drizzleDb = getDrizzle();
+  const drizzleDb = getMediaDrizzle();
   return drizzleDb
     .select({ id: comparisonDimensions.id })
     .from(comparisonDimensions)
@@ -55,7 +55,7 @@ function buildFilterContext(
 }
 
 function fetchOverallCount(ctx: FilterContext): number {
-  const rawDb = getDb();
+  const rawDb = getMediaRawDb();
   const result = rawDb
     .prepare(
       `SELECT COUNT(*) as total FROM (
@@ -71,7 +71,7 @@ function fetchOverallCount(ctx: FilterContext): number {
 }
 
 function fetchOverallRows(ctx: FilterContext, limit: number, offset: number): OverallRow[] {
-  const rawDb = getDb();
+  const rawDb = getMediaRawDb();
   return rawDb
     .prepare(
       `SELECT

--- a/apps/pops-api/src/modules/media/comparisons/service.ts
+++ b/apps/pops-api/src/modules/media/comparisons/service.ts
@@ -5,9 +5,8 @@ import { and, eq, or, sql } from 'drizzle-orm';
  *
  * Core orchestrators live here; extracted modules in lib/ handle specific domains.
  */
-import { comparisons, watchHistory } from '@pops/db-types';
+import { comparisons, watchHistory } from '@pops/media-db';
 
-import { getDb, getDrizzle } from '../../../db.js';
 import { getMediaDrizzle } from '../../../db/media-db-handle.js';
 import { NotFoundError, ValidationError } from '../../../shared/errors.js';
 import { getDimension } from './dimensions.service.js';
@@ -70,14 +69,14 @@ function validateRecordInput(input: RecordComparisonInput): void {
 }
 
 function fetchInserted(insertId: number): ComparisonRow {
-  const drizzleDb = getDrizzle();
+  const drizzleDb = getMediaDrizzle();
   const inserted = drizzleDb.select().from(comparisons).where(eq(comparisons.id, insertId)).get();
   if (!inserted) throw new Error('Failed to retrieve recorded comparison');
   return inserted;
 }
 
 function insertOverride(input: RecordComparisonInput, newSource: string): ComparisonRow {
-  const drizzleDb = getDrizzle();
+  const drizzleDb = getMediaDrizzle();
   const result = drizzleDb
     .insert(comparisons)
     .values({
@@ -97,7 +96,7 @@ function insertOverride(input: RecordComparisonInput, newSource: string): Compar
 }
 
 function insertIncremental(input: RecordComparisonInput, newSource: string): ComparisonRow {
-  const drizzleDb = getDrizzle();
+  const drizzleDb = getMediaDrizzle();
   const { deltaA, deltaB } = updateEloScores(input);
   const result = drizzleDb
     .insert(comparisons)
@@ -126,9 +125,8 @@ function insertIncremental(input: RecordComparisonInput, newSource: string): Com
 export function recordComparison(input: RecordComparisonInput): ComparisonRow {
   validateRecordInput(input);
   const newSource = input.source ?? 'arena';
-  const drizzleDb = getDrizzle();
-  const rawDb = getDb();
-  return rawDb.transaction(() => {
+  const drizzleDb = getMediaDrizzle();
+  return drizzleDb.transaction(() => {
     const existing = findExistingComparison({
       dimensionId: input.dimensionId,
       mediaAType: input.mediaAType,
@@ -146,7 +144,7 @@ export function recordComparison(input: RecordComparisonInput): ComparisonRow {
       return insertOverride(input, newSource);
     }
     return insertIncremental(input, newSource);
-  })();
+  });
 }
 
 /**
@@ -154,25 +152,21 @@ export function recordComparison(input: RecordComparisonInput): ComparisonRow {
  * Replays all remaining comparisons in chronological order to ensure accuracy.
  */
 export function deleteComparison(id: number): void {
-  const drizzleDb = getDrizzle();
-  const rawDb = getDb();
+  const drizzleDb = getMediaDrizzle();
 
   const comparison = drizzleDb.select().from(comparisons).where(eq(comparisons.id, id)).get();
   if (!comparison) throw new NotFoundError('Comparison', String(id));
 
   const dimensionId = comparison.dimensionId;
 
-  rawDb.transaction(() => {
-    // Delete the comparison
+  drizzleDb.transaction(() => {
     drizzleDb.delete(comparisons).where(eq(comparisons.id, id)).run();
-
-    // Recalculate ELO for the affected dimension
     recalcDimensionElo(dimensionId);
-  })();
+  });
 }
 
 function findAffectedDimensionIds(mediaType: string, mediaId: number): number[] {
-  const drizzleDb = getDrizzle();
+  const drizzleDb = getMediaDrizzle();
   const affectedComparisons = drizzleDb
     .select()
     .from(comparisons)
@@ -187,20 +181,16 @@ function findAffectedDimensionIds(mediaType: string, mediaId: number): number[] 
 }
 
 /**
- * Blacklist a movie: mark all its watch_history rows as blacklisted,
- * delete all comparisons involving it, and recalculate ELO for affected
- * dimensions. The `watch_history` UPDATE runs on the media handle; the
- * `comparisons` delete + ELO recalc stay on the shared handle (Track L2
- * scope). The outer transaction stays bound to the shared `pops.db` for
- * the comparisons writes — the media UPDATE is a single, idempotent
- * statement that can be replayed safely if a subsequent step fails.
+ * Blacklist a movie: mark all its watch_history rows as blacklisted, delete
+ * all comparisons involving it, and recalculate ELO for affected dimensions.
+ * After the Theme-13 Wave-5 cascade both `watch_history` and `comparisons` (+
+ * `media_scores`) live on the media handle, so the whole flow runs inside a
+ * single intra-pillar drizzle transaction.
  */
 export function blacklistMovie(mediaType: string, mediaId: number): BlacklistMovieResult {
-  const drizzleDb = getDrizzle();
   const mediaDb = getMediaDrizzle();
-  const rawDb = getDb();
 
-  return rawDb.transaction(() => {
+  return mediaDb.transaction(() => {
     const blacklistResult = mediaDb
       .update(watchHistory)
       .set({ blacklisted: 1 })
@@ -215,7 +205,7 @@ export function blacklistMovie(mediaType: string, mediaId: number): BlacklistMov
     const blacklistedCount = blacklistResult.changes;
 
     const affectedDimensionIds = findAffectedDimensionIds(mediaType, mediaId);
-    const deleteResult = drizzleDb
+    const deleteResult = mediaDb
       .delete(comparisons)
       .where(
         or(
@@ -234,7 +224,7 @@ export function blacklistMovie(mediaType: string, mediaId: number): BlacklistMov
       comparisonsDeleted: deleteResult.changes,
       dimensionsRecalculated: affectedDimensionIds.length,
     };
-  })();
+  });
 }
 
 /**

--- a/apps/pops-api/src/modules/media/debrief/queue-status.ts
+++ b/apps/pops-api/src/modules/media/debrief/queue-status.ts
@@ -1,25 +1,25 @@
 import { eq } from 'drizzle-orm';
 
 import { debriefStatus } from '@pops/cerebrum-db';
-import { comparisonDimensions } from '@pops/db-types';
+import { comparisonDimensions } from '@pops/media-db';
 
-import { getDrizzle } from '../../../db.js';
 import { getCerebrumDrizzle } from '../../../db/cerebrum-handle.js';
+import { getMediaDrizzle } from '../../../db/media-db-handle.js';
 
 /**
  * Queue debrief status rows for a media item — one per active dimension.
  *
  * Side-by-side handles (Theme-13 Wave-5 cascade): `comparison_dimensions`
- * still lives on the shared `pops.db` and is read through `getDrizzle()`;
- * the `debrief_status` upserts target the cerebrum handle. On conflict
- * (re-watch), `debriefed` / `dismissed` reset to 0 so the user is prompted
- * to debrief again.
+ * lives on the media handle (closing the cross-pillar JOIN that previously
+ * routed through the shared `pops.db`); the `debrief_status` upserts target
+ * the cerebrum handle. On conflict (re-watch), `debriefed` / `dismissed`
+ * reset to 0 so the user is prompted to debrief again.
  */
 export function queueDebriefStatus(mediaType: string, mediaId: number): number {
-  const sharedDb = getDrizzle();
+  const mediaDb = getMediaDrizzle();
   const cerebrumDb = getCerebrumDrizzle();
 
-  const dims = sharedDb
+  const dims = mediaDb
     .select({ id: comparisonDimensions.id })
     .from(comparisonDimensions)
     .where(eq(comparisonDimensions.active, 1))

--- a/apps/pops-api/src/modules/media/debrief/service.ts
+++ b/apps/pops-api/src/modules/media/debrief/service.ts
@@ -3,14 +3,12 @@ import { and, asc, eq, inArray } from 'drizzle-orm';
 /**
  * Debrief service — auto-queue and manage post-watch debrief sessions.
  * Theme-13 Wave-5 cascade: debrief tables routed through
- * `getCerebrumDrizzle()`, `watch_history` / `movies` via `getMediaDrizzle()`,
- * `comparison_dimensions` still on shared `getDrizzle()`.
+ * `getCerebrumDrizzle()`, `watch_history` / `movies` /
+ * `comparison_dimensions` via `getMediaDrizzle()`.
  */
 import { debriefResults, debriefSessions } from '@pops/cerebrum-db';
-import { comparisonDimensions } from '@pops/db-types';
-import { movies, watchHistory } from '@pops/media-db';
+import { comparisonDimensions, movies, watchHistory } from '@pops/media-db';
 
-import { getDrizzle } from '../../../db.js';
 import { getCerebrumDrizzle } from '../../../db/cerebrum-handle.js';
 import { getMediaDrizzle } from '../../../db/media-db-handle.js';
 import { NotFoundError } from '../../../shared/errors.js';
@@ -117,9 +115,9 @@ function buildDebriefDimensions(
   sessionId: number,
   watchEntry: typeof watchHistory.$inferSelect
 ): DebriefDimension[] {
-  const sharedDb = getDrizzle();
+  const mediaDb = getMediaDrizzle();
   const cerebrumDb = getCerebrumDrizzle();
-  const dims = sharedDb
+  const dims = mediaDb
     .select()
     .from(comparisonDimensions)
     .where(eq(comparisonDimensions.active, 1))

--- a/apps/pops-api/src/modules/media/discovery/service-preference-profile.ts
+++ b/apps/pops-api/src/modules/media/discovery/service-preference-profile.ts
@@ -6,9 +6,9 @@ import {
   mediaScores,
   movies,
   watchHistory,
-} from '@pops/db-types';
+} from '@pops/media-db';
 
-import { getDrizzle } from '../../../db.js';
+import { getMediaDrizzle } from '../../../db/media-db-handle.js';
 
 import type {
   DimensionWeight,
@@ -18,7 +18,7 @@ import type {
 } from './types.js';
 
 function getGenreAffinities(): GenreAffinity[] {
-  const db = getDrizzle();
+  const db = getMediaDrizzle();
   return db
     .select({
       genre: sql<string>`g.value`,
@@ -38,7 +38,7 @@ function getGenreAffinities(): GenreAffinity[] {
 }
 
 function getDimensionWeights(): DimensionWeight[] {
-  const db = getDrizzle();
+  const db = getMediaDrizzle();
   const compCountExpr = sql<number>`COALESCE(SUM(${mediaScores.comparisonCount}), 0)`;
   return db
     .select({
@@ -56,7 +56,7 @@ function getDimensionWeights(): DimensionWeight[] {
 }
 
 function getGenreDistribution(): { genres: GenreDistribution[]; totalWatched: number } {
-  const db = getDrizzle();
+  const db = getMediaDrizzle();
   const [totalResult] = db
     .select({ cnt: sql<number>`COUNT(DISTINCT ${watchHistory.mediaId})` })
     .from(watchHistory)
@@ -91,7 +91,7 @@ function getGenreDistribution(): { genres: GenreDistribution[]; totalWatched: nu
 }
 
 function getTotalComparisons(): number {
-  const db = getDrizzle();
+  const db = getMediaDrizzle();
   const [result] = db.select({ cnt: count() }).from(comparisons).all();
   return result?.cnt ?? 0;
 }

--- a/apps/pops-api/src/modules/media/discovery/shelf/local-score-shelves.ts
+++ b/apps/pops-api/src/modules/media/discovery/shelf/local-score-shelves.ts
@@ -1,9 +1,7 @@
 import { and, eq, sql } from 'drizzle-orm';
 
-import { comparisonDimensions } from '@pops/db-types';
-import { mediaScores, movies } from '@pops/media-db';
+import { comparisonDimensions, mediaScores, movies } from '@pops/media-db';
 
-import { getDrizzle } from '../../../../db.js';
 import { getMediaDrizzle } from '../../../../db/media-db-handle.js';
 import { movieCols, toResult } from './local-shelves-helpers.js';
 import { registerShelf } from './registry.js';
@@ -61,7 +59,7 @@ export const friendProofShelf: ShelfDefinition = {
         emoji: '🍿',
         score: 0.75,
         query: ({ limit, offset }) => {
-          const db = getDrizzle();
+          const db = getMediaDrizzle();
           const allScored = db
             .select({
               ...movieCols,

--- a/apps/pops-api/src/modules/media/discovery/shelf/local-shelves.test.ts
+++ b/apps/pops-api/src/modules/media/discovery/shelf/local-shelves.test.ts
@@ -84,6 +84,10 @@ vi.mock('@pops/media-db', () => ({
     score: 'score',
     dimensionId: 'dimension_id',
   },
+  comparisonDimensions: {
+    id: 'id',
+    name: 'name',
+  },
 }));
 
 vi.mock('./registry.js', () => ({

--- a/apps/pops-api/src/modules/media/plex/scheduler-sync-logs.ts
+++ b/apps/pops-api/src/modules/media/plex/scheduler-sync-logs.ts
@@ -1,8 +1,8 @@
 import { desc } from 'drizzle-orm';
 
-import { syncLogs } from '@pops/db-types';
+import { syncLogs } from '@pops/media-db';
 
-import { getDrizzle } from '../../../db.js';
+import { getMediaDrizzle } from '../../../db/media-db-handle.js';
 
 export interface SyncLogEntry {
   id: number;
@@ -23,7 +23,7 @@ export interface SyncLogRecord {
 
 export function writeSyncLog(record: SyncLogRecord): void {
   const { syncedAt, movieCount, tvCount, errors, durationMs } = record;
-  const db = getDrizzle();
+  const db = getMediaDrizzle();
   db.insert(syncLogs)
     .values({
       syncedAt,
@@ -36,7 +36,7 @@ export function writeSyncLog(record: SyncLogRecord): void {
 }
 
 export function getSyncLogs(limit = 20): SyncLogEntry[] {
-  const db = getDrizzle();
+  const db = getMediaDrizzle();
   const rows = db.select().from(syncLogs).orderBy(desc(syncLogs.syncedAt)).limit(limit).all();
   return rows.map((row) => ({
     id: row.id,
@@ -50,7 +50,7 @@ export function getSyncLogs(limit = 20): SyncLogEntry[] {
 
 export function getLastSyncAt(): string | null {
   try {
-    const db = getDrizzle();
+    const db = getMediaDrizzle();
     const row = db
       .select({ syncedAt: syncLogs.syncedAt })
       .from(syncLogs)
@@ -65,7 +65,7 @@ export function getLastSyncAt(): string | null {
 
 export function getLastSyncCounts(): { moviesSynced: number; tvShowsSynced: number } {
   try {
-    const db = getDrizzle();
+    const db = getMediaDrizzle();
     const row = db
       .select({ moviesSynced: syncLogs.moviesSynced, tvShowsSynced: syncLogs.tvShowsSynced })
       .from(syncLogs)
@@ -83,7 +83,7 @@ export function getLastSyncCounts(): { moviesSynced: number; tvShowsSynced: numb
 
 export function getLastSyncError(): string | null {
   try {
-    const db = getDrizzle();
+    const db = getMediaDrizzle();
     const row = db
       .select({ errors: syncLogs.errors, syncedAt: syncLogs.syncedAt })
       .from(syncLogs)

--- a/apps/pops-api/src/modules/media/plex/scheduler.test.ts
+++ b/apps/pops-api/src/modules/media/plex/scheduler.test.ts
@@ -97,12 +97,37 @@ vi.mock('@pops/core-db', () => ({
   },
 }));
 
+vi.mock('../../../db/media-db-handle.js', () => ({
+  getMediaDrizzle: vi.fn(() => ({
+    select: () => ({
+      from: () => ({
+        orderBy: () => ({
+          limit: () => ({
+            get: (): unknown => null,
+            all: (): unknown[] => mockSelectSyncLogs() as unknown[],
+          }),
+        }),
+      }),
+    }),
+    insert: () => ({
+      values: (vals: Record<string, unknown>) => {
+        if ('syncedAt' in vals) mockInsertSyncLog(vals);
+        return { run: vi.fn() };
+      },
+    }),
+  })),
+}));
+
 vi.mock('drizzle-orm', () => ({
   eq: vi.fn((_col: unknown, val: unknown) => val),
   desc: vi.fn(),
 }));
 
 vi.mock('@pops/db-types', () => ({
+  syncLogs: { syncedAt: 'synced_at', id: 'id', errors: 'errors' },
+}));
+
+vi.mock('@pops/media-db', () => ({
   syncLogs: { syncedAt: 'synced_at', id: 'id', errors: 'errors' },
 }));
 

--- a/packages/media-db/migrations/0032_comparisons_baseline.sql
+++ b/packages/media-db/migrations/0032_comparisons_baseline.sql
@@ -1,0 +1,84 @@
+-- Media pillar baseline for the comparisons cluster (Theme-13 Wave-5 cascade
+-- per PR #3191's MEDIA exit audit, closing the last unfinished per-table PR4
+-- cluster after #3212's media_scores + rotation_* slice). Mirrors the shared
+-- `pops.db` shape from the drizzle-migrations ancestry:
+--   `0002_magical_kid_colt`      — comparison_dimensions + comparisons baseline,
+--   `0009_red_quasimodo`         — ALTER comparison_dimensions ADD weight,
+--   `0013_worthless_speed`       — ALTER comparisons ADD draw_tier,
+--   `0016_certain_namor`         — comparison_skip_cooloffs baseline,
+--   `0022_elo_deltas`            — ALTER comparisons ADD delta_a, delta_b,
+--   `0023_kind_james_howlett`    — ALTER comparisons ADD source.
+--
+-- FK restoration: PR #3212 dropped the cross-pillar
+-- `media_scores.dimension_id -> comparison_dimensions(id)` FK because the
+-- dimensions table still lived on the shared `pops.db` and SQLite FKs cannot
+-- cross ATTACH-ed databases. Both tables now live in media-db so the FK is
+-- restored as an intra-pillar constraint via a `__new_media_scores` rebuild,
+-- mirroring drizzle's standard ALTER TABLE pattern for SQLite.
+--
+-- Existing rows are backfilled into media.db via the ATTACH bridge in
+-- `apps/pops-api/src/db/backfill-media-from-shared.ts`.
+
+CREATE TABLE `comparison_dimensions` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`name` text NOT NULL,
+	`description` text,
+	`active` integer DEFAULT 1 NOT NULL,
+	`sort_order` integer DEFAULT 0 NOT NULL,
+	`weight` real DEFAULT 1 NOT NULL,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `idx_comparison_dimensions_name` ON `comparison_dimensions` (`name`);--> statement-breakpoint
+CREATE TABLE `comparisons` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`dimension_id` integer NOT NULL,
+	`media_a_type` text NOT NULL,
+	`media_a_id` integer NOT NULL,
+	`media_b_type` text NOT NULL,
+	`media_b_id` integer NOT NULL,
+	`winner_type` text NOT NULL,
+	`winner_id` integer NOT NULL,
+	`draw_tier` text,
+	`source` text,
+	`delta_a` integer,
+	`delta_b` integer,
+	`compared_at` text DEFAULT (datetime('now')) NOT NULL,
+	FOREIGN KEY (`dimension_id`) REFERENCES `comparison_dimensions`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE INDEX `idx_comparisons_dimension_id` ON `comparisons` (`dimension_id`);--> statement-breakpoint
+CREATE INDEX `idx_comparisons_media_a` ON `comparisons` (`media_a_type`,`media_a_id`);--> statement-breakpoint
+CREATE INDEX `idx_comparisons_media_b` ON `comparisons` (`media_b_type`,`media_b_id`);--> statement-breakpoint
+CREATE TABLE `comparison_skip_cooloffs` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`dimension_id` integer NOT NULL,
+	`media_a_type` text NOT NULL,
+	`media_a_id` integer NOT NULL,
+	`media_b_type` text NOT NULL,
+	`media_b_id` integer NOT NULL,
+	`skip_until` integer NOT NULL,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL,
+	FOREIGN KEY (`dimension_id`) REFERENCES `comparison_dimensions`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `idx_comparison_skip_cooloffs_pair` ON `comparison_skip_cooloffs` (`dimension_id`,`media_a_type`,`media_a_id`,`media_b_type`,`media_b_id`);--> statement-breakpoint
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_media_scores` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`media_type` text NOT NULL,
+	`media_id` integer NOT NULL,
+	`dimension_id` integer NOT NULL,
+	`score` real DEFAULT 1500 NOT NULL,
+	`comparison_count` integer DEFAULT 0 NOT NULL,
+	`excluded` integer DEFAULT 0 NOT NULL,
+	`updated_at` text DEFAULT (datetime('now')) NOT NULL,
+	FOREIGN KEY (`dimension_id`) REFERENCES `comparison_dimensions`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+INSERT INTO `__new_media_scores`("id", "media_type", "media_id", "dimension_id", "score", "comparison_count", "excluded", "updated_at") SELECT "id", "media_type", "media_id", "dimension_id", "score", "comparison_count", "excluded", "updated_at" FROM `media_scores`;--> statement-breakpoint
+DROP TABLE `media_scores`;--> statement-breakpoint
+ALTER TABLE `__new_media_scores` RENAME TO `media_scores`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+CREATE UNIQUE INDEX `idx_media_scores_unique` ON `media_scores` (`media_type`,`media_id`,`dimension_id`);--> statement-breakpoint
+CREATE INDEX `idx_media_scores_dimension` ON `media_scores` (`dimension_id`);

--- a/packages/media-db/migrations/0033_sync_logs_baseline.sql
+++ b/packages/media-db/migrations/0033_sync_logs_baseline.sql
@@ -1,0 +1,23 @@
+-- Media pillar baseline for the sync_logs ledger (Theme-13 Wave-5 cascade
+-- per PR #3191's MEDIA exit audit, alongside the comparisons cluster in
+-- `0032_comparisons_baseline.sql`). Mirrors the shared `pops.db` shape from
+-- the drizzle-migrations ancestry: `0009_red_quasimodo`.
+--
+-- Although the shared journal entry is owned by `core` (the file also
+-- rebuilt `home_inventory` and seeded several non-media indexes), the
+-- `sync_logs` table itself is a media-pillar ledger of Plex → media-db
+-- sync runs (movie/tv counts, error payloads, durations) — it has no
+-- non-media reader. The 5 consumers all live in
+-- `apps/pops-api/src/modules/media/plex/scheduler-sync-logs.ts`.
+--
+-- Existing rows are backfilled into media.db via the ATTACH bridge in
+-- `apps/pops-api/src/db/backfill-media-from-shared.ts`.
+
+CREATE TABLE `sync_logs` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`synced_at` text NOT NULL,
+	`movies_synced` integer DEFAULT 0 NOT NULL,
+	`tv_shows_synced` integer DEFAULT 0 NOT NULL,
+	`errors` text,
+	`duration_ms` integer
+);

--- a/packages/media-db/migrations/meta/_journal.json
+++ b/packages/media-db/migrations/meta/_journal.json
@@ -78,6 +78,20 @@
       "when": 1797000001000,
       "tag": "0031_rotation_baseline",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1798000000000,
+      "tag": "0032_comparisons_baseline",
+      "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1798000001000,
+      "tag": "0033_sync_logs_baseline",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/media-db/src/__tests__/open-media-db.test.ts
+++ b/packages/media-db/src/__tests__/open-media-db.test.ts
@@ -108,6 +108,14 @@ describe('openMediaDb', () => {
       expect(idxByName.get('idx_media_scores_unique')).toBe(true);
       expect(idxByName.has('idx_media_scores_dimension')).toBe(true);
 
+      // 0032_comparisons_baseline lands AFTER 0030 and restores the
+      // intra-pillar `media_scores.dimension_id -> comparison_dimensions(id)`
+      // FK, so seed the dimension first.
+      raw
+        .prepare(
+          `INSERT INTO comparison_dimensions (id, name, description, active, sort_order, weight) VALUES (1, 'Test Dim', NULL, 1, 0, 1.0)`
+        )
+        .run();
       raw
         .prepare(
           `INSERT INTO media_scores (media_type, media_id, dimension_id, score, comparison_count, excluded) VALUES (?, ?, ?, ?, ?, ?)`
@@ -121,6 +129,116 @@ describe('openMediaDb', () => {
           )
           .run('movie', 1, 1, 1600, 0, 0)
       ).toThrow(/UNIQUE/);
+    } finally {
+      raw.close();
+    }
+  });
+
+  it('applies the comparisons baseline (0032) with the dimensions/comparisons/skip-cooloffs tables and restores the media_scores → comparison_dimensions FK', () => {
+    const path = join(tmpDir, 'media.db');
+    const { raw } = openMediaDb(path);
+    try {
+      const tables = raw
+        .prepare(
+          `SELECT name FROM sqlite_master WHERE type='table' AND name IN ('comparison_dimensions','comparisons','comparison_skip_cooloffs','media_scores')`
+        )
+        .all() as { name: string }[];
+      expect(new Set(tables.map((t) => t.name))).toEqual(
+        new Set([
+          'comparison_dimensions',
+          'comparisons',
+          'comparison_skip_cooloffs',
+          'media_scores',
+        ])
+      );
+
+      const dimColumns = raw.prepare(`PRAGMA table_info(comparison_dimensions)`).all() as {
+        name: string;
+      }[];
+      expect(new Set(dimColumns.map((c) => c.name))).toEqual(
+        new Set(['id', 'name', 'description', 'active', 'sort_order', 'weight', 'created_at'])
+      );
+
+      const compColumns = raw.prepare(`PRAGMA table_info(comparisons)`).all() as {
+        name: string;
+      }[];
+      const compNames = new Set(compColumns.map((c) => c.name));
+      expect(compNames.has('draw_tier')).toBe(true);
+      expect(compNames.has('source')).toBe(true);
+      expect(compNames.has('delta_a')).toBe(true);
+      expect(compNames.has('delta_b')).toBe(true);
+
+      const mediaScoreFks = raw.prepare(`PRAGMA foreign_key_list(media_scores)`).all() as {
+        table: string;
+        from: string;
+        to: string;
+      }[];
+      const dimFk = mediaScoreFks.find((f) => f.from === 'dimension_id');
+      expect(dimFk?.table).toBe('comparison_dimensions');
+      expect(dimFk?.to).toBe('id');
+
+      const dimRow = raw
+        .prepare(
+          `INSERT INTO comparison_dimensions (name, description) VALUES ('Test', 'desc') RETURNING id`
+        )
+        .get() as { id: number };
+      raw
+        .prepare(
+          `INSERT INTO comparisons (dimension_id, media_a_type, media_a_id, media_b_type, media_b_id, winner_type, winner_id) VALUES (?, 'movie', 1, 'movie', 2, 'movie', 1)`
+        )
+        .run(dimRow.id);
+
+      expect(() =>
+        raw
+          .prepare(
+            `INSERT INTO comparisons (dimension_id, media_a_type, media_a_id, media_b_type, media_b_id, winner_type, winner_id) VALUES (?, 'movie', 1, 'movie', 2, 'movie', 1)`
+          )
+          .run(9999)
+      ).toThrow(/FOREIGN KEY/);
+
+      expect(() =>
+        raw
+          .prepare(
+            `INSERT INTO media_scores (media_type, media_id, dimension_id, score, comparison_count, excluded) VALUES ('movie', 1, ?, 1500, 0, 0)`
+          )
+          .run(9999)
+      ).toThrow(/FOREIGN KEY/);
+
+      const cooloffIndexes = raw.prepare(`PRAGMA index_list(comparison_skip_cooloffs)`).all() as {
+        name: string;
+        unique: number;
+      }[];
+      const pairIdx = cooloffIndexes.find((i) => i.name === 'idx_comparison_skip_cooloffs_pair');
+      expect(pairIdx?.unique).toBe(1);
+    } finally {
+      raw.close();
+    }
+  });
+
+  it('applies the sync_logs baseline (0033) with the Plex ledger shape', () => {
+    const path = join(tmpDir, 'media.db');
+    const { raw } = openMediaDb(path);
+    try {
+      const columns = raw.prepare(`PRAGMA table_info(sync_logs)`).all() as {
+        name: string;
+      }[];
+      expect(new Set(columns.map((c) => c.name))).toEqual(
+        new Set(['id', 'synced_at', 'movies_synced', 'tv_shows_synced', 'errors', 'duration_ms'])
+      );
+
+      raw
+        .prepare(
+          `INSERT INTO sync_logs (synced_at, movies_synced, tv_shows_synced, errors, duration_ms) VALUES (?, ?, ?, ?, ?)`
+        )
+        .run(new Date().toISOString(), 5, 2, null, 1234);
+
+      const row = raw
+        .prepare(
+          `SELECT movies_synced as moviesSynced, tv_shows_synced as tvShowsSynced FROM sync_logs LIMIT 1`
+        )
+        .get() as { moviesSynced: number; tvShowsSynced: number } | undefined;
+      expect(row?.moviesSynced).toBe(5);
+      expect(row?.tvShowsSynced).toBe(2);
     } finally {
       raw.close();
     }

--- a/packages/media-db/src/schema.ts
+++ b/packages/media-db/src/schema.ts
@@ -12,6 +12,9 @@
  * subsequent Phase 1 PRs migrate additional media tables into this package.
  */
 export {
+  comparisonDimensions,
+  comparisons,
+  comparisonSkipCooloffs,
   comparisonStaleness,
   dismissedDiscover,
   episodes,
@@ -24,6 +27,7 @@ export {
   rotationSources,
   seasons,
   shelfImpressions,
+  syncLogs,
   tvShows,
   watchHistory,
 } from '@pops/db-types';


### PR DESCRIPTION
## Summary

Theme-13 Wave-5 cascade per PR #3191's MEDIA exit audit, closing the last unfinished per-table PR4 cluster after #3212's media_scores + rotation_* slice. Drops the comparisons cluster (`comparison_dimensions` + `comparisons` + `comparison_skip_cooloffs`) and the Plex `sync_logs` ledger onto `media.db` ahead of the shared-journal cleanup, and unblocks the two sites PR #3212 explicitly deferred because they JOIN-ed across `comparison_dimensions`.

- 4 tables move: `comparison_dimensions`, `comparisons`, `comparison_skip_cooloffs`, `sync_logs`.
- 2 new migrations: `0032_comparisons_baseline.sql` (idx 11) + `0033_sync_logs_baseline.sql` (idx 12).
- 21 writer/reader sites flipped to `getMediaDrizzle()` / `getMediaRawDb()`.
- The 2 deferred sites from PR #3212 (`discovery/service-preference-profile.ts` + `discovery/shelf/local-score-shelves.ts` `friendProofShelf`) are now flipped — every JOIN-ing site is intra-pillar.

## Highlights

**FK restoration.** PR #3212 had to drop the cross-pillar `media_scores.dimension_id -> comparison_dimensions(id)` FK because SQLite FKs can't cross ATTACH-ed files. With both tables now in media-db, `0032_comparisons_baseline.sql` rebuilds `media_scores` via a `__new_media_scores` swap and restores the FK as an intra-pillar constraint.

**Intra-pillar transactions.** Functions that previously bridged a shared raw `getDb().transaction(...)` around `mediaDb` + `sharedDb` writes (`recordComparison`, `deleteComparison`, `blacklistMovie`, `batchRecordComparisons`, `excludeFromDimension`, `recordDebriefComparison`, `recalcDimensionElo`) consolidate to a single `getMediaDrizzle().transaction(...)` (or `getCerebrumDrizzle().transaction(...)` for the debrief writer).

**Cross-pillar JOIN unblock.** `service-preference-profile.ts` and `friendProofShelf` (called out in PR #3212 as deferred) now route every read through `getMediaDrizzle()`. `debrief/queue-status.ts`, `debrief/service.ts`, and the comparisons `lib/debrief-*` helpers also drop their last `getDrizzle()` references — `comparison_dimensions` reads hop to the media handle while debrief writes stay on the cerebrum handle.

**sync_logs.** Stays in the shared `0009_red_quasimodo` journal as `core` (the file also rebuilds `home_inventory`), but the table itself has no non-media reader. Baselined in `0033_sync_logs_baseline.sql` and consumed via `getMediaDrizzle()` from `scheduler-sync-logs.ts`. The `media.plex.getSyncLogs` smoke-harness ignore is removed.

## Test plan

- [x] `pnpm --filter @pops/media-db test` — 9/9 files, 159/159 tests.
- [x] `pnpm --filter @pops/api test src/modules/media` — 90/90 files, 1446/1446 tests.
- [x] `pnpm --filter @pops/api test src/db` — 17/17 files, 128/128 tests.
- [x] `pnpm --filter @pops/api test` — 310/310 files, 4891/4891 tests.
- [x] `pnpm typecheck` — 71/71 tasks green.
- [x] `pnpm lint` — clean (pre-existing warnings only).
- [x] `pnpm lint:boundaries` — passes (baseline regenerated to absorb the new `@pops/media-db` imports from the flipped media modules).

## References

- #3191 — Wave 5 7-pillar audit (MEDIA exit cascade).
- #3212 — media_scores + rotation_* PR4 (the 2 deferred JOIN sites that file enumerated close here).
- #3198 — cerebrum debrief PR4 (mixed-tx writer cutover pattern).
- #3196 — named-import gotcha for pillar-db packages.
- #3194 — stale-mock silent-failure pattern.