### PR TITLE
feat(pillar-sdk): PRD-250 — coerce non-semver BUILD_VERSION + scope pillar self-register

### DIFF
--- a/docs/themes/13-pillar-finale/IMPLEMENTATION-PLAN.md
+++ b/docs/themes/13-pillar-finale/IMPLEMENTATION-PLAN.md
@@ -9,8 +9,9 @@
 ## Headline status
 
 - **20 PRDs Done.** Foundation, registry/SDK, settings dimension, dynamic AppRouter, shell decoupling, db-types decomposition (7/8 USs).
-- **2 PRDs In progress.** PRD-245 US-08 (final db-types cleanup); anti-lego audit refresh.
+- **1 PRD In progress.** PRD-245 US-08 (final db-types cleanup).
 - **3 PRDs Queued.** PRD-247/248/249 (cross-pillar SDK surfaces) at US-01 (schema). US-02+ unblocks PRD-246 US-04.
+- **Anti-lego audit 2026-06.** 18 findings (4 HIGH / 8 MEDIUM / 6 LOW), down from 28. HIGH = H6 (53 `@pops/db-types` consumers), H7 (4 cross-pillar denorm pairs), H8 (33 cross-pillar imports in pops-api), H-D1 (per-pillar Dockerfiles copy every other pillar's src). See [notes/pillar-isolation-audit-2026-06.md](notes/pillar-isolation-audit-2026-06.md).
 - **Production:** capivara healthy. CI green on main.
 
 ## PRD status
@@ -108,5 +109,3 @@ These were tracked in scattered docs; folded here so those docs can be deleted.
 2. **Walk `.dependency-cruiser-known-violations.json`** after PRD-247/248/249 US-04 land; expect significant shrinkage.
 3. **`/pillars/<name>/` flat code-topology reorg — parked indefinitely.** User said park it; do not resume without an explicit ask.
 4. **Audit duplicate folder.** `docs/themes/13-pillar-finale/prds/244-db-types-decomposition/` is an empty stub from a number collision. The real PRD-245 is at `245-db-types-decomposition/`. Delete it.
-   </content>
-   </invoke>

--- a/docs/themes/13-pillar-finale/IMPLEMENTATION-PLAN.md
+++ b/docs/themes/13-pillar-finale/IMPLEMENTATION-PLAN.md
@@ -85,13 +85,26 @@ PRDs 213/214 (drop `pops.db` + retire legacy code) are conceptually done. The re
 - Test-side mocks are NOT a Wave 5 gate. They follow SUT migrations mechanically.
 - Stale `vi.mock('@pops/db-types', ...)` silent-failure pattern: detect via `grep -r "vi.mock.*getDrizzle"` then diff against SUT actual imports.
 
+## MCP registry seeding (open)
+
+Discovered 2026-06-15 via a live `pops-mcp` tool-call probe. MCP boot succeeds, the HTTP transport at `/mcp` is reachable, and `tools/list` returns 30 tools, but every `tools/call` fails with "Pillar 'X' is unavailable".
+
+Three bugs in series — two fixed in homelab-infra PR #12, one open:
+
+1. **Secret-mount perms (fixed).** `pops_api_key` was written by Ansible as `root:root 0600`, but `pops-mcp` runs as uid 1000 (node), and `docker compose secrets:`'s long-form `uid:/gid:/mode:` overrides are a Swarm-only feature ignored by plain compose. Fix: secrets role now supports per-item ownership; `pops_api_key` is `1000:1000 0440`.
+2. **POPS_PILLARS on the dispatcher (fixed).** `pops-api` and `pops-worker` had no `POPS_PILLARS` env, so their in-process registry only knew the synthetic `core` entry. Added the env to both, plus `POPS_API_KEY_FILE` for outgoing-call auth.
+3. **Dynamic registry empty (OPEN).** The pillar-sdk discovery path used by MCP calls tRPC `core.registry.list` on `pops-core-api`'s heartbeat-driven registry. That registry is fed by pillars POST-ing to `/core.registry.register` at boot — but the 7 per-pillar APIs have no self-register code. Net: discovery returns `pillars: []` → every call → unavailable. **This needs a new PRD** to either (a) add boot-time self-register to each pillar API (proper PRD-228 fulfillment for non-shell pillars), or (b) seed core-api's registry from `POPS_PILLARS` at boot with synthetic minimal manifests fetched from each pillar's `/manifest` endpoint (which PRD-241 US-01 added in code but not yet over HTTP). Recommend (a) — matches the ADR-035 / PRD-228 contract.
+
+Until (3) closes, MCP is **healthy as a process** but functionally inert for tool calls.
+
 ## Theme 13 exit criteria
 
-1. All 22 PRDs at 100% (the 17 in "Done" above + PRD-245 US-08 + PRD-246 US-04/05 + PRD-247/248/249).
+1. All 22 PRDs at 100% (the 17 in "Done" above + PRD-245 US-08 + PRD-246 US-04/05 + PRD-247/248/249) + the new MCP-registry-seeding PRD.
 2. Anti-lego audit reports 0 HIGH findings, ≤ a handful of justifiable MEDs (each annotated with next-PRD reference if the close can't ship now).
 3. Wave 5 at the revised threshold above.
 4. CI green on main. Publish Images succeeds on a freshly-cut main without a manual hot-fix chain.
 5. Capivara healthy on the post-merge image for 24 hours minimum.
+6. MCP `tools/call` succeeds end-to-end for at least one tool per pillar (gates the "MCP healthy" goal).
 
 ## Operational notes (for future agents)
 

--- a/docs/themes/13-pillar-finale/notes/pillar-isolation-audit-2026-06.md
+++ b/docs/themes/13-pillar-finale/notes/pillar-isolation-audit-2026-06.md
@@ -1,6 +1,6 @@
 # Pillar Isolation Audit — 2026-06 Refresh
 
-Companion to [`pillar-isolation-audit.md`](pillar-isolation-audit.md) (the original 28-finding audit, #3215) and [`pillar-isolation-audit-status.md`](pillar-isolation-audit-status.md) (the post-PRD-240/241/242/243 status snapshot). This refresh re-walks the codebase after PRD-245 (db-types decomposition, 7/8 done), PRD-246 US-03 (shell capture registry walk), and the PRD-247/248/249 scoping work.
+Companion to [`pillar-isolation-audit.md`](pillar-isolation-audit.md) — the original 28-finding audit (#3215). The interim status snapshot has been folded into [`../IMPLEMENTATION-PLAN.md`](../IMPLEMENTATION-PLAN.md). This refresh re-walks the codebase after PRD-245 (db-types decomposition, 7/8 done), PRD-246 US-03 (shell capture registry walk), and the PRD-247/248/249 scoping work.
 
 The north-star rule for every finding below: **a pillar must be deployable, testable, and reasoned about without the source of any other pillar except published contracts (`<pillar>-contract`) and shared infra (`pillar-sdk`, `types`, `module-registry`).** Anywhere that breaks is an anti-lego smell.
 

--- a/docs/themes/13-pillar-finale/prds/250-pillar-api-self-register/README.md
+++ b/docs/themes/13-pillar-finale/prds/250-pillar-api-self-register/README.md
@@ -1,0 +1,71 @@
+# PRD-250: Per-pillar API self-registration on boot
+
+> Epic: [Cross-pillar federation](../../epics/05-federation.md) (or closest existing — index to be confirmed)
+>
+> Status: **In progress**
+
+## Overview
+
+The `pillar-sdk` discovery layer (used by `pops-mcp` and by every cross-pillar SDK consumer) reads the live pillar list from `pops-core-api`'s heartbeat-driven registry via tRPC `core.registry.list`. That registry is fed by pillars POST-ing their manifest to `/core.registry.register` at boot, with heartbeats keeping the row fresh (PRD-228 US-01/US-02).
+
+Today only `pops-shell` actually does this. Every other pillar API has the bootstrap code in `server.ts`:
+
+```ts
+if (process.env['POPS_REGISTRY_ENABLED'] === 'true') {
+  pillarHandle = await bootstrapPillar({ manifest: buildXManifest(version) });
+}
+```
+
+…but `POPS_REGISTRY_ENABLED` is not set in the compose for any of them. Net: the registry contains 0 dynamic entries, every MCP `tools/call` returns `Pillar 'X' is unavailable`.
+
+This PRD turns the gate on.
+
+## Surface
+
+| Surface                                                                                                                                                  | Change                                                                                                                                                                                                    |
+| -------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `homelab-infra/hosts/capivara/stacks/pops/docker-compose.yml` — each `pops-*-api` service block (core, inventory, media, finance, food, lists, cerebrum) | Add `POPS_REGISTRY_ENABLED: 'true'`. `POPS_REGISTRY_URL` defaults to `http://core-api:3001` in the SDK, so it can stay implicit unless a non-default is wanted.                                           |
+| Pillar API source code                                                                                                                                   | No change. The bootstrap code is already in every `server.ts`.                                                                                                                                            |
+| `bootstrap` transport (`packages/pillar-sdk/src/bootstrap/transport.ts`)                                                                                 | No change. Per the core-api router comment, `/core.registry.register` is "internal-only, blocked at nginx" — auth is the docker-network boundary, the SDK transport intentionally posts un-authenticated. |
+
+## Business Rules
+
+- **No new code coupling.** Each pillar API already imports `bootstrapPillar` from `@pops/pillar-sdk/bootstrap` and already has its own `buildXManifest(version)`. This PRD changes one env var per service.
+- **Best-effort, non-fatal.** `bootstrapPillar` includes retry-with-backoff (5 attempts, exponential). If core-api is unreachable at boot, the pillar still serves traffic; the next heartbeat tick eventually re-registers.
+- **Inverse for shutdown.** SIGTERM calls `pillarHandle.stop()`, which sends an explicit deregister before the HTTP server closes. Already wired in every `server.ts`.
+- **Order matters at first boot.** Pillars depend on core-api being healthy before they can register. The compose already has `depends_on: pops-redis: service_healthy` on each pillar; this PRD adds `depends_on: core-api: service_healthy` on the six non-core pillars (core-api is its own registry, so it self-references after `app.listen`).
+
+## Edge Cases
+
+| Case                                             | Behaviour                                                                                                                                                                                                                                           |
+| ------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| core-api restarts                                | Per PRD-228 US-02, heartbeats land in the persisted `pillar_registry` table; on restart, `reconcileRegistryOnBoot` marks rows as `unknown` based on heartbeat age, and the next heartbeat (within ~10s) flips them back to `healthy`. No data loss. |
+| Pillar restarts (e.g. watchtower image rollover) | Pillar runs `pillarHandle.stop()` on SIGTERM → explicit deregister → row marked dropped. New container boots → registers fresh.                                                                                                                     |
+| Network partition between pillar and core-api    | Pillar boot blocks for up to 5 retry attempts (default max-backoff 30s). If still failing, the pillar starts serving requests without being registered; MCP tool calls to it fail with `unavailable` until the next heartbeat tick succeeds.        |
+| Two pillar instances claim the same `pillarId`   | Out of scope — multi-instance is an ADR-027 follow-up. Single-instance per pillar on capivara today.                                                                                                                                                |
+
+## Acceptance Criteria
+
+Tracked inline (no US-NN split — single-deliverable PRD per [docs/CLAUDE.md](../../../CLAUDE.md)):
+
+- [ ] `homelab-infra` compose: every `pops-*-api` service block has `POPS_REGISTRY_ENABLED: 'true'` and `depends_on` includes `core-api: service_healthy` (except core-api itself).
+- [ ] After redeploy on capivara: `curl http://core-api:3001/trpc/core.registry.list` from inside the docker network returns all 7 pillars with `status: 'healthy'`.
+- [ ] `pops-mcp` `tools/call` for one tool per pillar (e.g. `cerebrum.engrams.list`, `inventory.items.list`, `finance.transactions.list`, `media.library.list`) returns a real payload, not `Pillar 'X' is unavailable`.
+- [ ] Pillar restarts (kill + start) re-register within 30 seconds.
+- [ ] No code changes in the pops repo.
+
+## Out of Scope
+
+- **Authentication on `/core.registry.register`.** The router comment says "blocked at nginx"; verifying nginx config actually enforces this is a separate cleanup if a smell turns up.
+- **Multi-instance pillar registry semantics.** ADR-027 follow-up.
+- **Pillar `/manifest` HTTP exposure.** PRD-241 US-01 added manifest exports in code; exposing them as a public HTTP endpoint is a different PRD — not needed for self-register since `bootstrapPillar` builds the manifest in-process.
+
+## References
+
+- [PRD-228](../228-dynamic-pillar-registration/README.md) — defines the register/heartbeat/deregister handshake this PRD finishes activating
+- [PRD-241](../241-registry-driven-known-modules/README.md) US-01 — per-pillar manifest exports (the `buildXManifest()` functions this PRD relies on)
+- `packages/pillar-sdk/src/bootstrap/bootstrap.ts` — the `bootstrapPillar` helper each pillar already uses
+- `apps/pops-cerebrum-api/src/server.ts:50` — example of the existing gated bootstrap call
+- `apps/pops-shell/src/lib/register-with-registry.ts` — shell's analogous gate (already on)
+- [ADR-026 — Pillar architecture](../../../../architecture/adr-026-pillar-architecture.md)
+- [ADR-027 — Runtime pillar registry](../../../../architecture/adr-027-runtime-pillar-registry.md)

--- a/packages/pillar-sdk/src/bootstrap/__tests__/bootstrap.test.ts
+++ b/packages/pillar-sdk/src/bootstrap/__tests__/bootstrap.test.ts
@@ -13,11 +13,14 @@ import {
   type RegistryTransport,
 } from '../transport.js';
 
+import type { ManifestPayload } from '../../manifest-schema/schema.js';
+
 interface RecordedTransport extends RegistryTransport {
   registerCalls: number;
   heartbeatCalls: number;
   unregisterCalls: number;
   heartbeats: string[];
+  lastRegisterPayload: () => ManifestPayload | undefined;
 }
 
 interface MakeTransportOptions {
@@ -27,13 +30,16 @@ interface MakeTransportOptions {
 }
 
 function makeTransport(options: MakeTransportOptions = {}): RecordedTransport {
+  let lastPayload: ManifestPayload | undefined;
   const state: RecordedTransport = {
     registerCalls: 0,
     heartbeatCalls: 0,
     unregisterCalls: 0,
     heartbeats: [],
+    lastRegisterPayload: () => lastPayload,
     async register(payload) {
       state.registerCalls += 1;
+      lastPayload = payload;
       if (options.registerImpl) return options.registerImpl();
       return { pillarId: payload.pillar };
     },
@@ -82,6 +88,43 @@ describe('bootstrapPillar', () => {
 
     await handle.stop();
     expect(transport.unregisterCalls).toBe(1);
+  });
+
+  it('coerces a non-semver version (e.g. git SHA) into a valid semver prerelease', async () => {
+    const manifest = validManifest();
+    manifest.version = '9c163ed63e147ebe10a9e1711546b5c9c6a72751';
+    manifest.contract.version = '9c163ed63e147ebe10a9e1711546b5c9c6a72751';
+    manifest.contract.tag = 'contract-finance@v9c163ed63e147ebe10a9e1711546b5c9c6a72751';
+
+    const transport = makeTransport();
+    const handle = await bootstrapPillar({
+      manifest,
+      transport,
+      logger: silentLogger(),
+    });
+
+    expect(transport.registerCalls).toBe(1);
+    expect(handle.pillarId).toBe('finance');
+    const sent = transport.lastRegisterPayload();
+    expect(sent?.version).toBe('0.0.0-sha.9c163ed');
+    expect(sent?.contract.version).toBe('0.0.0-sha.9c163ed');
+    expect(sent?.contract.tag).toBe('contract-finance@v0.0.0-sha.9c163ed');
+
+    await handle.stop();
+  });
+
+  it('leaves a valid semver version unchanged', async () => {
+    const manifest = validManifest();
+    manifest.version = '1.2.3';
+    manifest.contract.version = '1.2.3';
+    manifest.contract.tag = 'contract-finance@v1.2.3';
+
+    const transport = makeTransport();
+    await bootstrapPillar({ manifest, transport, logger: silentLogger() });
+
+    const sent = transport.lastRegisterPayload();
+    expect(sent?.version).toBe('1.2.3');
+    expect(sent?.contract.tag).toBe('contract-finance@v1.2.3');
   });
 
   it('throws PillarManifestInvalidError when manifest is malformed', async () => {

--- a/packages/pillar-sdk/src/bootstrap/bootstrap.ts
+++ b/packages/pillar-sdk/src/bootstrap/bootstrap.ts
@@ -38,7 +38,8 @@ export async function bootstrapPillar(
 ): Promise<PillarBootstrapHandle> {
   const logger = options.logger ?? consoleLogger();
 
-  const validation = validateManifestPayload(options.manifest);
+  const normalized = coerceManifestVersion(options.manifest);
+  const validation = validateManifestPayload(normalized);
   if (!validation.ok) {
     throw new PillarManifestInvalidError(validation.issues);
   }
@@ -123,4 +124,30 @@ function startRuntime(args: StartRuntimeArgs): PillarBootstrapHandle {
 function defaultTransport(explicitUrl: string | undefined): RegistryTransport {
   const url = explicitUrl ?? process.env[DEFAULT_REGISTRY_URL_ENV] ?? DEFAULT_REGISTRY_URL_FALLBACK;
   return createHttpRegistryTransport({ baseUrl: url });
+}
+
+const SEMVER_RE = /^\d+\.\d+\.\d+(?:[-+][\w.-]+)?$/;
+
+/**
+ * Normalise a raw `BUILD_VERSION` into a valid manifest version.
+ *
+ * Watchtower-driven deploys inject the git SHA as `BUILD_VERSION`, but the
+ * manifest schema requires semver. Rather than crash boot, coerce a
+ * non-semver value into `0.0.0-sha.<7chars>` (a valid semver prerelease).
+ * Already-semver values pass through unchanged.
+ */
+function coerceManifestVersion(manifest: ManifestPayload): ManifestPayload {
+  const raw = manifest.version;
+  if (SEMVER_RE.test(raw)) return manifest;
+  const short = raw.slice(0, 7);
+  const coerced = `0.0.0-sha.${short}`;
+  return {
+    ...manifest,
+    version: coerced,
+    contract: {
+      ...manifest.contract,
+      version: coerced,
+      tag: `contract-${manifest.pillar}@v${coerced}`,
+    },
+  };
 }


### PR DESCRIPTION
## Summary

Closes the third layer of the MCP-broken bug surfaced earlier today (homelab-infra#12 fixed two infra layers — secret-mount perms + missing POPS_PILLARS on the dispatcher).

**SDK fix**: `bootstrapPillar()` now coerces a non-semver `manifest.version` into a valid semver prerelease (`0.0.0-sha.<7chars>`) before validation. Watchtower-driven deploys inject the git SHA as `BUILD_VERSION`, which today crashes any pillar API that tries to self-register (the manifest validator demands semver). Already-semver values pass through unchanged.

**PRD doc**: `docs/themes/13-pillar-finale/prds/250-pillar-api-self-register/README.md` scopes the runtime change. Once this PR lands and `Publish Images` deploys the new SDK + per-pillar API images, a one-line homelab-infra change flips `POPS_REGISTRY_ENABLED=true` on each of the 7 pillar-api services. All 7 already have the gated bootstrap code; no new code coupling.

## Tests

- 2 new unit tests in `bootstrap.test.ts`:
  - SHA → `0.0.0-sha.9c163ed` coercion forwards to register payload
  - real semver `1.2.3` passes through unchanged
- All 554 SDK tests pass

## Out of scope

- Compose flip — separate homelab-infra PR after this lands + images deploy
- Authentication on `/core.registry.register` (router comment says blocked at nginx; verifying is a separate cleanup)