### PR TITLE
fix(shell): Dockerfile contract builds — unblock remaining pillar images

### DIFF
--- a/apps/pops-shell/Dockerfile
+++ b/apps/pops-shell/Dockerfile
@@ -32,6 +32,12 @@ COPY packages/navigation/package.json ./packages/navigation/
 COPY packages/types/package.json ./packages/types/
 COPY packages/module-registry/package.json ./packages/module-registry/
 COPY packages/finance-contract/package.json ./packages/finance-contract/
+COPY packages/cerebrum-contract/package.json ./packages/cerebrum-contract/
+COPY packages/core-contract/package.json ./packages/core-contract/
+COPY packages/inventory-contract/package.json ./packages/inventory-contract/
+COPY packages/media-contract/package.json ./packages/media-contract/
+COPY packages/food-contract/package.json ./packages/food-contract/
+COPY packages/lists-contract/package.json ./packages/lists-contract/
 COPY packages/pillar-sdk/package.json ./packages/pillar-sdk/
 
 # Install pnpm and dependencies (cached across builds)
@@ -57,6 +63,12 @@ COPY packages/food-db/ ./packages/food-db/
 COPY packages/lists-db/ ./packages/lists-db/
 COPY packages/food-contracts/ ./packages/food-contracts/
 COPY packages/finance-contract/ ./packages/finance-contract/
+COPY packages/cerebrum-contract/ ./packages/cerebrum-contract/
+COPY packages/core-contract/ ./packages/core-contract/
+COPY packages/inventory-contract/ ./packages/inventory-contract/
+COPY packages/media-contract/ ./packages/media-contract/
+COPY packages/food-contract/ ./packages/food-contract/
+COPY packages/lists-contract/ ./packages/lists-contract/
 COPY packages/pillar-sdk/ ./packages/pillar-sdk/
 WORKDIR /app/packages/db-types
 RUN pnpm build
@@ -85,6 +97,18 @@ RUN pnpm build
 WORKDIR /app/packages/app-food-db
 RUN pnpm build
 WORKDIR /app/packages/finance-contract
+RUN pnpm build
+WORKDIR /app/packages/cerebrum-contract
+RUN pnpm build
+WORKDIR /app/packages/core-contract
+RUN pnpm build
+WORKDIR /app/packages/inventory-contract
+RUN pnpm build
+WORKDIR /app/packages/media-contract
+RUN pnpm build
+WORKDIR /app/packages/food-contract
+RUN pnpm build
+WORKDIR /app/packages/lists-contract
 RUN pnpm build
 WORKDIR /app/packages/pillar-sdk
 RUN pnpm build


### PR DESCRIPTION
Same shape as #3261 (pops-api Dockerfile fix), now for pops-shell. The shell build references pops-api sources for type-only purposes, which transitively need PRD-239 `/settings` subpath exports from cerebrum/core/inventory/media/food/lists contracts. Without their dist/ in the build context, tsc fails with TS2307.

This unblocks the remaining pillar images in Publish Images (pops-mcp, pops-core-api, pops-inventory-api, pops-media-api, pops-finance-api, pops-food-api) which never got to build because shell failed first.

Capivara recovery requires the pops-api image with #3253 catch — that ALREADY pushed successfully on #3261. Watchtower will pull it on next poll cycle.