### PR TITLE
feat(infra): PRD-252 US-01 per-pillar Dockerfile generator + drift-check (closes H-D1 for core)

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -79,6 +79,25 @@ jobs:
         if: github.event_name == 'push' || needs.changes.outputs.relevant == 'true'
         run: docker build --target builder -f apps/pops-mcp/Dockerfile .
 
+      - uses: pnpm/action-setup@v5
+        if: github.event_name == 'push' || needs.changes.outputs.relevant == 'true'
+
+      - uses: actions/setup-node@v6
+        if: github.event_name == 'push' || needs.changes.outputs.relevant == 'true'
+        with:
+          node-version: "22"
+          cache: pnpm
+
+      # PRD-252 / audit H-D1: per-pillar Dockerfiles are generated, not
+      # hand-edited. The drift-check regenerates and fails on any diff.
+      # When a pillar gains/loses a transitive @pops/* dep, the regenerated
+      # Dockerfile must be committed alongside the change.
+      - name: Verify pops-core-api Dockerfile is up to date (PRD-252)
+        if: github.event_name == 'push' || needs.changes.outputs.relevant == 'true'
+        run: |
+          node scripts/generate-pillar-dockerfile.mjs core
+          git diff --exit-code apps/pops-core-api/Dockerfile
+
       - name: Build pops-core-api (builder stage)
         if: github.event_name == 'push' || needs.changes.outputs.relevant == 'true'
         run: docker build --target builder -f apps/pops-core-api/Dockerfile .

--- a/apps/pops-core-api/Dockerfile
+++ b/apps/pops-core-api/Dockerfile
@@ -1,123 +1,132 @@
+# DO NOT EDIT — regenerate with:
+#   node scripts/generate-pillar-dockerfile.mjs core
+# CI drift-check (.github/workflows/docker-build.yml) fails on hand-edits.
+# PRD-252 / audit H-D1.
+
 FROM node:22-slim AS builder
 WORKDIR /app
 
-# Copy workspace root files
+# Workspace root manifests — needed for pnpm install to resolve.
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json .oxfmtrc.json ./
 
-# Copy workspace package.json files (for dep resolution).
-# wire-conformance is included even though @pops/core-api does not depend on
-# it: pnpm's --legacy deploy resolves the full workspace graph from
-# pnpm-workspace.yaml and fails ERR_PNPM_WORKSPACE_PKG_NOT_FOUND when a
-# listed member is absent from the build context.
-COPY packages/db-types/package.json ./packages/db-types/
-COPY packages/inventory-db/package.json ./packages/inventory-db/
-COPY packages/finance-db/package.json ./packages/finance-db/
-COPY packages/media-db/package.json ./packages/media-db/
-COPY packages/app-lists-db/package.json ./packages/app-lists-db/
-COPY packages/cerebrum-db/package.json ./packages/cerebrum-db/
-COPY packages/food-db/package.json ./packages/food-db/
-COPY packages/types/package.json ./packages/types/
-COPY packages/core-db/package.json ./packages/core-db/
-COPY packages/finance-contract/package.json ./packages/finance-contract/
-COPY packages/cerebrum-contract/package.json ./packages/cerebrum-contract/
-COPY packages/core-contract/package.json ./packages/core-contract/
-COPY packages/inventory-contract/package.json ./packages/inventory-contract/
-COPY packages/media-contract/package.json ./packages/media-contract/
-COPY packages/food-contract/package.json ./packages/food-contract/
-COPY packages/lists-contract/package.json ./packages/lists-contract/
-COPY packages/pillar-sdk/package.json ./packages/pillar-sdk/
-COPY packages/wire-conformance/package.json ./packages/wire-conformance/
+# Phase 1: every workspace package.json. pnpm-workspace.yaml lists every
+# member; if any are missing at install time pnpm fails with
+# ERR_PNPM_WORKSPACE_PKG_NOT_FOUND. src/ + migrations/ for non-transitive
+# packages are intentionally NOT copied (PRD-252 / audit H-D1).
+COPY apps/pops-api/package.json ./apps/pops-api/
+COPY apps/pops-cerebrum-api/package.json ./apps/pops-cerebrum-api/
+COPY apps/pops-cli/package.json ./apps/pops-cli/
 COPY apps/pops-core-api/package.json ./apps/pops-core-api/
