### PR TITLE
docs(theme-13): track open MCP registry-seeding bug in IMPLEMENTATION-PLAN

### DIFF
--- a/docs/themes/13-pillar-finale/IMPLEMENTATION-PLAN.md
+++ b/docs/themes/13-pillar-finale/IMPLEMENTATION-PLAN.md
@@ -9,8 +9,9 @@
 ## Headline status
 
 - **20 PRDs Done.** Foundation, registry/SDK, settings dimension, dynamic AppRouter, shell decoupling, db-types decomposition (7/8 USs).
-- **2 PRDs In progress.** PRD-245 US-08 (final db-types cleanup); anti-lego audit refresh.
+- **1 PRD In progress.** PRD-245 US-08 (final db-types cleanup).
 - **3 PRDs Queued.** PRD-247/248/249 (cross-pillar SDK surfaces) at US-01 (schema). US-02+ unblocks PRD-246 US-04.
+- **Anti-lego audit 2026-06.** 18 findings (4 HIGH / 8 MEDIUM / 6 LOW), down from 28. HIGH = H6 (53 `@pops/db-types` consumers), H7 (4 cross-pillar denorm pairs), H8 (33 cross-pillar imports in pops-api), H-D1 (per-pillar Dockerfiles copy every other pillar's src). See [notes/pillar-isolation-audit-2026-06.md](notes/pillar-isolation-audit-2026-06.md).
 - **Production:** capivara healthy. CI green on main.
 
 ## PRD status
@@ -108,5 +109,3 @@ These were tracked in scattered docs; folded here so those docs can be deleted.
 2. **Walk `.dependency-cruiser-known-violations.json`** after PRD-247/248/249 US-04 land; expect significant shrinkage.
 3. **`/pillars/<name>/` flat code-topology reorg — parked indefinitely.** User said park it; do not resume without an explicit ask.
 4. **Audit duplicate folder.** `docs/themes/13-pillar-finale/prds/244-db-types-decomposition/` is an empty stub from a number collision. The real PRD-245 is at `245-db-types-decomposition/`. Delete it.
-   </content>
-   </invoke>

--- a/docs/themes/13-pillar-finale/IMPLEMENTATION-PLAN.md
+++ b/docs/themes/13-pillar-finale/IMPLEMENTATION-PLAN.md
@@ -85,13 +85,26 @@ PRDs 213/214 (drop `pops.db` + retire legacy code) are conceptually done. The re
 - Test-side mocks are NOT a Wave 5 gate. They follow SUT migrations mechanically.
 - Stale `vi.mock('@pops/db-types', ...)` silent-failure pattern: detect via `grep -r "vi.mock.*getDrizzle"` then diff against SUT actual imports.
 
+## MCP registry seeding (open)
+
+Discovered 2026-06-15 via a live `pops-mcp` tool-call probe. MCP boot succeeds, the HTTP transport at `/mcp` is reachable, and `tools/list` returns 30 tools, but every `tools/call` fails with "Pillar 'X' is unavailable".
+
+Three bugs in series — two fixed in homelab-infra PR #12, one open:
+
+1. **Secret-mount perms (fixed).** `pops_api_key` was written by Ansible as `root:root 0600`, but `pops-mcp` runs as uid 1000 (node), and `docker compose secrets:`'s long-form `uid:/gid:/mode:` overrides are a Swarm-only feature ignored by plain compose. Fix: secrets role now supports per-item ownership; `pops_api_key` is `1000:1000 0440`.
+2. **POPS_PILLARS on the dispatcher (fixed).** `pops-api` and `pops-worker` had no `POPS_PILLARS` env, so their in-process registry only knew the synthetic `core` entry. Added the env to both, plus `POPS_API_KEY_FILE` for outgoing-call auth.
+3. **Dynamic registry empty (OPEN).** The pillar-sdk discovery path used by MCP calls tRPC `core.registry.list` on `pops-core-api`'s heartbeat-driven registry. That registry is fed by pillars POST-ing to `/core.registry.register` at boot — but the 7 per-pillar APIs have no self-register code. Net: discovery returns `pillars: []` → every call → unavailable. **This needs a new PRD** to either (a) add boot-time self-register to each pillar API (proper PRD-228 fulfillment for non-shell pillars), or (b) seed core-api's registry from `POPS_PILLARS` at boot with synthetic minimal manifests fetched from each pillar's `/manifest` endpoint (which PRD-241 US-01 added in code but not yet over HTTP). Recommend (a) — matches the ADR-035 / PRD-228 contract.
+
+Until (3) closes, MCP is **healthy as a process** but functionally inert for tool calls.
+
 ## Theme 13 exit criteria
 
-1. All 22 PRDs at 100% (the 17 in "Done" above + PRD-245 US-08 + PRD-246 US-04/05 + PRD-247/248/249).
+1. All 22 PRDs at 100% (the 17 in "Done" above + PRD-245 US-08 + PRD-246 US-04/05 + PRD-247/248/249) + the new MCP-registry-seeding PRD.
 2. Anti-lego audit reports 0 HIGH findings, ≤ a handful of justifiable MEDs (each annotated with next-PRD reference if the close can't ship now).
 3. Wave 5 at the revised threshold above.
 4. CI green on main. Publish Images succeeds on a freshly-cut main without a manual hot-fix chain.
 5. Capivara healthy on the post-merge image for 24 hours minimum.
+6. MCP `tools/call` succeeds end-to-end for at least one tool per pillar (gates the "MCP healthy" goal).
 
 ## Operational notes (for future agents)
 

--- a/docs/themes/13-pillar-finale/notes/pillar-isolation-audit-2026-06.md
+++ b/docs/themes/13-pillar-finale/notes/pillar-isolation-audit-2026-06.md
@@ -1,6 +1,6 @@
 # Pillar Isolation Audit — 2026-06 Refresh
 
-Companion to [`pillar-isolation-audit.md`](pillar-isolation-audit.md) (the original 28-finding audit, #3215) and [`pillar-isolation-audit-status.md`](pillar-isolation-audit-status.md) (the post-PRD-240/241/242/243 status snapshot). This refresh re-walks the codebase after PRD-245 (db-types decomposition, 7/8 done), PRD-246 US-03 (shell capture registry walk), and the PRD-247/248/249 scoping work.
+Companion to [`pillar-isolation-audit.md`](pillar-isolation-audit.md) — the original 28-finding audit (#3215). The interim status snapshot has been folded into [`../IMPLEMENTATION-PLAN.md`](../IMPLEMENTATION-PLAN.md). This refresh re-walks the codebase after PRD-245 (db-types decomposition, 7/8 done), PRD-246 US-03 (shell capture registry walk), and the PRD-247/248/249 scoping work.
 
 The north-star rule for every finding below: **a pillar must be deployable, testable, and reasoned about without the source of any other pillar except published contracts (`<pillar>-contract`) and shared infra (`pillar-sdk`, `types`, `module-registry`).** Anywhere that breaks is an anti-lego smell.
 


### PR DESCRIPTION
Live probe of pops-mcp on capivara surfaced three bugs preventing tool calls from working end-to-end.

Two were infra-side and are fixed in homelab-infra#12:
- pops_api_key was `root:root 0600` but pops-mcp runs as uid 1000 (node); docker compose secrets uid/gid/mode overrides are a Swarm-only no-op. Fixed by per-item ownership in the Ansible secrets role.
- pops-api / pops-worker shipped without POPS_PILLARS env so the in-process registry only had 'core'. Added the env to both.

The third is a real product gap and needs a new PRD: the 7 per-pillar APIs do not self-register with core-api's heartbeat-driven registry at boot. pillar-sdk discovery (used by pops-mcp) reads tRPC core.registry.list and gets an empty list, so every cross-pillar tool call returns 'pillar unavailable'.

Adds a new 'MCP registry seeding' section to IMPLEMENTATION-PLAN with the full diagnosis + recommended close (option A: boot-time self-register on each pillar API, matching PRD-228's contract; option B: seed core-api's registry from POPS_PILLARS at boot). Adds exit-criterion #6: MCP tools/call must succeed end-to-end for at least one tool per pillar before the 'MCP healthy' goal is met.