### PR TITLE
fix(docker): add contract builds to remaining 8 Dockerfiles — unblock Publish Images for all pillar images

### DIFF
--- a/apps/pops-cerebrum-api/Dockerfile
+++ b/apps/pops-cerebrum-api/Dockerfile
@@ -10,6 +10,12 @@ COPY packages/types/package.json ./packages/types/
 COPY packages/core-db/package.json ./packages/core-db/
 COPY packages/cerebrum-db/package.json ./packages/cerebrum-db/
 COPY packages/finance-contract/package.json ./packages/finance-contract/
+COPY packages/cerebrum-contract/package.json ./packages/cerebrum-contract/
+COPY packages/core-contract/package.json ./packages/core-contract/
+COPY packages/inventory-contract/package.json ./packages/inventory-contract/
+COPY packages/media-contract/package.json ./packages/media-contract/
+COPY packages/food-contract/package.json ./packages/food-contract/
+COPY packages/lists-contract/package.json ./packages/lists-contract/
 COPY packages/pillar-sdk/package.json ./packages/pillar-sdk/
 COPY apps/pops-cerebrum-api/package.json ./apps/pops-cerebrum-api/
 
@@ -29,6 +35,12 @@ COPY packages/cerebrum-db/src ./packages/cerebrum-db/src
 COPY packages/cerebrum-db/tsconfig.json ./packages/cerebrum-db/
 COPY packages/cerebrum-db/migrations ./packages/cerebrum-db/migrations
 COPY packages/finance-contract/ ./packages/finance-contract/
+COPY packages/cerebrum-contract/ ./packages/cerebrum-contract/
+COPY packages/core-contract/ ./packages/core-contract/
+COPY packages/inventory-contract/ ./packages/inventory-contract/
+COPY packages/media-contract/ ./packages/media-contract/
+COPY packages/food-contract/ ./packages/food-contract/
+COPY packages/lists-contract/ ./packages/lists-contract/
 COPY packages/pillar-sdk/ ./packages/pillar-sdk/
 
 # Copy cerebrum-api source
@@ -45,6 +57,18 @@ RUN pnpm build
 WORKDIR /app/packages/cerebrum-db
 RUN pnpm build
 WORKDIR /app/packages/finance-contract
+RUN pnpm build
+WORKDIR /app/packages/cerebrum-contract
+RUN pnpm build
+WORKDIR /app/packages/core-contract
+RUN pnpm build
+WORKDIR /app/packages/inventory-contract
+RUN pnpm build
+WORKDIR /app/packages/media-contract
+RUN pnpm build
+WORKDIR /app/packages/food-contract
+RUN pnpm build
+WORKDIR /app/packages/lists-contract
 RUN pnpm build
 WORKDIR /app/packages/pillar-sdk
 RUN pnpm build

--- a/apps/pops-core-api/Dockerfile
+++ b/apps/pops-core-api/Dockerfile
@@ -13,6 +13,12 @@ COPY packages/db-types/package.json ./packages/db-types/
 COPY packages/types/package.json ./packages/types/
 COPY packages/core-db/package.json ./packages/core-db/
 COPY packages/finance-contract/package.json ./packages/finance-contract/
+COPY packages/cerebrum-contract/package.json ./packages/cerebrum-contract/
+COPY packages/core-contract/package.json ./packages/core-contract/
+COPY packages/inventory-contract/package.json ./packages/inventory-contract/
+COPY packages/media-contract/package.json ./packages/media-contract/
+COPY packages/food-contract/package.json ./packages/food-contract/
+COPY packages/lists-contract/package.json ./packages/lists-contract/
 COPY packages/pillar-sdk/package.json ./packages/pillar-sdk/
 COPY packages/wire-conformance/package.json ./packages/wire-conformance/
 COPY apps/pops-core-api/package.json ./apps/pops-core-api/
@@ -30,6 +36,12 @@ COPY packages/core-db/src ./packages/core-db/src
 COPY packages/core-db/tsconfig.json ./packages/core-db/
 COPY packages/core-db/migrations ./packages/core-db/migrations
 COPY packages/finance-contract/ ./packages/finance-contract/
+COPY packages/cerebrum-contract/ ./packages/cerebrum-contract/
+COPY packages/core-contract/ ./packages/core-contract/
+COPY packages/inventory-contract/ ./packages/inventory-contract/
+COPY packages/media-contract/ ./packages/media-contract/
+COPY packages/food-contract/ ./packages/food-contract/
+COPY packages/lists-contract/ ./packages/lists-contract/
 COPY packages/pillar-sdk/src ./packages/pillar-sdk/src
 COPY packages/pillar-sdk/tsconfig.json ./packages/pillar-sdk/
 
