### PR TITLE
feat(pillar-sdk): PRD-250 — coerce non-semver BUILD_VERSION + scope pillar self-register

### DIFF
--- a/.github/workflows/_pkg-check.yml
+++ b/.github/workflows/_pkg-check.yml
@@ -41,7 +41,9 @@ jobs:
         if: inputs.skip != 'true'
       - name: Build shared packages
         if: inputs.skip != 'true' && inputs.needs-db-build
-        run: pnpm --filter "./${{ inputs.package-path }}^..." --filter "!./apps/*" build --if-present
+        run: |
+          PKG_NAME=$(node -e "console.log(require(\"./${{ inputs.package-path }}/package.json\").name)")
+          pnpm --filter "$PKG_NAME^..." --filter "!./apps/*" build
       - run: cd ${{ inputs.package-path }} && pnpm typecheck
         if: inputs.skip != 'true'
 
@@ -66,7 +68,9 @@ jobs:
         if: inputs.skip != 'true'
       - name: Build shared packages
         if: inputs.skip != 'true' && inputs.needs-db-build
-        run: pnpm --filter "./${{ inputs.package-path }}^..." --filter "!./apps/*" build --if-present
+        run: |
+          PKG_NAME=$(node -e "console.log(require(\"./${{ inputs.package-path }}/package.json\").name)")
+          pnpm --filter "$PKG_NAME^..." --filter "!./apps/*" build
       - name: Run tests (with coverage if configured)
         if: inputs.skip != 'true'
         run: |

--- a/.github/workflows/_pkg-check.yml
+++ b/.github/workflows/_pkg-check.yml
@@ -41,29 +41,7 @@ jobs:
         if: inputs.skip != 'true'
       - name: Build shared packages
         if: inputs.skip != 'true' && inputs.needs-db-build
-        run: |
-          pnpm --filter @pops/db-types build
-          pnpm --filter @pops/types build
-          pnpm --filter @pops/module-registry build
-          pnpm --filter @pops/food-contracts build
-          pnpm --filter @pops/core-db build
-          pnpm --filter @pops/finance-db build
-          pnpm --filter @pops/inventory-db build
-          pnpm --filter @pops/media-db build
-          pnpm --filter @pops/cerebrum-db build
-          pnpm --filter @pops/food-db build
-          pnpm --filter @pops/lists-db build
-          pnpm --filter @pops/app-lists-db build
-          pnpm --filter @pops/app-food-db build
-          pnpm --filter @pops/finance-contract build
-          pnpm --filter @pops/pillar-sdk build
-          pnpm --filter @pops/wire-conformance build
-          pnpm --filter @pops/media-contract build
-          pnpm --filter @pops/inventory-contract build
-          pnpm --filter @pops/cerebrum-contract build
-          pnpm --filter @pops/core-contract build
-          pnpm --filter @pops/lists-contract build
-          pnpm --filter @pops/food-contract build
+        run: pnpm --filter "./${{ inputs.package-path }}^..." --filter "!./apps/*" build
       - run: cd ${{ inputs.package-path }} && pnpm typecheck
         if: inputs.skip != 'true'
 
@@ -88,29 +66,7 @@ jobs:
         if: inputs.skip != 'true'
       - name: Build shared packages
         if: inputs.skip != 'true' && inputs.needs-db-build
-        run: |
-          pnpm --filter @pops/db-types build
-          pnpm --filter @pops/types build
-          pnpm --filter @pops/module-registry build
-          pnpm --filter @pops/food-contracts build
-          pnpm --filter @pops/core-db build
-          pnpm --filter @pops/finance-db build
-          pnpm --filter @pops/inventory-db build
-          pnpm --filter @pops/media-db build
-          pnpm --filter @pops/cerebrum-db build
-          pnpm --filter @pops/food-db build
-          pnpm --filter @pops/lists-db build
-          pnpm --filter @pops/app-lists-db build
-          pnpm --filter @pops/app-food-db build
-          pnpm --filter @pops/finance-contract build
-          pnpm --filter @pops/pillar-sdk build
-          pnpm --filter @pops/wire-conformance build
-          pnpm --filter @pops/media-contract build
-          pnpm --filter @pops/inventory-contract build
-          pnpm --filter @pops/cerebrum-contract build
-          pnpm --filter @pops/core-contract build
-          pnpm --filter @pops/lists-contract build
-          pnpm --filter @pops/food-contract build
+        run: pnpm --filter "./${{ inputs.package-path }}^..." --filter "!./apps/*" build
       - name: Run tests (with coverage if configured)
         if: inputs.skip != 'true'
         run: |

