### PR TITLE
docs(theme-13): scoping PRD-241 — registry-driven known-modules (audit H1)

### DIFF
--- a/docs/themes/13-pillar-finale/epics/10-fe-sdk-dispatcher-generator.md
+++ b/docs/themes/13-pillar-finale/epics/10-fe-sdk-dispatcher-generator.md
@@ -22,6 +22,7 @@ Make the front-end registry-aware end-to-end. Three pieces:
 | 238 | Settings-imports off module-registry  | Migrate the 8 `apps/pops-api` sites still importing per-pillar `SettingsManifest` from `@pops/module-registry/settings`                                                                                      | Partial — US-01 done; US-02 closes via PRD-240 US-05                                              |
 | 239 | Settings-manifest physical relocation | Move the 10 manifests out of `@pops/module-registry/src/settings` into per-pillar contract packages; repoint `@pops/pillar-sdk/settings`; close PRD-238 US-02                                                | In progress — US-01 / US-03 / US-04 / US-05 done; US-02 in flight; US-06 folds into PRD-240 US-05 |
 | 240 | Settings as a manifest dimension      | Promote settings to a first-class manifest dimension peer of `searchAdapters` / `aiTools` / `sinks`; replace the static SDK barrel with `discoverSettings()`; closes PRD-238 US-02 + PRD-239 US-06 (ADR-037) | Not started                                                                                       |
+| 241 | Registry-driven `known-modules`       | Replace `MANIFEST_SOURCES` literal in `packages/module-registry/scripts/known-modules.ts` with workspace discovery over `@pops/*-contract` packages; closes audit H1; strict predecessor to PRD-218          | Not started                                                                                       |
 
 ## Dependencies
 

--- a/docs/themes/13-pillar-finale/notes/post-13-cleanup-plan.md
+++ b/docs/themes/13-pillar-finale/notes/post-13-cleanup-plan.md
@@ -117,7 +117,8 @@ Should NOT touch PRD content beyond status + framing. Domain redesigns are separ
 
 ### Trial run before committing
 
-Before doing the in-repo reorg, validate the layout on the next *external* pillar:
+Before doing the in-repo reorg, validate the layout on the next _external_ pillar:
+
 - If the HA bridge container moves into the homelab repo, ship it with `pillars/ha-bridge/` shape locally.
 - Or promote PRD-233 Rust pillar to its own repo with the same layout.
 - That gives a working precedent. If the layout creates friction in a self-contained external pillar, it'll create more friction in the monorepo — back off.

