### PR TITLE
feat(api): PRD-242 US-02 runtime mergeRouters composition + registry-event recomposition

### DIFF
--- a/apps/pops-api/src/app.ts
+++ b/apps/pops-api/src/app.ts
@@ -1,5 +1,5 @@
 import { createExpressMiddleware } from '@trpc/server/adapters/express';
-import express from 'express';
+import express, { type RequestHandler } from 'express';
 import helmet from 'helmet';
 import swaggerUi from 'swagger-ui-express';
 import { createOpenApiExpressMiddleware } from 'trpc-to-openapi';
@@ -22,7 +22,10 @@ import inventoryPhotosRouter from './routes/inventory/photos.js';
 import mediaImagesRouter from './routes/media/images.js';
 import pillarsRouter from './routes/pillars.js';
 import upBankRouter from './routes/webhooks/up-bank.js';
+import { getRuntimeAppRouter } from './runtime/index.js';
 import { createContext } from './trpc.js';
+
+import type { AnyRouter } from '@trpc/server';
 
 /**
  * Create and configure the Express application.
@@ -116,7 +119,10 @@ export function createApp(): express.Express {
   // Swagger UI — serves the interactive API docs
   app.use('/api/docs', ...swaggerUi.serve, swaggerUi.setup(openApiDocument, { explorer: true }));
 
-  // OpenAPI REST handler — mounted after auth; tRPC remains primary for the React frontend
+  // OpenAPI REST handler — mounted after auth; tRPC remains primary for the
+  // React frontend. The OpenAPI surface is statically typed at boot from the
+  // in-repo router; external (PRD-228) pillars are not OpenAPI-documented, so
+  // this consumer continues to read from the static export.
   app.use(
     '/api/v1',
     createOpenApiExpressMiddleware({
@@ -125,14 +131,31 @@ export function createApp(): express.Express {
     })
   );
 
-  // tRPC handler (auth via context/procedures)
-  app.use(
-    '/trpc',
-    createExpressMiddleware({
-      router: appRouter,
-      createContext,
-    })
-  );
+  // tRPC handler — reads the runtime router holder per request so external
+  // pillars registered after boot (PRD-228) become reachable without a
+  // restart. The static `appRouter` import above stays the type source for
+  // in-repo clients; the runtime accessor wraps it with the merged externals.
+  app.use('/trpc', createDynamicTrpcMiddleware());
 
   return app;
+}
+
+/**
+ * Build a tRPC express middleware that resolves the live router per request
+ * via `getRuntimeAppRouter()`. The underlying `createExpressMiddleware`
+ * closes over its `router` argument, so we re-create the inner handler when
+ * the runtime router reference changes (recompose). Strict identity check
+ * keeps the per-request overhead at one pointer compare in the steady state.
+ */
+function createDynamicTrpcMiddleware(): RequestHandler {
+  let lastRouter: AnyRouter | null = null;
+  let cached: RequestHandler | null = null;
+  return (req, res, next) => {
+    const current = getRuntimeAppRouter();
+    if (current !== lastRouter || cached === null) {
+      lastRouter = current;
+      cached = createExpressMiddleware({ router: current, createContext });
+    }
+    cached(req, res, next);
+  };
 }

--- a/apps/pops-api/src/router.ts
+++ b/apps/pops-api/src/router.ts
@@ -2,10 +2,16 @@
  * Main tRPC app router — composed from the build-time module registry
  * (`@pops/module-registry`) via the `installedManifests()` aggregator.
  *
- * PRD-101 US-03 removes the hand-edited list of domain routers from this
+ * PRD-101 US-03 removed the hand-edited list of domain routers from this
  * file: the root tRPC router is now `MODULES.map(m => m.backend?.router)`
  * filtered for installed modules. `core` is always mounted (it's the
  * always-installed platform shell, not a domain module).
