### PR TITLE
fix(shell): drop public nginx exposure of /core.registry.* endpoints

### DIFF
--- a/apps/pops-shell/nginx.conf
+++ b/apps/pops-shell/nginx.conf
@@ -169,30 +169,12 @@ server {
         proxy_send_timeout 10s;
     }
 
-    # External pillar registration HTTP-JSON surface (Theme 13 PRD-228).
-    #
-    # External services (pillars shipped from a different repo, running
-    # on the same docker network) POST a manifest + shared API key to
-    # `/core.registry.register` to appear in the dispatcher with no code
-    # change in `pops/`. The internal `/trpc/core.registry.*` surface
-    # stays blocked from external traffic; this sibling path is the
-    # explicit allow-list.
-    #
-    # US-02 adds `/core.registry.heartbeat` (per-tick liveness ping) and
-    # US-04 adds `/core.registry.deregister` (clean shutdown). All three
-    # are gated by the same shared `POPS_INTERNAL_API_KEY` in core-api.
-    location ~ ^/core\.registry\.(register|heartbeat|deregister)$ {
-        set $core_registry_upstream http://core-api:3001;
-        proxy_pass $core_registry_upstream;
-        proxy_http_version 1.1;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_connect_timeout 5s;
-        proxy_read_timeout 10s;
-        proxy_send_timeout 10s;
-    }
+    # NOTE: `/core.registry.{register,heartbeat,deregister}` are deliberately
+    # NOT exposed by this public nginx. Pillar registration runs entirely
+    # within the docker network — each pillar-api boots and POSTs directly
+    # to `http://core-api:3001/core.registry.register` over the internal
+    # bridge. Removing the public allow-list closes the only path an
+    # external caller could have reached the registration surface from.
 
     location ~ ^/pillars/health/?$ {
         proxy_pass http://pops-api:3000;

--- a/apps/pops-shell/scripts/nginx-conf-template.ts
+++ b/apps/pops-shell/scripts/nginx-conf-template.ts
@@ -133,30 +133,12 @@ export const NGINX_CONF_TAIL = `    # Legacy tRPC catch-all → pops-api.
         proxy_send_timeout 10s;
     }
 
-    # External pillar registration HTTP-JSON surface (Theme 13 PRD-228).
-    #
-    # External services (pillars shipped from a different repo, running
-    # on the same docker network) POST a manifest + shared API key to
-    # \`/core.registry.register\` to appear in the dispatcher with no code
-    # change in \`pops/\`. The internal \`/trpc/core.registry.*\` surface
-    # stays blocked from external traffic; this sibling path is the
-    # explicit allow-list.
-    #
-    # US-02 adds \`/core.registry.heartbeat\` (per-tick liveness ping) and
-    # US-04 adds \`/core.registry.deregister\` (clean shutdown). All three
-    # are gated by the same shared \`POPS_INTERNAL_API_KEY\` in core-api.
-    location ~ ^/core\\.registry\\.(register|heartbeat|deregister)$ {
-        set $core_registry_upstream http://core-api:3001;
-        proxy_pass $core_registry_upstream;
-        proxy_http_version 1.1;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_connect_timeout 5s;
-        proxy_read_timeout 10s;
-        proxy_send_timeout 10s;
-    }
+    # NOTE: \`/core.registry.{register,heartbeat,deregister}\` are deliberately
+    # NOT exposed by this public nginx. Pillar registration runs entirely
+    # within the docker network — each pillar-api boots and POSTs directly
+    # to \`http://core-api:3001/core.registry.register\` over the internal
+    # bridge. Removing the public allow-list closes the only path an
+    # external caller could have reached the registration surface from.
 
     location ~ ^/pillars/health/?$ {
         proxy_pass http://pops-api:3000;


### PR DESCRIPTION
## Summary

The shell's public nginx had an explicit allow-list at `/core.registry.{register,heartbeat,deregister}` proxying upstream to core-api:3001. Combined with the (shared) API key being the only auth, that surface was the public-facing registration boundary.

Pillars actually register **within** the docker network — each pillar-api boots and POSTs directly to `http://core-api:3001/core.registry.register` over the internal bridge. The public nginx allow-list was never needed; it was over-permissive scaffolding from PRD-228.

## After this lands

| Caller | Path | Behaviour |
|---|---|---|
| Pillar inside docker network | `http://core-api:3001/core.registry.register` | ✅ works |
| External browser → `https://shell.example.com/core.registry.register` | nginx | 404 (closes the hole) |
| Shell's nginx generator | `/trpc/core.registry.list` (read) | ✅ unchanged |

## Unblocks

- API-key removal (separate PR in flight): safe to drop the shared key entirely now that no public path reaches the register/heartbeat/deregister surface.
- PRD-250 self-register: pillars register over the docker network; no further auth needed.

## Validation

- `pnpm typecheck` clean
- `pnpm lint` clean
- nginx.conf still has 14 location blocks (was 15)
- No tests assert on the removed location