### PR TITLE
feat(pillar-sdk): PRD-246 US-01 captureOverlay manifest dimension

### DIFF
--- a/packages/pillar-sdk/src/__tests__/schema.test.ts
+++ b/packages/pillar-sdk/src/__tests__/schema.test.ts
@@ -734,4 +734,82 @@ describe('ManifestPayloadSchema', () => {
       }
     );
   });
+
+  describe('captureOverlay dimension (PRD-246 US-01)', () => {
+    const cerebrumCaptureOverlay = () => ({
+      bundleSlot: 'ingest-form',
+      order: 100,
+      hotkey: 'cmd+shift+k',
+      label: 'Capture',
+      labelKey: 'cerebrum.capture',
+    });
+
+    it('accepts a manifest with captureOverlay omitted (backwards-compatible)', () => {
+      const m = validManifest();
+      const result = ManifestPayloadSchema.safeParse(m);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.captureOverlay).toBeUndefined();
+      }
+    });
+
+    it('accepts a manifest with a valid captureOverlay contribution', () => {
+      const m = { ...validManifest(), captureOverlay: cerebrumCaptureOverlay() };
+      const result = ManifestPayloadSchema.safeParse(m);
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts a minimal captureOverlay with only the required fields', () => {
+      const m = {
+        ...validManifest(),
+        captureOverlay: { bundleSlot: 'ingest-form', order: 0 },
+      };
+      const result = ManifestPayloadSchema.safeParse(m);
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects captureOverlay missing the required bundleSlot field', () => {
+      const { bundleSlot: _omitted, ...rest } = cerebrumCaptureOverlay();
+      const m = { ...validManifest(), captureOverlay: rest };
+      const result = ManifestPayloadSchema.safeParse(m);
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects captureOverlay missing the required order field', () => {
+      const { order: _omitted, ...rest } = cerebrumCaptureOverlay();
+      const m = { ...validManifest(), captureOverlay: rest };
+      const result = ManifestPayloadSchema.safeParse(m);
+      expect(result.success).toBe(false);
+    });
+
+    it.each(['IngestForm', 'ingest_form', '-ingest', 'ingest--form'])(
+      'rejects a non-kebab-case bundleSlot (%s)',
+      (bundleSlot) => {
+        const m = {
+          ...validManifest(),
+          captureOverlay: { ...cerebrumCaptureOverlay(), bundleSlot },
+        };
+        const result = ManifestPayloadSchema.safeParse(m);
+        expect(result.success).toBe(false);
+      }
+    );
+
+    it('rejects an empty-string hotkey', () => {
+      const m = {
+        ...validManifest(),
+        captureOverlay: { ...cerebrumCaptureOverlay(), hotkey: '' },
+      };
+      const result = ManifestPayloadSchema.safeParse(m);
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects unknown field on captureOverlay descriptor (strict mode)', () => {
+      const m = {
+        ...validManifest(),
+        captureOverlay: { ...cerebrumCaptureOverlay(), sneaky: true },
+      };
+      const result = ManifestPayloadSchema.safeParse(m);
+      expect(result.success).toBe(false);
+    });
+  });
 });

--- a/packages/pillar-sdk/src/manifest-schema/index.ts
+++ b/packages/pillar-sdk/src/manifest-schema/index.ts
@@ -3,6 +3,7 @@ export {
   type ManifestPayload,
   type SinkDescriptor,
   type SettingsManifestDescriptor,
+  type CaptureOverlayDescriptor,
   type NavConfigDescriptor,
   type NavItemDescriptor,
   type PageDescriptor,

--- a/packages/pillar-sdk/src/manifest-schema/schema.ts
+++ b/packages/pillar-sdk/src/manifest-schema/schema.ts
@@ -3,8 +3,10 @@ import { z } from 'zod';
 import { SettingsBlockSchema, type SettingsManifestDescriptor } from './settings.js';
 import {
   AssetsBaseUrlSchema,
+  CaptureOverlayDescriptorSchema,
   NavConfigDescriptorSchema,
   PageDescriptorSchema,
+  type CaptureOverlayDescriptor,
   type NavConfigDescriptor,
   type NavItemDescriptor,
   type PageDescriptor,
@@ -178,6 +180,7 @@ export const ManifestPayloadSchema = z
     nav: NavConfigDescriptorSchema.optional(),
     pages: z.array(PageDescriptorSchema).optional(),
     assetsBaseUrl: AssetsBaseUrlSchema.optional(),
+    captureOverlay: CaptureOverlayDescriptorSchema.optional(),
     healthcheck: HEALTHCHECK,
   })
   .strict();
@@ -186,6 +189,6 @@ export type SinkDescriptor = z.infer<typeof SINK_DESCRIPTOR>;
 
 export type { SettingsManifestDescriptor };
 
-export type { NavConfigDescriptor, NavItemDescriptor, PageDescriptor };
+export type { CaptureOverlayDescriptor, NavConfigDescriptor, NavItemDescriptor, PageDescriptor };
 
 export type ManifestPayload = z.infer<typeof ManifestPayloadSchema>;

--- a/packages/pillar-sdk/src/manifest-schema/ui.ts
+++ b/packages/pillar-sdk/src/manifest-schema/ui.ts
@@ -64,6 +64,32 @@ export const PageDescriptorSchema = z
  */
 export const AssetsBaseUrlSchema = z.string().url();
 
