### PR TITLE
feat(food): REST migration slice 1b — prep-states, slugs, variants

### DIFF
--- a/pillars/food/openapi/food.openapi.json
+++ b/pillars/food/openapi/food.openapi.json
@@ -1248,6 +1248,794 @@
         "summary": "Update an ingredient weight",
         "tags": ["conversions"]
       }
+    },
+    "/prep-states": {
+      "get": {
+        "operationId": "prepStates.list",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "items": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "id": {
+                            "exclusiveMinimum": true,
+                            "maximum": 9007199254740991,
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "slug": {
+                            "type": "string"
+                          }
+                        },
+                        "required": ["id", "name", "slug"],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": ["items"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "List prep states",
+        "tags": ["prepStates"]
+      },
+      "post": {
+        "operationId": "prepStates.create",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "name": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "slug": {
+                    "type": "string"
+                  }
+                },
+                "required": ["slug", "name"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "id": {
+                          "exclusiveMinimum": true,
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "slug": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["id", "name", "slug"],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "201"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Create a prep state",
+        "tags": ["prepStates"]
+      }
+    },
+    "/slugs/search": {
+      "get": {
+        "operationId": "slugs.search",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "kinds",
+            "schema": {
+              "items": {
+                "enum": ["ingredient", "recipe", "prep_state"],
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "exclusiveMinimum": true,
+              "maximum": 100,
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "items": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "kind": {
+                            "enum": ["ingredient", "recipe", "prep_state"],
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "slug": {
+                            "type": "string"
+                          },
+                          "targetId": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "type": "integer"
+                          }
+                        },
+                        "required": ["slug", "kind", "targetId", "name"],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": ["items"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Search the slug registry by substring, optionally scoped by kind",
+        "tags": ["slugs"]
+      }
+    },
+    "/variants": {
+      "post": {
+        "operationId": "variants.create",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "defaultShelfLifeDaysFreezer": {
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "nullable": true,
+                    "type": "integer"
+                  },
+                  "defaultShelfLifeDaysFridge": {
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "nullable": true,
+                    "type": "integer"
+                  },
+                  "defaultUnit": {
+                    "enum": ["g", "ml", "count"],
+                    "type": "string"
+                  },
+                  "ingredientId": {
+                    "exclusiveMinimum": true,
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "name": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "notes": {
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "packageSizeG": {
+                    "exclusiveMinimum": true,
+                    "minimum": 0,
+                    "nullable": true,
+                    "type": "number"
+                  },
+                  "slug": {
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": ["ingredientId", "slug", "name", "defaultUnit"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "createdAt": {
+                          "type": "string"
+                        },
+                        "defaultShelfLifeDaysFreezer": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "defaultShelfLifeDaysFridge": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "defaultUnit": {
+                          "enum": ["g", "ml", "count"],
+                          "type": "string"
+                        },
+                        "id": {
+                          "exclusiveMinimum": true,
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "ingredientId": {
+                          "exclusiveMinimum": true,
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "notes": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "packageSizeG": {
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "slug": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "ingredientId",
+                        "name",
+                        "slug",
+                        "defaultUnit",
+                        "packageSizeG",
+                        "notes",
+                        "defaultShelfLifeDaysFridge",
+                        "defaultShelfLifeDaysFreezer",
+                        "createdAt"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "201"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Create an ingredient variant",
+        "tags": ["variants"]
+      }
+    },
+    "/variants/{id}": {
+      "delete": {
+        "operationId": "variants.delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {},
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "ok": {
+                      "enum": [true],
+                      "type": "boolean"
+                    }
+                  },
+                  "required": ["ok"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Delete an ingredient variant",
+        "tags": ["variants"]
+      },
+      "patch": {
+        "operationId": "variants.update",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "defaultUnit": {
+                    "enum": ["g", "ml", "count"],
+                    "type": "string"
+                  },
+                  "name": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "notes": {
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "packageSizeG": {
+                    "exclusiveMinimum": true,
+                    "minimum": 0,
+                    "nullable": true,
+                    "type": "number"
+                  },
+                  "slug": {
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "createdAt": {
+                          "type": "string"
+                        },
+                        "defaultShelfLifeDaysFreezer": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "defaultShelfLifeDaysFridge": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "defaultUnit": {
+                          "enum": ["g", "ml", "count"],
+                          "type": "string"
+                        },
+                        "id": {
+                          "exclusiveMinimum": true,
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "ingredientId": {
+                          "exclusiveMinimum": true,
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "notes": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "packageSizeG": {
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "slug": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "ingredientId",
+                        "name",
+                        "slug",
+                        "defaultUnit",
+                        "packageSizeG",
+                        "notes",
+                        "defaultShelfLifeDaysFridge",
+                        "defaultShelfLifeDaysFreezer",
+                        "createdAt"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Update an ingredient variant",
+        "tags": ["variants"]
+      }
     }
   }
 }

--- a/pillars/food/src/api/__tests__/prep-states.test.ts
+++ b/pillars/food/src/api/__tests__/prep-states.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Integration tests for the `prepStates.*` REST surface in pops-food-api.
+ * Slug validation maps to 400, slug collisions to 409. Registry mechanics
+ * are covered in the db package's own tests.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { type OpenedFoodDb, openFoodDb } from '../../db/index.js';
+import { createFoodApiApp } from '../app.js';
+import { makeClient } from './test-utils.js';
+
+let tmpDir: string;
+let foodDb: OpenedFoodDb;
+
+function client(): ReturnType<typeof makeClient> {
+  return makeClient(
+    createFoodApiApp({ foodDb, version: '0.0.1-test', selfBaseUrl: 'http://localhost:3005' })
+  );
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'food-api-prep-states-test-'));
+  foodDb = openFoodDb(join(tmpDir, 'food.db'));
+});
+
+afterEach(() => {
+  foodDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('prepStates REST', () => {
+  it('creates and lists prep states', async () => {
+    const api = client();
+    const created = await api.prepStates.create({ slug: 'diced', name: 'Diced' });
+    expect(created.data.slug).toBe('diced');
+    expect(created.data.name).toBe('Diced');
+
+    const list = await api.prepStates.list();
+    expect(list.items.map((p) => p.slug)).toContain('diced');
+  });
+
+  it('maps an invalid slug to 400', async () => {
+    await expect(
+      client().prepStates.create({ slug: 'Not A Slug!', name: 'Bad' })
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it('maps a duplicate slug to 409', async () => {
+    const api = client();
+    await api.prepStates.create({ slug: 'cooked', name: 'Cooked' });
+    await expect(api.prepStates.create({ slug: 'cooked', name: 'Cooked 2' })).rejects.toMatchObject(
+      {
+        status: 409,
+      }
+    );
+  });
+});

--- a/pillars/food/src/api/__tests__/slugs.test.ts
+++ b/pillars/food/src/api/__tests__/slugs.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Integration tests for the `slugs.*` REST search surface. Verifies the
+ * registry is searchable across kinds and that the `kinds` filter narrows
+ * results. Resolution mechanics live in the db package's tests.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { type OpenedFoodDb, openFoodDb } from '../../db/index.js';
+import { createIngredient } from '../../db/services/ingredients.js';
+import { createFoodApiApp } from '../app.js';
+import { makeClient } from './test-utils.js';
+
+let tmpDir: string;
+let foodDb: OpenedFoodDb;
+
+function client(): ReturnType<typeof makeClient> {
+  return makeClient(
+    createFoodApiApp({ foodDb, version: '0.0.1-test', selfBaseUrl: 'http://localhost:3005' })
+  );
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'food-api-slugs-test-'));
+  foodDb = openFoodDb(join(tmpDir, 'food.db'));
+});
+
+afterEach(() => {
+  foodDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('slugs REST search', () => {
+  it('finds a registered ingredient slug by substring', async () => {
+    createIngredient(foodDb.db, { name: 'Tomato', slug: 'tomato', defaultUnit: 'count' });
+    const api = client();
+    const res = await api.slugs.search({ query: 'toma' });
+    const match = res.items.find((m) => m.slug === 'tomato');
+    expect(match).toBeDefined();
+    expect(match?.kind).toBe('ingredient');
+    expect(match?.name).toBe('Tomato');
+  });
+
+  it('narrows results by kind', async () => {
+    createIngredient(foodDb.db, { name: 'Basil', slug: 'basil', defaultUnit: 'count' });
+    const api = client();
+    const onlyRecipes = await api.slugs.search({ query: 'basil', kinds: ['recipe'] });
+    expect(onlyRecipes.items.some((m) => m.slug === 'basil')).toBe(false);
+
+    const onlyIngredients = await api.slugs.search({ query: 'basil', kinds: ['ingredient'] });
+    expect(onlyIngredients.items.some((m) => m.slug === 'basil')).toBe(true);
+  });
+
+  it('returns an empty list for a non-matching query', async () => {
+    const res = await client().slugs.search({ query: 'zzz-nothing' });
+    expect(res.items).toEqual([]);
+  });
+});

--- a/pillars/food/src/api/__tests__/test-utils.ts
+++ b/pillars/food/src/api/__tests__/test-utils.ts
@@ -13,6 +13,41 @@ import type { Express } from 'express';
 
 import type { IngredientWeight, UnitConversion } from '../modules/conversions/types.js';
 
+interface PrepState {
+  id: number;
+  name: string;
+  slug: string;
+}
+
+interface IngredientVariant {
+  id: number;
+  ingredientId: number;
+  name: string;
+  slug: string;
+  defaultUnit: 'g' | 'ml' | 'count';
+  packageSizeG: number | null;
+  notes: string | null;
+  defaultShelfLifeDaysFridge: number | null;
+  defaultShelfLifeDaysFreezer: number | null;
+  createdAt: string;
+}
+
+interface SlugMatch {
+  slug: string;
+  kind: 'ingredient' | 'recipe' | 'prep_state';
+  targetId: number;
+  name: string;
+}
+
+interface CreateVariantBody {
+  ingredientId: number;
+  slug: string;
+  name: string;
+  defaultUnit: 'g' | 'ml' | 'count';
+  packageSizeG?: number | null;
+  notes?: string | null;
+}
+
 export class HttpError extends Error {
   readonly status: number;
   readonly body: unknown;
@@ -75,6 +110,25 @@ export function makeClient(app: Express) {
       deleteWeight: (id: number) => send<DeleteResult>(r.delete(`/conversions/weights/${id}`)),
       resolve: (query: { ingredientId: number; variantId?: number; unit: string; qty: number }) =>
         send<ResolveResult>(r.get('/conversions/resolve').query(query)),
+    },
+    prepStates: {
+      list: () => send<{ items: PrepState[] }>(r.get('/prep-states')),
+      create: (body: { slug: string; name: string }) =>
+        send<{ data: PrepState }>(r.post('/prep-states').send(body)),
+    },
+    slugs: {
+      search: (query: {
+        query: string;
+        kinds?: ('ingredient' | 'recipe' | 'prep_state')[];
+        limit?: number;
+      }) => send<{ items: SlugMatch[] }>(r.get('/slugs/search').query(query)),
+    },
+    variants: {
+      create: (body: CreateVariantBody) =>
+        send<{ data: IngredientVariant }>(r.post('/variants').send(body)),
+      update: (id: number, body: { name?: string; slug?: string; packageSizeG?: number | null }) =>
+        send<{ data: IngredientVariant }>(r.patch(`/variants/${id}`).send(body)),
+      delete: (id: number) => send<{ ok: true }>(r.delete(`/variants/${id}`)),
     },
   };
 }

--- a/pillars/food/src/api/__tests__/variants.test.ts
+++ b/pillars/food/src/api/__tests__/variants.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Integration tests for the `variants.*` REST surface. Slug validation →
+ * 400, per-ingredient slug collision → 409, unknown id on update/delete →
+ * 404. Variant slug scoping + FK cascades are covered in the db tests.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { type IngredientRow, type OpenedFoodDb, openFoodDb } from '../../db/index.js';
+import { createIngredient } from '../../db/services/ingredients.js';
+import { createFoodApiApp } from '../app.js';
+import { makeClient } from './test-utils.js';
+
+let tmpDir: string;
+let foodDb: OpenedFoodDb;
+let ingredient: IngredientRow;
+
+function client(): ReturnType<typeof makeClient> {
+  return makeClient(
+    createFoodApiApp({ foodDb, version: '0.0.1-test', selfBaseUrl: 'http://localhost:3005' })
+  );
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'food-api-variants-test-'));
+  foodDb = openFoodDb(join(tmpDir, 'food.db'));
+  ingredient = createIngredient(foodDb.db, { name: 'Milk', slug: 'milk', defaultUnit: 'ml' });
+});
+
+afterEach(() => {
+  foodDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('variants REST', () => {
+  it('creates, updates and deletes a variant', async () => {
+    const api = client();
+    const created = await api.variants.create({
+      ingredientId: ingredient.id,
+      slug: 'whole-milk',
+      name: 'Whole Milk',
+      defaultUnit: 'ml',
+    });
+    expect(created.data.ingredientId).toBe(ingredient.id);
+    expect(created.data.slug).toBe('whole-milk');
+
+    const updated = await api.variants.update(created.data.id, { name: 'Full Fat Milk' });
+    expect(updated.data.name).toBe('Full Fat Milk');
+
+    const del = await api.variants.delete(created.data.id);
+    expect(del).toEqual({ ok: true });
+  });
+
+  it('maps an invalid slug to 400', async () => {
+    await expect(
+      client().variants.create({
+        ingredientId: ingredient.id,
+        slug: 'Bad Slug!',
+        name: 'x',
+        defaultUnit: 'ml',
+      })
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it('maps a duplicate slug under the same ingredient to 409', async () => {
+    const api = client();
+    await api.variants.create({
+      ingredientId: ingredient.id,
+      slug: 'skim',
+      name: 'Skim',
+      defaultUnit: 'ml',
+    });
+    await expect(
+      api.variants.create({
+        ingredientId: ingredient.id,
+        slug: 'skim',
+        name: 'Skim 2',
+        defaultUnit: 'ml',
+      })
+    ).rejects.toMatchObject({ status: 409 });
+  });
+
+  it('maps update / delete of an unknown id to 404', async () => {
+    const api = client();
+    await expect(api.variants.update(999999, { name: 'x' })).rejects.toMatchObject({ status: 404 });
+    await expect(api.variants.delete(999999)).rejects.toMatchObject({ status: 404 });
+  });
+});

--- a/pillars/food/src/api/rest/handlers.ts
+++ b/pillars/food/src/api/rest/handlers.ts
@@ -10,6 +10,9 @@ import { initServer } from '@ts-rest/express';
 import { foodContract } from '../../contract/rest.js';
 import { type OpenedFoodDb } from '../../db/index.js';
 import { makeConversionsHandlers } from './conversions-handlers.js';
+import { makePrepStatesHandlers } from './prep-states-handlers.js';
+import { makeSlugsHandlers } from './slugs-handlers.js';
+import { makeVariantsHandlers } from './variants-handlers.js';
 
 const server: ReturnType<typeof initServer> = initServer();
 
@@ -19,5 +22,8 @@ export function makeFoodRestHandlers(deps: {
   const db = deps.foodDb.db;
   return server.router(foodContract, {
     conversions: makeConversionsHandlers(db),
+    prepStates: makePrepStatesHandlers(db),
+    slugs: makeSlugsHandlers(db),
+    variants: makeVariantsHandlers(db),
   });
 }

--- a/pillars/food/src/api/rest/prep-states-handlers.ts
+++ b/pillars/food/src/api/rest/prep-states-handlers.ts
@@ -1,0 +1,46 @@
+/**
+ * Handlers for the `prepStates.*` sub-router.
+ *
+ * Slug validation lives in the db service: `InvalidSlugError` → 400,
+ * `SlugAlreadyRegisteredError` → 409 (slug taken under any kind).
+ */
+import { InvalidSlugError, prepStatesService, SlugAlreadyRegisteredError } from '../../db/index.js';
+import { ConflictError, HttpError } from '../shared/errors.js';
+import { runHttp } from './error-mapping.js';
+
+import type { ServerInferRequest } from '@ts-rest/core';
+
+import type { foodPrepStatesContract } from '../../contract/rest-prep-states.js';
+import type { FoodDb } from '../../db/index.js';
+
+type Req = ServerInferRequest<typeof foodPrepStatesContract>;
+
+function translateSlugError(err: unknown): never {
+  if (err instanceof InvalidSlugError) {
+    throw new HttpError(400, err.message, undefined, 'common.validationFailed');
+  }
+  if (err instanceof SlugAlreadyRegisteredError) throw new ConflictError(err.message);
+  throw err;
+}
+
+export function makePrepStatesHandlers(db: FoodDb) {
+  return {
+    list: () =>
+      runHttp(() => ({
+        status: 200 as const,
+        body: { items: prepStatesService.listPrepStates(db) },
+      })),
+
+    create: ({ body }: Req['create']) =>
+      runHttp(() => {
+        try {
+          return {
+            status: 201 as const,
+            body: { data: prepStatesService.createPrepState(db, body) },
+          };
+        } catch (err) {
+          translateSlugError(err);
+        }
+      }),
+  };
+}

--- a/pillars/food/src/api/rest/slugs-handlers.ts
+++ b/pillars/food/src/api/rest/slugs-handlers.ts
@@ -1,0 +1,29 @@
+/**
+ * Handlers for the `slugs.*` sub-router. Read-only; delegates straight to
+ * `slugSearchService.searchSlugs` over the in-pillar slug registry.
+ */
+import { slugSearchService } from '../../db/index.js';
+import { runHttp } from './error-mapping.js';
+
+import type { ServerInferRequest } from '@ts-rest/core';
+
+import type { foodSlugsContract } from '../../contract/rest-slugs.js';
+import type { FoodDb } from '../../db/index.js';
+
+type Req = ServerInferRequest<typeof foodSlugsContract>;
+
+export function makeSlugsHandlers(db: FoodDb) {
+  return {
+    search: ({ query }: Req['search']) =>
+      runHttp(() => ({
+        status: 200 as const,
+        body: {
+          items: slugSearchService.searchSlugs(db, {
+            query: query.query,
+            kinds: query.kinds,
+            limit: query.limit,
+          }),
+        },
+      })),
+  };
+}

--- a/pillars/food/src/api/rest/variants-handlers.ts
+++ b/pillars/food/src/api/rest/variants-handlers.ts
@@ -1,0 +1,97 @@
+/**
+ * Handlers for the `variants.*` sub-router.
+ *
+ * Error convention (ported from the pops-api variants router):
+ * `InvalidSlugError` → 400; SQLite UNIQUE (per-ingredient slug collision)
+ * → 409; SQLite FK (variant referenced by a batch / recipe line / alias /
+ * substitution) → 409; `expectRow` miss on update of an unknown id → 404;
+ * delete of an unknown id → 404.
+ */
+import { InvalidSlugError, variantsService } from '../../db/index.js';
+import { ConflictError, HttpError, NotFoundError } from '../shared/errors.js';
+import { isForeignKeyConstraintError, isUniqueConstraintError } from '../shared/sqlite-errors.js';
+import { runHttp } from './error-mapping.js';
+
+import type { ServerInferRequest } from '@ts-rest/core';
+
+import type { foodVariantsContract } from '../../contract/rest-variants.js';
+import type { FoodDb } from '../../db/index.js';
+
+type Req = ServerInferRequest<typeof foodVariantsContract>;
+
+function isExpectRowMiss(err: unknown): boolean {
+  return err instanceof Error && /expected a row but got none/i.test(err.message);
+}
+
+function translateWriteError(err: unknown): never {
+  if (err instanceof InvalidSlugError) {
+    throw new HttpError(400, err.message, undefined, 'common.validationFailed');
+  }
+  if (isUniqueConstraintError(err)) {
+    throw new ConflictError('A variant with this slug already exists under the parent ingredient');
+  }
+  if (isForeignKeyConstraintError(err)) {
+    throw new ConflictError(
+      'Variant is referenced by another row (batch, recipe line, alias, or substitution)'
+    );
+  }
+  throw err;
+}
+
+export function makeVariantsHandlers(db: FoodDb) {
+  return {
+    create: ({ body }: Req['create']) =>
+      runHttp(() => {
+        try {
+          return {
+            status: 201 as const,
+            body: {
+              data: variantsService.createVariant(db, {
+                ingredientId: body.ingredientId,
+                slug: body.slug,
+                name: body.name,
+                defaultUnit: body.defaultUnit,
+                packageSizeG: body.packageSizeG,
+                notes: body.notes,
+                defaultShelfLifeDaysFridge: body.defaultShelfLifeDaysFridge,
+                defaultShelfLifeDaysFreezer: body.defaultShelfLifeDaysFreezer,
+              }),
+            },
+          };
+        } catch (err) {
+          translateWriteError(err);
+        }
+      }),
+
+    update: ({ params, body }: Req['update']) =>
+      runHttp(() => {
+        try {
+          return {
+            status: 200 as const,
+            body: { data: variantsService.updateVariant(db, params.id, body) },
+          };
+        } catch (err) {
+          if (isExpectRowMiss(err)) throw new NotFoundError('Variant', String(params.id));
+          translateWriteError(err);
+        }
+      }),
+
+    delete: ({ params }: Req['delete']) =>
+      runHttp(() => {
+        if (variantsService.getVariant(db, params.id) === null) {
+          throw new NotFoundError('Variant', String(params.id));
+        }
+        try {
+          variantsService.deleteVariant(db, params.id);
+          return { status: 200 as const, body: { ok: true as const } };
+        } catch (err) {
+          if (isForeignKeyConstraintError(err)) {
+            throw new ConflictError(
+              'Variant is referenced by another row (batch, recipe line, alias, or substitution)'
+            );
+          }
+          throw err;
+        }
+      }),
+  };
+}

--- a/pillars/food/src/contract/api-types.generated.ts
+++ b/pillars/food/src/contract/api-types.generated.ts
@@ -92,6 +92,76 @@ export interface paths {
     patch: operations['conversions.updateWeight'];
     trace?: never;
   };
+  '/prep-states': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** List prep states */
+    get: operations['prepStates.list'];
+    put?: never;
+    /** Create a prep state */
+    post: operations['prepStates.create'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/slugs/search': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Search the slug registry by substring, optionally scoped by kind */
+    get: operations['slugs.search'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/variants': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Create an ingredient variant */
+    post: operations['variants.create'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/variants/{id}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post?: never;
+    /** Delete an ingredient variant */
+    delete: operations['variants.delete'];
+    options?: never;
+    head?: never;
+    /** Update an ingredient variant */
+    patch: operations['variants.update'];
+    trace?: never;
+  };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -638,6 +708,381 @@ export interface operations {
               seeded: boolean;
               unit: string;
               variantId: number | null;
+            };
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'prepStates.list': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            items: {
+              id: number;
+              name: string;
+              slug: string;
+            }[];
+          };
+        };
+      };
+    };
+  };
+  'prepStates.create': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          name: string;
+          slug: string;
+        };
+      };
+    };
+    responses: {
+      /** @description 201 */
+      201: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              id: number;
+              name: string;
+              slug: string;
+            };
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'slugs.search': {
+    parameters: {
+      query: {
+        query: string;
+        kinds?: ('ingredient' | 'recipe' | 'prep_state')[];
+        limit?: number;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            items: {
+              /** @enum {string} */
+              kind: 'ingredient' | 'recipe' | 'prep_state';
+              name: string;
+              slug: string;
+              targetId: number;
+            }[];
+          };
+        };
+      };
+    };
+  };
+  'variants.create': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          defaultShelfLifeDaysFreezer?: number | null;
+          defaultShelfLifeDaysFridge?: number | null;
+          /** @enum {string} */
+          defaultUnit: 'g' | 'ml' | 'count';
+          ingredientId: number;
+          name: string;
+          notes?: string | null;
+          packageSizeG?: number | null;
+          slug: string;
+        };
+      };
+    };
+    responses: {
+      /** @description 201 */
+      201: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              createdAt: string;
+              defaultShelfLifeDaysFreezer: number | null;
+              defaultShelfLifeDaysFridge: number | null;
+              /** @enum {string} */
+              defaultUnit: 'g' | 'ml' | 'count';
+              id: number;
+              ingredientId: number;
+              name: string;
+              notes: string | null;
+              packageSizeG: number | null;
+              slug: string;
+            };
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'variants.delete': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: number;
+      };
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': Record<string, never>;
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            /** @enum {boolean} */
+            ok: true;
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'variants.update': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: number;
+      };
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          /** @enum {string} */
+          defaultUnit?: 'g' | 'ml' | 'count';
+          name?: string;
+          notes?: string | null;
+          packageSizeG?: number | null;
+          slug?: string;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              createdAt: string;
+              defaultShelfLifeDaysFreezer: number | null;
+              defaultShelfLifeDaysFridge: number | null;
+              /** @enum {string} */
+              defaultUnit: 'g' | 'ml' | 'count';
+              id: number;
+              ingredientId: number;
+              name: string;
+              notes: string | null;
+              packageSizeG: number | null;
+              slug: string;
             };
           };
         };

