### PR TITLE
feat(food): REST migration slice 2 — substitutions + solver (+ complete pillar migrations)

### DIFF
--- a/pillars/food/migrations/0061_food_remainder.sql
+++ b/pillars/food/migrations/0061_food_remainder.sql
@@ -1,0 +1,307 @@
+CREATE TABLE `recipes` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`slug` text NOT NULL,
+	`recipe_type` text DEFAULT 'plate' NOT NULL,
+	`current_version_id` integer,
+	`hero_image_path` text,
+	`archived_at` text,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL,
+	FOREIGN KEY (`current_version_id`) REFERENCES `recipe_versions`(`id`) ON UPDATE no action ON DELETE no action,
+	CONSTRAINT "ck_recipes_type" CHECK("recipes"."recipe_type" IN ('plate','component','technique','sauce','dressing','drink','condiment'))
+);
+--> statement-breakpoint
+CREATE INDEX `idx_recipes_type` ON `recipes` (`recipe_type`);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `recipes_slug_unique` ON `recipes` (`slug`);
+--> statement-breakpoint
+CREATE TABLE `recipe_tags` (
+	`recipe_id` integer NOT NULL,
+	`tag` text NOT NULL,
+	PRIMARY KEY(`recipe_id`, `tag`),
+	FOREIGN KEY (`recipe_id`) REFERENCES `recipes`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE INDEX `idx_recipe_tags_tag` ON `recipe_tags` (`tag` COLLATE NOCASE);
+--> statement-breakpoint
+CREATE TABLE `recipe_versions` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`recipe_id` integer NOT NULL,
+	`version_no` integer NOT NULL,
+	`status` text DEFAULT 'draft' NOT NULL,
+	`title` text NOT NULL,
+	`summary` text,
+	`body_dsl` text NOT NULL,
+	`yield_ingredient_id` integer,
+	`yield_variant_id` integer,
+	`yield_prep_state_id` integer,
+	`yield_qty` real,
+	`yield_unit` text,
+	`servings` integer,
+	`prep_minutes` integer,
+	`cook_minutes` integer,
+	`source_id` integer,
+	`compile_status` text DEFAULT 'uncompiled' NOT NULL,
+	`compile_error` text,
+	`compiled_at` text,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL,
+	FOREIGN KEY (`recipe_id`) REFERENCES `recipes`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`yield_ingredient_id`) REFERENCES `ingredients`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`yield_variant_id`) REFERENCES `ingredient_variants`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`yield_prep_state_id`) REFERENCES `prep_states`(`id`) ON UPDATE no action ON DELETE no action,
+	CONSTRAINT "ck_recipe_versions_status" CHECK("recipe_versions"."status" IN ('draft','current','archived')),
+	CONSTRAINT "ck_recipe_versions_compile_status" CHECK("recipe_versions"."compile_status" IN ('uncompiled','compiled','failed'))
+);
+--> statement-breakpoint
+CREATE INDEX `idx_recipe_versions_compile` ON `recipe_versions` (`compile_status`);
+--> statement-breakpoint
+CREATE INDEX `idx_recipe_versions_recipe` ON `recipe_versions` (`recipe_id`);
+--> statement-breakpoint
+CREATE INDEX `idx_recipe_versions_status` ON `recipe_versions` (`status`);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `uq_recipe_versions_one_current` ON `recipe_versions` (`recipe_id`) WHERE `status` = 'current';
+--> statement-breakpoint
+CREATE UNIQUE INDEX `uq_recipe_versions_recipe_no` ON `recipe_versions` (`recipe_id`,`version_no`);
+--> statement-breakpoint
+CREATE TABLE `recipe_lines` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`recipe_version_id` integer NOT NULL,
+	`position` integer NOT NULL,
+	`ingredient_id` integer NOT NULL,
+	`variant_id` integer,
+	`prep_state_id` integer,
+	`is_recipe_ref` integer DEFAULT 0 NOT NULL,
+	`recipe_ref_id` integer,
+	`original_text` text NOT NULL,
+	`original_qty` real NOT NULL,
+	`original_unit` text NOT NULL,
+	`qty_g` real,
+	`qty_ml` real,
+	`qty_count` real,
+	`canonical_unit` text NOT NULL,
+	`optional` integer DEFAULT 0 NOT NULL,
+	`notes` text,
+	FOREIGN KEY (`recipe_version_id`) REFERENCES `recipe_versions`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`ingredient_id`) REFERENCES `ingredients`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`variant_id`) REFERENCES `ingredient_variants`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`prep_state_id`) REFERENCES `prep_states`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`recipe_ref_id`) REFERENCES `recipes`(`id`) ON UPDATE no action ON DELETE no action,
+	CONSTRAINT "ck_recipe_lines_canonical_unit" CHECK("recipe_lines"."canonical_unit" IN ('g','ml','count')),
+	-- recipe-ref consistency: is_recipe_ref=0 ↔ recipe_ref_id IS NULL.
+	CONSTRAINT "ck_recipe_lines_recipe_ref" CHECK(
+		("recipe_lines"."is_recipe_ref" = 0 AND "recipe_lines"."recipe_ref_id" IS NULL)
+		OR ("recipe_lines"."is_recipe_ref" = 1 AND "recipe_lines"."recipe_ref_id" IS NOT NULL)
+	)
+);
+--> statement-breakpoint
+CREATE INDEX `idx_recipe_lines_ingredient` ON `recipe_lines` (`ingredient_id`);
+--> statement-breakpoint
+CREATE INDEX `idx_recipe_lines_recipe_ref` ON `recipe_lines` (`recipe_ref_id`) WHERE `recipe_ref_id` IS NOT NULL;
+--> statement-breakpoint
+CREATE UNIQUE INDEX `uq_recipe_lines_version_position` ON `recipe_lines` (`recipe_version_id`,`position`);
+--> statement-breakpoint
+CREATE TABLE `recipe_steps` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`recipe_version_id` integer NOT NULL,
+	`position` integer NOT NULL,
+	`body_md` text NOT NULL,
+	`body_resolved_json` text NOT NULL,
+	`duration_minutes` integer,
+	`temperature_value` real,
+	`temperature_unit` text,
+	FOREIGN KEY (`recipe_version_id`) REFERENCES `recipe_versions`(`id`) ON UPDATE no action ON DELETE no action,
+	CONSTRAINT "ck_recipe_steps_temperature_unit" CHECK("recipe_steps"."temperature_unit" IS NULL OR "recipe_steps"."temperature_unit" IN ('c','f','gas'))
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `uq_recipe_steps_version_position` ON `recipe_steps` (`recipe_version_id`,`position`);
+--> statement-breakpoint
+CREATE TABLE `recipe_version_proposed_slugs` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`recipe_version_id` integer NOT NULL,
+	`slug` text NOT NULL,
+	`suggested_kind` text,
+	`from_loc_json` text NOT NULL,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL,
+	FOREIGN KEY (`recipe_version_id`) REFERENCES `recipe_versions`(`id`) ON UPDATE no action ON DELETE no action,
+	CONSTRAINT "ck_proposed_slugs_kind" CHECK("recipe_version_proposed_slugs"."suggested_kind" IS NULL OR "recipe_version_proposed_slugs"."suggested_kind" IN ('ingredient','recipe','prep_state'))
+);
+--> statement-breakpoint
+CREATE INDEX `idx_proposed_slugs_slug` ON `recipe_version_proposed_slugs` (`slug`);
+--> statement-breakpoint
+CREATE INDEX `idx_proposed_slugs_version` ON `recipe_version_proposed_slugs` (`recipe_version_id`);
+--> statement-breakpoint
+CREATE TABLE `recipe_version_rejections` (
+	`version_id` integer PRIMARY KEY NOT NULL,
+	`reason` text NOT NULL,
+	`note` text,
+	`rejected_at` text DEFAULT (datetime('now')) NOT NULL,
+	FOREIGN KEY (`version_id`) REFERENCES `recipe_versions`(`id`) ON UPDATE no action ON DELETE cascade,
+	-- PRD-136 — reason is constrained to a 5-value enum. Drizzle-kit doesn't
+	-- emit CHECKs for `enum` text columns; hand-edited.
+	CONSTRAINT "ck_recipe_version_rejections_reason" CHECK("recipe_version_rejections"."reason" IN ('wrong-recipe','low-quality-extraction','duplicate','not-a-recipe','other'))
+);
+--> statement-breakpoint
+CREATE TABLE `recipe_runs` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`recipe_version_id` integer NOT NULL,
+	`started_at` text,
+	`completed_at` text,
+	`scale_factor` real DEFAULT 1 NOT NULL,
+	`yielded_batch_id` integer,
+	`rating` integer,
+	`notes` text,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL,
+	FOREIGN KEY (`recipe_version_id`) REFERENCES `recipe_versions`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`yielded_batch_id`) REFERENCES `batches`(`id`) ON UPDATE no action ON DELETE no action,
+	CONSTRAINT "ck_recipe_runs_scale" CHECK("recipe_runs"."scale_factor" > 0),
+	CONSTRAINT "ck_recipe_runs_rating" CHECK("recipe_runs"."rating" IS NULL OR ("recipe_runs"."rating" BETWEEN 1 AND 5))
+);
+--> statement-breakpoint
+CREATE INDEX `idx_recipe_runs_complete` ON `recipe_runs` (`completed_at`) WHERE `completed_at` IS NOT NULL;
+--> statement-breakpoint
+CREATE INDEX `idx_recipe_runs_version` ON `recipe_runs` (`recipe_version_id`);
+--> statement-breakpoint
+CREATE TABLE `batches` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`variant_id` integer NOT NULL,
+	`prep_state_id` integer,
+	`qty_remaining` real NOT NULL,
+	`unit` text NOT NULL,
+	`source_type` text NOT NULL,
+	`source_id` integer,
+	`location` text NOT NULL,
+	`produced_at` text NOT NULL,
+	`expires_at` text,
+	`notes` text,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL, `deleted_at` text,
+	FOREIGN KEY (`variant_id`) REFERENCES `ingredient_variants`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`prep_state_id`) REFERENCES `prep_states`(`id`) ON UPDATE no action ON DELETE no action,
+	CONSTRAINT "ck_batches_qty_remaining" CHECK("batches"."qty_remaining" >= 0),
+	CONSTRAINT "ck_batches_unit" CHECK("batches"."unit" IN ('g','ml','count')),
+	CONSTRAINT "ck_batches_source_type" CHECK("batches"."source_type" IN ('purchase','recipe_run','gift','other')),
+	CONSTRAINT "ck_batches_location" CHECK("batches"."location" IN ('pantry','fridge','freezer','other'))
+);
+--> statement-breakpoint
+CREATE INDEX `idx_batches_location_expiry` ON `batches` (`location`,`expires_at`);
+--> statement-breakpoint
+CREATE INDEX `idx_batches_remaining` ON `batches` (`variant_id`,`prep_state_id`) WHERE `qty_remaining` > 0;
+--> statement-breakpoint
+CREATE INDEX `idx_batches_variant_prep` ON `batches` (`variant_id`,`prep_state_id`);
+--> statement-breakpoint
+CREATE TABLE `batch_consumptions` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`recipe_run_id` integer NOT NULL,
+	`batch_id` integer NOT NULL,
+	`qty_consumed` real NOT NULL,
+	`unit` text NOT NULL,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL,
+	FOREIGN KEY (`recipe_run_id`) REFERENCES `recipe_runs`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`batch_id`) REFERENCES `batches`(`id`) ON UPDATE no action ON DELETE no action,
+	CONSTRAINT "ck_batch_consumptions_qty" CHECK("batch_consumptions"."qty_consumed" > 0),
+	CONSTRAINT "ck_batch_consumptions_unit" CHECK("batch_consumptions"."unit" IN ('g','ml','count'))
+);
+--> statement-breakpoint
+CREATE INDEX `idx_batch_consumptions_batch` ON `batch_consumptions` (`batch_id`);
+--> statement-breakpoint
+CREATE INDEX `idx_batch_consumptions_run` ON `batch_consumptions` (`recipe_run_id`);
+--> statement-breakpoint
+CREATE TABLE `substitutions` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`from_ingredient_id` integer,
+	`from_variant_id` integer,
+	`to_ingredient_id` integer,
+	`to_variant_id` integer,
+	`ratio` real DEFAULT 1 NOT NULL,
+	`context_tags` text DEFAULT '[]' NOT NULL,
+	`scope` text DEFAULT 'global' NOT NULL,
+	`recipe_id` integer,
+	`notes` text,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL,
+	FOREIGN KEY (`from_ingredient_id`) REFERENCES `ingredients`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`from_variant_id`) REFERENCES `ingredient_variants`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`to_ingredient_id`) REFERENCES `ingredients`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`to_variant_id`) REFERENCES `ingredient_variants`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`recipe_id`) REFERENCES `recipes`(`id`) ON UPDATE no action ON DELETE no action,
+	CONSTRAINT "ck_subs_xor_from" CHECK(("substitutions"."from_ingredient_id" IS NOT NULL) <> ("substitutions"."from_variant_id" IS NOT NULL)),
+	CONSTRAINT "ck_subs_xor_to" CHECK(("substitutions"."to_ingredient_id" IS NOT NULL) <> ("substitutions"."to_variant_id" IS NOT NULL)),
+	CONSTRAINT "ck_subs_scope_recipe" CHECK(("substitutions"."scope" = 'recipe' AND "substitutions"."recipe_id" IS NOT NULL) OR ("substitutions"."scope" = 'global' AND "substitutions"."recipe_id" IS NULL)),
+	CONSTRAINT "ck_subs_scope" CHECK("substitutions"."scope" IN ('global','recipe')),
+	CONSTRAINT "ck_subs_ratio_positive" CHECK("substitutions"."ratio" > 0)
+);
+--> statement-breakpoint
+CREATE INDEX `idx_subs_from_ing` ON `substitutions` (`from_ingredient_id`) WHERE `from_ingredient_id` IS NOT NULL;
+--> statement-breakpoint
+CREATE INDEX `idx_subs_from_var` ON `substitutions` (`from_variant_id`) WHERE `from_variant_id` IS NOT NULL;
+--> statement-breakpoint
+CREATE INDEX `idx_subs_scope_recipe` ON `substitutions` (`scope`,`recipe_id`) WHERE `scope` = 'recipe';
+--> statement-breakpoint
+CREATE UNIQUE INDEX `uq_subs_global_ing_ing` ON `substitutions` (`from_ingredient_id`,`to_ingredient_id`) WHERE `scope` = 'global' AND `from_variant_id` IS NULL AND `to_variant_id` IS NULL;
+--> statement-breakpoint
+CREATE UNIQUE INDEX `uq_subs_global_ing_var` ON `substitutions` (`from_ingredient_id`,`to_variant_id`) WHERE `scope` = 'global' AND `from_variant_id` IS NULL AND `to_ingredient_id` IS NULL;
+--> statement-breakpoint
+CREATE UNIQUE INDEX `uq_subs_global_var_ing` ON `substitutions` (`from_variant_id`,`to_ingredient_id`) WHERE `scope` = 'global' AND `from_ingredient_id` IS NULL AND `to_variant_id` IS NULL;
+--> statement-breakpoint
+CREATE UNIQUE INDEX `uq_subs_global_var_var` ON `substitutions` (`from_variant_id`,`to_variant_id`) WHERE `scope` = 'global' AND `from_ingredient_id` IS NULL AND `to_ingredient_id` IS NULL;
+--> statement-breakpoint
+CREATE UNIQUE INDEX `uq_subs_recipe_ing_ing` ON `substitutions` (`from_ingredient_id`,`to_ingredient_id`,`recipe_id`) WHERE `scope` = 'recipe' AND `from_variant_id` IS NULL AND `to_variant_id` IS NULL;
+--> statement-breakpoint
+CREATE UNIQUE INDEX `uq_subs_recipe_ing_var` ON `substitutions` (`from_ingredient_id`,`to_variant_id`,`recipe_id`) WHERE `scope` = 'recipe' AND `from_variant_id` IS NULL AND `to_ingredient_id` IS NULL;
+--> statement-breakpoint
+CREATE UNIQUE INDEX `uq_subs_recipe_var_ing` ON `substitutions` (`from_variant_id`,`to_ingredient_id`,`recipe_id`) WHERE `scope` = 'recipe' AND `from_ingredient_id` IS NULL AND `to_variant_id` IS NULL;
+--> statement-breakpoint
+CREATE UNIQUE INDEX `uq_subs_recipe_var_var` ON `substitutions` (`from_variant_id`,`to_variant_id`,`recipe_id`) WHERE `scope` = 'recipe' AND `from_ingredient_id` IS NULL AND `to_ingredient_id` IS NULL;
+--> statement-breakpoint
+CREATE TABLE `plan_entries` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`date` text NOT NULL,
+	`slot` text NOT NULL,
+	`position` integer DEFAULT 0 NOT NULL,
+	`recipe_id` integer NOT NULL,
+	`recipe_version_id` integer,
+	`planned_servings` integer DEFAULT 1 NOT NULL,
+	`recipe_run_id` integer,
+	`notes` text,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL,
+	FOREIGN KEY (`slot`) REFERENCES `plan_slots`(`slug`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`recipe_id`) REFERENCES `recipes`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`recipe_version_id`) REFERENCES `recipe_versions`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`recipe_run_id`) REFERENCES `recipe_runs`(`id`) ON UPDATE no action ON DELETE no action,
+	CONSTRAINT "ck_plan_entries_planned_servings" CHECK("plan_entries"."planned_servings" > 0)
+);
+--> statement-breakpoint
+CREATE INDEX `idx_plan_entries_date` ON `plan_entries` (`date`);
+--> statement-breakpoint
+CREATE INDEX `idx_plan_entries_date_slot` ON `plan_entries` (`date`,`slot`);
+--> statement-breakpoint
+CREATE INDEX `idx_plan_entries_recipe` ON `plan_entries` (`recipe_id`);
+--> statement-breakpoint
+CREATE INDEX `idx_plan_entries_unscheduled` ON `plan_entries` (`recipe_id`) WHERE `recipe_run_id` IS NULL;
+--> statement-breakpoint
+CREATE TABLE `plan_slots` (
+	`slug` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`display_order` integer DEFAULT 100 NOT NULL,
+	`is_default` integer DEFAULT 0 NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `ingest_sources` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`kind` text NOT NULL,
+	`url` text,
+	`caption` text,
+	`transcript_path` text,
+	`keyframes_dir` text,
+	`video_path` text,
+	`extracted_json` text,
+	`extractor_version` text NOT NULL,
+	`draft_recipe_id` integer,
+	`ingested_at` text DEFAULT (datetime('now')) NOT NULL,
+	`archived_at` text, `error_code` text, `error_message` text, `attempts` integer DEFAULT 0 NOT NULL, `reviewed_at` text,
+	FOREIGN KEY (`draft_recipe_id`) REFERENCES `recipes`(`id`) ON UPDATE no action ON DELETE no action,
+	CONSTRAINT "ck_ingest_sources_kind" CHECK("ingest_sources"."kind" IN ('url-web','url-instagram','text','screenshot'))
+);
+--> statement-breakpoint
+CREATE INDEX `idx_ingest_sources_ingested` ON `ingest_sources` (`ingested_at`);
+--> statement-breakpoint
+CREATE INDEX `idx_ingest_sources_kind` ON `ingest_sources` (`kind`);
+--> statement-breakpoint
+CREATE INDEX `idx_ingest_sources_recipe` ON `ingest_sources` (`draft_recipe_id`);

