### PR TITLE
feat(food): REST migration slice 4b — hero-image

### DIFF
--- a/pillars/food/openapi/food.openapi.json
+++ b/pillars/food/openapi/food.openapi.json
@@ -6704,6 +6704,283 @@
         "tags": ["recipes"]
       }
     },
+    "/recipes/{recipeId}/hero-image": {
+      "delete": {
+        "operationId": "heroImage.remove",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "recipeId",
+            "required": true,
+            "schema": {
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {},
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    },
+                    "ok": {
+                      "enum": [true],
+                      "type": "boolean"
+                    }
+                  },
+                  "required": ["ok", "message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Remove a recipe hero image",
+        "tags": ["heroImage"]
+      },
+      "post": {
+        "operationId": "heroImage.upload",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "recipeId",
+            "required": true,
+            "schema": {
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "contentBase64": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "mimeType": {
+                    "enum": ["image/jpeg", "image/png", "image/webp"],
+                    "type": "string"
+                  }
+                },
+                "required": ["mimeType", "contentBase64"],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "height": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer"
+                        },
+                        "heroImagePath": {
+                          "type": "string"
+                        },
+                        "sizeBytes": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer"
+                        },
+                        "width": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer"
+                        }
+                      },
+                      "required": ["heroImagePath", "sizeBytes", "width", "height"],
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["data", "message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "200"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "400"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "messageKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "409"
+          }
+        },
+        "summary": "Upload a recipe hero image (base64)",
+        "tags": ["heroImage"]
+      }
+    },
     "/recipes/{slug}": {
       "get": {
         "operationId": "recipes.getForRendering",

--- a/pillars/food/package.json
+++ b/pillars/food/package.json
@@ -61,6 +61,7 @@
     "ioredis": "^5.11.1",
     "jsdom": "^25.0.1",
     "pino": "^10.3.1",
+    "sharp": "^0.34.5",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/pillars/food/src/api/__tests__/hero-image.test.ts
+++ b/pillars/food/src/api/__tests__/hero-image.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Integration tests for the hero-image surface: ts-rest upload/remove
+ * (base64) + the plain Express binary serve route. A real PNG is produced
+ * with sharp so the dimension probe + thumbnail pass run. Files land in a
+ * per-test FOOD_RECIPES_DIR.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import sharp from 'sharp';
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { type OpenedFoodDb, openFoodDb } from '../../db/index.js';
+import { createFoodApiApp } from '../app.js';
+import { makeClient } from './test-utils.js';
+
+let tmpDir: string;
+let foodDb: OpenedFoodDb;
+let recipeId: number;
+
+const SIMPLE_DSL = `@recipe(slug="toast", title="Toast")
+@yield(toast, 1:count)
+@ingredient(1, bread, 1:count)
+@step("Toast @1.")
+`;
+
+function app() {
+  return createFoodApiApp({ foodDb, version: '0.0.1-test', selfBaseUrl: 'http://localhost:3005' });
+}
+
+async function pngBase64(): Promise<string> {
+  const buf = await sharp({
+    create: { width: 16, height: 12, channels: 3, background: { r: 200, g: 50, b: 50 } },
+  })
+    .png()
+    .toBuffer();
+  return buf.toString('base64');
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'food-api-hero-test-'));
+  process.env['FOOD_RECIPES_DIR'] = join(tmpDir, 'recipes');
+  foodDb = openFoodDb(join(tmpDir, 'food.db'));
+});
+
+afterEach(() => {
+  foodDb.raw.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+  delete process.env['FOOD_RECIPES_DIR'];
+});
+
+describe('hero-image REST', () => {
+  it('uploads, serves the binary, then removes', async () => {
+    const client = makeClient(app());
+    const created = await client.recipes.create(SIMPLE_DSL);
+    recipeId = created.recipeId;
+
+    const uploaded = await client.heroImage.upload(recipeId, 'image/png', await pngBase64());
+    expect(uploaded.data.heroImagePath).toBe(`${recipeId}/hero.png`);
+    expect(uploaded.data.width).toBe(16);
+    expect(uploaded.data.height).toBe(12);
+
+    const served = await request(app()).get(`/recipes/${recipeId}/hero.png`);
+    expect(served.status).toBe(200);
+    expect(served.headers['content-type']).toContain('image/png');
+
+    const thumb = await request(app()).get(`/recipes/${recipeId}/hero-thumb.webp`);
+    expect(thumb.status).toBe(200);
+
+    const removed = await client.heroImage.remove(recipeId);
+    expect(removed.ok).toBe(true);
+
+    const gone = await request(app()).get(`/recipes/${recipeId}/hero.png`);
+    expect(gone.status).toBe(404);
+  });
+
+  it('404s upload for an unknown recipe', async () => {
+    await expect(
+      makeClient(app()).heroImage.upload(999999, 'image/png', await pngBase64())
+    ).rejects.toMatchObject({ status: 404 });
+  });
+
+  it('400s upload of undecodable bytes', async () => {
+    const client = makeClient(app());
+    const created = await client.recipes.create(SIMPLE_DSL);
+    await expect(
+      client.heroImage.upload(
+        created.recipeId,
+        'image/png',
+        Buffer.from('not an image').toString('base64')
+      )
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it('falls through to the recipes route for a non-hero path', async () => {
+    // GET /recipes/:slug/drafts must NOT be shadowed by the serve route.
+    const client = makeClient(app());
+    await client.recipes.create(SIMPLE_DSL);
+    const drafts = await client.recipes.listDrafts('toast');
+    expect(Array.isArray(drafts.drafts)).toBe(true);
+  });
+});

--- a/pillars/food/src/api/__tests__/test-utils.ts
+++ b/pillars/food/src/api/__tests__/test-utils.ts
@@ -172,6 +172,13 @@ interface CreateRecipeResult {
   compile: unknown;
 }
 
+interface UploadHeroResult {
+  heroImagePath: string;
+  sizeBytes: number;
+  width: number;
+  height: number;
+}
+
 export class HttpError extends Error {
   readonly status: number;
   readonly body: unknown;
@@ -413,6 +420,14 @@ export function makeClient(app: Express) {
         ),
       listProposedSlugs: (versionId: number) =>
         send<{ items: unknown[] }>(r.get(`/recipes/versions/${versionId}/proposed-slugs`)),
+    },
+    heroImage: {
+      upload: (recipeId: number, mimeType: string, contentBase64: string) =>
+        send<{ data: UploadHeroResult; message: string }>(
+          r.post(`/recipes/${recipeId}/hero-image`).send({ mimeType, contentBase64 })
+        ),
+      remove: (recipeId: number) =>
+        send<{ ok: true; message: string }>(r.delete(`/recipes/${recipeId}/hero-image`)),
     },
   };
 }

--- a/pillars/food/src/api/app.ts
+++ b/pillars/food/src/api/app.ts
@@ -15,6 +15,7 @@ import express, { type Express, type Request, type Response } from 'express';
 
 import { foodContract } from '../contract/rest.js';
 import { type FoodApiDeps, makeRequestHandler } from './handlers.js';
+import { serveHeroImage } from './modules/hero-image/serve.js';
 import { makeFoodRestHandlers } from './rest/handlers.js';
 
 /**
@@ -40,6 +41,10 @@ export function createFoodApiApp(deps: FoodApiDeps): Express {
   app.get('/pillars', (_req: Request, res: Response) => {
     res.json(handlers.pillars());
   });
+
+  // Binary hero-image serving — registered before the ts-rest endpoints so
+  // `…/hero.jpg` resolves to a file; falls through to ts-rest otherwise.
+  app.get('/recipes/:recipeId/:filename', serveHeroImage);
 
   createExpressEndpoints(foodContract, makeFoodRestHandlers(deps), app);
 

--- a/pillars/food/src/api/modules/hero-image/paths.ts
+++ b/pillars/food/src/api/modules/hero-image/paths.ts
@@ -1,0 +1,81 @@
+/**
+ * Mirrors the layout in `@pops/app-food/src/storage/hero-paths.ts`. pops-api
+ * doesn't depend on the React-bearing app-food package at runtime, so the
+ * absolute-path resolution is duplicated here — keep both in sync.
+ */
+import { resolve, sep } from 'node:path';
+
+const DEFAULT_FOOD_RECIPES_DIR = './data/food/recipes';
+
+export const HERO_ORIGINAL_EXTENSIONS = ['jpg', 'jpeg', 'png', 'webp'] as const;
+export type HeroOriginalExtension = (typeof HERO_ORIGINAL_EXTENSIONS)[number];
+
+export const HERO_MIME_TO_EXTENSION: Readonly<Record<string, HeroOriginalExtension>> = {
+  'image/jpeg': 'jpg',
+  'image/png': 'png',
+  'image/webp': 'webp',
+};
+
+export const HERO_ALLOWED_MIME_TYPES = Object.keys(HERO_MIME_TO_EXTENSION);
+
+/** Resolve the configured root directory. Reads env each call so tests can stub. */
+export function recipesRootDir(): string {
+  const configured = process.env['FOOD_RECIPES_DIR'];
+  const raw = configured && configured.length > 0 ? configured : DEFAULT_FOOD_RECIPES_DIR;
+  return resolve(raw);
+}
+
+/** Throw if `recipeId` isn't a positive integer. */
+export function assertValidRecipeId(recipeId: unknown): asserts recipeId is number {
+  if (typeof recipeId !== 'number' || !Number.isInteger(recipeId) || recipeId <= 0) {
+    throw new Error(`Invalid recipe id: ${String(recipeId)}`);
+  }
+}
+
+export function recipeDirFor(recipeId: number): string {
+  assertValidRecipeId(recipeId);
+  return resolve(recipesRootDir(), String(recipeId));
+}
+
+export function heroAbsPathFor(recipeId: number, ext: HeroOriginalExtension): string {
+  return resolve(recipeDirFor(recipeId), `hero.${ext}`);
+}
+
+export function thumbAbsPathFor(recipeId: number): string {
+  return resolve(recipeDirFor(recipeId), 'hero-thumb.webp');
+}
+
+export function cardAbsPathFor(recipeId: number): string {
+  return resolve(recipeDirFor(recipeId), 'hero-card.webp');
+}
+
+/** Relative path stored in `recipes.hero_image_path` (POSIX separators). */
+export function relativeHeroPath(recipeId: number, ext: HeroOriginalExtension): string {
+  assertValidRecipeId(recipeId);
+  return `${recipeId}/hero.${ext}`;
+}
+
+/**
+ * True when `filename` is one of the recognised hero assets. Used by the
+ * static-file route to reject anything outside the known layout.
+ */
+export function isValidHeroFilename(filename: string): boolean {
+  if (typeof filename !== 'string' || filename.length === 0) return false;
+  if (filename.includes('/') || filename.includes('\\') || filename.includes('..')) return false;
+  if (filename === 'hero-thumb.webp' || filename === 'hero-card.webp') return true;
+  return /^hero\.(jpg|jpeg|png|webp)$/.test(filename);
+}
+
+/**
+ * Defence-in-depth sandbox check for the Express static route. Returns the
+ * absolute path iff it lives under the configured root and the filename is
+ * one of the known hero assets.
+ */
+export function resolveServablePath(recipeId: number, filename: string): string | null {
+  if (!isValidHeroFilename(filename)) return null;
+  assertValidRecipeId(recipeId);
+  const root = recipesRootDir();
+  const absPath = resolve(root, String(recipeId), filename);
+  if (absPath !== root && !absPath.startsWith(root + sep)) return null;
+  return absPath;
+}

--- a/pillars/food/src/api/modules/hero-image/serve.ts
+++ b/pillars/food/src/api/modules/hero-image/serve.ts
@@ -1,0 +1,44 @@
+/**
+ * Plain Express handler that streams a recipe hero-image file.
+ *
+ * Mounted as `GET /recipes/:recipeId/:filename` BEFORE the ts-rest
+ * endpoints. It falls through (`next()`) for anything that isn't a numeric
+ * recipe id + a known hero filename, so it never shadows the ts-rest
+ * `GET /recipes/:slug` / `/recipes/:slug/drafts` routes — only genuine
+ * `…/hero.jpg` / `…/hero-thumb.webp` / `…/hero-card.webp` requests serve a
+ * file. Path traversal is rejected by `resolveServablePath`'s sandbox check.
+ */
+import { existsSync } from 'node:fs';
+import { extname } from 'node:path';
+
+import { isValidHeroFilename, resolveServablePath } from './paths.js';
+
+import type { NextFunction, Request, Response } from 'express';
+
+const CONTENT_TYPE: Readonly<Record<string, string>> = {
+  '.webp': 'image/webp',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.png': 'image/png',
+};
+
+export function serveHeroImage(req: Request, res: Response, next: NextFunction): void {
+  const rawId = req.params['recipeId'];
+  const rawName = req.params['filename'];
+  const recipeId = typeof rawId === 'string' ? Number(rawId) : NaN;
+  const filename = typeof rawName === 'string' ? rawName : '';
+  if (!Number.isInteger(recipeId) || recipeId <= 0 || !isValidHeroFilename(filename)) {
+    next();
+    return;
+  }
+  const absPath = resolveServablePath(recipeId, filename);
+  if (absPath === null || !existsSync(absPath)) {
+    res.status(404).json({ message: 'Hero image not found' });
+    return;
+  }
+  const contentType = CONTENT_TYPE[extname(absPath).toLowerCase()];
+  if (contentType !== undefined) res.type(contentType);
+  // User-uploaded content: short private cache, revalidated on change.
+  res.setHeader('Cache-Control', 'private, max-age=3600');
+  res.sendFile(absPath);
+}

--- a/pillars/food/src/api/modules/hero-image/service.ts
+++ b/pillars/food/src/api/modules/hero-image/service.ts
@@ -1,0 +1,238 @@
+/**
+ * On-disk + DB lifecycle for `recipes.hero_image_path`:
+ *   - validates the upload (mime type, size, decodable image header)
+ *   - writes the original atomically (`.tmp` + rename)
+ *   - generates two derived thumbnails with sharp (320px webp, 640px webp)
+ *   - updates `recipes.hero_image_path` and removes any stale prior original
+ *
+ * sharp lives in this package (browser-bundled `@pops/app-food` can't
+ * carry it), so the heavy work is done here.
+ */
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { join, resolve } from 'node:path';
+
+import { eq } from 'drizzle-orm';
+import sharp from 'sharp';
+
+import { type FoodDb, recipes } from '../../../db/index.js';
+import { NotFoundError, ValidationError } from '../../shared/errors.js';
+import {
+  cardAbsPathFor,
+  heroAbsPathFor,
+  HERO_ALLOWED_MIME_TYPES,
+  HERO_MIME_TO_EXTENSION,
+  type HeroOriginalExtension,
+  recipeDirFor,
+  relativeHeroPath,
+  thumbAbsPathFor,
+} from './paths.js';
+
+const DEFAULT_MAX_BYTES = 8 * 1024 * 1024;
+
+export interface UploadHeroInput {
+  recipeId: number;
+  mimeType: string;
+  /** Raw decoded image bytes. The tRPC router decodes the base64 wire field. */
+  buffer: Buffer;
+}
+
+export interface UploadHeroResult {
+  heroImagePath: string;
+  sizeBytes: number;
+  width: number;
+  height: number;
+}
+
+/**
+ * Read the configured upload size cap. Reads env each call so tests can
+ * stub. Invalid or non-positive values fall back to the default.
+ */
+function maxBytes(): number {
+  const raw = process.env['FOOD_HERO_MAX_BYTES'];
+  if (raw === undefined || raw.length === 0) return DEFAULT_MAX_BYTES;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_MAX_BYTES;
+  return parsed;
+}
+
+function extensionFor(mimeType: string): HeroOriginalExtension {
+  const ext = HERO_MIME_TO_EXTENSION[mimeType];
+  if (ext === undefined) {
+    throw new ValidationError(
+      `Unsupported mime type "${mimeType}". Allowed: ${HERO_ALLOWED_MIME_TYPES.join(', ')}`
+    );
+  }
+  return ext;
+}
+
+function assertRecipeIdInteger(recipeId: number): void {
+  if (!Number.isInteger(recipeId) || recipeId <= 0) {
+    throw new ValidationError(`Invalid recipe id: ${recipeId}`);
+  }
+}
+
+function assertRecipeExists(db: FoodDb, recipeId: number): void {
+  const [row] = db.select({ id: recipes.id }).from(recipes).where(eq(recipes.id, recipeId)).all();
+  if (!row) throw new NotFoundError('Recipe', String(recipeId));
+}
+
+/**
+ * Write `bytes` to `target` atomically by writing to `${target}.tmp` then
+ * renaming. Rename is a single FS operation on POSIX, so readers either
+ * see the old file or the new one — never a half-written partial.
+ */
+function writeAtomic(target: string, bytes: Buffer): void {
+  const tmp = `${target}.tmp`;
+  writeFileSync(tmp, bytes);
+  renameSync(tmp, target);
+}
+
+/**
+ * Remove any `hero.*` originals in the directory that don't match the
+ * extension we just wrote. Replacement with a different mime type would
+ * otherwise leave the old file behind.
+ */
+function removeStaleOriginals(dir: string, keepExt: HeroOriginalExtension): void {
+  if (!existsSync(dir)) return;
+  for (const entry of readdirSync(dir)) {
+    if (!/^hero\.(jpg|jpeg|png|webp)$/.test(entry)) continue;
+    if (entry === `hero.${keepExt}`) continue;
+    try {
+      unlinkSync(join(dir, entry));
+    } catch {
+      // Best-effort cleanup; missing or locked files surface through the
+      // renderer fallback rather than the upload path.
+    }
+  }
+}
+
+interface ThumbnailWriteResult {
+  /** True if both thumbnails were produced; false logs a warning upstream. */
+  ok: boolean;
+}
+
+async function writeThumbnails(
+  originalBytes: Buffer,
+  thumbTarget: string,
+  cardTarget: string
+): Promise<ThumbnailWriteResult> {
+  // Sharp's default is "strip everything" on output unless `.withMetadata()`
+  // is called — EXIF is dropped from both webp variants. `.rotate()` applies
+  // the original EXIF orientation BEFORE the strip.
+  try {
+    const [thumb, card] = await Promise.all([
+      sharp(originalBytes).rotate().resize({ width: 320 }).webp({ quality: 80 }).toBuffer(),
+      sharp(originalBytes).rotate().resize({ width: 640 }).webp({ quality: 85 }).toBuffer(),
+    ]);
+    writeAtomic(thumbTarget, thumb);
+    writeAtomic(cardTarget, card);
+    return { ok: true };
+  } catch (err) {
+    console.warn('[food/hero] thumbnail generation failed; keeping original only', err);
+    bestEffortUnlink([thumbTarget, cardTarget, `${thumbTarget}.tmp`, `${cardTarget}.tmp`]);
+    return { ok: false };
+  }
+}
+
+function bestEffortUnlink(paths: readonly string[]): void {
+  for (const p of paths) {
+    if (!existsSync(p)) continue;
+    try {
+      unlinkSync(p);
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+async function probeDimensions(bytes: Buffer): Promise<{ width: number; height: number }> {
+  const meta = await sharp(bytes).metadata();
+  if (typeof meta.width !== 'number' || typeof meta.height !== 'number') {
+    throw new ValidationError('Image dimensions could not be determined.');
+  }
+  return { width: meta.width, height: meta.height };
+}
+
+/**
+ * Upload a hero image for `input.recipeId`. Writes the original + two
+ * thumbnails and updates `recipes.hero_image_path`. Atomic per file —
+ * concurrent uploads to the same recipe are last-wins on the DB column.
+ */
+export async function uploadHeroImage(
+  db: FoodDb,
+  input: UploadHeroInput
+): Promise<UploadHeroResult> {
+  assertRecipeIdInteger(input.recipeId);
+  const recipeId = input.recipeId;
+  if (input.buffer.length === 0) {
+    throw new ValidationError('Image upload is empty.');
+  }
+  if (input.buffer.length > maxBytes()) {
+    throw new ValidationError(`Image exceeds the maximum allowed size of ${maxBytes()} bytes.`);
+  }
+  const ext = extensionFor(input.mimeType);
+
+  let dimensions: { width: number; height: number };
+  try {
+    dimensions = await probeDimensions(input.buffer);
+  } catch (err) {
+    if (err instanceof ValidationError) throw err;
+    throw new ValidationError(
+      `Image could not be decoded (${err instanceof Error ? err.message : 'unknown error'})`
+    );
+  }
+
+  assertRecipeExists(db, recipeId);
+
+  const dir = recipeDirFor(recipeId);
+  mkdirSync(dir, { recursive: true });
+
+  const originalTarget = heroAbsPathFor(recipeId, ext);
+  writeAtomic(originalTarget, input.buffer);
+  removeStaleOriginals(dir, ext);
+
+  await writeThumbnails(input.buffer, thumbAbsPathFor(recipeId), cardAbsPathFor(recipeId));
+
+  const relPath = relativeHeroPath(recipeId, ext);
+  db.update(recipes).set({ heroImagePath: relPath }).where(eq(recipes.id, recipeId)).run();
+
+  return {
+    heroImagePath: relPath,
+    sizeBytes: input.buffer.length,
+    width: dimensions.width,
+    height: dimensions.height,
+  };
+}
+
+/**
+ * Remove a recipe's hero image and clear `recipes.hero_image_path`.
+ * Missing files are tolerated — the goal is "no hero after this returns",
+ * not strict file accounting.
+ */
+export function removeHeroImage(db: FoodDb, recipeIdInput: number): void {
+  assertRecipeIdInteger(recipeIdInput);
+  const recipeId = recipeIdInput;
+  assertRecipeExists(db, recipeId);
+
+  const dir = recipeDirFor(recipeId);
+  if (existsSync(dir)) {
+    for (const entry of readdirSync(dir)) {
+      if (!/^hero(\.|-)/.test(entry)) continue;
+      try {
+        rmSync(resolve(dir, entry), { force: true });
+      } catch {
+        /* best-effort */
+      }
+    }
+  }
+
+  db.update(recipes).set({ heroImagePath: null }).where(eq(recipes.id, recipeId)).run();
+}

--- a/pillars/food/src/api/modules/hero-image/types.ts
+++ b/pillars/food/src/api/modules/hero-image/types.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+import { HERO_ALLOWED_MIME_TYPES } from './paths.js';
+
+/** Mime types the upload endpoint accepts. */
+export const HeroImageMimeSchema = z.enum(HERO_ALLOWED_MIME_TYPES as [string, ...string[]]);
+
+export const UploadHeroSchema = z.object({
+  recipeId: z.number().int().positive(),
+  mimeType: HeroImageMimeSchema,
+  /** Base64-encoded image bytes. The router decodes this to a Buffer. */
+  contentBase64: z.string().min(1, 'Image content is required'),
+});
+export type UploadHeroSchemaInput = z.infer<typeof UploadHeroSchema>;
+
+export const RemoveHeroSchema = z.object({
+  recipeId: z.number().int().positive(),
+});
+export type RemoveHeroSchemaInput = z.infer<typeof RemoveHeroSchema>;

--- a/pillars/food/src/api/rest/handlers.ts
+++ b/pillars/food/src/api/rest/handlers.ts
@@ -13,6 +13,7 @@ import { makeAliasesHandlers } from './aliases-handlers.js';
 import { makeBatchesHandlers } from './batches-handlers.js';
 import { makeConversionsHandlers } from './conversions-handlers.js';
 import { makeFridgeHandlers } from './fridge-handlers.js';
+import { makeHeroImageHandlers } from './hero-image-handlers.js';
 import { makeInboxHandlers } from './inbox-handlers.js';
 import { makeIngredientTagsHandlers } from './ingredient-tags-handlers.js';
 import { makeIngredientsHandlers } from './ingredients-handlers.js';
@@ -34,6 +35,7 @@ export function makeFoodRestHandlers(deps: {
     batches: makeBatchesHandlers(db),
     conversions: makeConversionsHandlers(db),
     fridge: makeFridgeHandlers(db),
+    heroImage: makeHeroImageHandlers(db),
     inbox: makeInboxHandlers(db),
     ingredients: makeIngredientsHandlers(db),
     ingredientTags: makeIngredientTagsHandlers(db),

--- a/pillars/food/src/api/rest/hero-image-handlers.ts
+++ b/pillars/food/src/api/rest/hero-image-handlers.ts
@@ -1,0 +1,35 @@
+/**
+ * Handlers for the `heroImage.*` sub-router. Upload decodes the base64 body
+ * to a Buffer and delegates to the lifted service; the service throws
+ * `NotFoundError` (404) / `ValidationError` (400), which `runHttp` maps.
+ */
+import { removeHeroImage, uploadHeroImage } from '../modules/hero-image/service.js';
+import { runHttp } from './error-mapping.js';
+
+import type { ServerInferRequest } from '@ts-rest/core';
+
+import type { foodHeroImageContract } from '../../contract/rest-hero-image.js';
+import type { FoodDb } from '../../db/index.js';
+
+type Req = ServerInferRequest<typeof foodHeroImageContract>;
+
+export function makeHeroImageHandlers(db: FoodDb) {
+  return {
+    upload: ({ params, body }: Req['upload']) =>
+      runHttp(async () => {
+        const buffer = Buffer.from(body.contentBase64, 'base64');
+        const data = await uploadHeroImage(db, {
+          recipeId: params.recipeId,
+          mimeType: body.mimeType,
+          buffer,
+        });
+        return { status: 200 as const, body: { data, message: 'Hero image uploaded' } };
+      }),
+
+    remove: ({ params }: Req['remove']) =>
+      runHttp(() => {
+        removeHeroImage(db, params.recipeId);
+        return { status: 200 as const, body: { ok: true as const, message: 'Hero image removed' } };
+      }),
+  };
+}

--- a/pillars/food/src/contract/api-types.generated.ts
+++ b/pillars/food/src/contract/api-types.generated.ts
@@ -779,6 +779,24 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/recipes/{recipeId}/hero-image': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Upload a recipe hero image (base64) */
+    post: operations['heroImage.upload'];
+    /** Remove a recipe hero image */
+    delete: operations['heroImage.remove'];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/recipes/{slug}': {
     parameters: {
       query?: never;
@@ -4087,6 +4105,154 @@ export interface operations {
           'application/json': {
             newVersionId: number;
             newVersionNo: number;
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'heroImage.upload': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        recipeId: number;
+      };
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': {
+          contentBase64: string;
+          /** @enum {string} */
+          mimeType: 'image/jpeg' | 'image/png' | 'image/webp';
+        };
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: {
+              height: number;
+              heroImagePath: string;
+              sizeBytes: number;
+              width: number;
+            };
+            message: string;
+          };
+        };
+      };
+      /** @description 400 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 404 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+      /** @description 409 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            code?: string;
+            message: string;
+            messageKey?: string;
+          };
+        };
+      };
+    };
+  };
+  'heroImage.remove': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        recipeId: number;
+      };
+      cookie?: never;
+    };
+    /** @description Body */
+    requestBody?: {
+      content: {
+        'application/json': Record<string, never>;
+      };
+    };
+    responses: {
+      /** @description 200 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            message: string;
+            /** @enum {boolean} */
+            ok: true;
           };
         };
       };

--- a/pillars/food/src/contract/rest-hero-image.ts
+++ b/pillars/food/src/contract/rest-hero-image.ts
@@ -1,0 +1,43 @@
+/**
+ * `heroImage.*` sub-router — recipe hero-image upload (base64-in-JSON,
+ * parity with inventory photos) + removal. The binary GET serve route is a
+ * plain Express route in `app.ts` (it streams a file, not JSON).
+ */
+import { initContract } from '@ts-rest/core';
+import { z } from 'zod';
+
+import { ERR_RESPONSES, PathPositiveInt } from './rest-schemas.js';
+
+const c = initContract();
+
+const UploadHeroResultSchema = z.object({
+  heroImagePath: z.string(),
+  sizeBytes: z.number().int(),
+  width: z.number().int(),
+  height: z.number().int(),
+});
+
+export const foodHeroImageContract = c.router({
+  upload: {
+    method: 'POST',
+    path: '/recipes/:recipeId/hero-image',
+    pathParams: z.object({ recipeId: PathPositiveInt }),
+    body: z.object({
+      mimeType: z.enum(['image/jpeg', 'image/png', 'image/webp']),
+      contentBase64: z.string().min(1),
+    }),
+    responses: {
+      200: z.object({ data: UploadHeroResultSchema, message: z.string() }),
+      ...ERR_RESPONSES,
+    },
+    summary: 'Upload a recipe hero image (base64)',
+  },
+  remove: {
+    method: 'DELETE',
+    path: '/recipes/:recipeId/hero-image',
+    pathParams: z.object({ recipeId: PathPositiveInt }),
+    body: z.object({}).optional(),
+    responses: { 200: z.object({ ok: z.literal(true), message: z.string() }), ...ERR_RESPONSES },
+    summary: 'Remove a recipe hero image',
+  },
+});

--- a/pillars/food/src/contract/rest.ts
+++ b/pillars/food/src/contract/rest.ts
@@ -18,6 +18,7 @@ import { foodAliasesContract } from './rest-aliases.js';
 import { foodBatchesContract } from './rest-batches.js';
 import { foodConversionsContract } from './rest-conversions.js';
 import { foodFridgeContract } from './rest-fridge.js';
+import { foodHeroImageContract } from './rest-hero-image.js';
 import { foodInboxContract } from './rest-inbox.js';
 import { foodIngredientTagsContract } from './rest-ingredient-tags.js';
 import { foodIngredientsContract } from './rest-ingredients.js';
@@ -36,6 +37,7 @@ export const foodContract = c.router(
     batches: foodBatchesContract,
     conversions: foodConversionsContract,
     fridge: foodFridgeContract,
+    heroImage: foodHeroImageContract,
     inbox: foodInboxContract,
     ingredients: foodIngredientsContract,
     ingredientTags: foodIngredientTagsContract,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2254,6 +2254,9 @@ importers:
       pino:
         specifier: ^10.3.1
         version: 10.3.1
+      sharp:
+        specifier: ^0.34.5
+        version: 0.34.5
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -11822,7 +11825,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.3)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@25.0.1)(msw@2.14.6(@types/node@25.9.3)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
 
   '@vitest/expect@3.2.4':
     dependencies:


### PR DESCRIPTION
Slice 4 (part b) of the food tRPC→REST migration, after #3353. Ports recipe **hero-image** upload/remove/serve.

## Surface
- `POST /recipes/:recipeId/hero-image` (base64 upload), `DELETE /recipes/:recipeId/hero-image` — ts-rest, over a lifted service (`src/api/modules/hero-image/`) that writes the original + sharp 320/640 webp thumbnails and updates `recipes.hero_image_path`. The service takes `db` as a param (was `getDrizzle`). `NotFoundError`→404 / `ValidationError`→400 via `runHttp`.
- `GET /recipes/:recipeId/:filename` — plain Express binary serve route mounted before the ts-rest endpoints. It `next()`s for non-numeric ids / non-hero filenames so it never shadows `GET /recipes/:slug(/drafts)`; `resolveServablePath` sandboxes path traversal.

Adds the `sharp` dependency to the pillar.

## Safety
- Additive to the pillar only — `apps/pops-api` untouched.
- Validated locally: typecheck, lint, format, build, OpenAPI + api-types drift, **860 tests (70 files) green** incl. a real-PNG round-trip through sharp + a fall-through assertion for `listDrafts`.

## Remaining (slice 4)
4c send-to-list rewire onto lists `upsert-by-ref` REST (drops `@pops/app-lists-db`). Then plan/shopping → ingest/ai → Phase C/D/E.