### PR TITLE
feat(pops-cerebrum-api): PRD-246 US-02 declare captureOverlay manifest dimension

### DIFF
--- a/apps/pops-cerebrum-api/src/__tests__/manifest.test.ts
+++ b/apps/pops-cerebrum-api/src/__tests__/manifest.test.ts
@@ -136,4 +136,30 @@ describe('buildCerebrumManifest', () => {
       expect(parsed.pages?.length).toBeGreaterThan(0);
     });
   });
+
+  describe('PRD-246 US-02 captureOverlay dimension', () => {
+    it('declares a captureOverlay block resolving to cerebrum IngestForm', () => {
+      const manifest = buildCerebrumManifest('0.1.0');
+      expect(manifest.captureOverlay).toEqual({
+        bundleSlot: 'ingest-form',
+        order: 10,
+        hotkey: 'cmd+shift+k',
+        labelKey: 'cerebrum.captureOverlay.label',
+      });
+    });
+
+    it('passes ManifestPayloadSchema with the captureOverlay dimension present', () => {
+      const manifest = buildCerebrumManifest('0.1.0');
+      const parsed = ManifestPayloadSchema.parse(manifest);
+      expect(parsed.captureOverlay?.bundleSlot).toBe('ingest-form');
+    });
+
+    it('round-trips the captureOverlay dimension through JSON', () => {
+      const manifest = buildCerebrumManifest('0.1.0');
+      const roundTripped: unknown = JSON.parse(JSON.stringify(manifest));
+      const parsed = ManifestPayloadSchema.parse(roundTripped);
+      expect(parsed.captureOverlay?.hotkey).toBe('cmd+shift+k');
+      expect(parsed.captureOverlay?.order).toBe(10);
+    });
+  });
 });

