### PR TITLE
feat(pillar-sdk): PRD-243 US-01 nav + pages + assetsBaseUrl manifest dimensions

### DIFF
--- a/packages/pillar-sdk/src/__tests__/schema.test.ts
+++ b/packages/pillar-sdk/src/__tests__/schema.test.ts
@@ -625,4 +625,113 @@ describe('ManifestPayloadSchema', () => {
       expect(result.success).toBe(false);
     });
   });
+
+  describe('ui dimensions (PRD-243 US-01)', () => {
+    const financeNavDescriptor = () => ({
+      id: 'finance',
+      label: 'Finance',
+      labelKey: 'finance',
+      icon: 'dollar-sign',
+      color: 'emerald' as const,
+      basePath: '/finance',
+      order: 140,
+      items: [
+        { path: '', label: 'Dashboard', labelKey: 'finance.dashboard', icon: 'layout-dashboard' },
+        {
+          path: 'transactions',
+          label: 'Transactions',
+          labelKey: 'finance.transactions',
+          icon: 'list',
+        },
+      ],
+    });
+
+    const financePages = () => [
+      { path: '', index: true, bundleSlot: 'finance-dashboard' },
+      { path: 'transactions', bundleSlot: 'finance-transactions' },
+    ];
+
+    it('accepts a manifest with nav / pages / assetsBaseUrl all omitted (backwards-compatible)', () => {
+      const result = ManifestPayloadSchema.safeParse(validManifest());
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts a manifest with a valid nav + pages contribution', () => {
+      const m = { ...validManifest(), nav: financeNavDescriptor(), pages: financePages() };
+      const result = ManifestPayloadSchema.safeParse(m);
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts an empty pages array', () => {
+      const m = { ...validManifest(), pages: [] };
+      const result = ManifestPayloadSchema.safeParse(m);
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects nav without the required order field', () => {
+      const { order: _omitted, ...nav } = financeNavDescriptor();
+      const m = { ...validManifest(), nav };
+      const result = ManifestPayloadSchema.safeParse(m);
+      expect(result.success).toBe(false);
+    });
+
+    it.each(['finance', 'finance/dashboard', ''])(
+      'rejects nav.basePath that does not start with / (%s)',
+      (basePath) => {
+        const m = { ...validManifest(), nav: { ...financeNavDescriptor(), basePath } };
+        const result = ManifestPayloadSchema.safeParse(m);
+        expect(result.success).toBe(false);
+      }
+    );
+
+    it('rejects an unknown color enum value on nav', () => {
+      const m = { ...validManifest(), nav: { ...financeNavDescriptor(), color: 'crimson' } };
+      const result = ManifestPayloadSchema.safeParse(m);
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects a non-kebab-case icon identifier', () => {
+      const m = { ...validManifest(), nav: { ...financeNavDescriptor(), icon: 'DollarSign' } };
+      const result = ManifestPayloadSchema.safeParse(m);
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects unknown field on nav descriptor (strict mode)', () => {
+      const m = { ...validManifest(), nav: { ...financeNavDescriptor(), sneaky: true } };
+      const result = ManifestPayloadSchema.safeParse(m);
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects unknown field on a page descriptor (strict mode)', () => {
+      const pages = [{ ...financePages()[0]!, sneaky: true }];
+      const m = { ...validManifest(), pages };
+      const result = ManifestPayloadSchema.safeParse(m);
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects a page descriptor missing bundleSlot', () => {
+      const m = { ...validManifest(), pages: [{ path: 'transactions' }] };
+      const result = ManifestPayloadSchema.safeParse(m);
+      expect(result.success).toBe(false);
+    });
+
+    it.each([
+      'https://assets.example.com/finance/',
+      'https://cdn.example.com/v1/bundles/finance',
+      'http://localhost:5173/finance',
+    ])('accepts a valid absolute assetsBaseUrl (%s)', (assetsBaseUrl) => {
+      const m = { ...validManifest(), assetsBaseUrl };
+      const result = ManifestPayloadSchema.safeParse(m);
+      expect(result.success).toBe(true);
+    });
+
+    it.each(['/finance', 'finance/bundles', 'not a url', ''])(
+      'rejects a non-URL assetsBaseUrl (%s)',
+      (assetsBaseUrl) => {
+        const m = { ...validManifest(), assetsBaseUrl };
+        const result = ManifestPayloadSchema.safeParse(m);
+        expect(result.success).toBe(false);
+      }
+    );
+  });
 });

