### PR TITLE
feat(ha-bridge): PRD-229 retention worker cron — closes PRD-229 100%

### DIFF
--- a/apps/pops-ha-bridge-api/package.json
+++ b/apps/pops-ha-bridge-api/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@pops/ha-bridge-db": "workspace:*",
     "@pops/pillar-sdk": "workspace:*",
+    "@pops/types": "workspace:*",
     "express": "^5.1.0",
     "ws": "^8.18.0",
     "zod": "^4.4.3"

--- a/apps/pops-ha-bridge-api/src/__tests__/manifest.test.ts
+++ b/apps/pops-ha-bridge-api/src/__tests__/manifest.test.ts
@@ -13,6 +13,10 @@ import {
   HA_ENTITIES_ENTITY_TYPE,
   HA_ENTITIES_PROCEDURE_PATH,
 } from '../search/entities-adapter.js';
+import {
+  HA_BRIDGE_DEFAULT_RETENTION_DAYS,
+  HA_BRIDGE_RETENTION_SETTING_KEY,
+} from '../settings/manifest.js';
 
 describe('buildHaBridgeManifest', () => {
   it('produces a payload that passes the central manifest schema', () => {
@@ -99,5 +103,21 @@ describe('buildHaBridgeManifest', () => {
   it('rejects non-semver versions at the schema boundary', () => {
     const manifest = buildHaBridgeManifest('not-a-semver');
     expect(() => ManifestPayloadSchema.parse(manifest)).toThrow();
+  });
+
+  it('publishes the retention settings manifest (PRD-229 retention worker cron)', () => {
+    const manifest = buildHaBridgeManifest('0.1.0');
+    expect(manifest.settings?.manifests).toHaveLength(1);
+    const settingsManifest = manifest.settings?.manifests[0];
+    if (settingsManifest === undefined) throw new Error('haBridge settings manifest missing');
+    expect(settingsManifest.id).toBe('haBridge');
+    const field = settingsManifest.groups
+      .flatMap((group) => group.fields)
+      .find((f) => f.key === HA_BRIDGE_RETENTION_SETTING_KEY);
+    if (field === undefined) throw new Error('retention field missing');
+    expect(field.type).toBe('number');
+    expect(field.default).toBe(String(HA_BRIDGE_DEFAULT_RETENTION_DAYS));
+    expect(field.envFallback).toBe('HA_HISTORY_RETENTION_DAYS');
+    expect(field.validation?.min).toBe(0);
   });
 });

--- a/apps/pops-ha-bridge-api/src/__tests__/retention-worker.test.ts
+++ b/apps/pops-ha-bridge-api/src/__tests__/retention-worker.test.ts
@@ -9,6 +9,7 @@ vi.mock('@pops/ha-bridge-db', () => ({
 }));
 
 const { startRetentionWorker } = await import('../retention-worker.js');
+const { HA_BRIDGE_DEFAULT_RETENTION_DAYS } = await import('../settings/manifest.js');
 
 const fakeDb = { __tag: 'fake-db' } as unknown as HaBridgeDb;
 
@@ -86,6 +87,29 @@ describe('startRetentionWorker (PRD-229 US-01)', () => {
     vi.advanceTimersByTime(intervalMs * 10);
 
     expect(pruneHistoryMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to the manifest default retention when no option is provided', () => {
+    const handle = startRetentionWorker({ db: fakeDb });
+
+    const expectedCutoff = Date.now() - HA_BRIDGE_DEFAULT_RETENTION_DAYS * 24 * 60 * 60 * 1000;
+    expect(pruneHistoryMock).toHaveBeenLastCalledWith(fakeDb, expectedCutoff);
+
+    handle.stop();
+  });
+
+  it('is a no-op when no expired rows exist (pruneHistory returns 0)', () => {
+    pruneHistoryMock.mockReturnValueOnce(0);
+    const info = vi.fn();
+
+    const handle = startRetentionWorker({ db: fakeDb, retentionDays: 30, logger: { info } });
+
+    expect(info).toHaveBeenCalledWith(
+      'ha-bridge retention prune complete',
+      expect.objectContaining({ deleted: 0, retentionDays: 30 })
+    );
+
+    handle.stop();
   });
 
   it('logs deleted count via info logger after a successful prune', () => {

--- a/apps/pops-ha-bridge-api/src/manifest.ts
+++ b/apps/pops-ha-bridge-api/src/manifest.ts
@@ -4,6 +4,7 @@ import {
   HA_ENTITIES_ENTITY_TYPE,
   HA_ENTITIES_PROCEDURE_PATH,
 } from './search/entities-adapter.js';
+import { haBridgeSettingsManifest } from './settings/manifest.js';
 import { mappings } from './sinks/mapping.js';
 import { validateSinkMappings } from './sinks/validator.js';
 
@@ -72,6 +73,7 @@ export function buildHaBridgeManifest(version: string): ManifestPayload {
     },
     uri: { types: [] },
     consumedSettings: { keys: [] },
+    settings: { manifests: [haBridgeSettingsManifest] },
     healthcheck: { path: '/health' },
   };
 }

--- a/apps/pops-ha-bridge-api/src/retention-worker.ts
+++ b/apps/pops-ha-bridge-api/src/retention-worker.ts
@@ -11,6 +11,8 @@
  */
 import { pruneHistory, type HaBridgeDb } from '@pops/ha-bridge-db';
 
+import { HA_BRIDGE_DEFAULT_RETENTION_DAYS } from './settings/manifest.js';
+
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 export interface RetentionWorkerLogger {
@@ -32,7 +34,7 @@ export interface RetentionWorkerHandle {
 
 export function startRetentionWorker(options: RetentionWorkerOptions): RetentionWorkerHandle {
   const intervalMs = options.intervalMs ?? DAY_MS;
-  const retentionDays = options.retentionDays ?? 30;
+  const retentionDays = options.retentionDays ?? HA_BRIDGE_DEFAULT_RETENTION_DAYS;
   const now = options.now ?? Date.now;
   const logger = options.logger;
 

--- a/apps/pops-ha-bridge-api/src/server.ts
+++ b/apps/pops-ha-bridge-api/src/server.ts
@@ -105,12 +105,12 @@ if (process.env['POPS_REGISTRY_ENABLED'] === 'true') {
 subscriber.start();
 
 function resolveRetentionDays(): number | undefined {
-  const raw = process.env['HA_BRIDGE_RETENTION_DAYS'];
+  const raw = process.env['HA_HISTORY_RETENTION_DAYS'];
   if (raw === undefined || raw === '') return undefined;
   const parsed = Number(raw);
   if (!Number.isInteger(parsed) || parsed < 0) {
     throw new Error(
-      `[ha-bridge] HA_BRIDGE_RETENTION_DAYS must be a non-negative integer; got '${raw}'`
+      `[ha-bridge] HA_HISTORY_RETENTION_DAYS must be a non-negative integer; got '${raw}'`
     );
   }
   return parsed;

--- a/apps/pops-ha-bridge-api/src/server.ts
+++ b/apps/pops-ha-bridge-api/src/server.ts
@@ -108,9 +108,9 @@ function resolveRetentionDays(): number | undefined {
   const raw = process.env['HA_HISTORY_RETENTION_DAYS'];
   if (raw === undefined || raw === '') return undefined;
   const parsed = Number(raw);
-  if (!Number.isInteger(parsed) || parsed < 0) {
+  if (!Number.isInteger(parsed) || parsed < 0 || parsed > 3650) {
     throw new Error(
-      `[ha-bridge] HA_HISTORY_RETENTION_DAYS must be a non-negative integer; got '${raw}'`
+      `[ha-bridge] HA_HISTORY_RETENTION_DAYS must be an integer between 0 and 3650; got '${raw}'`
     );
   }
   return parsed;

--- a/apps/pops-ha-bridge-api/src/settings/manifest.ts
+++ b/apps/pops-ha-bridge-api/src/settings/manifest.ts
@@ -5,9 +5,10 @@ import type { SettingsManifest } from '@pops/types';
  * settings UI / `discoverSettings` (ADR-037 / PRD-240) can render and
  * validate the bridge's retention knob.
  *
- * The history retention worker (`src/retention-worker.ts`) reads
- * `HA_HISTORY_RETENTION_DAYS` from env at boot. This descriptor declares
- * the same key + default + bounds so the setting is discoverable; the
+ * The boot path (`src/server.ts`) reads `HA_HISTORY_RETENTION_DAYS` from
+ * env and passes the resolved value into `startRetentionWorker()`; the
+ * worker itself does not touch env. This descriptor declares the same
+ * key + default + bounds so the setting is discoverable; the
  * `envFallback` hint tells consumers which env var the runtime currently
  * resolves from when no user-set value exists.
  */

--- a/apps/pops-ha-bridge-api/src/settings/manifest.ts
+++ b/apps/pops-ha-bridge-api/src/settings/manifest.ts
@@ -1,0 +1,43 @@
+import type { SettingsManifest } from '@pops/types';
+
+/**
+ * HA bridge settings manifest — published by the pillar so the central
+ * settings UI / `discoverSettings` (ADR-037 / PRD-240) can render and
+ * validate the bridge's retention knob.
+ *
+ * The history retention worker (`src/retention-worker.ts`) reads
+ * `HA_HISTORY_RETENTION_DAYS` from env at boot. This descriptor declares
+ * the same key + default + bounds so the setting is discoverable; the
+ * `envFallback` hint tells consumers which env var the runtime currently
+ * resolves from when no user-set value exists.
+ */
+export const HA_BRIDGE_RETENTION_SETTING_KEY = 'haBridge.historyRetentionDays' as const;
+export const HA_BRIDGE_DEFAULT_RETENTION_DAYS = 30;
+
+export const haBridgeSettingsManifest: SettingsManifest = {
+  id: 'haBridge',
+  title: 'Home Assistant Bridge',
+  icon: 'Home',
+  order: 230,
+  groups: [
+    {
+      id: 'haBridgeRetention',
+      title: 'History Retention',
+      description:
+        'How long the bridge keeps `ha_state_history` rows before the periodic retention worker prunes them. The current-state snapshot in `ha_entities` is never pruned.',
+      fields: [
+        {
+          key: HA_BRIDGE_RETENTION_SETTING_KEY,
+          label: 'History Retention (days)',
+          type: 'number',
+          default: String(HA_BRIDGE_DEFAULT_RETENTION_DAYS),
+          description:
+            'Rows in `ha_state_history` older than this many days are deleted on each retention tick. Set to 0 to disable pruning entirely.',
+          validation: { min: 0, max: 3650 },
+          envFallback: 'HA_HISTORY_RETENTION_DAYS',
+          requiresRestart: true,
+        },
+      ],
+    },
+  ],
+};

--- a/docs/themes/13-pillar-finale/prds/229-ha-bridge-pillar/us-01-ws-subscriber-mirror.md
+++ b/docs/themes/13-pillar-finale/prds/229-ha-bridge-pillar/us-01-ws-subscriber-mirror.md
@@ -16,7 +16,7 @@ As `pops-ha-bridge-api`, I want to connect to a Home Assistant instance over Web
 - [ ] `HA_TOKEN` never appears in logs, tRPC responses, or the registered manifest.
 - [ ] If `HA_URL` / `HA_TOKEN` are missing or rejected, the pillar still boots, registers with the central registry, and `connection.status` returns `{ kind: 'offline' }`.
 - [ ] Unit tests cover: snapshot upsert, state-change upsert + history append, debouncing window, reconnect backoff, degraded-mode boot.
-- [ ] A retention worker deletes `ha_state_history` rows older than `HA_HISTORY_RETENTION_DAYS` (default 30) on a daily schedule.
+- [x] A retention worker deletes `ha_state_history` rows older than `HA_HISTORY_RETENTION_DAYS` (default 30) on a daily schedule.
 
 ## Notes
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -519,6 +519,9 @@ importers:
       '@pops/pillar-sdk':
         specifier: workspace:*
         version: link:../../packages/pillar-sdk
+      '@pops/types':
+        specifier: workspace:*
+        version: link:../../packages/types
       express:
         specifier: ^5.1.0
         version: 5.2.1


### PR DESCRIPTION
## Summary

- Aligns the HA bridge retention worker with PRD-229's spec by renaming the env var from `HA_BRIDGE_RETENTION_DAYS` to `HA_HISTORY_RETENTION_DAYS`.
- Publishes a `settings.manifests` entry (`haBridge.historyRetentionDays`, default 30, validated 0-3650, `envFallback: HA_HISTORY_RETENTION_DAYS`) so the knob is `discoverSettings`-discoverable per ADR-037 / PRD-240.
- Sources the worker's default from a shared manifest constant so schema, env fallback, and runtime default cannot drift.
- Ticks the final US-01 acceptance checkbox.

## Context

PRD-229's README already declares the pillar Done with US-01's "retention worker cron" called out as the one explicit follow-up. The retention worker scaffolding (`startRetentionWorker`, `pruneHistory`, `setTimeout`-based scheduling, error-recovery, server.ts wire-up) was already in place — what was missing was the spec alignment (env var name) and the `settings.manifests` discoverability hook so the knob shows up in the central settings UI.

## Test plan

- [x] `pnpm --filter @pops/ha-bridge-api test` — 85 passed (was 82; added 3: manifest-default fallback, no-op-on-zero-rows, settings manifest published)
- [x] `pnpm --filter @pops/ha-bridge-db test` — 18 passed
- [x] `pnpm --filter @pops/ha-bridge-api build`
- [x] `mise typecheck` — 73/73 pass
- [x] `mise lint` — no new findings under `apps/pops-ha-bridge-api`
- [x] `pnpm format:check` — clean