+COPY apps/pops-docs/package.json ./apps/pops-docs/
+COPY apps/pops-finance-api/package.json ./apps/pops-finance-api/
+COPY apps/pops-food-api/package.json ./apps/pops-food-api/
+COPY apps/pops-ha-bridge-api/package.json ./apps/pops-ha-bridge-api/
+COPY apps/pops-inventory-api/package.json ./apps/pops-inventory-api/
+COPY apps/pops-lists-api/package.json ./apps/pops-lists-api/
+COPY apps/pops-mcp/package.json ./apps/pops-mcp/
+COPY apps/pops-media-api/package.json ./apps/pops-media-api/
+COPY apps/pops-shell/package.json ./apps/pops-shell/
+COPY apps/pops-storybook/package.json ./apps/pops-storybook/
+COPY apps/pops-worker-food/package.json ./apps/pops-worker-food/
+COPY packages/api-client/package.json ./packages/api-client/
+COPY packages/app-ai/package.json ./packages/app-ai/
+COPY packages/app-cerebrum/package.json ./packages/app-cerebrum/
+COPY packages/app-finance/package.json ./packages/app-finance/
+COPY packages/app-food/package.json ./packages/app-food/
+COPY packages/app-food-db/package.json ./packages/app-food-db/
+COPY packages/app-inventory/package.json ./packages/app-inventory/
+COPY packages/app-lists/package.json ./packages/app-lists/
+COPY packages/app-lists-db/package.json ./packages/app-lists-db/
+COPY packages/app-media/package.json ./packages/app-media/
+COPY packages/cerebrum-contract/package.json ./packages/cerebrum-contract/
+COPY packages/cerebrum-db/package.json ./packages/cerebrum-db/
+COPY packages/core-contract/package.json ./packages/core-contract/
+COPY packages/core-db/package.json ./packages/core-db/
+COPY packages/db-types/package.json ./packages/db-types/
+COPY packages/finance-contract/package.json ./packages/finance-contract/
+COPY packages/finance-db/package.json ./packages/finance-db/
+COPY packages/food-contract/package.json ./packages/food-contract/
+COPY packages/food-contracts/package.json ./packages/food-contracts/
+COPY packages/food-db/package.json ./packages/food-db/
+COPY packages/ha-bridge-db/package.json ./packages/ha-bridge-db/
+COPY packages/inventory-contract/package.json ./packages/inventory-contract/
+COPY packages/inventory-db/package.json ./packages/inventory-db/
+COPY packages/lists-contract/package.json ./packages/lists-contract/
+COPY packages/lists-db/package.json ./packages/lists-db/
+COPY packages/media-contract/package.json ./packages/media-contract/
+COPY packages/media-db/package.json ./packages/media-db/
+COPY packages/module-registry/package.json ./packages/module-registry/
+COPY packages/navigation/package.json ./packages/navigation/
+COPY packages/overlay-ego/package.json ./packages/overlay-ego/
+COPY packages/pillar-sdk/package.json ./packages/pillar-sdk/
+COPY packages/types/package.json ./packages/types/
+COPY packages/ui/package.json ./packages/ui/
+COPY packages/wire-conformance/package.json ./packages/wire-conformance/
 
-# Install pnpm and all workspace dependencies
+# Install pnpm + every workspace dependency.
 RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
     corepack enable && pnpm install --frozen-lockfile
 
