### PR TITLE
feat(food): REST migration slice 3a — batches + fridge

### DIFF
--- a/pillars/food/openapi/food.openapi.json
+++ b/pillars/food/openapi/food.openapi.json
@@ -920,6 +920,867 @@
         "tags": ["aliases"]
       }
     },
+    "/batches": {
+      "post": {
+        "operationId": "batches.create",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "expiresAt": {
+                    "type": "string"
+                  },
+                  "location": {
+                    "enum": ["pantry", "fridge", "freezer", "other"],
+                    "type": "string"
+                  },
+                  "notes": {
+                    "maxLength": 1000,
+                    "type": "string"
+                  },
+                  "prepStateId": {
+                    "exclusiveMinimum": true,
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "nullable": true,
+                    "type": "integer"
+                  },
+                  "producedAt": {
+                    "type": "string"
+                  },
+                  "qty": {
+                    "minimum": 0,
+                    "type": "number"
+                  },
+                  "sourceType": {
+                    "enum": ["purchase", "gift", "other"],
+                    "type": "string"
+                  },
+                  "unit": {
+                    "enum": ["g", "ml", "count"],
+                    "type": "string"
+                  },
+                  "variantId": {
+                    "exclusiveMinimum": true,
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
+                "required": ["variantId", "prepStateId", "qty", "unit", "location", "sourceType"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "batchId": {
+                      "exclusiveMinimum": true,
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["batchId"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "201"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Create a manual batch",
+        "tags": ["batches"]
+      }
+    },
+    "/batches/search-for-consume": {
+      "post": {
+        "operationId": "batches.searchForConsume",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "ingredientId": {
+                    "exclusiveMinimum": true,
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "limit": {
+                    "exclusiveMinimum": true,
+                    "maximum": 100,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "location": {
+                    "enum": ["pantry", "fridge", "freezer", "other"],
+                    "type": "string"
+                  },
+                  "qtyGreaterThan": {
+                    "minimum": 0,
+                    "type": "number"
+                  },
+                  "variantId": {
+                    "exclusiveMinimum": true,
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "items": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "expiresAt": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "id": {
+                            "exclusiveMinimum": true,
+                            "maximum": 9007199254740991,
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "ingredientId": {
+                            "exclusiveMinimum": true,
+                            "maximum": 9007199254740991,
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "ingredientName": {
+                            "type": "string"
+                          },
+                          "location": {
+                            "enum": ["pantry", "fridge", "freezer", "other"],
+                            "type": "string"
+                          },
+                          "prepStateId": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "nullable": true,
+                            "type": "integer"
+                          },
+                          "prepStateLabel": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "producedAt": {
+                            "type": "string"
+                          },
+                          "qtyRemaining": {
+                            "type": "number"
+                          },
+                          "unit": {
+                            "enum": ["g", "ml", "count"],
+                            "type": "string"
+                          },
+                          "variantId": {
+                            "exclusiveMinimum": true,
+                            "maximum": 9007199254740991,
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "variantName": {
+                            "type": "string"
+                          },
+                          "variantSlug": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "variantId",
+                          "variantName",
+                          "variantSlug",
+                          "ingredientId",
+                          "ingredientName",
+                          "prepStateId",
+                          "prepStateLabel",
+                          "qtyRemaining",
+                          "unit",
+                          "location",
+                          "expiresAt",
+                          "producedAt"
+                        ],
+                        "type": "object"
+                      },
+                      "readOnly": true,
+                      "type": "array"
+                    }
+                  },
+                  "required": ["items"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "FIFO-ordered batches for the consume/override picker",
+        "tags": ["batches"]
+      }
+    },
+    "/batches/{id}": {
+      "delete": {
+        "operationId": "batches.delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {},
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "ok": {
+                          "enum": [true],
+                          "type": "boolean"
+                        }
+                      },
+                      "required": ["ok"],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "ok": {
+                          "enum": [false],
+                          "type": "boolean"
+                        },
+                        "reason": {
+                          "enum": [
+                            "BatchNotFound",
+                            "BatchDeleted",
+                            "NegativeQty",
+                            "CannotEditFromRun",
+                            "BadExpiry",
+                            "BadAdjustment"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": ["ok", "reason"],
+                      "type": "object"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Soft-delete a batch",
+        "tags": ["batches"]
+      },
+      "get": {
+        "operationId": "batches.get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "createdAt": {
+                          "type": "string"
+                        },
+                        "deletedAt": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "expiresAt": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "id": {
+                          "exclusiveMinimum": true,
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "ingredientId": {
+                          "exclusiveMinimum": true,
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "ingredientName": {
+                          "type": "string"
+                        },
+                        "ingredientSlug": {
+                          "type": "string"
+                        },
+                        "location": {
+                          "enum": ["pantry", "fridge", "freezer", "other"],
+                          "type": "string"
+                        },
+                        "notes": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "prepStateId": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "prepStateLabel": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "producedAt": {
+                          "type": "string"
+                        },
+                        "qtyRemaining": {
+                          "type": "number"
+                        },
+                        "sourceId": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "sourceRecipeRunId": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "sourceRecipeSlug": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "sourceType": {
+                          "enum": ["purchase", "recipe_run", "gift", "other"],
+                          "type": "string"
+                        },
+                        "unit": {
+                          "enum": ["g", "ml", "count"],
+                          "type": "string"
+                        },
+                        "variantId": {
+                          "exclusiveMinimum": true,
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "variantName": {
+                          "type": "string"
+                        },
+                        "variantSlug": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "variantId",
+                        "variantName",
+                        "variantSlug",
+                        "ingredientId",
+                        "ingredientName",
+                        "ingredientSlug",
+                        "prepStateId",
+                        "prepStateLabel",
+                        "qtyRemaining",
+                        "unit",
+                        "sourceType",
+                        "sourceId",
+                        "sourceRecipeRunId",
+                        "sourceRecipeSlug",
+                        "location",
+                        "producedAt",
+                        "expiresAt",
+                        "notes",
+                        "deletedAt",
+                        "createdAt"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": ["data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Get a batch with resolved variant / ingredient / source",
+        "tags": ["batches"]
+      },
+      "patch": {
+        "operationId": "batches.edit",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "expiresAt": {
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "notes": {
+                    "maxLength": 1000,
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "prepStateId": {
+                    "exclusiveMinimum": true,
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "nullable": true,
+                    "type": "integer"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "ok": {
+                          "enum": [true],
+                          "type": "boolean"
+                        }
+                      },
+                      "required": ["ok"],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "ok": {
+                          "enum": [false],
+                          "type": "boolean"
+                        },
+                        "reason": {
+                          "enum": [
+                            "BatchNotFound",
+                            "BatchDeleted",
+                            "NegativeQty",
+                            "CannotEditFromRun",
+                            "BadExpiry",
+                            "BadAdjustment"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": ["ok", "reason"],
+                      "type": "object"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Edit a batch (expiry / notes / prep state)",
+        "tags": ["batches"]
+      }
+    },
+    "/batches/{id}/adjust": {
+      "post": {
+        "operationId": "batches.adjustQty",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "delta": {
+                    "type": "number"
+                  },
+                  "reason": {
+                    "enum": ["spoiled", "wasted", "correction"],
+                    "type": "string"
+                  }
+                },
+                "required": ["delta", "reason"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "newQty": {
+                          "type": "number"
+                        },
+                        "ok": {
+                          "enum": [true],
+                          "type": "boolean"
+                        }
+                      },
+                      "required": ["ok", "newQty"],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "ok": {
+                          "enum": [false],
+                          "type": "boolean"
+                        },
+                        "reason": {
+                          "enum": [
+                            "BatchNotFound",
+                            "BatchDeleted",
+                            "NegativeQty",
+                            "CannotEditFromRun",
+                            "BadExpiry",
+                            "BadAdjustment"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": ["ok", "reason"],
+                      "type": "object"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Adjust a batch quantity (spoiled / wasted / correction)",
+        "tags": ["batches"]
+      }
+    },
+    "/batches/{id}/relocate": {
+      "post": {
+        "operationId": "batches.relocate",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "location": {
+                    "enum": ["pantry", "fridge", "freezer", "other"],
+                    "type": "string"
+                  }
+                },
+                "required": ["location"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "ok": {
+                          "enum": [true],
+                          "type": "boolean"
+                        }
+                      },
+                      "required": ["ok"],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "ok": {
+                          "enum": [false],
+                          "type": "boolean"
+                        },
+                        "reason": {
+                          "enum": [
+                            "BatchNotFound",
+                            "BatchDeleted",
+                            "NegativeQty",
+                            "CannotEditFromRun",
+                            "BadExpiry",
+                            "BadAdjustment"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": ["ok", "reason"],
+                      "type": "object"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Move a batch to another location",
+        "tags": ["batches"]
+      }
+    },
     "/conversions/resolve": {
       "get": {
         "operationId": "conversions.resolve",
@@ -2158,6 +3019,311 @@
         },
         "summary": "Update an ingredient weight",
         "tags": ["conversions"]
+      }
+    },
+    "/fridge/recipes-using-batch": {
+      "get": {
+        "operationId": "fridge.recipesUsingBatch",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "batchId",
+            "required": true,
+            "schema": {
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "exclusiveMinimum": true,
+              "maximum": 100,
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "items": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "lastCookedAt": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "lineCount": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "type": "integer"
+                          },
+                          "recipeId": {
+                            "exclusiveMinimum": true,
+                            "maximum": 9007199254740991,
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "recipeNeedsQty": {
+                            "nullable": true,
+                            "type": "number"
+                          },
+                          "recipeSlug": {
+                            "type": "string"
+                          },
+                          "recipeType": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "recipeId",
+                          "recipeSlug",
+                          "title",
+                          "recipeType",
+                          "lineCount",
+                          "recipeNeedsQty",
+                          "lastCookedAt"
+                        ],
+                        "type": "object"
+                      },
+                      "readOnly": true,
+                      "type": "array"
+                    }
+                  },
+                  "required": ["items"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Recipes that reference the batch’s variant (FIFO cook suggestions)",
+        "tags": ["fridge"]
+      }
+    },
+    "/fridge/view": {
+      "post": {
+        "operationId": "fridge.view",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "expiringSoon": {
+                    "type": "boolean"
+                  },
+                  "includeDeleted": {
+                    "type": "boolean"
+                  },
+                  "includeEmpty": {
+                    "type": "boolean"
+                  },
+                  "locations": {
+                    "items": {
+                      "enum": ["pantry", "fridge", "freezer", "other"],
+                      "type": "string"
+                    },
+                    "maxItems": 4,
+                    "minItems": 1,
+                    "type": "array"
+                  },
+                  "recipeYieldedOnly": {
+                    "type": "boolean"
+                  },
+                  "search": {
+                    "maxLength": 120,
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "counts": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "deleted": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer"
+                        },
+                        "empty": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer"
+                        },
+                        "visible": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer"
+                        }
+                      },
+                      "required": ["visible", "empty", "deleted"],
+                      "type": "object"
+                    },
+                    "sections": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "count": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "type": "integer"
+                          },
+                          "ingredients": {
+                            "items": {
+                              "additionalProperties": false,
+                              "properties": {
+                                "batches": {
+                                  "items": {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "daysToExpiry": {
+                                        "maximum": 9007199254740991,
+                                        "minimum": -9007199254740991,
+                                        "nullable": true,
+                                        "type": "integer"
+                                      },
+                                      "deletedAt": {
+                                        "nullable": true,
+                                        "type": "string"
+                                      },
+                                      "expiresAt": {
+                                        "nullable": true,
+                                        "type": "string"
+                                      },
+                                      "id": {
+                                        "exclusiveMinimum": true,
+                                        "maximum": 9007199254740991,
+                                        "minimum": 0,
+                                        "type": "integer"
+                                      },
+                                      "notes": {
+                                        "nullable": true,
+                                        "type": "string"
+                                      },
+                                      "prepStateLabel": {
+                                        "nullable": true,
+                                        "type": "string"
+                                      },
+                                      "producedAt": {
+                                        "type": "string"
+                                      },
+                                      "qtyRemaining": {
+                                        "type": "number"
+                                      },
+                                      "sourceRecipeSlug": {
+                                        "nullable": true,
+                                        "type": "string"
+                                      },
+                                      "sourceType": {
+                                        "enum": ["purchase", "recipe_run", "gift", "other"],
+                                        "type": "string"
+                                      },
+                                      "unit": {
+                                        "enum": ["g", "ml", "count"],
+                                        "type": "string"
+                                      },
+                                      "variantName": {
+                                        "nullable": true,
+                                        "type": "string"
+                                      },
+                                      "variantSlug": {
+                                        "nullable": true,
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "id",
+                                      "variantName",
+                                      "variantSlug",
+                                      "prepStateLabel",
+                                      "qtyRemaining",
+                                      "unit",
+                                      "expiresAt",
+                                      "daysToExpiry",
+                                      "producedAt",
+                                      "sourceType",
+                                      "sourceRecipeSlug",
+                                      "notes",
+                                      "deletedAt"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "readOnly": true,
+                                  "type": "array"
+                                },
+                                "ingredientId": {
+                                  "exclusiveMinimum": true,
+                                  "maximum": 9007199254740991,
+                                  "minimum": 0,
+                                  "type": "integer"
+                                },
+                                "ingredientName": {
+                                  "type": "string"
+                                },
+                                "ingredientSlug": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "ingredientId",
+                                "ingredientName",
+                                "ingredientSlug",
+                                "batches"
+                              ],
+                              "type": "object"
+                            },
+                            "readOnly": true,
+                            "type": "array"
+                          },
+                          "location": {
+                            "enum": ["pantry", "fridge", "freezer", "other"],
+                            "type": "string"
+                          }
+                        },
+                        "required": ["location", "count", "ingredients"],
+                        "type": "object"
+                      },
+                      "readOnly": true,
+                      "type": "array"
+                    }
+                  },
+                  "required": ["sections", "counts"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Fridge/pantry view grouped by location → ingredient → batch",
+        "tags": ["fridge"]
       }
     },
     "/ingredient-tags": {

--- a/pillars/food/src/api/__tests__/batches.test.ts
+++ b/pillars/food/src/api/__tests__/batches.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Integration tests for the `batches.*` REST surface — PRD-145 lifecycle +
+ * PRD-146 picker. Lifecycle mutations return the service's discriminated
+ * `{ ok, ... }` result (200); `create` answers 201/400; `get` 404s on a
+ * missing batch. Lifecycle invariants live in the db tests.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { type OpenedFoodDb, openFoodDb } from '../../db/index.js';
+import { createIngredient } from '../../db/services/ingredients.js';
+import { createVariant } from '../../db/services/variants.js';
+import { createFoodApiApp } from '../app.js';
+import { makeClient } from './test-utils.js';
+
+let tmpDir: string;
+let foodDb: OpenedFoodDb;
+let variantId: number;
+
+function client(): ReturnType<typeof makeClient> {
+  return makeClient(
+    createFoodApiApp({ foodDb, version: '0.0.1-test', selfBaseUrl: 'http://localhost:3005' })
+  );
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'food-api-batches-test-'));
+  foodDb = openFoodDb(join(tmpDir, 'food.db'));
+  const ing = createIngredient(foodDb.db, { name: 'Carrot', slug: 'carrot', defaultUnit: 'g' });
+  variantId = createVariant(foodDb.db, {
+    ingredientId: ing.id,
+    slug: 'carrot-loose',
+    name: 'Loose Carrot',
+    defaultUnit: 'g',
+  }).id;
+});
+
+afterEach(() => {
+  foodDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('batches REST — lifecycle', () => {
+  it('creates, gets, relocates, edits, adjusts and deletes a batch', async () => {
+    const api = client();
+    const created = await api.batches.create({
+      variantId,
+      prepStateId: null,
+      qty: 500,
+      unit: 'g',
+      location: 'pantry',
+      sourceType: 'purchase',
+    });
+    expect(created.batchId).toBeGreaterThan(0);
+
+    const got = await api.batches.get(created.batchId);
+    expect(got.data.qtyRemaining).toBe(500);
+    expect(got.data.location).toBe('pantry');
+
+    expect(await api.batches.relocate(created.batchId, 'fridge')).toEqual({ ok: true });
+    expect(await api.batches.edit(created.batchId, { notes: 'opened' })).toEqual({ ok: true });
+
+    const adjusted = await api.batches.adjustQty(created.batchId, -100, 'spoiled');
+    expect(adjusted).toEqual({ ok: true, newQty: 400 });
+
+    expect(await api.batches.delete(created.batchId)).toEqual({ ok: true });
+  });
+
+  it('404s on a missing batch get', async () => {
+    await expect(client().batches.get(999999)).rejects.toMatchObject({ status: 404 });
+  });
+
+  it('returns ok:false / BatchNotFound for lifecycle ops on a missing batch', async () => {
+    const res = await client().batches.relocate(999999, 'fridge');
+    expect(res).toEqual({ ok: false, reason: 'BatchNotFound' });
+  });
+
+  it('rejects a positive delta for a spoiled adjustment as ok:false', async () => {
+    const api = client();
+    const b = await api.batches.create({
+      variantId,
+      prepStateId: null,
+      qty: 100,
+      unit: 'g',
+      location: 'pantry',
+      sourceType: 'purchase',
+    });
+    const res = await api.batches.adjustQty(b.batchId, 50, 'spoiled');
+    expect(res).toMatchObject({ ok: false });
+  });
+});
+
+describe('batches REST — searchForConsume', () => {
+  it('returns non-empty batches FIFO for the picker', async () => {
+    const api = client();
+    await api.batches.create({
+      variantId,
+      prepStateId: null,
+      qty: 200,
+      unit: 'g',
+      location: 'pantry',
+      sourceType: 'purchase',
+    });
+    const res = await api.batches.searchForConsume({ variantId });
+    expect(res.items).toHaveLength(1);
+    expect(res.items[0]?.variantId).toBe(variantId);
+  });
+});

--- a/pillars/food/src/api/__tests__/fridge.test.ts
+++ b/pillars/food/src/api/__tests__/fridge.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Integration tests for the `fridge.*` REST surface — PRD-147 view +
+ * recipes-using-batch. Both read-only; grouping/query logic lives in the
+ * lifted `modules/fridge/` helpers and is covered by db-level tests.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { type OpenedFoodDb, openFoodDb } from '../../db/index.js';
+import { createIngredient } from '../../db/services/ingredients.js';
+import { createVariant } from '../../db/services/variants.js';
+import { createFoodApiApp } from '../app.js';
+import { makeClient } from './test-utils.js';
+
+let tmpDir: string;
+let foodDb: OpenedFoodDb;
+let variantId: number;
+
+function client(): ReturnType<typeof makeClient> {
+  return makeClient(
+    createFoodApiApp({ foodDb, version: '0.0.1-test', selfBaseUrl: 'http://localhost:3005' })
+  );
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'food-api-fridge-test-'));
+  foodDb = openFoodDb(join(tmpDir, 'food.db'));
+  const ing = createIngredient(foodDb.db, { name: 'Peas', slug: 'peas', defaultUnit: 'g' });
+  variantId = createVariant(foodDb.db, {
+    ingredientId: ing.id,
+    slug: 'frozen-peas',
+    name: 'Frozen Peas',
+    defaultUnit: 'g',
+  }).id;
+});
+
+afterEach(() => {
+  foodDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('fridge REST', () => {
+  it('returns an all-locations view with zeroed counts when empty', async () => {
+    const view = await client().fridge.view();
+    expect(view.sections).toHaveLength(4);
+    expect(view.counts).toEqual({ visible: 0, empty: 0, deleted: 0 });
+  });
+
+  it('groups a created batch under its location and ingredient', async () => {
+    const api = client();
+    await api.batches.create({
+      variantId,
+      prepStateId: null,
+      qty: 300,
+      unit: 'g',
+      location: 'freezer',
+      sourceType: 'purchase',
+    });
+
+    const view = await api.fridge.view();
+    expect(view.counts.visible).toBe(1);
+    const freezer = view.sections.find((s) => s.location === 'freezer');
+    expect(freezer?.count).toBe(1);
+    expect(freezer?.ingredients).toHaveLength(1);
+  });
+
+  it('returns an empty recipe list for a batch no recipe references', async () => {
+    const api = client();
+    const b = await api.batches.create({
+      variantId,
+      prepStateId: null,
+      qty: 100,
+      unit: 'g',
+      location: 'pantry',
+      sourceType: 'purchase',
+    });
+    const res = await api.fridge.recipesUsingBatch(b.batchId);
+    expect(res.items).toEqual([]);
+  });
+});

--- a/pillars/food/src/api/__tests__/test-utils.ts
+++ b/pillars/food/src/api/__tests__/test-utils.ts
@@ -116,6 +116,39 @@ interface SolveResult {
   recipes: unknown[];
 }
 
+type BatchLoc = 'pantry' | 'fridge' | 'freezer' | 'other';
+type BatchMutationResult = { ok: true } | { ok: false; reason: string };
+type BatchAdjustResult = { ok: true; newQty: number } | { ok: false; reason: string };
+
+interface BatchDetail {
+  id: number;
+  variantId: number;
+  qtyRemaining: number;
+  unit: 'g' | 'ml' | 'count';
+  location: BatchLoc;
+  sourceType: string;
+  expiresAt: string | null;
+  notes: string | null;
+  deletedAt: string | null;
+}
+
+interface CreateBatchBody {
+  variantId: number;
+  prepStateId: number | null;
+  qty: number;
+  unit: 'g' | 'ml' | 'count';
+  location: BatchLoc;
+  sourceType: 'purchase' | 'gift' | 'other';
+  producedAt?: string;
+  expiresAt?: string;
+  notes?: string;
+}
+
+interface FridgeView {
+  sections: { location: BatchLoc; count: number; ingredients: unknown[] }[];
+  counts: { visible: number; empty: number; deleted: number };
+}
+
 export class HttpError extends Error {
   readonly status: number;
   readonly body: unknown;
@@ -279,6 +312,37 @@ export function makeClient(app: Express) {
           maxMinutes?: number;
         } = {}
       ) => send<SolveResult>(r.post('/solver/can-i-cook').send(body)),
+    },
+    batches: {
+      create: (body: CreateBatchBody) => send<{ batchId: number }>(r.post('/batches').send(body)),
+      get: (id: number) => send<{ data: BatchDetail }>(r.get(`/batches/${id}`)),
+      relocate: (id: number, location: BatchLoc) =>
+        send<BatchMutationResult>(r.post(`/batches/${id}/relocate`).send({ location })),
+      edit: (
+        id: number,
+        body: { expiresAt?: string | null; notes?: string | null; prepStateId?: number | null }
+      ) => send<BatchMutationResult>(r.patch(`/batches/${id}`).send(body)),
+      adjustQty: (id: number, delta: number, reason: 'spoiled' | 'wasted' | 'correction') =>
+        send<BatchAdjustResult>(r.post(`/batches/${id}/adjust`).send({ delta, reason })),
+      delete: (id: number) => send<BatchMutationResult>(r.delete(`/batches/${id}`)),
+      searchForConsume: (
+        body: { variantId?: number; ingredientId?: number; location?: BatchLoc } = {}
+      ) =>
+        send<{ items: { id: number; variantId: number }[] }>(
+          r.post('/batches/search-for-consume').send(body)
+        ),
+    },
+    fridge: {
+      view: (
+        body: {
+          search?: string;
+          locations?: BatchLoc[];
+          includeEmpty?: boolean;
+          includeDeleted?: boolean;
+        } = {}
+      ) => send<FridgeView>(r.post('/fridge/view').send(body)),
+      recipesUsingBatch: (batchId: number, limit?: number) =>
+        send<{ items: unknown[] }>(r.get('/fridge/recipes-using-batch').query({ batchId, limit })),
     },
   };
 }

--- a/pillars/food/src/api/modules/batches/get.ts
+++ b/pillars/food/src/api/modules/batches/get.ts
@@ -1,0 +1,77 @@
+/**
+ * `food.batches.get` resolver — composes `BatchDetail` with joined
+ * ingredient / variant / prep-state / recipe-slug names.
+ *
+ * Kept here (not in `../../../db/index.js`) because the join is
+ * read-projection only — the service layer's mutations operate on the
+ * batches table alone. Future fridge-view / picker queries that need
+ * similar joins can promote this into the package if a second caller
+ * appears.
+ */
+import { eq } from 'drizzle-orm';
+
+import {
+  batches,
+  ingredients,
+  ingredientVariants,
+  prepStates,
+  recipeRuns,
+  recipes,
+  recipeVersions,
+  type FoodDb,
+} from '../../../db/index.js';
+
+import type { BatchDetail } from '../../../db/index.js';
+
+export function getBatchDetail(db: FoodDb, id: number): BatchDetail | null {
+  const rows = db
+    .select({
+      id: batches.id,
+      variantId: batches.variantId,
+      variantName: ingredientVariants.name,
+      variantSlug: ingredientVariants.slug,
+      ingredientId: ingredients.id,
+      ingredientName: ingredients.name,
+      ingredientSlug: ingredients.slug,
+      prepStateId: batches.prepStateId,
+      prepStateLabel: prepStates.name,
+      qtyRemaining: batches.qtyRemaining,
+      unit: batches.unit,
+      sourceType: batches.sourceType,
+      sourceId: batches.sourceId,
+      location: batches.location,
+      producedAt: batches.producedAt,
+      expiresAt: batches.expiresAt,
+      notes: batches.notes,
+      deletedAt: batches.deletedAt,
+      createdAt: batches.createdAt,
+    })
+    .from(batches)
+    .innerJoin(ingredientVariants, eq(ingredientVariants.id, batches.variantId))
+    .innerJoin(ingredients, eq(ingredients.id, ingredientVariants.ingredientId))
+    .leftJoin(prepStates, eq(prepStates.id, batches.prepStateId))
+    .where(eq(batches.id, id))
+    .all();
+  const row = rows[0];
+  if (row === undefined) return null;
+
+  const recipeInfo = row.sourceType === 'recipe_run' ? resolveRecipeRun(db, row.sourceId) : null;
+
+  return {
+    ...row,
+    sourceRecipeRunId: row.sourceType === 'recipe_run' ? row.sourceId : null,
+    sourceRecipeSlug: recipeInfo?.slug ?? null,
+  };
+}
+
+function resolveRecipeRun(db: FoodDb, runId: number | null): { slug: string } | null {
+  if (runId === null) return null;
+  const rows = db
+    .select({ slug: recipes.slug })
+    .from(recipeRuns)
+    .innerJoin(recipeVersions, eq(recipeVersions.id, recipeRuns.recipeVersionId))
+    .innerJoin(recipes, eq(recipes.id, recipeVersions.recipeId))
+    .where(eq(recipeRuns.id, runId))
+    .all();
+  return rows[0] ?? null;
+}

--- a/pillars/food/src/api/modules/batches/search-for-consume.ts
+++ b/pillars/food/src/api/modules/batches/search-for-consume.ts
@@ -1,0 +1,82 @@
+/**
+ * `food.batches.searchForConsume` resolver — PRD-146.
+ *
+ * Joined read projection used by `BatchOverridePicker` to surface
+ * batches a user can pick when overriding a shortfall. FIFO-ordered
+ * server-side (`expires_at ASC NULLS LAST, produced_at ASC`) so the
+ * picker dropdown defaults to the same row PRD-108's `consumeForRun`
+ * would draw next.
+ *
+ * Filters: soft-deleted batches (`deleted_at IS NOT NULL`) and empty
+ * batches (`qty_remaining <= qtyGreaterThan`, default 0) are excluded.
+ * `variantId` takes precedence over `ingredientId` when both are set.
+ */
+import { and, asc, eq, gt, isNull, sql, type SQL } from 'drizzle-orm';
+
+import {
+  batches,
+  ingredients,
+  ingredientVariants,
+  prepStates,
+  type FoodDb,
+} from '../../../db/index.js';
+
+import type { BatchForConsumeRow, BatchLocation } from '../../../db/index.js';
+
+const DEFAULT_LIMIT = 20;
+const DEFAULT_MIN_QTY = 0;
+
+export interface SearchForConsumeArgs {
+  ingredientId?: number;
+  variantId?: number;
+  location?: BatchLocation;
+  qtyGreaterThan?: number;
+  limit?: number;
+}
+
+export function searchForConsume(
+  db: FoodDb,
+  args: SearchForConsumeArgs
+): { items: BatchForConsumeRow[] } {
+  const minQty = args.qtyGreaterThan ?? DEFAULT_MIN_QTY;
+  const limit = args.limit ?? DEFAULT_LIMIT;
+
+  const conditions: SQL[] = [isNull(batches.deletedAt), gt(batches.qtyRemaining, minQty)];
+
+  if (args.variantId !== undefined) {
+    conditions.push(eq(batches.variantId, args.variantId));
+  } else if (args.ingredientId !== undefined) {
+    conditions.push(eq(ingredientVariants.ingredientId, args.ingredientId));
+  }
+
+  if (args.location !== undefined) {
+    conditions.push(eq(batches.location, args.location));
+  }
+
+  const rows = db
+    .select({
+      id: batches.id,
+      variantId: batches.variantId,
+      variantName: ingredientVariants.name,
+      variantSlug: ingredientVariants.slug,
+      ingredientId: ingredients.id,
+      ingredientName: ingredients.name,
+      prepStateId: batches.prepStateId,
+      prepStateLabel: prepStates.name,
+      qtyRemaining: batches.qtyRemaining,
+      unit: batches.unit,
+      location: batches.location,
+      expiresAt: batches.expiresAt,
+      producedAt: batches.producedAt,
+    })
+    .from(batches)
+    .innerJoin(ingredientVariants, eq(ingredientVariants.id, batches.variantId))
+    .innerJoin(ingredients, eq(ingredients.id, ingredientVariants.ingredientId))
+    .leftJoin(prepStates, eq(prepStates.id, batches.prepStateId))
+    .where(and(...conditions))
+    .orderBy(sql`${batches.expiresAt} IS NULL`, asc(batches.expiresAt), asc(batches.producedAt))
+    .limit(limit)
+    .all();
+
+  return { items: rows };
+}

--- a/pillars/food/src/api/modules/fridge/inputs.ts
+++ b/pillars/food/src/api/modules/fridge/inputs.ts
@@ -1,0 +1,27 @@
+/**
+ * Input Zod schemas for `food.fridge.*` procedures (PRD-147).
+ *
+ * `view` filters the batches list by location / search / expiry / source;
+ * `recipesUsingBatch` powers the "Cook now" picker on a batch row.
+ */
+
+import { z } from 'zod';
+
+const LOCATION = z.enum(['pantry', 'fridge', 'freezer', 'other']);
+
+export const FridgeViewInputSchema = z.object({
+  search: z.string().trim().max(120).optional(),
+  locations: z.array(LOCATION).min(1).max(4).optional(),
+  expiringSoon: z.boolean().optional(),
+  recipeYieldedOnly: z.boolean().optional(),
+  includeEmpty: z.boolean().optional(),
+  includeDeleted: z.boolean().optional(),
+});
+
+export const RecipesUsingBatchInputSchema = z.object({
+  batchId: z.number().int().positive(),
+  limit: z.number().int().positive().max(100).optional(),
+});
+
+export type FridgeViewInput = z.infer<typeof FridgeViewInputSchema>;
+export type RecipesUsingBatchInput = z.infer<typeof RecipesUsingBatchInputSchema>;

--- a/pillars/food/src/api/modules/fridge/recipes-using-batch.ts
+++ b/pillars/food/src/api/modules/fridge/recipes-using-batch.ts
@@ -1,0 +1,103 @@
+/**
+ * `food.fridge.recipesUsingBatch` query — PRD-147.
+ *
+ * Returns recipes whose **current version** has a `recipe_lines` row
+ * matching the batch's `variant_id`. Ordered by `last_cooked_at DESC`
+ * (NULLS LAST) then by recipe slug. Variant-only join — see PRD-147
+ * §Cook now: the variant match is deliberately not prep-aware (Epic 06
+ * delivers a prep-aware solver).
+ *
+ * `recipeNeedsQty` is summed across matching `recipe_lines` whose
+ * `canonical_unit` matches the batch's `unit`. When no matching-unit
+ * line exists for a recipe, the field is `null` (UI renders "Needs ~?").
+ */
+
+import { and, asc, desc, eq, isNotNull, sql, type AnyColumn, type SQL } from 'drizzle-orm';
+
+import {
+  batches,
+  recipeLines,
+  recipeRuns,
+  recipes,
+  recipeVersions,
+  type FoodDb,
+} from '../../../db/index.js';
+
+import type { BatchUnit, RecipeForCookRow } from '../../../db/index.js';
+
+const DEFAULT_LIMIT = 20;
+
+interface BatchKey {
+  variantId: number;
+  unit: BatchUnit;
+}
+
+export function recipesUsingBatch(
+  db: FoodDb,
+  batchId: number,
+  limit: number = DEFAULT_LIMIT
+): { items: readonly RecipeForCookRow[] } {
+  const key = lookupBatchKey(db, batchId);
+  if (key === null) return { items: [] };
+
+  const candidates = db
+    .select({
+      recipeId: recipes.id,
+      recipeSlug: recipes.slug,
+      title: recipeVersions.title,
+      recipeType: recipes.recipeType,
+      lineCount: sql<number>`COUNT(${recipeLines.id})`,
+      needsQty: sumQtyColumn(key.unit),
+      lastCookedAt: sql<string | null>`MAX(${recipeRuns.completedAt})`,
+    })
+    .from(recipes)
+    .innerJoin(recipeVersions, eq(recipeVersions.id, recipes.currentVersionId))
+    .innerJoin(recipeLines, eq(recipeLines.recipeVersionId, recipeVersions.id))
+    .leftJoin(
+      recipeRuns,
+      and(eq(recipeRuns.recipeVersionId, recipeVersions.id), isNotNull(recipeRuns.completedAt))
+    )
+    .where(eq(recipeLines.variantId, key.variantId))
+    .groupBy(recipes.id, recipes.slug, recipeVersions.title, recipes.recipeType)
+    .orderBy(
+      sql`${sql<string | null>`MAX(${recipeRuns.completedAt})`} IS NULL`,
+      desc(sql`MAX(${recipeRuns.completedAt})`),
+      asc(recipes.slug)
+    )
+    .limit(limit)
+    .all();
+
+  const items: RecipeForCookRow[] = candidates.map((row) => ({
+    recipeId: row.recipeId,
+    recipeSlug: row.recipeSlug,
+    title: row.title,
+    recipeType: row.recipeType ?? null,
+    lineCount: row.lineCount,
+    recipeNeedsQty: row.needsQty,
+    lastCookedAt: row.lastCookedAt,
+  }));
+
+  return { items };
+}
+
+function lookupBatchKey(db: FoodDb, batchId: number): BatchKey | null {
+  const row = db
+    .select({ variantId: batches.variantId, unit: batches.unit })
+    .from(batches)
+    .where(eq(batches.id, batchId))
+    .get();
+  return row ?? null;
+}
+
+function sumQtyColumn(unit: BatchUnit): SQL<number | null> {
+  const col = qtyColumnFor(unit);
+  return sql<
+    number | null
+  >`SUM(CASE WHEN ${recipeLines.canonicalUnit} = ${unit} THEN ${col} ELSE NULL END)`;
+}
+
+function qtyColumnFor(unit: BatchUnit): AnyColumn {
+  if (unit === 'g') return recipeLines.qtyG;
+  if (unit === 'ml') return recipeLines.qtyMl;
+  return recipeLines.qtyCount;
+}

--- a/pillars/food/src/api/modules/fridge/view-grouping.ts
+++ b/pillars/food/src/api/modules/fridge/view-grouping.ts
@@ -1,0 +1,120 @@
+/**
+ * In-memory grouping for `food.fridge.view` — PRD-147.
+ *
+ * Folds the flat batch rows into `FridgeLocationSection` →
+ * `FridgeIngredientGroup` → `FridgeBatchRow`. All four locations are
+ * always emitted (even empty) so the UI can render placeholder
+ * collapsed sections.
+ */
+import type {
+  BatchLocation,
+  FridgeBatchRow,
+  FridgeIngredientGroup,
+  FridgeLocationSection,
+} from '../../../db/index.js';
+import type { FlatBatchRow } from './view-query.js';
+
+const MS_PER_DAY = 86_400_000;
+const ALL_LOCATIONS: readonly BatchLocation[] = ['pantry', 'fridge', 'freezer', 'other'];
+
+interface IngredientMeta {
+  name: string;
+  slug: string;
+}
+
+export function groupIntoSections(
+  rows: readonly FlatBatchRow[],
+  recipeSlugByRun: ReadonlyMap<number, string>,
+  todayMs: number
+): FridgeLocationSection[] {
+  const byLocation = initLocationMap();
+  const ingredientMeta = new Map<number, IngredientMeta>();
+
+  for (const row of rows) {
+    const batch = toBatchRow(row, recipeSlugByRun, todayMs);
+    const section = byLocation.get(row.location);
+    if (section === undefined) continue;
+    const group = section.get(row.ingredientId) ?? [];
+    group.push(batch);
+    section.set(row.ingredientId, group);
+    if (!ingredientMeta.has(row.ingredientId)) {
+      ingredientMeta.set(row.ingredientId, {
+        name: row.ingredientName,
+        slug: row.ingredientSlug,
+      });
+    }
+  }
+
+  return ALL_LOCATIONS.map((location) =>
+    buildSection(location, byLocation.get(location) ?? new Map(), ingredientMeta)
+  );
+}
+
+function initLocationMap(): Map<BatchLocation, Map<number, FridgeBatchRow[]>> {
+  const m = new Map<BatchLocation, Map<number, FridgeBatchRow[]>>();
+  for (const loc of ALL_LOCATIONS) m.set(loc, new Map());
+  return m;
+}
+
+function toBatchRow(
+  row: FlatBatchRow,
+  recipeSlugByRun: ReadonlyMap<number, string>,
+  todayMs: number
+): FridgeBatchRow {
+  const slug = resolveRecipeSlugForRow(row, recipeSlugByRun);
+  return {
+    id: row.id,
+    variantName: row.variantName,
+    variantSlug: row.variantSlug,
+    prepStateLabel: row.prepStateLabel,
+    qtyRemaining: row.qtyRemaining,
+    unit: row.unit,
+    expiresAt: row.expiresAt,
+    daysToExpiry: computeDaysToExpiry(row.expiresAt, todayMs),
+    producedAt: row.producedAt,
+    sourceType: row.sourceType,
+    sourceRecipeSlug: slug,
+    notes: row.notes,
+    deletedAt: row.deletedAt,
+  };
+}
+
+function resolveRecipeSlugForRow(
+  row: FlatBatchRow,
+  recipeSlugByRun: ReadonlyMap<number, string>
+): string | null {
+  if (row.sourceType !== 'recipe_run' || row.sourceId === null) return null;
+  return recipeSlugByRun.get(row.sourceId) ?? null;
+}
+
+function buildSection(
+  location: BatchLocation,
+  ingredientMap: ReadonlyMap<number, FridgeBatchRow[]>,
+  ingredientMeta: ReadonlyMap<number, IngredientMeta>
+): FridgeLocationSection {
+  const ingredientList: FridgeIngredientGroup[] = [...ingredientMap.entries()]
+    .map(([ingredientId, batchList]) => {
+      const meta = ingredientMeta.get(ingredientId);
+      return {
+        ingredientId,
+        ingredientName: meta?.name ?? '',
+        ingredientSlug: meta?.slug ?? '',
+        batches: batchList,
+      };
+    })
+    .toSorted((a, b) => a.ingredientName.localeCompare(b.ingredientName));
+  const count = ingredientList.reduce((sum, g) => sum + g.batches.length, 0);
+  return { location, count, ingredients: ingredientList };
+}
+
+function computeDaysToExpiry(expiresAt: string | null, todayMs: number): number | null {
+  if (expiresAt === null) return null;
+  const d = new Date(expiresAt);
+  const expiryMs = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
+  if (Number.isNaN(expiryMs)) return null;
+  return Math.round((expiryMs - todayMs) / MS_PER_DAY);
+}
+
+export function toUtcMidnight(d: Date): number {
+  return Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
+}

--- a/pillars/food/src/api/modules/fridge/view-query.ts
+++ b/pillars/food/src/api/modules/fridge/view-query.ts
@@ -1,0 +1,182 @@
+/**
+ * SQL primitives for `food.fridge.view` — PRD-147.
+ *
+ * Owns the SELECT that pulls every batch row for the current filter
+ * combination plus the three head counts (visible / empty / deleted).
+ * The orchestrator in `view.ts` glues these to the in-memory grouping.
+ */
+import { and, asc, eq, isNotNull, isNull, like, or, sql, type SQL } from 'drizzle-orm';
+
+import {
+  batches,
+  ingredients,
+  ingredientVariants,
+  prepStates,
+  recipeRuns,
+  recipes,
+  recipeVersions,
+  type FoodDb,
+} from '../../../db/index.js';
+
+import type {
+  BatchLocation,
+  BatchSourceType,
+  BatchUnit,
+  FridgeViewCounts,
+} from '../../../db/index.js';
+import type { FridgeViewInput } from './inputs.js';
+
+const EXPIRING_SOON_DAYS = 7;
+const MS_PER_DAY = 86_400_000;
+
+export interface FlatBatchRow {
+  id: number;
+  variantId: number;
+  variantName: string | null;
+  variantSlug: string | null;
+  ingredientId: number;
+  ingredientName: string;
+  ingredientSlug: string;
+  prepStateLabel: string | null;
+  qtyRemaining: number;
+  unit: BatchUnit;
+  expiresAt: string | null;
+  producedAt: string;
+  sourceType: BatchSourceType;
+  sourceId: number | null;
+  location: BatchLocation;
+  notes: string | null;
+  deletedAt: string | null;
+}
+
+export function selectRows(db: FoodDb, input: FridgeViewInput, now: Date): FlatBatchRow[] {
+  const conds = baseConditions(input, now);
+  return db
+    .select({
+      id: batches.id,
+      variantId: batches.variantId,
+      variantName: ingredientVariants.name,
+      variantSlug: ingredientVariants.slug,
+      ingredientId: ingredients.id,
+      ingredientName: ingredients.name,
+      ingredientSlug: ingredients.slug,
+      prepStateLabel: prepStates.name,
+      qtyRemaining: batches.qtyRemaining,
+      unit: batches.unit,
+      expiresAt: batches.expiresAt,
+      producedAt: batches.producedAt,
+      sourceType: batches.sourceType,
+      sourceId: batches.sourceId,
+      location: batches.location,
+      notes: batches.notes,
+      deletedAt: batches.deletedAt,
+    })
+    .from(batches)
+    .innerJoin(ingredientVariants, eq(ingredientVariants.id, batches.variantId))
+    .innerJoin(ingredients, eq(ingredients.id, ingredientVariants.ingredientId))
+    .leftJoin(prepStates, eq(prepStates.id, batches.prepStateId))
+    .where(and(...conds))
+    .orderBy(
+      asc(batches.location),
+      asc(ingredients.name),
+      sql`${batches.expiresAt} IS NULL`,
+      asc(batches.expiresAt),
+      asc(batches.producedAt)
+    )
+    .all();
+}
+
+export function selectCounts(db: FoodDb, input: FridgeViewInput): FridgeViewCounts {
+  const locationFilter = buildLocationFilter(input);
+  return {
+    visible: countBy(
+      db,
+      and(sql`${batches.qtyRemaining} > 0`, isNull(batches.deletedAt), locationFilter)
+    ),
+    empty: countBy(
+      db,
+      and(sql`${batches.qtyRemaining} = 0`, isNull(batches.deletedAt), locationFilter)
+    ),
+    deleted: countBy(db, and(isNotNull(batches.deletedAt), locationFilter)),
+  };
+}
+
+export function resolveRecipeSlugs(db: FoodDb, rows: readonly FlatBatchRow[]): Map<number, string> {
+  const runIds = new Set<number>();
+  for (const row of rows) {
+    if (row.sourceType === 'recipe_run' && row.sourceId !== null) runIds.add(row.sourceId);
+  }
+  if (runIds.size === 0) return new Map();
+  const idList = [...runIds];
+  const found = db
+    .select({ runId: recipeRuns.id, slug: recipes.slug })
+    .from(recipeRuns)
+    .innerJoin(recipeVersions, eq(recipeVersions.id, recipeRuns.recipeVersionId))
+    .innerJoin(recipes, eq(recipes.id, recipeVersions.recipeId))
+    .where(sql`${recipeRuns.id} IN ${idList}`)
+    .all();
+  const map = new Map<number, string>();
+  for (const row of found) map.set(row.runId, row.slug);
+  return map;
+}
+
+function baseConditions(input: FridgeViewInput, now: Date): SQL[] {
+  const conds: SQL[] = [];
+  if (input.includeEmpty !== true) conds.push(sql`${batches.qtyRemaining} > 0`);
+  if (input.includeDeleted !== true) conds.push(isNull(batches.deletedAt));
+
+  const locations = input.locations ?? null;
+  if (locations !== null && locations.length > 0) {
+    conds.push(sql`${batches.location} IN ${locations}`);
+  }
+
+  if (input.recipeYieldedOnly === true) {
+    conds.push(eq(batches.sourceType, 'recipe_run'));
+  }
+
+  if (input.expiringSoon === true) {
+    conds.push(buildExpiringSoonCondition(now));
+  }
+
+  appendSearchCondition(conds, input.search);
+
+  return conds;
+}
+
+function appendSearchCondition(conds: SQL[], rawSearch: string | undefined): void {
+  const search = (rawSearch ?? '').trim();
+  if (search.length === 0) return;
+  const pattern = `%${search.toLowerCase()}%`;
+  const expr = or(
+    like(sql`LOWER(${ingredients.name})`, pattern),
+    like(sql`LOWER(${ingredientVariants.name})`, pattern)
+  );
+  if (expr !== undefined) conds.push(expr);
+}
+
+function buildExpiringSoonCondition(now: Date): SQL {
+  // Anchor on the injectable `now` so tests / backfills that pin the clock
+  // see a deterministic threshold (rather than `Date.now()` drifting between
+  // the SELECT and the `daysToExpiry` projection in `view-grouping.ts`).
+  const threshold = new Date(now.getTime() + EXPIRING_SOON_DAYS * MS_PER_DAY).toISOString();
+  const expr = and(isNotNull(batches.expiresAt), sql`${batches.expiresAt} <= ${threshold}`);
+  if (expr === undefined) throw new Error('expiringSoon condition assembly failed');
+  return expr;
+}
+
+function buildLocationFilter(input: FridgeViewInput): SQL {
+  if (input.locations !== undefined && input.locations.length > 0) {
+    return sql`${batches.location} IN ${input.locations}`;
+  }
+  return sql`1=1`;
+}
+
+function countBy(db: FoodDb, where: SQL | undefined): number {
+  return (
+    db
+      .select({ n: sql<number>`COUNT(*)` })
+      .from(batches)
+      .where(where)
+      .get()?.n ?? 0
+  );
+}

--- a/pillars/food/src/api/modules/fridge/view.ts
+++ b/pillars/food/src/api/modules/fridge/view.ts
@@ -1,0 +1,27 @@
+import { groupIntoSections, toUtcMidnight } from './view-grouping.js';
+import { resolveRecipeSlugs, selectCounts, selectRows } from './view-query.js';
+
+/**
+ * `food.fridge.view` query — PRD-147.
+ *
+ * Reads `batches` joined to `ingredient_variants` / `ingredients` /
+ * `prep_states`, applies the filter inputs, and projects into the
+ * `FridgeView` shape (sections by location → ingredient groups →
+ * batch rows). The default view excludes empties and soft-deleted rows
+ * (`qty_remaining > 0 AND deleted_at IS NULL`).
+ *
+ * `daysToExpiry` is computed in calendar days at UTC. We don't pull in
+ * date-fns server-side — the math is `(expiryUtcMidnight - todayUtcMidnight)
+ * / 86_400_000`, which matches `differenceInCalendarDays` semantics for
+ * date-only inputs.
+ */
+import type { FoodDb, FridgeView } from '../../../db/index.js';
+import type { FridgeViewInput } from './inputs.js';
+
+export function fridgeView(db: FoodDb, input: FridgeViewInput, now: Date = new Date()): FridgeView {
+  const rows = selectRows(db, input, now);
+  const recipeSlugByRun = resolveRecipeSlugs(db, rows);
+  const sections = groupIntoSections(rows, recipeSlugByRun, toUtcMidnight(now));
+  const counts = selectCounts(db, input);
+  return { sections, counts };
+}

--- a/pillars/food/src/api/rest/batches-handlers.ts
+++ b/pillars/food/src/api/rest/batches-handlers.ts
@@ -1,0 +1,92 @@
+/**
+ * Handlers for the `batches.*` sub-router. Lifecycle mutations return the
+ * service's discriminated result verbatim (200); `create` maps a failed
+ * result to 400 and a missing batch on `get` to 404.
+ */
+import { batchesLifecycleService } from '../../db/index.js';
+import { getBatchDetail } from '../modules/batches/get.js';
+import { searchForConsume } from '../modules/batches/search-for-consume.js';
+import { HttpError, NotFoundError } from '../shared/errors.js';
+import { runHttp } from './error-mapping.js';
+
+import type { ServerInferRequest } from '@ts-rest/core';
+
+import type { foodBatchesContract } from '../../contract/rest-batches.js';
+import type { FoodDb } from '../../db/index.js';
+
+type Req = ServerInferRequest<typeof foodBatchesContract>;
+
+export function makeBatchesHandlers(db: FoodDb) {
+  return {
+    create: ({ body }: Req['create']) =>
+      runHttp(() => {
+        const result = batchesLifecycleService.createBatchManual(db, {
+          variantId: body.variantId,
+          prepStateId: body.prepStateId,
+          qty: body.qty,
+          unit: body.unit,
+          location: body.location,
+          sourceType: body.sourceType,
+          producedAt: body.producedAt,
+          expiresAt: body.expiresAt,
+          notes: body.notes,
+        });
+        if (result.ok === false) {
+          throw new HttpError(
+            400,
+            `createBatchManual rejected: ${result.reason}`,
+            undefined,
+            'common.validationFailed'
+          );
+        }
+        return { status: 201 as const, body: { batchId: result.batchId } };
+      }),
+
+    get: ({ params }: Req['get']) =>
+      runHttp(() => {
+        const detail = getBatchDetail(db, params.id);
+        if (detail === null) throw new NotFoundError('Batch', String(params.id));
+        return { status: 200 as const, body: { data: detail } };
+      }),
+
+    relocate: ({ params, body }: Req['relocate']) =>
+      runHttp(() => ({
+        status: 200 as const,
+        body: batchesLifecycleService.relocateBatch(db, params.id, body.location),
+      })),
+
+    edit: ({ params, body }: Req['edit']) =>
+      runHttp(() => ({
+        status: 200 as const,
+        body: batchesLifecycleService.editBatch(db, params.id, {
+          expiresAt: body.expiresAt,
+          notes: body.notes,
+          prepStateId: body.prepStateId,
+        }),
+      })),
+
+    adjustQty: ({ params, body }: Req['adjustQty']) =>
+      runHttp(() => ({
+        status: 200 as const,
+        body: batchesLifecycleService.adjustBatchQty(db, params.id, body.delta, body.reason),
+      })),
+
+    delete: ({ params }: Req['delete']) =>
+      runHttp(() => ({
+        status: 200 as const,
+        body: batchesLifecycleService.deleteBatch(db, params.id),
+      })),
+
+    searchForConsume: ({ body }: Req['searchForConsume']) =>
+      runHttp(() => ({
+        status: 200 as const,
+        body: searchForConsume(db, {
+          ingredientId: body.ingredientId,
+          variantId: body.variantId,
+          location: body.location,
+          qtyGreaterThan: body.qtyGreaterThan,
+          limit: body.limit,
+        }),
+      })),
+  };
+}

--- a/pillars/food/src/api/rest/fridge-handlers.ts
+++ b/pillars/food/src/api/rest/fridge-handlers.ts
@@ -1,0 +1,27 @@
+import { recipesUsingBatch } from '../modules/fridge/recipes-using-batch.js';
+/**
+ * Handlers for the `fridge.*` sub-router. Both are read-only; the view +
+ * grouping logic lives in the lifted `modules/fridge/` helpers.
+ */
+import { fridgeView } from '../modules/fridge/view.js';
+import { runHttp } from './error-mapping.js';
+
+import type { ServerInferRequest } from '@ts-rest/core';
+
+import type { foodFridgeContract } from '../../contract/rest-fridge.js';
+import type { FoodDb } from '../../db/index.js';
+
+type Req = ServerInferRequest<typeof foodFridgeContract>;
+
+export function makeFridgeHandlers(db: FoodDb) {
+  return {
+    view: ({ body }: Req['view']) =>
+      runHttp(() => ({ status: 200 as const, body: fridgeView(db, body) })),
+
+    recipesUsingBatch: ({ query }: Req['recipesUsingBatch']) =>
+      runHttp(() => ({
+        status: 200 as const,
+        body: recipesUsingBatch(db, query.batchId, query.limit),
+      })),
+  };
+}

--- a/pillars/food/src/api/rest/handlers.ts
+++ b/pillars/food/src/api/rest/handlers.ts
@@ -10,7 +10,9 @@ import { initServer } from '@ts-rest/express';
 import { foodContract } from '../../contract/rest.js';
 import { type OpenedFoodDb } from '../../db/index.js';
 import { makeAliasesHandlers } from './aliases-handlers.js';
+import { makeBatchesHandlers } from './batches-handlers.js';
 import { makeConversionsHandlers } from './conversions-handlers.js';
+import { makeFridgeHandlers } from './fridge-handlers.js';
 import { makeIngredientTagsHandlers } from './ingredient-tags-handlers.js';
 import { makeIngredientsHandlers } from './ingredients-handlers.js';
 import { makePrepStatesHandlers } from './prep-states-handlers.js';
@@ -27,7 +29,9 @@ export function makeFoodRestHandlers(deps: {
   const db = deps.foodDb.db;
   return server.router(foodContract, {
     aliases: makeAliasesHandlers(db),
+    batches: makeBatchesHandlers(db),
     conversions: makeConversionsHandlers(db),
+    fridge: makeFridgeHandlers(db),
     ingredients: makeIngredientsHandlers(db),
     ingredientTags: makeIngredientTagsHandlers(db),
     prepStates: makePrepStatesHandlers(db),

--- a/pillars/food/src/contract/api-types.generated.ts
+++ b/pillars/food/src/contract/api-types.generated.ts
@@ -90,6 +90,93 @@ export interface paths {
     patch: operations['aliases.updateText'];
     trace?: never;
   };
+  '/batches': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Create a manual batch */
+    post: operations['batches.create'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/batches/search-for-consume': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** FIFO-ordered batches for the consume/override picker */
+    post: operations['batches.searchForConsume'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/batches/{id}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get a batch with resolved variant / ingredient / source */
+    get: operations['batches.get'];
+    put?: never;
+    post?: never;
+    /** Soft-delete a batch */
+    delete: operations['batches.delete'];
+    options?: never;
+    head?: never;
+    /** Edit a batch (expiry / notes / prep state) */
+    patch: operations['batches.edit'];
+    trace?: never;
+  };
+  '/batches/{id}/adjust': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Adjust a batch quantity (spoiled / wasted / correction) */
+    post: operations['batches.adjustQty'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/batches/{id}/relocate': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Move a batch to another location */
+    post: operations['batches.relocate'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/conversions/resolve': {
     parameters: {
       query?: never;
@@ -177,6 +264,40 @@ export interface paths {
     head?: never;
     /** Update an ingredient weight */
     patch: operations['conversions.updateWeight'];
+    trace?: never;
+  };
+  '/fridge/recipes-using-batch': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Recipes that reference the batch’s variant (FIFO cook suggestions) */
+    get: operations['fridge.recipesUsingBatch'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/fridge/view': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Fridge/pantry view grouped by location → ingredient → batch */
+    post: operations['fridge.view'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
     trace?: never;
   };
   '/ingredient-tags': {
@@ -973,6 +1094,407 @@ export interface operations {
       };
     };
   };
+  'batches.create': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          expiresAt?: string;
+          /** @enum {string} */
+          location: 'pantry' | 'fridge' | 'freezer' | 'other';
+          notes?: string;
+          prepStateId: number | null;
+          producedAt?: string;
+          qty: number;
+          /** @enum {string} */
+          sourceType: 'purchase' | 'gift' | 'other';
+          /** @enum {string} */
+          unit: 'g' | 'ml' | 'count';
+          variantId: number;
+        };
+      };
+    };
+    responses: {
+      /** @description 201 */
+      201: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            batchId: number;
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'batches.searchForConsume': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          ingredientId?: number;
+          limit?: number;
+          /** @enum {string} */
+          location?: 'pantry' | 'fridge' | 'freezer' | 'other';
+          qtyGreaterThan?: number;
+          variantId?: number;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            readonly items: {
+              expiresAt: string | null;
+              id: number;
+              ingredientId: number;
+              ingredientName: string;
+              /** @enum {string} */
+              location: 'pantry' | 'fridge' | 'freezer' | 'other';
+              prepStateId: number | null;
+              prepStateLabel: string | null;
+              producedAt: string;
+              qtyRemaining: number;
+              /** @enum {string} */
+              unit: 'g' | 'ml' | 'count';
+              variantId: number;
+              variantName: string;
+              variantSlug: string;
+            }[];
+          };
+        };
+      };
+    };
+  };
+  'batches.get': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              createdAt: string;
+              deletedAt: string | null;
+              expiresAt: string | null;
+              id: number;
+              ingredientId: number;
+              ingredientName: string;
+              ingredientSlug: string;
+              /** @enum {string} */
+              location: 'pantry' | 'fridge' | 'freezer' | 'other';
+              notes: string | null;
+              prepStateId: number | null;
+              prepStateLabel: string | null;
+              producedAt: string;
+              qtyRemaining: number;
+              sourceId: number | null;
+              sourceRecipeRunId: number | null;
+              sourceRecipeSlug: string | null;
+              /** @enum {string} */
+              sourceType: 'purchase' | 'recipe_run' | 'gift' | 'other';
+              /** @enum {string} */
+              unit: 'g' | 'ml' | 'count';
+              variantId: number;
+              variantName: string;
+              variantSlug: string;
+            };
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'batches.delete': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: number;
+      };
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': Record<string, never>;
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json':
+            | {
+                /** @enum {boolean} */
+                ok: true;
+              }
+            | {
+                /** @enum {boolean} */
+                ok: false;
+                /** @enum {string} */
+                reason:
+                  | 'BatchNotFound'
+                  | 'BatchDeleted'
+                  | 'NegativeQty'
+                  | 'CannotEditFromRun'
+                  | 'BadExpiry'
+                  | 'BadAdjustment';
+              };
+        };
+      };
+    };
+  };
+  'batches.edit': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: number;
+      };
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          expiresAt?: string | null;
+          notes?: string | null;
+          prepStateId?: number | null;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json':
+            | {
+                /** @enum {boolean} */
+                ok: true;
+              }
+            | {
+                /** @enum {boolean} */
+                ok: false;
+                /** @enum {string} */
+                reason:
+                  | 'BatchNotFound'
+                  | 'BatchDeleted'
+                  | 'NegativeQty'
+                  | 'CannotEditFromRun'
+                  | 'BadExpiry'
+                  | 'BadAdjustment';
+              };
+        };
+      };
+    };
+  };
+  'batches.adjustQty': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: number;
+      };
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          delta: number;
+          /** @enum {string} */
+          reason: 'spoiled' | 'wasted' | 'correction';
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json':
+            | {
+                newQty: number;
+                /** @enum {boolean} */
+                ok: true;
+              }
+            | {
+                /** @enum {boolean} */
+                ok: false;
+                /** @enum {string} */
+                reason:
+                  | 'BatchNotFound'
+                  | 'BatchDeleted'
+                  | 'NegativeQty'
+                  | 'CannotEditFromRun'
+                  | 'BadExpiry'
+                  | 'BadAdjustment';
+              };
+        };
+      };
+    };
+  };
+  'batches.relocate': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: number;
+      };
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          /** @enum {string} */
+          location: 'pantry' | 'fridge' | 'freezer' | 'other';
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json':
+            | {
+                /** @enum {boolean} */
+                ok: true;
+              }
+            | {
+                /** @enum {boolean} */
+                ok: false;
+                /** @enum {string} */
+                reason:
+                  | 'BatchNotFound'
+                  | 'BatchDeleted'
+                  | 'NegativeQty'
+                  | 'CannotEditFromRun'
+                  | 'BadExpiry'
+                  | 'BadAdjustment';
+              };
+        };
+      };
+    };
+  };
   'conversions.resolve': {
     parameters: {
       query: {
@@ -1547,6 +2069,104 @@ export interface operations {
             code?: string;
             message: string;
             messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'fridge.recipesUsingBatch': {
+    parameters: {
+      query: {
+        batchId: number;
+        limit?: number;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            readonly items: {
+              lastCookedAt: string | null;
+              lineCount: number;
+              recipeId: number;
+              recipeNeedsQty: number | null;
+              recipeSlug: string;
+              recipeType: string | null;
+              title: string;
+            }[];
+          };
+        };
+      };
+    };
+  };
+  'fridge.view': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          expiringSoon?: boolean;
+          includeDeleted?: boolean;
+          includeEmpty?: boolean;
+          locations?: ('pantry' | 'fridge' | 'freezer' | 'other')[];
+          recipeYieldedOnly?: boolean;
+          search?: string;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            counts: {
+              deleted: number;
+              empty: number;
+              visible: number;
+            };
+            readonly sections: {
+              count: number;
+              readonly ingredients: {
+                readonly batches: {
+                  daysToExpiry: number | null;
+                  deletedAt: string | null;
+                  expiresAt: string | null;
+                  id: number;
+                  notes: string | null;
+                  prepStateLabel: string | null;
+                  producedAt: string;
+                  qtyRemaining: number;
+                  sourceRecipeSlug: string | null;
+                  /** @enum {string} */
+                  sourceType: 'purchase' | 'recipe_run' | 'gift' | 'other';
+                  /** @enum {string} */
+                  unit: 'g' | 'ml' | 'count';
+                  variantName: string | null;
+                  variantSlug: string | null;
+                }[];
+                ingredientId: number;
+                ingredientName: string;
+                ingredientSlug: string;
+              }[];
+              /** @enum {string} */
+              location: 'pantry' | 'fridge' | 'freezer' | 'other';
+            }[];
           };
         };
       };