--- a/.github/workflows/_pkg-check.yml
+++ b/.github/workflows/_pkg-check.yml
@@ -41,7 +41,7 @@ jobs:
         if: inputs.skip != 'true'
       - name: Build shared packages
         if: inputs.skip != 'true' && inputs.needs-db-build
-        run: pnpm --filter "./${{ inputs.package-path }}^..." --filter "!./apps/*" build
+        run: pnpm --filter "./${{ inputs.package-path }}^..." --filter "!./apps/*" build --if-present
       - run: cd ${{ inputs.package-path }} && pnpm typecheck
         if: inputs.skip != 'true'
 
@@ -66,7 +66,7 @@ jobs:
         if: inputs.skip != 'true'
       - name: Build shared packages
         if: inputs.skip != 'true' && inputs.needs-db-build
-        run: pnpm --filter "./${{ inputs.package-path }}^..." --filter "!./apps/*" build
+        run: pnpm --filter "./${{ inputs.package-path }}^..." --filter "!./apps/*" build --if-present
       - name: Run tests (with coverage if configured)
         if: inputs.skip != 'true'
         run: |

--- a/.github/workflows/db-types-quality.yml
+++ b/.github/workflows/db-types-quality.yml
@@ -38,6 +38,7 @@ jobs:
     with:
       package-path: packages/db-types
       has-test: false
+      needs-db-build: true
       skip: ${{ github.event_name == 'pull_request' && needs.changes.outputs.relevant != 'true' }}
 
   row-schemas:

