### PR TITLE
test(infra): PRD-252 US-01 follow-up — unit tests for pillar Dockerfile generator

### DIFF
--- a/scripts/__tests__/generate-pillar-dockerfile.test.ts
+++ b/scripts/__tests__/generate-pillar-dockerfile.test.ts
@@ -1,0 +1,289 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  copySourcesFor,
+  generateDockerfile,
+  parsePillarTransitiveDeps,
+  parseWorkspacePackagePaths,
+  renderDockerfile,
+} from '../generate-pillar-dockerfile.mjs';
+
+interface FixtureFile {
+  readonly path: string;
+  readonly content?: string;
+}
+
+function writeFixture(root: string, files: readonly FixtureFile[]): void {
+  for (const f of files) {
+    const abs = resolve(root, f.path);
+    mkdirSync(resolve(abs, '..'), { recursive: true });
+    writeFileSync(abs, f.content ?? '');
+  }
+}
+
+describe('parseWorkspacePackagePaths', () => {
+  it('filters out the monorepo root and returns sorted repo-relative paths', () => {
+    const root = '/repo';
+    const raw = JSON.stringify([
+      { name: '@pops/monorepo', path: '/repo' },
+      { name: '@pops/core-api', path: '/repo/apps/pops-core-api' },
+      { name: '@pops/core-db', path: '/repo/packages/core-db' },
+      { name: '@pops/core-contract', path: '/repo/packages/core-contract' },
+    ]);
+
+    expect(parseWorkspacePackagePaths(raw, root)).toEqual([
+      'apps/pops-core-api',
+      'packages/core-contract',
+      'packages/core-db',
+    ]);
+  });
+
+  it('drops entries missing name or path', () => {
+    const raw = JSON.stringify([
+      { name: '@pops/core-db', path: '/repo/packages/core-db' },
+      { name: '@pops/orphan' },
+      { path: '/repo/packages/ghost' },
+    ]);
+
+    expect(parseWorkspacePackagePaths(raw, '/repo')).toEqual(['packages/core-db']);
+  });
+});
+
+describe('parsePillarTransitiveDeps', () => {
+  it('keeps @pops/* entries with paths and skips the monorepo root', () => {
+    const raw = JSON.stringify([
+      { name: '@pops/monorepo', path: '/repo' },
+      { name: '@pops/core-api', path: '/repo/apps/pops-core-api' },
+      { name: '@pops/core-db', path: '/repo/packages/core-db' },
+      { name: 'zod', path: '/repo/node_modules/zod' },
+    ]);
+
+    expect(parsePillarTransitiveDeps(raw, '/repo')).toEqual([
+      { name: '@pops/core-api', path: 'apps/pops-core-api' },
+      { name: '@pops/core-db', path: 'packages/core-db' },
+    ]);
+  });
+});
+
+describe('copySourcesFor', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'gen-dockerfile-'));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('returns only paths that exist on disk, in the canonical order', () => {
+    writeFixture(root, [
+      { path: 'packages/core-db/src/index.ts' },
+      { path: 'packages/core-db/migrations/0001.sql' },
+      { path: 'packages/core-db/tsconfig.json' },
+    ]);
+
+    expect(copySourcesFor(root, 'packages/core-db')).toEqual([
+      'packages/core-db/src',
+      'packages/core-db/migrations',
+      'packages/core-db/tsconfig.json',
+    ]);
+  });
+
+  it('returns the empty list when nothing matches', () => {
+    writeFixture(root, [{ path: 'packages/empty/README.md' }]);
+    expect(copySourcesFor(root, 'packages/empty')).toEqual([]);
+  });
+
+  it('emits scripts, openapi, and tsconfig.build.json when present', () => {
+    writeFixture(root, [
+      { path: 'packages/core-contract/src/index.ts' },
+      { path: 'packages/core-contract/scripts/build.ts' },
+      { path: 'packages/core-contract/openapi/spec.yaml' },
+      { path: 'packages/core-contract/tsconfig.json' },
+      { path: 'packages/core-contract/tsconfig.build.json' },
+    ]);
+
+    expect(copySourcesFor(root, 'packages/core-contract')).toEqual([
+      'packages/core-contract/src',
+      'packages/core-contract/scripts',
+      'packages/core-contract/openapi',
+      'packages/core-contract/tsconfig.json',
+      'packages/core-contract/tsconfig.build.json',
+    ]);
+  });
+});
+
+describe('renderDockerfile', () => {
+  it('emits Phase 1 COPY lines for every workspace package.json', () => {
+    const out = renderDockerfile({
+      pillar: 'core',
+      allWorkspacePaths: ['apps/pops-core-api', 'packages/core-db', 'packages/finance-db'],
+      sharedDeps: [],
+      appSources: ['apps/pops-core-api/src', 'apps/pops-core-api/tsconfig.json'],
+    });
+
+    expect(out).toContain('COPY apps/pops-core-api/package.json ./apps/pops-core-api/');
+    expect(out).toContain('COPY packages/core-db/package.json ./packages/core-db/');
+    expect(out).toContain('COPY packages/finance-db/package.json ./packages/finance-db/');
+  });
+
+  it('only emits Phase 2 source COPY lines for the transitive deps', () => {
+    const out = renderDockerfile({
+      pillar: 'core',
+      allWorkspacePaths: ['apps/pops-core-api', 'packages/core-db', 'packages/finance-db'],
+      sharedDeps: [
+        {
+          name: '@pops/core-db',
+          path: 'packages/core-db',
+          sources: ['packages/core-db/src', 'packages/core-db/migrations'],
+        },
+      ],
+      appSources: ['apps/pops-core-api/src'],
+    });
+
+    expect(out).toContain('# @pops/core-db');
+    expect(out).toContain('COPY packages/core-db/src ./packages/core-db/src');
+    expect(out).toContain('COPY packages/core-db/migrations ./packages/core-db/migrations');
+    expect(out).not.toContain('COPY packages/finance-db/src');
+    expect(out).not.toContain('COPY packages/finance-db/migrations');
+  });
+
+  it('skips shared deps with no buildable sources but keeps later deps', () => {
+    const out = renderDockerfile({
+      pillar: 'core',
+      allWorkspacePaths: ['apps/pops-core-api'],
+      sharedDeps: [
+        { name: '@pops/types-only', path: 'packages/types-only', sources: [] },
+        {
+          name: '@pops/core-db',
+          path: 'packages/core-db',
+          sources: ['packages/core-db/src'],
+        },
+      ],
+      appSources: ['apps/pops-core-api/src'],
+    });
+
+    expect(out).not.toContain('# @pops/types-only');
+    expect(out).toContain('# @pops/core-db');
+  });
+
+  it('uses topology-aware pnpm build filters for the pillar package', () => {
+    const out = renderDockerfile({
+      pillar: 'finance',
+      allWorkspacePaths: ['apps/pops-finance-api'],
+      sharedDeps: [],
+      appSources: ['apps/pops-finance-api/src'],
+    });
+
+    expect(out).toContain('RUN pnpm --filter "@pops/finance-api^..." build');
+    expect(out).toContain('RUN pnpm --filter "@pops/finance-api" build');
+    expect(out).toContain('RUN pnpm --filter @pops/finance-api deploy --prod --legacy /app/deploy');
+  });
+
+  it('includes the regeneration banner with the pillar name', () => {
+    const out = renderDockerfile({
+      pillar: 'inventory',
+      allWorkspacePaths: ['apps/pops-inventory-api'],
+      sharedDeps: [],
+      appSources: ['apps/pops-inventory-api/src'],
+    });
+
+    expect(out).toContain('node scripts/generate-pillar-dockerfile.mjs inventory');
+    expect(out).toContain('# DO NOT EDIT');
+    expect(out).toContain('PRD-252 / audit H-D1');
+  });
+
+  it('ends with a trailing newline', () => {
+    const out = renderDockerfile({
+      pillar: 'core',
+      allWorkspacePaths: [],
+      sharedDeps: [],
+      appSources: [],
+    });
+    expect(out.endsWith('\n')).toBe(true);
+  });
+});
+
+describe('generateDockerfile', () => {
+  it('walks transitive deps and narrows Phase 2 to the pillar subgraph', () => {
+    const out = generateDockerfile({
+      pillar: 'core',
+      allWorkspacePaths: [
+        'apps/pops-core-api',
+        'apps/pops-finance-api',
+        'packages/core-db',
+        'packages/finance-db',
+      ],
+      transitiveDeps: [
+        { name: '@pops/core-api', path: 'apps/pops-core-api' },
+        { name: '@pops/core-db', path: 'packages/core-db' },
+      ],
+      sourcesFor: (pkgDir) => {
+        const tree: Record<string, string[]> = {
+          'packages/core-db': ['packages/core-db/src', 'packages/core-db/migrations'],
+          'apps/pops-core-api': ['apps/pops-core-api/src', 'apps/pops-core-api/tsconfig.json'],
+        };
+        return tree[pkgDir] ?? [];
+      },
+    });
+
+    expect(out).toContain('COPY apps/pops-finance-api/package.json ./apps/pops-finance-api/');
+    expect(out).toContain('COPY packages/finance-db/package.json ./packages/finance-db/');
+    expect(out).not.toContain('COPY packages/finance-db/src');
+    expect(out).not.toContain('COPY packages/finance-db/migrations');
+    expect(out).toContain('COPY packages/core-db/src ./packages/core-db/src');
+    expect(out).toContain('COPY packages/core-db/migrations ./packages/core-db/migrations');
+    expect(out).toContain('COPY apps/pops-core-api/src ./apps/pops-core-api/src');
+  });
+
+  it('sorts shared deps by path for deterministic output', () => {
+    const out = generateDockerfile({
+      pillar: 'core',
+      allWorkspacePaths: ['apps/pops-core-api'],
+      transitiveDeps: [
+        { name: '@pops/core-api', path: 'apps/pops-core-api' },
+        { name: '@pops/types', path: 'packages/types' },
+        { name: '@pops/core-db', path: 'packages/core-db' },
+        { name: '@pops/core-contract', path: 'packages/core-contract' },
+      ],
+      sourcesFor: (pkgDir) => [`${pkgDir}/src`],
+    });
+
+    const idxContract = out.indexOf('# @pops/core-contract');
+    const idxDb = out.indexOf('# @pops/core-db');
+    const idxTypes = out.indexOf('# @pops/types');
+    expect(idxContract).toBeGreaterThan(-1);
+    expect(idxDb).toBeGreaterThan(idxContract);
+    expect(idxTypes).toBeGreaterThan(idxDb);
+  });
+
+  it('throws when the target app is not present in the dep graph', () => {
+    expect(() =>
+      generateDockerfile({
+        pillar: 'core',
+        allWorkspacePaths: ['apps/pops-core-api'],
+        transitiveDeps: [{ name: '@pops/core-db', path: 'packages/core-db' }],
+        sourcesFor: () => [],
+      })
+    ).toThrow(/did not return the target app @pops\/core-api/);
+  });
+
+  it('produces output stable across calls for the same input', () => {
+    const args = {
+      pillar: 'core' as const,
+      allWorkspacePaths: ['apps/pops-core-api', 'packages/core-db'],
+      transitiveDeps: [
+        { name: '@pops/core-api', path: 'apps/pops-core-api' },
+        { name: '@pops/core-db', path: 'packages/core-db' },
+      ],
+      sourcesFor: (pkgDir: string) => [`${pkgDir}/src`],
+    };
+
+    expect(generateDockerfile(args)).toBe(generateDockerfile(args));
+  });
+});

