### PR TITLE
feat(cerebrum-contract): PRD-248 US-01 cerebrum.debrief.* SDK schema + types

### DIFF
--- a/docs/themes/13-pillar-finale/prds/248-cerebrum-debrief-sdk-surface/us-01-debrief-schema-and-types.md
+++ b/docs/themes/13-pillar-finale/prds/248-cerebrum-debrief-sdk-surface/us-01-debrief-schema-and-types.md
@@ -8,19 +8,19 @@ As a downstream PRD-248 US (US-02, US-03, US-04), I want the zod schemas and Typ
 
 ## Acceptance Criteria
 
-- [ ] Zod schemas for debrief shapes live in a single module:
-  - [ ] `DebriefSessionSchema` — matches the `debriefSessions` table row, including the denormalised `mediaType` + `mediaId` columns from commit 9df171fe.
-  - [ ] `DebriefResultSchema` — matches `debriefResults` row.
-  - [ ] `DebriefStatusSchema` — matches `debriefStatus` row.
-  - [ ] Input schemas for each of the 8 procedures (`RecordInputSchema`, `DismissInputSchema`, `ListPendingInputSchema`, `CreateInputSchema`, `GetInputSchema`, `GetByMediaInputSchema`, `LogWatchCompletionInputSchema`, `DeleteByWatchHistoryIdInputSchema`).
-- [ ] The schemas live under a location reachable from both `apps/pops-api` (current in-monolith handlers) and `apps/pops-cerebrum-api` (new router). Pick one: a) promote to `@pops/cerebrum-db` types module, b) promote to a `packages/contracts-cerebrum` shared shapes module, c) keep in `apps/pops-cerebrum-api` and import from monolith handlers. US-01 picks at PR time; document the choice in the PR body.
-- [ ] The `debriefSessions` denormalised columns (`mediaType` + `mediaId`) are present in the schema and the underlying drizzle definition (verify the migration shipped in commit 9df171fe).
-- [ ] A type-level test (or compile-only assertion) asserts that:
-  - [ ] `DebriefSessionSchema` parses a row produced by the live drizzle table.
-  - [ ] `GetByMediaInputSchema` rejects a payload missing `mediaType` or `mediaId`.
-- [ ] No router procedure is registered in this US. The schemas are the only deliverable.
-- [ ] `pnpm typecheck`, `pnpm lint`, `pnpm build` pass clean.
-- [ ] Husky pre-commit + pre-push pass without `--no-verify`.
+- [x] Zod schemas for debrief shapes live in a single module:
+  - [x] `DebriefSessionSchema` — matches the `debriefSessions` table row, including the denormalised `mediaType` + `mediaId` columns from commit 9df171fe.
+  - [x] `DebriefResultSchema` — matches `debriefResults` row.
+  - [x] `DebriefStatusSchema` — matches `debriefStatus` row.
+  - [x] Input schemas for each of the 8 procedures (`RecordInputSchema`, `DismissInputSchema`, `ListPendingInputSchema`, `CreateInputSchema`, `GetInputSchema`, `GetByMediaInputSchema`, `LogWatchCompletionInputSchema`, `DeleteByWatchHistoryIdInputSchema`).
+- [x] The schemas live under a location reachable from both `apps/pops-api` (current in-monolith handlers) and `apps/pops-cerebrum-api` (new router). Pick one: a) promote to `@pops/cerebrum-db` types module, b) promote to a `packages/contracts-cerebrum` shared shapes module, c) keep in `apps/pops-cerebrum-api` and import from monolith handlers. US-01 picks at PR time; document the choice in the PR body.
+- [x] The `debriefSessions` denormalised columns (`mediaType` + `mediaId`) are present in the schema and the underlying drizzle definition (verify the migration shipped in commit 9df171fe).
+- [x] A type-level test (or compile-only assertion) asserts that:
+  - [x] `DebriefSessionSchema` parses a row produced by the live drizzle table.
+  - [x] `GetByMediaInputSchema` rejects a payload missing `mediaType` or `mediaId`.
+- [x] No router procedure is registered in this US. The schemas are the only deliverable.
+- [x] `pnpm typecheck`, `pnpm lint`, `pnpm build` pass clean.
+- [x] Husky pre-commit + pre-push pass without `--no-verify`.
 
 ## Notes
 

--- a/packages/cerebrum-contract/openapi/cerebrum.openapi.json
+++ b/packages/cerebrum-contract/openapi/cerebrum.openapi.json
@@ -14,6 +14,437 @@
         ],
         "type": "object"
       },
