### PR TITLE
chore(theme-13): batch close small audit findings (L8 manifest-pillar · M9 APP_ORDER)

### DIFF
--- a/apps/pops-shell/src/app/IndexRedirect.test.tsx
+++ b/apps/pops-shell/src/app/IndexRedirect.test.tsx
@@ -71,7 +71,7 @@ describe('IndexRedirect', () => {
     expect(screen.getByTestId('landed')).toHaveTextContent('/finance');
   });
 
-  it('picks the first installed app in APP_ORDER (finance > media > inventory > cerebrum)', () => {
+  it('picks the first installed app by nav.order ascending (finance > media > inventory > food > lists > cerebrum > ai)', () => {
     mocks.query.mockReturnValue(
       queryResult({ data: { apps: ['cerebrum', 'media', 'inventory'], overlays: [] } })
     );
@@ -79,7 +79,7 @@ describe('IndexRedirect', () => {
     expect(screen.getByTestId('landed')).toHaveTextContent('/media');
   });
 
-  it('redirects to /settings when no app from APP_ORDER is installed', () => {
+  it('redirects to /settings when no registered app is installed', () => {
     mocks.query.mockReturnValue(queryResult({ data: { apps: ['unknown'], overlays: [] } }));
     renderAt();
     expect(screen.getByTestId('landed')).toHaveTextContent('/settings');

--- a/apps/pops-shell/src/app/IndexRedirect.tsx
+++ b/apps/pops-shell/src/app/IndexRedirect.tsx
@@ -2,17 +2,18 @@ import { Navigate } from 'react-router';
 
 import { usePillarQuery } from '@pops/pillar-sdk/react';
 
+import { registeredApps } from './nav/registry';
+
 /**
  * `/` redirect that respects the installed-modules manifest (PRD-100).
- * Picks the first installed app in `APP_ORDER`; falls back to `/settings`
- * if no apps are installed (which means `core` is the only operational
- * surface).
+ * Picks the first installed app from `registeredApps` (manifest `nav.order`
+ * ascending, lexicographic tiebreak — see `nav/registry.ts`); falls back
+ * to `/settings` if no apps are installed.
  *
  * Default deployments (POPS_APPS unset → all installed) land on `/finance`
- * just like before.
+ * because finance carries the lowest `nav.order` (10) in the workspace
+ * bundle map.
  */
-const APP_ORDER = ['finance', 'media', 'inventory', 'cerebrum'] as const;
-
 type ShellManifest = {
   apps: readonly string[];
   overlays: readonly string[];
@@ -34,6 +35,6 @@ export function IndexRedirect() {
     return <Navigate to="/finance" replace />;
   }
 
-  const target = APP_ORDER.find((id) => data.apps.includes(id));
-  return <Navigate to={target ? `/${target}` : '/settings'} replace />;
+  const target = registeredApps.find((app) => data.apps.includes(app.id));
+  return <Navigate to={target ? `/${target.id}` : '/settings'} replace />;
 }

--- a/docs/themes/13-pillar-finale/notes/pillar-isolation-audit-status.md
+++ b/docs/themes/13-pillar-finale/notes/pillar-isolation-audit-status.md
@@ -7,11 +7,11 @@ Companion to [`pillar-isolation-audit.md`](pillar-isolation-audit.md). The origi
 | Bucket         | Closed | In Progress | Open   | Needs scoping |
 | -------------- | ------ | ----------- | ------ | ------------- |
 | HIGH (9)       | 5      | 1           | 3      | 0             |
-| MEDIUM (9)     | 1      | 2           | 3      | 3             |
-| LOW (10)       | 1      | 1           | 5      | 3             |
+| MEDIUM (9)     | 2      | 2           | 3      | 2             |
+| LOW (10)       | 0      | 1           | 5      | 4             |
 | **Total (28)** | **7**  | **4**       | **11** | **6**         |
 
-The four landed PRDs collectively closed 7 findings (5 HIGH, 1 MEDIUM, 1 LOW) — the entire top of the "shell + appRouter + module-registry + settings-barrel" anti-lego cluster. The remaining HIGH bucket is dominated by physical-decomposition work: `db-types` retirement (H6), the cross-pillar FKs that block the per-pillar SQLite split (H7), the cross-pillar runtime imports inside `apps/pops-api/src/modules/` (H8), and the shell↔cerebrum coupling in `CaptureModal` (H9).
+The four landed PRDs collectively closed 6 findings (5 HIGH, 1 MEDIUM); a follow-up batch closed M9 (`IndexRedirect` now derives from `registeredApps`) and reopened L8 after a verification grep found live consumers of the `manifest-pillar.ts` shim. The remaining HIGH bucket is dominated by physical-decomposition work: `db-types` retirement (H6), the cross-pillar FKs that block the per-pillar SQLite split (H7), the cross-pillar runtime imports inside `apps/pops-api/src/modules/` (H8), and the shell↔cerebrum coupling in `CaptureModal` (H9).
 
 ## How to read this doc
 
@@ -161,11 +161,11 @@ The four landed PRDs collectively closed 7 findings (5 HIGH, 1 MEDIUM, 1 LOW) �
 
 ### M9 — `apps/pops-shell/src/app/IndexRedirect.tsx` hand-curates default app order
 
-- **Status**: Open
-- **Owning PRD**: could fold into a follow-up to PRD-243 (manifest field `frontend.defaultRouteRank?: number`); not currently scoped.
-- **Severity (re-rated)**: LOW (downgraded — the catch-all route handles missing pillars; the only real cost is that new pillars are silently invisible to `/`. Now that `nav.order` exists on every manifest per PRD-243, falling back to `nav.order` ascending is a 5-line PR.)
-- **What remains**: Replace `APP_ORDER` literal with derivation from `nav.order`. Trivially small now that PRD-243 added the field.
-- **Proposed owner**: **needs new PRD** (trivial; could be a single-commit follow-up to PRD-243).
+- **Status**: Closed
+- **Closer PR**: small-audit-fixes batch — `IndexRedirect` now derives its candidate order from `registeredApps` (nav.order ascending, lexicographic tiebreak), so the literal is gone and external pillars are automatically eligible for the `/` redirect once their manifest enters the registry walk.
+- **Owning PRD**: [PRD-243](../prds/243-registry-driven-shell-ui/README.md) by side-effect (registeredApps consumer)
+- **Severity (re-rated)**: LOW (no change at closure)
+- **Notes**: Five-line change. The historical default (`/finance`) is preserved because finance carries the lowest `navOrder` (10) in the workspace bundle map.
 
 ## LOW findings
 
@@ -220,11 +220,13 @@ The four landed PRDs collectively closed 7 findings (5 HIGH, 1 MEDIUM, 1 LOW) �
 
 ### L8 — `apps/pops-shell/src/app/pillars/manifest-pillar.ts` is a deliberate no-op shim
 
-- **Status**: Closed
-- **Closer PR**: incidentally closes alongside #3241 (PRD-243 US-03) — when the shell rewrote `installed-modules.ts` against the registry walk, `pillarIdForModule()` is no longer load-bearing; manifests now declare their pillar baseUrl directly.
-- **Owning PRD**: [PRD-243](../prds/243-registry-driven-shell-ui/README.md) by side-effect
+- **Status**: Open (originally logged as Closed; follow-up grep on 2026-06-14 found live consumers — see Notes)
+- **Owning PRD**: needs new PRD (trivial — collapse `CORE_PILLAR_ID` + `pillarIdForModule` into the pillar baseUrl on the manifest, then delete the shim)
 - **Severity (re-rated)**: LOW (no change)
-- **Notes**: Worth a follow-up grep to confirm zero callers remain; the file itself may still exist as a dead export. If so, a single-commit deletion PR closes it definitively. (See "Open follow-ups" below.)
+- **Notes**: Re-verification on 2026-06-14 found two real consumers that the original closure note missed:
+  - `apps/pops-shell/src/app/router.tsx:78` still calls `pillarIdForModule(manifest.id)` to label each `PillarGuard`'s `pillarId` prop.
+  - `apps/pops-shell/src/app/pillars/pillar-registry-client.ts:87` still consumes `CORE_PILLAR_ID` for the synthetic `SELF_ENTRY` fallback.
+    Until both sites are migrated (router takes pillar id from the manifest directly; registry client inlines the `'core'` literal or sources it from a shared constant), the shim cannot be deleted. The L8 entry is reopened.
 
 ### L9 — `packages/pillar-sdk/src/contracts/index.ts` exports finance-only
 
@@ -251,8 +253,7 @@ Aggregating the "needs new PRD" entries above so they can be triaged in one pass
 | M4                | Collapse `pnpm-workspace.yaml` to `packages/*`               | Trivial | Single-commit PR                                                                                              |
 | M7                | i18n manifest slot                                           | Small   | `frontend.i18n: { namespace, resources }` aggregated at shell boot                                            |
 | M8 + L2 + L3 + L5 | CI / infra consolidation                                     | Medium  | Single PRD covering compose template + matrix-over-glob in 4 workflow files                                   |
-| M9                | `IndexRedirect` derives from `nav.order`                     | Trivial | Single-commit follow-up to PRD-243                                                                            |
-| L8                | Delete dead `manifest-pillar.ts` (verify zero callers first) | Trivial | Single-commit cleanup                                                                                         |
+| L8                | Retire `manifest-pillar.ts` shim                             | Small   | Re-verified open: 2 live consumers (`router.tsx`, `pillar-registry-client.ts`). Migrate then delete.          |
 | L9                | Delete `pillar-sdk/src/contracts/index.ts`                   | Trivial | SDK should not name pillars                                                                                   |
 
 Adjacent (already-scoped) PRDs that also chip at remaining findings:


### PR DESCRIPTION
## Summary

Small-fix batch against the pillar-isolation audit status doc (#3244).

- **M9 closed** — `apps/pops-shell/src/app/IndexRedirect.tsx` no longer hand-curates `APP_ORDER`. The candidate order now derives from `registeredApps` (nav.order ascending, lexicographic tiebreak — same source the app rail uses). External pillars become automatically eligible for the `/` redirect once their manifest enters the registry walk. Historical default (`/finance`) is preserved because finance carries the lowest `navOrder` (10) in the workspace bundle map.
- **L8 reopened** — a pre-deletion verification grep on `manifest-pillar` found two live consumers the original closure note in #3244 missed:
  - `apps/pops-shell/src/app/router.tsx:78` still calls `pillarIdForModule(manifest.id)` to label each `PillarGuard`'s `pillarId` prop.
  - `apps/pops-shell/src/app/pillars/pillar-registry-client.ts:87` still consumes `CORE_PILLAR_ID` for the synthetic `SELF_ENTRY` fallback.

  Shim cannot be deleted yet. The L8 entry is restated as `Open` with the two consumer sites called out as remaining work; the closure note in #3244 is corrected.

The audit status doc summary table is adjusted accordingly: MEDIUM closed 1 → 2, MEDIUM needs scoping 3 → 2, LOW closed 1 → 0, LOW needs scoping 3 → 4. Totals unchanged.

## Test plan

- [x] `pnpm --filter @pops/shell typecheck` — clean
- [x] `pnpm --filter @pops/shell test` — 508/508 passing (incl. updated `IndexRedirect.test.tsx`)
- [x] husky pre-commit (oxlint + oxfmt) — clean