--- a/scripts/__tests__/tsconfig.json
+++ b/scripts/__tests__/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "allowJs": true,
+    "checkJs": false,
+    "noEmit": true,
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["*.ts", "../*.mjs"]
+}

--- a/scripts/generate-pillar-dockerfile.mjs
+++ b/scripts/generate-pillar-dockerfile.mjs
@@ -2,7 +2,7 @@
 import { execFileSync } from 'node:child_process';
 import { existsSync, writeFileSync } from 'node:fs';
 import { dirname, join, relative, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const SELF = fileURLToPath(import.meta.url);
 const REPO_ROOT = resolve(dirname(SELF), '..');
@@ -24,46 +24,66 @@ const REPO_ROOT = resolve(dirname(SELF), '..');
  * Example: node scripts/generate-pillar-dockerfile.mjs core
  */
 
-const PILLAR = process.argv[2];
-if (!PILLAR) {
-  console.error('Usage: generate-pillar-dockerfile.mjs <pillar>');
-  console.error('Example: generate-pillar-dockerfile.mjs core');
-  process.exit(1);
-}
+const SOURCE_CANDIDATES = [
+  'src',
+  'scripts',
+  'migrations',
+  'openapi',
+  'tsconfig.json',
+  'tsconfig.build.json',
+];
 
-const APP_DIR = join('apps', `pops-${PILLAR}-api`);
-const APP_PKG_NAME = `@pops/${PILLAR}-api`;
-
-const appPkgPath = resolve(REPO_ROOT, APP_DIR, 'package.json');
-if (!existsSync(appPkgPath)) {
-  console.error(`pillar app not found: ${APP_DIR}/package.json`);
-  process.exit(1);
-}
-
-/** Read the full workspace package set so pnpm install can resolve. */
-function listWorkspacePackagePaths() {
+/**
+ * Read the full workspace package set so pnpm install can resolve.
+ * @param {string} repoRoot
+ * @returns {string[]} repo-relative paths, sorted
+ */
+export function listWorkspacePackagePaths(repoRoot) {
   const raw = execFileSync('pnpm', ['m', 'ls', '--json', '--depth', '-1'], {
-    cwd: REPO_ROOT,
+    cwd: repoRoot,
     encoding: 'utf8',
     maxBuffer: 32 * 1024 * 1024,
   });
+  return parseWorkspacePackagePaths(raw, repoRoot);
+}
+
+/**
+ * Pure parser for `pnpm m ls --json --depth -1` output.
+ * @param {string} raw
+ * @param {string} repoRoot
+ * @returns {string[]}
+ */
+export function parseWorkspacePackagePaths(raw, repoRoot) {
   const entries = JSON.parse(raw);
   return entries
     .filter((e) => e.name && e.name !== '@pops/monorepo' && e.path)
-    .map((e) => relative(REPO_ROOT, e.path))
+    .map((e) => relative(repoRoot, e.path))
     .toSorted();
 }
 
 /**
  * Resolve every transitive `@pops/*` workspace dep of the target pillar
  * (including the target itself), with repo-relative paths.
+ * @param {string} repoRoot
+ * @param {string} pkgName e.g. "@pops/core-api"
+ * @returns {{ name: string, path: string }[]}
  */
-function listPillarTransitiveDeps() {
+export function listPillarTransitiveDeps(repoRoot, pkgName) {
   const raw = execFileSync(
     'pnpm',
-    ['m', 'ls', '--filter', `${APP_PKG_NAME}...`, '--json', '--depth', '-1'],
-    { cwd: REPO_ROOT, encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 }
+    ['m', 'ls', '--filter', `${pkgName}...`, '--json', '--depth', '-1'],
+    { cwd: repoRoot, encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 }
   );
+  return parsePillarTransitiveDeps(raw, repoRoot);
+}
+
+/**
+ * Pure parser for the filtered `pnpm m ls` output.
+ * @param {string} raw
+ * @param {string} repoRoot
+ * @returns {{ name: string, path: string }[]}
+ */
+export function parsePillarTransitiveDeps(raw, repoRoot) {
   const entries = JSON.parse(raw);
   return entries
     .filter(
@@ -75,114 +95,181 @@ function listPillarTransitiveDeps() {
     )
     .map((e) => ({
       name: e.name,
-      path: relative(REPO_ROOT, e.path),
+      path: relative(repoRoot, e.path),
     }));
 }
-
-const allWorkspacePaths = listWorkspacePackagePaths();
-const transitiveDeps = listPillarTransitiveDeps();
-const transitiveDepPaths = new Set(transitiveDeps.map((d) => d.path));
-
-if (!transitiveDepPaths.has(APP_DIR)) {
-  console.error(`pnpm did not return the target app ${APP_PKG_NAME} in its dependency graph`);
-  process.exit(1);
-}
-
-const sharedDeps = transitiveDeps
-  .filter((d) => d.path !== APP_DIR)
-  .toSorted((a, b) => a.path.localeCompare(b.path));
 
 /**
  * For a workspace package directory, return the list of paths to COPY
  * during Phase 2 (source code, tsconfig variants, migrations, openapi).
  * Only paths that actually exist on disk are emitted so the Dockerfile
  * is deterministic against the current tree.
+ * @param {string} repoRoot
+ * @param {string} pkgDir repo-relative
+ * @returns {string[]}
  */
-function copySourcesFor(pkgDir) {
-  const abs = resolve(REPO_ROOT, pkgDir);
-  const candidates = [
-    'src',
-    'scripts',
-    'migrations',
-    'openapi',
-    'tsconfig.json',
-    'tsconfig.build.json',
-  ];
-  return candidates.filter((c) => existsSync(join(abs, c))).map((c) => `${pkgDir}/${c}`);
+export function copySourcesFor(repoRoot, pkgDir) {
+  const abs = resolve(repoRoot, pkgDir);
+  return SOURCE_CANDIDATES.filter((c) => existsSync(join(abs, c))).map((c) => `${pkgDir}/${c}`);
 }
 
-const lines = [];
-const push = (s = '') => lines.push(s);
+/**
+ * Pure Dockerfile renderer. Does not touch the filesystem.
+ *
+ * @param {object} args
+ * @param {string} args.pillar pillar slug (e.g. "core")
+ * @param {string[]} args.allWorkspacePaths every workspace package dir
+ *   (repo-relative), sorted. Used for Phase 1 package.json COPY lines.
+ * @param {{ name: string, path: string, sources: string[] }[]} args.sharedDeps
+ *   transitive `@pops/*` deps EXCLUDING the target app, each with the
+ *   already-resolved Phase 2 source COPY paths (repo-relative).
+ * @param {string[]} args.appSources source paths inside the target app
+ *   dir to COPY (repo-relative).
+ * @returns {string}
+ */
+export function renderDockerfile({ pillar, allWorkspacePaths, sharedDeps, appSources }) {
+  const appDir = `apps/pops-${pillar}-api`;
+  const appPkgName = `@pops/${pillar}-api`;
+  const lines = [];
+  const push = (s = '') => lines.push(s);
 
-push(`# DO NOT EDIT — regenerate with:`);
-push(`#   node scripts/generate-pillar-dockerfile.mjs ${PILLAR}`);
-push(`# CI drift-check (.github/workflows/docker-build.yml) fails on hand-edits.`);
-push(`# PRD-252 / audit H-D1.`);
-push(``);
-push(`FROM node:22-slim AS builder`);
-push(`WORKDIR /app`);
-push(``);
-push(`# Workspace root manifests — needed for pnpm install to resolve.`);
-push(`COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json .oxfmtrc.json ./`);
-push(``);
-push(`# Phase 1: every workspace package.json. pnpm-workspace.yaml lists every`);
-push(`# member; if any are missing at install time pnpm fails with`);
-push(`# ERR_PNPM_WORKSPACE_PKG_NOT_FOUND. src/ + migrations/ for non-transitive`);
-push(`# packages are intentionally NOT copied (PRD-252 / audit H-D1).`);
-for (const p of allWorkspacePaths) {
-  push(`COPY ${p}/package.json ./${p}/`);
-}
-push(``);
-push(`# Install pnpm + every workspace dependency.`);
-push(`RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \\`);
-push(`    corepack enable && pnpm install --frozen-lockfile`);
-push(``);
-push(`# Phase 2: sources for the transitive @pops/* deps of ${APP_PKG_NAME}`);
-push(`# (resolved via \`pnpm m ls --filter "${APP_PKG_NAME}..." --json\`).`);
-push(`# A change in a non-listed package does NOT invalidate this image's`);
-push(`# Phase 2 layer.`);
-for (const dep of sharedDeps) {
-  const sources = copySourcesFor(dep.path);
-  if (sources.length === 0) continue;
-  push(`# ${dep.name}`);
-  for (const src of sources) {
+  push(`# DO NOT EDIT — regenerate with:`);
+  push(`#   node scripts/generate-pillar-dockerfile.mjs ${pillar}`);
+  push(`# CI drift-check (.github/workflows/docker-build.yml) fails on hand-edits.`);
+  push(`# PRD-252 / audit H-D1.`);
+  push(``);
+  push(`FROM node:22-slim AS builder`);
+  push(`WORKDIR /app`);
+  push(``);
+  push(`# Workspace root manifests — needed for pnpm install to resolve.`);
+  push(`COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json .oxfmtrc.json ./`);
+  push(``);
+  push(`# Phase 1: every workspace package.json. pnpm-workspace.yaml lists every`);
+  push(`# member; if any are missing at install time pnpm fails with`);
+  push(`# ERR_PNPM_WORKSPACE_PKG_NOT_FOUND. src/ + migrations/ for non-transitive`);
+  push(`# packages are intentionally NOT copied (PRD-252 / audit H-D1).`);
+  for (const p of allWorkspacePaths) {
+    push(`COPY ${p}/package.json ./${p}/`);
+  }
+  push(``);
+  push(`# Install pnpm + every workspace dependency.`);
+  push(`RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \\`);
+  push(`    corepack enable && pnpm install --frozen-lockfile`);
+  push(``);
+  push(`# Phase 2: sources for the transitive @pops/* deps of ${appPkgName}`);
+  push(`# (resolved via \`pnpm m ls --filter "${appPkgName}..." --json\`).`);
+  push(`# A change in a non-listed package does NOT invalidate this image's`);
+  push(`# Phase 2 layer.`);
+  for (const dep of sharedDeps) {
+    if (dep.sources.length === 0) continue;
+    push(`# ${dep.name}`);
+    for (const src of dep.sources) {
+      push(`COPY ${src} ./${src}`);
+    }
+  }
+  push(``);
+  push(`# Pillar app sources.`);
+  for (const src of appSources) {
     push(`COPY ${src} ./${src}`);
   }
-}
-push(``);
-push(`# Pillar app sources.`);
-for (const src of copySourcesFor(APP_DIR)) {
-  push(`COPY ${src} ./${src}`);
-}
-push(``);
-push(`# Phase 3: build shared deps in pnpm topology order, then the app.`);
-push(`# \`^...\` expands to every dependency of the target excluding the target,`);
-push(`# letting pnpm compute build order from the lockfile (see #3285).`);
-push(`RUN pnpm --filter "${APP_PKG_NAME}^..." build`);
-push(`RUN pnpm --filter "${APP_PKG_NAME}" build`);
-push(``);
-push(`# Standalone deployment (production deps only, no symlinks).`);
-push(`RUN pnpm --filter ${APP_PKG_NAME} deploy --prod --legacy /app/deploy`);
-push(``);
-push(`FROM node:22-slim`);
-push(`WORKDIR /app`);
-push(
-  `RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*`
-);
-push(``);
-push(`COPY --from=builder --chown=node:node /app/deploy ./`);
-push(`COPY --from=builder --chown=node:node /app/${APP_DIR}/dist ./dist`);
-push(``);
-push(`ARG BUILD_VERSION=dev`);
-push(`ENV BUILD_VERSION=$BUILD_VERSION`);
-push(``);
-push(`EXPOSE 3001`);
-push(`USER node`);
-push(`CMD ["node", "dist/server.js"]`);
-push(``);
+  push(``);
+  push(`# Phase 3: build shared deps in pnpm topology order, then the app.`);
+  push(`# \`^...\` expands to every dependency of the target excluding the target,`);
+  push(`# letting pnpm compute build order from the lockfile (see #3285).`);
+  push(`RUN pnpm --filter "${appPkgName}^..." build`);
+  push(`RUN pnpm --filter "${appPkgName}" build`);
+  push(``);
+  push(`# Standalone deployment (production deps only, no symlinks).`);
+  push(`RUN pnpm --filter ${appPkgName} deploy --prod --legacy /app/deploy`);
+  push(``);
+  push(`FROM node:22-slim`);
+  push(`WORKDIR /app`);
+  push(
+    `RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*`
+  );
+  push(``);
+  push(`COPY --from=builder --chown=node:node /app/deploy ./`);
+  push(`COPY --from=builder --chown=node:node /app/${appDir}/dist ./dist`);
+  push(``);
+  push(`ARG BUILD_VERSION=dev`);
+  push(`ENV BUILD_VERSION=$BUILD_VERSION`);
+  push(``);
+  push(`EXPOSE 3001`);
+  push(`USER node`);
+  push(`CMD ["node", "dist/server.js"]`);
+  push(``);
 
-const outputPath = resolve(REPO_ROOT, APP_DIR, 'Dockerfile');
-writeFileSync(outputPath, lines.join('\n'));
-console.log(
-  `wrote ${relative(REPO_ROOT, outputPath)} (${sharedDeps.length} transitive @pops/* deps)`
-);
+  return lines.join('\n');
+}
+
+/**
+ * High-level orchestrator: narrows the per-pillar source list with
+ * `sourcesFor`, then renders the Dockerfile. Pure modulo the injected
+ * dependencies — `sourcesFor` is the only side-effectful seam.
+ *
+ * @param {object} args
+ * @param {string} args.pillar
+ * @param {string[]} args.allWorkspacePaths
+ * @param {{ name: string, path: string }[]} args.transitiveDeps
+ *   includes the target itself
+ * @param {(pkgDir: string) => string[]} args.sourcesFor
+ * @returns {string}
+ */
+export function generateDockerfile({ pillar, allWorkspacePaths, transitiveDeps, sourcesFor }) {
+  const appDir = `apps/pops-${pillar}-api`;
+  const appPkgName = `@pops/${pillar}-api`;
+
+  const transitivePaths = new Set(transitiveDeps.map((d) => d.path));
+  if (!transitivePaths.has(appDir)) {
+    throw new Error(`pnpm did not return the target app ${appPkgName} in its dependency graph`);
+  }
+
+  const sharedDeps = transitiveDeps
+    .filter((d) => d.path !== appDir)
+    .toSorted((a, b) => a.path.localeCompare(b.path))
+    .map((d) => ({ ...d, sources: sourcesFor(d.path) }));
+
+  const appSources = sourcesFor(appDir);
+
+  return renderDockerfile({
+    pillar,
+    allWorkspacePaths,
+    sharedDeps,
+    appSources,
+  });
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isMain) {
+  const pillar = process.argv[2];
+  if (!pillar) {
+    console.error('Usage: generate-pillar-dockerfile.mjs <pillar>');
+    console.error('Example: generate-pillar-dockerfile.mjs core');
+    process.exit(1);
+  }
+
+  const appDir = `apps/pops-${pillar}-api`;
+  const appPkgName = `@pops/${pillar}-api`;
+
+  if (!existsSync(resolve(REPO_ROOT, appDir, 'package.json'))) {
+    console.error(`pillar app not found: ${appDir}/package.json`);
+    process.exit(1);
+  }
+
+  const allWorkspacePaths = listWorkspacePackagePaths(REPO_ROOT);
+  const transitiveDeps = listPillarTransitiveDeps(REPO_ROOT, appPkgName);
+  const sourcesFor = (pkgDir) => copySourcesFor(REPO_ROOT, pkgDir);
+
+  const dockerfile = generateDockerfile({
+    pillar,
+    allWorkspacePaths,
+    transitiveDeps,
+    sourcesFor,
+  });
+
+  const outputPath = resolve(REPO_ROOT, appDir, 'Dockerfile');
+  writeFileSync(outputPath, dockerfile);
+  const sharedCount = transitiveDeps.filter((d) => d.path !== appDir).length;
+  console.log(`wrote ${relative(REPO_ROOT, outputPath)} (${sharedCount} transitive @pops/* deps)`);
+}


### PR DESCRIPTION
## Summary

- Follow-up to #3290 (PRD-252 US-01). The first PR landed the generator, the regenerated `apps/pops-core-api/Dockerfile`, and the CI drift-check in `.github/workflows/docker-build.yml`, but did not ship unit tests for the generator itself.
- Refactors `scripts/generate-pillar-dockerfile.mjs` so the workspace JSON parser, transitive-dep parser, on-disk source walker, Dockerfile renderer, and orchestrator are exported as pure functions. CLI behaviour stays identical, gated behind an `import.meta.url`/`argv[1]` check.
- Adds `scripts/__tests__/generate-pillar-dockerfile.test.ts` with 16 tests against fixture package.json trees (in `tmpdir`) and inline `pnpm m ls --json` payloads. Covers Phase 1 / Phase 2 split, source narrowing, dep sorting determinism, missing-target error path, and output stability.
- Regenerator output for `pops-core-api` is byte-identical, so the CI drift-check stays green.

## Test plan

- [ ] `npx vitest run scripts/__tests__/generate-pillar-dockerfile.test.ts` (16 passed locally)
- [ ] `node scripts/generate-pillar-dockerfile.mjs core` produces no diff
- [ ] `pnpm typecheck` green
- [ ] `pnpm lint` no new errors
- [ ] `pnpm format:check` clean