### PR TITLE
feat(pillar-sdk): PRD-240 US-02 discoverSettings + findSettingsManifest

### DIFF
--- a/packages/pillar-sdk/src/settings/__tests__/discover-settings.test.ts
+++ b/packages/pillar-sdk/src/settings/__tests__/discover-settings.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest';
+
+import { discoverSettings, findSettingsManifest } from '../discover-settings.js';
+
+import type { PillarSnapshot } from '../../discovery/types.js';
+import type { ManifestPayload, SettingsManifestDescriptor } from '../../manifest-schema/index.js';
+
+function descriptor(
+  id: string,
+  overrides: Partial<SettingsManifestDescriptor> = {}
+): SettingsManifestDescriptor {
+  return {
+    id,
+    title: `${id} settings`,
+    order: 0,
+    groups: [],
+    ...overrides,
+  };
+}
+
+function manifest(
+  pillarId: string,
+  manifests?: readonly SettingsManifestDescriptor[]
+): ManifestPayload {
+  const base: ManifestPayload = {
+    pillar: pillarId,
+    version: '1.0.0',
+    contract: {
+      package: `@pops/${pillarId}-contract`,
+      version: '1.0.0',
+      tag: `contract-${pillarId}@v1.0.0`,
+    },
+    routes: {
+      queries: [],
+      mutations: [],
+      subscriptions: [],
+    },
+    search: { adapters: [] },
+    ai: { tools: [] },
+    uri: { types: [`${pillarId}/entity`] },
+    consumedSettings: { keys: [] },
+    healthcheck: { path: '/health' },
+  };
+  if (manifests === undefined) return base;
+  return { ...base, settings: { manifests: [...manifests] } };
+}
+
+function snapshot(
+  pillarId: string,
+  manifests?: readonly SettingsManifestDescriptor[],
+  registered = true
+): PillarSnapshot {
+  return {
+    pillarId,
+    baseUrl: `https://${pillarId}.test`,
+    manifest: manifest(pillarId, manifests),
+    registered,
+    lastSeenAt: new Date('2026-01-01T00:00:00Z'),
+  };
+}
+
+describe('discoverSettings', () => {
+  it('returns an empty array when the registry has no pillars', async () => {
+    const result = await discoverSettings({ discovery: [] });
+    expect(result).toEqual([]);
+  });
+
+  it('returns the lone contribution when a single pillar contributes one manifest', async () => {
+    const finance = snapshot('finance', [descriptor('finance')]);
+    const result = await discoverSettings({ discovery: [finance] });
+    expect(result.map((m) => m.id)).toEqual(['finance']);
+  });
+
+  it('flattens contributions from a pillar declaring multiple manifests', async () => {
+    const cerebrum = snapshot('cerebrum', [
+      descriptor('cerebrum', { order: 0 }),
+      descriptor('ego', { order: 1 }),
+    ]);
+    const result = await discoverSettings({ discovery: [cerebrum] });
+    expect(result.map((m) => m.id)).toEqual(['cerebrum', 'ego']);
+  });
+
+  it('orders contributions by (pillarId, manifest.order, manifest.id) across pillars', async () => {
+    const media = snapshot('media', [
+      descriptor('plex', { order: 2 }),
+      descriptor('arr', { order: 1 }),
+      descriptor('rotation', { order: 1 }),
+    ]);
+    const finance = snapshot('finance', [descriptor('finance', { order: 0 })]);
+
+    const result = await discoverSettings({ discovery: [media, finance] });
+
+    expect(result.map((m) => m.id)).toEqual(['finance', 'arr', 'rotation', 'plex']);
+  });
+
+  it('skips pillars whose registration is not active', async () => {
+    const active = snapshot('finance', [descriptor('finance')]);
+    const inactive = snapshot('cerebrum', [descriptor('cerebrum')], false);
+
+    const result = await discoverSettings({ discovery: [active, inactive] });
+
+    expect(result.map((m) => m.id)).toEqual(['finance']);
+  });
+
+  it('treats a missing settings block as no contribution', async () => {
+    const contributor = snapshot('finance', [descriptor('finance')]);
+    const silent = snapshot('inventory');
+
+    const result = await discoverSettings({ discovery: [contributor, silent] });
+
+    expect(result.map((m) => m.id)).toEqual(['finance']);
+  });
+
+  it('resolves discovery from an async fetcher', async () => {
+    const finance = snapshot('finance', [descriptor('finance')]);
+    const result = await discoverSettings({ discovery: async () => [finance] });
+    expect(result.map((m) => m.id)).toEqual(['finance']);
+  });
+});
+
+describe('findSettingsManifest', () => {
+  it('returns the matching manifest when an id is present', async () => {
+    const cerebrum = snapshot('cerebrum', [descriptor('cerebrum'), descriptor('ego')]);
+    const manifests = await discoverSettings({ discovery: [cerebrum] });
+
+    const ego = findSettingsManifest(manifests, 'ego');
+
+    expect(ego?.id).toBe('ego');
+  });
+
+  it('returns undefined for an unknown id', async () => {
+    const finance = snapshot('finance', [descriptor('finance')]);
+    const manifests = await discoverSettings({ discovery: [finance] });
+
+    expect(findSettingsManifest(manifests, 'no-such-pillar')).toBeUndefined();
+  });
+});

