### PR TITLE
feat(food): REST migration slice 1c — ingredient-tags + aliases

### DIFF
--- a/pillars/food/openapi/food.openapi.json
+++ b/pillars/food/openapi/food.openapi.json
@@ -9,6 +9,917 @@
   },
   "openapi": "3.0.2",
   "paths": {
+    "/aliases": {
+      "get": {
+        "operationId": "aliases.list",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "search",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "source",
+            "schema": {
+              "enum": ["user", "llm", "ingest"],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "targetKind",
+            "schema": {
+              "enum": ["ingredient", "variant"],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "targetId",
+            "schema": {
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "items": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "alias": {
+                            "type": "string"
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          },
+                          "id": {
+                            "exclusiveMinimum": true,
+                            "maximum": 9007199254740991,
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "ingredientId": {
+                            "exclusiveMinimum": true,
+                            "maximum": 9007199254740991,
+                            "minimum": 0,
+                            "nullable": true,
+                            "type": "integer"
+                          },
+                          "source": {
+                            "enum": ["user", "llm", "ingest"],
+                            "type": "string"
+                          },
+                          "variantId": {
+                            "exclusiveMinimum": true,
+                            "maximum": 9007199254740991,
+                            "minimum": 0,
+                            "nullable": true,
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "ingredientId",
+                          "variantId",
+                          "alias",
+                          "source",
+                          "createdAt"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": ["items"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "List aliases (optionally filtered by search / source / target)",
+        "tags": ["aliases"]
+      },
+      "post": {
+        "operationId": "aliases.create",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "alias": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "source": {
+                    "enum": ["user", "llm", "ingest"],
+                    "type": "string"
+                  },
+                  "target": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "id": {
+                        "exclusiveMinimum": true,
+                        "maximum": 9007199254740991,
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "kind": {
+                        "enum": ["ingredient", "variant"],
+                        "type": "string"
+                      }
+                    },
+                    "required": ["kind", "id"],
+                    "type": "object"
+                  }
+                },
+                "required": ["alias", "target"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "alias": {
+                          "type": "string"
+                        },
+                        "createdAt": {
+                          "type": "string"
+                        },
+                        "id": {
+                          "exclusiveMinimum": true,
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "ingredientId": {
+                          "exclusiveMinimum": true,
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "source": {
+                          "enum": ["user", "llm", "ingest"],
+                          "type": "string"
+                        },
+                        "variantId": {
+                          "exclusiveMinimum": true,
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "nullable": true,
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "ingredientId",
+                        "variantId",
+                        "alias",
+                        "source",
+                        "createdAt"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "201"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Create an alias",
+        "tags": ["aliases"]
+      }
+    },
+    "/aliases/bulk-approve": {
+      "post": {
+        "operationId": "aliases.bulkApprove",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "aliasIds": {
+                    "items": {
+                      "exclusiveMinimum": true,
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                  }
+                },
+                "required": ["aliasIds"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "updatedCount": {
+                      "maximum": 9007199254740991,
+                      "minimum": -9007199254740991,
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["updatedCount"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Flip llm-sourced aliases to user-approved",
+        "tags": ["aliases"]
+      }
+    },
+    "/aliases/merge": {
+      "post": {
+        "operationId": "aliases.merge",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "aliasIds": {
+                    "items": {
+                      "exclusiveMinimum": true,
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                  },
+                  "target": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "id": {
+                        "exclusiveMinimum": true,
+                        "maximum": 9007199254740991,
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "kind": {
+                        "enum": ["ingredient", "variant"],
+                        "type": "string"
+                      }
+                    },
+                    "required": ["kind", "id"],
+                    "type": "object"
+                  }
+                },
+                "required": ["aliasIds", "target"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "mergedCount": {
+                      "maximum": 9007199254740991,
+                      "minimum": -9007199254740991,
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["mergedCount"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Re-point several aliases onto a single canonical target",
+        "tags": ["aliases"]
+      }
+    },
+    "/aliases/with-targets": {
+      "get": {
+        "operationId": "aliases.listWithTargets",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "search",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "source",
+            "schema": {
+              "enum": ["user", "llm", "ingest"],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "targetKind",
+            "schema": {
+              "enum": ["ingredient", "variant"],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "targetId",
+            "schema": {
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "items": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "alias": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "alias": {
+                                "type": "string"
+                              },
+                              "createdAt": {
+                                "type": "string"
+                              },
+                              "id": {
+                                "exclusiveMinimum": true,
+                                "maximum": 9007199254740991,
+                                "minimum": 0,
+                                "type": "integer"
+                              },
+                              "source": {
+                                "enum": ["user", "llm", "ingest"],
+                                "type": "string"
+                              }
+                            },
+                            "required": ["id", "alias", "source", "createdAt"],
+                            "type": "object"
+                          },
+                          "target": {
+                            "oneOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "id": {
+                                    "exclusiveMinimum": true,
+                                    "maximum": 9007199254740991,
+                                    "minimum": 0,
+                                    "type": "integer"
+                                  },
+                                  "kind": {
+                                    "enum": ["ingredient"],
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "slug": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": ["kind", "id", "slug", "name"],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "id": {
+                                    "exclusiveMinimum": true,
+                                    "maximum": 9007199254740991,
+                                    "minimum": 0,
+                                    "type": "integer"
+                                  },
+                                  "kind": {
+                                    "enum": ["variant"],
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "parentIngredientName": {
+                                    "type": "string"
+                                  },
+                                  "parentIngredientSlug": {
+                                    "type": "string"
+                                  },
+                                  "slug": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "kind",
+                                  "id",
+                                  "slug",
+                                  "name",
+                                  "parentIngredientSlug",
+                                  "parentIngredientName"
+                                ],
+                                "type": "object"
+                              }
+                            ]
+                          }
+                        },
+                        "required": ["alias", "target"],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": ["items"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "List aliases joined with their resolved target metadata",
+        "tags": ["aliases"]
+      }
+    },
+    "/aliases/{id}": {
+      "delete": {
+        "operationId": "aliases.delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {},
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "ok": {
+                      "enum": [true],
+                      "type": "boolean"
+                    }
+                  },
+                  "required": ["ok"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Delete an alias",
+        "tags": ["aliases"]
+      },
+      "patch": {
+        "operationId": "aliases.updateText",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "alias": {
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": ["alias"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "alias": {
+                          "type": "string"
+                        },
+                        "createdAt": {
+                          "type": "string"
+                        },
+                        "id": {
+                          "exclusiveMinimum": true,
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "ingredientId": {
+                          "exclusiveMinimum": true,
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "source": {
+                          "enum": ["user", "llm", "ingest"],
+                          "type": "string"
+                        },
+                        "variantId": {
+                          "exclusiveMinimum": true,
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "nullable": true,
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "ingredientId",
+                        "variantId",
+                        "alias",
+                        "source",
+                        "createdAt"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Rename an alias",
+        "tags": ["aliases"]
+      }
+    },
     "/conversions/resolve": {
       "get": {
         "operationId": "conversions.resolve",
@@ -1247,6 +2158,247 @@
         },
         "summary": "Update an ingredient weight",
         "tags": ["conversions"]
+      }
+    },
+    "/ingredient-tags": {
+      "get": {
+        "operationId": "ingredientTags.list",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "ingredientId",
+            "required": true,
+            "schema": {
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "tags": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": ["tags"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "List an ingredient's tags",
+        "tags": ["ingredientTags"]
+      }
+    },
+    "/ingredient-tags/by-tag": {
+      "get": {
+        "operationId": "ingredientTags.byTag",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "tag",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "ingredients": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "id": {
+                            "exclusiveMinimum": true,
+                            "maximum": 9007199254740991,
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "slug": {
+                            "type": "string"
+                          }
+                        },
+                        "required": ["id", "slug", "name"],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": ["ingredients"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Ingredients carrying a given tag",
+        "tags": ["ingredientTags"]
+      }
+    },
+    "/ingredient-tags/distinct": {
+      "get": {
+        "operationId": "ingredientTags.distinct",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "namespacePrefix",
+            "schema": {
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "exclusiveMinimum": true,
+              "maximum": 500,
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "tags": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "firstSeenAt": {
+                            "type": "string"
+                          },
+                          "ingredientCount": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "type": "integer"
+                          },
+                          "tag": {
+                            "type": "string"
+                          }
+                        },
+                        "required": ["tag", "ingredientCount", "firstSeenAt"],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": ["tags"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Distinct tags with usage counts (optionally namespace-scoped)",
+        "tags": ["ingredientTags"]
+      }
+    },
+    "/ingredient-tags/{ingredientId}": {
+      "put": {
+        "operationId": "ingredientTags.set",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "ingredientId",
+            "required": true,
+            "schema": {
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "tags": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": ["tags"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "ok": {
+                          "enum": [true],
+                          "type": "boolean"
+                        }
+                      },
+                      "required": ["ok"],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "ok": {
+                          "enum": [false],
+                          "type": "boolean"
+                        },
+                        "reason": {
+                          "enum": ["BadTagFormat", "TagTooLong", "IngredientNotFound"],
+                          "type": "string"
+                        }
+                      },
+                      "required": ["ok", "reason"],
+                      "type": "object"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Replace an ingredient's tag set",
+        "tags": ["ingredientTags"]
       }
     },
     "/prep-states": {

--- a/pillars/food/src/api/__tests__/aliases.test.ts
+++ b/pillars/food/src/api/__tests__/aliases.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Integration tests for the `aliases.*` REST surface — CRUD plus the bulk
+ * merge / approve operations. UNIQUE collisions map to 409; merge + approve
+ * return their service counts.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { type IngredientRow, type OpenedFoodDb, openFoodDb } from '../../db/index.js';
+import { createIngredient } from '../../db/services/ingredients.js';
+import { createFoodApiApp } from '../app.js';
+import { makeClient } from './test-utils.js';
+
+let tmpDir: string;
+let foodDb: OpenedFoodDb;
+let ingA: IngredientRow;
+let ingB: IngredientRow;
+
+function client(): ReturnType<typeof makeClient> {
+  return makeClient(
+    createFoodApiApp({ foodDb, version: '0.0.1-test', selfBaseUrl: 'http://localhost:3005' })
+  );
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'food-api-aliases-test-'));
+  foodDb = openFoodDb(join(tmpDir, 'food.db'));
+  ingA = createIngredient(foodDb.db, {
+    name: 'Coriander',
+    slug: 'coriander',
+    defaultUnit: 'count',
+  });
+  ingB = createIngredient(foodDb.db, { name: 'Cilantro', slug: 'cilantro', defaultUnit: 'count' });
+});
+
+afterEach(() => {
+  foodDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('aliases REST', () => {
+  it('creates, lists, renames and deletes an alias', async () => {
+    const api = client();
+    const created = await api.aliases.create({
+      alias: 'dhania',
+      target: { kind: 'ingredient', id: ingA.id },
+    });
+    expect(created.data.alias).toBe('dhania');
+    expect(created.data.ingredientId).toBe(ingA.id);
+    expect(created.data.source).toBe('user');
+
+    const list = await api.aliases.list();
+    expect(list.items.map((a) => a.alias)).toContain('dhania');
+
+    const renamed = await api.aliases.updateText(created.data.id, 'dhaniya');
+    expect(renamed.data.alias).toBe('dhaniya');
+
+    const del = await api.aliases.delete(created.data.id);
+    expect(del).toEqual({ ok: true });
+  });
+
+  it('maps a duplicate alias for the same target to 409', async () => {
+    const api = client();
+    await api.aliases.create({ alias: 'dhania', target: { kind: 'ingredient', id: ingA.id } });
+    await expect(
+      api.aliases.create({ alias: 'dhania', target: { kind: 'ingredient', id: ingA.id } })
+    ).rejects.toMatchObject({ status: 409 });
+  });
+
+  it('bulk-approves llm aliases to user', async () => {
+    const api = client();
+    const a = await api.aliases.create({
+      alias: 'koriander',
+      target: { kind: 'ingredient', id: ingA.id },
+      source: 'llm',
+    });
+    const res = await api.aliases.bulkApprove([a.data.id]);
+    expect(res.updatedCount).toBe(1);
+
+    const list = await api.aliases.list({ source: 'user' });
+    expect(list.items.some((x) => x.id === a.data.id)).toBe(true);
+  });
+
+  it('merges aliases onto a single target', async () => {
+    const api = client();
+    const a = await api.aliases.create({
+      alias: 'chinese-parsley',
+      target: { kind: 'ingredient', id: ingA.id },
+    });
+    const res = await api.aliases.merge([a.data.id], { kind: 'ingredient', id: ingB.id });
+    expect(res.mergedCount).toBeGreaterThanOrEqual(1);
+
+    // merge re-points by delete + re-insert, so the row id changes — assert
+    // on the stable alias text instead.
+    const all = await api.aliases.list();
+    const moved = all.items.find((x) => x.alias === 'chinese-parsley');
+    expect(moved?.ingredientId).toBe(ingB.id);
+  });
+});

--- a/pillars/food/src/api/__tests__/ingredient-tags.test.ts
+++ b/pillars/food/src/api/__tests__/ingredient-tags.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Integration tests for the `ingredientTags.*` REST surface. `set` is a
+ * full replacement; validation failures surface as a structured
+ * `{ ok: false, reason }` (200), not an HTTP error.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { type IngredientRow, type OpenedFoodDb, openFoodDb } from '../../db/index.js';
+import { createIngredient } from '../../db/services/ingredients.js';
+import { createFoodApiApp } from '../app.js';
+import { makeClient } from './test-utils.js';
+
+let tmpDir: string;
+let foodDb: OpenedFoodDb;
+let ing: IngredientRow;
+
+function client(): ReturnType<typeof makeClient> {
+  return makeClient(
+    createFoodApiApp({ foodDb, version: '0.0.1-test', selfBaseUrl: 'http://localhost:3005' })
+  );
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'food-api-ingredient-tags-test-'));
+  foodDb = openFoodDb(join(tmpDir, 'food.db'));
+  ing = createIngredient(foodDb.db, { name: 'Carrot', slug: 'carrot', defaultUnit: 'count' });
+});
+
+afterEach(() => {
+  foodDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('ingredientTags REST', () => {
+  it('sets and lists tags (full replacement)', async () => {
+    const api = client();
+    const set = await api.ingredientTags.set(ing.id, ['store-section:produce', 'diet:vegan']);
+    expect(set).toEqual({ ok: true });
+
+    const list = await api.ingredientTags.list(ing.id);
+    expect(list.tags.toSorted()).toEqual(['diet:vegan', 'store-section:produce']);
+
+    await api.ingredientTags.set(ing.id, ['diet:vegan']);
+    const after = await api.ingredientTags.list(ing.id);
+    expect(after.tags).toEqual(['diet:vegan']);
+  });
+
+  it('rejects a malformed tag with ok:false / BadTagFormat', async () => {
+    const res = await client().ingredientTags.set(ing.id, ['Not A Tag!']);
+    expect(res).toEqual({ ok: false, reason: 'BadTagFormat' });
+  });
+
+  it('reports an unknown ingredient as ok:false / IngredientNotFound', async () => {
+    const res = await client().ingredientTags.set(999999, ['diet:vegan']);
+    expect(res).toEqual({ ok: false, reason: 'IngredientNotFound' });
+  });
+
+  it('lists distinct tags with counts and finds ingredients by tag', async () => {
+    const api = client();
+    const beet = createIngredient(foodDb.db, { name: 'Beet', slug: 'beet', defaultUnit: 'count' });
+    await api.ingredientTags.set(ing.id, ['store-section:produce']);
+    await api.ingredientTags.set(beet.id, ['store-section:produce']);
+
+    const distinct = await api.ingredientTags.distinct({ namespacePrefix: 'store-section' });
+    const row = distinct.tags.find((t) => t.tag === 'store-section:produce');
+    expect(row?.ingredientCount).toBe(2);
+
+    const byTag = await api.ingredientTags.byTag('store-section:produce');
+    expect(byTag.ingredients.map((i) => i.slug).toSorted()).toEqual(['beet', 'carrot']);
+  });
+});

--- a/pillars/food/src/api/__tests__/test-utils.ts
+++ b/pillars/food/src/api/__tests__/test-utils.ts
@@ -48,6 +48,22 @@ interface CreateVariantBody {
   notes?: string | null;
 }
 
+type AliasSource = 'user' | 'llm' | 'ingest';
+type AliasTarget = { kind: 'ingredient' | 'variant'; id: number };
+
+interface IngredientAlias {
+  id: number;
+  ingredientId: number | null;
+  variantId: number | null;
+  alias: string;
+  source: AliasSource;
+  createdAt: string;
+}
+
+type TagOpResult =
+  | { ok: true }
+  | { ok: false; reason: 'BadTagFormat' | 'TagTooLong' | 'IngredientNotFound' };
+
 export class HttpError extends Error {
   readonly status: number;
   readonly body: unknown;
@@ -129,6 +145,35 @@ export function makeClient(app: Express) {
       update: (id: number, body: { name?: string; slug?: string; packageSizeG?: number | null }) =>
         send<{ data: IngredientVariant }>(r.patch(`/variants/${id}`).send(body)),
       delete: (id: number) => send<{ ok: true }>(r.delete(`/variants/${id}`)),
+    },
+    ingredientTags: {
+      list: (ingredientId: number) =>
+        send<{ tags: string[] }>(r.get('/ingredient-tags').query({ ingredientId })),
+      distinct: (query: { namespacePrefix?: string; limit?: number } = {}) =>
+        send<{ tags: { tag: string; ingredientCount: number; firstSeenAt: string }[] }>(
+          r.get('/ingredient-tags/distinct').query(query)
+        ),
+      byTag: (tag: string) =>
+        send<{ ingredients: { id: number; slug: string; name: string }[] }>(
+          r.get('/ingredient-tags/by-tag').query({ tag })
+        ),
+      set: (ingredientId: number, tags: string[]) =>
+        send<TagOpResult>(r.put(`/ingredient-tags/${ingredientId}`).send({ tags })),
+    },
+    aliases: {
+      list: (query: { search?: string; source?: AliasSource } = {}) =>
+        send<{ items: IngredientAlias[] }>(r.get('/aliases').query(query)),
+      listWithTargets: (query: { search?: string } = {}) =>
+        send<{ items: unknown[] }>(r.get('/aliases/with-targets').query(query)),
+      create: (body: { alias: string; target: AliasTarget; source?: AliasSource }) =>
+        send<{ data: IngredientAlias }>(r.post('/aliases').send(body)),
+      updateText: (id: number, alias: string) =>
+        send<{ data: IngredientAlias }>(r.patch(`/aliases/${id}`).send({ alias })),
+      delete: (id: number) => send<{ ok: true }>(r.delete(`/aliases/${id}`)),
+      merge: (aliasIds: number[], target: AliasTarget) =>
+        send<{ mergedCount: number }>(r.post('/aliases/merge').send({ aliasIds, target })),
+      bulkApprove: (aliasIds: number[]) =>
+        send<{ updatedCount: number }>(r.post('/aliases/bulk-approve').send({ aliasIds })),
     },
   };
 }

--- a/pillars/food/src/api/rest/aliases-handlers.ts
+++ b/pillars/food/src/api/rest/aliases-handlers.ts
@@ -1,0 +1,106 @@
+/**
+ * Handlers for the `aliases.*` sub-router.
+ *
+ * Error convention (ported from the pops-api aliases router): SQLite UNIQUE
+ * on create/rename (an alias already exists for that target) → 409. The
+ * list filters accept a `(targetKind, targetId)` pair which is folded back
+ * into the service's `{ kind, id }` target shape.
+ */
+import { aliasesService } from '../../db/index.js';
+import { ConflictError } from '../shared/errors.js';
+import { isUniqueConstraintError } from '../shared/sqlite-errors.js';
+import { runHttp } from './error-mapping.js';
+
+import type { ServerInferRequest } from '@ts-rest/core';
+
+import type { foodAliasesContract } from '../../contract/rest-aliases.js';
+import type { FoodDb } from '../../db/index.js';
+import type { AliasSource, AliasTarget } from '../../db/services/aliases.js';
+
+type Req = ServerInferRequest<typeof foodAliasesContract>;
+
+interface ListQuery {
+  search?: string;
+  source?: AliasSource;
+  targetKind?: 'ingredient' | 'variant';
+  targetId?: number;
+}
+
+function toListInput(query: ListQuery): {
+  search?: string;
+  source?: AliasSource;
+  target?: AliasTarget;
+} {
+  const target =
+    query.targetKind !== undefined && query.targetId !== undefined
+      ? { kind: query.targetKind, id: query.targetId }
+      : undefined;
+  return { search: query.search, source: query.source, target };
+}
+
+function runUniqueAsConflict<T>(message: string, fn: () => T): T {
+  try {
+    return fn();
+  } catch (err) {
+    if (isUniqueConstraintError(err)) throw new ConflictError(message);
+    throw err;
+  }
+}
+
+export function makeAliasesHandlers(db: FoodDb) {
+  return {
+    list: ({ query }: Req['list']) =>
+      runHttp(() => ({
+        status: 200 as const,
+        body: { items: aliasesService.listAliases(db, toListInput(query)) },
+      })),
+
+    listWithTargets: ({ query }: Req['listWithTargets']) =>
+      runHttp(() => ({
+        status: 200 as const,
+        body: { items: aliasesService.listAliasesWithTargets(db, toListInput(query)) },
+      })),
+
+    create: ({ body }: Req['create']) =>
+      runHttp(() => ({
+        status: 201 as const,
+        body: {
+          data: runUniqueAsConflict('An alias with this text already exists for the target', () =>
+            aliasesService.createAlias(db, {
+              alias: body.alias,
+              target: body.target,
+              source: body.source,
+            })
+          ),
+        },
+      })),
+
+    updateText: ({ params, body }: Req['updateText']) =>
+      runHttp(() => ({
+        status: 200 as const,
+        body: {
+          data: runUniqueAsConflict('An alias with this text already exists for the target', () =>
+            aliasesService.updateAliasText(db, params.id, body.alias)
+          ),
+        },
+      })),
+
+    delete: ({ params }: Req['delete']) =>
+      runHttp(() => {
+        aliasesService.deleteAlias(db, params.id);
+        return { status: 200 as const, body: { ok: true as const } };
+      }),
+
+    merge: ({ body }: Req['merge']) =>
+      runHttp(() => ({
+        status: 200 as const,
+        body: aliasesService.mergeAliases(db, { aliasIds: body.aliasIds, target: body.target }),
+      })),
+
+    bulkApprove: ({ body }: Req['bulkApprove']) =>
+      runHttp(() => ({
+        status: 200 as const,
+        body: aliasesService.bulkApproveAliases(db, body.aliasIds),
+      })),
+  };
+}

--- a/pillars/food/src/api/rest/handlers.ts
+++ b/pillars/food/src/api/rest/handlers.ts
@@ -9,7 +9,9 @@ import { initServer } from '@ts-rest/express';
 
 import { foodContract } from '../../contract/rest.js';
 import { type OpenedFoodDb } from '../../db/index.js';
+import { makeAliasesHandlers } from './aliases-handlers.js';
 import { makeConversionsHandlers } from './conversions-handlers.js';
+import { makeIngredientTagsHandlers } from './ingredient-tags-handlers.js';
 import { makePrepStatesHandlers } from './prep-states-handlers.js';
 import { makeSlugsHandlers } from './slugs-handlers.js';
 import { makeVariantsHandlers } from './variants-handlers.js';
@@ -21,7 +23,9 @@ export function makeFoodRestHandlers(deps: {
 }): ReturnType<typeof server.router<typeof foodContract>> {
   const db = deps.foodDb.db;
   return server.router(foodContract, {
+    aliases: makeAliasesHandlers(db),
     conversions: makeConversionsHandlers(db),
+    ingredientTags: makeIngredientTagsHandlers(db),
     prepStates: makePrepStatesHandlers(db),
     slugs: makeSlugsHandlers(db),
     variants: makeVariantsHandlers(db),

--- a/pillars/food/src/api/rest/ingredient-tags-handlers.ts
+++ b/pillars/food/src/api/rest/ingredient-tags-handlers.ts
@@ -1,0 +1,45 @@
+/**
+ * Handlers for the `ingredientTags.*` sub-router. All read-only paths
+ * delegate straight to the service; `set` returns the service's structured
+ * `TagOpResult` (validation failures are data, not HTTP errors).
+ */
+import { ingredientTagsService } from '../../db/index.js';
+import { runHttp } from './error-mapping.js';
+
+import type { ServerInferRequest } from '@ts-rest/core';
+
+import type { foodIngredientTagsContract } from '../../contract/rest-ingredient-tags.js';
+import type { FoodDb } from '../../db/index.js';
+
+type Req = ServerInferRequest<typeof foodIngredientTagsContract>;
+
+export function makeIngredientTagsHandlers(db: FoodDb) {
+  return {
+    list: ({ query }: Req['list']) =>
+      runHttp(() => ({
+        status: 200 as const,
+        body: ingredientTagsService.listTagsForIngredient(db, query.ingredientId),
+      })),
+
+    distinct: ({ query }: Req['distinct']) =>
+      runHttp(() => ({
+        status: 200 as const,
+        body: ingredientTagsService.listDistinctTags(db, {
+          namespacePrefix: query.namespacePrefix ?? null,
+          limit: query.limit,
+        }),
+      })),
+
+    byTag: ({ query }: Req['byTag']) =>
+      runHttp(() => ({
+        status: 200 as const,
+        body: ingredientTagsService.listIngredientsByTag(db, query.tag),
+      })),
+
+    set: ({ params, body }: Req['set']) =>
+      runHttp(() => ({
+        status: 200 as const,
+        body: ingredientTagsService.setTagsForIngredient(db, params.ingredientId, body.tags),
+      })),
+  };
+}

--- a/pillars/food/src/contract/api-types.generated.ts
+++ b/pillars/food/src/contract/api-types.generated.ts
@@ -3,6 +3,93 @@
  * Do not edit by hand — regenerate via `pnpm -F @pops/food generate:api-types`.
  */
 export interface paths {
+  '/aliases': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** List aliases (optionally filtered by search / source / target) */
+    get: operations['aliases.list'];
+    put?: never;
+    /** Create an alias */
+    post: operations['aliases.create'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/aliases/bulk-approve': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Flip llm-sourced aliases to user-approved */
+    post: operations['aliases.bulkApprove'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/aliases/merge': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Re-point several aliases onto a single canonical target */
+    post: operations['aliases.merge'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/aliases/with-targets': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** List aliases joined with their resolved target metadata */
+    get: operations['aliases.listWithTargets'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/aliases/{id}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post?: never;
+    /** Delete an alias */
+    delete: operations['aliases.delete'];
+    options?: never;
+    head?: never;
+    /** Rename an alias */
+    patch: operations['aliases.updateText'];
+    trace?: never;
+  };
   '/conversions/resolve': {
     parameters: {
       query?: never;
@@ -92,6 +179,74 @@ export interface paths {
     patch: operations['conversions.updateWeight'];
     trace?: never;
   };
+  '/ingredient-tags': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** List an ingredient's tags */
+    get: operations['ingredientTags.list'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/ingredient-tags/by-tag': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Ingredients carrying a given tag */
+    get: operations['ingredientTags.byTag'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/ingredient-tags/distinct': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Distinct tags with usage counts (optionally namespace-scoped) */
+    get: operations['ingredientTags.distinct'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/ingredient-tags/{ingredientId}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    /** Replace an ingredient's tag set */
+    put: operations['ingredientTags.set'];
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/prep-states': {
     parameters: {
       query?: never;
@@ -174,6 +329,425 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
+  'aliases.list': {
+    parameters: {
+      query?: {
+        search?: string;
+        source?: 'user' | 'llm' | 'ingest';
+        targetKind?: 'ingredient' | 'variant';
+        targetId?: number;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            items: {
+              alias: string;
+              createdAt: string;
+              id: number;
+              ingredientId: number | null;
+              /** @enum {string} */
+              source: 'user' | 'llm' | 'ingest';
+              variantId: number | null;
+            }[];
+          };
+        };
+      };
+    };
+  };
+  'aliases.create': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          alias: string;
+          /** @enum {string} */
+          source?: 'user' | 'llm' | 'ingest';
+          target: {
+            id: number;
+            /** @enum {string} */
+            kind: 'ingredient' | 'variant';
+          };
+        };
+      };
+    };
+    responses: {
+      /** @description 201 */
+      201: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              alias: string;
+              createdAt: string;
+              id: number;
+              ingredientId: number | null;
+              /** @enum {string} */
+              source: 'user' | 'llm' | 'ingest';
+              variantId: number | null;
+            };
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'aliases.bulkApprove': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          aliasIds: number[];
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            updatedCount: number;
+          };
+        };
+      };
+    };
+  };
+  'aliases.merge': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          aliasIds: number[];
+          target: {
+            id: number;
+            /** @enum {string} */
+            kind: 'ingredient' | 'variant';
+          };
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            mergedCount: number;
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'aliases.listWithTargets': {
+    parameters: {
+      query?: {
+        search?: string;
+        source?: 'user' | 'llm' | 'ingest';
+        targetKind?: 'ingredient' | 'variant';
+        targetId?: number;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            items: {
+              alias: {
+                alias: string;
+                createdAt: string;
+                id: number;
+                /** @enum {string} */
+                source: 'user' | 'llm' | 'ingest';
+              };
+              target:
+                | {
+                    id: number;
+                    /** @enum {string} */
+                    kind: 'ingredient';
+                    name: string;
+                    slug: string;
+                  }
+                | {
+                    id: number;
+                    /** @enum {string} */
+                    kind: 'variant';
+                    name: string;
+                    parentIngredientName: string;
+                    parentIngredientSlug: string;
+                    slug: string;
+                  };
+            }[];
+          };
+        };
+      };
+    };
+  };
+  'aliases.delete': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: number;
+      };
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': Record<string, never>;
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            /** @enum {boolean} */
+            ok: true;
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'aliases.updateText': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: number;
+      };
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          alias: string;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              alias: string;
+              createdAt: string;
+              id: number;
+              ingredientId: number | null;
+              /** @enum {string} */
+              source: 'user' | 'llm' | 'ingest';
+              variantId: number | null;
+            };
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
   'conversions.resolve': {
     parameters: {
       query: {
@@ -749,6 +1323,126 @@ export interface operations {
             message: string;
             messageKey?: string;
           };
+        };
+      };
+    };
+  };
+  'ingredientTags.list': {
+    parameters: {
+      query: {
+        ingredientId: number;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            tags: string[];
+          };
+        };
+      };
+    };
+  };
+  'ingredientTags.byTag': {
+    parameters: {
+      query: {
+        tag: string;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            ingredients: {
+              id: number;
+              name: string;
+              slug: string;
+            }[];
+          };
+        };
+      };
+    };
+  };
+  'ingredientTags.distinct': {
+    parameters: {
+      query?: {
+        namespacePrefix?: string;
+        limit?: number;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            tags: {
+              firstSeenAt: string;
+              ingredientCount: number;
+              tag: string;
+            }[];
+          };
+        };
+      };
+    };
+  };
+  'ingredientTags.set': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        ingredientId: number;
+      };
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          tags: string[];
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json':
+            | {
+                /** @enum {boolean} */
+                ok: true;
+              }
+            | {
+                /** @enum {boolean} */
+                ok: false;
+                /** @enum {string} */
+                reason: 'BadTagFormat' | 'TagTooLong' | 'IngredientNotFound';
+              };
         };
       };
     };