-# Copy shared package sources
-COPY packages/db-types/src ./packages/db-types/src
-COPY packages/db-types/tsconfig.json ./packages/db-types/
-COPY packages/inventory-db/src ./packages/inventory-db/src
-COPY packages/inventory-db/tsconfig.json ./packages/inventory-db/
-COPY packages/inventory-db/migrations ./packages/inventory-db/migrations
-COPY packages/finance-db/src ./packages/finance-db/src
-COPY packages/finance-db/tsconfig.json ./packages/finance-db/
-COPY packages/finance-db/migrations ./packages/finance-db/migrations
-COPY packages/media-db/src ./packages/media-db/src
-COPY packages/media-db/tsconfig.json ./packages/media-db/
-COPY packages/media-db/migrations ./packages/media-db/migrations
-COPY packages/app-lists-db/src ./packages/app-lists-db/src
-COPY packages/app-lists-db/tsconfig.json ./packages/app-lists-db/
-COPY packages/cerebrum-db/src ./packages/cerebrum-db/src
-COPY packages/cerebrum-db/tsconfig.json ./packages/cerebrum-db/
-COPY packages/cerebrum-db/migrations ./packages/cerebrum-db/migrations
-COPY packages/food-db/src ./packages/food-db/src
-COPY packages/food-db/tsconfig.json ./packages/food-db/
-COPY packages/food-db/migrations ./packages/food-db/migrations
-COPY packages/types/src ./packages/types/src
-COPY packages/types/tsconfig.json packages/types/tsconfig.build.json ./packages/types/
+# Phase 2: sources for the transitive @pops/* deps of @pops/core-api
+# (resolved via `pnpm m ls --filter "@pops/core-api..." --json`).
+# A change in a non-listed package does NOT invalidate this image's
+# Phase 2 layer.
+# @pops/cerebrum-contract
+COPY packages/cerebrum-contract/src ./packages/cerebrum-contract/src
+COPY packages/cerebrum-contract/scripts ./packages/cerebrum-contract/scripts
+COPY packages/cerebrum-contract/openapi ./packages/cerebrum-contract/openapi
+COPY packages/cerebrum-contract/tsconfig.json ./packages/cerebrum-contract/tsconfig.json
+# @pops/core-contract
+COPY packages/core-contract/src ./packages/core-contract/src
+COPY packages/core-contract/scripts ./packages/core-contract/scripts
+COPY packages/core-contract/openapi ./packages/core-contract/openapi
+COPY packages/core-contract/tsconfig.json ./packages/core-contract/tsconfig.json
+# @pops/core-db
 COPY packages/core-db/src ./packages/core-db/src
-COPY packages/core-db/tsconfig.json ./packages/core-db/
 COPY packages/core-db/migrations ./packages/core-db/migrations
-COPY packages/finance-contract/ ./packages/finance-contract/
-COPY packages/cerebrum-contract/ ./packages/cerebrum-contract/
-COPY packages/core-contract/ ./packages/core-contract/
-COPY packages/inventory-contract/ ./packages/inventory-contract/
-COPY packages/media-contract/ ./packages/media-contract/
-COPY packages/food-contract/ ./packages/food-contract/
-COPY packages/lists-contract/ ./packages/lists-contract/
+COPY packages/core-db/tsconfig.json ./packages/core-db/tsconfig.json
+# @pops/finance-contract
+COPY packages/finance-contract/src ./packages/finance-contract/src
+COPY packages/finance-contract/scripts ./packages/finance-contract/scripts
+COPY packages/finance-contract/openapi ./packages/finance-contract/openapi
+COPY packages/finance-contract/tsconfig.json ./packages/finance-contract/tsconfig.json
+# @pops/inventory-contract
+COPY packages/inventory-contract/src ./packages/inventory-contract/src
+COPY packages/inventory-contract/scripts ./packages/inventory-contract/scripts
+COPY packages/inventory-contract/openapi ./packages/inventory-contract/openapi
+COPY packages/inventory-contract/tsconfig.json ./packages/inventory-contract/tsconfig.json
+# @pops/media-contract
+COPY packages/media-contract/src ./packages/media-contract/src
+COPY packages/media-contract/scripts ./packages/media-contract/scripts
+COPY packages/media-contract/openapi ./packages/media-contract/openapi
+COPY packages/media-contract/tsconfig.json ./packages/media-contract/tsconfig.json
+# @pops/media-db
+COPY packages/media-db/src ./packages/media-db/src
+COPY packages/media-db/migrations ./packages/media-db/migrations
+COPY packages/media-db/tsconfig.json ./packages/media-db/tsconfig.json
+# @pops/pillar-sdk
 COPY packages/pillar-sdk/src ./packages/pillar-sdk/src
