### PR TITLE
feat(pops-inventory-api): PRD-240 US-03 declare settings dimension

### DIFF
--- a/apps/pops-inventory-api/package.json
+++ b/apps/pops-inventory-api/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@pops/core-db": "workspace:*",
     "@pops/db-types": "workspace:*",
+    "@pops/inventory-contract": "workspace:*",
     "@pops/inventory-db": "workspace:*",
     "@pops/pillar-sdk": "workspace:*",
     "@pops/types": "workspace:*",

--- a/apps/pops-inventory-api/src/__tests__/manifest.test.ts
+++ b/apps/pops-inventory-api/src/__tests__/manifest.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Manifest contract test — confirms the inventory pillar manifest
+ * payload validates against `ManifestPayloadSchema` and surfaces the
+ * `inventoryManifest` settings contribution introduced by PRD-240 US-03.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { inventoryManifest } from '@pops/inventory-contract/settings';
+import { ManifestPayloadSchema } from '@pops/pillar-sdk/manifest-schema';
+
+import { buildInventoryManifest } from '../manifest.js';
+
+describe('buildInventoryManifest', () => {
+  it('produces a payload that validates against ManifestPayloadSchema', () => {
+    const payload = buildInventoryManifest('1.2.3');
+    const result = ManifestPayloadSchema.safeParse(payload);
+    expect(result.success).toBe(true);
+  });
+
+  it('declares the inventory settings manifest under settings.manifests', () => {
+    const payload = buildInventoryManifest('1.2.3');
+    expect(payload.settings).toEqual({ manifests: [inventoryManifest] });
+  });
+
+  it('threads the version through the contract block', () => {
+    const payload = buildInventoryManifest('4.5.6');
+    expect(payload.contract).toEqual({
+      package: '@pops/inventory-contract',
+      version: '4.5.6',
+      tag: 'contract-inventory@v4.5.6',
+    });
+  });
+});

--- a/apps/pops-inventory-api/src/manifest.ts
+++ b/apps/pops-inventory-api/src/manifest.ts
@@ -1,0 +1,44 @@
+/**
+ * Inventory pillar manifest payload builder.
+ *
+ * Hand-rolled until PRD-155 generates this from the contract. Declares
+ * the inventory settings UI contribution under `settings.manifests` per
+ * PRD-240 US-03.
+ */
+import { inventoryManifest } from '@pops/inventory-contract/settings';
+
+import type { ManifestPayload } from '@pops/pillar-sdk/manifest-schema';
+
+export function buildInventoryManifest(version: string): ManifestPayload {
+  return {
+    pillar: 'inventory',
+    version,
+    contract: {
+      package: '@pops/inventory-contract',
+      version,
+      tag: `contract-inventory@v${version}`,
+    },
+    routes: {
+      queries: [
+        'inventory.locations.tree',
+        'inventory.locations.list',
+        'inventory.locations.get',
+        'inventory.locations.getPath',
+        'inventory.locations.children',
+        'inventory.locations.deleteStats',
+      ],
+      mutations: [
+        'inventory.locations.create',
+        'inventory.locations.update',
+        'inventory.locations.delete',
+      ],
+      subscriptions: [],
+    },
+    search: { adapters: [] },
+    ai: { tools: [] },
+    uri: { types: [] },
+    consumedSettings: { keys: [] },
+    settings: { manifests: [inventoryManifest] },
+    healthcheck: { path: '/health' },
+  };
+}

--- a/apps/pops-inventory-api/src/server.ts
+++ b/apps/pops-inventory-api/src/server.ts
@@ -24,9 +24,8 @@ import { bootstrapPillar, type PillarBootstrapHandle } from '@pops/pillar-sdk/bo
 import { createInventoryApiApp } from './app.js';
 import { resolveCoreSqlitePath } from './core-sqlite-path.js';
 import { resolveInventorySqlitePath } from './inventory-sqlite-path.js';
+import { buildInventoryManifest } from './manifest.js';
 import { parseBareOrigin } from './pillars/env.js';
-
-import type { ManifestPayload } from '@pops/pillar-sdk/manifest-schema';
 
 function resolvePort(): number {
   const raw = process.env['PORT'];
@@ -36,39 +35,6 @@ function resolvePort(): number {
     throw new Error(`[inventory-api] PORT must be a positive integer in 1-65535; got '${raw}'`);
   }
   return parsed;
-}
-
-function buildInventoryManifest(version: string): ManifestPayload {
-  return {
-    pillar: 'inventory',
-    version,
-    contract: {
-      package: '@pops/inventory-contract',
-      version,
-      tag: `contract-inventory@v${version}`,
-    },
-    routes: {
-      queries: [
-        'inventory.locations.tree',
-        'inventory.locations.list',
-        'inventory.locations.get',
-        'inventory.locations.getPath',
-        'inventory.locations.children',
-        'inventory.locations.deleteStats',
-      ],
-      mutations: [
-        'inventory.locations.create',
-        'inventory.locations.update',
-        'inventory.locations.delete',
-      ],
-      subscriptions: [],
-    },
-    search: { adapters: [] },
-    ai: { tools: [] },
-    uri: { types: [] },
-    consumedSettings: { keys: [] },
-    healthcheck: { path: '/health' },
-  };
 }
 
 const port = resolvePort();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -541,6 +541,9 @@ importers:
       '@pops/db-types':
         specifier: workspace:*
         version: link:../../packages/db-types
+      '@pops/inventory-contract':
+        specifier: workspace:*
+        version: link:../../packages/inventory-contract
       '@pops/inventory-db':
         specifier: workspace:*
         version: link:../../packages/inventory-db


### PR DESCRIPTION
## Summary

- Extract `buildInventoryManifest` into `apps/pops-inventory-api/src/manifest.ts` so the contract is testable without booting the server process.
- Contribute the inventory `SettingsManifest` via the new `settings.manifests` block introduced by PRD-240 US-01. Source is the canonical `inventoryManifest` from `@pops/inventory-contract/settings` (relocated under PRD-239 US-02).
- Add `@pops/inventory-contract` as a workspace dependency of `@pops/inventory-api`.
- Add a vitest case that round-trips the payload through `ManifestPayloadSchema` so future schema drift is caught at the pillar boundary.

Refs: [PRD-240 US-03](docs/themes/13-pillar-finale/prds/240-settings-as-manifest-dimension/us-03-pillar-manifest-contributions.md). Builds on PRs #3217 (US-01 schema) + #3219 (US-02 discoverSettings).

> Note: the US-03 acceptance criteria list the five pillar entry files in `apps/pops-api/src/modules/*/index.ts`, but inventory is now its own pillar process (`apps/pops-inventory-api`) — the manifest contribution lives where the manifest payload is actually built and shipped, i.e. `apps/pops-inventory-api/src/manifest.ts`.

## Test plan

- [x] `pnpm --filter @pops/inventory-api test` — 48 passed
- [x] `pnpm turbo typecheck --filter @pops/inventory-api` — clean
- [x] Husky pre-commit + pre-push hooks passed without `--no-verify`