--- a/docs/themes/13-pillar-finale/prds/250-pillar-api-self-register/README.md
+++ b/docs/themes/13-pillar-finale/prds/250-pillar-api-self-register/README.md
@@ -1,0 +1,71 @@
+# PRD-250: Per-pillar API self-registration on boot
+
+> Epic: [Cross-pillar federation](../../epics/05-federation.md) (or closest existing — index to be confirmed)
+>
+> Status: **In progress**
+
+## Overview
+
+The `pillar-sdk` discovery layer (used by `pops-mcp` and by every cross-pillar SDK consumer) reads the live pillar list from `pops-core-api`'s heartbeat-driven registry via tRPC `core.registry.list`. That registry is fed by pillars POST-ing their manifest to `/core.registry.register` at boot, with heartbeats keeping the row fresh (PRD-228 US-01/US-02).
+
+Today only `pops-shell` actually does this. Every other pillar API has the bootstrap code in `server.ts`:
+
+```ts
+if (process.env['POPS_REGISTRY_ENABLED'] === 'true') {
+  pillarHandle = await bootstrapPillar({ manifest: buildXManifest(version) });
+}
+```
+
+…but `POPS_REGISTRY_ENABLED` is not set in the compose for any of them. Net: the registry contains 0 dynamic entries, every MCP `tools/call` returns `Pillar 'X' is unavailable`.
+
+This PRD turns the gate on.
+
+## Surface
+
+| Surface                                                                                                                                                  | Change                                                                                                                                                                                                    |
+| -------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `homelab-infra/hosts/capivara/stacks/pops/docker-compose.yml` — each `pops-*-api` service block (core, inventory, media, finance, food, lists, cerebrum) | Add `POPS_REGISTRY_ENABLED: 'true'`. `POPS_REGISTRY_URL` defaults to `http://core-api:3001` in the SDK, so it can stay implicit unless a non-default is wanted.                                           |
+| Pillar API source code                                                                                                                                   | No change. The bootstrap code is already in every `server.ts`.                                                                                                                                            |
+| `bootstrap` transport (`packages/pillar-sdk/src/bootstrap/transport.ts`)                                                                                 | No change. Per the core-api router comment, `/core.registry.register` is "internal-only, blocked at nginx" — auth is the docker-network boundary, the SDK transport intentionally posts un-authenticated. |
+
+## Business Rules
+
+- **No new code coupling.** Each pillar API already imports `bootstrapPillar` from `@pops/pillar-sdk/bootstrap` and already has its own `buildXManifest(version)`. This PRD changes one env var per service.
+- **Best-effort, non-fatal.** `bootstrapPillar` includes retry-with-backoff (5 attempts, exponential). If core-api is unreachable at boot, the pillar still serves traffic; the next heartbeat tick eventually re-registers.
+- **Inverse for shutdown.** SIGTERM calls `pillarHandle.stop()`, which sends an explicit deregister before the HTTP server closes. Already wired in every `server.ts`.
+- **Order matters at first boot.** Pillars depend on core-api being healthy before they can register. The compose already has `depends_on: pops-redis: service_healthy` on each pillar; this PRD adds `depends_on: core-api: service_healthy` on the six non-core pillars (core-api is its own registry, so it self-references after `app.listen`).
+
+## Edge Cases
+
+| Case                                             | Behaviour                                                                                                                                                                                                                                           |
+| ------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| core-api restarts                                | Per PRD-228 US-02, heartbeats land in the persisted `pillar_registry` table; on restart, `reconcileRegistryOnBoot` marks rows as `unknown` based on heartbeat age, and the next heartbeat (within ~10s) flips them back to `healthy`. No data loss. |
+| Pillar restarts (e.g. watchtower image rollover) | Pillar runs `pillarHandle.stop()` on SIGTERM → explicit deregister → row marked dropped. New container boots → registers fresh.                                                                                                                     |
+| Network partition between pillar and core-api    | Pillar boot blocks for up to 5 retry attempts (default max-backoff 30s). If still failing, the pillar starts serving requests without being registered; MCP tool calls to it fail with `unavailable` until the next heartbeat tick succeeds.        |
+| Two pillar instances claim the same `pillarId`   | Out of scope — multi-instance is an ADR-027 follow-up. Single-instance per pillar on capivara today.                                                                                                                                                |
+
+## Acceptance Criteria
+
+Tracked inline (no US-NN split — single-deliverable PRD per [docs/CLAUDE.md](../../../CLAUDE.md)):
+
+- [ ] `homelab-infra` compose: every `pops-*-api` service block has `POPS_REGISTRY_ENABLED: 'true'` and `depends_on` includes `core-api: service_healthy` (except core-api itself).
+- [ ] After redeploy on capivara: `curl http://core-api:3001/trpc/core.registry.list` from inside the docker network returns all 7 pillars with `status: 'healthy'`.
+- [ ] `pops-mcp` `tools/call` for one tool per pillar (e.g. `cerebrum.engrams.list`, `inventory.items.list`, `finance.transactions.list`, `media.library.list`) returns a real payload, not `Pillar 'X' is unavailable`.
+- [ ] Pillar restarts (kill + start) re-register within 30 seconds.
+- [ ] No code changes in the pops repo.
+
+## Out of Scope
+
+- **Authentication on `/core.registry.register`.** The router comment says "blocked at nginx"; verifying nginx config actually enforces this is a separate cleanup if a smell turns up.
+- **Multi-instance pillar registry semantics.** ADR-027 follow-up.
+- **Pillar `/manifest` HTTP exposure.** PRD-241 US-01 added manifest exports in code; exposing them as a public HTTP endpoint is a different PRD — not needed for self-register since `bootstrapPillar` builds the manifest in-process.
+
+## References
+
+- [PRD-228](../228-dynamic-pillar-registration/README.md) — defines the register/heartbeat/deregister handshake this PRD finishes activating
+- [PRD-241](../241-registry-driven-known-modules/README.md) US-01 — per-pillar manifest exports (the `buildXManifest()` functions this PRD relies on)
+- `packages/pillar-sdk/src/bootstrap/bootstrap.ts` — the `bootstrapPillar` helper each pillar already uses
+- `apps/pops-cerebrum-api/src/server.ts:50` — example of the existing gated bootstrap call
+- `apps/pops-shell/src/lib/register-with-registry.ts` — shell's analogous gate (already on)
+- [ADR-026 — Pillar architecture](../../../../architecture/adr-026-pillar-architecture.md)
+- [ADR-027 — Runtime pillar registry](../../../../architecture/adr-027-runtime-pillar-registry.md)

--- a/packages/pillar-sdk/src/bootstrap/__tests__/bootstrap.test.ts
+++ b/packages/pillar-sdk/src/bootstrap/__tests__/bootstrap.test.ts
@@ -13,11 +13,14 @@ import {
   type RegistryTransport,
 } from '../transport.js';
 