--- a/pillars/food/migrations/meta/_journal.json
+++ b/pillars/food/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1781500777653,
       "tag": "0060_food_ingredient_tags",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1781500777654,
+      "tag": "0061_food_remainder",
+      "breakpoints": true
     }
   ]
 }

--- a/pillars/food/openapi/food.openapi.json
+++ b/pillars/food/openapi/food.openapi.json
@@ -3949,6 +3949,1698 @@
         "tags": ["slugs"]
       }
     },
+    "/solver/can-i-cook": {
+      "post": {
+        "operationId": "solver.canICook",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "excludeSubs": {
+                    "type": "boolean"
+                  },
+                  "maxMinutes": {
+                    "exclusiveMinimum": true,
+                    "maximum": 1440,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "recipeTypes": {
+                    "items": {
+                      "enum": [
+                        "plate",
+                        "component",
+                        "technique",
+                        "sauce",
+                        "dressing",
+                        "drink",
+                        "condiment"
+                      ],
+                      "type": "string"
+                    },
+                    "maxItems": 7,
+                    "type": "array"
+                  },
+                  "tags": {
+                    "items": {
+                      "maxLength": 64,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "maxItems": 32,
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "cookableCount": {
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "recipes": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "cookMinutes": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "nullable": true,
+                            "type": "integer"
+                          },
+                          "heroImagePath": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "lastCookedAt": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "prepMinutes": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "nullable": true,
+                            "type": "integer"
+                          },
+                          "recipeId": {
+                            "exclusiveMinimum": true,
+                            "maximum": 9007199254740991,
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "recipeSlug": {
+                            "type": "string"
+                          },
+                          "recipeType": {
+                            "enum": [
+                              "plate",
+                              "component",
+                              "technique",
+                              "sauce",
+                              "dressing",
+                              "drink",
+                              "condiment"
+                            ],
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "subs": {
+                            "items": {
+                              "additionalProperties": false,
+                              "properties": {
+                                "candidateSubName": {
+                                  "type": "string"
+                                },
+                                "fromIngredientName": {
+                                  "type": "string"
+                                },
+                                "fromVariantName": {
+                                  "nullable": true,
+                                  "type": "string"
+                                },
+                                "lineIndex": {
+                                  "maximum": 9007199254740991,
+                                  "minimum": -9007199254740991,
+                                  "type": "integer"
+                                },
+                                "substitutionId": {
+                                  "maximum": 9007199254740991,
+                                  "minimum": -9007199254740991,
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "lineIndex",
+                                "fromIngredientName",
+                                "fromVariantName",
+                                "candidateSubName",
+                                "substitutionId"
+                              ],
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "subsNeeded": {
+                            "maximum": 9007199254740991,
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "title": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "recipeId",
+                          "recipeSlug",
+                          "title",
+                          "recipeType",
+                          "heroImagePath",
+                          "prepMinutes",
+                          "cookMinutes",
+                          "lastCookedAt",
+                          "subsNeeded",
+                          "subs"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "totalCandidates": {
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["totalCandidates", "cookableCount", "recipes"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Rank cookable recipes by substitution count given current inventory",
+        "tags": ["solver"]
+      }
+    },
+    "/substitutions": {
+      "get": {
+        "operationId": "substitutions.list",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "fromIngredientId",
+            "schema": {
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "fromVariantId",
+            "schema": {
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "toIngredientId",
+            "schema": {
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "toVariantId",
+            "schema": {
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "scope",
+            "schema": {
+              "enum": ["global", "recipe"],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "recipeId",
+            "schema": {
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "contextTag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "items": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "contextTags": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "readOnly": true,
+                            "type": "array"
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          },
+                          "fromIngredientId": {
+                            "exclusiveMinimum": true,
+                            "maximum": 9007199254740991,
+                            "minimum": 0,
+                            "nullable": true,
+                            "type": "integer"
+                          },
+                          "fromVariantId": {
+                            "exclusiveMinimum": true,
+                            "maximum": 9007199254740991,
+                            "minimum": 0,
+                            "nullable": true,
+                            "type": "integer"
+                          },
+                          "id": {
+                            "exclusiveMinimum": true,
+                            "maximum": 9007199254740991,
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "notes": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "ratio": {
+                            "type": "number"
+                          },
+                          "recipeId": {
+                            "exclusiveMinimum": true,
+                            "maximum": 9007199254740991,
+                            "minimum": 0,
+                            "nullable": true,
+                            "type": "integer"
+                          },
+                          "scope": {
+                            "enum": ["global", "recipe"],
+                            "type": "string"
+                          },
+                          "toIngredientId": {
+                            "exclusiveMinimum": true,
+                            "maximum": 9007199254740991,
+                            "minimum": 0,
+                            "nullable": true,
+                            "type": "integer"
+                          },
+                          "toVariantId": {
+                            "exclusiveMinimum": true,
+                            "maximum": 9007199254740991,
+                            "minimum": 0,
+                            "nullable": true,
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "fromIngredientId",
+                          "fromVariantId",
+                          "toIngredientId",
+                          "toVariantId",
+                          "ratio",
+                          "contextTags",
+                          "scope",
+                          "recipeId",
+                          "notes",
+                          "createdAt"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": ["items"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "List substitutions (raw FK ids)",
+        "tags": ["substitutions"]
+      },
+      "post": {
+        "operationId": "substitutions.create",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "contextTags": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "from": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "ingredientId": {
+                        "exclusiveMinimum": true,
+                        "maximum": 9007199254740991,
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "variantId": {
+                        "exclusiveMinimum": true,
+                        "maximum": 9007199254740991,
+                        "minimum": 0,
+                        "type": "integer"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "notes": {
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "ratio": {
+                    "exclusiveMinimum": true,
+                    "minimum": 0,
+                    "type": "number"
+                  },
+                  "recipeId": {
+                    "exclusiveMinimum": true,
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "nullable": true,
+                    "type": "integer"
+                  },
+                  "scope": {
+                    "enum": ["global", "recipe"],
+                    "type": "string"
+                  },
+                  "to": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "ingredientId": {
+                        "exclusiveMinimum": true,
+                        "maximum": 9007199254740991,
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "variantId": {
+                        "exclusiveMinimum": true,
+                        "maximum": 9007199254740991,
+                        "minimum": 0,
+                        "type": "integer"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "required": ["from", "to"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "contextTags": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "readOnly": true,
+                          "type": "array"
+                        },
+                        "createdAt": {
+                          "type": "string"
+                        },
+                        "fromIngredientId": {
+                          "exclusiveMinimum": true,
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "fromVariantId": {
+                          "exclusiveMinimum": true,
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "id": {
+                          "exclusiveMinimum": true,
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "notes": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "ratio": {
+                          "type": "number"
+                        },
+                        "recipeId": {
+                          "exclusiveMinimum": true,
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "scope": {
+                          "enum": ["global", "recipe"],
+                          "type": "string"
+                        },
+                        "toIngredientId": {
+                          "exclusiveMinimum": true,
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "toVariantId": {
+                          "exclusiveMinimum": true,
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "nullable": true,
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "fromIngredientId",
+                        "fromVariantId",
+                        "toIngredientId",
+                        "toVariantId",
+                        "ratio",
+                        "contextTags",
+                        "scope",
+                        "recipeId",
+                        "notes",
+                        "createdAt"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "201"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Create a substitution edge",
+        "tags": ["substitutions"]
+      }
+    },
+    "/substitutions/graph-view": {
+      "get": {
+        "operationId": "substitutions.graphView",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "scope",
+            "schema": {
+              "enum": ["global", "recipe"],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "recipeId",
+            "schema": {
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "contextTag",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "search",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "edges": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "contextTags": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "readOnly": true,
+                            "type": "array"
+                          },
+                          "fromNodeId": {
+                            "type": "string"
+                          },
+                          "id": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "type": "integer"
+                          },
+                          "notes": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "ratio": {
+                            "type": "number"
+                          },
+                          "recipeId": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "nullable": true,
+                            "type": "integer"
+                          },
+                          "recipeSlug": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "scope": {
+                            "enum": ["global", "recipe"],
+                            "type": "string"
+                          },
+                          "toNodeId": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "fromNodeId",
+                          "toNodeId",
+                          "ratio",
+                          "contextTags",
+                          "scope",
+                          "recipeId",
+                          "recipeSlug",
+                          "notes"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "nodes": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "ingredientId": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "type": "integer"
+                          },
+                          "ingredientName": {
+                            "type": "string"
+                          },
+                          "ingredientSlug": {
+                            "type": "string"
+                          },
+                          "kind": {
+                            "enum": ["ingredient", "variant"],
+                            "type": "string"
+                          },
+                          "variantId": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "nullable": true,
+                            "type": "integer"
+                          },
+                          "variantName": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "variantSlug": {
+                            "nullable": true,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "kind",
+                          "ingredientId",
+                          "variantId",
+                          "ingredientSlug",
+                          "ingredientName",
+                          "variantSlug",
+                          "variantName"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": ["nodes", "edges"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Node/edge projection of the substitution graph",
+        "tags": ["substitutions"]
+      }
+    },
+    "/substitutions/hydrated": {
+      "get": {
+        "operationId": "substitutions.listHydrated",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "fromIngredientId",
+            "schema": {
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "fromVariantId",
+            "schema": {
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "toIngredientId",
+            "schema": {
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "toVariantId",
+            "schema": {
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "scope",
+            "schema": {
+              "enum": ["global", "recipe"],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "recipeId",
+            "schema": {
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "contextTag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "items": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "contextTags": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "readOnly": true,
+                            "type": "array"
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          },
+                          "from": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "id": {
+                                "maximum": 9007199254740991,
+                                "minimum": -9007199254740991,
+                                "type": "integer"
+                              },
+                              "kind": {
+                                "enum": ["ingredient", "variant"],
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "parentSlug": {
+                                "nullable": true,
+                                "type": "string"
+                              },
+                              "slug": {
+                                "type": "string"
+                              }
+                            },
+                            "required": ["kind", "id", "slug", "name", "parentSlug"],
+                            "type": "object"
+                          },
+                          "fromIngredientId": {
+                            "exclusiveMinimum": true,
+                            "maximum": 9007199254740991,
+                            "minimum": 0,
+                            "nullable": true,
+                            "type": "integer"
+                          },
+                          "fromVariantId": {
+                            "exclusiveMinimum": true,
+                            "maximum": 9007199254740991,
+                            "minimum": 0,
+                            "nullable": true,
+                            "type": "integer"
+                          },
+                          "id": {
+                            "exclusiveMinimum": true,
+                            "maximum": 9007199254740991,
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "notes": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "ratio": {
+                            "type": "number"
+                          },
+                          "recipeId": {
+                            "exclusiveMinimum": true,
+                            "maximum": 9007199254740991,
+                            "minimum": 0,
+                            "nullable": true,
+                            "type": "integer"
+                          },
+                          "recipeSlug": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "scope": {
+                            "enum": ["global", "recipe"],
+                            "type": "string"
+                          },
+                          "to": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "id": {
+                                "maximum": 9007199254740991,
+                                "minimum": -9007199254740991,
+                                "type": "integer"
+                              },
+                              "kind": {
+                                "enum": ["ingredient", "variant"],
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "parentSlug": {
+                                "nullable": true,
+                                "type": "string"
+                              },
+                              "slug": {
+                                "type": "string"
+                              }
+                            },
+                            "required": ["kind", "id", "slug", "name", "parentSlug"],
+                            "type": "object"
+                          },
+                          "toIngredientId": {
+                            "exclusiveMinimum": true,
+                            "maximum": 9007199254740991,
+                            "minimum": 0,
+                            "nullable": true,
+                            "type": "integer"
+                          },
+                          "toVariantId": {
+                            "exclusiveMinimum": true,
+                            "maximum": 9007199254740991,
+                            "minimum": 0,
+                            "nullable": true,
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "fromIngredientId",
+                          "fromVariantId",
+                          "toIngredientId",
+                          "toVariantId",
+                          "ratio",
+                          "contextTags",
+                          "scope",
+                          "recipeId",
+                          "notes",
+                          "createdAt",
+                          "from",
+                          "to",
+                          "recipeSlug"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": ["items"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "List substitutions widened with slug + display name per endpoint",
+        "tags": ["substitutions"]
+      }
+    },
+    "/substitutions/resolve-line": {
+      "get": {
+        "operationId": "substitutions.resolveForLine",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "recipeVersionId",
+            "required": true,
+            "schema": {
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "lineIndex",
+            "required": true,
+            "schema": {
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "candidates": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "batches": {
+                            "items": {
+                              "additionalProperties": false,
+                              "properties": {
+                                "batchId": {
+                                  "maximum": 9007199254740991,
+                                  "minimum": -9007199254740991,
+                                  "type": "integer"
+                                },
+                                "expiresAt": {
+                                  "nullable": true,
+                                  "type": "string"
+                                },
+                                "location": {
+                                  "enum": ["pantry", "fridge", "freezer", "other"],
+                                  "type": "string"
+                                },
+                                "prepStateId": {
+                                  "maximum": 9007199254740991,
+                                  "minimum": -9007199254740991,
+                                  "nullable": true,
+                                  "type": "integer"
+                                },
+                                "prepStateLabel": {
+                                  "nullable": true,
+                                  "type": "string"
+                                },
+                                "qtyRemaining": {
+                                  "type": "number"
+                                },
+                                "unit": {
+                                  "enum": ["g", "ml", "count"],
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "batchId",
+                                "qtyRemaining",
+                                "unit",
+                                "location",
+                                "expiresAt",
+                                "prepStateId",
+                                "prepStateLabel"
+                              ],
+                              "type": "object"
+                            },
+                            "readOnly": true,
+                            "type": "array"
+                          },
+                          "contextTags": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "readOnly": true,
+                            "type": "array"
+                          },
+                          "notes": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "ratio": {
+                            "type": "number"
+                          },
+                          "recipeId": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "nullable": true,
+                            "type": "integer"
+                          },
+                          "scope": {
+                            "enum": ["global", "recipe"],
+                            "type": "string"
+                          },
+                          "substituteIngredientId": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "type": "integer"
+                          },
+                          "substituteIngredientName": {
+                            "type": "string"
+                          },
+                          "substituteVariantId": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "type": "integer"
+                          },
+                          "substituteVariantName": {
+                            "type": "string"
+                          },
+                          "substitutionId": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "substitutionId",
+                          "ratio",
+                          "contextTags",
+                          "scope",
+                          "recipeId",
+                          "substituteVariantId",
+                          "substituteVariantName",
+                          "substituteIngredientId",
+                          "substituteIngredientName",
+                          "notes",
+                          "batches"
+                        ],
+                        "type": "object"
+                      },
+                      "readOnly": true,
+                      "type": "array"
+                    },
+                    "lineIndex": {
+                      "maximum": 9007199254740991,
+                      "minimum": -9007199254740991,
+                      "type": "integer"
+                    },
+                    "linePrepStateId": {
+                      "maximum": 9007199254740991,
+                      "minimum": -9007199254740991,
+                      "nullable": true,
+                      "type": "integer"
+                    },
+                    "linePrepStateLabel": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "lineQty": {
+                      "type": "number"
+                    },
+                    "lineUnit": {
+                      "enum": ["g", "ml", "count"],
+                      "type": "string"
+                    },
+                    "lineVariantId": {
+                      "maximum": 9007199254740991,
+                      "minimum": -9007199254740991,
+                      "type": "integer"
+                    },
+                    "lineVariantName": {
+                      "type": "string"
+                    },
+                    "recipeContextTags": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "readOnly": true,
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "lineIndex",
+                    "lineVariantId",
+                    "lineVariantName",
+                    "linePrepStateId",
+                    "linePrepStateLabel",
+                    "lineQty",
+                    "lineUnit",
+                    "recipeContextTags",
+                    "candidates"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Per-line substitution candidates with batch coverage",
+        "tags": ["substitutions"]
+      }
+    },
+    "/substitutions/{id}": {
+      "delete": {
+        "operationId": "substitutions.delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {},
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "ok": {
+                      "enum": [true],
+                      "type": "boolean"
+                    }
+                  },
+                  "required": ["ok"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Delete a substitution edge",
+        "tags": ["substitutions"]
+      },
+      "patch": {
+        "operationId": "substitutions.update",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "contextTags": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "notes": {
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "ratio": {
+                    "exclusiveMinimum": true,
+                    "minimum": 0,
+                    "type": "number"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "contextTags": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "readOnly": true,
+                          "type": "array"
+                        },
+                        "createdAt": {
+                          "type": "string"
+                        },
+                        "fromIngredientId": {
+                          "exclusiveMinimum": true,
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "fromVariantId": {
+                          "exclusiveMinimum": true,
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "id": {
+                          "exclusiveMinimum": true,
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "notes": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "ratio": {
+                          "type": "number"
+                        },
+                        "recipeId": {
+                          "exclusiveMinimum": true,
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "scope": {
+                          "enum": ["global", "recipe"],
+                          "type": "string"
+                        },
+                        "toIngredientId": {
+                          "exclusiveMinimum": true,
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "toVariantId": {
+                          "exclusiveMinimum": true,
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "nullable": true,
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "fromIngredientId",
+                        "fromVariantId",
+                        "toIngredientId",
+                        "toVariantId",
+                        "ratio",
+                        "contextTags",
+                        "scope",
+                        "recipeId",
+                        "notes",
+                        "createdAt"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Update a substitution edge",
+        "tags": ["substitutions"]
+      }
+    },
     "/variants": {
       "post": {
         "operationId": "variants.create",

--- a/pillars/food/src/api/__tests__/solver.test.ts
+++ b/pillars/food/src/api/__tests__/solver.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Integration test for the `solver.canICook` REST surface. The ranking +
+ * substitution-coverage maths live in the db/services tests; here we assert
+ * the wire envelope end-to-end (empty catalogue → empty result) and that
+ * the input filters validate.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { type OpenedFoodDb, openFoodDb } from '../../db/index.js';
+import { createFoodApiApp } from '../app.js';
+import { makeClient } from './test-utils.js';
+
+let tmpDir: string;
+let foodDb: OpenedFoodDb;
+
+function client(): ReturnType<typeof makeClient> {
+  return makeClient(
+    createFoodApiApp({ foodDb, version: '0.0.1-test', selfBaseUrl: 'http://localhost:3005' })
+  );
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'food-api-solver-test-'));
+  foodDb = openFoodDb(join(tmpDir, 'food.db'));
+});
+
+afterEach(() => {
+  foodDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('solver REST', () => {
+  it('returns an empty result for an empty catalogue', async () => {
+    const res = await client().solver.canICook({});
+    expect(res).toEqual({ totalCandidates: 0, cookableCount: 0, recipes: [] });
+  });
+
+  it('accepts the filter set without error', async () => {
+    const res = await client().solver.canICook({
+      excludeSubs: true,
+      recipeTypes: ['plate', 'sauce'],
+      tags: ['quick'],
+      maxMinutes: 30,
+    });
+    expect(res.recipes).toEqual([]);
+  });
+
+  it('rejects an invalid recipeType at the zod boundary with 400', async () => {
+    await expect(client().solver.canICook({ recipeTypes: ['not-a-type'] })).rejects.toMatchObject({
+      status: 400,
+    });
+  });
+});

--- a/pillars/food/src/api/__tests__/substitutions.test.ts
+++ b/pillars/food/src/api/__tests__/substitutions.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Integration tests for the `substitutions.*` REST surface — CRUD, the
+ * graph-view projection, and the resolve-line error path. The substitution
+ * resolution maths + graph assembly live in the db package's tests; here we
+ * assert the wire envelopes + HTTP status mapping.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { type IngredientRow, type OpenedFoodDb, openFoodDb } from '../../db/index.js';
+import { createIngredient } from '../../db/services/ingredients.js';
+import { createFoodApiApp } from '../app.js';
+import { makeClient } from './test-utils.js';
+
+let tmpDir: string;
+let foodDb: OpenedFoodDb;
+let from: IngredientRow;
+let to: IngredientRow;
+
+function client(): ReturnType<typeof makeClient> {
+  return makeClient(
+    createFoodApiApp({ foodDb, version: '0.0.1-test', selfBaseUrl: 'http://localhost:3005' })
+  );
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'food-api-substitutions-test-'));
+  foodDb = openFoodDb(join(tmpDir, 'food.db'));
+  from = createIngredient(foodDb.db, { name: 'Butter', slug: 'butter', defaultUnit: 'g' });
+  to = createIngredient(foodDb.db, { name: 'Olive Oil', slug: 'olive-oil', defaultUnit: 'ml' });
+});
+
+afterEach(() => {
+  foodDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('substitutions REST — CRUD', () => {
+  it('creates, lists, updates and deletes a global substitution', async () => {
+    const api = client();
+    const created = await api.substitutions.create({
+      from: { ingredientId: from.id },
+      to: { ingredientId: to.id },
+      ratio: 0.8,
+    });
+    expect(created.data.fromIngredientId).toBe(from.id);
+    expect(created.data.toIngredientId).toBe(to.id);
+    expect(created.data.scope).toBe('global');
+
+    const list = await api.substitutions.list();
+    expect(list.items).toHaveLength(1);
+
+    const updated = await api.substitutions.update(created.data.id, { ratio: 1.2 });
+    expect(updated.data.ratio).toBe(1.2);
+
+    const del = await api.substitutions.delete(created.data.id);
+    expect(del).toEqual({ ok: true });
+    expect((await api.substitutions.list()).items).toHaveLength(0);
+  });
+
+  it('rejects an endpoint that sets neither id with 400', async () => {
+    await expect(
+      client().substitutions.create({ from: {}, to: { ingredientId: to.id } })
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it('maps a self-substitution to 400', async () => {
+    await expect(
+      client().substitutions.create({
+        from: { ingredientId: from.id },
+        to: { ingredientId: from.id },
+      })
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it('rejects scope=recipe without a recipeId with 400', async () => {
+    await expect(
+      client().substitutions.create({
+        from: { ingredientId: from.id },
+        to: { ingredientId: to.id },
+        scope: 'recipe',
+      })
+    ).rejects.toMatchObject({ status: 400 });
+  });
+});
+
+describe('substitutions REST — graph view', () => {
+  it('projects nodes and edges from the stored substitutions', async () => {
+    const api = client();
+    await api.substitutions.create({
+      from: { ingredientId: from.id },
+      to: { ingredientId: to.id },
+    });
+    const graph = await api.substitutions.graphView();
+    expect(graph.edges).toHaveLength(1);
+    expect(graph.nodes.map((n) => n.id).toSorted()).toEqual([
+      `ingredient:${from.id}`,
+      `ingredient:${to.id}`,
+    ]);
+  });
+});
+
+describe('substitutions REST — resolve line', () => {
+  it('maps an unknown recipe line to 404', async () => {
+    await expect(client().substitutions.resolveForLine(999999, 1)).rejects.toMatchObject({
+      status: 404,
+    });
+  });
+});

--- a/pillars/food/src/api/__tests__/test-utils.ts
+++ b/pillars/food/src/api/__tests__/test-utils.ts
@@ -91,6 +91,31 @@ interface CreateIngredientBody {
   notes?: string | null;
 }
 
+type SubEndpoint = { ingredientId?: number; variantId?: number };
+
+interface SubstitutionView {
+  id: number;
+  fromIngredientId: number | null;
+  toIngredientId: number | null;
+  ratio: number;
+  contextTags: readonly string[];
+  scope: 'global' | 'recipe';
+  recipeId: number | null;
+  notes: string | null;
+  createdAt: string;
+}
+
+interface GraphView {
+  nodes: { id: string; kind: 'ingredient' | 'variant' }[];
+  edges: { id: number; fromNodeId: string; toNodeId: string }[];
+}
+
+interface SolveResult {
+  totalCandidates: number;
+  cookableCount: number;
+  recipes: unknown[];
+}
+
 export class HttpError extends Error {
   readonly status: number;
   readonly body: unknown;
@@ -224,6 +249,36 @@ export function makeClient(app: Express) {
       recipeRefs: (id: number) =>
         send<{ count: number; recipes: unknown[] }>(r.get(`/ingredients/${id}/recipe-refs`)),
       delete: (id: number) => send<IngredientDeleteResult>(r.delete(`/ingredients/${id}`)),
+    },
+    substitutions: {
+      list: (query: { scope?: 'global' | 'recipe'; recipeId?: number } = {}) =>
+        send<{ items: SubstitutionView[] }>(r.get('/substitutions').query(query)),
+      graphView: (query: { scope?: 'global' | 'recipe'; recipeId?: number } = {}) =>
+        send<GraphView>(r.get('/substitutions/graph-view').query(query)),
+      resolveForLine: (recipeVersionId: number, lineIndex: number) =>
+        send<unknown>(r.get('/substitutions/resolve-line').query({ recipeVersionId, lineIndex })),
+      create: (body: {
+        from: SubEndpoint;
+        to: SubEndpoint;
+        ratio?: number;
+        contextTags?: string[];
+        scope?: 'global' | 'recipe';
+        recipeId?: number | null;
+        notes?: string | null;
+      }) => send<{ data: SubstitutionView }>(r.post('/substitutions').send(body)),
+      update: (id: number, body: { ratio?: number; notes?: string | null }) =>
+        send<{ data: SubstitutionView }>(r.patch(`/substitutions/${id}`).send(body)),
+      delete: (id: number) => send<{ ok: true }>(r.delete(`/substitutions/${id}`)),
+    },
+    solver: {
+      canICook: (
+        body: {
+          excludeSubs?: boolean;
+          recipeTypes?: string[];
+          tags?: string[];
+          maxMinutes?: number;
+        } = {}
+      ) => send<SolveResult>(r.post('/solver/can-i-cook').send(body)),
     },
   };
 }

--- a/pillars/food/src/api/modules/solver/can-i-cook.ts
+++ b/pillars/food/src/api/modules/solver/can-i-cook.ts
@@ -1,0 +1,110 @@
+import {
+  loadBatchInventory,
+  loadSubstitutionsIndex,
+} from '../substitutions/substitutions-resolve.js';
+import { loadRecipeTagsMap, preFilterCandidates } from './candidates.js';
+import { evaluateRecipeLines } from './line-evaluator.js';
+import { loadRequiredLines } from './lines.js';
+import { buildNameLookup } from './name-lookup.js';
+
+/**
+ * `food.solver.canICook` orchestrator — PRD-150.
+ *
+ * Pipeline:
+ *   1. Pre-filter recipes (compiled + non-archived + current_version +
+ *      client filters).
+ *   2. Bulk-load required lines, pantry inventory, substitution index,
+ *      and recipe-tag lists for the candidate set.
+ *   3. Walk each recipe's lines via `evaluateRecipeLines`; drop
+ *      uncookable recipes; collect SubBreakdown entries.
+ *   4. Apply `excludeSubs` post-filter; sort by
+ *      `subsNeeded ASC, lastCookedAt DESC NULLS LAST, slug ASC`;
+ *      return totals + ranked rows.
+ *
+ * The cookableCount reported is post-`excludeSubs` so it always
+ * matches `recipes.length` — that's what the UI labels with
+ * "<cookable> of <total>".
+ */
+import type { FoodDb } from '../../../db/index.js';
+import type { CandidateRecipe } from './candidates.js';
+import type { CanICookInput } from './inputs.js';
+import type { SolveRecipeRow, SolveResult } from './types.js';
+
+function compareRows(a: SolveRecipeRow, b: SolveRecipeRow): number {
+  if (a.subsNeeded !== b.subsNeeded) return a.subsNeeded - b.subsNeeded;
+  if (a.lastCookedAt !== b.lastCookedAt) {
+    if (a.lastCookedAt === null) return 1;
+    if (b.lastCookedAt === null) return -1;
+    // DESC = newer first
+    return a.lastCookedAt < b.lastCookedAt ? 1 : -1;
+  }
+  return compareSlug(a.recipeSlug, b.recipeSlug);
+}
+
+function compareSlug(a: string, b: string): number {
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+}
+
+function rowFromCandidate(
+  candidate: CandidateRecipe,
+  subsNeeded: number,
+  subs: SolveRecipeRow['subs']
+): SolveRecipeRow {
+  return {
+    recipeId: candidate.recipeId,
+    recipeSlug: candidate.recipeSlug,
+    title: candidate.title,
+    recipeType: candidate.recipeType,
+    heroImagePath: candidate.heroImagePath,
+    prepMinutes: candidate.prepMinutes,
+    cookMinutes: candidate.cookMinutes,
+    lastCookedAt: candidate.lastCookedAt,
+    subsNeeded,
+    subs,
+  };
+}
+
+export function canICook(db: FoodDb, input: CanICookInput): SolveResult {
+  const candidates = preFilterCandidates(db, input);
+  if (candidates.length === 0) {
+    return { totalCandidates: 0, cookableCount: 0, recipes: [] };
+  }
+
+  const recipeIds = candidates.map((c) => c.recipeId);
+  const versionIds = candidates.map((c) => c.recipeVersionId);
+
+  const lineMap = loadRequiredLines(db, versionIds);
+  const inventory = loadBatchInventory(db);
+  const subIndex = loadSubstitutionsIndex(db, recipeIds);
+  const recipeTagsMap = loadRecipeTagsMap(db, recipeIds);
+  const names = buildNameLookup(db);
+
+  const rows: SolveRecipeRow[] = [];
+  for (const candidate of candidates) {
+    const lines = lineMap.get(candidate.recipeVersionId) ?? [];
+    const recipeTags = recipeTagsMap.get(candidate.recipeId) ?? [];
+    const evalResult = evaluateRecipeLines({
+      lines,
+      recipeId: candidate.recipeId,
+      recipeTags,
+      inventory,
+      subIndex,
+      names,
+    });
+    if (!evalResult.cookable) continue;
+    if (input.excludeSubs === true && evalResult.subsNeeded > 0) continue;
+    rows.push(rowFromCandidate(candidate, evalResult.subsNeeded, evalResult.subs));
+  }
+  rows.sort(compareRows);
+
+  // `totalCandidates` is the pool the solver ranged over BEFORE
+  // excludeSubs trims; that keeps the "X of Y cookable" caption
+  // honest for the user's current filter set.
+  return {
+    totalCandidates: candidates.length,
+    cookableCount: rows.length,
+    recipes: rows,
+  };
+}

--- a/pillars/food/src/api/modules/solver/candidates.ts
+++ b/pillars/food/src/api/modules/solver/candidates.ts
@@ -1,0 +1,156 @@
+/**
+ * Pre-filter the recipe candidate set for `food.solver.canICook` —
+ * PRD-150.
+ *
+ * Eligibility = non-archived recipe with a `current_version_id`
+ * pointing at a `compiled` version. Optional client filters
+ * (`recipeTypes`, `tags`, `maxMinutes`) are applied in SQL so the
+ * downstream line walker only sees real candidates.
+ *
+ * `lastCookedAt` is the MAX `recipe_runs.completed_at` across every
+ * version of the recipe (left join — recipes never cooked yield NULL).
+ */
+import { and, asc, eq, inArray, isNotNull, isNull, sql, type SQL } from 'drizzle-orm';
+
+import { recipeRuns, recipeTags, recipeVersions, recipes, type FoodDb } from '../../../db/index.js';
+
+import type { CanICookInput } from './inputs.js';
+import type { RecipeTypeLiteral } from './types.js';
+
+export interface CandidateRecipe {
+  recipeId: number;
+  recipeSlug: string;
+  title: string;
+  recipeType: RecipeTypeLiteral | null;
+  heroImagePath: string | null;
+  recipeVersionId: number;
+  prepMinutes: number | null;
+  cookMinutes: number | null;
+  lastCookedAt: string | null;
+}
+
+function maxTimeCondition(maxMinutes: number): SQL {
+  const prep = sql<number>`COALESCE(${recipeVersions.prepMinutes}, 0)`;
+  const cook = sql<number>`COALESCE(${recipeVersions.cookMinutes}, 0)`;
+  const cond = sql<boolean>`(${prep} + ${cook} <= ${maxMinutes}) OR (${recipeVersions.prepMinutes} IS NULL AND ${recipeVersions.cookMinutes} IS NULL)`;
+  return cond;
+}
+
+function buildWhere(input: CanICookInput): SQL {
+  const conds: SQL[] = [
+    isNull(recipes.archivedAt),
+    isNotNull(recipes.currentVersionId),
+    eq(recipeVersions.compileStatus, 'compiled'),
+  ];
+  if (input.recipeTypes !== undefined && input.recipeTypes.length > 0) {
+    conds.push(inArray(recipes.recipeType, input.recipeTypes));
+  }
+  if (input.maxMinutes !== undefined) {
+    conds.push(maxTimeCondition(input.maxMinutes));
+  }
+  const where = and(...conds);
+  if (where === undefined) throw new Error('candidate WHERE assembly failed');
+  return where;
+}
+
+function applyTagsFilter(
+  db: FoodDb,
+  pool: readonly CandidateRecipe[],
+  required: readonly string[]
+): CandidateRecipe[] {
+  if (pool.length === 0) return [];
+  const ids = pool.map((row) => row.recipeId);
+  const matchRows = db
+    .select({ recipeId: recipeTags.recipeId })
+    .from(recipeTags)
+    .where(and(inArray(recipeTags.recipeId, ids), inArray(recipeTags.tag, required)))
+    .groupBy(recipeTags.recipeId)
+    .having(sql`COUNT(DISTINCT ${recipeTags.tag}) = ${required.length}`)
+    .all();
+  const keep = new Set<number>();
+  for (const row of matchRows) keep.add(row.recipeId);
+  return pool.filter((row) => keep.has(row.recipeId));
+}
+
+/** Load + filter the candidate recipe set ahead of the line walker. */
+export function preFilterCandidates(db: FoodDb, input: CanICookInput): CandidateRecipe[] {
+  const where = buildWhere(input);
+  const rows = db
+    .select({
+      recipeId: recipes.id,
+      recipeSlug: recipes.slug,
+      title: recipeVersions.title,
+      recipeType: recipes.recipeType,
+      heroImagePath: recipes.heroImagePath,
+      recipeVersionId: recipeVersions.id,
+      prepMinutes: recipeVersions.prepMinutes,
+      cookMinutes: recipeVersions.cookMinutes,
+    })
+    .from(recipes)
+    .innerJoin(recipeVersions, eq(recipeVersions.id, recipes.currentVersionId))
+    .where(where)
+    .orderBy(asc(recipes.slug))
+    .all();
+  if (rows.length === 0) return [];
+  const lastCookedAt = loadLastCookedAt(
+    db,
+    rows.map((r) => r.recipeId)
+  );
+  const enriched: CandidateRecipe[] = rows.map((row) => ({
+    recipeId: row.recipeId,
+    recipeSlug: row.recipeSlug,
+    title: row.title,
+    recipeType: row.recipeType,
+    heroImagePath: row.heroImagePath,
+    recipeVersionId: row.recipeVersionId,
+    prepMinutes: row.prepMinutes,
+    cookMinutes: row.cookMinutes,
+    lastCookedAt: lastCookedAt.get(row.recipeId) ?? null,
+  }));
+  if (input.tags !== undefined && input.tags.length > 0) {
+    return applyTagsFilter(db, enriched, input.tags);
+  }
+  return enriched;
+}
+
+function loadLastCookedAt(db: FoodDb, recipeIds: readonly number[]): Map<number, string> {
+  if (recipeIds.length === 0) return new Map();
+  const rows = db
+    .select({
+      recipeId: recipeVersions.recipeId,
+      lastCookedAt: sql<string | null>`MAX(${recipeRuns.completedAt})`,
+    })
+    .from(recipeVersions)
+    .innerJoin(recipeRuns, eq(recipeRuns.recipeVersionId, recipeVersions.id))
+    .where(and(inArray(recipeVersions.recipeId, recipeIds), isNotNull(recipeRuns.completedAt)))
+    .groupBy(recipeVersions.recipeId)
+    .all();
+  const map = new Map<number, string>();
+  for (const row of rows) {
+    if (row.lastCookedAt !== null) map.set(row.recipeId, row.lastCookedAt);
+  }
+  return map;
+}
+
+/** Load recipe_tags for a recipe set; used by the line walker for context-tag matching. */
+export function loadRecipeTagsMap(
+  db: FoodDb,
+  recipeIds: readonly number[]
+): Map<number, readonly string[]> {
+  if (recipeIds.length === 0) return new Map();
+  const rows = db
+    .select({ recipeId: recipeTags.recipeId, tag: recipeTags.tag })
+    .from(recipeTags)
+    .where(inArray(recipeTags.recipeId, recipeIds))
+    .all();
+  const map = new Map<number, string[]>();
+  for (const row of rows) {
+    const bucket = map.get(row.recipeId);
+    if (bucket === undefined) {
+      map.set(row.recipeId, [row.tag]);
+    } else {
+      bucket.push(row.tag);
+    }
+  }
+  return map;
+}

--- a/pillars/food/src/api/modules/solver/inputs.ts
+++ b/pillars/food/src/api/modules/solver/inputs.ts
@@ -1,0 +1,33 @@
+/**
+ * Zod input schema for `food.solver.canICook` — PRD-150.
+ *
+ * All filters are optional. The `recipeTypes` enum mirrors
+ * `recipes.recipe_type` so an invalid type fails fast at the boundary
+ * instead of producing an empty result set.
+ */
+
+import { z } from 'zod';
+
+const RecipeType = z.enum([
+  'plate',
+  'component',
+  'technique',
+  'sauce',
+  'dressing',
+  'drink',
+  'condiment',
+]);
+
+export const CanICookInputSchema = z.object({
+  excludeSubs: z.boolean().optional(),
+  recipeTypes: z.array(RecipeType).max(7).optional(),
+  tags: z.array(z.string().trim().min(1).max(64)).max(32).optional(),
+  maxMinutes: z
+    .number()
+    .int()
+    .positive()
+    .max(24 * 60)
+    .optional(),
+});
+
+export type CanICookInput = z.infer<typeof CanICookInputSchema>;

--- a/pillars/food/src/api/modules/solver/line-evaluator.ts
+++ b/pillars/food/src/api/modules/solver/line-evaluator.ts
@@ -1,0 +1,122 @@
+/**
+ * Per-line cookability evaluator — PRD-150.
+ *
+ * For each non-optional line, asks two questions in order:
+ *
+ *   1. Does the pantry (`batches` sum filtered to (variantId,
+ *      prepStateId) with `qty_remaining > 0 AND deleted_at IS NULL`)
+ *      cover the line's canonical qty? FIFO covers it; no sub needed.
+ *   2. Otherwise: walk the substitution candidates (recipe-scoped
+ *      override + global, context-tag filtered) and find the first
+ *      whose `to` side has a batch sum that, multiplied by the edge's
+ *      `ratio`, satisfies the line.
+ *
+ * The first qualifying candidate wins. The line is `uncovered` if
+ * neither FIFO nor any sub clears the threshold — that recipe is then
+ * dropped from the result.
+ */
+import {
+  buildInventoryKey,
+  resolveCandidatesForLine,
+  type BatchInventory,
+  type SubstitutionsIndex,
+} from '../substitutions/substitutions-resolve.js';
+import { describeCandidate, type NameLookup } from './name-lookup.js';
+
+import type { SolverLine } from './lines.js';
+import type { SolveSubBreakdown } from './types.js';
+
+export interface LineEvaluation {
+  cookable: boolean;
+  subsNeeded: number;
+  subs: SolveSubBreakdown[];
+}
+
+function lineFifoCoverage(line: SolverLine, inventory: BatchInventory): number {
+  if (line.variantId === null) return 0;
+  const key = buildInventoryKey(line.variantId, line.prepStateId);
+  const entry = inventory.byVariantPrep.get(key);
+  if (entry === undefined) return 0;
+  return entry.totalQty;
+}
+
+function inventoryForCandidate(
+  inventory: BatchInventory,
+  toVariantId: number | null,
+  prepStateId: number | null
+): number {
+  if (toVariantId === null) return 0;
+  // Candidate match retains the line's prep state — the substitution
+  // doesn't change how the ingredient is prepared, only what it is.
+  // If the user actually has the sub in a different prep state, the
+  // strict (variant, prepState) key would miss it — fall back to the
+  // null-prep slot so subs match across prep variations.
+  const exactKey = buildInventoryKey(toVariantId, prepStateId);
+  const exact = inventory.byVariantPrep.get(exactKey);
+  if (exact !== undefined) return exact.totalQty;
+  if (prepStateId === null) return 0;
+  const fallback = inventory.byVariantPrep.get(buildInventoryKey(toVariantId, null));
+  return fallback?.totalQty ?? 0;
+}
+
+export interface EvaluateLinesArgs {
+  lines: readonly SolverLine[];
+  recipeId: number;
+  recipeTags: readonly string[];
+  inventory: BatchInventory;
+  subIndex: SubstitutionsIndex;
+  names: NameLookup;
+}
+
+function tryEvaluateLine(
+  line: SolverLine,
+  needed: number,
+  args: EvaluateLinesArgs
+): SolveSubBreakdown | null {
+  const candidates = resolveCandidatesForLine(args.subIndex, {
+    recipeId: args.recipeId,
+    ingredientId: line.ingredientId,
+    variantId: line.variantId,
+    recipeTags: args.recipeTags,
+  });
+  for (const candidate of candidates) {
+    const available = inventoryForCandidate(
+      args.inventory,
+      candidate.toVariantId,
+      line.prepStateId
+    );
+    if (available * candidate.ratio >= needed) {
+      return {
+        lineIndex: line.position,
+        fromIngredientName: line.ingredientName,
+        fromVariantName: line.variantName,
+        candidateSubName: describeCandidate(
+          args.names,
+          candidate.toIngredientId,
+          candidate.toVariantId
+        ),
+        substitutionId: candidate.edgeId,
+      };
+    }
+  }
+  return null;
+}
+
+export function evaluateRecipeLines(args: EvaluateLinesArgs): LineEvaluation {
+  const subs: SolveSubBreakdown[] = [];
+  for (const line of args.lines) {
+    // Lines with an unresolved canonical qty (compile couldn't pin
+    // grams/ml/count) fail closed — we don't know how much is needed,
+    // so we can't declare the recipe cookable.
+    if (line.qty === null) return { cookable: false, subsNeeded: 0, subs: [] };
+    const needed = line.qty;
+    const fifoQty = lineFifoCoverage(line, args.inventory);
+    if (fifoQty >= needed) continue;
+    const breakdown = tryEvaluateLine(line, needed, args);
+    if (breakdown === null) {
+      return { cookable: false, subsNeeded: 0, subs: [] };
+    }
+    subs.push(breakdown);
+  }
+  return { cookable: true, subsNeeded: subs.length, subs };
+}

--- a/pillars/food/src/api/modules/solver/lines.ts
+++ b/pillars/food/src/api/modules/solver/lines.ts
@@ -1,0 +1,98 @@
+/**
+ * Load + group `recipe_lines` for the solver — PRD-150.
+ *
+ * The solver evaluates one recipe at a time but issues a single bulk
+ * query for every required line across the candidate set. Optional
+ * lines (`optional = 1`) are filtered HERE per PRD-150's contract:
+ * they never block cookability and never appear in the breakdown.
+ */
+import { and, asc, eq, inArray } from 'drizzle-orm';
+
+import { ingredientVariants, ingredients, recipeLines, type FoodDb } from '../../../db/index.js';
+
+export type CanonicalUnit = 'g' | 'ml' | 'count';
+
+export interface SolverLine {
+  recipeVersionId: number;
+  position: number;
+  ingredientId: number;
+  ingredientName: string;
+  variantId: number | null;
+  variantName: string | null;
+  prepStateId: number | null;
+  canonicalUnit: CanonicalUnit;
+  /**
+   * Resolved canonical-unit qty for the line. `null` means the compile
+   * stage couldn't resolve the canonical quantity (e.g. a missing
+   * conversion). The line-evaluator treats that as a fail-closed
+   * shortfall — a recipe with any unresolved line is never declared
+   * cookable, otherwise the solver would silently approve recipes
+   * with unknown demand.
+   */
+  qty: number | null;
+}
+
+function canonicalQty(
+  qtyG: number | null,
+  qtyMl: number | null,
+  qtyCount: number | null,
+  unit: CanonicalUnit
+): number | null {
+  switch (unit) {
+    case 'g':
+      return qtyG;
+    case 'ml':
+      return qtyMl;
+    case 'count':
+      return qtyCount;
+  }
+}
+
+export function loadRequiredLines(
+  db: FoodDb,
+  recipeVersionIds: readonly number[]
+): Map<number, readonly SolverLine[]> {
+  if (recipeVersionIds.length === 0) return new Map();
+  const rows = db
+    .select({
+      recipeVersionId: recipeLines.recipeVersionId,
+      position: recipeLines.position,
+      ingredientId: recipeLines.ingredientId,
+      ingredientName: ingredients.name,
+      variantId: recipeLines.variantId,
+      variantName: ingredientVariants.name,
+      prepStateId: recipeLines.prepStateId,
+      canonicalUnit: recipeLines.canonicalUnit,
+      qtyG: recipeLines.qtyG,
+      qtyMl: recipeLines.qtyMl,
+      qtyCount: recipeLines.qtyCount,
+      optional: recipeLines.optional,
+    })
+    .from(recipeLines)
+    .innerJoin(ingredients, eq(ingredients.id, recipeLines.ingredientId))
+    .leftJoin(ingredientVariants, eq(ingredientVariants.id, recipeLines.variantId))
+    .where(and(inArray(recipeLines.recipeVersionId, recipeVersionIds), eq(recipeLines.optional, 0)))
+    .orderBy(asc(recipeLines.recipeVersionId), asc(recipeLines.position))
+    .all();
+  const map = new Map<number, SolverLine[]>();
+  for (const row of rows) {
+    const line: SolverLine = {
+      recipeVersionId: row.recipeVersionId,
+      position: row.position,
+      ingredientId: row.ingredientId,
+      ingredientName: row.ingredientName,
+      variantId: row.variantId,
+      variantName: row.variantName,
+      prepStateId: row.prepStateId,
+      canonicalUnit: row.canonicalUnit,
+      qty: canonicalQty(row.qtyG, row.qtyMl, row.qtyCount, row.canonicalUnit),
+    };
+    const bucket = map.get(line.recipeVersionId);
+    if (bucket === undefined) {
+      map.set(line.recipeVersionId, [line]);
+    } else {
+      bucket.push(line);
+    }
+  }
+  return map;
+}

--- a/pillars/food/src/api/modules/solver/name-lookup.ts
+++ b/pillars/food/src/api/modules/solver/name-lookup.ts
@@ -1,0 +1,78 @@
+/**
+ * Bulk-load ingredient + variant name dictionaries for the solver —
+ * PRD-150.
+ *
+ * Substitution candidates carry only (ingredientId, variantId) ids;
+ * the breakdown the UI renders needs human names. One name lookup at
+ * the start of the request beats N per-edge queries.
+ */
+import { ingredientVariants, ingredients, type FoodDb } from '../../../db/index.js';
+
+export interface NameLookup {
+  ingredientName(id: number): string;
+  variantName(id: number): string | null;
+  /** Parent ingredient ID for a variant ID, or null if unknown. */
+  variantIngredient(id: number): number | null;
+}
+
+interface NameMaps {
+  ingredients: ReadonlyMap<number, string>;
+  variants: ReadonlyMap<number, { name: string; ingredientId: number }>;
+}
+
+function loadNames(db: FoodDb): NameMaps {
+  const ingRows = db.select({ id: ingredients.id, name: ingredients.name }).from(ingredients).all();
+  const varRows = db
+    .select({
+      id: ingredientVariants.id,
+      name: ingredientVariants.name,
+      ingredientId: ingredientVariants.ingredientId,
+    })
+    .from(ingredientVariants)
+    .all();
+  const ingMap = new Map<number, string>();
+  for (const row of ingRows) ingMap.set(row.id, row.name);
+  const varMap = new Map<number, { name: string; ingredientId: number }>();
+  for (const row of varRows) varMap.set(row.id, { name: row.name, ingredientId: row.ingredientId });
+  return { ingredients: ingMap, variants: varMap };
+}
+
+export function buildNameLookup(db: FoodDb): NameLookup {
+  const maps = loadNames(db);
+  return {
+    ingredientName(id: number): string {
+      return maps.ingredients.get(id) ?? `#${id}`;
+    },
+    variantName(id: number): string | null {
+      return maps.variants.get(id)?.name ?? null;
+    },
+    variantIngredient(id: number): number | null {
+      return maps.variants.get(id)?.ingredientId ?? null;
+    },
+  };
+}
+
+/**
+ * Compose a human-readable label for a sub candidate target. When the
+ * edge only sets `to_variant_id`, the parent ingredient is looked up
+ * via the name dictionary so the label still leads with the ingredient
+ * name ("coconut-oil (refined)") instead of the bare variant slug
+ * ("refined") — that would be unreadable in the UI.
+ */
+export function describeCandidate(
+  names: NameLookup,
+  toIngredientId: number | null,
+  toVariantId: number | null
+): string {
+  if (toVariantId !== null) {
+    const varName = names.variantName(toVariantId);
+    const parent = toIngredientId ?? names.variantIngredient(toVariantId);
+    const parentName = parent !== null ? names.ingredientName(parent) : null;
+    if (varName !== null && parentName !== null) return `${parentName} (${varName})`;
+    if (parentName !== null) return parentName;
+    if (varName !== null) return varName;
+    return `variant#${toVariantId}`;
+  }
+  if (toIngredientId !== null) return names.ingredientName(toIngredientId);
+  return '—';
+}

--- a/pillars/food/src/api/modules/solver/types.ts
+++ b/pillars/food/src/api/modules/solver/types.ts
@@ -1,0 +1,53 @@
+/**
+ * Wire types for `food.solver.canICook` — PRD-150.
+ *
+ * Kept separate from the orchestrator so the tRPC router and the
+ * frontend can both depend on the types without pulling in service
+ * code. Mirrors the shapes defined in PRD-150's README.
+ */
+
+export type RecipeTypeLiteral =
+  | 'plate'
+  | 'component'
+  | 'technique'
+  | 'sauce'
+  | 'dressing'
+  | 'drink'
+  | 'condiment';
+
+export interface SolveSubBreakdown {
+  /** `recipe_lines.position` of the line resolved by this sub. */
+  lineIndex: number;
+  fromIngredientName: string;
+  fromVariantName: string | null;
+  candidateSubName: string;
+  /** `substitutions.id`. */
+  substitutionId: number;
+}
+
+export interface SolveRecipeRow {
+  recipeId: number;
+  recipeSlug: string;
+  title: string;
+  recipeType: RecipeTypeLiteral | null;
+  heroImagePath: string | null;
+  prepMinutes: number | null;
+  cookMinutes: number | null;
+  /** ISO datetime of the most recent completed `recipe_runs` row, or null. */
+  lastCookedAt: string | null;
+  /**
+   * Count of LINES resolved by a substitution. A single edge that
+   * resolves two lines counts as 2 (one per line).
+   */
+  subsNeeded: number;
+  subs: SolveSubBreakdown[];
+}
+
+export interface SolveResult {
+  /** Count of recipes considered after pre-filters (type/tags/maxMinutes). */
+  totalCandidates: number;
+  /** Count of recipes that turned out cookable; equals `recipes.length`. */
+  cookableCount: number;
+  /** Cookable recipes only; sorted by `subsNeeded ASC, lastCookedAt DESC NULLS LAST, slug ASC`. */
+  recipes: SolveRecipeRow[];
+}

--- a/pillars/food/src/api/modules/substitutions/graph-view.ts
+++ b/pillars/food/src/api/modules/substitutions/graph-view.ts
@@ -1,0 +1,75 @@
+/**
+ * Graph-view composition helpers for the substitutions router.
+ *
+ * Extracted from `substitutions.ts` so the router file fits under the
+ * per-file lint cap after PRD-149 added the `resolveForLine` procedure.
+ */
+import type { GraphViewEdgeRow, GraphViewSide } from '../../../db/index.js';
+
+export interface GraphViewNode {
+  id: string;
+  kind: 'ingredient' | 'variant';
+  ingredientId: number;
+  variantId: number | null;
+  ingredientSlug: string;
+  ingredientName: string;
+  variantSlug: string | null;
+  variantName: string | null;
+}
+
+export interface GraphViewEdge {
+  id: number;
+  fromNodeId: string;
+  toNodeId: string;
+  ratio: number;
+  contextTags: readonly string[];
+  scope: 'global' | 'recipe';
+  recipeId: number | null;
+  recipeSlug: string | null;
+  notes: string | null;
+}
+
+export interface GraphView {
+  nodes: GraphViewNode[];
+  edges: GraphViewEdge[];
+}
+
+/**
+ * Graph-view composite id. Encodes the side as `ingredient:<id>` or
+ * `variant:<id>` so the client can dedupe nodes across edges without
+ * doing any schema reasoning. Throws on a malformed side (`kind='variant'`
+ * without a `variantId`) rather than silently coercing to `variant:0`.
+ */
+export function sideToNodeId(side: GraphViewSide): string {
+  if (side.kind === 'variant') {
+    if (side.variantId === null) {
+      throw new Error(
+        `graphView: variant side missing variantId (CHECK drift on ingredient ${side.ingredientId})`
+      );
+    }
+    return `variant:${side.variantId}`;
+  }
+  return `ingredient:${side.ingredientId}`;
+}
+
+/** Compose the minimum spanning subgraph of nodes that any edge touches. */
+export function deriveNodes(edges: GraphViewEdgeRow[]): GraphViewNode[] {
+  const byId = new Map<string, GraphViewNode>();
+  for (const edge of edges) {
+    for (const side of [edge.fromSide, edge.toSide]) {
+      const id = sideToNodeId(side);
+      if (byId.has(id)) continue;
+      byId.set(id, {
+        id,
+        kind: side.kind,
+        ingredientId: side.ingredientId,
+        variantId: side.variantId,
+        ingredientSlug: side.ingredientSlug,
+        ingredientName: side.ingredientName,
+        variantSlug: side.variantSlug,
+        variantName: side.variantName,
+      });
+    }
+  }
+  return [...byId.values()];
+}

--- a/pillars/food/src/api/modules/substitutions/substitutions-resolve-line-loaders.ts
+++ b/pillars/food/src/api/modules/substitutions/substitutions-resolve-line-loaders.ts
@@ -1,0 +1,204 @@
+/**
+ * SQL loaders for `substitutions-resolve-line` — PRD-149.
+ *
+ * Split out so the public service module + the hydration helper stay
+ * under the 200-line per-file lint cap.
+ */
+import { and, eq, gt, inArray, isNull } from 'drizzle-orm';
+
+import {
+  batches,
+  ingredients,
+  ingredientVariants,
+  prepStates,
+  recipeLines,
+  recipeTags,
+  recipeVersions,
+} from '../../../db/index.js';
+
+import type { FoodDb } from '../../../db/index.js';
+import type { SubResolveLocation, SubResolveUnit } from './substitutions-resolve-line-types.js';
+
+export interface LineRow {
+  recipeId: number;
+  ingredientId: number;
+  variantId: number;
+  variantName: string;
+  prepStateId: number | null;
+  prepStateLabel: string | null;
+  qty: number;
+  unit: SubResolveUnit;
+}
+
+export function loadLine(
+  db: FoodDb,
+  args: { recipeVersionId: number; lineIndex: number }
+): LineRow | null {
+  const row = db
+    .select({
+      recipeId: recipeVersions.recipeId,
+      ingredientId: recipeLines.ingredientId,
+      variantId: recipeLines.variantId,
+      variantName: ingredientVariants.name,
+      prepStateId: recipeLines.prepStateId,
+      prepStateLabel: prepStates.name,
+      qtyG: recipeLines.qtyG,
+      qtyMl: recipeLines.qtyMl,
+      qtyCount: recipeLines.qtyCount,
+      canonicalUnit: recipeLines.canonicalUnit,
+    })
+    .from(recipeLines)
+    .innerJoin(recipeVersions, eq(recipeVersions.id, recipeLines.recipeVersionId))
+    .leftJoin(ingredientVariants, eq(ingredientVariants.id, recipeLines.variantId))
+    .leftJoin(prepStates, eq(prepStates.id, recipeLines.prepStateId))
+    .where(
+      and(
+        eq(recipeLines.recipeVersionId, args.recipeVersionId),
+        eq(recipeLines.position, args.lineIndex)
+      )
+    )
+    .all()[0];
+  if (row === undefined) return null;
+  if (row.variantId === null) return null;
+  const qty = canonicalQty(row);
+  if (qty === null) return null;
+  return {
+    recipeId: row.recipeId,
+    ingredientId: row.ingredientId,
+    variantId: row.variantId,
+    variantName: row.variantName ?? '',
+    prepStateId: row.prepStateId ?? null,
+    prepStateLabel: row.prepStateLabel ?? null,
+    qty,
+    unit: row.canonicalUnit,
+  };
+}
+
+function canonicalQty(row: {
+  qtyG: number | null;
+  qtyMl: number | null;
+  qtyCount: number | null;
+  canonicalUnit: 'g' | 'ml' | 'count';
+}): number | null {
+  if (row.canonicalUnit === 'g') return row.qtyG;
+  if (row.canonicalUnit === 'ml') return row.qtyMl;
+  return row.qtyCount;
+}
+
+export function loadRecipeTags(db: FoodDb, recipeId: number): readonly string[] {
+  const rows = db
+    .select({ tag: recipeTags.tag })
+    .from(recipeTags)
+    .where(eq(recipeTags.recipeId, recipeId))
+    .all();
+  return rows.map((r) => r.tag);
+}
+
+export interface VariantNameRow {
+  id: number;
+  name: string;
+  ingredientId: number;
+  ingredientName: string;
+}
+
+export function loadVariantNames(
+  db: FoodDb,
+  variantIds: readonly number[]
+): Map<number, VariantNameRow> {
+  const map = new Map<number, VariantNameRow>();
+  if (variantIds.length === 0) return map;
+  const rows = db
+    .select({
+      id: ingredientVariants.id,
+      name: ingredientVariants.name,
+      ingredientId: ingredientVariants.ingredientId,
+      ingredientName: ingredients.name,
+    })
+    .from(ingredientVariants)
+    .innerJoin(ingredients, eq(ingredients.id, ingredientVariants.ingredientId))
+    .where(inArray(ingredientVariants.id, [...variantIds]))
+    .all();
+  for (const r of rows) map.set(r.id, r);
+  return map;
+}
+
+export function loadVariantsByIngredient(
+  db: FoodDb,
+  ingredientIds: readonly number[]
+): Map<number, number[]> {
+  const map = new Map<number, number[]>();
+  if (ingredientIds.length === 0) return map;
+  const rows = db
+    .select({ id: ingredientVariants.id, ingredientId: ingredientVariants.ingredientId })
+    .from(ingredientVariants)
+    .where(inArray(ingredientVariants.ingredientId, [...ingredientIds]))
+    .all();
+  for (const r of rows) {
+    const bucket = map.get(r.ingredientId);
+    if (bucket === undefined) map.set(r.ingredientId, [r.id]);
+    else bucket.push(r.id);
+  }
+  return map;
+}
+
+export interface BatchRow {
+  id: number;
+  variantId: number;
+  qtyRemaining: number;
+  unit: SubResolveUnit;
+  location: SubResolveLocation;
+  expiresAt: string | null;
+  prepStateId: number | null;
+  prepStateLabel: string | null;
+  producedAt: string;
+}
+
+export function loadCandidateBatches(
+  db: FoodDb,
+  variantIds: readonly number[]
+): Map<number, BatchRow[]> {
+  const map = new Map<number, BatchRow[]>();
+  if (variantIds.length === 0) return map;
+  const rows = db
+    .select({
+      id: batches.id,
+      variantId: batches.variantId,
+      qtyRemaining: batches.qtyRemaining,
+      unit: batches.unit,
+      location: batches.location,
+      expiresAt: batches.expiresAt,
+      prepStateId: batches.prepStateId,
+      prepStateLabel: prepStates.name,
+      producedAt: batches.producedAt,
+    })
+    .from(batches)
+    .leftJoin(prepStates, eq(prepStates.id, batches.prepStateId))
+    .where(
+      and(
+        inArray(batches.variantId, [...variantIds]),
+        gt(batches.qtyRemaining, 0),
+        isNull(batches.deletedAt)
+      )
+    )
+    .all();
+  const enriched = rows.map((r) => ({ ...r, prepStateLabel: r.prepStateLabel ?? null }));
+  enriched.sort(compareFifo);
+  for (const row of enriched) {
+    const bucket = map.get(row.variantId);
+    if (bucket === undefined) map.set(row.variantId, [row]);
+    else bucket.push(row);
+  }
+  return map;
+}
+
+function compareFifo(a: BatchRow, b: BatchRow): number {
+  const aExp = a.expiresAt;
+  const bExp = b.expiresAt;
+  if (aExp === null && bExp !== null) return 1;
+  if (aExp !== null && bExp === null) return -1;
+  if (aExp !== null && bExp !== null) {
+    const cmp = aExp.localeCompare(bExp);
+    if (cmp !== 0) return cmp;
+  }
+  return a.producedAt.localeCompare(b.producedAt);
+}

--- a/pillars/food/src/api/modules/substitutions/substitutions-resolve-line-types.ts
+++ b/pillars/food/src/api/modules/substitutions/substitutions-resolve-line-types.ts
@@ -1,0 +1,57 @@
+/**
+ * PRD-149 — wire types for `food.substitutions.resolveForLine`.
+ *
+ * Owned by Epic 06; consumed by the tRPC router + the cook-modal picker
+ * via `inferRouterOutputs`. Kept in its own file so the service module
+ * and its sibling loaders both import without a cyclic edge.
+ */
+export type SubResolveUnit = 'g' | 'ml' | 'count';
+export type SubResolveLocation = 'pantry' | 'fridge' | 'freezer' | 'other';
+export type SubResolveScope = 'global' | 'recipe';
+
+export interface SubCandidateBatch {
+  batchId: number;
+  qtyRemaining: number;
+  unit: SubResolveUnit;
+  location: SubResolveLocation;
+  expiresAt: string | null;
+  prepStateId: number | null;
+  prepStateLabel: string | null;
+}
+
+export interface SubCandidate {
+  substitutionId: number;
+  ratio: number;
+  contextTags: readonly string[];
+  scope: SubResolveScope;
+  recipeId: number | null;
+  substituteVariantId: number;
+  substituteVariantName: string;
+  substituteIngredientId: number;
+  substituteIngredientName: string;
+  notes: string | null;
+  batches: readonly SubCandidateBatch[];
+}
+
+export interface SubResolution {
+  lineIndex: number;
+  lineVariantId: number;
+  lineVariantName: string;
+  linePrepStateId: number | null;
+  linePrepStateLabel: string | null;
+  lineQty: number;
+  lineUnit: SubResolveUnit;
+  recipeContextTags: readonly string[];
+  candidates: readonly SubCandidate[];
+}
+
+export type ResolveForLineError = 'LineNotFound';
+
+export type ResolveForLineResult =
+  | { ok: true; resolution: SubResolution }
+  | { ok: false; reason: ResolveForLineError };
+
+export interface ResolveForLineArgs {
+  recipeVersionId: number;
+  lineIndex: number;
+}

--- a/pillars/food/src/api/modules/substitutions/substitutions-resolve-line.ts
+++ b/pillars/food/src/api/modules/substitutions/substitutions-resolve-line.ts
@@ -1,0 +1,162 @@
+import {
+  loadCandidateBatches,
+  loadLine,
+  loadRecipeTags,
+  loadVariantNames,
+  loadVariantsByIngredient,
+  type BatchRow,
+  type VariantNameRow,
+} from './substitutions-resolve-line-loaders.js';
+/**
+ * PRD-149 — per-line substitution resolution for the cook-modal picker.
+ *
+ * Wraps PRD-150's shared `substitutions-resolve` service (the owner of
+ * the override + context-tag filtering pure functions) and hydrates
+ * each surviving candidate with the batch inventory + display names the
+ * `BatchOverridePicker` Substitutions section needs.
+ *
+ * Flow:
+ *   1. Load the recipe_line row for `(recipeVersionId, lineIndex)`.
+ *   2. Load the recipe's tags (PRD-109's `:C` parameter).
+ *   3. Bulk-load the substitutions index scoped to global + this recipe.
+ *   4. Apply `resolveCandidatesForLine` (PRD-150's `(from, to)`-pair
+ *      override + OR-overlap context filter).
+ *   5. For each candidate: collect target variants (ingredient-level
+ *      edges fan out), load batches per variant, hydrate names.
+ *
+ * Ranking + the 5-item display cap live in the picker UI; this service
+ * returns the full candidate set in PRD-150's resolution order so the
+ * frontend tests can pin the sort independent of the DB layer.
+ */
+import {
+  loadSubstitutionsIndex,
+  resolveCandidatesForLine,
+  type SubstitutionCandidate,
+} from './substitutions-resolve.js';
+
+import type { FoodDb } from '../../../db/index.js';
+import type {
+  ResolveForLineArgs,
+  ResolveForLineResult,
+  SubCandidate,
+} from './substitutions-resolve-line-types.js';
+
+export type * from './substitutions-resolve-line-types.js';
+
+export function resolveForLine(db: FoodDb, args: ResolveForLineArgs): ResolveForLineResult {
+  const line = loadLine(db, args);
+  if (line === null) return { ok: false, reason: 'LineNotFound' };
+
+  const recipeContextTags = loadRecipeTags(db, line.recipeId);
+  const subIndex = loadSubstitutionsIndex(db, [line.recipeId]);
+  const candidates = resolveCandidatesForLine(subIndex, {
+    recipeId: line.recipeId,
+    ingredientId: line.ingredientId,
+    variantId: line.variantId,
+    recipeTags: recipeContextTags,
+  });
+  const enriched = hydrateCandidates(db, candidates);
+
+  return {
+    ok: true,
+    resolution: {
+      lineIndex: args.lineIndex,
+      lineVariantId: line.variantId,
+      lineVariantName: line.variantName,
+      linePrepStateId: line.prepStateId,
+      linePrepStateLabel: line.prepStateLabel,
+      lineQty: line.qty,
+      lineUnit: line.unit,
+      recipeContextTags,
+      candidates: enriched,
+    },
+  };
+}
+
+function hydrateCandidates(
+  db: FoodDb,
+  candidates: readonly SubstitutionCandidate[]
+): readonly SubCandidate[] {
+  if (candidates.length === 0) return [];
+  const ingredientLevelIds = uniqueIngredientIds(candidates);
+  const ingredientToVariants = loadVariantsByIngredient(db, ingredientLevelIds);
+  const variantIds = collectVariantIds(candidates, ingredientToVariants);
+  if (variantIds.length === 0) {
+    return candidates.map((c) => buildCandidate(c, null, [], ingredientToVariants));
+  }
+  const variantRows = loadVariantNames(db, variantIds);
+  const batchesByVariant = loadCandidateBatches(db, variantIds);
+  return candidates.flatMap((candidate) => {
+    const targetVariantIds = expandVariants(candidate, ingredientToVariants);
+    if (targetVariantIds.length === 0) return [];
+    return targetVariantIds.flatMap((variantId) => {
+      const variant = variantRows.get(variantId);
+      if (variant === undefined) return [];
+      return [
+        buildCandidate(
+          candidate,
+          variant,
+          batchesByVariant.get(variantId) ?? [],
+          ingredientToVariants
+        ),
+      ];
+    });
+  });
+}
+
+function uniqueIngredientIds(candidates: readonly SubstitutionCandidate[]): number[] {
+  const set = new Set<number>();
+  for (const c of candidates) {
+    if (c.toVariantId === null && c.toIngredientId !== null) set.add(c.toIngredientId);
+  }
+  return [...set];
+}
+
+function collectVariantIds(
+  candidates: readonly SubstitutionCandidate[],
+  ingredientToVariants: ReadonlyMap<number, readonly number[]>
+): number[] {
+  const set = new Set<number>();
+  for (const c of candidates) {
+    for (const v of expandVariants(c, ingredientToVariants)) set.add(v);
+  }
+  return [...set];
+}
+
+function expandVariants(
+  candidate: SubstitutionCandidate,
+  ingredientToVariants: ReadonlyMap<number, readonly number[]>
+): readonly number[] {
+  if (candidate.toVariantId !== null) return [candidate.toVariantId];
+  if (candidate.toIngredientId === null) return [];
+  return ingredientToVariants.get(candidate.toIngredientId) ?? [];
+}
+
+function buildCandidate(
+  candidate: SubstitutionCandidate,
+  variant: VariantNameRow | null,
+  batchRows: readonly BatchRow[],
+  _ingredientToVariants: ReadonlyMap<number, readonly number[]>
+): SubCandidate {
+  return {
+    substitutionId: candidate.edgeId,
+    ratio: candidate.ratio,
+    contextTags: candidate.contextTags,
+    scope: candidate.scope,
+    recipeId: candidate.recipeId,
+    substituteVariantId: variant?.id ?? 0,
+    substituteVariantName: variant?.name ?? '',
+    substituteIngredientId: variant?.ingredientId ?? candidate.toIngredientId ?? 0,
+    substituteIngredientName: variant?.ingredientName ?? '',
+    notes: candidate.notes,
+    batches: batchRows.map((row) => ({
+      batchId: row.id,
+      qtyRemaining: row.qtyRemaining,
+      unit: row.unit,
+      location: row.location,
+      expiresAt: row.expiresAt,
+      prepStateId: row.prepStateId,
+      prepStateLabel: row.prepStateLabel,
+    })),
+  };
+}

--- a/pillars/food/src/api/modules/substitutions/substitutions-resolve-loaders.ts
+++ b/pillars/food/src/api/modules/substitutions/substitutions-resolve-loaders.ts
@@ -1,0 +1,149 @@
+/**
+ * SQL loaders for `substitutions-resolve` — PRD-150.
+ *
+ * Split out of the public service file so the per-file lint cap stays
+ * under 200 lines while keeping the loader signatures discoverable.
+ */
+import { and, eq, inArray, isNull, or, sql, type SQL } from 'drizzle-orm';
+
+import { batches, substitutions, type FoodDb } from '../../../db/index.js';
+
+import type {
+  BatchInventory,
+  BatchInventoryEntry,
+  SubstitutionEdge,
+  SubstitutionScope,
+  SubstitutionsIndex,
+} from './substitutions-resolve-types.js';
+
+function inventoryKey(variantId: number, prepStateId: number | null): string {
+  return prepStateId === null ? `${variantId}|*` : `${variantId}|${prepStateId}`;
+}
+
+export function buildInventoryKey(variantId: number, prepStateId: number | null): string {
+  return inventoryKey(variantId, prepStateId);
+}
+
+export function loadBatchInventory(db: FoodDb): BatchInventory {
+  const rows = db
+    .select({
+      variantId: batches.variantId,
+      prepStateId: batches.prepStateId,
+      qtyRemaining: batches.qtyRemaining,
+      unit: batches.unit,
+    })
+    .from(batches)
+    .where(and(sql`${batches.qtyRemaining} > 0`, isNull(batches.deletedAt)))
+    .all();
+  const map = new Map<string, BatchInventoryEntry>();
+  for (const row of rows) {
+    const key = inventoryKey(row.variantId, row.prepStateId);
+    const existing = map.get(key);
+    if (existing === undefined) {
+      map.set(key, { totalQty: row.qtyRemaining, unit: row.unit });
+    } else {
+      existing.totalQty += row.qtyRemaining;
+    }
+  }
+  return { byVariantPrep: map };
+}
+
+export function parseContextTags(raw: string): readonly string[] {
+  // Malformed JSON in a single `substitutions.context_tags` row must
+  // not crash the whole solver — treat unparseable / non-array rows as
+  // a wildcard (`[]`) so they apply universally rather than dropping
+  // out of the index altogether.
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(parsed)) return [];
+  const out: string[] = [];
+  for (const value of parsed) {
+    if (typeof value === 'string') out.push(value);
+  }
+  return out;
+}
+
+interface SubstitutionRow {
+  id: number;
+  fromIngredientId: number | null;
+  fromVariantId: number | null;
+  toIngredientId: number | null;
+  toVariantId: number | null;
+  ratio: number;
+  contextTags: string;
+  scope: SubstitutionScope;
+  recipeId: number | null;
+  notes: string | null;
+}
+
+function rowToEdge(row: SubstitutionRow): SubstitutionEdge {
+  return {
+    id: row.id,
+    fromIngredientId: row.fromIngredientId,
+    fromVariantId: row.fromVariantId,
+    toIngredientId: row.toIngredientId,
+    toVariantId: row.toVariantId,
+    ratio: row.ratio,
+    contextTags: parseContextTags(row.contextTags),
+    scope: row.scope,
+    recipeId: row.recipeId,
+    notes: row.notes,
+  };
+}
+
+function buildScopeFilter(recipeIds: readonly number[] | undefined): SQL {
+  if (recipeIds === undefined) {
+    // No caller-supplied recipe set — load every edge in the table.
+    return sql`1 = 1`;
+  }
+  const global = eq(substitutions.scope, 'global');
+  if (recipeIds.length === 0) return global;
+  const scoped = and(eq(substitutions.scope, 'recipe'), inArray(substitutions.recipeId, recipeIds));
+  const expr = or(global, scoped);
+  if (expr === undefined) throw new Error('substitutions scope filter assembly failed');
+  return expr;
+}
+
+function bucketEdges(rows: readonly SubstitutionRow[]): SubstitutionsIndex {
+  const global: SubstitutionEdge[] = [];
+  const byRecipe = new Map<number, SubstitutionEdge[]>();
+  for (const row of rows) {
+    const edge = rowToEdge(row);
+    if (edge.scope === 'global') {
+      global.push(edge);
+      continue;
+    }
+    if (edge.recipeId === null) continue;
+    const bucket = byRecipe.get(edge.recipeId);
+    if (bucket === undefined) byRecipe.set(edge.recipeId, [edge]);
+    else bucket.push(edge);
+  }
+  return { global, byRecipe };
+}
+
+export function loadSubstitutionsIndex(
+  db: FoodDb,
+  recipeIds?: readonly number[]
+): SubstitutionsIndex {
+  const rows = db
+    .select({
+      id: substitutions.id,
+      fromIngredientId: substitutions.fromIngredientId,
+      fromVariantId: substitutions.fromVariantId,
+      toIngredientId: substitutions.toIngredientId,
+      toVariantId: substitutions.toVariantId,
+      ratio: substitutions.ratio,
+      contextTags: substitutions.contextTags,
+      scope: substitutions.scope,
+      recipeId: substitutions.recipeId,
+      notes: substitutions.notes,
+    })
+    .from(substitutions)
+    .where(buildScopeFilter(recipeIds))
+    .all();
+  return bucketEdges(rows);
+}

--- a/pillars/food/src/api/modules/substitutions/substitutions-resolve-types.ts
+++ b/pillars/food/src/api/modules/substitutions/substitutions-resolve-types.ts
@@ -1,0 +1,62 @@
+/**
+ * Shared types for `substitutions-resolve` — PRD-150.
+ *
+ * Split out so the public service file and its SQL-loader sibling can
+ * both import without a circular reference.
+ */
+export type SubstitutionScope = 'global' | 'recipe';
+
+/** Bucket of pantry batches for one `(variantId, prepStateId|null)` key. */
+export interface BatchInventoryEntry {
+  /** Sum of `qty_remaining` across every non-deleted, non-empty batch. */
+  totalQty: number;
+  unit: 'g' | 'ml' | 'count';
+}
+
+/** Snapshot of every active batch indexed by `(variantId, prepStateId|null)`. */
+export interface BatchInventory {
+  byVariantPrep: ReadonlyMap<string, BatchInventoryEntry>;
+}
+
+export interface SubstitutionEdge {
+  id: number;
+  fromIngredientId: number | null;
+  fromVariantId: number | null;
+  toIngredientId: number | null;
+  toVariantId: number | null;
+  ratio: number;
+  contextTags: readonly string[];
+  scope: SubstitutionScope;
+  recipeId: number | null;
+  /** PRD-149 — edge notes rendered in the picker row tooltip. */
+  notes: string | null;
+}
+
+/** Bulk-loaded edge index — global + per-recipe scoped. */
+export interface SubstitutionsIndex {
+  global: readonly SubstitutionEdge[];
+  byRecipe: ReadonlyMap<number, readonly SubstitutionEdge[]>;
+}
+
+/** Inputs to the per-line resolver. */
+export interface LineCtx {
+  recipeId: number;
+  ingredientId: number;
+  variantId: number | null;
+  recipeTags: readonly string[];
+}
+
+/** One candidate edge after override + context-tag filtering. */
+export interface SubstitutionCandidate {
+  edgeId: number;
+  ratio: number;
+  toIngredientId: number | null;
+  toVariantId: number | null;
+  scope: SubstitutionScope;
+  /** PRD-149 — surfaced so the cook picker can render the edge's tags inline. */
+  contextTags: readonly string[];
+  /** PRD-149 — null for global-scoped edges, the owning recipe for recipe-scoped. */
+  recipeId: number | null;
+  /** PRD-149 — edge notes rendered in the picker row tooltip. */
+  notes: string | null;
+}

--- a/pillars/food/src/api/modules/substitutions/substitutions-resolve.ts
+++ b/pillars/food/src/api/modules/substitutions/substitutions-resolve.ts
@@ -1,0 +1,124 @@
+/**
+ * Shared per-line substitution resolver — PRD-150.
+ *
+ * Canonical home for the substitution-resolution logic that PRD-150's
+ * solver and PRD-149's cook-time picker both consume. Reads PRD-109's
+ * `substitutions` table with the override semantics carried forward
+ * from PRD-149:
+ *
+ *   - A line is identified by its `(ingredientId, variantId,
+ *     prepStateId)` triple. Subs match when their `from` side equals
+ *     the line's ingredient OR variant side (ingredient match implies
+ *     "applies to any variant of this ingredient"; variant-side match
+ *     pins to that variant).
+ *   - `scope = 'recipe'` rows override `scope = 'global'` rows for the
+ *     same `(from, to)` pair within that recipe. Other global edges
+ *     out of the same `from` are unaffected.
+ *   - Context tags follow PRD-109's OR-overlap rule: an empty
+ *     `context_tags` array is a wildcard; otherwise the sub matches
+ *     iff at least one of its tags overlaps the recipe's `recipe_tags`.
+ *
+ * The public surface is split into three layers:
+ *
+ *   - `loadSubstitutionsIndex(db, recipeIds?)` — one-shot bulk load
+ *     scoped via SQL to global edges + recipe-scoped edges for the
+ *     given recipe IDs (omit = every edge in the table).
+ *   - `resolveCandidatesForLine(index, ctx)` — pure function that
+ *     filters the prebuilt index for one line context.
+ *   - `loadBatchInventory(db)` — bulk pantry snapshot keyed by
+ *     `(variantId, prepStateId|null)`.
+ *
+ * SQL + type plumbing lives in sibling files (`-loaders.ts`,
+ * `-types.ts`) so each file stays under the per-file lint cap.
+ */
+export {
+  buildInventoryKey,
+  loadBatchInventory,
+  loadSubstitutionsIndex,
+  parseContextTags,
+} from './substitutions-resolve-loaders.js';
+export type {
+  BatchInventory,
+  BatchInventoryEntry,
+  LineCtx,
+  SubstitutionCandidate,
+  SubstitutionEdge,
+  SubstitutionScope,
+  SubstitutionsIndex,
+} from './substitutions-resolve-types.js';
+
+import type {
+  LineCtx,
+  SubstitutionCandidate,
+  SubstitutionEdge,
+  SubstitutionsIndex,
+} from './substitutions-resolve-types.js';
+
+function edgeMatchesFromSide(edge: SubstitutionEdge, ctx: LineCtx): boolean {
+  if (edge.fromVariantId !== null) {
+    return ctx.variantId !== null && edge.fromVariantId === ctx.variantId;
+  }
+  if (edge.fromIngredientId !== null) {
+    return edge.fromIngredientId === ctx.ingredientId;
+  }
+  return false;
+}
+
+function contextTagsMatch(edgeTags: readonly string[], recipeTags: readonly string[]): boolean {
+  if (edgeTags.length === 0) return true;
+  if (recipeTags.length === 0) return false;
+  const set = new Set(recipeTags);
+  for (const tag of edgeTags) {
+    if (set.has(tag)) return true;
+  }
+  return false;
+}
+
+function toPairKey(edge: SubstitutionEdge): string {
+  const from =
+    edge.fromVariantId !== null ? `v${edge.fromVariantId}` : `i${edge.fromIngredientId ?? 0}`;
+  const to = edge.toVariantId !== null ? `v${edge.toVariantId}` : `i${edge.toIngredientId ?? 0}`;
+  return `${from}->${to}`;
+}
+
+function toCandidate(edge: SubstitutionEdge): SubstitutionCandidate {
+  return {
+    edgeId: edge.id,
+    ratio: edge.ratio,
+    toIngredientId: edge.toIngredientId,
+    toVariantId: edge.toVariantId,
+    scope: edge.scope,
+    contextTags: edge.contextTags,
+    recipeId: edge.recipeId,
+    notes: edge.notes,
+  };
+}
+
+/**
+ * Apply PRD-109's `(from, to)`-pair override semantics + context-tag
+ * filter to a line's candidate set. Recipe-scoped edges supersede the
+ * global edge with the same pair key; other global edges from the
+ * same `from` survive unchanged.
+ */
+export function resolveCandidatesForLine(
+  index: SubstitutionsIndex,
+  ctx: LineCtx
+): SubstitutionCandidate[] {
+  const recipeBucket = index.byRecipe.get(ctx.recipeId) ?? [];
+  const recipeMatches: SubstitutionEdge[] = [];
+  const overriddenPairs = new Set<string>();
+  for (const edge of recipeBucket) {
+    if (!edgeMatchesFromSide(edge, ctx)) continue;
+    if (!contextTagsMatch(edge.contextTags, ctx.recipeTags)) continue;
+    recipeMatches.push(edge);
+    overriddenPairs.add(toPairKey(edge));
+  }
+  const globalMatches: SubstitutionEdge[] = [];
+  for (const edge of index.global) {
+    if (!edgeMatchesFromSide(edge, ctx)) continue;
+    if (overriddenPairs.has(toPairKey(edge))) continue;
+    if (!contextTagsMatch(edge.contextTags, ctx.recipeTags)) continue;
+    globalMatches.push(edge);
+  }
+  return [...recipeMatches, ...globalMatches].map(toCandidate);
+}

--- a/pillars/food/src/api/rest/handlers.ts
+++ b/pillars/food/src/api/rest/handlers.ts
@@ -15,6 +15,8 @@ import { makeIngredientTagsHandlers } from './ingredient-tags-handlers.js';
 import { makeIngredientsHandlers } from './ingredients-handlers.js';
 import { makePrepStatesHandlers } from './prep-states-handlers.js';
 import { makeSlugsHandlers } from './slugs-handlers.js';
+import { makeSolverHandlers } from './solver-handlers.js';
+import { makeSubstitutionsHandlers } from './substitutions-handlers.js';
 import { makeVariantsHandlers } from './variants-handlers.js';
 
 const server: ReturnType<typeof initServer> = initServer();
@@ -30,6 +32,8 @@ export function makeFoodRestHandlers(deps: {
     ingredientTags: makeIngredientTagsHandlers(db),
     prepStates: makePrepStatesHandlers(db),
     slugs: makeSlugsHandlers(db),
+    solver: makeSolverHandlers(db),
+    substitutions: makeSubstitutionsHandlers(db),
     variants: makeVariantsHandlers(db),
   });
 }

--- a/pillars/food/src/api/rest/solver-handlers.ts
+++ b/pillars/food/src/api/rest/solver-handlers.ts
@@ -1,0 +1,21 @@
+/**
+ * Handler for the `solver.*` sub-router. Delegates to the moved
+ * `canICook` orchestrator; pure read, no error mapping beyond the shared
+ * `runHttp` passthrough (assembly-level failures propagate as 500).
+ */
+import { canICook } from '../modules/solver/can-i-cook.js';
+import { runHttp } from './error-mapping.js';
+
+import type { ServerInferRequest } from '@ts-rest/core';
+
+import type { foodSolverContract } from '../../contract/rest-solver.js';
+import type { FoodDb } from '../../db/index.js';
+
+type Req = ServerInferRequest<typeof foodSolverContract>;
+
+export function makeSolverHandlers(db: FoodDb) {
+  return {
+    canICook: ({ body }: Req['canICook']) =>
+      runHttp(() => ({ status: 200 as const, body: canICook(db, body) })),
+  };
+}

--- a/pillars/food/src/api/rest/substitutions-handlers.ts
+++ b/pillars/food/src/api/rest/substitutions-handlers.ts
@@ -1,0 +1,94 @@
+/**
+ * Handlers for the `substitutions.*` sub-router.
+ *
+ * `CannotSubstituteSelf` (self-referential edge) → 400. `resolveForLine`
+ * returns `{ ok:false, reason:'LineNotFound' }` from the service → 404. The
+ * graph-view handler maps the service's edge rows to node ids via the
+ * moved `graph-view` helpers.
+ */
+import {
+  CannotSubstituteSelf,
+  substitutionsGraph,
+  substitutionsHydrate,
+  substitutionsQueries,
+  substitutionsService,
+} from '../../db/index.js';
+import { deriveNodes, sideToNodeId } from '../modules/substitutions/graph-view.js';
+import { resolveForLine } from '../modules/substitutions/substitutions-resolve-line.js';
+import { HttpError, NotFoundError } from '../shared/errors.js';
+import { runHttp } from './error-mapping.js';
+
+import type { ServerInferRequest } from '@ts-rest/core';
+
+import type { foodSubstitutionsContract } from '../../contract/rest-substitutions.js';
+import type { FoodDb } from '../../db/index.js';
+import type { GraphViewEdge } from '../modules/substitutions/graph-view.js';
+
+type Req = ServerInferRequest<typeof foodSubstitutionsContract>;
+
+export function makeSubstitutionsHandlers(db: FoodDb) {
+  return {
+    list: ({ query }: Req['list']) =>
+      runHttp(() => ({
+        status: 200 as const,
+        body: { items: substitutionsQueries.listSubstitutions(db, query) },
+      })),
+
+    listHydrated: ({ query }: Req['listHydrated']) =>
+      runHttp(() => ({
+        status: 200 as const,
+        body: { items: substitutionsHydrate.listSubstitutionsHydrated(db, query) },
+      })),
+
+    graphView: ({ query }: Req['graphView']) =>
+      runHttp(() => {
+        const { edges: hydrated } = substitutionsGraph.loadGraphView(db, query);
+        const edges: GraphViewEdge[] = hydrated.map((edge) => ({
+          id: edge.id,
+          fromNodeId: sideToNodeId(edge.fromSide),
+          toNodeId: sideToNodeId(edge.toSide),
+          ratio: edge.ratio,
+          contextTags: edge.contextTags,
+          scope: edge.scope,
+          recipeId: edge.recipeId,
+          recipeSlug: edge.recipeSlug,
+          notes: edge.notes,
+        }));
+        return { status: 200 as const, body: { nodes: deriveNodes(hydrated), edges } };
+      }),
+
+    resolveForLine: ({ query }: Req['resolveForLine']) =>
+      runHttp(() => {
+        const result = resolveForLine(db, query);
+        if (!result.ok) throw new NotFoundError('Recipe line', String(query.lineIndex));
+        return { status: 200 as const, body: result.resolution };
+      }),
+
+    create: ({ body }: Req['create']) =>
+      runHttp(() => {
+        try {
+          return {
+            status: 201 as const,
+            body: { data: substitutionsService.createSubstitution(db, body) },
+          };
+        } catch (err) {
+          if (err instanceof CannotSubstituteSelf) {
+            throw new HttpError(400, err.message, undefined, 'common.validationFailed');
+          }
+          throw err;
+        }
+      }),
+
+    update: ({ params, body }: Req['update']) =>
+      runHttp(() => ({
+        status: 200 as const,
+        body: { data: substitutionsQueries.updateSubstitution(db, params.id, body) },
+      })),
+
+    delete: ({ params }: Req['delete']) =>
+      runHttp(() => {
+        substitutionsService.deleteSubstitution(db, params.id);
+        return { status: 200 as const, body: { ok: true as const } };
+      }),
+  };
+}

--- a/pillars/food/src/contract/api-types.generated.ts
+++ b/pillars/food/src/contract/api-types.generated.ts
@@ -403,6 +403,110 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/solver/can-i-cook': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Rank cookable recipes by substitution count given current inventory */
+    post: operations['solver.canICook'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/substitutions': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** List substitutions (raw FK ids) */
+    get: operations['substitutions.list'];
+    put?: never;
+    /** Create a substitution edge */
+    post: operations['substitutions.create'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/substitutions/graph-view': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Node/edge projection of the substitution graph */
+    get: operations['substitutions.graphView'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/substitutions/hydrated': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** List substitutions widened with slug + display name per endpoint */
+    get: operations['substitutions.listHydrated'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/substitutions/resolve-line': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Per-line substitution candidates with batch coverage */
+    get: operations['substitutions.resolveForLine'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/substitutions/{id}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post?: never;
+    /** Delete a substitution edge */
+    delete: operations['substitutions.delete'];
+    options?: never;
+    head?: never;
+    /** Update a substitution edge */
+    patch: operations['substitutions.update'];
+    trace?: never;
+  };
   '/variants': {
     parameters: {
       query?: never;
@@ -2276,6 +2380,609 @@ export interface operations {
               slug: string;
               targetId: number;
             }[];
+          };
+        };
+      };
+    };
+  };
+  'solver.canICook': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          excludeSubs?: boolean;
+          maxMinutes?: number;
+          recipeTypes?: (
+            | 'plate'
+            | 'component'
+            | 'technique'
+            | 'sauce'
+            | 'dressing'
+            | 'drink'
+            | 'condiment'
+          )[];
+          tags?: string[];
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            cookableCount: number;
+            recipes: {
+              cookMinutes: number | null;
+              heroImagePath: string | null;
+              lastCookedAt: string | null;
+              prepMinutes: number | null;
+              recipeId: number;
+              recipeSlug: string;
+              /** @enum {string|null} */
+              recipeType:
+                | 'plate'
+                | 'component'
+                | 'technique'
+                | 'sauce'
+                | 'dressing'
+                | 'drink'
+                | 'condiment'
+                | null;
+              subs: {
+                candidateSubName: string;
+                fromIngredientName: string;
+                fromVariantName: string | null;
+                lineIndex: number;
+                substitutionId: number;
+              }[];
+              subsNeeded: number;
+              title: string;
+            }[];
+            totalCandidates: number;
+          };
+        };
+      };
+    };
+  };
+  'substitutions.list': {
+    parameters: {
+      query?: {
+        fromIngredientId?: number;
+        fromVariantId?: number;
+        toIngredientId?: number;
+        toVariantId?: number;
+        scope?: 'global' | 'recipe';
+        recipeId?: number;
+        contextTag?: string;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            items: {
+              readonly contextTags: string[];
+              createdAt: string;
+              fromIngredientId: number | null;
+              fromVariantId: number | null;
+              id: number;
+              notes: string | null;
+              ratio: number;
+              recipeId: number | null;
+              /** @enum {string} */
+              scope: 'global' | 'recipe';
+              toIngredientId: number | null;
+              toVariantId: number | null;
+            }[];
+          };
+        };
+      };
+    };
+  };
+  'substitutions.create': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          contextTags?: string[];
+          from: {
+            ingredientId?: number;
+            variantId?: number;
+          };
+          notes?: string | null;
+          ratio?: number;
+          recipeId?: number | null;
+          /** @enum {string} */
+          scope?: 'global' | 'recipe';
+          to: {
+            ingredientId?: number;
+            variantId?: number;
+          };
+        };
+      };
+    };
+    responses: {
+      /** @description 201 */
+      201: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              readonly contextTags: string[];
+              createdAt: string;
+              fromIngredientId: number | null;
+              fromVariantId: number | null;
+              id: number;
+              notes: string | null;
+              ratio: number;
+              recipeId: number | null;
+              /** @enum {string} */
+              scope: 'global' | 'recipe';
+              toIngredientId: number | null;
+              toVariantId: number | null;
+            };
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'substitutions.graphView': {
+    parameters: {
+      query?: {
+        scope?: 'global' | 'recipe';
+        recipeId?: number;
+        contextTag?: string;
+        search?: string;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            edges: {
+              readonly contextTags: string[];
+              fromNodeId: string;
+              id: number;
+              notes: string | null;
+              ratio: number;
+              recipeId: number | null;
+              recipeSlug: string | null;
+              /** @enum {string} */
+              scope: 'global' | 'recipe';
+              toNodeId: string;
+            }[];
+            nodes: {
+              id: string;
+              ingredientId: number;
+              ingredientName: string;
+              ingredientSlug: string;
+              /** @enum {string} */
+              kind: 'ingredient' | 'variant';
+              variantId: number | null;
+              variantName: string | null;
+              variantSlug: string | null;
+            }[];
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'substitutions.listHydrated': {
+    parameters: {
+      query?: {
+        fromIngredientId?: number;
+        fromVariantId?: number;
+        toIngredientId?: number;
+        toVariantId?: number;
+        scope?: 'global' | 'recipe';
+        recipeId?: number;
+        contextTag?: string;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            items: {
+              readonly contextTags: string[];
+              createdAt: string;
+              from: {
+                id: number;
+                /** @enum {string} */
+                kind: 'ingredient' | 'variant';
+                name: string;
+                parentSlug: string | null;
+                slug: string;
+              };
+              fromIngredientId: number | null;
+              fromVariantId: number | null;
+              id: number;
+              notes: string | null;
+              ratio: number;
+              recipeId: number | null;
+              recipeSlug: string | null;
+              /** @enum {string} */
+              scope: 'global' | 'recipe';
+              to: {
+                id: number;
+                /** @enum {string} */
+                kind: 'ingredient' | 'variant';
+                name: string;
+                parentSlug: string | null;
+                slug: string;
+              };
+              toIngredientId: number | null;
+              toVariantId: number | null;
+            }[];
+          };
+        };
+      };
+    };
+  };
+  'substitutions.resolveForLine': {
+    parameters: {
+      query: {
+        recipeVersionId: number;
+        lineIndex: number;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            readonly candidates: {
+              readonly batches: {
+                batchId: number;
+                expiresAt: string | null;
+                /** @enum {string} */
+                location: 'pantry' | 'fridge' | 'freezer' | 'other';
+                prepStateId: number | null;
+                prepStateLabel: string | null;
+                qtyRemaining: number;
+                /** @enum {string} */
+                unit: 'g' | 'ml' | 'count';
+              }[];
+              readonly contextTags: string[];
+              notes: string | null;
+              ratio: number;
+              recipeId: number | null;
+              /** @enum {string} */
+              scope: 'global' | 'recipe';
+              substituteIngredientId: number;
+              substituteIngredientName: string;
+              substituteVariantId: number;
+              substituteVariantName: string;
+              substitutionId: number;
+            }[];
+            lineIndex: number;
+            linePrepStateId: number | null;
+            linePrepStateLabel: string | null;
+            lineQty: number;
+            /** @enum {string} */
+            lineUnit: 'g' | 'ml' | 'count';
+            lineVariantId: number;
+            lineVariantName: string;
+            readonly recipeContextTags: string[];
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'substitutions.delete': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: number;
+      };
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': Record<string, never>;
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            /** @enum {boolean} */
+            ok: true;
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'substitutions.update': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: number;
+      };
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          contextTags?: string[];
+          notes?: string | null;
+          ratio?: number;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              readonly contextTags: string[];
+              createdAt: string;
+              fromIngredientId: number | null;
+              fromVariantId: number | null;
+              id: number;
+              notes: string | null;
+              ratio: number;
+              recipeId: number | null;
+              /** @enum {string} */
+              scope: 'global' | 'recipe';
+              toIngredientId: number | null;
+              toVariantId: number | null;
+            };
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
           };
         };
       };

--- a/pillars/food/src/contract/rest-solver.ts
+++ b/pillars/food/src/contract/rest-solver.ts
@@ -1,0 +1,71 @@
+/**
+ * `solver.*` sub-router — `canICook` ranks cookable recipes by how many
+ * substitutions each needs given current batch inventory (PRD-150).
+ *
+ * Modelled as `POST /solver/can-i-cook` with a JSON body rather than a GET:
+ * the filter set is array-shaped (recipeTypes, tags), which rides far more
+ * cleanly in a body than in repeated query params. It is still a pure read.
+ */
+import { initContract } from '@ts-rest/core';
+import { z } from 'zod';
+
+const c = initContract();
+
+const RecipeType = z.enum([
+  'plate',
+  'component',
+  'technique',
+  'sauce',
+  'dressing',
+  'drink',
+  'condiment',
+]);
+
+const CanICookBody = z.object({
+  excludeSubs: z.boolean().optional(),
+  recipeTypes: z.array(RecipeType).max(7).optional(),
+  tags: z.array(z.string().trim().min(1).max(64)).max(32).optional(),
+  maxMinutes: z
+    .number()
+    .int()
+    .positive()
+    .max(24 * 60)
+    .optional(),
+});
+
+const SolveSubBreakdownSchema = z.object({
+  lineIndex: z.number().int(),
+  fromIngredientName: z.string(),
+  fromVariantName: z.string().nullable(),
+  candidateSubName: z.string(),
+  substitutionId: z.number().int(),
+});
+
+const SolveRecipeRowSchema = z.object({
+  recipeId: z.number().int().positive(),
+  recipeSlug: z.string(),
+  title: z.string(),
+  recipeType: RecipeType.nullable(),
+  heroImagePath: z.string().nullable(),
+  prepMinutes: z.number().int().nullable(),
+  cookMinutes: z.number().int().nullable(),
+  lastCookedAt: z.string().nullable(),
+  subsNeeded: z.number().int().nonnegative(),
+  subs: z.array(SolveSubBreakdownSchema),
+});
+
+const SolveResultSchema = z.object({
+  totalCandidates: z.number().int().nonnegative(),
+  cookableCount: z.number().int().nonnegative(),
+  recipes: z.array(SolveRecipeRowSchema),
+});
+
+export const foodSolverContract = c.router({
+  canICook: {
+    method: 'POST',
+    path: '/solver/can-i-cook',
+    body: CanICookBody,
+    responses: { 200: SolveResultSchema },
+    summary: 'Rank cookable recipes by substitution count given current inventory',
+  },
+});

--- a/pillars/food/src/contract/rest-substitutions.ts
+++ b/pillars/food/src/contract/rest-substitutions.ts
@@ -1,0 +1,215 @@
+/**
+ * `substitutions.*` sub-router — the ingredient/variant substitution graph:
+ * CRUD, the hydrated list, the node/edge graph-view projection, and the
+ * per-line resolver (`resolveForLine`) the cook picker drives.
+ *
+ * Endpoints are XOR-shaped (exactly one of ingredientId / variantId per
+ * side); the db service enforces it and `CannotSubstituteSelf` maps to 400.
+ * Literal `/substitutions/graph-view` and `/substitutions/resolve-line` are
+ * declared before the `/substitutions/:id` param routes.
+ */
+import { initContract } from '@ts-rest/core';
+import { z } from 'zod';
+
+import { ERR_RESPONSES, PathPositiveInt, QueryPositiveInt } from './rest-schemas.js';
+
+const c = initContract();
+
+const ScopeEnum = z.enum(['global', 'recipe']);
+const UnitEnum = z.enum(['g', 'ml', 'count']);
+const ContextTags = z.array(z.string()).readonly();
+
+export const SubstitutionViewSchema = z.object({
+  id: z.number().int().positive(),
+  fromIngredientId: z.number().int().positive().nullable(),
+  fromVariantId: z.number().int().positive().nullable(),
+  toIngredientId: z.number().int().positive().nullable(),
+  toVariantId: z.number().int().positive().nullable(),
+  ratio: z.number(),
+  contextTags: ContextTags,
+  scope: ScopeEnum,
+  recipeId: z.number().int().positive().nullable(),
+  notes: z.string().nullable(),
+  createdAt: z.string(),
+});
+
+const HydratedEndpointSchema = z.object({
+  kind: z.enum(['ingredient', 'variant']),
+  id: z.number().int(),
+  slug: z.string(),
+  name: z.string(),
+  parentSlug: z.string().nullable(),
+});
+
+const HydratedSubstitutionViewSchema = SubstitutionViewSchema.extend({
+  from: HydratedEndpointSchema,
+  to: HydratedEndpointSchema,
+  recipeSlug: z.string().nullable(),
+});
+
+const GraphViewNodeSchema = z.object({
+  id: z.string(),
+  kind: z.enum(['ingredient', 'variant']),
+  ingredientId: z.number().int(),
+  variantId: z.number().int().nullable(),
+  ingredientSlug: z.string(),
+  ingredientName: z.string(),
+  variantSlug: z.string().nullable(),
+  variantName: z.string().nullable(),
+});
+
+const GraphViewEdgeSchema = z.object({
+  id: z.number().int(),
+  fromNodeId: z.string(),
+  toNodeId: z.string(),
+  ratio: z.number(),
+  contextTags: ContextTags,
+  scope: ScopeEnum,
+  recipeId: z.number().int().nullable(),
+  recipeSlug: z.string().nullable(),
+  notes: z.string().nullable(),
+});
+
+const GraphViewSchema = z.object({
+  nodes: z.array(GraphViewNodeSchema),
+  edges: z.array(GraphViewEdgeSchema),
+});
+
+const SubCandidateBatchSchema = z.object({
+  batchId: z.number().int(),
+  qtyRemaining: z.number(),
+  unit: UnitEnum,
+  location: z.enum(['pantry', 'fridge', 'freezer', 'other']),
+  expiresAt: z.string().nullable(),
+  prepStateId: z.number().int().nullable(),
+  prepStateLabel: z.string().nullable(),
+});
+
+const SubCandidateSchema = z.object({
+  substitutionId: z.number().int(),
+  ratio: z.number(),
+  contextTags: ContextTags,
+  scope: ScopeEnum,
+  recipeId: z.number().int().nullable(),
+  substituteVariantId: z.number().int(),
+  substituteVariantName: z.string(),
+  substituteIngredientId: z.number().int(),
+  substituteIngredientName: z.string(),
+  notes: z.string().nullable(),
+  batches: z.array(SubCandidateBatchSchema).readonly(),
+});
+
+const SubResolutionSchema = z.object({
+  lineIndex: z.number().int(),
+  lineVariantId: z.number().int(),
+  lineVariantName: z.string(),
+  linePrepStateId: z.number().int().nullable(),
+  linePrepStateLabel: z.string().nullable(),
+  lineQty: z.number(),
+  lineUnit: UnitEnum,
+  recipeContextTags: ContextTags,
+  candidates: z.array(SubCandidateSchema).readonly(),
+});
+
+const EndpointBody = z
+  .object({
+    ingredientId: z.number().int().positive().optional(),
+    variantId: z.number().int().positive().optional(),
+  })
+  .refine((v) => (v.ingredientId === undefined) !== (v.variantId === undefined), {
+    message: 'endpoint must set exactly one of ingredientId or variantId',
+  });
+
+const ListFilterQuery = z.object({
+  fromIngredientId: QueryPositiveInt.optional(),
+  fromVariantId: QueryPositiveInt.optional(),
+  toIngredientId: QueryPositiveInt.optional(),
+  toVariantId: QueryPositiveInt.optional(),
+  scope: ScopeEnum.optional(),
+  recipeId: QueryPositiveInt.optional(),
+  contextTag: z.string().optional(),
+});
+
+export const foodSubstitutionsContract = c.router({
+  list: {
+    method: 'GET',
+    path: '/substitutions',
+    query: ListFilterQuery,
+    responses: { 200: z.object({ items: z.array(SubstitutionViewSchema) }) },
+    summary: 'List substitutions (raw FK ids)',
+  },
+  listHydrated: {
+    method: 'GET',
+    path: '/substitutions/hydrated',
+    query: ListFilterQuery,
+    responses: { 200: z.object({ items: z.array(HydratedSubstitutionViewSchema) }) },
+    summary: 'List substitutions widened with slug + display name per endpoint',
+  },
+  graphView: {
+    method: 'GET',
+    path: '/substitutions/graph-view',
+    query: z.object({
+      scope: ScopeEnum.optional(),
+      recipeId: QueryPositiveInt.optional(),
+      contextTag: z.string().optional(),
+      search: z.string().optional(),
+    }),
+    responses: { 200: GraphViewSchema, ...ERR_RESPONSES },
+    summary: 'Node/edge projection of the substitution graph',
+  },
+  resolveForLine: {
+    method: 'GET',
+    path: '/substitutions/resolve-line',
+    query: z.object({
+      recipeVersionId: QueryPositiveInt,
+      lineIndex: QueryPositiveInt,
+    }),
+    responses: { 200: SubResolutionSchema, ...ERR_RESPONSES },
+    summary: 'Per-line substitution candidates with batch coverage',
+  },
+  create: {
+    method: 'POST',
+    path: '/substitutions',
+    body: z
+      .object({
+        from: EndpointBody,
+        to: EndpointBody,
+        ratio: z.number().positive().optional(),
+        contextTags: z.array(z.string()).optional(),
+        scope: ScopeEnum.optional(),
+        recipeId: z.number().int().positive().nullish(),
+        notes: z.string().nullish(),
+      })
+      .refine(
+        (v) => {
+          const scope = v.scope ?? 'global';
+          return scope === 'recipe'
+            ? v.recipeId !== undefined && v.recipeId !== null
+            : v.recipeId === undefined || v.recipeId === null;
+        },
+        { message: 'scope="recipe" requires recipeId; scope="global" must omit recipeId' }
+      ),
+    responses: { 201: z.object({ data: SubstitutionViewSchema }), ...ERR_RESPONSES },
+    summary: 'Create a substitution edge',
+  },
+  update: {
+    method: 'PATCH',
+    path: '/substitutions/:id',
+    pathParams: z.object({ id: PathPositiveInt }),
+    body: z.object({
+      ratio: z.number().positive().optional(),
+      contextTags: z.array(z.string()).optional(),
+      notes: z.string().nullish(),
+    }),
+    responses: { 200: z.object({ data: SubstitutionViewSchema }), ...ERR_RESPONSES },
+    summary: 'Update a substitution edge',
+  },
+  delete: {
+    method: 'DELETE',
+    path: '/substitutions/:id',
+    pathParams: z.object({ id: PathPositiveInt }),
+    body: z.object({}).optional(),
+    responses: { 200: z.object({ ok: z.literal(true) }), ...ERR_RESPONSES },
+    summary: 'Delete a substitution edge',
+  },
+});

--- a/pillars/food/src/contract/rest.ts
+++ b/pillars/food/src/contract/rest.ts
@@ -20,6 +20,8 @@ import { foodIngredientTagsContract } from './rest-ingredient-tags.js';
 import { foodIngredientsContract } from './rest-ingredients.js';
 import { foodPrepStatesContract } from './rest-prep-states.js';
 import { foodSlugsContract } from './rest-slugs.js';
+import { foodSolverContract } from './rest-solver.js';
+import { foodSubstitutionsContract } from './rest-substitutions.js';
 import { foodVariantsContract } from './rest-variants.js';
 
 const c = initContract();
@@ -32,6 +34,8 @@ export const foodContract = c.router(
     ingredientTags: foodIngredientTagsContract,
     prepStates: foodPrepStatesContract,
     slugs: foodSlugsContract,
+    solver: foodSolverContract,
+    substitutions: foodSubstitutionsContract,
     variants: foodVariantsContract,
   },
   {


### PR DESCRIPTION
Slice 2 of the food tRPC→REST migration (`docs/runbooks/food-rest-migration.md`), after #3339–#3342.

## Domains
- **substitutions** — `GET /substitutions`, `GET /substitutions/hydrated`, `GET /substitutions/graph-view`, `GET /substitutions/resolve-line`, `POST /substitutions`, `PATCH/DELETE /substitutions/:id`. XOR endpoint validation + scope/recipeId coherence at the zod boundary (→400); `CannotSubstituteSelf` → 400; `LineNotFound` → 404. The shared `substitutions-resolve*` loaders are lifted into `src/api/modules/substitutions/`.
- **solver** — `POST /solver/can-i-cook` (body-carried array filters; pure read). The `can-i-cook`/`candidates`/`line-evaluator`/`lines`/`name-lookup` logic is lifted into `src/api/modules/solver/` over the in-pillar db services.

## Migration completeness fix (important)
The food collapse only carried the 0058 baseline + the conversions/tags tail, so `openFoodDb` built an **incomplete schema** on a fresh DB — missing `recipes`, `recipe_versions`, `recipe_lines`, `recipe_steps`, `batches`, `batch_consumptions`, `recipe_runs`, `substitutions`, `plan_*`, `ingest_sources`, etc. Every non-leaf domain 500'd. This adds **`0061_food_remainder.sql`** (the 14 missing tables + 39 indexes, extracted from the fully-evolved schema and verified against the drizzle models) so the pillar is self-contained — matching how `pillars/inventory` ships a complete baseline. Required for this and all later slices.

## Safety
- Additive to the pillar only — `apps/pops-api` untouched (the resolve/solver files are copied, not moved; pops-api's red state is unchanged).
- Validated locally: typecheck, lint, format, build, OpenAPI + api-types drift, **837 tests (65 files) green**; OpenAPI idempotent.

## Remaining
batches/fridge/inbox → recipes (+send-to-list, hero-image) → plan/shopping → ingest/ai → Phase C/D/E.