### PR TITLE
feat(finance): REST migration slice 2 — tag-rules domain

### DIFF
--- a/pillars/finance/openapi/finance.openapi.json
+++ b/pillars/finance/openapi/finance.openapi.json
@@ -771,6 +771,1731 @@
         "tags": ["budgets"]
       }
     },
+    "/tag-rules/apply": {
+      "post": {
+        "operationId": "tagRules.apply",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "acceptedNewTags": {
+                    "default": [],
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "changeSet": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "ops": {
+                        "items": {
+                          "oneOf": [
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "data": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "confidence": {
+                                      "maximum": 1,
+                                      "minimum": 0,
+                                      "type": "number"
+                                    },
+                                    "descriptionPattern": {
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    "entityId": {
+                                      "nullable": true,
+                                      "type": "string"
+                                    },
+                                    "isActive": {
+                                      "type": "boolean"
+                                    },
+                                    "matchType": {
+                                      "default": "exact",
+                                      "enum": ["exact", "contains", "regex"],
+                                      "type": "string"
+                                    },
+                                    "priority": {
+                                      "maximum": 9007199254740991,
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    },
+                                    "tags": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "minItems": 1,
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": ["descriptionPattern", "matchType", "tags"],
+                                  "type": "object"
+                                },
+                                "op": {
+                                  "enum": ["add"],
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["op", "data"],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "data": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "confidence": {
+                                      "maximum": 1,
+                                      "minimum": 0,
+                                      "type": "number"
+                                    },
+                                    "entityId": {
+                                      "nullable": true,
+                                      "type": "string"
+                                    },
+                                    "isActive": {
+                                      "type": "boolean"
+                                    },
+                                    "priority": {
+                                      "maximum": 9007199254740991,
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    },
+                                    "tags": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "id": {
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "op": {
+                                  "enum": ["edit"],
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["op", "id", "data"],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "id": {
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "op": {
+                                  "enum": ["disable"],
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["op", "id"],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "id": {
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "op": {
+                                  "enum": ["remove"],
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["op", "id"],
+                              "type": "object"
+                            }
+                          ]
+                        },
+                        "minItems": 1,
+                        "type": "array"
+                      },
+                      "reason": {
+                        "type": "string"
+                      },
+                      "source": {
+                        "type": "string"
+                      }
+                    },
+                    "required": ["ops"],
+                    "type": "object"
+                  }
+                },
+                "required": ["changeSet", "acceptedNewTags"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "rules": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "confidence": {
+                            "type": "number"
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          },
+                          "descriptionPattern": {
+                            "type": "string"
+                          },
+                          "entityId": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "id": {
+                            "type": "string"
+                          },
+                          "isActive": {
+                            "type": "boolean"
+                          },
+                          "lastUsedAt": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "matchType": {
+                            "enum": ["exact", "contains", "regex"],
+                            "type": "string"
+                          },
+                          "priority": {
+                            "type": "number"
+                          },
+                          "tags": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "timesApplied": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "descriptionPattern",
+                          "matchType",
+                          "entityId",
+                          "tags",
+                          "isActive",
+                          "confidence",
+                          "priority",
+                          "timesApplied",
+                          "createdAt",
+                          "lastUsedAt"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": ["rules"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Apply a tag-rule ChangeSet; upserts accepted new vocabulary tags",
+        "tags": ["tagRules"]
+      }
+    },
+    "/tag-rules/preview": {
+      "post": {
+        "operationId": "tagRules.preview",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "changeSet": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "ops": {
+                        "items": {
+                          "oneOf": [
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "data": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "confidence": {
+                                      "maximum": 1,
+                                      "minimum": 0,
+                                      "type": "number"
+                                    },
+                                    "descriptionPattern": {
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    "entityId": {
+                                      "nullable": true,
+                                      "type": "string"
+                                    },
+                                    "isActive": {
+                                      "type": "boolean"
+                                    },
+                                    "matchType": {
+                                      "default": "exact",
+                                      "enum": ["exact", "contains", "regex"],
+                                      "type": "string"
+                                    },
+                                    "priority": {
+                                      "maximum": 9007199254740991,
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    },
+                                    "tags": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "minItems": 1,
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": ["descriptionPattern", "matchType", "tags"],
+                                  "type": "object"
+                                },
+                                "op": {
+                                  "enum": ["add"],
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["op", "data"],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "data": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "confidence": {
+                                      "maximum": 1,
+                                      "minimum": 0,
+                                      "type": "number"
+                                    },
+                                    "entityId": {
+                                      "nullable": true,
+                                      "type": "string"
+                                    },
+                                    "isActive": {
+                                      "type": "boolean"
+                                    },
+                                    "priority": {
+                                      "maximum": 9007199254740991,
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    },
+                                    "tags": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "id": {
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "op": {
+                                  "enum": ["edit"],
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["op", "id", "data"],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "id": {
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "op": {
+                                  "enum": ["disable"],
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["op", "id"],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "id": {
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "op": {
+                                  "enum": ["remove"],
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["op", "id"],
+                              "type": "object"
+                            }
+                          ]
+                        },
+                        "minItems": 1,
+                        "type": "array"
+                      },
+                      "reason": {
+                        "type": "string"
+                      },
+                      "source": {
+                        "type": "string"
+                      }
+                    },
+                    "required": ["ops"],
+                    "type": "object"
+                  },
+                  "maxPreviewItems": {
+                    "default": 200,
+                    "exclusiveMinimum": true,
+                    "maximum": 500,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "transactions": {
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "description": {
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "entityId": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "transactionId": {
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "userTags": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "required": ["transactionId", "description"],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": ["changeSet", "transactions", "maxPreviewItems"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "affected": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "after": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "suggestedTags": {
+                                "items": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "isNew": {
+                                      "type": "boolean"
+                                    },
+                                    "pattern": {
+                                      "type": "string"
+                                    },
+                                    "source": {
+                                      "enum": ["tag_rule", "rule", "ai", "entity"],
+                                      "type": "string"
+                                    },
+                                    "tag": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": ["tag", "source"],
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "required": ["suggestedTags"],
+                            "type": "object"
+                          },
+                          "before": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "suggestedTags": {
+                                "items": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "isNew": {
+                                      "type": "boolean"
+                                    },
+                                    "pattern": {
+                                      "type": "string"
+                                    },
+                                    "source": {
+                                      "enum": ["tag_rule", "rule", "ai", "entity"],
+                                      "type": "string"
+                                    },
+                                    "tag": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": ["tag", "source"],
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "required": ["suggestedTags"],
+                            "type": "object"
+                          },
+                          "description": {
+                            "type": "string"
+                          },
+                          "transactionId": {
+                            "type": "string"
+                          }
+                        },
+                        "required": ["transactionId", "description", "before", "after"],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "counts": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "affected": {
+                          "type": "number"
+                        },
+                        "newTagProposals": {
+                          "type": "number"
+                        },
+                        "suggestionChanges": {
+                          "type": "number"
+                        }
+                      },
+                      "required": ["affected", "suggestionChanges", "newTagProposals"],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["counts", "affected"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Preview the suggestion-impact of a tag-rule ChangeSet over the supplied transactions",
+        "tags": ["tagRules"]
+      }
+    },
+    "/tag-rules/propose": {
+      "post": {
+        "operationId": "tagRules.propose",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "maxPreviewItems": {
+                    "default": 200,
+                    "exclusiveMinimum": true,
+                    "maximum": 500,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "signal": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "descriptionPattern": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "entityId": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "matchType": {
+                        "enum": ["exact", "contains", "regex"],
+                        "type": "string"
+                      },
+                      "tags": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "minItems": 1,
+                        "type": "array"
+                      }
+                    },
+                    "required": ["descriptionPattern", "matchType", "tags"],
+                    "type": "object"
+                  },
+                  "transactions": {
+                    "default": [],
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "description": {
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "entityId": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "transactionId": {
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "userTags": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "required": ["transactionId", "description"],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": ["signal", "transactions", "maxPreviewItems"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "changeSet": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "ops": {
+                          "items": {
+                            "oneOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "data": {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "confidence": {
+                                        "maximum": 1,
+                                        "minimum": 0,
+                                        "type": "number"
+                                      },
+                                      "descriptionPattern": {
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "entityId": {
+                                        "nullable": true,
+                                        "type": "string"
+                                      },
+                                      "isActive": {
+                                        "type": "boolean"
+                                      },
+                                      "matchType": {
+                                        "default": "exact",
+                                        "enum": ["exact", "contains", "regex"],
+                                        "type": "string"
+                                      },
+                                      "priority": {
+                                        "maximum": 9007199254740991,
+                                        "minimum": 0,
+                                        "type": "integer"
+                                      },
+                                      "tags": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "minItems": 1,
+                                        "type": "array"
+                                      }
+                                    },
+                                    "required": ["descriptionPattern", "matchType", "tags"],
+                                    "type": "object"
+                                  },
+                                  "op": {
+                                    "enum": ["add"],
+                                    "type": "string"
+                                  }
+                                },
+                                "required": ["op", "data"],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "data": {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "confidence": {
+                                        "maximum": 1,
+                                        "minimum": 0,
+                                        "type": "number"
+                                      },
+                                      "entityId": {
+                                        "nullable": true,
+                                        "type": "string"
+                                      },
+                                      "isActive": {
+                                        "type": "boolean"
+                                      },
+                                      "priority": {
+                                        "maximum": 9007199254740991,
+                                        "minimum": 0,
+                                        "type": "integer"
+                                      },
+                                      "tags": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "id": {
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "op": {
+                                    "enum": ["edit"],
+                                    "type": "string"
+                                  }
+                                },
+                                "required": ["op", "id", "data"],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "id": {
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "op": {
+                                    "enum": ["disable"],
+                                    "type": "string"
+                                  }
+                                },
+                                "required": ["op", "id"],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "id": {
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "op": {
+                                    "enum": ["remove"],
+                                    "type": "string"
+                                  }
+                                },
+                                "required": ["op", "id"],
+                                "type": "object"
+                              }
+                            ]
+                          },
+                          "minItems": 1,
+                          "type": "array"
+                        },
+                        "reason": {
+                          "type": "string"
+                        },
+                        "source": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["ops"],
+                      "type": "object"
+                    },
+                    "preview": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "affected": {
+                          "items": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "after": {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "suggestedTags": {
+                                    "items": {
+                                      "additionalProperties": false,
+                                      "properties": {
+                                        "isNew": {
+                                          "type": "boolean"
+                                        },
+                                        "pattern": {
+                                          "type": "string"
+                                        },
+                                        "source": {
+                                          "enum": ["tag_rule", "rule", "ai", "entity"],
+                                          "type": "string"
+                                        },
+                                        "tag": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": ["tag", "source"],
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "required": ["suggestedTags"],
+                                "type": "object"
+                              },
+                              "before": {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "suggestedTags": {
+                                    "items": {
+                                      "additionalProperties": false,
+                                      "properties": {
+                                        "isNew": {
+                                          "type": "boolean"
+                                        },
+                                        "pattern": {
+                                          "type": "string"
+                                        },
+                                        "source": {
+                                          "enum": ["tag_rule", "rule", "ai", "entity"],
+                                          "type": "string"
+                                        },
+                                        "tag": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": ["tag", "source"],
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "required": ["suggestedTags"],
+                                "type": "object"
+                              },
+                              "description": {
+                                "type": "string"
+                              },
+                              "transactionId": {
+                                "type": "string"
+                              }
+                            },
+                            "required": ["transactionId", "description", "before", "after"],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "counts": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "affected": {
+                              "type": "number"
+                            },
+                            "newTagProposals": {
+                              "type": "number"
+                            },
+                            "suggestionChanges": {
+                              "type": "number"
+                            }
+                          },
+                          "required": ["affected", "suggestionChanges", "newTagProposals"],
+                          "type": "object"
+                        }
+                      },
+                      "required": ["counts", "affected"],
+                      "type": "object"
+                    },
+                    "rationale": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["changeSet", "rationale", "preview"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Propose a tag-rule ChangeSet from a tag-edit signal (deterministic, with impact preview)",
+        "tags": ["tagRules"]
+      }
+    },
+    "/tag-rules/reject": {
+      "post": {
+        "operationId": "tagRules.reject",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "changeSet": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "ops": {
+                        "items": {
+                          "oneOf": [
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "data": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "confidence": {
+                                      "maximum": 1,
+                                      "minimum": 0,
+                                      "type": "number"
+                                    },
+                                    "descriptionPattern": {
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    "entityId": {
+                                      "nullable": true,
+                                      "type": "string"
+                                    },
+                                    "isActive": {
+                                      "type": "boolean"
+                                    },
+                                    "matchType": {
+                                      "default": "exact",
+                                      "enum": ["exact", "contains", "regex"],
+                                      "type": "string"
+                                    },
+                                    "priority": {
+                                      "maximum": 9007199254740991,
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    },
+                                    "tags": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "minItems": 1,
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": ["descriptionPattern", "matchType", "tags"],
+                                  "type": "object"
+                                },
+                                "op": {
+                                  "enum": ["add"],
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["op", "data"],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "data": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "confidence": {
+                                      "maximum": 1,
+                                      "minimum": 0,
+                                      "type": "number"
+                                    },
+                                    "entityId": {
+                                      "nullable": true,
+                                      "type": "string"
+                                    },
+                                    "isActive": {
+                                      "type": "boolean"
+                                    },
+                                    "priority": {
+                                      "maximum": 9007199254740991,
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    },
+                                    "tags": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "id": {
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "op": {
+                                  "enum": ["edit"],
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["op", "id", "data"],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "id": {
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "op": {
+                                  "enum": ["disable"],
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["op", "id"],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "id": {
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "op": {
+                                  "enum": ["remove"],
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["op", "id"],
+                              "type": "object"
+                            }
+                          ]
+                        },
+                        "minItems": 1,
+                        "type": "array"
+                      },
+                      "reason": {
+                        "type": "string"
+                      },
+                      "source": {
+                        "type": "string"
+                      }
+                    },
+                    "required": ["ops"],
+                    "type": "object"
+                  },
+                  "feedback": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "maxPreviewItems": {
+                    "default": 200,
+                    "exclusiveMinimum": true,
+                    "maximum": 500,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "signal": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "descriptionPattern": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "entityId": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "matchType": {
+                        "enum": ["exact", "contains", "regex"],
+                        "type": "string"
+                      },
+                      "tags": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "minItems": 1,
+                        "type": "array"
+                      }
+                    },
+                    "required": ["descriptionPattern", "matchType", "tags"],
+                    "type": "object"
+                  },
+                  "transactions": {
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "description": {
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "entityId": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "transactionId": {
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "userTags": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "required": ["transactionId", "description"],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": ["changeSet", "feedback", "maxPreviewItems"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "followUpProposal": {
+                      "additionalProperties": false,
+                      "nullable": true,
+                      "properties": {
+                        "changeSet": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "ops": {
+                              "items": {
+                                "oneOf": [
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "data": {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                          "confidence": {
+                                            "maximum": 1,
+                                            "minimum": 0,
+                                            "type": "number"
+                                          },
+                                          "descriptionPattern": {
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "entityId": {
+                                            "nullable": true,
+                                            "type": "string"
+                                          },
+                                          "isActive": {
+                                            "type": "boolean"
+                                          },
+                                          "matchType": {
+                                            "default": "exact",
+                                            "enum": ["exact", "contains", "regex"],
+                                            "type": "string"
+                                          },
+                                          "priority": {
+                                            "maximum": 9007199254740991,
+                                            "minimum": 0,
+                                            "type": "integer"
+                                          },
+                                          "tags": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "minItems": 1,
+                                            "type": "array"
+                                          }
+                                        },
+                                        "required": ["descriptionPattern", "matchType", "tags"],
+                                        "type": "object"
+                                      },
+                                      "op": {
+                                        "enum": ["add"],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": ["op", "data"],
+                                    "type": "object"
+                                  },
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "data": {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                          "confidence": {
+                                            "maximum": 1,
+                                            "minimum": 0,
+                                            "type": "number"
+                                          },
+                                          "entityId": {
+                                            "nullable": true,
+                                            "type": "string"
+                                          },
+                                          "isActive": {
+                                            "type": "boolean"
+                                          },
+                                          "priority": {
+                                            "maximum": 9007199254740991,
+                                            "minimum": 0,
+                                            "type": "integer"
+                                          },
+                                          "tags": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "id": {
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "op": {
+                                        "enum": ["edit"],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": ["op", "id", "data"],
+                                    "type": "object"
+                                  },
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "id": {
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "op": {
+                                        "enum": ["disable"],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": ["op", "id"],
+                                    "type": "object"
+                                  },
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "id": {
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "op": {
+                                        "enum": ["remove"],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": ["op", "id"],
+                                    "type": "object"
+                                  }
+                                ]
+                              },
+                              "minItems": 1,
+                              "type": "array"
+                            },
+                            "reason": {
+                              "type": "string"
+                            },
+                            "source": {
+                              "type": "string"
+                            }
+                          },
+                          "required": ["ops"],
+                          "type": "object"
+                        },
+                        "preview": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "affected": {
+                              "items": {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "after": {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "suggestedTags": {
+                                        "items": {
+                                          "additionalProperties": false,
+                                          "properties": {
+                                            "isNew": {
+                                              "type": "boolean"
+                                            },
+                                            "pattern": {
+                                              "type": "string"
+                                            },
+                                            "source": {
+                                              "enum": ["tag_rule", "rule", "ai", "entity"],
+                                              "type": "string"
+                                            },
+                                            "tag": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": ["tag", "source"],
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "required": ["suggestedTags"],
+                                    "type": "object"
+                                  },
+                                  "before": {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "suggestedTags": {
+                                        "items": {
+                                          "additionalProperties": false,
+                                          "properties": {
+                                            "isNew": {
+                                              "type": "boolean"
+                                            },
+                                            "pattern": {
+                                              "type": "string"
+                                            },
+                                            "source": {
+                                              "enum": ["tag_rule", "rule", "ai", "entity"],
+                                              "type": "string"
+                                            },
+                                            "tag": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": ["tag", "source"],
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "required": ["suggestedTags"],
+                                    "type": "object"
+                                  },
+                                  "description": {
+                                    "type": "string"
+                                  },
+                                  "transactionId": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": ["transactionId", "description", "before", "after"],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "counts": {
+                              "additionalProperties": false,
+                              "properties": {
+                                "affected": {
+                                  "type": "number"
+                                },
+                                "newTagProposals": {
+                                  "type": "number"
+                                },
+                                "suggestionChanges": {
+                                  "type": "number"
+                                }
+                              },
+                              "required": ["affected", "suggestionChanges", "newTagProposals"],
+                              "type": "object"
+                            }
+                          },
+                          "required": ["counts", "affected"],
+                          "type": "object"
+                        },
+                        "rationale": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["changeSet", "rationale", "preview"],
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message", "followUpProposal"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Reject a ChangeSet with feedback; optionally returns a revised follow-up proposal",
+        "tags": ["tagRules"]
+      }
+    },
+    "/tag-rules/vocabulary": {
+      "get": {
+        "operationId": "tagRules.vocabulary",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "tags": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": ["tags"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "List the user tag vocabulary",
+        "tags": ["tagRules"]
+      }
+    },
     "/transactions": {
       "get": {
         "operationId": "transactions.list",

--- a/pillars/finance/src/api/__tests__/tag-rules.test.ts
+++ b/pillars/finance/src/api/__tests__/tag-rules.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Integration tests for the `tagRules.*` REST surface: vocabulary listing,
+ * deterministic ChangeSet propose/preview (impact diffs, new-tag flagging,
+ * userTags short-circuit, match-type semantics), apply (rule persistence +
+ * vocabulary upsert, 404 on editing an unknown rule), and reject (follow-up
+ * proposal only when a signal is supplied).
+ *
+ * The finance baseline migration seeds a default tag vocabulary, so tests
+ * use a clearly-unseeded tag (`CUSTOM_TAG`) for new-tag assertions rather
+ * than assuming an empty vocabulary.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { openFinanceDb, type OpenedFinanceDb } from '../../db/index.js';
+import { createFinanceApiApp } from '../app.js';
+import { makeClient } from './test-utils.js';
+
+let tmpDir: string;
+let financeDb: OpenedFinanceDb;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'finance-api-tagrules-test-'));
+  financeDb = openFinanceDb(join(tmpDir, 'finance.db'));
+});
+
+afterEach(() => {
+  financeDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function client() {
+  return makeClient(
+    createFinanceApiApp({ financeDb, version: '0.0.1-test', selfBaseUrl: 'http://localhost:3004' })
+  );
+}
+
+const CUSTOM_TAG = 'midnight-snacks';
+
+const addOp = {
+  source: 'test',
+  ops: [
+    {
+      op: 'add',
+      data: { descriptionPattern: 'WOOLWORTHS', matchType: 'contains', tags: [CUSTOM_TAG] },
+    },
+  ],
+};
+
+describe('tagRules — vocabulary & apply', () => {
+  it('upserts accepted new tags on apply, ignoring blanks', async () => {
+    const initial = (await client().tagRules.vocabulary()).tags;
+    expect(initial).not.toContain(CUSTOM_TAG); // unseeded
+    expect(initial.length).toBeGreaterThan(0); // baseline seed present
+
+    const applied = await client().tagRules.apply({
+      changeSet: addOp,
+      acceptedNewTags: [CUSTOM_TAG, '  '],
+    });
+    expect(applied.rules).toHaveLength(1);
+    expect(applied.rules[0]).toMatchObject({
+      descriptionPattern: 'WOOLWORTHS',
+      matchType: 'contains',
+      tags: [CUSTOM_TAG],
+      isActive: true,
+      confidence: 0.95,
+    });
+
+    const after = (await client().tagRules.vocabulary()).tags;
+    expect(after).toContain(CUSTOM_TAG);
+    expect(after).not.toContain(''); // blank-only entry ignored
+    expect(after.length).toBe(initial.length + 1);
+  });
+
+  it('edits and removes a persisted rule via ChangeSet ops', async () => {
+    const created = await client().tagRules.apply({ changeSet: addOp, acceptedNewTags: [] });
+    const id = created.rules[0]?.id ?? '';
+
+    const edited = await client().tagRules.apply({
+      changeSet: { ops: [{ op: 'edit', id, data: { tags: [CUSTOM_TAG, 'late-night'] } }] },
+      acceptedNewTags: [],
+    });
+    expect(edited.rules[0]?.tags).toEqual([CUSTOM_TAG, 'late-night']);
+
+    const removed = await client().tagRules.apply({
+      changeSet: { ops: [{ op: 'remove', id }] },
+      acceptedNewTags: [],
+    });
+    expect(removed.rules).toHaveLength(0);
+  });
+
+  it('404s an edit op targeting an unknown rule id', async () => {
+    await expect(
+      client().tagRules.apply({
+        changeSet: { ops: [{ op: 'edit', id: 'nope', data: { tags: ['x'] } }] },
+        acceptedNewTags: [],
+      })
+    ).rejects.toMatchObject({ status: 404 });
+  });
+});
+
+describe('tagRules — propose & preview', () => {
+  const txs = [
+    { transactionId: 't1', description: 'WOOLWORTHS 1234 SYDNEY', entityId: null },
+    { transactionId: 't2', description: 'COLES 5678', entityId: null },
+    { transactionId: 't3', description: 'WOOLWORTHS METRO', entityId: null, userTags: ['mine'] },
+  ];
+
+  it('proposes an add ChangeSet with a deterministic impact preview', async () => {
+    const proposal = await client().tagRules.propose({
+      signal: { descriptionPattern: 'WOOLWORTHS', matchType: 'contains', tags: [CUSTOM_TAG] },
+      transactions: txs,
+    });
+
+    expect(proposal.changeSet.ops).toHaveLength(1);
+    expect(proposal.rationale).toContain('WOOLWORTHS');
+    // t1 matches; t2 doesn't; t3 is skipped (has userTags).
+    expect(proposal.preview.counts.affected).toBe(1);
+    expect(proposal.preview.affected[0]?.transactionId).toBe('t1');
+    // CUSTOM_TAG is not in the seeded vocabulary → flagged new.
+    expect(proposal.preview.affected[0]?.after.suggestedTags[0]).toMatchObject({
+      tag: CUSTOM_TAG,
+      isNew: true,
+    });
+    expect(proposal.preview.counts.newTagProposals).toBe(1);
+  });
+
+  it('preview honours match-type semantics (exact vs contains)', async () => {
+    const exact = await client().tagRules.preview({
+      changeSet: {
+        ops: [
+          {
+            op: 'add',
+            data: { descriptionPattern: 'WOOLWORTHS', matchType: 'exact', tags: ['g'] },
+          },
+        ],
+      },
+      transactions: txs,
+    });
+    // No description equals 'WOOLWORTHS' exactly → nothing affected.
+    expect(exact.counts.affected).toBe(0);
+
+    const contains = await client().tagRules.preview({
+      changeSet: {
+        ops: [
+          { op: 'add', data: { descriptionPattern: 'COLES', matchType: 'contains', tags: ['g'] } },
+        ],
+      },
+      transactions: txs,
+    });
+    expect(contains.affected.map((a) => a.transactionId)).toEqual(['t2']);
+  });
+
+  it('marks a tag already in the vocabulary as not new', async () => {
+    await client().tagRules.apply({ changeSet: addOp, acceptedNewTags: [CUSTOM_TAG] });
+
+    const preview = await client().tagRules.preview({
+      changeSet: addOp,
+      transactions: [{ transactionId: 't1', description: 'WOOLWORTHS 1234', entityId: null }],
+    });
+    expect(preview.affected[0]?.after.suggestedTags[0]).toMatchObject({
+      tag: CUSTOM_TAG,
+      isNew: false,
+    });
+    expect(preview.counts.newTagProposals).toBe(0);
+  });
+});
+
+describe('tagRules — reject', () => {
+  it('returns a follow-up proposal only when a signal is supplied', async () => {
+    const withSignal = await client().tagRules.reject({
+      changeSet: addOp,
+      feedback: 'too broad',
+      signal: { descriptionPattern: 'WOOLWORTHS METRO', matchType: 'contains', tags: [CUSTOM_TAG] },
+      transactions: [],
+    });
+    expect(withSignal.message).toBe('Tag rule ChangeSet rejected');
+    expect(withSignal.followUpProposal).not.toBeNull();
+    expect(withSignal.followUpProposal?.rationale).toContain('too broad');
+
+    const withoutSignal = await client().tagRules.reject({ changeSet: addOp, feedback: 'no' });
+    expect(withoutSignal.followUpProposal).toBeNull();
+  });
+});

--- a/pillars/finance/src/api/__tests__/test-utils.ts
+++ b/pillars/finance/src/api/__tests__/test-utils.ts
@@ -89,6 +89,43 @@ export interface TransactionQuery {
   offset?: number;
 }
 
+interface TagSuggestion {
+  tag: string;
+  source: string;
+  pattern?: string;
+  isNew?: boolean;
+}
+
+interface TagRulePreview {
+  counts: { affected: number; suggestionChanges: number; newTagProposals: number };
+  affected: {
+    transactionId: string;
+    description: string;
+    before: { suggestedTags: TagSuggestion[] };
+    after: { suggestedTags: TagSuggestion[] };
+  }[];
+}
+
+interface TagRuleProposal {
+  changeSet: { source?: string; reason?: string; ops: unknown[] };
+  rationale: string;
+  preview: TagRulePreview;
+}
+
+interface TagRule {
+  id: string;
+  descriptionPattern: string;
+  matchType: string;
+  entityId: string | null;
+  tags: string[];
+  isActive: boolean;
+  confidence: number;
+  priority: number;
+  timesApplied: number;
+  createdAt: string;
+  lastUsedAt: string | null;
+}
+
 export function makeClient(app: Express) {
   const r = supertest(app);
   return {
@@ -125,6 +162,19 @@ export function makeClient(app: Express) {
       restore: (snapshot: TransactionSnapshot) =>
         send<{ data: Transaction; message: string }>(
           r.post('/transactions/restore').send(snapshot)
+        ),
+    },
+    tagRules: {
+      vocabulary: () => send<{ tags: string[] }>(r.get('/tag-rules/vocabulary')),
+      propose: (body: Record<string, unknown>) =>
+        send<TagRuleProposal>(r.post('/tag-rules/propose').send(body)),
+      preview: (body: Record<string, unknown>) =>
+        send<TagRulePreview>(r.post('/tag-rules/preview').send(body)),
+      apply: (body: Record<string, unknown>) =>
+        send<{ rules: TagRule[] }>(r.post('/tag-rules/apply').send(body)),
+      reject: (body: Record<string, unknown>) =>
+        send<{ message: string; followUpProposal: TagRuleProposal | null }>(
+          r.post('/tag-rules/reject').send(body)
         ),
     },
   };

--- a/pillars/finance/src/api/modules/tag-rules/preview.ts
+++ b/pillars/finance/src/api/modules/tag-rules/preview.ts
@@ -1,0 +1,123 @@
+/**
+ * Deterministic suggestion-impact preview for a tag-rule ChangeSet.
+ *
+ * Ported from `apps/pops-api/src/modules/core/tag-rules/preview.ts`, the
+ * only change being the `FinanceDb` handle is passed in rather than reached
+ * through `getFinanceDrizzle()`. Suggestion-only: rules never override
+ * user-entered tags, and the computation reads nothing but the supplied
+ * transactions plus the user vocabulary.
+ */
+import { type FinanceDb, tagVocabularyService } from '../../../db/index.js';
+
+import type { TagRuleChangeSet } from '../../../contract/rest-tag-rules.js';
+import type {
+  PreviewInputTransaction,
+  TagRuleImpactCounts,
+  TagRuleImpactItem,
+  TagSuggestion,
+} from './types.js';
+
+interface ProposedRule {
+  descriptionPattern: string;
+  matchType: 'exact' | 'contains' | 'regex';
+  entityId: string | null;
+  tags: string[];
+}
+
+function materializeProposedRules(changeSet: TagRuleChangeSet): ProposedRule[] {
+  const rules: ProposedRule[] = [];
+  for (const op of changeSet.ops) {
+    if (op.op === 'add') {
+      rules.push({
+        descriptionPattern: op.data.descriptionPattern,
+        matchType: op.data.matchType,
+        entityId: op.data.entityId ?? null,
+        tags: op.data.tags,
+      });
+    }
+  }
+  return rules;
+}
+
+function ruleMatchesDescription(
+  rule: ProposedRule,
+  description: string,
+  normalized: string
+): boolean {
+  const pattern = rule.descriptionPattern.toUpperCase();
+  if (rule.matchType === 'exact') return normalized === pattern;
+  if (rule.matchType === 'contains') return normalized.includes(pattern);
+  try {
+    return new RegExp(rule.descriptionPattern, 'i').test(description);
+  } catch {
+    return false;
+  }
+}
+
+function suggestFromRules(
+  description: string,
+  entityId: string | null,
+  rules: ProposedRule[],
+  vocabulary: Set<string>
+): TagSuggestion[] {
+  const normalized = description.toUpperCase();
+  const seen = new Set<string>();
+  const out: TagSuggestion[] = [];
+
+  for (const rule of rules) {
+    if (rule.entityId && rule.entityId !== entityId) continue;
+    if (!ruleMatchesDescription(rule, description, normalized)) continue;
+
+    for (const tag of rule.tags) {
+      if (seen.has(tag)) continue;
+      seen.add(tag);
+      out.push({
+        tag,
+        source: 'tag_rule',
+        pattern: rule.descriptionPattern,
+        isNew: !vocabulary.has(tag.toLowerCase()),
+      });
+    }
+  }
+  return out;
+}
+
+export function previewTagRuleChangeSet(
+  db: FinanceDb,
+  args: {
+    changeSet: TagRuleChangeSet;
+    transactions: PreviewInputTransaction[];
+    maxPreviewItems: number;
+  }
+): { counts: TagRuleImpactCounts; affected: TagRuleImpactItem[] } {
+  const txs = args.transactions.slice(0, args.maxPreviewItems);
+  const vocabulary = new Set(
+    tagVocabularyService.listVocabularyTags(db).map((t) => t.toLowerCase())
+  );
+  const proposedRules = materializeProposedRules(args.changeSet);
+
+  const affected: TagRuleImpactItem[] = [];
+  for (const t of txs) {
+    if (t.userTags && t.userTags.length > 0) continue;
+
+    const after = suggestFromRules(t.description, t.entityId ?? null, proposedRules, vocabulary);
+    const before: TagSuggestion[] = [];
+    if (JSON.stringify(before) !== JSON.stringify(after)) {
+      affected.push({
+        transactionId: t.transactionId,
+        description: t.description,
+        before: { suggestedTags: before },
+        after: { suggestedTags: after },
+      });
+    }
+  }
+
+  const newTagProposals = affected
+    .flatMap((a) => a.after.suggestedTags)
+    .filter((t) => t.isNew).length;
+
+  return {
+    counts: { affected: affected.length, suggestionChanges: affected.length, newTagProposals },
+    affected,
+  };
+}

--- a/pillars/finance/src/api/modules/tag-rules/service.ts
+++ b/pillars/finance/src/api/modules/tag-rules/service.ts
@@ -1,0 +1,142 @@
+/**
+ * Tag-rule ChangeSet service — propose (deterministic) + apply.
+ *
+ * Ported from `apps/pops-api/src/modules/core/tag-rules/service.ts`, the
+ * only change being the `FinanceDb` handle is threaded explicitly. The
+ * `apply` path wraps the ops in a single db transaction so a partial
+ * ChangeSet never lands.
+ */
+import {
+  type FinanceDb,
+  transactionTagRulesService,
+  type TransactionTagRuleRow,
+} from '../../../db/index.js';
+import { previewTagRuleChangeSet } from './preview.js';
+
+import type { TagRuleChangeSet, TagRuleChangeSetOp } from '../../../contract/rest-tag-rules.js';
+import type { PreviewInputTransaction, TagRuleChangeSetProposal } from './types.js';
+
+/** Persisted rule with `tags` parsed from its JSON column to a `string[]`. */
+export interface TagRule {
+  id: string;
+  descriptionPattern: string;
+  matchType: 'exact' | 'contains' | 'regex';
+  entityId: string | null;
+  tags: string[];
+  isActive: boolean;
+  confidence: number;
+  priority: number;
+  timesApplied: number;
+  createdAt: string;
+  lastUsedAt: string | null;
+}
+
+function parseTags(raw: string): string[] {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return Array.isArray(parsed) ? parsed.filter((t): t is string => typeof t === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+
+export function toTagRule(row: TransactionTagRuleRow): TagRule {
+  return {
+    id: row.id,
+    descriptionPattern: row.descriptionPattern,
+    matchType: row.matchType,
+    entityId: row.entityId,
+    tags: parseTags(row.tags),
+    isActive: row.isActive,
+    confidence: row.confidence,
+    priority: row.priority,
+    timesApplied: row.timesApplied,
+    createdAt: row.createdAt,
+    lastUsedAt: row.lastUsedAt,
+  };
+}
+
+function applyOp(tx: FinanceDb, op: TagRuleChangeSetOp): void {
+  switch (op.op) {
+    case 'add':
+      transactionTagRulesService.createTransactionTagRule(tx, {
+        descriptionPattern: op.data.descriptionPattern,
+        matchType: op.data.matchType,
+        entityId: op.data.entityId ?? null,
+        tags: op.data.tags,
+        confidence: op.data.confidence ?? 0.95,
+        isActive: op.data.isActive ?? true,
+        priority: op.data.priority ?? 0,
+      });
+      return;
+    case 'edit':
+      transactionTagRulesService.updateTransactionTagRule(tx, op.id, {
+        entityId: op.data.entityId,
+        tags: op.data.tags,
+        confidence: op.data.confidence,
+        isActive: op.data.isActive,
+        priority: op.data.priority,
+      });
+      return;
+    case 'disable':
+      transactionTagRulesService.disableTransactionTagRule(tx, op.id);
+      return;
+    case 'remove':
+      transactionTagRulesService.deleteTransactionTagRule(tx, op.id);
+  }
+}
+
+export function applyTagRuleChangeSet(db: FinanceDb, changeSet: TagRuleChangeSet): TagRule[] {
+  return db.transaction((tx) => {
+    for (const op of changeSet.ops) applyOp(tx, op);
+    return transactionTagRulesService.listTransactionTagRules(tx).map(toTagRule);
+  });
+}
+
+export function proposeTagRuleChangeSet(
+  db: FinanceDb,
+  args: {
+    signal: {
+      descriptionPattern: string;
+      matchType: 'exact' | 'contains' | 'regex';
+      entityId?: string | null;
+      tags: string[];
+    };
+    transactions: PreviewInputTransaction[];
+    maxPreviewItems: number;
+    rejectionFeedback?: string;
+  }
+): TagRuleChangeSetProposal {
+  const changeSet: TagRuleChangeSet = {
+    source: 'tag-edit-signal',
+    reason: args.rejectionFeedback
+      ? `Revised tag rule incorporating rejection feedback: ${args.rejectionFeedback}`
+      : 'Create new tag rule from tag edit signal',
+    ops: [
+      {
+        op: 'add',
+        data: {
+          descriptionPattern: args.signal.descriptionPattern,
+          matchType: args.signal.matchType,
+          entityId: args.signal.entityId ?? null,
+          tags: args.signal.tags,
+          confidence: 0.95,
+          isActive: true,
+        },
+      },
+    ],
+  };
+
+  const preview = previewTagRuleChangeSet(db, {
+    changeSet,
+    transactions: args.transactions,
+    maxPreviewItems: args.maxPreviewItems,
+  });
+
+  const baseRationale = `Add new tag rule (${args.signal.matchType}:${args.signal.descriptionPattern}) from tag edit signal`;
+  const rationale = args.rejectionFeedback
+    ? `${baseRationale} — revised after rejection: "${args.rejectionFeedback}"`
+    : baseRationale;
+
+  return { changeSet, rationale, preview };
+}

--- a/pillars/finance/src/api/modules/tag-rules/types.ts
+++ b/pillars/finance/src/api/modules/tag-rules/types.ts
@@ -1,0 +1,53 @@
+/**
+ * Internal TS shapes for the tag-rules domain logic. The zod request/
+ * response schemas live in the REST contract (`rest-tag-rules.ts`); these
+ * interfaces back the deterministic preview/propose computation.
+ */
+import type { TagRuleChangeSet } from '../../../contract/rest-tag-rules.js';
+
+export type TagSuggestionSource = 'tag_rule' | 'rule' | 'ai' | 'entity';
+
+export interface TagSuggestion {
+  tag: string;
+  source: TagSuggestionSource;
+  pattern?: string;
+  /** True when the tag is not yet in the user vocabulary. */
+  isNew?: boolean;
+}
+
+export interface TagRuleSuggestionOutcome {
+  suggestedTags: TagSuggestion[];
+}
+
+export interface TagRuleImpactCounts {
+  affected: number;
+  suggestionChanges: number;
+  newTagProposals: number;
+}
+
+export interface TagRuleImpactItem {
+  transactionId: string;
+  description: string;
+  before: TagRuleSuggestionOutcome;
+  after: TagRuleSuggestionOutcome;
+}
+
+export interface TagRulePreview {
+  counts: TagRuleImpactCounts;
+  affected: TagRuleImpactItem[];
+}
+
+export interface TagRuleChangeSetProposal {
+  changeSet: TagRuleChangeSet;
+  rationale: string;
+  preview: TagRulePreview;
+}
+
+/** A transaction the caller wants previewed against a ChangeSet. */
+export interface PreviewInputTransaction {
+  transactionId: string;
+  description: string;
+  entityId?: string | null;
+  /** User-entered tags in the current import; rule suggestions never override these. */
+  userTags?: string[];
+}

--- a/pillars/finance/src/api/rest/handlers.ts
+++ b/pillars/finance/src/api/rest/handlers.ts
@@ -10,6 +10,7 @@ import { initServer } from '@ts-rest/express';
 import { financeContract } from '../../contract/rest.js';
 import { type OpenedFinanceDb } from '../../db/index.js';
 import { makeBudgetsHandlers } from './budgets-handlers.js';
+import { makeTagRulesHandlers } from './tag-rules-handlers.js';
 import { makeTransactionsHandlers } from './transactions-handlers.js';
 import { makeWishlistHandlers } from './wishlist-handlers.js';
 
@@ -23,5 +24,6 @@ export function makeFinanceRestHandlers(deps: {
     wishlist: makeWishlistHandlers(db),
     budgets: makeBudgetsHandlers(db),
     transactions: makeTransactionsHandlers(db),
+    tagRules: makeTagRulesHandlers(db),
   });
 }

--- a/pillars/finance/src/api/rest/tag-rules-handlers.ts
+++ b/pillars/finance/src/api/rest/tag-rules-handlers.ts
@@ -1,0 +1,86 @@
+/**
+ * Handlers for the `tagRules.*` sub-router. The propose/preview paths are
+ * pure deterministic computations over caller-supplied transactions; apply
+ * mutates `transaction_tag_rules` (and upserts accepted vocabulary tags)
+ * inside a single db transaction.
+ *
+ * `TransactionTagRuleNotFoundError` (an edit/disable/remove op on an unknown
+ * id) maps to 404 via the shared `HttpError` path.
+ */
+import {
+  type FinanceDb,
+  tagVocabularyService,
+  TransactionTagRuleNotFoundError,
+} from '../../db/index.js';
+import { previewTagRuleChangeSet } from '../modules/tag-rules/preview.js';
+import { applyTagRuleChangeSet, proposeTagRuleChangeSet } from '../modules/tag-rules/service.js';
+import { NotFoundError } from '../shared/errors.js';
+import { runHttp } from './error-mapping.js';
+
+import type { ServerInferRequest } from '@ts-rest/core';
+
+import type { financeTagRulesContract } from '../../contract/rest-tag-rules.js';
+
+type Req = ServerInferRequest<typeof financeTagRulesContract>;
+
+export function makeTagRulesHandlers(db: FinanceDb) {
+  return {
+    vocabulary: () =>
+      runHttp(() => ({
+        status: 200 as const,
+        body: { tags: tagVocabularyService.listVocabularyTags(db) },
+      })),
+
+    propose: ({ body }: Req['propose']) =>
+      runHttp(() => ({
+        status: 200 as const,
+        body: proposeTagRuleChangeSet(db, {
+          signal: body.signal,
+          transactions: body.transactions,
+          maxPreviewItems: body.maxPreviewItems,
+        }),
+      })),
+
+    preview: ({ body }: Req['preview']) =>
+      runHttp(() => ({
+        status: 200 as const,
+        body: previewTagRuleChangeSet(db, {
+          changeSet: body.changeSet,
+          transactions: body.transactions,
+          maxPreviewItems: body.maxPreviewItems,
+        }),
+      })),
+
+    apply: ({ body }: Req['apply']) =>
+      runHttp(() => {
+        try {
+          for (const tag of body.acceptedNewTags) {
+            if (tag.trim()) tagVocabularyService.upsertVocabularyTag(db, tag.trim(), 'user');
+          }
+          const rules = applyTagRuleChangeSet(db, body.changeSet);
+          return { status: 200 as const, body: { rules } };
+        } catch (err) {
+          if (err instanceof TransactionTagRuleNotFoundError) {
+            throw new NotFoundError('transaction_tag_rules', err.id);
+          }
+          throw err;
+        }
+      }),
+
+    reject: ({ body }: Req['reject']) =>
+      runHttp(() => {
+        const followUpProposal = body.signal
+          ? proposeTagRuleChangeSet(db, {
+              signal: body.signal,
+              transactions: body.transactions ?? [],
+              maxPreviewItems: body.maxPreviewItems,
+              rejectionFeedback: body.feedback,
+            })
+          : null;
+        return {
+          status: 200 as const,
+          body: { message: 'Tag rule ChangeSet rejected', followUpProposal },
+        };
+      }),
+  };
+}

--- a/pillars/finance/src/contract/api-types.generated.ts
+++ b/pillars/finance/src/contract/api-types.generated.ts
@@ -40,6 +40,91 @@ export interface paths {
     patch: operations['budgets.update'];
     trace?: never;
   };
+  '/tag-rules/apply': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Apply a tag-rule ChangeSet; upserts accepted new vocabulary tags */
+    post: operations['tagRules.apply'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/tag-rules/preview': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Preview the suggestion-impact of a tag-rule ChangeSet over the supplied transactions */
+    post: operations['tagRules.preview'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/tag-rules/propose': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Propose a tag-rule ChangeSet from a tag-edit signal (deterministic, with impact preview) */
+    post: operations['tagRules.propose'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/tag-rules/reject': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Reject a ChangeSet with feedback; optionally returns a revised follow-up proposal */
+    post: operations['tagRules.reject'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/tag-rules/vocabulary': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** List the user tag vocabulary */
+    get: operations['tagRules.vocabulary'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/transactions': {
     parameters: {
       query?: never;
@@ -494,6 +579,663 @@ export interface operations {
             code?: string;
             message: string;
             messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'tagRules.apply': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          /** @default [] */
+          acceptedNewTags: string[];
+          changeSet: {
+            ops: (
+              | {
+                  data: {
+                    confidence?: number;
+                    descriptionPattern: string;
+                    entityId?: string | null;
+                    isActive?: boolean;
+                    /**
+                     * @default exact
+                     * @enum {string}
+                     */
+                    matchType: 'exact' | 'contains' | 'regex';
+                    priority?: number;
+                    tags: string[];
+                  };
+                  /** @enum {string} */
+                  op: 'add';
+                }
+              | {
+                  data: {
+                    confidence?: number;
+                    entityId?: string | null;
+                    isActive?: boolean;
+                    priority?: number;
+                    tags?: string[];
+                  };
+                  id: string;
+                  /** @enum {string} */
+                  op: 'edit';
+                }
+              | {
+                  id: string;
+                  /** @enum {string} */
+                  op: 'disable';
+                }
+              | {
+                  id: string;
+                  /** @enum {string} */
+                  op: 'remove';
+                }
+            )[];
+            reason?: string;
+            source?: string;
+          };
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            rules: {
+              confidence: number;
+              createdAt: string;
+              descriptionPattern: string;
+              entityId: string | null;
+              id: string;
+              isActive: boolean;
+              lastUsedAt: string | null;
+              /** @enum {string} */
+              matchType: 'exact' | 'contains' | 'regex';
+              priority: number;
+              tags: string[];
+              timesApplied: number;
+            }[];
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'tagRules.preview': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          changeSet: {
+            ops: (
+              | {
+                  data: {
+                    confidence?: number;
+                    descriptionPattern: string;
+                    entityId?: string | null;
+                    isActive?: boolean;
+                    /**
+                     * @default exact
+                     * @enum {string}
+                     */
+                    matchType: 'exact' | 'contains' | 'regex';
+                    priority?: number;
+                    tags: string[];
+                  };
+                  /** @enum {string} */
+                  op: 'add';
+                }
+              | {
+                  data: {
+                    confidence?: number;
+                    entityId?: string | null;
+                    isActive?: boolean;
+                    priority?: number;
+                    tags?: string[];
+                  };
+                  id: string;
+                  /** @enum {string} */
+                  op: 'edit';
+                }
+              | {
+                  id: string;
+                  /** @enum {string} */
+                  op: 'disable';
+                }
+              | {
+                  id: string;
+                  /** @enum {string} */
+                  op: 'remove';
+                }
+            )[];
+            reason?: string;
+            source?: string;
+          };
+          /** @default 200 */
+          maxPreviewItems: number;
+          transactions: {
+            description: string;
+            entityId?: string | null;
+            transactionId: string;
+            userTags?: string[];
+          }[];
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            affected: {
+              after: {
+                suggestedTags: {
+                  isNew?: boolean;
+                  pattern?: string;
+                  /** @enum {string} */
+                  source: 'tag_rule' | 'rule' | 'ai' | 'entity';
+                  tag: string;
+                }[];
+              };
+              before: {
+                suggestedTags: {
+                  isNew?: boolean;
+                  pattern?: string;
+                  /** @enum {string} */
+                  source: 'tag_rule' | 'rule' | 'ai' | 'entity';
+                  tag: string;
+                }[];
+              };
+              description: string;
+              transactionId: string;
+            }[];
+            counts: {
+              affected: number;
+              newTagProposals: number;
+              suggestionChanges: number;
+            };
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'tagRules.propose': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          /** @default 200 */
+          maxPreviewItems: number;
+          signal: {
+            descriptionPattern: string;
+            entityId?: string | null;
+            /** @enum {string} */
+            matchType: 'exact' | 'contains' | 'regex';
+            tags: string[];
+          };
+          /** @default [] */
+          transactions: {
+            description: string;
+            entityId?: string | null;
+            transactionId: string;
+            userTags?: string[];
+          }[];
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            changeSet: {
+              ops: (
+                | {
+                    data: {
+                      confidence?: number;
+                      descriptionPattern: string;
+                      entityId?: string | null;
+                      isActive?: boolean;
+                      /**
+                       * @default exact
+                       * @enum {string}
+                       */
+                      matchType: 'exact' | 'contains' | 'regex';
+                      priority?: number;
+                      tags: string[];
+                    };
+                    /** @enum {string} */
+                    op: 'add';
+                  }
+                | {
+                    data: {
+                      confidence?: number;
+                      entityId?: string | null;
+                      isActive?: boolean;
+                      priority?: number;
+                      tags?: string[];
+                    };
+                    id: string;
+                    /** @enum {string} */
+                    op: 'edit';
+                  }
+                | {
+                    id: string;
+                    /** @enum {string} */
+                    op: 'disable';
+                  }
+                | {
+                    id: string;
+                    /** @enum {string} */
+                    op: 'remove';
+                  }
+              )[];
+              reason?: string;
+              source?: string;
+            };
+            preview: {
+              affected: {
+                after: {
+                  suggestedTags: {
+                    isNew?: boolean;
+                    pattern?: string;
+                    /** @enum {string} */
+                    source: 'tag_rule' | 'rule' | 'ai' | 'entity';
+                    tag: string;
+                  }[];
+                };
+                before: {
+                  suggestedTags: {
+                    isNew?: boolean;
+                    pattern?: string;
+                    /** @enum {string} */
+                    source: 'tag_rule' | 'rule' | 'ai' | 'entity';
+                    tag: string;
+                  }[];
+                };
+                description: string;
+                transactionId: string;
+              }[];
+              counts: {
+                affected: number;
+                newTagProposals: number;
+                suggestionChanges: number;
+              };
+            };
+            rationale: string;
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'tagRules.reject': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          changeSet: {
+            ops: (
+              | {
+                  data: {
+                    confidence?: number;
+                    descriptionPattern: string;
+                    entityId?: string | null;
+                    isActive?: boolean;
+                    /**
+                     * @default exact
+                     * @enum {string}
+                     */
+                    matchType: 'exact' | 'contains' | 'regex';
+                    priority?: number;
+                    tags: string[];
+                  };
+                  /** @enum {string} */
+                  op: 'add';
+                }
+              | {
+                  data: {
+                    confidence?: number;
+                    entityId?: string | null;
+                    isActive?: boolean;
+                    priority?: number;
+                    tags?: string[];
+                  };
+                  id: string;
+                  /** @enum {string} */
+                  op: 'edit';
+                }
+              | {
+                  id: string;
+                  /** @enum {string} */
+                  op: 'disable';
+                }
+              | {
+                  id: string;
+                  /** @enum {string} */
+                  op: 'remove';
+                }
+            )[];
+            reason?: string;
+            source?: string;
+          };
+          feedback: string;
+          /** @default 200 */
+          maxPreviewItems: number;
+          signal?: {
+            descriptionPattern: string;
+            entityId?: string | null;
+            /** @enum {string} */
+            matchType: 'exact' | 'contains' | 'regex';
+            tags: string[];
+          };
+          transactions?: {
+            description: string;
+            entityId?: string | null;
+            transactionId: string;
+            userTags?: string[];
+          }[];
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            followUpProposal: {
+              changeSet: {
+                ops: (
+                  | {
+                      data: {
+                        confidence?: number;
+                        descriptionPattern: string;
+                        entityId?: string | null;
+                        isActive?: boolean;
+                        /**
+                         * @default exact
+                         * @enum {string}
+                         */
+                        matchType: 'exact' | 'contains' | 'regex';
+                        priority?: number;
+                        tags: string[];
+                      };
+                      /** @enum {string} */
+                      op: 'add';
+                    }
+                  | {
+                      data: {
+                        confidence?: number;
+                        entityId?: string | null;
+                        isActive?: boolean;
+                        priority?: number;
+                        tags?: string[];
+                      };
+                      id: string;
+                      /** @enum {string} */
+                      op: 'edit';
+                    }
+                  | {
+                      id: string;
+                      /** @enum {string} */
+                      op: 'disable';
+                    }
+                  | {
+                      id: string;
+                      /** @enum {string} */
+                      op: 'remove';
+                    }
+                )[];
+                reason?: string;
+                source?: string;
+              };
+              preview: {
+                affected: {
+                  after: {
+                    suggestedTags: {
+                      isNew?: boolean;
+                      pattern?: string;
+                      /** @enum {string} */
+                      source: 'tag_rule' | 'rule' | 'ai' | 'entity';
+                      tag: string;
+                    }[];
+                  };
+                  before: {
+                    suggestedTags: {
+                      isNew?: boolean;
+                      pattern?: string;
+                      /** @enum {string} */
+                      source: 'tag_rule' | 'rule' | 'ai' | 'entity';
+                      tag: string;
+                    }[];
+                  };
+                  description: string;
+                  transactionId: string;
+                }[];
+                counts: {
+                  affected: number;
+                  newTagProposals: number;
+                  suggestionChanges: number;
+                };
+              };
+              rationale: string;
+            } | null;
+            message: string;
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'tagRules.vocabulary': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            tags: string[];
           };
         };
       };

--- a/pillars/finance/src/contract/rest-tag-rules.ts
+++ b/pillars/finance/src/contract/rest-tag-rules.ts
@@ -1,0 +1,180 @@
+/**
+ * `tagRules.*` sub-router — the tag-suggestion rule surface (vocabulary +
+ * ChangeSet propose/preview/apply/reject).
+ *
+ * This domain is finance-owned (the `transaction_tag_rules` + `tag_vocabulary`
+ * tables live in the finance db) but is served today from the monolith's
+ * `core.tagRules.*` tRPC router. The REST shape here is the migration target;
+ * the propose/preview computations are deterministic (no AI) and operate on
+ * caller-supplied transactions, so the domain has no cross-pillar coupling.
+ *
+ * tRPC `query` procedures that carry a request body (propose/preview) become
+ * `POST` here — a GET cannot carry the transactions array.
+ */
+import { initContract } from '@ts-rest/core';
+import { z } from 'zod';
+
+import { ERR_RESPONSES } from './rest-schemas.js';
+
+const c = initContract();
+
+const MatchTypeSchema = z.enum(['exact', 'contains', 'regex']);
+
+const TagRuleDataSchema = z.object({
+  descriptionPattern: z.string().min(1),
+  matchType: MatchTypeSchema.default('exact'),
+  entityId: z.string().nullable().optional(),
+  tags: z.array(z.string()).min(1),
+  confidence: z.number().min(0).max(1).optional(),
+  isActive: z.boolean().optional(),
+  priority: z.number().int().nonnegative().optional(),
+});
+
+const TagRuleUpdateSchema = z.object({
+  entityId: z.string().nullable().optional(),
+  tags: z.array(z.string()).optional(),
+  confidence: z.number().min(0).max(1).optional(),
+  isActive: z.boolean().optional(),
+  priority: z.number().int().nonnegative().optional(),
+});
+
+export const TagRuleChangeSetOpSchema = z.discriminatedUnion('op', [
+  z.object({ op: z.literal('add'), data: TagRuleDataSchema }),
+  z.object({ op: z.literal('edit'), id: z.string().min(1), data: TagRuleUpdateSchema }),
+  z.object({ op: z.literal('disable'), id: z.string().min(1) }),
+  z.object({ op: z.literal('remove'), id: z.string().min(1) }),
+]);
+
+export const TagRuleChangeSetSchema = z.object({
+  source: z.string().optional(),
+  reason: z.string().optional(),
+  ops: z.array(TagRuleChangeSetOpSchema).min(1),
+});
+
+export type TagRuleChangeSetOp = z.infer<typeof TagRuleChangeSetOpSchema>;
+export type TagRuleChangeSet = z.infer<typeof TagRuleChangeSetSchema>;
+
+const TagRuleSignalSchema = z.object({
+  descriptionPattern: z.string().min(1),
+  matchType: MatchTypeSchema,
+  entityId: z.string().nullable().optional(),
+  tags: z.array(z.string()).min(1),
+});
+
+const PreviewInputTransactionSchema = z.object({
+  transactionId: z.string().min(1),
+  description: z.string().min(1),
+  entityId: z.string().nullable().optional(),
+  userTags: z.array(z.string()).optional(),
+});
+
+const TagSuggestionSchema = z.object({
+  tag: z.string(),
+  source: z.enum(['tag_rule', 'rule', 'ai', 'entity']),
+  pattern: z.string().optional(),
+  isNew: z.boolean().optional(),
+});
+
+const TagRuleSuggestionOutcomeSchema = z.object({ suggestedTags: z.array(TagSuggestionSchema) });
+
+const TagRuleImpactItemSchema = z.object({
+  transactionId: z.string(),
+  description: z.string(),
+  before: TagRuleSuggestionOutcomeSchema,
+  after: TagRuleSuggestionOutcomeSchema,
+});
+
+const TagRuleImpactCountsSchema = z.object({
+  affected: z.number(),
+  suggestionChanges: z.number(),
+  newTagProposals: z.number(),
+});
+
+const TagRulePreviewSchema = z.object({
+  counts: TagRuleImpactCountsSchema,
+  affected: z.array(TagRuleImpactItemSchema),
+});
+
+const TagRuleChangeSetProposalSchema = z.object({
+  changeSet: TagRuleChangeSetSchema,
+  rationale: z.string(),
+  preview: TagRulePreviewSchema,
+});
+
+/** Persisted rule row, with `tags` parsed to a `string[]` (column is JSON). */
+export const TagRuleSchema = z.object({
+  id: z.string(),
+  descriptionPattern: z.string(),
+  matchType: MatchTypeSchema,
+  entityId: z.string().nullable(),
+  tags: z.array(z.string()),
+  isActive: z.boolean(),
+  confidence: z.number(),
+  priority: z.number(),
+  timesApplied: z.number(),
+  createdAt: z.string(),
+  lastUsedAt: z.string().nullable(),
+});
+
+const MaxPreviewItems = z.coerce.number().int().positive().max(500).default(200);
+
+export const financeTagRulesContract = c.router({
+  vocabulary: {
+    method: 'GET',
+    path: '/tag-rules/vocabulary',
+    responses: { 200: z.object({ tags: z.array(z.string()) }) },
+    summary: 'List the user tag vocabulary',
+  },
+  propose: {
+    method: 'POST',
+    path: '/tag-rules/propose',
+    body: z.object({
+      signal: TagRuleSignalSchema,
+      transactions: z.array(PreviewInputTransactionSchema).default([]),
+      maxPreviewItems: MaxPreviewItems,
+    }),
+    responses: { 200: TagRuleChangeSetProposalSchema, ...ERR_RESPONSES },
+    summary:
+      'Propose a tag-rule ChangeSet from a tag-edit signal (deterministic, with impact preview)',
+  },
+  preview: {
+    method: 'POST',
+    path: '/tag-rules/preview',
+    body: z.object({
+      changeSet: TagRuleChangeSetSchema,
+      transactions: z.array(PreviewInputTransactionSchema),
+      maxPreviewItems: MaxPreviewItems,
+    }),
+    responses: { 200: TagRulePreviewSchema, ...ERR_RESPONSES },
+    summary: 'Preview the suggestion-impact of a tag-rule ChangeSet over the supplied transactions',
+  },
+  apply: {
+    method: 'POST',
+    path: '/tag-rules/apply',
+    body: z.object({
+      changeSet: TagRuleChangeSetSchema,
+      acceptedNewTags: z.array(z.string()).default([]),
+    }),
+    responses: { 200: z.object({ rules: z.array(TagRuleSchema) }), ...ERR_RESPONSES },
+    summary: 'Apply a tag-rule ChangeSet; upserts accepted new vocabulary tags',
+  },
+  reject: {
+    method: 'POST',
+    path: '/tag-rules/reject',
+    body: z.object({
+      changeSet: TagRuleChangeSetSchema,
+      feedback: z.string().min(1),
+      signal: TagRuleSignalSchema.optional(),
+      transactions: z.array(PreviewInputTransactionSchema).optional(),
+      maxPreviewItems: MaxPreviewItems,
+    }),
+    responses: {
+      200: z.object({
+        message: z.string(),
+        followUpProposal: TagRuleChangeSetProposalSchema.nullable(),
+      }),
+      ...ERR_RESPONSES,
+    },
+    summary: 'Reject a ChangeSet with feedback; optionally returns a revised follow-up proposal',
+  },
+});

--- a/pillars/finance/src/contract/rest.ts
+++ b/pillars/finance/src/contract/rest.ts
@@ -2,7 +2,7 @@
  * REST contract for the finance pillar — ts-rest single source of truth.
  *
  * Composes the migrated domain sub-routers (wishlist, budgets,
- * transactions) into the public wire surface.
+ * transactions, tagRules) into the public wire surface.
  * `generateOpenApi(financeContract, …)` projects this to
  * `openapi/finance.openapi.json`; `openapi-typescript` then projects the
  * JSON to `src/contract/api-types.generated.ts`.
@@ -13,6 +13,7 @@
 import { initContract } from '@ts-rest/core';
 
 import { financeBudgetsContract } from './rest-budgets.js';
+import { financeTagRulesContract } from './rest-tag-rules.js';
 import { financeTransactionsContract } from './rest-transactions.js';
 import { financeWishlistContract } from './rest-wishlist.js';
 
@@ -23,6 +24,7 @@ export const financeContract = c.router(
     wishlist: financeWishlistContract,
     budgets: financeBudgetsContract,
     transactions: financeTransactionsContract,
+    tagRules: financeTagRulesContract,
   },
   {
     pathPrefix: '',


### PR DESCRIPTION
## Finance REST migration — slice 2

Adds the **tag-rules** domain to `pillars/finance` (builds on slice 1, #3344).

`core/tag-rules` turned out to be fully **finance-owned and self-contained**: it reads/writes only finance-db (`transaction_tag_rules` + `tag_vocabulary`) and runs a deterministic suggestion-impact preview over caller-supplied transactions — no AI, no core/corrections, no cross-pillar coupling. So it ports cleanly into the pillar as a ts-rest domain.

### Endpoints
- `GET /tag-rules/vocabulary` — list user tag vocabulary
- `POST /tag-rules/propose` — deterministic ChangeSet proposal + impact preview
- `POST /tag-rules/preview` — preview a ChangeSet over supplied transactions
- `POST /tag-rules/apply` — apply ops in one db transaction; upsert accepted new tags; 404 on unknown rule
- `POST /tag-rules/reject` — record feedback; optional revised follow-up proposal

(propose/preview are tRPC `query`s carrying a body → `POST` in REST.)

### Notes
- 7 supertest cases; 237 tests total green. OpenAPI + api-types regenerated.
- Monolith `core.tagRules.*` keeps serving during the transition (rewired in the FE slice, deleted in cleanup).
- Pure addition to `pillars/finance` — no other bubble touched.