### PR TITLE
feat(pops-core-api): PRD-240 US-03 declare settings dimension

### DIFF
--- a/apps/pops-core-api/package.json
+++ b/apps/pops-core-api/package.json
@@ -17,6 +17,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@pops/core-contract": "workspace:*",
     "@pops/core-db": "workspace:*",
     "@pops/pillar-sdk": "workspace:*",
     "@pops/types": "workspace:*",

--- a/apps/pops-core-api/src/__tests__/core-manifest.test.ts
+++ b/apps/pops-core-api/src/__tests__/core-manifest.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Smoke test for the hand-rolled core pillar manifest payload (PRD-240
+ * US-03). Confirms the payload passes `validateManifestPayload` and
+ * exposes both `aiConfigManifest` + `coreOperationalManifest` as
+ * descriptors under `settings.manifests`.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { aiConfigManifest, coreOperationalManifest } from '@pops/core-contract/settings';
+import { validateManifestPayload } from '@pops/pillar-sdk';
+
+import { buildCoreManifest } from '../core-manifest.js';
+
+describe('buildCoreManifest — PRD-240 US-03 settings dimension', () => {
+  it('passes validateManifestPayload', () => {
+    const manifest = buildCoreManifest('0.0.1-test');
+    const result = validateManifestPayload(manifest);
+    expect(result.ok).toBe(true);
+  });
+
+  it('declares aiConfigManifest + coreOperationalManifest under settings.manifests', () => {
+    const manifest = buildCoreManifest('0.0.1-test');
+    expect(manifest.settings?.manifests).toEqual([aiConfigManifest, coreOperationalManifest]);
+  });
+
+  it('exposes both descriptors by id', () => {
+    const manifest = buildCoreManifest('0.0.1-test');
+    const ids = manifest.settings?.manifests.map((m) => m.id) ?? [];
+    expect(ids).toContain('ai.config');
+    expect(ids).toContain('core.operational');
+  });
+});

--- a/apps/pops-core-api/src/core-manifest.ts
+++ b/apps/pops-core-api/src/core-manifest.ts
@@ -1,0 +1,40 @@
+/**
+ * Hand-rolled core pillar manifest payload.
+ *
+ * Lives in its own module (rather than inline in `server.ts`) so tests can
+ * import the builder without triggering the boot side-effects that
+ * `server.ts` runs at module top-level (`openCoreDb`, `app.listen`,
+ * signal handlers).
+ */
+import { aiConfigManifest, coreOperationalManifest } from '@pops/core-contract/settings';
+
+import type { ManifestPayload } from '@pops/pillar-sdk/manifest-schema';
+
+export function buildCoreManifest(version: string): ManifestPayload {
+  return {
+    pillar: 'core',
+    version,
+    contract: {
+      package: '@pops/core-contract',
+      version,
+      tag: `contract-core@v${version}`,
+    },
+    routes: {
+      queries: ['core.registry.list', 'core.registry.get', 'core.serviceAccounts.list'],
+      mutations: [
+        'core.registry.register',
+        'core.registry.deregister',
+        'core.registry.heartbeat',
+        'core.serviceAccounts.create',
+        'core.serviceAccounts.revoke',
+      ],
+      subscriptions: [],
+    },
+    search: { adapters: [] },
+    ai: { tools: [] },
+    uri: { types: [] },
+    consumedSettings: { keys: [] },
+    settings: { manifests: [aiConfigManifest, coreOperationalManifest] },
+    healthcheck: { path: '/health' },
+  };
+}

--- a/apps/pops-core-api/src/server.ts
+++ b/apps/pops-core-api/src/server.ts
@@ -22,13 +22,12 @@ import { openCoreDb } from '@pops/core-db';
 import { bootstrapPillar, type PillarBootstrapHandle } from '@pops/pillar-sdk/bootstrap';
 
 import { createCoreApiApp } from './app.js';
+import { buildCoreManifest } from './core-manifest.js';
 import { resolveCoreSqlitePath } from './core-sqlite-path.js';
 import { reconcileRegistryOnBoot } from './modules/registry/boot.js';
 import { startEvictionTicker } from './modules/registry/eviction-ticker.js';
 import { startHeartbeatTicker } from './modules/registry/ticker.js';
 import { parseBareOrigin } from './pillars/env.js';
-
-import type { ManifestPayload } from '@pops/pillar-sdk/manifest-schema';
 
 function resolvePort(): number {
   const raw = process.env['PORT'];
@@ -38,34 +37,6 @@ function resolvePort(): number {
     throw new Error(`[core-api] PORT must be a positive integer in 1-65535; got '${raw}'`);
   }
   return parsed;
-}
-
-function buildCoreManifest(version: string): ManifestPayload {
-  return {
-    pillar: 'core',
-    version,
-    contract: {
-      package: '@pops/core-contract',
-      version,
-      tag: `contract-core@v${version}`,
-    },
-    routes: {
-      queries: ['core.registry.list', 'core.registry.get', 'core.serviceAccounts.list'],
-      mutations: [
-        'core.registry.register',
-        'core.registry.deregister',
-        'core.registry.heartbeat',
-        'core.serviceAccounts.create',
-        'core.serviceAccounts.revoke',
-      ],
-      subscriptions: [],
-    },
-    search: { adapters: [] },
-    ai: { tools: [] },
-    uri: { types: [] },
-    consumedSettings: { keys: [] },
-    healthcheck: { path: '/health' },
-  };
 }
 
 const port = resolvePort();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -315,6 +315,9 @@ importers:
 
   apps/pops-core-api:
     dependencies:
+      '@pops/core-contract':
+        specifier: workspace:*
+        version: link:../../packages/core-contract
       '@pops/core-db':
         specifier: workspace:*
         version: link:../../packages/core-db


### PR DESCRIPTION
Wires `aiConfigManifest` + `coreOperationalManifest` from `@pops/core-contract/settings` into the core pillar's hand-rolled manifest payload via `settings.manifests`. Builds on US-01 (#3217) + US-02 (#3219).