### PR TITLE
chore(shell): inline trpc client + isNetworkError, drop @pops/api-client dep

### DIFF
--- a/apps/pops-shell/package.json
+++ b/apps/pops-shell/package.json
@@ -21,7 +21,7 @@
     "registry:register": "tsx scripts/register-with-registry.ts"
   },
   "dependencies": {
-    "@pops/api-client": "workspace:*",
+    "@pops/api": "workspace:*",
     "@pops/app-ai": "workspace:*",
     "@pops/app-cerebrum": "workspace:*",
     "@pops/app-finance": "workspace:*",
@@ -37,6 +37,8 @@
     "@pops/ui": "workspace:*",
     "@tailwindcss/vite": "4.3.0",
     "@tanstack/react-query": "5.101.0",
+    "@trpc/client": "11.17.0",
+    "@trpc/react-query": "11.17.0",
     "i18next": "^26.3.1",
     "lucide-react": "^1.17.0",
     "react": "^19.2.7",

--- a/apps/pops-shell/src/app/App.tsx
+++ b/apps/pops-shell/src/app/App.tsx
@@ -1,3 +1,7 @@
+/**
+ * Root App component with all providers
+ */
+import { isNetworkError } from '@/lib/network-error';
 import { trpc, trpcClient } from '@/lib/trpc';
 import { useThemeStore } from '@/store/themeStore';
 import { MutationCache, QueryCache, QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -6,10 +10,6 @@ import { useEffect } from 'react';
 import { RouterProvider } from 'react-router';
 import { toast } from 'sonner';
 
-/**
- * Root App component with all providers
- */
-import { isNetworkError } from '@pops/api-client';
 import { PillarSdkProvider } from '@pops/pillar-sdk/react';
 import { Toaster, TooltipProvider } from '@pops/ui';
 

--- a/apps/pops-shell/src/lib/network-error.ts
+++ b/apps/pops-shell/src/lib/network-error.ts
@@ -1,0 +1,33 @@
+const NETWORK_ERROR_FRAGMENTS = [
+  'Failed to fetch',
+  'NetworkError',
+  'Network request failed',
+  'aborted',
+  'timeout',
+];
+
+function messageLooksLikeNetworkFailure(err: object): boolean {
+  if (!('message' in err) || typeof err.message !== 'string') return false;
+  return NETWORK_ERROR_FRAGMENTS.some((fragment) => (err.message as string).includes(fragment));
+}
+
+/**
+ * Heuristic: is this error a network/transport-level failure (server
+ * unreachable, request aborted, fetch threw) rather than a tRPC error
+ * returned by the server with a real status code?
+ *
+ * Server-returned errors have a `data` field with `httpStatus`. Network
+ * failures don't make it that far — they bubble up as a TRPCClientError
+ * wrapping a fetch error, an AbortError, or a `DOMException` (which is
+ * not an `Error` subclass in browsers).
+ */
+export function isNetworkError(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false;
+  if ('data' in err && err.data != null) return false;
+  if (messageLooksLikeNetworkFailure(err)) return true;
+  // `DOMException` (Web abort errors) is not an `Error` subclass, so the
+  // recursion needs to follow any throwable-shaped cause, not just `Error`.
+  const cause = 'cause' in err ? err.cause : undefined;
+  if (cause && typeof cause === 'object') return isNetworkError(cause);
+  return false;
+}

--- a/apps/pops-shell/src/lib/trpc.ts
+++ b/apps/pops-shell/src/lib/trpc.ts
@@ -1,5 +1,111 @@
+import { httpBatchLink, splitLink } from '@trpc/client';
+import { createTRPCReact } from '@trpc/react-query';
+
+import { PILLARS, type KnownPillarId } from '@pops/pillar-sdk/capabilities';
+
+import type { Operation, TRPCLink } from '@trpc/client';
+
+import type { AppRouter } from '@pops/api';
+
+/** React Query hooks for tRPC — shared across all app packages. */
+export const trpc = createTRPCReact<AppRouter>();
+
 /**
- * tRPC client re-export for the shell.
- * Single instance owned by @pops/api-client — shared across all packages.
+ * Without a timeout a hung backend leaves tRPC requests pending forever and
+ * the UI stuck on skeleton loaders. 15s is long enough for slow queries but
+ * short enough that the user notices something is wrong.
  */
-export { trpc, trpcClient } from '@pops/api-client';
+export const TRPC_FETCH_TIMEOUT_MS = 15_000;
+
+function fetchWithTimeout(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort('timeout'), TRPC_FETCH_TIMEOUT_MS);
+
+  // Chain the caller's signal (e.g. React Query cancellation) with our timeout
+  // so aborting either source aborts the request. The listener is registered
+  // with `once` and cleaned up explicitly in `finally` so a long-lived caller
+  // signal doesn't accumulate listeners across requests.
+  const callerSignal = init?.signal;
+  const onCallerAbort = (): void => controller.abort(callerSignal?.reason);
+  if (callerSignal) {
+    if (callerSignal.aborted) controller.abort(callerSignal.reason);
+    else callerSignal.addEventListener('abort', onCallerAbort, { once: true });
+  }
+
+  return fetch(input, { ...init, signal: controller.signal }).finally(() => {
+    clearTimeout(timeoutId);
+    callerSignal?.removeEventListener('abort', onCallerAbort);
+  });
+}
+
+/**
+ * tRPC URL prefix per pillar. Each pillar's API serves at its own URL so
+ * nginx can do a simple prefix match (no regex on procedure paths) and so
+ * the client batcher never assembles a batch URL targeting more than one
+ * pillar at a time.
+ */
+const PILLAR_TRPC_URLS: Readonly<Record<KnownPillarId, string>> = {
+  core: '/trpc-core',
+  finance: '/trpc-finance',
+  media: '/trpc-media',
+  inventory: '/trpc-inventory',
+  cerebrum: '/trpc-cerebrum',
+  food: '/trpc-food',
+  lists: '/trpc-lists',
+};
+
+/** Legacy pops-api URL — catches every procedure that isn't pillar-prefixed. */
+const LEGACY_TRPC_URL = '/trpc';
+
+const MAX_URL_LENGTH = 2083;
+
+const PILLAR_SET: ReadonlySet<string> = new Set(PILLARS);
+
+function isKnownPillarId(value: string): value is KnownPillarId {
+  return PILLAR_SET.has(value);
+}
+
+function pillarOfPath(path: string): KnownPillarId | null {
+  const namespace = path.split('.')[0];
+  if (!namespace) return null;
+  return isKnownPillarId(namespace) ? namespace : null;
+}
+
+function terminalLinkFor(url: string): TRPCLink<AppRouter> {
+  return httpBatchLink<AppRouter>({
+    url,
+    maxURLLength: MAX_URL_LENGTH,
+    fetch: fetchWithTimeout,
+  });
+}
+
+/**
+ * Builds a tRPC link that dispatches each operation to the per-pillar batch
+ * link matching its namespace, falling back to the legacy URL for anything
+ * else. tRPC's `splitLink` is binary, so the chain is nested once per pillar.
+ *
+ * Per-pillar links share no batch buffer: a request graph that mixes
+ * `core.foo` and `finance.bar` always produces two separate HTTP calls.
+ */
+function createPillarSplitLink(): TRPCLink<AppRouter> {
+  const legacyLink = terminalLinkFor(LEGACY_TRPC_URL);
+  return PILLARS.reduce<TRPCLink<AppRouter>>((falseBranch, pillar) => {
+    const pillarLink = terminalLinkFor(PILLAR_TRPC_URLS[pillar]);
+    return splitLink<AppRouter>({
+      condition: (op: Operation) => pillarOfPath(op.path) === pillar,
+      true: pillarLink,
+      false: falseBranch,
+    });
+  }, legacyLink);
+}
+
+/**
+ * tRPC client instance with a per-pillar splitLink (PRD-187).
+ *
+ * Each pillar's procedures route to their own batched URL
+ * (`/trpc-<pillar>`); non-pillar procedures keep flowing to the legacy
+ * `/trpc` endpoint. No batch URL ever spans more than one pillar.
+ */
+export const trpcClient = trpc.createClient({
+  links: [createPillarSplitLink()],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -758,9 +758,9 @@ importers:
 
   apps/pops-shell:
     dependencies:
-      '@pops/api-client':
+      '@pops/api':
         specifier: workspace:*
-        version: link:../../packages/api-client
+        version: link:../pops-api
       '@pops/app-ai':
         specifier: workspace:*
         version: link:../../packages/app-ai
@@ -806,6 +806,12 @@ importers:
       '@tanstack/react-query':
         specifier: 5.101.0
         version: 5.101.0(react@19.2.7)
+      '@trpc/client':
+        specifier: 11.17.0
+        version: 11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3)
+      '@trpc/react-query':
+        specifier: 11.17.0
+        version: 11.17.0(@tanstack/react-query@5.101.0(react@19.2.7))(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(@trpc/server@11.17.0(typescript@6.0.3))(react@19.2.7)(typescript@6.0.3)
       i18next:
         specifier: ^26.3.1
         version: 26.3.1(typescript@6.0.3)


### PR DESCRIPTION
## Summary

Option B PR 1 from the audit: inline the two production uses of `@pops/api-client` from `apps/pops-shell` (the last remaining workspace app on it) and remove the dep — zero behavior change.

- `apps/pops-shell/src/lib/trpc.ts` now constructs `trpc` + `trpcClient` directly. The 15s `fetchWithTimeout` (with caller-signal chaining + listener cleanup), the per-pillar `splitLink` routing (`/trpc-<pillar>` plus the legacy `/trpc` fallback), and the 2083-char `maxURLLength` batching budget are preserved.
- `apps/pops-shell/src/lib/network-error.ts` holds the same TRPC-client-error heuristic the `QueryCache` / `MutationCache` toast suppressor was using via `isNetworkError`.
- `@pops/api-client` removed from `apps/pops-shell/package.json`. Previously transitive `@pops/api`, `@trpc/client`, and `@trpc/react-query` are now direct deps (pinned to the same `11.17.0` the rest of the monorepo uses).

The `NudgeIndicator` top-bar component still falls back to `trpc.cerebrum.nudges.list.useQuery` when no `PillarSdkProvider` transport is configured — this is the intentional legacy fallback described in the comment at `NudgeIndicator.tsx:9-18` and is **deliberately untouched here**. PR 2 will retire that fallback once SDK transport is confirmed universal in prod.

## Follow-up scope (NOT in this PR)

These workspace packages still depend on `@pops/api-client` and need their own migrations later:

- `packages/app-ai`
- `packages/app-finance`
- `packages/app-food`
- `packages/navigation`
- `packages/overlay-ego`

This PR only drops the dep from `apps/pops-shell`.

## Test plan

- [x] `grep -rn "@pops/api-client" apps/pops-shell` → 0 hits
- [x] `pnpm --filter @pops/shell typecheck` passes (shell-owned files clean)
- [x] `pnpm --filter @pops/shell test` → 508/508 pass, including `NudgeIndicator.test.tsx`
- [x] `pnpm --filter @pops/shell build` passes
- [x] `pnpm lint:boundaries` — no new violations
- [x] `oxlint --type-aware` + `oxfmt --check` clean on the touched files
