### PR TITLE
feat(food-db): PR4 ingredients — move ingredients+variants+aliases+tags + slug partition + ATTACH backfill + flip 14 handler sites (Wave 5)

### DIFF
--- a/apps/pops-api/src/db/backfill-food-from-shared.test.ts
+++ b/apps/pops-api/src/db/backfill-food-from-shared.test.ts
@@ -1,11 +1,14 @@
 /**
- * Boot-time backfill tests for `backfillFoodFromShared`.
+ * Boot-time backfill tests for `backfillFoodFromShared` — Theme-13 Wave-5
+ * PR4 conversions + ingredients slices.
  *
  * Exercises the ATTACH-based copy from the shared `pops.db` to the
  * food pillar's `food.db` against on-disk SQLite files (in-memory DBs
- * can't be ATTACHed). The Theme-13 Wave-5 conversions PR4 carries
- * `unit_conversions` and `ingredient_weights` across; the existing
- * prep_states slice already lives in food.db so it is not in scope here.
+ * can't be ATTACHed). The conversions slice carries `unit_conversions`
+ * and `ingredient_weights`; the ingredients slice carries `ingredients`,
+ * `ingredient_variants`, `ingredient_aliases`, `ingredient_tags`, and
+ * the food-owned (`kind IN ('ingredient','prep_state')`) rows of
+ * `slug_registry`.
  *
  * Confirms:
  *   - first run carries existing rows across,
@@ -13,7 +16,12 @@
  *   - mixed state (some rows already in food.db) only inserts the missing ones,
  *   - the null-variant `ingredient_weights` row deduplicates correctly under
  *     SQLite's NULL-distinct join semantics (handled via `IS` not `=`),
- *   - missing source tables are tolerated without throwing.
+ *   - `slug_registry` copy is kind-scoped — `kind='recipe'` rows stay on the
+ *     shared DB (those still belong on pops.db until the recipes writer flips),
+ *     `kind='prep_state'` rows are tolerated (they may already be on food.db
+ *     from the earlier PR4 round),
+ *   - missing source tables are tolerated without throwing,
+ *   - the FK cascade from `ingredient_tags` is preserved post-copy.
  */
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -66,11 +74,85 @@ CREATE UNIQUE INDEX uq_ingredient_weights_any_variant
   ON ingredient_weights (ingredient_id, unit) WHERE variant_id IS NULL;
 `;
 
+const INGREDIENTS_SQL = `
+CREATE TABLE ingredients (
+  id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  parent_id integer,
+  name text NOT NULL,
+  slug text NOT NULL,
+  default_unit text NOT NULL,
+  density_g_per_ml real,
+  notes text,
+  created_at text DEFAULT (datetime('now')) NOT NULL,
+  FOREIGN KEY (parent_id) REFERENCES ingredients(id)
+);
+CREATE UNIQUE INDEX ingredients_slug_unique ON ingredients (slug);
+`;
+
+const INGREDIENT_VARIANTS_SQL = `
+CREATE TABLE ingredient_variants (
+  id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  ingredient_id integer NOT NULL,
+  name text NOT NULL,
+  slug text NOT NULL,
+  default_unit text NOT NULL,
+  package_size_g real,
+  notes text,
+  default_shelf_life_days_fridge integer,
+  default_shelf_life_days_freezer integer,
+  created_at text DEFAULT (datetime('now')) NOT NULL,
+  FOREIGN KEY (ingredient_id) REFERENCES ingredients(id)
+);
+CREATE UNIQUE INDEX uq_variants_ingredient_slug ON ingredient_variants (ingredient_id, slug);
+`;
+
+const INGREDIENT_ALIASES_SQL = `
+CREATE TABLE ingredient_aliases (
+  id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  ingredient_id integer,
+  variant_id integer,
+  alias text NOT NULL,
+  source text NOT NULL,
+  created_at text DEFAULT (datetime('now')) NOT NULL,
+  FOREIGN KEY (ingredient_id) REFERENCES ingredients(id),
+  FOREIGN KEY (variant_id) REFERENCES ingredient_variants(id)
+);
+CREATE UNIQUE INDEX uq_aliases_alias_ingredient
+  ON ingredient_aliases (alias, ingredient_id) WHERE variant_id IS NULL;
+CREATE UNIQUE INDEX uq_aliases_alias_variant
+  ON ingredient_aliases (alias, variant_id) WHERE ingredient_id IS NULL;
+`;
+
+const INGREDIENT_TAGS_SQL = `
+CREATE TABLE ingredient_tags (
+  ingredient_id integer NOT NULL,
+  tag text NOT NULL,
+  created_at text DEFAULT (datetime('now')) NOT NULL,
+  PRIMARY KEY(ingredient_id, tag),
+  FOREIGN KEY (ingredient_id) REFERENCES ingredients(id) ON DELETE cascade
+);
+`;
+
+const SLUG_REGISTRY_SQL = `
+CREATE TABLE slug_registry (
+  slug text PRIMARY KEY NOT NULL,
+  kind text NOT NULL,
+  target_id integer NOT NULL,
+  created_at text DEFAULT (datetime('now')) NOT NULL
+);
+CREATE INDEX idx_slug_registry_kind_target ON slug_registry (kind, target_id);
+`;
+
 function openSharedWithSeed(seed: (raw: BetterSqlite3.Database) => void): string {
   const path = join(tmpDir, 'pops.db');
   const raw = new BetterSqlite3(path);
   raw.exec(UNIT_CONVERSIONS_SQL);
   raw.exec(INGREDIENT_WEIGHTS_SQL);
+  raw.exec(INGREDIENTS_SQL);
+  raw.exec(INGREDIENT_VARIANTS_SQL);
+  raw.exec(INGREDIENT_ALIASES_SQL);
+  raw.exec(INGREDIENT_TAGS_SQL);
+  raw.exec(SLUG_REGISTRY_SQL);
   seed(raw);
   raw.close();
   return path;
@@ -107,7 +189,35 @@ function insertIngredientWeight(
     .run(ingredientId, variantId, unit, grams);
 }
 
-describe('backfillFoodFromShared', () => {
+function insertIngredient(
+  raw: BetterSqlite3.Database,
+  id: number,
+  slug: string,
+  name: string
+): void {
+  raw
+    .prepare(
+      `INSERT INTO ingredients (id, name, slug, default_unit, created_at)
+       VALUES (?, ?, ?, 'count', '2026-06-13T00:00:00Z')`
+    )
+    .run(id, name, slug);
+}
+
+function insertSlug(
+  raw: BetterSqlite3.Database,
+  slug: string,
+  kind: string,
+  targetId: number
+): void {
+  raw
+    .prepare(
+      `INSERT INTO slug_registry (slug, kind, target_id, created_at)
+       VALUES (?, ?, ?, '2026-06-13T00:00:00Z')`
+    )
+    .run(slug, kind, targetId);
+}
+
+describe('backfillFoodFromShared — conversions slice', () => {
   it('copies unit_conversions rows from the shared DB on first run', () => {
     const sharedPath = openSharedWithSeed((raw) => {
       insertUnitConversion(raw, 'cup', 'ml', 240);
@@ -286,6 +396,245 @@ describe('backfillFoodFromShared', () => {
     const food = openFoodDb(join(tmpDir, 'food.db'));
     try {
       expect(() => backfillFoodFromShared(food, sharedPath)).not.toThrow();
+    } finally {
+      food.raw.close();
+    }
+  });
+});
+
+describe('backfillFoodFromShared — ingredients slice', () => {
+  it('copies ingredients rows from the shared DB on first run', () => {
+    const sharedPath = openSharedWithSeed((raw) => {
+      insertIngredient(raw, 1, 'banana', 'Banana');
+      insertIngredient(raw, 2, 'apple', 'Apple');
+    });
+
+    const food = openFoodDb(join(tmpDir, 'food.db'));
+    try {
+      backfillFoodFromShared(food, sharedPath);
+      const rows = food.raw.prepare('SELECT id, slug, name FROM ingredients ORDER BY id').all() as {
+        id: number;
+        slug: string;
+        name: string;
+      }[];
+      expect(rows).toEqual([
+        { id: 1, slug: 'banana', name: 'Banana' },
+        { id: 2, slug: 'apple', name: 'Apple' },
+      ]);
+    } finally {
+      food.raw.close();
+    }
+  });
+
+  it('is idempotent — a second run does not duplicate ingredients rows', () => {
+    const sharedPath = openSharedWithSeed((raw) => insertIngredient(raw, 1, 'banana', 'Banana'));
+
+    const food = openFoodDb(join(tmpDir, 'food.db'));
+    try {
+      backfillFoodFromShared(food, sharedPath);
+      backfillFoodFromShared(food, sharedPath);
+      const { n } = food.raw.prepare('SELECT count(*) AS n FROM ingredients').get() as {
+        n: number;
+      };
+      expect(n).toBe(1);
+    } finally {
+      food.raw.close();
+    }
+  });
+
+  it('only inserts ingredients rows missing from the food copy (mixed state)', () => {
+    const sharedPath = openSharedWithSeed((raw) => {
+      insertIngredient(raw, 1, 'banana', 'Banana');
+      insertIngredient(raw, 2, 'apple', 'Apple');
+    });
+
+    const food = openFoodDb(join(tmpDir, 'food.db'));
+    try {
+      food.raw
+        .prepare(
+          `INSERT INTO ingredients (id, name, slug, default_unit, created_at)
+           VALUES (2, 'Apple (local)', 'apple', 'count', '2026-06-14T00:00:00Z')`
+        )
+        .run();
+      backfillFoodFromShared(food, sharedPath);
+
+      const rows = food.raw.prepare('SELECT id, name FROM ingredients ORDER BY id').all() as {
+        id: number;
+        name: string;
+      }[];
+      expect(rows).toEqual([
+        { id: 1, name: 'Banana' },
+        { id: 2, name: 'Apple (local)' },
+      ]);
+    } finally {
+      food.raw.close();
+    }
+  });
+
+  it('copies variants + aliases + tags following the ingredients copy', () => {
+    const sharedPath = openSharedWithSeed((raw) => {
+      insertIngredient(raw, 1, 'banana', 'Banana');
+      raw
+        .prepare(
+          `INSERT INTO ingredient_variants
+            (id, ingredient_id, name, slug, default_unit, package_size_g,
+             default_shelf_life_days_fridge, default_shelf_life_days_freezer, created_at)
+           VALUES (10, 1, 'Cavendish', 'cavendish', 'count', 120, 7, 90,
+                   '2026-06-13T00:00:00Z')`
+        )
+        .run();
+      raw
+        .prepare(
+          `INSERT INTO ingredient_aliases
+            (id, ingredient_id, variant_id, alias, source, created_at)
+           VALUES (100, 1, NULL, 'nana', 'user', '2026-06-13T00:00:00Z')`
+        )
+        .run();
+      raw
+        .prepare(
+          `INSERT INTO ingredient_tags (ingredient_id, tag, created_at)
+           VALUES (1, 'store-section:produce', '2026-06-13T00:00:00Z')`
+        )
+        .run();
+    });
+
+    const food = openFoodDb(join(tmpDir, 'food.db'));
+    try {
+      backfillFoodFromShared(food, sharedPath);
+
+      const variants = food.raw
+        .prepare(
+          'SELECT id, ingredient_id, slug, default_shelf_life_days_fridge FROM ingredient_variants'
+        )
+        .all() as {
+        id: number;
+        ingredient_id: number;
+        slug: string;
+        default_shelf_life_days_fridge: number | null;
+      }[];
+      expect(variants).toEqual([
+        { id: 10, ingredient_id: 1, slug: 'cavendish', default_shelf_life_days_fridge: 7 },
+      ]);
+
+      const aliases = food.raw
+        .prepare('SELECT id, alias, source FROM ingredient_aliases')
+        .all() as { id: number; alias: string; source: string }[];
+      expect(aliases).toEqual([{ id: 100, alias: 'nana', source: 'user' }]);
+
+      const tags = food.raw.prepare('SELECT ingredient_id, tag FROM ingredient_tags').all() as {
+        ingredient_id: number;
+        tag: string;
+      }[];
+      expect(tags).toEqual([{ ingredient_id: 1, tag: 'store-section:produce' }]);
+    } finally {
+      food.raw.close();
+    }
+  });
+
+  it('only copies kind=ingredient and kind=prep_state rows from slug_registry — kind=recipe stays on pops.db', () => {
+    const sharedPath = openSharedWithSeed((raw) => {
+      insertIngredient(raw, 1, 'banana', 'Banana');
+      insertSlug(raw, 'banana', 'ingredient', 1);
+      insertSlug(raw, 'banana-bread', 'recipe', 99);
+      insertSlug(raw, 'diced', 'prep_state', 7);
+    });
+
+    const food = openFoodDb(join(tmpDir, 'food.db'));
+    try {
+      backfillFoodFromShared(food, sharedPath);
+      const rows = food.raw
+        .prepare('SELECT slug, kind, target_id FROM slug_registry ORDER BY slug')
+        .all() as { slug: string; kind: string; target_id: number }[];
+      expect(rows).toEqual([
+        { slug: 'banana', kind: 'ingredient', target_id: 1 },
+        { slug: 'diced', kind: 'prep_state', target_id: 7 },
+      ]);
+    } finally {
+      food.raw.close();
+    }
+  });
+
+  it('slug_registry backfill is idempotent', () => {
+    const sharedPath = openSharedWithSeed((raw) => {
+      insertIngredient(raw, 1, 'banana', 'Banana');
+      insertSlug(raw, 'banana', 'ingredient', 1);
+    });
+
+    const food = openFoodDb(join(tmpDir, 'food.db'));
+    try {
+      backfillFoodFromShared(food, sharedPath);
+      backfillFoodFromShared(food, sharedPath);
+      const { n } = food.raw.prepare('SELECT count(*) AS n FROM slug_registry').get() as {
+        n: number;
+      };
+      expect(n).toBe(1);
+    } finally {
+      food.raw.close();
+    }
+  });
+
+  it('slug_registry copy does not clobber an existing food-side row for the same slug', () => {
+    const sharedPath = openSharedWithSeed((raw) => {
+      insertIngredient(raw, 1, 'banana', 'Banana');
+      insertSlug(raw, 'banana', 'ingredient', 1);
+    });
+
+    const food = openFoodDb(join(tmpDir, 'food.db'));
+    try {
+      food.raw
+        .prepare(
+          `INSERT INTO slug_registry (slug, kind, target_id, created_at)
+           VALUES ('banana', 'ingredient', 999, '2026-06-14T00:00:00Z')`
+        )
+        .run();
+      backfillFoodFromShared(food, sharedPath);
+      const rows = food.raw.prepare('SELECT slug, target_id FROM slug_registry').all() as {
+        slug: string;
+        target_id: number;
+      }[];
+      expect(rows).toEqual([{ slug: 'banana', target_id: 999 }]);
+    } finally {
+      food.raw.close();
+    }
+  });
+
+  it('preserves the ingredient_tags ON DELETE CASCADE after the copy', () => {
+    const sharedPath = openSharedWithSeed((raw) => {
+      insertIngredient(raw, 1, 'banana', 'Banana');
+      raw
+        .prepare(
+          `INSERT INTO ingredient_tags (ingredient_id, tag, created_at)
+           VALUES (1, 'vegan', '2026-06-13T00:00:00Z')`
+        )
+        .run();
+    });
+
+    const food = openFoodDb(join(tmpDir, 'food.db'));
+    try {
+      backfillFoodFromShared(food, sharedPath);
+      food.raw.prepare('DELETE FROM ingredients WHERE id = 1').run();
+      const { n } = food.raw.prepare('SELECT count(*) AS n FROM ingredient_tags').get() as {
+        n: number;
+      };
+      expect(n).toBe(0);
+    } finally {
+      food.raw.close();
+    }
+  });
+
+  it('tolerates a shared DB with no ingredient tables (post-PR4-drop scenario)', () => {
+    const sharedPath = join(tmpDir, 'pops.db');
+    const raw = new BetterSqlite3(sharedPath);
+    raw.exec(`CREATE TABLE other_table (id integer PRIMARY KEY)`);
+    raw.close();
+
+    const food = openFoodDb(join(tmpDir, 'food.db'));
+    try {
+      expect(() => backfillFoodFromShared(food, sharedPath)).not.toThrow();
+      const { n } = food.raw.prepare('SELECT count(*) AS n FROM ingredients').get() as {
+        n: number;
+      };
+      expect(n).toBe(0);
     } finally {
       food.raw.close();
     }

--- a/apps/pops-api/src/db/backfill-food-from-shared.ts
+++ b/apps/pops-api/src/db/backfill-food-from-shared.ts
@@ -1,15 +1,31 @@
 /**
  * Boot-time backfill from the legacy shared `pops.db` into the food
- * pillar's `food.db` for the Theme-13 Wave-5 PR4 conversions slice:
- * `unit_conversions` and `ingredient_weights`.
+ * pillar's `food.db` for the Theme-13 Wave-5 PR4 slices:
  *
- * Phase context: the earlier food slice (prep_states + the
- * `kind='prep_state'` rows of slug_registry) finished its PR4 writer
- * cutover in earlier rounds, so the original food backfill bridge was
- * retired. This module brings the bridge back for the new tables landing
- * in `0059_food_conversions.sql`. Each TABLE_COPIES entry retires after
- * its writer cutover is verified in prod and the shared `pops.db` stops
- * receiving new rows.
+ *   - conversions slice: `unit_conversions`, `ingredient_weights`
+ *     (landed in `0059_food_conversions.sql`).
+ *   - ingredients slice: `ingredients`, `ingredient_variants`,
+ *     `ingredient_aliases`, `ingredient_tags`, and the food-owned
+ *     `kind IN ('ingredient','prep_state')` rows of `slug_registry`
+ *     (landed in `0060_food_ingredient_tags.sql`).
+ *
+ * Phase context: the earlier prep_states slice finished its PR4 writer
+ * cutover so the original food backfill bridge was retired. This module
+ * brings the bridge back for the conversions + ingredients clusters —
+ * the writer flips land in the same PRs, and the boot bridge carries
+ * any rows still on the shared pops.db across so reads through
+ * `getFoodDrizzle()` see the full vocabulary on first deploy. Each
+ * TABLE_COPIES entry retires after its writer cutover is verified in
+ * prod and the shared `pops.db` stops receiving new rows.
+ *
+ * The slug_registry copy is split-aware: only `kind='ingredient'` and
+ * `kind='prep_state'` rows land on food.db. `kind='recipe'` rows still
+ * belong on the legacy shared pops.db (recipes router has not cut over
+ * yet); `kind='prep_state'` rows are already on food.db from the earlier
+ * PR4 round, so a `WHERE kind = 'prep_state'` copy is a no-op in steady
+ * state but is included here for completeness and to keep the bridge
+ * idempotent even when a stale pops.db still holds prep_state rows from
+ * before its own retirement.
  *
  * Subsequent boots find the food copy already populated and become a
  * no-op via the `WHERE NOT EXISTS (...)` existence filter.
@@ -40,7 +56,16 @@ interface TableCopy {
    * entries express a composite business-key tuple.
    */
   readonly idColumns: readonly [string, ...string[]];
+  /**
+   * Optional WHERE filter applied to the source rows. Used by the
+   * `slug_registry` entry to scope the copy to the food-owned kinds
+   * (`ingredient`, `prep_state`) — `kind='recipe'` rows still belong on
+   * the legacy pops.db until the recipes writer cuts over.
+   */
+  readonly sourceFilter?: string;
 }
+
+const FOOD_OWNED_SLUG_KINDS = ['ingredient', 'prep_state'];
 
 const TABLE_COPIES: readonly TableCopy[] = [
   {
@@ -76,6 +101,83 @@ const TABLE_COPIES: readonly TableCopy[] = [
     idColumns: ['ingredient_id', 'variant_id', 'unit'],
     columns: ['ingredient_id', 'variant_id', 'unit', 'grams', 'notes', 'is_seeded', 'created_at'],
   },
+  {
+    /**
+     * `id` is preserved so the dependent `ingredient_variants`,
+     * `ingredient_aliases`, `ingredient_tags`, and slug_registry rows
+     * carry the same FK target across without remapping. The food.db is
+     * freshly empty at first backfill; the SQLite autoincrement sequence
+     * picks up from `MAX(id)+1` after the copy. Dedupe on `id` keeps
+     * subsequent boots idempotent.
+     */
+    table: 'ingredients',
+    idColumns: ['id'],
+    columns: [
+      'id',
+      'parent_id',
+      'name',
+      'slug',
+      'default_unit',
+      'density_g_per_ml',
+      'notes',
+      'created_at',
+    ],
+  },
+  {
+    table: 'ingredient_variants',
+    idColumns: ['id'],
+    columns: [
+      'id',
+      'ingredient_id',
+      'name',
+      'slug',
+      'default_unit',
+      'package_size_g',
+      'notes',
+      'default_shelf_life_days_fridge',
+      'default_shelf_life_days_freezer',
+      'created_at',
+    ],
+  },
+  {
+    /**
+     * `ingredient_aliases` rows reference either an ingredient or a
+     * variant (XOR enforced by `ck_aliases_xor_target`). Dedupe on `id`
+     * — the partial UNIQUEs on `(alias, ingredient_id)` /
+     * `(alias, variant_id)` keep business-key uniqueness intact across
+     * the join even though we don't match on it here.
+     */
+    table: 'ingredient_aliases',
+    idColumns: ['id'],
+    columns: ['id', 'ingredient_id', 'variant_id', 'alias', 'source', 'created_at'],
+  },
+  {
+    /**
+     * `ingredient_tags` is a composite-PK junction table — no surrogate
+     * `id`. Dedupe on the natural key `(ingredient_id, tag)`.
+     */
+    table: 'ingredient_tags',
+    idColumns: ['ingredient_id', 'tag'],
+    columns: ['ingredient_id', 'tag', 'created_at'],
+  },
+  {
+    /**
+     * `slug_registry` is partitioned across pillars by `kind`:
+     *   - `kind='ingredient'` rows now belong on food.db (this PR cutover)
+     *   - `kind='prep_state'` rows already belong on food.db (earlier PR4)
+     *   - `kind='recipe'` rows still belong on the legacy pops.db.
+     * Scope the copy to the food-owned kinds so the bridge never drags
+     * recipe rows over and creates a phantom duplicate when the recipes
+     * writer eventually cuts over.
+     *
+     * Dedupe on `slug` (the PK on both sides) — natural identity, no
+     * surrogate to collide on.
+     */
+    table: 'slug_registry',
+    idColumns: ['slug'],
+    columns: ['slug', 'kind', 'target_id', 'created_at'],
+    sourceFilter: `kind IN ('${FOOD_OWNED_SLUG_KINDS.join("','")}')`,
+  },
 ];
 
 function buildKeyMatch(table: string, idColumns: readonly string[]): string {
@@ -90,11 +192,13 @@ function tryCopyTable(raw: Database.Database, copy: TableCopy): void {
     if (!hasTable) return;
     const cols = copy.columns.join(', ');
     const keyMatch = buildKeyMatch(copy.table, copy.idColumns);
+    const sourceWhere = copy.sourceFilter !== undefined ? `WHERE ${copy.sourceFilter}` : '';
     raw.exec(`
       INSERT INTO ${copy.table} (${cols})
       SELECT ${cols}
       FROM pops.${copy.table}
