### PR TITLE
feat: PRD-241 US-01 per-pillar /manifest exports

### DIFF
--- a/packages/cerebrum-contract/src/__tests__/module-manifest.test.ts
+++ b/packages/cerebrum-contract/src/__tests__/module-manifest.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import { assertModuleManifest } from '@pops/types';
+
+import { cerebrumManifest, egoManifest } from '../manifest.js';
+
+describe('cerebrum-contract /manifest — ModuleManifest exports (PRD-241 US-01)', () => {
+  it('cerebrumManifest passes assertModuleManifest with id=cerebrum', () => {
+    expect(() => assertModuleManifest(cerebrumManifest, 'modules.cerebrum')).not.toThrow();
+    expect(cerebrumManifest.id).toBe('cerebrum');
+    expect(cerebrumManifest.name).toBe('Cerebrum');
+    expect(cerebrumManifest.surfaces).toEqual(['app']);
+  });
+
+  it('cerebrumManifest contributes the cerebrum settings section', () => {
+    const sectionIds = (cerebrumManifest.settings ?? []).map((s) => s.id);
+    expect(sectionIds).toEqual(['cerebrum']);
+  });
+
+  it('egoManifest passes assertModuleManifest with id=ego and dual surfaces', () => {
+    expect(() => assertModuleManifest(egoManifest, 'modules.ego')).not.toThrow();
+    expect(egoManifest.id).toBe('ego');
+    expect(egoManifest.name).toBe('Ego');
+    expect(egoManifest.surfaces).toEqual(['app', 'overlay']);
+  });
+
+  it('egoManifest preserves the overlay chrome-slot + shortcut wiring', () => {
+    expect(egoManifest.frontend?.overlay).toEqual({
+      chromeSlot: 'assistant',
+      shortcut: 'mod+i',
+    });
+  });
+
+  it('egoManifest contributes the ego settings section', () => {
+    const sectionIds = (egoManifest.settings ?? []).map((s) => s.id);
+    expect(sectionIds).toEqual(['ego']);
+  });
+});

--- a/packages/cerebrum-contract/src/manifest.ts
+++ b/packages/cerebrum-contract/src/manifest.ts
@@ -4,5 +4,46 @@
  * `pnpm -F @pops/cerebrum-contract generate:manifest` (Theme 13 PRD-155).
  * This file remains the stable import path (`@pops/cerebrum-contract/manifest`)
  * so downstream consumers don't move with the generator output.
+ *
+ * PRD-241 US-01 adds the runtime `ModuleManifest` values for `cerebrum` and
+ * `ego` here. The values mirror the entries currently inlined in
+ * `packages/module-registry/scripts/known-modules.ts`'s `MANIFEST_SOURCES`.
+ * PRD-241 US-02 will replace that literal with a workspace discovery walk
+ * that consumes these exports.
+ *
+ * `ego` is co-located here because its settings already nest under cerebrum
+ * (PRD-239 / PRD-240); the pillar does not have its own contract package.
  */
+import {
+  cerebrumManifest as cerebrumSettingsManifest,
+  egoManifest as egoSettingsManifest,
+} from './settings/index.js';
+
+import type { ModuleManifest } from '@pops/types';
+
 export type { CerebrumContract } from './manifest.generated.js';
+
+export const cerebrumManifest: ModuleManifest = {
+  id: 'cerebrum',
+  name: 'Cerebrum',
+  version: '0.1.0',
+  surfaces: ['app'],
+  description:
+    'Engram storage, retrieval, ingest/emit, plexus, reflex, glia — knowledge graph and agents.',
+  settings: [cerebrumSettingsManifest],
+};
+
+export const egoManifest: ModuleManifest = {
+  id: 'ego',
+  name: 'Ego',
+  version: '0.1.0',
+  surfaces: ['app', 'overlay'],
+  description: 'Conversational AI interface to Cerebrum (PRD-087).',
+  frontend: {
+    overlay: {
+      chromeSlot: 'assistant',
+      shortcut: 'mod+i',
+    },
+  },
+  settings: [egoSettingsManifest],
+};