-COPY packages/pillar-sdk/tsconfig.json ./packages/pillar-sdk/
+COPY packages/pillar-sdk/tsconfig.json ./packages/pillar-sdk/tsconfig.json
+# @pops/types
+COPY packages/types/src ./packages/types/src
+COPY packages/types/tsconfig.json ./packages/types/tsconfig.json
+COPY packages/types/tsconfig.build.json ./packages/types/tsconfig.build.json
+# @pops/wire-conformance
+COPY packages/wire-conformance/src ./packages/wire-conformance/src
+COPY packages/wire-conformance/tsconfig.json ./packages/wire-conformance/tsconfig.json
+COPY packages/wire-conformance/tsconfig.build.json ./packages/wire-conformance/tsconfig.build.json
 
-# Copy core-api source
-COPY apps/pops-core-api/tsconfig.json ./apps/pops-core-api/
+# Pillar app sources.
 COPY apps/pops-core-api/src ./apps/pops-core-api/src
+COPY apps/pops-core-api/tsconfig.json ./apps/pops-core-api/tsconfig.json
 
-# Build shared packages first.
-# media-db / inventory-db / app-lists-db / cerebrum-db / food-db /
-# finance-db / core-db own canonical schemas; db-types re-exports them
-# via a transition shim, so all seven MUST build BEFORE db-types
-# (PRD-245 US-01 cerebrum + US-02 inventory + US-03 finance + US-04
-# media + US-05 food + US-06 lists + US-07 core / audit H6).
-WORKDIR /app/packages/media-db
-RUN pnpm build
-WORKDIR /app/packages/inventory-db
-RUN pnpm build
-WORKDIR /app/packages/app-lists-db
-RUN pnpm build
-WORKDIR /app/packages/cerebrum-db
-RUN pnpm build
-WORKDIR /app/packages/food-db
-RUN pnpm build
-WORKDIR /app/packages/core-db
-RUN pnpm build
-WORKDIR /app/packages/finance-db
-RUN pnpm build
-WORKDIR /app/packages/db-types
-RUN pnpm build
-WORKDIR /app/packages/types
-RUN pnpm build
-WORKDIR /app/packages/finance-contract
-RUN pnpm build
-WORKDIR /app/packages/cerebrum-contract
-RUN pnpm build
-WORKDIR /app/packages/core-contract
-RUN pnpm build
-WORKDIR /app/packages/inventory-contract
-RUN pnpm build
-WORKDIR /app/packages/media-contract
-RUN pnpm build
-WORKDIR /app/packages/food-contract
-RUN pnpm build
-WORKDIR /app/packages/lists-contract
-RUN pnpm build
-WORKDIR /app/packages/pillar-sdk
-RUN pnpm build
+# Phase 3: build shared deps in pnpm topology order, then the app.
+# `^...` expands to every dependency of the target excluding the target,
+# letting pnpm compute build order from the lockfile (see #3285).
+RUN pnpm --filter "@pops/core-api^..." build
+RUN pnpm --filter "@pops/core-api" build
 
-# Build core-api
-WORKDIR /app/apps/pops-core-api
-RUN pnpm build
-
-# Create standalone deployment (production deps only, no symlinks)
+# Standalone deployment (production deps only, no symlinks).
 RUN pnpm --filter @pops/core-api deploy --prod --legacy /app/deploy
 
 FROM node:22-slim

--- a/docs/themes/13-pillar-finale/prds/252-per-pillar-dockerfile-isolation-hd1/README.md
+++ b/docs/themes/13-pillar-finale/prds/252-per-pillar-dockerfile-isolation-hd1/README.md
@@ -2,7 +2,7 @@
 
 > Epic: [Pillar isolation](../../epics/) (final-mile)
 >
-> Status: **Not started**
+> Status: **In progress**
 
 ## Overview
 
@@ -38,15 +38,15 @@ The Dockerfile comments blame pnpm workspace resolver, but only the package.json
 
 ## User Stories
 
