### PR TITLE
docs(theme-13): scoping PRD-244 cross-pillar SDK surface (unblocks app-ai + app-finance batch 2)

### DIFF
--- a/docs/themes/13-pillar-finale/epics/10-fe-sdk-dispatcher-generator.md
+++ b/docs/themes/13-pillar-finale/epics/10-fe-sdk-dispatcher-generator.md
@@ -25,6 +25,7 @@ Make the front-end registry-aware end-to-end. Three pieces:
 | 241 | Registry-driven `known-modules`       | Replace `MANIFEST_SOURCES` literal in `packages/module-registry/scripts/known-modules.ts` with workspace discovery over `@pops/*-contract` packages; closes audit H1; strict predecessor to PRD-218          | Not started                                                                                       |
 | 242 | Dynamic `AppRouter` composition       | Replace the hand-curated `KNOWN_ROUTERS` literal in `apps/pops-api/src/router.ts` with a workspace-scan codegen catalogue + runtime `mergeRouters` over PRD-228 externals; closes pillar-isolation audit H3  | Not started                                                                                       |
 | 243 | Registry-driven shell UI aggregation  | Replace shell's hand-curated `installed-modules.ts` + `nav/registry.ts` with a registry walk; add `nav` / `pages` / `assetsBaseUrl` manifest dimensions; closes audit H4 + H5 + M7                           | Not started                                                                                       |
+| 244 | Cross-pillar SDK surface              | Unblock `app-ai` (14 sites) + `app-finance` batch 2 (23 sites) using `pillar('core').*` (Option A); post-mortem decides whether `crossPillarQuery` (Option B) ships in a successor PRD                       | Not started                                                                                       |
 
 ## Dependencies
 

