### PR TITLE
docs(theme-13): scoping PRD-242 — dynamic AppRouter composition (audit H3)

### DIFF
--- a/docs/themes/13-pillar-finale/epics/10-fe-sdk-dispatcher-generator.md
+++ b/docs/themes/13-pillar-finale/epics/10-fe-sdk-dispatcher-generator.md
@@ -23,6 +23,7 @@ Make the front-end registry-aware end-to-end. Three pieces:
 | 239 | Settings-manifest physical relocation | Move the 10 manifests out of `@pops/module-registry/src/settings` into per-pillar contract packages; repoint `@pops/pillar-sdk/settings`; close PRD-238 US-02                                                | In progress — US-01 / US-03 / US-04 / US-05 done; US-02 in flight; US-06 folds into PRD-240 US-05 |
 | 240 | Settings as a manifest dimension      | Promote settings to a first-class manifest dimension peer of `searchAdapters` / `aiTools` / `sinks`; replace the static SDK barrel with `discoverSettings()`; closes PRD-238 US-02 + PRD-239 US-06 (ADR-037) | Not started                                                                                       |
 | 241 | Registry-driven `known-modules`       | Replace `MANIFEST_SOURCES` literal in `packages/module-registry/scripts/known-modules.ts` with workspace discovery over `@pops/*-contract` packages; closes audit H1; strict predecessor to PRD-218          | Not started                                                                                       |
+| 242 | Dynamic `AppRouter` composition       | Replace the hand-curated `KNOWN_ROUTERS` literal in `apps/pops-api/src/router.ts` with a workspace-scan codegen catalogue + runtime `mergeRouters` over PRD-228 externals; closes pillar-isolation audit H3  | Not started                                                                                       |
 
 ## Dependencies
 