--- a/packages/pillar-sdk/src/manifest-schema/index.ts
+++ b/packages/pillar-sdk/src/manifest-schema/index.ts
@@ -3,6 +3,9 @@ export {
   type ManifestPayload,
   type SinkDescriptor,
   type SettingsManifestDescriptor,
+  type NavConfigDescriptor,
+  type NavItemDescriptor,
+  type PageDescriptor,
 } from './schema.js';
 export {
   validateManifestPayload,

--- a/packages/pillar-sdk/src/manifest-schema/schema.ts
+++ b/packages/pillar-sdk/src/manifest-schema/schema.ts
@@ -1,6 +1,14 @@
 import { z } from 'zod';
 
 import { SettingsBlockSchema, type SettingsManifestDescriptor } from './settings.js';
+import {
+  AssetsBaseUrlSchema,
+  NavConfigDescriptorSchema,
+  PageDescriptorSchema,
+  type NavConfigDescriptor,
+  type NavItemDescriptor,
+  type PageDescriptor,
+} from './ui.js';
 
 const PILLAR_ID = z.string().regex(/^[a-z][a-z0-9-]*$/, 'pillar id must be lowercase kebab-case');
 
@@ -167,6 +175,9 @@ export const ManifestPayloadSchema = z
     uri: URI,
     consumedSettings: CONSUMED_SETTINGS,
     settings: SettingsBlockSchema.optional(),
+    nav: NavConfigDescriptorSchema.optional(),
+    pages: z.array(PageDescriptorSchema).optional(),
+    assetsBaseUrl: AssetsBaseUrlSchema.optional(),
     healthcheck: HEALTHCHECK,
   })
   .strict();
@@ -174,5 +185,7 @@ export const ManifestPayloadSchema = z
 export type SinkDescriptor = z.infer<typeof SINK_DESCRIPTOR>;
 
 export type { SettingsManifestDescriptor };
+
+export type { NavConfigDescriptor, NavItemDescriptor, PageDescriptor };
 
 export type ManifestPayload = z.infer<typeof ManifestPayloadSchema>;

