### PR TITLE
docs(theme-13): PRD-241 US-03 in-repo vs external-pillar discovery boundary

### DIFF
--- a/docs/architecture/adr-027-runtime-pillar-registry.md
+++ b/docs/architecture/adr-027-runtime-pillar-registry.md
@@ -35,3 +35,9 @@ The registry is a **directory** (look up baseUrl + manifest, then call directly)
 - ❌ Boot ordering: pillars need core-api up to register. Mitigation: pillars retry registration with backoff; consumers tolerate `unknown` state during reconciliation windows.
 - ❌ core-api becomes a critical dependency for capability discovery. Mitigation: registry is read-mostly, cached aggressively, and tolerates short core-api outages.
 - ❌ One more table in core.db. Acceptable.
+
+## Related
+
+- [PRD-241 — Registry-driven `known-modules`](../themes/13-pillar-finale/prds/241-registry-driven-known-modules/README.md) covers **in-repo** discovery for workspace pillars: a build-time walk over `@pops/*-contract` packages that replaces the hand-curated `MANIFEST_SOURCES` literal. The workspace glob deliberately excludes `examples/`, so external pillars never appear in `packages/module-registry/src/generated.ts`. This ADR's runtime registry is the path for **external** (non-workspace) pillars — see PRD-241 US-03 for the boundary statement.
+- [PRD-228 — Dynamic pillar registration](../themes/13-pillar-finale/prds/228-dynamic-pillar-registration/README.md) implements the runtime register / heartbeat / deregister API external pillars call.
+- [PRD-233 — External pillar example (Rust)](../themes/13-pillar-finale/prds/233-external-pillar-example-repo/README.md) is the worked example that exercises the runtime path end-to-end.

