### PR TITLE
test(shell): PRD-243 US-04 integration — synthetic pillar mounts via registry (closes audit M7)

### DIFF
--- a/apps/pops-shell/src/tests/manifests.test.ts
+++ b/apps/pops-shell/src/tests/manifests.test.ts
@@ -1,30 +1,43 @@
+/**
+ * PRD-098/099 frontend module manifests — structural validation.
+ *
+ * PRD-243 US-04 migrated this test off the per-pillar named-import literal
+ * (audit finding M7). The manifest set is now derived from
+ * `installedFrontendManifests()` — the same registry-walk getter the
+ * shell uses at boot — so adding a new in-repo pillar requires no edit
+ * here.
+ */
 import { describe, expect, it } from 'vitest';
 
-import { manifest as aiManifest } from '@pops/app-ai';
-import { manifest as cerebrumManifest } from '@pops/app-cerebrum';
-import { manifest as financeManifest } from '@pops/app-finance';
-import { manifest as foodManifest } from '@pops/app-food';
-import { manifest as inventoryManifest } from '@pops/app-inventory';
-import { manifest as listsManifest } from '@pops/app-lists';
-import { manifest as mediaManifest } from '@pops/app-media';
-import { manifest as egoManifest } from '@pops/overlay-ego';
 import { assertModuleManifest, type ModuleManifest } from '@pops/types';
 
-const pageRoutedApps: ReadonlyArray<readonly [string, ModuleManifest]> = [
-  ['ai', aiManifest],
-  ['cerebrum', cerebrumManifest],
-  ['finance', financeManifest],
-  ['food', foodManifest],
-  ['inventory', inventoryManifest],
-  ['lists', listsManifest],
-  ['media', mediaManifest],
-];
+import { installedFrontendManifests } from '../app/installed-modules';
 
-const overlayModules: ReadonlyArray<readonly [string, ModuleManifest]> = [['ego', egoManifest]];
+type LabelledManifest = readonly [string, ModuleManifest];
 
