### PR TITLE
feat(finance): REST migration slice 3 — transactions read-helpers + tag-suggester

### DIFF
--- a/pillars/finance/openapi/finance.openapi.json
+++ b/pillars/finance/openapi/finance.openapi.json
@@ -2921,6 +2921,94 @@
         "tags": ["transactions"]
       }
     },
+    "/transactions/available-tags": {
+      "get": {
+        "operationId": "transactions.availableTags",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "tags": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": ["tags"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Distinct tag values across all transactions (autocomplete)",
+        "tags": ["transactions"]
+      }
+    },
+    "/transactions/descriptions-preview": {
+      "get": {
+        "operationId": "transactions.descriptionsForPreview",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "exclusiveMinimum": true,
+              "maximum": 2000,
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "checksum": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": "string"
+                          }
+                        },
+                        "required": ["description", "checksum"],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "total": {
+                      "type": "number"
+                    },
+                    "truncated": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": ["data", "total", "truncated"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Descriptions (+ checksums) of existing transactions for client-side rule preview",
+        "tags": ["transactions"]
+      }
+    },
     "/transactions/restore": {
       "post": {
         "operationId": "transactions.restore",
@@ -3179,6 +3267,52 @@
           }
         },
         "summary": "Restore a previously-deleted transaction from its snapshot",
+        "tags": ["transactions"]
+      }
+    },
+    "/transactions/suggest-tags": {
+      "get": {
+        "operationId": "transactions.suggestTags",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "description",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "entityId",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "tags": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": ["tags"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Rule-based tag suggestions for a description/entity (no LLM call)",
         "tags": ["transactions"]
       }
     },

