### PR TITLE
fix(api): catch FeatureNotFoundError in resumeRotationSchedulerIfEnabled (#3253 mirror)

### DIFF
--- a/apps/pops-api/src/modules/media/rotation/scheduler.ts
+++ b/apps/pops-api/src/modules/media/rotation/scheduler.ts
@@ -12,8 +12,18 @@ import cron, { type ScheduledTask } from 'node-cron';
 import { SettingNotFoundError, settingsService } from '@pops/core-db';
 
 import { getCoreDrizzle } from '../../../db.js';
+import { FeatureNotFoundError } from '../../core/features/errors.js';
 import { isEnabled } from '../../core/features/index.js';
 import { emptyResult } from './rotation-cycle-types.js';
+
+function isRotationEnabled(): boolean {
+  try {
+    return isEnabled('media.rotation');
+  } catch (err) {
+    if (err instanceof FeatureNotFoundError) return false;
+    throw err;
+  }
+}
 import { executeRotationCycle } from './rotation-cycle.js';
 import { writeRotationLog } from './rotation-log.js';
 
@@ -126,7 +136,7 @@ export function getRotationSchedulerStatus(): RotationSchedulerStatus {
 }
 
 export function resumeRotationSchedulerIfEnabled(): RotationSchedulerStatus | null {
-  if (!isEnabled('media.rotation')) return null;
+  if (!isRotationEnabled()) return null;
   const savedCron = getSetting(SETTINGS_KEYS.cronExpression) ?? DEFAULT_CRON;
   console.warn(`[Rotation] Auto-resuming scheduler (cron: ${savedCron})`);
   return startRotationScheduler({ cronExpression: savedCron });

--- a/apps/pops-shell/Dockerfile
+++ b/apps/pops-shell/Dockerfile
@@ -32,6 +32,12 @@ COPY packages/navigation/package.json ./packages/navigation/
 COPY packages/types/package.json ./packages/types/
 COPY packages/module-registry/package.json ./packages/module-registry/
 COPY packages/finance-contract/package.json ./packages/finance-contract/
+COPY packages/cerebrum-contract/package.json ./packages/cerebrum-contract/
+COPY packages/core-contract/package.json ./packages/core-contract/
+COPY packages/inventory-contract/package.json ./packages/inventory-contract/
+COPY packages/media-contract/package.json ./packages/media-contract/
+COPY packages/food-contract/package.json ./packages/food-contract/
+COPY packages/lists-contract/package.json ./packages/lists-contract/
 COPY packages/pillar-sdk/package.json ./packages/pillar-sdk/
 
 # Install pnpm and dependencies (cached across builds)
@@ -57,6 +63,12 @@ COPY packages/food-db/ ./packages/food-db/
 COPY packages/lists-db/ ./packages/lists-db/
 COPY packages/food-contracts/ ./packages/food-contracts/
 COPY packages/finance-contract/ ./packages/finance-contract/
+COPY packages/cerebrum-contract/ ./packages/cerebrum-contract/
+COPY packages/core-contract/ ./packages/core-contract/
+COPY packages/inventory-contract/ ./packages/inventory-contract/
+COPY packages/media-contract/ ./packages/media-contract/
+COPY packages/food-contract/ ./packages/food-contract/
+COPY packages/lists-contract/ ./packages/lists-contract/
 COPY packages/pillar-sdk/ ./packages/pillar-sdk/
 WORKDIR /app/packages/db-types
 RUN pnpm build
@@ -85,6 +97,18 @@ RUN pnpm build
 WORKDIR /app/packages/app-food-db
 RUN pnpm build
 WORKDIR /app/packages/finance-contract
+RUN pnpm build
+WORKDIR /app/packages/cerebrum-contract
+RUN pnpm build
+WORKDIR /app/packages/core-contract
+RUN pnpm build
+WORKDIR /app/packages/inventory-contract
+RUN pnpm build
+WORKDIR /app/packages/media-contract
+RUN pnpm build
+WORKDIR /app/packages/food-contract
+RUN pnpm build
+WORKDIR /app/packages/lists-contract
 RUN pnpm build
 WORKDIR /app/packages/pillar-sdk
 RUN pnpm build


### PR DESCRIPTION
Same shape as #3253. After #3266 unblocked Publish Images and a new image deployed to capivara, pops-api crashed on a different boot-path call: `resumeRotationSchedulerIfEnabled` → `isEnabled('media.rotation')` → `FeatureNotFoundError` when media isn't in the install-set.

Applies the identical try/catch pattern #3253 used for `media.plex.scheduler`. Both schedulers now treat 'feature not declared' as 'disabled' instead of 'crash'.