### PR TITLE
fix(ci): topology-aware build in pillar-schema-coverage workflow

### DIFF
--- a/.github/workflows/pillar-schema-coverage.yml
+++ b/.github/workflows/pillar-schema-coverage.yml
@@ -36,15 +36,7 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - name: Build pillar packages
-        run: |
-          pnpm --filter @pops/db-types build
-          pnpm --filter @pops/core-db build
-          pnpm --filter @pops/finance-db build
-          pnpm --filter @pops/inventory-db build
-          pnpm --filter @pops/media-db build
-          pnpm --filter @pops/cerebrum-db build
-          pnpm --filter @pops/food-db build
-          pnpm --filter @pops/lists-db build
+        run: pnpm --filter "@pops/db-types^..." --filter "@pops/db-types" build
       - name: Run schema-coverage check for ${{ matrix.pillar }}
         run: node scripts/check-pillar-schema-coverage.mjs --pillar ${{ matrix.pillar }}
 


### PR DESCRIPTION
Same root cause as #3285 / #3287 (CI fixes for the main / per-package quality workflows). The schema-coverage workflow has its own hardcoded ordered build that fails when one of the per-pillar -db packages now depends on another (post PRD-245).

Replace with a single `pnpm --filter "@pops/db-types^..." --filter "@pops/db-types" build` that resolves the graph in topology order.

Unblocks: #3283, #3294, #3295, #3298, #3299.