### PR TITLE
feat(shell): PRD-243 US-03 registry-driven installed-modules + nav (closes audit H4/H5)

### DIFF
--- a/apps/pops-shell/src/app/bundle-map.ts
+++ b/apps/pops-shell/src/app/bundle-map.ts
@@ -1,0 +1,63 @@
+/**
+ * Workspace bundle map — single source enumerating in-repo pillar ids in the
+ * shell (PRD-243 US-03).
+ *
+ * The shell discovers each in-repo pillar's UI surface (nav + pages) by
+ * walking this map. For external pillars (PRD-228) the registry will
+ * advertise an `assetsBaseUrl`; the lazy-load mechanism is gated on US-05
+ * landing — until then any external-only pillar id falls through the
+ * `external UI loading not implemented` skip path in `installed-modules.ts`.
+ *
+ * Each entry carries:
+ *
+ *   - `manifest`        — the frontend `ModuleManifest` re-exported by the
+ *                         pillar's `@pops/app-*` workspace package. Provides
+ *                         `frontend.routes` (lazy `RouteObject[]`) and the
+ *                         legacy `navConfig` the shell still uses to render
+ *                         the app rail. Bound by static import because the
+ *                         current shell consumer surface is synchronous.
+ *   - `navOrder`        — mirrors `nav.order` from the pillar's wire-format
+ *                         manifest payload (`apps/pops-<id>-api/src/manifest.ts`).
+ *                         Values follow the reconciled sparse scheme
+ *                         (finance=10, media=20, inventory=30, food=40,
+ *                         lists=50, cerebrum=60, ai=70) so the app rail
+ *                         renders the same seven entries in the same order
+ *                         as the pre-PR `registeredApps` literal.
+ *   - `assetsBaseUrl?`  — reserved for external pillars (US-05). Always
+ *                         `undefined` for in-repo entries today.
+ *
+ * Adding a new in-repo pillar = adding one entry here. External pillars
+ * never appear in this map; they reach the shell via the registry walk and
+ * (once US-05 lands) the asset-URL loading path.
+ */
+import { manifest as aiManifest } from '@pops/app-ai';
+import { manifest as cerebrumManifest } from '@pops/app-cerebrum';
+import { manifest as financeManifest } from '@pops/app-finance';
+import { manifest as foodManifest } from '@pops/app-food';
+import { manifest as inventoryManifest } from '@pops/app-inventory';
+import { manifest as listsManifest } from '@pops/app-lists';
+import { manifest as mediaManifest } from '@pops/app-media';
+import { manifest as egoManifest } from '@pops/overlay-ego';
+
+import type { ModuleManifest } from '@pops/types';
+
+export interface BundleEntry {
+  readonly manifest: ModuleManifest;
+  readonly navOrder: number;
+  readonly assetsBaseUrl?: string;
+}
+
+export const WORKSPACE_BUNDLE_MAP: Readonly<Record<string, BundleEntry>> = {
+  finance: { manifest: financeManifest, navOrder: 10 },
+  media: { manifest: mediaManifest, navOrder: 20 },
+  inventory: { manifest: inventoryManifest, navOrder: 30 },
+  food: { manifest: foodManifest, navOrder: 40 },
+  lists: { manifest: listsManifest, navOrder: 50 },
+  cerebrum: { manifest: cerebrumManifest, navOrder: 60 },
+  ai: { manifest: aiManifest, navOrder: 70 },
+  ego: { manifest: egoManifest, navOrder: Number.POSITIVE_INFINITY },
+};
+
+export function lookupBundleEntry(pillarId: string): BundleEntry | undefined {
+  return WORKSPACE_BUNDLE_MAP[pillarId];
+}