-| #   | Story                                        | Parallelisable       |
-| --- | -------------------------------------------- | -------------------- |
-| 01  | generator + drift-check (land with core-api) | Foundational         |
-| 02  | cerebrum Dockerfile                          | After US-01          |
-| 03  | finance Dockerfile                           | Parallel after US-01 |
-| 04  | inventory Dockerfile                         | Parallel after US-01 |
-| 05  | food Dockerfile                              | Parallel after US-01 |
-| 06  | lists Dockerfile                             | Parallel after US-01 |
-| 07  | media Dockerfile                             | Parallel after US-01 |
+| #   | Story                                        | Status      | Parallelisable       |
+| --- | -------------------------------------------- | ----------- | -------------------- |
+| 01  | generator + drift-check (land with core-api) | Done        | Foundational         |
+| 02  | cerebrum Dockerfile                          | Not started | After US-01          |
+| 03  | finance Dockerfile                           | Not started | Parallel after US-01 |
+| 04  | inventory Dockerfile                         | Not started | Parallel after US-01 |
+| 05  | food Dockerfile                              | Not started | Parallel after US-01 |
+| 06  | lists Dockerfile                             | Not started | Parallel after US-01 |
+| 07  | media Dockerfile                             | Not started | Parallel after US-01 |
 
 ## Acceptance Criteria
 

