### PR TITLE
feat(food): REST migration slice 3b — inbox

### DIFF
--- a/pillars/food/migrations/0062_food_ai_inference_log.sql
+++ b/pillars/food/migrations/0062_food_ai_inference_log.sql
@@ -1,0 +1,29 @@
+CREATE TABLE "ai_inference_log" (
+  `id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  `provider` text NOT NULL,
+  `model` text NOT NULL,
+  `operation` text NOT NULL,
+  `domain` text,
+  `input_tokens` integer NOT NULL DEFAULT 0,
+  `output_tokens` integer NOT NULL DEFAULT 0,
+  `cost_usd` real NOT NULL DEFAULT 0,
+  `latency_ms` integer NOT NULL DEFAULT 0,
+  `status` text NOT NULL DEFAULT 'success',
+  `cached` integer NOT NULL DEFAULT 0,
+  `context_id` text,
+  `error_message` text,
+  `metadata` text,
+  `created_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `idx_ai_inference_log_context_id` ON `ai_inference_log` (`context_id`);
+--> statement-breakpoint
+CREATE INDEX `idx_ai_inference_log_created_at` ON `ai_inference_log` (`created_at`);
+--> statement-breakpoint
+CREATE INDEX `idx_ai_inference_log_domain` ON `ai_inference_log` (`domain`);
+--> statement-breakpoint
+CREATE INDEX `idx_ai_inference_log_operation` ON `ai_inference_log` (`operation`);
+--> statement-breakpoint
+CREATE INDEX `idx_ai_inference_log_provider_model` ON `ai_inference_log` (`provider`, `model`);
+--> statement-breakpoint
+CREATE INDEX `idx_ai_inference_log_status` ON `ai_inference_log` (`status`);

--- a/pillars/food/migrations/meta/_journal.json
+++ b/pillars/food/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1781500777654,
       "tag": "0061_food_remainder",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1781500777655,
+      "tag": "0062_food_ai_inference_log",
+      "breakpoints": true
     }
   ]
 }

--- a/pillars/food/openapi/food.openapi.json
+++ b/pillars/food/openapi/food.openapi.json
@@ -3326,6 +3326,938 @@
         "tags": ["fridge"]
       }
     },
