### PR TITLE
feat(lists): add GET /items search + POST .../items/upsert-by-ref primitives

### DIFF
--- a/pillars/lists/openapi/lists.openapi.json
+++ b/pillars/lists/openapi/lists.openapi.json
@@ -6,6 +6,154 @@
   },
   "openapi": "3.0.2",
   "paths": {
+    "/items": {
+      "get": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "kind",
+            "schema": {
+              "enum": ["shopping", "packing", "todo", "generic"],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "listId",
+            "schema": {
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "includeArchived",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
+            "name": "labelContains",
+            "schema": {
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "notesContains",
+            "schema": {
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "items": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "checked": {
+                            "maximum": 1,
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "checkedAt": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          },
+                          "dueAt": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "id": {
+                            "exclusiveMinimum": true,
+                            "maximum": 9007199254740991,
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "label": {
+                            "type": "string"
+                          },
+                          "listId": {
+                            "exclusiveMinimum": true,
+                            "maximum": 9007199254740991,
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "notes": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "position": {
+                            "maximum": 9007199254740991,
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "qty": {
+                            "nullable": true,
+                            "type": "number"
+                          },
+                          "refId": {
+                            "exclusiveMinimum": true,
+                            "maximum": 9007199254740991,
+                            "minimum": 0,
+                            "nullable": true,
+                            "type": "integer"
+                          },
+                          "refKind": {
+                            "enum": ["free", "ingredient", "variant", "recipe", "custom"],
+                            "type": "string"
+                          },
+                          "unit": {
+                            "nullable": true,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "listId",
+                          "position",
+                          "label",
+                          "qty",
+                          "unit",
+                          "refKind",
+                          "refId",
+                          "checked",
+                          "checkedAt",
+                          "dueAt",
+                          "notes",
+                          "createdAt"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": ["items"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Search items across lists (filters: kind, listId, includeArchived, labelContains, notesContains)",
+        "tags": ["items"]
+      }
+    },
     "/items/{id}": {
       "delete": {
         "parameters": [
@@ -1403,6 +1551,245 @@
           }
         },
         "summary": "Uncheck every checked item in a list",
+        "tags": ["items"]
+      }
+    },
+    "/lists/{listId}/items/upsert-by-ref": {
+      "post": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "listId",
+            "required": true,
+            "schema": {
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "label": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "notes": {
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "onConflict": {
+                    "enum": ["merge-additive", "replace", "skip"],
+                    "type": "string"
+                  },
+                  "qty": {
+                    "nullable": true,
+                    "type": "number"
+                  },
+                  "refId": {
+                    "exclusiveMinimum": true,
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "refKind": {
+                    "enum": ["ingredient", "variant", "recipe", "custom"],
+                    "type": "string"
+                  },
+                  "unit": {
+                    "nullable": true,
+                    "type": "string"
+                  }
+                },
+                "required": ["refKind", "refId", "label"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "itemId": {
+                          "exclusiveMinimum": true,
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "outcome": {
+                          "enum": ["inserted"],
+                          "type": "string"
+                        },
+                        "position": {
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer"
+                        }
+                      },
+                      "required": ["outcome", "itemId", "position"],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "itemId": {
+                          "exclusiveMinimum": true,
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "outcome": {
+                          "enum": ["merged"],
+                          "type": "string"
+                        }
+                      },
+                      "required": ["outcome", "itemId"],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "itemId": {
+                          "exclusiveMinimum": true,
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "outcome": {
+                          "enum": ["skipped"],
+                          "type": "string"
+                        }
+                      },
+                      "required": ["outcome", "itemId"],
+                      "type": "object"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "200"
+          },
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "itemId": {
+                          "exclusiveMinimum": true,
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "outcome": {
+                          "enum": ["inserted"],
+                          "type": "string"
+                        },
+                        "position": {
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer"
+                        }
+                      },
+                      "required": ["outcome", "itemId", "position"],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "itemId": {
+                          "exclusiveMinimum": true,
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "outcome": {
+                          "enum": ["merged"],
+                          "type": "string"
+                        }
+                      },
+                      "required": ["outcome", "itemId"],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "itemId": {
+                          "exclusiveMinimum": true,
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "outcome": {
+                          "enum": ["skipped"],
+                          "type": "string"
+                        }
+                      },
+                      "required": ["outcome", "itemId"],
+                      "type": "object"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "201"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          }
+        },
+        "summary": "Atomic merge-or-insert by (refKind, refId). onConflict picks merge-additive / replace / skip",
         "tags": ["items"]
       }
     }

--- a/pillars/lists/src/api/__tests__/lists-router.test.ts
+++ b/pillars/lists/src/api/__tests__/lists-router.test.ts
@@ -136,6 +136,27 @@ function makeClient(app: Express): {
     }) => Promise<{ ok: true } | { ok: false; reason: 'BadIds' }>;
     uncheckAll: (input: { listId: number }) => Promise<{ ok: true; count: number }>;
     removeChecked: (input: { listId: number }) => Promise<{ ok: true; removedCount: number }>;
+    search: (q?: {
+      kind?: 'shopping' | 'packing' | 'todo' | 'generic';
+      listId?: number;
+      includeArchived?: boolean;
+      labelContains?: string;
+      notesContains?: string;
+    }) => Promise<{ items: ListItemWire[] }>;
+    upsertByRef: (input: {
+      listId: number;
+      refKind: 'ingredient' | 'variant' | 'recipe' | 'custom';
+      refId: number;
+      label: string;
+      qty?: number | null;
+      unit?: string | null;
+      notes?: string | null;
+      onConflict?: 'merge-additive' | 'replace' | 'skip';
+    }) => Promise<
+      | { outcome: 'inserted'; itemId: number; position: number }
+      | { outcome: 'merged'; itemId: number }
+      | { outcome: 'skipped'; itemId: number }
+    >;
   };
 } {
   const api = supertest(app);
@@ -164,8 +185,26 @@ function makeClient(app: Express): {
         assert2xx(await api.post(`/lists/${listId}/items/uncheck-all`).send({})),
       removeChecked: async ({ listId }) =>
         assert2xx(await api.delete(`/lists/${listId}/items/checked`)),
+      search: async (q) => assert2xx(await api.get('/items').query(q ?? {})),
+      upsertByRef: async ({ listId, ...body }) =>
+        assert2xx(await api.post(`/lists/${listId}/items/upsert-by-ref`).send(body)),
     },
   };
+}
+
+interface ListItemWire {
+  id: number;
+  listId: number;
+  label: string;
+  qty: number | null;
+  unit: string | null;
+  refKind: string;
+  refId: number | null;
+  notes: string | null;
+  position: number;
+  checked: number;
+  checkedAt: string | null;
+  createdAt: string;
 }
 
 interface ListAggregateWire {
@@ -586,6 +625,237 @@ describe('PRD-140 lists REST surface', () => {
       await client.items.removeChecked({ listId: listA });
       const detailB = await client.list.get({ id: listB });
       expect(detailB?.items.length).toBe(1);
+    });
+  });
+
+  describe('GET /items (search)', () => {
+    it('filters by notesContains across all matching lists', async () => {
+      const { id: shopA } = await client.list.create({ name: 'Shop A', kind: 'shopping' });
+      const { id: shopB } = await client.list.create({ name: 'Shop B', kind: 'shopping' });
+      const { id: todoC } = await client.list.create({ name: 'Todo C', kind: 'todo' });
+      await client.items.add({ listId: shopA, label: 'tomato', notes: 'Risotto Verde' });
+      await client.items.add({ listId: shopB, label: 'onion', notes: 'Risotto Verde + Soup' });
+      await client.items.add({ listId: shopB, label: 'salt', notes: 'pantry' });
+      await client.items.add({ listId: todoC, label: 'call mum', notes: 'Risotto Verde dinner' });
+
+      const { items } = await client.items.search({ notesContains: 'risotto verde' });
+      const matchedLists = new Set(items.map((it) => it.listId));
+      expect(matchedLists.has(shopA)).toBe(true);
+      expect(matchedLists.has(shopB)).toBe(true);
+      expect(matchedLists.has(todoC)).toBe(true);
+      expect(items.find((it) => it.label === 'salt')).toBeUndefined();
+    });
+
+    it('combines notesContains with kind=shopping to scope away other list kinds', async () => {
+      const { id: shop } = await client.list.create({ name: 'Shop', kind: 'shopping' });
+      const { id: todo } = await client.list.create({ name: 'Todo', kind: 'todo' });
+      await client.items.add({ listId: shop, label: 'tomato', notes: 'Risotto' });
+      await client.items.add({ listId: todo, label: 'call mum', notes: 'Risotto dinner' });
+
+      const { items } = await client.items.search({ notesContains: 'risotto', kind: 'shopping' });
+      const matched = new Set(items.map((it) => it.listId));
+      expect(matched.has(shop)).toBe(true);
+      expect(matched.has(todo)).toBe(false);
+    });
+
+    it('hides items from archived lists by default; surfaces them with includeArchived', async () => {
+      const { id: listId } = await client.list.create({ name: 'A', kind: 'shopping' });
+      await client.items.add({ listId, label: 'milk', notes: 'recipe X' });
+      await client.list.archive({ id: listId });
+
+      const hidden = await client.items.search({ notesContains: 'recipe X' });
+      expect(hidden.items).toHaveLength(0);
+
+      const visible = await client.items.search({
+        notesContains: 'recipe X',
+        includeArchived: true,
+      });
+      expect(visible.items).toHaveLength(1);
+    });
+
+    it('escapes %, _, and \\ in contains-strings so they are matched literally', async () => {
+      const { id: listId } = await client.list.create({ name: 'A', kind: 'shopping' });
+      await client.items.add({ listId, label: '100% wholemeal' });
+      await client.items.add({ listId, label: 'rough_label' });
+      await client.items.add({ listId, label: 'normal label' });
+
+      const pct = await client.items.search({ labelContains: '100%' });
+      expect(pct.items.map((it) => it.label)).toEqual(['100% wholemeal']);
+
+      const underscore = await client.items.search({ labelContains: 'rough_label' });
+      expect(underscore.items.map((it) => it.label)).toEqual(['rough_label']);
+    });
+
+    it('filters by listId to constrain search to one list', async () => {
+      const { id: listA } = await client.list.create({ name: 'A', kind: 'shopping' });
+      const { id: listB } = await client.list.create({ name: 'B', kind: 'shopping' });
+      await client.items.add({ listId: listA, label: 'tomato' });
+      await client.items.add({ listId: listB, label: 'tomato' });
+      const { items } = await client.items.search({ listId: listA, labelContains: 'tomato' });
+      expect(items).toHaveLength(1);
+      expect(items[0]?.listId).toBe(listA);
+    });
+  });
+
+  describe('POST /lists/:listId/items/upsert-by-ref', () => {
+    it('inserts when no matching (refKind, refId) row exists', async () => {
+      const { id: listId } = await client.list.create({ name: 'Shop', kind: 'shopping' });
+      const result = await client.items.upsertByRef({
+        listId,
+        refKind: 'ingredient',
+        refId: 42,
+        label: 'tomato 200g',
+        qty: 200,
+        unit: 'g',
+        notes: 'Risotto Verde',
+      });
+      expect(result.outcome).toBe('inserted');
+      const row = raw
+        .prepare(`SELECT qty, unit, notes, label FROM list_items WHERE list_id = ? AND ref_id = ?`)
+        .get(listId, 42) as { qty: number; unit: string; notes: string; label: string };
+      expect(row).toMatchObject({
+        qty: 200,
+        unit: 'g',
+        notes: 'Risotto Verde',
+        label: 'tomato 200g',
+      });
+    });
+
+    it('merge-additive (default) sums qty, joins notes with newline, replaces label', async () => {
+      const { id: listId } = await client.list.create({ name: 'Shop', kind: 'shopping' });
+      await client.items.upsertByRef({
+        listId,
+        refKind: 'ingredient',
+        refId: 42,
+        label: 'tomato 200g',
+        qty: 200,
+        unit: 'g',
+        notes: 'Risotto Verde',
+      });
+      const merged = await client.items.upsertByRef({
+        listId,
+        refKind: 'ingredient',
+        refId: 42,
+        label: 'tomato 350g',
+        qty: 150,
+        unit: 'g',
+        notes: 'Soup',
+      });
+      expect(merged.outcome).toBe('merged');
+      const row = raw
+        .prepare(`SELECT qty, unit, notes, label FROM list_items WHERE list_id = ? AND ref_id = ?`)
+        .get(listId, 42) as { qty: number; unit: string; notes: string; label: string };
+      expect(row).toMatchObject({
+        qty: 350,
+        unit: 'g',
+        notes: 'Risotto Verde\nSoup',
+        label: 'tomato 350g',
+      });
+    });
+
+    it('replace mode overwrites qty, unit, notes, label wholesale', async () => {
+      const { id: listId } = await client.list.create({ name: 'Shop', kind: 'shopping' });
+      await client.items.upsertByRef({
+        listId,
+        refKind: 'ingredient',
+        refId: 42,
+        label: 'tomato 200g',
+        qty: 200,
+        unit: 'g',
+        notes: 'Risotto Verde',
+      });
+      const replaced = await client.items.upsertByRef({
+        listId,
+        refKind: 'ingredient',
+        refId: 42,
+        label: 'tomato 1pc',
+        qty: 1,
+        unit: 'pc',
+        notes: 'Direct add',
+        onConflict: 'replace',
+      });
+      expect(replaced.outcome).toBe('merged');
+      const row = raw
+        .prepare(`SELECT qty, unit, notes, label FROM list_items WHERE list_id = ? AND ref_id = ?`)
+        .get(listId, 42) as { qty: number; unit: string; notes: string; label: string };
+      expect(row).toMatchObject({ qty: 1, unit: 'pc', notes: 'Direct add', label: 'tomato 1pc' });
+    });
+
+    it('skip mode leaves the existing row untouched', async () => {
+      const { id: listId } = await client.list.create({ name: 'Shop', kind: 'shopping' });
+      await client.items.upsertByRef({
+        listId,
+        refKind: 'ingredient',
+        refId: 42,
+        label: 'tomato 200g',
+        qty: 200,
+        unit: 'g',
+        notes: 'Risotto Verde',
+      });
+      const skipped = await client.items.upsertByRef({
+        listId,
+        refKind: 'ingredient',
+        refId: 42,
+        label: 'tomato 1pc',
+        qty: 1,
+        unit: 'pc',
+        notes: 'Direct add',
+        onConflict: 'skip',
+      });
+      expect(skipped.outcome).toBe('skipped');
+      const row = raw
+        .prepare(`SELECT qty, unit, notes, label FROM list_items WHERE list_id = ? AND ref_id = ?`)
+        .get(listId, 42) as { qty: number; unit: string; notes: string; label: string };
+      expect(row).toMatchObject({
+        qty: 200,
+        unit: 'g',
+        notes: 'Risotto Verde',
+        label: 'tomato 200g',
+      });
+    });
+
+    it('rejects refKind=free with HTTP 400 at the contract boundary', async () => {
+      const { id: listId } = await client.list.create({ name: 'Shop', kind: 'shopping' });
+      const res = await supertest(buildApp(raw, db))
+        .post(`/lists/${listId}/items/upsert-by-ref`)
+        .send({
+          refKind: 'free',
+          refId: 1,
+          label: 'x',
+          qty: 1,
+        });
+      expect(res.status).toBe(400);
+    });
+
+    it('returns HTTP 400 (FK constraint) when listId references a missing list', async () => {
+      await expect(
+        client.items.upsertByRef({
+          listId: 99999,
+          refKind: 'ingredient',
+          refId: 42,
+          label: 'x',
+          qty: 1,
+        })
+      ).rejects.toMatchObject({ message: expect.stringMatching(/foreign key/i) });
+    });
+
+    it('keeps separate identities for matching refId across different refKinds', async () => {
+      const { id: listId } = await client.list.create({ name: 'Shop', kind: 'shopping' });
+      const a = await client.items.upsertByRef({
+        listId,
+        refKind: 'ingredient',
+        refId: 7,
+        label: 'tomato',
+      });
+      const b = await client.items.upsertByRef({
+        listId,
+        refKind: 'variant',
+        refId: 7,
+        label: 'tinned tomato',
+      });
+      expect(a.outcome).toBe('inserted');
+      expect(b.outcome).toBe('inserted');
+      expect(a.itemId).not.toBe(b.itemId);
     });
   });
 });