--- a/scripts/generate-pillar-dockerfile.mjs
+++ b/scripts/generate-pillar-dockerfile.mjs
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+import { execFileSync } from 'node:child_process';
+import { existsSync, writeFileSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SELF = fileURLToPath(import.meta.url);
+const REPO_ROOT = resolve(dirname(SELF), '..');
+
+/**
+ * Generates the Dockerfile for a per-pillar `-api` app under
+ * `apps/pops-<pillar>-api/Dockerfile`.
+ *
+ * Why generated: every per-pillar Dockerfile was hand-copying the `src/`
+ * + `migrations/` of every other pillar's `-db` and `-contract` package,
+ * causing unrelated rebuilds (PRD-252 / audit H-D1). Phase 1 still needs
+ * every workspace `package.json` so pnpm install resolves the lockfile;
+ * Phase 2 narrows source copies to the pillar's transitive `@pops/*`
+ * dependencies; Phase 3 builds those deps in pnpm topology order via
+ * `pnpm --filter "@pops/<pillar>-api^..." build` (the same selector
+ * #3285 introduced for CI).
+ *
+ * Usage: node scripts/generate-pillar-dockerfile.mjs <pillar>
+ * Example: node scripts/generate-pillar-dockerfile.mjs core
+ */
+
+const PILLAR = process.argv[2];
+if (!PILLAR) {
+  console.error('Usage: generate-pillar-dockerfile.mjs <pillar>');
+  console.error('Example: generate-pillar-dockerfile.mjs core');
+  process.exit(1);
+}
+
+const APP_DIR = join('apps', `pops-${PILLAR}-api`);
+const APP_PKG_NAME = `@pops/${PILLAR}-api`;
+
+const appPkgPath = resolve(REPO_ROOT, APP_DIR, 'package.json');
+if (!existsSync(appPkgPath)) {
+  console.error(`pillar app not found: ${APP_DIR}/package.json`);
+  process.exit(1);
+}
+
+/** Read the full workspace package set so pnpm install can resolve. */
+function listWorkspacePackagePaths() {
+  const raw = execFileSync('pnpm', ['m', 'ls', '--json', '--depth', '-1'], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+    maxBuffer: 32 * 1024 * 1024,
+  });
+  const entries = JSON.parse(raw);
+  return entries
+    .filter((e) => e.name && e.name !== '@pops/monorepo' && e.path)
+    .map((e) => relative(REPO_ROOT, e.path))
+    .toSorted();
+}
+
+/**
+ * Resolve every transitive `@pops/*` workspace dep of the target pillar
+ * (including the target itself), with repo-relative paths.
+ */
+function listPillarTransitiveDeps() {
+  const raw = execFileSync(
+    'pnpm',
+    ['m', 'ls', '--filter', `${APP_PKG_NAME}...`, '--json', '--depth', '-1'],
+    { cwd: REPO_ROOT, encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 }
+  );
+  const entries = JSON.parse(raw);
+  return entries
+    .filter(
+      (e) =>
+        typeof e.name === 'string' &&
+        e.name.startsWith('@pops/') &&
+        e.name !== '@pops/monorepo' &&
+        e.path
+    )
+    .map((e) => ({
+      name: e.name,
+      path: relative(REPO_ROOT, e.path),
+    }));
+}
+
+const allWorkspacePaths = listWorkspacePackagePaths();
+const transitiveDeps = listPillarTransitiveDeps();
+const transitiveDepPaths = new Set(transitiveDeps.map((d) => d.path));
+
+if (!transitiveDepPaths.has(APP_DIR)) {
+  console.error(`pnpm did not return the target app ${APP_PKG_NAME} in its dependency graph`);
+  process.exit(1);
+}
+
+const sharedDeps = transitiveDeps
+  .filter((d) => d.path !== APP_DIR)
+  .toSorted((a, b) => a.path.localeCompare(b.path));
+
+/**
+ * For a workspace package directory, return the list of paths to COPY
+ * during Phase 2 (source code, tsconfig variants, migrations, openapi).
+ * Only paths that actually exist on disk are emitted so the Dockerfile
+ * is deterministic against the current tree.
+ */
+function copySourcesFor(pkgDir) {
+  const abs = resolve(REPO_ROOT, pkgDir);
+  const candidates = [
+    'src',
+    'scripts',
+    'migrations',
+    'openapi',
+    'tsconfig.json',
+    'tsconfig.build.json',
+  ];
+  return candidates.filter((c) => existsSync(join(abs, c))).map((c) => `${pkgDir}/${c}`);
+}
+
+const lines = [];
+const push = (s = '') => lines.push(s);
+
+push(`# DO NOT EDIT — regenerate with:`);
+push(`#   node scripts/generate-pillar-dockerfile.mjs ${PILLAR}`);
+push(`# CI drift-check (.github/workflows/docker-build.yml) fails on hand-edits.`);
+push(`# PRD-252 / audit H-D1.`);
+push(``);
+push(`FROM node:22-slim AS builder`);
+push(`WORKDIR /app`);
+push(``);
+push(`# Workspace root manifests — needed for pnpm install to resolve.`);
+push(`COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json .oxfmtrc.json ./`);
+push(``);
+push(`# Phase 1: every workspace package.json. pnpm-workspace.yaml lists every`);
+push(`# member; if any are missing at install time pnpm fails with`);
+push(`# ERR_PNPM_WORKSPACE_PKG_NOT_FOUND. src/ + migrations/ for non-transitive`);
+push(`# packages are intentionally NOT copied (PRD-252 / audit H-D1).`);
+for (const p of allWorkspacePaths) {
+  push(`COPY ${p}/package.json ./${p}/`);
+}
+push(``);
+push(`# Install pnpm + every workspace dependency.`);
+push(`RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \\`);
+push(`    corepack enable && pnpm install --frozen-lockfile`);
+push(``);
+push(`# Phase 2: sources for the transitive @pops/* deps of ${APP_PKG_NAME}`);
+push(`# (resolved via \`pnpm m ls --filter "${APP_PKG_NAME}..." --json\`).`);
+push(`# A change in a non-listed package does NOT invalidate this image's`);
+push(`# Phase 2 layer.`);
+for (const dep of sharedDeps) {
+  const sources = copySourcesFor(dep.path);
+  if (sources.length === 0) continue;
+  push(`# ${dep.name}`);
+  for (const src of sources) {
+    push(`COPY ${src} ./${src}`);
+  }
+}
+push(``);
+push(`# Pillar app sources.`);
+for (const src of copySourcesFor(APP_DIR)) {
+  push(`COPY ${src} ./${src}`);
+}
+push(``);
+push(`# Phase 3: build shared deps in pnpm topology order, then the app.`);
+push(`# \`^...\` expands to every dependency of the target excluding the target,`);
+push(`# letting pnpm compute build order from the lockfile (see #3285).`);
+push(`RUN pnpm --filter "${APP_PKG_NAME}^..." build`);
+push(`RUN pnpm --filter "${APP_PKG_NAME}" build`);
+push(``);
+push(`# Standalone deployment (production deps only, no symlinks).`);
+push(`RUN pnpm --filter ${APP_PKG_NAME} deploy --prod --legacy /app/deploy`);
+push(``);
+push(`FROM node:22-slim`);
+push(`WORKDIR /app`);
+push(
+  `RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*`
+);
+push(``);
+push(`COPY --from=builder --chown=node:node /app/deploy ./`);
+push(`COPY --from=builder --chown=node:node /app/${APP_DIR}/dist ./dist`);
+push(``);
+push(`ARG BUILD_VERSION=dev`);
+push(`ENV BUILD_VERSION=$BUILD_VERSION`);
+push(``);
+push(`EXPOSE 3001`);
+push(`USER node`);
+push(`CMD ["node", "dist/server.js"]`);
+push(``);
+
+const outputPath = resolve(REPO_ROOT, APP_DIR, 'Dockerfile');
+writeFileSync(outputPath, lines.join('\n'));
+console.log(
+  `wrote ${relative(REPO_ROOT, outputPath)} (${sharedDeps.length} transitive @pops/* deps)`
+);


