### PR TITLE
feat: PRD-243 US-02 nav+pages declarations for cerebrum / media / food / lists (batch B)

### DIFF
--- a/apps/pops-cerebrum-api/src/__tests__/manifest.test.ts
+++ b/apps/pops-cerebrum-api/src/__tests__/manifest.test.ts
@@ -50,4 +50,90 @@ describe('buildCerebrumManifest', () => {
   it('rejects non-semver versions at the schema boundary', () => {
     expect(() => ManifestPayloadSchema.parse(buildCerebrumManifest('not-a-semver'))).toThrow();
   });
+
+  describe('PRD-243 US-02 nav + pages dimensions', () => {
+    it('declares a nav block matching the shell-side cerebrum navConfig', () => {
+      const manifest = buildCerebrumManifest('0.1.0');
+      expect(manifest.nav?.id).toBe('cerebrum');
+      expect(manifest.nav?.basePath).toBe('/cerebrum');
+      expect(manifest.nav?.icon).toBe('book-open');
+      expect(manifest.nav?.color).toBe('sky');
+      expect(manifest.nav?.order).toBe(600);
+    });
+
+    it('mirrors the shell-side nav item count + paths (no drift)', () => {
+      const manifest = buildCerebrumManifest('0.1.0');
+      const paths = manifest.nav?.items.map((i) => i.path) ?? [];
+      expect(paths).toEqual([
+        '',
+        '/engrams',
+        '/query',
+        '/documents',
+        '/nudges',
+        '/proposals',
+        '/glia',
+        '/reflex',
+        '/plexus',
+      ]);
+    });
+
+    it('rewrites every nav icon as a kebab-case wire identifier', () => {
+      const manifest = buildCerebrumManifest('0.1.0');
+      const icons = [manifest.nav?.icon, ...(manifest.nav?.items.map((i) => i.icon) ?? [])].filter(
+        (v): v is string => typeof v === 'string'
+      );
+      for (const icon of icons) {
+        expect(icon).toMatch(/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/);
+      }
+    });
+
+    it('declares a pages descriptor for every cerebrum route surface', () => {
+      const manifest = buildCerebrumManifest('0.1.0');
+      const paths = manifest.pages?.map((p) => p.path) ?? [];
+      expect(paths).toEqual([
+        '',
+        'chat',
+        'nudges',
+        'proposals',
+        'engrams',
+        'engrams/:id',
+        'documents',
+        'query',
+        'reflex',
+        'reflex/:name',
+        'plexus',
+        'plexus/:adapterId',
+        'glia',
+      ]);
+    });
+
+    it('flags the index page (and only the index page)', () => {
+      const manifest = buildCerebrumManifest('0.1.0');
+      const indexes = manifest.pages?.filter((p) => p.index === true) ?? [];
+      expect(indexes).toHaveLength(1);
+      expect(indexes[0]?.bundleSlot).toBe('cerebrum-ingest');
+    });
+
+    it('gives every page a unique kebab-case bundleSlot', () => {
+      const manifest = buildCerebrumManifest('0.1.0');
+      const slots = manifest.pages?.map((p) => p.bundleSlot) ?? [];
+      expect(new Set(slots).size).toBe(slots.length);
+      for (const slot of slots) {
+        expect(slot).toMatch(/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/);
+      }
+    });
+
+    it('does NOT declare assetsBaseUrl (deferred to US-05)', () => {
+      const manifest = buildCerebrumManifest('0.1.0');
+      expect(manifest.assetsBaseUrl).toBeUndefined();
+    });
+
+    it('round-trips the nav + pages dimensions through JSON', () => {
+      const manifest = buildCerebrumManifest('0.1.0');
+      const roundTripped: unknown = JSON.parse(JSON.stringify(manifest));
+      const parsed = ManifestPayloadSchema.parse(roundTripped);
+      expect(parsed.nav?.id).toBe('cerebrum');
+      expect(parsed.pages?.length).toBeGreaterThan(0);
+    });
+  });
 });

--- a/apps/pops-cerebrum-api/src/manifest.ts
+++ b/apps/pops-cerebrum-api/src/manifest.ts
@@ -1,11 +1,87 @@
 import { cerebrumManifest, egoManifest } from '@pops/cerebrum-contract/settings';
 