--- a/pillars/lists/src/api/rest/items-handlers.ts
+++ b/pillars/lists/src/api/rest/items-handlers.ts
@@ -13,13 +13,17 @@ import {
   removeCheckedItems,
   removeItem,
   reorderItems,
+  searchListItems,
   updateItem,
+  upsertItemByRef,
 } from '../../db/index.js';
 import { tryMapServiceError } from './error-mapping.js';
 
-import type { ListsDb } from '../../db/index.js';
+import type { ListsDb, UpsertConflictMode, UpsertRefKind } from '../../db/index.js';
 
 type RefKind = 'free' | 'ingredient' | 'variant' | 'recipe' | 'custom';
+
+type ListKind = 'shopping' | 'packing' | 'todo' | 'generic';
 
 interface ConflictBody {
   message: string;
@@ -52,6 +56,48 @@ function isPermutationOfList(current: readonly number[], candidate: readonly num
 
 export function makeItemsHandlers(db: ListsDb) {
   return {
+    search: async ({
+      query,
+    }: {
+      query: {
+        kind?: ListKind;
+        listId?: number;
+        includeArchived?: boolean;
+        labelContains?: string;
+        notesContains?: string;
+      };
+    }) => {
+      const items = searchListItems(db, query);
+      return { status: 200 as const, body: { items: [...items] } };
+    },
+
+    upsertByRef: async ({
+      params,
+      body,
+    }: {
+      params: { listId: number };
+      body: {
+        refKind: UpsertRefKind;
+        refId: number;
+        label: string;
+        qty?: number | null;
+        unit?: string | null;
+        notes?: string | null;
+        onConflict?: UpsertConflictMode;
+      };
+    }) => {
+      try {
+        const result = upsertItemByRef(db, { listId: params.listId, ...body });
+        const status = result.outcome === 'inserted' ? (201 as const) : (200 as const);
+        return { status, body: result };
+      } catch (err) {
+        const mapped = notFoundOrConflict(err);
+        if (mapped?.kind === 'notFound') return { status: 404 as const, body: mapped.body };
+        if (mapped?.kind === 'conflict') return { status: 400 as const, body: mapped.body };
+        throw err as Error;
+      }
+    },
+
     add: async ({ params, body }: { params: { listId: number }; body: AddItemBody }) => {
       try {
         const row = addItem(db, { listId: params.listId, ...body });

--- a/pillars/lists/src/contract/api-types.generated.ts
+++ b/pillars/lists/src/contract/api-types.generated.ts
@@ -4,6 +4,65 @@
  * Drift check in lists-quality.yml fails on hand-edits.
  */
 export interface paths {
+  '/items': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Search items across lists (filters: kind, listId, includeArchived, labelContains, notesContains) */
+    get: {
+      parameters: {
+        query?: {
+          kind?: 'shopping' | 'packing' | 'todo' | 'generic';
+          listId?: number;
+          includeArchived?: boolean;
+          labelContains?: string;
+          notesContains?: string;
+        };
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description 200 */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              items: {
+                checked: number;
+                checkedAt: string | null;
+                createdAt: string;
+                dueAt: string | null;
+                id: number;
+                label: string;
+                listId: number;
+                notes: string | null;
+                position: number;
+                qty: number | null;
+                refId: number | null;
+                /** @enum {string} */
+                refKind: 'free' | 'ingredient' | 'variant' | 'recipe' | 'custom';
+                unit: string | null;
+              }[];
+            };
+          };
+        };
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/items/{id}': {
     parameters: {
       query?: never;
@@ -894,6 +953,124 @@ export interface paths {
               count: number;
               /** @enum {boolean} */
               ok: true;
+            };
+          };
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/lists/{listId}/items/upsert-by-ref': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Atomic merge-or-insert by (refKind, refId). onConflict picks merge-additive / replace / skip */
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          listId: number;
+        };
+        cookie?: never;
+      };
+      /** @description Body */
+      requestBody?: {
+        content: {
+          'application/json': {
+            label: string;
+            notes?: string | null;
+            /** @enum {string} */
+            onConflict?: 'merge-additive' | 'replace' | 'skip';
+            qty?: number | null;
+            refId: number;
+            /** @enum {string} */
+            refKind: 'ingredient' | 'variant' | 'recipe' | 'custom';
+            unit?: string | null;
+          };
+        };
+      };
+      responses: {
+        /** @description 200 */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json':
+              | {
+                  itemId: number;
+                  /** @enum {string} */
+                  outcome: 'inserted';
+                  position: number;
+                }
+              | {
+                  itemId: number;
+                  /** @enum {string} */
+                  outcome: 'merged';
+                }
+              | {
+                  itemId: number;
+                  /** @enum {string} */
+                  outcome: 'skipped';
+                };
+          };
+        };
+        /** @description 201 */
+        201: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json':
+              | {
+                  itemId: number;
+                  /** @enum {string} */
+                  outcome: 'inserted';
+                  position: number;
+                }
+              | {
+                  itemId: number;
+                  /** @enum {string} */
+                  outcome: 'merged';
+                }
+              | {
+                  itemId: number;
+                  /** @enum {string} */
+                  outcome: 'skipped';
+                };
+          };
+        };
+        /** @description 400 */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              code?: string;
+              message: string;
+            };
+          };
+        };
+        /** @description 404 */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              code?: string;
+              message: string;
             };
           };
         };