--- a/pillars/finance/src/api/__tests__/test-utils.ts
+++ b/pillars/finance/src/api/__tests__/test-utils.ts
@@ -163,6 +163,15 @@ export function makeClient(app: Express) {
         send<{ data: Transaction; message: string }>(
           r.post('/transactions/restore').send(snapshot)
         ),
+      suggestTags: (query: { description: string; entityId?: string }) =>
+        send<{ tags: string[] }>(r.get('/transactions/suggest-tags').query(query)),
+      descriptionsForPreview: (query: { limit?: number } = {}) =>
+        send<{
+          data: { description: string; checksum: string | null }[];
+          total: number;
+          truncated: boolean;
+        }>(r.get('/transactions/descriptions-preview').query(query)),
+      availableTags: () => send<{ tags: string[] }>(r.get('/transactions/available-tags')),
     },
     tagRules: {
       vocabulary: () => send<{ tags: string[] }>(r.get('/tag-rules/vocabulary')),

--- a/pillars/finance/src/api/__tests__/transactions-reads.test.ts
+++ b/pillars/finance/src/api/__tests__/transactions-reads.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Integration tests for the transactions read-helpers migrated alongside
+ * the CRUD slice: `suggestTags` (rule-based, via the ported tag-suggester),
+ * `descriptionsForPreview` (paged descriptions + truncation flag), and
+ * `availableTags` (distinct sorted tag values).
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { openFinanceDb, type OpenedFinanceDb } from '../../db/index.js';
+import { createFinanceApiApp } from '../app.js';
+import { makeClient } from './test-utils.js';
+
+let tmpDir: string;
+let financeDb: OpenedFinanceDb;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'finance-api-txreads-test-'));
+  financeDb = openFinanceDb(join(tmpDir, 'finance.db'));
+});
+
+afterEach(() => {
+  financeDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function client() {
+  return makeClient(
+    createFinanceApiApp({ financeDb, version: '0.0.1-test', selfBaseUrl: 'http://localhost:3004' })
+  );
+}
+
+const tx = (over: Record<string, unknown>) => ({
+  description: 'WOOLWORTHS METRO',
+  account: 'Everyday',
+  amount: -10,
+  date: '2026-01-01',
+  type: 'expense',
+  ...over,
+});
+
+describe('transactions.suggestTags', () => {
+  it('suggests tags from an active tag rule matching the description', async () => {
+    await client().tagRules.apply({
+      changeSet: {
+        ops: [
+          {
+            op: 'add',
+            data: { descriptionPattern: 'WOOLWORTHS', matchType: 'contains', tags: ['groceries'] },
+          },
+        ],
+      },
+      acceptedNewTags: [],
+    });
+
+    const matched = await client().transactions.suggestTags({ description: 'WOOLWORTHS METRO' });
+    expect(matched.tags).toContain('groceries');
+
+    const unmatched = await client().transactions.suggestTags({ description: 'ELECTRICITY BILL' });
+    expect(unmatched.tags).toEqual([]);
+  });
+});
+
+describe('transactions.availableTags', () => {
+  it('returns distinct, sorted tags across transactions and ignores empty arrays', async () => {
+    await client().transactions.create(tx({ description: 'A', tags: ['food', 'coffee'] }));
+    await client().transactions.create(tx({ description: 'B', tags: ['coffee', 'work'] }));
+    await client().transactions.create(tx({ description: 'C', tags: [] }));
+
+    const { tags } = await client().transactions.availableTags();
+    expect(tags).toEqual(['coffee', 'food', 'work']);
+  });
+
+  it('returns an empty array when no transactions exist', async () => {
+    expect((await client().transactions.availableTags()).tags).toEqual([]);
+  });
+});
+
+describe('transactions.descriptionsForPreview', () => {
+  it('returns descriptions with a truncation flag honouring the limit', async () => {
+    for (const d of ['one', 'two', 'three']) {
+      await client().transactions.create(tx({ description: d }));
+    }
+
+    const limited = await client().transactions.descriptionsForPreview({ limit: 2 });
+    expect(limited.data).toHaveLength(2);
+    expect(limited.total).toBe(3);
+    expect(limited.truncated).toBe(true);
+
+    const all = await client().transactions.descriptionsForPreview();
+    expect(all.data).toHaveLength(3);
+    expect(all.truncated).toBe(false);
+    expect(all.data[0]).toHaveProperty('checksum');
+  });
+});

--- a/pillars/finance/src/api/modules/tag-suggester/index.ts
+++ b/pillars/finance/src/api/modules/tag-suggester/index.ts
@@ -1,0 +1,157 @@
+/**
+ * Suggest tags for a transaction with source attribution.
+ *
+ * Strategy (order = priority for dedup):
+ *   1. Correction rules — tags from matching `transaction_corrections` (source: "rule")
+ *   2. Tag rules — tags from `transaction_tag_rules` (source: "rule")
+ *   3. AI tags — returned directly by AI or a validated category string (source: "ai")
+ *   4. Entity defaults — from `entities.default_tags` (source: "entity")
+ *
+ * Ported from `apps/pops-api/src/modules/finance/tag-suggester/index.ts`.
+ * Finance-owned: reads only finance-db tables. The injected `FinanceDb`
+ * handle replaces the monolith's `getFinanceDrizzle()`; the correction-match
+ * helpers come from `@pops/finance`'s own `transactionCorrectionsService`.
+ */
+import { eq } from 'drizzle-orm';
+
+import { entities, type FinanceDb, transactionCorrectionsService } from '../../../db/index.js';
+import { findMatchingTagRules } from './tag-rule-matching.js';
+
+export type TagSuggestionSource = 'rule' | 'ai' | 'entity';
+
+export interface SuggestedTag {
+  tag: string;
+  source: TagSuggestionSource;
+  pattern?: string;
+  isNew?: boolean;
+}
+
+export interface SuggestTagsOptions {
+  description: string;
+  entityId: string | null;
+  aiTags?: string[];
+  aiCategory?: string | null;
+  knownTags?: string[];
+  correctionTags?: string[];
+  correctionPattern?: string;
+}
+
+function parseTags(json: string | null | undefined): string[] {
+  if (!json) return [];
+  try {
+    const parsed = JSON.parse(json) as unknown;
+    return Array.isArray(parsed) ? parsed.filter((t): t is string => typeof t === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+
+interface TagPass {
+  db: FinanceDb;
+  description: string;
+  entityId: string | null;
+  seen: Set<string>;
+  result: SuggestedTag[];
+}
+
+function addCorrectionTags(
+  pass: TagPass,
+  correctionTags: string[] | undefined,
+  correctionPattern: string | undefined
+): void {
+  const { db, description, seen, result } = pass;
+  if (correctionTags && correctionTags.length > 0) {
+    for (const tag of correctionTags) {
+      if (seen.has(tag)) continue;
+      seen.add(tag);
+      result.push({ tag, source: 'rule', pattern: correctionPattern });
+    }
+    return;
+  }
+  for (const correction of transactionCorrectionsService.findAllMatchingTransactionCorrections(
+    db,
+    description
+  )) {
+    for (const tag of parseTags(correction.tags)) {
+      if (seen.has(tag)) continue;
+      seen.add(tag);
+      result.push({ tag, source: 'rule', pattern: correction.descriptionPattern ?? undefined });
+    }
+  }
+}
+
+function addTagRuleTags(pass: TagPass): void {
+  const { db, description, entityId, seen, result } = pass;
+  for (const rule of findMatchingTagRules(db, description, entityId)) {
+    for (const tag of parseTags(rule.tags)) {
+      if (seen.has(tag)) continue;
+      seen.add(tag);
+      result.push({ tag, source: 'rule', pattern: rule.descriptionPattern });
+    }
+  }
+}
+
+interface AddAiTagsArgs {
+  aiTags: string[] | undefined;
+  aiCategory: string | null | undefined;
+  knownTags: string[] | undefined;
+  seen: Set<string>;
+  result: SuggestedTag[];
+}
+
+function addAiTags(args: AddAiTagsArgs): void {
+  const { aiTags, aiCategory, knownTags, seen, result } = args;
+  const knownSet = new Set(knownTags?.map((t) => t.toLowerCase()) ?? []);
+  let tags: string[];
+  if (aiTags && aiTags.length > 0) {
+    tags = aiTags;
+  } else if (aiCategory && knownTags) {
+    const matched = knownTags.find((t) => t.toLowerCase() === aiCategory.toLowerCase());
+    tags = matched ? [matched] : [];
+  } else {
+    return;
+  }
+  for (const tag of tags) {
+    if (seen.has(tag)) continue;
+    seen.add(tag);
+    const isNew = !knownSet.has(tag.toLowerCase()) || undefined;
+    result.push({ tag, source: 'ai', ...(isNew ? { isNew: true } : {}) });
+  }
+}
+
+function addEntityTags(pass: TagPass): void {
+  const { db, entityId, seen, result } = pass;
+  if (!entityId) return;
+  const entity = db
+    .select({ defaultTags: entities.defaultTags })
+    .from(entities)
+    .where(eq(entities.id, entityId))
+    .get();
+  if (!entity?.defaultTags) return;
+  for (const tag of parseTags(entity.defaultTags)) {
+    if (seen.has(tag)) continue;
+    seen.add(tag);
+    result.push({ tag, source: 'entity' });
+  }
+}
+
+export function suggestTags(db: FinanceDb, opts: SuggestTagsOptions): SuggestedTag[] {
+  const pass: TagPass = {
+    db,
+    description: opts.description,
+    entityId: opts.entityId,
+    seen: new Set<string>(),
+    result: [],
+  };
+  addCorrectionTags(pass, opts.correctionTags, opts.correctionPattern);
+  addTagRuleTags(pass);
+  addAiTags({
+    aiTags: opts.aiTags,
+    aiCategory: opts.aiCategory,
+    knownTags: opts.knownTags,
+    seen: pass.seen,
+    result: pass.result,
+  });
+  addEntityTags(pass);
+  return pass.result;
+}

--- a/pillars/finance/src/api/modules/tag-suggester/tag-rule-matching.ts
+++ b/pillars/finance/src/api/modules/tag-suggester/tag-rule-matching.ts
@@ -1,0 +1,82 @@
+/**
+ * Tag-rule matching for the tag-suggester. Split from `index.ts` to keep
+ * each file under the per-file line cap. Resolves the active
+ * `transaction_tag_rules` whose pattern matches a description (exact /
+ * contains / regex), scoped to an optional entity.
+ */
+import { and, desc, eq, isNull, or, sql } from 'drizzle-orm';
+
+import {
+  type FinanceDb,
+  transactionCorrectionsService,
+  transactionTagRules,
+} from '../../../db/index.js';
+
+export interface TagRuleRow {
+  tags: string;
+  descriptionPattern: string;
+}
+
+function buildEntityFilter(entityId: string | null): ReturnType<typeof or> {
+  return entityId !== null
+    ? or(isNull(transactionTagRules.entityId), eq(transactionTagRules.entityId, entityId))
+    : isNull(transactionTagRules.entityId);
+}
+
+export function findMatchingTagRules(
+  db: FinanceDb,
+  description: string,
+  entityId: string | null
+): TagRuleRow[] {
+  const norm = transactionCorrectionsService.normalizeDescription(description);
+  const ef = buildEntityFilter(entityId);
+  const cols = {
+    tags: transactionTagRules.tags,
+    descriptionPattern: transactionTagRules.descriptionPattern,
+  };
+  const base = and(eq(transactionTagRules.isActive, true), ef);
+
+  const exact = db
+    .select(cols)
+    .from(transactionTagRules)
+    .where(
+      and(
+        base,
+        eq(transactionTagRules.matchType, 'exact'),
+        eq(transactionTagRules.descriptionPattern, norm)
+      )
+    )
+    .orderBy(desc(transactionTagRules.confidence))
+    .all();
+
+  const contains = db
+    .select(cols)
+    .from(transactionTagRules)
+    .where(
+      and(
+        base,
+        eq(transactionTagRules.matchType, 'contains'),
+        sql`${norm} LIKE '%' || upper(${transactionTagRules.descriptionPattern}) || '%'`
+      )
+    )
+    .orderBy(desc(transactionTagRules.confidence))
+    .all();
+
+  const regexCandidates = db
+    .select(cols)
+    .from(transactionTagRules)
+    .where(and(base, eq(transactionTagRules.matchType, 'regex')))
+    .orderBy(desc(transactionTagRules.confidence))
+    .all();
+
+  const regex = regexCandidates.filter((r) => {
+    try {
+      return new RegExp(r.descriptionPattern, 'i').test(description);
+    } catch {
+      console.warn(`[tag-rules] invalid regex pattern — skipping rule: ${r.descriptionPattern}`);
+      return false;
+    }
+  });
+
+  return [...exact, ...contains, ...regex];
+}

--- a/pillars/finance/src/api/rest/transactions-handlers.ts
+++ b/pillars/finance/src/api/rest/transactions-handlers.ts
@@ -12,6 +12,7 @@ import {
   TransactionNotFoundError,
   transactionsService,
 } from '../../db/index.js';
+import { suggestTags as computeSuggestedTags } from '../modules/tag-suggester/index.js';
 import { toTransaction } from '../modules/transactions-types.js';
 import { ConflictError, NotFoundError } from '../shared/errors.js';
 import { paginationMeta } from '../shared/pagination.js';
@@ -25,6 +26,7 @@ type Req = ServerInferRequest<typeof financeTransactionsContract>;
 
 const DEFAULT_LIMIT = 50;
 const DEFAULT_OFFSET = 0;
+const PREVIEW_DESCRIPTIONS_LIMIT = 2000;
 
 function translateTransactionError(err: unknown, id?: string): never {
   if (err instanceof TransactionNotFoundError) throw new NotFoundError('Transaction', id ?? err.id);
@@ -59,6 +61,30 @@ export function makeTransactionsHandlers(db: FinanceDb) {
           body: { data: rows.map(toTransaction), pagination: paginationMeta(total, limit, offset) },
         };
       }),
+
+    suggestTags: ({ query }: Req['suggestTags']) =>
+      runHttp(() => {
+        const suggested = computeSuggestedTags(db, {
+          description: query.description,
+          entityId: query.entityId ?? null,
+        });
+        return { status: 200 as const, body: { tags: suggested.map((s) => s.tag) } };
+      }),
+
+    descriptionsForPreview: ({ query }: Req['descriptionsForPreview']) =>
+      runHttp(() => ({
+        status: 200 as const,
+        body: transactionsService.listDescriptionsForPreview(
+          db,
+          query.limit ?? PREVIEW_DESCRIPTIONS_LIMIT
+        ),
+      })),
+
+    availableTags: () =>
+      runHttp(() => ({
+        status: 200 as const,
+        body: { tags: transactionsService.collectAvailableTags(db) },
+      })),
 
     get: ({ params }: Req['get']) =>
       runHttp(() => {

--- a/pillars/finance/src/contract/api-types.generated.ts
+++ b/pillars/finance/src/contract/api-types.generated.ts
@@ -143,6 +143,40 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/transactions/available-tags': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Distinct tag values across all transactions (autocomplete) */
+    get: operations['transactions.availableTags'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/transactions/descriptions-preview': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Descriptions (+ checksums) of existing transactions for client-side rule preview */
+    get: operations['transactions.descriptionsForPreview'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/transactions/restore': {
     parameters: {
       query?: never;
@@ -154,6 +188,23 @@ export interface paths {
     put?: never;
     /** Restore a previously-deleted transaction from its snapshot */
     post: operations['transactions.restore'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/transactions/suggest-tags': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Rule-based tag suggestions for a description/entity (no LLM call) */
+    get: operations['transactions.suggestTags'];
+    put?: never;
+    post?: never;
     delete?: never;
     options?: never;
     head?: never;
@@ -1392,6 +1443,57 @@ export interface operations {
       };
     };
   };
+  'transactions.availableTags': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            tags: string[];
+          };
+        };
+      };
+    };
+  };
+  'transactions.descriptionsForPreview': {
+    parameters: {
+      query?: {
+        limit?: number;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              checksum: string | null;
+              description: string;
+            }[];
+            total: number;
+            truncated: boolean;
+          };
+        };
+      };
+    };
+  };
   'transactions.restore': {
     parameters: {
       query?: never;
@@ -1487,6 +1589,31 @@ export interface operations {
             code?: string;
             message: string;
             messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'transactions.suggestTags': {
+    parameters: {
+      query: {
+        description: string;
+        entityId?: string;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            tags: string[];
           };
         };
       };

--- a/pillars/finance/src/contract/rest-transactions.ts
+++ b/pillars/finance/src/contract/rest-transactions.ts
@@ -125,6 +125,35 @@ export const financeTransactionsContract = c.router({
     },
     summary: 'List transactions with optional filters and pagination',
   },
+  // Literal sub-paths declared BEFORE `:id` so they are never shadowed by the param route.
+  suggestTags: {
+    method: 'GET',
+    path: '/transactions/suggest-tags',
+    query: z.object({ description: z.string(), entityId: z.string().optional() }),
+    responses: { 200: z.object({ tags: z.array(z.string()) }) },
+    summary: 'Rule-based tag suggestions for a description/entity (no LLM call)',
+  },
+  descriptionsForPreview: {
+    method: 'GET',
+    path: '/transactions/descriptions-preview',
+    query: z.object({
+      limit: z.coerce.number().int().positive().max(2000).optional(),
+    }),
+    responses: {
+      200: z.object({
+        data: z.array(z.object({ description: z.string(), checksum: z.string().nullable() })),
+        total: z.number(),
+        truncated: z.boolean(),
+      }),
+    },
+    summary: 'Descriptions (+ checksums) of existing transactions for client-side rule preview',
+  },
+  availableTags: {
+    method: 'GET',
+    path: '/transactions/available-tags',
+    responses: { 200: z.object({ tags: z.array(z.string()) }) },
+    summary: 'Distinct tag values across all transactions (autocomplete)',
+  },
   get: {
     method: 'GET',
     path: '/transactions/:id',

--- a/pillars/finance/src/db/services/transactions-reads.ts
+++ b/pillars/finance/src/db/services/transactions-reads.ts
@@ -1,0 +1,65 @@
+/**
+ * Read-only projections over the `transactions` table that back the
+ * autocomplete / rule-preview endpoints. Split from `transactions.ts` to
+ * keep that file under the per-file line cap; re-exported through it so
+ * they stay on the `transactionsService` namespace.
+ */
+import { count } from 'drizzle-orm';
+
+import { transactions } from '../schema.js';
+
+import type { FinanceDb } from './internal.js';
+
+/** A `{ description, checksum }` projection for in-memory rule-preview on the client. */
+export interface DescriptionPreviewRow {
+  description: string;
+  checksum: string | null;
+}
+
+/** Result of {@link listDescriptionsForPreview}. */
+export interface DescriptionPreviewResult {
+  data: DescriptionPreviewRow[];
+  total: number;
+  truncated: boolean;
+}
+
+/**
+ * Fetch up to `limit` `{ description, checksum }` rows for client-side rule
+ * preview. Reads one extra row to detect truncation; `total` reflects the
+ * real row count so the client can surface a "preview truncated" hint.
+ */
+export function listDescriptionsForPreview(db: FinanceDb, limit: number): DescriptionPreviewResult {
+  const rows = db
+    .select({ description: transactions.description, checksum: transactions.checksum })
+    .from(transactions)
+    .limit(limit + 1)
+    .all();
+  const truncated = rows.length > limit;
+  const data = truncated ? rows.slice(0, limit) : rows;
+  const totalRow = db.select({ total: count() }).from(transactions).all()[0];
+  return { data, total: totalRow?.total ?? 0, truncated };
+}
+
+function addParsedTags(target: Set<string>, raw: string): void {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return;
+  }
+  if (!Array.isArray(parsed)) return;
+  for (const tag of parsed) if (typeof tag === 'string') target.add(tag);
+}
+
+/**
+ * Distinct, sorted tag values across all transactions — for tag-editor
+ * autocomplete. Reflects the JSON `tags` column; empty arrays are skipped.
+ */
+export function collectAvailableTags(db: FinanceDb): string[] {
+  const rows = db.select({ tags: transactions.tags }).from(transactions).all();
+  const tagSet = new Set<string>();
+  for (const row of rows) {
+    if (row.tags && row.tags !== '[]') addParsedTags(tagSet, row.tags);
+  }
+  return [...tagSet].toSorted();
+}

--- a/pillars/finance/src/db/services/transactions.ts
+++ b/pillars/finance/src/db/services/transactions.ts
@@ -262,3 +262,10 @@ export function restoreTransaction(db: FinanceDb, snapshot: TransactionRow): Tra
   db.insert(transactions).values(snapshot).run();
   return getTransaction(db, snapshot.id);
 }
+
+export {
+  collectAvailableTags,
+  type DescriptionPreviewResult,
+  type DescriptionPreviewRow,
+  listDescriptionsForPreview,
+} from './transactions-reads.js';


### PR DESCRIPTION
## Finance REST migration — slice 3

Migrates the three `finance.transactions.*` read-helpers that stayed in the monolith (builds on #3344, #3345), completing the transactions domain.

### Endpoints (all GET)
- `/transactions/suggest-tags?description&entityId` — rule-based tag suggestions (no LLM)
- `/transactions/descriptions-preview?limit` — paged descriptions + checksums + truncation flag
- `/transactions/available-tags` — distinct sorted tag values (autocomplete)

Literal sub-paths are declared before `/:id` so the param route never shadows them.

### tag-suggester port
The `tag-suggester` is finance-owned and ported into `pillars/finance/src/api/modules/tag-suggester` (split into `index` + `tag-rule-matching` to respect the per-file lint cap). Its `core/corrections` imports resolve to `@pops/finance`'s own `transactionCorrectionsService` (`findAllMatchingTransactionCorrections` + `normalizeDescription`); `entities` comes from the finance-db schema re-export; `getFinanceDrizzle()` → injected handle. No genuine cross-pillar coupling. Read projections live in a new `transactions-reads` db service.

4 new tests; 241 total green. Pure addition to `pillars/finance`.