### PR TITLE
feat(pops-media-api): PRD-240 US-03 declare settings dimension

### DIFF
--- a/apps/pops-media-api/package.json
+++ b/apps/pops-media-api/package.json
@@ -17,6 +17,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@pops/media-contract": "workspace:*",
     "@pops/media-db": "workspace:*",
     "@pops/pillar-sdk": "workspace:*",
     "@pops/types": "workspace:*",

--- a/apps/pops-media-api/src/__tests__/manifest.test.ts
+++ b/apps/pops-media-api/src/__tests__/manifest.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Manifest payload tests for the media pillar (PRD-240 US-03).
+ *
+ * Asserts that `buildMediaManifest` produces a payload that:
+ *   1. Validates against `ManifestPayloadSchema` (the wire schema bumped
+ *      in US-01).
+ *   2. Declares `settings.manifests` with exactly the four media
+ *      sub-domain manifests (`arr`, `plex`, `rotation`,
+ *      `media-operational`) — sourced from the
+ *      `@pops/media-contract/settings` subpath.
+ *   3. Has unique manifest ids — duplicate ids surface as a clear error.
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+  arrManifest,
+  mediaOperationalManifest,
+  plexManifest,
+  rotationManifest,
+} from '@pops/media-contract/settings';
+import { ManifestPayloadSchema } from '@pops/pillar-sdk/manifest-schema';
+
+import { buildMediaManifest } from '../manifest.js';
+
+describe('buildMediaManifest', () => {
+  it('validates against ManifestPayloadSchema', () => {
+    const payload = buildMediaManifest('0.1.0');
+    const result = ManifestPayloadSchema.safeParse(payload);
+    expect(result.success).toBe(true);
+  });
+
+  it('declares the four media settings manifests in order', () => {
+    const payload = buildMediaManifest('0.1.0');
+    expect(payload.settings).toBeDefined();
+    expect(payload.settings?.manifests).toEqual([
+      arrManifest,
+      plexManifest,
+      rotationManifest,
+      mediaOperationalManifest,
+    ]);
+  });
+
+  it('contains no duplicate settings manifest ids', () => {
+    const payload = buildMediaManifest('0.1.0');
+    const ids = payload.settings?.manifests.map((m) => m.id) ?? [];
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('serialises and round-trips through JSON without losing the settings block', () => {
+    const payload = buildMediaManifest('0.1.0');
+    const roundTripped: unknown = JSON.parse(JSON.stringify(payload));
+    const result = ManifestPayloadSchema.safeParse(roundTripped);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.settings?.manifests.map((m) => m.id)).toEqual([
+        arrManifest.id,
+        plexManifest.id,
+        rotationManifest.id,
+        mediaOperationalManifest.id,
+      ]);
+    }
+  });
+});

--- a/apps/pops-media-api/src/manifest.ts
+++ b/apps/pops-media-api/src/manifest.ts
@@ -1,0 +1,53 @@
+/**
+ * Media pillar manifest payload.
+ *
+ * Theme 13 PRD-158 introduced the registry handshake; this file is the
+ * hand-rolled payload the media-api hands to `bootstrapPillar` at boot
+ * (PRD-155 will generate it later from the contract).
+ *
+ * PRD-240 US-03 adds the `settings.manifests` block — each per-pillar
+ * API contributes its own settings UI descriptors next to
+ * `search.adapters` / `ai.tools` / `sinks`. The four media manifests
+ * (`arr`, `plex`, `rotation`, `media-operational`) flow in from the
+ * `@pops/media-contract/settings` subpath rather than the legacy
+ * `@pops/module-registry/settings` or static `@pops/pillar-sdk/settings`
+ * barrels.
+ */
+import {
+  arrManifest,
+  mediaOperationalManifest,
+  plexManifest,
+  rotationManifest,
+} from '@pops/media-contract/settings';
+
+import type { ManifestPayload } from '@pops/pillar-sdk/manifest-schema';
+
+export const MEDIA_PILLAR_ID = 'media' as const;
+
+export function buildMediaManifest(version: string): ManifestPayload {
+  return {
+    pillar: MEDIA_PILLAR_ID,
+    version,
+    contract: {
+      package: '@pops/media-contract',
+      version,
+      tag: `contract-media@v${version}`,
+    },
+    routes: {
+      queries: [
+        'media.shelfImpressions.getRecentImpressions',
+        'media.shelfImpressions.getShelfFreshness',
+      ],
+      mutations: ['media.shelfImpressions.recordImpressions', 'media.shelfImpressions.cleanup'],
+      subscriptions: [],
+    },
+    search: { adapters: [] },
+    ai: { tools: [] },
+    uri: { types: [] },
+    consumedSettings: { keys: [] },
+    settings: {
+      manifests: [arrManifest, plexManifest, rotationManifest, mediaOperationalManifest],
+    },
+    healthcheck: { path: '/health' },
+  };
+}

