### PR TITLE
feat(api/media): Wave 5 batch 1 — flip seasons + episodes to getMediaDrizzle

### DIFF
--- a/apps/pops-api/src/modules/media/tv-shows/episodes-service.ts
+++ b/apps/pops-api/src/modules/media/tv-shows/episodes-service.ts
@@ -1,8 +1,25 @@
+/**
+ * Episodes CRUD — routes through the media pillar handle.
+ *
+ * `episodes` is owned by `@pops/media-db` and the library ingestion path
+ * (`library/tv-show-service.ts`) already inserts `episodes` rows via
+ * `getMediaDrizzle()` inside an atomic `tv_shows` + `seasons` +
+ * `episodes` transaction. Pinning these reads/writes to `getDrizzle()`
+ * would split-brain against the ingestion writer (rows visible on
+ * `media.db` but invisible to the episode router and vice-versa).
+ * Flipping closes that window — all `episodes` traffic now lands on the
+ * same store as the library writer.
+ *
+ * FK parent (`seasons`) resolves through `getMediaDrizzle()` via
+ * `seasons-service.ts`, so the `getSeason(seasonId)` existence checks
+ * in `listEpisodes` / `createEpisode` hit the same store as the episode
+ * insert.
+ */
 import { and, asc, eq } from 'drizzle-orm';
 
 import { episodes } from '@pops/media-db';
 
-import { getDrizzle } from '../../../db.js';
+import { getMediaDrizzle } from '../../../db/media-db-handle.js';
 import { ConflictError, NotFoundError } from '../../../shared/errors.js';
 import { getSeason } from './seasons-service.js';
 
