### PR TITLE
chore(inventory): drop dead package refs from Dockerfile + add dep-cruiser ban

### DIFF
--- a/.dependency-cruiser-known-violations.json
+++ b/.dependency-cruiser-known-violations.json
@@ -2561,5 +2561,27 @@
       "severity": "error",
       "name": "no-dead-lists-pkgs"
     }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/cerebrum/retrieval/semantic-search-metadata.ts",
+    "to": "@pops/inventory-db",
+    "unresolvedTo": "@pops/inventory-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-inventory-pkgs"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "apps/pops-api/src/modules/cerebrum/thalamus/cross-source.ts",
+    "to": "@pops/inventory-db",
+    "unresolvedTo": "@pops/inventory-db",
+    "dependencyTypes": ["unknown"],
+    "rule": {
+      "severity": "error",
+      "name": "no-dead-inventory-pkgs"
+    }
   }
 ]

--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -50,6 +50,14 @@ module.exports = {
       from: { path: '.*' },
       to: { path: '^@pops/(app-lists-db|lists-db|lists-contract|lists-api)(/|$)' },
     },
+    {
+      name: 'no-dead-inventory-pkgs',
+      severity: 'error',
+      comment:
+        'The `@pops/app-inventory-db`, `@pops/inventory-db`, `@pops/inventory-contract`, and `@pops/inventory-api` packages no longer exist — inventory collapsed into `pillars/inventory/`. Consumers go through `@pops/inventory` (contract types + api-types + openapi) and the inventory REST API for cross-pillar calls.',
+      from: { path: '.*' },
+      to: { path: '^@pops/(app-inventory-db|inventory-db|inventory-contract|inventory-api)(/|$)' },
+    },
     ...contractBoundaryRules,
   ],
   options: {

--- a/apps/pops-api/Dockerfile
+++ b/apps/pops-api/Dockerfile
@@ -15,13 +15,11 @@ COPY packages/finance-db/package.json ./packages/finance-db/
 COPY packages/finance-contract/package.json ./packages/finance-contract/
 COPY packages/cerebrum-contract/package.json ./packages/cerebrum-contract/
 COPY packages/core-contract/package.json ./packages/core-contract/
-COPY packages/inventory-contract/package.json ./packages/inventory-contract/
 COPY packages/media-contract/package.json ./packages/media-contract/
 COPY packages/food-contract/package.json ./packages/food-contract/
 COPY packages/pillar-sdk/package.json ./packages/pillar-sdk/
 COPY packages/media-db/package.json ./packages/media-db/
 COPY packages/food-contracts/package.json ./packages/food-contracts/
-COPY packages/inventory-db/package.json ./packages/inventory-db/
 COPY packages/cerebrum-db/package.json ./packages/cerebrum-db/
 COPY packages/food-db/package.json ./packages/food-db/
 COPY apps/pops-api/package.json ./apps/pops-api/
@@ -50,9 +48,6 @@ COPY packages/media-db/tsconfig.json ./packages/media-db/
 COPY packages/media-db/migrations ./packages/media-db/migrations
 COPY packages/food-contracts/src ./packages/food-contracts/src
 COPY packages/food-contracts/tsconfig.json ./packages/food-contracts/
-COPY packages/inventory-db/src ./packages/inventory-db/src
-COPY packages/inventory-db/tsconfig.json ./packages/inventory-db/
-COPY packages/inventory-db/migrations ./packages/inventory-db/migrations
 COPY packages/cerebrum-db/src ./packages/cerebrum-db/src
 COPY packages/cerebrum-db/tsconfig.json ./packages/cerebrum-db/
 COPY packages/cerebrum-db/migrations ./packages/cerebrum-db/migrations
@@ -62,7 +57,6 @@ COPY packages/food-db/migrations ./packages/food-db/migrations
 COPY packages/finance-contract/ ./packages/finance-contract/
 COPY packages/cerebrum-contract/ ./packages/cerebrum-contract/
 COPY packages/core-contract/ ./packages/core-contract/
-COPY packages/inventory-contract/ ./packages/inventory-contract/
 COPY packages/media-contract/ ./packages/media-contract/
 COPY packages/food-contract/ ./packages/food-contract/
 COPY packages/pillar-sdk/ ./packages/pillar-sdk/
@@ -76,8 +70,6 @@ COPY apps/pops-api/scripts ./apps/pops-api/scripts
 WORKDIR /app/packages/db-types
 RUN pnpm build
 WORKDIR /app/packages/media-db
-RUN pnpm build
-WORKDIR /app/packages/inventory-db
 RUN pnpm build
 WORKDIR /app/packages/cerebrum-db
 RUN pnpm build
@@ -100,8 +92,6 @@ RUN pnpm build
 WORKDIR /app/packages/cerebrum-contract
 RUN pnpm build
 WORKDIR /app/packages/core-contract
-RUN pnpm build
-WORKDIR /app/packages/inventory-contract
 RUN pnpm build
 WORKDIR /app/packages/media-contract
 RUN pnpm build
@@ -146,9 +136,6 @@ COPY --from=builder /app/packages/core-db/migrations ./node_modules/@pops/core-d
 COPY --from=builder /app/packages/finance-db/dist ./node_modules/@pops/finance-db/dist
 COPY --from=builder /app/packages/finance-db/package.json ./node_modules/@pops/finance-db/
 COPY --from=builder /app/packages/finance-db/migrations ./node_modules/@pops/finance-db/migrations
-COPY --from=builder /app/packages/inventory-db/dist ./node_modules/@pops/inventory-db/dist
-COPY --from=builder /app/packages/inventory-db/package.json ./node_modules/@pops/inventory-db/
-COPY --from=builder /app/packages/inventory-db/migrations ./node_modules/@pops/inventory-db/migrations
 COPY --from=builder /app/packages/media-db/dist ./node_modules/@pops/media-db/dist
 COPY --from=builder /app/packages/media-db/package.json ./node_modules/@pops/media-db/
 COPY --from=builder /app/packages/media-db/migrations ./node_modules/@pops/media-db/migrations


### PR DESCRIPTION
## What

Phase C of the inventory pillar tRPC→REST migration (mirrors lists #3334). Infra hygiene, no behaviour change.

- **dep-cruiser ban** (`no-dead-inventory-pkgs`): forbids value/type imports of `@pops/(app-inventory-db|inventory-db|inventory-contract|inventory-api)` — those packages no longer exist; inventory collapsed into `pillars/inventory/`. Consumers go through `@pops/inventory` (contract types + api-types + openapi) and the inventory REST API.
- **Baseline**: the two cerebrum consumers still importing `@pops/inventory-db` (`modules/cerebrum/thalamus/cross-source.ts`, `modules/cerebrum/retrieval/semantic-search-metadata.ts`) are recorded as known violations until cerebrum's own migration (the deferred consumer slice). `lint:boundaries` stays green.
- **pops-api Dockerfile**: removed the orphaned `inventory-db` / `inventory-contract` COPY / WORKDIR / build / node_modules steps (those paths don't exist on disk). Scoped to inventory; the file's other dead refs (food-*) are left for their own slice.

## Verification

- `pnpm lint:boundaries` → green (235 known violations = 233 prior + 2 inventory).
- Baseline edited surgically (2 entries appended in the file's existing style), not a wholesale regen.
