### PR TITLE
fix(pillar-sdk): align registry endpoint paths with server router

### DIFF
--- a/packages/pillar-sdk/src/bootstrap/__tests__/transport.test.ts
+++ b/packages/pillar-sdk/src/bootstrap/__tests__/transport.test.ts
@@ -26,7 +26,7 @@ function mockFetch(
 }
 
 describe('createHttpRegistryTransport', () => {
-  it('POSTs the manifest to /registry/register', async () => {
+  it('POSTs the manifest to /core.registry.register', async () => {
     const fetchImpl = mockFetch([{ status: 200, body: { pillarId: 'finance' } }]);
     const transport = createHttpRegistryTransport({
       baseUrl: 'http://registry.test',
@@ -37,7 +37,7 @@ describe('createHttpRegistryTransport', () => {
     expect(result.pillarId).toBe('finance');
     expect(fetchImpl).toHaveBeenCalledOnce();
     const [url, init] = (fetchImpl as ReturnType<typeof vi.fn>).mock.calls[0]!;
-    expect(url).toBe('http://registry.test/registry/register');
+    expect(url).toBe('http://registry.test/core.registry.register');
     expect((init as RequestInit).method).toBe('POST');
   });
 

--- a/packages/pillar-sdk/src/bootstrap/transport.ts
+++ b/packages/pillar-sdk/src/bootstrap/transport.ts
@@ -97,13 +97,13 @@ export function createHttpRegistryTransport(
 
   return {
     async register(payload) {
-      return post<RegistrationResult>('/registry/register', payload);
+      return post<RegistrationResult>('/core.registry.register', payload);
     },
     async heartbeat(pillarId) {
-      return post<HeartbeatResult>('/registry/heartbeat', { pillarId });
+      return post<HeartbeatResult>('/core.registry.heartbeat', { pillarId });
     },
     async unregister(pillarId) {
-      await post<void>('/registry/unregister', { pillarId });
+      await post<void>('/core.registry.deregister', { pillarId });
     },
   };
 }


### PR DESCRIPTION
## Summary

SDK transport posted to `/registry/{register,heartbeat,unregister}` but the server only exposes `/core.registry.{register,heartbeat,deregister}` (see `apps/pops-core-api/src/app.ts:52-72`). Result: every pillar boot with `POPS_REGISTRY_ENABLED=true` crashes with `PillarRegistrationRejectedError` 404, taking down `pops-core-api` and every pillar that depends on it.

Discovered when PRD-250's compose env flag landed on capivara — homelab Deploy workflow failed with `pops-core-api is unhealthy` and `dependency core-api failed to start`; `docker logs pops-core-api` showed the exception loop on every boot attempt.

`/registry/subscribe` stays unchanged — both SDK and server agree on that one.

## Why this didn't surface before

PRD-250 was the first time `POPS_REGISTRY_ENABLED=true` reached the running containers. Before that, the bootstrap was gated off so the SDK transport was dead code path in prod.

## Changes

- `packages/pillar-sdk/src/bootstrap/transport.ts` — register/heartbeat/unregister now POST to `/core.registry.*`
- `packages/pillar-sdk/src/bootstrap/__tests__/transport.test.ts` — assertion updated

## Validation

- `pnpm --filter @pops/pillar-sdk test` 554/554 green
- `pnpm typecheck` clean (after rebase + contract build)
- husky pre-push green

## Deploy path

After merge → Publish Images on main → watchtower pulls or manual `docker compose up -d` on capivara → core-api boots clean → MCP `tools/call` works.