+    "/inbox/approve": {
+      "post": {
+        "operationId": "inbox.approve",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "versionId": {
+                    "exclusiveMinimum": true,
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
+                "required": ["versionId"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "ok": {
+                          "enum": [true],
+                          "type": "boolean"
+                        },
+                        "promotedVersionNo": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer"
+                        },
+                        "recipeSlug": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["ok", "recipeSlug", "promotedVersionNo"],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "ok": {
+                          "enum": [false],
+                          "type": "boolean"
+                        },
+                        "reason": {
+                          "enum": [
+                            "NotIngestOriginated",
+                            "VersionNotFound",
+                            "NotADraft",
+                            "NotArchived",
+                            "NoRejectionRecord",
+                            "NotCompiled",
+                            "AlreadyReviewed",
+                            "RecipeArchived",
+                            "ConcurrentPromotion",
+                            "NoteRequired",
+                            "NoteTooLong"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": ["ok", "reason"],
+                      "type": "object"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Approve (promote) an ingest draft version",
+        "tags": ["inbox"]
+      }
+    },
+    "/inbox/failed": {
+      "post": {
+        "operationId": "inbox.listFailed",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "cursor": {
+                    "type": "string"
+                  },
+                  "errorCodes": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "kinds": {
+                    "items": {
+                      "enum": ["url-web", "url-instagram", "text", "screenshot"],
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "limit": {
+                    "exclusiveMinimum": true,
+                    "maximum": 100,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "sinceDays": {
+                    "anyOf": [
+                      {
+                        "enum": [7],
+                        "type": "number"
+                      },
+                      {
+                        "enum": [30],
+                        "type": "number"
+                      },
+                      {
+                        "enum": [90],
+                        "type": "number"
+                      }
+                    ],
+                    "nullable": true
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "items": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "attempts": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "type": "integer"
+                          },
+                          "errorCode": {
+                            "type": "string"
+                          },
+                          "errorMessage": {
+                            "type": "string"
+                          },
+                          "ingestKind": {
+                            "enum": ["url-web", "url-instagram", "text", "screenshot"],
+                            "type": "string"
+                          },
+                          "ingestedAt": {
+                            "type": "string"
+                          },
+                          "sourceId": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "type": "integer"
+                          },
+                          "sourceUrl": {
+                            "nullable": true,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "sourceId",
+                          "ingestKind",
+                          "sourceUrl",
+                          "errorCode",
+                          "errorMessage",
+                          "ingestedAt",
+                          "attempts"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "nextCursor": {
+                      "nullable": true,
+                      "type": "string"
+                    }
+                  },
+                  "required": ["items", "nextCursor"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "List failed ingest sources",
+        "tags": ["inbox"]
+      }
+    },
+    "/inbox/failed/error-codes": {
+      "get": {
+        "operationId": "inbox.failedErrorCodes",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "items": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": ["items"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Distinct error codes across failed ingests",
+        "tags": ["inbox"]
+      }
+    },
+    "/inbox/list": {
+      "post": {
+        "operationId": "inbox.list",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "bands": {
+                    "items": {
+                      "enum": ["clean", "minor", "attention", "blocked"],
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "cursor": {
+                    "type": "string"
+                  },
+                  "freshOnly": {
+                    "type": "boolean"
+                  },
+                  "kinds": {
+                    "items": {
+                      "enum": ["url-web", "url-instagram", "text", "screenshot"],
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "limit": {
+                    "exclusiveMinimum": true,
+                    "maximum": 100,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "partialReasons": {
+                    "items": {
+                      "enum": [
+                        "auth-dead",
+                        "rate-limited",
+                        "stt-failed",
+                        "vision-failed",
+                        "caption-only-fallback",
+                        "empty-extraction"
+                      ],
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "sort": {
+                    "enum": ["quality-asc", "quality-desc", "oldest", "newest"],
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "items": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "compileStatus": {
+                            "enum": ["uncompiled", "compiled", "failed"],
+                            "type": "string"
+                          },
+                          "creationCount": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "type": "integer"
+                          },
+                          "ingestKind": {
+                            "enum": ["url-web", "url-instagram", "text", "screenshot"],
+                            "type": "string"
+                          },
+                          "ingestedAt": {
+                            "type": "string"
+                          },
+                          "partialReason": {
+                            "enum": [
+                              "auth-dead",
+                              "rate-limited",
+                              "stt-failed",
+                              "vision-failed",
+                              "caption-only-fallback",
+                              "empty-extraction"
+                            ],
+                            "type": "string"
+                          },
+                          "proposedSlugCount": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "type": "integer"
+                          },
+                          "qualityBand": {
+                            "enum": ["clean", "minor", "attention", "blocked"],
+                            "type": "string"
+                          },
+                          "qualityScore": {
+                            "type": "number"
+                          },
+                          "recipeSlug": {
+                            "type": "string"
+                          },
+                          "recipeType": {
+                            "enum": [
+                              "plate",
+                              "component",
+                              "technique",
+                              "sauce",
+                              "dressing",
+                              "drink",
+                              "condiment"
+                            ],
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "sourceId": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "type": "integer"
+                          },
+                          "sourceUrl": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "title": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "topSignals": {
+                            "items": {
+                              "additionalProperties": false,
+                              "properties": {
+                                "code": {
+                                  "type": "string"
+                                },
+                                "detail": {
+                                  "type": "string"
+                                },
+                                "weight": {
+                                  "type": "number"
+                                }
+                              },
+                              "required": ["code", "weight"],
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "versionId": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "sourceId",
+                          "versionId",
+                          "recipeSlug",
+                          "title",
+                          "recipeType",
+                          "ingestKind",
+                          "sourceUrl",
+                          "ingestedAt",
+                          "qualityBand",
+                          "qualityScore",
+                          "topSignals",
+                          "proposedSlugCount",
+                          "creationCount",
+                          "compileStatus"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "nextCursor": {
+                      "nullable": true,
+                      "type": "string"
+                    }
+                  },
+                  "required": ["items", "nextCursor"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "List ingest drafts (scored + paginated)",
+        "tags": ["inbox"]
+      }
+    },
+    "/inbox/pending-count": {
+      "get": {
+        "operationId": "inbox.pendingCount",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "count": {
+                      "maximum": 9007199254740991,
+                      "minimum": -9007199254740991,
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["count"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Unfiltered pending-draft queue depth",
+        "tags": ["inbox"]
+      }
+    },
+    "/inbox/reject": {
+      "post": {
+        "operationId": "inbox.reject",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "note": {
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "reason": {
+                    "enum": [
+                      "wrong-recipe",
+                      "low-quality-extraction",
+                      "duplicate",
+                      "not-a-recipe",
+                      "other"
+                    ],
+                    "type": "string"
+                  },
+                  "versionId": {
+                    "exclusiveMinimum": true,
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
+                "required": ["versionId", "reason"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "ok": {
+                          "enum": [true],
+                          "type": "boolean"
+                        }
+                      },
+                      "required": ["ok"],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "ok": {
+                          "enum": [false],
+                          "type": "boolean"
+                        },
+                        "reason": {
+                          "enum": [
+                            "NotIngestOriginated",
+                            "VersionNotFound",
+                            "NotADraft",
+                            "NotArchived",
+                            "NoRejectionRecord",
+                            "NotCompiled",
+                            "AlreadyReviewed",
+                            "RecipeArchived",
+                            "ConcurrentPromotion",
+                            "NoteRequired",
+                            "NoteTooLong"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": ["ok", "reason"],
+                      "type": "object"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Reject an ingest draft version",
+        "tags": ["inbox"]
+      }
+    },
+    "/inbox/rejected": {
+      "post": {
+        "operationId": "inbox.listRejected",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "cursor": {
+                    "type": "string"
+                  },
+                  "kinds": {
+                    "items": {
+                      "enum": ["url-web", "url-instagram", "text", "screenshot"],
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "limit": {
+                    "exclusiveMinimum": true,
+                    "maximum": 100,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "reasons": {
+                    "items": {
+                      "enum": [
+                        "wrong-recipe",
+                        "low-quality-extraction",
+                        "duplicate",
+                        "not-a-recipe",
+                        "other"
+                      ],
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "sinceDays": {
+                    "anyOf": [
+                      {
+                        "enum": [7],
+                        "type": "number"
+                      },
+                      {
+                        "enum": [30],
+                        "type": "number"
+                      },
+                      {
+                        "enum": [90],
+                        "type": "number"
+                      }
+                    ],
+                    "nullable": true
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "items": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "ingestCostUsd": {
+                            "nullable": true,
+                            "type": "number"
+                          },
+                          "ingestKind": {
+                            "enum": ["url-web", "url-instagram", "text", "screenshot"],
+                            "type": "string"
+                          },
+                          "note": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "reason": {
+                            "enum": [
+                              "wrong-recipe",
+                              "low-quality-extraction",
+                              "duplicate",
+                              "not-a-recipe",
+                              "other"
+                            ],
+                            "type": "string"
+                          },
+                          "recipeSlug": {
+                            "type": "string"
+                          },
+                          "rejectedAt": {
+                            "type": "string"
+                          },
+                          "sourceId": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "type": "integer"
+                          },
+                          "sourceUrl": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "title": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "versionId": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "versionId",
+                          "recipeSlug",
+                          "sourceId",
+                          "title",
+                          "reason",
+                          "note",
+                          "rejectedAt",
+                          "ingestKind",
+                          "sourceUrl",
+                          "ingestCostUsd"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "nextCursor": {
+                      "nullable": true,
+                      "type": "string"
+                    }
+                  },
+                  "required": ["items", "nextCursor"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "List rejected draft versions",
+        "tags": ["inbox"]
+      }
+    },
+    "/inbox/review": {
+      "get": {
+        "operationId": "inbox.getForReview",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "sourceId",
+            "required": true,
+            "schema": {
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "ok": {
+                          "enum": [true],
+                          "type": "boolean"
+                        },
+                        "review": {}
+                      },
+                      "required": ["ok", "review"],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "ok": {
+                          "enum": [false],
+                          "type": "boolean"
+                        },
+                        "reason": {
+                          "enum": ["SourceNotFound"],
+                          "type": "string"
+                        }
+                      },
+                      "required": ["ok", "reason"],
+                      "type": "object"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Per-draft inspector view (source + draft aggregate)",
+        "tags": ["inbox"]
+      }
+    },
+    "/inbox/unreject": {
+      "post": {
+        "operationId": "inbox.unreject",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "versionId": {
+                    "exclusiveMinimum": true,
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
+                "required": ["versionId"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "ok": {
+                          "enum": [true],
+                          "type": "boolean"
+                        },
+                        "restoredAs": {
+                          "enum": ["draft"],
+                          "type": "string"
+                        }
+                      },
+                      "required": ["ok", "restoredAs"],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "ok": {
+                          "enum": [false],
+                          "type": "boolean"
+                        },
+                        "reason": {
+                          "enum": [
+                            "NotIngestOriginated",
+                            "VersionNotFound",
+                            "NotADraft",
+                            "NotArchived",
+                            "NoRejectionRecord",
+                            "NotCompiled",
+                            "AlreadyReviewed",
+                            "RecipeArchived",
+                            "ConcurrentPromotion",
+                            "NoteRequired",
+                            "NoteTooLong"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": ["ok", "reason"],
+                      "type": "object"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Restore a rejected draft back to draft",
+        "tags": ["inbox"]
+      }
+    },
     "/ingredient-tags": {
       "get": {
         "operationId": "ingredientTags.list",

--- a/pillars/food/src/api/__tests__/inbox.test.ts
+++ b/pillars/food/src/api/__tests__/inbox.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Integration tests for the `inbox.*` REST surface — recipe-ingest triage
+ * (PRD-134/135/136/138). Pure DB reads/writes; mutations + inspector return
+ * the service's discriminated result on 200. Draft scoring / cursor maths
+ * live in the db-layer tests; here we assert the wire envelopes + the
+ * empty/not-found paths.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { type OpenedFoodDb, openFoodDb } from '../../db/index.js';
+import { createFoodApiApp } from '../app.js';
+import { makeClient } from './test-utils.js';
+
+let tmpDir: string;
+let foodDb: OpenedFoodDb;
+
+function client(): ReturnType<typeof makeClient> {
+  return makeClient(
+    createFoodApiApp({ foodDb, version: '0.0.1-test', selfBaseUrl: 'http://localhost:3005' })
+  );
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'food-api-inbox-test-'));
+  foodDb = openFoodDb(join(tmpDir, 'food.db'));
+});
+
+afterEach(() => {
+  foodDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('inbox REST — empty-queue reads', () => {
+  it('reports an empty pending count and no failed error codes', async () => {
+    const api = client();
+    expect(await api.inbox.pendingCount()).toEqual({ count: 0 });
+    expect(await api.inbox.failedErrorCodes()).toEqual({ items: [] });
+  });
+
+  it('returns empty paginated lists', async () => {
+    const api = client();
+    expect(await api.inbox.list()).toEqual({ items: [], nextCursor: null });
+    expect(await api.inbox.listRejected()).toEqual({ items: [], nextCursor: null });
+    expect(await api.inbox.listFailed()).toEqual({ items: [], nextCursor: null });
+  });
+});
+
+describe('inbox REST — mutation + inspector guards', () => {
+  it('reports VersionNotFound when approving a missing version', async () => {
+    expect(await client().inbox.approve(999999)).toEqual({
+      ok: false,
+      reason: 'VersionNotFound',
+    });
+  });
+
+  it('reports NoteRequired when rejecting with reason=other and no note', async () => {
+    const res = await client().inbox.reject(999999, 'other');
+    expect(res).toMatchObject({ ok: false });
+  });
+
+  it('reports SourceNotFound for an unknown inspector source', async () => {
+    expect(await client().inbox.getForReview(999999)).toEqual({
+      ok: false,
+      reason: 'SourceNotFound',
+    });
+  });
+});

--- a/pillars/food/src/api/__tests__/test-utils.ts
+++ b/pillars/food/src/api/__tests__/test-utils.ts
@@ -149,6 +149,16 @@ interface FridgeView {
   counts: { visible: number; empty: number; deleted: number };
 }
 
+type ApproveResult =
+  | { ok: true; recipeSlug: string; promotedVersionNo: number }
+  | { ok: false; reason: string };
+type SimpleOkResult = { ok: true } | { ok: false; reason: string };
+type InspectorResult = { ok: true; review: unknown } | { ok: false; reason: 'SourceNotFound' };
+interface ListPage<T> {
+  items: T[];
+  nextCursor: string | null;
+}
+
 export class HttpError extends Error {
   readonly status: number;
   readonly body: unknown;
@@ -343,6 +353,24 @@ export function makeClient(app: Express) {
       ) => send<FridgeView>(r.post('/fridge/view').send(body)),
       recipesUsingBatch: (batchId: number, limit?: number) =>
         send<{ items: unknown[] }>(r.get('/fridge/recipes-using-batch').query({ batchId, limit })),
+    },
+    inbox: {
+      approve: (versionId: number) =>
+        send<ApproveResult>(r.post('/inbox/approve').send({ versionId })),
+      reject: (versionId: number, reason: string, note?: string | null) =>
+        send<SimpleOkResult>(r.post('/inbox/reject').send({ versionId, reason, note })),
+      unreject: (versionId: number) =>
+        send<SimpleOkResult>(r.post('/inbox/unreject').send({ versionId })),
+      list: (body: { limit?: number; cursor?: string } = {}) =>
+        send<ListPage<{ versionId: number }>>(r.post('/inbox/list').send(body)),
+      listRejected: (body: { limit?: number } = {}) =>
+        send<ListPage<{ versionId: number }>>(r.post('/inbox/rejected').send(body)),
+      listFailed: (body: { limit?: number } = {}) =>
+        send<ListPage<{ sourceId: number }>>(r.post('/inbox/failed').send(body)),
+      failedErrorCodes: () => send<{ items: string[] }>(r.get('/inbox/failed/error-codes')),
+      pendingCount: () => send<{ count: number }>(r.get('/inbox/pending-count')),
+      getForReview: (sourceId: number) =>
+        send<InspectorResult>(r.get('/inbox/review').query({ sourceId })),
     },
   };
 }

--- a/pillars/food/src/api/rest/handlers.ts
+++ b/pillars/food/src/api/rest/handlers.ts
@@ -13,6 +13,7 @@ import { makeAliasesHandlers } from './aliases-handlers.js';
 import { makeBatchesHandlers } from './batches-handlers.js';
 import { makeConversionsHandlers } from './conversions-handlers.js';
 import { makeFridgeHandlers } from './fridge-handlers.js';
+import { makeInboxHandlers } from './inbox-handlers.js';
 import { makeIngredientTagsHandlers } from './ingredient-tags-handlers.js';
 import { makeIngredientsHandlers } from './ingredients-handlers.js';
 import { makePrepStatesHandlers } from './prep-states-handlers.js';
@@ -32,6 +33,7 @@ export function makeFoodRestHandlers(deps: {
     batches: makeBatchesHandlers(db),
     conversions: makeConversionsHandlers(db),
     fridge: makeFridgeHandlers(db),
+    inbox: makeInboxHandlers(db),
     ingredients: makeIngredientsHandlers(db),
     ingredientTags: makeIngredientTagsHandlers(db),
     prepStates: makePrepStatesHandlers(db),

--- a/pillars/food/src/api/rest/inbox-handlers.ts
+++ b/pillars/food/src/api/rest/inbox-handlers.ts
@@ -1,0 +1,99 @@
+/**
+ * Handlers for the `inbox.*` sub-router. Pure DB reads/writes; mutations
+ * and the inspector return the service's discriminated result on 200. The
+ * list endpoints decode the opaque string cursor into the service's cursor
+ * shape and apply the default page size.
+ */
+import { inboxInspectorService, inboxQueries, inboxService } from '../../db/index.js';
+import { runHttp } from './error-mapping.js';
+
+import type { ServerInferRequest } from '@ts-rest/core';
+
+import type { foodInboxContract } from '../../contract/rest-inbox.js';
+import type { FoodDb } from '../../db/index.js';
+
+type Req = ServerInferRequest<typeof foodInboxContract>;
+
+const DEFAULT_LIMIT = 20;
+
+export function makeInboxHandlers(db: FoodDb) {
+  return {
+    approve: ({ body }: Req['approve']) =>
+      runHttp(() => ({
+        status: 200 as const,
+        body: inboxService.approveDraft(db, body.versionId),
+      })),
+
+    reject: ({ body }: Req['reject']) =>
+      runHttp(() => ({
+        status: 200 as const,
+        body: inboxService.rejectDraft(db, {
+          versionId: body.versionId,
+          reason: body.reason,
+          note: body.note,
+        }),
+      })),
+
+    unreject: ({ body }: Req['unreject']) =>
+      runHttp(() => ({
+        status: 200 as const,
+        body: inboxService.unrejectDraft(db, body.versionId),
+      })),
+
+    list: ({ body }: Req['list']) =>
+      runHttp(() => ({
+        status: 200 as const,
+        body: inboxQueries.listDrafts(db, {
+          bands: body.bands,
+          kinds: body.kinds,
+          partialReasons: body.partialReasons,
+          freshOnly: body.freshOnly,
+          sort: body.sort,
+          cursor: body.cursor === undefined ? null : inboxQueries.decodeDraftsCursor(body.cursor),
+          limit: body.limit ?? DEFAULT_LIMIT,
+        }),
+      })),
+
+    listRejected: ({ body }: Req['listRejected']) =>
+      runHttp(() => ({
+        status: 200 as const,
+        body: inboxQueries.listRejectedVersions(db, {
+          reasons: body.reasons,
+          kinds: body.kinds,
+          sinceDays: body.sinceDays,
+          cursor: body.cursor === undefined ? null : inboxQueries.decodeCursor(body.cursor),
+          limit: body.limit ?? DEFAULT_LIMIT,
+        }),
+      })),
+
+    listFailed: ({ body }: Req['listFailed']) =>
+      runHttp(() => ({
+        status: 200 as const,
+        body: inboxQueries.listFailedSources(db, {
+          errorCodes: body.errorCodes,
+          kinds: body.kinds,
+          sinceDays: body.sinceDays,
+          cursor: body.cursor === undefined ? null : inboxQueries.decodeCursor(body.cursor),
+          limit: body.limit ?? DEFAULT_LIMIT,
+        }),
+      })),
+
+    failedErrorCodes: () =>
+      runHttp(() => ({
+        status: 200 as const,
+        body: { items: inboxQueries.listFailedErrorCodes(db) },
+      })),
+
+    pendingCount: () =>
+      runHttp(() => ({
+        status: 200 as const,
+        body: { count: inboxQueries.countPendingDrafts(db) },
+      })),
+
+    getForReview: ({ query }: Req['getForReview']) =>
+      runHttp(() => ({
+        status: 200 as const,
+        body: inboxInspectorService.getInspectorView(db, query.sourceId),
+      })),
+  };
+}

--- a/pillars/food/src/contract/api-types.generated.ts
+++ b/pillars/food/src/contract/api-types.generated.ts
@@ -300,6 +300,159 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/inbox/approve': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Approve (promote) an ingest draft version */
+    post: operations['inbox.approve'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/inbox/failed': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** List failed ingest sources */
+    post: operations['inbox.listFailed'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/inbox/failed/error-codes': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Distinct error codes across failed ingests */
+    get: operations['inbox.failedErrorCodes'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/inbox/list': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** List ingest drafts (scored + paginated) */
+    post: operations['inbox.list'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/inbox/pending-count': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Unfiltered pending-draft queue depth */
+    get: operations['inbox.pendingCount'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/inbox/reject': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Reject an ingest draft version */
+    post: operations['inbox.reject'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/inbox/rejected': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** List rejected draft versions */
+    post: operations['inbox.listRejected'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/inbox/review': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Per-draft inspector view (source + draft aggregate) */
+    get: operations['inbox.getForReview'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/inbox/unreject': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Restore a rejected draft back to draft */
+    post: operations['inbox.unreject'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/ingredient-tags': {
     parameters: {
       query?: never;
@@ -2168,6 +2321,462 @@ export interface operations {
               location: 'pantry' | 'fridge' | 'freezer' | 'other';
             }[];
           };
+        };
+      };
+    };
+  };
+  'inbox.approve': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          versionId: number;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json':
+            | {
+                /** @enum {boolean} */
+                ok: true;
+                promotedVersionNo: number;
+                recipeSlug: string;
+              }
+            | {
+                /** @enum {boolean} */
+                ok: false;
+                /** @enum {string} */
+                reason:
+                  | 'NotIngestOriginated'
+                  | 'VersionNotFound'
+                  | 'NotADraft'
+                  | 'NotArchived'
+                  | 'NoRejectionRecord'
+                  | 'NotCompiled'
+                  | 'AlreadyReviewed'
+                  | 'RecipeArchived'
+                  | 'ConcurrentPromotion'
+                  | 'NoteRequired'
+                  | 'NoteTooLong';
+              };
+        };
+      };
+    };
+  };
+  'inbox.listFailed': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          cursor?: string;
+          errorCodes?: string[];
+          kinds?: ('url-web' | 'url-instagram' | 'text' | 'screenshot')[];
+          limit?: number;
+          sinceDays?: (7 | 30 | 90) | null;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            items: {
+              attempts: number;
+              errorCode: string;
+              errorMessage: string;
+              /** @enum {string} */
+              ingestKind: 'url-web' | 'url-instagram' | 'text' | 'screenshot';
+              ingestedAt: string;
+              sourceId: number;
+              sourceUrl: string | null;
+            }[];
+            nextCursor: string | null;
+          };
+        };
+      };
+    };
+  };
+  'inbox.failedErrorCodes': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            items: string[];
+          };
+        };
+      };
+    };
+  };
+  'inbox.list': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          bands?: ('clean' | 'minor' | 'attention' | 'blocked')[];
+          cursor?: string;
+          freshOnly?: boolean;
+          kinds?: ('url-web' | 'url-instagram' | 'text' | 'screenshot')[];
+          limit?: number;
+          partialReasons?: (
+            | 'auth-dead'
+            | 'rate-limited'
+            | 'stt-failed'
+            | 'vision-failed'
+            | 'caption-only-fallback'
+            | 'empty-extraction'
+          )[];
+          /** @enum {string} */
+          sort?: 'quality-asc' | 'quality-desc' | 'oldest' | 'newest';
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            items: {
+              /** @enum {string} */
+              compileStatus: 'uncompiled' | 'compiled' | 'failed';
+              creationCount: number;
+              /** @enum {string} */
+              ingestKind: 'url-web' | 'url-instagram' | 'text' | 'screenshot';
+              ingestedAt: string;
+              /** @enum {string} */
+              partialReason?:
+                | 'auth-dead'
+                | 'rate-limited'
+                | 'stt-failed'
+                | 'vision-failed'
+                | 'caption-only-fallback'
+                | 'empty-extraction';
+              proposedSlugCount: number;
+              /** @enum {string} */
+              qualityBand: 'clean' | 'minor' | 'attention' | 'blocked';
+              qualityScore: number;
+              recipeSlug: string;
+              /** @enum {string|null} */
+              recipeType:
+                | 'plate'
+                | 'component'
+                | 'technique'
+                | 'sauce'
+                | 'dressing'
+                | 'drink'
+                | 'condiment'
+                | null;
+              sourceId: number;
+              sourceUrl: string | null;
+              title: string | null;
+              topSignals: {
+                code: string;
+                detail?: string;
+                weight: number;
+              }[];
+              versionId: number;
+            }[];
+            nextCursor: string | null;
+          };
+        };
+      };
+    };
+  };
+  'inbox.pendingCount': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            count: number;
+          };
+        };
+      };
+    };
+  };
+  'inbox.reject': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          note?: string | null;
+          /** @enum {string} */
+          reason:
+            | 'wrong-recipe'
+            | 'low-quality-extraction'
+            | 'duplicate'
+            | 'not-a-recipe'
+            | 'other';
+          versionId: number;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json':
+            | {
+                /** @enum {boolean} */
+                ok: true;
+              }
+            | {
+                /** @enum {boolean} */
+                ok: false;
+                /** @enum {string} */
+                reason:
+                  | 'NotIngestOriginated'
+                  | 'VersionNotFound'
+                  | 'NotADraft'
+                  | 'NotArchived'
+                  | 'NoRejectionRecord'
+                  | 'NotCompiled'
+                  | 'AlreadyReviewed'
+                  | 'RecipeArchived'
+                  | 'ConcurrentPromotion'
+                  | 'NoteRequired'
+                  | 'NoteTooLong';
+              };
+        };
+      };
+    };
+  };
+  'inbox.listRejected': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          cursor?: string;
+          kinds?: ('url-web' | 'url-instagram' | 'text' | 'screenshot')[];
+          limit?: number;
+          reasons?: (
+            | 'wrong-recipe'
+            | 'low-quality-extraction'
+            | 'duplicate'
+            | 'not-a-recipe'
+            | 'other'
+          )[];
+          sinceDays?: (7 | 30 | 90) | null;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            items: {
+              ingestCostUsd: number | null;
+              /** @enum {string} */
+              ingestKind: 'url-web' | 'url-instagram' | 'text' | 'screenshot';
+              note: string | null;
+              /** @enum {string} */
+              reason:
+                | 'wrong-recipe'
+                | 'low-quality-extraction'
+                | 'duplicate'
+                | 'not-a-recipe'
+                | 'other';
+              recipeSlug: string;
+              rejectedAt: string;
+              sourceId: number;
+              sourceUrl: string | null;
+              title: string | null;
+              versionId: number;
+            }[];
+            nextCursor: string | null;
+          };
+        };
+      };
+    };
+  };
+  'inbox.getForReview': {
+    parameters: {
+      query: {
+        sourceId: number;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json':
+            | {
+                /** @enum {boolean} */
+                ok: true;
+                review: unknown;
+              }
+            | {
+                /** @enum {boolean} */
+                ok: false;
+                /** @enum {string} */
+                reason: 'SourceNotFound';
+              };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'inbox.unreject': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          versionId: number;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json':
+            | {
+                /** @enum {boolean} */
+                ok: true;
+                /** @enum {string} */
+                restoredAs: 'draft';
+              }
+            | {
+                /** @enum {boolean} */
+                ok: false;
+                /** @enum {string} */
+                reason:
+                  | 'NotIngestOriginated'
+                  | 'VersionNotFound'
+                  | 'NotADraft'
+                  | 'NotArchived'
+                  | 'NoRejectionRecord'
+                  | 'NotCompiled'
+                  | 'AlreadyReviewed'
+                  | 'RecipeArchived'
+                  | 'ConcurrentPromotion'
+                  | 'NoteRequired'
+                  | 'NoteTooLong';
+              };
         };
       };
     };

