### PR TITLE
fix(pops-api): unblock Publish Images — explicit string param in entities/types.ts (TS7006)

### DIFF
--- a/apps/pops-api/src/modules/core/entities/types.ts
+++ b/apps/pops-api/src/modules/core/entities/types.ts
@@ -38,7 +38,7 @@ export function toEntity(row: EntityRow & { transactionCount?: number }): Entity
     aliases: row.aliases
       ? row.aliases
           .split(',')
-          .map((s) => s.trim())
+          .map((s: string) => s.trim())
           .filter(Boolean)
       : [],
     defaultTransactionType: row.defaultTransactionType,


### PR DESCRIPTION
## Summary

- `apps/pops-api/src/modules/core/entities/types.ts:41` was failing TS7006 (implicit-any on `s`) after #3256 (revert of PRD-245 US-07) — blocking **Publish Images** on `main` and preventing capivara from picking up the prior hot-fixes (#3253 + #3254).
- Single-line fix: add explicit `(s: string)` annotation to the `.map()` callback in the `aliases` narrowing.
- Verified: `pnpm --filter @pops/api build` is green locally with this change as the only delta.

## Why not infer naturally?

`EntityRow.aliases` is `string | null` per `drizzle.InferSelectModel<typeof entities>`. After the truthy `row.aliases ?` narrowing it should be `string`, and `.split(',')` should yield `string[]`. tsc 5.x under strict mode is widening to `any` here for reasons related to the post-revert type graph — an explicit annotation is the minimal, type-safe restore. No `as any` / `as unknown as` / suppressions used.

## Test plan

- [x] `pnpm --filter @pops/api build` passes locally
- [ ] Publish Images workflow goes green on this PR
- [ ] Watchtower picks up the new pops-api image on capivara, scheduler crash loop resolves via #3253 catch