-const allManifests = [...pageRoutedApps, ...overlayModules];
+function labelled(manifests: readonly ModuleManifest[]): LabelledManifest[] {
+  return manifests.map((m) => [m.id, m] as const);
+}
+
+const allManifests: LabelledManifest[] = labelled(installedFrontendManifests());
+
+const pageRoutedApps: LabelledManifest[] = allManifests.filter(
+  ([, m]) => m.surfaces.includes('app') && Array.isArray(m.frontend?.routes)
+);
+
+const overlayModules: LabelledManifest[] = allManifests.filter(([, m]) =>
+  m.surfaces.includes('overlay')
+);
 
 describe('PRD-098/099 frontend module manifests', () => {
+  it('the registry walk surfaces at least one installed manifest', () => {
+    expect(allManifests.length).toBeGreaterThan(0);
+  });
+
+  it('the registry walk surfaces at least one page-routed app', () => {
+    expect(pageRoutedApps.length).toBeGreaterThan(0);
+  });
+
   it.each(allManifests)('%s manifest is structurally valid', (label, m) => {
     expect(() => assertModuleManifest(m, label)).not.toThrow();
   });

--- a/apps/pops-shell/src/tests/synthetic-pillar.integration.test.tsx
+++ b/apps/pops-shell/src/tests/synthetic-pillar.integration.test.tsx
@@ -1,0 +1,182 @@
+/**
+ * PRD-243 US-04 — registry-driven shell UI integration test.
+ *
+ * Closes audit M7. Proves the lego: a synthetic pillar that ships
+ * **no** patch to `WORKSPACE_BUNDLE_MAP`, `installed-modules.ts`,
+ * `nav/registry.ts`, the router, or any real `@pops/app-*` package
+ * still flows through the shell's registry walk and mounts:
+ *
+ *   - its `nav.navConfig` into the app rail (via `buildRegisteredAppsFromBundleMap`),
+ *   - its `frontend.routes` into the route tree (via `walkRegistry`),
+ *   - and gets withdrawn when the registry entry / bundle map entry is
+ *     dropped — the same shell code does the deregistration walk.
+ *
+ * The synthetic pillar's manifest, nav config, route fixture, and bundle
+ * entry are all declared **inline in this test file**, so the test would
+ * fail if any of those structures required a per-pillar source edit.
+ */
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Outlet, Route, Routes } from 'react-router';
+import { describe, expect, it } from 'vitest';
+
+import { WORKSPACE_BUNDLE_MAP, type BundleEntry } from '../app/bundle-map';
+import {
+  hasRoutes,
+  walkRegistry,
+  type FrontendManifest,
+  type RegistryEntry,
+} from '../app/installed-modules';
+import { buildRegisteredAppsFromBundleMap } from '../app/nav/registry';
+
+import type { RouteObject } from 'react-router';
+
+import type { AppNavConfig } from '../app/nav/types';
+
+const SYNTHETIC_ID = 'synthetic-foo';
+const SYNTHETIC_BASE_PATH = `/${SYNTHETIC_ID}`;
+const SYNTHETIC_NAV_ORDER = 25;
+
+function SyntheticPage() {
+  return <div data-testid="synthetic-page">synthetic</div>;
+}
+
+const SYNTHETIC_NAV: AppNavConfig = {
+  id: SYNTHETIC_ID,
+  label: 'Synthetic Foo',
+  labelKey: SYNTHETIC_ID,
+  icon: 'Bot',
+  basePath: SYNTHETIC_BASE_PATH,
+  items: [
+    {
+      path: '',
+      label: 'Home',
+      labelKey: `${SYNTHETIC_ID}.home`,
+      icon: 'LayoutDashboard',
+    },
+  ],
+};
+
+const SYNTHETIC_ROUTES: RouteObject[] = [{ index: true, element: <SyntheticPage /> }];
+
+const SYNTHETIC_MANIFEST: FrontendManifest = {
+  id: SYNTHETIC_ID,
+  name: 'Synthetic Foo',
+  surfaces: ['app'],
+  frontend: {
+    routes: SYNTHETIC_ROUTES,
+    navConfig: SYNTHETIC_NAV,
+  },
+};
+
+const SYNTHETIC_BUNDLE_ENTRY: BundleEntry = {
+  manifest: SYNTHETIC_MANIFEST,
+  navOrder: SYNTHETIC_NAV_ORDER,
+};
+
+function bundleMapWithSynthetic(): Record<string, BundleEntry> {
+  return { ...WORKSPACE_BUNDLE_MAP, [SYNTHETIC_ID]: SYNTHETIC_BUNDLE_ENTRY };
+}
+
+function registryEntriesForBundleMap(bundleMap: Record<string, BundleEntry>): RegistryEntry[] {
+  return Object.keys(bundleMap).map((pillarId) => ({ pillarId }));
+}
+
+function mountManifestRoutes(manifest: FrontendManifest, initialPath: string): void {
+  if (!hasRoutes(manifest)) {
+    throw new Error(`synthetic manifest missing frontend.routes — test fixture is invalid`);
+  }
+  render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Routes>
+        <Route path={manifest.id} element={<Outlet />}>
+          {manifest.frontend.routes.map((route) => (
+            <Route
+              key={route.path ?? (route.index ? '__index__' : 'unknown')}
+              index={route.index}
+              path={route.path}
+              element={route.element}
+            />
+          ))}
+        </Route>
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('PRD-243 US-04 — synthetic pillar mounts via registry (audit M7)', () => {
+  it('app rail nav surfaces the synthetic pillar at the navOrder-derived position', () => {
+    const apps = buildRegisteredAppsFromBundleMap(bundleMapWithSynthetic());
+    const ids = apps.map((app) => app.id);
+
+    expect(ids).toContain(SYNTHETIC_ID);
+
+    const realOrder = ['finance', 'media', 'inventory', 'food', 'lists', 'cerebrum', 'ai'];
+    expect(ids).toEqual([
+      'finance',
+      'media',
+      SYNTHETIC_ID,
+      'inventory',
+      'food',
+      'lists',
+      'cerebrum',
+      'ai',
+    ]);
+    expect(realOrder.every((id) => ids.includes(id))).toBe(true);
+  });
+
+  it('registry walk emits the synthetic manifest with its frontend.routes preserved', () => {
+    const bundleMap = bundleMapWithSynthetic();
+    const manifests = walkRegistry(registryEntriesForBundleMap(bundleMap), bundleMap);
+
+    const synthetic = manifests.find((m) => m.id === SYNTHETIC_ID);
+    expect(synthetic).toBeDefined();
+    expect(synthetic && hasRoutes(synthetic)).toBe(true);
+    expect(synthetic?.frontend?.routes).toHaveLength(1);
+  });
+
+  it('routing under the synthetic basePath renders the fixture page (registry → router)', () => {
+    const bundleMap = bundleMapWithSynthetic();
+    const manifests = walkRegistry(registryEntriesForBundleMap(bundleMap), bundleMap);
+    const synthetic = manifests.find((m) => m.id === SYNTHETIC_ID);
+    if (synthetic === undefined) throw new Error('synthetic manifest not produced by walk');
+
+    mountManifestRoutes(synthetic, SYNTHETIC_BASE_PATH);
+
+    expect(screen.getByTestId('synthetic-page')).toHaveTextContent('synthetic');
+  });
+
+  it('deregistering the synthetic pillar removes nav + manifest from the shell walk', () => {
+    const withSynthetic = bundleMapWithSynthetic();
+    const withSyntheticIds = buildRegisteredAppsFromBundleMap(withSynthetic).map((a) => a.id);
+    expect(withSyntheticIds).toContain(SYNTHETIC_ID);
+
+    const withoutSynthetic = { ...withSynthetic };
+    delete withoutSynthetic[SYNTHETIC_ID];
+
+    const apps = buildRegisteredAppsFromBundleMap(withoutSynthetic);
+    const manifests = walkRegistry(registryEntriesForBundleMap(withoutSynthetic), withoutSynthetic);
+
+    expect(apps.map((a) => a.id)).not.toContain(SYNTHETIC_ID);
+    expect(manifests.map((m) => m.id)).not.toContain(SYNTHETIC_ID);
+  });
+
+  it('synthetic registry entry without a bundle slot logs the US-05 stub and skips (no crash)', () => {
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (message: unknown) => {
+      warnings.push(String(message));
+    };
+    try {
+      const entries: RegistryEntry[] = [
+        { pillarId: SYNTHETIC_ID, assetsBaseUrl: 'https://cdn.example.com/synthetic-foo/' },
+      ];
+      const manifests = walkRegistry(entries, {});
+
+      expect(manifests).toHaveLength(0);
+      expect(warnings.some((m) => m.includes('external UI loading not implemented'))).toBe(true);
+      expect(warnings.some((m) => m.includes(SYNTHETIC_ID))).toBe(true);
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Adds an integration test (`apps/pops-shell/src/tests/synthetic-pillar.integration.test.tsx`) that registers a **synthetic in-repo pillar** (`synthetic-foo`) into a bundle map and asserts the shell's registry walk mounts its nav entry and routes through its `basePath` — **without** editing any production source file: `WORKSPACE_BUNDLE_MAP`, `installed-modules.ts`, `nav/registry.ts`, the router, or any `@pops/app-*` package.
- Migrates `apps/pops-shell/src/tests/manifests.test.ts` off the per-pillar named-import literal (the M7 finding from the pillar isolation audit) to iterate over `installedFrontendManifests()` — the same registry-walk getter the shell boots from.

This is the lego proof for PR #3241 (US-03): a fresh pillar joining only via the registry walk shows up in the app rail, mounts its routes, and disappears when removed from the registry.

## Integration cases (5)

1. App rail nav surfaces the synthetic pillar at the `navOrder`-derived position relative to the in-repo pillars: `finance, media, <synthetic>, inventory, food, lists, cerebrum, ai`.
2. `walkRegistry()` emits the synthetic manifest with `frontend.routes` preserved.
3. Routing under `/synthetic-foo` renders the inline `<div data-testid="synthetic-page">synthetic</div>` fixture — the registry → router seam wires end-to-end.
4. Removing the synthetic entry from the bundle map drops both nav and manifest. No source edit required.
5. Synthetic registry entry advertising `assetsBaseUrl` without a bundle slot falls into the US-05 `ExternalUiLoadingNotImplementedError` stub branch — logs once, skips, no crash.

## "No source edit needed" proof

The synthetic manifest, nav config, routes, and bundle entry are declared inline inside the test file. `git diff origin/main..HEAD` touches exactly two files, both under `apps/pops-shell/src/tests/`. The production bundle map (`WORKSPACE_BUNDLE_MAP`) and every in-repo pillar package are untouched.

## References

- US-04 spec: `docs/themes/13-pillar-finale/prds/243-registry-driven-shell-ui/us-04-integration-test.md`
- PR #3241 — US-03 shell rewrite (the SUT)
- #3215 — pillar isolation audit M7 finding (closed)

## Test plan

- [x] `pnpm --filter @pops/shell test` — 508 passing (was 501 before this PR: +5 integration cases, +2 net in the migrated `manifests.test.ts`)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (no new errors; warnings unchanged)
- [x] Husky `pre-commit` (lint-staged: oxlint + oxfmt) ran clean on commit
- [x] Husky `pre-push` (`pnpm typecheck`) ran clean on push