@@ -45,6 +57,18 @@ RUN pnpm build
 WORKDIR /app/packages/core-db
 RUN pnpm build
 WORKDIR /app/packages/finance-contract
+RUN pnpm build
+WORKDIR /app/packages/cerebrum-contract
+RUN pnpm build
+WORKDIR /app/packages/core-contract
+RUN pnpm build
+WORKDIR /app/packages/inventory-contract
+RUN pnpm build
+WORKDIR /app/packages/media-contract
+RUN pnpm build
+WORKDIR /app/packages/food-contract
+RUN pnpm build
+WORKDIR /app/packages/lists-contract
 RUN pnpm build
 WORKDIR /app/packages/pillar-sdk
 RUN pnpm build

--- a/apps/pops-finance-api/Dockerfile
+++ b/apps/pops-finance-api/Dockerfile
@@ -10,6 +10,12 @@ COPY packages/types/package.json ./packages/types/
 COPY packages/core-db/package.json ./packages/core-db/
 COPY packages/finance-db/package.json ./packages/finance-db/
 COPY packages/finance-contract/package.json ./packages/finance-contract/
+COPY packages/cerebrum-contract/package.json ./packages/cerebrum-contract/
+COPY packages/core-contract/package.json ./packages/core-contract/
+COPY packages/inventory-contract/package.json ./packages/inventory-contract/
+COPY packages/media-contract/package.json ./packages/media-contract/
+COPY packages/food-contract/package.json ./packages/food-contract/
+COPY packages/lists-contract/package.json ./packages/lists-contract/
 COPY packages/pillar-sdk/package.json ./packages/pillar-sdk/
 COPY apps/pops-finance-api/package.json ./apps/pops-finance-api/
 
@@ -29,6 +35,12 @@ COPY packages/finance-db/src ./packages/finance-db/src
 COPY packages/finance-db/tsconfig.json ./packages/finance-db/
 COPY packages/finance-db/migrations ./packages/finance-db/migrations
 COPY packages/finance-contract/ ./packages/finance-contract/
+COPY packages/cerebrum-contract/ ./packages/cerebrum-contract/
+COPY packages/core-contract/ ./packages/core-contract/
+COPY packages/inventory-contract/ ./packages/inventory-contract/
+COPY packages/media-contract/ ./packages/media-contract/
+COPY packages/food-contract/ ./packages/food-contract/
+COPY packages/lists-contract/ ./packages/lists-contract/
 COPY packages/pillar-sdk/src ./packages/pillar-sdk/src
 COPY packages/pillar-sdk/tsconfig.json ./packages/pillar-sdk/
 
@@ -46,6 +58,18 @@ RUN pnpm build
 WORKDIR /app/packages/finance-db
 RUN pnpm build
 WORKDIR /app/packages/finance-contract
+RUN pnpm build
+WORKDIR /app/packages/cerebrum-contract
+RUN pnpm build
+WORKDIR /app/packages/core-contract
+RUN pnpm build
+WORKDIR /app/packages/inventory-contract
+RUN pnpm build
+WORKDIR /app/packages/media-contract
+RUN pnpm build
+WORKDIR /app/packages/food-contract
+RUN pnpm build
+WORKDIR /app/packages/lists-contract
 RUN pnpm build
 WORKDIR /app/packages/pillar-sdk
 RUN pnpm build

--- a/apps/pops-food-api/Dockerfile
+++ b/apps/pops-food-api/Dockerfile
@@ -9,6 +9,12 @@ COPY packages/db-types/package.json ./packages/db-types/
 COPY packages/types/package.json ./packages/types/
 COPY packages/food-db/package.json ./packages/food-db/
 COPY packages/finance-contract/package.json ./packages/finance-contract/
+COPY packages/cerebrum-contract/package.json ./packages/cerebrum-contract/
+COPY packages/core-contract/package.json ./packages/core-contract/
+COPY packages/inventory-contract/package.json ./packages/inventory-contract/
+COPY packages/media-contract/package.json ./packages/media-contract/
+COPY packages/food-contract/package.json ./packages/food-contract/
+COPY packages/lists-contract/package.json ./packages/lists-contract/
 COPY packages/pillar-sdk/package.json ./packages/pillar-sdk/
 COPY apps/pops-food-api/package.json ./apps/pops-food-api/
 