-      WHERE NOT EXISTS (
+      ${sourceWhere}
+      ${copy.sourceFilter !== undefined ? 'AND' : 'WHERE'} NOT EXISTS (
         SELECT 1 FROM ${copy.table} AS target WHERE ${keyMatch}
       )
     `);

--- a/apps/pops-api/src/db/food-handle.ts
+++ b/apps/pops-api/src/db/food-handle.ts
@@ -5,9 +5,12 @@
  * migrations journal) at boot. PR 3 routed the prep_states slice
  * reads/writes through `getFoodDrizzle()` and ran a one-shot
  * ATTACH-based backfill from the legacy shared pops.db. Theme-13 Wave-5
- * reintroduces the backfill for the conversions slice landing in
- * `0059_food_conversions.sql` — `unit_conversions` and
- * `ingredient_weights` — ahead of the conversions writer cutover.
+ * reintroduces the backfill for two PR4 slices: the conversions slice
+ * (`unit_conversions`, `ingredient_weights`, landed in
+ * `0059_food_conversions.sql`) and the ingredients slice landing in this
+ * PR (`ingredients`, `ingredient_variants`, `ingredient_aliases`,
+ * `ingredient_tags`, and the food-owned rows of `slug_registry`) — each
+ * ahead of (and atomic with) the matching writer cutover.
  *
  * Lives in its own module so `db.ts` stays under the lint cap as more
  * pillars come online. Mirrors `core-handle.ts` / `inventory-handle.ts` /
@@ -88,11 +91,13 @@ export function setFoodDb(next: OpenedFoodDb | null): OpenedFoodDb | null {
 
 /**
  * Run the one-shot ATTACH backfill from the legacy shared pops.db into
- * the food pillar's food.db for the Theme-13 Wave-5 conversions slice
- * (`unit_conversions`, `ingredient_weights`). No-op if the food handle
- * isn't open. Idempotent against repeated boots via per-table
- * `WHERE NOT EXISTS (...)` filters. See `backfill-food-from-shared.ts`
- * for the table-by-table behaviour.
+ * the food pillar's food.db for the Theme-13 Wave-5 PR4 slices —
+ * the conversions slice (`unit_conversions`, `ingredient_weights`) and
+ * the ingredients slice (`ingredients`, `ingredient_variants`,
+ * `ingredient_aliases`, `ingredient_tags`, and the food-owned rows of
+ * `slug_registry`). No-op if the food handle isn't open. Idempotent
+ * against repeated boots via per-table `WHERE NOT EXISTS (...)` filters.
+ * See `backfill-food-from-shared.ts` for the table-by-table behaviour.
  */
 export function backfillFoodFromSharedDb(sharedPath: string): void {
   if (!foodDb) return;

--- a/apps/pops-api/src/index.ts
+++ b/apps/pops-api/src/index.ts
@@ -122,11 +122,14 @@ try {
 // Eagerly open the food pillar's SQLite + apply its journal at boot.
 // The earlier prep_states slice finished its PR4 writer cutover so the
 // original ATTACH bridge was retired. Theme-13 Wave-5 reintroduces the
-// bridge for the conversions slice landing in
-// `0059_food_conversions.sql` — `unit_conversions` + `ingredient_weights`.
-// The backfill is idempotent (per-table `WHERE NOT EXISTS (...)` filters
-// keyed on natural business keys) and non-fatal (partial failure logs +
-// continues).
+// bridge for two PR4 slices: the conversions slice
+// (`unit_conversions` + `ingredient_weights`, landed in
+// `0059_food_conversions.sql`) and the ingredients slice (this PR —
+// `ingredients`, `ingredient_variants`, `ingredient_aliases`,
+// `ingredient_tags`, and the food-owned rows of `slug_registry`). The
+// backfill is idempotent (per-table `WHERE NOT EXISTS (...)` filters
+// keyed on natural business keys or surrogate ids) and non-fatal
+// (partial failure logs + continues).
 try {
   getFoodDrizzle();
   backfillFoodFromSharedDb(resolveSqlitePath());

--- a/apps/pops-api/src/modules/food/__tests__/data-routers.test.ts
+++ b/apps/pops-api/src/modules/food/__tests__/data-routers.test.ts
@@ -621,4 +621,24 @@ describe('food.slugs.search', () => {
       name: 'Banana',
     });
   });
+
+  it('finds prep_states by substring with display name (food.db partition)', async () => {
+    await caller.food.prepStates.create({ slug: 'diced', name: 'Diced' });
+    const result = await caller.food.slugs.search({ query: 'dic', kinds: ['prep_state'] });
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]).toMatchObject({ slug: 'diced', kind: 'prep_state', name: 'Diced' });
+  });
+
+  it('merges ingredient + prep_state results across the food.db partition with a single query', async () => {
+    await caller.food.ingredients.create({ slug: 'date', name: 'Date', defaultUnit: 'count' });
+    await caller.food.prepStates.create({ slug: 'date-stuffed', name: 'Date-stuffed' });
+    const result = await caller.food.slugs.search({ query: 'date' });
+    const kinds = result.items.map((row) => row.kind).toSorted();
+    expect(kinds).toEqual(['ingredient', 'prep_state']);
+  });
+
+  it('honours `kinds: ["recipe"]` — recipes still resolve through the legacy pops.db partition', async () => {
+    const result = await caller.food.slugs.search({ query: 'whatever', kinds: ['recipe'] });
+    expect(Array.isArray(result.items)).toBe(true);
+  });
 });

--- a/apps/pops-api/src/modules/food/routers/ingredient-tags.ts
+++ b/apps/pops-api/src/modules/food/routers/ingredient-tags.ts
@@ -17,7 +17,7 @@ import { z } from 'zod';
 
 import { ingredientTagsService } from '@pops/app-food-db';
 
-import { getDrizzle } from '../../../db.js';
+import { getFoodDrizzle } from '../../../db/food-handle.js';
 import { protectedProcedure, router } from '../../../trpc.js';
 
 const TagOpOutput = z.union([
@@ -32,7 +32,7 @@ export const ingredientTagsRouter = router({
   list: protectedProcedure
     .input(z.object({ ingredientId: z.number().int().positive() }))
     .query(({ input }) =>
-      ingredientTagsService.listTagsForIngredient(getDrizzle(), input.ingredientId)
+      ingredientTagsService.listTagsForIngredient(getFoodDrizzle(), input.ingredientId)
     ),
 
   set: protectedProcedure
@@ -44,7 +44,7 @@ export const ingredientTagsRouter = router({
     )
     .output(TagOpOutput)
     .mutation(({ input }) =>
-      ingredientTagsService.setTagsForIngredient(getDrizzle(), input.ingredientId, input.tags)
+      ingredientTagsService.setTagsForIngredient(getFoodDrizzle(), input.ingredientId, input.tags)
     ),
 
   distinct: protectedProcedure
@@ -55,7 +55,7 @@ export const ingredientTagsRouter = router({
       })
     )
     .query(({ input }) =>
-      ingredientTagsService.listDistinctTags(getDrizzle(), {
+      ingredientTagsService.listDistinctTags(getFoodDrizzle(), {
         namespacePrefix: input.namespacePrefix ?? null,
         limit: input.limit,
       })
@@ -63,5 +63,5 @@ export const ingredientTagsRouter = router({
 
   findByTag: protectedProcedure
     .input(z.object({ tag: z.string().min(1) }))
-    .query(({ input }) => ingredientTagsService.listIngredientsByTag(getDrizzle(), input.tag)),
+    .query(({ input }) => ingredientTagsService.listIngredientsByTag(getFoodDrizzle(), input.tag)),
 });

--- a/apps/pops-api/src/modules/food/routers/ingredients.ts
+++ b/apps/pops-api/src/modules/food/routers/ingredients.ts
@@ -10,7 +10,7 @@ import {
   SlugAlreadyRegisteredError,
 } from '@pops/app-food-db';
 
-import { getDrizzle } from '../../../db.js';
+import { getFoodDrizzle } from '../../../db/food-handle.js';
 import { protectedProcedure, router } from '../../../trpc.js';
 import { ingredientTagsRouter } from './ingredient-tags.js';
 
@@ -69,7 +69,7 @@ export const ingredientsRouter = router({
   list: protectedProcedure
     .input(z.object({ search: z.string().optional(), parentId: z.number().nullable().optional() }))
     .query(({ input }) => {
-      const items = ingredientsQueries.listIngredients(getDrizzle(), input);
+      const items = ingredientsQueries.listIngredients(getFoodDrizzle(), input);
       // Stable order so the UI doesn't re-paint on every refetch and tests
       // can assert against a deterministic sequence. Sorting in JS is fine
       // at this scale (the canonical ingredient set is hundreds, not
@@ -82,7 +82,7 @@ export const ingredientsRouter = router({
   get: protectedProcedure
     .input(z.object({ idOrSlug: z.union([z.number(), z.string()]) }))
     .query(({ input }) => {
-      const db = getDrizzle();
+      const db = getFoodDrizzle();
       const ing =
         typeof input.idOrSlug === 'number'
           ? ingredientsQueries.getIngredient(db, input.idOrSlug)
@@ -109,7 +109,7 @@ export const ingredientsRouter = router({
     )
     .mutation(({ input }) => {
       try {
-        return ingredientsService.createIngredient(getDrizzle(), input);
+        return ingredientsService.createIngredient(getFoodDrizzle(), input);
       } catch (err) {
         mapServiceError(err);
       }
@@ -117,14 +117,18 @@ export const ingredientsRouter = router({
 
   update: protectedProcedure.input(UPDATE_INPUT).mutation(({ input }) => {
     const { id, ...patch } = input;
-    return ingredientsService.updateIngredient(getDrizzle(), id, patch);
+    return ingredientsService.updateIngredient(getFoodDrizzle(), id, patch);
   }),
 
   rename: protectedProcedure
     .input(z.object({ oldSlug: z.string(), newSlug: z.string() }))
     .mutation(({ input }) => {
       try {
-        return ingredientsService.renameIngredientSlug(getDrizzle(), input.oldSlug, input.newSlug);
+        return ingredientsService.renameIngredientSlug(
+          getFoodDrizzle(),
+          input.oldSlug,
+          input.newSlug
+        );
       } catch (err) {
         mapServiceError(err);
       }
@@ -134,7 +138,11 @@ export const ingredientsRouter = router({
     .input(z.object({ id: z.number(), newParentId: z.number().nullable() }))
     .mutation(({ input }) => {
       try {
-        return ingredientsService.changeIngredientParent(getDrizzle(), input.id, input.newParentId);
+        return ingredientsService.changeIngredientParent(
+          getFoodDrizzle(),
+          input.id,
+          input.newParentId
+        );
       } catch (err) {
         mapServiceError(err);
       }
@@ -142,14 +150,18 @@ export const ingredientsRouter = router({
 
   blockers: protectedProcedure
     .input(z.object({ id: z.number() }))
-    .query(({ input }) => ingredientsQueries.getIngredientDeleteBlockers(getDrizzle(), input.id)),
+    .query(({ input }) =>
+      ingredientsQueries.getIngredientDeleteBlockers(getFoodDrizzle(), input.id)
+    ),
 
   recipeRefs: protectedProcedure
     .input(z.object({ id: z.number() }))
-    .query(({ input }) => ingredientsQueries.getRecipeRefsForIngredient(getDrizzle(), input.id)),
+    .query(({ input }) =>
+      ingredientsQueries.getRecipeRefsForIngredient(getFoodDrizzle(), input.id)
+    ),
 
   delete: protectedProcedure.input(z.object({ id: z.number() })).mutation(({ input }) => {
-    const db = getDrizzle();
+    const db = getFoodDrizzle();
     const blockers = ingredientsQueries.getIngredientDeleteBlockers(db, input.id);
     if (blockers.variants > 0 || blockers.aliases > 0) {
       return { ok: false as const, blockers };

--- a/apps/pops-api/src/modules/food/routers/slugs.ts
+++ b/apps/pops-api/src/modules/food/routers/slugs.ts
@@ -9,8 +9,8 @@ import { protectedProcedure, router } from '../../../trpc.js';
 const SLUG_KIND = z.enum(['ingredient', 'recipe', 'prep_state']);
 type SlugKind = z.infer<typeof SLUG_KIND>;
 
-const FOOD_DB_KINDS: ReadonlySet<SlugKind> = new Set(['prep_state']);
-const LEGACY_DB_KINDS: ReadonlySet<SlugKind> = new Set(['ingredient', 'recipe']);
+const FOOD_DB_KINDS: ReadonlySet<SlugKind> = new Set(['ingredient', 'prep_state']);
+const LEGACY_DB_KINDS: ReadonlySet<SlugKind> = new Set(['recipe']);
 
 const ALL_KINDS: readonly SlugKind[] = ['ingredient', 'recipe', 'prep_state'];
 
@@ -24,12 +24,12 @@ interface SearchInput {
  * Run `searchSlugs` against the two backing handles for the requested
  * kinds and merge.
  *
- * Theme 13 PR 4 split the `slug_registry` table across two pillar DBs:
- * `kind='prep_state'` rows now live in `food.db` (via `getFoodDrizzle()`),
- * while `kind in ('ingredient','recipe')` rows still live in the legacy
- * shared `pops.db` (via `getDrizzle()`). A single-DB query would return
- * stale/incomplete results once writes have diverged, so we partition
- * the requested kinds by storage and merge the two result sets.
+ * Theme 13 Wave 5 split the `slug_registry` table across two pillar DBs:
+ * `kind in ('ingredient','prep_state')` rows now live in `food.db` (via
+ * `getFoodDrizzle()`), while `kind='recipe'` rows still live in the
+ * legacy shared `pops.db` (via `getDrizzle()`). A single-DB query would
+ * return stale/incomplete results once writes have diverged, so we
+ * partition the requested kinds by storage and merge the two result sets.
  *
  * `limit` is applied to each underlying query and again to the merged
  * output — slightly over-fetching in the worst case (limit*2 rows

--- a/packages/food-db/migrations/0060_food_ingredient_tags.sql
+++ b/packages/food-db/migrations/0060_food_ingredient_tags.sql
@@ -1,0 +1,30 @@
+-- Theme-13 Wave-5 PR4 ingredients slice — schema parity with pops.db ahead of
+-- the writer cutover.
+--
+-- 1. `ingredient_tags` is a brand-new table on the food-db side. The pops.db
+--    side picked it up in `0070_prd_151_ingredient_tags.sql`; the column /
+--    index shape matches that migration byte-for-byte so backfilled rows land
+--    intact.
+-- 2. `ingredient_variants` was created in `0058_high_sentinel.sql` without the
+--    shelf-life columns; pops.db's `0060_familiar_leo.sql` later ALTERed them
+--    in. Replay those ALTERs here so the food-db table matches the drizzle
+--    schema and `SELECT *` reads through `getFoodDrizzle()` don't trip on
+--    missing columns.
+CREATE TABLE `ingredient_tags` (
+	`ingredient_id` integer NOT NULL,
+	`tag` text NOT NULL,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL,
+	PRIMARY KEY(`ingredient_id`, `tag`),
+	FOREIGN KEY (`ingredient_id`) REFERENCES `ingredients`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+-- Case-insensitive index — the autocomplete picker filters by partial match
+-- without forcing the writer to remember the canonical casing.
+CREATE INDEX `idx_ingredient_tags_tag` ON `ingredient_tags` (`tag` COLLATE NOCASE);--> statement-breakpoint
+-- Expression index over the namespace prefix (segment before the first `:`).
+-- PRD-152's generator runs `WHERE tag LIKE 'store-section:%'` per recipe-line;
+-- the expression index lets SQLite skip the table scan. `WHERE INSTR(tag, ':')
+-- > 0` keeps the index sparse — namespace-less tags don't bloat it.
+CREATE INDEX `idx_ingredient_tags_namespace` ON `ingredient_tags` (SUBSTR(`tag`, 1, INSTR(`tag` || ':', ':') - 1)) WHERE INSTR(`tag`, ':') > 0;--> statement-breakpoint
+ALTER TABLE `ingredient_variants` ADD `default_shelf_life_days_fridge` integer;--> statement-breakpoint
+ALTER TABLE `ingredient_variants` ADD `default_shelf_life_days_freezer` integer;

--- a/packages/food-db/migrations/meta/_journal.json
+++ b/packages/food-db/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1781500777652,
       "tag": "0059_food_conversions",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1781500777653,
+      "tag": "0060_food_ingredient_tags",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/food-db/src/__tests__/open-food-db.test.ts
+++ b/packages/food-db/src/__tests__/open-food-db.test.ts
@@ -18,7 +18,13 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { openFoodDb } from '../open-food-db.js';
-import { ingredientWeights, prepStates, unitConversions } from '../schema.js';
+import {
+  ingredients,
+  ingredientTags,
+  ingredientWeights,
+  prepStates,
+  unitConversions,
+} from '../schema.js';
 import { listPrepStates } from '../services/prep-states.js';
 
 let tmpDir: string;
@@ -136,6 +142,58 @@ describe('openFoodDb', () => {
       db.insert(unitConversions).values({ fromUnit: 'cup', toUnit: 'ml', ratio: 240 }).run();
       expect(() =>
         db.insert(unitConversions).values({ fromUnit: 'cup', toUnit: 'ml', ratio: 250 }).run()
+      ).toThrow();
+    } finally {
+      raw.close();
+    }
+  });
+
+  it('applies the 0060 ingredient_tags migration — composite-PK round-trip + FK cascade', () => {
+    const path = join(tmpDir, 'food.db');
+    const { db, raw } = openFoodDb(path);
+    try {
+      const ing = db
+        .insert(ingredients)
+        .values({ name: 'Banana', slug: 'banana', defaultUnit: 'count' })
+        .returning()
+        .get();
+      expect(ing?.id).toBeGreaterThan(0);
+
+      db.insert(ingredientTags)
+        .values({ ingredientId: ing!.id, tag: 'store-section:produce' })
+        .run();
+      db.insert(ingredientTags).values({ ingredientId: ing!.id, tag: 'allergen:none' }).run();
+
+      const rows = raw
+        .prepare('SELECT ingredient_id, tag FROM ingredient_tags ORDER BY tag')
+        .all() as { ingredient_id: number; tag: string }[];
+      expect(rows).toEqual([
+        { ingredient_id: ing!.id, tag: 'allergen:none' },
+        { ingredient_id: ing!.id, tag: 'store-section:produce' },
+      ]);
+
+      raw.prepare('DELETE FROM ingredients WHERE id = ?').run(ing!.id);
+      const { n } = raw.prepare('SELECT count(*) AS n FROM ingredient_tags').get() as {
+        n: number;
+      };
+      expect(n).toBe(0);
+    } finally {
+      raw.close();
+    }
+  });
+
+  it('enforces the ingredient_tags composite primary key', () => {
+    const path = join(tmpDir, 'food.db');
+    const { db, raw } = openFoodDb(path);
+    try {
+      const ing = db
+        .insert(ingredients)
+        .values({ name: 'Apple', slug: 'apple', defaultUnit: 'count' })
+        .returning()
+        .get();
+      db.insert(ingredientTags).values({ ingredientId: ing!.id, tag: 'vegan' }).run();
+      expect(() =>
+        db.insert(ingredientTags).values({ ingredientId: ing!.id, tag: 'vegan' }).run()
       ).toThrow();
     } finally {
       raw.close();


### PR DESCRIPTION
## Summary

- Second food chunk of the Theme-13 Wave-5 PR4 cascade (after `prep_states` + `conversions`). Moves the ingredient cluster — `ingredients`, `ingredient_variants`, `ingredient_aliases`, `ingredient_tags`, and the `kind='ingredient'` rows of `slug_registry` — onto the food pillar's `food.db`.
- Adds the `ingredient_tags` table to the food-db migration journal (`0059_food_ingredient_tags.sql`) and replays the two `ingredient_variants` shelf-life ALTERs from pops.db's `0060_familiar_leo.sql` so the food-db schema matches what drizzle's `select()` issues. The other three ingredient tables + `slug_registry` were already lifted in `0058_high_sentinel.sql`.
- New ATTACH backfill module (`apps/pops-api/src/db/backfill-food-from-shared.ts`) carries ingredients + variants + aliases + tags across, plus a kind-scoped `slug_registry` copy (`WHERE kind IN ('ingredient', 'prep_state')`). `kind='recipe'` rows intentionally stay on pops.db until the recipes writer flips in a later cascade.
- 14 handler sites flipped from `getDrizzle()` to `getFoodDrizzle()` (10 in `routers/ingredients.ts`, 4 in `routers/ingredient-tags.ts`). The slug partitioner in `routers/slugs.ts` moves `ingredient` into the food-db set in the same PR — atomic with the writer flip so search reads never split-brain.
- Cross-pillar FKs from downstream tables that still live on pops.db (recipe_lines, substitutions, ingredient_weights, etc.) are intentionally omitted at the SQLite level. Those tables retire in their own PR4.

## Test plan

- [x] `pnpm --filter @pops/food-db typecheck/test/build` — 37 / 37 pass
- [x] `pnpm --filter @pops/api test src/modules/food src/db/backfill-food` — 352 / 352 pass
- [x] `pnpm --filter @pops/api test` — 4912 / 4912 pass
- [x] `pnpm typecheck` — 73 / 73 packages clean
- [x] `pnpm lint` — exit 0 (warnings only, all pre-existing)
- [x] `pnpm format:check` — clean
- [x] Husky pre-commit hook passes without `--no-verify`
- [ ] Boot bridge verified in dev: first start on a populated pops.db backfills ingredients + slug rows; second start is a no-op
- [ ] Smoke: `food.slugs.search({ query: 'ban' })` returns ingredient + prep_state hits merged from both pillar handles
- [ ] Prod verification window before the follow-up `TABLE_COPIES` cleanup that drops the source rows on pops.db
