### PR TITLE
docs(theme-13): strip tracker artifact, fix audit cross-link, refresh headline numbers

### DIFF
--- a/docs/themes/13-pillar-finale/IMPLEMENTATION-PLAN.md
+++ b/docs/themes/13-pillar-finale/IMPLEMENTATION-PLAN.md
@@ -9,8 +9,9 @@
 ## Headline status
 
 - **20 PRDs Done.** Foundation, registry/SDK, settings dimension, dynamic AppRouter, shell decoupling, db-types decomposition (7/8 USs).
-- **2 PRDs In progress.** PRD-245 US-08 (final db-types cleanup); anti-lego audit refresh.
+- **1 PRD In progress.** PRD-245 US-08 (final db-types cleanup).
 - **3 PRDs Queued.** PRD-247/248/249 (cross-pillar SDK surfaces) at US-01 (schema). US-02+ unblocks PRD-246 US-04.
+- **Anti-lego audit 2026-06.** 18 findings (4 HIGH / 8 MEDIUM / 6 LOW), down from 28. HIGH = H6 (53 `@pops/db-types` consumers), H7 (4 cross-pillar denorm pairs), H8 (33 cross-pillar imports in pops-api), H-D1 (per-pillar Dockerfiles copy every other pillar's src). See [notes/pillar-isolation-audit-2026-06.md](notes/pillar-isolation-audit-2026-06.md).
 - **Production:** capivara healthy. CI green on main.
 
 ## PRD status
@@ -108,5 +109,3 @@ These were tracked in scattered docs; folded here so those docs can be deleted.
 2. **Walk `.dependency-cruiser-known-violations.json`** after PRD-247/248/249 US-04 land; expect significant shrinkage.
 3. **`/pillars/<name>/` flat code-topology reorg — parked indefinitely.** User said park it; do not resume without an explicit ask.
 4. **Audit duplicate folder.** `docs/themes/13-pillar-finale/prds/244-db-types-decomposition/` is an empty stub from a number collision. The real PRD-245 is at `245-db-types-decomposition/`. Delete it.
-   </content>
-   </invoke>

--- a/docs/themes/13-pillar-finale/notes/pillar-isolation-audit-2026-06.md
+++ b/docs/themes/13-pillar-finale/notes/pillar-isolation-audit-2026-06.md
@@ -1,6 +1,6 @@
 # Pillar Isolation Audit — 2026-06 Refresh
 
-Companion to [`pillar-isolation-audit.md`](pillar-isolation-audit.md) (the original 28-finding audit, #3215) and [`pillar-isolation-audit-status.md`](pillar-isolation-audit-status.md) (the post-PRD-240/241/242/243 status snapshot). This refresh re-walks the codebase after PRD-245 (db-types decomposition, 7/8 done), PRD-246 US-03 (shell capture registry walk), and the PRD-247/248/249 scoping work.
+Companion to [`pillar-isolation-audit.md`](pillar-isolation-audit.md) — the original 28-finding audit (#3215). The interim status snapshot has been folded into [`../IMPLEMENTATION-PLAN.md`](../IMPLEMENTATION-PLAN.md). This refresh re-walks the codebase after PRD-245 (db-types decomposition, 7/8 done), PRD-246 US-03 (shell capture registry walk), and the PRD-247/248/249 scoping work.
 
 The north-star rule for every finding below: **a pillar must be deployable, testable, and reasoned about without the source of any other pillar except published contracts (`<pillar>-contract`) and shared infra (`pillar-sdk`, `types`, `module-registry`).** Anywhere that breaks is an anti-lego smell.
 


### PR DESCRIPTION
Cleanup of two issues Copilot flagged on the (now-closed) #3280:

1. `IMPLEMENTATION-PLAN.md` ended with stray `</content></invoke>` editor-template lines from the #3279 Write call. Removed.
2. `pillar-isolation-audit-2026-06.md` linked to the deleted `pillar-isolation-audit-status.md`. Repointed to the folded section in `IMPLEMENTATION-PLAN.md`.

Bonus: refresh headline status with the 18-finding audit numbers (4 HIGH / 8 MED / 6 LOW) now that the audit doc is on main. Was previously listed as 'audit refresh in progress'.