--- a/pillars/food/src/contract/rest-inbox-schemas.ts
+++ b/pillars/food/src/contract/rest-inbox-schemas.ts
@@ -1,0 +1,126 @@
+/**
+ * Shared zod building blocks for the `inbox.*` REST contract — enums, row
+ * schemas, page wrappers, and the approve/reject/unreject result unions.
+ * Split from `rest-inbox.ts` to keep that file's path map under the
+ * per-file line cap. Zod-only; no imports from `src/api/` or `src/db/`.
+ */
+import { z } from 'zod';
+
+export const IngestKind = z.enum(['url-web', 'url-instagram', 'text', 'screenshot']);
+export const RecipeType = z.enum([
+  'plate',
+  'component',
+  'technique',
+  'sauce',
+  'dressing',
+  'drink',
+  'condiment',
+]);
+export const QualityBand = z.enum(['clean', 'minor', 'attention', 'blocked']);
+export const CompileStatus = z.enum(['uncompiled', 'compiled', 'failed']);
+export const PartialReason = z.enum([
+  'auth-dead',
+  'rate-limited',
+  'stt-failed',
+  'vision-failed',
+  'caption-only-fallback',
+  'empty-extraction',
+]);
+export const RejectionReason = z.enum([
+  'wrong-recipe',
+  'low-quality-extraction',
+  'duplicate',
+  'not-a-recipe',
+  'other',
+]);
+export const DraftSort = z.enum(['quality-asc', 'quality-desc', 'oldest', 'newest']);
+export const SinceDays = z.union([z.literal(7), z.literal(30), z.literal(90)]);
+
+const ApproveRejectError = z.enum([
+  'NotIngestOriginated',
+  'VersionNotFound',
+  'NotADraft',
+  'NotArchived',
+  'NoRejectionRecord',
+  'NotCompiled',
+  'AlreadyReviewed',
+  'RecipeArchived',
+  'ConcurrentPromotion',
+  'NoteRequired',
+  'NoteTooLong',
+]);
+
+const Failure = z.object({ ok: z.literal(false), reason: ApproveRejectError });
+
+export const ApproveResult = z.discriminatedUnion('ok', [
+  z.object({ ok: z.literal(true), recipeSlug: z.string(), promotedVersionNo: z.number().int() }),
+  Failure,
+]);
+export const RejectResult = z.discriminatedUnion('ok', [
+  z.object({ ok: z.literal(true) }),
+  Failure,
+]);
+export const UnrejectResult = z.discriminatedUnion('ok', [
+  z.object({ ok: z.literal(true), restoredAs: z.literal('draft') }),
+  Failure,
+]);
+
+const QualitySignalSchema = z.object({
+  code: z.string(),
+  weight: z.number(),
+  detail: z.string().optional(),
+});
+
+const InboxDraftRowSchema = z.object({
+  sourceId: z.number().int(),
+  versionId: z.number().int(),
+  recipeSlug: z.string(),
+  title: z.string().nullable(),
+  recipeType: RecipeType.nullable(),
+  ingestKind: IngestKind,
+  sourceUrl: z.string().nullable(),
+  ingestedAt: z.string(),
+  qualityBand: QualityBand,
+  qualityScore: z.number(),
+  topSignals: z.array(QualitySignalSchema),
+  partialReason: PartialReason.optional(),
+  proposedSlugCount: z.number().int(),
+  creationCount: z.number().int(),
+  compileStatus: CompileStatus,
+});
+
+const RejectedRowSchema = z.object({
+  versionId: z.number().int(),
+  recipeSlug: z.string(),
+  sourceId: z.number().int(),
+  title: z.string().nullable(),
+  reason: RejectionReason,
+  note: z.string().nullable(),
+  rejectedAt: z.string(),
+  ingestKind: IngestKind,
+  sourceUrl: z.string().nullable(),
+  ingestCostUsd: z.number().nullable(),
+});
+
+const FailedRowSchema = z.object({
+  sourceId: z.number().int(),
+  ingestKind: IngestKind,
+  sourceUrl: z.string().nullable(),
+  errorCode: z.string(),
+  errorMessage: z.string(),
+  ingestedAt: z.string(),
+  attempts: z.number().int(),
+});
+
+export const DraftsPage = z.object({
+  items: z.array(InboxDraftRowSchema),
+  nextCursor: z.string().nullable(),
+});
+export const RejectedPage = z.object({
+  items: z.array(RejectedRowSchema),
+  nextCursor: z.string().nullable(),
+});
+export const FailedPage = z.object({
+  items: z.array(FailedRowSchema),
+  nextCursor: z.string().nullable(),
+});

