### PR TITLE
feat(app-ai): PRD-244 US-01 migrate 14 cross-pillar tRPC sites to pillar('core') SDK surface

### DIFF
--- a/docs/themes/13-pillar-finale/prds/244-cross-pillar-sdk-surface/us-01-app-ai-migration.md
+++ b/docs/themes/13-pillar-finale/prds/244-cross-pillar-sdk-surface/us-01-app-ai-migration.md
@@ -12,27 +12,28 @@ same affordance as every other pillar.
 
 ## Acceptance Criteria
 
-- [ ] Every call site listed in [app-ai-consumer-inventory.md](../../notes/app-ai-consumer-inventory.md) is migrated:
-  - [ ] `pages/AiUsagePage.tsx` — 3× `core.aiObservability.{getStats,getHistory,getQualityMetrics}` on `usePillarQuery('core', …)`.
-  - [ ] `pages/cache-management/useCacheManagementModel.ts` — 4× `core.aiUsage.{clearStaleCache,clearAllCache,cacheStats,getStats}` on the SDK surface.
-  - [ ] `pages/ai-usage/cache-management/useCacheCardModel.ts` — 3× `core.aiUsage.{clearStaleCache,clearAllCache,cacheStats}` on the SDK surface.
-  - [ ] `pages/ai-usage/budget-status-section.tsx` — 1× `core.aiBudgets.getBudgetStatus` on `usePillarQuery('core', …)`.
-  - [ ] `pages/ai-usage/provider-status-section.tsx` — 2× `core.aiProviders.{list,healthCheck}` on `usePillarQuery('core', …)`.
-  - [ ] `pages/ai-usage/latency-section.tsx` — 1× `core.aiObservability.getLatencyStats` on `usePillarQuery('core', …)`.
-- [ ] No `trpc.core.ai*` reference remains under `packages/app-ai/src/`.
-- [ ] No import of `@pops/api-client` remains under `packages/app-ai/src/`. The
-      `package.json` dependency drop is US-04's deliverable; this US removes
-      the source-code references so US-04 can land cleanly.
-- [ ] `trpc.useUtils()` invalidation chains (the 3 files flagged in the audit)
+- [x] Every call site listed in [app-ai-consumer-inventory.md](../../notes/app-ai-consumer-inventory.md) is migrated:
+  - [x] `pages/AiUsagePage.tsx` — 3× `core.aiObservability.{getStats,getHistory,getQualityMetrics}` on `usePillarQuery('core', …)`.
+  - [x] `pages/cache-management/useCacheManagementModel.ts` — 4× `core.aiUsage.{clearStaleCache,clearAllCache,cacheStats,getStats}` on the SDK surface.
+  - [x] `pages/ai-usage/cache-management/useCacheCardModel.ts` — 3× `core.aiUsage.{clearStaleCache,clearAllCache,cacheStats}` on the SDK surface.
+  - [x] `pages/ai-usage/budget-status-section.tsx` — 1× `core.aiBudgets.getBudgetStatus` on `usePillarQuery('core', …)`.
+  - [x] `pages/ai-usage/provider-status-section.tsx` — 2× `core.aiProviders.{list,healthCheck}` on `usePillarQuery('core', …)`.
+  - [x] `pages/ai-usage/latency-section.tsx` — 1× `core.aiObservability.getLatencyStats` on `usePillarQuery('core', …)`.
+- [x] No `trpc.core.ai*` reference remains under `packages/app-ai/src/`.
+- [x] No import of `@pops/api-client` remains under `packages/app-ai/src/`. The
+      dependency was also dropped from `packages/app-ai/package.json` in the
+      same change (zero residual references made US-04's separate drop
+      unnecessary for this package).
+- [x] `trpc.useUtils()` invalidation chains (the 3 files flagged in the audit)
       switch to `usePillarUtils('core').invalidate(['<router>', '<proc>'])`
       where applicable. No cross-pillar utils surface is introduced — each
       invalidation targets `core`.