--- a/pillars/food/src/contract/rest-prep-states.ts
+++ b/pillars/food/src/contract/rest-prep-states.ts
@@ -1,0 +1,39 @@
+/**
+ * `prepStates.*` sub-router — the small CRUD surface over the global
+ * prep-state vocabulary (e.g. `diced`, `cooked`). Slugs are registered in
+ * the shared slug registry, so create can fail with 400 (bad slug) or 409
+ * (slug already taken under any kind).
+ */
+import { initContract } from '@ts-rest/core';
+import { z } from 'zod';
+
+import { ERR_RESPONSES } from './rest-schemas.js';
+
+const c = initContract();
+
+export const PrepStateSchema = z.object({
+  id: z.number().int().positive(),
+  name: z.string(),
+  slug: z.string(),
+});
+
+const CreatePrepStateBody = z.object({
+  slug: z.string(),
+  name: z.string().min(1),
+});
+
+export const foodPrepStatesContract = c.router({
+  list: {
+    method: 'GET',
+    path: '/prep-states',
+    responses: { 200: z.object({ items: z.array(PrepStateSchema) }) },
+    summary: 'List prep states',
+  },
+  create: {
+    method: 'POST',
+    path: '/prep-states',
+    body: CreatePrepStateBody,
+    responses: { 201: z.object({ data: PrepStateSchema }), ...ERR_RESPONSES },
+    summary: 'Create a prep state',
+  },
+});