@@ -25,6 +31,12 @@ COPY packages/food-db/src ./packages/food-db/src
 COPY packages/food-db/tsconfig.json ./packages/food-db/
 COPY packages/food-db/migrations ./packages/food-db/migrations
 COPY packages/finance-contract/ ./packages/finance-contract/
+COPY packages/cerebrum-contract/ ./packages/cerebrum-contract/
+COPY packages/core-contract/ ./packages/core-contract/
+COPY packages/inventory-contract/ ./packages/inventory-contract/
+COPY packages/media-contract/ ./packages/media-contract/
+COPY packages/food-contract/ ./packages/food-contract/
+COPY packages/lists-contract/ ./packages/lists-contract/
 COPY packages/pillar-sdk/ ./packages/pillar-sdk/
 
 # Copy food-api source
@@ -39,6 +51,18 @@ RUN pnpm build
 WORKDIR /app/packages/food-db
 RUN pnpm build
 WORKDIR /app/packages/finance-contract
+RUN pnpm build
+WORKDIR /app/packages/cerebrum-contract
+RUN pnpm build
+WORKDIR /app/packages/core-contract
+RUN pnpm build
+WORKDIR /app/packages/inventory-contract
+RUN pnpm build
+WORKDIR /app/packages/media-contract
+RUN pnpm build
+WORKDIR /app/packages/food-contract
+RUN pnpm build
+WORKDIR /app/packages/lists-contract
 RUN pnpm build
 WORKDIR /app/packages/pillar-sdk
 RUN pnpm build

--- a/apps/pops-inventory-api/Dockerfile
+++ b/apps/pops-inventory-api/Dockerfile
@@ -10,6 +10,12 @@ COPY packages/types/package.json ./packages/types/
 COPY packages/core-db/package.json ./packages/core-db/
 COPY packages/inventory-db/package.json ./packages/inventory-db/
 COPY packages/finance-contract/package.json ./packages/finance-contract/
+COPY packages/cerebrum-contract/package.json ./packages/cerebrum-contract/
+COPY packages/core-contract/package.json ./packages/core-contract/
+COPY packages/inventory-contract/package.json ./packages/inventory-contract/
+COPY packages/media-contract/package.json ./packages/media-contract/
+COPY packages/food-contract/package.json ./packages/food-contract/
+COPY packages/lists-contract/package.json ./packages/lists-contract/
 COPY packages/pillar-sdk/package.json ./packages/pillar-sdk/
 COPY apps/pops-inventory-api/package.json ./apps/pops-inventory-api/
 
@@ -29,6 +35,12 @@ COPY packages/inventory-db/src ./packages/inventory-db/src
 COPY packages/inventory-db/tsconfig.json ./packages/inventory-db/
 COPY packages/inventory-db/migrations ./packages/inventory-db/migrations
 COPY packages/finance-contract/ ./packages/finance-contract/
+COPY packages/cerebrum-contract/ ./packages/cerebrum-contract/
+COPY packages/core-contract/ ./packages/core-contract/
+COPY packages/inventory-contract/ ./packages/inventory-contract/
+COPY packages/media-contract/ ./packages/media-contract/
+COPY packages/food-contract/ ./packages/food-contract/
+COPY packages/lists-contract/ ./packages/lists-contract/
 COPY packages/pillar-sdk/ ./packages/pillar-sdk/
 
 # Copy inventory-api source
@@ -45,6 +57,18 @@ RUN pnpm build
 WORKDIR /app/packages/inventory-db
 RUN pnpm build
 WORKDIR /app/packages/finance-contract
+RUN pnpm build
+WORKDIR /app/packages/cerebrum-contract
+RUN pnpm build
+WORKDIR /app/packages/core-contract
+RUN pnpm build
+WORKDIR /app/packages/inventory-contract
+RUN pnpm build
+WORKDIR /app/packages/media-contract
+RUN pnpm build
+WORKDIR /app/packages/food-contract
+RUN pnpm build
+WORKDIR /app/packages/lists-contract
 RUN pnpm build
 WORKDIR /app/packages/pillar-sdk
 RUN pnpm build

--- a/apps/pops-lists-api/Dockerfile
+++ b/apps/pops-lists-api/Dockerfile
@@ -9,6 +9,12 @@ COPY packages/db-types/package.json ./packages/db-types/
 COPY packages/types/package.json ./packages/types/
 COPY packages/lists-db/package.json ./packages/lists-db/
 COPY packages/finance-contract/package.json ./packages/finance-contract/
