### PR TITLE
fix: unblock Publish Images — Dockerfile contract builds + inventory-contract cycle break

### DIFF
--- a/apps/pops-api/Dockerfile
+++ b/apps/pops-api/Dockerfile
@@ -14,6 +14,12 @@ COPY packages/app-lists-db/package.json ./packages/app-lists-db/
 COPY packages/core-db/package.json ./packages/core-db/
 COPY packages/finance-db/package.json ./packages/finance-db/
 COPY packages/finance-contract/package.json ./packages/finance-contract/
+COPY packages/cerebrum-contract/package.json ./packages/cerebrum-contract/
+COPY packages/core-contract/package.json ./packages/core-contract/
+COPY packages/inventory-contract/package.json ./packages/inventory-contract/
+COPY packages/media-contract/package.json ./packages/media-contract/
+COPY packages/food-contract/package.json ./packages/food-contract/
+COPY packages/lists-contract/package.json ./packages/lists-contract/
 COPY packages/pillar-sdk/package.json ./packages/pillar-sdk/
 COPY packages/media-db/package.json ./packages/media-db/
 COPY packages/food-contracts/package.json ./packages/food-contracts/
@@ -62,6 +68,12 @@ COPY packages/lists-db/src ./packages/lists-db/src
 COPY packages/lists-db/tsconfig.json ./packages/lists-db/
 COPY packages/lists-db/migrations ./packages/lists-db/migrations
 COPY packages/finance-contract/ ./packages/finance-contract/
+COPY packages/cerebrum-contract/ ./packages/cerebrum-contract/
+COPY packages/core-contract/ ./packages/core-contract/
+COPY packages/inventory-contract/ ./packages/inventory-contract/
+COPY packages/media-contract/ ./packages/media-contract/
+COPY packages/food-contract/ ./packages/food-contract/
+COPY packages/lists-contract/ ./packages/lists-contract/
 COPY packages/pillar-sdk/ ./packages/pillar-sdk/
 COPY apps/pops-api/tsconfig.json ./apps/pops-api/
 COPY apps/pops-api/src ./apps/pops-api/src
@@ -95,6 +107,18 @@ RUN pnpm build
 WORKDIR /app/packages/app-food-db
 RUN pnpm build
 WORKDIR /app/packages/finance-contract
+RUN pnpm build
+WORKDIR /app/packages/cerebrum-contract
+RUN pnpm build
+WORKDIR /app/packages/core-contract
+RUN pnpm build
+WORKDIR /app/packages/inventory-contract
+RUN pnpm build
+WORKDIR /app/packages/media-contract
+RUN pnpm build
+WORKDIR /app/packages/food-contract
+RUN pnpm build
+WORKDIR /app/packages/lists-contract
 RUN pnpm build
 WORKDIR /app/packages/pillar-sdk
 RUN pnpm build

--- a/packages/inventory-contract/package.json
+++ b/packages/inventory-contract/package.json
@@ -48,19 +48,12 @@
   },
   "dependencies": {
     "@pops/types": "workspace:*",
+    "@trpc/server": "^11.17.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {
     "tsx": "^4.22.4",
     "typescript": "^6.0.3",
     "vitest": "^4.1.8"
-  },
-  "peerDependencies": {
-    "@pops/inventory-api": "workspace:*"
-  },
-  "peerDependenciesMeta": {
-    "@pops/inventory-api": {
-      "optional": true
-    }
   }
 }

--- a/packages/inventory-contract/src/router.ts
+++ b/packages/inventory-contract/src/router.ts
@@ -1,18 +1,18 @@
-/**
- * The inventory pillar's tRPC router *type*. Type-only re-export from
- * `apps/pops-inventory-api` — no runtime tRPC code crosses the contract
- * boundary. Consumers use this to type the `pillar('inventory').foo.bar(…)`
- * SDK calls (Epic 05 / PRD-191).
- *
- * Current shape: `typeof inventoryRouter`. Until PRD-153 us-04 + PRD-155 land
- * the build-time declaration bundler, this re-export means the contract's
- * emitted `.d.ts` still references `@pops/inventory-api` (which transitively
- * references `@pops/inventory-db`). The lint rule in PRD-156 stays focused
- * on *value* imports; type-only references through the contract are
- * tolerated as the migration intermediate. A committed OpenAPI snapshot
- * at `openapi/inventory.openapi.json` is the wire-typed alternative consumers
- * (e.g. iOS Swift codegen) can use instead.
- */
-import type { inventoryRouter } from '@pops/inventory-api/router';
+import type { AnyTRPCRouter } from '@trpc/server';
 