+/**
+ * Wire-shaped descriptor of a pillar's capture overlay contribution. The
+ * shell discovers overlays through the manifest registry the same way it
+ * discovers `nav` / `pages` (PRD-243) and mounts the React component
+ * resolved from the workspace bundle map at the shell side — no
+ * shell-side edit that names the pillar (PRD-246).
+ *
+ * `bundleSlot` follows the `PageDescriptor.bundleSlot` convention: a
+ * kebab-case identifier the workspace bundle map resolves to a component
+ * reference. `order` mirrors `NavConfigDescriptor.order`: ascending,
+ * ties broken alphabetically by pillar id at the shell. `hotkey` is
+ * wire-shaped (e.g. `'cmd+shift+k'`); semantic validation of the key
+ * combo is the shell's responsibility at bind time. `label` / `labelKey`
+ * pair the same way `NavConfigDescriptor` pairs them.
+ */
+export const CaptureOverlayDescriptorSchema = z
+  .object({
+    bundleSlot: KEBAB_IDENTIFIER,
+    order: z.number().int(),
+    hotkey: z.string().min(1).optional(),
+    label: z.string().min(1).optional(),
+    labelKey: I18N_KEY.optional(),
+  })
+  .strict();
+
 export type NavConfigDescriptor = z.infer<typeof NavConfigDescriptorSchema>;
 export type NavItemDescriptor = z.infer<typeof NAV_ITEM_DESCRIPTOR>;
 export type PageDescriptor = z.infer<typeof PageDescriptorSchema>;
+export type CaptureOverlayDescriptor = z.infer<typeof CaptureOverlayDescriptorSchema>;


### PR DESCRIPTION
## Summary

Extend `ManifestPayloadSchema` with the optional `captureOverlay?: CaptureOverlayDescriptor` dimension so the shell can discover and mount each pillar's capture overlay through the manifest registry — the same way it already discovers `nav` / `pages` (#3230 / PRD-243), `sinks` (PRD-236), and `settings` (PRD-240) — without any shell-side edit that names the pillar.

Implements PRD-246 US-01 — `docs/themes/13-pillar-finale/prds/246-shell-api-pillar-decoupling/us-01-extend-manifest-schema.md`. Spec landed in #3247. Mirrors the PRD-243 US-01 scaffold pattern from #3230.

## Pattern

| | sinks | settings | ui (#3230) | captureOverlay (this PR) |
|---|---|---|---|---|
| Module under `manifest-schema/` | inline in `schema.ts` | `settings.ts` | `ui.ts` | `ui.ts` |
| Top-level schema fields | `sinks?` | `settings?` | `nav?`, `pages?`, `assetsBaseUrl?` | `captureOverlay?` |
| Exported descriptor types | `SinkDescriptor` | `SettingsManifestDescriptor` | `NavConfigDescriptor`, `NavItemDescriptor`, `PageDescriptor` | `CaptureOverlayDescriptor` |

## Descriptor shape

`CaptureOverlayDescriptor`:

- `bundleSlot: string` — kebab-case identifier; the workspace bundle map resolves it to a React component reference. Same convention as `PageDescriptor.bundleSlot`. For in-repo pillars the slot id matches an export name in the pillar's `@pops/app-*` package (today's cerebrum case: `ingest-form`).
- `order: number` — selection order when multiple pillars contribute an overlay. Ascending; ties broken alphabetically by pillar id at the shell. Same shape as `nav.order`.
- `hotkey?: string` — optional wire-shaped keybinding (e.g. `'cmd+shift+k'`); validated as a non-empty string. Semantic validation (key combo parsing) is the shell's responsibility at bind time.
- `label?: string` — optional human-readable label for analytics / debug surfaces.
- `labelKey?: string` — optional i18n key, paired with `label` the way `NavConfigDescriptor` pairs them.

Strict descriptor, wire-format validation only — no behavioural change. The validator surfaces malformed `captureOverlay` payloads through the same `ValidationIssue` shape used for `sinks` / `settings` / `nav` / `pages`.

Backwards compatible: existing manifests without `captureOverlay` parse unchanged.

## Follows up

- US-02 — cerebrum manifest declares its `captureOverlay` (`bundleSlot: 'ingest-form'`).
- US-03 — shell rewrite: `useCaptureOverlay` walks the registry instead of importing `CerebrumIngestForm` directly.
- US-04 — integration test with a synthetic in-repo pillar via registry override.
- US-05 — external-pillar overlay loading via `assetsBaseUrl`.

## Test plan

- [x] `pnpm --filter @pops/pillar-sdk test` — 552 tests pass (was 542; +10 covering omitted block, valid descriptor, minimal required-only descriptor, missing `bundleSlot`, missing `order`, non-kebab `bundleSlot` rejections, empty-string `hotkey`, strict-mode unknown field).
- [x] `pnpm --filter @pops/pillar-sdk build` — clean.
- [x] `pnpm typecheck` — clean across the workspace (73 tasks successful).
- [x] Husky pre-commit (oxlint + oxfmt via lint-staged) and pre-push (typecheck + origin/main conflict check) pass without `--no-verify`.
- [x] Backwards compat: existing fixture manifests and per-pillar `manifest.test.ts` still validate unchanged.