+COPY packages/cerebrum-contract/package.json ./packages/cerebrum-contract/
+COPY packages/core-contract/package.json ./packages/core-contract/
+COPY packages/inventory-contract/package.json ./packages/inventory-contract/
+COPY packages/media-contract/package.json ./packages/media-contract/
+COPY packages/food-contract/package.json ./packages/food-contract/
+COPY packages/lists-contract/package.json ./packages/lists-contract/
 COPY packages/pillar-sdk/package.json ./packages/pillar-sdk/
 COPY apps/pops-lists-api/package.json ./apps/pops-lists-api/
 
@@ -25,6 +31,12 @@ COPY packages/lists-db/src ./packages/lists-db/src
 COPY packages/lists-db/tsconfig.json ./packages/lists-db/
 COPY packages/lists-db/migrations ./packages/lists-db/migrations
 COPY packages/finance-contract/ ./packages/finance-contract/
+COPY packages/cerebrum-contract/ ./packages/cerebrum-contract/
+COPY packages/core-contract/ ./packages/core-contract/
+COPY packages/inventory-contract/ ./packages/inventory-contract/
+COPY packages/media-contract/ ./packages/media-contract/
+COPY packages/food-contract/ ./packages/food-contract/
+COPY packages/lists-contract/ ./packages/lists-contract/
 COPY packages/pillar-sdk/ ./packages/pillar-sdk/
 
 # Copy lists-api source
@@ -39,6 +51,18 @@ RUN pnpm build
 WORKDIR /app/packages/lists-db
 RUN pnpm build
 WORKDIR /app/packages/finance-contract
+RUN pnpm build
+WORKDIR /app/packages/cerebrum-contract
+RUN pnpm build
+WORKDIR /app/packages/core-contract
+RUN pnpm build
+WORKDIR /app/packages/inventory-contract
+RUN pnpm build
+WORKDIR /app/packages/media-contract
+RUN pnpm build
+WORKDIR /app/packages/food-contract
+RUN pnpm build
+WORKDIR /app/packages/lists-contract
 RUN pnpm build
 WORKDIR /app/packages/pillar-sdk
 RUN pnpm build

--- a/apps/pops-mcp/Dockerfile
+++ b/apps/pops-mcp/Dockerfile
@@ -14,6 +14,12 @@ COPY packages/app-lists-db/package.json ./packages/app-lists-db/
 COPY packages/core-db/package.json ./packages/core-db/
 COPY packages/finance-db/package.json ./packages/finance-db/
 COPY packages/finance-contract/package.json ./packages/finance-contract/
+COPY packages/cerebrum-contract/package.json ./packages/cerebrum-contract/
+COPY packages/core-contract/package.json ./packages/core-contract/
+COPY packages/inventory-contract/package.json ./packages/inventory-contract/
+COPY packages/media-contract/package.json ./packages/media-contract/
+COPY packages/food-contract/package.json ./packages/food-contract/
+COPY packages/lists-contract/package.json ./packages/lists-contract/
 COPY packages/pillar-sdk/package.json ./packages/pillar-sdk/
 COPY packages/media-db/package.json ./packages/media-db/
 COPY packages/food-contracts/package.json ./packages/food-contracts/
@@ -63,6 +69,12 @@ COPY packages/lists-db/src ./packages/lists-db/src
 COPY packages/lists-db/tsconfig.json ./packages/lists-db/
 COPY packages/lists-db/migrations ./packages/lists-db/migrations
 COPY packages/finance-contract/ ./packages/finance-contract/
+COPY packages/cerebrum-contract/ ./packages/cerebrum-contract/
+COPY packages/core-contract/ ./packages/core-contract/
+COPY packages/inventory-contract/ ./packages/inventory-contract/
+COPY packages/media-contract/ ./packages/media-contract/
+COPY packages/food-contract/ ./packages/food-contract/
+COPY packages/lists-contract/ ./packages/lists-contract/
 COPY packages/pillar-sdk/ ./packages/pillar-sdk/
 
 # Copy pops-api source (needed only for AppRouter type resolution at compile time)
@@ -102,6 +114,18 @@ RUN pnpm build
 WORKDIR /app/packages/app-food-db
 RUN pnpm build
 WORKDIR /app/packages/finance-contract
+RUN pnpm build
+WORKDIR /app/packages/cerebrum-contract
+RUN pnpm build
+WORKDIR /app/packages/core-contract
+RUN pnpm build
+WORKDIR /app/packages/inventory-contract
+RUN pnpm build
+WORKDIR /app/packages/media-contract
+RUN pnpm build
+WORKDIR /app/packages/food-contract
+RUN pnpm build
+WORKDIR /app/packages/lists-contract
 RUN pnpm build
 WORKDIR /app/packages/pillar-sdk
 RUN pnpm build

