### PR TITLE
feat(food): REST migration slice 4a — recipes CRUD

### DIFF
--- a/pillars/food/openapi/food.openapi.json
+++ b/pillars/food/openapi/food.openapi.json
@@ -5968,6 +5968,1234 @@
         "tags": ["prepStates"]
       }
     },
+    "/recipes": {
+      "post": {
+        "operationId": "recipes.create",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "dsl": {
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": ["dsl"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "compile": {},
+                    "recipeId": {
+                      "maximum": 9007199254740991,
+                      "minimum": -9007199254740991,
+                      "type": "integer"
+                    },
+                    "slug": {
+                      "type": "string"
+                    },
+                    "versionId": {
+                      "maximum": 9007199254740991,
+                      "minimum": -9007199254740991,
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["slug", "recipeId", "versionId", "compile"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "201"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Create a recipe from DSL",
+        "tags": ["recipes"]
+      }
+    },
+    "/recipes/search": {
+      "post": {
+        "operationId": "recipes.list",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "cursor": {
+                    "type": "string"
+                  },
+                  "includeArchived": {
+                    "type": "boolean"
+                  },
+                  "includeDraftOnly": {
+                    "type": "boolean"
+                  },
+                  "limit": {
+                    "exclusiveMinimum": true,
+                    "maximum": 100,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "recipeTypes": {
+                    "items": {
+                      "enum": [
+                        "plate",
+                        "component",
+                        "technique",
+                        "sauce",
+                        "dressing",
+                        "drink",
+                        "condiment"
+                      ],
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "search": {
+                    "maxLength": 200,
+                    "type": "string"
+                  },
+                  "sort": {
+                    "enum": ["createdAtDesc", "titleAsc", "recentlyCooked"],
+                    "type": "string"
+                  },
+                  "tags": {
+                    "items": {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "items": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "archivedAt": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "cookMinutes": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "nullable": true,
+                            "type": "integer"
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          },
+                          "hasCurrentVersion": {
+                            "type": "boolean"
+                          },
+                          "heroImagePath": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "id": {
+                            "exclusiveMinimum": true,
+                            "maximum": 9007199254740991,
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "prepMinutes": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "nullable": true,
+                            "type": "integer"
+                          },
+                          "recipeType": {
+                            "enum": [
+                              "plate",
+                              "component",
+                              "technique",
+                              "sauce",
+                              "dressing",
+                              "drink",
+                              "condiment"
+                            ],
+                            "type": "string"
+                          },
+                          "servings": {
+                            "nullable": true,
+                            "type": "number"
+                          },
+                          "slug": {
+                            "type": "string"
+                          },
+                          "tags": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "title": {
+                            "nullable": true,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "slug",
+                          "title",
+                          "recipeType",
+                          "heroImagePath",
+                          "prepMinutes",
+                          "cookMinutes",
+                          "servings",
+                          "tags",
+                          "hasCurrentVersion",
+                          "archivedAt",
+                          "createdAt"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "nextCursor": {
+                      "nullable": true,
+                      "type": "string"
+                    }
+                  },
+                  "required": ["items", "nextCursor"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "List recipes (filtered, cursor-paginated)",
+        "tags": ["recipes"]
+      }
+    },
+    "/recipes/versions/{versionId}": {
+      "patch": {
+        "operationId": "recipes.saveDraft",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "versionId",
+            "required": true,
+            "schema": {
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "dsl": {
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": ["dsl"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "compile": {}
+                  },
+                  "required": ["compile"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Save + compile a draft version",
+        "tags": ["recipes"]
+      }
+    },
+    "/recipes/versions/{versionId}/archive": {
+      "post": {
+        "operationId": "recipes.archiveVersion",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "versionId",
+            "required": true,
+            "schema": {
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {},
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "ok": {
+                      "enum": [true],
+                      "type": "boolean"
+                    }
+                  },
+                  "required": ["ok"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Archive a recipe version",
+        "tags": ["recipes"]
+      }
+    },
+    "/recipes/versions/{versionId}/promote": {
+      "post": {
+        "operationId": "recipes.promote",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "versionId",
+            "required": true,
+            "schema": {
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {},
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "ok": {
+                          "enum": [true],
+                          "type": "boolean"
+                        },
+                        "versionId": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer"
+                        }
+                      },
+                      "required": ["ok", "versionId"],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "ok": {
+                          "enum": [false],
+                          "type": "boolean"
+                        },
+                        "reason": {
+                          "enum": [
+                            "ConcurrentPromotion",
+                            "CannotPromoteUncompiledVersion",
+                            "VersionNotFound"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": ["ok", "reason"],
+                      "type": "object"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "Promote a compiled draft to current",
+        "tags": ["recipes"]
+      }
+    },
+    "/recipes/versions/{versionId}/proposed-slugs": {
+      "get": {
+        "operationId": "recipes.listProposedSlugs",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "versionId",
+            "required": true,
+            "schema": {
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "items": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "createdAt": {
+                            "type": "string"
+                          },
+                          "fromLoc": {},
+                          "slug": {
+                            "type": "string"
+                          },
+                          "suggestedKind": {
+                            "enum": ["ingredient", "recipe", "prep_state"],
+                            "nullable": true,
+                            "type": "string"
+                          }
+                        },
+                        "required": ["slug", "suggestedKind", "fromLoc", "createdAt"],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": ["items"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          }
+        },
+        "summary": "List proposed slugs surfaced by a draft’s compile",
+        "tags": ["recipes"]
+      }
+    },
+    "/recipes/versions/{versionId}/restore": {
+      "post": {
+        "operationId": "recipes.restoreVersion",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "versionId",
+            "required": true,
+            "schema": {
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {},
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "newVersionId": {
+                      "maximum": 9007199254740991,
+                      "minimum": -9007199254740991,
+                      "type": "integer"
+                    },
+                    "newVersionNo": {
+                      "maximum": 9007199254740991,
+                      "minimum": -9007199254740991,
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["newVersionId", "newVersionNo"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "201"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Restore an archived/published version as a new draft",
+        "tags": ["recipes"]
+      }
+    },
+    "/recipes/{slug}": {
+      "get": {
+        "operationId": "recipes.getForRendering",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "slug",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "versionNo",
+            "schema": {
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Get a recipe version assembled for rendering",
+        "tags": ["recipes"]
+      }
+    },
+    "/recipes/{slug}/archive": {
+      "post": {
+        "operationId": "recipes.archiveRecipe",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "slug",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {},
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "ok": {
+                      "enum": [true],
+                      "type": "boolean"
+                    }
+                  },
+                  "required": ["ok"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Archive a recipe",
+        "tags": ["recipes"]
+      }
+    },
+    "/recipes/{slug}/drafts": {
+      "get": {
+        "operationId": "recipes.listDrafts",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "slug",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "drafts": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "compileStatus": {
+                            "enum": ["uncompiled", "compiled", "failed"],
+                            "type": "string"
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          },
+                          "preview": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "versionId": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "type": "integer"
+                          },
+                          "versionNo": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "versionId",
+                          "versionNo",
+                          "title",
+                          "compileStatus",
+                          "createdAt",
+                          "preview"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": ["drafts"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "List a recipe’s draft versions",
+        "tags": ["recipes"]
+      },
+      "post": {
+        "operationId": "recipes.createNewDraft",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "slug",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {},
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "versionId": {
+                      "maximum": 9007199254740991,
+                      "minimum": -9007199254740991,
+                      "type": "integer"
+                    },
+                    "versionNo": {
+                      "maximum": 9007199254740991,
+                      "minimum": -9007199254740991,
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["versionId", "versionNo"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "201"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Fork a new draft from a recipe’s current version",
+        "tags": ["recipes"]
+      }
+    },
     "/slugs/search": {
       "get": {
         "operationId": "slugs.search",

--- a/pillars/food/src/api/__tests__/recipes.test.ts
+++ b/pillars/food/src/api/__tests__/recipes.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Integration tests for the `recipes.*` REST surface (PRD-119). Covers the
+ * create→list→draft→save→promote lifecycle plus the not-found / bad-DSL
+ * error mapping. DSL parse/compile internals are covered by the dsl tests;
+ * here we assert the wire envelopes + HTTP status mapping.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { type OpenedFoodDb, openFoodDb } from '../../db/index.js';
+import { createFoodApiApp } from '../app.js';
+import { makeClient } from './test-utils.js';
+
+const SIMPLE_DSL = `@recipe(
+  slug="grilled-cheese",
+  title="Grilled Cheese"
+)
+@yield(grilled-cheese, 1:count)
+@ingredient(1, bread, 2:count)
+@ingredient(2, butter, 10:g)
+@step("Butter the @1 and grill.")
+`;
+
+let tmpDir: string;
+let foodDb: OpenedFoodDb;
+
+function client(): ReturnType<typeof makeClient> {
+  return makeClient(
+    createFoodApiApp({ foodDb, version: '0.0.1-test', selfBaseUrl: 'http://localhost:3005' })
+  );
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'food-api-recipes-test-'));
+  foodDb = openFoodDb(join(tmpDir, 'food.db'));
+});
+
+afterEach(() => {
+  foodDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('recipes REST — lifecycle', () => {
+  it('creates from DSL, lists it, and renders a specific version', async () => {
+    const api = client();
+    const created = await api.recipes.create(SIMPLE_DSL);
+    expect(created.slug).toBe('grilled-cheese');
+    expect(created.recipeId).toBeGreaterThan(0);
+    expect(created.versionId).toBeGreaterThan(0);
+
+    // Freshly created recipes are draft-only (no current version yet), so
+    // include drafts to see them in the list.
+    const list = await api.recipes.list({ includeDraftOnly: true });
+    expect(list.items.map((r) => r.slug)).toContain('grilled-cheese');
+
+    const rendered = await api.recipes.getForRendering('grilled-cheese', 1);
+    expect(rendered).toBeTruthy();
+
+    const drafts = await api.recipes.listDrafts('grilled-cheese');
+    expect(Array.isArray(drafts.drafts)).toBe(true);
+
+    const slugs = await api.recipes.listProposedSlugs(created.versionId);
+    expect(Array.isArray(slugs.items)).toBe(true);
+  });
+
+  it('saves a draft and reports a compile result', async () => {
+    const api = client();
+    const created = await api.recipes.create(SIMPLE_DSL);
+    const saved = await api.recipes.saveDraft(created.versionId, SIMPLE_DSL);
+    expect(saved).toHaveProperty('compile');
+  });
+
+  it('archives a recipe', async () => {
+    const api = client();
+    await api.recipes.create(SIMPLE_DSL);
+    expect(await api.recipes.archiveRecipe('grilled-cheese')).toEqual({ ok: true });
+  });
+});
+
+describe('recipes REST — error mapping', () => {
+  it('rejects DSL with no @recipe header as 400', async () => {
+    await expect(client().recipes.create('just some text')).rejects.toMatchObject({ status: 400 });
+  });
+
+  it('404s getForRendering + listDrafts for an unknown slug', async () => {
+    const api = client();
+    await expect(api.recipes.getForRendering('nope')).rejects.toMatchObject({ status: 404 });
+    await expect(api.recipes.listDrafts('nope')).rejects.toMatchObject({ status: 404 });
+  });
+
+  it('404s saveDraft on an unknown version', async () => {
+    await expect(client().recipes.saveDraft(999999, SIMPLE_DSL)).rejects.toMatchObject({
+      status: 404,
+    });
+  });
+});

--- a/pillars/food/src/api/__tests__/test-utils.ts
+++ b/pillars/food/src/api/__tests__/test-utils.ts
@@ -159,6 +159,19 @@ interface ListPage<T> {
   nextCursor: string | null;
 }
 
+interface RecipeListItem {
+  id: number;
+  slug: string;
+  title: string | null;
+}
+type PromoteResult = { ok: true; versionId: number } | { ok: false; reason: string };
+interface CreateRecipeResult {
+  slug: string;
+  recipeId: number;
+  versionId: number;
+  compile: unknown;
+}
+
 export class HttpError extends Error {
   readonly status: number;
   readonly body: unknown;
@@ -371,6 +384,35 @@ export function makeClient(app: Express) {
       pendingCount: () => send<{ count: number }>(r.get('/inbox/pending-count')),
       getForReview: (sourceId: number) =>
         send<InspectorResult>(r.get('/inbox/review').query({ sourceId })),
+    },
+    recipes: {
+      list: (body: { search?: string; includeDraftOnly?: boolean } = {}) =>
+        send<{ items: RecipeListItem[]; nextCursor: string | null }>(
+          r.post('/recipes/search').send(body)
+        ),
+      create: (dsl: string) => send<CreateRecipeResult>(r.post('/recipes').send({ dsl })),
+      getForRendering: (slug: string, versionNo?: number) =>
+        send<unknown>(r.get(`/recipes/${slug}`).query(versionNo ? { versionNo } : {})),
+      listDrafts: (slug: string) =>
+        send<{ drafts: { versionId: number; versionNo: number }[] }>(
+          r.get(`/recipes/${slug}/drafts`)
+        ),
+      createNewDraft: (slug: string) =>
+        send<{ versionId: number; versionNo: number }>(r.post(`/recipes/${slug}/drafts`).send({})),
+      archiveRecipe: (slug: string) =>
+        send<{ ok: true }>(r.post(`/recipes/${slug}/archive`).send({})),
+      saveDraft: (versionId: number, dsl: string) =>
+        send<{ compile: unknown }>(r.patch(`/recipes/versions/${versionId}`).send({ dsl })),
+      promote: (versionId: number) =>
+        send<PromoteResult>(r.post(`/recipes/versions/${versionId}/promote`).send({})),
+      archiveVersion: (versionId: number) =>
+        send<{ ok: true }>(r.post(`/recipes/versions/${versionId}/archive`).send({})),
+      restoreVersion: (versionId: number) =>
+        send<{ newVersionId: number; newVersionNo: number }>(
+          r.post(`/recipes/versions/${versionId}/restore`).send({})
+        ),
+      listProposedSlugs: (versionId: number) =>
+        send<{ items: unknown[] }>(r.get(`/recipes/versions/${versionId}/proposed-slugs`)),
     },
   };
 }

--- a/pillars/food/src/api/modules/recipes/create.ts
+++ b/pillars/food/src/api/modules/recipes/create.ts
@@ -1,0 +1,192 @@
+/**
+ * Creation flows: `create`, `createNewDraft`, `restoreVersion` — PRD-119.
+ *
+ * Each kicks the PRD-107 services that already own the recipe + version
+ * row inserts; the new pieces here are (a) parsing the DSL header to
+ * extract the slug + recipe metadata, and (b) running PRD-116's compile
+ * pipeline against the freshly-written draft so the editor's first
+ * response carries the `CompileResult`.
+ */
+import { and, eq } from 'drizzle-orm';
+
+import {
+  recipes,
+  recipesService,
+  recipeVersions,
+  recipeVersionsService,
+  type FoodDb,
+} from '../../../db/index.js';
+import { type RecipeAst, type RecipeHeader } from '../../../dsl/ast.js';
+import { compileRecipeVersion } from '../../../dsl/compile.js';
+import { parseRecipeDsl } from '../../../dsl/parser.js';
+import { HttpError } from '../../shared/errors.js';
+import { mapCreateRecipeError } from './error-mapping.js';
+
+import type {
+  CreateNewDraftResult,
+  CreateRecipeResult,
+  RecipeType,
+  RestoreVersionResult,
+} from './types.js';
+
+const { createRecipe } = recipesService;
+const { createNewVersion } = recipeVersionsService;
+
+function parseOrReject(dsl: string): { header: RecipeHeader; ast: RecipeAst } {
+  const parsed = parseRecipeDsl(dsl);
+  if (parsed.ok) {
+    return { header: parsed.ast.recipe, ast: parsed.ast };
+  }
+  // The editor surfaces every parse error inline (PRD-120-C). On create
+  // we reject with BAD_REQUEST so the toast can show a single message;
+  // saveDraft is the path that returns the full per-error CompileResult.
+  const first = parsed.errors[0];
+  const message =
+    first?.code === 'MissingRecipeHeader'
+      ? 'DSL is missing an @recipe(slug=...) header'
+      : (first?.message ?? 'DSL parse failed');
+  throw new HttpError(400, message, first, 'common.validationFailed');
+}
+
+export function createNewRecipe(db: FoodDb, dsl: string): CreateRecipeResult {
+  const { header } = parseOrReject(dsl);
+  try {
+    const result = createRecipe(db, {
+      slug: header.slug,
+      recipeType: header.recipeType as RecipeType | undefined,
+      firstVersion: {
+        title: header.title,
+        bodyDsl: dsl,
+        summary: header.summary ?? null,
+        servings: header.servings ?? null,
+        prepMinutes: minutesOf(header.prepTime?.qty, header.prepTime?.unit),
+        cookMinutes: minutesOf(header.cookTime?.qty, header.cookTime?.unit),
+      },
+    });
+    const compile = compileRecipeVersion(result.version.id, db);
+    return {
+      slug: result.recipe.slug,
+      recipeId: result.recipe.id,
+      versionId: result.version.id,
+      compile,
+    };
+  } catch (err) {
+    mapCreateRecipeError(err);
+  }
+}
+
+export function createNewDraftForSlug(db: FoodDb, slug: string): CreateNewDraftResult {
+  const recipeRow = db
+    .select({
+      id: recipes.id,
+      currentVersionId: recipes.currentVersionId,
+    })
+    .from(recipes)
+    .where(eq(recipes.slug, slug))
+    .all()[0];
+  if (recipeRow === undefined) {
+    throw new HttpError(404, `Recipe "${slug}" not found`, undefined, 'common.notFound');
+  }
+  const existingDraft = db
+    .select({ id: recipeVersions.id, versionNo: recipeVersions.versionNo })
+    .from(recipeVersions)
+    .where(and(eq(recipeVersions.recipeId, recipeRow.id), eq(recipeVersions.status, 'draft')))
+    .all()[0];
+  if (existingDraft !== undefined) {
+    return { versionId: existingDraft.id, versionNo: existingDraft.versionNo };
+  }
+  const source = sourceVersionFor(db, recipeRow.currentVersionId, slug);
+  const fresh = createNewVersion(db, {
+    recipeId: recipeRow.id,
+    title: source.title,
+    bodyDsl: source.bodyDsl,
+    summary: source.summary,
+    servings: source.servings,
+    prepMinutes: source.prepMinutes,
+    cookMinutes: source.cookMinutes,
+  });
+  return { versionId: fresh.id, versionNo: fresh.versionNo };
+}
+
+interface SourceVersion {
+  title: string;
+  bodyDsl: string;
+  summary: string | null;
+  servings: number | null;
+  prepMinutes: number | null;
+  cookMinutes: number | null;
+}
+
+function sourceVersionFor(
+  db: FoodDb,
+  currentVersionId: number | null,
+  slug: string
+): SourceVersion {
+  if (currentVersionId === null) {
+    throw new HttpError(
+      400,
+      `Recipe "${slug}" has no current version to fork from. Open the existing draft instead.`,
+      undefined,
+      'common.validationFailed'
+    );
+  }
+  const v = db
+    .select()
+    .from(recipeVersions)
+    .where(eq(recipeVersions.id, currentVersionId))
+    .all()[0];
+  if (v === undefined) {
+    // Integrity violation — surface as 500 via the Express error pipeline.
+    throw new Error('recipe.current_version_id points at a missing row');
+  }
+  return {
+    title: v.title,
+    bodyDsl: v.bodyDsl,
+    summary: v.summary,
+    servings: v.servings,
+    prepMinutes: v.prepMinutes,
+    cookMinutes: v.cookMinutes,
+  };
+}
+
+export function restoreVersionAsDraft(db: FoodDb, sourceVersionId: number): RestoreVersionResult {
+  const source = db
+    .select()
+    .from(recipeVersions)
+    .where(eq(recipeVersions.id, sourceVersionId))
+    .all()[0];
+  if (source === undefined) {
+    throw new HttpError(404, 'Source version not found', undefined, 'common.notFound');
+  }
+  const fresh = createNewVersion(db, {
+    recipeId: source.recipeId,
+    title: source.title,
+    bodyDsl: source.bodyDsl,
+    summary: source.summary,
+    servings: source.servings,
+    prepMinutes: source.prepMinutes,
+    cookMinutes: source.cookMinutes,
+  });
+  return { newVersionId: fresh.id, newVersionNo: fresh.versionNo };
+}
+
+const MINUTE_MULTIPLIERS: Record<string, number> = {
+  s: 1 / 60,
+  sec: 1 / 60,
+  second: 1 / 60,
+  seconds: 1 / 60,
+  min: 1,
+  minute: 1,
+  minutes: 1,
+  h: 60,
+  hr: 60,
+  hour: 60,
+  hours: 60,
+};
+
+function minutesOf(qty: number | undefined, unit: string | undefined): number | null {
+  if (qty === undefined || unit === undefined) return null;
+  const factor = MINUTE_MULTIPLIERS[unit.toLowerCase()];
+  if (factor === undefined) return null;
+  return Math.max(0, Math.round(qty * factor));
+}

--- a/pillars/food/src/api/modules/recipes/error-mapping.ts
+++ b/pillars/food/src/api/modules/recipes/error-mapping.ts
@@ -1,0 +1,78 @@
+/**
+ * Map typed PRD-107 / PRD-116 errors → HttpError or structured results.
+ */
+import {
+  CannotEditPublishedVersion,
+  CannotPromoteUncompiledVersion,
+  SlugAlreadyRegisteredError,
+} from '../../../db/index.js';
+import { ConflictError, HttpError } from '../../shared/errors.js';
+
+import type { PromoteReason, PromoteResult } from './types.js';
+
+export class MissingRecipeHeaderError extends Error {
+  constructor() {
+    super('DSL is missing an @recipe(slug=...) header');
+    this.name = 'MissingRecipeHeaderError';
+  }
+}
+
+/**
+ * Map a create-recipe failure to a TRPCError. `MissingRecipeHeader` is the
+ * editor's most common rejection — it gets BAD_REQUEST with a `cause` so the
+ * client can show the underlying parse-error span when surfacing the error
+ * inline.
+ */
+export function mapCreateRecipeError(err: unknown): never {
+  if (err instanceof MissingRecipeHeaderError) {
+    throw new HttpError(400, err.message, err, 'common.validationFailed');
+  }
+  if (err instanceof SlugAlreadyRegisteredError) throw new ConflictError(err.message);
+  throw err as Error;
+}
+
+// PRD-107's `updateDraftVersion` / `promoteVersion` throw an untyped
+// `Error("recipe_version #<id> not found")` when the id doesn't exist.
+// Detect that shape so we can map it cleanly instead of leaking a 500.
+function isMissingVersionError(err: unknown): boolean {
+  return err instanceof Error && /recipe_version #\d+ not found/i.test(err.message);
+}
+
+/**
+ * `saveDraft` operates only on draft rows; published/archived rows reject
+ * with a typed `CannotEditPublishedVersion`. A missing version row maps to
+ * `NOT_FOUND` rather than the raw service `Error`.
+ */
+export function mapSaveDraftError(err: unknown): never {
+  if (err instanceof CannotEditPublishedVersion) {
+    throw new HttpError(400, err.message, err, 'common.validationFailed');
+  }
+  if (isMissingVersionError(err)) {
+    throw new HttpError(404, (err as Error).message, err, 'common.notFound');
+  }
+  throw err as Error;
+}
+
+/**
+ * `promote` returns a discriminated result instead of throwing because the
+ * editor surfaces the reason inline (banner / toast) rather than blowing up
+ * the page. All four failure modes are user-actionable.
+ *
+ * `ConcurrentPromotion` arrives from `promoteVersion` as a structured result
+ * (PRD-136 amendment to PRD-107) and is forwarded by the caller; this mapper
+ * only handles the still-thrown variants: `CannotPromoteUncompiledVersion`
+ * and the "not found" pre-validation Error.
+ */
+export function promoteFailure(reason: PromoteReason): PromoteResult {
+  return { ok: false, reason };
+}
+
+export function mapPromoteError(err: unknown): PromoteResult | never {
+  if (err instanceof CannotPromoteUncompiledVersion) {
+    return promoteFailure('CannotPromoteUncompiledVersion');
+  }
+  if (isMissingVersionError(err)) {
+    return promoteFailure('VersionNotFound');
+  }
+  throw err as Error;
+}

--- a/pillars/food/src/api/modules/recipes/get-for-rendering.ts
+++ b/pillars/food/src/api/modules/recipes/get-for-rendering.ts
@@ -1,0 +1,177 @@
+/**
+ * Assemble `RecipeVersionWithCompiledData` — the input to PRD-121's renderer.
+ *
+ * One round-trip per joined table (recipes / versions / lines+joins /
+ * steps / tags / yield) so a 200-line recipe still renders in a single
+ * tRPC hit. Wire shape lives in `@pops/app-food-db` so both this
+ * procedure AND the React renderer import the same TypeScript type.
+ */
+import { and, asc, eq } from 'drizzle-orm';
+
+import {
+  ingredients,
+  ingredientVariants,
+  prepStates,
+  recipeLines,
+  recipes,
+  recipeSteps,
+  recipeTags,
+  recipeVersions,
+  type FoodDb,
+  type RecipeRow,
+  type RecipeVersionRow,
+} from '../../../db/index.js';
+import { NotFoundError } from '../../shared/errors.js';
+
+import type {
+  RecipeLineWithResolved,
+  RecipeVersionWithCompiledData,
+} from '../../../domain/recipe-renderer-types.js';
+
+export function getForRendering(
+  db: FoodDb,
+  slug: string,
+  versionNo: number | undefined
+): RecipeVersionWithCompiledData {
+  const recipeRow = db.select().from(recipes).where(eq(recipes.slug, slug)).all()[0];
+  if (recipeRow === undefined) throw new NotFoundError('Recipe', slug);
+  const version = pickVersion(db, recipeRow, versionNo);
+  return {
+    version,
+    recipe: recipeRow,
+    lines: hydrateLines(db, version.id),
+    steps: db
+      .select()
+      .from(recipeSteps)
+      .where(eq(recipeSteps.recipeVersionId, version.id))
+      .orderBy(asc(recipeSteps.position))
+      .all(),
+    ...hydrateYield(db, version),
+    tags: db
+      .select({ tag: recipeTags.tag })
+      .from(recipeTags)
+      .where(eq(recipeTags.recipeId, recipeRow.id))
+      .all()
+      .map((r) => r.tag)
+      .toSorted(),
+  };
+}
+
+function pickVersion(
+  db: FoodDb,
+  recipe: RecipeRow,
+  versionNo: number | undefined
+): RecipeVersionRow {
+  if (versionNo !== undefined) {
+    const v = db
+      .select()
+      .from(recipeVersions)
+      .where(and(eq(recipeVersions.recipeId, recipe.id), eq(recipeVersions.versionNo, versionNo)))
+      .all()[0];
+    if (v === undefined) {
+      throw new NotFoundError('Recipe version', `${recipe.slug}#${versionNo}`);
+    }
+    return v;
+  }
+  if (recipe.currentVersionId === null) {
+    throw new NotFoundError('Published recipe version', recipe.slug);
+  }
+  const v = db
+    .select()
+    .from(recipeVersions)
+    .where(eq(recipeVersions.id, recipe.currentVersionId))
+    .all()[0];
+  if (v === undefined) {
+    // Integrity violation (dangling current_version_id) — let it surface as
+    // a 500 via the Express error pipeline rather than masking it.
+    throw new Error('recipe.current_version_id points at a missing row');
+  }
+  return v;
+}
+
+interface YieldHydrated {
+  yieldIngredient: RecipeVersionWithCompiledData['yieldIngredient'];
+  yieldVariant: RecipeVersionWithCompiledData['yieldVariant'];
+  yieldPrepState: RecipeVersionWithCompiledData['yieldPrepState'];
+}
+
+function hydrateYield(db: FoodDb, version: RecipeVersionRow): YieldHydrated {
+  return {
+    yieldIngredient:
+      version.yieldIngredientId === null
+        ? null
+        : (db
+            .select()
+            .from(ingredients)
+            .where(eq(ingredients.id, version.yieldIngredientId))
+            .all()[0] ?? null),
+    yieldVariant:
+      version.yieldVariantId === null
+        ? null
+        : (db
+            .select()
+            .from(ingredientVariants)
+            .where(eq(ingredientVariants.id, version.yieldVariantId))
+            .all()[0] ?? null),
+    yieldPrepState:
+      version.yieldPrepStateId === null
+        ? null
+        : (db
+            .select()
+            .from(prepStates)
+            .where(eq(prepStates.id, version.yieldPrepStateId))
+            .all()[0] ?? null),
+  };
+}
+
+function hydrateLines(db: FoodDb, versionId: number): RecipeLineWithResolved[] {
+  // Self-joining `recipes` via `recipeRefId` is awkward in drizzle's
+  // builder — we keep the columns we need from the line + the joined
+  // ingredient / variant / prep_state / ref-recipe in one SELECT.
+  const refRecipes = recipes;
+  return db
+    .select({
+      // Line columns
+      id: recipeLines.id,
+      position: recipeLines.position,
+      ingredientId: recipeLines.ingredientId,
+      variantId: recipeLines.variantId,
+      prepStateId: recipeLines.prepStateId,
+      isRecipeRef: recipeLines.isRecipeRef,
+      recipeRefId: recipeLines.recipeRefId,
+      originalText: recipeLines.originalText,
+      originalQty: recipeLines.originalQty,
+      originalUnit: recipeLines.originalUnit,
+      qtyG: recipeLines.qtyG,
+      qtyMl: recipeLines.qtyMl,
+      qtyCount: recipeLines.qtyCount,
+      canonicalUnit: recipeLines.canonicalUnit,
+      optional: recipeLines.optional,
+      notes: recipeLines.notes,
+      // Joined display fields
+      ingredientName: ingredients.name,
+      ingredientSlug: ingredients.slug,
+      variantName: ingredientVariants.name,
+      variantSlug: ingredientVariants.slug,
+      prepStateName: prepStates.name,
+      prepStateSlug: prepStates.slug,
+      recipeRefSlug: refRecipes.slug,
+      recipeRefTitle: recipeVersions.title,
+    })
+    .from(recipeLines)
+    .leftJoin(ingredients, eq(ingredients.id, recipeLines.ingredientId))
+    .leftJoin(ingredientVariants, eq(ingredientVariants.id, recipeLines.variantId))
+    .leftJoin(prepStates, eq(prepStates.id, recipeLines.prepStateId))
+    .leftJoin(refRecipes, eq(refRecipes.id, recipeLines.recipeRefId))
+    .leftJoin(recipeVersions, eq(recipeVersions.id, refRecipes.currentVersionId))
+    .where(eq(recipeLines.recipeVersionId, versionId))
+    .orderBy(asc(recipeLines.position))
+    .all()
+    .map((r) => ({
+      ...r,
+      isRecipeRef: Boolean(r.isRecipeRef),
+      optional: Boolean(r.optional),
+      ingredientName: r.ingredientName ?? '',
+      ingredientSlug: r.ingredientSlug ?? '',
+    }));
+}

--- a/pillars/food/src/api/modules/recipes/queries-drafts.ts
+++ b/pillars/food/src/api/modules/recipes/queries-drafts.ts
@@ -1,0 +1,73 @@
+/**
+ * Read helpers for the drafts list + proposed-slug list — PRD-119.
+ *
+ * Split out of `queries.ts` purely to keep each file under the per-file
+ * 200-line lint cap. Imports + the public function signatures are
+ * unchanged from the consumer's view.
+ */
+import { and, desc, eq } from 'drizzle-orm';
+
+import {
+  recipes,
+  recipeVersionProposedSlugs,
+  recipeVersions,
+  type FoodDb,
+} from '../../../db/index.js';
+
+import type { ProposedSlugRow, RecipeDraftSummary } from './types.js';
+
+export function listDraftsForSlug(db: FoodDb, slug: string): RecipeDraftSummary[] | null {
+  const recipeRow = db
+    .select({ id: recipes.id })
+    .from(recipes)
+    .where(eq(recipes.slug, slug))
+    .all()[0];
+  if (recipeRow === undefined) return null;
+  const rows = db
+    .select({
+      id: recipeVersions.id,
+      versionNo: recipeVersions.versionNo,
+      title: recipeVersions.title,
+      compileStatus: recipeVersions.compileStatus,
+      createdAt: recipeVersions.createdAt,
+      bodyDsl: recipeVersions.bodyDsl,
+    })
+    .from(recipeVersions)
+    .where(and(eq(recipeVersions.recipeId, recipeRow.id), eq(recipeVersions.status, 'draft')))
+    .orderBy(desc(recipeVersions.versionNo))
+    .all();
+  return rows.map((r) => ({
+    versionId: r.id,
+    versionNo: r.versionNo,
+    title: r.title,
+    compileStatus: r.compileStatus,
+    createdAt: r.createdAt,
+    preview: previewFromDsl(r.bodyDsl),
+  }));
+}
+
+function previewFromDsl(dsl: string): string {
+  const collapsed = dsl.replace(/\s+/g, ' ').trim();
+  return collapsed.length <= 80 ? collapsed : `${collapsed.slice(0, 77)}...`;
+}
+
+export function listProposedSlugs(db: FoodDb, versionId: number): ProposedSlugRow[] {
+  const rows = db
+    .select({
+      slug: recipeVersionProposedSlugs.slug,
+      suggestedKind: recipeVersionProposedSlugs.suggestedKind,
+      fromLocJson: recipeVersionProposedSlugs.fromLocJson,
+      createdAt: recipeVersionProposedSlugs.createdAt,
+    })
+    .from(recipeVersionProposedSlugs)
+    .where(eq(recipeVersionProposedSlugs.recipeVersionId, versionId))
+    .all();
+  return rows.map((r) => ({
+    slug: r.slug,
+    suggestedKind: r.suggestedKind,
+    // PRD-116 stores `SourceSpan` as JSON; client treats it as the inline-
+    // diagnostic location for the PRD-120-C `issues` prop.
+    fromLoc: JSON.parse(r.fromLocJson) as ProposedSlugRow['fromLoc'],
+    createdAt: r.createdAt,
+  }));
+}

--- a/pillars/food/src/api/modules/recipes/queries.ts
+++ b/pillars/food/src/api/modules/recipes/queries.ts
@@ -1,0 +1,220 @@
+/**
+ * Read helpers for `food.recipes.list` — PRD-119.
+ *
+ * Cursor-based pagination, filter chips (search / type / tag / archived
+ * / draft-only), sort dropdown (createdAtDesc / titleAsc; the
+ * `recentlyCooked` mode falls back to createdAtDesc until Epic 05 lands
+ * `recipe_runs.completed_at` data the list can join on). Tags + drafts
+ * + proposed-slug helpers live in sibling files to honour the per-file
+ * line cap.
+ */
+import { and, asc, desc, eq, gt, inArray, lt, or, sql, type SQL } from 'drizzle-orm';
+
+import { recipes, recipeTags, recipeVersions, type FoodDb } from '../../../db/index.js';
+
+import type { RecipeListItem, RecipeType, SortOrder } from './types.js';
+
+export { listDraftsForSlug, listProposedSlugs } from './queries-drafts.js';
+
+export interface ListRecipesFilter {
+  search?: string;
+  recipeTypes?: RecipeType[];
+  tags?: string[];
+  includeArchived: boolean;
+  includeDraftOnly: boolean;
+  sort: SortOrder;
+  cursor?: { id: number; sortKey: string } | null;
+  limit: number;
+}
+
+export interface ListRecipesResult {
+  items: RecipeListItem[];
+  nextCursor: string | null;
+}
+
+function encodeCursor(id: number, sortKey: string): string {
+  return Buffer.from(`${sortKey}${CURSOR_SEP}${id}`, 'utf8').toString('base64url');
+}
+
+const CURSOR_SEP = '|';
+
+export function decodeCursor(cursor: string): { id: number; sortKey: string } | null {
+  try {
+    const decoded = Buffer.from(cursor, 'base64url').toString('utf8');
+    const sep = decoded.lastIndexOf(CURSOR_SEP);
+    if (sep === -1) return null;
+    const id = Number(decoded.slice(sep + 1));
+    if (!Number.isInteger(id) || id <= 0) return null;
+    return { id, sortKey: decoded.slice(0, sep) };
+  } catch {
+    return null;
+  }
+}
+
+interface JoinedRecipeRow {
+  id: number;
+  slug: string;
+  recipeType: string;
+  heroImagePath: string | null;
+  archivedAt: string | null;
+  createdAt: string;
+  currentVersionId: number | null;
+  title: string | null;
+  prepMinutes: number | null;
+  cookMinutes: number | null;
+  servings: number | null;
+}
+
+export function listRecipes(db: FoodDb, filter: ListRecipesFilter): ListRecipesResult {
+  const rows = selectRecipeRows(db, filter);
+  const trimmed = rows.slice(0, filter.limit);
+  const items = trimmed.map(
+    (r): RecipeListItem => ({
+      id: r.id,
+      slug: r.slug,
+      title: r.title,
+      recipeType: r.recipeType as RecipeType,
+      heroImagePath: r.heroImagePath,
+      prepMinutes: r.prepMinutes,
+      cookMinutes: r.cookMinutes,
+      servings: r.servings,
+      tags: [],
+      hasCurrentVersion: r.currentVersionId !== null,
+      archivedAt: r.archivedAt,
+      createdAt: r.createdAt,
+    })
+  );
+  hydrateTags(
+    db,
+    items,
+    trimmed.map((r) => r.id)
+  );
+  const last = trimmed[trimmed.length - 1];
+  const nextCursor =
+    rows.length > filter.limit && last !== undefined
+      ? encodeCursor(last.id, sortKeyFor(filter.sort, last))
+      : null;
+  return { items, nextCursor };
+}
+
+function selectRecipeRows(db: FoodDb, filter: ListRecipesFilter): JoinedRecipeRow[] {
+  const where = buildWhere(filter);
+  const order = buildOrder(filter.sort);
+  return db
+    .select({
+      id: recipes.id,
+      slug: recipes.slug,
+      recipeType: recipes.recipeType,
+      heroImagePath: recipes.heroImagePath,
+      archivedAt: recipes.archivedAt,
+      createdAt: recipes.createdAt,
+      currentVersionId: recipes.currentVersionId,
+      title: recipeVersions.title,
+      prepMinutes: recipeVersions.prepMinutes,
+      cookMinutes: recipeVersions.cookMinutes,
+      servings: recipeVersions.servings,
+    })
+    .from(recipes)
+    .leftJoin(recipeVersions, eq(recipeVersions.id, recipes.currentVersionId))
+    .where(where)
+    .orderBy(...order)
+    .limit(filter.limit + 1)
+    .all();
+}
+
+function buildWhere(filter: ListRecipesFilter): ReturnType<typeof and> {
+  const clauses = [
+    ...visibilityClauses(filter),
+    ...searchClauses(filter),
+    ...filterClauses(filter),
+  ];
+  if (filter.cursor) {
+    const cursorWhere = cursorClause(filter, filter.cursor);
+    if (cursorWhere !== undefined) clauses.push(cursorWhere);
+  }
+  return clauses.length === 0 ? undefined : and(...clauses);
+}
+
+function visibilityClauses(filter: ListRecipesFilter): SQL[] {
+  const clauses: SQL[] = [];
+  if (!filter.includeArchived) clauses.push(sql`${recipes.archivedAt} IS NULL`);
+  if (!filter.includeDraftOnly) clauses.push(sql`${recipes.currentVersionId} IS NOT NULL`);
+  return clauses;
+}
+
+function searchClauses(filter: ListRecipesFilter): SQL[] {
+  if (!filter.search || filter.search.length === 0) return [];
+  const pattern = `%${filter.search.toLowerCase()}%`;
+  const clause = or(
+    sql`lower(${recipeVersions.title}) LIKE ${pattern}`,
+    sql`lower(${recipes.slug}) LIKE ${pattern}`
+  );
+  return clause === undefined ? [] : [clause];
+}
+
+function filterClauses(filter: ListRecipesFilter): SQL[] {
+  const clauses: SQL[] = [];
+  if (filter.recipeTypes && filter.recipeTypes.length > 0) {
+    clauses.push(inArray(recipes.recipeType, filter.recipeTypes));
+  }
+  if (filter.tags && filter.tags.length > 0) {
+    clauses.push(
+      sql`EXISTS (SELECT 1 FROM ${recipeTags} WHERE ${recipeTags.recipeId} = ${recipes.id} AND ${recipeTags.tag} IN ${filter.tags})`
+    );
+  }
+  return clauses;
+}
+
+function cursorClause(
+  filter: ListRecipesFilter,
+  cursor: { id: number; sortKey: string }
+): ReturnType<typeof or> {
+  if (filter.sort === 'titleAsc') {
+    const lowerExpr = sql`lower(coalesce(${recipeVersions.title}, ${recipes.slug}))`;
+    return or(
+      gt(lowerExpr, cursor.sortKey),
+      and(eq(lowerExpr, cursor.sortKey), gt(recipes.id, cursor.id))
+    );
+  }
+  return or(
+    lt(recipes.createdAt, cursor.sortKey),
+    and(eq(recipes.createdAt, cursor.sortKey), lt(recipes.id, cursor.id))
+  );
+}
+
+function buildOrder(sort: SortOrder): ReturnType<typeof asc>[] {
+  if (sort === 'titleAsc') {
+    return [asc(sql`lower(coalesce(${recipeVersions.title}, ${recipes.slug}))`), asc(recipes.id)];
+  }
+  return [desc(recipes.createdAt), desc(recipes.id)];
+}
+
+function sortKeyFor(sort: SortOrder, row: JoinedRecipeRow): string {
+  if (sort === 'titleAsc') return (row.title ?? row.slug).toLowerCase();
+  return row.createdAt;
+}
+
+function hydrateTags(db: FoodDb, items: RecipeListItem[], ids: number[]): void {
+  if (ids.length === 0) return;
+  const tags = db
+    .select({ recipeId: recipeTags.recipeId, tag: recipeTags.tag })
+    .from(recipeTags)
+    .where(inArray(recipeTags.recipeId, ids))
+    .all();
+  const slugById = new Map<number, string>();
+  items.forEach((item, idx) => {
+    const id = ids[idx];
+    if (id !== undefined) slugById.set(id, item.slug);
+  });
+  const bySlug = new Map<string, string[]>();
+  for (const t of tags) {
+    const slug = slugById.get(t.recipeId);
+    if (slug === undefined) continue;
+    const bucket = bySlug.get(slug) ?? [];
+    bucket.push(t.tag);
+    bySlug.set(slug, bucket);
+  }
+  for (const item of items) {
+    item.tags = (bySlug.get(item.slug) ?? []).toSorted();
+  }
+}

--- a/pillars/food/src/api/modules/recipes/save.ts
+++ b/pillars/food/src/api/modules/recipes/save.ts
@@ -1,0 +1,52 @@
+/**
+ * Save / promote / archive flows — PRD-119.
+ *
+ * Thin wrappers around PRD-107's recipe + version services. The compile
+ * step on `saveDraft` is what feeds the editor's error squiggles
+ * (PRD-120-C `issues` prop).
+ */
+import { eq } from 'drizzle-orm';
+
+import { recipes, recipesService, recipeVersionsService, type FoodDb } from '../../../db/index.js';
+import { compileRecipeVersion } from '../../../dsl/compile.js';
+import { NotFoundError } from '../../shared/errors.js';
+import { mapPromoteError, mapSaveDraftError } from './error-mapping.js';
+
+import type { PromoteResult, SaveDraftResult } from './types.js';
+
+const { archiveRecipe } = recipesService;
+const { archiveVersion, promoteVersion, updateDraftVersion } = recipeVersionsService;
+
+export function saveDraft(db: FoodDb, versionId: number, dsl: string): SaveDraftResult {
+  try {
+    updateDraftVersion(db, versionId, { bodyDsl: dsl });
+  } catch (err) {
+    mapSaveDraftError(err);
+  }
+  const compile = compileRecipeVersion(versionId, db);
+  return { compile };
+}
+
+export function promote(db: FoodDb, versionId: number): PromoteResult {
+  try {
+    const result = promoteVersion(db, versionId);
+    if (!result.ok) {
+      return { ok: false, reason: result.reason };
+    }
+    return { ok: true, versionId: result.row.id };
+  } catch (err) {
+    return mapPromoteError(err);
+  }
+}
+
+export function archiveVersionRow(db: FoodDb, versionId: number): { ok: true } {
+  archiveVersion(db, versionId);
+  return { ok: true };
+}
+
+export function archiveRecipeBySlug(db: FoodDb, slug: string): { ok: true } {
+  const row = db.select({ id: recipes.id }).from(recipes).where(eq(recipes.slug, slug)).all()[0];
+  if (row === undefined) throw new NotFoundError('Recipe', slug);
+  archiveRecipe(db, row.id);
+  return { ok: true };
+}

--- a/pillars/food/src/api/modules/recipes/types.ts
+++ b/pillars/food/src/api/modules/recipes/types.ts
@@ -1,0 +1,85 @@
+/**
+ * Wire output shapes for `food.recipes.*` — PRD-119.
+ *
+ * Lightweight shapes for list / drafts / proposed slugs live here;
+ * the heavy `RecipeVersionWithCompiledData` returned by `getForRendering`
+ * is owned by `@pops/app-food-db` (PRD-121) and consumed verbatim.
+ */
+import { z } from 'zod';
+
+import type { SourceSpan } from '../../../dsl/ast.js';
+import type { CompileResult } from '../../../dsl/compile-types.js';
+
+export const RECIPE_TYPE_VALUES = [
+  'plate',
+  'component',
+  'technique',
+  'sauce',
+  'dressing',
+  'drink',
+  'condiment',
+] as const;
+
+export const RecipeTypeSchema = z.enum(RECIPE_TYPE_VALUES);
+export type RecipeType = z.infer<typeof RecipeTypeSchema>;
+
+export const SortOrderSchema = z.enum(['createdAtDesc', 'titleAsc', 'recentlyCooked']);
+export type SortOrder = z.infer<typeof SortOrderSchema>;
+
+export interface RecipeListItem {
+  id: number;
+  slug: string;
+  title: string | null;
+  recipeType: RecipeType;
+  heroImagePath: string | null;
+  prepMinutes: number | null;
+  cookMinutes: number | null;
+  servings: number | null;
+  tags: string[];
+  hasCurrentVersion: boolean;
+  archivedAt: string | null;
+  createdAt: string;
+}
+
+export interface RecipeDraftSummary {
+  versionId: number;
+  versionNo: number;
+  title: string;
+  compileStatus: 'uncompiled' | 'compiled' | 'failed';
+  createdAt: string;
+  preview: string;
+}
+
+export interface ProposedSlugRow {
+  slug: string;
+  suggestedKind: 'ingredient' | 'recipe' | 'prep_state' | null;
+  fromLoc: SourceSpan;
+  createdAt: string;
+}
+
+export type PromoteResult = { ok: true; versionId: number } | { ok: false; reason: PromoteReason };
+export type PromoteReason =
+  | 'ConcurrentPromotion'
+  | 'CannotPromoteUncompiledVersion'
+  | 'VersionNotFound';
+
+export interface CreateRecipeResult {
+  slug: string;
+  recipeId: number;
+  versionId: number;
+  compile: CompileResult;
+}
+
+export interface SaveDraftResult {
+  compile: CompileResult;
+}
+
+export interface CreateNewDraftResult {
+  versionId: number;
+  versionNo: number;
+}
+
+export interface RestoreVersionResult {
+  newVersionId: number;
+  newVersionNo: number;
+}

--- a/pillars/food/src/api/rest/handlers.ts
+++ b/pillars/food/src/api/rest/handlers.ts
@@ -17,6 +17,7 @@ import { makeInboxHandlers } from './inbox-handlers.js';
 import { makeIngredientTagsHandlers } from './ingredient-tags-handlers.js';
 import { makeIngredientsHandlers } from './ingredients-handlers.js';
 import { makePrepStatesHandlers } from './prep-states-handlers.js';
+import { makeRecipesHandlers } from './recipes-handlers.js';
 import { makeSlugsHandlers } from './slugs-handlers.js';
 import { makeSolverHandlers } from './solver-handlers.js';
 import { makeSubstitutionsHandlers } from './substitutions-handlers.js';
@@ -37,6 +38,7 @@ export function makeFoodRestHandlers(deps: {
     ingredients: makeIngredientsHandlers(db),
     ingredientTags: makeIngredientTagsHandlers(db),
     prepStates: makePrepStatesHandlers(db),
+    recipes: makeRecipesHandlers(db),
     slugs: makeSlugsHandlers(db),
     solver: makeSolverHandlers(db),
     substitutions: makeSubstitutionsHandlers(db),

--- a/pillars/food/src/api/rest/recipes-handlers.ts
+++ b/pillars/food/src/api/rest/recipes-handlers.ts
@@ -1,0 +1,94 @@
+/**
+ * Handlers for the `recipes.*` sub-router. Delegate to the lifted helper
+ * modules (queries / create / save / get-for-rendering) over the in-pillar
+ * db + dsl compile pipeline. Errors are translated to HttpError in the
+ * helpers / error-mapping; `runHttp` maps them to status envelopes.
+ */
+import {
+  createNewDraftForSlug,
+  createNewRecipe,
+  restoreVersionAsDraft,
+} from '../modules/recipes/create.js';
+import { getForRendering } from '../modules/recipes/get-for-rendering.js';
+import {
+  decodeCursor,
+  listDraftsForSlug,
+  listProposedSlugs,
+  listRecipes,
+} from '../modules/recipes/queries.js';
+import {
+  archiveRecipeBySlug,
+  archiveVersionRow,
+  promote,
+  saveDraft,
+} from '../modules/recipes/save.js';
+import { NotFoundError } from '../shared/errors.js';
+import { runHttp } from './error-mapping.js';
+
+import type { ServerInferRequest } from '@ts-rest/core';
+
+import type { foodRecipesContract } from '../../contract/rest-recipes.js';
+import type { FoodDb } from '../../db/index.js';
+
+type Req = ServerInferRequest<typeof foodRecipesContract>;
+
+const DEFAULT_LIMIT = 20;
+
+export function makeRecipesHandlers(db: FoodDb) {
+  return {
+    list: ({ body }: Req['list']) =>
+      runHttp(() => ({
+        status: 200 as const,
+        body: listRecipes(db, {
+          search: body.search,
+          recipeTypes: body.recipeTypes,
+          tags: body.tags,
+          includeArchived: body.includeArchived ?? false,
+          includeDraftOnly: body.includeDraftOnly ?? false,
+          sort: body.sort ?? 'createdAtDesc',
+          cursor: body.cursor === undefined ? null : decodeCursor(body.cursor),
+          limit: body.limit ?? DEFAULT_LIMIT,
+        }),
+      })),
+
+    create: ({ body }: Req['create']) =>
+      runHttp(() => ({ status: 201 as const, body: createNewRecipe(db, body.dsl) })),
+
+    getForRendering: ({ params, query }: Req['getForRendering']) =>
+      runHttp(() => ({
+        status: 200 as const,
+        body: getForRendering(db, params.slug, query.versionNo),
+      })),
+
+    listDrafts: ({ params }: Req['listDrafts']) =>
+      runHttp(() => {
+        const drafts = listDraftsForSlug(db, params.slug);
+        if (drafts === null) throw new NotFoundError('Recipe', params.slug);
+        return { status: 200 as const, body: { drafts } };
+      }),
+
+    createNewDraft: ({ params }: Req['createNewDraft']) =>
+      runHttp(() => ({ status: 201 as const, body: createNewDraftForSlug(db, params.slug) })),
+
+    archiveRecipe: ({ params }: Req['archiveRecipe']) =>
+      runHttp(() => ({ status: 200 as const, body: archiveRecipeBySlug(db, params.slug) })),
+
+    saveDraft: ({ params, body }: Req['saveDraft']) =>
+      runHttp(() => ({ status: 200 as const, body: saveDraft(db, params.versionId, body.dsl) })),
+
+    promote: ({ params }: Req['promote']) =>
+      runHttp(() => ({ status: 200 as const, body: promote(db, params.versionId) })),
+
+    archiveVersion: ({ params }: Req['archiveVersion']) =>
+      runHttp(() => ({ status: 200 as const, body: archiveVersionRow(db, params.versionId) })),
+
+    restoreVersion: ({ params }: Req['restoreVersion']) =>
+      runHttp(() => ({ status: 201 as const, body: restoreVersionAsDraft(db, params.versionId) })),
+
+    listProposedSlugs: ({ params }: Req['listProposedSlugs']) =>
+      runHttp(() => ({
+        status: 200 as const,
+        body: { items: listProposedSlugs(db, params.versionId) },
+      })),
+  };
+}

--- a/pillars/food/src/contract/api-types.generated.ts
+++ b/pillars/food/src/contract/api-types.generated.ts
@@ -660,6 +660,177 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/recipes': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Create a recipe from DSL */
+    post: operations['recipes.create'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/recipes/search': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** List recipes (filtered, cursor-paginated) */
+    post: operations['recipes.list'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/recipes/versions/{versionId}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    /** Save + compile a draft version */
+    patch: operations['recipes.saveDraft'];
+    trace?: never;
+  };
+  '/recipes/versions/{versionId}/archive': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Archive a recipe version */
+    post: operations['recipes.archiveVersion'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/recipes/versions/{versionId}/promote': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Promote a compiled draft to current */
+    post: operations['recipes.promote'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/recipes/versions/{versionId}/proposed-slugs': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** List proposed slugs surfaced by a draft’s compile */
+    get: operations['recipes.listProposedSlugs'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/recipes/versions/{versionId}/restore': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Restore an archived/published version as a new draft */
+    post: operations['recipes.restoreVersion'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/recipes/{slug}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get a recipe version assembled for rendering */
+    get: operations['recipes.getForRendering'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/recipes/{slug}/archive': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Archive a recipe */
+    post: operations['recipes.archiveRecipe'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/recipes/{slug}/drafts': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** List a recipe’s draft versions */
+    get: operations['recipes.listDrafts'];
+    put?: never;
+    /** Fork a new draft from a recipe’s current version */
+    post: operations['recipes.createNewDraft'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/slugs/search': {
     parameters: {
       query?: never;
@@ -3538,6 +3709,656 @@ export interface operations {
               name: string;
               slug: string;
             };
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'recipes.create': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          dsl: string;
+        };
+      };
+    };
+    responses: {
+      /** @description 201 */
+      201: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            compile: unknown;
+            recipeId: number;
+            slug: string;
+            versionId: number;
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'recipes.list': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          cursor?: string;
+          includeArchived?: boolean;
+          includeDraftOnly?: boolean;
+          limit?: number;
+          recipeTypes?: (
+            | 'plate'
+            | 'component'
+            | 'technique'
+            | 'sauce'
+            | 'dressing'
+            | 'drink'
+            | 'condiment'
+          )[];
+          search?: string;
+          /** @enum {string} */
+          sort?: 'createdAtDesc' | 'titleAsc' | 'recentlyCooked';
+          tags?: string[];
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            items: {
+              archivedAt: string | null;
+              cookMinutes: number | null;
+              createdAt: string;
+              hasCurrentVersion: boolean;
+              heroImagePath: string | null;
+              id: number;
+              prepMinutes: number | null;
+              /** @enum {string} */
+              recipeType:
+                | 'plate'
+                | 'component'
+                | 'technique'
+                | 'sauce'
+                | 'dressing'
+                | 'drink'
+                | 'condiment';
+              servings: number | null;
+              slug: string;
+              tags: string[];
+              title: string | null;
+            }[];
+            nextCursor: string | null;
+          };
+        };
+      };
+    };
+  };
+  'recipes.saveDraft': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        versionId: number;
+      };
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          dsl: string;
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            compile: unknown;
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'recipes.archiveVersion': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        versionId: number;
+      };
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': Record<string, never>;
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            /** @enum {boolean} */
+            ok: true;
+          };
+        };
+      };
+    };
+  };
+  'recipes.promote': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        versionId: number;
+      };
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': Record<string, never>;
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json':
+            | {
+                /** @enum {boolean} */
+                ok: true;
+                versionId: number;
+              }
+            | {
+                /** @enum {boolean} */
+                ok: false;
+                /** @enum {string} */
+                reason:
+                  | 'ConcurrentPromotion'
+                  | 'CannotPromoteUncompiledVersion'
+                  | 'VersionNotFound';
+              };
+        };
+      };
+    };
+  };
+  'recipes.listProposedSlugs': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        versionId: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            items: {
+              createdAt: string;
+              fromLoc: unknown;
+              slug: string;
+              /** @enum {string|null} */
+              suggestedKind: 'ingredient' | 'recipe' | 'prep_state' | null;
+            }[];
+          };
+        };
+      };
+    };
+  };
+  'recipes.restoreVersion': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        versionId: number;
+      };
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': Record<string, never>;
+      };
+    };
+    responses: {
+      /** @description 201 */
+      201: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            newVersionId: number;
+            newVersionNo: number;
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'recipes.getForRendering': {
+    parameters: {
+      query?: {
+        versionNo?: number;
+      };
+      header?: never;
+      path: {
+        slug: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'recipes.archiveRecipe': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        slug: string;
+      };
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': Record<string, never>;
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            /** @enum {boolean} */
+            ok: true;
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'recipes.listDrafts': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        slug: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            drafts: {
+              /** @enum {string} */
+              compileStatus: 'uncompiled' | 'compiled' | 'failed';
+              createdAt: string;
+              preview: string;
+              title: string;
+              versionId: number;
+              versionNo: number;
+            }[];
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'recipes.createNewDraft': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        slug: string;
+      };
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': Record<string, never>;
+      };
+    };
+    responses: {
+      /** @description 201 */
+      201: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            versionId: number;
+            versionNo: number;
           };
         };
       };

