### PR TITLE
fix(core-api): PRD-251 unify cross-pillar URI contract on core.users.get

### DIFF
--- a/apps/pops-core-api/src/modules/users/__tests__/router.test.ts
+++ b/apps/pops-core-api/src/modules/users/__tests__/router.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Tests for the `core.users.get` tRPC procedure (PRD-251 H7 cross-pillar
+ * reconciliation surface).
+ *
+ * Coverage targets the URI-shaped wire contract the procedure now exposes:
+ *
+ *   - happy path — URI resolves, response carries the URI back so the
+ *     caller can confirm it's the one they asked about
+ *   - 404 — URI parses but no `user_settings` row exists for the embedded
+ *     email, surfaces as `NOT_FOUND` so the consumer cron stamps stale
+ *   - bad URI — malformed scheme / wrong pillar / wrong type / missing id
+ *     all surface as `BAD_REQUEST` so the consumer cron records "bad URI"
+ *     for ops without touching the row
+ *   - auth gating — anonymous callers bounce on `UNAUTHORIZED`
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { TRPCError } from '@trpc/server';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { openCoreDb, userSettings, type OpenedCoreDb } from '@pops/core-db';
+
+import { appRouter } from '../../../router.js';
+import { type Context } from '../../../trpc.js';
+
+let tmpDir: string;
+let coreDb: OpenedCoreDb;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'core-api-users-test-'));
+  coreDb = openCoreDb(join(tmpDir, 'core.db'));
+});
+
+afterEach(() => {
+  coreDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function userCaller(): ReturnType<typeof appRouter.createCaller> {
+  const ctx: Context = {
+    user: { email: 'admin@example.com' },
+    serviceAccount: null,
+    coreDb: coreDb.db,
+  };
+  return appRouter.createCaller(ctx);
+}
+
+function anonCaller(): ReturnType<typeof appRouter.createCaller> {
+  const ctx: Context = {
+    user: null,
+    serviceAccount: null,
+    coreDb: coreDb.db,
+  };
+  return appRouter.createCaller(ctx);
+}
+
+function seedUser(email: string): void {
+  coreDb.db.insert(userSettings).values({ userEmail: email, key: 'seed', value: '1' }).run();
+}
+
+describe('core.users.get — URI contract', () => {
+  it('resolves a known user URI and echoes the URI back', async () => {
+    seedUser('joao@example.com');
+    const uri = 'pops://core/user/joao@example.com';
+
+    const res = await userCaller().core.users.get({ uri });
+
+    expect(res).toEqual({ data: { uri } });
+  });
+
+  it('throws NOT_FOUND when the URI parses but no user is seeded', async () => {
+    const uri = 'pops://core/user/nobody@example.com';
+
+    await expect(userCaller().core.users.get({ uri })).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    });
+  });
+
+  it.each([
+    ['wrong scheme', 'http://core/user/joao@example.com'],
+    ['wrong pillar', 'pops://finance/user/joao@example.com'],
+    ['wrong type', 'pops://core/entity/joao@example.com'],
+    ['empty id', 'pops://core/user/'],
+    ['plain string', 'joao@example.com'],
+  ])('throws BAD_REQUEST on malformed URI (%s)', async (_label, uri) => {
+    await expect(userCaller().core.users.get({ uri })).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+    });
+  });
+
+  it('bounces an anonymous caller on UNAUTHORIZED', async () => {
+    await expect(
+      anonCaller().core.users.get({ uri: 'pops://core/user/joao@example.com' })
+    ).rejects.toBeInstanceOf(TRPCError);
+  });
+});