+      "DebriefCreateInput": {
+        "additionalProperties": false,
+        "properties": {
+          "mediaId": {
+            "exclusiveMinimum": true,
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "mediaType": {
+            "enum": [
+              "movie",
+              "episode"
+            ],
+            "type": "string"
+          },
+          "watchHistoryId": {
+            "exclusiveMinimum": true,
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "watchHistoryId",
+          "mediaType",
+          "mediaId"
+        ],
+        "type": "object"
+      },
+      "DebriefDeleteByWatchHistoryIdInput": {
+        "additionalProperties": false,
+        "properties": {
+          "watchHistoryId": {
+            "exclusiveMinimum": true,
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "watchHistoryId"
+        ],
+        "type": "object"
+      },
+      "DebriefDeleteByWatchHistoryIdResponse": {
+        "properties": {
+          "deletedResults": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "deletedSessions": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "deletedSessions",
+          "deletedResults"
+        ],
+        "type": "object"
+      },
+      "DebriefDismissInput": {
+        "additionalProperties": false,
+        "properties": {
+          "sessionId": {
+            "exclusiveMinimum": true,
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "sessionId"
+        ],
+        "type": "object"
+      },
+      "DebriefGetByMediaInput": {
+        "additionalProperties": false,
+        "properties": {
+          "mediaId": {
+            "exclusiveMinimum": true,
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "mediaType": {
+            "enum": [
+              "movie",
+              "episode"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "mediaType",
+          "mediaId"
+        ],
+        "type": "object"
+      },
+      "DebriefGetInput": {
+        "additionalProperties": false,
+        "properties": {
+          "sessionId": {
+            "exclusiveMinimum": true,
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "sessionId"
+        ],
+        "type": "object"
+      },
+      "DebriefListPendingInput": {
+        "additionalProperties": false,
+        "properties": {
+          "limit": {
+            "exclusiveMinimum": true,
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "mediaId": {
+            "exclusiveMinimum": true,
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "mediaType": {
+            "enum": [
+              "movie",
+              "episode"
+            ],
+            "type": "string"
+          },
+          "offset": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "DebriefLogWatchCompletionInput": {
+        "additionalProperties": false,
+        "properties": {
+          "mediaId": {
+            "exclusiveMinimum": true,
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "mediaType": {
+            "enum": [
+              "movie",
+              "episode"
+            ],
+            "type": "string"
+          },
+          "watchHistoryId": {
+            "exclusiveMinimum": true,
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "watchHistoryId",
+          "mediaType",
+          "mediaId"
+        ],
+        "type": "object"
+      },
+      "DebriefLogWatchCompletionResponse": {
+        "properties": {
+          "dimensionsQueued": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "sessionId": {
+            "minimum": 1,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "sessionId",
+          "dimensionsQueued"
+        ],
+        "type": "object"
+      },
+      "DebriefMediaType": {
+        "enum": [
+          "movie",
+          "episode"
+        ],
+        "type": "string"
+      },
+      "DebriefRecordInput": {
+        "additionalProperties": false,
+        "properties": {
+          "comparisonId": {
+            "exclusiveMinimum": true,
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "nullable": true,
+            "type": "integer"
+          },
+          "dimensionId": {
+            "exclusiveMinimum": true,
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "sessionId": {
+            "exclusiveMinimum": true,
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "sessionId",
+          "dimensionId",
+          "comparisonId"
+        ],
+        "type": "object"
+      },
+      "DebriefResult": {
+        "additionalProperties": false,
+        "properties": {
+          "comparisonId": {
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "nullable": true,
+            "type": "integer"
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "dimensionId": {
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer"
+          },
+          "id": {
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer"
+          },
+          "sessionId": {
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "sessionId",
+          "dimensionId",
+          "comparisonId",
+          "createdAt"
+        ],
+        "type": "object"
+      },
+      "DebriefResultResponse": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/DebriefResult"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "DebriefSession": {
+        "additionalProperties": false,
+        "properties": {
+          "createdAt": {
+            "type": "string"
+          },
+          "id": {
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer"
+          },
+          "mediaId": {
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "nullable": true,
+            "type": "integer"
+          },
+          "mediaType": {
+            "enum": [
+              "movie",
+              "episode"
+            ],
+            "nullable": true,
+            "type": "string"
+          },
+          "status": {
+            "enum": [
+              "pending",
+              "active",
+              "complete"
+            ],
+            "type": "string"
+          },
+          "watchHistoryId": {
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "watchHistoryId",
+          "mediaType",
+          "mediaId",
+          "status",
+          "createdAt"
+        ],
+        "type": "object"
+      },
+      "DebriefSessionListResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/DebriefSession"
+            },
+            "type": "array"
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/Pagination"
+          }
+        },
+        "required": [
+          "data",
+          "pagination"
+        ],
+        "type": "object"
+      },
+      "DebriefSessionNullableResponse": {
+        "properties": {
+          "data": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/DebriefSession"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "DebriefSessionResponse": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/DebriefSession"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "DebriefSessionStatus": {
+        "enum": [
+          "pending",
+          "active",
+          "complete"
+        ],
+        "type": "string"
+      },
+      "DebriefStatus": {
+        "additionalProperties": false,
+        "properties": {
+          "createdAt": {
+            "type": "string"
+          },
+          "debriefed": {
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer"
+          },
+          "dimensionId": {
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer"
+          },
+          "dismissed": {
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer"
+          },
+          "id": {
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer"
+          },
+          "mediaId": {
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer"
+          },
+          "mediaType": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "mediaType",
+          "mediaId",
+          "dimensionId",
+          "debriefed",
+          "dismissed",
+          "createdAt",
+          "updatedAt"
+        ],
+        "type": "object"
+      },
       "DeleteResponse": {
         "properties": {
           "message": {
@@ -296,6 +727,291 @@
   },
   "openapi": "3.0.3",
   "paths": {
+    "/cerebrum/debrief/create": {
+      "post": {
+        "operationId": "cerebrum.debrief.create",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DebriefCreateInput"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DebriefSessionResponse"
+                }
+              }
+            },
+            "description": "Created debrief session"
+          }
+        },
+        "summary": "Create a debrief session pinned to a watch_history row",
+        "tags": [
+          "debrief"
+        ]
+      }
+    },
+    "/cerebrum/debrief/deleteByWatchHistoryId": {
+      "post": {
+        "operationId": "cerebrum.debrief.deleteByWatchHistoryId",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DebriefDeleteByWatchHistoryIdInput"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DebriefDeleteByWatchHistoryIdResponse"
+                }
+              }
+            },
+            "description": "Cascade deletion counts"
+          }
+        },
+        "summary": "Cascade-delete debrief rows pinned to a watch_history id",
+        "tags": [
+          "debrief"
+        ]
+      }
+    },
+    "/cerebrum/debrief/dismiss": {
+      "post": {
+        "operationId": "cerebrum.debrief.dismiss",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DebriefDismissInput"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DebriefSessionResponse"
+                }
+              }
+            },
+            "description": "Dismissed debrief session"
+          }
+        },
+        "summary": "Dismiss a debrief session (idempotent)",
+        "tags": [
+          "debrief"
+        ]
+      }
+    },
+    "/cerebrum/debrief/get": {
+      "get": {
+        "operationId": "cerebrum.debrief.get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "sessionId",
+            "required": true,
+            "schema": {
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DebriefSessionNullableResponse"
+                }
+              }
+            },
+            "description": "Debrief session or null"
+          }
+        },
+        "summary": "Get a debrief session by id",
+        "tags": [
+          "debrief"
+        ]
+      }
+    },
+    "/cerebrum/debrief/getByMedia": {
+      "get": {
+        "operationId": "cerebrum.debrief.getByMedia",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "mediaType",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/DebriefMediaType"
+            }
+          },
+          {
+            "in": "query",
+            "name": "mediaId",
+            "required": true,
+            "schema": {
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DebriefSessionNullableResponse"
+                }
+              }
+            },
+            "description": "Latest debrief session for the media tuple, or null"
+          }
+        },
+        "summary": "Get the latest debrief session for a media tuple (denormalised)",
+        "tags": [
+          "debrief"
+        ]
+      }
+    },
+    "/cerebrum/debrief/listPending": {
+      "get": {
+        "operationId": "cerebrum.debrief.listPending",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "mediaType",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/DebriefMediaType"
+            }
+          },
+          {
+            "in": "query",
+            "name": "mediaId",
+            "required": false,
+            "schema": {
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DebriefSessionListResponse"
+                }
+              }
+            },
+            "description": "Pending debrief sessions"
+          }
+        },
+        "summary": "List pending debrief sessions",
+        "tags": [
+          "debrief"
+        ]
+      }
+    },
+    "/cerebrum/debrief/logWatchCompletion": {
+      "post": {
+        "operationId": "cerebrum.debrief.logWatchCompletion",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DebriefLogWatchCompletionInput"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DebriefLogWatchCompletionResponse"
+                }
+              }
+            },
+            "description": "Debrief fan-out result"
+          }
+        },
+        "summary": "Log a watch completion (Option D entry point)",
+        "tags": [
+          "debrief"
+        ]
+      }
+    },
+    "/cerebrum/debrief/record": {
+      "post": {
+        "operationId": "cerebrum.debrief.record",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DebriefRecordInput"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DebriefResultResponse"
+                }
+              }
+            },
+            "description": "Recorded debrief result"
+          }
+        },
+        "summary": "Record a debrief result for a session/dimension",
+        "tags": [
+          "debrief"
+        ]
+      }
+    },
     "/cerebrum/embeddings/source-ids": {
       "get": {
         "operationId": "cerebrum.embeddings.listSourceIdsByType",
@@ -554,6 +1270,10 @@
     }
   ],
   "tags": [
+    {
+      "description": "Cerebrum debrief sessions, results, and status (PRD-248)",
+      "name": "debrief"
+    },
     {
       "description": "Cerebrum embeddings (read-only cross-pillar SDK)",
       "name": "embeddings"

--- a/packages/cerebrum-contract/scripts/generate-openapi.ts
+++ b/packages/cerebrum-contract/scripts/generate-openapi.ts
@@ -71,6 +71,10 @@ function buildDocument(): OpenApiDocument {
     },
     servers: [{ url: '/api/v1', description: 'Cerebrum pillar API' }],
     tags: [
+      {
+        name: 'debrief',
+        description: 'Cerebrum debrief sessions, results, and status (PRD-248)',
+      },
       { name: 'embeddings', description: 'Cerebrum embeddings (read-only cross-pillar SDK)' },
       { name: 'engrams', description: 'Cerebrum engrams' },
     ],

--- a/packages/cerebrum-contract/scripts/openapi-debrief-paths.ts
+++ b/packages/cerebrum-contract/scripts/openapi-debrief-paths.ts
@@ -1,0 +1,147 @@
+import { refTo, type OpenApiOperation, type OpenApiPathItem } from './openapi-types.js';
+
+const debriefRecordOp: OpenApiOperation = {
+  tags: ['debrief'],
+  summary: 'Record a debrief result for a session/dimension',
+  operationId: 'cerebrum.debrief.record',
+  requestBody: {
+    required: true,
+    content: { 'application/json': { schema: refTo('DebriefRecordInput') } },
+  },
+  responses: {
+    '200': {
+      description: 'Recorded debrief result',
+      content: { 'application/json': { schema: refTo('DebriefResultResponse') } },
+    },
+  },
+};
+
+const debriefDismissOp: OpenApiOperation = {
+  tags: ['debrief'],
+  summary: 'Dismiss a debrief session (idempotent)',
+  operationId: 'cerebrum.debrief.dismiss',
+  requestBody: {
+    required: true,
+    content: { 'application/json': { schema: refTo('DebriefDismissInput') } },
+  },
+  responses: {
+    '200': {
+      description: 'Dismissed debrief session',
+      content: { 'application/json': { schema: refTo('DebriefSessionResponse') } },
+    },
+  },
+};
+
+const debriefListPendingOp: OpenApiOperation = {
+  tags: ['debrief'],
+  summary: 'List pending debrief sessions',
+  operationId: 'cerebrum.debrief.listPending',
+  parameters: [
+    { name: 'mediaType', in: 'query', required: false, schema: refTo('DebriefMediaType') },
+    { name: 'mediaId', in: 'query', required: false, schema: { type: 'integer', minimum: 1 } },
+    { name: 'limit', in: 'query', required: false, schema: { type: 'integer', minimum: 1 } },
+    { name: 'offset', in: 'query', required: false, schema: { type: 'integer', minimum: 0 } },
+  ],
+  responses: {
+    '200': {
+      description: 'Pending debrief sessions',
+      content: { 'application/json': { schema: refTo('DebriefSessionListResponse') } },
+    },
+  },
+};
+
+const debriefCreateOp: OpenApiOperation = {
+  tags: ['debrief'],
+  summary: 'Create a debrief session pinned to a watch_history row',
+  operationId: 'cerebrum.debrief.create',
+  requestBody: {
+    required: true,
+    content: { 'application/json': { schema: refTo('DebriefCreateInput') } },
+  },
+  responses: {
+    '200': {
+      description: 'Created debrief session',
+      content: { 'application/json': { schema: refTo('DebriefSessionResponse') } },
+    },
+  },
+};
+
+const debriefGetOp: OpenApiOperation = {
+  tags: ['debrief'],
+  summary: 'Get a debrief session by id',
+  operationId: 'cerebrum.debrief.get',
+  parameters: [
+    { name: 'sessionId', in: 'query', required: true, schema: { type: 'integer', minimum: 1 } },
+  ],
+  responses: {
+    '200': {
+      description: 'Debrief session or null',
+      content: { 'application/json': { schema: refTo('DebriefSessionNullableResponse') } },
+    },
+  },
+};
+
+const debriefGetByMediaOp: OpenApiOperation = {
+  tags: ['debrief'],
+  summary: 'Get the latest debrief session for a media tuple (denormalised)',
+  operationId: 'cerebrum.debrief.getByMedia',
+  parameters: [
+    { name: 'mediaType', in: 'query', required: true, schema: refTo('DebriefMediaType') },
+    { name: 'mediaId', in: 'query', required: true, schema: { type: 'integer', minimum: 1 } },
+  ],
+  responses: {
+    '200': {
+      description: 'Latest debrief session for the media tuple, or null',
+      content: { 'application/json': { schema: refTo('DebriefSessionNullableResponse') } },
+    },
+  },
+};
+
+const debriefLogWatchCompletionOp: OpenApiOperation = {
+  tags: ['debrief'],
+  summary: 'Log a watch completion (Option D entry point)',
+  operationId: 'cerebrum.debrief.logWatchCompletion',
+  requestBody: {
+    required: true,
+    content: { 'application/json': { schema: refTo('DebriefLogWatchCompletionInput') } },
+  },
+  responses: {
+    '200': {
+      description: 'Debrief fan-out result',
+      content: { 'application/json': { schema: refTo('DebriefLogWatchCompletionResponse') } },
+    },
+  },
+};
+
+const debriefDeleteByWatchHistoryIdOp: OpenApiOperation = {
+  tags: ['debrief'],
+  summary: 'Cascade-delete debrief rows pinned to a watch_history id',
+  operationId: 'cerebrum.debrief.deleteByWatchHistoryId',
+  requestBody: {
+    required: true,
+    content: {
+      'application/json': { schema: refTo('DebriefDeleteByWatchHistoryIdInput') },
+    },
+  },
+  responses: {
+    '200': {
+      description: 'Cascade deletion counts',
+      content: {
+        'application/json': { schema: refTo('DebriefDeleteByWatchHistoryIdResponse') },
+      },
+    },
+  },
+};
+
+export function buildDebriefPaths(): Record<string, OpenApiPathItem> {
+  return {
+    '/cerebrum/debrief/record': { post: debriefRecordOp },
+    '/cerebrum/debrief/dismiss': { post: debriefDismissOp },
+    '/cerebrum/debrief/listPending': { get: debriefListPendingOp },
+    '/cerebrum/debrief/create': { post: debriefCreateOp },
+    '/cerebrum/debrief/get': { get: debriefGetOp },
+    '/cerebrum/debrief/getByMedia': { get: debriefGetByMediaOp },
+    '/cerebrum/debrief/logWatchCompletion': { post: debriefLogWatchCompletionOp },
+    '/cerebrum/debrief/deleteByWatchHistoryId': { post: debriefDeleteByWatchHistoryIdOp },
+  };
+}

--- a/packages/cerebrum-contract/scripts/openapi-debrief-schemas.ts
+++ b/packages/cerebrum-contract/scripts/openapi-debrief-schemas.ts
@@ -1,0 +1,84 @@
+import { z } from 'zod';
+
+import {
+  CreateInputSchema as DebriefCreateInputSchema,
+  DebriefMediaTypeSchema,
+  DebriefResultSchema,
+  DebriefSessionSchema,
+  DebriefSessionStatusSchema,
+  DebriefStatusSchema,
+  DeleteByWatchHistoryIdInputSchema as DebriefDeleteByWatchHistoryIdInputSchema,
+  DismissInputSchema as DebriefDismissInputSchema,
+  GetByMediaInputSchema as DebriefGetByMediaInputSchema,
+  GetInputSchema as DebriefGetInputSchema,
+  ListPendingInputSchema as DebriefListPendingInputSchema,
+  LogWatchCompletionInputSchema as DebriefLogWatchCompletionInputSchema,
+  RecordInputSchema as DebriefRecordInputSchema,
+} from '../src/schemas/debrief.js';
+import { refTo, type OpenApiSchema } from './openapi-types.js';
+
+function zodToOpenApiSchema(schema: z.ZodType): OpenApiSchema {
+  return z.toJSONSchema(schema, {
+    target: 'openapi-3.0',
+    unrepresentable: 'any',
+  }) as OpenApiSchema;
+}
+
+export function buildDebriefComponentSchemas(): Record<string, OpenApiSchema> {
+  return {
+    DebriefMediaType: zodToOpenApiSchema(DebriefMediaTypeSchema),
+    DebriefSessionStatus: zodToOpenApiSchema(DebriefSessionStatusSchema),
+    DebriefSession: zodToOpenApiSchema(DebriefSessionSchema),
+    DebriefResult: zodToOpenApiSchema(DebriefResultSchema),
+    DebriefStatus: zodToOpenApiSchema(DebriefStatusSchema),
+    DebriefRecordInput: zodToOpenApiSchema(DebriefRecordInputSchema),
+    DebriefDismissInput: zodToOpenApiSchema(DebriefDismissInputSchema),
+    DebriefListPendingInput: zodToOpenApiSchema(DebriefListPendingInputSchema),
+    DebriefCreateInput: zodToOpenApiSchema(DebriefCreateInputSchema),
+    DebriefGetInput: zodToOpenApiSchema(DebriefGetInputSchema),
+    DebriefGetByMediaInput: zodToOpenApiSchema(DebriefGetByMediaInputSchema),
+    DebriefLogWatchCompletionInput: zodToOpenApiSchema(DebriefLogWatchCompletionInputSchema),
+    DebriefDeleteByWatchHistoryIdInput: zodToOpenApiSchema(
+      DebriefDeleteByWatchHistoryIdInputSchema
+    ),
+    DebriefSessionResponse: {
+      type: 'object',
+      required: ['data'],
+      properties: { data: refTo('DebriefSession') },
+    },
+    DebriefSessionNullableResponse: {
+      type: 'object',
+      required: ['data'],
+      properties: { data: { oneOf: [refTo('DebriefSession'), { type: 'null' }] } },
+    },
+    DebriefSessionListResponse: {
+      type: 'object',
+      required: ['data', 'pagination'],
+      properties: {
+        data: { type: 'array', items: refTo('DebriefSession') },
+        pagination: refTo('Pagination'),
+      },
+    },
+    DebriefResultResponse: {
+      type: 'object',
+      required: ['data'],
+      properties: { data: refTo('DebriefResult') },
+    },
+    DebriefLogWatchCompletionResponse: {
+      type: 'object',
+      required: ['sessionId', 'dimensionsQueued'],
+      properties: {
+        sessionId: { type: 'integer', minimum: 1 },
+        dimensionsQueued: { type: 'integer', minimum: 0 },
+      },
+    },
+    DebriefDeleteByWatchHistoryIdResponse: {
+      type: 'object',
+      required: ['deletedSessions', 'deletedResults'],
+      properties: {
+        deletedSessions: { type: 'integer', minimum: 0 },
+        deletedResults: { type: 'integer', minimum: 0 },
+      },
+    },
+  };
+}

--- a/packages/cerebrum-contract/scripts/openapi-paths.ts
+++ b/packages/cerebrum-contract/scripts/openapi-paths.ts
@@ -1,3 +1,4 @@
+import { buildDebriefPaths } from './openapi-debrief-paths.js';
 import {
   refTo,
   type OpenApiOperation,
@@ -141,5 +142,6 @@ export function buildPaths(): Record<string, OpenApiPathItem> {
     '/cerebrum/embeddings/source-ids': { get: embeddingsListSourceIdsOp },
     '/cerebrum/engrams': { get: listOp, post: createOp },
     '/cerebrum/engrams/{id}': { get: getOp, patch: updateOp, delete: deleteOp },
+    ...buildDebriefPaths(),
   };
 }

--- a/packages/cerebrum-contract/scripts/openapi-schemas.ts
+++ b/packages/cerebrum-contract/scripts/openapi-schemas.ts
@@ -9,6 +9,7 @@ import {
 import { EngramSchema } from '../src/schemas/engram.js';
 import { NudgeSchema, NudgeStatusSchema } from '../src/schemas/nudge.js';
 import { ScopeSchema } from '../src/schemas/scope.js';
+import { buildDebriefComponentSchemas } from './openapi-debrief-schemas.js';
 import { refTo, type OpenApiSchema } from './openapi-types.js';
 
 const PAGINATION_SCHEMA: OpenApiSchema = {
@@ -73,5 +74,6 @@ export function buildComponentSchemas(): Record<string, OpenApiSchema> {
       required: ['message'],
       properties: { message: { type: 'string' } },
     },
+    ...buildDebriefComponentSchemas(),
   };
 }

--- a/packages/cerebrum-contract/src/__tests__/debrief.test.ts
+++ b/packages/cerebrum-contract/src/__tests__/debrief.test.ts
@@ -1,0 +1,312 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+
+import {
+  CreateInputSchema,
+  DebriefResultSchema,
+  DebriefSessionSchema,
+  DebriefStatusSchema,
+  DeleteByWatchHistoryIdInputSchema,
+  DismissInputSchema,
+  GetByMediaInputSchema,
+  GetInputSchema,
+  ListPendingInputSchema,
+  LogWatchCompletionInputSchema,
+  RecordInputSchema,
+} from '../schemas/debrief.js';
+
+import type { z } from 'zod';
+
+import type {
+  CreateInput,
+  DebriefResult,
+  DebriefSession,
+  DebriefStatus,
+  DeleteByWatchHistoryIdInput,
+  DismissInput,
+  GetByMediaInput,
+  GetInput,
+  ListPendingInput,
+  LogWatchCompletionInput,
+  RecordInput,
+} from '../types/debrief.js';
+
+describe('cerebrum.debrief contract — entity round-trip', () => {
+  it('DebriefSession ↔ DebriefSessionSchema agree structurally', () => {
+    expectTypeOf<z.infer<typeof DebriefSessionSchema>>().toEqualTypeOf<DebriefSession>();
+  });
+
+  it('DebriefResult ↔ DebriefResultSchema agree structurally', () => {
+    expectTypeOf<z.infer<typeof DebriefResultSchema>>().toEqualTypeOf<DebriefResult>();
+  });
+
+  it('DebriefStatus ↔ DebriefStatusSchema agree structurally', () => {
+    expectTypeOf<z.infer<typeof DebriefStatusSchema>>().toEqualTypeOf<DebriefStatus>();
+  });
+
+  it('DebriefSessionSchema accepts a well-formed pending row', () => {
+    const payload: DebriefSession = {
+      id: 1,
+      watchHistoryId: 42,
+      mediaType: 'movie',
+      mediaId: 123,
+      status: 'pending',
+      createdAt: '2026-06-15 02:55:00',
+    };
+    expect(DebriefSessionSchema.parse(payload)).toEqual(payload);
+  });
+
+  it('DebriefSessionSchema accepts null denormalised media columns (migration window)', () => {
+    const payload: DebriefSession = {
+      id: 7,
+      watchHistoryId: 100,
+      mediaType: null,
+      mediaId: null,
+      status: 'active',
+      createdAt: '2026-06-15 02:55:00',
+    };
+    expect(DebriefSessionSchema.parse(payload)).toEqual(payload);
+  });
+
+  it('DebriefSessionSchema rejects an unknown status', () => {
+    expect(() =>
+      DebriefSessionSchema.parse({
+        id: 1,
+        watchHistoryId: 42,
+        mediaType: 'movie',
+        mediaId: 123,
+        status: 'mystery',
+        createdAt: '2026-06-15 02:55:00',
+      })
+    ).toThrow();
+  });
+
+  it('DebriefSessionSchema rejects an unknown mediaType', () => {
+    expect(() =>
+      DebriefSessionSchema.parse({
+        id: 1,
+        watchHistoryId: 42,
+        mediaType: 'podcast',
+        mediaId: 123,
+        status: 'pending',
+        createdAt: '2026-06-15 02:55:00',
+      })
+    ).toThrow();
+  });
+
+  it('DebriefResultSchema accepts a dismissed dimension (null comparisonId)', () => {
+    const payload: DebriefResult = {
+      id: 10,
+      sessionId: 1,
+      dimensionId: 3,
+      comparisonId: null,
+      createdAt: '2026-06-15 02:55:00',
+    };
+    expect(DebriefResultSchema.parse(payload)).toEqual(payload);
+  });
+
+  it('DebriefResultSchema accepts a recorded comparison', () => {
+    const payload: DebriefResult = {
+      id: 11,
+      sessionId: 1,
+      dimensionId: 3,
+      comparisonId: 555,
+      createdAt: '2026-06-15 02:55:00',
+    };
+    expect(DebriefResultSchema.parse(payload)).toEqual(payload);
+  });
+
+  it('DebriefResultSchema rejects a non-integer sessionId', () => {
+    expect(() =>
+      DebriefResultSchema.parse({
+        id: 10,
+        sessionId: '1',
+        dimensionId: 3,
+        comparisonId: null,
+        createdAt: '2026-06-15 02:55:00',
+      })
+    ).toThrow();
+  });
+
+  it('DebriefStatusSchema accepts a well-formed row', () => {
+    const payload: DebriefStatus = {
+      id: 99,
+      mediaType: 'movie',
+      mediaId: 123,
+      dimensionId: 3,
+      debriefed: 0,
+      dismissed: 0,
+      createdAt: '2026-06-15 02:55:00',
+      updatedAt: '2026-06-15 02:55:00',
+    };
+    expect(DebriefStatusSchema.parse(payload)).toEqual(payload);
+  });
+
+  it('DebriefStatusSchema rejects a missing updatedAt', () => {
+    expect(() =>
+      DebriefStatusSchema.parse({
+        id: 99,
+        mediaType: 'movie',
+        mediaId: 123,
+        dimensionId: 3,
+        debriefed: 0,
+        dismissed: 0,
+        createdAt: '2026-06-15 02:55:00',
+      })
+    ).toThrow();
+  });
+});
+
+describe('cerebrum.debrief contract — procedure inputs', () => {
+  it('RecordInput ↔ RecordInputSchema agree structurally', () => {
+    expectTypeOf<z.infer<typeof RecordInputSchema>>().toEqualTypeOf<RecordInput>();
+  });
+
+  it('DismissInput ↔ DismissInputSchema agree structurally', () => {
+    expectTypeOf<z.infer<typeof DismissInputSchema>>().toEqualTypeOf<DismissInput>();
+  });
+
+  it('ListPendingInput ↔ ListPendingInputSchema agree structurally', () => {
+    expectTypeOf<z.infer<typeof ListPendingInputSchema>>().toEqualTypeOf<ListPendingInput>();
+  });
+
+  it('CreateInput ↔ CreateInputSchema agree structurally', () => {
+    expectTypeOf<z.infer<typeof CreateInputSchema>>().toEqualTypeOf<CreateInput>();
+  });
+
+  it('GetInput ↔ GetInputSchema agree structurally', () => {
+    expectTypeOf<z.infer<typeof GetInputSchema>>().toEqualTypeOf<GetInput>();
+  });
+
+  it('GetByMediaInput ↔ GetByMediaInputSchema agree structurally', () => {
+    expectTypeOf<z.infer<typeof GetByMediaInputSchema>>().toEqualTypeOf<GetByMediaInput>();
+  });
+
+  it('LogWatchCompletionInput ↔ LogWatchCompletionInputSchema agree structurally', () => {
+    expectTypeOf<
+      z.infer<typeof LogWatchCompletionInputSchema>
+    >().toEqualTypeOf<LogWatchCompletionInput>();
+  });
+
+  it('DeleteByWatchHistoryIdInput ↔ DeleteByWatchHistoryIdInputSchema agree structurally', () => {
+    expectTypeOf<
+      z.infer<typeof DeleteByWatchHistoryIdInputSchema>
+    >().toEqualTypeOf<DeleteByWatchHistoryIdInput>();
+  });
+
+  it('RecordInputSchema accepts a recorded comparison', () => {
+    const payload: RecordInput = { sessionId: 1, dimensionId: 3, comparisonId: 555 };
+    expect(RecordInputSchema.parse(payload)).toEqual(payload);
+  });
+
+  it('RecordInputSchema accepts a null comparisonId (skip)', () => {
+    const payload: RecordInput = { sessionId: 1, dimensionId: 3, comparisonId: null };
+    expect(RecordInputSchema.parse(payload)).toEqual(payload);
+  });
+
+  it('RecordInputSchema rejects a missing dimensionId', () => {
+    expect(() => RecordInputSchema.parse({ sessionId: 1, comparisonId: null })).toThrow();
+  });
+
+  it('RecordInputSchema rejects a non-positive sessionId', () => {
+    expect(() =>
+      RecordInputSchema.parse({ sessionId: 0, dimensionId: 3, comparisonId: null })
+    ).toThrow();
+  });
+
+  it('DismissInputSchema accepts a positive sessionId', () => {
+    expect(DismissInputSchema.parse({ sessionId: 99 })).toEqual({ sessionId: 99 });
+  });
+
+  it('DismissInputSchema rejects a missing sessionId', () => {
+    expect(() => DismissInputSchema.parse({})).toThrow();
+  });
+
+  it('ListPendingInputSchema accepts no filters', () => {
+    expect(ListPendingInputSchema.parse({})).toEqual({});
+  });
+
+  it('ListPendingInputSchema accepts a media-tuple filter + pagination', () => {
+    const payload: ListPendingInput = {
+      mediaType: 'episode',
+      mediaId: 7,
+      limit: 25,
+      offset: 50,
+    };
+    expect(ListPendingInputSchema.parse(payload)).toEqual(payload);
+  });
+
+  it('ListPendingInputSchema rejects an unknown mediaType', () => {
+    expect(() => ListPendingInputSchema.parse({ mediaType: 'podcast', mediaId: 1 })).toThrow();
+  });
+
+  it('ListPendingInputSchema rejects a negative offset', () => {
+    expect(() => ListPendingInputSchema.parse({ offset: -1 })).toThrow();
+  });
+
+  it('CreateInputSchema accepts a well-formed payload', () => {
+    const payload: CreateInput = {
+      watchHistoryId: 42,
+      mediaType: 'movie',
+      mediaId: 123,
+    };
+    expect(CreateInputSchema.parse(payload)).toEqual(payload);
+  });
+
+  it('CreateInputSchema rejects a missing mediaType', () => {
+    expect(() => CreateInputSchema.parse({ watchHistoryId: 42, mediaId: 123 })).toThrow();
+  });
+
+  it('CreateInputSchema rejects a missing mediaId', () => {
+    expect(() => CreateInputSchema.parse({ watchHistoryId: 42, mediaType: 'movie' })).toThrow();
+  });
+
+  it('GetInputSchema accepts a positive sessionId', () => {
+    expect(GetInputSchema.parse({ sessionId: 1 })).toEqual({ sessionId: 1 });
+  });
+
+  it('GetByMediaInputSchema accepts a well-formed payload', () => {
+    const payload: GetByMediaInput = { mediaType: 'movie', mediaId: 123 };
+    expect(GetByMediaInputSchema.parse(payload)).toEqual(payload);
+  });
+
+  it('GetByMediaInputSchema rejects a payload missing mediaType', () => {
+    expect(() => GetByMediaInputSchema.parse({ mediaId: 123 })).toThrow();
+  });
+
+  it('GetByMediaInputSchema rejects a payload missing mediaId', () => {
+    expect(() => GetByMediaInputSchema.parse({ mediaType: 'movie' })).toThrow();
+  });
+
+  it('GetByMediaInputSchema rejects an unknown mediaType', () => {
+    expect(() => GetByMediaInputSchema.parse({ mediaType: 'podcast', mediaId: 1 })).toThrow();
+  });
+
+  it('LogWatchCompletionInputSchema accepts a well-formed payload', () => {
+    const payload: LogWatchCompletionInput = {
+      watchHistoryId: 42,
+      mediaType: 'movie',
+      mediaId: 123,
+    };
+    expect(LogWatchCompletionInputSchema.parse(payload)).toEqual(payload);
+  });
+
+  it('LogWatchCompletionInputSchema rejects a non-positive watchHistoryId', () => {
+    expect(() =>
+      LogWatchCompletionInputSchema.parse({
+        watchHistoryId: 0,
+        mediaType: 'movie',
+        mediaId: 123,
+      })
+    ).toThrow();
+  });
+
+  it('DeleteByWatchHistoryIdInputSchema accepts a positive watchHistoryId', () => {
+    expect(DeleteByWatchHistoryIdInputSchema.parse({ watchHistoryId: 42 })).toEqual({
+      watchHistoryId: 42,
+    });
+  });
+
+  it('DeleteByWatchHistoryIdInputSchema rejects a missing watchHistoryId', () => {
+    expect(() => DeleteByWatchHistoryIdInputSchema.parse({})).toThrow();
+  });
+});

--- a/packages/cerebrum-contract/src/__tests__/openapi.test.ts
+++ b/packages/cerebrum-contract/src/__tests__/openapi.test.ts
@@ -95,4 +95,47 @@ describe('@pops/cerebrum-contract openapi snapshot', () => {
     expect(openapi.components.schemas).toHaveProperty('EmbeddingsListSourceIdsByTypeInput');
     expect(openapi.components.schemas).toHaveProperty('EmbeddingsListSourceIdsByTypeOutput');
   });
+
+  it('references the DebriefSession entity schema under components/schemas', () => {
+    expect(openapi.components.schemas).toHaveProperty('DebriefSession');
+  });
+
+  it('references the DebriefResult entity schema under components/schemas', () => {
+    expect(openapi.components.schemas).toHaveProperty('DebriefResult');
+  });
+
+  it('references the DebriefStatus entity schema under components/schemas', () => {
+    expect(openapi.components.schemas).toHaveProperty('DebriefStatus');
+  });
+
+  it('includes the debrief session status enum', () => {
+    const status = openapi.components.schemas['DebriefSessionStatus'] as {
+      enum?: readonly string[];
+    };
+    expect(status).toBeDefined();
+    expect(status.enum).toEqual(expect.arrayContaining(['pending', 'active', 'complete']));
+  });
+
+  it('includes the debrief media-type enum', () => {
+    const mediaType = openapi.components.schemas['DebriefMediaType'] as {
+      enum?: readonly string[];
+    };
+    expect(mediaType).toBeDefined();
+    expect(mediaType.enum).toEqual(expect.arrayContaining(['movie', 'episode']));
+  });
+
+  it.each([
+    ['/cerebrum/debrief/record', 'post', 'cerebrum.debrief.record'],
+    ['/cerebrum/debrief/dismiss', 'post', 'cerebrum.debrief.dismiss'],
+    ['/cerebrum/debrief/listPending', 'get', 'cerebrum.debrief.listPending'],
+    ['/cerebrum/debrief/create', 'post', 'cerebrum.debrief.create'],
+    ['/cerebrum/debrief/get', 'get', 'cerebrum.debrief.get'],
+    ['/cerebrum/debrief/getByMedia', 'get', 'cerebrum.debrief.getByMedia'],
+    ['/cerebrum/debrief/logWatchCompletion', 'post', 'cerebrum.debrief.logWatchCompletion'],
+    ['/cerebrum/debrief/deleteByWatchHistoryId', 'post', 'cerebrum.debrief.deleteByWatchHistoryId'],
+  ])('exposes %s %s as %s', (path, method, operationId) => {
+    const op = openapi.paths[path]?.[method];
+    expect(op).toBeDefined();
+    expect(op?.operationId).toBe(operationId);
+  });
 });

