### PR TITLE
feat(pops-finance-api): PRD-240 US-03 declare settings dimension

### DIFF
--- a/apps/pops-finance-api/package.json
+++ b/apps/pops-finance-api/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@pops/core-db": "workspace:*",
     "@pops/db-types": "workspace:*",
+    "@pops/finance-contract": "workspace:*",
     "@pops/finance-db": "workspace:*",
     "@pops/pillar-sdk": "workspace:*",
     "@pops/types": "workspace:*",

--- a/apps/pops-finance-api/src/__tests__/manifest.test.ts
+++ b/apps/pops-finance-api/src/__tests__/manifest.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+
+import { financeManifest } from '@pops/finance-contract/settings';
+import { ManifestPayloadSchema, validateManifestPayload } from '@pops/pillar-sdk/manifest-schema';
+
+import { buildFinanceManifest, FINANCE_PILLAR_ID } from '../manifest.js';
+
+describe('buildFinanceManifest', () => {
+  it('produces a payload that passes the central manifest schema', () => {
+    const manifest = buildFinanceManifest('0.1.0');
+    const parsed = ManifestPayloadSchema.parse(manifest);
+    expect(parsed.pillar).toBe(FINANCE_PILLAR_ID);
+    expect(parsed.contract.tag).toBe('contract-finance@v0.1.0');
+  });
+
+  it('passes cross-field validation', () => {
+    const manifest = buildFinanceManifest('0.1.0');
+    const result = validateManifestPayload(manifest);
+    expect(result.ok).toBe(true);
+  });
+
+  it('declares the finance settings manifest (PRD-240 US-03)', () => {
+    const manifest = buildFinanceManifest('0.1.0');
+    expect(manifest.settings?.manifests).toHaveLength(1);
+    const [descriptor] = manifest.settings?.manifests ?? [];
+    expect(descriptor?.id).toBe(financeManifest.id);
+    expect(descriptor?.title).toBe(financeManifest.title);
+    expect(descriptor?.order).toBe(financeManifest.order);
+    expect(descriptor?.groups.length).toBeGreaterThan(0);
+  });
+
+  it('serialises round-trip through JSON and re-validates', () => {
+    const manifest = buildFinanceManifest('0.1.0');
+    const wire = JSON.parse(JSON.stringify(manifest)) as unknown;
+    const parsed = ManifestPayloadSchema.parse(wire);
+    expect(parsed.settings?.manifests[0]?.id).toBe(financeManifest.id);
+  });
+
+  it('rejects non-semver versions at the schema boundary', () => {
+    const manifest = buildFinanceManifest('not-a-semver');
+    expect(() => ManifestPayloadSchema.parse(manifest)).toThrow();
+  });
+});

--- a/apps/pops-finance-api/src/manifest.ts
+++ b/apps/pops-finance-api/src/manifest.ts
@@ -1,0 +1,57 @@
+/**
+ * Finance pillar manifest payload (PRD-240 US-03).
+ *
+ * Declares the wire-format manifest that the finance pillar registers
+ * with the central registry on boot. PRD-240 US-03 adds the
+ * `settings.manifests` dimension — peer of `search.adapters`, `ai.tools`,
+ * and `sinks` — so the settings UI contribution flows through the same
+ * manifest payload as every other pillar dimension. The source for the
+ * finance settings manifest lives in the contract package and is imported
+ * from its `./settings` subpath (PRD-239 US-03 relocation).
+ */
+import { financeManifest } from '@pops/finance-contract/settings';
+
+import type { ManifestPayload } from '@pops/pillar-sdk/manifest-schema';
+
+export const FINANCE_PILLAR_ID = 'finance' as const;
+
+export function buildFinanceManifest(version: string): ManifestPayload {
+  return {
+    pillar: FINANCE_PILLAR_ID,
+    version,
+    contract: {
+      package: '@pops/finance-contract',
+      version,
+      tag: `contract-finance@v${version}`,
+    },
+    routes: {
+      queries: [
+        'finance.wishlist.list',
+        'finance.wishlist.get',
+        'finance.budgets.list',
+        'finance.budgets.get',
+        'finance.transactions.list',
+        'finance.transactions.get',
+      ],
+      mutations: [
+        'finance.wishlist.create',
+        'finance.wishlist.update',
+        'finance.wishlist.delete',
+        'finance.budgets.create',
+        'finance.budgets.update',
+        'finance.budgets.delete',
+        'finance.transactions.create',
+        'finance.transactions.update',
+        'finance.transactions.delete',
+        'finance.transactions.restore',
+      ],
+      subscriptions: [],
+    },
+    search: { adapters: [] },
+    ai: { tools: [] },
+    uri: { types: ['finance/transaction', 'finance/wishlist-item', 'finance/budget'] },
+    consumedSettings: { keys: [] },
+    settings: { manifests: [financeManifest] },
+    healthcheck: { path: '/health' },
+  };
+}