--- a/pillars/food/src/contract/rest-batches.ts
+++ b/pillars/food/src/contract/rest-batches.ts
@@ -1,0 +1,155 @@
+/**
+ * `batches.*` sub-router — PRD-145 batch lifecycle + PRD-146 consume
+ * picker. Lifecycle mutations (relocate/edit/adjust/delete) return the
+ * service's discriminated `{ ok, ... }` result on 200 (the FE narrows on
+ * it); `create` answers 201 or 400. `searchForConsume` is FIFO-ordered
+ * server-side.
+ */
+import { initContract } from '@ts-rest/core';
+import { z } from 'zod';
+
+import { ERR_RESPONSES, PathPositiveInt } from './rest-schemas.js';
+
+const c = initContract();
+
+const Unit = z.enum(['g', 'ml', 'count']);
+const Location = z.enum(['pantry', 'fridge', 'freezer', 'other']);
+const SourceType = z.enum(['purchase', 'recipe_run', 'gift', 'other']);
+const ManualSourceType = z.enum(['purchase', 'gift', 'other']);
+const AdjustReason = z.enum(['spoiled', 'wasted', 'correction']);
+const BatchErrorEnum = z.enum([
+  'BatchNotFound',
+  'BatchDeleted',
+  'NegativeQty',
+  'CannotEditFromRun',
+  'BadExpiry',
+  'BadAdjustment',
+]);
+
+const BatchMutationResultSchema = z.discriminatedUnion('ok', [
+  z.object({ ok: z.literal(true) }),
+  z.object({ ok: z.literal(false), reason: BatchErrorEnum }),
+]);
+
+const BatchAdjustResultSchema = z.discriminatedUnion('ok', [
+  z.object({ ok: z.literal(true), newQty: z.number() }),
+  z.object({ ok: z.literal(false), reason: BatchErrorEnum }),
+]);
+
+export const BatchDetailSchema = z.object({
+  id: z.number().int().positive(),
+  variantId: z.number().int().positive(),
+  variantName: z.string(),
+  variantSlug: z.string(),
+  ingredientId: z.number().int().positive(),
+  ingredientName: z.string(),
+  ingredientSlug: z.string(),
+  prepStateId: z.number().int().nullable(),
+  prepStateLabel: z.string().nullable(),
+  qtyRemaining: z.number(),
+  unit: Unit,
+  sourceType: SourceType,
+  sourceId: z.number().int().nullable(),
+  sourceRecipeRunId: z.number().int().nullable(),
+  sourceRecipeSlug: z.string().nullable(),
+  location: Location,
+  producedAt: z.string(),
+  expiresAt: z.string().nullable(),
+  notes: z.string().nullable(),
+  deletedAt: z.string().nullable(),
+  createdAt: z.string(),
+});
+
+const BatchForConsumeRowSchema = z.object({
+  id: z.number().int().positive(),
+  variantId: z.number().int().positive(),
+  variantName: z.string(),
+  variantSlug: z.string(),
+  ingredientId: z.number().int().positive(),
+  ingredientName: z.string(),
+  prepStateId: z.number().int().nullable(),
+  prepStateLabel: z.string().nullable(),
+  qtyRemaining: z.number(),
+  unit: Unit,
+  location: Location,
+  expiresAt: z.string().nullable(),
+  producedAt: z.string(),
+});
+
+export const foodBatchesContract = c.router({
+  create: {
+    method: 'POST',
+    path: '/batches',
+    body: z.object({
+      variantId: z.number().int().positive(),
+      prepStateId: z.number().int().positive().nullable(),
+      qty: z.number().finite().nonnegative(),
+      unit: Unit,
+      location: Location,
+      sourceType: ManualSourceType,
+      producedAt: z.string().optional(),
+      expiresAt: z.string().optional(),
+      notes: z.string().max(1000).optional(),
+    }),
+    responses: { 201: z.object({ batchId: z.number().int().positive() }), ...ERR_RESPONSES },
+    summary: 'Create a manual batch',
+  },
+  // POST (not GET) so the literal path can't be shadowed by GET /batches/:id
+  // — ts-rest/express does not order a literal segment ahead of a param one.
+  searchForConsume: {
+    method: 'POST',
+    path: '/batches/search-for-consume',
+    body: z.object({
+      ingredientId: z.number().int().positive().optional(),
+      variantId: z.number().int().positive().optional(),
+      location: Location.optional(),
+      qtyGreaterThan: z.number().finite().nonnegative().optional(),
+      limit: z.number().int().positive().max(100).optional(),
+    }),
+    responses: { 200: z.object({ items: z.array(BatchForConsumeRowSchema).readonly() }) },
+    summary: 'FIFO-ordered batches for the consume/override picker',
+  },
+  get: {
+    method: 'GET',
+    path: '/batches/:id',
+    pathParams: z.object({ id: PathPositiveInt }),
+    responses: { 200: z.object({ data: BatchDetailSchema }), ...ERR_RESPONSES },
+    summary: 'Get a batch with resolved variant / ingredient / source',
+  },
+  relocate: {
+    method: 'POST',
+    path: '/batches/:id/relocate',
+    pathParams: z.object({ id: PathPositiveInt }),
+    body: z.object({ location: Location }),
+    responses: { 200: BatchMutationResultSchema },
+    summary: 'Move a batch to another location',
+  },
+  edit: {
+    method: 'PATCH',
+    path: '/batches/:id',
+    pathParams: z.object({ id: PathPositiveInt }),
+    body: z.object({
+      expiresAt: z.string().nullish(),
+      notes: z.string().max(1000).nullish(),
+      prepStateId: z.number().int().positive().nullish(),
+    }),
+    responses: { 200: BatchMutationResultSchema },
+    summary: 'Edit a batch (expiry / notes / prep state)',
+  },
+  adjustQty: {
+    method: 'POST',
+    path: '/batches/:id/adjust',
+    pathParams: z.object({ id: PathPositiveInt }),
+    body: z.object({ delta: z.number().finite(), reason: AdjustReason }),
+    responses: { 200: BatchAdjustResultSchema },
+    summary: 'Adjust a batch quantity (spoiled / wasted / correction)',
+  },
+  delete: {
+    method: 'DELETE',
+    path: '/batches/:id',
+    pathParams: z.object({ id: PathPositiveInt }),
+    body: z.object({}).optional(),
+    responses: { 200: BatchMutationResultSchema },
+    summary: 'Soft-delete a batch',
+  },
+});