--- a/docs/themes/13-pillar-finale/prds/244-cross-pillar-sdk-surface/README.md
+++ b/docs/themes/13-pillar-finale/prds/244-cross-pillar-sdk-surface/README.md
@@ -1,0 +1,293 @@
+# PRD-244: Cross-pillar SDK surface (unblock app-ai + app-finance batch 2)
+
+> Epic: [FE pillar SDK + dispatcher generator](../../epics/10-fe-sdk-dispatcher-generator.md)
+>
+> Status: **Not started** — scoping PRD. Decisive recommendation: ship Option A
+> (typed proxy in a loop) for the immediate unblock; Option B / C only if pain
+> materialises.
+
+## Overview
+
+PRD-227's consumer-migration wave moved most `app-*` packages onto the per-pillar
+SDK surface. Two consumers remain blocked because they are **entirely
+cross-pillar**, and the SDK affordances added in PRD-227 (the typed `pillar()`
+proxy, `fetchQuery`, `usePillarQueries`, `setData` / `invalidate`,
+`PillarCallError` discriminants) all assume **single-pillar** call sites:
+
+- **`app-ai` — 0 / 14 sites migrated.** Every call is `trpc.core.ai*`-shaped.
+  `app-ai` is a front-end for the cross-pillar AI surface (budgets, providers,
+  usage, observability, cache) — it is not its own pillar. See
+  [app-ai-consumer-inventory](../../notes/app-ai-consumer-inventory.md) (PR
+  [#3146](https://github.com/knoxio/pops/pull/3146)).
+- **`app-finance` batch 2 — 23 deferred sites.** The trivial pillar-local 24
+  sites migrated in PRD-227's `app-finance` batch 1 (see
+  [app-finance-consumer-inventory](../../notes/app-finance-consumer-inventory.md));
+  the remaining 23 hit `trpc.core.{corrections,tagRules,entities}` from a
+  `finance`-shaped surface and have no first-class cross-pillar SDK affordance
+  today.
+
+The SDK has no first-class "give me a typed builder that aggregates calls across
+pillars" surface. Existing options are:
+
+- **Typed proxy** — `pillar('core').<router>.<proc>(input)` works for a single
+  call but offers no orchestration (parallel fan-out, tuple-typed result,
+  combined error discrimination).
+- **`callDynamic`** ([PR
+  #3131](https://github.com/knoxio/pops/pull/3131)) — works for external
+  pillars but loses end-to-end typing for known in-repo pillars. The typed
+  proxy is the right tool when the target pillar is in-repo (see
+  [internal-vs-external-pillar-call-sites](../../notes/internal-vs-external-pillar-call-sites.md)
+  shipped by PRD-242 US-05).
+
+PRD-244 scopes the design decision. The honest framing: this is a "do the
+boring thing first" PRD. The big affordance only ships if the boring thing
+hurts.
+
+## Background
+
+PRD-227's audit was scoped per `app-*` package and per single-pillar router.
+The audit doc + the PRD-227 surface delivered:
+
+- A typed `pillar(id)` proxy for single calls (`pillar('finance').wishlist.list(...)`).
+- Hook surfaces (`usePillarQuery`, `usePillarMutation`, `usePillarQueries`,
+  `useUtils()`) all keyed by **one** `pillarId`.
+- `PillarCallError` discriminants ([PR
+  #3170](https://github.com/knoxio/pops/pull/3170)) for typed error handling
+  per pillar.
+- A developer-facing note ([PR
+  #3242](https://github.com/knoxio/pops/pull/3242)) explaining typed-proxy vs
+  `callDynamic` — but only for the in-repo vs external split, not for the
+  cross-pillar fan-out case.
+
+What it did **not** cover: a consumer that needs to call **across pillar
+boundaries** as a unit. `app-ai` is that consumer in pure form (every call
+is `core.ai*`). `app-finance` batch 2 is that consumer in mixed form (some
+sites pull `core.entities.list` alongside a `finance.transactions.list`
+mutation in the same hook).
+
+Neither case requires new orchestration in the SDK to function — both work
+today with a `pillar('core').*` call (or two) per hook. The question is
+whether the SDK should offer a higher-level "aggregate across pillars"
+surface, or whether the typed proxy is enough.
+
+## Options Considered
+
+### Option A — Nothing new. Consumers call `pillar('core').*` directly (RECOMMENDED)
+
+Consumers issue one `pillar('core').<router>.<proc>(input)` call per site
+(or two, where the site mixes `core` + `finance`). For the React-hook sites,
+`usePillarQuery('core', ['ai-usage', 'getStats'], input)` is the existing
+PRD-227 surface — it just gets pointed at `core` instead of a pillar-local
+namespace.
+
+- **Pro.** Zero new SDK surface. PRD-227 is closed; no further additions to
+  the type machinery. Aligns with the "case-by-case" rule from PRD-227 sign-off.
+- **Pro.** Unblocks `app-ai` (14 sites) and `app-finance` batch 2 (23 sites)
+  immediately. Both packages can drop `@pops/api-client` after the swap.
+- **Pro.** Honest scoping — if no pain materialises, no affordance is built.
+  The big affordance is the kind of thing that grows tentacles; deferring it
+  until a real call site demands it is cheaper than designing speculatively.
+- **Con.** Multi-call sites (e.g. `useRuleFormState.ts` reads
+  `core.corrections.createOrUpdate` + `core.entities.list` in the same hook)
+  re-issue two independent queries with two separate loading / error states.
+  The consumer hand-rolls the `isLoading = aLoading || bLoading` aggregation.
+- **Con.** No typed "combined error" — each call surfaces its own
+  `PillarCallError`; the caller assembles a union by hand.
+- **Con.** Cache-invalidation chains that cross routers (PR
+  [#3146](https://github.com/knoxio/pops/pull/3146) audit flagged nine
+  `app-finance` files using `trpc.useUtils()` to invalidate sibling queries
+  across `finance` and `core`) become two `utils.invalidate()` calls instead
+  of one. Minor ergonomic loss, no correctness loss.
+
+### Option B — New `crossPillarQuery({ calls: [...] })` fan-out affordance
+
+A new SDK surface that fans calls out in parallel across pillars and returns
+a tuple of typed results:
+
+```ts
+const [usage, providers] = await crossPillarQuery({
+  calls: [
+    { pillarId: 'core', path: ['aiUsage', 'getStats'], input: { period: 'day' } },
+    { pillarId: 'core', path: ['aiProviders', 'list'], input: undefined },
+  ],
+});
+```
+
+Shape rhymes with `usePillarQueries` ([PR
+[#3177](https://github.com/knoxio/pops/pull/3177)) but across pillar
+boundaries. Returns a typed tuple, surfaces a combined `PillarCallError`
+union, and exposes a single `isLoading` / `isFetching` for the React-hook
+flavour.
+
+- **Pro.** Real ergonomic win for the cross-pillar multi-call sites
+  (`useRuleFormState.ts`, `useTagRuleMutations.ts` and similar). One hook
+  call replaces two, error handling is consolidated.
+- **Pro.** Parallel fan-out is structural — easier to reason about than
+  hand-rolled `Promise.all`.
+- **Con.** New SDK surface. Type machinery is non-trivial (typed-tuple
+  inference across heterogeneous `pillarId` × `path` keys). PRD-227 declared
+  further SDK additions case-by-case; this is one such case but the case
+  must be made by real pain, not speculation.
+- **Con.** Most `app-ai` sites (10 / 14) are single-call. Only the multi-call
+  sites benefit. The 14-site migration unblocks `app-ai` whether or not
+  Option B exists.
+
+### Option C — Cross-pillar pipeline (output of A feeds input of B)
+
+A pipeline / saga-style affordance:
+
+```ts
+const result = await crossPillarPipeline()
+  .step('entities', { pillarId: 'core', path: ['entities', 'list'] })
+  .step('proposal', (ctx) => ({
+    pillarId: 'core',
+    path: ['corrections', 'analyzeCorrection'],
+    input: { entityId: ctx.entities[0].id },
+  }))
+  .run();
+```
+
+- **Pro.** Expresses dependent cross-pillar workflows directly.
+- **Con.** Substantial design and type-machinery surface. No call site in
+  the deferred audits actually needs this — every site in
+  `app-ai-consumer-inventory.md` and the `core.*` section of
+  `app-finance-consumer-inventory.md` is an independent fan-out, not a
+  dependent pipeline.
+- **Con.** Tempting to build because it's interesting; expensive to maintain
+  because it's a DSL. Defer unless a real call site demands it.
+
+### Recommendation
+
+**Option A.** It's the only option that unblocks the deferred consumers
+without new SDK surface or speculative design. PRD-227's case-by-case rule
+applies: Option B is justified by aggregate pain that doesn't exist yet, and
+Option C is a DSL with no current consumer.
+
+US-03 is the explicit post-mortem checkpoint: after US-01 and US-02 ship, if
+the multi-call sites are demonstrably worse off, a successor PRD scopes
+Option B. If they're not, the affordance never ships and that's the right
+outcome.
+
+## Surface
+
+PRD-244 ships **no new code** in the SDK. All consumer changes use the
+existing PRD-227 surface.
+
+| Surface                                                                 | Used by                                                                                     | Status                       |
+| ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- | ---------------------------- |
+| `pillar('core').<router>.<proc>(input)` typed proxy                     | Node consumers in `app-ai` test utilities (if any)                                          | Existing — PRD-191 / PRD-227 |
+| `usePillarQuery('core', [...], input)` / `usePillarMutation('core', …)` | Every React-hook call site in `app-ai` and the 23 deferred `app-finance` cross-pillar sites | Existing — PRD-193 / PRD-215 |
+| `usePillarQueries({ queries: [{ pillarId: 'core', … }, …] })`           | Multi-call sites (where the consumer wants a single loading / error state)                  | Existing — PR #3177          |
+| `PillarCallError` discriminants                                         | Error-handling branches in the migrated sites                                               | Existing — PR #3170          |
+| `crossPillarQuery` / `crossPillarPipeline`                              | Out of scope. Successor PRD only if US-03 post-mortem surfaces a real need.                 | Not built                    |
+
+After the migration, `packages/app-ai/package.json` and
+`packages/app-finance/package.json` no longer list `@pops/api-client` as a
+dependency (US-04). The PRD-227 retirement-of-`@pops/api-client` line item
+gets one more box checked.
+
+## Business Rules
+
+- **No new SDK surface in PRD-244.** Every consumer change is mechanical:
+  swap `trpc.core.<router>.<proc>.useQuery(input)` for
+  `usePillarQuery('core', ['<router>', '<proc>'], input)` (or the mutation
+  equivalent). No type machinery extensions.
+- **Cross-pillar invalidation chains split into per-pillar
+  `utils.invalidate()` calls.** Where an `app-finance` site today calls
+  `utils.core.corrections.invalidate()` and
+  `utils.finance.transactions.invalidate()` in one hook, the migrated site
+  calls each on its respective pillar's `useUtils()`. No unified-cross-pillar
+  utils surface is introduced.
+- **Tests flip mocks from `@pops/api-client` to the SDK module name.**
+  Existing per-site mocks become per-pillar SDK mocks. No dual-mock state.
+- **US-03 is non-optional.** The post-mortem must be authored even if the
+  conclusion is "Option A was enough, no successor PRD." A documented
+  decision is the deliverable.
+- **No retroactive `@pops/api-client` re-introduction.** Once US-04 removes
+  the dependency from `packages/app-ai/package.json` and
+  `packages/app-finance/package.json`, any future cross-pillar call uses the
+  SDK surface or `callDynamic` — never `@pops/api-client`. This keeps the
+  PRD-218 retirement path clean.
+
+## Edge Cases
+
+| Case                                                                                                                                | Behaviour                                                                                                                                                                                                                                |
+| ----------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| A multi-call `app-finance` site (e.g. `useRuleFormState.ts`) reads `core.corrections.*` + `core.entities.list` in the same hook     | Two independent `usePillarQuery('core', …)` calls. The hook aggregates `isLoading` and error state by hand. Documented as the pattern in US-02; flagged as a candidate Option B pain point in US-03.                                     |
+| A migrated site needs to invalidate both `core.corrections.list` and `finance.transactions.list` after a mutation                   | Two `utils.invalidate()` calls — one on `usePillarUtils('core')`, one on `usePillarUtils('finance')`. No unified surface.                                                                                                                |
+| One pillar's call succeeds, the other fails                                                                                         | Each call surfaces its own `PillarCallError`. The consumer's UI either renders partial data or escalates. Same shape as any two independent `usePillarQuery` calls.                                                                      |
+| `app-ai`'s cache-management page consolidation (the `useCacheManagementModel.ts` + `useCacheCardModel.ts` duplicate noted in #3146) | Out of scope for PRD-244 — the audit flagged duplication; consolidation is its own follow-up. PRD-244 migrates both files as-is. The duplication does not block the SDK swap.                                                            |
+| Post-mortem (US-03) finds Option B is warranted                                                                                     | Successor PRD scopes the surface, named at the time it's filed. PRD-244 closes regardless — the work is done, the verdict is recorded.                                                                                                   |
+| Post-mortem finds Option B is **not** warranted                                                                                     | PRD-244 closes with the recorded decision. Future cross-pillar consumers (if any) follow the Option A pattern. No SDK changes.                                                                                                           |
+| `@pops/api-client` removal in US-04 reveals a test file or fixture still importing it                                               | The test is migrated (mocks flip to the SDK module) or removed if obsolete. The dependency drop only lands once `pnpm --filter @pops/app-ai typecheck/test/build` and `pnpm --filter @pops/app-finance typecheck/test/build` pass clean. |
+| A future cross-pillar consumer outside `app-ai` / `app-finance` lands before US-03                                                  | The new consumer follows Option A. US-03's post-mortem includes it in the pain-assessment. The post-mortem is not gated on the count of sites — three migrated packages is enough signal.                                                |
+
+## User Stories
+
+| #   | Story                                                                         | Summary                                                                                                                                                       | Parallelisable             |
+| --- | ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- |
+| 01  | [us-01-app-ai-migration](us-01-app-ai-migration.md)                           | Migrate `app-ai`'s 14 sites to `pillar('core').*` / `usePillarQuery('core', …)`. End-to-end unblock for `app-ai`.                                             | Yes — independent of US-02 |
+| 02  | [us-02-app-finance-batch-2-migration](us-02-app-finance-batch-2-migration.md) | Migrate `app-finance` batch 2's 23 cross-pillar sites (`core.{corrections,tagRules,entities}.*`) to `usePillarQuery('core', …)` and the mutation equivalents. | Yes — independent of US-01 |
+| 03  | [us-03-post-mortem](us-03-post-mortem.md)                                     | Author a post-mortem after US-01 + US-02 land. Verdict: ship Option B (scope successor PRD) or close the cross-pillar question (decision recorded).           | Blocked by US-01 + US-02   |
+| 04  | [us-04-drop-api-client-dependency](us-04-drop-api-client-dependency.md)       | Drop `@pops/api-client` from `packages/app-ai/package.json` and `packages/app-finance/package.json` once the migrations are clean. Update lockfile.           | Blocked by US-01 + US-02   |
+
+US-01 and US-02 are fully independent — different packages, different
+target files, different test surfaces. They can ship in parallel PRs. US-03
+and US-04 only land once the two migration PRs are merged.
+
+## Acceptance Criteria
+
+Tracked per-US — summary here for orientation:
+
+- All 14 `app-ai` call sites listed in
+  [app-ai-consumer-inventory.md](../../notes/app-ai-consumer-inventory.md)
+  use `usePillarQuery('core', …)` or `usePillarMutation('core', …)`. No
+  `trpc.core.ai*` reference remains under `packages/app-ai/src/`.
+- All 23 deferred `app-finance` cross-pillar sites listed in
+  [app-finance-consumer-inventory.md](../../notes/app-finance-consumer-inventory.md)
+  (the `trpc.core.*` table) use the SDK surface. No `trpc.core.*` reference
+  remains under `packages/app-finance/src/`.
+- `packages/app-ai/package.json` and `packages/app-finance/package.json` no
+  longer list `@pops/api-client` as a dependency. `pnpm-lock.yaml` updated.
+- A post-mortem note exists under `docs/themes/13-pillar-finale/notes/`
+  recording the cross-pillar SDK decision (ship Option B or close the
+  question).
+- `pnpm --filter @pops/app-ai typecheck/test/build`,
+  `pnpm --filter @pops/app-finance typecheck/test/build`, and the full
+  monorepo `pnpm typecheck`, `pnpm lint`, `pnpm build` pass clean.
+- Husky pre-commit + pre-push pass without `--no-verify`.
+
+## Out of Scope
+
+- **Option B (`crossPillarQuery`) implementation.** Successor PRD only if
+  US-03's post-mortem makes the case. PRD-244 explicitly does not design or
+  prototype this surface.
+- **Option C (`crossPillarPipeline`).** Deferred unless a real dependent
+  cross-pillar workflow surfaces. None exists in the inventories.
+- **Any new SDK type machinery.** PRD-227 is closed; further additions are
+  case-by-case. PRD-244 ships zero SDK changes.
+- **Consolidating `app-ai`'s `useCacheManagementModel.ts` /
+  `useCacheCardModel.ts` duplication.** Flagged by the audit; out of scope
+  here. Track separately if it becomes a problem.
+- **Type-only `@pops/api/modules/**` imports.\*\* Those are PRD-227 / contract
+  package territory; PRD-244 only addresses call-site swaps.
+- **Migrating any consumer outside `app-ai` and `app-finance`.** Other
+  packages are either already on the SDK (PRD-227 wave 4) or out of scope
+  for this PRD.
+- **Per-pillar SDK ai-surface packages** (e.g. a hypothetical
+  `@pops/ai-sdk`). The AI surface stays on `pillar('core').ai*` because the
+  AI procedures live on the `core` pillar per ADR-035. Splitting them off
+  is a separate architectural question.
+
+## References
+
+- [app-ai-consumer-inventory](../../notes/app-ai-consumer-inventory.md) — the 14-site audit (PR [#3146](https://github.com/knoxio/pops/pull/3146))
+- [app-finance-consumer-inventory](../../notes/app-finance-consumer-inventory.md) — the 23-site cross-pillar deferred set (PR [#3146](https://github.com/knoxio/pops/pull/3146))
+- [PRD-227](../227-sdk-consumer-migration-audit/README.md) — SDK consumer migration audit (the parent migration programme)
+- [PRD-242 US-05](../242-dynamic-approuter/us-05-developer-doc-typed-vs-calldynamic.md) + [internal-vs-external-pillar-call-sites](../../notes/internal-vs-external-pillar-call-sites.md) — the typed-proxy vs `callDynamic` split (in-repo vs external)
+- PR [#3131](https://github.com/knoxio/pops/pull/3131) — `callDynamic` escape hatch
+- PR [#3170](https://github.com/knoxio/pops/pull/3170) — typed `PillarCallError` discriminants
+- PR [#3177](https://github.com/knoxio/pops/pull/3177) — `usePillarQueries` (single-pillar fan-out — the shape Option B would rhyme with)
+- PR [#3242](https://github.com/knoxio/pops/pull/3242) — typed-proxy vs `callDynamic` developer doc
+- [ADR-035](../../../../architecture/adr-035-pillar-redefinition-and-implicit-kinds.md) — pillar redefinition; AI surface lives on `core`
+- `packages/pillar-sdk/src/client/proxy.ts:26-72` — `CallDynamicFn` definition (cross-references for the post-mortem)

--- a/docs/themes/13-pillar-finale/prds/244-cross-pillar-sdk-surface/us-01-app-ai-migration.md
+++ b/docs/themes/13-pillar-finale/prds/244-cross-pillar-sdk-surface/us-01-app-ai-migration.md
@@ -1,0 +1,52 @@
+# US-01: Migrate `app-ai` (14 sites) onto `pillar('core').*` SDK surface
+
+> PRD: [PRD-244 — Cross-pillar SDK surface](README.md)
+
+## Description
+
+As an `app-ai` consumer, I want every `trpc.core.ai*` call site swapped to the
+existing PRD-227 SDK surface (`usePillarQuery('core', …)` /
+`usePillarMutation('core', …)`) so that `app-ai` ships without depending on
+`@pops/api-client` and the cross-pillar AI surface is consumed through the
+same affordance as every other pillar.
+
+## Acceptance Criteria
+
+- [ ] Every call site listed in [app-ai-consumer-inventory.md](../../notes/app-ai-consumer-inventory.md) is migrated:
+  - [ ] `pages/AiUsagePage.tsx` — 3× `core.aiObservability.{getStats,getHistory,getQualityMetrics}` on `usePillarQuery('core', …)`.
+  - [ ] `pages/cache-management/useCacheManagementModel.ts` — 4× `core.aiUsage.{clearStaleCache,clearAllCache,cacheStats,getStats}` on the SDK surface.
+  - [ ] `pages/ai-usage/cache-management/useCacheCardModel.ts` — 3× `core.aiUsage.{clearStaleCache,clearAllCache,cacheStats}` on the SDK surface.
+  - [ ] `pages/ai-usage/budget-status-section.tsx` — 1× `core.aiBudgets.getBudgetStatus` on `usePillarQuery('core', …)`.
+  - [ ] `pages/ai-usage/provider-status-section.tsx` — 2× `core.aiProviders.{list,healthCheck}` on `usePillarQuery('core', …)`.
+  - [ ] `pages/ai-usage/latency-section.tsx` — 1× `core.aiObservability.getLatencyStats` on `usePillarQuery('core', …)`.
+- [ ] No `trpc.core.ai*` reference remains under `packages/app-ai/src/`.
+- [ ] No import of `@pops/api-client` remains under `packages/app-ai/src/`. The
+      `package.json` dependency drop is US-04's deliverable; this US removes
+      the source-code references so US-04 can land cleanly.
+- [ ] `trpc.useUtils()` invalidation chains (the 3 files flagged in the audit)
+      switch to `usePillarUtils('core').invalidate(['<router>', '<proc>'])`
+      where applicable. No cross-pillar utils surface is introduced — each
+      invalidation targets `core`.
+- [ ] Test mocks under `packages/app-ai/src/` flip from mocking
+      `@pops/api-client` to mocking the SDK module per the existing PRD-227
+      pattern (see `app-inventory` migration in PR
+      [#3146](https://github.com/knoxio/pops/pull/3146) for the reference shape).
+- [ ] `pnpm --filter @pops/app-ai typecheck/test/build` passes clean.
+- [ ] Husky pre-commit + pre-push pass without `--no-verify`.
+
+## Notes
+
+- All 14 sites are Medium-bucket in the audit. No optimistic updates, no
+  suspense queries, no infinite queries — the migration is mechanical.
+- The duplication between `useCacheManagementModel.ts` and
+  `useCacheCardModel.ts` is **not** consolidated in this US. The audit
+  flagged it as a follow-up; PRD-244 migrates both as-is. Track consolidation
+  separately if it becomes a problem.
+- The AI surface lives on `core` per ADR-035 — do not invent a
+  `@pops/ai-sdk` or split it off into its own pillar. The pillarId is
+  literally `'core'` for every call in this US.
+- The Wave-4 reference migration for the SDK swap shape lives in PR
+  [#3055](https://github.com/knoxio/pops/pull/3055) (`NudgeIndicator`
+  canary) and the recent batched migrations in PR
+  [#3146](https://github.com/knoxio/pops/pull/3146).
+- Worktree quirk: `pnpm install --frozen-lockfile` before husky.

--- a/docs/themes/13-pillar-finale/prds/244-cross-pillar-sdk-surface/us-02-app-finance-batch-2-migration.md
+++ b/docs/themes/13-pillar-finale/prds/244-cross-pillar-sdk-surface/us-02-app-finance-batch-2-migration.md
@@ -1,0 +1,65 @@
+# US-02: Migrate `app-finance` batch 2 (23 cross-pillar sites) onto `pillar('core').*`
+
+> PRD: [PRD-244 — Cross-pillar SDK surface](README.md)
+
+## Description
+
+As an `app-finance` consumer, I want the 23 deferred cross-pillar call sites
+(`trpc.core.{corrections,tagRules,entities}.*`) swapped to the existing
+PRD-227 SDK surface (`usePillarQuery('core', …)` /
+`usePillarMutation('core', …)`) so that `app-finance` ships without depending
+on `@pops/api-client` and the remaining batch-2 work from PRD-227 is closed.
+
+## Acceptance Criteria
+
+- [ ] Every cross-pillar site listed in [app-finance-consumer-inventory.md](../../notes/app-finance-consumer-inventory.md) under the `trpc.core.*` (Medium, 23) section is migrated:
+  - [ ] `pages/entities/useEntitiesPage.ts` — `core.entities.{create,update,delete,list}`.
+  - [ ] `pages/rules-browser/useRulesBrowserModel.ts` — `core.corrections.{delete,list}`.
+  - [ ] `pages/rules-browser/rule-form/useRuleFormState.ts` — `core.corrections.{createOrUpdate,update}`, `core.entities.list`.
+  - [ ] `pages/rules-browser/rule-form/useRulePreview.ts` — `core.corrections.previewMatches`.
+  - [ ] `pages/transactions/useTransactionsPage.ts` — `core.entities.list`.
+  - [ ] `components/ConfidenceSlider.tsx` — `core.corrections.adjustConfidence`.
+  - [ ] `components/imports/RulePicker.tsx` — `core.corrections.list`.
+  - [ ] `components/imports/hooks/useProposalGeneration.ts` — `core.corrections.analyzeCorrection`.
+  - [ ] `components/imports/hooks/usePreviewEffects.ts` — `core.corrections.previewChangeSet`.
+  - [ ] `components/imports/hooks/useApplyRejectMutations.ts` — `core.corrections.{rejectChangeSet,reviseChangeSet}`.
+  - [ ] `components/imports/hooks/bulk-assignment/use-accept.ts` — `core.entities.list`.
+  - [ ] `components/imports/tag-rule-dialog/useTagRuleProposal.ts` — `core.tagRules.proposeTagRuleChangeSet`.
+  - [ ] `components/imports/tag-rule-dialog/useTagRuleMutations.ts` — `core.tagRules.{applyTagRuleChangeSet,rejectTagRuleChangeSet}`.
+  - [ ] `components/imports/correction-proposal/rule-manager/useBrowseRules.ts` — `core.corrections.listMerged`.
+  - [ ] `components/imports/correction-proposal/workflow/useWorkflowHooks.ts` — `core.corrections.proposeChangeSet`.
+- [ ] No `trpc.core.*` reference remains under `packages/app-finance/src/`.
+- [ ] No import of `@pops/api-client` remains under `packages/app-finance/src/`.
+      The `package.json` dependency drop is US-04's deliverable.
+- [ ] Cross-pillar `utils.invalidate()` chains in the 9 audit-flagged
+      `useUtils()` files split per pillar: `usePillarUtils('finance')` for
+      `finance.*` invalidations and `usePillarUtils('core')` for `core.*`
+      invalidations. Two `utils.invalidate()` calls in one hook is the
+      expected shape; no unified-cross-pillar utils surface is introduced.
+- [ ] Multi-call sites (`useRuleFormState.ts` reads `core.corrections.*` +
+      `core.entities.list` in the same hook) are migrated as two independent
+      `usePillarQuery('core', …)` calls. `isLoading` / error aggregation is
+      hand-rolled per the Option A convention. These sites are explicitly
+      flagged in US-03's post-mortem.
+- [ ] Type-only imports from `@pops/api/modules/core/**` remain — PRD-244 only
+      addresses call-site swaps. The contract-package re-export work is
+      tracked by PRD-227 / PRD-153 separately.
+- [ ] Test mocks flip from `@pops/api-client` to the SDK module per the
+      existing PRD-227 pattern.
+- [ ] `pnpm --filter @pops/app-finance typecheck/test/build` passes clean.
+- [ ] Husky pre-commit + pre-push pass without `--no-verify`.
+
+## Notes
+
+- The 24 pillar-local `trpc.finance.*` sites are already on the SDK from
+  PRD-227's batch 1 (see PR
+  [#3146](https://github.com/knoxio/pops/pull/3146)). This US only touches
+  the 23 deferred cross-pillar sites — leave the migrated batch-1 sites
+  alone.
+- No optimistic updates, no suspense, no infinite queries — same shape as
+  US-01. Mechanical migration.
+- `useRuleFormState.ts` is the cleanest multi-call site to flag in the US-03
+  post-mortem: if the hook ends up with three `usePillarQuery` calls and a
+  hand-rolled `isLoading = a || b || c`, that's the Option B evidence. If it
+  reads naturally, Option A wins.
+- Worktree quirk: `pnpm install --frozen-lockfile` before husky.

--- a/docs/themes/13-pillar-finale/prds/244-cross-pillar-sdk-surface/us-03-post-mortem.md
+++ b/docs/themes/13-pillar-finale/prds/244-cross-pillar-sdk-surface/us-03-post-mortem.md
@@ -1,0 +1,53 @@
+# US-03: Post-mortem — does Option B (cross-pillar aggregation) need to ship?
+
+> PRD: [PRD-244 — Cross-pillar SDK surface](README.md)
+
+## Description
+
+As the maintainer of the cross-pillar consumption surface, I want a recorded
+verdict — after US-01 (`app-ai`) and US-02 (`app-finance` batch 2) have landed
+— on whether the Option B `crossPillarQuery` affordance is worth scoping into
+a successor PRD, so that the decision is documented instead of carried in
+head.
+
+## Acceptance Criteria
+
+- [ ] A note exists at
+      `docs/themes/13-pillar-finale/notes/cross-pillar-sdk-post-mortem.md` (or
+      an equivalent path inside `docs/themes/13-pillar-finale/notes/`).
+- [ ] The note records the count of multi-call cross-pillar sites observed in
+      the US-01 + US-02 migrations (the hand-rolled `isLoading = a || b`
+      pattern). Cites exact files.
+- [ ] The note records the count of cross-pillar `utils.invalidate()` chains
+      that required two SDK calls instead of one. Cites exact files.
+- [ ] The note assesses developer-experience pain on a small scale
+      (e.g. "fine / annoying / blocking") with concrete evidence — not a vibe
+      check.
+- [ ] The note delivers a verdict:
+  - **Ship Option B.** Scope successor PRD, name it inline. Identify the
+    one or two affordances that hurt most (likely
+    `usePillarQueries({ queries: [{ pillarId, … }, …] })` extended to
+    heterogeneous `pillarId`).
+  - **OR close the question.** Option A is enough. Future cross-pillar
+    consumers follow the same pattern. No successor PRD.
+- [ ] The note is linked from this PRD's `## Status` section, from PRD-227's
+      references, and from the cross-pillar SDK section of the FE-SDK epic
+      (epic 10).
+- [ ] The note is < 1 page (per `docs/CLAUDE.md`'s sizing rule).
+- [ ] Husky pre-commit + pre-push pass without `--no-verify`.
+
+## Notes
+
+- This US is **not optional** even when the verdict is "close the question."
+  The recorded decision is the deliverable; an undocumented "we decided not
+  to" is worth less than a documented one.
+- US-03 cannot start until US-01 and US-02 are both merged. The whole point
+  is to look at the migrated code, not at the audit doc.
+- If US-03's verdict is "ship Option B," the successor PRD is filed in this
+  US's wrap-up comment with a number reserved at the time. Do not pre-allocate
+  the number here.
+- Resist the urge to design Option B in this US. The deliverable is a
+  verdict, not a spec. If the verdict is "ship it," the successor PRD does
+  the design work.
+- Use the PRD-227 sign-off pattern (a short note, decisive language, no
+  hand-waving) as the template.

--- a/docs/themes/13-pillar-finale/prds/244-cross-pillar-sdk-surface/us-04-drop-api-client-dependency.md
+++ b/docs/themes/13-pillar-finale/prds/244-cross-pillar-sdk-surface/us-04-drop-api-client-dependency.md
@@ -1,0 +1,40 @@
+# US-04: Drop `@pops/api-client` from `app-ai` + `app-finance` `package.json`
+
+> PRD: [PRD-244 — Cross-pillar SDK surface](README.md)
+
+## Description
+
+As the maintainer of the PRD-218 retirement path for `@pops/api-client`, I
+want the dependency removed from `packages/app-ai/package.json` and
+`packages/app-finance/package.json` once US-01 and US-02 have eliminated every
+source-level reference, so that the retirement count moves and a future
+`@pops/api-client` change does not silently affect these packages.
+
+## Acceptance Criteria
+
+- [ ] `packages/app-ai/package.json` no longer lists `@pops/api-client` under
+      `dependencies`, `devDependencies`, or `peerDependencies`.
+- [ ] `packages/app-finance/package.json` no longer lists `@pops/api-client`
+      under `dependencies`, `devDependencies`, or `peerDependencies`.
+- [ ] `pnpm-lock.yaml` is regenerated and committed with the dependency drop.
+- [ ] `grep -rn "@pops/api-client" packages/app-ai packages/app-finance`
+      returns zero results.
+- [ ] `pnpm --filter @pops/app-ai typecheck/test/build` and
+      `pnpm --filter @pops/app-finance typecheck/test/build` pass clean
+      against the post-drop tree.
+- [ ] Full monorepo `pnpm typecheck`, `pnpm lint`, `pnpm build` pass clean.
+- [ ] Husky pre-commit + pre-push pass without `--no-verify`.
+
+## Notes
+
+- Cannot land until US-01 **and** US-02 are merged. The dependency drop is
+  a no-op safety check, not a migration step.
+- Worktree quirk: `pnpm install --frozen-lockfile` for husky; expect to
+  re-run `pnpm install` without the flag after editing the `package.json` to
+  regenerate the lockfile, then commit the lockfile alongside the manifest
+  change.
+- If the post-drop typecheck surfaces a test file or fixture still importing
+  `@pops/api-client`, that file was missed by US-01 / US-02 — go back and
+  migrate or remove it. Do not add the dependency back.
+- Verify the `@pops/api-client` retirement tracker (the PRD-218 / PRD-227
+  list of consumers) reflects the drop. Two more boxes checked.


### PR DESCRIPTION
## Summary

- Scopes PRD-244 (cross-pillar SDK surface) — unblocks `app-ai` (14 sites) and `app-finance` batch 2 (23 sites). Both consumers are entirely cross-pillar; PRD-227's SDK affordances assumed single-pillar call sites and didn't cover the fan-out case (see [PR #3146](https://github.com/knoxio/pops/pull/3146)'s `app-ai` + `app-finance` consumer inventories).
- Decisive recommendation: **Option A — call `pillar('core').*` directly via the existing PRD-227 surface.** No new SDK code. Option B (`crossPillarQuery` aggregation) is documented and deferred to a successor PRD only if US-03's post-mortem demonstrates real pain. Option C (cross-pillar pipeline) is deferred unless a real dependent workflow surfaces.
- User stories (4): US-01 `app-ai` migration, US-02 `app-finance` batch 2 migration, US-03 post-mortem with verdict, US-04 drop `@pops/api-client` dependency.
- Honest framing: "do the boring thing first" PRD. The big affordance only ships if the boring thing hurts.

References: PRD-227, [PR #3146](https://github.com/knoxio/pops/pull/3146) (consumer inventories), [PR #3131](https://github.com/knoxio/pops/pull/3131) (`callDynamic`), [PR #3170](https://github.com/knoxio/pops/pull/3170) (`PillarCallError` discriminants), [PR #3242](https://github.com/knoxio/pops/pull/3242) (typed-proxy vs `callDynamic` developer doc), ADR-035.

## Test plan

- [ ] Reviewer reads PRD-244 README and confirms Option A is the right call for the immediate unblock.
- [ ] Reviewer confirms US-01 / US-02 acceptance criteria match the `app-ai` + `app-finance` inventories from PR #3146.
- [ ] Reviewer confirms US-03 captures the right post-mortem signal (multi-call sites + cross-pillar invalidation chain counts).
- [ ] Reviewer confirms US-04 sequences after US-01 + US-02 with the right safety gate (`grep` returns zero results + typecheck/test/build clean).
- [ ] Epic 10 PRD table includes PRD-244.