--- a/apps/pops-shell/src/app/installed-modules.ts
+++ b/apps/pops-shell/src/app/installed-modules.ts
@@ -1,30 +1,23 @@
 /**
  * Shell-side aggregator that joins the build-time `MODULES` install set
- * (`@pops/module-registry`) with the live per-module frontend manifests
- * exported by `@pops/app-*` / `@pops/overlay-*` packages.
+ * (`@pops/module-registry`) with the workspace bundle map
+ * (`./bundle-map.ts`) — the single place the shell still enumerates
+ * in-repo pillar ids per PRD-243 US-03.
  *
- * Mirrors `apps/pops-api/src/modules/installed-modules.ts` on the API side
- * — the build-time registry intentionally carries only the serialisable
- * projection of each manifest; the code-bearing slots (React routes, nav
- * config, overlay component refs) live alongside the module that owns
- * them. This file is the join point on the shell.
+ * Prior to PRD-243 this file hand-imported each pillar's frontend
+ * manifest by name and reduced the registry intersection through the
+ * `KNOWN_FRONTEND_MANIFESTS` literal. The registry walk replaces both:
+ * every installed pillar id resolves through `lookupBundleEntry()`,
+ * which fronts the workspace bundle map. External pillars (PRD-228)
+ * that the registry advertises via `assetsBaseUrl` but the bundle map
+ * has not bound to a workspace bundle fall through the "external UI
+ * loading not implemented" branch — gated on PRD-243 US-05.
  *
- * Adding a new module: add it to `KNOWN_FRONTEND_MANIFESTS` below AND to
- * `packages/module-registry/scripts/known-modules.ts`. The registry build
- * validates the metadata; this file binds the metadata to the live React
- * references.
- *
- * See `docs/themes/01-foundation/prds/101-plugin-contract/us-03-routing-from-registry.md`.
+ * See `docs/themes/13-pillar-finale/prds/243-registry-driven-shell-ui/us-03-shell-registry-walk.md`.
  */
-import { manifest as aiManifest } from '@pops/app-ai';
-import { manifest as cerebrumManifest } from '@pops/app-cerebrum';
-import { manifest as financeManifest } from '@pops/app-finance';
-import { manifest as foodManifest } from '@pops/app-food';
-import { manifest as inventoryManifest } from '@pops/app-inventory';
-import { manifest as listsManifest } from '@pops/app-lists';
-import { manifest as mediaManifest } from '@pops/app-media';
 import { INSTALLED_MODULES, MODULES } from '@pops/module-registry';
-import { manifest as egoManifest } from '@pops/overlay-ego';
+
+import { WORKSPACE_BUNDLE_MAP, type BundleEntry } from './bundle-map';
 
 import type { RouteObject } from 'react-router';
 
@@ -48,55 +41,119 @@ export function hasRoutes(
 }
 
 /**
- * Every frontend manifest the shell binary knows how to mount. Keys must
- * match the corresponding registry / backend manifest `id`. Each entry's
- * declared type narrows `frontend.routes` to `RouteObject[]` (or omits it
- * entirely for overlay-only modules), so this array's inferred element
- * type already satisfies `FrontendManifest`.
+ * Thrown when the registry advertises a pillar via `assetsBaseUrl` (i.e.
+ * the pillar expects to be UI-mounted via the external loading
+ * mechanism) but PRD-243 US-05 has not yet landed the resolver. Caught
+ * in `walkRegistry()` so the shell logs once and skips the pillar
+ * instead of crashing the boot.
  */