--- a/pillars/food/src/contract/rest-fridge.ts
+++ b/pillars/food/src/contract/rest-fridge.ts
@@ -1,0 +1,91 @@
+/**
+ * `fridge.*` sub-router — PRD-147 fridge/pantry view + the "recipes using
+ * this batch" lookup. `view` is `POST`-with-body (its filter set carries a
+ * locations array + several booleans that ride a body more cleanly than
+ * query params); it is a pure read. Both are read-only.
+ */
+import { initContract } from '@ts-rest/core';
+import { z } from 'zod';
+
+import { QueryPositiveInt } from './rest-schemas.js';
+
+const c = initContract();
+
+const Unit = z.enum(['g', 'ml', 'count']);
+const Location = z.enum(['pantry', 'fridge', 'freezer', 'other']);
+const SourceType = z.enum(['purchase', 'recipe_run', 'gift', 'other']);
+
+const FridgeBatchRowSchema = z.object({
+  id: z.number().int().positive(),
+  variantName: z.string().nullable(),
+  variantSlug: z.string().nullable(),
+  prepStateLabel: z.string().nullable(),
+  qtyRemaining: z.number(),
+  unit: Unit,
+  expiresAt: z.string().nullable(),
+  daysToExpiry: z.number().int().nullable(),
+  producedAt: z.string(),
+  sourceType: SourceType,
+  sourceRecipeSlug: z.string().nullable(),
+  notes: z.string().nullable(),
+  deletedAt: z.string().nullable(),
+});
+
+const FridgeIngredientGroupSchema = z.object({
+  ingredientId: z.number().int().positive(),
+  ingredientName: z.string(),
+  ingredientSlug: z.string(),
+  batches: z.array(FridgeBatchRowSchema).readonly(),
+});
+
+const FridgeLocationSectionSchema = z.object({
+  location: Location,
+  count: z.number().int(),
+  ingredients: z.array(FridgeIngredientGroupSchema).readonly(),
+});
+
+const FridgeViewSchema = z.object({
+  sections: z.array(FridgeLocationSectionSchema).readonly(),
+  counts: z.object({
+    visible: z.number().int(),
+    empty: z.number().int(),
+    deleted: z.number().int(),
+  }),
+});
+
+const RecipeForCookRowSchema = z.object({
+  recipeId: z.number().int().positive(),
+  recipeSlug: z.string(),
+  title: z.string(),
+  recipeType: z.string().nullable(),
+  lineCount: z.number().int(),
+  recipeNeedsQty: z.number().nullable(),
+  lastCookedAt: z.string().nullable(),
+});
+
+export const foodFridgeContract = c.router({
+  view: {
+    method: 'POST',
+    path: '/fridge/view',
+    body: z.object({
+      search: z.string().trim().max(120).optional(),
+      locations: z.array(Location).min(1).max(4).optional(),
+      expiringSoon: z.boolean().optional(),
+      recipeYieldedOnly: z.boolean().optional(),
+      includeEmpty: z.boolean().optional(),
+      includeDeleted: z.boolean().optional(),
+    }),
+    responses: { 200: FridgeViewSchema },
+    summary: 'Fridge/pantry view grouped by location → ingredient → batch',
+  },
+  recipesUsingBatch: {
+    method: 'GET',
+    path: '/fridge/recipes-using-batch',
+    query: z.object({
+      batchId: QueryPositiveInt,
+      limit: z.coerce.number().int().positive().max(100).optional(),
+    }),
+    responses: { 200: z.object({ items: z.array(RecipeForCookRowSchema).readonly() }) },
+    summary: 'Recipes that reference the batch’s variant (FIFO cook suggestions)',
+  },
+});