--- a/pillars/food/src/contract/rest-recipes.ts
+++ b/pillars/food/src/contract/rest-recipes.ts
@@ -1,0 +1,179 @@
+/**
+ * `recipes.*` sub-router — PRD-119 recipe CRUD + draft lifecycle. The DSL
+ * compile result and the `getForRendering` aggregate are deep, renderer-
+ * owned shapes; they are projected as `unknown` in OpenAPI (consumers
+ * import the rich type from the api layer, as the inbox inspector does).
+ *
+ * send-to-list + hero-image are separate slices (4c / 4b).
+ */
+import { initContract } from '@ts-rest/core';
+import { z } from 'zod';
+
+import { ERR_RESPONSES, NonEmptyString, PathPositiveInt } from './rest-schemas.js';
+
+const c = initContract();
+
+const RecipeType = z.enum([
+  'plate',
+  'component',
+  'technique',
+  'sauce',
+  'dressing',
+  'drink',
+  'condiment',
+]);
+const SortOrder = z.enum(['createdAtDesc', 'titleAsc', 'recentlyCooked']);
+const CompileStatus = z.enum(['uncompiled', 'compiled', 'failed']);
+
+const RecipeListItemSchema = z.object({
+  id: z.number().int().positive(),
+  slug: z.string(),
+  title: z.string().nullable(),
+  recipeType: RecipeType,
+  heroImagePath: z.string().nullable(),
+  prepMinutes: z.number().int().nullable(),
+  cookMinutes: z.number().int().nullable(),
+  servings: z.number().nullable(),
+  tags: z.array(z.string()),
+  hasCurrentVersion: z.boolean(),
+  archivedAt: z.string().nullable(),
+  createdAt: z.string(),
+});
+
+const RecipeDraftSummarySchema = z.object({
+  versionId: z.number().int(),
+  versionNo: z.number().int(),
+  title: z.string(),
+  compileStatus: CompileStatus,
+  createdAt: z.string(),
+  preview: z.string(),
+});
+
+const ProposedSlugRowSchema = z.object({
+  slug: z.string(),
+  suggestedKind: z.enum(['ingredient', 'recipe', 'prep_state']).nullable(),
+  fromLoc: z.unknown(),
+  createdAt: z.string(),
+});
+
+const PromoteResultSchema = z.discriminatedUnion('ok', [
+  z.object({ ok: z.literal(true), versionId: z.number().int() }),
+  z.object({
+    ok: z.literal(false),
+    reason: z.enum(['ConcurrentPromotion', 'CannotPromoteUncompiledVersion', 'VersionNotFound']),
+  }),
+]);
+
+const Ok = z.object({ ok: z.literal(true) });
+
+export const foodRecipesContract = c.router({
+  list: {
+    method: 'POST',
+    path: '/recipes/search',
+    body: z.object({
+      search: z.string().max(200).optional(),
+      recipeTypes: z.array(RecipeType).optional(),
+      tags: z.array(z.string().min(1)).optional(),
+      includeArchived: z.boolean().optional(),
+      includeDraftOnly: z.boolean().optional(),
+      sort: SortOrder.optional(),
+      cursor: z.string().optional(),
+      limit: z.number().int().positive().max(100).optional(),
+    }),
+    responses: {
+      200: z.object({ items: z.array(RecipeListItemSchema), nextCursor: z.string().nullable() }),
+    },
+    summary: 'List recipes (filtered, cursor-paginated)',
+  },
+  create: {
+    method: 'POST',
+    path: '/recipes',
+    body: z.object({ dsl: NonEmptyString }),
+    responses: {
+      201: z.object({
+        slug: z.string(),
+        recipeId: z.number().int(),
+        versionId: z.number().int(),
+        compile: z.unknown(),
+      }),
+      ...ERR_RESPONSES,
+    },
+    summary: 'Create a recipe from DSL',
+  },
+  getForRendering: {
+    method: 'GET',
+    path: '/recipes/:slug',
+    pathParams: z.object({ slug: NonEmptyString }),
+    query: z.object({ versionNo: z.coerce.number().int().positive().optional() }),
+    responses: { 200: z.unknown(), ...ERR_RESPONSES },
+    summary: 'Get a recipe version assembled for rendering',
+  },
+  listDrafts: {
+    method: 'GET',
+    path: '/recipes/:slug/drafts',
+    pathParams: z.object({ slug: NonEmptyString }),
+    responses: { 200: z.object({ drafts: z.array(RecipeDraftSummarySchema) }), ...ERR_RESPONSES },
+    summary: 'List a recipe’s draft versions',
+  },
+  createNewDraft: {
+    method: 'POST',
+    path: '/recipes/:slug/drafts',
+    pathParams: z.object({ slug: NonEmptyString }),
+    body: z.object({}).optional(),
+    responses: {
+      201: z.object({ versionId: z.number().int(), versionNo: z.number().int() }),
+      ...ERR_RESPONSES,
+    },
+    summary: 'Fork a new draft from a recipe’s current version',
+  },
+  archiveRecipe: {
+    method: 'POST',
+    path: '/recipes/:slug/archive',
+    pathParams: z.object({ slug: NonEmptyString }),
+    body: z.object({}).optional(),
+    responses: { 200: Ok, ...ERR_RESPONSES },
+    summary: 'Archive a recipe',
+  },
+  saveDraft: {
+    method: 'PATCH',
+    path: '/recipes/versions/:versionId',
+    pathParams: z.object({ versionId: PathPositiveInt }),
+    body: z.object({ dsl: NonEmptyString }),
+    responses: { 200: z.object({ compile: z.unknown() }), ...ERR_RESPONSES },
+    summary: 'Save + compile a draft version',
+  },
+  promote: {
+    method: 'POST',
+    path: '/recipes/versions/:versionId/promote',
+    pathParams: z.object({ versionId: PathPositiveInt }),
+    body: z.object({}).optional(),
+    responses: { 200: PromoteResultSchema },
+    summary: 'Promote a compiled draft to current',
+  },
+  archiveVersion: {
+    method: 'POST',
+    path: '/recipes/versions/:versionId/archive',
+    pathParams: z.object({ versionId: PathPositiveInt }),
+    body: z.object({}).optional(),
+    responses: { 200: Ok },
+    summary: 'Archive a recipe version',
+  },
+  restoreVersion: {
+    method: 'POST',
+    path: '/recipes/versions/:versionId/restore',
+    pathParams: z.object({ versionId: PathPositiveInt }),
+    body: z.object({}).optional(),
+    responses: {
+      201: z.object({ newVersionId: z.number().int(), newVersionNo: z.number().int() }),
+      ...ERR_RESPONSES,
+    },
+    summary: 'Restore an archived/published version as a new draft',
+  },
+  listProposedSlugs: {
+    method: 'GET',
+    path: '/recipes/versions/:versionId/proposed-slugs',
+    pathParams: z.object({ versionId: PathPositiveInt }),
+    responses: { 200: z.object({ items: z.array(ProposedSlugRowSchema) }) },
+    summary: 'List proposed slugs surfaced by a draft’s compile',
+  },
+});