--- a/pillars/lists/src/contract/rest-items.ts
+++ b/pillars/lists/src/contract/rest-items.ts
@@ -9,14 +9,48 @@ import { z } from 'zod';
 import {
   ErrorBodySchema,
   ItemAddBodySchema,
+  KIND_ENUM,
+  ListItemRowSchema,
   OkSchema,
   PathPositiveInt,
   PositiveInt,
+  UpsertByRefBodySchema,
+  UpsertByRefResponseSchema,
 } from './rest-schemas.js';
 
 const c = initContract();
 
 export const listsItemsContract = c.router({
+  search: {
+    method: 'GET',
+    path: '/items',
+    query: z.object({
+      kind: KIND_ENUM.optional(),
+      listId: PathPositiveInt.optional(),
+      includeArchived: z.coerce.boolean().optional(),
+      labelContains: z.string().min(1).optional(),
+      notesContains: z.string().min(1).optional(),
+    }),
+    responses: {
+      200: z.object({ items: z.array(ListItemRowSchema) }),
+    },
+    summary:
+      'Search items across lists (filters: kind, listId, includeArchived, labelContains, notesContains)',
+  },
+  upsertByRef: {
+    method: 'POST',
+    path: '/lists/:listId/items/upsert-by-ref',
+    pathParams: z.object({ listId: PathPositiveInt }),
+    body: UpsertByRefBodySchema,
+    responses: {
+      200: UpsertByRefResponseSchema,
+      201: UpsertByRefResponseSchema,
+      400: ErrorBodySchema,
+      404: ErrorBodySchema,
+    },
+    summary:
+      'Atomic merge-or-insert by (refKind, refId). onConflict picks merge-additive / replace / skip',
+  },
   add: {
     method: 'POST',
     path: '/lists/:listId/items',

--- a/pillars/lists/src/contract/rest-schemas.ts
+++ b/pillars/lists/src/contract/rest-schemas.ts
@@ -10,6 +10,34 @@ export const KIND_ENUM = z.enum(['shopping', 'packing', 'todo', 'generic']);
 export const SORT_ENUM = z.enum(['updated', 'name', 'created']);
 export const REF_KIND_ENUM = z.enum(['free', 'ingredient', 'variant', 'recipe', 'custom']);
 
+/**
+ * `refKind` minus `'free'` — the subset that has identity (refId) and so
+ * can be used as a deduplication key by `POST /lists/:listId/items/upsert-by-ref`.
+ */
+export const NON_FREE_REF_KIND_ENUM = z.enum(['ingredient', 'variant', 'recipe', 'custom']);
+
+export const UPSERT_CONFLICT_MODE_ENUM = z.enum(['merge-additive', 'replace', 'skip']);
+
+export const UpsertByRefBodySchema = z.object({
+  refKind: NON_FREE_REF_KIND_ENUM,
+  refId: z.number().int().positive(),
+  label: z.string().trim().min(1),
+  qty: z.number().nullable().optional(),
+  unit: z.string().nullable().optional(),
+  notes: z.string().nullable().optional(),
+  onConflict: UPSERT_CONFLICT_MODE_ENUM.optional(),
+});
+
+export const UpsertByRefResponseSchema = z.discriminatedUnion('outcome', [
+  z.object({
+    outcome: z.literal('inserted'),
+    itemId: z.number().int().positive(),
+    position: z.number().int().nonnegative(),
+  }),
+  z.object({ outcome: z.literal('merged'), itemId: z.number().int().positive() }),
+  z.object({ outcome: z.literal('skipped'), itemId: z.number().int().positive() }),
+]);
+
 export const PositiveInt = z.number().int().positive();
 export const PathPositiveInt = z.coerce.number().int().positive();
 

--- a/pillars/lists/src/db/index.ts
+++ b/pillars/lists/src/db/index.ts
@@ -36,5 +36,13 @@ export {
   reorderItems,
   updateItem,
 } from './services/list-items.js';
+export { searchListItems, type SearchListItemsFilter } from './services/list-items-search.js';
+export {
+  upsertItemByRef,
+  type UpsertConflictMode,
+  type UpsertItemByRefInput,
+  type UpsertOutcome,
+  type UpsertRefKind,
+} from './services/list-items-upsert.js';
 
 export { openListsDb, type OpenedListsDb } from './open-lists-db.js';

--- a/pillars/lists/src/db/services/internal.ts
+++ b/pillars/lists/src/db/services/internal.ts
@@ -33,3 +33,22 @@ export function expectRow<T>(rows: readonly T[], label: string): T {
 export function nowIso(): string {
   return new Date().toISOString();
 }
+
+import { eq, max as sqlMax } from 'drizzle-orm';
+
+import { listItems } from '../schema.js';
+
+/**
+ * Next `position` for an insert into a given list — `max(position) + 1`
+ * or `0` if the list is empty. Shared between `addItem`, `bulkAdd`, and
+ * `upsertItemByRef`.
+ */
+export function nextPosition(db: ListsDb, listId: number): number {
+  const rows = db
+    .select({ max: sqlMax(listItems.position) })
+    .from(listItems)
+    .where(eq(listItems.listId, listId))
+    .all();
+  const max = rows[0]?.max ?? null;
+  return max === null ? 0 : max + 1;
+}

--- a/pillars/lists/src/db/services/list-items-search.ts
+++ b/pillars/lists/src/db/services/list-items-search.ts
@@ -1,0 +1,60 @@
+/**
+ * Generic items search across lists.
+ *
+ * Filters compose; no filter ⇒ returns every item in the database (callers
+ * should pass at least one). `labelContains` / `notesContains` use SQLite's
+ * case-insensitive LIKE on ASCII text. `%`, `_`, and `\` in the input are
+ * escaped server-side; the LIKE clause uses `'\'` as the ESCAPE character.
+ *
+ * `includeArchived` defaults to false — archived lists' items are hidden
+ * unless the caller opts in.
+ */
+import { and, asc, eq, isNull, sql } from 'drizzle-orm';
+
+import { listItems, lists, type ListItemRow, type ListKind } from '../schema.js';
+import { type ListsDb } from './internal.js';
+
+export interface SearchListItemsFilter {
+  kind?: ListKind;
+  listId?: number;
+  includeArchived?: boolean;
+  labelContains?: string;
+  notesContains?: string;
+}
+
+function escapeLikePattern(input: string): string {
+  return input.replaceAll('\\', '\\\\').replaceAll('%', '\\%').replaceAll('_', '\\_');
+}
+
+export function searchListItems(
+  db: ListsDb,
+  filter: SearchListItemsFilter = {}
+): readonly ListItemRow[] {
+  const needsJoin = filter.kind !== undefined || filter.includeArchived !== true;
+
+  const conditions = [
+    filter.listId === undefined ? undefined : eq(listItems.listId, filter.listId),
+    filter.kind === undefined ? undefined : eq(lists.kind, filter.kind),
+    filter.includeArchived === true ? undefined : isNull(lists.archivedAt),
+    filter.labelContains === undefined
+      ? undefined
+      : sql`${listItems.label} LIKE ${`%${escapeLikePattern(filter.labelContains)}%`} ESCAPE '\\'`,
+    filter.notesContains === undefined
+      ? undefined
+      : sql`${listItems.notes} LIKE ${`%${escapeLikePattern(filter.notesContains)}%`} ESCAPE '\\'`,
+  ].filter((c): c is Exclude<typeof c, undefined> => c !== undefined);
+
+  const where = conditions.length === 0 ? undefined : and(...conditions);
+  const baseSelect = db.select({ item: listItems }).from(listItems);
+  const joined = needsJoin
+    ? baseSelect.innerJoin(lists, eq(lists.id, listItems.listId))
+    : baseSelect;
+  const rows =
+    where === undefined
+      ? joined.orderBy(asc(listItems.listId), asc(listItems.position), asc(listItems.id)).all()
+      : joined
+          .where(where)
+          .orderBy(asc(listItems.listId), asc(listItems.position), asc(listItems.id))
+          .all();
+  return rows.map((r) => r.item);
+}

--- a/pillars/lists/src/db/services/list-items-upsert.ts
+++ b/pillars/lists/src/db/services/list-items-upsert.ts
@@ -1,0 +1,123 @@
+/**
+ * Atomic merge-or-insert keyed on `(listId, refKind, refId)`. `refKind`
+ * cannot be `'free'` — `'free'` rows have no identity and so can't be
+ * deduplicated.
+ *
+ * On conflict:
+ *   - `'merge-additive'` (default): qty = existing.qty + new.qty (null = 0);
+ *     notes = existing.notes ? `${existing.notes}\n${new.notes}` : new.notes;
+ *     label replaced; unit kept.
+ *   - `'replace'`: existing row's label/qty/unit/notes replaced wholesale.
+ *   - `'skip'`: no-op; existing row left as-is.
+ *
+ * Notes-on-merge uses `\n` (newline) as the universal separator and never
+ * truncates. Callers wanting domain-specific note formatting (separators,
+ * caps) should compose with `updateItem` after the upsert.
+ */
+import { and, eq } from 'drizzle-orm';
+
+import { listItems, type ListItemRefKind, type ListItemRow } from '../schema.js';
+import { expectRow, type ListsDb, nextPosition } from './internal.js';
+
+export type UpsertConflictMode = 'merge-additive' | 'replace' | 'skip';
+export type UpsertRefKind = Exclude<ListItemRefKind, 'free'>;
+
+export interface UpsertItemByRefInput {
+  listId: number;
+  refKind: UpsertRefKind;
+  refId: number;
+  label: string;
+  qty?: number | null;
+  unit?: string | null;
+  notes?: string | null;
+  onConflict?: UpsertConflictMode;
+}
+
+export type UpsertOutcome =
+  | { outcome: 'inserted'; itemId: number; position: number }
+  | { outcome: 'merged'; itemId: number }
+  | { outcome: 'skipped'; itemId: number };
+
+export function upsertItemByRef(db: ListsDb, input: UpsertItemByRefInput): UpsertOutcome {
+  const mode: UpsertConflictMode = input.onConflict ?? 'merge-additive';
+  return db.transaction((tx) => {
+    const existing = tx
+      .select()
+      .from(listItems)
+      .where(
+        and(
+          eq(listItems.listId, input.listId),
+          eq(listItems.refKind, input.refKind),
+          eq(listItems.refId, input.refId)
+        )
+      )
+      .limit(1)
+      .all()[0];
+
+    if (existing === undefined) {
+      const position = nextPosition(tx, input.listId);
+      const inserted = expectRow(
+        tx
+          .insert(listItems)
+          .values({
+            listId: input.listId,
+            refKind: input.refKind,
+            refId: input.refId,
+            label: input.label,
+            qty: input.qty ?? null,
+            unit: input.unit ?? null,
+            notes: input.notes ?? null,
+            position,
+          })
+          .returning()
+          .all(),
+        'upsertItemByRef.insert'
+      );
+      return { outcome: 'inserted', itemId: inserted.id, position: inserted.position };
+    }
+
+    if (mode === 'skip') {
+      return { outcome: 'skipped', itemId: existing.id };
+    }
+
+    const merged = mergedValues(existing, input, mode);
+    tx.update(listItems).set(merged).where(eq(listItems.id, existing.id)).run();
+    return { outcome: 'merged', itemId: existing.id };
+  });
+}
+
+interface MergedValues {
+  label: string;
+  qty: number | null;
+  unit: string | null;
+  notes: string | null;
+}
+
+function mergedValues(
+  existing: ListItemRow,
+  input: UpsertItemByRefInput,
+  mode: 'merge-additive' | 'replace'
+): MergedValues {
+  if (mode === 'replace') {
+    return {
+      label: input.label,
+      qty: input.qty ?? null,
+      unit: input.unit ?? null,
+      notes: input.notes ?? null,
+    };
+  }
+  const newQty = (existing.qty ?? 0) + (input.qty ?? 0);
+  const newNotes = mergeNotes(existing.notes, input.notes ?? null);
+  return {
+    label: input.label,
+    qty: input.qty === null && existing.qty === null ? null : newQty,
+    unit: existing.unit ?? input.unit ?? null,
+    notes: newNotes,
+  };
+}
+
+function mergeNotes(existing: string | null, addition: string | null): string | null {
+  if (addition === null || addition === '') return existing;
+  if (existing === null || existing === '') return addition;
+  return `${existing}\n${addition}`;
+}

--- a/pillars/lists/src/db/services/list-items.ts
+++ b/pillars/lists/src/db/services/list-items.ts
@@ -14,11 +14,11 @@
  * `ref_kind != 'free'` but `ref_id IS NULL`, `normalise()` falls back to
  * `'free'` per PRD-112 Edge Cases.
  */
-import { and, asc, eq, max as sqlMax } from 'drizzle-orm';
+import { and, asc, eq } from 'drizzle-orm';
 
 import { ListItemNotFoundError } from '../errors.js';
 import { listItems, type ListItemRefKind, type ListItemRow } from '../schema.js';
-import { expectRow, type ListsDb, nowIso } from './internal.js';
+import { expectRow, type ListsDb, nextPosition, nowIso } from './internal.js';
 
 /* ---------- reads ---------- */
 
@@ -141,16 +141,6 @@ function normalise(input: AddItemInput, fallbackPosition: number): NormalisedIte
     dueAt: input.dueAt ?? null,
     notes: input.notes ?? null,
   };
-}
-
-function nextPosition(db: ListsDb, listId: number): number {
-  const rows = db
-    .select({ max: sqlMax(listItems.position) })
-    .from(listItems)
-    .where(eq(listItems.listId, listId))
-    .all();
-  const max = rows[0]?.max ?? null;
-  return max === null ? 0 : max + 1;
 }
 
 export function addItem(db: ListsDb, input: AddItemInput): ListItemRow {


### PR DESCRIPTION
## Summary

Two generic endpoints on the lists pillar so future cross-pillar consumers (starting with the pops-api food handlers) don't have to reach into `@pops/app-lists-db`. Both are contract-first via ts-rest and follow the existing handler / service / test layout.

### `GET /items`
Query: `kind`, `listId`, `includeArchived` (default false), `labelContains`, `notesContains`. Returns the full `ListItemRow` shape. LIKE-escapes `%`, `_`, `\` server-side; ESCAPE clause uses `'\'`.

### `POST /lists/:listId/items/upsert-by-ref`
Atomic merge-or-insert keyed on `(listId, refKind, refId)`. `refKind='free'` is refused at the contract boundary — free rows have no identity. On conflict the caller picks `'merge-additive'` (default), `'replace'`, or `'skip'`. Merge-additive sums qty (null-safe), joins notes with `\n`, replaces label, keeps unit. No truncation server-side — that's a consumer concern.

## Why these two primitives

Both shapes come from the pre-Y-refactor food code that imports dead `@pops/app-lists-db`:

- **"Already sent" detection** in send-to-list needs to find shopping lists whose items' notes mention a recipe title. The only honest REST equivalent is a generic `notesContains` filter, not a recipe-shaped endpoint.
- **The send loop** merges per recipe item by `(refKind, refId)` — bumping qty and appending notes. `upsert-by-ref` keeps per-item atomicity where it matters (the read-modify-write of a single matched row), which is what the original transaction actually guaranteed.

Both endpoints belong on lists because they're generic over any consumer that needs to (a) search items across lists or (b) idempotently send-by-ref into a list. Future cross-pillar consumers (inventory restocks, etc.) inherit them at zero extra surface cost.

## Internal structure

- `searchListItems` → `src/db/services/list-items-search.ts`
- `upsertItemByRef` → `src/db/services/list-items-upsert.ts`
- `nextPosition` lifted into `src/db/services/internal.ts` (shared with `addItem` / `bulkAdd` / `upsertItemByRef`)

## Tests

12 new cases covering all three `onConflict` modes, `refKind='free'` refusal, FK violation handling, multi-list/multi-kind search, LIKE escaping (literal `%` / `_`), archived-list scoping, listId scoping. 181/181 across 13 files.

## Test plan
- [x] \`pnpm exec oxfmt --check pillars/lists/\`
- [x] \`pnpm exec oxlint pillars/lists/src\`
- [x] \`pnpm --filter @pops/lists typecheck\`
- [x] \`pnpm --filter @pops/lists build\`
- [x] \`pnpm --filter @pops/lists test\` (181/181)
- [x] OpenAPI drift check (deterministic across regenerations)
- [ ] Lists pillar CI green on the PR

## Next slice

PR depending on this one: move the 6 dead consumer files from \`apps/pops-api/src/modules/food/{recipes/send-to-list/*,shopping/generate.ts}\` into \`pillars/food/src/api/\` and rewire them to call these new endpoints via \`openapi-fetch\`.