### PR TITLE
feat(lists-api): PRD-252 US-06 regenerate Dockerfile via generator + drift-check

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -110,6 +110,12 @@ jobs:
           node scripts/generate-pillar-dockerfile.mjs food
           git diff --exit-code apps/pops-food-api/Dockerfile
 
+      - name: Verify pops-lists-api Dockerfile is up to date (PRD-252)
+        if: github.event_name == 'push' || needs.changes.outputs.relevant == 'true'
+        run: |
+          node scripts/generate-pillar-dockerfile.mjs lists
+          git diff --exit-code apps/pops-lists-api/Dockerfile
+
       - name: Build pops-core-api (builder stage)
         if: github.event_name == 'push' || needs.changes.outputs.relevant == 'true'
         run: docker build --target builder -f apps/pops-core-api/Dockerfile .

--- a/apps/pops-lists-api/Dockerfile
+++ b/apps/pops-lists-api/Dockerfile
@@ -1,123 +1,155 @@
+# DO NOT EDIT — regenerate with:
+#   node scripts/generate-pillar-dockerfile.mjs lists
+# CI drift-check (.github/workflows/docker-build.yml) fails on hand-edits.
+# PRD-252 / audit H-D1.
+
 FROM node:22-slim AS builder
 WORKDIR /app
 
-# Copy workspace root files
+# Workspace root manifests — needed for pnpm install to resolve.
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json .oxfmtrc.json ./
 
-# Copy workspace package.json files (for dep resolution)
-COPY packages/db-types/package.json ./packages/db-types/
-COPY packages/inventory-db/package.json ./packages/inventory-db/
-COPY packages/finance-db/package.json ./packages/finance-db/
-COPY packages/media-db/package.json ./packages/media-db/
-COPY packages/app-lists-db/package.json ./packages/app-lists-db/
-COPY packages/cerebrum-db/package.json ./packages/cerebrum-db/
-COPY packages/core-db/package.json ./packages/core-db/
-COPY packages/food-db/package.json ./packages/food-db/
-COPY packages/types/package.json ./packages/types/
-COPY packages/lists-db/package.json ./packages/lists-db/
-COPY packages/finance-contract/package.json ./packages/finance-contract/
-COPY packages/cerebrum-contract/package.json ./packages/cerebrum-contract/
-COPY packages/core-contract/package.json ./packages/core-contract/
-COPY packages/inventory-contract/package.json ./packages/inventory-contract/
-COPY packages/media-contract/package.json ./packages/media-contract/
-COPY packages/food-contract/package.json ./packages/food-contract/
-COPY packages/lists-contract/package.json ./packages/lists-contract/
-COPY packages/pillar-sdk/package.json ./packages/pillar-sdk/
+# Phase 1: every workspace package.json. pnpm-workspace.yaml lists every
+# member; if any are missing at install time pnpm fails with
+# ERR_PNPM_WORKSPACE_PKG_NOT_FOUND. src/ + migrations/ for non-transitive
+# packages are intentionally NOT copied (PRD-252 / audit H-D1).
+COPY apps/pops-api/package.json ./apps/pops-api/
+COPY apps/pops-cerebrum-api/package.json ./apps/pops-cerebrum-api/
+COPY apps/pops-cli/package.json ./apps/pops-cli/
+COPY apps/pops-core-api/package.json ./apps/pops-core-api/
+COPY apps/pops-docs/package.json ./apps/pops-docs/
+COPY apps/pops-finance-api/package.json ./apps/pops-finance-api/
+COPY apps/pops-food-api/package.json ./apps/pops-food-api/
+COPY apps/pops-ha-bridge-api/package.json ./apps/pops-ha-bridge-api/
+COPY apps/pops-inventory-api/package.json ./apps/pops-inventory-api/
 COPY apps/pops-lists-api/package.json ./apps/pops-lists-api/