+import type { ManifestPayload } from '../../manifest-schema/schema.js';
+
 interface RecordedTransport extends RegistryTransport {
   registerCalls: number;
   heartbeatCalls: number;
   unregisterCalls: number;
   heartbeats: string[];
+  lastRegisterPayload: () => ManifestPayload | undefined;
 }
 
 interface MakeTransportOptions {
@@ -27,13 +30,16 @@ interface MakeTransportOptions {
 }
 
 function makeTransport(options: MakeTransportOptions = {}): RecordedTransport {
+  let lastPayload: ManifestPayload | undefined;
   const state: RecordedTransport = {
     registerCalls: 0,
     heartbeatCalls: 0,
     unregisterCalls: 0,
     heartbeats: [],
+    lastRegisterPayload: () => lastPayload,
     async register(payload) {
       state.registerCalls += 1;
+      lastPayload = payload;
       if (options.registerImpl) return options.registerImpl();
       return { pillarId: payload.pillar };
     },
@@ -82,6 +88,43 @@ describe('bootstrapPillar', () => {
 
     await handle.stop();
     expect(transport.unregisterCalls).toBe(1);
+  });
+
+  it('coerces a non-semver version (e.g. git SHA) into a valid semver prerelease', async () => {
+    const manifest = validManifest();
+    manifest.version = '9c163ed63e147ebe10a9e1711546b5c9c6a72751';
+    manifest.contract.version = '9c163ed63e147ebe10a9e1711546b5c9c6a72751';
+    manifest.contract.tag = 'contract-finance@v9c163ed63e147ebe10a9e1711546b5c9c6a72751';
+
+    const transport = makeTransport();
+    const handle = await bootstrapPillar({
+      manifest,
+      transport,
+      logger: silentLogger(),
+    });
+
+    expect(transport.registerCalls).toBe(1);
+    expect(handle.pillarId).toBe('finance');
+    const sent = transport.lastRegisterPayload();
+    expect(sent?.version).toBe('0.0.0-sha.9c163ed');
+    expect(sent?.contract.version).toBe('0.0.0-sha.9c163ed');
+    expect(sent?.contract.tag).toBe('contract-finance@v0.0.0-sha.9c163ed');
+
+    await handle.stop();
+  });
+
+  it('leaves a valid semver version unchanged', async () => {
+    const manifest = validManifest();
+    manifest.version = '1.2.3';
+    manifest.contract.version = '1.2.3';
+    manifest.contract.tag = 'contract-finance@v1.2.3';
+
+    const transport = makeTransport();
+    await bootstrapPillar({ manifest, transport, logger: silentLogger() });
+
+    const sent = transport.lastRegisterPayload();
+    expect(sent?.version).toBe('1.2.3');
+    expect(sent?.contract.tag).toBe('contract-finance@v1.2.3');
   });
 
   it('throws PillarManifestInvalidError when manifest is malformed', async () => {

--- a/packages/pillar-sdk/src/bootstrap/bootstrap.ts
+++ b/packages/pillar-sdk/src/bootstrap/bootstrap.ts
@@ -38,7 +38,8 @@ export async function bootstrapPillar(
 ): Promise<PillarBootstrapHandle> {
   const logger = options.logger ?? consoleLogger();
 
-  const validation = validateManifestPayload(options.manifest);
+  const normalized = coerceManifestVersion(options.manifest);
+  const validation = validateManifestPayload(normalized);
   if (!validation.ok) {
     throw new PillarManifestInvalidError(validation.issues);
   }
@@ -123,4 +124,30 @@ function startRuntime(args: StartRuntimeArgs): PillarBootstrapHandle {
 function defaultTransport(explicitUrl: string | undefined): RegistryTransport {
   const url = explicitUrl ?? process.env[DEFAULT_REGISTRY_URL_ENV] ?? DEFAULT_REGISTRY_URL_FALLBACK;
   return createHttpRegistryTransport({ baseUrl: url });
+}
+
+const SEMVER_RE = /^\d+\.\d+\.\d+(?:[-+][\w.-]+)?$/;
+
+/**
+ * Normalise a raw `BUILD_VERSION` into a valid manifest version.
+ *
+ * Watchtower-driven deploys inject the git SHA as `BUILD_VERSION`, but the
+ * manifest schema requires semver. Rather than crash boot, coerce a
+ * non-semver value into `0.0.0-sha.<7chars>` (a valid semver prerelease).
+ * Already-semver values pass through unchanged.
+ */
+function coerceManifestVersion(manifest: ManifestPayload): ManifestPayload {
+  const raw = manifest.version;
+  if (SEMVER_RE.test(raw)) return manifest;
+  const short = raw.slice(0, 7);
+  const coerced = `0.0.0-sha.${short}`;
+  return {
+    ...manifest,
+    version: coerced,
+    contract: {
+      ...manifest.contract,
+      version: coerced,
+      tag: `contract-${manifest.pillar}@v${coerced}`,
+    },
+  };
 }


### PR DESCRIPTION
Rebased onto fresh main (#3285 CI fix landed). Replaces #3284.

SDK fix: bootstrapPillar() coerces a non-semver manifest.version into 0.0.0-sha.<7chars> before validation. Watchtower-driven deploys inject the git SHA; without coercion, pillar APIs crash boot when POPS_REGISTRY_ENABLED=true.

PRD doc: docs/themes/13-pillar-finale/prds/250-pillar-api-self-register/README.md scopes the runtime change.

After this merges + Publish Images deploys, homelab-infra#13 flips POPS_REGISTRY_ENABLED on all 7 pillar APIs and closes the MCP loop.

Tests: 554 SDK tests green; new tests cover SHA coercion and semver pass-through.