-import type { ManifestPayload } from '@pops/pillar-sdk/manifest-schema';
+import type {
+  ManifestPayload,
+  NavConfigDescriptor,
+  PageDescriptor,
+} from '@pops/pillar-sdk/manifest-schema';
 
 export const CEREBRUM_PILLAR_ID = 'cerebrum' as const;
 
 /**
- * Cerebrum pillar manifest (PRD-240 US-03).
+ * Wire-format nav contribution for the cerebrum pillar (PRD-243 US-02).
+ *
+ * Mirrors the shell-side `navConfig` exported from `@pops/app-cerebrum`
+ * (`packages/app-cerebrum/src/routes.tsx`) — same items, same order — with
+ * the runtime Lucide icon names rewritten as kebab-case identifiers per
+ * the `NavConfigDescriptor` wire shape from PR #3230. `order: 600` places
+ * cerebrum sixth in the shell's `registeredApps` array
+ * (`apps/pops-shell/src/app/nav/registry.ts`), matching today's layout.
+ */
+const CEREBRUM_NAV: NavConfigDescriptor = {
+  id: 'cerebrum',
+  label: 'Cerebrum',
+  labelKey: 'cerebrum',
+  icon: 'book-open',
+  color: 'sky',
+  basePath: '/cerebrum',
+  order: 600,
+  items: [
+    { path: '', label: 'Ingest', labelKey: 'cerebrum.ingest', icon: 'file-text' },
+    { path: '/engrams', label: 'Engrams', labelKey: 'cerebrum.engrams.nav', icon: 'library' },
+    { path: '/query', label: 'Query', labelKey: 'cerebrum.query.nav', icon: 'search' },
+    {
+      path: '/documents',
+      label: 'Documents',
+      labelKey: 'cerebrum.documents.nav',
+      icon: 'file-text',
+    },
+    { path: '/nudges', label: 'Nudges', labelKey: 'cerebrum.nudges', icon: 'bell' },
+    {
+      path: '/proposals',
+      label: 'Proposals',
+      labelKey: 'cerebrum.proposals',
+      icon: 'git-pull-request',
+    },
+    { path: '/glia', label: 'Glia', labelKey: 'cerebrum.glia.nav', icon: 'activity' },
+    { path: '/reflex', label: 'Reflex', labelKey: 'cerebrum.reflex.nav', icon: 'zap' },
+    { path: '/plexus', label: 'Plexus', labelKey: 'cerebrum.plexus.nav', icon: 'plug' },
+  ],
+};
+
+/**
+ * Wire-format pages contribution for the cerebrum pillar (PRD-243 US-02).
+ *
+ * One descriptor per route declared in `@pops/app-cerebrum`'s `routes`
+ * array. `bundleSlot` is the kebab-case identifier the shell-side
+ * workspace bundle map (PRD-243 US-03) will resolve back to the React
+ * component currently held in `installed-modules.ts`.
+ *
+ * The `chat` route hosts ego's chat panel (PRD-099) — it lives in
+ * `@pops/app-cerebrum` so it stays mounted under `/cerebrum/*` even
+ * though the chat panel itself ships from `@pops/overlay-ego`. Ego's
+ * overlay surface (the floating FAB) is NOT carried here: the current
+ * `NavConfigDescriptor` does not support overlay/shortcut shapes — that
+ * gap is tracked for follow-up (see PR body).
+ */
+const CEREBRUM_PAGES: readonly PageDescriptor[] = [
+  { path: '', index: true, bundleSlot: 'cerebrum-ingest' },
+  { path: 'chat', bundleSlot: 'cerebrum-chat' },
+  { path: 'nudges', bundleSlot: 'cerebrum-nudges' },
+  { path: 'proposals', bundleSlot: 'cerebrum-proposal-queue' },
+  { path: 'engrams', bundleSlot: 'cerebrum-engrams-list' },
+  { path: 'engrams/:id', bundleSlot: 'cerebrum-engram-detail' },
+  { path: 'documents', bundleSlot: 'cerebrum-documents' },
+  { path: 'query', bundleSlot: 'cerebrum-query' },
+  { path: 'reflex', bundleSlot: 'cerebrum-reflex-list' },
+  { path: 'reflex/:name', bundleSlot: 'cerebrum-reflex-detail' },
+  { path: 'plexus', bundleSlot: 'cerebrum-plexus-list' },
+  { path: 'plexus/:adapterId', bundleSlot: 'cerebrum-plexus-detail' },
+  { path: 'glia', bundleSlot: 'cerebrum-glia-dashboard' },
+];
+
+/**
+ * Cerebrum pillar manifest (PRD-240 US-03, extended in PRD-243 US-02).
  *
  * Declares the `settings.manifests` dimension on the cerebrum API's
  * manifest payload — the cerebrum sub-domain (`cerebrumManifest`) and
@@ -14,6 +90,11 @@ export const CEREBRUM_PILLAR_ID = 'cerebrum' as const;
  * the pillar is the sole declarer of its settings UI contribution. See
  * [ADR-037](../../../../docs/architecture/adr-037-settings-as-manifest-dimension.md)
  * for the dimension's design and PRD-240 for the rollout plan.
+ *
+ * PRD-243 US-02 adds the `nav` and `pages` UI dimensions. The cerebrum
+ * pillar carries its own app-rail entry + routable pages; ego's overlay
+ * surface stays mounted via `@pops/overlay-ego`'s manifest and is not
+ * representable in today's `NavConfigDescriptor` shape (deferred).
  */
 export function buildCerebrumManifest(version: string): ManifestPayload {
   return {
@@ -34,6 +115,8 @@ export function buildCerebrumManifest(version: string): ManifestPayload {
     uri: { types: [] },
     consumedSettings: { keys: [] },
     settings: { manifests: [cerebrumManifest, egoManifest] },
+    nav: CEREBRUM_NAV,
+    pages: [...CEREBRUM_PAGES],
     healthcheck: { path: '/health' },
   };
 }

--- a/apps/pops-food-api/src/__tests__/manifest.test.ts
+++ b/apps/pops-food-api/src/__tests__/manifest.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Manifest payload tests for the food pillar (PRD-243 US-02).
+ *
+ * `buildFoodManifest` was extracted from `server.ts` so the new `nav`
+ * and `pages` UI dimensions live next to the existing payload fields.
+ * These tests verify the payload still passes the wire schema AND
+ * carries the nav + pages descriptors expected by PRD-243's shell
+ * rewrite (US-03).
+ */
+import { describe, expect, it } from 'vitest';
+
+import { ManifestPayloadSchema, validateManifestPayload } from '@pops/pillar-sdk/manifest-schema';
+
+import { buildFoodManifest, FOOD_PILLAR_ID } from '../manifest.js';
+
+describe('buildFoodManifest', () => {
+  it('produces a payload that passes the central manifest schema', () => {
+    const manifest = buildFoodManifest('0.1.0');
+    const parsed = ManifestPayloadSchema.parse(manifest);
+    expect(parsed.pillar).toBe(FOOD_PILLAR_ID);
+    expect(parsed.contract.package).toBe('@pops/food-contract');
+    expect(parsed.contract.tag).toBe('contract-food@v0.1.0');
+  });
+
+  it('passes the full cross-field validator', () => {
+    const result = validateManifestPayload(buildFoodManifest('0.1.0'));
+    expect(result.ok).toBe(true);
+  });
+
+  it('declares no settings dimension today (no food settings ship yet)', () => {
+    const manifest = buildFoodManifest('0.1.0');
+    expect(manifest.settings).toBeUndefined();
+  });
+
+  it('rejects non-semver versions at the schema boundary', () => {
+    expect(() => ManifestPayloadSchema.parse(buildFoodManifest('not-a-semver'))).toThrow();
+  });
+
+  describe('PRD-243 US-02 nav + pages dimensions', () => {
+    it('declares a nav block matching the shell-side food navConfig', () => {
+      const manifest = buildFoodManifest('0.1.0');
+      expect(manifest.nav?.id).toBe('food');
+      expect(manifest.nav?.basePath).toBe('/food');
+      expect(manifest.nav?.icon).toBe('utensils');
+      expect(manifest.nav?.color).toBe('amber');
+      expect(manifest.nav?.order).toBe(400);
+    });
+
+    it('mirrors the shell-side nav item count + paths (no drift)', () => {
+      const manifest = buildFoodManifest('0.1.0');
+      expect(manifest.nav?.items.map((i) => i.path)).toEqual([
+        '',
+        '/recipes',
+        '/inbox',
+        '/plan',
+        '/fridge',
+        '/solve',
+        '/shopping/from-plan',
+        '/data',
+        '/prompts',
+      ]);
+    });
+
+    it('rewrites every nav icon as a kebab-case wire identifier', () => {
+      const manifest = buildFoodManifest('0.1.0');
+      const icons = [manifest.nav?.icon, ...(manifest.nav?.items.map((i) => i.icon) ?? [])].filter(
+        (v): v is string => typeof v === 'string'
+      );
+      for (const icon of icons) {
+        expect(icon).toMatch(/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/);
+      }
+    });
+
+    it('declares one descriptor for the index route and one per data tab', () => {
+      const manifest = buildFoodManifest('0.1.0');
+      const paths = manifest.pages?.map((p) => p.path) ?? [];
+      expect(paths).toContain('');
+      expect(paths).toContain('data');
+      expect(paths).toContain('data/ingredients');
+      expect(paths).toContain('data/aliases');
+      expect(paths).toContain('data/prep-states');
+      expect(paths).toContain('data/substitutions');
+      expect(paths).toContain('data/substitutions/graph');
+      expect(paths).toContain('data/conversions');
+      expect(paths).toContain('data/tags');
+    });
+
+    it('flags the index page (and only the index page)', () => {
+      const manifest = buildFoodManifest('0.1.0');
+      const indexes = manifest.pages?.filter((p) => p.index === true) ?? [];
+      expect(indexes).toHaveLength(1);
+      expect(indexes[0]?.bundleSlot).toBe('food-landing');
+    });
+
+    it('gives every page a unique kebab-case bundleSlot', () => {
+      const manifest = buildFoodManifest('0.1.0');
+      const slots = manifest.pages?.map((p) => p.bundleSlot) ?? [];
+      expect(new Set(slots).size).toBe(slots.length);
+      for (const slot of slots) {
+        expect(slot).toMatch(/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/);
+      }
+    });
+
+    it('does NOT declare assetsBaseUrl (deferred to US-05)', () => {
+      const manifest = buildFoodManifest('0.1.0');
+      expect(manifest.assetsBaseUrl).toBeUndefined();
+    });
+
+    it('round-trips the nav + pages dimensions through JSON', () => {
+      const manifest = buildFoodManifest('0.1.0');
+      const roundTripped: unknown = JSON.parse(JSON.stringify(manifest));
+      const parsed = ManifestPayloadSchema.parse(roundTripped);
+      expect(parsed.nav?.id).toBe('food');
+      expect(parsed.pages?.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/apps/pops-food-api/src/manifest.ts
+++ b/apps/pops-food-api/src/manifest.ts
@@ -1,0 +1,115 @@
+import type {
+  ManifestPayload,
+  NavConfigDescriptor,
+  PageDescriptor,
+} from '@pops/pillar-sdk/manifest-schema';
+
+export const FOOD_PILLAR_ID = 'food' as const;
+
+/**
+ * Wire-format nav contribution for the food pillar (PRD-243 US-02).
+ *
+ * Mirrors `@pops/app-food`'s `navConfig` (`packages/app-food/src/routes.tsx`)
+ * field-for-field; Lucide names are rewritten as kebab-case identifiers
+ * per the wire schema from PR #3230. `order: 400` matches today's
+ * position in `apps/pops-shell/src/app/nav/registry.ts`
+ * (`registeredApps[3]`).
+ */
+const FOOD_NAV: NavConfigDescriptor = {
+  id: 'food',
+  label: 'Food',
+  labelKey: 'food',
+  icon: 'utensils',
+  color: 'amber',
+  basePath: '/food',
+  order: 400,
+  items: [
+    { path: '', label: 'Home', labelKey: 'food.home', icon: 'layout-dashboard' },
+    { path: '/recipes', label: 'Recipes', labelKey: 'food.recipes', icon: 'book-open' },
+    { path: '/inbox', label: 'Inbox', labelKey: 'food.inbox', icon: 'bell' },
+    { path: '/plan', label: 'Plan', labelKey: 'food.plan', icon: 'clock' },
+    { path: '/fridge', label: 'Fridge', labelKey: 'food.fridge', icon: 'package' },
+    { path: '/solve', label: 'Solve', labelKey: 'food.solve', icon: 'compass' },
+    {
+      path: '/shopping/from-plan',
+      label: 'Shopping',
+      labelKey: 'food.shopping',
+      icon: 'list-checks',
+    },
+    { path: '/data', label: 'Manage data', labelKey: 'food.data', icon: 'database' },
+    { path: '/prompts', label: 'Prompts', labelKey: 'food.prompts', icon: 'file-text' },
+  ],
+};
+
+/**
+ * Wire-format pages contribution for the food pillar (PRD-243 US-02).
+ *
+ * One descriptor per route declared in `@pops/app-food`'s `routes`
+ * array. The nested `/food/data/*` subtree is flattened: each child
+ * becomes its own descriptor carrying the full `data/<tab>` path. The
+ * `FoodDataLayout` wrapper is carried as `food-data-layout` against the
+ * bare `data` path so the shell-side bundle map (PRD-243 US-03) can
+ * reconstruct the parent/child mounting today's nested
+ * `RouteObject.children` shape gives us.
+ */
+const FOOD_PAGES: readonly PageDescriptor[] = [
+  { path: '', index: true, bundleSlot: 'food-landing' },
+  { path: 'data', bundleSlot: 'food-data-layout' },
+  { path: 'data/ingredients', bundleSlot: 'food-data-ingredients' },
+  { path: 'data/aliases', bundleSlot: 'food-data-aliases' },
+  { path: 'data/prep-states', bundleSlot: 'food-data-prep-states' },
+  { path: 'data/substitutions', bundleSlot: 'food-data-substitutions' },
+  { path: 'data/substitutions/graph', bundleSlot: 'food-data-substitutions-graph' },
+  { path: 'data/conversions', bundleSlot: 'food-data-conversions' },
+  { path: 'data/tags', bundleSlot: 'food-data-tags' },
+  { path: 'recipes', bundleSlot: 'food-recipe-list' },
+  { path: 'recipes/new', bundleSlot: 'food-recipe-new' },
+  { path: 'recipes/:slug', bundleSlot: 'food-recipe-detail' },
+  { path: 'recipes/:slug/v/:versionNo', bundleSlot: 'food-recipe-version-detail' },
+  { path: 'recipes/:slug/edit', bundleSlot: 'food-recipe-edit' },
+  { path: 'recipes/:slug/drafts', bundleSlot: 'food-recipe-drafts' },
+  { path: 'recipes/:slug/drafts/:draftNo', bundleSlot: 'food-recipe-draft-edit' },
+  { path: 'prompts', bundleSlot: 'food-prompt-viewer' },
+  { path: 'plan', bundleSlot: 'food-plan' },
+  { path: 'fridge', bundleSlot: 'food-fridge' },
+  { path: 'solve', bundleSlot: 'food-solve' },
+  { path: 'shopping/from-plan', bundleSlot: 'food-shopping-from-plan' },
+  { path: 'inbox', bundleSlot: 'food-inbox' },
+  { path: 'inbox/:sourceId', bundleSlot: 'food-inbox-inspector' },
+];
+
+/**
+ * Food pillar manifest payload.
+ *
+ * Extracted out of `server.ts` in PRD-243 US-02 so the `nav` + `pages`
+ * UI dimensions PR #3230 introduces have a dedicated home alongside
+ * `buildCerebrumManifest` / `buildMediaManifest`.
+ *
+ * Drive-by fix: server.ts pinned the contract package as
+ * `@pops/food-contracts` (plural), which `ManifestPayloadSchema`'s
+ * `CONTRACT_PACKAGE` regex rejects (`^@pops\/[a-z-]+-contract$`). The
+ * value was never validated before because `buildFoodManifest` had no
+ * test coverage. The singular `@pops/food-contract` package exists at
+ * `packages/food-contract/` (see PRD-241 US-01 in #3229) and is the
+ * canonical contract package today — pinning the manifest there fixes
+ * the wire format AND aligns with the contract export landed in #3229.
+ */
+export function buildFoodManifest(version: string): ManifestPayload {
+  return {
+    pillar: FOOD_PILLAR_ID,
+    version,
+    contract: {
+      package: '@pops/food-contract',
+      version,
+      tag: `contract-food@v${version}`,
+    },
+    routes: { queries: [], mutations: [], subscriptions: [] },
+    search: { adapters: [] },
+    ai: { tools: [] },
+    uri: { types: [] },
+    consumedSettings: { keys: [] },
+    nav: FOOD_NAV,
+    pages: [...FOOD_PAGES],
+    healthcheck: { path: '/health' },
+  };
+}

--- a/apps/pops-food-api/src/server.ts
+++ b/apps/pops-food-api/src/server.ts
@@ -26,9 +26,8 @@ import { bootstrapPillar, type PillarBootstrapHandle } from '@pops/pillar-sdk/bo
 
 import { createFoodApiApp } from './app.js';
 import { resolveFoodSqlitePath } from './food-sqlite-path.js';
+import { buildFoodManifest } from './manifest.js';
 import { parseBareOrigin } from './pillars/env.js';
-
-import type { ManifestPayload } from '@pops/pillar-sdk/manifest-schema';
 
 function resolvePort(): number {
   // 3001 is core-api, 3002 is inventory-api, 3003 is media-api,
@@ -40,24 +39,6 @@ function resolvePort(): number {
     throw new Error(`[food-api] PORT must be a positive integer in 1-65535; got '${raw}'`);
   }
   return parsed;
-}
-
-function buildFoodManifest(version: string): ManifestPayload {
-  return {
-    pillar: 'food',
-    version,
-    contract: {
-      package: '@pops/food-contracts',
-      version,
-      tag: `contract-food@v${version}`,
-    },
-    routes: { queries: [], mutations: [], subscriptions: [] },
-    search: { adapters: [] },
-    ai: { tools: [] },
-    uri: { types: [] },
-    consumedSettings: { keys: [] },
-    healthcheck: { path: '/health' },
-  };
 }
 
 const port = resolvePort();

--- a/apps/pops-lists-api/src/__tests__/manifest.test.ts
+++ b/apps/pops-lists-api/src/__tests__/manifest.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Manifest payload tests for the lists pillar (PRD-243 US-02).
+ *
+ * `buildListsManifest` was extracted from `server.ts` so the new `nav`
+ * and `pages` UI dimensions live next to the existing payload fields.
+ * These tests verify the payload still passes the wire schema AND
+ * carries the nav + pages descriptors expected by PRD-243's shell
+ * rewrite (US-03).
+ */
+import { describe, expect, it } from 'vitest';
+
+import { ManifestPayloadSchema, validateManifestPayload } from '@pops/pillar-sdk/manifest-schema';
+
+import { buildListsManifest, LISTS_PILLAR_ID } from '../manifest.js';
+
+describe('buildListsManifest', () => {
+  it('produces a payload that passes the central manifest schema', () => {
+    const manifest = buildListsManifest('0.1.0');
+    const parsed = ManifestPayloadSchema.parse(manifest);
+    expect(parsed.pillar).toBe(LISTS_PILLAR_ID);
+    expect(parsed.contract.package).toBe('@pops/lists-contract');
+    expect(parsed.contract.tag).toBe('contract-lists@v0.1.0');
+  });
+
+  it('passes the full cross-field validator', () => {
+    const result = validateManifestPayload(buildListsManifest('0.1.0'));
+    expect(result.ok).toBe(true);
+  });
+
+  it('declares no settings dimension today (no lists settings ship yet)', () => {
+    const manifest = buildListsManifest('0.1.0');
+    expect(manifest.settings).toBeUndefined();
+  });
+
+  it('rejects non-semver versions at the schema boundary', () => {
+    expect(() => ManifestPayloadSchema.parse(buildListsManifest('not-a-semver'))).toThrow();
+  });
+
+  describe('PRD-243 US-02 nav + pages dimensions', () => {
+    it('declares a nav block matching the shell-side lists navConfig', () => {
+      const manifest = buildListsManifest('0.1.0');
+      expect(manifest.nav?.id).toBe('lists');
+      expect(manifest.nav?.basePath).toBe('/lists');
+      expect(manifest.nav?.icon).toBe('list-checks');
+      expect(manifest.nav?.color).toBe('sky');
+      expect(manifest.nav?.order).toBe(500);
+    });
+
+    it('mirrors the shell-side nav item count + paths (home only, no deep links)', () => {
+      const manifest = buildListsManifest('0.1.0');
+      expect(manifest.nav?.items.map((i) => i.path)).toEqual(['']);
+    });
+
+    it('rewrites every nav icon as a kebab-case wire identifier', () => {
+      const manifest = buildListsManifest('0.1.0');
+      const icons = [manifest.nav?.icon, ...(manifest.nav?.items.map((i) => i.icon) ?? [])].filter(
+        (v): v is string => typeof v === 'string'
+      );
+      for (const icon of icons) {
+        expect(icon).toMatch(/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/);
+      }
+    });
+
+    it('declares a pages descriptor for the index and the detail deep link', () => {
+      const manifest = buildListsManifest('0.1.0');
+      const paths = manifest.pages?.map((p) => p.path) ?? [];
+      expect(paths).toEqual(['', ':id']);
+    });
+
+    it('flags the index page (and only the index page)', () => {
+      const manifest = buildListsManifest('0.1.0');
+      const indexes = manifest.pages?.filter((p) => p.index === true) ?? [];
+      expect(indexes).toHaveLength(1);
+      expect(indexes[0]?.bundleSlot).toBe('lists-index');
+    });
+
+    it('gives every page a unique kebab-case bundleSlot', () => {
+      const manifest = buildListsManifest('0.1.0');
+      const slots = manifest.pages?.map((p) => p.bundleSlot) ?? [];
+      expect(new Set(slots).size).toBe(slots.length);
+      for (const slot of slots) {
+        expect(slot).toMatch(/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/);
+      }
+    });
+
+    it('does NOT declare assetsBaseUrl (deferred to US-05)', () => {
+      const manifest = buildListsManifest('0.1.0');
+      expect(manifest.assetsBaseUrl).toBeUndefined();
+    });
+
+    it('round-trips the nav + pages dimensions through JSON', () => {
+      const manifest = buildListsManifest('0.1.0');
+      const roundTripped: unknown = JSON.parse(JSON.stringify(manifest));
+      const parsed = ManifestPayloadSchema.parse(roundTripped);
+      expect(parsed.nav?.id).toBe('lists');
+      expect(parsed.pages?.length).toBe(2);
+    });
+  });
+});

--- a/apps/pops-lists-api/src/manifest.ts
+++ b/apps/pops-lists-api/src/manifest.ts
@@ -1,0 +1,67 @@
+import type {
+  ManifestPayload,
+  NavConfigDescriptor,
+  PageDescriptor,
+} from '@pops/pillar-sdk/manifest-schema';
+
+export const LISTS_PILLAR_ID = 'lists' as const;
+
+/**
+ * Wire-format nav contribution for the lists pillar (PRD-243 US-02).
+ *
+ * Mirrors `@pops/app-lists`'s `navConfig` (`packages/app-lists/src/routes.tsx`)
+ * field-for-field; Lucide names are rewritten as kebab-case identifiers
+ * per the wire schema from PR #3230. `order: 500` matches today's
+ * position in `apps/pops-shell/src/app/nav/registry.ts`
+ * (`registeredApps[4]`). Detail pages (`/lists/:id`) intentionally stay
+ * off the rail — they remain deep links, declared on the `pages`
+ * dimension below.
+ */
+const LISTS_NAV: NavConfigDescriptor = {
+  id: 'lists',
+  label: 'Lists',
+  labelKey: 'lists',
+  icon: 'list-checks',
+  color: 'sky',
+  basePath: '/lists',
+  order: 500,
+  items: [{ path: '', label: 'Home', labelKey: 'lists.home', icon: 'layout-dashboard' }],
+};
+
+/**
+ * Wire-format pages contribution for the lists pillar (PRD-243 US-02).
+ *
+ * One descriptor per route declared in `@pops/app-lists`'s `routes`
+ * array — index (`ListsIndexPage`) and the `:id` detail page.
+ */
+const LISTS_PAGES: readonly PageDescriptor[] = [
+  { path: '', index: true, bundleSlot: 'lists-index' },
+  { path: ':id', bundleSlot: 'lists-detail' },
+];
+
+/**
+ * Lists pillar manifest payload.
+ *
+ * Extracted out of `server.ts` in PRD-243 US-02 so the `nav` + `pages`
+ * UI dimensions PR #3230 introduces have a dedicated home alongside
+ * `buildCerebrumManifest` / `buildMediaManifest`.
+ */
+export function buildListsManifest(version: string): ManifestPayload {
+  return {
+    pillar: LISTS_PILLAR_ID,
+    version,
+    contract: {
+      package: '@pops/lists-contract',
+      version,
+      tag: `contract-lists@v${version}`,
+    },
+    routes: { queries: [], mutations: [], subscriptions: [] },
+    search: { adapters: [] },
+    ai: { tools: [] },
+    uri: { types: [] },
+    consumedSettings: { keys: [] },
+    nav: LISTS_NAV,
+    pages: [...LISTS_PAGES],
+    healthcheck: { path: '/health' },
+  };
+}

--- a/apps/pops-lists-api/src/server.ts
+++ b/apps/pops-lists-api/src/server.ts
@@ -26,9 +26,8 @@ import { bootstrapPillar, type PillarBootstrapHandle } from '@pops/pillar-sdk/bo
 
 import { createListsApiApp } from './app.js';
 import { resolveListsSqlitePath } from './lists-sqlite-path.js';
+import { buildListsManifest } from './manifest.js';
 import { parseBareOrigin } from './pillars/env.js';
-
-import type { ManifestPayload } from '@pops/pillar-sdk/manifest-schema';
 
 function resolvePort(): number {
   // 3001 is core-api, 3002 is inventory-api, 3003 is media-api,
@@ -41,24 +40,6 @@ function resolvePort(): number {
     throw new Error(`[lists-api] PORT must be a positive integer in 1-65535; got '${raw}'`);
   }
   return parsed;
-}
-
-function buildListsManifest(version: string): ManifestPayload {
-  return {
-    pillar: 'lists',
-    version,
-    contract: {
-      package: '@pops/lists-contract',
-      version,
-      tag: `contract-lists@v${version}`,
-    },
-    routes: { queries: [], mutations: [], subscriptions: [] },
-    search: { adapters: [] },
-    ai: { tools: [] },
-    uri: { types: [] },
-    consumedSettings: { keys: [] },
-    healthcheck: { path: '/health' },
-  };
 }
 
 const port = resolvePort();

--- a/apps/pops-media-api/src/__tests__/manifest.test.ts
+++ b/apps/pops-media-api/src/__tests__/manifest.test.ts
@@ -60,4 +60,79 @@ describe('buildMediaManifest', () => {
       ]);
     }
   });
+
+  describe('PRD-243 US-02 nav + pages dimensions', () => {
+    it('declares a nav block matching the shell-side media navConfig', () => {
+      const payload = buildMediaManifest('0.1.0');
+      expect(payload.nav?.id).toBe('media');
+      expect(payload.nav?.basePath).toBe('/media');
+      expect(payload.nav?.icon).toBe('film');
+      expect(payload.nav?.color).toBe('indigo');
+      expect(payload.nav?.order).toBe(200);
+    });
+
+    it('mirrors the shell-side nav item count + paths (no drift)', () => {
+      const payload = buildMediaManifest('0.1.0');
+      expect(payload.nav?.items.map((i) => i.path)).toEqual([
+        '',
+        '/watchlist',
+        '/history',
+        '/discover',
+        '/rankings',
+        '/search',
+        '/compare',
+        '/tier-list',
+      ]);
+    });
+
+    it('rewrites every nav icon as a kebab-case wire identifier', () => {
+      const payload = buildMediaManifest('0.1.0');
+      const icons = [payload.nav?.icon, ...(payload.nav?.items.map((i) => i.icon) ?? [])].filter(
+        (v): v is string => typeof v === 'string'
+      );
+      for (const icon of icons) {
+        expect(icon).toMatch(/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/);
+      }
+    });
+
+    it('declares a pages descriptor for every media route surface', () => {
+      const payload = buildMediaManifest('0.1.0');
+      const paths = payload.pages?.map((p) => p.path) ?? [];
+      expect(paths).toContain('');
+      expect(paths).toContain('movies/:id');
+      expect(paths).toContain('tv/:id/season/:num');
+      expect(paths).toContain('debrief/:movieId/results');
+      expect(paths).toContain('plex');
+      expect(paths).toContain('rotation/candidates');
+    });
+
+    it('flags the index page (and only the index page)', () => {
+      const payload = buildMediaManifest('0.1.0');
+      const indexes = payload.pages?.filter((p) => p.index === true) ?? [];
+      expect(indexes).toHaveLength(1);
+      expect(indexes[0]?.bundleSlot).toBe('media-library');
+    });
+
+    it('gives every page a unique kebab-case bundleSlot', () => {
+      const payload = buildMediaManifest('0.1.0');
+      const slots = payload.pages?.map((p) => p.bundleSlot) ?? [];
+      expect(new Set(slots).size).toBe(slots.length);
+      for (const slot of slots) {
+        expect(slot).toMatch(/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/);
+      }
+    });
+
+    it('does NOT declare assetsBaseUrl (deferred to US-05)', () => {
+      const payload = buildMediaManifest('0.1.0');
+      expect(payload.assetsBaseUrl).toBeUndefined();
+    });
+
+    it('round-trips the nav + pages dimensions through JSON', () => {
+      const payload = buildMediaManifest('0.1.0');
+      const roundTripped: unknown = JSON.parse(JSON.stringify(payload));
+      const parsed = ManifestPayloadSchema.parse(roundTripped);
+      expect(parsed.nav?.id).toBe('media');
+      expect(parsed.pages?.length).toBeGreaterThan(0);
+    });
+  });
 });

--- a/apps/pops-media-api/src/manifest.ts
+++ b/apps/pops-media-api/src/manifest.ts
@@ -1,3 +1,81 @@
+import {
+  arrManifest,
+  mediaOperationalManifest,
+  plexManifest,
+  rotationManifest,
+} from '@pops/media-contract/settings';
+
+import type {
+  ManifestPayload,
+  NavConfigDescriptor,
+  PageDescriptor,
+} from '@pops/pillar-sdk/manifest-schema';
+
+export const MEDIA_PILLAR_ID = 'media' as const;
+
+/**
+ * Wire-format nav contribution for the media pillar (PRD-243 US-02).
+ *
+ * Mirrors `@pops/app-media`'s `navConfig` field-for-field; Lucide names
+ * are rewritten as kebab-case identifiers per the wire schema from
+ * PR #3230. `order: 200` matches today's position in
+ * `apps/pops-shell/src/app/nav/registry.ts` (`registeredApps[1]`).
+ */
+const MEDIA_NAV: NavConfigDescriptor = {
+  id: 'media',
+  label: 'Media',
+  labelKey: 'media',
+  icon: 'film',
+  color: 'indigo',
+  basePath: '/media',
+  order: 200,
+  items: [
+    { path: '', label: 'Library', labelKey: 'media.library', icon: 'library' },
+    { path: '/watchlist', label: 'Watchlist', labelKey: 'media.watchlist', icon: 'bookmark' },
+    { path: '/history', label: 'History', labelKey: 'media.history', icon: 'clock' },
+    { path: '/discover', label: 'Discover', labelKey: 'media.discover', icon: 'compass' },
+    { path: '/rankings', label: 'Rankings', labelKey: 'media.rankings', icon: 'trophy' },
+    { path: '/search', label: 'Search', labelKey: 'media.search', icon: 'search' },
+    { path: '/compare', label: 'Compare', labelKey: 'media.compare', icon: 'arrow-left-right' },
+    { path: '/tier-list', label: 'Tier List', labelKey: 'media.tierList', icon: 'layers' },
+  ],
+};
+
+/**
+ * Wire-format pages contribution for the media pillar (PRD-243 US-02).
+ *
+ * One descriptor per route declared in `@pops/app-media`'s `routes`
+ * array. Settings-redirect routes (`/media/plex`, `/media/arr`,
+ * `/media/rotation`, `/media/calendar`) ARE included so the shell-side
+ * bundle map (PRD-243 US-03) can mount the same `<Navigate>` element
+ * that lives there today; the slot identifiers carry a `-redirect`
+ * suffix to keep them distinct from real pages.
+ */
+const MEDIA_PAGES: readonly PageDescriptor[] = [
+  { path: '', index: true, bundleSlot: 'media-library' },
+  { path: 'movies/:id', bundleSlot: 'media-movie-detail' },
+  { path: 'tv/:id', bundleSlot: 'media-tv-show-detail' },
+  { path: 'tv/:id/season/:num', bundleSlot: 'media-season-detail' },
+  { path: 'watchlist', bundleSlot: 'media-watchlist' },
+  { path: 'history', bundleSlot: 'media-history' },
+  { path: 'discover', bundleSlot: 'media-discover' },
+  { path: 'rankings', bundleSlot: 'media-rankings' },
+  { path: 'search', bundleSlot: 'media-search' },
+  { path: 'compare', bundleSlot: 'media-compare-arena' },
+  { path: 'compare/history', bundleSlot: 'media-comparison-history' },
+  { path: 'quick-pick', bundleSlot: 'media-quick-pick' },
+  { path: 'plex', bundleSlot: 'media-plex-redirect' },
+  { path: 'arr', bundleSlot: 'media-arr-redirect' },
+  { path: 'rotation', bundleSlot: 'media-rotation-redirect' },
+  { path: 'rotation/log', bundleSlot: 'media-rotation-log' },
+  { path: 'rotation/candidates', bundleSlot: 'media-candidate-queue' },
+  { path: 'arr/calendar', bundleSlot: 'media-calendar' },
+  { path: 'calendar', bundleSlot: 'media-calendar-redirect' },
+  { path: 'tier-list', bundleSlot: 'media-tier-list' },
+  { path: 'debrief/:movieId', bundleSlot: 'media-debrief' },
+  { path: 'debrief/:movieId/results', bundleSlot: 'media-debrief-results' },
+];
+
 /**
  * Media pillar manifest payload.
  *
@@ -12,18 +90,12 @@
  * `@pops/media-contract/settings` subpath rather than the legacy
  * `@pops/module-registry/settings` or static `@pops/pillar-sdk/settings`
  * barrels.
+ *
+ * PRD-243 US-02 adds the `nav` + `pages` UI dimensions — verbatim copies
+ * of the shell-side registry entries today, ready for the US-03 rewrite
+ * to walk these off the manifest instead of importing `@pops/app-*`
+ * directly.
  */
-import {
-  arrManifest,
-  mediaOperationalManifest,
-  plexManifest,
-  rotationManifest,
-} from '@pops/media-contract/settings';
-
-import type { ManifestPayload } from '@pops/pillar-sdk/manifest-schema';
-
-export const MEDIA_PILLAR_ID = 'media' as const;
-
 export function buildMediaManifest(version: string): ManifestPayload {
   return {
     pillar: MEDIA_PILLAR_ID,
@@ -48,6 +120,8 @@ export function buildMediaManifest(version: string): ManifestPayload {
     settings: {
       manifests: [arrManifest, plexManifest, rotationManifest, mediaOperationalManifest],
     },
+    nav: MEDIA_NAV,
+    pages: [...MEDIA_PAGES],
     healthcheck: { path: '/health' },
   };
 }


### PR DESCRIPTION
## Summary

Adds the `nav` + `pages` UI dimensions PR #3230 (PRD-243 US-01) introduced to the four in-repo pillar manifests in batch B. Batch A (core / inventory / finance / ai) ships separately.

## Per-pillar changes

| Pillar     | nav order | nav items | pages | Notes |
|------------|-----------|-----------|-------|-------|
| cerebrum   | 600       | 9         | 13    | Extends existing `apps/pops-cerebrum-api/src/manifest.ts`. `/cerebrum/chat` lands as `cerebrum-chat` (the route is owned by `@pops/app-cerebrum`, even though the chat panel ships from `@pops/overlay-ego`). |
| media      | 200       | 8         | 22    | Extends existing `apps/pops-media-api/src/manifest.ts`. Settings-redirect routes (`/media/plex`, `/media/arr`, `/media/rotation`, `/media/calendar`) ship as `-redirect` slots so the bundle map (US-03) can mount today's `<Navigate>` elements. |
| food       | 400       | 9         | 23    | **Extracted** `buildFoodManifest` from `server.ts` → new `src/manifest.ts`. Flattened the nested `/food/data/*` subtree: each child gets a `data/<tab>` descriptor; the parent layout becomes `food-data-layout`. **Drive-by**: fixed the contract package pin from `@pops/food-contracts` (plural, schema-invalid) to `@pops/food-contract` — never validated before because `buildFoodManifest` had no tests. |
| lists      | 500       | 1         | 2     | **Extracted** `buildListsManifest` from `server.ts` → new `src/manifest.ts`. `:id` is the only deep-link page. |

The `order` integers (200 / 400 / 500 / 600) match the visual order the shell's `registeredApps` array carries today (`apps/pops-shell/src/app/nav/registry.ts`), leaving 100 / 300 / 700 spacing for batch A's finance / inventory / ai.

Icons travel the wire as kebab-case (`book-open`, `list-checks`, `arrow-left-right`, etc.) per the `NavConfigDescriptor` shape from #3230; Lucide PascalCase resolution stays shell-side (deferred to US-03). `bundleSlot` values are kebab-case `<pillar>-<component>` identifiers the shell's workspace bundle map (US-03) will resolve back to the React components currently held in `installed-modules.ts`.

## Ego overlay — deferred

Per the brief, cerebrum is dual-domain with ego (PR #3229). On the shell-side `registeredApps` array there is **only one** nav entry for the cerebrum domain — ego does not contribute an app-rail item, only an overlay surface (the floating chat panel mounted via `@pops/overlay-ego`'s manifest, chrome slot `assistant`, shortcut `mod+i`). The current `NavConfigDescriptor` schema (PR #3230) has no overlay/shortcut shape, so:

- The `cerebrum-chat` ROUTE (`/cerebrum/chat`) lands as a page on the cerebrum manifest — it lives in `@pops/app-cerebrum`'s `routes` array today, so this is verbatim transfer.
- Ego's OVERLAY surface (chromeSlot + shortcut) is **not** declared on the wire here. Tracking as a follow-up — once the schema grows an overlay descriptor (US-05? or a separate US under PRD-243), overlay-ego's manifest can ship it.

## Out of scope

- Batch A pillars (core / inventory / finance / ai) — shipping separately.
- Shell rewrite that consumes these declarations (US-03).
- External-pillar UI loading (`assetsBaseUrl`, US-05).
- Ego overlay wire descriptor (no schema support today).

## Test plan

- [x] `pnpm install --frozen-lockfile && pnpm --filter @pops/pillar-sdk build`
- [x] `pnpm --filter @pops/cerebrum-api test` — 38 passed (was 30; +8 PRD-243 US-02 cases)
- [x] `pnpm --filter @pops/media-api test` — 30 passed (was 22; +8 PRD-243 US-02 cases)
- [x] `pnpm --filter @pops/food-api test` — 23 passed (new manifest suite contributes 12)
- [x] `pnpm --filter @pops/lists-api test` — 23 passed (new manifest suite contributes 12)
- [x] `pnpm typecheck` — 71 tasks green across the workspace
- [x] Husky pre-commit (oxlint + oxfmt) clean
- [x] Husky pre-push (typecheck + rebase) clean