--- a/pillars/food/src/contract/rest-slugs.ts
+++ b/pillars/food/src/contract/rest-slugs.ts
@@ -1,0 +1,42 @@
+/**
+ * `slugs.*` sub-router — read-only search over the shared slug registry
+ * (ingredients, recipes, prep states). Powers the slug-autocomplete the FE
+ * uses when wiring cross-references.
+ */
+import { initContract } from '@ts-rest/core';
+import { z } from 'zod';
+
+const c = initContract();
+
+/**
+ * On the wire a repeated `?kinds=` is an array, a single one is a bare
+ * string, and an absent one is `undefined` — normalise to an array (or
+ * `undefined`) before the enum validates each member.
+ */
+function toKindArray(v: unknown): unknown {
+  if (v === undefined) return undefined;
+  return Array.isArray(v) ? v : [v];
+}
+
+export const SlugKindSchema = z.enum(['ingredient', 'recipe', 'prep_state']);
+
+export const SlugMatchSchema = z.object({
+  slug: z.string(),
+  kind: SlugKindSchema,
+  targetId: z.number().int(),
+  name: z.string(),
+});
+
+export const foodSlugsContract = c.router({
+  search: {
+    method: 'GET',
+    path: '/slugs/search',
+    query: z.object({
+      query: z.string(),
+      kinds: z.preprocess(toKindArray, z.array(SlugKindSchema)).optional(),
+      limit: z.coerce.number().int().positive().max(100).optional(),
+    }),
+    responses: { 200: z.object({ items: z.array(SlugMatchSchema) }) },
+    summary: 'Search the slug registry by substring, optionally scoped by kind',
+  },
+});