--- a/pillars/food/src/contract/rest-inbox.ts
+++ b/pillars/food/src/contract/rest-inbox.ts
@@ -1,0 +1,121 @@
+/**
+ * `inbox.*` sub-router — recipe-ingest triage (PRD-134/135/136/138). Pure
+ * DB reads/writes. Mutations + inspector return the service's discriminated
+ * `{ ok, ... }` result on 200. List endpoints are POST-with-body (array
+ * filters + cursor). `getForReview.review` is projected as `unknown` (deep
+ * aggregate; consumers import the rich type from the api layer directly).
+ */
+import { initContract } from '@ts-rest/core';
+import { z } from 'zod';
+
+import {
+  ApproveResult,
+  DraftSort,
+  DraftsPage,
+  FailedPage,
+  IngestKind,
+  PartialReason,
+  QualityBand,
+  RejectResult,
+  RejectedPage,
+  RejectionReason,
+  SinceDays,
+  UnrejectResult,
+} from './rest-inbox-schemas.js';
+import { ERR_RESPONSES, QueryPositiveInt } from './rest-schemas.js';
+
+const c = initContract();
+
+export const foodInboxContract = c.router({
+  approve: {
+    method: 'POST',
+    path: '/inbox/approve',
+    body: z.object({ versionId: z.number().int().positive() }),
+    responses: { 200: ApproveResult },
+    summary: 'Approve (promote) an ingest draft version',
+  },
+  reject: {
+    method: 'POST',
+    path: '/inbox/reject',
+    body: z.object({
+      versionId: z.number().int().positive(),
+      reason: RejectionReason,
+      note: z.string().nullish(),
+    }),
+    responses: { 200: RejectResult },
+    summary: 'Reject an ingest draft version',
+  },
+  unreject: {
+    method: 'POST',
+    path: '/inbox/unreject',
+    body: z.object({ versionId: z.number().int().positive() }),
+    responses: { 200: UnrejectResult },
+    summary: 'Restore a rejected draft back to draft',
+  },
+  list: {
+    method: 'POST',
+    path: '/inbox/list',
+    body: z.object({
+      bands: z.array(QualityBand).optional(),
+      kinds: z.array(IngestKind).optional(),
+      partialReasons: z.array(PartialReason).optional(),
+      freshOnly: z.boolean().optional(),
+      sort: DraftSort.optional(),
+      cursor: z.string().optional(),
+      limit: z.number().int().positive().max(100).optional(),
+    }),
+    responses: { 200: DraftsPage },
+    summary: 'List ingest drafts (scored + paginated)',
+  },
+  listRejected: {
+    method: 'POST',
+    path: '/inbox/rejected',
+    body: z.object({
+      reasons: z.array(RejectionReason).optional(),
+      kinds: z.array(IngestKind).optional(),
+      sinceDays: SinceDays.nullish(),
+      cursor: z.string().optional(),
+      limit: z.number().int().positive().max(100).optional(),
+    }),
+    responses: { 200: RejectedPage },
+    summary: 'List rejected draft versions',
+  },
+  listFailed: {
+    method: 'POST',
+    path: '/inbox/failed',
+    body: z.object({
+      errorCodes: z.array(z.string()).optional(),
+      kinds: z.array(IngestKind).optional(),
+      sinceDays: SinceDays.nullish(),
+      cursor: z.string().optional(),
+      limit: z.number().int().positive().max(100).optional(),
+    }),
+    responses: { 200: FailedPage },
+    summary: 'List failed ingest sources',
+  },
+  failedErrorCodes: {
+    method: 'GET',
+    path: '/inbox/failed/error-codes',
+    responses: { 200: z.object({ items: z.array(z.string()) }) },
+    summary: 'Distinct error codes across failed ingests',
+  },
+  pendingCount: {
+    method: 'GET',
+    path: '/inbox/pending-count',
+    responses: { 200: z.object({ count: z.number().int() }) },
+    summary: 'Unfiltered pending-draft queue depth',
+  },
+  getForReview: {
+    method: 'GET',
+    path: '/inbox/review',
+    query: z.object({ sourceId: QueryPositiveInt }),
+    responses: {
+      200: z.discriminatedUnion('ok', [
+        z.object({ ok: z.literal(true), review: z.unknown() }),
+        z.object({ ok: z.literal(false), reason: z.literal('SourceNotFound') }),
+      ]),
+      ...ERR_RESPONSES,
+    },
+    summary: 'Per-draft inspector view (source + draft aggregate)',
+  },
+});

