### PR TITLE
feat(food): REST migration slice 1d — ingredients (leaf tier complete)

### DIFF
--- a/pillars/food/openapi/food.openapi.json
+++ b/pillars/food/openapi/food.openapi.json
@@ -2401,6 +2401,1298 @@
         "tags": ["ingredientTags"]
       }
     },
+    "/ingredients": {
+      "get": {
+        "operationId": "ingredients.list",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "search",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "parentId",
+            "schema": {
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "items": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "createdAt": {
+                            "type": "string"
+                          },
+                          "defaultUnit": {
+                            "enum": ["g", "ml", "count"],
+                            "type": "string"
+                          },
+                          "densityGPerMl": {
+                            "nullable": true,
+                            "type": "number"
+                          },
+                          "id": {
+                            "exclusiveMinimum": true,
+                            "maximum": 9007199254740991,
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "notes": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "parentId": {
+                            "exclusiveMinimum": true,
+                            "maximum": 9007199254740991,
+                            "minimum": 0,
+                            "nullable": true,
+                            "type": "integer"
+                          },
+                          "slug": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "parentId",
+                          "name",
+                          "slug",
+                          "defaultUnit",
+                          "densityGPerMl",
+                          "notes",
+                          "createdAt"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": ["items"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "List ingredients (optionally filtered by search / parent)",
+        "tags": ["ingredients"]
+      },
+      "post": {
+        "operationId": "ingredients.create",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "defaultUnit": {
+                    "enum": ["g", "ml", "count"],
+                    "type": "string"
+                  },
+                  "densityGPerMl": {
+                    "exclusiveMinimum": true,
+                    "minimum": 0,
+                    "nullable": true,
+                    "type": "number"
+                  },
+                  "name": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "notes": {
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "parentId": {
+                    "exclusiveMinimum": true,
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "nullable": true,
+                    "type": "integer"
+                  },
+                  "slug": {
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": ["slug", "name", "defaultUnit"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "createdAt": {
+                          "type": "string"
+                        },
+                        "defaultUnit": {
+                          "enum": ["g", "ml", "count"],
+                          "type": "string"
+                        },
+                        "densityGPerMl": {
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "id": {
+                          "exclusiveMinimum": true,
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "notes": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "parentId": {
+                          "exclusiveMinimum": true,
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "slug": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "parentId",
+                        "name",
+                        "slug",
+                        "defaultUnit",
+                        "densityGPerMl",
+                        "notes",
+                        "createdAt"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "201"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Create an ingredient",
+        "tags": ["ingredients"]
+      }
+    },
+    "/ingredients/rename": {
+      "post": {
+        "operationId": "ingredients.rename",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "newSlug": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "oldSlug": {
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": ["oldSlug", "newSlug"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "createdAt": {
+                          "type": "string"
+                        },
+                        "defaultUnit": {
+                          "enum": ["g", "ml", "count"],
+                          "type": "string"
+                        },
+                        "densityGPerMl": {
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "id": {
+                          "exclusiveMinimum": true,
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "notes": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "parentId": {
+                          "exclusiveMinimum": true,
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "slug": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "parentId",
+                        "name",
+                        "slug",
+                        "defaultUnit",
+                        "densityGPerMl",
+                        "notes",
+                        "createdAt"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Rename an ingredient slug (updates the slug registry)",
+        "tags": ["ingredients"]
+      }
+    },
+    "/ingredients/{idOrSlug}": {
+      "get": {
+        "operationId": "ingredients.get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "idOrSlug",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "ingredient": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "createdAt": {
+                          "type": "string"
+                        },
+                        "defaultUnit": {
+                          "enum": ["g", "ml", "count"],
+                          "type": "string"
+                        },
+                        "densityGPerMl": {
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "id": {
+                          "exclusiveMinimum": true,
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "notes": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "parentId": {
+                          "exclusiveMinimum": true,
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "slug": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "parentId",
+                        "name",
+                        "slug",
+                        "defaultUnit",
+                        "densityGPerMl",
+                        "notes",
+                        "createdAt"
+                      ],
+                      "type": "object"
+                    },
+                    "variants": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "createdAt": {
+                            "type": "string"
+                          },
+                          "defaultShelfLifeDaysFreezer": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "nullable": true,
+                            "type": "integer"
+                          },
+                          "defaultShelfLifeDaysFridge": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "nullable": true,
+                            "type": "integer"
+                          },
+                          "defaultUnit": {
+                            "enum": ["g", "ml", "count"],
+                            "type": "string"
+                          },
+                          "id": {
+                            "exclusiveMinimum": true,
+                            "maximum": 9007199254740991,
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "ingredientId": {
+                            "exclusiveMinimum": true,
+                            "maximum": 9007199254740991,
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "notes": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "packageSizeG": {
+                            "nullable": true,
+                            "type": "number"
+                          },
+                          "slug": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "ingredientId",
+                          "name",
+                          "slug",
+                          "defaultUnit",
+                          "packageSizeG",
+                          "notes",
+                          "defaultShelfLifeDaysFridge",
+                          "defaultShelfLifeDaysFreezer",
+                          "createdAt"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": ["ingredient", "variants"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Get an ingredient (by numeric id or slug) with its variants",
+        "tags": ["ingredients"]
+      }
+    },
+    "/ingredients/{id}": {
+      "delete": {
+        "operationId": "ingredients.delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {},
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "ok": {
+                          "enum": [true],
+                          "type": "boolean"
+                        }
+                      },
+                      "required": ["ok"],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "blockers": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "aliases": {
+                              "maximum": 9007199254740991,
+                              "minimum": -9007199254740991,
+                              "type": "integer"
+                            },
+                            "variants": {
+                              "maximum": 9007199254740991,
+                              "minimum": -9007199254740991,
+                              "type": "integer"
+                            }
+                          },
+                          "required": ["variants", "aliases"],
+                          "type": "object"
+                        },
+                        "ok": {
+                          "enum": [false],
+                          "type": "boolean"
+                        }
+                      },
+                      "required": ["ok", "blockers"],
+                      "type": "object"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Delete an ingredient; returns blockers when variants/aliases remain",
+        "tags": ["ingredients"]
+      },
+      "patch": {
+        "operationId": "ingredients.update",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "defaultUnit": {
+                    "enum": ["g", "ml", "count"],
+                    "type": "string"
+                  },
+                  "densityGPerMl": {
+                    "exclusiveMinimum": true,
+                    "minimum": 0,
+                    "nullable": true,
+                    "type": "number"
+                  },
+                  "name": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "notes": {
+                    "nullable": true,
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "createdAt": {
+                          "type": "string"
+                        },
+                        "defaultUnit": {
+                          "enum": ["g", "ml", "count"],
+                          "type": "string"
+                        },
+                        "densityGPerMl": {
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "id": {
+                          "exclusiveMinimum": true,
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "notes": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "parentId": {
+                          "exclusiveMinimum": true,
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "slug": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "parentId",
+                        "name",
+                        "slug",
+                        "defaultUnit",
+                        "densityGPerMl",
+                        "notes",
+                        "createdAt"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Update an ingredient",
+        "tags": ["ingredients"]
+      }
+    },
+    "/ingredients/{id}/blockers": {
+      "get": {
+        "operationId": "ingredients.blockers",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "aliases": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer"
+                        },
+                        "variants": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer"
+                        }
+                      },
+                      "required": ["variants", "aliases"],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "FK-backed delete blockers (variants + aliases counts)",
+        "tags": ["ingredients"]
+      }
+    },
+    "/ingredients/{id}/parent": {
+      "post": {
+        "operationId": "ingredients.changeParent",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "newParentId": {
+                    "exclusiveMinimum": true,
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "nullable": true,
+                    "type": "integer"
+                  }
+                },
+                "required": ["newParentId"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "createdAt": {
+                          "type": "string"
+                        },
+                        "defaultUnit": {
+                          "enum": ["g", "ml", "count"],
+                          "type": "string"
+                        },
+                        "densityGPerMl": {
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "id": {
+                          "exclusiveMinimum": true,
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "notes": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "parentId": {
+                          "exclusiveMinimum": true,
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "slug": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "parentId",
+                        "name",
+                        "slug",
+                        "defaultUnit",
+                        "densityGPerMl",
+                        "notes",
+                        "createdAt"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Re-parent an ingredient (cycle / depth guarded)",
+        "tags": ["ingredients"]
+      }
+    },
+    "/ingredients/{id}/recipe-refs": {
+      "get": {
+        "operationId": "ingredients.recipeRefs",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "count": {
+                      "maximum": 9007199254740991,
+                      "minimum": -9007199254740991,
+                      "type": "integer"
+                    },
+                    "recipes": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "recipeId": {
+                            "exclusiveMinimum": true,
+                            "maximum": 9007199254740991,
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "recipeSlug": {
+                            "type": "string"
+                          },
+                          "recipeTitle": {
+                            "type": "string"
+                          }
+                        },
+                        "required": ["recipeId", "recipeSlug", "recipeTitle"],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": ["count", "recipes"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Recipes referencing this ingredient via compiled lines",
+        "tags": ["ingredients"]
+      }
+    },
     "/prep-states": {
       "get": {
         "operationId": "prepStates.list",

--- a/pillars/food/src/api/__tests__/ingredients.test.ts
+++ b/pillars/food/src/api/__tests__/ingredients.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Integration tests for the `ingredients.*` REST surface — CRUD, slug
+ * rename, re-parent, and the soft-blocked delete. Hierarchy depth / cycle
+ * invariants live in the db tests; here we assert the wire envelopes + HTTP
+ * status mapping.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { type OpenedFoodDb, openFoodDb } from '../../db/index.js';
+import { createFoodApiApp } from '../app.js';
+import { makeClient } from './test-utils.js';
+
+let tmpDir: string;
+let foodDb: OpenedFoodDb;
+
+function client(): ReturnType<typeof makeClient> {
+  return makeClient(
+    createFoodApiApp({ foodDb, version: '0.0.1-test', selfBaseUrl: 'http://localhost:3005' })
+  );
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'food-api-ingredients-test-'));
+  foodDb = openFoodDb(join(tmpDir, 'food.db'));
+});
+
+afterEach(() => {
+  foodDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('ingredients REST — CRUD', () => {
+  it('creates, lists, gets (by id and slug), and updates', async () => {
+    const api = client();
+    const created = await api.ingredients.create({
+      slug: 'tomato',
+      name: 'Tomato',
+      defaultUnit: 'count',
+    });
+    expect(created.data.slug).toBe('tomato');
+
+    const list = await api.ingredients.list();
+    expect(list.items.map((i) => i.slug)).toContain('tomato');
+
+    const byId = await api.ingredients.get(created.data.id);
+    expect(byId.ingredient.slug).toBe('tomato');
+    expect(byId.variants).toEqual([]);
+
+    const bySlug = await api.ingredients.get('tomato');
+    expect(bySlug.ingredient.id).toBe(created.data.id);
+
+    const updated = await api.ingredients.update(created.data.id, { name: 'Roma Tomato' });
+    expect(updated.data.name).toBe('Roma Tomato');
+  });
+
+  it('maps an invalid slug to 400 and a duplicate slug to 409', async () => {
+    const api = client();
+    await expect(
+      api.ingredients.create({ slug: 'Bad Slug!', name: 'x', defaultUnit: 'count' })
+    ).rejects.toMatchObject({ status: 400 });
+
+    await api.ingredients.create({ slug: 'onion', name: 'Onion', defaultUnit: 'count' });
+    await expect(
+      api.ingredients.create({ slug: 'onion', name: 'Onion 2', defaultUnit: 'count' })
+    ).rejects.toMatchObject({ status: 409 });
+  });
+
+  it('maps an unknown ingredient to 404 on get and update', async () => {
+    const api = client();
+    await expect(api.ingredients.get('nope')).rejects.toMatchObject({ status: 404 });
+    await expect(api.ingredients.update(999999, { name: 'x' })).rejects.toMatchObject({
+      status: 404,
+    });
+  });
+});
+
+describe('ingredients REST — hierarchy', () => {
+  it('renames a slug and re-parents under another ingredient', async () => {
+    const api = client();
+    const parent = await api.ingredients.create({
+      slug: 'allium',
+      name: 'Allium',
+      defaultUnit: 'count',
+    });
+    const child = await api.ingredients.create({
+      slug: 'garlik',
+      name: 'Garlic',
+      defaultUnit: 'count',
+    });
+
+    const renamed = await api.ingredients.rename('garlik', 'garlic');
+    expect(renamed.data.slug).toBe('garlic');
+
+    const reparented = await api.ingredients.changeParent(child.data.id, parent.data.id);
+    expect(reparented.data.parentId).toBe(parent.data.id);
+
+    const children = await api.ingredients.list({ parentId: parent.data.id });
+    expect(children.items.map((i) => i.slug)).toContain('garlic');
+  });
+
+  it('maps a rename of an unknown slug to 404', async () => {
+    await expect(client().ingredients.rename('ghost', 'phantom')).rejects.toMatchObject({
+      status: 404,
+    });
+  });
+});
+
+describe('ingredients REST — delete blockers', () => {
+  it('deletes a blocker-free ingredient', async () => {
+    const api = client();
+    const ing = await api.ingredients.create({ slug: 'salt', name: 'Salt', defaultUnit: 'g' });
+    const blockers = await api.ingredients.blockers(ing.data.id);
+    expect(blockers.data).toEqual({ variants: 0, aliases: 0 });
+
+    const del = await api.ingredients.delete(ing.data.id);
+    expect(del).toEqual({ ok: true });
+  });
+
+  it('soft-blocks delete when a variant exists, reporting blockers', async () => {
+    const api = client();
+    const ing = await api.ingredients.create({ slug: 'milk', name: 'Milk', defaultUnit: 'ml' });
+    await api.variants.create({
+      ingredientId: ing.data.id,
+      slug: 'whole',
+      name: 'Whole',
+      defaultUnit: 'ml',
+    });
+
+    const del = await api.ingredients.delete(ing.data.id);
+    expect(del).toEqual({ ok: false, blockers: { variants: 1, aliases: 0 } });
+  });
+});

--- a/pillars/food/src/api/__tests__/test-utils.ts
+++ b/pillars/food/src/api/__tests__/test-utils.ts
@@ -64,6 +64,33 @@ type TagOpResult =
   | { ok: true }
   | { ok: false; reason: 'BadTagFormat' | 'TagTooLong' | 'IngredientNotFound' };
 
+interface Ingredient {
+  id: number;
+  parentId: number | null;
+  name: string;
+  slug: string;
+  defaultUnit: 'g' | 'ml' | 'count';
+  densityGPerMl: number | null;
+  notes: string | null;
+  createdAt: string;
+}
+
+interface DeleteBlockerSummary {
+  variants: number;
+  aliases: number;
+}
+
+type IngredientDeleteResult = { ok: true } | { ok: false; blockers: DeleteBlockerSummary };
+
+interface CreateIngredientBody {
+  slug: string;
+  name: string;
+  defaultUnit: 'g' | 'ml' | 'count';
+  parentId?: number | null;
+  densityGPerMl?: number | null;
+  notes?: string | null;
+}
+
 export class HttpError extends Error {
   readonly status: number;
   readonly body: unknown;
@@ -174,6 +201,29 @@ export function makeClient(app: Express) {
         send<{ mergedCount: number }>(r.post('/aliases/merge').send({ aliasIds, target })),
       bulkApprove: (aliasIds: number[]) =>
         send<{ updatedCount: number }>(r.post('/aliases/bulk-approve').send({ aliasIds })),
+    },
+    ingredients: {
+      list: (query: { search?: string; parentId?: number } = {}) =>
+        send<{ items: Ingredient[] }>(r.get('/ingredients').query(query)),
+      get: (idOrSlug: number | string) =>
+        send<{ ingredient: Ingredient; variants: IngredientVariant[] }>(
+          r.get(`/ingredients/${idOrSlug}`)
+        ),
+      create: (body: CreateIngredientBody) =>
+        send<{ data: Ingredient }>(r.post('/ingredients').send(body)),
+      update: (
+        id: number,
+        body: { name?: string; defaultUnit?: 'g' | 'ml' | 'count'; notes?: string | null }
+      ) => send<{ data: Ingredient }>(r.patch(`/ingredients/${id}`).send(body)),
+      rename: (oldSlug: string, newSlug: string) =>
+        send<{ data: Ingredient }>(r.post('/ingredients/rename').send({ oldSlug, newSlug })),
+      changeParent: (id: number, newParentId: number | null) =>
+        send<{ data: Ingredient }>(r.post(`/ingredients/${id}/parent`).send({ newParentId })),
+      blockers: (id: number) =>
+        send<{ data: DeleteBlockerSummary }>(r.get(`/ingredients/${id}/blockers`)),
+      recipeRefs: (id: number) =>
+        send<{ count: number; recipes: unknown[] }>(r.get(`/ingredients/${id}/recipe-refs`)),
+      delete: (id: number) => send<IngredientDeleteResult>(r.delete(`/ingredients/${id}`)),
     },
   };
 }

--- a/pillars/food/src/api/rest/handlers.ts
+++ b/pillars/food/src/api/rest/handlers.ts
@@ -12,6 +12,7 @@ import { type OpenedFoodDb } from '../../db/index.js';
 import { makeAliasesHandlers } from './aliases-handlers.js';
 import { makeConversionsHandlers } from './conversions-handlers.js';
 import { makeIngredientTagsHandlers } from './ingredient-tags-handlers.js';
+import { makeIngredientsHandlers } from './ingredients-handlers.js';
 import { makePrepStatesHandlers } from './prep-states-handlers.js';
 import { makeSlugsHandlers } from './slugs-handlers.js';
 import { makeVariantsHandlers } from './variants-handlers.js';
@@ -25,6 +26,7 @@ export function makeFoodRestHandlers(deps: {
   return server.router(foodContract, {
     aliases: makeAliasesHandlers(db),
     conversions: makeConversionsHandlers(db),
+    ingredients: makeIngredientsHandlers(db),
     ingredientTags: makeIngredientTagsHandlers(db),
     prepStates: makePrepStatesHandlers(db),
     slugs: makeSlugsHandlers(db),

--- a/pillars/food/src/api/rest/ingredients-handlers.ts
+++ b/pillars/food/src/api/rest/ingredients-handlers.ts
@@ -1,0 +1,166 @@
+/**
+ * Handlers for the `ingredients.*` sub-router.
+ *
+ * Error convention (ported from the pops-api ingredients router):
+ * `InvalidSlugError` / `IngredientCycleError` / `IngredientHierarchyDepthExceeded`
+ * → 400; `SlugAlreadyRegisteredError` → 409; SQLite FK (ingredient in use)
+ * → 409; `expectRow` miss on update / change-parent of an unknown id → 404.
+ * Delete is soft-blocked: when variants or aliases remain it answers
+ * `{ ok:false, blockers }` rather than deleting.
+ */
+import {
+  IngredientCycleError,
+  IngredientHierarchyDepthExceeded,
+  ingredientsQueries,
+  ingredientsService,
+  InvalidSlugError,
+  SlugAlreadyRegisteredError,
+} from '../../db/index.js';
+import { ConflictError, HttpError, NotFoundError } from '../shared/errors.js';
+import { isForeignKeyConstraintError } from '../shared/sqlite-errors.js';
+import { runHttp } from './error-mapping.js';
+
+import type { ServerInferRequest } from '@ts-rest/core';
+
+import type { foodIngredientsContract } from '../../contract/rest-ingredients.js';
+import type { FoodDb } from '../../db/index.js';
+
+type Req = ServerInferRequest<typeof foodIngredientsContract>;
+
+function isExpectRowMiss(err: unknown): boolean {
+  return err instanceof Error && /expected a row but got none/i.test(err.message);
+}
+
+function badRequest(message: string): HttpError {
+  return new HttpError(400, message, undefined, 'common.validationFailed');
+}
+
+function translateWriteError(err: unknown): never {
+  if (err instanceof InvalidSlugError) throw badRequest(err.message);
+  if (err instanceof IngredientCycleError) throw badRequest(err.message);
+  if (err instanceof IngredientHierarchyDepthExceeded) throw badRequest(err.message);
+  if (err instanceof SlugAlreadyRegisteredError) throw new ConflictError(err.message);
+  if (isForeignKeyConstraintError(err)) throw new ConflictError('Ingredient is in use');
+  throw err;
+}
+
+export function makeIngredientsHandlers(db: FoodDb) {
+  return {
+    list: ({ query }: Req['list']) =>
+      runHttp(() => ({
+        status: 200 as const,
+        body: {
+          items: ingredientsQueries.listIngredients(db, {
+            search: query.search,
+            parentId: query.parentId,
+          }),
+        },
+      })),
+
+    get: ({ params }: Req['get']) =>
+      runHttp(() => {
+        const ingredient = /^\d+$/.test(params.idOrSlug)
+          ? ingredientsQueries.getIngredient(db, Number(params.idOrSlug))
+          : ingredientsQueries.getIngredientBySlug(db, params.idOrSlug);
+        if (ingredient === null) throw new NotFoundError('Ingredient', params.idOrSlug);
+        return {
+          status: 200 as const,
+          body: {
+            ingredient,
+            variants: ingredientsQueries.listVariantsForIngredient(db, ingredient.id),
+          },
+        };
+      }),
+
+    create: ({ body }: Req['create']) =>
+      runHttp(() => {
+        try {
+          return {
+            status: 201 as const,
+            body: {
+              data: ingredientsService.createIngredient(db, {
+                slug: body.slug,
+                name: body.name,
+                defaultUnit: body.defaultUnit,
+                parentId: body.parentId,
+                densityGPerMl: body.densityGPerMl,
+                notes: body.notes,
+              }),
+            },
+          };
+        } catch (err) {
+          translateWriteError(err);
+        }
+      }),
+
+    update: ({ params, body }: Req['update']) =>
+      runHttp(() => {
+        try {
+          return {
+            status: 200 as const,
+            body: { data: ingredientsService.updateIngredient(db, params.id, body) },
+          };
+        } catch (err) {
+          if (isExpectRowMiss(err)) throw new NotFoundError('Ingredient', String(params.id));
+          translateWriteError(err);
+        }
+      }),
+
+    rename: ({ body }: Req['rename']) =>
+      runHttp(() => {
+        try {
+          return {
+            status: 200 as const,
+            body: { data: ingredientsService.renameIngredientSlug(db, body.oldSlug, body.newSlug) },
+          };
+        } catch (err) {
+          if (err instanceof Error && /not found/i.test(err.message) && !isExpectRowMiss(err)) {
+            throw new NotFoundError('Ingredient', body.oldSlug);
+          }
+          translateWriteError(err);
+        }
+      }),
+
+    changeParent: ({ params, body }: Req['changeParent']) =>
+      runHttp(() => {
+        try {
+          return {
+            status: 200 as const,
+            body: {
+              data: ingredientsService.changeIngredientParent(db, params.id, body.newParentId),
+            },
+          };
+        } catch (err) {
+          if (isExpectRowMiss(err)) throw new NotFoundError('Ingredient', String(params.id));
+          translateWriteError(err);
+        }
+      }),
+
+    blockers: ({ params }: Req['blockers']) =>
+      runHttp(() => ({
+        status: 200 as const,
+        body: { data: ingredientsQueries.getIngredientDeleteBlockers(db, params.id) },
+      })),
+
+    recipeRefs: ({ params }: Req['recipeRefs']) =>
+      runHttp(() => ({
+        status: 200 as const,
+        body: ingredientsQueries.getRecipeRefsForIngredient(db, params.id),
+      })),
+
+    delete: ({ params }: Req['delete']) =>
+      runHttp(() => {
+        const blockers = ingredientsQueries.getIngredientDeleteBlockers(db, params.id);
+        if (blockers.variants > 0 || blockers.aliases > 0) {
+          return { status: 200 as const, body: { ok: false as const, blockers } };
+        }
+        try {
+          ingredientsService.deleteIngredient(db, params.id);
+          return { status: 200 as const, body: { ok: true as const } };
+        } catch (err) {
+          if (isForeignKeyConstraintError(err)) throw new ConflictError('Ingredient is in use');
+          throw err;
+        }
+      }),
+  };
+}

--- a/pillars/food/src/contract/api-types.generated.ts
+++ b/pillars/food/src/contract/api-types.generated.ts
@@ -247,6 +247,127 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/ingredients': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** List ingredients (optionally filtered by search / parent) */
+    get: operations['ingredients.list'];
+    put?: never;
+    /** Create an ingredient */
+    post: operations['ingredients.create'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/ingredients/rename': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Rename an ingredient slug (updates the slug registry) */
+    post: operations['ingredients.rename'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/ingredients/{idOrSlug}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get an ingredient (by numeric id or slug) with its variants */
+    get: operations['ingredients.get'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/ingredients/{id}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post?: never;
+    /** Delete an ingredient; returns blockers when variants/aliases remain */
+    delete: operations['ingredients.delete'];
+    options?: never;
+    head?: never;
+    /** Update an ingredient */
+    patch: operations['ingredients.update'];
+    trace?: never;
+  };
+  '/ingredients/{id}/blockers': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** FK-backed delete blockers (variants + aliases counts) */
+    get: operations['ingredients.blockers'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/ingredients/{id}/parent': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Re-parent an ingredient (cycle / depth guarded) */
+    post: operations['ingredients.changeParent'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/ingredients/{id}/recipe-refs': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Recipes referencing this ingredient via compiled lines */
+    get: operations['ingredients.recipeRefs'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/prep-states': {
     parameters: {
       query?: never;
@@ -1443,6 +1564,588 @@ export interface operations {
                 /** @enum {string} */
                 reason: 'BadTagFormat' | 'TagTooLong' | 'IngredientNotFound';
               };
+        };
+      };
+    };
+  };
+  'ingredients.list': {
+    parameters: {
+      query?: {
+        search?: string;
+        parentId?: number;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            items: {
+              createdAt: string;
+              /** @enum {string} */
+              defaultUnit: 'g' | 'ml' | 'count';
+              densityGPerMl: number | null;
+              id: number;
+              name: string;
+              notes: string | null;
+              parentId: number | null;
+              slug: string;
+            }[];
+          };
+        };
+      };
+    };
+  };
+  'ingredients.create': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          /** @enum {string} */
+          defaultUnit: 'g' | 'ml' | 'count';
+          densityGPerMl?: number | null;
+          name: string;
+          notes?: string | null;
+          parentId?: number | null;
+          slug: string;
+        };
+      };
+    };
+    responses: {
+      /** @description 201 */
+      201: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              createdAt: string;
+              /** @enum {string} */
+              defaultUnit: 'g' | 'ml' | 'count';
+              densityGPerMl: number | null;
+              id: number;
+              name: string;
+              notes: string | null;
+              parentId: number | null;
+              slug: string;
+            };
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'ingredients.rename': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          newSlug: string;
+          oldSlug: string;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              createdAt: string;
+              /** @enum {string} */
+              defaultUnit: 'g' | 'ml' | 'count';
+              densityGPerMl: number | null;
+              id: number;
+              name: string;
+              notes: string | null;
+              parentId: number | null;
+              slug: string;
+            };
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'ingredients.get': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        idOrSlug: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            ingredient: {
+              createdAt: string;
+              /** @enum {string} */
+              defaultUnit: 'g' | 'ml' | 'count';
+              densityGPerMl: number | null;
+              id: number;
+              name: string;
+              notes: string | null;
+              parentId: number | null;
+              slug: string;
+            };
+            variants: {
+              createdAt: string;
+              defaultShelfLifeDaysFreezer: number | null;
+              defaultShelfLifeDaysFridge: number | null;
+              /** @enum {string} */
+              defaultUnit: 'g' | 'ml' | 'count';
+              id: number;
+              ingredientId: number;
+              name: string;
+              notes: string | null;
+              packageSizeG: number | null;
+              slug: string;
+            }[];
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'ingredients.delete': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: number;
+      };
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': Record<string, never>;
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json':
+            | {
+                /** @enum {boolean} */
+                ok: true;
+              }
+            | {
+                blockers: {
+                  aliases: number;
+                  variants: number;
+                };
+                /** @enum {boolean} */
+                ok: false;
+              };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'ingredients.update': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: number;
+      };
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          /** @enum {string} */
+          defaultUnit?: 'g' | 'ml' | 'count';
+          densityGPerMl?: number | null;
+          name?: string;
+          notes?: string | null;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              createdAt: string;
+              /** @enum {string} */
+              defaultUnit: 'g' | 'ml' | 'count';
+              densityGPerMl: number | null;
+              id: number;
+              name: string;
+              notes: string | null;
+              parentId: number | null;
+              slug: string;
+            };
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'ingredients.blockers': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              aliases: number;
+              variants: number;
+            };
+          };
+        };
+      };
+    };
+  };
+  'ingredients.changeParent': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: number;
+      };
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          newParentId: number | null;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              createdAt: string;
+              /** @enum {string} */
+              defaultUnit: 'g' | 'ml' | 'count';
+              densityGPerMl: number | null;
+              id: number;
+              name: string;
+              notes: string | null;
+              parentId: number | null;
+              slug: string;
+            };
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'ingredients.recipeRefs': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            count: number;
+            recipes: {
+              recipeId: number;
+              recipeSlug: string;
+              recipeTitle: string;
+            }[];
+          };
         };
       };
     };

