### PR TITLE
fix(ci): topology-aware build in pillar-schema-coverage self-test

### DIFF
--- a/.github/workflows/pillar-schema-coverage.yml
+++ b/.github/workflows/pillar-schema-coverage.yml
@@ -52,9 +52,7 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - name: Build finance-db
-        run: |
-          pnpm --filter @pops/db-types build
-          pnpm --filter @pops/finance-db build
+        run: pnpm --filter "@pops/finance-db^..." --filter "@pops/finance-db" build
       - name: Self-test (script catches injected missing table)
         run: |
           set +e


### PR DESCRIPTION
Companion to #3300. The self-test job within pillar-schema-coverage.yml has its own hardcoded build step that hit the same bug. Replace with the same name-based filter pattern.