--- a/apps/pops-media-api/src/server.ts
+++ b/apps/pops-media-api/src/server.ts
@@ -21,9 +21,8 @@ import { openMediaDb, shelfImpressionsService } from '@pops/media-db';
 import { bootstrapPillar, type PillarBootstrapHandle } from '@pops/pillar-sdk/bootstrap';
 
 import { createMediaApiApp } from './app.js';
+import { buildMediaManifest } from './manifest.js';
 import { resolveMediaSqlitePath } from './media-sqlite-path.js';
-
-import type { ManifestPayload } from '@pops/pillar-sdk/manifest-schema';
 
 function resolvePort(): number {
   // 3001 is core-api, 3002 is inventory-api, 3003 is media-api.
@@ -34,31 +33,6 @@ function resolvePort(): number {
     throw new Error(`[media-api] PORT must be a positive integer in 1-65535; got '${raw}'`);
   }
   return parsed;
-}
-
-function buildMediaManifest(version: string): ManifestPayload {
-  return {
-    pillar: 'media',
-    version,
-    contract: {
-      package: '@pops/media-contract',
-      version,
-      tag: `contract-media@v${version}`,
-    },
-    routes: {
-      queries: [
-        'media.shelfImpressions.getRecentImpressions',
-        'media.shelfImpressions.getShelfFreshness',
-      ],
-      mutations: ['media.shelfImpressions.recordImpressions', 'media.shelfImpressions.cleanup'],
-      subscriptions: [],
-    },
-    search: { adapters: [] },
-    ai: { tools: [] },
-    uri: { types: [] },
-    consumedSettings: { keys: [] },
-    healthcheck: { path: '/health' },
-  };
 }
 
 const port = resolvePort();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -673,6 +673,9 @@ importers:
 
   apps/pops-media-api:
     dependencies:
+      '@pops/media-contract':
+        specifier: workspace:*
+        version: link:../../packages/media-contract
       '@pops/media-db':
         specifier: workspace:*
         version: link:../../packages/media-db


### PR DESCRIPTION
## Summary

Per PRD-240 US-03, the media pillar API now declares its `settings.manifests` block on the manifest payload alongside `search.adapters` / `ai.tools` / `sinks`.

- Extracts the hand-rolled media manifest from `server.ts` into `apps/pops-media-api/src/manifest.ts` (mirrors the ha-bridge layout).
- Adds `settings: { manifests: [arrManifest, plexManifest, rotationManifest, mediaOperationalManifest] }`, sourced from the `@pops/media-contract/settings` subpath — no new imports from the legacy `@pops/module-registry/settings` or static `@pops/pillar-sdk/settings` barrels.
- Adds `@pops/media-contract` as a workspace dependency of `@pops/media-api`.
- New `manifest.test.ts` validates the payload against `ManifestPayloadSchema`, asserts the four manifests are present in order, checks ids are unique, and round-trips through JSON to confirm wire serialisation.

Scope is media-only; sibling pillars (core, inventory, finance, cerebrum) ship US-03 in parallel branches.

## Test plan

- [x] `pnpm --filter @pops/media-api test` clean (4 files / 22 tests).
- [x] `pnpm typecheck` clean across the workspace (71/71).
- [x] `oxlint --type-aware` + `oxfmt --check` clean on touched files.
- [x] Husky pre-commit (lint-staged) + pre-push (typecheck) pass without `--no-verify`.