--- a/pillars/food/src/contract/rest-aliases.ts
+++ b/pillars/food/src/contract/rest-aliases.ts
@@ -1,0 +1,124 @@
+/**
+ * `aliases.*` sub-router — alternate names that resolve to an ingredient or
+ * a variant during ingest. CRUD plus the bulk `merge` (re-point several
+ * aliases onto one target) and `bulkApprove` (flip `llm`-sourced rows to
+ * `user`) operations the inbox triage UI drives.
+ *
+ * Literal sub-paths (`/aliases/with-targets`, `/aliases/merge`,
+ * `/aliases/bulk-approve`) are declared before the `/aliases/:id` param
+ * routes so they register first.
+ */
+import { initContract } from '@ts-rest/core';
+import { z } from 'zod';
+
+import { ERR_RESPONSES, PathPositiveInt, QueryPositiveInt } from './rest-schemas.js';
+
+const c = initContract();
+
+const AliasSourceSchema = z.enum(['user', 'llm', 'ingest']);
+const TargetKindSchema = z.enum(['ingredient', 'variant']);
+const AliasTargetSchema = z.object({ kind: TargetKindSchema, id: z.number().int().positive() });
+
+export const IngredientAliasSchema = z.object({
+  id: z.number().int().positive(),
+  ingredientId: z.number().int().positive().nullable(),
+  variantId: z.number().int().positive().nullable(),
+  alias: z.string(),
+  source: AliasSourceSchema,
+  createdAt: z.string(),
+});
+
+export const AliasWithTargetSchema = z.object({
+  alias: z.object({
+    id: z.number().int().positive(),
+    alias: z.string(),
+    source: AliasSourceSchema,
+    createdAt: z.string(),
+  }),
+  target: z.discriminatedUnion('kind', [
+    z.object({
+      kind: z.literal('ingredient'),
+      id: z.number().int().positive(),
+      slug: z.string(),
+      name: z.string(),
+    }),
+    z.object({
+      kind: z.literal('variant'),
+      id: z.number().int().positive(),
+      slug: z.string(),
+      name: z.string(),
+      parentIngredientSlug: z.string(),
+      parentIngredientName: z.string(),
+    }),
+  ]),
+});
+
+const ListQuery = z.object({
+  search: z.string().optional(),
+  source: AliasSourceSchema.optional(),
+  targetKind: TargetKindSchema.optional(),
+  targetId: QueryPositiveInt.optional(),
+});
+
+const CreateAliasBody = z.object({
+  alias: z.string().min(1),
+  target: AliasTargetSchema,
+  source: AliasSourceSchema.optional(),
+});
+
+export const foodAliasesContract = c.router({
+  list: {
+    method: 'GET',
+    path: '/aliases',
+    query: ListQuery,
+    responses: { 200: z.object({ items: z.array(IngredientAliasSchema) }) },
+    summary: 'List aliases (optionally filtered by search / source / target)',
+  },
+  listWithTargets: {
+    method: 'GET',
+    path: '/aliases/with-targets',
+    query: ListQuery,
+    responses: { 200: z.object({ items: z.array(AliasWithTargetSchema) }) },
+    summary: 'List aliases joined with their resolved target metadata',
+  },
+  merge: {
+    method: 'POST',
+    path: '/aliases/merge',
+    body: z.object({
+      aliasIds: z.array(z.number().int().positive()).min(1),
+      target: AliasTargetSchema,
+    }),
+    responses: { 200: z.object({ mergedCount: z.number().int() }), ...ERR_RESPONSES },
+    summary: 'Re-point several aliases onto a single canonical target',
+  },
+  bulkApprove: {
+    method: 'POST',
+    path: '/aliases/bulk-approve',
+    body: z.object({ aliasIds: z.array(z.number().int().positive()).min(1) }),
+    responses: { 200: z.object({ updatedCount: z.number().int() }) },
+    summary: 'Flip llm-sourced aliases to user-approved',
+  },
+  create: {
+    method: 'POST',
+    path: '/aliases',
+    body: CreateAliasBody,
+    responses: { 201: z.object({ data: IngredientAliasSchema }), ...ERR_RESPONSES },
+    summary: 'Create an alias',
+  },
+  updateText: {
+    method: 'PATCH',
+    path: '/aliases/:id',
+    pathParams: z.object({ id: PathPositiveInt }),
+    body: z.object({ alias: z.string().min(1) }),
+    responses: { 200: z.object({ data: IngredientAliasSchema }), ...ERR_RESPONSES },
+    summary: 'Rename an alias',
+  },
+  delete: {
+    method: 'DELETE',
+    path: '/aliases/:id',
+    pathParams: z.object({ id: PathPositiveInt }),
+    body: z.object({}).optional(),
+    responses: { 200: z.object({ ok: z.literal(true) }), ...ERR_RESPONSES },
+    summary: 'Delete an alias',
+  },
+});