--- a/packages/core-contract/src/__tests__/module-manifest.test.ts
+++ b/packages/core-contract/src/__tests__/module-manifest.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import { assertModuleManifest } from '@pops/types';
+
+import { aiManifest, coreManifest } from '../manifest.js';
+
+describe('core-contract /manifest — ModuleManifest exports (PRD-241 US-01)', () => {
+  it('coreManifest passes assertModuleManifest with id=core', () => {
+    expect(() => assertModuleManifest(coreManifest, 'modules.core')).not.toThrow();
+    expect(coreManifest.id).toBe('core');
+    expect(coreManifest.name).toBe('Core');
+    expect(coreManifest.surfaces).toEqual(['app']);
+  });
+
+  it('coreManifest contributes the core settings sections', () => {
+    const sectionIds = (coreManifest.settings ?? []).map((s) => s.id);
+    expect(sectionIds).toEqual(['ai.config', 'core.operational']);
+  });
+
+  it('aiManifest passes assertModuleManifest with id=ai', () => {
+    expect(() => assertModuleManifest(aiManifest, 'modules.ai')).not.toThrow();
+    expect(aiManifest.id).toBe('ai');
+    expect(aiManifest.name).toBe('AI Ops');
+    expect(aiManifest.surfaces).toEqual(['app']);
+    expect(aiManifest.settings).toBeUndefined();
+  });
+});

--- a/packages/core-contract/src/manifest.ts
+++ b/packages/core-contract/src/manifest.ts
@@ -4,5 +4,36 @@
  * `pnpm -F @pops/core-contract generate:manifest` (Theme 13 PRD-155).
  * This file remains the stable import path (`@pops/core-contract/manifest`)
  * so downstream consumers don't move with the generator output.
+ *
+ * PRD-241 US-01 adds the runtime `ModuleManifest` values for `core` and `ai`
+ * here. The values mirror the entries currently inlined in
+ * `packages/module-registry/scripts/known-modules.ts`'s `MANIFEST_SOURCES`.
+ * PRD-241 US-02 will replace that literal with a workspace discovery walk
+ * that consumes these exports.
+ *
+ * `ai` is co-located here because its settings already nest under core
+ * (PRD-239); the pillar does not have its own contract package.
  */
+import { aiConfigManifest, coreOperationalManifest } from './settings/index.js';
+
+import type { ModuleManifest } from '@pops/types';
+
 export type { CoreContract } from './manifest.generated.js';
+
+export const coreManifest: ModuleManifest = {
+  id: 'core',
+  name: 'Core',
+  version: '0.1.0',
+  surfaces: ['app'],
+  description:
+    'Cross-cutting platform services: entities, AI usage/providers, settings, features, search.',
+  settings: [aiConfigManifest, coreOperationalManifest],
+};
+
+export const aiManifest: ModuleManifest = {
+  id: 'ai',
+  name: 'AI Ops',
+  version: '0.1.0',
+  surfaces: ['app'],
+  description: 'AI usage, providers, model config, prompts, and rules browser.',
+};

--- a/packages/finance-contract/src/__tests__/module-manifest.test.ts
+++ b/packages/finance-contract/src/__tests__/module-manifest.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+
+import { assertModuleManifest } from '@pops/types';
+
+import { financeManifest } from '../manifest.js';
+
+describe('finance-contract /manifest — ModuleManifest export (PRD-241 US-01)', () => {
+  it('financeManifest passes assertModuleManifest with id=finance', () => {
+    expect(() => assertModuleManifest(financeManifest, 'modules.finance')).not.toThrow();
+    expect(financeManifest.id).toBe('finance');
+    expect(financeManifest.name).toBe('Finance');
+    expect(financeManifest.surfaces).toEqual(['app']);
+  });
+
+  it('financeManifest contributes the finance settings section', () => {
+    const sectionIds = (financeManifest.settings ?? []).map((s) => s.id);
+    expect(sectionIds).toEqual(['finance']);
+  });
+});