--- a/pillars/food/src/contract/rest.ts
+++ b/pillars/food/src/contract/rest.ts
@@ -22,6 +22,7 @@ import { foodInboxContract } from './rest-inbox.js';
 import { foodIngredientTagsContract } from './rest-ingredient-tags.js';
 import { foodIngredientsContract } from './rest-ingredients.js';
 import { foodPrepStatesContract } from './rest-prep-states.js';
+import { foodRecipesContract } from './rest-recipes.js';
 import { foodSlugsContract } from './rest-slugs.js';
 import { foodSolverContract } from './rest-solver.js';
 import { foodSubstitutionsContract } from './rest-substitutions.js';
@@ -39,6 +40,7 @@ export const foodContract = c.router(
     ingredients: foodIngredientsContract,
     ingredientTags: foodIngredientTagsContract,
     prepStates: foodPrepStatesContract,
+    recipes: foodRecipesContract,
     slugs: foodSlugsContract,
     solver: foodSolverContract,
     substitutions: foodSubstitutionsContract,


### PR DESCRIPTION
Slice 4 (part a) of the food tRPC→REST migration (`docs/runbooks/food-rest-migration.md`), after #3339–#3347. Ports the **recipes CRUD + draft lifecycle** (PRD-119). send-to-list (4c) and hero-image (4b) follow as separate PRs.

## Surface (11 procedures)
`POST /recipes/search` (list), `POST /recipes` (create from DSL), `GET /recipes/:slug` (getForRendering), `GET/POST /recipes/:slug/drafts` (listDrafts / createNewDraft), `POST /recipes/:slug/archive`, `PATCH /recipes/versions/:versionId` (saveDraft), `POST /recipes/versions/:versionId/{promote,archive,restore}`, `GET /recipes/versions/:versionId/proposed-slugs`.

The query/create/save/get-for-rendering helpers are lifted into `src/api/modules/recipes/` over the in-pillar db + DSL compile pipeline (`parseRecipeDsl`/`compileRecipeVersion` from `src/dsl/*`). `TRPCError` is replaced with the pillar `HttpError` pattern (bad DSL → 400, unknown slug/version → 404, slug conflict → 409). The deep DSL compile result + `getForRendering` aggregate are projected as `unknown` in OpenAPI (consumers import the rich renderer types from the api layer, as the inbox inspector does).

## Safety
- Additive to the pillar only — `apps/pops-api` untouched.
- Validated locally: typecheck, lint, format, build, OpenAPI + api-types drift, **856 tests (69 files) green**; OpenAPI idempotent.

## Remaining (slice 4)
4b hero-image (upload/remove + Express binary serve, adds `sharp`), 4c send-to-list rewire onto lists `upsert-by-ref` REST (drops `@pops/app-lists-db`). Then plan/shopping → ingest/ai → Phase C/D/E.