--- a/pillars/food/src/contract/rest-ingredient-tags.ts
+++ b/pillars/food/src/contract/rest-ingredient-tags.ts
@@ -1,0 +1,67 @@
+/**
+ * `ingredientTags.*` sub-router — the free-form tag vocabulary attached to
+ * ingredients (e.g. `store-section:produce`, `diet:vegan`). `set` is a full
+ * replacement; tag normalisation + validation happen in the db service and
+ * surface as a structured `{ ok: false, reason }` rather than an HTTP error.
+ */
+import { initContract } from '@ts-rest/core';
+import { z } from 'zod';
+
+import { PathPositiveInt, QueryPositiveInt } from './rest-schemas.js';
+
+const c = initContract();
+
+const TagOpResultSchema = z.discriminatedUnion('ok', [
+  z.object({ ok: z.literal(true) }),
+  z.object({
+    ok: z.literal(false),
+    reason: z.enum(['BadTagFormat', 'TagTooLong', 'IngredientNotFound']),
+  }),
+]);
+
+const TagDistinctRowSchema = z.object({
+  tag: z.string(),
+  ingredientCount: z.number().int(),
+  firstSeenAt: z.string(),
+});
+
+const IngredientSummarySchema = z.object({
+  id: z.number().int().positive(),
+  slug: z.string(),
+  name: z.string(),
+});
+
+export const foodIngredientTagsContract = c.router({
+  list: {
+    method: 'GET',
+    path: '/ingredient-tags',
+    query: z.object({ ingredientId: QueryPositiveInt }),
+    responses: { 200: z.object({ tags: z.array(z.string()) }) },
+    summary: "List an ingredient's tags",
+  },
+  distinct: {
+    method: 'GET',
+    path: '/ingredient-tags/distinct',
+    query: z.object({
+      namespacePrefix: z.string().min(1).optional(),
+      limit: z.coerce.number().int().positive().max(500).optional(),
+    }),
+    responses: { 200: z.object({ tags: z.array(TagDistinctRowSchema) }) },
+    summary: 'Distinct tags with usage counts (optionally namespace-scoped)',
+  },
+  byTag: {
+    method: 'GET',
+    path: '/ingredient-tags/by-tag',
+    query: z.object({ tag: z.string().min(1) }),
+    responses: { 200: z.object({ ingredients: z.array(IngredientSummarySchema) }) },
+    summary: 'Ingredients carrying a given tag',
+  },
+  set: {
+    method: 'PUT',
+    path: '/ingredient-tags/:ingredientId',
+    pathParams: z.object({ ingredientId: PathPositiveInt }),
+    body: z.object({ tags: z.array(z.string()) }),
+    responses: { 200: TagOpResultSchema },
+    summary: "Replace an ingredient's tag set",
+  },
+});