--- a/pillars/food/src/contract/rest.ts
+++ b/pillars/food/src/contract/rest.ts
@@ -18,6 +18,7 @@ import { foodAliasesContract } from './rest-aliases.js';
 import { foodBatchesContract } from './rest-batches.js';
 import { foodConversionsContract } from './rest-conversions.js';
 import { foodFridgeContract } from './rest-fridge.js';
+import { foodInboxContract } from './rest-inbox.js';
 import { foodIngredientTagsContract } from './rest-ingredient-tags.js';
 import { foodIngredientsContract } from './rest-ingredients.js';
 import { foodPrepStatesContract } from './rest-prep-states.js';
@@ -34,6 +35,7 @@ export const foodContract = c.router(
     batches: foodBatchesContract,
     conversions: foodConversionsContract,
     fridge: foodFridgeContract,
+    inbox: foodInboxContract,
     ingredients: foodIngredientsContract,
     ingredientTags: foodIngredientTagsContract,
     prepStates: foodPrepStatesContract,


### PR DESCRIPTION
Completes slice 3 of the food tRPC→REST migration (`docs/runbooks/food-rest-migration.md`), after #3339–#3346. Ports the **inbox** (recipe-ingest triage) domain.

## Surface (9 procedures)
- Mutations: `POST /inbox/approve`, `POST /inbox/reject`, `POST /inbox/unreject` — return the service's discriminated `{ ok, ... }` result (200).
- Lists (POST-with-body, array filters + opaque cursor): `POST /inbox/list`, `/inbox/rejected`, `/inbox/failed`.
- `GET /inbox/failed/error-codes`, `GET /inbox/pending-count`.
- `GET /inbox/review?sourceId` — the per-draft inspector (`{ ok:true, review } | { ok:false, reason:'SourceNotFound' }`).

All pure DB reads/writes over the in-pillar inbox services — no worker enqueue (that's the ingest slice). Contract building blocks split into `rest-inbox-schemas.ts` to stay under the per-file line cap. `getForReview.review` is projected as `unknown` (deep aggregate; the rich type lives in the api layer).

## Migration: ai_inference_log
The rejected-list AI-cost rollup (and the food worker's AI logging) read `ai_inference_log`, which the pillar's `food.db` was missing. Adds **`0062_food_ai_inference_log.sql`**.

## Safety
- Additive to the pillar only — `apps/pops-api` untouched.
- Validated locally: typecheck, lint, format, build, OpenAPI + api-types drift, **850 tests (68 files) green**; OpenAPI idempotent.

## Remaining
recipes (+send-to-list rewire onto lists `upsert-by-ref`, hero-image) → plan/shopping → ingest/ai → Phase C/D/E.