--- a/packages/pillar-sdk/src/settings/discover-settings.ts
+++ b/packages/pillar-sdk/src/settings/discover-settings.ts
@@ -1,0 +1,112 @@
+/**
+ * Registry-driven settings discovery (PRD-240 US-02 / ADR-037).
+ *
+ * `discoverSettings()` walks the live discovery snapshot, filters to
+ * pillars whose manifest declares a `settings` block, flattens the
+ * per-pillar `manifests` contributions, and returns the array consumers
+ * iterate to render the settings UI tree. Pillars whose registration is
+ * not active (`registered: false`) are skipped — mirroring
+ * `publishEvent()` and `discoverSearchAdapters()`.
+ *
+ * Pure orchestration: discovery is injected (array or fetcher), there is
+ * no module-level fetch. The helper does not own discovery; it consumes
+ * it.
+ *
+ * Lookup by id replaces the named-import pattern the legacy
+ * `@pops/pillar-sdk/settings` barrel exposed. Consumers migrate from:
+ *
+ * ```ts
+ * import { financeManifest } from '@pops/pillar-sdk/settings';
+ * ```
+ *
+ * to:
+ *
+ * ```ts
+ * import { discoverSettings, findSettingsManifest } from '@pops/pillar-sdk/settings';
+ *
+ * const manifests = await discoverSettings({ discovery });
+ * const finance = findSettingsManifest(manifests, 'finance');
+ * ```
+ */
+
+import type { PillarSnapshot } from '../discovery/types.js';
+import type { SettingsManifestDescriptor } from '../manifest-schema/index.js';
+
+export type SettingsDiscoverySource =
+  | readonly PillarSnapshot[]
+  | (() => Promise<readonly PillarSnapshot[]>);
+
+export interface DiscoverSettingsOptions {
+  readonly discovery: SettingsDiscoverySource;
+}
+
+/**
+ * Enumerate every registered pillar's settings manifest contributions
+ * from the supplied discovery snapshot.
+ *
+ * Discovery is resolved at the time of call — passing a fetcher means a
+ * fresh snapshot is read each invocation; passing an array means the
+ * caller has already snapshotted. Either shape matches
+ * `publishEvent()` and `discoverSearchAdapters()`.
+ *
+ * Results are deterministically ordered for stable UI rendering: by
+ * `(pillarId, manifest.order, manifest.id)`. The pillar order matches
+ * the order the registry hands them out, which is the established
+ * cross-pillar iteration order for every other manifest dimension.
+ *
+ * Pillars whose registration is not active are skipped. Pillars that do
+ * not declare a `settings` block (or declare an empty one) contribute
+ * nothing — same fall-through as a pillar with no `sinks` or no
+ * `searchAdapters`.
+ */
+export async function discoverSettings(
+  options: DiscoverSettingsOptions
+): Promise<readonly SettingsManifestDescriptor[]> {
+  const pillars = await resolveDiscovery(options.discovery);
+  const contributions: { pillarId: string; descriptor: SettingsManifestDescriptor }[] = [];
+
+  for (const pillar of pillars) {
+    if (!pillar.registered) continue;
+    const manifests = pillar.manifest.settings?.manifests;
+    if (manifests === undefined || manifests.length === 0) continue;
+    for (const descriptor of manifests) {
+      contributions.push({ pillarId: pillar.pillarId, descriptor });
+    }
+  }
+
+  contributions.sort((a, b) => {
+    if (a.pillarId !== b.pillarId) return a.pillarId < b.pillarId ? -1 : 1;
+    if (a.descriptor.order !== b.descriptor.order) {
+      return a.descriptor.order - b.descriptor.order;
+    }
+    if (a.descriptor.id === b.descriptor.id) return 0;
+    return a.descriptor.id < b.descriptor.id ? -1 : 1;
+  });
+
+  return contributions.map((entry) => entry.descriptor);
+}
+
+/**
+ * Find a single settings manifest by id in a discovery result.
+ *
+ * The named-import replacement: where consumers used to write
+ * `import { financeManifest } from '@pops/pillar-sdk/settings'`, they now
+ * write `findSettingsManifest(await discoverSettings({ discovery }), 'finance')`.
+ *
+ * Returns `undefined` when no manifest with the given id is present —
+ * callers decide whether that is a soft miss (pillar not deployed in this
+ * federation) or a hard error.
+ */
+export function findSettingsManifest(
+  manifests: readonly SettingsManifestDescriptor[],
+  id: string
+): SettingsManifestDescriptor | undefined {
+  return manifests.find((manifest) => manifest.id === id);
+}
+
+async function resolveDiscovery(
+  source: SettingsDiscoverySource
+): Promise<readonly PillarSnapshot[]> {
+  if (typeof source === 'function') return source();
+  return source;
+}