--- a/apps/pops-media-api/Dockerfile
+++ b/apps/pops-media-api/Dockerfile
@@ -9,6 +9,12 @@ COPY packages/db-types/package.json ./packages/db-types/
 COPY packages/types/package.json ./packages/types/
 COPY packages/media-db/package.json ./packages/media-db/
 COPY packages/finance-contract/package.json ./packages/finance-contract/
+COPY packages/cerebrum-contract/package.json ./packages/cerebrum-contract/
+COPY packages/core-contract/package.json ./packages/core-contract/
+COPY packages/inventory-contract/package.json ./packages/inventory-contract/
+COPY packages/media-contract/package.json ./packages/media-contract/
+COPY packages/food-contract/package.json ./packages/food-contract/
+COPY packages/lists-contract/package.json ./packages/lists-contract/
 COPY packages/pillar-sdk/package.json ./packages/pillar-sdk/
 COPY apps/pops-media-api/package.json ./apps/pops-media-api/
 
@@ -25,6 +31,12 @@ COPY packages/media-db/src ./packages/media-db/src
 COPY packages/media-db/tsconfig.json ./packages/media-db/
 COPY packages/media-db/migrations ./packages/media-db/migrations
 COPY packages/finance-contract/ ./packages/finance-contract/
+COPY packages/cerebrum-contract/ ./packages/cerebrum-contract/
+COPY packages/core-contract/ ./packages/core-contract/
+COPY packages/inventory-contract/ ./packages/inventory-contract/
+COPY packages/media-contract/ ./packages/media-contract/
+COPY packages/food-contract/ ./packages/food-contract/
+COPY packages/lists-contract/ ./packages/lists-contract/
 COPY packages/pillar-sdk/ ./packages/pillar-sdk/
 
 # Copy media-api source
@@ -39,6 +51,18 @@ RUN pnpm build
 WORKDIR /app/packages/media-db
 RUN pnpm build
 WORKDIR /app/packages/finance-contract
+RUN pnpm build
+WORKDIR /app/packages/cerebrum-contract
+RUN pnpm build
+WORKDIR /app/packages/core-contract
+RUN pnpm build
+WORKDIR /app/packages/inventory-contract
+RUN pnpm build
+WORKDIR /app/packages/media-contract
+RUN pnpm build
+WORKDIR /app/packages/food-contract
+RUN pnpm build
+WORKDIR /app/packages/lists-contract
 RUN pnpm build
 WORKDIR /app/packages/pillar-sdk
 RUN pnpm build


### PR DESCRIPTION
## Summary

Publish Images CI was failing on every pillar API + pops-mcp because each Dockerfile was missing COPY + build steps for the 6 contract packages added by PRD-239 (cerebrum/core/inventory/media/food/lists). Their `/settings` subpath exports are transitively imported by the consumer's `tsc` step, but the contract `dist/` is never produced in the Docker build context.

This applies the same fix that landed for `pops-api` in #3261 and `pops-shell` in #3263 to the remaining 8 Dockerfiles. For each:

1. `COPY packages/<contract>/package.json ./packages/<contract>/` — so `pnpm install` resolves workspace deps
2. `COPY packages/<contract>/ ./packages/<contract>/` — source for the build
3. `WORKDIR /app/packages/<contract>` + `RUN pnpm build` — before the consumer's build

## Files changed

- `apps/pops-mcp/Dockerfile`
- `apps/pops-core-api/Dockerfile`
- `apps/pops-inventory-api/Dockerfile`
- `apps/pops-media-api/Dockerfile`
- `apps/pops-finance-api/Dockerfile`
- `apps/pops-food-api/Dockerfile`
- `apps/pops-cerebrum-api/Dockerfile`
- `apps/pops-lists-api/Dockerfile`

Each: +24 lines (6 package.json COPYs, 6 source COPYs, 6 WORKDIR + 6 `pnpm build`).

Skipped:
- `apps/pops-api/Dockerfile` — already fixed in #3261
- `apps/pops-shell/Dockerfile` — already fixed in #3263
- `apps/pops-ha-bridge-api/Dockerfile` — separate image, not part of Publish Images failure
- `apps/pops-docs/Dockerfile` — out of scope

## Test plan

- [ ] CI: Publish Images green for all 8 images
- [ ] CI: no regressions on existing pipelines
