### PR TITLE
fix(pillar-sdk): send envelope { pillarId, baseUrl, manifest } to /core.registry.register

### DIFF
--- a/apps/pops-cerebrum-api/src/server.ts
+++ b/apps/pops-cerebrum-api/src/server.ts
@@ -39,8 +39,22 @@ function resolvePort(): number {
   return parsed;
 }
 
+function resolveSelfBaseUrl(port: number): string {
+  const raw = process.env['CEREBRUM_SELF_BASE_URL'] ?? `http://cerebrum-api:${String(port)}`;
+  try {
+    new URL(raw);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`[cerebrum-api] CEREBRUM_SELF_BASE_URL ${raw} is invalid — ${message}`, {
+      cause: err,
+    });
+  }
+  return raw;
+}
+
 const port = resolvePort();
 const version = process.env['BUILD_VERSION'] ?? 'dev';
+const selfBaseUrl = resolveSelfBaseUrl(port);
 
 const cerebrumDb = openCerebrumDb(resolveCerebrumSqlitePath());
 const coreDb = openCoreDb(resolveCoreSqlitePath());
@@ -48,7 +62,10 @@ const app = createCerebrumApiApp({ cerebrumDb, coreDb, version });
 
 let pillarHandle: PillarBootstrapHandle | undefined;
 if (process.env['POPS_REGISTRY_ENABLED'] === 'true') {
-  pillarHandle = await bootstrapPillar({ manifest: buildCerebrumManifest(version) });
+  pillarHandle = await bootstrapPillar({
+    manifest: buildCerebrumManifest(version),
+    baseUrl: selfBaseUrl,
+  });
 }
 
 const server = app.listen(port, () => {

--- a/apps/pops-core-api/src/server.ts
+++ b/apps/pops-core-api/src/server.ts
@@ -70,7 +70,10 @@ const stopEvictionTicker = startEvictionTicker(coreDb.db);
 // HTTP server up.
 let pillarHandle: PillarBootstrapHandle | undefined;
 if (process.env['POPS_REGISTRY_ENABLED'] === 'true') {
-  pillarHandle = await bootstrapPillar({ manifest: buildCoreManifest(version) });
+  pillarHandle = await bootstrapPillar({
+    manifest: buildCoreManifest(version),
+    baseUrl: selfBaseUrl,
+  });
 }
 
 let shuttingDown = false;

--- a/apps/pops-finance-api/src/server.ts
+++ b/apps/pops-finance-api/src/server.ts
@@ -43,8 +43,22 @@ function resolvePort(): number {
   return parsed;
 }
 
+function resolveSelfBaseUrl(port: number): string {
+  const raw = process.env['FINANCE_SELF_BASE_URL'] ?? `http://finance-api:${String(port)}`;
+  try {
+    new URL(raw);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`[finance-api] FINANCE_SELF_BASE_URL ${raw} is invalid — ${message}`, {
+      cause: err,
+    });
+  }
+  return raw;
+}
+
 const port = resolvePort();
 const version = process.env['BUILD_VERSION'] ?? '0.1.0';
+const selfBaseUrl = resolveSelfBaseUrl(port);
 
 const financeDb = openFinanceDb(resolveFinanceSqlitePath());
 const coreDb = openCoreDb(resolveCoreSqlitePath());
@@ -52,7 +66,10 @@ const app = createFinanceApiApp({ financeDb, coreDb, version });
 
 let pillarHandle: PillarBootstrapHandle | undefined;
 if (process.env['POPS_REGISTRY_ENABLED'] === 'true') {
-  pillarHandle = await bootstrapPillar({ manifest: buildFinanceManifest(version) });
+  pillarHandle = await bootstrapPillar({
+    manifest: buildFinanceManifest(version),
+    baseUrl: selfBaseUrl,
+  });
 }
 
 const reconcileHandle = startReconcileCrossPillarWorker({

--- a/apps/pops-food-api/src/server.ts
+++ b/apps/pops-food-api/src/server.ts
@@ -70,7 +70,10 @@ const app = createFoodApiApp({ foodDb, version, selfBaseUrl });
 
 let pillarHandle: PillarBootstrapHandle | undefined;
 if (process.env['POPS_REGISTRY_ENABLED'] === 'true') {
-  pillarHandle = await bootstrapPillar({ manifest: buildFoodManifest(version) });
+  pillarHandle = await bootstrapPillar({
+    manifest: buildFoodManifest(version),
+    baseUrl: selfBaseUrl,
+  });
 }
 
 const server = app.listen(port, () => {

--- a/apps/pops-ha-bridge-api/src/server.ts
+++ b/apps/pops-ha-bridge-api/src/server.ts
@@ -43,6 +43,19 @@ function resolvePort(): number {
   return parsed;
 }
 
+function resolveSelfBaseUrl(port: number): string {
+  const raw = process.env['HA_BRIDGE_SELF_BASE_URL'] ?? `http://ha-bridge-api:${String(port)}`;
+  try {
+    new URL(raw);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`[ha-bridge] HA_BRIDGE_SELF_BASE_URL ${raw} is invalid — ${message}`, {
+      cause: err,
+    });
+  }
+  return raw;
+}
+
 function defaultWebSocketFactory(url: string): HaWebSocketLike {
   const ws = new WsWebSocket(url);
   return {
@@ -67,6 +80,7 @@ function defaultWebSocketFactory(url: string): HaWebSocketLike {
 }
 
 const port = resolvePort();
+const selfBaseUrl = resolveSelfBaseUrl(port);
 const version = process.env['BUILD_VERSION'] ?? '0.1.0';
 const haUrl = process.env['HA_URL'];
 const haToken = process.env['HA_TOKEN'];
@@ -99,7 +113,7 @@ const app = createHaBridgeApiApp({ manifest, version, subscriber });
 
 let pillarHandle: PillarBootstrapHandle | undefined;
 if (process.env['POPS_REGISTRY_ENABLED'] === 'true') {
-  pillarHandle = await bootstrapPillar({ manifest });
+  pillarHandle = await bootstrapPillar({ manifest, baseUrl: selfBaseUrl });
 }
 
 subscriber.start();

--- a/apps/pops-inventory-api/src/server.ts
+++ b/apps/pops-inventory-api/src/server.ts
@@ -67,7 +67,10 @@ const app = createInventoryApiApp({ inventoryDb, coreDb, version, selfBaseUrl })
 
 let pillarHandle: PillarBootstrapHandle | undefined;
 if (process.env['POPS_REGISTRY_ENABLED'] === 'true') {
-  pillarHandle = await bootstrapPillar({ manifest: buildInventoryManifest(version) });
+  pillarHandle = await bootstrapPillar({
+    manifest: buildInventoryManifest(version),
+    baseUrl: selfBaseUrl,
+  });
 }
 
 const server = app.listen(port, () => {

--- a/apps/pops-lists-api/src/server.ts
+++ b/apps/pops-lists-api/src/server.ts
@@ -71,7 +71,10 @@ const app = createListsApiApp({ listsDb, version, selfBaseUrl });
 
 let pillarHandle: PillarBootstrapHandle | undefined;
 if (process.env['POPS_REGISTRY_ENABLED'] === 'true') {
-  pillarHandle = await bootstrapPillar({ manifest: buildListsManifest(version) });
+  pillarHandle = await bootstrapPillar({
+    manifest: buildListsManifest(version),
+    baseUrl: selfBaseUrl,
+  });
 }
 
 const server = app.listen(port, () => {

--- a/apps/pops-media-api/src/server.ts
+++ b/apps/pops-media-api/src/server.ts
@@ -35,8 +35,22 @@ function resolvePort(): number {
   return parsed;
 }
 
+function resolveSelfBaseUrl(port: number): string {
+  const raw = process.env['MEDIA_SELF_BASE_URL'] ?? `http://media-api:${String(port)}`;
+  try {
+    new URL(raw);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`[media-api] MEDIA_SELF_BASE_URL ${raw} is invalid — ${message}`, {
+      cause: err,
+    });
+  }
+  return raw;
+}
+
 const port = resolvePort();
 const version = process.env['BUILD_VERSION'] ?? 'dev';
+const selfBaseUrl = resolveSelfBaseUrl(port);
 
 const mediaDb = openMediaDb(resolveMediaSqlitePath());
 // PRD-065 retention cleanup: the shelf-impressions service runs once at
@@ -47,7 +61,10 @@ const app = createMediaApiApp({ mediaDb, version });
 
 let pillarHandle: PillarBootstrapHandle | undefined;
 if (process.env['POPS_REGISTRY_ENABLED'] === 'true') {
-  pillarHandle = await bootstrapPillar({ manifest: buildMediaManifest(version) });
+  pillarHandle = await bootstrapPillar({
+    manifest: buildMediaManifest(version),
+    baseUrl: selfBaseUrl,
+  });
 }
 
 const server = app.listen(port, () => {

--- a/packages/pillar-sdk/src/bootstrap/__tests__/bootstrap.test.ts
+++ b/packages/pillar-sdk/src/bootstrap/__tests__/bootstrap.test.ts
@@ -10,17 +10,21 @@ import {
 import {
   RegistryNetworkError,
   RegistryTransportError,
+  type RegisterRequest,
   type RegistryTransport,
 } from '../transport.js';
 
 import type { ManifestPayload } from '../../manifest-schema/schema.js';
+
+const TEST_BASE_URL = 'http://finance-api:3004';
 
 interface RecordedTransport extends RegistryTransport {
   registerCalls: number;
   heartbeatCalls: number;
   unregisterCalls: number;
   heartbeats: string[];
-  lastRegisterPayload: () => ManifestPayload | undefined;
+  lastRegisterPayload: () => RegisterRequest | undefined;
+  lastRegisterManifest: () => ManifestPayload | undefined;
 }
 
 interface MakeTransportOptions {
@@ -30,18 +34,19 @@ interface MakeTransportOptions {
 }
 
 function makeTransport(options: MakeTransportOptions = {}): RecordedTransport {
-  let lastPayload: ManifestPayload | undefined;
+  let lastPayload: RegisterRequest | undefined;
   const state: RecordedTransport = {
     registerCalls: 0,
     heartbeatCalls: 0,
     unregisterCalls: 0,
     heartbeats: [],
     lastRegisterPayload: () => lastPayload,
+    lastRegisterManifest: () => lastPayload?.manifest,
     async register(payload) {
       state.registerCalls += 1;
       lastPayload = payload;
       if (options.registerImpl) return options.registerImpl();
-      return { pillarId: payload.pillar };
+      return { pillarId: payload.manifest.pillar };
     },
     async heartbeat(pillarId) {
       state.heartbeatCalls += 1;
@@ -78,6 +83,7 @@ describe('bootstrapPillar', () => {
     const transport = makeTransport();
     const handle = await bootstrapPillar({
       manifest: validManifest(),
+      baseUrl: TEST_BASE_URL,
       transport,
       logger: silentLogger(),
       heartbeatMs: 1_000,
@@ -99,16 +105,20 @@ describe('bootstrapPillar', () => {
     const transport = makeTransport();
     const handle = await bootstrapPillar({
       manifest,
+      baseUrl: TEST_BASE_URL,
       transport,
       logger: silentLogger(),
     });
 
     expect(transport.registerCalls).toBe(1);
     expect(handle.pillarId).toBe('finance');
-    const sent = transport.lastRegisterPayload();
+    const sent = transport.lastRegisterManifest();
     expect(sent?.version).toBe('0.0.0-sha.9c163ed');
     expect(sent?.contract.version).toBe('0.0.0-sha.9c163ed');
     expect(sent?.contract.tag).toBe('contract-finance@v0.0.0-sha.9c163ed');
+    const envelope = transport.lastRegisterPayload();
+    expect(envelope?.pillarId).toBe('finance');
+    expect(envelope?.baseUrl).toBe(TEST_BASE_URL);
 
     await handle.stop();
   });
@@ -120,9 +130,9 @@ describe('bootstrapPillar', () => {
     manifest.contract.tag = 'contract-finance@v1.2.3';
 
     const transport = makeTransport();
-    await bootstrapPillar({ manifest, transport, logger: silentLogger() });
+    await bootstrapPillar({ manifest, baseUrl: TEST_BASE_URL, transport, logger: silentLogger() });
 
-    const sent = transport.lastRegisterPayload();
+    const sent = transport.lastRegisterManifest();
     expect(sent?.version).toBe('1.2.3');
     expect(sent?.contract.tag).toBe('contract-finance@v1.2.3');
   });
@@ -135,6 +145,7 @@ describe('bootstrapPillar', () => {
     await expect(
       bootstrapPillar({
         manifest: bad,
+        baseUrl: TEST_BASE_URL,
         transport,
         logger: silentLogger(),
       })
@@ -151,6 +162,7 @@ describe('bootstrapPillar', () => {
     try {
       await bootstrapPillar({
         manifest: bad,
+        baseUrl: TEST_BASE_URL,
         transport: makeTransport(),
         logger: silentLogger(),
       });
@@ -184,6 +196,7 @@ describe('bootstrapPillar', () => {
     await expect(
       bootstrapPillar({
         manifest: validManifest(),
+        baseUrl: TEST_BASE_URL,
         transport,
         logger: silentLogger(),
       })
@@ -201,6 +214,7 @@ describe('bootstrapPillar', () => {
 
     const promise = bootstrapPillar({
       manifest: validManifest(),
+      baseUrl: TEST_BASE_URL,
       transport,
       logger: silentLogger(),
       maxRegisterAttempts: 3,
@@ -236,6 +250,7 @@ describe('bootstrapPillar', () => {
 
     const promise = bootstrapPillar({
       manifest: validManifest(),
+      baseUrl: TEST_BASE_URL,
       transport,
       logger: silentLogger(),
       heartbeatMs: 1_000_000,
@@ -268,6 +283,7 @@ describe('bootstrapPillar', () => {
 
     const promise = bootstrapPillar({
       manifest: validManifest(),
+      baseUrl: TEST_BASE_URL,
       transport,
       logger: silentLogger(),
       heartbeatMs: 1_000_000,
@@ -286,6 +302,7 @@ describe('bootstrapPillar', () => {
     const transport = makeTransport();
     const handle = await bootstrapPillar({
       manifest: validManifest(),
+      baseUrl: TEST_BASE_URL,
       transport,
       logger: silentLogger(),
       heartbeatMs: 1_000,
@@ -307,6 +324,7 @@ describe('bootstrapPillar', () => {
     const transport = makeTransport();
     const handle = await bootstrapPillar({
       manifest: validManifest(),
+      baseUrl: TEST_BASE_URL,
       transport,
       logger: silentLogger(),
       heartbeatMs: 500,
@@ -326,6 +344,7 @@ describe('bootstrapPillar', () => {
     const transport = makeTransport();
     const handle = await bootstrapPillar({
       manifest: validManifest(),
+      baseUrl: TEST_BASE_URL,
       transport,
       logger: silentLogger(),
       heartbeatMs: 1_000,
@@ -351,6 +370,7 @@ describe('bootstrapPillar', () => {
 
     const handle = await bootstrapPillar({
       manifest: validManifest(),
+      baseUrl: TEST_BASE_URL,
       transport,
       logger,
       heartbeatMs: 100,
@@ -387,6 +407,7 @@ describe('bootstrapPillar', () => {
     const transport = makeTransport();
     const handle = await bootstrapPillar({
       manifest: validManifest(),
+      baseUrl: TEST_BASE_URL,
       app,
       transport,
       logger: silentLogger(),
@@ -426,6 +447,7 @@ describe('bootstrapPillar', () => {
 
     const handle = await bootstrapPillar({
       manifest: validManifest(),
+      baseUrl: TEST_BASE_URL,
       transport,
       logger: silentLogger(),
       heartbeatMs: 1_000,

--- a/packages/pillar-sdk/src/bootstrap/__tests__/transport.test.ts
+++ b/packages/pillar-sdk/src/bootstrap/__tests__/transport.test.ts
@@ -25,20 +25,45 @@ function mockFetch(
   return vi.fn(fn);
 }
 
+function envelope(): {
+  pillarId: string;
+  baseUrl: string;
+  manifest: ReturnType<typeof validManifest>;
+} {
+  const manifest = validManifest();
+  return {
+    pillarId: manifest.pillar,
+    baseUrl: 'http://finance-api:3004',
+    manifest,
+  };
+}
+
 describe('createHttpRegistryTransport', () => {
-  it('POSTs the manifest to /core.registry.register', async () => {
+  it('POSTs the envelope to /core.registry.register', async () => {
     const fetchImpl = mockFetch([{ status: 200, body: { pillarId: 'finance' } }]);
     const transport = createHttpRegistryTransport({
       baseUrl: 'http://registry.test',
       fetchImpl,
     });
 
-    const result = await transport.register(validManifest());
+    const payload = envelope();
+    const result = await transport.register(payload);
     expect(result.pillarId).toBe('finance');
     expect(fetchImpl).toHaveBeenCalledOnce();
     const [url, init] = (fetchImpl as ReturnType<typeof vi.fn>).mock.calls[0]!;
     expect(url).toBe('http://registry.test/core.registry.register');
     expect((init as RequestInit).method).toBe('POST');
+    const bodyText = (init as RequestInit).body;
+    expect(typeof bodyText).toBe('string');
+    const sent = JSON.parse(bodyText as string) as {
+      pillarId: string;
+      baseUrl: string;
+      manifest: { pillar: string };
+    };
+    expect(sent.pillarId).toBe('finance');
+    expect(sent.baseUrl).toBe('http://finance-api:3004');
+    expect(sent.manifest.pillar).toBe('finance');
+    expect(Object.prototype.hasOwnProperty.call(sent, 'apiKey')).toBe(false);
   });
 
   it('throws RegistryNetworkError when fetch rejects', async () => {
@@ -48,7 +73,7 @@ describe('createHttpRegistryTransport', () => {
       fetchImpl,
     });
 
-    await expect(transport.register(validManifest())).rejects.toBeInstanceOf(RegistryNetworkError);
+    await expect(transport.register(envelope())).rejects.toBeInstanceOf(RegistryNetworkError);
   });
 
   it('throws non-retriable RegistryTransportError on 400 with parsed issues', async () => {
@@ -66,7 +91,7 @@ describe('createHttpRegistryTransport', () => {
     });
 
     try {
-      await transport.register(validManifest());
+      await transport.register(envelope());
       expect.fail('should have thrown');
     } catch (err) {
       expect(err).toBeInstanceOf(RegistryTransportError);

--- a/packages/pillar-sdk/src/bootstrap/bootstrap.ts
+++ b/packages/pillar-sdk/src/bootstrap/bootstrap.ts
@@ -8,6 +8,15 @@ import { createHttpRegistryTransport, type RegistryTransport } from './transport
 
 export interface BootstrapPillarOptions {
   manifest: ManifestPayload;
+  /**
+   * Base URL the registry should record for this pillar — the address
+   * other pillars dial to reach its `/health`, `/manifest.json`, and
+   * `/uri/resolve` routes. Must be a valid absolute URL (e.g.
+   * `http://finance-api:3004`). Persisted server-side as the
+   * `PillarRegistryEntry.baseUrl` column; required by
+   * `POST /core.registry.register`.
+   */
+  baseUrl: string;
   app?: HealthApp;
   transport?: RegistryTransport;
   heartbeatMs?: number;
@@ -56,6 +65,7 @@ export async function bootstrapPillar(
   const registration = await registerWithRetry({
     transport,
     manifest,
+    baseUrl: options.baseUrl,
     logger,
     maxAttempts: options.maxRegisterAttempts ?? DEFAULT_MAX_REGISTER_ATTEMPTS,
     initialBackoffMs: options.registerInitialBackoffMs ?? DEFAULT_REGISTER_INITIAL_BACKOFF_MS,

--- a/packages/pillar-sdk/src/bootstrap/index.ts
+++ b/packages/pillar-sdk/src/bootstrap/index.ts
@@ -16,6 +16,7 @@ export {
   RegistryTransportError,
   type HeartbeatResult,
   type HttpRegistryTransportOptions,
+  type RegisterRequest,
   type RegistrationResult,
   type RegistryTransport,
 } from './transport.js';

--- a/packages/pillar-sdk/src/bootstrap/register.ts
+++ b/packages/pillar-sdk/src/bootstrap/register.ts
@@ -15,6 +15,7 @@ import type { BootstrapLogger } from './logger.js';
 export interface RegisterWithRetryArgs {
   transport: RegistryTransport;
   manifest: ManifestPayload;
+  baseUrl: string;
   logger: BootstrapLogger;
   maxAttempts: number;
   initialBackoffMs: number;
@@ -29,7 +30,11 @@ export async function registerWithRetry(args: RegisterWithRetryArgs): Promise<Re
   while (attempt < args.maxAttempts) {
     attempt += 1;
     try {
-      const result = await args.transport.register(args.manifest);
+      const result = await args.transport.register({
+        pillarId: args.manifest.pillar,
+        baseUrl: args.baseUrl,
+        manifest: args.manifest,
+      });
       args.logger.info('[pillar-sdk] registered with registry', {
         pillar: result.pillarId,
         attempt,

--- a/packages/pillar-sdk/src/bootstrap/transport.ts
+++ b/packages/pillar-sdk/src/bootstrap/transport.ts
@@ -10,8 +10,14 @@ export interface HeartbeatResult {
   acknowledgedAt: string;
 }
 
+export interface RegisterRequest {
+  pillarId: string;
+  baseUrl: string;
+  manifest: ManifestPayload;
+}
+
 export interface RegistryTransport {
-  register(payload: ManifestPayload): Promise<RegistrationResult>;
+  register(payload: RegisterRequest): Promise<RegistrationResult>;
   heartbeat(pillarId: string): Promise<HeartbeatResult>;
   unregister(pillarId: string): Promise<void>;
 }


### PR DESCRIPTION
## Summary

- The pillar SDK was POSTing the raw manifest to `/core.registry.register`, but `parseRegisterBody` expects an envelope `{ pillarId, baseUrl, manifest }`. Every external pillar registration was rejected with a 400 — capivara bootlooped.
- Thread a required `baseUrl` through `bootstrapPillar` → `registerWithRetry` → `transport.register`, and POST the envelope shape the server already parses (no `apiKey` — that field was dropped in #3317).
- Each pillar's `server.ts` resolves its self URL from `<PILLAR>_SELF_BASE_URL` (falling back to the docker-network hostname `http://<pillar>-api:<port>`) and passes it explicitly to `bootstrapPillar`. Done for core, cerebrum, finance, food, inventory, lists, media, and ha-bridge.
- Updated SDK transport + bootstrap tests to assert the envelope shape on the wire and to thread `baseUrl` through every fixture.

## Test plan

- [x] `pnpm --filter @pops/pillar-sdk test` — 553/553 green
- [x] `pnpm turbo test` across all 8 affected API packages — green
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean (warnings only, none new)
- [ ] After merge: pull + recreate pillar-api containers on capivara so the new SDK envelope ships