--- a/docs/themes/13-pillar-finale/prds/242-dynamic-approuter/README.md
+++ b/docs/themes/13-pillar-finale/prds/242-dynamic-approuter/README.md
@@ -1,0 +1,181 @@
+# PRD-242: Dynamic `AppRouter` composition (type-level catch-up to PRD-228)
+
+> Epic: [FE pillar SDK + dispatcher generator](../../epics/10-fe-sdk-dispatcher-generator.md)
+>
+> Status: **Not started**
+
+## Overview
+
+[PR #3215's pillar-isolation audit](../../notes/pillar-isolation-audit.md) flagged `apps/pops-api/src/router.ts` as the H3 (top-severity) finding: the file's `KNOWN_ROUTERS` literal hand-imports eight pillar routers (`coreRouter`, `cerebrumRouter`, `egoRouter`, `financeRouter`, `foodRouter`, `inventoryRouter`, `listsRouter`, `mediaRouter`) and uses that literal to **type** the exported `AppRouter`. The runtime install set is already discovered via `installedManifests()`; the type-level catalogue is still hand-curated.
+
+The runtime side of pillar discovery has caught up:
+
+- [PRD-228](../228-dynamic-pillar-registration/README.md) lets an external service register a pillar over an HTTP shared-key surface and have the nginx dispatcher pick it up without a code change.
+- [PR #3131](https://github.com/knoxio/pops/pull/3131) shipped `pillar(id).callDynamic(routerName, procName, input, kind)` — the SDK escape hatch that lets a consumer call a procedure on a pillar whose router type is not known at compile time. See `packages/pillar-sdk/src/client/proxy.ts:26-72`.
+- [PRD-233](../233-external-pillar-example-repo/README.md) demonstrates an out-of-tree Rust pillar registering against `pops-core-api` and serving traffic.
+
+PRD-242 closes the _type-level_ gap. It deletes the `KNOWN_ROUTERS` literal, generates `AppRouter` from a workspace scan of in-repo pillar contract packages, and accepts that external pillars route through `callDynamic` rather than the typed proxy. The lego promise — drop a pillar in, no central file edit — finally holds at every layer.
+
+## Background
+
+`apps/pops-api/src/router.ts` (the SUT) is more nuanced than a barrel. It:
+
+1. **Imports eight pillar routers statically** (lines 18-26).
+2. **Builds a literal `KNOWN_ROUTERS` object** keyed by manifest id (lines 42-51) whose per-property types are preserved so the projected `AppRouter` carries exact nested router types per key.
+3. **Picks a runtime subset** via `installedManifests()` and `composeInstalledRouters()` (lines 90-100) — this part already supports the build-time install set baked by `@pops/module-registry`.
+4. **Types `AppRouter`** as `typeof appRouter` (line 122), where `appRouter = router(composeInstalledRouters())` — so `AppRouter`'s shape is the literal's projection.
+
+The runtime composition is already dynamic over `installedManifests()`. The blockers are:
+
+- **The eight `import` statements at the top of the file.** No external pillar can land its router into the dict without editing this file.
+- **The literal-keyed `KNOWN_ROUTERS` object.** External pillar router types cannot extend `AppRouter` at the type level even if they reach the runtime composition, because the type narrows to `Pick<KnownRouters, InstalledRouterId>` and `KnownRouters` is the typeof of that local literal.
+
+[H3 of the audit](../../notes/pillar-isolation-audit.md#h3---appspops-apisrcrouterts-hand-curates-every-pillars-trpc-router) (lines 41-47) names the architecturally correct end state — per ADR-026, each pillar's `-api` container exports its own typed router and the shell instantiates one tRPC client per pillar — but the monolith `apps/pops-api` remains the migration target for the foreseeable future and consumer shells still consume `AppRouter` for type narrowing. PRD-242 is the _interim_ fix that unblocks external pillars while ADR-026's per-`-api` split lands progressively.
+
+## Options Considered
+
+PRD-242 is the most architecturally interesting of the H-findings. Three options were considered before settling on a recommendation.
+
+### Option A — Build-time codegen of the `AppRouter` union from a workspace scan
+
+A codegen step scans `packages/*-contract` (and/or the per-pillar `apps/pops-api/src/modules/*/index.ts` exports) at build time, emits a generated file that imports every in-repo pillar router, and exports an intersection / union type:
+
+```ts
+export type AppRouter = CoreRouter &
+  FoodRouter &
+  CerebrumRouter &
+  InventoryRouter &
+  FinanceRouter &
+  ListsRouter &
+  MediaRouter &
+  EgoRouter;
+```
+
+- **Pro.** The in-repo developer experience stays the same: typed end-to-end, `trpc.<pillar>.<router>.<proc>` autocompletes. No central file gets hand-edited when adding an in-repo pillar — the codegen picks it up.
+- **Pro.** Existing consumer shells that consume `AppRouter` keep working unchanged.
+- **Con.** External pillars in other repos still can't extend `AppRouter` — the workspace scan only knows in-repo packages. The lego promise is half-kept.
+- **Con.** Adds a codegen step to the build graph; codegen drift is a recurring class of bug (see [PRD-155](../155-manifest-type-generation/README.md), [PRD-195](../195-type-generation-pipeline/README.md) for precedent).
+
+### Option B — Pure runtime composition via `mergeRouters`, no static type for external pillars
+
+Drop the literal entirely. `appRouter` is built at orchestrator boot from a registry walk via the existing `mergeRouters` export (`apps/pops-api/src/trpc.ts:161`). `AppRouter` becomes a degenerate type that only knows the procedures shape (`{ [routerName: string]: { [procName: string]: AnyProcedure } }`). Every consumer call site loses end-to-end typesafety and must use `pillar(id).callDynamic(...)` (or generated per-pillar SDK proxies).
+
+- **Pro.** No central file owns the pillar catalogue. External pillars are first-class. The lego promise holds at every layer.
+- **Pro.** Aligns naturally with ADR-026's end state (per-`-api` containers, no monolith `AppRouter`).
+- **Con.** Catastrophic regression in in-repo DX. Every existing `trpc.finance.wishlist.list.useQuery()` call site loses static types. The migration cost across the shell is large and PRD-204 has not finished it yet.
+- **Con.** Stalls the H3 fix on completion of the FE-side `pillar()` migration — which is the load-bearing dependency PRD-204 + PRD-227 are still working through.
+
+### Option C — Hybrid: codegen typed catalogue for in-repo pillars; `callDynamic` for external pillars (RECOMMENDED)
+
+Combine A and B. In-repo pillars are picked up by the workspace-scan codegen and stay strongly typed in `AppRouter`. External pillars route through the existing `pillar(id).callDynamic(routerName, procName, input, kind)` escape hatch shipped in [PR #3131](https://github.com/knoxio/pops/pull/3131). The orchestrator uses `mergeRouters` at runtime to compose both classes: codegen-imported routers for in-repo pillars and registry-discovered routers for external pillars.
+
+- **Pro.** Preserves the existing typed in-repo DX. No regression in consumer call sites.
+- **Pro.** Unblocks external pillars at every layer (registry + dispatcher + router catalogue).
+- **Pro.** Aligns with [PRD-228](../228-dynamic-pillar-registration/README.md)'s `origin: 'internal' | 'external'` split — the codegen reads the internal subset, the registry walk yields the external subset.
+- **Pro.** Codegen is local to `apps/pops-api` and one workspace-scan script. No multi-step type-generation pipeline.
+- **Con.** Two code paths (typed vs `callDynamic`) for in-repo vs external pillars. Documented in US-05.
+- **Con.** Still introduces a codegen step. Mitigated by keeping the script in `apps/pops-api/scripts/` with a single output file and a CI guard against staleness.
+
+**Recommended: Option C.** It is the only option that delivers the lego promise without breaking the typed in-repo DX that the entire shell + pops-api codebase relies on today.
+
+## Surface
+
+The change touches four code surfaces:
+
+| Surface                                                                                                   | Change                                                                                                                                                                                                                                         |
+| --------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `apps/pops-api/scripts/generate-app-router-catalogue.ts` (new)                                            | Workspace-scan codegen: walks `apps/pops-api/src/modules/*/index.ts`, emits `apps/pops-api/src/generated/router-catalogue.ts` with the import list and the `KNOWN_ROUTERS` literal shape. Wired into `apps/pops-api`'s `prebuild` script.      |
+| `apps/pops-api/src/generated/router-catalogue.ts` (generated)                                             | Output of the codegen step. Owns the static imports and the typed `KNOWN_ROUTERS` literal. Gitignored or committed with a CI staleness guard — same call as PRD-155 / PRD-195.                                                                 |
+| `apps/pops-api/src/router.ts`                                                                             | Deletes the eight hand-curated `import` lines + the inline `KNOWN_ROUTERS` literal. Consumes the generated catalogue. Adds a runtime `mergeRouters` pass over the registry's `origin: 'external'` pillars and the codegen-derived in-repo set. |
+| Developer documentation (`docs/themes/13-pillar-finale/notes/internal-vs-external-pillars.md` or similar) | Explains the typed-proxy vs `callDynamic` split. Pointed at by US-05. References `pillar(id).callDynamic` in `packages/pillar-sdk/src/client/proxy.ts:26-72`.                                                                                  |
+
+After the migration:
+
+```
+apps/pops-api/scripts/generate-app-router-catalogue.ts   → scans modules/*/index.ts, emits generated catalogue
+apps/pops-api/src/generated/router-catalogue.ts          → KNOWN_ROUTERS literal + per-key router types
+apps/pops-api/src/router.ts                              → consumes catalogue + mergeRouters over registry externals
+@pops/pillar-sdk/client                                  → pillar(id).callDynamic for external pillar procedures (PR #3131)
+```
+
+The eight hand-imported pillar routers no longer appear in any source file under `apps/pops-api/src/router.ts`. Adding an in-repo pillar requires only a manifest entry + the new module directory — no edit to `router.ts`.
+
+## Business Rules
+
+- **Codegen is the single source of truth for in-repo pillar types.** The generated catalogue file is the only place where pillar router imports live. `apps/pops-api/src/router.ts` consumes it and never re-imports a pillar router by name.
+- **CI fails on stale codegen.** A check (e.g. `pnpm --filter @pops/api generate:catalogue --check`) re-runs the codegen and fails if the working tree differs. Same shape as the existing PRD-155 / PRD-195 codegen guards.
+- **External pillars are merged at orchestrator boot, not at module load.** The runtime composition pass uses `installedManifests()` for in-repo pillars (unchanged) and `core.registry.snapshot()` filtered by `origin: 'external'` (per [PRD-228](../228-dynamic-pillar-registration/README.md)) for externals. The result is fed through `mergeRouters` (`apps/pops-api/src/trpc.ts:161`).
+- **External pillar procedures are not in `AppRouter`'s static type.** They are reachable at runtime via the orchestrator but only through `pillar(id).callDynamic(routerName, procName, input, kind)` on the consumer side. This is the [PR #3131](https://github.com/knoxio/pops/pull/3131) escape hatch — already shipped, already tested (`packages/pillar-sdk/src/client/__tests__/call-dynamic.test.ts`).
+- **`AppRouter` keeps narrowing to the installed in-repo subset.** The existing `InstalledRouterId` narrowing (line 62 of `router.ts`) stays. The codegen emits the full in-repo catalogue; runtime composition picks only installed entries. External pillars' procedures are addressable at runtime but typed as `unknown` outputs per `CallDynamicFn` (`packages/pillar-sdk/src/client/proxy.ts:26-33`).
+- **No double-registration.** A pillar id that exists in both the codegen catalogue and the registry's `origin: 'external'` set is rejected at boot. Echoes PRD-228's "external pillars cannot register as core pillars" (409 on id collision).
+- **No new SDK surface.** PRD-242 ships the orchestrator + codegen only. The consumer-side `callDynamic` is the existing surface; no new contract.
+- **Module-registry coupling stays out of scope.** PRD-218 retires `@pops/module-registry`; PRD-242 keeps consuming `installedManifests()` until that PRD lands. The codegen scan reads files, not the registry package.
+
+## Edge Cases
+
+| Case                                                                                                                | Behaviour                                                                                                                                                                                                                                                                                                    |
+| ------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| A new in-repo pillar is added under `apps/pops-api/src/modules/<id>/` but `pnpm generate:catalogue` hasn't been run | CI fails on the staleness guard. The author re-runs codegen and commits the regenerated `apps/pops-api/src/generated/router-catalogue.ts`. No router.ts edit needed.                                                                                                                                         |
+| An external pillar registers with a pillar id that collides with an in-repo entry                                   | Rejected at boot with a clear error naming the conflict. Mirrors PRD-228's reserved-id rejection. The orchestrator does not start a `mergeRouters` for the colliding id.                                                                                                                                     |
+| Codegen emits an import for a module whose router export name does not follow the `<id>Router` convention           | The codegen surfaces a parse-time error naming the offending file. The convention is enforced by the codegen, not by `router.ts`. Existing modules already conform.                                                                                                                                          |
+| Consumer calls `pillar('externalThing').widgets.list()` on the typed proxy (not `callDynamic`)                      | The typed proxy on the client is build-time-typed against the `AppRouter` shape. External pillars are not in `AppRouter`, so this is a TypeScript error at the call site. The author must switch to `pillar('externalThing').callDynamic('widgets', 'list', input)`. Per US-05, the docs make this explicit. |
+| External pillar registers, the orchestrator boots, the pillar then deregisters                                      | PRD-228's deregister path emits a registry event. PRD-242's runtime composition pass re-runs on the same event (debounced with PRD-228's nginx regen). The `mergeRouters` output excludes the deregistered pillar. In-flight calls fail with `not-registered` per PRD-228's heartbeat semantics.             |
+| The orchestrator boots before the registry has any external pillars                                                 | `appRouter` is `mergeRouters(coreRouter, ...inRepoInstalled)`. External merge is a no-op. The registry event subscription keeps the orchestrator ready to splice external pillars in as they register.                                                                                                       |
+| Two external pillars register before the orchestrator finishes its first composition pass                           | The composition pass is idempotent over the latest registry snapshot. The second event triggers a re-run; the second pillar is included. Debounce mirrors PRD-228's nginx regen contract (250ms).                                                                                                            |
+| An in-repo pillar's router file fails to load at orchestrator boot                                                  | Boot fails fast — same behaviour as today. The codegen catalogue treats in-repo imports as static; a syntax error in `apps/pops-api/src/modules/<id>/index.ts` is caught at build time, not at runtime.                                                                                                      |
+| `installedManifests()` returns a manifest id with no matching entry in the generated catalogue                      | Logged + skipped (matches the existing `composeInstalledRouters()` behaviour at line 92 — manifest ids without a `KNOWN_ROUTERS` entry are silently skipped today). Frontend-only modules (`ai`) preserve their no-op path.                                                                                  |
+| `AppRouter` consumed by `apps/pops-shell` after the migration                                                       | Unchanged. `AppRouter`'s static type still narrows to the installed in-repo subset. Shell call sites continue to work without edits. External pillars do not appear in `trpc.<pillar>`; the shell uses `pillar(id).callDynamic` for them.                                                                    |
+| `apps/pops-api`'s docker image build runs in a clean environment without the codegen output                         | The `prebuild` hook runs codegen; the generated file exists by the time `tsc` runs. Same shape as PRD-155 / PRD-195 builds today.                                                                                                                                                                            |
+
+## User Stories
+
+| #   | Story                                                                                                | Summary                                                                                                                                                                                                                                                                                     | Parallelisable                                                                            |
+| --- | ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| 01  | [us-01-workspace-scan-codegen](us-01-workspace-scan-codegen.md)                                      | Build a workspace-scan codegen at `apps/pops-api/scripts/generate-app-router-catalogue.ts`. Output: `apps/pops-api/src/generated/router-catalogue.ts` carrying the in-repo `KNOWN_ROUTERS` literal + per-key router types. Wire into `prebuild`. Add `--check` mode for CI staleness guard. | Yes — foundational, no other prereqs                                                      |
+| 02  | [us-02-runtime-mergerouters-orchestrator](us-02-runtime-mergerouters-orchestrator.md)                | Compose `appRouter` at orchestrator boot from `mergeRouters(<codegen catalogue>, <registry externals>)`. Subscribe to registry `registered` / `deregistered` events; recompose on change with PRD-228's debounce.                                                                           | Blocked by us-01 + [PRD-228](../228-dynamic-pillar-registration/README.md) externals path |
+| 03  | [us-03-delete-known-routers-literal](us-03-delete-known-routers-literal.md)                          | Delete the eight hand-imported pillar router imports + the inline `KNOWN_ROUTERS` literal from `apps/pops-api/src/router.ts`. Re-route consumption through the generated catalogue from US-01. `AppRouter`'s narrowing semantics unchanged.                                                 | Blocked by us-01                                                                          |
+| 04  | [us-04-e2e-external-pillar-procedure-call](us-04-e2e-external-pillar-procedure-call.md)              | Integration test: register an external pillar at runtime via the PRD-228 endpoint, call its procedure via `pillar(id).callDynamic(routerName, procName, input)`, verify the orchestrator's `mergeRouters` output routes the call to the registered base URL, verify deregister removes it.  | Blocked by us-02 + PRD-228 US-01..04                                                      |
+| 05  | [us-05-developer-doc-typed-vs-calldynamic](us-05-developer-doc-typed-vs-calldynamic.md) _(optional)_ | Author the developer-facing note that documents the "in-repo pillar → typed proxy; external pillar → `callDynamic`" split. Lives under `docs/themes/13-pillar-finale/notes/` and cross-links from PRD-228 + PRD-233.                                                                        | Yes — independent of us-01..04                                                            |
+
+US-01 is foundational. US-02 and US-03 are mutually independent once US-01 lands — US-02 wires the runtime composition without removing the literal; US-03 removes the literal once US-02's substitute is live. US-04 is the integration test that proves the loop closes end-to-end. US-05 is a low-cost documentation deliverable that can run in parallel from day one.
+
+## Acceptance Criteria
+
+Tracked per-US — summary here for orientation:
+
+- `apps/pops-api/scripts/generate-app-router-catalogue.ts` exists, runs as part of `apps/pops-api`'s `prebuild`, and emits a generated `KNOWN_ROUTERS` catalogue file under `apps/pops-api/src/generated/`.
+- CI fails when `pnpm --filter @pops/api generate:catalogue --check` detects a stale generated file.
+- `apps/pops-api/src/router.ts` no longer imports `coreRouter`, `cerebrumRouter`, `egoRouter`, `financeRouter`, `foodRouter`, `inventoryRouter`, `listsRouter`, `mediaRouter` by name. The inline `KNOWN_ROUTERS` literal at lines 42-51 is deleted.
+- `appRouter` is composed at orchestrator boot from `mergeRouters(...)` over the codegen catalogue plus registry `origin: 'external'` pillars.
+- The orchestrator subscribes to PRD-228 `registered` / `deregistered` events and recomposes the merged router on each event (debounced 250ms, matches PRD-228's nginx-regen contract).
+- An external pillar registered at runtime via [PRD-228](../228-dynamic-pillar-registration/README.md)'s `/core.registry.register` endpoint is callable via `pillar(id).callDynamic(routerName, procName, input)` end-to-end (US-04 test passes).
+- `AppRouter`'s exported type still narrows to the installed in-repo subset (no regression in shell type-checking).
+- `pnpm --filter @pops/api typecheck/test/build`, `pnpm --filter @pops/pillar-sdk typecheck/test`, and the full monorepo `pnpm typecheck`, `pnpm lint`, `pnpm build` all pass clean.
+- Husky pre-commit + pre-push pass without `--no-verify`.
+
+## Out of Scope
+
+- **The per-`-api` container split for every pillar.** ADR-026's end state — each pillar's `-api` container exports its own typed router, no monolith `AppRouter` — is tracked in the private migration roadmap and lands progressively. PRD-242 is the interim fix that unblocks external pillars while that migration runs.
+- **Generated typed proxies for external pillars.** Out-of-tree pillars could in principle ship typed SDK packages; that's a separate PRD (closer to [PRD-191](../191-client-surface/README.md) and [PRD-195](../195-type-generation-pipeline/README.md)'s scope). PRD-242 accepts that external pillars use `callDynamic`.
+- **Retiring `@pops/module-registry`.** Tracked separately by [PRD-218](../218-module-registry-deprecation/README.md). PRD-242 keeps consuming `installedManifests()` until PRD-218 lands.
+- **Frontend `AppRouter` regeneration.** The shell continues to consume the static `AppRouter` type for in-repo pillars. External pillars are not in `AppRouter`; the shell uses `pillar(id).callDynamic` for them. A future PRD may surface external pillars in the shell's typed catalogue via a separate codegen step.
+- **Multi-instance external pillars.** Inherits PRD-228's one-row-per-pillar-id stance.
+- **Runtime router invalidation on `health-changed → unavailable`.** The orchestrator recomposes on register / deregister; health-driven invalidation is PRD-216's `PillarGuard` rewrite territory.
+- **Cross-language wire-format details.** Covered by [PRD-231](../231-cross-language-wire-format-spec/README.md); PRD-242 assumes the wire format works.
+
+## References
+
+- [Pillar isolation audit — H3](../../notes/pillar-isolation-audit.md) — the finding this PRD closes
+- [PRD-228](../228-dynamic-pillar-registration/README.md) — runtime registration / heartbeat / deregister surface for external pillars (the runtime side of the type-level catch-up)
+- [PRD-233](../233-external-pillar-example-repo/README.md) — the Rust external-pillar example that exercises the full loop
+- [PRD-218](../218-module-registry-deprecation/README.md) — retires `@pops/module-registry`; PRD-242 inherits whatever PRD-218 leaves
+- [PRD-217](../217-nginx-config-generator/README.md) — registry-driven nginx generator; same event subscription shape as PRD-242's orchestrator recomposition
+- [PRD-204 / PRD-227](../227-sdk-consumer-migration-audit/README.md) — consumer migration onto the `pillar()` SDK; PRD-242 inherits their `callDynamic` consumer pattern
+- [ADR-026](../../../../architecture/adr-026-pillar-architecture.md) — the per-`-api` container end state PRD-242 is an interim step toward
+- [ADR-035](../../../../architecture/adr-035-pillar-redefinition-and-implicit-kinds.md) — pillar redefinition; external pillars are first-class
+- [ADR-037](../../../../architecture/adr-037-settings-as-manifest-dimension.md) — precedent for promoting a hand-curated barrel to registry-driven discovery (mirrors PRD-242's intent for `KNOWN_ROUTERS`)
+- PR [#3215](https://github.com/knoxio/pops/pull/3215) — the audit that surfaced H3
+- PR [#3131](https://github.com/knoxio/pops/pull/3131) — shipped `pillar(id).callDynamic`, the consumer escape hatch PRD-242 relies on
+- `apps/pops-api/src/router.ts` — the SUT (lines 18-26 imports, 42-51 literal, 90-100 runtime composition, 119-122 `AppRouter` export)
+- `apps/pops-api/src/trpc.ts:161` — `mergeRouters` export
+- `packages/pillar-sdk/src/client/proxy.ts:26-72` — `CallDynamicFn` definition

--- a/docs/themes/13-pillar-finale/prds/242-dynamic-approuter/us-01-workspace-scan-codegen.md
+++ b/docs/themes/13-pillar-finale/prds/242-dynamic-approuter/us-01-workspace-scan-codegen.md
@@ -1,0 +1,29 @@
+# US-01: Workspace-scan codegen for the `AppRouter` catalogue
+
+> PRD: [PRD-242 — Dynamic `AppRouter` composition](README.md)
+
+## Description
+
+As an `apps/pops-api` maintainer, I want a codegen script that scans `apps/pops-api/src/modules/*/index.ts` and emits a generated `KNOWN_ROUTERS` catalogue file so that adding a new in-repo pillar does not require hand-editing `apps/pops-api/src/router.ts`.
+
+## Acceptance Criteria
+
+- [ ] `apps/pops-api/scripts/generate-app-router-catalogue.ts` exists and is runnable via `pnpm --filter @pops/api generate:catalogue`.
+- [ ] The script walks `apps/pops-api/src/modules/*/index.ts`, identifies each module's exported `<id>Router` (e.g. `coreRouter`, `cerebrumRouter`, `egoRouter`), and emits `apps/pops-api/src/generated/router-catalogue.ts`.
+- [ ] The emitted file imports each router under a deterministic alias and exports a typed `KNOWN_ROUTERS` literal whose keys are manifest ids and whose values are the corresponding router exports. Per-property types are preserved (no widening to a common `Router` base) to keep the existing `AppRouter` inference intact.
+- [ ] The emitted file is deterministic across runs (stable import order, no timestamps in the output).
+- [ ] `pnpm --filter @pops/api generate:catalogue --check` exits non-zero if the working tree's generated file differs from a freshly regenerated one. Wired into CI as a fail-on-stale guard.
+- [ ] The codegen is wired into `apps/pops-api`'s `prebuild` script so docker image builds regenerate the file before `tsc` runs.
+- [ ] The codegen surfaces a parse-time error naming the offending file when a module's `index.ts` does not export a `<id>Router` matching the convention.
+- [ ] Unit tests cover: empty modules dir → empty catalogue, one module → one entry, multiple modules → multiple entries (deterministic order), missing `<id>Router` export → clear error message, frontend-only module without a router → silently skipped (matches existing `composeInstalledRouters()` behaviour).
+- [ ] `pnpm --filter @pops/api typecheck/test/build` is clean.
+- [ ] Husky pre-commit + pre-push pass without `--no-verify`.
+
+## Notes
+
+- The script lives in `apps/pops-api/scripts/` so it sits next to its consumer. No new package; no shared codegen library is introduced.
+- The convention `<id>Router` matches every existing module — see `apps/pops-api/src/router.ts:18-26` (`coreRouter`, `cerebrumRouter`, `egoRouter`, `financeRouter`, `foodRouter`, `inventoryRouter`, `listsRouter`, `mediaRouter`). The codegen enforces this convention; modules added in the future must follow it.
+- Whether the generated file is committed or `.gitignore`d is a maintainer call. The `--check` mode handles either policy: committed → CI fails on stale committed file; gitignored → CI fails if regenerated output is non-empty.
+- The codegen reads files only — it does not import `@pops/module-registry`. PRD-218 (module-registry deprecation) is unaffected.
+- The script's output replaces the inline `KNOWN_ROUTERS` literal at `apps/pops-api/src/router.ts:42-51`. The replacement happens in US-03 once US-02's runtime composition is wired up.
+- Frontend-only modules (e.g. `ai`) don't have an `apps/pops-api/src/modules/<id>/` directory and so don't appear in the scan. They're already a no-op on the API surface; the codegen preserves that.

--- a/docs/themes/13-pillar-finale/prds/242-dynamic-approuter/us-02-runtime-mergerouters-orchestrator.md
+++ b/docs/themes/13-pillar-finale/prds/242-dynamic-approuter/us-02-runtime-mergerouters-orchestrator.md
@@ -1,0 +1,31 @@
+# US-02: Compose `appRouter` at orchestrator boot via `mergeRouters`
+
+> PRD: [PRD-242 — Dynamic `AppRouter` composition](README.md)
+
+## Description
+
+As the `apps/pops-api` orchestrator, I want to compose `appRouter` at boot from `mergeRouters(<codegen catalogue>, <registry externals>)` and to re-run that composition on every registry `registered` / `deregistered` event so that external pillars registered at runtime via [PRD-228](../228-dynamic-pillar-registration/README.md) become reachable through the orchestrator without a restart.
+
+## Acceptance Criteria
+
+- [ ] `appRouter` is built at orchestrator boot by calling `mergeRouters(...)` (exported by `apps/pops-api/src/trpc.ts:161`) over the codegen catalogue from US-01 _and_ the registry's `origin: 'external'` pillars from [PRD-228](../228-dynamic-pillar-registration/README.md).
+- [ ] The in-repo branch of the composition preserves `installedManifests()`-driven narrowing (the existing logic from `apps/pops-api/src/router.ts:90-100`).
+- [ ] The external branch fetches the per-pillar router shape by issuing a tRPC HTTP-link client against the pillar's registered `baseUrl`. The orchestrator mounts that as a passthrough router under the pillar id.
+- [ ] The orchestrator subscribes to the PRD-228 / PRD-163 subscription stream (`type: 'registered' | 'deregistered'`) and recomposes the merged router on every event.
+- [ ] Recomposition is debounced (250ms) — same debounce contract as PRD-228's nginx-regen, so multiple registrations during a deploy collapse to a single recompose.
+- [ ] An external pillar id colliding with an entry in the codegen catalogue is rejected at boot with a clear error naming the conflict. Mirrors PRD-228's reserved-id rejection (409).
+- [ ] An external pillar's `baseUrl` becoming unreachable does not crash the orchestrator. The merged passthrough returns the upstream's error per tRPC's standard error semantics. PRD-216 (`PillarGuard`) owns user-facing degradation.
+- [ ] `AppRouter`'s static export keeps narrowing to the installed in-repo subset — no regression in shell type-checking.
+- [ ] Unit tests cover: composition over codegen-only catalogue (no externals), composition over codegen + one external, composition after a recompose event swaps the external set, id-collision rejection at boot, debounce coalesces two registrations within 250ms into one recompose, deregister event removes the pillar from the next composition.
+- [ ] Integration test (deferred to US-04) exercises the loop end-to-end against a real registered pillar.
+- [ ] `pnpm --filter @pops/api typecheck/test/build` is clean.
+- [ ] Husky pre-commit + pre-push pass without `--no-verify`.
+
+## Notes
+
+- `mergeRouters` is already exported from `apps/pops-api/src/trpc.ts:161`. PRD-242 is the first consumer that uses it for runtime composition; existing consumers compose at module-load.
+- The "passthrough router for an external pillar" pattern means the orchestrator does not own the external pillar's procedure code. It forwards via a `httpBatchLink` (or equivalent) keyed on the registered `baseUrl`. This matches ADR-027's docker-network trust boundary — the orchestrator is on the same network as the external pillar.
+- Recomposition swaps the `appRouter` reference held by the tRPC server middleware. tRPC's standard server adapter holds the router by reference; the swap is a single atomic assignment. No connection draining is required for HTTP request/response calls.
+- Streaming / subscription procedures on external pillars are out of scope for US-02 — the runtime composition handles HTTP request/response; if an external pillar declares a subscription procedure, the passthrough simply doesn't expose it. A follow-up PRD can extend if real demand surfaces.
+- The orchestrator does **not** introspect the external pillar's router shape at the type level. External procedures are unknown-output on the consumer side, which is exactly what `pillar(id).callDynamic` (`packages/pillar-sdk/src/client/proxy.ts:26-72`) is designed for.
+- Boot-time fetch of external pillar shapes is not required — the passthrough does not need the procedure list ahead of time, because tRPC's HTTP transport routes by path string. The orchestrator only needs to know the `baseUrl` and the pillar id.

--- a/docs/themes/13-pillar-finale/prds/242-dynamic-approuter/us-03-delete-known-routers-literal.md
+++ b/docs/themes/13-pillar-finale/prds/242-dynamic-approuter/us-03-delete-known-routers-literal.md
@@ -1,0 +1,29 @@
+# US-03: Delete the static `KNOWN_ROUTERS` literal from `apps/pops-api/src/router.ts`
+
+> PRD: [PRD-242 — Dynamic `AppRouter` composition](README.md)
+
+## Description
+
+As an `apps/pops-api` maintainer, I want the eight hand-curated pillar router imports + the inline `KNOWN_ROUTERS` literal removed from `apps/pops-api/src/router.ts` so that adding an in-repo pillar no longer requires editing this file, and external pillars are no longer locked out at the type level.
+
+## Acceptance Criteria
+
+- [ ] `apps/pops-api/src/router.ts` no longer contains any of the following `import` lines: `coreRouter`, `cerebrumRouter`, `egoRouter`, `financeRouter`, `foodRouter`, `inventoryRouter`, `listsRouter`, `mediaRouter`.
+- [ ] The inline `KNOWN_ROUTERS = { core: coreRouter, ... }` literal at lines 42-51 is deleted.
+- [ ] The file consumes the generated catalogue from US-01: `import { KNOWN_ROUTERS } from './generated/router-catalogue.js'`.
+- [ ] `composeInstalledRouters()` and the `InstalledRouterId` / `InstalledRouterMap` type narrowing (lines 62-69, 90-100) continue to work unchanged against the generated catalogue.
+- [ ] `AppRouter`'s static export shape is unchanged for in-repo pillars: shell call sites against `trpc.<pillar>.<router>.<proc>` keep their existing types.
+- [ ] The runtime composition path from US-02 (`mergeRouters` over codegen + registry externals) is the source of `appRouter`'s value at boot.
+- [ ] `grep -n "import { coreRouter\|import { cerebrumRouter\|import { egoRouter\|import { financeRouter\|import { foodRouter\|import { inventoryRouter\|import { listsRouter\|import { mediaRouter" apps/pops-api/src/router.ts` returns zero matches.
+- [ ] `grep -n "KNOWN_ROUTERS = {" apps/pops-api/src/router.ts` returns zero matches (the symbol is imported, not declared).
+- [ ] `pnpm --filter @pops/api typecheck/test/build` is clean.
+- [ ] `pnpm --filter @pops/shell typecheck` is clean — no shell call site broke as a result of the change.
+- [ ] Husky pre-commit + pre-push pass without `--no-verify`.
+
+## Notes
+
+- This is the visible end of PRD-242: the file the audit (H3) named gets surgically simplified. The eight `import` lines + the 10-line literal go; everything else (the runtime composition helpers, the narrowing types, the `AppRouter` export) stays.
+- The JSDoc at lines 1-17 of the current `router.ts` references PRD-101 US-03's history. Update the JSDoc to reference PRD-242 alongside (without rewriting history — PRD-101's invariant about the install set still holds).
+- The JSDoc instruction at line 40 ("Adding a new module: add the import + entry here AND a manifest entry in `packages/module-registry/scripts/known-modules.ts`") is now obsolete. Replace with: "Adding a new module: add the manifest entry; the codegen at `apps/pops-api/scripts/generate-app-router-catalogue.ts` picks up the router at build time."
+- The `isKnownRouterId` and `assignRouter` helpers (`apps/pops-api/src/router.ts:71-112`) keep working against the generated catalogue — they're generic over `KnownRouterId` which is now `keyof typeof KNOWN_ROUTERS` from the generated import.
+- The diff in this US is small (about 30 lines deleted, 1 import added, 1 JSDoc paragraph rewritten). The bulk of the work is in US-01 (codegen) and US-02 (runtime composition).

--- a/docs/themes/13-pillar-finale/prds/242-dynamic-approuter/us-04-e2e-external-pillar-procedure-call.md
+++ b/docs/themes/13-pillar-finale/prds/242-dynamic-approuter/us-04-e2e-external-pillar-procedure-call.md
@@ -1,0 +1,30 @@
+# US-04: End-to-end test — external pillar registers, procedure callable via `callDynamic`
+
+> PRD: [PRD-242 — Dynamic `AppRouter` composition](README.md)
+
+## Description
+
+As a platform engineer, I want an integration test that registers an external pillar at runtime via the [PRD-228](../228-dynamic-pillar-registration/README.md) `/core.registry.register` endpoint and then calls one of its procedures via `pillar(id).callDynamic(routerName, procName, input)` so that the typed-vs-`callDynamic` split that PRD-242 ships is proven end-to-end.
+
+## Acceptance Criteria
+
+- [ ] An integration test lives at `apps/pops-api/src/__tests__/external-pillar-e2e.test.ts` (or equivalent path under the repo's existing integration-test layout).
+- [ ] The test boots a throwaway pillar process exposing a single tRPC router with one query (`echo({ value }) => { value }`) and one mutation (`store({ key, value }) => { ok: true }`) — the smallest surface that exercises both kinds.
+- [ ] The test calls `POST /core.registry.register` against `pops-core-api` with the pillar's manifest and `baseUrl`. Registration succeeds (per PRD-228 US-01).
+- [ ] The test waits for the orchestrator's recompose debounce window (250ms + slack) and asserts that the registered pillar appears in the `core.registry.snapshot()` output with `origin: 'external'`.
+- [ ] The test calls `pillar('<throwaway-id>').callDynamic('echo', 'echo', { value: 'ping' }, 'query')` against `pops-core-api` and asserts the response payload equals `{ value: 'ping' }`. The call goes through the orchestrator's `mergeRouters` passthrough to the throwaway pillar.
+- [ ] The test calls `pillar('<throwaway-id>').callDynamic('echo', 'store', { key: 'k', value: 'v' }, 'mutation')` and asserts `{ ok: true }`.
+- [ ] The test calls `POST /core.registry.deregister` and asserts that subsequent `callDynamic` calls return the `not-registered` shape per PRD-228's heartbeat/deregister semantics.
+- [ ] The test does not edit `apps/pops-api/src/router.ts`. It does not edit the codegen catalogue. The external pillar reaches `appRouter` purely through registration + the orchestrator's runtime composition.
+- [ ] The test runs in CI under the existing integration-test job. No new long-lived infrastructure is introduced; the throwaway pillar is an in-process node module or a container the test spins up and tears down.
+- [ ] The test asserts at no point that the external pillar's procedures appear in the _static_ `AppRouter` type — they do not, by design.
+- [ ] Husky pre-commit + pre-push pass without `--no-verify`.
+
+## Notes
+
+- The throwaway pillar's manifest must declare the `echo` router so PRD-228's validator (PRD-157) accepts it. Manifest fields beyond router declarations (settings, search adapters, AI tools) can be omitted.
+- The test should not be a unit test against mocks. The whole point is to prove the loop closes against a real registration event + a real `callDynamic` call. Mocking either side hides the failure mode PRD-242 is fixing.
+- `pillar(id).callDynamic` is the shipped escape hatch from [PR #3131](https://github.com/knoxio/pops/pull/3131) — see `packages/pillar-sdk/src/client/proxy.ts:26-72` and the existing tests at `packages/pillar-sdk/src/client/__tests__/call-dynamic.test.ts`. US-04 exercises it against a real external pillar rather than the existing mock-driven tests.
+- This test is the load-bearing proof that the H3 finding is closed: an external pillar reaches `appRouter` purely by registering, no central file edit.
+- The reserved-pillar-id rejection (PRD-228 US-01, US-02 collision check) is exercised separately — US-04's throwaway pillar uses a non-reserved id (e.g. `e2e-test-pillar`).
+- The throwaway pillar can be a sibling tRPC server constructed in-process and bound to a free TCP port, matching the in-process integration-test pattern already used elsewhere in `apps/pops-api/src/__tests__/`.

--- a/docs/themes/13-pillar-finale/prds/242-dynamic-approuter/us-05-developer-doc-typed-vs-calldynamic.md
+++ b/docs/themes/13-pillar-finale/prds/242-dynamic-approuter/us-05-developer-doc-typed-vs-calldynamic.md
@@ -1,0 +1,28 @@
+# US-05 _(optional)_: Developer doc — typed proxy for in-repo pillars; `callDynamic` for external pillars
+
+> PRD: [PRD-242 — Dynamic `AppRouter` composition](README.md)
+
+## Description
+
+As an external-pillar author or an in-repo developer adding a new consumer call site, I want a one-page note that explains the split between the typed `trpc.<pillar>.<router>.<proc>` proxy (for in-repo pillars) and `pillar(id).callDynamic(routerName, procName, input, kind)` (for external pillars) so that I pick the right tool without having to reverse-engineer it from the codebase.
+
+## Acceptance Criteria
+
+- [ ] A note exists at `docs/themes/13-pillar-finale/notes/internal-vs-external-pillar-call-sites.md` (or equivalent path inside `docs/themes/13-pillar-finale/notes/`).
+- [ ] The note explains the two consumer-side paths:
+  - **In-repo pillar** → `trpc.<pillar>.<router>.<proc>` typed proxy (existing pattern). Static type comes from the codegen-derived `AppRouter`.
+  - **External pillar** → `pillar(id).callDynamic(routerName, procName, input, kind)` runtime escape hatch from [PR #3131](https://github.com/knoxio/pops/pull/3131). Return type is `CallResult<unknown>`; caller validates the response shape.
+- [ ] The note explains _why_ the split exists (TypeScript cannot know an out-of-repo pillar's procedure shape at compile time without a generated SDK package; PRD-242 deliberately stops short of that step).
+- [ ] The note gives one runnable example for each path.
+- [ ] The note cross-links to: [PRD-228](../228-dynamic-pillar-registration/README.md) (the registration surface), [PRD-233](../233-external-pillar-example-repo/README.md) (the Rust example pillar), [PRD-242](README.md) (this PRD), and `packages/pillar-sdk/src/client/proxy.ts:26-72` (`CallDynamicFn`).
+- [ ] The note is linked from the PRD-228 README's "References" section and the PRD-233 README's developer-onboarding section.
+- [ ] The note is < 1 page (per `docs/CLAUDE.md`'s sizing rule).
+- [ ] Husky pre-commit + pre-push pass without `--no-verify`.
+
+## Notes
+
+- This US is **optional** — it does not block the H3 finding's closure. US-01..04 deliver the working software; US-05 documents the decision for future authors.
+- It is the cheapest US in the PRD. Useful to ship alongside US-04 so the integration test's intent is documented.
+- The note belongs under `docs/themes/13-pillar-finale/notes/`, not under the PRD folder, because it has long-lived developer-onboarding value beyond PRD-242's completion.
+- The note is the natural follow-on to the pillar-isolation audit at `docs/themes/13-pillar-finale/notes/pillar-isolation-audit.md` — the audit named the problem (H3), the note names the resolution.
+- Per `docs/CLAUDE.md` (writing rules): no meta-commentary about the doc, no preamble. Start with the rule, follow with the example, end with the cross-links.


### PR DESCRIPTION
## Summary

Scopes PRD-242 to close the top-severity H3 finding from the [pillar-isolation audit (#3215)](https://github.com/knoxio/pops/pull/3215): the hand-curated \`KNOWN_ROUTERS\` literal in [\`apps/pops-api/src/router.ts:21-51\`](../blob/main/apps/pops-api/src/router.ts#L21-L51) that types \`AppRouter\` from eight imported pillar routers. External pillars currently cannot extend \`AppRouter\` at the type level even though the registry side ([PRD-228](../tree/main/docs/themes/13-pillar-finale/prds/228-dynamic-pillar-registration)) and the consumer-side \`callDynamic\` escape hatch (PR #3131) already support them.

This PR is **docs only**.

## What's in

- New PRD folder \`docs/themes/13-pillar-finale/prds/242-dynamic-approuter/\` with README + 5 user stories.
- Epic table update at \`docs/themes/13-pillar-finale/epics/10-fe-sdk-dispatcher-generator.md\` adding the PRD-242 row alongside PRD-241.

## Recommended option

PRD-242 weighs three options:

- **A.** Workspace-scan codegen of the in-repo \`AppRouter\` union — fixes the in-repo pain but external pillars still can't extend the type.
- **B.** Pure runtime composition via \`mergeRouters\`; \`AppRouter\` becomes degenerate — closes the lego promise but regresses every typed shell call site.
- **C. (RECOMMENDED)** Hybrid: codegen typed catalogue for in-repo pillars; \`pillar(id).callDynamic\` for external pillars; runtime \`mergeRouters\` composes both at orchestrator boot.

Option C is the only one that delivers the lego promise without breaking the typed in-repo DX the shell + pops-api codebase relies on today.

## User stories

| # | Story | Parallelisable |
| - | ----- | -------------- |
| 01 | Workspace-scan codegen for \`AppRouter\` catalogue | yes — foundational |
| 02 | Orchestrator \`mergeRouters\` composition + registry event subscription | blocked by US-01 + PRD-228 externals |
| 03 | Delete \`KNOWN_ROUTERS\` literal from \`router.ts\` | blocked by US-01 |
| 04 | E2E test: register external pillar, call procedure via \`callDynamic\` | blocked by US-02 + PRD-228 US-01..04 |
| 05 | Developer doc on typed-proxy vs \`callDynamic\` split (optional) | yes — independent |

## References

- Audit: \`docs/themes/13-pillar-finale/notes/pillar-isolation-audit.md\` H3
- [PRD-228](../tree/main/docs/themes/13-pillar-finale/prds/228-dynamic-pillar-registration) — runtime register / heartbeat / deregister surface (the runtime side this PRD's type layer catches up with)
- [PRD-233](../tree/main/docs/themes/13-pillar-finale/prds/233-external-pillar-example-repo) — Rust external-pillar example that exercises the loop
- PR #3215 — the audit that surfaced H3
- PR #3131 — shipped \`pillar(id).callDynamic\`, the consumer escape hatch PRD-242 relies on

## Test plan

- [ ] Docs review: PRD-242 README + 5 user stories read sensibly and are self-contained per \`docs/CLAUDE.md\`.
- [ ] Verify the epic table row for PRD-242 renders alongside PRD-241.
- [ ] Confirm the recommended option (C) is acceptable as the scoping direction; if not, comment for revision.