### PR TITLE
fix(pillar-apis): PRD-243 US-02 reconcile nav order values (10/20/30/40/50/60 sparse scheme)

### DIFF
--- a/apps/pops-cerebrum-api/src/__tests__/manifest.test.ts
+++ b/apps/pops-cerebrum-api/src/__tests__/manifest.test.ts
@@ -58,7 +58,7 @@ describe('buildCerebrumManifest', () => {
       expect(manifest.nav?.basePath).toBe('/cerebrum');
       expect(manifest.nav?.icon).toBe('book-open');
       expect(manifest.nav?.color).toBe('sky');
-      expect(manifest.nav?.order).toBe(600);
+      expect(manifest.nav?.order).toBe(60);
     });
 
     it('mirrors the shell-side nav item count + paths (no drift)', () => {

--- a/apps/pops-cerebrum-api/src/manifest.ts
+++ b/apps/pops-cerebrum-api/src/manifest.ts
@@ -14,7 +14,7 @@ export const CEREBRUM_PILLAR_ID = 'cerebrum' as const;
  * Mirrors the shell-side `navConfig` exported from `@pops/app-cerebrum`
  * (`packages/app-cerebrum/src/routes.tsx`) — same items, same order — with
  * the runtime Lucide icon names rewritten as kebab-case identifiers per
- * the `NavConfigDescriptor` wire shape from PR #3230. `order: 600` places
+ * the `NavConfigDescriptor` wire shape from PR #3230. `order: 60` places
  * cerebrum sixth in the shell's `registeredApps` array
  * (`apps/pops-shell/src/app/nav/registry.ts`), matching today's layout.
  */
@@ -25,7 +25,7 @@ const CEREBRUM_NAV: NavConfigDescriptor = {
   icon: 'book-open',
   color: 'sky',
   basePath: '/cerebrum',
-  order: 600,
+  order: 60,
   items: [
     { path: '', label: 'Ingest', labelKey: 'cerebrum.ingest', icon: 'file-text' },
     { path: '/engrams', label: 'Engrams', labelKey: 'cerebrum.engrams.nav', icon: 'library' },

--- a/apps/pops-food-api/src/__tests__/manifest.test.ts
+++ b/apps/pops-food-api/src/__tests__/manifest.test.ts
@@ -43,7 +43,7 @@ describe('buildFoodManifest', () => {
       expect(manifest.nav?.basePath).toBe('/food');
       expect(manifest.nav?.icon).toBe('utensils');
       expect(manifest.nav?.color).toBe('amber');
-      expect(manifest.nav?.order).toBe(400);
+      expect(manifest.nav?.order).toBe(40);
     });
 
     it('mirrors the shell-side nav item count + paths (no drift)', () => {

--- a/apps/pops-food-api/src/manifest.ts
+++ b/apps/pops-food-api/src/manifest.ts
@@ -11,7 +11,7 @@ export const FOOD_PILLAR_ID = 'food' as const;
  *
  * Mirrors `@pops/app-food`'s `navConfig` (`packages/app-food/src/routes.tsx`)
  * field-for-field; Lucide names are rewritten as kebab-case identifiers
- * per the wire schema from PR #3230. `order: 400` matches today's
+ * per the wire schema from PR #3230. `order: 40` matches today's
  * position in `apps/pops-shell/src/app/nav/registry.ts`
  * (`registeredApps[3]`).
  */
@@ -22,7 +22,7 @@ const FOOD_NAV: NavConfigDescriptor = {
   icon: 'utensils',
   color: 'amber',
   basePath: '/food',
-  order: 400,
+  order: 40,
   items: [
     { path: '', label: 'Home', labelKey: 'food.home', icon: 'layout-dashboard' },
     { path: '/recipes', label: 'Recipes', labelKey: 'food.recipes', icon: 'book-open' },

--- a/apps/pops-lists-api/src/__tests__/manifest.test.ts
+++ b/apps/pops-lists-api/src/__tests__/manifest.test.ts
@@ -43,7 +43,7 @@ describe('buildListsManifest', () => {
       expect(manifest.nav?.basePath).toBe('/lists');
       expect(manifest.nav?.icon).toBe('list-checks');
       expect(manifest.nav?.color).toBe('sky');
-      expect(manifest.nav?.order).toBe(500);
+      expect(manifest.nav?.order).toBe(50);
     });
 
     it('mirrors the shell-side nav item count + paths (home only, no deep links)', () => {

--- a/apps/pops-lists-api/src/manifest.ts
+++ b/apps/pops-lists-api/src/manifest.ts
@@ -11,7 +11,7 @@ export const LISTS_PILLAR_ID = 'lists' as const;
  *
  * Mirrors `@pops/app-lists`'s `navConfig` (`packages/app-lists/src/routes.tsx`)
  * field-for-field; Lucide names are rewritten as kebab-case identifiers
- * per the wire schema from PR #3230. `order: 500` matches today's
+ * per the wire schema from PR #3230. `order: 50` matches today's
  * position in `apps/pops-shell/src/app/nav/registry.ts`
  * (`registeredApps[4]`). Detail pages (`/lists/:id`) intentionally stay
  * off the rail — they remain deep links, declared on the `pages`
@@ -24,7 +24,7 @@ const LISTS_NAV: NavConfigDescriptor = {
   icon: 'list-checks',
   color: 'sky',
   basePath: '/lists',
-  order: 500,
+  order: 50,
   items: [{ path: '', label: 'Home', labelKey: 'lists.home', icon: 'layout-dashboard' }],
 };
 

--- a/apps/pops-media-api/src/__tests__/manifest.test.ts
+++ b/apps/pops-media-api/src/__tests__/manifest.test.ts
@@ -68,7 +68,7 @@ describe('buildMediaManifest', () => {
       expect(payload.nav?.basePath).toBe('/media');
       expect(payload.nav?.icon).toBe('film');
       expect(payload.nav?.color).toBe('indigo');
-      expect(payload.nav?.order).toBe(200);
+      expect(payload.nav?.order).toBe(20);
     });
 
     it('mirrors the shell-side nav item count + paths (no drift)', () => {

--- a/apps/pops-media-api/src/manifest.ts
+++ b/apps/pops-media-api/src/manifest.ts
@@ -18,7 +18,7 @@ export const MEDIA_PILLAR_ID = 'media' as const;
  *
  * Mirrors `@pops/app-media`'s `navConfig` field-for-field; Lucide names
  * are rewritten as kebab-case identifiers per the wire schema from
- * PR #3230. `order: 200` matches today's position in
+ * PR #3230. `order: 20` matches today's position in
  * `apps/pops-shell/src/app/nav/registry.ts` (`registeredApps[1]`).
  */
 const MEDIA_NAV: NavConfigDescriptor = {
@@ -28,7 +28,7 @@ const MEDIA_NAV: NavConfigDescriptor = {
   icon: 'film',
   color: 'indigo',
   basePath: '/media',
-  order: 200,
+  order: 20,
   items: [
     { path: '', label: 'Library', labelKey: 'media.library', icon: 'library' },
     { path: '/watchlist', label: 'Watchlist', labelKey: 'media.watchlist', icon: 'bookmark' },


### PR DESCRIPTION
## Summary

PRD-243 US-02 follow-up. Reconciles the `order` values declared by the seven in-repo pillar manifest builders so the shell's app rail renders in a stable, predictable order.

- Batch A (#3236) shipped `finance=10`, `inventory=30` on a sparse `10 / 20 / 30 ... / 70` scheme (per the US-02 acceptance scheme cited in that PR).
- Batch B (#3235) shipped `media=200`, `food=400`, `lists=500`, `cerebrum=600` on a `100`-step scheme.

Both passed the wire schema (`z.number().int()`), but the two scales mixed across pillars produces an inconsistent visual ordering for any new pillar slotted in between. Adopting batch A's scheme as canonical:

| pillar    | before | after |
|-----------|-------:|------:|
| finance   |   10   |  10   |
| media     |  200   |  20   |
| inventory |   30   |  30   |
| food      |  400   |  40   |
| lists     |  500   |  50   |
| cerebrum  |  600   |  60   |

`core` stays shell-owned (no manifest contribution); `ai` (`order: 70`) is reserved.

Updates the four batch-B manifest builders and the matching `manifest.test.ts` expectations.

## Test plan

- [x] `pnpm --filter @pops/cerebrum-api --filter @pops/media-api --filter @pops/food-api --filter @pops/lists-api test` — 4/4 packages pass (114 tests).
- [x] `pnpm typecheck` — 73/73 tasks pass.
- [x] Pre-commit hook (`lint-staged` → `oxlint` + `oxfmt`) clean.
