### PR TITLE
feat: PRD-243 US-02 nav+pages declarations for core / inventory / finance (batch A)

### DIFF
--- a/apps/pops-core-api/src/__tests__/core-manifest.test.ts
+++ b/apps/pops-core-api/src/__tests__/core-manifest.test.ts
@@ -29,4 +29,21 @@ describe('buildCoreManifest — PRD-240 US-03 settings dimension', () => {
     expect(ids).toContain('ai.config');
     expect(ids).toContain('core.operational');
   });
+
+  describe('PRD-243 US-02 — backend-only pillar omits UI dimensions', () => {
+    it('does not declare a nav block', () => {
+      const manifest = buildCoreManifest('0.0.1-test');
+      expect(manifest.nav).toBeUndefined();
+    });
+
+    it('does not declare a pages block', () => {
+      const manifest = buildCoreManifest('0.0.1-test');
+      expect(manifest.pages).toBeUndefined();
+    });
+
+    it('does not declare an assetsBaseUrl', () => {
+      const manifest = buildCoreManifest('0.0.1-test');
+      expect(manifest.assetsBaseUrl).toBeUndefined();
+    });
+  });
 });

--- a/apps/pops-core-api/src/core-manifest.ts
+++ b/apps/pops-core-api/src/core-manifest.ts
@@ -5,6 +5,11 @@
  * import the builder without triggering the boot side-effects that
  * `server.ts` runs at module top-level (`openCoreDb`, `app.listen`,
  * signal handlers).
+ *
+ * PRD-243 US-02: core is backend-only and intentionally omits the
+ * optional `nav` and `pages` UI dimensions. The shell-side aggregator
+ * skips backend-only pillars when walking the registry for app-rail
+ * entries and routes.
  */
 import { aiConfigManifest, coreOperationalManifest } from '@pops/core-contract/settings';
 

--- a/apps/pops-finance-api/src/__tests__/manifest.test.ts
+++ b/apps/pops-finance-api/src/__tests__/manifest.test.ts
@@ -40,4 +40,54 @@ describe('buildFinanceManifest', () => {
     const manifest = buildFinanceManifest('not-a-semver');
     expect(() => ManifestPayloadSchema.parse(manifest)).toThrow();
   });
+
+  describe('PRD-243 US-02 — nav + pages UI dimensions', () => {
+    it('declares the finance nav descriptor with id, basePath, order, and items', () => {
+      const manifest = buildFinanceManifest('0.1.0');
+      expect(manifest.nav).toMatchObject({
+        id: 'finance',
+        label: 'Finance',
+        labelKey: 'finance',
+        icon: 'dollar-sign',
+        color: 'emerald',
+        basePath: '/finance',
+        order: 10,
+      });
+      expect(manifest.nav?.items.map((item) => item.path)).toEqual([
+        '',
+        '/transactions',
+        '/entities',
+        '/budgets',
+        '/wishlist',
+        '/import',
+        '/rules',
+        '/prompts',
+      ]);
+    });
+
+    it('declares pages covering every finance route surface', () => {
+      const manifest = buildFinanceManifest('0.1.0');
+      expect(manifest.pages).toEqual([
+        { path: '', index: true, bundleSlot: 'finance-dashboard' },
+        { path: 'transactions', bundleSlot: 'finance-transactions' },
+        { path: 'entities', bundleSlot: 'finance-entities' },
+        { path: 'budgets', bundleSlot: 'finance-budgets' },
+        { path: 'wishlist', bundleSlot: 'finance-wishlist' },
+        { path: 'import', bundleSlot: 'finance-import' },
+        { path: 'rules', bundleSlot: 'finance-rules' },
+        { path: 'prompts', bundleSlot: 'finance-prompts' },
+      ]);
+    });
+
+    it('omits assetsBaseUrl for the in-repo case', () => {
+      const manifest = buildFinanceManifest('0.1.0');
+      expect(manifest.assetsBaseUrl).toBeUndefined();
+    });
+
+    it('passes wire-shaped validation with the new UI dimensions populated', () => {
+      const manifest = buildFinanceManifest('0.1.0');
+      const result = validateManifestPayload(manifest);
+      expect(result.ok).toBe(true);
+    });
+  });
 });