--- a/packages/finance-contract/src/manifest.ts
+++ b/packages/finance-contract/src/manifest.ts
@@ -4,5 +4,24 @@
  * `pnpm -F @pops/finance-contract generate:manifest` (Theme 13 PRD-155).
  * This file remains the stable import path (`@pops/finance-contract/manifest`)
  * so downstream consumers don't move with the generator output.
+ *
+ * PRD-241 US-01 adds the runtime `ModuleManifest` value for `finance` here.
+ * Mirrors the entry currently inlined in
+ * `packages/module-registry/scripts/known-modules.ts`'s `MANIFEST_SOURCES`.
+ * PRD-241 US-02 will replace that literal with a workspace discovery walk
+ * that consumes this export.
  */
+import { financeManifest as financeSettingsManifest } from './settings/index.js';
+
+import type { ModuleManifest } from '@pops/types';
+
 export type { FinanceContract } from './manifest.generated.js';
+
+export const financeManifest: ModuleManifest = {
+  id: 'finance',
+  name: 'Finance',
+  version: '0.1.0',
+  surfaces: ['app'],
+  description: 'Transactions, budgets, entities, and import pipeline.',
+  settings: [financeSettingsManifest],
+};

--- a/packages/food-contract/src/__tests__/module-manifest.test.ts
+++ b/packages/food-contract/src/__tests__/module-manifest.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+
+import { assertModuleManifest } from '@pops/types';
+
+import { foodManifest } from '../manifest.js';
+
+describe('food-contract /manifest — ModuleManifest export (PRD-241 US-01)', () => {
+  it('foodManifest passes assertModuleManifest with id=food', () => {
+    expect(() => assertModuleManifest(foodManifest, 'modules.food')).not.toThrow();
+    expect(foodManifest.id).toBe('food');
+    expect(foodManifest.name).toBe('Food');
+    expect(foodManifest.surfaces).toEqual(['app']);
+  });
+
+  it('foodManifest declares no settings dimension', () => {
+    expect(foodManifest.settings).toBeUndefined();
+  });
+});

--- a/packages/food-contract/src/manifest.ts
+++ b/packages/food-contract/src/manifest.ts
@@ -4,5 +4,21 @@
  * `pnpm -F @pops/food-contract generate:manifest` (Theme 13 PRD-155).
  * This file remains the stable import path (`@pops/food-contract/manifest`)
  * so downstream consumers don't move with the generator output.
+ *
+ * PRD-241 US-01 adds the runtime `ModuleManifest` value for `food` here.
+ * Mirrors the entry currently inlined in
+ * `packages/module-registry/scripts/known-modules.ts`'s `MANIFEST_SOURCES`.
+ * PRD-241 US-02 will replace that literal with a workspace discovery walk
+ * that consumes this export. Food declares no settings dimension today.
  */
+import type { ModuleManifest } from '@pops/types';
+
 export type { FoodContract } from './manifest.generated.js';
+
+export const foodManifest: ModuleManifest = {
+  id: 'food',
+  name: 'Food',
+  version: '0.1.0',
+  surfaces: ['app'],
+  description: 'Recipes, ingredients, meal planning, and multimodal ingestion.',
+};

--- a/packages/inventory-contract/src/__tests__/module-manifest.test.ts
+++ b/packages/inventory-contract/src/__tests__/module-manifest.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+
+import { assertModuleManifest } from '@pops/types';
+
+import { inventoryManifest } from '../manifest.js';
+
+describe('inventory-contract /manifest — ModuleManifest export (PRD-241 US-01)', () => {
+  it('inventoryManifest passes assertModuleManifest with id=inventory', () => {
+    expect(() => assertModuleManifest(inventoryManifest, 'modules.inventory')).not.toThrow();
+    expect(inventoryManifest.id).toBe('inventory');
+    expect(inventoryManifest.name).toBe('Inventory');
+    expect(inventoryManifest.surfaces).toEqual(['app']);
+  });
+
+  it('inventoryManifest contributes the inventory settings section', () => {
+    const sectionIds = (inventoryManifest.settings ?? []).map((s) => s.id);
+    expect(sectionIds).toEqual(['inventory']);
+  });
+});