--- a/apps/pops-core-api/src/modules/users/router.ts
+++ b/apps/pops-core-api/src/modules/users/router.ts
@@ -7,6 +7,16 @@
  * the consumer row stale rather than deleting it (PRD-251 §"Existence is
  * best-effort").
  *
+ * Input contract: URI shape (`{ uri: 'pops://core/user/<email>' }`). The
+ * URI shape is the PRD-251 cross-pillar wire contract — every consumer
+ * stores the denormalised reference as a URI on its own row, so passing
+ * the URI through end-to-end avoids per-call parsing in the consumer and
+ * keeps the same shape on both sides of the boundary.
+ *
+ * Malformed URIs (wrong scheme, wrong pillar, wrong type, missing id)
+ * surface as `BAD_REQUEST`; URIs that parse but don't resolve to a known
+ * user surface as `NOT_FOUND`.
+ *
  * No write surface is exposed by design: owning-pillar writes are
  * forbidden by PRD-251, and the canonical user identity flows in from
  * Cloudflare Access / the dev-fallback path in `trpc.ts`.
@@ -15,17 +25,27 @@ import { z } from 'zod';
 
 import { usersService } from '@pops/core-db';
 
-import { NotFoundError } from '../../shared/errors.js';
+import { NotFoundError, ValidationError } from '../../shared/errors.js';
 import { mapDomainErrors } from '../../shared/trpc-error-mapper.js';
 import { protectedProcedure, router } from '../../trpc.js';
 
 const GetUserInputSchema = z.object({
-  email: z.string().min(1),
+  uri: z.string().min(1),
 });
 
 const UserSchema = z.object({
-  email: z.string(),
+  uri: z.string(),
 });
+
+const URI_PATTERN = /^pops:\/\/core\/user\/(.+)$/;
+
+function extractUserEmailFromUri(uri: string): string {
+  const match = URI_PATTERN.exec(uri);
+  if (!match || !match[1]) {
+    throw new ValidationError({ reason: 'unsupported-uri', uri });
+  }
+  return match[1];
+}
 
 export const usersRouter = router({
   get: protectedProcedure
@@ -33,9 +53,10 @@ export const usersRouter = router({
     .output(z.object({ data: UserSchema }))
     .query(({ input, ctx }) =>
       mapDomainErrors(() => {
-        const user = usersService.getUser(ctx.coreDb, input.email);
-        if (!user) throw new NotFoundError('user', input.email);
-        return { data: user };
+        const email = extractUserEmailFromUri(input.uri);
+        const user = usersService.getUser(ctx.coreDb, email);
+        if (!user) throw new NotFoundError('user', input.uri);
+        return { data: { uri: input.uri } };
       })
     ),
 });

--- a/apps/pops-finance-api/src/cron/pillar-lookup.ts
+++ b/apps/pops-finance-api/src/cron/pillar-lookup.ts
@@ -4,6 +4,11 @@
  * folds the {@link CallResult} discriminants down to the cron's smaller
  * vocabulary (`ok` / `not-found` / `bad-uri` / `unavailable`).
  *
+ * Wire contract: PRD-251 §"Surface" specifies a URI-shaped cross-pillar
+ * contract — input `{ uri }`, output `{ data: { uri } }`. Both the
+ * inventory and finance crons go through the same `core.users.get` and
+ * pass the URI through end-to-end.
+ *
  * Kept separate from the worker so unit tests can wire a stub directly
  * without exercising the HTTP transport.
  */
@@ -11,7 +16,7 @@ import { isOk, pillar, type CallResult } from '@pops/pillar-sdk/client';
 
 import type { ReconcileLookupFn, ReconcileLookupResult } from './reconcile-cross-pillar.js';
 
-type UsersGetResponse = { uri: string; displayName: string; kind: string } | null;
+type UsersGetResponse = { data: { uri: string } };
 
 type CoreUsersHandle = {
   users: {
@@ -24,7 +29,6 @@ export function createPillarOwnerUriLookup(): ReconcileLookupFn {
     const handle = pillar<CoreUsersHandle>('core');
     const result = await handle.users.get({ uri });
     if (isOk(result)) {
-      if (result.value === null) return { kind: 'not-found' };
       return { kind: 'ok' };
     }
     switch (result.kind) {

--- a/apps/pops-inventory-api/src/cron/__tests__/reconcile-cross-pillar.test.ts
+++ b/apps/pops-inventory-api/src/cron/__tests__/reconcile-cross-pillar.test.ts
@@ -120,7 +120,7 @@ function makeFinanceProxy(byId: Record<string, FakeFinanceCall>): PillarHandle<F
   return fake as unknown as PillarHandle<FinanceRouter>;
 }
 
-function makeCoreProxy(byEmail: Record<string, FakeCoreCall>): PillarHandle<CoreRouter> {
+function makeCoreProxy(byUri: Record<string, FakeCoreCall>): PillarHandle<CoreRouter> {
   const fake = {
     callDynamic: vi.fn(
       async (
@@ -128,14 +128,14 @@ function makeCoreProxy(byEmail: Record<string, FakeCoreCall>): PillarHandle<Core
         _procName: string,
         input?: unknown
       ): Promise<CallResult<unknown>> => {
-        const email = (input as { email: string } | undefined)?.email ?? '';
-        const slot = byEmail[email];
+        const uri = (input as { uri: string } | undefined)?.uri ?? '';
+        const slot = byUri[uri];
         if (!slot) {
           return { kind: 'not-found', pillar: 'core' };
         }
         if (slot.error) throw slot.error;
         if (slot.result) return slot.result;
-        return { kind: 'ok', value: { data: { email } } };
+        return { kind: 'ok', value: { data: { uri } } };
       }
     ),
   };
@@ -186,7 +186,7 @@ describe('runReconciliation — happy-path', () => {
     );
 
     const finance = makeFinanceProxy({ 'tx-1': {} });
-    const core = makeCoreProxy({ 'joao@example.com': {} });
+    const core = makeCoreProxy({ 'pops://core/user/joao@example.com': {} });
     const info = vi.fn();
 
     const counters = await runReconciliation({

--- a/apps/pops-inventory-api/src/cron/reconcile-cross-pillar-runner.ts
+++ b/apps/pops-inventory-api/src/cron/reconcile-cross-pillar-runner.ts
@@ -33,7 +33,7 @@ export interface ReconcileBatch {
   expectedPillar: string;
   expectedType: string;
   parse: (uri: string) => ParsedUri | null;
-  probe: (parsed: ParsedUri) => Promise<ReconcileOutcome>;
+  probe: (parsed: ParsedUri, uri: string) => Promise<ReconcileOutcome>;
   onOk: (uri: string) => void;
   onNotFound: (uri: string) => void;
 }
@@ -84,7 +84,7 @@ export async function reconcileUriBatch(batch: ReconcileBatch): Promise<void> {
       );
       continue;
     }
-    const outcome = await batch.probe(parsed as ParsedUri);
+    const outcome = await batch.probe(parsed as ParsedUri, uri);
     applyOutcomeToBatch(batch, uri, outcome);
   }
 }

--- a/apps/pops-inventory-api/src/cron/reconcile-cross-pillar.ts
+++ b/apps/pops-inventory-api/src/cron/reconcile-cross-pillar.ts
@@ -137,7 +137,7 @@ export async function runReconciliation(options: {
     expectedPillar: 'finance',
     expectedType: 'transaction',
     parse: parseSoftUri,
-    probe: (parsed) =>
+    probe: (parsed, _uri) =>
       safeCall(() => finance.callDynamic('transactions', 'get', { id: parsed.id }, 'query')),
     onOk: (uri) => crossPillarUrisService.clearPurchaseTransactionUriStale(db, uri),
     onNotFound: (uri) => crossPillarUrisService.markPurchaseTransactionUriStale(db, uri, stampIso),
@@ -151,8 +151,7 @@ export async function runReconciliation(options: {
     expectedPillar: 'core',
     expectedType: 'user',
     parse: parseSoftUri,
-    probe: (parsed) =>
-      safeCall(() => core.callDynamic('users', 'get', { email: parsed.id }, 'query')),
+    probe: (_parsed, uri) => safeCall(() => core.callDynamic('users', 'get', { uri }, 'query')),
     onOk: (uri) => crossPillarUrisService.clearOwnerUriStale(db, uri),
     onNotFound: (uri) => crossPillarUrisService.markOwnerUriStale(db, uri, stampIso),
   });

--- a/docs/themes/13-pillar-finale/prds/251-cross-pillar-denorm-h7/README.md
+++ b/docs/themes/13-pillar-finale/prds/251-cross-pillar-denorm-h7/README.md
@@ -49,10 +49,11 @@ Cerebrum → media debrief denorm already landed.
 
 ## Acceptance Criteria
 
-- Zero `.references()` calls in `packages/{inventory,finance}-db/src/` cross a pillar boundary
-- Each cron has unit tests for ok / 404 / unavailable / bad-URI
-- Integration test boots core + inventory + finance, runs cron, asserts denorm cache
-- `pnpm typecheck/test/build` clean
+- [x] Zero `.references()` calls in `packages/{inventory,finance}-db/src/` cross a pillar boundary
+- [x] Cross-pillar wire contract is URI-shaped on every boundary call: input `{ uri: 'pops://<pillar>/<type>/<id>' }`, output `{ data: { uri } }`. Consumers pass the stored URI through end-to-end; the owning pillar parses internally.
+- [ ] Each cron has unit tests for ok / 404 / unavailable / bad-URI
+- [ ] Integration test boots core + inventory + finance, runs cron, asserts denorm cache
+- [ ] `pnpm typecheck/test/build` clean
 
 ## Out of Scope
 

--- a/packages/core-db/src/services/users.ts
+++ b/packages/core-db/src/services/users.ts
@@ -8,11 +8,12 @@
  * sibling pillar's reconciliation cron asks: "does this user URI still
  * resolve?".
  *
- * The cron resolves URIs of the form `pops://core/user/<email>`. If at
- * least one `user_settings` row exists for the given email we consider the
- * user known. The cron treats a `null` here as 404 — it stamps the
- * consumer row's `*_stale_at` rather than deleting it (PRD-251 §"Existence
- * is best-effort").
+ * The router accepts a URI (`pops://core/user/<email>`) per the PRD-251
+ * cross-pillar wire contract; this service is the email-shaped layer
+ * underneath. The router parses the URI and forwards the extracted email
+ * here. A `null` here is treated as 404 by the consumer — it stamps the
+ * consumer row's `*_stale_at` rather than deleting it (PRD-251
+ * §"Existence is best-effort").
  *
  * No write surface is exposed: owning-pillar writes are forbidden by the
  * PRD-251 business rules, and the dev-fallback email in `core-api/trpc.ts`


### PR DESCRIPTION
## Summary

PRD-251 §"Surface" calls for a URI-shaped cross-pillar wire contract: input `{ uri }`, output `{ data: { uri } }`. The two halves landed in #3296 disagreed on the shape:

- inventory cron called `core.users.get({ email })` (extracted from `parseSoftUri`)
- finance cron called `core.users.get({ uri })` (URI passed through)
- the handler accepted only `{ email }`, so finance-side reconciliation never resolved a single owner URI — every call short-circuited as a tRPC `BAD_REQUEST` and the row stayed in whatever stale state the previous tick left it.

## Unification

Per PRD-251, URI wins. Both sides now go through `core.users.get({ uri })`:

- `core.users.get` input is `{ uri }`; the router parses `pops://core/user/<email>` internally and maps malformed URIs to `BAD_REQUEST` and unresolved ones to `NOT_FOUND`. The response is `{ data: { uri } }` so the consumer can verify identity end-to-end.
- inventory cron's owner walker passes the stored URI through.
- finance `pillar-lookup` typing is corrected to the real handler shape.
- new `core.users.get` unit test covering happy / not-found / 5 malformed-URI variants / unauthorised.
- PRD-251 README §Acceptance Criteria ticks `Zero .references()` (still true from PRD-245) and adds an explicit clause pinning the URI wire contract.

Schema columns (`owner_uri`, `purchase_transaction_uri`) were already URI-shaped on both sides — no migration needed. The stale-marker column names differ between pillars (`owner_stale_at` on inventory vs `owner_uri_stale_at` on finance/core), but those are pillar-internal column names, not part of the cross-pillar contract; left alone.

## Test plan

- [x] `pnpm --filter @pops/inventory-api test` — 63/63 pass
- [x] `pnpm --filter @pops/finance-api test` — 39/39 pass
- [x] `pnpm --filter @pops/core-api test` — 144/144 pass (8 new in users router)
- [x] `pnpm --filter @pops/inventory-db test` — 130/130 pass
- [x] `pnpm --filter @pops/finance-db test` — 208/208 pass
- [x] `pnpm --filter @pops/core-db test` — 144/144 pass
- [x] `pnpm typecheck` — clean across 73 packages
- [x] `pnpm lint` — clean (warnings only, same set as main)
- [x] `pnpm format:check` — clean
- [x] `pnpm test` — 86/86 tasks pass
- [x] husky pre-commit hook green