### PR TITLE
fix(docker): include apps/pops-api/scripts/ in build context

### DIFF
--- a/apps/pops-api/Dockerfile
+++ b/apps/pops-api/Dockerfile
@@ -65,6 +65,7 @@ COPY packages/finance-contract/ ./packages/finance-contract/
 COPY packages/pillar-sdk/ ./packages/pillar-sdk/
 COPY apps/pops-api/tsconfig.json ./apps/pops-api/
 COPY apps/pops-api/src ./apps/pops-api/src
+COPY apps/pops-api/scripts ./apps/pops-api/scripts
 
 # Build shared packages first
 WORKDIR /app/packages/db-types


### PR DESCRIPTION
PR #3232 (PRD-242 US-01) wired `tsx scripts/generate-known-routers.ts` into pops-api's `pnpm build` but the Dockerfile only COPYs `apps/pops-api/src/`, not `scripts/`. Container build fails ERR_MODULE_NOT_FOUND before deploy. Last 2 Publish Images runs on main failed for this reason.

Same shape as #3155. One COPY line.

**Unblocks:** Publish Images on main + the pops-api redeploy on capivara (after #3253 hot-fix lands on the new image).