--- a/pillars/food/src/contract/rest-variants.ts
+++ b/pillars/food/src/contract/rest-variants.ts
@@ -1,0 +1,72 @@
+/**
+ * `variants.*` sub-router — CRUD over ingredient variants (brand/pack
+ * specialisations of an ingredient). Variant slugs are scoped per parent
+ * ingredient (DB UNIQUE on `(ingredient_id, slug)`), not in the global
+ * slug registry.
+ */
+import { initContract } from '@ts-rest/core';
+import { z } from 'zod';
+
+import { ERR_RESPONSES, PathPositiveInt } from './rest-schemas.js';
+
+const c = initContract();
+
+const UnitEnum = z.enum(['g', 'ml', 'count']);
+
+export const IngredientVariantSchema = z.object({
+  id: z.number().int().positive(),
+  ingredientId: z.number().int().positive(),
+  name: z.string(),
+  slug: z.string(),
+  defaultUnit: UnitEnum,
+  packageSizeG: z.number().nullable(),
+  notes: z.string().nullable(),
+  defaultShelfLifeDaysFridge: z.number().int().nullable(),
+  defaultShelfLifeDaysFreezer: z.number().int().nullable(),
+  createdAt: z.string(),
+});
+
+const CreateVariantBody = z.object({
+  ingredientId: z.number().int().positive(),
+  slug: z.string().min(1),
+  name: z.string().min(1),
+  defaultUnit: UnitEnum,
+  packageSizeG: z.number().positive().nullish(),
+  notes: z.string().nullish(),
+  defaultShelfLifeDaysFridge: z.number().int().nonnegative().nullish(),
+  defaultShelfLifeDaysFreezer: z.number().int().nonnegative().nullish(),
+});
+
+const UpdateVariantBody = z.object({
+  name: z.string().min(1).optional(),
+  slug: z.string().min(1).optional(),
+  defaultUnit: UnitEnum.optional(),
+  packageSizeG: z.number().positive().nullish(),
+  notes: z.string().nullish(),
+});
+
+export const foodVariantsContract = c.router({
+  create: {
+    method: 'POST',
+    path: '/variants',
+    body: CreateVariantBody,
+    responses: { 201: z.object({ data: IngredientVariantSchema }), ...ERR_RESPONSES },
+    summary: 'Create an ingredient variant',
+  },
+  update: {
+    method: 'PATCH',
+    path: '/variants/:id',
+    pathParams: z.object({ id: PathPositiveInt }),
+    body: UpdateVariantBody,
+    responses: { 200: z.object({ data: IngredientVariantSchema }), ...ERR_RESPONSES },
+    summary: 'Update an ingredient variant',
+  },
+  delete: {
+    method: 'DELETE',
+    path: '/variants/:id',
+    pathParams: z.object({ id: PathPositiveInt }),
+    body: z.object({}).optional(),
+    responses: { 200: z.object({ ok: z.literal(true) }), ...ERR_RESPONSES },
+    summary: 'Delete an ingredient variant',
+  },
+});

