### PR TITLE
fix(api): pops-api crash loop on boot when media not in install-set

### DIFF
--- a/apps/pops-api/src/modules/media/plex/scheduler.ts
+++ b/apps/pops-api/src/modules/media/plex/scheduler.ts
@@ -12,13 +12,19 @@ import { SettingNotFoundError, settingsService } from '@pops/core-db';
 
 import { getCoreDrizzle } from '../../../db.js';
 import { getSyncQueue } from '../../../jobs/queues.js';
+import { FeatureNotFoundError } from '../../core/features/errors.js';
 import { isEnabled } from '../../core/features/index.js';
 import { SETTINGS_KEYS } from '../../core/settings/keys.js';
 import { getLastSyncAt, getLastSyncCounts, getLastSyncError } from './scheduler-sync-logs.js';
 import { getPlexSectionIds } from './service.js';
 
 function isPlexSchedulerEnabled(): boolean {
-  return isEnabled('media.plex.scheduler');
+  try {
+    return isEnabled('media.plex.scheduler');
+  } catch (err) {
+    if (err instanceof FeatureNotFoundError) return false;
+    throw err;
+  }
 }
 
 export {


### PR DESCRIPTION
**Server health hot-fix.**

`pops-api` (the orchestrator container, install-set=['core']) crash-loops on boot:

```
FeatureNotFoundError: Unknown feature "media.plex.scheduler" — not declared by any installed module (searched: core)
  at resumeSchedulerIfEnabled (modules/media/plex/scheduler.js:131:23)
  at index.js:134:26
```

Root cause: `resumeSchedulerIfEnabled` runs unconditionally at boot. It calls `isPlexSchedulerEnabled()` which calls `isEnabled('media.plex.scheduler')` — but media isn't in the orchestrator's install set, so it throws.

`pops-media-api` (which DOES have media in its install set) owns the plex scheduler now. The boot call in `pops-api` is dead code masquerading as live code.

Fix: catch `FeatureNotFoundError` in `isPlexSchedulerEnabled` and return false. The scheduler skips resume in pops-api (correct), and continues working in pops-media-api (correct).

**Follow-up (not in this PR):** relocate the `resumeSchedulerIfEnabled()` call out of `pops-api/src/index.ts` and into `pops-media-api`'s boot path. That's the architecturally correct fix — this PR is the unblock.

**Verification:**
- `pnpm --filter @pops/api test src/modules/media/plex/scheduler.test` — 17/17 pass
- husky pre-commit + pre-push passed (oxlint + oxfmt + typecheck)

After merge: redeploy pops-api on capivara.