+ *
+ * PRD-242 US-02: the in-repo catalogue source has moved from the hand-
+ * curated `KNOWN_ROUTERS` literal below to the codegen output emitted by
+ * `apps/pops-api/scripts/generate-known-routers.ts`
+ * (`KNOWN_ROUTERS_GENERATED`). The literal stays in place during the US-02
+ * window for `git blame` continuity and is physically deleted by US-03.
  *
  * The static `AppRouter` type narrows to the modules present in `MODULES`
  * — frontend code that references an absent module fails the build via a
@@ -14,7 +20,13 @@
  * `moduleGate` (`trpc.ts`) is retained as defence-in-depth: absent modules'
  * routers are not in the root, but the gate still rejects calls whose path
  * targets a known-but-uninstalled module (belt and braces).
+ *
+ * Runtime `mergeRouters`-based composition (the dynamic external-pillar
+ * surface from PRD-228) lives alongside this static export in
+ * `./runtime/compose.ts`. The express middleware reads from that runtime
+ * holder so external pillars registered after boot appear without a restart.
  */
+import { KNOWN_ROUTERS_GENERATED } from './generated/known-routers.js';
 import { egoRouter } from './modules/cerebrum/ego/index.js';
 import { cerebrumRouter } from './modules/cerebrum/index.js';
 import { coreRouter } from './modules/core/index.js';
@@ -30,16 +42,16 @@ import type { InstalledModule } from '@pops/module-registry';
 
 /**
  * The full mapping of module id → tRPC router for every module the API
- * binary knows how to mount. Keys must match the corresponding manifest
- * `id`. `core` is included so the same lookup table powers the composition
- * step below; it's always mounted regardless of `InstalledModule`.
+ * binary knows how to mount. Pre-PRD-242 this was the only source of truth.
+ * Today the live composition reads `KNOWN_ROUTERS_GENERATED` (PRD-242 US-01)
+ * from the codegen output; the literal below is retained for `git blame`
+ * continuity until PRD-242 US-03 deletes it.
  *
  * Per-property types are preserved (not widened to a common Router base)
  * so the literal shape we project to `appRouter` carries the exact nested
- * router type per key. Adding a new module: add the import + entry here
- * AND a manifest entry in `packages/module-registry/scripts/known-modules.ts`.
+ * router type per key.
  */