@@ -16,7 +33,7 @@ export interface EpisodeListResult {
 }
 
 export function listEpisodes(seasonId: number): EpisodeListResult {
-  const db = getDrizzle();
+  const db = getMediaDrizzle();
   getSeason(seasonId);
   const rows = db
     .select()
@@ -28,14 +45,14 @@ export function listEpisodes(seasonId: number): EpisodeListResult {
 }
 
 export function getEpisode(id: number): EpisodeRow {
-  const db = getDrizzle();
+  const db = getMediaDrizzle();
   const row = db.select().from(episodes).where(eq(episodes.id, id)).get();
   if (!row) throw new NotFoundError('Episode', String(id));
   return row;
 }
 
 export function createEpisode(input: CreateEpisodeInput): EpisodeRow {
-  const db = getDrizzle();
+  const db = getMediaDrizzle();
   getSeason(input.seasonId);
 
   const existing = db
@@ -79,6 +96,6 @@ export function createEpisode(input: CreateEpisodeInput): EpisodeRow {
 
 export function deleteEpisode(id: number): void {
   getEpisode(id);
-  const db = getDrizzle();
+  const db = getMediaDrizzle();
   db.delete(episodes).where(eq(episodes.id, id)).run();
 }

--- a/apps/pops-api/src/modules/media/tv-shows/seasons-service.ts
+++ b/apps/pops-api/src/modules/media/tv-shows/seasons-service.ts
@@ -1,8 +1,25 @@
+/**
+ * Seasons CRUD — routes through the media pillar handle.
+ *
+ * `seasons` is owned by `@pops/media-db` and the library ingestion path
+ * (`library/tv-show-service.ts`) already writes `seasons` rows via
+ * `getMediaDrizzle()` inside an atomic `tv_shows` + `seasons` + `episodes`
+ * transaction. Pinning these reads/writes to `getDrizzle()` would
+ * split-brain against the ingestion writer (rows visible on `media.db`
+ * but invisible to the season router and vice-versa). Flipping closes
+ * that window — all `seasons` traffic now lands on the same store as
+ * the library writer.
+ *
+ * FK parent (`tv_shows`) already resolves through `getMediaDrizzle()`
+ * via `tv-shows-base.ts`, so the `getTvShow(tvShowId)` existence checks
+ * in `listSeasons` / `createSeason` hit the same store as the season
+ * insert.
+ */
 import { and, asc, eq } from 'drizzle-orm';
 
 import { seasons } from '@pops/media-db';
 
-import { getDrizzle } from '../../../db.js';
+import { getMediaDrizzle } from '../../../db/media-db-handle.js';
 import { ConflictError, NotFoundError } from '../../../shared/errors.js';
 import { getTvShow } from './tv-shows-base.js';
 
@@ -16,7 +33,7 @@ export interface SeasonListResult {
 }
 
 export function listSeasons(tvShowId: number): SeasonListResult {
-  const db = getDrizzle();
+  const db = getMediaDrizzle();
   getTvShow(tvShowId);
   const rows = db
     .select()
@@ -28,14 +45,14 @@ export function listSeasons(tvShowId: number): SeasonListResult {
 }
 
 export function getSeason(id: number): SeasonRow {
-  const db = getDrizzle();
+  const db = getMediaDrizzle();
   const row = db.select().from(seasons).where(eq(seasons.id, id)).get();
   if (!row) throw new NotFoundError('Season', String(id));
   return row;
 }
 
 export function createSeason(input: CreateSeasonInput): SeasonRow {
-  const db = getDrizzle();
+  const db = getMediaDrizzle();
   getTvShow(input.tvShowId);
 
   const existing = db
@@ -76,6 +93,6 @@ export function createSeason(input: CreateSeasonInput): SeasonRow {
 
 export function deleteSeason(id: number): void {
   getSeason(id);
-  const db = getDrizzle();
+  const db = getMediaDrizzle();
   db.delete(seasons).where(eq(seasons.id, id)).run();
 }

--- a/apps/pops-api/src/modules/media/tv-shows/tv-shows-base.ts
+++ b/apps/pops-api/src/modules/media/tv-shows/tv-shows-base.ts
@@ -2,43 +2,23 @@
  * TV shows wrapper — resolves the media-pillar drizzle handle and forwards
  * to `@pops/media-db`'s `tvShowsService` (PRD-166 cutover).
  *
- * Mirrors the movies PR 3 pattern: in-tree callers (router.ts,
- * library/tv-show-service.ts, plex sync helpers, watchlist push,
- * thetvdb service + refresh-episodes, …) keep importing from
- * `./tv-shows/service.js` unchanged. The handle now points at the media
- * pillar's per-pillar SQLite via `getMediaDrizzle()` instead of the
- * shared `pops.db` singleton, so every tv-shows write through this
- * wrapper lands in `media.db.tv_shows`.
- *
- * Cross-store consistency during the migration window:
- *  - `backfillMediaFromShared()` runs at boot and is one-way only
- *    (pops.db → media.db, idempotent via NOT IN id filter). It does NOT
- *    keep the two stores in sync at runtime; it only catches media.db
- *    up to pops.db on each restart.
- *  - In-tree code paths that still write tv_shows to the shared
- *    `pops.db` (notably `library/tv-show-service.ts` for plex/library
- *    ingestion, and `seasons-service.ts` / `episodes-service.ts` whose
- *    FK parents live on the legacy mount) remain the source of truth
- *    for `seasons.tv_show_id` and `episodes.season_id` joins. Until
- *    those slices ship to `@pops/media-db`, the seasons/episodes
- *    services intentionally read+write the shared DB so their FK joins
- *    resolve in one store, and the boot-time backfill carries rows
- *    written there into media.db on the next deploy.
- *  - This means a tv_show created via `createTvShow` (media.db only)
- *    will not satisfy an FK insert in `createSeason` (pops.db) until
- *    the seasons/episodes cutover ships. Callers that need both must
- *    keep going through the library ingestion path which writes to the
- *    shared DB; this wrapper is currently used by reads + the
- *    metadata-refresh writes that don't need new season FKs.
+ * In-tree callers (router.ts, library/tv-show-service.ts, plex sync
+ * helpers, watchlist push, thetvdb service + refresh-episodes, …) keep
+ * importing from `./tv-shows/service.js` unchanged. The handle points
+ * at the media pillar's per-pillar SQLite via `getMediaDrizzle()`
+ * instead of the shared `pops.db` singleton, so every tv-shows write
+ * through this wrapper lands in `media.db.tv_shows`. As of the Wave 5
+ * media batch 1 cutover, `seasons-service.ts` and `episodes-service.ts`
+ * do the same — every tv-shows / seasons / episodes read+write
+ * resolves through the media pillar handle, so the FK joins
+ * `seasons.tv_show_id` → `tv_shows.id` and `episodes.season_id` →
+ * `seasons.id` resolve inside one store with no cross-handle
+ * split-brain.
  *
  * Error translation: the package surface throws `TvShowNotFoundError` /
  * `TvShowConflictError`. We re-throw them as the in-tree `NotFoundError`
  * / `ConflictError` so the router's `instanceof` checks (and library /
  * plex callers that catch the same shapes) keep working without churn.
- *
- * Out of scope (per PRD-166): `seasons-service.ts` and
- * `episodes-service.ts` still route through `getDrizzle()`; they migrate
- * once their slices land in `@pops/media-db`.
  */
 import {
   tvShowsService,


### PR DESCRIPTION
## Summary

- Wave 5 long-tail handler burn-down for the **media** pillar, batch 1 (tv-shows submodule slice).
- Flips `seasons-service.ts` and `episodes-service.ts` from `getDrizzle()` to `getMediaDrizzle()` (4 + 4 sites).
- Updates the stale JSDoc in `tv-shows-base.ts` that still claimed seasons/episodes were intentionally pinned to the legacy mount.

## Why this slice is safe

`seasons` and `episodes` have been owned by `@pops/media-db` since PRD-166 PR4, and the library ingestion path (`library/tv-show-service.ts`) already inserts both tables via `getMediaDrizzle()` inside an atomic `tv_shows` + `seasons` + `episodes` transaction.

Keeping per-table CRUD on `getDrizzle()` while the writer was on `getMediaDrizzle()` was a split-brain bug: rows inserted via the library path landed in `media.db`, but `listSeasons` / `getSeason` / `createSeason` / `deleteSeason` (and parallel episodes equivalents) read from the shared `pops.db`, which only sees backfill snapshots at boot.

After this PR every tv-shows / seasons / episodes read+write resolves through the media pillar handle. FK joins `seasons.tv_show_id` -> `tv_shows.id` and `episodes.season_id` -> `seasons.id` resolve inside `media.db` with no cross-handle dependency.

Each migrated service carries a top-of-file JSDoc explaining the split-brain risk closed and why the FK joins remain safe.

## Numbers (apps/pops-api/src/modules/media, production-side `getDrizzle()` sites)

- **Before:** 43
- **After:** 35 (-8)

## Scope

- `apps/pops-api/src/modules/media/tv-shows/seasons-service.ts`
- `apps/pops-api/src/modules/media/tv-shows/episodes-service.ts`
- `apps/pops-api/src/modules/media/tv-shows/tv-shows-base.ts` (JSDoc only)

3 files changed, 56 insertions, 42 deletions.

## Test plan

- [x] `pnpm --filter @pops/api typecheck` clean
- [x] `pnpm --filter @pops/api test` — 312 files / 4899 tests pass
- [x] `pnpm --filter @pops/api build` clean
- [x] `pnpm typecheck` (all packages) clean
- [x] `pnpm lint` clean (no errors)
- [x] Husky pre-commit + pre-push pass without `--no-verify`
- [ ] CI green