### PR DESCRIPTION
## Summary

Closes audit 2026-06 finding H-D1 for `pops-core-api`: every per-pillar `-api` Dockerfile was hand-copying `src/` + `migrations/` of every other pillar's `-db` and `-contract` package, so a finance-schema change rebuilt the core-api image and unrelated source landed in the deploy.

PRD: [`docs/themes/13-pillar-finale/prds/252-per-pillar-dockerfile-isolation-hd1`](docs/themes/13-pillar-finale/prds/252-per-pillar-dockerfile-isolation-hd1/README.md).

### What lands

- **Generator** — `scripts/generate-pillar-dockerfile.mjs`. Walks the target pillar's transitive `@pops/*` graph via `pnpm m ls --filter "<pillar>..." --json` (same workspace-filter pattern as #3285) and emits a three-phase Dockerfile:
  1. COPY every workspace `package.json` (pnpm install needs the full set to resolve the lockfile).
  2. COPY `src/` + `scripts/` + `openapi/` + `migrations/` + `tsconfig*.json` **only for transitive `@pops/*` deps**.
  3. `pnpm --filter "<pillar>^..." build` for shared deps in pnpm-computed topology order, then build the app, then `pnpm deploy --legacy` for the runtime stage.
- **Regenerated** `apps/pops-core-api/Dockerfile` as the first pillar. `@pops/core-api`'s transitive graph is 10 packages: cerebrum-contract (via pillar-sdk), core-contract, core-db, finance-contract, inventory-contract, media-contract, media-db (re-exported by core-db), pillar-sdk, types, wire-conformance. `db-types`, `finance-db`, `inventory-db`, `food-db`, `cerebrum-db`, `app-lists-db`, `food-contract`, and `lists-contract` are no longer copied or built.
- **CI drift-check** — `.github/workflows/docker-build.yml` runs the generator and `git diff --exit-code apps/pops-core-api/Dockerfile`. PR fails on any hand-edit or stale regeneration.

US-02..07 (cerebrum, finance, inventory, food, lists, media) ship in separate PRs per the PRD's parallelisation table.

## Test plan

- [x] `node scripts/generate-pillar-dockerfile.mjs core` is deterministic — repeated runs leave the working tree clean.
- [x] `pnpm m ls --filter "@pops/core-api..." --json` returns 10 transitive `@pops/*` deps and the generator emits Phase 2 COPYs for all of them.
- [x] `pnpm lint`, `pnpm typecheck` clean locally.
- [x] Husky pre-commit passes (lint-staged ran oxlint + oxfmt on the staged files).
- [ ] CI `Docker Build` workflow: drift-check step is green; `Build pops-core-api (builder stage)` succeeds.
- [ ] Force a hand-edit on a follow-up PR to confirm the drift-check fails (will be exercised when US-02..07 land).
