### PR TITLE
chore(test): delete 10 stale-mock vi.mock blocks (silent-failure cleanup, audit-driven)

### DIFF
--- a/apps/pops-api/src/jobs/handlers/curation.test.ts
+++ b/apps/pops-api/src/jobs/handlers/curation.test.ts
@@ -56,10 +56,6 @@ vi.mock('../../modules/cerebrum/engrams/scope-reconciliation.js', () => ({
   }),
 }));
 
-vi.mock('../../db.js', () => ({
-  getDrizzle: () => ({}),
-}));
-
 vi.mock('../../db/cerebrum-handle.js', () => ({
   getCerebrumDrizzle: () => ({}),
 }));

--- a/apps/pops-api/src/modules/core/corrections/lib/rule-generator.test.ts
+++ b/apps/pops-api/src/modules/core/corrections/lib/rule-generator.test.ts
@@ -21,7 +21,6 @@ vi.mock('../../../../db.js', () => {
     }),
   };
   return {
-    getDrizzle: () => stubDrizzle,
     getCoreDrizzle: () => stubDrizzle,
   };
 });

--- a/apps/pops-api/src/modules/core/embeddings/service.test.ts
+++ b/apps/pops-api/src/modules/core/embeddings/service.test.ts
@@ -30,7 +30,6 @@ let testDrizzle: ReturnType<typeof drizzle>;
 let vecAvailable = true;
 
 vi.mock('../../../db.js', () => ({
-  getDrizzle: () => testDrizzle,
   getDb: () => testDb,
   isVecAvailable: () => vecAvailable,
 }));

--- a/apps/pops-api/src/modules/finance/imports/lib/ai-categorizer-disk.integration.test.ts
+++ b/apps/pops-api/src/modules/finance/imports/lib/ai-categorizer-disk.integration.test.ts
@@ -28,7 +28,6 @@ vi.mock('../../../../db.js', () => {
     })),
   };
   return {
-    getDrizzle: vi.fn(() => stubDrizzle),
     getCoreDrizzle: vi.fn(() => stubDrizzle),
     isNamedEnvContext: vi.fn().mockReturnValue(false),
   };

--- a/apps/pops-api/src/modules/finance/imports/lib/ai-categorizer.test.ts
+++ b/apps/pops-api/src/modules/finance/imports/lib/ai-categorizer.test.ts
@@ -34,7 +34,6 @@ vi.mock('../../../../db.js', () => {
     })),
   };
   return {
-    getDrizzle: vi.fn(() => stubDrizzle),
     getCoreDrizzle: vi.fn(() => stubDrizzle),
     // Always return false: tests exercise the real API path, not the named-env skip
     isNamedEnvContext: vi.fn().mockReturnValue(false),

--- a/apps/pops-api/src/modules/media/discovery/router.test.ts
+++ b/apps/pops-api/src/modules/media/discovery/router.test.ts
@@ -47,14 +47,6 @@ vi.mock('../tmdb/index.js', () => ({
   getTmdbClient: vi.fn(() => ({})),
 }));
 
-vi.mock('../../../db.js', () => ({
-  getDrizzle: vi.fn(() => ({
-    select: vi.fn().mockReturnThis(),
-    from: vi.fn().mockReturnThis(),
-    all: vi.fn(() => []),
-  })),
-}));
-
 import { createCaller } from '../../../shared/test-utils.js';
 import * as service from './service.js';
 import * as registry from './shelf/registry.js';

--- a/apps/pops-api/src/modules/media/plex/scheduler.test.ts
+++ b/apps/pops-api/src/modules/media/plex/scheduler.test.ts
@@ -56,24 +56,6 @@ vi.mock('../../../db.js', () => ({
       },
     }),
   })),
-  getDrizzle: vi.fn(() => ({
-    select: () => ({
-      from: () => ({
-        orderBy: () => ({
-          limit: () => ({
-            get: (): unknown => null,
-            all: (): unknown[] => mockSelectSyncLogs() as unknown[],
-          }),
-        }),
-      }),
-    }),
-    insert: () => ({
-      values: (vals: Record<string, unknown>) => {
-        if ('syncedAt' in vals) mockInsertSyncLog(vals);
-        return { run: vi.fn() };
-      },
-    }),
-  })),
 }));
 
 vi.mock('@pops/core-db', () => ({


### PR DESCRIPTION
## Summary

Wave 5 stale-mock cleanup. The audit flagged 10 `vi.mock('@pops/<pkg>')` blocks that supply a `getDrizzle` symbol the direct SUT no longer uses — dead weight that masks coupling regressions. After verifying each by deleting and running the affected test:

- **7 deletions kept**: mock was truly stale (full block removed when `getDrizzle` was the only export; single property removed when other exports remain in use by the SUT).
- **3 candidates restored**: the audit's "direct SUT clean" check missed transitive callers. Helpers downstream of the SUT still call `getDrizzle()` at runtime, so the mock IS load-bearing.

### Files modified (mock removed)

| File | Removed |
| --- | --- |
| `apps/pops-api/src/jobs/handlers/curation.test.ts` | full `db.js` mock block (only `getDrizzle`) |
| `apps/pops-api/src/modules/core/embeddings/service.test.ts` | `getDrizzle` line only |
| `apps/pops-api/src/modules/core/corrections/lib/rule-generator.test.ts` | `getDrizzle` line only |
| `apps/pops-api/src/modules/finance/imports/lib/ai-categorizer.test.ts` | `getDrizzle` line only |
| `apps/pops-api/src/modules/finance/imports/lib/ai-categorizer-disk.integration.test.ts` | `getDrizzle` line only |
| `apps/pops-api/src/modules/media/discovery/router.test.ts` | full `db.js` mock block (only `getDrizzle`) |
| `apps/pops-api/src/modules/media/plex/scheduler.test.ts` | full `getDrizzle` factory (duplicate of `getCoreDrizzle`) |

### Files skipped (load-bearing through transitive imports)

| File | Why |
| --- | --- |
| `apps/pops-api/src/jobs/handlers/embeddings.test.ts` | `embeddings-helpers.ts:207` calls `getDrizzle()` |
| `apps/pops-api/src/modules/media/plex/sync-tv.test.ts` | `sync-helpers.ts` (transitively imported) calls `getDrizzle()` |
| `apps/pops-api/src/modules/media/plex/sync-watch-history.test.ts` | same `sync-helpers.ts` transitive dependency |

Each "restored" item was confirmed by running the test with the mock removed and observing the failures (`No "getDrizzle" export is defined on the mock`), then putting the mock back. Worth noting for the audit harness: the "SUT clean" heuristic should walk one hop into local helpers.

## Test plan

- [x] Every affected test file passes individually
- [x] Full pops-api suite green (4899 tests)
- [x] Disk integration test passes (`vitest.integration.config.ts`)
- [x] `pnpm --filter @pops/api typecheck` clean
- [x] `oxlint --type-aware` clean on all 7 changed files