--- a/pillars/food/src/contract/rest.ts
+++ b/pillars/food/src/contract/rest.ts
@@ -14,7 +14,9 @@
  */
 import { initContract } from '@ts-rest/core';
 
+import { foodAliasesContract } from './rest-aliases.js';
 import { foodConversionsContract } from './rest-conversions.js';
+import { foodIngredientTagsContract } from './rest-ingredient-tags.js';
 import { foodPrepStatesContract } from './rest-prep-states.js';
 import { foodSlugsContract } from './rest-slugs.js';
 import { foodVariantsContract } from './rest-variants.js';
@@ -23,7 +25,9 @@ const c = initContract();
 
 export const foodContract = c.router(
   {
+    aliases: foodAliasesContract,
     conversions: foodConversionsContract,
+    ingredientTags: foodIngredientTagsContract,
     prepStates: foodPrepStatesContract,
     slugs: foodSlugsContract,
     variants: foodVariantsContract,


### PR DESCRIPTION
Continues the food tRPC→REST migration (`docs/runbooks/food-rest-migration.md`), building on #3339 + #3340. Ports two more leaf domains off the pops-api tRPC router into `pillars/food/src/api` as ts-rest over the in-pillar db services.

## Domains
- **ingredientTags** — `GET /ingredient-tags` (list), `PUT /ingredient-tags/:ingredientId` (full-replace set), `GET /ingredient-tags/distinct`, `GET /ingredient-tags/by-tag`. Tag validation/normalisation failures surface as the service's structured `{ ok:false, reason }` (200), not HTTP errors.
- **aliases** — `GET /aliases`, `GET /aliases/with-targets`, `POST /aliases`, `PATCH/DELETE /aliases/:id`, plus bulk `POST /aliases/merge` and `POST /aliases/bulk-approve`. UNIQUE collisions → 409. Literal sub-paths declared before the `:id` param routes.

## Safety
- Additive to the pillar only — `apps/pops-api` untouched.
- Validated locally: typecheck, lint, format, build, OpenAPI + api-types drift, **821 tests (62 files) green**; OpenAPI generation idempotent.

## Remaining
ingredients (hierarchy/blockers/rename — its own PR) → then substitutions/solver, batches/fridge/inbox, recipes (+send-to-list), plan/shopping, ingest/ai, Phase C/D/E.