--- a/apps/pops-finance-api/src/manifest.ts
+++ b/apps/pops-finance-api/src/manifest.ts
@@ -1,19 +1,65 @@
 /**
- * Finance pillar manifest payload (PRD-240 US-03).
+ * Finance pillar manifest payload (PRD-240 US-03, PRD-243 US-02).
  *
  * Declares the wire-format manifest that the finance pillar registers
- * with the central registry on boot. PRD-240 US-03 adds the
- * `settings.manifests` dimension — peer of `search.adapters`, `ai.tools`,
- * and `sinks` — so the settings UI contribution flows through the same
- * manifest payload as every other pillar dimension. The source for the
- * finance settings manifest lives in the contract package and is imported
- * from its `./settings` subpath (PRD-239 US-03 relocation).
+ * with the central registry on boot. PRD-240 US-03 added the
+ * `settings.manifests` dimension; PRD-243 US-02 adds the `nav` +
+ * `pages` UI dimensions so the shell can derive the finance app-rail
+ * entry and route surface from the registry walk instead of a static
+ * `@pops/app-finance` import. The source values match
+ * `packages/app-finance/src/routes.tsx` verbatim (icons translated to
+ * the kebab-case wire form required by `NavConfigDescriptorSchema`).
  */
 import { financeManifest } from '@pops/finance-contract/settings';
 
-import type { ManifestPayload } from '@pops/pillar-sdk/manifest-schema';
+import type {
+  ManifestPayload,
+  NavConfigDescriptor,
+  PageDescriptor,
+} from '@pops/pillar-sdk/manifest-schema';
 
 export const FINANCE_PILLAR_ID = 'finance' as const;
+
+const FINANCE_NAV: NavConfigDescriptor = {
+  id: 'finance',
+  label: 'Finance',
+  labelKey: 'finance',
+  icon: 'dollar-sign',
+  color: 'emerald',
+  basePath: '/finance',
+  order: 10,
+  items: [
+    { path: '', label: 'Dashboard', labelKey: 'finance.dashboard', icon: 'layout-dashboard' },
+    {
+      path: '/transactions',
+      label: 'Transactions',
+      labelKey: 'finance.transactions',
+      icon: 'credit-card',
+    },
+    { path: '/entities', label: 'Entities', labelKey: 'finance.entities', icon: 'building-2' },
+    { path: '/budgets', label: 'Budgets', labelKey: 'finance.budgets', icon: 'piggy-bank' },
+    { path: '/wishlist', label: 'Wish List', labelKey: 'finance.wishList', icon: 'star' },
+    { path: '/import', label: 'Import', labelKey: 'finance.import', icon: 'download' },
+    { path: '/rules', label: 'Rules', labelKey: 'finance.rules', icon: 'book-open' },
+    {
+      path: '/prompts',
+      label: 'Prompt Templates',
+      labelKey: 'finance.promptTemplates',
+      icon: 'file-text',
+    },
+  ],
+};
+
+const FINANCE_PAGES: PageDescriptor[] = [
+  { path: '', index: true, bundleSlot: 'finance-dashboard' },
+  { path: 'transactions', bundleSlot: 'finance-transactions' },
+  { path: 'entities', bundleSlot: 'finance-entities' },
+  { path: 'budgets', bundleSlot: 'finance-budgets' },
+  { path: 'wishlist', bundleSlot: 'finance-wishlist' },
+  { path: 'import', bundleSlot: 'finance-import' },
+  { path: 'rules', bundleSlot: 'finance-rules' },
+  { path: 'prompts', bundleSlot: 'finance-prompts' },
+];
 
 export function buildFinanceManifest(version: string): ManifestPayload {
   return {
@@ -52,6 +98,8 @@ export function buildFinanceManifest(version: string): ManifestPayload {
     uri: { types: ['finance/transaction', 'finance/wishlist-item', 'finance/budget'] },
     consumedSettings: { keys: [] },
     settings: { manifests: [financeManifest] },
+    nav: FINANCE_NAV,
+    pages: FINANCE_PAGES,
     healthcheck: { path: '/health' },
   };
 }

--- a/apps/pops-inventory-api/src/__tests__/manifest.test.ts
+++ b/apps/pops-inventory-api/src/__tests__/manifest.test.ts
@@ -1,12 +1,13 @@
 /**
  * Manifest contract test — confirms the inventory pillar manifest
  * payload validates against `ManifestPayloadSchema` and surfaces the
- * `inventoryManifest` settings contribution introduced by PRD-240 US-03.
+ * `inventoryManifest` settings contribution introduced by PRD-240 US-03
+ * plus the `nav` and `pages` UI dimensions introduced by PRD-243 US-02.
  */
 import { describe, expect, it } from 'vitest';
 
 import { inventoryManifest } from '@pops/inventory-contract/settings';
-import { ManifestPayloadSchema } from '@pops/pillar-sdk/manifest-schema';
+import { ManifestPayloadSchema, validateManifestPayload } from '@pops/pillar-sdk/manifest-schema';
 
 import { buildInventoryManifest } from '../manifest.js';
 
@@ -28,6 +29,54 @@ describe('buildInventoryManifest', () => {
       package: '@pops/inventory-contract',
       version: '4.5.6',
       tag: 'contract-inventory@v4.5.6',
+    });
+  });
+
+  describe('PRD-243 US-02 — nav + pages UI dimensions', () => {
+    it('declares the inventory nav descriptor with id, basePath, order, and items', () => {
+      const payload = buildInventoryManifest('1.2.3');
+      expect(payload.nav).toMatchObject({
+        id: 'inventory',
+        label: 'Inventory',
+        labelKey: 'inventory',
+        icon: 'package',
+        color: 'amber',
+        basePath: '/inventory',
+        order: 30,
+      });
+      expect(payload.nav?.items.map((item) => item.path)).toEqual([
+        '',
+        '/warranties',
+        '/locations',
+        '/reports',
+        '/connections',
+      ]);
+    });
+
+    it('declares pages covering every inventory route surface', () => {
+      const payload = buildInventoryManifest('1.2.3');
+      expect(payload.pages).toEqual([
+        { path: '', index: true, bundleSlot: 'inventory-items' },
+        { path: 'items/new', bundleSlot: 'inventory-item-form' },
+        { path: 'items/:id', bundleSlot: 'inventory-item-detail' },
+        { path: 'items/:id/edit', bundleSlot: 'inventory-item-form' },
+        { path: 'connections', bundleSlot: 'inventory-connections' },
+        { path: 'warranties', bundleSlot: 'inventory-warranties' },
+        { path: 'locations', bundleSlot: 'inventory-location-tree' },
+        { path: 'reports', bundleSlot: 'inventory-report-dashboard' },
+        { path: 'reports/insurance', bundleSlot: 'inventory-insurance-report' },
+      ]);
+    });
+
+    it('omits assetsBaseUrl for the in-repo case', () => {
+      const payload = buildInventoryManifest('1.2.3');
+      expect(payload.assetsBaseUrl).toBeUndefined();
+    });
+
+    it('passes wire-shaped validation with the new UI dimensions populated', () => {
+      const payload = buildInventoryManifest('1.2.3');
+      const result = validateManifestPayload(payload);
+      expect(result.ok).toBe(true);
     });
   });
 });