--- a/packages/inventory-contract/src/manifest.ts
+++ b/packages/inventory-contract/src/manifest.ts
@@ -4,5 +4,24 @@
  * `pnpm -F @pops/inventory-contract generate:manifest` (Theme 13 PRD-155).
  * This file remains the stable import path (`@pops/inventory-contract/manifest`)
  * so downstream consumers don't move with the generator output.
+ *
+ * PRD-241 US-01 adds the runtime `ModuleManifest` value for `inventory` here.
+ * Mirrors the entry currently inlined in
+ * `packages/module-registry/scripts/known-modules.ts`'s `MANIFEST_SOURCES`.
+ * PRD-241 US-02 will replace that literal with a workspace discovery walk
+ * that consumes this export.
  */
+import { inventoryManifest as inventorySettingsManifest } from './settings/index.js';
+
+import type { ModuleManifest } from '@pops/types';
+
 export type { InventoryContract } from './manifest.generated.js';
+
+export const inventoryManifest: ModuleManifest = {
+  id: 'inventory',
+  name: 'Inventory',
+  version: '0.1.0',
+  surfaces: ['app'],
+  description: 'Home items, locations, connections, warranties, and documents.',
+  settings: [inventorySettingsManifest],
+};

--- a/packages/lists-contract/src/__tests__/module-manifest.test.ts
+++ b/packages/lists-contract/src/__tests__/module-manifest.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+
+import { assertModuleManifest } from '@pops/types';
+
+import { listsManifest } from '../manifest.js';
+
+describe('lists-contract /manifest — ModuleManifest export (PRD-241 US-01)', () => {
+  it('listsManifest passes assertModuleManifest with id=lists', () => {
+    expect(() => assertModuleManifest(listsManifest, 'modules.lists')).not.toThrow();
+    expect(listsManifest.id).toBe('lists');
+    expect(listsManifest.name).toBe('Lists');
+    expect(listsManifest.surfaces).toEqual(['app']);
+  });
+
+  it('listsManifest declares no settings dimension', () => {
+    expect(listsManifest.settings).toBeUndefined();
+  });
+});

--- a/packages/lists-contract/src/manifest.ts
+++ b/packages/lists-contract/src/manifest.ts
@@ -4,5 +4,21 @@
  * `pnpm -F @pops/lists-contract generate:manifest` (Theme 13 PRD-155).
  * This file remains the stable import path (`@pops/lists-contract/manifest`)
  * so downstream consumers don't move with the generator output.
+ *
+ * PRD-241 US-01 adds the runtime `ModuleManifest` value for `lists` here.
+ * Mirrors the entry currently inlined in
+ * `packages/module-registry/scripts/known-modules.ts`'s `MANIFEST_SOURCES`.
+ * PRD-241 US-02 will replace that literal with a workspace discovery walk
+ * that consumes this export. Lists declares no settings dimension today.
  */
+import type { ModuleManifest } from '@pops/types';
+
 export type { ListsContract } from './manifest.generated.js';
+
+export const listsManifest: ModuleManifest = {
+  id: 'lists',
+  name: 'Lists',
+  version: '0.1.0',
+  surfaces: ['app'],
+  description: 'Generic lists — shopping, packing, todo. Food is the first consumer.',
+};