+COPY apps/pops-mcp/package.json ./apps/pops-mcp/
+COPY apps/pops-media-api/package.json ./apps/pops-media-api/
+COPY apps/pops-shell/package.json ./apps/pops-shell/
+COPY apps/pops-storybook/package.json ./apps/pops-storybook/
+COPY apps/pops-worker-food/package.json ./apps/pops-worker-food/
+COPY packages/api-client/package.json ./packages/api-client/
+COPY packages/app-ai/package.json ./packages/app-ai/
+COPY packages/app-cerebrum/package.json ./packages/app-cerebrum/
+COPY packages/app-finance/package.json ./packages/app-finance/
+COPY packages/app-food/package.json ./packages/app-food/
+COPY packages/app-food-db/package.json ./packages/app-food-db/
+COPY packages/app-inventory/package.json ./packages/app-inventory/
+COPY packages/app-lists/package.json ./packages/app-lists/
+COPY packages/app-lists-db/package.json ./packages/app-lists-db/
+COPY packages/app-media/package.json ./packages/app-media/
+COPY packages/cerebrum-contract/package.json ./packages/cerebrum-contract/
+COPY packages/cerebrum-db/package.json ./packages/cerebrum-db/
+COPY packages/core-contract/package.json ./packages/core-contract/
+COPY packages/core-db/package.json ./packages/core-db/
+COPY packages/db-types/package.json ./packages/db-types/
+COPY packages/finance-contract/package.json ./packages/finance-contract/
+COPY packages/finance-db/package.json ./packages/finance-db/
+COPY packages/food-contract/package.json ./packages/food-contract/
+COPY packages/food-contracts/package.json ./packages/food-contracts/
+COPY packages/food-db/package.json ./packages/food-db/
+COPY packages/ha-bridge-db/package.json ./packages/ha-bridge-db/
+COPY packages/inventory-contract/package.json ./packages/inventory-contract/
+COPY packages/inventory-db/package.json ./packages/inventory-db/
+COPY packages/lists-contract/package.json ./packages/lists-contract/
+COPY packages/lists-db/package.json ./packages/lists-db/
+COPY packages/media-contract/package.json ./packages/media-contract/
+COPY packages/media-db/package.json ./packages/media-db/
+COPY packages/module-registry/package.json ./packages/module-registry/
+COPY packages/navigation/package.json ./packages/navigation/
+COPY packages/overlay-ego/package.json ./packages/overlay-ego/
+COPY packages/pillar-sdk/package.json ./packages/pillar-sdk/
+COPY packages/types/package.json ./packages/types/
+COPY packages/ui/package.json ./packages/ui/
+COPY packages/wire-conformance/package.json ./packages/wire-conformance/
 
-# Install pnpm and all workspace dependencies
+# Install pnpm + every workspace dependency.
 RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
     corepack enable && pnpm install --frozen-lockfile
 
-# Copy shared package sources
-COPY packages/db-types/src ./packages/db-types/src
-COPY packages/db-types/tsconfig.json ./packages/db-types/
-COPY packages/inventory-db/src ./packages/inventory-db/src
-COPY packages/inventory-db/tsconfig.json ./packages/inventory-db/
-COPY packages/inventory-db/migrations ./packages/inventory-db/migrations
-COPY packages/finance-db/src ./packages/finance-db/src
-COPY packages/finance-db/tsconfig.json ./packages/finance-db/
-COPY packages/finance-db/migrations ./packages/finance-db/migrations
-COPY packages/media-db/src ./packages/media-db/src
-COPY packages/media-db/tsconfig.json ./packages/media-db/
-COPY packages/media-db/migrations ./packages/media-db/migrations
+# Phase 2: sources for the transitive @pops/* deps of @pops/lists-api
+# (resolved via `pnpm m ls --filter "@pops/lists-api..." --json`).
+# A change in a non-listed package does NOT invalidate this image's
+# Phase 2 layer.
+# @pops/app-lists-db
 COPY packages/app-lists-db/src ./packages/app-lists-db/src
-COPY packages/app-lists-db/tsconfig.json ./packages/app-lists-db/
+COPY packages/app-lists-db/tsconfig.json ./packages/app-lists-db/tsconfig.json
+# @pops/cerebrum-contract
+COPY packages/cerebrum-contract/src ./packages/cerebrum-contract/src
+COPY packages/cerebrum-contract/scripts ./packages/cerebrum-contract/scripts
+COPY packages/cerebrum-contract/openapi ./packages/cerebrum-contract/openapi
+COPY packages/cerebrum-contract/tsconfig.json ./packages/cerebrum-contract/tsconfig.json
+# @pops/cerebrum-db
 COPY packages/cerebrum-db/src ./packages/cerebrum-db/src
-COPY packages/cerebrum-db/tsconfig.json ./packages/cerebrum-db/
 COPY packages/cerebrum-db/migrations ./packages/cerebrum-db/migrations
+COPY packages/cerebrum-db/tsconfig.json ./packages/cerebrum-db/tsconfig.json
+# @pops/core-contract
+COPY packages/core-contract/src ./packages/core-contract/src
+COPY packages/core-contract/scripts ./packages/core-contract/scripts
+COPY packages/core-contract/openapi ./packages/core-contract/openapi
+COPY packages/core-contract/tsconfig.json ./packages/core-contract/tsconfig.json
+# @pops/core-db
 COPY packages/core-db/src ./packages/core-db/src
-COPY packages/core-db/tsconfig.json ./packages/core-db/
 COPY packages/core-db/migrations ./packages/core-db/migrations