--- a/apps/pops-inventory-api/src/manifest.ts
+++ b/apps/pops-inventory-api/src/manifest.ts
@@ -2,12 +2,59 @@
  * Inventory pillar manifest payload builder.
  *
  * Hand-rolled until PRD-155 generates this from the contract. Declares
- * the inventory settings UI contribution under `settings.manifests` per
- * PRD-240 US-03.
+ * the inventory settings UI contribution under `settings.manifests`
+ * (PRD-240 US-03) and, per PRD-243 US-02, the `nav` + `pages` UI
+ * dimensions so the shell can mount the inventory app-rail entry and
+ * routes from the registry walk. The `nav` and `pages` values mirror
+ * `packages/app-inventory/src/routes.tsx` verbatim (icons translated to
+ * the kebab-case wire form required by `NavConfigDescriptorSchema`).
  */
 import { inventoryManifest } from '@pops/inventory-contract/settings';
 
-import type { ManifestPayload } from '@pops/pillar-sdk/manifest-schema';
+import type {
+  ManifestPayload,
+  NavConfigDescriptor,
+  PageDescriptor,
+} from '@pops/pillar-sdk/manifest-schema';
+
+const INVENTORY_NAV: NavConfigDescriptor = {
+  id: 'inventory',
+  label: 'Inventory',
+  labelKey: 'inventory',
+  icon: 'package',
+  color: 'amber',
+  basePath: '/inventory',
+  order: 30,
+  items: [
+    { path: '', label: 'Items', labelKey: 'inventory.items', icon: 'package' },
+    {
+      path: '/warranties',
+      label: 'Warranties',
+      labelKey: 'inventory.warranties',
+      icon: 'shield-check',
+    },
+    { path: '/locations', label: 'Locations', labelKey: 'inventory.locations', icon: 'map-pin' },
+    { path: '/reports', label: 'Reports', labelKey: 'inventory.reports', icon: 'bar-chart-3' },
+    {
+      path: '/connections',
+      label: 'Connections',
+      labelKey: 'inventory.connections',
+      icon: 'network',
+    },
+  ],
+};
+
+const INVENTORY_PAGES: PageDescriptor[] = [
+  { path: '', index: true, bundleSlot: 'inventory-items' },
+  { path: 'items/new', bundleSlot: 'inventory-item-form' },
+  { path: 'items/:id', bundleSlot: 'inventory-item-detail' },
+  { path: 'items/:id/edit', bundleSlot: 'inventory-item-form' },
+  { path: 'connections', bundleSlot: 'inventory-connections' },
+  { path: 'warranties', bundleSlot: 'inventory-warranties' },
+  { path: 'locations', bundleSlot: 'inventory-location-tree' },
+  { path: 'reports', bundleSlot: 'inventory-report-dashboard' },
+  { path: 'reports/insurance', bundleSlot: 'inventory-insurance-report' },
+];
 
 export function buildInventoryManifest(version: string): ManifestPayload {
   return {
@@ -39,6 +86,8 @@ export function buildInventoryManifest(version: string): ManifestPayload {
     uri: { types: [] },
     consumedSettings: { keys: [] },
     settings: { manifests: [inventoryManifest] },
+    nav: INVENTORY_NAV,
+    pages: INVENTORY_PAGES,
     healthcheck: { path: '/health' },
   };
 }


### PR DESCRIPTION
## Summary

PRD-243 US-02 batch A. Declares the optional `nav` and `pages` UI dimensions (added in PR #3230 / US-01) on the manifest payloads of the in-repo finance and inventory pillars. Core stays backend-only and intentionally omits both UI dimensions; the test fixes that omission contract.

The values are sourced verbatim from the corresponding shell-side `@pops/app-<id>` registry exports — same id, label, labelKey, color, basePath, and items — with two wire-format adjustments dictated by the schema in PR #3230:

- Icons translated from PascalCase (`DollarSign`) to kebab-case (`dollar-sign`) because `NavConfigDescriptorSchema` enforces `KEBAB_IDENTIFIER`.
- `nav.order` set explicitly from the US-02 sparse scheme (`finance=10`, `media=20`, `inventory=30`, …) so future pillars can slot in without renumbering.

`assetsBaseUrl` is left unset on every pillar in this batch — these are in-repo pillars whose bundles the shell already ships; the field is reserved for the external-pillar case (PRD-243 US-05, deferred).

### Per-pillar sourcing

| Pillar    | `nav.id`    | items / pages | Sourced from                                          |
| --------- | ----------- | ------------- | ----------------------------------------------------- |
| finance   | `finance`   | 8 / 8         | `packages/app-finance/src/routes.tsx` (navConfig + routes) |
| inventory | `inventory` | 5 / 9         | `packages/app-inventory/src/routes.tsx` (navConfig + routes) |
| core      | n/a         | 0 / 0         | Backend-only — intentionally omits `nav`, `pages`, `assetsBaseUrl` |

### Out of scope

- Other pillars (cerebrum, media, food, lists) — batch B picks those up.
- Shell-side rewrite (US-03) — `installed-modules.ts` and `nav/registry.ts` are untouched.
- External-pillar UI loading (US-05) — deferred, `assetsBaseUrl` reserved only.

## Test plan

- [x] `pnpm --filter @pops/core-api test` — 118 tests pass, new tests cover the no-nav / no-pages / no-assetsBaseUrl omission contract.
- [x] `pnpm --filter @pops/inventory-api test` — 52 tests pass, new tests cover the inventory nav descriptor, the pages list (with `items/:id` + `reports/insurance`), and the wire-shaped `validateManifestPayload` round-trip.
- [x] `pnpm --filter @pops/finance-api test` — 32 tests pass, new tests cover the finance nav descriptor, the pages list, and the wire-shaped `validateManifestPayload` round-trip.
- [x] `pnpm typecheck` — clean across all 71 workspace projects.
- [x] Husky pre-commit (oxlint + oxfmt on staged files) and pre-push (root typecheck + merge-tree against origin/main) both pass without `--no-verify`.