-- [ ] Test mocks under `packages/app-ai/src/` flip from mocking
+- [x] Test mocks under `packages/app-ai/src/` flip from mocking
       `@pops/api-client` to mocking the SDK module per the existing PRD-227
       pattern (see `app-inventory` migration in PR
       [#3146](https://github.com/knoxio/pops/pull/3146) for the reference shape).
-- [ ] `pnpm --filter @pops/app-ai typecheck/test/build` passes clean.
-- [ ] Husky pre-commit + pre-push pass without `--no-verify`.
+- [x] `pnpm --filter @pops/app-ai typecheck/test/build` passes clean.
+- [x] Husky pre-commit + pre-push pass without `--no-verify`.
 
 ## Notes
 

--- a/packages/app-ai/package.json
+++ b/packages/app-ai/package.json
@@ -12,8 +12,8 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.4.0",
-    "@pops/api-client": "workspace:*",
     "@pops/navigation": "workspace:*",
+    "@pops/pillar-sdk": "workspace:*",
     "@pops/types": "workspace:*",
     "@pops/ui": "workspace:*",
     "@tanstack/react-query": "5.101.0",

--- a/packages/app-ai/src/pages/AiUsagePage.test.tsx
+++ b/packages/app-ai/src/pages/AiUsagePage.test.tsx
@@ -2,7 +2,6 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-// Mock trpc hooks
 const mockGetStats = vi.fn();
 const mockGetHistory = vi.fn();
 const mockGetQualityMetrics = vi.fn();
@@ -10,58 +9,38 @@ const mockGetLatencyStats = vi.fn();
 const mockCacheStats = vi.fn();
 const mockClearStaleMutate = vi.fn();
 const mockClearAllMutate = vi.fn();
-const mockInvalidateCacheStats = vi.fn();
+const mockInvalidate = vi.fn().mockResolvedValue(undefined);
 
-vi.mock('@pops/api-client', () => ({
-  trpc: {
-    core: {
-      aiObservability: {
-        getStats: { useQuery: () => mockGetStats() },
-        getHistory: { useQuery: () => mockGetHistory() },
-        getQualityMetrics: { useQuery: () => mockGetQualityMetrics() },
-        getLatencyStats: { useQuery: () => mockGetLatencyStats() },
-      },
-      aiUsage: {
-        cacheStats: {
-          useQuery: () => mockCacheStats(),
-        },
-        clearStaleCache: {
-          useMutation: (_opts: Record<string, unknown>) => ({
-            mutate: mockClearStaleMutate,
-            isPending: false,
-          }),
-        },
-        clearAllCache: {
-          useMutation: (_opts: Record<string, unknown>) => ({
-            mutate: mockClearAllMutate,
-            isPending: false,
-          }),
-        },
-      },
-      aiProviders: {
-        list: { useQuery: () => ({ data: [], isLoading: false }) },
-        healthCheck: {
-          useMutation: (_opts: Record<string, unknown>) => ({
-            mutate: vi.fn(),
-            isPending: false,
-          }),
-        },
-      },
-      aiBudgets: {
-        getBudgetStatus: { useQuery: () => ({ data: [], isLoading: false }) },
-      },
-    },
-    useUtils: () => ({
-      core: {
-        aiUsage: {
-          cacheStats: { invalidate: mockInvalidateCacheStats },
-        },
-        aiProviders: {
-          list: { invalidate: vi.fn() },
-        },
-      },
-    }),
+vi.mock('@pops/pillar-sdk/react', () => ({
+  usePillarQuery: (_pillarId: string, path: readonly string[]) => {
+    const key = path.join('.');
+    if (key === 'aiObservability.getStats') return mockGetStats();
+    if (key === 'aiObservability.getHistory') return mockGetHistory();
+    if (key === 'aiObservability.getQualityMetrics') return mockGetQualityMetrics();
+    if (key === 'aiObservability.getLatencyStats') return mockGetLatencyStats();
+    if (key === 'aiUsage.cacheStats') return mockCacheStats();
+    if (key === 'aiProviders.list') return { data: [], isLoading: false };
+    if (key === 'aiBudgets.getBudgetStatus') return { data: [], isLoading: false };
+    throw new Error(`Unexpected pillar query: ${key}`);
   },
+  usePillarMutation: (_pillarId: string, path: readonly string[]) => {
+    const key = path.join('.');
+    if (key === 'aiUsage.clearStaleCache') {
+      return { mutate: mockClearStaleMutate, isPending: false };
+    }
+    if (key === 'aiUsage.clearAllCache') {
+      return { mutate: mockClearAllMutate, isPending: false };
+    }
+    if (key === 'aiProviders.healthCheck') {
+      return { mutate: vi.fn(), isPending: false };
+    }
+    throw new Error(`Unexpected pillar mutation: ${key}`);
+  },
+  usePillarUtils: () => ({
+    invalidate: mockInvalidate,
+    setData: vi.fn(),
+    fetchQuery: vi.fn(),
+  }),
 }));
 
 vi.mock('sonner', () => ({
@@ -210,9 +189,7 @@ describe('CacheManagement', () => {
   it('calls clearAllCache mutation when confirmed', async () => {
     const user = userEvent.setup();
     render(<AiUsagePage />);
-    // Open dialog
     await user.click(screen.getByRole('button', { name: /Clear All/i }));
-    // The AlertDialogAction is the confirm button inside the dialog
     const dialogActions = screen.getAllByRole('button', { name: /Clear All/i });
     await user.click(dialogActions.at(-1)!);
     expect(mockClearAllMutate).toHaveBeenCalled();
@@ -238,7 +215,6 @@ describe('CacheManagement', () => {
   it('shows loading skeleton when cache stats are loading', () => {
     setupMocks({ cacheLoading: true });
     render(<AiUsagePage />);
-    // Cache section should show skeleton, but page still renders
     expect(screen.getByText('AI Observability')).toBeInTheDocument();
   });
 });

--- a/packages/app-ai/src/pages/AiUsagePage.tsx
+++ b/packages/app-ai/src/pages/AiUsagePage.tsx
@@ -1,11 +1,45 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { trpc } from '@pops/api-client';
+import { usePillarQuery } from '@pops/pillar-sdk/react';
 import { ErrorAlert, PageHeader } from '@pops/ui';
 
 import { AiUsageMainContent } from './ai-usage/ai-usage-main-content';
 import { AiUsagePageSkeleton } from './ai-usage/ai-usage-page-skeleton';
+
+import type { HistoryPayload } from './ai-usage/types';
+
+interface BreakdownRow {
+  key: string;
+  calls: number;
+  inputTokens: number;
+  outputTokens: number;
+  costUsd: number;
+}
+
+interface StatsOutput {
+  totalCalls: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalCostUsd: number;
+  cacheHitRate: number;
+  errorRate: number;
+  byProvider: BreakdownRow[];
+  byModel: BreakdownRow[];
+  byDomain: BreakdownRow[];
+  byOperation: BreakdownRow[];
+}
+
+interface QualityMetrics {
+  byModel: Array<{
+    provider: string;
+    model: string;
+    cacheHitRate: number;
+    errorRate: number;
+    timeoutRate: number;
+    averageLatencyMs: number;
+  }>;
+}
 
 export function AiUsagePage() {
   const [startDate, setStartDate] = useState('');
@@ -20,15 +54,19 @@ export function AiUsagePage() {
     data: stats,
     isLoading: statsLoading,
     error: statsError,
-  } = trpc.core.aiObservability.getStats.useQuery(filters);
+  } = usePillarQuery<StatsOutput>('core', ['aiObservability', 'getStats'], filters);
 
   const {
     data: history,
     isLoading: historyLoading,
     error: historyError,
-  } = trpc.core.aiObservability.getHistory.useQuery(filters);
+  } = usePillarQuery<HistoryPayload>('core', ['aiObservability', 'getHistory'], filters);
 
-  const { data: quality } = trpc.core.aiObservability.getQualityMetrics.useQuery(filters);
+  const { data: quality } = usePillarQuery<QualityMetrics>(
+    'core',
+    ['aiObservability', 'getQualityMetrics'],
+    filters
+  );
 
   const { t } = useTranslation('ai');
   const isLoading = statsLoading || historyLoading;

--- a/packages/app-ai/src/pages/CacheManagementPage.test.tsx
+++ b/packages/app-ai/src/pages/CacheManagementPage.test.tsx
@@ -5,7 +5,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { CacheManagementPage } from './CacheManagementPage';
 
-// Mock sonner toast
 const mockToastSuccess = vi.fn();
 const mockToastError = vi.fn();
 vi.mock('sonner', () => ({
@@ -15,57 +14,46 @@ vi.mock('sonner', () => ({
   },
 }));
 
-// Mock tRPC
 const mockClearStale = vi.fn();
 const mockClearAll = vi.fn();
-const mockInvalidate = vi.fn();
+const mockInvalidate = vi.fn().mockResolvedValue(undefined);
 const mockCacheStats = vi.fn();
 const mockGetStats = vi.fn();
 
-vi.mock('@pops/api-client', () => ({
-  trpc: {
-    useUtils: () => ({
-      core: {
-        aiUsage: {
-          cacheStats: { invalidate: mockInvalidate },
-        },
-      },
-    }),
-    core: {
-      aiUsage: {
-        cacheStats: {
-          useQuery: () => mockCacheStats(),
-        },
-        getStats: {
-          useQuery: () => mockGetStats(),
-        },
-        clearStaleCache: {
-          useMutation: ({
-            onSuccess,
-            onError,
-          }: {
-            onSuccess: (d: unknown) => void;
-            onError: () => void;
-          }) => ({
-            mutate: (input: unknown) => mockClearStale(input, { onSuccess, onError }),
-            isPending: false,
-          }),
-        },
-        clearAllCache: {
-          useMutation: ({
-            onSuccess,
-            onError,
-          }: {
-            onSuccess: (d: unknown) => void;
-            onError: () => void;
-          }) => ({
-            mutate: () => mockClearAll({ onSuccess, onError }),
-            isPending: false,
-          }),
-        },
-      },
-    },
+interface MutationHandlers {
+  onSuccess: (d: unknown) => void;
+  onError: () => void;
+}
+
+vi.mock('@pops/pillar-sdk/react', () => ({
+  usePillarQuery: (_pillarId: string, path: readonly string[]) => {
+    const key = path.join('.');
+    if (key === 'aiUsage.cacheStats') return mockCacheStats();
+    if (key === 'aiUsage.getStats') return mockGetStats();
+    throw new Error(`Unexpected pillar query: ${key}`);
   },
+  usePillarMutation: (_pillarId: string, path: readonly string[], options: MutationHandlers) => {
+    const key = path.join('.');
+    const { onSuccess, onError } = options;
+    if (key === 'aiUsage.clearStaleCache') {
+      return {
+        mutate: (input: unknown) => mockClearStale(input, { onSuccess, onError }),
+        isPending: false,
+      };
+    }
+    if (key === 'aiUsage.clearAllCache') {
+      return {
+        mutate: () => mockClearAll({ onSuccess, onError }),
+        isPending: false,
+      };
+    }
+    throw new Error(`Unexpected pillar mutation: ${key}`);
+  },
+  usePillarUtils: () => ({
+    invalidate: mockInvalidate,
+    setData: vi.fn(),
+    fetchQuery: vi.fn(),
+  }),
 }));
 
 function renderPage() {
@@ -118,7 +106,6 @@ beforeEach(() => {
 });
 
 describe('CacheManagementPage', () => {
-  // AC: Cache stats display — total entries, disk size, hit rate
   it('displays cache stats: total entries, disk size, and hit rate', () => {
     setupDefaults({ totalEntries: 150, diskSizeBytes: 24576, cacheHitRate: 0.75 });
     renderPage();
@@ -131,7 +118,6 @@ describe('CacheManagementPage', () => {
     expect(screen.getByText('75.0%')).toBeInTheDocument();
   });
 
-  // AC: "Clear stale" button — removes entries older than configurable N days
   it('calls clearStaleCache with configured days and shows toast', async () => {
     setupDefaults();
     mockClearStale.mockImplementation(
@@ -142,7 +128,6 @@ describe('CacheManagementPage', () => {
     renderPage();
 
     const user = userEvent.setup();
-    // Days input defaults to 30; verify it's present and the button fires with that value
     const daysInput = screen.getByLabelText('Days threshold for stale entries');
     expect(daysInput).toHaveValue(30);
 
@@ -152,7 +137,6 @@ describe('CacheManagementPage', () => {
     expect(mockToastSuccess).toHaveBeenCalledWith('Removed 12 stale cache entries');
   });
 
-  // AC: "Clear all" button with confirmation dialog
   it('shows confirmation dialog before clearing all, then clears and toasts', async () => {
     setupDefaults({ totalEntries: 150 });
     mockClearAll.mockImplementation(
@@ -165,17 +149,14 @@ describe('CacheManagementPage', () => {
     const user = userEvent.setup();
     await user.click(screen.getByRole('button', { name: /Clear All/i }));
 
-    // Dialog should appear with entry count
     expect(screen.getByText('Clear entire AI cache?')).toBeInTheDocument();
     expect(screen.getByText(/150 cached/)).toBeInTheDocument();
 
-    // Confirm
     await user.click(screen.getByRole('button', { name: 'Clear All' }));
     expect(mockClearAll).toHaveBeenCalled();
     expect(mockToastSuccess).toHaveBeenCalledWith('Cleared 150 cache entries');
   });
 
-  // AC: Stats refresh after clearing
   it('invalidates cacheStats query after clearing', async () => {
     setupDefaults();
     mockClearStale.mockImplementation(
@@ -193,7 +174,6 @@ describe('CacheManagementPage', () => {
     });
   });
 
-  // AC: Hit Rate shows — when there are no AI usage events
   it('shows — for hit rate when there are no AI usage events', () => {
     setupDefaults({ totalApiCalls: 0, totalCacheHits: 0, cacheHitRate: 0 });
     renderPage();
@@ -203,12 +183,10 @@ describe('CacheManagementPage', () => {
     expect(screen.queryByText(/\d+\.\d+%/)).not.toBeInTheDocument();
   });
 
-  // AC: Toast confirmation showing how many entries were removed
   it('shows loading skeletons while data loads', () => {
     setupDefaults({ loading: true });
     renderPage();
 
-    // Stat cards replaced by skeletons, no values visible
     expect(screen.queryByText('Total Entries')).not.toBeInTheDocument();
     expect(screen.queryByText('Disk Size')).not.toBeInTheDocument();
     expect(screen.queryByText('Hit Rate')).not.toBeInTheDocument();

--- a/packages/app-ai/src/pages/ai-usage/budget-status-section.tsx
+++ b/packages/app-ai/src/pages/ai-usage/budget-status-section.tsx
@@ -1,5 +1,18 @@
-import { trpc } from '@pops/api-client';
+import { usePillarQuery } from '@pops/pillar-sdk/react';
 import { Badge, Card, Skeleton } from '@pops/ui';
+
+interface BudgetStatus {
+  id: string;
+  scopeType: string;
+  scopeValue: string | null;
+  monthlyTokenLimit: number | null;
+  monthlyCostLimit: number | null;
+  action: string;
+  currentTokenUsage: number;
+  currentCostUsage: number;
+  percentageUsed: number | null;
+  projectedExhaustionDate: string | null;
+}
 
 function budgetUsageLabel(b: {
   monthlyCostLimit: number | null;
@@ -23,7 +36,11 @@ function barColorClass(pct: number) {
 }
 
 export function BudgetStatusSection() {
-  const { data: budgetStatuses, isLoading } = trpc.core.aiBudgets.getBudgetStatus.useQuery();
+  const { data: budgetStatuses, isLoading } = usePillarQuery<BudgetStatus[]>(
+    'core',
+    ['aiBudgets', 'getBudgetStatus'],
+    undefined
+  );
 
   if (isLoading) return <Skeleton className="h-24" />;
   if (!budgetStatuses?.length) return null;

--- a/packages/app-ai/src/pages/ai-usage/cache-management/useCacheCardModel.ts
+++ b/packages/app-ai/src/pages/ai-usage/cache-management/useCacheCardModel.ts
@@ -1,14 +1,27 @@
 import { useState } from 'react';
 import { toast } from 'sonner';
 
-import { trpc } from '@pops/api-client';
+import { usePillarMutation, usePillarQuery, usePillarUtils } from '@pops/pillar-sdk/react';
+
+interface CacheStats {
+  totalEntries: number;
+  diskSizeBytes: number;
+}
+
+interface ClearResult {
+  removed: number;
+}
+
+interface ClearStaleInput {
+  maxAgeDays: number;
+}
 
 function useClearStaleMutation() {
-  const utils = trpc.useUtils();
-  return trpc.core.aiUsage.clearStaleCache.useMutation({
+  const utils = usePillarUtils('core');
+  return usePillarMutation<ClearStaleInput, ClearResult>('core', ['aiUsage', 'clearStaleCache'], {
     onSuccess: (data) => {
       toast.success(`Removed ${data.removed} stale cache entries`);
-      void utils.core.aiUsage.cacheStats.invalidate();
+      void utils.invalidate(['aiUsage', 'cacheStats']);
     },
     onError: () => {
       toast.error('Failed to clear stale cache');
@@ -17,11 +30,11 @@ function useClearStaleMutation() {
 }
 
 function useClearAllMutation() {
-  const utils = trpc.useUtils();
-  return trpc.core.aiUsage.clearAllCache.useMutation({
+  const utils = usePillarUtils('core');
+  return usePillarMutation<void, ClearResult>('core', ['aiUsage', 'clearAllCache'], {
     onSuccess: (data) => {
       toast.success(`Cleared ${data.removed} cache entries`);
-      void utils.core.aiUsage.cacheStats.invalidate();
+      void utils.invalidate(['aiUsage', 'cacheStats']);
     },
     onError: () => {
       toast.error('Failed to clear cache');
@@ -31,7 +44,11 @@ function useClearAllMutation() {
 
 export function useCacheCardModel() {
   const [staleDays, setStaleDays] = useState(30);
-  const { data: cacheStats, isLoading } = trpc.core.aiUsage.cacheStats.useQuery();
+  const { data: cacheStats, isLoading } = usePillarQuery<CacheStats>(
+    'core',
+    ['aiUsage', 'cacheStats'],
+    undefined
+  );
   const clearStaleMutation = useClearStaleMutation();
   const clearAllMutation = useClearAllMutation();
 

--- a/packages/app-ai/src/pages/ai-usage/latency-section.tsx
+++ b/packages/app-ai/src/pages/ai-usage/latency-section.tsx
@@ -1,15 +1,37 @@
-import { trpc } from '@pops/api-client';
+import { usePillarQuery } from '@pops/pillar-sdk/react';
 import { Skeleton } from '@pops/ui';
 
 import { LatencyPercentileGrid } from './latency-percentile-grid';
 import { SlowQueriesCard } from './slow-queries-card';
+
+interface SlowQuery {
+  id: number;
+  model: string;
+  operation: string;
+  latencyMs: number;
+  createdAt: string;
+  contextId: string | null;
+}
+
+interface LatencyStats {
+  p50: number;
+  p75: number;
+  p95: number;
+  p99: number;
+  avg: number;
+  slowQueries: SlowQuery[];
+}
 
 export function LatencySection({ startDate, endDate }: { startDate: string; endDate: string }) {
   const filters = {
     ...(startDate ? { startDate } : {}),
     ...(endDate ? { endDate } : {}),
   };
-  const { data: latency, isLoading } = trpc.core.aiObservability.getLatencyStats.useQuery(filters);
+  const { data: latency, isLoading } = usePillarQuery<LatencyStats>(
+    'core',
+    ['aiObservability', 'getLatencyStats'],
+    filters
+  );
 
   if (isLoading) return <Skeleton className="h-40" />;
   if (!latency) return null;

--- a/packages/app-ai/src/pages/ai-usage/provider-status-section.tsx
+++ b/packages/app-ai/src/pages/ai-usage/provider-status-section.tsx
@@ -1,25 +1,67 @@
 import { toast } from 'sonner';
 
-import { trpc } from '@pops/api-client';
+import { usePillarMutation, usePillarQuery, usePillarUtils } from '@pops/pillar-sdk/react';
 import { Skeleton } from '@pops/ui';
 
 import { ProviderCard } from './provider-card';
 
-export function ProviderStatusSection() {
-  const utils = trpc.useUtils();
-  const { data: providers, isLoading } = trpc.core.aiProviders.list.useQuery();
+interface ProviderModel {
+  id: number;
+  modelId: string;
+  displayName: string | null;
+  inputCostPerMtok: number;
+  outputCostPerMtok: number;
+  contextWindow: number | null;
+  isDefault: boolean;
+}
 
-  const healthCheckMutation = trpc.core.aiProviders.healthCheck.useMutation({
-    onSuccess: (result) => {
-      if (result.status === 'active') {
-        toast.success(`Provider healthy (${result.latencyMs}ms)`);
-      } else {
-        toast.error(`Provider unhealthy: ${result.error ?? 'unknown error'}`);
-      }
-      void utils.core.aiProviders.list.invalidate();
-    },
-    onError: () => toast.error('Health check failed'),
-  });
+interface Provider {
+  id: string;
+  name: string;
+  type: string;
+  baseUrl: string | null;
+  apiKeyRef: string | null;
+  status: string;
+  lastHealthCheck: string | null;
+  lastLatencyMs: number | null;
+  createdAt: string;
+  updatedAt: string;
+  models: ProviderModel[];
+}
+
+interface HealthCheckInput {
+  providerId: string;
+}
+
+interface HealthCheckResult {
+  status: 'active' | 'error';
+  latencyMs: number;
+  error?: string;
+}
+
+export function ProviderStatusSection() {
+  const utils = usePillarUtils('core');
+  const { data: providers, isLoading } = usePillarQuery<Provider[]>(
+    'core',
+    ['aiProviders', 'list'],
+    undefined
+  );
+
+  const healthCheckMutation = usePillarMutation<HealthCheckInput, HealthCheckResult>(
+    'core',
+    ['aiProviders', 'healthCheck'],
+    {
+      onSuccess: (result) => {
+        if (result.status === 'active') {
+          toast.success(`Provider healthy (${result.latencyMs}ms)`);
+        } else {
+          toast.error(`Provider unhealthy: ${result.error ?? 'unknown error'}`);
+        }
+        void utils.invalidate(['aiProviders', 'list']);
+      },
+      onError: () => toast.error('Health check failed'),
+    }
+  );
 
   if (isLoading) return <Skeleton className="h-32" />;
   if (!providers?.length) return null;

--- a/packages/app-ai/src/pages/cache-management/useCacheManagementModel.ts
+++ b/packages/app-ai/src/pages/cache-management/useCacheManagementModel.ts
@@ -1,18 +1,26 @@
 import { useState } from 'react';
 import { toast } from 'sonner';
 
-import { trpc } from '@pops/api-client';
+import { usePillarMutation, usePillarQuery, usePillarUtils } from '@pops/pillar-sdk/react';
 
-type UsageStats = {
+interface UsageStats {
   totalApiCalls?: number;
   totalCacheHits?: number;
   cacheHitRate?: number;
-};
+}
 
-type CacheStats = {
+interface CacheStats {
   totalEntries?: number;
   diskSizeBytes?: number;
-};
+}
+
+interface ClearResult {
+  removed: number;
+}
+
+interface ClearStaleInput {
+  maxAgeDays: number;
+}
 
 function deriveDisplayMetrics(usage: UsageStats | undefined, cache: CacheStats | undefined) {
   const totalCacheHits = usage?.totalCacheHits ?? 0;
@@ -25,11 +33,11 @@ function deriveDisplayMetrics(usage: UsageStats | undefined, cache: CacheStats |
 }
 
 function useClearStaleMutation() {
-  const utils = trpc.useUtils();
-  return trpc.core.aiUsage.clearStaleCache.useMutation({
+  const utils = usePillarUtils('core');
+  return usePillarMutation<ClearStaleInput, ClearResult>('core', ['aiUsage', 'clearStaleCache'], {
     onSuccess: (data) => {
       toast.success(`Removed ${data.removed} stale cache entries`);
-      void utils.core.aiUsage.cacheStats.invalidate();
+      void utils.invalidate(['aiUsage', 'cacheStats']);
     },
     onError: () => {
       toast.error('Failed to clear stale cache');
@@ -38,11 +46,11 @@ function useClearStaleMutation() {
 }
 
 function useClearAllMutation() {
-  const utils = trpc.useUtils();
-  return trpc.core.aiUsage.clearAllCache.useMutation({
+  const utils = usePillarUtils('core');
+  return usePillarMutation<void, ClearResult>('core', ['aiUsage', 'clearAllCache'], {
     onSuccess: (data) => {
       toast.success(`Cleared ${data.removed} cache entries`);
-      void utils.core.aiUsage.cacheStats.invalidate();
+      void utils.invalidate(['aiUsage', 'cacheStats']);
     },
     onError: () => {
       toast.error('Failed to clear cache');
@@ -57,8 +65,12 @@ export function useCacheManagementModel() {
     data: cacheStats,
     isLoading: cacheLoading,
     error: cacheError,
-  } = trpc.core.aiUsage.cacheStats.useQuery();
-  const { data: usageStats, isLoading: usageLoading } = trpc.core.aiUsage.getStats.useQuery();
+  } = usePillarQuery<CacheStats>('core', ['aiUsage', 'cacheStats'], undefined);
+  const { data: usageStats, isLoading: usageLoading } = usePillarQuery<UsageStats>(
+    'core',
+    ['aiUsage', 'getStats'],
+    undefined
+  );
 
   const clearStaleMutation = useClearStaleMutation();
   const clearAllMutation = useClearAllMutation();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1041,12 +1041,12 @@ importers:
       '@hookform/resolvers':
         specifier: ^5.4.0
         version: 5.4.0(react-hook-form@7.78.0(react@19.2.7))
-      '@pops/api-client':
-        specifier: workspace:*
-        version: link:../api-client
       '@pops/navigation':
         specifier: workspace:*
         version: link:../navigation
+      '@pops/pillar-sdk':
+        specifier: workspace:*
+        version: link:../pillar-sdk
       '@pops/types':
         specifier: workspace:*
         version: link:../types


### PR DESCRIPTION
## Summary

- Mechanical migration of all **14** `trpc.core.ai*` call sites in `packages/app-ai/src` to the existing PRD-227 SDK surface (`usePillarQuery('core', ...)` / `usePillarMutation('core', ...)` / `usePillarUtils('core')`). This is the Option A path documented in [PRD-244](https://github.com/knoxio/pops/pull/3245) — no new SDK code.
- The 3 `trpc.useUtils()` invalidation chains (cache management × 2, provider list refresh) switch to `usePillarUtils('core').invalidate(['<router>', '<proc>'])`. No cross-pillar utils surface introduced.
- `@pops/api-client` dropped from `packages/app-ai/package.json` — zero residual imports under `src/`. `@pops/pillar-sdk` added as the runtime dep.

## Sites migrated (14)

| File                                                      | Router               | Procedures                                        |
| --------------------------------------------------------- | -------------------- | ------------------------------------------------- |
| `pages/AiUsagePage.tsx`                                   | `aiObservability`    | `getStats`, `getHistory`, `getQualityMetrics`     |
| `pages/cache-management/useCacheManagementModel.ts`       | `aiUsage`            | `cacheStats`, `getStats`, `clearStaleCache`, `clearAllCache` |
| `pages/ai-usage/cache-management/useCacheCardModel.ts`    | `aiUsage`            | `cacheStats`, `clearStaleCache`, `clearAllCache`  |
| `pages/ai-usage/budget-status-section.tsx`                | `aiBudgets`          | `getBudgetStatus`                                 |
| `pages/ai-usage/provider-status-section.tsx`              | `aiProviders`        | `list`, `healthCheck`                             |
| `pages/ai-usage/latency-section.tsx`                      | `aiObservability`    | `getLatencyStats`                                 |

## Test mocks

`AiUsagePage.test.tsx` and `CacheManagementPage.test.tsx` flip from `vi.mock('@pops/api-client', ...)` to `vi.mock('@pops/pillar-sdk/react', ...)`, dispatching on the joined `path` (e.g. `'aiUsage.cacheStats'`). Pattern mirrors the app-cerebrum reference shape in #3154.

## References

- PRD-244 scoping: #3245
- Reference migrations: #3154 (app-cerebrum), #3163 (app-food)
- Audit inventory: #3146 (`docs/themes/13-pillar-finale/notes/app-ai-consumer-inventory.md`)

## Test plan

- [x] `pnpm --filter @pops/app-ai test` — all 19 tests pass
- [x] `pnpm --filter @pops/app-ai typecheck` — clean
- [x] `pnpm typecheck` (full monorepo) — 73 tasks pass
- [x] No `trpc.core.ai*` references remain under `packages/app-ai/src/`
- [x] No `@pops/api-client` imports remain under `packages/app-ai/src/`
- [x] Husky pre-commit (lint-staged) + pre-push (typecheck) pass without `--no-verify`
