### PR TITLE
docs(theme-13): scope PRD-251 (H7 denorm) + PRD-252 (Dockerfile isolation, H-D1)

### DIFF
--- a/docs/themes/13-pillar-finale/prds/251-cross-pillar-denorm-h7/README.md
+++ b/docs/themes/13-pillar-finale/prds/251-cross-pillar-denorm-h7/README.md
@@ -1,0 +1,68 @@
+# PRD-251: Close H7 — cross-pillar denormalisation for inventory + finance
+
+> Epic: [Pillar isolation](../../epics/) (final-mile)
+>
+> Status: **Not started**
+
+## Overview
+
+PRD-245 closed the SQL-level half of audit H7 — every `.references()` under `packages/*-db/src/` is now intra-pillar. The denormalisation half survives: production data still leans on cross-pillar object identity. Replacement = URI-shaped soft references plus a periodic reconciliation cron.
+
+Three pairs:
+
+1. inventory → finance — purchase-side context
+2. inventory → core — owner reference
+3. finance → core — owner reference on entities + budgets
+
+Cerebrum → media debrief denorm already landed.
+
+## Surface
+
+- `packages/inventory-db/src/schema/items.ts` — add `purchaseTransactionUri`, `ownerUri` + indices
+- `packages/finance-db/src/schema/{entities,budgets}.ts` — add `ownerUri` + index
+- `apps/pops-inventory-api/src/cron/reconcile-cross-pillar.ts` (new)
+- `apps/pops-finance-api/src/cron/reconcile-cross-pillar.ts` (new)
+
+## Business Rules
+
+- Existence is best-effort. URI-no-resolve → warning, not delete.
+- Read-time fan-out forbidden. Reads from denorm columns; live SDK calls only inside the cron.
+- Owner-side writes only.
+- Inherits PRD-244 typed-proxy patterns for outbound calls.
+
+## Edge Cases
+
+| Case                     | Behaviour                                                                  |
+| ------------------------ | -------------------------------------------------------------------------- |
+| Owning pillar 404        | `staleAt = now`; don't delete                                              |
+| Owning pillar slow/down  | Cron logs + retries next tick                                              |
+| URI parses, type unknown | 404 path; log for ops                                                      |
+| Backfill missing URI     | Migration populates from legacy join column where possible, NULL otherwise |
+
+## User Stories
+
+| #   | Story                      | Parallelisable |
+| --- | -------------------------- | -------------- |
+| 01  | inventory → finance denorm | Yes            |
+| 02  | inventory → core denorm    | Yes            |
+| 03  | finance → core denorm      | Yes            |
+
+## Acceptance Criteria
+
+- Zero `.references()` calls in `packages/{inventory,finance}-db/src/` cross a pillar boundary
+- Each cron has unit tests for ok / 404 / unavailable / bad-URI
+- Integration test boots core + inventory + finance, runs cron, asserts denorm cache
+- `pnpm typecheck/test/build` clean
+
+## Out of Scope
+
+- Live read-time fan-out
+- Cerebrum → media debrief (done)
+- Bulk ops cleanup of pre-existing FK violations in production data
+
+## References
+
+- Pillar isolation audit 2026-06 §H7
+- PRD-244 typed-proxy
+- PRD-245 SQL-half closure
+- ADR-026

--- a/docs/themes/13-pillar-finale/prds/252-per-pillar-dockerfile-isolation-hd1/README.md
+++ b/docs/themes/13-pillar-finale/prds/252-per-pillar-dockerfile-isolation-hd1/README.md
@@ -1,0 +1,70 @@
+# PRD-252: Close H-D1 — per-pillar Dockerfile isolation
+
+> Epic: [Pillar isolation](../../epics/) (final-mile)
+>
+> Status: **Not started**
+
+## Overview
+
+Audit 2026-06 surfaced a new HIGH (H-D1): every per-pillar -api Dockerfile copies the package.json AND src/ AND migrations/ of every other pillar's -db and -contract package, then builds 8 sibling packages before its own. Net effect:
+
+- a finance-schema change rebuilds the core-api image
+- a cerebrum migration appears in the finance-api image layers
+- watchtower drags an unrelated pillar source into a deploy that does not need it
+
+The Dockerfile comments blame pnpm workspace resolver, but only the package.json of every workspace member needs to be present at install time — src and migrations should not have to be copied for packages a pillar does not transitively depend on.
+
+## Surface
+
+- apps/pops-<pillar>-api/Dockerfile (x7) — replace with generator output
+- scripts/generate-pillar-dockerfile.mjs (new) — reads package.json, walks transitive @pops/\* deps via pnpm m ls --filter <pillar>... --json, emits Dockerfile
+- .github/workflows/<pillar>-image.yml (x7) — drift-check step
+
+## Business Rules
+
+- Generated, not hand-written. Drift-check fails the PR on hand-edits.
+- Phase 1 (every workspace package.json) stays — pnpm needs it.
+- Phase 2 narrows to transitive deps only.
+- No new SDK/framework abstractions. Build-layer fix only.
+
+## Edge Cases
+
+| Case                               | Behaviour                                                   |
+| ---------------------------------- | ----------------------------------------------------------- |
+| Pillar adds new @pops/\* dep       | Generator picks up; CI drift-check fails until regenerated  |
+| Pillar removes a dep               | Same                                                        |
+| Two pillars share a transitive dep | Each Dockerfile lists it; BuildKit dedupes identical layers |
+| Build order inside a Dockerfile    | Topology-aware via pnpm --filter <pillar>^... build         |
+
+## User Stories
+
+| #   | Story                                        | Parallelisable       |
+| --- | -------------------------------------------- | -------------------- |
+| 01  | generator + drift-check (land with core-api) | Foundational         |
+| 02  | cerebrum Dockerfile                          | After US-01          |
+| 03  | finance Dockerfile                           | Parallel after US-01 |
+| 04  | inventory Dockerfile                         | Parallel after US-01 |
+| 05  | food Dockerfile                              | Parallel after US-01 |
+| 06  | lists Dockerfile                             | Parallel after US-01 |
+| 07  | media Dockerfile                             | Parallel after US-01 |
+
+## Acceptance Criteria
+
+- Each pillar Dockerfile copies src/ + migrations/ ONLY for transitive @pops/\* deps
+- CI drift-check fails on a forced hand-edit
+- docker buildx build completes locally for every pillar
+- A finance-schema-only commit does NOT rebuild the cerebrum image
+
+## Out of Scope
+
+- Dockerfile multi-stage refactor
+- Image-size optimisation beyond removing unnecessary src
+- pops-shell Dockerfile (already independent enough)
+- pops-api / pops-worker (legacy monolith)
+
+## References
+
+- Pillar isolation audit 2026-06 H-D1
+- apps/pops-core-api/Dockerfile (current shape)
+- ADR-026
+- PRD-245 (../245-db-types-decomposition/README.md)


### PR DESCRIPTION
Two doc-only PRDs for the audit HIGH-bucket closures.

PRD-251 closes audit H7 (PRD-245 closed the SQL half). The denormalisation half: inventory and finance get URI-shaped soft references + a nightly reconciliation cron. 3 parallelisable USs.

PRD-252 closes audit H-D1. Replace every per-pillar Dockerfile with generator output + CI drift-check. US-01 lands the generator; US-02..07 regenerate one pillar each.