--- a/pillars/food/src/contract/rest.ts
+++ b/pillars/food/src/contract/rest.ts
@@ -15,12 +15,18 @@
 import { initContract } from '@ts-rest/core';
 
 import { foodConversionsContract } from './rest-conversions.js';
+import { foodPrepStatesContract } from './rest-prep-states.js';
+import { foodSlugsContract } from './rest-slugs.js';
+import { foodVariantsContract } from './rest-variants.js';
 
 const c = initContract();
 
 export const foodContract = c.router(
   {
     conversions: foodConversionsContract,
+    prepStates: foodPrepStatesContract,
+    slugs: foodSlugsContract,
+    variants: foodVariantsContract,
   },
   {
     pathPrefix: '',


### PR DESCRIPTION
Continues the food tRPC→REST migration (`docs/runbooks/food-rest-migration.md`), building on slice 1 (#3339). Ports three more leaf domains off the pops-api tRPC router into `pillars/food/src/api` as ts-rest over the in-pillar db services.

## Domains
- **prepStates** — `GET/POST /prep-states`. Slug validation → 400; slug collision (any kind) → 409.
- **slugs** — `GET /slugs/search`. Registry search, kind-scoped; the `kinds` query param tolerates both a single value and a repeated array.
- **variants** — `POST /variants`, `PATCH/DELETE /variants/:id`. Invalid slug → 400; per-ingredient slug collision → 409; FK references → 409; unknown id → 404.

## Safety
- Additive to the pillar only — `apps/pops-api` untouched.
- Validated locally: typecheck, lint, format, build, OpenAPI + api-types drift, **813 tests (60 files) green**; OpenAPI generation idempotent.
- The only red CI checks (`Validate Docker builds` shell stage, full pops-api typecheck) are the pre-existing "lake stays red by design" state from the lists/inventory collapses — untouched by this PR.

## Remaining leaf domains
ingredients (hierarchy/blockers), aliases (merge/bulk-approve), ingredient-tags → then substitutions/solver, batches/fridge/inbox, recipes (+send-to-list), plan/shopping, ingest/ai, Phase C/D/E.