--- a/pillars/food/src/contract/rest-ingredients.ts
+++ b/pillars/food/src/contract/rest-ingredients.ts
@@ -1,0 +1,154 @@
+/**
+ * `ingredients.*` sub-router — the ingredient catalogue: CRUD plus the
+ * hierarchy operations (rename slug, change parent) and the delete-blocker
+ * projections (variants / aliases counts, recipe references) the FE shows
+ * before allowing a destructive delete.
+ *
+ * Literal sub-path `/ingredients/rename` is declared before the
+ * `/ingredients/:idOrSlug` param route so it registers first.
+ */
+import { initContract } from '@ts-rest/core';
+import { z } from 'zod';
+
+import { ERR_RESPONSES, PathPositiveInt, QueryPositiveInt } from './rest-schemas.js';
+
+const c = initContract();
+
+const UnitEnum = z.enum(['g', 'ml', 'count']);
+
+export const IngredientSchema = z.object({
+  id: z.number().int().positive(),
+  parentId: z.number().int().positive().nullable(),
+  name: z.string(),
+  slug: z.string(),
+  defaultUnit: UnitEnum,
+  densityGPerMl: z.number().nullable(),
+  notes: z.string().nullable(),
+  createdAt: z.string(),
+});
+
+const IngredientVariantSchema = z.object({
+  id: z.number().int().positive(),
+  ingredientId: z.number().int().positive(),
+  name: z.string(),
+  slug: z.string(),
+  defaultUnit: UnitEnum,
+  packageSizeG: z.number().nullable(),
+  notes: z.string().nullable(),
+  defaultShelfLifeDaysFridge: z.number().int().nullable(),
+  defaultShelfLifeDaysFreezer: z.number().int().nullable(),
+  createdAt: z.string(),
+});
+
+const DeleteBlockerSummarySchema = z.object({
+  variants: z.number().int(),
+  aliases: z.number().int(),
+});
+
+const RecipeRefsSummarySchema = z.object({
+  count: z.number().int(),
+  recipes: z.array(
+    z.object({
+      recipeId: z.number().int().positive(),
+      recipeSlug: z.string(),
+      recipeTitle: z.string(),
+    })
+  ),
+});
+
+const CreateIngredientBody = z.object({
+  slug: z.string().min(1),
+  name: z.string().min(1),
+  defaultUnit: UnitEnum,
+  parentId: z.number().int().positive().nullish(),
+  densityGPerMl: z.number().positive().nullish(),
+  notes: z.string().nullish(),
+});
+
+const UpdateIngredientBody = z.object({
+  name: z.string().min(1).optional(),
+  defaultUnit: UnitEnum.optional(),
+  densityGPerMl: z.number().positive().nullish(),
+  notes: z.string().nullish(),
+});
+
+export const foodIngredientsContract = c.router({
+  list: {
+    method: 'GET',
+    path: '/ingredients',
+    query: z.object({
+      search: z.string().optional(),
+      parentId: QueryPositiveInt.optional(),
+    }),
+    responses: { 200: z.object({ items: z.array(IngredientSchema) }) },
+    summary: 'List ingredients (optionally filtered by search / parent)',
+  },
+  rename: {
+    method: 'POST',
+    path: '/ingredients/rename',
+    body: z.object({ oldSlug: z.string().min(1), newSlug: z.string().min(1) }),
+    responses: { 200: z.object({ data: IngredientSchema }), ...ERR_RESPONSES },
+    summary: 'Rename an ingredient slug (updates the slug registry)',
+  },
+  create: {
+    method: 'POST',
+    path: '/ingredients',
+    body: CreateIngredientBody,
+    responses: { 201: z.object({ data: IngredientSchema }), ...ERR_RESPONSES },
+    summary: 'Create an ingredient',
+  },
+  get: {
+    method: 'GET',
+    path: '/ingredients/:idOrSlug',
+    pathParams: z.object({ idOrSlug: z.string().min(1) }),
+    responses: {
+      200: z.object({ ingredient: IngredientSchema, variants: z.array(IngredientVariantSchema) }),
+      ...ERR_RESPONSES,
+    },
+    summary: 'Get an ingredient (by numeric id or slug) with its variants',
+  },
+  update: {
+    method: 'PATCH',
+    path: '/ingredients/:id',
+    pathParams: z.object({ id: PathPositiveInt }),
+    body: UpdateIngredientBody,
+    responses: { 200: z.object({ data: IngredientSchema }), ...ERR_RESPONSES },
+    summary: 'Update an ingredient',
+  },
+  changeParent: {
+    method: 'POST',
+    path: '/ingredients/:id/parent',
+    pathParams: z.object({ id: PathPositiveInt }),
+    body: z.object({ newParentId: z.number().int().positive().nullable() }),
+    responses: { 200: z.object({ data: IngredientSchema }), ...ERR_RESPONSES },
+    summary: 'Re-parent an ingredient (cycle / depth guarded)',
+  },
+  blockers: {
+    method: 'GET',
+    path: '/ingredients/:id/blockers',
+    pathParams: z.object({ id: PathPositiveInt }),
+    responses: { 200: z.object({ data: DeleteBlockerSummarySchema }) },
+    summary: 'FK-backed delete blockers (variants + aliases counts)',
+  },
+  recipeRefs: {
+    method: 'GET',
+    path: '/ingredients/:id/recipe-refs',
+    pathParams: z.object({ id: PathPositiveInt }),
+    responses: { 200: RecipeRefsSummarySchema },
+    summary: 'Recipes referencing this ingredient via compiled lines',
+  },
+  delete: {
+    method: 'DELETE',
+    path: '/ingredients/:id',
+    pathParams: z.object({ id: PathPositiveInt }),
+    body: z.object({}).optional(),
+    responses: {
+      200: z.union([
+        z.object({ ok: z.literal(true) }),
+        z.object({ ok: z.literal(false), blockers: DeleteBlockerSummarySchema }),
+      ]),
+      ...ERR_RESPONSES,
+    },
+    summary: 'Delete an ingredient; returns blockers when variants/aliases remain',
+  },
+});