--- a/docs/themes/13-pillar-finale/notes/pillar-isolation-audit.md
+++ b/docs/themes/13-pillar-finale/notes/pillar-isolation-audit.md
@@ -28,7 +28,8 @@ This file is the source of truth that `pnpm registry:build` consumes to emit `pa
 
 - **Why HIGH** — it is the root that every other hand-curation in this audit ultimately mirrors. Adding a pillar (in-repo or external) cannot work until this file knows about it.
 - **Remediation** — replace the literal `MANIFEST_SOURCES` array with a build step that discovers `packages/<id>-contract/manifest.{ts,json}` (or `apps/pops-<id>-api/manifest.{ts,json}`) and aggregates them. For external pillars, the runtime registry (ADR-027) already does this via the `POPS_PILLARS` env var + `GET /manifest.json` per registered URL. The build-time `KNOWN_MODULES` is only needed for type narrowing — emit it from the discovered set. Settings manifests landed in per-pillar contract packages by PRD-239 already; the next step is to drop `MANIFEST_SOURCES` and discover via convention.
-- **In-flight** — PRD-218 (module-registry deprecation) plans to retire the package; this finding amplifies the case for ordering that work alongside the pillar discovery work.
+- **Closed by** — [PRD-241](../prds/241-registry-driven-known-modules/README.md): replaces `MANIFEST_SOURCES` with a build-time discovery walk over `@pops/*-contract` workspace packages. The external-pillar half of the remediation (workspace glob excludes `examples/`; external pillars take the ADR-027 runtime path) is documented in PRD-241 US-03 and cross-referenced from [ADR-027](../../../architecture/adr-027-runtime-pillar-registry.md), [PRD-218](../prds/218-module-registry-deprecation/README.md), and [PRD-233](../prds/233-external-pillar-example-repo/README.md).
+- **In-flight** — PRD-218 (module-registry deprecation) still retires the package itself; PRD-241 is a strict predecessor — `module-registry` cannot be retired until its hand-curated `known-modules.ts` is replaced. PRD-218 remains tracked against the broader `module-registry` retirement (and L1 closes with it), not against H1 specifically.
 
 #### H2 — `packages/pillar-sdk/src/settings/index.ts` is a hand-curated SDK barrel
 
@@ -265,7 +266,8 @@ A spot-check across `docs/architecture/adr-026-pillar-architecture.md`, `adr-035
 
 - **PRD-239** (settings manifest physical relocation) — relocates 10 settings manifests from `module-registry` into per-pillar `-contract/settings`. Does NOT eliminate the `pillar-sdk/settings` barrel itself — just changes where it re-exports from. Closes the H2 _location_ but not its hand-curation shape.
 - **"PRD-240"** (not yet numbered; user described as the discoverSettings replacement) — proposes replacing the hand-curated `pillar-sdk/settings/index.ts` with a runtime `discoverSettings()` over the registry. Closes H2.
-- **PRD-218** (module-registry deprecation) — retires `@pops/module-registry`. Closes H1, L1.
+- **PRD-241** (registry-driven `known-modules`) — replaces the `MANIFEST_SOURCES` literal with a workspace discovery walk. Closes H1. Strict predecessor to PRD-218.
+- **PRD-218** (module-registry deprecation) — retires `@pops/module-registry`. Closes L1; depends on PRD-241 for the build-script reshape that frees the package to be retired.
 - **ADR-026 migration roadmap** (private, `.claude/pillar-migration-roadmap.md`) — drives the per-pillar `-db` / `-api` split. Closes H3, H6, M1, M2, M5, L7, L8.
 - **PRD-228** (dynamic pillar registration) — runtime registry growth. Adjacent to H4, H5, H9, M7.
 - **PRD-156** (consumer import discipline) — produces `.dependency-cruiser.rules.generated.cjs`. Already gates new cross-pillar imports; existing violations are tracked in `.dependency-cruiser-known-violations.json` and itemised by H8.

--- a/docs/themes/13-pillar-finale/prds/218-module-registry-deprecation/README.md
+++ b/docs/themes/13-pillar-finale/prds/218-module-registry-deprecation/README.md
@@ -8,6 +8,8 @@
 
 The build-time `@pops/module-registry` (PRD-101) was the shell's static install-set registry. After Theme 13, the runtime registry (Epic 02) is authoritative. This PRD deprecates the build-time registry: it becomes a thin shim around the runtime registry, with an offline-dev fallback for cases where the registry isn't reachable.
 
+[PRD-241](../241-registry-driven-known-modules/README.md) is a strict predecessor: `module-registry` cannot be retired until its hand-curated `MANIFEST_SOURCES` literal in `scripts/known-modules.ts` is replaced by the workspace discovery walk. PRD-241 reshapes the build script; this PRD then retires the package on top of that.
+
 ## Data Model
 
 No data.

--- a/docs/themes/13-pillar-finale/prds/233-external-pillar-example-repo/README.md
+++ b/docs/themes/13-pillar-finale/prds/233-external-pillar-example-repo/README.md
@@ -25,6 +25,10 @@ examples/pops-pillar-rust-example/
 
 Out-of-tree from `pnpm-workspace.yaml`. No crate-level publishing.
 
+### Discovery boundary
+
+`examples/` is deliberately outside the workspace glob, so [PRD-241](../241-registry-driven-known-modules/README.md)'s build-time discovery walk over `@pops/*-contract` packages does not see this pillar — and never should. The Rust example reaches `core-api` via [ADR-027](../../../../architecture/adr-027-runtime-pillar-registry.md)'s runtime registry: it POSTs `core.registry.register` on boot (per [PRD-228](../228-dynamic-pillar-registration/README.md) §6) and is reflected in `pillar_registry` at runtime, not in `packages/module-registry/src/generated.ts`. PRD-241 (in-repo, build-time) and ADR-027 (external, runtime) are the two halves of the same discovery story; this PRD exercises the second.
+
 ## API Surface
 
 The example implements the subset of v1 needed to demonstrate end-to-end correctness:

--- a/docs/themes/13-pillar-finale/prds/241-registry-driven-known-modules/us-03-document-external-pillar-boundary.md
+++ b/docs/themes/13-pillar-finale/prds/241-registry-driven-known-modules/us-03-document-external-pillar-boundary.md
@@ -8,13 +8,13 @@ As a future pillar author, I want the docs to spell out where PRD-241's in-repo 
 
 ## Acceptance Criteria
 
-- [ ] The [pillar-isolation audit](../../notes/pillar-isolation-audit.md)'s `### H1 — packages/module-registry/scripts/known-modules.ts hand-curates every pillar` entry gains a status line: **Closed by [PRD-241](../prds/241-registry-driven-known-modules/README.md)**. The "In-flight" reference to PRD-218 stays; PRD-241 is the closer for H1 specifically.
-- [ ] [ADR-027](../../../../architecture/adr-027-runtime-pillar-registry.md) gains (or has confirmed already-present) a cross-reference to PRD-241 in the "Related" / "References" section: "PRD-241 covers in-repo discovery for workspace pillars; ADR-027's runtime registry covers external (non-workspace) pillars."
-- [ ] [PRD-218](../218-module-registry-deprecation/README.md) README acknowledges PRD-241 as a strict predecessor: `module-registry` cannot be retired until its hand-curated `known-modules.ts` is replaced. One sentence in the PRD-218 background or sequencing notes is enough.
-- [ ] [PRD-233](../233-external-pillar-example-repo/README.md) README explicitly notes the boundary: the Rust example pillar lives in `examples/` (outside the workspace glob), so PRD-241's discovery does not pick it up. The Rust pillar's path is the runtime registry per ADR-027. One sentence or short "Discovery boundary" note in the PRD background.
-- [ ] The PRD-241 README's `## Out of Scope` and `## Edge Cases` already describe the boundary. US-03 does not duplicate that prose — it makes the audit + ADR-027 + PRD-233 + PRD-218 mutually consistent so a reader landing on any one of them sees the same boundary articulated.
-- [ ] `pnpm format docs/` is clean.
-- [ ] Husky pre-commit + pre-push pass without `--no-verify`.
+- [x] The [pillar-isolation audit](../../notes/pillar-isolation-audit.md)'s `### H1 — packages/module-registry/scripts/known-modules.ts hand-curates every pillar` entry gains a status line: **Closed by [PRD-241](../prds/241-registry-driven-known-modules/README.md)**. The "In-flight" reference to PRD-218 stays; PRD-241 is the closer for H1 specifically.
+- [x] [ADR-027](../../../../architecture/adr-027-runtime-pillar-registry.md) gains (or has confirmed already-present) a cross-reference to PRD-241 in the "Related" / "References" section: "PRD-241 covers in-repo discovery for workspace pillars; ADR-027's runtime registry covers external (non-workspace) pillars."
+- [x] [PRD-218](../218-module-registry-deprecation/README.md) README acknowledges PRD-241 as a strict predecessor: `module-registry` cannot be retired until its hand-curated `known-modules.ts` is replaced. One sentence in the PRD-218 background or sequencing notes is enough.
+- [x] [PRD-233](../233-external-pillar-example-repo/README.md) README explicitly notes the boundary: the Rust example pillar lives in `examples/` (outside the workspace glob), so PRD-241's discovery does not pick it up. The Rust pillar's path is the runtime registry per ADR-027. One sentence or short "Discovery boundary" note in the PRD background.
+- [x] The PRD-241 README's `## Out of Scope` and `## Edge Cases` already describe the boundary. US-03 does not duplicate that prose — it makes the audit + ADR-027 + PRD-233 + PRD-218 mutually consistent so a reader landing on any one of them sees the same boundary articulated.
+- [x] `pnpm format docs/` is clean.
+- [x] Husky pre-commit + pre-push pass without `--no-verify`.
 
 ## Notes
 


### PR DESCRIPTION
## Summary

Implements [PRD-241 US-03](https://github.com/knoxio/pops/blob/main/docs/themes/13-pillar-finale/prds/241-registry-driven-known-modules/us-03-document-external-pillar-boundary.md) — the pure-docs deliverable that makes the in-repo vs external-pillar discovery boundary mutually consistent across the four touch points the US calls out.

- **Pillar-isolation audit ([H1](https://github.com/knoxio/pops/blob/main/docs/themes/13-pillar-finale/notes/pillar-isolation-audit.md))** — adds a `Closed by PRD-241` status line. Reshapes the in-flight reference so PRD-241 owns H1 closure (the `MANIFEST_SOURCES` literal) and PRD-218 stays tracked against the broader `module-registry` retirement (which closes L1 with it).
- **[ADR-027](https://github.com/knoxio/pops/blob/main/docs/architecture/adr-027-runtime-pillar-registry.md)** — gains a `Related` section. PRD-241 covers in-repo (build-time) discovery for workspace pillars; ADR-027's runtime registry is the path for external (non-workspace) pillars. PRD-228 is the runtime register/heartbeat API; PRD-233 is the Rust worked example.
- **[PRD-218](https://github.com/knoxio/pops/blob/main/docs/themes/13-pillar-finale/prds/218-module-registry-deprecation/README.md)** — acknowledges PRD-241 as a strict predecessor; `module-registry` cannot be retired until the hand-curated `known-modules.ts` is replaced.
- **[PRD-233](https://github.com/knoxio/pops/blob/main/docs/themes/13-pillar-finale/prds/233-external-pillar-example-repo/README.md)** — adds a `Discovery boundary` note: `examples/` is outside the workspace glob, so PRD-241's build-time walk never sees the Rust pillar. The Rust example reaches `core-api` via ADR-027 at runtime — PRD-241 and ADR-027 are the two halves of the same discovery story; PRD-233 exercises the second.

US-03 acceptance criteria checkboxes ticked. Independent of US-01/US-02 (which do the code work).

## Test plan

- [x] `pnpm format docs/` clean
- [x] Husky pre-commit + pre-push pass without `--no-verify`
- [x] Internal links resolve (relative paths verified against worktree layout)
- [x] No code changes — docs only