--- a/packages/pillar-sdk/src/manifest-schema/ui.ts
+++ b/packages/pillar-sdk/src/manifest-schema/ui.ts
@@ -1,0 +1,69 @@
+import { z } from 'zod';
+
+const KEBAB_IDENTIFIER = z
+  .string()
+  .regex(/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/, 'must be lowercase kebab-case identifier');
+
+const BASE_PATH = z.string().regex(/^\//, 'must start with /');
+
+const I18N_KEY = z.string().min(1);
+
+const NAV_COLOR = z.enum(['emerald', 'indigo', 'amber', 'rose', 'sky', 'violet']);
+
+const NAV_ITEM_DESCRIPTOR = z
+  .object({
+    path: z.string(),
+    label: z.string().min(1),
+    labelKey: I18N_KEY,
+    icon: KEBAB_IDENTIFIER,
+  })
+  .strict();
+
+/**
+ * Wire-shaped descriptor of a pillar's app-rail entry. Mirrors the
+ * `AppNavConfig` shape the shell consumes today (`apps/pops-shell/src/app/nav/types.ts`),
+ * minus the runtime `IconName` enum dependency — icons travel the wire as
+ * kebab-case identifiers and resolve to Lucide components shell-side.
+ *
+ * `order` is required: PRD-243 moves app-rail ordering off the
+ * `registeredApps` array index and onto the manifest. Ties break
+ * lexicographically by `id`.
+ */
+export const NavConfigDescriptorSchema = z
+  .object({
+    id: KEBAB_IDENTIFIER,
+    label: z.string().min(1),
+    labelKey: I18N_KEY,
+    icon: KEBAB_IDENTIFIER,
+    color: NAV_COLOR.optional(),
+    basePath: BASE_PATH,
+    order: z.number().int(),
+    items: z.array(NAV_ITEM_DESCRIPTOR),
+  })
+  .strict();
+
+/**
+ * Wire-shaped descriptor of a routable page contributed by a pillar.
+ * Carries the routing surface the shell consumes today; React component
+ * refs come from the workspace bundle map at the shell side (US-03), so
+ * the descriptor names a `bundleSlot` instead of carrying a component
+ * directly.
+ */
+export const PageDescriptorSchema = z
+  .object({
+    path: z.string(),
+    index: z.boolean().optional(),
+    bundleSlot: KEBAB_IDENTIFIER,
+  })
+  .strict();
+
+/**
+ * Absolute URL where a pillar's frontend bundle is served from. Reserved
+ * for the external-pillar UI loading mechanism (PRD-243 US-05, deferred).
+ * Validated at the wire layer in US-01; not consumed by the shell today.
+ */
+export const AssetsBaseUrlSchema = z.string().url();
+
+export type NavConfigDescriptor = z.infer<typeof NavConfigDescriptorSchema>;
+export type NavItemDescriptor = z.infer<typeof NAV_ITEM_DESCRIPTOR>;
+export type PageDescriptor = z.infer<typeof PageDescriptorSchema>;


### PR DESCRIPTION
## Summary

Extend `ManifestPayloadSchema` with three optional UI dimensions for the registry-driven shell aggregation pattern PRD-243 (#3228) introduces. Mirrors the PRD-240 US-01 (#3217) scaffold: new descriptor module under `manifest-schema/`, optional top-level blocks, strict descriptors, wire-format validation only — no behavioural change.

- **`nav?: NavConfigDescriptor`** — wire-shaped peer of the shell's `AppNavConfig` (`apps/pops-shell/src/app/nav/types.ts`), minus the runtime `IconName` enum dependency. Icons travel the wire as kebab-case identifiers. Adds a required `order: number` so app-rail ordering moves off the `registeredApps` array index and onto the manifest (ties break lexicographically by `id` in the shell — that's US-03).
- **`pages?: PageDescriptor[]`** — wire-shaped routing surface. Names a kebab-case `bundleSlot` instead of carrying a React component ref directly; the shell-side workspace bundle map (US-03) resolves the slot to a component.
- **`assetsBaseUrl?: string`** — absolute-URL reserved field for the deferred external-pillar UI loading mechanism (US-05). Validated at the wire layer here; the shell does not consume it yet.

Backwards compatible: existing manifests without these dimensions parse unchanged. Sinks + settings test suites stay green.

## Pattern

Same shape as the settings dimension landing (#3217 / PRD-240 US-01):

| | sinks | settings | ui (this PR) |
|---|---|---|---|
| Module under `manifest-schema/` | inline in `schema.ts` | `settings.ts` | `ui.ts` |
| Top-level schema fields | `sinks?` | `settings?` | `nav?`, `pages?`, `assetsBaseUrl?` |
| Exported descriptor types | `SinkDescriptor` | `SettingsManifestDescriptor` | `NavConfigDescriptor`, `NavItemDescriptor`, `PageDescriptor` |

## Follows up

- US-02 — per-pillar manifest contributions (the seven in-repo FE pillars declare their `nav` and `pages`).
- US-03 — shell rewrite (`installed-modules.ts` + `nav/registry.ts` become a registry walk; the literal `KNOWN_FRONTEND_MANIFESTS` + `registeredApps` arrays go away).
- US-04 — integration test (synthetic in-repo pillar via registry override).
- US-05 — external-pillar UI loading mechanism (deferred; doc-only stub).

## Test plan

- [x] `pnpm --filter @pops/pillar-sdk test` — 542 tests pass (was 523; +19 covering omitted blocks, valid nav + pages, empty pages array, missing required `order`, bad `basePath` / `color` / `icon`, strict-mode unknown fields on nav + page descriptors, absolute URL accept / non-URL reject for `assetsBaseUrl`).
- [x] `pnpm typecheck` — clean across the workspace.
- [x] Husky pre-commit (oxlint + oxfmt via lint-staged) passes.
- [x] Backwards compat: the fixture manifest in `@pops/wire-conformance` and every existing per-pillar `manifest.test.ts` still validate unchanged.