-const KNOWN_ROUTERS = {
+const _KNOWN_ROUTERS_LEGACY = {
   core: coreRouter,
   cerebrum: cerebrumRouter,
   ego: egoRouter,
@@ -49,8 +61,9 @@ const KNOWN_ROUTERS = {
   lists: listsRouter,
   media: mediaRouter,
 };
+void _KNOWN_ROUTERS_LEGACY;
 
-type KnownRouters = typeof KNOWN_ROUTERS;
+type KnownRouters = typeof KNOWN_ROUTERS_GENERATED;
 type KnownRouterId = keyof KnownRouters;
 
 /**
@@ -63,13 +76,13 @@ type InstalledRouterId = ('core' | InstalledModule['id']) & KnownRouterId;
 
 /**
  * The precise install set the root router exposes. `Pick` narrows the
- * `KNOWN_ROUTERS` literal to only the keys in the install set so the
- * inferred `AppRouter` carries an exact set of nested router types.
+ * codegen catalogue to only the keys in the install set so the inferred
+ * `AppRouter` carries an exact set of nested router types.
  */
 type InstalledRouterMap = Pick<KnownRouters, InstalledRouterId>;
 
 function isKnownRouterId(id: string): id is KnownRouterId {
-  return Object.prototype.hasOwnProperty.call(KNOWN_ROUTERS, id);
+  return Object.prototype.hasOwnProperty.call(KNOWN_ROUTERS_GENERATED, id);
 }
 
 /**
@@ -77,13 +90,13 @@ function isKnownRouterId(id: string): id is KnownRouterId {
  *
  * Source of truth is `installedManifests()` — it joins the build-time
  * `MODULES` install set to the live manifest exports and always includes
- * `core`. We project each manifest id back to its `KNOWN_ROUTERS` entry;
- * manifest ids without a matching entry (frontend-only modules such as
- * `ai`) are silently skipped — they're a no-op on the API surface.
+ * `core`. We project each manifest id back to its `KNOWN_ROUTERS_GENERATED`
+ * entry; manifest ids without a matching entry (frontend-only modules such
+ * as `ai`) are silently skipped — they're a no-op on the API surface.
  *
  * The runtime record is typed as `Partial<KnownRouters>` (every value, if
- * present, is the exact per-key router type from `KNOWN_ROUTERS`). The
- * final narrowing assertion to `InstalledRouterMap` reflects the
+ * present, is the exact per-key router type from `KNOWN_ROUTERS_GENERATED`).
+ * The final narrowing assertion to `InstalledRouterMap` reflects the
  * invariant that every id in `InstalledRouterId` corresponds to an entry
  * present in `MODULES` (plus `core`).
  */
@@ -91,8 +104,6 @@ function composeInstalledRouters(): InstalledRouterMap {
   const out: Partial<KnownRouters> = {};
   for (const manifest of installedManifests()) {
     if (isKnownRouterId(manifest.id)) {
-      // Assigning the matching per-key value preserves the literal type
-      // because both sides are indexed by the same narrowed id.
       assignRouter(out, manifest.id);
     }
   }
@@ -100,21 +111,25 @@ function composeInstalledRouters(): InstalledRouterMap {
 }
 
 /**
- * Generic helper that copies the `KNOWN_ROUTERS` entry for `key` into
- * `target` while preserving the per-key value type. Without this generic
- * indirection TypeScript collapses `out[id] = KNOWN_ROUTERS[id]` to the
- * widened router supertype (every key indexes into both sides at once),
- * which would in turn widen `Partial<KnownRouters>` and break the
- * `AppRouter` inference downstream.
+ * Generic helper that copies the catalogue entry for `key` into `target`
+ * while preserving the per-key value type. Without this generic indirection
+ * TypeScript collapses `out[id] = KNOWN_ROUTERS_GENERATED[id]` to the widened
+ * router supertype (every key indexes into both sides at once), which would
+ * in turn widen `Partial<KnownRouters>` and break the `AppRouter`
+ * inference downstream.
  */
 function assignRouter<K extends KnownRouterId>(target: Partial<KnownRouters>, key: K): void {
-  target[key] = KNOWN_ROUTERS[key];
+  target[key] = KNOWN_ROUTERS_GENERATED[key];
 }
 
 /**
  * Root application router. The shape narrows to the install set baked into
  * `@pops/module-registry`; consumers (tRPC clients, OpenAPI generator)
  * statically see only the procedures of installed modules.
+ *
+ * The dynamic external-pillar surface (PRD-228) lives in
+ * `./runtime/compose.ts` and wraps this export at boot. OpenAPI generation
+ * and static type narrowing continue to read from this constant directly.
  */
 export const appRouter = router(composeInstalledRouters());
 

--- a/apps/pops-api/src/runtime/__tests__/compose.test.ts
+++ b/apps/pops-api/src/runtime/__tests__/compose.test.ts
@@ -1,0 +1,144 @@
+/**
+ * PRD-242 US-02 — runtime `mergeRouters` composition + registry-event
+ * recomposition.
+ *
+ * Coverage:
+ *   1. At boot, the runtime appRouter exposes every top-level id in
+ *      `KNOWN_ROUTERS_GENERATED` (the codegen catalogue from PRD-242 US-01).
+ *   2. Registering a synthetic external pillar recomposes appRouter so the
+ *      pillar's `${id}.callDynamic` procedure becomes reachable.
+ *   3. Deregistering removes the pillar from the next composition.
+ *   4. Registering an id that collides with the codegen catalogue throws
+ *      `PillarIdCollisionError` — external pillars cannot shadow in-repo
+ *      pillars (PRD-228 reserved-id rule).
+ *   5. `mergeRouters` preserves the in-repo procedure surface: every
+ *      procedure key exposed by the static base appears verbatim on the
+ *      merged router.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { KNOWN_ROUTERS_GENERATED } from '../../generated/known-routers.js';
+import { appRouter as staticAppRouter } from '../../router.js';
+import { deferredExternalForwarder } from '../external-router.js';
+import {
+  composeAppRouter,
+  createExternalsRegistry,
+  installAppRouterHolder,
+  PillarIdCollisionError,
+} from '../index.js';
+
+interface RouterWithDef {
+  readonly _def: { readonly procedures: Readonly<Record<string, unknown>> };
+}
+
+const RESERVED_IDS = new Set(Object.keys(KNOWN_ROUTERS_GENERATED));
+
+function topLevelIds(rtr: RouterWithDef): Set<string> {
+  return new Set(Object.keys(rtr._def.procedures).map((path) => path.split('.')[0] ?? ''));
+}
+
+function procedurePaths(rtr: RouterWithDef): readonly string[] {
+  return Object.keys(rtr._def.procedures).toSorted();
+}
+
+describe('PRD-242 US-02 runtime appRouter composition', () => {
+  it('boot exposes every top-level id from KNOWN_ROUTERS_GENERATED', () => {
+    const registry = createExternalsRegistry(RESERVED_IDS);
+    const holder = installAppRouterHolder({
+      registry,
+      forward: deferredExternalForwarder,
+      debounceMs: 0,
+      staticBase: staticAppRouter,
+    });
+
+    try {
+      const tops = topLevelIds(holder.current);
+      for (const id of Object.keys(KNOWN_ROUTERS_GENERATED)) {
+        expect(tops.has(id), `expected runtime appRouter to expose '${id}'`).toBe(true);
+      }
+      // No external pillars at boot — runtime tops match in-repo tops.
+      expect(tops).toEqual(topLevelIds(staticAppRouter));
+    } finally {
+      holder.stop();
+    }
+  });
+
+  it('registering an external pillar adds it to the next composition', () => {
+    const registry = createExternalsRegistry(RESERVED_IDS);
+    const holder = installAppRouterHolder({
+      registry,
+      forward: deferredExternalForwarder,
+      debounceMs: 0,
+      staticBase: staticAppRouter,
+    });
+
+    try {
+      expect(topLevelIds(holder.current).has('recipes')).toBe(false);
+
+      registry.register({ pillarId: 'recipes', baseUrl: 'http://recipes-api:4010' });
+
+      const tops = topLevelIds(holder.current);
+      expect(tops.has('recipes')).toBe(true);
+      const paths = procedurePaths(holder.current);
+      expect(paths).toContain('recipes.callDynamic');
+    } finally {
+      holder.stop();
+    }
+  });
+
+  it('deregistering an external pillar removes it from the next composition', () => {
+    const registry = createExternalsRegistry(RESERVED_IDS);
+    const holder = installAppRouterHolder({
+      registry,
+      forward: deferredExternalForwarder,
+      debounceMs: 0,
+      staticBase: staticAppRouter,
+    });
+
+    try {
+      registry.register({ pillarId: 'recipes', baseUrl: 'http://recipes-api:4010' });
+      expect(topLevelIds(holder.current).has('recipes')).toBe(true);
+
+      const removed = registry.deregister('recipes');
+      expect(removed).toBe(true);
+      expect(topLevelIds(holder.current).has('recipes')).toBe(false);
+
+      // Idempotent: a second deregister returns false and does not throw.
+      expect(registry.deregister('recipes')).toBe(false);
+    } finally {
+      holder.stop();
+    }
+  });
+
+  it('external pillar id collisions with the codegen catalogue are rejected', () => {
+    const registry = createExternalsRegistry(RESERVED_IDS);
+
+    for (const id of Object.keys(KNOWN_ROUTERS_GENERATED)) {
+      expect(() => registry.register({ pillarId: id, baseUrl: 'http://x' })).toThrowError(
+        PillarIdCollisionError
+      );
+    }
+  });
+
+  it('mergeRouters preserves every in-repo procedure surface verbatim', () => {
+    const registry = createExternalsRegistry(RESERVED_IDS);
+    registry.register({ pillarId: 'recipes', baseUrl: 'http://recipes-api:4010' });
+
+    const merged = composeAppRouter({
+      registry,
+      forward: deferredExternalForwarder,
+      staticBase: staticAppRouter,
+    });
+
+    const baseProcedures = new Set(procedurePaths(staticAppRouter));
+    const mergedProcedures = new Set(procedurePaths(merged));
+
+    for (const path of baseProcedures) {
+      expect(mergedProcedures.has(path), `procedure '${path}' missing after merge`).toBe(true);
+    }
+
+    // The merge adds — does not subtract.
+    expect(mergedProcedures.size).toBeGreaterThanOrEqual(baseProcedures.size + 1);
+    expect(mergedProcedures.has('recipes.callDynamic')).toBe(true);
+  });
+});

--- a/apps/pops-api/src/runtime/compose.ts
+++ b/apps/pops-api/src/runtime/compose.ts
@@ -1,0 +1,122 @@
+/**
+ * Runtime `appRouter` composition (PRD-242 US-02).
+ *
+ * The orchestrator boot composes the live tRPC router from two halves:
+ *
+ *   - The static, in-repo half: the codegen catalogue
+ *     (`KNOWN_ROUTERS_GENERATED`, PRD-242 US-01) intersected with the install
+ *     set (`installedManifests()`). This is exactly the surface the build-
+ *     time `AppRouter` type describes; type-narrowing for in-repo clients
+ *     comes from here.
+ *
+ *   - The dynamic half: zero or more `origin: 'external'` pillars held in the
+ *     in-process `ExternalsRegistry`. Each is mounted as a passthrough router
+ *     under its pillar id (`buildExternalPillarRouter`).
+ *
+ * The two halves are combined with `mergeRouters` (re-exported from
+ * `apps/pops-api/src/trpc.ts`) so external pillars appear as sibling top-
+ * level routers alongside the in-repo bunch — exactly the surface a tRPC
+ * client sees.
+ *
+ * Recomposition is debounced (250ms, matching PRD-228's nginx-regen contract).
+ * Multiple register / deregister events during a deploy collapse to a single
+ * swap of the holder's `current` field. The express middleware reads
+ * `holder.current` per request, so the swap is observed atomically without
+ * connection draining.
+ */
+import { appRouter as defaultStaticAppRouter } from '../router.js';
+import { mergeRouters, router } from '../trpc.js';
+import {
+  buildExternalPillarRouter,
+  deferredExternalForwarder,
+  type ExternalForwarder,
+} from './external-router.js';
+import { type ExternalsRegistry } from './externals-registry.js';
+
+import type { AnyRouter } from '@trpc/server';
+
+export interface AppRouterHolder {
+  current: AnyRouter;
+  stop(): void;
+}
+
+export interface ComposeOptions {
+  readonly registry: ExternalsRegistry;
+  readonly forward?: ExternalForwarder;
+  readonly debounceMs?: number;
+  readonly staticBase?: AnyRouter;
+}
+
+const DEFAULT_DEBOUNCE_MS = 250;
+
+/**
+ * Wrap `inner` under a single top-level key `id` so the external pillar's
+ * procedures appear as `${id}.<proc>` rather than at the root after
+ * `mergeRouters` flattens its arguments.
+ */
+function namespaceUnderId(id: string, inner: AnyRouter): AnyRouter {
+  const record: Record<string, AnyRouter> = { [id]: inner };
+  return router(record);
+}
+
+/**
+ * Build the merged router at this instant — `staticBase` + every currently
+ * registered external. Pure function; suitable for both boot and tests.
+ */
+export function composeAppRouter(input: {
+  readonly registry: ExternalsRegistry;
+  readonly forward: ExternalForwarder;
+  readonly staticBase: AnyRouter;
+}): AnyRouter {
+  const externals = input.registry
+    .list()
+    .map((entry) =>
+      namespaceUnderId(entry.pillarId, buildExternalPillarRouter(entry, input.forward))
+    );
+  return mergeRouters(input.staticBase, ...externals);
+}
+
+/**
+ * Install the runtime composition: build the initial router, subscribe to
+ * registry events, and recompose on every change (debounced). Returns a
+ * holder whose `current` field is the live router and a `stop()` to detach
+ * the listener (used by tests).
+ */
+export function installAppRouterHolder(options: ComposeOptions): AppRouterHolder {
+  const staticBase = options.staticBase ?? defaultStaticAppRouter;
+  const forward = options.forward ?? deferredExternalForwarder;
+  const debounceMs = options.debounceMs ?? DEFAULT_DEBOUNCE_MS;
+
+  let pending: ReturnType<typeof setTimeout> | null = null;
+
+  const recompose = (): void => {
+    holder.current = composeAppRouter({ registry: options.registry, forward, staticBase });
+  };
+
+  const onChange = (): void => {
+    if (debounceMs <= 0) {
+      recompose();
+      return;
+    }
+    if (pending !== null) clearTimeout(pending);
+    pending = setTimeout(() => {
+      pending = null;
+      recompose();
+    }, debounceMs);
+  };
+
+  const unsubscribe = options.registry.onChange(onChange);
+
+  const holder: AppRouterHolder = {
+    current: composeAppRouter({ registry: options.registry, forward, staticBase }),
+    stop(): void {
+      unsubscribe();
+      if (pending !== null) {
+        clearTimeout(pending);
+        pending = null;
+      }
+    },
+  };
+
+  return holder;
+}

--- a/apps/pops-api/src/runtime/external-router.ts
+++ b/apps/pops-api/src/runtime/external-router.ts
@@ -1,0 +1,69 @@
+/**
+ * Passthrough tRPC router for one external (PRD-228) pillar.
+ *
+ * The orchestrator does not introspect the external pillar's procedure
+ * shape at the type level. Per PRD-242 US-02, external pillars surface a
+ * single `callDynamic` procedure that takes a runtime `{ procedure, input,
+ * kind }` payload and forwards it to the registered `baseUrl`. This mirrors
+ * the consumer-side `pillar(id).callDynamic` proxy shipped in PRD-242 PR
+ * #3131, so the consumer's type system stays static even for runtime-
+ * registered pillars.
+ *
+ * Forwarding itself is injectable (`forward` arg) so US-04 can plug in the
+ * real HTTP transport while US-02 unit tests inject an in-memory stub.
+ */
+import { z } from 'zod';
+
+import { protectedProcedure, router } from '../trpc.js';
+
+import type { ExternalPillarEntry } from './externals-registry.js';
+
+export type ExternalForwarder = (
+  entry: ExternalPillarEntry,
+  payload: {
+    readonly procedure: string;
+    readonly input: unknown;
+    readonly kind: 'query' | 'mutation';
+  }
+) => Promise<unknown>;
+
+const callDynamicInputSchema = z.object({
+  procedure: z.string().min(1),
+  input: z.unknown().optional(),
+  kind: z.enum(['query', 'mutation']).default('query'),
+});
+
+export function buildExternalPillarRouter(
+  entry: ExternalPillarEntry,
+  forward: ExternalForwarder
+): ReturnType<typeof router> {
+  const callDynamic = protectedProcedure
+    .input(callDynamicInputSchema)
+    .mutation(async ({ input }) => {
+      return forward(entry, {
+        procedure: input.procedure,
+        input: input.input,
+        kind: input.kind,
+      });
+    });
+
+  return router({
+    callDynamic,
+  });
+}
+
+/**
+ * Default forwarder: returns a `NOT_IMPLEMENTED`-shaped error result.
+ *
+ * US-02 stops at registering the external pillar surface; the actual HTTP
+ * forwarding ships in US-04. Until then a `callDynamic` call against an
+ * external pillar resolves with an explicit deferred-marker so production
+ * code can detect the unimplemented path.
+ */
+export const deferredExternalForwarder: ExternalForwarder = async (entry, payload) =>
+  Promise.resolve({
+    ok: false as const,
+    reason: 'external-forwarding-deferred' as const,
+    pillarId: entry.pillarId,
+    procedure: payload.procedure,
+  });

--- a/apps/pops-api/src/runtime/externals-registry.ts
+++ b/apps/pops-api/src/runtime/externals-registry.ts
@@ -1,0 +1,82 @@
+/**
+ * Runtime externals registry (PRD-242 US-02 / PRD-228 surface).
+ *
+ * Holds the orchestrator's in-process view of `origin: 'external'` pillars
+ * registered at runtime via PRD-228's HTTP register / deregister endpoints.
+ * It is intentionally a thin in-memory cache distinct from the persisted
+ * `pillar_registry` table — the table is the source of truth across
+ * restarts, this registry is the source of truth for the live `appRouter`
+ * composition between restarts.
+ *
+ * The registry emits `changed` events. The runtime router composition
+ * (`./compose.ts`) listens, debounces, and recomposes. Future PRD-228 HTTP
+ * route handlers call `registerExternal` / `deregisterExternal` on this
+ * module after persisting to the DB.
+ *
+ * Pillar-id collisions with in-repo (codegen) router ids are rejected at
+ * `register` time per PRD-228 reserved-id rules. The codegen id set is
+ * injected at construction so the registry is decoupled from any specific
+ * catalogue (testability).
+ */
+import { EventEmitter } from 'node:events';
+
+export interface ExternalPillarEntry {
+  readonly pillarId: string;
+  readonly baseUrl: string;
+}
+
+export interface ExternalsRegistry {
+  list(): readonly ExternalPillarEntry[];
+  register(entry: ExternalPillarEntry): void;
+  deregister(pillarId: string): boolean;
+  onChange(listener: () => void): () => void;
+  clear(): void;
+}
+
+export class PillarIdCollisionError extends Error {
+  constructor(public readonly pillarId: string) {
+    super(
+      `External pillar id '${pillarId}' collides with a reserved in-repo router id. ` +
+        `Per PRD-228, external pillars cannot shadow in-tree pillars.`
+    );
+    this.name = 'PillarIdCollisionError';
+  }
+}
+
+export function createExternalsRegistry(reservedIds: ReadonlySet<string>): ExternalsRegistry {
+  const entries = new Map<string, ExternalPillarEntry>();
+  const emitter = new EventEmitter();
+
+  return {
+    list(): readonly ExternalPillarEntry[] {
+      return [...entries.values()].toSorted((a, b) => {
+        if (a.pillarId < b.pillarId) return -1;
+        if (a.pillarId > b.pillarId) return 1;
+        return 0;
+      });
+    },
+    register(entry: ExternalPillarEntry): void {
+      if (reservedIds.has(entry.pillarId)) {
+        throw new PillarIdCollisionError(entry.pillarId);
+      }
+      entries.set(entry.pillarId, entry);
+      emitter.emit('changed');
+    },
+    deregister(pillarId: string): boolean {
+      const removed = entries.delete(pillarId);
+      if (removed) emitter.emit('changed');
+      return removed;
+    },
+    onChange(listener: () => void): () => void {
+      emitter.on('changed', listener);
+      return () => {
+        emitter.off('changed', listener);
+      };
+    },
+    clear(): void {
+      const hadEntries = entries.size > 0;
+      entries.clear();
+      if (hadEntries) emitter.emit('changed');
+    },
+  };
+}

--- a/apps/pops-api/src/runtime/index.ts
+++ b/apps/pops-api/src/runtime/index.ts
@@ -1,0 +1,66 @@
+/**
+ * Runtime composition barrel (PRD-242 US-02).
+ *
+ * Owns the singleton externals registry + app-router holder for the live
+ * orchestrator process. `app.ts` reaches in for `getRuntimeAppRouter()` when
+ * building the tRPC express middleware so external pillars registered after
+ * boot become reachable without a restart.
+ *
+ * The reserved-id set is derived from the codegen catalogue: any external
+ * pillar attempting to register under a known in-repo id is rejected with
+ * `PillarIdCollisionError` (PRD-228 reserved-id rule).
+ *
+ * Tests construct their own registries + holders through the named
+ * `createExternalsRegistry` / `installAppRouterHolder` exports.
+ */
+import { KNOWN_ROUTERS_GENERATED } from '../generated/known-routers.js';
+import { installAppRouterHolder, type AppRouterHolder } from './compose.js';
+import { createExternalsRegistry, type ExternalsRegistry } from './externals-registry.js';
+
+import type { AnyRouter } from '@trpc/server';
+
+const RESERVED_IDS: ReadonlySet<string> = new Set(Object.keys(KNOWN_ROUTERS_GENERATED));
+
+let singleton: { registry: ExternalsRegistry; holder: AppRouterHolder } | null = null;
+
+function bootstrap(): { registry: ExternalsRegistry; holder: AppRouterHolder } {
+  const registry = createExternalsRegistry(RESERVED_IDS);
+  const holder = installAppRouterHolder({ registry });
+  return { registry, holder };
+}
+
+function getSingleton(): { registry: ExternalsRegistry; holder: AppRouterHolder } {
+  singleton ??= bootstrap();
+  return singleton;
+}
+
+/**
+ * The orchestrator's runtime tRPC router. The express middleware reads this
+ * accessor per request, so an external-pillar register / deregister observed
+ * by the registry surfaces on the next request after recomposition settles.
+ */
+export function getRuntimeAppRouter(): AnyRouter {
+  return getSingleton().holder.current;
+}
+
+/** The orchestrator's externals registry. PRD-228 HTTP handlers call into this. */
+export function getExternalsRegistry(): ExternalsRegistry {
+  return getSingleton().registry;
+}
+
+/**
+ * Test-only reset: drops the singleton and stops the active holder's event
+ * subscription. The next call to `getRuntimeAppRouter` rebuilds from scratch.
+ */
+export function __resetRuntimeAppRouter(): void {
+  if (singleton !== null) {
+    singleton.holder.stop();
+    singleton = null;
+  }
+}
+
+export { createExternalsRegistry } from './externals-registry.js';
+export { installAppRouterHolder, composeAppRouter } from './compose.js';
+export type { ExternalsRegistry, ExternalPillarEntry } from './externals-registry.js';
+export type { AppRouterHolder } from './compose.js';
+export { PillarIdCollisionError } from './externals-registry.js';


### PR DESCRIPTION
## Summary

- Wires the live tRPC app router through `mergeRouters` over the codegen catalogue from #3232 plus an in-process externals registry that future PRD-228 register/deregister HTTP handlers will write to.
- Adds `apps/pops-api/src/runtime/`: registry, passthrough router builder, debounced composer, and a singleton holder. The express `/trpc` middleware now resolves the router per request via `getRuntimeAppRouter()` so externals registered after boot are reachable without a restart.
- `composeInstalledRouters()` in `apps/pops-api/src/router.ts` now reads from `KNOWN_ROUTERS_GENERATED` (#3232) instead of the hand-curated `KNOWN_ROUTERS` literal. The literal stays in place for PRD-242 US-03 to physically delete; the runtime composition no longer depends on it.
- External pillars expose a single `callDynamic` procedure per pillar id, mirroring the consumer-side `pillar(id).callDynamic` proxy from #3131. Forwarding is injectable — US-04 ships the real HTTP transport.
- Recomposition is debounced (250ms, matching PRD-228 nginx-regen) and id collisions with the codegen catalogue are rejected per PRD-228's reserved-id rule.

## Test plan

- [ ] `pnpm --filter @pops/api typecheck` clean.
- [ ] `pnpm --filter @pops/api test` — 4899 tests pass, including 5 new vitest cases in `apps/pops-api/src/runtime/__tests__/compose.test.ts` covering boot keys, register/deregister round-trip, id-collision rejection over every reserved id, and `mergeRouters` preserving the in-repo procedure surface.
- [ ] `pnpm lint` zero errors.
- [ ] `pnpm format:check` clean.
- [ ] `pnpm lint:boundaries` no new violations.

## References

- PRD-242 US-02 — runtime `mergeRouters` composition + registry-event recomposition.
- #3232 — PRD-242 US-01 workspace-scan codegen for `KNOWN_ROUTERS_GENERATED`.
- #3131 — `callDynamic` proxy on the consumer side.
- PRD-228 — dynamic pillar registration (the surface this US plugs into).