--- a/packages/pillar-sdk/src/settings/index.ts
+++ b/packages/pillar-sdk/src/settings/index.ts
@@ -1,12 +1,25 @@
 /**
- * Pillar-scoped settings manifests, re-exported from each pillar's own
- * contract package. With PRD-239 US-01..US-05 all landed, this barrel reads
- * exclusively from the per-pillar packages; the legacy
- * `@pops/module-registry/settings` subpath is no longer consumed here and is
- * scheduled for deletion in PRD-240 US-05.
+ * `@pops/pillar-sdk/settings` — settings UI manifest discovery surface
+ * (PRD-240 / ADR-037).
  *
- * Pure re-export — no shape change, no runtime behaviour change.
+ * Settings is the fourth registry-driven manifest dimension, peer of
+ * `searchAdapters` / `aiTools` / `sinks`. `discoverSettings()` walks the
+ * live discovery snapshot and returns the flattened per-pillar
+ * contributions; `findSettingsManifest()` is the by-id lookup that
+ * replaces the legacy named-import pattern.
+ *
+ * The named re-exports below (`financeManifest`, `cerebrumManifest`, …)
+ * are the still-extant migration shim. Consumers migrate to the
+ * discovery surface in PRD-240 US-04; the static barrel body is deleted
+ * in US-05.
  */
+export {
+  discoverSettings,
+  findSettingsManifest,
+  type DiscoverSettingsOptions,
+  type SettingsDiscoverySource,
+} from './discover-settings.js';
+
 export { aiConfigManifest, coreOperationalManifest } from '@pops/core-contract/settings';
 export { cerebrumManifest, egoManifest } from '@pops/cerebrum-contract/settings';
 export { financeManifest } from '@pops/finance-contract/settings';


### PR DESCRIPTION
## Summary

- Adds `discoverSettings({ discovery })` to `@pops/pillar-sdk/settings` — the registry-driven enumerator that walks the live discovery snapshot, filters to active pillars whose manifest carries a `settings` block, and returns the flattened `SettingsManifestDescriptor[]` ordered by `(pillarId, manifest.order, manifest.id)`.
- Adds `findSettingsManifest(manifests, id)` — the by-id lookup that replaces the legacy named-import access pattern (`import { financeManifest } from '@pops/pillar-sdk/settings'` → `findSettingsManifest(await discoverSettings({ discovery }), 'finance')`).
- The static named re-exports are left in place; they are removed in PRD-240 US-05 after consumers migrate in US-04.

Pattern mirrors `publishEvent()` (PRD-236 sinks): discovery is injected as `readonly PillarSnapshot[] | () => Promise<readonly PillarSnapshot[]>`, no module-level fetch, no hidden state.

Rides on #3217 (US-01 `ManifestPayloadSchema.settings`). Design recorded in [ADR-037](docs/architecture/adr-037-settings-as-manifest-dimension.md).

## Test plan

- [x] `pnpm --filter @pops/pillar-sdk test` — 523 tests pass (9 new tests cover empty registry, single contribution, multi-manifest flattening, cross-pillar ordering, unregistered-pillar skip, missing-settings-block fall-through, async fetcher resolution, `findSettingsManifest` happy path + miss).
- [x] `pnpm --filter @pops/pillar-sdk typecheck` clean.
- [x] `pnpm --filter @pops/pillar-sdk build` clean.
- [x] Workspace `pnpm typecheck` clean (71/71 packages).
- [x] Pre-push husky hook (full typecheck) passed.