--- a/pillars/food/src/contract/rest.ts
+++ b/pillars/food/src/contract/rest.ts
@@ -17,6 +17,7 @@ import { initContract } from '@ts-rest/core';
 import { foodAliasesContract } from './rest-aliases.js';
 import { foodConversionsContract } from './rest-conversions.js';
 import { foodIngredientTagsContract } from './rest-ingredient-tags.js';
+import { foodIngredientsContract } from './rest-ingredients.js';
 import { foodPrepStatesContract } from './rest-prep-states.js';
 import { foodSlugsContract } from './rest-slugs.js';
 import { foodVariantsContract } from './rest-variants.js';
@@ -27,6 +28,7 @@ export const foodContract = c.router(
   {
     aliases: foodAliasesContract,
     conversions: foodConversionsContract,
+    ingredients: foodIngredientsContract,
     ingredientTags: foodIngredientTagsContract,
     prepStates: foodPrepStatesContract,
     slugs: foodSlugsContract,


### PR DESCRIPTION
Completes the leaf CRUD tier of the food tRPC→REST migration (`docs/runbooks/food-rest-migration.md`), after #3339/#3340/#3341. Ports the ingredient catalogue off the pops-api tRPC router into `pillars/food/src/api` as ts-rest over the in-pillar db services.

## Surface
- `GET /ingredients` (search / parent filter), `GET /ingredients/:idOrSlug` (id or slug, returns ingredient + variants)
- `POST /ingredients`, `PATCH /ingredients/:id`
- `POST /ingredients/rename`, `POST /ingredients/:id/parent`
- `GET /ingredients/:id/blockers`, `GET /ingredients/:id/recipe-refs`
- `DELETE /ingredients/:id` — soft-blocked: returns `{ ok:false, blockers }` when variants/aliases remain

Error mapping: invalid slug / cycle / hierarchy-depth → 400; slug collision → 409; FK in-use → 409; unknown id/slug → 404.

## Safety
- Additive to the pillar only — `apps/pops-api` untouched.
- Validated locally: typecheck, lint, format, build, OpenAPI + api-types drift, **828 tests (63 files) green**; OpenAPI idempotent.

## Leaf tier done
conversions · prep-states · slugs · variants · ingredient-tags · aliases · ingredients. Next: substitutions/solver → batches/fridge/inbox → recipes (+send-to-list, hero-image) → plan/shopping → ingest/ai → Phase C/D/E.