--- a/pillars/food/src/contract/rest.ts
+++ b/pillars/food/src/contract/rest.ts
@@ -15,7 +15,9 @@
 import { initContract } from '@ts-rest/core';
 
 import { foodAliasesContract } from './rest-aliases.js';
+import { foodBatchesContract } from './rest-batches.js';
 import { foodConversionsContract } from './rest-conversions.js';
+import { foodFridgeContract } from './rest-fridge.js';
 import { foodIngredientTagsContract } from './rest-ingredient-tags.js';
 import { foodIngredientsContract } from './rest-ingredients.js';
 import { foodPrepStatesContract } from './rest-prep-states.js';
@@ -29,7 +31,9 @@ const c = initContract();
 export const foodContract = c.router(
   {
     aliases: foodAliasesContract,
+    batches: foodBatchesContract,
     conversions: foodConversionsContract,
+    fridge: foodFridgeContract,
     ingredients: foodIngredientsContract,
     ingredientTags: foodIngredientTagsContract,
     prepStates: foodPrepStatesContract,

--- a/pillars/food/src/db/index.ts
+++ b/pillars/food/src/db/index.ts
@@ -57,6 +57,30 @@ export type {
   BulkApproveAliasesResult,
   MergeAliasesResult,
 } from './services/aliases.js';
+// Batch + fridge domain view types — re-exported so the api-layer
+// resolvers (batches/fridge) can name them via the db barrel.
+export type {
+  BatchAdjustReason,
+  BatchAdjustResult,
+  BatchDetail,
+  BatchEditPatch,
+  BatchError,
+  BatchForConsumeRow,
+  BatchLocation,
+  BatchMutationResult,
+  BatchSourceType,
+  BatchUnit,
+  ManualBatchInput,
+  ManualBatchSourceType,
+} from '../domain/types/batches.js';
+export type {
+  FridgeBatchRow,
+  FridgeIngredientGroup,
+  FridgeLocationSection,
+  FridgeView,
+  FridgeViewCounts,
+  RecipeForCookRow,
+} from '../domain/types/fridge.js';
 export type {
   ApproveRejectError,
   ApproveRejectFailure,


### PR DESCRIPTION
Slice 3 (part a) of the food tRPC→REST migration (`docs/runbooks/food-rest-migration.md`), after #3339–#3343. Ports **batches** and **fridge**; the **inbox** domain (9 procedures, large inspector view) follows in 3b.

## Domains
- **batches** — `POST /batches` (201/400), `GET /batches/:id` (404 on missing), `POST /batches/:id/relocate`, `PATCH /batches/:id`, `POST /batches/:id/adjust`, `DELETE /batches/:id`, `POST /batches/search-for-consume`. Lifecycle mutations return the service's discriminated `{ ok, ... }` result on 200 (FE narrows on it). The `get` / `search-for-consume` resolvers are lifted into `src/api/modules/batches/`.
- **fridge** — `POST /fridge/view` (grouped location→ingredient→batch projection), `GET /fridge/recipes-using-batch`. The view/query/grouping helpers are lifted into `src/api/modules/fridge/`.

`fridge.view` and `batches.searchForConsume` are POST-with-body (array/filter shapes). searchForConsume is POST specifically so its literal path isn't shadowed by `GET /batches/:id` — ts-rest/express does not register a literal segment ahead of a param one.

The batch/fridge domain view types are re-exported from the pillar db barrel for the api-layer resolvers.

## Safety
- Additive to the pillar only — `apps/pops-api` untouched (resolvers copied, not moved).
- Validated locally: typecheck, lint, format, build, OpenAPI + api-types drift, **845 tests (67 files) green**; OpenAPI idempotent.

## Remaining
inbox (3b) → recipes (+send-to-list, hero-image) → plan/shopping → ingest/ai → Phase C/D/E.