-const KNOWN_FRONTEND_MANIFESTS: readonly FrontendManifest[] = [
-  aiManifest,
-  cerebrumManifest,
-  egoManifest,
-  financeManifest,
-  foodManifest,
-  inventoryManifest,
-  listsManifest,
-  mediaManifest,
-];
+export class ExternalUiLoadingNotImplementedError extends Error {
+  override readonly name = 'ExternalUiLoadingNotImplementedError';
+  readonly pillarId: string;
+  readonly assetsBaseUrl: string;
 
-function findKnownManifest(id: string): FrontendManifest | undefined {
-  return KNOWN_FRONTEND_MANIFESTS.find((m) => m.id === id);
+  constructor(pillarId: string, assetsBaseUrl: string) {
+    super(
+      `external UI loading not implemented (pillarId=${pillarId}, assetsBaseUrl=${assetsBaseUrl})`
+    );
+    this.pillarId = pillarId;
+    this.assetsBaseUrl = assetsBaseUrl;
+  }
+}
+
+/**
+ * Minimal "registry entry" shape the shell walks. Mirrors the
+ * `PillarSnapshot` projection `discoverSettings()` reads (PRD-240) but
+ * carries only the fields PRD-243 US-03 needs to decide which UI surface
+ * to mount: the pillar id and (for external pillars) the `assetsBaseUrl`
+ * the US-05 follow-up will consume.
+ *
+ * Backed by `MODULES` + `INSTALLED_MODULES` today; PRD-228 wires the
+ * runtime registry behind the same shape so external pillars flow
+ * through the same walk.
+ */
+export interface RegistryEntry {
+  readonly pillarId: string;
+  readonly assetsBaseUrl?: string;
+}
+
+/**
+ * Build the default registry-entry list from the build-time `MODULES`
+ * snapshot intersected with the runtime `INSTALLED_MODULES` shim. The
+ * synchronous walk source the shell uses at boot.
+ */
+function defaultRegistryEntries(): readonly RegistryEntry[] {
+  const out: RegistryEntry[] = [];
+  for (const module of MODULES) {
+    if (!INSTALLED_MODULES.includes(module.id)) continue;
+    out.push({ pillarId: module.id });
+  }
+  return out;
+}
+
+/**
+ * Walk a registry entry list against a workspace bundle map, returning
+ * the frontend manifests the shell should mount. Resolution per id:
+ *
+ *   - Bundle map hit → emit the workspace manifest.
+ *   - Bundle map miss + `assetsBaseUrl` set → log the structured
+ *     `ExternalUiLoadingNotImplementedError` message (PRD-243 US-05
+ *     deferred) and skip.
+ *   - Bundle map miss + no `assetsBaseUrl` → backend-only pillar, drop
+ *     silently. Mirrors the pre-PRD-243 behaviour where backend-only
+ *     ids simply weren't in `KNOWN_FRONTEND_MANIFESTS`.
+ */
+export function walkRegistry(
+  entries: readonly RegistryEntry[],
+  bundleMap: Readonly<Record<string, BundleEntry>>
+): readonly FrontendManifest[] {
+  const out: FrontendManifest[] = [];
+  for (const entry of entries) {
+    const bundle = bundleMap[entry.pillarId];
+    if (bundle !== undefined) {
+      out.push(bundle.manifest);
+      continue;
+    }
+    if (entry.assetsBaseUrl !== undefined) {
+      const err = new ExternalUiLoadingNotImplementedError(entry.pillarId, entry.assetsBaseUrl);
+      console.warn(`[installed-modules] ${err.message}`);
+      continue;
+    }
+    // Backend-only pillars (e.g. `core`) sit in `MODULES` but contribute
+    // no UI. They never appear in the bundle map and they never advertise
+    // an `assetsBaseUrl`, so the walk drops them silently — mirroring the
+    // pre-PRD-243 behaviour where they simply weren't in
+    // `KNOWN_FRONTEND_MANIFESTS`.
+  }
+  return out;
 }
 
 /**
  * Test-only override. When set, `installedFrontendManifests()` returns
- * this list verbatim instead of computing from the registry intersection.
+ * this list verbatim instead of computing from the registry walk.
  * Reset between tests via `__resetInstalledFrontendManifestsOverride()`.
  *
  * The override exists because `MODULES` / `INSTALLED_MODULES` are
  * computed at build / module-load time — there is no public API for
- * tests to inject synthetic module manifests into either.
+ * tests to inject synthetic module manifests into either. PRD-243 US-04
+ * is the integration test that exercises the live walk against a
+ * synthetic registry without using this hook.
  */
 let testOverride: readonly FrontendManifest[] | null = null;
 
 /**
- * Frontend manifests considered "installed" for this build — present in
- * `MODULES` (the build-time superset), inside `INSTALLED_MODULES` (the
- * runtime `POPS_APPS` / `POPS_OVERLAYS` install set per PRD-218 US-01),
- * and bound in `KNOWN_FRONTEND_MANIFESTS`. Backend-only modules (`core`)
- * are skipped at this layer: the shell has no React routes to mount for
- * them.
+ * Frontend manifests considered "installed" for this build. Walks the
+ * registry: every id in the `MODULES` superset that survives the runtime
+ * install set (`INSTALLED_MODULES`, per PRD-218 US-01) is resolved
+ * against the workspace bundle map.
+ *
+ * Skip path: a registered id with no entry in the workspace bundle map
+ * AND no `assetsBaseUrl` to defer to logs a warning and is omitted —
+ * external pillars (US-05 deferred) fall here today.
  */
 export function installedFrontendManifests(): readonly FrontendManifest[] {
   if (testOverride !== null) return testOverride;
-  const out: FrontendManifest[] = [];
-  for (const m of MODULES) {
-    if (!INSTALLED_MODULES.includes(m.id)) continue;
-    const live = findKnownManifest(m.id);
-    if (live !== undefined) out.push(live);
-  }
-  return out;
+  return walkRegistry(defaultRegistryEntries(), WORKSPACE_BUNDLE_MAP);
 }
 
 /**
@@ -116,8 +173,7 @@ export function installedAppManifests(): readonly (FrontendManifest & {
 
 /**
  * Test-only: replace the installed-manifest source with `manifests`.
- * Pass `null` to restore the production behaviour (read from `MODULES`
- * intersected with `INSTALLED_MODULES`).
+ * Pass `null` to restore the production behaviour (walk the registry).
  */
 export function __setInstalledFrontendManifestsOverride(
   manifests: readonly FrontendManifest[] | null

--- a/apps/pops-shell/src/app/nav/registry.test.ts
+++ b/apps/pops-shell/src/app/nav/registry.test.ts
@@ -10,6 +10,21 @@ describe('nav registry', () => {
     expect(registeredApps.length).toBeGreaterThan(0);
   });
 
+  // Parity gate — the seven in-repo pillars must render in the same order
+  // as the pre-PRD-243 hand-curated `registeredApps` literal. Drift here
+  // means audit H5's observable behaviour has regressed.
+  it('preserves the pre-PRD-243 app-rail order', () => {
+    expect(registeredApps.map((app) => app.id)).toEqual([
+      'finance',
+      'media',
+      'inventory',
+      'food',
+      'lists',
+      'cerebrum',
+      'ai',
+    ]);
+  });
+
   it.each(registeredApps.map((app) => [app.id, app] as const))(
     '%s app icon resolves through iconMap',
     (_, app) => {

--- a/apps/pops-shell/src/app/nav/registry.ts
+++ b/apps/pops-shell/src/app/nav/registry.ts
@@ -1,31 +1,69 @@
 /**
- * App registry — single source of truth for navigation.
+ * App-rail registry — derived from a registry walk over the workspace
+ * bundle map (PRD-243 US-03).
  *
- * To add a new app:
- * 1. Create a package in packages/app-<name>/
- * 2. Export a navConfig: AppNavConfig from its index.ts
- * 3. Import it here and add to the registeredApps array
- * 4. Add its routes to the shell router (app/router.tsx)
+ * Replaces the pre-PRD-243 hand-curated `registeredApps` literal that
+ * imported each `@pops/app-*` package's `navConfig` by name. The walk
+ * iterates the workspace bundle map, picks up each entry's
+ * `manifest.frontend.navConfig`, and sorts by the manifest-level
+ * `navOrder` (mirrors `nav.order` on the pillar's wire-format manifest
+ * payload, per PRD-243 US-02). Ties break lexicographically on the nav
+ * `id` so authoring order is deterministic without tight numbering.
+ *
+ * Today every workspace bundle map entry that contributes a `navConfig`
+ * is in-repo. External pillars (PRD-228, US-05 deferred) will join the
+ * walk via the same path once their assets-base-url loading mechanism
+ * lands; for now their bundle map entries do not exist.
  */
-import { navConfig as aiNavConfig } from '@pops/app-ai';
-import { navConfig as cerebrumNavConfig } from '@pops/app-cerebrum';
-import { navConfig as financeNavConfig } from '@pops/app-finance';
-import { navConfig as foodNavConfig } from '@pops/app-food';
-import { navConfig as inventoryNavConfig } from '@pops/app-inventory';
-import { navConfig as listsNavConfig } from '@pops/app-lists';
-import { navConfig as mediaNavConfig } from '@pops/app-media';
+import { WORKSPACE_BUNDLE_MAP, type BundleEntry } from '../bundle-map';
 
 import type { AppNavConfig } from './types';
 
-/** All registered app nav configs. Order determines display order in the app rail. */
-export const registeredApps: AppNavConfig[] = [
-  financeNavConfig,
-  mediaNavConfig,
-  inventoryNavConfig,
-  foodNavConfig,
-  listsNavConfig,
-  cerebrumNavConfig,
-  aiNavConfig,
-];
+interface RankedNavConfig {
+  readonly order: number;
+  readonly nav: AppNavConfig;
+}
+
+function navConfigFromManifest(manifest: unknown): AppNavConfig | undefined {
+  if (typeof manifest !== 'object' || manifest === null) return undefined;
+  const frontend = (manifest as { frontend?: { navConfig?: unknown } }).frontend;
+  if (frontend === undefined) return undefined;
+  const navConfig = frontend.navConfig;
+  if (typeof navConfig !== 'object' || navConfig === null) return undefined;
+  return navConfig as AppNavConfig;
+}
+
+function compareRankedNav(a: RankedNavConfig, b: RankedNavConfig): number {
+  if (a.order !== b.order) return a.order - b.order;
+  if (a.nav.id === b.nav.id) return 0;
+  return a.nav.id < b.nav.id ? -1 : 1;
+}
+
+/**
+ * Build the app-rail registry from a bundle map snapshot. Exported so
+ * the US-03 test suite can exercise the walk against a synthetic bundle
+ * map without mutating the live `WORKSPACE_BUNDLE_MAP` singleton.
+ */
+export function buildRegisteredAppsFromBundleMap(
+  bundleMap: Readonly<Record<string, BundleEntry>>
+): AppNavConfig[] {
+  const ranked: RankedNavConfig[] = [];
+  for (const entry of Object.values(bundleMap)) {
+    const nav = navConfigFromManifest(entry.manifest);
+    if (nav === undefined) continue;
+    ranked.push({ order: entry.navOrder, nav });
+  }
+  ranked.sort(compareRankedNav);
+  return ranked.map((entry) => entry.nav);
+}
+
+/**
+ * All registered app nav configs. Sorted by `navOrder` ascending with a
+ * stable lexicographic tiebreak on `id`. Today's display order
+ * (`finance, media, inventory, food, lists, cerebrum, ai`) is preserved
+ * by the reconciled sparse scheme in `bundle-map.ts`.
+ */
+export const registeredApps: AppNavConfig[] =
+  buildRegisteredAppsFromBundleMap(WORKSPACE_BUNDLE_MAP);
 
 export type { AppNavConfig, AppNavItem } from './types';

--- a/apps/pops-shell/src/app/registry-walk.test.ts
+++ b/apps/pops-shell/src/app/registry-walk.test.ts
@@ -1,0 +1,171 @@
+/**
+ * PRD-243 US-03 — registry-walk unit tests.
+ *
+ * Exercises the bundle-map-driven discovery path with synthetic data
+ * instead of the live `WORKSPACE_BUNDLE_MAP` / `MODULES` constants. The
+ * existing override-based `installed-modules.test.ts` covers the
+ * production wiring; this file pins the walk's contract:
+ *
+ *   - Two synthetic pillars produce two nav configs.
+ *   - Frontend manifests joined through the walk preserve `frontend.routes`.
+ *   - Pillars omitting both `nav` and `pages` are skipped from the rail.
+ *   - Pillars advertising an `assetsBaseUrl` without a bundle entry log
+ *     once and are skipped (the US-05 stub branch).
+ *   - Sort order respects `navOrder` ascending with a lexicographic
+ *     tiebreak on the nav id.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  ExternalUiLoadingNotImplementedError,
+  walkRegistry,
+  type FrontendManifest,
+  type RegistryEntry,
+} from './installed-modules';
+import { buildRegisteredAppsFromBundleMap } from './nav/registry';
+
+import type { BundleEntry } from './bundle-map';
+import type { AppNavConfig } from './nav/types';
+
+function manifestFor(
+  id: string,
+  navConfig: AppNavConfig | undefined,
+  routes: ReadonlyArray<{ path?: string; index?: boolean }> | undefined
+): FrontendManifest {
+  const frontend: FrontendManifest['frontend'] = {};
+  if (navConfig !== undefined) frontend.navConfig = navConfig;
+  if (routes !== undefined) frontend.routes = [...routes];
+  return {
+    id,
+    name: id,
+    surfaces: ['app'],
+    frontend,
+  };
+}
+
+function navFor(id: string, label: string): AppNavConfig {
+  return {
+    id,
+    label,
+    labelKey: id,
+    icon: 'Bot',
+    basePath: `/${id}`,
+    items: [{ path: '', label: 'Home', labelKey: `${id}.home`, icon: 'LayoutDashboard' }],
+  };
+}
+
+describe('walkRegistry', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('emits one manifest per registered pillar resolvable through the bundle map', () => {
+    const bundleMap: Record<string, BundleEntry> = {
+      finance: {
+        manifest: manifestFor('finance', navFor('finance', 'Finance'), [{ index: true }]),
+        navOrder: 10,
+      },
+      media: {
+        manifest: manifestFor('media', navFor('media', 'Media'), [{ index: true }]),
+        navOrder: 20,
+      },
+    };
+    const entries: RegistryEntry[] = [{ pillarId: 'finance' }, { pillarId: 'media' }];
+
+    const out = walkRegistry(entries, bundleMap);
+
+    expect(out.map((m) => m.id)).toEqual(['finance', 'media']);
+  });
+
+  it('preserves frontend.routes on the joined manifest so the router can mount them', () => {
+    const bundleMap: Record<string, BundleEntry> = {
+      finance: {
+        manifest: manifestFor('finance', navFor('finance', 'Finance'), [
+          { index: true },
+          { path: 'transactions' },
+        ]),
+        navOrder: 10,
+      },
+    };
+    const entries: RegistryEntry[] = [{ pillarId: 'finance' }];
+
+    const out = walkRegistry(entries, bundleMap);
+    const financeRoutes = out[0]?.frontend?.routes;
+
+    expect(Array.isArray(financeRoutes)).toBe(true);
+    expect(financeRoutes).toHaveLength(2);
+  });
+
+  it('skips registered pillars whose bundle map entry omits a navConfig', () => {
+    const bundleMap: Record<string, BundleEntry> = {
+      finance: {
+        manifest: manifestFor('finance', navFor('finance', 'Finance'), [{ index: true }]),
+        navOrder: 10,
+      },
+      backendOnly: {
+        manifest: manifestFor('backendOnly', undefined, undefined),
+        navOrder: 999,
+      },
+    };
+
+    const apps = buildRegisteredAppsFromBundleMap(bundleMap);
+
+    expect(apps.map((a) => a.id)).toEqual(['finance']);
+  });
+
+  it('logs and skips a registry entry that advertises assetsBaseUrl without a bundle map entry (US-05 stub branch)', () => {
+    const bundleMap: Record<string, BundleEntry> = {};
+    const entries: RegistryEntry[] = [
+      { pillarId: 'external-pillar', assetsBaseUrl: 'https://cdn.example.com/external/' },
+    ];
+
+    const out = walkRegistry(entries, bundleMap);
+
+    expect(out).toHaveLength(0);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const message = String(warnSpy.mock.calls[0]?.[0] ?? '');
+    expect(message).toContain('external UI loading not implemented');
+    expect(message).toContain('external-pillar');
+    expect(message).toContain('https://cdn.example.com/external/');
+  });
+
+  it('exposes the US-05 stub failure as a structured error type callers can detect', () => {
+    const err = new ExternalUiLoadingNotImplementedError('foo', 'https://x/');
+
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe('ExternalUiLoadingNotImplementedError');
+    expect(err.pillarId).toBe('foo');
+    expect(err.assetsBaseUrl).toBe('https://x/');
+  });
+
+  it('sorts registeredApps by navOrder ascending with a lexicographic tiebreak on id', () => {
+    const bundleMap: Record<string, BundleEntry> = {
+      gamma: {
+        manifest: manifestFor('gamma', navFor('gamma', 'Gamma'), [{ index: true }]),
+        navOrder: 30,
+      },
+      alpha: {
+        manifest: manifestFor('alpha', navFor('alpha', 'Alpha'), [{ index: true }]),
+        navOrder: 10,
+      },
+      betaA: {
+        manifest: manifestFor('beta-a', navFor('beta-a', 'Beta A'), [{ index: true }]),
+        navOrder: 20,
+      },
+      betaB: {
+        manifest: manifestFor('beta-b', navFor('beta-b', 'Beta B'), [{ index: true }]),
+        navOrder: 20,
+      },
+    };
+
+    const apps = buildRegisteredAppsFromBundleMap(bundleMap);
+
+    expect(apps.map((a) => a.id)).toEqual(['alpha', 'beta-a', 'beta-b', 'gamma']);
+  });
+});


### PR DESCRIPTION
## Summary

- Rewrites `apps/pops-shell/src/app/installed-modules.ts` and `apps/pops-shell/src/app/nav/registry.ts` to derive from a registry walk over a single workspace bundle map. Closes audit H4 (`KNOWN_FRONTEND_MANIFESTS` literal) and H5 (`registeredApps` literal) per PRD-243 US-03.
- New `apps/pops-shell/src/app/bundle-map.ts` is the lone seam where the shell still enumerates in-repo pillar ids. Each entry binds the pillar's `ModuleManifest` (from its `@pops/app-*` package) to a `navOrder` mirroring the reconciled `nav.order` scheme delivered by PRs #3235 + #3236 + the in-flight reconciliation (`finance=10, media=20, inventory=30, food=40, lists=50, cerebrum=60, ai=70`).
- External pillars (PRD-228) that arrive via `assetsBaseUrl` but have no bundle map entry hit `ExternalUiLoadingNotImplementedError`, get a one-line `console.warn`, and are skipped — the US-05 stub branch. Backend-only ids (`core`) with no bundle entry drop silently, matching pre-PR behaviour.
- App-rail observable order is preserved: `registeredApps.map((a) => a.id)` is still `[finance, media, inventory, food, lists, cerebrum, ai]`. Pinned by a new test in `nav/registry.test.ts`.

## Chain

- US-01 schema: PR #3230
- US-02 per-pillar contributions: PRs #3235 / #3236
- Order reconciliation: in-flight (`core=0`, sparse 10/20/30/40/50/60/70)
- US-03 (this PR): registry walk in the shell, closes audit H4/H5
- US-04 integration test: separate PR (covers M7 migration)
- US-05 external UI loading: separate stub PRD

## Tests

- `apps/pops-shell/src/app/registry-walk.test.ts` (new, 6 cases): synthetic registry with 2 pillars, frontend.routes preservation, no-nav skip, `assetsBaseUrl` US-05 stub branch, error type identity, ordering with lexicographic tiebreak.
- `apps/pops-shell/src/app/nav/registry.test.ts`: new parity gate pins the seven-entry pre-PR order.
- Existing 494 shell tests pass unchanged (501 total).

## Test plan

- [x] `pnpm --filter @pops/shell test` (501 passed)
- [x] `pnpm --filter @pops/shell build`
- [x] `pnpm typecheck` (73 tasks, all green)
- [x] `pnpm lint` (no new warnings; the two pre-existing `no-underscore-dangle` on `__set/__reset` predate this PR)
- [ ] Manual smoke: open the dev server and confirm the app rail renders the same seven entries in the same order.

## Out of scope

- US-04 integration test (synthetic in-repo pillar mounts) — needs this PR's rewrite first.
- US-05 external UI loading mechanism — separate stub PRD.
- `apps/pops-shell/src/tests/manifests.test.ts` migration (audit M7) — lands with US-04.
- Per-pillar manifest tweaks (US-02 territory).