-export type InventoryRouter = typeof inventoryRouter;
+/**
+ * Opaque tRPC router type for the inventory pillar. Mirrors the
+ * media-contract pattern: `InventoryRouter` is `AnyTRPCRouter`, so
+ * consumers using `pillar<InventoryRouter>('inventory')` get a fully
+ * opaque `PillarHandle` with no route or procedure keys preserved. The
+ * committed OpenAPI snapshot at `openapi/inventory.openapi.json` is the
+ * wire-typed alternative until PRD-155 ships the declaration bundler.
+ *
+ * Previously `typeof inventoryRouter` re-exported from
+ * `@pops/inventory-api`, but PRD-239 had `inventory-api` consume
+ * `inventoryManifest` from `@pops/inventory-contract/settings`, closing
+ * a `inventory-contract → inventory-api → inventory-contract`
+ * build-graph cycle that broke standalone Docker builds that don't ship
+ * `apps/pops-inventory-api/src`.
+ */
+export type InventoryRouter = AnyTRPCRouter;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2026,12 +2026,12 @@ importers:
 
   packages/inventory-contract:
     dependencies:
-      '@pops/inventory-api':
-        specifier: workspace:*
-        version: link:../../apps/pops-inventory-api
       '@pops/types':
         specifier: workspace:*
         version: link:../types
+      '@trpc/server':
+        specifier: ^11.17.0
+        version: 11.17.0(typescript@6.0.3)
       zod:
         specifier: ^4.4.3
         version: 4.4.3


### PR DESCRIPTION
## Summary

Publish Images for #3257 (the entities/types.ts unblock) still failed with two cascading errors:

1. **Contract `/settings` subpath resolution** — `Cannot find module '@pops/cerebrum-contract/settings'` and same for core/inventory/media/lists. PRD-239 added `/settings` subpath exports to every contract package, but the Dockerfile never COPY'd or built any of them except `finance-contract`. Their `dist/settings/index.d.ts` was missing in the Docker build context.
2. **Test typing cascade** — `Property 'cerebrum' / 'media' does not exist on type 'DecorateRouterRecord<...InstalledRouterMap>>'`. Downstream of #1: when the contract types fail to resolve, `InstalledRouterMap` inference cascades into a degraded state.
3. **Inventory-contract cycle** — `inventory-contract → inventory-api → inventory-contract` introduced by PRD-239 US-02 (inventory-api consumes `inventoryManifest` from `@pops/inventory-contract/settings`). Standalone Docker builds that don't ship `apps/pops-inventory-api/src` can't resolve this.

## Changes

- `apps/pops-api/Dockerfile`: add COPY (package.json + sources) + RUN `pnpm build` for `cerebrum-contract`, `core-contract`, `inventory-contract`, `media-contract`, `food-contract`, `lists-contract`.
- `packages/inventory-contract/src/router.ts`: switch from `typeof inventoryRouter` to opaque `AnyTRPCRouter` — mirrors the `MediaRouter` cycle-break pattern (PRD-239 US-05). OpenAPI snapshot remains the wire-typed alternative.
- `packages/inventory-contract/package.json`: add `@trpc/server` as runtime dep, drop the `@pops/inventory-api` optional peerDep (no longer needed).
- `pnpm-lock.yaml`: regenerated.

## Test plan

- [x] `pnpm --filter @pops/inventory-contract build` — passes
- [x] `pnpm --filter @pops/api build` — zero TS errors
- [ ] Publish Images workflow goes green on main after merge
- [ ] Watchtower pulls new pops-api image; capivara crash loop resolves (#3253 catch lands)