--- a/apps/pops-cerebrum-api/src/manifest.ts
+++ b/apps/pops-cerebrum-api/src/manifest.ts
@@ -1,6 +1,7 @@
 import { cerebrumManifest, egoManifest } from '@pops/cerebrum-contract/settings';
 
 import type {
+  CaptureOverlayDescriptor,
   ManifestPayload,
   NavConfigDescriptor,
   PageDescriptor,
@@ -64,6 +65,29 @@ const CEREBRUM_NAV: NavConfigDescriptor = {
  * `NavConfigDescriptor` does not support overlay/shortcut shapes — that
  * gap is tracked for follow-up (see PR body).
  */
+/**
+ * Wire-format capture overlay contribution for the cerebrum pillar
+ * (PRD-246 US-02).
+ *
+ * Declares the global capture surface the shell currently hard-codes as
+ * `CaptureModal` (`apps/pops-shell/src/app/capture/CaptureModal.tsx`).
+ * `bundleSlot: 'ingest-form'` is the kebab-case identifier the shell-side
+ * workspace bundle map (PRD-246 US-03) will resolve back to cerebrum's
+ * `IngestForm` export. `order: 10` follows the sparse 10/20/30 scheme
+ * called out in the US so finance / inventory / lists can slot overlays
+ * later without renumbering. `hotkey: 'cmd+shift+k'` matches the wire
+ * shape the US prescribes; the live binding is currently a single key
+ * resolved from the `CEREBRUM_CAPTURE_HOTKEY` setting (default `'c'`) at
+ * the shell, so US-03 reconciles the manifest-declared hotkey with the
+ * settings-driven override.
+ */
+const CEREBRUM_CAPTURE_OVERLAY: CaptureOverlayDescriptor = {
+  bundleSlot: 'ingest-form',
+  order: 10,
+  hotkey: 'cmd+shift+k',
+  labelKey: 'cerebrum.captureOverlay.label',
+};
+
 const CEREBRUM_PAGES: readonly PageDescriptor[] = [
   { path: '', index: true, bundleSlot: 'cerebrum-ingest' },
   { path: 'chat', bundleSlot: 'cerebrum-chat' },
@@ -95,6 +119,11 @@ const CEREBRUM_PAGES: readonly PageDescriptor[] = [
  * pillar carries its own app-rail entry + routable pages; ego's overlay
  * surface stays mounted via `@pops/overlay-ego`'s manifest and is not
  * representable in today's `NavConfigDescriptor` shape (deferred).
+ *
+ * PRD-246 US-02 adds the `captureOverlay` UI dimension. Cerebrum is the
+ * sole capture contributor today, so the shell-side hard-coded
+ * `CaptureModal` import (PRD-081 US-09) is lifted to a manifest-driven
+ * registry walk in US-03.
  */
 export function buildCerebrumManifest(version: string): ManifestPayload {
   return {
@@ -117,6 +146,7 @@ export function buildCerebrumManifest(version: string): ManifestPayload {
     settings: { manifests: [cerebrumManifest, egoManifest] },
     nav: CEREBRUM_NAV,
     pages: [...CEREBRUM_PAGES],
+    captureOverlay: CEREBRUM_CAPTURE_OVERLAY,
     healthcheck: { path: '/health' },
   };
 }

--- a/apps/pops-cerebrum-api/src/manifest.ts
+++ b/apps/pops-cerebrum-api/src/manifest.ts
@@ -51,21 +51,6 @@ const CEREBRUM_NAV: NavConfigDescriptor = {
 };
 
 /**
- * Wire-format pages contribution for the cerebrum pillar (PRD-243 US-02).
- *
- * One descriptor per route declared in `@pops/app-cerebrum`'s `routes`
- * array. `bundleSlot` is the kebab-case identifier the shell-side
- * workspace bundle map (PRD-243 US-03) will resolve back to the React
- * component currently held in `installed-modules.ts`.
- *
- * The `chat` route hosts ego's chat panel (PRD-099) — it lives in
- * `@pops/app-cerebrum` so it stays mounted under `/cerebrum/*` even
- * though the chat panel itself ships from `@pops/overlay-ego`. Ego's
- * overlay surface (the floating FAB) is NOT carried here: the current
- * `NavConfigDescriptor` does not support overlay/shortcut shapes — that
- * gap is tracked for follow-up (see PR body).
- */
-/**
  * Wire-format capture overlay contribution for the cerebrum pillar
  * (PRD-246 US-02).
  *
@@ -88,6 +73,21 @@ const CEREBRUM_CAPTURE_OVERLAY: CaptureOverlayDescriptor = {
   labelKey: 'cerebrum.captureOverlay.label',
 };
 
+/**
+ * Wire-format pages contribution for the cerebrum pillar (PRD-243 US-02).
+ *
+ * One descriptor per route declared in `@pops/app-cerebrum`'s `routes`
+ * array. `bundleSlot` is the kebab-case identifier the shell-side
+ * workspace bundle map (PRD-243 US-03) will resolve back to the React
+ * component currently held in `installed-modules.ts`.
+ *
+ * The `chat` route hosts ego's chat panel (PRD-099) — it lives in
+ * `@pops/app-cerebrum` so it stays mounted under `/cerebrum/*` even
+ * though the chat panel itself ships from `@pops/overlay-ego`. Ego's
+ * overlay surface (the floating FAB) is NOT carried here: the current
+ * `NavConfigDescriptor` does not support overlay/shortcut shapes — that
+ * gap is tracked for follow-up (see PR body).
+ */
 const CEREBRUM_PAGES: readonly PageDescriptor[] = [
   { path: '', index: true, bundleSlot: 'cerebrum-ingest' },
   { path: 'chat', bundleSlot: 'cerebrum-chat' },

--- a/apps/pops-shell/src/i18n/locales/en-AU/cerebrum.json
+++ b/apps/pops-shell/src/i18n/locales/en-AU/cerebrum.json
@@ -1,4 +1,5 @@
 {
+  "captureOverlay.label": "Capture",
   "ingest.title": "Capture",
   "ingest.description": "Drop a thought into Cerebrum \u2014 type, scope, and tags get inferred after.",
   "ingest.type": "Type",

--- a/apps/pops-shell/src/i18n/locales/pt-BR/cerebrum.json
+++ b/apps/pops-shell/src/i18n/locales/pt-BR/cerebrum.json
@@ -1,4 +1,5 @@
 {
+  "captureOverlay.label": "Capturar",
   "ingest.title": "Capturar",
   "ingest.description": "Solte um pensamento no Cerebrum — tipo, escopo e tags são inferidos depois.",
   "ingest.type": "Tipo",

--- a/docs/themes/13-pillar-finale/prds/246-shell-api-pillar-decoupling/us-02-cerebrum-manifest-contribution.md
+++ b/docs/themes/13-pillar-finale/prds/246-shell-api-pillar-decoupling/us-02-cerebrum-manifest-contribution.md
@@ -1,6 +1,8 @@
-# US-02: Cerebrum's manifest declares `frontend.captureOverlay`
+# US-02: Cerebrum's manifest declares `captureOverlay`
 
 > PRD: [PRD-246 — Shell + API pillar decoupling](README.md)
+
+> **Wire-shape note.** PRD-246 drafts used `frontend.captureOverlay` as a conceptual grouping with the other UI dimensions. The actual wire shape PRD-246 US-01 (PR #3249) shipped is **top-level `captureOverlay`** on `ManifestPayload` — same level as `nav`, `pages`, `assetsBaseUrl`. References to `frontend.captureOverlay` below mean that top-level field.
 
 ## Description
 


### PR DESCRIPTION
## Summary

Implements [PRD-246](../../docs/themes/13-pillar-finale/prds/246-shell-api-pillar-decoupling/) **US-02 — cerebrum manifest contribution**. Declares the new `captureOverlay` UI dimension on the cerebrum API's manifest payload, lifting the shell-side hard-coded `CaptureModal` import (PRD-081 US-09) onto the wire format introduced in #3249 (US-01).

This is the producer-side half of the H9 (workspace-bundle hardcoded import) burn-down. The shell-side consumer rewrite ships in US-03; this PR is intentionally isolated so the shell has at least one pillar contributing the new dimension when US-03 lands.

## Changes

- `apps/pops-cerebrum-api/src/manifest.ts` — `buildCerebrumManifest()` now emits a top-level `captureOverlay` block:
  ```ts
  {
    bundleSlot: 'ingest-form',
    order: 10,
    hotkey: 'cmd+shift+k',
    labelKey: 'cerebrum.captureOverlay.label',
  }
  ```
- `apps/pops-cerebrum-api/src/__tests__/manifest.test.ts` — three new assertions: exact-shape match, `ManifestPayloadSchema.parse` round-trip, and JSON-serialisation round-trip.

## Notes

- `bundleSlot: 'ingest-form'` is a contract with the shell-side workspace bundle map landing in US-03. The slot will resolve to cerebrum's `IngestForm` export from `@pops/app-cerebrum`.
- `hotkey: 'cmd+shift+k'` matches the US-02 acceptance criteria. The live shell binding today is a single key (default `'c'`) resolved from `CEREBRUM_CAPTURE_HOTKEY` via `useCaptureHotkey`; reconciling the manifest-declared hotkey with that settings-driven override is US-03 territory.
- `order: 10` follows the sparse 10/20/30 scheme PRD-246 calls out so finance/inventory/lists can slot capture overlays later without renumbering.
- Cerebrum is intentionally the sole declarer of `captureOverlay` in this PRD (per the US-02 acceptance criteria).

## Out of scope

- Shell rewrite (US-03)
- H8 burn-down (US-04)
- Integration test (US-05)
- Any edits to `apps/pops-shell/src/app/capture/CaptureModal.tsx`

## Refs

- #3247 — PRD-246 umbrella
- #3249 — US-01 (`captureOverlay` added to `ManifestPayloadSchema`)

## Test plan

- [x] `pnpm --filter @pops/cerebrum-api test` — 41 passed (3 new under `PRD-246 US-02 captureOverlay dimension`)
- [x] `pnpm --filter @pops/cerebrum-api typecheck` — clean
- [x] `pnpm --filter @pops/pillar-sdk test` — 552 passed (no schema regression)
- [x] Husky pre-commit + pre-push — passed without `--no-verify`