--- a/packages/media-contract/src/__tests__/module-manifest.test.ts
+++ b/packages/media-contract/src/__tests__/module-manifest.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+
+import { assertModuleManifest } from '@pops/types';
+
+import { mediaManifest } from '../manifest.js';
+
+describe('media-contract /manifest — ModuleManifest export (PRD-241 US-01)', () => {
+  it('mediaManifest passes assertModuleManifest with id=media', () => {
+    expect(() => assertModuleManifest(mediaManifest, 'modules.media')).not.toThrow();
+    expect(mediaManifest.id).toBe('media');
+    expect(mediaManifest.name).toBe('Media');
+    expect(mediaManifest.surfaces).toEqual(['app']);
+  });
+
+  it('mediaManifest contributes plex/arr/rotation/operational settings sections', () => {
+    const sectionIds = (mediaManifest.settings ?? []).map((s) => s.id);
+    expect(sectionIds).toEqual(['media.plex', 'media.arr', 'media.rotation', 'media.operational']);
+  });
+});

--- a/packages/media-contract/src/manifest.ts
+++ b/packages/media-contract/src/manifest.ts
@@ -4,5 +4,29 @@
  * `pnpm -F @pops/media-contract generate:manifest` (Theme 13 PRD-155).
  * This file remains the stable import path (`@pops/media-contract/manifest`)
  * so downstream consumers don't move with the generator output.
+ *
+ * PRD-241 US-01 adds the runtime `ModuleManifest` value for `media` here.
+ * Mirrors the entry currently inlined in
+ * `packages/module-registry/scripts/known-modules.ts`'s `MANIFEST_SOURCES`.
+ * PRD-241 US-02 will replace that literal with a workspace discovery walk
+ * that consumes this export.
  */
+import {
+  arrManifest,
+  mediaOperationalManifest,
+  plexManifest,
+  rotationManifest,
+} from './settings/index.js';
+
+import type { ModuleManifest } from '@pops/types';
+
 export type { MediaContract } from './manifest.generated.js';
+
+export const mediaManifest: ModuleManifest = {
+  id: 'media',
+  name: 'Media',
+  version: '0.1.0',
+  surfaces: ['app'],
+  description: 'Movies, TV shows, watch history, and Plex/TMDB/TVDB sync.',
+  settings: [plexManifest, arrManifest, rotationManifest, mediaOperationalManifest],
+};


### PR DESCRIPTION
## Summary

Lands PRD-241 US-01 — each pillar's contract package exposes its `ModuleManifest` value on the existing `./manifest` subpath. No consumer migration; `MANIFEST_SOURCES` still works. US-02 will swap the literal for a discovery walk over these exports.

- Adds a `ModuleManifest` value alongside the existing PRD-155 `*Contract` type re-export on each contract package's `src/manifest.ts`.
- Values mirror the entries currently inlined in `packages/module-registry/scripts/known-modules.ts`'s `MANIFEST_SOURCES` field-for-field (same `id`, `name`, `version`, `surfaces`, `description`, `settings`, and `frontend.overlay` for ego).
- Per-pillar unit tests (`module-manifest.test.ts`) validate every export via `assertModuleManifest` and pin the settings-section composition.
- No `package.json` edits required — all 7 contract packages already expose `./manifest` under `exports`.

## Per-pillar `/manifest` exports

| Pillar      | Contract package          | New value export(s)               | Source for settings                                                                          |
| ----------- | ------------------------- | --------------------------------- | -------------------------------------------------------------------------------------------- |
| `core`      | `@pops/core-contract`     | `coreManifest`                    | `aiConfigManifest`, `coreOperationalManifest` (from `./settings/index.js`)                   |
| `ai`        | `@pops/core-contract`     | `aiManifest`                      | none (matches today)                                                                         |
| `cerebrum`  | `@pops/cerebrum-contract` | `cerebrumManifest`                | `cerebrumManifest` (the `SettingsManifest`, aliased on import)                               |
| `ego`       | `@pops/cerebrum-contract` | `egoManifest`                     | `egoManifest` (the `SettingsManifest`, aliased on import); carries `frontend.overlay` config |
| `finance`   | `@pops/finance-contract`  | `financeManifest`                 | `financeManifest` (the `SettingsManifest`, aliased on import)                                |
| `food`      | `@pops/food-contract`     | `foodManifest`                    | none (matches today)                                                                         |
| `inventory` | `@pops/inventory-contract`| `inventoryManifest`               | `inventoryManifest` (the `SettingsManifest`, aliased on import)                              |
| `lists`     | `@pops/lists-contract`    | `listsManifest`                   | none (matches today)                                                                         |
| `media`     | `@pops/media-contract`    | `mediaManifest`                   | `plexManifest`, `arrManifest`, `rotationManifest`, `mediaOperationalManifest`                |