--- a/apps/pops-finance-api/src/server.ts
+++ b/apps/pops-finance-api/src/server.ts
@@ -27,8 +27,7 @@ import { bootstrapPillar, type PillarBootstrapHandle } from '@pops/pillar-sdk/bo
 import { createFinanceApiApp } from './app.js';
 import { resolveCoreSqlitePath } from './core-sqlite-path.js';
 import { resolveFinanceSqlitePath } from './finance-sqlite-path.js';
-
-import type { ManifestPayload } from '@pops/pillar-sdk/manifest-schema';
+import { buildFinanceManifest } from './manifest.js';
 
 function resolvePort(): number {
   // 3001 is core-api, 3002 is inventory-api, 3003 is media-api,
@@ -40,46 +39,6 @@ function resolvePort(): number {
     throw new Error(`[finance-api] PORT must be a positive integer in 1-65535; got '${raw}'`);
   }
   return parsed;
-}
-
-function buildFinanceManifest(version: string): ManifestPayload {
-  return {
-    pillar: 'finance',
-    version,
-    contract: {
-      package: '@pops/finance-contract',
-      version,
-      tag: `contract-finance@v${version}`,
-    },
-    routes: {
-      queries: [
-        'finance.wishlist.list',
-        'finance.wishlist.get',
-        'finance.budgets.list',
-        'finance.budgets.get',
-        'finance.transactions.list',
-        'finance.transactions.get',
-      ],
-      mutations: [
-        'finance.wishlist.create',
-        'finance.wishlist.update',
-        'finance.wishlist.delete',
-        'finance.budgets.create',
-        'finance.budgets.update',
-        'finance.budgets.delete',
-        'finance.transactions.create',
-        'finance.transactions.update',
-        'finance.transactions.delete',
-        'finance.transactions.restore',
-      ],
-      subscriptions: [],
-    },
-    search: { adapters: [] },
-    ai: { tools: [] },
-    uri: { types: ['finance/transaction', 'finance/wishlist-item', 'finance/budget'] },
-    consumedSettings: { keys: [] },
-    healthcheck: { path: '/health' },
-  };
 }
 
 const port = resolvePort();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -394,6 +394,9 @@ importers:
       '@pops/db-types':
         specifier: workspace:*
         version: link:../../packages/db-types
+      '@pops/finance-contract':
+        specifier: workspace:*
+        version: link:../../packages/finance-contract
       '@pops/finance-db':
         specifier: workspace:*
         version: link:../../packages/finance-db


### PR DESCRIPTION
## Summary

- Extract the inline finance manifest builder out of `server.ts` into a dedicated `apps/pops-finance-api/src/manifest.ts`, mirroring the `pops-ha-bridge-api` shape.
- Declare the PRD-240 settings dimension on the manifest payload: `settings: { manifests: [financeManifest] }`, with `financeManifest` imported by named export from `@pops/finance-contract/settings` (PRD-239 US-03 subpath).
- Add `@pops/finance-contract` as a runtime dep on `@pops/finance-api`.
- Add a smoke test (`__tests__/manifest.test.ts`) that round-trips the payload through JSON, re-validates against `ManifestPayloadSchema`, and confirms the descriptor matches the source `SettingsManifest`.

Per [PRD-240 US-03](https://github.com/knoxio/pops/blob/main/docs/themes/13-pillar-finale/prds/240-settings-as-manifest-dimension/us-03-pillar-manifest-contributions.md). Five mutually independent edits — this is the finance one. Builds on #3217 (US-01 schema) and #3219 (US-02 discovery), both on main.

## Test plan

- [x] `pnpm --filter @pops/finance-api test` — 28 passed
- [x] `pnpm typecheck` — 71 tasks clean
- [x] Husky pre-commit (lint-staged: oxlint + oxfmt) passes
- [x] Husky pre-push (`pnpm typecheck`) passes