--- a/packages/cerebrum-contract/src/schemas/debrief.ts
+++ b/packages/cerebrum-contract/src/schemas/debrief.ts
@@ -1,0 +1,77 @@
+import { z } from 'zod';
+
+import { DEBRIEF_MEDIA_TYPES, DEBRIEF_SESSION_STATUSES } from '../types/debrief.js';
+
+export const DebriefMediaTypeSchema = z.enum(DEBRIEF_MEDIA_TYPES);
+
+export const DebriefSessionStatusSchema = z.enum(DEBRIEF_SESSION_STATUSES);
+
+export const DebriefSessionSchema = z.object({
+  id: z.number().int(),
+  watchHistoryId: z.number().int(),
+  mediaType: DebriefMediaTypeSchema.nullable(),
+  mediaId: z.number().int().nullable(),
+  status: DebriefSessionStatusSchema,
+  createdAt: z.string(),
+});
+
+export const DebriefResultSchema = z.object({
+  id: z.number().int(),
+  sessionId: z.number().int(),
+  dimensionId: z.number().int(),
+  comparisonId: z.number().int().nullable(),
+  createdAt: z.string(),
+});
+
+export const DebriefStatusSchema = z.object({
+  id: z.number().int(),
+  mediaType: z.string(),
+  mediaId: z.number().int(),
+  dimensionId: z.number().int(),
+  debriefed: z.number().int(),
+  dismissed: z.number().int(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export const RecordInputSchema = z.object({
+  sessionId: z.number().int().positive(),
+  dimensionId: z.number().int().positive(),
+  comparisonId: z.number().int().positive().nullable(),
+});
+
+export const DismissInputSchema = z.object({
+  sessionId: z.number().int().positive(),
+});
+
+export const ListPendingInputSchema = z.object({
+  mediaType: DebriefMediaTypeSchema.optional(),
+  mediaId: z.number().int().positive().optional(),
+  limit: z.number().int().positive().optional(),
+  offset: z.number().int().nonnegative().optional(),
+});
+
+export const CreateInputSchema = z.object({
+  watchHistoryId: z.number().int().positive(),
+  mediaType: DebriefMediaTypeSchema,
+  mediaId: z.number().int().positive(),
+});
+
+export const GetInputSchema = z.object({
+  sessionId: z.number().int().positive(),
+});
+
+export const GetByMediaInputSchema = z.object({
+  mediaType: DebriefMediaTypeSchema,
+  mediaId: z.number().int().positive(),
+});
+
+export const LogWatchCompletionInputSchema = z.object({
+  watchHistoryId: z.number().int().positive(),
+  mediaType: DebriefMediaTypeSchema,
+  mediaId: z.number().int().positive(),
+});
+
+export const DeleteByWatchHistoryIdInputSchema = z.object({
+  watchHistoryId: z.number().int().positive(),
+});

--- a/packages/cerebrum-contract/src/schemas/index.ts
+++ b/packages/cerebrum-contract/src/schemas/index.ts
@@ -1,4 +1,19 @@
 export {
+  CreateInputSchema,
+  DebriefMediaTypeSchema,
+  DebriefResultSchema,
+  DebriefSessionSchema,
+  DebriefSessionStatusSchema,
+  DebriefStatusSchema,
+  DeleteByWatchHistoryIdInputSchema,
+  DismissInputSchema,
+  GetByMediaInputSchema,
+  GetInputSchema,
+  ListPendingInputSchema,
+  LogWatchCompletionInputSchema,
+  RecordInputSchema,
+} from './debrief.js';
+export {
   EmbeddingsGetStatusInputSchema,
   EmbeddingsGetStatusOutputSchema,
   EmbeddingsListSourceIdsByTypeInputSchema,

--- a/packages/cerebrum-contract/src/types/debrief.ts
+++ b/packages/cerebrum-contract/src/types/debrief.ts
@@ -1,0 +1,156 @@
+/**
+ * Public entity + input types for the `cerebrum.debrief.*` SDK surface
+ * (PRD-248). The cerebrum debrief subsystem is consumed cross-pillar by the
+ * media-pillar after a watch lands; it stores a post-watch reflection
+ * session per (re-)watch, queues a per-dimension status row, and records
+ * per-dimension reflection outcomes.
+ *
+ * Shapes mirror the cerebrum-db drizzle rows (`debriefSessions`,
+ * `debriefResults`, `debriefStatus`) one-to-one — the contract is the wire
+ * shape, not a UI projection. The accompanying zod schemas under
+ * `../schemas/debrief.ts` validate at runtime; the round-trip test in
+ * `__tests__/schemas.test.ts` keeps both halves in lock-step.
+ *
+ * Per PRD-248 §Wire shape highlights, `getByMedia` consumes the
+ * denormalised `media_type` + `media_id` columns added to `debrief_sessions`
+ * in commit `9df171fe` — no SQL inner-join into `watch_history` leaks into
+ * the cross-pillar read.
+ */
+
+export const DEBRIEF_MEDIA_TYPES = ['movie', 'episode'] as const;
+export type DebriefMediaType = (typeof DEBRIEF_MEDIA_TYPES)[number];
+
+export const DEBRIEF_SESSION_STATUSES = ['pending', 'active', 'complete'] as const;
+export type DebriefSessionStatus = (typeof DEBRIEF_SESSION_STATUSES)[number];
+
+/**
+ * A single post-watch debrief session — one row per (re-)watch.
+ *
+ * `mediaType` / `mediaId` are the denormalised media tuple from commit
+ * `9df171fe`; both are nullable in the current drizzle definition for the
+ * migration window and will tighten to NOT NULL once `debrief_sessions`
+ * physically moves to `cerebrum.db`. The contract reflects the on-the-wire
+ * shape today and surfaces both as nullable.
+ *
+ * `watchHistoryId` is a soft pointer into the media pillar's
+ * `watch_history` table (ADR-026); no cross-DB FK exists.
+ */
+export interface DebriefSession {
+  id: number;
+  watchHistoryId: number;
+  mediaType: DebriefMediaType | null;
+  mediaId: number | null;
+  status: DebriefSessionStatus;
+  /** ISO-8601 timestamp emitted by sqlite `(datetime('now'))`. */
+  createdAt: string;
+}
+
+/**
+ * A per-session, per-dimension reflection outcome. `comparisonId` is null
+ * when the dimension was dismissed (skipped); otherwise it pins the
+ * comparison row recorded for the dimension.
+ */
+export interface DebriefResult {
+  id: number;
+  sessionId: number;
+  dimensionId: number;
+  comparisonId: number | null;
+  /** ISO-8601 timestamp. */
+  createdAt: string;
+}
+
+/**
+ * Per (media tuple, dimension) row tracking whether the debrief flow for a
+ * dimension has been completed or dismissed. Upserted by
+ * `queueDebriefStatus` — `debriefed` / `dismissed` reset to 0 on re-watch.
+ */
+export interface DebriefStatus {
+  id: number;
+  mediaType: string;
+  mediaId: number;
+  dimensionId: number;
+  debriefed: number;
+  dismissed: number;
+  /** ISO-8601 timestamp. */
+  createdAt: string;
+  /** ISO-8601 timestamp. */
+  updatedAt: string;
+}
+
+/**
+ * Input for `cerebrum.debrief.record` — insert a debrief result row.
+ * `comparisonId` is null when the dimension is being recorded as a skip.
+ */
+export interface RecordInput {
+  sessionId: number;
+  dimensionId: number;
+  comparisonId: number | null;
+}
+
+/**
+ * Input for `cerebrum.debrief.dismiss` — mark a session as dismissed at
+ * the session level. Idempotent on already-dismissed sessions.
+ */
+export interface DismissInput {
+  sessionId: number;
+}
+
+/**
+ * Input for `cerebrum.debrief.listPending` — enumerate pending sessions,
+ * optionally filtered by media tuple. Pagination defaults are picked by
+ * the handler (US-03); the contract just shapes the optional knobs.
+ */
+export interface ListPendingInput {
+  mediaType?: DebriefMediaType;
+  mediaId?: number;
+  limit?: number;
+  offset?: number;
+}
+
+/**
+ * Input for `cerebrum.debrief.create` — create a debrief session pinned to
+ * a watch_history row. Deletes prior pending/active sessions for the same
+ * `(mediaType, mediaId)` first; matches today's `createDebriefSession`
+ * idempotency.
+ */
+export interface CreateInput {
+  watchHistoryId: number;
+  mediaType: DebriefMediaType;
+  mediaId: number;
+}
+
+/** Input for `cerebrum.debrief.get`. */
+export interface GetInput {
+  sessionId: number;
+}
+
+/**
+ * Input for `cerebrum.debrief.getByMedia` — denormalised lookup. Reads
+ * `debrief_sessions.media_type` + `media_id` directly (commit `9df171fe`);
+ * no inner-join into `watch_history`. Returns `null` when no session
+ * exists.
+ */
+export interface GetByMediaInput {
+  mediaType: DebriefMediaType;
+  mediaId: number;
+}
+
+/**
+ * Input for `cerebrum.debrief.logWatchCompletion` — Option D entry point.
+ * Wraps `createDebriefSession` + `queueDebriefStatus` in one cerebrum-side
+ * tx; idempotent on retry per `(watchHistoryId, mediaType, mediaId)`.
+ */
+export interface LogWatchCompletionInput {
+  watchHistoryId: number;
+  mediaType: DebriefMediaType;
+  mediaId: number;
+}
+
+/**
+ * Input for `cerebrum.debrief.deleteByWatchHistoryId` — cascade-delete
+ * `debriefSessions` rows pinned to the given watch row. Sister
+ * `debriefResults` rows cascade via the intra-cerebrum FK.
+ */
+export interface DeleteByWatchHistoryIdInput {
+  watchHistoryId: number;
+}

--- a/packages/cerebrum-contract/src/types/index.ts
+++ b/packages/cerebrum-contract/src/types/index.ts
@@ -3,6 +3,22 @@
  * a new entity means adding both a file under `types/` and a matching
  * schema under `schemas/`. The round-trip test enforces that they agree.
  */
+export { DEBRIEF_MEDIA_TYPES, DEBRIEF_SESSION_STATUSES } from './debrief.js';
+export type {
+  CreateInput,
+  DebriefMediaType,
+  DebriefResult,
+  DebriefSession,
+  DebriefSessionStatus,
+  DebriefStatus,
+  DeleteByWatchHistoryIdInput,
+  DismissInput,
+  GetByMediaInput,
+  GetInput,
+  ListPendingInput,
+  LogWatchCompletionInput,
+  RecordInput,
+} from './debrief.js';
 export type {
   EmbeddingsGetStatusInput,
   EmbeddingsGetStatusOutput,


### PR DESCRIPTION
## Summary

PRD-248 US-01 — foundational zod schemas + TypeScript types for the
cross-pillar `pillar('cerebrum').debrief.*` SDK surface. Unblocks
PRD-246 US-04 Sites 4–7 (the media → cerebrum debrief cluster) and
PRD-248 US-02..US-04 (the write / read / delete-and-dismiss surfaces).

**No router procedure is registered in this US — schemas + types only.**

## Module location choice

Per the US-01 AC's pick-at-PR-time: chose **(b) the existing
`packages/cerebrum-contract` shared shapes module** (PRD-153 scaffold)
rather than promoting to `@pops/cerebrum-db` types or keeping the
shapes inside `apps/pops-cerebrum-api`. `cerebrum-contract` already
plays the role of the cross-pillar wire shape for cerebrum (it ships
`Engram`, `Nudge`, `Scope`, the error envelope, the manifest, and the
OpenAPI snapshot consumed by iOS Swift codegen) and is consumed by both
`apps/pops-api` and `apps/pops-cerebrum-api`. Adding `debrief` here
keeps the contract package the single source of truth and avoids
introducing a new package or pulling `@pops/cerebrum-db` into the wire
graph.

## The 8 procedures shaped

| Procedure                  | Input schema                          | Notes                                                                                          |
| -------------------------- | ------------------------------------- | ---------------------------------------------------------------------------------------------- |
| `record`                   | `RecordInputSchema`                   | Insert a debrief result row. `comparisonId` nullable for dismissals.                            |
| `dismiss`                  | `DismissInputSchema`                  | Session-level dismiss. Idempotent.                                                              |
| `listPending`              | `ListPendingInputSchema`              | Optional media-tuple filter + pagination.                                                       |
| `create`                   | `CreateInputSchema`                   | Pins a session to a `watch_history` row.                                                        |
| `get`                      | `GetInputSchema`                      | By `sessionId`.                                                                                 |
| `getByMedia`               | `GetByMediaInputSchema`               | **Denormalised — `{ mediaType, mediaId }` only**; reads `debrief_sessions.media_type`/`media_id` |
| `logWatchCompletion`       | `LogWatchCompletionInputSchema`       | Option D mixed-tx entry point. Idempotent on retry.                                              |
| `deleteByWatchHistoryId`   | `DeleteByWatchHistoryIdInputSchema`   | Cascade-delete debrief rows for a watch row.                                                    |

Plus entity schemas: `DebriefSessionSchema`, `DebriefResultSchema`,
`DebriefStatusSchema`, and the supporting enums `DebriefMediaTypeSchema`
+ `DebriefSessionStatusSchema`.

## getByMedia denormalisation note

`GetByMediaInputSchema` accepts only `{ mediaType, mediaId }` (no
`watchHistoryId`). The contract intentionally exposes the read shape
that consumes the denormalised `media_type` + `media_id` columns added
to `debrief_sessions` in commit `9df171fe` — no `watch_history`
inner-join shape leaks across the pillar boundary. Both columns are
nullable in `DebriefSessionSchema` for the migration window per the
drizzle definition's `media_type text` / `media_id integer` (not
NOT NULL yet); a future migration tightens them once `debrief_sessions`
physically moves to `cerebrum.db`.

## References

- [PRD-248 README](../docs/themes/13-pillar-finale/prds/248-cerebrum-debrief-sdk-surface/README.md) — the SDK surface scope
- [US-01](../docs/themes/13-pillar-finale/prds/248-cerebrum-debrief-sdk-surface/us-01-debrief-schema-and-types.md) — AC for this PR (all ticked)
- [Option D mixed-tx design](../docs/themes/13-pillar-finale/notes/media-watch-history-mixed-tx-design.md) — the pattern `logWatchCompletion` is shaped to; codified by US-05
- Commit `9df171fe` — the `media_type` + `media_id` denormalisation

## Test plan

- [x] `pnpm --filter @pops/cerebrum-contract test` — 99 tests pass (round-trip + invalid-input cases across all entity + input schemas, including explicit `GetByMediaInputSchema` rejects-missing-{mediaType,mediaId} cases)
- [x] `pnpm --filter @pops/cerebrum-contract typecheck` clean
- [x] `pnpm --filter @pops/cerebrum-contract build` clean (manifest verify + tsc + OpenAPI regen)
- [x] `oxlint --type-aware packages/cerebrum-contract` clean
- [x] OpenAPI snapshot regenerated and committed; new `/cerebrum/debrief/*` paths + Debrief component schemas + `debrief` tag covered by `openapi.test.ts`
- [x] Husky pre-commit ran without `--no-verify`