### PR TITLE
feat(pops-cerebrum-api): PRD-240 US-03 declare settings dimension

### DIFF
--- a/apps/pops-cerebrum-api/package.json
+++ b/apps/pops-cerebrum-api/package.json
@@ -17,6 +17,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@pops/cerebrum-contract": "workspace:*",
     "@pops/cerebrum-db": "workspace:*",
     "@pops/core-db": "workspace:*",
     "@pops/pillar-sdk": "workspace:*",

--- a/apps/pops-cerebrum-api/src/__tests__/manifest.test.ts
+++ b/apps/pops-cerebrum-api/src/__tests__/manifest.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+
+import { cerebrumManifest, egoManifest } from '@pops/cerebrum-contract/settings';
+import { ManifestPayloadSchema, validateManifestPayload } from '@pops/pillar-sdk/manifest-schema';
+
+import { buildCerebrumManifest, CEREBRUM_PILLAR_ID } from '../manifest.js';
+
+describe('buildCerebrumManifest', () => {
+  it('produces a payload that passes the central manifest schema', () => {
+    const manifest = buildCerebrumManifest('0.1.0');
+    const parsed = ManifestPayloadSchema.parse(manifest);
+    expect(parsed.pillar).toBe(CEREBRUM_PILLAR_ID);
+    expect(parsed.contract.package).toBe('@pops/cerebrum-contract');
+    expect(parsed.contract.tag).toBe('contract-cerebrum@v0.1.0');
+  });
+
+  it('passes the full cross-field validator', () => {
+    const result = validateManifestPayload(buildCerebrumManifest('0.1.0'));
+    expect(result.ok).toBe(true);
+  });
+
+  it('declares both cerebrum and ego settings manifests on the settings dimension (PRD-240 US-03)', () => {
+    const manifest = buildCerebrumManifest('0.1.0');
+    expect(manifest.settings?.manifests.map((m) => m.id)).toEqual([
+      cerebrumManifest.id,
+      egoManifest.id,
+    ]);
+  });
+
+  it('forwards the cerebrum and ego descriptors verbatim from the contract package', () => {
+    const manifest = buildCerebrumManifest('0.1.0');
+    const [cerebrumDescriptor, egoDescriptor] = manifest.settings?.manifests ?? [];
+    expect(cerebrumDescriptor).toEqual(cerebrumManifest);
+    expect(egoDescriptor).toEqual(egoManifest);
+  });
+
+  it('the two declared settings manifests carry distinct ids', () => {
+    const manifest = buildCerebrumManifest('0.1.0');
+    const ids = manifest.settings?.manifests.map((m) => m.id) ?? [];
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('serialises through JSON without losing the settings dimension', () => {
+    const manifest = buildCerebrumManifest('0.1.0');
+    const roundTripped: unknown = JSON.parse(JSON.stringify(manifest));
+    const parsed = ManifestPayloadSchema.parse(roundTripped);
+    expect(parsed.settings?.manifests).toHaveLength(2);
+  });
+
+  it('rejects non-semver versions at the schema boundary', () => {
+    expect(() => ManifestPayloadSchema.parse(buildCerebrumManifest('not-a-semver'))).toThrow();
+  });
+});

--- a/apps/pops-cerebrum-api/src/manifest.ts
+++ b/apps/pops-cerebrum-api/src/manifest.ts
@@ -1,0 +1,39 @@
+import { cerebrumManifest, egoManifest } from '@pops/cerebrum-contract/settings';
+
+import type { ManifestPayload } from '@pops/pillar-sdk/manifest-schema';
+
+export const CEREBRUM_PILLAR_ID = 'cerebrum' as const;
+
+/**
+ * Cerebrum pillar manifest (PRD-240 US-03).
+ *
+ * Declares the `settings.manifests` dimension on the cerebrum API's
+ * manifest payload — the cerebrum sub-domain (`cerebrumManifest`) and
+ * the ego sub-domain (`egoManifest`) per ADR-026. Both descriptors are
+ * sourced from the cerebrum contract package's `./settings` subpath, so
+ * the pillar is the sole declarer of its settings UI contribution. See
+ * [ADR-037](../../../../docs/architecture/adr-037-settings-as-manifest-dimension.md)
+ * for the dimension's design and PRD-240 for the rollout plan.
+ */
+export function buildCerebrumManifest(version: string): ManifestPayload {
+  return {
+    pillar: CEREBRUM_PILLAR_ID,
+    version,
+    contract: {
+      package: '@pops/cerebrum-contract',
+      version,
+      tag: `contract-cerebrum@v${version}`,
+    },
+    routes: {
+      queries: ['cerebrum.nudges.list', 'cerebrum.nudges.get', 'cerebrum.nudges.contradictions'],
+      mutations: ['cerebrum.nudges.dismiss'],
+      subscriptions: [],
+    },
+    search: { adapters: [] },
+    ai: { tools: [] },
+    uri: { types: [] },
+    consumedSettings: { keys: [] },
+    settings: { manifests: [cerebrumManifest, egoManifest] },
+    healthcheck: { path: '/health' },
+  };
+}

--- a/apps/pops-cerebrum-api/src/server.ts
+++ b/apps/pops-cerebrum-api/src/server.ts
@@ -27,8 +27,7 @@ import { bootstrapPillar, type PillarBootstrapHandle } from '@pops/pillar-sdk/bo
 import { createCerebrumApiApp } from './app.js';
 import { resolveCerebrumSqlitePath } from './cerebrum-sqlite-path.js';
 import { resolveCoreSqlitePath } from './core-sqlite-path.js';
-
-import type { ManifestPayload } from '@pops/pillar-sdk/manifest-schema';
+import { buildCerebrumManifest } from './manifest.js';
 
 function resolvePort(): number {
   const raw = process.env['PORT'];
@@ -38,28 +37,6 @@ function resolvePort(): number {
     throw new Error(`[cerebrum-api] PORT must be a positive integer in 1-65535; got '${raw}'`);
   }
   return parsed;
-}
-
-function buildCerebrumManifest(version: string): ManifestPayload {
-  return {
-    pillar: 'cerebrum',
-    version,
-    contract: {
-      package: '@pops/cerebrum-contract',
-      version,
-      tag: `contract-cerebrum@v${version}`,
-    },
-    routes: {
-      queries: ['cerebrum.nudges.list', 'cerebrum.nudges.get', 'cerebrum.nudges.contradictions'],
-      mutations: ['cerebrum.nudges.dismiss'],
-      subscriptions: [],
-    },
-    search: { adapters: [] },
-    ai: { tools: [] },
-    uri: { types: [] },
-    consumedSettings: { keys: [] },
-    healthcheck: { path: '/health' },
-  };
 }
 
 const port = resolvePort();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -232,6 +232,9 @@ importers:
 
   apps/pops-cerebrum-api:
     dependencies:
+      '@pops/cerebrum-contract':
+        specifier: workspace:*
+        version: link:../../packages/cerebrum-contract
       '@pops/cerebrum-db':
         specifier: workspace:*
         version: link:../../packages/cerebrum-db


### PR DESCRIPTION
## Summary

PRD-240 US-03 — cerebrum pillar declares its `settings.manifests` dimension on the manifest payload.

- **New `apps/pops-cerebrum-api/src/manifest.ts`** owns `buildCerebrumManifest` + `CEREBRUM_PILLAR_ID`. Previously the builder was inlined in `server.ts` and unexported, so it wasn't testable.
- **Settings dimension** declared as `settings: { manifests: [cerebrumManifest, egoManifest] }` — both descriptors imported from `@pops/cerebrum-contract/settings` (the PRD-239 US-04 relocation target). Zero imports from `@pops/pillar-sdk/settings` or `@pops/module-registry/settings`.
- **Multi-manifest case.** Per ADR-026, ego is a sub-domain of cerebrum and both manifests belong on the cerebrum pillar's payload. This is the only PRD-240 contribution with two manifests in one pillar (`media` lands four in its own US-03 slice).
- **`@pops/cerebrum-contract`** added as a runtime dep (was previously absent from the cerebrum API package even though the contract package exists).
- **`server.ts`** now imports `buildCerebrumManifest` from `./manifest.js` and drops the stale `ManifestPayload` import.

Rides on PR #3217 (US-01 `ManifestPayloadSchema.settings`) and PR #3219 (US-02 `discoverSettings`), both on `main`.

## Test plan

- [x] `pnpm --filter @pops/cerebrum-api test` — 30/30 pass (6 new in `__tests__/manifest.test.ts`)
- [x] `pnpm --filter @pops/cerebrum-api typecheck` — clean
- [x] `pnpm typecheck` — 71/71 tasks pass
- [x] Husky pre-commit (lint-staged) + pre-push (`pnpm typecheck`) green, no `--no-verify`

## Test coverage

The new `manifest.test.ts` covers:

- Manifest passes `ManifestPayloadSchema.parse` and the full `validateManifestPayload` cross-field validator.
- `settings.manifests` carries `[cerebrumManifest.id, egoManifest.id]` in declared order.
- Descriptors are forwarded verbatim from `@pops/cerebrum-contract/settings` (no drift).
- The two declared ids are distinct (catches accidental future duplication).
- JSON round-trip preserves the settings dimension.
- Non-semver versions are rejected at the schema boundary.

## References

- [ADR-037](docs/architecture/adr-037-settings-as-manifest-dimension.md) — settings as a first-class manifest dimension
- [PRD-240 US-03](docs/themes/13-pillar-finale/prds/240-settings-as-manifest-dimension/us-03-pillar-manifest-contributions.md)
- PR #3217 — PRD-240 US-01 (`ManifestPayloadSchema.settings`)
- PR #3219 — PRD-240 US-02 (`discoverSettings` + `findSettingsManifest`)