--- a/docs/themes/13-pillar-finale/prds/241-registry-driven-known-modules/README.md
+++ b/docs/themes/13-pillar-finale/prds/241-registry-driven-known-modules/README.md
@@ -1,0 +1,112 @@
+# PRD-241: Registry-driven `known-modules`
+
+> Epic: [FE pillar SDK + dispatcher generator](../../epics/10-fe-sdk-dispatcher-generator.md)
+>
+> Status: **Not started**
+>
+> ADRs: [ADR-027](../../../../architecture/adr-027-runtime-pillar-registry.md), [ADR-035](../../../../architecture/adr-035-pillar-redefinition-and-implicit-kinds.md), [ADR-037](../../../../architecture/adr-037-settings-as-manifest-dimension.md)
+
+## Overview
+
+`packages/module-registry/scripts/known-modules.ts` declares `MANIFEST_SOURCES` as a literal array naming every in-repo pillar — `core`, `finance`, `food`, `lists`, `media`, `inventory`, `ai`, `cerebrum`, `ego`. Each entry inlines `id`, `name`, `version`, `surfaces`, `description`, `settings`, and (for `ego`) `frontend.overlay`. The file is the input to `pnpm registry:build`, which emits the 1706-line `packages/module-registry/src/generated.ts` checked into the repo. Every downstream "is this module installed" check loops over `MODULES` / `KNOWN_MODULES` derived from that single literal.
+
+This PRD replaces `MANIFEST_SOURCES` with build-time discovery over the workspace, drops the hand-curated imports, and reduces `generated.ts` to a deterministic projection of whatever the discovery walk found. After the cut-over, adding or removing an in-repo pillar is a contract-package edit — never a `module-registry` edit.
+
+## Background
+
+The [pillar-isolation audit](../../notes/pillar-isolation-audit.md#h1--packagesmodule-registryscriptsknown-modulests-hand-curates-every-pillar) flags `MANIFEST_SOURCES` as **H1 (top-severity)**. The remediation entry is explicit: _"replace the literal `MANIFEST_SOURCES` array with a build step that discovers `packages/<id>-contract/manifest.{ts,json}` (or `apps/pops-<id>-api/manifest.{ts,json}`) and aggregates them. […] The build-time `KNOWN_MODULES` is only needed for type narrowing — emit it from the discovered set."_
+
+PRD-241 is the same shape as [PRD-240](../240-settings-as-manifest-dimension/README.md), one layer deeper:
+
+- PRD-240 deletes the hand-curated `@pops/pillar-sdk/settings` barrel — consumers stop naming pillars.
+- PRD-241 deletes the hand-curated `MANIFEST_SOURCES` literal — the **build script** stops naming pillars.
+
+Both flow from the same anti-lego smell: a single platform-side file enumerating every pillar by name. Audit Findings H2/H3/H4/H5 all mirror H1 — they are downstream copies of the same pattern. H1 is the root.
+
+Adding a new in-repo pillar today requires editing `known-modules.ts`. Removing one requires editing it. External pillars cannot register at all — this file is unreachable from `packages/<id>-contract/` and `apps/pops-<id>-api/`. After [PRD-239](../239-settings-manifest-physical-relocation/README.md), each contract package owns its settings source; after [PRD-240](../240-settings-as-manifest-dimension/README.md), settings flows through registry discovery. The next thing to delete is the literal that still names them.
+
+Each pillar's `@pops/<id>-contract` package already exposes a `./manifest` subpath. PRD-241 takes the existing convention and uses it as the discovery contract: enumerate workspace packages matching `@pops/*-contract`, import each one's `./manifest` export, validate, project. No file in `module-registry` mentions a pillar id.
+
+## Surface
+
+| Surface                                             | Change                                                                                                                                                                                                                                                                                       |
+| --------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `packages/module-registry/scripts/known-modules.ts` | Replace the `MANIFEST_SOURCES` literal + the six named imports with a build-time discovery walk: enumerate workspace packages matching `@pops/*-contract`, import each one's `./manifest` export, collect manifests. Result is the same `readonly ModuleManifest[]` shape today.             |
+| `packages/module-registry/scripts/build.ts`         | No behavioural change. It still validates + sorts + emits `generated.ts`. The input now arrives from discovery instead of a literal. `pnpm registry:build` produces the same artefact for the same workspace state.                                                                          |
+| `packages/module-registry/src/generated.ts`         | Regenerated. The committed artefact is byte-stable across PRD-241 (same manifests, same order — sort is deterministic by id).                                                                                                                                                                |
+| `packages/module-registry/package.json`             | The `devDependencies` block currently lists each `@pops/*-contract` explicitly. After PRD-241 the list stays — it is the workspace-pin set the discovery walk iterates over — but no source file imports them by name. The pins are the discovery scope.                                     |
+| Per-pillar `packages/<id>-contract/`                | No change for contracts that already expose a `./manifest` subpath. Contracts that don't (or pillars without a contract package today: `food`, `lists`, `ai`, `ego`) gain a `./manifest` export carrying the same fields their `MANIFEST_SOURCES` entry currently inlines. Details in US-01. |
+
+After the migration:
+
+```
+packages/<id>-contract            → owns its ModuleManifest, exposed via ./manifest
+packages/module-registry/scripts  → discovers workspace contracts → projects to MANIFEST_SOURCES equivalent
+packages/module-registry/src      → unchanged; consumes the same generated.ts shape
+```
+
+## Business Rules
+
+- **Discovery over enumeration.** The build script reads the workspace once, finds every `@pops/*-contract` package via the workspace manifest, and asks each one for its `ModuleManifest` through its `./manifest` export. No source file in `@pops/module-registry` lists pillar names.
+- **Zero behavioural change to the output.** `generated.ts` is byte-stable for the existing workspace — same manifests, same sort, same `as const` shape. The CI guard (`git diff --exit-code packages/module-registry/src/generated.ts`) stays in place.
+- **Build-time discovery, not runtime.** `module-registry` is consumed as a workspace import — its runtime surface stays unchanged. Discovery happens during `pnpm registry:build` only, so it does not need filesystem access at app runtime.
+- **Contract-package convention is the contract.** A package opts in by being a workspace member matching `@pops/*-contract` and exposing `./manifest` returning a `ModuleManifest`. No registration call, no explicit list edit. Adding a new in-repo pillar = adding a contract package with a manifest export.
+- **The settings dimension stays where PRD-240 puts it.** PRD-241 does not re-touch settings. The discovered `ModuleManifest`s carry whatever settings dimension the contract package contributes — that is upstream of this PRD.
+- **Always-installed set stays explicit.** `ALWAYS_INSTALLED_IDS = ['core']` stays a literal in `known-modules.ts` (or moves to a clearly-named constants file). It is small, semantically distinct (platform-shell contract per PRD-100), and not a per-pillar enumeration.
+- **External pillars are out of scope here, documented at the boundary.** [PRD-233](../233-external-pillar-example-repo/README.md)'s Rust pillar lives outside `packages/` (in `examples/`) and is excluded by the workspace glob. The runtime registry ([ADR-027](../../../../architecture/adr-027-runtime-pillar-registry.md)) is the right path for external pillars; PRD-241 only widens the in-repo gate.
+
+## Edge Cases
+
+| Case                                                                                                                                                             | Behaviour                                                                                                                                                                                                                                                                                                                        |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| A workspace package matches `@pops/*-contract` but exposes no `./manifest`                                                                                       | Skipped with a build-log info line. The package is not a pillar contract — e.g. the legacy `food-contracts` plural variant, or a contract for something not yet promoted to pillar. Discovery does not throw; the build continues with the remaining contracts.                                                                  |
+| Two contract packages export manifests with the same `id`                                                                                                        | Build fails. The existing `assertModuleManifest()` + cross-manifest invariants already catch duplicate ids; discovery just hands them the input. The diagnostic names both offending packages so the conflict is locatable.                                                                                                      |
+| Contract package's `./manifest` export does not satisfy `assertModuleManifest`                                                                                   | Build fails with the contract package's name in the diagnostic. Surfacing the failure at registry-build time is the point — discovery is also a validator.                                                                                                                                                                       |
+| The five pillars currently expressed only inline in `MANIFEST_SOURCES` and lacking a `./manifest` export today (`food`, `lists`, `ai`, `ego`, and `core`'s case) | Each must gain a `./manifest` export in its owning contract package before the cut-over. US-01 covers the per-pillar edits; for each pillar the contract package gains the small `./manifest` export carrying exactly the literal's current fields (`id`, `name`, `surfaces`, `description`, `frontend.overlay` for ego).        |
+| External pillar (PRD-233) wants to opt in                                                                                                                        | Does not work via this discovery path — the Rust pillar lives in `examples/` and the workspace glob does not cover it. Documented as out of scope and routed to ADR-027's runtime registry. PRD-241 explicitly leaves this gap; closing it is a follow-up scoped under the external-pillar story.                                |
+| Generated.ts checked-in artefact drifts from discovery output                                                                                                    | CI runs `pnpm registry:build` and fails on `git diff --exit-code` against `generated.ts`. Existing guard; PRD-241 preserves it.                                                                                                                                                                                                  |
+| Discovery walk runs in a partial workspace (e.g. CI shard with filtered installs)                                                                                | The workspace manifest still lists every contract package even when their `node_modules` are filtered; discovery uses the workspace manifest, not `node_modules`. If a `./manifest` export cannot be resolved, the build fails with a clear "did you run pnpm install?" hint. CI's `pnpm install --frozen-lockfile` covers this. |
+| Contract package is added but `module-registry/package.json` does not list it as a devDependency                                                                 | Build fails on resolution — the workspace pin must exist for `tsx scripts/build.ts` to import `@pops/<id>-contract/manifest`. US-02 includes a check (CI step or test) that every `@pops/*-contract` workspace member is listed as a devDep of `module-registry`, so adding a contract package surfaces the missing pin loudly.  |
+
+## User Stories
+
+| #   | Story                                                                                 | Summary                                                                                                                                                                                                                                                                       | Parallelisable                                  |
+| --- | ------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| 01  | [us-01-add-manifest-export-per-pillar](us-01-add-manifest-export-per-pillar.md)       | Each contract package that does not already have a `./manifest` export gains one carrying exactly the `ModuleManifest` fields its entry currently inlines in `MANIFEST_SOURCES`. No discovery yet; this just makes every pillar uniformly contributable.                      | Yes — one independent edit per contract package |
+| 02  | [us-02-workspace-discovery-build-step](us-02-workspace-discovery-build-step.md)       | Replace `MANIFEST_SOURCES` with a discovery walk over `@pops/*-contract` workspace packages. Delete the hand-curated imports. `pnpm registry:build` produces a byte-identical `generated.ts` for the existing workspace.                                                      | Blocked by US-01                                |
+| 03  | [us-03-document-external-pillar-boundary](us-03-document-external-pillar-boundary.md) | Document the boundary between in-repo discovery (PRD-241) and external-pillar registration ([ADR-027](../../../../architecture/adr-027-runtime-pillar-registry.md), [PRD-233](../233-external-pillar-example-repo/README.md)). Update the audit's H1 entry status. Pure docs. | Yes — independent                               |
+
+US-01 is N independent edits (one per contract package missing a manifest export). US-02 cuts over the build script once every pillar has the export. US-03 is the docs deliverable that closes the audit's H1 entry.
+
+## Acceptance Criteria
+
+Tracked per-US — summary here for orientation:
+
+- Every workspace contract package contributing a pillar (`@pops/core-contract`, `@pops/cerebrum-contract`, `@pops/finance-contract`, `@pops/food-contract`, `@pops/inventory-contract`, `@pops/lists-contract`, `@pops/media-contract`, plus an `ai` and `ego` home — see US-01 for the exact mapping) exposes a `./manifest` subpath returning a structurally-complete `ModuleManifest`.
+- `packages/module-registry/scripts/known-modules.ts` no longer declares `MANIFEST_SOURCES` as a literal; the export becomes a discovery walk over workspace contract packages.
+- `packages/module-registry/scripts/known-modules.ts` no longer imports per-pillar settings manifests by name (`import { cerebrumManifest, … } from '@pops/<id>-contract/settings'`). Every manifest flows through the discovered `ModuleManifest`.
+- `pnpm registry:build` produces a `packages/module-registry/src/generated.ts` byte-identical to the current artefact for the existing workspace. CI's `git diff --exit-code` guard stays clean.
+- Adding a new in-repo pillar requires zero edits in `packages/module-registry/` source files. The only edit is `packages/module-registry/package.json`'s `devDependencies` to pin the new contract package (workspace convention; surfaced by the US-02 check).
+- The audit's [H1 entry](../../notes/pillar-isolation-audit.md#h1--packagesmodule-registryscriptsknown-modulests-hand-curates-every-pillar) is updated to "Closed by PRD-241".
+- `pnpm --filter @pops/module-registry typecheck/test/build`, the full monorepo `pnpm typecheck`, `pnpm lint`, `pnpm build` all pass clean.
+- Husky pre-commit + pre-push pass without `--no-verify`.
+
+## Out of Scope
+
+- **External-pillar discovery in a different repo.** The audit's H1 remediation calls out two paths: (a) widen the in-repo build-time gate via discovery; (b) use the runtime registry ([ADR-027](../../../../architecture/adr-027-runtime-pillar-registry.md)) for pillars outside the workspace. PRD-241 does (a). (b) stays under the broader external-pillar story (post-Theme-13 work scoped against [PRD-233](../233-external-pillar-example-repo/README.md)).
+- **Retiring `@pops/module-registry` itself.** The package still hosts the runtime install-set shim and `KNOWN_MODULES` consumers; retiring it is [PRD-218](../218-module-registry-deprecation/README.md). PRD-241 strictly removes the hand-curation inside the build script.
+- **Closing H2 / H3 / H4 / H5.** Each downstream audit finding has its own PRD (H2 → [PRD-240](../240-settings-as-manifest-dimension/README.md); H3 → ADR-026 monolith retirement; H4 → registry-driven FE manifest discovery; etc.). PRD-241 closes only H1.
+- **Moving `ALWAYS_INSTALLED_IDS` out of `known-modules.ts`.** The constant is small, semantically the platform-shell contract (PRD-100), and not a per-pillar enumeration. Out of scope here.
+- **A new runtime path for `MODULES`.** The runtime surface (`MODULES`, `INSTALLED_MODULES`, `findModule`) does not change. PRD-241 is purely a build-script reshape.
+
+## References
+
+- [Pillar-isolation audit — H1](../../notes/pillar-isolation-audit.md#h1--packagesmodule-registryscriptsknown-modulests-hand-curates-every-pillar) — the finding this PRD closes
+- PR [#3215](https://github.com/knoxio/pops/pull/3215) — the audit doc PR
+- [ADR-027](../../../../architecture/adr-027-runtime-pillar-registry.md) — runtime registry; the path for external (non-workspace) pillars
+- [ADR-035](../../../../architecture/adr-035-pillar-redefinition-and-implicit-kinds.md) — pillar redefinition; manifest is the contract
+- [ADR-037](../../../../architecture/adr-037-settings-as-manifest-dimension.md) — settings dimension precedent for this PRD's discovery direction
+- [PRD-218](../218-module-registry-deprecation/README.md) — final retirement of `@pops/module-registry`; PRD-241 strictly precedes it
+- [PRD-233](../233-external-pillar-example-repo/README.md) — external pillar example; documents the boundary US-03 calls out
+- [PRD-239](../239-settings-manifest-physical-relocation/README.md) — per-pillar settings sources already live in contract packages; prerequisite for the discovered manifest carrying settings cleanly
+- [PRD-240](../240-settings-as-manifest-dimension/README.md) — parallel work, same shape; PRD-241 is the build-script analogue

--- a/docs/themes/13-pillar-finale/prds/241-registry-driven-known-modules/us-01-add-manifest-export-per-pillar.md
+++ b/docs/themes/13-pillar-finale/prds/241-registry-driven-known-modules/us-01-add-manifest-export-per-pillar.md
@@ -1,0 +1,35 @@
+# US-01: Each pillar's contract package exposes a `./manifest` export
+
+> PRD: [PRD-241 — Registry-driven `known-modules`](README.md)
+
+## Description
+
+As a pillar maintainer, I want my pillar's `ModuleManifest` to live in my contract package's `./manifest` subpath — next to my settings source and search-adapter contributions — so that the platform registry can discover it via convention instead of hand-curating it in a central file.
+
+## Acceptance Criteria
+
+- [ ] Every pillar currently enumerated in `packages/module-registry/scripts/known-modules.ts`'s `MANIFEST_SOURCES` exposes a `./manifest` export on its owning contract package:
+  - `@pops/core-contract/manifest` — `ModuleManifest` for `core`: `id: 'core'`, `name: 'Core'`, `version`, `surfaces: ['app']`, `description`, `settings: [aiConfigManifest, coreOperationalManifest]` (the settings carry through from PRD-239 / PRD-240 already).
+  - `@pops/finance-contract/manifest` — `ModuleManifest` for `finance`: full fields as currently inlined in `MANIFEST_SOURCES`.
+  - `@pops/food-contract/manifest` — `ModuleManifest` for `food`: `id`, `name`, `version`, `surfaces`, `description`. No settings (matches today).
+  - `@pops/lists-contract/manifest` — `ModuleManifest` for `lists`: `id`, `name`, `version`, `surfaces`, `description`. No settings (matches today).
+  - `@pops/media-contract/manifest` — `ModuleManifest` for `media`: full fields including `settings: [plexManifest, arrManifest, rotationManifest, mediaOperationalManifest]`.
+  - `@pops/inventory-contract/manifest` — `ModuleManifest` for `inventory`: full fields including `settings: [inventoryManifest]`.
+  - `@pops/cerebrum-contract/manifest` — `ModuleManifest` for `cerebrum`: full fields including `settings: [cerebrumManifest]`.
+- [ ] `ai` and `ego` get explicit homes:
+  - `ai` ships as a sub-manifest from `@pops/core-contract` (its settings already nest under core per [PRD-239](../239-settings-manifest-physical-relocation/README.md)) — `@pops/core-contract/manifest` exports both `coreManifest` and `aiManifest` as `ModuleManifest`s.
+  - `ego` ships as a sub-manifest from `@pops/cerebrum-contract` — `@pops/cerebrum-contract/manifest` exports both `cerebrumManifest` and `egoManifest` as `ModuleManifest`s (mirrors the cerebrum/ego settings nesting from PRD-240).
+- [ ] Each `./manifest` export validates against `assertModuleManifest()` (the same validator `scripts/build.ts` already runs). Unit tests per contract package parse + validate the export.
+- [ ] Each contract package's `package.json` exposes the `./manifest` subpath under `exports` with both `types` and `default` entries. The `dist/manifest.{d.ts,js}` artefacts are produced by the contract package's existing build step.
+- [ ] The fields each export carries are **identical** to the current `MANIFEST_SOURCES` literal entry — same `id`, `name`, `version`, `surfaces`, `description`, `settings`, and (for `ego`) `frontend.overlay`. No drift. The PR description includes a side-by-side diff of each entry.
+- [ ] `pnpm --filter @pops/<id>-contract typecheck/test/build` is clean for every affected package.
+- [ ] Husky pre-commit + pre-push pass without `--no-verify`.
+
+## Notes
+
+- This US is **N mutually-independent edits** — one per contract package. They share no files. Land them in parallel behind the PRD-239 / PRD-240 prerequisites.
+- The `food-contracts` (plural) legacy package is **not** the home for `food`'s manifest. `@pops/food-contract` (singular) is. The plural variant is a pre-rename leftover that this US does not touch.
+- The `core` contract package may need its `package.json` `exports` map extended if `./manifest` is not yet present — same pattern as the existing `./settings` subpath.
+- The `egoManifest` `frontend.overlay` block (`chromeSlot: 'assistant'`, `shortcut: 'mod+i'`) carries through verbatim. Do not re-encode the shortcut elsewhere.
+- This US lands the **exports**. `MANIFEST_SOURCES` still references its in-place imports until [US-02](us-02-workspace-discovery-build-step.md) flips the build script. The two surfaces co-exist briefly — the literal still works, the export is also valid; both resolve to the same `ModuleManifest` values.
+- The [PRD-239](../239-settings-manifest-physical-relocation/README.md) per-pillar relocations are a **hard prerequisite** — until each pillar's settings manifest sources live in its contract package, the `./manifest` export has nothing local to reference. PRD-239 status should show all five relocations as Done before US-01 ends.

--- a/docs/themes/13-pillar-finale/prds/241-registry-driven-known-modules/us-02-workspace-discovery-build-step.md
+++ b/docs/themes/13-pillar-finale/prds/241-registry-driven-known-modules/us-02-workspace-discovery-build-step.md
@@ -1,0 +1,35 @@
+# US-02: Replace `MANIFEST_SOURCES` with workspace discovery
+
+> PRD: [PRD-241 — Registry-driven `known-modules`](README.md)
+
+## Description
+
+As a platform maintainer, I want `pnpm registry:build` to discover every in-repo pillar's `ModuleManifest` by walking the workspace for `@pops/*-contract` packages and importing each one's `./manifest` export, so that adding or removing a pillar never requires editing `packages/module-registry/`.
+
+## Acceptance Criteria
+
+- [ ] `packages/module-registry/scripts/known-modules.ts` no longer declares `MANIFEST_SOURCES` as a literal array. The named manifest imports (`aiConfigManifest`, `coreOperationalManifest`, `financeManifest`, `inventoryManifest`, `arrManifest`, `mediaOperationalManifest`, `plexManifest`, `rotationManifest`, `cerebrumManifest`, `egoManifest`) are deleted.
+- [ ] A new discovery routine — `discoverManifestSources()` (or named equivalent) — enumerates workspace packages matching `@pops/*-contract` via the workspace manifest (`pnpm-workspace.yaml` + each package's `package.json`), imports each one's `./manifest` export, collects the `ModuleManifest` values, and returns the same `readonly ModuleManifest[]` shape `MANIFEST_SOURCES` had.
+- [ ] `MANIFEST_SOURCES` becomes either a thin re-export of the discovery result or is removed in favour of `discoverManifestSources()` being called directly from `scripts/build.ts`. Whichever shape lands, no file lists pillar names.
+- [ ] Workspace packages matching `@pops/*-contract` that do not expose a `./manifest` export are skipped with a build-log info line naming the package. Discovery does not throw; this is the explicit opt-out path (e.g. `food-contracts` plural-legacy, future non-pillar contracts).
+- [ ] Discovery is **build-time only**. `packages/module-registry/src/` source files do not import `node:fs`, `node:path`, or anything else that would force filesystem access at app runtime. The runtime surface (`MODULES`, `INSTALLED_MODULES`, `findModule`) is unchanged.
+- [ ] `pnpm registry:build` produces a `packages/module-registry/src/generated.ts` byte-identical to the current artefact for the existing workspace (same manifests, same sort order, same `as const` literal). The CI guard (`git diff --exit-code packages/module-registry/src/generated.ts`) stays clean.
+- [ ] A test asserts that every `@pops/*-contract` workspace member is listed as a `devDependency` of `@pops/module-registry`'s `package.json`. Missing pins surface as a clear failure pointing at the new contract package.
+- [ ] A test asserts that re-running discovery on the current workspace yields the same `MANIFEST_SOURCES`-equivalent the deleted literal carried (same ids, same fields). The test is the structural regression guard.
+- [ ] `ALWAYS_INSTALLED_IDS = ['core']` stays explicit. It is small and semantically the platform-shell contract per [PRD-100](../../../01-foundation/prds/100-module-system/README.md) — not a per-pillar enumeration.
+- [ ] `pnpm --filter @pops/module-registry typecheck/test/build`, plus the full monorepo `pnpm typecheck`, `pnpm lint`, `pnpm build`, all pass clean.
+- [ ] Husky pre-commit + pre-push pass without `--no-verify`.
+
+## Notes
+
+- **Blocked by [US-01](us-01-add-manifest-export-per-pillar.md).** Discovery cannot succeed until every pillar's contract package exposes its `./manifest` export. US-01 status table should show every pillar as Done before US-02 starts.
+- The discovery walk has two equally-valid implementations:
+  - **Dynamic import** — iterate `@pops/*-contract` workspace pins, `await import('@pops/<id>-contract/manifest')`, collect exports. Simple, relies on tsx's ESM resolver; works because `module-registry/package.json` already lists every contract as a devDep.
+  - **Workspace manifest scan** — parse `pnpm-workspace.yaml` + each package's `package.json`, filter on name pattern, dynamic-import each one's `./manifest`. Slightly more robust against accidentally-missing devDep pins.
+
+  Pick the implementation that requires zero per-pillar edits to `module-registry` going forward. Either way, the contract is "be a workspace `@pops/*-contract` with a `./manifest` export".
+
+- Existing `assertModuleManifest()` + cross-manifest invariants (duplicate ids, dangling `dependsOn`, AI tool name collisions) run on the discovered set unchanged. The validator is the safety net; discovery just hands it the input.
+- A pillar can export multiple `ModuleManifest`s from one contract package — e.g. `@pops/core-contract/manifest` carries both `coreManifest` and `aiManifest`, `@pops/cerebrum-contract/manifest` carries both `cerebrumManifest` and `egoManifest`. The discovery routine flattens these into the `ModuleManifest[]` result. Documented in US-01.
+- After this US lands, the only place a new in-repo pillar gets added is its own contract package + a workspace-pin line in `module-registry/package.json` devDeps. No source-file edit anywhere in `packages/module-registry/`.
+- The generated artefact's stability is the load-bearing CI check. If discovery's iteration order is filesystem-dependent, sort the discovery output by package name before handing it to the rest of the build pipeline so the eventual id-sorted `generated.ts` does not drift between machines.

--- a/docs/themes/13-pillar-finale/prds/241-registry-driven-known-modules/us-03-document-external-pillar-boundary.md
+++ b/docs/themes/13-pillar-finale/prds/241-registry-driven-known-modules/us-03-document-external-pillar-boundary.md
@@ -1,0 +1,26 @@
+# US-03: Document the in-repo / external pillar discovery boundary
+
+> PRD: [PRD-241 — Registry-driven `known-modules`](README.md)
+
+## Description
+
+As a future pillar author, I want the docs to spell out where PRD-241's in-repo discovery stops and where the runtime registry takes over for external pillars, so I know which path to pick when adding a pillar in another repo.
+
+## Acceptance Criteria
+
+- [ ] The [pillar-isolation audit](../../notes/pillar-isolation-audit.md)'s `### H1 — packages/module-registry/scripts/known-modules.ts hand-curates every pillar` entry gains a status line: **Closed by [PRD-241](../prds/241-registry-driven-known-modules/README.md)**. The "In-flight" reference to PRD-218 stays; PRD-241 is the closer for H1 specifically.
+- [ ] [ADR-027](../../../../architecture/adr-027-runtime-pillar-registry.md) gains (or has confirmed already-present) a cross-reference to PRD-241 in the "Related" / "References" section: "PRD-241 covers in-repo discovery for workspace pillars; ADR-027's runtime registry covers external (non-workspace) pillars."
+- [ ] [PRD-218](../218-module-registry-deprecation/README.md) README acknowledges PRD-241 as a strict predecessor: `module-registry` cannot be retired until its hand-curated `known-modules.ts` is replaced. One sentence in the PRD-218 background or sequencing notes is enough.
+- [ ] [PRD-233](../233-external-pillar-example-repo/README.md) README explicitly notes the boundary: the Rust example pillar lives in `examples/` (outside the workspace glob), so PRD-241's discovery does not pick it up. The Rust pillar's path is the runtime registry per ADR-027. One sentence or short "Discovery boundary" note in the PRD background.
+- [ ] The PRD-241 README's `## Out of Scope` and `## Edge Cases` already describe the boundary. US-03 does not duplicate that prose — it makes the audit + ADR-027 + PRD-233 + PRD-218 mutually consistent so a reader landing on any one of them sees the same boundary articulated.
+- [ ] `pnpm format docs/` is clean.
+- [ ] Husky pre-commit + pre-push pass without `--no-verify`.
+
+## Notes
+
+- Pure docs. No code, no tests. The deliverable is internal consistency across four existing files plus the audit note.
+- This US is independent of [US-01](us-01-add-manifest-export-per-pillar.md) and [US-02](us-02-workspace-discovery-build-step.md) — it can land in any order. Most natural is "land first" so the audit + ADR-027 + PRD-218 + PRD-233 references settle before the build cut-over happens, but the deliverable is the same regardless of order.
+- The boundary itself is straightforward and worth restating in one place each:
+  - **In-repo pillar** → contract package in `packages/`, picked up by PRD-241's discovery walk. Zero extra steps.
+  - **External pillar** → registered at runtime via `POPS_PILLARS` + each registered URL's `GET /manifest.json` (ADR-027). The PRD-241 build-time walk does not see it; the runtime registry does.
+- If the audit note already lists "In-flight — PRD-218" against H1, replace it with "Closed by PRD-241" (and keep PRD-218 listed against the broader `module-registry` retirement, not against H1 specifically).


### PR DESCRIPTION
## Summary

- Scopes PRD-241 — replace the `MANIFEST_SOURCES` literal in `packages/module-registry/scripts/known-modules.ts` with build-time workspace discovery over `@pops/*-contract` packages. The build script stops naming pillars.
- Closes audit finding **H1** from the pillar-isolation audit (#3215) — the top-severity, root anti-lego registry. Audit findings H2/H3/H4/H5 are downstream copies of the same pattern.
- Same shape as PRD-240 (settings dimension), one layer deeper: PRD-240 stops consumers from naming pillars; PRD-241 stops the build script from naming them.

## What's in this PR

- `docs/themes/13-pillar-finale/prds/241-registry-driven-known-modules/README.md` — PRD scope
- `docs/themes/13-pillar-finale/prds/241-registry-driven-known-modules/us-01-add-manifest-export-per-pillar.md` — each contract package exposes `./manifest` (N independent edits)
- `docs/themes/13-pillar-finale/prds/241-registry-driven-known-modules/us-02-workspace-discovery-build-step.md` — replace `MANIFEST_SOURCES` with discovery walk (blocked by US-01)
- `docs/themes/13-pillar-finale/prds/241-registry-driven-known-modules/us-03-document-external-pillar-boundary.md` — document the in-repo vs external-pillar boundary; close audit H1 (pure docs)
- Epic table update — `docs/themes/13-pillar-finale/epics/10-fe-sdk-dispatcher-generator.md` gains the PRD-241 row
- One incidental formatter change to `notes/post-13-cleanup-plan.md`

## Scope boundaries

- **In scope:** in-repo pillar discovery via workspace contract packages.
- **Out of scope:** external (non-workspace) pillar discovery — routed to the runtime registry per ADR-027; PRD-233 documents the boundary.
- **Predecessor to PRD-218** — `@pops/module-registry` cannot be retired while its build input is hand-curated.

## Test plan

- [ ] Maintainer reviews the PRD/US scope and confirms US split is correct
- [ ] Confirm `MANIFEST_SOURCES` is the right cut point (vs reshaping `generated.ts`)
- [ ] Confirm the `ai` / `ego` mapping (`ai` → `@pops/core-contract/manifest`, `ego` → `@pops/cerebrum-contract/manifest`) matches the settings nesting from PRD-239 / PRD-240
- [ ] Verify the audit's H1 entry should be marked "Closed by PRD-241" once the work lands (US-03 deliverable)