+COPY packages/core-db/tsconfig.json ./packages/core-db/tsconfig.json
+# @pops/db-types
+COPY packages/db-types/src ./packages/db-types/src
+COPY packages/db-types/scripts ./packages/db-types/scripts
+COPY packages/db-types/tsconfig.json ./packages/db-types/tsconfig.json
+# @pops/finance-contract
+COPY packages/finance-contract/src ./packages/finance-contract/src
+COPY packages/finance-contract/scripts ./packages/finance-contract/scripts
+COPY packages/finance-contract/openapi ./packages/finance-contract/openapi
+COPY packages/finance-contract/tsconfig.json ./packages/finance-contract/tsconfig.json
+# @pops/finance-db
+COPY packages/finance-db/src ./packages/finance-db/src
+COPY packages/finance-db/migrations ./packages/finance-db/migrations
+COPY packages/finance-db/tsconfig.json ./packages/finance-db/tsconfig.json
+# @pops/food-db
 COPY packages/food-db/src ./packages/food-db/src
-COPY packages/food-db/tsconfig.json ./packages/food-db/
 COPY packages/food-db/migrations ./packages/food-db/migrations
-COPY packages/types/src ./packages/types/src
-COPY packages/types/tsconfig.json packages/types/tsconfig.build.json ./packages/types/
+COPY packages/food-db/tsconfig.json ./packages/food-db/tsconfig.json
+# @pops/inventory-contract
+COPY packages/inventory-contract/src ./packages/inventory-contract/src
+COPY packages/inventory-contract/scripts ./packages/inventory-contract/scripts
+COPY packages/inventory-contract/openapi ./packages/inventory-contract/openapi
+COPY packages/inventory-contract/tsconfig.json ./packages/inventory-contract/tsconfig.json
+# @pops/inventory-db
+COPY packages/inventory-db/src ./packages/inventory-db/src
+COPY packages/inventory-db/migrations ./packages/inventory-db/migrations
+COPY packages/inventory-db/tsconfig.json ./packages/inventory-db/tsconfig.json
+# @pops/lists-db
 COPY packages/lists-db/src ./packages/lists-db/src
-COPY packages/lists-db/tsconfig.json ./packages/lists-db/
 COPY packages/lists-db/migrations ./packages/lists-db/migrations
-COPY packages/finance-contract/ ./packages/finance-contract/
-COPY packages/cerebrum-contract/ ./packages/cerebrum-contract/
-COPY packages/core-contract/ ./packages/core-contract/
-COPY packages/inventory-contract/ ./packages/inventory-contract/
-COPY packages/media-contract/ ./packages/media-contract/
-COPY packages/food-contract/ ./packages/food-contract/
-COPY packages/lists-contract/ ./packages/lists-contract/
-COPY packages/pillar-sdk/ ./packages/pillar-sdk/
+COPY packages/lists-db/tsconfig.json ./packages/lists-db/tsconfig.json
+# @pops/media-contract
+COPY packages/media-contract/src ./packages/media-contract/src
+COPY packages/media-contract/scripts ./packages/media-contract/scripts
+COPY packages/media-contract/openapi ./packages/media-contract/openapi
+COPY packages/media-contract/tsconfig.json ./packages/media-contract/tsconfig.json
+# @pops/media-db
+COPY packages/media-db/src ./packages/media-db/src
+COPY packages/media-db/migrations ./packages/media-db/migrations
+COPY packages/media-db/tsconfig.json ./packages/media-db/tsconfig.json
+# @pops/pillar-sdk
+COPY packages/pillar-sdk/src ./packages/pillar-sdk/src
+COPY packages/pillar-sdk/tsconfig.json ./packages/pillar-sdk/tsconfig.json
+# @pops/types
+COPY packages/types/src ./packages/types/src
+COPY packages/types/tsconfig.json ./packages/types/tsconfig.json
+COPY packages/types/tsconfig.build.json ./packages/types/tsconfig.build.json
 
-# Copy lists-api source
-COPY apps/pops-lists-api/tsconfig.json ./apps/pops-lists-api/
+# Pillar app sources.
 COPY apps/pops-lists-api/src ./apps/pops-lists-api/src
+COPY apps/pops-lists-api/tsconfig.json ./apps/pops-lists-api/tsconfig.json
 