`ai` and `ego` ship from `core-contract` / `cerebrum-contract` respectively per PRD-241 README's mapping — their settings already nest there post-PRD-239 / PRD-240.

## Diff vs. current `MANIFEST_SOURCES` literal

Every field is byte-for-byte identical to the literal entry it mirrors. The PRD-241 acceptance criterion is "no drift". Spot-check examples:

- `core` — `id`, `name='Core'`, `version='0.1.0'`, `surfaces=['app']`, description identical, `settings=[aiConfigManifest, coreOperationalManifest]`.
- `ego` — `surfaces=['app','overlay']`, `frontend.overlay={ chromeSlot: 'assistant', shortcut: 'mod+i' }` (the shortcut is NOT re-encoded anywhere else, per the US-01 note), `settings=[egoManifest]`.
- `food` / `lists` — no `settings`, matches today.
- `media` — settings in declared order: plex, arr, rotation, operational.

## Notes on the implementation

- The `./manifest` subpath already existed on every contract package — it currently re-exports the PRD-155 `*Contract` snapshot type. The new value exports land beside the existing type export; no `package.json` change is needed and no existing consumer is affected.
- `cerebrum`, `finance`, `inventory` each have a settings-side export with the same identifier name (`cerebrumManifest`, `financeManifest`, `inventoryManifest`) typed as `SettingsManifest`. The new value exports — typed as `ModuleManifest` — live on the `./manifest` subpath, while the `SettingsManifest`s stay on `./settings`. Internally, the manifest source aliases the `SettingsManifest` on import (e.g. `import { financeManifest as financeSettingsManifest } from './settings/index.js'`) so it can compose the new value cleanly.
- Used named imports throughout (per the PRD-241 brief's #3196 gotcha note).
- No `as any`, no `as unknown as`, no `eslint-disable`, no `ts-ignore`.

## Test plan

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm --filter @pops/pillar-sdk build` (prerequisite)
- [x] `pnpm --filter @pops/<contract> build` per contract package — all 7 green, emits `dist/manifest.{d.ts,js}` containing both the type and value exports
- [x] `pnpm --filter @pops/<contract> test` per contract package — every new `module-manifest.test.ts` passes
- [x] `pnpm --filter @pops/module-registry test` — existing 74 tests stay green
- [x] `pnpm --filter @pops/module-registry build` — `generated.ts` byte-stable (no consumer change in this US)
- [x] `pnpm typecheck` — 71 tasks green
- [x] `pnpm lint` — no new errors; only pre-existing warnings
- [x] Husky `pre-commit` (lint-staged) clean
- [ ] Husky `pre-push` (typecheck + rebase check) clean on push

## References

- PRD-241 README: `docs/themes/13-pillar-finale/prds/241-registry-driven-known-modules/README.md`
- US-01 spec: `docs/themes/13-pillar-finale/prds/241-registry-driven-known-modules/us-01-add-manifest-export-per-pillar.md`
- PR #3224 — PRD-241 scoping (just landed)
- PR #3175 — settings subpath scaffold (pattern reference)
- PR #3227 — PRD-241 US-03 boundary docs

## Out of scope (next-PR fodder)

- Replacing the `MANIFEST_SOURCES` literal with a workspace discovery walk — PRD-241 US-02.
- Closing the audit's H1 entry — PRD-241 US-03 (already landed in #3227).