-# Build shared packages first.
-# media-db / inventory-db / app-lists-db / cerebrum-db / food-db /
-# finance-db / core-db own canonical schemas; db-types re-exports them
-# via a transition shim, so all seven MUST build BEFORE db-types
-# (PRD-245 US-01 cerebrum + US-02 inventory + US-03 finance + US-04
-# media + US-05 food + US-06 lists + US-07 core / audit H6).
-WORKDIR /app/packages/media-db
-RUN pnpm build
-WORKDIR /app/packages/inventory-db
-RUN pnpm build
-WORKDIR /app/packages/app-lists-db
-RUN pnpm build
-WORKDIR /app/packages/cerebrum-db
-RUN pnpm build
-WORKDIR /app/packages/food-db
-RUN pnpm build
-WORKDIR /app/packages/core-db
-RUN pnpm build
-WORKDIR /app/packages/finance-db
-RUN pnpm build
-WORKDIR /app/packages/db-types
-RUN pnpm build
-WORKDIR /app/packages/types
-RUN pnpm build
-WORKDIR /app/packages/lists-db
-RUN pnpm build
-WORKDIR /app/packages/finance-contract
-RUN pnpm build
-WORKDIR /app/packages/cerebrum-contract
-RUN pnpm build
-WORKDIR /app/packages/core-contract
-RUN pnpm build
-WORKDIR /app/packages/inventory-contract
-RUN pnpm build
-WORKDIR /app/packages/media-contract
-RUN pnpm build
-WORKDIR /app/packages/food-contract
-RUN pnpm build
-WORKDIR /app/packages/lists-contract
-RUN pnpm build
-WORKDIR /app/packages/pillar-sdk
-RUN pnpm build
+# Phase 3: build shared deps in pnpm topology order, then the app.
+# `^...` expands to every dependency of the target excluding the target,
+# letting pnpm compute build order from the lockfile (see #3285).
+RUN pnpm --filter "@pops/lists-api^..." build
+RUN pnpm --filter "@pops/lists-api" build
 
-# Build lists-api
-WORKDIR /app/apps/pops-lists-api
-RUN pnpm build
-
-# Create standalone deployment (production deps only, no symlinks)
+# Standalone deployment (production deps only, no symlinks).
 RUN pnpm --filter @pops/lists-api deploy --prod --legacy /app/deploy
 
 FROM node:22-slim
@@ -127,16 +159,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf 
 COPY --from=builder --chown=node:node /app/deploy ./
 COPY --from=builder --chown=node:node /app/apps/pops-lists-api/dist ./dist
 
-# Bundled migrations so openListsDb's import.meta.url-relative
-# `migrations/` lookup finds the journal at runtime under the deployed
-# node_modules layout. The opener computes the path from its own module
-# URL (`<pkg>/dist/open-lists-db.js` → `<pkg>/migrations/`), so the
-# folder has to land next to the built dist inside @pops/lists-db.
-COPY --from=builder --chown=node:node /app/packages/lists-db/migrations ./node_modules/@pops/lists-db/migrations
-
 ARG BUILD_VERSION=dev
 ENV BUILD_VERSION=$BUILD_VERSION
 
-EXPOSE 3006
+EXPOSE 3001
 USER node
 CMD ["node", "dist/server.js"]

--- a/docs/themes/13-pillar-finale/prds/252-per-pillar-dockerfile-isolation-hd1/README.md
+++ b/docs/themes/13-pillar-finale/prds/252-per-pillar-dockerfile-isolation-hd1/README.md
@@ -45,7 +45,7 @@ The Dockerfile comments blame pnpm workspace resolver, but only the package.json
 | 03  | finance Dockerfile                           | Not started | Parallel after US-01 |
 | 04  | inventory Dockerfile                         | Not started | Parallel after US-01 |
 | 05  | food Dockerfile                              | Done        | Parallel after US-01 |
-| 06  | lists Dockerfile                             | Not started | Parallel after US-01 |
+| 06  | lists Dockerfile                             | Done        | Parallel after US-01 |
 | 07  | media Dockerfile                             | Not started | Parallel after US-01 |
 
 ## Acceptance Criteria


### PR DESCRIPTION
## Summary

- Regenerate `apps/pops-lists-api/Dockerfile` via `scripts/generate-pillar-dockerfile.mjs` (introduced in PRD-252 US-01, #3290). Phase 2 narrows source copies to the 16 transitive `@pops/*` deps of `@pops/lists-api`; non-transitive packages keep only their `package.json` in Phase 1 so pnpm install can still resolve the workspace.
- Net effect: a food-contract, food-contracts or ha-bridge-db change no longer invalidates the lists-api image Phase 2 layer (audit H-D1 for the lists pillar).
- Add a drift-check step to `.github/workflows/docker-build.yml` that regenerates the lists Dockerfile and runs `git diff --exit-code`, mirroring the core-api step. Any hand-edit or stale regeneration fails the PR.

Updates PRD-252 README to tick US-06 as Done.

## Test plan

- [x] `node scripts/generate-pillar-dockerfile.mjs lists` runs clean (16 transitive deps reported)
- [x] `docker buildx build --target builder -f apps/pops-lists-api/Dockerfile .` succeeds locally
- [x] `pnpm typecheck --filter @pops/lists-api` green
- [x] `pnpm lint` green (warnings only)
- [x] Husky pre-commit hook green
- [ ] CI drift-check passes on this PR; force a hand-edit on the Dockerfile to verify the drift-check rejects it (manual)
